### PR TITLE
Correctly route code review attachments to orchestrated children/parents

### DIFF
--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -590,10 +590,10 @@ struct RelocateCommentsResult {
 
 /// Resolves which terminal code review actions should target.
 ///
-/// Injected by the hosting view (`RightPanelView`) so terminal selection is
+/// Injected by the hosting view (`RightPanelView`) so target selection is
 /// late-bound: actions land in the conversation the user is currently focused
 /// on rather than a terminal handle captured when the view was constructed.
-pub trait ReviewTerminalProvider {
+pub trait ReviewActionTargetProvider {
     /// The terminal that should receive attach-as-context payloads. Uses the
     /// same selection as review comment submission (focused > repo-preferred >
     /// any available), falling back to the focused terminal inside `repo_path`
@@ -664,7 +664,7 @@ pub struct CodeReviewView {
     diff_state_model: ModelHandle<DiffStateModel>,
     diff_selector: ViewHandle<DiffSelector>,
     header: CodeReviewHeader,
-    terminal_provider: Option<Box<dyn ReviewTerminalProvider>>,
+    action_target_provider: Option<Box<dyn ReviewActionTargetProvider>>,
     position_id_prefix: String,
     /// Whether the view is currently open (subscribed to diff state model).
     is_open: bool,
@@ -1138,7 +1138,7 @@ impl CodeReviewView {
         repo_path: Option<LocalOrRemotePath>,
         diff_state_model: ModelHandle<DiffStateModel>,
         comment_batch_model: Option<ModelHandle<ReviewCommentBatch>>,
-        terminal_provider: Option<Box<dyn ReviewTerminalProvider>>,
+        action_target_provider: Option<Box<dyn ReviewActionTargetProvider>>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
         // TODO(asweet): Migrate subscription and event handling of diff_state_model to RepositoryState
@@ -1356,7 +1356,7 @@ impl CodeReviewView {
             position_id_prefix: random_str,
             viewported_list_state: list_state,
             scroll_state: ScrollStateHandle::default(),
-            terminal_provider,
+            action_target_provider,
             window_id: ctx.window_id(),
             undo_action_button,
             last_revert: None,
@@ -2879,14 +2879,14 @@ impl CodeReviewView {
     /// or no suitable terminal.
     fn attach_target_terminal(&self, app: &AppContext) -> Option<ViewHandle<TerminalView>> {
         let repo_path = self.repo_path()?;
-        self.terminal_provider
+        self.action_target_provider
             .as_ref()?
             .attach_terminal(repo_path, app)
     }
 
     /// The focused terminal of the hosting pane group, if any.
     fn focused_terminal(&self, app: &AppContext) -> Option<ViewHandle<TerminalView>> {
-        self.terminal_provider.as_ref()?.focused_terminal(app)
+        self.action_target_provider.as_ref()?.focused_terminal(app)
     }
 
     fn diff_state(&self, app: &AppContext) -> DiffState {

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -588,6 +588,28 @@ struct RelocateCommentsResult {
     fallback_count: usize,
 }
 
+/// Resolves which terminal code review actions should target.
+///
+/// Injected by the hosting view (`RightPanelView`) so terminal selection is
+/// late-bound: actions land in the conversation the user is currently focused
+/// on rather than a terminal handle captured when the view was constructed.
+pub trait ReviewTerminalProvider {
+    /// The terminal that should receive attach-as-context payloads. Uses the
+    /// same selection as review comment submission (focused > repo-preferred >
+    /// any available), falling back to the focused terminal inside `repo_path`
+    /// when none are available so per-action handling for busy terminals still
+    /// targets the focused conversation.
+    fn attach_terminal(
+        &self,
+        repo_path: &LocalOrRemotePath,
+        app: &AppContext,
+    ) -> Option<ViewHandle<TerminalView>>;
+
+    /// The focused (or active) terminal of the hosting pane group, regardless
+    /// of repo. Used for environment checks and terminal-targeted actions.
+    fn focused_terminal(&self, app: &AppContext) -> Option<ViewHandle<TerminalView>>;
+}
+
 /// State shared among the entire code review view.
 pub struct CodeReviewView {
     active_repo: Option<RepositoryState>,
@@ -642,7 +664,7 @@ pub struct CodeReviewView {
     diff_state_model: ModelHandle<DiffStateModel>,
     diff_selector: ViewHandle<DiffSelector>,
     header: CodeReviewHeader,
-    terminal_view: Option<WeakViewHandle<TerminalView>>,
+    terminal_provider: Option<Box<dyn ReviewTerminalProvider>>,
     position_id_prefix: String,
     /// Whether the view is currently open (subscribed to diff state model).
     is_open: bool,
@@ -688,9 +710,7 @@ impl CodeReviewView {
     /// RPCs so the request rides the connection that's actually showing the
     /// review; `None` falls back to any connected session for the host.
     fn preferred_review_session(&self, ctx: &ViewContext<Self>) -> Option<SessionId> {
-        self.terminal_view
-            .as_ref()
-            .and_then(|tv| tv.upgrade(ctx))
+        self.focused_terminal(ctx)
             .and_then(|tv| tv.as_ref(ctx).active_block_session_id())
     }
 
@@ -1118,7 +1138,7 @@ impl CodeReviewView {
         repo_path: Option<LocalOrRemotePath>,
         diff_state_model: ModelHandle<DiffStateModel>,
         comment_batch_model: Option<ModelHandle<ReviewCommentBatch>>,
-        terminal_view: Option<WeakViewHandle<TerminalView>>,
+        terminal_provider: Option<Box<dyn ReviewTerminalProvider>>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
         // TODO(asweet): Migrate subscription and event handling of diff_state_model to RepositoryState
@@ -1336,7 +1356,7 @@ impl CodeReviewView {
             position_id_prefix: random_str,
             viewported_list_state: list_state,
             scroll_state: ScrollStateHandle::default(),
-            terminal_view,
+            terminal_provider,
             window_id: ctx.window_id(),
             undo_action_button,
             last_revert: None,
@@ -1378,10 +1398,6 @@ impl CodeReviewView {
         }
 
         view
-    }
-
-    pub fn set_terminal_view(&mut self, terminal_view: WeakViewHandle<TerminalView>) {
-        self.terminal_view = Some(terminal_view);
     }
 
     pub fn set_review_destination(
@@ -2858,9 +2874,19 @@ impl CodeReviewView {
         )
     }
 
-    /// Get the terminal view for the current repo. Returns None if no repo or no terminal.
-    pub fn terminal_view(&self, app: &AppContext) -> Option<ViewHandle<TerminalView>> {
-        self.terminal_view.as_ref().and_then(|tv| tv.upgrade(app))
+    /// The terminal that attach-as-context actions should target, resolved at
+    /// action time for the current repo. Returns None if no repo, no provider,
+    /// or no suitable terminal.
+    fn attach_target_terminal(&self, app: &AppContext) -> Option<ViewHandle<TerminalView>> {
+        let repo_path = self.repo_path()?;
+        self.terminal_provider
+            .as_ref()?
+            .attach_terminal(repo_path, app)
+    }
+
+    /// The focused terminal of the hosting pane group, if any.
+    fn focused_terminal(&self, app: &AppContext) -> Option<ViewHandle<TerminalView>> {
+        self.terminal_provider.as_ref()?.focused_terminal(app)
     }
 
     fn diff_state(&self, app: &AppContext) -> DiffState {
@@ -2883,7 +2909,7 @@ impl CodeReviewView {
 
     #[cfg(not(target_family = "wasm"))]
     fn session_env(&self, app: &AppContext) -> Option<GitSessionState> {
-        let terminal_view = self.terminal_view.as_ref()?.upgrade(app)?;
+        let terminal_view = self.focused_terminal(app)?;
         terminal_view.read(app, |terminal, ctx| {
             let session = terminal
                 .active_block_session_id()
@@ -3072,7 +3098,7 @@ impl CodeReviewView {
                 )
                 .with_selection_as_context(Box::new(move |_, app| {
                     self_handle.upgrade(app).and_then(|code_review_view| {
-                        code_review_view.as_ref(app).terminal_view(app)
+                        code_review_view.as_ref(app).attach_target_terminal(app)
                     })
                 }));
 
@@ -3165,7 +3191,7 @@ impl CodeReviewView {
                     local_code_view =
                         local_code_view.with_selection_as_context(Box::new(move |_, app| {
                             self_handle.upgrade(app).and_then(|code_review_view| {
-                                code_review_view.as_ref(app).terminal_view(app)
+                                code_review_view.as_ref(app).attach_target_terminal(app)
                             })
                         }));
                 }
@@ -4115,7 +4141,7 @@ impl CodeReviewView {
             .map(|path| {
                 let has_steps = InitProjectModel::should_have_available_steps(path, app);
                 let is_terminal_in_correct_dir = self
-                    .terminal_view(app)
+                    .focused_terminal(app)
                     .and_then(|view| {
                         view.read(app, |t, _| t.pwd().map(|pwd| pwd == path.to_string_lossy()))
                     })
@@ -5704,7 +5730,7 @@ impl CodeReviewView {
         selected_text: String,
         ctx: &mut ViewContext<Self>,
     ) {
-        if let Some(terminal_view) = self.terminal_view.as_ref().and_then(|tv| tv.upgrade(ctx)) {
+        if let Some(terminal_view) = self.attach_target_terminal(ctx) {
             // If a CLI agent is active, send appropriate content to the PTY.
             let prompt = if start_line == end_line {
                 // Single-line: send the literal text with file/line context.
@@ -5794,11 +5820,7 @@ impl CodeReviewView {
     /// Insert diff set as context in the terminal input (either all files or a specific file)
     #[cfg(feature = "local_fs")]
     fn insert_diff_as_context(&mut self, scope: DiffSetScope, ctx: &mut ViewContext<Self>) {
-        if let Some(terminal_view) = self
-            .terminal_view
-            .as_ref()
-            .and_then(|view| view.upgrade(ctx))
-        {
+        if let Some(terminal_view) = self.attach_target_terminal(ctx) {
             let active_cli_agent = terminal_view.read(ctx, |tv, ctx| tv.active_cli_agent(ctx));
 
             let diff_set_scope = match &scope {
@@ -6010,7 +6032,7 @@ impl CodeReviewView {
             return;
         };
         // Try to get the terminal view and insert the context
-        if let Some(terminal_view) = self.terminal_view.as_ref().and_then(|tv| tv.upgrade(ctx)) {
+        if let Some(terminal_view) = self.attach_target_terminal(ctx) {
             let is_long_running =
                 terminal_view.read(ctx, |terminal_view, _| terminal_view.is_long_running());
             let active_cli_agent = terminal_view.read(ctx, |tv, ctx| tv.active_cli_agent(ctx));
@@ -7488,14 +7510,14 @@ impl TypedActionView for CodeReviewView {
                 ctx.focus_self();
             }
             CodeReviewAction::OpenRepository => {
-                if let Some(terminal_view) = self.terminal_view(ctx) {
+                if let Some(terminal_view) = self.focused_terminal(ctx) {
                     terminal_view.update(ctx, |terminal, ctx| {
                         terminal.handle_action(&TerminalAction::PickRepoToOpen, ctx);
                     });
                 }
             }
             CodeReviewAction::InitProjectForCurrentDirectory => {
-                if let Some(terminal_view) = self.terminal_view(ctx) {
+                if let Some(terminal_view) = self.focused_terminal(ctx) {
                     terminal_view.update(ctx, |terminal, ctx| {
                         terminal.handle_action(&TerminalAction::InitProject, ctx);
                     });

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -884,7 +884,6 @@ enum DefaultSessionModeBehavior {
 struct CodeReviewPaneContext {
     repo_path: Option<LocalOrRemotePath>,
     diff_state_model: ModelHandle<DiffStateModel>,
-    terminal_view: WeakViewHandle<TerminalView>,
 }
 
 /// Parameters for updating the right panel's 'state.
@@ -8875,40 +8874,33 @@ impl Workspace {
         ctx: &mut ViewContext<Self>,
     ) {
         // If context is provided, use it directly. Otherwise, derive from active pane group.
-        let context_data: Option<(
-            Option<LocalOrRemotePath>,
-            ModelHandle<DiffStateModel>,
-            WeakViewHandle<TerminalView>,
-        )> = if let Some(context) = context {
-            Some((
-                context.repo_path.clone(),
-                context.diff_state_model.clone(),
-                context.terminal_view.clone(),
-            ))
-        } else {
-            let active_pane_group = self.active_tab_pane_group().clone();
-            // Read repo_path and terminal_view from the pane group (immutable context).
-            let read_result = active_pane_group.read(ctx, |pane_group, ctx| {
-                pane_group.active_session_view(ctx).map(|terminal_view| {
-                    let repo_path = terminal_view.as_ref(ctx).current_repo_path().cloned();
-                    let preferred_session = terminal_view.as_ref(ctx).active_block_session_id();
-                    (repo_path, preferred_session, terminal_view.downgrade())
-                })
-            });
-            // Resolve DiffStateModel outside the read closure (needs mutable context).
-            read_result.and_then(|(repo_path, preferred_session, terminal_view)| {
-                let diff_state_model = repo_path.as_ref().and_then(|rp| {
-                    self.working_directories_model.update(ctx, |model, ctx| {
-                        model.get_or_create_diff_state_model(rp.clone(), preferred_session, ctx)
+        let context_data: Option<(Option<LocalOrRemotePath>, ModelHandle<DiffStateModel>)> =
+            if let Some(context) = context {
+                Some((context.repo_path.clone(), context.diff_state_model.clone()))
+            } else {
+                let active_pane_group = self.active_tab_pane_group().clone();
+                // Read repo_path and preferred session from the pane group (immutable context).
+                let read_result = active_pane_group.read(ctx, |pane_group, ctx| {
+                    pane_group.active_session_view(ctx).map(|terminal_view| {
+                        let repo_path = terminal_view.as_ref(ctx).current_repo_path().cloned();
+                        let preferred_session = terminal_view.as_ref(ctx).active_block_session_id();
+                        (repo_path, preferred_session)
                     })
-                })?;
-                Some((repo_path, diff_state_model, terminal_view))
-            })
-        };
+                });
+                // Resolve DiffStateModel outside the read closure (needs mutable context).
+                read_result.and_then(|(repo_path, preferred_session)| {
+                    let diff_state_model = repo_path.as_ref().and_then(|rp| {
+                        self.working_directories_model.update(ctx, |model, ctx| {
+                            model.get_or_create_diff_state_model(rp.clone(), preferred_session, ctx)
+                        })
+                    })?;
+                    Some((repo_path, diff_state_model))
+                })
+            };
 
-        if let Some((repo, diff_state_model, terminal_view)) = context_data {
+        if let Some((repo, diff_state_model)) = context_data {
             self.right_panel_view.update(ctx, |right_pane_view, ctx| {
-                right_pane_view.open_code_review(repo, diff_state_model, terminal_view, ctx);
+                right_pane_view.open_code_review(repo, diff_state_model, ctx);
             });
         } else {
             self.right_panel_view.update(ctx, |right_panel_view, ctx| {
@@ -8951,7 +8943,6 @@ impl Workspace {
         let context = CodeReviewPaneContext {
             repo_path: repo_location,
             diff_state_model,
-            terminal_view: panel_context.terminal_view.clone(),
         };
 
         self.open_right_panel(
@@ -9051,21 +9042,17 @@ impl Workspace {
         let target_open_state =
             pane_group_handle.read(ctx, |pane_group, _| !pane_group.right_panel_open);
 
-        // Read repo_path and terminal_view from pane group (immutable context).
+        // Read repo_path and preferred session from pane group (immutable context).
         let read_result = pane_group_handle.read(ctx, |pane_group, ctx| {
             pane_group.active_session_view(ctx).map(|terminal_view| {
                 let repo_path = terminal_view.as_ref(ctx).current_repo_path().cloned();
                 let preferred_session = terminal_view.as_ref(ctx).active_block_session_id();
-                (repo_path, preferred_session, terminal_view.downgrade())
+                (repo_path, preferred_session)
             })
         });
         // Resolve DiffStateModel outside the read closure (needs mutable context).
         let context = read_result.and_then(
-            |(repo_path, preferred_session, terminal_view): (
-                Option<LocalOrRemotePath>,
-                Option<SessionId>,
-                WeakViewHandle<TerminalView>,
-            )| {
+            |(repo_path, preferred_session): (Option<LocalOrRemotePath>, Option<SessionId>)| {
                 let diff_state_model = repo_path.as_ref().and_then(|rp| {
                     self.working_directories_model.update(ctx, |model, ctx| {
                         model.get_or_create_diff_state_model(rp.clone(), preferred_session, ctx)
@@ -9074,7 +9061,6 @@ impl Workspace {
                 Some(CodeReviewPaneContext {
                     repo_path,
                     diff_state_model,
-                    terminal_view,
                 })
             },
         );
@@ -23505,10 +23491,10 @@ impl TypedActionView for Workspace {
                                     terminal_view.as_ref(ctx).current_repo_path().cloned();
                                 let preferred_session =
                                     terminal_view.as_ref(ctx).active_block_session_id();
-                                (repo_path, preferred_session, terminal_view.downgrade())
+                                (repo_path, preferred_session)
                             })
                     });
-                    if let Some((repo_path, preferred_session, terminal_view)) = read_result {
+                    if let Some((repo_path, preferred_session)) = read_result {
                         let diff_state_model = repo_path.as_ref().and_then(|rp| {
                             self.working_directories_model.update(ctx, |model, ctx| {
                                 model.get_or_create_diff_state_model(
@@ -23522,7 +23508,6 @@ impl TypedActionView for Workspace {
                             let context = CodeReviewPaneContext {
                                 repo_path,
                                 diff_state_model,
-                                terminal_view,
                             };
                             self.open_right_panel(
                                 &context,

--- a/app/src/workspace/view/right_panel.rs
+++ b/app/src/workspace/view/right_panel.rs
@@ -30,7 +30,7 @@ use crate::code_review::code_review_header::HEADER_BUTTON_PADDING;
 use crate::code_review::code_review_view::CodeReviewAction;
 use crate::code_review::code_review_view::{
     render_file_navigation_button, CodeReviewCommentDebugState, CodeReviewView,
-    CodeReviewViewEvent, ReviewTerminalProvider, CONTENT_LEFT_MARGIN, CONTENT_RIGHT_MARGIN,
+    CodeReviewViewEvent, ReviewActionTargetProvider, CONTENT_LEFT_MARGIN, CONTENT_RIGHT_MARGIN,
 };
 use crate::code_review::diff_state::DiffStateModel;
 use crate::code_review::telemetry_event::CodeReviewContextDestination;
@@ -118,14 +118,14 @@ impl ReviewTerminalStatus {
     }
 }
 
-/// `ReviewTerminalProvider` backed by the right panel's active pane group, so
-/// code review actions resolve their target terminal at action time instead
+/// `ReviewActionTargetProvider` backed by the right panel's active pane group,
+/// so code review actions resolve their target terminal at action time instead
 /// of using a handle captured when the review view was created.
-struct RightPanelReviewTerminalProvider {
+struct RightPanelReviewActionTargetProvider {
     right_panel: WeakViewHandle<RightPanelView>,
 }
 
-impl ReviewTerminalProvider for RightPanelReviewTerminalProvider {
+impl ReviewActionTargetProvider for RightPanelReviewActionTargetProvider {
     fn attach_terminal(
         &self,
         repo_path: &LocalOrRemotePath,
@@ -1233,8 +1233,8 @@ impl RightPanelView {
                 .update(ctx, |working_directories, ctx| {
                     working_directories.get_or_create_code_review_comments(repo_path, ctx)
                 });
-        let terminal_provider: Box<dyn ReviewTerminalProvider> =
-            Box::new(RightPanelReviewTerminalProvider {
+        let action_target_provider: Box<dyn ReviewActionTargetProvider> =
+            Box::new(RightPanelReviewActionTargetProvider {
                 right_panel: ctx.handle(),
             });
         let code_review_view = ctx.add_typed_action_view(|ctx| {
@@ -1242,7 +1242,7 @@ impl RightPanelView {
                 Some(repo_path.clone()),
                 diff_state_model_clone,
                 code_review_comment_batch,
-                Some(terminal_provider),
+                Some(action_target_provider),
                 ctx,
             )
         });
@@ -1751,7 +1751,7 @@ impl RightPanelView {
                 .is_some_and(|mut repos| repos.any(|r| &r == repo_path));
 
             // Only create a view when a terminal exists for the repo. The view
-            // resolves its target terminal lazily via `ReviewTerminalProvider`,
+            // resolves its target terminal lazily via `ReviewActionTargetProvider`,
             // so this is purely a creation gate.
             let has_review_terminal = if is_known_repo {
                 let Some(terminal_view_id) = self

--- a/app/src/workspace/view/right_panel.rs
+++ b/app/src/workspace/view/right_panel.rs
@@ -30,7 +30,7 @@ use crate::code_review::code_review_header::HEADER_BUTTON_PADDING;
 use crate::code_review::code_review_view::CodeReviewAction;
 use crate::code_review::code_review_view::{
     render_file_navigation_button, CodeReviewCommentDebugState, CodeReviewView,
-    CodeReviewViewEvent, CONTENT_LEFT_MARGIN, CONTENT_RIGHT_MARGIN,
+    CodeReviewViewEvent, ReviewTerminalProvider, CONTENT_LEFT_MARGIN, CONTENT_RIGHT_MARGIN,
 };
 use crate::code_review::diff_state::DiffStateModel;
 use crate::code_review::telemetry_event::CodeReviewContextDestination;
@@ -115,6 +115,64 @@ struct ReviewTerminalStatus {
 impl ReviewTerminalStatus {
     fn is_available(&self) -> bool {
         self.unavailable_reasons.is_empty()
+    }
+}
+
+/// `ReviewTerminalProvider` backed by the right panel's active pane group, so
+/// code review actions resolve their target terminal at action time instead
+/// of using a handle captured when the review view was created.
+struct RightPanelReviewTerminalProvider {
+    right_panel: WeakViewHandle<RightPanelView>,
+}
+
+impl ReviewTerminalProvider for RightPanelReviewTerminalProvider {
+    fn attach_terminal(
+        &self,
+        repo_path: &LocalOrRemotePath,
+        app: &AppContext,
+    ) -> Option<ViewHandle<TerminalView>> {
+        let right_panel = self.right_panel.upgrade(app)?;
+        right_panel.read(app, |panel, app| {
+            let pane_group = panel.active_pane_group.as_ref()?;
+            let ai_enabled = AISettings::as_ref(app).is_any_ai_enabled(app);
+            panel
+                .find_review_terminal(pane_group, repo_path, ai_enabled, app)
+                .or_else(|| {
+                    // No terminal is available (e.g. all candidates are
+                    // executing). Fall back to the focused terminal when it is
+                    // inside the repo, so per-action handling for busy
+                    // terminals still targets the focused conversation.
+                    let focused = pane_group
+                        .read(app, |pane_group, app| pane_group.focused_session_view(app))?;
+                    let status = RightPanelView::review_terminal_status(
+                        &focused,
+                        Some(repo_path),
+                        ai_enabled,
+                        app,
+                    );
+                    let in_repo = !status.unavailable_reasons.iter().any(|reason| {
+                        matches!(
+                            reason,
+                            ReviewTerminalUnavailableReason::NoSelectedRepo
+                                | ReviewTerminalUnavailableReason::SessionPathUnavailable
+                                | ReviewTerminalUnavailableReason::SessionOutsideSelectedRepo
+                        )
+                    });
+                    in_repo.then_some(focused)
+                })
+        })
+    }
+
+    fn focused_terminal(&self, app: &AppContext) -> Option<ViewHandle<TerminalView>> {
+        let right_panel = self.right_panel.upgrade(app)?;
+        right_panel.read(app, |panel, app| {
+            let pane_group = panel.active_pane_group.as_ref()?;
+            pane_group.read(app, |pane_group, app| {
+                pane_group
+                    .focused_session_view(app)
+                    .or_else(|| pane_group.active_session_view(app))
+            })
+        })
     }
 }
 
@@ -650,7 +708,6 @@ impl RightPanelView {
         &mut self,
         repo_path: Option<LocalOrRemotePath>,
         diff_state_model: ModelHandle<DiffStateModel>,
-        terminal_view: WeakViewHandle<TerminalView>,
         ctx: &mut ViewContext<Self>,
     ) {
         let Some(repo_dropdown_state) = &mut self.code_review_state else {
@@ -675,17 +732,12 @@ impl RightPanelView {
             .get_code_review_view(pane_group_id, repo_path);
         if let Some(view) = existing_view {
             view.update(ctx, |view, ctx| {
-                view.set_terminal_view(terminal_view);
                 view.on_open(ctx);
             });
             self.recompute_terminal_availability(ctx);
-        } else if let Some(view) = self.create_code_review_view(
-            repo_path,
-            diff_state_model.clone(),
-            pane_group_id,
-            terminal_view.clone(),
-            ctx,
-        ) {
+        } else if let Some(view) =
+            self.create_code_review_view(repo_path, diff_state_model.clone(), pane_group_id, ctx)
+        {
             view.update(ctx, |view, ctx| {
                 view.on_open(ctx);
             });
@@ -1157,7 +1209,6 @@ impl RightPanelView {
         repo_path: &LocalOrRemotePath,
         diff_state_model: ModelHandle<DiffStateModel>,
         pane_group_id: EntityId,
-        terminal_view: WeakViewHandle<TerminalView>,
         ctx: &mut ViewContext<Self>,
     ) -> Option<ViewHandle<CodeReviewView>> {
         // Early check: if pane group has no active repositories, don't create a view.
@@ -1182,12 +1233,16 @@ impl RightPanelView {
                 .update(ctx, |working_directories, ctx| {
                     working_directories.get_or_create_code_review_comments(repo_path, ctx)
                 });
+        let terminal_provider: Box<dyn ReviewTerminalProvider> =
+            Box::new(RightPanelReviewTerminalProvider {
+                right_panel: ctx.handle(),
+            });
         let code_review_view = ctx.add_typed_action_view(|ctx| {
             CodeReviewView::new(
                 Some(repo_path.clone()),
                 diff_state_model_clone,
                 code_review_comment_batch,
-                Some(terminal_view),
+                Some(terminal_provider),
                 ctx,
             )
         });
@@ -1695,7 +1750,10 @@ impl RightPanelView {
                 .most_recent_repositories_for_pane_group(pane_group_id)
                 .is_some_and(|mut repos| repos.any(|r| &r == repo_path));
 
-            let terminal_view = if is_known_repo {
+            // Only create a view when a terminal exists for the repo. The view
+            // resolves its target terminal lazily via `ReviewTerminalProvider`,
+            // so this is purely a creation gate.
+            let has_review_terminal = if is_known_repo {
                 let Some(terminal_view_id) = self
                     .working_directories_model
                     .as_ref(ctx)
@@ -1704,20 +1762,19 @@ impl RightPanelView {
                     return;
                 };
                 ctx.view_with_id::<TerminalView>(ctx.window_id(), terminal_view_id)
+                    .is_some()
             } else {
                 // For repos not yet tracked (e.g. remote repos from direct open),
                 // fall back to the active session.
-                pane_group.read(ctx, |pane_group, ctx| pane_group.active_session_view(ctx))
+                pane_group
+                    .read(ctx, |pane_group, ctx| pane_group.active_session_view(ctx))
+                    .is_some()
             };
 
-            if let Some(terminal_view) = terminal_view {
-                if let Some(view) = self.create_code_review_view(
-                    repo_path,
-                    diff_state_model,
-                    pane_group_id,
-                    terminal_view.downgrade(),
-                    ctx,
-                ) {
+            if has_review_terminal {
+                if let Some(view) =
+                    self.create_code_review_view(repo_path, diff_state_model, pane_group_id, ctx)
+                {
                     if is_panel_open {
                         view.update(ctx, |view, ctx| {
                             view.on_open(ctx);

--- a/specs/quality-840/TECH.md
+++ b/specs/quality-840/TECH.md
@@ -1,0 +1,75 @@
+# TECH: Route code review actions to the focused conversation's terminal
+
+Ticket: QUALITY-840 · PR: #12524 · Branch: `harry/quality-840-add-to-context-diff-hunk-targets-bound-terminal-view-not`
+
+Code references are pinned to commit `cc73265`.
+
+## Context
+
+The code review panel's "attach as context" actions write content into a `TerminalView` — a selection prompt, a `<change:...>` diff-hunk attachment, or a diff-set attachment. Before this change, `CodeReviewView` stored a `WeakViewHandle<TerminalView>` captured when the view was created and used it for every action. With agent orchestration, parent/child conversations swap panes in and out of the layout tree (`RevealChildAgent` / `SwapPaneToConversation` in `app/src/pane_group/pane/terminal_pane.rs`), so the captured handle could point at a sub-agent's (possibly hidden) terminal while the user was focused on the parent agent. Attach actions then landed in the wrong conversation's input.
+
+Review *comment submission* already solved this: it resolves its target at send time via `RightPanelView::find_review_terminal` (focused terminal > repo-preferred terminal > any available terminal). This spec brings the attach actions (and every other terminal use in the panel) onto that same late-bound resolution, and removes the stored `TerminalView` reference from `CodeReviewView` entirely.
+
+Affected surfaces, all in `app/src/code_review/code_review_view.rs`:
+
+- Selection highlight → "Add as context" tooltip / Cmd-L: `insert_selection_as_context` (`code_review_view.rs:5725`). The tooltip itself needs a terminal *synchronously during render* — `LocalCodeEditorView` calls a `terminal_target_fn` closure both to decide tooltip visibility and to compute the file path relative to the terminal's cwd (`app/src/code/local_code_editor.rs:1786`).
+- Gutter paperclip → attach diff hunk: `insert_diff_hunk_as_context` (`code_review_view.rs:6025`).
+- Header / per-file "Add diff set as context": `insert_diff_as_context` (`code_review_view.rs:5822`).
+- Non-attach uses of the old handle: `preferred_review_session` (session hint for remote `GetDiffState`), `session_env` (remote/WSL zero-state enablement), the "Initialize codebase" pwd check, and the `OpenRepository` / `InitProjectForCurrentDirectory` actions.
+
+Prior art, all in `app/src/workspace/view/right_panel.rs`:
+
+- `route_review_comments` (`right_panel.rs:1314`) — comment submission's routing entry point.
+- `find_review_terminal` (`right_panel.rs:1639`) → `find_available_terminal_for_review` (`right_panel.rs:1604`) — focused > repo-preferred > any available, gated by `review_terminal_status` (`right_panel.rs:1399`) (cwd inside repo; for non-CLI-agent terminals also AI enabled, not executing, input box visible).
+- `PaneGroup::visible_terminal_views` excludes hidden child-agent panes and `focused_session_view` reflects swapped-in conversations, so focused-first resolution always lands on the conversation the user is actually viewing.
+
+## Proposed changes
+
+### `ReviewActionTargetProvider` trait
+
+A provider trait defined next to the consumer, `code_review_view.rs (591-611)`:
+
+- `attach_terminal(repo_path, app)` — the terminal that should receive attach-as-context payloads.
+- `focused_terminal(app)` — the focused (or active) terminal of the hosting pane group, regardless of repo, for environment checks and terminal-targeted actions.
+
+`CodeReviewView` stores `Option<Box<dyn ReviewActionTargetProvider>>` (replacing the `WeakViewHandle<TerminalView>` field) and exposes two private helpers, `attach_target_terminal` / `focused_terminal` (`code_review_view.rs (2877-2890)`). All three attach paths, both selection-tooltip closures (`code_review_view.rs:3099`, `:3192`), and the non-attach uses resolve through these helpers at action/render time. `set_terminal_view` and the old getter are deleted, and the plumbing that threaded a terminal handle through `open_code_review`, `create_code_review_view`, and `CodeReviewPaneContext` is removed.
+
+### `RightPanelView` implementation
+
+`RightPanelReviewActionTargetProvider` (`right_panel.rs (121-177)`) holds a `WeakViewHandle<RightPanelView>` and is injected in `create_code_review_view`:
+
+- `attach_terminal`: calls the shared `find_review_terminal` (identical to comment routing). Only if that returns `None` does it fall back to the focused terminal, and only when `review_terminal_status` shows no repo-scoping failures (`NoSelectedRepo` / `SessionPathUnavailable` / `SessionOutsideSelectedRepo`) — i.e. the focused terminal is in the repo but merely busy.
+- `focused_terminal`: `pane_group.focused_session_view()` falling back to `active_session_view()`.
+
+Per-destination behavior inside each attach method (CLI agent → PTY/rich input, long-running fallback, input-box insert + attachment registration + agent-view entry, telemetry destinations) is unchanged; only the terminal it operates on is resolved differently.
+
+### Parity with comment routing
+
+Verified against the code at `cc73265`: attach actions call the *same* `find_review_terminal` used by `route_review_comments`, so for every case where comment submission finds a terminal, attach actions target the identical terminal. The two paths diverge only when `find_review_terminal` returns `None` (no available terminal anywhere):
+
+- Comments: `route_review_comments` reports `ReviewSubmissionResult::Error` (error toast) — there is no degraded way to deliver a comment batch.
+- Attach: falls back to the focused in-repo terminal so the actions' pre-existing degraded modes still work and still target the focused conversation — the "Cannot attach context when terminal is running" toast (`insert_selection_as_context`) and inserting the path into a running command via `handle_file_tree_drop_on_active_command` (`insert_diff_hunk_as_context`).
+
+This is consistency, not divergence: the fallback covers states comment submission treats as outright failure, and preserves attach behavior that predates this change.
+
+### Design decisions
+
+- **Synchronous provider rather than event bubbling.** Comment submission bubbles an event (`SubmitReviewComments`) to `RightPanelView`, which resolves the terminal and performs the send. That transport cannot cover the selection tooltip: `LocalCodeEditorView` resolves the terminal during render (`&AppContext`, no event emission possible) to decide tooltip visibility and compute the cwd-relative path. Since a synchronous resolver is required for that case anyway, all call sites use it — one resolution mechanism, so the tooltip, the relative path, and the eventual insert always agree on the same terminal. Splitting transports (events for actions, resolver for the tooltip) would allow them to drift.
+- **Trait rather than boxed closures or a direct `RightPanelView` handle.** A trait defined in `code_review` inverts the dependency (the panel declares the capability; the host implements it), matching the established provider pattern in this exact view (`ShowCommentEditorProvider`, `ShowFindReferencesCardProvider`). A direct `WeakViewHandle<RightPanelView>` would couple the panel upward to its host; a pair of boxed closures (the `TerminalTargetFn` style) loses the shared documented contract and can be wired inconsistently.
+- **Resolution against the right panel's `active_pane_group`.** Same scoping as comment routing. A cached `CodeReviewView` is only interactable while its pane group is active, so this cannot resolve against the wrong tab.
+- **Behavior deltas on non-attach surfaces.** `preferred_review_session`, `session_env`, the init-project pwd check, and `OpenRepository`/`InitProject` now act on the focused terminal rather than the panel-opening terminal. These are at-interaction-time concerns; focused is the more correct target, and `preferred_review_session` is only a dispatch hint (`None` falls back to any connected session).
+
+## Testing and validation
+
+- `cargo check -p warp` and `cargo check -p warp --tests` pass; `./script/format` and `cargo clippy -p warp --all-targets -- -D warnings` pass.
+- `cargo test -p warp --lib code_review`: 115 passed, 0 failed — includes `code_review_view_tests.rs` and `find_model_tests.rs`, which construct `CodeReviewView` with the new provider parameter (`None`).
+- The selection-priority logic is shared, unchanged code (`find_available_terminal_for_review`), already exercised by comment-routing usage; no new unit tests were added because the new code is glue requiring a live pane group + focus state.
+- Manual verification (the scenario from the bug report): open an orchestrator with a sub-agent, focus the parent conversation, and confirm each action lands in the parent's input — gutter paperclip, highlight + "Add as context", header "Add diff set as context", per-file diff attach. Repeat after swapping to the sub-agent's conversation to confirm it targets the sub-agent. Also confirm the selection tooltip hides when no in-repo terminal can be resolved.
+
+## Parallelization
+
+Not beneficial: the change is a single-PR refactor across three tightly coupled files (trait definition, consumer migration, host implementation) where every step depends on the previous one's types. It was implemented sequentially on one branch.
+
+## Follow-ups
+
+- The code pane (`app/src/code/view.rs`) has its own `with_selection_as_context` target function with window-scoped resolution; it was out of scope here but could adopt the same focused-first selection if similar mistargeting is reported outside the review panel.


### PR DESCRIPTION
## Description

There was a bug where "attach as context" actions from the code review panel were not always correctly routed to the focused agent input in orchestrated panes w/ multiple inputs.

We already solved this issue for code review comments by resolving the terminal to send the event to at send time through `RightPanelView::find_review_terminal`. However, we can't quite use the same solution across the board, as some consumers (specifically the selection tooltip) need to know the target terminal synchronously to decide things like visibility and relative path calculation.

Instead, this PR adds a new `ReviewActionTargetProvider` trait that tells consumers which view to send actions to (more info on this provider in the tech spec). This provider allows us to remove the `WeakViewHandle<TerminalView>` field on the `CodeReviewView` entirely.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

## Demo

https://www.loom.com/share/f661dfaf598d4e848f30be5c58136480

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed code review "attach as context" actions (diff hunk, selection, and diff set) sometimes targeting a different agent conversation than the one in focus when using orchestrated agents.