### PR TITLE
fix: stop agent prompt suggestion hover flicker in narrow panes

### DIFF
--- a/app/src/terminal/view/inline_banner/prompt_suggestions.rs
+++ b/app/src/terminal/view/inline_banner/prompt_suggestions.rs
@@ -179,8 +179,22 @@ fn render_button(
             }
         };
 
-        let mut flex = Flex::row()
-            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        let mut flex = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
+
+        // When the button expands on hover, force its row to span the full
+        // available width. Without this, the soft-wrapped text collapses to the
+        // width of its longest wrapped line, which is narrower than the clipped
+        // single-line (collapsed) state. That horizontal shrink moves the chip's
+        // right edge out from under the cursor, which flips hover off, which
+        // collapses the chip again, which puts the cursor back over it — an
+        // infinite hover/un-hover relayout loop that manifests as flickering /
+        // ghosted text. Keeping the expanded chip full-width keeps the hover
+        // target stable so the cursor stays inside it.
+        if should_expand_button {
+            flex = flex.with_main_axis_size(MainAxisSize::Max);
+        }
+
+        let mut flex = flex
             .with_child(
                 Container::new(
                     ConstrainedBox::new(Icon::new(icon.into(), icon_color).finish())


### PR DESCRIPTION
## Description
Fixes the hover-state flicker / "ghosted text" bug introduced by #12199 in the agent prompt suggestion chip.

### Root cause
#12199 made the chip toggle `soft_wrap` based on its own hover state (`should_expand_button = mouse_state.is_hovered()`):

- **Not hovered:** the text is laid out as a single line and `Shrinkable` clips it to the full available width, so the chip spans the whole row.
- **Hovered:** `soft_wrap(true)` makes the text wrap, and the wrapped block collapses to the width of its *longest line* — which is **narrower** than the clipped single-line state.

So the chip *shrinks horizontally* when it expands on hover. If the cursor is over the right portion of the chip, that shrink moves the chip's right edge out from under the cursor → hover flips off → the chip re-collapses to full width → the cursor is over it again → hover flips on → … An infinite hover/un-hover relayout loop. Each toggle also swaps between 1 line and N lines, so the whole pane re-lays-out every frame, which shows up as the flickering / doubled / ghosted text in the report.

### Fix
When the chip is expanded (hovered), force its row to `MainAxisSize::Max` so it spans the full available width. The hover target's right edge then stays put between the collapsed and expanded states, so the cursor stays inside it and the feedback loop is broken. The expand-on-hover behavior from #12199 is preserved.

## Linked Issue
Related to #12198 / #12199.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing
- `./script/format`
- `cargo clippy -p warp --lib --all-features --tests -- -D warnings`
- `cargo test -p warp --lib terminal::view::tests::ctrl_c_does_not_accept_prompt_suggestion_banner --all-features`

- [ ] I have manually tested my changes locally with `./script/run`

> Note: this is a layout/hover-loop fix that is best confirmed by hovering the prompt suggestion in a narrow split pane; automated coverage is limited to the existing banner test above.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed flickering/ghosted text caused by hovering an agent prompt suggestion in narrow panes.
-->


_Conversation: https://staging.warp.dev/conversation/cce6588a-2eba-4f3a-bf08-6de3bb4cd040_
_Run: https://oz.staging.warp.dev/runs/019eb80d-f2d8-7eb2-95e1-4c5facfab17a_

_This PR was generated with [Oz](https://warp.dev/oz)._
