### PR TITLE
[APP-4718] Add GEMINI_ENTERPRISE to client LlmModelHost GraphQL types

### DIFF
--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -134,6 +134,7 @@ pub enum LLMModelHost {
     DirectApi,
     AwsBedrock,
     CustomEndpoint,
+    GeminiEnterprise,
     #[serde(other)]
     Unknown,
 }

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -2826,6 +2826,9 @@ impl From<warp_graphql::queries::get_feature_model_choices::LlmModelHost> for LL
             warp_graphql::queries::get_feature_model_choices::LlmModelHost::CustomEndpoint => {
                 LLMModelHost::CustomEndpoint
             }
+            warp_graphql::queries::get_feature_model_choices::LlmModelHost::GeminiEnterprise => {
+                LLMModelHost::GeminiEnterprise
+            }
             warp_graphql::queries::get_feature_model_choices::LlmModelHost::Other(value) => {
                 report_error!(
                     anyhow!(

--- a/app/src/workspaces/gql_convert.rs
+++ b/app/src/workspaces/gql_convert.rs
@@ -748,6 +748,7 @@ impl From<warp_graphql::workspace::LlmModelHost> for crate::ai::llms::LLMModelHo
             GqlLlmModelHost::DirectApi => Self::DirectApi,
             GqlLlmModelHost::AwsBedrock => Self::AwsBedrock,
             GqlLlmModelHost::CustomEndpoint => Self::CustomEndpoint,
+            GqlLlmModelHost::GeminiEnterprise => Self::GeminiEnterprise,
             GqlLlmModelHost::Other(value) => {
                 report_error!(
                     anyhow!(

--- a/crates/graphql/src/api/queries/get_feature_model_choices.rs
+++ b/crates/graphql/src/api/queries/get_feature_model_choices.rs
@@ -72,6 +72,7 @@ pub enum LlmModelHost {
     AwsBedrock,
     CustomEndpoint,
     DirectApi,
+    GeminiEnterprise,
     #[cynic(fallback)]
     Other(String),
 }

--- a/crates/graphql/src/api/workspace.rs
+++ b/crates/graphql/src/api/workspace.rs
@@ -287,6 +287,7 @@ pub enum LlmModelHost {
     AwsBedrock,
     CustomEndpoint,
     DirectApi,
+    GeminiEnterprise,
     #[cynic(fallback)]
     Other(String),
 }

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -2044,6 +2044,7 @@ enum LlmModelHost {
   AWS_BEDROCK
   CUSTOM_ENDPOINT
   DIRECT_API
+  GEMINI_ENTERPRISE
 }
 
 type LlmModelHostSettings {


### PR DESCRIPTION
## Description

Fixes the local build error reported in [this Slack thread](https://warpdev.slack.com/archives/C08KTPNQN65/p1781196779295969):

```
[ERROR] [errors::report_error] Unknown LlmModelHost 'GEMINI_ENTERPRISE'. Make sure to update client GraphQL types!
```

**Why this happened:** the warp-server GEAP BYOLLM changes (REV-1599, merged on server `develop`) added `GEMINI_ENTERPRISE` to the `LlmModelHost` GraphQL enum. The server now returns that value to every client — in workspace `llmSettings.hostConfigs` and in per-model `LlmInfo.hostConfigs` — regardless of whether GEAP is enabled for the workspace. The client's cynic enums only knew `AWS_BEDROCK | CUSTOM_ENDPOINT | DIRECT_API`, so the new value fell into the `#[cynic(fallback)] Other(String)` arm and both `From` conversions fired `report_error!` once per run. This is the client-side half we needed to update to match the server changes.

**What this PR does (all additive):**
- `crates/warp_graphql_schema/api/schema.graphql` — add `GEMINI_ENTERPRISE` to the vendored `LlmModelHost` enum (cynic validates the Rust enums against this at compile time)
- `crates/graphql/src/api/workspace.rs` + `crates/graphql/src/api/queries/get_feature_model_choices.rs` — add `GeminiEnterprise` to both cynic `LlmModelHost` enums
- `app/src/ai/llms.rs` — add `GeminiEnterprise` to the app-side `LLMModelHost` enum
- `app/src/workspaces/gql_convert.rs` + `app/src/server/server_api/ai.rs` — map the new variant in both conversions instead of falling through to `Other` → `report_error!`

GEAP host entries now parse as a first-class `LLMModelHost::GeminiEnterprise` key in `host_configs` maps instead of collapsing to `Unknown`, which the upcoming GEAP client credential work builds on.

**No deployment-ordering risk:** enum variants only affect response deserialization — they are not baked into the query text cynic generates — so this client change is safe against any server version (the server-side enum is already live).

## Linked Issue

Linear: [APP-4718](https://linear.app/warpdotdev/issue/APP-4718)

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (not applicable — no UI change).

## Testing

- `cargo check -p warp --lib` — clean (this is also the consistency proof: the cynic proc-macros validate the Rust enum variants against `schema.graphql` at compile time)
- `cargo fmt -p warp -p warp_graphql -- --check` — clean
- `cargo clippy -p warp_graphql -p warp --lib -- -D warnings` — clean

No new tests added: the fix is exhaustive-match enum plumbing that the compiler + cynic schema validation enforce; there is no branching logic to regression-test. The error fired on every workspace settings sync against a server returning `GEMINI_ENTERPRISE`; with the variant known, the fallback arm is unreachable for this value.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode