### PR TITLE
Refresh settings editor text colors on appearance change

### DIFF
--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -48,8 +48,8 @@ use super::settings_page::{
     HEADER_PADDING, TOGGLE_BUTTON_RIGHT_PADDING,
 };
 use super::{
-    flags, SettingActionPairContexts, SettingActionPairDescriptions, SettingsAction,
-    SettingsSection, ToggleSettingActionPair,
+    editor_text_colors, flags, SettingActionPairContexts, SettingActionPairDescriptions,
+    SettingsAction, SettingsSection, ToggleSettingActionPair,
 };
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::aws_credentials::refresh_aws_credentials;
@@ -7498,6 +7498,24 @@ impl ApiKeysWidget {
             set_google_key,
             "AIzaSy..."
         );
+
+        // Editor text colors are snapshotted at construction via
+        // `text_colors_override`, so refresh them whenever the appearance
+        // (e.g. the theme) changes.
+        let api_key_editors = [
+            openai_api_key_editor.clone(),
+            anthropic_api_key_editor.clone(),
+            google_api_key_editor.clone(),
+        ];
+        ctx.subscribe_to_model(&Appearance::handle(ctx), move |_, _, _, ctx| {
+            let text_colors = editor_text_colors(Appearance::as_ref(ctx));
+            for editor in &api_key_editors {
+                let colors = text_colors.clone();
+                editor.update(ctx, move |editor, ctx| {
+                    editor.set_text_colors(colors, ctx);
+                });
+            }
+        });
 
         let grok_connect_button = ctx.add_typed_action_view(|_| {
             ActionButton::new("Connect", SecondaryTheme)

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -136,7 +136,7 @@ use std::sync::LazyLock;
 use markdown_parser::{FormattedText, FormattedTextFragment, FormattedTextLine};
 
 use crate::ai::{AIRequestUsageModel, AIRequestUsageModelEvent};
-use crate::appearance::Appearance;
+use crate::appearance::{Appearance, AppearanceEvent};
 use crate::editor::{EditorView, Event as EditorEvent, TextOptions};
 use crate::menu::{MenuItem, MenuItemFields};
 use crate::server::telemetry::{
@@ -7500,20 +7500,21 @@ impl ApiKeysWidget {
         );
 
         // Editor text colors are snapshotted at construction via
-        // `text_colors_override`, so refresh them whenever the appearance
-        // (e.g. the theme) changes.
+        // `text_colors_override`, so refresh them whenever the theme changes.
         let api_key_editors = [
             openai_api_key_editor.clone(),
             anthropic_api_key_editor.clone(),
             google_api_key_editor.clone(),
         ];
-        ctx.subscribe_to_model(&Appearance::handle(ctx), move |_, _, _, ctx| {
-            let text_colors = editor_text_colors(Appearance::as_ref(ctx));
-            for editor in &api_key_editors {
-                let colors = text_colors.clone();
-                editor.update(ctx, move |editor, ctx| {
-                    editor.set_text_colors(colors, ctx);
-                });
+        ctx.subscribe_to_model(&Appearance::handle(ctx), move |_, _, event, ctx| {
+            if let AppearanceEvent::ThemeChanged = event {
+                let text_colors = editor_text_colors(Appearance::as_ref(ctx));
+                for editor in &api_key_editors {
+                    let colors = text_colors.clone();
+                    editor.update(ctx, move |editor, ctx| {
+                        editor.set_text_colors(colors, ctx);
+                    });
+                }
             }
         });
 

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -173,7 +173,7 @@ const GIT_OPERATIONS_AUTOGEN_DESCRIPTION: &str =
     "Let AI generate commit messages and pull request titles and descriptions.";
 const WISPR_FLOW_URL: &str = "https://wisprflow.ai/";
 const CUSTOM_INFERENCE_LEARN_MORE_URL: &str =
-    "https://docs.warp.dev/support-and-community/plans-and-billing/bring-your-own-api-key/";
+    "https://docs.warp.dev/agent-platform/inference/custom-inference-endpoint/";
 const CUSTOM_INFERENCE_TERMS_URL: &str = "https://www.warp.dev/legal/terms-of-service";
 const CUSTOM_INFERENCE_INFO_TOOLTIP_MAX_WIDTH: f32 = 320.;
 

--- a/app/src/settings_view/custom_inference_modal.rs
+++ b/app/src/settings_view/custom_inference_modal.rs
@@ -86,6 +86,12 @@ impl CustomEndpointModal {
         editing_index: Option<usize>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
+        // Editor text colors are snapshotted at construction via
+        // `text_colors_override`, so refresh them whenever the appearance
+        // (e.g. the theme) changes.
+        ctx.subscribe_to_model(&Appearance::handle(ctx), |me, _, _, ctx| {
+            me.update_editor_text_colors(ctx);
+        });
         let font_family = Appearance::as_ref(ctx).ui_font_family();
         let text_colors = crate::settings_view::editor_text_colors(Appearance::as_ref(ctx));
 
@@ -352,6 +358,28 @@ impl CustomEndpointModal {
             });
             row.alias_editor.update(ctx, |editor, ctx| {
                 editor.clear_buffer_and_reset_undo_stack(ctx);
+            });
+        }
+    }
+
+    /// Re-applies theme-derived text colors to every editor in the modal.
+    /// Called on appearance changes since editors only snapshot their text
+    /// colors at construction.
+    fn update_editor_text_colors(&mut self, ctx: &mut ViewContext<Self>) {
+        let text_colors = crate::settings_view::editor_text_colors(Appearance::as_ref(ctx));
+        let mut editors = vec![
+            self.endpoint_name_editor.clone(),
+            self.endpoint_url_editor.clone(),
+            self.api_key_editor.clone(),
+        ];
+        for row in &self.model_rows {
+            editors.push(row.name_editor.clone());
+            editors.push(row.alias_editor.clone());
+        }
+        for editor in editors {
+            let colors = text_colors.clone();
+            editor.update(ctx, move |editor, ctx| {
+                editor.set_text_colors(colors, ctx);
             });
         }
     }

--- a/app/src/settings_view/custom_inference_modal.rs
+++ b/app/src/settings_view/custom_inference_modal.rs
@@ -14,7 +14,7 @@ use warpui::{
     AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle,
 };
 
-use crate::appearance::Appearance;
+use crate::appearance::{Appearance, AppearanceEvent};
 use crate::editor::{
     EditorView, Event as EditorEvent, PropagateAndNoOpNavigationKeys, SingleLineEditorOptions,
     TextOptions,
@@ -87,10 +87,11 @@ impl CustomEndpointModal {
         ctx: &mut ViewContext<Self>,
     ) -> Self {
         // Editor text colors are snapshotted at construction via
-        // `text_colors_override`, so refresh them whenever the appearance
-        // (e.g. the theme) changes.
-        ctx.subscribe_to_model(&Appearance::handle(ctx), |me, _, _, ctx| {
-            me.update_editor_text_colors(ctx);
+        // `text_colors_override`, so refresh them whenever the theme changes.
+        ctx.subscribe_to_model(&Appearance::handle(ctx), |me, _, event, ctx| {
+            if let AppearanceEvent::ThemeChanged = event {
+                me.update_editor_text_colors(ctx);
+            }
         });
         let font_family = Appearance::as_ref(ctx).ui_font_family();
         let text_colors = crate::settings_view::editor_text_colors(Appearance::as_ref(ctx));


### PR DESCRIPTION
## Description
Some AI settings text inputs become unreadable after switching themes (e.g. light text on a light background in the "Edit custom endpoint" modal).

`EditorView` text colors are snapshotted at construction via `TextOptions::text_colors_override`, and the parent view is responsible for keeping them in sync with appearance changes. The custom endpoint modal and the BYO API key editors never did, so they kept the colors of whatever theme was active when the AI settings page was constructed.

Fix: subscribe to `Appearance` and re-apply the theme-derived text colors on change, following the existing pattern in `update_environment_form.rs` / `environments_page.rs`:
- `CustomEndpointModal`: refreshes the endpoint name/URL/API key editors and all model-row editors (rows added later are also covered).
- `ApiKeysWidget`: refreshes the OpenAI/Anthropic/Google API key editors.

## Linked Issue
N/A — reported directly (unreadable fields in the "Edit custom endpoint" modal in some themes).

## Testing
- `cargo check -p warp`, `cargo clippy -p warp --all-features`, and `rustfmt --check` on the changed files all pass.
- No new automated tests: the resolved editor text colors are not currently exposed to tests; adding a test-only accessor was deferred to keep the fix localized.

###  Before
https://www.loom.com/share/413eedc0137043369383abfff3d1524e


### After
https://www.loom.com/share/5aa23145e77048249cee468169ffd8c1

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed custom inference endpoint and BYO API key settings inputs becoming unreadable after switching themes.

Conversation: https://staging.warp.dev/conversation/1662ca68-9b22-4b5e-bf71-3c08facec972

Co-Authored-By: Warp <agent@warp.dev>
Co-Authored-By: Oz <oz-agent@warp.dev>
