### PR TITLE
Add Nix to language grammars.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,7 @@ dependencies = [
  "arborium-json",
  "arborium-kotlin",
  "arborium-lua",
+ "arborium-nix",
  "arborium-objc",
  "arborium-php",
  "arborium-powershell",
@@ -836,6 +837,17 @@ name = "arborium-lua"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0132cce1b343560a26ae8a9af8da70bcec44432106c9670399ac9c59c61f2dee"
+dependencies = [
+ "arborium-sysroot",
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "arborium-nix"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a08a703d5502526e68f7ad8dbffd303537d6828005bed0ef0fc7d37e45bf7078"
 dependencies = [
  "arborium-sysroot",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,6 +311,7 @@ arborium = { version = "2", default-features = false, features = [
   "lang-jq",
   "lang-hcl",
   "lang-lua",
+  "lang-nix",
   "lang-ruby",
   "lang-php",
   "lang-toml",

--- a/crates/languages/grammars/nix/config.yaml
+++ b/crates/languages/grammars/nix/config.yaml
@@ -1,0 +1,11 @@
+display_name: "Nix"
+indent_unit:
+  space: 2
+comment_prefix: "#"
+brackets:
+  - start: "{"
+    end: "}"
+  - start: "("
+    end: ")"
+  - start: "["
+    end: "]"

--- a/crates/languages/grammars/nix/identifiers.scm
+++ b/crates/languages/grammars/nix/identifiers.scm
@@ -1,0 +1,6 @@
+(comment) @comment
+
+; Nix has no named function or class declarations; the meaningful symbols are
+; attribute bindings (`name = value;`) in attrsets and `let` blocks.
+(binding
+  attrpath: (attrpath) @definition.binding)

--- a/crates/languages/grammars/nix/indents.scm
+++ b/crates/languages/grammars/nix/indents.scm
@@ -1,0 +1,36 @@
+; Adapted from Helix's runtime/queries/nix/indents.scm, reduced to the plain
+; @indent / @outdent captures Warp's indent engine consumes.
+
+; One level per bracketed scope; the matching close token dedents.
+[
+  (attrset_expression)
+  (rec_attrset_expression)
+  (let_attrset_expression)
+  (list_expression)
+  (parenthesized_expression)
+  (formals)
+] @indent
+
+[
+  "}"
+  ")"
+  "]"
+] @outdent
+
+; A binding value carried onto the line(s) after `=`. It shares the `=` line
+; with a same-line bracket, so `x = { … }` is not indented twice.
+(binding) @indent
+
+; `let … in`: keep the bindings indented; pull the body back to the `let` level.
+(let_expression) @indent
+(let_expression body: (_) @outdent)
+
+; `if … then … else`: indent each branch.
+(if_expression
+  consequence: (_) @indent)
+(if_expression
+  alternative: (_) @indent)
+
+; Function application: arguments carried onto following lines. Nested
+; applications share a line, so they collapse to a single level.
+(apply_expression) @indent

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -18,7 +18,7 @@ lazy_static! {
     static ref LANGUAGE_REGISTRY: LanguageRegistry = LanguageRegistry::new();
 }
 
-pub const SUPPORTED_LANGUAGES: [&str; 33] = [
+pub const SUPPORTED_LANGUAGES: [&str; 34] = [
     "rust",
     "golang",
     "yaml",
@@ -52,6 +52,7 @@ pub const SUPPORTED_LANGUAGES: [&str; 33] = [
     "xml",
     "vue",
     "dockerfile",
+    "nix",
 ];
 
 /// Registry that holds all of the supported languages.
@@ -177,6 +178,7 @@ fn language_by_filename_parts(
         "jq" => language_by_name("jq"),
         "tf" | "hcl" | "tfvars" => language_by_name("hcl"),
         "lua" => language_by_name("lua"),
+        "nix" => language_by_name("nix"),
         "rb" => language_by_name("ruby"),
         "php" | "phtml" => language_by_name("php"),
         "toml" => language_by_name("toml"),
@@ -273,6 +275,7 @@ fn get_arborium_highlight_query(lang: &str) -> Option<&str> {
         "jq" => Some(arborium::lang_jq::HIGHLIGHTS_QUERY),
         "hcl" => Some(arborium::lang_hcl::HIGHLIGHTS_QUERY),
         "lua" => Some(arborium::lang_lua::HIGHLIGHTS_QUERY),
+        "nix" => Some(arborium::lang_nix::HIGHLIGHTS_QUERY),
         "ruby" => Some(arborium::lang_ruby::HIGHLIGHTS_QUERY),
         "php" => Some(arborium::lang_php::HIGHLIGHTS_QUERY),
         "toml" => Some(arborium::lang_toml::HIGHLIGHTS_QUERY),


### PR DESCRIPTION
## Description
This PR adds Nix language support to the built-in text editor. Resolves https://github.com/warpdotdev/warp/issues/12507. 

(I'll update this PR when the linked issue is labeled `ready-to-implement`, presumably after a maintainer verifies Oz's review of the issue.)

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<details>
<summary>Screenshot (master)</summary>

<img width="2866" height="2970" alt="Image" src="https://github.com/user-attachments/assets/ca35cf45-57e9-4607-b38e-ed0d70c7ca4c" />

</details>

<details>
<summary>Screenshot (this PR)</summary>

<img width="2866" height="2970" alt="Image" src="https://github.com/user-attachments/assets/4403cdb6-b67a-4ecb-8c7a-eef330b0f36b" />

</details>

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
