### PR TITLE
Log raw diff state errors

### DIFF
--- a/app/src/code_review/diff_state/error.rs
+++ b/app/src/code_review/diff_state/error.rs
@@ -146,6 +146,14 @@ impl DiffStateError {
         let cause = anyhow::anyhow!("{kind}");
         Self { kind, cause }
     }
+
+    /// Logs the raw underlying error locally, then reports the sanitized
+    /// [`DiffStateError`] through the normal reporting path.
+    pub(crate) fn report_and_log(&self) {
+        let cause = &self.cause;
+        log::warn!("Diff state error: {cause:#}");
+        warp_core::report_error!(self);
+    }
 }
 
 impl From<anyhow::Error> for DiffStateError {

--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -252,7 +252,7 @@ impl LocalDiffStateModel {
                         ctx.emit(DiffStateModelEvent::SingleFileUpdated { path, diff });
                     }
                     Err(err) => {
-                        warp_core::report_error!(err.as_ref());
+                        err.report_and_log();
                         send_telemetry_from_ctx!(
                             CodeReviewTelemetryEvent::LoadDiffFailed {
                                 backend_origin: me.backend_origin,
@@ -1637,7 +1637,7 @@ impl LocalDiffStateModel {
             }
             Err(e) => {
                 let err = DiffStateError::from(e);
-                warp_core::report_error!(&err);
+                err.report_and_log();
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::LoadMetadataFailed {
                         backend_origin: self.backend_origin,
@@ -1684,7 +1684,7 @@ impl LocalDiffStateModel {
                     .take()
                     .map(|start| start.elapsed());
                 let err = DiffStateError::from_message(e);
-                warp_core::report_error!(&err);
+                err.report_and_log();
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::LoadDiffFailed {
                         backend_origin: self.backend_origin,

--- a/app/src/code_review/diff_state/remote.rs
+++ b/app/src/code_review/diff_state/remote.rs
@@ -415,7 +415,7 @@ impl RemoteDiffStateModel {
                     .take()
                     .map(|start| start.elapsed());
                 let err = DiffStateError::from_message(&msg);
-                warp_core::report_error!(&err);
+                err.report_and_log();
                 send_telemetry_from_ctx!(
                     CodeReviewTelemetryEvent::LoadDiffFailed {
                         backend_origin: BackendOrigin::ClientRemote,
@@ -439,7 +439,7 @@ impl RemoteDiffStateModel {
                         .take()
                         .map(|start| start.elapsed());
                     let err = DiffStateError::empty_diff_data();
-                    warp_core::report_error!(&err);
+                    err.report_and_log();
                     send_telemetry_from_ctx!(
                         CodeReviewTelemetryEvent::LoadDiffFailed {
                             backend_origin: BackendOrigin::ClientRemote,


### PR DESCRIPTION
## Description 
* This change improves our ability to debug issues within the diff state by ensuring the raw underlying error is logged locally before the sanitized `DiffStateError` is reported. 
* Added a `report_and_log` helper method to `DiffStateError` to centralize error handling.
* Updated `LocalDiffStateModel` and `RemoteDiffStateModel` to use this new method, ensuring we capture detailed error context in the logs while maintaining existing reporting and telemetry flows.

## Testing
No-op

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode