### PR TITLE
aggregate child artifacts in parent info panel

### DIFF
--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -42,6 +42,7 @@ use crate::ai::artifacts::Artifact;
 use crate::ai::blocklist::orchestration_topology::orchestration_aware_conversation_status;
 use crate::ai::blocklist::{
     BlocklistAIHistoryEvent, BlocklistAIHistoryModel, ConversationStatusUpdate,
+    orchestration_topology,
 };
 use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::ai::conversation_navigation::ConversationNavigationData;
@@ -644,6 +645,11 @@ pub struct AgentConversationsModel {
     /// Earliest RTC timestamp received while no list surface was open.
     /// On next `register_view_open`, triggers a single `fetch_tasks_updated_after`.
     dirty_since: Option<DateTime<Utc>>,
+    /// Parent run IDs for which a child-run backfill has already been attempted
+    /// this session. Ensures `ensure_child_tasks_loaded` issues at most one
+    /// `ancestor_run_id` list request per parent, even across repeated panel
+    /// refreshes or after a failed attempt.
+    child_backfill_attempted: HashSet<AmbientAgentTaskId>,
 }
 
 pub enum AgentConversationsModelEvent {
@@ -694,6 +700,7 @@ impl AgentConversationsModel {
                 task_fetch_state: HashMap::new(),
                 rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
                 dirty_since: None,
+                child_backfill_attempted: HashSet::new(),
             };
         }
 
@@ -733,6 +740,7 @@ impl AgentConversationsModel {
             task_fetch_state: HashMap::new(),
             rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
             dirty_since: None,
+            child_backfill_attempted: HashSet::new(),
         };
 
         // Only sync local conversations if we're not in CLI mode. Server-side data
@@ -744,6 +752,24 @@ impl AgentConversationsModel {
             model.initial_load_state = InitialConversationLoadState::Loaded;
         }
         model
+    }
+
+    /// Empty model with no subscriptions or polling, for unit tests that only
+    /// need the singleton registered (e.g. details-panel data construction).
+    #[cfg(test)]
+    pub(crate) fn new_for_test() -> Self {
+        Self {
+            tasks: HashMap::new(),
+            conversations: HashMap::new(),
+            in_flight_poll_abort_handle: None,
+            next_poll_abort_handle: None,
+            active_data_consumers_per_window: HashMap::new(),
+            initial_load_state: InitialConversationLoadState::Loaded,
+            task_fetch_state: HashMap::new(),
+            rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
+            dirty_since: None,
+            child_backfill_attempted: HashSet::new(),
+        }
     }
 
     pub fn is_loading(&self) -> bool {
@@ -1338,7 +1364,7 @@ impl AgentConversationsModel {
                 }
                 continue;
             }
-            let entry = entry::entry_for_task(task, history_model, app);
+            let entry = entry::entry_for_task(task, &self.tasks, history_model, app);
             if let Some(conversation_id) = entry.identity.local_conversation_id {
                 attached_conversation_ids.insert(conversation_id);
             }
@@ -1350,7 +1376,7 @@ impl AgentConversationsModel {
             if attached_conversation_ids.contains(&conversation_id) {
                 continue;
             }
-            let entry = entry::entry_for_conversation(metadata, history_model, app);
+            let entry = entry::entry_for_conversation(metadata, &self.tasks, history_model, app);
             emitted_conversation_ids.insert(conversation_id);
             entries.push(entry);
         }
@@ -1366,6 +1392,7 @@ impl AgentConversationsModel {
             entries.push(entry::entry_for_historical_metadata(
                 metadata,
                 nav_data,
+                &self.tasks,
                 history_model,
                 app,
             ));
@@ -1384,11 +1411,13 @@ impl AgentConversationsModel {
             AgentConversationEntryId::AmbientRun(task_id) => self
                 .tasks
                 .get(task_id)
-                .map(|task| entry::entry_for_task(task, history_model, app)),
+                .map(|task| entry::entry_for_task(task, &self.tasks, history_model, app)),
             AgentConversationEntryId::Conversation(conversation_id) => self
                 .conversations
                 .get(conversation_id)
-                .map(|metadata| entry::entry_for_conversation(metadata, history_model, app))
+                .map(|metadata| {
+                    entry::entry_for_conversation(metadata, &self.tasks, history_model, app)
+                })
                 .or_else(|| {
                     history_model
                         .get_conversation_metadata(conversation_id)
@@ -1400,6 +1429,7 @@ impl AgentConversationsModel {
                             entry::entry_for_historical_metadata(
                                 metadata,
                                 nav_data,
+                                &self.tasks,
                                 history_model,
                                 app,
                             )
@@ -1571,14 +1601,14 @@ impl AgentConversationsModel {
             task.conversation_id()
                 .is_some_and(|conversation_id| conversation_id == server_token.as_str())
         }) {
-            return Some(entry::entry_for_task(task, history_model, app));
+            return Some(entry::entry_for_task(task, &self.tasks, history_model, app));
         }
 
         let conversation_id = history_model.find_conversation_id_by_server_token(server_token)?;
         if let Some(task) = self.tasks.values().find(|task| {
             entry::conversation_id_shadowed_by_task(task, history_model) == Some(conversation_id)
         }) {
-            return Some(entry::entry_for_task(task, history_model, app));
+            return Some(entry::entry_for_task(task, &self.tasks, history_model, app));
         }
 
         self.get_entry_by_id(
@@ -1825,6 +1855,129 @@ impl AgentConversationsModel {
                 }
                 RequestState::RequestFailedRetryPending(_) => {
                     // Wait for a terminal outcome before updating dedup/backoff state.
+                }
+            },
+        );
+    }
+
+    /// Aggregated artifacts for `task`: its own artifacts, its transitive
+    /// child runs' artifacts, and the linked local conversation subtree's
+    /// artifacts, deduped by identity. Reads only in-memory state.
+    pub fn aggregated_task_artifacts(
+        &self,
+        task: &AmbientAgentTask,
+        app: &AppContext,
+    ) -> Vec<Artifact> {
+        let history_model = BlocklistAIHistoryModel::as_ref(app);
+        let local_conversation_id = entry::conversation_id_shadowed_by_task(task, history_model);
+        entry::aggregated_run_artifacts(task, &self.tasks, local_conversation_id, history_model)
+    }
+
+    /// Aggregated artifacts for the conversation subtree rooted at `root_id`,
+    /// including artifacts on each node's backing run record (the only local
+    /// source for remote children's artifacts). Reads only in-memory state.
+    pub fn aggregated_conversation_artifacts(
+        &self,
+        root_id: AIConversationId,
+        app: &AppContext,
+    ) -> Vec<Artifact> {
+        orchestration_topology::aggregated_conversation_artifacts(
+            BlocklistAIHistoryModel::as_ref(app),
+            &self.tasks,
+            root_id,
+        )
+    }
+
+    /// Backfills missing child runs of `parent_task_id` into the model with a
+    /// single `ancestor_run_id` list request, then emits a task update event.
+    ///
+    /// Runs at most once per parent run per session: when every child is
+    /// already loaded this short-circuits before consulting the guard, and
+    /// otherwise `child_backfill_attempted` ensures repeated panel refreshes
+    /// (or a failed attempt) never issue another request.
+    pub fn ensure_child_tasks_loaded(
+        &mut self,
+        parent_task_id: &AmbientAgentTaskId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let Some(parent) = self.tasks.get(parent_task_id) else {
+            return;
+        };
+        let has_missing_child = parent.children.iter().any(|run_id| {
+            run_id
+                .parse::<AmbientAgentTaskId>()
+                .is_ok_and(|id| !self.tasks.contains_key(&id))
+        });
+        if !has_missing_child {
+            return;
+        }
+        self.spawn_child_backfill_once(*parent_task_id, ctx);
+    }
+
+    /// Conversation-rooted variant of [`Self::ensure_child_tasks_loaded`] for
+    /// local orchestrators: when any descendant conversation's backing run is
+    /// missing from the task map, backfills the orchestrator run's descendants
+    /// with a single `ancestor_run_id` request (once per parent run per
+    /// session). Used by panels rooted at a conversation, where the parent
+    /// run record itself may not be loaded.
+    pub fn ensure_child_tasks_loaded_for_conversation(
+        &mut self,
+        parent_conversation_id: AIConversationId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let history_model = BlocklistAIHistoryModel::as_ref(ctx);
+        let Some(parent_task_id) = history_model
+            .conversation(&parent_conversation_id)
+            .and_then(|conversation| conversation.task_id())
+        else {
+            return;
+        };
+        let has_missing_child = orchestration_topology::descendant_conversation_ids_in_spawn_order(
+            history_model,
+            parent_conversation_id,
+        )
+        .into_iter()
+        .filter_map(|id| {
+            history_model
+                .conversation(&id)
+                .and_then(|conversation| conversation.task_id())
+        })
+        .any(|task_id| !self.tasks.contains_key(&task_id));
+        if !has_missing_child {
+            return;
+        }
+        self.spawn_child_backfill_once(parent_task_id, ctx);
+    }
+
+    /// Issues the one-per-parent-run `ancestor_run_id` backfill request,
+    /// guarded by `child_backfill_attempted`. Failures are not retried.
+    fn spawn_child_backfill_once(
+        &mut self,
+        parent_task_id: AmbientAgentTaskId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if !self.child_backfill_attempted.insert(parent_task_id) {
+            return;
+        }
+
+        let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
+        let ancestor_run_id = parent_task_id.to_string();
+        ctx.spawn(
+            async move {
+                ai_client
+                    .list_ambient_agent_tasks(
+                        INITIAL_TASK_AMOUNT,
+                        TaskListFilter {
+                            ancestor_run_id: Some(ancestor_run_id),
+                            ..Default::default()
+                        },
+                    )
+                    .await
+            },
+            move |model, result, ctx| match result {
+                Ok(tasks) => model.update_model_with_new_tasks(tasks, ctx),
+                Err(e) => {
+                    log::warn!("Failed to backfill child runs for {parent_task_id}: {e:#}");
                 }
             },
         );

--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -86,7 +86,7 @@ const CHILD_RUNS_FETCH_FAILURE_COOLDOWN: Duration = Duration::from_secs(30);
 
 /// Upper bound on the number of child runs fetched for a single parent across
 /// pagination, so a pathological topology can't drive unbounded paging.
-const MAX_CHILD_RUNS_PER_PARENT: usize = 1_000;
+const MAX_CHILD_RUNS_PER_PARENT: usize = 500;
 
 /// Dedup + backoff state for the one-shot child-run fetch, keyed per parent run.
 enum ChildRunsFetchState {

--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -416,7 +416,7 @@ impl AgentRunDisplayStatus {
                     return Self::from_task_state(task);
                 }
                 let history_model = BlocklistAIHistoryModel::as_ref(app);
-                entry::conversation_id_shadowed_by_task(task, history_model)
+                orchestration_topology::conversation_id_shadowed_by_task(task, history_model)
                     .and_then(|conversation_id| history_model.conversation(&conversation_id))
                     .map(|conversation| {
                         // Roll the whole orchestration subtree (children,
@@ -1341,7 +1341,7 @@ impl AgentConversationsModel {
             // conversation shadowed by a child task is hidden along with it.
             if task.parent_run_id.is_some() {
                 if let Some(conversation_id) =
-                    entry::conversation_id_shadowed_by_task(task, history_model)
+                    orchestration_topology::conversation_id_shadowed_by_task(task, history_model)
                 {
                     attached_conversation_ids.insert(conversation_id);
                 }
@@ -1589,7 +1589,8 @@ impl AgentConversationsModel {
 
         let conversation_id = history_model.find_conversation_id_by_server_token(server_token)?;
         if let Some(task) = self.tasks.values().find(|task| {
-            entry::conversation_id_shadowed_by_task(task, history_model) == Some(conversation_id)
+            orchestration_topology::conversation_id_shadowed_by_task(task, history_model)
+                == Some(conversation_id)
         }) {
             return Some(entry::entry_for_task(task, &self.tasks, history_model, app));
         }
@@ -1685,7 +1686,7 @@ impl AgentConversationsModel {
             } => {
                 let history_model = BlocklistAIHistoryModel::as_ref(ctx);
                 for task in self.tasks.values_mut() {
-                    if entry::conversation_id_shadowed_by_task(task, history_model)
+                    if orchestration_topology::conversation_id_shadowed_by_task(task, history_model)
                         == Some(*conversation_id)
                     {
                         task.title = title.clone();
@@ -1843,20 +1844,22 @@ impl AgentConversationsModel {
         );
     }
 
-    /// Aggregated artifacts for `task`: its own artifacts, its transitive
-    /// child runs' artifacts, and the linked local conversation subtree's
-    /// artifacts, deduped by identity. Reads only in-memory state.
+    /// Aggregated artifacts for the orchestration tree rooted at `task`
+    /// (the run, its descendants' run records, and their linked local
+    /// conversations), deduped by identity. Reads only in-memory state.
     pub fn aggregated_task_artifacts(
         &self,
         task: &AmbientAgentTask,
         app: &AppContext,
     ) -> Vec<Artifact> {
-        let history_model = BlocklistAIHistoryModel::as_ref(app);
-        let local_conversation_id = entry::conversation_id_shadowed_by_task(task, history_model);
-        entry::aggregated_run_artifacts(task, &self.tasks, local_conversation_id, history_model)
+        orchestration_topology::aggregated_subtree_artifacts(
+            BlocklistAIHistoryModel::as_ref(app),
+            &self.tasks,
+            orchestration_topology::OrchestrationRoot::Run(task),
+        )
     }
 
-    /// Aggregated artifacts for the conversation subtree rooted at `root_id`,
+    /// Aggregated artifacts for the orchestration tree rooted at `root_id`,
     /// including artifacts on each node's backing run record (the only local
     /// source for remote children's artifacts). Reads only in-memory state.
     pub fn aggregated_conversation_artifacts(
@@ -1864,10 +1867,10 @@ impl AgentConversationsModel {
         root_id: AIConversationId,
         app: &AppContext,
     ) -> Vec<Artifact> {
-        orchestration_topology::aggregated_conversation_artifacts(
+        orchestration_topology::aggregated_subtree_artifacts(
             BlocklistAIHistoryModel::as_ref(app),
             &self.tasks,
-            root_id,
+            orchestration_topology::OrchestrationRoot::Conversation(root_id),
         )
     }
 

--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -437,7 +437,7 @@ impl AgentRunDisplayStatus {
                     return Self::from_task_state(task);
                 }
                 let history_model = BlocklistAIHistoryModel::as_ref(app);
-                orchestration_topology::conversation_id_shadowed_by_task(task, history_model)
+                orchestration_topology::local_conversation_id_for_task(task, history_model)
                     .and_then(|conversation_id| history_model.conversation(&conversation_id))
                     .map(|conversation| {
                         // Roll the whole orchestration subtree (children,
@@ -1360,7 +1360,7 @@ impl AgentConversationsModel {
             // conversation shadowed by a child task is hidden along with it.
             if task.parent_run_id.is_some() {
                 if let Some(conversation_id) =
-                    orchestration_topology::conversation_id_shadowed_by_task(task, history_model)
+                    orchestration_topology::local_conversation_id_for_task(task, history_model)
                 {
                     attached_conversation_ids.insert(conversation_id);
                 }
@@ -1608,7 +1608,7 @@ impl AgentConversationsModel {
 
         let conversation_id = history_model.find_conversation_id_by_server_token(server_token)?;
         if let Some(task) = self.tasks.values().find(|task| {
-            orchestration_topology::conversation_id_shadowed_by_task(task, history_model)
+            orchestration_topology::local_conversation_id_for_task(task, history_model)
                 == Some(conversation_id)
         }) {
             return Some(entry::entry_for_task(task, &self.tasks, history_model, app));
@@ -1705,10 +1705,8 @@ impl AgentConversationsModel {
             } => {
                 let history_model = BlocklistAIHistoryModel::as_ref(ctx);
                 for task in self.tasks.values_mut() {
-                    if orchestration_topology::conversation_id_shadowed_by_task(
-                        task,
-                        history_model,
-                    ) == Some(*conversation_id)
+                    if orchestration_topology::local_conversation_id_for_task(task, history_model)
+                        == Some(*conversation_id)
                     {
                         task.title = title.clone();
                     }

--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -31,7 +31,7 @@ use warpui::{
     WindowId, duration_with_jitter,
 };
 
-use crate::ai::active_agent_views_model::{ActiveAgentViewsModel, ConversationOrTaskId};
+use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
 use crate::ai::ambient_agents::{
@@ -77,6 +77,27 @@ const TRANSIENT_FETCH_FAILURE_COOLDOWN: Duration = Duration::from_secs(2);
 /// (e.g. an ACL grant) — but we wait long enough that streaming bursts and rapid re-entries
 /// can't cause a flood.
 const PERMANENT_FETCH_FAILURE_COOLDOWN: Duration = Duration::from_secs(60);
+
+/// How long to wait before retrying a failed child-run fetch. Unlike per-task
+/// fetches, child-run fetches aren't driven by streaming bursts, so a single
+/// modest cooldown (rather than a transient/permanent split) is enough to keep
+/// a persistent failure from hammering the server.
+const CHILD_RUNS_FETCH_FAILURE_COOLDOWN: Duration = Duration::from_secs(30);
+
+/// Upper bound on the number of child runs fetched for a single parent across
+/// pagination, so a pathological topology can't drive unbounded paging.
+const MAX_CHILD_RUNS_PER_PARENT: usize = 1_000;
+
+/// Dedup + backoff state for the one-shot child-run fetch, keyed per parent run.
+enum ChildRunsFetchState {
+    /// A paginating fetch is currently outstanding for this parent.
+    InFlight,
+    /// The full child-run set was loaded; not refetched again this session.
+    Loaded,
+    /// The last fetch failed; remember when so we can back off for
+    /// [`CHILD_RUNS_FETCH_FAILURE_COOLDOWN`] before retrying.
+    FailedAt(Instant),
+}
 
 /// Error details for a failed ambient-agent task metadata fetch.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -645,10 +666,10 @@ pub struct AgentConversationsModel {
     /// Earliest RTC timestamp received while no list surface was open.
     /// On next `register_view_open`, triggers a single `fetch_tasks_updated_after`.
     dirty_since: Option<DateTime<Utc>>,
-    /// Parent run IDs whose child runs we have already requested from the
-    /// server this session. Like `task_fetch_state`, this exists purely to
-    /// dedupe requests and ensure we don't try to fetch the same child run repeatedly.
-    requested_child_runs_for: HashSet<AmbientAgentTaskId>,
+    /// Per-parent dedup + backoff state for the one-shot child-run fetch. A
+    /// `Loaded` parent is never refetched this session; a `FailedAt` parent is
+    /// retried only after [`CHILD_RUNS_FETCH_FAILURE_COOLDOWN`] elapses.
+    requested_child_runs_for: HashMap<AmbientAgentTaskId, ChildRunsFetchState>,
 }
 
 pub enum AgentConversationsModelEvent {
@@ -699,7 +720,7 @@ impl AgentConversationsModel {
                 task_fetch_state: HashMap::new(),
                 rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
                 dirty_since: None,
-                requested_child_runs_for: HashSet::new(),
+                requested_child_runs_for: HashMap::new(),
             };
         }
 
@@ -739,7 +760,7 @@ impl AgentConversationsModel {
             task_fetch_state: HashMap::new(),
             rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
             dirty_since: None,
-            requested_child_runs_for: HashSet::new(),
+            requested_child_runs_for: HashMap::new(),
         };
 
         // Only sync local conversations if we're not in CLI mode. Server-side data
@@ -1684,8 +1705,10 @@ impl AgentConversationsModel {
             } => {
                 let history_model = BlocklistAIHistoryModel::as_ref(ctx);
                 for task in self.tasks.values_mut() {
-                    if orchestration_topology::conversation_id_shadowed_by_task(task, history_model)
-                        == Some(*conversation_id)
+                    if orchestration_topology::conversation_id_shadowed_by_task(
+                        task,
+                        history_model,
+                    ) == Some(*conversation_id)
                     {
                         task.title = title.clone();
                     }
@@ -1853,7 +1876,7 @@ impl AgentConversationsModel {
         orchestration_topology::aggregated_subtree_artifacts(
             BlocklistAIHistoryModel::as_ref(app),
             &self.tasks,
-            ConversationOrTaskId::TaskId(task.task_id),
+            orchestration_topology::SubtreeRoot::Task(task.task_id),
         )
     }
 
@@ -1868,18 +1891,19 @@ impl AgentConversationsModel {
         orchestration_topology::aggregated_subtree_artifacts(
             BlocklistAIHistoryModel::as_ref(app),
             &self.tasks,
-            ConversationOrTaskId::ConversationId(root_id),
+            orchestration_topology::SubtreeRoot::Conversation(root_id),
         )
     }
 
     /// Fetches child runs of `parent_task_id` that aren't loaded yet into the
-    /// model with a single `ancestor_run_id` list request, then emits a task
+    /// model with a paginated `ancestor_run_id` list request, then emits a task
     /// update event.
     ///
-    /// Runs at most once per parent run per session: when every child is
-    /// already loaded this short-circuits before consulting the guard, and
-    /// otherwise `requested_child_runs_for` ensures repeated panel refreshes
-    /// (or a failed request) never issue another one.
+    /// Fetches at most once per parent run per session on success: when every
+    /// child is already loaded this short-circuits before consulting the guard,
+    /// and otherwise `requested_child_runs_for` dedupes repeated panel
+    /// refreshes. A failed fetch is retried after
+    /// [`CHILD_RUNS_FETCH_FAILURE_COOLDOWN`].
     pub fn ensure_child_tasks_loaded(
         &mut self,
         parent_task_id: &AmbientAgentTaskId,
@@ -1934,35 +1958,68 @@ impl AgentConversationsModel {
         self.fetch_child_runs_once(parent_task_id, ctx);
     }
 
-    /// Issues the one-per-parent-run `ancestor_run_id` list request, deduped
-    /// via `requested_child_runs_for`. Failures are not retried.
+    /// Issues the per-parent-run `ancestor_run_id` list request, paging through
+    /// all descendants (up to [`MAX_CHILD_RUNS_PER_PARENT`]) in a single spawned
+    /// task. Deduped via `requested_child_runs_for`: a successful fetch is not
+    /// repeated this session, while a failed fetch is retried once
+    /// [`CHILD_RUNS_FETCH_FAILURE_COOLDOWN`] elapses.
     fn fetch_child_runs_once(
         &mut self,
         parent_task_id: AmbientAgentTaskId,
         ctx: &mut ModelContext<Self>,
     ) {
-        if !self.requested_child_runs_for.insert(parent_task_id) {
-            return;
+        match self.requested_child_runs_for.get(&parent_task_id) {
+            Some(ChildRunsFetchState::InFlight | ChildRunsFetchState::Loaded) => return,
+            Some(ChildRunsFetchState::FailedAt(at))
+                if at.elapsed() < CHILD_RUNS_FETCH_FAILURE_COOLDOWN =>
+            {
+                return;
+            }
+            _ => {}
         }
+        self.requested_child_runs_for
+            .insert(parent_task_id, ChildRunsFetchState::InFlight);
 
         let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
         let ancestor_run_id = parent_task_id.to_string();
         ctx.spawn(
             async move {
-                ai_client
-                    .list_ambient_agent_tasks(
-                        INITIAL_TASK_AMOUNT,
-                        TaskListFilter {
-                            ancestor_run_id: Some(ancestor_run_id),
-                            ..Default::default()
-                        },
-                    )
-                    .await
+                let mut all_tasks = Vec::new();
+                let mut cursor = None;
+                loop {
+                    let (tasks, next_cursor) = ai_client
+                        .list_ambient_agent_tasks_page(
+                            INITIAL_TASK_AMOUNT,
+                            TaskListFilter {
+                                ancestor_run_id: Some(ancestor_run_id.clone()),
+                                cursor,
+                                ..Default::default()
+                            },
+                        )
+                        .await?;
+                    all_tasks.extend(tasks);
+                    match next_cursor {
+                        Some(next) if all_tasks.len() < MAX_CHILD_RUNS_PER_PARENT => {
+                            cursor = Some(next);
+                        }
+                        _ => break,
+                    }
+                }
+                anyhow::Ok(all_tasks)
             },
             move |model, result, ctx| match result {
-                Ok(tasks) => model.update_model_with_new_tasks(tasks, ctx),
+                Ok(tasks) => {
+                    model
+                        .requested_child_runs_for
+                        .insert(parent_task_id, ChildRunsFetchState::Loaded);
+                    model.update_model_with_new_tasks(tasks, ctx);
+                }
                 Err(e) => {
                     log::warn!("Failed to fetch child runs for {parent_task_id}: {e:#}");
+                    model.requested_child_runs_for.insert(
+                        parent_task_id,
+                        ChildRunsFetchState::FailedAt(Instant::now()),
+                    );
                 }
             },
         );
@@ -2192,6 +2249,7 @@ impl AgentConversationsModel {
         self.abort_rtc_task_refresh_throttle();
         self.active_data_consumers_per_window.clear();
         self.task_fetch_state.clear();
+        self.requested_child_runs_for.clear();
         self.dirty_since = None;
         self.initial_load_state = InitialConversationLoadState::WaitingForCloud;
     }

--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -1280,16 +1280,9 @@ impl AgentConversationsModel {
         let mut has_updated_tasks = false;
 
         for task in tasks {
-            let task_id = task.task_id;
-            match self.tasks.get(&task_id) {
-                Some(existing_task) => {
-                    if existing_task != &task {
-                        has_updated_tasks = true
-                    }
-                }
-                None => has_new_tasks = true,
-            };
-            self.tasks.insert(task_id, task);
+            let (is_new, is_updated) = self.merge_task(task);
+            has_new_tasks |= is_new;
+            has_updated_tasks |= is_updated;
         }
 
         if has_new_tasks {
@@ -1297,6 +1290,30 @@ impl AgentConversationsModel {
         } else if has_updated_tasks {
             ctx.emit(AgentConversationsModelEvent::TasksUpdated);
         }
+    }
+
+    /// Merges one task and invalidates stale child-run fetch state on topology changes.
+    fn merge_task(&mut self, task: AmbientAgentTask) -> (bool, bool) {
+        let task_id = task.task_id;
+        let mut is_new = false;
+        let mut is_updated = false;
+        match self.tasks.get(&task_id) {
+            Some(existing_task) => {
+                let children_changed = existing_task.children != task.children;
+                is_updated = existing_task != &task;
+                if children_changed
+                    && matches!(
+                        self.requested_child_runs_for.get(&task_id),
+                        Some(ChildRunsFetchState::Loaded)
+                    )
+                {
+                    self.requested_child_runs_for.remove(&task_id);
+                }
+            }
+            None => is_new = true,
+        }
+        self.tasks.insert(task_id, task);
+        (is_new, is_updated)
     }
 
     /// Returns whether the unfiltered conversation list contains any entries.
@@ -2185,16 +2202,9 @@ impl AgentConversationsModel {
                     let mut has_updated_tasks = false;
 
                     for task in tasks {
-                        let task_id = task.task_id;
-                        match model.tasks.get(&task_id) {
-                            Some(existing_task) => {
-                                if existing_task != &task {
-                                    has_updated_tasks = true;
-                                }
-                            }
-                            None => has_new_tasks = true,
-                        };
-                        model.tasks.insert(task_id, task);
+                        let (is_new, is_updated) = model.merge_task(task);
+                        has_new_tasks |= is_new;
+                        has_updated_tasks |= is_updated;
                     }
 
                     // Enforce task cap

--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -31,7 +31,7 @@ use warpui::{
     WindowId, duration_with_jitter,
 };
 
-use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
+use crate::ai::active_agent_views_model::{ActiveAgentViewsModel, ConversationOrTaskId};
 use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
 use crate::ai::ambient_agents::{
@@ -647,9 +647,7 @@ pub struct AgentConversationsModel {
     dirty_since: Option<DateTime<Utc>>,
     /// Parent run IDs whose child runs we have already requested from the
     /// server this session. Like `task_fetch_state`, this exists purely to
-    /// dedupe requests: `ensure_child_tasks_loaded` issues at most one
-    /// `ancestor_run_id` list request per parent, even across repeated panel
-    /// refreshes or after a failed request.
+    /// dedupe requests and ensure we don't try to fetch the same child run repeatedly.
     requested_child_runs_for: HashSet<AmbientAgentTaskId>,
 }
 
@@ -1855,7 +1853,7 @@ impl AgentConversationsModel {
         orchestration_topology::aggregated_subtree_artifacts(
             BlocklistAIHistoryModel::as_ref(app),
             &self.tasks,
-            orchestration_topology::OrchestrationRoot::Run(task),
+            ConversationOrTaskId::TaskId(task.task_id),
         )
     }
 
@@ -1870,7 +1868,7 @@ impl AgentConversationsModel {
         orchestration_topology::aggregated_subtree_artifacts(
             BlocklistAIHistoryModel::as_ref(app),
             &self.tasks,
-            orchestration_topology::OrchestrationRoot::Conversation(root_id),
+            ConversationOrTaskId::ConversationId(root_id),
         )
     }
 

--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -645,11 +645,12 @@ pub struct AgentConversationsModel {
     /// Earliest RTC timestamp received while no list surface was open.
     /// On next `register_view_open`, triggers a single `fetch_tasks_updated_after`.
     dirty_since: Option<DateTime<Utc>>,
-    /// Parent run IDs for which a child-run backfill has already been attempted
-    /// this session. Ensures `ensure_child_tasks_loaded` issues at most one
+    /// Parent run IDs whose child runs we have already requested from the
+    /// server this session. Like `task_fetch_state`, this exists purely to
+    /// dedupe requests: `ensure_child_tasks_loaded` issues at most one
     /// `ancestor_run_id` list request per parent, even across repeated panel
-    /// refreshes or after a failed attempt.
-    child_backfill_attempted: HashSet<AmbientAgentTaskId>,
+    /// refreshes or after a failed request.
+    requested_child_runs_for: HashSet<AmbientAgentTaskId>,
 }
 
 pub enum AgentConversationsModelEvent {
@@ -700,7 +701,7 @@ impl AgentConversationsModel {
                 task_fetch_state: HashMap::new(),
                 rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
                 dirty_since: None,
-                child_backfill_attempted: HashSet::new(),
+                requested_child_runs_for: HashSet::new(),
             };
         }
 
@@ -740,7 +741,7 @@ impl AgentConversationsModel {
             task_fetch_state: HashMap::new(),
             rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
             dirty_since: None,
-            child_backfill_attempted: HashSet::new(),
+            requested_child_runs_for: HashSet::new(),
         };
 
         // Only sync local conversations if we're not in CLI mode. Server-side data
@@ -752,24 +753,6 @@ impl AgentConversationsModel {
             model.initial_load_state = InitialConversationLoadState::Loaded;
         }
         model
-    }
-
-    /// Empty model with no subscriptions or polling, for unit tests that only
-    /// need the singleton registered (e.g. details-panel data construction).
-    #[cfg(test)]
-    pub(crate) fn new_for_test() -> Self {
-        Self {
-            tasks: HashMap::new(),
-            conversations: HashMap::new(),
-            in_flight_poll_abort_handle: None,
-            next_poll_abort_handle: None,
-            active_data_consumers_per_window: HashMap::new(),
-            initial_load_state: InitialConversationLoadState::Loaded,
-            task_fetch_state: HashMap::new(),
-            rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
-            dirty_since: None,
-            child_backfill_attempted: HashSet::new(),
-        }
     }
 
     pub fn is_loading(&self) -> bool {
@@ -1888,13 +1871,14 @@ impl AgentConversationsModel {
         )
     }
 
-    /// Backfills missing child runs of `parent_task_id` into the model with a
-    /// single `ancestor_run_id` list request, then emits a task update event.
+    /// Fetches child runs of `parent_task_id` that aren't loaded yet into the
+    /// model with a single `ancestor_run_id` list request, then emits a task
+    /// update event.
     ///
     /// Runs at most once per parent run per session: when every child is
     /// already loaded this short-circuits before consulting the guard, and
-    /// otherwise `child_backfill_attempted` ensures repeated panel refreshes
-    /// (or a failed attempt) never issue another request.
+    /// otherwise `requested_child_runs_for` ensures repeated panel refreshes
+    /// (or a failed request) never issue another one.
     pub fn ensure_child_tasks_loaded(
         &mut self,
         parent_task_id: &AmbientAgentTaskId,
@@ -1911,12 +1895,12 @@ impl AgentConversationsModel {
         if !has_missing_child {
             return;
         }
-        self.spawn_child_backfill_once(*parent_task_id, ctx);
+        self.fetch_child_runs_once(*parent_task_id, ctx);
     }
 
     /// Conversation-rooted variant of [`Self::ensure_child_tasks_loaded`] for
     /// local orchestrators: when any descendant conversation's backing run is
-    /// missing from the task map, backfills the orchestrator run's descendants
+    /// missing from the task map, fetches the orchestrator run's descendants
     /// with a single `ancestor_run_id` request (once per parent run per
     /// session). Used by panels rooted at a conversation, where the parent
     /// run record itself may not be loaded.
@@ -1946,17 +1930,17 @@ impl AgentConversationsModel {
         if !has_missing_child {
             return;
         }
-        self.spawn_child_backfill_once(parent_task_id, ctx);
+        self.fetch_child_runs_once(parent_task_id, ctx);
     }
 
-    /// Issues the one-per-parent-run `ancestor_run_id` backfill request,
-    /// guarded by `child_backfill_attempted`. Failures are not retried.
-    fn spawn_child_backfill_once(
+    /// Issues the one-per-parent-run `ancestor_run_id` list request, deduped
+    /// via `requested_child_runs_for`. Failures are not retried.
+    fn fetch_child_runs_once(
         &mut self,
         parent_task_id: AmbientAgentTaskId,
         ctx: &mut ModelContext<Self>,
     ) {
-        if !self.child_backfill_attempted.insert(parent_task_id) {
+        if !self.requested_child_runs_for.insert(parent_task_id) {
             return;
         }
 
@@ -1977,7 +1961,7 @@ impl AgentConversationsModel {
             move |model, result, ctx| match result {
                 Ok(tasks) => model.update_model_with_new_tasks(tasks, ctx),
                 Err(e) => {
-                    log::warn!("Failed to backfill child runs for {parent_task_id}: {e:#}");
+                    log::warn!("Failed to fetch child runs for {parent_task_id}: {e:#}");
                 }
             },
         );

--- a/app/src/ai/agent_conversations_model/entry.rs
+++ b/app/src/ai/agent_conversations_model/entry.rs
@@ -21,7 +21,7 @@ use crate::ai::ambient_agents::{
 use crate::ai::artifacts::Artifact;
 use crate::ai::blocklist::history_model::{AIConversationMetadata, BlocklistAIHistoryModel};
 use crate::ai::blocklist::orchestration_topology::{
-    aggregated_subtree_artifacts, conversation_id_shadowed_by_task,
+    SubtreeRoot, aggregated_subtree_artifacts, conversation_id_shadowed_by_task,
     orchestration_aware_conversation_status,
 };
 use crate::ai::conversation_navigation::ConversationNavigationData;
@@ -518,7 +518,7 @@ pub(super) fn entry_for_task(
             artifacts: aggregated_subtree_artifacts(
                 history_model,
                 tasks,
-                ConversationOrTaskId::TaskId(task.task_id),
+                SubtreeRoot::Task(task.task_id),
             ),
         },
         backing: AgentConversationBackingData {
@@ -637,7 +637,7 @@ fn entry_for_conversation_parts(
             artifacts: aggregated_subtree_artifacts(
                 history_model,
                 tasks,
-                ConversationOrTaskId::ConversationId(conversation_id),
+                SubtreeRoot::Conversation(conversation_id),
             ),
         },
         backing: AgentConversationBackingData {

--- a/app/src/ai/agent_conversations_model/entry.rs
+++ b/app/src/ai/agent_conversations_model/entry.rs
@@ -21,7 +21,7 @@ use crate::ai::ambient_agents::{
 use crate::ai::artifacts::Artifact;
 use crate::ai::blocklist::history_model::{AIConversationMetadata, BlocklistAIHistoryModel};
 use crate::ai::blocklist::orchestration_topology::{
-    OrchestrationRoot, aggregated_subtree_artifacts, conversation_id_shadowed_by_task,
+    aggregated_subtree_artifacts, conversation_id_shadowed_by_task,
     orchestration_aware_conversation_status,
 };
 use crate::ai::conversation_navigation::ConversationNavigationData;
@@ -518,7 +518,7 @@ pub(super) fn entry_for_task(
             artifacts: aggregated_subtree_artifacts(
                 history_model,
                 tasks,
-                OrchestrationRoot::Run(task),
+                ConversationOrTaskId::TaskId(task.task_id),
             ),
         },
         backing: AgentConversationBackingData {
@@ -637,7 +637,7 @@ fn entry_for_conversation_parts(
             artifacts: aggregated_subtree_artifacts(
                 history_model,
                 tasks,
-                OrchestrationRoot::Conversation(conversation_id),
+                ConversationOrTaskId::ConversationId(conversation_id),
             ),
         },
         backing: AgentConversationBackingData {

--- a/app/src/ai/agent_conversations_model/entry.rs
+++ b/app/src/ai/agent_conversations_model/entry.rs
@@ -21,7 +21,7 @@ use crate::ai::ambient_agents::{
 use crate::ai::artifacts::Artifact;
 use crate::ai::blocklist::history_model::{AIConversationMetadata, BlocklistAIHistoryModel};
 use crate::ai::blocklist::orchestration_topology::{
-    SubtreeRoot, aggregated_subtree_artifacts, conversation_id_shadowed_by_task,
+    SubtreeRoot, aggregated_subtree_artifacts, local_conversation_id_for_task,
     orchestration_aware_conversation_status,
 };
 use crate::ai::conversation_navigation::ConversationNavigationData;
@@ -445,7 +445,7 @@ pub(super) fn entry_for_task(
     history_model: &BlocklistAIHistoryModel,
     app: &AppContext,
 ) -> AgentConversationEntry {
-    let local_conversation_id = conversation_id_shadowed_by_task(task, history_model);
+    let local_conversation_id = local_conversation_id_for_task(task, history_model);
     let conversation_metadata =
         local_conversation_id.and_then(|id| history_model.get_conversation_metadata(&id));
     let server_conversation_token = task

--- a/app/src/ai/agent_conversations_model/entry.rs
+++ b/app/src/ai/agent_conversations_model/entry.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
 use session_sharing_protocol::common::SessionId;
@@ -18,10 +18,10 @@ use crate::ai::ambient_agents::{
     AgentSource, AmbientAgentLiveSessionState, AmbientAgentTask, AmbientAgentTaskId,
     ExecutionLocation,
 };
-use crate::ai::artifacts::{Artifact, merge_artifacts};
+use crate::ai::artifacts::Artifact;
 use crate::ai::blocklist::history_model::{AIConversationMetadata, BlocklistAIHistoryModel};
 use crate::ai::blocklist::orchestration_topology::{
-    aggregated_conversation_artifacts, conversation_subtree_artifact_lists,
+    OrchestrationRoot, aggregated_subtree_artifacts, conversation_id_shadowed_by_task,
     orchestration_aware_conversation_status,
 };
 use crate::ai::conversation_navigation::ConversationNavigationData;
@@ -300,27 +300,6 @@ impl AgentConversationEntry {
     }
 }
 
-/// Returns the local conversation ID represented by the given task, if this task and a
-/// conversation entry both point at the same underlying local run.
-///
-/// We first match using the orchestration agent ID (task ID / run ID under v2), and fall back
-/// to the server conversation token for cases where the task only carries conversation identity
-/// through `conversation_id`.
-pub(super) fn conversation_id_shadowed_by_task(
-    task: &AmbientAgentTask,
-    history_model: &BlocklistAIHistoryModel,
-) -> Option<AIConversationId> {
-    history_model
-        .conversation_id_for_agent_id(&task.run_id().to_string())
-        .or_else(|| {
-            task.conversation_id().and_then(|conversation_id| {
-                history_model.find_conversation_id_by_server_token(&ServerConversationToken::new(
-                    conversation_id.to_string(),
-                ))
-            })
-        })
-}
-
 pub(super) fn task_creator_name(task: &AmbientAgentTask, app: &AppContext) -> Option<String> {
     task.creator_display_name().or_else(|| {
         let uid = task.creator.as_ref().map(|creator| &creator.uid)?;
@@ -417,51 +396,6 @@ fn conversation_request_usage(
                 .get_conversation_metadata(&metadata.nav_data.id)
                 .and_then(|metadata| metadata.credits_spent)
         })
-}
-
-/// Borrowed artifact slices for a run and its transitive child runs, reading
-/// only in-memory task data. Child runs that aren't loaded contribute nothing.
-fn run_subtree_artifact_lists<'a>(
-    root: &'a AmbientAgentTask,
-    tasks: &'a HashMap<AmbientAgentTaskId, AmbientAgentTask>,
-) -> Vec<&'a [Artifact]> {
-    let mut visited = HashSet::from([root.task_id]);
-    let mut lists: Vec<&[Artifact]> = vec![&root.artifacts];
-    let mut queue: VecDeque<&String> = root.children.iter().collect();
-    while let Some(run_id) = queue.pop_front() {
-        let Ok(task_id) = run_id.parse::<AmbientAgentTaskId>() else {
-            continue;
-        };
-        if !visited.insert(task_id) {
-            continue;
-        }
-        let Some(task) = tasks.get(&task_id) else {
-            continue;
-        };
-        lists.push(&task.artifacts);
-        queue.extend(task.children.iter());
-    }
-    lists
-}
-
-/// Aggregated artifacts for a run: the run's own artifacts, its transitive
-/// child runs' artifacts, and the linked local conversation subtree's
-/// artifacts, deduped by identity. In-memory only — never fetches.
-pub(super) fn aggregated_run_artifacts(
-    task: &AmbientAgentTask,
-    tasks: &HashMap<AmbientAgentTaskId, AmbientAgentTask>,
-    local_conversation_id: Option<AIConversationId>,
-    history_model: &BlocklistAIHistoryModel,
-) -> Vec<Artifact> {
-    let mut lists = run_subtree_artifact_lists(task, tasks);
-    if let Some(conversation_id) = local_conversation_id {
-        lists.extend(conversation_subtree_artifact_lists(
-            history_model,
-            tasks,
-            conversation_id,
-        ));
-    }
-    merge_artifacts(lists)
 }
 
 fn principal_from_user_profile(profile: &UserProfileWithUID) -> AgentConversationPrincipal {
@@ -581,7 +515,11 @@ pub(super) fn entry_for_task(
                 .as_ref()
                 .and_then(|snapshot| snapshot.environment_id.clone()),
             harness: task_harness(task),
-            artifacts: aggregated_run_artifacts(task, tasks, local_conversation_id, history_model),
+            artifacts: aggregated_subtree_artifacts(
+                history_model,
+                tasks,
+                OrchestrationRoot::Run(task),
+            ),
         },
         backing: AgentConversationBackingData {
             has_loaded_conversation: local_conversation_id
@@ -696,7 +634,11 @@ fn entry_for_conversation_parts(
                 .and_then(|metadata| metadata.server_conversation_metadata.as_ref())
                 .map(|metadata| Harness::from(metadata.harness))
                 .or(Some(Harness::Oz)),
-            artifacts: aggregated_conversation_artifacts(history_model, tasks, conversation_id),
+            artifacts: aggregated_subtree_artifacts(
+                history_model,
+                tasks,
+                OrchestrationRoot::Conversation(conversation_id),
+            ),
         },
         backing: AgentConversationBackingData {
             has_loaded_conversation,

--- a/app/src/ai/agent_conversations_model/entry.rs
+++ b/app/src/ai/agent_conversations_model/entry.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+
 use chrono::{DateTime, Utc};
 use session_sharing_protocol::common::SessionId;
 use warp_cli::agent::Harness;
@@ -16,9 +18,11 @@ use crate::ai::ambient_agents::{
     AgentSource, AmbientAgentLiveSessionState, AmbientAgentTask, AmbientAgentTaskId,
     ExecutionLocation,
 };
-use crate::ai::artifacts::Artifact;
+use crate::ai::artifacts::{Artifact, merge_artifacts};
 use crate::ai::blocklist::history_model::{AIConversationMetadata, BlocklistAIHistoryModel};
-use crate::ai::blocklist::orchestration_topology::orchestration_aware_conversation_status;
+use crate::ai::blocklist::orchestration_topology::{
+    aggregated_conversation_artifacts, orchestration_aware_conversation_status,
+};
 use crate::ai::conversation_navigation::ConversationNavigationData;
 use crate::auth::{AuthStateProvider, UserUid};
 use crate::util::time_format::human_readable_precise_duration;
@@ -414,19 +418,49 @@ fn conversation_request_usage(
         })
 }
 
-fn conversation_artifacts(
-    metadata: &ConversationMetadata,
+/// Artifact lists for a run and its transitive child runs, reading only
+/// in-memory task data. Child runs that aren't loaded contribute nothing.
+fn run_subtree_artifact_lists(
+    root: &AmbientAgentTask,
+    tasks: &HashMap<AmbientAgentTaskId, AmbientAgentTask>,
+) -> Vec<Vec<Artifact>> {
+    let mut visited = HashSet::from([root.task_id]);
+    let mut lists = vec![root.artifacts.clone()];
+    let mut queue: VecDeque<&String> = root.children.iter().collect();
+    while let Some(run_id) = queue.pop_front() {
+        let Ok(task_id) = run_id.parse::<AmbientAgentTaskId>() else {
+            continue;
+        };
+        if !visited.insert(task_id) {
+            continue;
+        }
+        let Some(task) = tasks.get(&task_id) else {
+            continue;
+        };
+        lists.push(task.artifacts.clone());
+        queue.extend(task.children.iter());
+    }
+    lists
+}
+
+/// Aggregated artifacts for a run: the run's own artifacts, its transitive
+/// child runs' artifacts, and the linked local conversation subtree's
+/// artifacts, deduped by identity. In-memory only — never fetches.
+pub(super) fn aggregated_run_artifacts(
+    task: &AmbientAgentTask,
+    tasks: &HashMap<AmbientAgentTaskId, AmbientAgentTask>,
+    local_conversation_id: Option<AIConversationId>,
     history_model: &BlocklistAIHistoryModel,
 ) -> Vec<Artifact> {
-    history_model
-        .conversation(&metadata.nav_data.id)
-        .map(|conversation| conversation.artifacts().to_vec())
-        .or_else(|| {
-            history_model
-                .get_conversation_metadata(&metadata.nav_data.id)
-                .map(|metadata| metadata.artifacts.clone())
-        })
-        .unwrap_or_default()
+    let mut lists = run_subtree_artifact_lists(task, tasks);
+    if let Some(conversation_id) = local_conversation_id {
+        lists.push(aggregated_conversation_artifacts(
+            history_model,
+            tasks,
+            conversation_id,
+        ));
+    }
+    merge_artifacts(lists)
 }
 
 fn principal_from_user_profile(profile: &UserProfileWithUID) -> AgentConversationPrincipal {
@@ -472,6 +506,7 @@ fn conversation_creator(
 
 pub(super) fn entry_for_task(
     task: &AmbientAgentTask,
+    tasks: &HashMap<AmbientAgentTaskId, AmbientAgentTask>,
     history_model: &BlocklistAIHistoryModel,
     app: &AppContext,
 ) -> AgentConversationEntry {
@@ -545,7 +580,7 @@ pub(super) fn entry_for_task(
                 .as_ref()
                 .and_then(|snapshot| snapshot.environment_id.clone()),
             harness: task_harness(task),
-            artifacts: task.artifacts.clone(),
+            artifacts: aggregated_run_artifacts(task, tasks, local_conversation_id, history_model),
         },
         backing: AgentConversationBackingData {
             has_loaded_conversation: local_conversation_id
@@ -571,6 +606,7 @@ pub(super) fn entry_for_task(
 
 pub(super) fn entry_for_conversation(
     metadata: &ConversationMetadata,
+    tasks: &HashMap<AmbientAgentTaskId, AmbientAgentTask>,
     history_model: &BlocklistAIHistoryModel,
     app: &AppContext,
 ) -> AgentConversationEntry {
@@ -578,6 +614,7 @@ pub(super) fn entry_for_conversation(
     entry_for_conversation_parts(
         metadata.nav_data.clone(),
         conversation_metadata,
+        tasks,
         history_model,
         app,
     )
@@ -586,15 +623,17 @@ pub(super) fn entry_for_conversation(
 pub(super) fn entry_for_historical_metadata(
     metadata: &AIConversationMetadata,
     nav_data: ConversationNavigationData,
+    tasks: &HashMap<AmbientAgentTaskId, AmbientAgentTask>,
     history_model: &BlocklistAIHistoryModel,
     app: &AppContext,
 ) -> AgentConversationEntry {
-    entry_for_conversation_parts(nav_data, Some(metadata), history_model, app)
+    entry_for_conversation_parts(nav_data, Some(metadata), tasks, history_model, app)
 }
 
 fn entry_for_conversation_parts(
     nav_data: ConversationNavigationData,
     conversation_metadata: Option<&AIConversationMetadata>,
+    tasks: &HashMap<AmbientAgentTaskId, AmbientAgentTask>,
     history_model: &BlocklistAIHistoryModel,
     app: &AppContext,
 ) -> AgentConversationEntry {
@@ -656,7 +695,7 @@ fn entry_for_conversation_parts(
                 .and_then(|metadata| metadata.server_conversation_metadata.as_ref())
                 .map(|metadata| Harness::from(metadata.harness))
                 .or(Some(Harness::Oz)),
-            artifacts: conversation_artifacts(&metadata, history_model),
+            artifacts: aggregated_conversation_artifacts(history_model, tasks, conversation_id),
         },
         backing: AgentConversationBackingData {
             has_loaded_conversation,

--- a/app/src/ai/agent_conversations_model/entry.rs
+++ b/app/src/ai/agent_conversations_model/entry.rs
@@ -21,7 +21,8 @@ use crate::ai::ambient_agents::{
 use crate::ai::artifacts::{Artifact, merge_artifacts};
 use crate::ai::blocklist::history_model::{AIConversationMetadata, BlocklistAIHistoryModel};
 use crate::ai::blocklist::orchestration_topology::{
-    aggregated_conversation_artifacts, orchestration_aware_conversation_status,
+    aggregated_conversation_artifacts, conversation_subtree_artifact_lists,
+    orchestration_aware_conversation_status,
 };
 use crate::ai::conversation_navigation::ConversationNavigationData;
 use crate::auth::{AuthStateProvider, UserUid};
@@ -418,14 +419,14 @@ fn conversation_request_usage(
         })
 }
 
-/// Artifact lists for a run and its transitive child runs, reading only
-/// in-memory task data. Child runs that aren't loaded contribute nothing.
-fn run_subtree_artifact_lists(
-    root: &AmbientAgentTask,
-    tasks: &HashMap<AmbientAgentTaskId, AmbientAgentTask>,
-) -> Vec<Vec<Artifact>> {
+/// Borrowed artifact slices for a run and its transitive child runs, reading
+/// only in-memory task data. Child runs that aren't loaded contribute nothing.
+fn run_subtree_artifact_lists<'a>(
+    root: &'a AmbientAgentTask,
+    tasks: &'a HashMap<AmbientAgentTaskId, AmbientAgentTask>,
+) -> Vec<&'a [Artifact]> {
     let mut visited = HashSet::from([root.task_id]);
-    let mut lists = vec![root.artifacts.clone()];
+    let mut lists: Vec<&[Artifact]> = vec![&root.artifacts];
     let mut queue: VecDeque<&String> = root.children.iter().collect();
     while let Some(run_id) = queue.pop_front() {
         let Ok(task_id) = run_id.parse::<AmbientAgentTaskId>() else {
@@ -437,7 +438,7 @@ fn run_subtree_artifact_lists(
         let Some(task) = tasks.get(&task_id) else {
             continue;
         };
-        lists.push(task.artifacts.clone());
+        lists.push(&task.artifacts);
         queue.extend(task.children.iter());
     }
     lists
@@ -454,7 +455,7 @@ pub(super) fn aggregated_run_artifacts(
 ) -> Vec<Artifact> {
     let mut lists = run_subtree_artifact_lists(task, tasks);
     if let Some(conversation_id) = local_conversation_id {
-        lists.push(aggregated_conversation_artifacts(
+        lists.extend(conversation_subtree_artifact_lists(
             history_model,
             tasks,
             conversation_id,

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -670,7 +670,131 @@ fn create_test_model() -> AgentConversationsModel {
         task_fetch_state: Default::default(),
         rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
         dirty_since: None,
+        child_backfill_attempted: Default::default(),
     }
+}
+
+/// Convenience: a PR artifact with the given URL (the URL is the dedupe identity).
+fn pr_artifact(url: &str) -> Artifact {
+    Artifact::PullRequest {
+        url: url.to_string(),
+        branch: "main".to_string(),
+        repo: None,
+        number: None,
+    }
+}
+
+#[test]
+fn test_entry_for_task_aggregates_child_run_artifacts() {
+    App::test((), |mut app| async move {
+        add_entry_projection_test_models(&mut app);
+
+        let now = Utc::now();
+        let mut model = create_test_model();
+        let mut parent = create_test_task(&make_uuid(8300), "user-a", now);
+        let mut child = create_test_task(&make_uuid(8301), "user-a", now);
+
+        let parent_pr = pr_artifact("https://github.com/o/r/pull/1");
+        let child_pr = pr_artifact("https://github.com/o/r/pull/2");
+        parent.artifacts = vec![parent_pr.clone()];
+        // The child also re-reports the parent's PR; aggregation must dedupe.
+        child.artifacts = vec![child_pr.clone(), parent_pr.clone()];
+        parent.children = vec![child.task_id.to_string()];
+
+        model.tasks.insert(parent.task_id, parent.clone());
+        model.tasks.insert(child.task_id, child.clone());
+
+        app.update(|ctx| {
+            let parent_entry = model
+                .get_entry_by_id(&AgentConversationEntryId::AmbientRun(parent.task_id), ctx)
+                .expect("parent entry exists");
+            assert_eq!(
+                parent_entry.display.artifacts,
+                vec![parent_pr.clone(), child_pr.clone()]
+            );
+
+            // The child's own entry shows just its artifacts.
+            let child_entry = model
+                .get_entry_by_id(&AgentConversationEntryId::AmbientRun(child.task_id), ctx)
+                .expect("child entry exists");
+            assert_eq!(child_entry.display.artifacts, vec![child_pr, parent_pr]);
+        });
+    });
+}
+
+#[test]
+fn test_aggregated_conversation_artifacts_includes_remote_child_run_artifacts() {
+    App::test((), |mut app| async move {
+        add_entry_projection_test_models(&mut app);
+
+        let parent_id = AIConversationId::new();
+        let child_id = AIConversationId::new();
+        let child_run_id = make_uuid(8400);
+
+        let parent = create_restored_conversation(
+            parent_id,
+            "parent-root-task",
+            AgentConversationData {
+                server_conversation_token: None,
+                conversation_usage_metadata: None,
+                reverted_action_ids: None,
+                forked_from_server_conversation_token: None,
+                artifacts_json: None,
+                parent_agent_id: None,
+                agent_name: None,
+                orchestration_harness_type: None,
+                parent_conversation_id: None,
+                is_remote_child: false,
+                root_task_is_optimistic: None,
+                run_id: None,
+                autoexecute_override: None,
+                last_event_sequence: None,
+                pinned: false,
+            },
+        );
+        // Remote-child placeholder: linked to the parent and carrying the
+        // child run id, but with no locally-applied artifacts.
+        let child = create_restored_conversation(
+            child_id,
+            "child-root-task",
+            AgentConversationData {
+                server_conversation_token: None,
+                conversation_usage_metadata: None,
+                reverted_action_ids: None,
+                forked_from_server_conversation_token: None,
+                artifacts_json: None,
+                parent_agent_id: None,
+                agent_name: Some("remote-child".to_string()),
+                orchestration_harness_type: None,
+                parent_conversation_id: Some(parent_id.to_string()),
+                is_remote_child: true,
+                root_task_is_optimistic: None,
+                run_id: Some(child_run_id.clone()),
+                autoexecute_override: None,
+                last_event_sequence: None,
+                pinned: false,
+            },
+        );
+
+        BlocklistAIHistoryModel::handle(&app).update(&mut app, |model, ctx| {
+            model.restore_conversations(EntityId::new(), vec![parent, child], ctx);
+        });
+
+        let mut model = create_test_model();
+        let child_pr = pr_artifact("https://github.com/o/r/pull/9");
+        let mut child_task = create_test_task(&child_run_id, "user-a", Utc::now());
+        child_task.artifacts = vec![child_pr.clone()];
+        model.tasks.insert(child_task.task_id, child_task);
+
+        app.update(|ctx| {
+            // The remote child's artifacts only exist on its run record, yet
+            // the parent's subtree aggregation should surface them.
+            assert_eq!(
+                model.aggregated_conversation_artifacts(parent_id, ctx),
+                vec![child_pr]
+            );
+        });
+    });
 }
 
 #[test]

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -670,7 +670,7 @@ fn create_test_model() -> AgentConversationsModel {
         task_fetch_state: Default::default(),
         rtc_task_refresh_throttle_state: RtcTaskRefreshThrottleState::default(),
         dirty_since: None,
-        child_backfill_attempted: Default::default(),
+        requested_child_runs_for: Default::default(),
     }
 }
 

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -16,10 +16,11 @@ use super::entry::{
 use super::query::{DEFAULT_RESULT_COUNT, MAX_SEARCH_RESULTS};
 use super::{
     AgentConversationsModel, AgentConversationsModelEvent, AgentManagementFilters,
-    AgentRunDisplayStatus, ArtifactFilter, ConversationMetadata, ConversationUpdateKind,
-    EnvironmentFilter, HarnessFilter, InitialConversationLoadState, MAX_PERSONAL_TASKS,
-    MAX_TEAM_TASKS, OwnerFilter, RtcTaskRefreshThrottleState, StatusFilter, TaskFetchError,
-    TaskFetchState, query_conversation_entries, record_earliest_rtc_task_refresh_timestamp,
+    AgentRunDisplayStatus, ArtifactFilter, ChildRunsFetchState, ConversationMetadata,
+    ConversationUpdateKind, EnvironmentFilter, HarnessFilter, InitialConversationLoadState,
+    MAX_PERSONAL_TASKS, MAX_TEAM_TASKS, OwnerFilter, RtcTaskRefreshThrottleState, StatusFilter,
+    TaskFetchError, TaskFetchState, query_conversation_entries,
+    record_earliest_rtc_task_refresh_timestamp,
 };
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent::api::ServerConversationToken;
@@ -672,6 +673,152 @@ fn create_test_model() -> AgentConversationsModel {
         dirty_since: None,
         requested_child_runs_for: Default::default(),
     }
+}
+#[test]
+fn loaded_child_run_fetch_state_is_cleared_when_direct_children_change() {
+    App::test((), |mut app| async move {
+        let now = Utc::now();
+        let mut parent = create_test_task(&make_uuid(8200), "user-a", now);
+        let child_a = create_test_task(&make_uuid(8201), "user-a", now);
+        let child_b = create_test_task(&make_uuid(8202), "user-a", now);
+        parent.children = vec![child_a.task_id.to_string()];
+        let parent_task_id = parent.task_id;
+        let model_handle = app.add_singleton_model(|_| {
+            let mut model = create_test_model();
+            model.tasks.insert(parent_task_id, parent.clone());
+            model
+                .requested_child_runs_for
+                .insert(parent_task_id, ChildRunsFetchState::Loaded);
+            model
+        });
+
+        let mut updated_parent = parent.clone();
+        updated_parent.children.push(child_b.task_id.to_string());
+        model_handle.update(&mut app, |model, ctx| {
+            model.update_model_with_new_tasks(vec![updated_parent], ctx);
+        });
+
+        model_handle.read(&app, |model, _| {
+            assert!(!model.requested_child_runs_for.contains_key(&parent_task_id));
+        });
+    });
+}
+
+#[test]
+fn loaded_child_run_fetch_state_survives_non_topology_updates() {
+    App::test((), |mut app| async move {
+        let now = Utc::now();
+        let mut parent = create_test_task(&make_uuid(8210), "user-a", now);
+        let child = create_test_task(&make_uuid(8211), "user-a", now);
+        parent.children = vec![child.task_id.to_string()];
+        let parent_task_id = parent.task_id;
+        let model_handle = app.add_singleton_model(|_| {
+            let mut model = create_test_model();
+            model.tasks.insert(parent_task_id, parent.clone());
+            model
+                .requested_child_runs_for
+                .insert(parent_task_id, ChildRunsFetchState::Loaded);
+            model
+        });
+
+        let mut updated_parent = parent.clone();
+        updated_parent.title = "updated title".to_string();
+        model_handle.update(&mut app, |model, ctx| {
+            model.update_model_with_new_tasks(vec![updated_parent], ctx);
+        });
+
+        model_handle.read(&app, |model, _| {
+            assert!(matches!(
+                model.requested_child_runs_for.get(&parent_task_id),
+                Some(ChildRunsFetchState::Loaded)
+            ));
+        });
+    });
+}
+
+#[test]
+fn loaded_child_run_fetch_state_survives_child_task_updates() {
+    App::test((), |mut app| async move {
+        let now = Utc::now();
+        let mut parent = create_test_task(&make_uuid(8220), "user-a", now);
+        let child = create_test_task(&make_uuid(8221), "user-a", now);
+        parent.children = vec![child.task_id.to_string()];
+        let parent_task_id = parent.task_id;
+        let model_handle = app.add_singleton_model(|_| {
+            let mut model = create_test_model();
+            model.tasks.insert(parent_task_id, parent.clone());
+            model.tasks.insert(child.task_id, child.clone());
+            model
+                .requested_child_runs_for
+                .insert(parent_task_id, ChildRunsFetchState::Loaded);
+            model
+        });
+
+        let mut updated_child = child.clone();
+        updated_child.title = "updated child title".to_string();
+        model_handle.update(&mut app, |model, ctx| {
+            model.update_model_with_new_tasks(vec![updated_child], ctx);
+        });
+
+        model_handle.read(&app, |model, _| {
+            assert!(matches!(
+                model.requested_child_runs_for.get(&parent_task_id),
+                Some(ChildRunsFetchState::Loaded)
+            ));
+        });
+    });
+}
+
+#[test]
+fn topology_changes_preserve_non_loaded_child_run_fetch_state() {
+    App::test((), |mut app| async move {
+        let now = Utc::now();
+        let mut parent = create_test_task(&make_uuid(8240), "user-a", now);
+        let child_a = create_test_task(&make_uuid(8241), "user-a", now);
+        let child_b = create_test_task(&make_uuid(8242), "user-a", now);
+        parent.children = vec![child_a.task_id.to_string()];
+        let parent_task_id = parent.task_id;
+        let model_handle = app.add_singleton_model(|_| {
+            let mut model = create_test_model();
+            model.tasks.insert(parent_task_id, parent.clone());
+            model
+                .requested_child_runs_for
+                .insert(parent_task_id, ChildRunsFetchState::InFlight);
+            model
+        });
+
+        let mut updated_parent = parent.clone();
+        updated_parent.children.push(child_b.task_id.to_string());
+        model_handle.update(&mut app, |model, ctx| {
+            model.update_model_with_new_tasks(vec![updated_parent.clone()], ctx);
+        });
+
+        model_handle.read(&app, |model, _| {
+            assert!(matches!(
+                model.requested_child_runs_for.get(&parent_task_id),
+                Some(ChildRunsFetchState::InFlight)
+            ));
+        });
+
+        model_handle.update(&mut app, |model, _| {
+            model.requested_child_runs_for.insert(
+                parent_task_id,
+                ChildRunsFetchState::FailedAt(Instant::now()),
+            );
+        });
+        let mut updated_parent_again = updated_parent;
+        updated_parent_again.children.push(make_uuid(8243));
+        model_handle.update(&mut app, |model, ctx| {
+            model.update_model_with_new_tasks(vec![updated_parent_again], ctx);
+        });
+
+        model_handle.read(&app, |model, _| {
+            assert!(matches!(
+                model.requested_child_runs_for.get(&parent_task_id),
+                Some(ChildRunsFetchState::FailedAt(_))
+            ));
+        });
+    });
 }
 
 /// Convenience: a PR artifact with the given URL (the URL is the dedupe identity).

--- a/app/src/ai/agent_management/view.rs
+++ b/app/src/ai/agent_management/view.rs
@@ -1359,9 +1359,10 @@ impl AgentManagementView {
         });
     }
 
-    /// Update just the artifact buttons for a specific conversation.
-    /// Also refreshes cards for the conversation's orchestration ancestors,
-    /// since parent cards display aggregated subtree artifacts.
+    /// Update the artifact buttons for a specific conversation and its
+    /// orchestration ancestors (parent cards display aggregated subtree
+    /// artifacts). Each card is updated at most once per call, and cards
+    /// whose artifacts are unchanged no-op in `update_artifacts`.
     fn update_artifacts_for_conversation(
         &mut self,
         conversation_id: AIConversationId,

--- a/app/src/ai/agent_management/view.rs
+++ b/app/src/ai/agent_management/view.rs
@@ -55,7 +55,8 @@ use crate::ai::agent_management::telemetry::{
 };
 use crate::ai::ambient_agents::{AgentSource, cancel_task_with_toast};
 use crate::ai::artifacts::{Artifact, ArtifactButtonsRow, ArtifactButtonsRowEvent};
-use crate::ai::blocklist::format_credits;
+use crate::ai::blocklist::orchestration_topology::conversation_and_ancestors;
+use crate::ai::blocklist::{BlocklistAIHistoryModel, format_credits};
 use crate::ai::conversation_details_panel::{
     ConversationDetailsData, ConversationDetailsPanel, ConversationDetailsPanelEvent,
 };
@@ -1358,32 +1359,45 @@ impl AgentManagementView {
         });
     }
 
-    /// Update just the artifact buttons for a specific conversation
+    /// Update just the artifact buttons for a specific conversation.
+    /// Also refreshes cards for the conversation's orchestration ancestors,
+    /// since parent cards display aggregated subtree artifacts.
     fn update_artifacts_for_conversation(
         &mut self,
         conversation_id: AIConversationId,
         ctx: &mut ViewContext<Self>,
     ) {
         let model = AgentConversationsModel::as_ref(ctx);
-        let Some((index, entry)) = self.items.iter().enumerate().find_map(|(index, card)| {
-            let entry = model.get_entry_by_id(&card.item_id, ctx)?;
-            (entry.identity.local_conversation_id == Some(conversation_id))
-                .then_some((index, entry))
-        }) else {
+        let affected_conversation_ids =
+            conversation_and_ancestors(BlocklistAIHistoryModel::as_ref(ctx), conversation_id);
+        let updates: Vec<(usize, Vec<Artifact>)> = self
+            .items
+            .iter()
+            .enumerate()
+            .filter_map(|(index, card)| {
+                let entry = model.get_entry_by_id(&card.item_id, ctx)?;
+                let local_conversation_id = entry.identity.local_conversation_id?;
+                affected_conversation_ids
+                    .contains(&local_conversation_id)
+                    .then_some((index, entry.display.artifacts))
+            })
+            .collect();
+        if updates.is_empty() {
             return;
-        };
-        let artifacts = entry.display.artifacts;
+        }
 
-        // Update the artifact buttons for this card
-        if should_show_artifacts(&artifacts) {
-            if let Some(view) = &self.items[index].artifact_buttons_view {
-                view.update(ctx, |v, ctx| v.update_artifacts(&artifacts, ctx));
+        for (index, artifacts) in updates {
+            // Update the artifact buttons for this card
+            if should_show_artifacts(&artifacts) {
+                if let Some(view) = &self.items[index].artifact_buttons_view {
+                    view.update(ctx, |v, ctx| v.update_artifacts(&artifacts, ctx));
+                } else {
+                    let new_view = self.create_artifact_buttons_view(&artifacts, ctx);
+                    self.items[index].artifact_buttons_view = Some(new_view);
+                }
             } else {
-                let new_view = self.create_artifact_buttons_view(&artifacts, ctx);
-                self.items[index].artifact_buttons_view = Some(new_view);
+                self.items[index].artifact_buttons_view = None;
             }
-        } else {
-            self.items[index].artifact_buttons_view = None;
         }
         ctx.notify();
     }

--- a/app/src/ai/artifacts/buttons.rs
+++ b/app/src/ai/artifacts/buttons.rs
@@ -17,6 +17,7 @@ const BUTTON_MAX_TEXT_WIDTH: f32 = 200.;
 
 /// A view that renders a set of artifact buttons (plans, branches, PRs)
 pub struct ArtifactButtonsRow {
+    artifacts: Vec<Artifact>,
     buttons: Vec<ViewHandle<ActionButton>>,
     theme: Arc<dyn ActionButtonTheme>,
 }
@@ -25,6 +26,7 @@ impl ArtifactButtonsRow {
     pub fn new(artifacts: &[Artifact], ctx: &mut ViewContext<Self>) -> Self {
         let theme: Arc<dyn ActionButtonTheme> = Arc::new(SecondaryTheme);
         Self {
+            artifacts: artifacts.to_vec(),
             buttons: collect_buttons(artifacts, &theme, ctx),
             theme,
         }
@@ -36,12 +38,20 @@ impl ArtifactButtonsRow {
         ctx: &mut ViewContext<Self>,
     ) -> Self {
         Self {
+            artifacts: artifacts.to_vec(),
             buttons: collect_buttons(artifacts, &theme, ctx),
             theme,
         }
     }
 
+    /// Rebuilds the buttons for `artifacts`. No-ops when the artifacts are
+    /// unchanged, so redundant refreshes (e.g. several children reporting
+    /// into the same ancestor card) skip the rebuild and re-render.
     pub fn update_artifacts(&mut self, artifacts: &[Artifact], ctx: &mut ViewContext<Self>) {
+        if self.artifacts == artifacts {
+            return;
+        }
+        self.artifacts = artifacts.to_vec();
         self.buttons = collect_buttons(artifacts, &self.theme, ctx);
         ctx.notify();
     }

--- a/app/src/ai/artifacts/buttons.rs
+++ b/app/src/ai/artifacts/buttons.rs
@@ -15,6 +15,11 @@ use crate::view_components::action_button::{
 const BUTTON_SPACING: f32 = 8.;
 const BUTTON_MAX_TEXT_WIDTH: f32 = 200.;
 
+/// Maximum number of artifact pills rendered before collapsing the remainder
+/// into a single "+N more" indicator, so an orchestration tree with many
+/// artifacts (e.g. 100 PRs) doesn't flood the row.
+const MAX_VISIBLE_ARTIFACT_BUTTONS: usize = 25;
+
 /// A view that renders a set of artifact buttons (plans, branches, PRs)
 pub struct ArtifactButtonsRow {
     artifacts: Vec<Artifact>,
@@ -212,7 +217,26 @@ fn collect_buttons(
         }));
     }
 
+    if buttons.len() > MAX_VISIBLE_ARTIFACT_BUTTONS {
+        let hidden_count = buttons.len() - MAX_VISIBLE_ARTIFACT_BUTTONS;
+        buttons.truncate(MAX_VISIBLE_ARTIFACT_BUTTONS);
+        let theme = theme.clone();
+        buttons.push(ctx.add_typed_action_view(move |_| make_overflow_button(hidden_count, theme)));
+    }
+
     buttons
+}
+
+/// Builds the non-interactive "+N more" pill shown when the artifact count
+/// exceeds [`MAX_VISIBLE_ARTIFACT_BUTTONS`]. Has no click handler; users open
+/// the run itself to see the full artifact set.
+fn make_overflow_button(hidden_count: usize, theme: Arc<dyn ActionButtonTheme>) -> ActionButton {
+    ActionButton::new_with_boxed_theme(format!("+{hidden_count} more"), theme)
+        .with_size(ButtonSize::Small)
+        .with_tooltip("Open this run to see all artifacts")
+        .with_tooltip_alignment(TooltipAlignment::Center)
+        .with_tooltip_positioning_provider(Arc::new(MenuPositioning::BelowInputBox))
+        .with_max_label_width(BUTTON_MAX_TEXT_WIDTH)
 }
 
 fn make_plan_button(

--- a/app/src/ai/artifacts/buttons.rs
+++ b/app/src/ai/artifacts/buttons.rs
@@ -2,12 +2,17 @@ use std::sync::Arc;
 
 use warp_core::ui::icons::Icon;
 use warp_core::ui::theme::AnsiColorIdentifier;
-use warpui::elements::{ChildView, Element, Empty, ParentElement, Wrap};
-use warpui::{AppContext, Entity, TypedActionView, View, ViewContext, ViewHandle};
+use warpui::elements::{
+    ChildView, Container, CrossAxisAlignment, Element, Empty, Flex, MainAxisSize, ParentElement,
+    Text, Wrap,
+};
+use warpui::{AppContext, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle};
 
 use super::{Artifact, file_button_label};
+use crate::appearance::Appearance;
 use crate::notebooks::NotebookId;
 use crate::terminal::input::MenuPositioning;
+use crate::ui_components::blended_colors;
 use crate::view_components::action_button::{
     ActionButton, ActionButtonTheme, ButtonSize, SecondaryTheme, TooltipAlignment,
 };
@@ -92,18 +97,51 @@ impl View for ArtifactButtonsRow {
         "ArtifactButtonsRow"
     }
 
-    fn render(&self, _: &AppContext) -> Box<dyn Element> {
+    fn render(&self, app: &AppContext) -> Box<dyn Element> {
         if self.buttons.is_empty() {
             return Empty::new().finish();
         }
 
-        Wrap::row()
+        let pills = Wrap::row()
             .with_spacing(BUTTON_SPACING)
             .with_run_spacing(BUTTON_SPACING)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_children(
                 self.buttons
                     .iter()
+                    .take(MAX_VISIBLE_ARTIFACT_BUTTONS)
                     .map(|button| ChildView::new(button).finish()),
+            )
+            .finish();
+
+        let hidden_count = self
+            .buttons
+            .len()
+            .saturating_sub(MAX_VISIBLE_ARTIFACT_BUTTONS);
+        if hidden_count == 0 {
+            return pills;
+        }
+
+        // Plain, muted text on its own line below the pills — deliberately not a
+        // button/chip, so it has no hover or click affordance.
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+        let more_label = Text::new(
+            format!("+{hidden_count} more"),
+            appearance.ui_font_family(),
+            appearance.ui_font_size(),
+        )
+        .with_color(blended_colors::text_sub(theme, theme.surface_1()))
+        .finish();
+
+        Flex::column()
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_cross_axis_alignment(CrossAxisAlignment::Start)
+            .with_child(pills)
+            .with_child(
+                Container::new(more_label)
+                    .with_margin_top(BUTTON_SPACING)
+                    .finish(),
             )
             .finish()
     }
@@ -217,26 +255,7 @@ fn collect_buttons(
         }));
     }
 
-    if buttons.len() > MAX_VISIBLE_ARTIFACT_BUTTONS {
-        let hidden_count = buttons.len() - MAX_VISIBLE_ARTIFACT_BUTTONS;
-        buttons.truncate(MAX_VISIBLE_ARTIFACT_BUTTONS);
-        let theme = theme.clone();
-        buttons.push(ctx.add_typed_action_view(move |_| make_overflow_button(hidden_count, theme)));
-    }
-
     buttons
-}
-
-/// Builds the non-interactive "+N more" pill shown when the artifact count
-/// exceeds [`MAX_VISIBLE_ARTIFACT_BUTTONS`]. Has no click handler; users open
-/// the run itself to see the full artifact set.
-fn make_overflow_button(hidden_count: usize, theme: Arc<dyn ActionButtonTheme>) -> ActionButton {
-    ActionButton::new_with_boxed_theme(format!("+{hidden_count} more"), theme)
-        .with_size(ButtonSize::Small)
-        .with_tooltip("Open this run to see all artifacts")
-        .with_tooltip_alignment(TooltipAlignment::Center)
-        .with_tooltip_positioning_provider(Arc::new(MenuPositioning::BelowInputBox))
-        .with_max_label_width(BUTTON_MAX_TEXT_WIDTH)
 }
 
 fn make_plan_button(

--- a/app/src/ai/artifacts/mod.rs
+++ b/app/src/ai/artifacts/mod.rs
@@ -293,14 +293,15 @@ impl Artifact {
     }
 }
 
-/// Merges artifact lists into a flat, order-preserving list deduped by
-/// [`Artifact::identity`]; the first occurrence wins.
-pub fn merge_artifacts(lists: impl IntoIterator<Item = Vec<Artifact>>) -> Vec<Artifact> {
+/// Merges borrowed artifact lists into a flat, order-preserving list deduped
+/// by [`Artifact::identity`]; the first occurrence wins. Only kept artifacts
+/// are cloned.
+pub fn merge_artifacts<'a>(lists: impl IntoIterator<Item = &'a [Artifact]>) -> Vec<Artifact> {
     let mut seen = HashSet::new();
     let mut merged = Vec::new();
     for artifact in lists.into_iter().flatten() {
-        if seen.insert(artifact.identity().to_string()) {
-            merged.push(artifact);
+        if seen.insert(artifact.identity()) {
+            merged.push(artifact.clone());
         }
     }
     merged

--- a/app/src/ai/artifacts/mod.rs
+++ b/app/src/ai/artifacts/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::Path;
 #[cfg(feature = "local_fs")]
 use std::path::PathBuf;
@@ -275,6 +276,34 @@ impl TryFrom<warp_graphql::ai::AIConversationArtifact> for Artifact {
             warp_graphql::ai::AIConversationArtifact::Unknown => Err(()),
         }
     }
+}
+
+impl Artifact {
+    /// Stable identity key used to dedupe the same artifact reported by
+    /// multiple conversations/runs (e.g. a child's PR copied to the parent
+    /// on fork/handoff).
+    fn identity(&self) -> &str {
+        match self {
+            Artifact::Plan { document_uid, .. } => document_uid,
+            Artifact::PullRequest { url, .. } | Artifact::ExternalReference { url, .. } => url,
+            Artifact::Screenshot { artifact_uid, .. } | Artifact::File { artifact_uid, .. } => {
+                artifact_uid
+            }
+        }
+    }
+}
+
+/// Merges artifact lists into a flat, order-preserving list deduped by
+/// [`Artifact::identity`]; the first occurrence wins.
+pub fn merge_artifacts(lists: impl IntoIterator<Item = Vec<Artifact>>) -> Vec<Artifact> {
+    let mut seen = HashSet::new();
+    let mut merged = Vec::new();
+    for artifact in lists.into_iter().flatten() {
+        if seen.insert(artifact.identity().to_string()) {
+            merged.push(artifact);
+        }
+    }
+    merged
 }
 
 /// Parse GitHub PR URL to extract repo and number.

--- a/app/src/ai/artifacts/mod_tests.rs
+++ b/app/src/ai/artifacts/mod_tests.rs
@@ -163,6 +163,51 @@ fn download_success_message_includes_filename_and_directory() {
 }
 
 #[test]
+fn merge_artifacts_dedupes_by_identity_and_preserves_order() {
+    let plan = Artifact::Plan {
+        document_uid: "doc-1".to_string(),
+        notebook_uid: None,
+        title: Some("Plan".to_string()),
+    };
+    // Same plan identity, different metadata: the first occurrence must win.
+    let plan_with_notebook = Artifact::Plan {
+        document_uid: "doc-1".to_string(),
+        notebook_uid: None,
+        title: Some("Plan (synced)".to_string()),
+    };
+    let pr = Artifact::PullRequest {
+        url: "https://github.com/o/r/pull/1".to_string(),
+        branch: "main".to_string(),
+        repo: None,
+        number: None,
+    };
+    let screenshot = Artifact::Screenshot {
+        artifact_uid: "shot-1".to_string(),
+        mime_type: "image/png".to_string(),
+        description: None,
+    };
+    let external_reference = Artifact::ExternalReference {
+        reference_type: "linear_issue".to_string(),
+        url: "https://linear.app/warp/issue/QUALITY-696".to_string(),
+        title: Some("Aggregate artifacts".to_string()),
+        metadata: None,
+    };
+    let updated_external_reference = Artifact::ExternalReference {
+        reference_type: "linear_issue".to_string(),
+        url: "https://linear.app/warp/issue/QUALITY-696".to_string(),
+        title: Some("Updated title".to_string()),
+        metadata: None,
+    };
+
+    let merged = merge_artifacts([
+        vec![plan.clone(), pr.clone(), external_reference.clone()],
+        vec![pr.clone(), screenshot.clone()],
+        vec![plan_with_notebook, updated_external_reference],
+    ]);
+    assert_eq!(merged, vec![plan, pr, external_reference, screenshot]);
+}
+
+#[test]
 fn converts_graphql_file_artifact() {
     let artifact = Artifact::try_from(warp_graphql::ai::AIConversationArtifact::FileArtifact(
         warp_graphql::ai::FileArtifact {

--- a/app/src/ai/artifacts/mod_tests.rs
+++ b/app/src/ai/artifacts/mod_tests.rs
@@ -199,11 +199,10 @@ fn merge_artifacts_dedupes_by_identity_and_preserves_order() {
         metadata: None,
     };
 
-    let merged = merge_artifacts([
-        vec![plan.clone(), pr.clone(), external_reference.clone()],
-        vec![pr.clone(), screenshot.clone()],
-        vec![plan_with_notebook, updated_external_reference],
-    ]);
+    let list_a = vec![plan.clone(), pr.clone(), external_reference.clone()];
+    let list_b = vec![pr.clone(), screenshot.clone()];
+    let list_c = vec![plan_with_notebook, updated_external_reference];
+    let merged = merge_artifacts([list_a.as_slice(), list_b.as_slice(), list_c.as_slice()]);
     assert_eq!(merged, vec![plan, pr, external_reference, screenshot]);
 }
 

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -7,7 +7,11 @@
 //! tree without duplicating the logic.
 use std::collections::HashSet;
 
+use std::collections::HashMap;
+
 use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
+use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskId};
+use crate::ai::artifacts::{Artifact, merge_artifacts};
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -466,6 +470,75 @@ fn aggregate_loaded_subtree(
         ConversationStatus::Success
     };
     (loaded_descendant_count, status)
+}
+
+/// Returns the artifacts for the orchestration tree rooted at `root_id`:
+/// the root's artifacts followed by each descendant's in spawn order,
+/// deduped by artifact identity (first occurrence wins).
+///
+/// Each node contributes its conversation artifacts (falling back to cached
+/// historical metadata when not loaded) plus the artifacts on its backing
+/// run record in `tasks`. The run record matters for remote children: their
+/// artifact events are never applied to the local placeholder conversation,
+/// so the run is the only local source. Reads only in-memory state — never
+/// fetches. For non-orchestration conversations this degrades to the
+/// conversation's own artifacts.
+pub fn aggregated_conversation_artifacts(
+    history: &BlocklistAIHistoryModel,
+    tasks: &HashMap<AmbientAgentTaskId, AmbientAgentTask>,
+    root_id: AIConversationId,
+) -> Vec<Artifact> {
+    let lists = std::iter::once(root_id)
+        .chain(descendant_conversation_ids_in_spawn_order(history, root_id))
+        .flat_map(|id| {
+            let conversation = history.conversation(&id);
+            let conversation_artifacts = conversation
+                .map(|conversation| conversation.artifacts().to_vec())
+                .or_else(|| {
+                    history
+                        .get_conversation_metadata(&id)
+                        .map(|metadata| metadata.artifacts.clone())
+                })
+                .unwrap_or_default();
+            let run_artifacts = conversation
+                .and_then(|conversation| conversation.task_id())
+                .and_then(|task_id| tasks.get(&task_id))
+                .map(|task| task.artifacts.clone())
+                .unwrap_or_default();
+            [conversation_artifacts, run_artifacts]
+        });
+    merge_artifacts(lists)
+}
+
+/// Returns `conversation_id` followed by its orchestration ancestors
+/// (nearest parent first), walking parent links on loaded conversations.
+pub fn conversation_and_ancestors(
+    history: &BlocklistAIHistoryModel,
+    conversation_id: AIConversationId,
+) -> Vec<AIConversationId> {
+    let mut chain = vec![conversation_id];
+    let mut current = conversation_id;
+    while let Some(parent) = history.conversation(&current).and_then(|conversation| {
+        history.resolved_parent_conversation_id_for_conversation(conversation)
+    }) {
+        // Guard against parent-link cycles.
+        if chain.contains(&parent) {
+            break;
+        }
+        chain.push(parent);
+        current = parent;
+    }
+    chain
+}
+
+/// Returns whether `conversation_id` is `root_id` itself or one of its
+/// descendants, by walking parent links upward from `conversation_id`.
+pub fn is_in_orchestration_subtree(
+    history: &BlocklistAIHistoryModel,
+    root_id: AIConversationId,
+    conversation_id: AIConversationId,
+) -> bool {
+    conversation_and_ancestors(history, conversation_id).contains(&root_id)
 }
 
 /// Returns a conversation's direct status, or the aggregated subtree status

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -485,21 +485,16 @@ pub(crate) enum SubtreeRoot {
     Task(AmbientAgentTaskId),
 }
 
-/// Returns the artifacts for the orchestration tree rooted at `root`, in
-/// pre-order and deduped by artifact identity (first occurrence wins).
+/// Returns the subtree's artifacts in pre-order, deduped by identity (first
+/// occurrence wins). Reads only in-memory state; never fetches.
 ///
-/// The same tree is stored from two sides — run records link children via
-/// [`AmbientAgentTask::children`], conversations via the parent → children
-/// index — and either side may be missing nodes (remote children often have
-/// no local conversation; local children may have no loaded run record), so
-/// the walk follows both edge types. Each node contributes its conversation
-/// artifacts (falling back to cached historical metadata when not loaded)
-/// followed by the artifacts on its run record in `tasks`. The run record
-/// matters for remote children: their artifact events are never applied to
-/// the local placeholder conversation, so the run is the only local source.
-/// Reads only in-memory state — never fetches; a `Task` root not present
-/// in `tasks` contributes nothing. For non-orchestration roots this degrades
-/// to the root's own artifacts.
+/// Walks both the run-record child links ([`AmbientAgentTask::children`]) and
+/// the conversation parent → children index, since either side may be missing
+/// nodes (remote children often lack a local conversation; local children may
+/// have no loaded run record). Each node contributes its conversation artifacts
+/// (or cached metadata when unloaded) plus its run record's artifacts — the
+/// only local source for a remote child's artifacts. A `Task` root absent from
+/// `tasks` contributes nothing.
 pub(crate) fn aggregated_subtree_artifacts<'a>(
     history: &'a BlocklistAIHistoryModel,
     tasks: &'a HashMap<AmbientAgentTaskId, AmbientAgentTask>,

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -8,7 +8,6 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::ai::active_agent_views_model::ConversationOrTaskId;
 use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
 use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskId};
@@ -165,23 +164,12 @@ pub fn descendant_conversation_ids_in_spawn_order(
     parent_id: AIConversationId,
 ) -> Vec<AIConversationId> {
     let mut descendants = Vec::new();
-    collect_descendant_conversation_ids_in_spawn_order(history, parent_id, &mut descendants);
+    let mut visited = HashSet::from([parent_id]);
+    collect_descendants_guarded(history, parent_id, &mut visited, &mut descendants);
     descendants
 }
 
-/// Recursive worker for [`descendant_conversation_ids_in_spawn_order`]. Kept
-/// separate so it can be invoked from existing call sites that already own a
-/// buffer.
-pub fn collect_descendant_conversation_ids_in_spawn_order(
-    history: &BlocklistAIHistoryModel,
-    parent_id: AIConversationId,
-    descendants: &mut Vec<AIConversationId>,
-) {
-    let mut visited = HashSet::from([parent_id]);
-    collect_descendants_guarded(history, parent_id, &mut visited, descendants);
-}
-
-/// Recursive worker for [`collect_descendant_conversation_ids_in_spawn_order`].
+/// Recursive worker for [`descendant_conversation_ids_in_spawn_order`].
 /// `visited` guards against cycles and diamonds in the parent/child index so a
 /// corrupted topology can't cause infinite recursion or duplicate entries.
 fn collect_descendants_guarded(
@@ -489,6 +477,14 @@ fn aggregate_loaded_subtree(
     (loaded_descendant_count, status)
 }
 
+/// Root of an orchestration subtree for [`aggregated_subtree_artifacts`]: either
+/// a local conversation or an ambient run record. Scoped to this helper so the
+/// low-level topology utilities don't depend on view-model identity types.
+pub(crate) enum SubtreeRoot {
+    Conversation(AIConversationId),
+    Task(AmbientAgentTaskId),
+}
+
 /// Returns the artifacts for the orchestration tree rooted at `root`, in
 /// pre-order and deduped by artifact identity (first occurrence wins).
 ///
@@ -501,13 +497,13 @@ fn aggregate_loaded_subtree(
 /// followed by the artifacts on its run record in `tasks`. The run record
 /// matters for remote children: their artifact events are never applied to
 /// the local placeholder conversation, so the run is the only local source.
-/// Reads only in-memory state — never fetches; a `TaskId` root not present
+/// Reads only in-memory state — never fetches; a `Task` root not present
 /// in `tasks` contributes nothing. For non-orchestration roots this degrades
 /// to the root's own artifacts.
 pub(crate) fn aggregated_subtree_artifacts<'a>(
     history: &'a BlocklistAIHistoryModel,
     tasks: &'a HashMap<AmbientAgentTaskId, AmbientAgentTask>,
-    root: ConversationOrTaskId,
+    root: SubtreeRoot,
 ) -> Vec<Artifact> {
     let mut walker = SubtreeArtifactWalker {
         history,
@@ -517,10 +513,8 @@ pub(crate) fn aggregated_subtree_artifacts<'a>(
         artifact_lists: Vec::new(),
     };
     match root {
-        ConversationOrTaskId::TaskId(task_id) => walker.visit(tasks.get(&task_id), None),
-        ConversationOrTaskId::ConversationId(conversation_id) => {
-            walker.visit(None, Some(conversation_id))
-        }
+        SubtreeRoot::Task(task_id) => walker.visit(tasks.get(&task_id), None),
+        SubtreeRoot::Conversation(conversation_id) => walker.visit(None, Some(conversation_id)),
     }
     merge_artifacts(walker.artifact_lists)
 }

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -543,7 +543,7 @@ impl<'a> SubtreeArtifactWalker<'a> {
         let history = self.history;
         let tasks = self.tasks;
         let conversation_id = conversation_id
-            .or_else(|| task.and_then(|task| conversation_id_shadowed_by_task(task, history)));
+            .or_else(|| task.and_then(|task| local_conversation_id_for_task(task, history)));
         let conversation = conversation_id.and_then(|id| history.conversation(&id));
         let task = task.or_else(|| {
             conversation
@@ -591,13 +591,13 @@ impl<'a> SubtreeArtifactWalker<'a> {
     }
 }
 
-/// Returns the local conversation ID represented by the given task, if this task and a
+/// Returns the local conversation ID that backs the given task, if this task and a
 /// conversation entry both point at the same underlying local run.
 ///
 /// We first match using the orchestration agent ID (task ID / run ID under v2), and fall back
 /// to the server conversation token for cases where the task only carries conversation identity
 /// through `conversation_id`.
-pub(crate) fn conversation_id_shadowed_by_task(
+pub(crate) fn local_conversation_id_for_task(
     task: &AmbientAgentTask,
     history_model: &BlocklistAIHistoryModel,
 ) -> Option<AIConversationId> {

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -5,9 +5,8 @@
 //! orchestration pill bar so other surfaces (e.g. keyboard navigation and
 //! the agent-mode usage footer's credit rollup) can walk and order the same
 //! tree without duplicating the logic.
-use std::collections::HashSet;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
 use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskId};
@@ -176,9 +175,25 @@ pub fn collect_descendant_conversation_ids_in_spawn_order(
     parent_id: AIConversationId,
     descendants: &mut Vec<AIConversationId>,
 ) {
+    let mut visited = HashSet::from([parent_id]);
+    collect_descendants_guarded(history, parent_id, &mut visited, descendants);
+}
+
+/// Recursive worker for [`collect_descendant_conversation_ids_in_spawn_order`].
+/// `visited` guards against cycles and diamonds in the parent/child index so a
+/// corrupted topology can't cause infinite recursion or duplicate entries.
+fn collect_descendants_guarded(
+    history: &BlocklistAIHistoryModel,
+    parent_id: AIConversationId,
+    visited: &mut HashSet<AIConversationId>,
+    descendants: &mut Vec<AIConversationId>,
+) {
     for child_id in history.child_conversation_ids_of(&parent_id) {
+        if !visited.insert(*child_id) {
+            continue;
+        }
         descendants.push(*child_id);
-        collect_descendant_conversation_ids_in_spawn_order(history, *child_id, descendants);
+        collect_descendants_guarded(history, *child_id, visited, descendants);
     }
 }
 
@@ -488,26 +503,38 @@ pub fn aggregated_conversation_artifacts(
     tasks: &HashMap<AmbientAgentTaskId, AmbientAgentTask>,
     root_id: AIConversationId,
 ) -> Vec<Artifact> {
-    let lists = std::iter::once(root_id)
+    merge_artifacts(conversation_subtree_artifact_lists(history, tasks, root_id))
+}
+
+/// Borrowed artifact slices contributed by the conversation subtree rooted at
+/// `root_id`, in spawn order: each node's conversation artifacts (falling back
+/// to cached historical metadata when not loaded) followed by the artifacts on
+/// its backing run record in `tasks`. Callers dedupe via [`merge_artifacts`].
+pub(crate) fn conversation_subtree_artifact_lists<'a>(
+    history: &'a BlocklistAIHistoryModel,
+    tasks: &'a HashMap<AmbientAgentTaskId, AmbientAgentTask>,
+    root_id: AIConversationId,
+) -> Vec<&'a [Artifact]> {
+    std::iter::once(root_id)
         .chain(descendant_conversation_ids_in_spawn_order(history, root_id))
         .flat_map(|id| {
             let conversation = history.conversation(&id);
             let conversation_artifacts = conversation
-                .map(|conversation| conversation.artifacts().to_vec())
+                .map(|conversation| conversation.artifacts())
                 .or_else(|| {
                     history
                         .get_conversation_metadata(&id)
-                        .map(|metadata| metadata.artifacts.clone())
+                        .map(|metadata| metadata.artifacts.as_slice())
                 })
                 .unwrap_or_default();
             let run_artifacts = conversation
                 .and_then(|conversation| conversation.task_id())
                 .and_then(|task_id| tasks.get(&task_id))
-                .map(|task| task.artifacts.clone())
+                .map(|task| task.artifacts.as_slice())
                 .unwrap_or_default();
             [conversation_artifacts, run_artifacts]
-        });
-    merge_artifacts(lists)
+        })
+        .collect()
 }
 
 /// Returns `conversation_id` followed by its orchestration ancestors

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -8,6 +8,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
 use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskId};
 use crate::ai::artifacts::{Artifact, merge_artifacts};
@@ -487,54 +488,139 @@ fn aggregate_loaded_subtree(
     (loaded_descendant_count, status)
 }
 
-/// Returns the artifacts for the orchestration tree rooted at `root_id`:
-/// the root's artifacts followed by each descendant's in spawn order,
-/// deduped by artifact identity (first occurrence wins).
-///
-/// Each node contributes its conversation artifacts (falling back to cached
-/// historical metadata when not loaded) plus the artifacts on its backing
-/// run record in `tasks`. The run record matters for remote children: their
-/// artifact events are never applied to the local placeholder conversation,
-/// so the run is the only local source. Reads only in-memory state — never
-/// fetches. For non-orchestration conversations this degrades to the
-/// conversation's own artifacts.
-pub fn aggregated_conversation_artifacts(
-    history: &BlocklistAIHistoryModel,
-    tasks: &HashMap<AmbientAgentTaskId, AmbientAgentTask>,
-    root_id: AIConversationId,
-) -> Vec<Artifact> {
-    merge_artifacts(conversation_subtree_artifact_lists(history, tasks, root_id))
+/// A root of an orchestration tree: either a server run record or a local
+/// conversation. The same tree is stored from two sides — run records link
+/// children via [`AmbientAgentTask::children`], conversations via the
+/// parent → children index — and either side may be missing nodes (remote
+/// children often have no local conversation; local children may have no
+/// loaded run record), so artifact aggregation walks both edge types.
+pub(crate) enum OrchestrationRoot<'a> {
+    Run(&'a AmbientAgentTask),
+    Conversation(AIConversationId),
 }
 
-/// Borrowed artifact slices contributed by the conversation subtree rooted at
-/// `root_id`, in spawn order: each node's conversation artifacts (falling back
-/// to cached historical metadata when not loaded) followed by the artifacts on
-/// its backing run record in `tasks`. Callers dedupe via [`merge_artifacts`].
-pub(crate) fn conversation_subtree_artifact_lists<'a>(
+/// Returns the artifacts for the orchestration tree rooted at `root`, in
+/// pre-order and deduped by artifact identity (first occurrence wins).
+///
+/// Each node contributes its conversation artifacts (falling back to cached
+/// historical metadata when not loaded) followed by the artifacts on its run
+/// record in `tasks`. The run record matters for remote children: their
+/// artifact events are never applied to the local placeholder conversation,
+/// so the run is the only local source. Reads only in-memory state — never
+/// fetches. For non-orchestration roots this degrades to the root's own
+/// artifacts.
+pub(crate) fn aggregated_subtree_artifacts<'a>(
     history: &'a BlocklistAIHistoryModel,
     tasks: &'a HashMap<AmbientAgentTaskId, AmbientAgentTask>,
-    root_id: AIConversationId,
-) -> Vec<&'a [Artifact]> {
-    std::iter::once(root_id)
-        .chain(descendant_conversation_ids_in_spawn_order(history, root_id))
-        .flat_map(|id| {
-            let conversation = history.conversation(&id);
-            let conversation_artifacts = conversation
+    root: OrchestrationRoot<'a>,
+) -> Vec<Artifact> {
+    let mut walker = SubtreeArtifactWalker {
+        history,
+        tasks,
+        visited_runs: HashSet::new(),
+        visited_conversations: HashSet::new(),
+        artifact_lists: Vec::new(),
+    };
+    match root {
+        OrchestrationRoot::Run(task) => walker.visit(Some(task), None),
+        OrchestrationRoot::Conversation(conversation_id) => {
+            walker.visit(None, Some(conversation_id))
+        }
+    }
+    merge_artifacts(walker.artifact_lists)
+}
+
+/// Pre-order DFS state for [`aggregated_subtree_artifacts`]. Each visit
+/// handles one agent node — the pairing of a run record and its linked local
+/// conversation — and the per-identity visited sets both guard against
+/// cycles and stop a node reached through one tree from contributing again
+/// when reached through the other.
+struct SubtreeArtifactWalker<'a> {
+    history: &'a BlocklistAIHistoryModel,
+    tasks: &'a HashMap<AmbientAgentTaskId, AmbientAgentTask>,
+    visited_runs: HashSet<AmbientAgentTaskId>,
+    visited_conversations: HashSet<AIConversationId>,
+    artifact_lists: Vec<&'a [Artifact]>,
+}
+
+impl<'a> SubtreeArtifactWalker<'a> {
+    /// Visits one node given whichever of its identities the caller knows,
+    /// resolving the other half through the run ↔ conversation links.
+    fn visit(
+        &mut self,
+        task: Option<&'a AmbientAgentTask>,
+        conversation_id: Option<AIConversationId>,
+    ) {
+        let history = self.history;
+        let tasks = self.tasks;
+        let conversation_id = conversation_id
+            .or_else(|| task.and_then(|task| conversation_id_shadowed_by_task(task, history)));
+        let conversation = conversation_id.and_then(|id| history.conversation(&id));
+        let task = task.or_else(|| {
+            conversation
+                .and_then(|conversation| conversation.task_id())
+                .and_then(|task_id| tasks.get(&task_id))
+        });
+
+        // `filter` doubles as the visited guard: an identity already seen
+        // contributes nothing and is not traversed again.
+        let new_conversation_id =
+            conversation_id.filter(|id| self.visited_conversations.insert(*id));
+        let new_task = task.filter(|task| self.visited_runs.insert(task.task_id));
+
+        if let Some(conversation_id) = new_conversation_id {
+            let artifacts = conversation
                 .map(|conversation| conversation.artifacts())
                 .or_else(|| {
                     history
-                        .get_conversation_metadata(&id)
+                        .get_conversation_metadata(&conversation_id)
                         .map(|metadata| metadata.artifacts.as_slice())
                 })
                 .unwrap_or_default();
-            let run_artifacts = conversation
-                .and_then(|conversation| conversation.task_id())
-                .and_then(|task_id| tasks.get(&task_id))
-                .map(|task| task.artifacts.as_slice())
-                .unwrap_or_default();
-            [conversation_artifacts, run_artifacts]
+            self.artifact_lists.push(artifacts);
+        }
+        if let Some(task) = new_task {
+            self.artifact_lists.push(&task.artifacts);
+        }
+
+        if let Some(conversation_id) = new_conversation_id {
+            for child_id in history.child_conversation_ids_of(&conversation_id) {
+                self.visit(None, Some(*child_id));
+            }
+        }
+        if let Some(task) = new_task {
+            for run_id in &task.children {
+                if let Some(child_task) = run_id
+                    .parse::<AmbientAgentTaskId>()
+                    .ok()
+                    .and_then(|id| tasks.get(&id))
+                {
+                    self.visit(Some(child_task), None);
+                }
+            }
+        }
+    }
+}
+
+/// Returns the local conversation ID represented by the given task, if this task and a
+/// conversation entry both point at the same underlying local run.
+///
+/// We first match using the orchestration agent ID (task ID / run ID under v2), and fall back
+/// to the server conversation token for cases where the task only carries conversation identity
+/// through `conversation_id`.
+pub(crate) fn conversation_id_shadowed_by_task(
+    task: &AmbientAgentTask,
+    history_model: &BlocklistAIHistoryModel,
+) -> Option<AIConversationId> {
+    history_model
+        .conversation_id_for_agent_id(&task.run_id().to_string())
+        .or_else(|| {
+            task.conversation_id().and_then(|conversation_id| {
+                history_model.find_conversation_id_by_server_token(&ServerConversationToken::new(
+                    conversation_id.to_string(),
+                ))
+            })
         })
-        .collect()
 }
 
 /// Returns `conversation_id` followed by its orchestration ancestors

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -8,6 +8,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+use crate::ai::active_agent_views_model::ConversationOrTaskId;
 use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
 use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskId};
@@ -488,31 +489,25 @@ fn aggregate_loaded_subtree(
     (loaded_descendant_count, status)
 }
 
-/// A root of an orchestration tree: either a server run record or a local
-/// conversation. The same tree is stored from two sides — run records link
-/// children via [`AmbientAgentTask::children`], conversations via the
-/// parent → children index — and either side may be missing nodes (remote
-/// children often have no local conversation; local children may have no
-/// loaded run record), so artifact aggregation walks both edge types.
-pub(crate) enum OrchestrationRoot<'a> {
-    Run(&'a AmbientAgentTask),
-    Conversation(AIConversationId),
-}
-
 /// Returns the artifacts for the orchestration tree rooted at `root`, in
 /// pre-order and deduped by artifact identity (first occurrence wins).
 ///
-/// Each node contributes its conversation artifacts (falling back to cached
-/// historical metadata when not loaded) followed by the artifacts on its run
-/// record in `tasks`. The run record matters for remote children: their
-/// artifact events are never applied to the local placeholder conversation,
-/// so the run is the only local source. Reads only in-memory state — never
-/// fetches. For non-orchestration roots this degrades to the root's own
-/// artifacts.
+/// The same tree is stored from two sides — run records link children via
+/// [`AmbientAgentTask::children`], conversations via the parent → children
+/// index — and either side may be missing nodes (remote children often have
+/// no local conversation; local children may have no loaded run record), so
+/// the walk follows both edge types. Each node contributes its conversation
+/// artifacts (falling back to cached historical metadata when not loaded)
+/// followed by the artifacts on its run record in `tasks`. The run record
+/// matters for remote children: their artifact events are never applied to
+/// the local placeholder conversation, so the run is the only local source.
+/// Reads only in-memory state — never fetches; a `TaskId` root not present
+/// in `tasks` contributes nothing. For non-orchestration roots this degrades
+/// to the root's own artifacts.
 pub(crate) fn aggregated_subtree_artifacts<'a>(
     history: &'a BlocklistAIHistoryModel,
     tasks: &'a HashMap<AmbientAgentTaskId, AmbientAgentTask>,
-    root: OrchestrationRoot<'a>,
+    root: ConversationOrTaskId,
 ) -> Vec<Artifact> {
     let mut walker = SubtreeArtifactWalker {
         history,
@@ -522,8 +517,8 @@ pub(crate) fn aggregated_subtree_artifacts<'a>(
         artifact_lists: Vec::new(),
     };
     match root {
-        OrchestrationRoot::Run(task) => walker.visit(Some(task), None),
-        OrchestrationRoot::Conversation(conversation_id) => {
+        ConversationOrTaskId::TaskId(task_id) => walker.visit(tasks.get(&task_id), None),
+        ConversationOrTaskId::ConversationId(conversation_id) => {
             walker.visit(None, Some(conversation_id))
         }
     }

--- a/app/src/ai/blocklist/orchestration_topology_tests.rs
+++ b/app/src/ai/blocklist/orchestration_topology_tests.rs
@@ -127,7 +127,7 @@ fn aggregated_subtree_artifacts_merges_conversation_subtree_and_dedupes() {
                 aggregated_subtree_artifacts(
                     history_model,
                     &tasks,
-                    OrchestrationRoot::Conversation(orchestrator_id)
+                    ConversationOrTaskId::ConversationId(orchestrator_id)
                 ),
                 vec![parent_pr.clone(), child_a_pr.clone(), child_b_pr],
             );
@@ -136,7 +136,7 @@ fn aggregated_subtree_artifacts_merges_conversation_subtree_and_dedupes() {
                 aggregated_subtree_artifacts(
                     history_model,
                     &tasks,
-                    OrchestrationRoot::Conversation(child_a)
+                    ConversationOrTaskId::ConversationId(child_a)
                 ),
                 vec![child_a_pr, parent_pr],
             );

--- a/app/src/ai/blocklist/orchestration_topology_tests.rs
+++ b/app/src/ai/blocklist/orchestration_topology_tests.rs
@@ -127,7 +127,7 @@ fn aggregated_subtree_artifacts_merges_conversation_subtree_and_dedupes() {
                 aggregated_subtree_artifacts(
                     history_model,
                     &tasks,
-                    ConversationOrTaskId::ConversationId(orchestrator_id)
+                    SubtreeRoot::Conversation(orchestrator_id)
                 ),
                 vec![parent_pr.clone(), child_a_pr.clone(), child_b_pr],
             );
@@ -136,7 +136,7 @@ fn aggregated_subtree_artifacts_merges_conversation_subtree_and_dedupes() {
                 aggregated_subtree_artifacts(
                     history_model,
                     &tasks,
-                    ConversationOrTaskId::ConversationId(child_a)
+                    SubtreeRoot::Conversation(child_a)
                 ),
                 vec![child_a_pr, parent_pr],
             );

--- a/app/src/ai/blocklist/orchestration_topology_tests.rs
+++ b/app/src/ai/blocklist/orchestration_topology_tests.rs
@@ -84,6 +84,118 @@ fn participant_resolution_uses_the_direct_parent_as_orchestrator() {
     });
 }
 
+/// Convenience: a PR artifact with the given URL (the URL is the dedupe identity).
+fn pr_artifact(url: &str) -> Artifact {
+    Artifact::PullRequest {
+        url: url.to_string(),
+        branch: "main".to_string(),
+        repo: None,
+        number: None,
+    }
+}
+
+#[test]
+fn aggregated_conversation_artifacts_merges_subtree_and_dedupes() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let (terminal_view_id, orchestrator_id, child_a, child_b) =
+            build_orchestrator_with_two_children(&mut app, &history_model);
+
+        let parent_pr = pr_artifact("https://github.com/o/r/pull/1");
+        let child_a_pr = pr_artifact("https://github.com/o/r/pull/2");
+        let child_b_pr = pr_artifact("https://github.com/o/r/pull/3");
+
+        history_model.update(&mut app, |history_model, ctx| {
+            for (conversation_id, artifact) in [
+                (orchestrator_id, parent_pr.clone()),
+                (child_a, child_a_pr.clone()),
+                // A child re-reporting the parent's PR must be deduped.
+                (child_a, parent_pr.clone()),
+                (child_b, child_b_pr.clone()),
+            ] {
+                history_model
+                    .conversation_mut(&conversation_id)
+                    .expect("conversation exists")
+                    .add_artifact(artifact, terminal_view_id, ctx);
+            }
+        });
+
+        history_model.read(&app, |history_model, _| {
+            let tasks = HashMap::new();
+            assert_eq!(
+                aggregated_conversation_artifacts(history_model, &tasks, orchestrator_id),
+                vec![parent_pr.clone(), child_a_pr.clone(), child_b_pr],
+            );
+            // A child's aggregation only covers its own subtree.
+            assert_eq!(
+                aggregated_conversation_artifacts(history_model, &tasks, child_a),
+                vec![child_a_pr, parent_pr],
+            );
+        });
+    });
+}
+
+#[test]
+fn conversation_ancestors_and_subtree_membership() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let terminal_view_id = EntityId::new();
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+
+        let orchestrator_id = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+        let child = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_child_conversation(
+                terminal_view_id,
+                "child".to_string(),
+                orchestrator_id,
+                None,
+                ctx,
+            )
+        });
+        let grandchild = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_child_conversation(
+                terminal_view_id,
+                "grandchild".to_string(),
+                child,
+                None,
+                ctx,
+            )
+        });
+        let unrelated = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+
+        history_model.read(&app, |history_model, _| {
+            assert_eq!(
+                conversation_and_ancestors(history_model, grandchild),
+                vec![grandchild, child, orchestrator_id],
+            );
+            assert!(is_in_orchestration_subtree(
+                history_model,
+                orchestrator_id,
+                grandchild
+            ));
+            assert!(is_in_orchestration_subtree(
+                history_model,
+                orchestrator_id,
+                orchestrator_id
+            ));
+            assert!(!is_in_orchestration_subtree(
+                history_model,
+                orchestrator_id,
+                unrelated
+            ));
+            assert!(!is_in_orchestration_subtree(
+                history_model,
+                child,
+                orchestrator_id
+            ));
+        });
+    });
+}
 #[test]
 fn pill_order_keys_prioritize_attention_then_in_progress_then_done() {
     let blocked = ConversationStatus::Blocked {

--- a/app/src/ai/blocklist/orchestration_topology_tests.rs
+++ b/app/src/ai/blocklist/orchestration_topology_tests.rs
@@ -95,7 +95,7 @@ fn pr_artifact(url: &str) -> Artifact {
 }
 
 #[test]
-fn aggregated_conversation_artifacts_merges_subtree_and_dedupes() {
+fn aggregated_subtree_artifacts_merges_conversation_subtree_and_dedupes() {
     App::test((), |mut app| async move {
         initialize_history_persistence_for_tests(&mut app);
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
@@ -124,12 +124,20 @@ fn aggregated_conversation_artifacts_merges_subtree_and_dedupes() {
         history_model.read(&app, |history_model, _| {
             let tasks = HashMap::new();
             assert_eq!(
-                aggregated_conversation_artifacts(history_model, &tasks, orchestrator_id),
+                aggregated_subtree_artifacts(
+                    history_model,
+                    &tasks,
+                    OrchestrationRoot::Conversation(orchestrator_id)
+                ),
                 vec![parent_pr.clone(), child_a_pr.clone(), child_b_pr],
             );
             // A child's aggregation only covers its own subtree.
             assert_eq!(
-                aggregated_conversation_artifacts(history_model, &tasks, child_a),
+                aggregated_subtree_artifacts(
+                    history_model,
+                    &tasks,
+                    OrchestrationRoot::Conversation(child_a)
+                ),
                 vec![child_a_pr, parent_pr],
             );
         });

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -752,6 +752,12 @@ impl ConversationDetailsPanel {
         }
     }
 
+    /// Artifacts currently displayed in the panel. Lets callers skip a
+    /// refresh when freshly aggregated artifacts are unchanged.
+    pub(crate) fn current_artifacts(&self) -> &[Artifact] {
+        &self.data.artifacts
+    }
+
     pub fn set_conversation_details(
         &mut self,
         data: ConversationDetailsData,

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -39,7 +39,7 @@ use crate::ai::agent::conversation::{
 };
 use crate::ai::agent_conversations_model::entry::PrincipalType;
 use crate::ai::agent_conversations_model::{
-    AgentConversationEntry, AgentRunDisplayStatus, TaskFetchError,
+    AgentConversationEntry, AgentConversationsModel, AgentRunDisplayStatus, TaskFetchError,
 };
 use crate::ai::agent_management::details_action_buttons::{
     ActionButtonsConfig, AgentDetailsButtonEvent, ConversationActionButtonsRow,
@@ -360,7 +360,10 @@ impl ConversationDetailsData {
             created_at,
             credits: Some(conversation.credits_spent()),
             run_time,
-            artifacts: conversation.artifacts().to_vec(),
+            // Parents of orchestrated conversations show artifacts for the
+            // whole subtree (their own + all descendants'), deduped.
+            artifacts: AgentConversationsModel::as_ref(app)
+                .aggregated_conversation_artifacts(conversation.id(), app),
             open_action: None,
             source_prompt: conversation.initial_query(),
             copy_link_url,
@@ -422,7 +425,9 @@ impl ConversationDetailsData {
             // whether to also show the short orchestrator label here.
             title: task.title.clone(),
             created_at: Some(task.created_at.with_timezone(&Local)),
-            artifacts: task.artifacts.clone(),
+            // Includes artifacts from child runs and the linked local
+            // conversation subtree, deduped.
+            artifacts: AgentConversationsModel::as_ref(app).aggregated_task_artifacts(task, app),
             credits,
             run_time: task.run_time(),
             open_action,

--- a/app/src/ai/conversation_details_panel_tests.rs
+++ b/app/src/ai/conversation_details_panel_tests.rs
@@ -58,7 +58,7 @@ fn create_test_task(task_id: &str) -> AmbientAgentTask {
 fn test_from_conversation_prefers_server_creator_profile() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
-        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
+        app.add_singleton_model(AgentConversationsModel::new);
         let conversation_id = AIConversationId::new();
         let mut conversation = create_restored_conversation(
             conversation_id,
@@ -219,7 +219,7 @@ fn test_from_task_includes_linked_directory_when_run_id_matches() {
     App::test((), |mut app| async move {
         let history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
-        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
+        app.add_singleton_model(AgentConversationsModel::new);
 
         let conversation_id = AIConversationId::new();
         let task_id = "550e8400-e29b-41d4-a716-000000004000";
@@ -302,7 +302,7 @@ fn test_from_task_resolves_harness() {
     App::test((), |mut app| async move {
         let _history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
-        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
+        app.add_singleton_model(AgentConversationsModel::new);
 
         // Base task has `agent_config_snapshot: None`; cloning lets us mutate per case.
         let base_task = create_test_task("550e8400-e29b-41d4-a716-000000004020");
@@ -342,8 +342,7 @@ fn test_from_task_aggregates_child_run_artifacts() {
     App::test((), |mut app| async move {
         let _history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
-        let conversations_model =
-            app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
+        let conversations_model = app.add_singleton_model(AgentConversationsModel::new);
 
         let pr_artifact = |url: &str| Artifact::PullRequest {
             url: url.to_string(),
@@ -378,7 +377,7 @@ fn test_from_task_populates_executor() {
     App::test((), |mut app| async move {
         let _history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
-        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
+        app.add_singleton_model(AgentConversationsModel::new);
         let mut task = create_test_task("550e8400-e29b-41d4-a716-000000004030");
         task.executor = Some(TaskPrincipalInfo {
             creator_type: "service_account".to_string(),
@@ -406,7 +405,7 @@ fn test_from_conversation_populates_local_conversation_fields() {
     App::test((), |mut app| async move {
         let history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
-        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
+        app.add_singleton_model(AgentConversationsModel::new);
 
         let conversation_id = AIConversationId::new();
         let directory = "/tmp/local-conversation-directory";
@@ -480,7 +479,7 @@ fn test_oz_run_url_present_for_task_and_absent_for_conversation() {
     App::test((), |mut app| async move {
         let _history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
-        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
+        app.add_singleton_model(AgentConversationsModel::new);
         let task_id = "550e8400-e29b-41d4-a716-000000004050";
         let task = create_test_task(task_id);
 
@@ -520,7 +519,7 @@ fn test_from_task_includes_linked_directory_when_server_token_matches() {
     App::test((), |mut app| async move {
         let history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
-        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
+        app.add_singleton_model(AgentConversationsModel::new);
 
         let conversation_id = AIConversationId::new();
         let server_token = "server-token-123";
@@ -573,7 +572,7 @@ fn test_from_task_includes_linked_directory_when_server_token_matches() {
 fn test_from_task_carries_the_runner_the_run_named() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
-        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
+        app.add_singleton_model(AgentConversationsModel::new);
 
         let mut task = create_test_task("550e8400-e29b-41d4-a716-000000005001");
         task.agent_config_snapshot = Some(AgentConfigSnapshot {
@@ -599,7 +598,7 @@ fn test_from_task_carries_the_runner_the_run_named() {
 fn test_from_task_leaves_the_runner_absent_when_the_run_names_none() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
-        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
+        app.add_singleton_model(AgentConversationsModel::new);
 
         let mut task = create_test_task("550e8400-e29b-41d4-a716-000000005002");
         task.agent_config_snapshot = Some(AgentConfigSnapshot {
@@ -626,7 +625,7 @@ fn test_from_task_leaves_the_runner_absent_when_the_run_names_none() {
 fn test_conversation_mode_carries_no_runner() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
-        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
+        app.add_singleton_model(AgentConversationsModel::new);
         let conversation_id = AIConversationId::new();
         let conversation = create_restored_conversation(
             conversation_id,

--- a/app/src/ai/conversation_details_panel_tests.rs
+++ b/app/src/ai/conversation_details_panel_tests.rs
@@ -11,8 +11,10 @@ use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::{
     AIAgentHarness, AIConversation, AIConversationId, ServerAIConversationMetadata,
 };
+use crate::ai::agent_conversations_model::AgentConversationsModel;
 use crate::ai::ambient_agents::task::{AgentConfigSnapshot, HarnessConfig, TaskPrincipalInfo};
 use crate::ai::ambient_agents::{AmbientAgentTask, AmbientAgentTaskState};
+use crate::ai::artifacts::Artifact;
 use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
 use crate::auth::UserUid;
 use crate::cloud_object::{Revision, ServerMetadata, ServerPermissions};
@@ -55,6 +57,8 @@ fn create_test_task(task_id: &str) -> AmbientAgentTask {
 #[test]
 fn test_from_conversation_prefers_server_creator_profile() {
     App::test((), |mut app| async move {
+        app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
         let conversation_id = AIConversationId::new();
         let mut conversation = create_restored_conversation(
             conversation_id,
@@ -215,6 +219,7 @@ fn test_from_task_includes_linked_directory_when_run_id_matches() {
     App::test((), |mut app| async move {
         let history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
 
         let conversation_id = AIConversationId::new();
         let task_id = "550e8400-e29b-41d4-a716-000000004000";
@@ -297,6 +302,7 @@ fn test_from_task_resolves_harness() {
     App::test((), |mut app| async move {
         let _history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
 
         // Base task has `agent_config_snapshot: None`; cloning lets us mutate per case.
         let base_task = create_test_task("550e8400-e29b-41d4-a716-000000004020");
@@ -332,10 +338,47 @@ fn test_from_task_resolves_harness() {
 }
 
 #[test]
+fn test_from_task_aggregates_child_run_artifacts() {
+    App::test((), |mut app| async move {
+        let _history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        let conversations_model =
+            app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
+
+        let pr_artifact = |url: &str| Artifact::PullRequest {
+            url: url.to_string(),
+            branch: "main".to_string(),
+            repo: None,
+            number: None,
+        };
+        let parent_pr = pr_artifact("https://github.com/o/r/pull/1");
+        let child_pr = pr_artifact("https://github.com/o/r/pull/2");
+
+        let mut parent = create_test_task("550e8400-e29b-41d4-a716-000000004040");
+        let mut child = create_test_task("550e8400-e29b-41d4-a716-000000004041");
+        parent.artifacts = vec![parent_pr.clone()];
+        // The child also re-reports the parent's PR; aggregation must dedupe.
+        child.artifacts = vec![child_pr.clone(), parent_pr.clone()];
+        parent.children = vec![child.task_id.to_string()];
+
+        conversations_model.update(&mut app, |model, _| {
+            model.insert_task_for_test(parent.clone());
+            model.insert_task_for_test(child);
+        });
+
+        app.update(|ctx| {
+            let data = ConversationDetailsData::from_task(&parent, None, None, ctx);
+            assert_eq!(data.artifacts, vec![parent_pr, child_pr]);
+        });
+    });
+}
+
+#[test]
 fn test_from_task_populates_executor() {
     App::test((), |mut app| async move {
         let _history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
         let mut task = create_test_task("550e8400-e29b-41d4-a716-000000004030");
         task.executor = Some(TaskPrincipalInfo {
             creator_type: "service_account".to_string(),
@@ -363,6 +406,7 @@ fn test_from_conversation_populates_local_conversation_fields() {
     App::test((), |mut app| async move {
         let history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
 
         let conversation_id = AIConversationId::new();
         let directory = "/tmp/local-conversation-directory";
@@ -436,6 +480,7 @@ fn test_oz_run_url_present_for_task_and_absent_for_conversation() {
     App::test((), |mut app| async move {
         let _history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
         let task_id = "550e8400-e29b-41d4-a716-000000004050";
         let task = create_test_task(task_id);
 
@@ -475,6 +520,7 @@ fn test_from_task_includes_linked_directory_when_server_token_matches() {
     App::test((), |mut app| async move {
         let history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
 
         let conversation_id = AIConversationId::new();
         let server_token = "server-token-123";
@@ -527,6 +573,7 @@ fn test_from_task_includes_linked_directory_when_server_token_matches() {
 fn test_from_task_carries_the_runner_the_run_named() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
 
         let mut task = create_test_task("550e8400-e29b-41d4-a716-000000005001");
         task.agent_config_snapshot = Some(AgentConfigSnapshot {
@@ -552,6 +599,7 @@ fn test_from_task_carries_the_runner_the_run_named() {
 fn test_from_task_leaves_the_runner_absent_when_the_run_names_none() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
 
         let mut task = create_test_task("550e8400-e29b-41d4-a716-000000005002");
         task.agent_config_snapshot = Some(AgentConfigSnapshot {
@@ -577,6 +625,8 @@ fn test_from_task_leaves_the_runner_absent_when_the_run_names_none() {
 #[test]
 fn test_conversation_mode_carries_no_runner() {
     App::test((), |mut app| async move {
+        app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+        app.add_singleton_model(|_| AgentConversationsModel::new_for_test());
         let conversation_id = AIConversationId::new();
         let conversation = create_restored_conversation(
             conversation_id,

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -880,6 +880,9 @@ pub(crate) fn build_rename_conversation_url(conversation_id: &str) -> String {
 
 struct ListRunsResponse {
     runs: Vec<AmbientAgentTask>,
+    /// Opaque cursor for the next page, from the server's `page_info.next_cursor`.
+    /// `None` once the result set is exhausted.
+    next_cursor: Option<String>,
 }
 
 impl<'de> serde::Deserialize<'de> for ListRunsResponse {
@@ -890,6 +893,14 @@ impl<'de> serde::Deserialize<'de> for ListRunsResponse {
         #[derive(serde::Deserialize)]
         struct RawResponse {
             runs: Vec<serde_json::Value>,
+            #[serde(default)]
+            page_info: Option<RawPageInfo>,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct RawPageInfo {
+            #[serde(default)]
+            next_cursor: Option<String>,
         }
 
         let raw = RawResponse::deserialize(deserializer)?;
@@ -905,7 +916,10 @@ impl<'de> serde::Deserialize<'de> for ListRunsResponse {
             }
         }
 
-        Ok(ListRunsResponse { runs })
+        Ok(ListRunsResponse {
+            runs,
+            next_cursor: raw.page_info.and_then(|page_info| page_info.next_cursor),
+        })
     }
 }
 
@@ -1269,6 +1283,16 @@ pub trait AIClient: 'static + Send + Sync {
         limit: i32,
         filter: TaskListFilter,
     ) -> anyhow::Result<Vec<AmbientAgentTask>, anyhow::Error>;
+
+    /// Fetches a single page of agent runs, returning the page's runs along with
+    /// the opaque `page_info.next_cursor` (`None` once the result set is
+    /// exhausted). Callers paginate by feeding the returned cursor back in via
+    /// [`TaskListFilter::cursor`].
+    async fn list_ambient_agent_tasks_page(
+        &self,
+        limit: i32,
+        filter: TaskListFilter,
+    ) -> anyhow::Result<(Vec<AmbientAgentTask>, Option<String>), anyhow::Error>;
 
     /// List agent runs and return the raw server JSON response.
     async fn list_agent_runs_raw(
@@ -2230,9 +2254,17 @@ impl AIClient for ServerApi {
         limit: i32,
         filter: TaskListFilter,
     ) -> anyhow::Result<Vec<AmbientAgentTask>, anyhow::Error> {
+        Ok(self.list_ambient_agent_tasks_page(limit, filter).await?.0)
+    }
+
+    async fn list_ambient_agent_tasks_page(
+        &self,
+        limit: i32,
+        filter: TaskListFilter,
+    ) -> anyhow::Result<(Vec<AmbientAgentTask>, Option<String>), anyhow::Error> {
         let url = build_list_agent_runs_url(limit, &filter);
         let response: ListRunsResponse = self.get_public_api(&url).await?;
-        Ok(response.runs)
+        Ok((response.runs, response.next_cursor))
     }
 
     async fn list_agent_runs_raw(

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -3714,14 +3714,12 @@ impl TerminalView {
                         .ambient_agent_view_model
                         .as_ref()
                         .is_some_and(|model| model.as_ref(ctx).is_ambient_agent());
-                    // Non-ambient panes refresh when an artifact update lands in
-                    // the active conversation's orchestration subtree, or when
-                    // task data changes the subtree's aggregated artifacts
-                    // (remote children report artifacts on their run records,
-                    // which arrive via task updates). Task events can only
-                    // affect the panel through artifacts, so unrelated task
-                    // updates are skipped by comparing against what the panel
-                    // already shows.
+
+                    // Non-ambient panes refresh only for artifact changes in
+                    // the active conversation's subtree: direct artifact
+                    // updates, or task updates that change the aggregated
+                    // artifacts (remote children report artifacts on their
+                    // run records).
                     let is_subtree_artifact_update = match event {
                         AgentConversationsModelEvent::ConversationArtifactsUpdated {
                             conversation_id,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -245,7 +245,9 @@ use crate::ai::blocklist::inline_action::code_diff_view::CodeDiffView;
 use crate::ai::blocklist::model::{
     AIBlockModel, AIBlockModelHelper, AIBlockModelImpl, AIBlockOutputStatus,
 };
-use crate::ai::blocklist::orchestration_topology::OrchestrationNavigationDirection;
+use crate::ai::blocklist::orchestration_topology::{
+    OrchestrationNavigationDirection, is_in_orchestration_subtree,
+};
 use crate::ai::blocklist::suggested_agent_mode_workflow_modal::SuggestedAgentModeWorkflowAndId;
 use crate::ai::blocklist::suggested_rule_modal::SuggestedRuleAndId;
 use crate::ai::blocklist::summarization_cancel_dialog::SummarizationCancelDialog;
@@ -3707,15 +3709,47 @@ impl TerminalView {
                         | AgentConversationsModelEvent::ConversationArtifactsUpdated { .. }
                 );
                 // Only refresh panel if it's currently open (avoids unnecessary work)
-                if should_refresh_details_panel
-                    && me.is_conversation_details_panel_open
-                    && me
+                if should_refresh_details_panel && me.is_conversation_details_panel_open {
+                    let is_ambient = me
                         .ambient_agent_view_model
                         .as_ref()
-                        .is_some_and(|model| model.as_ref(ctx).is_ambient_agent())
-                {
-                    me.fetch_and_update_conversation_details_panel(ctx);
-                    ctx.notify();
+                        .is_some_and(|model| model.as_ref(ctx).is_ambient_agent());
+                    // Non-ambient panes refresh when an artifact update lands in
+                    // the active conversation's orchestration subtree, or when
+                    // task data changes while the active conversation has
+                    // children (remote children report artifacts on their run
+                    // records, which arrive via task updates).
+                    let is_subtree_artifact_update = match event {
+                        AgentConversationsModelEvent::ConversationArtifactsUpdated {
+                            conversation_id,
+                        } => {
+                            let history = BlocklistAIHistoryModel::as_ref(ctx);
+                            history
+                                .active_conversation(me.view_id)
+                                .is_some_and(|active| {
+                                    is_in_orchestration_subtree(
+                                        history,
+                                        active.id(),
+                                        *conversation_id,
+                                    )
+                                })
+                        }
+                        AgentConversationsModelEvent::NewTasksReceived
+                        | AgentConversationsModelEvent::TasksUpdated => {
+                            let history = BlocklistAIHistoryModel::as_ref(ctx);
+                            history
+                                .active_conversation(me.view_id)
+                                .is_some_and(|active| {
+                                    !history.child_conversation_ids_of(&active.id()).is_empty()
+                                })
+                        }
+                        AgentConversationsModelEvent::ConversationsLoaded
+                        | AgentConversationsModelEvent::ConversationUpdated { .. } => false,
+                    };
+                    if is_ambient || is_subtree_artifact_update {
+                        me.fetch_and_update_conversation_details_panel(ctx);
+                        ctx.notify();
+                    }
                 }
             },
         );

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -3716,9 +3716,12 @@ impl TerminalView {
                         .is_some_and(|model| model.as_ref(ctx).is_ambient_agent());
                     // Non-ambient panes refresh when an artifact update lands in
                     // the active conversation's orchestration subtree, or when
-                    // task data changes while the active conversation has
-                    // children (remote children report artifacts on their run
-                    // records, which arrive via task updates).
+                    // task data changes the subtree's aggregated artifacts
+                    // (remote children report artifacts on their run records,
+                    // which arrive via task updates). Task events can only
+                    // affect the panel through artifacts, so unrelated task
+                    // updates are skipped by comparing against what the panel
+                    // already shows.
                     let is_subtree_artifact_update = match event {
                         AgentConversationsModelEvent::ConversationArtifactsUpdated {
                             conversation_id,
@@ -3741,6 +3744,12 @@ impl TerminalView {
                                 .active_conversation(me.view_id)
                                 .is_some_and(|active| {
                                     !history.child_conversation_ids_of(&active.id()).is_empty()
+                                        && AgentConversationsModel::as_ref(ctx)
+                                            .aggregated_conversation_artifacts(active.id(), ctx)
+                                            != me
+                                                .conversation_details_panel
+                                                .as_ref(ctx)
+                                                .current_artifacts()
                                 })
                         }
                         AgentConversationsModelEvent::ConversationsLoaded

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -964,7 +964,11 @@ impl TerminalView {
             let conversations_handle =
                 crate::ai::agent_conversations_model::AgentConversationsModel::handle(ctx);
             let task = conversations_handle.update(ctx, |model, ctx| {
-                model.get_or_async_fetch_task_data(&task_id, ctx)
+                let task = model.get_or_async_fetch_task_data(&task_id, ctx);
+                // Backfill missing child runs so the panel can aggregate their
+                // artifacts; at most one request per parent run per session.
+                model.ensure_child_tasks_loaded(&task_id, ctx);
+                task
             });
 
             let data = task
@@ -986,6 +990,24 @@ impl TerminalView {
         // No backing cloud task — populate from the active local conversation, if any.
         let view_id = self.id();
         let history_model = BlocklistAIHistoryModel::handle(ctx);
+        let Some(active_conversation_id) = history_model
+            .as_ref(ctx)
+            .active_conversation(view_id)
+            .map(|conversation| conversation.id())
+        else {
+            return;
+        };
+
+        // Backfill missing child runs (e.g. remote children of a local
+        // orchestrator) so the panel can aggregate their artifacts; at most
+        // one request per parent run per session.
+        crate::ai::agent_conversations_model::AgentConversationsModel::handle(ctx).update(
+            ctx,
+            |model, ctx| {
+                model.ensure_child_tasks_loaded_for_conversation(active_conversation_id, ctx);
+            },
+        );
+
         let data = history_model
             .as_ref(ctx)
             .active_conversation(view_id)

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -965,7 +965,7 @@ impl TerminalView {
                 crate::ai::agent_conversations_model::AgentConversationsModel::handle(ctx);
             let task = conversations_handle.update(ctx, |model, ctx| {
                 let task = model.get_or_async_fetch_task_data(&task_id, ctx);
-                // Backfill missing child runs so the panel can aggregate their
+                // Fetch missing child runs so the panel can aggregate their
                 // artifacts; at most one request per parent run per session.
                 model.ensure_child_tasks_loaded(&task_id, ctx);
                 task
@@ -998,7 +998,7 @@ impl TerminalView {
             return;
         };
 
-        // Backfill missing child runs (e.g. remote children of a local
+        // Fetch missing child runs (e.g. remote children of a local
         // orchestrator) so the panel can aggregate their artifacts; at most
         // one request per parent run per session.
         crate::ai::agent_conversations_model::AgentConversationsModel::handle(ctx).update(

--- a/app/src/workspace/view/wasm_view.rs
+++ b/app/src/workspace/view/wasm_view.rs
@@ -166,7 +166,7 @@ impl Workspace {
                 let conversations_model_handle = AgentConversationsModel::handle(ctx);
                 let task = conversations_model_handle.update(ctx, |conversations_model, ctx| {
                     let task = conversations_model.get_or_async_fetch_task_data(&task_id, ctx);
-                    // Backfill missing child runs so the panel can aggregate their
+                    // Fetch missing child runs so the panel can aggregate their
                     // artifacts; at most one request per parent run per session.
                     conversations_model.ensure_child_tasks_loaded(&task_id, ctx);
                     task

--- a/app/src/workspace/view/wasm_view.rs
+++ b/app/src/workspace/view/wasm_view.rs
@@ -165,7 +165,11 @@ impl Workspace {
             if let Some(task_id) = task_id {
                 let conversations_model_handle = AgentConversationsModel::handle(ctx);
                 let task = conversations_model_handle.update(ctx, |conversations_model, ctx| {
-                    conversations_model.get_or_async_fetch_task_data(&task_id, ctx)
+                    let task = conversations_model.get_or_async_fetch_task_data(&task_id, ctx);
+                    // Backfill missing child runs so the panel can aggregate their
+                    // artifacts; at most one request per parent run per session.
+                    conversations_model.ensure_child_tasks_loaded(&task_id, ctx);
+                    task
                 });
                 if let Some(task) = task {
                     let details = ConversationDetailsData::from_task(&task, None, None, ctx);


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

For orchestrated conversations, the parent agent's artifacts section in the info panel should hold all artifacts for every child agent (local and cloud), as these are all artifacts of the same overarching conversation.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/2a0187e632c34b4d9df86cd4e8be3cae

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode