### PR TITLE
Run the Oz CLI agent and remote-server daemon in a single process

### DIFF
--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -655,6 +655,10 @@ impl AgentDriverRunner {
             let bedrock_role_region = args.bedrock_role_region.clone();
             let has_task_id = args.task_id.is_some();
             let args_harness = args.harness;
+            // Combined single-process mode (`--remote-server-daemon`): the
+            // in-process daemon keeps serving coding clients after the agent
+            // run completes, so the driver must not terminate the process.
+            let keep_process_alive_on_completion = args.remote_server_daemon;
             // `--conversation` path (user-invoked local resume): validate before any task side
             // effects so mismatches fail fast. The `--task-id` path derives its conversation id
             // from the server-side task metadata inside `build_driver_options_and_task`. Both
@@ -772,6 +776,7 @@ impl AgentDriverRunner {
                         output_format,
                         share_requests,
                         task,
+                        keep_process_alive_on_completion,
                     );
                 })
                 .await?;
@@ -1419,6 +1424,10 @@ impl AgentDriverRunner {
     }
 
     /// Create the AgentDriver and start running the task.
+    ///
+    /// When `keep_process_alive_on_completion` is set (combined single-process
+    /// mode with an in-process remote-server daemon), successful completion
+    /// leaves the process running instead of terminating it.
     #[tracing::instrument(skip_all, fields(tags.cloud_agent = true))]
     fn create_and_run_driver(
         ctx: &mut AppContext,
@@ -1426,6 +1435,7 @@ impl AgentDriverRunner {
         output_format: OutputFormat,
         share_requests: Option<Vec<ShareRequest>>,
         task: driver::Task,
+        keep_process_alive_on_completion: bool,
     ) {
         maybe_warn_team_api_key(ctx);
 
@@ -1444,9 +1454,16 @@ impl AgentDriverRunner {
                 tracing::info_span!("AgentDriver::run", tags.cloud_agent = true, ?task.model, ?task.harness);
             let agent_future = driver.run(task, ctx).instrument(span);
 
-            ctx.spawn(agent_future, |_, result, ctx| match result {
+            ctx.spawn(agent_future, move |_, result, ctx| match result {
                 Ok(()) => {
-                    ctx.terminate_app(TerminationMode::ForceTerminate, None);
+                    if keep_process_alive_on_completion {
+                        log::info!(
+                            "Agent run complete; keeping process alive for the \
+                             in-process remote-server daemon"
+                        );
+                    } else {
+                        ctx.terminate_app(TerminationMode::ForceTerminate, None);
+                    }
                 }
                 Err(err) => {
                     report_fatal_error(err.into(), ctx);

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -436,21 +436,6 @@ impl LaunchMode {
         }
     }
 
-    /// Returns `true` if this process also runs the in-process remote-server
-    /// daemon alongside an agent run (`oz agent run --remote-server-daemon`).
-    fn runs_in_process_remote_server_daemon(&self) -> bool {
-        match self {
-            LaunchMode::CommandLine { command, .. } => match command {
-                CliCommand::Agent(AgentCommand::Run(args)) => args.remote_server_daemon,
-                _ => false,
-            },
-            LaunchMode::App { .. }
-            | LaunchMode::Test { .. }
-            | LaunchMode::RemoteServerProxy
-            | LaunchMode::RemoteServerDaemon { .. } => false,
-        }
-    }
-
     fn execution_mode(&self) -> ExecutionMode {
         match self {
             LaunchMode::App { .. } => ExecutionMode::App,
@@ -1607,12 +1592,7 @@ pub(crate) fn initialize_app(
             });
         }
 
-        // The remote-server daemon (standalone, or in-process via
-        // `oz agent run --remote-server-daemon`) emits incremental repo
-        // metadata updates so connected coding clients receive live file
-        // tree changes.
-        let emit_incremental_updates = matches!(launch_mode, LaunchMode::RemoteServerDaemon { .. })
-            || launch_mode.runs_in_process_remote_server_daemon();
+        let emit_incremental_updates = matches!(launch_mode, LaunchMode::RemoteServerDaemon { .. });
         ctx.add_singleton_model(|ctx| {
             let model = if emit_incremental_updates {
                 RepoMetadataModel::new_with_incremental_updates(ctx)

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -436,6 +436,21 @@ impl LaunchMode {
         }
     }
 
+    /// Returns `true` if this process also runs the in-process remote-server
+    /// daemon alongside an agent run (`oz agent run --remote-server-daemon`).
+    fn runs_in_process_remote_server_daemon(&self) -> bool {
+        match self {
+            LaunchMode::CommandLine { command, .. } => match command {
+                CliCommand::Agent(AgentCommand::Run(args)) => args.remote_server_daemon,
+                _ => false,
+            },
+            LaunchMode::App { .. }
+            | LaunchMode::Test { .. }
+            | LaunchMode::RemoteServerProxy
+            | LaunchMode::RemoteServerDaemon { .. } => false,
+        }
+    }
+
     fn execution_mode(&self) -> ExecutionMode {
         match self {
             LaunchMode::App { .. } => ExecutionMode::App,
@@ -715,7 +730,7 @@ pub fn run() -> Result<()> {
                     _ => (false, None),
                 };
 
-                return run_internal(LaunchMode::CommandLine {
+                let result = run_internal(LaunchMode::CommandLine {
                     command: cmd.as_ref().clone(),
                     global_options: GlobalOptions {
                         output_format: args.output_format(),
@@ -725,6 +740,21 @@ pub fn run() -> Result<()> {
                     is_sandboxed,
                     computer_use_override,
                 });
+
+                // Combined single-process mode: remove the in-process daemon's
+                // socket and PID files now that the event loop has exited.
+                #[cfg(unix)]
+                if let warp_cli::CliCommand::Agent(warp_cli::agent::AgentCommand::Run(run_args)) =
+                    cmd.as_ref()
+                {
+                    if run_args.remote_server_daemon {
+                        crate::remote_server::unix::cleanup_daemon_files(
+                            run_args.identity_key.as_deref().unwrap_or_default(),
+                        );
+                    }
+                }
+
+                return result;
             }
             warp_cli::Command::DumpDebugInfo => {
                 return debug_dump::run();
@@ -1577,7 +1607,12 @@ pub(crate) fn initialize_app(
             });
         }
 
-        let emit_incremental_updates = matches!(launch_mode, LaunchMode::RemoteServerDaemon { .. });
+        // The remote-server daemon (standalone, or in-process via
+        // `oz agent run --remote-server-daemon`) emits incremental repo
+        // metadata updates so connected coding clients receive live file
+        // tree changes.
+        let emit_incremental_updates = matches!(launch_mode, LaunchMode::RemoteServerDaemon { .. })
+            || launch_mode.runs_in_process_remote_server_daemon();
         ctx.add_singleton_model(|ctx| {
             let model = if emit_incremental_updates {
                 RepoMetadataModel::new_with_incremental_updates(ctx)
@@ -2616,6 +2651,25 @@ fn launch(ctx: &mut warpui::AppContext, app_state: Option<AppState>, launch_mode
                 if #[cfg(target_family = "wasm")] {
                     panic!("Cannot execute CLI command {command:?} on the web");
                 } else {
+                    // Combined single-process mode: bind the remote-server
+                    // daemon socket alongside the agent run so coding clients
+                    // can connect to this process.
+                    if let CliCommand::Agent(AgentCommand::Run(run_args)) = &command {
+                        if run_args.remote_server_daemon {
+                            cfg_if::cfg_if! {
+                                if #[cfg(unix)] {
+                                    remote_server::unix::launch_in_process_daemon(
+                                        run_args.identity_key.as_deref().unwrap_or_default(),
+                                        ctx,
+                                    );
+                                } else {
+                                    log::error!(
+                                        "--remote-server-daemon is not supported on this platform"
+                                    );
+                                }
+                            }
+                        }
+                    }
                     if let Err(err) = crate::ai::agent_sdk::run(ctx, command.clone(), global_options.clone()) {
                         eprintln!("{err:#}");
                         report_error!(err);

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -244,6 +244,12 @@ pub struct ServerModel {
     /// In-flight host-scoped requests whose response may be delivered on
     /// a different connection if the originating connection disconnects.
     host_scoped_requests: HashMap<RequestId, ConnectionId>,
+    /// Whether this model owns process shutdown. `true` for the standalone
+    /// daemon, which exits after [`GRACE_PERIOD`] with no connections;
+    /// `false` when the daemon runs in-process alongside an `oz agent run`
+    /// (`--remote-server-daemon`), where terminating would also kill the
+    /// co-resident agent run.
+    manages_process_lifetime: bool,
 }
 
 impl Entity for ServerModel {
@@ -254,6 +260,19 @@ impl SingletonEntity for ServerModel {}
 
 impl ServerModel {
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
+        Self::new_with_lifetime_policy(true, ctx)
+    }
+
+    /// Creates a `ServerModel` with an explicit process-lifetime policy.
+    ///
+    /// `manages_process_lifetime` is `true` for the standalone daemon, which
+    /// owns process shutdown via the no-connection grace timer. It is `false`
+    /// when the daemon runs in-process with an `oz agent run`
+    /// (`--remote-server-daemon`), where the agent-run path owns shutdown.
+    pub fn new_with_lifetime_policy(
+        manages_process_lifetime: bool,
+        ctx: &mut ModelContext<Self>,
+    ) -> Self {
         let host_id = uuid::Uuid::new_v4().to_string();
         log::info!(
             "Daemon started: PID={}, host_id={}",
@@ -272,6 +291,7 @@ impl ServerModel {
             buffers: ServerBufferTracker::new(),
             diff_states: ctx.add_model(|_| RemoteDiffStateManager::new()),
             host_scoped_requests: HashMap::new(),
+            manages_process_lifetime,
         };
         // Subscribe to FileModel and RepoMetadataModel events
         // file operation results and repo metadata pushes are forwarded to all
@@ -672,7 +692,6 @@ impl ServerModel {
         let remaining = self.connection_senders.len();
         log::info!("Daemon: connection {conn_id} deregistered — {remaining} active remaining");
         if remaining == 0 {
-            log::info!("Daemon: grace timer started ({GRACE_PERIOD:?})");
             self.start_grace_timer(ctx);
         }
         ctx.notify();
@@ -683,7 +702,16 @@ impl ServerModel {
     /// running its abort handle is cancelled before the new one is stored.
     /// When a proxy connects, `register_connection` aborts the handle,
     /// preventing the shutdown.
+    ///
+    /// No-ops when this model does not manage process lifetime (in-process
+    /// daemon mode), since terminating would also kill the co-resident
+    /// agent run.
     fn start_grace_timer(&mut self, ctx: &mut ModelContext<Self>) {
+        if !self.manages_process_lifetime {
+            log::debug!("Daemon: skipping grace timer (process lifetime managed externally)");
+            return;
+        }
+        log::info!("Daemon: grace timer started ({GRACE_PERIOD:?})");
         if let Some(handle) = self.grace_timer_cancel.take() {
             handle.abort();
         }

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -17,6 +17,12 @@ use crate::code_review::diff_state::DiffMode;
 use crate::remote_server::diff_state_tracker::DiffModelKey;
 
 fn test_model(app: &mut App) -> ServerModel {
+    // Tests default to the in-process policy so no test can accidentally arm
+    // a real grace timer that terminates the test app.
+    test_model_with_lifetime_policy(app, false)
+}
+
+fn test_model_with_lifetime_policy(app: &mut App, manages_process_lifetime: bool) -> ServerModel {
     ServerModel {
         connection_senders: HashMap::new(),
         snapshot_sent_roots_by_connection: HashMap::new(),
@@ -29,6 +35,7 @@ fn test_model(app: &mut App) -> ServerModel {
         buffers: ServerBufferTracker::new(),
         diff_states: app.add_model(|_| RemoteDiffStateManager::new()),
         host_scoped_requests: HashMap::new(),
+        manages_process_lifetime,
     }
 }
 
@@ -265,6 +272,65 @@ fn host_scoped_response_fails_over_when_target_missing() {
             .expect("alternate should receive failover response");
         assert_eq!(received.request_id, request_id.to_string());
         assert!(!model.host_scoped_requests.contains_key(&request_id));
+    });
+}
+
+// ── Process lifetime policy ────────────────────────────────────────
+
+#[test]
+fn grace_timer_starts_when_lifetime_managed() {
+    App::test((), |mut app| async move {
+        let model = test_model_with_lifetime_policy(&mut app, true);
+        let handle = app.add_model(move |_| model);
+
+        handle.update(&mut app, |me, ctx| me.start_grace_timer(ctx));
+
+        let started = handle.read(&app, |me, _| me.grace_timer_cancel.is_some());
+        assert!(started, "standalone daemon should arm the grace timer");
+
+        // Abort the timer so it doesn't outlive the test.
+        handle.update(&mut app, |me, _| {
+            if let Some(timer) = me.grace_timer_cancel.take() {
+                timer.abort();
+            }
+        });
+    });
+}
+
+#[test]
+fn grace_timer_skipped_when_lifetime_not_managed() {
+    App::test((), |mut app| async move {
+        let model = test_model_with_lifetime_policy(&mut app, false);
+        let handle = app.add_model(move |_| model);
+
+        handle.update(&mut app, |me, ctx| me.start_grace_timer(ctx));
+
+        let started = handle.read(&app, |me, _| me.grace_timer_cancel.is_some());
+        assert!(
+            !started,
+            "in-process daemon must not arm the grace timer — it would kill the agent run"
+        );
+    });
+}
+
+#[test]
+fn deregister_last_connection_skips_grace_timer_when_lifetime_not_managed() {
+    App::test((), |mut app| async move {
+        let model = test_model_with_lifetime_policy(&mut app, false);
+        let handle = app.add_model(move |_| model);
+        let conn: ConnectionId = uuid::Uuid::new_v4();
+
+        let (conn_tx, _conn_rx) = async_channel::unbounded();
+        handle.update(&mut app, |me, ctx| {
+            me.register_connection(conn, conn_tx, ctx);
+            me.deregister_connection(conn, ctx);
+        });
+
+        let started = handle.read(&app, |me, _| me.grace_timer_cancel.is_some());
+        assert!(
+            !started,
+            "losing the last connection must not arm the grace timer in in-process mode"
+        );
     });
 }
 

--- a/app/src/remote_server/unix/mod.rs
+++ b/app/src/remote_server/unix/mod.rs
@@ -35,18 +35,43 @@ pub fn run_daemon(identity_key: String) -> anyhow::Result<()> {
     });
 
     // Clean up socket and PID files after the event loop exits.
-    let socket_path = proxy::socket_path(&identity_key);
-    let pid_path = proxy::pid_path(&identity_key);
-    let _ = std::fs::remove_file(&socket_path);
-    let _ = std::fs::remove_file(&pid_path);
+    cleanup_daemon_files(&identity_key);
     log::info!("Daemon exiting");
     result
+}
+
+/// Removes the daemon's socket and PID files for the given identity key.
+/// Called after the event loop exits, in both standalone daemon mode and
+/// combined single-process mode (`oz agent run --remote-server-daemon`).
+pub(crate) fn cleanup_daemon_files(identity_key: &str) {
+    let socket_path = proxy::socket_path(identity_key);
+    let pid_path = proxy::pid_path(identity_key);
+    let _ = std::fs::remove_file(&socket_path);
+    let _ = std::fs::remove_file(&pid_path);
 }
 
 /// Called from `launch()` inside the headless AppBuilder callback.
 /// Binds the Unix domain socket, writes the PID file, spawns the
 /// accept loop, and registers the `ServerModel` singleton.
 pub(crate) fn launch_daemon(identity_key: &str, ctx: &mut warpui::AppContext) {
+    launch_daemon_internal(identity_key, true, ctx);
+}
+
+/// Combined single-process mode (`oz agent run --remote-server-daemon`):
+/// binds the daemon socket alongside the agent run in this process.
+///
+/// The `ServerModel` does not manage process lifetime — the agent-run path
+/// owns shutdown — and daemon startup telemetry is skipped since this
+/// process already reports CLI startup telemetry.
+pub(crate) fn launch_in_process_daemon(identity_key: &str, ctx: &mut warpui::AppContext) {
+    launch_daemon_internal(identity_key, false, ctx);
+}
+
+fn launch_daemon_internal(
+    identity_key: &str,
+    manages_process_lifetime: bool,
+    ctx: &mut warpui::AppContext,
+) {
     let socket_path = proxy::socket_path(identity_key);
     let pid_path = proxy::pid_path(identity_key);
 
@@ -82,15 +107,20 @@ pub(crate) fn launch_daemon(identity_key: &str, ctx: &mut warpui::AppContext) {
     // and `TelemetryCollector` is already running its periodic flush.
     // The flush sends directly to Rudderstack using a baked-in write
     // key — no user auth token is required.
-    let timing_data =
-        warp_core::interval_timer::IntervalTimer::handle(ctx).update(ctx, |timer, _| {
-            timer.mark_interval_end("DAEMON_SOCKET_BOUND");
-            timer.compute_stats()
-        });
-    send_telemetry_from_app_ctx!(
-        TelemetryEvent::RemoteServerDaemonStartup { timing_data },
-        ctx
-    );
+    //
+    // Skipped in combined single-process mode: that process is an agent run
+    // first and reports CLI startup telemetry instead.
+    if manages_process_lifetime {
+        let timing_data =
+            warp_core::interval_timer::IntervalTimer::handle(ctx).update(ctx, |timer, _| {
+                timer.mark_interval_end("DAEMON_SOCKET_BOUND");
+                timer.compute_stats()
+            });
+        send_telemetry_from_app_ctx!(
+            TelemetryEvent::RemoteServerDaemonStartup { timing_data },
+            ctx
+        );
+    }
 
     let _ = std::fs::write(&pid_path, std::process::id().to_string());
 
@@ -129,7 +159,7 @@ pub(crate) fn launch_daemon(identity_key: &str, ctx: &mut warpui::AppContext) {
         })
         .detach();
 
-        ServerModel::new(ctx)
+        ServerModel::new_with_lifetime_policy(manages_process_lifetime, ctx)
     });
 }
 

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -404,6 +404,19 @@ pub struct RunAgentArgs {
         conflicts_with_all = ["prompt", "saved_prompt", "file"]
     )]
     pub skip_initial_turn: bool,
+
+    /// Also run the long-lived remote development server daemon inside this
+    /// process, serving coding features (file tree, buffers, diffs, git ops)
+    /// alongside the agent run. The process stays alive after the agent run
+    /// completes so coding clients can keep using it.
+    #[arg(long = "remote-server-daemon", hide = true)]
+    pub remote_server_daemon: bool,
+
+    /// Identity key partitioning the in-process remote-server daemon's socket
+    /// and data directories. Optional; an absent key maps to the shared
+    /// "empty" identity directory.
+    #[arg(long = "identity-key", hide = true, requires = "remote_server_daemon")]
+    pub identity_key: Option<String>,
 }
 
 impl RunAgentArgs {

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -114,6 +114,72 @@ fn agent_run_rejects_bedrock_role_region_without_role() {
 }
 
 #[test]
+fn agent_run_accepts_remote_server_daemon_flag() {
+    let args = Args::try_parse_from([
+        "warp",
+        "agent",
+        "run",
+        "--prompt",
+        "hello",
+        "--remote-server-daemon",
+        "--identity-key",
+        "test-identity",
+    ])
+    .unwrap();
+
+    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
+        panic!("Expected `warp agent run` command");
+    };
+    let CliCommand::Agent(AgentCommand::Run(run_args)) = boxed_cmd.as_ref() else {
+        panic!("Expected `warp agent run` command");
+    };
+
+    assert!(run_args.remote_server_daemon);
+    assert_eq!(run_args.identity_key.as_deref(), Some("test-identity"));
+}
+
+#[test]
+fn agent_run_accepts_remote_server_daemon_without_identity_key() {
+    let args = Args::try_parse_from([
+        "warp",
+        "agent",
+        "run",
+        "--prompt",
+        "hello",
+        "--remote-server-daemon",
+    ])
+    .unwrap();
+
+    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
+        panic!("Expected `warp agent run` command");
+    };
+    let CliCommand::Agent(AgentCommand::Run(run_args)) = boxed_cmd.as_ref() else {
+        panic!("Expected `warp agent run` command");
+    };
+
+    assert!(run_args.remote_server_daemon);
+    assert_eq!(run_args.identity_key, None);
+}
+
+#[test]
+fn agent_run_rejects_identity_key_without_remote_server_daemon() {
+    let err = Args::try_parse_from([
+        "warp",
+        "agent",
+        "run",
+        "--prompt",
+        "hello",
+        "--identity-key",
+        "test-identity",
+    ])
+    .expect_err("--identity-key must require --remote-server-daemon");
+    assert!(
+        err.to_string().contains("--remote-server-daemon"),
+        "expected error to reference --remote-server-daemon, got: {err}"
+    );
+}
+
+#[test]
 fn model_list_parses() {
     let args = Args::try_parse_from(["warp", "model", "list"]).unwrap();
 


### PR DESCRIPTION
## Description

This PR adds an option to run the Oz CLI agent and remote server daemon in a single process to set up getting coding features in Oz working. After this, I'll make a `warp-server` update to actually use this flag 

<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue

N/A

<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

![image.png](https://app.graphite.com/user-attachments/assets/a842045a-7ace-4c77-b686-76e1d4ac3437.png)

<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->