### PR TITLE
Return focus to input after command completes with blocks selected

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -1617,6 +1617,20 @@ pub struct ExecuteCommandEvent {
     pub source: CommandExecutionSource,
 }
 
+/// Controls how existing block/text selections influence focus when redetermining
+/// focus in [`TerminalView::redetermine_global_focus_with_policy`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SelectionFocusPolicy {
+    /// In shell mode, selected blocks/text keep the terminal focused so blocklist
+    /// navigation continues to work.
+    HoldsFocus,
+    /// Selections only keep the terminal focused while the user is actively making a
+    /// selection (mid text-selection drag or mid block click). Used when a command
+    /// completes, so a selection made before or during the command doesn't prevent
+    /// focus from returning to the input box.
+    HoldsFocusOnlyWhileSelecting,
+}
+
 /// Actions that can be taken on a passive code diff via the input editor.
 #[derive(Clone, Debug)]
 pub enum CodeDiffAction {
@@ -10673,6 +10687,17 @@ impl TerminalView {
     ///
     /// See [`Self::redetermine_global_focus`] to change focus without checking that the terminal is focused.
     fn redetermine_terminal_focus(&mut self, ctx: &mut ViewContext<Self>) -> bool {
+        self.redetermine_terminal_focus_with_policy(SelectionFocusPolicy::HoldsFocus, ctx)
+    }
+
+    /// Like [`Self::redetermine_terminal_focus`], but with an explicit
+    /// [`SelectionFocusPolicy`] controlling whether existing block/text selections keep
+    /// the terminal focused.
+    fn redetermine_terminal_focus_with_policy(
+        &mut self,
+        selection_focus_policy: SelectionFocusPolicy,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
         // Only reset focus if this terminal is focused; don't steal it from another part
         // of the app, or from an AI block / code diff the user is navigating.
         let reset_focus = ctx.is_self_or_child_focused()
@@ -10680,7 +10705,7 @@ impl TerminalView {
             && !self.block_filter_editor.is_self_or_child_focused(ctx)
             && !self.is_any_ai_block_focused(ctx);
         if reset_focus {
-            self.redetermine_global_focus(ctx);
+            self.redetermine_global_focus_with_policy(selection_focus_policy, ctx);
         }
 
         reset_focus
@@ -11479,8 +11504,16 @@ impl TerminalView {
 
                 // In-band commands finishing should never trigger a focus change as it could steal
                 // focus from the TerminalView.
+                //
+                // A block/text selection made before or during the command shouldn't pin focus
+                // to the terminal now that the command has finished -- focus should return to
+                // the input box so the user can type the next command. The exception is when
+                // the user is actively making a selection at this very moment.
                 if !matches!(block_completed_event.block_type, BlockType::InBandCommand) {
-                    let reset_focus = self.redetermine_terminal_focus(ctx);
+                    let reset_focus = self.redetermine_terminal_focus_with_policy(
+                        SelectionFocusPolicy::HoldsFocusOnlyWhileSelecting,
+                        ctx,
+                    );
                     // There are two different cases for redraws here:
                     // 1. If this terminal or its children were focused, redraw immediately after
                     //    this event.
@@ -20363,6 +20396,17 @@ impl TerminalView {
     ///
     /// TODO: https://linear.app/warpdotdev/issue/CORE-277
     pub fn redetermine_global_focus(&mut self, ctx: &mut ViewContext<Self>) {
+        self.redetermine_global_focus_with_policy(SelectionFocusPolicy::HoldsFocus, ctx);
+    }
+
+    /// Like [`Self::redetermine_global_focus`], but with an explicit
+    /// [`SelectionFocusPolicy`] controlling whether existing block/text selections keep
+    /// the terminal focused.
+    fn redetermine_global_focus_with_policy(
+        &mut self,
+        selection_focus_policy: SelectionFocusPolicy,
+        ctx: &mut ViewContext<Self>,
+    ) {
         if self.context_menu_state.is_some() {
             // This is a hack to avoid focusing on the terminal which
             // calls on_blur and closes the context menu when it is supposed
@@ -20416,8 +20460,16 @@ impl TerminalView {
             // navigation continues to work, unless the user has opted to preserve input focus.
             let preserve_input_focus =
                 *BlockListSettings::as_ref(ctx).preserve_input_focus_on_block_selection;
-            let has_block_or_text_selection_in_shell_mode =
-                is_shell_mode && !preserve_input_focus && (are_blocks_selected || is_text_selected);
+            let selection_holds_focus = match selection_focus_policy {
+                SelectionFocusPolicy::HoldsFocus => true,
+                SelectionFocusPolicy::HoldsFocusOnlyWhileSelecting => {
+                    self.is_selecting || self.mouse_down_block_index.is_some()
+                }
+            };
+            let has_block_or_text_selection_in_shell_mode = is_shell_mode
+                && !preserve_input_focus
+                && (are_blocks_selected || is_text_selected)
+                && selection_holds_focus;
 
             has_active_user_terminal_command || has_block_or_text_selection_in_shell_mode
         };
@@ -20887,15 +20939,6 @@ impl TerminalView {
                     .and_then(|session_id| self.sessions.as_ref(ctx).get(session_id))
                 {
                     active_session.cancel_active_commands();
-                }
-
-                // Clear any block selections for user-sourced commands so that focus can
-                // return to the input box once the command completes. Otherwise, the
-                // lingering selection forces `redetermine_global_focus` to keep the
-                // terminal focused after the block finishes. AI-sourced commands keep
-                // their selections, since selected blocks act as conversation context.
-                if !event.source.is_ai_command() {
-                    self.clear_selected_blocks(ctx);
                 }
 
                 // Don't steal focus from other parts of the app.

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -20889,6 +20889,15 @@ impl TerminalView {
                     active_session.cancel_active_commands();
                 }
 
+                // Clear any block selections for user-sourced commands so that focus can
+                // return to the input box once the command completes. Otherwise, the
+                // lingering selection forces `redetermine_global_focus` to keep the
+                // terminal focused after the block finishes. AI-sourced commands keep
+                // their selections, since selected blocks act as conversation context.
+                if !event.source.is_ai_command() {
+                    self.clear_selected_blocks(ctx);
+                }
+
                 // Don't steal focus from other parts of the app.
                 if ctx.is_self_or_child_focused() {
                     self.focus_terminal(ctx);


### PR DESCRIPTION
## Description
Fixes a focus bug: if a shell command is run while one or more blocks are selected in the block list (in either terminal or agent view), focus does not return to the input box after the command finishes.

Root cause: when a block completes, `redetermine_terminal_focus` → `redetermine_global_focus` keeps the terminal focused whenever blocks/text are selected in shell mode, so the lingering selection prevents the input from regaining focus.

Fix: introduce a `SelectionFocusPolicy` for focus redetermination. When a command's block completes, existing block/text selections no longer pin focus to the terminal — focus returns to the input box — unless the user is actively making a selection at that moment (mid text-selection drag or mid block click). Selections are preserved (not cleared), so they remain usable as context/filter/navigation state. All other focus-redetermination call sites keep the existing selection-holds-focus behavior.

## Linked Issue
N/A — reported directly.

## Testing
- `cargo check -p warp`, `cargo clippy -p warp --all-targets -- -D warnings`, and `./script/format` all pass.
- Manually validated end-to-end on a local build: selected a block, ran `sleep 4`, and confirmed the block's selection highlight persists during and after the command, while typed characters land in the input box immediately after completion without any mouse interaction.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed an issue where focus would not return to the input box after running a command while blocks were selected in the block list.

_Conversation: https://staging.warp.dev/conversation/d4659c13-1c6e-4f39-98c0-5b67d1adb643_
_Run: https://oz.staging.warp.dev/runs/019ebcab-84bd-7126-9cf9-9990daa4d5e7_

_This PR was generated with [Oz](https://warp.dev/oz)._
