### PR TITLE
fix(macos): preserve native window chrome events

### DIFF
--- a/crates/warpui/src/platform/mac/objc/window.m
+++ b/crates/warpui/src/platform/mac/objc/window.m
@@ -214,42 +214,6 @@ static NSView *get_titlebar_container_view(NSWindow *window) {
     return [titleBarView superview];
 }
 
-static NSButton *standard_window_button_at_event(NSWindow *window, NSEvent *event) {
-    NSWindowButton buttons[] = {
-        NSWindowCloseButton,
-        NSWindowMiniaturizeButton,
-        NSWindowZoomButton,
-    };
-
-    for (NSUInteger i = 0; i < sizeof(buttons) / sizeof(buttons[0]); i++) {
-        NSButton *button = [window standardWindowButton:buttons[i]];
-        if (button && !button.hidden) {
-            NSPoint point = [button convertPoint:event.locationInWindow fromView:nil];
-            if (NSPointInRect(point, button.bounds)) {
-                return button;
-            }
-        }
-    }
-
-    return nil;
-}
-
-static BOOL event_is_over_resize_edge(NSWindow *window, NSEvent *event) {
-    if ((window.styleMask & NSWindowStyleMaskResizable) == 0 || !window.contentView) {
-        return NO;
-    }
-
-    NSPoint point = [window.contentView convertPoint:event.locationInWindow fromView:nil];
-    NSRect bounds = window.contentView.bounds;
-    if (!NSPointInRect(point, bounds)) {
-        return YES;
-    }
-
-    static const CGFloat RESIZE_EDGE_THICKNESS = 6.0;
-    return point.x <= RESIZE_EDGE_THICKNESS || point.y <= RESIZE_EDGE_THICKNESS ||
-           point.x >= NSMaxX(bounds) - RESIZE_EDGE_THICKNESS ||
-           point.y >= NSMaxY(bounds) - RESIZE_EDGE_THICKNESS;
-}
 
 // Configures titlebar height and traffic light button constraints for a window.
 // Returns the height constraint if newly created, or NULL if just updating.
@@ -353,6 +317,15 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
     }
 }
 
+@interface NSWindow (PrivateAPI)
+- (NSInteger)_resizeDirectionForMouseLocation:(NSPoint)location;
+@end
+
+@interface WarpWindow ()
+- (NSButton *)standardWindowButtonAtEvent:(NSEvent *)event;
+- (BOOL)eventIsOverResizeEdge:(NSEvent *)event;
+@end
+
 @implementation WarpWindow {
     // The windowState is managed on the Rust side.
     void *windowState;
@@ -439,16 +412,46 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
     return [super constrainFrameRect:frameRect toScreen:screen];
 }
 
+- (NSButton *)standardWindowButtonAtEvent:(NSEvent *)event {
+    NSWindowButton buttons[] = {
+        NSWindowCloseButton,
+        NSWindowMiniaturizeButton,
+        NSWindowZoomButton,
+    };
+
+    for (NSUInteger i = 0; i < sizeof(buttons) / sizeof(buttons[0]); i++) {
+        NSButton *button = [self standardWindowButton:buttons[i]];
+        if (button && !button.hidden) {
+            NSPoint point = [button convertPoint:event.locationInWindow fromView:nil];
+            if (NSPointInRect(point, button.bounds)) {
+                return button;
+            }
+        }
+    }
+
+    return nil;
+}
+
+- (BOOL)eventIsOverResizeEdge:(NSEvent *)event {
+    if ((self.styleMask & NSWindowStyleMaskResizable) == 0) {
+        return NO;
+    }
+    if ([self respondsToSelector:@selector(_resizeDirectionForMouseLocation:)]) {
+        return [self _resizeDirectionForMouseLocation:event.locationInWindow] != -1;
+    }
+    return NO;
+}
+
 - (void)sendEvent:(NSEvent *)event {
     switch (event.type) {
         case NSEventTypeLeftMouseDown: {
-            NSButton *windowButton = standard_window_button_at_event(self, event);
+            NSButton *windowButton = [self standardWindowButtonAtEvent:event];
             if (windowButton) {
                 _leftMouseDownStartedInNativeWindowChrome = NO;
                 [windowButton mouseDown:event];
                 break;
             }
-            _leftMouseDownStartedInNativeWindowChrome = event_is_over_resize_edge(self, event);
+            _leftMouseDownStartedInNativeWindowChrome = [self eventIsOverResizeEdge:event];
             [super sendEvent:event];
             break;
         }
@@ -462,7 +465,7 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
         // This breaks drag-and-drop for panes and tabs (see CLD-2581), so we work around it with
         // custom dispatching.
         case NSEventTypeLeftMouseUp:
-            if (_leftMouseDownStartedInNativeWindowChrome) {
+            if (_leftMouseDownStartedInNativeWindowChrome && @available(macOS 27, *)) {
                 [super sendEvent:event];
             } else {
                 [self.contentView mouseUp:event];
@@ -470,7 +473,7 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
             _leftMouseDownStartedInNativeWindowChrome = NO;
             break;
         case NSEventTypeLeftMouseDragged:
-            if (_leftMouseDownStartedInNativeWindowChrome) {
+            if (_leftMouseDownStartedInNativeWindowChrome && @available(macOS 27, *)) {
                 [super sendEvent:event];
             } else {
                 [self.contentView mouseDragged:event];

--- a/crates/warpui/src/platform/mac/objc/window.m
+++ b/crates/warpui/src/platform/mac/objc/window.m
@@ -214,7 +214,6 @@ static NSView *get_titlebar_container_view(NSWindow *window) {
     return [titleBarView superview];
 }
 
-
 // Configures titlebar height and traffic light button constraints for a window.
 // Returns the height constraint if newly created, or NULL if just updating.
 static NSLayoutConstraint *configure_titlebar_height(NSWindow *window, CGFloat height,

--- a/crates/warpui/src/platform/mac/objc/window.m
+++ b/crates/warpui/src/platform/mac/objc/window.m
@@ -214,6 +214,48 @@ static NSView *get_titlebar_container_view(NSWindow *window) {
     return [titleBarView superview];
 }
 
+static BOOL event_is_over_standard_window_button(NSWindow *window, NSEvent *event) {
+    NSWindowButton buttons[] = {
+        NSWindowCloseButton,
+        NSWindowMiniaturizeButton,
+        NSWindowZoomButton,
+    };
+
+    for (NSUInteger i = 0; i < sizeof(buttons) / sizeof(buttons[0]); i++) {
+        NSButton *button = [window standardWindowButton:buttons[i]];
+        if (button && !button.hidden) {
+            NSPoint point = [button convertPoint:event.locationInWindow fromView:nil];
+            if ([button hitTest:point]) {
+                return YES;
+            }
+        }
+    }
+
+    return NO;
+}
+
+static BOOL event_is_over_resize_edge(NSWindow *window, NSEvent *event) {
+    if ((window.styleMask & NSWindowStyleMaskResizable) == 0 || !window.contentView) {
+        return NO;
+    }
+
+    NSPoint point = [window.contentView convertPoint:event.locationInWindow fromView:nil];
+    NSRect bounds = window.contentView.bounds;
+    if (!NSPointInRect(point, bounds)) {
+        return YES;
+    }
+
+    static const CGFloat RESIZE_EDGE_THICKNESS = 6.0;
+    return point.x <= RESIZE_EDGE_THICKNESS || point.y <= RESIZE_EDGE_THICKNESS ||
+           point.x >= NSMaxX(bounds) - RESIZE_EDGE_THICKNESS ||
+           point.y >= NSMaxY(bounds) - RESIZE_EDGE_THICKNESS;
+}
+
+static BOOL event_is_over_native_window_chrome(NSWindow *window, NSEvent *event) {
+    return event_is_over_standard_window_button(window, event) ||
+           event_is_over_resize_edge(window, event);
+}
+
 // Configures titlebar height and traffic light button constraints for a window.
 // Returns the height constraint if newly created, or NULL if just updating.
 static NSLayoutConstraint *configure_titlebar_height(NSWindow *window, CGFloat height,
@@ -332,6 +374,7 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
     // macOS from cascading or clamping the window position while a tab-drag preview window is
     // being created and positioned under the cursor.
     BOOL _suppressFrameConstraintsDuringDrag;
+    BOOL _leftMouseDownStartedInNativeWindowChrome;
 }
 
 @synthesize testMode;
@@ -403,6 +446,12 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
 
 - (void)sendEvent:(NSEvent *)event {
     switch (event.type) {
+        case NSEventTypeLeftMouseDown:
+            _leftMouseDownStartedInNativeWindowChrome =
+                event_is_over_native_window_chrome(self, event);
+            [super sendEvent:event];
+            break;
+
         // In some cases, NSWindow's default sendEvent: implementation will dispatch a MouseDown
         // event and subsequent MouseDragged events to the content view, but then dispatch the
         // remaining MouseDragged events and MouseUp event elsewhere.
@@ -412,10 +461,19 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
         // This breaks drag-and-drop for panes and tabs (see CLD-2581), so we work around it with
         // custom dispatching.
         case NSEventTypeLeftMouseUp:
-            [self.contentView mouseUp:event];
+            if (_leftMouseDownStartedInNativeWindowChrome) {
+                [super sendEvent:event];
+            } else {
+                [self.contentView mouseUp:event];
+            }
+            _leftMouseDownStartedInNativeWindowChrome = NO;
             break;
         case NSEventTypeLeftMouseDragged:
-            [self.contentView mouseDragged:event];
+            if (_leftMouseDownStartedInNativeWindowChrome) {
+                [super sendEvent:event];
+            } else {
+                [self.contentView mouseDragged:event];
+            }
             break;
 
         // The NSWindow's default sendEvent: implementation does not propagate RightMouseDown events

--- a/crates/warpui/src/platform/mac/objc/window.m
+++ b/crates/warpui/src/platform/mac/objc/window.m
@@ -444,8 +444,8 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
         case NSEventTypeLeftMouseDown: {
             NSButton *windowButton = standard_window_button_at_event(self, event);
             if (windowButton) {
-                [windowButton mouseDown:event];
                 _leftMouseDownStartedInNativeWindowChrome = NO;
+                [windowButton mouseDown:event];
                 break;
             }
             _leftMouseDownStartedInNativeWindowChrome = event_is_over_resize_edge(self, event);

--- a/crates/warpui/src/platform/mac/objc/window.m
+++ b/crates/warpui/src/platform/mac/objc/window.m
@@ -214,7 +214,7 @@ static NSView *get_titlebar_container_view(NSWindow *window) {
     return [titleBarView superview];
 }
 
-static BOOL event_is_over_standard_window_button(NSWindow *window, NSEvent *event) {
+static NSButton *standard_window_button_at_event(NSWindow *window, NSEvent *event) {
     NSWindowButton buttons[] = {
         NSWindowCloseButton,
         NSWindowMiniaturizeButton,
@@ -225,13 +225,13 @@ static BOOL event_is_over_standard_window_button(NSWindow *window, NSEvent *even
         NSButton *button = [window standardWindowButton:buttons[i]];
         if (button && !button.hidden) {
             NSPoint point = [button convertPoint:event.locationInWindow fromView:nil];
-            if ([button hitTest:point]) {
-                return YES;
+            if (NSPointInRect(point, button.bounds)) {
+                return button;
             }
         }
     }
 
-    return NO;
+    return nil;
 }
 
 static BOOL event_is_over_resize_edge(NSWindow *window, NSEvent *event) {
@@ -249,11 +249,6 @@ static BOOL event_is_over_resize_edge(NSWindow *window, NSEvent *event) {
     return point.x <= RESIZE_EDGE_THICKNESS || point.y <= RESIZE_EDGE_THICKNESS ||
            point.x >= NSMaxX(bounds) - RESIZE_EDGE_THICKNESS ||
            point.y >= NSMaxY(bounds) - RESIZE_EDGE_THICKNESS;
-}
-
-static BOOL event_is_over_native_window_chrome(NSWindow *window, NSEvent *event) {
-    return event_is_over_standard_window_button(window, event) ||
-           event_is_over_resize_edge(window, event);
 }
 
 // Configures titlebar height and traffic light button constraints for a window.
@@ -446,11 +441,17 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
 
 - (void)sendEvent:(NSEvent *)event {
     switch (event.type) {
-        case NSEventTypeLeftMouseDown:
-            _leftMouseDownStartedInNativeWindowChrome =
-                event_is_over_native_window_chrome(self, event);
+        case NSEventTypeLeftMouseDown: {
+            NSButton *windowButton = standard_window_button_at_event(self, event);
+            if (windowButton) {
+                [windowButton mouseDown:event];
+                _leftMouseDownStartedInNativeWindowChrome = NO;
+                break;
+            }
+            _leftMouseDownStartedInNativeWindowChrome = event_is_over_resize_edge(self, event);
             [super sendEvent:event];
             break;
+        }
 
         // In some cases, NSWindow's default sendEvent: implementation will dispatch a MouseDown
         // event and subsequent MouseDragged events to the content view, but then dispatch the


### PR DESCRIPTION

https://github.com/user-attachments/assets/271b027e-063d-4091-862d-24886ae69b10

## summary

- preserve native AppKit event dispatch for macOS traffic light buttons and resize edges
- keep Warp's custom mouse event dispatch for pane and tab drag behavior
- latch event ownership from the initial mouse-down so content drags cannot switch to AppKit when crossing window chrome

## issue

On macOS 27 beta, clicking the native window controls or dragging resize edges does not affect the Warp window, while keyboard shortcuts still work. Warp currently redirects left mouse-up and drag events to its content view, which prevents AppKit from completing native window chrome interactions.

Closes #12389

## verification

- `xcrun clang -fsyntax-only -fblocks -fobjc-exceptions -Werror -Wno-deprecated-declarations -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I crates/warpui/src/platform/mac/objc crates/warpui/src/platform/mac/objc/window.m`
- `git diff --check`
- `cargo check -p warpui` using cargo and rustc provisioned through Nix

The Cargo check compiled dependencies through the `warpui` build script, then stopped because the installed Apple Command Line Tools do not include the Xcode `metal` and `metallib` shader compilers required by `crates/warpui/build.rs`.