### PR TITLE
fix: tolerate unreadable untracked entries in diff metadata aggregation

### DIFF
--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -2181,7 +2181,9 @@ impl LocalDiffStateModel {
             } else if matches!(status, GitFileStatus::Untracked) {
                 // Get total size of the file
                 let num_lines =
-                    Self::num_lines_in_file_if_non_binary(&repo_path.join(file_path)).await?;
+                    Self::num_lines_in_file_if_non_binary(&repo_path.join(file_path))
+                        .await
+                        .unwrap_or(None);
                 (num_lines.unwrap_or(0), 0)
             } else {
                 (0, 0)
@@ -2836,7 +2838,8 @@ pub(crate) async fn diff_metadata_against_head(
         } else if matches!(status, GitFileStatus::Untracked) {
             let num_lines =
                 LocalDiffStateModel::num_lines_in_file_if_non_binary(&repo_path.join(file_path))
-                    .await?;
+                    .await
+                    .unwrap_or(None);
             (num_lines.unwrap_or(0), 0)
         } else {
             (0, 0)


### PR DESCRIPTION
## Summary

Fixes #12546

Nested git worktrees checked out inside a parent working tree (e.g.
`git worktree add ./nested -b nested`) cause the code review button and
diff stats chip to show zero lines changed.

## Root Cause

`git status --porcelain=v2` emits a nested worktree as a single
untracked directory entry (`? nested/`). Both `diff_metadata_against_head`
and `diff_metadata_against_base` iterate over every untracked entry and
call `num_lines_in_file_if_non_binary(repo_root.join(path))` to count
added lines.

On macOS, `File::open` on a directory succeeds, but the subsequent
`read()` call fails with `EISDIR`. Because the call site used `?`, the
error propagated out of the entire metadata computation, setting
`metadata = None` and blanking out all diff stats in the UI.

## Fix

Replace `.await?` with `.await.unwrap_or(None)` at both call sites so
that a per-file read failure (directory, permission error, broken
symlink, etc.) is treated as 0 lines changed for that entry instead of
aborting the whole aggregation. The rest of the file entries are still
counted normally.

### Changed file

- `app/src/code_review/diff_state/local.rs`
  — `diff_metadata_against_head`: L2184
  — `diff_metadata_against_base` (free fn): L2838

## Testing

1. `mkdir repro && cd repro && git init`
2. `echo hello > file.txt && git add . && git commit -m init`
3. `echo change >> file.txt` — diff chip shows `+1` ✅
4. `git worktree add ./nested -b nested` — diff chip still shows `+1` ✅
5. `git worktree remove ./nested` — diff chip remains correct ✅

Before this patch, step 4 would blank the chip entirely.