### PR TITLE
REV-1625 C2: rework onboarding to support no AI on free

### DIFF
--- a/app/src/ai/onboarding.rs
+++ b/app/src/ai/onboarding.rs
@@ -6,7 +6,7 @@ use onboarding::OnboardingAuthState;
 use warp_core::ui::icons::Icon;
 use warpui::{AppContext, SingletonEntity};
 
-use super::llms::{DisableReason, LLMInfo, LLMPreferences};
+use super::llms::{LLMInfo, LLMPreferences};
 use crate::auth::AuthStateProvider;
 use crate::workspaces::user_workspaces::UserWorkspaces;
 
@@ -16,7 +16,6 @@ impl From<&LLMInfo> for OnboardingModelInfo {
             id: llm.id.clone(),
             title: llm.display_name.clone(),
             icon: llm.provider.icon().unwrap_or(Icon::Oz),
-            requires_upgrade: matches!(llm.disable_reason, Some(DisableReason::RequiresUpgrade)),
             is_default: false,
         }
     }

--- a/app/src/auth/login_slide.rs
+++ b/app/src/auth/login_slide.rs
@@ -1,5 +1,8 @@
 use std::cell::Cell;
 
+use onboarding::components::feature_optout_dialog::{
+    render_feature_optout_dialog, FeatureOptOutDialog,
+};
 use onboarding::slides::{layout, slide_content};
 use onboarding::{OnboardingIntention, AI_FEATURES, WARP_DRIVE_FEATURES};
 use pathfinder_color::ColorU;
@@ -12,10 +15,10 @@ use warp_core::ui::Icon;
 use warpui::actions::StandardAction;
 use warpui::clipboard::ClipboardContent;
 use warpui::elements::{
-    Align, Border, CacheOption, ChildAnchor, ClippedScrollStateHandle, ConstrainedBox, Container,
-    CornerRadius, CrossAxisAlignment, Dismiss, Fill, Flex, FormattedTextElement,
-    HighlightedHyperlink, Image, MainAxisAlignment, MainAxisSize, MouseStateHandle,
-    OffsetPositioning, ParentAnchor, ParentElement, ParentOffsetBounds, Radius, Shrinkable, Stack,
+    Align, CacheOption, ChildAnchor, ClippedScrollStateHandle, Container, CornerRadius,
+    CrossAxisAlignment, Dismiss, Fill, Flex, FormattedTextElement, HighlightedHyperlink, Image,
+    MainAxisAlignment, MainAxisSize, MouseStateHandle, OffsetPositioning, ParentAnchor,
+    ParentElement, ParentOffsetBounds, Radius, Shrinkable, Stack,
 };
 use warpui::fonts::Weight;
 use warpui::keymap::{FixedBinding, Keystroke};
@@ -95,6 +98,7 @@ pub enum LoginSlideAction {
     Enter,
     ShowSkipDialog,
     ConfirmSkip,
+    LoginFromSkipDialog,
     DismissDialog,
     DismissOverlayOrBack,
     Back,
@@ -146,6 +150,16 @@ enum LoginStep {
 #[derive(Copy, Clone, Debug)]
 enum LoginSlideOverlay {
     SkipDialog,
+}
+
+/// Why the login slide is being shown, which drives its copy. The Warp-agent
+/// and Terminal+Drive paths require an account (server-side inference / cloud
+/// sync), so skipping is framed as losing that feature; the third-party path
+/// only encourages an account, so it gets softer, skip-friendly wording.
+enum LoginPurpose {
+    WarpAgent,
+    WarpDrive,
+    ThirdParty,
 }
 
 // ---------------------------------------------------------------------------
@@ -414,6 +428,24 @@ impl LoginSlideView {
         ctx.emit(LoginSlideEvent::LoginLaterConfirmed);
     }
 
+    /// Starts the browser sign-up flow. Shared by the Continue button and the
+    /// skip dialog's cancel button.
+    fn start_login(&mut self, ctx: &mut ViewContext<Self>) {
+        send_telemetry_from_ctx!(
+            TelemetryEvent::LoginButtonClicked {
+                source: LoginEventSource::OnboardingSlide,
+            },
+            ctx
+        );
+        self.last_login_failure_reason = None;
+        self.step = LoginStep::BrowserOpen;
+        AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| {
+            let sign_up_url = auth_manager.sign_up_url();
+            ctx.open_url(&sign_up_url);
+        });
+        ctx.notify();
+    }
+
     // ------------------------------------------------------------------
     // Rendering — main layout
     // ------------------------------------------------------------------
@@ -473,16 +505,37 @@ impl LoginSlideView {
         }
     }
 
+    fn login_purpose(&self) -> LoginPurpose {
+        match self.intention {
+            OnboardingIntention::Terminal => LoginPurpose::WarpDrive,
+            OnboardingIntention::AgentDrivenDevelopment => {
+                if self.ai_enabled {
+                    LoginPurpose::WarpAgent
+                } else {
+                    LoginPurpose::ThirdParty
+                }
+            }
+        }
+    }
+
     fn render_select_auth_content(&self, appearance: &Appearance) -> Vec<Box<dyn Element>> {
         let theme = appearance.theme();
         let sub_text_color = internal_colors::text_sub(theme, theme.background().into_solid());
         let ui_builder = appearance.ui_builder();
 
-        let is_terminal = matches!(self.intention, OnboardingIntention::Terminal);
-        let title_text = if is_terminal {
-            "Get started with Warp Drive"
-        } else {
-            "Get started with AI"
+        let (title_text, subtitle_text) = match self.login_purpose() {
+            LoginPurpose::WarpDrive => (
+                "Get started with Warp Drive",
+                "Connect your account to save and share notebooks, workflows, and more across devices.",
+            ),
+            LoginPurpose::WarpAgent => (
+                "Get started with AI",
+                "Connect your account to enable AI-powered planning, coding, and automation.",
+            ),
+            LoginPurpose::ThirdParty => (
+                "Create an account",
+                "Create a Warp account to enable AI-powered planning, coding, and automations.",
+            ),
         };
         let title = FormattedTextElement::from_str(title_text, appearance.ui_font_family(), 36.)
             .with_color(internal_colors::text_main(
@@ -493,11 +546,6 @@ impl LoginSlideView {
             .with_alignment(TextAlignment::Left)
             .finish();
 
-        let subtitle_text = if is_terminal {
-            "Connect your account to save and share notebooks, workflows, and more across devices."
-        } else {
-            "Connect your account to enable AI-powered planning, coding, and automation."
-        };
         let subtitle =
             FormattedTextElement::from_str(subtitle_text, appearance.ui_font_family(), 16.)
                 .with_color(sub_text_color)
@@ -603,10 +651,10 @@ impl LoginSlideView {
         );
 
         let cmd_enter = Keystroke::parse("cmdorctrl-enter").unwrap_or_default();
-        let skip_label = if matches!(self.intention, OnboardingIntention::Terminal) {
-            "Disable Warp Drive"
-        } else {
-            "Disable AI features"
+        let skip_label = match self.login_purpose() {
+            LoginPurpose::WarpDrive => "Disable Warp Drive",
+            LoginPurpose::WarpAgent => "Disable AI features",
+            LoginPurpose::ThirdParty => "Skip for now",
         };
         let skip_button = self.skip_button.render(
             appearance,
@@ -894,22 +942,31 @@ impl LoginSlideView {
     // ------------------------------------------------------------------
 
     fn render_skip_dialog(&self, appearance: &Appearance) -> Box<dyn Element> {
-        let theme = appearance.theme();
-        let dialog_surface = theme.surface_1();
-        let dialog_surface_solid = dialog_surface.into_solid();
-        let border_color = internal_colors::neutral_4(theme);
-
-        let is_terminal = matches!(self.intention, OnboardingIntention::Terminal);
-        let title_text = if is_terminal {
-            "Are you sure you want to disable Warp Drive?"
-        } else {
-            "Are you sure you want to disable AI features?"
+        let (title, body, features, cancel_label): (
+            &'static str,
+            &'static str,
+            &'static [&'static str],
+            &'static str,
+        ) = match self.login_purpose() {
+            LoginPurpose::WarpDrive => (
+                "Are you sure you want to disable Warp Drive?",
+                "Warp Drive lets you save workflows and knowledge across devices and share them with your team. By continuing, you won't have access to the following features:",
+                WARP_DRIVE_FEATURES,
+                "Enable Warp Drive",
+            ),
+            LoginPurpose::WarpAgent => (
+                "Are you sure you want to disable AI features?",
+                "Warp is better with AI. By continuing, you won't have access to any of the following features:",
+                AI_FEATURES,
+                "Enable AI features",
+            ),
+            LoginPurpose::ThirdParty => (
+                "Are you sure you want to skip login?",
+                "Warp is better with an account. By continuing, you won't have access to any of the following features:",
+                AI_FEATURES,
+                "Create an account",
+            ),
         };
-        let title = FormattedTextElement::from_str(title_text, appearance.ui_font_family(), 16.)
-            .with_color(internal_colors::text_main(theme, dialog_surface_solid))
-            .with_weight(Weight::Bold)
-            .with_line_height_ratio(1.25)
-            .finish();
 
         // Close button with ESC keyboard-shortcut badge.
         let escape = Keystroke::parse("escape").unwrap_or_default();
@@ -928,82 +985,14 @@ impl LoginSlideView {
             },
         );
 
-        let title_row = Flex::row()
-            .with_main_axis_size(MainAxisSize::Max)
-            .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
-            .with_cross_axis_alignment(CrossAxisAlignment::Start)
-            .with_child(Shrinkable::new(1., title).finish())
-            .with_child(close_button)
-            .finish();
-
-        let body_text_str = if is_terminal {
-            "Warp Drive lets you save workflows and knowledge across devices and share them with your team. By continuing, you won't have access to the following features:"
-        } else {
-            "Warp is better with AI. By continuing, you won't have access to any of the following features:"
-        };
-        let body_text =
-            FormattedTextElement::from_str(body_text_str, appearance.ui_font_family(), 14.)
-                .with_color(internal_colors::text_main(theme, dialog_surface_solid))
-                .with_weight(Weight::Normal)
-                .with_line_height_ratio(1.2)
-                .finish();
-
-        let feature_row_color: ColorU = theme.foreground().into();
-        let feature_x_fill: ThemeFill = ThemeFill::Solid(theme.ansi_fg_red());
-        let mut feature_list =
-            Flex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
-        let feature_items: &[&str] = if is_terminal {
-            WARP_DRIVE_FEATURES
-        } else {
-            AI_FEATURES
-        };
-        for &item in feature_items {
-            let icon_el = ConstrainedBox::new(Icon::X.to_warpui_icon(feature_x_fill).finish())
-                .with_width(16.)
-                .with_height(16.)
-                .finish();
-            let text_el = FormattedTextElement::from_str(item, appearance.ui_font_family(), 14.)
-                .with_color(feature_row_color)
-                .with_weight(Weight::Normal)
-                .with_alignment(TextAlignment::Left)
-                .with_line_height_ratio(1.0)
-                .finish();
-            let row = Flex::row()
-                .with_cross_axis_alignment(CrossAxisAlignment::Center)
-                .with_child(icon_el)
-                .with_child(Container::new(text_el).with_margin_left(4.).finish())
-                .finish();
-            feature_list = feature_list.with_child(
-                Container::new(row)
-                    .with_padding_top(4.)
-                    .with_padding_bottom(4.)
-                    .finish(),
-            );
-        }
-
-        let body_section = Flex::column()
-            .with_cross_axis_alignment(CrossAxisAlignment::Start)
-            .with_child(body_text)
-            .with_child(
-                Container::new(feature_list.finish())
-                    .with_margin_top(12.)
-                    .finish(),
-            )
-            .finish();
-
-        let cancel_label = if is_terminal {
-            "Enable Warp Drive"
-        } else {
-            "Enable AI features"
-        };
-        let login_button = self.dialog_login_button.render(
+        let cancel_button = self.dialog_login_button.render(
             appearance,
             button::Params {
                 content: button::Content::Label(cancel_label.into()),
                 theme: &button::themes::Naked,
                 options: button::Options {
                     on_click: Some(Box::new(|ctx, _app, _pos| {
-                        ctx.dispatch_typed_action(LoginSlideAction::DismissDialog);
+                        ctx.dispatch_typed_action(LoginSlideAction::LoginFromSkipDialog);
                     })),
                     ..button::Options::default(appearance)
                 },
@@ -1011,7 +1000,7 @@ impl LoginSlideView {
         );
 
         let dialog_enter = Keystroke::parse("enter").unwrap_or_default();
-        let skip_confirm_button = self.dialog_skip_button.render(
+        let confirm_button = self.dialog_skip_button.render(
             appearance,
             button::Params {
                 content: button::Content::Label("Skip for now".into()),
@@ -1026,51 +1015,17 @@ impl LoginSlideView {
             },
         );
 
-        let footer = Container::new(
-            Flex::row()
-                .with_main_axis_size(MainAxisSize::Max)
-                .with_main_axis_alignment(MainAxisAlignment::End)
-                .with_cross_axis_alignment(CrossAxisAlignment::Center)
-                .with_child(login_button)
-                .with_child(
-                    Container::new(skip_confirm_button)
-                        .with_margin_left(8.)
-                        .finish(),
-                )
-                .finish(),
+        render_feature_optout_dialog(
+            appearance,
+            FeatureOptOutDialog {
+                title,
+                body,
+                features,
+                close_button,
+                cancel_button,
+                confirm_button,
+            },
         )
-        .with_border(Border::top(1.).with_border_color(border_color))
-        .with_horizontal_padding(24.)
-        .with_vertical_padding(12.)
-        .finish();
-
-        let dialog = Flex::column()
-            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
-            .with_child(
-                Container::new(title_row)
-                    .with_horizontal_padding(24.)
-                    .with_padding_top(24.)
-                    .with_padding_bottom(12.)
-                    .finish(),
-            )
-            .with_child(
-                Container::new(body_section)
-                    .with_horizontal_padding(24.)
-                    .with_padding_bottom(16.)
-                    .finish(),
-            )
-            .with_child(footer)
-            .finish();
-
-        ConstrainedBox::new(
-            Container::new(dialog)
-                .with_background(dialog_surface)
-                .with_border(Border::all(1.).with_border_color(border_color))
-                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
-                .finish(),
-        )
-        .with_width(460.)
-        .finish()
     }
 }
 
@@ -1137,6 +1092,13 @@ impl View for LoginSlideView {
         // Skip dialog overlay
         if matches!(self.active_overlay, Some(LoginSlideOverlay::SkipDialog)) {
             let dialog = self.render_skip_dialog(appearance);
+            stack.add_child(
+                warpui::elements::Rect::new()
+                    .with_background(
+                        warp_core::ui::theme::Fill::Solid(ColorU::black()).with_opacity(60),
+                    )
+                    .finish(),
+            );
             let centered = Align::new(dialog).finish();
             stack.add_child(
                 Dismiss::new(centered)
@@ -1184,19 +1146,7 @@ impl TypedActionView for LoginSlideView {
                     return;
                 }
                 // Otherwise Enter is log in
-                send_telemetry_from_ctx!(
-                    TelemetryEvent::LoginButtonClicked {
-                        source: LoginEventSource::OnboardingSlide,
-                    },
-                    ctx
-                );
-                self.last_login_failure_reason = None;
-                self.step = LoginStep::BrowserOpen;
-                AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| {
-                    let sign_up_url = auth_manager.sign_up_url();
-                    ctx.open_url(&sign_up_url);
-                });
-                ctx.notify();
+                self.start_login(ctx);
             }
             LoginSlideAction::ShowSkipDialog => {
                 send_telemetry_from_ctx!(
@@ -1211,6 +1161,10 @@ impl TypedActionView for LoginSlideView {
             LoginSlideAction::ConfirmSkip => {
                 self.active_overlay = None;
                 self.handle_login_later(ctx);
+            }
+            LoginSlideAction::LoginFromSkipDialog => {
+                self.active_overlay = None;
+                self.start_login(ctx);
             }
             LoginSlideAction::DismissDialog => {
                 self.active_overlay = None;

--- a/app/src/auth/mod.rs
+++ b/app/src/auth/mod.rs
@@ -9,6 +9,7 @@ mod login_failure_notification;
 pub mod login_slide;
 pub mod needs_sso_link_view;
 pub mod paste_auth_token_modal;
+pub mod provider_keys_modal;
 mod user_properties;
 pub use warp_server_auth::{auth_state, credentials, user, user_uid};
 #[cfg(target_family = "wasm")]
@@ -59,6 +60,7 @@ pub fn init(app: &mut AppContext) {
     auth_override_warning_body::init(app);
     login_slide::init(app);
     paste_auth_token_modal::init(app);
+    provider_keys_modal::init(app);
 }
 
 /// If the app has running processes or dirty objects, we'll show a confirmation modal before logging out.

--- a/app/src/auth/provider_keys_modal.rs
+++ b/app/src/auth/provider_keys_modal.rs
@@ -1,0 +1,355 @@
+use pathfinder_color::ColorU;
+use ui_components::{button, Component as _, Options as _};
+use warp_core::ui::theme::color::internal_colors;
+use warpui::elements::{
+    Align, Border, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Dismiss, Fill,
+    Flex, FormattedTextElement, MainAxisAlignment, MainAxisSize, MouseStateHandle, ParentElement,
+    Radius, Shrinkable, Stack,
+};
+use warpui::fonts::Weight;
+use warpui::keymap::FixedBinding;
+use warpui::text_layout::TextAlignment;
+use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
+use warpui::{
+    AppContext, Element, Entity, FocusContext, SingletonEntity, TypedActionView, View, ViewContext,
+    ViewHandle,
+};
+
+use crate::appearance::Appearance;
+use crate::editor::{
+    EditorView, PropagateAndNoOpNavigationKeys, SingleLineEditorOptions, TextOptions,
+};
+
+const MODAL_WIDTH: f32 = 460.;
+const INPUT_BORDER_RADIUS: Radius = Radius::Pixels(4.);
+
+pub fn init(app: &mut AppContext) {
+    use warpui::keymap::macros::*;
+    app.register_fixed_bindings([FixedBinding::new(
+        "escape",
+        ProviderKeysModalAction::Cancel,
+        id!(ProviderKeysModalView::ui_name()),
+    )]);
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum ProviderKeysModalAction {
+    Save,
+    Cancel,
+}
+
+#[derive(Clone, Debug)]
+pub enum ProviderKeysModalEvent {
+    Cancelled,
+    Save {
+        openai: Option<String>,
+        anthropic: Option<String>,
+        google: Option<String>,
+    },
+}
+
+pub struct ProviderKeysModalView {
+    openai_input: ViewHandle<EditorView>,
+    anthropic_input: ViewHandle<EditorView>,
+    google_input: ViewHandle<EditorView>,
+    cancel_button: button::Button,
+    add_button: button::Button,
+    close_mouse_state: MouseStateHandle,
+}
+
+impl ProviderKeysModalView {
+    pub fn new(
+        openai: Option<String>,
+        anthropic: Option<String>,
+        google: Option<String>,
+        ctx: &mut ViewContext<Self>,
+    ) -> Self {
+        let openai_input = Self::make_key_editor("sk-...", openai, ctx);
+        let anthropic_input = Self::make_key_editor("sk-ant-...", anthropic, ctx);
+        let google_input = Self::make_key_editor("AIzaSy...", google, ctx);
+
+        Self {
+            openai_input,
+            anthropic_input,
+            google_input,
+            cancel_button: button::Button::default(),
+            add_button: button::Button::default(),
+            close_mouse_state: MouseStateHandle::default(),
+        }
+    }
+
+    fn make_key_editor(
+        placeholder: &str,
+        initial: Option<String>,
+        ctx: &mut ViewContext<Self>,
+    ) -> ViewHandle<EditorView> {
+        let placeholder = placeholder.to_string();
+        ctx.add_typed_action_view(move |ctx| {
+            let appearance = Appearance::as_ref(ctx);
+            let text_colors = crate::settings_view::editor_text_colors(appearance);
+            let options = SingleLineEditorOptions {
+                is_password: true,
+                text: TextOptions {
+                    font_family_override: Some(appearance.ui_font_family()),
+                    text_colors_override: Some(text_colors),
+                    ..Default::default()
+                },
+                propagate_and_no_op_vertical_navigation_keys:
+                    PropagateAndNoOpNavigationKeys::Always,
+                ..Default::default()
+            };
+            let mut editor = EditorView::single_line(options, ctx);
+            editor.set_placeholder_text(&placeholder, ctx);
+            if let Some(initial) = initial {
+                editor.set_buffer_text(&initial, ctx);
+            }
+            editor
+        })
+    }
+
+    fn submit(&mut self, ctx: &mut ViewContext<Self>) {
+        let read = |handle: &ViewHandle<EditorView>, ctx: &ViewContext<Self>| {
+            let text = handle.as_ref(ctx).buffer_text(ctx);
+            let trimmed = text.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        };
+        let openai = read(&self.openai_input, ctx);
+        let anthropic = read(&self.anthropic_input, ctx);
+        let google = read(&self.google_input, ctx);
+        ctx.emit(ProviderKeysModalEvent::Save {
+            openai,
+            anthropic,
+            google,
+        });
+    }
+
+    fn render_field(
+        &self,
+        appearance: &Appearance,
+        label: &'static str,
+        editor: ViewHandle<EditorView>,
+    ) -> Box<dyn Element> {
+        let theme = appearance.theme();
+        let dialog_surface_solid = theme.surface_1().into_solid();
+        let input_bg = theme.surface_2();
+        let input_bg_solid = input_bg.into_solid();
+        let input_text_color: ColorU = internal_colors::text_main(theme, input_bg_solid);
+        let border_color = internal_colors::neutral_4(theme);
+
+        let label_el = FormattedTextElement::from_str(label, appearance.ui_font_family(), 12.)
+            .with_color(internal_colors::text_main(theme, dialog_surface_solid))
+            .with_weight(Weight::Normal)
+            .with_alignment(TextAlignment::Left)
+            .with_line_height_ratio(1.0)
+            .finish();
+
+        let input = appearance
+            .ui_builder()
+            .text_input(editor)
+            .with_style(UiComponentStyles {
+                background: Some(input_bg.into()),
+                border_width: Some(1.),
+                border_color: Some(Fill::Solid(border_color)),
+                border_radius: Some(CornerRadius::with_all(INPUT_BORDER_RADIUS)),
+                font_color: Some(input_text_color),
+                padding: Some(Coords {
+                    top: 10.,
+                    bottom: 10.,
+                    left: 16.,
+                    right: 16.,
+                }),
+                ..Default::default()
+            })
+            .build()
+            .finish();
+
+        Flex::column()
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_child(label_el)
+            .with_child(Container::new(input).with_margin_top(8.).finish())
+            .finish()
+    }
+}
+
+impl Entity for ProviderKeysModalView {
+    type Event = ProviderKeysModalEvent;
+}
+
+impl View for ProviderKeysModalView {
+    fn ui_name() -> &'static str {
+        "ProviderKeysModalView"
+    }
+
+    fn on_focus(&mut self, focus_ctx: &FocusContext, ctx: &mut ViewContext<Self>) {
+        if focus_ctx.is_self_focused() {
+            ctx.focus(&self.openai_input);
+            ctx.notify();
+        }
+    }
+
+    fn render(&self, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+        let dialog_surface = theme.surface_1();
+        let dialog_surface_solid = dialog_surface.into_solid();
+        let border_color = internal_colors::neutral_4(theme);
+        let ui_builder = appearance.ui_builder();
+
+        let title = FormattedTextElement::from_str("Add API key", appearance.ui_font_family(), 16.)
+            .with_color(internal_colors::text_main(theme, dialog_surface_solid))
+            .with_weight(Weight::Bold)
+            .with_line_height_ratio(1.25)
+            .finish();
+
+        let close_button = ui_builder
+            .close_button(24., self.close_mouse_state.clone())
+            .build()
+            .on_click(|ctx: &mut warpui::EventContext, _, _| {
+                ctx.dispatch_typed_action(ProviderKeysModalAction::Cancel);
+            })
+            .finish();
+
+        let title_row = Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+            .with_cross_axis_alignment(CrossAxisAlignment::Start)
+            .with_child(Shrinkable::new(1., title).finish())
+            .with_child(close_button)
+            .finish();
+
+        let subtitle = FormattedTextElement::from_str(
+            "Use your own API keys from model providers for Warp Agent.",
+            appearance.ui_font_family(),
+            14.,
+        )
+        .with_color(internal_colors::text_sub(theme, dialog_surface_solid))
+        .with_weight(Weight::Normal)
+        .with_alignment(TextAlignment::Left)
+        .with_line_height_ratio(1.2)
+        .finish();
+
+        let body = Flex::column()
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_child(Container::new(subtitle).with_margin_bottom(16.).finish())
+            .with_child(self.render_field(appearance, "OpenAI API key", self.openai_input.clone()))
+            .with_child(
+                Container::new(self.render_field(
+                    appearance,
+                    "Anthropic API key",
+                    self.anthropic_input.clone(),
+                ))
+                .with_margin_top(16.)
+                .finish(),
+            )
+            .with_child(
+                Container::new(self.render_field(
+                    appearance,
+                    "Google API key",
+                    self.google_input.clone(),
+                ))
+                .with_margin_top(16.)
+                .finish(),
+            )
+            .finish();
+
+        let cancel_button = self.cancel_button.render(
+            appearance,
+            button::Params {
+                content: button::Content::Label("Cancel".into()),
+                theme: &button::themes::Naked,
+                options: button::Options {
+                    on_click: Some(Box::new(|ctx, _app, _pos| {
+                        ctx.dispatch_typed_action(ProviderKeysModalAction::Cancel);
+                    })),
+                    ..button::Options::default(appearance)
+                },
+            },
+        );
+
+        let add_button = self.add_button.render(
+            appearance,
+            button::Params {
+                content: button::Content::Label("Add keys".into()),
+                theme: &button::themes::Primary,
+                options: button::Options {
+                    on_click: Some(Box::new(|ctx, _app, _pos| {
+                        ctx.dispatch_typed_action(ProviderKeysModalAction::Save);
+                    })),
+                    ..button::Options::default(appearance)
+                },
+            },
+        );
+
+        let footer = Container::new(
+            Flex::row()
+                .with_main_axis_size(MainAxisSize::Max)
+                .with_main_axis_alignment(MainAxisAlignment::End)
+                .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                .with_child(cancel_button)
+                .with_child(Container::new(add_button).with_margin_left(8.).finish())
+                .finish(),
+        )
+        .with_border(Border::top(1.).with_border_color(border_color))
+        .with_horizontal_padding(24.)
+        .with_vertical_padding(12.)
+        .finish();
+
+        let dialog = Flex::column()
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_child(
+                Container::new(title_row)
+                    .with_horizontal_padding(24.)
+                    .with_padding_top(24.)
+                    .with_padding_bottom(12.)
+                    .finish(),
+            )
+            .with_child(
+                Container::new(body)
+                    .with_horizontal_padding(24.)
+                    .with_padding_bottom(16.)
+                    .finish(),
+            )
+            .with_child(footer)
+            .finish();
+
+        let modal = ConstrainedBox::new(
+            Container::new(dialog)
+                .with_background(dialog_surface)
+                .with_border(Border::all(1.).with_border_color(border_color))
+                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
+                .finish(),
+        )
+        .with_width(MODAL_WIDTH)
+        .finish();
+
+        let mut stack = Stack::new();
+        stack.add_child(
+            Container::new(warpui::elements::Empty::new().finish())
+                .with_background_color(ColorU::new(0, 0, 0, 179))
+                .finish(),
+        );
+        stack.add_child(
+            Dismiss::new(Align::new(modal).finish())
+                .on_dismiss(|ctx, _app| {
+                    ctx.dispatch_typed_action(ProviderKeysModalAction::Cancel);
+                })
+                .finish(),
+        );
+        stack.finish()
+    }
+}
+
+impl TypedActionView for ProviderKeysModalView {
+    type Action = ProviderKeysModalAction;
+
+    fn handle_action(&mut self, action: &ProviderKeysModalAction, ctx: &mut ViewContext<Self>) {
+        match action {
+            ProviderKeysModalAction::Save => {
+                self.submit(ctx);
+            }
+            ProviderKeysModalAction::Cancel => {
+                ctx.emit(ProviderKeysModalEvent::Cancelled);
+            }
+        }
+    }
+}

--- a/app/src/root_view.rs
+++ b/app/src/root_view.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc::SyncSender;
 use std::sync::Arc;
 
+use ai::api_keys::{ApiKeyManager, ApiKeyManagerEvent};
 use anyhow::Result;
 use cfg_if::cfg_if;
 use itertools::Itertools;
@@ -24,10 +25,11 @@ use warpui::clipboard::ClipboardContent;
 use warpui::elements::{
     Border, ChildAnchor, OffsetPositioning, ParentAnchor, ParentElement, ParentOffsetBounds, Stack,
 };
-use warpui::keymap::{EditableBinding, FixedBinding};
+use warpui::keymap::{EditableBinding, FixedBinding, Keystroke};
 use warpui::platform::{WindowBounds, WindowStyle};
 use warpui::presenter::ChildView;
 use warpui::rendering::OnGPUDeviceSelected;
+use warpui::ui_components::components::UiComponentStyles;
 use warpui::windowing::WindowManager;
 use warpui::{
     id, AddWindowOptions, AppContext, DisplayId, Element, Entity, EntityId, FocusContext,
@@ -50,6 +52,7 @@ use crate::auth::auth_view_modal::{AuthRedirectPayload, AuthView, AuthViewVarian
 use crate::auth::login_slide::{LoginSlideEvent, LoginSlideSource, LoginSlideView};
 use crate::auth::needs_sso_link_view::NeedsSsoLinkView;
 use crate::auth::paste_auth_token_modal::{PasteAuthTokenModalEvent, PasteAuthTokenModalView};
+use crate::auth::provider_keys_modal::{ProviderKeysModalEvent, ProviderKeysModalView};
 #[cfg(target_family = "wasm")]
 use crate::auth::web_handoff::{WebHandoffEvent, WebHandoffView};
 use crate::auth::{AuthStateProvider, LoginFailureReason};
@@ -65,6 +68,7 @@ use crate::features::FeatureFlag;
 use crate::interval_timer::IntervalTimer;
 use crate::launch_configs::launch_config;
 use crate::linear::LinearIssueWork;
+use crate::modal::{Modal, ModalEvent};
 use crate::notebooks::manager::NotebookSource;
 use crate::pane_group::{NewTerminalOptions, PanesLayout};
 use crate::persistence::ModelEvent;
@@ -77,6 +81,7 @@ use crate::settings::cloud_preferences_syncer::{
     CloudPreferencesSyncer, CloudPreferencesSyncerEvent,
 };
 use crate::settings::{apply_onboarding_settings, AISettings, QuakeModeSettings, ThemeSettings};
+use crate::settings_view::custom_inference_modal::{CustomEndpointModal, CustomEndpointModalEvent};
 use crate::settings_view::mcp_servers_page::MCPServersSettingsPage;
 use crate::settings_view::{flags, OpenTeamsSettingsModalArgs, SettingsSection};
 use crate::terminal::available_shells::AvailableShell;
@@ -1621,6 +1626,10 @@ pub struct RootView {
     /// settings to apply after a new user login / initial cloud load completes
     pending_post_auth_onboarding_settings: Option<SelectedSettings>,
     paste_auth_token_modal: Option<ViewHandle<PasteAuthTokenModalView>>,
+    /// BYOK "Add API key" modal.
+    add_api_key_modal: Option<ViewHandle<ProviderKeysModalView>>,
+    /// BYOK "Add custom endpoint" modal — reuses the settings `CustomEndpointModal`.
+    add_custom_endpoint_modal: Option<ViewHandle<Modal<CustomEndpointModal>>>,
 }
 
 impl RootView {
@@ -1721,6 +1730,8 @@ impl RootView {
             pending_tutorial: None,
             pending_post_auth_onboarding_settings: None,
             paste_auth_token_modal: None,
+            add_api_key_modal: None,
+            add_custom_endpoint_modal: None,
         };
 
         match &root_view.auth_onboarding_state {
@@ -1996,6 +2007,30 @@ impl RootView {
             },
         );
 
+        // Gate the AI-access slide's "Next" on having a BYOK key/endpoint and
+        // surface how many are configured: seed from the current `ApiKeyManager`
+        // state and keep it in sync as the user adds keys/endpoints via the
+        // onboarding BYOK modals.
+        let keys = ApiKeyManager::as_ref(ctx).keys();
+        let (key_count, endpoint_count) = (keys.provider_key_count(), keys.custom_endpoints.len());
+        onboarding_view.update(ctx, |view, ctx| {
+            view.set_byok_status(key_count, endpoint_count, ctx);
+        });
+        let onboarding_view_for_keys = onboarding_view.clone();
+        ctx.subscribe_to_model(
+            &ApiKeyManager::handle(ctx),
+            move |_, api_key_manager, event, ctx| {
+                if matches!(event, ApiKeyManagerEvent::KeysUpdated) {
+                    let keys = api_key_manager.as_ref(ctx).keys();
+                    let (key_count, endpoint_count) =
+                        (keys.provider_key_count(), keys.custom_endpoints.len());
+                    onboarding_view_for_keys.update(ctx, |view, ctx| {
+                        view.set_byok_status(key_count, endpoint_count, ctx);
+                    });
+                }
+            },
+        );
+
         ctx.subscribe_to_view(&onboarding_view, |me, _view, event, ctx| {
             me.handle_agent_onboarding_event(event, ctx);
         });
@@ -2240,6 +2275,144 @@ impl RootView {
                 });
                 ctx.focus(&modal);
                 self.paste_auth_token_modal = Some(modal);
+                ctx.notify();
+            }
+            AgentOnboardingEvent::AddApiKeyRequested => {
+                // Pre-fill the modal with any keys the user already saved so they
+                // persist across reopens and can be edited or cleared in place.
+                let existing = ApiKeyManager::as_ref(ctx).keys();
+                let (openai, anthropic, google) = (
+                    existing.openai.clone(),
+                    existing.anthropic.clone(),
+                    existing.google.clone(),
+                );
+                let modal = ctx.add_typed_action_view(move |ctx| {
+                    ProviderKeysModalView::new(openai, anthropic, google, ctx)
+                });
+                ctx.subscribe_to_view(&modal, |me, _, event, ctx| match event {
+                    ProviderKeysModalEvent::Cancelled => {
+                        me.add_api_key_modal = None;
+                        me.focus(ctx);
+                        ctx.notify();
+                    }
+                    ProviderKeysModalEvent::Save {
+                        openai,
+                        anthropic,
+                        google,
+                    } => {
+                        let (openai, anthropic, google) =
+                            (openai.clone(), anthropic.clone(), google.clone());
+                        // Replace rather than merge so an emptied field clears the
+                        // stored key, keeping the saved state and the modal in sync.
+                        ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
+                            manager.set_openai_key(openai, ctx);
+                            manager.set_anthropic_key(anthropic, ctx);
+                            manager.set_google_key(google, ctx);
+                        });
+                        me.add_api_key_modal = None;
+                        me.focus(ctx);
+                        ctx.notify();
+                    }
+                });
+                ctx.focus(&modal);
+                self.add_api_key_modal = Some(modal);
+                ctx.notify();
+            }
+            AgentOnboardingEvent::AddCustomEndpointRequested => {
+                // Pre-fill with the existing endpoint (if any) so its content
+                // persists across reopens and edits in place instead of silently
+                // adding a duplicate. Onboarding exposes a single endpoint; the
+                // settings page manages multiples later.
+                let existing = ApiKeyManager::as_ref(ctx)
+                    .keys()
+                    .custom_endpoints
+                    .first()
+                    .cloned();
+                let is_editing = existing.is_some();
+                let editing_index = is_editing.then_some(0);
+                let title = if is_editing {
+                    "Edit custom endpoint"
+                } else {
+                    "Add custom endpoint"
+                }
+                .to_string();
+                let body = ctx.add_typed_action_view(move |ctx| {
+                    CustomEndpointModal::new(existing.as_ref(), editing_index, ctx)
+                });
+                ctx.subscribe_to_view(&body, |me, _, event, ctx| match event {
+                    CustomEndpointModalEvent::Close => {
+                        me.add_custom_endpoint_modal = None;
+                        me.focus(ctx);
+                        ctx.notify();
+                    }
+                    CustomEndpointModalEvent::AddEndpoint {
+                        name,
+                        url,
+                        api_key,
+                        models,
+                    } => {
+                        let (name, url, api_key, models) =
+                            (name.clone(), url.clone(), api_key.clone(), models.clone());
+                        ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
+                            manager.add_custom_endpoint(name, url, api_key, models, ctx);
+                        });
+                        me.add_custom_endpoint_modal = None;
+                        me.focus(ctx);
+                        ctx.notify();
+                    }
+                    CustomEndpointModalEvent::SaveEndpoint {
+                        index,
+                        name,
+                        url,
+                        api_key,
+                        models,
+                    } => {
+                        let (index, name, url, api_key, models) = (
+                            *index,
+                            name.clone(),
+                            url.clone(),
+                            api_key.clone(),
+                            models.clone(),
+                        );
+                        ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
+                            manager.save_custom_endpoint(index, name, url, api_key, models, ctx);
+                        });
+                        me.add_custom_endpoint_modal = None;
+                        me.focus(ctx);
+                        ctx.notify();
+                    }
+                    CustomEndpointModalEvent::RemoveEndpoint { index } => {
+                        let index = *index;
+                        ApiKeyManager::handle(ctx).update(ctx, |manager, ctx| {
+                            manager.remove_custom_endpoint(index, ctx);
+                        });
+                        me.add_custom_endpoint_modal = None;
+                        me.focus(ctx);
+                        ctx.notify();
+                    }
+                });
+
+                let body_for_modal = body.clone();
+                let modal = ctx.add_typed_action_view(move |ctx| {
+                    Modal::new(Some(title), body_for_modal, ctx)
+                        .with_modal_style(UiComponentStyles {
+                            width: Some(560.),
+                            height: Some(600.),
+                            ..Default::default()
+                        })
+                        .with_background_opacity(100)
+                        .with_dismiss_on_click()
+                        .with_dismiss_keystroke(Keystroke::parse("escape").unwrap_or_default())
+                });
+                ctx.subscribe_to_view(&modal, |me, _, event, ctx| match event {
+                    ModalEvent::Close => {
+                        me.add_custom_endpoint_modal = None;
+                        me.focus(ctx);
+                        ctx.notify();
+                    }
+                });
+                body.update(ctx, |body, ctx| body.on_open(ctx));
+                self.add_custom_endpoint_modal = Some(modal);
                 ctx.notify();
             }
             AgentOnboardingEvent::PrivacySettingsFromTerminalThemeSlideRequested => {
@@ -3235,7 +3408,10 @@ impl View for RootView {
     fn on_focus(&mut self, focus_ctx: &FocusContext, ctx: &mut ViewContext<Self>) {
         if focus_ctx.is_self_focused() {
             self.focus(ctx);
-        } else if self.paste_auth_token_modal.is_some() {
+        } else if self.paste_auth_token_modal.is_some()
+            || self.add_api_key_modal.is_some()
+            || self.add_custom_endpoint_modal.is_some()
+        {
             // Modal is open — focus belongs to the editor inside it.
         } else if matches!(
             self.auth_onboarding_state,
@@ -3281,6 +3457,14 @@ impl View for RootView {
         stack.add_child(child);
 
         if let Some(modal) = &self.paste_auth_token_modal {
+            stack.add_child(ChildView::new(modal).finish());
+        }
+
+        if let Some(modal) = &self.add_api_key_modal {
+            stack.add_child(ChildView::new(modal).finish());
+        }
+
+        if let Some(modal) = &self.add_custom_endpoint_modal {
             stack.add_child(ChildView::new(modal).finish());
         }
 

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -81,7 +81,7 @@ mod billing_and_usage_dispatch;
 mod billing_and_usage_page;
 mod billing_and_usage_page_v2;
 mod code_page;
-mod custom_inference_modal;
+pub(crate) mod custom_inference_modal;
 mod delete_environment_confirmation_dialog;
 mod directory_color_add_picker;
 pub(crate) mod environments_page;

--- a/crates/ai/src/api_keys.rs
+++ b/crates/ai/src/api_keys.rs
@@ -86,6 +86,21 @@ impl ApiKeys {
     pub fn has_custom_endpoints(&self) -> bool {
         !self.custom_endpoints.is_empty()
     }
+
+    /// Number of single-provider API keys currently configured (OpenAI,
+    /// Anthropic, Google, OpenRouter). Custom endpoints are counted separately
+    /// via `custom_endpoints`.
+    pub fn provider_key_count(&self) -> usize {
+        [
+            &self.openai,
+            &self.anthropic,
+            &self.google,
+            &self.open_router,
+        ]
+        .into_iter()
+        .filter(|key| key.as_deref().is_some_and(|v| !v.trim().is_empty()))
+        .count()
+    }
 }
 
 /// OAuth tokens for a connected xAI / Grok subscription (e.g. SuperGrok).

--- a/crates/ai/src/api_keys_tests.rs
+++ b/crates/ai/src/api_keys_tests.rs
@@ -216,6 +216,39 @@ fn has_custom_endpoints_true_when_present() {
     assert!(keys.has_custom_endpoints());
 }
 
+// ── provider_key_count ─────────────────────────────────────────
+
+#[test]
+fn provider_key_count_zero_when_empty() {
+    assert_eq!(ApiKeys::default().provider_key_count(), 0);
+}
+
+#[test]
+fn provider_key_count_counts_each_provider_key() {
+    let keys = ApiKeys {
+        openai: Some("sk-o".into()),
+        anthropic: Some("sk-a".into()),
+        google: Some("AIza".into()),
+        open_router: Some("sk-or".into()),
+        custom_endpoints: vec![],
+    };
+    assert_eq!(keys.provider_key_count(), 4);
+}
+
+#[test]
+fn provider_key_count_ignores_blank_keys_and_endpoints() {
+    let keys = ApiKeys {
+        openai: Some("sk-o".into()),
+        anthropic: Some("   ".into()),
+        google: None,
+        open_router: None,
+        custom_endpoints: vec![endpoint("ep", "https://a.io", "k", &[("m", None)])],
+    };
+    // Only the non-blank OpenAI key counts; the whitespace Anthropic key and the
+    // custom endpoint are excluded.
+    assert_eq!(keys.provider_key_count(), 1);
+}
+
 // ── custom_model_providers_for_request ──────────────────────────
 
 #[test]

--- a/crates/onboarding/Cargo.toml
+++ b/crates/onboarding/Cargo.toml
@@ -33,3 +33,6 @@ warp_core = { workspace = true }
 warpui.workspace = true
 warpui_core.workspace = true
 warp_logging.workspace = true
+
+[dev-dependencies]
+warp_core = { workspace = true, features = ["test-util"] }

--- a/crates/onboarding/src/agent_onboarding_view.rs
+++ b/crates/onboarding/src/agent_onboarding_view.rs
@@ -9,30 +9,39 @@ use warpui_core::image_cache::ImageType;
 use warpui_core::windowing::state::{ApplicationStage, StateEvent};
 use warpui_core::windowing::WindowManager;
 
+use crate::components::feature_optout_dialog::{render_feature_optout_dialog, FeatureOptOutDialog};
 use crate::model::{
     OnboardingAuthState, OnboardingStateEvent, OnboardingStateModel, OnboardingStep,
     SelectedSettings,
 };
 use crate::slides::{
-    AgentSlide, AgentSlideEvent, CustomizeUISlide, IntentionSlide, IntroSlide, IntroSlideEvent,
-    OnboardingModelInfo, OnboardingSlide, ProjectSlide, ThemePickerSlide, ThemePickerSlideEvent,
-    ThirdPartySlide,
+    AgentSlide, AiAccessSlide, AiAccessSlideEvent, AiSetupSlide, CustomizeUISlide, IntentionSlide,
+    IntroSlide, IntroSlideEvent, OnboardingModelInfo, OnboardingSlide, ProjectSlide,
+    ThemePickerSlide, ThemePickerSlideEvent, ThirdPartySlide,
 };
 use crate::telemetry::OnboardingEvent;
+use crate::AI_FEATURES;
 
 const APP_BECAME_ACTIVE_DEBOUNCE: Duration = Duration::from_secs(15);
 
+const PLAN_ACTIVATED_TOAST_DURATION: Duration = Duration::from_secs(5);
+
+use pathfinder_color::ColorU;
 use pathfinder_geometry::vector::vec2f;
 use ui_components::{button, Component as _, Options as _};
 use warp_core::ui::appearance::Appearance;
-use warp_core::ui::theme::WarpTheme;
+use warp_core::ui::theme::{Fill, WarpTheme};
+use warp_core::ui::Icon;
 use warpui_core::elements::{
-    CacheOption, ChildAnchor, Container, Empty, Image, OffsetPositioning, ParentAnchor,
-    ParentElement, ParentOffsetBounds, Rect, Shrinkable, Stack,
+    Align, CacheOption, ChildAnchor, ConstrainedBox, Container, CrossAxisAlignment, Dismiss, Empty,
+    Flex, Image, MainAxisAlignment, MainAxisSize, MouseStateHandle, OffsetPositioning,
+    ParentAnchor, ParentElement, ParentOffsetBounds, Rect, Shrinkable, Stack,
 };
+use warpui_core::fonts::Weight;
 use warpui_core::keymap::macros::*;
 use warpui_core::keymap::{FixedBinding, Keystroke};
 use warpui_core::presenter::ChildView;
+use warpui_core::ui_components::components::{UiComponent as _, UiComponentStyles};
 use warpui_core::{
     AppContext, Element, Entity, ModelHandle, SingletonEntity as _, TypedActionView, View,
     ViewContext, ViewHandle,
@@ -58,6 +67,8 @@ pub enum AgentOnboardingEvent {
     UpgradeRequested,
     UpgradeCopyUrlRequested,
     UpgradePasteTokenFromClipboardRequested,
+    AddApiKeyRequested,
+    AddCustomEndpointRequested,
     /// Emitted when the app regains focus (e.g. user returns from the browser).
     /// The parent should refresh any stale data: available models, workspace/billing metadata, etc.
     AppBecameActive,
@@ -68,13 +79,21 @@ pub struct AgentOnboardingView {
     intro_slide: ViewHandle<IntroSlide>,
     theme_picker_slide: ViewHandle<ThemePickerSlide>,
     intention_slide: ViewHandle<IntentionSlide>,
+    ai_setup_slide: ViewHandle<AiSetupSlide>,
     customize_slide: ViewHandle<CustomizeUISlide>,
     agent_slide: ViewHandle<AgentSlide>,
+    ai_access_slide: ViewHandle<AiAccessSlide>,
     third_party_slide: ViewHandle<ThirdPartySlide>,
     project_slide: ViewHandle<ProjectSlide>,
     skippable: bool,
     close_button: button::Button,
+    no_ai_confirm_button: button::Button,
+    no_ai_cancel_button: button::Button,
+    no_ai_close_button: button::Button,
     last_model_refresh: Option<Instant>,
+    show_plan_activated_toast: bool,
+    last_auth_state: OnboardingAuthState,
+    plan_activated_close_mouse_state: MouseStateHandle,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -87,6 +106,10 @@ pub enum AgentOnboardingAction {
     EnterKey,
     CmdOrCtrlEnterKey,
     Escape,
+    NoAiConfirm,
+    NoAiCancel,
+    NoAiDismiss,
+    DismissPlanActivatedToast,
 }
 
 fn dispatch_onboarding_action_to_slide<V: OnboardingSlide>(
@@ -103,6 +126,11 @@ fn dispatch_onboarding_action_to_slide<V: OnboardingSlide>(
         AgentOnboardingAction::EnterKey => slide.on_enter(ctx),
         AgentOnboardingAction::CmdOrCtrlEnterKey => slide.on_cmd_or_ctrl_enter(ctx),
         AgentOnboardingAction::Escape => slide.on_escape(ctx),
+        // Parent-level actions are handled by the parent view, never routed to a slide.
+        AgentOnboardingAction::NoAiConfirm
+        | AgentOnboardingAction::NoAiCancel
+        | AgentOnboardingAction::NoAiDismiss
+        | AgentOnboardingAction::DismissPlanActivatedToast => {}
     }
 }
 
@@ -142,7 +170,13 @@ impl AgentOnboardingView {
                 OnboardingStateEvent::UpgradeRequested => {
                     ctx.emit(AgentOnboardingEvent::UpgradeRequested);
                 }
-                _ => {}
+                OnboardingStateEvent::AuthStateChanged => {
+                    me.handle_auth_state_changed(ctx);
+                }
+                OnboardingStateEvent::ModelsUpdated
+                | OnboardingStateEvent::SelectedSlideChanged
+                | OnboardingStateEvent::IntentionChanged
+                | OnboardingStateEvent::NoAiConfirmationChanged => {}
             }
         });
 
@@ -170,6 +204,11 @@ impl AgentOnboardingView {
             ctx.add_typed_action_view(move |_| IntentionSlide::new(onboarding_state))
         };
 
+        let ai_setup_slide = {
+            let onboarding_state = onboarding_state.clone();
+            ctx.add_typed_action_view(move |_| AiSetupSlide::new(onboarding_state))
+        };
+
         let customize_slide = {
             let onboarding_state = onboarding_state.clone();
             ctx.add_typed_action_view(move |ctx| CustomizeUISlide::new(onboarding_state, ctx))
@@ -184,11 +223,22 @@ impl AgentOnboardingView {
             ctx.add_typed_action_view(move |ctx| AgentSlide::new(onboarding_state, ctx))
         };
 
-        ctx.subscribe_to_view(&agent_slide, |_me, _view, event, ctx| match event {
-            AgentSlideEvent::CopyUpgradeUrlRequested => {
+        let ai_access_slide = {
+            let onboarding_state = onboarding_state.clone();
+            ctx.add_typed_action_view(move |_| AiAccessSlide::new(onboarding_state))
+        };
+
+        ctx.subscribe_to_view(&ai_access_slide, |_me, _view, event, ctx| match event {
+            AiAccessSlideEvent::AddApiKeyRequested => {
+                ctx.emit(AgentOnboardingEvent::AddApiKeyRequested);
+            }
+            AiAccessSlideEvent::AddCustomEndpointRequested => {
+                ctx.emit(AgentOnboardingEvent::AddCustomEndpointRequested);
+            }
+            AiAccessSlideEvent::CopyUpgradeUrlRequested => {
                 ctx.emit(AgentOnboardingEvent::UpgradeCopyUrlRequested);
             }
-            AgentSlideEvent::PasteAuthTokenFromClipboardRequested => {
+            AiAccessSlideEvent::PasteAuthTokenFromClipboardRequested => {
                 ctx.emit(AgentOnboardingEvent::UpgradePasteTokenFromClipboardRequested);
             }
         });
@@ -227,13 +277,21 @@ impl AgentOnboardingView {
             intro_slide,
             theme_picker_slide,
             intention_slide,
+            ai_setup_slide,
             customize_slide,
             agent_slide,
+            ai_access_slide,
             third_party_slide,
             project_slide,
             skippable,
             close_button: button::Button::default(),
+            no_ai_confirm_button: button::Button::default(),
+            no_ai_cancel_button: button::Button::default(),
+            no_ai_close_button: button::Button::default(),
             last_model_refresh: None,
+            show_plan_activated_toast: false,
+            last_auth_state: auth_state,
+            plan_activated_close_mouse_state: MouseStateHandle::default(),
         }
     }
 
@@ -262,6 +320,20 @@ impl AgentOnboardingView {
             state.set_auth_state(auth_state, ctx);
         });
         ctx.notify();
+    }
+
+    /// Updates how many BYOK provider keys and custom endpoints the user has
+    /// configured. This drives the AI-access slide's "connected" status line and
+    /// gates "Next" on the bring-your-own path.
+    pub fn set_byok_status(
+        &mut self,
+        key_count: usize,
+        endpoint_count: usize,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.ai_access_slide.update(ctx, |slide, ctx| {
+            slide.set_byok_status(key_count, endpoint_count, ctx);
+        });
     }
 
     /// The current `use_vertical_tabs` value on the onboarding UI customization.
@@ -305,6 +377,12 @@ impl AgentOnboardingView {
         for path in IntentionSlide::VISUAL_IMAGE_PATHS {
             asset_cache.load_asset::<ImageType>(AssetSource::Bundled { path });
         }
+        for path in AiSetupSlide::VISUAL_IMAGE_PATHS {
+            asset_cache.load_asset::<ImageType>(AssetSource::Bundled { path });
+        }
+        for path in AiAccessSlide::VISUAL_IMAGE_PATHS {
+            asset_cache.load_asset::<ImageType>(AssetSource::Bundled { path });
+        }
         for path in CustomizeUISlide::VISUAL_IMAGE_PATHS {
             asset_cache.load_asset::<ImageType>(AssetSource::Bundled { path });
         }
@@ -318,9 +396,167 @@ impl AgentOnboardingView {
         // which are already in CustomizeUISlide::VISUAL_IMAGE_PATHS.
     }
 
+    fn render_no_ai_dialog(&self, appearance: &Appearance) -> Box<dyn Element> {
+        let escape = Keystroke::parse("escape").unwrap_or_default();
+        let close_button = self.no_ai_close_button.render(
+            appearance,
+            button::Params {
+                content: button::Content::Icon(Icon::X),
+                theme: &button::themes::Naked,
+                options: button::Options {
+                    keystroke: Some(escape),
+                    on_click: Some(Box::new(|ctx, _app, _pos| {
+                        ctx.dispatch_typed_action(AgentOnboardingAction::NoAiDismiss);
+                    })),
+                    ..button::Options::default(appearance)
+                },
+            },
+        );
+
+        let cancel_button = self.no_ai_cancel_button.render(
+            appearance,
+            button::Params {
+                content: button::Content::Label("Give me AI features".into()),
+                theme: &button::themes::Naked,
+                options: button::Options {
+                    on_click: Some(Box::new(|ctx, _app, _pos| {
+                        ctx.dispatch_typed_action(AgentOnboardingAction::NoAiCancel);
+                    })),
+                    ..button::Options::default(appearance)
+                },
+            },
+        );
+
+        let enter = Keystroke::parse("enter").unwrap_or_default();
+        let confirm_button = self.no_ai_confirm_button.render(
+            appearance,
+            button::Params {
+                content: button::Content::Label("I don't want AI".into()),
+                theme: &button::themes::Primary,
+                options: button::Options {
+                    keystroke: Some(enter),
+                    on_click: Some(Box::new(|ctx, _app, _pos| {
+                        ctx.dispatch_typed_action(AgentOnboardingAction::NoAiConfirm);
+                    })),
+                    ..button::Options::default(appearance)
+                },
+            },
+        );
+
+        render_feature_optout_dialog(
+            appearance,
+            FeatureOptOutDialog {
+                title: "Are you sure you don't want AI?",
+                body: "Warp is better with AI. By continuing, you won't have access to any of the \
+                       following features:",
+                features: AI_FEATURES,
+                close_button,
+                cancel_button,
+                confirm_button,
+            },
+        )
+    }
+
     fn handle_onboarding_completed(&mut self, ctx: &mut ViewContext<Self>) {
         let settings = self.onboarding_state.as_ref(ctx).settings();
         ctx.emit(AgentOnboardingEvent::OnboardingCompleted(settings));
+    }
+
+    /// Reacts to a billing/auth transition. When the user becomes a paying user
+    /// we show a success toast; if they're still on the AI-access slide we also
+    /// advance them, since selecting a plan was the remaining action there.
+    fn handle_auth_state_changed(&mut self, ctx: &mut ViewContext<Self>) {
+        let new_state = self.onboarding_state.as_ref(ctx).auth_state();
+        let became_paying = new_state == OnboardingAuthState::PayingUser
+            && self.last_auth_state != OnboardingAuthState::PayingUser;
+        self.last_auth_state = new_state;
+        if !became_paying {
+            return;
+        }
+
+        let on_ai_access = self.onboarding_state.as_ref(ctx).step() == OnboardingStep::AiAccess;
+        if on_ai_access {
+            self.onboarding_state
+                .update(ctx, |model, ctx| model.next(ctx));
+        }
+
+        self.show_plan_activated_toast = true;
+        let _ = ctx.spawn(
+            warpui_core::r#async::Timer::after(PLAN_ACTIVATED_TOAST_DURATION),
+            |me: &mut Self, _, ctx| {
+                if me.show_plan_activated_toast {
+                    me.show_plan_activated_toast = false;
+                    ctx.notify();
+                }
+            },
+        );
+    }
+
+    /// Green success pill shown after billing succeeds. Hosted at the view level
+    /// (not the slide) so it survives the auto-advance off the AI-access slide.
+    fn render_plan_activated_toast(&self, appearance: &Appearance) -> Box<dyn Element> {
+        const TOAST_MIN_HEIGHT: f32 = 40.;
+        const ICON_SIZE: f32 = 14.;
+        const CLOSE_SIZE: f32 = 16.;
+        const FONT_SIZE: f32 = 12.;
+
+        let theme = appearance.theme();
+        let toast_bg: Fill = theme.ansi_fg_green().into();
+        let text_color: ColorU = theme.font_color(toast_bg.into_solid()).into();
+        let ui_builder = appearance.ui_builder();
+
+        let check_icon = ConstrainedBox::new(Box::new(
+            Icon::CheckSkinny.to_warpui_icon(Fill::Solid(text_color)),
+        ))
+        .with_width(ICON_SIZE)
+        .with_height(ICON_SIZE)
+        .finish();
+
+        let text = ui_builder
+            .span("Plan successfully activated!")
+            .with_style(UiComponentStyles {
+                font_color: Some(text_color),
+                font_size: Some(FONT_SIZE),
+                font_weight: Some(Weight::Medium),
+                ..Default::default()
+            })
+            .build()
+            .finish();
+
+        let close_button = ui_builder
+            .close_button(CLOSE_SIZE, self.plan_activated_close_mouse_state.clone())
+            .with_style(UiComponentStyles {
+                font_color: Some(text_color),
+                ..Default::default()
+            })
+            .build()
+            .on_click(|ctx, _, _| {
+                ctx.dispatch_typed_action(AgentOnboardingAction::DismissPlanActivatedToast);
+            })
+            .finish();
+
+        let left = Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(check_icon)
+            .with_child(Container::new(text).with_margin_left(8.).finish())
+            .finish();
+
+        let row = Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(left)
+            .with_child(close_button)
+            .finish();
+
+        ConstrainedBox::new(
+            Container::new(row)
+                .with_background(toast_bg)
+                .with_horizontal_padding(16.)
+                .finish(),
+        )
+        .with_min_height(TOAST_MIN_HEIGHT)
+        .finish()
     }
 
     fn handle_theme_picker_slide_event(
@@ -391,8 +627,10 @@ impl View for AgentOnboardingView {
             OnboardingStep::Intro => ChildView::new(&self.intro_slide).finish(),
             OnboardingStep::ThemePicker => ChildView::new(&self.theme_picker_slide).finish(),
             OnboardingStep::Intention => ChildView::new(&self.intention_slide).finish(),
+            OnboardingStep::AiSetup => ChildView::new(&self.ai_setup_slide).finish(),
             OnboardingStep::Customize => ChildView::new(&self.customize_slide).finish(),
             OnboardingStep::Agent => ChildView::new(&self.agent_slide).finish(),
+            OnboardingStep::AiAccess => ChildView::new(&self.ai_access_slide).finish(),
             OnboardingStep::ThirdParty => ChildView::new(&self.third_party_slide).finish(),
             OnboardingStep::Project => ChildView::new(&self.project_slide).finish(),
         };
@@ -429,6 +667,35 @@ impl View for AgentOnboardingView {
             );
         }
 
+        if self
+            .onboarding_state
+            .as_ref(app)
+            .no_ai_confirmation()
+            .is_some()
+        {
+            let dialog = self.render_no_ai_dialog(appearance);
+            stack.add_child(
+                Rect::new()
+                    .with_background(Fill::Solid(ColorU::black()).with_opacity(60))
+                    .finish(),
+            );
+            stack.add_child(
+                Dismiss::new(Align::new(dialog).finish())
+                    .on_dismiss(|ctx, _app| {
+                        ctx.dispatch_typed_action(AgentOnboardingAction::NoAiDismiss);
+                    })
+                    .finish(),
+            );
+        }
+
+        if self.show_plan_activated_toast {
+            stack.add_child(
+                Align::new(self.render_plan_activated_toast(appearance))
+                    .bottom_center()
+                    .finish(),
+            );
+        }
+
         stack.finish()
     }
 }
@@ -437,8 +704,38 @@ impl TypedActionView for AgentOnboardingView {
     type Action = AgentOnboardingAction;
 
     fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        if self
+            .onboarding_state
+            .as_ref(ctx)
+            .no_ai_confirmation()
+            .is_some()
+        {
+            match action {
+                AgentOnboardingAction::NoAiConfirm | AgentOnboardingAction::EnterKey => {
+                    self.onboarding_state
+                        .update(ctx, |model, ctx| model.confirm_no_ai(ctx));
+                }
+                AgentOnboardingAction::NoAiCancel => {
+                    self.onboarding_state
+                        .update(ctx, |model, ctx| model.cancel_no_ai(ctx));
+                }
+                AgentOnboardingAction::NoAiDismiss | AgentOnboardingAction::Escape => {
+                    self.onboarding_state
+                        .update(ctx, |model, ctx| model.dismiss_no_ai(ctx));
+                }
+                _ => {}
+            }
+            return;
+        }
+
         if matches!(action, AgentOnboardingAction::Escape) && self.skippable {
             ctx.emit(AgentOnboardingEvent::OnboardingSkipped);
+            return;
+        }
+
+        if matches!(action, AgentOnboardingAction::DismissPlanActivatedToast) {
+            self.show_plan_activated_toast = false;
+            ctx.notify();
             return;
         }
 
@@ -454,10 +751,16 @@ impl TypedActionView for AgentOnboardingView {
             OnboardingStep::Intention => self.intention_slide.update(ctx, |slide, ctx| {
                 dispatch_onboarding_action_to_slide(slide, *action, ctx)
             }),
+            OnboardingStep::AiSetup => self.ai_setup_slide.update(ctx, |slide, ctx| {
+                dispatch_onboarding_action_to_slide(slide, *action, ctx)
+            }),
             OnboardingStep::Customize => self.customize_slide.update(ctx, |slide, ctx| {
                 dispatch_onboarding_action_to_slide(slide, *action, ctx)
             }),
             OnboardingStep::Agent => self.agent_slide.update(ctx, |slide, ctx| {
+                dispatch_onboarding_action_to_slide(slide, *action, ctx)
+            }),
+            OnboardingStep::AiAccess => self.ai_access_slide.update(ctx, |slide, ctx| {
                 dispatch_onboarding_action_to_slide(slide, *action, ctx)
             }),
             OnboardingStep::ThirdParty => self.third_party_slide.update(ctx, |slide, ctx| {

--- a/crates/onboarding/src/bin/main.rs
+++ b/crates/onboarding/src/bin/main.rs
@@ -90,26 +90,23 @@ impl OnboardingMainView {
                 id: LLMId::from("auto"),
                 title: "Auto".to_string(),
                 icon: Icon::Oz,
-                requires_upgrade: false,
                 is_default: true,
             },
             OnboardingModelInfo {
                 id: LLMId::from("claude-sonnet"),
                 title: "Claude Sonnet".to_string(),
                 icon: Icon::ClaudeLogo,
-                requires_upgrade: false,
                 is_default: false,
             },
             OnboardingModelInfo {
                 id: LLMId::from("gpt-4o"),
                 title: "GPT-4o".to_string(),
                 icon: Icon::OpenAILogo,
-                requires_upgrade: true,
                 is_default: false,
             },
         ];
         let onboarding_view = ctx.add_typed_action_view(move |ctx| {
-            // agent_modality_enabled and no_ai_experiment are false for demo purposes
+            // agent_modality_enabled is false for demo purposes
             AgentOnboardingView::new(
                 themes.clone(),
                 true,
@@ -117,8 +114,6 @@ impl OnboardingMainView {
                 default_model_id.clone(),
                 false,
                 false,
-                false,
-                None,
                 onboarding::OnboardingAuthState::LoggedOut,
                 ctx,
             )
@@ -173,6 +168,8 @@ impl OnboardingMainView {
             | AgentOnboardingEvent::UpgradePasteTokenFromClipboardRequested
             | AgentOnboardingEvent::LoginFromWelcomeRequested
             | AgentOnboardingEvent::PrivacySettingsFromTerminalThemeSlideRequested
+            | AgentOnboardingEvent::AddApiKeyRequested
+            | AgentOnboardingEvent::AddCustomEndpointRequested
             | AgentOnboardingEvent::AppBecameActive => {
                 // No-op in the standalone demo binary
             }

--- a/crates/onboarding/src/components/feature_optout_dialog.rs
+++ b/crates/onboarding/src/components/feature_optout_dialog.rs
@@ -1,0 +1,135 @@
+use pathfinder_color::ColorU;
+use warp_core::ui::appearance::Appearance;
+use warp_core::ui::theme::color::internal_colors;
+use warp_core::ui::theme::Fill;
+use warp_core::ui::Icon;
+use warpui_core::elements::{
+    Border, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Flex,
+    FormattedTextElement, MainAxisAlignment, MainAxisSize, ParentElement, Radius, Shrinkable,
+};
+use warpui_core::fonts::Weight;
+use warpui_core::text_layout::TextAlignment;
+use warpui_core::Element;
+
+/// Content for a "you'll lose these features" opt-out confirmation dialog.
+pub struct FeatureOptOutDialog {
+    pub title: &'static str,
+    pub body: &'static str,
+    pub features: &'static [&'static str],
+    pub close_button: Box<dyn Element>,
+    pub cancel_button: Box<dyn Element>,
+    pub confirm_button: Box<dyn Element>,
+}
+
+pub fn render_feature_optout_dialog(
+    appearance: &Appearance,
+    dialog: FeatureOptOutDialog,
+) -> Box<dyn Element> {
+    let theme = appearance.theme();
+    let dialog_surface = theme.surface_1();
+    let dialog_surface_solid = dialog_surface.into_solid();
+    let border_color = internal_colors::neutral_4(theme);
+
+    let title = FormattedTextElement::from_str(dialog.title, appearance.ui_font_family(), 16.)
+        .with_color(internal_colors::text_main(theme, dialog_surface_solid))
+        .with_weight(Weight::Bold)
+        .with_line_height_ratio(1.25)
+        .finish();
+
+    let title_row = Flex::row()
+        .with_main_axis_size(MainAxisSize::Max)
+        .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+        .with_cross_axis_alignment(CrossAxisAlignment::Start)
+        .with_child(Shrinkable::new(1., title).finish())
+        .with_child(dialog.close_button)
+        .finish();
+
+    let body_text = FormattedTextElement::from_str(dialog.body, appearance.ui_font_family(), 14.)
+        .with_color(internal_colors::text_main(theme, dialog_surface_solid))
+        .with_weight(Weight::Normal)
+        .with_line_height_ratio(1.2)
+        .finish();
+
+    let feature_row_color: ColorU = theme.foreground().into();
+    let feature_x_fill = Fill::Solid(theme.ansi_fg_red());
+    let mut feature_list = Flex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+    for &item in dialog.features {
+        let icon_el = ConstrainedBox::new(Icon::X.to_warpui_icon(feature_x_fill).finish())
+            .with_width(16.)
+            .with_height(16.)
+            .finish();
+        let text_el = FormattedTextElement::from_str(item, appearance.ui_font_family(), 14.)
+            .with_color(feature_row_color)
+            .with_weight(Weight::Normal)
+            .with_alignment(TextAlignment::Left)
+            .with_line_height_ratio(1.0)
+            .finish();
+        let row = Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(icon_el)
+            .with_child(Container::new(text_el).with_margin_left(4.).finish())
+            .finish();
+        feature_list = feature_list.with_child(
+            Container::new(row)
+                .with_padding_top(4.)
+                .with_padding_bottom(4.)
+                .finish(),
+        );
+    }
+
+    let body_section = Flex::column()
+        .with_cross_axis_alignment(CrossAxisAlignment::Start)
+        .with_child(body_text)
+        .with_child(
+            Container::new(feature_list.finish())
+                .with_margin_top(12.)
+                .finish(),
+        )
+        .finish();
+
+    let footer = Container::new(
+        Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::End)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(dialog.cancel_button)
+            .with_child(
+                Container::new(dialog.confirm_button)
+                    .with_margin_left(8.)
+                    .finish(),
+            )
+            .finish(),
+    )
+    .with_border(Border::top(1.).with_border_color(border_color))
+    .with_horizontal_padding(24.)
+    .with_vertical_padding(12.)
+    .finish();
+
+    let dialog_body = Flex::column()
+        .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+        .with_child(
+            Container::new(title_row)
+                .with_horizontal_padding(24.)
+                .with_padding_top(24.)
+                .with_padding_bottom(12.)
+                .finish(),
+        )
+        .with_child(
+            Container::new(body_section)
+                .with_horizontal_padding(24.)
+                .with_padding_bottom(16.)
+                .finish(),
+        )
+        .with_child(footer)
+        .finish();
+
+    ConstrainedBox::new(
+        Container::new(dialog_body)
+            .with_background(dialog_surface)
+            .with_border(Border::all(1.).with_border_color(border_color))
+            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
+            .finish(),
+    )
+    .with_width(460.)
+    .finish()
+}

--- a/crates/onboarding/src/components/mod.rs
+++ b/crates/onboarding/src/components/mod.rs
@@ -1,1 +1,2 @@
+pub mod feature_optout_dialog;
 pub mod onboarding_callout;

--- a/crates/onboarding/src/lib.rs
+++ b/crates/onboarding/src/lib.rs
@@ -29,12 +29,12 @@ pub use callout::{OnboardingCalloutView, OnboardingKeybindings};
 /// skip-login confirmation dialog so the two always stay in sync.
 pub const AI_FEATURES: &[&str] = &[
     "Warp agents",
-    "Oz cloud agents platform",
-    "Next command predictions",
+    "Oz Cloud Agents Platform",
     "Prompt suggestions",
-    "Codebase context",
-    "Remote control with Claude Code, Codex, and other agents",
-    "Agents over SSH",
+    "Next command predictions",
+    "Full Terminal Use",
+    "Codebase Context",
+    "Remote Control with Claude Code, Codex, and other agents",
 ];
 
 /// User-facing names of the Warp Drive features enabled when the terminal

--- a/crates/onboarding/src/model.rs
+++ b/crates/onboarding/src/model.rs
@@ -115,11 +115,61 @@ impl SelectedSettings {
 pub(crate) enum OnboardingStep {
     Intro,
     Intention,
+    AiSetup,
     Customize,
     Agent,
+    AiAccess,
     ThirdParty,
     Project,
     ThemePicker,
+}
+
+/// The AI setup selected on the "Choose your AI setup" slide.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum AiSetupChoice {
+    #[default]
+    WarpAgent,
+    ThirdParty,
+}
+
+impl std::fmt::Display for AiSetupChoice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AiSetupChoice::WarpAgent => write!(f, "warp_agent"),
+            AiSetupChoice::ThirdParty => write!(f, "third_party"),
+        }
+    }
+}
+
+/// The access method selected on the "Choose how to access AI" slide (Warp Agent path).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum AiAccessChoice {
+    #[default]
+    Subscription,
+    Byok,
+}
+
+impl std::fmt::Display for AiAccessChoice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AiAccessChoice::Subscription => write!(f, "subscription"),
+            AiAccessChoice::Byok => write!(f, "byok"),
+        }
+    }
+}
+
+/// Which opt-out entry point opened the "Are you sure you don't want AI?" modal.
+/// Determines where "Give me AI features" routes the user on cancel.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum NoAiConfirmationSource {
+    /// Triggered from the intention slide via "Just use the terminal" + Next.
+    Intention,
+    /// Triggered from the AI-setup slide via "I don't want AI".
+    AiSetup,
+    /// Triggered from the "Customize your Warp Agent" slide via "I don't want AI".
+    Agent,
+    /// Triggered from the "Choose how to access AI" slide via "I don't want AI".
+    AiAccess,
 }
 
 #[derive(Clone, Debug)]
@@ -130,6 +180,7 @@ pub(crate) enum OnboardingStateEvent {
     Completed,
     UpgradeRequested,
     AuthStateChanged,
+    NoAiConfirmationChanged,
 }
 
 #[derive(Clone, Debug)]
@@ -144,8 +195,15 @@ pub(crate) struct OnboardingStateModel {
     workspace_enforces_autonomy: bool,
     /// Whether the AgentView feature flag is enabled.
     agent_modality_enabled: bool,
+    /// The AI setup selected on the "Choose your AI setup" slide.
+    ai_setup_choice: AiSetupChoice,
+    /// The access method selected on the "Choose how to access AI" slide.
+    ai_access_choice: AiAccessChoice,
     /// Auth / billing state of the user.
     auth_state: OnboardingAuthState,
+    /// When set, the "Are you sure you don't want AI?" confirmation modal is
+    /// shown; the value records which entry point triggered it.
+    no_ai_confirmation: Option<NoAiConfirmationSource>,
 }
 
 impl OnboardingStateModel {
@@ -166,7 +224,10 @@ impl OnboardingStateModel {
             models,
             workspace_enforces_autonomy,
             agent_modality_enabled,
+            ai_setup_choice: AiSetupChoice::default(),
+            ai_access_choice: AiAccessChoice::default(),
             auth_state,
+            no_ai_confirmation: None,
         }
     }
 
@@ -244,6 +305,115 @@ impl OnboardingStateModel {
 
     pub(crate) fn agent_modality_enabled(&self) -> bool {
         self.agent_modality_enabled
+    }
+
+    /// Whether the DES-816 V3 onboarding flow (the "Choose your AI setup" fork on the
+    /// AI-first path) is active. True for all users when the new settings-modes flow
+    /// is enabled, since new users always enter a world where Warp-provided AI is not free.
+    pub(crate) fn ai_setup_flow_active(&self) -> bool {
+        use warp_core::features::FeatureFlag;
+        FeatureFlag::OpenWarpNewSettingsModes.is_enabled()
+    }
+
+    pub(crate) fn ai_setup_choice(&self) -> AiSetupChoice {
+        self.ai_setup_choice
+    }
+
+    pub(crate) fn ai_access_choice(&self) -> AiAccessChoice {
+        self.ai_access_choice
+    }
+
+    pub(crate) fn set_ai_setup_choice(
+        &mut self,
+        choice: AiSetupChoice,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if self.ai_setup_choice == choice {
+            return;
+        }
+        send_telemetry_from_ctx!(
+            OnboardingEvent::SettingChanged {
+                setting: "ai_setup".to_string(),
+                value: choice.to_string(),
+            },
+            ctx
+        );
+        self.ai_setup_choice = choice;
+        self.agent_settings.disable_oz = matches!(choice, AiSetupChoice::ThirdParty);
+        ctx.notify();
+    }
+
+    pub(crate) fn set_ai_access_choice(
+        &mut self,
+        choice: AiAccessChoice,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if self.ai_access_choice == choice {
+            return;
+        }
+        send_telemetry_from_ctx!(
+            OnboardingEvent::SettingChanged {
+                setting: "ai_access".to_string(),
+                value: choice.to_string(),
+            },
+            ctx
+        );
+        self.ai_access_choice = choice;
+        ctx.notify();
+    }
+
+    pub(crate) fn no_ai_confirmation(&self) -> Option<NoAiConfirmationSource> {
+        self.no_ai_confirmation
+    }
+
+    /// Shows the "Are you sure you don't want AI?" confirmation modal, recording
+    /// which opt-out entry point triggered it so cancel can route appropriately.
+    pub(crate) fn request_no_ai_confirmation(
+        &mut self,
+        source: NoAiConfirmationSource,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        send_telemetry_from_ctx!(OnboardingEvent::NoAiConfirmationShown, ctx);
+        self.no_ai_confirmation = Some(source);
+        ctx.emit(OnboardingStateEvent::NoAiConfirmationChanged);
+        ctx.notify();
+    }
+
+    /// "I don't want AI": commit to the terminal-only path (AI features off) and
+    /// continue the flow there, so declining AI never dead-ends onboarding.
+    pub(crate) fn confirm_no_ai(&mut self, ctx: &mut ModelContext<Self>) {
+        send_telemetry_from_ctx!(OnboardingEvent::NoAiConfirmed, ctx);
+        self.no_ai_confirmation = None;
+        self.set_intention(OnboardingIntention::Terminal, ctx);
+        self.set_step(OnboardingStep::Customize, ctx);
+    }
+
+    /// "Give me AI features": abort the opt-out. From the intention slide this is
+    /// an explicit request for AI, so route onto the AI path; from the AI-setup
+    /// slide the user is already on the AI path, so just close the modal.
+    pub(crate) fn cancel_no_ai(&mut self, ctx: &mut ModelContext<Self>) {
+        send_telemetry_from_ctx!(OnboardingEvent::NoAiConfirmationCancelled, ctx);
+        match self.no_ai_confirmation.take() {
+            Some(NoAiConfirmationSource::Intention) => {
+                self.set_intention(OnboardingIntention::AgentDrivenDevelopment, ctx);
+                self.set_step(OnboardingStep::AiSetup, ctx);
+            }
+            Some(NoAiConfirmationSource::AiSetup)
+            | Some(NoAiConfirmationSource::Agent)
+            | Some(NoAiConfirmationSource::AiAccess)
+            | None => {
+                ctx.emit(OnboardingStateEvent::NoAiConfirmationChanged);
+                ctx.notify();
+            }
+        }
+    }
+
+    /// Closes the confirmation modal without changing the user's path (ESC / X).
+    pub(crate) fn dismiss_no_ai(&mut self, ctx: &mut ModelContext<Self>) {
+        if self.no_ai_confirmation.take().is_some() {
+            ctx.emit(OnboardingStateEvent::NoAiConfirmationChanged);
+            ctx.notify();
+        }
     }
 
     pub fn ui_customization(&self) -> &UICustomizationSettings {
@@ -468,23 +638,12 @@ impl OnboardingStateModel {
         self.set_intention(OnboardingIntention::AgentDrivenDevelopment, ctx);
     }
 
-    pub(crate) fn is_model_disabled(&self, model_id: &LLMId) -> bool {
-        self.models
-            .iter()
-            .find(|m| &m.id == model_id)
-            .is_some_and(|m| m.requires_upgrade)
-    }
-
     pub(crate) fn request_upgrade(&mut self, ctx: &mut ModelContext<Self>) {
         ctx.emit(OnboardingStateEvent::UpgradeRequested);
     }
 
     pub(crate) fn on_user_selected_model(&mut self, model_id: LLMId, ctx: &mut ModelContext<Self>) {
         if self.agent_settings.selected_model_id == model_id {
-            return;
-        }
-
-        if self.is_model_disabled(&model_id) {
             return;
         }
 
@@ -621,25 +780,44 @@ impl OnboardingStateModel {
     pub(crate) fn back(&mut self, ctx: &mut ModelContext<Self>) {
         use warp_core::features::FeatureFlag;
         let theme_picker_last = FeatureFlag::OpenWarpNewSettingsModes.is_enabled();
+        let ai_setup_flow = self.ai_setup_flow_active();
+        let agent_intention = matches!(self.intention, OnboardingIntention::AgentDrivenDevelopment);
 
         let prev = if theme_picker_last {
             match self.step {
                 OnboardingStep::Intro => None,
                 OnboardingStep::Intention => Some(OnboardingStep::Intro),
-                OnboardingStep::Customize => Some(OnboardingStep::Intention),
-                OnboardingStep::Agent => Some(OnboardingStep::Customize),
-                OnboardingStep::ThirdParty => match self.intention {
-                    OnboardingIntention::Terminal => Some(OnboardingStep::Customize),
-                    OnboardingIntention::AgentDrivenDevelopment => Some(OnboardingStep::Agent),
-                },
+                OnboardingStep::AiSetup => Some(OnboardingStep::Intention),
+                OnboardingStep::Customize => {
+                    if ai_setup_flow && agent_intention {
+                        match self.ai_setup_choice {
+                            AiSetupChoice::WarpAgent => Some(OnboardingStep::AiAccess),
+                            AiSetupChoice::ThirdParty => Some(OnboardingStep::ThirdParty),
+                        }
+                    } else {
+                        Some(OnboardingStep::Intention)
+                    }
+                }
+                OnboardingStep::AiAccess => Some(OnboardingStep::Agent),
+                OnboardingStep::Agent => {
+                    if ai_setup_flow {
+                        Some(OnboardingStep::AiSetup)
+                    } else {
+                        Some(OnboardingStep::Customize)
+                    }
+                }
+                OnboardingStep::ThirdParty => Some(OnboardingStep::AiSetup),
                 OnboardingStep::Project => Some(OnboardingStep::ThirdParty),
-                OnboardingStep::ThemePicker => Some(OnboardingStep::ThirdParty),
+                OnboardingStep::ThemePicker => Some(OnboardingStep::Customize),
             }
         } else {
             match self.step {
                 OnboardingStep::Intro => None,
                 OnboardingStep::ThemePicker => Some(OnboardingStep::Intro),
                 OnboardingStep::Intention => Some(OnboardingStep::ThemePicker),
+                // Unreachable in the legacy flow.
+                OnboardingStep::AiSetup => None,
+                OnboardingStep::AiAccess => None,
                 OnboardingStep::Customize => None,
                 OnboardingStep::ThirdParty => None,
                 OnboardingStep::Agent => Some(OnboardingStep::Intention),
@@ -667,17 +845,52 @@ impl OnboardingStateModel {
         }
 
         if theme_picker_last {
+            let ai_setup_flow = self.ai_setup_flow_active();
             match self.step {
                 OnboardingStep::Intro => self.set_step(OnboardingStep::Intention, ctx),
-                OnboardingStep::Intention => self.set_step(OnboardingStep::Customize, ctx),
-                OnboardingStep::Customize => match self.intention {
-                    OnboardingIntention::Terminal => self.set_step(OnboardingStep::ThirdParty, ctx),
+                OnboardingStep::Intention => match self.intention {
+                    OnboardingIntention::Terminal => self.set_step(OnboardingStep::Customize, ctx),
                     OnboardingIntention::AgentDrivenDevelopment => {
-                        self.set_step(OnboardingStep::Agent, ctx)
+                        if ai_setup_flow {
+                            self.set_step(OnboardingStep::AiSetup, ctx)
+                        } else {
+                            self.set_step(OnboardingStep::Customize, ctx)
+                        }
                     }
                 },
-                OnboardingStep::Agent => self.set_step(OnboardingStep::ThirdParty, ctx),
-                OnboardingStep::ThirdParty => self.set_step(OnboardingStep::ThemePicker, ctx),
+                OnboardingStep::AiSetup => match self.ai_setup_choice {
+                    AiSetupChoice::WarpAgent => self.set_step(OnboardingStep::Agent, ctx),
+                    AiSetupChoice::ThirdParty => self.set_step(OnboardingStep::ThirdParty, ctx),
+                },
+                OnboardingStep::Customize => match self.intention {
+                    OnboardingIntention::Terminal => {
+                        self.set_step(OnboardingStep::ThemePicker, ctx)
+                    }
+                    OnboardingIntention::AgentDrivenDevelopment => {
+                        if ai_setup_flow {
+                            self.set_step(OnboardingStep::ThemePicker, ctx)
+                        } else {
+                            self.set_step(OnboardingStep::Agent, ctx)
+                        }
+                    }
+                },
+                OnboardingStep::Agent => {
+                    if ai_setup_flow {
+                        self.set_step(OnboardingStep::AiAccess, ctx)
+                    } else {
+                        self.set_step(OnboardingStep::ThirdParty, ctx)
+                    }
+                }
+                OnboardingStep::AiAccess => self.set_step(OnboardingStep::Customize, ctx),
+                OnboardingStep::ThirdParty => {
+                    if ai_setup_flow
+                        && matches!(self.intention, OnboardingIntention::AgentDrivenDevelopment)
+                    {
+                        self.set_step(OnboardingStep::Customize, ctx)
+                    } else {
+                        self.set_step(OnboardingStep::ThemePicker, ctx)
+                    }
+                }
                 OnboardingStep::Project => self.set_step(OnboardingStep::ThemePicker, ctx),
                 OnboardingStep::ThemePicker => {}
             }
@@ -686,6 +899,9 @@ impl OnboardingStateModel {
                 OnboardingStep::Intro => self.set_step(OnboardingStep::ThemePicker, ctx),
                 OnboardingStep::ThemePicker => self.set_step(OnboardingStep::Intention, ctx),
                 OnboardingStep::Intention => self.set_step(OnboardingStep::Agent, ctx),
+                // Unreachable in the legacy flow.
+                OnboardingStep::AiSetup => {}
+                OnboardingStep::AiAccess => {}
                 OnboardingStep::Customize => {}
                 OnboardingStep::ThirdParty => {}
                 OnboardingStep::Agent => self.set_step(OnboardingStep::Project, ctx),
@@ -722,6 +938,22 @@ impl OnboardingStateModel {
                 send_telemetry_from_ctx!(
                     OnboardingEvent::SlideViewed {
                         slide_name: "intention".to_string(),
+                    },
+                    ctx
+                );
+            }
+            OnboardingStep::AiSetup => {
+                send_telemetry_from_ctx!(
+                    OnboardingEvent::SlideViewed {
+                        slide_name: "ai_setup".to_string(),
+                    },
+                    ctx
+                );
+            }
+            OnboardingStep::AiAccess => {
+                send_telemetry_from_ctx!(
+                    OnboardingEvent::SlideViewed {
+                        slide_name: "ai_access".to_string(),
                     },
                     ctx
                 );
@@ -763,8 +995,65 @@ impl OnboardingStateModel {
         ctx.emit(OnboardingStateEvent::SelectedSlideChanged);
         ctx.notify();
     }
+
+    /// The `(step_index, step_count)` shown by the bottom-nav progress dots for the
+    /// current step, intention, and flow variant.
+    pub(crate) fn progress(&self) -> (usize, usize) {
+        use warp_core::features::FeatureFlag;
+
+        let is_terminal = matches!(self.intention, OnboardingIntention::Terminal);
+        if !FeatureFlag::OpenWarpNewSettingsModes.is_enabled() {
+            // Legacy flow: ThemePicker → Intention → Agent → Project.
+            return match self.step {
+                OnboardingStep::Intro | OnboardingStep::ThemePicker => (0, 4),
+                OnboardingStep::Intention | OnboardingStep::AiSetup | OnboardingStep::Customize => {
+                    (1, 4)
+                }
+                OnboardingStep::Agent | OnboardingStep::ThirdParty | OnboardingStep::AiAccess => {
+                    (2, 4)
+                }
+                OnboardingStep::Project => (3, 4),
+            };
+        }
+
+        // The Warp Agent path has the extra "Choose how to access AI" step, so it
+        // is one longer than the third-party-agent path.
+        let is_warp_agent_path =
+            !is_terminal && matches!(self.ai_setup_choice, AiSetupChoice::WarpAgent);
+        let step_count = if is_terminal {
+            3
+        } else if is_warp_agent_path {
+            6
+        } else {
+            5
+        };
+        let step_index = match self.step {
+            OnboardingStep::Intro | OnboardingStep::Intention => 0,
+            OnboardingStep::AiSetup => 1,
+            OnboardingStep::Agent => 2,
+            OnboardingStep::AiAccess => 3,
+            OnboardingStep::Customize => {
+                if is_terminal {
+                    1
+                } else if is_warp_agent_path {
+                    4
+                } else {
+                    3
+                }
+            }
+            OnboardingStep::ThirdParty => 2,
+            // Unreachable in the new flow; keep the legacy position.
+            OnboardingStep::Project => 3,
+            OnboardingStep::ThemePicker => step_count - 1,
+        };
+        (step_index, step_count)
+    }
 }
 
 impl Entity for OnboardingStateModel {
     type Event = OnboardingStateEvent;
 }
+
+#[cfg(test)]
+#[path = "model_tests.rs"]
+mod tests;

--- a/crates/onboarding/src/model_tests.rs
+++ b/crates/onboarding/src/model_tests.rs
@@ -1,0 +1,355 @@
+use ai::LLMId;
+use warp_core::features::FeatureFlag;
+use warp_core::telemetry::testing::MockTelemetryContextProvider;
+use warpui_core::{App, ModelHandle};
+
+use crate::model::{
+    AiSetupChoice, NoAiConfirmationSource, OnboardingAuthState, OnboardingStateModel,
+    OnboardingStep, SelectedSettings,
+};
+use crate::OnboardingIntention;
+
+fn add_test_model(app: &mut App) -> ModelHandle<OnboardingStateModel> {
+    app.update(MockTelemetryContextProvider::register);
+    app.add_model(|_| {
+        OnboardingStateModel::new(
+            Vec::new(),
+            LLMId::from("auto"),
+            false,
+            true,
+            OnboardingAuthState::FreeUser,
+        )
+    })
+}
+
+fn step(app: &App, model: &ModelHandle<OnboardingStateModel>) -> OnboardingStep {
+    model.read(app, |model, _| model.step())
+}
+
+#[test]
+fn agent_path_routes_through_ai_setup() {
+    let _flag = FeatureFlag::OpenWarpNewSettingsModes.override_enabled(true);
+    App::test((), |mut app| async move {
+        let model = add_test_model(&mut app);
+
+        // Default intention is agent-driven development.
+        model.update(&mut app, |model, ctx| model.next(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::Intention);
+        model.update(&mut app, |model, ctx| model.next(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::AiSetup);
+
+        // The default AI setup choice is the Warp agent.
+        model.update(&mut app, |model, ctx| model.next(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::Agent);
+        model.update(&mut app, |model, ctx| model.next(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::AiAccess);
+        model.update(&mut app, |model, ctx| model.next(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::Customize);
+        model.update(&mut app, |model, ctx| model.next(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::ThemePicker);
+
+        // Back navigation mirrors the forward path.
+        model.update(&mut app, |model, ctx| model.back(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::Customize);
+        model.update(&mut app, |model, ctx| model.back(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::AiAccess);
+        model.update(&mut app, |model, ctx| model.back(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::Agent);
+        model.update(&mut app, |model, ctx| model.back(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::AiSetup);
+        model.update(&mut app, |model, ctx| model.back(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::Intention);
+    });
+}
+
+#[test]
+fn third_party_choice_routes_to_third_party_slide() {
+    let _flag = FeatureFlag::OpenWarpNewSettingsModes.override_enabled(true);
+    App::test((), |mut app| async move {
+        let model = add_test_model(&mut app);
+
+        model.update(&mut app, |model, ctx| {
+            model.next(ctx); // Intro → Intention
+            model.next(ctx); // Intention → AiSetup
+            model.set_ai_setup_choice(AiSetupChoice::ThirdParty, ctx);
+            model.next(ctx); // AiSetup → ThirdParty
+        });
+        assert_eq!(step(&app, &model), OnboardingStep::ThirdParty);
+
+        model.update(&mut app, |model, ctx| model.next(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::Customize);
+
+        // Back from Customize returns to the chosen AI-setup slide.
+        model.update(&mut app, |model, ctx| model.back(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::ThirdParty);
+        model.update(&mut app, |model, ctx| model.back(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::AiSetup);
+    });
+}
+
+#[test]
+fn confirm_no_ai_switches_to_terminal_path() {
+    let _flag = FeatureFlag::OpenWarpNewSettingsModes.override_enabled(true);
+    App::test((), |mut app| async move {
+        let model = add_test_model(&mut app);
+
+        model.update(&mut app, |model, ctx| {
+            model.next(ctx); // Intro → Intention
+            model.next(ctx); // Intention → AiSetup
+            model.request_no_ai_confirmation(NoAiConfirmationSource::AiSetup, ctx);
+        });
+
+        // The confirmation modal is shown without leaving the AI-setup slide yet.
+        assert_eq!(step(&app, &model), OnboardingStep::AiSetup);
+        model.read(&app, |model, _| {
+            assert_eq!(
+                model.no_ai_confirmation(),
+                Some(NoAiConfirmationSource::AiSetup)
+            );
+        });
+
+        // Confirming "I don't want AI" lands on the terminal path, never a dead end.
+        model.update(&mut app, |model, ctx| model.confirm_no_ai(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::Customize);
+        model.read(&app, |model, _| {
+            assert_eq!(model.no_ai_confirmation(), None);
+            assert_eq!(*model.intention(), OnboardingIntention::Terminal);
+            assert!(!model.settings().is_ai_enabled());
+        });
+
+        // The terminal path continues to completion, skipping the third-party slide.
+        model.update(&mut app, |model, ctx| model.next(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::ThemePicker);
+    });
+}
+
+#[test]
+fn confirm_no_ai_from_intention_then_back_returns_to_intention() {
+    let _flag = FeatureFlag::OpenWarpNewSettingsModes.override_enabled(true);
+    App::test((), |mut app| async move {
+        let model = add_test_model(&mut app);
+
+        model.update(&mut app, |model, ctx| {
+            model.next(ctx); // Intro → Intention
+            model.set_intention_terminal(ctx);
+            model.request_no_ai_confirmation(NoAiConfirmationSource::Intention, ctx);
+        });
+
+        // "Just use the terminal" + Next does not advance until the user confirms.
+        assert_eq!(step(&app, &model), OnboardingStep::Intention);
+
+        model.update(&mut app, |model, ctx| model.confirm_no_ai(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::Customize);
+
+        // Back from Customize goes to the intention fork, not the AI-setup slide.
+        model.update(&mut app, |model, ctx| model.back(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::Intention);
+    });
+}
+
+#[test]
+fn cancel_no_ai_from_intention_routes_to_ai_setup() {
+    let _flag = FeatureFlag::OpenWarpNewSettingsModes.override_enabled(true);
+    App::test((), |mut app| async move {
+        let model = add_test_model(&mut app);
+
+        model.update(&mut app, |model, ctx| {
+            model.next(ctx); // Intro → Intention
+            model.set_intention_terminal(ctx);
+            model.request_no_ai_confirmation(NoAiConfirmationSource::Intention, ctx);
+        });
+
+        // "Give me AI features" switches onto the AI path and opens the AI-setup slide.
+        model.update(&mut app, |model, ctx| model.cancel_no_ai(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::AiSetup);
+        model.read(&app, |model, _| {
+            assert_eq!(model.no_ai_confirmation(), None);
+            assert_eq!(
+                *model.intention(),
+                OnboardingIntention::AgentDrivenDevelopment
+            );
+        });
+    });
+}
+
+#[test]
+fn cancel_no_ai_from_ai_setup_stays_on_slide() {
+    let _flag = FeatureFlag::OpenWarpNewSettingsModes.override_enabled(true);
+    App::test((), |mut app| async move {
+        let model = add_test_model(&mut app);
+
+        model.update(&mut app, |model, ctx| {
+            model.next(ctx); // Intro → Intention
+            model.next(ctx); // Intention → AiSetup
+            model.request_no_ai_confirmation(NoAiConfirmationSource::AiSetup, ctx);
+            model.cancel_no_ai(ctx);
+        });
+
+        // Already on the AI path, so cancelling just closes the modal in place.
+        assert_eq!(step(&app, &model), OnboardingStep::AiSetup);
+        model.read(&app, |model, _| {
+            assert_eq!(model.no_ai_confirmation(), None);
+            assert_eq!(
+                *model.intention(),
+                OnboardingIntention::AgentDrivenDevelopment
+            );
+        });
+    });
+}
+
+#[test]
+fn dismiss_no_ai_closes_without_changing_path() {
+    let _flag = FeatureFlag::OpenWarpNewSettingsModes.override_enabled(true);
+    App::test((), |mut app| async move {
+        let model = add_test_model(&mut app);
+
+        model.update(&mut app, |model, ctx| {
+            model.next(ctx); // Intro → Intention
+            model.next(ctx); // Intention → AiSetup
+            model.request_no_ai_confirmation(NoAiConfirmationSource::AiSetup, ctx);
+            model.dismiss_no_ai(ctx);
+        });
+
+        assert_eq!(step(&app, &model), OnboardingStep::AiSetup);
+        model.read(&app, |model, _| {
+            assert_eq!(model.no_ai_confirmation(), None);
+            assert_eq!(
+                *model.intention(),
+                OnboardingIntention::AgentDrivenDevelopment
+            );
+        });
+    });
+}
+
+#[test]
+fn terminal_settings_disable_ai() {
+    let _flag = FeatureFlag::OpenWarpNewSettingsModes.override_enabled(true);
+    App::test((), |mut app| async move {
+        let model = add_test_model(&mut app);
+        model.update(&mut app, |model, ctx| model.set_intention_terminal(ctx));
+        model.read(&app, |model, _| {
+            assert!(matches!(
+                model.settings(),
+                SelectedSettings::Terminal { .. }
+            ));
+            assert!(!model.settings().is_ai_enabled());
+        });
+    });
+}
+
+#[test]
+fn third_party_choice_disables_warp_ai() {
+    let _flag = FeatureFlag::OpenWarpNewSettingsModes.override_enabled(true);
+    App::test((), |mut app| async move {
+        let model = add_test_model(&mut app);
+
+        // Default agent intention + "Use Warp Agent" keeps Warp AI on.
+        model.read(&app, |model, _| assert!(model.settings().is_ai_enabled()));
+
+        // "Use third party agents" turns Warp AI off.
+        model.update(&mut app, |model, ctx| {
+            model.set_ai_setup_choice(AiSetupChoice::ThirdParty, ctx)
+        });
+        model.read(&app, |model, _| assert!(!model.settings().is_ai_enabled()));
+
+        // Switching back to Warp Agent re-enables it.
+        model.update(&mut app, |model, ctx| {
+            model.set_ai_setup_choice(AiSetupChoice::WarpAgent, ctx)
+        });
+        model.read(&app, |model, _| assert!(model.settings().is_ai_enabled()));
+    });
+}
+
+#[test]
+fn terminal_path_skips_third_party() {
+    let _flag = FeatureFlag::OpenWarpNewSettingsModes.override_enabled(true);
+    App::test((), |mut app| async move {
+        let model = add_test_model(&mut app);
+        model.update(&mut app, |model, ctx| model.set_intention_terminal(ctx));
+
+        // Terminal goes Intention → Customize → ThemePicker; the "Customize third
+        // party agents" slide is only for the agent → third-party choice.
+        for expected in [
+            OnboardingStep::Intention,
+            OnboardingStep::Customize,
+            OnboardingStep::ThemePicker,
+        ] {
+            model.update(&mut app, |model, ctx| model.next(ctx));
+            assert_eq!(step(&app, &model), expected);
+        }
+
+        // Back navigation mirrors the forward path, also skipping third-party.
+        model.update(&mut app, |model, ctx| model.back(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::Customize);
+        model.update(&mut app, |model, ctx| model.back(ctx));
+        assert_eq!(step(&app, &model), OnboardingStep::Intention);
+    });
+}
+
+#[test]
+fn progress_reports_v3_positions_for_agent_path() {
+    let _flag = FeatureFlag::OpenWarpNewSettingsModes.override_enabled(true);
+    App::test((), |mut app| async move {
+        let model = add_test_model(&mut app);
+
+        // Warp Agent path: Intention → AiSetup → Agent → AiAccess → Customize → ThemePicker.
+        let cases = [
+            (OnboardingStep::Intention, (0, 6)),
+            (OnboardingStep::AiSetup, (1, 6)),
+            (OnboardingStep::Agent, (2, 6)),
+            (OnboardingStep::AiAccess, (3, 6)),
+            (OnboardingStep::Customize, (4, 6)),
+            (OnboardingStep::ThemePicker, (5, 6)),
+        ];
+        for (target, expected) in cases {
+            model.update(&mut app, |model, ctx| model.set_step(target, ctx));
+            let progress = model.read(&app, |model, _| model.progress());
+            assert_eq!(progress, expected, "unexpected dots for {target:?}");
+        }
+    });
+}
+
+#[test]
+fn progress_reports_v3_positions_for_third_party_path() {
+    let _flag = FeatureFlag::OpenWarpNewSettingsModes.override_enabled(true);
+    App::test((), |mut app| async move {
+        let model = add_test_model(&mut app);
+        model.update(&mut app, |model, ctx| {
+            model.set_ai_setup_choice(AiSetupChoice::ThirdParty, ctx)
+        });
+
+        // Third-party path has no "Choose how to access AI" step, so it is one
+        // dot shorter than the Warp Agent path.
+        let cases = [
+            (OnboardingStep::Intention, (0, 5)),
+            (OnboardingStep::AiSetup, (1, 5)),
+            (OnboardingStep::ThirdParty, (2, 5)),
+            (OnboardingStep::Customize, (3, 5)),
+            (OnboardingStep::ThemePicker, (4, 5)),
+        ];
+        for (target, expected) in cases {
+            model.update(&mut app, |model, ctx| model.set_step(target, ctx));
+            let progress = model.read(&app, |model, _| model.progress());
+            assert_eq!(progress, expected, "unexpected dots for {target:?}");
+        }
+    });
+}
+
+#[test]
+fn progress_reports_terminal_path_uses_three_dot_variant() {
+    let _flag = FeatureFlag::OpenWarpNewSettingsModes.override_enabled(true);
+    App::test((), |mut app| async move {
+        let model = add_test_model(&mut app);
+        model.update(&mut app, |model, ctx| model.set_intention_terminal(ctx));
+        let cases = [
+            (OnboardingStep::Intention, (0, 3)),
+            (OnboardingStep::Customize, (1, 3)),
+            (OnboardingStep::ThemePicker, (2, 3)),
+        ];
+        for (target, expected) in cases {
+            model.update(&mut app, |model, ctx| model.set_step(target, ctx));
+            let progress = model.read(&app, |model, _| model.progress());
+            assert_eq!(progress, expected, "unexpected dots for {target:?}");
+        }
+    });
+}

--- a/crates/onboarding/src/slides/agent_slide.rs
+++ b/crates/onboarding/src/slides/agent_slide.rs
@@ -1,10 +1,7 @@
 use ai::LLMId;
 use pathfinder_color::ColorU;
-use pathfinder_geometry::vector::vec2f;
-use ui_components::button::State as ButtonState;
 use ui_components::{button, Component as _, Options as _};
 use warp_core::features::FeatureFlag;
-use warp_core::send_telemetry_from_ctx;
 use warp_core::ui::appearance::Appearance;
 use warp_core::ui::icons::Icon;
 use warp_core::ui::theme::color::internal_colors;
@@ -23,48 +20,14 @@ use warpui_core::scene::DropShadow;
 use warpui_core::text_layout::TextAlignment;
 use warpui_core::ui_components::components::{UiComponent as _, UiComponentStyles};
 use warpui_core::{
-    AppContext, Element, Entity, Gradient, SingletonEntity as _, TypedActionView, View, ViewContext,
+    AppContext, Element, Entity, SingletonEntity as _, TypedActionView, View, ViewContext,
 };
 
 use super::two_line_button::{render_two_line_button, TwoLineButtonSpec};
 use super::OnboardingSlide;
-use crate::model::{OnboardingAuthState, OnboardingStateEvent, OnboardingStateModel};
+use crate::model::{NoAiConfirmationSource, OnboardingStateEvent, OnboardingStateModel};
 use crate::slides::{bottom_nav, layout, slide_content};
-use crate::telemetry::OnboardingEvent;
 use crate::visuals::agent_visual;
-
-/// high-contrast "inverted" fill (foreground color)
-struct UpgradeButtonTheme;
-
-impl button::Theme for UpgradeButtonTheme {
-    fn background(
-        &self,
-        button_state: ButtonState,
-        appearance: &Appearance,
-    ) -> Option<warp_core::ui::theme::Fill> {
-        use warp_core::ui::color::blend::Blend;
-        let theme = appearance.theme();
-        let base = theme.foreground();
-        match button_state {
-            ButtonState::Default => Some(base),
-            // Blend a little of the theme background back in to dim on hover /
-            // press. Opacities are relative to the foreground fill.
-            ButtonState::Hovered => Some(base.blend(&theme.background().with_opacity(15))),
-            ButtonState::Pressed => Some(base.blend(&theme.background().with_opacity(30))),
-        }
-    }
-
-    fn text_color(
-        &self,
-        background: Option<warp_core::ui::theme::Fill>,
-        appearance: &Appearance,
-    ) -> ColorU {
-        let bg = background
-            .unwrap_or_else(|| appearance.theme().background())
-            .into_solid();
-        appearance.theme().font_color(bg).into()
-    }
-}
 
 /// Information about a model displayed on the onboarding slide.
 #[derive(Clone, Debug)]
@@ -72,7 +35,6 @@ pub struct OnboardingModelInfo {
     pub id: LLMId,
     pub title: String,
     pub icon: Icon,
-    pub requires_upgrade: bool,
     pub is_default: bool,
 }
 
@@ -134,17 +96,8 @@ pub enum AgentSlideAction {
     SelectAutonomy(AgentAutonomy),
     ToggleDisableOz,
     BackClicked,
+    NoAiClicked,
     NextClicked,
-    UpgradeClicked,
-    CopyUpgradeUrlClicked,
-    PasteAuthTokenFromClipboardClicked,
-    DismissPlanActivatedToast,
-}
-
-#[derive(Debug, Clone)]
-pub enum AgentSlideEvent {
-    CopyUpgradeUrlRequested,
-    PasteAuthTokenFromClipboardRequested,
 }
 
 pub struct AgentSlide {
@@ -160,39 +113,20 @@ pub struct AgentSlide {
     autonomy_partial_mouse_state: MouseStateHandle,
     autonomy_none_mouse_state: MouseStateHandle,
 
-    disable_oz_mouse: MouseStateHandle,
-
     back_button: button::Button,
+    no_ai_button: button::Button,
     next_button: button::Button,
-    upgrade_button: button::Button,
     scroll_state: ClippedScrollStateHandle,
     dropdown_scroll_state: ClippedScrollStateHandle,
     is_model_list_expanded: bool,
     highlighted_model_id: Option<LLMId>,
-    show_auth_prompt_bar: bool,
-    copy_url_mouse_state: MouseStateHandle,
-    paste_token_mouse_state: MouseStateHandle,
-    show_plan_activated_toast: bool,
-    last_auth_state: OnboardingAuthState,
-    plan_activated_close_mouse_state: MouseStateHandle,
 }
-
-const PLAN_ACTIVATED_TOAST_DURATION: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Produces the `SavePosition` id for the model row at `index` in the
 /// dropdown list. Used by `scroll_to_position` to scroll a specific row into
 /// view as the keyboard highlight moves.
 fn model_row_position_id(index: usize) -> String {
     format!("agent_slide_model_row_{index}")
-}
-
-/// Returns the slide's view of the model list: free-tier before premium,
-/// with server order preserved within each tier. The slide owns this sort so
-/// state storage can stay in server order.
-fn sorted_models(models: &[OnboardingModelInfo]) -> Vec<OnboardingModelInfo> {
-    let (free, premium): (Vec<_>, Vec<_>) =
-        models.iter().cloned().partition(|m| !m.requires_upgrade);
-    free.into_iter().chain(premium).collect()
 }
 
 impl AgentSlide {
@@ -204,8 +138,6 @@ impl AgentSlide {
         let model_mouse_states = (0..model_count)
             .map(|_| MouseStateHandle::default())
             .collect();
-
-        let initial_auth_state = onboarding_state.as_ref(ctx).auth_state();
 
         ctx.subscribe_to_model(&onboarding_state, |me, model, event, ctx| {
             match event {
@@ -222,30 +154,12 @@ impl AgentSlide {
                     let model_count = state.models().len();
                     me.ensure_mouse_states_for_models(model_count, ctx);
                 }
-                OnboardingStateEvent::AuthStateChanged => {
-                    let new_state = model.as_ref(ctx).auth_state();
-                    if new_state == OnboardingAuthState::PayingUser
-                        && me.last_auth_state != OnboardingAuthState::PayingUser
-                    {
-                        me.show_plan_activated_toast = true;
-                        // Auto-dismiss after the configured duration.
-                        let _ = ctx.spawn(
-                            warpui_core::r#async::Timer::after(PLAN_ACTIVATED_TOAST_DURATION),
-                            |me: &mut Self, _, ctx| {
-                                if me.show_plan_activated_toast {
-                                    me.show_plan_activated_toast = false;
-                                    ctx.notify();
-                                }
-                            },
-                        );
-                    }
-                    me.last_auth_state = new_state;
-                    ctx.notify();
-                }
-                OnboardingStateEvent::SelectedSlideChanged
+                OnboardingStateEvent::AuthStateChanged
+                | OnboardingStateEvent::SelectedSlideChanged
                 | OnboardingStateEvent::IntentionChanged
                 | OnboardingStateEvent::Completed
-                | OnboardingStateEvent::UpgradeRequested => {}
+                | OnboardingStateEvent::UpgradeRequested
+                | OnboardingStateEvent::NoAiConfirmationChanged => {}
             }
         });
 
@@ -256,20 +170,13 @@ impl AgentSlide {
             autonomy_full_mouse_state: MouseStateHandle::default(),
             autonomy_partial_mouse_state: MouseStateHandle::default(),
             autonomy_none_mouse_state: MouseStateHandle::default(),
-            disable_oz_mouse: MouseStateHandle::default(),
             back_button: button::Button::default(),
+            no_ai_button: button::Button::default(),
             next_button: button::Button::default(),
-            upgrade_button: button::Button::default(),
             scroll_state: ClippedScrollStateHandle::new(),
             dropdown_scroll_state: ClippedScrollStateHandle::new(),
             is_model_list_expanded: false,
             highlighted_model_id: None,
-            show_auth_prompt_bar: false,
-            copy_url_mouse_state: MouseStateHandle::default(),
-            paste_token_mouse_state: MouseStateHandle::default(),
-            show_plan_activated_toast: false,
-            last_auth_state: initial_auth_state,
-            plan_activated_close_mouse_state: MouseStateHandle::default(),
         }
     }
 
@@ -304,7 +211,7 @@ impl AgentSlide {
         // state is a floating overlay (built in `View::render`) that sits *on top
         // of* this content, so the underlying layout never shifts between the two
         // states. That keeps the header + picker chip pinned in place.
-        let bottom_nav = self.render_bottom_nav(appearance);
+        let bottom_nav = self.render_bottom_nav(appearance, app);
         slide_content::onboarding_slide_content(
             vec![
                 self.render_header(appearance),
@@ -329,7 +236,7 @@ impl AgentSlide {
             .finish();
 
         let subtitle = FormattedTextElement::from_str(
-            "Select your in-app agent's defaults.",
+            "Select your Warp Agent's defaults.",
             appearance.ui_font_family(),
             16.,
         )
@@ -385,18 +292,9 @@ impl AgentSlide {
             upper_col.finish()
         };
 
-        let mut col = Flex::column()
+        let col = Flex::column()
             .with_cross_axis_alignment(CrossAxisAlignment::Start)
             .with_child(upper_sections);
-
-        if FeatureFlag::OpenWarpNewSettingsModes.is_enabled() {
-            let disable_oz_section = self.render_disable_oz_section(appearance, settings);
-            col = col.with_child(
-                Container::new(disable_oz_section)
-                    .with_margin_top(24.)
-                    .finish(),
-            );
-        }
 
         Container::new(col.finish()).with_margin_top(40.).finish()
     }
@@ -454,31 +352,15 @@ impl AgentSlide {
             );
         }
 
-        let has_disabled = self
-            .onboarding_state
-            .as_ref(app)
-            .models()
-            .iter()
-            .any(|m| m.requires_upgrade);
-
-        let mut col = Flex::column()
+        Flex::column()
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
             .with_child(header)
             .with_child(
                 Container::new(chip_stack.finish())
                     .with_margin_top(12.)
                     .finish(),
-            );
-
-        if has_disabled {
-            col = col.with_child(
-                Container::new(self.render_upgrade_banner(appearance))
-                    .with_margin_top(12.)
-                    .finish(),
-            );
-        }
-
-        col.finish()
+            )
+            .finish()
     }
 
     /// Renders the single-row collapsed picker button: provider icon, selected title,
@@ -591,9 +473,8 @@ impl AgentSlide {
     }
 
     /// Renders the vertical list of model rows shown inside the floating dropdown
-    /// overlay. Each row: provider icon + title on the left, pill on the right
-    /// (Premium for paywalled rows). Disabled rows are rendered dimmed and are
-    /// not clickable or hover-selectable.
+    /// overlay. Each row shows a provider icon + title on the left, with a
+    /// "Recommended" pill on the right for the default model.
     fn render_model_list_rows(
         &self,
         appearance: &Appearance,
@@ -605,7 +486,7 @@ impl AgentSlide {
         let state = self.onboarding_state.as_ref(app);
         let highlighted_id = self.highlighted_model_id.clone();
         let selected_id = state.agent_settings().selected_model_id.clone();
-        let models = sorted_models(state.models());
+        let models = state.models();
 
         let mut col = Flex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
 
@@ -691,18 +572,11 @@ impl AgentSlide {
         let background_for_text = theme.background().into_solid();
         let ui_font_family = appearance.ui_font_family();
 
-        let is_disabled = model.requires_upgrade;
-
-        let title_color: ColorU = if is_disabled {
-            internal_colors::text_disabled(theme, background_for_text)
-        } else {
-            internal_colors::text_main(theme, background_for_text)
-        };
+        let title_color: ColorU = internal_colors::text_main(theme, background_for_text);
 
         let row_id = model.id.clone();
         let title = model.title.clone();
         let icon = model.icon;
-        let requires_upgrade = model.requires_upgrade;
         let is_default = model.is_default;
 
         let hoverable_body = Hoverable::new(mouse_state, move |_| {
@@ -726,10 +600,7 @@ impl AgentSlide {
                 .with_child(Container::new(title_el).with_margin_left(8.).finish())
                 .finish();
 
-            // Trailing pills: "Recommended" on the server-designated default
-            // model, "Premium" on paywalled rows. In practice a single row is
-            // at most one of these, but both can be shown side-by-side if the
-            // default is also premium for any reason.
+            // "Recommended" pill on the server-designated default model.
             let make_pill = |label: &'static str| -> Box<dyn Element> {
                 let badge = Text::new(label.to_string(), ui_font_family, 11.0)
                     .with_color(internal_colors::text_sub(theme, background_for_text))
@@ -751,8 +622,6 @@ impl AgentSlide {
 
             let trailing: Box<dyn Element> = if is_default {
                 make_pill("Recommended")
-            } else if requires_upgrade {
-                make_pill("Premium")
             } else {
                 Empty::new().finish()
             };
@@ -765,7 +634,7 @@ impl AgentSlide {
                 .with_child(trailing)
                 .finish();
 
-            let background = if is_highlighted && !is_disabled {
+            let background = if is_highlighted {
                 Some(Fill::Solid(internal_colors::neutral_2(theme)))
             } else {
                 None
@@ -783,26 +652,19 @@ impl AgentSlide {
                 .finish()
         });
 
-        if is_disabled {
-            // Disabled rows: no click, no hover-updates-highlight, muted.
-            hoverable_body.finish()
-        } else {
-            let click_id = row_id.clone();
-            let hover_id = row_id;
-            hoverable_body
-                .with_cursor(Cursor::PointingHand)
-                .on_hover(move |is_hovered, ctx, _, _| {
-                    if is_hovered {
-                        ctx.dispatch_typed_action(AgentSlideAction::HighlightModel(
-                            hover_id.clone(),
-                        ));
-                    }
-                })
-                .on_click(move |ctx, _, _| {
-                    ctx.dispatch_typed_action(AgentSlideAction::SelectModel(click_id.clone()));
-                })
-                .finish()
-        }
+        let click_id = row_id.clone();
+        let hover_id = row_id;
+        hoverable_body
+            .with_cursor(Cursor::PointingHand)
+            .on_hover(move |is_hovered, ctx, _, _| {
+                if is_hovered {
+                    ctx.dispatch_typed_action(AgentSlideAction::HighlightModel(hover_id.clone()));
+                }
+            })
+            .on_click(move |ctx, _, _| {
+                ctx.dispatch_typed_action(AgentSlideAction::SelectModel(click_id.clone()));
+            })
+            .finish()
     }
 
     fn render_autonomy_workspace_enforced(&self, appearance: &Appearance) -> Box<dyn Element> {
@@ -877,19 +739,19 @@ impl AgentSlide {
             (
                 AgentAutonomy::Full,
                 "Full",
-                "Runs commands, writes code, and reads files without asking.",
+                "Warp Agent runs commands, writes code, and reads files without asking.",
                 self.autonomy_full_mouse_state.clone(),
             ),
             (
                 AgentAutonomy::Partial,
                 "Partial",
-                "Can plan, read files, and execute low-risk commands. Asks before making any changes or executing sensitive commands.",
+                "Warp Agent can plan, read files, and execute low-risk commands. Asks before making any changes or executing sensitive commands.",
                 self.autonomy_partial_mouse_state.clone(),
             ),
             (
                 AgentAutonomy::None,
                 "None",
-                "Takes no actions without your approval.",
+                "Warp Agent takes no actions without your approval.",
                 self.autonomy_none_mouse_state.clone(),
             ),
         ];
@@ -935,39 +797,7 @@ impl AgentSlide {
             .finish()
     }
 
-    fn render_disable_oz_section(
-        &self,
-        appearance: &Appearance,
-        settings: &AgentDevelopmentSettings,
-    ) -> Box<dyn Element> {
-        let theme = appearance.theme();
-        let background_for_text = theme.background().into_solid();
-
-        let checkbox = appearance
-            .ui_builder()
-            .checkbox(self.disable_oz_mouse.clone(), Some(12.))
-            .check(settings.disable_oz)
-            .build()
-            .on_click(|ctx, _, _| ctx.dispatch_typed_action(AgentSlideAction::ToggleDisableOz))
-            .finish();
-
-        let label = Text::new("Disable Warp Agent", appearance.ui_font_family(), 14.0)
-            .with_color(internal_colors::text_sub(theme, background_for_text))
-            .with_style(Properties {
-                weight: Weight::Normal,
-                ..Default::default()
-            })
-            .with_line_height_ratio(1.0)
-            .finish();
-
-        Flex::row()
-            .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_child(checkbox)
-            .with_child(Container::new(label).with_margin_left(8.).finish())
-            .finish()
-    }
-
-    fn render_bottom_nav(&self, appearance: &Appearance) -> Box<dyn Element> {
+    fn render_bottom_nav(&self, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
         let back_button = self.back_button.render(
             appearance,
             button::Params {
@@ -976,6 +806,22 @@ impl AgentSlide {
                 options: button::Options {
                     on_click: Some(Box::new(|ctx, _app, _pos| {
                         ctx.dispatch_typed_action(AgentSlideAction::BackClicked);
+                    })),
+                    ..button::Options::default(appearance)
+                },
+            },
+        );
+
+        let no_ai_keystroke = Keystroke::parse("cmdorctrl-enter").unwrap_or_default();
+        let no_ai_button = self.no_ai_button.render(
+            appearance,
+            button::Params {
+                content: button::Content::Label("I don't want AI".into()),
+                theme: &button::themes::Naked,
+                options: button::Options {
+                    keystroke: Some(no_ai_keystroke),
+                    on_click: Some(Box::new(|ctx, _app, _pos| {
+                        ctx.dispatch_typed_action(AgentSlideAction::NoAiClicked);
                     })),
                     ..button::Options::default(appearance)
                 },
@@ -998,112 +844,21 @@ impl AgentSlide {
             },
         );
 
-        let step_index = 2;
-        let step_count = if warp_core::features::FeatureFlag::OpenWarpNewSettingsModes.is_enabled()
-        {
-            5
-        } else {
-            4
-        };
+        let right_buttons = Flex::row()
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(no_ai_button)
+            .with_child(Container::new(next_button).with_margin_left(8.).finish())
+            .finish();
+
+        let (step_index, step_count) = self.onboarding_state.as_ref(app).progress();
         bottom_nav::onboarding_bottom_nav(
             appearance,
             step_index,
             step_count,
             Some(back_button),
-            Some(next_button),
+            Some(right_buttons),
         )
-    }
-
-    fn render_upgrade_banner(&self, appearance: &Appearance) -> Box<dyn Element> {
-        // Diagonal magenta → yellow gradient (top-left to bottom-right). Chosen
-        // to match the "premium" glow styling in the Figma mocks.
-        const GRADIENT_START_MAGENTA: ColorU = ColorU {
-            r: 0xE2,
-            g: 0x48,
-            b: 0xBC,
-            a: 0xFF,
-        };
-        const GRADIENT_END_YELLOW: ColorU = ColorU {
-            r: 0xF5,
-            g: 0xB7,
-            b: 0x00,
-            a: 0xFF,
-        };
-
-        let theme = appearance.theme();
-        let background_for_text = theme.background().into_solid();
-        let ui_font_family = appearance.ui_font_family();
-
-        // Primary "heading" line: bolder, full-contrast.
-        let title = Text::new(
-            "Upgrade for access to premium models.",
-            ui_font_family,
-            13.0,
-        )
-        .with_color(internal_colors::text_main(theme, background_for_text))
-        .with_style(Properties {
-            weight: Weight::Medium,
-            ..Default::default()
-        })
-        .with_line_height_ratio(1.2)
-        .finish();
-
-        // Secondary subtext: muted, normal weight.
-        let subtitle = Text::new(
-            "State-of-the-art models require paid plans.",
-            ui_font_family,
-            12.0,
-        )
-        .with_color(internal_colors::text_sub(theme, background_for_text))
-        .with_style(Properties {
-            weight: Weight::Normal,
-            ..Default::default()
-        })
-        .with_line_height_ratio(1.2)
-        .finish();
-
-        let text_col = Flex::column()
-            .with_main_axis_size(MainAxisSize::Min)
-            .with_cross_axis_alignment(CrossAxisAlignment::Start)
-            .with_child(title)
-            .with_child(Container::new(subtitle).with_margin_top(4.).finish())
-            .finish();
-
-        let upgrade_button = self.upgrade_button.render(
-            appearance,
-            button::Params {
-                content: button::Content::Label("Upgrade".into()),
-                theme: &UpgradeButtonTheme,
-                options: button::Options {
-                    size: button::Size::Small,
-                    on_click: Some(Box::new(|ctx, _app, _pos| {
-                        ctx.dispatch_typed_action(AgentSlideAction::UpgradeClicked);
-                    })),
-                    ..button::Options::default(appearance)
-                },
-            },
-        );
-
-        let row = Flex::row()
-            .with_main_axis_size(MainAxisSize::Max)
-            .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
-            .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_child(text_col)
-            .with_child(upgrade_button)
-            .finish();
-
-        Container::new(row)
-            .with_uniform_padding(12.)
-            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
-            .with_border(Border::all(1.).with_border_gradient(
-                vec2f(0., 0.),
-                vec2f(1., 1.),
-                Gradient {
-                    start: GRADIENT_START_MAGENTA,
-                    end: GRADIENT_END_YELLOW,
-                },
-            ))
-            .finish()
     }
 
     fn render_visual(&self, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
@@ -1134,187 +889,10 @@ impl AgentSlide {
                 .finish()
         }
     }
-
-    /// Full-width bar pinned below the slide's two-column layout. Shown after
-    /// the user clicks the Upgrade button, so they can fall back to copying
-    /// the upgrade URL (or pasting the returned auth token) if the browser
-    /// didn't launch automatically.
-    fn render_auth_prompt_bar(&self, appearance: &Appearance) -> Box<dyn Element> {
-        const BAR_HEIGHT: f32 = 40.;
-        const ICON_SIZE: f32 = 14.;
-        const FONT_SIZE: f32 = 12.;
-
-        let theme = appearance.theme();
-        let bar_bg = theme.surface_1();
-        let bar_bg_solid = bar_bg.into_solid();
-        let text_color = internal_colors::text_sub(theme, bar_bg_solid);
-        let ui_builder = appearance.ui_builder();
-
-        let text_styles = UiComponentStyles {
-            font_color: Some(text_color),
-            font_size: Some(FONT_SIZE),
-            ..Default::default()
-        };
-        let link_styles = UiComponentStyles {
-            font_size: Some(FONT_SIZE),
-            ..Default::default()
-        };
-
-        let icon = ConstrainedBox::new(Box::new(
-            Icon::AlertCircle.to_warpui_icon(Fill::Solid(text_color)),
-        ))
-        .with_width(ICON_SIZE)
-        .with_height(ICON_SIZE)
-        .finish();
-
-        let copy_url_link = ui_builder
-            .link(
-                "copy the URL".into(),
-                None,
-                Some(Box::new(|ctx| {
-                    ctx.dispatch_typed_action(AgentSlideAction::CopyUpgradeUrlClicked);
-                })),
-                self.copy_url_mouse_state.clone(),
-            )
-            .soft_wrap(false)
-            .with_style(link_styles)
-            .build()
-            .finish();
-
-        let paste_token_link = ui_builder
-            .link(
-                "Click here".into(),
-                None,
-                Some(Box::new(|ctx| {
-                    ctx.dispatch_typed_action(AgentSlideAction::PasteAuthTokenFromClipboardClicked);
-                })),
-                self.paste_token_mouse_state.clone(),
-            )
-            .soft_wrap(false)
-            .with_style(link_styles)
-            .build()
-            .finish();
-
-        let text_row = Flex::row()
-            .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_child(icon)
-            .with_child(
-                Container::new(
-                    ui_builder
-                        .span("If your browser hasn't launched, ")
-                        .with_style(text_styles)
-                        .build()
-                        .finish(),
-                )
-                .with_margin_left(8.)
-                .finish(),
-            )
-            .with_child(copy_url_link)
-            .with_child(
-                ui_builder
-                    .span(" and open the page manually. ")
-                    .with_style(text_styles)
-                    .build()
-                    .finish(),
-            )
-            .with_child(paste_token_link)
-            .with_child(
-                ui_builder
-                    .span(" to paste your token from the browser.")
-                    .with_style(text_styles)
-                    .build()
-                    .finish(),
-            )
-            .finish();
-
-        let row = Flex::row()
-            .with_main_axis_size(MainAxisSize::Max)
-            .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_child(text_row)
-            .finish();
-
-        ConstrainedBox::new(
-            Container::new(row)
-                .with_background(bar_bg)
-                .with_border(Border::top(1.).with_border_color(internal_colors::neutral_4(theme)))
-                .with_horizontal_padding(16.)
-                .finish(),
-        )
-        .with_min_height(BAR_HEIGHT)
-        .finish()
-    }
-
-    /// Green success pill shown when the user's `OnboardingAuthState`
-    /// transitions into `PayingUser`. Auto-dismisses after
-    /// `PLAN_ACTIVATED_TOAST_DURATION`; also dismissable via the close X.
-    fn render_plan_activated_toast(&self, appearance: &Appearance) -> Box<dyn Element> {
-        const TOAST_MIN_HEIGHT: f32 = 40.;
-        const ICON_SIZE: f32 = 14.;
-        const CLOSE_SIZE: f32 = 16.;
-        const FONT_SIZE: f32 = 12.;
-
-        let theme = appearance.theme();
-        let toast_bg: Fill = theme.ansi_fg_green().into();
-        let text_color: ColorU = theme.font_color(toast_bg.into_solid()).into();
-        let ui_builder = appearance.ui_builder();
-
-        let check_icon = ConstrainedBox::new(Box::new(
-            Icon::CheckSkinny.to_warpui_icon(Fill::Solid(text_color)),
-        ))
-        .with_width(ICON_SIZE)
-        .with_height(ICON_SIZE)
-        .finish();
-
-        let text = ui_builder
-            .span("Plan successfully activated. All premium models are available.")
-            .with_style(UiComponentStyles {
-                font_color: Some(text_color),
-                font_size: Some(FONT_SIZE),
-                font_weight: Some(Weight::Medium),
-                ..Default::default()
-            })
-            .build()
-            .finish();
-
-        let close_button = ui_builder
-            .close_button(CLOSE_SIZE, self.plan_activated_close_mouse_state.clone())
-            .with_style(UiComponentStyles {
-                font_color: Some(text_color),
-                ..Default::default()
-            })
-            .build()
-            .on_click(|ctx, _, _| {
-                ctx.dispatch_typed_action(AgentSlideAction::DismissPlanActivatedToast);
-            })
-            .finish();
-
-        let left = Flex::row()
-            .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_child(check_icon)
-            .with_child(Container::new(text).with_margin_left(8.).finish())
-            .finish();
-
-        let row = Flex::row()
-            .with_main_axis_size(MainAxisSize::Max)
-            .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
-            .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_child(left)
-            .with_child(close_button)
-            .finish();
-
-        ConstrainedBox::new(
-            Container::new(row)
-                .with_background(toast_bg)
-                .with_horizontal_padding(16.)
-                .finish(),
-        )
-        .with_min_height(TOAST_MIN_HEIGHT)
-        .finish()
-    }
 }
 
 impl Entity for AgentSlide {
-    type Event = AgentSlideEvent;
+    type Event = ();
 }
 
 impl View for AgentSlide {
@@ -1330,39 +908,10 @@ impl View for AgentSlide {
         // The floating dropdown overlay is built inside `render_model_section`
         // so it inherits the column width naturally. Here we only need the
         // base two-column layout.
-        let slide = layout::static_left(
+        layout::static_left(
             || self.render_content(appearance, settings, workspace_enforces_autonomy, app),
             || self.render_visual(appearance, app),
-        );
-
-        // Upgrade-prompt bar: shown after the user clicks Upgrade, as long as
-        // they aren't yet on a paid plan. Overlays the bottom of the slide
-        // (doesn't bump slide content up) so the slide layout stays stable
-        // whether or not the bar is visible.
-        //
-        // The plan-activated success toast supersedes the bar (and any other
-        // bottom overlay) while it's visible.
-        let auth_state = self.onboarding_state.as_ref(app).auth_state();
-        let show_bar =
-            self.show_auth_prompt_bar && !matches!(auth_state, OnboardingAuthState::PayingUser);
-        if !show_bar && !self.show_plan_activated_toast {
-            return slide;
-        }
-
-        let bottom_overlay = if self.show_plan_activated_toast {
-            self.render_plan_activated_toast(appearance)
-        } else {
-            self.render_auth_prompt_bar(appearance)
-        };
-
-        let mut stack = Stack::new();
-        stack.add_child(slide);
-        stack.add_child(
-            warpui_core::elements::Align::new(bottom_overlay)
-                .bottom_center()
-                .finish(),
-        );
-        stack.finish()
+        )
     }
 }
 
@@ -1384,10 +933,7 @@ impl AgentSlide {
             // starts on the selected row.
             let state = self.onboarding_state.as_ref(ctx);
             let selected_id = state.agent_settings().selected_model_id.clone();
-            if let Some(index) = sorted_models(state.models())
-                .iter()
-                .position(|m| m.id == selected_id)
-            {
+            if let Some(index) = state.models().iter().position(|m| m.id == selected_id) {
                 self.dropdown_scroll_state.scroll_to_position(ScrollTarget {
                     position_id: model_row_position_id(index),
                     mode: ScrollToPositionMode::FullyIntoView,
@@ -1398,55 +944,33 @@ impl AgentSlide {
         ctx.notify();
     }
 
-    /// Finds the next enabled model index in the given direction, wrapping
-    /// around. Indices are into the slide's sorted view of the model list.
-    /// Returns `None` if all models are paywalled.
-    fn next_enabled_model_index(
-        &self,
-        start: usize,
-        forward: bool,
-        ctx: &AppContext,
-    ) -> Option<usize> {
-        let models = sorted_models(self.onboarding_state.as_ref(ctx).models());
-        let count = models.len();
-        if count == 0 {
-            return None;
-        }
-        for offset in 1..=count {
-            let idx = if forward {
-                (start + offset) % count
-            } else {
-                (start + count - offset) % count
-            };
-            if !models[idx].requires_upgrade {
-                return Some(idx);
-            }
-        }
-        None
-    }
-
-    /// Advances the highlight cursor to the next/previous enabled model, wrapping.
-    /// The origin of the walk is the currently-highlighted id (if any), else the
+    /// Advances the highlight cursor to the next/previous model, wrapping. The
+    /// origin of the walk is the currently-highlighted id (if any), else the
     /// currently-selected id. Also scrolls the dropdown so the newly-highlighted
     /// row stays visible — same `SavePosition` + `scroll_to_position` pattern
     /// used by `VerticalTabsPanelState::scroll_to_tab`.
     fn advance_highlighted_model(&mut self, forward: bool, ctx: &mut ViewContext<Self>) {
-        let state = self.onboarding_state.as_ref(ctx);
-        let sorted = sorted_models(state.models());
-        let selected_id = state.agent_settings().selected_model_id.clone();
+        let (model_ids, selected_id) = {
+            let state = self.onboarding_state.as_ref(ctx);
+            let ids: Vec<LLMId> = state.models().iter().map(|m| m.id.clone()).collect();
+            (ids, state.agent_settings().selected_model_id.clone())
+        };
+        let count = model_ids.len();
+        if count == 0 {
+            return;
+        }
         let start_index = self
             .highlighted_model_id
             .as_ref()
-            .and_then(|id| sorted.iter().position(|m| &m.id == id))
-            .or_else(|| sorted.iter().position(|m| m.id == selected_id))
+            .and_then(|id| model_ids.iter().position(|m| m == id))
+            .or_else(|| model_ids.iter().position(|m| *m == selected_id))
             .unwrap_or(0);
-        let Some(next_index) = self.next_enabled_model_index(start_index, forward, ctx) else {
-            return;
+        let next_index = if forward {
+            (start_index + 1) % count
+        } else {
+            (start_index + count - 1) % count
         };
-        let Some(next_id) = sorted.get(next_index).map(|m| m.id.clone()) else {
-            return;
-        };
-        self.highlighted_model_id = Some(next_id);
+        self.highlighted_model_id = Some(model_ids[next_index].clone());
         // Scroll the dropdown so the new highlight is visible. `FullyIntoView`
         // is a no-op when the row is already fully in view, otherwise it
         // scrolls the minimum amount to show it.
@@ -1528,16 +1052,7 @@ impl OnboardingSlide for AgentSlide {
         // and collapses the list. Does NOT advance to the next slide.
         if self.is_model_list_expanded {
             if let Some(id) = self.highlighted_model_id.clone() {
-                // Only select if the highlighted row is still enabled.
-                let enabled = self
-                    .onboarding_state
-                    .as_ref(ctx)
-                    .models()
-                    .iter()
-                    .any(|m| m.id == id && !m.requires_upgrade);
-                if enabled {
-                    self.select_model(id, ctx);
-                }
+                self.select_model(id, ctx);
             }
             self.set_model_list_expanded(false, ctx);
             return;
@@ -1550,6 +1065,12 @@ impl OnboardingSlide for AgentSlide {
         if self.is_model_list_expanded {
             self.set_model_list_expanded(false, ctx);
         }
+    }
+
+    fn on_cmd_or_ctrl_enter(&mut self, ctx: &mut ViewContext<Self>) {
+        self.onboarding_state.update(ctx, |model, ctx| {
+            model.request_no_ai_confirmation(NoAiConfirmationSource::Agent, ctx);
+        });
     }
 }
 
@@ -1574,16 +1095,7 @@ impl TypedActionView for AgentSlide {
                 self.set_model_list_expanded(!self.is_model_list_expanded, ctx);
             }
             AgentSlideAction::HighlightModel(model_id) => {
-                // Only update if the id corresponds to an enabled row. Callers
-                // (hover handlers) already filter this out, but we defend against
-                // stale actions fired while the list was re-rendering.
-                let enabled = self
-                    .onboarding_state
-                    .as_ref(ctx)
-                    .models()
-                    .iter()
-                    .any(|m| m.id == *model_id && !m.requires_upgrade);
-                if enabled && self.highlighted_model_id.as_ref() != Some(model_id) {
+                if self.highlighted_model_id.as_ref() != Some(model_id) {
                     self.highlighted_model_id = Some(model_id.clone());
                     ctx.notify();
                 }
@@ -1609,31 +1121,13 @@ impl TypedActionView for AgentSlide {
                     state.back(ctx);
                 });
             }
-            AgentSlideAction::NextClicked => {
-                self.next(ctx);
-            }
-            AgentSlideAction::UpgradeClicked => {
-                send_telemetry_from_ctx!(OnboardingEvent::AgentSlideUpgradeClicked, ctx);
-                if !matches!(
-                    self.onboarding_state.as_ref(ctx).auth_state(),
-                    OnboardingAuthState::PayingUser,
-                ) {
-                    self.show_auth_prompt_bar = true;
-                    ctx.notify();
-                }
-                self.onboarding_state.update(ctx, |state, ctx| {
-                    state.request_upgrade(ctx);
+            AgentSlideAction::NoAiClicked => {
+                self.onboarding_state.update(ctx, |model, ctx| {
+                    model.request_no_ai_confirmation(NoAiConfirmationSource::Agent, ctx);
                 });
             }
-            AgentSlideAction::CopyUpgradeUrlClicked => {
-                ctx.emit(AgentSlideEvent::CopyUpgradeUrlRequested);
-            }
-            AgentSlideAction::PasteAuthTokenFromClipboardClicked => {
-                ctx.emit(AgentSlideEvent::PasteAuthTokenFromClipboardRequested);
-            }
-            AgentSlideAction::DismissPlanActivatedToast => {
-                self.show_plan_activated_toast = false;
-                ctx.notify();
+            AgentSlideAction::NextClicked => {
+                self.next(ctx);
             }
         }
     }

--- a/crates/onboarding/src/slides/ai_access_slide.rs
+++ b/crates/onboarding/src/slides/ai_access_slide.rs
@@ -1,0 +1,831 @@
+use ui_components::{button, tooltip, Component as _, Options as _};
+use warp_core::ui::appearance::Appearance;
+use warp_core::ui::icons::Icon;
+use warp_core::ui::theme::color::internal_colors;
+use warp_core::ui::theme::Fill;
+use warpui_core::elements::{
+    Border, ClippedScrollStateHandle, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment,
+    Flex, FormattedTextElement, Hoverable, MainAxisAlignment, MainAxisSize, MouseStateHandle,
+    ParentElement, Radius, Stack,
+};
+use warpui_core::fonts::Weight;
+use warpui_core::keymap::Keystroke;
+use warpui_core::platform::Cursor;
+use warpui_core::prelude::Align;
+use warpui_core::text_layout::TextAlignment;
+use warpui_core::ui_components::components::{UiComponent as _, UiComponentStyles};
+use warpui_core::{
+    AppContext, Element, Entity, ModelHandle, SingletonEntity as _, TypedActionView, View,
+    ViewContext,
+};
+
+use super::OnboardingSlide;
+use crate::model::{
+    AiAccessChoice, NoAiConfirmationSource, OnboardingAuthState, OnboardingStateModel,
+};
+use crate::slides::{bottom_nav, layout, slide_content};
+
+#[derive(Debug, Clone)]
+pub enum AiAccessSlideAction {
+    SelectSubscription,
+    SelectByok,
+    ChoosePlanClicked,
+    AddApiKeyClicked,
+    AddCustomEndpointClicked,
+    CopyUpgradeUrlClicked,
+    PasteAuthTokenFromClipboardClicked,
+    BackClicked,
+    NextClicked,
+    NoAiClicked,
+}
+
+/// Emitted to the parent onboarding view so the (app-crate) settings modals can be
+/// hosted at the root level — the onboarding crate can't reference them directly.
+#[derive(Debug, Clone)]
+pub enum AiAccessSlideEvent {
+    AddApiKeyRequested,
+    AddCustomEndpointRequested,
+    CopyUpgradeUrlRequested,
+    PasteAuthTokenFromClipboardRequested,
+}
+
+/// The "Choose how to access AI" slide (Warp Agent path). Forks between a paid
+/// subscription and bring-your-own-key / custom endpoint, with an "I don't want AI"
+/// escape onto the terminal-only path.
+pub struct AiAccessSlide {
+    onboarding_state: ModelHandle<OnboardingStateModel>,
+    subscription_mouse_state: MouseStateHandle,
+    byok_mouse_state: MouseStateHandle,
+    choose_plan_button: button::Button,
+    add_key_button: button::Button,
+    add_endpoint_button: button::Button,
+    back_button: button::Button,
+    next_button: button::Button,
+    no_ai_button: button::Button,
+    scroll_state: ClippedScrollStateHandle,
+    show_auth_prompt_bar: bool,
+    copy_url_mouse_state: MouseStateHandle,
+    paste_token_mouse_state: MouseStateHandle,
+    /// How many BYOK provider keys and custom endpoints the user has configured
+    /// (mirrors the app's `ApiKeyManager`). Drives the "N keys connected" status
+    /// line and gates "Next" on the bring-your-own path.
+    byok_key_count: usize,
+    byok_endpoint_count: usize,
+}
+
+impl AiAccessSlide {
+    pub(crate) fn new(onboarding_state: ModelHandle<OnboardingStateModel>) -> Self {
+        Self {
+            onboarding_state,
+            subscription_mouse_state: MouseStateHandle::default(),
+            byok_mouse_state: MouseStateHandle::default(),
+            choose_plan_button: button::Button::default(),
+            add_key_button: button::Button::default(),
+            add_endpoint_button: button::Button::default(),
+            back_button: button::Button::default(),
+            next_button: button::Button::default(),
+            no_ai_button: button::Button::default(),
+            scroll_state: ClippedScrollStateHandle::new(),
+            show_auth_prompt_bar: false,
+            copy_url_mouse_state: MouseStateHandle::default(),
+            paste_token_mouse_state: MouseStateHandle::default(),
+            byok_key_count: 0,
+            byok_endpoint_count: 0,
+        }
+    }
+
+    // The final DES-816 visual exports have not landed yet, so the right panel
+    // reuses the existing bundled agent welcome image.
+    pub(crate) const VISUAL_IMAGE_PATHS: &'static [&'static str] =
+        &["async/png/onboarding/welcome_agent.png"];
+
+    fn choice(&self, app: &AppContext) -> AiAccessChoice {
+        self.onboarding_state.as_ref(app).ai_access_choice()
+    }
+
+    /// Whether "Next" should be enabled. The subscription path advances via the
+    /// checkout return (auto-advance once billing flips to `PayingUser`), so
+    /// "Next" is only live there if the user is already paying. The BYOK path
+    /// requires at least one key/endpoint to be configured first.
+    fn can_advance(&self, app: &AppContext) -> bool {
+        match self.choice(app) {
+            AiAccessChoice::Subscription => matches!(
+                self.onboarding_state.as_ref(app).auth_state(),
+                OnboardingAuthState::PayingUser
+            ),
+            AiAccessChoice::Byok => self.byok_key_count > 0 || self.byok_endpoint_count > 0,
+        }
+    }
+
+    fn render_content(
+        &self,
+        appearance: &Appearance,
+        choice: AiAccessChoice,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let bottom_nav = Align::new(self.render_bottom_nav(appearance, app)).finish();
+
+        slide_content::onboarding_slide_content(
+            vec![
+                Align::new(self.render_header(appearance)).left().finish(),
+                Align::new(self.render_options(appearance, choice)).finish(),
+            ],
+            bottom_nav,
+            self.scroll_state.clone(),
+            appearance,
+        )
+    }
+
+    fn render_header(&self, appearance: &Appearance) -> Box<dyn Element> {
+        let theme = appearance.theme();
+
+        let title = appearance
+            .ui_builder()
+            .paragraph("Choose how to access AI")
+            .with_style(UiComponentStyles {
+                font_size: Some(36.),
+                font_weight: Some(Weight::Medium),
+                ..Default::default()
+            })
+            .build()
+            .finish();
+
+        let subtitle = FormattedTextElement::from_str(
+            "Save with a recurring plan, or use your own key or endpoint.",
+            appearance.ui_font_family(),
+            16.,
+        )
+        .with_color(internal_colors::text_sub(
+            theme,
+            theme.background().into_solid(),
+        ))
+        .with_weight(Weight::Normal)
+        .with_alignment(TextAlignment::Left)
+        .with_line_height_ratio(1.0)
+        .finish();
+
+        Flex::column()
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_cross_axis_alignment(CrossAxisAlignment::Start)
+            .with_child(title)
+            .with_child(Container::new(subtitle).with_margin_top(16.).finish())
+            .finish()
+    }
+
+    fn render_options(&self, appearance: &Appearance, choice: AiAccessChoice) -> Box<dyn Element> {
+        let subscription_card = self
+            .render_subscription_card(appearance, matches!(choice, AiAccessChoice::Subscription));
+
+        let byok_card = self.render_byok_card(appearance, matches!(choice, AiAccessChoice::Byok));
+
+        Container::new(
+            Flex::column()
+                .with_main_axis_size(MainAxisSize::Min)
+                .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+                .with_child(
+                    Container::new(subscription_card)
+                        .with_margin_bottom(12.)
+                        .finish(),
+                )
+                .with_child(byok_card)
+                .finish(),
+        )
+        .with_margin_top(38.)
+        .finish()
+    }
+
+    /// Shared chrome for an option card: selected/unselected background + border,
+    /// hover/click to select.
+    fn render_card_chrome(
+        appearance: &Appearance,
+        is_selected: bool,
+        mouse_state: MouseStateHandle,
+        select_action: AiAccessSlideAction,
+        content: Box<dyn Element>,
+    ) -> Box<dyn Element> {
+        const RADIUS: f32 = 8.;
+
+        let theme = appearance.theme();
+        let background = if is_selected {
+            Some(internal_colors::accent_overlay_1(theme))
+        } else {
+            None
+        };
+        let border_color = if is_selected {
+            theme.accent()
+        } else {
+            Fill::Solid(internal_colors::neutral_4(theme))
+        };
+
+        Hoverable::new(mouse_state, move |_| {
+            let mut container = Container::new(content)
+                .with_uniform_padding(24.)
+                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(RADIUS)))
+                .with_border(Border::all(1.).with_border_fill(border_color));
+            if let Some(bg) = background {
+                container = container.with_background(bg);
+            }
+            container.finish()
+        })
+        .with_cursor(Cursor::PointingHand)
+        .on_click(move |ctx, _, _| {
+            ctx.dispatch_typed_action(select_action.clone());
+        })
+        .finish()
+    }
+
+    fn render_subscription_card(
+        &self,
+        appearance: &Appearance,
+        is_selected: bool,
+    ) -> Box<dyn Element> {
+        let theme = appearance.theme();
+        let bg_solid = theme.background().into_solid();
+        let label_color = if is_selected {
+            internal_colors::text_main(theme, bg_solid)
+        } else {
+            internal_colors::text_sub(theme, bg_solid)
+        };
+        let description_color = internal_colors::text_sub(theme, bg_solid);
+
+        let label = appearance
+            .ui_builder()
+            .paragraph("Subscription")
+            .with_style(UiComponentStyles {
+                font_size: Some(16.),
+                font_weight: Some(Weight::Semibold),
+                font_color: Some(label_color),
+                ..Default::default()
+            })
+            .build()
+            .finish();
+
+        let badge = {
+            let green = theme.ansi_fg_green();
+            let badge_text = appearance
+                .ui_builder()
+                .paragraph("Best value")
+                .with_style(UiComponentStyles {
+                    font_size: Some(12.),
+                    font_weight: Some(Weight::Normal),
+                    font_color: Some(green),
+                    ..Default::default()
+                })
+                .build()
+                .finish();
+            Container::new(badge_text)
+                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(11.)))
+                .with_border(Border::all(1.).with_border_fill(Fill::Solid(green)))
+                .with_horizontal_padding(8.)
+                .with_vertical_padding(3.)
+                .finish()
+        };
+
+        let header_row = Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(label)
+            .with_child(badge)
+            .finish();
+
+        let description = FormattedTextElement::from_str(
+            "Starting at $18 / mo, available with monthly or annual plans. Includes base credits, \
+             frontier models, cloud agents, collaboration, and more.",
+            appearance.ui_font_family(),
+            14.,
+        )
+        .with_color(description_color)
+        .with_weight(Weight::Normal)
+        .with_alignment(TextAlignment::Left)
+        .with_line_height_ratio(1.2)
+        .finish();
+
+        let choose_plan_button = self.choose_plan_button.render(
+            appearance,
+            button::Params {
+                content: button::Content::Label("Choose plan".into()),
+                theme: &button::themes::Secondary,
+                options: button::Options {
+                    on_click: Some(Box::new(|ctx, _app, _pos| {
+                        ctx.dispatch_typed_action(AiAccessSlideAction::ChoosePlanClicked);
+                    })),
+                    ..button::Options::default(appearance)
+                },
+            },
+        );
+
+        let content = Flex::column()
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_cross_axis_alignment(CrossAxisAlignment::Start)
+            .with_child(header_row)
+            .with_child(Container::new(description).with_margin_top(12.).finish())
+            .with_child(
+                Container::new(choose_plan_button)
+                    .with_margin_top(16.)
+                    .finish(),
+            )
+            .finish();
+
+        Self::render_card_chrome(
+            appearance,
+            is_selected,
+            self.subscription_mouse_state.clone(),
+            AiAccessSlideAction::SelectSubscription,
+            content,
+        )
+    }
+
+    fn render_byok_card(&self, appearance: &Appearance, is_selected: bool) -> Box<dyn Element> {
+        let theme = appearance.theme();
+        let bg_solid = theme.background().into_solid();
+        let label_color = if is_selected {
+            internal_colors::text_main(theme, bg_solid)
+        } else {
+            internal_colors::text_sub(theme, bg_solid)
+        };
+        let description_color = internal_colors::text_sub(theme, bg_solid);
+
+        let label = appearance
+            .ui_builder()
+            .paragraph("Use my own key or endpoint")
+            .with_style(UiComponentStyles {
+                font_size: Some(16.),
+                font_weight: Some(Weight::Semibold),
+                font_color: Some(label_color),
+                ..Default::default()
+            })
+            .build()
+            .finish();
+
+        let description = FormattedTextElement::from_str(
+            "Use your own API key or OpenAI-compatible endpoint with Warp for free.",
+            appearance.ui_font_family(),
+            14.,
+        )
+        .with_color(description_color)
+        .with_weight(Weight::Normal)
+        .with_alignment(TextAlignment::Left)
+        .with_line_height_ratio(1.2)
+        .finish();
+
+        let add_key_button = self.add_key_button.render(
+            appearance,
+            button::Params {
+                content: button::Content::Label("+ Add key".into()),
+                theme: &button::themes::Secondary,
+                options: button::Options {
+                    on_click: Some(Box::new(|ctx, _app, _pos| {
+                        ctx.dispatch_typed_action(AiAccessSlideAction::AddApiKeyClicked);
+                    })),
+                    ..button::Options::default(appearance)
+                },
+            },
+        );
+
+        let add_endpoint_button = self.add_endpoint_button.render(
+            appearance,
+            button::Params {
+                content: button::Content::Label("+ Add custom endpoint".into()),
+                theme: &button::themes::Secondary,
+                options: button::Options {
+                    on_click: Some(Box::new(|ctx, _app, _pos| {
+                        ctx.dispatch_typed_action(AiAccessSlideAction::AddCustomEndpointClicked);
+                    })),
+                    ..button::Options::default(appearance)
+                },
+            },
+        );
+
+        let buttons_row = Flex::row()
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(add_key_button)
+            .with_child(
+                Container::new(add_endpoint_button)
+                    .with_margin_left(8.)
+                    .finish(),
+            )
+            .finish();
+
+        let mut content = Flex::column()
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_cross_axis_alignment(CrossAxisAlignment::Start)
+            .with_child(label)
+            .with_child(Container::new(description).with_margin_top(12.).finish())
+            .with_child(Container::new(buttons_row).with_margin_top(16.).finish());
+
+        // Surface how many keys/endpoints are already configured, mirroring the
+        // app's `ApiKeyManager` so the state is visible without reopening a modal.
+        if let Some(status) = self.render_byok_status(appearance) {
+            content = content.with_child(Container::new(status).with_margin_top(16.).finish());
+        }
+
+        Self::render_card_chrome(
+            appearance,
+            is_selected,
+            self.byok_mouse_state.clone(),
+            AiAccessSlideAction::SelectByok,
+            content.finish(),
+        )
+    }
+
+    /// "N keys connected" / "1 key and 1 endpoint connected" summary for the
+    /// BYOK card, or `None` when nothing is configured yet.
+    fn byok_status_text(&self) -> Option<String> {
+        fn count_label(count: usize, noun: &str) -> String {
+            format!("{count} {noun}{}", if count == 1 { "" } else { "s" })
+        }
+        match (self.byok_key_count, self.byok_endpoint_count) {
+            (0, 0) => None,
+            (keys, 0) => Some(format!("{} connected", count_label(keys, "key"))),
+            (0, endpoints) => Some(format!("{} connected", count_label(endpoints, "endpoint"))),
+            (keys, endpoints) => Some(format!(
+                "{} and {} connected",
+                count_label(keys, "key"),
+                count_label(endpoints, "endpoint"),
+            )),
+        }
+    }
+
+    fn render_byok_status(&self, appearance: &Appearance) -> Option<Box<dyn Element>> {
+        const ICON_SIZE: f32 = 14.;
+
+        let text = self.byok_status_text()?;
+        let green = appearance.theme().ansi_fg_green();
+
+        let icon = ConstrainedBox::new(Box::new(
+            Icon::CheckSkinny.to_warpui_icon(Fill::Solid(green)),
+        ))
+        .with_width(ICON_SIZE)
+        .with_height(ICON_SIZE)
+        .finish();
+
+        let label = appearance
+            .ui_builder()
+            .span(text)
+            .with_style(UiComponentStyles {
+                font_color: Some(green),
+                font_size: Some(14.),
+                ..Default::default()
+            })
+            .build()
+            .finish();
+
+        Some(
+            Flex::row()
+                .with_main_axis_size(MainAxisSize::Min)
+                .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                .with_child(icon)
+                .with_child(Container::new(label).with_margin_left(8.).finish())
+                .finish(),
+        )
+    }
+
+    fn render_bottom_nav(&self, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
+        let back_button = self.back_button.render(
+            appearance,
+            button::Params {
+                content: button::Content::Label("Back".into()),
+                theme: &button::themes::Naked,
+                options: button::Options {
+                    on_click: Some(Box::new(|ctx, _app, _pos| {
+                        ctx.dispatch_typed_action(AiAccessSlideAction::BackClicked);
+                    })),
+                    ..button::Options::default(appearance)
+                },
+            },
+        );
+
+        let no_ai_keystroke = Keystroke::parse("cmdorctrl-enter").unwrap_or_default();
+        let no_ai_button = self.no_ai_button.render(
+            appearance,
+            button::Params {
+                content: button::Content::Label("I don't want AI".into()),
+                theme: &button::themes::Naked,
+                options: button::Options {
+                    keystroke: Some(no_ai_keystroke),
+                    on_click: Some(Box::new(|ctx, _app, _pos| {
+                        ctx.dispatch_typed_action(AiAccessSlideAction::NoAiClicked);
+                    })),
+                    ..button::Options::default(appearance)
+                },
+            },
+        );
+
+        let can_advance = self.can_advance(app);
+        let enter = Keystroke::parse("enter").unwrap_or_default();
+        let next_button = self.next_button.render(
+            appearance,
+            button::Params {
+                content: button::Content::Label("Next".into()),
+                theme: &button::themes::Primary,
+                options: button::Options {
+                    disabled: !can_advance,
+                    // Explain why the user can't continue yet: Warp Agent needs a
+                    // paid plan or a configured key/endpoint.
+                    tooltip: (!can_advance).then(|| button::Tooltip {
+                        params: tooltip::Params {
+                            label:
+                                "Warp Agent requires a subscription or inference supplied by you"
+                                    .into(),
+                            options: tooltip::Options {
+                                keyboard_shortcut: None,
+                            },
+                        },
+                        alignment: button::TooltipAlignment::Right,
+                    }),
+                    keystroke: can_advance.then_some(enter),
+                    on_click: Some(Box::new(|ctx, _app, _pos| {
+                        ctx.dispatch_typed_action(AiAccessSlideAction::NextClicked);
+                    })),
+                    ..button::Options::default(appearance)
+                },
+            },
+        );
+
+        let right_buttons = Flex::row()
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(no_ai_button)
+            .with_child(Container::new(next_button).with_margin_left(8.).finish())
+            .finish();
+
+        let (step_index, step_count) = self.onboarding_state.as_ref(app).progress();
+        bottom_nav::onboarding_bottom_nav(
+            appearance,
+            step_index,
+            step_count,
+            Some(back_button),
+            Some(right_buttons),
+        )
+    }
+
+    fn render_visual(&self) -> Box<dyn Element> {
+        layout::onboarding_right_panel_with_bg(
+            Self::VISUAL_IMAGE_PATHS[0],
+            layout::FOREGROUND_LAYOUT_DEFAULT,
+        )
+    }
+
+    /// Full-width bar pinned below the slide's two-column layout. Shown after
+    /// the user clicks "Choose plan", so they can fall back to copying the
+    /// upgrade URL (or pasting the returned auth token) if the browser didn't
+    /// launch automatically.
+    fn render_auth_prompt_bar(&self, appearance: &Appearance) -> Box<dyn Element> {
+        const BAR_HEIGHT: f32 = 40.;
+        const ICON_SIZE: f32 = 14.;
+        const FONT_SIZE: f32 = 12.;
+
+        let theme = appearance.theme();
+        let bar_bg = theme.surface_1();
+        let bar_bg_solid = bar_bg.into_solid();
+        let text_color = internal_colors::text_sub(theme, bar_bg_solid);
+        let ui_builder = appearance.ui_builder();
+
+        let text_styles = UiComponentStyles {
+            font_color: Some(text_color),
+            font_size: Some(FONT_SIZE),
+            ..Default::default()
+        };
+        let link_styles = UiComponentStyles {
+            font_size: Some(FONT_SIZE),
+            ..Default::default()
+        };
+
+        let icon = ConstrainedBox::new(Box::new(
+            Icon::AlertCircle.to_warpui_icon(Fill::Solid(text_color)),
+        ))
+        .with_width(ICON_SIZE)
+        .with_height(ICON_SIZE)
+        .finish();
+
+        let copy_url_link = ui_builder
+            .link(
+                "copy the URL".into(),
+                None,
+                Some(Box::new(|ctx| {
+                    ctx.dispatch_typed_action(AiAccessSlideAction::CopyUpgradeUrlClicked);
+                })),
+                self.copy_url_mouse_state.clone(),
+            )
+            .soft_wrap(false)
+            .with_style(link_styles)
+            .build()
+            .finish();
+
+        let paste_token_link = ui_builder
+            .link(
+                "Click here".into(),
+                None,
+                Some(Box::new(|ctx| {
+                    ctx.dispatch_typed_action(
+                        AiAccessSlideAction::PasteAuthTokenFromClipboardClicked,
+                    );
+                })),
+                self.paste_token_mouse_state.clone(),
+            )
+            .soft_wrap(false)
+            .with_style(link_styles)
+            .build()
+            .finish();
+
+        let text_row = Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(icon)
+            .with_child(
+                Container::new(
+                    ui_builder
+                        .span("If your browser hasn't launched, ")
+                        .with_style(text_styles)
+                        .build()
+                        .finish(),
+                )
+                .with_margin_left(8.)
+                .finish(),
+            )
+            .with_child(copy_url_link)
+            .with_child(
+                ui_builder
+                    .span(" and open the page manually. ")
+                    .with_style(text_styles)
+                    .build()
+                    .finish(),
+            )
+            .with_child(paste_token_link)
+            .with_child(
+                ui_builder
+                    .span(" to paste your token from the browser.")
+                    .with_style(text_styles)
+                    .build()
+                    .finish(),
+            )
+            .finish();
+
+        let row = Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(text_row)
+            .finish();
+
+        ConstrainedBox::new(
+            Container::new(row)
+                .with_background(bar_bg)
+                .with_border(Border::top(1.).with_border_color(internal_colors::neutral_4(theme)))
+                .with_horizontal_padding(16.)
+                .finish(),
+        )
+        .with_min_height(BAR_HEIGHT)
+        .finish()
+    }
+}
+
+impl Entity for AiAccessSlide {
+    type Event = AiAccessSlideEvent;
+}
+
+impl View for AiAccessSlide {
+    fn ui_name() -> &'static str {
+        "AiAccessSlide"
+    }
+
+    fn render(&self, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let choice = self.choice(app);
+
+        let slide = layout::static_left(
+            || self.render_content(appearance, choice, app),
+            || self.render_visual(),
+        );
+
+        // Overlay the fallback bar at the bottom (rather than adding it to the
+        // column) so the slide layout stays stable whether or not it's shown.
+        let show_bar = self.show_auth_prompt_bar
+            && !matches!(
+                self.onboarding_state.as_ref(app).auth_state(),
+                OnboardingAuthState::PayingUser,
+            );
+        if !show_bar {
+            return slide;
+        }
+
+        let mut stack = Stack::new();
+        stack.add_child(slide);
+        stack.add_child(
+            Align::new(self.render_auth_prompt_bar(appearance))
+                .bottom_center()
+                .finish(),
+        );
+        stack.finish()
+    }
+}
+
+impl AiAccessSlide {
+    fn select_choice(&mut self, choice: AiAccessChoice, ctx: &mut ViewContext<Self>) {
+        self.onboarding_state.update(ctx, |model, ctx| {
+            model.set_ai_access_choice(choice, ctx);
+        });
+        ctx.notify();
+    }
+
+    fn next(&mut self, ctx: &mut ViewContext<Self>) {
+        self.onboarding_state.update(ctx, |model, ctx| {
+            model.next(ctx);
+        });
+    }
+
+    pub(crate) fn set_byok_status(
+        &mut self,
+        key_count: usize,
+        endpoint_count: usize,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if self.byok_key_count == key_count && self.byok_endpoint_count == endpoint_count {
+            return;
+        }
+        self.byok_key_count = key_count;
+        self.byok_endpoint_count = endpoint_count;
+        ctx.notify();
+    }
+}
+
+impl OnboardingSlide for AiAccessSlide {
+    fn on_up(&mut self, ctx: &mut ViewContext<Self>) {
+        self.select_choice(AiAccessChoice::Subscription, ctx);
+    }
+
+    fn on_down(&mut self, ctx: &mut ViewContext<Self>) {
+        self.select_choice(AiAccessChoice::Byok, ctx);
+    }
+
+    fn on_enter(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.can_advance(ctx) {
+            self.next(ctx);
+        }
+    }
+
+    fn on_cmd_or_ctrl_enter(&mut self, ctx: &mut ViewContext<Self>) {
+        self.onboarding_state.update(ctx, |model, ctx| {
+            model.request_no_ai_confirmation(NoAiConfirmationSource::AiAccess, ctx);
+        });
+    }
+}
+
+impl TypedActionView for AiAccessSlide {
+    type Action = AiAccessSlideAction;
+
+    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        match action {
+            AiAccessSlideAction::SelectSubscription => {
+                self.select_choice(AiAccessChoice::Subscription, ctx);
+            }
+            AiAccessSlideAction::SelectByok => {
+                self.select_choice(AiAccessChoice::Byok, ctx);
+            }
+            AiAccessSlideAction::ChoosePlanClicked => {
+                self.select_choice(AiAccessChoice::Subscription, ctx);
+                // Surface the manual-fallback bar in case the browser doesn't
+                // launch; it's hidden again once billing flips to PayingUser.
+                if !matches!(
+                    self.onboarding_state.as_ref(ctx).auth_state(),
+                    OnboardingAuthState::PayingUser,
+                ) {
+                    self.show_auth_prompt_bar = true;
+                }
+                self.onboarding_state.update(ctx, |model, ctx| {
+                    model.request_upgrade(ctx);
+                });
+                ctx.notify();
+            }
+            AiAccessSlideAction::AddApiKeyClicked => {
+                self.select_choice(AiAccessChoice::Byok, ctx);
+                ctx.emit(AiAccessSlideEvent::AddApiKeyRequested);
+            }
+            AiAccessSlideAction::AddCustomEndpointClicked => {
+                self.select_choice(AiAccessChoice::Byok, ctx);
+                ctx.emit(AiAccessSlideEvent::AddCustomEndpointRequested);
+            }
+            AiAccessSlideAction::CopyUpgradeUrlClicked => {
+                ctx.emit(AiAccessSlideEvent::CopyUpgradeUrlRequested);
+            }
+            AiAccessSlideAction::PasteAuthTokenFromClipboardClicked => {
+                ctx.emit(AiAccessSlideEvent::PasteAuthTokenFromClipboardRequested);
+            }
+            AiAccessSlideAction::BackClicked => {
+                self.onboarding_state.update(ctx, |model, ctx| {
+                    model.back(ctx);
+                });
+            }
+            AiAccessSlideAction::NextClicked => {
+                if self.can_advance(ctx) {
+                    self.next(ctx);
+                }
+            }
+            AiAccessSlideAction::NoAiClicked => {
+                self.onboarding_state.update(ctx, |model, ctx| {
+                    model.request_no_ai_confirmation(NoAiConfirmationSource::AiAccess, ctx);
+                });
+            }
+        }
+    }
+}

--- a/crates/onboarding/src/slides/ai_setup_slide.rs
+++ b/crates/onboarding/src/slides/ai_setup_slide.rs
@@ -1,5 +1,4 @@
 use ui_components::{button, Component as _, Options as _};
-use warp_core::features::FeatureFlag;
 use warp_core::ui::appearance::Appearance;
 use warp_core::ui::theme::color::internal_colors;
 use warp_core::ui::theme::Fill;
@@ -21,50 +20,78 @@ use warpui_core::{
 };
 
 use super::OnboardingSlide;
-use crate::model::{NoAiConfirmationSource, OnboardingStateModel};
+use crate::model::{AiSetupChoice, NoAiConfirmationSource, OnboardingStateModel};
 use crate::slides::{bottom_nav, layout, slide_content};
-use crate::visuals::{intention_terminal_visual, intention_visual};
-use crate::{OnboardingIntention, AI_FEATURES};
+
+/// Checklist shown on the "Use Warp agent" card.
+const WARP_AGENT_FEATURES: &[&str] = &[
+    "Best harness for terminal tasks and agentic coding",
+    "Frontier models from OpenAI, Anthropic, and Google",
+    "Model routing across frontier and open-weight models",
+    "Multi-agent orchestration",
+];
 
 #[derive(Debug, Clone)]
-pub enum IntentionSlideAction {
-    SelectOption { index: usize },
+pub enum AiSetupSlideAction {
+    SelectWarpAgent,
+    SelectThirdParty,
     BackClicked,
     NextClicked,
+    NoAiClicked,
 }
 
-pub struct IntentionSlide {
+/// The "Choose your AI setup" slide (DES-816 V3), shown on the AI-first path for
+/// users enrolled in the FREE_AI_REMOVAL experiment arm. Forks between the Warp
+/// agent (paid-plan path) and third-party agents (works on Free), with an
+/// "I don't want AI" escape onto the terminal-only path.
+pub struct AiSetupSlide {
     onboarding_state: ModelHandle<OnboardingStateModel>,
-    agent_driven_development_mouse_state: MouseStateHandle,
-    classic_terminal_mouse_state: MouseStateHandle,
+    warp_agent_mouse_state: MouseStateHandle,
+    third_party_mouse_state: MouseStateHandle,
     back_button: button::Button,
     next_button: button::Button,
+    no_ai_button: button::Button,
     scroll_state: ClippedScrollStateHandle,
 }
 
-impl IntentionSlide {
+impl AiSetupSlide {
     pub(crate) fn new(onboarding_state: ModelHandle<OnboardingStateModel>) -> Self {
         Self {
             onboarding_state,
-            agent_driven_development_mouse_state: MouseStateHandle::default(),
-            classic_terminal_mouse_state: MouseStateHandle::default(),
+            warp_agent_mouse_state: MouseStateHandle::default(),
+            third_party_mouse_state: MouseStateHandle::default(),
             back_button: button::Button::default(),
             next_button: button::Button::default(),
+            no_ai_button: button::Button::default(),
             scroll_state: ClippedScrollStateHandle::new(),
         }
     }
 
-    fn model_intention(&self, app: &AppContext) -> OnboardingIntention {
-        *self.onboarding_state.as_ref(app).intention()
+    // The final DES-816 visual exports have not landed yet, so the right panel
+    // reuses existing bundled assets that match each choice: the agent
+    // experience for "Use Warp agent" and the CLI-agent toolbar for
+    // "Use third party agents".
+    pub(crate) const VISUAL_IMAGE_PATHS: &'static [&'static str] = &[
+        "async/png/onboarding/welcome_agent.png",
+        "async/png/onboarding/thirdparty_toolbar_enabled_vertical.png",
+    ];
+
+    fn choice(&self, app: &AppContext) -> AiSetupChoice {
+        self.onboarding_state.as_ref(app).ai_setup_choice()
     }
 
-    fn render_content(&self, appearance: &Appearance, selected_index: usize) -> Box<dyn Element> {
-        let bottom_nav = Align::new(self.render_bottom_nav(appearance, selected_index)).finish();
+    fn render_content(
+        &self,
+        appearance: &Appearance,
+        choice: AiSetupChoice,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let bottom_nav = Align::new(self.render_bottom_nav(appearance, app)).finish();
 
         slide_content::onboarding_slide_content(
             vec![
                 Align::new(self.render_header(appearance)).left().finish(),
-                Align::new(self.render_options(appearance, selected_index)).finish(),
+                Align::new(self.render_options(appearance, choice)).finish(),
             ],
             bottom_nav,
             self.scroll_state.clone(),
@@ -83,7 +110,7 @@ impl IntentionSlide {
 
         let title = appearance
             .ui_builder()
-            .paragraph("Welcome to Warp")
+            .paragraph("Choose your AI setup")
             .with_style(UiComponentStyles {
                 font_size: Some(36.),
                 font_weight: Some(Weight::Medium),
@@ -93,7 +120,7 @@ impl IntentionSlide {
             .finish();
 
         let subtitle = FormattedTextElement::from_str(
-            "How do you want to work?",
+            "Choose if you'd like to use Warp Agent or third party agents.",
             appearance.ui_font_family(),
             16.,
         )
@@ -116,39 +143,43 @@ impl IntentionSlide {
             .finish()
     }
 
-    fn render_options(&self, appearance: &Appearance, selected_index: usize) -> Box<dyn Element> {
-        let agent_card = self.render_agent_card(
+    fn render_options(&self, appearance: &Appearance, choice: AiSetupChoice) -> Box<dyn Element> {
+        let warp_agent_card = self.render_warp_agent_card(
             appearance,
-            selected_index == 0,
-            self.agent_driven_development_mouse_state.clone(),
+            matches!(choice, AiSetupChoice::WarpAgent),
+            self.warp_agent_mouse_state.clone(),
         );
 
-        let terminal_card = self.render_terminal_card(
+        let third_party_card = self.render_third_party_card(
             appearance,
-            selected_index == 1,
-            self.classic_terminal_mouse_state.clone(),
+            matches!(choice, AiSetupChoice::ThirdParty),
+            self.third_party_mouse_state.clone(),
         );
 
         Container::new(
             Flex::column()
                 .with_main_axis_size(MainAxisSize::Min)
                 .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
-                .with_child(Container::new(agent_card).with_margin_bottom(12.).finish())
-                .with_child(terminal_card)
+                .with_child(
+                    Container::new(warp_agent_card)
+                        .with_margin_bottom(12.)
+                        .finish(),
+                )
+                .with_child(third_party_card)
                 .finish(),
         )
         .with_margin_top(38.)
         .finish()
     }
 
-    /// Shared chrome for an intention-slide option card. Applies the selected/unselected
+    /// Shared chrome for an AI-setup option card. Applies the selected/unselected
     /// background + border + rounded corners, wires up hover/click, and emits the
-    /// `SelectOption` action for the provided `index`.
+    /// provided select action.
     fn render_card_chrome(
         appearance: &Appearance,
         is_selected: bool,
-        index: usize,
         mouse_state: MouseStateHandle,
+        select_action: AiSetupSlideAction,
         content: Box<dyn Element>,
     ) -> Box<dyn Element> {
         const RADIUS: f32 = 8.;
@@ -177,12 +208,12 @@ impl IntentionSlide {
         })
         .with_cursor(Cursor::PointingHand)
         .on_click(move |ctx, _, _| {
-            ctx.dispatch_typed_action(IntentionSlideAction::SelectOption { index });
+            ctx.dispatch_typed_action(select_action.clone());
         })
         .finish()
     }
 
-    fn render_agent_card(
+    fn render_warp_agent_card(
         &self,
         appearance: &Appearance,
         is_selected: bool,
@@ -196,13 +227,11 @@ impl IntentionSlide {
             internal_colors::text_sub(theme, bg_solid)
         };
         let description_color = internal_colors::text_sub(theme, bg_solid);
-        let checklist_color = label_color;
-        let icon_fill = Fill::Solid(label_color);
 
         let header_row = {
             let label = appearance
                 .ui_builder()
-                .paragraph("Build faster with AI agents")
+                .paragraph("Use Warp Agent")
                 .with_style(UiComponentStyles {
                     font_size: Some(16.),
                     font_weight: Some(Weight::Semibold),
@@ -212,35 +241,38 @@ impl IntentionSlide {
                 .build()
                 .finish();
 
-            let mut icon_row = Flex::row()
-                .with_main_axis_size(MainAxisSize::Min)
-                .with_cross_axis_alignment(CrossAxisAlignment::Center);
-            for (i, icon) in [Icon::Oz, Icon::ClaudeLogo, Icon::OpenAILogo]
-                .iter()
-                .enumerate()
-            {
-                let el = ConstrainedBox::new(icon.to_warpui_icon(icon_fill).finish())
-                    .with_width(16.)
-                    .with_height(16.)
+            let badge = {
+                let green = theme.ansi_fg_green();
+                let badge_text = appearance
+                    .ui_builder()
+                    .paragraph("Access more models")
+                    .with_style(UiComponentStyles {
+                        font_size: Some(12.),
+                        font_weight: Some(Weight::Normal),
+                        font_color: Some(green),
+                        ..Default::default()
+                    })
+                    .build()
                     .finish();
-                icon_row = if i == 0 {
-                    icon_row.with_child(el)
-                } else {
-                    icon_row.with_child(Container::new(el).with_margin_left(8.).finish())
-                };
-            }
+                Container::new(badge_text)
+                    .with_corner_radius(CornerRadius::with_all(Radius::Pixels(11.)))
+                    .with_border(Border::all(1.).with_border_fill(Fill::Solid(green)))
+                    .with_horizontal_padding(8.)
+                    .with_vertical_padding(3.)
+                    .finish()
+            };
 
             Flex::row()
                 .with_main_axis_size(MainAxisSize::Max)
                 .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
                 .with_cross_axis_alignment(CrossAxisAlignment::Center)
                 .with_child(label)
-                .with_child(icon_row.finish())
+                .with_child(badge)
                 .finish()
         };
 
         let description = FormattedTextElement::from_str(
-            "An agent-first experience with best in class terminal support. Get terminal and agent driven development AI features like:",
+            "State of the art agent harness deeply integrated into the terminal.",
             appearance.ui_font_family(),
             14.,
         )
@@ -251,18 +283,17 @@ impl IntentionSlide {
         .finish();
 
         let checklist = {
-            let items = AI_FEATURES;
-            // When the agent card is selected, use the theme's green to match the
+            // When the card is selected, use the theme's green to match the
             // "Blended ANSI/green_fg" token in the design.
             let check_fill = if is_selected {
                 Fill::Solid(theme.ansi_fg_green())
             } else {
-                Fill::Solid(checklist_color)
+                Fill::Solid(label_color)
             };
             let mut col = Flex::column()
                 .with_main_axis_size(MainAxisSize::Min)
                 .with_cross_axis_alignment(CrossAxisAlignment::Start);
-            for &item in items {
+            for &item in WARP_AGENT_FEATURES {
                 let icon_el = ConstrainedBox::new(Icon::Check.to_warpui_icon(check_fill).finish())
                     .with_width(16.)
                     .with_height(16.)
@@ -273,7 +304,7 @@ impl IntentionSlide {
                     .with_style(UiComponentStyles {
                         font_size: Some(14.),
                         font_weight: Some(Weight::Normal),
-                        font_color: Some(checklist_color),
+                        font_color: Some(label_color),
                         ..Default::default()
                     })
                     .build()
@@ -302,10 +333,16 @@ impl IntentionSlide {
             .with_child(Container::new(checklist).with_margin_top(12.).finish())
             .finish();
 
-        Self::render_card_chrome(appearance, is_selected, 0, mouse_state, content)
+        Self::render_card_chrome(
+            appearance,
+            is_selected,
+            mouse_state,
+            AiSetupSlideAction::SelectWarpAgent,
+            content,
+        )
     }
 
-    fn render_terminal_card(
+    fn render_third_party_card(
         &self,
         appearance: &Appearance,
         is_selected: bool,
@@ -321,7 +358,7 @@ impl IntentionSlide {
 
         let label = appearance
             .ui_builder()
-            .paragraph("Just use the terminal")
+            .paragraph("Use third party agents")
             .with_style(UiComponentStyles {
                 font_size: Some(16.),
                 font_weight: Some(Weight::Semibold),
@@ -331,36 +368,8 @@ impl IntentionSlide {
             .build()
             .finish();
 
-        let badge = {
-            let badge_text = appearance
-                .ui_builder()
-                .paragraph("No AI features")
-                .with_style(UiComponentStyles {
-                    font_size: Some(12.),
-                    font_weight: Some(Weight::Semibold),
-                    font_color: Some(text_color),
-                    ..Default::default()
-                })
-                .build()
-                .finish();
-            Container::new(badge_text)
-                .with_background(internal_colors::fg_overlay_2(theme))
-                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(3.)))
-                .with_horizontal_padding(4.)
-                .with_vertical_padding(2.)
-                .finish()
-        };
-
-        let header_row = Flex::row()
-            .with_main_axis_size(MainAxisSize::Max)
-            .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
-            .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_child(label)
-            .with_child(badge)
-            .finish();
-
         let description = FormattedTextElement::from_str(
-            "A modern terminal optimized for speed, context, and control without AI.",
+            "Use agents like Claude Code, Codex, and Gemini.",
             appearance.ui_font_family(),
             14.,
         )
@@ -373,18 +382,20 @@ impl IntentionSlide {
         let content = Flex::column()
             .with_main_axis_size(MainAxisSize::Min)
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
-            .with_child(header_row)
+            .with_child(label)
             .with_child(Container::new(description).with_margin_top(12.).finish())
             .finish();
 
-        Self::render_card_chrome(appearance, is_selected, 1, mouse_state, content)
+        Self::render_card_chrome(
+            appearance,
+            is_selected,
+            mouse_state,
+            AiSetupSlideAction::SelectThirdParty,
+            content,
+        )
     }
 
-    fn render_bottom_nav(
-        &self,
-        appearance: &Appearance,
-        selected_index: usize,
-    ) -> Box<dyn Element> {
+    fn render_bottom_nav(&self, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
         let back_button = self.back_button.render(
             appearance,
             button::Params {
@@ -392,199 +403,155 @@ impl IntentionSlide {
                 theme: &button::themes::Naked,
                 options: button::Options {
                     on_click: Some(Box::new(|ctx, _app, _pos| {
-                        ctx.dispatch_typed_action(IntentionSlideAction::BackClicked);
+                        ctx.dispatch_typed_action(AiSetupSlideAction::BackClicked);
                     })),
                     ..button::Options::default(appearance)
                 },
             },
         );
 
-        let new_settings_modes = FeatureFlag::OpenWarpNewSettingsModes.is_enabled();
-        let next_text = if !new_settings_modes && selected_index == 1 {
-            "Get Warping"
-        } else {
-            "Next"
-        };
+        let no_ai_keystroke = Keystroke::parse("cmdorctrl-enter").unwrap_or_default();
+        let no_ai_button = self.no_ai_button.render(
+            appearance,
+            button::Params {
+                content: button::Content::Label("I don't want AI".into()),
+                theme: &button::themes::Naked,
+                options: button::Options {
+                    keystroke: Some(no_ai_keystroke),
+                    on_click: Some(Box::new(|ctx, _app, _pos| {
+                        ctx.dispatch_typed_action(AiSetupSlideAction::NoAiClicked);
+                    })),
+                    ..button::Options::default(appearance)
+                },
+            },
+        );
+
         let enter = Keystroke::parse("enter").unwrap_or_default();
         let next_button = self.next_button.render(
             appearance,
             button::Params {
-                content: button::Content::Label(next_text.into()),
+                content: button::Content::Label("Next".into()),
                 theme: &button::themes::Primary,
                 options: button::Options {
                     keystroke: Some(enter),
                     on_click: Some(Box::new(|ctx, _app, _pos| {
-                        ctx.dispatch_typed_action(IntentionSlideAction::NextClicked);
+                        ctx.dispatch_typed_action(AiSetupSlideAction::NextClicked);
                     })),
                     ..button::Options::default(appearance)
                 },
             },
         );
 
-        let is_terminal = selected_index == 1;
-        let (step_index, step_count) = if new_settings_modes {
-            if is_terminal {
-                (0, 4)
-            } else {
-                (0, 5)
-            }
-        } else {
-            (1, 4)
-        };
+        let right_buttons = Flex::row()
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(no_ai_button)
+            .with_child(Container::new(next_button).with_margin_left(8.).finish())
+            .finish();
+
+        let (step_index, step_count) = self.onboarding_state.as_ref(app).progress();
         bottom_nav::onboarding_bottom_nav(
             appearance,
             step_index,
             step_count,
             Some(back_button),
-            Some(next_button),
+            Some(right_buttons),
         )
     }
 
-    /// All onboarding image paths used by the intention slide visual.
-    pub(crate) const VISUAL_IMAGE_PATHS: &'static [&'static str] = &[
-        "async/png/onboarding/welcome_agent.png",
-        "async/png/onboarding/welcome_terminal.png",
-    ];
-
-    fn render_visual(&self, appearance: &Appearance, selected_index: usize) -> Box<dyn Element> {
-        let theme = appearance.theme();
-
-        if FeatureFlag::OpenWarpNewSettingsModes.is_enabled() {
-            let path = if selected_index == 1 {
-                Self::VISUAL_IMAGE_PATHS[1]
-            } else {
-                Self::VISUAL_IMAGE_PATHS[0]
-            };
-            layout::onboarding_right_panel_with_bg(path, layout::FOREGROUND_LAYOUT_DEFAULT)
-        } else {
-            let panel_background = internal_colors::neutral_2(theme);
-            let neutral = internal_colors::neutral_4(theme);
-            let neutral_highlight = internal_colors::neutral_6(theme);
-            let accent = internal_colors::accent(theme);
-
-            let visual = if selected_index == 1 {
-                intention_terminal_visual(
-                    panel_background,
-                    neutral,
-                    neutral_highlight,
-                    accent.into_solid(),
-                )
-            } else {
-                let blue = theme.ansi_fg_blue();
-                let green = theme.ansi_fg_green();
-                let yellow = theme.ansi_fg_yellow();
-                intention_visual(panel_background, neutral, blue, green, yellow)
-            };
-
-            Container::new(visual)
-                .with_background_color(internal_colors::neutral_1(theme))
-                .finish()
+    fn render_visual(&self, choice: AiSetupChoice) -> Box<dyn Element> {
+        match choice {
+            AiSetupChoice::WarpAgent => layout::onboarding_right_panel_with_bg(
+                Self::VISUAL_IMAGE_PATHS[0],
+                layout::FOREGROUND_LAYOUT_DEFAULT,
+            ),
+            AiSetupChoice::ThirdParty => layout::onboarding_right_panel_with_bg(
+                Self::VISUAL_IMAGE_PATHS[1],
+                layout::FOREGROUND_LAYOUT_THIRD_PARTY,
+            ),
         }
     }
 }
 
-impl Entity for IntentionSlide {
+impl Entity for AiSetupSlide {
     type Event = ();
 }
 
-impl View for IntentionSlide {
+impl View for AiSetupSlide {
     fn ui_name() -> &'static str {
-        "IntentionSlide"
+        "AiSetupSlide"
     }
 
     fn render(&self, app: &AppContext) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
-
-        let intention = self.model_intention(app);
-
-        let selected_index = match intention {
-            OnboardingIntention::AgentDrivenDevelopment => 0,
-            OnboardingIntention::Terminal => 1,
-        };
+        let choice = self.choice(app);
 
         // Background is rendered by the parent onboarding view (including background images).
         layout::static_left(
-            || self.render_content(appearance, selected_index),
-            || self.render_visual(appearance, selected_index),
+            || self.render_content(appearance, choice, app),
+            || self.render_visual(choice),
         )
     }
 }
 
-impl IntentionSlide {
-    fn select_option(&mut self, index: usize, ctx: &mut ViewContext<Self>) {
-        self.onboarding_state.update(ctx, |model, ctx| match index {
-            0 => model.set_intention_agent_driven_development(ctx),
-            1 => model.set_intention_terminal(ctx),
-            _ => {}
+impl AiSetupSlide {
+    fn select_choice(&mut self, choice: AiSetupChoice, ctx: &mut ViewContext<Self>) {
+        self.onboarding_state.update(ctx, |model, ctx| {
+            model.set_ai_setup_choice(choice, ctx);
         });
         ctx.notify();
     }
 
     fn next(&mut self, ctx: &mut ViewContext<Self>) {
         self.onboarding_state.update(ctx, |model, ctx| {
-            if FeatureFlag::OpenWarpNewSettingsModes.is_enabled() {
-                match model.intention() {
-                    // "Just use the terminal" confirms leaving AI behind before advancing.
-                    OnboardingIntention::Terminal => {
-                        model.request_no_ai_confirmation(NoAiConfirmationSource::Intention, ctx);
-                    }
-                    // Agent intention routes to the next step (the AI-setup fork).
-                    OnboardingIntention::AgentDrivenDevelopment => model.next(ctx),
-                }
-            } else {
-                match model.intention() {
-                    OnboardingIntention::Terminal => {
-                        model.complete(ctx);
-                    }
-                    OnboardingIntention::AgentDrivenDevelopment => {
-                        model.next(ctx);
-                    }
-                }
-            }
+            model.next(ctx);
         });
     }
 }
 
-impl OnboardingSlide for IntentionSlide {
+impl OnboardingSlide for AiSetupSlide {
     fn on_up(&mut self, ctx: &mut ViewContext<Self>) {
-        let selected_index: usize = match self.model_intention(ctx) {
-            OnboardingIntention::AgentDrivenDevelopment => 0,
-            OnboardingIntention::Terminal => 1,
-        };
-
-        self.select_option(selected_index.saturating_sub(1), ctx);
+        self.select_choice(AiSetupChoice::WarpAgent, ctx);
     }
 
     fn on_down(&mut self, ctx: &mut ViewContext<Self>) {
-        let selected_index: usize = match self.model_intention(ctx) {
-            OnboardingIntention::AgentDrivenDevelopment => 0,
-            OnboardingIntention::Terminal => 1,
-        };
-
-        self.select_option((selected_index + 1).min(1), ctx);
+        self.select_choice(AiSetupChoice::ThirdParty, ctx);
     }
 
     fn on_enter(&mut self, ctx: &mut ViewContext<Self>) {
         self.next(ctx);
     }
+
+    fn on_cmd_or_ctrl_enter(&mut self, ctx: &mut ViewContext<Self>) {
+        self.onboarding_state.update(ctx, |model, ctx| {
+            model.request_no_ai_confirmation(NoAiConfirmationSource::AiSetup, ctx);
+        });
+    }
 }
 
-impl TypedActionView for IntentionSlide {
-    type Action = IntentionSlideAction;
+impl TypedActionView for AiSetupSlide {
+    type Action = AiSetupSlideAction;
 
     fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
         match action {
-            IntentionSlideAction::SelectOption { index } => {
-                self.select_option(*index, ctx);
+            AiSetupSlideAction::SelectWarpAgent => {
+                self.select_choice(AiSetupChoice::WarpAgent, ctx);
             }
-            IntentionSlideAction::BackClicked => {
-                let onboarding_state = self.onboarding_state.clone();
-                onboarding_state.update(ctx, |model, ctx| {
+            AiSetupSlideAction::SelectThirdParty => {
+                self.select_choice(AiSetupChoice::ThirdParty, ctx);
+            }
+            AiSetupSlideAction::BackClicked => {
+                self.onboarding_state.update(ctx, |model, ctx| {
                     model.back(ctx);
                 });
             }
-            IntentionSlideAction::NextClicked => {
+            AiSetupSlideAction::NextClicked => {
                 self.next(ctx);
+            }
+            AiSetupSlideAction::NoAiClicked => {
+                self.onboarding_state.update(ctx, |model, ctx| {
+                    model.request_no_ai_confirmation(NoAiConfirmationSource::AiSetup, ctx);
+                });
             }
         }
     }

--- a/crates/onboarding/src/slides/bottom_nav.rs
+++ b/crates/onboarding/src/slides/bottom_nav.rs
@@ -14,22 +14,28 @@ pub fn onboarding_bottom_nav(
     next_button: Option<Box<dyn Element>>,
 ) -> Box<dyn Element> {
     let dots = progress_dots::progress_dots(step_count, step_index, appearance);
+    let dots_row = Container::new(Align::new(dots).finish())
+        .with_margin_bottom(16.)
+        .finish();
 
     let back_button = back_button.unwrap_or_else(|| Empty::new().finish());
     let next_button = next_button.unwrap_or_else(|| Empty::new().finish());
 
-    // Use equal-size flex slots on the left and right so the dots remain centered regardless of the
-    // button widths.
     let left = Shrinkable::new(1., Align::new(back_button).left().finish()).finish();
     let right = Shrinkable::new(1., Align::new(next_button).right().finish()).finish();
+    let buttons_row = Flex::row()
+        .with_main_axis_size(MainAxisSize::Max)
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .with_child(left)
+        .with_child(right)
+        .finish();
 
     Container::new(
-        Flex::row()
-            .with_main_axis_size(MainAxisSize::Max)
-            .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_child(left)
-            .with_child(dots)
-            .with_child(right)
+        Flex::column()
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
+            .with_child(dots_row)
+            .with_child(buttons_row)
             .finish(),
     )
     .finish()

--- a/crates/onboarding/src/slides/customize_slide.rs
+++ b/crates/onboarding/src/slides/customize_slide.rs
@@ -129,8 +129,9 @@ impl CustomizeUISlide {
         appearance: &Appearance,
         intention: OnboardingIntention,
         ui: &UICustomizationSettings,
+        app: &AppContext,
     ) -> Box<dyn Element> {
-        let bottom_nav = Align::new(self.render_bottom_nav(appearance, intention)).finish();
+        let bottom_nav = Align::new(self.render_bottom_nav(appearance, app)).finish();
 
         slide_content::onboarding_slide_content(
             vec![
@@ -404,11 +405,7 @@ impl CustomizeUISlide {
 
     // --- Bottom nav ---
 
-    fn render_bottom_nav(
-        &self,
-        appearance: &Appearance,
-        intention: OnboardingIntention,
-    ) -> Box<dyn Element> {
+    fn render_bottom_nav(&self, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
         let back_button = self.back_button.render(
             appearance,
             button::Params {
@@ -439,8 +436,7 @@ impl CustomizeUISlide {
             },
         );
 
-        let is_terminal = matches!(intention, OnboardingIntention::Terminal);
-        let (step_index, step_count) = if is_terminal { (1, 4) } else { (1, 5) };
+        let (step_index, step_count) = self.onboarding_state.as_ref(app).progress();
         bottom_nav::onboarding_bottom_nav(
             appearance,
             step_index,
@@ -642,7 +638,7 @@ impl View for CustomizeUISlide {
         let ui = self.model_ui_customization(app);
 
         layout::static_left(
-            || self.render_content(appearance, intention, &ui),
+            || self.render_content(appearance, intention, &ui, app),
             || self.render_visual(appearance, intention, &ui),
         )
     }

--- a/crates/onboarding/src/slides/mod.rs
+++ b/crates/onboarding/src/slides/mod.rs
@@ -1,4 +1,6 @@
 mod agent_slide;
+mod ai_access_slide;
+mod ai_setup_slide;
 mod bottom_nav;
 mod customize_slide;
 mod intention_slide;
@@ -13,9 +15,9 @@ mod third_party_slide;
 mod toggle_card;
 mod two_line_button;
 
-pub use agent_slide::{
-    AgentAutonomy, AgentDevelopmentSettings, AgentSlide, AgentSlideEvent, OnboardingModelInfo,
-};
+pub use agent_slide::{AgentAutonomy, AgentDevelopmentSettings, AgentSlide, OnboardingModelInfo};
+pub use ai_access_slide::{AiAccessSlide, AiAccessSlideEvent};
+pub use ai_setup_slide::AiSetupSlide;
 pub use bottom_nav::onboarding_bottom_nav;
 pub use customize_slide::CustomizeUISlide;
 pub use intention_slide::IntentionSlide;

--- a/crates/onboarding/src/slides/slide_content.rs
+++ b/crates/onboarding/src/slides/slide_content.rs
@@ -55,7 +55,7 @@ pub fn onboarding_slide_content(
         .with_child(Shrinkable::new(1., scrollable).finish())
         .with_child(
             Container::new(bottom_nav)
-                .with_margin_top(24.)
+                .with_margin_top(16.)
                 .with_padding_right(PADDING)
                 .finish(),
         )
@@ -65,7 +65,7 @@ pub fn onboarding_slide_content(
     // inside the scrollable and bottom nav so the scrollbar stays at the edge.
     Container::new(outer)
         .with_padding_top(PADDING)
-        .with_padding_bottom(PADDING)
+        .with_padding_bottom(PADDING - 16.)
         .with_padding_left(PADDING)
         .finish()
 }

--- a/crates/onboarding/src/slides/third_party_slide.rs
+++ b/crates/onboarding/src/slides/third_party_slide.rs
@@ -111,8 +111,9 @@ impl ThirdPartySlide {
         cli_toolbar_enabled: bool,
         show_agent_notifications: bool,
         intention: OnboardingIntention,
+        app: &AppContext,
     ) -> Box<dyn Element> {
-        let bottom_nav = Align::new(self.render_bottom_nav(appearance, intention)).finish();
+        let bottom_nav = Align::new(self.render_bottom_nav(appearance, app)).finish();
 
         let mut sections = vec![
             self.render_header(appearance),
@@ -263,11 +264,7 @@ impl ThirdPartySlide {
         .finish()
     }
 
-    fn render_bottom_nav(
-        &self,
-        appearance: &Appearance,
-        intention: OnboardingIntention,
-    ) -> Box<dyn Element> {
+    fn render_bottom_nav(&self, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
         let back_button = self.back_button.render(
             appearance,
             button::Params {
@@ -298,8 +295,7 @@ impl ThirdPartySlide {
             },
         );
 
-        let is_terminal = matches!(intention, OnboardingIntention::Terminal);
-        let (step_index, step_count) = if is_terminal { (2, 4) } else { (3, 5) };
+        let (step_index, step_count) = self.onboarding_state.as_ref(app).progress();
         bottom_nav::onboarding_bottom_nav(
             appearance,
             step_index,
@@ -361,6 +357,7 @@ impl View for ThirdPartySlide {
                     cli_toolbar_enabled,
                     show_agent_notifications,
                     intention,
+                    app,
                 )
             },
             || self.render_visual(cli_toolbar_enabled, show_agent_notifications, vertical),

--- a/crates/onboarding/src/telemetry.rs
+++ b/crates/onboarding/src/telemetry.rs
@@ -37,6 +37,12 @@ pub enum OnboardingEvent {
     SlideNavigatedNext,
     /// The user navigated to the previous slide.
     SlideNavigatedBack,
+    /// The user was shown the "Are you sure you don't want AI?" confirmation modal.
+    NoAiConfirmationShown,
+    /// The user confirmed they don't want AI in the confirmation modal.
+    NoAiConfirmed,
+    /// The user chose to keep AI ("Give me AI features") in the confirmation modal.
+    NoAiConfirmationCancelled,
     /// The user clicked the "Upgrade" button on the "Customize your agent" slide.
     AgentSlideUpgradeClicked,
     /// The user clicked the "Log in" link on the welcome/intro slide.
@@ -58,6 +64,9 @@ impl TelemetryEvent for OnboardingEvent {
             OnboardingEvent::CalloutCompleted { .. } => "onboarding_callout_completed",
             OnboardingEvent::SlideNavigatedNext => "onboarding_slide_navigated_next",
             OnboardingEvent::SlideNavigatedBack => "onboarding_slide_navigated_back",
+            OnboardingEvent::NoAiConfirmationShown => "onboarding_no_ai_confirmation_shown",
+            OnboardingEvent::NoAiConfirmed => "onboarding_no_ai_confirmed",
+            OnboardingEvent::NoAiConfirmationCancelled => "onboarding_no_ai_confirmation_cancelled",
             OnboardingEvent::AgentSlideUpgradeClicked => "onboarding_agent_slide_upgrade_clicked",
             OnboardingEvent::WelcomeLoginClicked => "onboarding_welcome_login_clicked",
         }
@@ -96,6 +105,9 @@ impl TelemetryEvent for OnboardingEvent {
             })),
             OnboardingEvent::SlideNavigatedNext => None,
             OnboardingEvent::SlideNavigatedBack => None,
+            OnboardingEvent::NoAiConfirmationShown => None,
+            OnboardingEvent::NoAiConfirmed => None,
+            OnboardingEvent::NoAiConfirmationCancelled => None,
             OnboardingEvent::AgentSlideUpgradeClicked => None,
             OnboardingEvent::WelcomeLoginClicked => None,
         }
@@ -117,6 +129,13 @@ impl TelemetryEvent for OnboardingEvent {
             OnboardingEvent::CalloutCompleted { .. } => "User completed the callout flow",
             OnboardingEvent::SlideNavigatedNext => "User navigated to the next slide",
             OnboardingEvent::SlideNavigatedBack => "User navigated to the previous slide",
+            OnboardingEvent::NoAiConfirmationShown => "User was shown the no-AI confirmation modal",
+            OnboardingEvent::NoAiConfirmed => {
+                "User confirmed they don't want AI in the confirmation modal"
+            }
+            OnboardingEvent::NoAiConfirmationCancelled => {
+                "User chose to keep AI in the confirmation modal"
+            }
             OnboardingEvent::AgentSlideUpgradeClicked => {
                 "User clicked the Upgrade button on the Customize your agent slide"
             }
@@ -156,6 +175,13 @@ impl TelemetryEventDesc for OnboardingEventDiscriminant {
             OnboardingEventDiscriminant::CalloutCompleted => "onboarding_callout_completed",
             OnboardingEventDiscriminant::SlideNavigatedNext => "onboarding_slide_navigated_next",
             OnboardingEventDiscriminant::SlideNavigatedBack => "onboarding_slide_navigated_back",
+            OnboardingEventDiscriminant::NoAiConfirmationShown => {
+                "onboarding_no_ai_confirmation_shown"
+            }
+            OnboardingEventDiscriminant::NoAiConfirmed => "onboarding_no_ai_confirmed",
+            OnboardingEventDiscriminant::NoAiConfirmationCancelled => {
+                "onboarding_no_ai_confirmation_cancelled"
+            }
             OnboardingEventDiscriminant::AgentSlideUpgradeClicked => {
                 "onboarding_agent_slide_upgrade_clicked"
             }
@@ -184,6 +210,15 @@ impl TelemetryEventDesc for OnboardingEventDiscriminant {
             OnboardingEventDiscriminant::SlideNavigatedNext => "User navigated to the next slide",
             OnboardingEventDiscriminant::SlideNavigatedBack => {
                 "User navigated to the previous slide"
+            }
+            OnboardingEventDiscriminant::NoAiConfirmationShown => {
+                "User was shown the no-AI confirmation modal"
+            }
+            OnboardingEventDiscriminant::NoAiConfirmed => {
+                "User confirmed they don't want AI in the confirmation modal"
+            }
+            OnboardingEventDiscriminant::NoAiConfirmationCancelled => {
+                "User chose to keep AI in the confirmation modal"
             }
             OnboardingEventDiscriminant::AgentSlideUpgradeClicked => {
                 "User clicked the Upgrade button on the Customize your agent slide"


### PR DESCRIPTION
## Description

C2 of the REV-1625 stack (C1 is merged; this branch is rebased onto current `master`). Reworks onboarding for the world where Warp-provided AI is no longer free, guiding new users down one of three paths:

1. **Use Warp Agent** — Warp's agent, which now requires a subscription or bring-your-own-key / custom endpoint. Inference routes through Warp, so this path requires an account.
2. **Use third party agents** — e.g. Claude Code / Codex. Works while logged out; Warp-provided AI is turned off (`disable_oz`).
3. **Just use the terminal** — no AI.

Key changes:
- New **"Choose your AI setup"** slide forks the AI path into Warp Agent vs. third-party.
- Warp Agent continues to **"Choose how to access AI"** (subscription vs. BYOK / custom endpoint). **Next** is gated until a plan is active or a key/endpoint is configured, with a tooltip explaining why it's disabled.
- An **"I don't want AI"** escape hatch on the AI-setup, agent, and AI-access slides drops to the terminal-only path, so declining AI never dead-ends onboarding. The terminal path skips the third-party customize slide.
- The end-of-onboarding **account prompt** is purpose-aware: required for Warp Agent (server-side inference) and Warp Drive (cloud sync), optional/skippable for third-party (account encouraged, but you keep your 3p agents). Its cancel action routes into the sign-up flow.
- Progress dots are computed per-path (`OnboardingStateModel::progress()`) and render on their own line above the nav buttons.

Active for all new users via the `OpenWarpNewSettingsModes` feature flag; the legacy onboarding flow is unchanged.

## Linked Issue

Tracked in Linear (REV-1625) rather than a GitHub issue.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

Walked all three paths end to end (Warp Agent + subscription / BYOK, third-party, terminal), the "I don't want AI" escape from each AI slide, and the end-of-onboarding account prompt for each case (required vs. optional). Onboarding model unit tests pass: `cargo nextest run -p onboarding` (13 tests). UI reviewed with design.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

---
_Conversation: https://staging.warp.dev/conversation/3b2c870b-67c0-4469-acf6-30172be36c2c_
_Run: https://oz.staging.warp.dev/runs/019eb89c-4bdb-78e4-a7de-9b92d0258095_

_This PR was generated with [Oz](https://warp.dev/oz)._
