### PR TITLE
Fix codex gating in prod.

### DIFF
--- a/app/src/ai/agent_sdk/driver/harness/codex.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex.rs
@@ -12,6 +12,7 @@ use serde_json::{Map, Value};
 use tempfile::NamedTempFile;
 use uuid::Uuid;
 use warp_cli::agent::Harness;
+use warp_core::features::FeatureFlag;
 use warp_managed_secrets::ManagedSecretValue;
 use warpui::{ModelHandle, ModelSpawner, SingletonEntity};
 
@@ -89,7 +90,7 @@ impl ThirdPartyHarness for CodexHarness {
     }
 
     fn requires_verified_platform_plugin(&self) -> bool {
-        true
+        FeatureFlag::CodexPlugin.is_enabled()
     }
 
     /// Fetch the codex transcript for the current task's conversation and wrap it into a

--- a/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex_tests.rs
@@ -664,11 +664,6 @@ fn codex_command_with_session_id_invokes_resume_subcommand() {
 }
 
 #[test]
-fn codex_harness_requires_verified_platform_plugin() {
-    assert!(CodexHarness.requires_verified_platform_plugin());
-}
-
-#[test]
 fn codex_command_without_session_id_bypasses_hook_trust() {
     let cmd = codex_command("codex", None, "/tmp/prompt.txt");
     assert!(


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
This PR addresses a regression that was introduced in https://github.com/warpdotdev/warp/pull/11892, where codex multi-harness runs always require that we use a plugin, even in prod where the plugin install is gated behind a feature flag.

We now gate this check behind the feature flag, so we only error out of a codex run without a plugin if it's possible for it to even install the plugin.
