### PR TITLE
Fix fork button tooltip, command insertion, /continue-locally visibility

### DIFF
--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -1060,6 +1060,11 @@ impl View for AIBlock {
             app,
         );
         drop(terminal_model);
+        let is_not_cloud_agent_context = !(FeatureFlag::CloudMode.is_enabled()
+            && self
+                .ambient_agent_view_model
+                .as_ref()
+                .is_some_and(|model| model.as_ref(app).is_ambient_agent()));
 
         contents.add_child(output::render(
             output::Props {
@@ -1114,6 +1119,7 @@ impl View for AIBlock {
                 shared_session_status: &shared_session_status,
                 terminal_view_id: self.terminal_view_id,
                 is_conversation_transcript_viewer,
+                is_not_cloud_agent_context,
                 aws_bedrock_credentials_error_view: self
                     .aws_bedrock_credentials_error_view
                     .as_ref(),

--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -1061,6 +1061,7 @@ impl View for AIBlock {
         );
         drop(terminal_model);
 
+        #[cfg(not(target_family = "wasm"))]
         let is_cloud_agent_context = FeatureFlag::CloudMode.is_enabled()
             && self
                 .ambient_agent_view_model
@@ -1120,6 +1121,7 @@ impl View for AIBlock {
                 shared_session_status: &shared_session_status,
                 terminal_view_id: self.terminal_view_id,
                 is_conversation_transcript_viewer,
+                #[cfg(not(target_family = "wasm"))]
                 is_cloud_agent_context,
                 aws_bedrock_credentials_error_view: self
                     .aws_bedrock_credentials_error_view

--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -1060,11 +1060,12 @@ impl View for AIBlock {
             app,
         );
         drop(terminal_model);
-        let is_not_cloud_agent_context = !(FeatureFlag::CloudMode.is_enabled()
+
+        let is_cloud_agent_context = FeatureFlag::CloudMode.is_enabled()
             && self
                 .ambient_agent_view_model
                 .as_ref()
-                .is_some_and(|model| model.as_ref(app).is_ambient_agent()));
+                .is_some_and(|model| model.as_ref(app).is_ambient_agent());
 
         contents.add_child(output::render(
             output::Props {
@@ -1119,7 +1120,7 @@ impl View for AIBlock {
                 shared_session_status: &shared_session_status,
                 terminal_view_id: self.terminal_view_id,
                 is_conversation_transcript_viewer,
-                is_not_cloud_agent_context,
+                is_cloud_agent_context,
                 aws_bedrock_credentials_error_view: self
                     .aws_bedrock_credentials_error_view
                     .as_ref(),

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -3225,6 +3225,23 @@ fn render_response_footer(props: Props, app: &AppContext) -> Option<Box<dyn Elem
     }
 
     if !props.is_conversation_transcript_viewer && !cfg!(target_family = "wasm") {
+        // Use "Continue locally" tooltip when the button will insert /continue-locally
+        // (i.e. for cloud Oz conversations where /fork is unavailable).
+        #[cfg(not(target_family = "wasm"))]
+        let fork_button_tooltip = {
+            use crate::terminal::input::slash_commands::conversation_is_cloud_oz_for_slash_command;
+            let is_cloud_oz = props
+                .model
+                .conversation_id(app)
+                .is_some_and(|id| conversation_is_cloud_oz_for_slash_command(id, app));
+            if is_cloud_oz {
+                "Continue locally"
+            } else {
+                "Fork conversation"
+            }
+        };
+        #[cfg(target_family = "wasm")]
+        let fork_button_tooltip = "Fork conversation";
         let ui_builder = appearance.ui_builder().clone();
         let fork_button = icon_button(
             appearance,
@@ -3234,7 +3251,7 @@ fn render_response_footer(props: Props, app: &AppContext) -> Option<Box<dyn Elem
         )
         .with_tooltip(move || {
             ui_builder
-                .tool_tip("Fork conversation".to_string())
+                .tool_tip(fork_button_tooltip.to_string())
                 .build()
                 .finish()
         })

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -173,6 +173,7 @@ pub(crate) struct Props<'a> {
     pub(super) shared_session_status: &'a SharedSessionStatus,
     pub(super) terminal_view_id: EntityId,
     pub(super) is_conversation_transcript_viewer: bool,
+    #[cfg(not(target_family = "wasm"))]
     pub(super) is_cloud_agent_context: bool,
     pub(super) aws_bedrock_credentials_error_view:
         Option<&'a ViewHandle<AwsBedrockCredentialsErrorView>>,

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -173,6 +173,7 @@ pub(crate) struct Props<'a> {
     pub(super) shared_session_status: &'a SharedSessionStatus,
     pub(super) terminal_view_id: EntityId,
     pub(super) is_conversation_transcript_viewer: bool,
+    pub(super) is_not_cloud_agent_context: bool,
     pub(super) aws_bedrock_credentials_error_view:
         Option<&'a ViewHandle<AwsBedrockCredentialsErrorView>>,
     pub(super) imported_comments: &'a HashMap<AIAgentActionId, ImportedCommentGroup>,
@@ -3228,7 +3229,12 @@ fn render_response_footer(props: Props, app: &AppContext) -> Option<Box<dyn Elem
 
     #[cfg(not(target_family = "wasm"))]
     if !props.is_conversation_transcript_viewer {
-        let fork_button_tooltip = fork_button_action(props.model.conversation_id(app), app).tooltip;
+        let fork_button_tooltip = fork_button_action(
+            props.model.conversation_id(app),
+            props.is_not_cloud_agent_context,
+            app,
+        )
+        .tooltip;
 
         let ui_builder = appearance.ui_builder().clone();
         let fork_button = icon_button(

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -173,7 +173,7 @@ pub(crate) struct Props<'a> {
     pub(super) shared_session_status: &'a SharedSessionStatus,
     pub(super) terminal_view_id: EntityId,
     pub(super) is_conversation_transcript_viewer: bool,
-    pub(super) is_not_cloud_agent_context: bool,
+    pub(super) is_cloud_agent_context: bool,
     pub(super) aws_bedrock_credentials_error_view:
         Option<&'a ViewHandle<AwsBedrockCredentialsErrorView>>,
     pub(super) imported_comments: &'a HashMap<AIAgentActionId, ImportedCommentGroup>,
@@ -3231,7 +3231,7 @@ fn render_response_footer(props: Props, app: &AppContext) -> Option<Box<dyn Elem
     if !props.is_conversation_transcript_viewer {
         let fork_button_tooltip = fork_button_action(
             props.model.conversation_id(app),
-            props.is_not_cloud_agent_context,
+            props.is_cloud_agent_context,
             app,
         )
         .tooltip;

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -108,6 +108,8 @@ use crate::appearance::Appearance;
 use crate::code::diff_viewer::DisplayMode;
 use crate::code::editor_management::CodeSource;
 use crate::settings_view::SettingsSection;
+#[cfg(not(target_family = "wasm"))]
+use crate::terminal::input::slash_commands::fork_button_action;
 use crate::terminal::model::session::active_session::ActiveSession;
 use crate::terminal::shared_session::SharedSessionStatus;
 use crate::terminal::ShellLaunchData;
@@ -3224,16 +3226,10 @@ fn render_response_footer(props: Props, app: &AppContext) -> Option<Box<dyn Elem
         flex.add_child(continue_button);
     }
 
-    if !props.is_conversation_transcript_viewer && !cfg!(target_family = "wasm") {
-        // Tooltip matches the slash command the button will insert.
-        // Both are determined by fork_button_action so they always agree.
-        #[cfg(not(target_family = "wasm"))]
-        let fork_button_tooltip = {
-            use crate::terminal::input::slash_commands::fork_button_action;
-            fork_button_action(props.model.conversation_id(app), app).tooltip
-        };
-        #[cfg(target_family = "wasm")]
-        let fork_button_tooltip = "Fork conversation";
+    #[cfg(not(target_family = "wasm"))]
+    if !props.is_conversation_transcript_viewer {
+        let fork_button_tooltip = fork_button_action(props.model.conversation_id(app), app).tooltip;
+
         let ui_builder = appearance.ui_builder().clone();
         let fork_button = icon_button(
             appearance,

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -3225,20 +3225,12 @@ fn render_response_footer(props: Props, app: &AppContext) -> Option<Box<dyn Elem
     }
 
     if !props.is_conversation_transcript_viewer && !cfg!(target_family = "wasm") {
-        // Use "Continue locally" tooltip when the button will insert /continue-locally
-        // (i.e. for cloud Oz conversations where /fork is unavailable).
+        // Tooltip matches the slash command the button will insert.
+        // Both are determined by fork_button_action so they always agree.
         #[cfg(not(target_family = "wasm"))]
         let fork_button_tooltip = {
-            use crate::terminal::input::slash_commands::conversation_is_cloud_oz_for_slash_command;
-            let is_cloud_oz = props
-                .model
-                .conversation_id(app)
-                .is_some_and(|id| conversation_is_cloud_oz_for_slash_command(id, app));
-            if is_cloud_oz {
-                "Continue locally"
-            } else {
-                "Fork conversation"
-            }
+            use crate::terminal::input::slash_commands::fork_button_action;
+            fork_button_action(props.model.conversation_id(app), app).tooltip
         };
         #[cfg(target_family = "wasm")]
         let fork_button_tooltip = "Fork conversation";

--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -460,7 +460,7 @@ pub const FORK_FROM: StaticCommand = StaticCommand {
 };
 
 pub static CONTINUE_LOCALLY: LazyLock<StaticCommand> = LazyLock::new(|| {
-    let hint_text = "<optional prompt to send in forked conversation>";
+    let hint_text = "<optional prompt to send in local conversation>";
     StaticCommand {
         name: "/continue-locally",
         description: "Continue this cloud conversation locally",

--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -176,8 +176,7 @@ pub static FORK: LazyLock<StaticCommand> = LazyLock::new(|| {
         availability: Availability::AGENT_VIEW
             | Availability::ACTIVE_CONVERSATION
             | Availability::NO_LRC_CONTROL
-            | Availability::AI_ENABLED
-            | Availability::NOT_CLOUD_AGENT,
+            | Availability::AI_ENABLED,
         auto_enter_ai_mode: true,
         argument: Some(Argument::optional().with_hint_text(hint_text)),
     }

--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -322,7 +322,7 @@ pub static HOST: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     icon_path: "bundled/svg/oz-cloud.svg",
     availability: Availability::AGENT_VIEW
         | Availability::AI_ENABLED
-        | Availability::CLOUD_AGENT_V2,
+        | Availability::CLOUD_MODE_V2_COMPOSER,
     auto_enter_ai_mode: true,
     argument: None,
 });
@@ -333,7 +333,7 @@ pub static HARNESS: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand {
     icon_path: "bundled/svg/oz.svg",
     availability: Availability::AGENT_VIEW
         | Availability::AI_ENABLED
-        | Availability::CLOUD_AGENT_V2,
+        | Availability::CLOUD_MODE_V2_COMPOSER,
     auto_enter_ai_mode: true,
     argument: None,
 });
@@ -344,7 +344,7 @@ pub static ENVIRONMENT: LazyLock<StaticCommand> = LazyLock::new(|| StaticCommand
     icon_path: "bundled/svg/globe-04.svg",
     availability: Availability::AGENT_VIEW
         | Availability::AI_ENABLED
-        | Availability::CLOUD_AGENT_V2,
+        | Availability::CLOUD_MODE_V2_COMPOSER,
     auto_enter_ai_mode: true,
     argument: None,
 });
@@ -467,7 +467,8 @@ pub static CONTINUE_LOCALLY: LazyLock<StaticCommand> = LazyLock::new(|| {
         icon_path: "bundled/svg/arrow-split.svg",
         availability: Availability::AGENT_VIEW
             | Availability::ACTIVE_CONVERSATION
-            | Availability::AI_ENABLED,
+            | Availability::AI_ENABLED
+            | Availability::CLOUD_AGENT,
         auto_enter_ai_mode: true,
         argument: Some(Argument::optional().with_hint_text(hint_text)),
     }

--- a/app/src/search/slash_command_menu/static_commands/commands_tests.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands_tests.rs
@@ -60,7 +60,10 @@ fn continue_locally_command_is_registered() {
     assert!(command.auto_enter_ai_mode);
     assert_eq!(
         command.availability,
-        Availability::AGENT_VIEW | Availability::ACTIVE_CONVERSATION | Availability::AI_ENABLED
+        Availability::AGENT_VIEW
+            | Availability::ACTIVE_CONVERSATION
+            | Availability::AI_ENABLED
+            | Availability::CLOUD_AGENT
     );
 
     let argument = command
@@ -71,7 +74,7 @@ fn continue_locally_command_is_registered() {
     assert!(!argument.should_execute_on_selection);
     assert_eq!(
         argument.hint_text,
-        Some("<optional prompt to send in forked conversation>")
+        Some("<optional prompt to send in local conversation>")
     );
 }
 

--- a/app/src/search/slash_command_menu/static_commands/mod.rs
+++ b/app/src/search/slash_command_menu/static_commands/mod.rs
@@ -34,12 +34,15 @@ bitflags! {
         const CODEBASE_CONTEXT = 1 << 6;
         /// Requires AI to be globally enabled.
         const AI_ENABLED = 1 << 7;
+        /// Requires a non-cloud-agent context.
         const NOT_CLOUD_AGENT = 1 << 8;
+        /// Requires a cloud-agent context.
+        const CLOUD_AGENT = 1 << 9;
         /// Set on the session context iff the slash command data source was constructed via
         /// `SlashCommandDataSource::for_cloud_mode_v2` *and* `FeatureFlag::CloudModeInputV2`
         /// is enabled. Commands that require this bit are hidden everywhere except the V2
         /// cloud-mode composing input.
-        const CLOUD_AGENT_V2 = 1 << 9;
+        const CLOUD_MODE_V2_COMPOSER = 1 << 10;
     }
 }
 

--- a/app/src/search/slash_command_menu/static_commands/mod_tests.rs
+++ b/app/src/search/slash_command_menu/static_commands/mod_tests.rs
@@ -162,28 +162,48 @@ fn codebase_context_requirement_not_satisfied_when_disabled() {
     assert!(!session.contains(command));
 }
 
-// --- CLOUD_AGENT_V2 flag tests ---
+// --- CLOUD_AGENT flag tests ---
 #[test]
-fn cloud_agent_v2_required_command_satisfied_in_v2_session() {
-    let command =
-        Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::CLOUD_AGENT_V2;
+fn cloud_agent_required_command_satisfied_in_cloud_agent_session() {
+    let command = Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::CLOUD_AGENT;
 
-    // V2 cloud-mode composing input has AGENT_VIEW + AI_ENABLED + CLOUD_AGENT_V2 set.
-    let session =
-        Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::CLOUD_AGENT_V2;
+    let session = Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::CLOUD_AGENT;
     assert!(session.contains(command));
 }
 
 #[test]
-fn cloud_agent_v2_required_command_not_satisfied_outside_v2() {
+fn cloud_agent_required_command_not_satisfied_outside_cloud_agent_session() {
+    let command = Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::CLOUD_AGENT;
+
+    let session =
+        Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::NOT_CLOUD_AGENT;
+    assert!(!session.contains(command));
+}
+
+// --- CLOUD_MODE_V2_COMPOSER flag tests ---
+#[test]
+fn cloud_mode_v2_composer_required_command_satisfied_in_v2_composer_session() {
     let command =
-        Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::CLOUD_AGENT_V2;
+        Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::CLOUD_MODE_V2_COMPOSER;
+    // V2 cloud-mode composing input has AGENT_VIEW + AI_ENABLED + CLOUD_AGENT +
+    // CLOUD_MODE_V2_COMPOSER set.
+    let session = Availability::AGENT_VIEW
+        | Availability::AI_ENABLED
+        | Availability::CLOUD_AGENT
+        | Availability::CLOUD_MODE_V2_COMPOSER;
+    assert!(session.contains(command));
+}
+
+#[test]
+fn cloud_mode_v2_composer_required_command_not_satisfied_outside_v2_composer() {
+    let command =
+        Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::CLOUD_MODE_V2_COMPOSER;
 
     // A regular agent view session without the V2 bit must not match.
     let session = Availability::AGENT_VIEW | Availability::AI_ENABLED;
     assert!(!session.contains(command));
 
-    // Local-mode agent view (NOT_CLOUD_AGENT instead of CLOUD_AGENT_V2) must not match either.
+    // Local-mode agent view (NOT_CLOUD_AGENT instead of CLOUD_MODE_V2_COMPOSER) must not match either.
     let session =
         Availability::AGENT_VIEW | Availability::AI_ENABLED | Availability::NOT_CLOUD_AGENT;
     assert!(!session.contains(command));

--- a/app/src/terminal/input/slash_commands/data_source/mod.rs
+++ b/app/src/terminal/input/slash_commands/data_source/mod.rs
@@ -289,10 +289,12 @@ impl SlashCommandDataSource {
         }
 
         if self.is_cloud_mode_v2 && FeatureFlag::CloudModeInputV2.is_enabled() {
-            session_context |= Availability::CLOUD_AGENT_V2;
+            session_context |= Availability::CLOUD_MODE_V2_COMPOSER;
         }
 
-        if !self.is_cloud_mode(ctx) {
+        if self.is_cloud_mode(ctx) {
+            session_context |= Availability::CLOUD_AGENT;
+        } else {
             session_context |= Availability::NOT_CLOUD_AGENT;
         }
 
@@ -329,15 +331,11 @@ impl SlashCommandDataSource {
         if command.name == commands::MOVE_TO_CLOUD.name && !context.is_cloud_handoff_enabled {
             return false;
         }
-        // /continue-locally replaces /fork only when /fork is unavailable in cloud-agent
-        // contexts. Local conversations and non-Oz cloud runs (Claude, Gemini) are filtered
-        // out so the slash menu doesn't surface a no-op command.
+        // /continue-locally only applies to cloud Oz conversations. Non-Oz cloud runs
+        // (Claude, Gemini) are filtered out so the slash menu doesn't surface a no-op command.
         #[cfg(not(target_family = "wasm"))]
         if command.name == commands::CONTINUE_LOCALLY.name
-            && (!context.active_conversation_is_cloud_oz
-                || context
-                    .session_context
-                    .contains(Availability::NOT_CLOUD_AGENT))
+            && !context.active_conversation_is_cloud_oz
         {
             return false;
         }

--- a/app/src/terminal/input/slash_commands/data_source/mod.rs
+++ b/app/src/terminal/input/slash_commands/data_source/mod.rs
@@ -331,6 +331,13 @@ impl SlashCommandDataSource {
         if command.name == commands::MOVE_TO_CLOUD.name && !context.is_cloud_handoff_enabled {
             return false;
         }
+        if command.name == commands::FORK.name
+            && context
+                .session_context
+                .contains(Availability::CLOUD_MODE_V2_COMPOSER)
+        {
+            return false;
+        }
         // /continue-locally only applies to cloud Oz conversations. Non-Oz cloud runs
         // (Claude, Gemini) are filtered out so the slash menu doesn't surface a no-op command.
         #[cfg(not(target_family = "wasm"))]

--- a/app/src/terminal/input/slash_commands/data_source/mod.rs
+++ b/app/src/terminal/input/slash_commands/data_source/mod.rs
@@ -329,12 +329,15 @@ impl SlashCommandDataSource {
         if command.name == commands::MOVE_TO_CLOUD.name && !context.is_cloud_handoff_enabled {
             return false;
         }
-        // /continue-locally only applies to cloud Oz conversations. Local conversations
-        // and non-Oz cloud runs (Claude, Gemini) are filtered out so the slash menu
-        // doesn't surface a no-op command.
+        // /continue-locally replaces /fork only when /fork is unavailable in cloud-agent
+        // contexts. Local conversations and non-Oz cloud runs (Claude, Gemini) are filtered
+        // out so the slash menu doesn't surface a no-op command.
         #[cfg(not(target_family = "wasm"))]
         if command.name == commands::CONTINUE_LOCALLY.name
-            && !context.active_conversation_is_cloud_oz
+            && (!context.active_conversation_is_cloud_oz
+                || context
+                    .session_context
+                    .contains(Availability::NOT_CLOUD_AGENT))
         {
             return false;
         }

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -793,7 +793,7 @@ impl Input {
             harness if command.name == commands::HARNESS.name => {
                 if !self.is_cloud_mode_input_v2_composing(ctx) {
                     // Defensive: the command is registered only when the V2 flag is on and its
-                    // availability requires CLOUD_AGENT_V2, so this branch should be unreachable.
+                    // availability requires CLOUD_MODE_V2_COMPOSER, so this branch should be unreachable.
                     return false;
                 }
                 self.suggestions_mode_model.update(ctx, |model, ctx| {
@@ -1398,7 +1398,7 @@ impl Input {
 
 /// Returns true when the conversation with `conversation_id` is associated with an Oz
 /// `AmbientAgentTask`. Callers deciding between `/fork` and `/continue-locally` should also
-/// check the same `NOT_CLOUD_AGENT` context that gates `/fork`.
+/// check the same `CLOUD_AGENT` context that gates `/continue-locally`.
 #[cfg(not(target_family = "wasm"))]
 pub(crate) fn conversation_is_cloud_oz_for_slash_command(
     conversation_id: AIConversationId,
@@ -1442,10 +1442,10 @@ pub(crate) struct ForkButtonAction {
 #[cfg(not(target_family = "wasm"))]
 pub(crate) fn fork_button_action(
     conversation_id: Option<AIConversationId>,
-    is_not_cloud_agent_context: bool,
+    is_cloud_agent_context: bool,
     ctx: &AppContext,
 ) -> ForkButtonAction {
-    if !is_not_cloud_agent_context
+    if is_cloud_agent_context
         && conversation_id.is_some_and(|id| conversation_is_cloud_oz_for_slash_command(id, ctx))
     {
         ForkButtonAction {

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -1401,7 +1401,7 @@ impl Input {
 /// keybinding-triggered execution can't fall through onto a non-cloud-Oz conversation after
 /// the menu has been recomputed. Mirrors `SlashCommandDataSource::active_conversation_is_cloud_oz`.
 #[cfg(not(target_family = "wasm"))]
-fn conversation_is_cloud_oz_for_slash_command(
+pub(crate) fn conversation_is_cloud_oz_for_slash_command(
     conversation_id: AIConversationId,
     ctx: &AppContext,
 ) -> bool {

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -1396,10 +1396,9 @@ impl Input {
     }
 }
 
-/// Returns true when the conversation with `conversation_id` is associated with a cloud Oz
-/// `AmbientAgentTask`. Used as the defensive runtime gate for `/continue-locally` so a
-/// keybinding-triggered execution can't fall through onto a non-cloud-Oz conversation after
-/// the menu has been recomputed. Mirrors `SlashCommandDataSource::active_conversation_is_cloud_oz`.
+/// Returns true when the conversation with `conversation_id` is associated with an Oz
+/// `AmbientAgentTask`. Callers deciding between `/fork` and `/continue-locally` should also
+/// check the same `NOT_CLOUD_AGENT` context that gates `/fork`.
 #[cfg(not(target_family = "wasm"))]
 pub(crate) fn conversation_is_cloud_oz_for_slash_command(
     conversation_id: AIConversationId,
@@ -1438,14 +1437,17 @@ pub(crate) struct ForkButtonAction {
 }
 
 /// Returns the tooltip and slash command for the fork button given an optional
-/// conversation ID. Uses `/continue-locally` for cloud Oz conversations where
-/// `/fork` is unavailable, and `/fork` otherwise.
+/// conversation ID. Uses `/continue-locally` for Oz conversations when `/fork`
+/// is unavailable in the current cloud-agent context, and `/fork` otherwise.
 #[cfg(not(target_family = "wasm"))]
 pub(crate) fn fork_button_action(
     conversation_id: Option<AIConversationId>,
+    is_not_cloud_agent_context: bool,
     ctx: &AppContext,
 ) -> ForkButtonAction {
-    if conversation_id.is_some_and(|id| conversation_is_cloud_oz_for_slash_command(id, ctx)) {
+    if !is_not_cloud_agent_context
+        && conversation_id.is_some_and(|id| conversation_is_cloud_oz_for_slash_command(id, ctx))
+    {
         ForkButtonAction {
             tooltip: "Continue locally",
             command_name: commands::CONTINUE_LOCALLY.name,

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -1429,6 +1429,35 @@ pub(crate) fn conversation_is_cloud_oz_for_slash_command(
     }
 }
 
+/// Tooltip and slash command name for the fork button, returned as a unit so
+/// callers rendering the button and callers inserting the command always agree.
+#[cfg(not(target_family = "wasm"))]
+pub(crate) struct ForkButtonAction {
+    pub tooltip: &'static str,
+    pub command_name: &'static str,
+}
+
+/// Returns the tooltip and slash command for the fork button given an optional
+/// conversation ID. Uses `/continue-locally` for cloud Oz conversations where
+/// `/fork` is unavailable, and `/fork` otherwise.
+#[cfg(not(target_family = "wasm"))]
+pub(crate) fn fork_button_action(
+    conversation_id: Option<AIConversationId>,
+    ctx: &AppContext,
+) -> ForkButtonAction {
+    if conversation_id.is_some_and(|id| conversation_is_cloud_oz_for_slash_command(id, ctx)) {
+        ForkButtonAction {
+            tooltip: "Continue locally",
+            command_name: commands::CONTINUE_LOCALLY.name,
+        }
+    } else {
+        ForkButtonAction {
+            tooltip: "Fork conversation",
+            command_name: commands::FORK.name,
+        }
+    }
+}
+
 #[cfg(test)]
 #[path = "mod_tests.rs"]
 mod tests;

--- a/app/src/terminal/input/slash_commands/mod_tests.rs
+++ b/app/src/terminal/input/slash_commands/mod_tests.rs
@@ -15,7 +15,7 @@ fn not_cloud_agent_commands_are_only_active_outside_cloud_mode() {
     assert!(!commands::NEW.is_active(cloud_context));
 
     let _cloud_mode_input_v2 = FeatureFlag::CloudModeInputV2.override_enabled(true);
-    let cloud_mode_v2_context = BASELINE_AVAILABILITY | Availability::CLOUD_AGENT_V2;
+    let cloud_mode_v2_context = BASELINE_AVAILABILITY | Availability::CLOUD_MODE_V2_COMPOSER;
     assert!(!commands::AGENT.is_active(cloud_mode_v2_context));
     assert!(!commands::NEW.is_active(cloud_mode_v2_context));
 }
@@ -26,7 +26,7 @@ fn cloud_mode_v2_commands_are_active_only_in_cloud_mode_v2_context() {
     assert!(!commands::HARNESS.is_active(cloud_context));
 
     let _cloud_mode_input_v2 = FeatureFlag::CloudModeInputV2.override_enabled(true);
-    let cloud_mode_v2_context = BASELINE_AVAILABILITY | Availability::CLOUD_AGENT_V2;
+    let cloud_mode_v2_context = BASELINE_AVAILABILITY | Availability::CLOUD_MODE_V2_COMPOSER;
     assert!(commands::PLAN.is_active(cloud_mode_v2_context));
     assert!(commands::MODEL.is_active(cloud_mode_v2_context));
     assert!(commands::HARNESS.is_active(cloud_mode_v2_context));

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -6698,6 +6698,49 @@ impl TerminalView {
         self.redetermine_global_focus(ctx);
     }
 
+    /// Inserts the appropriate fork-like slash command into the input:
+    /// `/continue-locally` for cloud Oz conversations, `/fork` for others.
+    pub(crate) fn insert_fork_or_continue_locally_slash_command(
+        &mut self,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let command_name = self.fork_or_continue_locally_command_name(ctx);
+        self.input.update(ctx, |input, ctx| {
+            input.replace_buffer_content(&format!("{} ", command_name), ctx);
+            ctx.focus_self();
+        });
+    }
+
+    /// Returns the slash command name for the fork button action.
+    /// Uses `/continue-locally` for cloud Oz conversations where `/fork` is unavailable.
+    fn fork_or_continue_locally_command_name(&self, ctx: &AppContext) -> &'static str {
+        #[cfg(not(target_family = "wasm"))]
+        if self.active_conversation_is_cloud_oz(ctx) {
+            return commands::CONTINUE_LOCALLY.name;
+        }
+        commands::FORK.name
+    }
+
+    /// Returns `true` when the active conversation is a cloud Oz run.
+    /// Mirrors `SlashCommandDataSource::active_conversation_is_cloud_oz`.
+    #[cfg(not(target_family = "wasm"))]
+    fn active_conversation_is_cloud_oz(&self, ctx: &AppContext) -> bool {
+        use crate::terminal::input::slash_commands::conversation_is_cloud_oz_for_slash_command;
+        let conversation_id = match self
+            .agent_view_controller
+            .as_ref(ctx)
+            .agent_view_state()
+            .active_conversation_id()
+        {
+            Some(id) => id,
+            None => match BlocklistAIHistoryModel::as_ref(ctx).active_conversation(self.view_id) {
+                Some(conv) => conv.id(),
+                None => return false,
+            },
+        };
+        conversation_is_cloud_oz_for_slash_command(conversation_id, ctx)
+    }
+
     fn handle_resume_conversation(
         &mut self,
         conversation_id: &AIConversationId,
@@ -20116,10 +20159,7 @@ impl TerminalView {
                 self.handle_resume_conversation(conversation_id, ctx);
             }
             AIBlockEvent::InsertForkSlashCommand => {
-                self.input.update(ctx, |input, ctx| {
-                    input.replace_buffer_content(&format!("{} ", commands::FORK.name), ctx);
-                    ctx.focus_self();
-                });
+                self.insert_fork_or_continue_locally_slash_command(ctx);
             }
             AIBlockEvent::ChildViewTextSelected => {
                 self.clear_selected_text_except(Some(block.id()), ctx);

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -20123,6 +20123,8 @@ impl TerminalView {
 
                 #[cfg(not(target_family = "wasm"))]
                 let command_name = {
+                    let is_not_cloud_agent_context = !(self.is_ambient_agent_session(ctx)
+                        || self.input.as_ref(ctx).is_cloud_mode_input_v2_composing(ctx));
                     let conversation_id = self
                         .agent_view_controller
                         .as_ref(ctx)
@@ -20133,7 +20135,8 @@ impl TerminalView {
                                 .active_conversation(self.view_id)
                                 .map(|conv| conv.id())
                         });
-                    fork_button_action(conversation_id, ctx).command_name
+                    fork_button_action(conversation_id, is_not_cloud_agent_context, ctx)
+                        .command_name
                 };
 
                 self.input.update(ctx, |input, ctx| {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -6711,34 +6711,27 @@ impl TerminalView {
         });
     }
 
-    /// Returns the slash command name for the fork button action.
-    /// Uses `/continue-locally` for cloud Oz conversations where `/fork` is unavailable.
+    /// Returns the slash command name for the fork button.
+    /// Delegates to `fork_button_action` to keep the command in sync with the tooltip.
     fn fork_or_continue_locally_command_name(&self, ctx: &AppContext) -> &'static str {
-        #[cfg(not(target_family = "wasm"))]
-        if self.active_conversation_is_cloud_oz(ctx) {
-            return commands::CONTINUE_LOCALLY.name;
-        }
-        commands::FORK.name
-    }
+        #[cfg(target_family = "wasm")]
+        return commands::FORK.name;
 
-    /// Returns `true` when the active conversation is a cloud Oz run.
-    /// Mirrors `SlashCommandDataSource::active_conversation_is_cloud_oz`.
-    #[cfg(not(target_family = "wasm"))]
-    fn active_conversation_is_cloud_oz(&self, ctx: &AppContext) -> bool {
-        use crate::terminal::input::slash_commands::conversation_is_cloud_oz_for_slash_command;
-        let conversation_id = match self
-            .agent_view_controller
-            .as_ref(ctx)
-            .agent_view_state()
-            .active_conversation_id()
+        #[cfg(not(target_family = "wasm"))]
         {
-            Some(id) => id,
-            None => match BlocklistAIHistoryModel::as_ref(ctx).active_conversation(self.view_id) {
-                Some(conv) => conv.id(),
-                None => return false,
-            },
-        };
-        conversation_is_cloud_oz_for_slash_command(conversation_id, ctx)
+            use crate::terminal::input::slash_commands::fork_button_action;
+            let conversation_id = self
+                .agent_view_controller
+                .as_ref(ctx)
+                .agent_view_state()
+                .active_conversation_id()
+                .or_else(|| {
+                    BlocklistAIHistoryModel::as_ref(ctx)
+                        .active_conversation(self.view_id)
+                        .map(|conv| conv.id())
+                });
+            fork_button_action(conversation_id, ctx).command_name
+        }
     }
 
     fn handle_resume_conversation(

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -406,6 +406,8 @@ use crate::terminal::general_settings::GeneralSettings;
 use crate::terminal::grid_size_util::grid_cell_dimensions;
 use crate::terminal::input::decorations::InputBackgroundJobOptions;
 use crate::terminal::input::inline_menu::InlineMenuPositioner;
+#[cfg(not(target_family = "wasm"))]
+use crate::terminal::input::slash_commands::fork_button_action;
 use crate::terminal::input::{
     CommandExecutionSource, InputAction, InputEmptyStateChangeReason, InputState, MenuPositioning,
     MenuPositioningProvider,
@@ -6696,42 +6698,6 @@ impl TerminalView {
 
         // Focus the input
         self.redetermine_global_focus(ctx);
-    }
-
-    /// Inserts the appropriate fork-like slash command into the input:
-    /// `/continue-locally` for cloud Oz conversations, `/fork` for others.
-    pub(crate) fn insert_fork_or_continue_locally_slash_command(
-        &mut self,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        let command_name = self.fork_or_continue_locally_command_name(ctx);
-        self.input.update(ctx, |input, ctx| {
-            input.replace_buffer_content(&format!("{} ", command_name), ctx);
-            ctx.focus_self();
-        });
-    }
-
-    /// Returns the slash command name for the fork button.
-    /// Delegates to `fork_button_action` to keep the command in sync with the tooltip.
-    fn fork_or_continue_locally_command_name(&self, ctx: &AppContext) -> &'static str {
-        #[cfg(target_family = "wasm")]
-        return commands::FORK.name;
-
-        #[cfg(not(target_family = "wasm"))]
-        {
-            use crate::terminal::input::slash_commands::fork_button_action;
-            let conversation_id = self
-                .agent_view_controller
-                .as_ref(ctx)
-                .agent_view_state()
-                .active_conversation_id()
-                .or_else(|| {
-                    BlocklistAIHistoryModel::as_ref(ctx)
-                        .active_conversation(self.view_id)
-                        .map(|conv| conv.id())
-                });
-            fork_button_action(conversation_id, ctx).command_name
-        }
     }
 
     fn handle_resume_conversation(
@@ -20152,7 +20118,28 @@ impl TerminalView {
                 self.handle_resume_conversation(conversation_id, ctx);
             }
             AIBlockEvent::InsertForkSlashCommand => {
-                self.insert_fork_or_continue_locally_slash_command(ctx);
+                #[cfg(target_family = "wasm")]
+                let command_name = commands::FORK.name;
+
+                #[cfg(not(target_family = "wasm"))]
+                let command_name = {
+                    let conversation_id = self
+                        .agent_view_controller
+                        .as_ref(ctx)
+                        .agent_view_state()
+                        .active_conversation_id()
+                        .or_else(|| {
+                            BlocklistAIHistoryModel::as_ref(ctx)
+                                .active_conversation(self.view_id)
+                                .map(|conv| conv.id())
+                        });
+                    fork_button_action(conversation_id, ctx).command_name
+                };
+
+                self.input.update(ctx, |input, ctx| {
+                    input.replace_buffer_content(&format!("{} ", command_name), ctx);
+                    ctx.focus_self();
+                });
             }
             AIBlockEvent::ChildViewTextSelected => {
                 self.clear_selected_text_except(Some(block.id()), ctx);

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -20123,8 +20123,8 @@ impl TerminalView {
 
                 #[cfg(not(target_family = "wasm"))]
                 let command_name = {
-                    let is_not_cloud_agent_context = !(self.is_ambient_agent_session(ctx)
-                        || self.input.as_ref(ctx).is_cloud_mode_input_v2_composing(ctx));
+                    let is_cloud_agent_context = self.is_ambient_agent_session(ctx)
+                        || self.input.as_ref(ctx).is_cloud_mode_input_v2_composing(ctx);
                     let conversation_id = self
                         .agent_view_controller
                         .as_ref(ctx)
@@ -20135,8 +20135,7 @@ impl TerminalView {
                                 .active_conversation(self.view_id)
                                 .map(|conv| conv.id())
                         });
-                    fork_button_action(conversation_id, is_not_cloud_agent_context, ctx)
-                        .command_name
+                    fork_button_action(conversation_id, is_cloud_agent_context, ctx).command_name
                 };
 
                 self.input.update(ctx, |input, ctx| {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -307,7 +307,6 @@ use crate::search::command_search::searcher::{
 };
 use crate::search::command_search::settings::CommandSearchSettings;
 use crate::search::command_search::view::{CommandSearchEvent, CommandSearchView};
-use crate::search::slash_command_menu::static_commands::commands;
 use crate::search::{self, QueryFilter};
 use crate::server::cloud_objects::update_manager::{
     ObjectOperation, OperationSuccessType, UpdateManager, UpdateManagerEvent,
@@ -24633,13 +24632,7 @@ impl TypedActionView for Workspace {
                 self.active_tab_pane_group().update(ctx, |pane_group, ctx| {
                     if let Some(terminal_view) = pane_group.active_session_view(ctx) {
                         terminal_view.update(ctx, |terminal, ctx| {
-                            terminal.input().update(ctx, |input, ctx| {
-                                input.replace_buffer_content(
-                                    &format!("{} ", commands::FORK.name),
-                                    ctx,
-                                );
-                                ctx.focus_self();
-                            });
+                            terminal.insert_fork_or_continue_locally_slash_command(ctx);
                         });
                     }
                 });

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -307,6 +307,8 @@ use crate::search::command_search::searcher::{
 };
 use crate::search::command_search::settings::CommandSearchSettings;
 use crate::search::command_search::view::{CommandSearchEvent, CommandSearchView};
+#[cfg(target_family = "wasm")]
+use crate::search::slash_command_menu::static_commands::commands;
 use crate::search::{self, QueryFilter};
 use crate::server::cloud_objects::update_manager::{
     ObjectOperation, OperationSuccessType, UpdateManager, UpdateManagerEvent,
@@ -371,6 +373,8 @@ use crate::terminal::enable_auto_reload_modal::{
     EnableAutoReloadModal, EnableAutoReloadModalEvent,
 };
 use crate::terminal::general_settings::GeneralSettings;
+#[cfg(not(target_family = "wasm"))]
+use crate::terminal::input::slash_commands::fork_button_action;
 use crate::terminal::input::{Input, MenuPositioning};
 use crate::terminal::keys_settings::KeysSettings;
 use crate::terminal::ligature_settings::should_use_ligature_rendering;
@@ -24632,7 +24636,24 @@ impl TypedActionView for Workspace {
                 self.active_tab_pane_group().update(ctx, |pane_group, ctx| {
                     if let Some(terminal_view) = pane_group.active_session_view(ctx) {
                         terminal_view.update(ctx, |terminal, ctx| {
-                            terminal.insert_fork_or_continue_locally_slash_command(ctx);
+                            #[cfg(target_family = "wasm")]
+                            let command_name = commands::FORK.name;
+
+                            #[cfg(not(target_family = "wasm"))]
+                            let command_name = {
+                                let conversation_id =
+                                    terminal.active_conversation_id(ctx).or_else(|| {
+                                        BlocklistAIHistoryModel::as_ref(ctx)
+                                            .active_conversation(terminal.id())
+                                            .map(|conv| conv.id())
+                                    });
+                                fork_button_action(conversation_id, ctx).command_name
+                            };
+
+                            terminal.input().update(ctx, |input, ctx| {
+                                input.replace_buffer_content(&format!("{} ", command_name), ctx);
+                                ctx.focus_self();
+                            });
                         });
                     }
                 });

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -24641,13 +24641,20 @@ impl TypedActionView for Workspace {
 
                             #[cfg(not(target_family = "wasm"))]
                             let command_name = {
+                                let is_not_cloud_agent_context = !(terminal
+                                    .is_ambient_agent_session(ctx)
+                                    || terminal
+                                        .input()
+                                        .as_ref(ctx)
+                                        .is_cloud_mode_input_v2_composing(ctx));
                                 let conversation_id =
                                     terminal.active_conversation_id(ctx).or_else(|| {
                                         BlocklistAIHistoryModel::as_ref(ctx)
                                             .active_conversation(terminal.id())
                                             .map(|conv| conv.id())
                                     });
-                                fork_button_action(conversation_id, ctx).command_name
+                                fork_button_action(conversation_id, is_not_cloud_agent_context, ctx)
+                                    .command_name
                             };
 
                             terminal.input().update(ctx, |input, ctx| {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -24641,19 +24641,18 @@ impl TypedActionView for Workspace {
 
                             #[cfg(not(target_family = "wasm"))]
                             let command_name = {
-                                let is_not_cloud_agent_context = !(terminal
-                                    .is_ambient_agent_session(ctx)
+                                let is_cloud_agent_context = terminal.is_ambient_agent_session(ctx)
                                     || terminal
                                         .input()
                                         .as_ref(ctx)
-                                        .is_cloud_mode_input_v2_composing(ctx));
+                                        .is_cloud_mode_input_v2_composing(ctx);
                                 let conversation_id =
                                     terminal.active_conversation_id(ctx).or_else(|| {
                                         BlocklistAIHistoryModel::as_ref(ctx)
                                             .active_conversation(terminal.id())
                                             .map(|conv| conv.id())
                                     });
-                                fork_button_action(conversation_id, is_not_cloud_agent_context, ctx)
+                                fork_button_action(conversation_id, is_cloud_agent_context, ctx)
                                     .command_name
                             };
 


### PR DESCRIPTION
## Description

When in a cloud agent conversation, the fork button in the ai block footer inserts the `/fork` command into the input even though `/fork` isn't available in cloud agent conversations. This PR changes it so that, in cloud conversations, this button now inserts `/continue-locally` instead (with a tooltip for continuing locally instead of forking).

Relatedly, while working on this PR I noticed that we don't provide the `/fork` option for cloud conversations, but we _do_ provide the `/continue-locally` button in all contexts, including local conversations. I changed it so that we get rid of the `/continue-locally` command in local conversations, as this option doesn't really make sense in that context.

Finally, I changed it so that we stop hiding the `/fork` option in cloud mode conversations. I think this command is completely valid in cloud mode conversations, even if it's duplicative of /continue-locally (which we just added for extra visibility's sake). We still filter the `/fork` option out when we're in the cloud mode v2 composer, but once we're in a regular cloud conversation I think it makes sense for this slash command to be available.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

## Demo

https://www.loom.com/share/5ab05b909ca14257b73aead5d5167b4f

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode