### PR TITLE
Don't auto-submit multi-select agent questions on toggle

### DIFF
--- a/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
+++ b/app/src/ai/blocklist/inline_action/ask_user_question_view.rs
@@ -85,8 +85,11 @@ fn ask_user_question_header_height(appearance: &Appearance, app: &AppContext) ->
         + (2. * INLINE_ACTION_HEADER_VERTICAL_PADDING)
 }
 
-fn ask_user_question_auto_advance_enabled(is_multiselect: bool, is_last_question: bool) -> bool {
-    is_last_question || !is_multiselect
+fn ask_user_question_auto_advance_enabled(is_multiselect: bool) -> bool {
+    // Single-select answers auto-advance (and the last one auto-submits) as soon as an option is
+    // toggled. Multi-select answers never auto-submit on toggle so the user can pick multiple
+    // options via mouse/number keys first; they explicitly submit with Enter.
+    !is_multiselect
 }
 
 pub fn init(app: &mut AppContext) {
@@ -332,8 +335,9 @@ struct AskUserQuestionSession {
 /// status, returning effects for the view to execute.
 impl AskUserQuestionSession {
     fn new(mut questions: Vec<AskUserQuestionItem>) -> Self {
-        // Put multi-select questions before single-select so the last question
-        // can auto-submit after a single option toggle.
+        // Put multi-select questions before single-select so a single-select question is last when
+        // the set is mixed. Single-select toggles auto-advance, so this lets the final answer
+        // auto-submit the questionnaire; multi-select questions only submit on an explicit Enter.
         questions.sort_by_key(|q| !q.is_multiselect());
         Self {
             state: AskUserQuestionState::Editing(AskUserQuestionEditingState::new(questions.len())),
@@ -395,15 +399,6 @@ impl AskUserQuestionSession {
         }
     }
 
-    fn is_last_question(&self) -> bool {
-        match &self.state {
-            AskUserQuestionState::Editing(editing) => {
-                editing.is_last_question(self.questions.len())
-            }
-            AskUserQuestionState::Completed { .. } => false,
-        }
-    }
-
     // Centralize all state transitions so the view layer only maps UI events to actions and then
     // applies the returned effect.
     fn apply(&mut self, action: AskUserQuestionAction) -> AskUserQuestionEffect {
@@ -436,7 +431,7 @@ impl AskUserQuestionSession {
             let is_multi_select = current.question.is_multiselect();
             (
                 is_multi_select,
-                ask_user_question_auto_advance_enabled(is_multi_select, self.is_last_question()),
+                ask_user_question_auto_advance_enabled(is_multi_select),
             )
         }) else {
             return AskUserQuestionEffect::Noop;
@@ -450,12 +445,11 @@ impl AskUserQuestionSession {
         editing.update_current_draft(|draft| {
             if is_multi_select {
                 // Multiselect behaves like a checklist: toggling one option should not affect any
-                // of the other selected options, and only the last question is allowed to auto-advance.
+                // of the other selected options, and toggling never auto-submits — the user picks
+                // options with the mouse/number keys and submits explicitly with Enter.
                 if !draft.selected_option_indices.insert(option_index) {
                     draft.selected_option_indices.remove(&option_index);
                 }
-                should_auto_advance_after_toggle =
-                    auto_advance_enabled && !draft.selected_option_indices.is_empty();
                 return;
             }
             // Single-select behaves like a radio group, except clicking the selected option again
@@ -503,12 +497,10 @@ impl AskUserQuestionSession {
     }
 
     fn save_other_text(&mut self, text: Option<String>) -> AskUserQuestionEffect {
-        let Some(auto_advance_enabled) = self.current().map(|current| {
-            ask_user_question_auto_advance_enabled(
-                current.question.is_multiselect(),
-                self.is_last_question(),
-            )
-        }) else {
+        let Some(auto_advance_enabled) = self
+            .current()
+            .map(|current| ask_user_question_auto_advance_enabled(current.question.is_multiselect()))
+        else {
             return AskUserQuestionEffect::Noop;
         };
         let Some(editing) = self.editing_state_mut() else {
@@ -563,8 +555,9 @@ impl AskUserQuestionSession {
         highlighted_index: Option<usize>,
         active_other_text: Option<String>,
     ) -> AskUserQuestionEffect {
-        let Some((supports_other, option_count)) = self.current().map(|current| {
+        let Some((is_multiselect, supports_other, option_count)) = self.current().map(|current| {
             (
+                current.question.is_multiselect(),
                 current.question.supports_other(),
                 current
                     .question
@@ -579,9 +572,14 @@ impl AskUserQuestionSession {
             return self.open_other_input();
         }
 
-        if let Some(option_index) = highlighted_index.filter(|index| *index < option_count) {
-            let _ = self.toggle_option(option_index);
-            return self.enter_submit_effect();
+        // Single-select activates the highlighted option on Enter before submitting. Multi-select
+        // options are toggled explicitly via click or number keys, so Enter only commits the
+        // current selection and never toggles the highlighted option.
+        if !is_multiselect {
+            if let Some(option_index) = highlighted_index.filter(|index| *index < option_count) {
+                let _ = self.toggle_option(option_index);
+                return self.enter_submit_effect();
+            }
         }
 
         if self

--- a/app/src/ai/blocklist/inline_action/ask_user_question_view_tests.rs
+++ b/app/src/ai/blocklist/inline_action/ask_user_question_view_tests.rs
@@ -162,24 +162,26 @@ fn enter_on_single_select_option_toggles_it_and_schedules_auto_advance() {
 }
 
 #[test]
-fn enter_on_non_last_multi_select_option_toggles_it_and_schedules_auto_advance() {
+fn enter_on_multi_select_does_not_toggle_highlighted_option() {
     let mut session = build_session(vec![
         build_question("q1", "First", true, true, &["Stable", "Nightly"]),
         build_question("q2", "Second", false, false, &["CLI"]),
     ]);
 
+    // For multi-select, Enter must not toggle the highlighted option. With nothing selected it
+    // commits the (empty) answer and advances to the next question.
     assert_eq!(
         session.apply(AskUserQuestionAction::PressEnter {
             highlighted_index: Some(1),
             active_other_text: None,
         }),
-        AskUserQuestionEffect::ScheduleAutoAdvance
+        AskUserQuestionEffect::ShowQuestion
     );
-    assert!(current_draft(&session).is_some_and(|draft| draft.selected_option_indices.contains(&1)));
+    assert_eq!(session.current_question_index(), 1);
 }
 
 #[test]
-fn enter_on_answered_non_last_multi_select_option_keeps_existing_selection_and_advances() {
+fn enter_on_answered_multi_select_keeps_selection_without_toggling_highlighted_option() {
     let mut session = build_session(vec![
         build_question("q1", "First", true, true, &["Stable", "Nightly"]),
         build_question("q2", "Second", false, false, &["CLI"]),
@@ -189,6 +191,8 @@ fn enter_on_answered_non_last_multi_select_option_keeps_existing_selection_and_a
         session.apply(AskUserQuestionAction::ToggleOption { option_index: 0 }),
         AskUserQuestionEffect::RefreshCurrent
     );
+    // Enter keeps the existing selection (0) and schedules the advance without toggling the
+    // highlighted option (1).
     assert_eq!(
         session.apply(AskUserQuestionAction::PressEnter {
             highlighted_index: Some(1),
@@ -197,7 +201,7 @@ fn enter_on_answered_non_last_multi_select_option_keeps_existing_selection_and_a
         AskUserQuestionEffect::ScheduleAutoAdvance
     );
     assert!(current_draft(&session).is_some_and(|draft| {
-        draft.selected_option_indices.contains(&0) && draft.selected_option_indices.contains(&1)
+        draft.selected_option_indices.contains(&0) && !draft.selected_option_indices.contains(&1)
     }));
 }
 
@@ -232,7 +236,7 @@ fn multi_select_non_last_toggle_does_not_auto_advance() {
 }
 
 #[test]
-fn last_multi_select_toggle_schedules_auto_advance() {
+fn last_multi_select_toggle_does_not_auto_advance() {
     let mut session = build_session(vec![build_question(
         "q1",
         "Only",
@@ -241,11 +245,53 @@ fn last_multi_select_toggle_schedules_auto_advance() {
         &["Rust", "Go"],
     )]);
 
-    let effect = session.apply(AskUserQuestionAction::ToggleOption { option_index: 0 });
-
-    assert_eq!(effect, AskUserQuestionEffect::ScheduleAutoAdvance);
+    // Toggling options on the last multi-select question must never auto-submit; the user picks
+    // options with the mouse/number keys and submits explicitly with Enter.
+    assert_eq!(
+        session.apply(AskUserQuestionAction::ToggleOption { option_index: 0 }),
+        AskUserQuestionEffect::RefreshCurrent
+    );
+    assert_eq!(
+        session.apply(AskUserQuestionAction::ToggleOption { option_index: 1 }),
+        AskUserQuestionEffect::RefreshCurrent
+    );
     assert_eq!(session.current_question_index(), 0);
-    assert!(current_draft(&session).is_some_and(|draft| draft.selected_option_indices.contains(&0)));
+    assert!(matches!(session.phase(), AskUserQuestionPhase::Editing));
+    assert!(current_draft(&session).is_some_and(|draft| {
+        draft.selected_option_indices.contains(&0) && draft.selected_option_indices.contains(&1)
+    }));
+}
+
+#[test]
+fn last_multi_select_submits_on_enter() {
+    let mut session = build_session(vec![build_question(
+        "q1",
+        "Only",
+        true,
+        false,
+        &["Rust", "Go"],
+    )]);
+
+    session.apply(AskUserQuestionAction::ToggleOption { option_index: 0 });
+
+    // Enter on the last multi-select question schedules the auto-advance that submits it.
+    assert_eq!(
+        session.apply(AskUserQuestionAction::PressEnter {
+            highlighted_index: None,
+            active_other_text: None,
+        }),
+        AskUserQuestionEffect::ScheduleAutoAdvance
+    );
+
+    // Confirming (as the auto-advance timer does) submits the answered question.
+    assert_eq!(
+        session.apply(AskUserQuestionAction::Confirm),
+        AskUserQuestionEffect::Submit(vec![AskUserQuestionAnswerItem::Answered {
+            question_id: "q1".to_string(),
+            selected_options: vec!["Rust".to_string()],
+            other_text: String::new(),
+        }])
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description
For the `AskUserQuestion` tool, the last multi-select question would auto-submit the whole questionnaire as soon as a single option was toggled — whether by clicking it with the mouse or pressing its number key. This made it impossible to select more than one option (the reported case: a user clicked the first option intending to also click the next, but it submitted after the first click).

Multi-select questions now never auto-submit on toggle. Options are toggled explicitly via mouse click or number keys, and the user submits the question with **Enter**. Single-select behavior is unchanged (toggling an option still auto-advances / auto-submits the last question).

### Changes
- `ask_user_question_auto_advance_enabled` now keys off `is_multiselect` only — single-select auto-advances, multi-select never does.
- `toggle_option` no longer schedules an auto-advance for multi-select questions.
- `save_other_text` follows the same rule for the "Other…" free-text path on multi-select questions.
- `press_enter` no longer toggles the highlighted option for multi-select; it just commits the current selection and submits/advances (single-select still activates the highlighted option on Enter). This also fixes Enter accidentally un-toggling the last-clicked/hovered option in multi-select.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Updated and extended the `ask_user_question_view` unit tests to cover the new behavior, and ran them:

```
cargo nextest run -p warp -E 'test(ask_user_question_view)'
19 tests run: 19 passed
```

- New/updated tests: `last_multi_select_toggle_does_not_auto_advance`, `last_multi_select_submits_on_enter`, `enter_on_multi_select_does_not_toggle_highlighted_option`, `enter_on_answered_multi_select_keeps_selection_without_toggling_highlighted_option`.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Multi-select agent questions no longer auto-submit when toggling an option; select multiple options and press Enter to submit.
-->

_Conversation: https://staging.warp.dev/conversation/5044c0f2-de4e-4143-989e-7e55b7a6c62e_
_Run: https://oz.staging.warp.dev/runs/019eb8d5-5f41-77df-b381-ce5db367205a_

_This PR was generated with [Oz](https://warp.dev/oz)._
