### PR TITLE
Address review follow-ups for remote bundled skills

### DIFF
--- a/app/src/ai/skills/bundled.rs
+++ b/app/src/ai/skills/bundled.rs
@@ -236,7 +236,9 @@ impl BundledSkill {
                 // the local figma catalog loaded from `mcp_skills/figma`.
                 let icon = match &activation {
                     BundledSkillActivation::RequiresMcp(McpIntegration::Figma) => Icon::Figma,
-                    BundledSkillActivation::Always | BundledSkillActivation::RequiresFile(_) => {
+                    BundledSkillActivation::Always
+                    | BundledSkillActivation::RequiresFeature(_)
+                    | BundledSkillActivation::RequiresFile(_) => {
                         icon_for_bundled_skill(&id)
                     }
                 };

--- a/app/src/ai/skills/bundled.rs
+++ b/app/src/ai/skills/bundled.rs
@@ -238,9 +238,7 @@ impl BundledSkill {
                     BundledSkillActivation::RequiresMcp(McpIntegration::Figma) => Icon::Figma,
                     BundledSkillActivation::Always
                     | BundledSkillActivation::RequiresFeature(_)
-                    | BundledSkillActivation::RequiresFile(_) => {
-                        icon_for_bundled_skill(&id)
-                    }
+                    | BundledSkillActivation::RequiresFile(_) => icon_for_bundled_skill(&id),
                 };
                 (
                     id,

--- a/app/src/ai/skills/bundled.rs
+++ b/app/src/ai/skills/bundled.rs
@@ -9,6 +9,7 @@ use warp_core::ui::icons::Icon;
 use warp_core::{report_error, safe_warn};
 use warp_util::host_id::HostId;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warp_util::remote_path::RemotePath;
 use warpui::{AppContext, SingletonEntity};
 
 use super::SkillDescriptor;
@@ -79,28 +80,22 @@ impl BundledSkills {
     /// addressed by path (their paths are real files on the remote host),
     /// unlike local bundled skills which are addressed by
     /// [`SkillReference::BundledSkillId`].
-    pub fn remote_skill_by_path(&self, path: &LocalOrRemotePath) -> Option<&ParsedSkill> {
-        let LocalOrRemotePath::Remote(remote_path) = path else {
-            return None;
-        };
+    pub fn remote_skill_by_path(&self, path: &RemotePath) -> Option<&ParsedSkill> {
         self.remote_by_host
-            .get(&remote_path.host_id)?
-            .skill_by_path(path)
+            .get(&path.host_id)?
+            .skill_by_path(&LocalOrRemotePath::Remote(path.clone()))
     }
 
     /// Like [`Self::remote_skill_by_path`], but only returns the skill when
     /// its activation condition is met.
     pub fn remote_active_skill_by_path(
         &self,
-        path: &LocalOrRemotePath,
+        path: &RemotePath,
         ctx: &AppContext,
     ) -> Option<&ParsedSkill> {
-        let LocalOrRemotePath::Remote(remote_path) = path else {
-            return None;
-        };
         self.remote_by_host
-            .get(&remote_path.host_id)?
-            .active_skill_by_path(path, ctx)
+            .get(&path.host_id)?
+            .active_skill_by_path(&LocalOrRemotePath::Remote(path.clone()), ctx)
     }
 
     #[cfg(test)]
@@ -163,6 +158,27 @@ impl BundledSkill {
             .collect()
     }
 
+    /// Returns descriptors for bundled skills whose activation conditions are
+    /// met, referenced by their `SKILL.md` paths instead of
+    /// [`SkillReference::BundledSkillId`].
+    ///
+    /// Used for remote-host catalogs: a `BundledSkillId` reference resolves
+    /// against the local catalog, so descriptors listed from a remote catalog
+    /// must carry the skill's real remote path — which resolves back to this
+    /// catalog through the path lookups — or invoking a listed skill would
+    /// serve the local client's content.
+    pub fn active_path_referenced_descriptors(&self, ctx: &AppContext) -> Vec<SkillDescriptor> {
+        self.definitions
+            .values()
+            .filter(|definition| definition.activation.is_enabled(ctx))
+            .map(|definition| {
+                let mut descriptor = SkillDescriptor::from(definition.skill.clone());
+                descriptor.icon_override = Some(definition.icon);
+                descriptor
+            })
+            .collect()
+    }
+
     /// Returns a bundled skill reference when the path belongs to a bundled skill.
     pub fn reference_for_path(&self, path: &LocalOrRemotePath) -> Option<SkillReference> {
         self.definitions
@@ -216,7 +232,14 @@ impl BundledSkill {
         let definitions = definitions
             .into_iter()
             .map(|(id, skill, activation)| {
-                let icon = icon_for_bundled_skill(&id);
+                // MCP-gated skills carry their integration's brand icon, like
+                // the local figma catalog loaded from `mcp_skills/figma`.
+                let icon = match &activation {
+                    BundledSkillActivation::RequiresMcp(McpIntegration::Figma) => Icon::Figma,
+                    BundledSkillActivation::Always | BundledSkillActivation::RequiresFile(_) => {
+                        icon_for_bundled_skill(&id)
+                    }
+                };
                 (
                     id,
                     BundledSkillDefinition {
@@ -306,6 +329,12 @@ async fn load_figma_skill_definitions(
 /// Read bundled skill definitions from the specified directory, rendering
 /// handlebars variables against this host's filesystem (`resources_dir` is
 /// the resources root the skills belong to).
+///
+/// Only ever runs against the calling process's own filesystem: the local
+/// app reads its bundled resources, and the remote daemon reads its global
+/// install location before pushing the rendered content over the wire.
+/// Clients never call this for files on another host, so local `Path`
+/// semantics (this OS's encoding) are correct here.
 pub(crate) async fn read_bundled_skills(
     skills_dir: &Path,
     resources_dir: &Path,

--- a/app/src/ai/skills/remote.rs
+++ b/app/src/ai/skills/remote.rs
@@ -143,9 +143,10 @@ fn bundled_skill_from_protos(host_id: &HostId, skills: &[BundledSkillProto]) -> 
 ///
 /// `RequiresFile` activations are evaluated here — the daemon owns the
 /// files — so the client only ever receives `Always` or `RequiresMcp`
-/// conditions.
+/// conditions. The result is sorted by skill ID so pushes are
+/// deterministic across daemon restarts.
 pub(crate) fn bundled_skills_snapshot_protos(catalog: &BundledSkill) -> Vec<BundledSkillProto> {
-    catalog
+    let mut protos: Vec<BundledSkillProto> = catalog
         .iter_definitions()
         .filter_map(|(id, skill, activation)| {
             let requires_mcp = match activation {
@@ -175,7 +176,9 @@ pub(crate) fn bundled_skills_snapshot_protos(catalog: &BundledSkill) -> Vec<Bund
                 requires_mcp,
             })
         })
-        .collect()
+        .collect();
+    protos.sort_by(|a, b| a.id.cmp(&b.id));
+    protos
 }
 
 #[cfg(test)]

--- a/app/src/ai/skills/skill_manager.rs
+++ b/app/src/ai/skills/skill_manager.rs
@@ -167,16 +167,19 @@ impl SkillManager {
         // Append bundled skills whose activation condition is met, from the
         // catalog of the host that owns the working directory: SSH sessions
         // see the remote daemon's catalog (empty until its snapshot arrives),
-        // never the local client's.
+        // never the local client's. Remote catalog descriptors are referenced
+        // by their remote paths so invocation resolves back to the same
+        // host's catalog; `BundledSkillId` references are local-only.
         if FeatureFlag::BundledSkills.is_enabled() {
-            let bundled = match working_directory {
+            match working_directory {
                 Some(LocalOrRemotePath::Remote(remote)) => {
-                    self.bundled_skills.remote(&remote.host_id)
+                    if let Some(bundled) = self.bundled_skills.remote(&remote.host_id) {
+                        skills.extend(bundled.active_path_referenced_descriptors(ctx));
+                    }
                 }
-                Some(LocalOrRemotePath::Local(_)) | None => Some(self.bundled_skills.local()),
-            };
-            if let Some(bundled) = bundled {
-                skills.extend(bundled.active_descriptors(ctx));
+                Some(LocalOrRemotePath::Local(_)) | None => {
+                    skills.extend(self.bundled_skills.local().active_descriptors(ctx));
+                }
             }
         }
 
@@ -305,9 +308,11 @@ impl SkillManager {
         skill_path: &P,
     ) -> Option<&ParsedSkill> {
         let location = skill_path.to_skill_location();
-        self.skills_by_path
-            .get(&location)
-            .or_else(|| self.bundled_skills.remote_skill_by_path(&location))
+        self.skills_by_path.get(&location).or_else(|| {
+            location
+                .as_remote()
+                .and_then(|remote| self.bundled_skills.remote_skill_by_path(remote))
+        })
     }
 
     /// Returns the appropriate `SkillReference` for a skill at the given path.
@@ -328,10 +333,10 @@ impl SkillManager {
     /// Get the definition of a skill, if it is cached.
     pub fn skill_by_reference(&self, reference: &SkillReference) -> Option<&ParsedSkill> {
         match reference {
-            SkillReference::Path(path) => self
-                .skills_by_path
-                .get(path)
-                .or_else(|| self.bundled_skills.remote_skill_by_path(path)),
+            SkillReference::Path(path) => self.skills_by_path.get(path).or_else(|| {
+                path.as_remote()
+                    .and_then(|remote| self.bundled_skills.remote_skill_by_path(remote))
+            }),
             SkillReference::BundledSkillId(id) => self.bundled_skills.local().skill(id),
         }
     }
@@ -348,10 +353,10 @@ impl SkillManager {
         ctx: &AppContext,
     ) -> Option<&ParsedSkill> {
         match reference {
-            SkillReference::Path(path) => self
-                .skills_by_path
-                .get(path)
-                .or_else(|| self.bundled_skills.remote_active_skill_by_path(path, ctx)),
+            SkillReference::Path(path) => self.skills_by_path.get(path).or_else(|| {
+                path.as_remote()
+                    .and_then(|remote| self.bundled_skills.remote_active_skill_by_path(remote, ctx))
+            }),
             SkillReference::BundledSkillId(id) => self.active_bundled_skill(id, ctx),
         }
     }

--- a/app/src/ai/skills/skill_manager_tests.rs
+++ b/app/src/ai/skills/skill_manager_tests.rs
@@ -714,6 +714,10 @@ fn get_skills_for_working_directory_respects_location() {
             remote_bundled_descriptor.reference,
             SkillReference::Path(remote_bundled_path.clone())
         );
+        // Path-referenced remote bundled descriptors keep their bundled scope:
+        // filters that hide non-invokable bundled skills (e.g. the `/open-skill`
+        // selector) key off the scope, not the reference variant.
+        assert_eq!(remote_bundled_descriptor.scope, SkillScope::Bundled);
         let resolved_content = handle.read(&app, |manager, ctx| {
             manager
                 .active_skill_by_reference(&remote_bundled_descriptor.reference, ctx)

--- a/app/src/ai/skills/skill_manager_tests.rs
+++ b/app/src/ai/skills/skill_manager_tests.rs
@@ -641,6 +641,8 @@ fn get_skills_for_working_directory_respects_location() {
         scope: SkillScope::Bundled,
     };
 
+    let remote_bundled_path = remote_bundled_skill.path.clone();
+
     let mut directory_skills = HashMap::new();
     let mut skills_by_path = HashMap::new();
     for (dir, skill) in [
@@ -700,6 +702,25 @@ fn get_skills_for_working_directory_respects_location() {
         assert!(!remote_names.contains("local-project"));
         assert!(!remote_names.contains("other-host-project"));
 
+        // Remote catalog descriptors are path-referenced, and that reference
+        // resolves back to the remote host's catalog entry. A
+        // `BundledSkillId` reference would resolve against the local catalog
+        // and serve the wrong content.
+        let remote_bundled_descriptor = remote_skills
+            .iter()
+            .find(|skill| skill.name == "remote-bundled")
+            .unwrap();
+        assert_eq!(
+            remote_bundled_descriptor.reference,
+            SkillReference::Path(remote_bundled_path.clone())
+        );
+        let resolved_content = handle.read(&app, |manager, ctx| {
+            manager
+                .active_skill_by_reference(&remote_bundled_descriptor.reference, ctx)
+                .map(|skill| skill.content.clone())
+        });
+        assert_eq!(resolved_content, Some("# remote-bundled".to_string()));
+
         let disconnected_remote_skills = handle.read(&app, |manager, ctx| {
             manager.get_skills_for_working_directory(None, ctx)
         });
@@ -722,6 +743,16 @@ fn get_skills_for_working_directory_respects_location() {
         assert!(!local_names.contains("remote-bundled"));
         assert!(!local_names.contains("same-host-project"));
         assert!(!local_names.contains("other-host-project"));
+
+        // Local catalog descriptors keep their ID-based references.
+        let local_bundled_descriptor = local_skills
+            .iter()
+            .find(|skill| skill.name == "bundled")
+            .unwrap();
+        assert_eq!(
+            local_bundled_descriptor.reference,
+            SkillReference::BundledSkillId("bundled".to_string())
+        );
 
         handle.update(&mut app, |manager, _| {
             manager.is_cloud_environment = true;

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -255,6 +255,12 @@ pub struct ServerModel {
     /// `BundledSkillsSnapshot` push. `None` until startup parsing completes
     /// (or forever, when the global resources directory is absent).
     bundled_skills: Option<Vec<BundledSkillProto>>,
+    /// Connections that have already received the `BundledSkillsSnapshot`
+    /// push, either from the parse-completion broadcast or during their
+    /// `Initialize` handshake. Prevents a duplicate push when parsing
+    /// completes between a connection registering its sender and its
+    /// `Initialize` being handled.
+    bundled_skills_sent: HashSet<ConnectionId>,
     /// Per-session command executors created from `SessionBootstrapped` notifications.
     executors: HashMap<SessionId, Arc<LocalCommandExecutor>>,
     /// Tracks in-flight file write/delete operations and handles cleanup.
@@ -312,6 +318,7 @@ impl ServerModel {
             in_progress: HashMap::new(),
             host_id,
             bundled_skills: None,
+            bundled_skills_sent: HashSet::new(),
             executors: HashMap::new(),
             pending_file_ops: PendingFileOps::new(),
             auth_state: AuthStateProvider::as_ref(ctx).get().clone(),
@@ -692,6 +699,27 @@ impl ServerModel {
             None,
             server_message::Message::BundledSkillsSnapshot(BundledSkillsSnapshot { skills }),
         );
+        self.bundled_skills_sent
+            .extend(self.connection_senders.keys().copied());
+    }
+
+    /// Pushes the parsed bundled skill catalog to a single connection.
+    /// No-op until startup parsing has completed, or when the catalog was
+    /// already delivered to this connection (e.g. it registered before the
+    /// parse-completion broadcast fired).
+    fn send_bundled_skills_snapshot_to_connection(&mut self, conn_id: ConnectionId) {
+        if self.bundled_skills_sent.contains(&conn_id) {
+            return;
+        }
+        let Some(skills) = self.bundled_skills.clone() else {
+            return;
+        };
+        self.send_server_message(
+            Some(conn_id),
+            None,
+            server_message::Message::BundledSkillsSnapshot(BundledSkillsSnapshot { skills }),
+        );
+        self.bundled_skills_sent.insert(conn_id);
     }
 
     /// Called when a proxy connects.  Inserts `conn_tx` into the connection
@@ -721,6 +749,7 @@ impl ServerModel {
     /// and starts the grace timer if no connections remain.
     pub fn deregister_connection(&mut self, conn_id: ConnectionId, ctx: &mut ModelContext<Self>) {
         self.snapshot_sent_roots_by_connection.remove(&conn_id);
+        self.bundled_skills_sent.remove(&conn_id);
         // Guard against double-deregister (reader and writer tasks both call
         // this on connection close; the second call must be a safe no-op).
         if self.connection_senders.remove(&conn_id).is_none() {
@@ -1562,15 +1591,12 @@ impl ServerModel {
         }
 
         // Push the bundled skill catalog to this connection if it is already
-        // parsed. Enqueued on the same channel as the response below, so the
-        // client buffers it as a push event during the handshake.
-        if let Some(skills) = self.bundled_skills.clone() {
-            self.send_server_message(
-                Some(conn_id),
-                None,
-                server_message::Message::BundledSkillsSnapshot(BundledSkillsSnapshot { skills }),
-            );
-        }
+        // parsed and the parse-completion broadcast didn't already deliver it
+        // (parsing can complete between this connection registering its
+        // sender and its `Initialize` being handled). Enqueued on the same
+        // channel as the response below, so the client buffers it as a push
+        // event during the handshake.
+        self.send_bundled_skills_snapshot_to_connection(conn_id);
 
         let server_version = ChannelState::app_version().unwrap_or("").to_string();
         HandlerOutcome::Sync(server_message::Message::InitializeResponse(

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use warp_util::standardized_path::StandardizedPath;
@@ -24,6 +24,7 @@ fn test_model(app: &mut App) -> ServerModel {
         in_progress: HashMap::new(),
         host_id: "test-host-id".to_string(),
         bundled_skills: None,
+        bundled_skills_sent: HashSet::new(),
         executors: HashMap::new(),
         pending_file_ops: PendingFileOps::new(),
         auth_state: Arc::new(AuthState::new_logged_out_for_test()),
@@ -91,6 +92,52 @@ fn bundled_skills_broadcast_reaches_all_connections() {
                 other => panic!("expected BundledSkillsSnapshot, got {other:?}"),
             }
         }
+    });
+}
+
+/// A connection can register its sender before its `Initialize` is handled.
+/// When parsing completes in that window, the parse-completion broadcast
+/// delivers the catalog; the `Initialize` push must not deliver it again.
+#[test]
+fn initialize_after_broadcast_does_not_resend_bundled_skills() {
+    App::test((), |mut app| async move {
+        let mut model = test_model(&mut app);
+        let conn = uuid::Uuid::new_v4();
+        let (tx, rx) = async_channel::unbounded();
+        model.connection_senders.insert(conn, tx);
+
+        // Initialize handled before parsing completes: nothing to send.
+        model.send_bundled_skills_snapshot_to_connection(conn);
+        assert!(rx.try_recv().is_err());
+
+        // Parsing completes and the broadcast reaches the registered connection.
+        model.bundled_skills = Some(vec![test_bundled_skill_proto("test-skill")]);
+        model.broadcast_bundled_skills_snapshot();
+        assert!(matches!(
+            rx.try_recv().map(|msg| msg.message),
+            Ok(Some(server_message::Message::BundledSkillsSnapshot(_)))
+        ));
+
+        // The connection's Initialize is handled after the broadcast: the
+        // catalog must not be delivered a second time.
+        model.send_bundled_skills_snapshot_to_connection(conn);
+        assert!(
+            rx.try_recv().is_err(),
+            "snapshot must not be re-sent to a connection that already received the broadcast"
+        );
+
+        // A connection that initializes after the broadcast still receives
+        // the catalog exactly once.
+        let late_conn = uuid::Uuid::new_v4();
+        let (late_tx, late_rx) = async_channel::unbounded();
+        model.connection_senders.insert(late_conn, late_tx);
+        model.send_bundled_skills_snapshot_to_connection(late_conn);
+        assert!(matches!(
+            late_rx.try_recv().map(|msg| msg.message),
+            Ok(Some(server_message::Message::BundledSkillsSnapshot(_)))
+        ));
+        model.send_bundled_skills_snapshot_to_connection(late_conn);
+        assert!(late_rx.try_recv().is_err());
     });
 }
 

--- a/app/src/terminal/input/skills/data_source.rs
+++ b/app/src/terminal/input/skills/data_source.rs
@@ -124,6 +124,9 @@ impl SyncDataSource for SkillSelectorDataSource {
         let skills = SkillManager::as_ref(app).get_skills_for_working_directory(cwd.as_ref(), app);
 
         // Filter out bundled skills when in open mode, since they cannot be opened.
+        // Bundled skills are identified by scope rather than reference: local
+        // catalog entries are `BundledSkillId`-referenced, but remote catalog
+        // entries are path-referenced, and both must be excluded here.
         // When CLI agent input is open, filter to skills that exist in a supported
         // provider folder. We check all paths for the skill name (not just the
         // deduplicated provider) because deduplication may pick a higher-priority
@@ -135,8 +138,7 @@ impl SyncDataSource for SkillSelectorDataSource {
                 if let Some(providers) = &cli_agent_providers {
                     skill_manager.skill_exists_for_any_provider(skill, providers)
                 } else {
-                    self.include_bundled
-                        || !matches!(skill.reference, SkillReference::BundledSkillId(_))
+                    self.include_bundled || skill.scope != SkillScope::Bundled
                 }
             })
             .map(|mut skill| {

--- a/crates/warp_util/src/local_or_remote_path.rs
+++ b/crates/warp_util/src/local_or_remote_path.rs
@@ -101,6 +101,16 @@ impl LocalOrRemotePath {
         }
     }
 
+    /// Returns the remote path if this is a `Remote` location, `None` for `Local`.
+    /// Callers that only work with remote files should use this to gate their
+    /// behavior.
+    pub fn as_remote(&self) -> Option<&RemotePath> {
+        match self {
+            LocalOrRemotePath::Local(_) => None,
+            LocalOrRemotePath::Remote(remote) => Some(remote),
+        }
+    }
+
     /// Joins a (typically repo-relative) segment onto this location, preserving
     /// the host.
     ///


### PR DESCRIPTION
## Description

Follow-ups to #12378 (remote bundled skills), addressing post-merge review comments plus a correctness fix for remote catalog skill references.

**Review comment fixes:**
- `BundledSkills::remote_skill_by_path` / `remote_active_skill_by_path` now take `&RemotePath` instead of `&LocalOrRemotePath`, making the remote-only contract a compile-time guarantee. Adds `LocalOrRemotePath::as_remote()` (mirroring `to_local_path()`) for callers to gate explicitly.
- Clarified the `read_bundled_skills` doc: it only ever runs against the calling process's own filesystem (the local app reads its bundled resources; the remote daemon reads its global install before pushing rendered content over the wire), so local `Path` semantics are correct.
- Fixed a double-send race for the `BundledSkillsSnapshot` push: parsing could complete between a connection registering its sender and its `Initialize` being handled, delivering the catalog twice (once via the parse-completion broadcast, once via the handshake push). The daemon now tracks per-connection delivery in `bundled_skills_sent`.

**Additional follow-ups:**
- Remote catalog descriptors are now referenced by their remote `SKILL.md` paths instead of `BundledSkillId`, so invoking a listed remote skill resolves against the owning host's catalog rather than serving the local client's content.
- Remote MCP-gated skills carry their integration's brand icon (e.g. Figma), matching the local catalog.
- Snapshot protos are sorted by skill ID for deterministic pushes.

## Linked Issue
Follow-up to #12378.

## Testing
- New regression test `initialize_after_broadcast_does_not_resend_bundled_skills` covering the register → broadcast → initialize ordering.
- New assertions in `get_skills_for_working_directory_respects_location` verifying remote descriptors are path-referenced and resolve to the remote catalog's content, while local descriptors keep ID references.
- `cargo nextest run -p warp -p warp_util` for the skills/server-model/path suites: 130 passed.
- `./script/format` and `cargo clippy -p warp -p warp_util --all-targets --all-features -- -D warnings` pass.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Warp conversation](https://staging.warp.dev/conversation/efa6970c-76ef-433b-8844-28c495fb8fc2)

Co-Authored-By: Oz <oz-agent@warp.dev>

<!--
CHANGELOG-NONE
-->
