### PR TITLE
Inline code review comments: InlineCommentView, InlineCommentsController, editor wiring

### DIFF
--- a/app/src/code/editor/comment_editor.rs
+++ b/app/src/code/editor/comment_editor.rs
@@ -5,6 +5,7 @@ use pathfinder_geometry::vector::Vector2F;
 use warp_core::ui::appearance::Appearance;
 use warp_core::ui::theme::Fill;
 use warp_editor::render::element::VerticalExpansionBehavior;
+use warp_editor::render::model::RenderState;
 use warpui::elements::{
     Border, ChildView, Clipped, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Flex,
     MainAxisAlignment, MainAxisSize, ParentElement, Radius, Shrinkable, Text,
@@ -21,6 +22,7 @@ use crate::code::editor::comments::{EditorCommentsModel, PendingCommentEvent};
 use crate::code::editor::line::EditorLineLocation;
 use crate::code_review::comments::{CommentId, CommentOrigin};
 use crate::editor::InteractionState;
+use crate::features::FeatureFlag;
 use crate::notebooks::editor::model::NotebooksEditorModel;
 use crate::notebooks::editor::rich_text_styles;
 use crate::notebooks::editor::view::{EditorViewEvent, RichTextEditorConfig, RichTextEditorView};
@@ -34,6 +36,97 @@ use crate::view_components::action_button::{
 
 /// Default width of the comment editor, in pixels.
 pub(crate) const DEFAULT_COMMENT_MAX_WIDTH: f32 = 750.0;
+
+/// Maximum height of the comment editor, in pixels. Past this height the editor scrolls its content
+/// internally instead of growing further.
+pub(crate) const MAX_COMMENT_HEIGHT: f32 = 200.0;
+
+/// Chrome dimensions for the inline comment shell. These values mirror the padding/border used
+/// in [`render_inline_comment_shell`] and are kept as named constants so [`comment_chrome_height`]
+/// stays in sync with the shell's visual layout automatically.
+mod chrome {
+    /// Top padding of the body area inside the comment shell.
+    pub(super) const BODY_TOP_PADDING: f32 = 8.0;
+    /// Bottom padding of the body area inside the comment shell.
+    pub(super) const BODY_BOTTOM_PADDING: f32 = 4.0;
+    /// Vertical padding of the footer row (top + bottom).
+    pub(super) const FOOTER_VERTICAL_PADDING: f32 = 4.0 * 2.0;
+    /// Top border separating body from footer.
+    pub(super) const FOOTER_BORDER: f32 = 1.0;
+    /// Outer container border (top + bottom).
+    pub(super) const OUTER_BORDER: f32 = 1.0 * 2.0;
+
+    /// Fixed vertical chrome excluding the footer button row (which scales with appearance).
+    /// Slightly generous so the reserved inline block is never shorter than the painted shell.
+    pub(super) const STATIC_HEIGHT: f32 = BODY_TOP_PADDING
+        + BODY_BOTTOM_PADDING
+        + FOOTER_VERTICAL_PADDING
+        + FOOTER_BORDER
+        + OUTER_BORDER
+        + 1.0; // extra pixel of tolerance
+}
+
+/// Total vertical chrome around the inner comment editor: the static paddings/borders plus the
+/// footer button row measured at the current appearance, so the reserved inline height tracks
+/// button-height changes (e.g. UI font scaling) instead of assuming the default 24px row.
+pub(crate) fn comment_chrome_height(
+    footer_button: &ViewHandle<ActionButton>,
+    app: &AppContext,
+) -> f32 {
+    chrome::STATIC_HEIGHT + footer_button.as_ref(app).height(app)
+}
+
+pub(crate) fn inline_comment_background(appearance: &Appearance) -> ColorU {
+    blended_colors::neutral_2(appearance.theme())
+}
+
+pub(crate) fn inline_comment_border_color(appearance: &Appearance) -> ColorU {
+    blended_colors::neutral_4(appearance.theme())
+}
+
+pub(crate) fn render_inline_comment_shell(
+    body: Box<dyn Element>,
+    footer_row: Box<dyn Element>,
+    max_height: Option<f32>,
+    footer_horizontal_padding: f32,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    let background = inline_comment_background(appearance);
+    let border_color = inline_comment_border_color(appearance);
+
+    let body = Container::new(Clipped::new(body).finish())
+        .with_padding_bottom(chrome::BODY_BOTTOM_PADDING)
+        .with_padding_top(chrome::BODY_TOP_PADDING)
+        .with_horizontal_padding(12.)
+        .finish();
+    let body = if max_height.is_some() {
+        Shrinkable::new(1., body).finish()
+    } else {
+        body
+    };
+
+    let content = Flex::column()
+        .with_child(body)
+        .with_child(
+            Container::new(footer_row)
+                .with_vertical_padding(chrome::FOOTER_VERTICAL_PADDING / 2.0)
+                .with_horizontal_padding(footer_horizontal_padding)
+                .with_border(Border::top(chrome::FOOTER_BORDER).with_border_fill(border_color))
+                .finish(),
+        )
+        .finish();
+
+    let mut constrained = ConstrainedBox::new(content).with_max_width(DEFAULT_COMMENT_MAX_WIDTH);
+    if let Some(max_height) = max_height {
+        constrained = constrained.with_max_height(max_height);
+    }
+
+    Container::new(constrained.finish())
+        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
+        .with_background_color(background)
+        .with_border(Border::all(chrome::OUTER_BORDER / 2.0).with_border_fill(border_color))
+        .finish()
+}
 
 #[derive(Debug)]
 pub enum CommentEditorEvent {
@@ -104,46 +197,20 @@ impl CommentEditor {
         me
     }
 
-    #[allow(unused)] // TODO(CODE-1464): use this
-    pub fn new_embedded(
-        ctx: &mut ViewContext<Self>,
-        comment_model: ModelHandle<EditorCommentsModel>,
-        comment_id: Option<CommentId>,
-        line: EditorLineLocation,
-    ) -> Self {
-        let editor = create_editable_comment_markdown_editor(None, ctx);
-
-        ctx.subscribe_to_view(&editor, |me, _, event, ctx| {
-            me.handle_editor_event(event, ctx);
-        });
-
-        ctx.subscribe_to_model(&comment_model, |me, _, event, ctx| {
-            me.handle_comment_model_event(event, ctx);
-        });
-
-        let (save_button, close_button, remove_button) = Self::create_buttons(ctx);
-
-        let show_remove_button = comment_id.is_some();
-
-        let mut me = Self {
-            comment_id,
-            editor,
-            save_button,
-            close_button,
-            remove_button,
-            line: Some(line),
-            show_remove_button,
-            save_button_disabled: true,
-            laid_out_size: RefCell::new(None),
-            is_imported_comment: false,
-        };
-        me.update_save_button_state(ctx);
-        me
-    }
-
     #[cfg_attr(not(feature = "local_fs"), allow(unused))]
     pub fn comment_text(&self, app: &AppContext) -> String {
         self.editor.as_ref(app).model().as_ref(app).markdown(app)
+    }
+
+    /// The render state backing the inner markdown editor. Observing it lets a host re-measure the
+    /// composer's reserved inline height when its content (and therefore laid-out height) changes.
+    pub fn inner_render_state(&self, app: &AppContext) -> ModelHandle<RenderState> {
+        self.editor
+            .as_ref(app)
+            .model()
+            .as_ref(app)
+            .render_state()
+            .clone()
     }
 
     #[cfg_attr(not(feature = "local_fs"), allow(unused))]
@@ -151,7 +218,6 @@ impl CommentEditor {
         self.laid_out_size.borrow().as_ref().cloned()
     }
 
-    #[allow(unused)] // TODO(CODE-1464): use this
     pub fn set_laid_out_size(&self, value: Vector2F) {
         self.laid_out_size.replace(Some(value));
     }
@@ -236,13 +302,30 @@ impl CommentEditor {
                 self.save_comment(ctx);
             }
             EditorViewEvent::EscapePressed => {
-                // Dismiss the comment composer when pressing Escape on an empty draft.
-                if self.editor.as_ref(ctx).model().as_ref(ctx).is_empty(ctx) {
-                    self.reset(ctx);
-                    ctx.emit(CommentEditorEvent::CloseEditor);
-                }
+                self.handle_escape(ctx);
             }
-            _ => {}
+            EditorViewEvent::Focused
+            | EditorViewEvent::Navigate(_)
+            | EditorViewEvent::OpenFile { .. }
+            | EditorViewEvent::RunWorkflow(_)
+            | EditorViewEvent::EditWorkflow(_)
+            | EditorViewEvent::OpenedBlockInsertionMenu(_)
+            | EditorViewEvent::OpenedEmbeddedObjectSearch
+            | EditorViewEvent::OpenedFindBar
+            | EditorViewEvent::InsertedEmbeddedObject(_)
+            | EditorViewEvent::CopiedBlock { .. }
+            | EditorViewEvent::NavigatedCommands
+            | EditorViewEvent::ChangedSelectionMode(_)
+            | EditorViewEvent::TextSelectionChanged => {}
+        }
+    }
+
+    /// Dismiss the composer when Escape is pressed, but only if the draft body is empty.
+    /// A non-empty draft is preserved so Escape doesn't silently discard work.
+    fn handle_escape(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.editor.as_ref(ctx).model().as_ref(ctx).is_empty(ctx) {
+            self.reset(ctx);
+            ctx.emit(CommentEditorEvent::CloseEditor);
         }
     }
 
@@ -252,7 +335,13 @@ impl CommentEditor {
             // The `reset_with_markdown` call below is a band-aid fix.
             editor.reset_with_markdown("", ctx);
         });
+        self.comment_id = None;
         self.line = Some(line.clone());
+        self.show_remove_button = false;
+        self.is_imported_comment = false;
+        self.save_button.update(ctx, |button, ctx| {
+            button.set_label("Comment", ctx);
+        });
         self.update_save_button_state(ctx);
     }
 
@@ -315,7 +404,6 @@ impl CommentEditor {
             comment_text: comment_text.clone(),
             line: self.line.clone(),
         });
-        self.reset(ctx);
         ctx.emit(CommentEditorEvent::CloseEditor);
     }
 
@@ -400,45 +488,22 @@ impl View for CommentEditor {
 
     fn render(&self, ctx: &AppContext) -> Box<dyn Element> {
         let appearance = Appearance::handle(ctx).as_ref(ctx);
-        let theme = appearance.theme();
-        let background = blended_colors::neutral_2(theme);
-        let border_color = blended_colors::neutral_4(theme);
+        let background = inline_comment_background(appearance);
 
         let footer_row = self.render_footer_row(appearance, background);
 
-        Container::new(
-            ConstrainedBox::new(
-                Flex::column()
-                    .with_child(
-                        Shrinkable::new(
-                            1.,
-                            Container::new(
-                                Clipped::new(ChildView::new(&self.editor).finish()).finish(),
-                            )
-                            .with_padding_bottom(4.)
-                            .with_padding_top(8.)
-                            .with_horizontal_padding(12.)
-                            .finish(),
-                        )
-                        .finish(),
-                    )
-                    .with_child(
-                        Container::new(footer_row)
-                            .with_vertical_padding(4.)
-                            .with_horizontal_padding(4.)
-                            .with_border(Border::top(1.).with_border_fill(border_color))
-                            .finish(),
-                    )
-                    .finish(),
-            )
-            .with_max_height(200.)
-            .with_max_width(DEFAULT_COMMENT_MAX_WIDTH)
-            .finish(),
+        let footer_padding = if FeatureFlag::EmbeddedCodeReviewComments.is_enabled() {
+            12.
+        } else {
+            4.
+        };
+        render_inline_comment_shell(
+            ChildView::new(&self.editor).finish(),
+            footer_row,
+            Some(MAX_COMMENT_HEIGHT),
+            footer_padding,
+            appearance,
         )
-        .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.)))
-        .with_background_color(background)
-        .with_border(Border::all(1.).with_border_fill(border_color))
-        .finish()
     }
 
     fn on_focus(&mut self, focus_ctx: &FocusContext, ctx: &mut ViewContext<Self>) {

--- a/app/src/code/editor/element.rs
+++ b/app/src/code/editor/element.rs
@@ -16,7 +16,8 @@ use warp_editor::editor::EditorView;
 use warp_editor::render::element::lens_element::RichTextElementLens;
 use warp_editor::render::element::{RenderableBlock, RichTextElement, VerticalExpansionBehavior};
 use warp_editor::render::model::{
-    gutter_expansion_button_types, BlockLocation, ExpansionType, LineCount, RenderState,
+    gutter_expansion_button_types, BlockLocation, ExpansionType, LineCount, LineDecoration,
+    RenderLineLocation, RenderState,
 };
 use warpui::elements::new_scrollable::{NewScrollableElement, ScrollableAxis};
 use warpui::elements::{
@@ -50,6 +51,14 @@ fn highlight_element(appearance: &Appearance) -> Box<dyn Element> {
     Container::new(Empty::new().finish())
         .with_border(Border::all(2.).with_border_fill(border_color))
         .finish()
+}
+
+fn should_hide_comment_gutter_icons(
+    has_attached_comment: bool,
+    has_open_comment_box: bool,
+) -> bool {
+    (has_attached_comment || has_open_comment_box)
+        && FeatureFlag::EmbeddedCodeReviewComments.is_enabled()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -410,8 +419,9 @@ pub struct EditorWrapper<V: EditorView> {
     comment_button: Option<CommentButton>,
     // Todo: kc combine all comment related fields into a struct.
     comment_box: Option<CommentBox>,
-    /// Lines with saved comments attached. These lines always have an
-    /// indicator in the gutter element.
+    /// Lines with saved comments attached. These lines have an indicator in the gutter element
+    /// unless embedded inline comments are enabled, in which case the inline card replaces the
+    /// redundant gutter indicator.
     saved_comments: Vec<SavedComment>,
     gutter_element_hover_target: GutterHoverTarget,
     expand_diff_indicator_width_on_hover: bool,
@@ -419,6 +429,27 @@ pub struct EditorWrapper<V: EditorView> {
     find_references_save_position_id: String,
     /// The line where find references card is anchored (if active).
     find_references_anchor: Option<EditorLineLocation>,
+}
+
+/// Returns the content-space bottom of the inline comment block anchored at `line`, if that
+/// anchor line falls within `decoration`'s line range. `None` when the comment doesn't belong
+/// to this decoration. Callers extend the decoration's painted end to cover the block.
+fn inline_comment_decoration_end(
+    decoration: &LineDecoration,
+    line: &EditorLineLocation,
+    model: &RenderState,
+) -> Option<Pixels> {
+    // Only current lines can carry added-line decorations; removed-line comments
+    // are painted via `paint_removed_line_overlays` instead.
+    let EditorLineLocation::Current { line_number, .. } = line else {
+        return None;
+    };
+    if *line_number < decoration.start || *line_number >= decoration.end {
+        return None;
+    }
+    let position =
+        model.comment_block_position(line.clone().into_inline_comment_render_line_location())?;
+    Some(position.start_y_offset + position.content_height)
 }
 
 impl<V: EditorView> EditorWrapper<V> {
@@ -469,14 +500,22 @@ impl<V: EditorView> EditorWrapper<V> {
                 continue;
             }
 
-            let Some(overlay) = element.overlay else {
-                flush(&mut group);
-                continue;
-            };
-
+            // current_range/start_y/end_y are computed before the overlay check because the
+            // None-overlay branch below needs them to extend an existing group.
             let current_range = element.line.line_range().clone();
             let start_y = element.offset.as_f32();
             let end_y = start_y + element.height;
+
+            let Some(overlay) = element.overlay else {
+                if let Some(group) = &mut group {
+                    if group.line_range == current_range {
+                        group.end_y = end_y;
+                        continue;
+                    }
+                }
+                flush(&mut group);
+                continue;
+            };
 
             match &mut group {
                 Some(group) if group.line_range == current_range && group.overlay == overlay => {
@@ -569,6 +608,28 @@ impl<V: EditorView> EditorWrapper<V> {
             .iter()
             .find(|comment| comment.location().is_same_line(line))
             .cloned()
+    }
+
+    /// The [`EditorLineLocation`] for a gutter row at `line_count`, spanning its containing diff
+    /// range on the removed or added side, plus whether that range is currently hovered.
+    fn gutter_line_at(
+        &self,
+        line_count: LineCount,
+        removed_side: bool,
+        hovered_range: Option<&EditorLineLocation>,
+    ) -> (EditorLineLocation, bool) {
+        let diff_range = if removed_side {
+            self.diff_status.removed_diff_range(line_count)
+        } else {
+            self.diff_status.added_diff_range(line_count)
+        };
+        let line = EditorLineLocation::Current {
+            line_number: line_count,
+            line_range: diff_range.unwrap_or(line_count..line_count + 1),
+        };
+        let range_hovered = hovered_range
+            .is_some_and(|hovered_line| hovered_line.line_range() == line.line_range());
+        (line, range_hovered)
     }
 
     fn should_display_relative_line_number(&self) -> bool {
@@ -808,6 +869,59 @@ impl<V: EditorView> EditorWrapper<V> {
 
                 continue;
             }
+            if let Some(embedded_comment_location) = block.embedded_comment_location() {
+                let height = block.viewport_item().content_size.y();
+                let is_removed_comment = matches!(
+                    embedded_comment_location,
+                    RenderLineLocation::Temporary { .. }
+                );
+                let diff_hunk = if is_removed_comment {
+                    match diff_hunk {
+                        Some(DiffHunkDisplay::Replacement { remove_color, .. }) => {
+                            Some(DiffHunkDisplay::Remove(remove_color))
+                        }
+                        diff_hunk => diff_hunk,
+                    }
+                } else {
+                    diff_hunk
+                };
+                let (line, range_hovered) = self.gutter_line_at(
+                    line_count,
+                    is_removed_comment || is_removal,
+                    hovered_range.as_ref(),
+                );
+                let element = self.render_gutter_element(
+                    None,
+                    line_number_config,
+                    false,
+                    false,
+                    false,
+                    None,
+                    height,
+                    height,
+                    &line,
+                    block.overlay_decoration(),
+                    true,
+                    appearance,
+                );
+                elements.push(GutterElement {
+                    element,
+                    height,
+                    offset,
+                    hovered: range_hovered,
+                    line,
+                    element_type: GutterElementType::DiffHunk {
+                        hunk: diff_hunk,
+                        change_type: if is_removed_comment || is_removal {
+                            ChangeType::Remove
+                        } else {
+                            ChangeType::Add
+                        },
+                    },
+                    overlay: block.overlay_decoration(),
+                });
+                continue;
+            }
             let diff_range = self.diff_status.added_diff_range(line_count);
             let range_already_clicked = diff_range
                 .as_ref()
@@ -829,14 +943,8 @@ impl<V: EditorView> EditorWrapper<V> {
             // Check if this line is part of any diff hunk when diff hunks are expanded and hovered
             let is_diff_line = self.diff_hunks_are_expanded() && diff_hunk.is_some();
 
-            let line = EditorLineLocation::Current {
-                line_number: line_count,
-                line_range: diff_range.unwrap_or(line_count..line_count + 1),
-            };
-
-            let range_hovered = hovered_range
-                .as_ref()
-                .is_some_and(|hovered_line| hovered_line.line_range() == line.line_range());
+            let (line, range_hovered) =
+                self.gutter_line_at(line_count, false, hovered_range.as_ref());
 
             // Show comment button only on the specific hovered line
             let is_this_line_hovered = hovered_range
@@ -1190,12 +1298,23 @@ impl<V: EditorView> EditorWrapper<V> {
         let show_revert_diff_hunk =
             FeatureFlag::RevertDiffHunk.is_enabled() && self.revert_hunk_button.is_some();
 
-        // Show comment button independently of diff hunk state when requested
+        let hide_comment_gutter_icons = should_hide_comment_gutter_icons(
+            attached_comment.is_some(),
+            self.comment_box
+                .as_ref()
+                .is_some_and(|comment_box| comment_box.line.is_same_line(line)),
+        );
+        let show_saved_comment_indicator =
+            is_active_comment_on_current_line && !hide_comment_gutter_icons;
+        let should_show_diff_hunk_icons = should_show_diff_hunk_icons && !hide_comment_gutter_icons;
+
+        // Show comment button independently of diff hunk state when requested.
         let show_comment_button = FeatureFlag::InlineCodeReview.is_enabled()
             && self.comment_button.is_some()
-            && (should_show_comment_button || is_active_comment_on_current_line);
+            && !hide_comment_gutter_icons
+            && (should_show_comment_button || show_saved_comment_indicator);
 
-        if should_show_diff_hunk_icons || is_active_comment_on_current_line || show_comment_button {
+        if should_show_diff_hunk_icons || show_saved_comment_indicator || show_comment_button {
             let mut buttons = Flex::row().with_main_axis_size(MainAxisSize::Min);
             if let Some(comment_button) =
                 self.comment_button.as_ref().filter(|_| show_comment_button)
@@ -1388,10 +1507,26 @@ impl<V: EditorView> Element for EditorWrapper<V> {
             for decoration in model.decorations().line_decoration_ranges() {
                 let start_y = content.y_offset_at_line(decoration.start);
                 let end_y = content.y_offset_at_line(decoration.end);
+                let mut extended_end_y = end_y;
+                let comment_lines = self
+                    .comment_box
+                    .as_ref()
+                    .map(|comment_box| &comment_box.line)
+                    .into_iter()
+                    .chain(self.saved_comments.iter().map(|comment| comment.location()));
+                for line in comment_lines {
+                    if let Some(block_end) =
+                        inline_comment_decoration_end(decoration, line, model)
+                    {
+                        if block_end > extended_end_y {
+                            extended_end_y = block_end;
+                        }
+                    }
+                }
                 ctx.scene
                     .draw_rect_without_hit_recording(RectF::new(
                         origin + vec2f(0., (start_y - y_adjustment).as_f32()),
-                        vec2f(wrapper_size.x(), (end_y - start_y).as_f32()),
+                        vec2f(wrapper_size.x(), (extended_end_y - start_y).as_f32()),
                     ))
                     .with_background(decoration.overlay);
             }

--- a/app/src/code/editor/embedded_comment.rs
+++ b/app/src/code/editor/embedded_comment.rs
@@ -13,18 +13,40 @@ use warp_editor::render::layout::TextLayout;
 use warp_editor::render::model::viewport::ViewportItem;
 use warp_editor::render::model::{
     BlockSpacing, EmbeddedItem, EmbeddedItemHTMLRepresentation, EmbeddedItemRichFormat,
-    LaidOutEmbeddedItem, RenderState,
+    LaidOutEmbeddedItem, RenderLineLocation, RenderState,
 };
+use warpui::elements::ChildView;
 use warpui::event::DispatchedEvent;
 use warpui::units::Pixels;
-use warpui::{AppContext, EntityId, EventContext, LayoutContext, ViewHandle, WindowId};
+use warpui::{
+    AppContext, Element, EntityId, EventContext, LayoutContext, SizeConstraint, ViewHandle,
+    WindowId,
+};
 
-use crate::code::editor::comment_editor::CommentEditor;
+use crate::code::editor::comment_editor::{CommentEditor, MAX_COMMENT_HEIGHT};
+use crate::code::editor::inline_comment_view::InlineCommentView;
 use crate::code_review::comments::CommentId;
+
+/// Height constraint for a saved inline comment card: effectively unconstrained so the card
+/// reserves its full laid-out height and the whole comment is visible inline without scrolling.
+/// Uses `f32::INFINITY` rather than a large finite constant so the constraint is semantically
+/// correct (no maximum) and avoids overflow if layout code accumulates heights.
+const UNBOUNDED_COMMENT_HEIGHT: f32 = f32::INFINITY;
+
+/// Height of the first visible line used for `first_line_bound` in inline comment blocks.
+/// Matches `ButtonSize::Small.button_height()` at the default appearance (24px).
+const INLINE_COMMENT_FIRST_LINE_HEIGHT: f32 = 24.0;
 
 const COMMENT_ID_MAPPING_KEY: &str = "comment_id";
 const ENTITY_ID_MAPPING_KEY: &str = "entity_id";
 const WINDOW_ID_MAPPING_KEY: &str = "window_id";
+
+fn viewport_pinned_origin(viewport_item: &ViewportItem, ctx: &RenderContext) -> Vector2F {
+    let content_rect = viewport_item.content_bounds(ctx);
+    let mut origin = content_rect.origin();
+    origin.set_x(ctx.bounds.origin_x());
+    origin
+}
 
 #[derive(Debug)]
 pub struct EmbeddedCommentSpace {
@@ -70,7 +92,11 @@ impl EmbeddedItem for EmbeddedCommentSpace {
                 Vector2F::new(100.0, 24.0)
             });
 
-        Box::new(LaidOutEmbeddedCommentSpace { size })
+        Box::new(LaidOutEmbeddedCommentSpace::new(
+            self.editor_entity_id,
+            self.window_id,
+            size,
+        ))
     }
 
     fn hashed_id(&self) -> &str {
@@ -109,6 +135,22 @@ impl EmbeddedItem for EmbeddedCommentSpace {
 #[derive(Debug)]
 pub struct LaidOutEmbeddedCommentSpace {
     pub size: Vector2F,
+    editor_entity_id: EntityId,
+    window_id: WindowId,
+}
+
+impl LaidOutEmbeddedCommentSpace {
+    pub fn new(editor_entity_id: EntityId, window_id: WindowId, size: Vector2F) -> Self {
+        Self {
+            size,
+            editor_entity_id,
+            window_id,
+        }
+    }
+
+    fn comment_editor(&self, app: &AppContext) -> Option<ViewHandle<CommentEditor>> {
+        app.view_with_id::<CommentEditor>(self.window_id, self.editor_entity_id)
+    }
 }
 
 impl LaidOutEmbeddedItem for LaidOutEmbeddedCommentSpace {
@@ -121,7 +163,7 @@ impl LaidOutEmbeddedItem for LaidOutEmbeddedCommentSpace {
     }
 
     fn first_line_bound(&self) -> Vector2F {
-        vec2f(self.size.x(), 24.0)
+        vec2f(self.size.x(), INLINE_COMMENT_FIRST_LINE_HEIGHT)
     }
 
     fn element(
@@ -129,10 +171,33 @@ impl LaidOutEmbeddedItem for LaidOutEmbeddedCommentSpace {
         _state: &RenderState,
         viewport_item: ViewportItem,
         _model: Option<&dyn EmbeddedItemModel>,
-        _ctx: &AppContext,
+        ctx: &AppContext,
     ) -> Box<dyn RenderableBlock> {
-        // Just create a spacer - no child view rendering here
-        Box::new(RenderableEmbeddedCommentSpace::new(viewport_item))
+        // Host the comment editor's element in-tree so it occupies real vertical space at its line
+        // and scrolls with the surrounding content. If the editor handle can't be resolved, fall
+        // back to a no-op spacer that still reserves the block's height. This legacy path hosts a
+        // markdown embed (not a per-view comment block), so it carries no comment anchor.
+        match self.comment_editor(ctx) {
+            Some(editor) => {
+                let child = ChildView::new(&editor).finish();
+                let window_id = self.window_id;
+                let entity_id = self.editor_entity_id;
+                Box::new(RenderableHostedComment::new(
+                    viewport_item,
+                    child,
+                    MAX_COMMENT_HEIGHT,
+                    None,
+                    Some(Box::new(move |measured, app| {
+                        if let Some(editor) =
+                            app.view_with_id::<CommentEditor>(window_id, entity_id)
+                        {
+                            editor.read(app, |editor, _| editor.set_laid_out_size(measured));
+                        }
+                    })),
+                ))
+            }
+            None => Box::new(RenderableEmbeddedCommentSpace::new(viewport_item, None)),
+        }
     }
 
     fn spacing(&self) -> BlockSpacing {
@@ -144,13 +209,107 @@ impl LaidOutEmbeddedItem for LaidOutEmbeddedCommentSpace {
     }
 }
 
+type SizeWriteBack = Box<dyn Fn(Vector2F, &AppContext)>;
+
+/// Hosts an inline comment view's element (either the active composer or a saved-comment card)
+/// inside a per-view inline comment block. It lays out the child against the block's content width
+/// (capped at `max_height`), optionally writes the measured size back via `write_back_size` (the
+/// legacy composer reserves space from its last measured size; inline cards derive their reserved
+/// height from their render state instead), and paints and routes events to the child in content
+/// space (so it scrolls with its anchored line).
+pub struct RenderableHostedComment {
+    viewport_item: ViewportItem,
+    child: Box<dyn Element>,
+    max_height: f32,
+    /// The anchor of the inline comment block hosting this child, when known. Surfaced through
+    /// [`RenderableBlock::embedded_comment_location`] so gutter rendering can classify comment
+    /// rows without a reverse lookup into the content tree.
+    embedded_comment_location: Option<RenderLineLocation>,
+    /// Size write-back used only by the legacy [`LaidOutEmbeddedCommentSpace`] / [`CommentEditor`]
+    /// path. After each layout pass the measured size is written back to the view so
+    /// `EmbeddedCommentSpace::layout` can read it on the next frame. `InlineCommentView` always
+    /// passes `None` here and uses the render-state observation path instead (see
+    /// `InlineCommentsController::wire_view`). Remove when the legacy path is cleaned up.
+    write_back_size: Option<SizeWriteBack>,
+}
+
+impl RenderableHostedComment {
+    fn new(
+        viewport_item: ViewportItem,
+        child: Box<dyn Element>,
+        max_height: f32,
+        embedded_comment_location: Option<RenderLineLocation>,
+        write_back_size: Option<SizeWriteBack>,
+    ) -> Self {
+        Self {
+            viewport_item,
+            child,
+            max_height,
+            embedded_comment_location,
+            write_back_size,
+        }
+    }
+}
+
+impl RenderableBlock for RenderableHostedComment {
+    fn viewport_item(&self) -> &ViewportItem {
+        &self.viewport_item
+    }
+
+    fn layout(&mut self, _model: &RenderState, ctx: &mut LayoutContext, app: &AppContext) {
+        let width = self.viewport_item.content_size.x();
+        let measured = self.child.layout(
+            SizeConstraint::new(vec2f(0., 0.), vec2f(width, self.max_height)),
+            ctx,
+            app,
+        );
+
+        if let Some(write_back_size) = &self.write_back_size {
+            write_back_size(measured, app);
+        }
+    }
+
+    fn paint(&mut self, _model: &RenderState, ctx: &mut RenderContext, app: &AppContext) {
+        let origin = viewport_pinned_origin(&self.viewport_item, ctx);
+        ctx.paint.scene.start_layer(warpui::ClipBounds::ActiveLayer);
+        self.child.paint(origin, ctx.paint, app);
+        ctx.paint.scene.stop_layer();
+    }
+
+    fn after_layout(&mut self, ctx: &mut warpui::AfterLayoutContext, app: &AppContext) {
+        self.child.after_layout(ctx, app);
+    }
+
+    fn dispatch_event(
+        &mut self,
+        _model: &RenderState,
+        event: &DispatchedEvent,
+        ctx: &mut EventContext,
+        app: &AppContext,
+    ) -> bool {
+        self.child.dispatch_event(event, ctx, app)
+    }
+
+    fn embedded_comment_location(&self) -> Option<RenderLineLocation> {
+        self.embedded_comment_location
+    }
+}
+
 pub struct RenderableEmbeddedCommentSpace {
     viewport_item: ViewportItem,
+    /// See [`RenderableHostedComment::embedded_comment_location`].
+    embedded_comment_location: Option<RenderLineLocation>,
 }
 
 impl RenderableEmbeddedCommentSpace {
-    pub(crate) fn new(viewport_item: ViewportItem) -> Self {
-        Self { viewport_item }
+    pub(crate) fn new(
+        viewport_item: ViewportItem,
+        embedded_comment_location: Option<RenderLineLocation>,
+    ) -> Self {
+        Self {
+            viewport_item,
+            embedded_comment_location,
+        }
     }
 }
 
@@ -178,6 +337,92 @@ impl RenderableBlock for RenderableEmbeddedCommentSpace {
         false
     }
 
+    fn embedded_comment_location(&self) -> Option<RenderLineLocation> {
+        self.embedded_comment_location
+    }
+}
+
+/// An already-laid-out inline block hosting a saved-comment [`InlineCommentView`] (the read-only
+/// card). It mirrors [`LaidOutEmbeddedCommentSpace`] but hosts the saved card rather than the active
+/// composer, resolving the view by its window + entity id so the host stays independent of the
+/// app-crate view type at the `warp_editor` boundary.
+#[derive(Debug)]
+pub struct LaidOutInlineSavedComment {
+    pub size: Vector2F,
+    view_entity_id: EntityId,
+    window_id: WindowId,
+    /// The anchor of the comment block hosting this card, forwarded to the renderable so gutter
+    /// rendering can classify the row without a reverse lookup into the content tree.
+    location: RenderLineLocation,
+}
+
+impl LaidOutInlineSavedComment {
+    pub fn new(
+        view_entity_id: EntityId,
+        window_id: WindowId,
+        size: Vector2F,
+        location: RenderLineLocation,
+    ) -> Self {
+        Self {
+            size,
+            view_entity_id,
+            window_id,
+            location,
+        }
+    }
+
+    fn inline_view(&self, app: &AppContext) -> Option<ViewHandle<InlineCommentView>> {
+        app.view_with_id::<InlineCommentView>(self.window_id, self.view_entity_id)
+    }
+}
+
+impl LaidOutEmbeddedItem for LaidOutInlineSavedComment {
+    fn height(&self) -> Pixels {
+        Pixels::new(self.size.y())
+    }
+
+    fn size(&self) -> Vector2F {
+        self.size
+    }
+
+    fn first_line_bound(&self) -> Vector2F {
+        vec2f(self.size.x(), INLINE_COMMENT_FIRST_LINE_HEIGHT)
+    }
+
+    fn element(
+        &self,
+        _state: &RenderState,
+        viewport_item: ViewportItem,
+        _model: Option<&dyn EmbeddedItemModel>,
+        ctx: &AppContext,
+    ) -> Box<dyn RenderableBlock> {
+        match self.inline_view(ctx) {
+            Some(view) => {
+                let child = ChildView::new(&view).finish();
+                // No size write-back: the inline card's reserved height is derived from its body
+                // editor's render state (see `InlineCommentView::inline_height`).
+                Box::new(RenderableHostedComment::new(
+                    viewport_item,
+                    child,
+                    UNBOUNDED_COMMENT_HEIGHT,
+                    Some(self.location),
+                    None,
+                ))
+            }
+            None => Box::new(RenderableEmbeddedCommentSpace::new(
+                viewport_item,
+                Some(self.location),
+            )),
+        }
+    }
+
+    fn spacing(&self) -> BlockSpacing {
+        BlockSpacing::default()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 /// The embedded item transformation for comments.

--- a/app/src/code/editor/inline_comment_view.rs
+++ b/app/src/code/editor/inline_comment_view.rs
@@ -1,0 +1,516 @@
+use chrono::{DateTime, Local};
+use pathfinder_color::ColorU;
+use warp_core::ui::theme::Fill;
+use warp_editor::render::model::RenderState;
+use warpui::elements::{
+    ChildView, ConstrainedBox, CrossAxisAlignment, Flex, MainAxisAlignment, MainAxisSize,
+    ParentElement, Shrinkable, Text,
+};
+use warpui::text_layout::ClipConfig;
+use warpui::units::Pixels;
+use warpui::{
+    AppContext, Element, Entity, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
+    ViewHandle,
+};
+
+use crate::appearance::Appearance;
+use crate::code::editor::comment_editor::{
+    comment_chrome_height, create_editable_comment_markdown_editor, inline_comment_background,
+    render_inline_comment_shell,
+};
+use crate::code::editor::line::EditorLineLocation;
+use crate::code::editor::EditorReviewComment;
+use crate::code_review::comments::{CommentId, CommentOrigin};
+use crate::editor::InteractionState;
+use crate::notebooks::editor::view::{EditorViewEvent, RichTextEditorView};
+use crate::ui_components::icons::Icon;
+use crate::util::time_format::human_readable_approx_duration;
+use crate::view_components::action_button::{
+    ActionButton, ButtonSize, DangerNakedTheme, NakedTheme, PrimaryTheme,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InlineCommentMode {
+    Saved,
+    NewDraft,
+    EditingExisting,
+}
+
+/// Bundled configuration for constructing an [`InlineCommentView`].
+struct InlineCommentConfig {
+    id: CommentId,
+    line: EditorLineLocation,
+    saved_content: String,
+    last_update_time: DateTime<Local>,
+    origin: CommentOrigin,
+    mode: InlineCommentMode,
+}
+
+#[derive(Debug)]
+pub enum InlineCommentViewAction {
+    Edit,
+    Remove,
+    Save,
+    Cancel,
+}
+
+#[derive(Debug)]
+pub enum InlineCommentViewEvent {
+    RequestEdit {
+        id: CommentId,
+    },
+    RequestRemove {
+        id: CommentId,
+    },
+    CommentSaved {
+        id: CommentId,
+        line: EditorLineLocation,
+        comment_text: String,
+    },
+    Cancelled {
+        id: CommentId,
+    },
+    ContentChanged,
+}
+
+/// A per-comment inline code-review comment view hosted in the diff editor.
+///
+/// The same view owns the same inner [`RichTextEditorView`] while moving between saved and editing
+/// modes, so saving an inline comment does not replace the editor subtree and cause a transient
+/// sizing mismatch.
+pub struct InlineCommentView {
+    id: CommentId,
+    line: EditorLineLocation,
+    saved_content: String,
+    last_update_time: DateTime<Local>,
+    origin: CommentOrigin,
+    mode: InlineCommentMode,
+    body_editor: ViewHandle<RichTextEditorView>,
+    edit_button: ViewHandle<ActionButton>,
+    remove_button: ViewHandle<ActionButton>,
+    save_button: ViewHandle<ActionButton>,
+    cancel_button: ViewHandle<ActionButton>,
+    save_button_disabled: bool,
+}
+
+impl InlineCommentView {
+    pub fn new(comment: EditorReviewComment, ctx: &mut ViewContext<Self>) -> Self {
+        let body_editor =
+            create_editable_comment_markdown_editor(Some(&comment.comment_content), ctx);
+        Self::new_inner(
+            InlineCommentConfig {
+                id: comment.id,
+                line: comment.line,
+                saved_content: comment.comment_content,
+                last_update_time: comment.last_update_time,
+                origin: comment.origin,
+                mode: InlineCommentMode::Saved,
+            },
+            body_editor,
+            ctx,
+        )
+    }
+
+    pub fn new_draft(line: EditorLineLocation, ctx: &mut ViewContext<Self>) -> Self {
+        let body_editor = create_editable_comment_markdown_editor(None, ctx);
+        Self::new_inner(
+            InlineCommentConfig {
+                id: CommentId::new(),
+                line,
+                saved_content: String::new(),
+                last_update_time: Local::now(),
+                origin: CommentOrigin::default(),
+                mode: InlineCommentMode::NewDraft,
+            },
+            body_editor,
+            ctx,
+        )
+    }
+
+    fn new_inner(
+        config: InlineCommentConfig,
+        body_editor: ViewHandle<RichTextEditorView>,
+        ctx: &mut ViewContext<Self>,
+    ) -> Self {
+        let edit_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("Edit", NakedTheme)
+                .with_size(ButtonSize::Small)
+                .on_click(|ctx| ctx.dispatch_typed_action(InlineCommentViewAction::Edit))
+        });
+        let remove_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("Remove", DangerNakedTheme)
+                .with_size(ButtonSize::Small)
+                .on_click(|ctx| ctx.dispatch_typed_action(InlineCommentViewAction::Remove))
+        });
+        let save_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("Comment", PrimaryTheme)
+                .with_size(ButtonSize::Small)
+                .on_click(|ctx| ctx.dispatch_typed_action(InlineCommentViewAction::Save))
+        });
+        let cancel_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("Cancel", NakedTheme)
+                .with_size(ButtonSize::Small)
+                .on_click(|ctx| ctx.dispatch_typed_action(InlineCommentViewAction::Cancel))
+        });
+
+        ctx.subscribe_to_view(&body_editor, |me, _, event, ctx| {
+            me.handle_body_editor_event(event, ctx);
+        });
+
+        let mut me = Self {
+            id: config.id,
+            line: config.line,
+            saved_content: config.saved_content,
+            last_update_time: config.last_update_time,
+            origin: config.origin,
+            mode: config.mode,
+            body_editor,
+            edit_button,
+            remove_button,
+            save_button,
+            cancel_button,
+            save_button_disabled: true,
+        };
+        me.apply_mode(ctx);
+        me.update_save_button_state(ctx);
+        me
+    }
+
+    /// Refresh this view's saved data in place when the review comment batch delivers an update.
+    /// Called instead of destroying and recreating the view, which would collapse the block height
+    /// and discard in-progress edits.
+    ///
+    /// Metadata (line, timestamp, origin) is always updated. The body editor is only reset when
+    /// the view is in `Saved` mode — if the user is actively editing, their draft is preserved and
+    /// only `saved_content` is updated so that Cancel reverts to the latest server version.
+    pub fn update_source(&mut self, comment: EditorReviewComment, ctx: &mut ViewContext<Self>) {
+        self.id = comment.id;
+        self.line = comment.line;
+        self.last_update_time = comment.last_update_time;
+        self.origin = comment.origin;
+        if self.mode == InlineCommentMode::Saved && comment.comment_content != self.saved_content {
+            self.body_editor.update(ctx, |editor, ctx| {
+                editor.model().update(ctx, |model, ctx| {
+                    model.reset_with_markdown(&comment.comment_content, ctx);
+                });
+            });
+        }
+        self.saved_content = comment.comment_content;
+        if self.mode == InlineCommentMode::Saved {
+            self.apply_mode(ctx);
+        }
+        ctx.notify();
+    }
+
+    pub fn begin_editing(&mut self, ctx: &mut ViewContext<Self>) {
+        self.mode = InlineCommentMode::EditingExisting;
+        self.body_editor.update(ctx, |editor, ctx| {
+            editor.model().update(ctx, |model, ctx| {
+                model.reset_with_markdown(&self.saved_content, ctx);
+            });
+        });
+        self.apply_mode(ctx);
+        self.update_save_button_state(ctx);
+        ctx.focus(&self.body_editor);
+        ctx.notify();
+    }
+
+    pub fn complete_save(&mut self, comment: EditorReviewComment, ctx: &mut ViewContext<Self>) {
+        self.id = comment.id;
+        self.line = comment.line;
+        self.saved_content = comment.comment_content;
+        self.last_update_time = comment.last_update_time;
+        self.origin = comment.origin;
+        self.mode = InlineCommentMode::Saved;
+        self.apply_mode(ctx);
+        ctx.notify();
+    }
+
+    pub fn cancel_editing(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.mode == InlineCommentMode::EditingExisting {
+            self.mode = InlineCommentMode::Saved;
+            self.body_editor.update(ctx, |editor, ctx| {
+                editor.model().update(ctx, |model, ctx| {
+                    model.reset_with_markdown(&self.saved_content, ctx);
+                });
+            });
+            self.apply_mode(ctx);
+            ctx.notify();
+        }
+    }
+
+    pub fn id(&self) -> CommentId {
+        self.id
+    }
+
+    pub fn line(&self) -> &EditorLineLocation {
+        &self.line
+    }
+
+    pub fn is_editing(&self) -> bool {
+        matches!(
+            self.mode,
+            InlineCommentMode::NewDraft | InlineCommentMode::EditingExisting
+        )
+    }
+
+    pub fn is_new_draft(&self) -> bool {
+        self.mode == InlineCommentMode::NewDraft
+    }
+
+    pub fn focus_body(&self, ctx: &mut ViewContext<Self>) {
+        ctx.focus(&self.body_editor);
+    }
+
+    pub fn comment_text(&self, app: &AppContext) -> String {
+        self.body_editor
+            .as_ref(app)
+            .model()
+            .as_ref(app)
+            .markdown(app)
+    }
+
+    pub fn inner_render_state(&self, app: &AppContext) -> ModelHandle<RenderState> {
+        self.body_editor
+            .as_ref(app)
+            .model()
+            .as_ref(app)
+            .render_state()
+            .clone()
+    }
+
+    pub fn inline_height(&self, app: &AppContext) -> Pixels {
+        // Read directly from the inner render state so the reserved block height is always
+        // current. The `inner_render_state` observer fires after every layout pass (including
+        // non-keystroke edits like select-all + delete), so `sync_inline_comment_blocks` always
+        // sees an up-to-date value here.
+        let content_height = self.inner_render_state(app).as_ref(app).height().as_f32();
+        Pixels::new(content_height + comment_chrome_height(&self.save_button, app))
+    }
+
+    fn apply_mode(&mut self, ctx: &mut ViewContext<Self>) {
+        let interaction_state = if self.is_editing() {
+            InteractionState::Editable
+        } else {
+            InteractionState::Selectable
+        };
+        self.body_editor.update(ctx, |editor, ctx| {
+            editor.set_interaction_state(interaction_state, ctx);
+        });
+        self.save_button.update(ctx, |button, ctx| {
+            button.set_label(
+                if self.mode == InlineCommentMode::EditingExisting {
+                    "Update"
+                } else {
+                    "Comment"
+                },
+                ctx,
+            );
+        });
+    }
+
+    fn update_save_button_state(&mut self, ctx: &mut ViewContext<Self>) {
+        let is_empty = self
+            .body_editor
+            .as_ref(ctx)
+            .model()
+            .as_ref(ctx)
+            .is_empty(ctx);
+        if is_empty != self.save_button_disabled {
+            self.save_button_disabled = is_empty;
+            self.save_button.update(ctx, |button, ctx| {
+                button.set_disabled(is_empty, ctx);
+            });
+        }
+    }
+
+    fn handle_body_editor_event(&mut self, event: &EditorViewEvent, ctx: &mut ViewContext<Self>) {
+        match event {
+            EditorViewEvent::Edited => {
+                self.update_save_button_state(ctx);
+                ctx.emit(InlineCommentViewEvent::ContentChanged);
+            }
+            EditorViewEvent::CmdEnter => self.save(ctx),
+            EditorViewEvent::EscapePressed => self.handle_escape(ctx),
+            EditorViewEvent::Focused
+            | EditorViewEvent::Navigate(_)
+            | EditorViewEvent::OpenFile { .. }
+            | EditorViewEvent::RunWorkflow(_)
+            | EditorViewEvent::EditWorkflow(_)
+            | EditorViewEvent::OpenedBlockInsertionMenu(_)
+            | EditorViewEvent::OpenedEmbeddedObjectSearch
+            | EditorViewEvent::OpenedFindBar
+            | EditorViewEvent::InsertedEmbeddedObject(_)
+            | EditorViewEvent::CopiedBlock { .. }
+            | EditorViewEvent::NavigatedCommands
+            | EditorViewEvent::ChangedSelectionMode(_)
+            | EditorViewEvent::TextSelectionChanged => {}
+        }
+    }
+
+    fn save(&mut self, ctx: &mut ViewContext<Self>) {
+        let comment_text = self.comment_text(ctx);
+        if comment_text.trim().is_empty() {
+            return;
+        }
+        ctx.emit(InlineCommentViewEvent::CommentSaved {
+            id: self.id,
+            line: self.line.clone(),
+            comment_text,
+        });
+    }
+
+    fn cancel(&mut self, ctx: &mut ViewContext<Self>) {
+        ctx.emit(InlineCommentViewEvent::Cancelled { id: self.id });
+    }
+
+    /// Escape must not discard unsaved work: a new draft cancels only while its body is empty, and
+    /// an edit of an existing comment cancels only while the body still matches the saved content.
+    /// Otherwise Escape is a no-op and the footer Cancel button remains the explicit way to discard
+    /// changes.
+    fn handle_escape(&mut self, ctx: &mut ViewContext<Self>) {
+        let can_discard = match self.mode {
+            InlineCommentMode::NewDraft => self
+                .body_editor
+                .as_ref(ctx)
+                .model()
+                .as_ref(ctx)
+                .is_empty(ctx),
+            InlineCommentMode::EditingExisting => self.comment_text(ctx) == self.saved_content,
+            InlineCommentMode::Saved => false,
+        };
+        if can_discard {
+            self.cancel(ctx);
+        }
+    }
+
+    fn render_metadata(&self, appearance: &Appearance, background: ColorU) -> Box<dyn Element> {
+        let theme = appearance.theme();
+        let sub_text_color = theme.sub_text_color(Fill::Solid(background)).into_solid();
+        let mut leading = Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_spacing(4.);
+
+        if self.origin.is_imported_from_github() {
+            leading = leading.with_child(
+                ConstrainedBox::new(
+                    Icon::Github
+                        .to_warpui_icon(Fill::Solid(sub_text_color))
+                        .finish(),
+                )
+                .with_width(14.)
+                .with_height(14.)
+                .finish(),
+            );
+        }
+
+        let relative_time = human_readable_approx_duration(
+            Local::now() - self.last_update_time,
+            true, /* sentence_case */
+        );
+        leading = leading.with_child(
+            Text::new(
+                relative_time,
+                appearance.ui_font_family(),
+                appearance.ui_font_size(),
+            )
+            .soft_wrap(false)
+            .with_clip(ClipConfig::end())
+            .with_color(sub_text_color)
+            .finish(),
+        );
+        leading.finish()
+    }
+
+    fn render_saved_actions(&self) -> Box<dyn Element> {
+        Flex::row()
+            .with_spacing(4.)
+            .with_children([
+                ChildView::new(&self.edit_button).finish(),
+                ChildView::new(&self.remove_button).finish(),
+            ])
+            .with_main_axis_alignment(MainAxisAlignment::End)
+            .finish()
+    }
+
+    fn render_editing_actions(&self) -> Box<dyn Element> {
+        let mut actions = vec![ChildView::new(&self.cancel_button).finish()];
+        if self.mode == InlineCommentMode::EditingExisting {
+            actions.push(ChildView::new(&self.remove_button).finish());
+        }
+        actions.push(ChildView::new(&self.save_button).finish());
+
+        Flex::row()
+            .with_spacing(4.)
+            .with_children(actions)
+            .with_main_axis_alignment(MainAxisAlignment::End)
+            .finish()
+    }
+
+    fn render_footer_row(&self, appearance: &Appearance, background: ColorU) -> Box<dyn Element> {
+        let action_buttons = if self.is_editing() {
+            self.render_editing_actions()
+        } else {
+            self.render_saved_actions()
+        };
+
+        let footer_row = Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center);
+
+        if self.mode == InlineCommentMode::NewDraft {
+            footer_row
+                .with_main_axis_alignment(MainAxisAlignment::End)
+                .with_child(action_buttons)
+                .finish()
+        } else {
+            footer_row
+                .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+                .with_child(
+                    Shrinkable::new(1., self.render_metadata(appearance, background)).finish(),
+                )
+                .with_child(action_buttons)
+                .finish()
+        }
+    }
+}
+
+impl Entity for InlineCommentView {
+    type Event = InlineCommentViewEvent;
+}
+
+impl TypedActionView for InlineCommentView {
+    type Action = InlineCommentViewAction;
+
+    fn handle_action(&mut self, action: &InlineCommentViewAction, ctx: &mut ViewContext<Self>) {
+        match action {
+            InlineCommentViewAction::Edit => {
+                ctx.emit(InlineCommentViewEvent::RequestEdit { id: self.id });
+            }
+            InlineCommentViewAction::Remove => {
+                ctx.emit(InlineCommentViewEvent::RequestRemove { id: self.id });
+            }
+            InlineCommentViewAction::Save => self.save(ctx),
+            InlineCommentViewAction::Cancel => self.cancel(ctx),
+        }
+    }
+}
+
+impl View for InlineCommentView {
+    fn ui_name() -> &'static str {
+        "InlineCommentView"
+    }
+
+    fn render(&self, ctx: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(ctx);
+        let background = inline_comment_background(appearance);
+        let footer_row = self.render_footer_row(appearance, background);
+        render_inline_comment_shell(
+            ChildView::new(&self.body_editor).finish(),
+            footer_row,
+            None,
+            12.,
+            appearance,
+        )
+    }
+}

--- a/app/src/code/editor/inline_comments.rs
+++ b/app/src/code/editor/inline_comments.rs
@@ -1,0 +1,214 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use pathfinder_geometry::vector::vec2f;
+use warp_editor::render::model::{CommentBlock, RenderLineLocation};
+use warpui::units::Pixels;
+use warpui::{EntityId, ModelHandle, ViewContext, ViewHandle, WindowId};
+
+use crate::code::editor::comment_editor::DEFAULT_COMMENT_MAX_WIDTH;
+use crate::code::editor::embedded_comment::LaidOutInlineSavedComment;
+use crate::code::editor::inline_comment_view::InlineCommentView;
+use crate::code::editor::line::EditorLineLocation;
+use crate::code::editor::model::CodeEditorModel;
+use crate::code::editor::view::CodeEditorView;
+use crate::code::editor::EditorReviewComment;
+use crate::code_review::comments::CommentId;
+use crate::features::FeatureFlag;
+
+/// The desired render-state entry for one inline comment view: its anchor, reserved height, and
+/// the hosted view's entity id. Comparing the full entry set against the last synced one lets
+/// [`InlineCommentsController::sync_blocks`] skip the render-tree rebuild when nothing changed.
+type BlockEntry = (RenderLineLocation, Pixels, EntityId);
+
+/// Embedded inline review-comment state for one `CodeEditorView`.
+///
+/// Owns the per-comment [`InlineCommentView`] handles (saved cards and unsaved drafts, keyed by
+/// [`CommentId`]) and reconciles them into per-view [`CommentBlock`]s on the editor's render
+/// state. The owning `CodeEditorView` keeps subscription wiring, comment persistence
+/// (`save_comment`), and `CodeEditorEvent` emission; everything specific to the
+/// `EmbeddedCodeReviewComments` flag's inline presentation lives here, so removing either the
+/// embedded path or the legacy floating composer later stays localized.
+///
+/// Views are created and destroyed only in `&mut self` methods, never during `render`.
+pub(crate) struct InlineCommentsController {
+    /// Per-comment inline views, reconciled from the `ReviewCommentBatch` source of truth via
+    /// [`Self::reconcile_saved`] (create new, update changed in place, drop removed) plus, when
+    /// open, unsaved draft views. Only populated for line-targeted, non-outdated comments while
+    /// the `EmbeddedCodeReviewComments` flag is enabled.
+    views: HashMap<CommentId, ViewHandle<InlineCommentView>>,
+    /// The block set most recently pushed to the render state, sorted deterministically.
+    /// [`Self::sync_blocks`] early-outs when the desired set is unchanged, so frequent
+    /// re-measure triggers (every inner body-editor layout pass) don't rebuild the host
+    /// editor's content tree.
+    ///
+    /// The cache stays valid because the render state never drops `EmbeddedComment` blocks on
+    /// its own: buffer edits and temporary-block resets both preserve them.
+    last_synced_blocks: Vec<BlockEntry>,
+}
+
+impl InlineCommentsController {
+    pub fn new() -> Self {
+        Self {
+            views: HashMap::new(),
+            last_synced_blocks: Vec::new(),
+        }
+    }
+
+    /// Reconcile the saved-comment views against the incoming batch, mirroring how
+    /// `CommentListView::set_comments_internal` reconciles its cards: existing ids reuse (and
+    /// update in place) their handle, new ids create one, and removed ids are dropped. Unsaved
+    /// draft views are preserved. When the `EmbeddedCodeReviewComments` flag is off, no views are
+    /// created so no inline blocks are rendered and there is no flag-off regression.
+    pub fn reconcile_saved(
+        &mut self,
+        comments: Vec<EditorReviewComment>,
+        ctx: &mut ViewContext<CodeEditorView>,
+    ) {
+        let mut new_views: HashMap<CommentId, ViewHandle<InlineCommentView>> = HashMap::new();
+
+        if FeatureFlag::EmbeddedCodeReviewComments.is_enabled() {
+            for comment in comments {
+                let id = comment.id;
+                let view = match self.views.remove(&id) {
+                    Some(existing) => {
+                        existing.update(ctx, |view, ctx| view.update_source(comment, ctx));
+                        existing
+                    }
+                    None => {
+                        let view =
+                            ctx.add_typed_action_view(|ctx| InlineCommentView::new(comment, ctx));
+                        Self::wire_view(&view, ctx);
+                        view
+                    }
+                };
+                new_views.insert(id, view);
+            }
+        }
+
+        // Preserve unsaved draft views; any other handles still left correspond to removed saved
+        // comments and are dropped here.
+        for (id, view) in std::mem::take(&mut self.views) {
+            if view.as_ref(ctx).is_new_draft() {
+                new_views.insert(id, view);
+            }
+        }
+        self.views = new_views;
+    }
+
+    /// Create a new unsaved draft view anchored below `line` and return its handle so the caller
+    /// can focus its body.
+    pub fn open_draft(
+        &mut self,
+        line: EditorLineLocation,
+        ctx: &mut ViewContext<CodeEditorView>,
+    ) -> ViewHandle<InlineCommentView> {
+        let view = ctx.add_typed_action_view(|ctx| InlineCommentView::new_draft(line, ctx));
+        Self::wire_view(&view, ctx);
+        self.views.insert(view.as_ref(ctx).id(), view.clone());
+        view
+    }
+
+    /// Switch the saved card for `id` into editing mode. Returns `false` when no inline view
+    /// exists for that id.
+    pub fn begin_editing(&mut self, id: &CommentId, ctx: &mut ViewContext<CodeEditorView>) -> bool {
+        let Some(view) = self.views.get(id).cloned() else {
+            return false;
+        };
+        view.update(ctx, |view, ctx| view.begin_editing(ctx));
+        true
+    }
+
+    /// Apply a persisted comment back onto the same inline view (draft or edit -> saved).
+    pub fn complete_save(
+        &mut self,
+        comment: EditorReviewComment,
+        ctx: &mut ViewContext<CodeEditorView>,
+    ) {
+        if let Some(view) = self.views.get(&comment.id).cloned() {
+            view.update(ctx, |view, ctx| view.complete_save(comment, ctx));
+        }
+    }
+
+    /// Cancel the inline view for `id`: an unsaved draft is dropped entirely, while an edit of a
+    /// saved comment is restored to its saved content.
+    pub fn cancel(&mut self, id: &CommentId, ctx: &mut ViewContext<CodeEditorView>) {
+        let Some(view) = self.views.get(id).cloned() else {
+            return;
+        };
+        if view.as_ref(ctx).is_new_draft() {
+            self.views.remove(id);
+        } else {
+            view.update(ctx, |view, ctx| view.cancel_editing(ctx));
+        }
+    }
+
+    /// Drop all inline views. The next [`Self::sync_blocks`] clears the rendered blocks.
+    pub fn clear(&mut self) {
+        self.views.clear();
+    }
+
+    /// Reconcile the full set of inline comment blocks on the per-view render state with the
+    /// current views: one block per inline view (saved card or unsaved draft), each reserving the
+    /// view's current inline height at its anchor line. When the desired set matches what was
+    /// last synced, this is a no-op, so callers can invoke it on every potential change (e.g.
+    /// every body-editor layout pass) without rebuilding the host editor's content tree.
+    ///
+    /// When the `EmbeddedCodeReviewComments` flag is off the desired set is empty, which removes
+    /// any previously synced blocks and otherwise does nothing.
+    pub fn sync_blocks(
+        &mut self,
+        model: &ModelHandle<CodeEditorModel>,
+        window_id: WindowId,
+        ctx: &mut ViewContext<CodeEditorView>,
+    ) {
+        let mut entries: Vec<BlockEntry> = Vec::new();
+        if FeatureFlag::EmbeddedCodeReviewComments.is_enabled() {
+            for view in self.views.values() {
+                let view_ref = view.as_ref(ctx);
+                let location = view_ref
+                    .line()
+                    .clone()
+                    .into_inline_comment_render_line_location();
+                entries.push((location, view_ref.inline_height(ctx), view.id()));
+            }
+            // Deterministic ordering: keeps same-line stacking stable across syncs and makes the
+            // equality check below meaningful despite hash-map iteration order.
+            entries.sort_by_key(|(location, _, entity_id)| (*location, *entity_id));
+        }
+
+        if entries == self.last_synced_blocks {
+            return;
+        }
+
+        let blocks = entries
+            .iter()
+            .map(|(location, height, entity_id)| {
+                let size = vec2f(DEFAULT_COMMENT_MAX_WIDTH, height.as_f32());
+                CommentBlock::new(
+                    *location,
+                    Arc::new(LaidOutInlineSavedComment::new(
+                        *entity_id, window_id, size, *location,
+                    )),
+                )
+            })
+            .collect();
+        model.update(ctx, |model, ctx| {
+            model.set_inline_comment_blocks(blocks, ctx);
+        });
+        self.last_synced_blocks = entries;
+    }
+
+    /// Wire a newly created inline view: route its events to the owning `CodeEditorView` and
+    /// re-sync the reserved blocks whenever its body editor re-lays out (so the block grows and
+    /// shrinks with the content).
+    fn wire_view(view: &ViewHandle<InlineCommentView>, ctx: &mut ViewContext<CodeEditorView>) {
+        ctx.subscribe_to_view(view, |me, _, event, ctx| {
+            me.handle_inline_comment_event(event, ctx);
+        });
+        let inner_render_state = view.as_ref(ctx).inner_render_state(ctx);
+        ctx.observe(&inner_render_state, |me, _, ctx| {
+            me.sync_inline_comment_blocks(ctx);
+        });
+    }
+}

--- a/app/src/code/editor/mod.rs
+++ b/app/src/code/editor/mod.rs
@@ -7,6 +7,8 @@ mod element;
 pub mod embedded_comment;
 pub mod find;
 pub mod goto_line;
+pub mod inline_comment_view;
+mod inline_comments;
 pub mod line;
 mod line_iterator;
 pub mod model;

--- a/app/src/code/editor/model.rs
+++ b/app/src/code/editor/model.rs
@@ -47,7 +47,7 @@ use warp_editor::editor::TextDecoration;
 use warp_editor::model::{CoreEditorModel, PlainTextEditorModel};
 use warp_editor::multiline::{AnyMultilineString, MultilineString, LF};
 use warp_editor::render::model::{
-    AutoScrollMode, BlockItem, Decoration, LineCount, LineDecoration, RenderEvent,
+    AutoScrollMode, BlockItem, CommentBlock, Decoration, LineCount, LineDecoration, RenderEvent,
     RenderLineLocation, RenderState, RichTextStyles, StyleUpdateAction,
     UpdateDecorationAfterLayout, WidthSetting,
 };
@@ -3847,6 +3847,20 @@ impl CodeEditorModel {
                 comment_text: comment_text.to_owned(),
                 origin: origin.to_owned(),
             });
+        });
+    }
+
+    /// Replace the full set of per-view inline comment blocks on this view's [`RenderState`] with
+    /// `blocks` (the saved-comment cards plus, when open, the active composer). An empty vector
+    /// removes all inline comment blocks. This lives on the per-view render state only (never the
+    /// shared buffer), so it cannot leak into other views of the same file.
+    pub fn set_inline_comment_blocks(
+        &mut self,
+        blocks: Vec<CommentBlock>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.render_state.update(ctx, |render_state, _| {
+            render_state.set_comment_blocks(blocks)
         });
     }
 }

--- a/app/src/code/editor/view.rs
+++ b/app/src/code/editor/view.rs
@@ -39,8 +39,8 @@ use warpui::elements::new_scrollable::{
 };
 use warpui::elements::{
     ChildAnchor, ChildView, Dismiss, Fill, Flex, Margin, MouseStateHandle, NewScrollable,
-    OffsetPositioning, Padding, ParentAnchor, ParentElement, ParentOffsetBounds, ScrollStateHandle,
-    Shrinkable, Stack,
+    OffsetPositioning, Padding, ParentAnchor, ParentElement, ParentOffsetBounds, SavePosition,
+    ScrollStateHandle, Shrinkable, Stack,
 };
 use warpui::event::ModifiersState;
 use warpui::keymap::Keystroke;
@@ -63,6 +63,8 @@ use crate::code::editor::element::{
 };
 use crate::code::editor::find::view::{CodeEditorFind as Find, Event as FindViewEvent};
 use crate::code::editor::goto_line::view::{Event as GoToLineEvent, GoToLineView};
+use crate::code::editor::inline_comment_view::InlineCommentViewEvent;
+use crate::code::editor::inline_comments::InlineCommentsController;
 use crate::code::editor::line::EditorLineLocation;
 use crate::code::editor::model::{
     CodeEditorModel, CodeEditorModelEvent, HoverableLink, LineBound, StableEditorLine,
@@ -274,8 +276,15 @@ pub struct CodeEditorView {
     active_comment_editor: ViewHandle<CommentEditor>,
     /// TODO: maybe turn into a map for fast UUID or range lookup
     comment_locations: Vec<SavedComment>,
+    /// Embedded inline review-comment state (per-comment views and their rendered blocks). The
+    /// hosted views are presented inline by the per-view render state while the
+    /// `EmbeddedCodeReviewComments` flag is enabled.
+    inline_comments: InlineCommentsController,
     /// Save position of the comment button rendered within this code editor view.
     comment_save_position_id: String,
+    /// Save position of the flag-OFF floating comment composer overlay, so its painted presence and
+    /// offset can be observed (it lives outside the content tree, unlike the inline block).
+    comment_overlay_position_id: String,
     show_comment_editor_provider: Box<dyn ShowCommentEditorProvider>,
     /// Save position of the anchor point for find references card.
     find_references_save_position_id: String,
@@ -378,6 +387,12 @@ impl CodeEditorView {
         ctx.subscribe_to_view(&comment_editor, |me, _, event, ctx| {
             me.handle_comment_editor_event(event, ctx);
         });
+        // Re-measure the inline composer's reserved height whenever the editor's content re-lays
+        // out, so the block grows and shrinks with the draft.
+        let comment_render_state = comment_editor.as_ref(ctx).inner_render_state(ctx);
+        ctx.observe(&comment_render_state, |me, _, ctx| {
+            me.sync_inline_comment_blocks(ctx);
+        });
 
         Self {
             searcher,
@@ -389,6 +404,7 @@ impl CodeEditorView {
             self_handle: ctx.handle(),
             nav_bar,
             comment_locations: Vec::new(),
+            inline_comments: InlineCommentsController::new(),
             display_options: CodeEditorViewDisplayOptions {
                 vertical_expansion_behavior: render_options.vertical_expansion_behavior,
                 can_show_diff_ui: true,
@@ -422,6 +438,7 @@ impl CodeEditorView {
             last_search_direction: Direction::Forward,
             active_comment_editor: comment_editor,
             comment_save_position_id: format!("code_editor_comment_{}", ctx.view_id()),
+            comment_overlay_position_id: format!("code_editor_comment_overlay_{}", ctx.view_id()),
             show_comment_editor_provider: render_options.show_comment_editor_provider,
             find_references_save_position_id: format!(
                 "code_editor_find_references_{}",
@@ -1111,6 +1128,15 @@ impl CodeEditorView {
         }
     }
 
+    /// Reconcile the rendered inline comment blocks with the current inline views and notify.
+    /// Cheap when nothing changed (see [`InlineCommentsController::sync_blocks`]), so this is safe
+    /// to call on every potential change, including every body-editor layout pass.
+    pub(super) fn sync_inline_comment_blocks(&mut self, ctx: &mut ViewContext<Self>) {
+        self.inline_comments
+            .sync_blocks(&self.model, self.window_id, ctx);
+        ctx.notify();
+    }
+
     fn handle_comment_editor_event(
         &mut self,
         event: &CommentEditorEvent,
@@ -1118,8 +1144,7 @@ impl CodeEditorView {
     ) {
         match event {
             CommentEditorEvent::ContentChanged => {
-                // Handle comment content changes if needed
-                ctx.notify();
+                self.sync_inline_comment_blocks(ctx);
             }
             CommentEditorEvent::CommentSaved {
                 id,
@@ -1139,7 +1164,7 @@ impl CodeEditorView {
                         comments.pending_comment = PendingComment::Closed;
                     });
                 });
-                ctx.notify();
+                self.sync_inline_comment_blocks(ctx);
             }
             CommentEditorEvent::DeleteComment { id } => {
                 ctx.emit(CodeEditorEvent::DeleteComment { id: *id });
@@ -1153,7 +1178,7 @@ impl CodeEditorView {
         comment_text: &str,
         line: &EditorLineLocation,
         ctx: &mut ViewContext<Self>,
-    ) {
+    ) -> EditorReviewComment {
         let line_content = self.model.as_ref(ctx).get_diff_content_for_line(line, ctx);
 
         let review_comment = match id {
@@ -1175,32 +1200,84 @@ impl CodeEditorView {
         });
 
         ctx.emit(CodeEditorEvent::CommentSaved {
-            comment: review_comment,
+            comment: review_comment.clone(),
         });
         ctx.notify();
+        review_comment
     }
 
     /// Update all comment locations in this editor.
+    ///
+    /// Besides the gutter markers (`comment_locations`), this reconciles the embedded inline
+    /// views against the incoming batch via [`InlineCommentsController::reconcile_saved`]. View
+    /// handles are created/destroyed there in `&mut self`, never in `render`.
     pub fn set_comment_locations(
         &mut self,
         comments: impl Iterator<Item = EditorReviewComment>,
         ctx: &mut ViewContext<Self>,
     ) {
-        self.comment_locations.clear();
-        for comment in comments {
+        // Preserve existing MouseStateHandles so hover state survives across refreshes.
+        let prev_handles: HashMap<CommentId, MouseStateHandle> = self
+            .comment_locations
+            .drain(..)
+            .map(|sc| (sc.uuid, sc.mouse_state))
+            .collect();
+
+        let comments: Vec<EditorReviewComment> = comments.collect();
+        for comment in &comments {
+            let mouse_state = prev_handles.get(&comment.id).cloned().unwrap_or_default();
             self.comment_locations.push(SavedComment {
                 uuid: comment.id,
                 location: comment.line.clone(),
-                mouse_state: MouseStateHandle::default(),
+                mouse_state,
             });
         }
-        ctx.notify();
+
+        self.inline_comments.reconcile_saved(comments, ctx);
+        // Reconcile the rendered inline blocks (saved cards + drafts) against the new set.
+        self.sync_inline_comment_blocks(ctx);
+    }
+
+    pub(super) fn handle_inline_comment_event(
+        &mut self,
+        event: &InlineCommentViewEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match event {
+            InlineCommentViewEvent::RequestEdit { id } => {
+                if !self.inline_comments.begin_editing(id, ctx) {
+                    return;
+                }
+                self.sync_inline_comment_blocks(ctx);
+                ctx.emit(CodeEditorEvent::CommentEditorOpened);
+            }
+            InlineCommentViewEvent::RequestRemove { id } => {
+                ctx.emit(CodeEditorEvent::DeleteComment { id: *id });
+            }
+            InlineCommentViewEvent::CommentSaved {
+                id,
+                line,
+                comment_text,
+            } => {
+                let review_comment = self.save_comment(Some(*id), comment_text, line, ctx);
+                self.inline_comments.complete_save(review_comment, ctx);
+                self.sync_inline_comment_blocks(ctx);
+            }
+            InlineCommentViewEvent::Cancelled { id } => {
+                self.inline_comments.cancel(id, ctx);
+                self.sync_inline_comment_blocks(ctx);
+            }
+            InlineCommentViewEvent::ContentChanged => {
+                self.sync_inline_comment_blocks(ctx);
+            }
+        }
     }
 
     /// Clear all comment locations in this editor.
     pub fn clear_comment_locations(&mut self, ctx: &mut ViewContext<Self>) {
         self.comment_locations.clear();
-        ctx.notify();
+        self.inline_comments.clear();
+        self.sync_inline_comment_blocks(ctx);
     }
 
     fn line_number_config(&self, ctx: &AppContext) -> Option<LineNumberConfig> {
@@ -1650,6 +1727,23 @@ impl CodeEditorView {
         render_state_ref.line_number_to_offset_range(line_number)
     }
 
+    /// Content-space top offset and reserved height of the inline comment block anchored at `line`,
+    /// or `None` if no inline block is anchored there (e.g. the comment is outdated or the inline
+    /// feature is off). Used to scroll the card itself — not just its bare line — into view.
+    pub fn comment_block_content_bounds(
+        &self,
+        line: &EditorLineLocation,
+        ctx: &AppContext,
+    ) -> Option<(Pixels, Pixels)> {
+        let render_location = line.clone().into_inline_comment_render_line_location();
+        self.model
+            .as_ref(ctx)
+            .render_state()
+            .as_ref(ctx)
+            .comment_block_position(render_location)
+            .map(|position| (position.start_y_offset, position.content_height))
+    }
+
     pub fn offset_to_lsp_position(
         &self,
         offset: CharOffset,
@@ -1831,9 +1925,7 @@ impl CodeEditorView {
                     first_replace = if first_replace.is_uppercase() {
                         first_replace
                     } else {
-                        {
-                            first_replace.to_uppercase().next().unwrap_or(first_replace)
-                        }
+                        first_replace.to_uppercase().next().unwrap_or(first_replace)
                     };
                     result.push(first_replace);
                     result.push_str(&replace_chars.collect::<String>().to_lowercase());
@@ -2121,6 +2213,18 @@ impl CodeEditorView {
             );
             return;
         }
+        if FeatureFlag::EmbeddedCodeReviewComments.is_enabled() {
+            if !self.inline_comments.begin_editing(id, ctx) {
+                log::warn!(
+                    "open_existing_comment: no inline comment view found for id {:?}",
+                    id
+                );
+                return;
+            }
+            self.sync_inline_comment_blocks(ctx);
+            ctx.emit(CodeEditorEvent::CommentEditorOpened);
+            return;
+        }
 
         self.active_comment_editor
             .update(ctx, |comment_editor, ctx| {
@@ -2136,9 +2240,8 @@ impl CodeEditorView {
         self.model.update(ctx, |editor_model, ctx| {
             editor_model.reopen_comment_line(id, location, comment_text, origin, ctx);
         });
+        self.sync_inline_comment_blocks(ctx);
         ctx.emit(CodeEditorEvent::CommentEditorOpened);
-
-        ctx.notify();
     }
 }
 
@@ -2251,14 +2354,21 @@ impl View for CodeEditorView {
             self.find_references_save_position_id.clone(),
         );
 
-        let pending_comment = &self
-            .model
-            .as_ref(app)
-            .comments()
-            .as_ref(app)
-            .pending_comment;
-        // Check if there's an open comment in the model and set the comment box
-        if let PendingComment::Open { line, .. } = pending_comment {
+        let embedded_comments_enabled = FeatureFlag::EmbeddedCodeReviewComments.is_enabled();
+        let pending_comment = if embedded_comments_enabled {
+            None
+        } else {
+            Some(
+                &self
+                    .model
+                    .as_ref(app)
+                    .comments()
+                    .as_ref(app)
+                    .pending_comment,
+            )
+        };
+        // Check if there's an open legacy floating comment in the model and set the comment box.
+        if let Some(PendingComment::Open { line, .. }) = pending_comment {
             code_editor.set_comment_box(line.clone(), app);
         }
 
@@ -2326,7 +2436,7 @@ impl View for CodeEditorView {
 
         if !FeatureFlag::EmbeddedCodeReviewComments.is_enabled() {
             // Render the open comment editor.
-            if let PendingComment::Open { line, .. } = pending_comment {
+            if let Some(PendingComment::Open { line, .. }) = pending_comment {
                 let render_state_ref = render_state.as_ref(app);
                 let vertical_offset = render_state_ref
                     .vertical_offset_at_render_location(line.clone().into_render_line_location())
@@ -2347,7 +2457,11 @@ impl View for CodeEditorView {
 
                 if should_render_comment_editor {
                     stack.add_positioned_child(
-                        ChildView::new(&self.active_comment_editor).finish(),
+                        SavePosition::new(
+                            ChildView::new(&self.active_comment_editor).finish(),
+                            &self.comment_overlay_position_id,
+                        )
+                        .finish(),
                         OffsetPositioning::offset_from_parent(
                             vec2f(0., vertical_offset.as_f32()),
                             ParentOffsetBounds::ParentByPosition,

--- a/app/src/code/editor/view/actions.rs
+++ b/app/src/code/editor/view/actions.rs
@@ -1086,9 +1086,17 @@ impl TypedActionView for CodeEditorView {
             }
             NewCommentOnLine { line: line_info } => {
                 if FeatureFlag::InlineCodeReview.is_enabled() {
+                    if FeatureFlag::EmbeddedCodeReviewComments.is_enabled() {
+                        let view = self.inline_comments.open_draft(line_info.clone(), ctx);
+                        self.sync_inline_comment_blocks(ctx);
+                        ctx.emit(CodeEditorEvent::CommentEditorOpened);
+                        view.update(ctx, |view, ctx| view.focus_body(ctx));
+                        return;
+                    }
                     self.model.update(ctx, |model: &mut CodeEditorModel, ctx| {
                         model.open_comment_line(line_info, ctx);
                     });
+                    self.sync_inline_comment_blocks(ctx);
                     ctx.emit(CodeEditorEvent::CommentEditorOpened);
 
                     ctx.focus(&self.active_comment_editor);

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -1885,7 +1885,12 @@ impl CodeReviewView {
                 };
 
                 if let AttachedReviewCommentTarget::Line { line, .. } = &comment.target {
-                    self.scroll_to_line(editor_index, line, 0.0, ctx);
+                    // Bring the inline card itself into view — not just its bare line — so a jump
+                    // from the panel reveals the comment. Falls back to the line when no inline
+                    // block is anchored there (inline feature off, or the comment is outdated).
+                    if !self.scroll_inline_comment_into_view(editor_index, line, ctx) {
+                        self.scroll_to_line(editor_index, line, 0.0, ctx);
+                    }
                 } else {
                     self.viewported_list_state
                         .scroll_to_with_offset(editor_index, Pixels::new(0.0));
@@ -2178,6 +2183,62 @@ impl CodeReviewView {
                     - self.viewported_list_state.get_viewport_height(),
             );
         }
+    }
+
+    /// Scrolls the inline comment card anchored at `line` of the editor at `editor_index` into the
+    /// viewport, treating the card's full content-space range (not the bare line) as the target.
+    /// Returns `false` if no inline block is anchored there, so the caller can fall back to
+    /// scrolling the line.
+    fn scroll_inline_comment_into_view(
+        &mut self,
+        editor_index: usize,
+        line: &EditorLineLocation,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
+        let CodeReviewViewState::Loaded(state) = self.state() else {
+            return false;
+        };
+        let Some(editor) = state
+            .file_states
+            .get_index(editor_index)
+            .and_then(|(_, file_state)| file_state.editor_state.as_ref())
+            .map(|editor_state| editor_state.editor.clone())
+        else {
+            return false;
+        };
+        let Some((block_top, block_height)) = editor
+            .as_ref(ctx)
+            .editor()
+            .read(ctx, |code_editor_view, ctx| {
+                code_editor_view.comment_block_content_bounds(line, ctx)
+            })
+        else {
+            return false;
+        };
+
+        let card_top = Pixels::new(FILE_HEADER_HEIGHT) + block_top;
+        let card_bottom = card_top + block_height;
+
+        // Leave the scroll alone if the whole card is already on-screen.
+        if self
+            .viewported_list_state
+            .is_vertical_range_visible(editor_index, card_top, card_bottom)
+        {
+            return true;
+        }
+
+        // Bring the card to the top of the viewport (keeping a small buffer above so the anchor line
+        // stays adjacent), which leaves the rest of the viewport below the card. This deliberately
+        // top-aligns rather than bottom-aligning to the viewport edge so small relayout drift can't
+        // push the card's bottom out of view.
+        self.viewported_list_state
+            .scroll_to_with_offset(editor_index, card_top - Pixels::new(EDITOR_GAP));
+
+        if let Some(context) = self.compute_scroll_context_for_index(editor_index, &editor, ctx) {
+            self.viewported_list_state.set_scroll_context(Some(context));
+        }
+        ctx.notify();
+        true
     }
 
     #[cfg(target_family = "wasm")]


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
