### PR TITLE
Return focus to input after running a command with a block selection

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -21305,6 +21305,18 @@ impl TerminalView {
                     active_session.cancel_active_commands();
                 }
 
+                // Running a shell command means the user is done navigating/interacting with any
+                // selected blocks or text, so clear the selection. A lingering selection in shell
+                // mode keeps `redetermine_global_focus` pinned to the terminal, which prevents
+                // focus from returning to the input box once the command finishes (the focus is
+                // recomputed on `ModelEvent::BlockCompleted`). Only do this for user-initiated
+                // commands so that agent-, queued-, and shared-session-driven commands don't wipe
+                // the user's selected-block AI context.
+                if matches!(event.source, CommandExecutionSource::User) {
+                    self.clear_selected_blocks(ctx);
+                    self.clear_selected_text(ctx);
+                }
+
                 // Don't steal focus from other parts of the app.
                 if ctx.is_self_or_child_focused() {
                     self.focus_terminal(ctx);

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -3710,6 +3710,83 @@ fn test_navigate_blocks() {
 //     run_navigation_test(InputMode::PinnedToTop);
 // }
 
+fn execute_command_event(source: CommandExecutionSource) -> InputEvent {
+    InputEvent::ExecuteCommand(Box::new(ExecuteCommandEvent {
+        command: "echo hi".into(),
+        session_id: 1.into(),
+        workflow_id: None,
+        workflow_command: None,
+        should_add_command_to_history: true,
+        source,
+    }))
+}
+
+/// Running a user-initiated shell command while a block is selected should clear the
+/// selection. In shell mode a lingering selection keeps focus pinned to the terminal
+/// (see `redetermine_global_focus`), which prevents focus from returning to the input box
+/// once the command finishes.
+#[test]
+fn running_user_command_clears_block_selection() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            {
+                let mut model = view.model.lock();
+                for _ in 0..3 {
+                    model.simulate_block("ls", "foo");
+                }
+            }
+
+            view.select_most_recent_blocks(1, ctx);
+            assert!(
+                !view.selected_blocks.is_empty(),
+                "a block should be selected before running the command"
+            );
+
+            view.handle_input_event(&execute_command_event(CommandExecutionSource::User), ctx);
+
+            assert!(
+                view.selected_blocks.is_empty(),
+                "running a user command should clear the block selection"
+            );
+        });
+    })
+}
+
+/// A command that is not user-initiated (e.g. a queued-prompt or agent-driven command)
+/// must not wipe the user's selected-block AI context.
+#[test]
+fn running_non_user_command_preserves_block_selection() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            {
+                let mut model = view.model.lock();
+                for _ in 0..3 {
+                    model.simulate_block("ls", "foo");
+                }
+            }
+
+            view.select_most_recent_blocks(1, ctx);
+            assert!(!view.selected_blocks.is_empty());
+
+            view.handle_input_event(
+                &execute_command_event(CommandExecutionSource::QueuedCommand),
+                ctx,
+            );
+
+            assert!(
+                !view.selected_blocks.is_empty(),
+                "a non-user command should preserve the block selection"
+            );
+        });
+    })
+}
+
 #[test]
 fn test_alt_scroll_sequences() {
     App::test((), |mut app| async move {


### PR DESCRIPTION
## Description
Fixes a bug where focus did not return to the input box after running a shell command while a block (or text) selection was active in the block list — in both the terminal and agent views.

### Root cause
When a block or text selection is active in shell mode, `redetermine_global_focus` intentionally keeps focus on the terminal so block-list navigation (arrow keys) keeps working. After a command finishes, focus is recomputed in the `ModelEvent::BlockCompleted` handler via `redetermine_terminal_focus`. Because the selection was never cleared when the command ran, that recomputation kept focus pinned to the terminal instead of returning it to the input box.

### Fix
When a user-initiated shell command is executed (`InputEvent::ExecuteCommand` with `CommandExecutionSource::User`), clear the active block and text selections. Running a command means the user is done navigating the block list, so the selection is cleared and focus correctly returns to the input once the command finishes.

The clear is gated to `CommandExecutionSource::User` so that agent-, queued-, and shared-session-driven commands do not wipe the user's selected-block AI context.

## Linked Issue
Reported in the `#feedback-app` Slack channel. No GitHub issue.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Added two regression unit tests in `app/src/terminal/view_tests.rs`:
- `running_user_command_clears_block_selection` — selecting a block then running a user command clears the selection (so focus returns to the input).
- `running_non_user_command_preserves_block_selection` — a non-user (queued) command preserves the selection / AI context.

`cargo check -p warp --tests` and `rustfmt --check` pass. Note: the full `warp` test binary and GUI app could not be compiled/run in the cloud agent sandbox because they exceed the environment's hard memory limit (the linker was OOM/SIGKILL-ed), so end-to-end manual/computer-use validation could not be performed here.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Focus now returns to the input box after running a shell command while a block or text selection is active in the block list.
-->
