### PR TITLE
Show synced-inputs indicator in vertical tabs sidebar

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -73,7 +73,7 @@ const TAB_CLOSE_BUTTON_OPACITY: Opacity = 60;
 const TAB_CLOSE_BUTTON_WIDTH: f32 = 20.0;
 const MAX_TOOLTIP_LENGTH: usize = 80;
 
-const TAB_INDICATOR_SYNCED_COLOR: u32 = 0x4A93FFFF;
+pub(crate) const TAB_INDICATOR_SYNCED_COLOR: u32 = 0x4A93FFFF;
 
 // Width threshold (in px) below which we render an icon-only tab
 const COMPACT_TAB_WIDTH_THRESHOLD: f32 = 42.0;

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -55,7 +55,7 @@ use crate::pane_group::{
     CodePane, NotebookPane, PaneGroup, PaneId, TabBarHoverIndex, TerminalPane, WorkflowPane,
 };
 use crate::safe_triangle::SafeTriangle;
-use crate::tab::{tab_position_id, SelectedTabColor, TabData};
+use crate::tab::{tab_position_id, SelectedTabColor, TabData, TAB_INDICATOR_SYNCED_COLOR};
 use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
 use crate::terminal::session_settings::SessionSettings;
 use crate::terminal::view::TerminalViewState;
@@ -70,6 +70,7 @@ use crate::util::color::Opacity;
 use crate::workspace::action::{NewSessionMenuAnchor, WorkspaceAction};
 use crate::workspace::cross_window_tab_drag::CrossWindowTabDrag;
 use crate::workspace::hoa_onboarding::HoaOnboardingStep;
+use crate::workspace::sync_inputs::SyncedInputState;
 use crate::workspace::tab_group::{TabGroup, TabGroupId};
 use crate::workspace::tab_settings::{
     TabSettings, VerticalTabsCompactSubtitle, VerticalTabsDisplayGranularity,
@@ -393,6 +394,7 @@ fn render_pane_row_element(
         stack_position,
         is_in_multi_selection,
         is_in_multi_tab_selection,
+        is_inputs_synced: _,
         pane_color,
         badge_mouse_states: _,
         detail_hover_state,
@@ -797,6 +799,10 @@ struct PaneProps<'a> {
     /// The right-click handler dispatches the selection menu when set,
     /// otherwise the single-pane menu.
     is_in_multi_tab_selection: bool,
+    /// True when this row's pane group has synchronized inputs enabled, mirroring
+    /// the synced indicator shown on horizontal tabs (`tab.rs`). Drives the
+    /// `LinkHorizontal` indicator rendered next to the row title.
+    is_inputs_synced: bool,
     pane_color: Option<ThemeFill>,
     badge_mouse_states: PaneRowBadgeMouseStates,
     detail_hover_state: VerticalTabsDetailHoverState,
@@ -3108,6 +3114,7 @@ fn has_unread_activity_for_terminal_view(terminal_view_id: EntityId, app: &AppCo
 }
 
 const INDICATOR_DOT_SIZE: f32 = 8.;
+const SYNCED_INDICATOR_ICON_SIZE: f32 = 12.;
 
 fn render_title_indicator(theme: &WarpTheme) -> Box<dyn Element> {
     ConstrainedBox::new(
@@ -3117,6 +3124,20 @@ fn render_title_indicator(theme: &WarpTheme) -> Box<dyn Element> {
     )
     .with_width(INDICATOR_DOT_SIZE)
     .with_height(INDICATOR_DOT_SIZE)
+    .finish()
+}
+
+/// Blue link indicator for a vertical-tabs row whose pane group has synchronized
+/// inputs enabled. Mirrors the horizontal tab bar's synced indicator
+/// (`Indicator::Synced` in `tab.rs`) so the sidebar shows where keystrokes broadcast.
+fn render_synced_inputs_indicator() -> Box<dyn Element> {
+    ConstrainedBox::new(
+        WarpIcon::LinkHorizontal
+            .to_warpui_icon(ColorU::from_u32(TAB_INDICATOR_SYNCED_COLOR).into())
+            .finish(),
+    )
+    .with_width(SYNCED_INDICATOR_ICON_SIZE)
+    .with_height(SYNCED_INDICATOR_ICON_SIZE)
     .finish()
 }
 
@@ -3174,6 +3195,13 @@ fn render_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn Element> {
             )
             .finish(),
         );
+        if props.is_inputs_synced {
+            title_row.add_child(
+                Container::new(render_synced_inputs_indicator())
+                    .with_margin_left(4.)
+                    .finish(),
+            );
+        }
         if has_indicator {
             title_row.add_child(
                 Container::new(render_title_indicator(theme))
@@ -3562,6 +3590,9 @@ impl<'a> PaneProps<'a> {
             stack_position: PaneRowStackPosition::Standalone,
             is_in_multi_selection,
             is_in_multi_tab_selection,
+            // Read `window_id` (a Copy) before `detail_hover_state` is moved into the struct below.
+            is_inputs_synced: SyncedInputState::as_ref(app)
+                .should_sync_this_pane_group(pane_group_id, detail_hover_state.window_id),
             pane_color: pane_row_state.pane_color,
             badge_mouse_states: pane_row_state.badge_mouse_states,
             detail_hover_state,
@@ -4393,20 +4424,27 @@ fn render_summary_tab_item(
         }
     }
     let title_region = title_region.finish();
-    if summary.has_unread_activity {
-        text_col.add_child(
-            Flex::row()
-                .with_main_axis_size(MainAxisSize::Max)
-                .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
-                .with_cross_axis_alignment(CrossAxisAlignment::Center)
-                .with_child(Shrinkable::new(1., title_region).finish())
-                .with_child(
-                    Container::new(render_title_indicator(theme))
-                        .with_margin_left(4.)
-                        .finish(),
-                )
-                .finish(),
-        );
+    if summary.has_unread_activity || props.is_inputs_synced {
+        let mut title_row = Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(Shrinkable::new(1., title_region).finish());
+        if props.is_inputs_synced {
+            title_row.add_child(
+                Container::new(render_synced_inputs_indicator())
+                    .with_margin_left(4.)
+                    .finish(),
+            );
+        }
+        if summary.has_unread_activity {
+            title_row.add_child(
+                Container::new(render_title_indicator(theme))
+                    .with_margin_left(4.)
+                    .finish(),
+            );
+        }
+        text_col.add_child(title_row.finish());
     } else {
         text_col.add_child(title_region);
     }
@@ -6939,19 +6977,28 @@ fn render_compact_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn El
             (title, subtitle)
         };
 
-    // Title row with optional indicator
-    let title_row = if has_indicator {
-        Flex::row()
+    // Title row with optional indicators (synced inputs link + unread/badge dot).
+    let title_row = if has_indicator || props.is_inputs_synced {
+        let mut row = Flex::row()
             .with_main_axis_size(MainAxisSize::Max)
             .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_child(Shrinkable::new(1., title_element).finish())
-            .with_child(
+            .with_child(Shrinkable::new(1., title_element).finish());
+        if props.is_inputs_synced {
+            row.add_child(
+                Container::new(render_synced_inputs_indicator())
+                    .with_margin_left(4.)
+                    .finish(),
+            );
+        }
+        if has_indicator {
+            row.add_child(
                 Container::new(render_title_indicator(theme))
                     .with_margin_left(4.)
                     .finish(),
-            )
-            .finish()
+            );
+        }
+        row.finish()
     } else {
         title_element
     };


### PR DESCRIPTION
## Description

Synchronized inputs render a blue link indicator on synced tabs in the
horizontal tab bar (`Indicator::Synced` → `Icon::LinkHorizontal` in
`app/src/tab.rs`), but the vertical tabs sidebar never queried
`SyncedInputState`, so there was no indication there of which tabs
broadcast keystrokes — you had to switch back to horizontal tabs to tell.

This adds the same indicator to the vertical tabs sidebar:

- `app/src/tab.rs`: make `TAB_INDICATOR_SYNCED_COLOR` `pub(crate)` so the
  sidebar reuses the identical color (no drift from the horizontal indicator).
- `app/src/workspace/view/vertical_tabs.rs`:
  - Add `is_inputs_synced` to `PaneProps`, computed once in `PaneProps::new`
    via `SyncedInputState::should_sync_this_pane_group(pane_group_id, window_id)`.
  - Add `render_synced_inputs_indicator()` rendering the same
    `LinkHorizontal` icon in the synced blue.
  - Render it next to the row title in all three vertical-tabs modes:
    Expanded (`render_pane_row`), Compact (`render_compact_pane_row`), and
    Summary (`render_summary_tab_item`).

No new subscription is needed: toggling sync already calls `ctx.notify()` in
`Workspace::process_updated_sync_state`, which re-renders the workspace (and
the sidebar), and `PaneProps::new` recomputes the flag on each render — the
same mechanism the horizontal tab indicator relies on.

## Linked Issue

Fixes #12495 — a triaged, actionable bug (`bug`, `triaged`, `repro:high`).

## Testing

- [x] I have manually tested my changes locally with `./script/run`

Built and ran from source. Split panes, toggled synchronized inputs with
Ctrl/Cmd+Alt+I — the indicator appears on synced rows in the sidebar and
clears when disabled. Verified in Expanded, Compact, and Summary modes.
`cargo fmt --check` and `cargo clippy -p warp -- -D warnings` are clean.

### Screenshots / Videos

| Before | After |
| ---| ---|
|<img width="2891" height="1532" alt="image" src="https://github.com/user-attachments/assets/ed5e434f-8341-4602-87db-ab0e13003b4a" />|<img width="2240" height="1400" alt="image" src="https://github.com/user-attachments/assets/a44ba0dc-afa9-4cf2-a002-d715e0ca9294" />|


## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Show the synchronized-inputs indicator on synced tabs in the vertical tabs sidebar.
