### PR TITLE
[REV-1599] Sync Gemini Enterprise federation config to clients and add the member enablement gate

### DIFF
--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -1069,6 +1069,20 @@ define_settings_group!(AISettings, settings: [
         sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
         private: true,
     }
+    // Whether to mint and attach Gemini Enterprise (GEAP) credentials to eligible agent
+    // requests, routing them through the workspace's Google Cloud project. Only consulted
+    // when the admin sets the GEAP host to RESPECT_USER_SETTING; ENFORCE bypasses it.
+    // Prefer [`UserWorkspaces::is_gemini_enterprise_credentials_enabled`] to interpret
+    // this setting.
+    gemini_enterprise_credentials_enabled: GeminiEnterpriseCredentialsEnabled {
+        type: bool,
+        default: false,
+        supported_platforms: SupportedPlatforms::DESKTOP,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        private: false,
+        toml_path: "cloud_platform.third_party_api_keys.gemini_enterprise_credentials_enabled",
+        description: "Whether Warp should route eligible requests through your workspace's Gemini Enterprise Google Cloud project.",
+    }
     // Whether or not the user wants agent mode requests to use their saved rules.
     memory_enabled: MemoryEnabled {
         type: bool,

--- a/app/src/workspaces/gql_convert.rs
+++ b/app/src/workspaces/gql_convert.rs
@@ -770,6 +770,8 @@ impl From<warp_graphql::workspace::LlmHostSettings> for super::workspace::LlmHos
                 .enablement_setting
                 .map(Into::into)
                 .unwrap_or_default(),
+            gcp_audience: gql_settings.gcp_audience,
+            gcp_sa_email: gql_settings.gcp_sa_email,
         }
     }
 }

--- a/app/src/workspaces/user_workspaces.rs
+++ b/app/src/workspaces/user_workspaces.rs
@@ -556,6 +556,63 @@ impl UserWorkspaces {
         }
     }
 
+    pub fn gemini_enterprise_host_settings(&self) -> Option<&super::workspace::LlmHostSettings> {
+        self.current_workspace().and_then(|workspace| {
+            workspace
+                .settings
+                .llm_settings
+                .host_configs
+                .get(&LLMModelHost::GeminiEnterprise)
+        })
+    }
+
+    /// Did the admin enable Gemini Enterprise (GEAP) for the current workspace?
+    pub fn is_gemini_enterprise_available_from_workspace(&self) -> bool {
+        self.current_workspace().is_some_and(|workspace| {
+            workspace.settings.llm_settings.enabled
+                && self
+                    .gemini_enterprise_host_settings()
+                    .is_some_and(|settings| settings.enabled)
+        })
+    }
+
+    pub fn gemini_enterprise_host_enablement_setting(&self) -> HostEnablementSetting {
+        self.gemini_enterprise_host_settings()
+            .map(|settings| settings.enablement_setting.clone())
+            .unwrap_or_default()
+    }
+
+    pub fn is_gemini_enterprise_credentials_toggleable(&self) -> bool {
+        matches!(
+            self.gemini_enterprise_host_enablement_setting(),
+            HostEnablementSetting::RespectUserSetting
+        )
+    }
+
+    /// Whether Gemini Enterprise (GEAP) credentials should be minted and attached for the
+    /// current user. Anonymous/logged-out guard from [`Self::is_byo_api_key_enabled`]:
+    /// a GEAP credential mint is rooted in the user's Warp session, so without one
+    /// there is nothing to mint from.
+    pub fn is_gemini_enterprise_credentials_enabled(&self, app: &AppContext) -> bool {
+        if AuthStateProvider::as_ref(app)
+            .get()
+            .is_anonymous_or_logged_out()
+        {
+            return false;
+        }
+        // i.e. did the admin toggle on Gemini Enterprise in the admin panel?
+        if !self.is_gemini_enterprise_available_from_workspace() {
+            return false;
+        }
+
+        match self.gemini_enterprise_host_enablement_setting() {
+            HostEnablementSetting::Enforce => true,
+            HostEnablementSetting::RespectUserSetting => *AISettings::as_ref(app)
+                .gemini_enterprise_credentials_enabled
+                .value(),
+        }
+    }
+
     /// Returns the AI autonomy settings that are enforced by the workspace for all its members.
     /// If a setting is `None`, the workspace doesn't enforce a particular setting.
     pub fn ai_autonomy_settings(&self) -> AiAutonomySettings {

--- a/app/src/workspaces/user_workspaces_tests.rs
+++ b/app/src/workspaces/user_workspaces_tests.rs
@@ -41,6 +41,22 @@ fn initialize_app(
     team_client: Arc<dyn TeamClient>,
     workspace_client: Arc<dyn WorkspaceClient>,
 ) {
+    initialize_app_with_auth(
+        app,
+        resources,
+        team_client,
+        workspace_client,
+        AuthStateProvider::new_for_test(),
+    );
+}
+
+fn initialize_app_with_auth(
+    app: &mut App,
+    resources: CachedResources,
+    team_client: Arc<dyn TeamClient>,
+    workspace_client: Arc<dyn WorkspaceClient>,
+    auth_state_provider: AuthStateProvider,
+) {
     // Add the necessary singleton models to the App
     app.add_singleton_model(|_| NetworkStatus::new());
     app.add_singleton_model(|_| SystemStats::new());
@@ -59,7 +75,7 @@ fn initialize_app(
     app.add_singleton_model(UpdateManager::mock);
     app.add_singleton_model(PrivacySettings::mock);
     app.add_singleton_model(|_| ServerApiProvider::new_for_test());
-    app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+    app.add_singleton_model(|_| auth_state_provider);
     app.add_singleton_model(AuthManager::new_for_test);
     app.add_singleton_model(AppTelemetryContextProvider::new_context_provider);
     app.add_singleton_model(|_| {
@@ -240,6 +256,7 @@ fn test_aws_bedrock_credentials_default_off_when_admin_respects_user_setting() {
         LlmHostSettings {
             enabled: true,
             enablement_setting: HostEnablementSetting::RespectUserSetting,
+            ..Default::default()
         },
     );
 
@@ -276,6 +293,7 @@ fn test_aws_bedrock_credentials_respect_user_setting() {
         LlmHostSettings {
             enabled: true,
             enablement_setting: HostEnablementSetting::RespectUserSetting,
+            ..Default::default()
         },
     );
     let mut team_client = MockTeamClient::new();
@@ -331,6 +349,7 @@ fn test_aws_bedrock_credentials_enforced_by_admin() {
         LlmHostSettings {
             enabled: true,
             enablement_setting: HostEnablementSetting::Enforce,
+            ..Default::default()
         },
     );
     let mut team_client = MockTeamClient::new();
@@ -372,6 +391,254 @@ fn test_aws_bedrock_credentials_enforced_by_admin() {
                 !UserWorkspaces::as_ref(ctx).is_aws_bedrock_credentials_toggleable(),
                 "enforced Bedrock host policy should disable the local Bedrock credentials toggle"
             );
+        });
+    })
+}
+
+const TEST_GCP_AUDIENCE: &str = "//iam.googleapis.com/projects/123456/locations/global/workloadIdentityPools/warp-pool/providers/warp-provider";
+const TEST_GCP_SA_EMAIL: &str = "warp-geap@test-project.iam.gserviceaccount.com";
+
+fn workspace_with_gemini_enterprise_host(
+    team: &Team,
+    enabled: bool,
+    enablement_setting: HostEnablementSetting,
+) -> Workspace {
+    let mut workspace = workspace_for_test(team);
+    workspace.settings.llm_settings.enabled = true;
+    workspace.settings.llm_settings.host_configs.insert(
+        LLMModelHost::GeminiEnterprise,
+        LlmHostSettings {
+            enabled,
+            enablement_setting,
+            gcp_audience: Some(TEST_GCP_AUDIENCE.to_string()),
+            gcp_sa_email: Some(TEST_GCP_SA_EMAIL.to_string()),
+        },
+    );
+    workspace
+}
+
+#[test]
+fn test_gemini_enterprise_credentials_default_off_when_admin_respects_user_setting() {
+    let team = team_for_test();
+    let workspace = workspace_with_gemini_enterprise_host(
+        &team,
+        true,
+        HostEnablementSetting::RespectUserSetting,
+    );
+
+    App::test((), |mut app| async move {
+        initialize_app(
+            &mut app,
+            CachedResources {
+                workspaces: vec![workspace],
+            },
+            Arc::new(MockTeamClient::new()),
+            Arc::new(MockWorkspaceClient::new()),
+        );
+
+        app.read(|ctx| {
+            assert!(
+                !UserWorkspaces::as_ref(ctx).is_gemini_enterprise_credentials_enabled(ctx),
+                "respect-user-setting should default the local Gemini Enterprise credentials toggle to off"
+            );
+            assert!(
+                UserWorkspaces::as_ref(ctx).is_gemini_enterprise_credentials_toggleable(),
+                "respect-user-setting should leave the local Gemini Enterprise credentials toggle editable"
+            );
+        });
+    })
+}
+
+#[test]
+fn test_gemini_enterprise_credentials_respect_user_setting_honors_member_toggle() {
+    let team = team_for_test();
+    let workspace = workspace_with_gemini_enterprise_host(
+        &team,
+        true,
+        HostEnablementSetting::RespectUserSetting,
+    );
+
+    App::test((), |mut app| async move {
+        initialize_app(
+            &mut app,
+            CachedResources {
+                workspaces: vec![workspace],
+            },
+            Arc::new(MockTeamClient::new()),
+            Arc::new(MockWorkspaceClient::new()),
+        );
+
+        AISettings::handle(&app).update(&mut app, |settings, ctx| {
+            let _ = settings
+                .gemini_enterprise_credentials_enabled
+                .set_value(true, ctx);
+        });
+
+        app.read(|ctx| {
+            assert!(
+                UserWorkspaces::as_ref(ctx).is_gemini_enterprise_credentials_enabled(ctx),
+                "respect-user-setting should honor an opted-in Gemini Enterprise credentials toggle"
+            );
+        });
+    })
+}
+
+#[test]
+fn test_gemini_enterprise_credentials_enforced_by_admin() {
+    let team = team_for_test();
+    let workspace =
+        workspace_with_gemini_enterprise_host(&team, true, HostEnablementSetting::Enforce);
+
+    App::test((), |mut app| async move {
+        initialize_app(
+            &mut app,
+            CachedResources {
+                workspaces: vec![workspace],
+            },
+            Arc::new(MockTeamClient::new()),
+            Arc::new(MockWorkspaceClient::new()),
+        );
+
+        AISettings::handle(&app).update(&mut app, |settings, ctx| {
+            let _ = settings
+                .gemini_enterprise_credentials_enabled
+                .set_value(false, ctx);
+        });
+
+        app.read(|ctx| {
+            assert!(
+                UserWorkspaces::as_ref(ctx).is_gemini_enterprise_credentials_enabled(ctx),
+                "enforced Gemini Enterprise host policy should ignore the local credentials toggle"
+            );
+            assert!(
+                !UserWorkspaces::as_ref(ctx).is_gemini_enterprise_credentials_toggleable(),
+                "enforced Gemini Enterprise host policy should disable the local credentials toggle"
+            );
+        });
+    })
+}
+
+#[test]
+fn test_gemini_enterprise_credentials_disabled_when_host_disabled() {
+    let team = team_for_test();
+    let workspace =
+        workspace_with_gemini_enterprise_host(&team, false, HostEnablementSetting::Enforce);
+
+    App::test((), |mut app| async move {
+        initialize_app(
+            &mut app,
+            CachedResources {
+                workspaces: vec![workspace],
+            },
+            Arc::new(MockTeamClient::new()),
+            Arc::new(MockWorkspaceClient::new()),
+        );
+
+        app.read(|ctx| {
+            assert!(
+                !UserWorkspaces::as_ref(ctx).is_gemini_enterprise_available_from_workspace(),
+                "a disabled Gemini Enterprise host should not be available from the workspace"
+            );
+            assert!(
+                !UserWorkspaces::as_ref(ctx).is_gemini_enterprise_credentials_enabled(ctx),
+                "a disabled Gemini Enterprise host should gate credentials off even under ENFORCE"
+            );
+        });
+    })
+}
+
+#[test]
+fn test_gemini_enterprise_credentials_disabled_when_host_absent() {
+    let team = team_for_test();
+    // Bedrock-only workspace: proves the GEAP gate reads its own host entry.
+    let mut workspace = workspace_for_test(&team);
+    workspace.settings.llm_settings.enabled = true;
+    workspace.settings.llm_settings.host_configs.insert(
+        LLMModelHost::AwsBedrock,
+        LlmHostSettings {
+            enabled: true,
+            enablement_setting: HostEnablementSetting::Enforce,
+            ..Default::default()
+        },
+    );
+
+    App::test((), |mut app| async move {
+        initialize_app(
+            &mut app,
+            CachedResources {
+                workspaces: vec![workspace],
+            },
+            Arc::new(MockTeamClient::new()),
+            Arc::new(MockWorkspaceClient::new()),
+        );
+
+        app.read(|ctx| {
+            assert!(
+                UserWorkspaces::as_ref(ctx)
+                    .gemini_enterprise_host_settings()
+                    .is_none(),
+                "a workspace without a Gemini Enterprise host entry should expose no settings"
+            );
+            assert!(
+                !UserWorkspaces::as_ref(ctx).is_gemini_enterprise_credentials_enabled(ctx),
+                "a workspace without a Gemini Enterprise host entry should gate credentials off"
+            );
+        });
+    })
+}
+
+#[test]
+fn test_gemini_enterprise_credentials_disabled_when_logged_out() {
+    let team = team_for_test();
+    let workspace =
+        workspace_with_gemini_enterprise_host(&team, true, HostEnablementSetting::Enforce);
+
+    App::test((), |mut app| async move {
+        initialize_app_with_auth(
+            &mut app,
+            CachedResources {
+                workspaces: vec![workspace],
+            },
+            Arc::new(MockTeamClient::new()),
+            Arc::new(MockWorkspaceClient::new()),
+            AuthStateProvider::new_logged_out_for_test(),
+        );
+
+        app.read(|ctx| {
+            assert!(
+                !UserWorkspaces::as_ref(ctx).is_gemini_enterprise_credentials_enabled(ctx),
+                "logged-out users should never mint or attach Gemini Enterprise credentials"
+            );
+        });
+    })
+}
+
+#[test]
+fn test_gemini_enterprise_host_settings_carries_federation_config() {
+    let team = team_for_test();
+    let workspace = workspace_with_gemini_enterprise_host(
+        &team,
+        true,
+        HostEnablementSetting::RespectUserSetting,
+    );
+
+    App::test((), |mut app| async move {
+        initialize_app(
+            &mut app,
+            CachedResources {
+                workspaces: vec![workspace],
+            },
+            Arc::new(MockTeamClient::new()),
+            Arc::new(MockWorkspaceClient::new()),
+        );
+
+        app.read(|ctx| {
+            let user_workspaces = UserWorkspaces::as_ref(ctx);
+            let settings = user_workspaces
+                .gemini_enterprise_host_settings()
+                .expect("workspace should expose the Gemini Enterprise host settings");
+            assert_eq!(settings.gcp_audience.as_deref(), Some(TEST_GCP_AUDIENCE));
+            assert_eq!(settings.gcp_sa_email.as_deref(), Some(TEST_GCP_SA_EMAIL));
         });
     })
 }

--- a/app/src/workspaces/workspace.rs
+++ b/app/src/workspaces/workspace.rs
@@ -747,6 +747,17 @@ mod tests;
 pub struct LlmHostSettings {
     pub enabled: bool,
     pub enablement_setting: HostEnablementSetting,
+    /// Full resource name of the GCP workload identity provider that Gemini Enterprise
+    /// (GEAP) credential minting exchanges Warp OIDC JWTs against. Only populated on the
+    /// `GeminiEnterprise` host entry; `None` for other hosts and for workspace caches
+    /// written before this field existed.
+    #[serde(default)]
+    pub gcp_audience: Option<String>,
+    /// Email of the GCP service account that Gemini Enterprise credential minting
+    /// impersonates after the STS exchange. `None` (or empty) means the federated token
+    /// is used directly.
+    #[serde(default)]
+    pub gcp_sa_email: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]

--- a/crates/graphql/src/api/workspace.rs
+++ b/crates/graphql/src/api/workspace.rs
@@ -304,6 +304,8 @@ pub struct LlmHostSettings {
     pub enabled: bool,
     pub opt_out_of_new_models: bool,
     pub enablement_setting: Option<HostEnablementSetting>,
+    pub gcp_audience: Option<String>,
+    pub gcp_sa_email: Option<String>,
 }
 
 #[derive(cynic::QueryFragment, Debug, Clone)]

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -1991,6 +1991,19 @@ type LlmHostSettings {
   enablementSetting: HostEnablementSetting
 
   """
+  Full resource name of the GCP workload identity provider that Gemini Enterprise
+  clients exchange Warp OIDC JWTs against (used as both the JWT audience and the
+  STS exchange audience).
+  """
+  gcpAudience: String
+
+  """
+  Email of the GCP service account that Gemini Enterprise clients impersonate after
+  the STS exchange. Empty means the federated token is used directly.
+  """
+  gcpSaEmail: String
+
+  """
   IAM role ARN that Oz Cloud Agents assume via the OIDC trust flow to obtain credentials for AWS Bedrock requests.
   """
   oidcAssumeRoleArn: String


### PR DESCRIPTION
## Description

First client PR for **REV-1599 — GEAP (Gemini Enterprise Agent Platform) BYOLLM**, implementing the config-sync and enablement-gate portion of the client tech spec (#12493).

This PR is plumbing, no credential is minted or attached:

- **Workspace federation config sync**: adds `gcpAudience` / `gcpSaEmail` to the the `LlmHostSettings` schema type, the cynic `QueryFragment`, the app-side workspace model, and the GraphQL→app conversion. These are the two admin-configured, client-consumed WIF parameters: the workload identity provider resource name (JWT `aud` + STS audience) and the service account to impersonate. The server-side dispatch parameters (`gcpProjectId`/`gcpLocation`) are not queried by the client (only needed by the server to forward the request properly). 
- **Member enablement toggle (data model only)**: `AISettings::gemini_enterprise_credentials_enabled`, default `false` (opt-in), cloud-synced, mirroring `aws_bedrock_credentials_enabled`. No Settings UI row yet.
- **Enablement gate**: `UserWorkspaces::is_gemini_enterprise_credentials_enabled()` plus accessors: logged-out guard → admin availability (`llm_settings.enabled` + GEAP host `enabled`) → `ENFORCE` (on for all members) / `RESPECT_USER_SETTING` (defer to the member toggle). The logged-out guard is the one deliberate divergence from Bedrock: a GEAP mint is rooted in the Warp session, so without one there is nothing to mint from. Nothing calls the gate yet.

### Follow-up PRs

- **PR 2 — GEAP credential engine**: `GeapCredentialsState` state machine on `ApiKeyManager`, the 3-leg WIF mint (Warp OIDC JWT → STS exchange → SA impersonation), proactive one-shot refresh timer + request-time safety net, and request attachment via `api_keys_for_request` (always-send semantics; Google stays the authority on token validity). First consumer of this PR's gate and federation config.
- **PR 3 — Recovery UX**: the Settings > Warp Agent toggle row ("Enabled by your workspace" under `ENFORCE`) with a manual **Refresh credentials** button, and the inline credential error view with auto-remint + Retry.

## Linked Issue

Linear: [REV-1599](https://linear.app/warpdotdev/issue/REV-1599)

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (not applicable — no UI or behavior change).

## Testing

- `cargo nextest run -p warp -E 'test(gemini_enterprise) or test(aws_bedrock_credentials)'` — 11 passed (7 new GEAP gate tests + existing Bedrock gate tests)
- `cargo nextest run -p warp -E 'test(workspaces::) or test(settings::)'` — 132 passed
- `cargo check -p warp_graphql -p warp --lib` — clean (cynic validates the fragment against the vendored schema at compile time)
- `./script/format` — clean
- `cargo clippy -p warp -p warp_graphql --all-targets --tests -- -D warnings` — clean

New tests cover: default-off under `RESPECT_USER_SETTING` (pins opt-in semantics), member opt-in honored, `ENFORCE` overriding the toggle (and hiding it), host-disabled beating `ENFORCE`, host-absent workspaces, logged-out users always gated off, and the federation config round-tripping through the workspace model.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
