### PR TITLE
Modify existing tab and group functionality to enforce pinning invariant

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -193,16 +193,29 @@ impl TabData {
         index: usize,
         tabs_len: usize,
         tab_groups: &HashMap<TabGroupId, TabGroup>,
+        can_move_left: bool,
+        can_move_right: bool,
         ctx: &AppContext,
     ) -> Vec<MenuItem<WorkspaceAction>> {
-        self.menu_items_with_pane_name_target(index, tabs_len, tab_groups, None, ctx)
+        self.menu_items_with_pane_name_target(
+            index,
+            tabs_len,
+            tab_groups,
+            can_move_left,
+            can_move_right,
+            None,
+            ctx,
+        )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn menu_items_with_pane_name_target(
         &self,
         index: usize,
         tabs_len: usize,
         tab_groups: &HashMap<TabGroupId, TabGroup>,
+        can_move_left: bool,
+        can_move_right: bool,
         pane_name_target: Option<PaneNameMenuTarget>,
         ctx: &AppContext,
     ) -> Vec<MenuItem<WorkspaceAction>> {
@@ -215,7 +228,7 @@ impl TabData {
             self.tab_group_menu_items(index, tab_groups),
             self.session_sharing_menu_items(index, ctx),
             self.copy_metadata_menu_items(pane_name_target, ctx),
-            self.modify_tab_menu_items(index, tabs_len, pane_name_target, ctx),
+            self.modify_tab_menu_items(index, can_move_left, can_move_right, pane_name_target, ctx),
             self.close_tab_menu_items(index, tabs_len, ctx),
             Self::save_config_menu_items(index),
             self.color_option_menu_items(index, terminal_colors),
@@ -417,7 +430,8 @@ impl TabData {
     fn modify_tab_menu_items(
         &self,
         index: usize,
-        tabs_len: usize,
+        can_move_left: bool,
+        can_move_right: bool,
         pane_name_target: Option<PaneNameMenuTarget>,
         ctx: &AppContext,
     ) -> Vec<MenuItem<WorkspaceAction>> {
@@ -442,10 +456,10 @@ impl TabData {
         if let Some(pane_name_target) = pane_name_target {
             menu_items.extend(self.pane_name_menu_items(pane_name_target, ctx));
         }
-        // Don't show options that aren't relevant (moving end tabs, closing
-        // other tabs when you don't have any others to close)
-        let not_last_tab = index != tabs_len - 1;
-        if not_last_tab {
+        // `can_move_left` / `can_move_right` come from `Workspace::can_move_tab`
+        // and gate the "Move Tab Up/Down" entries so they disappear when the
+        // move would cross the pinned/unpinned boundary, group boundary or tab list bounds.
+        if can_move_right {
             menu_items.push(
                 MenuItemFields::new(if uses_vertical_tabs {
                     "Move Tab Down"
@@ -456,7 +470,7 @@ impl TabData {
                 .into_item(),
             );
         }
-        if index != 0 {
+        if can_move_left {
             menu_items.push(
                 MenuItemFields::new(if uses_vertical_tabs {
                     "Move Tab Up"

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6824,16 +6824,16 @@ impl Workspace {
             ctx,
         );
         let new_tab_index = self.active_tab_index;
+
+        // Ensure that new tab groups always land below pinned items, but above
+        // any other items in the tab list.
+        let target = self.pinned_boundary_index();
+
         if let Some(tab) = self.tabs.get_mut(new_tab_index) {
             tab.group_id = Some(group_id);
         }
 
-        // New tab groups always land at the top of the tab list.
-        if new_tab_index != 0 {
-            let tab = self.tabs.remove(new_tab_index);
-            self.tabs.insert(0, tab);
-            self.active_tab_index = 0;
-        }
+        self.move_tab_to_index(new_tab_index, target, ctx);
 
         ctx.dispatch_global_action("workspace:save_app", ());
         ctx.notify();
@@ -6919,10 +6919,15 @@ impl Workspace {
             });
     }
 
-    /// Creates a new group containing the tab, anchored at the tab's original
-    /// position. If the tab was pulled out of an existing group, leaving it in
-    /// place would split that group's contiguous run, so the new group lands
-    /// just past the old group's last remaining member instead.
+    /// Creates a new group containing the tab. The new group is unpinned
+    /// regardless of whether the source tab was pinned — tab pinning and
+    /// group pinning are independent concepts, and the user can pin the new
+    /// group explicitly after creation. The block lands at the source tab's
+    /// original slot, except:
+    /// * If the tab was in an existing group, anchor past that group's last
+    ///   remaining member so the old group stays contiguous.
+    /// * If the tab was effectively pinned, clamp past the pinned region so
+    ///   the new (unpinned) group doesn't land inside the pinned area.
     fn new_tab_group_from_tab(&mut self, tab_index: usize, ctx: &mut ViewContext<Self>) {
         if !FeatureFlag::GroupedTabs.is_enabled() {
             return;
@@ -6937,15 +6942,21 @@ impl Workspace {
         let group_id = group.id;
         self.tab_groups.insert(group_id, group);
 
-        self.tabs[tab_index].group_id = Some(group_id);
+        // If the tab we are making a group from, is already in a group
+        // our target index is directly after the group's last member.
+        // Otherwise it is the tab's current index.
+        let natural_target = previous_group_id
+            .and_then(|gid| self.index_after_group(gid))
+            .unwrap_or(tab_index);
 
-        // When the tab leaves an existing group, reposition it just past that
-        // group's last remaining member so the old group stays contiguous.
-        if let Some(prev_group_id) = previous_group_id {
-            if let Some(last) = group_member_indices(&self.tabs, prev_group_id).last() {
-                self.move_tab_to_index(tab_index, last + 1, ctx);
-            }
-        }
+        // Our target index should always be after all existing pinned items.
+        let target = self.clamp_to_unpinned_region(&self.tabs, natural_target);
+
+        self.tabs[tab_index].group_id = Some(group_id);
+        // Pin state is cleared when a new group with this tab is created.
+        self.tabs[tab_index].pinned = false;
+
+        self.move_tab_to_index(tab_index, target, ctx);
 
         // The move above may have shifted the tab; the new group has exactly
         // one member, so its position is the new active index.
@@ -6985,11 +6996,13 @@ impl Workspace {
         }
         let previous_group_id = tab.group_id;
 
-        let target_index = group_member_indices(&self.tabs, group_id)
-            .last()
-            .map(|i| i + 1)
+        let target_index = self
+            .index_after_group(group_id)
             .unwrap_or(self.tabs.len());
         self.tabs[tab_index].group_id = Some(group_id);
+
+        // Moving a tab to a group, clear its pinned state.
+        self.tabs[tab_index].pinned = false;
         self.expand_tab_group(group_id, ctx);
         self.move_tab_to_index(tab_index, target_index, ctx);
 
@@ -7003,7 +7016,8 @@ impl Workspace {
     }
 
     /// Removes the tab from its current group and repositions it just past
-    /// the group's last remaining member.
+    /// the group's last remaining member, or further if the group was pinned
+    /// (the removed tab is now unpinned and must clear the pinned region).
     fn remove_tab_from_group(&mut self, tab_index: usize, ctx: &mut ViewContext<Self>) {
         if !FeatureFlag::GroupedTabs.is_enabled() {
             return;
@@ -7015,10 +7029,17 @@ impl Workspace {
             return;
         };
 
+        // The target index is after the last tab in this group.
+        // If this group was pinned, we want to move this tab after
+        // the pinned region.
+        let target = self
+            .index_after_group(previous_group_id)
+            .map(|t| self.clamp_to_unpinned_region(&self.tabs, t));
+
         self.tabs[tab_index].group_id = None;
 
-        if let Some(last) = group_member_indices(&self.tabs, previous_group_id).last() {
-            self.move_tab_to_index(tab_index, last + 1, ctx);
+        if let Some(target) = target {
+            self.move_tab_to_index(tab_index, target, ctx);
         }
 
         self.prune_empty_tab_group(previous_group_id, ctx);
@@ -7032,12 +7053,39 @@ impl Workspace {
         if !FeatureFlag::GroupedTabs.is_enabled() || !self.tab_groups.contains_key(&group_id) {
             return;
         }
+        // Capture the group's contiguous member range and pinned state
+        // before mutating; we need them to relocate the block out of the
+        // pinned region when the group was pinned.
+        let was_pinned = self.tab_groups.get(&group_id).is_some_and(|g| g.pinned);
+        let member_range = group_member_index_range(&self.tabs, group_id);
+
         for tab in &mut self.tabs {
             if tab.group_id == Some(group_id) {
                 tab.group_id = None;
             }
         }
         self.tab_groups.remove(&group_id);
+
+        // If the group was pinned, we must reposition the group's
+        // members after the pinned area. They are now ungrouped and
+        // thus no longer pinned.
+        if was_pinned {
+            if let Some((first, last)) = member_range {
+                // Remove ungrouped tabs from the tab list.
+                let active_pane_group_id = self
+                    .tabs
+                    .get(self.active_tab_index)
+                    .map(|tab| tab.pane_group.id());
+                let drained: Vec<TabData> = self.tabs.drain(first..=last).collect();
+                // Recompute boundary now that the (formerly group-pinned)
+                // block has been removed from the list.
+                let target = self.pinned_boundary_index();
+                // Place the ungrouped tabs at their new target index.
+                self.tabs.splice(target..target, drained);
+                self.restore_active_tab_index(active_pane_group_id);
+            }
+        }
+
         ctx.dispatch_global_action("workspace:save_app", ());
         ctx.notify();
     }
@@ -7068,9 +7116,8 @@ impl Workspace {
             let new_idx = self.active_tab_index;
             // Resolve the destination from the group's existing members before
             // adding the new tab to the group.
-            let target_index = group_member_indices(&self.tabs, group_id)
-                .last()
-                .map(|last| last + 1)
+            let target_index = self
+                .index_after_group(group_id)
                 .unwrap_or(self.tabs.len());
             if let Some(tab) = self.tabs.get_mut(new_idx) {
                 tab.group_id = Some(group_id);
@@ -7078,6 +7125,38 @@ impl Workspace {
             self.move_tab_to_index(new_idx, target_index, ctx);
         }
         self.expand_tab_group(group_id, ctx);
+    }
+    
+    /// True when the user-initiated reorder of `group_id` in `direction`
+    /// would not cross the pinned/unpinned boundary or go beyond the tab list bounds.
+    /// Used for the tab group menu which supports 'move group up/down' (or for htabs left/right).
+    pub(super) fn can_move_tab_group(&self, group_id: TabGroupId, direction: TabMovement) -> bool {
+        let Some((first, last)) = group_member_index_range(&self.tabs, group_id) else {
+            return false;
+        };
+        let group_pinned = self.tab_groups.get(&group_id).is_some_and(|g| g.pinned);
+        match direction {
+            TabMovement::Left => {
+                // Group can not move up/left if it is the first item.
+                if first == 0 {
+                    return false;
+                }
+                let neighbor = &self.tabs[first - 1];
+                // This group can only move up/left if it is pinned or the
+                // item before it is not pinned.
+                group_pinned || !self.is_tab_effectively_pinned(neighbor)
+            }
+            TabMovement::Right => {
+                // Group can not move down/right if it is the last item.
+                if last + 1 >= self.tabs.len() {
+                    return false;
+                }
+                let neighbor = &self.tabs[last + 1];
+                // This group can only move down.right if it is not pinned
+                // or the item after it is pinned.
+                !group_pinned || self.is_tab_effectively_pinned(neighbor)
+            }
+        }
     }
 
     /// Moves the whole group up or down by one "slot", where a slot is the
@@ -7098,14 +7177,14 @@ impl Workspace {
         if !FeatureFlag::GroupedTabs.is_enabled() {
             return;
         }
+        if !self.can_move_tab_group(group_id, direction) {
+            return;
+        }
         let Some((first, last)) = group_member_index_range(&self.tabs, group_id) else {
             return;
         };
         match direction {
             TabMovement::Left => {
-                if first == 0 {
-                    return;
-                }
                 // The upward neighbor is the tab directly above the group.
                 let above_index = first - 1;
                 // If that neighbor is itself grouped, land above its whole
@@ -7119,9 +7198,6 @@ impl Workspace {
                 self.move_group_block(group_id, target, ctx);
             }
             TabMovement::Right => {
-                if last + 1 >= self.tabs.len() {
-                    return;
-                }
                 // The downward neighbor is the tab directly below the group.
                 let below_index = last + 1;
                 // If that neighbor is itself grouped, expand to its whole
@@ -7227,7 +7303,9 @@ impl Workspace {
 
     /// Flips `tab_index`'s group membership. Callers are responsible for
     /// positioning the tab so groups remain contiguous; this method only
-    /// mutates `group_id` and prunes the old group when empty.
+    /// mutates `group_id`, clears the per-tab pinned flag when entering a
+    /// group (groups own pinning for their members — see `pin_tab_group`),
+    /// and prunes the old group when empty.
     pub fn assign_tab_to_group(
         &mut self,
         tab_index: usize,
@@ -7254,6 +7332,11 @@ impl Workspace {
 
         let previous_group_id = self.tabs[tab_index].group_id;
         self.tabs[tab_index].group_id = group_id;
+        // Entering a group: drop any individual pinned flag. The group's own
+        // `pinned` flag now governs whether this tab is in the pinned region.
+        if group_id.is_some() {
+            self.tabs[tab_index].pinned = false;
+        }
 
         if let Some(previous_group_id) = previous_group_id {
             self.prune_empty_tab_group(previous_group_id, ctx);
@@ -7367,9 +7450,18 @@ impl Workspace {
             return;
         }
 
+        let can_move_left = self.can_move_tab(tab_index, TabMovement::Left);
+        let can_move_right = self.can_move_tab(tab_index, TabMovement::Right);
         let menu_items = {
             let tab = &self.tabs[tab_index];
-            tab.menu_items(tab_index, self.tabs.len(), &self.tab_groups, ctx)
+            tab.menu_items(
+                tab_index,
+                self.tabs.len(),
+                &self.tab_groups,
+                can_move_left,
+                can_move_right,
+                ctx,
+            )
         };
         ctx.update_view(&self.tab_right_click_menu, |context_menu, view_ctx| {
             context_menu.set_items(menu_items, view_ctx);
@@ -7441,10 +7533,15 @@ impl Workspace {
                 reset_label: "Reset active pane name",
             },
         };
+        let can_move_left = self.can_move_tab(tab_index, TabMovement::Left);
+        let can_move_right = self.can_move_tab(tab_index, TabMovement::Right);
+        let tab = &self.tabs[tab_index];
         let menu_items = tab.menu_items_with_pane_name_target(
             tab_index,
             self.tabs.len(),
             &self.tab_groups,
+            can_move_left,
+            can_move_right,
             Some(pane_name_target),
             ctx,
         );
@@ -9407,10 +9504,15 @@ impl Workspace {
         let has_tabs_above = first > 0;
         let has_tabs_below = last + 1 < self.tabs.len();
         let has_tabs_outside = (last - first + 1) < self.tabs.len();
+        // Move entries are hidden when the move would cross the
+        // pinned/unpinned boundary, or go beyond the tab list bounds
+        // so the user never sees an option that would be a no-op.
+        let can_move_up = has_tabs_above && self.can_move_tab_group(group_id, TabMovement::Left);
+        let can_move_down = has_tabs_below && self.can_move_tab_group(group_id, TabMovement::Right);
 
         let move_section = {
             let mut items = vec![];
-            if has_tabs_above {
+            if can_move_up {
                 let label = if is_vertical {
                     "Move group up"
                 } else {
@@ -9422,7 +9524,7 @@ impl Workspace {
                         .into_item(),
                 );
             }
-            if has_tabs_below {
+            if can_move_down {
                 let label = if is_vertical {
                     "Move group down"
                 } else {
@@ -11780,9 +11882,7 @@ impl Workspace {
         let insert_index = if let Some(group_id) = tab_data.group_id {
             if self.tab_groups.contains_key(&group_id) {
                 // Group still exists — append after its current last member.
-                group_member_indices(&self.tabs, group_id)
-                    .last()
-                    .map(|i| i + 1)
+                self.index_after_group(group_id)
                     .unwrap_or(self.tabs.len())
             } else {
                 // Group was pruned — drop membership.
@@ -12120,11 +12220,7 @@ impl Workspace {
                 // contiguous run instead of past it so the setting is
                 // honored within the group's bounds.
                 let insert_idx = active_tab_group_id
-                    .and_then(|gid| {
-                        group_member_indices(&self.tabs, gid)
-                            .last()
-                            .map(|last| last + 1)
-                    })
+                    .and_then(|gid| self.index_after_group(gid))
                     .unwrap_or(self.tabs.len());
                 self.tabs.insert(insert_idx, TabData::new(new_pane_group));
                 self.tab_mru_order
@@ -12143,18 +12239,24 @@ impl Workspace {
                     // inherit the active tab's group. If the active tab is inside
                     // a group, land after the group's last member so we don't
                     // split it.
-                    let insert_idx = if is_restoration {
+                    let mut insert_idx = if is_restoration {
                         active_tab
                             .and_then(|t| t.group_id)
-                            .and_then(|gid| {
-                                group_member_indices(&self.tabs, gid)
-                                    .last()
-                                    .map(|last| last + 1)
-                            })
+                            .and_then(|gid| self.index_after_group(gid))
                             .unwrap_or(self.active_tab_index + 1)
                     } else {
                         self.active_tab_index + 1
                     };
+                    // When the new tab inherits the active tab's group it
+                    // joins that group's contiguous block, which lives
+                    // wherever the group lives (pinned or unpinned) —
+                    // placement is already correct. Without group
+                    // inheritance, the new tab is unpinned and standalone, so
+                    // we push it past the pinned boundary to avoid landing
+                    // inside the pinned area when the active tab is pinned.
+                    if active_tab_group_id.is_none() {
+                        insert_idx = self.clamp_to_unpinned_region(&self.tabs, insert_idx);
+                    }
                     self.tabs.insert(insert_idx, TabData::new(new_pane_group));
                     self.tab_mru_order
                         .push(self.tabs[insert_idx].pane_group.id());
@@ -13366,6 +13468,44 @@ impl Workspace {
         });
     }
 
+    /// True when reordering the tab at `index` in `direction` would not
+    /// split a group or cross the pinned/unpinned boundary. Used by the
+    /// action handler to no-op blocked moves and by `modify_tab_menu_items`
+    /// to hide the entry.
+    pub(super) fn can_move_tab(&self, index: usize, direction: TabMovement) -> bool {
+        let Some(tab) = self.tabs.get(index) else {
+            return false;
+        };
+        let tab_pinned = self.is_tab_effectively_pinned(tab);
+        match direction {
+            TabMovement::Left => {
+                if index == 0 {
+                    return false;
+                }
+                let neighbor = &self.tabs[index - 1];
+                // A grouped tab can only reorder within its own group;
+                // crossing the group boundary would split its contiguous
+                // run (first member moving left, etc.).
+                if tab.group_id.is_some() {
+                    return tab.group_id == neighbor.group_id;
+                }
+                // Unpinned tab can't move up into the pinned region.
+                tab_pinned || !self.is_tab_effectively_pinned(neighbor)
+            }
+            TabMovement::Right => {
+                if index + 1 >= self.tabs.len() {
+                    return false;
+                }
+                let neighbor = &self.tabs[index + 1];
+                if tab.group_id.is_some() {
+                    return tab.group_id == neighbor.group_id;
+                }
+                // Pinned tab can't move down into the unpinned region.
+                !tab_pinned || self.is_tab_effectively_pinned(neighbor)
+            }
+        }
+    }
+
     /// Moves the tab at `index` one slot left/right, where a "slot" is either a
     /// single tab or an entire adjacent group. If the neighbor in the move
     /// direction belongs to a *different* group, the tab hops over that whole
@@ -13373,6 +13513,9 @@ impl Workspace {
     /// ungrouped tab, or reordering within the tab's own group, is an ordinary
     /// one-slot move.
     fn move_tab(&mut self, index: usize, direction: TabMovement, ctx: &mut ViewContext<Self>) {
+        if !self.can_move_tab(index, direction) {
+            return;
+        }
         let tabs_len = self.tabs.len();
         // The group the moved tab belongs to (if any), so we can distinguish
         // "reorder within my own group" from "hop over a different group".

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6996,9 +6996,7 @@ impl Workspace {
         }
         let previous_group_id = tab.group_id;
 
-        let target_index = self
-            .index_after_group(group_id)
-            .unwrap_or(self.tabs.len());
+        let target_index = self.index_after_group(group_id).unwrap_or(self.tabs.len());
         self.tabs[tab_index].group_id = Some(group_id);
 
         // Moving a tab to a group, clear its pinned state.
@@ -7116,9 +7114,7 @@ impl Workspace {
             let new_idx = self.active_tab_index;
             // Resolve the destination from the group's existing members before
             // adding the new tab to the group.
-            let target_index = self
-                .index_after_group(group_id)
-                .unwrap_or(self.tabs.len());
+            let target_index = self.index_after_group(group_id).unwrap_or(self.tabs.len());
             if let Some(tab) = self.tabs.get_mut(new_idx) {
                 tab.group_id = Some(group_id);
             }
@@ -7126,7 +7122,7 @@ impl Workspace {
         }
         self.expand_tab_group(group_id, ctx);
     }
-    
+
     /// True when the user-initiated reorder of `group_id` in `direction`
     /// would not cross the pinned/unpinned boundary or go beyond the tab list bounds.
     /// Used for the tab group menu which supports 'move group up/down' (or for htabs left/right).
@@ -11882,8 +11878,7 @@ impl Workspace {
         let insert_index = if let Some(group_id) = tab_data.group_id {
             if self.tab_groups.contains_key(&group_id) {
                 // Group still exists — append after its current last member.
-                self.index_after_group(group_id)
-                    .unwrap_or(self.tabs.len())
+                self.index_after_group(group_id).unwrap_or(self.tabs.len())
             } else {
                 // Group was pruned — drop membership.
                 tab_data.group_id = None;

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6827,7 +6827,7 @@ impl Workspace {
 
         // Ensure that new tab groups always land below pinned items, but above
         // any other items in the tab list.
-        let target = self.pinned_boundary_index();
+        let target = self.pinned_boundary_index(&self.tabs);
 
         if let Some(tab) = self.tabs.get_mut(new_tab_index) {
             tab.group_id = Some(group_id);
@@ -7077,7 +7077,7 @@ impl Workspace {
                 let drained: Vec<TabData> = self.tabs.drain(first..=last).collect();
                 // Recompute boundary now that the (formerly group-pinned)
                 // block has been removed from the list.
-                let target = self.pinned_boundary_index();
+                let target = self.pinned_boundary_index(&self.tabs);
                 // Place the ungrouped tabs at their new target index.
                 self.tabs.splice(target..target, drained);
                 self.restore_active_tab_index(active_pane_group_id);

--- a/app/src/workspace/view/tab_grouping.rs
+++ b/app/src/workspace/view/tab_grouping.rs
@@ -146,7 +146,7 @@ impl Workspace {
     /// Re-seats `active_tab_index` so the previously-active pane group stays
     /// visually active across a tab reorder. Pass the pane group id captured
     /// before the reorder; no-op if it can't be found.
-    fn restore_active_tab_index(&mut self, pane_group_id: Option<EntityId>) {
+    pub(super) fn restore_active_tab_index(&mut self, pane_group_id: Option<EntityId>) {
         if let Some(active_id) = pane_group_id {
             if let Some(new_index) = self
                 .tabs
@@ -203,10 +203,12 @@ impl Workspace {
         let anchor_index = selected_indices[0];
         let anchor_previous_group_id = self.tabs[anchor_index].group_id;
 
-        // Assign membership and clear flags for every selected tab.
+        // Assign membership and clear flags for every selected tab. The new
+        // group is unpinned, so any selected tab in set as unpinned.
         for &index in &selected_indices {
             let tab = &mut self.tabs[index];
             tab.group_id = Some(group_id);
+            tab.pinned = false;
             tab.in_multi_selection = false;
         }
 
@@ -242,6 +244,9 @@ impl Workspace {
                     .map(|last| last + 1)
             })
             .unwrap_or(anchor_index);
+
+        // Our insertion index for this group should be below any pinned items.
+        let insert_at = self.clamp_to_unpinned_region(&other_tabs, insert_at);
 
         other_tabs.splice(insert_at..insert_at, selected_tabs);
         self.tabs = other_tabs;
@@ -302,10 +307,13 @@ impl Workspace {
             .get(self.active_tab_index)
             .map(|tab| tab.pane_group.id());
 
-        // Assign membership and clear flags for every selected tab.
+        // Assign membership and clear flags for every selected tab. Entering
+        // the group removes any per-tab pinned flag — the destination group's
+        // own `pinned` flag now governs the member's position.
         for &index in &selected_indices {
             let tab = &mut self.tabs[index];
             tab.group_id = Some(group_id);
+            tab.pinned = false;
             tab.in_multi_selection = false;
         }
 
@@ -393,10 +401,14 @@ impl Workspace {
                 });
         // Anchor the removed block just after the group's remaining members;
         // if none remain, fall back to the pre-computed prefix position.
-        let insert_at = match rest.iter().rposition(|tab| tab.group_id == Some(group_id)) {
+        let natural_insert_at = match rest.iter().rposition(|tab| tab.group_id == Some(group_id)) {
             Some(last) => last + 1,
             None => kept_before_group,
         };
+        // The removed tabs are now unpinned (they left a possibly-pinned
+        // group); they must land past every effectively pinned tab in
+        // not just past the source group's remaining members.
+        let insert_at = self.clamp_to_unpinned_region(&rest, natural_insert_at);
         rest.splice(insert_at..insert_at, removed);
         self.tabs = rest;
 
@@ -469,7 +481,7 @@ impl Workspace {
     /// True when `tab` is positioned in the pinned region of the tab list —
     /// either because its own `pinned` flag is set (ungrouped pinned tab) or
     /// because it belongs to a pinned group.
-    fn is_tab_effectively_pinned(&self, tab: &TabData) -> bool {
+    pub(super) fn is_tab_effectively_pinned(&self, tab: &TabData) -> bool {
         tab.pinned
             || tab
                 .group_id
@@ -478,11 +490,30 @@ impl Workspace {
 
     /// Index where the unpinned region begins: the count of leading tabs that
     /// belong to the pinned region.
-    fn pinned_boundary_index(&self) -> usize {
+    pub(super) fn pinned_boundary_index(&self) -> usize {
         self.tabs
             .iter()
             .take_while(|tab| self.is_tab_effectively_pinned(tab))
             .count()
+    }
+
+    /// Pushes `idx` past the leading effectively-pinned tabs in `tabs` if it
+    /// falls inside that prefix. 
+    pub(super) fn clamp_to_unpinned_region(&self, tabs: &[TabData], idx: usize) -> usize {
+        let boundary = tabs
+            .iter()
+            .take_while(|tab| self.is_tab_effectively_pinned(tab))
+            .count();
+        idx.max(boundary)
+    }
+
+    /// Returns the slot just past the last member of `group_id`, suitable as
+    /// an insert/move target that keeps the group contiguous. `None` when the
+    /// group has no members.
+    pub(super) fn index_after_group(&self, group_id: TabGroupId) -> Option<usize> {
+        group_member_indices(&self.tabs, group_id)
+            .last()
+            .map(|last| last + 1)
     }
 
     /// Pins the tab. Grouped tabs are extracted from their group first

--- a/app/src/workspace/view/tab_grouping.rs
+++ b/app/src/workspace/view/tab_grouping.rs
@@ -488,11 +488,10 @@ impl Workspace {
                 .is_some_and(|gid| self.tab_groups.get(&gid).is_some_and(|g| g.pinned))
     }
 
-    /// Index where the unpinned region begins: the count of leading tabs that
-    /// belong to the pinned region.
-    pub(super) fn pinned_boundary_index(&self) -> usize {
-        self.tabs
-            .iter()
+    /// Index where the unpinned region begins within `tabs`: the count of
+    /// leading tabs that belong to the pinned region.
+    pub(super) fn pinned_boundary_index(&self, tabs: &[TabData]) -> usize {
+        tabs.iter()
             .take_while(|tab| self.is_tab_effectively_pinned(tab))
             .count()
     }
@@ -500,11 +499,7 @@ impl Workspace {
     /// Pushes `idx` past the leading effectively-pinned tabs in `tabs` if it
     /// falls inside that prefix.
     pub(super) fn clamp_to_unpinned_region(&self, tabs: &[TabData], idx: usize) -> usize {
-        let boundary = tabs
-            .iter()
-            .take_while(|tab| self.is_tab_effectively_pinned(tab))
-            .count();
-        idx.max(boundary)
+        idx.max(self.pinned_boundary_index(tabs))
     }
 
     /// Returns the slot just past the last member of `group_id`, suitable as
@@ -534,7 +529,7 @@ impl Workspace {
         let previous_group_id = tab.group_id;
 
         // Identify where this newly pinned tab should land (after the last pinned item).
-        let target = self.pinned_boundary_index();
+        let target = self.pinned_boundary_index(&self.tabs);
 
         self.tabs[tab_index].group_id = None;
         self.tabs[tab_index].pinned = true;
@@ -563,7 +558,7 @@ impl Workspace {
         }
 
         // This tab should land right after all pinned items.
-        let target = self.pinned_boundary_index();
+        let target = self.pinned_boundary_index(&self.tabs);
 
         self.tabs[tab_index].pinned = false;
         self.move_tab_to_index(tab_index, target, ctx);
@@ -590,7 +585,7 @@ impl Workspace {
             return;
         }
 
-        let target = self.pinned_boundary_index();
+        let target = self.pinned_boundary_index(&self.tabs);
         if let Some(group) = self.tab_groups.get_mut(&group_id) {
             group.pinned = true;
         }
@@ -615,7 +610,7 @@ impl Workspace {
             return;
         }
 
-        let target = self.pinned_boundary_index();
+        let target = self.pinned_boundary_index(&self.tabs);
         if let Some(group) = self.tab_groups.get_mut(&group_id) {
             group.pinned = false;
         }

--- a/app/src/workspace/view/tab_grouping.rs
+++ b/app/src/workspace/view/tab_grouping.rs
@@ -498,7 +498,7 @@ impl Workspace {
     }
 
     /// Pushes `idx` past the leading effectively-pinned tabs in `tabs` if it
-    /// falls inside that prefix. 
+    /// falls inside that prefix.
     pub(super) fn clamp_to_unpinned_region(&self, tabs: &[TabData], idx: usize) -> usize {
         let boundary = tabs
             .iter()

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -1920,7 +1920,7 @@ fn test_tab_context_menu_share_session_items() {
         // When there's a single shared session in a tab (focused), the options
         // for sharing are "Stop sharing" and "Stop sharing all".
         workspace.read(&app, |workspace, ctx| {
-            let items = workspace.tabs[1].menu_items(1, 3, &workspace.tab_groups, ctx);
+            let items = workspace.tabs[1].menu_items(1, 3, &workspace.tab_groups, true, true, ctx);
             assert!(items[0]
                 .is_approximately_same_item_as(&MenuItemFields::new("Stop sharing").into_item()));
             assert!(items[1].is_approximately_same_item_as(
@@ -1941,7 +1941,7 @@ fn test_tab_context_menu_share_session_items() {
         // When there's a single shared session in a tab (unfocused), the options
         // for sharing are "Share session" and "Stop sharing all".
         workspace.read(&app, |workspace, ctx| {
-            let items = workspace.tabs[1].menu_items(1, 3, &workspace.tab_groups, ctx);
+            let items = workspace.tabs[1].menu_items(1, 3, &workspace.tab_groups, true, true, ctx);
             assert!(items[0]
                 .is_approximately_same_item_as(&MenuItemFields::new("Share session").into_item()));
             assert!(items[1].is_approximately_same_item_as(
@@ -1957,7 +1957,7 @@ fn test_tab_context_menu_share_session_items() {
 
         // When there's no shared sessions in a tab, the only option is "Share session".
         workspace.read(&app, |workspace, ctx| {
-            let items = workspace.tabs[1].menu_items(1, 3, &workspace.tab_groups, ctx);
+            let items = workspace.tabs[1].menu_items(1, 3, &workspace.tab_groups, true, true, ctx);
             assert!(items[0]
                 .is_approximately_same_item_as(&MenuItemFields::new("Share session").into_item()));
             assert!(items[1].is_approximately_same_item_as(&MenuItem::Separator));


### PR DESCRIPTION
## Description

Updates existing tab and tab-group operations so they respect the new invariant for pinned items: effectively pinned tabs (individually pinned, or members of a pinned group) always form a contiguous block at the front of the tab list. Without these changes, several existing flows could land tabs/groups inside the pinned region without ever being pinned. 

**NOTE**: It is important to understand that pinning a tab and group are independent events and that a tab within a pinned group is not equivalent to a pinned tab. Tabs can be in the pinned region as part of a pinned group.

TLDR all pinned items must appear before all unpinned items. 

This PR **also** fixes a bug with tab groups. If the first/last tab in a group was repositioned with the "move tab up/down" action in the tab menu, it could be removed from the group and cause it to split. This is now not possible. Tabs can only be repositioned within their group unless explicitly removed from group or dragged out. 

## How it works 

All of the changes are to the existing tab grouping functions. Rather than explaining any logic, I will explain the product behavior below. This is quite dense, happy to go over sync:

Updated several tab/group operations so that new tabs/groups land after the pinned region, when applicable:

- New tab placement: creating a new tab ensures the tab lands after the pinned region, unless it is part of a group 
- Creating new tab groups: new tab groups are now inserted after the pinned region, instead of the beginning of the tab list
- Move to group: moving one or multiple tabs to a group remove the individual pin state on all of those tabs
- Remove from group: removing one or multiple tabs from a group cause them to land after the pinned region, if that group was pinned (rather than just after the group)
- Group from selection: creating a group from one or more tabs unpins any selected tab(s) and positions the group where the first selected tab originally was (if this was within the pinned region, it is moved to after the pinned region)
- Ungrouping: when a group is pinned and ungrouped, all the members are moved to after the pinned region
- Reorder gating: created new helper function's `can_move_tab()` and `can_move_tab_group()` to gate the move tab up/down options in the tab menus (same for groups). This ensures that tabs/groups can not be moved into the pinned region, and can not be moved out of the tab lists bounds. Additionally, it prevents tabs from being moved out of a group, which fixes the bug described above.


Added a few new helpers that are used throughout this PR, probably helpful to scan:
- `pinned_boundary_index()`: used to find the boundary between pinned and unpinned items, for deciding where certain items should land
- `clamp_to_unpinned_region(index)`: pushes an index to the beginning of the unpinned region/after the pinned region, if the index param is within the pinned region. Used whenever we want something to land at 'index' but it can not land within the pinned region
- `index_after_group(group_id)`: determines the index directly after the last tab in a group. Used for appending to groups and placing items directly after a group. 


## Linked Issue

https://linear.app/warpdotdev/issue/APP-4721/modify-existing-tab-and-group-functionality-to-respect-pinning

and 

https://linear.app/warpdotdev/issue/APP-4729/fix-bug-with-move-tabs-option

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo of bug](https://www.loom.com/share/3042f8f022464a888f59ca45df601a47)

[Demo of fix](https://www.loom.com/share/e205d80c65ae414bab713d4017b6951f)

- the demo is just showing that the 'move up' option is not available for the first tab, and the 'move down' option is not available for the last tab

[Demo of grouping behavior with pinning](https://www.loom.com/share/1f13a351b8744a7d8b738487f4c632bd)