### PR TITLE
Revert "fix: wrap agent prompt suggestions in narrow panes (#12199)"

### DIFF
--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -15193,12 +15193,16 @@ impl Input {
         banner: Box<dyn Element>,
         is_compact_mode: bool,
         input_mode: InputMode,
+        appearance: &Appearance,
         app: &AppContext,
     ) -> Box<dyn Element> {
+        let constrained_banner = ConstrainedBox::new(banner)
+            .with_height(2. * appearance.line_height_ratio() * appearance.monospace_font_size())
+            .finish();
         let should_use_udi_spacing = self.should_show_universal_developer_input(app)
             || (FeatureFlag::AgentView.is_enabled()
                 && self.agent_view_controller.as_ref(app).is_active());
-        let mut container: Container = Container::new(banner);
+        let mut container: Container = Container::new(constrained_banner);
         let (suggestion_to_prompt_padding, suggestion_to_input_border_padding) =
             if should_use_udi_spacing {
                 (0., 0.)
@@ -15223,6 +15227,7 @@ impl Input {
     /// Renders a banner that should stay next to the input box.
     fn render_input_banner(
         &self,
+        appearance: &Appearance,
         app: &AppContext,
         input_mode: InputMode,
         is_compact_mode: bool,
@@ -15238,6 +15243,7 @@ impl Input {
                 prompt_suggestions_banner,
                 is_compact_mode,
                 input_mode,
+                appearance,
                 app,
             ))
         } else {

--- a/app/src/terminal/input/agent.rs
+++ b/app/src/terminal/input/agent.rs
@@ -93,7 +93,7 @@ impl Input {
         let mut column = Flex::column();
 
         if let Some(banner) =
-            self.render_input_banner(app, input_mode, /*is_compact_mode=*/ false)
+            self.render_input_banner(appearance, app, input_mode, /*is_compact_mode=*/ false)
         {
             column.add_child(
                 Container::new(banner)

--- a/app/src/terminal/input/classic.rs
+++ b/app/src/terminal/input/classic.rs
@@ -103,7 +103,9 @@ impl Input {
         let mut column = Flex::column();
 
         if matches!(input_mode, InputMode::PinnedToBottom | InputMode::Waterfall) {
-            if let Some(banner) = self.render_input_banner(app, input_mode, is_compact_mode) {
+            if let Some(banner) =
+                self.render_input_banner(appearance, app, input_mode, is_compact_mode)
+            {
                 column.add_child(banner);
             }
         }
@@ -145,7 +147,9 @@ impl Input {
         }
 
         if matches!(input_mode, InputMode::PinnedToTop) {
-            if let Some(banner) = self.render_input_banner(app, input_mode, is_compact_mode) {
+            if let Some(banner) =
+                self.render_input_banner(appearance, app, input_mode, is_compact_mode)
+            {
                 column.add_child(banner);
             }
         }

--- a/app/src/terminal/input/terminal.rs
+++ b/app/src/terminal/input/terminal.rs
@@ -42,7 +42,7 @@ impl Input {
         let mut column = Flex::column();
 
         if matches!(input_mode, InputMode::PinnedToBottom | InputMode::Waterfall) {
-            if let Some(banner) = self.render_input_banner(app, input_mode, false) {
+            if let Some(banner) = self.render_input_banner(appearance, app, input_mode, false) {
                 column.add_child(
                     Container::new(banner)
                         .with_margin_top(spacing::UDI_CHIP_MARGIN)
@@ -86,7 +86,7 @@ impl Input {
         }
 
         if matches!(input_mode, InputMode::PinnedToTop) {
-            if let Some(banner) = self.render_input_banner(app, input_mode, false) {
+            if let Some(banner) = self.render_input_banner(appearance, app, input_mode, false) {
                 column.add_child(
                     Container::new(banner)
                         .with_margin_bottom(spacing::UDI_CHIP_MARGIN)

--- a/app/src/terminal/input/universal.rs
+++ b/app/src/terminal/input/universal.rs
@@ -53,7 +53,9 @@ impl Input {
         let mut column = Flex::column();
 
         if matches!(input_mode, InputMode::PinnedToBottom | InputMode::Waterfall) {
-            if let Some(banner) = self.render_input_banner(app, input_mode, is_compact_mode) {
+            if let Some(banner) =
+                self.render_input_banner(appearance, app, input_mode, is_compact_mode)
+            {
                 column.add_child(
                     Container::new(banner)
                         .with_margin_top(spacing::UDI_CHIP_MARGIN)
@@ -91,7 +93,9 @@ impl Input {
         column.add_child(ChildView::new(&self.universal_developer_input_button_bar).finish());
 
         if matches!(input_mode, InputMode::PinnedToTop) {
-            if let Some(banner) = self.render_input_banner(app, input_mode, is_compact_mode) {
+            if let Some(banner) =
+                self.render_input_banner(appearance, app, input_mode, is_compact_mode)
+            {
                 column.add_child(
                     Container::new(banner)
                         .with_margin_bottom(spacing::UDI_CHIP_MARGIN)

--- a/app/src/terminal/view/inline_banner/prompt_suggestions.rs
+++ b/app/src/terminal/view/inline_banner/prompt_suggestions.rs
@@ -38,7 +38,6 @@ use crate::util::bindings::keybinding_name_to_keystroke;
 
 const INLINE_BANNER_SPACING: f32 = 8.;
 const INLINE_BANNER_BUTTON_PADDING: f32 = 8.;
-const INLINE_BANNER_BUTTON_VERTICAL_PADDING: f32 = 4.;
 
 const DELINQUENT_DUE_TO_PAYMENT_ISSUE_TOOLTIP_MESSAGE: &str = "Restricted due to payment issue";
 const OUT_OF_REQUESTS_TOOLTIP_MESSAGE: &str = "Out of credits";
@@ -130,6 +129,7 @@ fn render_button(
     prompt_alert_state: &PromptAlertState,
     should_shrink: bool,
     appearance: &Appearance,
+    app: &AppContext,
 ) -> Box<dyn Element> {
     let theme = appearance.theme();
     let is_button_disabled = matches!(
@@ -158,17 +158,21 @@ fn render_button(
         }
 
         let icon_size = appearance.monospace_font_size();
+        let button_height = app.font_cache().line_height(
+            appearance.monospace_font_size(),
+            appearance.line_height_ratio(),
+        ) + 14.;
+        // Need this to have reasonable keyboard shortcut heights.
+        // let keyboard_shortcut_icon_height = button_height - 6.;
         let mut icon_color = blended_colors::text_main(theme, theme.surface_1());
         icon_color.a = opacity_u8;
 
-        let should_expand_button = mouse_state.is_hovered();
         let text = {
-            let base = Text::new(
+            let base = Text::new_inline(
                 text,
                 appearance.ui_font_family(),
                 appearance.monospace_font_size(),
             )
-            .soft_wrap(should_expand_button)
             .with_color(text_color)
             .finish();
 
@@ -223,9 +227,7 @@ fn render_button(
         let mut container = Container::new(flex.finish())
             .with_background(background_fill)
             .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
-            .with_padding_right(INLINE_BANNER_BUTTON_PADDING)
-            .with_padding_top(INLINE_BANNER_BUTTON_VERTICAL_PADDING)
-            .with_padding_bottom(INLINE_BANNER_BUTTON_VERTICAL_PADDING);
+            .with_padding_right(INLINE_BANNER_BUTTON_PADDING);
 
         if button_index != 0 {
             container = container.with_margin_left(INLINE_BANNER_SPACING);
@@ -263,7 +265,9 @@ fn render_button(
             }
         }
 
-        stack.finish()
+        ConstrainedBox::new(stack.finish())
+            .with_height(button_height)
+            .finish()
     })
     .with_cursor(Cursor::PointingHand);
 
@@ -416,6 +420,7 @@ impl View for PromptSuggestionsView {
                     prompt_alert_state,
                     true, // should_shrink
                     appearance,
+                    app,
                 ),
             )
             .finish(),


### PR DESCRIPTION
## Description

Reverts #12199 which introduced expand-on-hover behavior for the passive suggestion chip, causing layout shifts whenever the mouse crosses the banner (tracked in #12584).

Note: PR #12531 was also referenced but was closed without merging, so there is nothing to revert for it.

## Linked Issue

Closes #12584

## Testing

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Warp <agent@warp.dev>