### PR TITLE
Fix cloud icon shown for local orchestration subagents

### DIFF
--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -912,6 +912,25 @@ impl TerminalView {
                 .is_some_and(|model| model.as_ref(ctx).is_ambient_agent())
     }
 
+    /// Whether this terminal view is hosting a live, locally-executed orchestration
+    /// child conversation. Local children carry a server-side task id for orchestration
+    /// tracking but run on the local machine, so the agent chrome must render the local
+    /// agent icon rather than the cloud/ambient treatment. Remote children (which execute
+    /// on a cloud worker, `AIConversation::is_remote_child`) are intentionally excluded so
+    /// they keep the cloud icon.
+    pub(crate) fn is_local_orchestration_child(&self, ctx: &AppContext) -> bool {
+        if self.is_ambient_agent_session(ctx) {
+            return false;
+        }
+        let history = BlocklistAIHistoryModel::as_ref(ctx);
+        self.active_conversation_id(ctx)
+            .and_then(|id| history.conversation(&id))
+            .or_else(|| history.active_conversation(self.view_id))
+            .is_some_and(|conversation| {
+                conversation.is_child_agent_conversation() && !conversation.is_remote_child()
+            })
+    }
+
     fn selected_conversation_for_user_facing_chrome<'a>(
         &'a self,
         ctx: &'a AppContext,

--- a/app/src/ui_components/agent_icon.rs
+++ b/app/src/ui_components/agent_icon.rs
@@ -50,6 +50,12 @@ pub(crate) fn terminal_view_agent_icon_variant(
     let task_data = ambient_task_id
         .and_then(|task_id| AgentConversationsModel::as_ref(app).get_task_data(&task_id));
 
+    // A locally-hosted orchestration child runs on this machine even though it carries a
+    // server-side task id for orchestration tracking. It must render the local agent icon
+    // (no cloud lobe), so suppress the ambient treatment that a bare task id would otherwise
+    // imply. Remote children stay ambient because `is_local_orchestration_child` is false.
+    let is_local_orchestration_child = terminal_view.is_local_orchestration_child(app);
+
     // Defer to the card helper when we have task data and no CLI session takes precedence.
     if cli_agent_session.is_none() {
         if let Some(task) = task_data.as_ref() {
@@ -60,13 +66,18 @@ pub(crate) fn terminal_view_agent_icon_variant(
                 .and_then(|config| config.harness.as_ref())
                 .map(|harness| harness.harness_type)
                 .unwrap_or(Harness::Oz);
-            return Some(agent_icon_variant_for_run(harness, status, true));
+            return Some(agent_icon_variant_for_run(
+                harness,
+                status,
+                !is_local_orchestration_child,
+            ));
         }
     }
 
     let is_ambient = terminal_view.is_ambient_agent_session(app) || ambient_task_id.is_some();
     let inputs = TerminalIconInputs {
         is_ambient,
+        is_local_orchestration_child,
         cli_session: cli_agent_session.map(|session| CLISessionInputs {
             agent: session.agent,
             has_listener: session.listener.is_some(),
@@ -102,6 +113,10 @@ pub(crate) fn agent_conversation_entry_icon_variant(
 /// [`TerminalView`] / [`AppContext`].
 struct TerminalIconInputs {
     is_ambient: bool,
+    /// Whether the terminal view is hosting a live, locally-executed orchestration child.
+    /// When true, the ambient/cloud treatment is suppressed even if `is_ambient` would
+    /// otherwise be set (local children carry a server-side task id but run locally).
+    is_local_orchestration_child: bool,
     cli_session: Option<CLISessionInputs>,
     /// Third-party CLI agent for a live ambient run before task data is available (e.g.
     /// Claude pre-dispatch). `None` otherwise; task-derived harnesses are handled upstream.
@@ -129,6 +144,11 @@ struct CLISessionInputs {
 fn agent_icon_variant_from_terminal_inputs(
     inputs: &TerminalIconInputs,
 ) -> Option<IconWithStatusVariant> {
+    // A locally-hosted orchestration child runs on this machine, so it must never render the
+    // cloud lobe even though it has a server-side task id. Collapse `is_ambient` to false in
+    // that case; every downstream arm reads this effective value.
+    let is_ambient = inputs.is_ambient && !inputs.is_local_orchestration_child;
+
     // 1. CLI session with a known (non-Unknown) agent wins. Status is only meaningful when
     //    the session is plugin-backed and the handler exposes rich status.
     if let Some(session) = inputs
@@ -141,14 +161,14 @@ fn agent_icon_variant_from_terminal_inputs(
         return Some(IconWithStatusVariant::CLIAgent {
             agent: session.agent,
             status,
-            is_ambient: inputs.is_ambient,
+            is_ambient,
         });
     }
 
     // 2. Live ambient run with a third-party harness selected, before task data is
     //    available (e.g. Claude pre-dispatch). `Unknown` is filtered so an unrecognized
     //    harness doesn't render as an unbranded gray circle.
-    if inputs.is_ambient {
+    if is_ambient {
         if let Some(agent) = inputs
             .selected_third_party_cli_agent
             .filter(|agent| !matches!(agent, CLIAgent::Unknown))
@@ -162,10 +182,10 @@ fn agent_icon_variant_from_terminal_inputs(
     }
 
     // 3. Selected conversation OR ambient (Oz) terminal: Oz agent variant.
-    if inputs.has_selected_conversation || inputs.is_ambient {
+    if inputs.has_selected_conversation || is_ambient {
         return Some(IconWithStatusVariant::OzAgent {
             status: inputs.selected_conversation_status.clone(),
-            is_ambient: inputs.is_ambient,
+            is_ambient,
         });
     }
 

--- a/app/src/ui_components/agent_icon_tests.rs
+++ b/app/src/ui_components/agent_icon_tests.rs
@@ -74,6 +74,10 @@ enum CanonicalRunState {
     PlainTerminal,
     /// Local Warp-native (Oz) conversation, in-progress.
     LocalOzInProgress,
+    /// Local orchestration child (Oz), in-progress. Carries a server-side task id for
+    /// orchestration tracking (so the inputs look ambient), but executes locally, so the
+    /// icon must render as a local Oz agent with no cloud lobe.
+    LocalOzChildInProgress,
     /// Cloud-mode Oz run, in-progress.
     CloudOzInProgress,
     /// Cloud Claude harness selected, pre-dispatch (no session, no status yet).
@@ -100,6 +104,7 @@ impl CanonicalRunState {
         &[
             PlainTerminal,
             LocalOzInProgress,
+            LocalOzChildInProgress,
             CloudOzInProgress,
             CloudClaudePreDispatch,
             CloudClaudeInProgress,
@@ -117,6 +122,14 @@ impl CanonicalRunState {
         match self {
             PlainTerminal => None,
             LocalOzInProgress => Some(AgentIconFields {
+                is_cli: false,
+                cli_agent: None,
+                status: Some(ConversationStatus::InProgress),
+                is_ambient: false,
+            }),
+            // A local orchestration child renders as a local Oz agent (no cloud lobe) even
+            // though its inputs carry a server-side task id.
+            LocalOzChildInProgress => Some(AgentIconFields {
                 is_cli: false,
                 cli_agent: None,
                 status: Some(ConversationStatus::InProgress),
@@ -175,6 +188,7 @@ impl CanonicalRunState {
         match self {
             PlainTerminal => TerminalIconInputs {
                 is_ambient: false,
+                is_local_orchestration_child: false,
                 cli_session: None,
                 selected_third_party_cli_agent: None,
                 selected_conversation_status: None,
@@ -182,6 +196,18 @@ impl CanonicalRunState {
             },
             LocalOzInProgress => TerminalIconInputs {
                 is_ambient: false,
+                is_local_orchestration_child: false,
+                cli_session: None,
+                selected_third_party_cli_agent: None,
+                selected_conversation_status: Some(ConversationStatus::InProgress),
+                has_selected_conversation: true,
+            },
+            // A live local orchestration child carries a server-side task id, so its inputs
+            // look ambient, but `is_local_orchestration_child` collapses that to the local
+            // Oz treatment.
+            LocalOzChildInProgress => TerminalIconInputs {
+                is_ambient: true,
+                is_local_orchestration_child: true,
                 cli_session: None,
                 selected_third_party_cli_agent: None,
                 selected_conversation_status: Some(ConversationStatus::InProgress),
@@ -189,6 +215,7 @@ impl CanonicalRunState {
             },
             CloudOzInProgress => TerminalIconInputs {
                 is_ambient: true,
+                is_local_orchestration_child: false,
                 cli_session: None,
                 selected_third_party_cli_agent: None,
                 selected_conversation_status: Some(ConversationStatus::InProgress),
@@ -196,6 +223,7 @@ impl CanonicalRunState {
             },
             CloudClaudePreDispatch => TerminalIconInputs {
                 is_ambient: true,
+                is_local_orchestration_child: false,
                 cli_session: None,
                 selected_third_party_cli_agent: Some(CLIAgent::Claude),
                 selected_conversation_status: None,
@@ -203,6 +231,7 @@ impl CanonicalRunState {
             },
             CloudClaudeInProgress => TerminalIconInputs {
                 is_ambient: true,
+                is_local_orchestration_child: false,
                 cli_session: None,
                 selected_third_party_cli_agent: Some(CLIAgent::Claude),
                 selected_conversation_status: Some(ConversationStatus::InProgress),
@@ -212,6 +241,7 @@ impl CanonicalRunState {
                 // VM has shut down: the caller resolves these fields from the conversation's
                 // server metadata, so the waterfall sees the same shape as a live run.
                 is_ambient: true,
+                is_local_orchestration_child: false,
                 cli_session: None,
                 selected_third_party_cli_agent: Some(CLIAgent::Codex),
                 selected_conversation_status: Some(ConversationStatus::Success),
@@ -219,6 +249,7 @@ impl CanonicalRunState {
             },
             LocalClaudePluginInProgress => TerminalIconInputs {
                 is_ambient: false,
+                is_local_orchestration_child: false,
                 cli_session: Some(CLISessionInputs {
                     agent: CLIAgent::Claude,
                     has_listener: true,
@@ -231,6 +262,7 @@ impl CanonicalRunState {
             },
             LocalClaudePluginBlocked => TerminalIconInputs {
                 is_ambient: false,
+                is_local_orchestration_child: false,
                 cli_session: Some(CLISessionInputs {
                     agent: CLIAgent::Claude,
                     has_listener: true,
@@ -245,6 +277,7 @@ impl CanonicalRunState {
             },
             LocalClaudeCommandDetected => TerminalIconInputs {
                 is_ambient: false,
+                is_local_orchestration_child: false,
                 cli_session: Some(CLISessionInputs {
                     agent: CLIAgent::Claude,
                     has_listener: false,
@@ -272,6 +305,7 @@ impl CanonicalRunState {
             }
             PlainTerminal
             | LocalOzInProgress
+            | LocalOzChildInProgress
             | LocalClaudePluginInProgress
             | LocalClaudePluginBlocked
             | LocalClaudeCommandDetected => None,
@@ -311,7 +345,9 @@ fn every_canonical_state_produces_consistent_icon_across_surfaces() {
 }
 
 /// Structural invariant: the `is_ambient` flag on the rendered variant must match the
-/// `is_ambient` flag on the terminal inputs. Catches accidental drift in the waterfall.
+/// effective ambient value derived from the inputs — `is_ambient` unless the run is a
+/// locally-hosted orchestration child, which collapses it to false. Catches accidental
+/// drift in the waterfall.
 #[test]
 fn terminal_is_ambient_matches_inputs_for_every_state() {
     for state in CanonicalRunState::all() {
@@ -321,8 +357,9 @@ fn terminal_is_ambient_matches_inputs_for_every_state() {
         };
         let fields = AgentIconFields::from_variant(&variant)
             .expect("terminal helper must only return agent variants");
+        let expected_is_ambient = inputs.is_ambient && !inputs.is_local_orchestration_child;
         assert_eq!(
-            fields.is_ambient, inputs.is_ambient,
+            fields.is_ambient, expected_is_ambient,
             "is_ambient drifted for {state:?}"
         );
     }


### PR DESCRIPTION
## Description
Local orchestration subagents were rendering the cloud-agent icon (purple circle + cloud lobe) in the subagent `PaneHeader` and vertical tabs, making a locally-executed child look like a cloud agent.

Root cause: the shared agent-icon helper `terminal_view_agent_icon_variant` (`app/src/ui_components/agent_icon.rs`) treats any task-backed run as ambient/cloud (`is_ambient: true`). Local orchestration children carry a server-side task id for orchestration tracking but execute on the local machine, so the bare presence of a task id incorrectly forced the cloud treatment.

Fix: detect a locally-hosted orchestration child via the existing `AIConversation::is_remote_child()` signal and suppress the ambient/cloud lobe for it. A new `TerminalView::is_local_orchestration_child` returns true when the view's active conversation is a child agent conversation (`is_child_agent_conversation()`) that is **not** a remote child. This value is threaded through the icon waterfall so both the task path and the no-task path collapse `is_ambient` to `false` for local children. Remote children (which run on a cloud worker) keep the cloud icon.

## Linked Issue
APP-4726

## Testing
- Extended the cross-surface equivalence suite in `app/src/ui_components/agent_icon_tests.rs` with a new `LocalOzChildInProgress` canonical state whose inputs look ambient (server-side task id) but resolve to a local Oz agent (no cloud lobe).
- Updated `terminal_is_ambient_matches_inputs_for_every_state` to assert the effective ambient value (collapsed for local children).
- `cargo nextest run -p warp agent_icon` — all 6 tests pass.
- `cargo check -p warp` passes.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Local orchestration subagents now render the local agent icon instead of the cloud-agent icon in the pane header and tabs.

_Conversation: https://staging.warp.dev/conversation/663bac34-6ef0-4a18-93c0-fab0c15ed02b_
_Run: https://oz.staging.warp.dev/runs/019eb8ef-55ae-76f4-ab49-2bcadab94ecb_

_This PR was generated with [Oz](https://warp.dev/oz)._
