### PR TITLE
add back pane_leaves to sqlite save_app_state which was mistakenly deleted

### DIFF
--- a/app/src/persistence/sqlite.rs
+++ b/app/src/persistence/sqlite.rs
@@ -857,6 +857,7 @@ fn save_app_state(conn: &mut SqliteConnection, app_state: &AppState) -> Result<(
         diesel::delete(schema::mcp_server_panes::dsl::mcp_server_panes).execute(conn)?;
         diesel::delete(schema::code_review_panes::dsl::code_review_panes).execute(conn)?;
         diesel::delete(schema::ambient_agent_panes::dsl::ambient_agent_panes).execute(conn)?;
+        diesel::delete(schema::pane_leaves::dsl::pane_leaves).execute(conn)?;
         diesel::delete(schema::pane_branches::dsl::pane_branches).execute(conn)?;
         diesel::delete(schema::pane_nodes::dsl::pane_nodes).execute(conn)?;
         diesel::delete(schema::tabs::dsl::tabs).execute(conn)?;


### PR DESCRIPTION
## Description

I tried to delete some dead code in #12614 but accidentally deleted something we need. Adding it back.
