### PR TITLE
Rely on server sending protocol-level ping frames, ensure one connection

### DIFF
--- a/app/src/terminal/shared_session/network/heartbeat.rs
+++ b/app/src/terminal/shared_session/network/heartbeat.rs
@@ -46,8 +46,13 @@ impl Heartbeat {
     /// Starts the periodic ping and the idle timeout tracker.
     pub fn start(&mut self, ctx: &mut ModelContext<Self>) {
         self.reset_idle_timeout(ctx);
+        // Abort any existing ping timer so we don't accumulate chains across reconnects.
+        if let Some(handle) = self.periodic_ping_abort_handle.take() {
+            handle.abort();
+        }
         self.periodic_ping(ctx);
     }
+
     pub fn stop(&mut self) {
         if let Some(handle) = self.idle_timeout_abort_handle.take() {
             handle.abort();

--- a/app/src/terminal/shared_session/network/heartbeat.rs
+++ b/app/src/terminal/shared_session/network/heartbeat.rs
@@ -1,3 +1,8 @@
+// Session sharing now relies on the server sending protocol-level ping frames that the client responds to,
+// and the server initiates disconnect if the client is unresponsive.
+// This module is no longer used, but we keep the code around for now.
+#![allow(dead_code)]
+
 use std::time::Duration;
 
 use futures::stream::AbortHandle;

--- a/app/src/terminal/shared_session/sharer/network.rs
+++ b/app/src/terminal/shared_session/sharer/network.rs
@@ -1,7 +1,10 @@
 //! The "sender" of a shared session represents the sharer's end.
 //!
 //! Currently there is no way to share a session from wasm.
-#![cfg_attr(any(test, feature = "integration_tests", target_family = "wasm"), allow(dead_code))]
+#![cfg_attr(
+    any(test, feature = "integration_tests", target_family = "wasm"),
+    allow(dead_code)
+)]
 
 use std::collections::HashMap;
 use std::pin::pin;

--- a/app/src/terminal/shared_session/sharer/network.rs
+++ b/app/src/terminal/shared_session/sharer/network.rs
@@ -37,7 +37,7 @@ use session_sharing_protocol::sharer::{
 };
 use warp_core::features::FeatureFlag;
 use warpui::r#async::Timer;
-use warpui::{Entity, ModelContext, ModelHandle, RequestState, RetryOption, SingletonEntity};
+use warpui::{Entity, ModelContext, RequestState, RetryOption, SingletonEntity};
 use websocket::{Message, Sink, Stream, WebSocket, WebsocketMessage as _};
 
 use crate::auth::{AuthStateProvider, UserUid};
@@ -45,7 +45,6 @@ use crate::editor::{CrdtOperation, ReplicaId};
 use crate::server::iap::IapManager;
 use crate::server::server_api::ServerApiProvider;
 use crate::terminal::model::block::BlockId;
-use crate::terminal::shared_session::network::heartbeat::{Event as HeartbeatEvent, Heartbeat};
 use crate::terminal::shared_session::{
     connect_endpoint, max_session_size, EventNumber, SharedSessionScrollbackType,
     SharedSessionSource, SELECTION_THROTTLE_PERIOD,
@@ -253,7 +252,6 @@ fn startup_max_attempts(source: &SharedSessionSource) -> usize {
 pub struct Network {
     model: Arc<FairMutex<TerminalModel>>,
     stage: Stage,
-    heartbeat: ModelHandle<Heartbeat>,
 
     /// The next event number to use when sending an event to the server.
     event_no: EventNumber,
@@ -309,10 +307,7 @@ impl Network {
         let (selection_throttled_tx, selection_rx) = async_channel::unbounded();
         let selection_throttled_rx = throttle(SELECTION_THROTTLE_PERIOD, selection_rx);
         let init_block_id = model.lock().block_list().active_block_id().clone();
-        let heartbeat = ctx.add_model(|_| Heartbeat::default());
-
         let network = Network {
-            heartbeat,
             event_no: EventNumber::new(),
             selection_event_no: EventNumber::new(),
             model: model.clone(),
@@ -385,7 +380,6 @@ impl Network {
         let (selection_throttled_tx, selection_rx) = async_channel::unbounded();
         let selection_throttled_rx = throttle(SELECTION_THROTTLE_PERIOD, selection_rx);
         let init_block_id = model.lock().block_list().active_block_id().clone();
-        let heartbeat = ctx.add_model(|_| Heartbeat::default());
         let window_size = {
             let size_info = *model.lock().block_list().size();
             WindowSize {
@@ -410,7 +404,6 @@ impl Network {
         };
 
         let mut network = Network {
-            heartbeat,
             event_no: EventNumber::new(),
             selection_event_no: EventNumber::new(),
             model: model.clone(),
@@ -506,21 +499,6 @@ impl Network {
         let message = UpstreamMessage::EndSession { reason };
         self.send_message_to_server(message);
         self.close_without_reconnection();
-    }
-
-    /// We need to ensure we're maintaining a heartbeat with the server.
-    /// This helps us detect if the server has gone away silently and helps
-    /// the server detect if we (the client) have disconnected quietly.
-    fn handle_heartbeat_event(&mut self, event: &HeartbeatEvent, ctx: &mut ModelContext<Self>) {
-        match event {
-            HeartbeatEvent::Ping => {
-                self.send_message_to_server(UpstreamMessage::Ping { data: vec![] });
-            }
-            HeartbeatEvent::Idle => {
-                sharer_info!(self, "Sharer reconnecting: heartbeat idle timeout");
-                self.reconnect_websocket(ctx);
-            }
-        }
     }
 
     pub fn send_active_prompt_update_if_changed(&mut self, active_prompt: ActivePrompt) {
@@ -762,7 +740,7 @@ impl Network {
         };
 
         self.abort_startup_handles();
-        self.close_startup_transport(ctx);
+        self.close_startup_transport();
 
         let (ws_proxy_tx, ws_proxy_rx) = async_channel::unbounded();
         self.ws_proxy_tx = ws_proxy_tx;
@@ -963,7 +941,7 @@ impl Network {
         }
     }
 
-    fn close_startup_transport(&mut self, ctx: &mut ModelContext<Self>) {
+    fn close_startup_transport(&mut self) {
         self.ws_proxy_tx.close();
     }
 
@@ -997,7 +975,7 @@ impl Network {
                 );
             }
             self.abort_startup_handles();
-            self.close_startup_transport(ctx);
+            self.close_startup_transport();
 
             #[cfg(not(any(test, feature = "integration_tests")))]
             self.start_create_session_attempt(ctx);
@@ -1017,7 +995,7 @@ impl Network {
         }
         self.abort_startup_handles();
         self.stage = Stage::Finished;
-        self.close_startup_transport(ctx);
+        self.close_startup_transport();
         self.startup_config = None;
 
         #[cfg(not(any(test, feature = "integration_tests")))]

--- a/app/src/terminal/shared_session/sharer/network.rs
+++ b/app/src/terminal/shared_session/sharer/network.rs
@@ -310,7 +310,6 @@ impl Network {
         let selection_throttled_rx = throttle(SELECTION_THROTTLE_PERIOD, selection_rx);
         let init_block_id = model.lock().block_list().active_block_id().clone();
         let heartbeat = ctx.add_model(|_| Heartbeat::default());
-        ctx.subscribe_to_model(&heartbeat, Self::handle_heartbeat_event);
 
         let network = Network {
             heartbeat,
@@ -387,7 +386,6 @@ impl Network {
         let selection_throttled_rx = throttle(SELECTION_THROTTLE_PERIOD, selection_rx);
         let init_block_id = model.lock().block_list().active_block_id().clone();
         let heartbeat = ctx.add_model(|_| Heartbeat::default());
-        ctx.subscribe_to_model(&heartbeat, Self::handle_heartbeat_event);
         let window_size = {
             let size_info = *model.lock().block_list().size();
             WindowSize {
@@ -967,9 +965,6 @@ impl Network {
 
     fn close_startup_transport(&mut self, ctx: &mut ModelContext<Self>) {
         self.ws_proxy_tx.close();
-        self.heartbeat.update(ctx, |heartbeat, _| {
-            heartbeat.stop();
-        });
     }
 
     fn handle_startup_failure(&mut self, failure: StartupFailure, ctx: &mut ModelContext<Self>) {
@@ -1168,10 +1163,6 @@ impl Network {
         stream: impl Stream,
         ctx: &mut ModelContext<Self>,
     ) {
-        self.heartbeat.update(ctx, |heartbeat, ctx| {
-            heartbeat.start(ctx);
-        });
-
         // Handle any messages we receive over the websocket.
         ctx.spawn_stream_local(
             stream,
@@ -1182,9 +1173,6 @@ impl Network {
                     }) {
                         return;
                     }
-                    network.heartbeat.update(ctx, |heartbeat, ctx| {
-                        heartbeat.reset_idle_timeout(ctx);
-                    });
                     network.process_websocket_message(message, ctx);
                 }
                 Err(e) => {

--- a/app/src/terminal/shared_session/sharer/network.rs
+++ b/app/src/terminal/shared_session/sharer/network.rs
@@ -1,7 +1,7 @@
 //! The "sender" of a shared session represents the sharer's end.
 //!
 //! Currently there is no way to share a session from wasm.
-#![cfg_attr(target_family = "wasm", allow(dead_code))]
+#![cfg_attr(any(test, feature = "integration_tests", target_family = "wasm"), allow(dead_code))]
 
 use std::collections::HashMap;
 use std::pin::pin;

--- a/app/src/terminal/shared_session/viewer/network.rs
+++ b/app/src/terminal/shared_session/viewer/network.rs
@@ -293,10 +293,6 @@ impl Network {
             }
             HeartbeatEvent::Idle => {
                 log::info!("Viewer reconnecting: heartbeat idle timeout");
-                // Close the old connection before reconnecting so the server
-                // sees WebsocketClosed immediately rather than waiting for its
-                // own 30 s idle timer to fire on the now-silent connection.
-                self.close();
                 self.reconnect_websocket(ctx);
             }
         }
@@ -360,13 +356,13 @@ impl Network {
             },
             |network, ctx| {
                 log::info!("Websocket to session sharing server ended");
-                // Close our current websocket proxy, because we may try to reconnect and that will create a new websocket proxy.
-                // This must be done before trying to reconnect.
-                network.close();
                 if matches!(network.stage, Stage::JoinedSuccessfully) {
                     // The connection may have timed out or the server restarted.
                     log::info!("Viewer reconnecting: websocket closed by server");
                     network.reconnect_websocket(ctx);
+                } else if !matches!(network.stage, Stage::Reconnecting { .. }) {
+                    // Not reconnecting — clean up the proxy channel.
+                    network.close();
                 }
             },
         );
@@ -460,6 +456,11 @@ impl Network {
         if matches!(self.stage, Stage::Finished | Stage::Reconnecting { .. }) {
             return;
         }
+        // Close the old connection before reconnecting so the server sees
+        // WebsocketClosed immediately rather than waiting for its own idle
+        // timer. Stage is guaranteed not Reconnecting here, so close() will
+        // not abort any in-progress reconnect handle.
+        self.close();
         let Some(event_loop) = self.event_loop.clone() else {
             log::error!("Cannot reconnect to server as viewer when event loop does not exist");
             return;

--- a/app/src/terminal/shared_session/viewer/network.rs
+++ b/app/src/terminal/shared_session/viewer/network.rs
@@ -293,6 +293,10 @@ impl Network {
             }
             HeartbeatEvent::Idle => {
                 log::info!("Viewer reconnecting: heartbeat idle timeout");
+                // Close the old connection before reconnecting so the server
+                // sees WebsocketClosed immediately rather than waiting for its
+                // own 30 s idle timer to fire on the now-silent connection.
+                self.close();
                 self.reconnect_websocket(ctx);
             }
         }

--- a/app/src/terminal/shared_session/viewer/network.rs
+++ b/app/src/terminal/shared_session/viewer/network.rs
@@ -164,7 +164,6 @@ impl Network {
         let (selection_throttled_tx, selection_rx) = async_channel::unbounded();
         let selection_throttled_rx = throttle(SELECTION_THROTTLE_PERIOD, selection_rx);
         let heartbeat = ctx.add_model(|_| Heartbeat::default());
-        ctx.subscribe_to_model(&heartbeat, Self::handle_heartbeat_event);
 
         let model = Network {
             heartbeat,
@@ -225,7 +224,6 @@ impl Network {
         let (selection_throttled_tx, selection_rx) = async_channel::unbounded();
         let selection_throttled_rx = throttle(SELECTION_THROTTLE_PERIOD, selection_rx);
         let heartbeat = ctx.add_model(|_| Heartbeat::default());
-        ctx.subscribe_to_model(&heartbeat, Self::handle_heartbeat_event);
 
         let session_id = SessionId::new();
         let viewer_id = ParticipantId::new();
@@ -336,18 +334,11 @@ impl Network {
         stream: impl Stream,
         ctx: &mut ModelContext<Self>,
     ) {
-        self.heartbeat.update(ctx, |heartbeat, ctx| {
-            heartbeat.start(ctx);
-        });
-
         // Receive messages from the server.
         ctx.spawn_stream_local(
             stream,
             |network, item, ctx| match item {
                 Ok(message) => {
-                    network.heartbeat.update(ctx, |heartbeat, ctx| {
-                        heartbeat.reset_idle_timeout(ctx);
-                    });
                     network.process_websocket_message(message, ctx);
                 }
                 Err(e) => {

--- a/app/src/terminal/shared_session/viewer/network.rs
+++ b/app/src/terminal/shared_session/viewer/network.rs
@@ -43,7 +43,6 @@ use crate::server::server_api::ServerApiProvider;
 use crate::server::telemetry::telemetry_context;
 use crate::terminal::event_listener::ChannelEventListener;
 use crate::terminal::model::block::BlockId;
-use crate::terminal::shared_session::network::heartbeat::{Event as HeartbeatEvent, Heartbeat};
 use crate::terminal::shared_session::shared_handlers::RemoteUpdateGuard;
 use crate::terminal::shared_session::viewer::event_loop::{
     EventLoop, SharedSessionInitialLoadMode,
@@ -108,8 +107,6 @@ struct CachedLatestState {
 /// The network interface to allow communication to and from the
 /// cloud-backed shared session.
 pub struct Network {
-    heartbeat: ModelHandle<Heartbeat>,
-
     session_id: SessionId,
     /// [`None`] until the viewer receives the successful join ack.
     event_loop: Option<ModelHandle<EventLoop>>,
@@ -163,10 +160,7 @@ impl Network {
         let (ws_proxy_tx, ws_proxy_rx) = async_channel::unbounded();
         let (selection_throttled_tx, selection_rx) = async_channel::unbounded();
         let selection_throttled_rx = throttle(SELECTION_THROTTLE_PERIOD, selection_rx);
-        let heartbeat = ctx.add_model(|_| Heartbeat::default());
-
         let model = Network {
-            heartbeat,
             session_id,
             event_loop: None,
             ws_proxy_tx,
@@ -223,15 +217,12 @@ impl Network {
         let (ws_proxy_tx, ws_proxy_rx) = async_channel::unbounded();
         let (selection_throttled_tx, selection_rx) = async_channel::unbounded();
         let selection_throttled_rx = throttle(SELECTION_THROTTLE_PERIOD, selection_rx);
-        let heartbeat = ctx.add_model(|_| Heartbeat::default());
-
         let session_id = SessionId::new();
         let viewer_id = ParticipantId::new();
         let viewer_firebase_uid = UserUid::new("mock_firebase_uid");
         let active_prompt = ActivePrompt::WarpPrompt("test warp prompt".to_owned());
 
         let model = Network {
-            heartbeat,
             session_id,
             event_loop: None,
             ws_proxy_tx,
@@ -279,21 +270,6 @@ impl Network {
             |_, _| {},
         );
         model
-    }
-
-    /// We need to ensure we're maintaining a heartbeat with the server.
-    /// This helps us detect if the server has gone away silently and helps
-    /// the server detect if we (the client) have disconnected quietly.
-    fn handle_heartbeat_event(&mut self, event: &HeartbeatEvent, ctx: &mut ModelContext<Self>) {
-        match event {
-            HeartbeatEvent::Ping => {
-                self.send_message_to_server(UpstreamMessage::Ping { data: vec![] });
-            }
-            HeartbeatEvent::Idle => {
-                log::info!("Viewer reconnecting: heartbeat idle timeout");
-                self.reconnect_websocket(ctx);
-            }
-        }
     }
 
     async fn get_user_id(


### PR DESCRIPTION
## Description

Was debugging https://linear.app/warpdotdev/issue/REMOTE-1883/investigate-enterprise-report-of-cant-send-follow-up-to-oz

The server was not receiving pings from the client (supposed to be sent every 5s), and the server terminates the connection after not receiving a ping from the client for 30s. The reconnects succeed immediately after the server terminates the connection.

This is because the browser throttles background timers to be at most every 60s. The wasm client was both sending pings every ~60s and checking idle timeout every ~60s. This would cause the server to terminate the connection every 60-90s which is what I saw. 

The wasm client would also end up in a state where its own idle timeout fired, showing "Offline, trying to reconnect..." but it actually was permanently disconnected:
```
INFO app/src/terminal/shared_session/viewer/network.rs:295 Viewer reconnecting: heartbeat idle timeout
warp.js:1111 INFO app/src/terminal/shared_session/viewer/network.rs:469 Attempting to reconnect to session sharing server as viewer
warp.js:1111 INFO app/src/terminal/shared_session/viewer/network.rs:487 Successfully reconnected to server as viewer
warp.js:1111 INFO app/src/terminal/shared_session/viewer/network.rs:385 Closing websocket to session sharing server as viewer
warp.js:1111 INFO app/src/terminal/shared_session/viewer/network.rs:358 Websocket to session sharing server ended
warp.js:1111 INFO app/src/terminal/shared_session/viewer/network.rs:385 Closing websocket to session sharing server as viewer
warp.js:1111 INFO app/src/terminal/shared_session/viewer/network.rs:358 Websocket to session sharing server ended
warp.js:1111 INFO app/src/terminal/shared_session/viewer/network.rs:295 Viewer reconnecting: heartbeat idle timeout
```

This was due to a race where the idle timeout could cause the client to reconnect before the original stream closed. Once the original stream closed, we called `network.close()` which closed the reconnected websocket. We prevent this and ensure old websockets are closed before reconnecting.

Remove client sending application-level pings entirely, and replace with protocol-level ping frames sent by the server every 15s, with 45s timeout. Tungstenite (library we use) automatically responds with protocol-level pong. The browser also autoresponds and this doesn't use a timer that gets throttled. The server will be responsible for terminating idle connections, and the client will not do anything but respond with pongs.

## Testing

Before this change, leaving a wasm viewer for > 1 min would result in both server and client terminating connection, and only a refresh would fix.

Tested locally, killed session sharing server and restarted, sharer and viewer still reconnecting fine. Both wasm and desktop viewer can be left indefinitely and remain connected and able to send follow ups