### PR TITLE
apply file size limit on tree-sitter

### DIFF
--- a/app/src/code/editor/model.rs
+++ b/app/src/code/editor/model.rs
@@ -255,7 +255,7 @@ impl DelayRendering {
         model.render_state.update(ctx, move |render_state, _| {
             let should_autoscroll = self.should_autoscroll;
             for (delta, content_version) in self.edits {
-                render_state.add_pending_edit(delta.clone(), content_version);
+                render_state.add_pending_edit(delta, content_version);
             }
             match should_autoscroll {
                 ShouldAutoscroll::Yes => render_state.request_autoscroll(),

--- a/crates/editor/src/content/buffer.rs
+++ b/crates/editor/src/content/buffer.rs
@@ -535,6 +535,10 @@ impl BufferSnapshot {
     pub fn bytes(&self) -> Bytes<'_> {
         Bytes::from_sum_tree(&self.content, ByteOffset::from(0), self.byte_len)
     }
+
+    pub fn byte_len(&self) -> usize {
+        self.byte_len.as_usize()
+    }
 }
 
 /// Model for storing the content of an editor.

--- a/crates/syntax_tree/src/lib.rs
+++ b/crates/syntax_tree/src/lib.rs
@@ -23,6 +23,13 @@ use warpui_core::{AppContext, Entity, ModelContext, WeakModelHandle};
 
 const MAX_SYNTAX_TREES: usize = 3;
 
+/// Maximum buffer size in bytes for which we attempt to parse a syntax tree.
+/// Files larger than this are skipped to avoid tree-sitter's super-linear
+/// memory growth on large inputs (consistent with snacks.nvim / astrocore defaults).
+/// See this tree-sitter issue:
+/// https://github.com/tree-sitter/tree-sitter/issues/222#issuecomment-435987441
+const MAX_PARSE_BYTES: usize = 2 * 1024 * 1024; // 2 MB
+
 thread_local! {
     static PARSER: RefCell<Parser> = RefCell::new(Parser::new());
 }
@@ -215,12 +222,17 @@ impl SyntaxTreeState {
     }
 
     /// Re-parse the tree based on the updated tree and source content.
+    ///
+    /// Returns `None` if the buffer exceeds [`MAX_PARSE_BYTES`].
     async fn parse_text(
         content: BufferSnapshot,
         old_tree: Option<Tree>,
         language: &Language,
-    ) -> Tree {
-        PARSER.with(|parser| {
+    ) -> Option<Tree> {
+        if content.byte_len() > MAX_PARSE_BYTES {
+            return None;
+        }
+        Some(PARSER.with(|parser| {
             let mut parser = parser.borrow_mut();
             parser
                 .set_language(&language.grammar)
@@ -234,7 +246,7 @@ impl SyntaxTreeState {
             parser
                 .parse_with_options(&mut callback, old_tree.as_ref(), None)
                 .expect("Should succeed")
-        })
+        }))
     }
 
     /// Translate an incoming edit delta into an InputEdit for incrementally updating the syntax
@@ -345,6 +357,13 @@ impl DecorationLayer for SyntaxTreeState {
                     new_tree
                 },
                 move |model, new_tree, ctx| {
+                    let Some(new_tree) = new_tree else {
+                        // Buffer exceeded MAX_PARSE_BYTES; skip updating the syntax tree, but
+                        // still emit DecorationUpdated so any delayed rendering is flushed
+                        // (the editor delays showing content until this event fires).
+                        ctx.emit(DecorationStateEvent::DecorationUpdated { version });
+                        return;
+                    };
                     let mut syntax_tree_lock = model.syntax_tree.lock();
                     model.invalidate_highlight_cache_for_version(version);
                     if let Some(old_tree) = syntax_tree_lock.get_mut(&version) {

--- a/crates/syntax_tree/src/lib.rs
+++ b/crates/syntax_tree/src/lib.rs
@@ -359,6 +359,10 @@ impl DecorationLayer for SyntaxTreeState {
                     let Some(new_tree) = new_tree else {
                         // Buffer exceeded MAX_PARSE_BYTES; skip updating the syntax tree, but
                         // still emit DecorationUpdated so any delayed rendering is flushed
+                        let mut syntax_tree_lock = model.syntax_tree.lock();
+                        syntax_tree_lock.remove(&version);
+                        drop(syntax_tree_lock);
+                        model.invalidate_highlight_cache_for_version(version);
                         // (the editor delays showing content until this event fires).
                         ctx.emit(DecorationStateEvent::DecorationUpdated { version });
                         return;

--- a/crates/syntax_tree/src/lib.rs
+++ b/crates/syntax_tree/src/lib.rs
@@ -25,8 +25,7 @@ const MAX_SYNTAX_TREES: usize = 3;
 
 /// Maximum buffer size in bytes for which we attempt to parse a syntax tree.
 /// Files larger than this are skipped to avoid tree-sitter's super-linear
-/// memory growth on large inputs (consistent with snacks.nvim / astrocore defaults).
-/// See this tree-sitter issue:
+/// memory growth on large inputs. See this tree-sitter issue:
 /// https://github.com/tree-sitter/tree-sitter/issues/222#issuecomment-435987441
 const MAX_PARSE_BYTES: usize = 2 * 1024 * 1024; // 2 MB
 

--- a/crates/syntax_tree/src/queries/indent_query_tests.rs
+++ b/crates/syntax_tree/src/queries/indent_query_tests.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use arborium::tree_sitter::Tree;
-use languages::{Language, language_by_filename};
+use languages::{language_by_filename, Language};
 use warp_editor::content::buffer::{Buffer, BufferSnapshot};
 use warp_editor::content::selection_model::BufferSelectionModel;
 use warp_editor::content::text::IndentBehavior;

--- a/crates/syntax_tree/src/queries/indent_query_tests.rs
+++ b/crates/syntax_tree/src/queries/indent_query_tests.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use arborium::tree_sitter::Tree;
-use languages::{language_by_filename, Language};
+use languages::{Language, language_by_filename};
 use warp_editor::content::buffer::{Buffer, BufferSnapshot};
 use warp_editor::content::selection_model::BufferSelectionModel;
 use warp_editor::content::text::IndentBehavior;
@@ -17,7 +17,8 @@ fn mock_buffer_and_tree(text_content: &str, language: Arc<Language>) -> (Buffer,
     let snapshot = BufferSnapshot::from_plain_text(text_content);
     let tree = warpui_core::r#async::block_on(async {
         SyntaxTreeState::parse_text(snapshot, None, &language).await
-    });
+    })
+    .expect("test buffer is small and should parse");
 
     // Create a minimal buffer
     let buffer = Buffer::new(Box::new(|_, _| IndentBehavior::Ignore));
@@ -61,7 +62,8 @@ fn test_indent_query() {
         let buffer_snapshot = buffer_handle.read(&app, |buffer, _| buffer.buffer_snapshot());
         let tree = warpui_core::r#async::block_on(async {
             SyntaxTreeState::parse_text(buffer_snapshot, None, &language).await
-        });
+        })
+        .expect("test buffer is small and should parse");
 
         let query = language.as_ref().indents_query.as_ref().unwrap();
 
@@ -157,7 +159,8 @@ fn test_indent_query_on_go() {
         let buffer_snapshot = buffer_handle.read(&app, |buffer, _| buffer.buffer_snapshot());
         let tree = warpui_core::r#async::block_on(async {
             SyntaxTreeState::parse_text(buffer_snapshot, None, &language).await
-        });
+        })
+        .expect("test buffer is small and should parse");
 
         let query = &language.as_ref().indents_query.as_ref().unwrap();
 


### PR DESCRIPTION
## Description

This PR is part of the fix for opening large files in the Warp code editor causing huge (>10GB) memory spikes.

One of the reasons for the memory spikes is tree-sitter itself. The parse tree uses more memory than the text it parses. In fact, the memory usage grows super-linearly, [see here](https://github.com/tree-sitter/tree-sitter/issues/222#issuecomment-435987441). Maintainers recommend setting limits on input sizes. This PR imposes a limit of 2MB on inputs to tree-sitter. I chose this number for the following reasons:

1. It's in the ballpark of other tools that consume tree-sitter. For example, some things in the NeoVim ecosystem:
    a. [AstroNvim](https://github.com/AstroNvim/astrocore/blob/a9217f7145b7fcd6b220a7f46e725e252ef64565/lua/astrocore/config.lua#L434) uses 1.5 MB.
    b. [Snacks](https://github.com/folke/snacks.nvim/blob/882c996cf28183f4d63640de0b4c02ec886d01f2/lua/snacks/bigfile.lua#L14) uses 1.5 MB.
    c. [LunarNvim](https://github.com/LunarVim/bigfile.nvim/blob/33eb067e3d7029ac77e081cfe7c45361887a311a/lua/bigfile/init.lua#L10) uses 2 MB.
2. Our biggest files, e.g. `app/src/terminal/view.rs`, are around 1.2MB so this is enough to not inhibit us opening Warp source files.

## Linked Issue

(partly) fixes #12561

## Testing

Memory usage doesn't grow as much when opening files >2MB.

This is part of the fix in #11344 but splits it into its own PR. #11344 contains some layout stuff which I think can be a separate PR.