### PR TITLE
Drain queued prompts per conversation when a sibling block masks turn end

### DIFF
--- a/app/src/ai/blocklist/block/model.rs
+++ b/app/src/ai/blocklist/block/model.rs
@@ -233,6 +233,7 @@ pub mod testing {
         input: Vec<AIAgentInput>,
         output: Shared<AIAgentOutput>,
         model_id: LLMId,
+        is_streaming: bool,
     }
 
     impl FakeAIBlockModel {
@@ -241,6 +242,18 @@ pub mod testing {
                 input,
                 output: Shared::new(output),
                 model_id: "fake-llm".to_owned().into(),
+                is_streaming: false,
+            }
+        }
+
+        /// Builds a fake model whose status stays [`AIBlockOutputStatus::Pending`],
+        /// modeling a block that is still streaming output.
+        pub fn new_streaming(input: Vec<AIAgentInput>) -> Self {
+            Self {
+                input,
+                output: Shared::new(AIAgentOutput::default()),
+                model_id: "fake-llm".to_owned().into(),
+                is_streaming: true,
             }
         }
     }
@@ -249,8 +262,12 @@ pub mod testing {
         type View = AIBlock;
 
         fn status(&self, _app: &AppContext) -> AIBlockOutputStatus {
-            AIBlockOutputStatus::Complete {
-                output: self.output.clone(),
+            if self.is_streaming {
+                AIBlockOutputStatus::Pending
+            } else {
+                AIBlockOutputStatus::Complete {
+                    output: self.output.clone(),
+                }
             }
         }
 

--- a/app/src/ai/blocklist/block/model.rs
+++ b/app/src/ai/blocklist/block/model.rs
@@ -231,18 +231,18 @@ pub mod testing {
 
     pub struct FakeAIBlockModel {
         input: Vec<AIAgentInput>,
-        output: Shared<AIAgentOutput>,
+        /// `None` models a block that is still streaming output, so its status
+        /// stays [`AIBlockOutputStatus::Pending`].
+        output: Option<Shared<AIAgentOutput>>,
         model_id: LLMId,
-        is_streaming: bool,
     }
 
     impl FakeAIBlockModel {
         pub fn new(input: Vec<AIAgentInput>, output: AIAgentOutput) -> Self {
             Self {
                 input,
-                output: Shared::new(output),
+                output: Some(Shared::new(output)),
                 model_id: "fake-llm".to_owned().into(),
-                is_streaming: false,
             }
         }
 
@@ -251,9 +251,8 @@ pub mod testing {
         pub fn new_streaming(input: Vec<AIAgentInput>) -> Self {
             Self {
                 input,
-                output: Shared::new(AIAgentOutput::default()),
+                output: None,
                 model_id: "fake-llm".to_owned().into(),
-                is_streaming: true,
             }
         }
     }
@@ -262,12 +261,11 @@ pub mod testing {
         type View = AIBlock;
 
         fn status(&self, _app: &AppContext) -> AIBlockOutputStatus {
-            if self.is_streaming {
-                AIBlockOutputStatus::Pending
-            } else {
-                AIBlockOutputStatus::Complete {
-                    output: self.output.clone(),
-                }
+            match &self.output {
+                Some(output) => AIBlockOutputStatus::Complete {
+                    output: output.clone(),
+                },
+                None => AIBlockOutputStatus::Pending,
             }
         }
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -5256,11 +5256,9 @@ impl TerminalView {
             // handing off to it — not the end of the overall turn. Defer
             // conversation-finished side effects (e.g. firing a queued `/queue`
             // prompt) until the entire turn is actually done.
-            let has_active_subagent = || {
-                BlocklistAIHistoryModel::as_ref(ctx)
-                    .conversation(conversation_id)
-                    .is_some_and(|c| c.has_active_subagent())
-            };
+            let has_active_subagent = BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(conversation_id)
+                .is_some_and(|c| c.has_active_subagent());
 
             let mut finish_reason: Option<FinishReason> = None;
             if let Some(active_ai_block) = self.active_ai_block(ctx) {
@@ -5279,7 +5277,7 @@ impl TerminalView {
                 if self.pending_user_query_view_id.is_some() && !is_same_conversation {
                     self.remove_pending_user_query_block(ctx);
                 }
-            } else if !has_active_subagent() {
+            } else if !has_active_subagent {
                 if let Some(last_ai_block) = self.last_ai_block() {
                     finish_reason = last_ai_block.as_ref(ctx).finish_reason();
                 }
@@ -5287,6 +5285,17 @@ impl TerminalView {
 
             if let Some(reason) = finish_reason {
                 self.handle_finished_conversation(*conversation_id, reason, ctx);
+            } else if !has_active_subagent {
+                // The pane-global checks above can be masked by a sibling
+                // conversation: an orchestration pane hosts the lead and local
+                // child conversations in one view, so when this conversation's
+                // turn ends while a sibling is mid-turn, `active_ai_block` /
+                // `last_ai_block` observe the sibling's block instead. Still
+                // drain this conversation's queued prompts using its own last
+                // block so a queued prompt isn't stranded.
+                if let Some(reason) = self.finish_reason_for_conversation(*conversation_id, ctx) {
+                    self.drain_queued_prompts(*conversation_id, reason, ctx);
+                }
             }
 
             // If the most recent action in the current interaction turn created or updated a plan
@@ -20267,6 +20276,32 @@ impl TerminalView {
         })
     }
 
+    /// Returns the finish reason of the most recent AI block belonging to
+    /// `conversation_id`, or `None` when the conversation has no AI blocks in
+    /// this view or its most recent block is still in flight.
+    ///
+    /// Unlike [`Self::active_ai_block`] / [`Self::last_ai_block`], this is
+    /// scoped to a single conversation: orchestration panes host the lead and
+    /// local child conversations in one view, so the pane-global helpers can
+    /// observe a sibling conversation's block instead of the one that
+    /// finished.
+    fn finish_reason_for_conversation(
+        &self,
+        conversation_id: AIConversationId,
+        ctx: &AppContext,
+    ) -> Option<FinishReason> {
+        self.rich_content_views
+            .iter()
+            .rev()
+            .filter(|rc| !rc.is_usage_footer() && !rc.is_pending_user_query())
+            .find_map(|rc| {
+                let ai_metadata = rc.ai_block_metadata()?;
+                (ai_metadata.conversation_id == conversation_id)
+                    .then_some(&ai_metadata.ai_block_handle)
+            })
+            .and_then(|ai_block| ai_block.as_ref(ctx).finish_reason())
+    }
+
     /// Check if there's an active (non-completed, non-cancelled) /init in progress
     fn has_active_init_project(&self, ctx: &AppContext) -> bool {
         self.active_init_project_model
@@ -22348,6 +22383,31 @@ impl TerminalView {
         output: String,
         ctx: &mut ViewContext<Self>,
     ) -> ViewHandle<AIBlock> {
+        self.insert_dummy_ai_block_internal(query, output, /* is_streaming */ false, ctx)
+    }
+
+    /// Inserts a dummy AI block that is still streaming (unfinished), for tests
+    /// that need an in-flight block in the pane.
+    #[cfg(any(test, feature = "integration_tests"))]
+    pub fn insert_dummy_streaming_ai_block(
+        &mut self,
+        query: String,
+        ctx: &mut ViewContext<Self>,
+    ) -> ViewHandle<AIBlock> {
+        self.insert_dummy_ai_block_internal(query, String::new(), /* is_streaming */ true, ctx)
+    }
+
+    /// Shared body for the dummy AI block insertion helpers. Creates a fresh
+    /// conversation for the block; `is_streaming` controls whether the block is
+    /// finished (Complete) or still in flight.
+    #[cfg(any(test, feature = "integration_tests"))]
+    fn insert_dummy_ai_block_internal(
+        &mut self,
+        query: String,
+        output: String,
+        is_streaming: bool,
+        ctx: &mut ViewContext<Self>,
+    ) -> ViewHandle<AIBlock> {
         use rand::distributions::{Alphanumeric, DistString};
 
         use crate::ai::agent::{
@@ -22399,7 +22459,11 @@ impl TerminalView {
         });
         let conversation_id = new_conversation_id.expect("conversation created for dummy AI block");
 
-        let ai_block_model = Rc::new(FakeAIBlockModel::new(inputs, output));
+        let ai_block_model = Rc::new(if is_streaming {
+            FakeAIBlockModel::new_streaming(inputs)
+        } else {
+            FakeAIBlockModel::new(inputs, output)
+        });
         let ai_block = ctx.add_typed_action_view(|ctx| {
             AIBlock::new(
                 ai_block_model,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4878,9 +4878,24 @@ impl TerminalView {
             .push(Box::new(callback));
     }
 
+    /// Handles `conversation_id`'s turn finishing with `finish_reason`: fires
+    /// the pane-level finished callbacks and drains the conversation's queued
+    /// prompts.
     fn handle_finished_conversation(
         &mut self,
         conversation_id: AIConversationId,
+        finish_reason: FinishReason,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.fire_conversation_finished_callbacks(finish_reason, ctx);
+        self.drain_queued_prompts(conversation_id, finish_reason, ctx);
+    }
+
+    /// Fires the pane-level one-shot callbacks registered via
+    /// [`Self::on_next_conversation_finished`], plus the queued-prompt
+    /// callback if one is armed.
+    fn fire_conversation_finished_callbacks(
+        &mut self,
         finish_reason: FinishReason,
         ctx: &mut ViewContext<Self>,
     ) {
@@ -4895,7 +4910,6 @@ impl TerminalView {
         if let Some(callback) = queued_prompt {
             callback(self, finish_reason, ctx);
         }
-        self.drain_queued_prompts(conversation_id, finish_reason, ctx);
     }
 
     /// Advances the queued-prompts queue after a dispatched queued command's block completes.
@@ -5260,7 +5274,7 @@ impl TerminalView {
                 .conversation(conversation_id)
                 .is_some_and(|c| c.has_active_subagent());
 
-            let mut finish_reason: Option<FinishReason> = None;
+            let mut pane_finish_reason: Option<FinishReason> = None;
             if let Some(active_ai_block) = self.active_ai_block(ctx) {
                 // A new exchange is already active, so callbacks for the
                 // just-finished exchange will be skipped. Clear any pending
@@ -5279,20 +5293,23 @@ impl TerminalView {
                 }
             } else if !has_active_subagent {
                 if let Some(last_ai_block) = self.last_ai_block() {
-                    finish_reason = last_ai_block.as_ref(ctx).finish_reason();
+                    pane_finish_reason = last_ai_block.as_ref(ctx).finish_reason();
                 }
             }
 
-            if let Some(reason) = finish_reason {
-                self.handle_finished_conversation(*conversation_id, reason, ctx);
-            } else if !has_active_subagent {
-                // The pane-global checks above can be masked by a sibling
-                // conversation: an orchestration pane hosts the lead and local
-                // child conversations in one view, so when this conversation's
-                // turn ends while a sibling is mid-turn, `active_ai_block` /
-                // `last_ai_block` observe the sibling's block instead. Still
-                // drain this conversation's queued prompts using its own last
-                // block so a queued prompt isn't stranded.
+            // Pane-scoped: the one-shot conversation-finished callbacks fire
+            // when the pane's most recent block is done.
+            if let Some(reason) = pane_finish_reason {
+                self.fire_conversation_finished_callbacks(reason, ctx);
+            }
+
+            // Conversation-scoped: drain this conversation's queued prompts
+            // keyed off its own most recent block. The pane-global lookup
+            // above can observe a sibling conversation's block instead
+            // (orchestration panes host the lead and local child conversations
+            // in one view), so it can't drive the drain decision or supply the
+            // finish reason.
+            if !has_active_subagent {
                 if let Some(reason) = self.finish_reason_for_conversation(*conversation_id, ctx) {
                     self.drain_queued_prompts(*conversation_id, reason, ctx);
                 }
@@ -20279,27 +20296,14 @@ impl TerminalView {
     /// Returns the finish reason of the most recent AI block belonging to
     /// `conversation_id`, or `None` when the conversation has no AI blocks in
     /// this view or its most recent block is still in flight.
-    ///
-    /// Unlike [`Self::active_ai_block`] / [`Self::last_ai_block`], this is
-    /// scoped to a single conversation: orchestration panes host the lead and
-    /// local child conversations in one view, so the pane-global helpers can
-    /// observe a sibling conversation's block instead of the one that
-    /// finished.
     fn finish_reason_for_conversation(
         &self,
         conversation_id: AIConversationId,
         ctx: &AppContext,
     ) -> Option<FinishReason> {
-        self.rich_content_views
-            .iter()
-            .rev()
-            .filter(|rc| !rc.is_usage_footer() && !rc.is_pending_user_query())
-            .find_map(|rc| {
-                let ai_metadata = rc.ai_block_metadata()?;
-                (ai_metadata.conversation_id == conversation_id)
-                    .then_some(&ai_metadata.ai_block_handle)
-            })
-            .and_then(|ai_block| ai_block.as_ref(ctx).finish_reason())
+        self.ai_block_metadata_for_current_thread(&conversation_id, ctx)
+            .next()
+            .and_then(|ai_metadata| ai_metadata.ai_block_handle.as_ref(ctx).finish_reason())
     }
 
     /// Check if there's an active (non-completed, non-cancelled) /init in progress
@@ -22383,7 +22387,7 @@ impl TerminalView {
         output: String,
         ctx: &mut ViewContext<Self>,
     ) -> ViewHandle<AIBlock> {
-        self.insert_dummy_ai_block_internal(query, output, /* is_streaming */ false, ctx)
+        self.insert_dummy_ai_block_internal(query, Some(output), ctx)
     }
 
     /// Inserts a dummy AI block that is still streaming (unfinished), for tests
@@ -22394,18 +22398,17 @@ impl TerminalView {
         query: String,
         ctx: &mut ViewContext<Self>,
     ) -> ViewHandle<AIBlock> {
-        self.insert_dummy_ai_block_internal(query, String::new(), /* is_streaming */ true, ctx)
+        self.insert_dummy_ai_block_internal(query, None, ctx)
     }
 
     /// Shared body for the dummy AI block insertion helpers. Creates a fresh
-    /// conversation for the block; `is_streaming` controls whether the block is
-    /// finished (Complete) or still in flight.
+    /// conversation for the block; a `None` output models a block that is
+    /// still streaming (unfinished).
     #[cfg(any(test, feature = "integration_tests"))]
     fn insert_dummy_ai_block_internal(
         &mut self,
         query: String,
-        output: String,
-        is_streaming: bool,
+        output: Option<String>,
         ctx: &mut ViewContext<Self>,
     ) -> ViewHandle<AIBlock> {
         use rand::distributions::{Alphanumeric, DistString};
@@ -22431,7 +22434,7 @@ impl TerminalView {
             intended_agent: None,
         }];
 
-        let output = AIAgentOutput {
+        let output = output.map(|output| AIAgentOutput {
             messages: vec![AIAgentOutputMessage::text(
                 MessageId::new("fake-id".to_owned()),
                 AIAgentText {
@@ -22445,7 +22448,7 @@ impl TerminalView {
                 Alphanumeric.sample_string(&mut rand::thread_rng(), 24)
             ))),
             ..Default::default()
-        };
+        });
 
         // Create a real conversation in the history model for this dummy block so it renders.
         let terminal_view_id = ctx.view_id();
@@ -22459,10 +22462,9 @@ impl TerminalView {
         });
         let conversation_id = new_conversation_id.expect("conversation created for dummy AI block");
 
-        let ai_block_model = Rc::new(if is_streaming {
-            FakeAIBlockModel::new_streaming(inputs)
-        } else {
-            FakeAIBlockModel::new(inputs, output)
+        let ai_block_model = Rc::new(match output {
+            Some(output) => FakeAIBlockModel::new(inputs, output),
+            None => FakeAIBlockModel::new_streaming(inputs),
         });
         let ai_block = ctx.add_typed_action_view(|ctx| {
             AIBlock::new(

--- a/app/src/terminal/view/queued_prompts_tests.rs
+++ b/app/src/terminal/view/queued_prompts_tests.rs
@@ -22,8 +22,9 @@ use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
 use crate::ai::blocklist::block::FinishReason;
 use crate::ai::blocklist::{
-    AutofireAction, BlocklistAIHistoryEvent, BlocklistAIHistoryModel, ConversationStatusUpdate,
-    PendingAttachment, QueuedQuery, QueuedQueryId, QueuedQueryModel, QueuedQueryOrigin,
+    AutofireAction, BlocklistAIControllerEvent, BlocklistAIHistoryEvent, BlocklistAIHistoryModel,
+    ConversationStatusUpdate, PendingAttachment, QueuedQuery, QueuedQueryId, QueuedQueryModel,
+    QueuedQueryOrigin, ResponseStreamId,
 };
 use crate::features::FeatureFlag;
 use crate::server::server_api::ai::SpawnAgentRequest;
@@ -1509,6 +1510,56 @@ fn finish_reason_is_scoped_to_the_finished_conversation() {
             assert_eq!(
                 view.finish_reason_for_conversation(AIConversationId::new(), ctx),
                 None
+            );
+        });
+    });
+}
+
+#[test]
+fn finished_receiving_output_drains_queue_when_sibling_block_masks_turn_end() {
+    // End-to-end through the controller-event path: `FinishedReceivingOutput` for a finished
+    // conversation must drain that conversation's queue even when a sibling conversation's
+    // still-streaming block is the most recent block in the pane (orchestration panes host the
+    // lead and local child conversations in one view).
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            let finished_block =
+                view.insert_dummy_ai_block("review".to_owned(), "done".to_owned(), ctx);
+            let finished_conversation = finished_block.as_ref(ctx).conversation_id();
+            // Inserted after the finished block, so it is the last block in the pane and
+            // masks the pane-global `active_ai_block` / `last_ai_block` lookups.
+            let streaming_block = view.insert_dummy_streaming_ai_block("working".to_owned(), ctx);
+            let streaming_conversation = streaming_block.as_ref(ctx).conversation_id();
+            assert_ne!(finished_conversation, streaming_conversation);
+
+            QueuedQueryModel::handle(ctx).update(ctx, |model, ctx| {
+                model.append(finished_conversation, user_query("queued follow up"), ctx);
+                model.append(
+                    streaming_conversation,
+                    user_query("sibling stays queued"),
+                    ctx,
+                );
+            });
+
+            view.handle_ai_controller_event(
+                view.ai_controller.clone(),
+                &BlocklistAIControllerEvent::FinishedReceivingOutput {
+                    stream_id: ResponseStreamId::new_for_test(),
+                    conversation_id: finished_conversation,
+                },
+                ctx,
+            );
+
+            // The finished conversation's queued prompt fired; the still-streaming sibling's
+            // queue is untouched.
+            let model = QueuedQueryModel::as_ref(ctx);
+            assert!(model.queue(finished_conversation).is_empty());
+            assert_eq!(model.queue(streaming_conversation).len(), 1);
+            assert_eq!(
+                model.queue(streaming_conversation)[0].text(),
+                "sibling stays queued"
             );
         });
     });

--- a/app/src/terminal/view/queued_prompts_tests.rs
+++ b/app/src/terminal/view/queued_prompts_tests.rs
@@ -1477,3 +1477,39 @@ fn multi_cycle_queue_keeps_each_rows_attachments_independent() {
         });
     });
 }
+
+#[test]
+fn finish_reason_is_scoped_to_the_finished_conversation() {
+    // An orchestration pane hosts the lead and local child conversations in one view, so the
+    // most recent block in the pane can belong to a sibling conversation that is still
+    // mid-turn. The per-conversation lookup must report the finished conversation's own block
+    // as Complete (so its queued prompts drain) and the streaming sibling's as unfinished.
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            let finished_block =
+                view.insert_dummy_ai_block("review".to_owned(), "done".to_owned(), ctx);
+            let finished_conversation = finished_block.as_ref(ctx).conversation_id();
+            // Inserted after the finished block, so it is the last block in the pane and
+            // masks the pane-global `active_ai_block` / `last_ai_block` lookups.
+            let streaming_block = view.insert_dummy_streaming_ai_block("working".to_owned(), ctx);
+            let streaming_conversation = streaming_block.as_ref(ctx).conversation_id();
+            assert_ne!(finished_conversation, streaming_conversation);
+
+            assert_eq!(
+                view.finish_reason_for_conversation(finished_conversation, ctx),
+                Some(FinishReason::Complete)
+            );
+            assert_eq!(
+                view.finish_reason_for_conversation(streaming_conversation, ctx),
+                None
+            );
+            // A conversation with no blocks in this pane has no finish reason.
+            assert_eq!(
+                view.finish_reason_for_conversation(AIConversationId::new(), ctx),
+                None
+            );
+        });
+    });
+}


### PR DESCRIPTION
## Description

@vkodithala ran into an issue where queued prompts sometimes weren't being sent in sub-agent conversations. This issue is semi-flaky (no consistent repro), but looking at Varoon's logs with the agent I think I pinpointed at least one issue.

The problem was that, when a conversation's turn ends, `handle_ai_controller_event` receives `BlocklistAIControllerEvent::FinishedReceivingOutput` and decides whether to fire conversation-finished side effects. This decision relied on global pane helpers, specifically `active_ai_block` and `last_ai_block`. However, an orchestration pane hosts the lead and local child conversations in a single TerminalView, so when one conversation's turn ends while a sibling is mid-turn, those helpers observe the sibling's still-streaming block instead. In this edge-case, the finish reason comes back None, so we don't drain the finished event, meaning we don't send the queued prompt.

The fix is, when the pane-global path yields no finish reason (and no subagent is active), fall back to a new conversation-scoped lookup (finish_reason_for_conversation) that finds the finished conversation's own most recent block, and drain its queued prompts from there.

## Testing
- Added `finish_reason_is_scoped_to_the_finished_conversation`, which builds a pane with a finished block and a later streaming sibling block and asserts the scoped lookup reports `Complete` for the finished conversation, `None` for the streaming one, and `None` for an unknown conversation.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/15494e48-16a7-4830-9e12-09f3e5cc1152_
_Run: https://oz.staging.warp.dev/runs/019ebc23-56cd-7e96-8928-b6d51eeb3017_

_This PR was generated with [Oz](https://warp.dev/oz)._
