### PR TITLE
Add /interrupt slash command complementary to /queue

### DIFF
--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -431,6 +431,18 @@ pub static QUEUE: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     argument: Some(Argument::required().with_hint_text("<prompt to send when agent is done>")),
 });
 
+pub static INTERRUPT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
+    name: "/interrupt",
+    description: "Interrupt the agent and send a prompt right away",
+    icon_path: "bundled/svg/lightning-02.svg",
+    availability: Availability::AGENT_VIEW
+        | Availability::ACTIVE_CONVERSATION
+        | Availability::AI_ENABLED
+        | Availability::NOT_CLOUD_AGENT,
+    auto_enter_ai_mode: true,
+    argument: Some(Argument::required().with_hint_text("<prompt to send now>")),
+});
+
 pub static FORK_AND_COMPACT: LazyLock<StaticCommand> = LazyLock::new(|| {
     let hint_text = "<optional prompt to send after compaction>";
     StaticCommand {
@@ -681,6 +693,7 @@ fn all_commands() -> Vec<StaticCommand> {
 
     if FeatureFlag::QueueSlashCommand.is_enabled() {
         commands.push(QUEUE.clone());
+        commands.push(INTERRUPT.clone());
     }
 
     if !cfg!(target_family = "wasm") {

--- a/app/src/search/slash_command_menu/static_commands/commands_tests.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands_tests.rs
@@ -99,6 +99,23 @@ fn set_tab_color_command_requires_argument() {
 }
 
 #[test]
+fn interrupt_command_mirrors_queue_availability_and_requires_argument() {
+    assert_eq!(INTERRUPT.name, "/interrupt");
+    assert_eq!(INTERRUPT.icon_path, "bundled/svg/lightning-02.svg");
+    assert!(INTERRUPT.auto_enter_ai_mode);
+    // /interrupt and /queue are complementary, so they share the same availability bits.
+    assert_eq!(INTERRUPT.availability, QUEUE.availability);
+
+    let argument = INTERRUPT
+        .argument
+        .as_ref()
+        .expect("expected /interrupt to require an argument");
+    assert!(!argument.is_optional);
+    assert!(!argument.should_execute_on_selection);
+    assert_eq!(argument.hint_text, Some("<prompt to send now>"));
+}
+
+#[test]
 fn strip_command_prefix_matches_orchestrate() {
     let result = strip_command_prefix("/orchestrate deploy services", "/orchestrate");
     assert_eq!(result, Some("deploy services".to_string()));

--- a/app/src/terminal/input/slash_commands/data_source/mod.rs
+++ b/app/src/terminal/input/slash_commands/data_source/mod.rs
@@ -21,7 +21,9 @@ use super::AcceptSlashCommandOrSavedPrompt;
 use crate::ai::agent_conversations_model::{AgentConversationsModel, AgentConversationsModelEvent};
 use crate::ai::blocklist::agent_view::{AgentViewController, AgentViewControllerEvent};
 use crate::ai::blocklist::block::cli_controller::{CLISubagentController, CLISubagentEvent};
-use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
+use crate::ai::blocklist::{
+    BlocklistAIHistoryEvent, BlocklistAIHistoryModel, QueuedQueryEvent, QueuedQueryModel,
+};
 use crate::ai::skills::{SkillDescriptor, SkillManager};
 use crate::search::data_source::{Query, QueryResult};
 use crate::search::mixer::DataSourceRunErrorWrapper;
@@ -59,6 +61,9 @@ struct ActiveCommandsContext {
     active_conversation_is_cloud_oz: bool,
     has_default_host: bool,
     is_cli_agent_input: bool,
+    /// Whether the active conversation has queue-next-prompt (queue mode) on. Gates `/queue`
+    /// (shown only when on) and `/interrupt` (shown only when off).
+    is_queue_next_prompt_enabled: bool,
 }
 
 pub struct SlashCommandDataSource {
@@ -179,6 +184,16 @@ impl SlashCommandDataSource {
                 me.recompute_active_commands(ctx);
             }
         });
+        // Recompute when queue mode flips so /queue and /interrupt swap visibility.
+        ctx.subscribe_to_model(&QueuedQueryModel::handle(ctx), |me, event, ctx| {
+            if matches!(
+                event,
+                QueuedQueryEvent::QueueNextPromptToggled { .. }
+                    | QueuedQueryEvent::DefaultModeChanged
+            ) {
+                me.recompute_active_commands(ctx);
+            }
+        });
 
         let mut me = Self {
             active_session,
@@ -268,17 +283,22 @@ impl SlashCommandDataSource {
             session_context |= Availability::NO_LRC_CONTROL;
         }
 
+        let active_conversation_id =
+            BlocklistAIHistoryModel::as_ref(ctx).active_conversation_id(self.terminal_view_id);
         let has_active_conversation = if is_agent_view_active {
             // There is always an active conversation in the agent view.
             true
         } else {
-            BlocklistAIHistoryModel::as_ref(ctx)
-                .active_conversation(self.terminal_view_id)
-                .is_some()
+            active_conversation_id.is_some()
         };
         if has_active_conversation {
             session_context |= Availability::ACTIVE_CONVERSATION;
         }
+
+        // Queue mode is per-conversation. With no active conversation this is irrelevant since
+        // both /queue and /interrupt also require ACTIVE_CONVERSATION.
+        let is_queue_next_prompt_enabled = active_conversation_id
+            .is_some_and(|id| QueuedQueryModel::as_ref(ctx).is_queue_next_prompt_enabled(id));
 
         if UserWorkspaces::as_ref(ctx).is_codebase_context_enabled(ctx) {
             session_context |= Availability::CODEBASE_CONTEXT;
@@ -312,6 +332,7 @@ impl SlashCommandDataSource {
             active_conversation_is_cloud_oz: self.active_conversation_is_cloud_oz(ctx),
             has_default_host,
             is_cli_agent_input,
+            is_queue_next_prompt_enabled,
         }
     }
 
@@ -340,6 +361,14 @@ impl SlashCommandDataSource {
         }
         // /host is only useful when a default self-hosted host is configured.
         if command.name == commands::HOST.name && !context.has_default_host {
+            return false;
+        }
+        // /queue and /interrupt are complementary: /queue is only useful in queue mode (the
+        // queue chip is on), and /interrupt only when queue mode is off.
+        if command.name == commands::QUEUE.name && !context.is_queue_next_prompt_enabled {
+            return false;
+        }
+        if command.name == commands::INTERRUPT.name && context.is_queue_next_prompt_enabled {
             return false;
         }
         // When CLI agent input is open, restrict to the explicit allowlist.

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -1156,6 +1156,27 @@ impl Input {
                     self.submit_user_query_now(prompt, ctx);
                 }
             }
+            interrupt if command.name == commands::INTERRUPT.name => {
+                if self
+                    .ai_context_model
+                    .as_ref(ctx)
+                    .selected_conversation_id(ctx)
+                    .is_none()
+                {
+                    show_error_toast("/interrupt requires an active conversation".to_owned(), ctx);
+                    return true;
+                };
+
+                let Some(prompt) = argument.filter(|a| !a.is_empty()).cloned() else {
+                    show_error_toast("/interrupt requires a prompt argument".to_owned(), ctx);
+                    return true;
+                };
+
+                // Submit immediately. The normal send path cancels any in-progress work on the
+                // active conversation before sending, so this interrupts the agent rather than
+                // queueing behind it.
+                self.submit_user_query_now(prompt, ctx);
+            }
             open_repo if command.name == commands::OPEN_REPO.name => {
                 if !FeatureFlag::InlineRepoMenu.is_enabled() {
                     return false;


### PR DESCRIPTION
## Description
Adds a `/interrupt` slash command that complements the existing `/queue` command, and makes the two mutually exclusive based on the conversation's queue mode (the "queue next prompt" chip):

- `/queue` is now only available when the active conversation is in **queue mode** (chip active). It queues the prompt to send after the agent finishes.
- `/interrupt` is only available when queue mode is **off**. It submits the prompt immediately, interrupting any in-progress agent work.

Both commands share the same availability bits (`AGENT_VIEW | ACTIVE_CONVERSATION | AI_ENABLED | NOT_CLOUD_AGENT`) and are gated behind `FeatureFlag::QueueSlashCommand`.

### Implementation notes
- `commands.rs`: new `INTERRUPT` static command (icon `lightning-02.svg`, required prompt argument), registered alongside `QUEUE`.
- `data_source/mod.rs`: `ActiveCommandsContext` now carries `is_queue_next_prompt_enabled` (read from `QueuedQueryModel` for the active conversation). The data source subscribes to `QueueNextPromptToggled` / `DefaultModeChanged` so the menu swaps the two commands when queue mode flips. `command_is_active_in_context` hides `/queue` when queue mode is off and `/interrupt` when it is on.
- `slash_commands/mod.rs`: `/interrupt` handler requires an active conversation and a prompt, then calls `submit_user_query_now`. The normal send path cancels in-progress work on the active conversation before sending (`CancellationReason::FollowUpSubmitted`), so the agent is interrupted rather than queued behind.

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

Added a unit test (`interrupt_command_mirrors_queue_availability_and_requires_argument`) and ran the static-commands test module (12 passed). `cargo check`, `cargo fmt`, and `cargo clippy -p warp --tests` all pass.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Added a `/interrupt` slash command to send a prompt and interrupt the agent immediately; `/queue` and `/interrupt` now appear based on whether queue mode is active.

_Conversation: https://staging.warp.dev/conversation/56b7db95-14b7-47ce-9d9b-30f2610a5f02_
_Run: https://oz.staging.warp.dev/runs/019ecc3f-0816-78c7-9a03-177d416e52f7_

_This PR was generated with [Oz](https://warp.dev/oz)._
