### PR TITLE
fix(ssh): drop tmux control-mode commands after the underlying transport closes (#9900)

### DIFF
--- a/app/src/terminal/writeable_pty/pty_controller.rs
+++ b/app/src/terminal/writeable_pty/pty_controller.rs
@@ -719,6 +719,25 @@ impl<T: EventLoopSender> PtyController<T> {
             return;
         }
 
+        // Drop tmux commands whose target control-mode session has
+        // gone away (e.g. the underlying SSH transport dropped and
+        // killed the remote tmux). Without this guard the literal
+        // bytes `new-window -d ... '(builtin echo -n "^^^..."; cmd;
+        // builtin echo "|||$?$$$")|command cat; command sleep 1'`
+        // fall through to the local zsh, which prints
+        // `command not found: new-window` plus the inner
+        // instrumentation cmd for every emission (see #9900). The
+        // bytes were destined for tmux control mode, not the user's
+        // local shell, so silently dropping is the correct fallback.
+        if self.tmux_control_mode.is_none() && raw_tmux_command {
+            log::warn!(
+                "Dropping tmux control-mode command sent without an active \
+                 control-mode session (likely after the remote SSH/tmux \
+                 transport closed)."
+            );
+            return;
+        }
+
         let bytes_to_write = match &mut self.tmux_control_mode {
             None => bytes_to_write,
             Some(_) if raw_tmux_command => bytes_to_write,


### PR DESCRIPTION
## Description

Fixes #9900.

When an SSH session hosting tmux control mode drops (network timeout, broken pipe, etc.), the in-flight `PtyWrite::TmuxCommand` writes from command-instrumentation kept being delivered to the *local* zsh pty because the existing match block in `send_write_to_event_loop` (at [`app/src/terminal/writeable_pty/pty_controller.rs:722`](https://github.com/warpdotdev/warp/blob/master/app/src/terminal/writeable_pty/pty_controller.rs#L722)) had no special arm for *"no active control mode + raw tmux command"*. The literal bytes

```
new-window -d <…> -PF "<…>" '(builtin echo -n "^^^<id>|||"; <cmd>; builtin echo "|||$?\$\$\$")|command cat; command sleep 1'\n
```

fell through `None => bytes_to_write` and were written to whatever pty was now connected to that terminal — the user's local shell. The user observed eight such emissions in ~50 ms, each producing both a `command not found: new-window` error and a leaked `ltin echo -n "^^^…"` fragment from the inner instrumentation payload.

## Root cause

`pty_controller.rs:700-703` already had a `debug_assert!(self.tmux_control_mode.is_some(), "Received tmux command outside of control mode.")`, but it's debug-only — release builds silently fall through to the buggy match arm.

## Fix

Add a guard *before* the existing match block:

```rust
if self.tmux_control_mode.is_none() && raw_tmux_command {
    log::warn!(
        "Dropping tmux control-mode command sent without an active \
         control-mode session (likely after the remote SSH/tmux \
         transport closed)."
    );
    return;
}
```

`raw_tmux_command` is `true` only for `PtyWrite::TmuxCommand`; all other write kinds (user commands, agent input, raw bytes, native-shell completions) retain the existing "fall through to local pty" semantics so the user's own typing still executes after an SSH drop.

## Testing

- `cargo check -p warp --bin warp-oss` ✅
- `cargo fmt -p warp` ✅
- `cargo clippy -p warp --lib --no-deps -- -D warnings` ✅

Manual repro (per the issue):
1. SSH from Warp on macOS to a warpified remote host
2. Trigger directory-listing instrumentation by `cd dir`
3. Drop the network (turn off Wi-Fi) until SSH reports `client_loop: send disconnect: Broken pipe`
4. **Before:** local zsh prints repeated `zsh: command not found: new-window` plus `ltin echo -n "^^^…"` fragments
5. **After:** writes are dropped with a single `log::warn!`; no spurious commands reach the local shell

## Out of scope (deferred)

The companion ask from the issue — *"a single, clear notice should be shown to the user"* — isn't part of this PR. This change is the lower-half plumbing (stop the bleed); a user-facing toast can be a separate ticket targeting `RemoteServerManager` / SSH transport state, which is where the disconnect signal originates.

## Server API dependencies

N/A — client-only change.

- [x] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4): **No**

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fix `command not found: new-window` and `ltin echo` fragments leaking into the local shell after an SSH session with tmux control mode drops (#9900).