### PR TITLE
Fix vertical tabs traffic light padding

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -20303,9 +20303,7 @@ impl Workspace {
             .platform_window(self.window_id)
             .map(|window| window.fullscreen_state() == FullscreenState::Fullscreen)
             .unwrap_or(false);
-        if self.is_left_panel_open(ctx) {
-            0.
-        } else if is_window_fullscreen && cfg!(target_os = "macos") {
+        if is_window_fullscreen && cfg!(target_os = "macos") {
             // Full-screen mode on MacOS does not need as much padding (traffic lights are hidden).
             TAB_BAR_PADDING_LEFT
         } else {

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -339,11 +339,70 @@ fn test_theme_chooser_does_not_suppress_tab_bar_traffic_light_padding() {
             workspace.open_left_panel(ctx);
             assert_eq!(
                 workspace.compute_tab_bar_left_padding(ctx),
-                0.,
-                "Actual left panel should still suppress tab bar left padding"
+                closed_padding,
+                "Open tools panel should still reserve tab bar traffic light padding"
             );
         });
     });
+}
+
+fn assert_vertical_tabs_tools_panel_preserves_padding(config: HeaderToolbarChipSelection) {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        app.update(|ctx| {
+            TabSettings::handle(ctx).update(ctx, |settings, ctx| {
+                report_if_error!(settings.use_vertical_tabs.set_value(true, ctx));
+                report_if_error!(settings
+                    .header_toolbar_chip_selection
+                    .set_value(config, ctx));
+            });
+        });
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            let closed_padding = workspace.compute_tab_bar_left_padding(ctx);
+            assert!(
+                closed_padding > 0.,
+                "Vertical tabs should reserve traffic light padding"
+            );
+
+            workspace.open_left_panel(ctx);
+            assert_eq!(
+                workspace.compute_tab_bar_left_padding(ctx),
+                closed_padding,
+                "An open tools panel should still reserve traffic light padding in vertical tabs"
+            );
+        });
+    });
+}
+
+#[test]
+fn test_tools_panel_does_not_suppress_vertical_tab_bar_traffic_light_padding() {
+    let _vertical_tabs_guard = FeatureFlag::VerticalTabs.override_enabled(true);
+    for config in [
+        HeaderToolbarChipSelection::Custom {
+            left: vec![HeaderToolbarItemKind::AgentManagement],
+            right: vec![
+                HeaderToolbarItemKind::TabsPanel,
+                HeaderToolbarItemKind::ToolsPanel,
+                HeaderToolbarItemKind::CodeReview,
+                HeaderToolbarItemKind::NotificationsMailbox,
+            ],
+        },
+        HeaderToolbarChipSelection::Custom {
+            left: vec![
+                HeaderToolbarItemKind::TabsPanel,
+                HeaderToolbarItemKind::ToolsPanel,
+                HeaderToolbarItemKind::AgentManagement,
+            ],
+            right: vec![
+                HeaderToolbarItemKind::CodeReview,
+                HeaderToolbarItemKind::NotificationsMailbox,
+            ],
+        },
+    ] {
+        assert_vertical_tabs_tools_panel_preserves_padding(config);
+    }
 }
 #[cfg(feature = "local_fs")]
 fn open_worktree_sidecar(workspace: &ViewHandle<Workspace>, app: &mut App) {


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/af530f6e-1b41-421f-91af-2f90ef4ce242

Fixes macOS traffic-light overlap in vertical tabs when the tools panel is open. Vertical tabs now continue reserving titlebar traffic-light padding even when the tools panel is open, whether the tools button is configured on the left or right side of the toolbar.

This also keeps the theme chooser from suppressing tab bar traffic-light padding, preserving the existing PR #11052 behavior.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `./script/format`
- [x] `cargo test -p warp traffic_light_padding`
- [x] Cloud verification agent: `./script/format`, `cargo test -p warp traffic_light_padding`, `cargo build -p warp`, and Linux visual smoke test for tools-panel-right/theme chooser paths
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Reported from macOS screenshot in the linked conversation; cloud visual verification could not reproduce macOS left traffic lights because the cloud environment used Linux window controls.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed vertical tabs toolbar buttons appearing underneath macOS traffic light buttons when the tools panel is open.

_Conversation: https://staging.warp.dev/conversation/804d665d-63da-4a31-8955-ae82393f323c_
_This PR was generated with [Oz](https://warp.dev/oz)._

Co-Authored-By: Oz <oz-agent@warp.dev>
