### PR TITLE
throwaway: NLD latency instrumentation N=2000 (do not merge)

### DIFF
--- a/app/src/ai/blocklist/input_model.rs
+++ b/app/src/ai/blocklist/input_model.rs
@@ -772,11 +772,16 @@ impl BlocklistAIInputModel {
         });
 
         // Gather agent prompt history
+        let clone_start = Instant::now();
         let prompt_entries = cfg!(feature = "nld_prompt_history_match")
             .then(|| BlocklistAIHistoryModel::as_ref(ctx).nld_prompt_history());
+        let clone_us = clone_start.elapsed().as_micros() as u64;
+        let n_prompts = prompt_entries.as_ref().map(|v| v.len()).unwrap_or(0);
 
         let buffer_cloned = input.buffer_text.clone();
+        let buffer_for_log = buffer_cloned.clone();
         let other_buffer_cloned = buffer_cloned.clone();
+        let future_start = Instant::now();
         let current_input_type = self.input_type();
 
         let is_udi_enabled = InputSettings::as_ref(ctx).is_universal_developer_input_enabled(ctx);
@@ -835,6 +840,7 @@ impl BlocklistAIInputModel {
 
                         if let Some(prompt_entries) = &prompt_entries {
                             // `prompt_entries` is already newest-first.
+                            let prompt_scan_start = Instant::now();
                             let prompt_match = most_recent_close_match(
                                 &buffer_cloned,
                                 prompt_entries
@@ -843,6 +849,9 @@ impl BlocklistAIInputModel {
                                 HISTORY_ENTRY_MATCH_CUTOFF,
                             )
                             .await;
+                            let prompt_scan_us = prompt_scan_start.elapsed().as_micros() as u64;
+                            let total_us = future_start.elapsed().as_micros() as u64;
+                            log::info!("NLD_LATENCY n_prompts={n_prompts} clone_us={clone_us} prompt_scan_us={prompt_scan_us} total_us={total_us} query={buffer_for_log:?}");
 
                             if let Some(decision) =
                                 resolve_history_match(command_match, prompt_match)


### PR DESCRIPTION
## NLD History-Match Latency: N=2000 Measurement (throwaway)

**DO NOT MERGE** — This is a throwaway instrumentation branch for the NLD latency stress test (N=2000). See plan for context.

### What this does
Adds `Instant` timing around `nld_prompt_history()` clone and `most_recent_close_match` prompt scan in `detect_and_set_input_type`, emitting a `NLD_LATENCY` grep-able log line per detection.

### Results (N=2000, in-process Rust benchmark)

Full-query scan (prompt_scan_us p50/p90):
- "make a pr": 3µs / 3µs
- "debug this failure": 3µs / 3µs
- "curl ...URL" (full, 58 chars): 4µs / 5µs

Curl URL intermediate spike (buffer ≈ seed length ~39-42 chars):
- Peak prefix[41] = "curl https://github.com/warpdotdev/warp/p": **p50=4,365µs / p90=4,405µs**
- Spike window: prefix lengths 33–51
- Scales roughly linearly with N (agent-c N=10000 saw ~33-39ms, ~8x ratio for 5x N)

_Conversation: https://staging.warp.dev/conversation/51ba4553-dc0d-4479-bac4-36983518d0b6_
_Run: https://oz.staging.warp.dev/runs/019ecd70-9a72-77a4-8555-8631bdfc5edb_
_This PR was generated with [Oz](https://warp.dev/oz)._
