### PR TITLE
feat(ai): Display token count in agent usage footer

### DIFF
--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -97,7 +97,7 @@ use crate::ai::blocklist::inline_action::web_search::WebSearchView;
 use crate::ai::blocklist::keyboard_navigable_buttons::KeyboardNavigableButtons;
 use crate::ai::blocklist::secret_redaction::SecretRedactionState;
 use crate::ai::blocklist::usage::rollup::compute_orchestration_rollup;
-use crate::ai::blocklist::view_util::format_credits;
+use crate::ai::blocklist::view_util::{format_credits, format_token_count};
 use crate::ai::blocklist::{AIBlockResponseRating, BlocklistAIActionModel, SuggestionChipView};
 use crate::ai::paths::shell_native_absolute_path;
 use crate::ai::skills::{
@@ -3334,6 +3334,15 @@ fn render_usage_button(props: Props, app: &AppContext) -> Box<dyn Element> {
                     format!("{credit_usage_text} (+{credits_spent_for_last_block:.1})");
             }
         }
+    }
+
+    let total_tokens: u64 = conversation
+        .token_usage()
+        .iter()
+        .map(|u| u64::from(u.warp_tokens + u.byok_tokens + u.custom_endpoint_tokens))
+        .sum();
+    if total_tokens > 0 {
+        credit_usage_text = format!("{credit_usage_text} · {}", format_token_count(total_tokens));
     }
 
     let icon_size = icon_size(app);

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -21,7 +21,7 @@ use crate::ai::blocklist::usage::render_context_window_usage_icon;
 use crate::ai::blocklist::usage::rollup::{
     compute_orchestration_rollup, AgentAvatar, OrchestrationCreditRollup, PerAgentCreditEntry,
 };
-use crate::ai::blocklist::view_util::format_credits;
+use crate::ai::blocklist::view_util::{format_credits, format_token_count};
 use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::appearance::Appearance;
 use crate::persistence::model::{
@@ -343,6 +343,20 @@ impl ConversationUsageView {
             format_value_text(self.usage_info.tool_calls, "call"),
             appearance,
         ));
+
+        let total_tokens: u64 = self
+            .usage_info
+            .models
+            .iter()
+            .map(|u| u64::from(u.warp_tokens + u.byok_tokens + u.custom_endpoint_tokens))
+            .sum();
+        if total_tokens > 0 {
+            labels.push(render_label_text("Tokens", appearance));
+            values.push(render_value_text(
+                format_token_count(total_tokens),
+                appearance,
+            ));
+        }
 
         let entries_by_category = self.collect_models_by_category();
         let mut categories: Vec<_> = entries_by_category.keys().cloned().collect();

--- a/app/src/ai/blocklist/view_util.rs
+++ b/app/src/ai/blocklist/view_util.rs
@@ -1,4 +1,8 @@
 //! This module contains common utilities for rendering Blocklist AI UI.
+
+#[cfg(test)]
+#[path = "view_util_tests.rs"]
+mod tests;
 use std::sync::LazyLock;
 
 use pathfinder_color::ColorU;
@@ -137,6 +141,11 @@ pub fn get_attached_blocks_chip_element_position_id(view_id: EntityId) -> String
 /// Returns the saved position ID of the overflow menu inside the [`AIBlock`] header.
 pub fn get_ai_block_overflow_menu_element_position_id(view_id: EntityId) -> String {
     format!("aiblock:{view_id}.overflow_menu_position")
+}
+
+/// Formats a token count for display, e.g. 1247 becomes "1247 tok".
+pub fn format_token_count(tokens: u64) -> String {
+    format!("{tokens} tok")
 }
 
 /// Formats credit count to display as whole numbers when the value is effectively a whole number,

--- a/app/src/ai/blocklist/view_util_tests.rs
+++ b/app/src/ai/blocklist/view_util_tests.rs
@@ -1,0 +1,21 @@
+use super::format_token_count;
+
+#[test]
+fn test_format_token_count_zero() {
+    assert_eq!(format_token_count(0), "0 tok");
+}
+
+#[test]
+fn test_format_token_count_small() {
+    assert_eq!(format_token_count(42), "42 tok");
+}
+
+#[test]
+fn test_format_token_count_thousands() {
+    assert_eq!(format_token_count(1247), "1247 tok");
+}
+
+#[test]
+fn test_format_token_count_large() {
+    assert_eq!(format_token_count(1_000_000), "1000000 tok");
+}


### PR DESCRIPTION
## Description

Closes #12627

Adds token usage display to the AI agent conversation footer. Previously, the usage button only showed credits spent. Now it also shows the total token count for the conversation, both in the compact usage pill and in the expanded usage details panel.

**Before:**
```
3.5 credits ›
```

**After (compact pill):**
```
3.5 credits · 1247 tok ›
```

**After (expanded details panel):**
```
USAGE SUMMARY
Credits spent (total)   3.5 credits
Tool calls              2 calls
Tokens                  1247 tok     ← new
Models                  claude-...
Context window used     12%
```

## Linked Issue

- [x] Linked to #12627

## Changes

- `app/src/ai/blocklist/view_util.rs` — added `format_token_count()` utility function
- `app/src/ai/blocklist/block/view_impl/output.rs` — appends token count to the compact usage pill
- `app/src/ai/blocklist/usage/conversation_usage_view.rs` — adds a "Tokens" row in the expanded usage details panel
- `app/src/ai/blocklist/view_util_tests.rs` — unit tests for `format_token_count`

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

<!-- CHANGELOG-IMPROVEMENT: Token count is now shown alongside credits in the AI agent usage footer. -->