### PR TITLE
Reorganize git repo models

### DIFF
--- a/app/src/ai/blocklist/context_model.rs
+++ b/app/src/ai/blocklist/context_model.rs
@@ -998,7 +998,7 @@ impl BlocklistAIContextModel {
     #[cfg(feature = "local_fs")]
     fn repository_context(&self, app: &AppContext) -> Option<AIAgentContext> {
         let handle = self.github_repo_model.as_ref()?.upgrade(app)?;
-        let repository_info = handle.as_ref(app).repository_info()?;
+        let repository_info = handle.as_ref(app).repository_info(app)?;
         Some(Self::repository_context_from_repository_info(
             repository_info,
         ))
@@ -1019,7 +1019,7 @@ impl BlocklistAIContextModel {
     #[cfg(feature = "local_fs")]
     fn pull_request_context(&self, app: &AppContext) -> Option<AIAgentContext> {
         let handle = self.github_repo_model.as_ref()?.upgrade(app)?;
-        let pr_info = handle.as_ref(app).pr_info()?;
+        let pr_info = handle.as_ref(app).pr_info(app)?;
         Self::pull_request_context_from_pr_info(pr_info)
     }
     #[cfg(not(feature = "local_fs"))]

--- a/app/src/ai/blocklist/context_model_tests.rs
+++ b/app/src/ai/blocklist/context_model_tests.rs
@@ -24,7 +24,7 @@ use crate::ai::blocklist::{
     BlocklistAIHistoryModel, QueuedQuery, QueuedQueryModel, QueuedQueryOrigin,
 };
 #[cfg(feature = "local_fs")]
-use crate::code_review::git_status_update::GitRepoStatusModel;
+use crate::code_review::git_repo_model::GitRepoStatusModel;
 #[cfg(feature = "local_fs")]
 use crate::code_review::github_repo_model::GitHubRepoModel;
 use crate::terminal::color::{self, Colors};
@@ -66,8 +66,10 @@ fn repository_context_reads_github_repo_model() {
                 )
                 .unwrap()
         });
-        let git_status = app.add_model(move |_| GitRepoStatusModel::new_for_test(repository, None));
-        let github_repo_model = app.add_model(move |_| GitHubRepoModel::new_for_test(git_status));
+        let git_status =
+            app.add_model(move |ctx| GitRepoStatusModel::new_local_for_test(repository, None, ctx));
+        let github_repo_model =
+            app.add_model(move |ctx| GitHubRepoModel::new_local_for_test(git_status, ctx));
 
         github_repo_model.update(&mut app, |model, ctx| {
             model.set_repository_info_for_test(
@@ -248,8 +250,10 @@ fn pull_request_context_reads_github_repo_model() {
                 )
                 .unwrap()
         });
-        let git_status = app.add_model(move |_| GitRepoStatusModel::new_for_test(repository, None));
-        let github_repo_model = app.add_model(move |_| GitHubRepoModel::new_for_test(git_status));
+        let git_status =
+            app.add_model(move |ctx| GitRepoStatusModel::new_local_for_test(repository, None, ctx));
+        let github_repo_model =
+            app.add_model(move |ctx| GitHubRepoModel::new_local_for_test(git_status, ctx));
 
         github_repo_model.update(&mut app, |model, ctx| {
             model.set_pr_info_for_test(

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -100,9 +100,7 @@ use crate::code_review::diff_state::{
 use crate::code_review::editor_state::CodeReviewEditorState;
 use crate::code_review::find_model::CodeReviewFindModel;
 #[cfg(feature = "local_fs")]
-use crate::code_review::git_status_update::{
-    GitRepoStatusEvent, GitRepoStatusModel, GitStatusUpdateModel,
-};
+use crate::code_review::git_repo_model::{GitRepoModels, GitRepoStatusEvent, GitRepoStatusModel};
 #[cfg(feature = "local_fs")]
 use crate::code_review::github_repo_model::{GitHubRepoEvent, GitHubRepoModel};
 use crate::code_review::hidden_lines::calculate_hidden_lines;
@@ -6336,7 +6334,7 @@ impl CodeReviewView {
         cfg_if::cfg_if! {
             if #[cfg(feature = "local_fs")] {
                 let github_repo_model = self.github_repo_model.as_ref()?;
-                github_repo_model.as_ref(ctx).pr_info().cloned()
+                github_repo_model.as_ref(ctx).pr_info(ctx).cloned()
             } else {
                 None
             }
@@ -6349,7 +6347,7 @@ impl CodeReviewView {
         {
             self.github_repo_model
                 .as_ref()
-                .map(|h| h.as_ref(ctx).is_refreshing_pr_info())
+                .map(|h| h.as_ref(ctx).is_refreshing_pr_info(ctx))
                 .unwrap_or(false)
         }
 
@@ -6383,8 +6381,8 @@ impl CodeReviewView {
         else {
             return;
         };
-        let result = GitStatusUpdateModel::handle(ctx)
-            .update(ctx, |model, ctx| model.subscribe(&repo_path, ctx));
+        let result =
+            GitRepoModels::handle(ctx).update(ctx, |model, ctx| model.subscribe(&repo_path, ctx));
         let handle = match result {
             Ok(handle) => handle,
             Err(err) => {
@@ -6411,7 +6409,7 @@ impl CodeReviewView {
             return;
         };
 
-        let result = GitStatusUpdateModel::handle(ctx).update(ctx, |model, ctx| {
+        let result = GitRepoModels::handle(ctx).update(ctx, |model, ctx| {
             model.subscribe_github_repo(&repo_path, ctx)
         });
         let handle = match result {

--- a/app/src/code_review/code_review_view_tests.rs
+++ b/app/src/code_review/code_review_view_tests.rs
@@ -30,7 +30,7 @@ use crate::code_review::comments::{
 use crate::code_review::diff_size_limits::DiffSize;
 use crate::code_review::diff_state::{DiffStateModel, FileDiff, GitFileStatus};
 use crate::code_review::editor_state::CodeReviewEditorState;
-use crate::code_review::git_status_update::GitStatusUpdateModel;
+use crate::code_review::git_repo_model::GitRepoModels;
 use crate::code_review::GlobalCodeReviewModel;
 use crate::pane_group::WorkingDirectoriesModel;
 use crate::server::server_api::team::MockTeamClient;
@@ -77,7 +77,7 @@ fn initialize_test_app(app: &mut App) {
     app.add_singleton_model(|_| VimRegisters::new());
     app.add_singleton_model(|_| KeybindingChangedNotifier::mock());
     app.add_singleton_model(|_| DetectedRepositories::default());
-    app.add_singleton_model(|_| GitStatusUpdateModel::new());
+    app.add_singleton_model(|_| GitRepoModels::new());
     app.add_singleton_model(|_| LspManagerModel::new());
     app.add_singleton_model(|_| LocalShellState::NotLoaded);
     app.add_singleton_model(PersistedWorkspace::new_for_test);

--- a/app/src/code_review/git_repo_model/local.rs
+++ b/app/src/code_review/git_repo_model/local.rs
@@ -1,156 +1,16 @@
-#[cfg(feature = "local_fs")]
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
-#[cfg(feature = "local_fs")]
-use warpui::ModelContext;
-use warpui::{Entity, SingletonEntity};
-#[cfg(feature = "local_fs")]
-use {
-    crate::throttle::throttle,
-    crate::util::git::{detect_current_branch_display, detect_main_branch},
-    async_channel::Sender,
-    repo_metadata::{
-        repositories::DetectedRepositories,
-        repository::{RepositorySubscriber, SubscriberId},
-        Repository, RepositoryUpdate,
-    },
-    std::{collections::HashMap, time::Duration},
-    warpui::{r#async::SpawnedFutureHandle, ModelHandle, WeakModelHandle},
-};
+use async_channel::Sender;
+use repo_metadata::repository::{RepositorySubscriber, SubscriberId};
+use repo_metadata::{Repository, RepositoryUpdate};
+use warpui::r#async::SpawnedFutureHandle;
+use warpui::{Entity, ModelContext, ModelHandle};
 
-#[cfg(feature = "local_fs")]
-use super::diff_state::{diff_metadata_against_head, DiffStats};
-#[cfg(feature = "local_fs")]
-use super::github_repo_model::GitHubRepoModel;
-
-/// Public metadata exposed to consumers — the subset of diff metadata
-/// that the git chip (prompt display, agent view footer) needs.
-#[cfg(feature = "local_fs")]
-#[derive(Debug, Clone)]
-pub struct GitStatusMetadata {
-    pub current_branch_name: String,
-    pub main_branch_name: String,
-    pub stats_against_head: DiffStats,
-}
-
-// ── GitStatusUpdateModel (singleton cache) ──────────────────────────────────
-
-/// Singleton model that acts as a cache / factory for per-repository
-/// [`GitRepoStatusModel`] and [`GitHubRepoModel`] instances.
-///
-/// Multiple terminals in the same repo share a single sub-model.  When the last
-/// strong handle to a sub-model is dropped, the models are torn down automatically.
-pub struct GitStatusUpdateModel {
-    #[cfg(feature = "local_fs")]
-    git_repo_status_models: HashMap<PathBuf, WeakModelHandle<GitRepoStatusModel>>,
-    #[cfg(feature = "local_fs")]
-    github_repo_models: HashMap<PathBuf, WeakModelHandle<GitHubRepoModel>>,
-}
-
-// ── Non-local_fs stub ───────────────────────────────────────────────────────
-
-#[cfg(not(feature = "local_fs"))]
-#[allow(dead_code)]
-impl GitStatusUpdateModel {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-// ── local_fs implementation ─────────────────────────────────────────────────
-
-#[cfg(feature = "local_fs")]
-impl GitStatusUpdateModel {
-    pub fn new() -> Self {
-        Self {
-            git_repo_status_models: HashMap::new(),
-            github_repo_models: HashMap::new(),
-        }
-    }
-
-    /// Get or create a per-repo status model for `repo_path`.
-    ///
-    /// If a live model already exists for this path, returns a new strong handle
-    /// to it.  Otherwise, creates a new [`GitRepoStatusModel`] with an active
-    /// filesystem watcher and returns a handle to it.
-    ///
-    /// Callers hold the returned `ModelHandle` for as long as they need updates.
-    /// When all handles are dropped, the model (and its watcher) is torn down.
-    pub fn subscribe(
-        &mut self,
-        repo_path: &Path,
-        ctx: &mut ModelContext<Self>,
-    ) -> anyhow::Result<ModelHandle<GitRepoStatusModel>> {
-        let repo_path_buf = repo_path.to_path_buf();
-
-        // Check the cache for an existing live model.
-        if let Some(weak) = self.git_repo_status_models.get(&repo_path_buf) {
-            if let Some(handle) = weak.upgrade(ctx) {
-                return Ok(handle);
-            }
-        }
-
-        // Create a new sub-model.
-        let Some(repository_model) =
-            DetectedRepositories::as_ref(ctx).get_local_watched_repo_for_path(repo_path, ctx)
-        else {
-            anyhow::bail!(
-                "No watched repository found for path: {}",
-                repo_path.display()
-            );
-        };
-
-        let handle = ctx
-            .add_model(|ctx| GitRepoStatusModel::new(repo_path_buf.clone(), repository_model, ctx));
-
-        self.git_repo_status_models
-            .insert(repo_path_buf, handle.downgrade());
-        Ok(handle)
-    }
-
-    /// Get or create a per-repo GitHub-info model for `repo_path`.
-    ///
-    /// If a live model already exists for this path, returns a new strong handle
-    /// to it.  Otherwise, creates a new [`GitHubRepoModel`].
-    ///
-    /// The model subscribes to the git status model for the repository and
-    /// tracks the current branch. GitHub PR info and repository info are fetched
-    /// on creation, on branch change, and on a periodic timer.
-    ///
-    /// Callers hold the returned `ModelHandle` for as long as they need updates.
-    /// When all handles are dropped, the model and its in-flight fetches are torn down.
-    pub fn subscribe_github_repo(
-        &mut self,
-        repo_path: &Path,
-        ctx: &mut ModelContext<Self>,
-    ) -> anyhow::Result<ModelHandle<GitHubRepoModel>> {
-        let repo_path_buf = repo_path.to_path_buf();
-
-        // Check the cache for an existing live model.
-        if let Some(weak) = self.github_repo_models.get(&repo_path_buf) {
-            if let Some(handle) = weak.upgrade(ctx) {
-                return Ok(handle);
-            }
-        }
-
-        // GitHubRepoModel needs a sibling GitRepoStatusModel for branch info.
-        let git_status = self.subscribe(repo_path, ctx)?;
-        let handle =
-            ctx.add_model(|ctx| GitHubRepoModel::new(repo_path_buf.clone(), git_status, ctx));
-
-        self.github_repo_models
-            .insert(repo_path_buf, handle.downgrade());
-        Ok(handle)
-    }
-}
-
-impl Entity for GitStatusUpdateModel {
-    type Event = ();
-}
-
-impl SingletonEntity for GitStatusUpdateModel {}
-
-// ── GitRepoStatusModel ──────────────────────────────────────────────────────
+use super::{GitRepoStatusEvent, GitStatusMetadata};
+use crate::code_review::diff_state::diff_metadata_against_head;
+use crate::throttle::throttle;
+use crate::util::git::{detect_current_branch_display, detect_main_branch};
 
 /// Per-repository model that owns the filesystem watcher and exposes git status
 /// metadata. Consumers hold a `ModelHandle<GitRepoStatusModel>` and subscribe
@@ -158,8 +18,7 @@ impl SingletonEntity for GitStatusUpdateModel {}
 ///
 /// When all strong handles are dropped the model (and its watcher) is
 /// automatically torn down.
-#[cfg(feature = "local_fs")]
-pub struct GitRepoStatusModel {
+pub struct LocalGitRepoStatusModel {
     repo_path: PathBuf,
     repository: ModelHandle<Repository>,
     subscriber_id: Option<SubscriberId>,
@@ -167,32 +26,14 @@ pub struct GitRepoStatusModel {
     computing_metadata_abort_handle: Option<SpawnedFutureHandle>,
 }
 
-#[cfg(not(feature = "local_fs"))]
-#[allow(dead_code)]
-pub struct GitRepoStatusModel;
-
-#[cfg(not(feature = "local_fs"))]
-impl Entity for GitRepoStatusModel {
-    type Event = ();
-}
-
-#[cfg(feature = "local_fs")]
-#[derive(Debug)]
-pub enum GitRepoStatusEvent {
-    /// Emitted whenever the metadata changes (branch name, diff stats, etc.).
-    MetadataChanged,
-}
-
-#[cfg(feature = "local_fs")]
-impl Entity for GitRepoStatusModel {
+impl Entity for LocalGitRepoStatusModel {
     type Event = GitRepoStatusEvent;
 }
 
-#[cfg(feature = "local_fs")]
-impl GitRepoStatusModel {
+impl LocalGitRepoStatusModel {
     /// Create a new per-repo status model, set up the filesystem watcher, and
     /// kick off the initial metadata computation.
-    fn new(
+    pub(super) fn new(
         repo_path: PathBuf,
         repository_model: ModelHandle<Repository>,
         ctx: &mut ModelContext<Self>,
@@ -348,8 +189,8 @@ impl GitRepoStatusModel {
     }
 }
 
-#[cfg(all(test, feature = "local_fs"))]
-impl GitRepoStatusModel {
+#[cfg(test)]
+impl LocalGitRepoStatusModel {
     pub(crate) fn new_for_test(
         repository: ModelHandle<Repository>,
         metadata: Option<GitStatusMetadata>,
@@ -373,12 +214,11 @@ impl GitRepoStatusModel {
     }
 }
 
-#[cfg(all(test, feature = "local_fs"))]
-#[path = "git_status_update_tests.rs"]
+#[cfg(test)]
+#[path = "local_tests.rs"]
 mod tests;
 
-#[cfg(feature = "local_fs")]
-impl Drop for GitRepoStatusModel {
+impl Drop for LocalGitRepoStatusModel {
     fn drop(&mut self) {
         // Note: we cannot call `repository.update()` here because `Drop` does
         // not have access to `ModelContext`.  The `Repository` model will clean
@@ -391,12 +231,10 @@ impl Drop for GitRepoStatusModel {
 
 // ── Repository subscriber adapter ───────────────────────────────────────────
 
-#[cfg(feature = "local_fs")]
 struct GitStatusRepositorySubscriber {
     repository_update_tx: Sender<RepositoryUpdate>,
 }
 
-#[cfg(feature = "local_fs")]
 impl RepositorySubscriber for GitStatusRepositorySubscriber {
     fn on_scan(
         &mut self,

--- a/app/src/code_review/git_repo_model/local_tests.rs
+++ b/app/src/code_review/git_repo_model/local_tests.rs
@@ -4,14 +4,13 @@ use repo_metadata::{RepositoryUpdate, TargetFile};
 
 use super::*;
 
-#[cfg(feature = "local_fs")]
 #[test]
 fn should_refresh_metadata_ignores_ignored_file_updates() {
     let mut ignored_update = RepositoryUpdate::default();
     ignored_update
         .modified
         .insert(TargetFile::new(PathBuf::from("/repo/ignored.log"), true));
-    assert!(!GitRepoStatusModel::should_refresh_metadata(
+    assert!(!LocalGitRepoStatusModel::should_refresh_metadata(
         &ignored_update
     ));
 
@@ -19,13 +18,15 @@ fn should_refresh_metadata_ignores_ignored_file_updates() {
     tracked_update
         .modified
         .insert(TargetFile::new(PathBuf::from("/repo/src/main.rs"), false));
-    assert!(GitRepoStatusModel::should_refresh_metadata(&tracked_update));
+    assert!(LocalGitRepoStatusModel::should_refresh_metadata(
+        &tracked_update
+    ));
 
     let remote_ref_update = RepositoryUpdate {
         remote_ref_updated: true,
         ..Default::default()
     };
-    assert!(GitRepoStatusModel::should_refresh_metadata(
+    assert!(LocalGitRepoStatusModel::should_refresh_metadata(
         &remote_ref_update
     ));
 }

--- a/app/src/code_review/git_repo_model/mod.rs
+++ b/app/src/code_review/git_repo_model/mod.rs
@@ -1,4 +1,6 @@
-use warpui::{AppContext, Entity, ModelContext, ModelHandle};
+#[cfg(feature = "local_fs")]
+use warpui::ModelHandle;
+use warpui::{AppContext, Entity, ModelContext};
 
 #[cfg(feature = "local_fs")]
 mod local;
@@ -11,6 +13,7 @@ pub use super::git_repo_models::GitRepoModels;
 
 /// Public metadata exposed to consumers — the subset of diff metadata
 /// that the git chip (prompt display, agent view footer) needs.
+#[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
 #[derive(Debug, Clone)]
 pub struct GitStatusMetadata {
     pub current_branch_name: String,
@@ -18,6 +21,7 @@ pub struct GitStatusMetadata {
     pub stats_against_head: DiffStats,
 }
 
+#[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
 #[derive(Debug)]
 pub enum GitRepoStatusEvent {
     /// Emitted whenever the metadata changes (branch name, diff stats, etc.).
@@ -26,6 +30,7 @@ pub enum GitRepoStatusEvent {
 
 /// Unified per-repo git status model. PR 1 only contains the local backend;
 /// remote support is added in the stacked PR.
+#[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
 pub enum GitRepoStatusModel {
     #[cfg(feature = "local_fs")]
     Local(ModelHandle<LocalGitRepoStatusModel>),
@@ -35,9 +40,11 @@ impl Entity for GitRepoStatusModel {
     type Event = GitRepoStatusEvent;
 }
 
+#[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
 impl GitRepoStatusModel {
     /// Re-emit a sub-model event so subscribers of the unified model observe
     /// the same `GitRepoStatusEvent`s regardless of backend.
+    #[cfg(feature = "local_fs")]
     fn forward_event(&mut self, event: &GitRepoStatusEvent, ctx: &mut ModelContext<Self>) {
         match event {
             GitRepoStatusEvent::MetadataChanged => ctx.emit(GitRepoStatusEvent::MetadataChanged),
@@ -49,6 +56,13 @@ impl GitRepoStatusModel {
         match self {
             #[cfg(feature = "local_fs")]
             Self::Local(m) => m.as_ref(ctx).metadata(),
+            // Without `local_fs` the enum has no variants, so a value can
+            // never be constructed and this arm is unreachable.
+            #[cfg(not(feature = "local_fs"))]
+            _ => {
+                let _ = ctx;
+                unreachable!("GitRepoStatusModel cannot be constructed without local_fs")
+            }
         }
     }
 
@@ -57,6 +71,13 @@ impl GitRepoStatusModel {
         match self {
             #[cfg(feature = "local_fs")]
             Self::Local(m) => m.update(ctx, |m, ctx| m.refresh_metadata(ctx)),
+            // Without `local_fs` the enum has no variants, so a value can
+            // never be constructed and this arm is unreachable.
+            #[cfg(not(feature = "local_fs"))]
+            _ => {
+                let _ = ctx;
+                unreachable!("GitRepoStatusModel cannot be constructed without local_fs")
+            }
         }
     }
 }

--- a/app/src/code_review/git_repo_model/mod.rs
+++ b/app/src/code_review/git_repo_model/mod.rs
@@ -1,0 +1,100 @@
+use warpui::{AppContext, Entity, ModelContext, ModelHandle};
+
+#[cfg(feature = "local_fs")]
+mod local;
+#[cfg(feature = "local_fs")]
+pub use local::LocalGitRepoStatusModel;
+
+use super::diff_state::DiffStats;
+#[cfg(feature = "local_fs")]
+pub use super::git_repo_models::GitRepoModels;
+
+/// Public metadata exposed to consumers — the subset of diff metadata
+/// that the git chip (prompt display, agent view footer) needs.
+#[derive(Debug, Clone)]
+pub struct GitStatusMetadata {
+    pub current_branch_name: String,
+    pub main_branch_name: String,
+    pub stats_against_head: DiffStats,
+}
+
+#[derive(Debug)]
+pub enum GitRepoStatusEvent {
+    /// Emitted whenever the metadata changes (branch name, diff stats, etc.).
+    MetadataChanged,
+}
+
+/// Unified per-repo git status model. PR 1 only contains the local backend;
+/// remote support is added in the stacked PR.
+pub enum GitRepoStatusModel {
+    #[cfg(feature = "local_fs")]
+    Local(ModelHandle<LocalGitRepoStatusModel>),
+}
+
+impl Entity for GitRepoStatusModel {
+    type Event = GitRepoStatusEvent;
+}
+
+impl GitRepoStatusModel {
+    /// Re-emit a sub-model event so subscribers of the unified model observe
+    /// the same `GitRepoStatusEvent`s regardless of backend.
+    fn forward_event(&mut self, event: &GitRepoStatusEvent, ctx: &mut ModelContext<Self>) {
+        match event {
+            GitRepoStatusEvent::MetadataChanged => ctx.emit(GitRepoStatusEvent::MetadataChanged),
+        }
+    }
+
+    /// Mode-independent status metadata (branch names + HEAD diff stats).
+    pub fn metadata<'a>(&self, ctx: &'a AppContext) -> Option<&'a GitStatusMetadata> {
+        match self {
+            #[cfg(feature = "local_fs")]
+            Self::Local(m) => m.as_ref(ctx).metadata(),
+        }
+    }
+
+    /// Force a metadata refresh (branch names, diff stats).
+    pub fn refresh_metadata(&self, ctx: &mut ModelContext<Self>) {
+        match self {
+            #[cfg(feature = "local_fs")]
+            Self::Local(m) => m.update(ctx, |m, ctx| m.refresh_metadata(ctx)),
+        }
+    }
+}
+
+#[cfg(feature = "local_fs")]
+pub(super) fn new_local_git_repo_status_model(
+    repo_path: std::path::PathBuf,
+    repository_model: ModelHandle<repo_metadata::Repository>,
+    ctx: &mut ModelContext<GitRepoModels>,
+) -> ModelHandle<GitRepoStatusModel> {
+    let inner = ctx.add_model(|ctx| LocalGitRepoStatusModel::new(repo_path, repository_model, ctx));
+    ctx.add_model(|ctx| {
+        ctx.subscribe_to_model(&inner, GitRepoStatusModel::forward_event);
+        GitRepoStatusModel::Local(inner)
+    })
+}
+
+#[cfg(all(test, feature = "local_fs"))]
+impl GitRepoStatusModel {
+    /// Wraps a local-backend test model in the unified enum.
+    pub(crate) fn new_local_for_test(
+        repository: ModelHandle<repo_metadata::Repository>,
+        metadata: Option<GitStatusMetadata>,
+        ctx: &mut ModelContext<Self>,
+    ) -> Self {
+        let inner =
+            ctx.add_model(move |_| LocalGitRepoStatusModel::new_for_test(repository, metadata));
+        ctx.subscribe_to_model(&inner, Self::forward_event);
+        Self::Local(inner)
+    }
+
+    pub(crate) fn set_metadata_for_test(
+        &mut self,
+        metadata: Option<GitStatusMetadata>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        match self {
+            Self::Local(m) => m.update(ctx, |m, ctx| m.set_metadata_for_test(metadata, ctx)),
+        }
+    }
+}

--- a/app/src/code_review/git_repo_models.rs
+++ b/app/src/code_review/git_repo_models.rs
@@ -1,0 +1,92 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use repo_metadata::repositories::DetectedRepositories;
+use warpui::{Entity, ModelContext, ModelHandle, SingletonEntity, WeakModelHandle};
+
+use super::git_repo_model::{new_local_git_repo_status_model, GitRepoStatusModel};
+use super::github_repo_model::{GitHubRepoModel, LocalGitHubRepoModel};
+
+/// Singleton model that acts as a cache / factory for per-repository
+/// [`GitRepoStatusModel`] and [`GitHubRepoModel`] instances.
+///
+/// Multiple terminals in the same repo share a single sub-model. When the last
+/// strong handle to a sub-model is dropped, the models are torn down automatically.
+pub struct GitRepoModels {
+    git_status_models: HashMap<PathBuf, WeakModelHandle<GitRepoStatusModel>>,
+    github_repo_models: HashMap<PathBuf, WeakModelHandle<GitHubRepoModel>>,
+}
+
+impl GitRepoModels {
+    pub fn new() -> Self {
+        Self {
+            git_status_models: HashMap::new(),
+            github_repo_models: HashMap::new(),
+        }
+    }
+
+    /// Get or create the per-repo status model for a local repo.
+    pub fn subscribe(
+        &mut self,
+        repo_path: &Path,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<ModelHandle<GitRepoStatusModel>> {
+        if let Some(handle) = self
+            .git_status_models
+            .get(repo_path)
+            .and_then(|weak| weak.upgrade(ctx))
+        {
+            return Ok(handle);
+        }
+
+        let Some(repository_model) =
+            DetectedRepositories::as_ref(ctx).get_local_watched_repo_for_path(repo_path, ctx)
+        else {
+            anyhow::bail!(
+                "No watched repository found for path: {}",
+                repo_path.display()
+            );
+        };
+        let handle =
+            new_local_git_repo_status_model(repo_path.to_path_buf(), repository_model, ctx);
+
+        self.git_status_models
+            .insert(repo_path.to_path_buf(), handle.downgrade());
+        Ok(handle)
+    }
+
+    /// Get or create the per-repo GitHub-info model for a local repo.
+    pub fn subscribe_github_repo(
+        &mut self,
+        repo_path: &Path,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<ModelHandle<GitHubRepoModel>> {
+        if let Some(handle) = self
+            .github_repo_models
+            .get(repo_path)
+            .and_then(|weak| weak.upgrade(ctx))
+        {
+            return Ok(handle);
+        }
+
+        let git_status = self.subscribe(repo_path, ctx)?;
+        let repo_path = repo_path.to_path_buf();
+        let repo_path_for_model = repo_path.clone();
+        let inner =
+            ctx.add_model(|ctx| LocalGitHubRepoModel::new(repo_path_for_model, git_status, ctx));
+        let handle = ctx.add_model(|ctx| {
+            ctx.subscribe_to_model(&inner, GitHubRepoModel::forward_event);
+            GitHubRepoModel::Local(inner)
+        });
+
+        self.github_repo_models
+            .insert(repo_path, handle.downgrade());
+        Ok(handle)
+    }
+}
+
+impl Entity for GitRepoModels {
+    type Event = ();
+}
+
+impl SingletonEntity for GitRepoModels {}

--- a/app/src/code_review/github_repo_model/local.rs
+++ b/app/src/code_review/github_repo_model/local.rs
@@ -5,7 +5,8 @@ use settings::Setting as _;
 use warpui::r#async::SpawnedFutureHandle;
 use warpui::{Entity, ModelContext, ModelHandle, SingletonEntity as _};
 
-use super::git_status_update::{GitRepoStatusEvent, GitRepoStatusModel};
+use super::GitHubRepoEvent;
+use crate::code_review::git_repo_model::{GitRepoStatusEvent, GitRepoStatusModel};
 use crate::report_if_error;
 #[cfg(feature = "local_tty")]
 use crate::terminal::local_shell::LocalShellState;
@@ -18,6 +19,7 @@ use crate::util::git::{
 const PR_INFO_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 const GITHUB_INFO_PERIODIC_REFRESH: Duration = Duration::from_secs(60);
 const REPOSITORY_INFO_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Per-repository model that owns the GitHub-sourced metadata lifecycle for a
 /// single repo — the values fetched through the (relatively expensive) `gh`
 /// CLI rather than local `git`:
@@ -25,7 +27,7 @@ const REPOSITORY_INFO_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 ///   - `repository_info` (name/owner) for the repo (`gh repo view`).
 ///
 /// `GitHubRepoModel` is created lazily when a consumer asks for it via
-/// [`super::git_status_update::GitStatusUpdateModel::subscribe_github_repo`].
+/// [`crate::code_review::git_repo_model::GitRepoModels::subscribe_github_repo`].
 /// While at least one strong `ModelHandle<GitHubRepoModel>` is alive, the model:
 ///   - tracks the current branch by subscribing to its sibling
 ///     [`GitRepoStatusModel`] for `MetadataChanged` events,
@@ -41,9 +43,9 @@ const REPOSITORY_INFO_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 ///
 /// When the last strong handle is dropped, the model is torn down and any
 /// in-flight `gh` fetch is aborted. The sibling [`GitRepoStatusModel`] is
-/// retained via a strong handle, so creating a `GitHubRepoModel` keeps git
+/// retained via a strong handle, so creating a `LocalGitHubRepoModel` keeps git
 /// status alive for as long as GitHub info is needed.
-pub struct GitHubRepoModel {
+pub struct LocalGitHubRepoModel {
     repo_path: PathBuf,
     /// Strong handle to the sibling git-status model. Keeps it alive so we
     /// always have a branch source.
@@ -69,20 +71,11 @@ pub struct GitHubRepoModel {
     periodic_refresh_handle: Option<SpawnedFutureHandle>,
 }
 
-#[derive(Debug)]
-pub enum GitHubRepoEvent {
-    /// Emitted when `pr_info` changes value (fetch result differs from
-    /// cached, branch change cleared the cache, etc.).
-    PrInfoChanged,
-    /// Emitted when `repository_info` changes value.
-    RepositoryInfoChanged,
-}
-
-impl Entity for GitHubRepoModel {
+impl Entity for LocalGitHubRepoModel {
     type Event = GitHubRepoEvent;
 }
 
-impl GitHubRepoModel {
+impl LocalGitHubRepoModel {
     /// Create a new per-repo GitHub-info model.
     ///
     /// Subscribes to `git_status` for `MetadataChanged` events to track the
@@ -98,7 +91,7 @@ impl GitHubRepoModel {
     ) -> Self {
         let branch = git_status
             .as_ref(ctx)
-            .metadata()
+            .metadata(ctx)
             .map(|m| m.current_branch_name.clone());
 
         // Track branch changes from the sibling. Only PR info depends on the
@@ -108,7 +101,7 @@ impl GitHubRepoModel {
                 let new_branch = me
                     .git_status
                     .as_ref(ctx)
-                    .metadata()
+                    .metadata(ctx)
                     .map(|m| m.current_branch_name.clone());
                 if new_branch != me.branch {
                     me.branch = new_branch;
@@ -179,8 +172,8 @@ impl GitHubRepoModel {
     }
 
     /// Manually trigger a PR-info refresh. Called after `gh`/`gt` commands
-    /// complete, since those don't touch `.git/` and so won't be picked up by
-    /// the filesystem watcher.
+    /// complete, since those don't touch `.git/` so the filesystem watcher won't
+    /// catch them.
     pub fn refresh_pr_info(&mut self, ctx: &mut ModelContext<Self>) {
         let Some(branch) = self.branch.clone() else {
             return;
@@ -227,7 +220,7 @@ impl GitHubRepoModel {
     /// on creation and re-checked by the periodic timer on each tick. Never
     /// called from the branch-change path, so switching branches does not
     /// trigger a `gh repo view`.
-    fn refresh_repository_info(&mut self, ctx: &mut ModelContext<Self>) {
+    pub fn refresh_repository_info(&mut self, ctx: &mut ModelContext<Self>) {
         // Guard against overlapping fetches.
         if self.repository_info_abort_handle.is_some() {
             return;
@@ -341,11 +334,10 @@ impl GitHubRepoModel {
 }
 
 #[cfg(test)]
-impl GitHubRepoModel {
+impl LocalGitHubRepoModel {
     /// Inert constructor: no branch-tracking subscription, timers, or `gh`
     /// fetch, so tests stay deterministic and never spawn a real subprocess.
-    /// Mirrors `GitRepoStatusModel::new_for_test`. Drive state via the
-    /// `set_*_for_test` helpers.
+    /// Drive state via the `set_*_for_test` helpers.
     pub(crate) fn new_for_test(git_status: ModelHandle<GitRepoStatusModel>) -> Self {
         Self {
             repo_path: PathBuf::from("/test"),
@@ -379,10 +371,10 @@ impl GitHubRepoModel {
 }
 
 #[cfg(test)]
-#[path = "github_repo_model_tests.rs"]
+#[path = "local_tests.rs"]
 mod tests;
 
-impl Drop for GitHubRepoModel {
+impl Drop for LocalGitHubRepoModel {
     fn drop(&mut self) {
         if let Some(h) = self.refreshing_pr_info_abort_handle.take() {
             h.abort();

--- a/app/src/code_review/github_repo_model/local_tests.rs
+++ b/app/src/code_review/github_repo_model/local_tests.rs
@@ -3,7 +3,7 @@ use warp_util::standardized_path::StandardizedPath;
 use warpui::{App, ModelHandle};
 
 use super::*;
-use crate::code_review::git_status_update::GitRepoStatusModel;
+use crate::code_review::git_repo_model::GitRepoStatusModel;
 use crate::util::git::RepositoryInfo;
 
 fn pr(number: u64) -> PrInfo {
@@ -42,11 +42,12 @@ fn test_repository_handle(
 /// model. The model never subscribes or fetches; tests drive state directly.
 fn new_github_repo_model_for_test(
     app: &mut App,
-) -> (tempfile::TempDir, ModelHandle<GitHubRepoModel>) {
+) -> (tempfile::TempDir, ModelHandle<LocalGitHubRepoModel>) {
     let temp_dir = tempfile::TempDir::new().unwrap();
     let repository = test_repository_handle(app, &temp_dir);
-    let git_status = app.add_model(move |_| GitRepoStatusModel::new_for_test(repository, None));
-    let model = app.add_model(move |_| GitHubRepoModel::new_for_test(git_status));
+    let git_status =
+        app.add_model(move |ctx| GitRepoStatusModel::new_local_for_test(repository, None, ctx));
+    let model = app.add_model(move |_| LocalGitHubRepoModel::new_for_test(git_status));
     (temp_dir, model)
 }
 

--- a/app/src/code_review/github_repo_model/mod.rs
+++ b/app/src/code_review/github_repo_model/mod.rs
@@ -1,0 +1,119 @@
+use warpui::{AppContext, Entity, ModelContext, ModelHandle};
+
+#[cfg(feature = "local_fs")]
+mod local;
+#[cfg(feature = "local_fs")]
+pub use local::LocalGitHubRepoModel;
+
+#[cfg(all(test, feature = "local_fs"))]
+use crate::code_review::git_repo_model::GitRepoStatusModel;
+use crate::util::git::{PrInfo, RepositoryInfo};
+
+#[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
+#[derive(Debug)]
+pub enum GitHubRepoEvent {
+    /// Emitted when `pr_info` changes value (fetch result differs from
+    /// cached, branch change cleared the cache, etc.).
+    PrInfoChanged,
+    /// Emitted when `repository_info` changes value.
+    RepositoryInfoChanged,
+}
+
+/// Unified per-repo GitHub-info model. PR 1 only contains the local backend;
+/// remote support is added in the stacked PR.
+pub enum GitHubRepoModel {
+    #[cfg(feature = "local_fs")]
+    Local(ModelHandle<LocalGitHubRepoModel>),
+}
+
+impl Entity for GitHubRepoModel {
+    type Event = GitHubRepoEvent;
+}
+
+impl GitHubRepoModel {
+    /// Re-emit a sub-model event so subscribers of the unified model observe
+    /// the same `GitHubRepoEvent`s regardless of backend.
+    pub(crate) fn forward_event(&mut self, event: &GitHubRepoEvent, ctx: &mut ModelContext<Self>) {
+        match event {
+            GitHubRepoEvent::PrInfoChanged => ctx.emit(GitHubRepoEvent::PrInfoChanged),
+            GitHubRepoEvent::RepositoryInfoChanged => {
+                ctx.emit(GitHubRepoEvent::RepositoryInfoChanged)
+            }
+        }
+    }
+
+    /// PR info for the current branch.
+    pub fn pr_info<'a>(&self, ctx: &'a AppContext) -> Option<&'a PrInfo> {
+        match self {
+            #[cfg(feature = "local_fs")]
+            Self::Local(m) => m.as_ref(ctx).pr_info(),
+        }
+    }
+
+    /// Repository info (name/owner) returned by `gh repo view`.
+    pub fn repository_info<'a>(&self, ctx: &'a AppContext) -> Option<&'a RepositoryInfo> {
+        match self {
+            #[cfg(feature = "local_fs")]
+            Self::Local(m) => m.as_ref(ctx).repository_info(),
+        }
+    }
+
+    /// Whether a `gh pr view` fetch is currently in flight.
+    pub fn is_refreshing_pr_info(&self, ctx: &AppContext) -> bool {
+        match self {
+            #[cfg(feature = "local_fs")]
+            Self::Local(m) => m.as_ref(ctx).is_refreshing_pr_info(),
+        }
+    }
+
+    /// Force a PR info refresh (e.g. after a `gh`/`gt` command completes).
+    pub fn refresh_pr_info(&self, ctx: &mut ModelContext<Self>) {
+        match self {
+            #[cfg(feature = "local_fs")]
+            Self::Local(m) => m.update(ctx, |m, ctx| m.refresh_pr_info(ctx)),
+        }
+    }
+
+    /// Force a repository-info refresh.
+    pub fn refresh_repository_info(&self, ctx: &mut ModelContext<Self>) {
+        match self {
+            #[cfg(feature = "local_fs")]
+            Self::Local(m) => m.update(ctx, |m, ctx| m.refresh_repository_info(ctx)),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "local_fs"))]
+impl GitHubRepoModel {
+    /// Wraps an inert local-backend test model in the unified enum.
+    pub(crate) fn new_local_for_test(
+        git_status: ModelHandle<GitRepoStatusModel>,
+        ctx: &mut ModelContext<Self>,
+    ) -> Self {
+        let inner = ctx.add_model(move |_| LocalGitHubRepoModel::new_for_test(git_status));
+        ctx.subscribe_to_model(&inner, Self::forward_event);
+        Self::Local(inner)
+    }
+
+    pub(crate) fn set_pr_info_for_test(
+        &mut self,
+        pr_info: Option<PrInfo>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        match self {
+            Self::Local(m) => m.update(ctx, |m, ctx| m.set_pr_info_for_test(pr_info, ctx)),
+        }
+    }
+
+    pub(crate) fn set_repository_info_for_test(
+        &mut self,
+        repository_info: Option<RepositoryInfo>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        match self {
+            Self::Local(m) => m.update(ctx, |m, ctx| {
+                m.set_repository_info_for_test(repository_info, ctx)
+            }),
+        }
+    }
+}

--- a/app/src/code_review/mod.rs
+++ b/app/src/code_review/mod.rs
@@ -8,7 +8,9 @@ pub mod editor_state;
 pub(crate) mod find_model;
 pub(crate) mod git_actions;
 pub(crate) mod git_dialog;
-pub mod git_status_update;
+pub mod git_repo_model;
+#[cfg(feature = "local_fs")]
+mod git_repo_models;
 #[cfg(feature = "local_fs")]
 pub mod github_repo_model;
 mod hidden_lines;

--- a/app/src/context_chips/current_prompt.rs
+++ b/app/src/context_chips/current_prompt.rs
@@ -24,7 +24,7 @@ use super::logging::{ChipCommandLogEntry, PromptChipExecutionPhase, PromptChipLo
 use super::prompt::Prompt;
 use super::{chips_to_string, ChipResult, ChipValue, ContextChipKind};
 #[cfg(feature = "local_fs")]
-use crate::code_review::git_status_update::{GitRepoStatusEvent, GitRepoStatusModel};
+use crate::code_review::git_repo_model::{GitRepoStatusEvent, GitRepoStatusModel};
 #[cfg(feature = "local_fs")]
 use crate::code_review::github_repo_model::{GitHubRepoEvent, GitHubRepoModel};
 #[cfg(feature = "local_fs")]
@@ -1421,7 +1421,7 @@ impl CurrentPrompt {
                 // have completed before we subscribed). If it hasn't finished
                 // yet, the subscription above will catch the `MetadataChanged`
                 // event when it does.
-                if strong.as_ref(ctx).metadata().is_some() {
+                if strong.as_ref(ctx).metadata(ctx).is_some() {
                     self.apply_git_repo_metadata(ctx);
                 }
             }
@@ -1479,7 +1479,7 @@ impl CurrentPrompt {
             .git_repo_status
             .as_ref()
             .and_then(|w| w.upgrade(ctx))
-            .and_then(|h| h.as_ref(ctx).metadata().cloned());
+            .and_then(|h| h.as_ref(ctx).metadata(ctx).cloned());
 
         let Some(metadata) = metadata else {
             return;
@@ -1523,7 +1523,7 @@ impl CurrentPrompt {
             .and_then(|w| w.upgrade(ctx))
             .and_then(|h| {
                 h.as_ref(ctx)
-                    .pr_info()
+                    .pr_info(ctx)
                     .map(|info| ChipValue::Text(info.url.clone()))
             });
         let current_pr = self

--- a/app/src/context_chips/current_prompt_tests.rs
+++ b/app/src/context_chips/current_prompt_tests.rs
@@ -19,7 +19,7 @@ use crate::auth::AuthStateProvider;
 #[cfg(feature = "local_fs")]
 use crate::code_review::diff_state::DiffStats;
 #[cfg(feature = "local_fs")]
-use crate::code_review::git_status_update::{GitRepoStatusModel, GitStatusMetadata};
+use crate::code_review::git_repo_model::{GitRepoStatusModel, GitStatusMetadata};
 #[cfg(feature = "local_fs")]
 use crate::code_review::github_repo_model::GitHubRepoModel;
 use crate::context_chips::context_chip::{Environment, PromptGenerator};
@@ -521,8 +521,8 @@ fn test_externally_driven_chip_skips_periodic_timer() {
                 )
                 .unwrap()
         });
-        let git_status =
-            app.add_model(move |_| GitRepoStatusModel::new_for_test(repo_handle, None));
+        let git_status = app
+            .add_model(move |ctx| GitRepoStatusModel::new_local_for_test(repo_handle, None, ctx));
 
         let sessions = app.add_model(|_| Sessions::new_for_test());
         let current_prompt = app.add_model(move |ctx| CurrentPrompt::new(sessions, ctx));
@@ -588,8 +588,8 @@ fn test_git_status_change_updates_chip_value() {
             main_branch_name: "main".to_string(),
             stats_against_head: DiffStats::default(),
         };
-        let git_status = app.add_model(move |_| {
-            GitRepoStatusModel::new_for_test(repo_handle, Some(initial_metadata))
+        let git_status = app.add_model(move |ctx| {
+            GitRepoStatusModel::new_local_for_test(repo_handle, Some(initial_metadata), ctx)
         });
 
         let sessions = app.add_model(|_| Sessions::new_for_test());
@@ -666,19 +666,20 @@ fn test_git_status_pr_info_updates_github_pr_chip_value() {
                 .unwrap()
         });
 
-        let git_status = app.add_model(move |_| {
-            GitRepoStatusModel::new_for_test(
+        let git_status = app.add_model(move |ctx| {
+            GitRepoStatusModel::new_local_for_test(
                 repo_handle,
                 Some(GitStatusMetadata {
                     current_branch_name: "feature-a".to_string(),
                     main_branch_name: "main".to_string(),
                     stats_against_head: DiffStats::default(),
                 }),
+                ctx,
             )
         });
         let github_repo_model = {
             let git_status = git_status.clone();
-            app.add_model(move |_| GitHubRepoModel::new_for_test(git_status))
+            app.add_model(move |ctx| GitHubRepoModel::new_local_for_test(git_status, ctx))
         };
 
         let sessions = app.add_model(|_| Sessions::new_for_test());

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1616,6 +1616,7 @@ pub(crate) fn initialize_app(
         });
     }
 
+    #[cfg(feature = "local_fs")]
     {
         use code_review::git_repo_model::GitRepoModels;
         ctx.add_singleton_model(|_| GitRepoModels::new());

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1617,8 +1617,8 @@ pub(crate) fn initialize_app(
     }
 
     {
-        use code_review::git_status_update::GitStatusUpdateModel;
-        ctx.add_singleton_model(|_| GitStatusUpdateModel::new());
+        use code_review::git_repo_model::GitRepoModels;
+        ctx.add_singleton_model(|_| GitRepoModels::new());
     }
 
     ctx.add_singleton_model(|ctx| {

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -189,7 +189,7 @@ fn initialize_app(app: &mut App) {
     app.add_singleton_model(RepoMetadataModel::new);
     app.add_singleton_model(SkillManager::new);
     app.add_singleton_model(FileSearchModel::new);
-    app.add_singleton_model(|_| crate::code_review::git_status_update::GitStatusUpdateModel::new());
+    app.add_singleton_model(|_| crate::code_review::git_repo_model::GitRepoModels::new());
     app.add_singleton_model(RepoOutlines::new_for_test);
     crate::terminal::available_shells::register(app);
     app.update(experiments::init);

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -261,7 +261,7 @@ pub fn initialize_app(app: &mut App) {
     app.add_singleton_model(DirectoryWatcher::new);
     app.add_singleton_model(|_| DetectedRepositories::default());
     app.add_singleton_model(crate::remote_server::manager::RemoteServerManager::new);
-    app.add_singleton_model(|_| crate::code_review::git_status_update::GitStatusUpdateModel::new());
+    app.add_singleton_model(|_| crate::code_review::git_repo_model::GitRepoModels::new());
     app.add_singleton_model(RepoMetadataModel::new);
     app.add_singleton_model(FileSearchModel::new);
     app.add_singleton_model(RepoOutlines::new_for_test);

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -321,9 +321,7 @@ use crate::code_review::context::{
 use crate::code_review::diff_state::LocalDiffStateModel;
 use crate::code_review::diff_state::{DiffMode, GitDeltaPreference};
 #[cfg(feature = "local_fs")]
-use crate::code_review::git_status_update::{
-    GitRepoStatusModel, GitStatusMetadata, GitStatusUpdateModel,
-};
+use crate::code_review::git_repo_model::{GitRepoModels, GitRepoStatusModel, GitStatusMetadata};
 #[cfg(feature = "local_fs")]
 use crate::code_review::github_repo_model::GitHubRepoModel;
 use crate::code_review::telemetry_event::CodeReviewPaneEntrypoint;
@@ -5024,7 +5022,7 @@ impl TerminalView {
     fn git_status_metadata<'a>(&'a self, ctx: &'a AppContext) -> Option<&'a GitStatusMetadata> {
         self.git_repo_status
             .as_ref()
-            .and_then(|h| h.as_ref(ctx).metadata())
+            .and_then(|h| h.as_ref(ctx).metadata(ctx))
     }
 
     #[cfg(feature = "local_fs")]
@@ -5140,7 +5138,7 @@ impl TerminalView {
             let Some(repo_path) = self.current_local_repo_path().map(Path::to_path_buf) else {
                 return;
             };
-            let result = GitStatusUpdateModel::handle(ctx).update(ctx, |model, ctx| {
+            let result = GitRepoModels::handle(ctx).update(ctx, |model, ctx| {
                 model.subscribe_github_repo(&repo_path, ctx)
             });
             match result {
@@ -5205,7 +5203,7 @@ impl TerminalView {
             if self.git_repo_status.is_some() {
                 self.sync_pr_info_subscription(ctx);
             } else if let Some(repo_path) = self.current_local_repo_path().map(Path::to_path_buf) {
-                let result = GitStatusUpdateModel::handle(ctx)
+                let result = GitRepoModels::handle(ctx)
                     .update(ctx, |model, ctx| model.subscribe(&repo_path, ctx));
                 match result {
                     Ok(handle) => {
@@ -5227,7 +5225,7 @@ impl TerminalView {
                         self.sync_pr_info_subscription(ctx);
                     }
                     Err(err) => {
-                        log::warn!("GitStatusUpdateModel subscribe failed: {err}");
+                        log::warn!("GitRepoModels subscribe failed: {err}");
                     }
                 }
             }

--- a/app/src/test_util/terminal.rs
+++ b/app/src/test_util/terminal.rs
@@ -38,7 +38,7 @@ use crate::auth::auth_manager::AuthManager;
 use crate::auth::AuthStateProvider;
 use crate::changelog_model::ChangelogModel;
 use crate::cloud_object::model::persistence::CloudModel;
-use crate::code_review::git_status_update::GitStatusUpdateModel;
+use crate::code_review::git_repo_model::GitRepoModels;
 use crate::context_chips::prompt::Prompt;
 use crate::network::NetworkStatus;
 use crate::pricing::PricingInfoModel;
@@ -147,7 +147,7 @@ pub fn initialize_app_for_terminal_view(app: &mut App) {
         model
     });
     app.add_singleton_model(FileSearchModel::new);
-    app.add_singleton_model(|_| GitStatusUpdateModel::new());
+    app.add_singleton_model(|_| GitRepoModels::new());
     app.add_singleton_model(RepoOutlines::new_for_test);
     app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
     app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -191,7 +191,7 @@ pub(crate) fn initialize_app(app: &mut App) {
     app.add_singleton_model(|ctx| ServerExperiments::new_from_cache(vec![], ctx));
     app.add_singleton_model(DefaultTerminal::new);
     app.add_singleton_model(|_| IgnoredSuggestionsModel::new(vec![]));
-    app.add_singleton_model(|_| crate::code_review::git_status_update::GitStatusUpdateModel::new());
+    app.add_singleton_model(|_| crate::code_review::git_repo_model::GitRepoModels::new());
     app.add_singleton_model(remote_server::manager::RemoteServerManager::new);
     #[cfg(not(target_family = "wasm"))]
     app.add_singleton_model(RemoteCodebaseIndexModel::new);


### PR DESCRIPTION
## Description
* WISOTT 
* Builds on https://github.com/warpdotdev/warp/pull/12456 + split of https://github.com/warpdotdev/warp/pull/12498 
* Updates the existing models `GitHubRepoModel` and `GitRepoStatusModel` such that each model is moved to its own folder with a wrapper and local variant (remote variant to be added) 
* Renames `GitStatusUpdateModel` to `GitRepoModels` and moves the model to its own file 

## Linked issue 
* [APP-4590: remote git chips](https://linear.app/warpdotdev/issue/APP-4590/improve-remote-git-related-chip-experience)
* [APP-4560: remote pr chip](https://linear.app/warpdotdev/issue/APP-4560/code-feature-support-pr-chip)

## Testing
Should be a no-op
- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode