### PR TITLE
Block requests on a one-shot Grok token refresh when the stored token is expired

### DIFF
--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -2372,9 +2372,8 @@ impl BlocklistAIController {
         // Safety net: if the connected Grok subscription's OAuth token is
         // nearing expiry, kick off a background refresh so upcoming requests
         // can authenticate even when the proactive refresh loop isn't
-        // running. (A token already past its expiry is instead refreshed by a
-        // blocking, one-shot attempt in `ResponseStream` before the request
-        // is sent.)
+        // running. (A token already past its expiry is instead refreshed by
+        // the blocking, one-shot attempt started below.)
         #[cfg(not(target_family = "wasm"))]
         {
             use ::ai::api_keys::ApiKeyManager;
@@ -2396,6 +2395,25 @@ impl BlocklistAIController {
         request_params.parent_agent_id = parent_agent_id;
         request_params.agent_name = agent_name;
 
+        // If the Grok OAuth token this request carries is already past its
+        // hard expiry, start a single refresh attempt for the request to
+        // block on before it is sent (awaited in the request task, off the
+        // main thread). If the attempt fails, the request proceeds with the
+        // stale token — the server is the authority on its validity.
+        #[cfg(not(target_family = "wasm"))]
+        let pending_grok_token = request_params
+            .api_keys
+            .as_ref()
+            .is_some_and(|keys| !keys.grok_oauth_access_token.is_empty())
+            .then(|| {
+                ::ai::api_keys::ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
+                    manager.blocking_grok_refresh_for_request(ctx)
+                })
+            })
+            .flatten();
+        #[cfg(target_family = "wasm")]
+        let pending_grok_token = None;
+
         let server_conversation_token_for_identifiers =
             conversation_data.server_conversation_token.clone();
 
@@ -2412,6 +2430,7 @@ impl BlocklistAIController {
                 request_params.clone(),
                 ai_identifiers,
                 can_attempt_resume_on_error,
+                pending_grok_token,
                 ctx,
             )
         });

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -354,13 +354,6 @@ pub struct BlocklistAIController {
             Option<PassiveSuggestionTrigger>,
         )>,
     >,
-
-    /// Conversations whose next request dispatch is deferred behind a
-    /// blocking Grok OAuth token refresh. Presence makes the conversation
-    /// count as having an active request (so concurrent sends are rejected
-    /// like any in-flight request); removal by
-    /// [`Self::cancel_conversation_progress`] abandons the deferred dispatch.
-    conversations_awaiting_grok_refresh: HashSet<AIConversationId>,
 }
 
 enum InputQueryType {
@@ -424,26 +417,6 @@ impl InputQuery {
             InputQueryType::AIInputType { ai_input } => ai_input.user_query().unwrap_or_default(),
         }
     }
-}
-
-/// A validated, ready-to-dispatch agent request: the output of
-/// [`BlocklistAIController::send_request_input`]'s synchronous validation
-/// phase, bundled so the dispatch tail
-/// ([`BlocklistAIController::dispatch_request_input`]) can run either inline
-/// or deferred behind a blocking Grok OAuth token refresh.
-struct PreparedRequestDispatch {
-    request_input: RequestInput,
-    conversation_data: api::ConversationData,
-    query_metadata: Option<RequestMetadata>,
-    default_to_follow_up_on_success: bool,
-    can_attempt_resume_on_error: bool,
-    is_queued_prompt: bool,
-    /// When set, dispatch emits an additional `SentRequest` event marked
-    /// `contains_user_query: true` (e.g. `/summarize`, whose inputs aren't
-    /// user queries but should still clear the input buffer).
-    emit_user_query_sent_event: bool,
-    parent_agent_id: Option<String>,
-    agent_name: Option<String>,
 }
 
 impl BlocklistAIController {
@@ -521,7 +494,10 @@ impl BlocklistAIController {
                 // subscription callback was queued in response to auto-cancelling pending actions
                 // in the process of constructing a request. In such cases, we don't want to update
                 // conversation status to Cancelled/Success.
-                if !me.has_active_stream_for_conversation(*conversation_id, ctx) {
+                if !me
+                    .in_flight_response_streams
+                    .has_active_stream_for_conversation(*conversation_id, ctx)
+                {
                     // If the completed actions do not trigger a follow-up request, update conversation
                     // status based on the outcome of the actions.
                     //
@@ -649,7 +625,6 @@ impl BlocklistAIController {
             pending_local_claude_wakes: HashMap::new(),
             pending_passive_follow_ups: HashSet::new(),
             pending_passive_suggestion_results: HashMap::new(),
-            conversations_awaiting_grok_refresh: HashSet::new(),
         }
     }
 
@@ -868,7 +843,6 @@ impl BlocklistAIController {
             /*default_to_follow_up_on_success*/ true,
             /*can_attempt_resume_on_error*/ true,
             is_queued_prompt,
-            /*emit_user_query_sent_event*/ false,
             ctx,
         );
 
@@ -1406,7 +1380,10 @@ impl BlocklistAIController {
     ) {
         self.pending_passive_follow_ups.insert(conversation_id);
 
-        if self.has_active_stream_for_conversation(conversation_id, ctx) {
+        if self
+            .in_flight_response_streams
+            .has_active_stream_for_conversation(conversation_id, ctx)
+        {
             return;
         }
 
@@ -1534,7 +1511,10 @@ impl BlocklistAIController {
         trigger: FollowUpTrigger,
         ctx: &mut ModelContext<Self>,
     ) {
-        if self.has_active_stream_for_conversation(conversation_id, ctx) {
+        if self
+            .in_flight_response_streams
+            .has_active_stream_for_conversation(conversation_id, ctx)
+        {
             return;
         }
 
@@ -1624,7 +1604,6 @@ impl BlocklistAIController {
             /*default_to_follow_up_on_success*/ false,
             /*can_attempt_resume_on_error*/ true,
             /*is_queued_prompt*/ false,
-            /*emit_user_query_sent_event*/ false,
             ctx,
         );
 
@@ -1645,7 +1624,9 @@ impl BlocklistAIController {
         let owns = BlocklistAIHistoryModel::as_ref(ctx)
             .all_live_conversations_for_terminal_view(self.terminal_view_id)
             .any(|conversation| conversation.id() == conversation_id);
-        let has_active_stream = self.has_active_stream_for_conversation(conversation_id, ctx);
+        let has_active_stream = self
+            .in_flight_response_streams
+            .has_active_stream_for_conversation(conversation_id, ctx);
         let Some(conversation) =
             BlocklistAIHistoryModel::as_ref(ctx).conversation(&conversation_id)
         else {
@@ -1894,7 +1875,6 @@ impl BlocklistAIController {
                 /*default_to_follow_up_on_success*/ true,
                 /*can_attempt_resume_on_error*/ true,
                 /*is_queued_prompt*/ false,
-                /*emit_user_query_sent_event*/ false,
                 ctx,
             )
             .is_err()
@@ -2017,7 +1997,6 @@ impl BlocklistAIController {
             /*default_to_follow_up_on_success*/ true,
             can_attempt_resume_on_error,
             /*is_queued_prompt*/ false,
-            /*emit_user_query_sent_event*/ false,
             ctx,
         );
     }
@@ -2028,7 +2007,7 @@ impl BlocklistAIController {
         block_id: &BlockId,
         file_contexts: Vec<FileContext>,
         ctx: &mut ModelContext<Self>,
-    ) -> anyhow::Result<(AIConversationId, Option<ResponseStreamId>)> {
+    ) -> anyhow::Result<(AIConversationId, ResponseStreamId)> {
         let mut input_context = file_contexts
             .into_iter()
             .map(AIAgentContext::File)
@@ -2066,7 +2045,6 @@ impl BlocklistAIController {
             /*default_to_follow_up_on_success=*/ false,
             /*can_attempt_resume_on_error*/ true,
             /*is_queued_prompt*/ false,
-            /*emit_user_query_sent_event*/ false,
             ctx,
         )
     }
@@ -2196,7 +2174,7 @@ impl BlocklistAIController {
         block_output: String,
         trigger: PassiveSuggestionTrigger,
         ctx: &mut ModelContext<Self>,
-    ) -> anyhow::Result<(AIConversationId, Option<ResponseStreamId>)> {
+    ) -> anyhow::Result<(AIConversationId, ResponseStreamId)> {
         let attachments = vec![AIAgentAttachment::PlainText(block_output.to_string())];
         let trigger_type = (&trigger).into();
         let inputs = vec![AIAgentInput::TriggerPassiveSuggestion {
@@ -2233,7 +2211,6 @@ impl BlocklistAIController {
             /*default_to_follow_up_on_success*/ false,
             /*can_attempt_resume_on_error*/ true,
             /*is_queued_prompt*/ false,
-            /*emit_user_query_sent_event*/ false,
             ctx,
         )
     }
@@ -2291,16 +2268,12 @@ impl BlocklistAIController {
     /// existing in-flight request. Emits an event containing a receiver for the AI's output.
     /// If conversation_id is Some, we follow up in that conversation.
     /// If it's None or we can't find a conversation with that ID, we start a new one.
-    /// Returns the conversation ID of the affected conversation, and the response stream ID
-    /// when the request was dispatched inline. The stream ID is `None` when the dispatch was
-    /// deferred behind a blocking refresh of an expired Grok OAuth token; the eventual
-    /// `SentRequest` event carries the stream ID for both paths.
+    /// Returns the conversation ID of affected conversation and response stream ID.
     ///
     ///  This function does not handle cancelling any in flight requests (and sending them back as
     /// input) for an existing conversation. Consider calling [`Self::send_custom_ai_input_query`] if
     /// you're trying to send a query with a custom [`AIAgentInput`] type where you'd like the "normal"
     /// flow that handles existing conversations properly.
-    #[allow(clippy::too_many_arguments)]
     fn send_request_input(
         &mut self,
         request_input: RequestInput,
@@ -2308,9 +2281,8 @@ impl BlocklistAIController {
         default_to_follow_up_on_success: bool,
         can_attempt_resume_on_error: bool,
         is_queued_prompt: bool,
-        emit_user_query_sent_event: bool,
         ctx: &mut ModelContext<Self>,
-    ) -> anyhow::Result<(AIConversationId, Option<ResponseStreamId>)> {
+    ) -> anyhow::Result<(AIConversationId, ResponseStreamId)> {
         let history_model = BlocklistAIHistoryModel::handle(ctx);
         let (
             conversation_id,
@@ -2353,10 +2325,12 @@ impl BlocklistAIController {
             handle.abort();
         }
 
-        // Make sure there's no existing response stream for the conversation
-        // (including a send already deferred behind a Grok token refresh). If
+        // Make sure there's no existing response stream for the conversation. If
         // there is, something has gone wrong.
-        if self.has_active_stream_for_conversation(conversation_id, ctx) {
+        if self
+            .in_flight_response_streams
+            .has_active_stream_for_conversation(conversation_id, ctx)
+        {
             send_telemetry_from_ctx!(
                 TelemetryEvent::AIInputNotSent {
                     entrypoint: query_metadata.map(|metadata| metadata.entrypoint),
@@ -2395,98 +2369,20 @@ impl BlocklistAIController {
             &conversation_data.server_conversation_token,
         );
 
-        let dispatch = PreparedRequestDispatch {
-            request_input,
-            conversation_data,
-            query_metadata,
-            default_to_follow_up_on_success,
-            can_attempt_resume_on_error,
-            is_queued_prompt,
-            emit_user_query_sent_event,
-            parent_agent_id,
-            agent_name,
-        };
-
-        // The connected Grok subscription's OAuth token is BYO auth that
-        // `RequestParams::new` reads from `ApiKeyManager` when the dispatch
-        // builds the request. Keep it usable:
-        // - nearing expiry: refresh in the background (safety net for the
-        //   proactive refresh loop) without delaying this request;
-        // - already expired: block this request on a single refresh attempt
-        //   by deferring its dispatch until the attempt resolves, so the
-        //   request carries whichever token is then stored — refreshed on
-        //   success, stale on failure/timeout (the server is the authority
-        //   on token validity).
+        // Safety net: if the connected Grok subscription's OAuth token is
+        // nearing or past expiry, kick off a background refresh so upcoming
+        // requests can authenticate even when the proactive refresh loop
+        // isn't running. This request still carries the currently stored
+        // token; the server is the authority on its validity.
         #[cfg(not(target_family = "wasm"))]
         {
             use ::ai::api_keys::ApiKeyManager;
 
             let byo_allowed = UserWorkspaces::as_ref(ctx).is_byo_api_key_enabled(ctx);
-            let pending_refresh = ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
+            ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
                 manager.refresh_grok_tokens_if_needed(byo_allowed, ctx);
-                // When BYO auth is disabled the token is never sent, so a
-                // request must not wait on a refresh.
-                byo_allowed
-                    .then(|| manager.refresh_expired_grok_tokens_before_send(ctx))
-                    .flatten()
             });
-            if let Some(refresh_done) = pending_refresh {
-                let conversation_id = dispatch.conversation_data.id;
-                self.conversations_awaiting_grok_refresh
-                    .insert(conversation_id);
-                ctx.spawn(
-                    // Resolves on success, failure, or timeout; an `Err`
-                    // means the manager dropped the sender, which still
-                    // means the attempt is over.
-                    async move {
-                        let _ = refresh_done.await;
-                    },
-                    move |me, _, ctx| {
-                        // The pending mark doubles as the cancellation
-                        // signal: `cancel_conversation_progress` removes it
-                        // to abandon a deferred dispatch.
-                        if !me
-                            .conversations_awaiting_grok_refresh
-                            .remove(&conversation_id)
-                        {
-                            log::info!(
-                                "Dropping deferred agent request for {conversation_id:?}: cancelled while awaiting the Grok token refresh"
-                            );
-                            return;
-                        }
-                        me.dispatch_request_input(dispatch, ctx);
-                    },
-                );
-                return Ok((conversation_id, None));
-            }
         }
-
-        let (conversation_id, response_stream_id) = self.dispatch_request_input(dispatch, ctx);
-        Ok((conversation_id, Some(response_stream_id)))
-    }
-
-    /// Dispatches a validated agent request: builds the request params
-    /// (injecting BYO API keys — including the currently stored Grok OAuth
-    /// token — at build time), creates the response stream, and performs all
-    /// post-send bookkeeping. Runs inline from [`Self::send_request_input`],
-    /// or deferred behind a blocking Grok token refresh.
-    fn dispatch_request_input(
-        &mut self,
-        dispatch: PreparedRequestDispatch,
-        ctx: &mut ModelContext<Self>,
-    ) -> (AIConversationId, ResponseStreamId) {
-        let PreparedRequestDispatch {
-            request_input,
-            conversation_data,
-            query_metadata,
-            default_to_follow_up_on_success,
-            can_attempt_resume_on_error,
-            is_queued_prompt,
-            emit_user_query_sent_event,
-            parent_agent_id,
-            agent_name,
-        } = dispatch;
-        let history_model = BlocklistAIHistoryModel::handle(ctx);
 
         let mut request_params = api::RequestParams::new(
             Some(self.terminal_view_id),
@@ -2607,16 +2503,6 @@ impl BlocklistAIController {
             model_id: request_params.model.clone(),
             stream_id: response_stream_id.clone(),
         });
-        // Some non-user-query inputs (e.g. `/summarize`) should still drive
-        // user-query side effects like clearing the input buffer.
-        if emit_user_query_sent_event && !input_contains_user_query {
-            ctx.emit(BlocklistAIControllerEvent::SentRequest {
-                contains_user_query: true,
-                is_queued_prompt,
-                model_id: request_params.model.clone(),
-                stream_id: response_stream_id.clone(),
-            });
-        }
         if !is_passive_request {
             history_model.update(ctx, |history_model, ctx| {
                 history_model.mark_active_conversation_id(
@@ -2656,7 +2542,7 @@ impl BlocklistAIController {
             });
         }
 
-        (conversation_data.id, response_stream_id)
+        Ok((conversation_data.id, response_stream_id))
     }
 
     /// Cancels a pending AI request response stream, given the exchange ID, if it exists.
@@ -2676,13 +2562,8 @@ impl BlocklistAIController {
         conversation_id: AIConversationId,
         app: &AppContext,
     ) -> bool {
-        // A send deferred behind a Grok token refresh counts as active: its
-        // dispatch is already committed and will create a stream shortly.
-        self.conversations_awaiting_grok_refresh
-            .contains(&conversation_id)
-            || self
-                .in_flight_response_streams
-                .has_active_stream_for_conversation(conversation_id, app)
+        self.in_flight_response_streams
+            .has_active_stream_for_conversation(conversation_id, app)
     }
 
     /// Cancels 'progress' for the active conversation if there is one:
@@ -2702,17 +2583,6 @@ impl BlocklistAIController {
         // Discard any queued passive suggestion results for this conversation.
         self.pending_passive_suggestion_results
             .remove(&conversation_id);
-
-        // Abandon any send deferred behind a Grok token refresh; its dispatch
-        // callback no-ops once the mark is gone.
-        if self
-            .conversations_awaiting_grok_refresh
-            .remove(&conversation_id)
-        {
-            log::info!(
-                "Cancelled an agent request awaiting a Grok token refresh for {conversation_id:?}"
-            );
-        }
 
         if !self
             .in_flight_response_streams

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -2369,6 +2369,22 @@ impl BlocklistAIController {
             &conversation_data.server_conversation_token,
         );
 
+        // Safety net: if the connected Grok subscription's OAuth token is
+        // nearing expiry, kick off a background refresh so upcoming requests
+        // can authenticate even when the proactive refresh loop isn't
+        // running. (A token already past its expiry is instead refreshed by a
+        // blocking, one-shot attempt in `ResponseStream` before the request
+        // is sent.)
+        #[cfg(not(target_family = "wasm"))]
+        {
+            use ::ai::api_keys::ApiKeyManager;
+
+            let byo_allowed = UserWorkspaces::as_ref(ctx).is_byo_api_key_enabled(ctx);
+            ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
+                manager.refresh_grok_tokens_if_needed(byo_allowed, ctx);
+            });
+        }
+
         let mut request_params = api::RequestParams::new(
             Some(self.terminal_view_id),
             SessionContext::from_session(self.active_session.as_ref(ctx), ctx),

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -354,6 +354,13 @@ pub struct BlocklistAIController {
             Option<PassiveSuggestionTrigger>,
         )>,
     >,
+
+    /// Conversations whose next request dispatch is deferred behind a
+    /// blocking Grok OAuth token refresh. Presence makes the conversation
+    /// count as having an active request (so concurrent sends are rejected
+    /// like any in-flight request); removal by
+    /// [`Self::cancel_conversation_progress`] abandons the deferred dispatch.
+    conversations_awaiting_grok_refresh: HashSet<AIConversationId>,
 }
 
 enum InputQueryType {
@@ -417,6 +424,26 @@ impl InputQuery {
             InputQueryType::AIInputType { ai_input } => ai_input.user_query().unwrap_or_default(),
         }
     }
+}
+
+/// A validated, ready-to-dispatch agent request: the output of
+/// [`BlocklistAIController::send_request_input`]'s synchronous validation
+/// phase, bundled so the dispatch tail
+/// ([`BlocklistAIController::dispatch_request_input`]) can run either inline
+/// or deferred behind a blocking Grok OAuth token refresh.
+struct PreparedRequestDispatch {
+    request_input: RequestInput,
+    conversation_data: api::ConversationData,
+    query_metadata: Option<RequestMetadata>,
+    default_to_follow_up_on_success: bool,
+    can_attempt_resume_on_error: bool,
+    is_queued_prompt: bool,
+    /// When set, dispatch emits an additional `SentRequest` event marked
+    /// `contains_user_query: true` (e.g. `/summarize`, whose inputs aren't
+    /// user queries but should still clear the input buffer).
+    emit_user_query_sent_event: bool,
+    parent_agent_id: Option<String>,
+    agent_name: Option<String>,
 }
 
 impl BlocklistAIController {
@@ -494,10 +521,7 @@ impl BlocklistAIController {
                 // subscription callback was queued in response to auto-cancelling pending actions
                 // in the process of constructing a request. In such cases, we don't want to update
                 // conversation status to Cancelled/Success.
-                if !me
-                    .in_flight_response_streams
-                    .has_active_stream_for_conversation(*conversation_id, ctx)
-                {
+                if !me.has_active_stream_for_conversation(*conversation_id, ctx) {
                     // If the completed actions do not trigger a follow-up request, update conversation
                     // status based on the outcome of the actions.
                     //
@@ -625,6 +649,7 @@ impl BlocklistAIController {
             pending_local_claude_wakes: HashMap::new(),
             pending_passive_follow_ups: HashSet::new(),
             pending_passive_suggestion_results: HashMap::new(),
+            conversations_awaiting_grok_refresh: HashSet::new(),
         }
     }
 
@@ -843,6 +868,7 @@ impl BlocklistAIController {
             /*default_to_follow_up_on_success*/ true,
             /*can_attempt_resume_on_error*/ true,
             is_queued_prompt,
+            /*emit_user_query_sent_event*/ false,
             ctx,
         );
 
@@ -1380,10 +1406,7 @@ impl BlocklistAIController {
     ) {
         self.pending_passive_follow_ups.insert(conversation_id);
 
-        if self
-            .in_flight_response_streams
-            .has_active_stream_for_conversation(conversation_id, ctx)
-        {
+        if self.has_active_stream_for_conversation(conversation_id, ctx) {
             return;
         }
 
@@ -1511,10 +1534,7 @@ impl BlocklistAIController {
         trigger: FollowUpTrigger,
         ctx: &mut ModelContext<Self>,
     ) {
-        if self
-            .in_flight_response_streams
-            .has_active_stream_for_conversation(conversation_id, ctx)
-        {
+        if self.has_active_stream_for_conversation(conversation_id, ctx) {
             return;
         }
 
@@ -1604,6 +1624,7 @@ impl BlocklistAIController {
             /*default_to_follow_up_on_success*/ false,
             /*can_attempt_resume_on_error*/ true,
             /*is_queued_prompt*/ false,
+            /*emit_user_query_sent_event*/ false,
             ctx,
         );
 
@@ -1624,9 +1645,7 @@ impl BlocklistAIController {
         let owns = BlocklistAIHistoryModel::as_ref(ctx)
             .all_live_conversations_for_terminal_view(self.terminal_view_id)
             .any(|conversation| conversation.id() == conversation_id);
-        let has_active_stream = self
-            .in_flight_response_streams
-            .has_active_stream_for_conversation(conversation_id, ctx);
+        let has_active_stream = self.has_active_stream_for_conversation(conversation_id, ctx);
         let Some(conversation) =
             BlocklistAIHistoryModel::as_ref(ctx).conversation(&conversation_id)
         else {
@@ -1875,6 +1894,7 @@ impl BlocklistAIController {
                 /*default_to_follow_up_on_success*/ true,
                 /*can_attempt_resume_on_error*/ true,
                 /*is_queued_prompt*/ false,
+                /*emit_user_query_sent_event*/ false,
                 ctx,
             )
             .is_err()
@@ -1997,6 +2017,7 @@ impl BlocklistAIController {
             /*default_to_follow_up_on_success*/ true,
             can_attempt_resume_on_error,
             /*is_queued_prompt*/ false,
+            /*emit_user_query_sent_event*/ false,
             ctx,
         );
     }
@@ -2007,7 +2028,7 @@ impl BlocklistAIController {
         block_id: &BlockId,
         file_contexts: Vec<FileContext>,
         ctx: &mut ModelContext<Self>,
-    ) -> anyhow::Result<(AIConversationId, ResponseStreamId)> {
+    ) -> anyhow::Result<(AIConversationId, Option<ResponseStreamId>)> {
         let mut input_context = file_contexts
             .into_iter()
             .map(AIAgentContext::File)
@@ -2045,6 +2066,7 @@ impl BlocklistAIController {
             /*default_to_follow_up_on_success=*/ false,
             /*can_attempt_resume_on_error*/ true,
             /*is_queued_prompt*/ false,
+            /*emit_user_query_sent_event*/ false,
             ctx,
         )
     }
@@ -2174,7 +2196,7 @@ impl BlocklistAIController {
         block_output: String,
         trigger: PassiveSuggestionTrigger,
         ctx: &mut ModelContext<Self>,
-    ) -> anyhow::Result<(AIConversationId, ResponseStreamId)> {
+    ) -> anyhow::Result<(AIConversationId, Option<ResponseStreamId>)> {
         let attachments = vec![AIAgentAttachment::PlainText(block_output.to_string())];
         let trigger_type = (&trigger).into();
         let inputs = vec![AIAgentInput::TriggerPassiveSuggestion {
@@ -2211,6 +2233,7 @@ impl BlocklistAIController {
             /*default_to_follow_up_on_success*/ false,
             /*can_attempt_resume_on_error*/ true,
             /*is_queued_prompt*/ false,
+            /*emit_user_query_sent_event*/ false,
             ctx,
         )
     }
@@ -2268,12 +2291,16 @@ impl BlocklistAIController {
     /// existing in-flight request. Emits an event containing a receiver for the AI's output.
     /// If conversation_id is Some, we follow up in that conversation.
     /// If it's None or we can't find a conversation with that ID, we start a new one.
-    /// Returns the conversation ID of affected conversation and response stream ID.
+    /// Returns the conversation ID of the affected conversation, and the response stream ID
+    /// when the request was dispatched inline. The stream ID is `None` when the dispatch was
+    /// deferred behind a blocking refresh of an expired Grok OAuth token; the eventual
+    /// `SentRequest` event carries the stream ID for both paths.
     ///
     ///  This function does not handle cancelling any in flight requests (and sending them back as
     /// input) for an existing conversation. Consider calling [`Self::send_custom_ai_input_query`] if
     /// you're trying to send a query with a custom [`AIAgentInput`] type where you'd like the "normal"
     /// flow that handles existing conversations properly.
+    #[allow(clippy::too_many_arguments)]
     fn send_request_input(
         &mut self,
         request_input: RequestInput,
@@ -2281,8 +2308,9 @@ impl BlocklistAIController {
         default_to_follow_up_on_success: bool,
         can_attempt_resume_on_error: bool,
         is_queued_prompt: bool,
+        emit_user_query_sent_event: bool,
         ctx: &mut ModelContext<Self>,
-    ) -> anyhow::Result<(AIConversationId, ResponseStreamId)> {
+    ) -> anyhow::Result<(AIConversationId, Option<ResponseStreamId>)> {
         let history_model = BlocklistAIHistoryModel::handle(ctx);
         let (
             conversation_id,
@@ -2325,12 +2353,10 @@ impl BlocklistAIController {
             handle.abort();
         }
 
-        // Make sure there's no existing response stream for the conversation. If
+        // Make sure there's no existing response stream for the conversation
+        // (including a send already deferred behind a Grok token refresh). If
         // there is, something has gone wrong.
-        if self
-            .in_flight_response_streams
-            .has_active_stream_for_conversation(conversation_id, ctx)
-        {
+        if self.has_active_stream_for_conversation(conversation_id, ctx) {
             send_telemetry_from_ctx!(
                 TelemetryEvent::AIInputNotSent {
                     entrypoint: query_metadata.map(|metadata| metadata.entrypoint),
@@ -2369,20 +2395,98 @@ impl BlocklistAIController {
             &conversation_data.server_conversation_token,
         );
 
-        // Safety net: if the connected Grok subscription's OAuth token is
-        // nearing expiry, kick off a background refresh so upcoming requests
-        // can authenticate even when the proactive refresh loop isn't
-        // running. (A token already past its expiry is instead refreshed by
-        // the blocking, one-shot attempt started below.)
+        let dispatch = PreparedRequestDispatch {
+            request_input,
+            conversation_data,
+            query_metadata,
+            default_to_follow_up_on_success,
+            can_attempt_resume_on_error,
+            is_queued_prompt,
+            emit_user_query_sent_event,
+            parent_agent_id,
+            agent_name,
+        };
+
+        // The connected Grok subscription's OAuth token is BYO auth that
+        // `RequestParams::new` reads from `ApiKeyManager` when the dispatch
+        // builds the request. Keep it usable:
+        // - nearing expiry: refresh in the background (safety net for the
+        //   proactive refresh loop) without delaying this request;
+        // - already expired: block this request on a single refresh attempt
+        //   by deferring its dispatch until the attempt resolves, so the
+        //   request carries whichever token is then stored — refreshed on
+        //   success, stale on failure/timeout (the server is the authority
+        //   on token validity).
         #[cfg(not(target_family = "wasm"))]
         {
             use ::ai::api_keys::ApiKeyManager;
 
             let byo_allowed = UserWorkspaces::as_ref(ctx).is_byo_api_key_enabled(ctx);
-            ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
+            let pending_refresh = ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
                 manager.refresh_grok_tokens_if_needed(byo_allowed, ctx);
+                // When BYO auth is disabled the token is never sent, so a
+                // request must not wait on a refresh.
+                byo_allowed
+                    .then(|| manager.refresh_expired_grok_tokens_before_send(ctx))
+                    .flatten()
             });
+            if let Some(refresh_done) = pending_refresh {
+                let conversation_id = dispatch.conversation_data.id;
+                self.conversations_awaiting_grok_refresh
+                    .insert(conversation_id);
+                ctx.spawn(
+                    // Resolves on success, failure, or timeout; an `Err`
+                    // means the manager dropped the sender, which still
+                    // means the attempt is over.
+                    async move {
+                        let _ = refresh_done.await;
+                    },
+                    move |me, _, ctx| {
+                        // The pending mark doubles as the cancellation
+                        // signal: `cancel_conversation_progress` removes it
+                        // to abandon a deferred dispatch.
+                        if !me
+                            .conversations_awaiting_grok_refresh
+                            .remove(&conversation_id)
+                        {
+                            log::info!(
+                                "Dropping deferred agent request for {conversation_id:?}: cancelled while awaiting the Grok token refresh"
+                            );
+                            return;
+                        }
+                        me.dispatch_request_input(dispatch, ctx);
+                    },
+                );
+                return Ok((conversation_id, None));
+            }
         }
+
+        let (conversation_id, response_stream_id) = self.dispatch_request_input(dispatch, ctx);
+        Ok((conversation_id, Some(response_stream_id)))
+    }
+
+    /// Dispatches a validated agent request: builds the request params
+    /// (injecting BYO API keys — including the currently stored Grok OAuth
+    /// token — at build time), creates the response stream, and performs all
+    /// post-send bookkeeping. Runs inline from [`Self::send_request_input`],
+    /// or deferred behind a blocking Grok token refresh.
+    fn dispatch_request_input(
+        &mut self,
+        dispatch: PreparedRequestDispatch,
+        ctx: &mut ModelContext<Self>,
+    ) -> (AIConversationId, ResponseStreamId) {
+        let PreparedRequestDispatch {
+            request_input,
+            conversation_data,
+            query_metadata,
+            default_to_follow_up_on_success,
+            can_attempt_resume_on_error,
+            is_queued_prompt,
+            emit_user_query_sent_event,
+            parent_agent_id,
+            agent_name,
+        } = dispatch;
+        let history_model = BlocklistAIHistoryModel::handle(ctx);
 
         let mut request_params = api::RequestParams::new(
             Some(self.terminal_view_id),
@@ -2394,25 +2498,6 @@ impl BlocklistAIController {
         );
         request_params.parent_agent_id = parent_agent_id;
         request_params.agent_name = agent_name;
-
-        // If the Grok OAuth token this request carries is already past its
-        // hard expiry, start a single refresh attempt for the request to
-        // block on before it is sent (awaited in the request task, off the
-        // main thread). If the attempt fails, the request proceeds with the
-        // stale token — the server is the authority on its validity.
-        #[cfg(not(target_family = "wasm"))]
-        let pending_grok_token = request_params
-            .api_keys
-            .as_ref()
-            .is_some_and(|keys| !keys.grok_oauth_access_token.is_empty())
-            .then(|| {
-                ::ai::api_keys::ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
-                    manager.blocking_grok_refresh_for_request(ctx)
-                })
-            })
-            .flatten();
-        #[cfg(target_family = "wasm")]
-        let pending_grok_token = None;
 
         let server_conversation_token_for_identifiers =
             conversation_data.server_conversation_token.clone();
@@ -2430,7 +2515,6 @@ impl BlocklistAIController {
                 request_params.clone(),
                 ai_identifiers,
                 can_attempt_resume_on_error,
-                pending_grok_token,
                 ctx,
             )
         });
@@ -2523,6 +2607,16 @@ impl BlocklistAIController {
             model_id: request_params.model.clone(),
             stream_id: response_stream_id.clone(),
         });
+        // Some non-user-query inputs (e.g. `/summarize`) should still drive
+        // user-query side effects like clearing the input buffer.
+        if emit_user_query_sent_event && !input_contains_user_query {
+            ctx.emit(BlocklistAIControllerEvent::SentRequest {
+                contains_user_query: true,
+                is_queued_prompt,
+                model_id: request_params.model.clone(),
+                stream_id: response_stream_id.clone(),
+            });
+        }
         if !is_passive_request {
             history_model.update(ctx, |history_model, ctx| {
                 history_model.mark_active_conversation_id(
@@ -2562,7 +2656,7 @@ impl BlocklistAIController {
             });
         }
 
-        Ok((conversation_data.id, response_stream_id))
+        (conversation_data.id, response_stream_id)
     }
 
     /// Cancels a pending AI request response stream, given the exchange ID, if it exists.
@@ -2582,8 +2676,13 @@ impl BlocklistAIController {
         conversation_id: AIConversationId,
         app: &AppContext,
     ) -> bool {
-        self.in_flight_response_streams
-            .has_active_stream_for_conversation(conversation_id, app)
+        // A send deferred behind a Grok token refresh counts as active: its
+        // dispatch is already committed and will create a stream shortly.
+        self.conversations_awaiting_grok_refresh
+            .contains(&conversation_id)
+            || self
+                .in_flight_response_streams
+                .has_active_stream_for_conversation(conversation_id, app)
     }
 
     /// Cancels 'progress' for the active conversation if there is one:
@@ -2603,6 +2702,17 @@ impl BlocklistAIController {
         // Discard any queued passive suggestion results for this conversation.
         self.pending_passive_suggestion_results
             .remove(&conversation_id);
+
+        // Abandon any send deferred behind a Grok token refresh; its dispatch
+        // callback no-ops once the mark is gone.
+        if self
+            .conversations_awaiting_grok_refresh
+            .remove(&conversation_id)
+        {
+            log::info!(
+                "Cancelled an agent request awaiting a Grok token refresh for {conversation_id:?}"
+            );
+        }
 
         if !self
             .in_flight_response_streams

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -354,6 +354,13 @@ pub struct BlocklistAIController {
             Option<PassiveSuggestionTrigger>,
         )>,
     >,
+
+    /// Conversations whose next request dispatch is deferred behind a
+    /// blocking Grok OAuth token refresh. Presence makes the conversation
+    /// count as having an active request (so concurrent sends are rejected
+    /// like any in-flight request); removal by
+    /// [`Self::cancel_conversation_progress`] abandons the deferred dispatch.
+    conversations_awaiting_grok_refresh: HashSet<AIConversationId>,
 }
 
 enum InputQueryType {
@@ -417,6 +424,26 @@ impl InputQuery {
             InputQueryType::AIInputType { ai_input } => ai_input.user_query().unwrap_or_default(),
         }
     }
+}
+
+/// A validated, ready-to-dispatch agent request: the output of
+/// [`BlocklistAIController::send_request_input`]'s synchronous validation
+/// phase, bundled so the dispatch tail
+/// ([`BlocklistAIController::dispatch_request_input`]) can run either inline
+/// or deferred behind a blocking Grok OAuth token refresh.
+struct PreparedRequestDispatch {
+    request_input: RequestInput,
+    conversation_data: api::ConversationData,
+    query_metadata: Option<RequestMetadata>,
+    default_to_follow_up_on_success: bool,
+    can_attempt_resume_on_error: bool,
+    is_queued_prompt: bool,
+    /// When set, dispatch emits an additional `SentRequest` event marked
+    /// `contains_user_query: true` (e.g. `/summarize`, whose inputs aren't
+    /// user queries but should still clear the input buffer).
+    emit_user_query_sent_event: bool,
+    parent_agent_id: Option<String>,
+    agent_name: Option<String>,
 }
 
 impl BlocklistAIController {
@@ -494,10 +521,7 @@ impl BlocklistAIController {
                 // subscription callback was queued in response to auto-cancelling pending actions
                 // in the process of constructing a request. In such cases, we don't want to update
                 // conversation status to Cancelled/Success.
-                if !me
-                    .in_flight_response_streams
-                    .has_active_stream_for_conversation(*conversation_id, ctx)
-                {
+                if !me.has_active_stream_for_conversation(*conversation_id, ctx) {
                     // If the completed actions do not trigger a follow-up request, update conversation
                     // status based on the outcome of the actions.
                     //
@@ -625,6 +649,7 @@ impl BlocklistAIController {
             pending_local_claude_wakes: HashMap::new(),
             pending_passive_follow_ups: HashSet::new(),
             pending_passive_suggestion_results: HashMap::new(),
+            conversations_awaiting_grok_refresh: HashSet::new(),
         }
     }
 
@@ -843,6 +868,7 @@ impl BlocklistAIController {
             /*default_to_follow_up_on_success*/ true,
             /*can_attempt_resume_on_error*/ true,
             is_queued_prompt,
+            /*emit_user_query_sent_event*/ false,
             ctx,
         );
 
@@ -1380,10 +1406,7 @@ impl BlocklistAIController {
     ) {
         self.pending_passive_follow_ups.insert(conversation_id);
 
-        if self
-            .in_flight_response_streams
-            .has_active_stream_for_conversation(conversation_id, ctx)
-        {
+        if self.has_active_stream_for_conversation(conversation_id, ctx) {
             return;
         }
 
@@ -1511,10 +1534,7 @@ impl BlocklistAIController {
         trigger: FollowUpTrigger,
         ctx: &mut ModelContext<Self>,
     ) {
-        if self
-            .in_flight_response_streams
-            .has_active_stream_for_conversation(conversation_id, ctx)
-        {
+        if self.has_active_stream_for_conversation(conversation_id, ctx) {
             return;
         }
 
@@ -1604,6 +1624,7 @@ impl BlocklistAIController {
             /*default_to_follow_up_on_success*/ false,
             /*can_attempt_resume_on_error*/ true,
             /*is_queued_prompt*/ false,
+            /*emit_user_query_sent_event*/ false,
             ctx,
         );
 
@@ -1624,9 +1645,7 @@ impl BlocklistAIController {
         let owns = BlocklistAIHistoryModel::as_ref(ctx)
             .all_live_conversations_for_terminal_view(self.terminal_view_id)
             .any(|conversation| conversation.id() == conversation_id);
-        let has_active_stream = self
-            .in_flight_response_streams
-            .has_active_stream_for_conversation(conversation_id, ctx);
+        let has_active_stream = self.has_active_stream_for_conversation(conversation_id, ctx);
         let Some(conversation) =
             BlocklistAIHistoryModel::as_ref(ctx).conversation(&conversation_id)
         else {
@@ -1875,6 +1894,7 @@ impl BlocklistAIController {
                 /*default_to_follow_up_on_success*/ true,
                 /*can_attempt_resume_on_error*/ true,
                 /*is_queued_prompt*/ false,
+                /*emit_user_query_sent_event*/ false,
                 ctx,
             )
             .is_err()
@@ -1997,6 +2017,7 @@ impl BlocklistAIController {
             /*default_to_follow_up_on_success*/ true,
             can_attempt_resume_on_error,
             /*is_queued_prompt*/ false,
+            /*emit_user_query_sent_event*/ false,
             ctx,
         );
     }
@@ -2007,7 +2028,7 @@ impl BlocklistAIController {
         block_id: &BlockId,
         file_contexts: Vec<FileContext>,
         ctx: &mut ModelContext<Self>,
-    ) -> anyhow::Result<(AIConversationId, ResponseStreamId)> {
+    ) -> anyhow::Result<(AIConversationId, Option<ResponseStreamId>)> {
         let mut input_context = file_contexts
             .into_iter()
             .map(AIAgentContext::File)
@@ -2045,6 +2066,7 @@ impl BlocklistAIController {
             /*default_to_follow_up_on_success=*/ false,
             /*can_attempt_resume_on_error*/ true,
             /*is_queued_prompt*/ false,
+            /*emit_user_query_sent_event*/ false,
             ctx,
         )
     }
@@ -2174,7 +2196,7 @@ impl BlocklistAIController {
         block_output: String,
         trigger: PassiveSuggestionTrigger,
         ctx: &mut ModelContext<Self>,
-    ) -> anyhow::Result<(AIConversationId, ResponseStreamId)> {
+    ) -> anyhow::Result<(AIConversationId, Option<ResponseStreamId>)> {
         let attachments = vec![AIAgentAttachment::PlainText(block_output.to_string())];
         let trigger_type = (&trigger).into();
         let inputs = vec![AIAgentInput::TriggerPassiveSuggestion {
@@ -2211,6 +2233,7 @@ impl BlocklistAIController {
             /*default_to_follow_up_on_success*/ false,
             /*can_attempt_resume_on_error*/ true,
             /*is_queued_prompt*/ false,
+            /*emit_user_query_sent_event*/ false,
             ctx,
         )
     }
@@ -2268,12 +2291,16 @@ impl BlocklistAIController {
     /// existing in-flight request. Emits an event containing a receiver for the AI's output.
     /// If conversation_id is Some, we follow up in that conversation.
     /// If it's None or we can't find a conversation with that ID, we start a new one.
-    /// Returns the conversation ID of affected conversation and response stream ID.
+    /// Returns the conversation ID of the affected conversation, and the response stream ID
+    /// when the request was dispatched inline. The stream ID is `None` when the dispatch was
+    /// deferred behind a blocking refresh of an expired Grok OAuth token; the eventual
+    /// `SentRequest` event carries the stream ID for both paths.
     ///
     ///  This function does not handle cancelling any in flight requests (and sending them back as
     /// input) for an existing conversation. Consider calling [`Self::send_custom_ai_input_query`] if
     /// you're trying to send a query with a custom [`AIAgentInput`] type where you'd like the "normal"
     /// flow that handles existing conversations properly.
+    #[allow(clippy::too_many_arguments)]
     fn send_request_input(
         &mut self,
         request_input: RequestInput,
@@ -2281,8 +2308,9 @@ impl BlocklistAIController {
         default_to_follow_up_on_success: bool,
         can_attempt_resume_on_error: bool,
         is_queued_prompt: bool,
+        emit_user_query_sent_event: bool,
         ctx: &mut ModelContext<Self>,
-    ) -> anyhow::Result<(AIConversationId, ResponseStreamId)> {
+    ) -> anyhow::Result<(AIConversationId, Option<ResponseStreamId>)> {
         let history_model = BlocklistAIHistoryModel::handle(ctx);
         let (
             conversation_id,
@@ -2325,12 +2353,10 @@ impl BlocklistAIController {
             handle.abort();
         }
 
-        // Make sure there's no existing response stream for the conversation. If
+        // Make sure there's no existing response stream for the conversation
+        // (including a send already deferred behind a Grok token refresh). If
         // there is, something has gone wrong.
-        if self
-            .in_flight_response_streams
-            .has_active_stream_for_conversation(conversation_id, ctx)
-        {
+        if self.has_active_stream_for_conversation(conversation_id, ctx) {
             send_telemetry_from_ctx!(
                 TelemetryEvent::AIInputNotSent {
                     entrypoint: query_metadata.map(|metadata| metadata.entrypoint),
@@ -2369,20 +2395,98 @@ impl BlocklistAIController {
             &conversation_data.server_conversation_token,
         );
 
-        // Safety net: if the connected Grok subscription's OAuth token is
-        // nearing or past expiry, kick off a background refresh so upcoming
-        // requests can authenticate even when the proactive refresh loop
-        // isn't running. This request still carries the currently stored
-        // token; the server is the authority on its validity.
+        let dispatch = PreparedRequestDispatch {
+            request_input,
+            conversation_data,
+            query_metadata,
+            default_to_follow_up_on_success,
+            can_attempt_resume_on_error,
+            is_queued_prompt,
+            emit_user_query_sent_event,
+            parent_agent_id,
+            agent_name,
+        };
+
+        // The connected Grok subscription's OAuth token is BYO auth that
+        // `RequestParams::new` reads from `ApiKeyManager` when the dispatch
+        // builds the request. Keep it usable:
+        // - nearing expiry: refresh in the background (safety net for the
+        //   proactive refresh loop) without delaying this request;
+        // - already expired: block this request on a single refresh attempt
+        //   by deferring its dispatch until the attempt resolves, so the
+        //   request carries whichever token is then stored — refreshed on
+        //   success, stale on failure/timeout (the server is the authority
+        //   on token validity).
         #[cfg(not(target_family = "wasm"))]
         {
             use ::ai::api_keys::ApiKeyManager;
 
             let byo_allowed = UserWorkspaces::as_ref(ctx).is_byo_api_key_enabled(ctx);
-            ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
+            let pending_refresh = ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
                 manager.refresh_grok_tokens_if_needed(byo_allowed, ctx);
+                // When BYO auth is disabled the token is never sent, so a
+                // request must not wait on a refresh.
+                byo_allowed
+                    .then(|| manager.refresh_expired_grok_tokens_before_send(ctx))
+                    .flatten()
             });
+            if let Some(refresh_done) = pending_refresh {
+                let conversation_id = dispatch.conversation_data.id;
+                self.conversations_awaiting_grok_refresh
+                    .insert(conversation_id);
+                ctx.spawn(
+                    // Resolves on success, failure, or timeout; an `Err`
+                    // means the manager dropped the sender, which still
+                    // means the attempt is over.
+                    async move {
+                        let _ = refresh_done.await;
+                    },
+                    move |me, _, ctx| {
+                        // The pending mark doubles as the cancellation
+                        // signal: `cancel_conversation_progress` removes it
+                        // to abandon a deferred dispatch.
+                        if !me
+                            .conversations_awaiting_grok_refresh
+                            .remove(&conversation_id)
+                        {
+                            log::info!(
+                                "Dropping deferred agent request for {conversation_id:?}: cancelled while awaiting the Grok token refresh"
+                            );
+                            return;
+                        }
+                        me.dispatch_request_input(dispatch, ctx);
+                    },
+                );
+                return Ok((conversation_id, None));
+            }
         }
+
+        let (conversation_id, response_stream_id) = self.dispatch_request_input(dispatch, ctx);
+        Ok((conversation_id, Some(response_stream_id)))
+    }
+
+    /// Dispatches a validated agent request: builds the request params
+    /// (injecting BYO API keys — including the currently stored Grok OAuth
+    /// token — at build time), creates the response stream, and performs all
+    /// post-send bookkeeping. Runs inline from [`Self::send_request_input`],
+    /// or deferred behind a blocking Grok token refresh.
+    fn dispatch_request_input(
+        &mut self,
+        dispatch: PreparedRequestDispatch,
+        ctx: &mut ModelContext<Self>,
+    ) -> (AIConversationId, ResponseStreamId) {
+        let PreparedRequestDispatch {
+            request_input,
+            conversation_data,
+            query_metadata,
+            default_to_follow_up_on_success,
+            can_attempt_resume_on_error,
+            is_queued_prompt,
+            emit_user_query_sent_event,
+            parent_agent_id,
+            agent_name,
+        } = dispatch;
+        let history_model = BlocklistAIHistoryModel::handle(ctx);
 
         let mut request_params = api::RequestParams::new(
             Some(self.terminal_view_id),
@@ -2503,6 +2607,16 @@ impl BlocklistAIController {
             model_id: request_params.model.clone(),
             stream_id: response_stream_id.clone(),
         });
+        // Some non-user-query inputs (e.g. `/summarize`) should still drive
+        // user-query side effects like clearing the input buffer.
+        if emit_user_query_sent_event && !input_contains_user_query {
+            ctx.emit(BlocklistAIControllerEvent::SentRequest {
+                contains_user_query: true,
+                is_queued_prompt,
+                model_id: request_params.model.clone(),
+                stream_id: response_stream_id.clone(),
+            });
+        }
         if !is_passive_request {
             history_model.update(ctx, |history_model, ctx| {
                 history_model.mark_active_conversation_id(
@@ -2542,7 +2656,7 @@ impl BlocklistAIController {
             });
         }
 
-        Ok((conversation_data.id, response_stream_id))
+        (conversation_data.id, response_stream_id)
     }
 
     /// Cancels a pending AI request response stream, given the exchange ID, if it exists.
@@ -2562,8 +2676,13 @@ impl BlocklistAIController {
         conversation_id: AIConversationId,
         app: &AppContext,
     ) -> bool {
-        self.in_flight_response_streams
-            .has_active_stream_for_conversation(conversation_id, app)
+        // A send deferred behind a Grok token refresh counts as active: its
+        // dispatch is already committed and will create a stream shortly.
+        self.conversations_awaiting_grok_refresh
+            .contains(&conversation_id)
+            || self
+                .in_flight_response_streams
+                .has_active_stream_for_conversation(conversation_id, app)
     }
 
     /// Cancels 'progress' for the active conversation if there is one:
@@ -2583,6 +2702,17 @@ impl BlocklistAIController {
         // Discard any queued passive suggestion results for this conversation.
         self.pending_passive_suggestion_results
             .remove(&conversation_id);
+
+        // Abandon any send deferred behind a Grok token refresh; its dispatch
+        // callback no-ops once the mark is gone.
+        if self
+            .conversations_awaiting_grok_refresh
+            .remove(&conversation_id)
+        {
+            log::info!(
+                "Cancelled an agent request awaiting a Grok token refresh for {conversation_id:?}"
+            );
+        }
 
         if !self
             .in_flight_response_streams

--- a/app/src/ai/blocklist/controller/response_stream.rs
+++ b/app/src/ai/blocklist/controller/response_stream.rs
@@ -35,112 +35,43 @@ impl ResponseStreamId {
 /// Spawns the multi-agent API request for `params`, routing the result to
 /// `ResponseStream::handle_response_stream_result`.
 ///
-/// When the params carry a Grok OAuth token that is already past its hard
-/// expiry, the request first blocks on a single refresh attempt so it goes
-/// out with a usable token. A failed attempt is logged and the request
-/// proceeds with the stale token — the server is the authority on validity.
+/// `pending_grok_token` is an optional in-flight Grok OAuth token refresh
+/// started by the controller (see `BlocklistAIController::send_request_input`)
+/// for a token that is already past its expiry. When present, the request
+/// blocks on it and carries the refreshed token; on failure it proceeds with
+/// the stale token — the server is the authority on validity. The refreshed
+/// token is also written back to `ResponseStream::params` so retries reuse it.
 fn spawn_request(
-    #[cfg_attr(target_family = "wasm", allow(unused_mut))] mut params: api::RequestParams,
+    mut params: api::RequestParams,
+    pending_grok_token: Option<oneshot::Receiver<Option<String>>>,
     cancellation_rx: oneshot::Receiver<()>,
     request_id: Uuid,
     ctx: &mut ModelContext<ResponseStream>,
 ) {
     let server_api = ServerApiProvider::as_ref(ctx).get();
-
-    #[cfg(not(target_family = "wasm"))]
-    {
-        use ::ai::api_keys::ApiKeyManager;
-
-        let grok_refresh_token = claim_expired_grok_token_refresh(&mut params, ctx);
-        let _ = ctx.spawn(
-            async move {
-                // `None`: no refresh was needed; `Some(None)`: the attempt
-                // failed; `Some(Some(response))`: refreshed successfully.
-                let refresh_outcome = match grok_refresh_token {
-                    Some(refresh_token) => Some(refresh_expired_grok_token(refresh_token).await),
-                    None => None,
-                };
-                if let Some(Some(response)) = &refresh_outcome {
-                    if let Some(api_keys) = params.api_keys.as_mut() {
-                        api_keys.grok_oauth_access_token = response.access_token.clone();
-                    }
-                }
-                let stream = generate_multi_agent_output(server_api, params, cancellation_rx).await;
-                (refresh_outcome, stream)
-            },
-            move |me, (refresh_outcome, stream), ctx| {
-                if let Some(outcome) = refresh_outcome {
-                    ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
-                        manager.finish_blocking_grok_refresh(outcome, ctx);
-                    });
-                }
-                me.handle_response_stream_result(request_id, stream, ctx);
-            },
-        );
-    }
-
-    #[cfg(target_family = "wasm")]
-    {
-        let _ = ctx.spawn(
-            async move { generate_multi_agent_output(server_api, params, cancellation_rx).await },
-            move |me, stream, ctx| {
-                me.handle_response_stream_result(request_id, stream, ctx);
-            },
-        );
-    }
-}
-
-/// Claims a single request-blocking refresh of the Grok OAuth token when the
-/// stored token is already past its hard expiry, returning the refresh token
-/// to exchange. Also swaps the request's Grok token for the latest stored
-/// one, since a background refresh may have rotated it after the params were
-/// built (e.g. for retries).
-///
-/// The caller MUST report the refresh outcome via
-/// `ApiKeyManager::finish_blocking_grok_refresh` to release the claim.
-#[cfg(not(target_family = "wasm"))]
-fn claim_expired_grok_token_refresh(
-    params: &mut api::RequestParams,
-    ctx: &mut ModelContext<ResponseStream>,
-) -> Option<String> {
-    use ::ai::api_keys::{ApiKeyManager, GrokTokens};
-
-    let api_keys = params.api_keys.as_mut()?;
-    // An empty token means no Grok subscription is connected or BYO auth is
-    // disallowed by policy; either way there's nothing to refresh.
-    if api_keys.grok_oauth_access_token.is_empty() {
-        return None;
-    }
-    ApiKeyManager::handle(ctx).update(ctx, |manager, _| {
-        if let Some(token) = manager
-            .grok_tokens()
-            .and_then(GrokTokens::access_token_for_request)
-        {
-            api_keys.grok_oauth_access_token = token.to_owned();
-        }
-        manager.claim_blocking_grok_refresh()
-    })
-}
-
-/// Performs the single blocking Grok token refresh attempt for a request,
-/// logging the outcome. Returns `None` when the attempt failed.
-#[cfg(not(target_family = "wasm"))]
-async fn refresh_expired_grok_token(
-    refresh_token: String,
-) -> Option<::ai::grok_subscription::oauth::TokenResponse> {
-    use ::ai::grok_subscription::oauth;
-
-    log::info!("Grok OAuth token is past its expiry; refreshing it before sending the request");
-    match oauth::refresh_access_token(&refresh_token).await {
-        Ok(response) => Some(response),
-        Err(err) => {
-            log::error!(
-                "Failed to refresh the expired Grok OAuth token before a request; \
-                 sending the stale token: {err:#}"
-            );
-            None
-        }
-    }
+    let _ = ctx.spawn(
+        async move {
+            // `None` (refresh failed, or the refresher was dropped) keeps the
+            // stale token already present in the params.
+            let refreshed_token = match pending_grok_token {
+                Some(receiver) => receiver.await.ok().flatten(),
+                None => None,
+            };
+            if let (Some(token), Some(api_keys)) = (&refreshed_token, params.api_keys.as_mut()) {
+                api_keys.grok_oauth_access_token = token.clone();
+            }
+            let stream = generate_multi_agent_output(server_api, params, cancellation_rx).await;
+            (refreshed_token, stream)
+        },
+        move |me, (refreshed_token, stream), ctx| {
+            // Keep the stored params in sync so a retry sends the refreshed
+            // token rather than the stale one captured at build time.
+            if let (Some(token), Some(api_keys)) = (refreshed_token, me.params.api_keys.as_mut()) {
+                api_keys.grok_oauth_access_token = token;
+            }
+            me.handle_response_stream_result(request_id, stream, ctx);
+        },
+    );
 }
 
 /// Model wrapping an agent API response stream.
@@ -191,13 +122,20 @@ impl ResponseStream {
         params: api::RequestParams,
         ai_identifiers: AIIdentifiers,
         can_attempt_resume_on_error: bool,
+        pending_grok_token: Option<oneshot::Receiver<Option<String>>>,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         let (cancellation_tx, cancellation_rx) = oneshot::channel();
         let start_time = Local::now();
 
         let request_id = Uuid::new_v4();
-        spawn_request(params.clone(), cancellation_rx, request_id, ctx);
+        spawn_request(
+            params.clone(),
+            pending_grok_token,
+            cancellation_rx,
+            request_id,
+            ctx,
+        );
         Self {
             id: ResponseStreamId(Uuid::new_v4().to_string()),
             params: params.clone(),
@@ -252,7 +190,7 @@ impl ResponseStream {
 
         let request_id = Uuid::new_v4();
         self.current_request_id = Some(request_id);
-        spawn_request(self.params.clone(), cancellation_rx, request_id, ctx);
+        spawn_request(self.params.clone(), None, cancellation_rx, request_id, ctx);
     }
 
     /// Cancels the stream. The conversation_id is preserved in the emitted event for async handling.

--- a/app/src/ai/blocklist/controller/response_stream.rs
+++ b/app/src/ai/blocklist/controller/response_stream.rs
@@ -32,6 +32,117 @@ impl ResponseStreamId {
     }
 }
 
+/// Spawns the multi-agent API request for `params`, routing the result to
+/// `ResponseStream::handle_response_stream_result`.
+///
+/// When the params carry a Grok OAuth token that is already past its hard
+/// expiry, the request first blocks on a single refresh attempt so it goes
+/// out with a usable token. A failed attempt is logged and the request
+/// proceeds with the stale token — the server is the authority on validity.
+fn spawn_request(
+    #[cfg_attr(target_family = "wasm", allow(unused_mut))] mut params: api::RequestParams,
+    cancellation_rx: oneshot::Receiver<()>,
+    request_id: Uuid,
+    ctx: &mut ModelContext<ResponseStream>,
+) {
+    let server_api = ServerApiProvider::as_ref(ctx).get();
+
+    #[cfg(not(target_family = "wasm"))]
+    {
+        use ::ai::api_keys::ApiKeyManager;
+
+        let grok_refresh_token = claim_expired_grok_token_refresh(&mut params, ctx);
+        let _ = ctx.spawn(
+            async move {
+                // `None`: no refresh was needed; `Some(None)`: the attempt
+                // failed; `Some(Some(response))`: refreshed successfully.
+                let refresh_outcome = match grok_refresh_token {
+                    Some(refresh_token) => Some(refresh_expired_grok_token(refresh_token).await),
+                    None => None,
+                };
+                if let Some(Some(response)) = &refresh_outcome {
+                    if let Some(api_keys) = params.api_keys.as_mut() {
+                        api_keys.grok_oauth_access_token = response.access_token.clone();
+                    }
+                }
+                let stream = generate_multi_agent_output(server_api, params, cancellation_rx).await;
+                (refresh_outcome, stream)
+            },
+            move |me, (refresh_outcome, stream), ctx| {
+                if let Some(outcome) = refresh_outcome {
+                    ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
+                        manager.finish_blocking_grok_refresh(outcome, ctx);
+                    });
+                }
+                me.handle_response_stream_result(request_id, stream, ctx);
+            },
+        );
+    }
+
+    #[cfg(target_family = "wasm")]
+    {
+        let _ = ctx.spawn(
+            async move { generate_multi_agent_output(server_api, params, cancellation_rx).await },
+            move |me, stream, ctx| {
+                me.handle_response_stream_result(request_id, stream, ctx);
+            },
+        );
+    }
+}
+
+/// Claims a single request-blocking refresh of the Grok OAuth token when the
+/// stored token is already past its hard expiry, returning the refresh token
+/// to exchange. Also swaps the request's Grok token for the latest stored
+/// one, since a background refresh may have rotated it after the params were
+/// built (e.g. for retries).
+///
+/// The caller MUST report the refresh outcome via
+/// `ApiKeyManager::finish_blocking_grok_refresh` to release the claim.
+#[cfg(not(target_family = "wasm"))]
+fn claim_expired_grok_token_refresh(
+    params: &mut api::RequestParams,
+    ctx: &mut ModelContext<ResponseStream>,
+) -> Option<String> {
+    use ::ai::api_keys::{ApiKeyManager, GrokTokens};
+
+    let api_keys = params.api_keys.as_mut()?;
+    // An empty token means no Grok subscription is connected or BYO auth is
+    // disallowed by policy; either way there's nothing to refresh.
+    if api_keys.grok_oauth_access_token.is_empty() {
+        return None;
+    }
+    ApiKeyManager::handle(ctx).update(ctx, |manager, _| {
+        if let Some(token) = manager
+            .grok_tokens()
+            .and_then(GrokTokens::access_token_for_request)
+        {
+            api_keys.grok_oauth_access_token = token.to_owned();
+        }
+        manager.claim_blocking_grok_refresh()
+    })
+}
+
+/// Performs the single blocking Grok token refresh attempt for a request,
+/// logging the outcome. Returns `None` when the attempt failed.
+#[cfg(not(target_family = "wasm"))]
+async fn refresh_expired_grok_token(
+    refresh_token: String,
+) -> Option<::ai::grok_subscription::oauth::TokenResponse> {
+    use ::ai::grok_subscription::oauth;
+
+    log::info!("Grok OAuth token is past its expiry; refreshing it before sending the request");
+    match oauth::refresh_access_token(&refresh_token).await {
+        Ok(response) => Some(response),
+        Err(err) => {
+            log::error!(
+                "Failed to refresh the expired Grok OAuth token before a request; \
+                 sending the stale token: {err:#}"
+            );
+            None
+        }
+    }
+}
+
 /// Model wrapping an agent API response stream.
 ///
 /// Emits events when the output corresponding to the stream is updated, typically after receiving
@@ -82,21 +193,11 @@ impl ResponseStream {
         can_attempt_resume_on_error: bool,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
-        let server_api = ServerApiProvider::as_ref(ctx).get();
         let (cancellation_tx, cancellation_rx) = oneshot::channel();
         let start_time = Local::now();
 
         let request_id = Uuid::new_v4();
-        let params_clone = params.clone();
-        let _ =
-            ctx.spawn(
-                async move {
-                    generate_multi_agent_output(server_api, params_clone, cancellation_rx).await
-                },
-                move |me, stream, ctx| {
-                    me.handle_response_stream_result(request_id, stream, ctx);
-                },
-            );
+        spawn_request(params.clone(), cancellation_rx, request_id, ctx);
         Self {
             id: ResponseStreamId(Uuid::new_v4().to_string()),
             params: params.clone(),
@@ -151,14 +252,7 @@ impl ResponseStream {
 
         let request_id = Uuid::new_v4();
         self.current_request_id = Some(request_id);
-        let params = self.params.clone();
-        let server_api = ServerApiProvider::as_ref(ctx).get();
-        let _ = ctx.spawn(
-            async move { generate_multi_agent_output(server_api, params, cancellation_rx).await },
-            move |me, stream, ctx| {
-                me.handle_response_stream_result(request_id, stream, ctx);
-            },
-        );
+        spawn_request(self.params.clone(), cancellation_rx, request_id, ctx);
     }
 
     /// Cancels the stream. The conversation_id is preserved in the emitted event for async handling.

--- a/app/src/ai/blocklist/controller/response_stream.rs
+++ b/app/src/ai/blocklist/controller/response_stream.rs
@@ -32,48 +32,6 @@ impl ResponseStreamId {
     }
 }
 
-/// Spawns the multi-agent API request for `params`, routing the result to
-/// `ResponseStream::handle_response_stream_result`.
-///
-/// `pending_grok_token` is an optional in-flight Grok OAuth token refresh
-/// started by the controller (see `BlocklistAIController::send_request_input`)
-/// for a token that is already past its expiry. When present, the request
-/// blocks on it and carries the refreshed token; on failure it proceeds with
-/// the stale token — the server is the authority on validity. The refreshed
-/// token is also written back to `ResponseStream::params` so retries reuse it.
-fn spawn_request(
-    mut params: api::RequestParams,
-    pending_grok_token: Option<oneshot::Receiver<Option<String>>>,
-    cancellation_rx: oneshot::Receiver<()>,
-    request_id: Uuid,
-    ctx: &mut ModelContext<ResponseStream>,
-) {
-    let server_api = ServerApiProvider::as_ref(ctx).get();
-    let _ = ctx.spawn(
-        async move {
-            // `None` (refresh failed, or the refresher was dropped) keeps the
-            // stale token already present in the params.
-            let refreshed_token = match pending_grok_token {
-                Some(receiver) => receiver.await.ok().flatten(),
-                None => None,
-            };
-            if let (Some(token), Some(api_keys)) = (&refreshed_token, params.api_keys.as_mut()) {
-                api_keys.grok_oauth_access_token = token.clone();
-            }
-            let stream = generate_multi_agent_output(server_api, params, cancellation_rx).await;
-            (refreshed_token, stream)
-        },
-        move |me, (refreshed_token, stream), ctx| {
-            // Keep the stored params in sync so a retry sends the refreshed
-            // token rather than the stale one captured at build time.
-            if let (Some(token), Some(api_keys)) = (refreshed_token, me.params.api_keys.as_mut()) {
-                api_keys.grok_oauth_access_token = token;
-            }
-            me.handle_response_stream_result(request_id, stream, ctx);
-        },
-    );
-}
-
 /// Model wrapping an agent API response stream.
 ///
 /// Emits events when the output corresponding to the stream is updated, typically after receiving
@@ -122,20 +80,23 @@ impl ResponseStream {
         params: api::RequestParams,
         ai_identifiers: AIIdentifiers,
         can_attempt_resume_on_error: bool,
-        pending_grok_token: Option<oneshot::Receiver<Option<String>>>,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
+        let server_api = ServerApiProvider::as_ref(ctx).get();
         let (cancellation_tx, cancellation_rx) = oneshot::channel();
         let start_time = Local::now();
 
         let request_id = Uuid::new_v4();
-        spawn_request(
-            params.clone(),
-            pending_grok_token,
-            cancellation_rx,
-            request_id,
-            ctx,
-        );
+        let params_clone = params.clone();
+        let _ =
+            ctx.spawn(
+                async move {
+                    generate_multi_agent_output(server_api, params_clone, cancellation_rx).await
+                },
+                move |me, stream, ctx| {
+                    me.handle_response_stream_result(request_id, stream, ctx);
+                },
+            );
         Self {
             id: ResponseStreamId(Uuid::new_v4().to_string()),
             params: params.clone(),
@@ -190,7 +151,14 @@ impl ResponseStream {
 
         let request_id = Uuid::new_v4();
         self.current_request_id = Some(request_id);
-        spawn_request(self.params.clone(), None, cancellation_rx, request_id, ctx);
+        let params = self.params.clone();
+        let server_api = ServerApiProvider::as_ref(ctx).get();
+        let _ = ctx.spawn(
+            async move { generate_multi_agent_output(server_api, params, cancellation_rx).await },
+            move |me, stream, ctx| {
+                me.handle_response_stream_result(request_id, stream, ctx);
+            },
+        );
     }
 
     /// Cancels the stream. The conversation_id is preserved in the emitted event for async handling.

--- a/app/src/ai/blocklist/controller/slash_command.rs
+++ b/app/src/ai/blocklist/controller/slash_command.rs
@@ -5,7 +5,7 @@ use warpui::{AppContext, ModelContext, SingletonEntity};
 
 use super::{
     add_pending_file_attachments, input_context_for_request, parse_context_attachments,
-    BlocklistAIController, RequestInput,
+    BlocklistAIController, BlocklistAIControllerEvent, RequestInput,
 };
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent::{
@@ -179,6 +179,7 @@ impl SlashCommandRequest {
             controller.terminal_view_id,
             ctx,
         );
+        let model_id = request_input.model_id.clone();
 
         match controller.send_request_input(
             request_input,
@@ -190,19 +191,23 @@ impl SlashCommandRequest {
             /*default_to_follow_up_on_success*/ true,
             /*can_attempt_resume_on_error*/ true,
             is_queued_prompt,
-            // `/summarize` inputs aren't user queries, but submitting one
-            // should still clear the input buffer like a user query; the
-            // dispatch emits the user-query `SentRequest` event for it.
-            /*emit_user_query_sent_event*/
-            is_summarize,
             ctx,
         ) {
-            Ok(_) => {
+            Ok((_, stream_id)) => {
                 // Direct skills consume live pending context; queued skills consume row-owned
                 // context and must not clear a new draft's staged attachments.
                 if is_invoke_skill && !is_queued_prompt {
                     controller.context_model.update(ctx, |context_model, ctx| {
                         context_model.reset_context_to_default(ctx);
+                    });
+                }
+                // Emit SentRequest event to trigger buffer clearing
+                if is_summarize {
+                    ctx.emit(BlocklistAIControllerEvent::SentRequest {
+                        contains_user_query: true,
+                        is_queued_prompt,
+                        model_id,
+                        stream_id,
                     });
                 }
             }

--- a/app/src/ai/blocklist/controller/slash_command.rs
+++ b/app/src/ai/blocklist/controller/slash_command.rs
@@ -5,7 +5,7 @@ use warpui::{AppContext, ModelContext, SingletonEntity};
 
 use super::{
     add_pending_file_attachments, input_context_for_request, parse_context_attachments,
-    BlocklistAIController, BlocklistAIControllerEvent, RequestInput,
+    BlocklistAIController, RequestInput,
 };
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent::{
@@ -179,7 +179,6 @@ impl SlashCommandRequest {
             controller.terminal_view_id,
             ctx,
         );
-        let model_id = request_input.model_id.clone();
 
         match controller.send_request_input(
             request_input,
@@ -191,23 +190,19 @@ impl SlashCommandRequest {
             /*default_to_follow_up_on_success*/ true,
             /*can_attempt_resume_on_error*/ true,
             is_queued_prompt,
+            // `/summarize` inputs aren't user queries, but submitting one
+            // should still clear the input buffer like a user query; the
+            // dispatch emits the user-query `SentRequest` event for it.
+            /*emit_user_query_sent_event*/
+            is_summarize,
             ctx,
         ) {
-            Ok((_, stream_id)) => {
+            Ok(_) => {
                 // Direct skills consume live pending context; queued skills consume row-owned
                 // context and must not clear a new draft's staged attachments.
                 if is_invoke_skill && !is_queued_prompt {
                     controller.context_model.update(ctx, |context_model, ctx| {
                         context_model.reset_context_to_default(ctx);
-                    });
-                }
-                // Emit SentRequest event to trigger buffer clearing
-                if is_summarize {
-                    ctx.emit(BlocklistAIControllerEvent::SentRequest {
-                        contains_user_query: true,
-                        is_queued_prompt,
-                        model_id,
-                        stream_id,
                     });
                 }
             }

--- a/app/src/ai/blocklist/passive_suggestions/legacy.rs
+++ b/app/src/ai/blocklist/passive_suggestions/legacy.rs
@@ -356,24 +356,8 @@ impl PassiveSuggestionsModel {
                             ctx,
                         )
                     });
-                    match request {
-                        Ok((_, Some(stream_id))) => {
-                            me.pending_unit_test_stream_id = Some(stream_id);
-                        }
-                        Ok((conversation_id, None)) => {
-                            // Dispatch was deferred behind a Grok token
-                            // refresh. Passive suggestions are best-effort,
-                            // so abandon the deferred send instead of
-                            // tracking it.
-                            me.ai_controller.update(ctx, |controller, ctx| {
-                                controller.cancel_conversation_progress(
-                                    conversation_id,
-                                    CancellationReason::ManuallyCancelled,
-                                    ctx,
-                                );
-                            });
-                        }
-                        Err(_) => {}
+                    if let Ok((_, stream_id)) = request {
+                        me.pending_unit_test_stream_id = Some(stream_id.clone());
                     }
                 },
             ));
@@ -513,7 +497,7 @@ impl PassiveSuggestionsModel {
                 });
 
                 match result {
-                    Ok((conversation_id, Some(stream_id))) => {
+                    Ok((conversation_id, stream_id)) => {
                         me.pending_code_diff_stream_id = Some(stream_id.clone());
                         let code_exchange_id = BlocklistAIHistoryModel::as_ref(ctx)
                             .conversation(&conversation_id)
@@ -525,21 +509,6 @@ impl PassiveSuggestionsModel {
                             block_id: block_id.clone(),
                         });
                         me.start_code_diff_timeout(stream_id, ctx);
-                    }
-                    Ok((conversation_id, None)) => {
-                        // Dispatch was deferred behind a Grok token refresh.
-                        // Passive code diffs are time-sensitive, so abandon
-                        // the deferred send and fall back like a failed one.
-                        me.ai_controller.update(ctx, |controller, ctx| {
-                            controller.cancel_conversation_progress(
-                                conversation_id,
-                                CancellationReason::ManuallyCancelled,
-                                ctx,
-                            );
-                        });
-                        ctx.emit(PassiveSuggestionsEvent::PassiveCodeDiffFailed {
-                            reason: PromptSuggestionFallbackReason::FailedToSendAIRequest,
-                        });
                     }
                     Err(_) => {
                         ctx.emit(PassiveSuggestionsEvent::PassiveCodeDiffFailed {

--- a/app/src/ai/blocklist/passive_suggestions/legacy.rs
+++ b/app/src/ai/blocklist/passive_suggestions/legacy.rs
@@ -356,8 +356,24 @@ impl PassiveSuggestionsModel {
                             ctx,
                         )
                     });
-                    if let Ok((_, stream_id)) = request {
-                        me.pending_unit_test_stream_id = Some(stream_id.clone());
+                    match request {
+                        Ok((_, Some(stream_id))) => {
+                            me.pending_unit_test_stream_id = Some(stream_id);
+                        }
+                        Ok((conversation_id, None)) => {
+                            // Dispatch was deferred behind a Grok token
+                            // refresh. Passive suggestions are best-effort,
+                            // so abandon the deferred send instead of
+                            // tracking it.
+                            me.ai_controller.update(ctx, |controller, ctx| {
+                                controller.cancel_conversation_progress(
+                                    conversation_id,
+                                    CancellationReason::ManuallyCancelled,
+                                    ctx,
+                                );
+                            });
+                        }
+                        Err(_) => {}
                     }
                 },
             ));
@@ -497,7 +513,7 @@ impl PassiveSuggestionsModel {
                 });
 
                 match result {
-                    Ok((conversation_id, stream_id)) => {
+                    Ok((conversation_id, Some(stream_id))) => {
                         me.pending_code_diff_stream_id = Some(stream_id.clone());
                         let code_exchange_id = BlocklistAIHistoryModel::as_ref(ctx)
                             .conversation(&conversation_id)
@@ -509,6 +525,21 @@ impl PassiveSuggestionsModel {
                             block_id: block_id.clone(),
                         });
                         me.start_code_diff_timeout(stream_id, ctx);
+                    }
+                    Ok((conversation_id, None)) => {
+                        // Dispatch was deferred behind a Grok token refresh.
+                        // Passive code diffs are time-sensitive, so abandon
+                        // the deferred send and fall back like a failed one.
+                        me.ai_controller.update(ctx, |controller, ctx| {
+                            controller.cancel_conversation_progress(
+                                conversation_id,
+                                CancellationReason::ManuallyCancelled,
+                                ctx,
+                            );
+                        });
+                        ctx.emit(PassiveSuggestionsEvent::PassiveCodeDiffFailed {
+                            reason: PromptSuggestionFallbackReason::FailedToSendAIRequest,
+                        });
                     }
                     Err(_) => {
                         ctx.emit(PassiveSuggestionsEvent::PassiveCodeDiffFailed {

--- a/crates/ai/src/api_keys.rs
+++ b/crates/ai/src/api_keys.rs
@@ -127,12 +127,6 @@ impl GrokTokens {
             None => false,
         }
     }
-
-    /// Returns `true` when the token is known to be past its hard expiry.
-    /// Tokens with an unknown expiry never report as expired.
-    pub fn is_expired(&self) -> bool {
-        self.needs_refresh(Duration::ZERO)
-    }
 }
 
 /// Controls how AWS credentials are refreshed by [`ApiKeyManager`].

--- a/crates/ai/src/api_keys.rs
+++ b/crates/ai/src/api_keys.rs
@@ -109,22 +109,13 @@ pub struct GrokTokens {
 }
 
 impl GrokTokens {
-    /// Stop sending / start refreshing this long before the hard expiry so we
-    /// never hand the server a token that expires mid-flight.
-    const EXPIRY_SKEW: Duration = Duration::from_secs(60);
-
-    /// Returns the access token when it is non-empty and not within
-    /// [`Self::EXPIRY_SKEW`] of expiring. An unknown (`None`) expiry is treated
-    /// as valid — the server remains the final authority on the token.
-    pub fn valid_access_token(&self) -> Option<&str> {
-        if self.access_token.trim().is_empty() {
-            return None;
-        }
-        match self.expires_at {
-            Some(expires_at) => (expires_at > SystemTime::now() + Self::EXPIRY_SKEW)
-                .then_some(self.access_token.as_str()),
-            None => Some(self.access_token.as_str()),
-        }
+    /// Returns the access token whenever it is non-empty, regardless of
+    /// expiry. Possibly-expired tokens are still sent so the server stays the
+    /// final authority on token validity (it rejects truly invalid tokens);
+    /// `crate::grok_subscription` refreshes (nearly) expired tokens in the
+    /// background.
+    pub fn access_token_for_request(&self) -> Option<&str> {
+        (!self.access_token.trim().is_empty()).then_some(self.access_token.as_str())
     }
 
     /// Returns `true` when the token is known to expire within `lead_time` and
@@ -135,6 +126,12 @@ impl GrokTokens {
             Some(expires_at) => expires_at <= SystemTime::now() + lead_time,
             None => false,
         }
+    }
+
+    /// Returns `true` when the token is known to be past its hard expiry.
+    /// Tokens with an unknown expiry never report as expired.
+    pub fn is_expired(&self) -> bool {
+        self.needs_refresh(Duration::ZERO)
     }
 }
 
@@ -166,6 +163,11 @@ pub struct ApiKeyManager {
     /// via `ApiKeyManager::set_grok_refresh_allowed` (`crate::grok_subscription`).
     #[cfg(not(target_family = "wasm"))]
     pub(crate) grok_refresh_allowed: bool,
+    /// Guards against overlapping Grok token refreshes: the proactive refresh
+    /// timer and the request-time safety net
+    /// (`ApiKeyManager::refresh_grok_tokens_if_needed`) can otherwise race.
+    #[cfg(not(target_family = "wasm"))]
+    pub(crate) grok_refresh_in_flight: bool,
     pub(crate) aws_credentials_state: AwsCredentialsState,
     aws_credentials_refresh_strategy: AwsCredentialsRefreshStrategy,
     secure_storage_write_version: u64,
@@ -181,6 +183,8 @@ impl ApiKeyManager {
             grok_tokens,
             #[cfg(not(target_family = "wasm"))]
             grok_refresh_allowed: false,
+            #[cfg(not(target_family = "wasm"))]
+            grok_refresh_in_flight: false,
             aws_credentials_state: AwsCredentialsState::Missing,
             aws_credentials_refresh_strategy: AwsCredentialsRefreshStrategy::default(),
             secure_storage_write_version: 0,
@@ -408,12 +412,13 @@ impl ApiKeyManager {
         // The connected Grok subscription's OAuth access token is user-provided
         // auth, just like a pasted BYO API key, so it respects the same BYO
         // policy gate: when BYO keys are disabled (e.g. by workspace policy),
-        // the token must not be sent.
+        // the token must not be sent. Possibly-expired tokens ARE sent — the
+        // server is the authority on validity.
         let grok_oauth_access_token = include_byo_keys
             .then(|| {
                 self.grok_tokens
                     .as_ref()
-                    .and_then(GrokTokens::valid_access_token)
+                    .and_then(GrokTokens::access_token_for_request)
                     .map(str::to_owned)
             })
             .flatten()

--- a/crates/ai/src/api_keys.rs
+++ b/crates/ai/src/api_keys.rs
@@ -127,6 +127,12 @@ impl GrokTokens {
             None => false,
         }
     }
+
+    /// Returns `true` when the token is known to be past its hard expiry.
+    /// Tokens with an unknown expiry never report as expired.
+    pub fn is_expired(&self) -> bool {
+        self.needs_refresh(Duration::ZERO)
+    }
 }
 
 /// Controls how AWS credentials are refreshed by [`ApiKeyManager`].

--- a/crates/ai/src/api_keys_tests.rs
+++ b/crates/ai/src/api_keys_tests.rs
@@ -12,6 +12,8 @@ fn make_manager_with_grok(keys: ApiKeys, grok_tokens: Option<GrokTokens>) -> Api
         grok_tokens,
         #[cfg(not(target_family = "wasm"))]
         grok_refresh_allowed: false,
+        #[cfg(not(target_family = "wasm"))]
+        grok_refresh_in_flight: false,
         aws_credentials_state: AwsCredentialsState::Missing,
         aws_credentials_refresh_strategy: AwsCredentialsRefreshStrategy::default(),
         secure_storage_write_version: 0,
@@ -357,34 +359,34 @@ fn api_keys_for_request_none_for_custom_endpoints_only() {
 // ── grok oauth token ────────────────────────────────────────────
 
 #[test]
-fn grok_valid_access_token_present_without_expiry() {
+fn grok_access_token_present_without_expiry() {
     let t = GrokTokens {
         access_token: "tok".into(),
         ..Default::default()
     };
-    assert_eq!(t.valid_access_token(), Some("tok"));
+    assert_eq!(t.access_token_for_request(), Some("tok"));
 }
 
 #[test]
-fn grok_valid_access_token_blank_is_none() {
+fn grok_access_token_blank_is_none() {
     let t = GrokTokens {
         access_token: "   ".into(),
         ..Default::default()
     };
-    assert_eq!(t.valid_access_token(), None);
+    assert_eq!(t.access_token_for_request(), None);
 }
 
 #[test]
-fn grok_valid_access_token_near_expiry_is_none() {
-    // Expires now, i.e. within the skew window, so it should not be sent.
+fn grok_access_token_near_expiry_still_sent() {
+    // Expired tokens are still sent; the server is the authority on validity.
     let t = grok_tokens("tok", Some(0));
-    assert_eq!(t.valid_access_token(), None);
+    assert_eq!(t.access_token_for_request(), Some("tok"));
 }
 
 #[test]
-fn grok_valid_access_token_far_future_is_some() {
+fn grok_access_token_far_future_is_some() {
     let t = grok_tokens("tok", Some(3600));
-    assert_eq!(t.valid_access_token(), Some("tok"));
+    assert_eq!(t.access_token_for_request(), Some("tok"));
 }
 
 #[test]
@@ -393,6 +395,41 @@ fn grok_needs_refresh_within_lead_time() {
     assert!(!grok_tokens("tok", Some(3600)).needs_refresh(Duration::from_secs(300)));
     // Unknown expiry never reports as needing refresh.
     assert!(!grok_tokens("tok", None).needs_refresh(Duration::from_secs(300)));
+}
+
+#[test]
+fn grok_is_expired_only_past_hard_expiry() {
+    assert!(grok_tokens("tok", Some(0)).is_expired());
+    assert!(!grok_tokens("tok", Some(3600)).is_expired());
+    // Unknown expiry never reports as expired.
+    assert!(!grok_tokens("tok", None).is_expired());
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn claim_blocking_grok_refresh_claims_expired_token_once() {
+    let mut mgr = make_manager_with_grok(ApiKeys::default(), Some(grok_tokens("tok", Some(0))));
+    assert_eq!(mgr.claim_blocking_grok_refresh(), Some("refresh".into()));
+    // The claim marks a refresh as in flight, so a second claim is refused.
+    assert_eq!(mgr.claim_blocking_grok_refresh(), None);
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn claim_blocking_grok_refresh_ignores_valid_token() {
+    let mut mgr = make_manager_with_grok(ApiKeys::default(), Some(grok_tokens("tok", Some(3600))));
+    assert_eq!(mgr.claim_blocking_grok_refresh(), None);
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn claim_blocking_grok_refresh_requires_refresh_token() {
+    let tokens = GrokTokens {
+        refresh_token: None,
+        ..grok_tokens("tok", Some(0))
+    };
+    let mut mgr = make_manager_with_grok(ApiKeys::default(), Some(tokens));
+    assert_eq!(mgr.claim_blocking_grok_refresh(), None);
 }
 
 #[test]
@@ -418,7 +455,10 @@ fn api_keys_for_request_omits_grok_token_when_byo_disabled() {
 }
 
 #[test]
-fn api_keys_for_request_omits_expired_grok_token() {
+fn api_keys_for_request_includes_expired_grok_token() {
+    // Expired tokens are still sent in requests; the server rejects truly
+    // invalid ones and the background refresh replaces them.
     let mgr = make_manager_with_grok(ApiKeys::default(), Some(grok_tokens("grok-abc", Some(0))));
-    assert!(mgr.api_keys_for_request(true, false).is_none());
+    let result = mgr.api_keys_for_request(true, false).unwrap();
+    assert_eq!(result.grok_oauth_access_token, "grok-abc");
 }

--- a/crates/ai/src/api_keys_tests.rs
+++ b/crates/ai/src/api_keys_tests.rs
@@ -393,43 +393,10 @@ fn grok_access_token_far_future_is_some() {
 fn grok_needs_refresh_within_lead_time() {
     assert!(grok_tokens("tok", Some(30)).needs_refresh(Duration::from_secs(300)));
     assert!(!grok_tokens("tok", Some(3600)).needs_refresh(Duration::from_secs(300)));
+    // Expired tokens still need a refresh.
+    assert!(grok_tokens("tok", Some(0)).needs_refresh(Duration::from_secs(300)));
     // Unknown expiry never reports as needing refresh.
     assert!(!grok_tokens("tok", None).needs_refresh(Duration::from_secs(300)));
-}
-
-#[test]
-fn grok_is_expired_only_past_hard_expiry() {
-    assert!(grok_tokens("tok", Some(0)).is_expired());
-    assert!(!grok_tokens("tok", Some(3600)).is_expired());
-    // Unknown expiry never reports as expired.
-    assert!(!grok_tokens("tok", None).is_expired());
-}
-
-#[cfg(not(target_family = "wasm"))]
-#[test]
-fn claim_blocking_grok_refresh_claims_expired_token_once() {
-    let mut mgr = make_manager_with_grok(ApiKeys::default(), Some(grok_tokens("tok", Some(0))));
-    assert_eq!(mgr.claim_blocking_grok_refresh(), Some("refresh".into()));
-    // The claim marks a refresh as in flight, so a second claim is refused.
-    assert_eq!(mgr.claim_blocking_grok_refresh(), None);
-}
-
-#[cfg(not(target_family = "wasm"))]
-#[test]
-fn claim_blocking_grok_refresh_ignores_valid_token() {
-    let mut mgr = make_manager_with_grok(ApiKeys::default(), Some(grok_tokens("tok", Some(3600))));
-    assert_eq!(mgr.claim_blocking_grok_refresh(), None);
-}
-
-#[cfg(not(target_family = "wasm"))]
-#[test]
-fn claim_blocking_grok_refresh_requires_refresh_token() {
-    let tokens = GrokTokens {
-        refresh_token: None,
-        ..grok_tokens("tok", Some(0))
-    };
-    let mut mgr = make_manager_with_grok(ApiKeys::default(), Some(tokens));
-    assert_eq!(mgr.claim_blocking_grok_refresh(), None);
 }
 
 #[test]

--- a/crates/ai/src/api_keys_tests.rs
+++ b/crates/ai/src/api_keys_tests.rs
@@ -393,10 +393,43 @@ fn grok_access_token_far_future_is_some() {
 fn grok_needs_refresh_within_lead_time() {
     assert!(grok_tokens("tok", Some(30)).needs_refresh(Duration::from_secs(300)));
     assert!(!grok_tokens("tok", Some(3600)).needs_refresh(Duration::from_secs(300)));
-    // Expired tokens still need a refresh.
-    assert!(grok_tokens("tok", Some(0)).needs_refresh(Duration::from_secs(300)));
     // Unknown expiry never reports as needing refresh.
     assert!(!grok_tokens("tok", None).needs_refresh(Duration::from_secs(300)));
+}
+
+#[test]
+fn grok_is_expired_only_past_hard_expiry() {
+    assert!(grok_tokens("tok", Some(0)).is_expired());
+    assert!(!grok_tokens("tok", Some(3600)).is_expired());
+    // Unknown expiry never reports as expired.
+    assert!(!grok_tokens("tok", None).is_expired());
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn claim_blocking_grok_refresh_claims_expired_token_once() {
+    let mut mgr = make_manager_with_grok(ApiKeys::default(), Some(grok_tokens("tok", Some(0))));
+    assert_eq!(mgr.claim_blocking_grok_refresh(), Some("refresh".into()));
+    // The claim marks a refresh as in flight, so a second claim is refused.
+    assert_eq!(mgr.claim_blocking_grok_refresh(), None);
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn claim_blocking_grok_refresh_ignores_valid_token() {
+    let mut mgr = make_manager_with_grok(ApiKeys::default(), Some(grok_tokens("tok", Some(3600))));
+    assert_eq!(mgr.claim_blocking_grok_refresh(), None);
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn claim_blocking_grok_refresh_requires_refresh_token() {
+    let tokens = GrokTokens {
+        refresh_token: None,
+        ..grok_tokens("tok", Some(0))
+    };
+    let mut mgr = make_manager_with_grok(ApiKeys::default(), Some(tokens));
+    assert_eq!(mgr.claim_blocking_grok_refresh(), None);
 }
 
 #[test]

--- a/crates/ai/src/grok_subscription/mod.rs
+++ b/crates/ai/src/grok_subscription/mod.rs
@@ -19,6 +19,7 @@ pub mod oauth;
 
 use std::time::{Duration, SystemTime};
 
+use futures::channel::oneshot;
 use warpui_core::r#async::Timer;
 use warpui_core::ModelContext;
 
@@ -92,7 +93,7 @@ impl ApiKeyManager {
     /// never armed or died (e.g. a stale BYO policy at startup, or an earlier
     /// failed refresh). Tokens already past their hard expiry are instead
     /// refreshed by the request-blocking path
-    /// ([`Self::claim_blocking_grok_refresh`]).
+    /// ([`Self::blocking_grok_refresh_for_request`]).
     ///
     /// `byo_allowed` is the BYO API key policy as freshly evaluated by the
     /// caller at request time. It also re-syncs the stored policy mirror,
@@ -123,18 +124,66 @@ impl ApiKeyManager {
         spawn_grok_refresh(self, refresh_token, ctx);
     }
 
-    /// Claims a request-blocking refresh of the stored Grok tokens, returning
-    /// the refresh token to exchange when the access token is already past
-    /// its hard expiry and no other refresh is in flight.
+    /// When the stored Grok access token is already past its hard expiry,
+    /// kicks off a single refresh attempt that the triggering request should
+    /// block on before being sent, returning a receiver that resolves to the
+    /// access token the request should carry: the refreshed token on success,
+    /// or `None` when the attempt failed (the request keeps its stale token;
+    /// the server is the authority on validity). Returns `None` when no
+    /// blocking refresh is needed or another refresh is already in flight.
     ///
-    /// Marks the refresh as in flight so the proactive timer and the
-    /// near-expiry safety net can't race it. Callers MUST report the outcome
-    /// via [`Self::finish_blocking_grok_refresh`] to release the claim.
+    /// Persisting the refreshed tokens, releasing the in-flight guard, and
+    /// scheduling the next proactive refresh all happen here on the manager's
+    /// own context — callers only observe the token to send.
+    pub fn blocking_grok_refresh_for_request(
+        &mut self,
+        ctx: &mut ModelContext<Self>,
+    ) -> Option<oneshot::Receiver<Option<String>>> {
+        let refresh_token = self.claim_blocking_grok_refresh()?;
+        let (tx, rx) = oneshot::channel();
+        log::info!("Grok OAuth token is past its expiry; refreshing it before the request is sent");
+        ctx.spawn(
+            async move { oauth::refresh_access_token(&refresh_token).await },
+            move |manager, result, ctx| {
+                manager.grok_refresh_in_flight = false;
+                match result {
+                    Ok(response) => {
+                        log::info!(
+                            "Refreshed expired Grok OAuth token before a request (expires_in={:?}, has_refresh_token={})",
+                            response.expires_in,
+                            response.refresh_token.is_some(),
+                        );
+                        // Unblock the waiting request first, then persist and
+                        // reschedule the proactive refresh.
+                        let _ = tx.send(Some(response.access_token.clone()));
+                        apply_grok_tokens(manager, response, ctx);
+                    }
+                    Err(err) => {
+                        // Leave the stale tokens in place; the server remains
+                        // the authority and will reject them if truly invalid.
+                        log::error!(
+                            "Failed to refresh the expired Grok OAuth token before a request; \
+                             the request will send the stale token: {err:#}"
+                        );
+                        let _ = tx.send(None);
+                    }
+                }
+            },
+        );
+        Some(rx)
+    }
+
+    /// Claims the request-blocking refresh performed by
+    /// [`Self::blocking_grok_refresh_for_request`]: returns the refresh token
+    /// to exchange when the access token is already past its hard expiry and
+    /// no other refresh is in flight, marking the refresh as in flight so the
+    /// proactive timer and the near-expiry safety net can't race it.
     ///
-    /// This intentionally ignores the stored BYO policy mirror: callers claim
-    /// a refresh for a request that is already carrying the token, which is
-    /// only the case when the policy allowed it at request-build time.
-    pub fn claim_blocking_grok_refresh(&mut self) -> Option<String> {
+    /// This intentionally ignores the stored BYO policy mirror: a blocking
+    /// refresh is only claimed for a request that is already carrying the
+    /// token, which is only the case when the policy allowed it at
+    /// request-build time.
+    pub(crate) fn claim_blocking_grok_refresh(&mut self) -> Option<String> {
         if self.grok_refresh_in_flight {
             return None;
         }
@@ -145,27 +194,6 @@ impl ApiKeyManager {
         let refresh_token = tokens.refresh_token.clone()?;
         self.grok_refresh_in_flight = true;
         Some(refresh_token)
-    }
-
-    /// Completes a request-blocking refresh started with
-    /// [`Self::claim_blocking_grok_refresh`], storing the refreshed tokens
-    /// (and scheduling the next proactive refresh) on success. `response` is
-    /// `None` when the refresh attempt failed; the stale tokens stay in place
-    /// since the server remains the authority on their validity.
-    pub fn finish_blocking_grok_refresh(
-        &mut self,
-        response: Option<TokenResponse>,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        self.grok_refresh_in_flight = false;
-        if let Some(response) = response {
-            log::info!(
-                "Refreshed expired Grok OAuth token before a request (expires_in={:?}, has_refresh_token={})",
-                response.expires_in,
-                response.refresh_token.is_some(),
-            );
-            apply_grok_tokens(self, response, ctx);
-        }
     }
 }
 

--- a/crates/ai/src/grok_subscription/mod.rs
+++ b/crates/ai/src/grok_subscription/mod.rs
@@ -19,9 +19,6 @@ pub mod oauth;
 
 use std::time::{Duration, SystemTime};
 
-use futures::channel::oneshot;
-use futures::future::{self, Either};
-use futures::pin_mut;
 use warpui_core::r#async::Timer;
 use warpui_core::ModelContext;
 
@@ -33,12 +30,6 @@ use crate::api_keys::{ApiKeyManager, GrokTokens};
 /// server is the authority on validity), so this lead time is purely about
 /// keeping the token fresh, not about when it stops being sent.
 const REFRESH_LEAD_TIME: Duration = Duration::from_secs(5 * 60);
-
-/// Hard cap on how long a request dispatch may be held waiting for the
-/// blocking refresh of an already-expired token
-/// ([`ApiKeyManager::refresh_expired_grok_tokens_before_send`]). On timeout
-/// the attempt is abandoned and the request proceeds with the stale token.
-const BLOCKING_REFRESH_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Builds [`GrokTokens`] from a token-endpoint [`TokenResponse`], computing the
 /// absolute `expires_at` from the relative `expires_in`. Values not present in
@@ -96,12 +87,11 @@ impl ApiKeyManager {
     }
 
     /// Request-time safety net: kicks off a background refresh of the stored
-    /// Grok tokens when they are nearing (but not yet past) expiry, so
+    /// Grok tokens when they are nearing (or already past) expiry, so
     /// upcoming requests can authenticate even if the proactive refresh loop
     /// never armed or died (e.g. a stale BYO policy at startup, or an earlier
-    /// failed refresh). Tokens already past their hard expiry are instead
-    /// refreshed by the request-blocking path
-    /// ([`Self::refresh_expired_grok_tokens_before_send`]).
+    /// failed refresh). The triggering request still carries the currently
+    /// stored token — the server is the authority on its validity.
     ///
     /// `byo_allowed` is the BYO API key policy as freshly evaluated by the
     /// caller at request time. It also re-syncs the stored policy mirror,
@@ -119,108 +109,16 @@ impl ApiKeyManager {
         let Some(tokens) = self.grok_tokens() else {
             return;
         };
-        // Tokens already past their hard expiry are refreshed by the
-        // request-blocking path instead, so the request waits for a usable
-        // token rather than racing a background refresh.
-        if tokens.is_expired() || !tokens.needs_refresh(REFRESH_LEAD_TIME) {
+        if !tokens.needs_refresh(REFRESH_LEAD_TIME) {
             return;
         }
         let Some(refresh_token) = tokens.refresh_token.clone() else {
             return;
         };
-        log::info!("Grok OAuth token is nearing expiry at request time; refreshing in background");
-        spawn_grok_refresh(self, refresh_token, ctx);
-    }
-
-    /// When the stored Grok access token is already past its hard expiry,
-    /// kicks off a single refresh attempt that the triggering request should
-    /// block on before being dispatched. The returned receiver resolves when
-    /// the attempt finishes — success, failure, or timeout — after which the
-    /// caller should build the request, picking up whichever token is then
-    /// stored: refreshed on success, stale otherwise (the server is the
-    /// authority on token validity). Returns `None` when no blocking refresh
-    /// is needed or another refresh is already in flight.
-    ///
-    /// Persisting the refreshed tokens, releasing the in-flight guard, and
-    /// scheduling the next proactive refresh all happen here on the manager's
-    /// own context — completion is the only signal callers receive.
-    pub fn refresh_expired_grok_tokens_before_send(
-        &mut self,
-        ctx: &mut ModelContext<Self>,
-    ) -> Option<oneshot::Receiver<()>> {
-        let refresh_token = self.claim_blocking_grok_refresh()?;
-        let (done_tx, done_rx) = oneshot::channel();
-        log::info!("Grok OAuth token is past its expiry; refreshing it before the request is sent");
-        ctx.spawn(
-            async move {
-                // Cap the wait so a hung token endpoint can't stall the
-                // deferred request indefinitely. Timing out abandons this
-                // attempt; a later request may claim a new one.
-                let refresh = oauth::refresh_access_token(&refresh_token);
-                pin_mut!(refresh);
-                let cap = Timer::after(BLOCKING_REFRESH_TIMEOUT);
-                pin_mut!(cap);
-                match future::select(refresh, cap).await {
-                    Either::Left((result, _)) => Some(result),
-                    Either::Right(_) => None,
-                }
-            },
-            move |manager, outcome, ctx| {
-                manager.grok_refresh_in_flight = false;
-                match outcome {
-                    Some(Ok(response)) => {
-                        log::info!(
-                            "Refreshed expired Grok OAuth token before a request (expires_in={:?}, has_refresh_token={})",
-                            response.expires_in,
-                            response.refresh_token.is_some(),
-                        );
-                        apply_grok_tokens(manager, response, ctx);
-                    }
-                    Some(Err(err)) => {
-                        // Leave the stale tokens in place; the server remains
-                        // the authority and will reject them if truly invalid.
-                        log::error!(
-                            "Failed to refresh the expired Grok OAuth token before a request; \
-                             the request will send the stale token: {err:#}"
-                        );
-                    }
-                    None => {
-                        log::error!(
-                            "Timed out refreshing the expired Grok OAuth token before a request; \
-                             the request will send the stale token"
-                        );
-                    }
-                }
-                // Unblock the deferred request regardless of outcome. The
-                // receiver may already be gone if the send was cancelled.
-                let _ = done_tx.send(());
-            },
+        log::info!(
+            "Grok OAuth token is nearing or past expiry at request time; refreshing in background"
         );
-        Some(done_rx)
-    }
-
-    /// Claims the request-blocking refresh performed by
-    /// [`Self::refresh_expired_grok_tokens_before_send`]: returns the refresh
-    /// token to exchange when the access token is already past its hard
-    /// expiry and no other refresh is in flight, marking the refresh as in
-    /// flight so the proactive timer and the near-expiry safety net can't
-    /// race it.
-    ///
-    /// This intentionally ignores the stored BYO policy mirror: a blocking
-    /// refresh is only claimed for a request that is already carrying the
-    /// token, which is only the case when the policy allowed it at
-    /// request-build time.
-    pub(crate) fn claim_blocking_grok_refresh(&mut self) -> Option<String> {
-        if self.grok_refresh_in_flight {
-            return None;
-        }
-        let tokens = self.grok_tokens()?;
-        if !tokens.is_expired() {
-            return None;
-        }
-        let refresh_token = tokens.refresh_token.clone()?;
-        self.grok_refresh_in_flight = true;
-        Some(refresh_token)
+        spawn_grok_refresh(self, refresh_token, ctx);
     }
 }
 

--- a/crates/ai/src/grok_subscription/mod.rs
+++ b/crates/ai/src/grok_subscription/mod.rs
@@ -25,9 +25,10 @@ use warpui_core::ModelContext;
 use self::oauth::TokenResponse;
 use crate::api_keys::{ApiKeyManager, GrokTokens};
 
-/// Refresh the access token this long before its hard expiry so a request never
-/// races the expiration. Must be larger than `GrokTokens::EXPIRY_SKEW` so the
-/// token is refreshed before it stops being sent.
+/// Refresh the access token this long before its hard expiry so a request
+/// never races the expiration. Possibly-expired tokens are still sent (the
+/// server is the authority on validity), so this lead time is purely about
+/// keeping the token fresh, not about when it stops being sent.
 const REFRESH_LEAD_TIME: Duration = Duration::from_secs(5 * 60);
 
 /// Builds [`GrokTokens`] from a token-endpoint [`TokenResponse`], computing the
@@ -82,6 +83,88 @@ impl ApiKeyManager {
         self.grok_refresh_allowed = allowed;
         if allowed {
             schedule_grok_token_refresh(self, ctx);
+        }
+    }
+
+    /// Request-time safety net: kicks off a background refresh of the stored
+    /// Grok tokens when they are nearing (but not yet past) expiry, so
+    /// upcoming requests can authenticate even if the proactive refresh loop
+    /// never armed or died (e.g. a stale BYO policy at startup, or an earlier
+    /// failed refresh). Tokens already past their hard expiry are instead
+    /// refreshed by the request-blocking path
+    /// ([`Self::claim_blocking_grok_refresh`]).
+    ///
+    /// `byo_allowed` is the BYO API key policy as freshly evaluated by the
+    /// caller at request time. It also re-syncs the stored policy mirror,
+    /// which can go stale between `TeamsChanged` events; a disabled ->
+    /// enabled transition re-arms the proactive refresh loop.
+    pub fn refresh_grok_tokens_if_needed(
+        &mut self,
+        byo_allowed: bool,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.set_grok_refresh_allowed(byo_allowed, ctx);
+        if !byo_allowed || self.grok_refresh_in_flight {
+            return;
+        }
+        let Some(tokens) = self.grok_tokens() else {
+            return;
+        };
+        // Tokens already past their hard expiry are refreshed by the
+        // request-blocking path instead, so the request waits for a usable
+        // token rather than racing a background refresh.
+        if tokens.is_expired() || !tokens.needs_refresh(REFRESH_LEAD_TIME) {
+            return;
+        }
+        let Some(refresh_token) = tokens.refresh_token.clone() else {
+            return;
+        };
+        log::info!("Grok OAuth token is nearing expiry at request time; refreshing in background");
+        spawn_grok_refresh(self, refresh_token, ctx);
+    }
+
+    /// Claims a request-blocking refresh of the stored Grok tokens, returning
+    /// the refresh token to exchange when the access token is already past
+    /// its hard expiry and no other refresh is in flight.
+    ///
+    /// Marks the refresh as in flight so the proactive timer and the
+    /// near-expiry safety net can't race it. Callers MUST report the outcome
+    /// via [`Self::finish_blocking_grok_refresh`] to release the claim.
+    ///
+    /// This intentionally ignores the stored BYO policy mirror: callers claim
+    /// a refresh for a request that is already carrying the token, which is
+    /// only the case when the policy allowed it at request-build time.
+    pub fn claim_blocking_grok_refresh(&mut self) -> Option<String> {
+        if self.grok_refresh_in_flight {
+            return None;
+        }
+        let tokens = self.grok_tokens()?;
+        if !tokens.is_expired() {
+            return None;
+        }
+        let refresh_token = tokens.refresh_token.clone()?;
+        self.grok_refresh_in_flight = true;
+        Some(refresh_token)
+    }
+
+    /// Completes a request-blocking refresh started with
+    /// [`Self::claim_blocking_grok_refresh`], storing the refreshed tokens
+    /// (and scheduling the next proactive refresh) on success. `response` is
+    /// `None` when the refresh attempt failed; the stale tokens stay in place
+    /// since the server remains the authority on their validity.
+    pub fn finish_blocking_grok_refresh(
+        &mut self,
+        response: Option<TokenResponse>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.grok_refresh_in_flight = false;
+        if let Some(response) = response {
+            log::info!(
+                "Refreshed expired Grok OAuth token before a request (expires_in={:?}, has_refresh_token={})",
+                response.expires_in,
+                response.refresh_token.is_some(),
+            );
+            apply_grok_tokens(self, response, ctx);
         }
     }
 }
@@ -145,7 +228,7 @@ fn schedule_grok_token_refresh(manager: &mut ApiKeyManager, ctx: &mut ModelConte
                 .and_then(|t| t.refresh_token.as_deref())
                 == Some(refresh_token.as_str());
             if still_current {
-                spawn_grok_refresh(refresh_token, ctx);
+                spawn_grok_refresh(manager, refresh_token, ctx);
             }
         },
     );
@@ -153,22 +236,39 @@ fn schedule_grok_token_refresh(manager: &mut ApiKeyManager, ctx: &mut ModelConte
 
 /// Kicks off a background token refresh using `refresh_token`, applying the
 /// result (which reschedules the next refresh) or logging the failure.
-fn spawn_grok_refresh(refresh_token: String, ctx: &mut ModelContext<ApiKeyManager>) {
+///
+/// No-op when a refresh is already in flight, so the proactive timer and the
+/// request-time safety net can't issue overlapping refreshes.
+fn spawn_grok_refresh(
+    manager: &mut ApiKeyManager,
+    refresh_token: String,
+    ctx: &mut ModelContext<ApiKeyManager>,
+) {
+    if manager.grok_refresh_in_flight {
+        return;
+    }
+    manager.grok_refresh_in_flight = true;
     ctx.spawn(
         async move { oauth::refresh_access_token(&refresh_token).await },
-        |manager, result, ctx| match result {
-            Ok(response) => {
-                log::info!(
-                    "Refreshed Grok OAuth token (expires_in={:?}, has_refresh_token={})",
-                    response.expires_in,
-                    response.refresh_token.is_some(),
-                );
-                apply_grok_tokens(manager, response, ctx);
-            }
-            Err(err) => {
-                // Leave the existing (soon-to-expire) token in place; the server
-                // remains the authority and will reject it if it's truly invalid.
-                log::error!("Failed to refresh Grok OAuth token: {err:#}");
+        |manager, result, ctx| {
+            manager.grok_refresh_in_flight = false;
+            match result {
+                Ok(response) => {
+                    log::info!(
+                        "Refreshed Grok OAuth token (expires_in={:?}, has_refresh_token={})",
+                        response.expires_in,
+                        response.refresh_token.is_some(),
+                    );
+                    apply_grok_tokens(manager, response, ctx);
+                }
+                Err(err) => {
+                    // Leave the existing (possibly expired) token in place; the
+                    // server remains the authority and will reject it if it's
+                    // truly invalid. The request-time safety net
+                    // (`ApiKeyManager::refresh_grok_tokens_if_needed`) retries
+                    // on the next request.
+                    log::error!("Failed to refresh Grok OAuth token: {err:#}");
+                }
             }
         },
     );

--- a/crates/ai/src/grok_subscription/mod.rs
+++ b/crates/ai/src/grok_subscription/mod.rs
@@ -19,6 +19,9 @@ pub mod oauth;
 
 use std::time::{Duration, SystemTime};
 
+use futures::channel::oneshot;
+use futures::future::{self, Either};
+use futures::pin_mut;
 use warpui_core::r#async::Timer;
 use warpui_core::ModelContext;
 
@@ -30,6 +33,12 @@ use crate::api_keys::{ApiKeyManager, GrokTokens};
 /// server is the authority on validity), so this lead time is purely about
 /// keeping the token fresh, not about when it stops being sent.
 const REFRESH_LEAD_TIME: Duration = Duration::from_secs(5 * 60);
+
+/// Hard cap on how long a request dispatch may be held waiting for the
+/// blocking refresh of an already-expired token
+/// ([`ApiKeyManager::refresh_expired_grok_tokens_before_send`]). On timeout
+/// the attempt is abandoned and the request proceeds with the stale token.
+const BLOCKING_REFRESH_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Builds [`GrokTokens`] from a token-endpoint [`TokenResponse`], computing the
 /// absolute `expires_at` from the relative `expires_in`. Values not present in
@@ -87,11 +96,12 @@ impl ApiKeyManager {
     }
 
     /// Request-time safety net: kicks off a background refresh of the stored
-    /// Grok tokens when they are nearing (or already past) expiry, so
+    /// Grok tokens when they are nearing (but not yet past) expiry, so
     /// upcoming requests can authenticate even if the proactive refresh loop
     /// never armed or died (e.g. a stale BYO policy at startup, or an earlier
-    /// failed refresh). The triggering request still carries the currently
-    /// stored token — the server is the authority on its validity.
+    /// failed refresh). Tokens already past their hard expiry are instead
+    /// refreshed by the request-blocking path
+    /// ([`Self::refresh_expired_grok_tokens_before_send`]).
     ///
     /// `byo_allowed` is the BYO API key policy as freshly evaluated by the
     /// caller at request time. It also re-syncs the stored policy mirror,
@@ -109,16 +119,108 @@ impl ApiKeyManager {
         let Some(tokens) = self.grok_tokens() else {
             return;
         };
-        if !tokens.needs_refresh(REFRESH_LEAD_TIME) {
+        // Tokens already past their hard expiry are refreshed by the
+        // request-blocking path instead, so the request waits for a usable
+        // token rather than racing a background refresh.
+        if tokens.is_expired() || !tokens.needs_refresh(REFRESH_LEAD_TIME) {
             return;
         }
         let Some(refresh_token) = tokens.refresh_token.clone() else {
             return;
         };
-        log::info!(
-            "Grok OAuth token is nearing or past expiry at request time; refreshing in background"
-        );
+        log::info!("Grok OAuth token is nearing expiry at request time; refreshing in background");
         spawn_grok_refresh(self, refresh_token, ctx);
+    }
+
+    /// When the stored Grok access token is already past its hard expiry,
+    /// kicks off a single refresh attempt that the triggering request should
+    /// block on before being dispatched. The returned receiver resolves when
+    /// the attempt finishes — success, failure, or timeout — after which the
+    /// caller should build the request, picking up whichever token is then
+    /// stored: refreshed on success, stale otherwise (the server is the
+    /// authority on token validity). Returns `None` when no blocking refresh
+    /// is needed or another refresh is already in flight.
+    ///
+    /// Persisting the refreshed tokens, releasing the in-flight guard, and
+    /// scheduling the next proactive refresh all happen here on the manager's
+    /// own context — completion is the only signal callers receive.
+    pub fn refresh_expired_grok_tokens_before_send(
+        &mut self,
+        ctx: &mut ModelContext<Self>,
+    ) -> Option<oneshot::Receiver<()>> {
+        let refresh_token = self.claim_blocking_grok_refresh()?;
+        let (done_tx, done_rx) = oneshot::channel();
+        log::info!("Grok OAuth token is past its expiry; refreshing it before the request is sent");
+        ctx.spawn(
+            async move {
+                // Cap the wait so a hung token endpoint can't stall the
+                // deferred request indefinitely. Timing out abandons this
+                // attempt; a later request may claim a new one.
+                let refresh = oauth::refresh_access_token(&refresh_token);
+                pin_mut!(refresh);
+                let cap = Timer::after(BLOCKING_REFRESH_TIMEOUT);
+                pin_mut!(cap);
+                match future::select(refresh, cap).await {
+                    Either::Left((result, _)) => Some(result),
+                    Either::Right(_) => None,
+                }
+            },
+            move |manager, outcome, ctx| {
+                manager.grok_refresh_in_flight = false;
+                match outcome {
+                    Some(Ok(response)) => {
+                        log::info!(
+                            "Refreshed expired Grok OAuth token before a request (expires_in={:?}, has_refresh_token={})",
+                            response.expires_in,
+                            response.refresh_token.is_some(),
+                        );
+                        apply_grok_tokens(manager, response, ctx);
+                    }
+                    Some(Err(err)) => {
+                        // Leave the stale tokens in place; the server remains
+                        // the authority and will reject them if truly invalid.
+                        log::error!(
+                            "Failed to refresh the expired Grok OAuth token before a request; \
+                             the request will send the stale token: {err:#}"
+                        );
+                    }
+                    None => {
+                        log::error!(
+                            "Timed out refreshing the expired Grok OAuth token before a request; \
+                             the request will send the stale token"
+                        );
+                    }
+                }
+                // Unblock the deferred request regardless of outcome. The
+                // receiver may already be gone if the send was cancelled.
+                let _ = done_tx.send(());
+            },
+        );
+        Some(done_rx)
+    }
+
+    /// Claims the request-blocking refresh performed by
+    /// [`Self::refresh_expired_grok_tokens_before_send`]: returns the refresh
+    /// token to exchange when the access token is already past its hard
+    /// expiry and no other refresh is in flight, marking the refresh as in
+    /// flight so the proactive timer and the near-expiry safety net can't
+    /// race it.
+    ///
+    /// This intentionally ignores the stored BYO policy mirror: a blocking
+    /// refresh is only claimed for a request that is already carrying the
+    /// token, which is only the case when the policy allowed it at
+    /// request-build time.
+    pub(crate) fn claim_blocking_grok_refresh(&mut self) -> Option<String> {
+        if self.grok_refresh_in_flight {
+            return None;
+        }
+        let tokens = self.grok_tokens()?;
+        if !tokens.is_expired() {
+            return None;
+        }
+        let refresh_token = tokens.refresh_token.clone()?;
+        self.grok_refresh_in_flight = true;
+        Some(refresh_token)
     }
 }
 

--- a/crates/ai/src/grok_subscription/mod.rs
+++ b/crates/ai/src/grok_subscription/mod.rs
@@ -20,6 +20,8 @@ pub mod oauth;
 use std::time::{Duration, SystemTime};
 
 use futures::channel::oneshot;
+use futures::future::{self, Either};
+use futures::pin_mut;
 use warpui_core::r#async::Timer;
 use warpui_core::ModelContext;
 
@@ -31,6 +33,12 @@ use crate::api_keys::{ApiKeyManager, GrokTokens};
 /// server is the authority on validity), so this lead time is purely about
 /// keeping the token fresh, not about when it stops being sent.
 const REFRESH_LEAD_TIME: Duration = Duration::from_secs(5 * 60);
+
+/// Hard cap on how long a request dispatch may be held waiting for the
+/// blocking refresh of an already-expired token
+/// ([`ApiKeyManager::refresh_expired_grok_tokens_before_send`]). On timeout
+/// the attempt is abandoned and the request proceeds with the stale token.
+const BLOCKING_REFRESH_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Builds [`GrokTokens`] from a token-endpoint [`TokenResponse`], computing the
 /// absolute `expires_at` from the relative `expires_in`. Values not present in
@@ -93,7 +101,7 @@ impl ApiKeyManager {
     /// never armed or died (e.g. a stale BYO policy at startup, or an earlier
     /// failed refresh). Tokens already past their hard expiry are instead
     /// refreshed by the request-blocking path
-    /// ([`Self::blocking_grok_refresh_for_request`]).
+    /// ([`Self::refresh_expired_grok_tokens_before_send`]).
     ///
     /// `byo_allowed` is the BYO API key policy as freshly evaluated by the
     /// caller at request time. It also re-syncs the stored policy mirror,
@@ -126,58 +134,77 @@ impl ApiKeyManager {
 
     /// When the stored Grok access token is already past its hard expiry,
     /// kicks off a single refresh attempt that the triggering request should
-    /// block on before being sent, returning a receiver that resolves to the
-    /// access token the request should carry: the refreshed token on success,
-    /// or `None` when the attempt failed (the request keeps its stale token;
-    /// the server is the authority on validity). Returns `None` when no
-    /// blocking refresh is needed or another refresh is already in flight.
+    /// block on before being dispatched. The returned receiver resolves when
+    /// the attempt finishes — success, failure, or timeout — after which the
+    /// caller should build the request, picking up whichever token is then
+    /// stored: refreshed on success, stale otherwise (the server is the
+    /// authority on token validity). Returns `None` when no blocking refresh
+    /// is needed or another refresh is already in flight.
     ///
     /// Persisting the refreshed tokens, releasing the in-flight guard, and
     /// scheduling the next proactive refresh all happen here on the manager's
-    /// own context — callers only observe the token to send.
-    pub fn blocking_grok_refresh_for_request(
+    /// own context — completion is the only signal callers receive.
+    pub fn refresh_expired_grok_tokens_before_send(
         &mut self,
         ctx: &mut ModelContext<Self>,
-    ) -> Option<oneshot::Receiver<Option<String>>> {
+    ) -> Option<oneshot::Receiver<()>> {
         let refresh_token = self.claim_blocking_grok_refresh()?;
-        let (tx, rx) = oneshot::channel();
+        let (done_tx, done_rx) = oneshot::channel();
         log::info!("Grok OAuth token is past its expiry; refreshing it before the request is sent");
         ctx.spawn(
-            async move { oauth::refresh_access_token(&refresh_token).await },
-            move |manager, result, ctx| {
+            async move {
+                // Cap the wait so a hung token endpoint can't stall the
+                // deferred request indefinitely. Timing out abandons this
+                // attempt; a later request may claim a new one.
+                let refresh = oauth::refresh_access_token(&refresh_token);
+                pin_mut!(refresh);
+                let cap = Timer::after(BLOCKING_REFRESH_TIMEOUT);
+                pin_mut!(cap);
+                match future::select(refresh, cap).await {
+                    Either::Left((result, _)) => Some(result),
+                    Either::Right(_) => None,
+                }
+            },
+            move |manager, outcome, ctx| {
                 manager.grok_refresh_in_flight = false;
-                match result {
-                    Ok(response) => {
+                match outcome {
+                    Some(Ok(response)) => {
                         log::info!(
                             "Refreshed expired Grok OAuth token before a request (expires_in={:?}, has_refresh_token={})",
                             response.expires_in,
                             response.refresh_token.is_some(),
                         );
-                        // Unblock the waiting request first, then persist and
-                        // reschedule the proactive refresh.
-                        let _ = tx.send(Some(response.access_token.clone()));
                         apply_grok_tokens(manager, response, ctx);
                     }
-                    Err(err) => {
+                    Some(Err(err)) => {
                         // Leave the stale tokens in place; the server remains
                         // the authority and will reject them if truly invalid.
                         log::error!(
                             "Failed to refresh the expired Grok OAuth token before a request; \
                              the request will send the stale token: {err:#}"
                         );
-                        let _ = tx.send(None);
+                    }
+                    None => {
+                        log::error!(
+                            "Timed out refreshing the expired Grok OAuth token before a request; \
+                             the request will send the stale token"
+                        );
                     }
                 }
+                // Unblock the deferred request regardless of outcome. The
+                // receiver may already be gone if the send was cancelled.
+                let _ = done_tx.send(());
             },
         );
-        Some(rx)
+        Some(done_rx)
     }
 
     /// Claims the request-blocking refresh performed by
-    /// [`Self::blocking_grok_refresh_for_request`]: returns the refresh token
-    /// to exchange when the access token is already past its hard expiry and
-    /// no other refresh is in flight, marking the refresh as in flight so the
-    /// proactive timer and the near-expiry safety net can't race it.
+    /// [`Self::refresh_expired_grok_tokens_before_send`]: returns the refresh
+    /// token to exchange when the access token is already past its hard
+    /// expiry and no other refresh is in flight, marking the refresh as in
+    /// flight so the proactive timer and the near-expiry safety net can't
+    /// race it.
     ///
     /// This intentionally ignores the stored BYO policy mirror: a blocking
     /// refresh is only claimed for a request that is already carrying the


### PR DESCRIPTION
## Description

**Stacked on #12516** (background Grok token refresh) — review only the top commit.

**What:** #12516 keeps the Grok OAuth token fresh in the background, but if the token is already past its hard expiry when a request is sent (e.g. first request after a long idle period, or after the app was closed), that request still goes out with the stale token and fails. This PR blocks such a request on a single refresh attempt so it goes out with a usable token.

**How:**
- `BlocklistAIController::send_request_input` is split into a synchronous validation phase and a dispatch tail (`dispatch_request_input`). When the stored token is past its hard expiry, the controller defers the dispatch behind a one-shot refresh owned by `ApiKeyManager` (`refresh_expired_grok_tokens_before_send`, capped at 10s). Since `RequestParams::new` reads the token from `ApiKeyManager` at build time, the deferred request naturally carries whichever token is then stored — refreshed on success, stale on failure/timeout (logged; the server stays the authority on validity). `ResponseStream` and the request/api layer are untouched.
- The refresh runs on `ApiKeyManager`'s own context: it persists tokens, releases the shared in-flight guard (so the proactive timer, near-expiry safety net, and blocking path can't overlap), and re-arms the proactive schedule. The controller only receives a completion signal.
- Deferred sends are tracked per conversation: they count as active for all in-flight guards (concurrent sends are rejected like today), and `cancel_conversation_progress` abandons the deferred dispatch.
- `send_request_input` now returns `Option<ResponseStreamId>` (`None` while deferred). `/summarize`'s synthetic `SentRequest` emission moved behind a dispatch flag; passive code-diff/unit-test suggestion paths abandon deferred sends instead of tracking them.
- The background safety net from #12516 goes back to covering near-expiry tokens only; expired tokens take the blocking path.

**Trade-off:** in the (rare) expired-token case, exchange creation and `SentRequest` happen after the refresh resolves, so the user's message renders when dispatch runs — typically sub-second, hard-capped at 10s.

## Linked Issue

N/A — follow-up to #12516 ([conversation](https://staging.warp.dev/conversation/b2d9cfb0-4ca0-4da5-8815-4d297b1f0034)).

## Testing

- Unit tests in `crates/ai/src/api_keys_tests.rs`: `is_expired` semantics; the blocking-refresh claim fires only for expired tokens with a refresh token, and only once while in flight.
- `cargo nextest run -p ai` (264 tests) and `cargo nextest run -p warp -E 'test(blocklist) or test(slash) or test(queued) or test(passive)'` (721 tests) pass; presubmit `cargo clippy` and `./script/format` pass.
- Not manually tested end-to-end against xAI (requires holding a token at its expiry boundary). The deferral/cancellation paths are exercised by the existing blocklist controller tests; log lines make the refresh observable.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
