### PR TITLE
Fix /orchestrate slash command not detected due to race condition with shell startup

### DIFF
--- a/app/src/terminal/input/slash_commands/data_source/mod.rs
+++ b/app/src/terminal/input/slash_commands/data_source/mod.rs
@@ -251,11 +251,19 @@ impl SlashCommandDataSource {
             session_context |= Availability::REPOSITORY;
         }
 
+        // Treat an absent session type (session not yet initialized / bootstrapping) as
+        // local. This matches the permissive default already used in
+        // `ActiveSession::location_for_path` and fixes a race condition where commands
+        // that require `Availability::LOCAL` (e.g. `/orchestrate`) are missing from the
+        // slash-command menu when the user types quickly right after shell startup.
+        // Once the session finishes bootstrapping, `recompute_active_commands` is
+        // called via `ActiveSessionEvent::Bootstrapped`, so a remote session that
+        // initially had an unknown type will correctly remove the LOCAL flag.
         let is_local = self
             .active_session
             .as_ref(ctx)
             .session_type(ctx)
-            .is_some_and(|st| st == SessionType::Local);
+            .is_none_or(|st| st == SessionType::Local);
         if is_local {
             session_context |= Availability::LOCAL;
         }


### PR DESCRIPTION
## Description

Fix a race condition where `/orchestrate` (and other `LOCAL`-gated slash commands like `/open-file`, `/open-repo`) wouldn't appear in the slash command menu when typed immediately after shell startup.

**Root cause:** `SlashCommandDataSource::active_commands_context` determines whether to set the `Availability::LOCAL` flag by calling `ActiveSession::session_type()`, which returns `Option<SessionType>`. Before the shell finishes bootstrapping, this returns `None`. The previous check used `is_some_and(|st| st == SessionType::Local)`, which evaluates `None` as `false` — so `LOCAL` was never set during the window before bootstrap completes.

**Fix:** Use `is_none_or(|st| st == SessionType::Local)` to treat an absent session (not yet initialized) as local. This matches the permissive default already used in `ActiveSession::location_for_path` (`Some(SessionType::Local) | None => ...`). Once the session finishes bootstrapping, the existing `ActiveSessionEvent::Bootstrapped` subscription on `SlashCommandDataSource` calls `recompute_active_commands`, so any remote session that temporarily showed LOCAL-gated commands will correctly remove them at that point.

## Linked Issue

- APP-4748

## Testing

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed `/orchestrate` and other slash commands not appearing in the menu when typed immediately after shell startup.
-->

_Conversation: https://staging.warp.dev/conversation/c25a7fe3-d153-4859-bf22-03d7f68705e3_
_Run: https://oz.staging.warp.dev/runs/019eccab-4042-7ed0-ad64-5cbc075d460b_
_This PR was generated with [Oz](https://warp.dev/oz)._
