### PR TITLE
clean up child agent chips when runs immediately fail

### DIFF
--- a/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
@@ -207,8 +207,9 @@ fn subscribe_to_start_agent_requests(
     let captured = app.add_model(|_| CapturedStartAgentRequests::default());
     captured.update(app, |_, ctx| {
         ctx.subscribe_to_model(start_agent_executor, |captured, event, _ctx| {
-            let StartAgentExecutorEvent::CreateAgent(request) = event;
-            captured.0.push(request.clone());
+            if let StartAgentExecutorEvent::CreateAgent(request) = event {
+                captured.0.push(request.clone());
+            }
         });
     });
     captured

--- a/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
@@ -208,7 +208,7 @@ fn subscribe_to_start_agent_requests(
     captured.update(app, |_, ctx| {
         ctx.subscribe_to_model(start_agent_executor, |captured, event, _ctx| {
             if let StartAgentExecutorEvent::CreateAgent(request) = event {
-                captured.0.push(request.clone());
+                captured.0.push(request.as_ref().clone());
             }
         });
     });

--- a/app/src/ai/blocklist/action_model/execute/start_agent.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_agent.rs
@@ -197,16 +197,27 @@ impl StartAgentExecutor {
     fn complete_pending_as_error(
         &mut self,
         request_id: StartAgentRequestId,
-        _child_conversation_id: AIConversationId,
+        child_conversation_id: AIConversationId,
         error_msg: String,
-        _ctx: &mut ModelContext<Self>,
+        ctx: &mut ModelContext<Self>,
     ) {
         let Some(pending) = self.pending.remove(&request_id) else {
             return;
         };
-        let _ = pending
-            .sender
-            .try_send(StartAgentOutcome::Error(error_msg.clone()));
+        let _ = pending.sender.try_send(StartAgentOutcome::Error(error_msg));
+        // A child that reaches `complete_pending_as_error` never obtained an
+        // agent id, so it failed at the launch stage. Clean up its hidden
+        // pane + conversation so the orchestration pill bar does not retain a
+        // dead chip — but only for terminal failures, leaving recoverable
+        // `Blocked` startup states (e.g. awaiting GitHub auth) intact.
+        let should_cleanup = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&child_conversation_id)
+            .is_some_and(|conversation| should_cleanup_failed_child_launch(conversation.status()));
+        if should_cleanup {
+            ctx.emit(StartAgentExecutorEvent::CleanupFailedChildLaunch {
+                conversation_id: child_conversation_id,
+            });
+        }
     }
 
     fn maybe_complete_pending_for_child_state(
@@ -556,6 +567,20 @@ impl StartAgentExecutor {
     }
 }
 
+/// Whether a child that failed before launch should have its hidden pane and
+/// conversation cleaned up. Only terminal launch failures qualify; recoverable
+/// `Blocked` startup states (e.g. awaiting GitHub auth) keep their chip so the
+/// user can resolve them.
+fn should_cleanup_failed_child_launch(status: &ConversationStatus) -> bool {
+    match status {
+        ConversationStatus::Error | ConversationStatus::Cancelled => true,
+        ConversationStatus::Blocked { .. }
+        | ConversationStatus::InProgress
+        | ConversationStatus::Success
+        | ConversationStatus::WaitingForEvents => false,
+    }
+}
+
 fn start_agent_error_message_for_status(
     status: &ConversationStatus,
     error_message: Option<&str>,
@@ -595,6 +620,12 @@ impl Entity for StartAgentExecutor {
 
 pub enum StartAgentExecutorEvent {
     CreateAgent(StartAgentRequest),
+    /// A child agent failed at the launch stage (never started a server-side
+    /// run). The owning terminal view removes its hidden pane and conversation
+    /// so the orchestration pill bar does not retain a dead chip.
+    CleanupFailedChildLaunch {
+        conversation_id: AIConversationId,
+    },
 }
 
 #[cfg(test)]

--- a/app/src/ai/blocklist/action_model/execute/start_agent.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_agent.rs
@@ -493,15 +493,17 @@ impl StartAgentExecutor {
             },
         );
 
-        ctx.emit(StartAgentExecutorEvent::CreateAgent(StartAgentRequest {
-            id: request_id,
-            name: name.clone(),
-            prompt,
-            execution_mode,
-            lifecycle_subscription: lifecycle_subscription.clone(),
-            parent_conversation_id,
-            parent_run_id,
-        }));
+        ctx.emit(StartAgentExecutorEvent::CreateAgent(Box::new(
+            StartAgentRequest {
+                id: request_id,
+                name: name.clone(),
+                prompt,
+                execution_mode,
+                lifecycle_subscription: lifecycle_subscription.clone(),
+                parent_conversation_id,
+                parent_run_id,
+            },
+        )));
 
         ActionExecution::new_async(async move { receiver.recv().await }, move |result, _ctx| {
             match result {
@@ -546,15 +548,17 @@ impl StartAgentExecutor {
                 sender,
             },
         );
-        ctx.emit(StartAgentExecutorEvent::CreateAgent(StartAgentRequest {
-            id: request_id,
-            name,
-            prompt,
-            execution_mode,
-            lifecycle_subscription,
-            parent_conversation_id,
-            parent_run_id,
-        }));
+        ctx.emit(StartAgentExecutorEvent::CreateAgent(Box::new(
+            StartAgentRequest {
+                id: request_id,
+                name,
+                prompt,
+                execution_mode,
+                lifecycle_subscription,
+                parent_conversation_id,
+                parent_run_id,
+            },
+        )));
         receiver
     }
 
@@ -619,7 +623,7 @@ impl Entity for StartAgentExecutor {
 }
 
 pub enum StartAgentExecutorEvent {
-    CreateAgent(StartAgentRequest),
+    CreateAgent(Box<StartAgentRequest>),
     /// A child agent failed at the launch stage (never started a server-side
     /// run). The owning terminal view removes its hidden pane and conversation
     /// so the orchestration pill bar does not retain a dead chip.

--- a/app/src/ai/blocklist/action_model/execute/start_agent_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_agent_tests.rs
@@ -1,6 +1,6 @@
 use ai::agent::action_result::StartAgentVersion;
 use warp_core::features::FeatureFlag;
-use warpui::{App, EntityId};
+use warpui::{App, Entity, EntityId, ModelHandle};
 
 use super::*;
 use crate::ai::agent::conversation::ConversationStatus;
@@ -829,6 +829,184 @@ fn parallel_pendings_each_resolve_independently_via_recorded_child_id() {
 
         drop(future_a);
         drop(complete_a);
+    });
+}
+
+#[derive(Default)]
+struct CapturedCleanupEvents(Vec<AIConversationId>);
+
+impl Entity for CapturedCleanupEvents {
+    type Event = ();
+}
+
+/// Per-test handles for the launch-cleanup tests, returned by
+/// [`dispatch_pending_child_launch`].
+struct PendingChildLaunch {
+    history_model: ModelHandle<BlocklistAIHistoryModel>,
+    captured: ModelHandle<CapturedCleanupEvents>,
+    terminal_view_id: EntityId,
+    child_conversation_id: AIConversationId,
+}
+
+/// Dispatches a local child launch and creates (but does not yet link) its
+/// child conversation, leaving one in-flight pending in the executor with a
+/// model subscribed to capture `CleanupFailedChildLaunch` events. Tests link
+/// the child and drive it to a terminal state, then assert on cleanup. The
+/// returned executor handle must be kept alive for the duration of the test so
+/// the executor (and its history subscription) is not dropped before the child
+/// status change is processed.
+fn dispatch_pending_child_launch(
+    app: &mut App,
+) -> (PendingChildLaunch, ModelHandle<StartAgentExecutor>) {
+    initialize_history_persistence_for_tests(app);
+    let terminal_view_id = EntityId::new();
+    let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+    let executor = app.add_model(StartAgentExecutor::new);
+    let captured = app.add_model(|_| CapturedCleanupEvents::default());
+    captured.update(app, |_, ctx| {
+        ctx.subscribe_to_model(&executor, |captured, event, _ctx| {
+            if let StartAgentExecutorEvent::CleanupFailedChildLaunch { conversation_id } = event {
+                captured.0.push(*conversation_id);
+            }
+        });
+    });
+    let parent_conversation_id = history_model.update(app, |history_model, ctx| {
+        history_model.start_new_conversation(terminal_view_id, false, false, false, ctx)
+    });
+    history_model.update(app, |model, ctx| {
+        model.assign_run_id_for_conversation(
+            parent_conversation_id,
+            PARENT_RUN_ID.to_string(),
+            None,
+            terminal_view_id,
+            ctx,
+        );
+    });
+    let action = build_start_agent_action(
+        StartAgentVersion::V1,
+        StartAgentExecutionMode::local_with_defaults(),
+    );
+    // The pending lives in the executor regardless of the returned execution,
+    // and cleanup is emitted synchronously from the child status update, so the
+    // action-result plumbing is discarded.
+    executor.update(app, |executor, ctx| {
+        let _: AnyActionExecution = executor
+            .execute(
+                ExecuteActionInput {
+                    action: &action,
+                    conversation_id: parent_conversation_id,
+                },
+                ctx,
+            )
+            .into();
+    });
+    let child_conversation_id = history_model.update(app, |history_model, ctx| {
+        history_model.start_new_child_conversation(
+            terminal_view_id,
+            "Agent 1".to_string(),
+            parent_conversation_id,
+            None,
+            ctx,
+        )
+    });
+    (
+        PendingChildLaunch {
+            history_model,
+            captured,
+            terminal_view_id,
+            child_conversation_id,
+        },
+        executor,
+    )
+}
+
+/// Links the dispatched child conversation back to its pending request,
+/// which lets subsequent child status changes resolve the pending.
+fn link_pending_child(state: &PendingChildLaunch, app: &mut App) {
+    state.history_model.update(app, |model, ctx| {
+        model.record_new_conversation_request_complete(
+            FIRST_REQUEST_ID,
+            state.child_conversation_id,
+            ctx,
+        );
+    });
+}
+
+#[test]
+fn errored_child_launch_emits_cleanup_event() {
+    App::test((), |mut app| async move {
+        let (state, _executor) = dispatch_pending_child_launch(&mut app);
+        link_pending_child(&state, &mut app);
+        state.history_model.update(&mut app, |model, ctx| {
+            model.update_conversation_status_with_error_message(
+                state.terminal_view_id,
+                state.child_conversation_id,
+                ConversationStatus::Error,
+                Some("Child agent failed to spawn".to_string()),
+                ctx,
+            );
+        });
+
+        state.captured.read(&app, |captured, _| {
+            assert_eq!(captured.0, vec![state.child_conversation_id]);
+        });
+    });
+}
+
+#[test]
+fn blocked_child_launch_does_not_emit_cleanup_event() {
+    App::test((), |mut app| async move {
+        let (state, _executor) = dispatch_pending_child_launch(&mut app);
+        link_pending_child(&state, &mut app);
+        // A recoverable startup block (e.g. awaiting GitHub auth) keeps its
+        // chip so the user can resolve it.
+        state.history_model.update(&mut app, |model, ctx| {
+            model.update_conversation_status(
+                state.terminal_view_id,
+                state.child_conversation_id,
+                ConversationStatus::Blocked {
+                    blocked_action: "GitHub authentication required.".to_string(),
+                },
+                ctx,
+            );
+        });
+
+        state.captured.read(&app, |captured, _| {
+            assert!(
+                captured.0.is_empty(),
+                "blocked startup should not schedule chip cleanup"
+            );
+        });
+    });
+}
+
+#[test]
+fn successfully_started_child_does_not_emit_cleanup_event() {
+    App::test((), |mut app| async move {
+        let (state, _executor) = dispatch_pending_child_launch(&mut app);
+        // `OrchestrationEventStreamer::new` reads the history singleton, so it
+        // must be registered after the helper registers it.
+        app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+        app.add_singleton_model(OrchestrationEventStreamer::new);
+        // Assigning a run id before linkage marks the child as started, so the
+        // executor resolves the pending as a success, not a launch failure.
+        state.history_model.update(&mut app, |model, ctx| {
+            model.assign_run_id_for_conversation(
+                state.child_conversation_id,
+                uuid::Uuid::new_v4().to_string(),
+                None,
+                state.terminal_view_id,
+                ctx,
+            );
+        });
+        link_pending_child(&state, &mut app);
+
+        state.captured.read(&app, |captured, _| {
+            assert!(
+                captured.0.is_empty(),
+                "a child that started successfully should not be cleaned up"
+            );
+        });
     });
 }
 

--- a/app/src/ai/blocklist/inline_action/inline_action_icons.rs
+++ b/app/src/ai/blocklist/inline_action/inline_action_icons.rs
@@ -28,6 +28,15 @@ pub fn red_x_icon(appearance: &Appearance) -> warpui::elements::Icon {
     )
 }
 
+/// Yellow warning triangle for terminal states that only partially succeeded
+/// (e.g. some child agents launched and others failed).
+pub fn warning_icon(appearance: &Appearance) -> warpui::elements::Icon {
+    warpui::elements::Icon::new(
+        Icon::Triangle.into(),
+        AnsiColorIdentifier::Yellow.to_ansi_color(&appearance.theme().terminal_colors().normal),
+    )
+}
+
 pub fn cancelled_icon(appearance: &Appearance) -> warpui::elements::Icon {
     warpui::elements::Icon::new(
         Icon::Cancelled.into(),

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -1364,21 +1364,28 @@ pub(crate) fn format_terminal_state(result: &RunAgentsResult) -> (String, Status
                 .iter()
                 .filter(|a| matches!(a.kind, RunAgentsAgentOutcomeKind::Launched { .. }))
                 .count();
-            let label = if launched == total {
-                if total == 1 {
+            if launched == total {
+                let label = if total == 1 {
                     "Spawned 1 agent".to_string()
                 } else {
                     format!("Spawned {total} agents")
-                }
+                };
+                (label, StatusKind::Success)
+            } else if launched == 0 {
+                // Every child failed to launch: surface a terminal failure
+                // rather than the in-progress-looking mixed state.
+                let label = if total == 1 {
+                    "Failed to spawn agent".to_string()
+                } else {
+                    format!("Failed to spawn {total} agents")
+                };
+                (label, StatusKind::Failure)
             } else {
-                format!("Spawned {launched} of {total} agents")
-            };
-            let kind = if launched == total {
-                StatusKind::Success
-            } else {
-                StatusKind::Mixed
-            };
-            (label, kind)
+                (
+                    format!("Spawned {launched} of {total} agents"),
+                    StatusKind::Mixed,
+                )
+            }
         }
         RunAgentsResult::Denied { reason } => {
             let body = if reason.is_empty() {
@@ -1434,7 +1441,10 @@ fn render_status_only_card(
 ) -> Box<dyn Element> {
     let theme = appearance.theme();
     let icon = match kind {
-        StatusKind::Spawning | StatusKind::Mixed => icons::yellow_running_icon(appearance).finish(),
+        StatusKind::Spawning => icons::yellow_running_icon(appearance).finish(),
+        // Partial success is terminal, so use a static warning glyph rather
+        // than the in-progress-looking running circle.
+        StatusKind::Mixed => inline_action_icons::warning_icon(appearance).finish(),
         StatusKind::Success => inline_action_icons::green_check_icon(appearance).finish(),
         StatusKind::Failure => inline_action_icons::red_x_icon(appearance).finish(),
         StatusKind::Cancelled => inline_action_icons::cancelled_icon(appearance).finish(),

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view_tests.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view_tests.rs
@@ -306,6 +306,26 @@ mod format_terminal_state_tests {
     }
 
     #[test]
+    fn all_failed_uses_failure_status_not_mixed() {
+        let result = launched_result(vec![
+            failed("a", "boom"),
+            failed("b", "boom"),
+            failed("c", "boom"),
+        ]);
+        let (label, kind) = format_terminal_state(&result);
+        assert_eq!(label, "Failed to spawn 3 agents");
+        assert!(matches!(kind, StatusKind::Failure));
+    }
+
+    #[test]
+    fn single_failed_uses_singular_failure_label() {
+        let result = launched_result(vec![failed("a", "boom")]);
+        let (label, kind) = format_terminal_state(&result);
+        assert_eq!(label, "Failed to spawn agent");
+        assert!(matches!(kind, StatusKind::Failure));
+    }
+
+    #[test]
     fn failure_with_error_includes_error_text() {
         let (label, kind) = format_terminal_state(&RunAgentsResult::Failure {
             error: "server rejected request".to_string(),

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7458,6 +7458,15 @@ impl TerminalView {
             StartAgentExecutorEvent::CreateAgent(request) => {
                 ctx.emit(Event::StartAgentConversation(request.clone()));
             }
+            StartAgentExecutorEvent::CleanupFailedChildLaunch { conversation_id } => {
+                // The child failed at launch and never started a server-side
+                // run; reuse the Kill path to drop its hidden pane and
+                // conversation so the orchestration pill bar stops showing a
+                // dead chip.
+                ctx.emit(Event::KillAgentConversation {
+                    conversation_id: *conversation_id,
+                });
+            }
         }
     }
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7456,7 +7456,7 @@ impl TerminalView {
     ) {
         match event {
             StartAgentExecutorEvent::CreateAgent(request) => {
-                ctx.emit(Event::StartAgentConversation(request.clone()));
+                ctx.emit(Event::StartAgentConversation(request.as_ref().clone()));
             }
             StartAgentExecutorEvent::CleanupFailedChildLaunch { conversation_id } => {
                 // The child failed at launch and never started a server-side


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

When child agent launches fail immediately, we should clean up the chips instead of keeping them around (given that they're empty and don't contain any useful information).

Related, I noticed that if every child agent fails to spawn, we get stuck in a "setting up x agents..." state instead of transitioning to a failure stage. This PR fixes that as well.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/8e6381fc0b0743aa807fefcbacbee496

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode