### PR TITLE
fix: avoid Bash 5.3 segfault when indexing executables on large PATHs

### DIFF
--- a/crates/warp_terminal/src/shell/mod.rs
+++ b/crates/warp_terminal/src/shell/mod.rs
@@ -608,10 +608,10 @@ impl ShellType {
                 // doesn't include any info about what the type of the word is), we filter down to
                 // executable "file"s. Note that we do this at the shell level since if we did this
                 // as a post-process step, it would require N filesystem calls, which would not scale
-                // well for remote sessions. Additionally, we invoke `type` once, passing it the full
-                // list of commands, to avoid a lot of overhead invoking it thousands of times for
-                // systems with a lot of installed commands.
-                r#"COMMANDS=($(compgen -c)); TYPES=($(type -t ${COMMANDS[@]})); for i in "${!COMMANDS[@]}"; do if [[ ${TYPES[$i]} == "file" ]]; then echo ${COMMANDS[$i]}; fi; done"#
+                // well for remote sessions. We stream the commands through a dedupe step and check
+                // each command individually so Bash 5.3 does not need to expand a large PATH into a
+                // single bulk `type -t ${COMMANDS[@]}` call, which can segfault.
+                r#"seen=$'\n'; compgen -c | while IFS= read -r cmd; do if [[ $seen != *$'\n'"$cmd"$'\n'* ]]; then seen+="$cmd"$'\n'; if [[ $(type -t "$cmd") == "file" ]]; then printf '%s\n' "$cmd"; fi; fi; done"#
             }
             ShellType::Fish => {
                 // Although `complete -C` returns more than just executables, we don't check the type here

--- a/crates/warp_terminal/src/shell/mod_tests.rs
+++ b/crates/warp_terminal/src/shell/mod_tests.rs
@@ -165,6 +165,29 @@ fn test_from_markdown_language_spec() {
 }
 
 #[test]
+fn test_shell_command_to_get_executables_avoids_bash_bulk_type_expansion() {
+    let bash_command = ShellType::Bash.shell_command_to_get_executables();
+
+    assert!(!bash_command.contains("type -t ${COMMANDS[@]}"));
+    assert!(bash_command.contains(r#"type -t "$cmd""#));
+    assert!(bash_command.contains("compgen -c | while IFS= read -r cmd"));
+    assert!(bash_command.contains("seen+="));
+
+    assert_eq!(
+        ShellType::Zsh.shell_command_to_get_executables(),
+        "builtin print -l -- ${(ok)commands}",
+    );
+    assert_eq!(
+        ShellType::Fish.shell_command_to_get_executables(),
+        "complete -C --escape '' || complete -C ''",
+    );
+    assert_eq!(
+        ShellType::PowerShell.shell_command_to_get_executables(),
+        r#"$names = Get-Command -CommandType Application | Select-Object -ExpandProperty Name; $text = [string]::Join([Environment]::NewLine, $names); $bytes = [System.Text.UTF8Encoding]::new($false).GetBytes($text); [Console]::OpenStandardOutput().Write($bytes, 0, $bytes.Length)"#,
+    );
+}
+
+#[test]
 fn test_fish_parse_abbrs() {
     let raw_abbrs = "abbr -a -U -- gco 'git checkout'
 abbr -a -g -- gq 'git commit'


### PR DESCRIPTION
## Description

On Bash 5.3, Warp's background "index executables" command segfaults (SIGSEGV) when the user has a very large `$PATH` (~9,000+ entries, many duplicated through the `/bin` -> `/usr/bin` symlink). The crash prevented command completion from being indexed on affected machines.

The Bash branch of `shell_command_to_get_executables` collected every name from `compgen -c` into a `COMMANDS` array and then expanded the entire array into a single `type -t ${COMMANDS[@]}` call. On Bash 5.3 that one bulk invocation with a massive argument list is what segfaults.

This change rewrites only the Bash branch so it no longer builds an unbounded array or runs a single bulk `type -t`. It instead streams `compgen -c` through a `while read` loop, dedupes names using an in-shell `seen` string, and calls `type -t "$cmd"` per command, emitting only entries whose type is `file`. The output contract is unchanged (one executable name per line) and the command stays `--norc`-safe using only Bash builtins (`compgen`, `type`, `read`, `[[`, `printf`). Because the loop runs entirely inside the single remote shell invocation, it adds no extra round trips for remote sessions. The Zsh, Fish, and PowerShell branches are untouched.

## Linked Issue

Fixes #12533

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- Added a regression unit test in `crates/warp_terminal/src/shell/mod_tests.rs` asserting the Bash command no longer contains the bulk `type -t ${COMMANDS[@]}` expansion, that it uses a per-command `type -t "$cmd"` test plus a dedupe step, and that the Zsh, Fish, and PowerShell command strings are unchanged.
- Verified the new command is valid under `bash --norc -n` (syntax) and, at runtime under `bash --norc`, that it: dedupes a command name that appears in two `$PATH` directories down to a single line, still emits real file executables (for example `ls`), and excludes shell builtins (for example `cd`). The deduped output matches the previous command's `sort -u` output (identical command set).

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed a crash when indexing executables on Bash 5.3 with a very large PATH.
