### PR TITLE
Configure git credentials with Github.

### DIFF
--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -834,7 +834,23 @@ impl AgentDriverRunner {
     async fn bootstrap_git_credentials_for_task(
         foreground: &ModelSpawner<Self>,
         task_id_str: &str,
+        args: &RunAgentArgs,
     ) -> Result<(), AgentDriverError> {
+        if warp_isolation_platform::detect().is_none() && args.configure_git_credentials_with_github {
+            foreground.spawn(|_, _| {
+                command::blocking::Command::new("gh")
+                    .args(["auth", "setup-git"])
+                    .spawn()
+                    .map_err(|err| {
+                        AgentDriverError::SkillResolutionFailed(format!(
+                            "gh auth setup-git failed: {err:?}"
+                        ))
+                    })
+            })
+            .await?
+            .map(|_| ())?
+        }
+
         if !FeatureFlag::GitCredentialRefresh.is_enabled() {
             return Ok(());
         }
@@ -964,7 +980,7 @@ impl AgentDriverRunner {
         .map_err(AgentDriverError::ConfigBuildFailed)?;
 
         if let Some(task_id_str) = args.task_id.as_ref() {
-            Self::bootstrap_git_credentials_for_task(foreground, task_id_str).await?;
+            Self::bootstrap_git_credentials_for_task(foreground, task_id_str, &args).await?;
         }
         // Resolve the skill, if we have one
         let resolved_skill =

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -836,19 +836,21 @@ impl AgentDriverRunner {
         task_id_str: &str,
         args: &RunAgentArgs,
     ) -> Result<(), AgentDriverError> {
-        if warp_isolation_platform::detect().is_none() && args.configure_git_credentials_with_github {
-            foreground.spawn(|_, _| {
-                command::blocking::Command::new("gh")
-                    .args(["auth", "setup-git"])
-                    .spawn()
-                    .map_err(|err| {
-                        AgentDriverError::SkillResolutionFailed(format!(
-                            "gh auth setup-git failed: {err:?}"
-                        ))
-                    })
-            })
-            .await?
-            .map(|_| ())?
+        if warp_isolation_platform::detect().is_none() && args.configure_git_credentials_with_github
+        {
+            foreground
+                .spawn(|_, _| {
+                    command::blocking::Command::new("gh")
+                        .args(["auth", "setup-git"])
+                        .spawn()
+                        .map_err(|err| {
+                            AgentDriverError::SkillResolutionFailed(format!(
+                                "gh auth setup-git failed: {err:?}"
+                            ))
+                        })
+                })
+                .await?
+                .map(|_| ())?
         }
 
         if !FeatureFlag::GitCredentialRefresh.is_enabled() {

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -844,13 +844,14 @@ impl AgentDriverRunner {
                         .args(["auth", "setup-git"])
                         .spawn()
                         .map_err(|err| {
-                            AgentDriverError::SkillResolutionFailed(format!(
+                            AgentDriverError::ConfigBuildFailed(anyhow::anyhow!(
                                 "gh auth setup-git failed: {err:?}"
                             ))
                         })
                 })
                 .await?
-                .map(|_| ())?
+                .map(|_| ())?;
+            return Ok(());
         }
 
         if !FeatureFlag::GitCredentialRefresh.is_enabled() {

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -420,6 +420,9 @@ pub struct RunAgentArgs {
         conflicts_with_all = ["prompt", "saved_prompt", "file"]
     )]
     pub skip_initial_turn: bool,
+
+    #[arg(long = "configure-git-credentials-with-github", hide = true, requires_all = ["task_id"])]
+    pub configure_git_credentials_with_github: bool,
 }
 
 impl RunAgentArgs {


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

This helps with testing out changes on `oz-local` after Jason's recent changes to have oz local runs not clobber global git state. I noticed this when the OZ CLI tried to clone a private repository owned by the warpdotdev org for codex plugin support. 

In conjunction with https://github.com/warpdotdev/warp-server/pull/11835.


## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

I tested downstream that we can clone the repo in question.

