### PR TITLE
[client] Fix LRC transfer handback resume flow

### DIFF
--- a/app/src/ai/blocklist/action_model/execute/shell_command.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command.rs
@@ -431,10 +431,6 @@ impl ShellCommandExecutor {
                         match transfer_result {
                             TransferControlResult::ControlHandedBack
                             | TransferControlResult::BlockFinished => {
-                                let is_preempted = matches!(
-                                    transfer_result,
-                                    TransferControlResult::ControlHandedBack
-                                );
                                 match model.block_list().block_with_id(&block_id) {
                                     Some(block) => {
                                         if block.finished() {
@@ -464,7 +460,7 @@ impl ShellCommandExecutor {
                                                 grid_contents,
                                                 cursor: CURSOR_MARKER,
                                                 is_alt_screen_active: model.is_alt_screen_active(),
-                                                is_preempted,
+                                                is_preempted: false,
                                             }
                                         }
                                     }

--- a/app/src/ai/blocklist/action_model/execute/shell_command.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command.rs
@@ -431,6 +431,10 @@ impl ShellCommandExecutor {
                         match transfer_result {
                             TransferControlResult::ControlHandedBack
                             | TransferControlResult::BlockFinished => {
+                                let is_preempted = matches!(
+                                    transfer_result,
+                                    TransferControlResult::ControlHandedBack
+                                );
                                 match model.block_list().block_with_id(&block_id) {
                                     Some(block) => {
                                         if block.finished() {
@@ -460,7 +464,7 @@ impl ShellCommandExecutor {
                                                 grid_contents,
                                                 cursor: CURSOR_MARKER,
                                                 is_alt_screen_active: model.is_alt_screen_active(),
-                                                is_preempted: false,
+                                                is_preempted,
                                             }
                                         }
                                     }

--- a/app/src/ai/blocklist/block/cli_controller.rs
+++ b/app/src/ai/blocklist/block/cli_controller.rs
@@ -406,28 +406,30 @@ impl CLISubagentController {
         }
 
         // Trigger an auto-resume of the conversation when handing control to the agent.
-        if let Some(conversation_id) = conversation_id {
-            let is_viewing_shared_session = BlocklistAIHistoryModel::as_ref(ctx)
-                .conversation(&conversation_id)
-                .is_some_and(|conversation| conversation.is_viewing_shared_session());
-            if !is_viewing_shared_session {
-                let resume_context = {
-                    let terminal_model = self.terminal_model.lock();
-                    block_context_from_terminal_model(&terminal_model, &block_id, false)
-                        .map(Box::new)
-                        .map(AIAgentContext::Block)
-                        .into_iter()
-                        .collect()
-                };
-                self.controller.update(ctx, |controller, ctx| {
-                    controller.resume_conversation(
-                        conversation_id,
-                        /*can_attempt_resume_on_error*/ true,
-                        /*is_auto_resume_after_error*/ false,
-                        resume_context,
-                        ctx,
-                    );
-                });
+        if !was_transfer_from_agent {
+            if let Some(conversation_id) = conversation_id {
+                let is_viewing_shared_session = BlocklistAIHistoryModel::as_ref(ctx)
+                    .conversation(&conversation_id)
+                    .is_some_and(|conversation| conversation.is_viewing_shared_session());
+                if !is_viewing_shared_session {
+                    let resume_context = {
+                        let terminal_model = self.terminal_model.lock();
+                        block_context_from_terminal_model(&terminal_model, &block_id, false)
+                            .map(Box::new)
+                            .map(AIAgentContext::Block)
+                            .into_iter()
+                            .collect()
+                    };
+                    self.controller.update(ctx, |controller, ctx| {
+                        controller.resume_conversation(
+                            conversation_id,
+                            /*can_attempt_resume_on_error*/ true,
+                            /*is_auto_resume_after_error*/ false,
+                            resume_context,
+                            ctx,
+                        );
+                    });
+                }
             }
         }
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -10778,9 +10778,9 @@ impl TerminalView {
                         && ai_metadata
                             .long_running_control_state()
                             .is_some_and(|state| {
-                                state
-                                    .user_take_over_reason()
-                                    .is_some_and(|reason| !reason.is_stop())
+                                state.user_take_over_reason().is_some_and(|reason| {
+                                    !reason.is_stop() && !reason.is_transfer_from_agent()
+                                })
                             }) =>
                 {
                     Some(*ai_metadata.conversation_id())

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -19,7 +19,8 @@ use super::*;
 use crate::ai::agent::conversation::{AIConversation, ConversationStatus};
 use crate::ai::agent::task::TaskId;
 use crate::ai::agent::{
-    AIAgentExchange, AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus, UserQueryMode,
+    AIAgentActionId, AIAgentExchange, AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus,
+    UserQueryMode,
 };
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::agent_view::toolbar_item::AgentToolbarItemKind;
@@ -5291,6 +5292,84 @@ fn inline_agent_view_persists_across_transfer_takeover_for_monitored_long_runnin
             assert!(view.is_input_box_visible(&model, ctx));
         });
     })
+}
+
+#[test]
+fn completed_agent_requested_command_auto_resume_skips_transfer_takeover() {
+    fn assert_resume_exchange_count(reason: UserTakeOverReason, expected_count: usize) {
+        App::test((), move |mut app| async move {
+            initialize_app_for_terminal_view(&mut app);
+
+            let terminal = add_window_with_terminal(&mut app, None);
+
+            terminal.update(&mut app, |view, ctx| {
+                let (conversation_id, task_id) =
+                    BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
+                        let conversation_id = history_model.start_new_conversation(
+                            view.view_id,
+                            false,
+                            false,
+                            false,
+                            ctx,
+                        );
+                        let task_id = history_model
+                            .conversation(&conversation_id)
+                            .expect("conversation should exist")
+                            .get_root_task_id()
+                            .clone();
+                        (conversation_id, task_id)
+                    });
+
+                let block_id = {
+                    let mut model = view.model.lock();
+                    model.init_shell(InitShellValue {
+                        session_id: 0.into(),
+                        shell: "zsh".to_owned(),
+                        ..Default::default()
+                    });
+                    model.bootstrapped(BootstrappedValue {
+                        shell: "zsh".to_owned(),
+                        ..Default::default()
+                    });
+                    model.simulate_long_running_block("ssh localhost", "Password:");
+
+                    let active_block = model.block_list_mut().active_block_mut();
+                    active_block.set_agent_interaction_mode_for_requested_command(
+                        AIAgentActionId::from("test-action".to_owned()),
+                        Some(task_id.clone()),
+                        conversation_id,
+                    );
+                    active_block
+                        .set_agent_interaction_mode_for_agent_monitored_command(
+                            &task_id,
+                            conversation_id,
+                        )
+                        .expect("requested command should transition to agent-monitored");
+                    active_block.id().clone()
+                };
+
+                view.cli_subagent_controller.update(ctx, |controller, ctx| {
+                    controller.switch_control_to_user(reason, ctx);
+                });
+
+                view.on_user_block_completed(&block_id, ctx);
+
+                let exchange_count = BlocklistAIHistoryModel::as_ref(ctx)
+                    .conversation(&conversation_id)
+                    .expect("conversation should exist")
+                    .exchange_count();
+                assert_eq!(exchange_count, expected_count);
+            });
+        });
+    }
+
+    assert_resume_exchange_count(UserTakeOverReason::Manual, 1);
+    assert_resume_exchange_count(
+        UserTakeOverReason::TransferFromAgent {
+            reason: "Enter your password".to_owned(),
+        },
+        0,
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description
Avoid emitting a generic `ResumeConversation` for agent-initiated transfer-control handbacks. The client now relies on the `TransferShellCommandControlToUser` tool result for both explicit handback and command-completion-after-transfer paths, while preserving the existing resume behavior for manual/non-transfer user takeovers.

Plan: https://staging.warp.dev/drive/notebook/3QQR0dUeW6wI0r7QvUXFzn
Conversation: https://staging.warp.dev/conversation/707a6938-98bb-4caf-a4b3-d0f75df6c797

## Linked Issue
No linked issue.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `./script/format --check`
- [x] `./script/check_no_inline_test_modules`
- [x] `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- [x] `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- [x] `./script/run-clang-format.py -r --extensions 'c,h,cpp,m' ./crates/warpui/src/ ./app/src/`
- [x] `find . -name "*.wgsl" -exec wgslfmt --check {} +`
- [x] `cargo test -p warp completed_agent_requested_command_auto_resume_skips_transfer_takeover --lib`
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A — protocol/control-flow fix covered by focused regression test.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed local Agent sometimes resuming twice after long-running command control is handed back.

Co-Authored-By: Oz <oz-agent@warp.dev>