### PR TITLE
Add EmbeddedComment block type and set_comment_blocks API to render model

### DIFF
--- a/app/src/code/editor/embedded_comment.rs
+++ b/app/src/code/editor/embedded_comment.rs
@@ -178,9 +178,6 @@ impl RenderableBlock for RenderableEmbeddedCommentSpace {
         false
     }
 
-    fn is_embedded_comment(&self) -> bool {
-        true
-    }
 }
 
 /// The embedded item transformation for comments.

--- a/app/src/code/editor/model.rs
+++ b/app/src/code/editor/model.rs
@@ -842,6 +842,7 @@ impl CodeEditorModel {
                 | BlockItem::OrderedList { .. }
                 | BlockItem::Header { .. }
                 | BlockItem::Embedded(_)
+                | BlockItem::EmbeddedComment { .. }
                 | BlockItem::HorizontalRule(_)
                 | BlockItem::Image { .. }
                 | BlockItem::Table(_)

--- a/crates/editor/src/render/element/mod.rs
+++ b/crates/editor/src/render/element/mod.rs
@@ -41,7 +41,8 @@ use self::text_block::RenderableTextBlock;
 use self::unordered_list::RenderableBulletList;
 use super::model::viewport::{SizeInfo, ViewportItem};
 use super::model::{
-    BlockItem, ElementUpdate, HitTestOptions, Location, RenderState, RichTextStyles, UNIT_MARGIN,
+    BlockItem, ElementUpdate, HitTestOptions, Location, RenderLineLocation, RenderState,
+    RichTextStyles, UNIT_MARGIN,
 };
 use crate::content::version::BufferVersion;
 use crate::editor::EditorView;
@@ -281,8 +282,12 @@ pub trait RenderableBlock {
         false
     }
 
-    fn is_embedded_comment(&self) -> bool {
-        false
+    /// The anchor of the inline comment block backing this renderable, or `None` if this block is
+    /// not an inline comment. Carrying the anchor on the renderable lets gutter rendering classify
+    /// comment rows (including the removed-line side) without a per-frame reverse lookup into the
+    /// content tree.
+    fn embedded_comment_location(&self) -> Option<RenderLineLocation> {
+        None
     }
 
     fn finish(self) -> Box<dyn RenderableBlock>
@@ -906,7 +911,7 @@ impl<V: EditorView> RichTextElement<V> {
                     BlockItem::Table { .. } => RenderableTable::new(item).finish(),
                     BlockItem::TrailingNewLine(_) => Empty::new(item).finish(),
                     BlockItem::Hidden { .. } => RenderableHiddenSection::new(item, ctx).finish(),
-                    BlockItem::Embedded(embed) => {
+                    BlockItem::Embedded(embed) | BlockItem::EmbeddedComment { item: embed, .. } => {
                         let start_offset = item.block_offset;
                         let child_model = parent.embedded_item_at(start_offset, ctx);
                         embed.element(model, item, child_model, ctx)

--- a/crates/editor/src/render/model/debug.rs
+++ b/crates/editor/src/render/model/debug.rs
@@ -124,6 +124,7 @@ impl Describe for BlockItem {
             )?,
             BlockItem::TrailingNewLine(_) => f.write_str("Trailing Newline")?,
             BlockItem::Embedded(_) => f.write_str("Embedded Item")?,
+            BlockItem::EmbeddedComment { .. } => f.write_str("Embedded Comment")?,
             BlockItem::Hidden { .. } => f.write_str("Hidden")?,
         }
 

--- a/crates/editor/src/render/model/location.rs
+++ b/crates/editor/src/render/model/location.rs
@@ -218,6 +218,7 @@ impl<'a> Positioned<'a, BlockItem> {
             | BlockItem::Image { .. }
             | BlockItem::TrailingNewLine(_)
             | BlockItem::TemporaryBlock { .. }
+            | BlockItem::EmbeddedComment { .. }
             | BlockItem::Hidden { .. } => Location::Text {
                 char_offset: self.start_char_offset,
                 clamped: true,

--- a/crates/editor/src/render/model/mod.rs
+++ b/crates/editor/src/render/model/mod.rs
@@ -405,6 +405,11 @@ pub struct RenderState {
     show_final_trailing_newline_when_non_empty: bool,
     has_final_trailing_newline: Cell<bool>,
 
+    /// Whether the content tree currently contains any [`BlockItem::EmbeddedComment`] blocks.
+    /// Updated by `apply_comment_blocks` so that an empty incoming set can skip the full tree
+    /// rebuild when there are no existing comment blocks to remove.
+    has_comment_blocks: Cell<bool>,
+
     width_setting: WidthSetting,
 
     /// Channel for propagating updates from [`super::element::RichTextElement`] such as the
@@ -681,6 +686,32 @@ impl RenderLineLocation {
     }
 }
 
+/// An inline comment block to host on a per-view [`RenderState`]. The child element is supplied by
+/// the app via a [`LaidOutEmbeddedItem`] (the same cross-crate boundary used by markdown embeds),
+/// keeping `warp_editor` independent of app-crate views.
+#[derive(Clone, Debug)]
+pub struct CommentBlock {
+    /// The render line the comment is anchored below.
+    pub location: RenderLineLocation,
+    /// The app-supplied, already laid-out child. Its height determines the reserved block height.
+    pub item: Arc<dyn LaidOutEmbeddedItem>,
+}
+
+impl CommentBlock {
+    pub fn new(location: RenderLineLocation, item: Arc<dyn LaidOutEmbeddedItem>) -> Self {
+        Self { location, item }
+    }
+}
+
+/// Content-space position of an inline comment block.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct CommentBlockPosition {
+    /// Content-space Y offset of the block's top (does not subtract scroll).
+    pub start_y_offset: Pixels,
+    /// The reserved height of the block (equal to the hosted element's laid-out height).
+    pub content_height: Pixels,
+}
+
 /// A point within the editor. Unlike character and hard-wrap offsets/points, this accounts for
 /// soft-wrapping, the layout of different block types, and proportional fonts.
 ///
@@ -789,6 +820,22 @@ pub enum BlockItem {
         paragraph: Paragraph,
     },
     Embedded(Arc<dyn LaidOutEmbeddedItem>),
+    /// A per-view inline comment block. It hosts an app-supplied child element (via
+    /// [`LaidOutEmbeddedItem::element`]) and reserves vertical space equal to that element's
+    /// laid-out height, while contributing no buffer characters or lines (like a
+    /// [`BlockItem::TemporaryBlock`]).
+    ///
+    /// It is intentionally a DISTINCT variant from [`BlockItem::TemporaryBlock`] so that
+    /// `reset_temporary_block` (run on every diff refresh) never removes it, and so it can only
+    /// ever live on a per-view [`RenderState`] — never on the shared buffer.
+    EmbeddedComment {
+        /// The full anchor of this comment. Carrying the location on the block (rather than
+        /// inferring it from tree position) lets `comment_block_position` match a comment by its
+        /// exact [`RenderLineLocation`] — including the `Temporary` removed-line slot index — even
+        /// after `reset_temporary_block` rebuilds the surrounding removed-line blocks.
+        location: RenderLineLocation,
+        item: Arc<dyn LaidOutEmbeddedItem>,
+    },
     HorizontalRule(HorizontalRuleConfig),
     Image {
         alt_text: String,
@@ -1749,6 +1796,7 @@ impl RenderState {
             styles,
             show_final_trailing_newline_when_non_empty: true,
             has_final_trailing_newline: Cell::new(true),
+            has_comment_blocks: Cell::new(false),
             viewport: ViewportState::new(viewport_width, viewport_height),
             selections: Default::default(),
             decorations: Default::default(),
@@ -2398,6 +2446,22 @@ impl RenderState {
                 ctx.emit(RenderEvent::LayoutUpdated);
                 ctx.notify();
             }
+            LayoutAction::SetCommentBlocks(blocks) => {
+                // Comment blocks are supplied already laid out by the app, so they don't require
+                // text layout. When laying out lazily, defer the reconcile to element-layout time
+                // for consistency with temporary blocks; otherwise apply it immediately.
+                if self.lazy_layout {
+                    self.pending_edits
+                        .lock()
+                        .push(PendingLayout::CommentBlocks(blocks));
+                } else {
+                    self.apply_comment_blocks(blocks);
+                    self.update_content_sizing();
+                }
+
+                ctx.emit(RenderEvent::LayoutUpdated);
+                ctx.notify();
+            }
             LayoutAction::BufferEdit {
                 delta,
                 buffer_version,
@@ -2510,6 +2574,9 @@ impl RenderState {
                     PendingLayout::TemporaryBlocks(blocks) => {
                         self.layout_temporary_blocks(blocks, app);
                     }
+                    PendingLayout::CommentBlocks(blocks) => {
+                        self.apply_comment_blocks(blocks);
+                    }
                 };
             }
         }
@@ -2560,6 +2627,211 @@ impl RenderState {
 
     pub fn add_temporary_blocks(&mut self, temporary_blocks: Vec<TemporaryBlock>) {
         self.submit_layout_action(LayoutAction::LayoutTemporaryBlock(temporary_blocks));
+    }
+
+    /// Reconcile the per-view set of inline comment blocks. `blocks` is the complete desired set:
+    /// existing comment blocks not present here are removed, and the supplied blocks are inserted
+    /// at their anchor lines. This is independent of [`Self::add_temporary_blocks`] — comment
+    /// blocks and diff removed-line temporary blocks coexist and never clobber each other.
+    pub fn set_comment_blocks(&mut self, blocks: Vec<CommentBlock>) {
+        self.submit_layout_action(LayoutAction::SetCommentBlocks(blocks));
+    }
+
+    /// Remove all inline comment blocks from this view, leaving temporary blocks untouched.
+    pub fn clear_comment_blocks(&mut self) {
+        self.set_comment_blocks(Vec::new());
+    }
+
+    /// Find the first inline comment block at `location` and map its hosted item through `f`. A
+    /// comment is matched by the FULL `RenderLineLocation` it carries, not by its line alone.
+    /// Because the anchor (including a `Temporary` removed-line slot index) travels on the block
+    /// itself, two comments sharing an `at_line` resolve unambiguously and the match holds even
+    /// after `reset_temporary_block` rebuilds the surrounding removed-line blocks.
+    ///
+    /// Comment blocks contribute zero lines, so every candidate sits exactly at the anchor's line
+    /// boundary: seek there (O(log n)) and scan only that boundary's run instead of walking the
+    /// whole tree. `SeekBias::Left` stops before the zero-extent items at the boundary; the scan
+    /// ends as soon as an item starts past the anchor line.
+    fn with_comment_block_at<T>(
+        &self,
+        location: RenderLineLocation,
+        f: impl FnOnce(Pixels, &Arc<dyn LaidOutEmbeddedItem>) -> T,
+    ) -> Option<T> {
+        let target = location.line_count();
+        let content = self.content.borrow();
+        let mut cursor = content.cursor::<LineCount, LayoutSummary>();
+        cursor.seek_clamped(&target, SeekBias::Left);
+        while let Some(positioned) = cursor.positioned_item() {
+            if positioned.start_line > target {
+                break;
+            }
+            if let BlockItem::EmbeddedComment {
+                location: block_location,
+                item,
+            } = positioned.item
+                && *block_location == location
+            {
+                return Some(f(positioned.start_y_offset, item));
+            }
+            cursor.next();
+        }
+        None
+    }
+
+    /// Content-space position and reserved height of the inline comment block anchored at
+    /// `location`, if one is present. `start_y_offset` is in content space (not viewport space)
+    /// and `content_height` is the hosted element's laid-out height.
+    pub fn comment_block_position(
+        &self,
+        location: RenderLineLocation,
+    ) -> Option<CommentBlockPosition> {
+        self.with_comment_block_at(location, |start_y_offset, item| CommentBlockPosition {
+            start_y_offset,
+            content_height: item.height(),
+        })
+    }
+
+    /// The app-supplied hosted item of the inline comment block anchored at `location`, or `None`
+    /// if no comment block is anchored there. Lets a host resolve the block's rendered content (for
+    /// example its body text) by downcasting the returned [`LaidOutEmbeddedItem`].
+    pub fn comment_block_item(
+        &self,
+        location: RenderLineLocation,
+    ) -> Option<Arc<dyn LaidOutEmbeddedItem>> {
+        self.with_comment_block_at(location, |_, item| item.clone())
+    }
+
+    /// Number of inline comment blocks ([`BlockItem::EmbeddedComment`]) currently in this view's
+    /// content tree, across all anchor lines. Diff removed-line temporary blocks are not counted.
+    pub fn comment_block_count(&self) -> usize {
+        let content = self.content.borrow();
+        let mut cursor = content.cursor::<LineCount, LayoutSummary>();
+        cursor.descend_to_first_item(&content, |_| true);
+        let mut count = 0;
+        while let Some(positioned) = cursor.positioned_item() {
+            if matches!(positioned.item, BlockItem::EmbeddedComment { .. }) {
+                count += 1;
+            }
+            cursor.next();
+        }
+        count
+    }
+
+    /// Group comment blocks by their full anchor [`RenderLineLocation`] and reconcile them into the
+    /// content tree. `Current` anchors are keyed by line; `Temporary` anchors are keyed by both the
+    /// `at_line` and the removed-line slot index, so two comments sharing an `at_line` but targeting
+    /// different removed-line slots do not collide.
+    fn apply_comment_blocks(&self, blocks: Vec<CommentBlock>) {
+        // Fast path: skip the full tree rebuild when nothing changes.
+        if blocks.is_empty() && !self.has_comment_blocks.get() {
+            return;
+        }
+        self.has_comment_blocks.set(!blocks.is_empty());
+
+        let mut current: HashMap<LineCount, Vec<BlockItem>> = HashMap::new();
+        let mut temporary: HashMap<(LineCount, usize), Vec<BlockItem>> = HashMap::new();
+        for block in blocks {
+            let item = BlockItem::EmbeddedComment {
+                location: block.location,
+                item: block.item,
+            };
+            match block.location {
+                RenderLineLocation::Current(line) => {
+                    current.entry(line).or_default().push(item);
+                }
+                RenderLineLocation::Temporary {
+                    at_line,
+                    index_from_at_line,
+                } => {
+                    temporary
+                        .entry((at_line, index_from_at_line))
+                        .or_default()
+                        .push(item);
+                }
+            }
+        }
+        self.reset_comment_blocks(current, temporary);
+    }
+
+    /// Replace all [`BlockItem::EmbeddedComment`]s in the content tree with a new set, keyed by the
+    /// full [`RenderLineLocation`] each block is anchored to. Every other block (including diff
+    /// removed-line [`BlockItem::TemporaryBlock`]s) is preserved exactly.
+    ///
+    /// A `Current(line)` comment is inserted after every block on that line (so it follows any
+    /// removed-line blocks). A `Temporary { at_line, index_from_at_line: k }` comment is inserted
+    /// immediately after the `k`-th removed-line [`BlockItem::TemporaryBlock`] on `at_line`, placing
+    /// it at exactly that removed-line slot. Skipping prior comment blocks while counting temporary
+    /// blocks keeps removed-line slot indices stable regardless of how many comments are anchored.
+    fn reset_comment_blocks(
+        &self,
+        mut current: HashMap<LineCount, Vec<BlockItem>>,
+        mut temporary: HashMap<(LineCount, usize), Vec<BlockItem>>,
+    ) {
+        let mut new_tree = SumTree::new();
+        {
+            let content = self.content.borrow();
+            let mut cursor = content.cursor::<LineCount, CharOffset>();
+
+            // Comments anchored before the first line of content.
+            if let Some(items) = current.remove(&LineCount::zero()) {
+                for item in items {
+                    new_tree.push(item);
+                }
+            }
+
+            cursor.descend_to_first_item(&content, |_| true);
+            let mut last_temp_line: Option<LineCount> = None;
+            let mut temp_index: usize = 0;
+            while let Some(item) = cursor.item() {
+                if !matches!(item, BlockItem::EmbeddedComment { .. }) {
+                    new_tree.push(item.clone());
+                }
+
+                let line_at_end = cursor.end_seek_position();
+
+                // A removed-line block defines a `Temporary` slot. Append any comment anchored to
+                // that exact (at_line, index) slot, then advance the slot index for this line.
+                if matches!(item, BlockItem::TemporaryBlock { .. }) {
+                    temp_index = if last_temp_line == Some(line_at_end) {
+                        temp_index + 1
+                    } else {
+                        0
+                    };
+                    last_temp_line = Some(line_at_end);
+                    if let Some(items) = temporary.remove(&(line_at_end, temp_index)) {
+                        for item in items {
+                            new_tree.push(item);
+                        }
+                    }
+                }
+
+                cursor.next();
+
+                // Once every (possibly zero-line) item on `line_at_end` has been pushed — detected
+                // when the next item begins a later line, or the tree ends — append that line's
+                // `Current` comment blocks. This keeps them after any temporary blocks on the line.
+                let line_complete = match cursor.item() {
+                    None => true,
+                    Some(_) => cursor.end_seek_position() > line_at_end,
+                };
+                if line_complete && let Some(items) = current.remove(&line_at_end) {
+                    for item in items {
+                        new_tree.push(item);
+                    }
+                }
+            }
+        }
+        if !current.is_empty() || !temporary.is_empty() {
+            log::debug!(
+                "reset_comment_blocks: {} current and {} temporary comment blocks had no matching \
+                 anchor line and were dropped",
+                current.len(),
+                temporary.len(),
+            );
+        }
+        self.has_final_trailing_newline
+            .set(Self::tree_ends_with_trailing_newline(&new_tree));
+        *self.content.borrow_mut() = new_tree;
     }
 
     /// Replace all temporary blocks in the BlockItem cache with a new set of temporary
@@ -2662,8 +2934,11 @@ impl RenderState {
             sub_tree_cursor.descend_to_first_item(&sub_tree, |_| true);
 
             while let Some(item) = sub_tree_cursor.item() {
-                // Do not remove the temporary blocks within the replaced range.
-                if matches!(item, BlockItem::TemporaryBlock { .. }) {
+                // Do not remove the temporary or comment blocks within the replaced range.
+                if matches!(
+                    item,
+                    BlockItem::TemporaryBlock { .. } | BlockItem::EmbeddedComment { .. }
+                ) {
                     new_tree.push(item.clone());
                 }
 
@@ -2697,10 +2972,12 @@ impl RenderState {
                 // exclusive, we can't otherwise represent "before the first block".
                 if effective_end > CharOffset::zero() {
                     if let Some(item) = cursor.item() {
-                        // Do not remove the temporary blocks within the replaced range.
-                        if matches!(item, BlockItem::TemporaryBlock { .. })
-                            || (cursor.end() > effective_end
-                                && matches!(item, BlockItem::Hidden(_)))
+                        // Do not remove the temporary or comment blocks within the replaced range.
+                        if matches!(
+                            item,
+                            BlockItem::TemporaryBlock { .. } | BlockItem::EmbeddedComment { .. }
+                        ) || (cursor.end() > effective_end
+                            && matches!(item, BlockItem::Hidden(_)))
                         {
                             new_tree.push(item.clone());
                         }
@@ -3303,6 +3580,7 @@ enum PendingLayout {
         hidden_ranges: Option<RangeSet<CharOffset>>,
     },
     TemporaryBlocks(Vec<TemporaryBlock>),
+    CommentBlocks(Vec<CommentBlock>),
 }
 
 struct PendingSelectionUpdate {
@@ -3326,6 +3604,9 @@ enum LayoutAction {
         buffer_version: BufferVersion,
     },
     LayoutTemporaryBlock(Vec<TemporaryBlock>),
+    /// Reconcile the set of per-view inline comment blocks. The supplied vector is the complete
+    /// desired set: any existing comment blocks not present here are removed.
+    SetCommentBlocks(Vec<CommentBlock>),
     /// Autoscroll, to the specified range if `Some` or to the cursor location if `None`.
     Autoscroll {
         mode: AutoScrollMode,
@@ -3484,7 +3765,11 @@ impl BlockItem {
             BlockItem::HorizontalRule(config) => config.line_height.as_f32(),
             BlockItem::Image { config, .. } => config.height.as_f32(),
             BlockItem::Table(laid_out_table) => laid_out_table.height().as_f32(),
-            BlockItem::Embedded(embedded_item) => embedded_item.height().as_f32(),
+            BlockItem::Embedded(embedded_item)
+            | BlockItem::EmbeddedComment {
+                item: embedded_item,
+                ..
+            } => embedded_item.height().as_f32(),
             BlockItem::Hidden(config) => config.height().as_f32(),
         }
     }
@@ -3508,7 +3793,11 @@ impl BlockItem {
             BlockItem::HorizontalRule(config) => config.spacing,
             BlockItem::Image { config, .. } => config.spacing,
             BlockItem::Table(laid_out_table) => laid_out_table.spacing(),
-            BlockItem::Embedded(embedded_item) => embedded_item.spacing(),
+            BlockItem::Embedded(embedded_item)
+            | BlockItem::EmbeddedComment {
+                item: embedded_item,
+                ..
+            } => embedded_item.spacing(),
             BlockItem::Hidden { .. } => BlockSpacing::default(),
         }
     }
@@ -3541,7 +3830,11 @@ impl BlockItem {
                 }
                 height
             }
-            BlockItem::Embedded(embedded_item) => embedded_item.height(),
+            BlockItem::Embedded(embedded_item)
+            | BlockItem::EmbeddedComment {
+                item: embedded_item,
+                ..
+            } => embedded_item.height(),
             BlockItem::HorizontalRule(rule) => rule.line_height,
             BlockItem::Image { config, .. } => config.height,
             BlockItem::Table(laid_out_table) => laid_out_table.height(),
@@ -3565,7 +3858,9 @@ impl BlockItem {
             } => paragraph_block.width(),
             BlockItem::MermaidDiagram { config, .. } => config.width,
             BlockItem::TrailingNewLine(cursor) => cursor.width,
-            BlockItem::Embedded(object) => object.size().x().into_pixels(),
+            BlockItem::Embedded(object) | BlockItem::EmbeddedComment { item: object, .. } => {
+                object.size().x().into_pixels()
+            }
             BlockItem::HorizontalRule(rule) => rule.width,
             BlockItem::Image { config, .. } => config.width,
             BlockItem::Table(laid_out_table) => laid_out_table.width(),
@@ -3593,7 +3888,9 @@ impl BlockItem {
             BlockItem::RunnableCodeBlock {
                 paragraph_block, ..
             } => paragraph_block.content_length(),
-            BlockItem::TemporaryBlock { .. } => CharOffset::zero(),
+            BlockItem::TemporaryBlock { .. } | BlockItem::EmbeddedComment { .. } => {
+                CharOffset::zero()
+            }
             BlockItem::MermaidDiagram { content_length, .. } => *content_length,
             BlockItem::TrailingNewLine(_)
             | BlockItem::Embedded(_)
@@ -3615,7 +3912,7 @@ impl BlockItem {
             BlockItem::RunnableCodeBlock {
                 paragraph_block, ..
             } => paragraph_block.lines(),
-            BlockItem::TemporaryBlock { .. } => LineCount(0),
+            BlockItem::TemporaryBlock { .. } | BlockItem::EmbeddedComment { .. } => LineCount(0),
             BlockItem::MermaidDiagram { .. } => LineCount(1),
             BlockItem::TrailingNewLine(_)
             | BlockItem::Embedded(_)
@@ -3642,6 +3939,7 @@ impl BlockItem {
             BlockItem::MermaidDiagram { .. } => false,
             // Embeds, images, tables, and horizontal rules are never empty.
             BlockItem::Embedded(_)
+            | BlockItem::EmbeddedComment { .. }
             | BlockItem::HorizontalRule(_)
             | BlockItem::Image { .. }
             | BlockItem::Table(_)
@@ -3701,6 +3999,7 @@ impl Positioned<'_, BlockItem> {
             BlockItem::MermaidDiagram { .. } => self.start_char_offset,
             BlockItem::TrailingNewLine(_)
             | BlockItem::Embedded(_)
+            | BlockItem::EmbeddedComment { .. }
             | BlockItem::HorizontalRule(_)
             | BlockItem::Image { .. }
             | BlockItem::TemporaryBlock { .. }
@@ -3766,6 +4065,7 @@ impl Positioned<'_, BlockItem> {
             }
             BlockItem::TrailingNewLine(_)
             | BlockItem::Embedded(_)
+            | BlockItem::EmbeddedComment { .. }
             | BlockItem::HorizontalRule(_)
             | BlockItem::Image { .. }
             | BlockItem::TemporaryBlock { .. }
@@ -3849,7 +4149,9 @@ impl Positioned<'_, BlockItem> {
                 let origin = self.content_origin();
                 Some(RectF::new(origin, embedded_item.size()))
             }
-            BlockItem::TemporaryBlock { .. } | BlockItem::Hidden { .. } => None,
+            BlockItem::TemporaryBlock { .. }
+            | BlockItem::EmbeddedComment { .. }
+            | BlockItem::Hidden { .. } => None,
         }
     }
 
@@ -3907,7 +4209,9 @@ impl Positioned<'_, BlockItem> {
                 let origin = self.visible_origin();
                 RectF::new(origin, embedded_item.first_line_bound())
             }
-            BlockItem::TemporaryBlock { .. } | BlockItem::Hidden { .. } => return None,
+            BlockItem::TemporaryBlock { .. }
+            | BlockItem::EmbeddedComment { .. }
+            | BlockItem::Hidden { .. } => return None,
         };
 
         // At the block level, we want to include any space for list bullets and other

--- a/specs/embedded-code-review-comments/PRODUCT.md
+++ b/specs/embedded-code-review-comments/PRODUCT.md
@@ -1,0 +1,82 @@
+# Embedded Code Review Comments
+
+## Summary
+Embedded code review comments render directly inside the code review diff at the line they reference. Users can create, read, edit, update, remove, and cancel comments inline without switching to a separate bottom-panel-only workflow, and inline comments should visually behave like part of the diff row rather than like floating overlays.
+
+## Problem
+The previous inline review experience used gutter icons and floating composers that could obscure code, duplicate saved-comment affordances, and shift between different visual treatments when moving from draft to saved state. The desired experience is closer to GitHub's inline review model: the comment appears below the reviewed line, the surrounding diff background continues through the comment area, and saved comments use the same stable comment surface as edits.
+
+## Figma
+Figma: none provided.
+
+## Goals
+- Make line-targeted review comments visible in context, directly below their referenced diff line.
+- Keep the inline comment surface stable when a comment transitions between draft, saved, and editing states.
+- Preserve the existing non-embedded / floating composer behavior when embedded comments are disabled.
+- Keep file-level, general, and outdated comments out of the inline diff surface.
+
+## Non-goals
+- Replacing the bottom review comments panel.
+- Changing how review comments are submitted to agents or GitHub.
+- Supporting threaded inline conversations beyond the existing flattened comment body behavior.
+
+## Behavior
+1. When embedded code review comments are enabled, creating a comment on a diff line opens an inline comment editor directly below that line.
+
+2. The inline editor is anchored to the reviewed line, not to the user's current cursor position or scroll position. Vertical scrolling moves the editor with the surrounding diff content.
+
+3. The inline editor appears below the reviewed line. It must not cover the text of the reviewed line.
+
+4. The diff background for the reviewed hunk continues behind the inline comment editor. Added-line comments continue the added-line background; removed-line comments continue the removed-line background; replacement hunks preserve the correct added or removed side color for the line being commented on.
+
+5. The inline comment editor is horizontally stable relative to the visible editor viewport. Horizontal code scrolling must not clip the comment editor or cause the card to move off-screen with long code lines.
+
+6. Inline comment cards use a consistent shell in draft, saved, and editing states: the same max width, rounded border, background, body padding, footer border, footer padding, and bottom-aligned actions.
+
+7. A new draft comment has an editable body and footer actions for canceling or saving the comment. The primary save action is disabled while the draft body is empty.
+
+8. Saving a new draft converts the same inline comment surface into a saved comment. The transition should not visibly flicker, jump height, swap to a narrower card for a frame, or briefly show an empty editor.
+
+9. Saved comments show the rendered comment body and a footer with lightweight metadata, including relative update time. If a comment was imported from GitHub, the saved/footer metadata includes a GitHub indicator.
+
+10. Saved comments show Edit and Remove actions in the footer. Edit appears to the left of Remove.
+
+11. Selecting Edit on a saved inline comment changes that same comment surface into an editable state. It must not replace the card with a separate editor view or cause a visible size jump.
+
+12. Editing an existing comment shows the saved body as the editable draft, uses an Update primary action, and includes Cancel and Remove actions.
+
+13. Saving an edit updates the same inline comment surface back to saved mode with the updated body.
+
+14. Canceling an edit restores the saved content and returns the same inline comment surface to saved mode.
+
+15. Canceling a new unsaved draft removes that draft from the inline diff surface.
+
+16. Removing a saved inline comment deletes the comment from the review comment set and removes the inline card from the diff.
+
+17. Multiple saved comments on distinct lines render as independent inline cards at their own lines.
+
+18. Comments on the same current line stack without overlapping each other or the surrounding code.
+
+19. Removed-line comments are anchored to the specific removed-line slot they reference, not just to the current line number of the hunk.
+
+20. A removed-line comment and a current-line comment with the same displayed line number are treated as different anchors.
+
+21. When the embedded comments feature is disabled, opening a line comment uses the existing floating comment composer behavior. Lines below the commented line must not be pushed down by an inline block in this mode.
+
+22. When embedded comments are enabled, the old saved-comment gutter icon is hidden for lines that already have inline cards. The inline card itself is the saved-comment affordance.
+
+23. When an inline draft or edit is active on a line, the gutter should not show duplicate comment icons or action buttons for that same inline comment row.
+
+24. Gutter add-comment affordances remain available for changed lines that do not currently have an inline draft or saved inline comment occupying their comment affordance.
+
+25. The inline comment block should not render a duplicate line number for the reserved comment row. Only actual code/diff lines show line numbers.
+
+26. Inline comment cards do not render the diff snippet that bottom-panel comment cards include. The line context is already visible in the surrounding diff.
+
+27. File-level comments, general/diffset comments, and outdated line comments do not render as inline cards in the diff. They remain visible through the existing review comment surfaces.
+
+28. Switching diff modes or refreshing the review comment batch updates inline comment positions to the latest valid line anchors. Comments that can no longer be anchored inline should not leave stale inline cards behind.
+
+29. Inline comments preserve keyboard and focus expectations: opening a draft or edit focuses the editable comment body; saved comments are selectable but not editable; escape/cancel behavior should not discard non-empty drafts unexpectedly.
+
+30. The review experience must remain usable with long code lines, horizontal scrolling, expanded deletion hunks, replacement hunks, and multiple comments in one file.

--- a/specs/embedded-code-review-comments/TECH.md
+++ b/specs/embedded-code-review-comments/TECH.md
@@ -1,0 +1,188 @@
+# Embedded Code Review Comments Technical Spec
+## Context
+This spec implements the behavior described in [`PRODUCT.md`](PRODUCT.md). The legacy floating-overlay path (`CommentEditor`, `PendingComment`) is unchanged and remains active when `FeatureFlag::EmbeddedCodeReviewComments` is off.
+
+**High-level architecture**: each inline comment has one `InlineCommentView` keyed by `CommentId`. When a comment is created or the batch refreshes, `InlineCommentsController` reconciles the view map, reads each view's current height from its inner render state, and pushes a `CommentBlock` to `CodeEditorModel::set_inline_comment_blocks`. The model stores these as `BlockItem::EmbeddedComment` entries in a sumtree alongside regular text blocks and diff removed-line blocks; the sumtree's aggregate layout pushes surrounding lines down by each block's reserved height.
+
+Key files:
+- `app/src/code/editor/inline_comment_view.rs` — stable per-comment view; owns the body editor across all mode transitions
+- `app/src/code/editor/inline_comments.rs` — `InlineCommentsController`; owns the view map and syncs blocks
+- `app/src/code/editor/embedded_comment.rs` — `LaidOutInlineSavedComment` / `RenderableHostedComment` (new inline path) and `EmbeddedCommentSpace` / `LaidOutEmbeddedCommentSpace` (legacy markdown-embed path, see Decision 5)
+- `crates/editor/src/render/model/mod.rs` — `BlockItem::EmbeddedComment`, `apply_comment_blocks`, `reset_comment_blocks`
+- `app/src/code/editor/model.rs` — `CodeEditorModel::set_inline_comment_blocks`
+
+## Design Decision 1: How the editor space grows with content
+The body editor inside each `InlineCommentView` has its own inner `RenderState` whose `height()` reflects the content laid-out height. The outer editor's reserved block height is kept in sync by observing this inner render state and re-pushing an updated `CommentBlock` whenever it changes.
+
+**Data flow**
+
+1. `InlineCommentsController::wire_view` subscribes to the inner render state of each newly created view:
+   ```rust path=app/src/code/editor/inline_comments.rs start=209
+   let inner_render_state = view.as_ref(ctx).inner_render_state(ctx);
+   ctx.observe(&inner_render_state, |me, _, ctx| {
+       me.sync_inline_comment_blocks(ctx);
+   });
+   ```
+2. On every layout pass of the body editor (keystrokes, paste, select-all+delete), `inner_render_state` emits `RenderEvent::LayoutUpdated`, which fires the observer.
+3. `sync_inline_comment_blocks` → `InlineCommentsController::sync_blocks` reads `inline_height()` from each view:
+   ```rust path=app/src/code/editor/inline_comment_view.rs start=277
+   pub fn inline_height(&self, app: &AppContext) -> Pixels {
+       let content_height = self.inner_render_state(app).as_ref(app).height().as_f32();
+       Pixels::new(content_height + comment_chrome_height(&self.save_button, app))
+   }
+   ```
+   `comment_chrome_height` is computed from named constants in `comment_editor.rs` (body padding, footer padding, footer border, outer border) plus the footer button's measured height, so the reserved space tracks button-height scaling automatically.
+4. `sync_blocks` is needed — rather than each view updating its own block independently — because `reset_comment_blocks` replaces the *entire* comment block set atomically in the sumtree. You can't update one view's height in isolation; you must re-collect every view's current height and push the full set together. `sync_blocks` does this: it collects `(RenderLineLocation, Pixels, EntityId)` triples from all views, sorts them deterministically, and compares the result against `last_synced_blocks`. The equality check is critical: the observer fires on *every* body editor layout pass, including keystrokes that don't change the height (e.g. typing horizontally within a single line). Without the early-out, every keystroke in any draft would trigger a full sumtree rebuild.
+5. When the set has changed, `sync_blocks` calls `CodeEditorModel::set_inline_comment_blocks`, which forwards to `RenderState::set_comment_blocks` → `LayoutAction::SetCommentBlocks`.
+6. `apply_comment_blocks` → `reset_comment_blocks` rebuilds the content sumtree with `BlockItem::EmbeddedComment` entries at the new heights. The sumtree is the editor's source of truth for vertical layout: every block's Y offset is derived from the summed heights of all blocks before it, so inserting or resizing a `BlockItem::EmbeddedComment` automatically shifts every line below it.
+
+**Height cap**: editable drafts cap at `MAX_COMMENT_HEIGHT` and scroll internally so a large draft doesn't push all diff lines off-screen. Saved cards use `UNBOUNDED_COMMENT_HEIGHT` so the full comment is always visible inline.
+
+## Design Decision 2: Per-view isolation from the shared buffer
+The editor buffer is shared across all `CodeEditorView`s open on the same file. Spacing for inline comments must not bleed into other views of that file.
+
+**Why `BlockItem::EmbeddedComment` is its own variant**
+
+The existing `BlockItem::TemporaryBlock` is used for removed-line diff blocks and is also per-view. The two block types must coexist and never clobber each other:
+- `reset_temporary_block` (called on every diff refresh) skips `EmbeddedComment` items so comment blocks survive diff reloads.
+- `reset_comment_blocks` (called from `apply_comment_blocks`) skips `TemporaryBlock` items so diff removed-line blocks survive comment updates.
+- `layout_pending_edit` (buffer edits) preserves both variants explicitly.
+
+If `EmbeddedComment` had reused `TemporaryBlock`, a diff refresh would silently erase all inline comment spacing.
+
+**Where the write lands**
+
+`CodeEditorModel::set_inline_comment_blocks` updates `self.render_state`, which is a `ModelHandle<RenderState>` owned exclusively by one `CodeEditorView`'s `CodeEditorModel`. Each `CodeEditorView` has its own `CodeEditorModel` and therefore its own `RenderState`. The shared buffer is never touched.
+
+```rust path=app/src/code/editor/model.rs start=3857
+pub fn set_inline_comment_blocks(
+    &mut self,
+    blocks: Vec<CommentBlock>,
+    ctx: &mut ModelContext<Self>,
+) {
+    self.render_state.update(ctx, |render_state, _| {
+        render_state.set_comment_blocks(blocks)
+    });
+}
+```
+
+**Anchor encoding for removed lines**
+
+Current lines map to `RenderLineLocation::Current(line_number + 1)` so the block appears below the anchor line. Removed lines (which already occupy a `Temporary` slot in the content tree) map to `RenderLineLocation::Temporary { at_line, index_from_at_line }` — the same slot as the removed-line block itself. `reset_comment_blocks` inserts the comment block *after* the matching `TemporaryBlock`, so the comment renders below the removed line without a line-number offset.
+
+## Design Decision 3: Single stable view across all modes
+The old model used a single shared `CommentEditor` for drafts and separate read-only cards for saved comments. Saving called `self.reset(ctx)` on the composer, collapsing the block, then a server round-trip created a new card with the correct height. This caused a visible flash: block collapse → reinsertion.
+
+**The new model**
+
+Each comment has exactly one `InlineCommentView` for its entire lifetime, keyed by `CommentId`. The view owns the same `RichTextEditorView` (body editor) across three internal modes:
+
+- `NewDraft` — editable, no saved content yet; `CommentId` is assigned at creation
+- `EditingExisting` — editable, body pre-loaded with saved content
+- `Saved` — selectable (read-only)
+
+Mode transitions update `InteractionState`, footer buttons, and `saved_content` in place. The body editor's view handle is never replaced.
+
+**Save without a view swap**
+
+`InlineCommentView::save` emits `CommentSaved { id, line, comment_text }`. `CodeEditorView::handle_inline_comment_event` saves the comment, then calls `inline_comments.complete_save(review_comment, ctx)`, which forwards to `InlineCommentView::complete_save` on the *same* view:
+```rust path=app/src/code/editor/inline_comment_view.rs start=213
+pub fn complete_save(&mut self, comment: EditorReviewComment, ctx: &mut ViewContext<Self>) {
+    self.saved_content = comment.comment_content;
+    self.mode = InlineCommentMode::Saved;
+    self.apply_mode(ctx);
+    ctx.notify();
+}
+```
+Because the view and its body editor are unchanged, the block height never collapses and there is no flash.
+
+**When reconciliation fires**
+
+`reconcile_saved` is called from `CodeEditorView::set_comment_locations`, which is called by `CodeReviewView::update_editor_comment_markers`. That method fires in response to `ReviewCommentBatchEvent::Changed`, emitted whenever a comment is upserted, deleted, or relocated (e.g. after a diff mode switch). Understanding this timing matters for the `update_source` guard below: batch updates can arrive while the user is mid-edit.
+
+**Reconciliation preserves view identity**
+
+`InlineCommentsController::reconcile_saved` matches by `CommentId`: existing IDs call `update_source` (in-place metadata/content update) and reuse their handle; only truly new IDs create a new view; IDs absent from the batch are dropped unless they are unsaved drafts.
+
+`update_source` guards the body-editor reset behind `mode == Saved`, so an in-flight edit is never overwritten by a concurrent batch update. If the user is in `EditingExisting` mode when a batch arrives, `saved_content` is updated (so Cancel reverts to the latest server version) but the body editor is left untouched.
+
+## Design Decision 4: Crossing the `warp_editor` crate boundary
+`warp_editor` is a standalone crate with no dependency on the app crate. `InlineCommentView` and `CommentEditor` are app-crate view types, so they can't be referenced directly inside `warp_editor`'s render block interface.
+
+The solution is to pass the view's identity — a `(WindowId, EntityId)` pair — through the `LaidOutEmbeddedItem` trait, and resolve it at render time using `app.view_with_id`. `warp_editor` never holds a typed view handle; it only stores opaque IDs.
+
+`LaidOutInlineSavedComment` (for `InlineCommentView`) and `LaidOutEmbeddedCommentSpace` (for the legacy `CommentEditor`) both follow this pattern:
+```rust path=app/src/code/editor/embedded_comment.rs start=368
+fn inline_view(&self, app: &AppContext) -> Option<ViewHandle<InlineCommentView>> {
+    app.view_with_id::<InlineCommentView>(self.window_id, self.view_entity_id)
+}
+```
+The `element()` method on `LaidOutEmbeddedItem` receives an `&AppContext`, resolves the view handle there, wraps it in a `ChildView`, and returns a `RenderableHostedComment`. If the view can't be resolved (e.g. the window was closed mid-frame), it falls back to a no-op `RenderableEmbeddedCommentSpace` that preserves the block's reserved height without painting anything. Preserving the height rather than collapsing it is intentional: the block's height was set by `sync_blocks` earlier in the same frame, and clearing it would cause a one-frame content jump before the observer can correct it.
+
+## Design Decision 5: Two height-tracking mechanisms (write-back vs. observation)
+`RenderableHostedComment` has an optional `write_back_size` callback. There are two callers that use it differently, and understanding why clarifies `RenderableHostedComment`'s asymmetric construction.
+
+**Context: the legacy `EmbeddedCommentSpace` mechanism**
+
+`EmbeddedCommentSpace` (also in `embedded_comment.rs`) is the older mechanism used when comments were stored as markdown-style embeds in the buffer content. In that model, the comment's reserved height wasn't derived from a render-state observer — it was bootstrapped from a size stored on the `CommentEditor` view itself. `EmbeddedCommentSpace` reads `get_laid_out_size()` from the view during `layout()` and uses that stored value as the block height. The write-back path exists to keep that stored size current.
+
+**Legacy `CommentEditor` path — write-back**: `RenderableHostedComment` calls the write-back after each layout pass to update the stored size on the view:
+```rust path=app/src/code/editor/embedded_comment.rs start=189
+Some(Box::new(move |measured, app| {
+    if let Some(editor) = app.view_with_id::<CommentEditor>(window_id, entity_id) {
+        editor.read(app, |editor, _| editor.set_laid_out_size(measured));
+    }
+}))
+```
+The next `EmbeddedCommentSpace::layout` call reads the stored size back to determine the block's reserved height.
+
+**`InlineCommentView` path — render-state observation**: The inline path passes `None` for `write_back_size`. Height tracking goes through a completely different control flow: `InlineCommentsController::wire_view` observes the body editor's inner `RenderState`; when it changes, the observation fires `sync_inline_comment_blocks` → `sync_blocks` → `set_inline_comment_blocks`, which rebuilds the outer editor's sumtree with the updated height (Decision 1).
+
+**Why write-back can't work for inline views**: write-back has a one-frame lag. It stores the measured height on the view during layout, but the outer editor only learns about that new height on its *next* layout pass when `EmbeddedCommentSpace::layout()` reads the stored value. For `CommentEditor`'s floating overlay, a one-frame lag is acceptable — the overlay is positioned externally and doesn't affect the sumtree. For `InlineCommentView`, the height drives sumtree layout, which determines the Y positions of every line below the block. A stale height means those lines shift by a pixel or more every time the draft grows — a visible jump on each keystroke. The observation approach fires within the same layout cycle as the body editor's layout, so the sumtree is updated before the outer editor computes its final line positions.
+
+The write-back path is retained only to avoid a larger refactor of the legacy `EmbeddedCommentSpace` / `CommentEditor` embedding.
+
+## Design Decision 6: Why `inline_comment_decoration_end` is needed
+The problem is that the diff-hunk colored background (green for added lines, red for removed lines) must visually cover the area occupied by the inline comment editor, not stop at the bottom of the anchor line. Without any special handling, the colored rectangle ends at the last diff line, and the comment card sits against the default editor background — a visible break in the hunk's color.
+
+The simplest fix would be to give each comment block's gutter row a copy of the parent hunk's overlay color so it joins the group naturally. But that would require passing diff-status information into the comment block rendering path, which is currently completely decoupled from diff hunk colors. The extension approach avoids that coupling by post-processing the already-computed decoration bounds.
+
+Diff hunk colored backgrounds are painted in `element.rs` by merging consecutive gutter elements into *groups*. An element joins the current group when its line range matches the group's range and either: its overlay matches (same color), or it has no overlay at all but is part of the same diff range. The merged group is painted as a single rectangle from the group's top to its bottom.
+
+`EmbeddedComment` blocks produce gutter entries with no overlay and a line range that no longer matches the diff hunk's range (the block is anchored *after* its line, not on it). The group collector treats this as a range mismatch and flushes the group early — leaving the comment row uncolored and the background split.
+
+There are two places this needs fixing:
+
+**Overlay group flushing (removed-line backgrounds)**: the group flush path in `element.rs` now checks whether a no-overlay element shares the current group's line range; if so, `end_y` is extended rather than flushing. This keeps removed-line overlay groups contiguous through comment rows in replacement hunks.
+
+**Decoration rectangles (added-line backgrounds)**: the decoration loop separately paints `line_decoration_ranges` as rectangles. `inline_comment_decoration_end` detects whether an inline comment block starts at or very near the decoration's current bottom edge and returns the block's bottom if so:
+```rust path=app/src/code/editor/element.rs start=1510
+for line in comment_lines {
+    if let Some(block_end) =
+        inline_comment_decoration_end(start_y, end_y, line, model)
+    {
+        if block_end > extended_end_y {
+            extended_end_y = block_end;
+        }
+    }
+}
+```
+The outer loop extends the painted rectangle to `extended_end_y` instead of stopping at the bare anchor line.
+
+## Supporting changes
+
+**Gutter icons**: when the `EmbeddedCodeReviewComments` flag is on, saved-comment gutter indicators and diff-hunk action buttons are suppressed for any line that has an inline card or open draft. The inline card itself serves as the visual anchor.
+
+**Horizontal pinning**: inline comment cards reserve vertical space in the content sumtree (so they scroll vertically with their anchor line) but are painted at the viewport's left edge rather than at the code's horizontal scroll position. This is done in `viewport_pinned_origin` by replacing the content rect's x origin with `ctx.bounds.origin_x()` (the visible viewport origin) before calling `child.paint`. Without this, the card would scroll horizontally with long code lines and disappear off-screen on wide diffs.
+
+**Scroll-to-comment**: `CodeReviewView::scroll_inline_comment_into_view` uses `comment_block_content_bounds` (which queries `RenderState::comment_block_position`) to bring the full card — not just its anchor line — into the viewport when jumping from the review panel.
+
+**`MouseStateHandle` preservation**: `set_comment_locations` now collects existing `MouseStateHandle`s by `CommentId` before clearing `comment_locations` and restores them when rebuilding the vec. Previously, a new `MouseStateHandle::default()` was created on every batch refresh, discarding all hover state. Per the WarpUI architecture, a `MouseStateHandle` must be created once during construction and reused; creating one inline during render or refresh breaks all mouse interactions for that element.
+
+## Risks and mitigations
+
+- Risk: `reset_temporary_block` and `reset_comment_blocks` must stay coordinated — if one forgets to preserve the other's variant, comment blocks or diff blocks disappear silently on the next diff refresh or comment sync. Mitigation: each reset skips the other's variant, and `layout_pending_edit` has explicit guards for both.
+- Risk: `inline_height()` reads the inner render state before the first layout pass completes; the height is 0 at that point, causing a one-frame zero-height block. The observer fires after the first layout and corrects it, so the flash lasts at most one frame but is not fully eliminated.
+- Risk: **Outdated comment filtering depends on a second feature flag.** `ReviewCommentBatch::editor_comments_for_file` only filters outdated comments when `FeatureFlag::PRCommentsSlashCommand` is enabled. If `EmbeddedCodeReviewComments` is on but `PRCommentsSlashCommand` is off, outdated line comments pass through `set_comment_locations` and create inline views, violating PRODUCT.md behavior 27. This is an open gap with no current mitigation.
+- Risk: Large saved comments create tall inline blocks that can push most of the diff off-screen. Mitigation: editable drafts cap at `MAX_COMMENT_HEIGHT`; saved cards show at full height intentionally (the whole comment should be visible inline).
+- Risk: The flag-off path (`active_comment_editor`, `PendingComment`) must stay intact. Mitigation: all embedded-path actions are explicitly gated on `FeatureFlag::EmbeddedCodeReviewComments.is_enabled()`.


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
