### PR TITLE
Fix reversed line range when first in-range line exceeds byte budget

### DIFF
--- a/crates/warp_files/src/text_file_reader.rs
+++ b/crates/warp_files/src/text_file_reader.rs
@@ -134,7 +134,13 @@ impl TextFileAccumulator {
         let line_range = if self.whole_file && !self.truncated {
             None
         } else if self.truncated {
-            Some(range.start..self.last_line)
+            // `last_line` is the last line that was successfully buffered. If the
+            // very first line in this range already exceeded the byte budget,
+            // nothing was buffered and `last_line` is still 0 (its initial /
+            // post-flush value), which would produce a reversed range like
+            // `1..0`. Clamp the end to `range.start` so a truncated range with
+            // no buffered lines is reported as an empty `start..start` range.
+            Some(range.start..self.last_line.max(range.start))
         } else {
             Some(range)
         };

--- a/crates/warp_files/src/text_file_reader_tests.rs
+++ b/crates/warp_files/src/text_file_reader_tests.rs
@@ -194,6 +194,40 @@ fn range_truncated_at_byte_limit() {
 }
 
 #[test]
+fn whole_file_truncated_on_first_line_is_not_reversed() {
+    // Regression: when the very first line already exceeds the byte budget,
+    // nothing is buffered and `last_line` stays 0, which used to produce a
+    // reversed range `Some(1..0)` (start > end).
+    let mut acc = make_accumulator(&[], 4);
+    push(&mut acc, "hello"); // 5 bytes > 4 → truncated, nothing buffered
+    push(&mut acc, "world");
+    let (segments, _bytes_read) = acc.finalize();
+
+    assert_eq!(segments.len(), 1);
+    assert_eq!(segments[0].content, "");
+    let range = segments[0].line_range.clone().expect("truncated → range shown");
+    assert!(range.start <= range.end, "range must not be reversed: {range:?}");
+    assert_eq!(range, 1..1);
+}
+
+#[test]
+fn range_truncated_on_first_in_range_line_is_not_reversed() {
+    // Same regression for an explicit range whose first in-range line exceeds
+    // the budget: previously produced `Some(2..0)`.
+    let mut acc = make_accumulator(&[2..6], 4);
+    push(&mut acc, "skip"); // line 1, outside range
+    push(&mut acc, "aaaaa"); // line 2, 5 bytes > 4 → truncated, nothing buffered
+    push(&mut acc, "bbbb");
+    let (segments, _bytes_read) = acc.finalize();
+
+    assert_eq!(segments.len(), 1);
+    assert_eq!(segments[0].content, "");
+    let range = segments[0].line_range.clone().expect("truncated → range shown");
+    assert!(range.start <= range.end, "range must not be reversed: {range:?}");
+    assert_eq!(range, 2..2);
+}
+
+#[test]
 fn global_budget_shared_across_ranges() {
     // Budget of 12 bytes. First range uses 5, leaving 7 for the second.
     let mut acc = make_accumulator(&[1..2, 3..5], 12);


### PR DESCRIPTION
## Summary

Fixes #12502.

`TextFileAccumulator::flush_range` builds the truncated line range as `range.start..self.last_line`:

```rust
} else if self.truncated {
    Some(range.start..self.last_line)   // text_file_reader.rs:137
}
```

`self.last_line` is only updated in `push_line` when a line is **successfully buffered** (it fit within the byte budget); it is initialized to `0` and reset to `0` after every flush. If the **first line that falls inside the range already exceeds the remaining byte budget**, `push_line` sets `truncated = true` and returns without updating `last_line`, so `last_line` stays `0` and the range becomes `range.start..0` — a reversed range (`start > end`).

This is reachable on the AI file-read path (`FileModel::read_text_file`), where the byte budget is the *remaining* shared batch budget and shrinks as files are read. A reversed `Range<usize>` yields an empty / nonsensical line span downstream and panics if ever used to slice.

## Fix

Clamp the truncated end to at least `range.start`:

```rust
Some(range.start..self.last_line.max(range.start))
```

When at least one line was buffered, `last_line >= range.start` and behavior is unchanged. When nothing was buffered (`last_line == 0`), the range becomes an empty `start..start`, matching the existing truncation contract (`Some(1..1)` / `Some(2..2)`).

## Testing

- Added `whole_file_truncated_on_first_line_is_not_reversed` and `range_truncated_on_first_in_range_line_is_not_reversed`, asserting `start <= end` and the expected empty range.
- `cargo test -p warp_files` → **30 passed** (all existing truncation tests unchanged).
