### PR TITLE
Bump mermaid_to_svg dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3853,7 +3853,7 @@ dependencies = [
 [[package]]
 name = "dagre_rust"
 version = "0.0.5"
-source = "git+https://github.com/warpdotdev/mermaid-to-svg.git?rev=40cecf2be376e47e15053eadbfb782a531777420#40cecf2be376e47e15053eadbfb782a531777420"
+source = "git+https://github.com/warpdotdev/mermaid-to-svg.git?rev=79aecc74187c29a027e85e18d070ff0dd884a0a7#79aecc74187c29a027e85e18d070ff0dd884a0a7"
 dependencies = [
  "graphlib_rust",
  "ordered_hashmap",
@@ -8029,7 +8029,7 @@ dependencies = [
 [[package]]
 name = "mermaid_to_svg"
 version = "0.1.0"
-source = "git+https://github.com/warpdotdev/mermaid-to-svg.git?rev=40cecf2be376e47e15053eadbfb782a531777420#40cecf2be376e47e15053eadbfb782a531777420"
+source = "git+https://github.com/warpdotdev/mermaid-to-svg.git?rev=79aecc74187c29a027e85e18d070ff0dd884a0a7#79aecc74187c29a027e85e18d070ff0dd884a0a7"
 dependencies = [
  "dagre_rust",
  "graphlib_rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ lazy_static = "1.4.0"
 libc = "0.2.81"
 line-ending = "1.4.0"
 log = { version = "0.4", features = ["serde", "std"] }
-mermaid_to_svg = { git = "https://github.com/warpdotdev/mermaid-to-svg.git", rev = "40cecf2be376e47e15053eadbfb782a531777420" }
+mermaid_to_svg = { git = "https://github.com/warpdotdev/mermaid-to-svg.git", rev = "79aecc74187c29a027e85e18d070ff0dd884a0a7" }
 mime_guess = "2.0"
 minimp4 = "0.1.2"
 nix = { version = "0.26.4", default-features = false, features = ["signal"] }


### PR DESCRIPTION
## Description

Updates the `mermaid_to_svg` git dependency to the latest upstream revision and refreshes `Cargo.lock` for both `mermaid_to_svg` and its vendored `dagre_rust` dependency.

Agent context: https://staging.warp.dev/conversation/1a263a26-8fac-46d2-848d-e25ba9d183b8

## Linked Issue

N/A

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `cargo metadata --no-deps --format-version 1 --manifest-path /Users/zach/Projects/warp/Cargo.toml`
- `/Users/zach/Projects/warp/script/format`
- `cargo clippy --workspace --all-targets --all-features --tests --manifest-path /Users/zach/Projects/warp/Cargo.toml -- -D warnings`

No new tests were added because this only updates a pinned dependency revision and lockfile source entries.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
