### PR TITLE
App-layer data model prep for inline comment blocks

### DIFF
--- a/app/src/code/editor/comments.rs
+++ b/app/src/code/editor/comments.rs
@@ -47,6 +47,7 @@ pub struct EditorReviewComment {
     pub diff_content: LineDiffContent,
     pub comment_content: String,
     pub last_update_time: DateTime<Local>,
+    pub origin: CommentOrigin,
 }
 
 impl EditorReviewComment {
@@ -61,6 +62,7 @@ impl EditorReviewComment {
             diff_content,
             comment_content,
             last_update_time: Local::now(),
+            origin: CommentOrigin::default(),
         }
     }
 
@@ -76,6 +78,7 @@ impl EditorReviewComment {
             diff_content,
             comment_content,
             last_update_time: Local::now(),
+            origin: CommentOrigin::default(),
         }
     }
 }
@@ -91,6 +94,7 @@ impl TryFrom<AttachedReviewComment> for EditorReviewComment {
                 diff_content: content,
                 comment_content: comment.content,
                 last_update_time: comment.last_update_time,
+                origin: comment.origin,
             }),
             _ => Err(()),
         }

--- a/app/src/code/editor/line.rs
+++ b/app/src/code/editor/line.rs
@@ -72,7 +72,35 @@ impl EditorLineLocation {
                 index_from_at_line: index,
             },
             EditorLineLocation::Collapsed { line_range } => {
-                debug_assert!(false, "We don't support converting from collapsed line location to render line location yet");
+                debug_assert!(
+                    false,
+                    "We don't support converting from collapsed line location to render line location yet"
+                );
+                RenderLineLocation::Current(line_range.start)
+            }
+        }
+    }
+
+    pub fn into_inline_comment_render_line_location(self) -> RenderLineLocation {
+        match self {
+            EditorLineLocation::Current { line_number, .. } => {
+                RenderLineLocation::Current(line_number + LineCount::from(1))
+            }
+            // For removed lines the comment block uses the same `Temporary` slot as the
+            // removed-line block itself (no +1 offset). `reset_comment_blocks` inserts comment
+            // blocks *after* the matching `TemporaryBlock` at this slot, so the comment renders
+            // below its removed line despite sharing the same `RenderLineLocation`.
+            EditorLineLocation::Removed {
+                line_number, index, ..
+            } => RenderLineLocation::Temporary {
+                at_line: line_number,
+                index_from_at_line: index,
+            },
+            EditorLineLocation::Collapsed { line_range } => {
+                debug_assert!(
+                    false,
+                    "We don't support converting from collapsed line location to render line location yet"
+                );
                 RenderLineLocation::Current(line_range.start)
             }
         }

--- a/app/src/code_review/comments/comment.rs
+++ b/app/src/code_review/comments/comment.rs
@@ -14,8 +14,9 @@ pub enum CommentOrigin {
     /// Comments originally created in the Warp UI.
     #[default]
     Native,
-    /// Comments imported from a GitHub pull request.
-    ImportedFromGitHub(ImportedCommentDetails),
+    /// Comments imported from a GitHub pull request. Boxed to keep `CommentOrigin` (and the
+    /// `EditorReviewComment` that carries it through the editor's saved-comment events) small.
+    ImportedFromGitHub(Box<ImportedCommentDetails>),
 }
 
 impl CommentOrigin {
@@ -214,7 +215,7 @@ impl AttachedReviewComment {
             },
             last_update_time: comment.last_update_time,
             outdated: false,
-            origin: CommentOrigin::Native,
+            origin: comment.origin,
         }
     }
 

--- a/app/src/code_review/comments/flatten.rs
+++ b/app/src/code_review/comments/flatten.rs
@@ -107,7 +107,7 @@ fn flatten_pending_imported_thread(
         ));
     }
 
-    let origin = CommentOrigin::ImportedFromGitHub(root.github_details_without_parent());
+    let origin = CommentOrigin::ImportedFromGitHub(Box::new(root.github_details_without_parent()));
 
     AttachedReviewComment {
         id: CommentId::new(),


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
