### PR TITLE
Downgrade unknown LlmModelHost report to warn log

### DIFF
--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -2830,11 +2830,8 @@ impl From<warp_graphql::queries::get_feature_model_choices::LlmModelHost> for LL
                 LLMModelHost::GeminiEnterprise
             }
             warp_graphql::queries::get_feature_model_choices::LlmModelHost::Other(value) => {
-                report_error!(
-                    anyhow!(
-                        "Unknown LlmModelHost '{value}'. Make sure to update client GraphQL types!"
-                    ),
-                    warp_core::errors::ReportErrorLogMode::OncePerRun
+                log::warn!(
+                    "Unknown LlmModelHost '{value}'. Make sure to update client GraphQL types!"
                 );
                 LLMModelHost::Unknown
             }

--- a/app/src/workspaces/gql_convert.rs
+++ b/app/src/workspaces/gql_convert.rs
@@ -750,11 +750,8 @@ impl From<warp_graphql::workspace::LlmModelHost> for crate::ai::llms::LLMModelHo
             GqlLlmModelHost::CustomEndpoint => Self::CustomEndpoint,
             GqlLlmModelHost::GeminiEnterprise => Self::GeminiEnterprise,
             GqlLlmModelHost::Other(value) => {
-                report_error!(
-                    anyhow!(
-                        "Unknown LlmModelHost '{value}'. Make sure to update client GraphQL types!"
-                    ),
-                    warp_core::errors::ReportErrorLogMode::OncePerRun
+                log::warn!(
+                    "Unknown LlmModelHost '{value}'. Make sure to update client GraphQL types!"
                 );
                 Self::Unknown
             }


### PR DESCRIPTION
## Description
The `LlmModelHost` GraphQL enum conversions report unknown values (`Other(value)`) via `report_error!` at `Error` level, which captures to Sentry. Unknown enum values are an *expected* condition during a server-ahead-of-client rollout — when the server starts returning a new host like `GEMINI_ENTERPRISE`, every older client that can't parse it fires this report. At our scale this flooded Sentry (millions of events, ~220k users) and got us rate limited.

`ReportErrorLogMode::OncePerRun` doesn't help here: it dedupes once per process run via a `static AtomicBool`, so it does nothing across users or app restarts.

This changes both `LlmModelHost` `Other(value)` arms to `log::warn!` instead of `report_error!`:
- `app/src/workspaces/gql_convert.rs` (workspace settings)
- `app/src/server/server_api/ai.rs` (get_feature_model_choices query)

Only `Error`-level `report_error!` logs are captured to Sentry, so this stops the flood. The fallback to `Self::Unknown` / `LLMModelHost::Unknown` is unchanged.

Note: other `Other(value)` enum arms in these files (LlmProvider, AgentHarness, host enablement, autonomy values, etc.) still report to Sentry as actionable tripwires.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Log-level-only change with no behavioral impact (fallback values unchanged). Verified the crate formats cleanly with `cargo fmt`.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->
