### PR TITLE
Fix duplicated prefix in rendered multiline command blocks

### DIFF
--- a/app/src/terminal/model/block_tests.rs
+++ b/app/src/terminal/model/block_tests.rs
@@ -1296,6 +1296,109 @@ fn test_clone_command_from_blockgrid_to_empty() {
     assert_eq!(new_content, "clone1\nclone2\nclone3");
 }
 
+#[test]
+fn test_multiline_preexec_reconciles_command_grid_redraw_prefix() {
+    let cases = [
+        (
+            "ececho \"line one\" && \\\r\necho \"line two\"",
+            "echo \"line one\" && \\\necho \"line two\"",
+        ),
+        ("aasdf\r\nasdf", "asdf\nasdf"),
+    ];
+
+    for (command_grid_text, reported_command) in cases {
+        let prompt_and_command_grid = mock_blockgrid(command_grid_text);
+        let mut rprompt_grid = mock_blockgrid("");
+        rprompt_grid.finish();
+        let mut output_grid = mock_blockgrid("");
+        output_grid.finish();
+
+        let mut block = create_test_block_with_grids(
+            BlockIndex::zero(),
+            prompt_and_command_grid,
+            rprompt_grid,
+            output_grid,
+            false, /* honor_ps1 */
+        );
+        block.set_honor_ps1(false);
+
+        block.preexec(PreexecValue {
+            command: reported_command.to_owned(),
+            session_id: None,
+        });
+
+        assert_eq!(block.command_to_string(), reported_command);
+        assert_eq!(
+            block.prompt_and_command_with_secrets_unobfuscated(false),
+            reported_command
+        );
+    }
+}
+
+#[test]
+fn test_multiline_preexec_reconciliation_preserves_prompt_demarcation() {
+    let prompt = "warp> ";
+    let reported_command = "echo \"line one\" && \\\necho \"line two\"";
+    let mut block = TestBlockBuilder::new().with_honor_ps1(true).build();
+    block.prompt_marker(ansi::PromptMarker::StartPrompt {
+        kind: ansi::PromptKind::Initial,
+    });
+    for c in prompt.chars() {
+        block.input(c);
+    }
+    block.prompt_marker(ansi::PromptMarker::EndPrompt);
+    block.start();
+    for c in "ececho \"line one\" && \\".chars() {
+        block.input(c);
+    }
+    block.carriage_return();
+    block.linefeed();
+    for c in "echo \"line two\"".chars() {
+        block.input(c);
+    }
+
+    block.preexec(PreexecValue {
+        command: reported_command.to_owned(),
+        session_id: None,
+    });
+
+    assert_eq!(block.command_to_string(), reported_command);
+    assert_eq!(
+        block.prompt_and_command_with_secrets_unobfuscated(false),
+        format!("{prompt}{reported_command}")
+    );
+}
+
+#[test]
+fn test_multiline_preexec_preserves_legitimate_repeated_command_prefix() {
+    let reported_command = "aasdf\nasdf";
+    let prompt_and_command_grid = mock_blockgrid("aasdf\r\nasdf");
+    let mut rprompt_grid = mock_blockgrid("");
+    rprompt_grid.finish();
+    let mut output_grid = mock_blockgrid("");
+    output_grid.finish();
+
+    let mut block = create_test_block_with_grids(
+        BlockIndex::zero(),
+        prompt_and_command_grid,
+        rprompt_grid,
+        output_grid,
+        false, /* honor_ps1 */
+    );
+    block.set_honor_ps1(false);
+
+    block.preexec(PreexecValue {
+        command: reported_command.to_owned(),
+        session_id: None,
+    });
+
+    assert_eq!(block.command_to_string(), reported_command);
+    assert_eq!(
+        block.prompt_and_command_with_secrets_unobfuscated(false),
+        reported_command
+    );
+}
+
 /// Tests is_command_empty for an empty command with the combined grid.
 #[test]
 fn test_command_is_empty_combined_grid() {

--- a/app/src/terminal/model/header_grid.rs
+++ b/app/src/terminal/model/header_grid.rs
@@ -656,6 +656,101 @@ impl HeaderGrid {
         }
     }
 
+    fn has_leading_prefix_redraw_artifact(command_grid_text: &str, preexec_command: &str) -> bool {
+        if preexec_command.is_empty()
+            || command_grid_text == preexec_command
+            || command_grid_text.len() <= preexec_command.len()
+        {
+            return false;
+        }
+
+        let Some(extra_prefix) = command_grid_text.strip_suffix(preexec_command) else {
+            return false;
+        };
+
+        !extra_prefix.is_empty() && preexec_command.starts_with(extra_prefix)
+    }
+
+    fn prompt_text_for_preexec_reconciliation(&self, include_escape_sequences: bool) -> String {
+        if !self.honor_ps1 {
+            return String::new();
+        }
+
+        self.prompt_to_string_internal(
+            include_escape_sequences,
+            RespectObfuscatedSecrets::No,
+            false, /* force_obfuscated_secrets */
+        )
+    }
+
+    fn should_reconcile_command_grid_with_preexec_command(&self, preexec_command: &str) -> bool {
+        let command_grid_text = self.command_with_secrets_unobfuscated(false);
+        if Self::has_leading_prefix_redraw_artifact(&command_grid_text, preexec_command) {
+            return true;
+        }
+
+        let prompt = self.prompt_text_for_preexec_reconciliation(false);
+        let combined = self.prompt_and_command_with_secrets_unobfuscated(false);
+        let Some(rendered_after_prompt) = combined.strip_prefix(&prompt) else {
+            return false;
+        };
+
+        Self::has_leading_prefix_redraw_artifact(rendered_after_prompt, preexec_command)
+    }
+
+    fn reconcile_command_grid_with_preexec_command(&mut self, preexec_command: &str) {
+        if !self.should_reconcile_command_grid_with_preexec_command(preexec_command) {
+            return;
+        }
+
+        let prompt = self.prompt_text_for_preexec_reconciliation(true);
+
+        self.prompt_and_command_grid.reset_state();
+        self.prompt_and_command_grid.start();
+        self.cached_prompt_end_point = None;
+        self.cached_command_start_point = None;
+
+        let mut processor = Processor::new();
+        Self::parse_logical_text_into_command_grid(
+            &mut self.prompt_and_command_grid,
+            &mut processor,
+            &prompt,
+        );
+        self.mark_and_cache_end_of_prompt();
+
+        self.prompt_and_command_grid.terminal_attribute(Attr::Bold);
+        Self::parse_logical_text_into_command_grid(
+            &mut self.prompt_and_command_grid,
+            &mut processor,
+            preexec_command,
+        );
+    }
+
+    fn parse_logical_text_into_command_grid(
+        grid: &mut BlockGrid,
+        processor: &mut Processor,
+        text: impl AsRef<str>,
+    ) {
+        let mut lines = text.as_ref().split('\n');
+        if let Some(line) = lines.next() {
+            processor.parse_bytes(
+                grid,
+                line.strip_suffix('\r').unwrap_or(line).as_bytes(),
+                &mut io::sink(),
+            );
+        }
+
+        for line in lines {
+            grid.carriage_return();
+            grid.linefeed();
+            processor.parse_bytes(
+                grid,
+                line.strip_suffix('\r').unwrap_or(line).as_bytes(),
+                &mut io::sink(),
+            );
+        }
+    }
+
     pub fn is_command_finished(&self) -> bool {
         self.prompt_and_command_grid.finished()
     }
@@ -1208,7 +1303,13 @@ impl ansi::Handler for HeaderGrid {
         }
     }
 
-    fn preexec(&mut self, _data: PreexecValue) {
+    fn preexec(&mut self, data: PreexecValue) {
+        // The command grid is built from the shell's line-editor echo stream before preexec.
+        // Some shells redraw a short command prefix before echoing the full multiline command.
+        // Finish the grid first so the full multiline text is inspectable, then use preexec's
+        // canonical command only when the grid is provably that command with a redrawn prefix.
+        self.finish_command_grid();
+        self.reconcile_command_grid_with_preexec_command(&data.command);
         self.finish_command_grid();
     }
 


### PR DESCRIPTION
## Description

Fixes a terminal model rendering bug where completed multiline command blocks can show duplicated leading characters, such as `eecho ...`, `ccurl ...`, `mmkdir ...`, or `pprintf ...`, even though the shell receives and executes the correct command.

## Problem

When a user runs a multiline command, Warp sometimes shows extra characters at the start of the command in the completed block. The command itself still runs correctly, but the saved block can look wrong. For example, a command that should display as `echo ...` can appear as `eecho ...`, or `curl ...` can appear as `ccurl ...`.

That is confusing because the visual command history no longer matches what the user actually ran. It is especially risky for agent workflows, where the agent may read the completed block and treat the extra characters as if they were part of the command.

The duplicate characters are not coming from the bytes Warp sends to the shell. They come from the shell's line editor/redraw output while Warp is building the command grid for the completed block.

## Solution

Use the command reported by `preexec` as the source of truth for what the shell is about to execute, but only after the command grid has been finalized and only when the grid clearly contains a redraw artifact.

In practice, this means Warp now checks for one narrow shape: the finished command grid must look like a short duplicated prefix followed by the exact `preexec` command. If that shape is present, Warp rebuilds the prompt and command grid using the existing prompt boundary and the canonical `preexec` command.

The fix does not implement a cosmetic "drop first characters" rule. Commands that legitimately start with repeated characters, such as `asdf\nasdf`, are preserved.

## Linked Issue

Closes #5024.

Related evidence:

- #11282 reports phantom characters at the start of agent-run multiline commands.
- #4069 reports bogus leading characters for displayed multiline commands.

- [x] The linked issue is labeled `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

## Implementation Notes

- Finish the command grid at `preexec` before inspecting it, so multiline command text is fully available.
- Detect only the narrow redraw-artifact shape: finished command-grid text must be longer than the `preexec` command, must end with the exact `preexec` command, and the extra leading text must be a prefix of that same command.
- Rebuild the prompt and command grid from the existing prompt demarcation plus the canonical `preexec` command when that narrow condition holds.
- Preserve prompt/command boundaries and avoid changing shell input bytes.

## Testing

Automated:

- [x] `cargo test --manifest-path Cargo.toml -p warp multiline_preexec -- --nocapture`
- [x] `cargo nextest run --manifest-path Cargo.toml --no-fail-fast -p warp -E 'test(multiline)'`
- [x] `./script/format`
- [x] `./script/check_no_inline_test_modules`
- [x] `cargo clippy --manifest-path Cargo.toml -p warp --tests -- -D warnings`

New regression coverage:

- `test_multiline_preexec_reconciles_command_grid_redraw_prefix`
- `test_multiline_preexec_reconciliation_preserves_prompt_demarcation`
- `test_multiline_preexec_preserves_legitimate_repeated_command_prefix`

Manual repro cases:

1. Basic multiline echo:

```sh
echo "line one" && \
echo "line two"
```

Expected: the completed block renders `echo "line one" ...`, not `eecho ...` or `ececho ...`.

BEFORE 
<img width="880" height="573" alt="11" src="https://github.com/user-attachments/assets/5f08b66e-903c-48de-a392-5bb13eab94cb" />

AFTER
<img width="823" height="579" alt="1" src="https://github.com/user-attachments/assets/67bca702-6387-4859-b8de-0de8a1702ea9" />


2. Valid repeated-prefix guard:

```sh
asdf
asdf
```

Expected: the command may fail with `command not found`, which is fine. The completed block should still render the command exactly as entered and should not remove the leading `a`.

BEFORE
<img width="880" height="573" alt="12" src="https://github.com/user-attachments/assets/b2873c67-7cb3-4b12-a980-5611b8538f62" />

AFTER
<img width="823" height="579" alt="2" src="https://github.com/user-attachments/assets/49a92f5e-71ba-4a47-9519-a118d736deda" />


3. Curl-style multiline command from related reports:

```sh
curl \
'https://example.com'
```

Expected: the completed block renders `curl ...`, not `ccurl ...`.

BEFORE
<img width="880" height="573" alt="13" src="https://github.com/user-attachments/assets/22fa30a6-6a9d-436d-b9a5-956ac8391914" />

AFTER
<img width="823" height="579" alt="3" src="https://github.com/user-attachments/assets/1a5b500e-3ba2-46d6-bea4-2a00788b0c6d" />


4. Zip/deploy-style multiline command:

```sh
mkdir -p /tmp/warp-multiline-repro && \
printf "hello from warp\n" > /tmp/warp-multiline-repro/index.txt && \
cd /tmp/warp-multiline-repro && \
zip -r repro.zip index.txt && \
ls -lh repro.zip
```

Expected: the completed block starts with `mkdir`, with no duplicated or phantom prefix.

BEFORE
<img width="880" height="573" alt="14" src="https://github.com/user-attachments/assets/ad81cfd0-b873-492b-931c-037d515573cd" />

AFTER
<img width="823" height="579" alt="4" src="https://github.com/user-attachments/assets/5340ec28-c9d8-43e8-9b93-250191f45823" />


5. Longer pipeline:

```sh
printf "alpha\nbeta\ngamma\n" | \
grep "beta" | \
awk '{ print "matched:", $0 }'
```

Expected: the completed block starts with `printf`, with no extra leading characters.

BEFORE
<img width="880" height="573" alt="15" src="https://github.com/user-attachments/assets/158e403e-403d-4cba-9313-c0fe891e5c7f" />


AFTER 
<img width="823" height="579" alt="5" src="https://github.com/user-attachments/assets/7f04a15a-d4e0-4091-877e-ee4f9fa7397b" />


### Screenshots / Videos

Full `./script/presubmit` was attempted locally. It failed only on SSH/GCloud integration tests (`test_ssh_into_ash`, `test_ssh_into_sh`, `test_ssh_wrapper_into_bash`, `test_ssh_wrapper_into_zsh`, `test_ssh_with_shell_override`) because this machine does not have an active GCloud account/access to Warp's `warp-ssh-integration-testing` project.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed duplicated leading characters in rendered multi-line command blocks.
