### PR TITLE
feat(session-journal): new crate for resequencable event ring + JSONL mirror (R3.1 foundation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15280,6 +15280,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "warp_session_journal"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "warp_terminal"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ warp_ripgrep = { path = "crates/warp_ripgrep" }
 warp_search_core = { path = "crates/warp_search_core" }
 warp_server_auth = { path = "crates/warp_server_auth" }
 warp_server_client = { path = "crates/warp_server_client" }
+warp_session_journal = { path = "crates/warp_session_journal" }
 warp_terminal = { path = "crates/warp_terminal" }
 warp_util = { path = "crates/warp_util" }
 warp_web_event_bus = { path = "crates/warp_web_event_bus" }

--- a/crates/warp_session_journal/Cargo.toml
+++ b/crates/warp_session_journal/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "warp_session_journal"
+version = "0.1.0"
+edition = "2021"
+authors = ["Warp Team <dev@warp.dev>"]
+publish.workspace = true
+license.workspace = true
+
+[dependencies]
+log.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/warp_session_journal/src/lib.rs
+++ b/crates/warp_session_journal/src/lib.rs
@@ -1,0 +1,344 @@
+//! Per-session ring buffer of resequencable events with an optional
+//! on-disk JSONL mirror.
+//!
+//! Foundation for SSH session resilience: when a connection drops
+//! between a long-running task and the desktop client, the client
+//! reconnects and asks "give me events since seq N" instead of
+//! starting mid-stream. The journal keeps a bounded window of recent
+//! events so a fresh client can catch up to the live tail, and
+//! reports a gap when the requested cursor is older than the
+//! oldest surviving entry.
+//!
+//! Designed against the [#11925](https://github.com/warpdotdev/warp/issues/11925)
+//! and [#12329](https://github.com/warpdotdev/warp/issues/12329)
+//! reattach + agent-notification asks. R3.1 of the SSH connection
+//! management roadmap.
+//!
+//! ## Sequence semantics
+//!
+//! Sequence numbers are per-`EventJournal`, start at 1, monotonically
+//! increase, and never reset for the lifetime of the journal.
+//! [`EventJournal::head_seq`] is 0 before the first append. Overflow
+//! at `u64::MAX` panics — a single session producing 2^64 events is
+//! treated as a logic error, not a recoverable runtime condition.
+//!
+//! ## Eviction
+//!
+//! Bounded by entry count (default [`DEFAULT_CAPACITY`] = 1024). When
+//! the ring is full the oldest entry is dropped, so the journal can
+//! outrun a slow reattach indefinitely without unbounded memory.
+//! Eviction means [`EventJournal::replay_since`] can no longer satisfy
+//! a `since_seq` older than the oldest seq still in the ring — the
+//! returned [`ReplaySnapshot::replay_gap`] reports the earliest
+//! surviving seq so the caller can fall back to a full reload.
+//!
+//! ## Disk mirror
+//!
+//! When [`EventJournal::with_disk_writer`] attaches a
+//! [`JournalDiskWriter`], every successful in-memory append also
+//! appends one JSON-encoded line to the disk file. A disk write
+//! failure detaches the writer (logged once) but does not abort the
+//! in-memory append — losing durability for one event is acceptable
+//! whereas dropping a live event the consumer is waiting on is not.
+
+use std::collections::VecDeque;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+/// Default ring capacity. Sized to hold roughly ten typical agent
+/// turns of streaming output (each turn ≈ 50-100 events). Override
+/// via [`EventJournal::with_capacity`] if profiling shows the right
+/// number is different for a given workload.
+pub const DEFAULT_CAPACITY: usize = 1024;
+
+/// A single recorded event in the journal: a monotonically-assigned
+/// sequence number, the wall-clock timestamp at which it was
+/// appended, and the caller's payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JournalEntry<P> {
+    pub seq: u64,
+    pub ts_ms: i64,
+    pub payload: P,
+}
+
+/// Result of an [`EventJournal::replay_since`] call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplaySnapshot<P> {
+    /// Entries the caller asked for, in seq order.
+    pub entries: Vec<JournalEntry<P>>,
+    /// `Some(earliest_available)` when the caller's `since_seq`
+    /// would have required entries the ring has evicted. Callers
+    /// interpret this as "the local cursor is behind the journal's
+    /// oldest surviving entry — fall back to a full reload or accept
+    /// the gap".
+    pub replay_gap: Option<u64>,
+    /// Highest seq currently observed (0 when the journal is empty).
+    /// Callers store this so a follow-up reattach knows where to
+    /// resume.
+    pub head_seq: u64,
+}
+
+/// Bounded ring buffer of events, monotonically sequenced.
+pub struct EventJournal<P> {
+    ring: VecDeque<JournalEntry<P>>,
+    /// Seq number for the next append (always `head_seq + 1`). Held
+    /// outside the ring so eviction doesn't reset the counter.
+    next_seq: u64,
+    capacity: usize,
+    /// Optional disk-backed mirror. When set, every successful
+    /// in-memory append is also written to the on-disk JSONL file
+    /// so the journal can be reconstructed across restarts.
+    disk_writer: Option<JournalDiskWriter<P>>,
+}
+
+impl<P> std::fmt::Debug for EventJournal<P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventJournal")
+            .field("ring_len", &self.ring.len())
+            .field("next_seq", &self.next_seq)
+            .field("capacity", &self.capacity)
+            .field("disk_backed", &self.disk_writer.is_some())
+            .finish()
+    }
+}
+
+impl<P> Default for EventJournal<P> {
+    fn default() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+}
+
+impl<P> EventJournal<P> {
+    /// Build a journal with the given ring capacity.
+    ///
+    /// A zero-capacity ring would refuse every append, so the input
+    /// is clamped to 1. Tests exercising eviction behaviour use
+    /// small but non-zero capacities; production callers should
+    /// stick with [`DEFAULT_CAPACITY`] or a measured override.
+    pub fn with_capacity(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        Self {
+            ring: VecDeque::with_capacity(capacity),
+            next_seq: 1,
+            capacity,
+            disk_writer: None,
+        }
+    }
+
+    /// Attach a disk-backed JSONL mirror. Idempotent — a second call
+    /// overwrites the prior writer. Production wires the writer once
+    /// at journal creation; this builder shape exists so tests can
+    /// drive the disk-backed path without a second factory.
+    pub fn with_disk_writer(mut self, writer: JournalDiskWriter<P>) -> Self {
+        self.disk_writer = Some(writer);
+        self
+    }
+
+    /// Highest seq currently observed. 0 before the first append.
+    pub fn head_seq(&self) -> u64 {
+        self.next_seq.saturating_sub(1)
+    }
+
+    /// Number of entries currently held in the ring (after any
+    /// evictions). Useful for tests + diagnostics.
+    pub fn len(&self) -> usize {
+        self.ring.len()
+    }
+
+    /// `true` iff no entries are held. Mirrors [`Self::len`] for
+    /// callers preferring the boolean shape.
+    pub fn is_empty(&self) -> bool {
+        self.ring.is_empty()
+    }
+}
+
+impl<P: Clone + Serialize> EventJournal<P> {
+    /// Append `payload` with a fresh seq. Evicts the oldest entry
+    /// when the ring is full. Returns the appended seq so the caller
+    /// can include it on the wire alongside the event.
+    pub fn append(&mut self, payload: P) -> u64 {
+        let seq = self.next_seq;
+        self.next_seq = seq
+            .checked_add(1)
+            .expect("event journal seq overflow (2^64 events in one session)");
+        if self.ring.len() >= self.capacity {
+            self.ring.pop_front();
+        }
+        let entry = JournalEntry {
+            seq,
+            ts_ms: now_ms(),
+            payload,
+        };
+        // Mirror to disk before pushing into the ring so the
+        // on-disk order matches the in-memory order. A write
+        // failure detaches the writer (defensive — repeated failures
+        // would spam logs) but lets the in-memory append succeed.
+        if let Some(writer) = self.disk_writer.as_mut() {
+            if let Err(err) = writer.append(&entry) {
+                log::warn!(
+                    "journal: disk append failed at seq {}: {err}; detaching disk mirror",
+                    entry.seq,
+                );
+                self.disk_writer = None;
+            }
+        }
+        self.ring.push_back(entry);
+        seq
+    }
+}
+
+impl<P: Clone> EventJournal<P> {
+    /// Snapshot entries the caller asked for.
+    ///
+    /// `since_seq=None` means "give me everything currently in the
+    /// ring". `since_seq=Some(n)` means "give me entries with
+    /// `seq > n`"; if the ring no longer holds seq `n+1` (the caller
+    /// missed events that have been evicted) the snapshot reports
+    /// the gap via [`ReplaySnapshot::replay_gap`] so the caller can
+    /// fall back to a full reload.
+    pub fn replay_since(&self, since_seq: Option<u64>) -> ReplaySnapshot<P> {
+        let head_seq = self.head_seq();
+        let replay_gap = match (since_seq, self.ring.front()) {
+            // Caller asked for entries newer than `n`. The smallest
+            // seq still in the ring is `earliest.seq`. If
+            // `earliest.seq > n + 1`, the entry at `n + 1` was
+            // evicted — gap.
+            (Some(n), Some(earliest)) if earliest.seq > n.saturating_add(1) => Some(earliest.seq),
+            _ => None,
+        };
+        let cutoff = since_seq.unwrap_or(0);
+        let entries: Vec<JournalEntry<P>> = self
+            .ring
+            .iter()
+            .filter(|e| e.seq > cutoff)
+            .cloned()
+            .collect();
+        ReplaySnapshot {
+            entries,
+            replay_gap,
+            head_seq,
+        }
+    }
+}
+
+/// Disk-backed JSONL mirror of an [`EventJournal`]. Each call to
+/// [`Self::append`] writes one line of the form `<json>\n` where the
+/// JSON is the serde-serialized [`JournalEntry`].
+pub struct JournalDiskWriter<P> {
+    writer: BufWriter<File>,
+    path: PathBuf,
+    _marker: std::marker::PhantomData<fn() -> P>,
+}
+
+impl<P> std::fmt::Debug for JournalDiskWriter<P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JournalDiskWriter")
+            .field("path", &self.path)
+            .finish()
+    }
+}
+
+impl<P: Serialize> JournalDiskWriter<P> {
+    /// Create (or truncate) the JSONL file at `path`. Parent
+    /// directory is created if it doesn't exist.
+    pub fn create(path: impl Into<PathBuf>) -> std::io::Result<Self> {
+        let path = path.into();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&path)?;
+        Ok(Self {
+            writer: BufWriter::new(file),
+            path,
+            _marker: std::marker::PhantomData,
+        })
+    }
+
+    /// Open the file at `path` for appending. Does NOT truncate, so
+    /// existing entries are preserved.
+    pub fn append_to(path: impl Into<PathBuf>) -> std::io::Result<Self> {
+        let path = path.into();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)?;
+        Ok(Self {
+            writer: BufWriter::new(file),
+            path,
+            _marker: std::marker::PhantomData,
+        })
+    }
+
+    /// Append one entry as a JSONL line. Flushes before returning so
+    /// a process crash between calls can lose at most the
+    /// most-recent entry.
+    pub fn append(&mut self, entry: &JournalEntry<P>) -> std::io::Result<()> {
+        let line = serde_json::to_string(entry)?;
+        self.writer.write_all(line.as_bytes())?;
+        self.writer.write_all(b"\n")?;
+        self.writer.flush()?;
+        Ok(())
+    }
+
+    /// Path the writer is mirroring to.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Consume the writer and return the path (e.g. so a later
+    /// replay reader can be opened).
+    pub fn into_path(self) -> PathBuf {
+        self.path
+    }
+}
+
+/// Read a JSONL journal file produced by [`JournalDiskWriter`] back
+/// into a vector of entries. Malformed lines are logged and skipped;
+/// the rest are returned in file order.
+pub fn read_journal_entries<P: DeserializeOwned>(
+    path: &Path,
+) -> std::io::Result<Vec<JournalEntry<P>>> {
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut entries = Vec::new();
+    for (line_no, line) in reader.lines().enumerate() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<JournalEntry<P>>(&line) {
+            Ok(entry) => entries.push(entry),
+            Err(err) => {
+                log::warn!(
+                    "journal: skipping malformed JSONL line {} in {}: {err}",
+                    line_no + 1,
+                    path.display(),
+                );
+            }
+        }
+    }
+    Ok(entries)
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+#[path = "lib_tests.rs"]
+mod tests;

--- a/crates/warp_session_journal/src/lib_tests.rs
+++ b/crates/warp_session_journal/src/lib_tests.rs
@@ -1,0 +1,271 @@
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+use super::{read_journal_entries, EventJournal, JournalDiskWriter, JournalEntry};
+
+fn payload(label: &str) -> Value {
+    json!({ "type": "test", "label": label })
+}
+
+// ── sequence assignment ─────────────────────────────────────────────
+
+#[test]
+fn append_assigns_monotonic_seqs_starting_at_one() {
+    let mut journal = EventJournal::default();
+    assert_eq!(journal.append(payload("a")), 1);
+    assert_eq!(journal.append(payload("b")), 2);
+    assert_eq!(journal.append(payload("c")), 3);
+}
+
+#[test]
+fn head_seq_is_zero_before_any_append() {
+    let journal: EventJournal<Value> = EventJournal::default();
+    assert_eq!(journal.head_seq(), 0);
+}
+
+#[test]
+fn head_seq_advances_with_each_append() {
+    let mut journal = EventJournal::default();
+    journal.append(payload("a"));
+    assert_eq!(journal.head_seq(), 1);
+    journal.append(payload("b"));
+    assert_eq!(journal.head_seq(), 2);
+}
+
+#[test]
+fn empty_journal_reports_is_empty() {
+    let journal: EventJournal<Value> = EventJournal::default();
+    assert!(journal.is_empty());
+    assert_eq!(journal.len(), 0);
+}
+
+// ── ring capacity / eviction ────────────────────────────────────────
+
+#[test]
+fn zero_capacity_clamps_to_one_entry() {
+    let mut journal = EventJournal::with_capacity(0);
+    let seq = journal.append(payload("a"));
+    assert_eq!(seq, 1);
+    assert_eq!(journal.len(), 1);
+}
+
+#[test]
+fn eviction_drops_oldest_when_capacity_exceeded() {
+    let mut journal = EventJournal::with_capacity(2);
+    journal.append(payload("a")); // seq 1, evicted by overflow
+    journal.append(payload("b")); // seq 2
+    journal.append(payload("c")); // seq 3 — pushes seq 1 out
+
+    let snapshot = journal.replay_since(None);
+    let seqs: Vec<u64> = snapshot.entries.iter().map(|e| e.seq).collect();
+    assert_eq!(seqs, vec![2, 3]);
+    assert_eq!(journal.len(), 2);
+}
+
+#[test]
+fn eviction_does_not_reset_seq_counter() {
+    // Eviction must not let `next_seq` walk backwards — that would
+    // hand out a duplicate seq and confuse readers reattaching with
+    // a cursor in the middle of the new range.
+    let mut journal = EventJournal::with_capacity(2);
+    journal.append(payload("a")); // seq 1, evicted
+    journal.append(payload("b")); // seq 2, evicted
+    journal.append(payload("c")); // seq 3
+    journal.append(payload("d")); // seq 4
+    assert_eq!(journal.head_seq(), 4);
+    let snapshot = journal.replay_since(None);
+    assert_eq!(snapshot.entries.first().map(|e| e.seq), Some(3));
+    assert_eq!(snapshot.entries.last().map(|e| e.seq), Some(4));
+}
+
+// ── replay_since ────────────────────────────────────────────────────
+
+#[test]
+fn replay_since_none_returns_full_ring() {
+    let mut journal = EventJournal::default();
+    journal.append(payload("a"));
+    journal.append(payload("b"));
+    journal.append(payload("c"));
+
+    let snapshot = journal.replay_since(None);
+    assert_eq!(snapshot.entries.len(), 3);
+    assert_eq!(snapshot.replay_gap, None);
+    assert_eq!(snapshot.head_seq, 3);
+}
+
+#[test]
+fn replay_since_skips_already_seen() {
+    let mut journal = EventJournal::default();
+    journal.append(payload("a"));
+    journal.append(payload("b"));
+    journal.append(payload("c"));
+
+    let snapshot = journal.replay_since(Some(1));
+    let seqs: Vec<u64> = snapshot.entries.iter().map(|e| e.seq).collect();
+    assert_eq!(seqs, vec![2, 3]);
+    assert_eq!(snapshot.replay_gap, None);
+    assert_eq!(snapshot.head_seq, 3);
+}
+
+#[test]
+fn replay_since_at_head_returns_empty_no_gap() {
+    let mut journal = EventJournal::default();
+    journal.append(payload("a"));
+    journal.append(payload("b"));
+
+    let snapshot = journal.replay_since(Some(2));
+    assert!(snapshot.entries.is_empty());
+    assert_eq!(snapshot.replay_gap, None);
+    assert_eq!(snapshot.head_seq, 2);
+}
+
+#[test]
+fn replay_gap_reports_evicted_floor() {
+    // Caller asks for "since seq 1", but seq 2 has been evicted.
+    // Snapshot should report `replay_gap = Some(3)` so the caller
+    // knows the oldest available seq is 3, not the requested 2.
+    let mut journal = EventJournal::with_capacity(2);
+    journal.append(payload("a")); // seq 1
+    journal.append(payload("b")); // seq 2
+    journal.append(payload("c")); // seq 3 — evicts seq 1
+    journal.append(payload("d")); // seq 4 — evicts seq 2
+
+    let snapshot = journal.replay_since(Some(1));
+    assert_eq!(snapshot.replay_gap, Some(3));
+    let seqs: Vec<u64> = snapshot.entries.iter().map(|e| e.seq).collect();
+    assert_eq!(seqs, vec![3, 4]);
+    assert_eq!(snapshot.head_seq, 4);
+}
+
+#[test]
+fn replay_gap_not_reported_when_cursor_is_at_or_above_evicted_floor() {
+    let mut journal = EventJournal::with_capacity(2);
+    journal.append(payload("a")); // seq 1, evicted
+    journal.append(payload("b")); // seq 2
+    journal.append(payload("c")); // seq 3 — evicts seq 1
+
+    // since_seq = 2 → we want seq > 2, ring has [2, 3], earliest = 2,
+    // 2 > 2+1 is false → no gap.
+    let snapshot = journal.replay_since(Some(2));
+    assert_eq!(snapshot.replay_gap, None);
+    assert_eq!(snapshot.entries.len(), 1);
+    assert_eq!(snapshot.entries[0].seq, 3);
+}
+
+#[test]
+fn replay_since_with_empty_ring_returns_no_entries_no_gap() {
+    let journal: EventJournal<Value> = EventJournal::default();
+    let snapshot = journal.replay_since(Some(5));
+    assert!(snapshot.entries.is_empty());
+    assert_eq!(snapshot.replay_gap, None);
+    assert_eq!(snapshot.head_seq, 0);
+}
+
+// ── disk mirror ─────────────────────────────────────────────────────
+
+#[test]
+fn disk_writer_persists_entries_as_jsonl() {
+    let tmp = TempDir::new().expect("tempdir");
+    let path = tmp.path().join("journal.jsonl");
+    let writer = JournalDiskWriter::<Value>::create(&path).expect("create writer");
+    let mut journal = EventJournal::default().with_disk_writer(writer);
+
+    journal.append(payload("a"));
+    journal.append(payload("b"));
+    journal.append(payload("c"));
+
+    // Read the file back as raw lines and check the count + first
+    // field shape. A round-trip through `read_journal_entries`
+    // covers the full decode path in a separate test.
+    let body = std::fs::read_to_string(&path).expect("read");
+    let lines: Vec<&str> = body.lines().collect();
+    assert_eq!(lines.len(), 3);
+    assert!(lines[0].contains("\"seq\":1"));
+    assert!(lines[1].contains("\"seq\":2"));
+    assert!(lines[2].contains("\"seq\":3"));
+}
+
+#[test]
+fn disk_replay_recovers_appended_entries() {
+    let tmp = TempDir::new().expect("tempdir");
+    let path = tmp.path().join("journal.jsonl");
+    {
+        let writer = JournalDiskWriter::<Value>::create(&path).expect("create writer");
+        let mut journal = EventJournal::default().with_disk_writer(writer);
+        journal.append(payload("a"));
+        journal.append(payload("b"));
+        journal.append(payload("c"));
+    }
+
+    let recovered: Vec<JournalEntry<Value>> =
+        read_journal_entries(&path).expect("read journal");
+    assert_eq!(recovered.len(), 3);
+    let seqs: Vec<u64> = recovered.iter().map(|e| e.seq).collect();
+    assert_eq!(seqs, vec![1, 2, 3]);
+}
+
+#[test]
+fn disk_replay_skips_malformed_lines_silently() {
+    let tmp = TempDir::new().expect("tempdir");
+    let path = tmp.path().join("journal.jsonl");
+    let well_formed = serde_json::to_string(&JournalEntry {
+        seq: 1u64,
+        ts_ms: 100,
+        payload: payload("a"),
+    })
+    .expect("serialize");
+    std::fs::write(
+        &path,
+        format!("{well_formed}\nthis is not valid json\n{well_formed}\n"),
+    )
+    .expect("write");
+
+    let recovered: Vec<JournalEntry<Value>> =
+        read_journal_entries(&path).expect("read");
+    assert_eq!(recovered.len(), 2);
+}
+
+#[test]
+fn disk_replay_treats_empty_lines_as_skipped() {
+    let tmp = TempDir::new().expect("tempdir");
+    let path = tmp.path().join("journal.jsonl");
+    std::fs::write(&path, "\n\n\n").expect("write");
+
+    let recovered: Vec<JournalEntry<Value>> =
+        read_journal_entries(&path).expect("read");
+    assert!(recovered.is_empty());
+}
+
+#[test]
+fn append_to_preserves_existing_file_contents() {
+    // The disk mirror's append-to variant must not truncate — that's
+    // the only useful difference from `create`. If a daemon restarts
+    // and resumes journaling, prior entries stay.
+    let tmp = TempDir::new().expect("tempdir");
+    let path = tmp.path().join("journal.jsonl");
+    {
+        let writer = JournalDiskWriter::<Value>::create(&path).expect("create");
+        let mut journal = EventJournal::default().with_disk_writer(writer);
+        journal.append(payload("a"));
+    }
+    {
+        let writer = JournalDiskWriter::<Value>::append_to(&path).expect("append_to");
+        let mut journal = EventJournal::default().with_disk_writer(writer);
+        journal.append(payload("b"));
+    }
+
+    let recovered: Vec<JournalEntry<Value>> =
+        read_journal_entries(&path).expect("read");
+    assert_eq!(recovered.len(), 2);
+    let labels: Vec<String> = recovered
+        .iter()
+        .map(|e| {
+            e.payload
+                .get("label")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string()
+        })
+        .collect();
+    assert_eq!(labels, vec!["a", "b"]);
+}


### PR DESCRIPTION
## Description

Foundation for SSH session resilience — a per-session ring buffer of monotonically-sequenced events with an optional on-disk JSONL mirror. When a connection drops mid-task, a reconnecting client asks `replay_since(Some(N))` to catch up to the live tail instead of starting mid-stream. When the requested cursor is older than the oldest surviving entry, the snapshot reports `replay_gap` so the caller can fall back to a full reload.

Refs [#11925](https://github.com/warpdotdev/warp/issues/11925) (SSH session disconnects when agent resumes), [#12329](https://github.com/warpdotdev/warp/issues/12329) (CLI agent notifications over SSH+tmux). This PR ships the **journal only** — the `attach(since_seq)` RPC integration with `RemoteServerManager` is a follow-up phase. Surfacing now so the data structure can be reviewed independently of the SSH-transport wiring.

The design is a Warp port of the production journal shipping in [helmor](https://github.com/david-engelmann/helmor) (~5 months of soak time across daemon restarts + reattach storms). I prepared a roadmap describing the full chain at [warp-roadmap-r3](https://github.com/david-engelmann/warp/blob/david/r3.1-session-journal/CHANGELOG.md) — happy to break out a separate design discussion if helpful.

## Public surface

```rust
let mut journal: EventJournal<MyEvent> = EventJournal::default();
let seq: u64 = journal.append(event);

// On reattach:
let snapshot = journal.replay_since(client_cursor); // Option<u64>
// snapshot.entries: Vec<JournalEntry<MyEvent>>
// snapshot.replay_gap: Option<u64>  ← Some(earliest_available) when the cursor is too old
// snapshot.head_seq: u64
```

Generic over `P` so consumers can plumb whatever event type (terminal output chunks, agent deltas, structured notifications) without the crate baking in domain knowledge.

Optional disk mirror via `JournalDiskWriter<P>` (JSONL, flushed per-line) lets the journal survive process restarts. Read back with `read_journal_entries(path)`.

## Design choices

- Per-journal seq starts at 1, monotonic, never resets. `head_seq() == 0` before the first append.
- Capacity-bounded eviction (default 1024 entries). Oldest dropped when ring is full. **Eviction does NOT decrement the seq counter** — that would hand out duplicate seqs on the next append.
- Disk write failures detach the writer (logged once) but don't abort the in-memory append. Durability for one event is less important than dropping a live event the consumer is waiting on.
- Malformed JSONL lines on replay are logged + skipped, not fatal.
- Zero capacity is clamped to 1 so the contract stays simple.

## Testing

- 18 unit tests covering:
  - **Sequence behaviour:** monotonic from 1; `head_seq=0` before first append; head advances; empty-state predicates.
  - **Ring/eviction:** zero-capacity clamps to 1; eviction drops oldest; eviction does NOT reset the seq counter (regression-protector for the "after eviction, next append gets seq 1 again" footgun).
  - **`replay_since` permutations:** `None`→full ring; in-range cursor→skips already-seen; cursor at head→empty no-gap; cursor below evicted floor→reports `replay_gap`; cursor at/above floor→no gap; empty ring→no entries, no gap.
  - **Disk:** persists as JSONL; replay roundtrip recovers entries; malformed lines skipped; empty lines skipped; `append_to` preserves existing file.

```
$ cargo test -p warp_session_journal
running 18 tests
... (all 18)
test result: ok. 18 passed; 0 failed
```

- `cargo fmt -p warp_session_journal --check` clean
- `cargo clippy -p warp_session_journal --tests --no-deps -- -D warnings` clean

## What this does NOT do (deferred)

- No consumer yet — this PR is the journal crate in isolation, ready to be wired into `RemoteServerManager` in a follow-up.
- No `attach(since_seq)` RPC — that's the next phase. Adds an `Attach` variant to the remote protocol, calls `replay_since` on the server, ships entries back over the existing transport.
- No auto-reconnect / liveness loop — separate phase building on the journal + attach surface.

## Server API dependencies

N/A — pure client-side crate, no protocol or server changes.

- [x] Is this change necessary to make the client compatible with a desired [server API breaking change](https://www.notion.so/warpdev/How-to-safely-introduce-server-API-breaking-changes-0aa805ff5d5d41fd8834f3c95caba0b4): **No**

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

(none — internal plumbing crate with no user-facing change in this PR)