### PR TITLE
late async search results added to the mixer last

### DIFF
--- a/crates/warp_search_core/src/mixer.rs
+++ b/crates/warp_search_core/src/mixer.rs
@@ -205,7 +205,7 @@ impl<T: Action + Clone> SearchMixer<T> {
     ///
     /// Old results remain visible while new results are buffered. The visible result set is
     /// replaced atomically once all sources finish, or after [`INITIAL_RESULTS_TIMEOUT`] elapses.
-    /// Late-arriving async results are appended without reordering existing results.
+    /// Late-arriving async results are placed at the low-priority edge without reordering existing results.
     pub fn run_query(&mut self, query: Query, ctx: &mut ModelContext<Self>) {
         self.pending_results = Some(Vec::new());
         self.finished_sources.clear();
@@ -422,8 +422,10 @@ impl<T: Action + Clone> SearchMixer<T> {
                 } else if self.initial_results_emitted {
                     let mut late_results = results_with_order;
                     late_results.sort_by_key(|r| (r.priority_tier(), r.score(), r.source_order));
+                    let mut existing_results = std::mem::take(&mut self.results);
+                    self.results = late_results;
+                    self.results.append(&mut existing_results);
 
-                    self.results.extend(late_results);
                     ctx.emit(SearchMixerEvent::ResultsChanged);
                 } else {
                     self.results.extend(results_with_order);
@@ -446,7 +448,8 @@ impl<T: Action + Clone> SearchMixer<T> {
     }
 
     /// Commits buffered results from the current query, replacing the visible result set.
-    /// After this, any late-arriving results are added directly to `results`.
+    /// After this, any late-arriving results are added directly to the low-priority edge of
+    /// `results`.
     fn commit_pending_results(&mut self, ctx: &mut ModelContext<Self>) {
         let Some(pending) = self.pending_results.take() else {
             return;

--- a/crates/warp_search_core/src/mixer_tests.rs
+++ b/crates/warp_search_core/src/mixer_tests.rs
@@ -276,7 +276,7 @@ fn test_initial_results_timeout_and_appends_late_async_results_without_reorderin
                     result: TestSearchItem {
                         id: "late_async".to_string(),
                         priority_tier: 0,
-                        score: 0.0,
+                        score: 100.0,
                     },
                 },
                 [QueryFilter::Actions],
@@ -328,8 +328,8 @@ fn test_initial_results_timeout_and_appends_late_async_results_without_reorderin
             );
         });
 
-        // When the async source finishes later, its results are appended to the end without
-        // reordering the already-visible sync results.
+        // When the async source finishes later, its results are placed at the low-priority edge
+        // without reordering the already-visible sync results.
         Timer::after(Duration::from_millis(200)).await;
 
         app.read(|app| {
@@ -341,7 +341,7 @@ fn test_initial_results_timeout_and_appends_late_async_results_without_reorderin
                     .iter()
                     .map(|result| result.accept_result().id)
                     .collect::<Vec<_>>(),
-                vec!["sync", "late_async"]
+                vec!["late_async", "sync"]
             );
         });
     });


### PR DESCRIPTION
## Description

This PR fixes an issue where command search (ctrl-r in the terminal input) usually doesn't show *any* command history items. Here is the scenario:

https://www.loom.com/share/e40d832305d542d8b93eba152072237c

To summarize the video, searching a command the appears a lot in my history, e.g. `oz-dev`, should turn up a lot of history items in the results. Instead, I only see notebooks.

<img width="1219" height="750" alt="Screenshot 2026-06-12 at 1 24 49 PM" src="https://github.com/user-attachments/assets/29107cf2-805b-4322-8da4-12887ec51b87" />


I've traced this back to the behavior added in #warpdotdev/warp-internal#22987 which AFAICT is not working as intended. The intention is that "late" async results are appended to the *end* in order to avoid a re-shuffle of the results.

I have confirmed that the notebooks are returning "late" (after the timeout) in the video. However, they are actually added to the beginning, not the end as intended. You can see it in this trimmed recording. The correct results flicker very quickly and then get replaced by the notebooks


https://github.com/user-attachments/assets/3f744e63-f251-47f6-b42d-7438d44b8f1c

The problem is that the mixer results is stored in *ascending* order (highest score last). This is true whether the results are top-down or bottom-up (a separate field controls that). Underlying ordering is ascending. This means that appending to the end is actually showing the late items *first*, i.e. as the highest scoring items. This results in a total replacement of the results.

I have fixed this by prepending (inserting at the lowest-scoring edge) instead of appending late results.

## Linked Issue

Fixes #11787

## Testing

### After

<img width="1024" height="626" alt="Screenshot 2026-06-12 at 5 12 09 PM" src="https://github.com/user-attachments/assets/12694164-b269-4fb4-a383-fdda706a9645" />


<!--
## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Command search in the terminal (ctrl-r) now prioritizes commands in your history.
-->
