### PR TITLE
feat(panes): add adjustable inactive-pane dim strength

### DIFF
--- a/app/src/pane_group/pane/view/mod.rs
+++ b/app/src/pane_group/pane/view/mod.rs
@@ -111,6 +111,7 @@ impl<P: BackingView> PaneView<P> {
             if matches!(
                 event,
                 PaneSettingsChangedEvent::ShouldDimInactivePanes { .. }
+                    | PaneSettingsChangedEvent::InactivePaneDimStrength { .. }
             ) {
                 ctx.notify();
             }
@@ -400,17 +401,21 @@ impl<P: BackingView> View for PaneView<P> {
         }
 
         // Dim inactive panes.
-        let should_dim_inactive_panes = *PaneSettings::as_ref(app).should_dim_inactive_panes;
+        let pane_settings = PaneSettings::as_ref(app);
+        let should_dim_inactive_panes = *pane_settings.should_dim_inactive_panes;
+        let dim_strength = *pane_settings.inactive_pane_dim_strength;
         let dim_even_if_focused = pane_configuration.dim_even_if_focused();
         if should_dim_inactive_panes {
             if dim_even_if_focused {
                 // Focus is in a side panel: dim this pane regardless of split state or focus.
-                container =
-                    container.with_foreground_overlay(appearance.theme().inactive_pane_overlay());
+                container = container.with_foreground_overlay(
+                    appearance.theme().inactive_pane_dim_overlay(dim_strength),
+                );
             } else if split_pane_state.is_in_split_pane() && !split_pane_state.is_focused() {
                 // Normal behavior: in a split, dim only unfocused panes.
-                container =
-                    container.with_foreground_overlay(appearance.theme().inactive_pane_overlay());
+                container = container.with_foreground_overlay(
+                    appearance.theme().inactive_pane_dim_overlay(dim_strength),
+                );
             }
         }
 

--- a/app/src/settings/pane.rs
+++ b/app/src/settings/pane.rs
@@ -11,6 +11,15 @@ define_settings_group!(PaneSettings, settings: [
         toml_path: "appearance.panes.should_dim_inactive_panes",
         description: "Whether inactive panes are visually dimmed.",
     },
+    inactive_pane_dim_strength: InactivePaneDimStrength {
+        type: u8,
+        default: 35,
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        private: false,
+        toml_path: "appearance.panes.inactive_pane_dim_strength",
+        description: "How strongly inactive panes are dimmed, from 5 to 80 percent.",
+    },
     focus_panes_on_hover: FocusPaneOnHover {
         type: bool,
         default: false,
@@ -21,3 +30,16 @@ define_settings_group!(PaneSettings, settings: [
         description: "Whether panes are focused when hovered over.",
     }
 ]);
+
+impl InactivePaneDimStrength {
+    /// Minimum dim strength, expressed as a percentage. Kept above zero so the slider
+    /// always produces a visible effect when dimming is enabled.
+    pub const MIN: u8 = 5;
+    /// Maximum dim strength, expressed as a percentage. Capped below full opacity so the
+    /// inactive pane's contents remain at least faintly visible.
+    pub const MAX: u8 = 80;
+
+    fn validate(&self, new_value: u8) -> u8 {
+        new_value.clamp(Self::MIN, Self::MAX)
+    }
+}

--- a/app/src/settings_view/appearance_page.rs
+++ b/app/src/settings_view/appearance_page.rs
@@ -59,9 +59,9 @@ use crate::settings::app_icon::{AppIcon, AppIconSettings};
 use crate::settings::{
     active_theme_kind, respect_system_theme, AIFontName, AppEditorSettings, CursorBlink,
     CursorBlinkEnabled, CursorDisplayType, EnforceMinimumContrast, FocusPaneOnHover, FontSettings,
-    FontSettingsChangedEvent, GPUSettings, InputBoxType, InputModeSettings, InputModeState,
-    InputSettings, InputSettingsChangedEvent, MonospaceFontName, PaneSettings,
-    ShouldDimInactivePanes, ThemeSettings, UseSystemTheme, UseThinStrokes,
+    FontSettingsChangedEvent, GPUSettings, InactivePaneDimStrength, InputBoxType,
+    InputModeSettings, InputModeState, InputSettings, InputSettingsChangedEvent, MonospaceFontName,
+    PaneSettings, ShouldDimInactivePanes, ThemeSettings, UseSystemTheme, UseThinStrokes,
     DEFAULT_MONOSPACE_FONT_NAME,
 };
 use crate::terminal::block_list_viewport::InputMode;
@@ -492,6 +492,8 @@ pub enum AppearancePageAction {
     SetBlur(f32),
     OpacitySliderDragged(f32),
     BlurSliderDragged(f32),
+    SetInactivePaneDimStrength(f32),
+    InactivePaneDimStrengthSliderDragged(f32),
     SetFontFamily(String),
     SetAIFontFamily(String),
     SetThinStrokes(ThinStrokes),
@@ -652,6 +654,10 @@ impl TypedActionView for AppearanceSettingsPageView {
             SetCursorType(cursor_display_type) => self.set_cursor_type(*cursor_display_type, ctx),
             OpacitySliderDragged(val) => self.set_opacity(*val, false, ctx),
             BlurSliderDragged(val) => self.set_blur(*val, false, ctx),
+            SetInactivePaneDimStrength(val) => self.set_inactive_pane_dim_strength(*val, ctx),
+            InactivePaneDimStrengthSliderDragged(val) => {
+                self.set_inactive_pane_dim_strength(*val, ctx)
+            }
             OpenUrl(url) => {
                 ctx.open_url(url);
             }
@@ -1393,6 +1399,7 @@ impl AppearanceSettingsPageView {
             "Panes",
             vec![
                 Box::new(DimInactivePanesWidget::default()),
+                Box::new(DimInactivePanesStrengthWidget::default()),
                 Box::new(FocusFollowsMouseWidget::default()),
             ],
         ));
@@ -2237,6 +2244,17 @@ impl AppearanceSettingsPageView {
                 }
             }
         });
+    }
+
+    fn set_inactive_pane_dim_strength(&mut self, value: f32, ctx: &mut ViewContext<Self>) {
+        let clamped =
+            (value as u8).clamp(InactivePaneDimStrength::MIN, InactivePaneDimStrength::MAX);
+        PaneSettings::handle(ctx).update(ctx, |pane_settings, ctx| {
+            report_if_error!(pane_settings
+                .inactive_pane_dim_strength
+                .set_value(clamped, ctx));
+        });
+        ctx.notify();
     }
 
     pub fn toggle_blur_texture(&mut self, ctx: &mut ViewContext<Self>) {
@@ -3618,6 +3636,75 @@ impl SettingsWidget for DimInactivePanesWidget {
                 .on_click(move |ctx, _, _| {
                     ctx.dispatch_typed_action(AppearancePageAction::ToggleDimInactivePanes);
                 })
+                .finish(),
+            None,
+        )
+    }
+}
+
+#[derive(Default)]
+struct DimInactivePanesStrengthWidget {
+    slider_state: SliderStateHandle,
+}
+
+impl SettingsWidget for DimInactivePanesStrengthWidget {
+    type View = AppearanceSettingsPageView;
+
+    fn search_terms(&self) -> &str {
+        "dim inactive panes strength amount radiance slider"
+    }
+
+    fn render(
+        &self,
+        view: &Self::View,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let pane_settings = PaneSettings::as_ref(app);
+        let dim_enabled = *pane_settings.should_dim_inactive_panes;
+        let dim_strength = *pane_settings.inactive_pane_dim_strength;
+
+        // The strength slider only has an effect while dimming is enabled, so reflect that
+        // in the label's toggle state.
+        let toggle_state = if dim_enabled {
+            ToggleState::Enabled
+        } else {
+            ToggleState::Disabled
+        };
+
+        render_body_item::<AppearancePageAction>(
+            format!("Inactive pane dim strength: {dim_strength}%"),
+            None,
+            LocalOnlyIconState::for_setting(
+                InactivePaneDimStrength::storage_key(),
+                InactivePaneDimStrength::sync_to_cloud(),
+                &mut view.local_only_icon_tooltip_states.borrow_mut(),
+                app,
+            ),
+            toggle_state,
+            appearance,
+            appearance
+                .ui_builder()
+                .slider(self.slider_state.clone())
+                .with_range(
+                    InactivePaneDimStrength::MIN as f32..InactivePaneDimStrength::MAX as f32,
+                )
+                .with_default_value(dim_strength as f32)
+                .with_style(UiComponentStyles {
+                    width: Some(OPACITY_SLIDER_WIDTH),
+                    // Margin is 3. to add up with 7. padding on slider for a total of 10.
+                    margin: Some(Coords::default().top(3.).bottom(3.)),
+                    ..Default::default()
+                })
+                .on_drag(|ctx, _, val| {
+                    ctx.dispatch_typed_action(
+                        AppearancePageAction::InactivePaneDimStrengthSliderDragged(val),
+                    )
+                })
+                .on_change(|ctx, _, val| {
+                    ctx.dispatch_typed_action(AppearancePageAction::SetInactivePaneDimStrength(val))
+                })
+                .build()
                 .finish(),
             None,
         )

--- a/crates/warp_core/src/ui/theme/color.rs
+++ b/crates/warp_core/src/ui/theme/color.rs
@@ -339,8 +339,20 @@ impl WarpTheme {
         fg_overlay_3(self)
     }
 
+    /// A subtle foreground wash, used to indicate a view is inactive (e.g. behind a modal).
     pub fn inactive_pane_overlay(&self) -> Fill {
         fg_overlay_2(self)
+    }
+
+    /// Overlay used by the "Dim inactive panes" feature to dim a pane by `dim_strength` percent.
+    ///
+    /// We lay a translucent black scrim over the pane so its radiance is *reduced*. Overlaying
+    /// the theme foreground (as `inactive_pane_overlay` does) lightens panes in dark themes
+    /// instead of dimming them, because the foreground color is light. A black scrim darkens
+    /// consistently across both light and dark themes.
+    /// See https://github.com/warpdotdev/warp/issues/5401.
+    pub fn inactive_pane_dim_overlay(&self, dim_strength: Opacity) -> Fill {
+        Fill::Solid(ColorU::black()).with_opacity(dim_strength)
     }
 
     pub fn subshell_background(&self) -> Fill {


### PR DESCRIPTION
## Description
Adds the ability to customize how strongly inactive panes are dimmed, and fixes the long-standing bug where "Dim inactive panes" *lightens* panes in dark themes instead of dimming them.

The old behavior overlaid the theme **foreground** color at low opacity. In dark themes the foreground is light, so the "dim" overlay actually raised the pane's radiance (made it brighter). This change uses a translucent **black scrim** instead, which reduces radiance consistently across both light and dark themes.

On top of the fix, there's a new **Inactive pane dim strength** slider (5–80%) under Settings → Appearance → Panes so users can tune the amount of dimming to their lighting conditions — the exact ask from the linked feature request.

### What changed
- `crates/warp_core/src/ui/theme/color.rs`: added `inactive_pane_dim_overlay(dim_strength)` (translucent black scrim). The generic `inactive_pane_overlay()` token is left unchanged so modal-dimming and file-upload backgrounds keep their existing look.
- `app/src/settings/pane.rs`: new synced `inactive_pane_dim_strength` setting (`u8`, default 35, clamped 5–80).
- `app/src/pane_group/pane/view/mod.rs`: pane dimming reads the new strength and re-renders when it changes.
- `app/src/settings_view/appearance_page.rs`: new "Inactive pane dim strength" slider in the Panes category, greyed out when dimming is off.

## Linked Issue
Closes #5401
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

Validated with `cargo check -p warp` and `cargo clippy -p warp -p warp_core --tests -- -D warnings` (both clean), plus `./script/format`.

### Screenshots / Videos
_To be added._

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: Inactive pane dimming now actually darkens panes in dark themes (instead of lightening them), and you can tune the dim amount with a new "Inactive pane dim strength" slider under Settings > Appearance > Panes.
-->

_Conversation: https://staging.warp.dev/conversation/c6beefd1-0c81-4f70-a0e1-bd04d7867870_
_Run: https://oz.staging.warp.dev/runs/019eb937-02c2-73ab-8e46-e47ade31ff08_

_This PR was generated with [Oz](https://warp.dev/oz)._
