### PR TITLE
Fix stale-PR auto-close timer to anchor on most recent requested-changes review

### DIFF
--- a/.github/scripts/stale-requested-changes-prs.js
+++ b/.github/scripts/stale-requested-changes-prs.js
@@ -21,10 +21,12 @@ module.exports = async ({ github, context }) => {
   const now = Date.now();
   const ts = (value) => (value ? new Date(value).getTime() : 0);
 
-  // A PR has active requested changes when any reviewer's latest *decisive*
-  // review (APPROVED / CHANGES_REQUESTED / DISMISSED, tracked separately from
-  // COMMENTED so a later comment-reply doesn't flip state) is CHANGES_REQUESTED.
-  const hasActiveChangesRequested = (reviews) => {
+  // Returns the submitted_at (ms) of the most recent active requested-changes
+  // review, or 0 when no reviewer currently has changes requested. A reviewer's
+  // latest *decisive* review (APPROVED / CHANGES_REQUESTED / DISMISSED, tracked
+  // separately from COMMENTED so a later comment-reply doesn't flip state)
+  // determines their effective state.
+  const latestActiveChangesRequestedAt = (reviews) => {
     const decisive = new Map();
     const latest = new Map();
     for (const r of reviews) {
@@ -40,11 +42,12 @@ module.exports = async ({ github, context }) => {
         }
       }
     }
+    let latestAt = 0;
     for (const login of latest.keys()) {
       const eff = decisive.get(login) || latest.get(login);
-      if (eff.state === 'CHANGES_REQUESTED') return true;
+      if (eff.state === 'CHANGES_REQUESTED') latestAt = Math.max(latestAt, eff.at);
     }
-    return false;
+    return latestAt;
   };
 
   const openPRs = await github.paginate(github.rest.pulls.list, {
@@ -71,7 +74,8 @@ module.exports = async ({ github, context }) => {
       pull_number: pr.number,
       per_page: 100,
     });
-    if (!hasActiveChangesRequested(reviews)) continue;
+    const changesRequestedAt = latestActiveChangesRequestedAt(reviews);
+    if (!changesRequestedAt) continue;
 
     const [issueComments, reviewComments] = await Promise.all([
       github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: pr.number, per_page: 100 }),
@@ -98,9 +102,13 @@ module.exports = async ({ github, context }) => {
     const prGraph = pushData.repository.pullRequest;
     const headCommit = (prGraph.commits.nodes[0] || {}).commit || {};
 
-    // Author-driven last activity: PR creation, head-branch push, and comments
-    // by the PR author. Maintainer/third-party/bot activity is ignored.
-    let lastActivity = ts(pr.created_at);
+    // Staleness anchor: the most recent active requested-changes review, plus
+    // author-driven events that reset the timer (PR creation, head-branch push,
+    // and comments by the PR author). Anchoring on the latest review ensures a
+    // subsequent requested-changes review restarts the window instead of
+    // measuring from stale, pre-review author activity. Maintainer/third-party/
+    // bot activity is otherwise ignored.
+    let lastActivity = Math.max(ts(pr.created_at), changesRequestedAt);
     lastActivity = Math.max(lastActivity, ts(headCommit.pushedDate || headCommit.committedDate));
     for (const ev of prGraph.timelineItems.nodes) {
       lastActivity = Math.max(lastActivity, ts(ev.createdAt));


### PR DESCRIPTION
## Description
Fixes an arithmetic bug in the auto-close workflow for stale external-contributor PRs with requested changes (`.github/scripts/stale-requested-changes-prs.js`).

The script computed author inactivity (`lastActivity`) only from author-driven events: PR creation, head-branch pushes/force-pushes, and author comments. It never anchored on **when changes were actually requested**. So when a reviewer requested changes well after the author's last activity, the elapsed window was already measured from that stale baseline. A *subsequent* requested-changes review could then push the PR straight past the 14-day close threshold — closing it before the author had any realistic chance to respond.

Concretely, on #11563:
- Author's last activity was at PR creation (no pushes since).
- `acarl005` requested changes ~18 days later.
- The script computed ~18 days of "inactivity" the moment that review landed, even though the review itself was brand new.

### Fix
Anchor the staleness window on the most recent active `CHANGES_REQUESTED` review **in addition to** author activity:
- `hasActiveChangesRequested(reviews)` becomes `latestActiveChangesRequestedAt(reviews)`, returning the `submitted_at` of the most recent active requested-changes review (`0` when none is active).
- `lastActivity` now starts from `max(pr.created_at, changesRequestedAt)` before folding in head pushes, force-pushes, and author comments.

This makes the timer start from the **most recent** review rather than the earliest baseline. A new requested-changes review now restarts the window (and, via the existing `created_at >= lastActivity` marker check, restarts the reminder cycle), so contributors get the full reminder-then-close runway after each review.

## Linked Issue
N/A — internal CI tooling fix surfaced from the #oss-contributions thread re: #11563.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Testing
Validated the script parses with `node --check`. Behavior verified by tracing the #11563 review timeline against the old vs. new `lastActivity` computation. No automated test harness exists for `.github/scripts/`, so no unit test was added.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

_Conversation: https://staging.warp.dev/conversation/2b228c2b-cace-4d17-bf62-149199f47eb9_
_Run: https://oz.staging.warp.dev/runs/019eb81a-3c8d-7867-9977-962a27d0b6a5_

_This PR was generated with [Oz](https://warp.dev/oz)._
