### PR TITLE
Fix file link line navigation for "Open file" tooltip and Cmd+Click

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6228,7 +6228,7 @@ impl Workspace {
                     line_col,
                     CodeSource::Link {
                         path,
-                        range_start: None,
+                        range_start: line_col,
                         range_end: None,
                     },
                     ctx,
@@ -16351,7 +16351,7 @@ impl Workspace {
                     *line_col,
                     CodeSource::Link {
                         path: path.clone(),
-                        range_start: None,
+                        range_start: *line_col,
                         range_end: None,
                     },
                     ctx,


### PR DESCRIPTION
## Description

Clicking "Open file" from the file link tooltip (or Cmd+Click when Warp is the default editor) did not navigate to the detected line number, even when the link included one (e.g. `foo.rs:42`). Clicking "Open in Warp" in the same tooltip worked correctly.

**Root cause**: `CodePane::pre_attach()` derives the navigation line from `CodeSource::Link.range_start`. The "Open in Warp" path correctly populates `range_start` with the detected line number, but the two `OpenFileWithTarget` event handlers in `workspace/view.rs` constructed `CodeSource::Link` with `range_start: None`, discarding the `line_col` that was already in scope.

**Fix**: Two one-line changes in `workspace/view.rs` — populate `range_start` from `line_col` when constructing `CodeSource::Link` in the `pane_group::Event::OpenFileWithTarget` and `RightPanelEvent::OpenFileWithTarget` handlers.

## Linked Issue

N/A (bug reported in Slack #feedback-app)

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

Verified via code analysis: `open_highlighted_link` and `open_rich_content_link` both correctly pass `line_and_column_num` through to `open_file_path`; the only missing piece was the `range_start` field in the `CodeSource::Link` used by `pre_attach`.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed "Open file" tooltip link and Cmd+Click not navigating to the detected line number in file links that include line numbers (e.g. `src/main.rs:42`).
-->

_Conversation: https://staging.warp.dev/conversation/8db99de6-95be-4b52-8a6e-413964b7348d_
_Run: https://oz.staging.warp.dev/runs/019ebd71-e543-7be5-919a-47cb8925b265_
_This PR was generated with [Oz](https://warp.dev/oz)._
