### PR TITLE
Show cloud environment setup steps in tab name instead of setup command

### DIFF
--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -119,10 +119,16 @@ impl TerminalView {
         let is_ambient_agent = self.is_ambient_agent_session(ctx);
         let selected_conversation_title = self.selected_conversation_display_title(ctx);
         let selected_cli_agent_title = self.selected_cli_agent_title_for_chrome(ctx);
+        let cloud_setup_status = self.cloud_agent_setup_status_text(ctx);
 
-        // Prefer CLI agent session text before the terminal title,
+        // While a cloud agent is provisioning its environment, show the setup step
+        // (e.g. "Connecting to Host") rather than the raw setup command.
+        // Otherwise prefer CLI agent session text before the terminal title,
         // matching the vertical-tab behavior in terminal_primary_line_data().
-        let new_pane_title = if let Some(cli_agent_title) = selected_cli_agent_title {
+        let new_pane_title = if let Some(setup_status) = cloud_setup_status {
+            self.is_using_conversation_for_pane_header_title = false;
+            setup_status
+        } else if let Some(cli_agent_title) = selected_cli_agent_title {
             self.is_using_conversation_for_pane_header_title = false;
             cli_agent_title
         } else if self.is_long_running_and_user_controlled() && !self.terminal_title.is_empty() {
@@ -963,6 +969,31 @@ impl TerminalView {
             &model,
             ctx,
         )
+    }
+
+    /// User-facing setup-step text for tab and pane titles while this cloud (ambient) agent
+    /// pane provisions its environment, e.g. "Connecting to Host (Step 1/3)" or
+    /// "Running setup commands...". Returns `None` for non-cloud sessions and once setup is
+    /// done, so titles fall back to the conversation title or terminal command.
+    pub fn cloud_agent_setup_status_text(&self, ctx: &AppContext) -> Option<String> {
+        if !self.is_ambient_agent_session(ctx) {
+            return None;
+        }
+        let model = self.ambient_agent_view_model.as_ref()?.as_ref(ctx);
+        if model.is_waiting_for_session() {
+            if let Some(progress) = model.agent_progress() {
+                return Some(progress.setup_status_text().to_string());
+            }
+        }
+        if self
+            .model
+            .lock()
+            .block_list()
+            .is_executing_oz_environment_startup_commands()
+        {
+            return Some("Running setup commands...".to_string());
+        }
+        None
     }
 
     /// Selected conversation status for chrome, or [`ConversationStatus::InProgress`] while the

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -3487,6 +3487,7 @@ fn build_vertical_tabs_summary_data(
 
                 let primary_label = terminal_primary_line_data(
                     terminal_view.is_long_running_and_user_controlled(),
+                    terminal_view.cloud_agent_setup_status_text(app),
                     conversation_display_title,
                     cli_agent_title,
                     title_text.as_str(),
@@ -3757,6 +3758,7 @@ fn terminal_pane_search_text_fragments(
         .unwrap_or_else(|| {
             terminal_primary_line_data(
                 terminal_view.is_long_running_and_user_controlled(),
+                terminal_view.cloud_agent_setup_status_text(app),
                 conversation_display_title,
                 cli_agent_title,
                 title_text.as_str(),
@@ -3803,8 +3805,10 @@ fn terminal_search_text_fragments(
     fragments
 }
 
+#[allow(clippy::too_many_arguments)]
 fn terminal_primary_line_data(
     is_long_running: bool,
+    cloud_setup_status: Option<String>,
     conversation_display_title: Option<String>,
     cli_agent_title: Option<String>,
     terminal_title: &str,
@@ -3814,6 +3818,13 @@ fn terminal_primary_line_data(
 ) -> TerminalPrimaryLineData {
     let trimmed_title = terminal_title.trim();
     let trimmed_working_directory = working_directory.trim();
+    // While a cloud agent is provisioning its environment, surface the setup step instead of
+    // the raw setup command that would otherwise win via the long-running branch below.
+    if let Some(cloud_setup_status) = cloud_setup_status {
+        return TerminalPrimaryLineData::StatusText {
+            text: cloud_setup_status,
+        };
+    }
     if let Some(cli_agent_title) = cli_agent_title {
         return TerminalPrimaryLineData::StatusText {
             text: cli_agent_title,
@@ -4045,8 +4056,10 @@ fn resolved_terminal_working_directory(
         .or(working_directory)
 }
 
-/// For cloud agent panes, builds a composite string from the environment name,
-/// setup status, and/or working directory. Returns `None` for non-cloud sessions.
+/// For cloud agent panes, builds a composite string from the environment name and working
+/// directory. The setup status is surfaced on the primary line (see
+/// [`TerminalView::cloud_agent_setup_status_text`]) rather than here. Returns `None` for
+/// non-cloud sessions.
 fn cloud_agent_working_directory_and_env(
     terminal_view: &TerminalView,
     working_directory: Option<&str>,
@@ -4062,14 +4075,10 @@ fn cloud_agent_working_directory_and_env(
         .and_then(|id| CloudAmbientAgentEnvironment::get_by_id(id, app))
         .map(|env| env.model().string_model.display_name());
 
-    let setup_status: Option<&str> = model_ref.agent_progress().map(|p| p.setup_status_text());
-
-    match (env_name, setup_status, working_directory) {
-        (Some(env), Some(status), _) => Some(format!("{env} · {status}")),
-        (Some(env), None, Some(wd)) => Some(format!("{env} · {wd}")),
-        (Some(env), None, None) => Some(env),
-        (None, Some(status), _) => Some(status.to_string()),
-        (None, None, _) => None,
+    match (env_name, working_directory) {
+        (Some(env), Some(wd)) => Some(format!("{env} · {wd}")),
+        (Some(env), None) => Some(env),
+        (None, _) => None,
     }
 }
 
@@ -4915,6 +4924,7 @@ fn render_terminal_primary_line_for_view(
     render_terminal_primary_line(
         terminal_primary_line_data(
             terminal_view.is_long_running_and_user_controlled(),
+            terminal_view.cloud_agent_setup_status_text(app),
             conversation_display_title,
             cli_agent_title,
             title_text.as_str(),
@@ -6455,6 +6465,7 @@ fn render_terminal_detail_section(
     let title_text = terminal_view.terminal_title_from_shell();
     let primary_line = terminal_primary_line_data(
         terminal_view.is_long_running_and_user_controlled(),
+        terminal_view.cloud_agent_setup_status_text(app),
         conversation_display_title,
         cli_agent_title,
         title_text.as_str(),
@@ -6968,6 +6979,7 @@ fn render_compact_pane_row(props: PaneProps<'_>, app: &AppContext) -> Box<dyn El
                         preferred_agent_tab_titles(&agent_text, agent_tab_text_preference(app));
                     let line_data = terminal_primary_line_data(
                         terminal_view.is_long_running_and_user_controlled(),
+                        terminal_view.cloud_agent_setup_status_text(app),
                         conv_title,
                         cli_title,
                         terminal_title.as_str(),

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -202,6 +202,7 @@ fn terminal_primary_line_uses_terminal_title_when_disabled_cli_has_only_prompt()
 
     let line = terminal_primary_line_data(
         false,
+        None,
         conversation_title,
         cli_title,
         "Generated Claude Code title",
@@ -255,6 +256,7 @@ fn terminal_primary_line_uses_cli_prompt_when_enabled_cli_has_prompt() {
 
     let line = terminal_primary_line_data(
         false,
+        None,
         conversation_title,
         cli_title,
         "Generated Claude Code title",
@@ -281,6 +283,7 @@ fn terminal_primary_line_uses_cli_prompt_when_enabled_cli_is_long_running() {
 
     let line = terminal_primary_line_data(
         true,
+        None,
         conversation_title,
         cli_title,
         "Generated Claude Code title",
@@ -290,6 +293,28 @@ fn terminal_primary_line_uses_cli_prompt_when_enabled_cli_is_long_running() {
     );
 
     assert_eq!(line.text(), "Latest CLI prompt");
+}
+
+#[test]
+fn terminal_primary_line_prefers_cloud_setup_status_over_running_command() {
+    let agent_text = TerminalAgentText {
+        is_oz_agent: true,
+        ..Default::default()
+    };
+
+    let line = terminal_primary_line_data(
+        true,
+        Some("Connecting to Host (Step 1/3)".to_string()),
+        Some("Set up environment".to_string()),
+        None,
+        "npm install",
+        "~/warp",
+        terminal_title_fallback_font(&agent_text),
+        None,
+    );
+
+    assert_eq!(line.text(), "Connecting to Host (Step 1/3)");
+    assert!(matches!(line, TerminalPrimaryLineData::StatusText { .. }));
 }
 
 #[test]
@@ -641,6 +666,7 @@ fn terminal_primary_line_prefers_cli_agent_display_title() {
     let line = terminal_primary_line_data(
         false,
         None,
+        None,
         Some("Review the failing tests".to_string()),
         "~/warp",
         "~/warp",
@@ -655,6 +681,7 @@ fn terminal_primary_line_prefers_cli_agent_display_title() {
 fn terminal_primary_line_prefers_cli_agent_display_title_over_conversation_title() {
     let line = terminal_primary_line_data(
         false,
+        None,
         Some("Review the failing tests".to_string()),
         Some("Summarize the failures".to_string()),
         "~/warp",
@@ -672,6 +699,7 @@ fn terminal_primary_line_falls_through_to_terminal_title_when_cli_agent_has_no_p
         false,
         None,
         None,
+        None,
         "codex - ~/warp",
         "~/warp",
         TerminalPrimaryLineFont::Monospace,
@@ -685,6 +713,7 @@ fn terminal_primary_line_falls_through_to_terminal_title_when_cli_agent_has_no_p
 fn terminal_primary_line_uses_terminal_title_as_fallback() {
     let line = terminal_primary_line_data(
         false,
+        None,
         None,
         None,
         "nvim src/workspace/view/vertical_tabs.rs",
@@ -702,6 +731,7 @@ fn terminal_primary_line_uses_last_completed_command_when_shell_title_matches_wo
         false,
         None,
         None,
+        None,
         "~/warp",
         "~/warp",
         TerminalPrimaryLineFont::Monospace,
@@ -715,6 +745,7 @@ fn terminal_primary_line_uses_last_completed_command_when_shell_title_matches_wo
 fn terminal_primary_line_falls_back_to_new_session() {
     let line = terminal_primary_line_data(
         false,
+        None,
         None,
         None,
         "~/warp",
@@ -737,6 +768,7 @@ fn terminal_primary_line_falls_back_to_new_session() {
 fn terminal_primary_line_uses_monospace_for_last_completed_command() {
     let line = terminal_primary_line_data(
         false,
+        None,
         None,
         None,
         "~/warp",


### PR DESCRIPTION
## Description
When setting up a cloud environment, the tab/pane title showed the raw setup command that was currently running (because the environment-setup block is long-running), which felt wrong and surfaced no info about what setup step was happening.

This change shows the setup step in the tab name instead:
- During spawn (`WaitingForSession`): `Connecting to Host (Step 1/3)` → `Creating Environment (Step 2/3)` → `Starting Environment (Step 3/3)`.
- While the environment startup commands run: `Running setup commands...`.

Implementation:
- Adds `TerminalView::cloud_agent_setup_status_text`, which returns setup-step text only for cloud (ambient) agent panes that are still provisioning, and `None` otherwise.
- Threads it through the pane title (`update_pane_configuration`) and the vertical-tab primary line (`terminal_primary_line_data`), where it takes precedence over the long-running-command branch.
- Drops the setup status from the secondary working-directory line (added in #11006) to avoid duplicating it now that it lives on the primary line; that line keeps showing `{env} · {wd}` / `{env}`.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- Added a `terminal_primary_line_data` unit test asserting the cloud setup status takes precedence over a long-running command, and updated existing unit tests for the new argument. `cargo nextest run -p warp --lib terminal_primary_line` passes (11/11).
- `cargo clippy -p warp --lib` is clean and `./script/format` applied.
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A (cloud sandbox — no GUI). Behavior is covered by unit tests.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: Cloud environment setup now shows the current setup step (e.g. "Connecting to Host") in the tab name instead of the raw setup command.
-->

_Conversation: https://staging.warp.dev/conversation/d3e05814-8a7b-4fb7-91d7-1dcbbf51530c_
_Run: https://oz.staging.warp.dev/runs/019ecc05-0c06-7a64-9c39-34868ff24f2c_

_This PR was generated with [Oz](https://warp.dev/oz)._
