### PR TITLE
Horizontal tabs pinning UI

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -72,6 +72,7 @@ const WARP_2_HOVERED_TAB_COLOR_OPACITY: Opacity = 50;
 const TAB_CLOSE_BUTTON_OPACITY: Opacity = 60;
 const TAB_CLOSE_BUTTON_WIDTH: f32 = 20.0;
 const MAX_TOOLTIP_LENGTH: usize = 80;
+pub(crate) const TAB_PIN_INDICATOR_ICON_SIZE: f32 = 16.0;
 
 const TAB_INDICATOR_SYNCED_COLOR: u32 = 0x4A93FFFF;
 
@@ -1301,6 +1302,26 @@ impl<'a> TabComponent<'a> {
                     ctx.dispatch_typed_action(WorkspaceAction::CloseTab(tab_index))
                 })
                 .finish()
+        } else if self.show_pin_indicator() {
+            // Pinned: render the pin in the exact slot the close button uses so
+            // hovering swaps icons in place without changing the layout.
+            let theme = self.appearance.theme();
+            ConstrainedBox::new(
+                Align::new(
+                    ConstrainedBox::new(
+                        Icon::PinFilledDiagonal
+                            .to_warpui_icon(theme.main_text_color(theme.background()))
+                            .finish(),
+                    )
+                    .with_width(TAB_PIN_INDICATOR_ICON_SIZE)
+                    .with_height(TAB_PIN_INDICATOR_ICON_SIZE)
+                    .finish(),
+                )
+                .finish(),
+            )
+            .with_width(ICON_DIMENSIONS)
+            .with_height(ICON_DIMENSIONS)
+            .finish()
         } else {
             ConstrainedBox::new(Empty::new().finish())
                 .with_width(ICON_DIMENSIONS)
@@ -1312,6 +1333,13 @@ impl<'a> TabComponent<'a> {
             SavePosition::new(button, &format!("close_tab_button:{}", self.tab_index)).finish(),
         )
         .finish()
+    }
+
+    /// True when this tab should display the pinned indicator in its close-
+    /// button slot: pinning is enabled, the tab is pinned, and it isn't a
+    /// grouped member (groups render their own pin).
+    fn show_pin_indicator(&self) -> bool {
+        FeatureFlag::PinnedTabs.is_enabled() && self.tab.pinned && !self.grouped_member
     }
 
     fn render_indicator(&self) -> Option<Box<dyn Element>> {
@@ -1629,6 +1657,8 @@ impl<'a> TabComponent<'a> {
                 )
             };
 
+        // `render_close_tab_button` renders the close button or a pin icon
+        // when the tab is pinned.
         let build_close_button_overlay = |is_hovered: bool| {
             Container::new(
                 ConstrainedBox::new(

--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -1229,7 +1229,10 @@ impl<'a> TabComponent<'a> {
         }
     }
 
-    fn render_close_tab_button(
+    /// Renders the close-button slot for the tab: the close button when
+    /// hovered, a pin indicator when the tab is pinned, or an empty
+    /// width-reserving placeholder otherwise.
+    fn render_close_button_or_pin_icon(
         &self,
         background: Option<Fill>,
         is_hovered: bool,
@@ -1657,12 +1660,10 @@ impl<'a> TabComponent<'a> {
                 )
             };
 
-        // `render_close_tab_button` renders the close button or a pin icon
-        // when the tab is pinned.
         let build_close_button_overlay = |is_hovered: bool| {
             Container::new(
                 ConstrainedBox::new(
-                    self.render_close_tab_button(Some(close_button_background), is_hovered),
+                    self.render_close_button_or_pin_icon(Some(close_button_background), is_hovered),
                 )
                 .with_width(TAB_CLOSE_BUTTON_WIDTH)
                 .with_height(TAB_CLOSE_BUTTON_WIDTH)

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -344,7 +344,7 @@ use crate::shell_indicator::ShellIndicatorType;
 use crate::tab::{
     tab_position_id, uses_vertical_tabs, NewSessionMenuItem, PaneNameMenuTarget, SelectedTabColor,
     TabBarState, TabComponent, TabData, TabTelemetryAction, MOVE_TO_GROUP_LABEL,
-    TAB_BAR_BORDER_HEIGHT,
+    TAB_BAR_BORDER_HEIGHT, TAB_PIN_INDICATOR_ICON_SIZE,
 };
 use crate::tab_configs::action_sidecar::SidecarItemKind;
 use crate::tab_configs::remove_confirmation_dialog::{
@@ -19192,6 +19192,12 @@ impl Workspace {
             }
         }
 
+        // Pinned + expanded: trailing pin indicator after the last member.
+        let group_pinned = FeatureFlag::PinnedTabs.is_enabled() && group.pinned;
+        if group_pinned && !is_collapsed {
+            row.add_child(render_horizontal_group_pin_indicator(appearance));
+        }
+
         // Additional padding on expanded groups,
         // allowing tabs to be dropped into the last position of the group.
         const EXPANDED_GROUP_TRAILING_PADDING: f32 = 8.;
@@ -19293,12 +19299,18 @@ impl Workspace {
             .finish()
         };
 
-        let row = Flex::row()
+        let mut row = Flex::row()
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_spacing(6.)
             .with_child(icon_circle)
-            .with_child(name_element)
-            .finish();
+            .with_child(name_element);
+        // Collapsed + pinned: pin indicator to the right of the name, where an
+        // ungrouped tab would show its close button. Expanded groups show the
+        // pin after their last member instead.
+        if FeatureFlag::PinnedTabs.is_enabled() && group.pinned && is_collapsed {
+            row.add_child(render_horizontal_group_pin_indicator(appearance));
+        }
+        let row = row.finish();
 
         let header_active_bg = internal_colors::fg_overlay_2(theme);
         let header_hover_bg = internal_colors::fg_overlay_1(theme);
@@ -27512,6 +27524,21 @@ fn should_reserve_traffic_light_space_in_tab_bar(side: TrafficLightSide) -> bool
 
 /// Total width/height of the collage area in the group header.
 const GROUP_ICON_COLLAGE_SIZE: f32 = 22.0;
+
+/// Renders the diagonal pin indicator shown on a pinned horizontal tab group:
+/// trailing the members of an expanded group, or to the right of the name on a
+/// collapsed group's header.
+fn render_horizontal_group_pin_indicator(appearance: &Appearance) -> Box<dyn Element> {
+    let theme = appearance.theme();
+    ConstrainedBox::new(
+        Icon::PinFilledDiagonal
+            .to_warpui_icon(theme.main_text_color(theme.background()))
+            .finish(),
+    )
+    .with_width(TAB_PIN_INDICATOR_ICON_SIZE)
+    .with_height(TAB_PIN_INDICATOR_ICON_SIZE)
+    .finish()
+}
 
 /// Renders the icon block for a tab-group header from 0-4 deduped pane kinds.
 /// 1 or 2 icons reuse the vertical Summary `Single`/`Pair` layout so the

--- a/app/src/workspace/view/tab_grouping.rs
+++ b/app/src/workspace/view/tab_grouping.rs
@@ -482,6 +482,11 @@ impl Workspace {
     /// either because its own `pinned` flag is set (ungrouped pinned tab) or
     /// because it belongs to a pinned group.
     pub(super) fn is_tab_effectively_pinned(&self, tab: &TabData) -> bool {
+        // Safety net, ensures no behavioral changes if feature flag
+        // is off and some tabs have a pinned state saved.
+        if !FeatureFlag::PinnedTabs.is_enabled() {
+            return false;
+        }
         tab.pinned
             || tab
                 .group_id


### PR DESCRIPTION
## Description

Adds pinned state rendering to horizontal tabs. This renders a pin icon to the right of the tab name, or to the right of all tabs in a tab group.

This also adds a safety net feature flag check to the `is_effectively_pinned()` function so that behavior remains unchanged when the feature flag is off (and a tab is pinned somehow). I ack that this should be in a separate PR but have a few changes I need to stack on top of this and want to prioritize velocity. This PR is also quite simple.

## How it works

For tabs: modifies `render_close_tab_button()` to render the pin icon in place of the close button when the tab is pinned and not hovered.

For groups: adds a helper `render_horizontal_group_pin_indicator()` for rendering the pin icon. This is placed after the group title when the group is collapsed, otherwise after the last tab displayed in the group.

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4698/horizontal-tabs-pinning-ui

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo video ](https://www.loom.com/share/8c86700ad55d46b795ce2f126910f844)
