### PR TITLE
listen for cache TTL and show in input (dev only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15181,6 +15181,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=a04c490e6dd5d7f9073befb954894a681bf0ea88#a04c490e6dd5d7f9073befb954894a681bf0ea88"
 dependencies = [
  "prost",
  "prost-reflect",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15181,7 +15181,6 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=97d1b367b955c562812e0a1315a6ec7ee6a5389e#97d1b367b955c562812e0a1315a6ec7ee6a5389e"
 dependencies = [
  "prost",
  "prost-reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -547,7 +547,8 @@ tikv-jemalloc-sys = { git = "https://github.com/warpdotdev/jemallocator.git", re
 
 [patch."https://github.com/warpdotdev/warp-proto-apis.git"]
 # Uncomment for local development of warp-proto-apis
-# warp_multi_agent_api = { path = "../warp-proto-apis/apis/multi_agent/v1/gen/rust" }
+# TODO: revert to the published git rev once the proto PR merges
+warp_multi_agent_api = { path = "../warp-proto-apis/apis/multi_agent/v1/gen/rust" }
 
 [patch."https://github.com/warpdotdev/session-sharing-protocol.git"]
 # Uncomment for local development of session-sharing-protocol

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,7 +335,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "97d1b367b955c562812e0a1315a6ec7ee6a5389e" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "a04c490e6dd5d7f9073befb954894a681bf0ea88" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [
@@ -547,8 +547,7 @@ tikv-jemalloc-sys = { git = "https://github.com/warpdotdev/jemallocator.git", re
 
 [patch."https://github.com/warpdotdev/warp-proto-apis.git"]
 # Uncomment for local development of warp-proto-apis
-# TODO: revert to the published git rev once the proto PR merges
-warp_multi_agent_api = { path = "../warp-proto-apis/apis/multi_agent/v1/gen/rust" }
+# warp_multi_agent_api = { path = "../warp-proto-apis/apis/multi_agent/v1/gen/rust" }
 
 [patch."https://github.com/warpdotdev/session-sharing-protocol.git"]
 # Uncomment for local development of session-sharing-protocol

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -1010,6 +1010,7 @@ cloud_mode_setup_v2 = ["cloud_mode"]
 cloud_mode_input_v2 = ["cloud_mode"]
 handoff_cloud_cloud = ["cloud_mode_setup_v2"]
 git_credential_refresh = []
+prompt_cache_expiry_warning = []
 
 [package.metadata.bundle.bin.warp-oss]
 category = "public.app-category.developer-tools"

--- a/app/src/ai/agent/api/convert_conversation.rs
+++ b/app/src/ai/agent/api/convert_conversation.rs
@@ -1885,6 +1885,10 @@ fn create_exchange_from_messages(
             model_id: model.model_id.clone().into(),
             display_name: model.model_display_name.clone(),
             is_fallback: model.is_fallback,
+            prompt_cache_expires_at: model
+                .prompt_cache_expires_at
+                .as_ref()
+                .map(|ts| proto_timestamp_to_local_datetime(ts.seconds, ts.nanos)),
         }),
         request_cost: None,
     };

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -2708,13 +2708,6 @@ impl AIConversation {
                                 .prompt_cache_expires_at
                                 .as_ref()
                                 .map(|ts| proto_timestamp_to_local_datetime(ts.seconds, ts.nanos));
-                            log::info!(
-                                "[DEBUG] ModelUsed received: model_id={} is_fallback={} prompt_cache_expires_at={:?} (in {:?})",
-                                model_used.model_id,
-                                model_used.is_fallback,
-                                prompt_cache_expires_at,
-                                prompt_cache_expires_at.map(|t| t - Local::now()),
-                            );
                             let exchange_id = self
                                 .added_exchanges_by_response
                                 .get(response_stream_id)

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -2704,6 +2704,17 @@ impl AIConversation {
                             }
                         }
                         Some(api::message::Message::ModelUsed(model_used)) => {
+                            let prompt_cache_expires_at = model_used
+                                .prompt_cache_expires_at
+                                .as_ref()
+                                .map(|ts| proto_timestamp_to_local_datetime(ts.seconds, ts.nanos));
+                            log::info!(
+                                "[DEBUG] ModelUsed received: model_id={} is_fallback={} prompt_cache_expires_at={:?} (in {:?})",
+                                model_used.model_id,
+                                model_used.is_fallback,
+                                prompt_cache_expires_at,
+                                prompt_cache_expires_at.map(|t| t - Local::now()),
+                            );
                             let exchange_id = self
                                 .added_exchanges_by_response
                                 .get(response_stream_id)
@@ -2717,6 +2728,7 @@ impl AIConversation {
                                     model_id: model_used.model_id.clone().into(),
                                     display_name: model_used.model_display_name.clone(),
                                     is_fallback: model_used.is_fallback,
+                                    prompt_cache_expires_at,
                                 });
                             }
                         }

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -425,6 +425,9 @@ pub struct OutputModelInfo {
     pub model_id: LLMId,
     pub display_name: String,
     pub is_fallback: bool,
+    /// When the provider-side prompt cache for this request is expected to
+    /// expire. `None` means unknown / no cache-expiry info.
+    pub prompt_cache_expires_at: Option<DateTime<Local>>,
 }
 
 impl Display for AIAgentOutput {

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -2039,10 +2039,11 @@ impl AgentInputFooter {
 
             self.context_window_button.update(ctx, |button, ctx| {
                 button.set_icon(Some(icon), ctx);
-                button.set_icon_ansi_color(
-                    is_cache_expired.then_some(AnsiColorIdentifier::Yellow),
-                    ctx,
-                );
+                if is_cache_expired {
+                    button.set_theme(WarningAgentInputButtonTheme, ctx);
+                } else {
+                    button.set_theme(AgentInputButtonTheme, ctx);
+                }
                 button.set_tooltip(Some(tooltip), ctx);
             });
 
@@ -2871,6 +2872,43 @@ impl ActionButtonTheme for InstallPluginButtonTheme {
 
     fn should_opt_out_of_contrast_adjustment(&self) -> bool {
         true
+    }
+}
+
+/// Yellow-tinted variant of [`AgentInputButtonTheme`] used to flag a warning
+/// state on an input chip (e.g. expired prompt cache); slightly darker on hover.
+struct WarningAgentInputButtonTheme;
+
+impl ActionButtonTheme for WarningAgentInputButtonTheme {
+    fn background(&self, hovered: bool, appearance: &Appearance) -> Option<Fill> {
+        let yellow = appearance.theme().ansi_fg_yellow();
+        let base = appearance.theme().surface_1();
+        Some(if hovered {
+            base.blend(&Fill::Solid(yellow).with_opacity(45))
+        } else {
+            base.blend(&Fill::Solid(yellow).with_opacity(30))
+        })
+    }
+
+    fn text_color(
+        &self,
+        hovered: bool,
+        background: Option<Fill>,
+        appearance: &Appearance,
+    ) -> ColorU {
+        AgentInputButtonTheme.text_color(hovered, background, appearance)
+    }
+
+    fn border(&self, appearance: &Appearance) -> Option<ColorU> {
+        AgentInputButtonTheme.border(appearance)
+    }
+
+    fn should_opt_out_of_contrast_adjustment(&self) -> bool {
+        AgentInputButtonTheme.should_opt_out_of_contrast_adjustment()
+    }
+
+    fn font_properties(&self) -> Option<warpui::fonts::Properties> {
+        AgentInputButtonTheme.font_properties()
     }
 }
 

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -48,7 +48,6 @@ pub(crate) use self::environment_selector::sort_environments_by_recency;
 pub(crate) use self::environment_selector::{
     EnvironmentSelector, EnvironmentSelectorEvent, EnvironmentSelectorTarget,
 };
-use crate::ai::agent::conversation::AIConversation;
 use crate::ai::blocklist::agent_view::is_in_cloud_context;
 use crate::ai::blocklist::history_model::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::ai::blocklist::prompt::prompt_alert::{PromptAlertEvent, PromptAlertView};
@@ -168,13 +167,6 @@ fn plugin_chip_key(agent_prefix: &str, remote_host: &Option<String>) -> String {
         Some(host) => format!("{agent_prefix}@{host}"),
         None => agent_prefix.to_owned(),
     }
-}
-
-/// Returns the prompt-cache expiry reported for the conversation's most
-/// recent exchange output, if known.
-fn prompt_cache_expiry(conversation: &AIConversation) -> Option<DateTime<Local>> {
-    let output = conversation.latest_exchange()?.output_status.output()?;
-    output.get().model_info.as_ref()?.prompt_cache_expires_at
 }
 
 fn is_conversation_transcript_context(
@@ -2028,13 +2020,17 @@ impl AgentInputFooter {
             let icon = icon_for_context_window_usage(usage);
             let remaining_pct = ((1.0 - usage) * 100.0).round() as i32;
 
-            let expiry = prompt_cache_expiry(conversation);
+            let expiry = conversation.latest_exchange().and_then(|exchange| {
+                let output = exchange.output_status.output()?;
+                output.get().model_info.as_ref()?.prompt_cache_expires_at
+            });
             let is_cache_expired = FeatureFlag::PromptCacheExpiryWarning.is_enabled()
                 && expiry.is_some_and(|expiry| expiry <= Local::now());
+            let context_remaining_tooltip = format!("{remaining_pct}% context remaining");
             let tooltip = if is_cache_expired {
-                "prompt cache expired".to_string()
+                format!("{context_remaining_tooltip} · prompt cache expired")
             } else {
-                format!("{remaining_pct}% context remaining")
+                context_remaining_tooltip
             };
 
             self.context_window_button.update(ctx, |button, ctx| {

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ai::document::{AIDocumentId, AIDocumentVersion};
+use chrono::{DateTime, Local};
 use parking_lot::FairMutex;
 use pathfinder_color::ColorU;
 use pathfinder_geometry::vector::{vec2f, Vector2F};
@@ -36,10 +37,7 @@ use warpui::elements::{
     PositionedElementOffsetBounds, Radius, Shrinkable, Stack, Text, Wrap, WrapFill,
     WrapFillEntireRun, DEFAULT_UI_LINE_HEIGHT_RATIO,
 };
-#[cfg(feature = "voice_input")]
-use warpui::r#async::SpawnedFutureHandle;
-#[cfg(not(target_family = "wasm"))]
-use warpui::r#async::Timer;
+use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::{
     AppContext, Entity, EntityId, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
     ViewHandle,
@@ -50,6 +48,7 @@ pub(crate) use self::environment_selector::sort_environments_by_recency;
 pub(crate) use self::environment_selector::{
     EnvironmentSelector, EnvironmentSelectorEvent, EnvironmentSelectorTarget,
 };
+use crate::ai::agent::conversation::AIConversation;
 use crate::ai::blocklist::agent_view::is_in_cloud_context;
 use crate::ai::blocklist::history_model::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::ai::blocklist::prompt::prompt_alert::{PromptAlertEvent, PromptAlertView};
@@ -171,6 +170,13 @@ fn plugin_chip_key(agent_prefix: &str, remote_host: &Option<String>) -> String {
     }
 }
 
+/// Returns the prompt-cache expiry reported for the conversation's most
+/// recent exchange output, if known.
+fn prompt_cache_expiry(conversation: &AIConversation) -> Option<DateTime<Local>> {
+    let output = conversation.latest_exchange()?.output_status.output()?;
+    output.get().model_info.as_ref()?.prompt_cache_expires_at
+}
+
 fn is_conversation_transcript_context(
     terminal_view_id: EntityId,
     terminal_model: &TerminalModel,
@@ -249,6 +255,10 @@ pub struct AgentInputFooter {
     #[cfg(feature = "voice_input")]
     cli_transcription_handle: Option<SpawnedFutureHandle>,
     v2_model_selector: Option<ViewHandle<ModelSelector>>,
+
+    /// Pending one-shot timer that refreshes the context-window button at the
+    /// prompt-cache expiry instant so the yellow tint appears while idle.
+    prompt_cache_expiry_timer_handle: Option<SpawnedFutureHandle>,
 }
 
 impl AgentInputFooter {
@@ -875,6 +885,7 @@ impl AgentInputFooter {
                     })
             }),
             v2_model_selector,
+            prompt_cache_expiry_timer_handle: None,
         };
         me.sync_fast_forward_button(ctx);
         me.sync_remote_control_button(ctx);
@@ -2016,13 +2027,57 @@ impl AgentInputFooter {
             let usage = conversation.context_window_usage();
             let icon = icon_for_context_window_usage(usage);
             let remaining_pct = ((1.0 - usage) * 100.0).round() as i32;
-            let tooltip = format!("{remaining_pct}% context remaining");
+
+            let expiry = prompt_cache_expiry(conversation);
+            let is_cache_expired = FeatureFlag::PromptCacheExpiryWarning.is_enabled()
+                && expiry.is_some_and(|expiry| expiry <= Local::now());
+            let tooltip = if is_cache_expired {
+                "prompt cache expired".to_string()
+            } else {
+                format!("{remaining_pct}% context remaining")
+            };
 
             self.context_window_button.update(ctx, |button, ctx| {
                 button.set_icon(Some(icon), ctx);
+                button.set_icon_ansi_color(
+                    is_cache_expired.then_some(AnsiColorIdentifier::Yellow),
+                    ctx,
+                );
                 button.set_tooltip(Some(tooltip), ctx);
             });
+
+            self.reschedule_prompt_cache_expiry_timer(expiry, ctx);
         }
+    }
+
+    /// Schedules a refresh of the context-window button at the prompt-cache
+    /// expiry instant so the yellow tint appears while the conversation is idle.
+    fn reschedule_prompt_cache_expiry_timer(
+        &mut self,
+        expiry: Option<DateTime<Local>>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if let Some(handle) = self.prompt_cache_expiry_timer_handle.take() {
+            handle.abort();
+        }
+        if !FeatureFlag::PromptCacheExpiryWarning.is_enabled() {
+            return;
+        }
+        // Only future expiries need a timer; past ones already render as expired.
+        let Some(delay) = expiry.and_then(|expiry| (expiry - Local::now()).to_std().ok()) else {
+            return;
+        };
+        let handle = ctx.spawn(
+            async move {
+                Timer::after(delay).await;
+            },
+            |me, _, ctx| {
+                me.prompt_cache_expiry_timer_handle = None;
+                me.update_context_window_button(ctx);
+                ctx.notify();
+            },
+        );
+        self.prompt_cache_expiry_timer_handle = Some(handle);
     }
 
     fn render_toolbar_item(

--- a/app/src/ai/blocklist/block/status_bar.rs
+++ b/app/src/ai/blocklist/block/status_bar.rs
@@ -987,6 +987,7 @@ fn latest_model_used_before_exchange<V: View>(
                 model_id: model_info.model_id.to_string(),
                 model_display_name: model_info.display_name.clone(),
                 is_fallback: model_info.is_fallback,
+                ..Default::default()
             })
         })
 }

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -499,6 +499,8 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::SuperGrok,
         #[cfg(feature = "gemini_enterprise")]
         FeatureFlag::GeminiEnterprise,
+        #[cfg(feature = "prompt_cache_expiry_warning")]
+        FeatureFlag::PromptCacheExpiryWarning,
     ]);
 
     flags

--- a/app/src/view_components/action_button.rs
+++ b/app/src/view_components/action_button.rs
@@ -426,17 +426,6 @@ impl ActionButton {
         ctx.notify();
     }
 
-    /// Set or clear the ANSI-palette icon color override. `None` restores the
-    /// default theme-derived icon color.
-    pub fn set_icon_ansi_color(
-        &mut self,
-        icon_ansi_color: Option<AnsiColorIdentifier>,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        self.icon_ansi_color = icon_ansi_color;
-        ctx.notify();
-    }
-
     pub fn set_label(&mut self, label: impl Into<Cow<'static, str>>, ctx: &mut ViewContext<Self>) {
         self.label = label.into();
         ctx.notify();

--- a/app/src/view_components/action_button.rs
+++ b/app/src/view_components/action_button.rs
@@ -426,6 +426,17 @@ impl ActionButton {
         ctx.notify();
     }
 
+    /// Set or clear the ANSI-palette icon color override. `None` restores the
+    /// default theme-derived icon color.
+    pub fn set_icon_ansi_color(
+        &mut self,
+        icon_ansi_color: Option<AnsiColorIdentifier>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.icon_ansi_color = icon_ansi_color;
+        ctx.notify();
+    }
+
     pub fn set_label(&mut self, label: impl Into<Cow<'static, str>>, ctx: &mut ViewContext<Self>) {
         self.label = label.into();
         ctx.notify();

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -880,6 +880,9 @@ pub enum FeatureFlag {
     /// Gates Gemini Enterprise (GEAP) BYOLLM, which lets users
     /// route eliglible models to GEAP instead of Warp-managed inference.
     GeminiEnterprise,
+    /// Shows a warning in the agent view when the active conversation's
+    /// provider-side prompt cache has expired.
+    PromptCacheExpiryWarning,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =
@@ -946,6 +949,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::GPTConfigurableContextWindow,
     FeatureFlag::RestorePromptOnInlineModelSelectorSearch,
     FeatureFlag::WarpControlCli,
+    FeatureFlag::PromptCacheExpiryWarning,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

This PR adds a dev-only indicator (for now over the context window indicator) when the cache expires for a given conversation (as reported by the server). This is dev-only for now so I kind of freestyled on the design, but if folks find this useful we can get an actual design for prod release.

Note: this PR depends on a proto change in [this PR](https://github.com/warpdotdev/warp-proto-apis/pull/324) and a server change in [this PR](https://github.com/warpdotdev/warp-server/pull/11876)

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

See [server PR](https://github.com/warpdotdev/warp-server/pull/11876) for a demo video. I didn't want to attach the video here as it has some server/maa debugger info that is maybe good to keep private.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode