### PR TITLE
Add double-click on empty vertical tabs panel to open new tab

### DIFF
--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -1641,6 +1641,9 @@ fn render_vertical_tabs_panel(
             });
         }
     })
+    .on_double_click(|ctx, _, _| {
+        ctx.dispatch_typed_action(WorkspaceAction::AddDefaultTab);
+    })
     .with_defer_events_to_children()
     .finish();
 


### PR DESCRIPTION
## Description

Double-clicking the empty area of the vertical tabs panel now opens a new tab, matching the common terminal-emulator pattern (empty tab-strip → new tab).

This wires an `on_double_click` handler dispatching `WorkspaceAction::AddDefaultTab` onto the existing panel-level `Hoverable` in `vertical_tabs.rs` — the same one that already handles `on_right_click` for the empty space. `with_defer_events_to_children()` is already in place, so tab/pane row interactions (double-click to rename) and the right-click menu are unaffected; only double-clicks on the genuine empty space reach this handler.

## Linked Issue

Closes #9390

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] I have manually tested my changes locally with `./script/run`

Manually verified end-to-end (see video below):

- Double-click the empty space in the vertical tabs panel → a new tab opens.
- Double-click on an existing tab still renames it.

No automated test added: this is event wiring to `WorkspaceAction::AddDefaultTab`, an existing and already-exercised action. The behavior is covered by the manual test above.

### Screenshots / Videos


https://github.com/user-attachments/assets/8e57b7aa-468c-4236-97a9-29a5517de9b5



## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Double-click the empty area of the vertical tabs panel to open a new tab.