### PR TITLE
Fix double-slash prefix in read_skill display when skill is not found

### DIFF
--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -13,7 +13,7 @@ use ai::agent::action::{
     RequestComputerUseRequest, SuggestPromptRequest, UploadArtifactRequest, UseComputerRequest,
 };
 use ai::agent::file_locations::group_file_contexts_for_display;
-use ai::skills::SkillReference;
+use ai::skills::{ParsedSkill, SkillReference};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use markdown_parser::{FormattedText, FormattedTextFragment, FormattedTextLine};
@@ -1723,6 +1723,21 @@ pub fn render_read_files_text<A: Action>(
     formatted_files
 }
 
+/// Returns the display text for a `read_skill` action.
+///
+/// When the skill is found in the manager, formats it as a slash command
+/// (e.g. `/hello-world`). When the skill is unknown, falls back to the
+/// raw reference string (e.g. the path) **without** prepending an extra
+/// `/`, which would otherwise produce paths like `//home/user/…`.
+fn read_skill_display_text(
+    skill: Option<&ParsedSkill>,
+    skill_reference: &SkillReference,
+) -> String {
+    skill
+        .map(|s| format!("/{}", s.name))
+        .unwrap_or_else(|| skill_reference.to_string())
+}
+
 fn render_read_skill(
     props: Props,
     id: &AIAgentActionId,
@@ -1732,12 +1747,8 @@ fn render_read_skill(
     let appearance = Appearance::as_ref(app);
     let skill = SkillManager::as_ref(app).skill_by_reference(skill_reference);
 
-    let display_name = skill
-        .map(|skill| skill.name.clone())
-        .unwrap_or_else(|| skill_reference.to_string());
-
     let formatted_text = render_requested_action_body_text(
-        format!("/{display_name}").into(),
+        read_skill_display_text(skill, skill_reference).into(),
         appearance.monospace_font_family(),
         app,
     );

--- a/app/src/ai/blocklist/block/view_impl/output_tests.rs
+++ b/app/src/ai/blocklist/block/view_impl/output_tests.rs
@@ -1,5 +1,5 @@
 use ai::agent::action::UploadArtifactRequest;
-use ai::skills::{ParsedSkill, SkillProvider, SkillScope};
+use ai::skills::{ParsedSkill, SkillProvider, SkillReference, SkillScope};
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::{DirectoryWatcher, RepoMetadataModel};
 use warp_util::host_id::HostId;
@@ -9,7 +9,9 @@ use warp_util::standardized_path::StandardizedPath;
 use warpui::App;
 use watcher::HomeDirectoryWatcher;
 
-use super::{format_upload_artifact_text, parsed_skill_for_common_locations};
+use super::{
+    format_upload_artifact_text, parsed_skill_for_common_locations, read_skill_display_text,
+};
 use crate::ai::agent::UploadArtifactResult;
 use crate::ai::skills::SkillManager;
 use crate::settings::AISettings;
@@ -73,6 +75,59 @@ fn format_upload_artifact_text_includes_terminal_status() {
     let cancelled_text =
         format_upload_artifact_text(&request, Some(&UploadArtifactResult::Cancelled));
     assert_eq!(cancelled_text, "Upload artifact: reports/daily.txt");
+}
+
+fn make_skill(name: &str) -> ParsedSkill {
+    ParsedSkill {
+        name: name.to_string(),
+        description: String::new(),
+        path: LocalOrRemotePath::Local(
+            std::path::PathBuf::from("/home/user/.agents/skills")
+                .join(name)
+                .join("SKILL.md"),
+        ),
+        content: String::new(),
+        line_range: None,
+        provider: SkillProvider::Agents,
+        scope: SkillScope::Home,
+    }
+}
+
+#[test]
+fn read_skill_display_text_shows_slash_command_when_skill_found() {
+    let skill = make_skill("hello-world");
+    let reference = SkillReference::Path(skill.path.clone());
+    assert_eq!(
+        read_skill_display_text(Some(&skill), &reference),
+        "/hello-world"
+    );
+}
+
+#[test]
+fn read_skill_display_text_no_double_slash_when_skill_not_found_with_path_reference() {
+    // When the skill is not in the manager the fallback is skill_reference.to_string(),
+    // which for a path reference is an absolute path starting with '/'.  The display
+    // text must NOT prepend an extra '/' — doing so would produce '//home/…'.
+    let path = LocalOrRemotePath::Local(std::path::PathBuf::from(
+        "/home/devbox/.warp-local/skills/hello-world/SKILL.md",
+    ));
+    let reference = SkillReference::Path(path);
+    let display = read_skill_display_text(None, &reference);
+    assert!(
+        !display.starts_with("//"),
+        "display text must not start with '//': {display}"
+    );
+    assert!(
+        display.starts_with('/'),
+        "display text should start with '/': {display}"
+    );
+}
+
+#[test]
+fn read_skill_display_text_bundled_id_fallback_when_skill_not_found() {
+    let reference = SkillReference::BundledSkillId("create-pr".to_string());
+    let display = read_skill_display_text(None, &reference);
+    assert_eq!(display, "@warp-skill:create-pr");
 }
 
 fn remote_location(host_id: &HostId, path: &str) -> LocalOrRemotePath {


### PR DESCRIPTION
## Description

When a `read_skill` action is rendered and the skill is **not** found in the manager (e.g. it hasn't been indexed yet, or is in an unrecognized directory), the display text was constructed as:

```rust
format!("/{display_name}")  // display_name = skill_reference.to_string()
```

For path-based `SkillReference`s, `to_string()` returns the full absolute path (e.g. `/home/devbox/.warp-local/skills/hello-world/SKILL.md`). Prepending another `/` produced `//home/devbox/...` in the UI action header.

**Fix:** Extract the display-text logic into `read_skill_display_text()`. The `/` slash-command prefix is only added when the skill is found (so we know we have a short name like `hello-world`). When the skill is unknown, the reference string is used as-is.

## Linked Issue

N/A — discovered during local skill invocation testing.

## Testing
<img width="952" height="141" alt="Screenshot 2026-06-15 at 3 27 41 PM" src="https://github.com/user-attachments/assets/69ec4ae8-edda-4de7-a29d-e66285e2f24a" />

- Added 3 unit tests to `output_tests.rs`:
  - `read_skill_display_text_shows_slash_command_when_skill_found` — verifies `/hello-world` format for known skills
  - `read_skill_display_text_no_double_slash_when_skill_not_found_with_path_reference` — directly reproduces the bug and asserts it is fixed
  - `read_skill_display_text_bundled_id_fallback_when_skill_not_found` — verifies bundled ID fallback format

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/b00b8173-db74-4987-9433-a95c0f7cc294

CHANGELOG-BUG-FIX: Fixed double-slash prefix (e.g. `//home/user/...`) shown in the read_skill action header when the skill is not yet indexed by Warp.
-->