### PR TITLE
Client: dev-only context-window segment breakdown in usage card

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15181,7 +15181,6 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=a04c490e6dd5d7f9073befb954894a681bf0ea88#a04c490e6dd5d7f9073befb954894a681bf0ea88"
 dependencies = [
  "prost",
  "prost-reflect",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15181,6 +15181,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=6c1a481ec4c39eadd996a2de097ed0ea11384307#6c1a481ec4c39eadd996a2de097ed0ea11384307"
 dependencies = [
  "prost",
  "prost-reflect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -335,7 +335,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "a04c490e6dd5d7f9073befb954894a681bf0ea88" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "6c1a481ec4c39eadd996a2de097ed0ea11384307" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [
@@ -547,8 +547,7 @@ tikv-jemalloc-sys = { git = "https://github.com/warpdotdev/jemallocator.git", re
 
 [patch."https://github.com/warpdotdev/warp-proto-apis.git"]
 # Uncomment for local development of warp-proto-apis
-# TODO: revert and bump the git rev (Cargo.toml:337) once the warp-proto-apis change is merged
-warp_multi_agent_api = { path = "../warp-proto-apis/apis/multi_agent/v1/gen/rust" }
+# warp_multi_agent_api = { path = "../warp-proto-apis/apis/multi_agent/v1/gen/rust" }
 
 [patch."https://github.com/warpdotdev/session-sharing-protocol.git"]
 # Uncomment for local development of session-sharing-protocol

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -547,7 +547,8 @@ tikv-jemalloc-sys = { git = "https://github.com/warpdotdev/jemallocator.git", re
 
 [patch."https://github.com/warpdotdev/warp-proto-apis.git"]
 # Uncomment for local development of warp-proto-apis
-# warp_multi_agent_api = { path = "../warp-proto-apis/apis/multi_agent/v1/gen/rust" }
+# TODO: revert and bump the git rev (Cargo.toml:337) once the warp-proto-apis change is merged
+warp_multi_agent_api = { path = "../warp-proto-apis/apis/multi_agent/v1/gen/rust" }
 
 [patch."https://github.com/warpdotdev/session-sharing-protocol.git"]
 # Uncomment for local development of session-sharing-protocol

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -934,7 +934,6 @@ web_search_ui = []
 web_fetch_ui = []
 fork_from_command = []
 context_window_usage_v2 = []
-# Dev-only: not added to `default`, enable via `cargo run --features context_window_usage_breakdown`.
 context_window_usage_breakdown = []
 global_search = []
 file_and_diff_set_comments = []

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -934,6 +934,8 @@ web_search_ui = []
 web_fetch_ui = []
 fork_from_command = []
 context_window_usage_v2 = []
+# Dev-only: not added to `default`, enable via `cargo run --features context_window_usage_breakdown`.
+context_window_usage_breakdown = []
 global_search = []
 file_and_diff_set_comments = []
 revert_to_checkpoints = []

--- a/app/src/ai/agent/api/convert_conversation_tests.rs
+++ b/app/src/ai/agent/api/convert_conversation_tests.rs
@@ -30,6 +30,7 @@ fn test_server_metadata(
             credits_spent_for_last_block: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
+            context_window_segments: Vec::new(),
         },
         metadata: ServerMetadata {
             uid: ServerId::default(),

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -62,8 +62,8 @@ use crate::ai::skills::SkillDescriptor;
 use crate::code_review::CodeReviewTelemetryEvent;
 use crate::notebooks::NotebookId;
 use crate::persistence::model::{
-    AgentConversationData, ConversationUsageMetadata, ModelTokenUsage, PersistedAutoexecuteMode,
-    ToolUsageMetadata,
+    AgentConversationData, ContextWindowSegment, ConversationUsageMetadata, ModelTokenUsage,
+    PersistedAutoexecuteMode, ToolUsageMetadata,
 };
 use crate::persistence::ModelEvent;
 use crate::server::ids::ServerId;
@@ -671,6 +671,13 @@ impl AIConversation {
 
     pub fn context_window_usage(&self) -> f32 {
         self.conversation_usage_metadata.context_window_usage
+    }
+
+    /// The per-segment breakdown of the context window (e.g. system prompt,
+    /// tool definitions, conversation history). Scaled so the segments sum to
+    /// `context_window_usage`. Empty when the server did not emit segments.
+    pub fn context_window_segments(&self) -> &[ContextWindowSegment] {
+        &self.conversation_usage_metadata.context_window_segments
     }
 
     /// Total credits spent in the conversation, including both LLM inference
@@ -1966,6 +1973,12 @@ impl AIConversation {
                 .as_ref()
                 .map(Into::into)
                 .unwrap_or_default();
+
+            self.conversation_usage_metadata.context_window_segments = usage_metadata
+                .context_window_segments
+                .iter()
+                .map(Into::into)
+                .collect();
 
             // A conversation can never go from summarized to un-summarized,
             // so we only update the summarized flag if it's going from false to true.

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -135,8 +135,10 @@ fn custom_endpoint_usage_metadata(
         summarized: false,
         token_usage: vec![],
         tool_usage_metadata: None,
+        total_input_tokens: 0,
         warp_token_usage: HashMap::new(),
         byok_token_usage: HashMap::new(),
+        context_window_segments: Vec::new(),
         custom_endpoint_token_usage: HashMap::from([(
             config_key.to_string(),
             api::response_event::stream_finished::ModelTokenUsage {
@@ -370,6 +372,7 @@ fn footer_model_token_usage_keeps_custom_endpoint_usage_distinct_from_same_label
             #[allow(deprecated)]
             token_usage: vec![],
             tool_usage_metadata: None,
+            total_input_tokens: 0,
             warp_token_usage: HashMap::new(),
             byok_token_usage: HashMap::from([(
                 "Resolved custom".to_string(),
@@ -387,6 +390,7 @@ fn footer_model_token_usage_keeps_custom_endpoint_usage_distinct_from_same_label
                     token_usage_by_category: HashMap::from([(category.clone(), 6)]),
                 },
             )]),
+            context_window_segments: Vec::new(),
         };
 
         let model_usage =
@@ -433,6 +437,7 @@ fn footer_model_token_usage_preserves_unresolved_custom_endpoint_usage_with_fall
             #[allow(deprecated)]
             token_usage: vec![],
             tool_usage_metadata: None,
+            total_input_tokens: 0,
             warp_token_usage: HashMap::new(),
             byok_token_usage: HashMap::new(),
             custom_endpoint_token_usage: HashMap::from([(
@@ -443,6 +448,7 @@ fn footer_model_token_usage_preserves_unresolved_custom_endpoint_usage_with_fall
                     token_usage_by_category: HashMap::from([(category.clone(), 9)]),
                 },
             )]),
+            context_window_segments: Vec::new(),
         };
 
         let model_usage =

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -790,6 +790,7 @@ fn create_server_conversation_metadata(
             credits_spent_for_last_block: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
+            context_window_segments: Vec::new(),
         },
         metadata: mock_server_metadata(),
         creator: None,

--- a/app/src/ai/agent_sdk/artifact_upload_tests.rs
+++ b/app/src/ai/agent_sdk/artifact_upload_tests.rs
@@ -42,6 +42,7 @@ fn create_conversation_metadata(
             credits_spent_for_last_block: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
+            context_window_segments: Vec::new(),
         },
         metadata: create_mock_server_metadata(),
         creator: None,

--- a/app/src/ai/blocklist/block/status_bar.rs
+++ b/app/src/ai/blocklist/block/status_bar.rs
@@ -987,6 +987,7 @@ fn latest_model_used_before_exchange<V: View>(
                 model_id: model_info.model_id.to_string(),
                 model_display_name: model_info.display_name.clone(),
                 is_fallback: model_info.is_fallback,
+                prompt_cache_expires_at: None,
                 ..Default::default()
             })
         })

--- a/app/src/ai/blocklist/block/status_bar.rs
+++ b/app/src/ai/blocklist/block/status_bar.rs
@@ -988,7 +988,6 @@ fn latest_model_used_before_exchange<V: View>(
                 model_display_name: model_info.display_name.clone(),
                 is_fallback: model_info.is_fallback,
                 prompt_cache_expires_at: None,
-                ..Default::default()
             })
         })
 }

--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -527,6 +527,11 @@ impl BlocklistAIController {
                         .iter()
                         .filter_map(|u| u.to_proto_custom_endpoint_usage())
                         .collect(),
+                    context_window_segments: conversation
+                        .context_window_segments()
+                        .iter()
+                        .map(Into::into)
+                        .collect(),
                 })
         });
 

--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -505,6 +505,7 @@ impl BlocklistAIController {
                     credits_spent: conversation.inference_credits_spent(),
                     platform_credits_spent: conversation.platform_credits_spent(),
                     summarized: conversation.was_summarized(),
+                    total_input_tokens: 0,
                     #[allow(deprecated)]
                     token_usage: conversation
                         .token_usage()

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -1079,6 +1079,7 @@ fn create_server_metadata(
         credits_spent_for_last_block: None,
         token_usage: vec![],
         tool_usage_metadata: Default::default(),
+        context_window_segments: Vec::new(),
     };
 
     ServerAIConversationMetadata {

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -239,6 +239,7 @@ fn make_server_metadata_with_harness(
             credits_spent_for_last_block: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
+            context_window_segments: Vec::new(),
         },
         metadata: ServerMetadata {
             uid: ServerId::default(),

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
 
+use warp_core::features::FeatureFlag;
 use warp_core::ui::theme::color::internal_colors;
 use warp_core::ui::Icon;
 use warpui::elements::{
@@ -25,8 +26,8 @@ use crate::ai::blocklist::view_util::format_credits;
 use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::appearance::Appearance;
 use crate::persistence::model::{
-    token_usage_category_display_name, ModelTokenUsage, FULL_TERMINAL_USE_CATEGORY,
-    PRIMARY_AGENT_CATEGORY,
+    token_usage_category_display_name, ContextWindowSegment, ModelTokenUsage,
+    FULL_TERMINAL_USE_CATEGORY, PRIMARY_AGENT_CATEGORY,
 };
 use crate::ui_components::blended_colors;
 
@@ -45,6 +46,9 @@ pub struct ConversationUsageInfo {
     pub tool_calls: i32,
     pub models: Vec<ModelTokenUsage>,
     pub context_window_usage: f32,
+    /// Per-segment breakdown of the context window. Scaled so the segments
+    /// sum to `context_window_usage`. Empty when the server did not emit it.
+    pub context_window_segments: Vec<ContextWindowSegment>,
     pub files_changed: i32,
     pub lines_added: i32,
     pub lines_removed: i32,
@@ -76,6 +80,8 @@ pub enum ConversationUsageViewAction {
     /// Reveal the truncated rows beyond the first 5 in the per-agent
     /// breakdown.
     ShowAllAgentRows,
+    /// Flip the context-window per-segment breakdown expand toggle.
+    ToggleContextWindowExpanded,
 }
 
 /// View to hold a conversation usage info block.
@@ -107,6 +113,11 @@ pub struct ConversationUsageView {
     /// survives across renders.
     details_toggle_mouse_state: MouseStateHandle,
     show_more_mouse_state: MouseStateHandle,
+    /// Local UI state: whether the context-window per-segment breakdown is
+    /// expanded. Resets on view rebuild, like `details_expanded`.
+    context_window_expanded: bool,
+    /// Mouse state for the context-window breakdown toggle link.
+    context_window_toggle_mouse_state: MouseStateHandle,
 }
 
 impl ConversationUsageView {
@@ -126,6 +137,8 @@ impl ConversationUsageView {
             show_all_clicked: false,
             details_toggle_mouse_state: MouseStateHandle::default(),
             show_more_mouse_state: MouseStateHandle::default(),
+            context_window_expanded: false,
+            context_window_toggle_mouse_state: MouseStateHandle::default(),
         }
     }
 
@@ -197,6 +210,8 @@ impl ConversationUsageView {
             show_all_clicked: false,
             details_toggle_mouse_state: MouseStateHandle::default(),
             show_more_mouse_state: MouseStateHandle::default(),
+            context_window_expanded: false,
+            context_window_toggle_mouse_state: MouseStateHandle::default(),
         }
     }
 
@@ -439,8 +454,9 @@ impl ConversationUsageView {
         labels.push(render_label_text("Context window used", appearance));
         let context_usage_str =
             format!("{}%", (self.usage_info.context_window_usage * 100.).round());
-        let context_window_element = Flex::row()
+        let mut context_window_row = Flex::row()
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_main_axis_size(MainAxisSize::Min)
             .with_spacing(4.)
             .with_child(
                 Text::new(context_usage_str, appearance.ui_font_family(), font_size)
@@ -456,9 +472,15 @@ impl ConversationUsageView {
                 .with_width(font_size)
                 .with_height(font_size)
                 .finish(),
-            )
-            .finish();
-        values.push(context_window_element);
+            );
+        if self.context_window_breakdown_enabled() {
+            context_window_row = context_window_row
+                .with_spacing(8.)
+                .with_child(self.render_context_window_toggle(appearance));
+        }
+        values.push(context_window_row.finish());
+
+        self.append_context_window_segment_rows(&mut labels, &mut values, appearance);
 
         // Space between sections
         labels.push(
@@ -715,6 +737,85 @@ impl ConversationUsageView {
         .finish()
     }
 
+    /// Whether the dev-only per-segment context-window breakdown should be
+    /// offered. Requires the feature flag and at least one server-emitted
+    /// segment.
+    fn context_window_breakdown_enabled(&self) -> bool {
+        FeatureFlag::ContextWindowUsageBreakdown.is_enabled()
+            && !self.usage_info.context_window_segments.is_empty()
+    }
+
+    /// Renders the "View breakdown ▾" / "Hide breakdown ▴" toggle shown
+    /// beside the "Context window used" value when the dev-only breakdown
+    /// is enabled. Styled like [`Self::render_details_toggle`].
+    fn render_context_window_toggle(&self, appearance: &Appearance) -> Box<dyn Element> {
+        let theme = appearance.theme();
+        let font_size = appearance.ui_font_size() + 2.;
+        let link_color = theme.ansi_fg_blue();
+        let icon_size = font_size;
+        let (label, icon) = if self.context_window_expanded {
+            ("Hide breakdown", Icon::ChevronUp)
+        } else {
+            ("View breakdown", Icon::ChevronDown)
+        };
+        Hoverable::new(
+            self.context_window_toggle_mouse_state.clone(),
+            move |_hover_state| {
+                let text_element =
+                    Text::new(label.to_string(), appearance.ui_font_family(), font_size)
+                        .with_color(link_color)
+                        .with_selectable(false)
+                        .finish();
+                let icon_element =
+                    ConstrainedBox::new(icon.to_warpui_icon(link_color.into()).finish())
+                        .with_width(icon_size)
+                        .with_height(icon_size)
+                        .finish();
+                Flex::row()
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_main_axis_size(MainAxisSize::Min)
+                    .with_spacing(4.)
+                    .with_child(text_element)
+                    .with_child(icon_element)
+                    .finish()
+            },
+        )
+        .with_cursor(Cursor::PointingHand)
+        .on_click(|ctx, _, _| {
+            ctx.dispatch_typed_action(ConversationUsageViewAction::ToggleContextWindowExpanded);
+        })
+        .finish()
+    }
+
+    /// Pushes the per-segment context-window breakdown rows into the
+    /// two-column layout when the dev-only breakdown is enabled and
+    /// expanded. Segment percentages are estimated/derived, so the rows
+    /// are introduced by an "ESTIMATED BREAKDOWN" header and each value is
+    /// prefixed with `~` to signal approximation.
+    fn append_context_window_segment_rows(
+        &self,
+        labels: &mut Vec<Box<dyn Element>>,
+        values: &mut Vec<Box<dyn Element>>,
+        appearance: &Appearance,
+    ) {
+        if !self.context_window_breakdown_enabled() || !self.context_window_expanded {
+            return;
+        }
+        labels.push(render_section_header(
+            "ESTIMATED BREAKDOWN".to_string(),
+            appearance,
+        ));
+        values.push(render_section_header("".to_string(), appearance));
+        for segment in &self.usage_info.context_window_segments {
+            labels.push(render_label_text(
+                &token_usage_category_display_name(&segment.name),
+                appearance,
+            ));
+            let pct = (segment.fraction * 100.).round();
+            values.push(render_value_text(format!("~{pct}%"), appearance));
+        }
+    }
+
     /// Renders the avatar + label cell for a per-agent breakdown row,
     /// plus the credit value cell, returned as a `(label, value)` pair so
     /// the caller can append them to the existing two-column flex layout.
@@ -880,6 +981,10 @@ impl TypedActionView for ConversationUsageView {
             }
             ConversationUsageViewAction::ShowAllAgentRows => {
                 self.show_all_clicked = true;
+                ctx.notify();
+            }
+            ConversationUsageViewAction::ToggleContextWindowExpanded => {
+                self.context_window_expanded = !self.context_window_expanded;
                 ctx.notify();
             }
         }

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -1,3 +1,5 @@
+use pathfinder_color::ColorU;
+use pathfinder_geometry::vector::vec2f;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 
@@ -5,8 +7,9 @@ use warp_core::features::FeatureFlag;
 use warp_core::ui::theme::color::internal_colors;
 use warp_core::ui::Icon;
 use warpui::elements::{
-    Border, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Empty, Flex, Hoverable,
-    MainAxisSize, MouseStateHandle, ParentElement, Radius, Text,
+    Border, ChildAnchor, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, DropShadow,
+    Empty, Flex, Hoverable, MainAxisSize, MouseStateHandle, OffsetPositioning, ParentAnchor,
+    ParentElement, ParentOffsetBounds, Radius, Stack, Text,
 };
 use warpui::fonts::{Properties, Weight};
 use warpui::platform::Cursor;
@@ -118,6 +121,8 @@ pub struct ConversationUsageView {
     context_window_expanded: bool,
     /// Mouse state for the context-window breakdown toggle link.
     context_window_toggle_mouse_state: MouseStateHandle,
+    /// Mouse state for the context-window "Other" segment info tooltip.
+    context_window_other_tooltip_mouse_state: MouseStateHandle,
 }
 
 impl ConversationUsageView {
@@ -139,6 +144,7 @@ impl ConversationUsageView {
             show_more_mouse_state: MouseStateHandle::default(),
             context_window_expanded: false,
             context_window_toggle_mouse_state: MouseStateHandle::default(),
+            context_window_other_tooltip_mouse_state: MouseStateHandle::default(),
         }
     }
 
@@ -212,6 +218,7 @@ impl ConversationUsageView {
             show_more_mouse_state: MouseStateHandle::default(),
             context_window_expanded: false,
             context_window_toggle_mouse_state: MouseStateHandle::default(),
+            context_window_other_tooltip_mouse_state: MouseStateHandle::default(),
         }
     }
 
@@ -296,6 +303,13 @@ impl ConversationUsageView {
         let theme = appearance.theme();
         let font_size = appearance.ui_font_size() + 2.;
         let text_color = blended_colors::text_main(theme, theme.surface_2());
+        let context_window_breakdown_enabled = FeatureFlag::ContextWindowUsageBreakdown
+            .is_enabled()
+            && self
+                .usage_info
+                .context_window_segments
+                .iter()
+                .any(|segment| context_window_segment_display_percentage(segment).is_some());
 
         let rollup = self.rollup(app);
 
@@ -452,8 +466,13 @@ impl ConversationUsageView {
         }
 
         labels.push(render_label_text("Context window used", appearance));
-        let context_usage_str =
-            format!("{}%", (self.usage_info.context_window_usage * 100.).round());
+        let context_usage_pct = self.usage_info.context_window_usage * 100.;
+        let context_usage_str = if context_window_breakdown_enabled && self.context_window_expanded
+        {
+            format!("{context_usage_pct:.2}%")
+        } else {
+            format!("{}%", context_usage_pct.round())
+        };
         let mut context_window_row = Flex::row()
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_main_axis_size(MainAxisSize::Min)
@@ -473,14 +492,27 @@ impl ConversationUsageView {
                 .with_height(font_size)
                 .finish(),
             );
-        if self.context_window_breakdown_enabled() {
-            context_window_row = context_window_row
-                .with_spacing(8.)
-                .with_child(self.render_context_window_toggle(appearance));
+        if context_window_breakdown_enabled {
+            context_window_row =
+                context_window_row
+                    .with_spacing(8.)
+                    .with_child(render_toggle_link(
+                        self.context_window_toggle_mouse_state.clone(),
+                        self.context_window_expanded,
+                        "Hide breakdown",
+                        "View breakdown",
+                        ConversationUsageViewAction::ToggleContextWindowExpanded,
+                        appearance,
+                    ));
         }
         values.push(context_window_row.finish());
 
-        self.append_context_window_segment_rows(&mut labels, &mut values, appearance);
+        self.append_context_window_segment_rows(
+            &mut labels,
+            &mut values,
+            context_window_breakdown_enabled,
+            appearance,
+        );
 
         // Space between sections
         labels.push(
@@ -678,7 +710,14 @@ impl ConversationUsageView {
             return value_text;
         }
 
-        let toggle = self.render_details_toggle(appearance);
+        let toggle = render_toggle_link(
+            self.details_toggle_mouse_state.clone(),
+            self.details_expanded,
+            "Hide details",
+            "View details",
+            ConversationUsageViewAction::ToggleDetailsExpanded,
+            appearance,
+        );
         Flex::row()
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_main_axis_size(MainAxisSize::Min)
@@ -688,131 +727,61 @@ impl ConversationUsageView {
             .finish()
     }
 
-    /// Renders the "View details ▾" / "Hide details ▴" toggle link
-    /// rendered to the right of the "Credits spent (total)" value when
-    /// a rollup applies. The link is styled in the theme's hyperlink
-    /// color (`ansi_fg_blue`) — the same color the `FormattedTextElement`
-    /// uses for in-line hyperlinks throughout Agent Mode — so it reads
-    /// as a clickable affordance rather than a passive label. The
-    /// `Hoverable` carries a `PointingHand` cursor on hover; we don't
-    /// also flip the color or weight on hover because `Text` doesn't
-    /// expose an underline knob and changing color in this two-token
-    /// theme system tends to push the link into the accent space.
-    fn render_details_toggle(&self, appearance: &Appearance) -> Box<dyn Element> {
-        let theme = appearance.theme();
-        let font_size = appearance.ui_font_size() + 2.;
-        let link_color = theme.ansi_fg_blue();
-        let icon_size = font_size;
-        let (label, icon) = if self.details_expanded {
-            ("Hide details", Icon::ChevronUp)
-        } else {
-            ("View details", Icon::ChevronDown)
-        };
-        Hoverable::new(
-            self.details_toggle_mouse_state.clone(),
-            move |_hover_state| {
-                let text_element =
-                    Text::new(label.to_string(), appearance.ui_font_family(), font_size)
-                        .with_color(link_color)
-                        .with_selectable(false)
-                        .finish();
-                let icon_element =
-                    ConstrainedBox::new(icon.to_warpui_icon(link_color.into()).finish())
-                        .with_width(icon_size)
-                        .with_height(icon_size)
-                        .finish();
-                Flex::row()
-                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
-                    .with_main_axis_size(MainAxisSize::Min)
-                    .with_spacing(4.)
-                    .with_child(text_element)
-                    .with_child(icon_element)
-                    .finish()
-            },
-        )
-        .with_cursor(Cursor::PointingHand)
-        .on_click(|ctx, _, _| {
-            ctx.dispatch_typed_action(ConversationUsageViewAction::ToggleDetailsExpanded);
-        })
-        .finish()
-    }
-
-    /// Whether the dev-only per-segment context-window breakdown should be
-    /// offered. Requires the feature flag and at least one server-emitted
-    /// segment.
-    fn context_window_breakdown_enabled(&self) -> bool {
-        FeatureFlag::ContextWindowUsageBreakdown.is_enabled()
-            && !self.usage_info.context_window_segments.is_empty()
-    }
-
-    /// Renders the "View breakdown ▾" / "Hide breakdown ▴" toggle shown
-    /// beside the "Context window used" value when the dev-only breakdown
-    /// is enabled. Styled like [`Self::render_details_toggle`].
-    fn render_context_window_toggle(&self, appearance: &Appearance) -> Box<dyn Element> {
-        let theme = appearance.theme();
-        let font_size = appearance.ui_font_size() + 2.;
-        let link_color = theme.ansi_fg_blue();
-        let icon_size = font_size;
-        let (label, icon) = if self.context_window_expanded {
-            ("Hide breakdown", Icon::ChevronUp)
-        } else {
-            ("View breakdown", Icon::ChevronDown)
-        };
-        Hoverable::new(
-            self.context_window_toggle_mouse_state.clone(),
-            move |_hover_state| {
-                let text_element =
-                    Text::new(label.to_string(), appearance.ui_font_family(), font_size)
-                        .with_color(link_color)
-                        .with_selectable(false)
-                        .finish();
-                let icon_element =
-                    ConstrainedBox::new(icon.to_warpui_icon(link_color.into()).finish())
-                        .with_width(icon_size)
-                        .with_height(icon_size)
-                        .finish();
-                Flex::row()
-                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
-                    .with_main_axis_size(MainAxisSize::Min)
-                    .with_spacing(4.)
-                    .with_child(text_element)
-                    .with_child(icon_element)
-                    .finish()
-            },
-        )
-        .with_cursor(Cursor::PointingHand)
-        .on_click(|ctx, _, _| {
-            ctx.dispatch_typed_action(ConversationUsageViewAction::ToggleContextWindowExpanded);
-        })
-        .finish()
-    }
-
     /// Pushes the per-segment context-window breakdown rows into the
     /// two-column layout when the dev-only breakdown is enabled and
-    /// expanded. Segment percentages are estimated/derived, so the rows
-    /// are introduced by an "ESTIMATED BREAKDOWN" header and each value is
-    /// prefixed with `~` to signal approximation.
+    /// expanded. Segment percentages are estimated/derived.
     fn append_context_window_segment_rows(
         &self,
         labels: &mut Vec<Box<dyn Element>>,
         values: &mut Vec<Box<dyn Element>>,
+        context_window_breakdown_enabled: bool,
         appearance: &Appearance,
     ) {
-        if !self.context_window_breakdown_enabled() || !self.context_window_expanded {
+        if !context_window_breakdown_enabled || !self.context_window_expanded {
             return;
         }
-        labels.push(render_section_header(
-            "ESTIMATED BREAKDOWN".to_string(),
-            appearance,
-        ));
-        values.push(render_section_header("".to_string(), appearance));
+        let theme = appearance.theme();
+        let background = theme.surface_2();
+        let font_size = appearance.ui_font_size() + 2.;
+        let label_color = blended_colors::text_disabled(theme, background);
+        let value_color = blended_colors::text_sub(theme, background);
         for segment in &self.usage_info.context_window_segments {
-            labels.push(render_label_text(
-                &token_usage_category_display_name(&segment.name),
-                appearance,
-            ));
-            let pct = (segment.fraction * 100.).round();
-            values.push(render_value_text(format!("~{pct}%"), appearance));
+            let Some(pct) = context_window_segment_display_percentage(segment) else {
+                continue;
+            };
+            let label = Text::new(
+                token_usage_category_display_name(&segment.name),
+                appearance.ui_font_family(),
+                font_size,
+            )
+            .with_color(label_color)
+            .finish();
+            labels.push(if segment.name == "other" {
+                let info_icon = render_context_window_other_info_icon(
+                    appearance,
+                    self.context_window_other_tooltip_mouse_state.clone(),
+                    font_size,
+                );
+                Flex::row()
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_child(label)
+                    .with_child(Container::new(info_icon).with_margin_left(4.).finish())
+                    .finish()
+            } else {
+                label
+            });
+            values.push(
+                Text::new(
+                    format!(
+                        "{pct:.precision$}%",
+                        precision = CONTEXT_WINDOW_SEGMENT_PERCENT_DECIMAL_PLACES
+                    ),
+                    appearance.ui_font_family(),
+                    font_size,
+                )
+                .with_color(value_color)
+                .finish(),
+            );
         }
     }
 
@@ -1036,6 +1005,119 @@ fn render_value_text(text: String, appearance: &Appearance) -> Box<dyn Element> 
         .finish()
 }
 
+/// Renders a hyperlink-styled expand/collapse toggle with a chevron.
+fn render_toggle_link(
+    mouse_state: MouseStateHandle,
+    expanded: bool,
+    expanded_label: &'static str,
+    collapsed_label: &'static str,
+    action: ConversationUsageViewAction,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    let theme = appearance.theme();
+    let font_size = appearance.ui_font_size() + 2.;
+    let link_color = theme.ansi_fg_blue();
+    let icon_size = font_size;
+    let (label, icon) = if expanded {
+        (expanded_label, Icon::ChevronUp)
+    } else {
+        (collapsed_label, Icon::ChevronDown)
+    };
+    Hoverable::new(mouse_state, move |_hover_state| {
+        let text_element = Text::new(label.to_string(), appearance.ui_font_family(), font_size)
+            .with_color(link_color)
+            .with_selectable(false)
+            .finish();
+        let icon_element = ConstrainedBox::new(icon.to_warpui_icon(link_color.into()).finish())
+            .with_width(icon_size)
+            .with_height(icon_size)
+            .finish();
+        Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_main_axis_size(MainAxisSize::Min)
+            .with_spacing(4.)
+            .with_child(text_element)
+            .with_child(icon_element)
+            .finish()
+    })
+    .with_cursor(Cursor::PointingHand)
+    .on_click(move |ctx, _, _| {
+        ctx.dispatch_typed_action(action.clone());
+    })
+    .finish()
+}
+
+/// Returns the display percentage for a context-window segment, or `None`
+/// when that display value would be zero.
+fn context_window_segment_display_percentage(segment: &ContextWindowSegment) -> Option<f32> {
+    let multiplier = 10f32.powi(CONTEXT_WINDOW_SEGMENT_PERCENT_DECIMAL_PLACES as i32);
+    let pct = (segment.fraction * 100. * multiplier).round() / multiplier;
+    (pct != 0.).then_some(pct)
+}
+
+/// Renders the "Other" segment info icon with an unclipped overlay tooltip.
+fn render_context_window_other_info_icon(
+    appearance: &Appearance,
+    mouse_state: MouseStateHandle,
+    font_size: f32,
+) -> Box<dyn Element> {
+    let icon_size = font_size * 0.85;
+    Hoverable::new(mouse_state, move |state| {
+        let icon_color = appearance
+            .theme()
+            .sub_text_color(appearance.theme().surface_2());
+        let icon = ConstrainedBox::new(Icon::Info.to_warpui_icon(icon_color).finish())
+            .with_width(icon_size)
+            .with_height(icon_size)
+            .finish();
+        let mut stack = Stack::new();
+        stack.add_child(icon);
+        if state.is_hovered() {
+            stack.add_positioned_overlay_child(
+                render_context_window_other_tooltip(appearance),
+                OffsetPositioning::offset_from_parent(
+                    vec2f(0., -6.),
+                    ParentOffsetBounds::WindowByPosition,
+                    ParentAnchor::TopMiddle,
+                    ChildAnchor::BottomMiddle,
+                ),
+            );
+        }
+        stack.finish()
+    })
+    .with_cursor(Cursor::PointingHand)
+    .finish()
+}
+
+/// Renders the explanatory tooltip for the context-window "Other" segment.
+fn render_context_window_other_tooltip(appearance: &Appearance) -> Box<dyn Element> {
+    let theme = appearance.theme();
+    let background = theme.tooltip_background();
+    let text = ConstrainedBox::new(
+        Text::new(
+            "Includes other request context and temporary instructions added to help the agent better respond.".to_string(),
+            appearance.ui_font_family(),
+            appearance.ui_font_size() - 2.,
+        )
+        .soft_wrap(true)
+        .with_color(theme.main_text_color(background.into()).into_solid())
+        .finish(),
+    )
+    .with_max_width(CONTEXT_WINDOW_OTHER_TOOLTIP_MAX_WIDTH)
+    .finish();
+    Container::new(text)
+        .with_background_color(background)
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
+        .with_border(Border::all(1.).with_border_color(theme.outline().into_solid()))
+        .with_horizontal_padding(8.)
+        .with_vertical_padding(5.)
+        .with_drop_shadow(
+            DropShadow::new_with_standard_offset_and_spread(ColorU::new(0, 0, 0, 48))
+                .with_offset(vec2f(0., 4.)),
+        )
+        .finish()
+}
+
 /// Renders a placeholder value cell that occupies one full line of the
 /// value column without painting any visible text. Used opposite the
 /// "Show N more" link so the two-column flex stays row-aligned for the
@@ -1063,6 +1145,12 @@ const PER_AGENT_LABEL_MAX_WIDTH: f32 = 110.;
 /// invariants 5e (≤ 5 rows render in full) and 5f (> 5 rows render the
 /// first 5 followed by a "Show N more" link).
 const PER_AGENT_BREAKDOWN_TRUNCATION_CAP: usize = 5;
+
+/// Decimal precision used for visible context-window segment percentages.
+const CONTEXT_WINDOW_SEGMENT_PERCENT_DECIMAL_PLACES: usize = 2;
+
+/// Maximum width of the context-window "Other" tooltip before wrapping.
+const CONTEXT_WINDOW_OTHER_TOOLTIP_MAX_WIDTH: f32 = 280.;
 
 #[cfg(test)]
 #[path = "conversation_usage_view_tests.rs"]

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -1,8 +1,8 @@
-use pathfinder_color::ColorU;
-use pathfinder_geometry::vector::vec2f;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 
+use pathfinder_color::ColorU;
+use pathfinder_geometry::vector::vec2f;
 use warp_core::features::FeatureFlag;
 use warp_core::ui::theme::color::internal_colors;
 use warp_core::ui::Icon;
@@ -1076,7 +1076,7 @@ fn context_window_segment_display_rows(
             let pct = (context_window_usage * (s.token_count as f32) / total_f * 100. * multiplier)
                 .round()
                 / multiplier;
-            (pct != 0.).then(|| (s.segment_type, pct))
+            (pct != 0.).then_some((s.segment_type, pct))
         })
         .collect();
     rows.sort_by(|a, b| match (a.0, b.0) {

--- a/app/src/ai/blocklist/usage/conversation_usage_view.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view.rs
@@ -29,8 +29,8 @@ use crate::ai::blocklist::view_util::format_credits;
 use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::appearance::Appearance;
 use crate::persistence::model::{
-    token_usage_category_display_name, ContextWindowSegment, ModelTokenUsage,
-    FULL_TERMINAL_USE_CATEGORY, PRIMARY_AGENT_CATEGORY,
+    token_usage_category_display_name, ContextWindowSegment, ContextWindowSegmentType,
+    ModelTokenUsage, FULL_TERMINAL_USE_CATEGORY, PRIMARY_AGENT_CATEGORY,
 };
 use crate::ui_components::blended_colors;
 
@@ -305,11 +305,11 @@ impl ConversationUsageView {
         let text_color = blended_colors::text_main(theme, theme.surface_2());
         let context_window_breakdown_enabled = FeatureFlag::ContextWindowUsageBreakdown
             .is_enabled()
-            && self
-                .usage_info
-                .context_window_segments
-                .iter()
-                .any(|segment| context_window_segment_display_percentage(segment).is_some());
+            && !context_window_segment_display_rows(
+                self.usage_info.context_window_usage,
+                &self.usage_info.context_window_segments,
+            )
+            .is_empty();
 
         let rollup = self.rollup(app);
 
@@ -729,7 +729,7 @@ impl ConversationUsageView {
 
     /// Pushes the per-segment context-window breakdown rows into the
     /// two-column layout when the dev-only breakdown is enabled and
-    /// expanded. Segment percentages are estimated/derived.
+    /// expanded. Segment percentages are derived from token counts.
     fn append_context_window_segment_rows(
         &self,
         labels: &mut Vec<Box<dyn Element>>,
@@ -745,18 +745,19 @@ impl ConversationUsageView {
         let font_size = appearance.ui_font_size() + 2.;
         let label_color = blended_colors::text_disabled(theme, background);
         let value_color = blended_colors::text_sub(theme, background);
-        for segment in &self.usage_info.context_window_segments {
-            let Some(pct) = context_window_segment_display_percentage(segment) else {
-                continue;
-            };
+        let rows = context_window_segment_display_rows(
+            self.usage_info.context_window_usage,
+            &self.usage_info.context_window_segments,
+        );
+        for (segment_type, pct) in rows {
             let label = Text::new(
-                token_usage_category_display_name(&segment.name),
+                token_usage_category_display_name(segment_type.as_str()),
                 appearance.ui_font_family(),
                 font_size,
             )
             .with_color(label_color)
             .finish();
-            labels.push(if segment.name == "other" {
+            labels.push(if segment_type == ContextWindowSegmentType::Other {
                 let info_icon = render_context_window_other_info_icon(
                     appearance,
                     self.context_window_other_tooltip_mouse_state.clone(),
@@ -1047,12 +1048,43 @@ fn render_toggle_link(
     .finish()
 }
 
-/// Returns the display percentage for a context-window segment, or `None`
-/// when that display value would be zero.
-fn context_window_segment_display_percentage(segment: &ContextWindowSegment) -> Option<f32> {
+/// Computes the per-segment display rows for the context-window breakdown.
+/// Each row's percentage is derived as
+/// `context_window_usage * token_count / total_positive_segment_token_count * 100`,
+/// so the segments sum to `context_window_usage`. Rows that round to zero
+/// are dropped. Rows are sorted by percentage descending with `Other` last.
+fn context_window_segment_display_rows(
+    context_window_usage: f32,
+    segments: &[ContextWindowSegment],
+) -> Vec<(ContextWindowSegmentType, f32)> {
+    let total: u32 = segments
+        .iter()
+        .map(|s| s.token_count)
+        .filter(|&t| t > 0)
+        .sum();
+    if total == 0 || context_window_usage <= 0. {
+        return Vec::new();
+    }
+    let total_f = total as f32;
     let multiplier = 10f32.powi(CONTEXT_WINDOW_SEGMENT_PERCENT_DECIMAL_PLACES as i32);
-    let pct = (segment.fraction * 100. * multiplier).round() / multiplier;
-    (pct != 0.).then_some(pct)
+    let mut rows: Vec<(ContextWindowSegmentType, f32)> = segments
+        .iter()
+        .filter_map(|s| {
+            if s.token_count == 0 {
+                return None;
+            }
+            let pct = (context_window_usage * (s.token_count as f32) / total_f * 100. * multiplier)
+                .round()
+                / multiplier;
+            (pct != 0.).then(|| (s.segment_type, pct))
+        })
+        .collect();
+    rows.sort_by(|a, b| match (a.0, b.0) {
+        (ContextWindowSegmentType::Other, _) => Ordering::Greater,
+        (_, ContextWindowSegmentType::Other) => Ordering::Less,
+        _ => b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal),
+    });
+    rows
 }
 
 /// Renders the "Other" segment info icon with an unclipped overlay tooltip.

--- a/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
+++ b/app/src/ai/blocklist/usage/conversation_usage_view_tests.rs
@@ -39,6 +39,7 @@ fn placeholder_usage_info() -> ConversationUsageInfo {
         tool_calls: 0,
         models: Vec::new(),
         context_window_usage: 0.0,
+        context_window_segments: Vec::new(),
         files_changed: 0,
         lines_added: 0,
         lines_removed: 0,

--- a/app/src/ai/conversation_details_panel_tests.rs
+++ b/app/src/ai/conversation_details_panel_tests.rs
@@ -185,6 +185,7 @@ fn create_test_server_metadata(
             credits_spent_for_last_block: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
+            context_window_segments: Vec::new(),
         },
         metadata: ServerMetadata {
             uid: ServerId::default(),

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -311,6 +311,8 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::ForkFromCommand,
         #[cfg(feature = "context_window_usage_v2")]
         FeatureFlag::ContextWindowUsageV2,
+        #[cfg(feature = "context_window_usage_breakdown")]
+        FeatureFlag::ContextWindowUsageBreakdown,
         #[cfg(feature = "global_search")]
         FeatureFlag::GlobalSearch,
         #[cfg(feature = "embedded_code_review_comments")]

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -346,6 +346,7 @@ fn test_server_conversation_metadata(
             credits_spent_for_last_block: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
+            context_window_segments: Vec::new(),
         },
         metadata: mock_server_metadata(),
         creator: None,

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -3015,6 +3015,7 @@ fn convert_usage_metadata(
     context_window_usage: f64,
     credits_spent: f64,
     platform_credits_spent: f64,
+    context_window_segments: &[warp_graphql::ai::ContextWindowSegment],
 ) -> ConversationUsageMetadata {
     ConversationUsageMetadata {
         was_summarized: summarized,
@@ -3024,9 +3025,7 @@ fn convert_usage_metadata(
         credits_spent_for_last_block: None,
         token_usage: vec![],
         tool_usage_metadata: Default::default(),
-        // The per-segment context window breakdown is live-stream only;
-        // it is not part of the historical GraphQL conversation metadata.
-        context_window_segments: vec![],
+        context_window_segments: context_window_segments.iter().map(Into::into).collect(),
     }
 }
 
@@ -3039,6 +3038,7 @@ impl TryFrom<warp_graphql::ai::AIConversation> for ServerAIConversationMetadata 
             value.usage.usage_metadata.context_window_usage,
             value.usage.usage_metadata.credits_spent,
             value.usage.usage_metadata.platform_credits_spent,
+            &value.usage.usage_metadata.context_window_segments,
         );
         let metadata = value.metadata.try_into()?;
         let permissions = value.permissions.try_into()?;
@@ -3085,6 +3085,7 @@ impl TryFrom<warp_graphql::queries::list_ai_conversations::AIConversationMetadat
             value.usage.usage_metadata.context_window_usage,
             value.usage.usage_metadata.credits_spent,
             value.usage.usage_metadata.platform_credits_spent,
+            &value.usage.usage_metadata.context_window_segments,
         );
         let metadata = value.metadata.try_into()?;
         let permissions = value.permissions.try_into()?;

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -3024,6 +3024,9 @@ fn convert_usage_metadata(
         credits_spent_for_last_block: None,
         token_usage: vec![],
         tool_usage_metadata: Default::default(),
+        // The per-segment context window breakdown is live-stream only;
+        // it is not part of the historical GraphQL conversation metadata.
+        context_window_segments: vec![],
     }
 }
 

--- a/app/src/terminal/shared_session/replay_agent_conversations.rs
+++ b/app/src/terminal/shared_session/replay_agent_conversations.rs
@@ -191,6 +191,11 @@ fn create_finished_event_from_conversation(conversation: &AIConversation) -> Res
                 .iter()
                 .filter_map(|u| u.to_proto_custom_endpoint_usage())
                 .collect(),
+            context_window_segments: conversation
+                .context_window_segments()
+                .iter()
+                .map(Into::into)
+                .collect(),
         },
     );
 

--- a/app/src/terminal/shared_session/replay_agent_conversations.rs
+++ b/app/src/terminal/shared_session/replay_agent_conversations.rs
@@ -169,6 +169,7 @@ fn create_finished_event_from_conversation(conversation: &AIConversation) -> Res
             credits_spent: conversation.inference_credits_spent(),
             platform_credits_spent: conversation.platform_credits_spent(),
             summarized: conversation.was_summarized(),
+            total_input_tokens: 0,
             #[allow(deprecated)]
             token_usage: conversation
                 .token_usage()

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -6852,6 +6852,7 @@ impl TerminalView {
             tool_calls: tool_usage.total_tool_calls(),
             models: conversation.token_usage().to_vec(),
             context_window_usage: conversation.context_window_usage(),
+            context_window_segments: conversation.context_window_segments().to_vec(),
             files_changed: tool_usage.apply_file_diff_stats.files_changed,
             lines_added: tool_usage.apply_file_diff_stats.lines_added,
             lines_removed: tool_usage.apply_file_diff_stats.lines_removed,

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
@@ -278,6 +278,7 @@ fn server_conversation_metadata(
             credits_spent_for_last_block: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
+            context_window_segments: Vec::new(),
         },
         metadata: server_metadata(creator_uid),
         creator: None,

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -584,6 +584,7 @@ fn server_conversation_metadata(
             credits_spent_for_last_block: None,
             token_usage: vec![],
             tool_usage_metadata: Default::default(),
+            context_window_segments: Vec::new(),
         },
         metadata: ServerMetadata {
             uid: ServerId::default(),

--- a/app/src/workspaces/gql_convert.rs
+++ b/app/src/workspaces/gql_convert.rs
@@ -247,6 +247,7 @@ impl From<&gql_usage::ConversationUsage> for ConversationUsageInfo {
             token_usage: models,
             tool_usage_metadata: tool,
             context_window_usage,
+            context_window_segments,
             ..
         } = (&gql.usage_metadata).into();
         ConversationUsageInfo {
@@ -256,6 +257,7 @@ impl From<&gql_usage::ConversationUsage> for ConversationUsageInfo {
             tool_calls: tool.total_tool_calls(),
             models,
             context_window_usage,
+            context_window_segments,
             files_changed: tool.apply_file_diff_stats.files_changed,
             lines_added: tool.apply_file_diff_stats.lines_added,
             lines_removed: tool.apply_file_diff_stats.lines_removed,

--- a/crates/graphql/src/api/ai.rs
+++ b/crates/graphql/src/api/ai.rs
@@ -173,19 +173,42 @@ pub struct ConversationUsageMetadata {
     pub summarized: bool,
 }
 
+#[derive(cynic::Enum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ContextWindowSegmentType {
+    Unknown,
+    SystemPrompt,
+    ToolDefinitions,
+    ConversationHistory,
+    LatestInput,
+    Images,
+    Other,
+}
+
 #[derive(cynic::QueryFragment, Debug, Clone)]
 pub struct ContextWindowSegment {
-    pub name: String,
+    pub segment_type: ContextWindowSegmentType,
     pub token_count: i32,
-    pub fraction: f64,
+}
+
+impl From<ContextWindowSegmentType> for persistence::model::ContextWindowSegmentType {
+    fn from(value: ContextWindowSegmentType) -> Self {
+        match value {
+            ContextWindowSegmentType::Unknown => Self::Unknown,
+            ContextWindowSegmentType::SystemPrompt => Self::SystemPrompt,
+            ContextWindowSegmentType::ToolDefinitions => Self::ToolDefinitions,
+            ContextWindowSegmentType::ConversationHistory => Self::ConversationHistory,
+            ContextWindowSegmentType::LatestInput => Self::LatestInput,
+            ContextWindowSegmentType::Images => Self::Images,
+            ContextWindowSegmentType::Other => Self::Other,
+        }
+    }
 }
 
 impl From<&ContextWindowSegment> for persistence::model::ContextWindowSegment {
     fn from(gql: &ContextWindowSegment) -> Self {
         Self {
-            name: gql.name.clone(),
+            segment_type: gql.segment_type.into(),
             token_count: u32::try_from(gql.token_count).unwrap_or_default(),
-            fraction: gql.fraction as f32,
         }
     }
 }

--- a/crates/graphql/src/api/ai.rs
+++ b/crates/graphql/src/api/ai.rs
@@ -167,7 +167,25 @@ pub struct ConversationUsage {
 #[derive(cynic::QueryFragment, Debug, Clone)]
 pub struct ConversationUsageMetadata {
     pub context_window_usage: f64,
+    pub context_window_segments: Vec<ContextWindowSegment>,
     pub credits_spent: f64,
     pub platform_credits_spent: f64,
     pub summarized: bool,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+pub struct ContextWindowSegment {
+    pub name: String,
+    pub token_count: i32,
+    pub fraction: f64,
+}
+
+impl From<&ContextWindowSegment> for persistence::model::ContextWindowSegment {
+    fn from(gql: &ContextWindowSegment) -> Self {
+        Self {
+            name: gql.name.clone(),
+            token_count: u32::try_from(gql.token_count).unwrap_or_default(),
+            fraction: gql.fraction as f32,
+        }
+    }
 }

--- a/crates/graphql/src/api/queries/get_conversation_usage.rs
+++ b/crates/graphql/src/api/queries/get_conversation_usage.rs
@@ -124,11 +124,21 @@ pub struct ConversationUsageMetadata {
     pub tool_usage_metadata: ToolUsageMetadata,
 }
 
+#[derive(cynic::Enum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ContextWindowSegmentType {
+    Unknown,
+    SystemPrompt,
+    ToolDefinitions,
+    ConversationHistory,
+    LatestInput,
+    Images,
+    Other,
+}
+
 #[derive(cynic::QueryFragment, Debug, Clone)]
 pub struct ContextWindowSegment {
-    pub name: String,
+    pub segment_type: ContextWindowSegmentType,
     pub token_count: i32,
-    pub fraction: f64,
 }
 
 fn convert_token_usage(
@@ -189,12 +199,25 @@ impl From<&ConversationUsageMetadata> for persistence::model::ConversationUsageM
     }
 }
 
+impl From<ContextWindowSegmentType> for persistence::model::ContextWindowSegmentType {
+    fn from(value: ContextWindowSegmentType) -> Self {
+        match value {
+            ContextWindowSegmentType::Unknown => Self::Unknown,
+            ContextWindowSegmentType::SystemPrompt => Self::SystemPrompt,
+            ContextWindowSegmentType::ToolDefinitions => Self::ToolDefinitions,
+            ContextWindowSegmentType::ConversationHistory => Self::ConversationHistory,
+            ContextWindowSegmentType::LatestInput => Self::LatestInput,
+            ContextWindowSegmentType::Images => Self::Images,
+            ContextWindowSegmentType::Other => Self::Other,
+        }
+    }
+}
+
 impl From<&ContextWindowSegment> for persistence::model::ContextWindowSegment {
     fn from(gql: &ContextWindowSegment) -> Self {
         Self {
-            name: gql.name.clone(),
+            segment_type: gql.segment_type.into(),
             token_count: u32::try_from(gql.token_count).unwrap_or_default(),
-            fraction: gql.fraction as f32,
         }
     }
 }

--- a/crates/graphql/src/api/queries/get_conversation_usage.rs
+++ b/crates/graphql/src/api/queries/get_conversation_usage.rs
@@ -176,6 +176,9 @@ impl From<&ConversationUsageMetadata> for persistence::model::ConversationUsageM
             credits_spent_for_last_block: None,
             token_usage: convert_token_usage(&gql.warp_token_usage, &gql.byok_token_usage),
             tool_usage_metadata: (&gql.tool_usage_metadata).into(),
+            // The per-segment context window breakdown is live-stream only;
+            // it is not part of the historical GraphQL usage payload.
+            context_window_segments: Vec::new(),
         }
     }
 }

--- a/crates/graphql/src/api/queries/get_conversation_usage.rs
+++ b/crates/graphql/src/api/queries/get_conversation_usage.rs
@@ -114,6 +114,7 @@ pub struct ConversationUsage {
 #[derive(cynic::QueryFragment, Debug, Clone)]
 pub struct ConversationUsageMetadata {
     pub context_window_usage: f64,
+    pub context_window_segments: Vec<ContextWindowSegment>,
     pub credits_spent: f64,
     pub platform_credits_spent: f64,
     pub summarized: bool,
@@ -121,6 +122,13 @@ pub struct ConversationUsageMetadata {
     pub warp_token_usage: Vec<TokenUsage>,
     pub byok_token_usage: Vec<TokenUsage>,
     pub tool_usage_metadata: ToolUsageMetadata,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+pub struct ContextWindowSegment {
+    pub name: String,
+    pub token_count: i32,
+    pub fraction: f64,
 }
 
 fn convert_token_usage(
@@ -176,9 +184,17 @@ impl From<&ConversationUsageMetadata> for persistence::model::ConversationUsageM
             credits_spent_for_last_block: None,
             token_usage: convert_token_usage(&gql.warp_token_usage, &gql.byok_token_usage),
             tool_usage_metadata: (&gql.tool_usage_metadata).into(),
-            // The per-segment context window breakdown is live-stream only;
-            // it is not part of the historical GraphQL usage payload.
-            context_window_segments: Vec::new(),
+            context_window_segments: gql.context_window_segments.iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<&ContextWindowSegment> for persistence::model::ContextWindowSegment {
+    fn from(gql: &ContextWindowSegment) -> Self {
+        Self {
+            name: gql.name.clone(),
+            token_count: u32::try_from(gql.token_count).unwrap_or_default(),
+            fraction: gql.fraction as f32,
         }
     }
 }

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -1361,24 +1361,96 @@ impl From<&stream_finished::ToolUsageMetadata> for ToolUsageMetadata {
     }
 }
 
-/// A single named portion of the context window (e.g. "system_prompt"),
-/// scaled so the segments sum to `context_window_usage`.
+/// The kind of a context-window segment, mirroring the proto
+/// `ContextWindowSegmentType` enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextWindowSegmentType {
+    #[default]
+    Unknown,
+    SystemPrompt,
+    ToolDefinitions,
+    ConversationHistory,
+    LatestInput,
+    Images,
+    Other,
+}
+
+impl ContextWindowSegmentType {
+    /// Snake-case identifier used for display-name lookup.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ContextWindowSegmentType::Unknown => "unknown",
+            ContextWindowSegmentType::SystemPrompt => "system_prompt",
+            ContextWindowSegmentType::ToolDefinitions => "tool_definitions",
+            ContextWindowSegmentType::ConversationHistory => "conversation_history",
+            ContextWindowSegmentType::LatestInput => "latest_input",
+            ContextWindowSegmentType::Images => "images",
+            ContextWindowSegmentType::Other => "other",
+        }
+    }
+}
+
+impl From<i32> for ContextWindowSegmentType {
+    fn from(value: i32) -> Self {
+        match stream_finished::ContextWindowSegmentType::try_from(value) {
+            Ok(stream_finished::ContextWindowSegmentType::SystemPrompt) => Self::SystemPrompt,
+            Ok(stream_finished::ContextWindowSegmentType::ToolDefinitions) => Self::ToolDefinitions,
+            Ok(stream_finished::ContextWindowSegmentType::ConversationHistory) => {
+                Self::ConversationHistory
+            }
+            Ok(stream_finished::ContextWindowSegmentType::LatestInput) => Self::LatestInput,
+            Ok(stream_finished::ContextWindowSegmentType::Images) => Self::Images,
+            Ok(stream_finished::ContextWindowSegmentType::Other) => Self::Other,
+            // Unknown (0) and any unrecognized value map to Unknown.
+            _ => Self::Unknown,
+        }
+    }
+}
+
+impl From<ContextWindowSegmentType> for i32 {
+    fn from(value: ContextWindowSegmentType) -> Self {
+        match value {
+            ContextWindowSegmentType::Unknown => {
+                stream_finished::ContextWindowSegmentType::Unknown as i32
+            }
+            ContextWindowSegmentType::SystemPrompt => {
+                stream_finished::ContextWindowSegmentType::SystemPrompt as i32
+            }
+            ContextWindowSegmentType::ToolDefinitions => {
+                stream_finished::ContextWindowSegmentType::ToolDefinitions as i32
+            }
+            ContextWindowSegmentType::ConversationHistory => {
+                stream_finished::ContextWindowSegmentType::ConversationHistory as i32
+            }
+            ContextWindowSegmentType::LatestInput => {
+                stream_finished::ContextWindowSegmentType::LatestInput as i32
+            }
+            ContextWindowSegmentType::Images => {
+                stream_finished::ContextWindowSegmentType::Images as i32
+            }
+            ContextWindowSegmentType::Other => {
+                stream_finished::ContextWindowSegmentType::Other as i32
+            }
+        }
+    }
+}
+
+/// A single portion of the context window, described by its kind and an
+/// estimated token count. Segment token counts add up to the token total
+/// represented by `context_window_usage`.
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ContextWindowSegment {
-    /// Server-defined segment name (e.g. "system_prompt", "tool_definitions").
-    pub name: String,
+    pub segment_type: ContextWindowSegmentType,
     /// Estimated number of tokens this segment occupies in the context window.
     pub token_count: u32,
-    /// Fraction of the model's context window this segment occupies.
-    pub fraction: f32,
 }
 
 impl From<&stream_finished::ContextWindowSegment> for ContextWindowSegment {
     fn from(segment: &stream_finished::ContextWindowSegment) -> Self {
         Self {
-            name: segment.name.clone(),
+            segment_type: segment.segment_type.into(),
             token_count: segment.token_count,
-            fraction: segment.fraction,
         }
     }
 }
@@ -1386,9 +1458,8 @@ impl From<&stream_finished::ContextWindowSegment> for ContextWindowSegment {
 impl From<&ContextWindowSegment> for stream_finished::ContextWindowSegment {
     fn from(segment: &ContextWindowSegment) -> Self {
         Self {
-            name: segment.name.clone(),
+            segment_type: segment.segment_type.into(),
             token_count: segment.token_count,
-            fraction: segment.fraction,
         }
     }
 }

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -1361,6 +1361,38 @@ impl From<&stream_finished::ToolUsageMetadata> for ToolUsageMetadata {
     }
 }
 
+/// A single named portion of the context window (e.g. "system_prompt"),
+/// scaled so the segments sum to `context_window_usage`.
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct ContextWindowSegment {
+    /// Server-defined segment name (e.g. "system_prompt", "tool_definitions").
+    pub name: String,
+    /// Estimated number of tokens this segment occupies in the context window.
+    pub token_count: u32,
+    /// Fraction of the model's context window this segment occupies.
+    pub fraction: f32,
+}
+
+impl From<&stream_finished::ContextWindowSegment> for ContextWindowSegment {
+    fn from(segment: &stream_finished::ContextWindowSegment) -> Self {
+        Self {
+            name: segment.name.clone(),
+            token_count: segment.token_count,
+            fraction: segment.fraction,
+        }
+    }
+}
+
+impl From<&ContextWindowSegment> for stream_finished::ContextWindowSegment {
+    fn from(segment: &ContextWindowSegment) -> Self {
+        Self {
+            name: segment.name.clone(),
+            token_count: segment.token_count,
+            fraction: segment.fraction,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ConversationUsageMetadata {
     pub was_summarized: bool,
@@ -1374,6 +1406,8 @@ pub struct ConversationUsageMetadata {
     pub token_usage: Vec<ModelTokenUsage>,
     #[serde(default)]
     pub tool_usage_metadata: ToolUsageMetadata,
+    #[serde(default)]
+    pub context_window_segments: Vec<ContextWindowSegment>,
 }
 
 impl ConversationUsageMetadata {

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -512,6 +512,10 @@ pub enum FeatureFlag {
     /// Enables v2 of the context window usage UI.
     ContextWindowUsageV2,
 
+    /// Dev-only: enables the expandable per-segment context window usage
+    /// breakdown in the conversation usage card.
+    ContextWindowUsageBreakdown,
+
     /// Enables global search
     GlobalSearch,
 

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -955,6 +955,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::WarpControlCli,
     FeatureFlag::PromptCacheExpiryWarning,
     FeatureFlag::PinnedTabs,
+    FeatureFlag::ContextWindowUsageBreakdown,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -780,6 +780,18 @@ type ContentDataFieldValue {
 
 scalar ContentHash
 
+"""A single named portion of the context window (e.g. "system_prompt")."""
+type ContextWindowSegment {
+  """The fraction of the model's context window this segment occupies."""
+  fraction: Float!
+
+  """The server-defined segment name (e.g. system_prompt, tool_definitions)."""
+  name: String!
+
+  """The estimated number of tokens this segment occupies."""
+  tokenCount: Int!
+}
+
 """Represents usage data for a single multi-agent conversation."""
 type ConversationUsage {
   conversationId: String!
@@ -792,6 +804,12 @@ type ConversationUsage {
 type ConversationUsageMetadata {
   """Token usage using a user's API key, keyed by model."""
   byokTokenUsage: [TokenUsage!]!
+
+  """
+  A breakdown of the context window usage into named segments, scaled so
+  they sum to contextWindowUsage.
+  """
+  contextWindowSegments: [ContextWindowSegment!]!
   contextWindowUsage: Float!
 
   """The total number of inference credits spent so far in the conversation"""

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -780,13 +780,21 @@ type ContentDataFieldValue {
 
 scalar ContentHash
 
-"""A single named portion of the context window (e.g. "system_prompt")."""
-type ContextWindowSegment {
-  """The fraction of the model's context window this segment occupies."""
-  fraction: Float!
+"""The kind of a context-window segment."""
+enum ContextWindowSegmentType {
+  UNKNOWN
+  SYSTEM_PROMPT
+  TOOL_DEFINITIONS
+  CONVERSATION_HISTORY
+  LATEST_INPUT
+  IMAGES
+  OTHER
+}
 
-  """The server-defined segment name (e.g. system_prompt, tool_definitions)."""
-  name: String!
+"""A single portion of the context window, described by its kind and token count."""
+type ContextWindowSegment {
+  """The kind of context window segment this entry represents."""
+  segmentType: ContextWindowSegmentType!
 
   """The estimated number of tokens this segment occupies."""
   tokenCount: Int!
@@ -806,8 +814,10 @@ type ConversationUsageMetadata {
   byokTokenUsage: [TokenUsage!]!
 
   """
-  A breakdown of the context window usage into named segments, scaled so
-  they sum to contextWindowUsage.
+  A breakdown of the context window usage into segments, each carrying a
+  kind and token count. Segment token counts add up to the token total
+  represented by contextWindowUsage. The client derives per-segment
+  percentages.
   """
   contextWindowSegments: [ContextWindowSegment!]!
   contextWindowUsage: Float!


### PR DESCRIPTION
## Description

This PR adds a dev-only (for now) detailed view of how the model's context window is being used up, between things like images, input, conversation history, system prompt, etc. The server passes this information to the client w/ this [server-side change](https://github.com/warpdotdev/warp-server/pull/11895), and then the client can easily display the new info in a sub-section of the context window section in the conversation usage footer. This sub-section follows the existing design of the credit usage dropdown for child agent credit usage in orchestrated conversations (in the same usage footer).

## Demo

https://www.loom.com/share/aef838b2f63c48fa9c20551caa2017e3

_Conversation: https://staging.warp.dev/conversation/95bb9b48-02cf-4f8d-a157-bc4653694e6f_
_Run: https://oz.staging.warp.dev/runs/019ecbbe-4836-75e3-987f-656c693aa297_

_This PR was generated with [Oz](https://warp.dev/oz)._
