### PR TITLE
Enforce pinning invariant and group contiguity on tab restoration

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -11931,9 +11931,7 @@ impl Workspace {
         let before = self.tabs[index - 1].group_id;
         let after = self.tabs[index].group_id;
         match before {
-            Some(group_id) if before == after => {
-                self.index_after_group(group_id).unwrap_or(index)
-            }
+            Some(group_id) if before == after => self.index_after_group(group_id).unwrap_or(index),
             _ => index,
         }
     }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -11873,18 +11873,17 @@ impl Workspace {
         // If the tab belonged to a group, try to re-join it by appending after
         // the group's current last member. If the group no longer exists (it was
         // pruned when the tab was closed), drop the membership and fall back to
-        // the original index instead.
+        // the original index instead. On restoration, we must ensure the pin
+        // invariant holds. That is, pinned items appear before unpinned items.
         let insert_index = if let Some(group_id) = tab_data.group_id {
             if self.tab_groups.contains_key(&group_id) {
-                // Group still exists — append after its current last member.
                 self.index_after_group(group_id).unwrap_or(self.tabs.len())
             } else {
-                // Group was pruned — drop membership.
                 tab_data.group_id = None;
-                tab_index
+                self.index_for_restored_tab(&tab_data, tab_index)
             }
         } else {
-            tab_index
+            self.index_for_restored_tab(&tab_data, tab_index)
         };
 
         self.tabs.insert(insert_index, tab_data);
@@ -11899,6 +11898,44 @@ impl Workspace {
         self.activate_tab(insert_index, ctx);
 
         ctx.notify();
+    }
+
+    /// Insertion index for a restored tab that is not part of an existing group.
+    /// If the tab was pinned, it must land at it's original index or the end of
+    /// the pinned region. If the tab is not pinned, it must land at it's original
+    /// index or after all pinned items.
+    fn index_for_restored_tab(&self, tab: &TabData, original_index: usize) -> usize {
+        let boundary = self.pinned_boundary_index(&self.tabs);
+        let region_clamped = if tab.pinned {
+            // Original index or before all unpinned items.
+            original_index.min(boundary)
+        } else {
+            // Original index or after all pinned items.
+            original_index.max(boundary)
+        };
+        // Safety net so the new index is not beyond the lists bounds.
+        // By definition of MRU ordering, this is not possible.
+        let index = region_clamped.min(self.tabs.len());
+
+        // Ensure that the index we are restoring to does not land
+        // in the middle of a group.
+        self.index_avoiding_group_split(index)
+    }
+
+    /// If `index` would split a group (same group on both sides of the slot),
+    /// returns the slot just past that group; otherwise returns `index`.
+    fn index_avoiding_group_split(&self, index: usize) -> usize {
+        if index == 0 || index >= self.tabs.len() {
+            return index;
+        }
+        let before = self.tabs[index - 1].group_id;
+        let after = self.tabs[index].group_id;
+        match before {
+            Some(group_id) if before == after => {
+                self.index_after_group(group_id).unwrap_or(index)
+            }
+            _ => index,
+        }
     }
 
     pub fn open_autoupdate_failure_link(&mut self, ctx: &mut ViewContext<Self>) {


### PR DESCRIPTION
## Description

There are a few bugs with tab restoration (closing a tab and then using "restore session") that this PR solves:
- a pinned tab that is restored could land outside the pinned region
- an unpinned tab that is restored could land inside the pinned region
- a tab that is restored to its original index could split a group (land in the middle without being owned by the group)

With the changes in this PR, restored tabs now respect the pinned invariant (pinned items appear before unpinned items) and will not land within a group.

## How it works

Modified `restore_closed_tab` logic as follows
- If the restored tab is not in a group (or the group no longer exists), use the new helper `index_for_restored_tab`
- The helper does the following: 
  - if the tab was pinned and the original index is within the pinned region, place it there. Otherwise append to the pinned region
  - if the tab was not pinned and the original index is outside the pinned region, place it there. Otherwise place after the pinned region
  - if the index produced from the logic above is within a group, place it after the groups last member

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4746/restoring-a-pinned-tab-should-land-in-pinned-region

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo of bug](https://www.loom.com/share/cf71c91ab7a14924bf460c402152d2ce)

[Demo of fix](https://www.loom.com/share/86c8d38e1a474a20b9692d92d4ed2565)