### PR TITLE
Remove stale PR automation and update contributing guidelines

### DIFF
--- a/app/src/code/editor/comment_editor.rs
+++ b/app/src/code/editor/comment_editor.rs
@@ -5,6 +5,7 @@ use pathfinder_geometry::vector::Vector2F;
 use warp_core::ui::appearance::Appearance;
 use warp_core::ui::theme::Fill;
 use warp_editor::render::element::VerticalExpansionBehavior;
+use warp_editor::render::model::RenderState;
 use warpui::elements::{
     Border, ChildView, Clipped, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Flex,
     MainAxisAlignment, MainAxisSize, ParentElement, Radius, Shrinkable, Text,
@@ -21,6 +22,7 @@ use crate::code::editor::comments::{EditorCommentsModel, PendingCommentEvent};
 use crate::code::editor::line::EditorLineLocation;
 use crate::code_review::comments::{CommentId, CommentOrigin};
 use crate::editor::InteractionState;
+use crate::features::FeatureFlag;
 use crate::notebooks::editor::model::NotebooksEditorModel;
 use crate::notebooks::editor::rich_text_styles;
 use crate::notebooks::editor::view::{EditorViewEvent, RichTextEditorConfig, RichTextEditorView};
@@ -34,6 +36,97 @@ use crate::view_components::action_button::{
 
 /// Default width of the comment editor, in pixels.
 pub(crate) const DEFAULT_COMMENT_MAX_WIDTH: f32 = 750.0;
+
+/// Maximum height of the comment editor, in pixels. Past this height the editor scrolls its content
+/// internally instead of growing further.
+pub(crate) const MAX_COMMENT_HEIGHT: f32 = 200.0;
+
+/// Chrome dimensions for the inline comment shell. These values mirror the padding/border used
+/// in [`render_inline_comment_shell`] and are kept as named constants so [`comment_chrome_height`]
+/// stays in sync with the shell's visual layout automatically.
+mod chrome {
+    /// Top padding of the body area inside the comment shell.
+    pub(super) const BODY_TOP_PADDING: f32 = 8.0;
+    /// Bottom padding of the body area inside the comment shell.
+    pub(super) const BODY_BOTTOM_PADDING: f32 = 4.0;
+    /// Vertical padding of the footer row (top + bottom).
+    pub(super) const FOOTER_VERTICAL_PADDING: f32 = 4.0 * 2.0;
+    /// Top border separating body from footer.
+    pub(super) const FOOTER_BORDER: f32 = 1.0;
+    /// Outer container border (top + bottom).
+    pub(super) const OUTER_BORDER: f32 = 1.0 * 2.0;
+
+    /// Fixed vertical chrome excluding the footer button row (which scales with appearance).
+    /// Slightly generous so the reserved inline block is never shorter than the painted shell.
+    pub(super) const STATIC_HEIGHT: f32 = BODY_TOP_PADDING
+        + BODY_BOTTOM_PADDING
+        + FOOTER_VERTICAL_PADDING
+        + FOOTER_BORDER
+        + OUTER_BORDER
+        + 1.0; // extra pixel of tolerance
+}
+
+/// Total vertical chrome around the inner comment editor: the static paddings/borders plus the
+/// footer button row measured at the current appearance, so the reserved inline height tracks
+/// button-height changes (e.g. UI font scaling) instead of assuming the default 24px row.
+pub(crate) fn comment_chrome_height(
+    footer_button: &ViewHandle<ActionButton>,
+    app: &AppContext,
+) -> f32 {
+    chrome::STATIC_HEIGHT + footer_button.as_ref(app).height(app)
+}
+
+pub(crate) fn inline_comment_background(appearance: &Appearance) -> ColorU {
+    blended_colors::neutral_2(appearance.theme())
+}
+
+pub(crate) fn inline_comment_border_color(appearance: &Appearance) -> ColorU {
+    blended_colors::neutral_4(appearance.theme())
+}
+
+pub(crate) fn render_inline_comment_shell(
+    body: Box<dyn Element>,
+    footer_row: Box<dyn Element>,
+    max_height: Option<f32>,
+    footer_horizontal_padding: f32,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    let background = inline_comment_background(appearance);
+    let border_color = inline_comment_border_color(appearance);
+
+    let body = Container::new(Clipped::new(body).finish())
+        .with_padding_bottom(chrome::BODY_BOTTOM_PADDING)
+        .with_padding_top(chrome::BODY_TOP_PADDING)
+        .with_horizontal_padding(12.)
+        .finish();
+    let body = if max_height.is_some() {
+        Shrinkable::new(1., body).finish()
+    } else {
+        body
+    };
+
+    let content = Flex::column()
+        .with_child(body)
+        .with_child(
+            Container::new(footer_row)
+                .with_vertical_padding(chrome::FOOTER_VERTICAL_PADDING / 2.0)
+                .with_horizontal_padding(footer_horizontal_padding)
+                .with_border(Border::top(chrome::FOOTER_BORDER).with_border_fill(border_color))
+                .finish(),
+        )
+        .finish();
+
+    let mut constrained = ConstrainedBox::new(content).with_max_width(DEFAULT_COMMENT_MAX_WIDTH);
+    if let Some(max_height) = max_height {
+        constrained = constrained.with_max_height(max_height);
+    }
+
+    Container::new(constrained.finish())
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
+        .with_background_color(background)
+        .with_border(Border::all(chrome::OUTER_BORDER / 2.0).with_border_fill(border_color))
+        .finish()
+}
 
 #[derive(Debug)]
 pub enum CommentEditorEvent {
@@ -104,46 +197,20 @@ impl CommentEditor {
         me
     }
 
-    #[allow(unused)] // TODO(CODE-1464): use this
-    pub fn new_embedded(
-        ctx: &mut ViewContext<Self>,
-        comment_model: ModelHandle<EditorCommentsModel>,
-        comment_id: Option<CommentId>,
-        line: EditorLineLocation,
-    ) -> Self {
-        let editor = create_editable_comment_markdown_editor(None, ctx);
-
-        ctx.subscribe_to_view(&editor, |me, _, event, ctx| {
-            me.handle_editor_event(event, ctx);
-        });
-
-        ctx.subscribe_to_model(&comment_model, |me, _, event, ctx| {
-            me.handle_comment_model_event(event, ctx);
-        });
-
-        let (save_button, close_button, remove_button) = Self::create_buttons(ctx);
-
-        let show_remove_button = comment_id.is_some();
-
-        let mut me = Self {
-            comment_id,
-            editor,
-            save_button,
-            close_button,
-            remove_button,
-            line: Some(line),
-            show_remove_button,
-            save_button_disabled: true,
-            laid_out_size: RefCell::new(None),
-            is_imported_comment: false,
-        };
-        me.update_save_button_state(ctx);
-        me
-    }
-
     #[cfg_attr(not(feature = "local_fs"), allow(unused))]
     pub fn comment_text(&self, app: &AppContext) -> String {
         self.editor.as_ref(app).model().as_ref(app).markdown(app)
+    }
+
+    /// The render state backing the inner markdown editor. Observing it lets a host re-measure the
+    /// composer's reserved inline height when its content (and therefore laid-out height) changes.
+    pub fn inner_render_state(&self, app: &AppContext) -> ModelHandle<RenderState> {
+        self.editor
+            .as_ref(app)
+            .model()
+            .as_ref(app)
+            .render_state()
+            .clone()
     }
 
     #[cfg_attr(not(feature = "local_fs"), allow(unused))]
@@ -151,7 +218,6 @@ impl CommentEditor {
         self.laid_out_size.borrow().as_ref().cloned()
     }
 
-    #[allow(unused)] // TODO(CODE-1464): use this
     pub fn set_laid_out_size(&self, value: Vector2F) {
         self.laid_out_size.replace(Some(value));
     }
@@ -236,13 +302,30 @@ impl CommentEditor {
                 self.save_comment(ctx);
             }
             EditorViewEvent::EscapePressed => {
-                // Dismiss the comment composer when pressing Escape on an empty draft.
-                if self.editor.as_ref(ctx).model().as_ref(ctx).is_empty(ctx) {
-                    self.reset(ctx);
-                    ctx.emit(CommentEditorEvent::CloseEditor);
-                }
+                self.handle_escape(ctx);
             }
-            _ => {}
+            EditorViewEvent::Focused
+            | EditorViewEvent::Navigate(_)
+            | EditorViewEvent::OpenFile { .. }
+            | EditorViewEvent::RunWorkflow(_)
+            | EditorViewEvent::EditWorkflow(_)
+            | EditorViewEvent::OpenedBlockInsertionMenu(_)
+            | EditorViewEvent::OpenedEmbeddedObjectSearch
+            | EditorViewEvent::OpenedFindBar
+            | EditorViewEvent::InsertedEmbeddedObject(_)
+            | EditorViewEvent::CopiedBlock { .. }
+            | EditorViewEvent::NavigatedCommands
+            | EditorViewEvent::ChangedSelectionMode(_)
+            | EditorViewEvent::TextSelectionChanged => {}
+        }
+    }
+
+    /// Dismiss the composer when Escape is pressed, but only if the draft body is empty.
+    /// A non-empty draft is preserved so Escape doesn't silently discard work.
+    fn handle_escape(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.editor.as_ref(ctx).model().as_ref(ctx).is_empty(ctx) {
+            self.reset(ctx);
+            ctx.emit(CommentEditorEvent::CloseEditor);
         }
     }
 
@@ -252,7 +335,13 @@ impl CommentEditor {
             // The `reset_with_markdown` call below is a band-aid fix.
             editor.reset_with_markdown("", ctx);
         });
+        self.comment_id = None;
         self.line = Some(line.clone());
+        self.show_remove_button = false;
+        self.is_imported_comment = false;
+        self.save_button.update(ctx, |button, ctx| {
+            button.set_label("Comment", ctx);
+        });
         self.update_save_button_state(ctx);
     }
 
@@ -315,7 +404,6 @@ impl CommentEditor {
             comment_text: comment_text.clone(),
             line: self.line.clone(),
         });
-        self.reset(ctx);
         ctx.emit(CommentEditorEvent::CloseEditor);
     }
 
@@ -400,45 +488,22 @@ impl View for CommentEditor {
 
     fn render(&self, ctx: &AppContext) -> Box<dyn Element> {
         let appearance = Appearance::handle(ctx).as_ref(ctx);
-        let theme = appearance.theme();
-        let background = blended_colors::neutral_2(theme);
-        let border_color = blended_colors::neutral_4(theme);
+        let background = inline_comment_background(appearance);
 
         let footer_row = self.render_footer_row(appearance, background);
 
-        Container::new(
-            ConstrainedBox::new(
-                Flex::column()
-                    .with_child(
-                        Shrinkable::new(
-                            1.,
-                            Container::new(
-                                Clipped::new(ChildView::new(&self.editor).finish()).finish(),
-                            )
-                            .with_padding_bottom(4.)
-                            .with_padding_top(8.)
-                            .with_horizontal_padding(12.)
-                            .finish(),
-                        )
-                        .finish(),
-                    )
-                    .with_child(
-                        Container::new(footer_row)
-                            .with_vertical_padding(4.)
-                            .with_horizontal_padding(4.)
-                            .with_border(Border::top(1.).with_border_fill(border_color))
-                            .finish(),
-                    )
-                    .finish(),
-            )
-            .with_max_height(200.)
-            .with_max_width(DEFAULT_COMMENT_MAX_WIDTH)
-            .finish(),
+        let footer_padding = if FeatureFlag::EmbeddedCodeReviewComments.is_enabled() {
+            12.
+        } else {
+            4.
+        };
+        render_inline_comment_shell(
+            ChildView::new(&self.editor).finish(),
+            footer_row,
+            Some(MAX_COMMENT_HEIGHT),
+            footer_padding,
+            appearance,
         )
-        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
-        .with_background_color(background)
-        .with_border(Border::all(1.).with_border_fill(border_color))
-        .finish()
     }
 
     fn on_focus(&mut self, focus_ctx: &FocusContext, ctx: &mut ViewContext<Self>) {

--- a/app/src/code/editor/comments.rs
+++ b/app/src/code/editor/comments.rs
@@ -47,6 +47,7 @@ pub struct EditorReviewComment {
     pub diff_content: LineDiffContent,
     pub comment_content: String,
     pub last_update_time: DateTime<Local>,
+    pub origin: CommentOrigin,
 }
 
 impl EditorReviewComment {
@@ -61,6 +62,7 @@ impl EditorReviewComment {
             diff_content,
             comment_content,
             last_update_time: Local::now(),
+            origin: CommentOrigin::default(),
         }
     }
 
@@ -76,6 +78,7 @@ impl EditorReviewComment {
             diff_content,
             comment_content,
             last_update_time: Local::now(),
+            origin: CommentOrigin::default(),
         }
     }
 }
@@ -91,6 +94,7 @@ impl TryFrom<AttachedReviewComment> for EditorReviewComment {
                 diff_content: content,
                 comment_content: comment.content,
                 last_update_time: comment.last_update_time,
+                origin: comment.origin,
             }),
             _ => Err(()),
         }

--- a/app/src/code/editor/element.rs
+++ b/app/src/code/editor/element.rs
@@ -16,7 +16,8 @@ use warp_editor::editor::EditorView;
 use warp_editor::render::element::lens_element::RichTextElementLens;
 use warp_editor::render::element::{RenderableBlock, RichTextElement, VerticalExpansionBehavior};
 use warp_editor::render::model::{
-    gutter_expansion_button_types, BlockLocation, ExpansionType, LineCount, RenderState,
+    gutter_expansion_button_types, BlockLocation, ExpansionType, LineCount, LineDecoration,
+    RenderLineLocation, RenderState,
 };
 use warpui::elements::new_scrollable::{NewScrollableElement, ScrollableAxis};
 use warpui::elements::{
@@ -50,6 +51,14 @@ fn highlight_element(appearance: &Appearance) -> Box<dyn Element> {
     Container::new(Empty::new().finish())
         .with_border(Border::all(2.).with_border_fill(border_color))
         .finish()
+}
+
+fn should_hide_comment_gutter_icons(
+    has_attached_comment: bool,
+    has_open_comment_box: bool,
+) -> bool {
+    (has_attached_comment || has_open_comment_box)
+        && FeatureFlag::EmbeddedCodeReviewComments.is_enabled()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -410,8 +419,9 @@ pub struct EditorWrapper<V: EditorView> {
     comment_button: Option<CommentButton>,
     // Todo: kc combine all comment related fields into a struct.
     comment_box: Option<CommentBox>,
-    /// Lines with saved comments attached. These lines always have an
-    /// indicator in the gutter element.
+    /// Lines with saved comments attached. These lines have an indicator in the gutter element
+    /// unless embedded inline comments are enabled, in which case the inline card replaces the
+    /// redundant gutter indicator.
     saved_comments: Vec<SavedComment>,
     gutter_element_hover_target: GutterHoverTarget,
     expand_diff_indicator_width_on_hover: bool,
@@ -419,6 +429,27 @@ pub struct EditorWrapper<V: EditorView> {
     find_references_save_position_id: String,
     /// The line where find references card is anchored (if active).
     find_references_anchor: Option<EditorLineLocation>,
+}
+
+/// Returns the content-space bottom of the inline comment block anchored at `line`, if that
+/// anchor line falls within `decoration`'s line range. `None` when the comment doesn't belong
+/// to this decoration. Callers extend the decoration's painted end to cover the block.
+fn inline_comment_decoration_end(
+    decoration: &LineDecoration,
+    line: &EditorLineLocation,
+    model: &RenderState,
+) -> Option<Pixels> {
+    // Only current lines can carry added-line decorations; removed-line comments
+    // are painted via `paint_removed_line_overlays` instead.
+    let EditorLineLocation::Current { line_number, .. } = line else {
+        return None;
+    };
+    if *line_number < decoration.start || *line_number >= decoration.end {
+        return None;
+    }
+    let position =
+        model.comment_block_position(line.clone().into_inline_comment_render_line_location())?;
+    Some(position.start_y_offset + position.content_height)
 }
 
 impl<V: EditorView> EditorWrapper<V> {
@@ -469,14 +500,22 @@ impl<V: EditorView> EditorWrapper<V> {
                 continue;
             }
 
-            let Some(overlay) = element.overlay else {
-                flush(&mut group);
-                continue;
-            };
-
+            // current_range/start_y/end_y are computed before the overlay check because the
+            // None-overlay branch below needs them to extend an existing group.
             let current_range = element.line.line_range().clone();
             let start_y = element.offset.as_f32();
             let end_y = start_y + element.height;
+
+            let Some(overlay) = element.overlay else {
+                if let Some(group) = &mut group {
+                    if group.line_range == current_range {
+                        group.end_y = end_y;
+                        continue;
+                    }
+                }
+                flush(&mut group);
+                continue;
+            };
 
             match &mut group {
                 Some(group) if group.line_range == current_range && group.overlay == overlay => {
@@ -569,6 +608,28 @@ impl<V: EditorView> EditorWrapper<V> {
             .iter()
             .find(|comment| comment.location().is_same_line(line))
             .cloned()
+    }
+
+    /// The [`EditorLineLocation`] for a gutter row at `line_count`, spanning its containing diff
+    /// range on the removed or added side, plus whether that range is currently hovered.
+    fn gutter_line_at(
+        &self,
+        line_count: LineCount,
+        removed_side: bool,
+        hovered_range: Option<&EditorLineLocation>,
+    ) -> (EditorLineLocation, bool) {
+        let diff_range = if removed_side {
+            self.diff_status.removed_diff_range(line_count)
+        } else {
+            self.diff_status.added_diff_range(line_count)
+        };
+        let line = EditorLineLocation::Current {
+            line_number: line_count,
+            line_range: diff_range.unwrap_or(line_count..line_count + 1),
+        };
+        let range_hovered = hovered_range
+            .is_some_and(|hovered_line| hovered_line.line_range() == line.line_range());
+        (line, range_hovered)
     }
 
     fn should_display_relative_line_number(&self) -> bool {
@@ -808,6 +869,59 @@ impl<V: EditorView> EditorWrapper<V> {
 
                 continue;
             }
+            if let Some(embedded_comment_location) = block.embedded_comment_location() {
+                let height = block.viewport_item().content_size.y();
+                let is_removed_comment = matches!(
+                    embedded_comment_location,
+                    RenderLineLocation::Temporary { .. }
+                );
+                let diff_hunk = if is_removed_comment {
+                    match diff_hunk {
+                        Some(DiffHunkDisplay::Replacement { remove_color, .. }) => {
+                            Some(DiffHunkDisplay::Remove(remove_color))
+                        }
+                        diff_hunk => diff_hunk,
+                    }
+                } else {
+                    diff_hunk
+                };
+                let (line, range_hovered) = self.gutter_line_at(
+                    line_count,
+                    is_removed_comment || is_removal,
+                    hovered_range.as_ref(),
+                );
+                let element = self.render_gutter_element(
+                    None,
+                    line_number_config,
+                    false,
+                    false,
+                    false,
+                    None,
+                    height,
+                    height,
+                    &line,
+                    block.overlay_decoration(),
+                    true,
+                    appearance,
+                );
+                elements.push(GutterElement {
+                    element,
+                    height,
+                    offset,
+                    hovered: range_hovered,
+                    line,
+                    element_type: GutterElementType::DiffHunk {
+                        hunk: diff_hunk,
+                        change_type: if is_removed_comment || is_removal {
+                            ChangeType::Remove
+                        } else {
+                            ChangeType::Add
+                        },
+                    },
+                    overlay: block.overlay_decoration(),
+                });
+                continue;
+            }
             let diff_range = self.diff_status.added_diff_range(line_count);
             let range_already_clicked = diff_range
                 .as_ref()
@@ -829,14 +943,8 @@ impl<V: EditorView> EditorWrapper<V> {
             // Check if this line is part of any diff hunk when diff hunks are expanded and hovered
             let is_diff_line = self.diff_hunks_are_expanded() && diff_hunk.is_some();
 
-            let line = EditorLineLocation::Current {
-                line_number: line_count,
-                line_range: diff_range.unwrap_or(line_count..line_count + 1),
-            };
-
-            let range_hovered = hovered_range
-                .as_ref()
-                .is_some_and(|hovered_line| hovered_line.line_range() == line.line_range());
+            let (line, range_hovered) =
+                self.gutter_line_at(line_count, false, hovered_range.as_ref());
 
             // Show comment button only on the specific hovered line
             let is_this_line_hovered = hovered_range
@@ -1190,12 +1298,23 @@ impl<V: EditorView> EditorWrapper<V> {
         let show_revert_diff_hunk =
             FeatureFlag::RevertDiffHunk.is_enabled() && self.revert_hunk_button.is_some();
 
-        // Show comment button independently of diff hunk state when requested
+        let hide_comment_gutter_icons = should_hide_comment_gutter_icons(
+            attached_comment.is_some(),
+            self.comment_box
+                .as_ref()
+                .is_some_and(|comment_box| comment_box.line.is_same_line(line)),
+        );
+        let show_saved_comment_indicator =
+            is_active_comment_on_current_line && !hide_comment_gutter_icons;
+        let should_show_diff_hunk_icons = should_show_diff_hunk_icons && !hide_comment_gutter_icons;
+
+        // Show comment button independently of diff hunk state when requested.
         let show_comment_button = FeatureFlag::InlineCodeReview.is_enabled()
             && self.comment_button.is_some()
-            && (should_show_comment_button || is_active_comment_on_current_line);
+            && !hide_comment_gutter_icons
+            && (should_show_comment_button || show_saved_comment_indicator);
 
-        if should_show_diff_hunk_icons || is_active_comment_on_current_line || show_comment_button {
+        if should_show_diff_hunk_icons || show_saved_comment_indicator || show_comment_button {
             let mut buttons = Flex::row().with_main_axis_size(MainAxisSize::Min);
             if let Some(comment_button) =
                 self.comment_button.as_ref().filter(|_| show_comment_button)
@@ -1388,10 +1507,26 @@ impl<V: EditorView> Element for EditorWrapper<V> {
             for decoration in model.decorations().line_decoration_ranges() {
                 let start_y = content.y_offset_at_line(decoration.start);
                 let end_y = content.y_offset_at_line(decoration.end);
+                let mut extended_end_y = end_y;
+                let comment_lines = self
+                    .comment_box
+                    .as_ref()
+                    .map(|comment_box| &comment_box.line)
+                    .into_iter()
+                    .chain(self.saved_comments.iter().map(|comment| comment.location()));
+                for line in comment_lines {
+                    if let Some(block_end) =
+                        inline_comment_decoration_end(decoration, line, model)
+                    {
+                        if block_end > extended_end_y {
+                            extended_end_y = block_end;
+                        }
+                    }
+                }
                 ctx.scene
                     .draw_rect_without_hit_recording(RectF::new(
                         origin + vec2f(0., (start_y - y_adjustment).as_f32()),
-                        vec2f(wrapper_size.x(), (end_y - start_y).as_f32()),
+                        vec2f(wrapper_size.x(), (extended_end_y - start_y).as_f32()),
                     ))
                     .with_background(decoration.overlay);
             }

--- a/app/src/code/editor/embedded_comment.rs
+++ b/app/src/code/editor/embedded_comment.rs
@@ -13,18 +13,40 @@ use warp_editor::render::layout::TextLayout;
 use warp_editor::render::model::viewport::ViewportItem;
 use warp_editor::render::model::{
     BlockSpacing, EmbeddedItem, EmbeddedItemHTMLRepresentation, EmbeddedItemRichFormat,
-    LaidOutEmbeddedItem, RenderState,
+    LaidOutEmbeddedItem, RenderLineLocation, RenderState,
 };
+use warpui::elements::ChildView;
 use warpui::event::DispatchedEvent;
 use warpui::units::Pixels;
-use warpui::{AppContext, EntityId, EventContext, LayoutContext, ViewHandle, WindowId};
+use warpui::{
+    AppContext, Element, EntityId, EventContext, LayoutContext, SizeConstraint, ViewHandle,
+    WindowId,
+};
 
-use crate::code::editor::comment_editor::CommentEditor;
+use crate::code::editor::comment_editor::{CommentEditor, MAX_COMMENT_HEIGHT};
+use crate::code::editor::inline_comment_view::InlineCommentView;
 use crate::code_review::comments::CommentId;
+
+/// Height constraint for a saved inline comment card: effectively unconstrained so the card
+/// reserves its full laid-out height and the whole comment is visible inline without scrolling.
+/// Uses `f32::INFINITY` rather than a large finite constant so the constraint is semantically
+/// correct (no maximum) and avoids overflow if layout code accumulates heights.
+const UNBOUNDED_COMMENT_HEIGHT: f32 = f32::INFINITY;
+
+/// Height of the first visible line used for `first_line_bound` in inline comment blocks.
+/// Matches `ButtonSize::Small.button_height()` at the default appearance (24px).
+const INLINE_COMMENT_FIRST_LINE_HEIGHT: f32 = 24.0;
 
 const COMMENT_ID_MAPPING_KEY: &str = "comment_id";
 const ENTITY_ID_MAPPING_KEY: &str = "entity_id";
 const WINDOW_ID_MAPPING_KEY: &str = "window_id";
+
+fn viewport_pinned_origin(viewport_item: &ViewportItem, ctx: &RenderContext) -> Vector2F {
+    let content_rect = viewport_item.content_bounds(ctx);
+    let mut origin = content_rect.origin();
+    origin.set_x(ctx.bounds.origin_x());
+    origin
+}
 
 #[derive(Debug)]
 pub struct EmbeddedCommentSpace {
@@ -70,7 +92,11 @@ impl EmbeddedItem for EmbeddedCommentSpace {
                 Vector2F::new(100.0, 24.0)
             });
 
-        Box::new(LaidOutEmbeddedCommentSpace { size })
+        Box::new(LaidOutEmbeddedCommentSpace::new(
+            self.editor_entity_id,
+            self.window_id,
+            size,
+        ))
     }
 
     fn hashed_id(&self) -> &str {
@@ -109,6 +135,22 @@ impl EmbeddedItem for EmbeddedCommentSpace {
 #[derive(Debug)]
 pub struct LaidOutEmbeddedCommentSpace {
     pub size: Vector2F,
+    editor_entity_id: EntityId,
+    window_id: WindowId,
+}
+
+impl LaidOutEmbeddedCommentSpace {
+    pub fn new(editor_entity_id: EntityId, window_id: WindowId, size: Vector2F) -> Self {
+        Self {
+            size,
+            editor_entity_id,
+            window_id,
+        }
+    }
+
+    fn comment_editor(&self, app: &AppContext) -> Option<ViewHandle<CommentEditor>> {
+        app.view_with_id::<CommentEditor>(self.window_id, self.editor_entity_id)
+    }
 }
 
 impl LaidOutEmbeddedItem for LaidOutEmbeddedCommentSpace {
@@ -121,7 +163,7 @@ impl LaidOutEmbeddedItem for LaidOutEmbeddedCommentSpace {
     }
 
     fn first_line_bound(&self) -> Vector2F {
-        vec2f(self.size.x(), 24.0)
+        vec2f(self.size.x(), INLINE_COMMENT_FIRST_LINE_HEIGHT)
     }
 
     fn element(
@@ -129,10 +171,33 @@ impl LaidOutEmbeddedItem for LaidOutEmbeddedCommentSpace {
         _state: &RenderState,
         viewport_item: ViewportItem,
         _model: Option<&dyn EmbeddedItemModel>,
-        _ctx: &AppContext,
+        ctx: &AppContext,
     ) -> Box<dyn RenderableBlock> {
-        // Just create a spacer - no child view rendering here
-        Box::new(RenderableEmbeddedCommentSpace::new(viewport_item))
+        // Host the comment editor's element in-tree so it occupies real vertical space at its line
+        // and scrolls with the surrounding content. If the editor handle can't be resolved, fall
+        // back to a no-op spacer that still reserves the block's height. This legacy path hosts a
+        // markdown embed (not a per-view comment block), so it carries no comment anchor.
+        match self.comment_editor(ctx) {
+            Some(editor) => {
+                let child = ChildView::new(&editor).finish();
+                let window_id = self.window_id;
+                let entity_id = self.editor_entity_id;
+                Box::new(RenderableHostedComment::new(
+                    viewport_item,
+                    child,
+                    MAX_COMMENT_HEIGHT,
+                    None,
+                    Some(Box::new(move |measured, app| {
+                        if let Some(editor) =
+                            app.view_with_id::<CommentEditor>(window_id, entity_id)
+                        {
+                            editor.read(app, |editor, _| editor.set_laid_out_size(measured));
+                        }
+                    })),
+                ))
+            }
+            None => Box::new(RenderableEmbeddedCommentSpace::new(viewport_item, None)),
+        }
     }
 
     fn spacing(&self) -> BlockSpacing {
@@ -144,13 +209,107 @@ impl LaidOutEmbeddedItem for LaidOutEmbeddedCommentSpace {
     }
 }
 
+type SizeWriteBack = Box<dyn Fn(Vector2F, &AppContext)>;
+
+/// Hosts an inline comment view's element (either the active composer or a saved-comment card)
+/// inside a per-view inline comment block. It lays out the child against the block's content width
+/// (capped at `max_height`), optionally writes the measured size back via `write_back_size` (the
+/// legacy composer reserves space from its last measured size; inline cards derive their reserved
+/// height from their render state instead), and paints and routes events to the child in content
+/// space (so it scrolls with its anchored line).
+pub struct RenderableHostedComment {
+    viewport_item: ViewportItem,
+    child: Box<dyn Element>,
+    max_height: f32,
+    /// The anchor of the inline comment block hosting this child, when known. Surfaced through
+    /// [`RenderableBlock::embedded_comment_location`] so gutter rendering can classify comment
+    /// rows without a reverse lookup into the content tree.
+    embedded_comment_location: Option<RenderLineLocation>,
+    /// Size write-back used only by the legacy [`LaidOutEmbeddedCommentSpace`] / [`CommentEditor`]
+    /// path. After each layout pass the measured size is written back to the view so
+    /// `EmbeddedCommentSpace::layout` can read it on the next frame. `InlineCommentView` always
+    /// passes `None` here and uses the render-state observation path instead (see
+    /// `InlineCommentsController::wire_view`). Remove when the legacy path is cleaned up.
+    write_back_size: Option<SizeWriteBack>,
+}
+
+impl RenderableHostedComment {
+    fn new(
+        viewport_item: ViewportItem,
+        child: Box<dyn Element>,
+        max_height: f32,
+        embedded_comment_location: Option<RenderLineLocation>,
+        write_back_size: Option<SizeWriteBack>,
+    ) -> Self {
+        Self {
+            viewport_item,
+            child,
+            max_height,
+            embedded_comment_location,
+            write_back_size,
+        }
+    }
+}
+
+impl RenderableBlock for RenderableHostedComment {
+    fn viewport_item(&self) -> &ViewportItem {
+        &self.viewport_item
+    }
+
+    fn layout(&mut self, _model: &RenderState, ctx: &mut LayoutContext, app: &AppContext) {
+        let width = self.viewport_item.content_size.x();
+        let measured = self.child.layout(
+            SizeConstraint::new(vec2f(0., 0.), vec2f(width, self.max_height)),
+            ctx,
+            app,
+        );
+
+        if let Some(write_back_size) = &self.write_back_size {
+            write_back_size(measured, app);
+        }
+    }
+
+    fn paint(&mut self, _model: &RenderState, ctx: &mut RenderContext, app: &AppContext) {
+        let origin = viewport_pinned_origin(&self.viewport_item, ctx);
+        ctx.paint.scene.start_layer(warpui::ClipBounds::ActiveLayer);
+        self.child.paint(origin, ctx.paint, app);
+        ctx.paint.scene.stop_layer();
+    }
+
+    fn after_layout(&mut self, ctx: &mut warpui::AfterLayoutContext, app: &AppContext) {
+        self.child.after_layout(ctx, app);
+    }
+
+    fn dispatch_event(
+        &mut self,
+        _model: &RenderState,
+        event: &DispatchedEvent,
+        ctx: &mut EventContext,
+        app: &AppContext,
+    ) -> bool {
+        self.child.dispatch_event(event, ctx, app)
+    }
+
+    fn embedded_comment_location(&self) -> Option<RenderLineLocation> {
+        self.embedded_comment_location
+    }
+}
+
 pub struct RenderableEmbeddedCommentSpace {
     viewport_item: ViewportItem,
+    /// See [`RenderableHostedComment::embedded_comment_location`].
+    embedded_comment_location: Option<RenderLineLocation>,
 }
 
 impl RenderableEmbeddedCommentSpace {
-    pub(crate) fn new(viewport_item: ViewportItem) -> Self {
-        Self { viewport_item }
+    pub(crate) fn new(
+        viewport_item: ViewportItem,
+        embedded_comment_location: Option<RenderLineLocation>,
+    ) -> Self {
+        Self {
+            viewport_item,
+            embedded_comment_location,
+        }
     }
 }
 
@@ -178,8 +337,91 @@ impl RenderableBlock for RenderableEmbeddedCommentSpace {
         false
     }
 
-    fn is_embedded_comment(&self) -> bool {
-        true
+    fn embedded_comment_location(&self) -> Option<RenderLineLocation> {
+        self.embedded_comment_location
+    }
+}
+
+/// An already-laid-out inline block hosting a saved-comment [`InlineCommentView`] (the read-only
+/// card). It mirrors [`LaidOutEmbeddedCommentSpace`] but hosts the saved card rather than the active
+/// composer, resolving the view by its window + entity id so the host stays independent of the
+/// app-crate view type at the `warp_editor` boundary.
+#[derive(Debug)]
+pub struct LaidOutInlineSavedComment {
+    pub size: Vector2F,
+    view_entity_id: EntityId,
+    window_id: WindowId,
+    /// The anchor of the comment block hosting this card, forwarded to the renderable so gutter
+    /// rendering can classify the row without a reverse lookup into the content tree.
+    location: RenderLineLocation,
+}
+
+impl LaidOutInlineSavedComment {
+    pub fn new(
+        view_entity_id: EntityId,
+        window_id: WindowId,
+        size: Vector2F,
+        location: RenderLineLocation,
+    ) -> Self {
+        Self {
+            size,
+            view_entity_id,
+            window_id,
+            location,
+        }
+    }
+
+    fn inline_view(&self, app: &AppContext) -> Option<ViewHandle<InlineCommentView>> {
+        app.view_with_id::<InlineCommentView>(self.window_id, self.view_entity_id)
+    }
+}
+
+impl LaidOutEmbeddedItem for LaidOutInlineSavedComment {
+    fn height(&self) -> Pixels {
+        Pixels::new(self.size.y())
+    }
+
+    fn size(&self) -> Vector2F {
+        self.size
+    }
+
+    fn first_line_bound(&self) -> Vector2F {
+        vec2f(self.size.x(), INLINE_COMMENT_FIRST_LINE_HEIGHT)
+    }
+
+    fn element(
+        &self,
+        _state: &RenderState,
+        viewport_item: ViewportItem,
+        _model: Option<&dyn EmbeddedItemModel>,
+        ctx: &AppContext,
+    ) -> Box<dyn RenderableBlock> {
+        match self.inline_view(ctx) {
+            Some(view) => {
+                let child = ChildView::new(&view).finish();
+                // No size write-back: the inline card's reserved height is derived from its body
+                // editor's render state (see `InlineCommentView::inline_height`).
+                Box::new(RenderableHostedComment::new(
+                    viewport_item,
+                    child,
+                    UNBOUNDED_COMMENT_HEIGHT,
+                    Some(self.location),
+                    None,
+                ))
+            }
+            None => Box::new(RenderableEmbeddedCommentSpace::new(
+                viewport_item,
+                Some(self.location),
+            )),
+        }
+    }
+
+    fn spacing(&self) -> BlockSpacing {
+        BlockSpacing::default()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/app/src/code/editor/inline_comment_view.rs
+++ b/app/src/code/editor/inline_comment_view.rs
@@ -1,0 +1,516 @@
+use chrono::{DateTime, Local};
+use pathfinder_color::ColorU;
+use warp_core::ui::theme::Fill;
+use warp_editor::render::model::RenderState;
+use warpui::elements::{
+    ChildView, ConstrainedBox, CrossAxisAlignment, Flex, MainAxisAlignment, MainAxisSize,
+    ParentElement, Shrinkable, Text,
+};
+use warpui::text_layout::ClipConfig;
+use warpui::units::Pixels;
+use warpui::{
+    AppContext, Element, Entity, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
+    ViewHandle,
+};
+
+use crate::appearance::Appearance;
+use crate::code::editor::comment_editor::{
+    comment_chrome_height, create_editable_comment_markdown_editor, inline_comment_background,
+    render_inline_comment_shell,
+};
+use crate::code::editor::line::EditorLineLocation;
+use crate::code::editor::EditorReviewComment;
+use crate::code_review::comments::{CommentId, CommentOrigin};
+use crate::editor::InteractionState;
+use crate::notebooks::editor::view::{EditorViewEvent, RichTextEditorView};
+use crate::ui_components::icons::Icon;
+use crate::util::time_format::human_readable_approx_duration;
+use crate::view_components::action_button::{
+    ActionButton, ButtonSize, DangerNakedTheme, NakedTheme, PrimaryTheme,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InlineCommentMode {
+    Saved,
+    NewDraft,
+    EditingExisting,
+}
+
+/// Bundled configuration for constructing an [`InlineCommentView`].
+struct InlineCommentConfig {
+    id: CommentId,
+    line: EditorLineLocation,
+    saved_content: String,
+    last_update_time: DateTime<Local>,
+    origin: CommentOrigin,
+    mode: InlineCommentMode,
+}
+
+#[derive(Debug)]
+pub enum InlineCommentViewAction {
+    Edit,
+    Remove,
+    Save,
+    Cancel,
+}
+
+#[derive(Debug)]
+pub enum InlineCommentViewEvent {
+    RequestEdit {
+        id: CommentId,
+    },
+    RequestRemove {
+        id: CommentId,
+    },
+    CommentSaved {
+        id: CommentId,
+        line: EditorLineLocation,
+        comment_text: String,
+    },
+    Cancelled {
+        id: CommentId,
+    },
+    ContentChanged,
+}
+
+/// A per-comment inline code-review comment view hosted in the diff editor.
+///
+/// The same view owns the same inner [`RichTextEditorView`] while moving between saved and editing
+/// modes, so saving an inline comment does not replace the editor subtree and cause a transient
+/// sizing mismatch.
+pub struct InlineCommentView {
+    id: CommentId,
+    line: EditorLineLocation,
+    saved_content: String,
+    last_update_time: DateTime<Local>,
+    origin: CommentOrigin,
+    mode: InlineCommentMode,
+    body_editor: ViewHandle<RichTextEditorView>,
+    edit_button: ViewHandle<ActionButton>,
+    remove_button: ViewHandle<ActionButton>,
+    save_button: ViewHandle<ActionButton>,
+    cancel_button: ViewHandle<ActionButton>,
+    save_button_disabled: bool,
+}
+
+impl InlineCommentView {
+    pub fn new(comment: EditorReviewComment, ctx: &mut ViewContext<Self>) -> Self {
+        let body_editor =
+            create_editable_comment_markdown_editor(Some(&comment.comment_content), ctx);
+        Self::new_inner(
+            InlineCommentConfig {
+                id: comment.id,
+                line: comment.line,
+                saved_content: comment.comment_content,
+                last_update_time: comment.last_update_time,
+                origin: comment.origin,
+                mode: InlineCommentMode::Saved,
+            },
+            body_editor,
+            ctx,
+        )
+    }
+
+    pub fn new_draft(line: EditorLineLocation, ctx: &mut ViewContext<Self>) -> Self {
+        let body_editor = create_editable_comment_markdown_editor(None, ctx);
+        Self::new_inner(
+            InlineCommentConfig {
+                id: CommentId::new(),
+                line,
+                saved_content: String::new(),
+                last_update_time: Local::now(),
+                origin: CommentOrigin::default(),
+                mode: InlineCommentMode::NewDraft,
+            },
+            body_editor,
+            ctx,
+        )
+    }
+
+    fn new_inner(
+        config: InlineCommentConfig,
+        body_editor: ViewHandle<RichTextEditorView>,
+        ctx: &mut ViewContext<Self>,
+    ) -> Self {
+        let edit_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("Edit", NakedTheme)
+                .with_size(ButtonSize::Small)
+                .on_click(|ctx| ctx.dispatch_typed_action(InlineCommentViewAction::Edit))
+        });
+        let remove_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("Remove", DangerNakedTheme)
+                .with_size(ButtonSize::Small)
+                .on_click(|ctx| ctx.dispatch_typed_action(InlineCommentViewAction::Remove))
+        });
+        let save_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("Comment", PrimaryTheme)
+                .with_size(ButtonSize::Small)
+                .on_click(|ctx| ctx.dispatch_typed_action(InlineCommentViewAction::Save))
+        });
+        let cancel_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("Cancel", NakedTheme)
+                .with_size(ButtonSize::Small)
+                .on_click(|ctx| ctx.dispatch_typed_action(InlineCommentViewAction::Cancel))
+        });
+
+        ctx.subscribe_to_view(&body_editor, |me, _, event, ctx| {
+            me.handle_body_editor_event(event, ctx);
+        });
+
+        let mut me = Self {
+            id: config.id,
+            line: config.line,
+            saved_content: config.saved_content,
+            last_update_time: config.last_update_time,
+            origin: config.origin,
+            mode: config.mode,
+            body_editor,
+            edit_button,
+            remove_button,
+            save_button,
+            cancel_button,
+            save_button_disabled: true,
+        };
+        me.apply_mode(ctx);
+        me.update_save_button_state(ctx);
+        me
+    }
+
+    /// Refresh this view's saved data in place when the review comment batch delivers an update.
+    /// Called instead of destroying and recreating the view, which would collapse the block height
+    /// and discard in-progress edits.
+    ///
+    /// Metadata (line, timestamp, origin) is always updated. The body editor is only reset when
+    /// the view is in `Saved` mode — if the user is actively editing, their draft is preserved and
+    /// only `saved_content` is updated so that Cancel reverts to the latest server version.
+    pub fn update_source(&mut self, comment: EditorReviewComment, ctx: &mut ViewContext<Self>) {
+        self.id = comment.id;
+        self.line = comment.line;
+        self.last_update_time = comment.last_update_time;
+        self.origin = comment.origin;
+        if self.mode == InlineCommentMode::Saved && comment.comment_content != self.saved_content {
+            self.body_editor.update(ctx, |editor, ctx| {
+                editor.model().update(ctx, |model, ctx| {
+                    model.reset_with_markdown(&comment.comment_content, ctx);
+                });
+            });
+        }
+        self.saved_content = comment.comment_content;
+        if self.mode == InlineCommentMode::Saved {
+            self.apply_mode(ctx);
+        }
+        ctx.notify();
+    }
+
+    pub fn begin_editing(&mut self, ctx: &mut ViewContext<Self>) {
+        self.mode = InlineCommentMode::EditingExisting;
+        self.body_editor.update(ctx, |editor, ctx| {
+            editor.model().update(ctx, |model, ctx| {
+                model.reset_with_markdown(&self.saved_content, ctx);
+            });
+        });
+        self.apply_mode(ctx);
+        self.update_save_button_state(ctx);
+        ctx.focus(&self.body_editor);
+        ctx.notify();
+    }
+
+    pub fn complete_save(&mut self, comment: EditorReviewComment, ctx: &mut ViewContext<Self>) {
+        self.id = comment.id;
+        self.line = comment.line;
+        self.saved_content = comment.comment_content;
+        self.last_update_time = comment.last_update_time;
+        self.origin = comment.origin;
+        self.mode = InlineCommentMode::Saved;
+        self.apply_mode(ctx);
+        ctx.notify();
+    }
+
+    pub fn cancel_editing(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.mode == InlineCommentMode::EditingExisting {
+            self.mode = InlineCommentMode::Saved;
+            self.body_editor.update(ctx, |editor, ctx| {
+                editor.model().update(ctx, |model, ctx| {
+                    model.reset_with_markdown(&self.saved_content, ctx);
+                });
+            });
+            self.apply_mode(ctx);
+            ctx.notify();
+        }
+    }
+
+    pub fn id(&self) -> CommentId {
+        self.id
+    }
+
+    pub fn line(&self) -> &EditorLineLocation {
+        &self.line
+    }
+
+    pub fn is_editing(&self) -> bool {
+        matches!(
+            self.mode,
+            InlineCommentMode::NewDraft | InlineCommentMode::EditingExisting
+        )
+    }
+
+    pub fn is_new_draft(&self) -> bool {
+        self.mode == InlineCommentMode::NewDraft
+    }
+
+    pub fn focus_body(&self, ctx: &mut ViewContext<Self>) {
+        ctx.focus(&self.body_editor);
+    }
+
+    pub fn comment_text(&self, app: &AppContext) -> String {
+        self.body_editor
+            .as_ref(app)
+            .model()
+            .as_ref(app)
+            .markdown(app)
+    }
+
+    pub fn inner_render_state(&self, app: &AppContext) -> ModelHandle<RenderState> {
+        self.body_editor
+            .as_ref(app)
+            .model()
+            .as_ref(app)
+            .render_state()
+            .clone()
+    }
+
+    pub fn inline_height(&self, app: &AppContext) -> Pixels {
+        // Read directly from the inner render state so the reserved block height is always
+        // current. The `inner_render_state` observer fires after every layout pass (including
+        // non-keystroke edits like select-all + delete), so `sync_inline_comment_blocks` always
+        // sees an up-to-date value here.
+        let content_height = self.inner_render_state(app).as_ref(app).height().as_f32();
+        Pixels::new(content_height + comment_chrome_height(&self.save_button, app))
+    }
+
+    fn apply_mode(&mut self, ctx: &mut ViewContext<Self>) {
+        let interaction_state = if self.is_editing() {
+            InteractionState::Editable
+        } else {
+            InteractionState::Selectable
+        };
+        self.body_editor.update(ctx, |editor, ctx| {
+            editor.set_interaction_state(interaction_state, ctx);
+        });
+        self.save_button.update(ctx, |button, ctx| {
+            button.set_label(
+                if self.mode == InlineCommentMode::EditingExisting {
+                    "Update"
+                } else {
+                    "Comment"
+                },
+                ctx,
+            );
+        });
+    }
+
+    fn update_save_button_state(&mut self, ctx: &mut ViewContext<Self>) {
+        let is_empty = self
+            .body_editor
+            .as_ref(ctx)
+            .model()
+            .as_ref(ctx)
+            .is_empty(ctx);
+        if is_empty != self.save_button_disabled {
+            self.save_button_disabled = is_empty;
+            self.save_button.update(ctx, |button, ctx| {
+                button.set_disabled(is_empty, ctx);
+            });
+        }
+    }
+
+    fn handle_body_editor_event(&mut self, event: &EditorViewEvent, ctx: &mut ViewContext<Self>) {
+        match event {
+            EditorViewEvent::Edited => {
+                self.update_save_button_state(ctx);
+                ctx.emit(InlineCommentViewEvent::ContentChanged);
+            }
+            EditorViewEvent::CmdEnter => self.save(ctx),
+            EditorViewEvent::EscapePressed => self.handle_escape(ctx),
+            EditorViewEvent::Focused
+            | EditorViewEvent::Navigate(_)
+            | EditorViewEvent::OpenFile { .. }
+            | EditorViewEvent::RunWorkflow(_)
+            | EditorViewEvent::EditWorkflow(_)
+            | EditorViewEvent::OpenedBlockInsertionMenu(_)
+            | EditorViewEvent::OpenedEmbeddedObjectSearch
+            | EditorViewEvent::OpenedFindBar
+            | EditorViewEvent::InsertedEmbeddedObject(_)
+            | EditorViewEvent::CopiedBlock { .. }
+            | EditorViewEvent::NavigatedCommands
+            | EditorViewEvent::ChangedSelectionMode(_)
+            | EditorViewEvent::TextSelectionChanged => {}
+        }
+    }
+
+    fn save(&mut self, ctx: &mut ViewContext<Self>) {
+        let comment_text = self.comment_text(ctx);
+        if comment_text.trim().is_empty() {
+            return;
+        }
+        ctx.emit(InlineCommentViewEvent::CommentSaved {
+            id: self.id,
+            line: self.line.clone(),
+            comment_text,
+        });
+    }
+
+    fn cancel(&mut self, ctx: &mut ViewContext<Self>) {
+        ctx.emit(InlineCommentViewEvent::Cancelled { id: self.id });
+    }
+
+    /// Escape must not discard unsaved work: a new draft cancels only while its body is empty, and
+    /// an edit of an existing comment cancels only while the body still matches the saved content.
+    /// Otherwise Escape is a no-op and the footer Cancel button remains the explicit way to discard
+    /// changes.
+    fn handle_escape(&mut self, ctx: &mut ViewContext<Self>) {
+        let can_discard = match self.mode {
+            InlineCommentMode::NewDraft => self
+                .body_editor
+                .as_ref(ctx)
+                .model()
+                .as_ref(ctx)
+                .is_empty(ctx),
+            InlineCommentMode::EditingExisting => self.comment_text(ctx) == self.saved_content,
+            InlineCommentMode::Saved => false,
+        };
+        if can_discard {
+            self.cancel(ctx);
+        }
+    }
+
+    fn render_metadata(&self, appearance: &Appearance, background: ColorU) -> Box<dyn Element> {
+        let theme = appearance.theme();
+        let sub_text_color = theme.sub_text_color(Fill::Solid(background)).into_solid();
+        let mut leading = Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_spacing(4.);
+
+        if self.origin.is_imported_from_github() {
+            leading = leading.with_child(
+                ConstrainedBox::new(
+                    Icon::Github
+                        .to_warpui_icon(Fill::Solid(sub_text_color))
+                        .finish(),
+                )
+                .with_width(14.)
+                .with_height(14.)
+                .finish(),
+            );
+        }
+
+        let relative_time = human_readable_approx_duration(
+            Local::now() - self.last_update_time,
+            true, /* sentence_case */
+        );
+        leading = leading.with_child(
+            Text::new(
+                relative_time,
+                appearance.ui_font_family(),
+                appearance.ui_font_size(),
+            )
+            .soft_wrap(false)
+            .with_clip(ClipConfig::end())
+            .with_color(sub_text_color)
+            .finish(),
+        );
+        leading.finish()
+    }
+
+    fn render_saved_actions(&self) -> Box<dyn Element> {
+        Flex::row()
+            .with_spacing(4.)
+            .with_children([
+                ChildView::new(&self.edit_button).finish(),
+                ChildView::new(&self.remove_button).finish(),
+            ])
+            .with_main_axis_alignment(MainAxisAlignment::End)
+            .finish()
+    }
+
+    fn render_editing_actions(&self) -> Box<dyn Element> {
+        let mut actions = vec![ChildView::new(&self.cancel_button).finish()];
+        if self.mode == InlineCommentMode::EditingExisting {
+            actions.push(ChildView::new(&self.remove_button).finish());
+        }
+        actions.push(ChildView::new(&self.save_button).finish());
+
+        Flex::row()
+            .with_spacing(4.)
+            .with_children(actions)
+            .with_main_axis_alignment(MainAxisAlignment::End)
+            .finish()
+    }
+
+    fn render_footer_row(&self, appearance: &Appearance, background: ColorU) -> Box<dyn Element> {
+        let action_buttons = if self.is_editing() {
+            self.render_editing_actions()
+        } else {
+            self.render_saved_actions()
+        };
+
+        let footer_row = Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center);
+
+        if self.mode == InlineCommentMode::NewDraft {
+            footer_row
+                .with_main_axis_alignment(MainAxisAlignment::End)
+                .with_child(action_buttons)
+                .finish()
+        } else {
+            footer_row
+                .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                .with_child(
+                    Shrinkable::new(1., self.render_metadata(appearance, background)).finish(),
+                )
+                .with_child(action_buttons)
+                .finish()
+        }
+    }
+}
+
+impl Entity for InlineCommentView {
+    type Event = InlineCommentViewEvent;
+}
+
+impl TypedActionView for InlineCommentView {
+    type Action = InlineCommentViewAction;
+
+    fn handle_action(&mut self, action: &InlineCommentViewAction, ctx: &mut ViewContext<Self>) {
+        match action {
+            InlineCommentViewAction::Edit => {
+                ctx.emit(InlineCommentViewEvent::RequestEdit { id: self.id });
+            }
+            InlineCommentViewAction::Remove => {
+                ctx.emit(InlineCommentViewEvent::RequestRemove { id: self.id });
+            }
+            InlineCommentViewAction::Save => self.save(ctx),
+            InlineCommentViewAction::Cancel => self.cancel(ctx),
+        }
+    }
+}
+
+impl View for InlineCommentView {
+    fn ui_name() -> &'static str {
+        "InlineCommentView"
+    }
+
+    fn render(&self, ctx: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(ctx);
+        let background = inline_comment_background(appearance);
+        let footer_row = self.render_footer_row(appearance, background);
+        render_inline_comment_shell(
+            ChildView::new(&self.body_editor).finish(),
+            footer_row,
+            None,
+            12.,
+            appearance,
+        )
+    }
+}

--- a/app/src/code/editor/inline_comments.rs
+++ b/app/src/code/editor/inline_comments.rs
@@ -1,0 +1,214 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use pathfinder_geometry::vector::vec2f;
+use warp_editor::render::model::{CommentBlock, RenderLineLocation};
+use warpui::units::Pixels;
+use warpui::{EntityId, ModelHandle, ViewContext, ViewHandle, WindowId};
+
+use crate::code::editor::comment_editor::DEFAULT_COMMENT_MAX_WIDTH;
+use crate::code::editor::embedded_comment::LaidOutInlineSavedComment;
+use crate::code::editor::inline_comment_view::InlineCommentView;
+use crate::code::editor::line::EditorLineLocation;
+use crate::code::editor::model::CodeEditorModel;
+use crate::code::editor::view::CodeEditorView;
+use crate::code::editor::EditorReviewComment;
+use crate::code_review::comments::CommentId;
+use crate::features::FeatureFlag;
+
+/// The desired render-state entry for one inline comment view: its anchor, reserved height, and
+/// the hosted view's entity id. Comparing the full entry set against the last synced one lets
+/// [`InlineCommentsController::sync_blocks`] skip the render-tree rebuild when nothing changed.
+type BlockEntry = (RenderLineLocation, Pixels, EntityId);
+
+/// Embedded inline review-comment state for one `CodeEditorView`.
+///
+/// Owns the per-comment [`InlineCommentView`] handles (saved cards and unsaved drafts, keyed by
+/// [`CommentId`]) and reconciles them into per-view [`CommentBlock`]s on the editor's render
+/// state. The owning `CodeEditorView` keeps subscription wiring, comment persistence
+/// (`save_comment`), and `CodeEditorEvent` emission; everything specific to the
+/// `EmbeddedCodeReviewComments` flag's inline presentation lives here, so removing either the
+/// embedded path or the legacy floating composer later stays localized.
+///
+/// Views are created and destroyed only in `&mut self` methods, never during `render`.
+pub(crate) struct InlineCommentsController {
+    /// Per-comment inline views, reconciled from the `ReviewCommentBatch` source of truth via
+    /// [`Self::reconcile_saved`] (create new, update changed in place, drop removed) plus, when
+    /// open, unsaved draft views. Only populated for line-targeted, non-outdated comments while
+    /// the `EmbeddedCodeReviewComments` flag is enabled.
+    views: HashMap<CommentId, ViewHandle<InlineCommentView>>,
+    /// The block set most recently pushed to the render state, sorted deterministically.
+    /// [`Self::sync_blocks`] early-outs when the desired set is unchanged, so frequent
+    /// re-measure triggers (every inner body-editor layout pass) don't rebuild the host
+    /// editor's content tree.
+    ///
+    /// The cache stays valid because the render state never drops `EmbeddedComment` blocks on
+    /// its own: buffer edits and temporary-block resets both preserve them.
+    last_synced_blocks: Vec<BlockEntry>,
+}
+
+impl InlineCommentsController {
+    pub fn new() -> Self {
+        Self {
+            views: HashMap::new(),
+            last_synced_blocks: Vec::new(),
+        }
+    }
+
+    /// Reconcile the saved-comment views against the incoming batch, mirroring how
+    /// `CommentListView::set_comments_internal` reconciles its cards: existing ids reuse (and
+    /// update in place) their handle, new ids create one, and removed ids are dropped. Unsaved
+    /// draft views are preserved. When the `EmbeddedCodeReviewComments` flag is off, no views are
+    /// created so no inline blocks are rendered and there is no flag-off regression.
+    pub fn reconcile_saved(
+        &mut self,
+        comments: Vec<EditorReviewComment>,
+        ctx: &mut ViewContext<CodeEditorView>,
+    ) {
+        let mut new_views: HashMap<CommentId, ViewHandle<InlineCommentView>> = HashMap::new();
+
+        if FeatureFlag::EmbeddedCodeReviewComments.is_enabled() {
+            for comment in comments {
+                let id = comment.id;
+                let view = match self.views.remove(&id) {
+                    Some(existing) => {
+                        existing.update(ctx, |view, ctx| view.update_source(comment, ctx));
+                        existing
+                    }
+                    None => {
+                        let view =
+                            ctx.add_typed_action_view(|ctx| InlineCommentView::new(comment, ctx));
+                        Self::wire_view(&view, ctx);
+                        view
+                    }
+                };
+                new_views.insert(id, view);
+            }
+        }
+
+        // Preserve unsaved draft views; any other handles still left correspond to removed saved
+        // comments and are dropped here.
+        for (id, view) in std::mem::take(&mut self.views) {
+            if view.as_ref(ctx).is_new_draft() {
+                new_views.insert(id, view);
+            }
+        }
+        self.views = new_views;
+    }
+
+    /// Create a new unsaved draft view anchored below `line` and return its handle so the caller
+    /// can focus its body.
+    pub fn open_draft(
+        &mut self,
+        line: EditorLineLocation,
+        ctx: &mut ViewContext<CodeEditorView>,
+    ) -> ViewHandle<InlineCommentView> {
+        let view = ctx.add_typed_action_view(|ctx| InlineCommentView::new_draft(line, ctx));
+        Self::wire_view(&view, ctx);
+        self.views.insert(view.as_ref(ctx).id(), view.clone());
+        view
+    }
+
+    /// Switch the saved card for `id` into editing mode. Returns `false` when no inline view
+    /// exists for that id.
+    pub fn begin_editing(&mut self, id: &CommentId, ctx: &mut ViewContext<CodeEditorView>) -> bool {
+        let Some(view) = self.views.get(id).cloned() else {
+            return false;
+        };
+        view.update(ctx, |view, ctx| view.begin_editing(ctx));
+        true
+    }
+
+    /// Apply a persisted comment back onto the same inline view (draft or edit -> saved).
+    pub fn complete_save(
+        &mut self,
+        comment: EditorReviewComment,
+        ctx: &mut ViewContext<CodeEditorView>,
+    ) {
+        if let Some(view) = self.views.get(&comment.id).cloned() {
+            view.update(ctx, |view, ctx| view.complete_save(comment, ctx));
+        }
+    }
+
+    /// Cancel the inline view for `id`: an unsaved draft is dropped entirely, while an edit of a
+    /// saved comment is restored to its saved content.
+    pub fn cancel(&mut self, id: &CommentId, ctx: &mut ViewContext<CodeEditorView>) {
+        let Some(view) = self.views.get(id).cloned() else {
+            return;
+        };
+        if view.as_ref(ctx).is_new_draft() {
+            self.views.remove(id);
+        } else {
+            view.update(ctx, |view, ctx| view.cancel_editing(ctx));
+        }
+    }
+
+    /// Drop all inline views. The next [`Self::sync_blocks`] clears the rendered blocks.
+    pub fn clear(&mut self) {
+        self.views.clear();
+    }
+
+    /// Reconcile the full set of inline comment blocks on the per-view render state with the
+    /// current views: one block per inline view (saved card or unsaved draft), each reserving the
+    /// view's current inline height at its anchor line. When the desired set matches what was
+    /// last synced, this is a no-op, so callers can invoke it on every potential change (e.g.
+    /// every body-editor layout pass) without rebuilding the host editor's content tree.
+    ///
+    /// When the `EmbeddedCodeReviewComments` flag is off the desired set is empty, which removes
+    /// any previously synced blocks and otherwise does nothing.
+    pub fn sync_blocks(
+        &mut self,
+        model: &ModelHandle<CodeEditorModel>,
+        window_id: WindowId,
+        ctx: &mut ViewContext<CodeEditorView>,
+    ) {
+        let mut entries: Vec<BlockEntry> = Vec::new();
+        if FeatureFlag::EmbeddedCodeReviewComments.is_enabled() {
+            for view in self.views.values() {
+                let view_ref = view.as_ref(ctx);
+                let location = view_ref
+                    .line()
+                    .clone()
+                    .into_inline_comment_render_line_location();
+                entries.push((location, view_ref.inline_height(ctx), view.id()));
+            }
+            // Deterministic ordering: keeps same-line stacking stable across syncs and makes the
+            // equality check below meaningful despite hash-map iteration order.
+            entries.sort_by_key(|(location, _, entity_id)| (*location, *entity_id));
+        }
+
+        if entries == self.last_synced_blocks {
+            return;
+        }
+
+        let blocks = entries
+            .iter()
+            .map(|(location, height, entity_id)| {
+                let size = vec2f(DEFAULT_COMMENT_MAX_WIDTH, height.as_f32());
+                CommentBlock::new(
+                    *location,
+                    Arc::new(LaidOutInlineSavedComment::new(
+                        *entity_id, window_id, size, *location,
+                    )),
+                )
+            })
+            .collect();
+        model.update(ctx, |model, ctx| {
+            model.set_inline_comment_blocks(blocks, ctx);
+        });
+        self.last_synced_blocks = entries;
+    }
+
+    /// Wire a newly created inline view: route its events to the owning `CodeEditorView` and
+    /// re-sync the reserved blocks whenever its body editor re-lays out (so the block grows and
+    /// shrinks with the content).
+    fn wire_view(view: &ViewHandle<InlineCommentView>, ctx: &mut ViewContext<CodeEditorView>) {
+        ctx.subscribe_to_view(view, |me, _, event, ctx| {
+            me.handle_inline_comment_event(event, ctx);
+        });
+        let inner_render_state = view.as_ref(ctx).inner_render_state(ctx);
+        ctx.observe(&inner_render_state, |me, _, ctx| {
+            me.sync_inline_comment_blocks(ctx);
+        });
+    }
+}

--- a/app/src/code/editor/line.rs
+++ b/app/src/code/editor/line.rs
@@ -72,7 +72,35 @@ impl EditorLineLocation {
                 index_from_at_line: index,
             },
             EditorLineLocation::Collapsed { line_range } => {
-                debug_assert!(false, "We don't support converting from collapsed line location to render line location yet");
+                debug_assert!(
+                    false,
+                    "We don't support converting from collapsed line location to render line location yet"
+                );
+                RenderLineLocation::Current(line_range.start)
+            }
+        }
+    }
+
+    pub fn into_inline_comment_render_line_location(self) -> RenderLineLocation {
+        match self {
+            EditorLineLocation::Current { line_number, .. } => {
+                RenderLineLocation::Current(line_number + LineCount::from(1))
+            }
+            // For removed lines the comment block uses the same `Temporary` slot as the
+            // removed-line block itself (no +1 offset). `reset_comment_blocks` inserts comment
+            // blocks *after* the matching `TemporaryBlock` at this slot, so the comment renders
+            // below its removed line despite sharing the same `RenderLineLocation`.
+            EditorLineLocation::Removed {
+                line_number, index, ..
+            } => RenderLineLocation::Temporary {
+                at_line: line_number,
+                index_from_at_line: index,
+            },
+            EditorLineLocation::Collapsed { line_range } => {
+                debug_assert!(
+                    false,
+                    "We don't support converting from collapsed line location to render line location yet"
+                );
                 RenderLineLocation::Current(line_range.start)
             }
         }

--- a/app/src/code/editor/mod.rs
+++ b/app/src/code/editor/mod.rs
@@ -7,6 +7,8 @@ mod element;
 pub mod embedded_comment;
 pub mod find;
 pub mod goto_line;
+pub mod inline_comment_view;
+mod inline_comments;
 pub mod line;
 mod line_iterator;
 pub mod model;

--- a/app/src/code/editor/model.rs
+++ b/app/src/code/editor/model.rs
@@ -47,7 +47,7 @@ use warp_editor::editor::TextDecoration;
 use warp_editor::model::{CoreEditorModel, PlainTextEditorModel};
 use warp_editor::multiline::{AnyMultilineString, MultilineString, LF};
 use warp_editor::render::model::{
-    AutoScrollMode, BlockItem, Decoration, LineCount, LineDecoration, RenderEvent,
+    AutoScrollMode, BlockItem, CommentBlock, Decoration, LineCount, LineDecoration, RenderEvent,
     RenderLineLocation, RenderState, RichTextStyles, StyleUpdateAction,
     UpdateDecorationAfterLayout, WidthSetting,
 };
@@ -842,6 +842,7 @@ impl CodeEditorModel {
                 | BlockItem::OrderedList { .. }
                 | BlockItem::Header { .. }
                 | BlockItem::Embedded(_)
+                | BlockItem::EmbeddedComment { .. }
                 | BlockItem::HorizontalRule(_)
                 | BlockItem::Image { .. }
                 | BlockItem::Table(_)
@@ -3846,6 +3847,20 @@ impl CodeEditorModel {
                 comment_text: comment_text.to_owned(),
                 origin: origin.to_owned(),
             });
+        });
+    }
+
+    /// Replace the full set of per-view inline comment blocks on this view's [`RenderState`] with
+    /// `blocks` (the saved-comment cards plus, when open, the active composer). An empty vector
+    /// removes all inline comment blocks. This lives on the per-view render state only (never the
+    /// shared buffer), so it cannot leak into other views of the same file.
+    pub fn set_inline_comment_blocks(
+        &mut self,
+        blocks: Vec<CommentBlock>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.render_state.update(ctx, |render_state, _| {
+            render_state.set_comment_blocks(blocks)
         });
     }
 }

--- a/app/src/code/editor/view.rs
+++ b/app/src/code/editor/view.rs
@@ -39,8 +39,8 @@ use warpui::elements::new_scrollable::{
 };
 use warpui::elements::{
     ChildAnchor, ChildView, Dismiss, Fill, Flex, Margin, MouseStateHandle, NewScrollable,
-    OffsetPositioning, Padding, ParentAnchor, ParentElement, ParentOffsetBounds, ScrollStateHandle,
-    Shrinkable, Stack,
+    OffsetPositioning, Padding, ParentAnchor, ParentElement, ParentOffsetBounds, SavePosition,
+    ScrollStateHandle, Shrinkable, Stack,
 };
 use warpui::event::ModifiersState;
 use warpui::keymap::Keystroke;
@@ -63,6 +63,8 @@ use crate::code::editor::element::{
 };
 use crate::code::editor::find::view::{CodeEditorFind as Find, Event as FindViewEvent};
 use crate::code::editor::goto_line::view::{Event as GoToLineEvent, GoToLineView};
+use crate::code::editor::inline_comment_view::InlineCommentViewEvent;
+use crate::code::editor::inline_comments::InlineCommentsController;
 use crate::code::editor::line::EditorLineLocation;
 use crate::code::editor::model::{
     CodeEditorModel, CodeEditorModelEvent, HoverableLink, LineBound, StableEditorLine,
@@ -274,8 +276,15 @@ pub struct CodeEditorView {
     active_comment_editor: ViewHandle<CommentEditor>,
     /// TODO: maybe turn into a map for fast UUID or range lookup
     comment_locations: Vec<SavedComment>,
+    /// Embedded inline review-comment state (per-comment views and their rendered blocks). The
+    /// hosted views are presented inline by the per-view render state while the
+    /// `EmbeddedCodeReviewComments` flag is enabled.
+    inline_comments: InlineCommentsController,
     /// Save position of the comment button rendered within this code editor view.
     comment_save_position_id: String,
+    /// Save position of the flag-OFF floating comment composer overlay, so its painted presence and
+    /// offset can be observed (it lives outside the content tree, unlike the inline block).
+    comment_overlay_position_id: String,
     show_comment_editor_provider: Box<dyn ShowCommentEditorProvider>,
     /// Save position of the anchor point for find references card.
     find_references_save_position_id: String,
@@ -378,6 +387,12 @@ impl CodeEditorView {
         ctx.subscribe_to_view(&comment_editor, |me, _, event, ctx| {
             me.handle_comment_editor_event(event, ctx);
         });
+        // Re-measure the inline composer's reserved height whenever the editor's content re-lays
+        // out, so the block grows and shrinks with the draft.
+        let comment_render_state = comment_editor.as_ref(ctx).inner_render_state(ctx);
+        ctx.observe(&comment_render_state, |me, _, ctx| {
+            me.sync_inline_comment_blocks(ctx);
+        });
 
         Self {
             searcher,
@@ -389,6 +404,7 @@ impl CodeEditorView {
             self_handle: ctx.handle(),
             nav_bar,
             comment_locations: Vec::new(),
+            inline_comments: InlineCommentsController::new(),
             display_options: CodeEditorViewDisplayOptions {
                 vertical_expansion_behavior: render_options.vertical_expansion_behavior,
                 can_show_diff_ui: true,
@@ -422,6 +438,7 @@ impl CodeEditorView {
             last_search_direction: Direction::Forward,
             active_comment_editor: comment_editor,
             comment_save_position_id: format!("code_editor_comment_{}", ctx.view_id()),
+            comment_overlay_position_id: format!("code_editor_comment_overlay_{}", ctx.view_id()),
             show_comment_editor_provider: render_options.show_comment_editor_provider,
             find_references_save_position_id: format!(
                 "code_editor_find_references_{}",
@@ -1111,6 +1128,15 @@ impl CodeEditorView {
         }
     }
 
+    /// Reconcile the rendered inline comment blocks with the current inline views and notify.
+    /// Cheap when nothing changed (see [`InlineCommentsController::sync_blocks`]), so this is safe
+    /// to call on every potential change, including every body-editor layout pass.
+    pub(super) fn sync_inline_comment_blocks(&mut self, ctx: &mut ViewContext<Self>) {
+        self.inline_comments
+            .sync_blocks(&self.model, self.window_id, ctx);
+        ctx.notify();
+    }
+
     fn handle_comment_editor_event(
         &mut self,
         event: &CommentEditorEvent,
@@ -1118,8 +1144,7 @@ impl CodeEditorView {
     ) {
         match event {
             CommentEditorEvent::ContentChanged => {
-                // Handle comment content changes if needed
-                ctx.notify();
+                self.sync_inline_comment_blocks(ctx);
             }
             CommentEditorEvent::CommentSaved {
                 id,
@@ -1139,7 +1164,7 @@ impl CodeEditorView {
                         comments.pending_comment = PendingComment::Closed;
                     });
                 });
-                ctx.notify();
+                self.sync_inline_comment_blocks(ctx);
             }
             CommentEditorEvent::DeleteComment { id } => {
                 ctx.emit(CodeEditorEvent::DeleteComment { id: *id });
@@ -1153,7 +1178,7 @@ impl CodeEditorView {
         comment_text: &str,
         line: &EditorLineLocation,
         ctx: &mut ViewContext<Self>,
-    ) {
+    ) -> EditorReviewComment {
         let line_content = self.model.as_ref(ctx).get_diff_content_for_line(line, ctx);
 
         let review_comment = match id {
@@ -1175,32 +1200,84 @@ impl CodeEditorView {
         });
 
         ctx.emit(CodeEditorEvent::CommentSaved {
-            comment: review_comment,
+            comment: review_comment.clone(),
         });
         ctx.notify();
+        review_comment
     }
 
     /// Update all comment locations in this editor.
+    ///
+    /// Besides the gutter markers (`comment_locations`), this reconciles the embedded inline
+    /// views against the incoming batch via [`InlineCommentsController::reconcile_saved`]. View
+    /// handles are created/destroyed there in `&mut self`, never in `render`.
     pub fn set_comment_locations(
         &mut self,
         comments: impl Iterator<Item = EditorReviewComment>,
         ctx: &mut ViewContext<Self>,
     ) {
-        self.comment_locations.clear();
-        for comment in comments {
+        // Preserve existing MouseStateHandles so hover state survives across refreshes.
+        let prev_handles: HashMap<CommentId, MouseStateHandle> = self
+            .comment_locations
+            .drain(..)
+            .map(|sc| (sc.uuid, sc.mouse_state))
+            .collect();
+
+        let comments: Vec<EditorReviewComment> = comments.collect();
+        for comment in &comments {
+            let mouse_state = prev_handles.get(&comment.id).cloned().unwrap_or_default();
             self.comment_locations.push(SavedComment {
                 uuid: comment.id,
                 location: comment.line.clone(),
-                mouse_state: MouseStateHandle::default(),
+                mouse_state,
             });
         }
-        ctx.notify();
+
+        self.inline_comments.reconcile_saved(comments, ctx);
+        // Reconcile the rendered inline blocks (saved cards + drafts) against the new set.
+        self.sync_inline_comment_blocks(ctx);
+    }
+
+    pub(super) fn handle_inline_comment_event(
+        &mut self,
+        event: &InlineCommentViewEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match event {
+            InlineCommentViewEvent::RequestEdit { id } => {
+                if !self.inline_comments.begin_editing(id, ctx) {
+                    return;
+                }
+                self.sync_inline_comment_blocks(ctx);
+                ctx.emit(CodeEditorEvent::CommentEditorOpened);
+            }
+            InlineCommentViewEvent::RequestRemove { id } => {
+                ctx.emit(CodeEditorEvent::DeleteComment { id: *id });
+            }
+            InlineCommentViewEvent::CommentSaved {
+                id,
+                line,
+                comment_text,
+            } => {
+                let review_comment = self.save_comment(Some(*id), comment_text, line, ctx);
+                self.inline_comments.complete_save(review_comment, ctx);
+                self.sync_inline_comment_blocks(ctx);
+            }
+            InlineCommentViewEvent::Cancelled { id } => {
+                self.inline_comments.cancel(id, ctx);
+                self.sync_inline_comment_blocks(ctx);
+            }
+            InlineCommentViewEvent::ContentChanged => {
+                self.sync_inline_comment_blocks(ctx);
+            }
+        }
     }
 
     /// Clear all comment locations in this editor.
     pub fn clear_comment_locations(&mut self, ctx: &mut ViewContext<Self>) {
         self.comment_locations.clear();
-        ctx.notify();
+        self.inline_comments.clear();
+        self.sync_inline_comment_blocks(ctx);
     }
 
     fn line_number_config(&self, ctx: &AppContext) -> Option<LineNumberConfig> {
@@ -1650,6 +1727,23 @@ impl CodeEditorView {
         render_state_ref.line_number_to_offset_range(line_number)
     }
 
+    /// Content-space top offset and reserved height of the inline comment block anchored at `line`,
+    /// or `None` if no inline block is anchored there (e.g. the comment is outdated or the inline
+    /// feature is off). Used to scroll the card itself — not just its bare line — into view.
+    pub fn comment_block_content_bounds(
+        &self,
+        line: &EditorLineLocation,
+        ctx: &AppContext,
+    ) -> Option<(Pixels, Pixels)> {
+        let render_location = line.clone().into_inline_comment_render_line_location();
+        self.model
+            .as_ref(ctx)
+            .render_state()
+            .as_ref(ctx)
+            .comment_block_position(render_location)
+            .map(|position| (position.start_y_offset, position.content_height))
+    }
+
     pub fn offset_to_lsp_position(
         &self,
         offset: CharOffset,
@@ -1831,9 +1925,7 @@ impl CodeEditorView {
                     first_replace = if first_replace.is_uppercase() {
                         first_replace
                     } else {
-                        {
-                            first_replace.to_uppercase().next().unwrap_or(first_replace)
-                        }
+                        first_replace.to_uppercase().next().unwrap_or(first_replace)
                     };
                     result.push(first_replace);
                     result.push_str(&replace_chars.collect::<String>().to_lowercase());
@@ -2121,6 +2213,18 @@ impl CodeEditorView {
             );
             return;
         }
+        if FeatureFlag::EmbeddedCodeReviewComments.is_enabled() {
+            if !self.inline_comments.begin_editing(id, ctx) {
+                log::warn!(
+                    "open_existing_comment: no inline comment view found for id {:?}",
+                    id
+                );
+                return;
+            }
+            self.sync_inline_comment_blocks(ctx);
+            ctx.emit(CodeEditorEvent::CommentEditorOpened);
+            return;
+        }
 
         self.active_comment_editor
             .update(ctx, |comment_editor, ctx| {
@@ -2136,9 +2240,8 @@ impl CodeEditorView {
         self.model.update(ctx, |editor_model, ctx| {
             editor_model.reopen_comment_line(id, location, comment_text, origin, ctx);
         });
+        self.sync_inline_comment_blocks(ctx);
         ctx.emit(CodeEditorEvent::CommentEditorOpened);
-
-        ctx.notify();
     }
 }
 
@@ -2251,14 +2354,21 @@ impl View for CodeEditorView {
             self.find_references_save_position_id.clone(),
         );
 
-        let pending_comment = &self
-            .model
-            .as_ref(app)
-            .comments()
-            .as_ref(app)
-            .pending_comment;
-        // Check if there's an open comment in the model and set the comment box
-        if let PendingComment::Open { line, .. } = pending_comment {
+        let embedded_comments_enabled = FeatureFlag::EmbeddedCodeReviewComments.is_enabled();
+        let pending_comment = if embedded_comments_enabled {
+            None
+        } else {
+            Some(
+                &self
+                    .model
+                    .as_ref(app)
+                    .comments()
+                    .as_ref(app)
+                    .pending_comment,
+            )
+        };
+        // Check if there's an open legacy floating comment in the model and set the comment box.
+        if let Some(PendingComment::Open { line, .. }) = pending_comment {
             code_editor.set_comment_box(line.clone(), app);
         }
 
@@ -2326,7 +2436,7 @@ impl View for CodeEditorView {
 
         if !FeatureFlag::EmbeddedCodeReviewComments.is_enabled() {
             // Render the open comment editor.
-            if let PendingComment::Open { line, .. } = pending_comment {
+            if let Some(PendingComment::Open { line, .. }) = pending_comment {
                 let render_state_ref = render_state.as_ref(app);
                 let vertical_offset = render_state_ref
                     .vertical_offset_at_render_location(line.clone().into_render_line_location())
@@ -2347,7 +2457,11 @@ impl View for CodeEditorView {
 
                 if should_render_comment_editor {
                     stack.add_positioned_child(
-                        ChildView::new(&self.active_comment_editor).finish(),
+                        SavePosition::new(
+                            ChildView::new(&self.active_comment_editor).finish(),
+                            &self.comment_overlay_position_id,
+                        )
+                        .finish(),
                         OffsetPositioning::offset_from_parent(
                             vec2f(0., vertical_offset.as_f32()),
                             ParentOffsetBounds::ParentByPosition,

--- a/app/src/code/editor/view/actions.rs
+++ b/app/src/code/editor/view/actions.rs
@@ -1086,9 +1086,17 @@ impl TypedActionView for CodeEditorView {
             }
             NewCommentOnLine { line: line_info } => {
                 if FeatureFlag::InlineCodeReview.is_enabled() {
+                    if FeatureFlag::EmbeddedCodeReviewComments.is_enabled() {
+                        let view = self.inline_comments.open_draft(line_info.clone(), ctx);
+                        self.sync_inline_comment_blocks(ctx);
+                        ctx.emit(CodeEditorEvent::CommentEditorOpened);
+                        view.update(ctx, |view, ctx| view.focus_body(ctx));
+                        return;
+                    }
                     self.model.update(ctx, |model: &mut CodeEditorModel, ctx| {
                         model.open_comment_line(line_info, ctx);
                     });
+                    self.sync_inline_comment_blocks(ctx);
                     ctx.emit(CodeEditorEvent::CommentEditorOpened);
 
                     ctx.focus(&self.active_comment_editor);

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -1885,7 +1885,12 @@ impl CodeReviewView {
                 };
 
                 if let AttachedReviewCommentTarget::Line { line, .. } = &comment.target {
-                    self.scroll_to_line(editor_index, line, 0.0, ctx);
+                    // Bring the inline card itself into view — not just its bare line — so a jump
+                    // from the panel reveals the comment. Falls back to the line when no inline
+                    // block is anchored there (inline feature off, or the comment is outdated).
+                    if !self.scroll_inline_comment_into_view(editor_index, line, ctx) {
+                        self.scroll_to_line(editor_index, line, 0.0, ctx);
+                    }
                 } else {
                     self.viewported_list_state
                         .scroll_to_with_offset(editor_index, Pixels::new(0.0));
@@ -2178,6 +2183,62 @@ impl CodeReviewView {
                     - self.viewported_list_state.get_viewport_height(),
             );
         }
+    }
+
+    /// Scrolls the inline comment card anchored at `line` of the editor at `editor_index` into the
+    /// viewport, treating the card's full content-space range (not the bare line) as the target.
+    /// Returns `false` if no inline block is anchored there, so the caller can fall back to
+    /// scrolling the line.
+    fn scroll_inline_comment_into_view(
+        &mut self,
+        editor_index: usize,
+        line: &EditorLineLocation,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
+        let CodeReviewViewState::Loaded(state) = self.state() else {
+            return false;
+        };
+        let Some(editor) = state
+            .file_states
+            .get_index(editor_index)
+            .and_then(|(_, file_state)| file_state.editor_state.as_ref())
+            .map(|editor_state| editor_state.editor.clone())
+        else {
+            return false;
+        };
+        let Some((block_top, block_height)) = editor
+            .as_ref(ctx)
+            .editor()
+            .read(ctx, |code_editor_view, ctx| {
+                code_editor_view.comment_block_content_bounds(line, ctx)
+            })
+        else {
+            return false;
+        };
+
+        let card_top = Pixels::new(FILE_HEADER_HEIGHT) + block_top;
+        let card_bottom = card_top + block_height;
+
+        // Leave the scroll alone if the whole card is already on-screen.
+        if self
+            .viewported_list_state
+            .is_vertical_range_visible(editor_index, card_top, card_bottom)
+        {
+            return true;
+        }
+
+        // Bring the card to the top of the viewport (keeping a small buffer above so the anchor line
+        // stays adjacent), which leaves the rest of the viewport below the card. This deliberately
+        // top-aligns rather than bottom-aligning to the viewport edge so small relayout drift can't
+        // push the card's bottom out of view.
+        self.viewported_list_state
+            .scroll_to_with_offset(editor_index, card_top - Pixels::new(EDITOR_GAP));
+
+        if let Some(context) = self.compute_scroll_context_for_index(editor_index, &editor, ctx) {
+            self.viewported_list_state.set_scroll_context(Some(context));
+        }
+        ctx.notify();
+        true
     }
 
     #[cfg(target_family = "wasm")]

--- a/app/src/code_review/comments/comment.rs
+++ b/app/src/code_review/comments/comment.rs
@@ -14,8 +14,9 @@ pub enum CommentOrigin {
     /// Comments originally created in the Warp UI.
     #[default]
     Native,
-    /// Comments imported from a GitHub pull request.
-    ImportedFromGitHub(ImportedCommentDetails),
+    /// Comments imported from a GitHub pull request. Boxed to keep `CommentOrigin` (and the
+    /// `EditorReviewComment` that carries it through the editor's saved-comment events) small.
+    ImportedFromGitHub(Box<ImportedCommentDetails>),
 }
 
 impl CommentOrigin {
@@ -214,7 +215,7 @@ impl AttachedReviewComment {
             },
             last_update_time: comment.last_update_time,
             outdated: false,
-            origin: CommentOrigin::Native,
+            origin: comment.origin,
         }
     }
 

--- a/app/src/code_review/comments/flatten.rs
+++ b/app/src/code_review/comments/flatten.rs
@@ -107,7 +107,7 @@ fn flatten_pending_imported_thread(
         ));
     }
 
-    let origin = CommentOrigin::ImportedFromGitHub(root.github_details_without_parent());
+    let origin = CommentOrigin::ImportedFromGitHub(Box::new(root.github_details_without_parent()));
 
     AttachedReviewComment {
         id: CommentId::new(),

--- a/crates/editor/src/render/element/mod.rs
+++ b/crates/editor/src/render/element/mod.rs
@@ -41,7 +41,8 @@ use self::text_block::RenderableTextBlock;
 use self::unordered_list::RenderableBulletList;
 use super::model::viewport::{SizeInfo, ViewportItem};
 use super::model::{
-    BlockItem, ElementUpdate, HitTestOptions, Location, RenderState, RichTextStyles, UNIT_MARGIN,
+    BlockItem, ElementUpdate, HitTestOptions, Location, RenderLineLocation, RenderState,
+    RichTextStyles, UNIT_MARGIN,
 };
 use crate::content::version::BufferVersion;
 use crate::editor::EditorView;
@@ -281,8 +282,12 @@ pub trait RenderableBlock {
         false
     }
 
-    fn is_embedded_comment(&self) -> bool {
-        false
+    /// The anchor of the inline comment block backing this renderable, or `None` if this block is
+    /// not an inline comment. Carrying the anchor on the renderable lets gutter rendering classify
+    /// comment rows (including the removed-line side) without a per-frame reverse lookup into the
+    /// content tree.
+    fn embedded_comment_location(&self) -> Option<RenderLineLocation> {
+        None
     }
 
     fn finish(self) -> Box<dyn RenderableBlock>
@@ -906,7 +911,7 @@ impl<V: EditorView> RichTextElement<V> {
                     BlockItem::Table { .. } => RenderableTable::new(item).finish(),
                     BlockItem::TrailingNewLine(_) => Empty::new(item).finish(),
                     BlockItem::Hidden { .. } => RenderableHiddenSection::new(item, ctx).finish(),
-                    BlockItem::Embedded(embed) => {
+                    BlockItem::Embedded(embed) | BlockItem::EmbeddedComment { item: embed, .. } => {
                         let start_offset = item.block_offset;
                         let child_model = parent.embedded_item_at(start_offset, ctx);
                         embed.element(model, item, child_model, ctx)

--- a/crates/editor/src/render/model/debug.rs
+++ b/crates/editor/src/render/model/debug.rs
@@ -124,6 +124,7 @@ impl Describe for BlockItem {
             )?,
             BlockItem::TrailingNewLine(_) => f.write_str("Trailing Newline")?,
             BlockItem::Embedded(_) => f.write_str("Embedded Item")?,
+            BlockItem::EmbeddedComment { .. } => f.write_str("Embedded Comment")?,
             BlockItem::Hidden { .. } => f.write_str("Hidden")?,
         }
 

--- a/crates/editor/src/render/model/location.rs
+++ b/crates/editor/src/render/model/location.rs
@@ -218,6 +218,7 @@ impl<'a> Positioned<'a, BlockItem> {
             | BlockItem::Image { .. }
             | BlockItem::TrailingNewLine(_)
             | BlockItem::TemporaryBlock { .. }
+            | BlockItem::EmbeddedComment { .. }
             | BlockItem::Hidden { .. } => Location::Text {
                 char_offset: self.start_char_offset,
                 clamped: true,

--- a/crates/editor/src/render/model/mod.rs
+++ b/crates/editor/src/render/model/mod.rs
@@ -405,6 +405,11 @@ pub struct RenderState {
     show_final_trailing_newline_when_non_empty: bool,
     has_final_trailing_newline: Cell<bool>,
 
+    /// Whether the content tree currently contains any [`BlockItem::EmbeddedComment`] blocks.
+    /// Updated by `apply_comment_blocks` so that an empty incoming set can skip the full tree
+    /// rebuild when there are no existing comment blocks to remove.
+    has_comment_blocks: Cell<bool>,
+
     width_setting: WidthSetting,
 
     /// Channel for propagating updates from [`super::element::RichTextElement`] such as the
@@ -681,6 +686,32 @@ impl RenderLineLocation {
     }
 }
 
+/// An inline comment block to host on a per-view [`RenderState`]. The child element is supplied by
+/// the app via a [`LaidOutEmbeddedItem`] (the same cross-crate boundary used by markdown embeds),
+/// keeping `warp_editor` independent of app-crate views.
+#[derive(Clone, Debug)]
+pub struct CommentBlock {
+    /// The render line the comment is anchored below.
+    pub location: RenderLineLocation,
+    /// The app-supplied, already laid-out child. Its height determines the reserved block height.
+    pub item: Arc<dyn LaidOutEmbeddedItem>,
+}
+
+impl CommentBlock {
+    pub fn new(location: RenderLineLocation, item: Arc<dyn LaidOutEmbeddedItem>) -> Self {
+        Self { location, item }
+    }
+}
+
+/// Content-space position of an inline comment block.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct CommentBlockPosition {
+    /// Content-space Y offset of the block's top (does not subtract scroll).
+    pub start_y_offset: Pixels,
+    /// The reserved height of the block (equal to the hosted element's laid-out height).
+    pub content_height: Pixels,
+}
+
 /// A point within the editor. Unlike character and hard-wrap offsets/points, this accounts for
 /// soft-wrapping, the layout of different block types, and proportional fonts.
 ///
@@ -789,6 +820,22 @@ pub enum BlockItem {
         paragraph: Paragraph,
     },
     Embedded(Arc<dyn LaidOutEmbeddedItem>),
+    /// A per-view inline comment block. It hosts an app-supplied child element (via
+    /// [`LaidOutEmbeddedItem::element`]) and reserves vertical space equal to that element's
+    /// laid-out height, while contributing no buffer characters or lines (like a
+    /// [`BlockItem::TemporaryBlock`]).
+    ///
+    /// It is intentionally a DISTINCT variant from [`BlockItem::TemporaryBlock`] so that
+    /// `reset_temporary_block` (run on every diff refresh) never removes it, and so it can only
+    /// ever live on a per-view [`RenderState`] — never on the shared buffer.
+    EmbeddedComment {
+        /// The full anchor of this comment. Carrying the location on the block (rather than
+        /// inferring it from tree position) lets `comment_block_position` match a comment by its
+        /// exact [`RenderLineLocation`] — including the `Temporary` removed-line slot index — even
+        /// after `reset_temporary_block` rebuilds the surrounding removed-line blocks.
+        location: RenderLineLocation,
+        item: Arc<dyn LaidOutEmbeddedItem>,
+    },
     HorizontalRule(HorizontalRuleConfig),
     Image {
         alt_text: String,
@@ -1749,6 +1796,7 @@ impl RenderState {
             styles,
             show_final_trailing_newline_when_non_empty: true,
             has_final_trailing_newline: Cell::new(true),
+            has_comment_blocks: Cell::new(false),
             viewport: ViewportState::new(viewport_width, viewport_height),
             selections: Default::default(),
             decorations: Default::default(),
@@ -2398,6 +2446,22 @@ impl RenderState {
                 ctx.emit(RenderEvent::LayoutUpdated);
                 ctx.notify();
             }
+            LayoutAction::SetCommentBlocks(blocks) => {
+                // Comment blocks are supplied already laid out by the app, so they don't require
+                // text layout. When laying out lazily, defer the reconcile to element-layout time
+                // for consistency with temporary blocks; otherwise apply it immediately.
+                if self.lazy_layout {
+                    self.pending_edits
+                        .lock()
+                        .push(PendingLayout::CommentBlocks(blocks));
+                } else {
+                    self.apply_comment_blocks(blocks);
+                    self.update_content_sizing();
+                }
+
+                ctx.emit(RenderEvent::LayoutUpdated);
+                ctx.notify();
+            }
             LayoutAction::BufferEdit {
                 delta,
                 buffer_version,
@@ -2510,6 +2574,9 @@ impl RenderState {
                     PendingLayout::TemporaryBlocks(blocks) => {
                         self.layout_temporary_blocks(blocks, app);
                     }
+                    PendingLayout::CommentBlocks(blocks) => {
+                        self.apply_comment_blocks(blocks);
+                    }
                 };
             }
         }
@@ -2560,6 +2627,211 @@ impl RenderState {
 
     pub fn add_temporary_blocks(&mut self, temporary_blocks: Vec<TemporaryBlock>) {
         self.submit_layout_action(LayoutAction::LayoutTemporaryBlock(temporary_blocks));
+    }
+
+    /// Reconcile the per-view set of inline comment blocks. `blocks` is the complete desired set:
+    /// existing comment blocks not present here are removed, and the supplied blocks are inserted
+    /// at their anchor lines. This is independent of [`Self::add_temporary_blocks`] — comment
+    /// blocks and diff removed-line temporary blocks coexist and never clobber each other.
+    pub fn set_comment_blocks(&mut self, blocks: Vec<CommentBlock>) {
+        self.submit_layout_action(LayoutAction::SetCommentBlocks(blocks));
+    }
+
+    /// Remove all inline comment blocks from this view, leaving temporary blocks untouched.
+    pub fn clear_comment_blocks(&mut self) {
+        self.set_comment_blocks(Vec::new());
+    }
+
+    /// Find the first inline comment block at `location` and map its hosted item through `f`. A
+    /// comment is matched by the FULL `RenderLineLocation` it carries, not by its line alone.
+    /// Because the anchor (including a `Temporary` removed-line slot index) travels on the block
+    /// itself, two comments sharing an `at_line` resolve unambiguously and the match holds even
+    /// after `reset_temporary_block` rebuilds the surrounding removed-line blocks.
+    ///
+    /// Comment blocks contribute zero lines, so every candidate sits exactly at the anchor's line
+    /// boundary: seek there (O(log n)) and scan only that boundary's run instead of walking the
+    /// whole tree. `SeekBias::Left` stops before the zero-extent items at the boundary; the scan
+    /// ends as soon as an item starts past the anchor line.
+    fn with_comment_block_at<T>(
+        &self,
+        location: RenderLineLocation,
+        f: impl FnOnce(Pixels, &Arc<dyn LaidOutEmbeddedItem>) -> T,
+    ) -> Option<T> {
+        let target = location.line_count();
+        let content = self.content.borrow();
+        let mut cursor = content.cursor::<LineCount, LayoutSummary>();
+        cursor.seek_clamped(&target, SeekBias::Left);
+        while let Some(positioned) = cursor.positioned_item() {
+            if positioned.start_line > target {
+                break;
+            }
+            if let BlockItem::EmbeddedComment {
+                location: block_location,
+                item,
+            } = positioned.item
+                && *block_location == location
+            {
+                return Some(f(positioned.start_y_offset, item));
+            }
+            cursor.next();
+        }
+        None
+    }
+
+    /// Content-space position and reserved height of the inline comment block anchored at
+    /// `location`, if one is present. `start_y_offset` is in content space (not viewport space)
+    /// and `content_height` is the hosted element's laid-out height.
+    pub fn comment_block_position(
+        &self,
+        location: RenderLineLocation,
+    ) -> Option<CommentBlockPosition> {
+        self.with_comment_block_at(location, |start_y_offset, item| CommentBlockPosition {
+            start_y_offset,
+            content_height: item.height(),
+        })
+    }
+
+    /// The app-supplied hosted item of the inline comment block anchored at `location`, or `None`
+    /// if no comment block is anchored there. Lets a host resolve the block's rendered content (for
+    /// example its body text) by downcasting the returned [`LaidOutEmbeddedItem`].
+    pub fn comment_block_item(
+        &self,
+        location: RenderLineLocation,
+    ) -> Option<Arc<dyn LaidOutEmbeddedItem>> {
+        self.with_comment_block_at(location, |_, item| item.clone())
+    }
+
+    /// Number of inline comment blocks ([`BlockItem::EmbeddedComment`]) currently in this view's
+    /// content tree, across all anchor lines. Diff removed-line temporary blocks are not counted.
+    pub fn comment_block_count(&self) -> usize {
+        let content = self.content.borrow();
+        let mut cursor = content.cursor::<LineCount, LayoutSummary>();
+        cursor.descend_to_first_item(&content, |_| true);
+        let mut count = 0;
+        while let Some(positioned) = cursor.positioned_item() {
+            if matches!(positioned.item, BlockItem::EmbeddedComment { .. }) {
+                count += 1;
+            }
+            cursor.next();
+        }
+        count
+    }
+
+    /// Group comment blocks by their full anchor [`RenderLineLocation`] and reconcile them into the
+    /// content tree. `Current` anchors are keyed by line; `Temporary` anchors are keyed by both the
+    /// `at_line` and the removed-line slot index, so two comments sharing an `at_line` but targeting
+    /// different removed-line slots do not collide.
+    fn apply_comment_blocks(&self, blocks: Vec<CommentBlock>) {
+        // Fast path: skip the full tree rebuild when nothing changes.
+        if blocks.is_empty() && !self.has_comment_blocks.get() {
+            return;
+        }
+        self.has_comment_blocks.set(!blocks.is_empty());
+
+        let mut current: HashMap<LineCount, Vec<BlockItem>> = HashMap::new();
+        let mut temporary: HashMap<(LineCount, usize), Vec<BlockItem>> = HashMap::new();
+        for block in blocks {
+            let item = BlockItem::EmbeddedComment {
+                location: block.location,
+                item: block.item,
+            };
+            match block.location {
+                RenderLineLocation::Current(line) => {
+                    current.entry(line).or_default().push(item);
+                }
+                RenderLineLocation::Temporary {
+                    at_line,
+                    index_from_at_line,
+                } => {
+                    temporary
+                        .entry((at_line, index_from_at_line))
+                        .or_default()
+                        .push(item);
+                }
+            }
+        }
+        self.reset_comment_blocks(current, temporary);
+    }
+
+    /// Replace all [`BlockItem::EmbeddedComment`]s in the content tree with a new set, keyed by the
+    /// full [`RenderLineLocation`] each block is anchored to. Every other block (including diff
+    /// removed-line [`BlockItem::TemporaryBlock`]s) is preserved exactly.
+    ///
+    /// A `Current(line)` comment is inserted after every block on that line (so it follows any
+    /// removed-line blocks). A `Temporary { at_line, index_from_at_line: k }` comment is inserted
+    /// immediately after the `k`-th removed-line [`BlockItem::TemporaryBlock`] on `at_line`, placing
+    /// it at exactly that removed-line slot. Skipping prior comment blocks while counting temporary
+    /// blocks keeps removed-line slot indices stable regardless of how many comments are anchored.
+    fn reset_comment_blocks(
+        &self,
+        mut current: HashMap<LineCount, Vec<BlockItem>>,
+        mut temporary: HashMap<(LineCount, usize), Vec<BlockItem>>,
+    ) {
+        let mut new_tree = SumTree::new();
+        {
+            let content = self.content.borrow();
+            let mut cursor = content.cursor::<LineCount, CharOffset>();
+
+            // Comments anchored before the first line of content.
+            if let Some(items) = current.remove(&LineCount::zero()) {
+                for item in items {
+                    new_tree.push(item);
+                }
+            }
+
+            cursor.descend_to_first_item(&content, |_| true);
+            let mut last_temp_line: Option<LineCount> = None;
+            let mut temp_index: usize = 0;
+            while let Some(item) = cursor.item() {
+                if !matches!(item, BlockItem::EmbeddedComment { .. }) {
+                    new_tree.push(item.clone());
+                }
+
+                let line_at_end = cursor.end_seek_position();
+
+                // A removed-line block defines a `Temporary` slot. Append any comment anchored to
+                // that exact (at_line, index) slot, then advance the slot index for this line.
+                if matches!(item, BlockItem::TemporaryBlock { .. }) {
+                    temp_index = if last_temp_line == Some(line_at_end) {
+                        temp_index + 1
+                    } else {
+                        0
+                    };
+                    last_temp_line = Some(line_at_end);
+                    if let Some(items) = temporary.remove(&(line_at_end, temp_index)) {
+                        for item in items {
+                            new_tree.push(item);
+                        }
+                    }
+                }
+
+                cursor.next();
+
+                // Once every (possibly zero-line) item on `line_at_end` has been pushed — detected
+                // when the next item begins a later line, or the tree ends — append that line's
+                // `Current` comment blocks. This keeps them after any temporary blocks on the line.
+                let line_complete = match cursor.item() {
+                    None => true,
+                    Some(_) => cursor.end_seek_position() > line_at_end,
+                };
+                if line_complete && let Some(items) = current.remove(&line_at_end) {
+                    for item in items {
+                        new_tree.push(item);
+                    }
+                }
+            }
+        }
+        if !current.is_empty() || !temporary.is_empty() {
+            log::debug!(
+                "reset_comment_blocks: {} current and {} temporary comment blocks had no matching \
+                 anchor line and were dropped",
+                current.len(),
+                temporary.len(),
+            );
+        }
+        self.has_final_trailing_newline
+            .set(Self::tree_ends_with_trailing_newline(&new_tree));
+        *self.content.borrow_mut() = new_tree;
     }
 
     /// Replace all temporary blocks in the BlockItem cache with a new set of temporary
@@ -2662,8 +2934,11 @@ impl RenderState {
             sub_tree_cursor.descend_to_first_item(&sub_tree, |_| true);
 
             while let Some(item) = sub_tree_cursor.item() {
-                // Do not remove the temporary blocks within the replaced range.
-                if matches!(item, BlockItem::TemporaryBlock { .. }) {
+                // Do not remove the temporary or comment blocks within the replaced range.
+                if matches!(
+                    item,
+                    BlockItem::TemporaryBlock { .. } | BlockItem::EmbeddedComment { .. }
+                ) {
                     new_tree.push(item.clone());
                 }
 
@@ -2697,10 +2972,12 @@ impl RenderState {
                 // exclusive, we can't otherwise represent "before the first block".
                 if effective_end > CharOffset::zero() {
                     if let Some(item) = cursor.item() {
-                        // Do not remove the temporary blocks within the replaced range.
-                        if matches!(item, BlockItem::TemporaryBlock { .. })
-                            || (cursor.end() > effective_end
-                                && matches!(item, BlockItem::Hidden(_)))
+                        // Do not remove the temporary or comment blocks within the replaced range.
+                        if matches!(
+                            item,
+                            BlockItem::TemporaryBlock { .. } | BlockItem::EmbeddedComment { .. }
+                        ) || (cursor.end() > effective_end
+                            && matches!(item, BlockItem::Hidden(_)))
                         {
                             new_tree.push(item.clone());
                         }
@@ -3303,6 +3580,7 @@ enum PendingLayout {
         hidden_ranges: Option<RangeSet<CharOffset>>,
     },
     TemporaryBlocks(Vec<TemporaryBlock>),
+    CommentBlocks(Vec<CommentBlock>),
 }
 
 struct PendingSelectionUpdate {
@@ -3326,6 +3604,9 @@ enum LayoutAction {
         buffer_version: BufferVersion,
     },
     LayoutTemporaryBlock(Vec<TemporaryBlock>),
+    /// Reconcile the set of per-view inline comment blocks. The supplied vector is the complete
+    /// desired set: any existing comment blocks not present here are removed.
+    SetCommentBlocks(Vec<CommentBlock>),
     /// Autoscroll, to the specified range if `Some` or to the cursor location if `None`.
     Autoscroll {
         mode: AutoScrollMode,
@@ -3484,7 +3765,11 @@ impl BlockItem {
             BlockItem::HorizontalRule(config) => config.line_height.as_f32(),
             BlockItem::Image { config, .. } => config.height.as_f32(),
             BlockItem::Table(laid_out_table) => laid_out_table.height().as_f32(),
-            BlockItem::Embedded(embedded_item) => embedded_item.height().as_f32(),
+            BlockItem::Embedded(embedded_item)
+            | BlockItem::EmbeddedComment {
+                item: embedded_item,
+                ..
+            } => embedded_item.height().as_f32(),
             BlockItem::Hidden(config) => config.height().as_f32(),
         }
     }
@@ -3508,7 +3793,11 @@ impl BlockItem {
             BlockItem::HorizontalRule(config) => config.spacing,
             BlockItem::Image { config, .. } => config.spacing,
             BlockItem::Table(laid_out_table) => laid_out_table.spacing(),
-            BlockItem::Embedded(embedded_item) => embedded_item.spacing(),
+            BlockItem::Embedded(embedded_item)
+            | BlockItem::EmbeddedComment {
+                item: embedded_item,
+                ..
+            } => embedded_item.spacing(),
             BlockItem::Hidden { .. } => BlockSpacing::default(),
         }
     }
@@ -3541,7 +3830,11 @@ impl BlockItem {
                 }
                 height
             }
-            BlockItem::Embedded(embedded_item) => embedded_item.height(),
+            BlockItem::Embedded(embedded_item)
+            | BlockItem::EmbeddedComment {
+                item: embedded_item,
+                ..
+            } => embedded_item.height(),
             BlockItem::HorizontalRule(rule) => rule.line_height,
             BlockItem::Image { config, .. } => config.height,
             BlockItem::Table(laid_out_table) => laid_out_table.height(),
@@ -3565,7 +3858,9 @@ impl BlockItem {
             } => paragraph_block.width(),
             BlockItem::MermaidDiagram { config, .. } => config.width,
             BlockItem::TrailingNewLine(cursor) => cursor.width,
-            BlockItem::Embedded(object) => object.size().x().into_pixels(),
+            BlockItem::Embedded(object) | BlockItem::EmbeddedComment { item: object, .. } => {
+                object.size().x().into_pixels()
+            }
             BlockItem::HorizontalRule(rule) => rule.width,
             BlockItem::Image { config, .. } => config.width,
             BlockItem::Table(laid_out_table) => laid_out_table.width(),
@@ -3593,7 +3888,9 @@ impl BlockItem {
             BlockItem::RunnableCodeBlock {
                 paragraph_block, ..
             } => paragraph_block.content_length(),
-            BlockItem::TemporaryBlock { .. } => CharOffset::zero(),
+            BlockItem::TemporaryBlock { .. } | BlockItem::EmbeddedComment { .. } => {
+                CharOffset::zero()
+            }
             BlockItem::MermaidDiagram { content_length, .. } => *content_length,
             BlockItem::TrailingNewLine(_)
             | BlockItem::Embedded(_)
@@ -3615,7 +3912,7 @@ impl BlockItem {
             BlockItem::RunnableCodeBlock {
                 paragraph_block, ..
             } => paragraph_block.lines(),
-            BlockItem::TemporaryBlock { .. } => LineCount(0),
+            BlockItem::TemporaryBlock { .. } | BlockItem::EmbeddedComment { .. } => LineCount(0),
             BlockItem::MermaidDiagram { .. } => LineCount(1),
             BlockItem::TrailingNewLine(_)
             | BlockItem::Embedded(_)
@@ -3642,6 +3939,7 @@ impl BlockItem {
             BlockItem::MermaidDiagram { .. } => false,
             // Embeds, images, tables, and horizontal rules are never empty.
             BlockItem::Embedded(_)
+            | BlockItem::EmbeddedComment { .. }
             | BlockItem::HorizontalRule(_)
             | BlockItem::Image { .. }
             | BlockItem::Table(_)
@@ -3701,6 +3999,7 @@ impl Positioned<'_, BlockItem> {
             BlockItem::MermaidDiagram { .. } => self.start_char_offset,
             BlockItem::TrailingNewLine(_)
             | BlockItem::Embedded(_)
+            | BlockItem::EmbeddedComment { .. }
             | BlockItem::HorizontalRule(_)
             | BlockItem::Image { .. }
             | BlockItem::TemporaryBlock { .. }
@@ -3766,6 +4065,7 @@ impl Positioned<'_, BlockItem> {
             }
             BlockItem::TrailingNewLine(_)
             | BlockItem::Embedded(_)
+            | BlockItem::EmbeddedComment { .. }
             | BlockItem::HorizontalRule(_)
             | BlockItem::Image { .. }
             | BlockItem::TemporaryBlock { .. }
@@ -3849,7 +4149,9 @@ impl Positioned<'_, BlockItem> {
                 let origin = self.content_origin();
                 Some(RectF::new(origin, embedded_item.size()))
             }
-            BlockItem::TemporaryBlock { .. } | BlockItem::Hidden { .. } => None,
+            BlockItem::TemporaryBlock { .. }
+            | BlockItem::EmbeddedComment { .. }
+            | BlockItem::Hidden { .. } => None,
         }
     }
 
@@ -3907,7 +4209,9 @@ impl Positioned<'_, BlockItem> {
                 let origin = self.visible_origin();
                 RectF::new(origin, embedded_item.first_line_bound())
             }
-            BlockItem::TemporaryBlock { .. } | BlockItem::Hidden { .. } => return None,
+            BlockItem::TemporaryBlock { .. }
+            | BlockItem::EmbeddedComment { .. }
+            | BlockItem::Hidden { .. } => return None,
         };
 
         // At the block level, we want to include any space for list bullets and other

--- a/specs/embedded-code-review-comments/PRODUCT.md
+++ b/specs/embedded-code-review-comments/PRODUCT.md
@@ -1,0 +1,82 @@
+# Embedded Code Review Comments
+
+## Summary
+Embedded code review comments render directly inside the code review diff at the line they reference. Users can create, read, edit, update, remove, and cancel comments inline without switching to a separate bottom-panel-only workflow, and inline comments should visually behave like part of the diff row rather than like floating overlays.
+
+## Problem
+The previous inline review experience used gutter icons and floating composers that could obscure code, duplicate saved-comment affordances, and shift between different visual treatments when moving from draft to saved state. The desired experience is closer to GitHub's inline review model: the comment appears below the reviewed line, the surrounding diff background continues through the comment area, and saved comments use the same stable comment surface as edits.
+
+## Figma
+Figma: none provided.
+
+## Goals
+- Make line-targeted review comments visible in context, directly below their referenced diff line.
+- Keep the inline comment surface stable when a comment transitions between draft, saved, and editing states.
+- Preserve the existing non-embedded / floating composer behavior when embedded comments are disabled.
+- Keep file-level, general, and outdated comments out of the inline diff surface.
+
+## Non-goals
+- Replacing the bottom review comments panel.
+- Changing how review comments are submitted to agents or GitHub.
+- Supporting threaded inline conversations beyond the existing flattened comment body behavior.
+
+## Behavior
+1. When embedded code review comments are enabled, creating a comment on a diff line opens an inline comment editor directly below that line.
+
+2. The inline editor is anchored to the reviewed line, not to the user's current cursor position or scroll position. Vertical scrolling moves the editor with the surrounding diff content.
+
+3. The inline editor appears below the reviewed line. It must not cover the text of the reviewed line.
+
+4. The diff background for the reviewed hunk continues behind the inline comment editor. Added-line comments continue the added-line background; removed-line comments continue the removed-line background; replacement hunks preserve the correct added or removed side color for the line being commented on.
+
+5. The inline comment editor is horizontally stable relative to the visible editor viewport. Horizontal code scrolling must not clip the comment editor or cause the card to move off-screen with long code lines.
+
+6. Inline comment cards use a consistent shell in draft, saved, and editing states: the same max width, rounded border, background, body padding, footer border, footer padding, and bottom-aligned actions.
+
+7. A new draft comment has an editable body and footer actions for canceling or saving the comment. The primary save action is disabled while the draft body is empty.
+
+8. Saving a new draft converts the same inline comment surface into a saved comment. The transition should not visibly flicker, jump height, swap to a narrower card for a frame, or briefly show an empty editor.
+
+9. Saved comments show the rendered comment body and a footer with lightweight metadata, including relative update time. If a comment was imported from GitHub, the saved/footer metadata includes a GitHub indicator.
+
+10. Saved comments show Edit and Remove actions in the footer. Edit appears to the left of Remove.
+
+11. Selecting Edit on a saved inline comment changes that same comment surface into an editable state. It must not replace the card with a separate editor view or cause a visible size jump.
+
+12. Editing an existing comment shows the saved body as the editable draft, uses an Update primary action, and includes Cancel and Remove actions.
+
+13. Saving an edit updates the same inline comment surface back to saved mode with the updated body.
+
+14. Canceling an edit restores the saved content and returns the same inline comment surface to saved mode.
+
+15. Canceling a new unsaved draft removes that draft from the inline diff surface.
+
+16. Removing a saved inline comment deletes the comment from the review comment set and removes the inline card from the diff.
+
+17. Multiple saved comments on distinct lines render as independent inline cards at their own lines.
+
+18. Comments on the same current line stack without overlapping each other or the surrounding code.
+
+19. Removed-line comments are anchored to the specific removed-line slot they reference, not just to the current line number of the hunk.
+
+20. A removed-line comment and a current-line comment with the same displayed line number are treated as different anchors.
+
+21. When the embedded comments feature is disabled, opening a line comment uses the existing floating comment composer behavior. Lines below the commented line must not be pushed down by an inline block in this mode.
+
+22. When embedded comments are enabled, the old saved-comment gutter icon is hidden for lines that already have inline cards. The inline card itself is the saved-comment affordance.
+
+23. When an inline draft or edit is active on a line, the gutter should not show duplicate comment icons or action buttons for that same inline comment row.
+
+24. Gutter add-comment affordances remain available for changed lines that do not currently have an inline draft or saved inline comment occupying their comment affordance.
+
+25. The inline comment block should not render a duplicate line number for the reserved comment row. Only actual code/diff lines show line numbers.
+
+26. Inline comment cards do not render the diff snippet that bottom-panel comment cards include. The line context is already visible in the surrounding diff.
+
+27. File-level comments, general/diffset comments, and outdated line comments do not render as inline cards in the diff. They remain visible through the existing review comment surfaces.
+
+28. Switching diff modes or refreshing the review comment batch updates inline comment positions to the latest valid line anchors. Comments that can no longer be anchored inline should not leave stale inline cards behind.
+
+29. Inline comments preserve keyboard and focus expectations: opening a draft or edit focuses the editable comment body; saved comments are selectable but not editable; escape/cancel behavior should not discard non-empty drafts unexpectedly.
+
+30. The review experience must remain usable with long code lines, horizontal scrolling, expanded deletion hunks, replacement hunks, and multiple comments in one file.

--- a/specs/embedded-code-review-comments/TECH.md
+++ b/specs/embedded-code-review-comments/TECH.md
@@ -1,0 +1,188 @@
+# Embedded Code Review Comments Technical Spec
+## Context
+This spec implements the behavior described in [`PRODUCT.md`](PRODUCT.md). The legacy floating-overlay path (`CommentEditor`, `PendingComment`) is unchanged and remains active when `FeatureFlag::EmbeddedCodeReviewComments` is off.
+
+**High-level architecture**: each inline comment has one `InlineCommentView` keyed by `CommentId`. When a comment is created or the batch refreshes, `InlineCommentsController` reconciles the view map, reads each view's current height from its inner render state, and pushes a `CommentBlock` to `CodeEditorModel::set_inline_comment_blocks`. The model stores these as `BlockItem::EmbeddedComment` entries in a sumtree alongside regular text blocks and diff removed-line blocks; the sumtree's aggregate layout pushes surrounding lines down by each block's reserved height.
+
+Key files:
+- `app/src/code/editor/inline_comment_view.rs` — stable per-comment view; owns the body editor across all mode transitions
+- `app/src/code/editor/inline_comments.rs` — `InlineCommentsController`; owns the view map and syncs blocks
+- `app/src/code/editor/embedded_comment.rs` — `LaidOutInlineSavedComment` / `RenderableHostedComment` (new inline path) and `EmbeddedCommentSpace` / `LaidOutEmbeddedCommentSpace` (legacy markdown-embed path, see Decision 5)
+- `crates/editor/src/render/model/mod.rs` — `BlockItem::EmbeddedComment`, `apply_comment_blocks`, `reset_comment_blocks`
+- `app/src/code/editor/model.rs` — `CodeEditorModel::set_inline_comment_blocks`
+
+## Design Decision 1: How the editor space grows with content
+The body editor inside each `InlineCommentView` has its own inner `RenderState` whose `height()` reflects the content laid-out height. The outer editor's reserved block height is kept in sync by observing this inner render state and re-pushing an updated `CommentBlock` whenever it changes.
+
+**Data flow**
+
+1. `InlineCommentsController::wire_view` subscribes to the inner render state of each newly created view:
+   ```rust path=app/src/code/editor/inline_comments.rs start=209
+   let inner_render_state = view.as_ref(ctx).inner_render_state(ctx);
+   ctx.observe(&inner_render_state, |me, _, ctx| {
+       me.sync_inline_comment_blocks(ctx);
+   });
+   ```
+2. On every layout pass of the body editor (keystrokes, paste, select-all+delete), `inner_render_state` emits `RenderEvent::LayoutUpdated`, which fires the observer.
+3. `sync_inline_comment_blocks` → `InlineCommentsController::sync_blocks` reads `inline_height()` from each view:
+   ```rust path=app/src/code/editor/inline_comment_view.rs start=277
+   pub fn inline_height(&self, app: &AppContext) -> Pixels {
+       let content_height = self.inner_render_state(app).as_ref(app).height().as_f32();
+       Pixels::new(content_height + comment_chrome_height(&self.save_button, app))
+   }
+   ```
+   `comment_chrome_height` is computed from named constants in `comment_editor.rs` (body padding, footer padding, footer border, outer border) plus the footer button's measured height, so the reserved space tracks button-height scaling automatically.
+4. `sync_blocks` is needed — rather than each view updating its own block independently — because `reset_comment_blocks` replaces the *entire* comment block set atomically in the sumtree. You can't update one view's height in isolation; you must re-collect every view's current height and push the full set together. `sync_blocks` does this: it collects `(RenderLineLocation, Pixels, EntityId)` triples from all views, sorts them deterministically, and compares the result against `last_synced_blocks`. The equality check is critical: the observer fires on *every* body editor layout pass, including keystrokes that don't change the height (e.g. typing horizontally within a single line). Without the early-out, every keystroke in any draft would trigger a full sumtree rebuild.
+5. When the set has changed, `sync_blocks` calls `CodeEditorModel::set_inline_comment_blocks`, which forwards to `RenderState::set_comment_blocks` → `LayoutAction::SetCommentBlocks`.
+6. `apply_comment_blocks` → `reset_comment_blocks` rebuilds the content sumtree with `BlockItem::EmbeddedComment` entries at the new heights. The sumtree is the editor's source of truth for vertical layout: every block's Y offset is derived from the summed heights of all blocks before it, so inserting or resizing a `BlockItem::EmbeddedComment` automatically shifts every line below it.
+
+**Height cap**: editable drafts cap at `MAX_COMMENT_HEIGHT` and scroll internally so a large draft doesn't push all diff lines off-screen. Saved cards use `UNBOUNDED_COMMENT_HEIGHT` so the full comment is always visible inline.
+
+## Design Decision 2: Per-view isolation from the shared buffer
+The editor buffer is shared across all `CodeEditorView`s open on the same file. Spacing for inline comments must not bleed into other views of that file.
+
+**Why `BlockItem::EmbeddedComment` is its own variant**
+
+The existing `BlockItem::TemporaryBlock` is used for removed-line diff blocks and is also per-view. The two block types must coexist and never clobber each other:
+- `reset_temporary_block` (called on every diff refresh) skips `EmbeddedComment` items so comment blocks survive diff reloads.
+- `reset_comment_blocks` (called from `apply_comment_blocks`) skips `TemporaryBlock` items so diff removed-line blocks survive comment updates.
+- `layout_pending_edit` (buffer edits) preserves both variants explicitly.
+
+If `EmbeddedComment` had reused `TemporaryBlock`, a diff refresh would silently erase all inline comment spacing.
+
+**Where the write lands**
+
+`CodeEditorModel::set_inline_comment_blocks` updates `self.render_state`, which is a `ModelHandle<RenderState>` owned exclusively by one `CodeEditorView`'s `CodeEditorModel`. Each `CodeEditorView` has its own `CodeEditorModel` and therefore its own `RenderState`. The shared buffer is never touched.
+
+```rust path=app/src/code/editor/model.rs start=3857
+pub fn set_inline_comment_blocks(
+    &mut self,
+    blocks: Vec<CommentBlock>,
+    ctx: &mut ModelContext<Self>,
+) {
+    self.render_state.update(ctx, |render_state, _| {
+        render_state.set_comment_blocks(blocks)
+    });
+}
+```
+
+**Anchor encoding for removed lines**
+
+Current lines map to `RenderLineLocation::Current(line_number + 1)` so the block appears below the anchor line. Removed lines (which already occupy a `Temporary` slot in the content tree) map to `RenderLineLocation::Temporary { at_line, index_from_at_line }` — the same slot as the removed-line block itself. `reset_comment_blocks` inserts the comment block *after* the matching `TemporaryBlock`, so the comment renders below the removed line without a line-number offset.
+
+## Design Decision 3: Single stable view across all modes
+The old model used a single shared `CommentEditor` for drafts and separate read-only cards for saved comments. Saving called `self.reset(ctx)` on the composer, collapsing the block, then a server round-trip created a new card with the correct height. This caused a visible flash: block collapse → reinsertion.
+
+**The new model**
+
+Each comment has exactly one `InlineCommentView` for its entire lifetime, keyed by `CommentId`. The view owns the same `RichTextEditorView` (body editor) across three internal modes:
+
+- `NewDraft` — editable, no saved content yet; `CommentId` is assigned at creation
+- `EditingExisting` — editable, body pre-loaded with saved content
+- `Saved` — selectable (read-only)
+
+Mode transitions update `InteractionState`, footer buttons, and `saved_content` in place. The body editor's view handle is never replaced.
+
+**Save without a view swap**
+
+`InlineCommentView::save` emits `CommentSaved { id, line, comment_text }`. `CodeEditorView::handle_inline_comment_event` saves the comment, then calls `inline_comments.complete_save(review_comment, ctx)`, which forwards to `InlineCommentView::complete_save` on the *same* view:
+```rust path=app/src/code/editor/inline_comment_view.rs start=213
+pub fn complete_save(&mut self, comment: EditorReviewComment, ctx: &mut ViewContext<Self>) {
+    self.saved_content = comment.comment_content;
+    self.mode = InlineCommentMode::Saved;
+    self.apply_mode(ctx);
+    ctx.notify();
+}
+```
+Because the view and its body editor are unchanged, the block height never collapses and there is no flash.
+
+**When reconciliation fires**
+
+`reconcile_saved` is called from `CodeEditorView::set_comment_locations`, which is called by `CodeReviewView::update_editor_comment_markers`. That method fires in response to `ReviewCommentBatchEvent::Changed`, emitted whenever a comment is upserted, deleted, or relocated (e.g. after a diff mode switch). Understanding this timing matters for the `update_source` guard below: batch updates can arrive while the user is mid-edit.
+
+**Reconciliation preserves view identity**
+
+`InlineCommentsController::reconcile_saved` matches by `CommentId`: existing IDs call `update_source` (in-place metadata/content update) and reuse their handle; only truly new IDs create a new view; IDs absent from the batch are dropped unless they are unsaved drafts.
+
+`update_source` guards the body-editor reset behind `mode == Saved`, so an in-flight edit is never overwritten by a concurrent batch update. If the user is in `EditingExisting` mode when a batch arrives, `saved_content` is updated (so Cancel reverts to the latest server version) but the body editor is left untouched.
+
+## Design Decision 4: Crossing the `warp_editor` crate boundary
+`warp_editor` is a standalone crate with no dependency on the app crate. `InlineCommentView` and `CommentEditor` are app-crate view types, so they can't be referenced directly inside `warp_editor`'s render block interface.
+
+The solution is to pass the view's identity — a `(WindowId, EntityId)` pair — through the `LaidOutEmbeddedItem` trait, and resolve it at render time using `app.view_with_id`. `warp_editor` never holds a typed view handle; it only stores opaque IDs.
+
+`LaidOutInlineSavedComment` (for `InlineCommentView`) and `LaidOutEmbeddedCommentSpace` (for the legacy `CommentEditor`) both follow this pattern:
+```rust path=app/src/code/editor/embedded_comment.rs start=368
+fn inline_view(&self, app: &AppContext) -> Option<ViewHandle<InlineCommentView>> {
+    app.view_with_id::<InlineCommentView>(self.window_id, self.view_entity_id)
+}
+```
+The `element()` method on `LaidOutEmbeddedItem` receives an `&AppContext`, resolves the view handle there, wraps it in a `ChildView`, and returns a `RenderableHostedComment`. If the view can't be resolved (e.g. the window was closed mid-frame), it falls back to a no-op `RenderableEmbeddedCommentSpace` that preserves the block's reserved height without painting anything. Preserving the height rather than collapsing it is intentional: the block's height was set by `sync_blocks` earlier in the same frame, and clearing it would cause a one-frame content jump before the observer can correct it.
+
+## Design Decision 5: Two height-tracking mechanisms (write-back vs. observation)
+`RenderableHostedComment` has an optional `write_back_size` callback. There are two callers that use it differently, and understanding why clarifies `RenderableHostedComment`'s asymmetric construction.
+
+**Context: the legacy `EmbeddedCommentSpace` mechanism**
+
+`EmbeddedCommentSpace` (also in `embedded_comment.rs`) is the older mechanism used when comments were stored as markdown-style embeds in the buffer content. In that model, the comment's reserved height wasn't derived from a render-state observer — it was bootstrapped from a size stored on the `CommentEditor` view itself. `EmbeddedCommentSpace` reads `get_laid_out_size()` from the view during `layout()` and uses that stored value as the block height. The write-back path exists to keep that stored size current.
+
+**Legacy `CommentEditor` path — write-back**: `RenderableHostedComment` calls the write-back after each layout pass to update the stored size on the view:
+```rust path=app/src/code/editor/embedded_comment.rs start=189
+Some(Box::new(move |measured, app| {
+    if let Some(editor) = app.view_with_id::<CommentEditor>(window_id, entity_id) {
+        editor.read(app, |editor, _| editor.set_laid_out_size(measured));
+    }
+}))
+```
+The next `EmbeddedCommentSpace::layout` call reads the stored size back to determine the block's reserved height.
+
+**`InlineCommentView` path — render-state observation**: The inline path passes `None` for `write_back_size`. Height tracking goes through a completely different control flow: `InlineCommentsController::wire_view` observes the body editor's inner `RenderState`; when it changes, the observation fires `sync_inline_comment_blocks` → `sync_blocks` → `set_inline_comment_blocks`, which rebuilds the outer editor's sumtree with the updated height (Decision 1).
+
+**Why write-back can't work for inline views**: write-back has a one-frame lag. It stores the measured height on the view during layout, but the outer editor only learns about that new height on its *next* layout pass when `EmbeddedCommentSpace::layout()` reads the stored value. For `CommentEditor`'s floating overlay, a one-frame lag is acceptable — the overlay is positioned externally and doesn't affect the sumtree. For `InlineCommentView`, the height drives sumtree layout, which determines the Y positions of every line below the block. A stale height means those lines shift by a pixel or more every time the draft grows — a visible jump on each keystroke. The observation approach fires within the same layout cycle as the body editor's layout, so the sumtree is updated before the outer editor computes its final line positions.
+
+The write-back path is retained only to avoid a larger refactor of the legacy `EmbeddedCommentSpace` / `CommentEditor` embedding.
+
+## Design Decision 6: Why `inline_comment_decoration_end` is needed
+The problem is that the diff-hunk colored background (green for added lines, red for removed lines) must visually cover the area occupied by the inline comment editor, not stop at the bottom of the anchor line. Without any special handling, the colored rectangle ends at the last diff line, and the comment card sits against the default editor background — a visible break in the hunk's color.
+
+The simplest fix would be to give each comment block's gutter row a copy of the parent hunk's overlay color so it joins the group naturally. But that would require passing diff-status information into the comment block rendering path, which is currently completely decoupled from diff hunk colors. The extension approach avoids that coupling by post-processing the already-computed decoration bounds.
+
+Diff hunk colored backgrounds are painted in `element.rs` by merging consecutive gutter elements into *groups*. An element joins the current group when its line range matches the group's range and either: its overlay matches (same color), or it has no overlay at all but is part of the same diff range. The merged group is painted as a single rectangle from the group's top to its bottom.
+
+`EmbeddedComment` blocks produce gutter entries with no overlay and a line range that no longer matches the diff hunk's range (the block is anchored *after* its line, not on it). The group collector treats this as a range mismatch and flushes the group early — leaving the comment row uncolored and the background split.
+
+There are two places this needs fixing:
+
+**Overlay group flushing (removed-line backgrounds)**: the group flush path in `element.rs` now checks whether a no-overlay element shares the current group's line range; if so, `end_y` is extended rather than flushing. This keeps removed-line overlay groups contiguous through comment rows in replacement hunks.
+
+**Decoration rectangles (added-line backgrounds)**: the decoration loop separately paints `line_decoration_ranges` as rectangles. `inline_comment_decoration_end` detects whether an inline comment block starts at or very near the decoration's current bottom edge and returns the block's bottom if so:
+```rust path=app/src/code/editor/element.rs start=1510
+for line in comment_lines {
+    if let Some(block_end) =
+        inline_comment_decoration_end(start_y, end_y, line, model)
+    {
+        if block_end > extended_end_y {
+            extended_end_y = block_end;
+        }
+    }
+}
+```
+The outer loop extends the painted rectangle to `extended_end_y` instead of stopping at the bare anchor line.
+
+## Supporting changes
+
+**Gutter icons**: when the `EmbeddedCodeReviewComments` flag is on, saved-comment gutter indicators and diff-hunk action buttons are suppressed for any line that has an inline card or open draft. The inline card itself serves as the visual anchor.
+
+**Horizontal pinning**: inline comment cards reserve vertical space in the content sumtree (so they scroll vertically with their anchor line) but are painted at the viewport's left edge rather than at the code's horizontal scroll position. This is done in `viewport_pinned_origin` by replacing the content rect's x origin with `ctx.bounds.origin_x()` (the visible viewport origin) before calling `child.paint`. Without this, the card would scroll horizontally with long code lines and disappear off-screen on wide diffs.
+
+**Scroll-to-comment**: `CodeReviewView::scroll_inline_comment_into_view` uses `comment_block_content_bounds` (which queries `RenderState::comment_block_position`) to bring the full card — not just its anchor line — into the viewport when jumping from the review panel.
+
+**`MouseStateHandle` preservation**: `set_comment_locations` now collects existing `MouseStateHandle`s by `CommentId` before clearing `comment_locations` and restores them when rebuilding the vec. Previously, a new `MouseStateHandle::default()` was created on every batch refresh, discarding all hover state. Per the WarpUI architecture, a `MouseStateHandle` must be created once during construction and reused; creating one inline during render or refresh breaks all mouse interactions for that element.
+
+## Risks and mitigations
+
+- Risk: `reset_temporary_block` and `reset_comment_blocks` must stay coordinated — if one forgets to preserve the other's variant, comment blocks or diff blocks disappear silently on the next diff refresh or comment sync. Mitigation: each reset skips the other's variant, and `layout_pending_edit` has explicit guards for both.
+- Risk: `inline_height()` reads the inner render state before the first layout pass completes; the height is 0 at that point, causing a one-frame zero-height block. The observer fires after the first layout and corrects it, so the flash lasts at most one frame but is not fully eliminated.
+- Risk: **Outdated comment filtering depends on a second feature flag.** `ReviewCommentBatch::editor_comments_for_file` only filters outdated comments when `FeatureFlag::PRCommentsSlashCommand` is enabled. If `EmbeddedCodeReviewComments` is on but `PRCommentsSlashCommand` is off, outdated line comments pass through `set_comment_locations` and create inline views, violating PRODUCT.md behavior 27. This is an open gap with no current mitigation.
+- Risk: Large saved comments create tall inline blocks that can push most of the diff off-screen. Mitigation: editable drafts cap at `MAX_COMMENT_HEIGHT`; saved cards show at full height intentionally (the whole comment should be visible inline).
+- Risk: The flag-off path (`active_comment_editor`, `PendingComment`) must stay intact. Mitigation: all embedded-path actions are explicitly gated on `FeatureFlag::EmbeddedCodeReviewComments.is_enabled()`.


### PR DESCRIPTION
Support embedded comments in the code review pane behind the  `EmbeddedCodeReviewComments` feature flag.

See product and tech specs for product / technical implementation.

## Demo

This PR introduces inline code review capabilities, allowing users to view and compose comments directly within the diff editor.

Key changes include:
*   **Inline Comment Rendering:** Saved code-review comments are now rendered as per-line cards directly in the diff view.
*   **Composer Integration:** Added a new inline composer primitive that allows users to draft and submit comments without leaving the editor context.
*   **State Synchronization:** Implemented logic to sync saved-comment state into the diff editor's inline-view map, ensuring consistent UI updates.
*   **Improved UX:** Refined styling and layout for the embedded gutter and comment blocks to handle various edge cases.
*   **Cleanup:** Removed legacy automation scripts and documentation related to stale PR management, as these are no longer required.