### PR TITLE
Only require visual evidence for external contributors

### DIFF
--- a/.agents/skills/review-pr-local/SKILL.md
+++ b/.agents/skills/review-pr-local/SKILL.md
@@ -27,7 +27,14 @@ skill marks as overridable.
 - In WarpUI code, flag inline `MouseStateHandle::default()` usage during render or event handling. Mouse state handles should be created during construction and then cloned/referenced where needed.
 - For user-facing UI changes, mention missing validation only when it is tied to a concrete risk or when the PR changes behavior that should be verified visually.
 
-## Behavioral or UI-impacting changes require visual evidence
+## Behavioral or UI-impacting changes require visual evidence (external contributors only)
+
+This requirement applies only to pull requests from external contributors. Determine the author's trust from the `Author` line in `pr_description.txt`: a `trust=TRUSTED` author (association `MEMBER`, `OWNER`, or `COLLABORATOR`) is an organization member, while `trust=UNVERIFIED` (or any non-member association) is an external contributor.
+
+- If the PR author is an organization member (`trust=TRUSTED`), do not request visual evidence and do not block the review for missing screenshots or recordings. Skip the rest of this section.
+- If the `Author` line is absent (older runs that predate this signal), treat the author as an external contributor and apply the requirement below.
+
+For external contributors (`trust=UNVERIFIED`):
 
 - If the PR changes anything user-visible (UI components, layout, styling, copy in surfaces users see, terminal/Warp app visuals, or other behavior a user can perceive), analyze both `pr_description.txt` and any PR comments available in the workflow context for attached screenshots, GIFs, or videos demonstrating the change end to end.
   - Treat markdown image/video embeds (`![...](...)`, `<img ...>`, `<video ...>`), GitHub user-attachment links (e.g. `https://github.com/user-attachments/...`, `https://user-images.githubusercontent.com/...`), Loom links, and similar hosted media as valid evidence.


### PR DESCRIPTION
## Description

Scopes the `review-pr-local` "visual evidence" gate so it applies **only to external contributors**. Org members are now exempt: a member's user-facing PR no longer gets an automated `Request changes` purely because it lacks a screenshot or recording.

The skill keys off the new `Author` line in `pr_description.txt` (added in the companion `warpdotdev/oz-for-oss` PR):
- `trust=TRUSTED` (`MEMBER`/`OWNER`/`COLLABORATOR`) → exempt, skip the requirement.
- `trust=UNVERIFIED` (or the line is absent on older runs) → external contributor, requirement still applies.

This keeps the original intent of the gate (easier review of external PRs + deterring drive-by bot contributions) while removing the friction internal contributors have been hitting on nearly every PR.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

N/A — this is a documentation-only change to a review-agent skill (no user-visible UI).

## Testing

- [ ] N/A — Markdown-only skill change; behavior is exercised by the review agent. Companion control-plane change is unit-tested in `warpdotdev/oz-for-oss`.

### Screenshots / Videos
N/A — not a user-visible change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

_Conversation: https://staging.warp.dev/conversation/484fda0c-894d-40f0-b9af-e9688acfb6fa_
_Run: https://oz.staging.warp.dev/runs/019ecd58-d020-7d93-9008-d5b4cb9fc0b2_

_This PR was generated with [Oz](https://warp.dev/oz)._
