### PR TITLE
Fix u8 overflow on long Markdown delimiter runs

### DIFF
--- a/crates/markdown_parser/src/markdown_parser.rs
+++ b/crates/markdown_parser/src/markdown_parser.rs
@@ -1472,7 +1472,7 @@ fn process_emphasis(state: &mut InlineState, stack_bottom: Option<usize>) {
 /// Helper for [`process_emphasis`] that removes `count` delimiters of `kind` from `node`.
 ///
 /// In debug builds, this panics if `node` is not a run of `kind` delimiters.
-fn truncate_delimiters(node: &mut FormattedTextFragment, kind: DelimiterKind, count: u8) {
+fn truncate_delimiters(node: &mut FormattedTextFragment, kind: DelimiterKind, count: usize) {
     let delimiter = kind.as_str();
     if cfg!(debug_assertions) {
         let text = &node.text;
@@ -1484,7 +1484,7 @@ fn truncate_delimiters(node: &mut FormattedTextFragment, kind: DelimiterKind, co
     }
 
     node.text
-        .truncate(node.text.len() - count as usize * delimiter.len());
+        .truncate(node.text.len() - count * delimiter.len());
 }
 
 /// Helper to merge adjacent text fragments with the same styling. Such fragments might come from:
@@ -1674,7 +1674,7 @@ fn parse_code_span<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum InlineToken<'a> {
     /// A run of `count` delimiter characters of `kind`.
-    Delimiter { kind: DelimiterKind, count: u8 },
+    Delimiter { kind: DelimiterKind, count: usize },
     /// A run of non-delimiter text.
     Text(&'a str),
     /// A backslash-escaped character.
@@ -1700,9 +1700,9 @@ struct Delimiter {
     kind: DelimiterKind,
     /// The count of repeated delimiter units. This is modified during parsing as delimiters are
     /// consumed.
-    count: u8,
+    count: usize,
     /// The count at the time the delimiter was parsed.
-    original_count: u8,
+    original_count: usize,
     /// Whether or not this delimiter is active (only applies to link delimiters).
     active: bool,
     /// The index of the [`FormattedTextFragment`] corresponding to this delimiter.
@@ -1721,7 +1721,7 @@ impl Delimiter {
     fn new(
         node_index: usize,
         kind: DelimiterKind,
-        count: u8,
+        count: usize,
         preceding_char: Option<char>,
         following_char: Option<char>,
     ) -> Self {
@@ -1774,7 +1774,7 @@ impl Delimiter {
 
     /// Convert this delimiter to literal text.
     fn to_text(&self) -> String {
-        self.kind.as_str().repeat(self.count as usize)
+        self.kind.as_str().repeat(self.count)
     }
 
     /// Whether or not this delimiter can open for the given closing delimiter.
@@ -1814,7 +1814,7 @@ enum DelimiterKind {
 
 impl DelimiterKind {
     /// Whether or not `count` is a valid run length for this delimiter.
-    fn valid_count(self, count: u8) -> bool {
+    fn valid_count(self, count: usize) -> bool {
         match self {
             // Emphasis and strong emphasis may be repeated arbitrarily.
             DelimiterKind::Asterisk | DelimiterKind::Underscore => true,

--- a/crates/markdown_parser/src/markdown_parser_tests.rs
+++ b/crates/markdown_parser/src/markdown_parser_tests.rs
@@ -37,6 +37,28 @@ fn test_parse_line_endings() {
 }
 
 #[test]
+fn test_parse_long_delimiter_run_does_not_overflow() {
+    // Regression test: a run of 256+ identical emphasis delimiters used to overflow
+    // the `u8` delimiter-run counter in `parse_delimiter_run`, panicking in debug
+    // builds ("attempt to add with overflow") and wrapping to 0 (silently corrupting
+    // the rendered output) in release builds. The counter is now `usize`.
+    for delimiter in ['*', '_', '~'] {
+        for run_len in [255usize, 256, 300] {
+            let source: String = std::iter::repeat(delimiter).take(run_len).collect();
+            // Unmatched delimiters round-trip to literal text, so the whole run must be
+            // preserved verbatim as a single plain-text fragment.
+            assert_eq!(
+                test_parse_markdown(&source),
+                vec![FormattedTextLine::Line(vec![
+                    FormattedTextFragment::plain_text(&source),
+                ])],
+                "{run_len} '{delimiter}' delimiters should parse to literal text"
+            );
+        }
+    }
+}
+
+#[test]
 fn test_parse_single_line() {
     // Ensure we can parse without a trailing newline.
     assert_eq!(


### PR DESCRIPTION
## Summary

Fixes #12500.

`parse_delimiter_run` folds a run of emphasis delimiters into a counter that is inferred as `u8`, because the result is stored in `InlineToken::Delimiter { count: u8 }`:

```rust
fold_many1(tag(kind.as_str()), || 0, |counter, _| counter + 1)
```

A run of **256 or more** identical delimiter characters (`*`, `_`, or `~`) overflows that counter. The 256th increment is `255 + 1`, which:

- **panics in debug builds / `cargo test`** — `attempt to add with overflow` at `markdown_parser.rs:1653`, so `parse_markdown` / `parse_inline_markdown` panic; and
- **wraps `256 → 0` in release builds** (the workspace sets no `overflow-checks`), silently corrupting output — unmatched delimiters round-trip to literal text via `Delimiter::to_text`, and a wrapped count of `0` drops all the characters.

These are public entry points used to render arbitrary, possibly untrusted Markdown (agent/AI output, pasted content, table cells), so such a run is easy to hit. There is also a latent second instance at `markdown_parser.rs:1795` (`self.original_count + other.original_count`).

## Fix

Widen the delimiter-run count from `u8` to `usize` everywhere it flows:

- `InlineToken::Delimiter::count`
- `Delimiter::count` and `Delimiter::original_count`
- the `count` parameters of `Delimiter::new`, `DelimiterKind::valid_count`, and `truncate_delimiters`

A delimiter run can never be longer than the input, so `usize` cannot overflow for any real input, the literal-text round-trip is preserved exactly, and the paired-run check at `:1795` no longer overflows.

## Testing

- Added `test_parse_long_delimiter_run_does_not_overflow`, covering 255/256/300-long runs of `*`, `_`, and `~`, asserting each parses to the run preserved verbatim as literal text.
- `cargo test -p markdown_parser` → **138 passed**.

Before this change, `parse_markdown(&"*".repeat(256))` panicked:

```
thread '...' panicked at crates/markdown_parser/src/markdown_parser.rs:1653:59:
attempt to add with overflow
```
