### PR TITLE
Fail fast on PTY spawn errors with specific error messages

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -436,7 +436,7 @@ pub enum AgentDriverError {
     NotLoggedIn,
     #[error("Saved prompt not found for id {0}")]
     AIWorkflowNotFound(String),
-    #[error("Terminal bootstrap failed: {error}")]
+    #[error("Terminal bootstrap failed")]
     BootstrapFailed {
         #[source]
         error: terminal::BootstrapError,

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -436,8 +436,11 @@ pub enum AgentDriverError {
     NotLoggedIn,
     #[error("Saved prompt not found for id {0}")]
     AIWorkflowNotFound(String),
-    #[error("Terminal bootstrap failed: {reason}")]
-    BootstrapFailed { reason: String },
+    #[error("Terminal bootstrap failed: {error}")]
+    BootstrapFailed {
+        #[source]
+        error: terminal::BootstrapError,
+    },
     #[error("Unable to share agent session")]
     ShareSessionFailed {
         #[source]
@@ -1835,6 +1838,7 @@ impl AgentDriver {
                     })
                     .await?
                     .await
+                    .map_err(|error| AgentDriverError::BootstrapFailed { error })
             })
             .await?;
 

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -436,8 +436,8 @@ pub enum AgentDriverError {
     NotLoggedIn,
     #[error("Saved prompt not found for id {0}")]
     AIWorkflowNotFound(String),
-    #[error("Terminal bootstrap failed")]
-    BootstrapFailed,
+    #[error("Terminal bootstrap failed: {reason}")]
+    BootstrapFailed { reason: String },
     #[error("Unable to share agent session")]
     ShareSessionFailed {
         #[source]
@@ -1831,8 +1831,7 @@ impl AgentDriver {
                 foreground
                     .spawn(|me, ctx| {
                         me.terminal_driver
-                            .as_ref(ctx)
-                            .wait_for_session_bootstrapped()
+                            .update(ctx, |driver, _| driver.wait_for_session_bootstrapped())
                     })
                     .await?
                     .await

--- a/app/src/ai/agent_sdk/driver/error_classification.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification.rs
@@ -17,10 +17,10 @@ pub fn classify_driver_error(error: &AgentDriverError) -> (AgentTaskState, TaskS
                 PlatformErrorCode::InternalError,
             ),
         ),
-        AgentDriverError::BootstrapFailed { reason } => (
+        AgentDriverError::BootstrapFailed { error } => (
             AgentTaskState::Error,
             TaskStatusUpdate::with_error_code(
-                format!("Terminal session failed to start: {reason}"),
+                format!("Terminal session failed to start: {error}"),
                 PlatformErrorCode::InternalError,
             ),
         ),

--- a/app/src/ai/agent_sdk/driver/error_classification.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification.rs
@@ -17,10 +17,10 @@ pub fn classify_driver_error(error: &AgentDriverError) -> (AgentTaskState, TaskS
                 PlatformErrorCode::InternalError,
             ),
         ),
-        AgentDriverError::BootstrapFailed => (
+        AgentDriverError::BootstrapFailed { reason } => (
             AgentTaskState::Error,
             TaskStatusUpdate::with_error_code(
-                "Terminal session failed to start. Please try running your task again.",
+                format!("Terminal session failed to start: {reason}"),
                 PlatformErrorCode::InternalError,
             ),
         ),

--- a/app/src/ai/agent_sdk/driver/error_classification_tests.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification_tests.rs
@@ -1,7 +1,7 @@
 use warp_graphql::ai::{AgentTaskState, PlatformErrorCode};
 
 use super::classify_driver_error;
-use crate::ai::agent_sdk::driver::terminal::ShareSessionError;
+use crate::ai::agent_sdk::driver::terminal::{BootstrapError, ShareSessionError};
 use crate::ai::agent_sdk::driver::AgentDriverError;
 
 fn assert_state_and_code(
@@ -20,9 +20,11 @@ fn assert_state_and_code(
 // --- Infrastructure errors → ERROR ---
 
 #[test]
-fn bootstrap_failed_is_error_with_internal() {
+fn bootstrap_pty_spawn_failed_with_reason_includes_reason_in_message() {
     let (state, update) = classify_driver_error(&AgentDriverError::BootstrapFailed {
-        reason: "Argument list too long (os error 7)".to_string(),
+        error: BootstrapError::PtySpawnFailed {
+            reason: Some("Argument list too long (os error 7)".to_string()),
+        },
     });
     assert_eq!(state, AgentTaskState::Error);
     assert_eq!(update.error_code, Some(PlatformErrorCode::InternalError));
@@ -31,6 +33,43 @@ fn bootstrap_failed_is_error_with_internal() {
         "message should include the specific failure reason: {:?}",
         update.message
     );
+}
+
+#[test]
+fn bootstrap_pty_spawn_failed_without_reason_is_generic() {
+    let (state, update) = classify_driver_error(&AgentDriverError::BootstrapFailed {
+        error: BootstrapError::PtySpawnFailed { reason: None },
+    });
+    assert_eq!(state, AgentTaskState::Error);
+    assert_eq!(update.error_code, Some(PlatformErrorCode::InternalError));
+    assert!(
+        update.message.contains("Shell spawn failed"),
+        "message should describe the spawn failure: {:?}",
+        update.message
+    );
+}
+
+#[test]
+fn bootstrap_timed_out_is_error_with_internal() {
+    let (state, update) = classify_driver_error(&AgentDriverError::BootstrapFailed {
+        error: BootstrapError::TimedOut,
+    });
+    assert_eq!(state, AgentTaskState::Error);
+    assert_eq!(update.error_code, Some(PlatformErrorCode::InternalError));
+    assert!(
+        update.message.contains("did not start within"),
+        "message should describe the timeout: {:?}",
+        update.message
+    );
+}
+
+#[test]
+fn bootstrap_internal_error_is_error_with_internal() {
+    let (state, update) = classify_driver_error(&AgentDriverError::BootstrapFailed {
+        error: BootstrapError::InternalError,
+    });
+    assert_eq!(state, AgentTaskState::Error);
+    assert_eq!(update.error_code, Some(PlatformErrorCode::InternalError));
 }
 
 #[test]

--- a/app/src/ai/agent_sdk/driver/error_classification_tests.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification_tests.rs
@@ -21,10 +21,15 @@ fn assert_state_and_code(
 
 #[test]
 fn bootstrap_failed_is_error_with_internal() {
-    assert_state_and_code(
-        AgentDriverError::BootstrapFailed,
-        AgentTaskState::Error,
-        Some(PlatformErrorCode::InternalError),
+    let (state, update) = classify_driver_error(&AgentDriverError::BootstrapFailed {
+        reason: "Argument list too long (os error 7)".to_string(),
+    });
+    assert_eq!(state, AgentTaskState::Error);
+    assert_eq!(update.error_code, Some(PlatformErrorCode::InternalError));
+    assert!(
+        update.message.contains("Argument list too long"),
+        "message should include the specific failure reason: {:?}",
+        update.message
     );
 }
 

--- a/app/src/ai/agent_sdk/driver/terminal.rs
+++ b/app/src/ai/agent_sdk/driver/terminal.rs
@@ -578,7 +578,7 @@ impl TerminalDriver {
                     // PTY spawn failed — use the specific reason from the view.
                     futures::future::Either::Right((Ok(reason), _)) => reason,
                     // Sender dropped without sending (shouldn't happen in practice).
-                    futures::future::Either::Right((Err(_), _)) => return Ok(()),
+                    futures::future::Either::Right((Err(_), _)) => "Internal error".to_string(),
                 }
             } else {
                 // No failure channel — wait for bootstrap with the standard timeout.
@@ -731,10 +731,7 @@ impl TerminalDriver {
                 if !self.session_bootstrapped.is_set() {
                     if let Some(tx) = self.spawn_failure_tx.take() {
                         let _ = tx.send(
-                            "Shell spawn failed. This can happen when env vars or secrets \
-                             are too long — check your image for excessively long \
-                             environment variables or Oz for excessively long secrets."
-                                .to_string(),
+                            "Shell spawn failed. Check the Warp logs for details.".to_string(),
                         );
                     }
                 }

--- a/app/src/ai/agent_sdk/driver/terminal.rs
+++ b/app/src/ai/agent_sdk/driver/terminal.rs
@@ -731,10 +731,10 @@ impl TerminalDriver {
                 if !self.session_bootstrapped.is_set() {
                     if let Some(tx) = self.spawn_failure_tx.take() {
                         let _ = tx.send(
-                            "The shell process exited before the Warp bootstrap script \
-                             completed. Check any environment variables or secrets \
-                             configured for this run."
-                            .to_string(),
+                            "Shell spawn failed. This can happen when env vars or secrets \
+                             are too long — check your image for excessively long \
+                             environment variables or Oz for excessively long secrets."
+                                .to_string(),
                         );
                     }
                 }

--- a/app/src/ai/agent_sdk/driver/terminal.rs
+++ b/app/src/ai/agent_sdk/driver/terminal.rs
@@ -724,6 +724,21 @@ impl TerminalDriver {
                     let _ = tx.send(reason.clone());
                 }
             }
+            crate::terminal::view::Event::Exited => {
+                // The shell process exited. If bootstrap hasn't completed yet
+                // it never will — cancel the wait immediately rather than
+                // sitting out the full 60 s timeout.
+                if !self.session_bootstrapped.is_set() {
+                    if let Some(tx) = self.spawn_failure_tx.take() {
+                        let _ = tx.send(
+                            "The shell process exited before the Warp bootstrap script \
+                             completed. Check any environment variables or secrets \
+                             configured for this run."
+                            .to_string(),
+                        );
+                    }
+                }
+            }
             crate::terminal::view::Event::SlowBootstrap => {
                 ctx.emit(TerminalDriverEvent::SlowBootstrap);
             }

--- a/app/src/ai/agent_sdk/driver/terminal.rs
+++ b/app/src/ai/agent_sdk/driver/terminal.rs
@@ -16,7 +16,6 @@ use warp_core::command::ExitCode;
 use warp_core::features::FeatureFlag;
 use warp_terminal::model::grid::Dimensions;
 use warp_util::path::ShellFamily;
-use warp_util::sync::Condition;
 use warpui::r#async::FutureExt;
 use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity as _, ViewHandle};
 
@@ -36,6 +35,45 @@ use crate::terminal::shell::ShellType;
 use crate::terminal::view::{ConversationRestorationInNewPaneType, Event};
 use crate::terminal::TerminalView;
 use crate::workspaces::user_workspaces::UserWorkspaces;
+
+/// Describes why a terminal session bootstrap failed.
+#[derive(Debug)]
+pub(crate) enum BootstrapError {
+    /// The PTY or shell process failed before the bootstrap script completed.
+    /// When `reason` is `Some`, the message is
+    /// "Shell spawn failed: {reason}. Check the Warp logs for details."
+    /// When `reason` is `None`, it is
+    /// "Shell spawn failed. Check the Warp logs for details."
+    PtySpawnFailed { reason: Option<String> },
+    /// The bootstrap script did not complete within the expected time.
+    TimedOut,
+    /// An unexpected internal error in the bootstrap channel
+    /// (e.g. the sender was dropped without sending).
+    InternalError,
+}
+
+impl std::fmt::Display for BootstrapError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BootstrapError::PtySpawnFailed { reason: Some(r) } => {
+                write!(f, "Shell spawn failed: {r}. Check the Warp logs for details.")
+            }
+            BootstrapError::PtySpawnFailed { reason: None } => {
+                write!(f, "Shell spawn failed. Check the Warp logs for details.")
+            }
+            BootstrapError::TimedOut => write!(
+                f,
+                "Terminal session did not start within the expected time. \
+                 Check the Warp logs for details."
+            ),
+            BootstrapError::InternalError => {
+                write!(f, "An unexpected internal error occurred during bootstrap.")
+            }
+        }
+    }
+}
+
+impl std::error::Error for BootstrapError {}
 
 /// Describes why an agent's session-sharing request failed.
 #[derive(Debug, thiserror::Error)]
@@ -92,19 +130,17 @@ pub(crate) enum TerminalDriverEvent {
 /// - Detecting block completion
 pub(crate) struct TerminalDriver {
     terminal_view: ViewHandle<TerminalView>,
-    session_bootstrapped: Condition,
+    /// Sender half of the bootstrap result channel. Exactly one of
+    /// `SessionBootstrapped`, `PtySpawnFailed`, or `Exited` (pre-bootstrap)
+    /// will send the outcome; all others no-op after the first send.
+    bootstrap_tx: Option<oneshot::Sender<Result<(), BootstrapError>>>,
+    /// Receiver half consumed by `wait_for_session_bootstrapped`.
+    bootstrap_rx: Option<oneshot::Receiver<Result<(), BootstrapError>>>,
     /// The session ID once sharing has been established.
     shared_session_id: Option<SessionId>,
     /// Receiver for the session sharing result. Present when sharing is expected
     /// and `wait_for_session_shared` has not yet been called.
     session_share_rx: Option<oneshot::Receiver<Result<(), ShareSessionError>>>,
-    /// Sender half of the PTY-spawn-failure channel. When `PtySpawnFailed` fires
-    /// before bootstrap completes, the reason is sent here so that
-    /// `wait_for_session_bootstrapped` can race against it and fail immediately
-    /// instead of waiting for the full 60 s timeout.
-    spawn_failure_tx: Option<oneshot::Sender<String>>,
-    /// Receiver half consumed by `wait_for_session_bootstrapped`.
-    spawn_failure_rx: Option<oneshot::Receiver<String>>,
     pending_share_requests: Vec<ShareRequest>,
     waiting_command: Option<oneshot::Sender<ExitCode>>,
 
@@ -192,8 +228,6 @@ impl TerminalDriver {
         working_dir: PathBuf,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
-        let session_bootstrapped = Condition::new();
-
         // Create a oneshot channel for session sharing when sharing is expected.
         // When sharing is disabled (or running against ngrok), leave both halves
         // as None so that `wait_for_session_shared` returns immediately.
@@ -239,9 +273,11 @@ impl TerminalDriver {
             me.handle_terminal_view_event(event, &mut session_share_tx, ctx);
         });
 
-        // If the session already bootstrapped before we subscribed, set the
-        // condition immediately so callers of `wait_for_session_bootstrapped`
-        // don't block forever.
+        let (bootstrap_tx_inner, bootstrap_rx) =
+            oneshot::channel::<Result<(), BootstrapError>>();
+
+        // If bootstrap already completed before we subscribed, resolve the
+        // channel immediately so `wait_for_session_bootstrapped` doesn't block.
         let already_bootstrapped = terminal_view.read(ctx, |terminal, _| {
             terminal
                 .model
@@ -249,19 +285,19 @@ impl TerminalDriver {
                 .block_list()
                 .is_bootstrapping_precmd_done()
         });
-        if already_bootstrapped {
-            session_bootstrapped.set();
-        }
-
-        let (spawn_failure_tx, spawn_failure_rx) = oneshot::channel();
+        let bootstrap_tx = if already_bootstrapped {
+            let _ = bootstrap_tx_inner.send(Ok(()));
+            None
+        } else {
+            Some(bootstrap_tx_inner)
+        };
 
         Self {
             terminal_view,
-            session_bootstrapped,
+            bootstrap_tx,
+            bootstrap_rx: Some(bootstrap_rx),
             shared_session_id: None,
             session_share_rx,
-            spawn_failure_tx: Some(spawn_failure_tx),
-            spawn_failure_rx: Some(spawn_failure_rx),
             pending_share_requests: Vec::new(),
             waiting_command: None,
             pending_command_start: None,
@@ -548,54 +584,33 @@ impl TerminalDriver {
 
     /// Returns a future that resolves when the session has bootstrapped.
     ///
-    /// Races the 60 s bootstrap timeout against a `PtySpawnFailed` signal:
-    /// if the PTY failed to spawn before bootstrap completes, the failure
-    /// reason is delivered immediately via the `spawn_failure_rx` channel
-    /// and we return `BootstrapFailed` without waiting for the timeout.
+    /// The bootstrap result channel carries `Ok(())` on success or
+    /// `Err(BootstrapError)` on failure. If the channel times out, the error
+    /// is `BootstrapError::TimedOut`.
     pub fn wait_for_session_bootstrapped(
         &mut self,
-    ) -> impl Future<Output = Result<(), AgentDriverError>> {
-        let session_bootstrapped = self.session_bootstrapped.clone();
-        let spawn_failure_rx = self.spawn_failure_rx.take();
+    ) -> impl Future<Output = Result<(), BootstrapError>> {
+        let bootstrap_rx = self.bootstrap_rx.take();
 
         async move {
-            let reason = if let Some(failure_rx) = spawn_failure_rx {
-                // Race: bootstrap success vs. early PTY-spawn failure.
-                let success_future = session_bootstrapped
-                    .wait()
-                    .with_timeout(TERMINAL_SESSION_BOOTSTRAP_TIMEOUT);
-                futures::pin_mut!(success_future);
-                futures::pin_mut!(failure_rx);
-                match futures::future::select(success_future, failure_rx).await {
-                    // Bootstrap completed successfully.
-                    futures::future::Either::Left((Ok(()), _)) => return Ok(()),
-                    // Timed out before bootstrap or spawn-failure signal.
-                    futures::future::Either::Left((Err(_), _)) => {
-                        "Terminal session did not start within the expected time. \
-                         Check the Warp logs for details."
-                            .to_string()
-                    }
-                    // PTY spawn failed — use the specific reason from the view.
-                    futures::future::Either::Right((Ok(reason), _)) => reason,
-                    // Sender dropped without sending (shouldn't happen in practice).
-                    futures::future::Either::Right((Err(_), _)) => "Internal error".to_string(),
+            let result = if let Some(rx) = bootstrap_rx {
+                // Map channel cancellation (sender dropped without sending)
+                // to InternalError — this shouldn't happen in practice.
+                let inner =
+                    async move { rx.await.unwrap_or(Err(BootstrapError::InternalError)) };
+                match inner.with_timeout(TERMINAL_SESSION_BOOTSTRAP_TIMEOUT).await {
+                    Ok(result) => result,
+                    Err(_timeout) => Err(BootstrapError::TimedOut),
                 }
             } else {
-                // No failure channel — wait for bootstrap with the standard timeout.
-                match session_bootstrapped
-                    .wait()
-                    .with_timeout(TERMINAL_SESSION_BOOTSTRAP_TIMEOUT)
-                    .await
-                {
-                    Ok(()) => return Ok(()),
-                    Err(_) => "Terminal session did not start within the expected time. \
-                               Check the Warp logs for details."
-                        .to_string(),
-                }
+                // bootstrap_rx already consumed — shouldn't happen in normal flow.
+                Err(BootstrapError::InternalError)
             };
 
-            log::error!("Terminal bootstrap failed: {reason}");
-            Err(AgentDriverError::BootstrapFailed { reason })
+            if let Err(ref e) = result {
+                log::error!("Terminal bootstrap failed: {e}");
+            }
+            result
         }
     }
 
@@ -714,26 +729,27 @@ impl TerminalDriver {
     ) {
         match event {
             crate::terminal::view::Event::SessionBootstrapped => {
-                self.session_bootstrapped.set();
+                if let Some(tx) = self.bootstrap_tx.take() {
+                    let _ = tx.send(Ok(()));
+                }
             }
             crate::terminal::view::Event::PtySpawnFailed { reason } => {
                 // Signal the bootstrap waiter immediately so it doesn't wait
                 // for the full 60 s timeout when a spawn failure has already
                 // been confirmed.
-                if let Some(tx) = self.spawn_failure_tx.take() {
-                    let _ = tx.send(reason.clone());
+                if let Some(tx) = self.bootstrap_tx.take() {
+                    let _ = tx.send(Err(BootstrapError::PtySpawnFailed {
+                        reason: Some(reason.clone()),
+                    }));
                 }
             }
             crate::terminal::view::Event::Exited => {
-                // The shell process exited. If bootstrap hasn't completed yet
-                // it never will — cancel the wait immediately rather than
-                // sitting out the full 60 s timeout.
-                if !self.session_bootstrapped.is_set() {
-                    if let Some(tx) = self.spawn_failure_tx.take() {
-                        let _ = tx.send(
-                            "Shell spawn failed. Check the Warp logs for details.".to_string(),
-                        );
-                    }
+                // The shell process exited before bootstrap completed —
+                // cancel the wait immediately rather than sitting out the
+                // full 60 s timeout. No specific reason is known at this
+                // point; the logs will have details.
+                if let Some(tx) = self.bootstrap_tx.take() {
+                    let _ = tx.send(Err(BootstrapError::PtySpawnFailed { reason: None }));
                 }
             }
             crate::terminal::view::Event::SlowBootstrap => {

--- a/app/src/ai/agent_sdk/driver/terminal.rs
+++ b/app/src/ai/agent_sdk/driver/terminal.rs
@@ -56,7 +56,10 @@ impl std::fmt::Display for BootstrapError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             BootstrapError::PtySpawnFailed { reason: Some(r) } => {
-                write!(f, "Shell spawn failed: {r}. Check the Warp logs for details.")
+                write!(
+                    f,
+                    "Shell spawn failed: {r}. Check the Warp logs for details."
+                )
             }
             BootstrapError::PtySpawnFailed { reason: None } => {
                 write!(f, "Shell spawn failed. Check the Warp logs for details.")
@@ -273,8 +276,7 @@ impl TerminalDriver {
             me.handle_terminal_view_event(event, &mut session_share_tx, ctx);
         });
 
-        let (bootstrap_tx_inner, bootstrap_rx) =
-            oneshot::channel::<Result<(), BootstrapError>>();
+        let (bootstrap_tx_inner, bootstrap_rx) = oneshot::channel::<Result<(), BootstrapError>>();
 
         // If bootstrap already completed before we subscribed, resolve the
         // channel immediately so `wait_for_session_bootstrapped` doesn't block.
@@ -596,8 +598,7 @@ impl TerminalDriver {
             let result = if let Some(rx) = bootstrap_rx {
                 // Map channel cancellation (sender dropped without sending)
                 // to InternalError — this shouldn't happen in practice.
-                let inner =
-                    async move { rx.await.unwrap_or(Err(BootstrapError::InternalError)) };
+                let inner = async move { rx.await.unwrap_or(Err(BootstrapError::InternalError)) };
                 match inner.with_timeout(TERMINAL_SESSION_BOOTSTRAP_TIMEOUT).await {
                     Ok(result) => result,
                     Err(_timeout) => Err(BootstrapError::TimedOut),

--- a/app/src/ai/agent_sdk/driver/terminal.rs
+++ b/app/src/ai/agent_sdk/driver/terminal.rs
@@ -8,10 +8,8 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 
 use futures::channel::oneshot;
-use futures::TryFutureExt as _;
 use session_sharing_protocol::common::{Role, SessionId};
 use session_sharing_protocol::sharer::SessionRetentionReason;
-use tracing::Instrument as _;
 use warp_cli::share::{ShareAccessLevel, ShareRequest, ShareSubject};
 use warp_completer::completer::CommandOutput;
 use warp_core::command::ExitCode;
@@ -100,6 +98,13 @@ pub(crate) struct TerminalDriver {
     /// Receiver for the session sharing result. Present when sharing is expected
     /// and `wait_for_session_shared` has not yet been called.
     session_share_rx: Option<oneshot::Receiver<Result<(), ShareSessionError>>>,
+    /// Sender half of the PTY-spawn-failure channel. When `PtySpawnFailed` fires
+    /// before bootstrap completes, the reason is sent here so that
+    /// `wait_for_session_bootstrapped` can race against it and fail immediately
+    /// instead of waiting for the full 60 s timeout.
+    spawn_failure_tx: Option<oneshot::Sender<String>>,
+    /// Receiver half consumed by `wait_for_session_bootstrapped`.
+    spawn_failure_rx: Option<oneshot::Receiver<String>>,
     pending_share_requests: Vec<ShareRequest>,
     waiting_command: Option<oneshot::Sender<ExitCode>>,
 
@@ -248,11 +253,15 @@ impl TerminalDriver {
             session_bootstrapped.set();
         }
 
+        let (spawn_failure_tx, spawn_failure_rx) = oneshot::channel();
+
         Self {
             terminal_view,
             session_bootstrapped,
             shared_session_id: None,
             session_share_rx,
+            spawn_failure_tx: Some(spawn_failure_tx),
+            spawn_failure_rx: Some(spawn_failure_rx),
             pending_share_requests: Vec::new(),
             waiting_command: None,
             pending_command_start: None,
@@ -539,27 +548,54 @@ impl TerminalDriver {
 
     /// Returns a future that resolves when the session has bootstrapped.
     ///
-    /// This only waits for the `SessionBootstrapped` terminal view event.
+    /// Races the 60 s bootstrap timeout against a `PtySpawnFailed` signal:
+    /// if the PTY failed to spawn before bootstrap completes, the failure
+    /// reason is delivered immediately via the `spawn_failure_rx` channel
+    /// and we return `BootstrapFailed` without waiting for the timeout.
     pub fn wait_for_session_bootstrapped(
-        &self,
+        &mut self,
     ) -> impl Future<Output = Result<(), AgentDriverError>> {
         let session_bootstrapped = self.session_bootstrapped.clone();
+        let spawn_failure_rx = self.spawn_failure_rx.take();
 
         async move {
-            session_bootstrapped
-                .wait()
-                .with_timeout(TERMINAL_SESSION_BOOTSTRAP_TIMEOUT)
-                .map_err(|err| {
-                    log::error!("Timed out waiting for session bootstrap");
-                    tracing::error!(error = %err);
+            let reason = if let Some(failure_rx) = spawn_failure_rx {
+                // Race: bootstrap success vs. early PTY-spawn failure.
+                let success_future = session_bootstrapped
+                    .wait()
+                    .with_timeout(TERMINAL_SESSION_BOOTSTRAP_TIMEOUT);
+                futures::pin_mut!(success_future);
+                futures::pin_mut!(failure_rx);
+                match futures::future::select(success_future, failure_rx).await {
+                    // Bootstrap completed successfully.
+                    futures::future::Either::Left((Ok(()), _)) => return Ok(()),
+                    // Timed out before bootstrap or spawn-failure signal.
+                    futures::future::Either::Left((Err(_), _)) => {
+                        "Terminal session did not start within the expected time. \
+                         Check the Warp logs for details."
+                            .to_string()
+                    }
+                    // PTY spawn failed — use the specific reason from the view.
+                    futures::future::Either::Right((Ok(reason), _)) => reason,
+                    // Sender dropped without sending (shouldn't happen in practice).
+                    futures::future::Either::Right((Err(_), _)) => return Ok(()),
+                }
+            } else {
+                // No failure channel — wait for bootstrap with the standard timeout.
+                match session_bootstrapped
+                    .wait()
+                    .with_timeout(TERMINAL_SESSION_BOOTSTRAP_TIMEOUT)
+                    .await
+                {
+                    Ok(()) => return Ok(()),
+                    Err(_) => "Terminal session did not start within the expected time. \
+                               Check the Warp logs for details."
+                        .to_string(),
+                }
+            };
 
-                    AgentDriverError::BootstrapFailed
-                })
-                .instrument(tracing::info_span!(
-                    "wait_for_session_bootstrapped",
-                    tags.cloud_agent = true
-                ))
-                .await
+            log::error!("Terminal bootstrap failed: {reason}");
+            Err(AgentDriverError::BootstrapFailed { reason })
         }
     }
 
@@ -679,6 +715,14 @@ impl TerminalDriver {
         match event {
             crate::terminal::view::Event::SessionBootstrapped => {
                 self.session_bootstrapped.set();
+            }
+            crate::terminal::view::Event::PtySpawnFailed { reason } => {
+                // Signal the bootstrap waiter immediately so it doesn't wait
+                // for the full 60 s timeout when a spawn failure has already
+                // been confirmed.
+                if let Some(tx) = self.spawn_failure_tx.take() {
+                    let _ = tx.send(reason.clone());
+                }
             }
             crate::terminal::view::Event::SlowBootstrap => {
                 ctx.emit(TerminalDriverEvent::SlowBootstrap);

--- a/app/src/terminal/local_tty/spawner.rs
+++ b/app/src/terminal/local_tty/spawner.rs
@@ -188,9 +188,7 @@ impl PtySpawner {
 
         #[cfg(unix)]
         if let Some(server) = &self.server {
-            let result = Self::spawn_pty_via_server(server, options.clone()).context(
-                "Failed to spawn pty via terminal server; falling back to spawning locally...",
-            );
+            let result = Self::spawn_pty_via_server(server, options.clone());
             if let Err(err) = result {
                 // Log env var names + sizes for any terminal server failure.
                 // Large env vars are the most common cause (E2BIG on Linux,
@@ -200,16 +198,16 @@ impl PtySpawner {
 
                 // E2BIG is deterministic — retrying from the main process with
                 // the same PtyOptions would hit the same limit — so fail
-                // immediately rather than silently falling back and waiting for
-                // the bootstrap timeout.
+                // immediately rather than falling back.
                 if is_e2big(&err) {
                     return Err(err.context(
-                        "Shell spawn failed. This can happen when env vars or secrets are \
-                         too long — check your image for excessively long environment \
-                         variables or Oz for excessively long secrets.",
+                        "Shell spawn failed. This can happen when env vars in the image or Oz secrets are \
+                         too long. Check the Warp logs for details.",
                     ));
                 }
-                report_error!(err);
+                report_error!(err.context(
+                    "Failed to spawn pty via terminal server; falling back to spawning locally...",
+                ));
                 is_fallback = true;
             } else {
                 send_telemetry_from_app_ctx!(

--- a/app/src/terminal/local_tty/spawner.rs
+++ b/app/src/terminal/local_tty/spawner.rs
@@ -192,13 +192,17 @@ impl PtySpawner {
                 "Failed to spawn pty via terminal server; falling back to spawning locally...",
             );
             if let Err(err) = result {
-                // E2BIG means the combined environment + argument block passed to execve
-                // exceeds the kernel's ARG_MAX limit. This is deterministic — retrying from
-                // the main process with the same PtyOptions would hit the same limit — so
-                // fail immediately with a diagnostic message instead of silently falling back
-                // and then waiting for the bootstrap timeout.
+                // Log env var names + sizes for any terminal server failure.
+                // Large env vars are the most common cause (E2BIG on Linux,
+                // socket overflow on macOS), so logging them on every failure
+                // makes both cases diagnosable from the logs.
+                log_env_var_diagnostics(&options.env_vars);
+
+                // E2BIG is deterministic — retrying from the main process with
+                // the same PtyOptions would hit the same limit — so fail
+                // immediately rather than silently falling back and waiting for
+                // the bootstrap timeout.
                 if is_e2big(&err) {
-                    log_e2big_env_diagnostics(&options.env_vars);
                     return Err(err.context(
                         "Shell spawn failed. This can happen when env vars or secrets are \
                          too long — check your image for excessively long environment \
@@ -299,15 +303,12 @@ fn is_e2big(err: &anyhow::Error) -> bool {
     msg.contains("os error 7") || msg.contains("Argument list too long")
 }
 
-/// Logs the names and byte-lengths (not values) of the env vars that are
-/// likely contributing to an E2BIG failure, to help diagnose oversized
-/// environment configurations in cloud runs.
+/// Logs the names and byte-lengths (not values) of env vars passed to the
+/// shell. Called on any terminal server failure to aid diagnosis of oversized
+/// env var / secret configurations (E2BIG on Linux, socket overflow on macOS).
 #[cfg(unix)]
-fn log_e2big_env_diagnostics(extra_env_vars: &HashMap<OsString, OsString>) {
-    log::error!(
-        "Oversized env var diagnostics: shell spawn failed due to a large \
-         environment variable (E2BIG on Linux, socket overflow on macOS)."
-    );
+fn log_env_var_diagnostics(extra_env_vars: &HashMap<OsString, OsString>) {
+    log::error!("Shell spawn env var diagnostics (names and sizes only, no values):");
 
     // Log the additional env vars supplied via PtyOptions.
     let mut extra: Vec<(&OsString, usize)> = extra_env_vars

--- a/app/src/terminal/local_tty/spawner.rs
+++ b/app/src/terminal/local_tty/spawner.rs
@@ -2,13 +2,8 @@ use anyhow::Result;
 use warpui::{AppContext, Entity, SingletonEntity};
 #[cfg(unix)]
 use {
-    crate::report_error,
-    crate::terminal::local_tty::server::TerminalServer,
-    anyhow::{bail, Context},
-    std::cmp::Reverse,
-    std::collections::HashMap,
-    std::ffi::OsString,
-    std::process::Child,
+    crate::report_error, crate::terminal::local_tty::server::TerminalServer, anyhow::bail,
+    std::cmp::Reverse, std::collections::HashMap, std::ffi::OsString, std::process::Child,
 };
 
 #[cfg(target_os = "windows")]

--- a/app/src/terminal/local_tty/spawner.rs
+++ b/app/src/terminal/local_tty/spawner.rs
@@ -192,11 +192,29 @@ impl PtySpawner {
                 "Failed to spawn pty via terminal server; falling back to spawning locally...",
             );
             if let Err(err) = result {
-                // E2BIG means the combined environment + argument block passed to execve
-                // exceeds the kernel's ARG_MAX limit. This is deterministic — retrying from
-                // the main process with the same PtyOptions would hit the same limit — so
-                // fail immediately with a diagnostic message instead of silently falling back
-                // and then waiting for the bootstrap timeout.
+                // Two failure modes can be caused by large values in env_vars:
+                //
+                // 1. E2BIG (Linux): execve rejects the combined argv + envp block when
+                //    the total exceeds ARG_MAX, or a single value exceeds MAX_ARG_STRLEN.
+                // 2. Socket overflow (macOS and others): the SpawnShellRequest message
+                //    serialises env_vars in full; large values exceed the Unix socket
+                //    receive-buffer and produce a truncated-read error on the server side.
+                //
+                // In both cases retrying via the direct-spawn fallback would hit the
+                // same limit, so we fail immediately with actionable diagnostics.
+                //
+                // We check for oversized env vars first (covers both cases), then fall
+                // back to E2BIG string-matching for inherited process-env overflows that
+                // don't come from env_vars.
+                if let Some((key, value_len)) = find_oversized_env_var(&options.env_vars) {
+                    log_e2big_env_diagnostics(&options.env_vars);
+                    return Err(err.context(format!(
+                        "Shell spawn failed: env var {key:?} is {value_len} bytes, which \
+                         exceeds the maximum allowed for values passed to the shell. \
+                         Large secret values should be stored in a file and referenced \
+                         by path rather than embedded directly as an environment variable."
+                    )));
+                }
                 if is_e2big(&err) {
                     log_e2big_env_diagnostics(&options.env_vars);
                     return Err(err.context(
@@ -277,6 +295,26 @@ impl Entity for PtySpawner {
 
 impl SingletonEntity for PtySpawner {}
 
+/// The maximum byte-length of a single env var *value* that Warp will pass to
+/// the terminal server. Larger values cause two distinct failures:
+///   - On Linux: `execve` returns E2BIG (MAX_ARG_STRLEN is typically 128 KiB).
+///   - On macOS: the serialised `SpawnShellRequest` overflows the Unix socket
+///     receive buffer, producing a truncated-read error on the server side.
+/// 128 KiB is conservative enough to stay under both limits.
+#[cfg(unix)]
+const MAX_ENV_VAR_VALUE_BYTES: usize = 128 * 1024;
+
+/// If any value in `env_vars` exceeds [`MAX_ENV_VAR_VALUE_BYTES`], returns
+/// the name and byte-length of the largest offender; otherwise returns `None`.
+#[cfg(unix)]
+fn find_oversized_env_var(env_vars: &HashMap<OsString, OsString>) -> Option<(&OsString, usize)> {
+    env_vars
+        .iter()
+        .filter(|(_, v)| v.len() > MAX_ENV_VAR_VALUE_BYTES)
+        .max_by_key(|(_, v)| v.len())
+        .map(|(k, v)| (k, v.len()))
+}
+
 /// Returns `true` if the error (or any cause in its chain) indicates that
 /// `execve` failed with `ENAMETOOLONG` / E2BIG ("Argument list too long").
 ///
@@ -305,8 +343,8 @@ fn is_e2big(err: &anyhow::Error) -> bool {
 #[cfg(unix)]
 fn log_e2big_env_diagnostics(extra_env_vars: &HashMap<OsString, OsString>) {
     log::error!(
-        "E2BIG env diagnostics: shell spawn failed because the combined \
-         environment block exceeds the kernel ARG_MAX limit."
+        "Oversized env var diagnostics: shell spawn failed due to a large \
+         environment variable (E2BIG on Linux, socket overflow on macOS)."
     );
 
     // Log the additional env vars supplied via PtyOptions.

--- a/app/src/terminal/local_tty/spawner.rs
+++ b/app/src/terminal/local_tty/spawner.rs
@@ -192,35 +192,17 @@ impl PtySpawner {
                 "Failed to spawn pty via terminal server; falling back to spawning locally...",
             );
             if let Err(err) = result {
-                // Two failure modes can be caused by large values in env_vars:
-                //
-                // 1. E2BIG (Linux): execve rejects the combined argv + envp block when
-                //    the total exceeds ARG_MAX, or a single value exceeds MAX_ARG_STRLEN.
-                // 2. Socket overflow (macOS and others): the SpawnShellRequest message
-                //    serialises env_vars in full; large values exceed the Unix socket
-                //    receive-buffer and produce a truncated-read error on the server side.
-                //
-                // In both cases retrying via the direct-spawn fallback would hit the
-                // same limit, so we fail immediately with actionable diagnostics.
-                //
-                // We check for oversized env vars first (covers both cases), then fall
-                // back to E2BIG string-matching for inherited process-env overflows that
-                // don't come from env_vars.
-                if let Some((key, value_len)) = find_oversized_env_var(&options.env_vars) {
-                    log_e2big_env_diagnostics(&options.env_vars);
-                    return Err(err.context(format!(
-                        "Shell spawn failed: env var {key:?} is {value_len} bytes, which \
-                         exceeds the maximum allowed for values passed to the shell. \
-                         Large secret values should be stored in a file and referenced \
-                         by path rather than embedded directly as an environment variable."
-                    )));
-                }
+                // E2BIG means the combined environment + argument block passed to execve
+                // exceeds the kernel's ARG_MAX limit. This is deterministic — retrying from
+                // the main process with the same PtyOptions would hit the same limit — so
+                // fail immediately with a diagnostic message instead of silently falling back
+                // and then waiting for the bootstrap timeout.
                 if is_e2big(&err) {
                     log_e2big_env_diagnostics(&options.env_vars);
                     return Err(err.context(
-                        "Shell spawn failed: the combined environment is too large (E2BIG / \"Argument list too long\"). \
-                         Check the Warp logs for a breakdown of env var sizes. \
-                         Reduce or remove large environment variables from the run configuration.",
+                        "Shell spawn failed. This can happen when env vars or secrets are \
+                         too long — check your image for excessively long environment \
+                         variables or Oz for excessively long secrets.",
                     ));
                 }
                 report_error!(err);
@@ -294,26 +276,6 @@ impl Entity for PtySpawner {
 }
 
 impl SingletonEntity for PtySpawner {}
-
-/// The maximum byte-length of a single env var *value* that Warp will pass to
-/// the terminal server. Larger values cause two distinct failures:
-///   - On Linux: `execve` returns E2BIG (MAX_ARG_STRLEN is typically 128 KiB).
-///   - On macOS: the serialised `SpawnShellRequest` overflows the Unix socket
-///     receive buffer, producing a truncated-read error on the server side.
-/// 128 KiB is conservative enough to stay under both limits.
-#[cfg(unix)]
-const MAX_ENV_VAR_VALUE_BYTES: usize = 128 * 1024;
-
-/// If any value in `env_vars` exceeds [`MAX_ENV_VAR_VALUE_BYTES`], returns
-/// the name and byte-length of the largest offender; otherwise returns `None`.
-#[cfg(unix)]
-fn find_oversized_env_var(env_vars: &HashMap<OsString, OsString>) -> Option<(&OsString, usize)> {
-    env_vars
-        .iter()
-        .filter(|(_, v)| v.len() > MAX_ENV_VAR_VALUE_BYTES)
-        .max_by_key(|(_, v)| v.len())
-        .map(|(k, v)| (k, v.len()))
-}
 
 /// Returns `true` if the error (or any cause in its chain) indicates that
 /// `execve` failed with `ENAMETOOLONG` / E2BIG ("Argument list too long").

--- a/app/src/terminal/local_tty/spawner.rs
+++ b/app/src/terminal/local_tty/spawner.rs
@@ -195,9 +195,10 @@ impl PtySpawner {
                 // the same PtyOptions would hit the same limit — so fail
                 // immediately rather than falling back.
                 if is_e2big(&err) {
+                    // err already contains the original message. We add some context on how to fix.
                     return Err(err.context(
-                        "Shell spawn failed. This can happen when env vars in the image or Oz secrets are \
-                         too long. Check the Warp logs for details.",
+                        "This can happen when env vars in the image or Oz secrets are \
+                         too long.",
                     ));
                 }
                 report_error!(err.context(

--- a/app/src/terminal/local_tty/spawner.rs
+++ b/app/src/terminal/local_tty/spawner.rs
@@ -5,6 +5,9 @@ use {
     crate::report_error,
     crate::terminal::local_tty::server::TerminalServer,
     anyhow::{bail, Context},
+    std::cmp::Reverse,
+    std::collections::HashMap,
+    std::ffi::OsString,
     std::process::Child,
 };
 
@@ -189,6 +192,19 @@ impl PtySpawner {
                 "Failed to spawn pty via terminal server; falling back to spawning locally...",
             );
             if let Err(err) = result {
+                // E2BIG means the combined environment + argument block passed to execve
+                // exceeds the kernel's ARG_MAX limit. This is deterministic — retrying from
+                // the main process with the same PtyOptions would hit the same limit — so
+                // fail immediately with a diagnostic message instead of silently falling back
+                // and then waiting for the bootstrap timeout.
+                if is_e2big(&err) {
+                    log_e2big_env_diagnostics(&options.env_vars);
+                    return Err(err.context(
+                        "Shell spawn failed: the combined environment is too large (E2BIG / \"Argument list too long\"). \
+                         Check the Warp logs for a breakdown of env var sizes. \
+                         Reduce or remove large environment variables from the run configuration.",
+                    ));
+                }
                 report_error!(err);
                 is_fallback = true;
             } else {
@@ -260,3 +276,65 @@ impl Entity for PtySpawner {
 }
 
 impl SingletonEntity for PtySpawner {}
+
+/// Returns `true` if the error (or any cause in its chain) indicates that
+/// `execve` failed with `ENAMETOOLONG` / E2BIG ("Argument list too long").
+///
+/// The terminal-server IPC path stringifies the raw `io::Error`, so we cannot
+/// reliably downcast; instead we check the formatted error message as a
+/// fallback.
+#[cfg(unix)]
+fn is_e2big(err: &anyhow::Error) -> bool {
+    // Try the "real" io::Error in the chain first (direct-spawn path).
+    if err.chain().any(|e| {
+        e.downcast_ref::<std::io::Error>()
+            .and_then(|e| e.raw_os_error())
+            .is_some_and(|code| code == libc::E2BIG)
+    }) {
+        return true;
+    }
+    // Fall back to string matching for the IPC path where the io::Error
+    // was serialised to a String before being sent back to the client.
+    let msg = format!("{err:#}");
+    msg.contains("os error 7") || msg.contains("Argument list too long")
+}
+
+/// Logs the names and byte-lengths (not values) of the env vars that are
+/// likely contributing to an E2BIG failure, to help diagnose oversized
+/// environment configurations in cloud runs.
+#[cfg(unix)]
+fn log_e2big_env_diagnostics(extra_env_vars: &HashMap<OsString, OsString>) {
+    log::error!(
+        "E2BIG env diagnostics: shell spawn failed because the combined \
+         environment block exceeds the kernel ARG_MAX limit."
+    );
+
+    // Log the additional env vars supplied via PtyOptions.
+    let mut extra: Vec<(&OsString, usize)> = extra_env_vars
+        .iter()
+        .map(|(k, v)| (k, k.len() + v.len() + 2))
+        .collect();
+    extra.sort_by_key(|(_, size)| Reverse(*size));
+    log::error!("  PtyOptions env_vars ({} entries):", extra_env_vars.len());
+    for (key, size) in extra.iter().take(20) {
+        log::error!("    {:?} — {} bytes", key, size);
+    }
+
+    // Log the largest vars from the inherited process environment.
+    let mut inherited: Vec<(OsString, usize)> = std::env::vars_os()
+        .map(|(k, v)| {
+            let size = k.len() + v.len() + 2;
+            (k, size)
+        })
+        .collect();
+    inherited.sort_by_key(|(_, size)| Reverse(*size));
+    let total: usize = inherited.iter().map(|(_, s)| s).sum();
+    log::error!(
+        "  Inherited process env ({} vars, ~{} bytes total):",
+        inherited.len(),
+        total
+    );
+    for (key, size) in inherited.iter().take(20) {
+        log::error!("    {:?} — {} bytes", key, size);
+    }
+}

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -1856,6 +1856,12 @@ pub enum Event {
     SessionBootstrapped,
     AnonymousUserSignup,
     ShellSpawned(ShellType),
+    /// Emitted when the PTY failed to spawn. Carries a human-readable reason
+    /// string (not secret values) so the terminal driver can surface a
+    /// specific error without waiting for the full bootstrap timeout.
+    PtySpawnFailed {
+        reason: String,
+    },
 
     /// This terminal pane has initiated a file upload to a remote host.
     CopyFileToRemote {
@@ -15804,6 +15810,10 @@ impl TerminalView {
         ctx: &mut ViewContext<Self>,
     ) {
         self.pty_spawn_failed = true;
+        // Emit before the banner so the terminal driver can cancel its
+        // bootstrap wait immediately, without waiting for the 60 s timeout.
+        let reason = format!("{pty_spawn_error:#}");
+        ctx.emit(Event::PtySpawnFailed { reason });
         self.insert_shell_process_terminated_banner(
             shell_terminated_banner::TerminationType::PtySpawnFailure { pty_spawn_error },
             ctx,


### PR DESCRIPTION
## Description

Resolves REMOTE-1935 https://linear.app/warpdotdev/issue/REMOTE-1935/investigate-terminal-bootstrapping-failures
- Note it was one user who tried multiple times

When the terminal server fails to spawn a shell (e.g. due to E2BIG / "Argument list too long"), Warp previously fell back to a direct spawn and then waited the full 60 s bootstrap timeout before surfacing a generic "Terminal session failed to start. Please try running your task again." error. This makes cloud agent failures from oversized environments take over a minute and give the user no actionable information.

This error can happen when env vars or secrets are too long. The syscall `execve` fails when spawning the initial shell with `/bin/bash -c "exec -a bash '/bin/bash' --rcfile <(echo '<bootstrap_script>')"`.

If the shell fails to spawn, we immediately return the error instead of waiting the full timeout, and give a more actionable error message. We also log some diagnostic information to see what is so large.

## Testing
 
Reproduced the original error by starting an oz run with a really long secret.

After the fix, see error message and logs
<img width="449" height="776" alt="Screenshot 2026-06-15 at 6 37 42 PM" src="https://github.com/user-attachments/assets/8033861c-d7ee-455b-b3f5-d04d0feb56f6" />


```
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner] Shell spawn env var diagnostics (names and sizes only, no values):
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]   PtyOptions env_vars (9 entries):
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "roland-long-fake-secret" — 1500025 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "OZ_CLI" — 89 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "WARP_FOCUS_URL" — 68 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "WARP_TERMINAL_SESSION_UUID" — 60 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "WARP_SESSION_SHARING_SERVER_URL" — 52 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "WARP_WS_SERVER_URL" — 50 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "OZ_RUN_ID" — 47 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "WARP_SERVER_ROOT_URL" — 43 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "OZ_HARNESS" — 14 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]   Inherited process env (15 vars, ~1236 bytes total):
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "PATH" — 630 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "WARP_WORKLOAD_TOKEN" — 85 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "WARP_API_KEY" — 83 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "GITHUB_ACCESS_TOKEN" — 61 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "TMPDIR" — 57 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "GH_TOKEN" — 50 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "OZ_RUN_ID" — 47 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "TASK_ID" — 45 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "__CF_USER_TEXT_ENCODING" — 38 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "WITH_LOCAL_SESSION_SHARING_SERVER" — 36 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "HOME" — 24 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "GIT_TERMINAL_PROMPT" — 22 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "GH_PROMPT_DISABLED" — 21 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "WITH_LOCAL_SERVER" — 20 bytes
2026-06-16T01:36:46Z [ERROR] [warp::terminal::local_tty::spawner]     "LANG" — 17 bytes
2026-06-16T01:36:46Z [ERROR] [errors::report_error] Failed to spawn pty via terminal server; falling back to spawning locally...: Received error reading message back from terminal server
2026-06-16T01:36:46Z [INFO] [warp::terminal::local_tty::unix] Starting shell /bin/zsh
2026-06-16T01:36:46Z [INFO] [warp::terminal::local_tty::unix] Successfully spawned child zsh process with pid 57986
2026-06-16T01:36:46Z [INFO] [warp::terminal::model::terminal_model] Tried to exit the alternate screen, but it was already inactive
2026-06-16T01:36:46Z [INFO] [warp::terminal::model::block] Block finished with new state DoneWithNoExecution
2026-06-16T01:36:46Z [INFO] [warpui_core::core::app] dispatching typed action: warp::pane_group::PaneGroupAction::HandleFocusChange
2026-06-16T01:36:46Z [WARN] [warpui_core::core::app] Action HandleFocusChange was dispatched, but no view handled it
2026-06-16T01:36:46Z [ERROR] [warp::ai::agent_sdk::driver::terminal] Terminal bootstrap failed: Shell spawn failed. This can happen when env vars or secrets are too long — check your image for excessively long environment variables or Oz for excessively long secrets.
```