### PR TITLE
Fix CLI subagent command takeover semantics

### DIFF
--- a/app/src/ai/blocklist/block/cli_controller.rs
+++ b/app/src/ai/blocklist/block/cli_controller.rs
@@ -27,8 +27,8 @@ use crate::BlocklistAIHistoryModel;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum UserTakeOverReason {
+    #[serde(alias = "Stop")]
     Manual,
-    Stop,
     /// The agent explicitly transferred control to the user via the
     /// TransferShellCommandControlToUser tool call.
     TransferFromAgent {
@@ -44,10 +44,6 @@ struct ActiveCLISubagentState {
 }
 
 impl UserTakeOverReason {
-    pub fn is_stop(&self) -> bool {
-        matches!(self, Self::Stop)
-    }
-
     pub fn is_transfer_from_agent(&self) -> bool {
         matches!(self, Self::TransferFromAgent { .. })
     }
@@ -225,25 +221,6 @@ impl CLISubagentController {
                     .as_ref()
                     .is_some_and(|state| state.task_id.is_some())
                 {
-                    let is_inline_agent_view =
-                        me.agent_view_controller.as_ref().is_some_and(|controller| {
-                            controller.read(ctx, |controller, _| controller.is_inline())
-                        });
-
-                    if is_inline_agent_view {
-                        // Mark conversation as successfully completed BEFORE exiting agent view.
-                        // The command finished naturally, so this is a successful completion.
-                        if let Some(conversation_id) = conversation_id {
-                            me.controller.update(ctx, |controller, ctx| {
-                                controller.cancel_conversation_progress(
-                                    conversation_id,
-                                    CancellationReason::OptimisticCLISubagentCompletion,
-                                    ctx,
-                                );
-                            });
-                        }
-                    }
-
                     ctx.emit(CLISubagentEvent::FinishedSubagent {
                         block_id,
                         conversation_id,

--- a/app/src/ai/blocklist/inline_action/requested_command.rs
+++ b/app/src/ai/blocklist/inline_action/requested_command.rs
@@ -80,7 +80,6 @@ const MCP_TOOL_WAITING_FOR_USER_MESSAGE: &str = "OK if I call this MCP tool?";
 const MONITORING_COMMAND_MESSAGE: &str = "Agent is monitoring command...";
 const AGENT_NEEDS_INPUT_MESSAGE: &str = "Agent needs your input to continue";
 const USER_TOOK_CONTROL_COMMAND_MESSAGE: &str = "User is in control.";
-const USER_STOPPED_CLI_SUBAGENT_COMMAND_MESSAGE: &str = "Paused agent. User is in control.";
 const AGENT_REQUESTED_USER_TAKE_CONTROL_COMMAND_MESSAGE: &str = "User in control";
 const AGENT_ERRORED_COMMAND_MESSAGE: &str = "Agent ran into an issue. Take over control.";
 pub const VIEWING_COMMAND_DETAIL_MESSAGE: &str = "Viewing command detail";
@@ -1318,7 +1317,6 @@ pub(crate) fn header_message_for_user_take_over_reason(
 ) -> &'static str {
     match reason {
         UserTakeOverReason::Manual => USER_TOOK_CONTROL_COMMAND_MESSAGE,
-        UserTakeOverReason::Stop => USER_STOPPED_CLI_SUBAGENT_COMMAND_MESSAGE,
         UserTakeOverReason::TransferFromAgent { .. } => {
             AGENT_REQUESTED_USER_TAKE_CONTROL_COMMAND_MESSAGE
         }

--- a/app/src/terminal/model/block/interaction_mode.rs
+++ b/app/src/terminal/model/block/interaction_mode.rs
@@ -156,16 +156,14 @@ impl Block {
         }
     }
 
-    /// Sets control to user with Stop reason if a long-running control state exists.
-    pub fn set_user_control_with_stop_reason(&mut self) {
-        if let InteractionMode::Agent(AgentInteractionMetadata {
-            long_running_control_state: Some(ref mut state),
-            ..
-        }) = self.interaction_mode
-        {
-            *state = LongRunningCommandControlState::User {
-                reason: UserTakeOverReason::Stop,
-            };
+    pub fn suppress_agent_auto_resume(&mut self) {
+        if let InteractionMode::Agent(metadata) = &mut self.interaction_mode {
+            metadata.suppress_auto_resume = true;
+            if let Some(state) = &mut metadata.long_running_control_state {
+                *state = LongRunningCommandControlState::User {
+                    reason: UserTakeOverReason::Manual,
+                };
+            }
         }
     }
 
@@ -230,6 +228,7 @@ impl Block {
             long_running_control_state: None,
             has_agent_written_to_block: false,
             should_hide_block: true,
+            suppress_auto_resume: false,
         })
     }
 
@@ -341,13 +340,16 @@ impl InteractionMode {
         task_id: &TaskId,
         conversation_id: AIConversationId,
     ) -> Result<Self, UpdateInteractionModeError> {
-        let requested_command_action_id = match self {
-            InteractionMode::User(_) => None,
+        let (requested_command_action_id, suppress_auto_resume) = match self {
+            InteractionMode::User(_) => (None, false),
             InteractionMode::Agent(metadata) => {
                 if metadata.conversation_id != conversation_id {
                     return Err(UpdateInteractionModeError::UnexpectedConversationId);
                 }
-                metadata.requested_command_action_id.clone()
+                (
+                    metadata.requested_command_action_id.clone(),
+                    metadata.suppress_auto_resume,
+                )
             }
         };
 
@@ -361,6 +363,7 @@ impl InteractionMode {
             }),
             has_agent_written_to_block: false,
             should_hide_block: false,
+            suppress_auto_resume,
         }))
     }
 
@@ -485,6 +488,8 @@ pub struct AgentInteractionMetadata {
     /// `true` if this block should be hidden from the user (as is the case with AI-requested
     /// commands, for example).
     should_hide_block: bool,
+
+    suppress_auto_resume: bool,
 }
 
 impl AgentInteractionMetadata {
@@ -504,6 +509,7 @@ impl AgentInteractionMetadata {
             long_running_control_state,
             has_agent_written_to_block,
             should_hide_block,
+            suppress_auto_resume: false,
         }
     }
 
@@ -550,6 +556,13 @@ impl AgentInteractionMetadata {
 
     pub fn should_hide_block(&self) -> bool {
         self.should_hide_block
+    }
+    pub fn suppress_auto_resume(&mut self) {
+        self.suppress_auto_resume = true;
+    }
+
+    pub fn should_suppress_auto_resume(&self) -> bool {
+        self.suppress_auto_resume
     }
 }
 

--- a/app/src/terminal/model/block/serialized_block.rs
+++ b/app/src/terminal/model/block/serialized_block.rs
@@ -113,6 +113,9 @@ pub struct SerializedAIMetadata {
     /// commands, for example).
     #[serde(default = "default_as_true", skip)]
     should_hide_block: bool,
+
+    #[serde(default)]
+    suppress_auto_resume: bool,
 }
 
 impl From<AgentInteractionMetadata> for SerializedAIMetadata {
@@ -124,20 +127,25 @@ impl From<AgentInteractionMetadata> for SerializedAIMetadata {
             long_running_control_state: value.long_running_control_state().cloned(),
             has_agent_written_to_block: value.has_agent_written_to_block(),
             should_hide_block: value.should_hide_block(),
+            suppress_auto_resume: value.should_suppress_auto_resume(),
         }
     }
 }
 
 impl From<SerializedAIMetadata> for AgentInteractionMetadata {
     fn from(value: SerializedAIMetadata) -> Self {
-        AgentInteractionMetadata::new(
+        let mut metadata = AgentInteractionMetadata::new(
             value.requested_command_action_id,
             value.conversation_id,
             value.subagent_task_id,
             value.long_running_control_state,
             value.has_agent_written_to_block,
             value.should_hide_block,
-        )
+        );
+        if value.suppress_auto_resume {
+            metadata.suppress_auto_resume();
+        }
+        metadata
     }
 }
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -2380,7 +2380,6 @@ pub struct TerminalViewStateChange {
 struct CtrlCActiveBlockState {
     is_long_running: bool,
     is_agent_in_control_of_command: bool,
-    conversation_id_to_stop: Option<AIConversationId>,
 }
 
 impl Default for TerminalViewStateChange {
@@ -3757,7 +3756,21 @@ impl TerminalView {
                 });
                 ctx.emit(Event::SummarizationCancelDialogToggled { is_open: *is_open });
             }
-            BlocklistAIStatusBarEvent::Stop => me.ctrl_c(ctx),
+            BlocklistAIStatusBarEvent::Stop => {
+                let conversation_id = me
+                    .agent_view_controller
+                    .as_ref(ctx)
+                    .agent_view_state()
+                    .active_conversation_id()
+                    .or_else(|| {
+                        BlocklistAIHistoryModel::as_ref(ctx).active_conversation_id(me.view_id)
+                    });
+                if let Some(conversation_id) = conversation_id {
+                    me.stop_local_agent_conversation(conversation_id, ctx);
+                } else {
+                    me.ctrl_c(ctx);
+                }
+            }
         });
         if let Some(ambient_agent_view_model) = ambient_agent_view_model.as_ref() {
             ctx.subscribe_to_model(ambient_agent_view_model, |me, _, event, ctx| {
@@ -8431,7 +8444,7 @@ impl TerminalView {
                 || active_block.is_active_and_long_running();
 
             if active_block_matches && command_is_running {
-                active_block.set_user_control_with_stop_reason();
+                active_block.suppress_agent_auto_resume();
                 true
             } else {
                 false
@@ -8509,19 +8522,9 @@ impl TerminalView {
             let active_block = model.block_list().active_block();
             let is_long_running = active_block.is_active_and_long_running();
             let is_agent_in_control_of_command = active_block.is_agent_in_control();
-            let conversation_id_to_stop = active_block
-                .long_running_control_state()
-                .and_then(|state| {
-                    state
-                        .user_take_over_reason()
-                        .is_some_and(UserTakeOverReason::is_stop)
-                        .then(|| active_block.ai_conversation_id())
-                })
-                .flatten();
             let active_block_state = CtrlCActiveBlockState {
                 is_long_running,
                 is_agent_in_control_of_command,
-                conversation_id_to_stop,
             };
             (
                 has_block_list_selection,
@@ -8635,15 +8638,10 @@ impl TerminalView {
     ) {
         if active_block_state.is_agent_in_control_of_command {
             self.cli_subagent_controller.update(ctx, |controller, ctx| {
-                controller.switch_control_to_user(UserTakeOverReason::Stop, ctx);
+                controller.switch_control_to_user(UserTakeOverReason::Manual, ctx);
             });
         } else if active_block_state.is_long_running {
-            // A second Ctrl+C after Stop takeover should cancel both the command and conversation.
-            if let Some(conversation_id) = active_block_state.conversation_id_to_stop {
-                self.stop_local_agent_conversation(conversation_id, ctx);
-            } else {
-                self.user_write_ctrl_c_to_pty(ctx);
-            }
+            self.user_write_ctrl_c_to_pty(ctx);
         } else {
             self.maybe_handle_ctrl_c_in_rich_content_block(ctx);
         }
@@ -10855,13 +10853,10 @@ impl TerminalView {
             match ai_metadata {
                 Some(ai_metadata)
                     if ai_metadata.requested_command_action_id().is_some()
+                        && !ai_metadata.should_suppress_auto_resume()
                         && ai_metadata
                             .long_running_control_state()
-                            .is_some_and(|state| {
-                                state
-                                    .user_take_over_reason()
-                                    .is_some_and(|reason| !reason.is_stop())
-                            }) =>
+                            .is_some_and(|state| state.user_take_over_reason().is_some()) =>
                 {
                     Some(*ai_metadata.conversation_id())
                 }
@@ -24575,8 +24570,8 @@ impl TerminalView {
             );
         });
 
-        // If the active block is a running command from this conversation, stop it and
-        // set the take-over reason to Stop to prevent automatic conversation resume.
+        // If the active block is a running command from this conversation, suppress
+        // automatic conversation resume when the command eventually completes.
         let should_stop_running_command = {
             let mut model = self.model.lock();
             let active_block = model.block_list_mut().active_block_mut();
@@ -24585,7 +24580,7 @@ impl TerminalView {
                 && active_block.ai_conversation_id() == Some(conversation_id);
 
             if is_from_this_conversation {
-                active_block.set_user_control_with_stop_reason();
+                active_block.suppress_agent_auto_resume();
             }
 
             is_from_this_conversation

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -19,7 +19,8 @@ use super::*;
 use crate::ai::agent::conversation::{AIConversation, ConversationStatus};
 use crate::ai::agent::task::TaskId;
 use crate::ai::agent::{
-    AIAgentExchange, AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus, UserQueryMode,
+    AIAgentActionId, AIAgentExchange, AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus,
+    UserQueryMode,
 };
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::agent_view::toolbar_item::AgentToolbarItemKind;
@@ -5212,7 +5213,7 @@ fn inline_agent_view_exits_when_tagged_in_long_running_command_is_tagged_out() {
 }
 
 #[test]
-fn ctrl_c_after_stop_takeover_cancels_conversation() {
+fn ctrl_c_after_takeover_interrupts_command_without_cancelling_conversation() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         FeatureFlag::AgentView.set_enabled(true);
@@ -5245,11 +5246,24 @@ fn ctrl_c_after_stop_takeover_cancels_conversation() {
                 .set_agent_interaction_mode_for_agent_monitored_command(&task_id, conversation_id)
                 .expect("command should become agent monitored");
 
-            view.cli_subagent_controller.update(ctx, |controller, ctx| {
-                controller.switch_control_to_user(UserTakeOverReason::Stop, ctx);
-            });
-
             conversation_id
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            view.handle_action(&TerminalAction::CtrlC, ctx);
+        });
+        assert!(pty_writes.borrow().is_empty());
+        terminal.read(&app, |view, ctx| {
+            let model = view.model.lock();
+            let active_block = model.block_list().active_block();
+            assert!(active_block
+                .long_running_control_state()
+                .and_then(|state| state.user_take_over_reason())
+                .is_some_and(|reason| matches!(reason, UserTakeOverReason::Manual)));
+            let conversation = BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(&conversation_id)
+                .expect("conversation should exist");
+            assert_eq!(conversation.status(), &ConversationStatus::InProgress);
         });
 
         terminal.update(&mut app, |view, ctx| {
@@ -5261,7 +5275,7 @@ fn ctrl_c_after_stop_takeover_cancels_conversation() {
             let conversation = BlocklistAIHistoryModel::as_ref(ctx)
                 .conversation(&conversation_id)
                 .expect("conversation should exist");
-            assert_eq!(conversation.status(), &ConversationStatus::Cancelled);
+            assert_eq!(conversation.status(), &ConversationStatus::InProgress);
         });
     })
 }
@@ -5325,6 +5339,52 @@ fn ctrl_c_after_transfer_takeover_does_not_cancel_conversation() {
             // completion to the agent, so Ctrl-C should interrupt the command without
             // cancelling the conversation.
             assert_eq!(conversation.status(), &ConversationStatus::InProgress);
+        });
+    })
+}
+
+#[test]
+fn completed_user_controlled_lrc_respects_auto_resume_suppression() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            let conversation_id =
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                    history.start_new_conversation(view.view_id, false, false, false, ctx)
+                });
+            view.model
+                .lock()
+                .simulate_long_running_block("sleep 20", "running");
+            let task_id = TaskId::new("test-cli-subagent".to_owned());
+            let block_id = {
+                let mut model = view.model.lock();
+                let active_block = model.block_list_mut().active_block_mut();
+                active_block.set_agent_interaction_mode_for_requested_command(
+                    AIAgentActionId::from("requested-command".to_owned()),
+                    Some(task_id.clone()),
+                    conversation_id,
+                );
+                active_block
+                    .set_agent_interaction_mode_for_agent_monitored_command(
+                        &task_id,
+                        conversation_id,
+                    )
+                    .expect("command should become agent monitored");
+                active_block
+                    .take_over_control_for_user(UserTakeOverReason::Manual)
+                    .expect("user takeover should succeed");
+                active_block.suppress_agent_auto_resume();
+                active_block.id().clone()
+            };
+
+            view.on_user_block_completed(&block_id, ctx);
+
+            assert!(!view
+                .ai_controller
+                .as_ref(ctx)
+                .has_active_stream_for_conversation(conversation_id, ctx));
         });
     })
 }


### PR DESCRIPTION
## Description
Replaces the previous idle-completion/status-success approach with the two intended control-flow fixes for CLI subagent long-running commands:

- Ctrl-C while the agent controls an attached command now takes user control with `UserTakeOverReason::Manual` rather than a separate `Stop` reason. This keeps takeover resumable, and a subsequent Ctrl-C only interrupts the PTY command.
- Explicit stop/rewind paths now persist a separate `suppress_auto_resume` bit on command metadata. If that command completes later, `on_user_block_completed` skips the stale auto-resume instead of relying on takeover provenance.

This also keeps old serialized `Stop` metadata readable as `Manual`.

## Linked Issue
N/A

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `./script/format`
- [x] `cargo test -p warp ctrl_c_after_ --lib`
- [x] `cargo test -p warp completed_user_controlled_lrc_respects_auto_resume_suppression --lib`
- [x] `git diff --check`
- [x] `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed a CLI subagent long-running-command control issue where stopped or rewound conversations could resume unexpectedly after the command completed.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/7ef3a855-2c03-44fd-9992-068d433cd036_
_Run: https://oz.staging.warp.dev/runs/019ecd53-6f5e-7023-bc50-4933e3e224b2_
_This PR was generated with [Oz](https://warp.dev/oz)._
