### PR TITLE
feat(oz): support cloning GitLab environment repos

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -55,7 +55,7 @@ use crate::ai::blocklist::{
     BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIPermissions,
 };
 use crate::ai::cloud_environments::{
-    AmbientAgentEnvironment, CloudAmbientAgentEnvironment, GithubRepo,
+    AmbientAgentEnvironment, CloudAmbientAgentEnvironment, GithubRepo, SourceRepo,
 };
 use crate::ai::document::ai_document_model::{AIDocumentModel, AIDocumentModelEvent};
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
@@ -1572,7 +1572,12 @@ impl AgentDriver {
             return Ok(());
         }
 
-        let global_skill_repos = global_skill_repos.to_vec();
+        // Global skill specs are still GitHub-only, while the shared environment clone
+        // helper accepts provider-neutral repositories. Adapt them only at the clone boundary.
+        let global_skill_repos = global_skill_repos
+            .iter()
+            .map(SourceRepo::from)
+            .collect::<Vec<_>>();
         let clone_future = foreground
             .spawn(move |me, ctx| {
                 let working_dir = me.working_dir.clone();
@@ -1597,7 +1602,7 @@ impl AgentDriver {
     /// It's assumed that `prepare_environment` registers all cloned repositories
     /// with the `DetectedRepositories` model, so that we can scan for skills
     // here.
-    async fn load_environment_skills(foreground: &ModelSpawner<Self>, repos: Vec<GithubRepo>) {
+    async fn load_environment_skills(foreground: &ModelSpawner<Self>, repos: Vec<SourceRepo>) {
         if repos.is_empty() {
             log::info!("No environment repositories for skill loading");
             return;
@@ -1955,8 +1960,8 @@ impl AgentDriver {
 
         if let Some(environment) = environment_opt {
             log::info!("Loading environment...");
-            let environment_github_repos = environment.github_repos.clone();
-            environment_skill_repos = environment_github_repos.clone();
+            let environment_source_repos = environment.effective_repos();
+            environment_skill_repos = environment_source_repos.clone();
 
             // Subscribe to file-based MCP discovery BEFORE prepare_environment triggers the
             // pipeline so no CloudEnvMcpScanComplete events are missed.
@@ -1965,11 +1970,11 @@ impl AgentDriver {
             // TODO(REMOTE-1345): handle MCP setup for third-party harnesses.
             let file_based_discovery_rx = match &task.harness {
                 HarnessKind::Oz => {
-                    let github_repos = environment_github_repos.clone();
+                    let source_repos = environment_source_repos.clone();
                     Some(
                         foreground
                             .spawn(move |me, ctx| {
-                                let expected_repo_paths: Vec<PathBuf> = github_repos
+                                let expected_repo_paths: Vec<PathBuf> = source_repos
                                     .iter()
                                     .map(|repo| me.working_dir.join(&repo.repo))
                                     .collect();

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -20,7 +20,7 @@ use warpui::{ModelContext, ModelSpawner, SingletonEntity};
 use super::terminal::TerminalDriver;
 use super::AgentDriverError;
 use crate::ai::agent_sdk::setup_observability::{SetupClientEventReporter, SetupStep};
-use crate::ai::cloud_environments::{AmbientAgentEnvironment, GithubRepo};
+use crate::ai::cloud_environments::{AmbientAgentEnvironment, SourceRepo};
 use crate::terminal::model::session::command_executor::shell_escape_single_quotes;
 use crate::terminal::shell::ShellType;
 
@@ -62,16 +62,13 @@ pub fn prepare_environment(
 ) -> impl Future<Output = Result<(), PrepareEnvironmentError>> {
     let spawner = ctx.spawner();
     async move {
-        let AmbientAgentEnvironment {
-            github_repos,
-            setup_commands,
-            ..
-        } = environment;
+        let source_repos = environment.effective_repos();
+        let setup_commands = environment.setup_commands;
 
         // Only index the codebase for the Oz harness; third-party harnesses (e.g. Claude)
         // have their own methods for navigating a codebase.
         let should_index_codebase = harness == Harness::Oz;
-        let should_subscribe_to_index_updates = should_index_codebase && !github_repos.is_empty();
+        let should_subscribe_to_index_updates = should_index_codebase && !source_repos.is_empty();
         let repo_channels = Arc::new(Mutex::new(HashMap::<PathBuf, oneshot::Sender<()>>::new()));
 
         if should_subscribe_to_index_updates {
@@ -82,7 +79,7 @@ pub fn prepare_environment(
             &spawner,
             working_dir.as_path(),
             is_sandbox,
-            &github_repos,
+            &source_repos,
             setup_commands,
             should_index_codebase,
             Arc::clone(&repo_channels),
@@ -107,7 +104,7 @@ async fn prepare_environment_impl(
     spawner: &ModelSpawner<TerminalDriver>,
     working_dir: &Path,
     is_sandbox: bool,
-    github_repos: &[GithubRepo],
+    source_repos: &[SourceRepo],
     setup_commands: Vec<String>,
     should_index_codebase: bool,
     repo_channels: Arc<Mutex<HashMap<PathBuf, oneshot::Sender<()>>>>,
@@ -127,11 +124,11 @@ async fn prepare_environment_impl(
     }
     let mut codebase_context_receivers = Vec::new();
 
-    if !github_repos.is_empty() {
+    if !source_repos.is_empty() {
         setup_events
             .record_result(SetupStep::EnvironmentRepoClone, async {
-                clone_repos(github_repos, working_dir, spawner).await?;
-                for repo in github_repos {
+                clone_repos(source_repos, working_dir, spawner).await?;
+                for repo in source_repos {
                     register_cloned_repo(repo, working_dir, is_sandbox, spawner).await?;
                     if !is_sandbox && should_index_codebase {
                         let receiver = index_repo_codebase(
@@ -201,7 +198,7 @@ async fn prepare_environment_impl(
                 Ok::<(), PrepareEnvironmentError>(())
             })
             .await?;
-    } else if should_index_codebase && github_repos.is_empty() {
+    } else if should_index_codebase && source_repos.is_empty() {
         let _ = spawner
             .spawn(|_, ctx| {
                 ctx.unsubscribe_from_model(&CodebaseIndexManager::handle(ctx));
@@ -209,13 +206,13 @@ async fn prepare_environment_impl(
             .await;
     }
 
-    if should_index_codebase && github_repos.is_empty() {
+    if should_index_codebase && source_repos.is_empty() {
         log::info!("No repositories to index for codebase context");
     }
 
     // If there's only one repo in the environment, start the agent in that repo.
     // This way, it doesn't have to locate the correct repo to work on.
-    if let Some(repo_name) = single_repo_name(github_repos) {
+    if let Some(repo_name) = single_repo_name(source_repos) {
         safe_info!(
             safe: ("Changing directory into single repository"),
             full: ("Changing directory into single repository: {repo_name}")
@@ -264,7 +261,7 @@ fn record_codebase_indexing(
     });
 }
 
-fn build_parallel_clone_command(repos: &[GithubRepo], shell_type: ShellType) -> String {
+fn build_parallel_clone_command(repos: &[SourceRepo], shell_type: ShellType) -> String {
     let mut script = String::from(
         r#"set +e
 failed=0
@@ -291,7 +288,7 @@ clone_repo() {
     let mut log_outputs = String::new();
     for (index, repo) in repos.iter().enumerate() {
         let repo_name = format!("{}/{}", repo.owner, repo.repo);
-        let repo_url = format!("https://github.com/{repo_name}.git");
+        let repo_url = repo.https_clone_url();
         let escaped_repo_name = shell_escape_single_quotes(&repo_name, ShellType::Bash);
         let escaped_repo_url = shell_escape_single_quotes(&repo_url, ShellType::Bash);
         let escaped_target = shell_escape_single_quotes(&repo.repo, ShellType::Bash);
@@ -330,10 +327,10 @@ exit "$failed"
     format!("sh -c '{escaped_script}'")
 }
 
-/// Clone all GitHub repositories to `{working_dir}/{repo.repo}` if they do not already exist.
+/// Clone all source repositories to `{working_dir}/{repo.repo}` if they do not already exist.
 /// Multiple repositories are cloned in parallel to reduce environment setup time.
 pub(super) async fn clone_repos(
-    repos: &[GithubRepo],
+    repos: &[SourceRepo],
     working_dir: &Path,
     spawner: &ModelSpawner<TerminalDriver>,
 ) -> Result<(), PrepareEnvironmentError> {
@@ -376,16 +373,16 @@ pub(super) async fn clone_repos(
     }
 }
 
-/// Clone a GitHub repository to `{working_dir}/{repo.repo}` if it does not already exist.
+/// Clone a source repository to `{working_dir}/{repo.repo}` if it does not already exist.
 /// This only performs the clone -- it does NOT register the repo with `DetectedRepositories`.
 #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true, repo = %repo))]
 pub(super) async fn clone_repo(
-    repo: &GithubRepo,
+    repo: &SourceRepo,
     working_dir: &Path,
     spawner: &ModelSpawner<TerminalDriver>,
 ) -> Result<(), PrepareEnvironmentError> {
     let repo_name = format!("{}/{}", repo.owner, repo.repo);
-    let repo_url = format!("https://github.com/{repo_name}.git");
+    let repo_url = repo.https_clone_url();
     // Get the session's shell type for proper escaping, falling back to Bash
     // when the session is not yet bootstrapped or the spawn fails.
     let shell_type = spawner
@@ -437,11 +434,11 @@ pub(super) async fn clone_repo(
     Ok(())
 }
 
-/// Register a cloned GitHub repository with `DetectedRepositories` so that the
+/// Register a cloned source repository with `DetectedRepositories` so that the
 /// skill watcher and other repo-aware subsystems can discover it.
 #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true, repo = %repo, is_sandbox = is_sandbox))]
 pub(super) async fn register_cloned_repo(
-    repo: &GithubRepo,
+    repo: &SourceRepo,
     working_dir: &Path,
     is_sandbox: bool,
     spawner: &ModelSpawner<TerminalDriver>,
@@ -648,7 +645,7 @@ async fn cd_in_terminal(
         })
 }
 
-fn single_repo_name(repos: &[GithubRepo]) -> Option<String> {
+fn single_repo_name(repos: &[SourceRepo]) -> Option<String> {
     if repos.len() != 1 {
         return None;
     }

--- a/app/src/ai/agent_sdk/driver/environment_tests.rs
+++ b/app/src/ai/agent_sdk/driver/environment_tests.rs
@@ -1,10 +1,13 @@
+use cloud_object_models::CodeForge;
+
 use super::{build_parallel_clone_command, single_repo_name};
-use crate::ai::cloud_environments::GithubRepo;
+use crate::ai::cloud_environments::SourceRepo;
 use crate::terminal::shell::ShellType;
 
 #[test]
 fn single_repo_name_returns_repo_when_exactly_one_repo() {
-    let repos = vec![GithubRepo::new(
+    let repos = vec![SourceRepo::new(
+        CodeForge::GitHub,
         "warpdotdev".to_string(),
         "warp-internal".to_string(),
     )];
@@ -14,12 +17,20 @@ fn single_repo_name_returns_repo_when_exactly_one_repo() {
 
 #[test]
 fn single_repo_name_returns_none_for_zero_or_many_repos() {
-    let no_repos = Vec::<GithubRepo>::new();
+    let no_repos = Vec::<SourceRepo>::new();
     assert_eq!(single_repo_name(&no_repos), None);
 
     let two_repos = vec![
-        GithubRepo::new("warpdotdev".to_string(), "warp-internal".to_string()),
-        GithubRepo::new("warpdotdev".to_string(), "warp-server".to_string()),
+        SourceRepo::new(
+            CodeForge::GitHub,
+            "warpdotdev".to_string(),
+            "warp-internal".to_string(),
+        ),
+        SourceRepo::new(
+            CodeForge::GitHub,
+            "warpdotdev".to_string(),
+            "warp-server".to_string(),
+        ),
     ];
     assert_eq!(single_repo_name(&two_repos), None);
 }
@@ -27,8 +38,16 @@ fn single_repo_name_returns_none_for_zero_or_many_repos() {
 #[test]
 fn parallel_clone_command_runs_repos_in_background_and_waits() {
     let repos = vec![
-        GithubRepo::new("warpdotdev".to_string(), "warp".to_string()),
-        GithubRepo::new("warpdotdev".to_string(), "warp-server".to_string()),
+        SourceRepo::new(
+            CodeForge::GitHub,
+            "warpdotdev".to_string(),
+            "warp".to_string(),
+        ),
+        SourceRepo::new(
+            CodeForge::GitLab,
+            "platform/backend".to_string(),
+            "api".to_string(),
+        ),
     ];
 
     let command = build_parallel_clone_command(&repos, ShellType::Bash);
@@ -36,8 +55,8 @@ fn parallel_clone_command_runs_repos_in_background_and_waits() {
     assert!(command.starts_with("sh -c '"));
     assert!(command.contains("warpdotdev/warp"));
     assert!(command.contains("https://github.com/warpdotdev/warp.git"));
-    assert!(command.contains("warpdotdev/warp-server"));
-    assert!(command.contains("https://github.com/warpdotdev/warp-server.git"));
+    assert!(command.contains("platform/backend/api"));
+    assert!(command.contains("https://gitlab.com/platform/backend/api.git"));
     assert_eq!(command.matches("clone_repo").count(), 3);
     assert_eq!(command.matches("2>&1 &").count(), 2);
     assert!(command.contains("mktemp -d"));
@@ -51,7 +70,7 @@ fn parallel_clone_command_runs_repos_in_background_and_waits() {
     assert!(command.contains("wait \"$pid\""));
     assert!(command.contains("===== warpdotdev/warp ====="));
     assert!(command.contains("cat \"$log_file_0\""));
-    assert!(command.contains("===== warpdotdev/warp-server ====="));
+    assert!(command.contains("===== platform/backend/api ====="));
     assert!(command.contains("cat \"$log_file_1\""));
     assert!(command.contains("exit \"$failed\""));
 }

--- a/app/src/ai/agent_sdk/driver/git_credentials.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials.rs
@@ -1,8 +1,8 @@
 /// Git credentials management for cloud agent sandboxes.
 ///
 /// This module handles:
-/// - Writing `~/.git-credentials` and `~/.config/gh/hosts.yml` so that `git`
-///   and the `gh` CLI can authenticate to GitHub without requiring environment
+/// - Writing provider credentials to `~/.git-credentials`, plus GitHub
+///   credentials to `~/.config/gh/hosts.yml`, without requiring environment
 ///   variables.
 /// - One-time git configuration (`credential.helper store`, SSH→HTTPS URL
 ///   rewrites).
@@ -20,11 +20,12 @@ use command::blocking::Command as BlockingCommand;
 use crate::server::server_api::ai::{AIClient, GitCredential};
 
 /// How long to wait between credential refresh attempts (~50 minutes, staying
-/// well ahead of the one-hour GitHub token expiry).
+/// well ahead of the shortest-lived one-hour token expiry).
 pub(crate) const GIT_CREDENTIALS_REFRESH_INTERVAL: Duration = Duration::from_secs(50 * 60);
 
 const DEFAULT_GIT_NAME: &str = "Oz";
 const DEFAULT_GIT_EMAIL: &str = "oz-agent@warp.dev";
+const GITHUB_HOST: &str = "github.com";
 const GH_HOSTS_FILENAME: &str = "hosts.yml";
 
 fn home_dir() -> Result<PathBuf> {
@@ -61,6 +62,18 @@ fn write_secret_file(path: &std::path::Path, content: &str) -> Result<()> {
     Ok(())
 }
 
+fn git_credentials_file_content(credentials: &[GitCredential]) -> String {
+    let mut content = String::new();
+    for cred in credentials {
+        let userinfo = match &cred.username {
+            Some(username) => format!("{username}:{}", cred.token),
+            None => format!("x-access-token:{}", cred.token),
+        };
+        content.push_str(&format!("https://{}@{}\n", userinfo, cred.host));
+    }
+    content
+}
+
 /// Write `~/.git-credentials` with the given credentials.
 ///
 /// Each credential entry is formatted as:
@@ -76,16 +89,7 @@ fn write_git_credentials_file(credentials: &[GitCredential]) -> Result<()> {
     let home = home_dir()?;
     let path = home.join(".git-credentials");
     let tmp_path = home.join(".git-credentials.tmp");
-
-    let mut content = String::new();
-    for cred in credentials {
-        let userinfo = match &cred.username {
-            Some(username) => format!("{username}:{}", cred.token),
-            None => format!("x-access-token:{}", cred.token),
-        };
-        content.push_str(&format!("https://{}@{}\n", userinfo, cred.host));
-    }
-
+    let content = git_credentials_file_content(credentials);
     write_secret_file(&tmp_path, &content)?;
     std::fs::rename(&tmp_path, &path).with_context(|| {
         format!(
@@ -110,7 +114,11 @@ fn write_git_credentials_file(credentials: &[GitCredential]) -> Result<()> {
 ///
 /// The write is atomic: a temporary file is written then renamed.
 fn write_gh_hosts_yml(credentials: &[GitCredential], home: &std::path::Path) -> Result<()> {
-    if credentials.is_empty() {
+    let github_credentials = credentials
+        .iter()
+        .filter(|credential| credential.host == GITHUB_HOST)
+        .collect::<Vec<_>>();
+    if github_credentials.is_empty() {
         return Ok(());
     }
     let gh_config_dir = home.join(".config").join("gh");
@@ -120,7 +128,7 @@ fn write_gh_hosts_yml(credentials: &[GitCredential], home: &std::path::Path) -> 
     let tmp_path = gh_config_dir.join(format!("{GH_HOSTS_FILENAME}.tmp"));
 
     let mut yaml = String::new();
-    for cred in credentials {
+    for cred in github_credentials {
         yaml.push_str(&format!("{}:\n", cred.host));
         yaml.push_str(&format!("    oauth_token: {}\n", cred.token));
         yaml.push_str("    git_protocol: https\n");
@@ -141,6 +149,22 @@ fn write_gh_hosts_yml(credentials: &[GitCredential], home: &std::path::Path) -> 
     Ok(())
 }
 
+/// Formats non-sensitive metadata for verifying local credential injection.
+pub(crate) fn credential_diagnostics(credentials: &[GitCredential]) -> String {
+    credentials
+        .iter()
+        .map(|credential| {
+            format!(
+                "{}(token_present={}, username_present={})",
+                credential.host,
+                !credential.token.is_empty(),
+                credential.username.is_some()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 pub(crate) fn write_git_credentials(credentials: &[GitCredential]) -> Result<()> {
     if credentials.is_empty() {
         return Ok(());
@@ -148,6 +172,11 @@ pub(crate) fn write_git_credentials(credentials: &[GitCredential]) -> Result<()>
     write_git_credentials_file(credentials)?;
     let home = home_dir()?;
     write_gh_hosts_yml(credentials, &home)?;
+    log::info!(
+        "Wrote {} git credential(s) to the local credential store: {}",
+        credentials.len(),
+        credential_diagnostics(credentials)
+    );
     Ok(())
 }
 
@@ -283,7 +312,8 @@ async fn try_refresh(task_id: &str, ai_client: &Arc<dyn AIClient>) -> Result<()>
 /// On each iteration:
 /// 1. Issue a short-lived workload token.
 /// 2. Call `taskGitCredentials` to get a fresh token from the server.
-/// 3. Overwrite `~/.git-credentials` and `~/.config/gh/hosts.yml`.
+/// 3. Overwrite `~/.git-credentials` and refresh GitHub credentials in
+///    `~/.config/gh/hosts.yml`.
 ///
 /// On transient failure, the refresh is retried up to three times with
 /// exponential backoff (1 min, 2 min, 4 min), keeping all retries within the

--- a/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
@@ -29,3 +29,95 @@ fn write_gh_hosts_yml_uses_gh_cli_filename() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn write_gh_hosts_yml_excludes_gitlab_credentials() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let gh_config_dir = temp_dir.path().join(".config").join("gh");
+
+    write_gh_hosts_yml(
+        &[
+            GitCredential {
+                token: "github-token".to_string(),
+                username: Some("octocat".to_string()),
+                email: None,
+                host: "github.com".to_string(),
+            },
+            GitCredential {
+                token: "gitlab-token".to_string(),
+                username: Some("oauth2".to_string()),
+                email: None,
+                host: "gitlab.com".to_string(),
+            },
+        ],
+        temp_dir.path(),
+    )?;
+
+    let hosts = std::fs::read_to_string(gh_config_dir.join(GH_HOSTS_FILENAME))?;
+    assert!(hosts.contains("github.com:"));
+    assert!(!hosts.contains("gitlab.com:"));
+    assert!(!hosts.contains("gitlab-token"));
+
+    Ok(())
+}
+
+#[test]
+fn write_gh_hosts_yml_skips_gitlab_only_credentials() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+
+    write_gh_hosts_yml(
+        &[GitCredential {
+            token: "gitlab-token".to_string(),
+            username: Some("oauth2".to_string()),
+            email: None,
+            host: "gitlab.com".to_string(),
+        }],
+        temp_dir.path(),
+    )?;
+
+    assert!(!temp_dir.path().join(".config").join("gh").exists());
+
+    Ok(())
+}
+
+#[test]
+fn git_credentials_file_content_includes_each_provider_host() {
+    let content = git_credentials_file_content(&[
+        GitCredential {
+            token: "github-token".to_string(),
+            username: None,
+            email: None,
+            host: "github.com".to_string(),
+        },
+        GitCredential {
+            token: "gitlab-token".to_string(),
+            username: Some("oauth2".to_string()),
+            email: None,
+            host: "gitlab.com".to_string(),
+        },
+    ]);
+
+    assert_eq!(
+        content,
+        "https://x-access-token:github-token@github.com\n\
+         https://oauth2:gitlab-token@gitlab.com\n"
+    );
+}
+
+#[test]
+fn credential_diagnostics_reports_presence_without_values() {
+    let diagnostics = credential_diagnostics(&[GitCredential {
+        token: "secret-token".to_string(),
+        username: Some("oauth2".to_string()),
+        email: Some("user@example.com".to_string()),
+        host: "gitlab.com".to_string(),
+    }]);
+
+    assert_eq!(
+        diagnostics,
+        "gitlab.com(token_present=true, username_present=true)"
+    );
+    assert!(!diagnostics.contains("secret-token"));
+    assert!(!diagnostics.contains("oauth2"));
+    assert!(!diagnostics.contains("user@example.com"));
+}

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
+use cloud_object_models::CodeForge;
 use futures::channel::oneshot;
 use repo_metadata::{DirectoryWatcher, RepoMetadataEvent, RepoMetadataModel, RepositoryIdentifier};
 use tempfile::TempDir;
@@ -31,7 +32,7 @@ use crate::ai::agent::{
 };
 use crate::ai::agent_sdk::task_env_vars;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
-use crate::ai::cloud_environments::GithubRepo;
+use crate::ai::cloud_environments::{GithubRepo, SourceRepo};
 use crate::ai::mcp::parsing::normalize_mcp_json;
 use crate::ai::skills::SkillManager;
 use crate::test_util::terminal::{add_window_with_terminal, initialize_app_for_terminal_view};
@@ -707,7 +708,11 @@ fn split_loading_env_loads_all_global_loads_subset() {
 
         // Run both loading methods through the driver's ModelSpawner.
         let (done_tx, done_rx) = futures::channel::oneshot::channel::<()>();
-        let env_repos = vec![GithubRepo::new("org".to_string(), "env-repo".to_string())];
+        let env_repos = vec![SourceRepo::new(
+            CodeForge::GitHub,
+            "org".to_string(),
+            "env-repo".to_string(),
+        )];
         let global_repos = vec![GithubRepo::new(
             "org".to_string(),
             "global-repo".to_string(),
@@ -826,7 +831,8 @@ fn overlap_repo_in_env_and_global_loads_all_skills_without_duplicates() {
         // The same repo is listed in both env repos and global repos.
         // The global spec targets only "deploy".
         let (done_tx, done_rx) = futures::channel::oneshot::channel::<()>();
-        let env_repos = vec![GithubRepo::new(
+        let env_repos = vec![SourceRepo::new(
+            CodeForge::GitHub,
             "org".to_string(),
             "shared-repo".to_string(),
         )];

--- a/app/src/ai/cloud_environments/mod.rs
+++ b/app/src/ai/cloud_environments/mod.rs
@@ -3,7 +3,7 @@
 #[cfg_attr(target_family = "wasm", expect(unused_imports))]
 pub use cloud_object_models::{
     AmbientAgentEnvironment, AwsProviderConfig, BaseImage, CloudAmbientAgentEnvironment,
-    CloudAmbientAgentEnvironmentModel, GcpProviderConfig, GithubRepo, ProvidersConfig,
+    CloudAmbientAgentEnvironmentModel, GcpProviderConfig, GithubRepo, ProvidersConfig, SourceRepo,
 };
 use cloud_objects::cloud_object::Owner;
 use warpui::{AppContext, SingletonEntity as _};

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -671,13 +671,13 @@ pub struct CreateFileArtifactUploadResponse {
 /// A single git credential entry returned by `taskGitCredentials`.
 #[derive(Clone)]
 pub struct GitCredential {
-    /// The GitHub token (OAuth user token or App installation token).
+    /// The provider's OAuth or installation access token.
     pub token: String,
-    /// The GitHub username. `None` for service-account (installation token) principals.
+    /// The provider-specific git username, when available.
     pub username: Option<String>,
-    /// The GitHub email. `None` for service-account principals.
+    /// The provider account's email, when available.
     pub email: Option<String>,
-    /// The host (always `"github.com"` in V1).
+    /// The managed git host, such as `"github.com"` or `"gitlab.com"`.
     pub host: String,
 }
 

--- a/crates/cloud_object_models/src/cloud_environment.rs
+++ b/crates/cloud_object_models/src/cloud_environment.rs
@@ -8,6 +8,34 @@ use serde::{Deserialize, Serialize};
 
 use crate::{JsonModel, JsonSerializer};
 
+/// Source-control provider hosting an environment's repositories.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub enum CodeForge {
+    #[default]
+    #[serde(rename = "GITHUB")]
+    GitHub,
+    #[serde(rename = "GITLAB")]
+    GitLab,
+}
+
+impl CodeForge {
+    pub const fn host(self) -> &'static str {
+        match self {
+            CodeForge::GitHub => "github.com",
+            CodeForge::GitLab => "gitlab.com",
+        }
+    }
+}
+
+impl fmt::Display for CodeForge {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CodeForge::GitHub => write!(f, "GitHub"),
+            CodeForge::GitLab => write!(f, "GitLab"),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GithubRepo {
     /// Repository owner (e.g. "warpdotdev")
@@ -28,6 +56,58 @@ impl fmt::Display for GithubRepo {
     }
 }
 
+/// Identifies a repository and the source-control provider that hosts it.
+///
+/// For GitLab, `owner` contains the full, potentially nested namespace.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SourceRepo {
+    /// The repository's explicit source-control provider.
+    ///
+    /// When absent, this inherits the associated environment's effective forge.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code_forge: Option<CodeForge>,
+    pub owner: String,
+    pub repo: String,
+}
+
+impl SourceRepo {
+    pub fn new(code_forge: CodeForge, owner: String, repo: String) -> Self {
+        Self {
+            code_forge: Some(code_forge),
+            owner,
+            repo,
+        }
+    }
+    pub fn with_default_code_forge(&self, code_forge: CodeForge) -> Self {
+        Self::new(
+            self.code_forge.unwrap_or(code_forge),
+            self.owner.clone(),
+            self.repo.clone(),
+        )
+    }
+
+    pub fn https_clone_url(&self) -> String {
+        format!(
+            "https://{}/{}/{}.git",
+            self.code_forge.unwrap_or_default().host(),
+            self.owner,
+            self.repo
+        )
+    }
+}
+
+/// Converts a legacy GitHub repository into the provider-neutral representation.
+impl From<&GithubRepo> for SourceRepo {
+    fn from(repo: &GithubRepo) -> Self {
+        Self::new(CodeForge::GitHub, repo.owner.clone(), repo.repo.clone())
+    }
+}
+/// Formats the forge-relative repository path.
+impl fmt::Display for SourceRepo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.owner, self.repo)
+    }
+}
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum BaseImage {
@@ -87,9 +167,20 @@ pub struct AmbientAgentEnvironment {
     /// Optional description of the environment (max 240 characters)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Source-control provider hosting this environment's repositories.
+    ///
+    /// Absent means GitHub for legacy environments.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code_forge: Option<CodeForge>,
     /// List of GitHub repositories
     #[serde(default)]
     pub github_repos: Vec<GithubRepo>,
+    /// Provider-neutral repository list.
+    ///
+    /// When present, including when empty, this is authoritative over
+    /// `github_repos`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_repos: Option<Vec<SourceRepo>>,
     /// Base image specification
     #[serde(flatten)]
     pub base_image: BaseImage,
@@ -118,11 +209,35 @@ impl AmbientAgentEnvironment {
         Self {
             name,
             description,
+            code_forge: None,
             github_repos,
+            source_repos: None,
             base_image: BaseImage::DockerImage(docker_image),
             setup_commands,
             providers: ProvidersConfig::default(),
             secrets: None,
+        }
+    }
+
+    /// Returns the environment's source-control provider, defaulting to GitHub
+    /// for legacy environments.
+    pub fn effective_code_forge(&self) -> CodeForge {
+        self.code_forge.unwrap_or_default()
+    }
+
+    /// Returns the authoritative provider-neutral repository list.
+    pub fn effective_repos(&self) -> Vec<SourceRepo> {
+        let code_forge = self.effective_code_forge();
+        match &self.source_repos {
+            Some(source_repos) => source_repos
+                .iter()
+                .map(|repo| repo.with_default_code_forge(code_forge))
+                .collect(),
+            None => self
+                .github_repos
+                .iter()
+                .map(|repo| SourceRepo::new(code_forge, repo.owner.clone(), repo.repo.clone()))
+                .collect(),
         }
     }
 }

--- a/crates/cloud_object_models/src/cloud_environment_tests.rs
+++ b/crates/cloud_object_models/src/cloud_environment_tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    AmbientAgentEnvironment, AwsProviderConfig, BaseImage, EnvironmentSecretRef, GcpProviderConfig,
-    GithubRepo, ProvidersConfig,
+    AmbientAgentEnvironment, AwsProviderConfig, BaseImage, CodeForge, EnvironmentSecretRef,
+    GcpProviderConfig, GithubRepo, ProvidersConfig, SourceRepo,
 };
 
 #[test]
@@ -16,11 +16,83 @@ fn deserialize_legacy_environment_without_providers() {
     assert_eq!(env.name, "my-env");
     assert_eq!(env.providers, ProvidersConfig::default());
     assert_eq!(env.github_repos.len(), 1);
+    assert_eq!(env.code_forge, None);
+    assert_eq!(env.source_repos, None);
+    assert_eq!(
+        env.effective_repos(),
+        vec![SourceRepo::new(
+            CodeForge::GitHub,
+            "warpdotdev".into(),
+            "warp".into()
+        )]
+    );
     assert_eq!(
         env.base_image,
         BaseImage::DockerImage("ubuntu:latest".into())
     );
     assert_eq!(env.setup_commands, vec!["echo hello"]);
+}
+
+#[test]
+fn deserialize_gitlab_environment_uses_authoritative_source_repos() {
+    let json = serde_json::json!({
+        "name": "gitlab-env",
+        "code_forge": "GITLAB",
+        "github_repos": [{"owner": "legacy-mirror", "repo": "ignored"}],
+        "source_repos": [{
+            "owner": "platform/backend",
+            "repo": "api"
+        }],
+        "docker_image": "ubuntu:latest"
+    });
+
+    let env: AmbientAgentEnvironment = serde_json::from_value(json).unwrap();
+
+    assert_eq!(env.effective_code_forge(), CodeForge::GitLab);
+    assert_eq!(env.source_repos.as_ref().unwrap()[0].code_forge, None);
+    assert_eq!(
+        env.effective_repos(),
+        vec![SourceRepo::new(
+            CodeForge::GitLab,
+            "platform/backend".into(),
+            "api".into()
+        )]
+    );
+    assert_eq!(
+        env.effective_repos()[0].https_clone_url(),
+        "https://gitlab.com/platform/backend/api.git"
+    );
+}
+
+#[test]
+fn present_empty_source_repos_override_legacy_mirror() {
+    let json = serde_json::json!({
+        "name": "empty-env",
+        "code_forge": "GITLAB",
+        "github_repos": [{"owner": "legacy-mirror", "repo": "ignored"}],
+        "source_repos": [],
+        "docker_image": "ubuntu:latest"
+    });
+
+    let env: AmbientAgentEnvironment = serde_json::from_value(json).unwrap();
+
+    assert!(env.effective_repos().is_empty());
+}
+
+#[test]
+fn legacy_environment_serialization_omits_provider_neutral_fields() {
+    let env = AmbientAgentEnvironment::new(
+        "legacy-env".into(),
+        None,
+        vec![GithubRepo::new("warpdotdev".into(), "warp".into())],
+        "ubuntu:latest".into(),
+        vec![],
+    );
+
+    let json = serde_json::to_value(&env).unwrap();
+
+    assert!(!json.as_object().unwrap().contains_key("code_forge"));
+    assert!(!json.as_object().unwrap().contains_key("source_repos"));
 }
 
 #[test]

--- a/crates/graphql/src/api/queries/task_git_credentials.rs
+++ b/crates/graphql/src/api/queries/task_git_credentials.rs
@@ -4,9 +4,9 @@ use crate::schema;
 
 /// A GraphQL query to fetch git credentials for a specific task.
 ///
-/// This query is used by Agent Mode tasks to retrieve a fresh GitHub token that the
-/// driver uses to configure git and the gh CLI, and to refresh those credentials
-/// periodically so long-running agents retain GitHub access for their full duration.
+/// This query is used by Agent Mode tasks to retrieve fresh provider credentials that
+/// the driver uses to configure git and supported provider CLIs, and to refresh those
+/// credentials periodically so long-running agents retain repository access.
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(graphql_type = "RootQuery", variables = "TaskGitCredentialsVariables")]
 pub struct TaskGitCredentials {


### PR DESCRIPTION
## Description

Support cloning GitLab repositories during local Warp/Oz cloud environment setup.

- Add provider-neutral environment repository modeling with legacy GitHub compatibility.
- Resolve omitted source-repository forges from the environment's configured code forge.
- Use forge-aware clone URLs throughout environment cloning, registration, indexing, MCP discovery, and skill loading.
- Store credentials for all managed git hosts while keeping GitHub CLI configuration GitHub-only.
- Log non-sensitive credential injection diagnostics without exposing tokens, usernames, or emails.

Implementation plan: https://staging.warp.dev/drive/notebook/VPOgs3sL5WvVNxr1BRONAW
Agent conversation: https://staging.warp.dev/conversation/940bd50f-1875-43fb-a5b2-ab3f87274969

## Linked Issue

REMOTE-1861

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Screenshots or videos are not applicable because this change has no UI changes.

## Testing

- [x] `./script/format`
- [x] `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- [x] `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- [x] `cargo test -p cloud_object_models`
- [x] Focused environment cloning and git credential tests
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-OZ: Support cloning GitLab repositories during cloud environment setup.

Co-Authored-By: Oz <oz-agent@warp.dev>
