### PR TITLE
[REMOTE-1782] Show departed participants' avatars on their agent queries in shared sessions

### DIFF
--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -959,7 +959,9 @@ impl View for AIBlock {
             }
             // Derive the display info for the participant who initiated this exchange.
             // For non-shared sessions, this is just the current user.
-            // For shared sessions, this is the user who initiated the request.
+            // For shared sessions, this is the user who initiated the request, even if
+            // they have since left the session (in which case we use their last-known
+            // profile data without a live presence color).
             let (avatar_display_name, profile_image_path, avatar_color) = self
                 .model
                 .response_initiator(app)
@@ -968,17 +970,17 @@ impl View for AIBlock {
                         .and_then(|terminal_view| {
                             terminal_view.read(app, |view, app| {
                                 view.shared_session_presence_manager().and_then(move |pm| {
-                                    pm.as_ref(app).get_participant(&participant_id).map(
-                                        |participant| {
-                                            // Get the display info from the participant
-                                            // who sent this query.
+                                    // Get the display info from the participant
+                                    // who sent this query.
+                                    pm.as_ref(app)
+                                        .get_participant_attribution(&participant_id)
+                                        .map(|attribution| {
                                             (
-                                                participant.info.profile_data.display_name.clone(),
-                                                participant.info.profile_data.photo_url.clone(),
-                                                Some(participant.color),
+                                                attribution.display_name,
+                                                attribution.photo_url,
+                                                attribution.color,
                                             )
-                                        },
-                                    )
+                                        })
                                 })
                             })
                         })

--- a/app/src/terminal/shared_session/presence_manager.rs
+++ b/app/src/terminal/shared_session/presence_manager.rs
@@ -153,6 +153,17 @@ impl Participant {
     }
 }
 
+/// Display info for attributing past activity (e.g. who initiated an agent
+/// exchange) to a participant, even if they have since left the session.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ParticipantAttribution {
+    pub display_name: String,
+    pub photo_url: Option<String>,
+    /// The participant's live presence color. `None` if the participant is no
+    /// longer present in the session.
+    pub color: Option<ColorU>,
+}
+
 /// Helper struct containing presence information about a participant who selected a particular block.
 pub struct ParticipantAtSelectedBlock<'a> {
     /// The participant who selected the block.
@@ -361,6 +372,36 @@ impl PresenceManager {
             }
         }
         None
+    }
+
+    /// Returns display info used to attribute past activity (e.g. the agent
+    /// query an exchange was initiated with) to the participant identified by
+    /// `id`.
+    ///
+    /// Unlike [`Self::get_participant`], this also resolves participants who
+    /// are no longer present in the session using their last-known profile
+    /// data, since attribution of past activity should survive the participant
+    /// leaving the session. Absent participants are resolved without a live
+    /// presence color.
+    pub fn get_participant_attribution(
+        &self,
+        id: &ParticipantId,
+    ) -> Option<ParticipantAttribution> {
+        if let Some(participant) = self.get_participant(id) {
+            return Some(ParticipantAttribution {
+                display_name: participant.info.profile_data.display_name.clone(),
+                photo_url: participant.info.profile_data.photo_url.clone(),
+                color: Some(participant.color),
+            });
+        }
+
+        self.absent_viewers
+            .get(id)
+            .map(|absent| ParticipantAttribution {
+                display_name: absent.participant_info.profile_data.display_name.clone(),
+                photo_url: absent.participant_info.profile_data.photo_url.clone(),
+                color: None,
+            })
     }
 
     /// Returns the participants who have the block at the block index selected.

--- a/app/src/terminal/shared_session/presence_manager_tests.rs
+++ b/app/src/terminal/shared_session/presence_manager_tests.rs
@@ -415,3 +415,189 @@ fn test_selected_block_index_for_avatar() {
         });
     });
 }
+
+fn participant_info_with_profile(
+    id: &ParticipantId,
+    display_name: &str,
+    photo_url: Option<&str>,
+) -> ParticipantInfo {
+    ParticipantInfo {
+        id: id.clone(),
+        profile_data: ProfileData {
+            firebase_uid: format!("{display_name}-uid"),
+            display_name: display_name.to_owned(),
+            photo_url: photo_url.map(str::to_owned),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn participant_list_with(sharer: Sharer, viewers: Vec<Viewer>) -> ParticipantList {
+    ParticipantList {
+        sharer,
+        viewers,
+        present_viewers: Default::default(),
+        absent_viewers: Default::default(),
+        guests: Default::default(),
+        pending_guests: Default::default(),
+    }
+}
+
+#[test]
+fn attribution_resolves_absent_viewer_profile_without_presence_color() {
+    App::test((), |mut app| async move {
+        let absent_id = ParticipantId::new();
+        let sharer_id = ParticipantId::new();
+        let sharer = Sharer {
+            info: participant_info_with_profile(&sharer_id, "Sharer", None),
+        };
+        let absent_viewer = Viewer {
+            info: participant_info_with_profile(
+                &absent_id,
+                "Departed Viewer",
+                Some("https://example.com/departed.png"),
+            ),
+            role: Role::Reader,
+            is_present: false,
+        };
+
+        let presence_manager = app.add_model(|ctx| {
+            PresenceManager::new_for_viewer(
+                ParticipantId::new(),
+                UserUid::new("self-uid"),
+                participant_list_with(sharer, vec![absent_viewer]),
+                ctx,
+            )
+        });
+
+        presence_manager.read(&app, |presence_manager, _ctx| {
+            // The live-presence lookup intentionally excludes absent viewers.
+            assert!(presence_manager.get_participant(&absent_id).is_none());
+
+            // But attribution of past activity (e.g. the agent query the
+            // departed viewer initiated) should still resolve their profile.
+            let attribution = presence_manager
+                .get_participant_attribution(&absent_id)
+                .expect("absent viewer should be resolvable for attribution");
+            assert_eq!(attribution.display_name, "Departed Viewer");
+            assert_eq!(
+                attribution.photo_url.as_deref(),
+                Some("https://example.com/departed.png")
+            );
+            assert_eq!(attribution.color, None);
+        });
+    });
+}
+
+#[test]
+fn attribution_still_resolves_viewer_after_they_leave() {
+    App::test((), |mut app| async move {
+        let viewer_id = ParticipantId::new();
+        let sharer_id = ParticipantId::new();
+        let sharer = Sharer {
+            info: participant_info_with_profile(&sharer_id, "Sharer", None),
+        };
+        let mut viewer = Viewer {
+            info: participant_info_with_profile(&viewer_id, "Prompt Sender", None),
+            role: Role::Reader,
+            is_present: true,
+        };
+
+        let presence_manager = app.add_model(|ctx| {
+            PresenceManager::new_for_viewer(
+                ParticipantId::new(),
+                UserUid::new("self-uid"),
+                participant_list_with(sharer.clone(), vec![viewer.clone()]),
+                ctx,
+            )
+        });
+
+        // Ensure participants are loaded before continuing.
+        presence_manager
+            .update(&mut app, |presence_manager, ctx| {
+                let spawned_future = presence_manager
+                    .load_participants_imgs_future_handle
+                    .as_ref()
+                    .expect("should have future handle");
+                ctx.await_spawned_future(spawned_future.future_id())
+            })
+            .await;
+
+        // While present, attribution carries the live presence color.
+        presence_manager.read(&app, |presence_manager, _ctx| {
+            let attribution = presence_manager
+                .get_participant_attribution(&viewer_id)
+                .expect("present viewer should be resolvable for attribution");
+            assert_eq!(attribution.display_name, "Prompt Sender");
+            assert!(attribution.color.is_some());
+        });
+
+        // The viewer leaves the session.
+        viewer.is_present = false;
+        presence_manager.update(&mut app, |presence_manager, ctx| {
+            presence_manager.update_participants(participant_list_with(sharer, vec![viewer]), ctx);
+        });
+
+        presence_manager.read(&app, |presence_manager, _ctx| {
+            assert!(presence_manager.get_participant(&viewer_id).is_none());
+
+            let attribution = presence_manager
+                .get_participant_attribution(&viewer_id)
+                .expect("departed viewer should still be resolvable for attribution");
+            assert_eq!(attribution.display_name, "Prompt Sender");
+            assert_eq!(attribution.color, None);
+        });
+    });
+}
+
+#[test]
+fn attribution_resolves_sharer_with_presence_color() {
+    App::test((), |mut app| async move {
+        let sharer_id = ParticipantId::new();
+        let sharer = Sharer {
+            info: participant_info_with_profile(&sharer_id, "Sharer", None),
+        };
+
+        let presence_manager = app.add_model(|ctx| {
+            PresenceManager::new_for_viewer(
+                ParticipantId::new(),
+                UserUid::new("self-uid"),
+                participant_list_with(sharer, vec![]),
+                ctx,
+            )
+        });
+
+        presence_manager.read(&app, |presence_manager, _ctx| {
+            let attribution = presence_manager
+                .get_participant_attribution(&sharer_id)
+                .expect("sharer should be resolvable for attribution");
+            assert_eq!(attribution.display_name, "Sharer");
+            assert!(attribution.color.is_some());
+        });
+    });
+}
+
+#[test]
+fn attribution_returns_none_for_unknown_participant() {
+    App::test((), |mut app| async move {
+        let sharer = Sharer {
+            info: participant_info_with_profile(&ParticipantId::new(), "Sharer", None),
+        };
+
+        let presence_manager = app.add_model(|ctx| {
+            PresenceManager::new_for_viewer(
+                ParticipantId::new(),
+                UserUid::new("self-uid"),
+                participant_list_with(sharer, vec![]),
+                ctx,
+            )
+        });
+
+        presence_manager.read(&app, |presence_manager, _ctx| {
+            assert!(presence_manager
+                .get_participant_attribution(&ParticipantId::new())
+                .is_none());
+        });
+    });
+}


### PR DESCRIPTION
## Description

When viewing a live shared session (most commonly a running cloud agent session), the avatar next to a user prompt showed the **viewing user's own** name/photo instead of the person who actually sent the prompt, whenever that person was no longer connected to the session.

**Why:** The AI block resolves the exchange's `response_initiator` (a session-sharing `ParticipantId`) through `PresenceManager::get_participant()`, which only returns *present* participants. Once the initiator disconnected, the lookup failed and the view fell back to the current user's auth state — so every later viewer saw themselves as the prompt author. (PR #11725 fixed the analogous bug for conversation *transcripts*, but live sessions resolve avatars through presence, not server conversation metadata.)

**How:** The presence manager already tracks departed participants in `absent_viewers` with their last-known profile data — it just wasn't consulted. This PR adds `PresenceManager::get_participant_attribution()`, which resolves present participants and the sharer as before, and falls back to absent viewers' last-known display name/photo (without a live presence color). The AI block query avatar now uses this attribution lookup. All live-presence call sites (cursors, role checks, block selections) intentionally keep using `get_participant()` and continue to exclude absent participants.

Note: this does **not** address follow-ups injected via warp-server's identity-less `/sessions/inject` path (those are attributed to the sharer by design today); that's a larger cross-service change tracked separately.

## Linked Issue

Linear: [REMOTE-1782](https://linear.app/warpdotdev/issue/REMOTE-1782/show-original-user-avatar-when-viewing-a-conversation-transcript-or) — the live shared-session half of the report (the transcript half shipped in #11725).

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

Automated coverage added in `presence_manager_tests.rs`:
- `attribution_resolves_absent_viewer_profile_without_presence_color` — regression test: an absent viewer is not resolvable via `get_participant` but is via the new attribution lookup
- `attribution_still_resolves_viewer_after_they_leave` — present → absent transition keeps attribution working and drops the presence color
- `attribution_resolves_sharer_with_presence_color`
- `attribution_returns_none_for_unknown_participant`

Validation run locally:
- `cargo nextest run -E 'test(presence_manager)'` — 9/9 pass
- `./script/format` — clean
- `cargo clippy -p warp --all-targets --tests -- -D warnings` — clean

Manual two-client repro (sharer runs an agent prompt; viewer B joins with executor role, sends a follow-up, disconnects; viewer C joins) is the end-to-end check — before this change C sees their own avatar on B's prompt, after it C sees B's name/photo.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation](https://staging.warp.dev/conversation/0f4a1187-15d5-4337-8c18-33bd9b192652)

CHANGELOG-BUG-FIX: Fixed shared session viewers seeing their own avatar on agent prompts sent by participants who have since left the session.

Co-Authored-By: Oz <oz-agent@warp.dev>
