### PR TITLE
Show "Continue locally" button for in-progress cloud Oz runs

### DIFF
--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -748,14 +748,8 @@ impl ConversationDetailsPanel {
                 Some(*ai_conversation_id.as_ref()?)
             }
             PanelMode::Task {
-                display_status,
-                conversation_id,
-                ..
+                conversation_id, ..
             } => {
-                let status = display_status.as_ref()?;
-                if status.is_working() {
-                    return None;
-                }
                 // Hide for non-Oz harnesses (e.g. Claude, Gemini): they can't be
                 // forked into a local Warp conversation.
                 if matches!(self.data.harness, Some(h) if h != Harness::Oz) {


### PR DESCRIPTION
## Description

Show the "Continue locally" button in the side panel for in-progress cloud Oz runs, not just completed ones.

Previously the button was hidden whenever `display_status.is_working()` returned true (Queued/Pending/Claimed/InProgress/ConversationInProgress). This was inconsistent with `/continue-locally`, which has no status gate and calls the same underlying `fork_ai_conversation` path.

The only real prerequisite for the fork to work is a resolvable local `AIConversationId` (looked up via `BlocklistAIHistoryModel::find_conversation_id_by_server_token`). The `is_working()` check was an independent, redundant gate on top of that. Removing it makes the button available for any Oz task — in-progress or finished — as long as the client has a locally-tracked conversation.

Non-Oz harness guard (Claude Code, Gemini, Codex, etc.) is kept since those can't be forked locally.

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [X] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Quick demo/explainer here! https://www.loom.com/share/6567567370704ad188d0e331360a0c51

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-OZ: "Continue locally" button in the side panel now appears for in-progress cloud Oz runs, not just completed ones.
-->

_Conversation: https://staging.warp.dev/conversation/584a799d-44a4-4b06-abe7-05903da3894c_
_Run: https://oz.staging.warp.dev/runs/019ec6e1-589b-7c18-931a-5d2769359c44_
_This PR was generated with [Oz](https://warp.dev/oz)._
