### PR TITLE
Handle early Ctrl-C for requested commands

### DIFF
--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -1022,11 +1022,12 @@ impl BlocklistAIActionModel {
         self.handle_action_result(conversation_id, Arc::new(action_result), None, ctx);
     }
 
-    /// Cancels a command requested by the agent before a CLI subagent attaches.
+    /// Cancels local action state for an agent-requested shell command before a CLI
+    /// subagent attaches.
     ///
     /// The command may still be queued, actively starting, or represented by an
-    /// unsent long-running snapshot. Returns `false` once there is no local result
-    /// left to rewrite, so callers can cancel the conversation directly instead.
+    /// unsent long-running snapshot. Returns `false` once there is no local action
+    /// state left to cancel, so callers can cancel the conversation directly instead.
     pub(crate) fn cancel_requested_command_with_id(
         &mut self,
         conversation_id: AIConversationId,
@@ -1046,6 +1047,8 @@ impl BlocklistAIActionModel {
             self.cancel_action_with_id(conversation_id, action_id, reason, ctx);
             return true;
         }
+        // Once the initial long-running snapshot is buffered, cancelling the action
+        // means rewriting that snapshot before the next agent follow-up consumes it.
 
         let Some(action_result) = self
             .finished_action_results

--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -1022,7 +1022,66 @@ impl BlocklistAIActionModel {
         self.handle_action_result(conversation_id, Arc::new(action_result), None, ctx);
     }
 
-    pub(super) fn cancel_action_with_id(
+    /// Cancels a command requested by the agent before a CLI subagent attaches.
+    ///
+    /// The command may still be queued, actively starting, or represented by an
+    /// unsent long-running snapshot. Returns `false` once there is no local result
+    /// left to rewrite, so callers can cancel the conversation directly instead.
+    pub(crate) fn cancel_requested_command_with_id(
+        &mut self,
+        conversation_id: AIConversationId,
+        action_id: &AIAgentActionId,
+        reason: CancellationReason,
+        ctx: &mut ModelContext<Self>,
+    ) -> bool {
+        if self
+            .running_actions
+            .get(&conversation_id)
+            .is_some_and(|running| running.contains(action_id))
+            || self
+                .pending_actions
+                .get(&conversation_id)
+                .is_some_and(|actions| actions.iter().any(|action| action.id == *action_id))
+        {
+            self.cancel_action_with_id(conversation_id, action_id, reason, ctx);
+            return true;
+        }
+
+        let Some(action_result) = self
+            .finished_action_results
+            .get_mut(&conversation_id)
+            .and_then(|results| {
+                results.iter_mut().find(|result| {
+                    result.id == *action_id
+                        && matches!(
+                            result.result,
+                            AIAgentActionResultType::RequestCommandOutput(
+                                RequestCommandOutputResult::LongRunningCommandSnapshot { .. }
+                            )
+                        )
+                })
+            })
+        else {
+            return false;
+        };
+
+        *action_result = Arc::new(AIAgentActionResult {
+            id: action_result.id.clone(),
+            task_id: action_result.task_id.clone(),
+            result: AIAgentActionResultType::RequestCommandOutput(
+                RequestCommandOutputResult::CancelledBeforeExecution,
+            ),
+        });
+        self.sort_finished_results(conversation_id);
+        ctx.emit(BlocklistAIActionEvent::FinishedAction {
+            action_id: action_id.clone(),
+            conversation_id,
+            cancellation_reason: Some(reason),
+        });
+        true
+    }
+
+    pub(crate) fn cancel_action_with_id(
         &mut self,
         conversation_id: AIConversationId,
         action_id: &AIAgentActionId,

--- a/app/src/ai/blocklist/action_model/execute/shell_command.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command.rs
@@ -617,8 +617,9 @@ impl ShellCommandExecutor {
     }
 
     pub(super) fn cancel_execution(&mut self, id: &AIAgentActionId, _ctx: &mut ModelContext<Self>) {
-        // Requested commands wait on an action id before the terminal block id is
-        // stable. Later LRC interactions wait on the block id, so clear both handles.
+        // Requested commands register by action id before the terminal block id is
+        // stable. Later LRC interactions register by block id, and cancellation can
+        // race across that handoff, so clear either waiter if present.
         let requested_command_selector = BlockSelector::RequestedCommandId(id.clone());
         self.block_finished_senders
             .remove(&requested_command_selector);

--- a/app/src/ai/blocklist/action_model/execute/shell_command.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command.rs
@@ -617,22 +617,25 @@ impl ShellCommandExecutor {
     }
 
     pub(super) fn cancel_execution(&mut self, id: &AIAgentActionId, _ctx: &mut ModelContext<Self>) {
-        let terminal_model = self.terminal_model.lock();
-        let active_block = terminal_model.block_list().active_block();
-        if !active_block.is_active_and_long_running() {
-            return;
-        }
+        // Requested commands wait on an action id before the terminal block id is
+        // stable. Later LRC interactions wait on the block id, so clear both handles.
+        let requested_command_selector = BlockSelector::RequestedCommandId(id.clone());
+        self.block_finished_senders
+            .remove(&requested_command_selector);
+        self.force_refresh_senders
+            .remove(&requested_command_selector);
 
-        let selector = if active_block
-            .requested_command_action_id()
-            .is_some_and(|requested_command_id| requested_command_id == id)
-        {
-            BlockSelector::RequestedCommandId(id.clone())
-        } else {
-            BlockSelector::Id(active_block.id().clone())
+        let active_block_selector = {
+            let terminal_model = self.terminal_model.lock();
+            let active_block = terminal_model.block_list().active_block();
+            active_block
+                .is_active_and_long_running()
+                .then(|| BlockSelector::Id(active_block.id().clone()))
         };
-        self.block_finished_senders.remove(&selector);
-        self.force_refresh_senders.remove(&selector);
+        if let Some(selector) = active_block_selector {
+            self.block_finished_senders.remove(&selector);
+            self.force_refresh_senders.remove(&selector);
+        }
     }
 
     /// Force any in-flight poll for the given long-running command block to resolve

--- a/app/src/terminal/model/block/interaction_mode.rs
+++ b/app/src/terminal/model/block/interaction_mode.rs
@@ -123,6 +123,7 @@ impl Block {
             .is_some_and(|metadata| {
                 metadata.requested_command_action_id().is_some()
                     && metadata.long_running_control_state().is_none()
+                    && !metadata.should_suppress_auto_resume()
             })
     }
 
@@ -164,19 +165,6 @@ impl Block {
                     reason: UserTakeOverReason::Manual,
                 };
             }
-        }
-    }
-
-    /// Marks an agent-associated command as stopped by the user.
-    pub fn set_user_control_with_stop_reason(&mut self) {
-        if let InteractionMode::Agent(AgentInteractionMetadata {
-            ref mut long_running_control_state,
-            ..
-        }) = self.interaction_mode
-        {
-            *long_running_control_state = Some(LongRunningCommandControlState::User {
-                reason: UserTakeOverReason::Stop,
-            });
         }
     }
 
@@ -366,14 +354,22 @@ impl InteractionMode {
             }
         };
 
+        let long_running_control_state = if suppress_auto_resume {
+            Some(LongRunningCommandControlState::User {
+                reason: UserTakeOverReason::Manual,
+            })
+        } else {
+            Some(LongRunningCommandControlState::Agent {
+                is_blocked: false,
+                should_hide_responses: false,
+            })
+        };
+
         Ok(Self::Agent(AgentInteractionMetadata {
             requested_command_action_id,
             conversation_id,
             subagent_task_id: Some(task_id.clone()),
-            long_running_control_state: Some(LongRunningCommandControlState::Agent {
-                is_blocked: false,
-                should_hide_responses: false,
-            }),
+            long_running_control_state,
             has_agent_written_to_block: false,
             should_hide_block: false,
             suppress_auto_resume,

--- a/app/src/terminal/model/block/interaction_mode.rs
+++ b/app/src/terminal/model/block/interaction_mode.rs
@@ -167,6 +167,19 @@ impl Block {
         }
     }
 
+    /// Marks an agent-associated command as stopped by the user.
+    pub fn set_user_control_with_stop_reason(&mut self) {
+        if let InteractionMode::Agent(AgentInteractionMetadata {
+            ref mut long_running_control_state,
+            ..
+        }) = self.interaction_mode
+        {
+            *long_running_control_state = Some(LongRunningCommandControlState::User {
+                reason: UserTakeOverReason::Stop,
+            });
+        }
+    }
+
     /// Returns `true` if agent responses should be hidden in the UI.
     pub fn should_hide_responses(&self) -> bool {
         self.is_active_and_long_running()

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -7438,15 +7438,17 @@ impl TerminalView {
 
                 // While the command was blocked on confirmation, the AI block grabbed focus so
                 // Enter could accept it. Now that it's executing, hand focus back to the
-                // input/terminal so Ctrl-C reaches the command and follow-ups reach the CLI
-                // subagent input if the command becomes long-running.
+                // input/terminal so Ctrl-C reaches the command. If the command becomes
+                // long-running, follow-ups should reach the CLI subagent input box without
+                // requiring the user to refocus it.
                 // We call `redetermine_global_focus` rather than `redetermine_terminal_focus`
                 // because the latter deliberately no-ops while an AI block is focused.
                 if ctx.is_self_or_child_focused() {
                     self.redetermine_global_focus(ctx);
                 }
 
-                // If the command turns out to be long-running, lock the input in agent mode.
+                // If the command turns out to be long-running and the agent still owns it,
+                // lock the input in agent mode.
                 ctx.spawn(
                     // Command execution is triggered by a subscriber to the event above, so
                     // give some buffer to actually determine if its long running.
@@ -8503,6 +8505,8 @@ impl TerminalView {
             if active_block.ai_conversation_id() == Some(conversation_id)
                 && active_block.requested_command_action_id() == Some(&action_id)
             {
+                // Mark this before sending ETX so a command that ignores Ctrl-C is no
+                // longer treated as agent-driven if it later becomes long-running.
                 active_block.set_user_control_with_stop_reason();
             }
             drop(model);

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -594,6 +594,14 @@ lazy_static! {
     /// See [`TerminalView::resize_alt_screen_redundantly`] for more details.
     static ref ALT_SCREEN_APPS_THAT_MUST_MATCH_BLOCKLIST_PADDING: HashSet<&'static str> = HashSet::from(["k9s", "lazygit"]);
 }
+enum ActiveCommandCtrlCAction {
+    CancelRequestedCommand {
+        conversation_id: AIConversationId,
+        action_id: AIAgentActionId,
+    },
+    StopConversation(AIConversationId),
+    WriteCtrlCToPty,
+}
 
 pub const AI_CONTROL_PANEL_MARGIN: f32 = 10.;
 
@@ -2336,6 +2344,7 @@ struct TerminalViewMouseStates {
     breadcrumbs_horizontal_scroll: ClippedScrollStateHandle,
 }
 
+
 /// Where content was routed when sent to a CLI agent.
 /// Returned by [`TerminalView::try_send_text_to_cli_agent_or_rich_input`]
 /// so callers can report the correct telemetry destination without a
@@ -2375,11 +2384,6 @@ pub(in crate::terminal::view) enum ConversationDetailsPanelAutoOpenPolicy {
 pub struct TerminalViewStateChange {
     pub state: TerminalViewState,
     pub timestamp: Instant,
-}
-#[derive(Clone, Copy)]
-struct CtrlCActiveBlockState {
-    is_long_running: bool,
-    is_agent_in_control_of_command: bool,
 }
 
 impl Default for TerminalViewStateChange {
@@ -7432,6 +7436,16 @@ impl TerminalView {
                     });
                 }
 
+                // While the command was blocked on confirmation, the AI block grabbed focus so
+                // Enter could accept it. Now that it's executing, hand focus back to the
+                // input/terminal so Ctrl-C reaches the command and follow-ups reach the CLI
+                // subagent input if the command becomes long-running.
+                // We call `redetermine_global_focus` rather than `redetermine_terminal_focus`
+                // because the latter deliberately no-ops while an AI block is focused.
+                if ctx.is_self_or_child_focused() {
+                    self.redetermine_global_focus(ctx);
+                }
+
                 // If the command turns out to be long-running, lock the input in agent mode.
                 ctx.spawn(
                     // Command execution is triggered by a subscriber to the event above, so
@@ -7443,7 +7457,10 @@ impl TerminalView {
                             .lock()
                             .block_list()
                             .block_with_id(&block_id)
-                            .is_some_and(|block| block.is_active_and_long_running())
+                            .is_some_and(|block| {
+                                block.is_agent_driving_command()
+                                    && block.is_active_and_long_running()
+                            })
                         {
                             me.input.update(ctx, |input, ctx| {
                                 input.set_input_mode_agent(false, ctx);
@@ -8466,6 +8483,34 @@ impl TerminalView {
             });
         }
     }
+    fn cancel_requested_long_running_command(
+        &mut self,
+        conversation_id: AIConversationId,
+        action_id: AIAgentActionId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let did_cancel_local_action = self.ai_action_model.update(ctx, |action_model, ctx| {
+            action_model.cancel_requested_command_with_id(
+                conversation_id,
+                &action_id,
+                CancellationReason::ManuallyCancelled,
+                ctx,
+            )
+        });
+        if did_cancel_local_action {
+            let mut model = self.model.lock();
+            let active_block = model.block_list_mut().active_block_mut();
+            if active_block.ai_conversation_id() == Some(conversation_id)
+                && active_block.requested_command_action_id() == Some(&action_id)
+            {
+                active_block.set_user_control_with_stop_reason();
+            }
+            drop(model);
+            self.user_write_ctrl_c_to_pty(ctx);
+        } else {
+            self.stop_local_agent_conversation(conversation_id, ctx);
+        }
+    }
 
     fn user_write_ctrl_c_to_pty(&mut self, ctx: &mut ViewContext<Self>) {
         self.write_user_bytes_to_pty(vec![escape_sequences::C0::ETX], ctx);
@@ -8515,33 +8560,50 @@ impl TerminalView {
     /// Windows users expect ctrl-c to copy if there is selected text. Otherwise,
     /// we perform the normal ctrl-c action.
     fn ctrl_c(&mut self, ctx: &mut ViewContext<Self>) {
-        let (has_block_list_selection, has_alt_screen_selection, active_block_state) = {
+        // We don't want to copy blocks in AI input mode because those are
+        // context blocks.
+        let has_copiable_block_selection = !self.selected_blocks.is_empty()
+            && !self.ai_input_model.as_ref(ctx).is_ai_input_enabled();
+        let (
+            has_block_list_selection,
+            has_alt_screen_selection,
+            is_long_running,
+            is_agent_in_control_of_command,
+            is_executing_agent_requested_command,
+        ) = {
             let model = self.model.lock();
             let has_alt_screen_selection = model.alt_screen().selection().is_some();
             let has_block_list_selection = model.block_list().selection().is_some();
             let active_block = model.block_list().active_block();
             let is_long_running = active_block.is_active_and_long_running();
             let is_agent_in_control_of_command = active_block.is_agent_in_control();
-            let active_block_state = CtrlCActiveBlockState {
-                is_long_running,
-                is_agent_in_control_of_command,
-            };
+            let is_not_monitored_by_agent = active_block.long_running_control_state().is_none()
+                || active_block
+                    .long_running_control_state()
+                    .and_then(|state| state.user_take_over_reason())
+                    .is_some_and(UserTakeOverReason::is_stop);
+            // Agent-requested commands need PTY cancellation even before the LRC
+            // threshold; otherwise Ctrl-C may be routed to the AI/rich-content path.
+            let is_executing_agent_requested_command = !is_long_running
+                && is_not_monitored_by_agent
+                && active_block.requested_command_action_id().is_some()
+                && active_block.ai_conversation_id().is_some()
+                && (active_block.is_executing() || active_block.is_command_grid_active());
             (
                 has_block_list_selection,
                 has_alt_screen_selection,
-                active_block_state,
+                is_long_running,
+                is_agent_in_control_of_command,
+                is_executing_agent_requested_command,
             )
         };
-        // We don't want to copy blocks in AI input mode because those are
-        // context blocks.
-        let has_copiable_block_selection = !self.selected_blocks.is_empty()
-            && !self.ai_input_model.as_ref(ctx).is_ai_input_enabled();
-
         self.ctrl_c_internal(
             has_copiable_block_selection,
             has_block_list_selection,
             has_alt_screen_selection,
-            active_block_state,
+            is_long_running,
+            is_agent_in_control_of_command,
+            is_executing_agent_requested_command,
             ctx,
         );
 
@@ -8553,12 +8615,15 @@ impl TerminalView {
     /// Copy if there is a selection. Otherwise, we defer to the normal ctrl-c
     /// behaviour.
     #[cfg(windows)]
+    #[allow(clippy::too_many_arguments)]
     fn ctrl_c_internal(
         &mut self,
         has_copiable_block_selection: bool,
         has_block_list_selection: bool,
         has_alt_screen_selection: bool,
-        active_block_state: CtrlCActiveBlockState,
+        is_long_running: bool,
+        is_agent_in_control_of_command: bool,
+        is_executing_agent_requested_command: bool,
         ctx: &mut ViewContext<Self>,
     ) {
         if has_block_list_selection {
@@ -8576,7 +8641,12 @@ impl TerminalView {
             self.clear_selections_when_shell_mode_without_focusing_input(ctx);
         }
 
-        self.ctrl_c_to_active_block(active_block_state, ctx);
+        self.ctrl_c_to_active_block(
+            is_long_running,
+            is_agent_in_control_of_command,
+            is_executing_agent_requested_command,
+            ctx,
+        );
     }
 
     /// Focuses the provided AI block if this terminal view (or some part of it)
@@ -8615,12 +8685,15 @@ impl TerminalView {
     }
 
     #[cfg(not(windows))]
+    #[allow(clippy::too_many_arguments)]
     fn ctrl_c_internal(
         &mut self,
         has_copiable_block_selection: bool,
         has_block_list_selection: bool,
         has_alt_screen_selection: bool,
-        active_block_state: CtrlCActiveBlockState,
+        is_long_running: bool,
+        is_agent_in_control_of_command: bool,
+        is_executing_agent_requested_command: bool,
         ctx: &mut ViewContext<Self>,
     ) {
         if has_block_list_selection || has_copiable_block_selection {
@@ -8628,23 +8701,68 @@ impl TerminalView {
         } else if has_alt_screen_selection {
             self.model.lock().alt_screen_mut().clear_selection();
         }
-        self.ctrl_c_to_active_block(active_block_state, ctx);
+        self.ctrl_c_to_active_block(
+            is_long_running,
+            is_agent_in_control_of_command,
+            is_executing_agent_requested_command,
+            ctx,
+        );
     }
 
     fn ctrl_c_to_active_block(
         &mut self,
-        active_block_state: CtrlCActiveBlockState,
+        is_long_running: bool,
+        is_agent_in_control_of_command: bool,
+        is_executing_agent_requested_command: bool,
         ctx: &mut ViewContext<Self>,
     ) {
-        if active_block_state.is_agent_in_control_of_command {
+        if is_agent_in_control_of_command {
             self.cli_subagent_controller.update(ctx, |controller, ctx| {
-                controller.switch_control_to_user(UserTakeOverReason::Manual, ctx);
+                controller.switch_control_to_user(UserTakeOverReason::Stop, ctx);
             });
-        } else if active_block_state.is_long_running {
-            self.user_write_ctrl_c_to_pty(ctx);
+        } else if is_long_running || is_executing_agent_requested_command {
+            match self.active_command_ctrl_c_action() {
+                ActiveCommandCtrlCAction::CancelRequestedCommand {
+                    conversation_id,
+                    action_id,
+                } => self.cancel_requested_long_running_command(conversation_id, action_id, ctx),
+                ActiveCommandCtrlCAction::StopConversation(conversation_id) => {
+                    self.stop_local_agent_conversation(conversation_id, ctx)
+                }
+                ActiveCommandCtrlCAction::WriteCtrlCToPty => self.user_write_ctrl_c_to_pty(ctx),
+            }
         } else {
             self.maybe_handle_ctrl_c_in_rich_content_block(ctx);
         }
+    }
+
+    fn active_command_ctrl_c_action(&self) -> ActiveCommandCtrlCAction {
+        let model = self.model.lock();
+        let active_block = model.block_list().active_block();
+
+        if active_block.long_running_control_state().is_none() {
+            if let Some((conversation_id, action_id)) = active_block
+                .ai_conversation_id()
+                .zip(active_block.requested_command_action_id().cloned())
+            {
+                return ActiveCommandCtrlCAction::CancelRequestedCommand {
+                    conversation_id,
+                    action_id,
+                };
+            }
+        }
+
+        if active_block
+            .long_running_control_state()
+            .and_then(|state| state.user_take_over_reason())
+            .is_some_and(UserTakeOverReason::is_stop)
+        {
+            if let Some(conversation_id) = active_block.ai_conversation_id() {
+                return ActiveCommandCtrlCAction::StopConversation(conversation_id);
+            }
+        }
+
+        ActiveCommandCtrlCAction::WriteCtrlCToPty
     }
 
     /// Returns whether ctrl-c should exit the agent view.
@@ -10856,7 +10974,11 @@ impl TerminalView {
                         && !ai_metadata.should_suppress_auto_resume()
                         && ai_metadata
                             .long_running_control_state()
-                            .is_some_and(|state| state.user_take_over_reason().is_some()) =>
+                            .is_some_and(|state| {
+                                state
+                                    .user_take_over_reason()
+                                    .is_some_and(|reason| !reason.is_stop())
+                            }) =>
                 {
                     Some(*ai_metadata.conversation_id())
                 }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -599,7 +599,6 @@ enum ActiveCommandCtrlCAction {
         conversation_id: AIConversationId,
         action_id: AIAgentActionId,
     },
-    StopConversation(AIConversationId),
     WriteCtrlCToPty,
 }
 
@@ -2343,7 +2342,6 @@ struct TerminalViewMouseStates {
     /// can pan to read clipped labels.
     breadcrumbs_horizontal_scroll: ClippedScrollStateHandle,
 }
-
 
 /// Where content was routed when sent to a CLI agent.
 /// Returned by [`TerminalView::try_send_text_to_cli_agent_or_rich_input`]
@@ -7438,9 +7436,8 @@ impl TerminalView {
 
                 // While the command was blocked on confirmation, the AI block grabbed focus so
                 // Enter could accept it. Now that it's executing, hand focus back to the
-                // input/terminal so Ctrl-C reaches the command. If the command becomes
-                // long-running, follow-ups should reach the CLI subagent input box without
-                // requiring the user to refocus it.
+                // input/terminal. This keeps Ctrl-C routed to the command and lets the
+                // CLI subagent input receive follow-ups without requiring a refocus.
                 // We call `redetermine_global_focus` rather than `redetermine_terminal_focus`
                 // because the latter deliberately no-ops while an AI block is focused.
                 if ctx.is_self_or_child_focused() {
@@ -8507,7 +8504,7 @@ impl TerminalView {
             {
                 // Mark this before sending ETX so a command that ignores Ctrl-C is no
                 // longer treated as agent-driven if it later becomes long-running.
-                active_block.set_user_control_with_stop_reason();
+                active_block.suppress_agent_auto_resume();
             }
             drop(model);
             self.user_write_ctrl_c_to_pty(ctx);
@@ -8581,15 +8578,10 @@ impl TerminalView {
             let active_block = model.block_list().active_block();
             let is_long_running = active_block.is_active_and_long_running();
             let is_agent_in_control_of_command = active_block.is_agent_in_control();
-            let is_not_monitored_by_agent = active_block.long_running_control_state().is_none()
-                || active_block
-                    .long_running_control_state()
-                    .and_then(|state| state.user_take_over_reason())
-                    .is_some_and(UserTakeOverReason::is_stop);
             // Agent-requested commands need PTY cancellation even before the LRC
             // threshold; otherwise Ctrl-C may be routed to the AI/rich-content path.
             let is_executing_agent_requested_command = !is_long_running
-                && is_not_monitored_by_agent
+                && active_block.long_running_control_state().is_none()
                 && active_block.requested_command_action_id().is_some()
                 && active_block.ai_conversation_id().is_some()
                 && (active_block.is_executing() || active_block.is_command_grid_active());
@@ -8722,7 +8714,7 @@ impl TerminalView {
     ) {
         if is_agent_in_control_of_command {
             self.cli_subagent_controller.update(ctx, |controller, ctx| {
-                controller.switch_control_to_user(UserTakeOverReason::Stop, ctx);
+                controller.switch_control_to_user(UserTakeOverReason::Manual, ctx);
             });
         } else if is_long_running || is_executing_agent_requested_command {
             match self.active_command_ctrl_c_action() {
@@ -8730,9 +8722,6 @@ impl TerminalView {
                     conversation_id,
                     action_id,
                 } => self.cancel_requested_long_running_command(conversation_id, action_id, ctx),
-                ActiveCommandCtrlCAction::StopConversation(conversation_id) => {
-                    self.stop_local_agent_conversation(conversation_id, ctx)
-                }
                 ActiveCommandCtrlCAction::WriteCtrlCToPty => self.user_write_ctrl_c_to_pty(ctx),
             }
         } else {
@@ -8753,16 +8742,6 @@ impl TerminalView {
                     conversation_id,
                     action_id,
                 };
-            }
-        }
-
-        if active_block
-            .long_running_control_state()
-            .and_then(|state| state.user_take_over_reason())
-            .is_some_and(UserTakeOverReason::is_stop)
-        {
-            if let Some(conversation_id) = active_block.ai_conversation_id() {
-                return ActiveCommandCtrlCAction::StopConversation(conversation_id);
             }
         }
 
@@ -10978,11 +10957,7 @@ impl TerminalView {
                         && !ai_metadata.should_suppress_auto_resume()
                         && ai_metadata
                             .long_running_control_state()
-                            .is_some_and(|state| {
-                                state
-                                    .user_take_over_reason()
-                                    .is_some_and(|reason| !reason.is_stop())
-                            }) =>
+                            .is_some_and(|state| state.user_take_over_reason().is_some()) =>
                 {
                     Some(*ai_metadata.conversation_id())
                 }

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -19,7 +19,8 @@ use super::*;
 use crate::ai::agent::conversation::{AIConversation, ConversationStatus};
 use crate::ai::agent::task::TaskId;
 use crate::ai::agent::{
-    AIAgentActionId, AIAgentExchange, AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus,
+    AIAgentActionId, AIAgentActionResult, AIAgentActionResultType, AIAgentExchange,
+    AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus, RequestCommandOutputResult,
     UserQueryMode,
 };
 use crate::ai::ambient_agents::AmbientAgentTaskId;
@@ -625,7 +626,6 @@ fn unregister_cli_agent_session_restores_unlocked_input_config() {
 fn clear_buffer_action_in_fullscreen_agent_view_starts_new_conversation() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
-        FeatureFlag::AgentView.set_enabled(true);
 
         let terminal = add_window_with_terminal(&mut app, None);
 
@@ -5213,7 +5213,166 @@ fn inline_agent_view_exits_when_tagged_in_long_running_command_is_tagged_out() {
 }
 
 #[test]
-fn ctrl_c_after_takeover_interrupts_command_without_cancelling_conversation() {
+fn ctrl_c_cancels_requested_long_running_command_after_snapshot_follow_up() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        FeatureFlag::AgentView.set_enabled(true);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        let pty_writes: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+        let writes = pty_writes.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&terminal, move |_, event, _| {
+                if let Event::WriteBytesToPty { bytes } = event {
+                    writes.borrow_mut().push(bytes.to_vec());
+                }
+            });
+        });
+
+        let action_id = AIAgentActionId::from("requested-command".to_owned());
+
+        let conversation_id = terminal.update(&mut app, |view, ctx| {
+            let conversation_id =
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                    history.start_new_conversation(view.view_id, false, false, false, ctx)
+                });
+            let task_id = BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(&conversation_id)
+                .expect("conversation should exist")
+                .get_root_task_id()
+                .clone();
+
+            view.model
+                .lock()
+                .simulate_long_running_block("sleep 20", "running");
+            let block_id = view.model.lock().block_list().active_block().id().clone();
+            view.model
+                .lock()
+                .block_list_mut()
+                .active_block_mut()
+                .set_agent_interaction_mode_for_requested_command(
+                    action_id.clone(),
+                    None,
+                    conversation_id,
+                );
+            view.ai_action_model.update(ctx, |action_model, ctx| {
+                action_model.apply_finished_action_result(
+                    conversation_id,
+                    AIAgentActionResult {
+                        id: action_id.clone(),
+                        task_id,
+                        result: AIAgentActionResultType::RequestCommandOutput(
+                            RequestCommandOutputResult::LongRunningCommandSnapshot {
+                                block_id,
+                                command: "sleep 20".to_owned(),
+                                grid_contents: String::new(),
+                                cursor: String::new(),
+                                is_alt_screen_active: false,
+                            },
+                        ),
+                    },
+                    ctx,
+                );
+            });
+            view.ai_controller.update(ctx, |controller, ctx| {
+                controller.clear_finished_action_results(conversation_id, ctx);
+            });
+
+            let model = view.model.lock();
+            let active_block = model.block_list().active_block();
+            assert!(active_block.is_active_and_long_running());
+            assert!(active_block.requested_command_action_id().is_some());
+            assert!(active_block.long_running_control_state().is_none());
+            assert!(view
+                .ai_action_model
+                .as_ref(ctx)
+                .get_action_status(&action_id)
+                .is_none());
+            conversation_id
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            view.handle_action(&TerminalAction::CtrlC, ctx);
+        });
+
+        assert_eq!(*pty_writes.borrow(), vec![vec![C0::ETX]]);
+        terminal.read(&app, |view, ctx| {
+            assert!(!view
+                .ai_controller
+                .as_ref(ctx)
+                .has_active_stream_for_conversation(conversation_id, ctx));
+            let conversation = BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(&conversation_id)
+                .expect("conversation should exist");
+            assert_eq!(conversation.status(), &ConversationStatus::Cancelled);
+            let model = view.model.lock();
+            assert!(!model.block_list().active_block().is_agent_driving_command());
+        });
+    })
+}
+
+#[test]
+fn ctrl_c_interrupts_requested_command_before_long_running_threshold() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        FeatureFlag::AgentView.set_enabled(true);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        let pty_writes: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+        let writes = pty_writes.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&terminal, move |_, event, _| {
+                if let Event::WriteBytesToPty { bytes } = event {
+                    writes.borrow_mut().push(bytes.to_vec());
+                }
+            });
+        });
+
+        let action_id = AIAgentActionId::from("requested-command".to_owned());
+        let conversation_id = terminal.update(&mut app, |view, ctx| {
+            let conversation_id =
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                    history.start_new_conversation(view.view_id, false, false, false, ctx)
+                });
+
+            let mut model = view.model.lock();
+            model.block_list_mut().active_block_mut().start();
+            model.simulate_cmd("sleep 20");
+            model.process_bytes("running");
+            model
+                .block_list_mut()
+                .active_block_mut()
+                .set_agent_interaction_mode_for_requested_command(action_id, None, conversation_id);
+
+            let active_block = model.block_list().active_block();
+            assert!(!active_block.is_active_and_long_running());
+            assert!(active_block.is_executing() || active_block.is_command_grid_active());
+            assert!(active_block.requested_command_action_id().is_some());
+            assert!(active_block.long_running_control_state().is_none());
+
+            conversation_id
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            view.handle_action(&TerminalAction::CtrlC, ctx);
+        });
+
+        assert_eq!(*pty_writes.borrow(), vec![vec![C0::ETX]]);
+        terminal.read(&app, |_, ctx| {
+            let conversation = BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(&conversation_id)
+                .expect("conversation should exist");
+            assert_eq!(conversation.status(), &ConversationStatus::Cancelled);
+        });
+        terminal.read(&app, |view, _| {
+            let model = view.model.lock();
+            assert!(!model.block_list().active_block().is_agent_driving_command());
+        });
+    })
+}
+
+#[test]
+fn ctrl_c_after_stop_takeover_cancels_conversation() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         FeatureFlag::AgentView.set_enabled(true);
@@ -5246,24 +5405,11 @@ fn ctrl_c_after_takeover_interrupts_command_without_cancelling_conversation() {
                 .set_agent_interaction_mode_for_agent_monitored_command(&task_id, conversation_id)
                 .expect("command should become agent monitored");
 
-            conversation_id
-        });
+            view.cli_subagent_controller.update(ctx, |controller, ctx| {
+                controller.switch_control_to_user(UserTakeOverReason::Stop, ctx);
+            });
 
-        terminal.update(&mut app, |view, ctx| {
-            view.handle_action(&TerminalAction::CtrlC, ctx);
-        });
-        assert!(pty_writes.borrow().is_empty());
-        terminal.read(&app, |view, ctx| {
-            let model = view.model.lock();
-            let active_block = model.block_list().active_block();
-            assert!(active_block
-                .long_running_control_state()
-                .and_then(|state| state.user_take_over_reason())
-                .is_some_and(|reason| matches!(reason, UserTakeOverReason::Manual)));
-            let conversation = BlocklistAIHistoryModel::as_ref(ctx)
-                .conversation(&conversation_id)
-                .expect("conversation should exist");
-            assert_eq!(conversation.status(), &ConversationStatus::InProgress);
+            conversation_id
         });
 
         terminal.update(&mut app, |view, ctx| {
@@ -5275,7 +5421,7 @@ fn ctrl_c_after_takeover_interrupts_command_without_cancelling_conversation() {
             let conversation = BlocklistAIHistoryModel::as_ref(ctx)
                 .conversation(&conversation_id)
                 .expect("conversation should exist");
-            assert_eq!(conversation.status(), &ConversationStatus::InProgress);
+            assert_eq!(conversation.status(), &ConversationStatus::Cancelled);
         });
     })
 }

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -5372,7 +5372,7 @@ fn ctrl_c_interrupts_requested_command_before_long_running_threshold() {
 }
 
 #[test]
-fn ctrl_c_after_stop_takeover_cancels_conversation() {
+fn ctrl_c_after_takeover_interrupts_command_without_cancelling_conversation() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         FeatureFlag::AgentView.set_enabled(true);
@@ -5405,11 +5405,24 @@ fn ctrl_c_after_stop_takeover_cancels_conversation() {
                 .set_agent_interaction_mode_for_agent_monitored_command(&task_id, conversation_id)
                 .expect("command should become agent monitored");
 
-            view.cli_subagent_controller.update(ctx, |controller, ctx| {
-                controller.switch_control_to_user(UserTakeOverReason::Stop, ctx);
-            });
-
             conversation_id
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            view.handle_action(&TerminalAction::CtrlC, ctx);
+        });
+        assert!(pty_writes.borrow().is_empty());
+        terminal.read(&app, |view, ctx| {
+            let model = view.model.lock();
+            let active_block = model.block_list().active_block();
+            assert!(active_block
+                .long_running_control_state()
+                .and_then(|state| state.user_take_over_reason())
+                .is_some_and(|reason| matches!(reason, UserTakeOverReason::Manual)));
+            let conversation = BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(&conversation_id)
+                .expect("conversation should exist");
+            assert_eq!(conversation.status(), &ConversationStatus::InProgress);
         });
 
         terminal.update(&mut app, |view, ctx| {
@@ -5421,7 +5434,7 @@ fn ctrl_c_after_stop_takeover_cancels_conversation() {
             let conversation = BlocklistAIHistoryModel::as_ref(ctx)
                 .conversation(&conversation_id)
                 .expect("conversation should exist");
-            assert_eq!(conversation.status(), &ConversationStatus::Cancelled);
+            assert_eq!(conversation.status(), &ConversationStatus::InProgress);
         });
     })
 }


### PR DESCRIPTION
## Description

Stacked on #12667, which is stacked on #12623. This PR handles the early Ctrl-C path for agent-requested long-running commands, before the CLI subagent has attached to the command.

When an agent-requested shell command is accepted, there is a short window where the command may already be running but Warp has not yet classified it as long-running or attached the CLI subagent input. In that window, Ctrl-C should interrupt the terminal process and cancel the requested-command/conversation state instead of being routed through the AI block.

This PR covers that window by:

- returning focus to the terminal/input after the requested command starts, so Ctrl-C and follow-ups route correctly;
- recognizing agent-requested commands before the long-running threshold;
- cancelling pending/running requested-command action state, or rewriting the initial long-running snapshot to a cancelled result when it has not been consumed yet;
- falling back to conversation cancellation once that snapshot has already been consumed by an automatic follow-up;
- marking the block as user-stopped before writing Ctrl-C, so commands that ignore Ctrl-C are not later treated as agent-driven and re-locked into agent mode.

This is intentionally separate from the downstack PRs: #12623 handles Stop after the CLI subagent is already monitoring a command, and #12667 handles natural completion after user takeover. This PR handles the earlier agent-requested-command lifecycle before subagent attachment.

## Linked Issue

N/A

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Here's a demo/explainer of how this works: https://www.loom.com/share/c769cf04dd7e4f47ac2928119e0be595!

- [x] `./script/format`
- [x] `git --no-pager diff --check`
- [x] `cargo nextest run -p warp -E 'test(ctrl_c_cancels_requested_long_running_command_after_snapshot_follow_up) | test(ctrl_c_interrupts_requested_command_before_long_running_threshold)'`
- [x] `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed Ctrl-C handling for agent-requested long-running commands before CLI subagent attachment.

_Conversation: https://staging.warp.dev/conversation/b1555a3d-e4bd-437b-abad-ddfe5d2374c8_
_Run: https://oz.staging.warp.dev/runs/019ecd53-6f4f-7922-80f7-0449bcc42a66_
_This PR was generated with_ [_Oz](https://warp.dev/oz)._


Co-Authored-By: Oz <oz-agent@warp.dev>
