### PR TITLE
Enable warpctrl for dogfood builds

### DIFF
--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -953,6 +953,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::AsyncFind,
     FeatureFlag::GPTConfigurableContextWindow,
     FeatureFlag::RestorePromptOnInlineModelSelectorSearch,
+    FeatureFlag::WarpControlCli,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description
Enable `FeatureFlag::WarpControlCli` for WarpDev/dogfood builds so the existing Scripting settings page and dogfood-default local-control mode are reachable.

PR #12327 made local control default to enabled on dogfood channels, but the outer feature flag was not included in `DOGFOOD_FLAGS`.

## Linked Issue
No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `./script/format`
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- `cargo check -p warp_features`
- `git diff --check`

No new integration test was added because this only promotes an existing feature flag and does not introduce new UI or control behavior.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>