### PR TITLE
Add remote support for git chips

### DIFF
--- a/app/src/ai/blocklist/context_model.rs
+++ b/app/src/ai/blocklist/context_model.rs
@@ -9,9 +9,9 @@ use ai::project_context::model::ProjectContextModel;
 use parking_lot::FairMutex;
 use warp_core::features::FeatureFlag;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
-#[cfg(feature = "local_fs")]
-use warpui::WeakModelHandle;
-use warpui::{AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonEntity};
+use warpui::{
+    AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonEntity, WeakModelHandle,
+};
 
 use super::agent_view::{AgentViewController, AgentViewEntryOrigin, EnterAgentViewError};
 use super::block::DirectoryContext;
@@ -28,14 +28,12 @@ use crate::ai::block_context::BlockContext;
 use crate::ai::document::ai_document_model::AIDocumentId;
 use crate::ai::llms::{LLMPreferences, LLMPreferencesEvent};
 use crate::ai::outline::RepoOutlines;
-#[cfg(feature = "local_fs")]
 use crate::code_review::github_repo_model::GitHubRepoModel;
 use crate::terminal::event::{BlockCompletedEvent, BlockType};
 use crate::terminal::model::block::{BlockId, BlockMetadata};
 use crate::terminal::model::session::Sessions;
 use crate::terminal::model_events::{ModelEvent, ModelEventDispatcher};
 use crate::terminal::TerminalModel;
-#[cfg(any(feature = "local_fs", test))]
 use crate::util::git::{PrInfo, RepositoryInfo};
 use crate::workspaces::user_workspaces::UserWorkspaces;
 
@@ -105,7 +103,6 @@ impl PendingQueryState {
 pub struct BlocklistAIContextModel {
     terminal_model: Arc<FairMutex<TerminalModel>>,
     directory_context: DirectoryContext,
-    #[cfg(feature = "local_fs")]
     github_repo_model: Option<WeakModelHandle<GitHubRepoModel>>,
 
     /// `BlockId`s corresponding to blocks to be included as context with the next AI query.
@@ -285,7 +282,6 @@ impl BlocklistAIContextModel {
         Self {
             terminal_model,
             directory_context: Default::default(),
-            #[cfg(feature = "local_fs")]
             github_repo_model: None,
             pending_context_block_ids: HashSet::new(),
             pending_context_selected_text: None,
@@ -314,7 +310,6 @@ impl BlocklistAIContextModel {
         Self {
             terminal_model,
             directory_context: Default::default(),
-            #[cfg(feature = "local_fs")]
             github_repo_model: None,
             pending_context_block_ids: HashSet::new(),
             pending_context_selected_text: None,
@@ -989,13 +984,11 @@ impl BlocklistAIContextModel {
         }
     }
 
-    #[cfg(feature = "local_fs")]
     pub fn set_github_repo_model(&mut self, handle: Option<WeakModelHandle<GitHubRepoModel>>) {
         self.github_repo_model = handle;
     }
 
     /// Builds an `AIAgentContext::Repository` from cached git remote metadata, if available.
-    #[cfg(feature = "local_fs")]
     fn repository_context(&self, app: &AppContext) -> Option<AIAgentContext> {
         let handle = self.github_repo_model.as_ref()?.upgrade(app)?;
         let repository_info = handle.as_ref(app).repository_info(app)?;
@@ -1003,12 +996,6 @@ impl BlocklistAIContextModel {
             repository_info,
         ))
     }
-    #[cfg(not(feature = "local_fs"))]
-    fn repository_context(&self, _app: &AppContext) -> Option<AIAgentContext> {
-        None
-    }
-
-    #[cfg(any(feature = "local_fs", test))]
     fn repository_context_from_repository_info(repository_info: &RepositoryInfo) -> AIAgentContext {
         AIAgentContext::Repository {
             name: repository_info.name.clone(),
@@ -1016,18 +1003,11 @@ impl BlocklistAIContextModel {
         }
     }
 
-    #[cfg(feature = "local_fs")]
     fn pull_request_context(&self, app: &AppContext) -> Option<AIAgentContext> {
         let handle = self.github_repo_model.as_ref()?.upgrade(app)?;
         let pr_info = handle.as_ref(app).pr_info(app)?;
         Self::pull_request_context_from_pr_info(pr_info)
     }
-    #[cfg(not(feature = "local_fs"))]
-    fn pull_request_context(&self, _app: &AppContext) -> Option<AIAgentContext> {
-        None
-    }
-
-    #[cfg(any(feature = "local_fs", test))]
     fn pull_request_context_from_pr_info(pr_info: &PrInfo) -> Option<AIAgentContext> {
         Some(AIAgentContext::PullRequest {
             number: i32::try_from(pr_info.number).ok()?,

--- a/app/src/ai/blocklist/context_model.rs
+++ b/app/src/ai/blocklist/context_model.rs
@@ -998,7 +998,7 @@ impl BlocklistAIContextModel {
     #[cfg(feature = "local_fs")]
     fn repository_context(&self, app: &AppContext) -> Option<AIAgentContext> {
         let handle = self.github_repo_model.as_ref()?.upgrade(app)?;
-        let repository_info = handle.as_ref(app).repository_info()?;
+        let repository_info = handle.as_ref(app).repository_info(app)?;
         Some(Self::repository_context_from_repository_info(
             repository_info,
         ))
@@ -1019,7 +1019,7 @@ impl BlocklistAIContextModel {
     #[cfg(feature = "local_fs")]
     fn pull_request_context(&self, app: &AppContext) -> Option<AIAgentContext> {
         let handle = self.github_repo_model.as_ref()?.upgrade(app)?;
-        let pr_info = handle.as_ref(app).pr_info()?;
+        let pr_info = handle.as_ref(app).pr_info(app)?;
         Self::pull_request_context_from_pr_info(pr_info)
     }
     #[cfg(not(feature = "local_fs"))]

--- a/app/src/ai/blocklist/context_model_tests.rs
+++ b/app/src/ai/blocklist/context_model_tests.rs
@@ -24,7 +24,7 @@ use crate::ai::blocklist::{
     BlocklistAIHistoryModel, QueuedQuery, QueuedQueryModel, QueuedQueryOrigin,
 };
 #[cfg(feature = "local_fs")]
-use crate::code_review::git_status_update::GitRepoStatusModel;
+use crate::code_review::git_repo_model::GitRepoStatusModel;
 #[cfg(feature = "local_fs")]
 use crate::code_review::github_repo_model::GitHubRepoModel;
 use crate::terminal::color::{self, Colors};
@@ -66,8 +66,10 @@ fn repository_context_reads_github_repo_model() {
                 )
                 .unwrap()
         });
-        let git_status = app.add_model(move |_| GitRepoStatusModel::new_for_test(repository, None));
-        let github_repo_model = app.add_model(move |_| GitHubRepoModel::new_for_test(git_status));
+        let git_status =
+            app.add_model(move |ctx| GitRepoStatusModel::new_local_for_test(repository, None, ctx));
+        let github_repo_model =
+            app.add_model(move |ctx| GitHubRepoModel::new_local_for_test(git_status, ctx));
 
         github_repo_model.update(&mut app, |model, ctx| {
             model.set_repository_info_for_test(
@@ -248,8 +250,10 @@ fn pull_request_context_reads_github_repo_model() {
                 )
                 .unwrap()
         });
-        let git_status = app.add_model(move |_| GitRepoStatusModel::new_for_test(repository, None));
-        let github_repo_model = app.add_model(move |_| GitHubRepoModel::new_for_test(git_status));
+        let git_status =
+            app.add_model(move |ctx| GitRepoStatusModel::new_local_for_test(repository, None, ctx));
+        let github_repo_model =
+            app.add_model(move |ctx| GitHubRepoModel::new_local_for_test(git_status, ctx));
 
         github_repo_model.update(&mut app, |model, ctx| {
             model.set_pr_info_for_test(

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -99,9 +99,7 @@ use crate::code_review::diff_state::{
 };
 use crate::code_review::editor_state::CodeReviewEditorState;
 use crate::code_review::find_model::CodeReviewFindModel;
-#[cfg(feature = "local_fs")]
 use crate::code_review::git_repo_model::{GitRepoModels, GitRepoStatusEvent, GitRepoStatusModel};
-#[cfg(feature = "local_fs")]
 use crate::code_review::github_repo_model::{GitHubRepoEvent, GitHubRepoModel};
 use crate::code_review::hidden_lines::calculate_hidden_lines;
 #[cfg(feature = "local_fs")]
@@ -649,10 +647,8 @@ pub struct CodeReviewView {
     /// Active git-operation dialog overlay (commit / push / publish), if open.
     git_dialog: Option<ViewHandle<GitDialog>>,
     /// Per-repo git status model for the current repository, if any.
-    #[cfg(feature = "local_fs")]
     git_repo_status: Option<ModelHandle<GitRepoStatusModel>>,
     /// Per-repo GitHub-info model for the current repository, if any.
-    #[cfg(feature = "local_fs")]
     github_repo_model: Option<ModelHandle<GitHubRepoModel>>,
 }
 
@@ -701,11 +697,8 @@ impl CodeReviewView {
         self.is_open = true;
 
         ctx.subscribe_to_model(&self.diff_state_model, Self::handle_diff_state_model_event);
-        #[cfg(feature = "local_fs")]
-        {
-            self.subscribe_to_git_repo_status_model(ctx);
-            self.subscribe_to_github_repo_model(ctx);
-        }
+        self.subscribe_to_git_repo_status_model(ctx);
+        self.subscribe_to_github_repo_model(ctx);
         if self.repo_path().is_some() {
             self.fetch_branches_and_setup_dropdown(ctx);
         }
@@ -770,11 +763,8 @@ impl CodeReviewView {
         }
 
         ctx.unsubscribe_to_model(&self.diff_state_model);
-        #[cfg(feature = "local_fs")]
-        {
-            self.unsubscribe_from_git_repo_status_model(ctx);
-            self.unsubscribe_from_github_repo_model(ctx);
-        }
+        self.unsubscribe_from_git_repo_status_model(ctx);
+        self.unsubscribe_from_github_repo_model(ctx);
 
         self.code_review_footer = None;
 
@@ -1350,9 +1340,7 @@ impl CodeReviewView {
             is_open: false,
             code_review_footer: None,
             git_dialog: None,
-            #[cfg(feature = "local_fs")]
             git_repo_status: None,
-            #[cfg(feature = "local_fs")]
             github_repo_model: None,
         };
         view.set_active_repo_comment_model(comment_batch_model, ctx);
@@ -6309,35 +6297,18 @@ impl CodeReviewView {
     /// The model dispatches to a local `gh`-driven backend or a remote
     /// GitHub PR-info push receiver.
     fn pr_info(&self, ctx: &AppContext) -> Option<PrInfo> {
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "local_fs")] {
-                let github_repo_model = self.github_repo_model.as_ref()?;
-                github_repo_model.as_ref(ctx).pr_info(ctx).cloned()
-            } else {
-                let _ = ctx;
-                None
-            }
-        }
+        let github_repo_model = self.github_repo_model.as_ref()?;
+        github_repo_model.as_ref(ctx).pr_info(ctx).cloned()
     }
 
     /// Whether a `gh pr view` lookup is currently in flight.
     fn is_pr_info_refreshing(&self, ctx: &AppContext) -> bool {
-        #[cfg(feature = "local_fs")]
-        {
-            self.github_repo_model
-                .as_ref()
-                .map(|h| h.as_ref(ctx).is_refreshing_pr_info(ctx))
-                .unwrap_or(false)
-        }
-
-        #[cfg(not(feature = "local_fs"))]
-        {
-            let _ = ctx;
-            false
-        }
+        self.github_repo_model
+            .as_ref()
+            .map(|h| h.as_ref(ctx).is_refreshing_pr_info(ctx))
+            .unwrap_or(false)
     }
 
-    #[cfg(feature = "local_fs")]
     fn refresh_pr_info(&self, ctx: &mut ViewContext<Self>) {
         let Some(handle) = self.github_repo_model.as_ref() else {
             return;
@@ -6347,11 +6318,7 @@ impl CodeReviewView {
         });
     }
 
-    #[cfg(not(feature = "local_fs"))]
-    fn refresh_pr_info(&self, _ctx: &mut ViewContext<Self>) {}
-
     /// Subscribes to the per-repo git status model.
-    #[cfg(feature = "local_fs")]
     fn subscribe_to_git_repo_status_model(&mut self, ctx: &mut ViewContext<Self>) {
         let Some(repo) = self.repo_path().cloned() else {
             return;
@@ -6374,7 +6341,6 @@ impl CodeReviewView {
     }
 
     /// Subscribes to the per-repo GitHub-info model.
-    #[cfg(feature = "local_fs")]
     fn subscribe_to_github_repo_model(&mut self, ctx: &mut ViewContext<Self>) {
         let Some(repo) = self.repo_path().cloned() else {
             return;
@@ -6399,14 +6365,12 @@ impl CodeReviewView {
         self.github_repo_model = Some(handle);
     }
 
-    #[cfg(feature = "local_fs")]
     fn unsubscribe_from_git_repo_status_model(&mut self, ctx: &mut ViewContext<Self>) {
         if let Some(handle) = self.git_repo_status.take() {
             ctx.unsubscribe_to_model(&handle);
         }
     }
 
-    #[cfg(feature = "local_fs")]
     fn unsubscribe_from_github_repo_model(&mut self, ctx: &mut ViewContext<Self>) {
         if let Some(handle) = self.github_repo_model.take() {
             ctx.unsubscribe_to_model(&handle);

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -706,15 +706,6 @@ impl CodeReviewView {
             self.subscribe_to_git_repo_status_model(ctx);
             self.subscribe_to_github_repo_model(ctx);
         }
-        // Remote repos kick off a separate `GetPrInfo` fetch via the remote server manager.
-        // TODO: source the info from the `GitRepoStatusModel` as done for local repos.
-        if FeatureFlag::GitOperationsInCodeReview.is_enabled()
-            && self.repo_path().is_some_and(LocalOrRemotePath::is_remote)
-        {
-            self.diff_state_model.update(ctx, |model, ctx| {
-                model.fetch_pr_info(ctx);
-            });
-        }
         if self.repo_path().is_some() {
             self.fetch_branches_and_setup_dropdown(ctx);
         }
@@ -2319,17 +2310,6 @@ impl CodeReviewView {
             DiffStateModelEvent::CurrentBranchChanged => {
                 self.fetch_branches_and_setup_dropdown(ctx);
                 self.update_diff_selector_selection(ctx);
-                // PR info is branch-specific. Local repos re-fetch automatically
-                // via `GitRepoStatusModel` (it keys off branch changes); remote
-                // repos must re-issue `GetPrInfo` here, since the diff-state
-                // sync doesn't carry PR info.
-                if FeatureFlag::GitOperationsInCodeReview.is_enabled()
-                    && self.repo_path().is_some_and(LocalOrRemotePath::is_remote)
-                {
-                    self.diff_state_model.update(ctx, |model, ctx| {
-                        model.fetch_pr_info(ctx);
-                    });
-                }
             }
             DiffStateModelEvent::NewDiffsComputed {
                 diffs,

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -6325,16 +6325,14 @@ impl CodeReviewView {
 
     /// Returns PR info for the current branch.
     ///
-    /// Routed by repo location: local repos read from the per-repo
-    /// `GitHubRepoModel`, while remote repos read from the diff model.
+    /// Local and remote repos both read from the per-repo `GitHubRepoModel`.
+    /// The model dispatches to a local `gh`-driven backend or a remote
+    /// GitHub PR-info push receiver.
     fn pr_info(&self, ctx: &AppContext) -> Option<PrInfo> {
-        if self.repo_path().is_some_and(LocalOrRemotePath::is_remote) {
-            return self.diff_state_model.as_ref(ctx).pr_info(ctx);
-        }
         cfg_if::cfg_if! {
             if #[cfg(feature = "local_fs")] {
                 let github_repo_model = self.github_repo_model.as_ref()?;
-                github_repo_model.as_ref(ctx).pr_info().cloned()
+                github_repo_model.as_ref(ctx).pr_info(ctx).cloned()
             } else {
                 None
             }
@@ -6347,7 +6345,7 @@ impl CodeReviewView {
         {
             self.github_repo_model
                 .as_ref()
-                .map(|h| h.as_ref(ctx).is_refreshing_pr_info())
+                .map(|h| h.as_ref(ctx).is_refreshing_pr_info(ctx))
                 .unwrap_or(false)
         }
 
@@ -6374,11 +6372,7 @@ impl CodeReviewView {
     /// Subscribes to the per-repo git status model.
     #[cfg(feature = "local_fs")]
     fn subscribe_to_git_repo_status_model(&mut self, ctx: &mut ViewContext<Self>) {
-        let Some(repo_path) = self
-            .repo_path()
-            .and_then(LocalOrRemotePath::to_local_path)
-            .map(Path::to_path_buf)
-        else {
+        let Some(repo) = self.repo_path().cloned() else {
             return;
         };
         let result =
@@ -6401,11 +6395,7 @@ impl CodeReviewView {
     /// Subscribes to the per-repo GitHub-info model.
     #[cfg(feature = "local_fs")]
     fn subscribe_to_github_repo_model(&mut self, ctx: &mut ViewContext<Self>) {
-        let Some(repo_path) = self
-            .repo_path()
-            .and_then(LocalOrRemotePath::to_local_path)
-            .map(Path::to_path_buf)
-        else {
+        let Some(repo) = self.repo_path().cloned() else {
             return;
         };
 

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -6314,6 +6314,7 @@ impl CodeReviewView {
                 let github_repo_model = self.github_repo_model.as_ref()?;
                 github_repo_model.as_ref(ctx).pr_info(ctx).cloned()
             } else {
+                let _ = ctx;
                 None
             }
         }

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -100,9 +100,7 @@ use crate::code_review::diff_state::{
 use crate::code_review::editor_state::CodeReviewEditorState;
 use crate::code_review::find_model::CodeReviewFindModel;
 #[cfg(feature = "local_fs")]
-use crate::code_review::git_status_update::{
-    GitRepoStatusEvent, GitRepoStatusModel, GitStatusUpdateModel,
-};
+use crate::code_review::git_repo_model::{GitRepoModels, GitRepoStatusEvent, GitRepoStatusModel};
 #[cfg(feature = "local_fs")]
 use crate::code_review::github_repo_model::{GitHubRepoEvent, GitHubRepoModel};
 use crate::code_review::hidden_lines::calculate_hidden_lines;
@@ -6383,8 +6381,8 @@ impl CodeReviewView {
         else {
             return;
         };
-        let result = GitStatusUpdateModel::handle(ctx)
-            .update(ctx, |model, ctx| model.subscribe(&repo_path, ctx));
+        let result =
+            GitRepoModels::handle(ctx).update(ctx, |model, ctx| model.subscribe(&repo, ctx));
         let handle = match result {
             Ok(handle) => handle,
             Err(err) => {
@@ -6411,9 +6409,8 @@ impl CodeReviewView {
             return;
         };
 
-        let result = GitStatusUpdateModel::handle(ctx).update(ctx, |model, ctx| {
-            model.subscribe_github_repo(&repo_path, ctx)
-        });
+        let result = GitRepoModels::handle(ctx)
+            .update(ctx, |model, ctx| model.subscribe_github_repo(&repo, ctx));
         let handle = match result {
             Ok(handle) => handle,
             Err(err) => {

--- a/app/src/code_review/code_review_view_tests.rs
+++ b/app/src/code_review/code_review_view_tests.rs
@@ -30,7 +30,7 @@ use crate::code_review::comments::{
 use crate::code_review::diff_size_limits::DiffSize;
 use crate::code_review::diff_state::{DiffStateModel, FileDiff, GitFileStatus};
 use crate::code_review::editor_state::CodeReviewEditorState;
-use crate::code_review::git_status_update::GitStatusUpdateModel;
+use crate::code_review::git_repo_model::GitRepoModels;
 use crate::code_review::GlobalCodeReviewModel;
 use crate::pane_group::WorkingDirectoriesModel;
 use crate::server::server_api::team::MockTeamClient;
@@ -77,7 +77,7 @@ fn initialize_test_app(app: &mut App) {
     app.add_singleton_model(|_| VimRegisters::new());
     app.add_singleton_model(|_| KeybindingChangedNotifier::mock());
     app.add_singleton_model(|_| DetectedRepositories::default());
-    app.add_singleton_model(|_| GitStatusUpdateModel::new());
+    app.add_singleton_model(|_| GitRepoModels::new());
     app.add_singleton_model(|_| LspManagerModel::new());
     app.add_singleton_model(|_| LocalShellState::NotLoaded);
     app.add_singleton_model(PersistedWorkspace::new_for_test);

--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -1571,7 +1571,6 @@ impl LocalDiffStateModel {
             has_head_commit,
             unpushed_commits,
             upstream_ref,
-            pr_info: None,
         })
     }
 

--- a/app/src/code_review/diff_state/mod.rs
+++ b/app/src/code_review/diff_state/mod.rs
@@ -335,7 +335,6 @@ pub struct DiffMetadata {
     pub has_head_commit: bool,
     pub unpushed_commits: Vec<Commit>,
     pub upstream_ref: Option<String>,
-    pub pr_info: Option<PrInfo>,
 }
 
 #[derive(Clone, Default, Debug)]
@@ -391,7 +390,7 @@ pub enum DiffStateModelEvent {
     /// Branch list received from the backend (local git or remote server).
     BranchesReceived(Vec<BranchEntry>),
     /// A remote git operation completed. The model has already applied any
-    /// successful delta / PR info to the cached metadata.
+    /// successful metadata delta to the cached metadata.
     GitOpCompleted(GitOpResult),
     /// An AI-generated commit message arrived from the remote daemon (issued
     /// at commit-dialog open). `Ok` carries the message, `Err` the error
@@ -822,19 +821,6 @@ impl DiffStateModel {
         }
     }
 
-    /// Fetches PR info for the current branch. Remote repos issue the
-    /// `GetPrInfo` RPC; the result lands in `metadata.pr_info` and emits
-    /// `MetadataRefreshed`. Local repos source PR info from
-    /// `GitRepoStatusModel`, so this is a no-op for them.
-    pub(crate) fn fetch_pr_info(&self, ctx: &mut ModelContext<Self>) {
-        match self {
-            Self::Local(_) => {}
-            Self::Remote(model) => model.update(ctx, |model, ctx| {
-                model.fetch_pr_info(ctx);
-            }),
-        }
-    }
-
     /// Fetches the committed branch files (`merge_base(HEAD, main)..HEAD`) for
     /// the Create PR dialog's Changes box. Both backends deliver the result via
     /// `DiffStateModelEvent::BranchCommittedFilesReceived`: the local model
@@ -849,15 +835,6 @@ impl DiffStateModel {
             Self::Remote(model) => model.update(ctx, |model, ctx| {
                 model.fetch_committed_branch_files(ctx);
             }),
-        }
-    }
-
-    /// PR info for the current branch, for remote repos only. Local repos
-    /// source PR info from `GitRepoStatusModel`, so this returns `None`.
-    pub(crate) fn pr_info(&self, ctx: &AppContext) -> Option<PrInfo> {
-        match self {
-            Self::Local(_) => None,
-            Self::Remote(m) => m.as_ref(ctx).pr_info().cloned(),
         }
     }
 

--- a/app/src/code_review/diff_state/remote.rs
+++ b/app/src/code_review/diff_state/remote.rs
@@ -197,13 +197,6 @@ impl RemoteDiffStateModel {
             } if host_id == &self.remote_path.host_id && repo_path == &self.remote_path.path => {
                 self.handle_create_pr_response(result, ctx);
             }
-            RemoteServerManagerEvent::GetPrInfoResponse {
-                host_id,
-                repo_path,
-                result,
-            } if host_id == &self.remote_path.host_id && repo_path == &self.remote_path.path => {
-                self.handle_get_pr_info_response(result, ctx);
-            }
             RemoteServerManagerEvent::GenerateCommitMessageResponse {
                 host_id,
                 repo_path,
@@ -479,18 +472,7 @@ impl RemoteDiffStateModel {
         let branch_changed =
             previous_branch.is_some_and(|prev| prev != metadata.current_branch_name.as_str());
 
-        // PR info is owned by the separate GetPrInfo / CreatePr channel
-        // (`apply_pr_info`), not the diff-state sync: the daemon's
-        // `load_metadata_for_repo` always sends `pr_info: None`. A wholesale
-        // replace would therefore wipe the fetched value and revert the
-        // header's PR button on the next server push. Preserve the cached value
-        // when the sync doesn't carry one and the branch is unchanged — PR info
-        // is branch-specific, so a branch change clears it (the view re-fetches
-        // on `CurrentBranchChanged`).
-        let mut metadata = metadata.clone();
-        if !branch_changed && metadata.pr_info.is_none() {
-            metadata.pr_info = self.metadata.as_ref().and_then(|m| m.pr_info.clone());
-        }
+        let metadata = metadata.clone();
         self.metadata = Some(metadata.clone());
 
         // Only emit CurrentBranchChanged when there was a previous branch to
@@ -649,9 +631,9 @@ impl RemoteDiffStateModel {
     ) {
         let domain_result = match result {
             Ok(success) => {
-                // Apply the delta and any created-PR info in a single metadata
-                // mutation so the header re-renders from one
-                // `MetadataRefreshed` rather than two.
+                // Apply the delta before emitting the completion event so the
+                // header updates immediately. PR info is returned in the event
+                // result and refreshed through the shared `GitHubRepoModel`.
                 let commits = success
                     .delta
                     .unpushed_commits
@@ -662,9 +644,6 @@ impl RemoteDiffStateModel {
                 let metadata = self.metadata.get_or_insert_with(DiffMetadata::default);
                 metadata.unpushed_commits = commits;
                 metadata.upstream_ref = success.delta.upstream_ref.clone();
-                if let Some(ref pr) = pr_info {
-                    metadata.pr_info = Some(pr.clone());
-                }
                 ctx.emit(DiffStateModelEvent::MetadataRefreshed(Box::new(
                     metadata.clone(),
                 )));
@@ -700,37 +679,12 @@ impl RemoteDiffStateModel {
         ctx: &mut ModelContext<Self>,
     ) {
         let domain_result = match result {
-            Ok(proto_pr) => {
-                let pr_info = PrInfo::from(proto_pr);
-                // Reuse the shared PR-info applier (sets metadata.pr_info and
-                // emits MetadataRefreshed).
-                self.apply_pr_info(Some(pr_info.clone()), ctx);
-                Ok(pr_info)
-            }
+            Ok(proto_pr) => Ok(PrInfo::from(proto_pr)),
             Err(msg) => Err(msg.clone()),
         };
         ctx.emit(DiffStateModelEvent::GitOpCompleted(
             super::GitOpResult::PrCreated(domain_result),
         ));
-    }
-
-    /// Handles a `GetPrInfoResponse`: applies the fetched PR info (or clears
-    /// it when there is no open PR) so the header reflects real PR state.
-    /// Errors are logged and leave the cached value untouched.
-    fn handle_get_pr_info_response(
-        &mut self,
-        result: &Result<Option<remote_server::proto::PrInfo>, String>,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        match result {
-            Ok(proto_pr) => {
-                let pr_info = proto_pr.as_ref().map(PrInfo::from);
-                self.apply_pr_info(pr_info, ctx);
-            }
-            Err(msg) => {
-                log::warn!("RemoteDiffStateModel: GetPrInfo failed: {msg}");
-            }
-        }
     }
 
     /// Handles a `GetCommittedBranchFilesResponse`: converts the proto entries
@@ -799,17 +753,6 @@ impl RemoteDiffStateModel {
         let repo_path = self.remote_path.path.clone();
         RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
             mgr.git_generate_commit_message(host_id, repo_path, include_unstaged, branch_name, ctx);
-        });
-    }
-
-    /// Fetches PR info for the current branch via the remote `GetPrInfo`
-    /// command. The result arrives as a `GetPrInfoResponse` manager event,
-    /// handled in `handle_manager_event`, which applies it to metadata.
-    pub fn fetch_pr_info(&self, ctx: &mut ModelContext<Self>) {
-        let host_id = self.remote_path.host_id.clone();
-        let repo_path = self.remote_path.path.clone();
-        RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
-            mgr.git_get_pr_info(host_id, repo_path, ctx);
         });
     }
 
@@ -927,23 +870,6 @@ impl RemoteDiffStateModel {
         ctx.emit(DiffStateModelEvent::MetadataRefreshed(Box::new(
             metadata.clone(),
         )));
-    }
-
-    /// Applies PR info fetched via the remote `GetPrInfo` / `CreatePr` command
-    /// to the cached metadata and emits `MetadataRefreshed`. This is the
-    /// remote source of PR info (the local `GitRepoStatusModel` has no remote
-    /// equivalent yet).
-    pub fn apply_pr_info(&mut self, pr_info: Option<PrInfo>, ctx: &mut ModelContext<Self>) {
-        let metadata = self.metadata.get_or_insert_with(DiffMetadata::default);
-        metadata.pr_info = pr_info;
-        ctx.emit(DiffStateModelEvent::MetadataRefreshed(Box::new(
-            metadata.clone(),
-        )));
-    }
-
-    /// Returns the cached PR info for the current branch, if any.
-    pub fn pr_info(&self) -> Option<&PrInfo> {
-        self.metadata.as_ref().and_then(|m| m.pr_info.as_ref())
     }
 }
 

--- a/app/src/code_review/diff_state/remote_tests.rs
+++ b/app/src/code_review/diff_state/remote_tests.rs
@@ -12,7 +12,7 @@ use crate::code_review::diff_state::{
     GitDiffWithBaseContent, GitFileStatus, RemoteDiffStateModel,
 };
 use crate::server::telemetry::context_provider::AppTelemetryContextProvider;
-use crate::util::git::{Commit, PrInfo};
+use crate::util::git::Commit;
 
 impl RemoteDiffStateModel {
     fn new_for_test(
@@ -46,7 +46,6 @@ fn empty_metadata(branch: &str) -> DiffMetadata {
         has_head_commit: true,
         unpushed_commits: vec![],
         upstream_ref: None,
-        pr_info: None,
     }
 }
 
@@ -129,13 +128,6 @@ fn test_metadata(branch: &str) -> DiffMetadata {
             files: vec![],
         }],
         upstream_ref: Some("origin/feature".to_string()),
-        pr_info: Some(PrInfo {
-            number: 42,
-            url: "https://github.com/test/repo/pull/42".to_string(),
-            state: String::new(),
-            draft: false,
-            base_branch: String::new(),
-        }),
     }
 }
 

--- a/app/src/code_review/git_actions.rs
+++ b/app/src/code_review/git_actions.rs
@@ -78,13 +78,6 @@ pub async fn create_pr(
     }
 }
 
-/// Fetches PR info for the current branch (the "view PR" action). Returns
-/// `Ok(None)` when the branch has no open PR.
-#[cfg_attr(target_family = "wasm", allow(dead_code))]
-pub async fn get_pr(repo_path: &Path, path_env: Option<&str>) -> anyhow::Result<Option<PrInfo>> {
-    git::get_pr_for_branch(repo_path, path_env).await
-}
-
 /// Generates an AI commit message for the working-tree changes.
 /// Bails when there's nothing to summarize (empty diff) or the model returns an empty message.
 pub async fn generate_commit_message(

--- a/app/src/code_review/git_repo_model/local.rs
+++ b/app/src/code_review/git_repo_model/local.rs
@@ -1,156 +1,16 @@
-#[cfg(feature = "local_fs")]
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
-#[cfg(feature = "local_fs")]
-use warpui::ModelContext;
-use warpui::{Entity, SingletonEntity};
-#[cfg(feature = "local_fs")]
-use {
-    crate::throttle::throttle,
-    crate::util::git::{detect_current_branch_display, detect_main_branch},
-    async_channel::Sender,
-    repo_metadata::{
-        repositories::DetectedRepositories,
-        repository::{RepositorySubscriber, SubscriberId},
-        Repository, RepositoryUpdate,
-    },
-    std::{collections::HashMap, time::Duration},
-    warpui::{r#async::SpawnedFutureHandle, ModelHandle, WeakModelHandle},
-};
+use async_channel::Sender;
+use repo_metadata::repository::{RepositorySubscriber, SubscriberId};
+use repo_metadata::{Repository, RepositoryUpdate};
+use warpui::r#async::SpawnedFutureHandle;
+use warpui::{Entity, ModelContext, ModelHandle};
 
-#[cfg(feature = "local_fs")]
-use super::diff_state::{diff_metadata_against_head, DiffStats};
-#[cfg(feature = "local_fs")]
-use super::github_repo_model::GitHubRepoModel;
-
-/// Public metadata exposed to consumers — the subset of diff metadata
-/// that the git chip (prompt display, agent view footer) needs.
-#[cfg(feature = "local_fs")]
-#[derive(Debug, Clone)]
-pub struct GitStatusMetadata {
-    pub current_branch_name: String,
-    pub main_branch_name: String,
-    pub stats_against_head: DiffStats,
-}
-
-// ── GitStatusUpdateModel (singleton cache) ──────────────────────────────────
-
-/// Singleton model that acts as a cache / factory for per-repository
-/// [`GitRepoStatusModel`] and [`GitHubRepoModel`] instances.
-///
-/// Multiple terminals in the same repo share a single sub-model.  When the last
-/// strong handle to a sub-model is dropped, the models are torn down automatically.
-pub struct GitStatusUpdateModel {
-    #[cfg(feature = "local_fs")]
-    git_repo_status_models: HashMap<PathBuf, WeakModelHandle<GitRepoStatusModel>>,
-    #[cfg(feature = "local_fs")]
-    github_repo_models: HashMap<PathBuf, WeakModelHandle<GitHubRepoModel>>,
-}
-
-// ── Non-local_fs stub ───────────────────────────────────────────────────────
-
-#[cfg(not(feature = "local_fs"))]
-#[allow(dead_code)]
-impl GitStatusUpdateModel {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-// ── local_fs implementation ─────────────────────────────────────────────────
-
-#[cfg(feature = "local_fs")]
-impl GitStatusUpdateModel {
-    pub fn new() -> Self {
-        Self {
-            git_repo_status_models: HashMap::new(),
-            github_repo_models: HashMap::new(),
-        }
-    }
-
-    /// Get or create a per-repo status model for `repo_path`.
-    ///
-    /// If a live model already exists for this path, returns a new strong handle
-    /// to it.  Otherwise, creates a new [`GitRepoStatusModel`] with an active
-    /// filesystem watcher and returns a handle to it.
-    ///
-    /// Callers hold the returned `ModelHandle` for as long as they need updates.
-    /// When all handles are dropped, the model (and its watcher) is torn down.
-    pub fn subscribe(
-        &mut self,
-        repo_path: &Path,
-        ctx: &mut ModelContext<Self>,
-    ) -> anyhow::Result<ModelHandle<GitRepoStatusModel>> {
-        let repo_path_buf = repo_path.to_path_buf();
-
-        // Check the cache for an existing live model.
-        if let Some(weak) = self.git_repo_status_models.get(&repo_path_buf) {
-            if let Some(handle) = weak.upgrade(ctx) {
-                return Ok(handle);
-            }
-        }
-
-        // Create a new sub-model.
-        let Some(repository_model) =
-            DetectedRepositories::as_ref(ctx).get_local_watched_repo_for_path(repo_path, ctx)
-        else {
-            anyhow::bail!(
-                "No watched repository found for path: {}",
-                repo_path.display()
-            );
-        };
-
-        let handle = ctx
-            .add_model(|ctx| GitRepoStatusModel::new(repo_path_buf.clone(), repository_model, ctx));
-
-        self.git_repo_status_models
-            .insert(repo_path_buf, handle.downgrade());
-        Ok(handle)
-    }
-
-    /// Get or create a per-repo GitHub-info model for `repo_path`.
-    ///
-    /// If a live model already exists for this path, returns a new strong handle
-    /// to it.  Otherwise, creates a new [`GitHubRepoModel`].
-    ///
-    /// The model subscribes to the git status model for the repository and
-    /// tracks the current branch. GitHub PR info and repository info are fetched
-    /// on creation, on branch change, and on a periodic timer.
-    ///
-    /// Callers hold the returned `ModelHandle` for as long as they need updates.
-    /// When all handles are dropped, the model and its in-flight fetches are torn down.
-    pub fn subscribe_github_repo(
-        &mut self,
-        repo_path: &Path,
-        ctx: &mut ModelContext<Self>,
-    ) -> anyhow::Result<ModelHandle<GitHubRepoModel>> {
-        let repo_path_buf = repo_path.to_path_buf();
-
-        // Check the cache for an existing live model.
-        if let Some(weak) = self.github_repo_models.get(&repo_path_buf) {
-            if let Some(handle) = weak.upgrade(ctx) {
-                return Ok(handle);
-            }
-        }
-
-        // GitHubRepoModel needs a sibling GitRepoStatusModel for branch info.
-        let git_status = self.subscribe(repo_path, ctx)?;
-        let handle =
-            ctx.add_model(|ctx| GitHubRepoModel::new(repo_path_buf.clone(), git_status, ctx));
-
-        self.github_repo_models
-            .insert(repo_path_buf, handle.downgrade());
-        Ok(handle)
-    }
-}
-
-impl Entity for GitStatusUpdateModel {
-    type Event = ();
-}
-
-impl SingletonEntity for GitStatusUpdateModel {}
-
-// ── GitRepoStatusModel ──────────────────────────────────────────────────────
+use super::{GitRepoStatusEvent, GitStatusMetadata};
+use crate::code_review::diff_state::diff_metadata_against_head;
+use crate::throttle::throttle;
+use crate::util::git::{detect_current_branch_display, detect_main_branch};
 
 /// Per-repository model that owns the filesystem watcher and exposes git status
 /// metadata. Consumers hold a `ModelHandle<GitRepoStatusModel>` and subscribe
@@ -158,8 +18,7 @@ impl SingletonEntity for GitStatusUpdateModel {}
 ///
 /// When all strong handles are dropped the model (and its watcher) is
 /// automatically torn down.
-#[cfg(feature = "local_fs")]
-pub struct GitRepoStatusModel {
+pub struct LocalGitRepoStatusModel {
     repo_path: PathBuf,
     repository: ModelHandle<Repository>,
     subscriber_id: Option<SubscriberId>,
@@ -167,32 +26,14 @@ pub struct GitRepoStatusModel {
     computing_metadata_abort_handle: Option<SpawnedFutureHandle>,
 }
 
-#[cfg(not(feature = "local_fs"))]
-#[allow(dead_code)]
-pub struct GitRepoStatusModel;
-
-#[cfg(not(feature = "local_fs"))]
-impl Entity for GitRepoStatusModel {
-    type Event = ();
-}
-
-#[cfg(feature = "local_fs")]
-#[derive(Debug)]
-pub enum GitRepoStatusEvent {
-    /// Emitted whenever the metadata changes (branch name, diff stats, etc.).
-    MetadataChanged,
-}
-
-#[cfg(feature = "local_fs")]
-impl Entity for GitRepoStatusModel {
+impl Entity for LocalGitRepoStatusModel {
     type Event = GitRepoStatusEvent;
 }
 
-#[cfg(feature = "local_fs")]
-impl GitRepoStatusModel {
+impl LocalGitRepoStatusModel {
     /// Create a new per-repo status model, set up the filesystem watcher, and
     /// kick off the initial metadata computation.
-    fn new(
+    pub(super) fn new(
         repo_path: PathBuf,
         repository_model: ModelHandle<Repository>,
         ctx: &mut ModelContext<Self>,
@@ -348,8 +189,8 @@ impl GitRepoStatusModel {
     }
 }
 
-#[cfg(all(test, feature = "local_fs"))]
-impl GitRepoStatusModel {
+#[cfg(test)]
+impl LocalGitRepoStatusModel {
     pub(crate) fn new_for_test(
         repository: ModelHandle<Repository>,
         metadata: Option<GitStatusMetadata>,
@@ -373,12 +214,11 @@ impl GitRepoStatusModel {
     }
 }
 
-#[cfg(all(test, feature = "local_fs"))]
-#[path = "git_status_update_tests.rs"]
+#[cfg(test)]
+#[path = "local_tests.rs"]
 mod tests;
 
-#[cfg(feature = "local_fs")]
-impl Drop for GitRepoStatusModel {
+impl Drop for LocalGitRepoStatusModel {
     fn drop(&mut self) {
         // Note: we cannot call `repository.update()` here because `Drop` does
         // not have access to `ModelContext`.  The `Repository` model will clean
@@ -391,12 +231,10 @@ impl Drop for GitRepoStatusModel {
 
 // ── Repository subscriber adapter ───────────────────────────────────────────
 
-#[cfg(feature = "local_fs")]
 struct GitStatusRepositorySubscriber {
     repository_update_tx: Sender<RepositoryUpdate>,
 }
 
-#[cfg(feature = "local_fs")]
 impl RepositorySubscriber for GitStatusRepositorySubscriber {
     fn on_scan(
         &mut self,

--- a/app/src/code_review/git_repo_model/local_tests.rs
+++ b/app/src/code_review/git_repo_model/local_tests.rs
@@ -4,14 +4,13 @@ use repo_metadata::{RepositoryUpdate, TargetFile};
 
 use super::*;
 
-#[cfg(feature = "local_fs")]
 #[test]
 fn should_refresh_metadata_ignores_ignored_file_updates() {
     let mut ignored_update = RepositoryUpdate::default();
     ignored_update
         .modified
         .insert(TargetFile::new(PathBuf::from("/repo/ignored.log"), true));
-    assert!(!GitRepoStatusModel::should_refresh_metadata(
+    assert!(!LocalGitRepoStatusModel::should_refresh_metadata(
         &ignored_update
     ));
 
@@ -19,13 +18,15 @@ fn should_refresh_metadata_ignores_ignored_file_updates() {
     tracked_update
         .modified
         .insert(TargetFile::new(PathBuf::from("/repo/src/main.rs"), false));
-    assert!(GitRepoStatusModel::should_refresh_metadata(&tracked_update));
+    assert!(LocalGitRepoStatusModel::should_refresh_metadata(
+        &tracked_update
+    ));
 
     let remote_ref_update = RepositoryUpdate {
         remote_ref_updated: true,
         ..Default::default()
     };
-    assert!(GitRepoStatusModel::should_refresh_metadata(
+    assert!(LocalGitRepoStatusModel::should_refresh_metadata(
         &remote_ref_update
     ));
 }

--- a/app/src/code_review/git_repo_model/mod.rs
+++ b/app/src/code_review/git_repo_model/mod.rs
@@ -1,24 +1,18 @@
-use warpui::Entity;
-#[cfg(feature = "local_fs")]
-use warpui::{AppContext, ModelContext, ModelHandle};
+use warpui::{AppContext, Entity, ModelContext, ModelHandle};
 
 #[cfg(feature = "local_fs")]
 mod local;
 #[cfg(feature = "local_fs")]
 pub use local::LocalGitRepoStatusModel;
 
-#[cfg(feature = "local_fs")]
 mod remote;
-#[cfg(feature = "local_fs")]
 pub use remote::RemoteGitRepoStatusModel;
 
-#[cfg(feature = "local_fs")]
 use super::diff_state::DiffStats;
 pub use super::git_repo_models::GitRepoModels;
 
 /// Public metadata exposed to consumers — the subset of diff metadata
 /// that the git chip (prompt display, agent view footer) needs.
-#[cfg(feature = "local_fs")]
 #[derive(Debug, Clone)]
 pub struct GitStatusMetadata {
     pub current_branch_name: String,
@@ -28,16 +22,6 @@ pub struct GitStatusMetadata {
 
 // ── GitRepoStatusModel ──────────────────────────────────────────────────────
 
-#[cfg(not(feature = "local_fs"))]
-#[allow(dead_code)]
-pub struct GitRepoStatusModel;
-
-#[cfg(not(feature = "local_fs"))]
-impl Entity for GitRepoStatusModel {
-    type Event = ();
-}
-
-#[cfg(feature = "local_fs")]
 #[derive(Debug)]
 pub enum GitRepoStatusEvent {
     /// Emitted whenever the metadata changes (branch name, diff stats, etc.).
@@ -53,18 +37,16 @@ pub enum GitRepoStatusEvent {
 /// `ModelHandle<GitRepoStatusModel>` and subscribe to its [`GitRepoStatusEvent`]s
 /// without caring whether the repository is local or on an SSH host. Only one
 /// variant is populated at a time.
-#[cfg(feature = "local_fs")]
 pub enum GitRepoStatusModel {
+    #[cfg(feature = "local_fs")]
     Local(ModelHandle<LocalGitRepoStatusModel>),
     Remote(ModelHandle<RemoteGitRepoStatusModel>),
 }
 
-#[cfg(feature = "local_fs")]
 impl Entity for GitRepoStatusModel {
     type Event = GitRepoStatusEvent;
 }
 
-#[cfg(feature = "local_fs")]
 impl GitRepoStatusModel {
     /// Re-emit a sub-model event so subscribers of the unified model observe
     /// the same `GitRepoStatusEvent`s regardless of backend.
@@ -77,6 +59,7 @@ impl GitRepoStatusModel {
     /// Mode-independent status metadata (branch names + HEAD diff stats).
     pub fn metadata<'a>(&self, ctx: &'a AppContext) -> Option<&'a GitStatusMetadata> {
         match self {
+            #[cfg(feature = "local_fs")]
             Self::Local(m) => m.as_ref(ctx).metadata(),
             Self::Remote(m) => m.as_ref(ctx).metadata(),
         }
@@ -85,6 +68,7 @@ impl GitRepoStatusModel {
     /// Force a metadata refresh (branch names, diff stats).
     pub fn refresh_metadata(&self, ctx: &mut ModelContext<Self>) {
         match self {
+            #[cfg(feature = "local_fs")]
             Self::Local(m) => m.update(ctx, |m, ctx| m.refresh_metadata(ctx)),
             Self::Remote(m) => m.update(ctx, |m, ctx| m.request_snapshot(ctx)),
         }
@@ -104,7 +88,6 @@ pub(super) fn new_local_git_repo_status_model(
     })
 }
 
-#[cfg(feature = "local_fs")]
 pub(super) fn new_remote_git_repo_status_model(
     remote_path: warp_util::remote_path::RemotePath,
     ctx: &mut ModelContext<GitRepoModels>,
@@ -135,6 +118,7 @@ impl GitRepoStatusModel {
         ctx: &mut ModelContext<Self>,
     ) {
         match self {
+            #[cfg(feature = "local_fs")]
             Self::Local(m) => m.update(ctx, |m, ctx| m.set_metadata_for_test(metadata, ctx)),
             Self::Remote(_) => unreachable!("remote test models are not used"),
         }

--- a/app/src/code_review/git_repo_model/mod.rs
+++ b/app/src/code_review/git_repo_model/mod.rs
@@ -1,13 +1,6 @@
+use warpui::Entity;
 #[cfg(feature = "local_fs")]
-use std::collections::HashMap;
-
-#[cfg(feature = "local_fs")]
-use repo_metadata::repositories::DetectedRepositories;
-#[cfg(feature = "local_fs")]
-use warp_util::local_or_remote_path::LocalOrRemotePath;
-#[cfg(feature = "local_fs")]
-use warpui::{AppContext, ModelContext, ModelHandle, WeakModelHandle};
-use warpui::{Entity, SingletonEntity};
+use warpui::{AppContext, ModelContext, ModelHandle};
 
 #[cfg(feature = "local_fs")]
 mod local;
@@ -21,8 +14,7 @@ pub use remote::RemoteGitRepoStatusModel;
 
 #[cfg(feature = "local_fs")]
 use super::diff_state::DiffStats;
-#[cfg(feature = "local_fs")]
-use super::github_repo_model::{GitHubRepoModel, LocalGitHubRepoModel, RemoteGitHubRepoModel};
+pub use super::git_repo_models::GitRepoModels;
 
 /// Public metadata exposed to consumers — the subset of diff metadata
 /// that the git chip (prompt display, agent view footer) needs.
@@ -33,160 +25,6 @@ pub struct GitStatusMetadata {
     pub main_branch_name: String,
     pub stats_against_head: DiffStats,
 }
-
-// ── GitRepoModels (singleton cache) ─────────────────────────────────────────
-
-/// Singleton model that acts as a cache / factory for per-repository
-/// [`GitRepoStatusModel`] and [`GitHubRepoModel`] instances.
-///
-/// Multiple terminals in the same repo share a single sub-model.  When the last
-/// strong handle to a sub-model is dropped, the models are torn down automatically.
-pub struct GitRepoModels {
-    // Per-repo status / GitHub-info models, keyed by `LocalOrRemotePath` so a
-    // single cache covers both local (watcher-backed) and remote (push
-    // receiver) repos. Each entry stores the unified-enum handle; callers in
-    // the same repo share it, and it is torn down when the last strong handle
-    // is dropped.
-    #[cfg(feature = "local_fs")]
-    git_status_models: HashMap<LocalOrRemotePath, WeakModelHandle<GitRepoStatusModel>>,
-    #[cfg(feature = "local_fs")]
-    github_repo_models: HashMap<LocalOrRemotePath, WeakModelHandle<GitHubRepoModel>>,
-}
-
-// ── Non-local_fs stub ───────────────────────────────────────────────────────
-
-#[cfg(not(feature = "local_fs"))]
-#[allow(dead_code)]
-impl GitRepoModels {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-// ── local_fs implementation ─────────────────────────────────────────────────
-
-#[cfg(feature = "local_fs")]
-impl GitRepoModels {
-    pub fn new() -> Self {
-        Self {
-            git_status_models: HashMap::new(),
-            github_repo_models: HashMap::new(),
-        }
-    }
-
-    /// Get or create the per-repo status model for `repo`, returning a unified
-    /// [`GitRepoStatusModel`] handle that dispatches to a local watcher-backed
-    /// model or a remote push receiver based on the location.
-    ///
-    /// Multiple callers in the same repo share one model (cached by
-    /// `LocalOrRemotePath`); it is torn down when the last strong handle is
-    /// dropped.
-    ///
-    /// Callers hold the returned `ModelHandle` for as long as they need updates.
-    pub fn subscribe(
-        &mut self,
-        repo: &LocalOrRemotePath,
-        ctx: &mut ModelContext<Self>,
-    ) -> anyhow::Result<ModelHandle<GitRepoStatusModel>> {
-        if let Some(handle) = self
-            .git_status_models
-            .get(repo)
-            .and_then(|weak| weak.upgrade(ctx))
-        {
-            return Ok(handle);
-        }
-
-        let handle = match repo {
-            LocalOrRemotePath::Local(repo_path) => {
-                let Some(repository_model) = DetectedRepositories::as_ref(ctx)
-                    .get_local_watched_repo_for_path(repo_path, ctx)
-                else {
-                    anyhow::bail!(
-                        "No watched repository found for path: {}",
-                        repo_path.display()
-                    );
-                };
-                let repo_path = repo_path.clone();
-                let inner = ctx.add_model(|ctx| {
-                    LocalGitRepoStatusModel::new(repo_path, repository_model, ctx)
-                });
-                ctx.add_model(|ctx| {
-                    ctx.subscribe_to_model(&inner, GitRepoStatusModel::forward_event);
-                    GitRepoStatusModel::Local(inner)
-                })
-            }
-            LocalOrRemotePath::Remote(remote_path) => {
-                let inner =
-                    ctx.add_model(|ctx| RemoteGitRepoStatusModel::new(remote_path.clone(), ctx));
-                ctx.add_model(|ctx| {
-                    ctx.subscribe_to_model(&inner, GitRepoStatusModel::forward_event);
-                    GitRepoStatusModel::Remote(inner)
-                })
-            }
-        };
-
-        self.git_status_models
-            .insert(repo.clone(), handle.downgrade());
-        Ok(handle)
-    }
-
-    /// Get or create the per-repo GitHub-info model for `repo`, returning a
-    /// unified [`GitHubRepoModel`] handle that dispatches to a local
-    /// `gh`-driven model or a remote push receiver based on the location.
-    ///
-    /// The local backend subscribes to the sibling git status model to track
-    /// the current branch and fetches PR / repository info on creation, on
-    /// branch change, and on a periodic timer. Multiple callers in the same
-    /// repo share one model (cached by `LocalOrRemotePath`).
-    ///
-    /// Callers hold the returned `ModelHandle` for as long as they need updates.
-    pub fn subscribe_github_repo(
-        &mut self,
-        repo: &LocalOrRemotePath,
-        ctx: &mut ModelContext<Self>,
-    ) -> anyhow::Result<ModelHandle<GitHubRepoModel>> {
-        if let Some(handle) = self
-            .github_repo_models
-            .get(repo)
-            .and_then(|weak| weak.upgrade(ctx))
-        {
-            return Ok(handle);
-        }
-
-        let handle = match repo {
-            LocalOrRemotePath::Local(repo_path) => {
-                // LocalGitHubRepoModel needs a sibling GitRepoStatusModel for
-                // branch info.
-                let git_status = self.subscribe(repo, ctx)?;
-                let repo_path = repo_path.clone();
-                let inner =
-                    ctx.add_model(|ctx| LocalGitHubRepoModel::new(repo_path, git_status, ctx));
-                ctx.add_model(|ctx| {
-                    ctx.subscribe_to_model(&inner, GitHubRepoModel::forward_event);
-                    GitHubRepoModel::Local(inner)
-                })
-            }
-            LocalOrRemotePath::Remote(remote_path) => {
-                let inner =
-                    ctx.add_model(|ctx| RemoteGitHubRepoModel::new(remote_path.clone(), ctx));
-                ctx.add_model(|ctx| {
-                    ctx.subscribe_to_model(&inner, GitHubRepoModel::forward_event);
-                    GitHubRepoModel::Remote(inner)
-                })
-            }
-        };
-
-        self.github_repo_models
-            .insert(repo.clone(), handle.downgrade());
-        Ok(handle)
-    }
-}
-
-impl Entity for GitRepoModels {
-    type Event = ();
-}
-
-impl SingletonEntity for GitRepoModels {}
 
 // ── GitRepoStatusModel ──────────────────────────────────────────────────────
 
@@ -253,6 +91,30 @@ impl GitRepoStatusModel {
     }
 }
 
+#[cfg(feature = "local_fs")]
+pub(super) fn new_local_git_repo_status_model(
+    repo_path: std::path::PathBuf,
+    repository_model: ModelHandle<repo_metadata::Repository>,
+    ctx: &mut ModelContext<GitRepoModels>,
+) -> ModelHandle<GitRepoStatusModel> {
+    let inner = ctx.add_model(|ctx| LocalGitRepoStatusModel::new(repo_path, repository_model, ctx));
+    ctx.add_model(|ctx| {
+        ctx.subscribe_to_model(&inner, GitRepoStatusModel::forward_event);
+        GitRepoStatusModel::Local(inner)
+    })
+}
+
+#[cfg(feature = "local_fs")]
+pub(super) fn new_remote_git_repo_status_model(
+    remote_path: warp_util::remote_path::RemotePath,
+    ctx: &mut ModelContext<GitRepoModels>,
+) -> ModelHandle<GitRepoStatusModel> {
+    let inner = ctx.add_model(|ctx| RemoteGitRepoStatusModel::new(remote_path, ctx));
+    ctx.add_model(|ctx| {
+        ctx.subscribe_to_model(&inner, GitRepoStatusModel::forward_event);
+        GitRepoStatusModel::Remote(inner)
+    })
+}
 #[cfg(all(test, feature = "local_fs"))]
 impl GitRepoStatusModel {
     /// Wraps a local-backend test model in the unified enum.

--- a/app/src/code_review/git_repo_model/mod.rs
+++ b/app/src/code_review/git_repo_model/mod.rs
@@ -1,0 +1,280 @@
+#[cfg(feature = "local_fs")]
+use std::collections::HashMap;
+
+#[cfg(feature = "local_fs")]
+use repo_metadata::repositories::DetectedRepositories;
+#[cfg(feature = "local_fs")]
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+#[cfg(feature = "local_fs")]
+use warpui::{AppContext, ModelContext, ModelHandle, WeakModelHandle};
+use warpui::{Entity, SingletonEntity};
+
+#[cfg(feature = "local_fs")]
+mod local;
+#[cfg(feature = "local_fs")]
+pub use local::LocalGitRepoStatusModel;
+
+#[cfg(feature = "local_fs")]
+mod remote;
+#[cfg(feature = "local_fs")]
+pub use remote::RemoteGitRepoStatusModel;
+
+#[cfg(feature = "local_fs")]
+use super::diff_state::DiffStats;
+#[cfg(feature = "local_fs")]
+use super::github_repo_model::{GitHubRepoModel, LocalGitHubRepoModel, RemoteGitHubRepoModel};
+
+/// Public metadata exposed to consumers — the subset of diff metadata
+/// that the git chip (prompt display, agent view footer) needs.
+#[cfg(feature = "local_fs")]
+#[derive(Debug, Clone)]
+pub struct GitStatusMetadata {
+    pub current_branch_name: String,
+    pub main_branch_name: String,
+    pub stats_against_head: DiffStats,
+}
+
+// ── GitRepoModels (singleton cache) ─────────────────────────────────────────
+
+/// Singleton model that acts as a cache / factory for per-repository
+/// [`GitRepoStatusModel`] and [`GitHubRepoModel`] instances.
+///
+/// Multiple terminals in the same repo share a single sub-model.  When the last
+/// strong handle to a sub-model is dropped, the models are torn down automatically.
+pub struct GitRepoModels {
+    // Per-repo status / GitHub-info models, keyed by `LocalOrRemotePath` so a
+    // single cache covers both local (watcher-backed) and remote (push
+    // receiver) repos. Each entry stores the unified-enum handle; callers in
+    // the same repo share it, and it is torn down when the last strong handle
+    // is dropped.
+    #[cfg(feature = "local_fs")]
+    git_status_models: HashMap<LocalOrRemotePath, WeakModelHandle<GitRepoStatusModel>>,
+    #[cfg(feature = "local_fs")]
+    github_repo_models: HashMap<LocalOrRemotePath, WeakModelHandle<GitHubRepoModel>>,
+}
+
+// ── Non-local_fs stub ───────────────────────────────────────────────────────
+
+#[cfg(not(feature = "local_fs"))]
+#[allow(dead_code)]
+impl GitRepoModels {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+// ── local_fs implementation ─────────────────────────────────────────────────
+
+#[cfg(feature = "local_fs")]
+impl GitRepoModels {
+    pub fn new() -> Self {
+        Self {
+            git_status_models: HashMap::new(),
+            github_repo_models: HashMap::new(),
+        }
+    }
+
+    /// Get or create the per-repo status model for `repo`, returning a unified
+    /// [`GitRepoStatusModel`] handle that dispatches to a local watcher-backed
+    /// model or a remote push receiver based on the location.
+    ///
+    /// Multiple callers in the same repo share one model (cached by
+    /// `LocalOrRemotePath`); it is torn down when the last strong handle is
+    /// dropped.
+    ///
+    /// Callers hold the returned `ModelHandle` for as long as they need updates.
+    pub fn subscribe(
+        &mut self,
+        repo: &LocalOrRemotePath,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<ModelHandle<GitRepoStatusModel>> {
+        if let Some(handle) = self
+            .git_status_models
+            .get(repo)
+            .and_then(|weak| weak.upgrade(ctx))
+        {
+            return Ok(handle);
+        }
+
+        let handle = match repo {
+            LocalOrRemotePath::Local(repo_path) => {
+                let Some(repository_model) = DetectedRepositories::as_ref(ctx)
+                    .get_local_watched_repo_for_path(repo_path, ctx)
+                else {
+                    anyhow::bail!(
+                        "No watched repository found for path: {}",
+                        repo_path.display()
+                    );
+                };
+                let repo_path = repo_path.clone();
+                let inner = ctx.add_model(|ctx| {
+                    LocalGitRepoStatusModel::new(repo_path, repository_model, ctx)
+                });
+                ctx.add_model(|ctx| {
+                    ctx.subscribe_to_model(&inner, GitRepoStatusModel::forward_event);
+                    GitRepoStatusModel::Local(inner)
+                })
+            }
+            LocalOrRemotePath::Remote(remote_path) => {
+                let inner =
+                    ctx.add_model(|ctx| RemoteGitRepoStatusModel::new(remote_path.clone(), ctx));
+                ctx.add_model(|ctx| {
+                    ctx.subscribe_to_model(&inner, GitRepoStatusModel::forward_event);
+                    GitRepoStatusModel::Remote(inner)
+                })
+            }
+        };
+
+        self.git_status_models
+            .insert(repo.clone(), handle.downgrade());
+        Ok(handle)
+    }
+
+    /// Get or create the per-repo GitHub-info model for `repo`, returning a
+    /// unified [`GitHubRepoModel`] handle that dispatches to a local
+    /// `gh`-driven model or a remote push receiver based on the location.
+    ///
+    /// The local backend subscribes to the sibling git status model to track
+    /// the current branch and fetches PR / repository info on creation, on
+    /// branch change, and on a periodic timer. Multiple callers in the same
+    /// repo share one model (cached by `LocalOrRemotePath`).
+    ///
+    /// Callers hold the returned `ModelHandle` for as long as they need updates.
+    pub fn subscribe_github_repo(
+        &mut self,
+        repo: &LocalOrRemotePath,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<ModelHandle<GitHubRepoModel>> {
+        if let Some(handle) = self
+            .github_repo_models
+            .get(repo)
+            .and_then(|weak| weak.upgrade(ctx))
+        {
+            return Ok(handle);
+        }
+
+        let handle = match repo {
+            LocalOrRemotePath::Local(repo_path) => {
+                // LocalGitHubRepoModel needs a sibling GitRepoStatusModel for
+                // branch info.
+                let git_status = self.subscribe(repo, ctx)?;
+                let repo_path = repo_path.clone();
+                let inner =
+                    ctx.add_model(|ctx| LocalGitHubRepoModel::new(repo_path, git_status, ctx));
+                ctx.add_model(|ctx| {
+                    ctx.subscribe_to_model(&inner, GitHubRepoModel::forward_event);
+                    GitHubRepoModel::Local(inner)
+                })
+            }
+            LocalOrRemotePath::Remote(remote_path) => {
+                let inner =
+                    ctx.add_model(|ctx| RemoteGitHubRepoModel::new(remote_path.clone(), ctx));
+                ctx.add_model(|ctx| {
+                    ctx.subscribe_to_model(&inner, GitHubRepoModel::forward_event);
+                    GitHubRepoModel::Remote(inner)
+                })
+            }
+        };
+
+        self.github_repo_models
+            .insert(repo.clone(), handle.downgrade());
+        Ok(handle)
+    }
+}
+
+impl Entity for GitRepoModels {
+    type Event = ();
+}
+
+impl SingletonEntity for GitRepoModels {}
+
+// ── GitRepoStatusModel ──────────────────────────────────────────────────────
+
+#[cfg(not(feature = "local_fs"))]
+#[allow(dead_code)]
+pub struct GitRepoStatusModel;
+
+#[cfg(not(feature = "local_fs"))]
+impl Entity for GitRepoStatusModel {
+    type Event = ();
+}
+
+#[cfg(feature = "local_fs")]
+#[derive(Debug)]
+pub enum GitRepoStatusEvent {
+    /// Emitted whenever the metadata changes (branch name, diff stats, etc.).
+    MetadataChanged,
+}
+
+// ── Unified GitRepoStatusModel (local or remote backend) ────────────────────
+
+/// Unified per-repo git status model that dispatches to a local or remote
+/// backend, mirroring [`crate::code_review::diff_state::DiffStateModel`].
+///
+/// Consumers (prompt chips, tabs, code review, agent context) hold a
+/// `ModelHandle<GitRepoStatusModel>` and subscribe to its [`GitRepoStatusEvent`]s
+/// without caring whether the repository is local or on an SSH host. Only one
+/// variant is populated at a time.
+#[cfg(feature = "local_fs")]
+pub enum GitRepoStatusModel {
+    Local(ModelHandle<LocalGitRepoStatusModel>),
+    Remote(ModelHandle<RemoteGitRepoStatusModel>),
+}
+
+#[cfg(feature = "local_fs")]
+impl Entity for GitRepoStatusModel {
+    type Event = GitRepoStatusEvent;
+}
+
+#[cfg(feature = "local_fs")]
+impl GitRepoStatusModel {
+    /// Re-emit a sub-model event so subscribers of the unified model observe
+    /// the same `GitRepoStatusEvent`s regardless of backend.
+    fn forward_event(&mut self, event: &GitRepoStatusEvent, ctx: &mut ModelContext<Self>) {
+        match event {
+            GitRepoStatusEvent::MetadataChanged => ctx.emit(GitRepoStatusEvent::MetadataChanged),
+        }
+    }
+
+    /// Mode-independent status metadata (branch names + HEAD diff stats).
+    pub fn metadata<'a>(&self, ctx: &'a AppContext) -> Option<&'a GitStatusMetadata> {
+        match self {
+            Self::Local(m) => m.as_ref(ctx).metadata(),
+            Self::Remote(m) => m.as_ref(ctx).metadata(),
+        }
+    }
+
+    /// Force a metadata refresh (branch names, diff stats).
+    pub fn refresh_metadata(&self, ctx: &mut ModelContext<Self>) {
+        match self {
+            Self::Local(m) => m.update(ctx, |m, ctx| m.refresh_metadata(ctx)),
+            Self::Remote(m) => m.update(ctx, |m, ctx| m.request_snapshot(ctx)),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "local_fs"))]
+impl GitRepoStatusModel {
+    /// Wraps a local-backend test model in the unified enum.
+    pub(crate) fn new_local_for_test(
+        repository: ModelHandle<repo_metadata::Repository>,
+        metadata: Option<GitStatusMetadata>,
+        ctx: &mut ModelContext<Self>,
+    ) -> Self {
+        let inner =
+            ctx.add_model(move |_| LocalGitRepoStatusModel::new_for_test(repository, metadata));
+        ctx.subscribe_to_model(&inner, Self::forward_event);
+        Self::Local(inner)
+    }
+
+    pub(crate) fn set_metadata_for_test(
+        &mut self,
+        metadata: Option<GitStatusMetadata>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        match self {
+            Self::Local(m) => m.update(ctx, |m, ctx| m.set_metadata_for_test(metadata, ctx)),
+            Self::Remote(_) => unreachable!("remote test models are not used"),
+        }
+    }
+}

--- a/app/src/code_review/git_repo_model/remote.rs
+++ b/app/src/code_review/git_repo_model/remote.rs
@@ -1,0 +1,88 @@
+use remote_server::manager::{RemoteServerManager, RemoteServerManagerEvent};
+use warp_util::remote_path::RemotePath;
+use warpui::{Entity, ModelContext, SingletonEntity};
+
+use super::{GitRepoStatusEvent, GitStatusMetadata};
+use crate::remote_server::proto;
+
+/// Client-side per-repo git status for a repository on an SSH host.
+///
+/// Presents the same read surface as [`super::LocalGitRepoStatusModel`] and emits the
+/// same [`GitRepoStatusEvent`]s so the unified [`super::GitRepoStatusModel`] can
+/// substitute it transparently (mirrors `RemoteDiffStateModel`).
+///
+/// Holds the latest status for its `(host_id, repo_path)`. On construction
+/// (and again on reconnect) it sends an `UpdateGitStatus` notification
+/// requesting the daemon to push the current snapshot; live watcher updates
+/// then arrive as `GitStatusPush` messages filtered by `(host_id, repo_path)`.
+/// `HostDisconnected` preserves stale data.
+pub struct RemoteGitRepoStatusModel {
+    remote_path: RemotePath,
+    metadata: Option<GitStatusMetadata>,
+}
+
+impl Entity for RemoteGitRepoStatusModel {
+    type Event = GitRepoStatusEvent;
+}
+
+impl RemoteGitRepoStatusModel {
+    pub fn new(remote_path: RemotePath, ctx: &mut ModelContext<Self>) -> Self {
+        let mgr = RemoteServerManager::handle(ctx);
+        ctx.subscribe_to_model(&mgr, Self::handle_manager_event);
+        let model = Self {
+            remote_path,
+            metadata: None,
+        };
+        model.request_snapshot(ctx);
+        model
+    }
+
+    fn handle_manager_event(
+        &mut self,
+        event: &RemoteServerManagerEvent,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        match event {
+            RemoteServerManagerEvent::GitStatusPushReceived {
+                host_id,
+                repo_path,
+                metadata,
+            } if host_id == &self.remote_path.host_id && repo_path == &self.remote_path.path => {
+                self.apply_push(metadata, ctx);
+            }
+            RemoteServerManagerEvent::HostConnected { host_id }
+                if host_id == &self.remote_path.host_id =>
+            {
+                self.request_snapshot(ctx);
+            }
+            _ => {}
+        }
+    }
+
+    pub(super) fn request_snapshot(&self, ctx: &mut ModelContext<Self>) {
+        RemoteServerManager::handle(ctx).update(ctx, |mgr, _| {
+            mgr.update_git_status(self.remote_path.host_id.clone(), &self.remote_path.path);
+        });
+    }
+
+    /// Decode a pushed `GitStatusMetadata` (branch + stats) and replace the
+    /// stored value, emitting `MetadataChanged`.
+    fn apply_push(&mut self, metadata: &proto::GitStatusMetadata, ctx: &mut ModelContext<Self>) {
+        match GitStatusMetadata::try_from(metadata) {
+            Ok(status) => {
+                self.metadata = Some(status);
+                ctx.emit(GitRepoStatusEvent::MetadataChanged);
+            }
+            Err(error) => {
+                warp_core::safe_error!(
+                    safe: ("RemoteGitRepoStatusModel: failed to decode git status push"),
+                    full: ("RemoteGitRepoStatusModel: failed to decode git status push: {error}")
+                );
+            }
+        }
+    }
+
+    pub fn metadata(&self) -> Option<&GitStatusMetadata> {
+        self.metadata.as_ref()
+    }
+}

--- a/app/src/code_review/git_repo_models.rs
+++ b/app/src/code_review/git_repo_models.rs
@@ -1,20 +1,16 @@
-#[cfg(feature = "local_fs")]
 use std::collections::HashMap;
 
 #[cfg(feature = "local_fs")]
 use repo_metadata::repositories::DetectedRepositories;
-#[cfg(feature = "local_fs")]
 use warp_util::local_or_remote_path::LocalOrRemotePath;
-use warpui::{Entity, SingletonEntity};
-#[cfg(feature = "local_fs")]
-use warpui::{ModelContext, ModelHandle, WeakModelHandle};
+use warpui::{Entity, ModelContext, ModelHandle, SingletonEntity, WeakModelHandle};
 
 #[cfg(feature = "local_fs")]
-use super::git_repo_model::{
-    new_local_git_repo_status_model, new_remote_git_repo_status_model, GitRepoStatusModel,
-};
+use super::git_repo_model::new_local_git_repo_status_model;
+use super::git_repo_model::{new_remote_git_repo_status_model, GitRepoStatusModel};
 #[cfg(feature = "local_fs")]
-use super::github_repo_model::{GitHubRepoModel, LocalGitHubRepoModel, RemoteGitHubRepoModel};
+use super::github_repo_model::LocalGitHubRepoModel;
+use super::github_repo_model::{GitHubRepoModel, RemoteGitHubRepoModel};
 
 // ── GitRepoModels (singleton cache) ─────────────────────────────────────────
 
@@ -29,17 +25,13 @@ pub struct GitRepoModels {
     // receiver) repos. Each entry stores the unified-enum handle; callers in
     // the same repo share it, and it is torn down when the last strong handle
     // is dropped.
-    #[cfg(feature = "local_fs")]
     git_status_models: HashMap<LocalOrRemotePath, WeakModelHandle<GitRepoStatusModel>>,
-    #[cfg(feature = "local_fs")]
     github_repo_models: HashMap<LocalOrRemotePath, WeakModelHandle<GitHubRepoModel>>,
 }
 impl GitRepoModels {
     pub fn new() -> Self {
         Self {
-            #[cfg(feature = "local_fs")]
             git_status_models: HashMap::new(),
-            #[cfg(feature = "local_fs")]
             github_repo_models: HashMap::new(),
         }
     }
@@ -53,7 +45,6 @@ impl GitRepoModels {
     /// dropped.
     ///
     /// Callers hold the returned `ModelHandle` for as long as they need updates.
-    #[cfg(feature = "local_fs")]
     pub fn subscribe(
         &mut self,
         repo: &LocalOrRemotePath,
@@ -69,15 +60,25 @@ impl GitRepoModels {
 
         let handle = match repo {
             LocalOrRemotePath::Local(repo_path) => {
-                let Some(repository_model) = DetectedRepositories::as_ref(ctx)
-                    .get_local_watched_repo_for_path(repo_path, ctx)
-                else {
+                #[cfg(feature = "local_fs")]
+                {
+                    let Some(repository_model) = DetectedRepositories::as_ref(ctx)
+                        .get_local_watched_repo_for_path(repo_path, ctx)
+                    else {
+                        anyhow::bail!(
+                            "No watched repository found for path: {}",
+                            repo_path.display()
+                        );
+                    };
+                    new_local_git_repo_status_model(repo_path.clone(), repository_model, ctx)
+                }
+                #[cfg(not(feature = "local_fs"))]
+                {
                     anyhow::bail!(
                         "No watched repository found for path: {}",
                         repo_path.display()
                     );
-                };
-                new_local_git_repo_status_model(repo_path.clone(), repository_model, ctx)
+                }
             }
             LocalOrRemotePath::Remote(remote_path) => {
                 new_remote_git_repo_status_model(remote_path.clone(), ctx)
@@ -99,7 +100,6 @@ impl GitRepoModels {
     /// repo share one model (cached by `LocalOrRemotePath`).
     ///
     /// Callers hold the returned `ModelHandle` for as long as they need updates.
-    #[cfg(feature = "local_fs")]
     pub fn subscribe_github_repo(
         &mut self,
         repo: &LocalOrRemotePath,
@@ -115,16 +115,26 @@ impl GitRepoModels {
 
         let handle = match repo {
             LocalOrRemotePath::Local(repo_path) => {
-                // LocalGitHubRepoModel needs a sibling GitRepoStatusModel for
-                // branch info.
-                let git_status = self.subscribe(repo, ctx)?;
-                let repo_path = repo_path.clone();
-                let inner =
-                    ctx.add_model(|ctx| LocalGitHubRepoModel::new(repo_path, git_status, ctx));
-                ctx.add_model(|ctx| {
-                    ctx.subscribe_to_model(&inner, GitHubRepoModel::forward_event);
-                    GitHubRepoModel::Local(inner)
-                })
+                #[cfg(feature = "local_fs")]
+                {
+                    // LocalGitHubRepoModel needs a sibling GitRepoStatusModel for
+                    // branch info.
+                    let git_status = self.subscribe(repo, ctx)?;
+                    let repo_path = repo_path.clone();
+                    let inner =
+                        ctx.add_model(|ctx| LocalGitHubRepoModel::new(repo_path, git_status, ctx));
+                    ctx.add_model(|ctx| {
+                        ctx.subscribe_to_model(&inner, GitHubRepoModel::forward_event);
+                        GitHubRepoModel::Local(inner)
+                    })
+                }
+                #[cfg(not(feature = "local_fs"))]
+                {
+                    anyhow::bail!(
+                        "Local GitHub repo info is unavailable without local_fs: {}",
+                        repo_path.display()
+                    );
+                }
             }
             LocalOrRemotePath::Remote(remote_path) => {
                 let inner =

--- a/app/src/code_review/git_repo_models.rs
+++ b/app/src/code_review/git_repo_models.rs
@@ -1,0 +1,149 @@
+#[cfg(feature = "local_fs")]
+use std::collections::HashMap;
+
+#[cfg(feature = "local_fs")]
+use repo_metadata::repositories::DetectedRepositories;
+#[cfg(feature = "local_fs")]
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warpui::{Entity, SingletonEntity};
+#[cfg(feature = "local_fs")]
+use warpui::{ModelContext, ModelHandle, WeakModelHandle};
+
+#[cfg(feature = "local_fs")]
+use super::git_repo_model::{
+    new_local_git_repo_status_model, new_remote_git_repo_status_model, GitRepoStatusModel,
+};
+#[cfg(feature = "local_fs")]
+use super::github_repo_model::{GitHubRepoModel, LocalGitHubRepoModel, RemoteGitHubRepoModel};
+
+// ── GitRepoModels (singleton cache) ─────────────────────────────────────────
+
+/// Singleton model that acts as a cache / factory for per-repository
+/// [`GitRepoStatusModel`] and [`GitHubRepoModel`] instances.
+///
+/// Multiple terminals in the same repo share a single sub-model.  When the last
+/// strong handle to a sub-model is dropped, the models are torn down automatically.
+pub struct GitRepoModels {
+    // Per-repo status / GitHub-info models, keyed by `LocalOrRemotePath` so a
+    // single cache covers both local (watcher-backed) and remote (push
+    // receiver) repos. Each entry stores the unified-enum handle; callers in
+    // the same repo share it, and it is torn down when the last strong handle
+    // is dropped.
+    #[cfg(feature = "local_fs")]
+    git_status_models: HashMap<LocalOrRemotePath, WeakModelHandle<GitRepoStatusModel>>,
+    #[cfg(feature = "local_fs")]
+    github_repo_models: HashMap<LocalOrRemotePath, WeakModelHandle<GitHubRepoModel>>,
+}
+impl GitRepoModels {
+    pub fn new() -> Self {
+        Self {
+            #[cfg(feature = "local_fs")]
+            git_status_models: HashMap::new(),
+            #[cfg(feature = "local_fs")]
+            github_repo_models: HashMap::new(),
+        }
+    }
+
+    /// Get or create the per-repo status model for `repo`, returning a unified
+    /// [`GitRepoStatusModel`] handle that dispatches to a local watcher-backed
+    /// model or a remote push receiver based on the location.
+    ///
+    /// Multiple callers in the same repo share one model (cached by
+    /// `LocalOrRemotePath`); it is torn down when the last strong handle is
+    /// dropped.
+    ///
+    /// Callers hold the returned `ModelHandle` for as long as they need updates.
+    #[cfg(feature = "local_fs")]
+    pub fn subscribe(
+        &mut self,
+        repo: &LocalOrRemotePath,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<ModelHandle<GitRepoStatusModel>> {
+        if let Some(handle) = self
+            .git_status_models
+            .get(repo)
+            .and_then(|weak| weak.upgrade(ctx))
+        {
+            return Ok(handle);
+        }
+
+        let handle = match repo {
+            LocalOrRemotePath::Local(repo_path) => {
+                let Some(repository_model) = DetectedRepositories::as_ref(ctx)
+                    .get_local_watched_repo_for_path(repo_path, ctx)
+                else {
+                    anyhow::bail!(
+                        "No watched repository found for path: {}",
+                        repo_path.display()
+                    );
+                };
+                new_local_git_repo_status_model(repo_path.clone(), repository_model, ctx)
+            }
+            LocalOrRemotePath::Remote(remote_path) => {
+                new_remote_git_repo_status_model(remote_path.clone(), ctx)
+            }
+        };
+
+        self.git_status_models
+            .insert(repo.clone(), handle.downgrade());
+        Ok(handle)
+    }
+
+    /// Get or create the per-repo GitHub-info model for `repo`, returning a
+    /// unified [`GitHubRepoModel`] handle that dispatches to a local
+    /// `gh`-driven model or a remote push receiver based on the location.
+    ///
+    /// The local backend subscribes to the sibling git status model to track
+    /// the current branch and fetches PR / repository info on creation, on
+    /// branch change, and on a periodic timer. Multiple callers in the same
+    /// repo share one model (cached by `LocalOrRemotePath`).
+    ///
+    /// Callers hold the returned `ModelHandle` for as long as they need updates.
+    #[cfg(feature = "local_fs")]
+    pub fn subscribe_github_repo(
+        &mut self,
+        repo: &LocalOrRemotePath,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<ModelHandle<GitHubRepoModel>> {
+        if let Some(handle) = self
+            .github_repo_models
+            .get(repo)
+            .and_then(|weak| weak.upgrade(ctx))
+        {
+            return Ok(handle);
+        }
+
+        let handle = match repo {
+            LocalOrRemotePath::Local(repo_path) => {
+                // LocalGitHubRepoModel needs a sibling GitRepoStatusModel for
+                // branch info.
+                let git_status = self.subscribe(repo, ctx)?;
+                let repo_path = repo_path.clone();
+                let inner =
+                    ctx.add_model(|ctx| LocalGitHubRepoModel::new(repo_path, git_status, ctx));
+                ctx.add_model(|ctx| {
+                    ctx.subscribe_to_model(&inner, GitHubRepoModel::forward_event);
+                    GitHubRepoModel::Local(inner)
+                })
+            }
+            LocalOrRemotePath::Remote(remote_path) => {
+                let inner =
+                    ctx.add_model(|ctx| RemoteGitHubRepoModel::new(remote_path.clone(), ctx));
+                ctx.add_model(|ctx| {
+                    ctx.subscribe_to_model(&inner, GitHubRepoModel::forward_event);
+                    GitHubRepoModel::Remote(inner)
+                })
+            }
+        };
+
+        self.github_repo_models
+            .insert(repo.clone(), handle.downgrade());
+        Ok(handle)
+    }
+}
+
+impl Entity for GitRepoModels {
+    type Event = ();
+}
+
+impl SingletonEntity for GitRepoModels {}

--- a/app/src/code_review/github_repo_model/local.rs
+++ b/app/src/code_review/github_repo_model/local.rs
@@ -258,19 +258,19 @@ impl LocalGitHubRepoModel {
 
     fn handle_repository_info_result(
         &mut self,
-        result: anyhow::Result<RepositoryInfo>,
+        result: anyhow::Result<Option<RepositoryInfo>>,
         ctx: &mut ModelContext<Self>,
     ) {
-        let repository_info = match result {
-            Ok(repository_info) => Some(repository_info),
+        match result {
+            Ok(repository_info) => {
+                if self.repository_info != repository_info {
+                    self.repository_info = repository_info;
+                    ctx.emit(GitHubRepoEvent::RepositoryInfoChanged);
+                }
+            }
             Err(err) => {
                 log::debug!("GitHubRepoModel: repository info load failed: {err}");
-                None
             }
-        };
-        if self.repository_info != repository_info {
-            self.repository_info = repository_info;
-            ctx.emit(GitHubRepoEvent::RepositoryInfoChanged);
         }
     }
 

--- a/app/src/code_review/github_repo_model/local.rs
+++ b/app/src/code_review/github_repo_model/local.rs
@@ -5,7 +5,8 @@ use settings::Setting as _;
 use warpui::r#async::SpawnedFutureHandle;
 use warpui::{Entity, ModelContext, ModelHandle, SingletonEntity as _};
 
-use super::git_status_update::{GitRepoStatusEvent, GitRepoStatusModel};
+use super::GitHubRepoEvent;
+use crate::code_review::git_repo_model::{GitRepoStatusEvent, GitRepoStatusModel};
 use crate::report_if_error;
 #[cfg(feature = "local_tty")]
 use crate::terminal::local_shell::LocalShellState;
@@ -18,6 +19,7 @@ use crate::util::git::{
 const PR_INFO_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 const GITHUB_INFO_PERIODIC_REFRESH: Duration = Duration::from_secs(60);
 const REPOSITORY_INFO_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Per-repository model that owns the GitHub-sourced metadata lifecycle for a
 /// single repo — the values fetched through the (relatively expensive) `gh`
 /// CLI rather than local `git`:
@@ -25,7 +27,7 @@ const REPOSITORY_INFO_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 ///   - `repository_info` (name/owner) for the repo (`gh repo view`).
 ///
 /// `GitHubRepoModel` is created lazily when a consumer asks for it via
-/// [`super::git_status_update::GitStatusUpdateModel::subscribe_github_repo`].
+/// [`crate::code_review::git_repo_model::GitRepoModels::subscribe_github_repo`].
 /// While at least one strong `ModelHandle<GitHubRepoModel>` is alive, the model:
 ///   - tracks the current branch by subscribing to its sibling
 ///     [`GitRepoStatusModel`] for `MetadataChanged` events,
@@ -41,9 +43,9 @@ const REPOSITORY_INFO_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 ///
 /// When the last strong handle is dropped, the model is torn down and any
 /// in-flight `gh` fetch is aborted. The sibling [`GitRepoStatusModel`] is
-/// retained via a strong handle, so creating a `GitHubRepoModel` keeps git
+/// retained via a strong handle, so creating a `LocalGitHubRepoModel` keeps git
 /// status alive for as long as GitHub info is needed.
-pub struct GitHubRepoModel {
+pub struct LocalGitHubRepoModel {
     repo_path: PathBuf,
     /// Strong handle to the sibling git-status model. Keeps it alive so we
     /// always have a branch source.
@@ -69,20 +71,11 @@ pub struct GitHubRepoModel {
     periodic_refresh_handle: Option<SpawnedFutureHandle>,
 }
 
-#[derive(Debug)]
-pub enum GitHubRepoEvent {
-    /// Emitted when `pr_info` changes value (fetch result differs from
-    /// cached, branch change cleared the cache, etc.).
-    PrInfoChanged,
-    /// Emitted when `repository_info` changes value.
-    RepositoryInfoChanged,
-}
-
-impl Entity for GitHubRepoModel {
+impl Entity for LocalGitHubRepoModel {
     type Event = GitHubRepoEvent;
 }
 
-impl GitHubRepoModel {
+impl LocalGitHubRepoModel {
     /// Create a new per-repo GitHub-info model.
     ///
     /// Subscribes to `git_status` for `MetadataChanged` events to track the
@@ -98,7 +91,7 @@ impl GitHubRepoModel {
     ) -> Self {
         let branch = git_status
             .as_ref(ctx)
-            .metadata()
+            .metadata(ctx)
             .map(|m| m.current_branch_name.clone());
 
         // Track branch changes from the sibling. Only PR info depends on the
@@ -108,7 +101,7 @@ impl GitHubRepoModel {
                 let new_branch = me
                     .git_status
                     .as_ref(ctx)
-                    .metadata()
+                    .metadata(ctx)
                     .map(|m| m.current_branch_name.clone());
                 if new_branch != me.branch {
                     me.branch = new_branch;
@@ -179,8 +172,8 @@ impl GitHubRepoModel {
     }
 
     /// Manually trigger a PR-info refresh. Called after `gh`/`gt` commands
-    /// complete, since those don't touch `.git/` and so won't be picked up by
-    /// the filesystem watcher.
+    /// complete, since those don't touch `.git/` so the filesystem watcher won't
+    /// catch them.
     pub fn refresh_pr_info(&mut self, ctx: &mut ModelContext<Self>) {
         let Some(branch) = self.branch.clone() else {
             return;
@@ -227,7 +220,7 @@ impl GitHubRepoModel {
     /// on creation and re-checked by the periodic timer on each tick. Never
     /// called from the branch-change path, so switching branches does not
     /// trigger a `gh repo view`.
-    fn refresh_repository_info(&mut self, ctx: &mut ModelContext<Self>) {
+    pub fn refresh_repository_info(&mut self, ctx: &mut ModelContext<Self>) {
         // Guard against overlapping fetches.
         if self.repository_info_abort_handle.is_some() {
             return;
@@ -341,11 +334,10 @@ impl GitHubRepoModel {
 }
 
 #[cfg(test)]
-impl GitHubRepoModel {
+impl LocalGitHubRepoModel {
     /// Inert constructor: no branch-tracking subscription, timers, or `gh`
     /// fetch, so tests stay deterministic and never spawn a real subprocess.
-    /// Mirrors `GitRepoStatusModel::new_for_test`. Drive state via the
-    /// `set_*_for_test` helpers.
+    /// Drive state via the `set_*_for_test` helpers.
     pub(crate) fn new_for_test(git_status: ModelHandle<GitRepoStatusModel>) -> Self {
         Self {
             repo_path: PathBuf::from("/test"),
@@ -379,10 +371,10 @@ impl GitHubRepoModel {
 }
 
 #[cfg(test)]
-#[path = "github_repo_model_tests.rs"]
+#[path = "local_tests.rs"]
 mod tests;
 
-impl Drop for GitHubRepoModel {
+impl Drop for LocalGitHubRepoModel {
     fn drop(&mut self) {
         if let Some(h) = self.refreshing_pr_info_abort_handle.take() {
             h.abort();

--- a/app/src/code_review/github_repo_model/local_tests.rs
+++ b/app/src/code_review/github_repo_model/local_tests.rs
@@ -79,7 +79,7 @@ fn pr_info_cleared_on_branch_change() {
 }
 
 #[test]
-fn repository_info_cleared_on_fetch_error() {
+fn repository_info_preserved_on_fetch_error() {
     App::test((), |mut app| async move {
         let (_temp_dir, model) = new_github_repo_model_for_test(&mut app);
 
@@ -92,6 +92,27 @@ fn repository_info_cleared_on_fetch_error() {
 
         model.update(&mut app, |model, ctx| {
             model.handle_repository_info_result(Err(anyhow::anyhow!("gh failed")), ctx);
+        });
+        model.read(&app, |model, _| {
+            assert_eq!(model.repository_info(), Some(&repository_info()));
+        });
+    });
+}
+
+#[test]
+fn repository_info_cleared_on_authoritative_empty_result() {
+    App::test((), |mut app| async move {
+        let (_temp_dir, model) = new_github_repo_model_for_test(&mut app);
+
+        model.update(&mut app, |model, ctx| {
+            model.set_repository_info_for_test(Some(repository_info()), ctx);
+        });
+        model.read(&app, |model, _| {
+            assert_eq!(model.repository_info(), Some(&repository_info()));
+        });
+
+        model.update(&mut app, |model, ctx| {
+            model.handle_repository_info_result(Ok(None), ctx);
         });
         model.read(&app, |model, _| {
             assert_eq!(model.repository_info(), None);

--- a/app/src/code_review/github_repo_model/local_tests.rs
+++ b/app/src/code_review/github_repo_model/local_tests.rs
@@ -3,7 +3,7 @@ use warp_util::standardized_path::StandardizedPath;
 use warpui::{App, ModelHandle};
 
 use super::*;
-use crate::code_review::git_status_update::GitRepoStatusModel;
+use crate::code_review::git_repo_model::GitRepoStatusModel;
 use crate::util::git::RepositoryInfo;
 
 fn pr(number: u64) -> PrInfo {
@@ -42,11 +42,12 @@ fn test_repository_handle(
 /// model. The model never subscribes or fetches; tests drive state directly.
 fn new_github_repo_model_for_test(
     app: &mut App,
-) -> (tempfile::TempDir, ModelHandle<GitHubRepoModel>) {
+) -> (tempfile::TempDir, ModelHandle<LocalGitHubRepoModel>) {
     let temp_dir = tempfile::TempDir::new().unwrap();
     let repository = test_repository_handle(app, &temp_dir);
-    let git_status = app.add_model(move |_| GitRepoStatusModel::new_for_test(repository, None));
-    let model = app.add_model(move |_| GitHubRepoModel::new_for_test(git_status));
+    let git_status =
+        app.add_model(move |ctx| GitRepoStatusModel::new_local_for_test(repository, None, ctx));
+    let model = app.add_model(move |_| LocalGitHubRepoModel::new_for_test(git_status));
     (temp_dir, model)
 }
 

--- a/app/src/code_review/github_repo_model/mod.rs
+++ b/app/src/code_review/github_repo_model/mod.rs
@@ -1,20 +1,15 @@
-use warpui::Entity;
-#[cfg(feature = "local_fs")]
-use warpui::{AppContext, ModelContext, ModelHandle};
+use warpui::{AppContext, Entity, ModelContext, ModelHandle};
 
 #[cfg(feature = "local_fs")]
 mod local;
 #[cfg(feature = "local_fs")]
 pub use local::LocalGitHubRepoModel;
 
-#[cfg(feature = "local_fs")]
 mod remote;
-#[cfg(feature = "local_fs")]
 pub use remote::RemoteGitHubRepoModel;
 
 #[cfg(all(test, feature = "local_fs"))]
 use crate::code_review::git_repo_model::GitRepoStatusModel;
-#[cfg(feature = "local_fs")]
 use crate::util::git::{PrInfo, RepositoryInfo};
 
 #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
@@ -29,31 +24,20 @@ pub enum GitHubRepoEvent {
 
 // ── Unified GitHubRepoModel (local or remote backend) ───────────────────────
 
-#[cfg(not(feature = "local_fs"))]
-#[allow(dead_code)]
-pub struct GitHubRepoModel;
-
-#[cfg(not(feature = "local_fs"))]
-impl Entity for GitHubRepoModel {
-    type Event = ();
-}
-
 /// Unified per-repo GitHub-info model that dispatches to a local or remote
 /// backend, mirroring [`crate::code_review::git_repo_model::GitRepoStatusModel`].
 ///
 /// Consumers (prompt chips, code review, agent context) hold a
 /// `ModelHandle<GitHubRepoModel>` and subscribe to its [`GitHubRepoEvent`]s
 /// without caring whether the repository is local or on an SSH host.
-#[cfg(feature = "local_fs")]
 pub enum GitHubRepoModel {
+    #[cfg(feature = "local_fs")]
     Local(ModelHandle<LocalGitHubRepoModel>),
     Remote(ModelHandle<RemoteGitHubRepoModel>),
 }
-#[cfg(feature = "local_fs")]
 impl Entity for GitHubRepoModel {
     type Event = GitHubRepoEvent;
 }
-#[cfg(feature = "local_fs")]
 impl GitHubRepoModel {
     /// Re-emit a sub-model event so subscribers of the unified model observe
     /// the same `GitHubRepoEvent`s regardless of backend.
@@ -69,6 +53,7 @@ impl GitHubRepoModel {
     /// PR info for the current branch.
     pub fn pr_info<'a>(&self, ctx: &'a AppContext) -> Option<&'a PrInfo> {
         match self {
+            #[cfg(feature = "local_fs")]
             Self::Local(m) => m.as_ref(ctx).pr_info(),
             Self::Remote(m) => m.as_ref(ctx).pr_info(),
         }
@@ -77,6 +62,7 @@ impl GitHubRepoModel {
     /// Repository info (name/owner) returned by `gh repo view`.
     pub fn repository_info<'a>(&self, ctx: &'a AppContext) -> Option<&'a RepositoryInfo> {
         match self {
+            #[cfg(feature = "local_fs")]
             Self::Local(m) => m.as_ref(ctx).repository_info(),
             Self::Remote(m) => m.as_ref(ctx).repository_info(),
         }
@@ -85,6 +71,7 @@ impl GitHubRepoModel {
     /// Whether a `gh pr view` fetch is currently in flight.
     pub fn is_refreshing_pr_info(&self, ctx: &AppContext) -> bool {
         match self {
+            #[cfg(feature = "local_fs")]
             Self::Local(m) => m.as_ref(ctx).is_refreshing_pr_info(),
             Self::Remote(m) => m.as_ref(ctx).is_refreshing_pr_info(),
         }
@@ -93,6 +80,7 @@ impl GitHubRepoModel {
     /// Force a PR info refresh (e.g. after a `gh`/`gt` command completes).
     pub fn refresh_pr_info(&self, ctx: &mut ModelContext<Self>) {
         match self {
+            #[cfg(feature = "local_fs")]
             Self::Local(m) => m.update(ctx, |m, ctx| m.refresh_pr_info(ctx)),
             Self::Remote(m) => m.update(ctx, |m, ctx| m.refresh_pr_info(ctx)),
         }
@@ -101,6 +89,7 @@ impl GitHubRepoModel {
     /// Force a repository-info refresh.
     pub fn refresh_repository_info(&self, ctx: &mut ModelContext<Self>) {
         match self {
+            #[cfg(feature = "local_fs")]
             Self::Local(m) => m.update(ctx, |m, ctx| m.refresh_repository_info(ctx)),
             Self::Remote(m) => m.update(ctx, |m, ctx| m.refresh_repository_info(ctx)),
         }
@@ -125,6 +114,7 @@ impl GitHubRepoModel {
         ctx: &mut ModelContext<Self>,
     ) {
         match self {
+            #[cfg(feature = "local_fs")]
             Self::Local(m) => m.update(ctx, |m, ctx| m.set_pr_info_for_test(pr_info, ctx)),
             Self::Remote(_) => unreachable!("remote test models are not used"),
         }
@@ -136,6 +126,7 @@ impl GitHubRepoModel {
         ctx: &mut ModelContext<Self>,
     ) {
         match self {
+            #[cfg(feature = "local_fs")]
             Self::Local(m) => m.update(ctx, |m, ctx| {
                 m.set_repository_info_for_test(repository_info, ctx)
             }),

--- a/app/src/code_review/github_repo_model/mod.rs
+++ b/app/src/code_review/github_repo_model/mod.rs
@@ -1,0 +1,127 @@
+use warpui::{AppContext, Entity, ModelContext, ModelHandle};
+
+mod local;
+pub use local::LocalGitHubRepoModel;
+
+mod remote;
+pub use remote::RemoteGitHubRepoModel;
+
+#[cfg(test)]
+use crate::code_review::git_repo_model::GitRepoStatusModel;
+use crate::util::git::{PrInfo, RepositoryInfo};
+
+#[derive(Debug)]
+pub enum GitHubRepoEvent {
+    /// Emitted when `pr_info` changes value (fetch result differs from
+    /// cached, branch change cleared the cache, etc.).
+    PrInfoChanged,
+    /// Emitted when `repository_info` changes value.
+    RepositoryInfoChanged,
+}
+
+// ── Unified GitHubRepoModel (local or remote backend) ───────────────────────
+
+/// Unified per-repo GitHub-info model that dispatches to a local or remote
+/// backend, mirroring [`crate::code_review::git_repo_model::GitRepoStatusModel`].
+///
+/// Consumers (prompt chips, code review, agent context) hold a
+/// `ModelHandle<GitHubRepoModel>` and subscribe to its [`GitHubRepoEvent`]s
+/// without caring whether the repository is local or on an SSH host.
+pub enum GitHubRepoModel {
+    Local(ModelHandle<LocalGitHubRepoModel>),
+    Remote(ModelHandle<RemoteGitHubRepoModel>),
+}
+
+impl Entity for GitHubRepoModel {
+    type Event = GitHubRepoEvent;
+}
+
+impl GitHubRepoModel {
+    /// Re-emit a sub-model event so subscribers of the unified model observe
+    /// the same `GitHubRepoEvent`s regardless of backend.
+    pub(crate) fn forward_event(&mut self, event: &GitHubRepoEvent, ctx: &mut ModelContext<Self>) {
+        match event {
+            GitHubRepoEvent::PrInfoChanged => ctx.emit(GitHubRepoEvent::PrInfoChanged),
+            GitHubRepoEvent::RepositoryInfoChanged => {
+                ctx.emit(GitHubRepoEvent::RepositoryInfoChanged)
+            }
+        }
+    }
+
+    /// PR info for the current branch.
+    pub fn pr_info<'a>(&self, ctx: &'a AppContext) -> Option<&'a PrInfo> {
+        match self {
+            Self::Local(m) => m.as_ref(ctx).pr_info(),
+            Self::Remote(m) => m.as_ref(ctx).pr_info(),
+        }
+    }
+
+    /// Repository info (name/owner) returned by `gh repo view`.
+    pub fn repository_info<'a>(&self, ctx: &'a AppContext) -> Option<&'a RepositoryInfo> {
+        match self {
+            Self::Local(m) => m.as_ref(ctx).repository_info(),
+            Self::Remote(m) => m.as_ref(ctx).repository_info(),
+        }
+    }
+
+    /// Whether a `gh pr view` fetch is currently in flight.
+    pub fn is_refreshing_pr_info(&self, ctx: &AppContext) -> bool {
+        match self {
+            Self::Local(m) => m.as_ref(ctx).is_refreshing_pr_info(),
+            Self::Remote(m) => m.as_ref(ctx).is_refreshing_pr_info(),
+        }
+    }
+
+    /// Force a PR info refresh (e.g. after a `gh`/`gt` command completes).
+    pub fn refresh_pr_info(&self, ctx: &mut ModelContext<Self>) {
+        match self {
+            Self::Local(m) => m.update(ctx, |m, ctx| m.refresh_pr_info(ctx)),
+            Self::Remote(m) => m.update(ctx, |m, ctx| m.refresh_pr_info(ctx)),
+        }
+    }
+
+    /// Force a repository-info refresh.
+    pub fn refresh_repository_info(&self, ctx: &mut ModelContext<Self>) {
+        match self {
+            Self::Local(m) => m.update(ctx, |m, ctx| m.refresh_repository_info(ctx)),
+            Self::Remote(m) => m.update(ctx, |m, ctx| m.refresh_repository_info(ctx)),
+        }
+    }
+}
+
+#[cfg(test)]
+impl GitHubRepoModel {
+    /// Wraps an inert local-backend test model in the unified enum.
+    pub(crate) fn new_local_for_test(
+        git_status: ModelHandle<GitRepoStatusModel>,
+        ctx: &mut ModelContext<Self>,
+    ) -> Self {
+        let inner = ctx.add_model(move |_| LocalGitHubRepoModel::new_for_test(git_status));
+        ctx.subscribe_to_model(&inner, Self::forward_event);
+        Self::Local(inner)
+    }
+
+    pub(crate) fn set_pr_info_for_test(
+        &mut self,
+        pr_info: Option<PrInfo>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        match self {
+            Self::Local(m) => m.update(ctx, |m, ctx| m.set_pr_info_for_test(pr_info, ctx)),
+            Self::Remote(_) => unreachable!("remote test models are not used"),
+        }
+    }
+
+    pub(crate) fn set_repository_info_for_test(
+        &mut self,
+        repository_info: Option<RepositoryInfo>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        match self {
+            Self::Local(m) => m.update(ctx, |m, ctx| {
+                m.set_repository_info_for_test(repository_info, ctx)
+            }),
+            Self::Remote(_) => unreachable!("remote test models are not used"),
+        }
+    }
+}

--- a/app/src/code_review/github_repo_model/mod.rs
+++ b/app/src/code_review/github_repo_model/mod.rs
@@ -1,13 +1,20 @@
-use warpui::{AppContext, Entity, ModelContext, ModelHandle};
+use warpui::Entity;
+#[cfg(feature = "local_fs")]
+use warpui::{AppContext, ModelContext, ModelHandle};
 
+#[cfg(feature = "local_fs")]
 mod local;
+#[cfg(feature = "local_fs")]
 pub use local::LocalGitHubRepoModel;
 
+#[cfg(feature = "local_fs")]
 mod remote;
+#[cfg(feature = "local_fs")]
 pub use remote::RemoteGitHubRepoModel;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "local_fs"))]
 use crate::code_review::git_repo_model::GitRepoStatusModel;
+#[cfg(feature = "local_fs")]
 use crate::util::git::{PrInfo, RepositoryInfo};
 
 #[derive(Debug)]
@@ -21,21 +28,31 @@ pub enum GitHubRepoEvent {
 
 // ── Unified GitHubRepoModel (local or remote backend) ───────────────────────
 
+#[cfg(not(feature = "local_fs"))]
+#[allow(dead_code)]
+pub struct GitHubRepoModel;
+
+#[cfg(not(feature = "local_fs"))]
+impl Entity for GitHubRepoModel {
+    type Event = ();
+}
+
 /// Unified per-repo GitHub-info model that dispatches to a local or remote
 /// backend, mirroring [`crate::code_review::git_repo_model::GitRepoStatusModel`].
 ///
 /// Consumers (prompt chips, code review, agent context) hold a
 /// `ModelHandle<GitHubRepoModel>` and subscribe to its [`GitHubRepoEvent`]s
 /// without caring whether the repository is local or on an SSH host.
+#[cfg(feature = "local_fs")]
 pub enum GitHubRepoModel {
     Local(ModelHandle<LocalGitHubRepoModel>),
     Remote(ModelHandle<RemoteGitHubRepoModel>),
 }
-
+#[cfg(feature = "local_fs")]
 impl Entity for GitHubRepoModel {
     type Event = GitHubRepoEvent;
 }
-
+#[cfg(feature = "local_fs")]
 impl GitHubRepoModel {
     /// Re-emit a sub-model event so subscribers of the unified model observe
     /// the same `GitHubRepoEvent`s regardless of backend.
@@ -89,7 +106,7 @@ impl GitHubRepoModel {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "local_fs"))]
 impl GitHubRepoModel {
     /// Wraps an inert local-backend test model in the unified enum.
     pub(crate) fn new_local_for_test(

--- a/app/src/code_review/github_repo_model/mod.rs
+++ b/app/src/code_review/github_repo_model/mod.rs
@@ -17,6 +17,7 @@ use crate::code_review::git_repo_model::GitRepoStatusModel;
 #[cfg(feature = "local_fs")]
 use crate::util::git::{PrInfo, RepositoryInfo};
 
+#[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
 #[derive(Debug)]
 pub enum GitHubRepoEvent {
     /// Emitted when `pr_info` changes value (fetch result differs from

--- a/app/src/code_review/github_repo_model/remote.rs
+++ b/app/src/code_review/github_repo_model/remote.rs
@@ -1,0 +1,224 @@
+use remote_server::manager::{RemoteServerManager, RemoteServerManagerEvent};
+use warp_util::remote_path::RemotePath;
+use warpui::{Entity, ModelContext, SingletonEntity};
+
+use super::GitHubRepoEvent;
+use crate::remote_server::proto;
+use crate::util::git::{PrInfo, RepositoryInfo};
+
+/// Client-side per-repo GitHub info for a repository on an SSH host.
+///
+/// Presents the same read surface as [`super::LocalGitHubRepoModel`] and emits the
+/// same [`GitHubRepoEvent`]s so the unified [`super::GitHubRepoModel`] can substitute
+/// it transparently (mirrors `RemoteGitRepoStatusModel`).
+///
+/// Holds the latest PR / repository info for its `(host_id, repo_path)`. On
+/// construction (and again on reconnect) it sends host-scoped requests for the
+/// current snapshots; live updates then arrive as server-broadcast PR-info and
+/// repository-info push messages, filtered by `(host_id, repo_path)`.
+/// `HostDisconnected` preserves stale data.
+pub struct RemoteGitHubRepoModel {
+    remote_path: RemotePath,
+    pr_info: Option<PrInfo>,
+    repository_info: Option<RepositoryInfo>,
+    refreshing_pr_info: bool,
+    refreshing_repository_info: bool,
+}
+
+impl Entity for RemoteGitHubRepoModel {
+    type Event = GitHubRepoEvent;
+}
+
+impl RemoteGitHubRepoModel {
+    pub fn new(remote_path: RemotePath, ctx: &mut ModelContext<Self>) -> Self {
+        let mgr = RemoteServerManager::handle(ctx);
+        ctx.subscribe_to_model(&mgr, Self::handle_manager_event);
+        let mut model = Self {
+            remote_path,
+            pr_info: None,
+            repository_info: None,
+            refreshing_pr_info: false,
+            refreshing_repository_info: false,
+        };
+        model.request_github_info(ctx);
+        model
+    }
+
+    fn handle_manager_event(
+        &mut self,
+        event: &RemoteServerManagerEvent,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        match event {
+            RemoteServerManagerEvent::GitHubPrInfoPushReceived {
+                host_id,
+                repo_path,
+                pr_info,
+            } if host_id == &self.remote_path.host_id && repo_path == &self.remote_path.path => {
+                self.apply_pr_info_push(pr_info.as_ref(), ctx);
+            }
+            RemoteServerManagerEvent::GitHubRepositoryInfoPushReceived {
+                host_id,
+                repo_path,
+                repository_info,
+            } if host_id == &self.remote_path.host_id && repo_path == &self.remote_path.path => {
+                self.apply_repository_info_push(repository_info.as_ref(), ctx);
+            }
+            RemoteServerManagerEvent::GetGitHubPrInfoResponse {
+                host_id,
+                repo_path,
+                result,
+            } if host_id == &self.remote_path.host_id && repo_path == &self.remote_path.path => {
+                self.handle_pr_info_response(result, ctx);
+            }
+            RemoteServerManagerEvent::GetGitHubRepoInfoResponse {
+                host_id,
+                repo_path,
+                result,
+            } if host_id == &self.remote_path.host_id && repo_path == &self.remote_path.path => {
+                self.handle_repository_info_response(result, ctx);
+            }
+            RemoteServerManagerEvent::HostConnected { host_id }
+                if host_id == &self.remote_path.host_id =>
+            {
+                self.request_github_info(ctx);
+            }
+            _ => {}
+        }
+    }
+
+    fn request_github_info(&mut self, ctx: &mut ModelContext<Self>) {
+        self.request_pr_info(ctx);
+        self.request_repository_info(ctx);
+    }
+
+    fn request_pr_info(&mut self, ctx: &mut ModelContext<Self>) {
+        if self.refreshing_pr_info {
+            return;
+        }
+        self.refreshing_pr_info = true;
+        ctx.emit(GitHubRepoEvent::PrInfoChanged);
+
+        let host_id = self.remote_path.host_id.clone();
+        let repo_path = self.remote_path.path.clone();
+        RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
+            mgr.get_github_pr_info(host_id, repo_path, ctx);
+        });
+    }
+
+    fn request_repository_info(&mut self, ctx: &mut ModelContext<Self>) {
+        if self.refreshing_repository_info {
+            return;
+        }
+        self.refreshing_repository_info = true;
+
+        let host_id = self.remote_path.host_id.clone();
+        let repo_path = self.remote_path.path.clone();
+        RemoteServerManager::handle(ctx).update(ctx, |mgr, ctx| {
+            mgr.get_github_repo_info(host_id, repo_path, ctx);
+        });
+    }
+
+    /// Replace the stored PR info from a push, emitting `PrInfoChanged` only
+    /// when the value moved.
+    fn apply_pr_info_push(
+        &mut self,
+        pr_info: Option<&proto::PrInfo>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let pr_info = pr_info.map(PrInfo::from);
+        let pr_changed = if self.refreshing_pr_info && pr_info.is_none() {
+            false
+        } else {
+            let changed = self.pr_info != pr_info;
+            self.pr_info = pr_info;
+            changed
+        };
+        if pr_changed {
+            ctx.emit(GitHubRepoEvent::PrInfoChanged);
+        }
+    }
+
+    /// Replace the stored repository info from a push, emitting
+    /// `RepositoryInfoChanged` only when the value moved.
+    fn apply_repository_info_push(
+        &mut self,
+        repository_info: Option<&proto::RepositoryInfo>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let repository_info = repository_info.map(RepositoryInfo::from);
+        let repo_changed = if self.refreshing_repository_info && repository_info.is_none() {
+            false
+        } else {
+            let changed = self.repository_info != repository_info;
+            self.repository_info = repository_info;
+            changed
+        };
+        if repo_changed {
+            ctx.emit(GitHubRepoEvent::RepositoryInfoChanged);
+        }
+    }
+
+    fn handle_pr_info_response(
+        &mut self,
+        result: &Result<Option<proto::PrInfo>, String>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let mut pr_changed = false;
+        match result {
+            Ok(pr_info) => {
+                let pr_info = pr_info.as_ref().map(PrInfo::from);
+                pr_changed = self.pr_info != pr_info;
+                self.pr_info = pr_info;
+            }
+            Err(error) => {
+                log::debug!("RemoteGitHubRepoModel: PR info load failed: {error}");
+            }
+        }
+
+        let refreshing_changed = self.refreshing_pr_info;
+        self.refreshing_pr_info = false;
+        if pr_changed || refreshing_changed {
+            ctx.emit(GitHubRepoEvent::PrInfoChanged);
+        }
+    }
+
+    fn handle_repository_info_response(
+        &mut self,
+        result: &Result<Option<proto::RepositoryInfo>, String>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let repository_info = match result {
+            Ok(repository_info) => repository_info.as_ref().map(RepositoryInfo::from),
+            Err(error) => {
+                log::debug!("RemoteGitHubRepoModel: repository info load failed: {error}");
+                None
+            }
+        };
+        self.refreshing_repository_info = false;
+        if self.repository_info != repository_info {
+            self.repository_info = repository_info;
+            ctx.emit(GitHubRepoEvent::RepositoryInfoChanged);
+        }
+    }
+
+    pub fn pr_info(&self) -> Option<&PrInfo> {
+        self.pr_info.as_ref()
+    }
+
+    pub fn repository_info(&self) -> Option<&RepositoryInfo> {
+        self.repository_info.as_ref()
+    }
+
+    pub fn is_refreshing_pr_info(&self) -> bool {
+        self.refreshing_pr_info
+    }
+
+    pub fn refresh_pr_info(&mut self, ctx: &mut ModelContext<Self>) {
+        self.request_pr_info(ctx);
+    }
+
+    pub fn refresh_repository_info(&mut self, ctx: &mut ModelContext<Self>) {
+        self.request_repository_info(ctx);
+    }
+}

--- a/app/src/code_review/github_repo_model/remote.rs
+++ b/app/src/code_review/github_repo_model/remote.rs
@@ -188,16 +188,19 @@ impl RemoteGitHubRepoModel {
         result: &Result<Option<proto::RepositoryInfo>, String>,
         ctx: &mut ModelContext<Self>,
     ) {
-        let repository_info = match result {
-            Ok(repository_info) => repository_info.as_ref().map(RepositoryInfo::from),
+        let mut repo_changed = false;
+        match result {
+            Ok(repository_info) => {
+                let repository_info = repository_info.as_ref().map(RepositoryInfo::from);
+                repo_changed = self.repository_info != repository_info;
+                self.repository_info = repository_info;
+            }
             Err(error) => {
                 log::debug!("RemoteGitHubRepoModel: repository info load failed: {error}");
-                None
             }
-        };
+        }
         self.refreshing_repository_info = false;
-        if self.repository_info != repository_info {
-            self.repository_info = repository_info;
+        if repo_changed {
             ctx.emit(GitHubRepoEvent::RepositoryInfoChanged);
         }
     }

--- a/app/src/code_review/mod.rs
+++ b/app/src/code_review/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod find_model;
 pub(crate) mod git_actions;
 pub(crate) mod git_dialog;
 pub mod git_repo_model;
-#[cfg(feature = "local_fs")]
+mod git_repo_models;
 pub mod github_repo_model;
 mod hidden_lines;
 pub mod telemetry_event;

--- a/app/src/code_review/mod.rs
+++ b/app/src/code_review/mod.rs
@@ -8,7 +8,7 @@ pub mod editor_state;
 pub(crate) mod find_model;
 pub(crate) mod git_actions;
 pub(crate) mod git_dialog;
-pub mod git_status_update;
+pub mod git_repo_model;
 #[cfg(feature = "local_fs")]
 pub mod github_repo_model;
 mod hidden_lines;

--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -9,10 +9,9 @@ use warp_completer::completer::CommandExitStatus;
 use warp_core::r#async::debounce;
 use warp_core::user_preferences::GetUserPreferences;
 use warpui::r#async::{SpawnedFutureHandle, Timer};
-#[cfg(feature = "local_fs")]
-use warpui::WeakModelHandle;
 use warpui::{
     AppContext, Entity, ModelAsRef, ModelContext, ModelHandle, SingletonEntity, ViewHandle,
+    WeakModelHandle,
 };
 
 use super::context_chip::{
@@ -23,11 +22,8 @@ use super::context_chip::{
 use super::logging::{ChipCommandLogEntry, PromptChipExecutionPhase, PromptChipLogger};
 use super::prompt::Prompt;
 use super::{chips_to_string, ChipResult, ChipValue, ContextChipKind};
-#[cfg(feature = "local_fs")]
 use crate::code_review::git_repo_model::{GitRepoStatusEvent, GitRepoStatusModel};
-#[cfg(feature = "local_fs")]
 use crate::code_review::github_repo_model::{GitHubRepoEvent, GitHubRepoModel};
-#[cfg(feature = "local_fs")]
 use crate::context_chips::display_chip::GitLineChanges;
 use crate::editor::EditorView;
 use crate::features::FeatureFlag;
@@ -162,12 +158,10 @@ pub struct CurrentPrompt {
 
     /// When set, git-backed chip values are populated from `GitRepoStatusModel`.
     /// `ShellGitBranch` and `GitDiffStats` are driven by filesystem events.
-    #[cfg(feature = "local_fs")]
     git_repo_status: Option<WeakModelHandle<GitRepoStatusModel>>,
 
     /// When set, the `GithubPullRequest` chip value is populated from
     /// `GitHubRepoModel` for the current repository.
-    #[cfg(feature = "local_fs")]
     github_repo_model: Option<WeakModelHandle<GitHubRepoModel>>,
 }
 
@@ -238,9 +232,7 @@ impl CurrentPrompt {
             update_tx,
             same_line_prompt_enabled: prompt.as_ref(ctx).same_line_prompt_enabled(),
             separator: prompt.as_ref(ctx).separator(),
-            #[cfg(feature = "local_fs")]
             git_repo_status: None,
-            #[cfg(feature = "local_fs")]
             github_repo_model: None,
         }
     }
@@ -1003,7 +995,6 @@ impl CurrentPrompt {
                     // `GithubPullRequest` only emits when cached PR info actually
                     // changes, so after a rebuild there may be no event to restore
                     // the already-cached value until the next periodic refresh.
-                    #[cfg(feature = "local_fs")]
                     if matches!(chip_kind, ContextChipKind::GithubPullRequest) {
                         self.sync_pr_chip_from_model(ctx);
                     }
@@ -1384,7 +1375,6 @@ impl CurrentPrompt {
     /// metadata events so git-backed prompt chips are updated from the
     /// per-repo status model. PR info is handled separately by
     /// [`Self::set_github_repo_model`].
-    #[cfg(feature = "local_fs")]
     pub fn set_git_repo_status(
         &mut self,
         handle: Option<WeakModelHandle<GitRepoStatusModel>>,
@@ -1430,7 +1420,6 @@ impl CurrentPrompt {
 
     /// Set the per-repo GitHub-info model handle. When `Some`, subscribes to
     /// its events so the `GithubPullRequest` chip value is updated.
-    #[cfg(feature = "local_fs")]
     pub fn set_github_repo_model(
         &mut self,
         handle: Option<WeakModelHandle<GitHubRepoModel>>,
@@ -1473,7 +1462,6 @@ impl CurrentPrompt {
 
     /// Read the current `GitRepoStatusModel` metadata and push it into the
     /// `ShellGitBranch` and `GitDiffStats` chip states.
-    #[cfg(feature = "local_fs")]
     fn apply_git_repo_metadata(&mut self, ctx: &mut ModelContext<Self>) {
         let metadata = self
             .git_repo_status
@@ -1515,7 +1503,6 @@ impl CurrentPrompt {
 
     /// Reads PR info from the per-repo `GitHubRepoModel` and updates the
     /// `GithubPullRequest` chip value if it differs from the current one.
-    #[cfg(feature = "local_fs")]
     fn sync_pr_chip_from_model(&mut self, ctx: &AppContext) {
         let new_pr_value = self
             .github_repo_model
@@ -1537,20 +1524,13 @@ impl CurrentPrompt {
     /// Returns `true` when the given chip's value is updated externally
     /// (e.g. by a filesystem watcher) and the periodic timer should be skipped.
     fn is_updated_externally(&self, chip_kind: &ContextChipKind) -> bool {
-        #[cfg(feature = "local_fs")]
-        {
-            match chip_kind {
-                ContextChipKind::ShellGitBranch | ContextChipKind::GitDiffStats => {
-                    return self.git_repo_status.is_some();
-                }
-                ContextChipKind::GithubPullRequest => {
-                    return self.github_repo_model.is_some();
-                }
-                _ => {}
+        match chip_kind {
+            ContextChipKind::ShellGitBranch | ContextChipKind::GitDiffStats => {
+                self.git_repo_status.is_some()
             }
+            ContextChipKind::GithubPullRequest => self.github_repo_model.is_some(),
+            _ => false,
         }
-        let _ = chip_kind;
-        false
     }
 
     /// Whether or not context chips are active. If this is false, we can skip running them.

--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -24,7 +24,7 @@ use super::logging::{ChipCommandLogEntry, PromptChipExecutionPhase, PromptChipLo
 use super::prompt::Prompt;
 use super::{chips_to_string, ChipResult, ChipValue, ContextChipKind};
 #[cfg(feature = "local_fs")]
-use crate::code_review::git_status_update::{GitRepoStatusEvent, GitRepoStatusModel};
+use crate::code_review::git_repo_model::{GitRepoStatusEvent, GitRepoStatusModel};
 #[cfg(feature = "local_fs")]
 use crate::code_review::github_repo_model::{GitHubRepoEvent, GitHubRepoModel};
 #[cfg(feature = "local_fs")]

--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -1421,7 +1421,7 @@ impl CurrentPrompt {
                 // have completed before we subscribed). If it hasn't finished
                 // yet, the subscription above will catch the `MetadataChanged`
                 // event when it does.
-                if strong.as_ref(ctx).metadata().is_some() {
+                if strong.as_ref(ctx).metadata(ctx).is_some() {
                     self.apply_git_repo_metadata(ctx);
                 }
             }
@@ -1479,7 +1479,7 @@ impl CurrentPrompt {
             .git_repo_status
             .as_ref()
             .and_then(|w| w.upgrade(ctx))
-            .and_then(|h| h.as_ref(ctx).metadata().cloned());
+            .and_then(|h| h.as_ref(ctx).metadata(ctx).cloned());
 
         let Some(metadata) = metadata else {
             return;
@@ -1523,7 +1523,7 @@ impl CurrentPrompt {
             .and_then(|w| w.upgrade(ctx))
             .and_then(|h| {
                 h.as_ref(ctx)
-                    .pr_info()
+                    .pr_info(ctx)
                     .map(|info| ChipValue::Text(info.url.clone()))
             });
         let current_pr = self

--- a/app/src/context_chips/current_prompt_tests.rs
+++ b/app/src/context_chips/current_prompt_tests.rs
@@ -19,7 +19,7 @@ use crate::auth::AuthStateProvider;
 #[cfg(feature = "local_fs")]
 use crate::code_review::diff_state::DiffStats;
 #[cfg(feature = "local_fs")]
-use crate::code_review::git_status_update::{GitRepoStatusModel, GitStatusMetadata};
+use crate::code_review::git_repo_model::{GitRepoStatusModel, GitStatusMetadata};
 #[cfg(feature = "local_fs")]
 use crate::code_review::github_repo_model::GitHubRepoModel;
 use crate::context_chips::context_chip::{Environment, PromptGenerator};
@@ -521,8 +521,8 @@ fn test_externally_driven_chip_skips_periodic_timer() {
                 )
                 .unwrap()
         });
-        let git_status =
-            app.add_model(move |_| GitRepoStatusModel::new_for_test(repo_handle, None));
+        let git_status = app
+            .add_model(move |ctx| GitRepoStatusModel::new_local_for_test(repo_handle, None, ctx));
 
         let sessions = app.add_model(|_| Sessions::new_for_test());
         let current_prompt = app.add_model(move |ctx| CurrentPrompt::new(sessions, ctx));
@@ -588,8 +588,8 @@ fn test_git_status_change_updates_chip_value() {
             main_branch_name: "main".to_string(),
             stats_against_head: DiffStats::default(),
         };
-        let git_status = app.add_model(move |_| {
-            GitRepoStatusModel::new_for_test(repo_handle, Some(initial_metadata))
+        let git_status = app.add_model(move |ctx| {
+            GitRepoStatusModel::new_local_for_test(repo_handle, Some(initial_metadata), ctx)
         });
 
         let sessions = app.add_model(|_| Sessions::new_for_test());
@@ -666,19 +666,20 @@ fn test_git_status_pr_info_updates_github_pr_chip_value() {
                 .unwrap()
         });
 
-        let git_status = app.add_model(move |_| {
-            GitRepoStatusModel::new_for_test(
+        let git_status = app.add_model(move |ctx| {
+            GitRepoStatusModel::new_local_for_test(
                 repo_handle,
                 Some(GitStatusMetadata {
                     current_branch_name: "feature-a".to_string(),
                     main_branch_name: "main".to_string(),
                     stats_against_head: DiffStats::default(),
                 }),
+                ctx,
             )
         });
         let github_repo_model = {
             let git_status = git_status.clone();
-            app.add_model(move |_| GitHubRepoModel::new_for_test(git_status))
+            app.add_model(move |ctx| GitHubRepoModel::new_local_for_test(git_status, ctx))
         };
 
         let sessions = app.add_model(|_| Sessions::new_for_test());

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1617,8 +1617,8 @@ pub(crate) fn initialize_app(
     }
 
     {
-        use code_review::git_status_update::GitStatusUpdateModel;
-        ctx.add_singleton_model(|_| GitStatusUpdateModel::new());
+        use code_review::git_repo_model::GitRepoModels;
+        ctx.add_singleton_model(|_| GitRepoModels::new());
     }
 
     ctx.add_singleton_model(|ctx| {

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -189,7 +189,7 @@ fn initialize_app(app: &mut App) {
     app.add_singleton_model(RepoMetadataModel::new);
     app.add_singleton_model(SkillManager::new);
     app.add_singleton_model(FileSearchModel::new);
-    app.add_singleton_model(|_| crate::code_review::git_status_update::GitStatusUpdateModel::new());
+    app.add_singleton_model(|_| crate::code_review::git_repo_model::GitRepoModels::new());
     app.add_singleton_model(RepoOutlines::new_for_test);
     crate::terminal::available_shells::register(app);
     app.update(experiments::init);

--- a/app/src/remote_server/codebase_index_model.rs
+++ b/app/src/remote_server/codebase_index_model.rs
@@ -459,12 +459,17 @@ impl RemoteCodebaseIndexModel {
             | RemoteServerManagerEvent::DiffStateSnapshotReceived { .. }
             | RemoteServerManagerEvent::DiffStateMetadataUpdateReceived { .. }
             | RemoteServerManagerEvent::DiffStateFileDeltaReceived { .. }
+            | RemoteServerManagerEvent::GitStatusPushReceived { .. }
+            | RemoteServerManagerEvent::GitHubPrInfoPushReceived { .. }
+            | RemoteServerManagerEvent::GitHubRepositoryInfoPushReceived { .. }
             | RemoteServerManagerEvent::GetBranchesResponse { .. }
             | RemoteServerManagerEvent::CommitChainResponse { .. }
             | RemoteServerManagerEvent::GitPushResponse { .. }
             | RemoteServerManagerEvent::CreatePrResponse { .. }
             | RemoteServerManagerEvent::GenerateCommitMessageResponse { .. }
             | RemoteServerManagerEvent::GetCommittedBranchFilesResponse { .. }
+            | RemoteServerManagerEvent::GetGitHubPrInfoResponse { .. }
+            | RemoteServerManagerEvent::GetGitHubRepoInfoResponse { .. }
             | RemoteServerManagerEvent::SetupStateChanged { .. }
             | RemoteServerManagerEvent::BinaryCheckComplete { .. }
             | RemoteServerManagerEvent::BinaryInstallComplete { .. }

--- a/app/src/remote_server/codebase_index_model.rs
+++ b/app/src/remote_server/codebase_index_model.rs
@@ -464,7 +464,6 @@ impl RemoteCodebaseIndexModel {
             | RemoteServerManagerEvent::GitPushResponse { .. }
             | RemoteServerManagerEvent::CreatePrResponse { .. }
             | RemoteServerManagerEvent::GenerateCommitMessageResponse { .. }
-            | RemoteServerManagerEvent::GetPrInfoResponse { .. }
             | RemoteServerManagerEvent::GetCommittedBranchFilesResponse { .. }
             | RemoteServerManagerEvent::SetupStateChanged { .. }
             | RemoteServerManagerEvent::BinaryCheckComplete { .. }

--- a/app/src/remote_server/diff_state_proto.rs
+++ b/app/src/remote_server/diff_state_proto.rs
@@ -159,7 +159,6 @@ impl TryFrom<&proto::DiffMetadata> for DiffMetadata {
             has_head_commit: metadata.has_head_commit,
             unpushed_commits: metadata.unpushed_commits.iter().map(Commit::from).collect(),
             upstream_ref: metadata.upstream_ref.clone(),
-            pr_info: metadata.pr_info.as_ref().map(PrInfo::from),
         })
     }
 }
@@ -457,7 +456,6 @@ impl From<&DiffMetadata> for proto::DiffMetadata {
             has_head_commit: m.has_head_commit,
             unpushed_commits: m.unpushed_commits.iter().map(proto::Commit::from).collect(),
             upstream_ref: m.upstream_ref.clone(),
-            pr_info: m.pr_info.as_ref().map(proto::PrInfo::from),
         }
     }
 }

--- a/app/src/remote_server/diff_state_proto_tests.rs
+++ b/app/src/remote_server/diff_state_proto_tests.rs
@@ -5,10 +5,9 @@ use warp_util::standardized_path::StandardizedPath;
 use super::super::proto;
 use crate::code_review::diff_size_limits::{DiffSize, UnrenderableReason, MAX_DIFF_SIZE};
 use crate::code_review::diff_state::{
-    DiffMetadata, DiffMetadataAgainstBase, DiffMode, DiffState, DiffStats, FileDiff,
-    FileDiffAndContent, FileStatusInfo, GitDiffWithBaseContent, GitFileStatus,
+    DiffMetadata, DiffMetadataAgainstBase, DiffMode, DiffState, FileDiff, FileDiffAndContent,
+    FileStatusInfo, GitDiffWithBaseContent, GitFileStatus,
 };
-use crate::util::git::PrInfo;
 
 // ── FileStatusInfo path validation (TryFrom) ────────────────────
 
@@ -78,7 +77,6 @@ fn diff_metadata_requires_against_head() {
         has_head_commit: true,
         unpushed_commits: vec![],
         upstream_ref: None,
-        pr_info: None,
     };
 
     assert!(DiffMetadata::try_from(&metadata).is_err());
@@ -92,49 +90,6 @@ fn diff_metadata_against_base_requires_stats() {
     };
 
     assert!(DiffMetadataAgainstBase::try_from(&against_base).is_err());
-}
-
-#[test]
-fn diff_metadata_preserves_pr_info() {
-    let metadata = DiffMetadata {
-        main_branch_name: "main".to_string(),
-        current_branch_name: "feature".to_string(),
-        against_head: DiffMetadataAgainstBase {
-            aggregate_stats: DiffStats {
-                files_changed: 1,
-                total_additions: 2,
-                total_deletions: 3,
-            },
-            files: vec![],
-        },
-        against_base_branch: None,
-        has_head_commit: true,
-        unpushed_commits: vec![],
-        upstream_ref: Some("origin/feature".to_string()),
-        pr_info: Some(PrInfo {
-            number: 42,
-            url: "https://github.com/test/repo/pull/42".to_string(),
-            state: "OPEN".to_string(),
-            draft: true,
-            base_branch: "main".to_string(),
-        }),
-    };
-
-    let proto_metadata = proto::DiffMetadata::from(&metadata);
-    let proto_pr_info = proto_metadata
-        .pr_info
-        .as_ref()
-        .expect("proto metadata should include PR info");
-    assert_eq!(proto_pr_info.number, 42);
-    assert_eq!(proto_pr_info.url, "https://github.com/test/repo/pull/42");
-
-    let decoded_metadata =
-        DiffMetadata::try_from(&proto_metadata).expect("metadata should decode from proto");
-    let decoded_pr_info = decoded_metadata
-        .pr_info
-        .expect("decoded metadata should include PR info");
-    assert_eq!(decoded_pr_info.number, 42);
-    assert_eq!(decoded_pr_info.url, "https://github.com/test/repo/pull/42");
 }
 
 #[test]

--- a/app/src/remote_server/git_status_proto.rs
+++ b/app/src/remote_server/git_status_proto.rs
@@ -1,0 +1,57 @@
+//! Conversion between the git-status / GitHub-info proto types and the app
+//! domain types consumed by `RemoteGitRepoStatusModel` and
+//! `RemoteGitHubRepoModel`.
+//!
+//! Rust types are canonical, proto types are the wire format. Git status
+//! (branch + HEAD diff stats), GitHub PR info, and GitHub repository info are
+//! kept separate so they can be pushed on independent cadences. The
+//! `DiffStats` / `PrInfo` conversions are reused from `diff_state_proto`.
+
+use super::proto;
+use crate::code_review::diff_state::DiffStats;
+use crate::code_review::git_repo_model::GitStatusMetadata;
+use crate::util::git::RepositoryInfo;
+
+impl From<&proto::RepositoryInfo> for RepositoryInfo {
+    fn from(info: &proto::RepositoryInfo) -> Self {
+        RepositoryInfo {
+            name: info.name.clone(),
+            owner: info.owner.clone(),
+        }
+    }
+}
+
+impl From<&RepositoryInfo> for proto::RepositoryInfo {
+    fn from(info: &RepositoryInfo) -> Self {
+        proto::RepositoryInfo {
+            name: info.name.clone(),
+            owner: info.owner.clone(),
+        }
+    }
+}
+
+impl From<&GitStatusMetadata> for proto::GitStatusMetadata {
+    fn from(metadata: &GitStatusMetadata) -> Self {
+        proto::GitStatusMetadata {
+            current_branch_name: metadata.current_branch_name.clone(),
+            main_branch_name: metadata.main_branch_name.clone(),
+            stats_against_head: Some((&metadata.stats_against_head).into()),
+        }
+    }
+}
+
+impl TryFrom<&proto::GitStatusMetadata> for GitStatusMetadata {
+    type Error = String;
+
+    fn try_from(metadata: &proto::GitStatusMetadata) -> Result<Self, Self::Error> {
+        let stats = metadata
+            .stats_against_head
+            .as_ref()
+            .ok_or_else(|| "missing stats_against_head in GitStatusMetadata".to_string())?;
+        Ok(GitStatusMetadata {
+            current_branch_name: metadata.current_branch_name.clone(),
+            main_branch_name: metadata.main_branch_name.clone(),
+            stats_against_head: DiffStats::from(stats),
+        })
+    }
+}

--- a/app/src/remote_server/mod.rs
+++ b/app/src/remote_server/mod.rs
@@ -23,6 +23,8 @@ pub mod diff_state_proto;
 #[cfg(not(target_family = "wasm"))]
 pub mod diff_state_tracker;
 #[cfg(not(target_family = "wasm"))]
+pub mod git_status_proto;
+#[cfg(not(target_family = "wasm"))]
 pub(crate) mod handoff_snapshot;
 #[cfg(not(target_family = "wasm"))]
 pub mod server_buffer_tracker;

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -18,6 +18,7 @@ use warp_core::{safe_error, SessionId};
 use warp_files::{FileModel, FileModelEvent};
 use warp_util::content_version::ContentVersion;
 use warp_util::file::FileId;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::standardized_path::StandardizedPath;
 use warpui::platform::TerminationMode;
 use warpui::r#async::{Spawnable, SpawnableOutput, SpawnedFutureHandle};
@@ -36,10 +37,10 @@ use super::proto::{
     client_message, delete_file_response, discard_files_response, get_diff_state_response,
     get_fragment_metadata_from_hash_response, git_commit_chain_response, git_create_pr_response,
     git_generate_commit_message_response, git_get_committed_branch_files_response,
-    git_get_pr_info_response, git_push_response, host_scoped_request, notification,
-    resolve_conflict_response, run_command_response, save_buffer_response, server_message,
-    session_scoped_request, write_file_response, Abort, Authenticate, BranchInfo, BufferEdit,
-    BufferUpdatedPush, ClientMessage, CloseBuffer, CodebaseIndexLimits, CodebaseIndexStatus,
+    git_push_response, host_scoped_request, notification, resolve_conflict_response,
+    run_command_response, save_buffer_response, server_message, session_scoped_request,
+    write_file_response, Abort, Authenticate, BranchInfo, BufferEdit, BufferUpdatedPush,
+    ClientMessage, CloseBuffer, CodebaseIndexLimits, CodebaseIndexStatus,
     CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, CodebaseResyncMode, DeleteFile,
     DeleteFileResponse, DeleteFileSuccess, DiscardFilesError, DiscardFilesResponse,
     DiscardFilesSuccess, DropCodebaseIndex, ErrorCode, ErrorResponse, FailedFileRead,
@@ -47,22 +48,26 @@ use super::proto::{
     FragmentMetadataLookupError as ProtoFragmentMetadataLookupError,
     FragmentMetadataLookupErrorCode, GetBranchesError, GetBranchesResponse, GetBranchesSuccess,
     GetDiffStateResponse, GetFragmentMetadataFromHash, GetFragmentMetadataFromHashResponse,
-    GetFragmentMetadataFromHashSuccess, GitCommitChainMode, GitCommitChainRequest,
+    GetFragmentMetadataFromHashSuccess, GetGitHubPrInfoRequest, GetGitHubPrInfoResponse,
+    GetGitHubRepoInfoRequest, GetGitHubRepoInfoResponse, GitCommitChainMode, GitCommitChainRequest,
     GitCommitChainResponse, GitCommitChainSuccess, GitCreatePrRequest, GitCreatePrResponse,
     GitGenerateCommitMessageRequest, GitGenerateCommitMessageResponse,
     GitGetCommittedBranchFilesRequest, GitGetCommittedBranchFilesResponse,
-    GitGetCommittedBranchFilesSuccess, GitGetPrInfoRequest, GitGetPrInfoResponse,
-    GitGetPrInfoSuccess, GitOpDelta, GitOpError, GitPushRequest, GitPushResponse, IndexCodebase,
-    Initialize, InitializeResponse, MissingFragmentMetadata, NavigatedToDirectory,
+    GitGetCommittedBranchFilesSuccess, GitHubPrInfoPush, GitHubRepositoryInfoPush, GitOpDelta,
+    GitOpError, GitPushRequest, GitPushResponse, GitStatusPush, IndexCodebase, Initialize,
+    InitializeResponse, MissingFragmentMetadata, NavigatedToDirectory,
     NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse, ReadFileContextResponse,
     ResolveConflict, ResolveConflictResponse, ResolveConflictSuccess, ResyncCodebase,
     RunCommandError, RunCommandErrorCode, RunCommandRequest, RunCommandResponse, RunCommandSuccess,
     SaveBuffer, SaveBufferResponse, SaveBufferSuccess, ServerMessage, SessionBootstrapped,
-    TextEdit, UploadHandoffSnapshot, WriteFile, WriteFileResponse, WriteFileSuccess,
+    TextEdit, UpdateGitStatus, UploadHandoffSnapshot, WriteFile, WriteFileResponse,
+    WriteFileSuccess,
 };
 use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
 use crate::code::global_buffer_model::{GlobalBufferModel, GlobalBufferModelEvent};
 use crate::code_review::diff_state::{CommitChainMode, DiffMode, FileStatusInfo};
+use crate::code_review::git_repo_model::{GitRepoModels, GitRepoStatusModel};
+use crate::code_review::github_repo_model::{GitHubRepoEvent, GitHubRepoModel};
 #[cfg(feature = "local_tty")]
 use crate::terminal::local_shell::LocalShellState;
 use crate::terminal::shell::ShellType;
@@ -244,6 +249,26 @@ pub struct ServerModel {
     /// In-flight host-scoped requests whose response may be delivered on
     /// a different connection if the originating connection disconnects.
     host_scoped_requests: HashMap<RequestId, ConnectionId>,
+    /// Per-repo local git status models tracked on the daemon, keyed by repo
+    /// path. Created when `NavigatedToDirectory` resolves a git root or a
+    /// client requests a snapshot; each is subscribed so watcher ticks
+    /// broadcast `GitStatusPush` to every connection.
+    git_status_models: HashMap<StandardizedPath, ModelHandle<GitRepoStatusModel>>,
+    /// Per-repo local GitHub-info models tracked on the daemon, keyed by repo
+    /// path. Created lazily on the first GitHub-info notification; each is
+    /// subscribed so `gh`-driven changes broadcast PR-info and repository-info
+    /// pushes to every connection.
+    github_repo_models: HashMap<StandardizedPath, ModelHandle<GitHubRepoModel>>,
+    /// Connections subscribed (via navigation) to each repo's git status,
+    /// keyed by repo path. A repo's git-status *and* GitHub-info models live
+    /// while this set is non-empty and are evicted once the last connection
+    /// unsubscribes (navigates away or disconnects). Mirrors
+    /// `RemoteDiffStateManager`'s per-key connection sets, keyed by repo only.
+    git_status_subscribers: HashMap<StandardizedPath, HashSet<ConnectionId>>,
+    /// Each connection's current git repo (a connection is in at most one repo
+    /// at a time), so a navigation can move its subscription and a disconnect
+    /// can drop it.
+    conn_current_repo: HashMap<ConnectionId, StandardizedPath>,
 }
 
 impl Entity for ServerModel {
@@ -272,6 +297,10 @@ impl ServerModel {
             buffers: ServerBufferTracker::new(),
             diff_states: ctx.add_model(|_| RemoteDiffStateManager::new()),
             host_scoped_requests: HashMap::new(),
+            git_status_models: HashMap::new(),
+            github_repo_models: HashMap::new(),
+            git_status_subscribers: HashMap::new(),
+            conn_current_repo: HashMap::new(),
         };
         // Subscribe to FileModel and RepoMetadataModel events
         // file operation results and repo metadata pushes are forwarded to all
@@ -669,6 +698,10 @@ impl ServerModel {
         self.diff_states
             .update(ctx, |mgr, _| mgr.remove_connection(conn_id));
 
+        // Drop this connection's git-status / GitHub-info subscription. The
+        // per-repo models are evicted once no connection remains in the repo.
+        self.unsubscribe_connection(conn_id);
+
         let remaining = self.connection_senders.len();
         log::info!("Daemon: connection {conn_id} deregistered — {remaining} active remaining");
         if remaining == 0 {
@@ -769,6 +802,12 @@ impl ServerModel {
                     Some(host_scoped_request::Message::GitGetCommittedBranchFiles(m)) => {
                         self.handle_get_committed_branch_files(m, &request_id, conn_id, ctx)
                     }
+                    Some(host_scoped_request::Message::GetGithubPrInfo(m)) => {
+                        self.handle_get_github_pr_info(m, &request_id, conn_id, ctx)
+                    }
+                    Some(host_scoped_request::Message::GetGithubRepositoryInfo(m)) => {
+                        self.handle_get_github_repo_info(m, &request_id, conn_id, ctx)
+                    }
                     None => {
                         log::warn!(
                             "HostScopedRequest with no inner message (request_id={request_id})"
@@ -841,6 +880,9 @@ impl ServerModel {
                     }
                     Some(notification::Message::UnsubscribeDiffState(m)) => {
                         self.handle_unsubscribe_diff_state(m, conn_id, ctx);
+                    }
+                    Some(notification::Message::UpdateGitStatus(m)) => {
+                        self.handle_update_git_status(m, ctx);
                     }
                     None => {
                         log::warn!("Notification with no inner message (request_id={request_id})");
@@ -1885,6 +1927,14 @@ impl ServerModel {
                     StandardizedPath::from_local_canonicalized(Path::new(&indexed_path))
                 {
                     if is_git {
+                        // Navigation is the interest signal: record this
+                        // connection as subscribed to the repo, ensure the
+                        // per-repo git-status model exists, and opportunistically
+                        // push its current value before relying on watcher ticks
+                        // or explicit get-status notifications.
+                        me.subscribe_connection(conn_id_for_response, &root_path);
+                        me.subscribe_to_git_status_updates(&root_path, ctx);
+                        me.push_git_status(&root_path, ctx);
                         let already_sent = me
                             .snapshot_sent_roots_by_connection
                             .get(&conn_id_for_response)
@@ -1896,6 +1946,11 @@ impl ServerModel {
                             );
                             return;
                         }
+                    } else {
+                        // Navigated out of any git repo: drop this connection's
+                        // subscription so the previously-current repo's models
+                        // are evicted once no connection remains in it.
+                        me.unsubscribe_connection(conn_id_for_response);
                     }
 
                     let id = RepositoryIdentifier::local(root_path.clone());
@@ -3177,6 +3232,315 @@ impl ServerModel {
             ctx,
         );
         HandlerOutcome::Async(Some(handle))
+    }
+
+    /// Subscribes the daemon to per-repo local git status updates. On first
+    /// creation it wires model events to broadcast a `GitStatusPush`. No-op if
+    /// already subscribed, or when the repo is not yet a watched repository;
+    /// the next navigation or explicit snapshot request will try again.
+    fn subscribe_to_git_status_updates(
+        &mut self,
+        repo_path: &StandardizedPath,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if self.git_status_models.contains_key(repo_path) {
+            return;
+        }
+        let repo = LocalOrRemotePath::Local(PathBuf::from(repo_path.as_str()));
+        let handle = match GitRepoModels::handle(ctx)
+            .update(ctx, |factory, ctx| factory.subscribe(&repo, ctx))
+        {
+            Ok(handle) => handle,
+            Err(e) => {
+                log::warn!("Daemon: git status subscribe failed for {repo_path}: {e}");
+                return;
+            }
+        };
+
+        let path_for_sub = repo_path.clone();
+        ctx.subscribe_to_model(&handle, move |me, _event, ctx| {
+            let proto_metadata = {
+                let Some(handle) = me.git_status_models.get(&path_for_sub) else {
+                    return;
+                };
+                let Some(metadata) = handle.as_ref(ctx).metadata(ctx) else {
+                    return;
+                };
+                metadata.into()
+            };
+            me.send_server_message(
+                None,
+                None,
+                server_message::Message::GitStatusPush(GitStatusPush {
+                    repo_path: path_for_sub.to_string(),
+                    metadata: Some(proto_metadata),
+                }),
+            );
+        });
+
+        self.git_status_models.insert(repo_path.clone(), handle);
+    }
+
+    /// Subscribe `conn` to `repo`'s git status (navigation in), moving it off
+    /// any repo it was previously in. Pure bookkeeping — the caller ensures the
+    /// per-repo git-status model exists via `subscribe_to_git_status_updates`.
+    fn subscribe_connection(&mut self, conn: ConnectionId, repo: &StandardizedPath) {
+        match self.conn_current_repo.get(&conn) {
+            Some(prev) if prev == repo => return,
+            Some(prev) => {
+                let prev = prev.clone();
+                self.drop_subscription(&prev, conn);
+            }
+            None => {}
+        }
+        self.conn_current_repo.insert(conn, repo.clone());
+        self.git_status_subscribers
+            .entry(repo.clone())
+            .or_default()
+            .insert(conn);
+    }
+
+    /// Unsubscribe `conn` from its current repo (navigation out of git, or
+    /// disconnect). A connection is in at most one repo, so this single method
+    /// also serves as the disconnect sweep.
+    fn unsubscribe_connection(&mut self, conn: ConnectionId) {
+        if let Some(repo) = self.conn_current_repo.remove(&conn) {
+            self.drop_subscription(&repo, conn);
+        }
+    }
+
+    /// Remove one `(repo, conn)` subscription, evicting the per-repo git-status
+    /// and GitHub-info models once the repo has no subscribers left. The local
+    /// models' `Drop` impls reclaim the filesystem watcher and the `gh` timer.
+    fn drop_subscription(&mut self, repo: &StandardizedPath, conn: ConnectionId) {
+        let Some(subscribers) = self.git_status_subscribers.get_mut(repo) else {
+            return;
+        };
+        subscribers.remove(&conn);
+        if subscribers.is_empty() {
+            self.git_status_subscribers.remove(repo);
+            // Drop the GitHub model first so it releases its strong handle to
+            // the sibling git-status model, then drop the git-status model.
+            self.github_repo_models.remove(repo);
+            self.git_status_models.remove(repo);
+        }
+    }
+
+    /// Handles `UpdateGitStatus` notification (fire-and-forget).
+    fn handle_update_git_status(&mut self, msg: UpdateGitStatus, ctx: &mut ModelContext<Self>) {
+        let std_path = match StandardizedPath::from_local_canonicalized(Path::new(&msg.repo_path)) {
+            Ok(p) => p,
+            Err(e) => {
+                log::warn!("Invalid repo_path for UpdateGitStatus: {e}");
+                return;
+            }
+        };
+
+        self.subscribe_to_git_status_updates(&std_path, ctx);
+        self.push_git_status(&std_path, ctx);
+    }
+
+    fn push_git_status(&mut self, repo_path: &StandardizedPath, ctx: &mut ModelContext<Self>) {
+        let Some(handle) = self.git_status_models.get(repo_path) else {
+            return;
+        };
+        let Some(metadata) = handle.as_ref(ctx).metadata(ctx) else {
+            return;
+        };
+        let proto_metadata = metadata.into();
+        self.send_server_message(
+            None,
+            None,
+            server_message::Message::GitStatusPush(GitStatusPush {
+                repo_path: repo_path.to_string(),
+                metadata: Some(proto_metadata),
+            }),
+        );
+    }
+
+    /// Handles `GetGitHubPrInfoRequest` host-scoped request.
+    fn handle_get_github_pr_info(
+        &mut self,
+        msg: GetGitHubPrInfoRequest,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) -> HandlerOutcome {
+        let std_path = match StandardizedPath::from_local_canonicalized(Path::new(&msg.repo_path)) {
+            Ok(p) => p,
+            Err(e) => {
+                return invalid_request_response(format!(
+                    "Invalid repo_path for GetGitHubPrInfoRequest: {e}"
+                ));
+            }
+        };
+
+        // Ensure the per-repo model exists so its own lifecycle (creation
+        // fetch, 60s timer, branch change) keeps broadcasting PR-info pushes
+        // to all connections. We deliberately do NOT trigger `refresh_pr_info`
+        // here: the `get_pr_for_branch` fetch below already produces this
+        // request's fresh result for the direct response, so triggering the
+        // model too would run a redundant `gh pr view`.
+        self.subscribe_to_github_info_updates(&std_path, ctx);
+
+        let repo_path = std_path.to_local_path_lossy();
+        let path_future = Self::interactive_path_future(ctx);
+        let request_id_for_response = request_id.clone();
+        let handle = self.spawn_request_handler(
+            request_id.clone(),
+            async move {
+                let path_env = path_future.await;
+                git::get_pr_for_branch(&repo_path, path_env.as_deref()).await
+            },
+            move |me, result, _ctx| {
+                let response = match result {
+                    Ok(pr_info) => GetGitHubPrInfoResponse {
+                        pr_info: pr_info.as_ref().map(super::proto::PrInfo::from),
+                        error: None,
+                    },
+                    Err(e) => GetGitHubPrInfoResponse {
+                        pr_info: None,
+                        error: Some(GitOpError {
+                            message: format!("{e:#}"),
+                        }),
+                    },
+                };
+                me.send_server_message(
+                    Some(conn_id),
+                    Some(&request_id_for_response),
+                    server_message::Message::GetGithubPrInfoResponse(response),
+                );
+            },
+            ctx,
+        );
+        HandlerOutcome::Async(Some(handle))
+    }
+
+    /// Handles `GetGitHubRepoInfoRequest` host-scoped request.
+    fn handle_get_github_repo_info(
+        &mut self,
+        msg: GetGitHubRepoInfoRequest,
+        request_id: &RequestId,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) -> HandlerOutcome {
+        let std_path = match StandardizedPath::from_local_canonicalized(Path::new(&msg.repo_path)) {
+            Ok(p) => p,
+            Err(e) => {
+                return invalid_request_response(format!(
+                    "Invalid repo_path for GetGitHubRepoInfoRequest: {e}"
+                ));
+            }
+        };
+
+        // Ensure the per-repo model exists so its own lifecycle (creation
+        // fetch, 60s timer) keeps broadcasting repository-info pushes to all
+        // connections. We deliberately do NOT trigger `refresh_repository_info`
+        // here: the `get_repository_info` fetch below already produces this
+        // request's fresh result for the direct response, so triggering the
+        // model too would run a redundant `gh repo view`.
+        self.subscribe_to_github_info_updates(&std_path, ctx);
+
+        let repo_path = std_path.to_local_path_lossy();
+        let path_future = Self::interactive_path_future(ctx);
+        let request_id_for_response = request_id.clone();
+        let handle = self.spawn_request_handler(
+            request_id.clone(),
+            async move {
+                let path_env = path_future.await;
+                git::get_repository_info(&repo_path, path_env.as_deref()).await
+            },
+            move |me, result, _ctx| {
+                let response = match result {
+                    Ok(repository_info) => GetGitHubRepoInfoResponse {
+                        repository_info: Some(super::proto::RepositoryInfo::from(&repository_info)),
+                        error: None,
+                    },
+                    Err(e) => GetGitHubRepoInfoResponse {
+                        repository_info: None,
+                        error: Some(GitOpError {
+                            message: format!("{e:#}"),
+                        }),
+                    },
+                };
+                me.send_server_message(
+                    Some(conn_id),
+                    Some(&request_id_for_response),
+                    server_message::Message::GetGithubRepoInfoResponse(response),
+                );
+            },
+            ctx,
+        );
+        HandlerOutcome::Async(Some(handle))
+    }
+
+    fn push_github_pr_info(&mut self, repo_path: &StandardizedPath, ctx: &mut ModelContext<Self>) {
+        let Some(handle) = self.github_repo_models.get(repo_path) else {
+            return;
+        };
+        let pr_info = handle.as_ref(ctx).pr_info(ctx).map(Into::into);
+        self.send_server_message(
+            None,
+            None,
+            server_message::Message::GithubPrInfoPush(GitHubPrInfoPush {
+                repo_path: repo_path.to_string(),
+                pr_info,
+            }),
+        );
+    }
+
+    fn push_github_repository_info(
+        &mut self,
+        repo_path: &StandardizedPath,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(handle) = self.github_repo_models.get(repo_path) else {
+            return;
+        };
+        let repository_info = handle.as_ref(ctx).repository_info(ctx).map(Into::into);
+        self.send_server_message(
+            None,
+            None,
+            server_message::Message::GithubRepositoryInfoPush(GitHubRepositoryInfoPush {
+                repo_path: repo_path.to_string(),
+                repository_info,
+            }),
+        );
+    }
+
+    /// Subscribes the daemon to per-repo local GitHub info updates. On first
+    /// creation it wires model events to broadcast separate PR-info and
+    /// repository-info pushes. No-op if already subscribed, or when the repo is
+    /// not yet a watched repository
+    /// (the client requests another snapshot on `HostConnected`).
+    fn subscribe_to_github_info_updates(
+        &mut self,
+        repo_path: &StandardizedPath,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if self.github_repo_models.contains_key(repo_path) {
+            return;
+        }
+        let repo = LocalOrRemotePath::Local(PathBuf::from(repo_path.as_str()));
+        let handle = match GitRepoModels::handle(ctx).update(ctx, |factory, ctx| {
+            factory.subscribe_github_repo(&repo, ctx)
+        }) {
+            Ok(handle) => handle,
+            Err(e) => {
+                log::warn!("Daemon: github repo subscribe failed for {repo_path}: {e}");
+                return;
+            }
+        };
+
+        let path_for_sub = repo_path.clone();
+        ctx.subscribe_to_model(&handle, move |me, event, ctx| match event {
+            GitHubRepoEvent::PrInfoChanged => me.push_github_pr_info(&path_for_sub, ctx),
+            GitHubRepoEvent::RepositoryInfoChanged => {
+                me.push_github_repository_info(&path_for_sub, ctx)
+            }
+        });
+
+        self.github_repo_models.insert(repo_path.clone(), handle);
     }
 
     /// Returns a future resolving to the host's interactive login-shell PATH

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -763,9 +763,6 @@ impl ServerModel {
                     Some(host_scoped_request::Message::GitCreatePr(m)) => {
                         self.handle_create_pr(m, &request_id, conn_id, ctx)
                     }
-                    Some(host_scoped_request::Message::GitGetPrInfo(m)) => {
-                        self.handle_get_pr_info(m, &request_id, conn_id, ctx)
-                    }
                     Some(host_scoped_request::Message::GitGenerateCommitMessage(m)) => {
                         self.handle_generate_git_commit_message(m, &request_id, conn_id, ctx)
                     }
@@ -3057,53 +3054,6 @@ impl ServerModel {
                     }),
                     Err(e) => server_message::Message::GitCreatePrResponse(GitCreatePrResponse {
                         result: Some(git_create_pr_response::Result::Error(GitOpError {
-                            message: format!("{e:#}"),
-                        })),
-                    }),
-                };
-                me.send_server_message(Some(conn_id), Some(&request_id_for_response), message);
-            },
-            ctx,
-        );
-        HandlerOutcome::Async(Some(handle))
-    }
-
-    /// Handles `GitGetPrInfoRequest` — runs `gh pr view` on the remote
-    /// filesystem. This is the remote PR get/view command.
-    fn handle_get_pr_info(
-        &mut self,
-        msg: GitGetPrInfoRequest,
-        request_id: &RequestId,
-        conn_id: ConnectionId,
-        ctx: &mut ModelContext<Self>,
-    ) -> HandlerOutcome {
-        let repo_path = match requested_repo_path(&msg.repo_path) {
-            Ok(p) => p,
-            Err(e) => return invalid_request_response(e),
-        };
-        log::info!(
-            "Handling GetPrInfo repo={} (request_id={request_id})",
-            msg.repo_path
-        );
-        let path_future = Self::interactive_path_future(ctx);
-        let request_id_for_response = request_id.clone();
-        let handle = self.spawn_request_handler(
-            request_id.clone(),
-            async move {
-                let path_env = path_future.await;
-                git_actions::get_pr(&repo_path, path_env.as_deref()).await
-            },
-            move |me, result, _ctx| {
-                let message = match result {
-                    Ok(pr) => server_message::Message::GitGetPrInfoResponse(GitGetPrInfoResponse {
-                        result: Some(git_get_pr_info_response::Result::Success(
-                            GitGetPrInfoSuccess {
-                                pr_info: pr.as_ref().map(super::proto::PrInfo::from),
-                            },
-                        )),
-                    }),
-                    Err(e) => server_message::Message::GitGetPrInfoResponse(GitGetPrInfoResponse {
-                        result: Some(git_get_pr_info_response::Result::Error(GitOpError {
                             message: format!("{e:#}"),
                         })),
                     }),

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -268,7 +268,7 @@ pub struct ServerModel {
     /// Each connection's current git repo (a connection is in at most one repo
     /// at a time), so a navigation can move its subscription and a disconnect
     /// can drop it.
-    conn_current_repo: HashMap<ConnectionId, StandardizedPath>,
+    git_status_repo_by_conn: HashMap<ConnectionId, StandardizedPath>,
 }
 
 impl Entity for ServerModel {
@@ -300,7 +300,7 @@ impl ServerModel {
             git_status_models: HashMap::new(),
             github_repo_models: HashMap::new(),
             git_status_subscribers: HashMap::new(),
-            conn_current_repo: HashMap::new(),
+            git_status_repo_by_conn: HashMap::new(),
         };
         // Subscribe to FileModel and RepoMetadataModel events
         // file operation results and repo metadata pushes are forwarded to all
@@ -700,7 +700,7 @@ impl ServerModel {
 
         // Drop this connection's git-status / GitHub-info subscription. The
         // per-repo models are evicted once no connection remains in the repo.
-        self.unsubscribe_connection(conn_id);
+        self.unsubscribe_git_status(conn_id);
 
         let remaining = self.connection_senders.len();
         log::info!("Daemon: connection {conn_id} deregistered — {remaining} active remaining");
@@ -1932,7 +1932,7 @@ impl ServerModel {
                         // per-repo git-status model exists, and opportunistically
                         // push its current value before relying on watcher ticks
                         // or explicit get-status notifications.
-                        me.subscribe_connection(conn_id_for_response, &root_path);
+                        me.subscribe_git_status(conn_id_for_response, &root_path);
                         me.subscribe_to_git_status_updates(&root_path, ctx);
                         me.push_git_status(&root_path, ctx);
                         let already_sent = me
@@ -1950,7 +1950,7 @@ impl ServerModel {
                         // Navigated out of any git repo: drop this connection's
                         // subscription so the previously-current repo's models
                         // are evicted once no connection remains in it.
-                        me.unsubscribe_connection(conn_id_for_response);
+                        me.unsubscribe_git_status(conn_id_for_response);
                     }
 
                     let id = RepositoryIdentifier::local(root_path.clone());
@@ -3246,7 +3246,7 @@ impl ServerModel {
         if self.git_status_models.contains_key(repo_path) {
             return;
         }
-        let repo = LocalOrRemotePath::Local(PathBuf::from(repo_path.as_str()));
+        let repo = LocalOrRemotePath::Local(repo_path.to_local_path_lossy());
         let handle = match GitRepoModels::handle(ctx)
             .update(ctx, |factory, ctx| factory.subscribe(&repo, ctx))
         {
@@ -3284,8 +3284,8 @@ impl ServerModel {
     /// Subscribe `conn` to `repo`'s git status (navigation in), moving it off
     /// any repo it was previously in. Pure bookkeeping — the caller ensures the
     /// per-repo git-status model exists via `subscribe_to_git_status_updates`.
-    fn subscribe_connection(&mut self, conn: ConnectionId, repo: &StandardizedPath) {
-        match self.conn_current_repo.get(&conn) {
+    fn subscribe_git_status(&mut self, conn: ConnectionId, repo: &StandardizedPath) {
+        match self.git_status_repo_by_conn.get(&conn) {
             Some(prev) if prev == repo => return,
             Some(prev) => {
                 let prev = prev.clone();
@@ -3293,7 +3293,7 @@ impl ServerModel {
             }
             None => {}
         }
-        self.conn_current_repo.insert(conn, repo.clone());
+        self.git_status_repo_by_conn.insert(conn, repo.clone());
         self.git_status_subscribers
             .entry(repo.clone())
             .or_default()
@@ -3303,8 +3303,8 @@ impl ServerModel {
     /// Unsubscribe `conn` from its current repo (navigation out of git, or
     /// disconnect). A connection is in at most one repo, so this single method
     /// also serves as the disconnect sweep.
-    fn unsubscribe_connection(&mut self, conn: ConnectionId) {
-        if let Some(repo) = self.conn_current_repo.remove(&conn) {
+    fn unsubscribe_git_status(&mut self, conn: ConnectionId) {
+        if let Some(repo) = self.git_status_repo_by_conn.remove(&conn) {
             self.drop_subscription(&repo, conn);
         }
     }
@@ -3341,7 +3341,7 @@ impl ServerModel {
             }
         };
 
-        self.subscribe_connection(conn_id, &std_path);
+        self.subscribe_git_status(conn_id, &std_path);
         self.subscribe_to_git_status_updates(&std_path, ctx);
         self.push_git_status(&std_path, ctx);
     }
@@ -3527,7 +3527,7 @@ impl ServerModel {
         if self.github_repo_models.contains_key(repo_path) {
             return;
         }
-        let repo = LocalOrRemotePath::Local(PathBuf::from(repo_path.as_str()));
+        let repo = LocalOrRemotePath::Local(repo_path.to_local_path_lossy());
         let handle = match GitRepoModels::handle(ctx).update(ctx, |factory, ctx| {
             factory.subscribe_github_repo(&repo, ctx)
         }) {

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -57,11 +57,11 @@ use super::proto::{
     GitOpError, GitPushRequest, GitPushResponse, GitStatusPush, IndexCodebase, Initialize,
     InitializeResponse, MissingFragmentMetadata, NavigatedToDirectory,
     NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse, ReadFileContextResponse,
-    ResolveConflict, ResolveConflictResponse, ResolveConflictSuccess, ResyncCodebase,
-    RunCommandError, RunCommandErrorCode, RunCommandRequest, RunCommandResponse, RunCommandSuccess,
-    SaveBuffer, SaveBufferResponse, SaveBufferSuccess, ServerMessage, SessionBootstrapped,
-    TextEdit, UpdateGitStatus, UploadHandoffSnapshot, WriteFile, WriteFileResponse,
-    WriteFileSuccess,
+    RepositoryInfo, ResolveConflict, ResolveConflictResponse, ResolveConflictSuccess,
+    ResyncCodebase, RunCommandError, RunCommandErrorCode, RunCommandRequest, RunCommandResponse,
+    RunCommandSuccess, SaveBuffer, SaveBufferResponse, SaveBufferSuccess, ServerMessage,
+    SessionBootstrapped, TextEdit, UpdateGitStatus, UploadHandoffSnapshot, WriteFile,
+    WriteFileResponse, WriteFileSuccess,
 };
 use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
 use crate::code::global_buffer_model::{GlobalBufferModel, GlobalBufferModelEvent};
@@ -882,7 +882,7 @@ impl ServerModel {
                         self.handle_unsubscribe_diff_state(m, conn_id, ctx);
                     }
                     Some(notification::Message::UpdateGitStatus(m)) => {
-                        self.handle_update_git_status(m, ctx);
+                        self.handle_update_git_status(m, conn_id, ctx);
                     }
                     None => {
                         log::warn!("Notification with no inner message (request_id={request_id})");
@@ -3327,7 +3327,12 @@ impl ServerModel {
     }
 
     /// Handles `UpdateGitStatus` notification (fire-and-forget).
-    fn handle_update_git_status(&mut self, msg: UpdateGitStatus, ctx: &mut ModelContext<Self>) {
+    fn handle_update_git_status(
+        &mut self,
+        msg: UpdateGitStatus,
+        conn_id: ConnectionId,
+        ctx: &mut ModelContext<Self>,
+    ) {
         let std_path = match StandardizedPath::from_local_canonicalized(Path::new(&msg.repo_path)) {
             Ok(p) => p,
             Err(e) => {
@@ -3336,6 +3341,7 @@ impl ServerModel {
             }
         };
 
+        self.subscribe_connection(conn_id, &std_path);
         self.subscribe_to_git_status_updates(&std_path, ctx);
         self.push_git_status(&std_path, ctx);
     }
@@ -3453,7 +3459,7 @@ impl ServerModel {
             move |me, result, _ctx| {
                 let response = match result {
                     Ok(repository_info) => GetGitHubRepoInfoResponse {
-                        repository_info: Some(super::proto::RepositoryInfo::from(&repository_info)),
+                        repository_info: repository_info.as_ref().map(RepositoryInfo::from),
                         error: None,
                     },
                     Err(e) => GetGitHubRepoInfoResponse {

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -29,6 +29,10 @@ fn test_model(app: &mut App) -> ServerModel {
         buffers: ServerBufferTracker::new(),
         diff_states: app.add_model(|_| RemoteDiffStateManager::new()),
         host_scoped_requests: HashMap::new(),
+        git_status_models: HashMap::new(),
+        github_repo_models: HashMap::new(),
+        git_status_subscribers: HashMap::new(),
+        conn_current_repo: HashMap::new(),
     }
 }
 
@@ -187,6 +191,92 @@ fn diff_states_starts_empty() {
             mgr.subscribed_connections(&key).is_empty()
         });
         assert!(empty);
+    });
+}
+
+// ── Git status / GitHub: navigation-driven model cleanup ────────────
+
+#[test]
+fn subscribe_connection_records_subscriber_and_current_repo() {
+    App::test((), |mut app| async move {
+        let mut model = test_model(&mut app);
+        let conn = uuid::Uuid::new_v4();
+        let repo = StandardizedPath::try_new("/repo").unwrap();
+
+        model.subscribe_connection(conn, &repo);
+
+        assert_eq!(model.conn_current_repo.get(&conn), Some(&repo));
+        assert!(model.git_status_subscribers[&repo].contains(&conn));
+    });
+}
+
+#[test]
+fn navigating_between_repos_moves_the_subscription() {
+    App::test((), |mut app| async move {
+        let mut model = test_model(&mut app);
+        let conn = uuid::Uuid::new_v4();
+        let repo_a = StandardizedPath::try_new("/repo-a").unwrap();
+        let repo_b = StandardizedPath::try_new("/repo-b").unwrap();
+
+        model.subscribe_connection(conn, &repo_a);
+        model.subscribe_connection(conn, &repo_b);
+
+        // Moved off A (now empty) and onto B.
+        assert!(!model.git_status_subscribers.contains_key(&repo_a));
+        assert!(model.git_status_subscribers[&repo_b].contains(&conn));
+        assert_eq!(model.conn_current_repo.get(&conn), Some(&repo_b));
+    });
+}
+
+#[test]
+fn last_subscriber_leaving_evicts_the_repo() {
+    App::test((), |mut app| async move {
+        let mut model = test_model(&mut app);
+        let conn = uuid::Uuid::new_v4();
+        let repo = StandardizedPath::try_new("/repo").unwrap();
+
+        model.subscribe_connection(conn, &repo);
+        assert!(model.git_status_subscribers.contains_key(&repo));
+
+        model.unsubscribe_connection(conn);
+
+        // Subscriber set, current-repo mapping, and the per-repo model maps are
+        // all cleared once no connection remains in the repo.
+        assert!(!model.git_status_subscribers.contains_key(&repo));
+        assert!(!model.conn_current_repo.contains_key(&conn));
+        assert!(!model.git_status_models.contains_key(&repo));
+        assert!(!model.github_repo_models.contains_key(&repo));
+    });
+}
+
+#[test]
+fn sibling_connection_keeps_the_repo_alive() {
+    App::test((), |mut app| async move {
+        let mut model = test_model(&mut app);
+        let conn_a = uuid::Uuid::new_v4();
+        let conn_b = uuid::Uuid::new_v4();
+        let repo = StandardizedPath::try_new("/repo").unwrap();
+
+        model.subscribe_connection(conn_a, &repo);
+        model.subscribe_connection(conn_b, &repo);
+
+        // First connection leaves: the repo stays for the sibling.
+        model.unsubscribe_connection(conn_a);
+        assert!(model.git_status_subscribers[&repo].contains(&conn_b));
+
+        // Second connection leaves: now evicted.
+        model.unsubscribe_connection(conn_b);
+        assert!(!model.git_status_subscribers.contains_key(&repo));
+    });
+}
+
+#[test]
+fn unsubscribe_unknown_connection_is_a_noop() {
+    App::test((), |mut app| async move {
+        let mut model = test_model(&mut app);
+        model.unsubscribe_connection(uuid::Uuid::new_v4());
+        assert!(model.git_status_subscribers.is_empty());
+        assert!(model.conn_current_repo.is_empty());
     });
 }
 

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -32,7 +32,7 @@ fn test_model(app: &mut App) -> ServerModel {
         git_status_models: HashMap::new(),
         github_repo_models: HashMap::new(),
         git_status_subscribers: HashMap::new(),
-        conn_current_repo: HashMap::new(),
+        git_status_repo_by_conn: HashMap::new(),
     }
 }
 
@@ -197,15 +197,15 @@ fn diff_states_starts_empty() {
 // ── Git status / GitHub: navigation-driven model cleanup ────────────
 
 #[test]
-fn subscribe_connection_records_subscriber_and_current_repo() {
+fn subscribe_git_status_records_subscriber_and_current_repo() {
     App::test((), |mut app| async move {
         let mut model = test_model(&mut app);
         let conn = uuid::Uuid::new_v4();
         let repo = StandardizedPath::try_new("/repo").unwrap();
 
-        model.subscribe_connection(conn, &repo);
+        model.subscribe_git_status(conn, &repo);
 
-        assert_eq!(model.conn_current_repo.get(&conn), Some(&repo));
+        assert_eq!(model.git_status_repo_by_conn.get(&conn), Some(&repo));
         assert!(model.git_status_subscribers[&repo].contains(&conn));
     });
 }
@@ -218,13 +218,13 @@ fn navigating_between_repos_moves_the_subscription() {
         let repo_a = StandardizedPath::try_new("/repo-a").unwrap();
         let repo_b = StandardizedPath::try_new("/repo-b").unwrap();
 
-        model.subscribe_connection(conn, &repo_a);
-        model.subscribe_connection(conn, &repo_b);
+        model.subscribe_git_status(conn, &repo_a);
+        model.subscribe_git_status(conn, &repo_b);
 
         // Moved off A (now empty) and onto B.
         assert!(!model.git_status_subscribers.contains_key(&repo_a));
         assert!(model.git_status_subscribers[&repo_b].contains(&conn));
-        assert_eq!(model.conn_current_repo.get(&conn), Some(&repo_b));
+        assert_eq!(model.git_status_repo_by_conn.get(&conn), Some(&repo_b));
     });
 }
 
@@ -235,15 +235,15 @@ fn last_subscriber_leaving_evicts_the_repo() {
         let conn = uuid::Uuid::new_v4();
         let repo = StandardizedPath::try_new("/repo").unwrap();
 
-        model.subscribe_connection(conn, &repo);
+        model.subscribe_git_status(conn, &repo);
         assert!(model.git_status_subscribers.contains_key(&repo));
 
-        model.unsubscribe_connection(conn);
+        model.unsubscribe_git_status(conn);
 
         // Subscriber set, current-repo mapping, and the per-repo model maps are
         // all cleared once no connection remains in the repo.
         assert!(!model.git_status_subscribers.contains_key(&repo));
-        assert!(!model.conn_current_repo.contains_key(&conn));
+        assert!(!model.git_status_repo_by_conn.contains_key(&conn));
         assert!(!model.git_status_models.contains_key(&repo));
         assert!(!model.github_repo_models.contains_key(&repo));
     });
@@ -257,15 +257,15 @@ fn sibling_connection_keeps_the_repo_alive() {
         let conn_b = uuid::Uuid::new_v4();
         let repo = StandardizedPath::try_new("/repo").unwrap();
 
-        model.subscribe_connection(conn_a, &repo);
-        model.subscribe_connection(conn_b, &repo);
+        model.subscribe_git_status(conn_a, &repo);
+        model.subscribe_git_status(conn_b, &repo);
 
         // First connection leaves: the repo stays for the sibling.
-        model.unsubscribe_connection(conn_a);
+        model.unsubscribe_git_status(conn_a);
         assert!(model.git_status_subscribers[&repo].contains(&conn_b));
 
         // Second connection leaves: now evicted.
-        model.unsubscribe_connection(conn_b);
+        model.unsubscribe_git_status(conn_b);
         assert!(!model.git_status_subscribers.contains_key(&repo));
     });
 }
@@ -274,9 +274,9 @@ fn sibling_connection_keeps_the_repo_alive() {
 fn unsubscribe_unknown_connection_is_a_noop() {
     App::test((), |mut app| async move {
         let mut model = test_model(&mut app);
-        model.unsubscribe_connection(uuid::Uuid::new_v4());
+        model.unsubscribe_git_status(uuid::Uuid::new_v4());
         assert!(model.git_status_subscribers.is_empty());
-        assert!(model.conn_current_repo.is_empty());
+        assert!(model.git_status_repo_by_conn.is_empty());
     });
 }
 

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -261,7 +261,7 @@ pub fn initialize_app(app: &mut App) {
     app.add_singleton_model(DirectoryWatcher::new);
     app.add_singleton_model(|_| DetectedRepositories::default());
     app.add_singleton_model(crate::remote_server::manager::RemoteServerManager::new);
-    app.add_singleton_model(|_| crate::code_review::git_status_update::GitStatusUpdateModel::new());
+    app.add_singleton_model(|_| crate::code_review::git_repo_model::GitRepoModels::new());
     app.add_singleton_model(RepoMetadataModel::new);
     app.add_singleton_model(FileSearchModel::new);
     app.add_singleton_model(RepoOutlines::new_for_test);

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -188,8 +188,12 @@ impl Sessions {
                 | RemoteServerManagerEvent::GitPushResponse { .. }
                 | RemoteServerManagerEvent::CreatePrResponse { .. }
                 | RemoteServerManagerEvent::GenerateCommitMessageResponse { .. }
-                | RemoteServerManagerEvent::GetPrInfoResponse { .. }
-                | RemoteServerManagerEvent::GetCommittedBranchFilesResponse { .. } => {}
+                | RemoteServerManagerEvent::GetCommittedBranchFilesResponse { .. }
+                | RemoteServerManagerEvent::GetGitHubPrInfoResponse { .. }
+                | RemoteServerManagerEvent::GetGitHubRepoInfoResponse { .. }
+                | RemoteServerManagerEvent::GitStatusPushReceived { .. }
+                | RemoteServerManagerEvent::GitHubPrInfoPushReceived { .. }
+                | RemoteServerManagerEvent::GitHubRepositoryInfoPushReceived { .. } => {}
                 RemoteServerManagerEvent::SessionReconnected {
                     session_id: sid,
                     client,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -320,16 +320,12 @@ use crate::code_review::context::{
 #[cfg(feature = "local_fs")]
 use crate::code_review::diff_state::LocalDiffStateModel;
 use crate::code_review::diff_state::{DiffMode, GitDeltaPreference};
-#[cfg(feature = "local_fs")]
 use crate::code_review::git_repo_model::{GitRepoModels, GitRepoStatusModel, GitStatusMetadata};
-#[cfg(feature = "local_fs")]
 use crate::code_review::github_repo_model::GitHubRepoModel;
 use crate::code_review::telemetry_event::CodeReviewPaneEntrypoint;
 #[cfg(feature = "local_fs")]
 use crate::code_review::DiffSetScope;
-use crate::context_chips::prompt::Prompt;
-#[cfg(feature = "local_fs")]
-use crate::context_chips::prompt::PromptSelection;
+use crate::context_chips::prompt::{Prompt, PromptSelection};
 use crate::context_chips::prompt_type::PromptType;
 use crate::context_chips::ContextChipKind;
 use crate::drive::settings::WarpDriveSettings;
@@ -2791,17 +2787,14 @@ pub struct TerminalView {
     agent_todos_popup: ViewHandle<AgentTodosPopupView>,
 
     /// Per-repo git status model for the current repository, if any.
-    #[cfg(feature = "local_fs")]
     git_repo_status: Option<ModelHandle<GitRepoStatusModel>>,
 
     /// Per-repo GitHub-info model for the current repository, if any.
-    #[cfg(feature = "local_fs")]
     github_repo_model: Option<ModelHandle<GitHubRepoModel>>,
 
     /// Deferred code review open request, stashed when [`GitDeltaPreference::OnlyDirty`] is
     /// requested but git status metadata has not loaded yet. Consumed in
     /// [`Self::handle_git_repo_status_event`].
-    #[cfg(feature = "local_fs")]
     deferred_code_review_open: Option<DeferredCodeReviewOpen>,
 
     /// A list of callbacks to run on the next [`ModelEvent::AfterBlockCompleted`] received.
@@ -2912,7 +2905,6 @@ pub struct TerminalView {
 /// Parameters stashed when a code review pane open is requested with
 /// [`GitDeltaPreference::OnlyDirty`] but git status metadata is not yet available.
 /// Consumed once the per-repo [`GitRepoStatusModel`] delivers its first update.
-#[cfg(feature = "local_fs")]
 struct DeferredCodeReviewOpen {
     git_delta_preference: GitDeltaPreference,
     focus_new_pane: bool,
@@ -4358,11 +4350,8 @@ impl TerminalView {
             model_events_handle,
             is_todo_popup_visible: false,
             agent_todos_popup,
-            #[cfg(feature = "local_fs")]
             git_repo_status: None,
-            #[cfg(feature = "local_fs")]
             github_repo_model: None,
-            #[cfg(feature = "local_fs")]
             deferred_code_review_open: None,
             block_completed_callbacks: Default::default(),
             conversation_completed_callbacks: Default::default(),
@@ -4949,7 +4938,6 @@ impl TerminalView {
             .is_some()
     }
 
-    #[cfg(feature = "local_fs")]
     fn handle_git_repo_status_event(&mut self, ctx: &mut ViewContext<Self>) {
         if let Some(deferred) = self.deferred_code_review_open.take() {
             self.toggle_code_review_pane(
@@ -4969,7 +4957,6 @@ impl TerminalView {
     /// repo path. Use this when unsubscribing because the subscription is no
     /// longer needed (e.g. the git chip was removed) but the user is still in
     /// the same repository.
-    #[cfg(feature = "local_fs")]
     fn clear_git_repo_status_subscription(&mut self, ctx: &mut ViewContext<Self>) {
         let git_repo_status = self.git_repo_status.take();
         if let Some(handle) = &git_repo_status {
@@ -4987,7 +4974,6 @@ impl TerminalView {
         });
     }
 
-    #[cfg(feature = "local_fs")]
     fn clear_github_repo_model(&mut self, ctx: &mut ViewContext<Self>) {
         let Some(handle) = self.github_repo_model.take() else {
             return;
@@ -5013,7 +4999,6 @@ impl TerminalView {
 
     /// Fully clear the per-repo git status handle, including the input's repo
     /// path. Use this when navigating out of a git repository.
-    #[cfg(feature = "local_fs")]
     fn clear_git_repo_status(&mut self, ctx: &mut ViewContext<Self>) {
         self.clear_git_repo_status_subscription(ctx);
         self.input.update(ctx, |input, ctx| {
@@ -5022,14 +5007,12 @@ impl TerminalView {
     }
 
     /// Helper to read metadata from the per-repo sub-model.
-    #[cfg(feature = "local_fs")]
     fn git_status_metadata<'a>(&'a self, ctx: &'a AppContext) -> Option<&'a GitStatusMetadata> {
         self.git_repo_status
             .as_ref()
             .and_then(|h| h.as_ref(ctx).metadata(ctx))
     }
 
-    #[cfg(feature = "local_fs")]
     fn uses_git_status_chips(chips: Vec<ContextChipKind>) -> bool {
         chips.iter().any(|chip| {
             matches!(
@@ -5040,7 +5023,6 @@ impl TerminalView {
     }
 
     /// Returns whether visible prompt/footer chips need git status updates.
-    #[cfg(feature = "local_fs")]
     fn needs_git_status_for_chip_ui(&self, ctx: &AppContext) -> bool {
         // Agent view: subscribe when the configured agent footer includes
         // git stats or PR info.
@@ -5074,19 +5056,16 @@ impl TerminalView {
         is_using_warp_prompt && Self::uses_git_status_chips(Prompt::as_ref(ctx).chip_kinds())
     }
 
-    #[cfg(feature = "local_fs")]
     fn needs_git_status_for_agent_context(&self, ctx: &AppContext) -> bool {
         self.current_repo_path.is_some() && self.ai_input_model.as_ref(ctx).is_ai_input_enabled()
     }
 
     /// Returns whether this terminal view should subscribe to git status updates.
-    #[cfg(feature = "local_fs")]
     fn should_subscribe_to_git_status(&self, ctx: &AppContext) -> bool {
         self.needs_git_status_for_chip_ui(ctx) || self.needs_git_status_for_agent_context(ctx)
     }
 
     /// Whether the terminal's prompt/footer chips need PR info.
-    #[cfg(feature = "local_fs")]
     fn needs_pr_info_for_chip_ui(&self, ctx: &AppContext) -> bool {
         if self.agent_view_controller.as_ref(ctx).is_active() {
             return SessionSettings::as_ref(ctx)
@@ -5112,18 +5091,15 @@ impl TerminalView {
                     .contains(&ContextChipKind::GithubPullRequest))
     }
 
-    #[cfg(feature = "local_fs")]
     fn needs_pr_info_for_agent_context(&self, ctx: &AppContext) -> bool {
         self.current_repo_path.is_some() && self.ai_input_model.as_ref(ctx).is_ai_input_enabled()
     }
 
     /// Whether this terminal needs PR info from the git status model.
-    #[cfg(feature = "local_fs")]
     fn needs_pr_info(&self, ctx: &AppContext) -> bool {
         self.needs_pr_info_for_chip_ui(ctx) || self.needs_pr_info_for_agent_context(ctx)
     }
 
-    #[cfg(feature = "local_fs")]
     fn should_retry_default_pr_chip_validation(ctx: &AppContext) -> bool {
         let settings = SessionSettings::as_ref(ctx);
         FeatureFlag::GithubPrPromptChip.is_enabled()
@@ -5133,7 +5109,6 @@ impl TerminalView {
 
     /// Re-evaluate whether the terminal needs a PR-info subscription, and
     /// acquire or drop the handle accordingly.
-    #[cfg(feature = "local_fs")]
     fn sync_pr_info_subscription(&mut self, ctx: &mut ViewContext<Self>) {
         let needs_pr_info = self.needs_pr_info(ctx);
         if needs_pr_info && self.github_repo_model.is_none() {
@@ -5175,7 +5150,6 @@ impl TerminalView {
     /// These commands don't touch `.git/` so the filesystem watcher won't
     /// catch them; we refresh explicitly while a PR-info subscription is
     /// active for this terminal.
-    #[cfg(feature = "local_fs")]
     fn refresh_pr_info_after_gh_or_gt_command(&mut self, ctx: &mut ViewContext<Self>) {
         // Ensure we have a subscription to the per-repo status model and the
         // per-repo PR-info model. `should_subscribe_to_git_status` already
@@ -5192,14 +5166,8 @@ impl TerminalView {
         });
     }
 
-    /// No-op when the `local_fs` feature is disabled – git status is not
-    /// available so there is nothing to subscribe to.
-    #[cfg(not(feature = "local_fs"))]
-    fn update_git_status_subscription(&mut self, _ctx: &mut ViewContext<Self>) {}
-
     /// Re-evaluate whether this terminal view should be subscribed to git
     /// status updates and subscribe/unsubscribe accordingly.
-    #[cfg(feature = "local_fs")]
     fn update_git_status_subscription(&mut self, ctx: &mut ViewContext<Self>) {
         let should_subscribe = self.should_subscribe_to_git_status(ctx);
         if !should_subscribe {
@@ -11706,16 +11674,13 @@ impl TerminalView {
 
                                     // Wire up the remote git-status chips when the
                                     // remote repo changed (mirrors the local branch).
-                                    #[cfg(feature = "local_fs")]
-                                    {
-                                        let changed = !matches!(
-                                            old_repo_path.as_ref(),
-                                            Some(LocalOrRemotePath::Remote(rp)) if rp == remote_path
-                                        );
-                                        if changed {
-                                            me.clear_git_repo_status_subscription(ctx);
-                                            me.update_git_status_subscription(ctx);
-                                        }
+                                    let changed = !matches!(
+                                        old_repo_path.as_ref(),
+                                        Some(LocalOrRemotePath::Remote(rp)) if rp == remote_path
+                                    );
+                                    if changed {
+                                        me.clear_git_repo_status_subscription(ctx);
+                                        me.update_git_status_subscription(ctx);
                                     }
                                 }
                                 Some(LocalOrRemotePath::Local(repo_path)) => {
@@ -11786,7 +11751,6 @@ impl TerminalView {
                                     let _ = repo_path;
                                 }
                                 None => {
-                                    #[cfg(feature = "local_fs")]
                                     me.clear_git_repo_status(ctx);
                                     ctx.notify();
                                 }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4740,8 +4740,12 @@ impl TerminalView {
                     | RemoteServerManagerEvent::GitPushResponse { .. }
                     | RemoteServerManagerEvent::CreatePrResponse { .. }
                     | RemoteServerManagerEvent::GenerateCommitMessageResponse { .. }
-                    | RemoteServerManagerEvent::GetPrInfoResponse { .. }
-                    | RemoteServerManagerEvent::GetCommittedBranchFilesResponse { .. } => {}
+                    | RemoteServerManagerEvent::GetCommittedBranchFilesResponse { .. }
+                    | RemoteServerManagerEvent::GetGitHubPrInfoResponse { .. }
+                    | RemoteServerManagerEvent::GetGitHubRepoInfoResponse { .. }
+                    | RemoteServerManagerEvent::GitStatusPushReceived { .. }
+                    | RemoteServerManagerEvent::GitHubPrInfoPushReceived { .. }
+                    | RemoteServerManagerEvent::GitHubRepositoryInfoPushReceived { .. } => {}
                 }
             });
         }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5224,37 +5224,31 @@ impl TerminalView {
         let result =
             GitRepoModels::handle(ctx).update(ctx, |model, ctx| model.subscribe(&repo, ctx));
         match result {
-            Ok(handle) => self.wire_git_repo_status_handle(handle, ctx),
+            Ok(handle) => {
+                // Wire the freshly-obtained per-repo `GitRepoStatusModel` handle
+                // (local or remote) into this view: subscribe for events, feed
+                // the prompt, store the handle, and sync the PR-info consumer slot.
+                ctx.subscribe_to_model(&handle, |me, _, _, ctx| {
+                    me.handle_git_repo_status_event(ctx);
+                });
+                let weak_for_prompt = handle.downgrade();
+                self.git_repo_status = Some(handle);
+                self.current_prompt.update(ctx, |prompt_type, ctx| {
+                    if let PromptType::Dynamic { prompt } = prompt_type {
+                        prompt.update(ctx, |current_prompt, ctx| {
+                            current_prompt.set_git_repo_status(Some(weak_for_prompt), ctx);
+                        });
+                    }
+                });
+                // Acquire a GitHub-info handle if the terminal's prompt/footer
+                // chips or agent context need PR or repository info. The AI
+                // context model reads PR / repository info from that GitHub-info
+                // handle, so it is wired up by `sync_pr_info_subscription` rather
+                // than here.
+                self.sync_pr_info_subscription(ctx);
+            }
             Err(err) => log::warn!("GitRepoModels subscribe failed: {err}"),
         }
-    }
-
-    /// Wires a freshly-obtained per-repo `GitRepoStatusModel` handle (local or
-    /// remote) into this view: subscribes for events, feeds the prompt and AI
-    /// context models, stores the handle, and syncs the PR-info consumer slot.
-    #[cfg(feature = "local_fs")]
-    fn wire_git_repo_status_handle(
-        &mut self,
-        handle: ModelHandle<GitRepoStatusModel>,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        ctx.subscribe_to_model(&handle, |me, _, _, ctx| {
-            me.handle_git_repo_status_event(ctx);
-        });
-        let weak_for_prompt = handle.downgrade();
-        self.git_repo_status = Some(handle);
-        self.current_prompt.update(ctx, |prompt_type, ctx| {
-            if let PromptType::Dynamic { prompt } = prompt_type {
-                prompt.update(ctx, |current_prompt, ctx| {
-                    current_prompt.set_git_repo_status(Some(weak_for_prompt), ctx);
-                });
-            }
-        });
-        // Acquire a GitHub-info handle if the terminal's prompt/footer chips or
-        // agent context need PR or repository info. The AI context model reads
-        // PR / repository info from that GitHub-info handle, so it is wired up
-        // by `sync_pr_info_subscription` rather than here.
-        self.sync_pr_info_subscription(ctx);
     }
 
     fn handle_ai_controller_event(

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -321,9 +321,7 @@ use crate::code_review::context::{
 use crate::code_review::diff_state::LocalDiffStateModel;
 use crate::code_review::diff_state::{DiffMode, GitDeltaPreference};
 #[cfg(feature = "local_fs")]
-use crate::code_review::git_status_update::{
-    GitRepoStatusModel, GitStatusMetadata, GitStatusUpdateModel,
-};
+use crate::code_review::git_repo_model::{GitRepoModels, GitRepoStatusModel, GitStatusMetadata};
 #[cfg(feature = "local_fs")]
 use crate::code_review::github_repo_model::GitHubRepoModel;
 use crate::code_review::telemetry_event::CodeReviewPaneEntrypoint;

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5022,7 +5022,7 @@ impl TerminalView {
     fn git_status_metadata<'a>(&'a self, ctx: &'a AppContext) -> Option<&'a GitStatusMetadata> {
         self.git_repo_status
             .as_ref()
-            .and_then(|h| h.as_ref(ctx).metadata())
+            .and_then(|h| h.as_ref(ctx).metadata(ctx))
     }
 
     #[cfg(feature = "local_fs")]
@@ -5072,8 +5072,7 @@ impl TerminalView {
 
     #[cfg(feature = "local_fs")]
     fn needs_git_status_for_agent_context(&self, ctx: &AppContext) -> bool {
-        self.current_local_repo_path().is_some()
-            && self.ai_input_model.as_ref(ctx).is_ai_input_enabled()
+        self.current_repo_path.is_some() && self.ai_input_model.as_ref(ctx).is_ai_input_enabled()
     }
 
     /// Returns whether this terminal view should subscribe to git status updates.
@@ -5111,8 +5110,7 @@ impl TerminalView {
 
     #[cfg(feature = "local_fs")]
     fn needs_pr_info_for_agent_context(&self, ctx: &AppContext) -> bool {
-        self.current_local_repo_path().is_some()
-            && self.ai_input_model.as_ref(ctx).is_ai_input_enabled()
+        self.current_repo_path.is_some() && self.ai_input_model.as_ref(ctx).is_ai_input_enabled()
     }
 
     /// Whether this terminal needs PR info from the git status model.
@@ -5135,12 +5133,14 @@ impl TerminalView {
     fn sync_pr_info_subscription(&mut self, ctx: &mut ViewContext<Self>) {
         let needs_pr_info = self.needs_pr_info(ctx);
         if needs_pr_info && self.github_repo_model.is_none() {
-            let Some(repo_path) = self.current_local_repo_path().map(Path::to_path_buf) else {
+            // Acquire a GitHub-info handle for the current repo. The factory
+            // dispatches on the `LocalOrRemotePath` to a local `gh`-driven model
+            // or a remote push receiver, both wired up identically.
+            let Some(repo) = self.current_repo_path.clone() else {
                 return;
             };
-            let result = GitStatusUpdateModel::handle(ctx).update(ctx, |model, ctx| {
-                model.subscribe_github_repo(&repo_path, ctx)
-            });
+            let result = GitRepoModels::handle(ctx)
+                .update(ctx, |model, ctx| model.subscribe_github_repo(&repo, ctx));
             match result {
                 Ok(handle) => {
                     let weak_for_prompt = handle.downgrade();
@@ -5198,40 +5198,59 @@ impl TerminalView {
     #[cfg(feature = "local_fs")]
     fn update_git_status_subscription(&mut self, ctx: &mut ViewContext<Self>) {
         let should_subscribe = self.should_subscribe_to_git_status(ctx);
-        if should_subscribe {
-            // Subscribe if we have a repo path but no active subscription.
+        if !should_subscribe {
             if self.git_repo_status.is_some() {
-                self.sync_pr_info_subscription(ctx);
-            } else if let Some(repo_path) = self.current_local_repo_path().map(Path::to_path_buf) {
-                let result = GitStatusUpdateModel::handle(ctx)
-                    .update(ctx, |model, ctx| model.subscribe(&repo_path, ctx));
-                match result {
-                    Ok(handle) => {
-                        ctx.subscribe_to_model(&handle, |me, _, _, ctx| {
-                            me.handle_git_repo_status_event(ctx);
-                        });
-                        let weak_for_prompt = handle.downgrade();
-                        self.git_repo_status = Some(handle);
-                        self.current_prompt.update(ctx, |prompt_type, ctx| {
-                            if let PromptType::Dynamic { prompt } = prompt_type {
-                                prompt.update(ctx, |current_prompt, ctx| {
-                                    current_prompt.set_git_repo_status(Some(weak_for_prompt), ctx);
-                                });
-                            }
-                        });
-                        // Acquire a GitHub-info handle if the terminal's
-                        // prompt/footer chips or agent context need PR or
-                        // repository info.
-                        self.sync_pr_info_subscription(ctx);
-                    }
-                    Err(err) => {
-                        log::warn!("GitStatusUpdateModel subscribe failed: {err}");
-                    }
-                }
+                self.clear_git_repo_status_subscription(ctx);
             }
-        } else if self.git_repo_status.is_some() {
-            self.clear_git_repo_status_subscription(ctx);
+            return;
         }
+
+        // Already subscribed — keep the PR-info (GitHub) subscription in sync.
+        if self.git_repo_status.is_some() {
+            self.sync_pr_info_subscription(ctx);
+            return;
+        }
+
+        // No active subscription: create one for the current repo. The factory
+        // dispatches on the `LocalOrRemotePath` to a local watcher-backed model
+        // or a remote push receiver, both wired up identically.
+        let Some(repo) = self.current_repo_path.clone() else {
+            return;
+        };
+        let result =
+            GitRepoModels::handle(ctx).update(ctx, |model, ctx| model.subscribe(&repo, ctx));
+        match result {
+            Ok(handle) => self.wire_git_repo_status_handle(handle, ctx),
+            Err(err) => log::warn!("GitRepoModels subscribe failed: {err}"),
+        }
+    }
+
+    /// Wires a freshly-obtained per-repo `GitRepoStatusModel` handle (local or
+    /// remote) into this view: subscribes for events, feeds the prompt and AI
+    /// context models, stores the handle, and syncs the PR-info consumer slot.
+    #[cfg(feature = "local_fs")]
+    fn wire_git_repo_status_handle(
+        &mut self,
+        handle: ModelHandle<GitRepoStatusModel>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        ctx.subscribe_to_model(&handle, |me, _, _, ctx| {
+            me.handle_git_repo_status_event(ctx);
+        });
+        let weak_for_prompt = handle.downgrade();
+        self.git_repo_status = Some(handle);
+        self.current_prompt.update(ctx, |prompt_type, ctx| {
+            if let PromptType::Dynamic { prompt } = prompt_type {
+                prompt.update(ctx, |current_prompt, ctx| {
+                    current_prompt.set_git_repo_status(Some(weak_for_prompt), ctx);
+                });
+            }
+        });
+        // Acquire a GitHub-info handle if the terminal's prompt/footer chips or
+        // agent context need PR or repository info. The AI context model reads
+        // PR / repository info from that GitHub-info handle, so it is wired up
+        // by `sync_pr_info_subscription` rather than here.
+        self.sync_pr_info_subscription(ctx);
     }
 
     fn handle_ai_controller_event(
@@ -11686,6 +11705,20 @@ impl TerminalView {
                                     ctx.emit(Event::Pane(PaneEvent::RemoteRepoNavigated {
                                         remote_path: remote_path.clone(),
                                     }));
+
+                                    // Wire up the remote git-status chips when the
+                                    // remote repo changed (mirrors the local branch).
+                                    #[cfg(feature = "local_fs")]
+                                    {
+                                        let changed = !matches!(
+                                            old_repo_path.as_ref(),
+                                            Some(LocalOrRemotePath::Remote(rp)) if rp == remote_path
+                                        );
+                                        if changed {
+                                            me.clear_git_repo_status_subscription(ctx);
+                                            me.update_git_status_subscription(ctx);
+                                        }
+                                    }
                                 }
                                 Some(LocalOrRemotePath::Local(repo_path)) => {
                                     #[cfg(feature = "local_fs")]

--- a/app/src/terminal/view/tab_metadata.rs
+++ b/app/src/terminal/view/tab_metadata.rs
@@ -33,20 +33,12 @@ impl TerminalView {
             .unwrap_or(fallback_title)
     }
 
-    #[cfg_attr(not(feature = "local_fs"), allow(clippy::unnecessary_lazy_evaluations))]
     pub fn current_git_branch(&self, ctx: &AppContext) -> Option<String> {
         self.prompt_chip_value(&ContextChipKind::ShellGitBranch, ctx)
             .or_else(|| {
-                #[cfg(feature = "local_fs")]
-                {
-                    self.git_status_metadata(ctx)
-                        .map(|metadata| metadata.current_branch_name.clone())
-                        .filter(|branch| !branch.trim().is_empty())
-                }
-                #[cfg(not(feature = "local_fs"))]
-                {
-                    None
-                }
+                self.git_status_metadata(ctx)
+                    .map(|metadata| metadata.current_branch_name.clone())
+                    .filter(|branch| !branch.trim().is_empty())
             })
     }
 
@@ -85,18 +77,14 @@ impl TerminalView {
             .filter(|value| !value.trim().is_empty())
     }
 
-    #[cfg_attr(not(feature = "local_fs"), allow(clippy::unnecessary_lazy_evaluations))]
     pub fn current_diff_line_changes(&self, ctx: &AppContext) -> Option<GitLineChanges> {
-        // Prefer the filesystem-event-based GitRepoStatusModel (which includes
-        // untracked files) over parsing the raw shell chip output. This matches
-        // the preference order used by the prompt chip display (display.rs) and
-        // agent footer (chips.rs).
-        #[cfg(feature = "local_fs")]
+        // Prefer the externally-updated GitRepoStatusModel (local filesystem
+        // watcher or remote daemon push receiver) over parsing the raw shell
+        // chip output. This matches the preference order used by the prompt
+        // chip display (display.rs) and agent footer (chips.rs).
         let from_model = self
             .git_status_metadata(ctx)
             .map(|metadata| GitLineChanges::from_diff_stats(&metadata.stats_against_head));
-        #[cfg(not(feature = "local_fs"))]
-        let from_model: Option<GitLineChanges> = None;
 
         from_model
             .or_else(|| {

--- a/app/src/terminal/writeable_pty/remote_server_controller.rs
+++ b/app/src/terminal/writeable_pty/remote_server_controller.rs
@@ -158,8 +158,12 @@ impl<T: EventLoopSender> RemoteServerController<T> {
             | RemoteServerManagerEvent::GitPushResponse { .. }
             | RemoteServerManagerEvent::CreatePrResponse { .. }
             | RemoteServerManagerEvent::GenerateCommitMessageResponse { .. }
-            | RemoteServerManagerEvent::GetPrInfoResponse { .. }
-            | RemoteServerManagerEvent::GetCommittedBranchFilesResponse { .. } => {}
+            | RemoteServerManagerEvent::GetCommittedBranchFilesResponse { .. }
+            | RemoteServerManagerEvent::GetGitHubPrInfoResponse { .. }
+            | RemoteServerManagerEvent::GetGitHubRepoInfoResponse { .. }
+            | RemoteServerManagerEvent::GitStatusPushReceived { .. }
+            | RemoteServerManagerEvent::GitHubPrInfoPushReceived { .. }
+            | RemoteServerManagerEvent::GitHubRepositoryInfoPushReceived { .. } => {}
         });
 
         Self {

--- a/app/src/test_util/terminal.rs
+++ b/app/src/test_util/terminal.rs
@@ -38,7 +38,7 @@ use crate::auth::auth_manager::AuthManager;
 use crate::auth::AuthStateProvider;
 use crate::changelog_model::ChangelogModel;
 use crate::cloud_object::model::persistence::CloudModel;
-use crate::code_review::git_status_update::GitStatusUpdateModel;
+use crate::code_review::git_repo_model::GitRepoModels;
 use crate::context_chips::prompt::Prompt;
 use crate::network::NetworkStatus;
 use crate::pricing::PricingInfoModel;
@@ -147,7 +147,7 @@ pub fn initialize_app_for_terminal_view(app: &mut App) {
         model
     });
     app.add_singleton_model(FileSearchModel::new);
-    app.add_singleton_model(|_| GitStatusUpdateModel::new());
+    app.add_singleton_model(|_| GitRepoModels::new());
     app.add_singleton_model(RepoOutlines::new_for_test);
     app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
     app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);

--- a/app/src/util/git.rs
+++ b/app/src/util/git.rs
@@ -763,21 +763,38 @@ fn repository_info_from_gh_output(output: &str) -> Result<RepositoryInfo> {
 pub async fn get_repository_info(
     repo_path: &Path,
     path_env: Option<&str>,
-) -> Result<RepositoryInfo> {
-    let stdout = run_gh_command(
+) -> Result<Option<RepositoryInfo>> {
+    if run_git_command(repo_path, &["rev-parse", "--is-inside-work-tree"])
+        .await
+        .is_err()
+    {
+        return Ok(None);
+    }
+
+    match run_gh_command(
         repo_path,
         &["repo", "view", "--json", "name,owner"],
         path_env,
     )
-    .await?;
-    repository_info_from_gh_output(&stdout)
+    .await
+    {
+        Ok(stdout) => repository_info_from_gh_output(&stdout).map(Some),
+        Err(e) => {
+            let msg = e.to_string();
+            if is_repository_lookup_not_applicable_error(&msg) {
+                Ok(None)
+            } else {
+                Err(e)
+            }
+        }
+    }
 }
 
 #[cfg(not(feature = "local_fs"))]
 pub async fn get_repository_info(
     _repo_path: &Path,
     _path_env: Option<&str>,
-) -> Result<RepositoryInfo> {
+) -> Result<Option<RepositoryInfo>> {
     Err(anyhow!("Not supported without local_fs"))
 }
 
@@ -914,6 +931,19 @@ fn is_pr_lookup_not_applicable_error(error_msg: &str) -> bool {
             "none of the git remotes configured for this repository point to a known github host",
         )
         || lower.contains("no github remotes")
+        || lower.contains("not a github repository")
+        || lower.contains("could not determine base repo")
+}
+
+/// Classifies `gh repo view` failures that authoritatively mean the current
+/// repository has no GitHub repository info, rather than a transient fetch
+/// failure.
+#[cfg(feature = "local_fs")]
+fn is_repository_lookup_not_applicable_error(error_msg: &str) -> bool {
+    let lower = error_msg.to_lowercase();
+    lower.contains(
+        "none of the git remotes configured for this repository point to a known github host",
+    ) || lower.contains("no github remotes")
         || lower.contains("not a github repository")
         || lower.contains("could not determine base repo")
 }

--- a/app/src/util/git_tests.rs
+++ b/app/src/util/git_tests.rs
@@ -37,6 +37,38 @@ fn repository_info_from_gh_output_parses_name_and_owner() {
     );
 }
 
+#[cfg(all(feature = "local_fs", unix))]
+#[tokio::test]
+async fn get_repository_info_returns_none_when_gh_cannot_resolve_github_repo() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    let (_dir, repo) = init_repo().await;
+
+    let fake_bin = tempfile::tempdir().expect("failed to create fake bin dir");
+    let gh_path = fake_bin.path().join("gh");
+    fs::write(
+        &gh_path,
+        "#!/bin/sh\nprintf 'none of the git remotes configured for this repository point to a known GitHub host\\n' >&2\nexit 1\n",
+    )
+    .expect("failed to write fake gh");
+    let mut permissions = fs::metadata(&gh_path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&gh_path, permissions).unwrap();
+
+    let path_env = format!(
+        "{}:{}",
+        fake_bin.path().display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    assert_eq!(
+        super::get_repository_info(&repo, Some(&path_env))
+            .await
+            .unwrap(),
+        None
+    );
+}
+
 #[cfg(feature = "local_fs")]
 #[test]
 fn repository_info_from_gh_output_rejects_missing_name() {
@@ -111,10 +143,10 @@ async fn get_repository_info_reads_gh_repo_view() {
         super::get_repository_info(&repo, Some(&path_env))
             .await
             .unwrap(),
-        RepositoryInfo {
+        Some(RepositoryInfo {
             name: "warp-internal".to_owned(),
             owner: Some("warpdotdev".to_owned()),
-        }
+        })
     );
 }
 
@@ -149,6 +181,26 @@ fn detects_no_pr_for_branch_errors() {
     ));
     assert!(!super::is_no_pr_for_branch_error("authentication required"));
     assert!(!super::is_no_pr_for_branch_error("repository not found"));
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
+fn detects_repository_lookup_not_applicable_errors() {
+    assert!(super::is_repository_lookup_not_applicable_error(
+        "gh command failed: none of the git remotes configured for this repository point to a known GitHub host"
+    ));
+    assert!(super::is_repository_lookup_not_applicable_error(
+        "gh command failed: no GitHub remotes"
+    ));
+    assert!(super::is_repository_lookup_not_applicable_error(
+        "gh command failed: not a GitHub repository"
+    ));
+    assert!(!super::is_repository_lookup_not_applicable_error(
+        "authentication required"
+    ));
+    assert!(!super::is_repository_lookup_not_applicable_error(
+        "repository not found"
+    ));
 }
 
 #[tokio::test]

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -191,7 +191,7 @@ pub(crate) fn initialize_app(app: &mut App) {
     app.add_singleton_model(|ctx| ServerExperiments::new_from_cache(vec![], ctx));
     app.add_singleton_model(DefaultTerminal::new);
     app.add_singleton_model(|_| IgnoredSuggestionsModel::new(vec![]));
-    app.add_singleton_model(|_| crate::code_review::git_status_update::GitStatusUpdateModel::new());
+    app.add_singleton_model(|_| crate::code_review::git_repo_model::GitRepoModels::new());
     app.add_singleton_model(remote_server::manager::RemoteServerManager::new);
     #[cfg(not(target_family = "wasm"))]
     app.add_singleton_model(RemoteCodebaseIndexModel::new);

--- a/crates/remote_server/proto/diff_state.proto
+++ b/crates/remote_server/proto/diff_state.proto
@@ -186,7 +186,6 @@ message DiffMetadata {
   bool has_head_commit = 5;
   repeated Commit unpushed_commits = 6;
   optional string upstream_ref = 7;
-  optional PrInfo pr_info = 8;
 }
 
 // Mirrors FileStatusInfo in Rust. Identifies a file and its git status
@@ -317,7 +316,7 @@ message GetBranchesError {
   string message = 1;
 }
 
-// ── Git operations (commit / push / create-PR / PR info) ──────────
+// ── Git operations (commit / push / create-PR) ────────────────────
 // Run git / gh on the remote filesystem. These mirror the local code
 // review git dialog operations in app/src/code_review/git_dialog/*.
 
@@ -406,24 +405,6 @@ message GitCreatePrResponse {
   }
 }
 
-// Client → server: look up the PR for the current branch (`gh pr view`).
-// This is the remote PR get/view command; it does not depend on a remote
-// git-status model.
-message GitGetPrInfoRequest {
-  string repo_path = 1;
-}
-
-message GitGetPrInfoResponse {
-  oneof result {
-    GitGetPrInfoSuccess success = 1;
-    GitOpError error = 2;
-  }
-}
-
-// `pr_info` absent => there is no open PR for the current branch.
-message GitGetPrInfoSuccess {
-  optional PrInfo pr_info = 1;
-}
 
 // Client → server: list the committed file changes for the current branch's
 // PR-ready diff (merge_base(HEAD, main)..HEAD). Backs the Create PR dialog's

--- a/crates/remote_server/proto/diff_state.proto
+++ b/crates/remote_server/proto/diff_state.proto
@@ -464,3 +464,67 @@ message GitGenerateCommitMessageResponse {
     GitOpError error = 2;
   }
 }
+
+// ── Git and GitHub info ──────────────────────────────────────────────────
+
+// Mirrors RepositoryInfo in Rust (util/git.rs). Returned by `gh repo view`.
+message RepositoryInfo {
+  string name = 1;
+  optional string owner = 2;
+}
+
+// Mirrors GitStatusMetadata in Rust (code_review/git_repo_model/mod.rs).
+message GitStatusMetadata {
+  string current_branch_name = 1;
+  string main_branch_name = 2;
+  DiffStats stats_against_head = 3;
+}
+
+// Server -> client push: aggregate git status for a repo. Sent on every
+// watcher tick, opportunistically after navigation resolves a git root, and
+// when a client requests a current snapshot.
+message GitStatusPush {
+  string repo_path = 1;
+  GitStatusMetadata metadata = 2;
+}
+
+// Client -> server notification: ask the daemon to create the per-repo git
+// status model if needed and push the current GitStatusPush snapshot when
+// available. Fire-and-forget; no response is sent.
+message UpdateGitStatus {
+  string repo_path = 1;
+}
+
+// Server -> client push: PR info for a repo's current branch. Sent when the
+// daemon's `GitHubRepoModel` recomputes PR info.
+message GitHubPrInfoPush {
+  string repo_path = 1;
+  optional PrInfo pr_info = 2;
+}
+// Server -> client push: repository name/owner info for a repo. Sent when the
+// daemon's `GitHubRepoModel` recomputes repository info.
+message GitHubRepositoryInfoPush {
+  string repo_path = 1;
+  optional RepositoryInfo repository_info = 2;
+}
+// Client -> server request: ask the daemon to create the per-repo
+// GitHubRepoModel if needed and refresh PR info for the current branch.
+message GetGitHubPrInfoRequest {
+  string repo_path = 1;
+}
+// Server -> client response for GetGitHubPrInfoRequest. `pr_info = None`
+// means the lookup completed and the current branch has no PR.
+message GetGitHubPrInfoResponse {
+  optional PrInfo pr_info = 1;
+  GitOpError error = 2;
+}
+// Client -> server request: ask the daemon to create the per-repo
+// GitHubRepoModel if needed and refresh repository name/owner.
+message GetGitHubRepoInfoRequest {
+  string repo_path = 1;
+}
+// Server -> client response for GetGitHubRepoInfoRequest.
+message GetGitHubRepoInfoResponse {
+  optional RepositoryInfo repository_info = 1;
+  GitOpError error = 2;
+}

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -29,7 +29,8 @@ message HostScopedRequest {
   // 4 (open_buffer) and 7 (get_diff_state) moved to SessionScopedRequest:
   // they establish per-connection subscription state, so they must be
   // delivered on (and answered by) a specific connection, never failed over.
-  reserved 4, 7;
+  // 18 (git_get_pr_info) was removed in favor of GitHub-specific requests.
+  reserved 4, 7, 18;
   oneof message {
     WriteFile write_file = 1;
     DeleteFile delete_file = 2;
@@ -46,9 +47,10 @@ message HostScopedRequest {
     GitCommitChainRequest git_commit_chain = 15;
     GitPushRequest git_push = 16;
     GitCreatePrRequest git_create_pr = 17;
-    GitGetPrInfoRequest git_get_pr_info = 18;
     GitGenerateCommitMessageRequest git_generate_commit_message = 19;
     GitGetCommittedBranchFilesRequest git_get_committed_branch_files = 20;
+    GetGitHubPrInfoRequest get_github_pr_info = 21;
+    GetGitHubRepoInfoRequest get_github_repository_info = 22;
   }
 }
 
@@ -79,6 +81,7 @@ message Notification {
     BufferEdit buffer_edit = 5;
     CloseBuffer close_buffer = 6;
     UnsubscribeDiffState unsubscribe_diff_state = 7;
+    UpdateGitStatus update_git_status = 8;
   }
 }
 // Top-level envelope for all server → client messages.
@@ -115,9 +118,13 @@ message ServerMessage {
     GitCommitChainResponse git_commit_chain_response = 27;
     GitPushResponse git_push_response = 28;
     GitCreatePrResponse git_create_pr_response = 29;
-    GitGetPrInfoResponse git_get_pr_info_response = 30;
     GitGenerateCommitMessageResponse git_generate_commit_message_response = 31;
     GitGetCommittedBranchFilesResponse git_get_committed_branch_files_response = 32;
+    GitStatusPush git_status_push = 33;
+    GitHubPrInfoPush github_pr_info_push = 35;
+    GetGitHubPrInfoResponse get_github_pr_info_response = 36;
+    GetGitHubRepoInfoResponse get_github_repo_info_response = 37;
+    GitHubRepositoryInfoPush github_repository_info_push = 38;
   }
 }
 

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -16,9 +16,10 @@ use crate::codebase_index_proto::{
 use crate::proto::{
     notification, server_message, session_scoped_request, Abort, Authenticate, BufferEdit,
     ClientMessage, CloseBuffer, CodebaseIndexLimits, DiffMode, DiffStateFileDelta,
-    DiffStateMetadataUpdate, DiffStateSnapshot, ErrorCode, Initialize, InitializeResponse,
-    LoadRepoMetadataDirectoryResponse, NavigatedToDirectoryResponse, RunCommandRequest,
-    RunCommandResponse, ServerMessage, SessionBootstrapped, TextEdit, UnsubscribeDiffState,
+    DiffStateMetadataUpdate, DiffStateSnapshot, ErrorCode, GitStatusMetadata, Initialize,
+    InitializeResponse, LoadRepoMetadataDirectoryResponse, NavigatedToDirectoryResponse, PrInfo,
+    RepositoryInfo, RunCommandRequest, RunCommandResponse, ServerMessage, SessionBootstrapped,
+    TextEdit, UnsubscribeDiffState, UpdateGitStatus,
 };
 use crate::repo_metadata_proto::{proto_snapshot_to_update, proto_to_repo_metadata_update};
 
@@ -124,6 +125,22 @@ pub enum ClientEvent {
         repo_path: StandardizedPath,
         mode: DiffMode,
         delta: DiffStateFileDelta,
+    },
+    /// An aggregate git status push (branch + diff stats) was pushed by the
+    /// server for the tab / prompt chips.
+    GitStatusPushReceived {
+        repo_path: StandardizedPath,
+        metadata: GitStatusMetadata,
+    },
+    /// PR info for the current branch was pushed by the server for the PR chip.
+    GitHubPrInfoPushReceived {
+        repo_path: StandardizedPath,
+        pr_info: Option<PrInfo>,
+    },
+    /// Repository name/owner info was pushed by the server for repository chips.
+    GitHubRepositoryInfoPushReceived {
+        repo_path: StandardizedPath,
+        repository_info: Option<RepositoryInfo>,
     },
 }
 
@@ -668,6 +685,46 @@ impl RemoteServerClient {
                     delta,
                 })
             }
+            server_message::Message::GitStatusPush(push) => {
+                let Some(repo_path) = StandardizedPath::try_new(&push.repo_path).ok() else {
+                    log::warn!("GitStatusPush: invalid repo_path: {}", push.repo_path);
+                    return None;
+                };
+                let Some(metadata) = push.metadata else {
+                    log::warn!(
+                        "GitStatusPush: missing metadata for repo_path: {}",
+                        push.repo_path
+                    );
+                    return None;
+                };
+                Some(ClientEvent::GitStatusPushReceived {
+                    repo_path,
+                    metadata,
+                })
+            }
+            server_message::Message::GithubPrInfoPush(push) => {
+                let Some(repo_path) = StandardizedPath::try_new(&push.repo_path).ok() else {
+                    log::warn!("GitHubPrInfoPush: invalid repo_path: {}", push.repo_path);
+                    return None;
+                };
+                Some(ClientEvent::GitHubPrInfoPushReceived {
+                    repo_path,
+                    pr_info: push.pr_info,
+                })
+            }
+            server_message::Message::GithubRepositoryInfoPush(push) => {
+                let Some(repo_path) = StandardizedPath::try_new(&push.repo_path).ok() else {
+                    log::warn!(
+                        "GitHubRepositoryInfoPush: invalid repo_path: {}",
+                        push.repo_path
+                    );
+                    return None;
+                };
+                Some(ClientEvent::GitHubRepositoryInfoPushReceived {
+                    repo_path,
+                    repository_info: push.repository_info,
+                })
+            }
             other => {
                 safe_warn!(
                     safe: ("Unhandled push message variant"),
@@ -689,7 +746,16 @@ impl RemoteServerClient {
         self.send_notification(msg);
     }
 
-    /// Sends a `RunCommand` request
+    /// Sends an `UpdateGitStatus` notification (fire-and-forget).
+    pub fn update_git_status(&self, repo_path: &StandardizedPath) {
+        let msg =
+            ClientMessage::notification(notification::Message::UpdateGitStatus(UpdateGitStatus {
+                repo_path: repo_path.to_string(),
+            }));
+        self.send_notification(msg);
+    }
+
+    /// Sends a `RunCommand` request.
     pub async fn run_command(
         &self,
         session_id: SessionId,

--- a/crates/remote_server/src/host_response_tests.rs
+++ b/crates/remote_server/src/host_response_tests.rs
@@ -164,9 +164,10 @@ fn every_host_scoped_request_has_a_response_disposition() {
             M::GitCommitChain(_) => "manager::commit_chain",
             M::GitPush(_) => "manager::push",
             M::GitCreatePr(_) => "manager::create_pr",
-            M::GitGetPrInfo(_) => "manager::get_pr_info",
             M::GitGenerateCommitMessage(_) => "manager::generate_commit_message",
             M::GitGetCommittedBranchFiles(_) => "manager::get_committed_branch_files",
+            M::GetGithubPrInfo(_) => "manager::get_github_pr_info",
+            M::GetGithubRepositoryInfo(_) => "manager::get_github_repo_info",
         }
     }
 

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -28,7 +28,7 @@ use crate::codebase_index_proto::RemoteCodebaseIndexStatus;
 use crate::proto::{
     diff_state, get_diff_state_response, CodebaseIndexLimits, DiffMode, DiffState,
     DiffStateErrorValue, DiffStateFileDelta, DiffStateMetadataUpdate, DiffStateSnapshot,
-    FileStatusInfo, GetDiffStateResponse, GitOpDelta, TextEdit,
+    FileStatusInfo, GetDiffStateResponse, GitOpDelta, GitStatusMetadata, RepositoryInfo, TextEdit,
 };
 use crate::repo_metadata_proto::proto_load_repo_metadata_directory_response_to_update;
 #[cfg(not(target_family = "wasm"))]
@@ -284,6 +284,9 @@ fn client_event_kind(event: &ClientEvent) -> &'static str {
         ClientEvent::DiffStateSnapshotReceived { .. } => "diff_state_snapshot",
         ClientEvent::DiffStateMetadataUpdateReceived { .. } => "diff_state_metadata_update",
         ClientEvent::DiffStateFileDeltaReceived { .. } => "diff_state_file_delta",
+        ClientEvent::GitStatusPushReceived { .. } => "git_status_push",
+        ClientEvent::GitHubPrInfoPushReceived { .. } => "github_pr_info_push",
+        ClientEvent::GitHubRepositoryInfoPushReceived { .. } => "github_repository_info_push",
         ClientEvent::MessageDecodingError => "message_decoding_error",
     }
 }
@@ -582,6 +585,43 @@ pub enum RemoteServerManagerEvent {
         result: Result<Vec<crate::proto::FileChangeEntry>, String>,
     },
 
+    // --- Git status events (forwarded from ClientEvent push channel) ---
+    /// Response to a PR-info refresh request. `Ok(None)` means the lookup
+    /// completed and the current branch has no PR.
+    GetGitHubPrInfoResponse {
+        host_id: HostId,
+        repo_path: StandardizedPath,
+        result: Result<Option<crate::proto::PrInfo>, String>,
+    },
+    /// Response to a repository-info refresh request.
+    GetGitHubRepoInfoResponse {
+        host_id: HostId,
+        repo_path: StandardizedPath,
+        result: Result<Option<crate::proto::RepositoryInfo>, String>,
+    },
+    /// An aggregate git status push (branch + diff stats) was pushed by the
+    /// server. Consumed by `RemoteGitRepoStatusModel` to drive the tab /
+    /// prompt chips for remote repositories.
+    GitStatusPushReceived {
+        host_id: HostId,
+        repo_path: StandardizedPath,
+        metadata: GitStatusMetadata,
+    },
+    /// PR info for the current branch was pushed by the server. Consumed by
+    /// `RemoteGitHubRepoModel` to drive PR chips for remote repositories.
+    GitHubPrInfoPushReceived {
+        host_id: HostId,
+        repo_path: StandardizedPath,
+        pr_info: Option<crate::proto::PrInfo>,
+    },
+    /// Repository name/owner info was pushed by the server. Consumed by
+    /// `RemoteGitHubRepoModel` to drive repository chips for remote repositories.
+    GitHubRepositoryInfoPushReceived {
+        host_id: HostId,
+        repo_path: StandardizedPath,
+        repository_info: Option<RepositoryInfo>,
+    },
+
     // --- Setup events ---
     /// Intermediate state change during the binary check/install flow.
     SetupStateChanged {
@@ -679,8 +719,12 @@ impl RemoteServerManagerEvent {
             | RemoteServerManagerEvent::GitPushResponse { .. }
             | RemoteServerManagerEvent::CreatePrResponse { .. }
             | RemoteServerManagerEvent::GenerateCommitMessageResponse { .. }
-            | RemoteServerManagerEvent::GetPrInfoResponse { .. }
-            | RemoteServerManagerEvent::GetCommittedBranchFilesResponse { .. } => None,
+            | RemoteServerManagerEvent::GetCommittedBranchFilesResponse { .. }
+            | RemoteServerManagerEvent::GetGitHubPrInfoResponse { .. }
+            | RemoteServerManagerEvent::GetGitHubRepoInfoResponse { .. }
+            | RemoteServerManagerEvent::GitStatusPushReceived { .. }
+            | RemoteServerManagerEvent::GitHubPrInfoPushReceived { .. }
+            | RemoteServerManagerEvent::GitHubRepositoryInfoPushReceived { .. } => None,
             RemoteServerManagerEvent::CodebaseIndexStatusUpdated {
                 session_id: Some(session_id),
                 ..
@@ -1150,6 +1194,63 @@ impl HostRequestHandle {
             }
             other => {
                 log::error!("Unexpected response variant for GenerateCommitMessage: {other:?}");
+                Err(HostRequestError::UnexpectedResponse)
+            }
+        }
+    }
+
+    /// Fetches PR info for the current branch on the remote host. `Ok(None)`
+    /// means the lookup completed and the branch has no PR.
+    pub async fn get_github_pr_info(
+        &self,
+        repo_path: &StandardizedPath,
+    ) -> Result<Option<crate::proto::PrInfo>, HostRequestError> {
+        let msg = self
+            .send(crate::proto::host_scoped_request::Message::GetGithubPrInfo(
+                crate::proto::GetGitHubPrInfoRequest {
+                    repo_path: repo_path.to_string(),
+                },
+            ))
+            .await?;
+        match msg.message {
+            Some(crate::proto::server_message::Message::GetGithubPrInfoResponse(resp)) => {
+                if let Some(error) = resp.error {
+                    Err(HostRequestError::OperationFailed(error.message))
+                } else {
+                    Ok(resp.pr_info)
+                }
+            }
+            other => {
+                log::error!("Unexpected response variant for GetGitHubPrInfo: {other:?}");
+                Err(HostRequestError::UnexpectedResponse)
+            }
+        }
+    }
+
+    /// Fetches repository name/owner info on the remote host.
+    pub async fn get_github_repo_info(
+        &self,
+        repo_path: &StandardizedPath,
+    ) -> Result<Option<crate::proto::RepositoryInfo>, HostRequestError> {
+        let msg = self
+            .send(
+                crate::proto::host_scoped_request::Message::GetGithubRepositoryInfo(
+                    crate::proto::GetGitHubRepoInfoRequest {
+                        repo_path: repo_path.to_string(),
+                    },
+                ),
+            )
+            .await?;
+        match msg.message {
+            Some(crate::proto::server_message::Message::GetGithubRepoInfoResponse(resp)) => {
+                if let Some(error) = resp.error {
+                    Err(HostRequestError::OperationFailed(error.message))
+                } else {
+                    Ok(resp.repository_info)
+                }
+            }
+            other => {
+                log::error!("Unexpected response variant for GetGitHubRepositoryInfo: {other:?}");
                 Err(HostRequestError::UnexpectedResponse)
             }
         }
@@ -3181,38 +3282,6 @@ impl RemoteServerManager {
             .detach();
     }
 
-    /// Fetches PR info for the current branch on the remote host and emits
-    /// `GetPrInfoResponse` with the result (`Ok(None)` = no open PR).
-    pub fn git_get_pr_info(
-        &mut self,
-        host_id: HostId,
-        repo_path: StandardizedPath,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        let handle = self.host_request_handle(&host_id);
-
-        let repo_path_for_event = repo_path.clone();
-        let host_id_for_event = host_id.clone();
-        let spawner = self.spawner.clone();
-        ctx.background_executor()
-            .spawn(async move {
-                let result = handle
-                    .git_get_pr_info(&repo_path)
-                    .await
-                    .map_err(|e| e.to_string());
-                let _ = spawner
-                    .spawn(move |_me, ctx| {
-                        ctx.emit(RemoteServerManagerEvent::GetPrInfoResponse {
-                            host_id: host_id_for_event,
-                            repo_path: repo_path_for_event,
-                            result,
-                        });
-                    })
-                    .await;
-            })
-            .detach();
-    }
-
     /// Fetches the committed branch files (`merge_base(HEAD, main)..HEAD`) for
     /// the current branch on the remote host and emits
     /// `GetCommittedBranchFilesResponse` with the result.
@@ -3236,6 +3305,78 @@ impl RemoteServerManager {
                 let _ = spawner
                     .spawn(move |_me, ctx| {
                         ctx.emit(RemoteServerManagerEvent::GetCommittedBranchFilesResponse {
+                            host_id: host_id_for_event,
+                            repo_path: repo_path_for_event,
+                            result,
+                        });
+                    })
+                    .await;
+            })
+            .detach();
+    }
+
+    /// Sends an `UpdateGitStatus` notification (fire-and-forget) to the
+    /// remote server for the given host.
+    pub fn update_git_status(&self, host_id: HostId, repo_path: &StandardizedPath) {
+        if let Some(client) = self.client_for_host(&host_id) {
+            client.update_git_status(repo_path);
+        } else {
+            log::debug!("Remote server update_git_status: no client for host={host_id}");
+        }
+    }
+
+    /// Fetches PR info for the current branch on the remote host and emits a
+    /// host-scoped response event.
+    pub fn get_github_pr_info(
+        &mut self,
+        host_id: HostId,
+        repo_path: StandardizedPath,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let handle = self.host_request_handle(&host_id);
+        let repo_path_for_event = repo_path.clone();
+        let host_id_for_event = host_id.clone();
+        let spawner = self.spawner.clone();
+        ctx.background_executor()
+            .spawn(async move {
+                let result = handle
+                    .get_github_pr_info(&repo_path)
+                    .await
+                    .map_err(|e| e.to_string());
+                let _ = spawner
+                    .spawn(move |_me, ctx| {
+                        ctx.emit(RemoteServerManagerEvent::GetGitHubPrInfoResponse {
+                            host_id: host_id_for_event,
+                            repo_path: repo_path_for_event,
+                            result,
+                        });
+                    })
+                    .await;
+            })
+            .detach();
+    }
+
+    /// Fetches repository name/owner info on the remote host and emits a
+    /// host-scoped response event.
+    pub fn get_github_repo_info(
+        &mut self,
+        host_id: HostId,
+        repo_path: StandardizedPath,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let handle = self.host_request_handle(&host_id);
+        let repo_path_for_event = repo_path.clone();
+        let host_id_for_event = host_id.clone();
+        let spawner = self.spawner.clone();
+        ctx.background_executor()
+            .spawn(async move {
+                let result = handle
+                    .get_github_repo_info(&repo_path)
+                    .await
+                    .map_err(|e| e.to_string());
+                let _ = spawner
+                    .spawn(move |_me, ctx| {
+                        ctx.emit(RemoteServerManagerEvent::GetGitHubRepoInfoResponse {
                             host_id: host_id_for_event,
                             repo_path: repo_path_for_event,
                             result,
@@ -3372,6 +3513,33 @@ impl RemoteServerManager {
                     repo_path,
                     mode,
                     delta,
+                });
+            }
+            ClientEvent::GitStatusPushReceived {
+                repo_path,
+                metadata,
+            } => {
+                ctx.emit(RemoteServerManagerEvent::GitStatusPushReceived {
+                    host_id,
+                    repo_path,
+                    metadata,
+                });
+            }
+            ClientEvent::GitHubPrInfoPushReceived { repo_path, pr_info } => {
+                ctx.emit(RemoteServerManagerEvent::GitHubPrInfoPushReceived {
+                    host_id,
+                    repo_path,
+                    pr_info,
+                });
+            }
+            ClientEvent::GitHubRepositoryInfoPushReceived {
+                repo_path,
+                repository_info,
+            } => {
+                ctx.emit(RemoteServerManagerEvent::GitHubRepositoryInfoPushReceived {
+                    host_id,
+                    repo_path,
+                    repository_info,
                 });
             }
             ClientEvent::Disconnected => {

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -138,7 +138,6 @@ pub enum RemoteServerOperation {
     CommitChain,
     Push,
     CreatePr,
-    GetPrInfo,
     GenerateCommitMessage,
 }
 
@@ -573,13 +572,6 @@ pub enum RemoteServerManagerEvent {
         host_id: HostId,
         repo_path: StandardizedPath,
         result: Result<String, String>,
-    },
-    /// Response to a standalone get-PR-info (`gh pr view`). `Ok(None)` means
-    /// there is no open PR for the current branch.
-    GetPrInfoResponse {
-        host_id: HostId,
-        repo_path: StandardizedPath,
-        result: Result<Option<crate::proto::PrInfo>, String>,
     },
     /// Response to a committed-branch-files request (backs the Create PR
     /// dialog's Changes box). Carries the committed per-file entries
@@ -1085,38 +1077,6 @@ impl HostRequestHandle {
             }
             other => {
                 log::error!("Unexpected response variant for CreatePr: {other:?}");
-                Err(HostRequestError::UnexpectedResponse)
-            }
-        }
-    }
-
-    /// Looks up the PR for the current branch (`gh pr view`) on the remote
-    /// host. `Ok(None)` means there is no open PR.
-    pub async fn git_get_pr_info(
-        &self,
-        repo_path: &StandardizedPath,
-    ) -> Result<Option<crate::proto::PrInfo>, HostRequestError> {
-        let msg = self
-            .send(crate::proto::host_scoped_request::Message::GitGetPrInfo(
-                crate::proto::GitGetPrInfoRequest {
-                    repo_path: repo_path.to_string(),
-                },
-            ))
-            .await?;
-        match msg.message {
-            Some(crate::proto::server_message::Message::GitGetPrInfoResponse(resp)) => {
-                match resp.result {
-                    Some(crate::proto::git_get_pr_info_response::Result::Success(success)) => {
-                        Ok(success.pr_info)
-                    }
-                    Some(crate::proto::git_get_pr_info_response::Result::Error(e)) => {
-                        Err(HostRequestError::OperationFailed(e.message))
-                    }
-                    None => Err(HostRequestError::UnexpectedResponse),
-                }
-            }
-            other => {
-                log::error!("Unexpected response variant for GetPrInfo: {other:?}");
                 Err(HostRequestError::UnexpectedResponse)
             }
         }

--- a/specs/remote-git-repo-status/TECH.md
+++ b/specs/remote-git-repo-status/TECH.md
@@ -1,0 +1,65 @@
+# TECH: Remote-capable git status + GitHub info
+## Context
+Tabs and prompt/footer chips read git status and GitHub info from two per-repo models vended by the `GitRepoModels` singleton factory:
+- `GitRepoStatusModel` (`app/src/code_review/git_repo_model/`) — cheap, filesystem-watcher-driven status: `current_branch_name`, `main_branch_name`, `stats_against_head`. Event: `GitRepoStatusEvent::MetadataChanged`.
+- `GitHubRepoModel` (`app/src/code_review/github_repo_model/`) — expensive, `gh`-CLI-driven `pr_info` (`gh pr view`) plus `repository_info` (`gh repo view`), refreshed on creation, on branch changes for PR info, and on a 60s timer. Event: `GitHubRepoEvent::{PrInfoChanged, RepositoryInfoChanged}`.
+The local backend owns filesystem watchers and runs local `git`/`gh` commands. Remote sessions cannot run those commands locally, so the remote backend acts as a push receiver keyed by `(host_id, repo_path)` while the daemon runs the local models on the remote host.
+Key code:
+- `app/src/code_review/git_repo_model/` — unified `GitRepoStatusModel`, `LocalGitRepoStatusModel`, `RemoteGitRepoStatusModel`, factory cache keyed by `LocalOrRemotePath`.
+- `app/src/code_review/github_repo_model/` — unified `GitHubRepoModel`, `LocalGitHubRepoModel`, `RemoteGitHubRepoModel`.
+- `app/src/remote_server/server_model.rs` — daemon-side model cache, git-status notification handler, GitHub host-scoped handlers, and broadcasts.
+- `crates/remote_server/proto/diff_state.proto` — `GitStatusMetadata`, `GitStatusPush`, `UpdateGitStatus`, `GitHubPrInfoPush`, `GitHubRepositoryInfoPush`, `GetGitHubPrInfoRequest` / `GetGitHubPrInfoResponse`, `GetGitHubRepositoryInfoRequest` / `GetGitHubRepoInfoResponse`.
+- `crates/remote_server/proto/remote_server.proto` — `UpdateGitStatus` as a `Notification`, GitHub refreshes as `HostScopedRequest` variants, and the matching push / response `ServerMessage` variants.
+- `crates/remote_server/src/manager.rs` and `crates/remote_server/src/client/mod.rs` — manager events, the fire-and-forget git-status notification helper, and the host-scoped GitHub refresh helpers.
+## Proposed changes
+### 1. Unified local/remote models
+Each model is a unified enum that forwards events and preserves the existing read API:
+- `GitRepoStatusModel = enum { Local(LocalGitRepoStatusModel), Remote(RemoteGitRepoStatusModel) }` exposes `metadata()` and `refresh_metadata()`.
+- `GitHubRepoModel = enum { Local(LocalGitHubRepoModel), Remote(RemoteGitHubRepoModel) }` exposes `pr_info()`, `repository_info()`, `is_refreshing_pr_info()`, `refresh_pr_info()`, and `refresh_repository_info()`.
+`GitRepoModels` caches both model types by `LocalOrRemotePath`, so prompt chips, code review, tabs, and agent context all hold the same `ModelHandle<GitRepoStatusModel>` / `ModelHandle<GitHubRepoModel>` regardless of backend. Remote receivers preserve stale data across disconnects and update only from pushes or responses matching their `(host_id, repo_path)`.
+### 2. Transport shape: git-status notification, GitHub host-scoped refreshes
+Git status is shared per-repo model state and is small enough to remain a notification-triggered push stream:
+- `UpdateGitStatus { repo_path }` is a `Notification`. It asks the daemon to subscribe/create the per-repo git-status model and push the current `GitStatusPush` snapshot when metadata is available. It has no request id, no response, and is best-effort.
+- `RemoteGitRepoStatusModel` sends that notification on construction and again on `HostConnected`; live watcher changes arrive later as `GitStatusPush` messages filtered by `(host_id, repo_path)`.
+GitHub info is also shared cached state, but explicit refreshes use host-scoped request/response so the client can track request completion and surface PR-refresh loading state:
+- `GetGitHubPrInfoRequest { repo_path }` is a `HostScopedRequest`. The daemon validates the path, subscribes/creates the per-repo `GitHubRepoModel` (whose own lifecycle drives `GitHubPrInfoPush` broadcasts), runs `git::get_pr_for_branch` for the requesting client, and returns `GetGitHubPrInfoResponse`. It does not separately trigger `refresh_pr_info`, which would run a redundant `gh pr view`.
+- `GetGitHubRepositoryInfoRequest { repo_path }` is a `HostScopedRequest`. The daemon validates the path, subscribes/creates the same `GitHubRepoModel`, runs `git::get_repository_info` for the requesting client, and returns `GetGitHubRepoInfoResponse`. It does not separately trigger `refresh_repository_info`.
+- The daemon-side `GitHubRepoModel` broadcasts `GitHubPrInfoPush { repo_path, pr_info }` on PR changes and `GitHubRepositoryInfoPush { repo_path, repository_info }` on repository-info changes, so other consumers and later updates use shared push streams even though explicit refreshes also get direct responses.
+### 3. Why GitHub PR and repository refreshes are split
+The cached model read surface remains unified because consumers want a single `GitHubRepoModel`, but the client-to-daemon refreshes and pushes are split because PR info is requested more often:
+- PR refreshes happen after `gh`/`gt` commands, on branch changes, on reconnect, and from explicit code-review refreshes; those should only run `gh pr view`.
+- Repository info is branch-independent and should only run `gh repo view` on initial activation, reconnect, explicit repository-info refresh, or the periodic local timer.
+Splitting the host-scoped requests and push messages avoids turning frequent PR refreshes into unnecessary repository-info refreshes or combined payload updates. Creating the daemon-side `LocalGitHubRepoModel` still kicks off its normal initial/periodic lifecycle, which drives the shared broadcasts; repeated PR requests run only `gh pr view` (via `git::get_pr_for_branch`) and return a PR-specific response to the requesting client.
+### 4. Server-side broadcast model
+`ServerModel` keeps two daemon-side caches keyed by `StandardizedPath`:
+- `git_status_models: HashMap<StandardizedPath, ModelHandle<GitRepoStatusModel>>`
+- `github_repo_models: HashMap<StandardizedPath, ModelHandle<GitHubRepoModel>>`
+On first subscription, `ServerModel` wires model events to `send_server_message(None, None, …)`, broadcasting pushes to all connections:
+- `GitRepoStatusEvent::MetadataChanged` broadcasts `GitStatusPush { repo_path, metadata }`.
+- `GitHubRepoEvent::PrInfoChanged` broadcasts `GitHubPrInfoPush { repo_path, pr_info }`.
+- `GitHubRepoEvent::RepositoryInfoChanged` broadcasts `GitHubRepositoryInfoPush { repo_path, repository_info }`.
+Host-scoped GitHub refresh requests additionally return `GetGitHubPrInfoResponse` or `GetGitHubRepoInfoResponse` to the originating request id. The response path updates the requesting remote model's loading state; the push path keeps the shared cache and sibling consumers up to date.
+Navigation still acts as an opportunistic git-status interest signal: after `NavigatedToDirectory` resolves a git root, the daemon subscribes to the git-status model and pushes the current snapshot if available. `RemoteGitRepoStatusModel` also sends `UpdateGitStatus` after subscribing and again on `HostConnected`, covering the race where navigation's opportunistic push arrives before the receiver exists.
+### 5. Client-side receivers and matching
+`RemoteServerClient` parses `GitStatusPush`, `GitHubPrInfoPush`, and `GitHubRepositoryInfoPush` into client events, and `RemoteServerManager` attaches the resolved `HostId` before emitting manager events. GitHub host-scoped helpers also emit response events keyed by `(host_id, repo_path)`. Remote models filter on both host and repo:
+- `RemoteGitRepoStatusModel` accepts only `GitStatusPushReceived { host_id, repo_path, metadata }` matching its `RemotePath`.
+- `RemoteGitHubRepoModel` accepts matching `GitHubPrInfoPushReceived`, `GitHubRepositoryInfoPushReceived`, `GetGitHubPrInfoResponse`, and `GetGitHubRepoInfoResponse` events. Pushes update cached fields and emit only when values move; while a field-specific request is in flight, an empty push value does not clear the requested field before the direct response arrives.
+This keeps git-status notifications fire-and-forget while preserving host/repo correctness. GitHub refreshes use host-scoped request/response for explicit completion semantics, and the split GitHub push messages carry the durable shared state and subsequent model updates.
+### 6. Wire protocol summary
+`crates/remote_server/proto/diff_state.proto` owns the payloads:
+- `GitStatusMetadata { current_branch_name, main_branch_name, DiffStats stats_against_head }`
+- `GitStatusPush { repo_path, metadata }`
+- `UpdateGitStatus { repo_path }`
+- `GitHubPrInfoPush { repo_path, optional PrInfo pr_info }`
+- `GitHubRepositoryInfoPush { repo_path, optional RepositoryInfo repository_info }`
+- `GetGitHubPrInfoRequest { repo_path }`
+- `GetGitHubPrInfoResponse { optional PrInfo pr_info, GitOpError error }`
+- `GetGitHubRepositoryInfoRequest { repo_path }`
+- `GetGitHubRepoInfoResponse { optional RepositoryInfo repository_info, GitOpError error }`
+`crates/remote_server/proto/remote_server.proto` exposes `UpdateGitStatus` as a `Notification`, exposes `GetGitHubPrInfoRequest` and `GetGitHubRepositoryInfoRequest` as `HostScopedRequest` variants, and exposes `GitStatusPush`, `GitHubPrInfoPush`, `GitHubRepositoryInfoPush`, `GetGitHubPrInfoResponse`, and `GetGitHubRepoInfoResponse` as `ServerMessage` variants. There is no combined `GetGitHubInfo` request/response or push in the current protocol.
+### 7. Consumer wiring
+- `update_git_status_subscription` passes the current `LocalOrRemotePath` to `GitRepoModels::subscribe` and wires the unified status handle into prompt chips, tab metadata, code review refreshes, and the branch source needed by GitHub/agent-context subscriptions.
+- `sync_pr_info_subscription` passes the current `LocalOrRemotePath` to `subscribe_github_repo` when prompt/footer chips or AI context need PR/repository info. It wires the unified GitHub handle into prompt PR chips and the AI context model.
+- `CodeReviewView` subscribes to both per-repo models: git-status events refresh git-operation UI, while GitHub PR events drive PR-aware actions (`View PR`, `Create PR`, commit-and-create-PR eligibility) through the unified `GitHubRepoModel` instead of a local/remote split.
+- After `gh`/`gt` commands and git-dialog completion, callers refresh PR info through the unified `GitHubRepoModel`; local backends run `gh pr view` directly, while remote backends send `GetGitHubPrInfoRequest`.
+- AI-context repository and PR gates use `current_repo_path` plus the unified GitHub handle so both local and remote repos can provide repository and PR context when data is available.


### PR DESCRIPTION
## Description 
* Adds support for various git/github-backed features like prompt chips and git operations dialog over a remote environment 
* Builds on https://github.com/warpdotdev/warp/pull/12456
* Key changes include:
  * Updates the existing models `GitHubRepoModel` and `GitRepoStatusModel` to support a repo backed by `LocalOrRemotePath`, each model is moved to its own folder with local/remote variants 
  * Updates `GitStatusUpdateModel` to `GitRepoModels` which maps both models to `LocalOrRemotePath` 
  * Remote repositories now also source PR information from the `GitHubRepoModel`, removing the need for `DiffStateModel` to manage PR-specific state - deprecated the field and associated methods 
  * Introduces new proto calls to subscribe to and fetch github info, as well as subscribe to and receive git status updates 

** Note to reviewer: recommend reviewing by commit 

## Linked issue 
* [APP-4590: remote git chips](https://linear.app/warpdotdev/issue/APP-4590/improve-remote-git-related-chip-experience)
* [APP-4560: remote pr chip](https://linear.app/warpdotdev/issue/APP-4560/code-feature-support-pr-chip)

## Testing 
https://www.loom.com/share/2a3a8ddbc83b400e84c0c2d60586edf6

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable
CHANGELOG-NEW-FEATURE: Adds support for git chips over remote environments