### PR TITLE
Fix editor find/replace not matching non-ASCII text

### DIFF
--- a/crates/editor/src/content/find.rs
+++ b/crates/editor/src/content/find.rs
@@ -312,7 +312,16 @@ impl Engine {
                         }
                     } else if let Some(character) = cursor.char() {
                         let mut bytes = [0u8; 4];
-                        for byte in character.encode_utf8(&mut bytes).bytes() {
+                        let encoded = character.encode_utf8(&mut bytes).len();
+                        let utf8 = &mut bytes[..encoded];
+                        // The reverse DFA was compiled over the reversed byte stream, so a
+                        // multi-byte character's bytes must be fed to it back-to-front.
+                        // Single-byte (ASCII) characters are unaffected, which is why the bug
+                        // only surfaced for non-ASCII (e.g. CJK) queries.
+                        if matches!(direction, SearchDirection::Reverse) {
+                            utf8.reverse();
+                        }
+                        for &byte in utf8.iter() {
                             state = dfa
                                 .next_state(cache, state, byte)
                                 .context("Couldn't advance to next state")?;

--- a/crates/editor/src/content/find_tests.rs
+++ b/crates/editor/src/content/find_tests.rs
@@ -140,6 +140,74 @@ fn test_end_of_buffer() {
 }
 
 #[test]
+fn test_search_non_ascii() {
+    App::test((), |mut app| async move {
+        let (buffer, _selection) = Buffer::mock_from_markdown(
+            "你好aaaaa\n再見你好",
+            None,
+            Box::new(|_, _| IndentBehavior::Ignore),
+            &mut app,
+        );
+        buffer.read(&app, |buffer, _| {
+            // ASCII literal search works regardless of the bug.
+            assert_matches(
+                buffer,
+                &SearchConfig::new("a"),
+                [
+                    (3, 4, "a"),
+                    (4, 5, "a"),
+                    (5, 6, "a"),
+                    (6, 7, "a"),
+                    (7, 8, "a"),
+                ],
+            );
+
+            // Multi-byte literal search must find every occurrence. Each CJK
+            // character is one `CharOffset` but several UTF-8 bytes; the reverse
+            // DFA pass that locates a match's start has to consume those bytes in
+            // reverse order, which is what this regression guards.
+            assert_matches(
+                buffer,
+                &SearchConfig::new("你好"),
+                [(1, 3, "你好"), (11, 13, "你好")],
+            );
+
+            // A multi-byte query mixing scripts also works.
+            assert_matches(buffer, &SearchConfig::new("好a"), [(2, 4, "好a")]);
+
+            // Regex over multi-byte content keeps working.
+            assert_matches(
+                buffer,
+                &SearchConfig::regex("你."),
+                [(1, 3, "你好"), (11, 13, "你好")],
+            );
+        });
+    });
+}
+
+#[test]
+fn test_search_non_ascii_case_insensitive() {
+    App::test((), |mut app| async move {
+        let (buffer, _selection) = Buffer::mock_from_markdown(
+            "CAFÉ café",
+            None,
+            Box::new(|_, _| IndentBehavior::Ignore),
+            &mut app,
+        );
+        buffer.read(&app, |buffer, _| {
+            // Case-insensitive matching over multi-byte characters (`É`/`é` are
+            // two UTF-8 bytes) must find both the upper- and lower-case forms,
+            // exercising the reverse-DFA byte order on case-folded input.
+            assert_matches(
+                buffer,
+                &SearchConfig::new("café").with_case_sensitive(false),
+                [(1, 5, "CAFÉ"), (6, 10, "café")],
+            );
+        });
+    });
+}
+
+#[test]
 fn test_word_boundaries() {
     App::test((), |mut app| async move {
         let (buffer, _selection) = Buffer::mock_from_markdown(


### PR DESCRIPTION
## Description

Find/replace in the code/markdown editor returned no matches for non-ASCII queries (e.g. Chinese/CJK text), even when the same text was clearly present, while ASCII queries in the same buffer worked.

Root cause is in the editor search engine (`crates/editor/src/content/find.rs`). A match's end is located with a forward DFA, and its start is then located with a reverse DFA that is compiled over the *reversed* byte stream. The byte-feeding loop is shared by both passes and always fed a character's UTF-8 bytes front-to-back. For multi-byte characters this gives the reverse DFA its bytes in the wrong order, so it never finds the start; the forward pass still reports an end, but with no start the match is silently discarded. Single-byte ASCII characters are unaffected, which is why the bug only showed up for non-ASCII text.

The fix feeds each character's bytes back-to-front during the reverse pass only. Added regression tests covering CJK literal search, mixed-script literals, regex over multi-byte content, and case-insensitive matching of multi-byte (accented) characters.

## Linked Issue
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

Fixes #12239

## Testing
- [x] `rustfmt --edition 2024 --check` on the changed files
- [x] `cargo check -p warp_editor`
- [x] `cargo clippy -p warp_editor --all-targets --all-features --tests -- -D warnings` (No issues found)
- [x] `cargo nextest run -p warp_editor` (429 passed, including new `test_search_non_ascii` and `test_search_non_ascii_case_insensitive`)
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Searching the literal `你好` in the editor find bar against a file containing `你好aaaaa`:

- **Before (stable Warp):** the find bar reports **No matches**, even though ASCII queries (`a` → 1/5) in the same file work.
- **After (this patch):** the same query correctly returns **1/1** and highlights the match.

<img width="1600" height="1230" alt="warp-12239-before-after" src="https://github.com/user-attachments/assets/bd9bf3c4-6185-42d7-a338-abaf9a8cf6db" />

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fix editor find/replace returning no matches for non-ASCII (e.g. CJK) queries
-->
