### PR TITLE
Update tab/group dragging behavior to respect pinning invariant

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -26658,7 +26658,7 @@ impl Workspace {
     ///
     /// Cross-window drags carry ungrouped, unpinned tabs, so the insertion
     /// point — and the ghost slot drawn from it — must never land inside the
-    /// pinned prefix. 
+    /// pinned prefix.
     pub(crate) fn tab_insertion_index_for_cursor(
         &self,
         window_id: WindowId,
@@ -27180,14 +27180,12 @@ impl Workspace {
             let target_group_pinned = expanded_target
                 .and_then(|gid| self.tab_groups.get(&gid))
                 .is_some_and(|g| g.pinned);
-            // Check if we are dragging a pinned tab into an unpinned group. 
+            // Check if we are dragging a pinned tab into an unpinned group.
             // This is not supported as pinned items can not leave the pinned area.
             let pinned_into_unpinned_group =
                 was_pinned && expanded_target.is_some() && !target_group_pinned;
 
-            // 
             if expanded_target != source_group && !pinned_into_unpinned_group {
-
                 // Check if a tab is being dragged out of a pinned group.
                 // If the tab is currently pinned, that means the user is
                 // repositioning it within the pinned area, and passed over
@@ -27198,13 +27196,13 @@ impl Workspace {
                         .and_then(|gid| self.tab_groups.get(&gid))
                         .is_some_and(|g| g.pinned)
                     && !was_pinned;
-                
+
                 // Capture the beginning of the unpinned region during the drag.
                 // If a tab is leaving a pinned group, this is the next position
                 // that it can land.
                 let unpinned_region_start =
                     leaving_pinned_group.then(|| self.pinned_boundary_index());
-                
+
                 // The bounds of the group that a tab could be dragged into.
                 let target_group_range =
                     expanded_target.and_then(|gid| group_member_index_range(&self.tabs, gid));
@@ -27242,8 +27240,8 @@ impl Workspace {
 
         if new_index != current_index {
             // Do not allow a tab to swap places with a neighbouring tab if the
-            // pinned states do not match. This prevents an unpinned tab from 
-            // entering the pinned area (and vice versa). Dragging into a pinned tab 
+            // pinned states do not match. This prevents an unpinned tab from
+            // entering the pinned area (and vice versa). Dragging into a pinned tab
             // group is already handled by grouping logic above.
             if self.is_tab_effectively_pinned(&self.tabs[current_index])
                 != self.is_tab_effectively_pinned(&self.tabs[new_index])

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -27201,7 +27201,7 @@ impl Workspace {
                 // If a tab is leaving a pinned group, this is the next position
                 // that it can land.
                 let unpinned_region_start =
-                    leaving_pinned_group.then(|| self.pinned_boundary_index());
+                    leaving_pinned_group.then(|| self.pinned_boundary_index(&self.tabs));
 
                 // The bounds of the group that a tab could be dragged into.
                 let target_group_range =

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -7298,9 +7298,7 @@ impl Workspace {
 
     /// Flips `tab_index`'s group membership. Callers are responsible for
     /// positioning the tab so groups remain contiguous; this method only
-    /// mutates `group_id`, clears the per-tab pinned flag when entering a
-    /// group (groups own pinning for their members — see `pin_tab_group`),
-    /// and prunes the old group when empty.
+    /// mutates `group_id` and prunes the old group when empty.
     pub fn assign_tab_to_group(
         &mut self,
         tab_index: usize,
@@ -7327,11 +7325,6 @@ impl Workspace {
 
         let previous_group_id = self.tabs[tab_index].group_id;
         self.tabs[tab_index].group_id = group_id;
-        // Entering a group: drop any individual pinned flag. The group's own
-        // `pinned` flag now governs whether this tab is in the pinned region.
-        if group_id.is_some() {
-            self.tabs[tab_index].pinned = false;
-        }
 
         if let Some(previous_group_id) = previous_group_id {
             self.prune_empty_tab_group(previous_group_id, ctx);
@@ -23968,6 +23961,15 @@ impl TypedActionView for Workspace {
                         continue;
                     }
                     tab.detached = false;
+                    // Tab's pin state is cleared when dropped into a group. The
+                    // tab group's pin state is the source of truth for its position.
+                    // This is to handle the case where a user wants to drag
+                    // to reorder pinned tabs within the pinned region, and drags
+                    // over a pinned tab group. It should not lose its pinned state
+                    // during the drag, so we commit it on drop.
+                    if tab.pinned && tab.group_id.is_some() {
+                        tab.pinned = false;
+                    }
                 }
                 send_telemetry_from_ctx!(TelemetryEvent::DragAndDropTab, ctx);
                 if is_cross_window {
@@ -26641,6 +26643,8 @@ impl Workspace {
         });
 
         let index = insertion_index.min(self.tabs.len());
+        // Safety net to ensure the tab lands after all pinned items.
+        let index = self.clamp_to_unpinned_region(&self.tabs, index);
         let mut tab_data = TabData::new(pane_group);
         tab_data.selected_color = color.map_or(SelectedTabColor::Unset, SelectedTabColor::Color);
         tab_data.draggable_state = draggable_state;
@@ -26650,11 +26654,28 @@ impl Workspace {
     }
 
     /// Returns the tab-bar index where a dragged tab would be inserted for
-    /// the given cursor position. Skips tabs clipped by the overflow area
+    /// the given cursor position, clamped to the unpinned region.
+    ///
+    /// Cross-window drags carry ungrouped, unpinned tabs, so the insertion
+    /// point — and the ghost slot drawn from it — must never land inside the
+    /// pinned prefix. 
+    pub(crate) fn tab_insertion_index_for_cursor(
+        &self,
+        window_id: WindowId,
+        cursor_position_on_screen: Vector2F,
+        ctx: &AppContext,
+    ) -> usize {
+        let raw_index =
+            self.raw_tab_insertion_index_for_cursor(window_id, cursor_position_on_screen, ctx);
+        self.clamp_to_unpinned_region(&self.tabs, raw_index)
+    }
+
+    /// Computes the tab-bar insertion index purely from cursor geometry,
+    /// independent of pinning. Skips tabs clipped by the overflow area
     /// (width below `MIN_VISIBLE_TAB_WIDTH`), and picks between horizontal
     /// and vertical layout by comparing the spread of tab centers on each
     /// axis.
-    pub(crate) fn tab_insertion_index_for_cursor(
+    fn raw_tab_insertion_index_for_cursor(
         &self,
         window_id: WindowId,
         cursor_position_on_screen: Vector2F,
@@ -27153,19 +27174,61 @@ impl Workspace {
             let source_group = self.tabs[current_index].group_id;
             let expanded_target =
                 hovered_group.filter(|gid| !self.tab_groups.get(gid).is_some_and(|g| g.collapsed));
-            if expanded_target != source_group {
+            // A pinned tab keeps its individual pin while dragging over a
+            // pinned group (it's committed on drop — see the `DropTab` handler).
+            let was_pinned = self.tabs[current_index].pinned;
+            let target_group_pinned = expanded_target
+                .and_then(|gid| self.tab_groups.get(&gid))
+                .is_some_and(|g| g.pinned);
+            // Check if we are dragging a pinned tab into an unpinned group. 
+            // This is not supported as pinned items can not leave the pinned area.
+            let pinned_into_unpinned_group =
+                was_pinned && expanded_target.is_some() && !target_group_pinned;
+
+            // 
+            if expanded_target != source_group && !pinned_into_unpinned_group {
+
+                // Check if a tab is being dragged out of a pinned group.
+                // If the tab is currently pinned, that means the user is
+                // repositioning it within the pinned area, and passed over
+                // a group as part of the drag. In that case we do not want
+                // to flag this as a tab leaving a pinned group.
+                let leaving_pinned_group = expanded_target.is_none()
+                    && source_group
+                        .and_then(|gid| self.tab_groups.get(&gid))
+                        .is_some_and(|g| g.pinned)
+                    && !was_pinned;
+                
+                // Capture the beginning of the unpinned region during the drag.
+                // If a tab is leaving a pinned group, this is the next position
+                // that it can land.
+                let unpinned_region_start =
+                    leaving_pinned_group.then(|| self.pinned_boundary_index());
+                
+                // The bounds of the group that a tab could be dragged into.
+                let target_group_range =
+                    expanded_target.and_then(|gid| group_member_index_range(&self.tabs, gid));
+
+                // Assign the tab to the group we're dragging over (or clear its
+                // group if none). This intentionally leaves the pin untouched:
+                // a pinned tab dragged into a pinned group keeps its pin for the
+                // duration of the drag and only loses it on drop (see the
+                // `DropTab` handler).
                 self.assign_tab_to_group(current_index, expanded_target, ctx);
+
                 // Hop into the target group's contiguous block so the group
                 // stays one rendered container. Vertical tab rendering only
                 // groups consecutive tabs, so leaving `current_index` outside
                 // the block would split the group across the panel.
-                if let Some(target_gid) = expanded_target {
-                    if let Some((first, last)) = group_member_index_range(&self.tabs, target_gid) {
-                        let insert_at = if current_index < first { first } else { last };
-                        if insert_at != current_index {
-                            self.hop_tab_to_index(current_index, insert_at, ctx);
-                        }
+                if let Some((first, last)) = target_group_range {
+                    let insert_at = if current_index < first { first } else { last };
+                    if insert_at != current_index {
+                        self.hop_tab_to_index(current_index, insert_at, ctx);
                     }
+                } else if let Some(target) = unpinned_region_start {
+                    // Relocate the now-unpinned tab to the first unpinned slot
+                    // so the pinned region stays contiguous.
+                    self.move_tab_to_index(current_index, target, ctx);
                 }
                 return;
             }
@@ -27178,6 +27241,16 @@ impl Workspace {
         };
 
         if new_index != current_index {
+            // Do not allow a tab to swap places with a neighbouring tab if the
+            // pinned states do not match. This prevents an unpinned tab from 
+            // entering the pinned area (and vice versa). Dragging into a pinned tab 
+            // group is already handled by grouping logic above.
+            if self.is_tab_effectively_pinned(&self.tabs[current_index])
+                != self.is_tab_effectively_pinned(&self.tabs[new_index])
+            {
+                return;
+            }
+
             // Prevent dropping into a collapsed group: if the swap target is a
             // collapsed-group member the dragged tab doesn't belong to, hop
             // past the whole block instead of swapping into it.
@@ -27435,6 +27508,10 @@ impl Workspace {
         let Some((first, last)) = group_member_index_range(&self.tabs, group_id) else {
             return;
         };
+        // Reorders that would carry the block across the pinned/unpinned
+        // boundary are skipped below: a pinned group must stay in the pinned
+        // prefix and an unpinned group must stay out of it.
+        let group_pinned = self.tab_groups.get(&group_id).is_some_and(|g| g.pinned);
         let is_vertical = uses_vertical_tabs(ctx);
         let midpoint_drag = if is_vertical {
             (position.min_y() + position.max_y()) / 2.
@@ -27465,8 +27542,9 @@ impl Workspace {
         };
 
         // Swap toward the start of the bar: check the neighbor directly
-        // before the group's first member.
-        if first > 0 {
+        // before the group's first member. Do not allow the swap if pinned
+        // states do not match.
+        if first > 0 && self.is_tab_effectively_pinned(&self.tabs[first - 1]) == group_pinned {
             let before_index = first - 1;
             if let Some(rect) = self.neighbor_drag_rect(before_index, is_vertical, ctx) {
                 if midpoint_drag < swap_before_threshold(rect) {
@@ -27486,8 +27564,11 @@ impl Workspace {
         // Swap toward the end of the bar: check the neighbor directly after
         // the group's last member. Pass `after_block_last + 1` (the
         // pre-drain target index); `move_group_block` accounts for the
-        // drain internally when `target > last`.
-        if last + 1 < self.tabs.len() {
+        // drain internally when `target > last`. Do not allow the swap if
+        // pinned states do not match.
+        if last + 1 < self.tabs.len()
+            && self.is_tab_effectively_pinned(&self.tabs[last + 1]) == group_pinned
+        {
             let after_index = last + 1;
             if let Some(rect) = self.neighbor_drag_rect(after_index, is_vertical, ctx) {
                 if midpoint_drag > swap_after_threshold(rect) {


### PR DESCRIPTION
## Description

Modifies tab and tab-group dragging to respect the pinned-prefix invariant from the prior PRs: effectively pinned tabs (individually pinned tabs + members of pinned groups) stay as a contiguous block at the front of the list. Before this, dragging could move tabs across the pinned boundary. Gated on the pinning/grouping flags — with pinning off, behavior is unchanged.

## How it works

Modified tab and group dragging helpers to prevent neighboring items from swapping positions when their pin states are different. This ensures that unpinned items can not be dragged into the pinned area and vice versa. 

Modified group assignment logic and `on tab drop` behavior so that pinned state is only assigned to a tab when it is dropped into a group, rather than dragging over it. Reasoning: 
- currently a tab is assigned to a group on drag, when the tab enters the groups bounds. Originally this also set the pin state to false for that tab (when a tab is part of a group its pin state is cleared and the group's pin state is source of truth). 
- However, when dragging pinned tabs within the pinned region, we may not want to move it past a pinned group, rather than dropping it inside of the group. If we were to clear the pin state on drag, a tab that you are currently dragging could unexpectedly lose its pin state when the user was trying to reposition it within the pinned area

Modified cross window dragging to clamp new tabs past the pinned region within the new window, enforcing our pinning invariant. 

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4727/update-tab-dragging-to-respect-pinned-states

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo Video](https://www.loom.com/share/67d35c19806f4806a9e9489c8869c949)