### PR TITLE
Render local orchestration subagents with the local agent icon (APP-4726)

### DIFF
--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -1030,6 +1030,17 @@ impl TerminalView {
             })
     }
 
+    /// Whether the selected conversation is a local orchestration child: it was spawned by a
+    /// parent orchestrator and is not executing on a remote worker. These runs are backed by a
+    /// server task (so they carry an ambient task id) but execute locally, so their agent icon
+    /// must use the local treatment rather than the cloud/ambient one.
+    pub(crate) fn selected_conversation_is_local_child(&self, ctx: &AppContext) -> bool {
+        self.selected_conversation_for_user_facing_chrome(ctx)
+            .is_some_and(|conversation| {
+                conversation.is_child_agent_conversation() && !conversation.is_remote_child()
+            })
+    }
+
     /// Server metadata for the selected conversation, if any.
     pub fn selected_conversation_server_metadata<'a>(
         &'a self,

--- a/app/src/ui_components/agent_icon.rs
+++ b/app/src/ui_components/agent_icon.rs
@@ -50,6 +50,10 @@ pub(crate) fn terminal_view_agent_icon_variant(
     let task_data = ambient_task_id
         .and_then(|task_id| AgentConversationsModel::as_ref(app).get_task_data(&task_id));
 
+    // Local orchestration children are dispatched as server tasks (so they carry an ambient
+    // task id) but execute on the user's machine, so they must not get the cloud treatment.
+    let is_local_child = terminal_view.selected_conversation_is_local_child(app);
+
     // Defer to the card helper when we have task data and no CLI session takes precedence.
     if cli_agent_session.is_none() {
         if let Some(task) = task_data.as_ref() {
@@ -60,11 +64,12 @@ pub(crate) fn terminal_view_agent_icon_variant(
                 .and_then(|config| config.harness.as_ref())
                 .map(|harness| harness.harness_type)
                 .unwrap_or(Harness::Oz);
-            return Some(agent_icon_variant_for_run(harness, status, true));
+            return Some(agent_icon_variant_for_run(harness, status, !is_local_child));
         }
     }
 
-    let is_ambient = terminal_view.is_ambient_agent_session(app) || ambient_task_id.is_some();
+    let is_ambient = terminal_view.is_ambient_agent_session(app)
+        || (ambient_task_id.is_some() && !is_local_child);
     let inputs = TerminalIconInputs {
         is_ambient,
         cli_session: cli_agent_session.map(|session| CLISessionInputs {


### PR DESCRIPTION
## Description
Local orchestration subagents rendered the **cloud** agent icon in the pane header / vertical tab, making a local subagent look like a cloud (Oz) run (see APP-4726).

The icon shape is driven by an `is_ambient` flag computed in `terminal_view_agent_icon_variant` (`app/src/ui_components/agent_icon.rs`). When a conversation resolves to a server agent task, the helper hardcoded `is_ambient = true` (and the fallback waterfall OR'd `ambient_task_id.is_some()`). Local orchestration children are dispatched as server agent tasks too (they appear in the Oz `/runs` list), so they resolved to task data and were incorrectly treated as ambient → cloud treatment (`OzCloud` glyph + lavender ambient background + `CloudFilled` lobe).

This change excludes **local children** — conversations that have a parent agent but are not remote children — from the ambient flag, so they render the plain local Oz icon. This mirrors how the orchestration pill bar already distinguishes local vs cloud children via `AIConversation::is_remote_child()`.

Remote/cloud children and genuine cloud runs are unaffected (still `is_ambient = true`).

## Linked Issue
APP-4726 — Wrong icon rendered for local orchestration subagents (shows cloud-agent icon)

## Testing
Here's a demo! https://www.loom.com/share/a99f57af6b944cc2a0dd88871b908756

- `cargo nextest run -p warp agent_icon` — all 6 cross-surface icon tests pass.
- `cargo check -p warp --lib`, `./script/format`, and `cargo clippy -p warp --lib` all clean.
- Attempted an end-to-end computer-use repro against staging: launched the dev build, started an agent, and triggered `run_agents` for a **Local** child. The local child spawn was blocked by the sandbox environment (403 Forbidden), so a fully-running subagent couldn't be reproduced here; the local subagent UI rendered with local-style (non-cloud) avatars. Manual verification of the running-subagent state is still recommended.

- [X] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Local orchestration subagents now render the local agent icon instead of the Oz cloud icon.
-->

_Conversation: https://staging.warp.dev/conversation/4bb70e8d-3338-467d-9046-fef2a10b96ee_

_Run: https://oz.staging.warp.dev/runs/019ec0f3-9d93-777c-93db-76b480df4110_

_This PR was generated with [Oz](https://warp.dev/oz)._
