### PR TITLE
Ship channel-specific warpctrl wrappers and PATH install support

### DIFF
--- a/app/src/ai/skills/bundled.rs
+++ b/app/src/ai/skills/bundled.rs
@@ -359,6 +359,8 @@ pub(crate) async fn read_bundled_skills(
 /// Supported variables:
 /// - `{{warp_server_url}}` - The server root URL (e.g., `https://api.warp.dev`)
 /// - `{{warp_cli_binary_name}}` - The CLI binary name (e.g., `warp` or `warp-cli`)
+/// - `{{warpctrl_binary_name}}` - The channel-specific Warp Control command name
+/// - `{{warpctrl_wrapper_path}}` - Path to the bundled Warp Control wrapper
 /// - `{{warp_url_scheme}}` - The URL scheme (e.g., `warp`, `warpdev`, `warppreview`)
 /// - `{{settings_schema_path}}` - Path to the bundled JSON settings schema
 /// - `{{skill_dir}}` - Path to the bundled skill's directory
@@ -376,6 +378,18 @@ pub(crate) fn build_bundled_skill_context(
         (
             "warp_cli_binary_name".to_owned(),
             ChannelState::channel().cli_command_name().to_owned(),
+        ),
+        (
+            "warpctrl_binary_name".to_owned(),
+            ChannelState::channel().warpctrl_command_name().to_owned(),
+        ),
+        (
+            "warpctrl_wrapper_path".to_owned(),
+            resources_dir
+                .join("bin")
+                .join(ChannelState::channel().warpctrl_command_name())
+                .display()
+                .to_string(),
         ),
         (
             "warp_url_scheme".to_owned(),

--- a/app/src/ai/skills/skill_manager_tests.rs
+++ b/app/src/ai/skills/skill_manager_tests.rs
@@ -392,6 +392,7 @@ description: Test skill with variables
 ---
 
 Run `{{warp_cli_binary_name}}` to connect to {{warp_server_url}}.
+Use `{{warpctrl_binary_name}}` from {{warpctrl_wrapper_path}}.
 "#,
     )
     .unwrap();
@@ -405,6 +406,12 @@ Run `{{warp_cli_binary_name}}` to connect to {{warp_server_url}}.
     let expected_url = ChannelState::server_root_url();
     assert!(skill.content.contains(&format!(
         "Run `{expected_cli}` to connect to {expected_url}."
+    )));
+    let expected_warpctrl = ChannelState::channel().warpctrl_command_name();
+    let expected_wrapper = resources_dir.join("bin").join(expected_warpctrl);
+    assert!(skill.content.contains(&format!(
+        "Use `{expected_warpctrl}` from {}.",
+        expected_wrapper.display()
     )));
 }
 
@@ -515,9 +522,11 @@ fn test_build_bundled_skill_context() {
     let skill_dir = resources_dir.join("bundled/skills/test-skill");
     let context = build_bundled_skill_context(resources_dir, &skill_dir);
 
-    assert_eq!(context.len(), 7);
+    assert_eq!(context.len(), 9);
     assert!(context.contains_key("warp_server_url"));
     assert!(context.contains_key("warp_cli_binary_name"));
+    assert!(context.contains_key("warpctrl_binary_name"));
+    assert!(context.contains_key("warpctrl_wrapper_path"));
     assert!(context.contains_key("warp_url_scheme"));
     assert!(context.contains_key("settings_file_path"));
     assert!(context.contains_key("keybindings_file_path"));
@@ -540,6 +549,18 @@ fn test_build_bundled_skill_context() {
     assert_eq!(
         context.get("warp_cli_binary_name").unwrap(),
         ChannelState::channel().cli_command_name()
+    );
+    assert_eq!(
+        context.get("warpctrl_binary_name").unwrap(),
+        ChannelState::channel().warpctrl_command_name()
+    );
+    assert_eq!(
+        context.get("warpctrl_wrapper_path").unwrap(),
+        &resources_dir
+            .join("bin")
+            .join(ChannelState::channel().warpctrl_command_name())
+            .display()
+            .to_string()
     );
     assert_eq!(
         context.get("warp_url_scheme").unwrap(),

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -580,7 +580,11 @@ fn apply_scroll_multiplier(event: &mut Event, app: &AppContext) {
     }
 }
 
-/// Runs the app. If a subcommand was requested, it'll be run instead of the main application.
+/// Runs the shared Warp executable as the app or as one of its command-line modes.
+///
+/// The bundled Warp Control wrapper injects `--warpctrl`, which is dispatched
+/// before the normal Warp/Oz parser. Oz subcommands are part of that normal
+/// parser and therefore do not require a separate mode flag.
 #[::tracing::instrument(skip_all, fields(tags.cloud_agent = true))]
 pub fn run() -> Result<()> {
     // Perform any necessary platform-specific initialization.

--- a/app/src/settings_view/scripting_page.rs
+++ b/app/src/settings_view/scripting_page.rs
@@ -3,7 +3,13 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 
 use settings::Setting as _;
+#[cfg(target_os = "macos")]
+use warp_core::channel::ChannelState;
 use warpui::elements::{ChildView, Element, MouseStateHandle};
+#[cfg(target_os = "macos")]
+use warpui::ui_components::button::ButtonVariant;
+#[cfg(target_os = "macos")]
+use warpui::ui_components::components::UiComponent;
 use warpui::{AppContext, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle};
 
 use super::settings_page::{
@@ -15,17 +21,25 @@ use crate::appearance::Appearance;
 use crate::features::FeatureFlag;
 use crate::report_if_error;
 use crate::settings::{LocalControlMode, LocalControlModeSetting, LocalControlSettings};
+#[cfg(target_os = "macos")]
+use crate::view_components::DismissibleToast;
 use crate::view_components::{Dropdown, DropdownItem};
+#[cfg(target_os = "macos")]
+use crate::workspace::{cli_install, ToastStack};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ScriptingSettingsPageAction {
     SetLocalControlMode(LocalControlMode),
+    #[cfg(target_os = "macos")]
+    InstallWarpControlCli,
 }
 
 pub struct ScriptingSettingsPageView {
     page: PageType<Self>,
     local_only_icon_tooltip_states: RefCell<HashMap<String, MouseStateHandle>>,
     local_control_mode_dropdown: ViewHandle<Dropdown<ScriptingSettingsPageAction>>,
+    #[cfg(target_os = "macos")]
+    warpctrl_installing: bool,
 }
 
 impl ScriptingSettingsPageView {
@@ -47,13 +61,21 @@ impl ScriptingSettingsPageView {
             });
         }
 
+        #[cfg(target_os = "macos")]
+        let widgets: Vec<Box<dyn SettingsWidget<View = Self>>> = vec![
+            Box::new(WarpControlCliInstallWidget::default()),
+            Box::new(LocalControlModeWidget),
+        ];
+        #[cfg(not(target_os = "macos"))]
+        let widgets: Vec<Box<dyn SettingsWidget<View = Self>>> =
+            vec![Box::new(LocalControlModeWidget)];
+
         Self {
-            page: PageType::new_uncategorized(
-                vec![Box::new(LocalControlModeWidget)],
-                Some("Scripting"),
-            ),
+            page: PageType::new_uncategorized(widgets, Some("Scripting")),
             local_only_icon_tooltip_states: RefCell::new(HashMap::new()),
             local_control_mode_dropdown,
+            #[cfg(target_os = "macos")]
+            warpctrl_installing: false,
         }
     }
 
@@ -81,6 +103,50 @@ impl ScriptingSettingsPageView {
             );
         });
     }
+
+    #[cfg(target_os = "macos")]
+    fn install_warpctrl(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.warpctrl_installing || cli_install::is_warpctrl_installed() {
+            return;
+        }
+
+        self.warpctrl_installing = true;
+        ctx.notify();
+        let window_id = ctx.window_id();
+        ctx.spawn(
+            async { cli_install::install_warpctrl() },
+            move |view, result, ctx| {
+                view.warpctrl_installing = false;
+                match result {
+                    Ok(()) => {
+                        let command_name = ChannelState::channel().warpctrl_command_name();
+                        let message = format!(
+                            "Successfully installed the Warp Control CLI! You can now run '{command_name}' from the command line."
+                        );
+                        ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                            toast_stack.add_ephemeral_toast(
+                                DismissibleToast::success(message),
+                                window_id,
+                                ctx,
+                            );
+                        });
+                    }
+                    Err(error) => {
+                        let message = format!("Failed to install Warp Control command: {error}");
+                        log::warn!("{message}");
+                        ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                            toast_stack.add_persistent_toast(
+                                DismissibleToast::error(message),
+                                window_id,
+                                ctx,
+                            );
+                        });
+                    }
+                }
+                ctx.notify();
+            },
+        );
+    }
 }
 
 impl Entity for ScriptingSettingsPageView {
@@ -98,6 +164,8 @@ impl TypedActionView for ScriptingSettingsPageView {
                 });
                 ctx.notify();
             }
+            #[cfg(target_os = "macos")]
+            ScriptingSettingsPageAction::InstallWarpControlCli => self.install_warpctrl(ctx),
         }
     }
 }
@@ -140,6 +208,67 @@ impl From<ViewHandle<ScriptingSettingsPageView>> for SettingsPageViewHandle {
     }
 }
 
+#[cfg(target_os = "macos")]
+#[derive(Default)]
+struct WarpControlCliInstallWidget {
+    install_button_mouse_state: MouseStateHandle,
+}
+
+#[cfg(target_os = "macos")]
+impl SettingsWidget for WarpControlCliInstallWidget {
+    type View = ScriptingSettingsPageView;
+
+    fn search_terms(&self) -> &str {
+        "warp control cli command warpctrl install scripting"
+    }
+
+    fn render(
+        &self,
+        view: &Self::View,
+        appearance: &Appearance,
+        _app: &AppContext,
+    ) -> Box<dyn Element> {
+        let installed = cli_install::is_warpctrl_installed();
+        let disabled = view.warpctrl_installing || installed;
+        let label = if view.warpctrl_installing {
+            "Installing…"
+        } else if installed {
+            "Installed"
+        } else {
+            "Install"
+        };
+        let mut button = appearance
+            .ui_builder()
+            .button(
+                ButtonVariant::Secondary,
+                self.install_button_mouse_state.clone(),
+            )
+            .with_text_label(label.to_owned());
+        if disabled {
+            button = button.disabled();
+        }
+        let button = if disabled {
+            button.build().finish()
+        } else {
+            button
+                .build()
+                .on_click(|ctx, _, _| {
+                    ctx.dispatch_typed_action(ScriptingSettingsPageAction::InstallWarpControlCli);
+                })
+                .finish()
+        };
+
+        render_body_item::<ScriptingSettingsPageAction>(
+            "Warp Control CLI command".into(),
+            None,
+            LocalOnlyIconState::Hidden,
+            ToggleState::Enabled,
+            appearance,
+            button,
+            Some("Install the warpctrl command for scripting Warp from your terminal.".to_owned()),
+        )
+    }
+}
 struct LocalControlModeWidget;
 
 impl SettingsWidget for LocalControlModeWidget {

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -629,6 +629,12 @@ pub enum WorkspaceAction {
     /// Uninstall the Warp CLI command from /usr/local/bin
     #[cfg(target_os = "macos")]
     UninstallCLI,
+    /// Install the Warp Control CLI command to /usr/local/bin
+    #[cfg(target_os = "macos")]
+    InstallWarpctrl,
+    /// Uninstall the Warp Control CLI command from /usr/local/bin
+    #[cfg(target_os = "macos")]
+    UninstallWarpctrl,
     UndoRevertInCodeReviewPane {
         window_id: WindowId,
         view_id: EntityId,
@@ -1134,6 +1140,8 @@ impl WorkspaceAction {
             SampleProcess => false,
             #[cfg(target_os = "macos")]
             InstallCLI | UninstallCLI => false,
+            #[cfg(target_os = "macos")]
+            InstallWarpctrl | UninstallWarpctrl => false,
             #[cfg(feature = "local_fs")]
             FileRenamed { .. } => false, // File rename doesn't change workspace state
             #[cfg(feature = "local_fs")]

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -623,12 +623,12 @@ pub enum WorkspaceAction {
         /// Optional prompt to send after summarization completes successfully.
         initial_prompt: Option<String>,
     },
-    /// Install the Warp CLI command to /usr/local/bin
+    /// Install the Oz CLI command to /usr/local/bin
     #[cfg(target_os = "macos")]
-    InstallCLI,
-    /// Uninstall the Warp CLI command from /usr/local/bin
+    InstallOz,
+    /// Uninstall the Oz CLI command from /usr/local/bin
     #[cfg(target_os = "macos")]
-    UninstallCLI,
+    UninstallOz,
     /// Install the Warp Control CLI command to /usr/local/bin
     #[cfg(target_os = "macos")]
     InstallWarpctrl,
@@ -1139,7 +1139,7 @@ impl WorkspaceAction {
             #[cfg(target_os = "macos")]
             SampleProcess => false,
             #[cfg(target_os = "macos")]
-            InstallCLI | UninstallCLI => false,
+            InstallOz | UninstallOz => false,
             #[cfg(target_os = "macos")]
             InstallWarpctrl | UninstallWarpctrl => false,
             #[cfg(feature = "local_fs")]

--- a/app/src/workspace/cli_install.rs
+++ b/app/src/workspace/cli_install.rs
@@ -108,6 +108,11 @@ fn remove_file_with_admin(target: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Install a channel-specific CLI symlink.
+///
+/// The target must either be absent or already be a symlink. Installation first
+/// attempts to create the symlink without elevated privileges, then falls back
+/// to prompting for administrator privileges.
 fn install_symlink(source: &Path, target: &Path, command_name: &str) -> Result<()> {
     if target.exists() && !target.is_symlink() {
         return Err(anyhow!(
@@ -135,6 +140,11 @@ fn install_symlink(source: &Path, target: &Path, command_name: &str) -> Result<(
     Ok(())
 }
 
+/// Uninstall a channel-specific CLI symlink.
+///
+/// The target must be a symlink so uninstalling cannot remove an unrelated
+/// file. Removal first runs without elevated privileges, then falls back to
+/// prompting for administrator privileges.
 fn uninstall_symlink(target: &Path, command_name: &str) -> Result<()> {
     if !target.exists() {
         return Err(anyhow!("{command_name} is not currently installed."));

--- a/app/src/workspace/cli_install.rs
+++ b/app/src/workspace/cli_install.rs
@@ -8,7 +8,7 @@ use warp_core::channel::ChannelState;
 use warp_util::path::ShellFamily;
 
 /// Compute the target path where the Oz CLI symlink should be installed, based on channel
-fn cli_install_target_path() -> PathBuf {
+fn oz_install_target_path() -> PathBuf {
     PathBuf::from("/usr/local/bin").join(ChannelState::channel().cli_command_name())
 }
 
@@ -18,6 +18,9 @@ fn warpctrl_install_target_path() -> PathBuf {
 }
 
 /// Compute the source path of the warpctrl wrapper inside the current app bundle.
+///
+/// Warp Control needs the wrapper as its symlink source because the wrapper adds
+/// the hidden `--warpctrl` flag. Oz can symlink directly to the current executable.
 fn warpctrl_bundle_source_path() -> Result<PathBuf> {
     let current_binary =
         std::env::current_exe().context("Failed to get current executable path")?;
@@ -173,16 +176,16 @@ fn uninstall_symlink(target: &Path, command_name: &str) -> Result<()> {
 }
 
 /// Install the Oz CLI by creating a symlink in /usr/local/bin
-pub fn install_cli() -> Result<()> {
-    let cli_path = cli_install_target_path();
+pub fn install_oz() -> Result<()> {
+    let oz_path = oz_install_target_path();
     let current_binary =
         std::env::current_exe().context("Failed to get current executable path")?;
-    install_symlink(&current_binary, &cli_path, "Oz CLI")
+    install_symlink(&current_binary, &oz_path, "Oz CLI")
 }
 
 /// Uninstall the Oz CLI by removing the symlink from /usr/local/bin
-pub fn uninstall_cli() -> Result<()> {
-    uninstall_symlink(&cli_install_target_path(), "Oz command")
+pub fn uninstall_oz() -> Result<()> {
+    uninstall_symlink(&oz_install_target_path(), "Oz command")
 }
 
 /// Install the Warp Control CLI by creating a symlink in /usr/local/bin

--- a/app/src/workspace/cli_install.rs
+++ b/app/src/workspace/cli_install.rs
@@ -37,6 +37,23 @@ fn warpctrl_bundle_source_path() -> Result<PathBuf> {
         .join("Contents/Resources/bin")
         .join(ChannelState::channel().warpctrl_command_name()))
 }
+fn path_resolves_to(path: &Path, expected_path: &Path) -> bool {
+    let Ok(path) = path.canonicalize() else {
+        return false;
+    };
+    let Ok(expected_path) = expected_path.canonicalize() else {
+        return false;
+    };
+    path == expected_path
+}
+
+/// Whether the installed Warp Control command resolves to this app bundle's wrapper.
+pub fn is_warpctrl_installed() -> bool {
+    let Ok(source) = warpctrl_bundle_source_path() else {
+        return false;
+    };
+    path_resolves_to(&warpctrl_install_target_path(), &source)
+}
 
 /// Create a symlink with elevated privileges using osascript
 ///
@@ -220,3 +237,7 @@ pub fn install_warpctrl() -> Result<()> {
 pub fn uninstall_warpctrl() -> Result<()> {
     uninstall_symlink(&warpctrl_install_target_path(), "Warp Control command")
 }
+
+#[cfg(test)]
+#[path = "cli_install_tests.rs"]
+mod tests;

--- a/app/src/workspace/cli_install.rs
+++ b/app/src/workspace/cli_install.rs
@@ -7,9 +7,28 @@ use command::blocking::Command;
 use warp_core::channel::ChannelState;
 use warp_util::path::ShellFamily;
 
-/// Compute the target path where the symlink should be installed, based on channel
+/// Compute the target path where the Oz CLI symlink should be installed, based on channel
 fn cli_install_target_path() -> PathBuf {
     PathBuf::from("/usr/local/bin").join(ChannelState::channel().cli_command_name())
+}
+
+/// Compute the target path where the Warp Control symlink should be installed, based on channel
+fn warpctrl_install_target_path() -> PathBuf {
+    PathBuf::from("/usr/local/bin").join(ChannelState::channel().warpctrl_command_name())
+}
+
+/// Compute the source path of the warpctrl wrapper inside the current app bundle.
+fn warpctrl_bundle_source_path() -> Result<PathBuf> {
+    let current_binary =
+        std::env::current_exe().context("Failed to get current executable path")?;
+    let bundle_root = current_binary
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+        .ok_or_else(|| anyhow!("Current executable is not inside a bundled app"))?;
+    Ok(bundle_root
+        .join("Contents/Resources/bin")
+        .join(ChannelState::channel().warpctrl_command_name()))
 }
 
 /// Create a symlink with elevated privileges using osascript
@@ -89,87 +108,89 @@ fn remove_file_with_admin(target: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Install the CLI by creating a symlink (channel-specific target)
-///
-/// This function:
-/// 1. Detects the current Warp channel and finds the appropriate binary
-/// 2. Attempts to create a symlink without admin privileges first
-/// 3. Falls back to prompting for admin privileges if needed
-/// 4. Handles existing installations and edge cases
-pub fn install_cli() -> Result<()> {
-    let cli_path = cli_install_target_path();
-    let current_binary =
-        std::env::current_exe().context("Failed to get current executable path")?;
-
-    // Check if target file exists and handle conflicts
-    if cli_path.exists() && !cli_path.is_symlink() {
+fn install_symlink(source: &Path, target: &Path, command_name: &str) -> Result<()> {
+    if target.exists() && !target.is_symlink() {
         return Err(anyhow!(
-            "Cannot install: {:?} exists but is not a symlink. Please remove it manually first.",
-            cli_path
+            "Cannot install {command_name}: {:?} exists but is not a symlink. Please remove it manually first.",
+            target
         ));
     }
 
-    // Try to create symlink without admin privileges first
-    let symlink_result = symlink(&current_binary, &cli_path);
-
-    match symlink_result {
+    match symlink(source, target) {
         Ok(_) => {
             log::debug!(
-                "CLI installed successfully without admin privileges: {:?} -> {}",
-                cli_path,
-                current_binary.display()
+                "{command_name} installed successfully without admin privileges: {:?} -> {}",
+                target,
+                source.display()
             );
         }
         Err(_) => {
-            log::debug!("Symlink creation failed, trying with admin privileges");
-
-            create_symlink_with_admin(&current_binary, &cli_path)
+            log::debug!("{command_name} symlink creation failed, trying with admin privileges");
+            create_symlink_with_admin(source, target)
                 .context("Failed to create symlink even with admin privileges")?;
-
-            log::debug!("CLI installed successfully with admin privileges");
+            log::debug!("{command_name} installed successfully with admin privileges");
         }
     }
 
     Ok(())
 }
 
-/// Uninstall the CLI by removing the symlink (channel-specific target)
-///
-/// This function:
-/// 1. Verifies that the target is actually a symlink (safety check)
-/// 2. Attempts to remove without admin privileges first
-/// 3. Falls back to prompting for admin privileges if needed
-pub fn uninstall_cli() -> Result<()> {
-    let cli_path = cli_install_target_path();
-
-    if !cli_path.exists() {
-        return Err(anyhow!("Oz command is not currently installed."));
+fn uninstall_symlink(target: &Path, command_name: &str) -> Result<()> {
+    if !target.exists() {
+        return Err(anyhow!("{command_name} is not currently installed."));
     }
 
-    // Safety check: verify it's actually a symlink before removing
-    if !cli_path.is_symlink() {
+    if !target.is_symlink() {
         return Err(anyhow!(
-            "Cannot uninstall: {:?} exists but is not a symlink. Please remove it manually.",
-            cli_path
+            "Cannot uninstall {command_name}: {:?} exists but is not a symlink. Please remove it manually.",
+            target
         ));
     }
 
-    // Try to remove without admin privileges first
-    let remove_result = fs::remove_file(&cli_path);
-
-    match remove_result {
+    match fs::remove_file(target) {
         Ok(_) => {
-            log::debug!("CLI uninstalled successfully without admin privileges");
+            log::debug!("{command_name} uninstalled successfully without admin privileges");
         }
         Err(_) => {
-            log::debug!("File removal failed, trying with admin privileges");
-
-            remove_file_with_admin(&cli_path)
+            log::debug!("{command_name} file removal failed, trying with admin privileges");
+            remove_file_with_admin(target)
                 .context("Failed to remove symlink even with admin privileges")?;
-
-            log::debug!("CLI uninstalled successfully with admin privileges");
+            log::debug!("{command_name} uninstalled successfully with admin privileges");
         }
     }
 
     Ok(())
+}
+
+/// Install the Oz CLI by creating a symlink in /usr/local/bin
+pub fn install_cli() -> Result<()> {
+    let cli_path = cli_install_target_path();
+    let current_binary =
+        std::env::current_exe().context("Failed to get current executable path")?;
+    install_symlink(&current_binary, &cli_path, "Oz CLI")
+}
+
+/// Uninstall the Oz CLI by removing the symlink from /usr/local/bin
+pub fn uninstall_cli() -> Result<()> {
+    uninstall_symlink(&cli_install_target_path(), "Oz command")
+}
+
+/// Install the Warp Control CLI by creating a symlink in /usr/local/bin
+pub fn install_warpctrl() -> Result<()> {
+    let warpctrl_path = warpctrl_install_target_path();
+    let warpctrl_source = warpctrl_bundle_source_path()?;
+
+    if !warpctrl_source.exists() {
+        return Err(anyhow!(
+            "Cannot install Warp Control CLI: bundled wrapper not found at {}",
+            warpctrl_source.display()
+        ));
+    }
+
+    install_symlink(&warpctrl_source, &warpctrl_path, "Warp Control CLI")
+}
+
+/// Uninstall the Warp Control CLI by removing the symlink from /usr/local/bin
+pub fn uninstall_warpctrl() -> Result<()> {
+    uninstall_symlink(&warpctrl_install_target_path(), "Warp Control command")
 }

--- a/app/src/workspace/cli_install.rs
+++ b/app/src/workspace/cli_install.rs
@@ -19,8 +19,12 @@ fn warpctrl_install_target_path() -> PathBuf {
 
 /// Compute the source path of the warpctrl wrapper inside the current app bundle.
 ///
-/// Warp Control needs the wrapper as its symlink source because the wrapper adds
-/// the hidden `--warpctrl` flag. Oz can symlink directly to the current executable.
+/// Oz commands are part of the shared executable's normal argument parser, so
+/// Oz can symlink directly to the current executable. Warp Control has a
+/// separate parser selected by the hidden `--warpctrl` flag, so its installed
+/// symlink must target the bundled wrapper that injects that flag. Without it,
+/// Warp Control subcommands such as `tab` would reach the normal parser and be
+/// rejected as unknown.
 fn warpctrl_bundle_source_path() -> Result<PathBuf> {
     let current_binary =
         std::env::current_exe().context("Failed to get current executable path")?;
@@ -175,7 +179,11 @@ fn uninstall_symlink(target: &Path, command_name: &str) -> Result<()> {
     Ok(())
 }
 
-/// Install the Oz CLI by creating a symlink in /usr/local/bin
+/// Install the Oz CLI by symlinking the shared Warp executable into /usr/local/bin.
+///
+/// The normal argument parser dispatches Oz subcommands directly. It also uses
+/// the `oz`-prefixed invocation name to print CLI help rather than launch the
+/// GUI when no subcommand is provided.
 pub fn install_oz() -> Result<()> {
     let oz_path = oz_install_target_path();
     let current_binary =
@@ -188,7 +196,12 @@ pub fn uninstall_oz() -> Result<()> {
     uninstall_symlink(&oz_install_target_path(), "Oz command")
 }
 
-/// Install the Warp Control CLI by creating a symlink in /usr/local/bin
+/// Install Warp Control by symlinking its bundled wrapper into /usr/local/bin.
+///
+/// The wrapper contains no control implementation. It resolves this installed
+/// symlink back into the app bundle, launches the shared Warp executable, and
+/// injects `--warpctrl` so startup selects the separate Warp Control parser
+/// before normal parsing or GUI startup.
 pub fn install_warpctrl() -> Result<()> {
     let warpctrl_path = warpctrl_install_target_path();
     let warpctrl_source = warpctrl_bundle_source_path()?;

--- a/app/src/workspace/cli_install_tests.rs
+++ b/app/src/workspace/cli_install_tests.rs
@@ -1,0 +1,21 @@
+use std::fs;
+use std::os::unix::fs::symlink;
+
+use anyhow::Result;
+
+use super::*;
+
+#[test]
+fn path_resolves_to_detects_matching_symlink() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let source = temp_dir.path().join("source");
+    let target = temp_dir.path().join("target");
+
+    fs::write(&source, "wrapper")?;
+    assert!(!path_resolves_to(&target, &source));
+
+    symlink(&source, &target)?;
+    assert!(path_resolves_to(&target, &source));
+
+    Ok(())
+}

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -1106,6 +1106,20 @@ pub fn init(app: &mut AppContext) {
             )
             .with_group(bindings::BindingGroup::Settings.as_str())
             .with_context_predicate(id!("Workspace")),
+            EditableBinding::new(
+                "workspace:install_warpctrl",
+                "Install Warp Control CLI command",
+                WorkspaceAction::InstallWarpctrl,
+            )
+            .with_group(bindings::BindingGroup::Settings.as_str())
+            .with_context_predicate(id!("Workspace")),
+            EditableBinding::new(
+                "workspace:uninstall_warpctrl",
+                "Uninstall Warp Control CLI command",
+                WorkspaceAction::UninstallWarpctrl,
+            )
+            .with_group(bindings::BindingGroup::Settings.as_str())
+            .with_context_predicate(id!("Workspace")),
         ]);
     }
 

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -1106,21 +1106,25 @@ pub fn init(app: &mut AppContext) {
             )
             .with_group(bindings::BindingGroup::Settings.as_str())
             .with_context_predicate(id!("Workspace")),
-            EditableBinding::new(
-                "workspace:install_warpctrl",
-                "Install Warp Control CLI command",
-                WorkspaceAction::InstallWarpctrl,
-            )
-            .with_group(bindings::BindingGroup::Settings.as_str())
-            .with_context_predicate(id!("Workspace")),
-            EditableBinding::new(
-                "workspace:uninstall_warpctrl",
-                "Uninstall Warp Control CLI command",
-                WorkspaceAction::UninstallWarpctrl,
-            )
-            .with_group(bindings::BindingGroup::Settings.as_str())
-            .with_context_predicate(id!("Workspace")),
         ]);
+        if FeatureFlag::WarpControlCli.is_enabled() {
+            app.register_editable_bindings([
+                EditableBinding::new(
+                    "workspace:install_warpctrl",
+                    "Install Warp Control CLI command",
+                    WorkspaceAction::InstallWarpctrl,
+                )
+                .with_group(bindings::BindingGroup::Settings.as_str())
+                .with_context_predicate(id!("Workspace")),
+                EditableBinding::new(
+                    "workspace:uninstall_warpctrl",
+                    "Uninstall Warp Control CLI command",
+                    WorkspaceAction::UninstallWarpctrl,
+                )
+                .with_group(bindings::BindingGroup::Settings.as_str())
+                .with_context_predicate(id!("Workspace")),
+            ]);
+        }
     }
 
     if FeatureFlag::Changelog.is_enabled() {

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -1088,21 +1088,21 @@ pub fn init(app: &mut AppContext) {
         .with_context_predicate(id!("Workspace") & id!(flags::ENABLE_WARP_DRIVE))]);
     }
 
-    // CLI install/uninstall actions (macOS only)
+    // Oz and Warp Control CLI install/uninstall actions (macOS only)
     #[cfg(target_os = "macos")]
     {
         app.register_editable_bindings([
             EditableBinding::new(
                 "workspace:install_cli",
                 "Install Oz CLI command",
-                WorkspaceAction::InstallCLI,
+                WorkspaceAction::InstallOz,
             )
             .with_group(bindings::BindingGroup::Settings.as_str())
             .with_context_predicate(id!("Workspace")),
             EditableBinding::new(
                 "workspace:uninstall_cli",
                 "Uninstall Oz CLI command",
-                WorkspaceAction::UninstallCLI,
+                WorkspaceAction::UninstallOz,
             )
             .with_group(bindings::BindingGroup::Settings.as_str())
             .with_context_predicate(id!("Workspace")),

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -3,7 +3,7 @@ mod active_session;
 pub(crate) mod auto_handoff;
 pub mod bonus_grant_notification_model;
 #[cfg(target_os = "macos")]
-mod cli_install;
+pub(crate) mod cli_install;
 mod close_session_confirmation_dialog;
 pub(crate) mod cross_window_tab_drag;
 pub mod delete_conversation_confirmation_dialog;

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -41,6 +41,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use ::settings::{Setting, ToggleableSetting};
 use ai::index::full_source_code_embedding::manager::CodebaseIndexManager;
+#[cfg(target_os = "macos")]
+use anyhow::Result;
 use autoupdate::AutoupdateStage;
 #[cfg(target_os = "macos")]
 use command::blocking::Command;
@@ -8547,33 +8549,43 @@ impl Workspace {
         }
     }
 
+    /// Show an ephemeral success toast or persistent failure toast for a CLI command operation.
+    #[cfg(target_os = "macos")]
+    fn handle_cli_command_result(
+        &mut self,
+        result: Result<()>,
+        success_toast: DismissibleToast<WorkspaceAction>,
+        failure_message: &str,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match result {
+            Ok(()) => {
+                self.toast_stack.update(ctx, |toast_stack, ctx| {
+                    toast_stack.add_ephemeral_toast(success_toast, ctx);
+                });
+            }
+            Err(error) => {
+                let error_message = format!("{failure_message}: {error}");
+                log::warn!("{error_message}");
+                self.toast_stack.update(ctx, |toast_stack, ctx| {
+                    let toast = DismissibleToast::error(error_message);
+                    toast_stack.add_persistent_toast(toast, ctx);
+                });
+            }
+        }
+    }
+
     /// Install the Warp CLI by creating a symlink in /usr/local/bin
     #[cfg(target_os = "macos")]
     fn install_cli(&mut self, ctx: &mut ViewContext<Self>) {
         ctx.spawn(async { cli_install::install_cli() }, |view, result, ctx| {
-            match result {
-                Ok(_) => {
-                    let command_name = ChannelState::channel().cli_command_name();
-                    let message = format!("Successfully installed the Oz CLI! You can now run '{command_name}' from the command line.");
-                    view.toast_stack.update(ctx, |toast_stack, ctx| {
-                        let toast = DismissibleToast::success(message.to_string())
-                            .with_link(
-                                ToastLink::new("Learn more".to_string()).with_href(
-                                    "https://docs.warp.dev/reference/cli".to_string(),
-                                ),
-                            );
-                        toast_stack.add_ephemeral_toast(toast, ctx);
-                    });
-                }
-                Err(error) => {
-                    let error_message = format!("Failed to install Oz command: {error}");
-                    log::error!("{error_message}");
-                    view.toast_stack.update(ctx, |toast_stack, ctx| {
-                        let toast = DismissibleToast::error(error_message);
-                        toast_stack.add_persistent_toast(toast, ctx);
-                    });
-                }
-            }
+            let command_name = ChannelState::channel().cli_command_name();
+            let message = format!("Successfully installed the Oz CLI! You can now run '{command_name}' from the command line.");
+            let toast = DismissibleToast::success(message).with_link(
+                ToastLink::new("Learn more".to_string())
+                    .with_href("https://docs.warp.dev/reference/cli".to_string()),
+            );
+            view.handle_cli_command_result(result, toast, "Failed to install Oz command", ctx);
         });
     }
 
@@ -8582,22 +8594,16 @@ impl Workspace {
     fn uninstall_cli(&mut self, ctx: &mut ViewContext<Self>) {
         ctx.spawn(
             async { cli_install::uninstall_cli() },
-            |view, result, ctx| match result {
-                Ok(_) => {
-                    let message = "Successfully uninstalled the Oz command.";
-                    view.toast_stack.update(ctx, |toast_stack, ctx| {
-                        let toast = DismissibleToast::success(message.to_string());
-                        toast_stack.add_ephemeral_toast(toast, ctx);
-                    });
-                }
-                Err(error) => {
-                    let error_message = format!("Failed to uninstall Oz command: {error}");
-                    log::error!("{error_message}");
-                    view.toast_stack.update(ctx, |toast_stack, ctx| {
-                        let toast = DismissibleToast::error(error_message);
-                        toast_stack.add_persistent_toast(toast, ctx);
-                    });
-                }
+            |view, result, ctx| {
+                let toast = DismissibleToast::success(
+                    "Successfully uninstalled the Oz command.".to_string(),
+                );
+                view.handle_cli_command_result(
+                    result,
+                    toast,
+                    "Failed to uninstall Oz command",
+                    ctx,
+                );
             },
         );
     }
@@ -8607,23 +8613,16 @@ impl Workspace {
     fn install_warpctrl(&mut self, ctx: &mut ViewContext<Self>) {
         ctx.spawn(
             async { cli_install::install_warpctrl() },
-            |view, result, ctx| match result {
-                Ok(_) => {
-                    let command_name = ChannelState::channel().warpctrl_command_name();
-                    let message = format!("Successfully installed the Warp Control CLI! You can now run '{command_name}' from the command line.");
-                    view.toast_stack.update(ctx, |toast_stack, ctx| {
-                        let toast = DismissibleToast::success(message.to_string());
-                        toast_stack.add_ephemeral_toast(toast, ctx);
-                    });
-                }
-                Err(error) => {
-                    let error_message = format!("Failed to install Warp Control command: {error}");
-                    log::error!("{error_message}");
-                    view.toast_stack.update(ctx, |toast_stack, ctx| {
-                        let toast = DismissibleToast::error(error_message);
-                        toast_stack.add_persistent_toast(toast, ctx);
-                    });
-                }
+            |view, result, ctx| {
+                let command_name = ChannelState::channel().warpctrl_command_name();
+                let message = format!("Successfully installed the Warp Control CLI! You can now run '{command_name}' from the command line.");
+                let toast = DismissibleToast::success(message);
+                view.handle_cli_command_result(
+                    result,
+                    toast,
+                    "Failed to install Warp Control command",
+                    ctx,
+                );
             },
         );
     }
@@ -8633,23 +8632,16 @@ impl Workspace {
     fn uninstall_warpctrl(&mut self, ctx: &mut ViewContext<Self>) {
         ctx.spawn(
             async { cli_install::uninstall_warpctrl() },
-            |view, result, ctx| match result {
-                Ok(_) => {
-                    let message = "Successfully uninstalled the Warp Control command.";
-                    view.toast_stack.update(ctx, |toast_stack, ctx| {
-                        let toast = DismissibleToast::success(message.to_string());
-                        toast_stack.add_ephemeral_toast(toast, ctx);
-                    });
-                }
-                Err(error) => {
-                    let error_message =
-                        format!("Failed to uninstall Warp Control command: {error}");
-                    log::error!("{error_message}");
-                    view.toast_stack.update(ctx, |toast_stack, ctx| {
-                        let toast = DismissibleToast::error(error_message);
-                        toast_stack.add_persistent_toast(toast, ctx);
-                    });
-                }
+            |view, result, ctx| {
+                let toast = DismissibleToast::success(
+                    "Successfully uninstalled the Warp Control command.".to_string(),
+                );
+                view.handle_cli_command_result(
+                    result,
+                    toast,
+                    "Failed to uninstall Warp Control command",
+                    ctx,
+                );
             },
         );
     }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -8575,10 +8575,10 @@ impl Workspace {
         }
     }
 
-    /// Install the Warp CLI by creating a symlink in /usr/local/bin
+    /// Install the Oz CLI by creating a symlink in /usr/local/bin
     #[cfg(target_os = "macos")]
-    fn install_cli(&mut self, ctx: &mut ViewContext<Self>) {
-        ctx.spawn(async { cli_install::install_cli() }, |view, result, ctx| {
+    fn install_oz(&mut self, ctx: &mut ViewContext<Self>) {
+        ctx.spawn(async { cli_install::install_oz() }, |view, result, ctx| {
             let command_name = ChannelState::channel().cli_command_name();
             let message = format!("Successfully installed the Oz CLI! You can now run '{command_name}' from the command line.");
             let toast = DismissibleToast::success(message).with_link(
@@ -8589,11 +8589,11 @@ impl Workspace {
         });
     }
 
-    /// Uninstall the Warp CLI by removing the symlink from /usr/local/bin
+    /// Uninstall the Oz CLI by removing the symlink from /usr/local/bin
     #[cfg(target_os = "macos")]
-    fn uninstall_cli(&mut self, ctx: &mut ViewContext<Self>) {
+    fn uninstall_oz(&mut self, ctx: &mut ViewContext<Self>) {
         ctx.spawn(
-            async { cli_install::uninstall_cli() },
+            async { cli_install::uninstall_oz() },
             |view, result, ctx| {
                 let toast = DismissibleToast::success(
                     "Successfully uninstalled the Oz command.".to_string(),
@@ -23308,9 +23308,9 @@ impl TypedActionView for Workspace {
                 });
             }
             #[cfg(target_os = "macos")]
-            InstallCLI => self.install_cli(ctx),
+            InstallOz => self.install_oz(ctx),
             #[cfg(target_os = "macos")]
-            UninstallCLI => self.uninstall_cli(ctx),
+            UninstallOz => self.uninstall_oz(ctx),
             #[cfg(target_os = "macos")]
             InstallWarpctrl => self.install_warpctrl(ctx),
             #[cfg(target_os = "macos")]

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -8602,6 +8602,58 @@ impl Workspace {
         );
     }
 
+    /// Install the Warp Control CLI by creating a symlink in /usr/local/bin
+    #[cfg(target_os = "macos")]
+    fn install_warpctrl(&mut self, ctx: &mut ViewContext<Self>) {
+        ctx.spawn(
+            async { cli_install::install_warpctrl() },
+            |view, result, ctx| match result {
+                Ok(_) => {
+                    let command_name = ChannelState::channel().warpctrl_command_name();
+                    let message = format!("Successfully installed the Warp Control CLI! You can now run '{command_name}' from the command line.");
+                    view.toast_stack.update(ctx, |toast_stack, ctx| {
+                        let toast = DismissibleToast::success(message.to_string());
+                        toast_stack.add_ephemeral_toast(toast, ctx);
+                    });
+                }
+                Err(error) => {
+                    let error_message = format!("Failed to install Warp Control command: {error}");
+                    log::error!("{error_message}");
+                    view.toast_stack.update(ctx, |toast_stack, ctx| {
+                        let toast = DismissibleToast::error(error_message);
+                        toast_stack.add_persistent_toast(toast, ctx);
+                    });
+                }
+            },
+        );
+    }
+
+    /// Uninstall the Warp Control CLI by removing the symlink from /usr/local/bin
+    #[cfg(target_os = "macos")]
+    fn uninstall_warpctrl(&mut self, ctx: &mut ViewContext<Self>) {
+        ctx.spawn(
+            async { cli_install::uninstall_warpctrl() },
+            |view, result, ctx| match result {
+                Ok(_) => {
+                    let message = "Successfully uninstalled the Warp Control command.";
+                    view.toast_stack.update(ctx, |toast_stack, ctx| {
+                        let toast = DismissibleToast::success(message.to_string());
+                        toast_stack.add_ephemeral_toast(toast, ctx);
+                    });
+                }
+                Err(error) => {
+                    let error_message =
+                        format!("Failed to uninstall Warp Control command: {error}");
+                    log::error!("{error_message}");
+                    view.toast_stack.update(ctx, |toast_stack, ctx| {
+                        let toast = DismissibleToast::error(error_message);
+                        toast_stack.add_persistent_toast(toast, ctx);
+                    });
+                }
+            },
+        );
+    }
+
     fn undo_revert_in_code_review_pane(
         &mut self,
         window_id: WindowId,
@@ -23267,6 +23319,10 @@ impl TypedActionView for Workspace {
             InstallCLI => self.install_cli(ctx),
             #[cfg(target_os = "macos")]
             UninstallCLI => self.uninstall_cli(ctx),
+            #[cfg(target_os = "macos")]
+            InstallWarpctrl => self.install_warpctrl(ctx),
+            #[cfg(target_os = "macos")]
+            UninstallWarpctrl => self.uninstall_warpctrl(ctx),
             UndoRevertInCodeReviewPane { window_id, view_id } => {
                 self.undo_revert_in_code_review_pane(*window_id, *view_id, ctx)
             }

--- a/crates/local_control/src/discovery.rs
+++ b/crates/local_control/src/discovery.rs
@@ -274,23 +274,23 @@ pub fn discovery_dir() -> PathBuf {
     PathBuf::from(home).join(".warp").join("local-control")
 }
 
-/// Returns compatible live instances that pass an authenticated app ping.
+/// Returns compatible live instances from `channel` that pass an authenticated app ping.
 ///
 /// The ping follows the normal broker-to-HTTP flow and verifies the responding
 /// app's instance ID, so a live PID and parseable record alone are insufficient.
-pub fn list_instances() -> Vec<InstanceRecord> {
-    list_instances_from_dir(&discovery_dir())
+pub fn list_instances(channel: &str) -> Vec<InstanceRecord> {
+    list_instances_from_dir(&discovery_dir(), channel)
         .into_iter()
         .filter(|record| crate::client::probe_instance(record).is_ok())
         .collect()
 }
 
-/// Parses structurally valid candidate records and prunes records with dead PIDs.
+/// Parses structurally valid candidate records from `channel` and prunes records with dead PIDs.
 ///
 /// This lower-level scan does not contact the advertised endpoint; callers that
 /// need invokable instances should use [`list_instances`] so candidates also
 /// pass the authenticated probe.
-pub fn list_instances_from_dir(dir: &Path) -> Vec<InstanceRecord> {
+pub fn list_instances_from_dir(dir: &Path, channel: &str) -> Vec<InstanceRecord> {
     let Ok(entries) = fs::read_dir(dir) else {
         return Vec::new();
     };
@@ -306,6 +306,9 @@ pub fn list_instances_from_dir(dir: &Path) -> Vec<InstanceRecord> {
             Err(_) => continue,
         };
         if record.protocol_version != PROTOCOL_VERSION {
+            continue;
+        }
+        if record.channel != channel {
             continue;
         }
         if record.validate_local_control_authority().is_err() {

--- a/crates/local_control/src/discovery.rs
+++ b/crates/local_control/src/discovery.rs
@@ -24,10 +24,12 @@
 //! OS users. The broker's kernel-reported peer-UID check is the authoritative
 //! same-user check before credential issuance. Neither mechanism distinguishes
 //! trusted Warp code from arbitrary software already running as that user.
+use std::collections::HashSet;
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt as _;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 #[cfg(windows)]
@@ -38,6 +40,8 @@ use crate::protocol::{ActionMetadata, ControlError, ErrorCode, PROTOCOL_VERSION}
 
 const DISCOVERY_DIR_ENV: &str = "WARP_LOCAL_CONTROL_DISCOVERY_DIR";
 const BROKER_SOCKET_SUFFIX: &str = ".broker.sock";
+const TEMP_RECORD_SUFFIX: &str = ".json.tmp";
+const ORPHAN_SOCKET_GRACE_PERIOD: Duration = Duration::from_secs(60);
 
 /// Stable identifier for one running Warp instance.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -237,23 +241,33 @@ fn write_record(path: &Path, record: &InstanceRecord) -> Result<(), ControlError
             err.to_string(),
         )
     })?;
-    fs::write(path, bytes).map_err(|err| {
+    let temp_path = path.with_extension("json.tmp");
+    fs::write(&temp_path, bytes).map_err(|err| {
         ControlError::with_details(
             ErrorCode::Internal,
-            "failed to write local-control discovery record",
+            "failed to write temporary local-control discovery record",
             err.to_string(),
         )
     })?;
-    set_private_permissions(path)?;
+    if let Err(error) = set_private_permissions(&temp_path) {
+        let _ = fs::remove_file(&temp_path);
+        return Err(error);
+    }
+    fs::rename(&temp_path, path).map_err(|err| {
+        let _ = fs::remove_file(&temp_path);
+        ControlError::with_details(
+            ErrorCode::Internal,
+            "failed to publish local-control discovery record",
+            err.to_string(),
+        )
+    })?;
     Ok(())
 }
 
 impl Drop for RegisteredInstance {
     // Drop-time cleanup is the best-effort fast path for graceful shutdown.
-    // `list_instances_from_dir` is the robust cleanup path: it treats records
-    // whose PID is no longer alive as stale, removes them, and ignores malformed
-    // or unreadable records so a crash can leave at most a temporary zombie
-    // reference that is pruned on the next discovery scan.
+    // `list_instances_from_dir` is the robust cleanup path: it removes stale
+    // records, matching broker sockets, and abandoned registry artifacts.
     fn drop(&mut self) {
         let _ = fs::remove_file(&self.path);
         if let Some(path) = &self.broker_socket_path {
@@ -279,9 +293,18 @@ pub fn discovery_dir() -> PathBuf {
 /// The ping follows the normal broker-to-HTTP flow and verifies the responding
 /// app's instance ID, so a live PID and parseable record alone are insufficient.
 pub fn list_instances(channel: &str) -> Vec<InstanceRecord> {
-    list_instances_from_dir(&discovery_dir(), channel)
+    let dir = discovery_dir();
+    list_instances_from_dir(&dir, channel)
         .into_iter()
-        .filter(|record| crate::client::probe_instance(record).is_ok())
+        .filter(|record| {
+            if crate::client::probe_instance(record).is_ok() {
+                return true;
+            }
+            if !is_pid_alive(record.pid) {
+                remove_instance_artifacts(&dir, &record.instance_id);
+            }
+            false
+        })
         .collect()
 }
 
@@ -295,16 +318,33 @@ pub fn list_instances_from_dir(dir: &Path, channel: &str) -> Vec<InstanceRecord>
         return Vec::new();
     };
     let mut records = Vec::new();
+    let mut retained_broker_sockets = HashSet::new();
     for entry in entries.filter_map(Result::ok) {
         let path = entry.path();
+        if !is_record_path(&path) {
+            continue;
+        }
         let contents = match fs::read_to_string(&path) {
             Ok(c) => c,
-            Err(_) => continue,
+            Err(_) => {
+                remove_malformed_record_artifacts(dir, &path);
+                continue;
+            }
         };
         let record = match serde_json::from_str::<InstanceRecord>(&contents) {
             Ok(r) => r,
-            Err(_) => continue,
+            Err(_) => {
+                remove_malformed_record_artifacts(dir, &path);
+                continue;
+            }
         };
+        if !is_pid_alive(record.pid) {
+            remove_instance_artifacts(dir, &record.instance_id);
+            continue;
+        }
+        if record.credential_broker.is_some() {
+            retained_broker_sockets.insert(broker_socket_filename(&record.instance_id));
+        }
         if record.protocol_version != PROTOCOL_VERSION {
             continue;
         }
@@ -314,14 +354,83 @@ pub fn list_instances_from_dir(dir: &Path, channel: &str) -> Vec<InstanceRecord>
         if record.validate_local_control_authority().is_err() {
             continue;
         }
-        if !is_pid_alive(record.pid) {
-            let _ = fs::remove_file(&path);
-            continue;
-        }
         records.push(record);
     }
+    sweep_orphan_broker_sockets(dir, &retained_broker_sockets, ORPHAN_SOCKET_GRACE_PERIOD);
+    sweep_abandoned_temp_records(dir, ORPHAN_SOCKET_GRACE_PERIOD);
     records.sort_by_key(|record| record.started_at);
     records
+}
+
+fn is_record_path(path: &Path) -> bool {
+    path.extension().and_then(|extension| extension.to_str()) == Some("json")
+}
+
+fn remove_malformed_record_artifacts(dir: &Path, path: &Path) {
+    let _ = fs::remove_file(path);
+    let Some(instance_id) = path.file_stem().and_then(|stem| stem.to_str()) else {
+        return;
+    };
+    let _ = fs::remove_file(dir.join(format!("{instance_id}{BROKER_SOCKET_SUFFIX}")));
+}
+
+fn remove_instance_artifacts(dir: &Path, instance_id: &InstanceId) {
+    let _ = fs::remove_file(record_path(dir, instance_id));
+    let _ = fs::remove_file(dir.join(broker_socket_filename(instance_id)));
+}
+
+fn sweep_orphan_broker_sockets(
+    dir: &Path,
+    retained_broker_sockets: &HashSet<PathBuf>,
+    grace_period: Duration,
+) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        let Some(filename) = path.file_name().and_then(|filename| filename.to_str()) else {
+            continue;
+        };
+        if !filename.ends_with(BROKER_SOCKET_SUFFIX)
+            || retained_broker_sockets.contains(Path::new(filename))
+        {
+            continue;
+        }
+        let Ok(age) = entry.metadata().and_then(|metadata| metadata.modified()) else {
+            continue;
+        };
+        let Ok(age) = age.elapsed() else {
+            continue;
+        };
+        if age >= grace_period {
+            let _ = fs::remove_file(path);
+        }
+    }
+}
+
+fn sweep_abandoned_temp_records(dir: &Path, grace_period: Duration) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        let Some(filename) = path.file_name().and_then(|filename| filename.to_str()) else {
+            continue;
+        };
+        if !filename.ends_with(TEMP_RECORD_SUFFIX) {
+            continue;
+        }
+        let Ok(age) = entry.metadata().and_then(|metadata| metadata.modified()) else {
+            continue;
+        };
+        let Ok(age) = age.elapsed() else {
+            continue;
+        };
+        if age >= grace_period {
+            let _ = fs::remove_file(path);
+        }
+    }
 }
 
 #[cfg(unix)]

--- a/crates/local_control/src/discovery_tests.rs
+++ b/crates/local_control/src/discovery_tests.rs
@@ -44,7 +44,7 @@ fn registered_instance_round_trips_discovery_record() {
     );
     let _registered = RegisteredInstance::register_in_dir_for_test(record.clone(), dir.path())
         .expect("registered");
-    let records = list_instances_from_dir(dir.path());
+    let records = list_instances_from_dir(dir.path(), "local");
     assert_eq!(records, vec![record]);
 }
 
@@ -62,7 +62,7 @@ fn incompatible_protocol_record_is_ignored() {
     let _registered =
         RegisteredInstance::register_in_dir_for_test(record, dir.path()).expect("registered");
 
-    assert!(list_instances_from_dir(dir.path()).is_empty());
+    assert!(list_instances_from_dir(dir.path(), "local").is_empty());
 }
 #[cfg(unix)]
 #[test]
@@ -84,7 +84,7 @@ fn stale_process_record_is_pruned() {
     let registered =
         RegisteredInstance::register_in_dir_for_test(record, dir.path()).expect("registered");
 
-    assert!(list_instances_from_dir(dir.path()).is_empty());
+    assert!(list_instances_from_dir(dir.path(), "local").is_empty());
     assert!(!registered.path.exists());
 }
 #[cfg(unix)]
@@ -122,7 +122,7 @@ fn multiple_live_process_records_are_discovered() {
     let _second = RegisteredInstance::register_in_dir_for_test(second_record, dir.path())
         .expect("second registered");
 
-    let ids = list_instances_from_dir(dir.path())
+    let ids = list_instances_from_dir(dir.path(), "local")
         .into_iter()
         .map(|record| record.instance_id)
         .collect::<Vec<_>>();
@@ -136,6 +136,21 @@ fn multiple_live_process_records_are_discovered() {
     second_process.wait().expect("second process reaped");
 }
 
+#[test]
+fn records_from_other_channels_are_ignored() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let record = InstanceRecord::for_current_process(
+        Some(ControlEndpoint::localhost(4000)),
+        "dev",
+        "dev.warp.Warp-Dev",
+        Some("test".to_owned()),
+        crate::protocol::ActionKind::implemented_metadata(),
+    );
+    let _registered =
+        RegisteredInstance::register_in_dir_for_test(record, dir.path()).expect("registered");
+
+    assert!(list_instances_from_dir(dir.path(), "local").is_empty());
+}
 #[test]
 fn serialized_discovery_record_does_not_contain_raw_credential_material() {
     let raw_secret = "raw-secret-token-material";

--- a/crates/local_control/src/discovery_tests.rs
+++ b/crates/local_control/src/discovery_tests.rs
@@ -64,6 +64,49 @@ fn incompatible_protocol_record_is_ignored() {
 
     assert!(list_instances_from_dir(dir.path(), "local").is_empty());
 }
+
+#[test]
+fn malformed_record_and_matching_broker_socket_are_pruned() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let record_path = dir.path().join("inst_malformed.json");
+    let socket_path = dir.path().join("inst_malformed.broker.sock");
+    fs::write(&record_path, "not json").expect("write malformed record");
+    fs::write(&socket_path, "").expect("write broker socket");
+
+    assert!(list_instances_from_dir(dir.path(), "local").is_empty());
+    assert!(!record_path.exists());
+    assert!(!socket_path.exists());
+}
+
+#[test]
+fn orphan_broker_sockets_are_pruned_after_grace_period() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let orphan_path = dir.path().join("inst_orphan.broker.sock");
+    let retained_filename = PathBuf::from("inst_retained.broker.sock");
+    let retained_path = dir.path().join(&retained_filename);
+    fs::write(&orphan_path, "").expect("write orphan socket");
+    fs::write(&retained_path, "").expect("write retained socket");
+
+    sweep_orphan_broker_sockets(
+        dir.path(),
+        &HashSet::from([retained_filename]),
+        Duration::ZERO,
+    );
+
+    assert!(!orphan_path.exists());
+    assert!(retained_path.exists());
+}
+
+#[test]
+fn abandoned_temp_records_are_pruned_after_grace_period() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let temp_path = dir.path().join("inst_abandoned.json.tmp");
+    fs::write(&temp_path, "").expect("write temporary record");
+
+    sweep_abandoned_temp_records(dir.path(), Duration::ZERO);
+
+    assert!(!temp_path.exists());
+}
 #[cfg(unix)]
 #[test]
 fn stale_process_record_is_pruned() {
@@ -81,11 +124,14 @@ fn stale_process_record_is_pruned() {
         crate::protocol::ActionKind::implemented_metadata(),
     );
     record.pid = pid;
+    let socket_path = dir.path().join(broker_socket_filename(&record.instance_id));
+    fs::write(&socket_path, "").expect("write broker socket");
     let registered =
         RegisteredInstance::register_in_dir_for_test(record, dir.path()).expect("registered");
 
     assert!(list_instances_from_dir(dir.path(), "local").is_empty());
     assert!(!registered.path.exists());
+    assert!(!socket_path.exists());
 }
 #[cfg(unix)]
 #[test]
@@ -146,10 +192,13 @@ fn records_from_other_channels_are_ignored() {
         Some("test".to_owned()),
         crate::protocol::ActionKind::implemented_metadata(),
     );
+    let socket_path = dir.path().join(broker_socket_filename(&record.instance_id));
+    fs::write(&socket_path, "").expect("write broker socket");
     let _registered =
         RegisteredInstance::register_in_dir_for_test(record, dir.path()).expect("registered");
 
     assert!(list_instances_from_dir(dir.path(), "local").is_empty());
+    assert!(socket_path.exists());
 }
 #[test]
 fn serialized_discovery_record_does_not_contain_raw_credential_material() {

--- a/crates/warp_cli/src/lib.rs
+++ b/crates/warp_cli/src/lib.rs
@@ -93,7 +93,11 @@ pub struct GlobalOptions {
     pub output_format: OutputFormat,
 }
 
-/// Command-line argument parser for the main Warp binary. This is used across all channels.
+/// Normal argument parser for the shared Warp executable across all channels.
+///
+/// Oz commands are subcommands of this parser, so invoking an `oz` symlink does
+/// not require a mode flag. Warp Control uses its separate [`local_control::ControlArgs`]
+/// parser, selected before this parser sees the arguments.
 #[derive(Debug, Default, Parser, Clone)]
 #[command(
     name = "oz",

--- a/crates/warp_cli/src/local_control/commands.rs
+++ b/crates/warp_cli/src/local_control/commands.rs
@@ -775,10 +775,7 @@ fn run_action_with_params<T: Serialize>(
     output_format: OutputFormat,
 ) -> Result<(), ControlError> {
     let selector = instance_selector(&args);
-    let records = local_control::discovery::list_instances_from_dir(
-        &local_control::discovery::discovery_dir(),
-        &ChannelState::channel().to_string(),
-    );
+    let records = local_control::discovery::list_instances(&ChannelState::channel().to_string());
     let target = target_selector(&args)?;
     let instance = select_instance(&records, &selector)?;
     let mut request = RequestEnvelope::new(Action::with_params(action, params)?);

--- a/crates/warp_cli/src/local_control/commands.rs
+++ b/crates/warp_cli/src/local_control/commands.rs
@@ -9,6 +9,7 @@ use local_control::protocol::{
 };
 use local_control::selection::select_instance;
 use serde::Serialize;
+use warp_core::channel::ChannelState;
 
 use crate::agent::OutputFormat;
 use crate::local_control::output::{write_json, write_json_line};
@@ -189,9 +190,10 @@ pub(super) fn run_instance_command(
     output_format: OutputFormat,
 ) -> Result<(), ControlError> {
     match command {
-        InstanceCommand::List => {
-            render_instance_list(local_control::discovery::list_instances(), output_format)
-        }
+        InstanceCommand::List => render_instance_list(
+            local_control::discovery::list_instances(&ChannelState::channel().to_string()),
+            output_format,
+        ),
         InstanceCommand::Inspect(args) => run_action_with_params(
             args,
             ActionKind::InstanceInspect,
@@ -775,6 +777,7 @@ fn run_action_with_params<T: Serialize>(
     let selector = instance_selector(&args);
     let records = local_control::discovery::list_instances_from_dir(
         &local_control::discovery::discovery_dir(),
+        &ChannelState::channel().to_string(),
     );
     let target = target_selector(&args)?;
     let instance = select_instance(&records, &selector)?;

--- a/crates/warp_cli/src/local_control/mod.rs
+++ b/crates/warp_cli/src/local_control/mod.rs
@@ -63,11 +63,17 @@ impl ControlArgs {
         Self::try_parse_from_args(std::env::args_os(), bin_name).unwrap_or_else(|err| err.exit())
     }
 
+    /// Parse Warp Control arguments only when the wrapper-injected mode flag is present.
+    ///
+    /// Startup calls this before the normal Warp/Oz parser. Arguments through
+    /// `--warpctrl` are removed, and the remaining arguments are parsed as if
+    /// the standalone command name were `warpctrl`.
     pub fn from_control_mode_env() -> Option<Self> {
         Self::try_parse_control_mode_from(std::env::args_os())
             .map(|result| result.unwrap_or_else(|err| err.exit()))
     }
 
+    /// Testable implementation of [`Self::from_control_mode_env`].
     pub fn try_parse_control_mode_from<I, T>(args: I) -> Option<Result<Self, clap::Error>>
     where
         I: IntoIterator<Item = T>,

--- a/crates/warp_core/src/channel/mod.rs
+++ b/crates/warp_core/src/channel/mod.rs
@@ -58,6 +58,18 @@ impl Channel {
             Channel::Oss => "warp-oss",
         }
     }
+
+    /// Returns the Warp Control CLI command name corresponding to this channel.
+    pub fn warpctrl_command_name(&self) -> &'static str {
+        match self {
+            Channel::Stable => "warpctrl",
+            Channel::Dev => "warpctrl-dev",
+            Channel::Preview => "warpctrl-preview",
+            Channel::Local => "warpctrl-local",
+            Channel::Integration => "warpctrl-integration",
+            Channel::Oss => "warpctrl-oss",
+        }
+    }
 }
 
 impl fmt::Display for Channel {

--- a/resources/bundled/skills/warpctrl/SKILL.md
+++ b/resources/bundled/skills/warpctrl/SKILL.md
@@ -9,7 +9,56 @@ Use `warpctrl` to inspect or control an already-running local Warp application. 
 
 Prefer `warpctrl` when the requested action changes Warp itself rather than the user's project or operating system. Examples include creating a Warp tab, splitting a pane, staging text in Warp's input, opening Warp settings, or focusing a Warp window.
 
+## How to invoke Warp Control
+
+Warp Control is bundled into the Warp application. It is not a separate standalone binary; it is a hidden control mode that is served by the running Warp process. A small wrapper script is installed into the app bundle at `Contents/Resources/bin/warpctrl`, and the Warp UI can install a symlink for that wrapper to `/usr/local/bin` so it is available on `PATH`.
+
+When invoking Warp Control, use the wrapper name that matches the currently running Warp channel:
+
+- **Warp (Stable):** `warpctrl`
+- **WarpDev:** `warpctrl-dev`
+- **WarpPreview:** `warpctrl-preview`
+- **WarpLocal:** `warpctrl-local`
+- **WarpOss:** `warpctrl-oss`
+
+If the wrapper is not on `PATH`, invoke it from the app bundle by running the matching wrapper path:
+
+- **Warp (Stable):** `/Applications/Warp.app/Contents/Resources/bin/warpctrl`
+- **WarpDev:** `/Applications/WarpDev.app/Contents/Resources/bin/warpctrl-dev`
+- **WarpPreview:** `/Applications/WarpPreview.app/Contents/Resources/bin/warpctrl-preview`
+- **WarpOss:** `/Applications/WarpOss.app/Contents/Resources/bin/warpctrl-oss`
+- **WarpLocal:** `<bundle-path>/WarpLocal.app/Contents/Resources/bin/warpctrl-local`
+
+If the wrapper is missing from the bundle (e.g., older builds), invoke the channel executable directly with the `--warpctrl` flag:
+
+- **WarpDev:** `/Applications/WarpDev.app/Contents/MacOS/dev --warpctrl ...`
+- **WarpPreview:** `/Applications/WarpPreview.app/Contents/MacOS/preview --warpctrl ...`
+- **Warp (Stable):** `/Applications/Warp.app/Contents/MacOS/stable --warpctrl ...`
+- **WarpOss:** `/Applications/WarpOss.app/Contents/MacOS/warp-oss --warpctrl ...`
+- **WarpLocal:** `<bundle-path>/WarpLocal.app/Contents/MacOS/warp --warpctrl ...`
+
+To install the wrapper on `PATH` from the Warp UI, use the command palette entry **Install Warp Control CLI command** (or `workspace:install_warpctrl`). To uninstall it, use **Uninstall Warp Control CLI command** (or `workspace:uninstall_warpctrl`).
+
+For a local checkout, invoke the hidden control mode with `cargo run` using the channel-specific binary target. **Do not run a development build automatically. If the user wants to use the local checkout, ask which channel they want to build before running `cargo run`.**
+
+> Ask the user which channel to build before running a development command.
+> Example: "Do you want to run the dev, preview, or stable channel build?"
+> For the dev channel, the command would be:
+> ```sh
+> cargo run -p warp --bin dev --features warp_control_cli -- --warpctrl instance list
+> ```
+
+The easiest way to verify a working invocation is to run the wrapper that matches the running Warp build, e.g.:
+
+```sh
+warpctrl-dev app version
+```
+
+which should print the channel, app ID, and protocol version.
+
 ## Workflow
+
+Always prefer discovering commands from `warpctrl` itself rather than guessing or inventing them. The CLI provides full help and an action catalog that is the source of truth for what the installed build supports.
 
 1. Discover running Warp instances:
 
@@ -19,17 +68,7 @@ Prefer `warpctrl` when the requested action changes Warp itself rather than the 
 
 2. If exactly one instance is running, commands select it automatically. If multiple instances are running, select one explicitly with `--instance <instance_id>` or `--pid <pid>`.
 
-3. Inspect the active target chain or list the relevant targets before changing them:
-
-   ```sh
-   warpctrl app active
-   warpctrl window list
-   warpctrl tab list
-   warpctrl pane list
-   warpctrl session list
-   ```
-
-4. Discover the exact command and parameters instead of guessing:
+3. Discover the exact command and parameters instead of guessing. This is the preferred source of truth for the available command surface:
 
    ```sh
    warpctrl help
@@ -39,9 +78,21 @@ Prefer `warpctrl` when the requested action changes Warp itself rather than the 
    warpctrl action inspect <action.name>
    ```
 
+4. Inspect the active target chain or list the relevant targets before changing them:
+
+   ```sh
+   warpctrl app active
+   warpctrl window list
+   warpctrl tab list
+   warpctrl pane list
+   warpctrl session list
+   ```
+
 5. Invoke the narrowest action that satisfies the request, then verify the result with the corresponding `list`, `inspect`, or `get` command when useful.
 
 ## Common actions
+
+These are frequently used commands that are safe to invoke directly. For less common commands, use `warpctrl help`, `warpctrl action list`, or `warpctrl <group> <command> --help` to discover the exact syntax supported by the running build.
 
 ```sh
 # Create and manage tabs and panes
@@ -109,10 +160,18 @@ Use `surface list` before a walkthrough or multi-step UI workflow. It reports bo
 
 ## Manual setup and troubleshooting
 
-Warp Control must be enabled in **Settings > Scripting**, and the installed build must include the Warp Control feature. The installed `warpctrl` wrapper invokes the matching channel-specific Warp executable.
+Warp Control availability depends on the build channel and the **Settings > Scripting** toggle. The local-control mode defaults to enabled on internal dogfood builds (e.g., WarpDev) and disabled on public channels (Stable, Preview, OSS). On any channel, the final gate is the **Settings > Scripting** toggle. The installed `warpctrl` wrapper invokes the matching channel-specific Warp executable.
 
-If `warpctrl instance list` is empty, confirm that a compatible Warp app is running and Scripting is enabled. If a command reports multiple instances, rerun it with `--instance <instance_id>`. If `warpctrl` is not installed while developing Warp locally, invoke the hidden control mode directly:
+If `warpctrl instance list` is empty, confirm that a compatible Warp app is running and Scripting is enabled. If a command reports multiple instances, rerun it with `--instance <instance_id>`.
+
+If the wrapper is not present in the bundle (e.g., older builds), invoke the channel executable directly with the `--warpctrl` flag:
 
 ```sh
-cargo run -p warp --bin warp --features warp_control_cli -- --warpctrl instance list
+/Applications/WarpDev.app/Contents/MacOS/dev --warpctrl instance list
+```
+
+If the wrapper is present but not on `PATH`, use the full bundle path to the channel-specific wrapper:
+
+```sh
+/Applications/WarpDev.app/Contents/Resources/bin/warpctrl-dev instance list
 ```

--- a/resources/bundled/skills/warpctrl/SKILL.md
+++ b/resources/bundled/skills/warpctrl/SKILL.md
@@ -11,7 +11,7 @@ Prefer `warpctrl` when the requested action changes Warp itself rather than the 
 
 ## How to invoke Warp Control
 
-Warp Control is bundled into the Warp application. It is not a separate standalone binary; it is a hidden control mode that is served by the running Warp process. A small wrapper script is installed into the app bundle at `Contents/Resources/bin/warpctrl`, and the Warp UI can install a symlink for that wrapper to `/usr/local/bin` so it is available on `PATH`.
+Warp Control is bundled into the Warp application. It is not a separate standalone binary; it is a hidden control mode that is served by the running Warp process. A small channel-specific wrapper script is installed into the app bundle under `Contents/Resources/bin`, and the Warp UI can install a symlink for that wrapper to `/usr/local/bin` so it is available on `PATH`.
 
 When invoking Warp Control, use the wrapper name that matches the currently running Warp channel:
 
@@ -164,14 +164,4 @@ Warp Control availability depends on the build channel and the **Settings > Scri
 
 If `warpctrl instance list` is empty, confirm that a compatible Warp app is running and Scripting is enabled. If a command reports multiple instances, rerun it with `--instance <instance_id>`.
 
-If the wrapper is not present in the bundle (e.g., older builds), invoke the channel executable directly with the `--warpctrl` flag:
-
-```sh
-/Applications/WarpDev.app/Contents/MacOS/dev --warpctrl instance list
-```
-
-If the wrapper is present but not on `PATH`, use the full bundle path to the channel-specific wrapper:
-
-```sh
-/Applications/WarpDev.app/Contents/Resources/bin/warpctrl-dev instance list
-```
+If the wrapper is missing from the bundle or is not on `PATH`, use the matching direct-executable or full-bundle invocation documented in **How to invoke Warp Control**.

--- a/resources/bundled/skills/warpctrl/SKILL.md
+++ b/resources/bundled/skills/warpctrl/SKILL.md
@@ -34,7 +34,15 @@ The Warp UI also exposes **Install Warp Control CLI command** and **Uninstall Wa
 
 ## Workflow
 
-Always prefer discovering commands from `{{warpctrl_binary_name}}` itself rather than guessing or inventing them. The CLI provides full help and an action catalog that is the source of truth for what the installed build supports.
+Always prefer discovering commands from `{{warpctrl_binary_name}}` itself rather than guessing or inventing them. The CLI provides full help and an action catalog that is the authoritative source of truth for what the installed build supports.
+
+### Execute serially and validate results
+
+Run Warp Control commands serially. Never dispatch multiple `{{warpctrl_binary_name}}` commands through parallel shell-tool calls, even when the commands appear independent. They act on the same running app and may change the active target or the terminal context used to execute and observe later commands. For multi-step requests, prefer one shell-tool call that chains commands sequentially, or issue separate shell-tool calls one at a time.
+
+After an action that creates, activates, navigates, or focuses a window, tab, pane, session, or surface, do not assume the active target is unchanged. Use explicit selectors for later commands when exact targeting matters, or rerun `{{warpctrl_binary_name}} app active` before continuing.
+
+Validate that each result corresponds to the command that was invoked. If output describes a different action, reports an unexpected instance or channel, or otherwise conflicts with the request, stop and rerun `{{warpctrl_binary_name}} instance list` serially before retrying. Do not report success until the requested final state has been verified when a corresponding `list`, `inspect`, or `get` command is available.
 
 ### Route by intent
 

--- a/resources/bundled/skills/warpctrl/SKILL.md
+++ b/resources/bundled/skills/warpctrl/SKILL.md
@@ -5,135 +5,133 @@ description: Control and inspect the currently running local Warp application wi
 
 # Warp Control
 
-Use `warpctrl` to inspect or control an already-running local Warp application. The built-in Warp agent can invoke it through shell commands, and users can run the same commands manually.
+Use `{{warpctrl_binary_name}}` to inspect or control the already-running local Warp application that provided this skill. The command name and wrapper path in this skill are injected for the current Warp channel, so do not inspect running processes or guess which channel is active.
 
-Prefer `warpctrl` when the requested action changes Warp itself rather than the user's project or operating system. Examples include creating a Warp tab, splitting a pane, staging text in Warp's input, opening Warp settings, or focusing a Warp window.
+Prefer `{{warpctrl_binary_name}}` when the requested action changes Warp itself rather than the user's project or operating system. Examples include creating a Warp tab, splitting a pane, staging text in Warp's input, opening Warp settings, or focusing a Warp window.
 
 ## How to invoke Warp Control
 
-Warp Control is bundled into the Warp application. It is not a separate standalone binary; it is a hidden control mode that is served by the running Warp process. A small channel-specific wrapper script is installed into the app bundle under `Contents/Resources/bin`, and the Warp UI can install a symlink for that wrapper to `/usr/local/bin` so it is available on `PATH`.
+Warp Control is bundled into the Warp application. It is not a separate standalone binary; it is a hidden control mode served by the running Warp process.
 
-When invoking Warp Control, use the wrapper name that matches the currently running Warp channel:
+- Command for the current Warp channel: `{{warpctrl_binary_name}}`
+- Bundled wrapper for the current Warp channel: `{{warpctrl_wrapper_path}}`
+- Optional PATH symlink: `/usr/local/bin/{{warpctrl_binary_name}}`
 
-- **Warp (Stable):** `warpctrl`
-- **WarpDev:** `warpctrl-dev`
-- **WarpPreview:** `warpctrl-preview`
-- **WarpLocal:** `warpctrl-local`
-- **WarpOss:** `warpctrl-oss`
+### Ensure the command is available
 
-If the wrapper is not on `PATH`, invoke it from the app bundle by running the matching wrapper path:
+Before invoking Warp Control for the first time in a task, prefer the shortest available path and avoid unnecessary setup research:
 
-- **Warp (Stable):** `/Applications/Warp.app/Contents/Resources/bin/warpctrl`
-- **WarpDev:** `/Applications/WarpDev.app/Contents/Resources/bin/warpctrl-dev`
-- **WarpPreview:** `/Applications/WarpPreview.app/Contents/Resources/bin/warpctrl-preview`
-- **WarpOss:** `/Applications/WarpOss.app/Contents/Resources/bin/warpctrl-oss`
-- **WarpLocal:** `<bundle-path>/WarpLocal.app/Contents/Resources/bin/warpctrl-local`
+1. If `command -v {{warpctrl_binary_name}}` succeeds, use `{{warpctrl_binary_name}}` for the rest of the task. Do not inspect the bundled wrapper or verify the symlink unless a later command fails.
+2. If `command -v {{warpctrl_binary_name}}` fails, verify that `{{warpctrl_wrapper_path}}` exists and is executable. If it is missing, tell the user that this Warp build does not contain the expected wrapper and stop.
+3. Inspect `/usr/local/bin/{{warpctrl_binary_name}}`. Treat setup as complete only when it is a symlink that resolves to the exact `{{warpctrl_wrapper_path}}` bundled wrapper.
+4. If the expected symlink is missing, broken, or points elsewhere, use the `ask_user_question` tool to ask whether the user wants to install it at `/usr/local/bin/{{warpctrl_binary_name}}` pointing to `{{warpctrl_wrapper_path}}`. Offer **Install command** as the recommended option and **Not now** as the alternative. Do not create or replace a symlink without an affirmative response.
+5. After approval, create or update only the expected symlink by running `ln -sf "{{warpctrl_wrapper_path}}" "/usr/local/bin/{{warpctrl_binary_name}}"`. Try without elevation first. If macOS permissions prevent the change, run that same command through `osascript` with administrator privileges; never request or expose the user's password directly.
+6. Verify the result with `command -v {{warpctrl_binary_name}}`, `readlink /usr/local/bin/{{warpctrl_binary_name}}`, and `{{warpctrl_binary_name}} app version`.
 
-If the wrapper is missing from the bundle (e.g., older builds), invoke the channel executable directly with the `--warpctrl` flag:
+If the user chooses **Not now**, do not create the symlink. Use the bundled wrapper at `{{warpctrl_wrapper_path}}` directly for the current task.
 
-- **WarpDev:** `/Applications/WarpDev.app/Contents/MacOS/dev --warpctrl ...`
-- **WarpPreview:** `/Applications/WarpPreview.app/Contents/MacOS/preview --warpctrl ...`
-- **Warp (Stable):** `/Applications/Warp.app/Contents/MacOS/stable --warpctrl ...`
-- **WarpOss:** `/Applications/WarpOss.app/Contents/MacOS/warp-oss --warpctrl ...`
-- **WarpLocal:** `<bundle-path>/WarpLocal.app/Contents/MacOS/warp --warpctrl ...`
-
-To install the wrapper on `PATH` from the Warp UI, use the command palette entry **Install Warp Control CLI command** (or `workspace:install_warpctrl`). To uninstall it, use **Uninstall Warp Control CLI command** (or `workspace:uninstall_warpctrl`).
-
-For a local checkout, invoke the hidden control mode with `cargo run` using the channel-specific binary target. **Do not run a development build automatically. If the user wants to use the local checkout, ask which channel they want to build before running `cargo run`.**
-
-> Ask the user which channel to build before running a development command.
-> Example: "Do you want to run the dev, preview, or stable channel build?"
-> For the dev channel, the command would be:
-> ```sh
-> cargo run -p warp --bin dev --features warp_control_cli -- --warpctrl instance list
-> ```
-
-The easiest way to verify a working invocation is to run the wrapper that matches the running Warp build, e.g.:
-
-```sh
-warpctrl-dev app version
-```
-
-which should print the channel, app ID, and protocol version.
+The Warp UI also exposes **Install Warp Control CLI command** and **Uninstall Warp Control CLI command** in the Command Palette and an install control under **Settings > Scripting**.
 
 ## Workflow
 
-Always prefer discovering commands from `warpctrl` itself rather than guessing or inventing them. The CLI provides full help and an action catalog that is the source of truth for what the installed build supports.
+Always prefer discovering commands from `{{warpctrl_binary_name}}` itself rather than guessing or inventing them. The CLI provides full help and an action catalog that is the source of truth for what the installed build supports.
 
-1. Discover running Warp instances:
+### Route by intent
+
+Before discovering commands, route the request to the narrowest matching top-level group:
+
+1. Requests to open, show, view, or toggle a named Warp UI destination, panel, picker, or settings page use `surface`. Convert natural-language names to kebab case, such as "Warp Drive" to `warp-drive` and "code review" to `code-review`. Prefer `surface <name> open` when the requested final state is open. Use `surface list` or `surface help` when the destination or supported verb is unknown. Do not infer an internal action name for a UI destination.
+2. Requests about windows, tabs, panes, or sessions use the matching `window`, `tab`, `pane`, or `session` group.
+3. Requests to stage or inspect editor input use `input`.
+4. Requests to open a file in Warp use `file`.
+5. Requests about themes, appearance, settings, or keybindings use the matching `theme`, `appearance`, `setting`, or `keybinding` group.
+6. Use the generic `action` catalog only when no dedicated CLI group matches. Internal or catalog action names are not guaranteed to be reachable as standalone parser commands.
+
+1. Discover running Warp instances from the current Warp channel:
 
    ```sh
-   warpctrl instance list
+   {{warpctrl_binary_name}} instance list
    ```
 
-2. If exactly one instance is running, commands select it automatically. If multiple instances are running, select one explicitly with `--instance <instance_id>` or `--pid <pid>`.
+2. If exactly one same-channel instance is running, commands select it automatically. If multiple same-channel instances are running, select one explicitly with `--instance <instance_id>` or `--pid <pid>`.
 
-3. Discover the exact command and parameters instead of guessing. This is the preferred source of truth for the available command surface:
+3. Discover the exact command and parameters from the routed group instead of guessing. This is the preferred source of truth for the available command surface:
 
    ```sh
-   warpctrl help
-   warpctrl <group> help
-   warpctrl <group> <command> --help
-   warpctrl action list
-   warpctrl action inspect <action.name>
+   {{warpctrl_binary_name}} help
+   {{warpctrl_binary_name}} <group> help
+   {{warpctrl_binary_name}} <group> <command> --help
+   ```
+
+   Only when no dedicated group matches, inspect the generic action catalog:
+
+   ```sh
+   {{warpctrl_binary_name}} action list
+   {{warpctrl_binary_name}} action inspect <action.name>
    ```
 
 4. Inspect the active target chain or list the relevant targets before changing them:
 
    ```sh
-   warpctrl app active
-   warpctrl window list
-   warpctrl tab list
-   warpctrl pane list
-   warpctrl session list
+   {{warpctrl_binary_name}} app active
+   {{warpctrl_binary_name}} window list
+   {{warpctrl_binary_name}} tab list
+   {{warpctrl_binary_name}} pane list
+   {{warpctrl_binary_name}} session list
    ```
 
 5. Invoke the narrowest action that satisfies the request, then verify the result with the corresponding `list`, `inspect`, or `get` command when useful.
 
 ## Common actions
 
-These are frequently used commands that are safe to invoke directly. For less common commands, use `warpctrl help`, `warpctrl action list`, or `warpctrl <group> <command> --help` to discover the exact syntax supported by the running build.
+These are frequently used commands that are safe to invoke directly. For less common commands, route by intent and use `{{warpctrl_binary_name}} <group> help` or `{{warpctrl_binary_name}} <group> <command> --help` to discover the exact syntax supported by the running build. Inspect the generic action catalog only when no dedicated group matches.
 
 ```sh
 # Create and manage tabs and panes
-warpctrl tab create
-warpctrl tab create --type agent
-warpctrl tab rename "server logs"
-warpctrl pane split --direction right
-warpctrl pane navigate --direction next
+{{warpctrl_binary_name}} tab create
+{{warpctrl_binary_name}} tab create --type agent
+{{warpctrl_binary_name}} tab rename "server logs"
+{{warpctrl_binary_name}} pane split --direction right
+{{warpctrl_binary_name}} pane navigate --direction next
 
 # Stage text in Warp's input without submitting it
-warpctrl input insert "git status"
-warpctrl input replace "cargo test"
+{{warpctrl_binary_name}} input insert "git status"
+{{warpctrl_binary_name}} input replace "cargo test"
 
-# Open Warp UI surfaces
-warpctrl surface list
-warpctrl surface settings open
-warpctrl surface command-palette open --query "theme"
-warpctrl surface theme-picker open
-warpctrl surface keybindings open
-warpctrl surface project-explorer open
-warpctrl surface global-search open
-warpctrl surface conversation-list open
-warpctrl surface code-review open
-warpctrl surface vertical-tabs open
-warpctrl surface agent-management open
+# Open or toggle Warp UI surfaces
+{{warpctrl_binary_name}} surface list
+{{warpctrl_binary_name}} surface settings open
+{{warpctrl_binary_name}} surface command-palette open --query "theme"
+{{warpctrl_binary_name}} surface command-search open
+{{warpctrl_binary_name}} surface theme-picker open
+{{warpctrl_binary_name}} surface keybindings open
+{{warpctrl_binary_name}} surface warp-drive open
+{{warpctrl_binary_name}} surface resource-center toggle
+{{warpctrl_binary_name}} surface ai-assistant toggle
+{{warpctrl_binary_name}} surface project-explorer open
+{{warpctrl_binary_name}} surface global-search open
+{{warpctrl_binary_name}} surface conversation-list open
+{{warpctrl_binary_name}} surface code-review open
+{{warpctrl_binary_name}} surface left-panel toggle
+{{warpctrl_binary_name}} surface right-panel toggle
+{{warpctrl_binary_name}} surface vertical-tabs open
+{{warpctrl_binary_name}} surface agent-management open
 
 # Open a file in Warp
-warpctrl file open ./src/main.rs --line 42
+{{warpctrl_binary_name}} file open ./src/main.rs --line 42
 
 # Inspect and update supported state
-warpctrl theme get
-warpctrl theme set "Dracula"
-warpctrl appearance get
-warpctrl setting list
-warpctrl keybinding list
+{{warpctrl_binary_name}} theme get
+{{warpctrl_binary_name}} theme set "Dracula"
+{{warpctrl_binary_name}} appearance get
+{{warpctrl_binary_name}} setting list
+{{warpctrl_binary_name}} keybinding list
 ```
 
 Add `--output-format json` when structured output is easier to consume:
 
 ```sh
-warpctrl --output-format json tab list
+{{warpctrl_binary_name}} --output-format json tab list
 ```
 
 ## Targeting
@@ -154,14 +152,15 @@ Use `surface list` before a walkthrough or multi-step UI workflow. It reports bo
 
 - Invoke close actions only when the user explicitly asks to close something. Close actions flow through normal Warp close behavior and may trigger existing app warnings.
 - `input insert` and `input replace` only stage text. Warp Control intentionally does not provide an action that submits or runs the input.
-- Do not invent unsupported commands. Use `help`, `action list`, or `action inspect` to discover the allowlisted surface.
+- Do not invent unsupported commands. Use the matching group's `help` first, then use `action list` or `action inspect` only when no dedicated group matches.
 - Warp Control affects only a running local Warp application owned by the same user. It does not control remote or cloud Warp instances.
+- Each channel-specific Warp Control CLI lists and targets only Warp instances from its own channel.
 - On Windows, local-control publication is disabled until authenticated broker transport is supported.
 
 ## Manual setup and troubleshooting
 
-Warp Control availability depends on the build channel and the **Settings > Scripting** toggle. The local-control mode defaults to enabled on internal dogfood builds (e.g., WarpDev) and disabled on public channels (Stable, Preview, OSS). On any channel, the final gate is the **Settings > Scripting** toggle. The installed `warpctrl` wrapper invokes the matching channel-specific Warp executable.
+Warp Control availability depends on the build channel and the **Settings > Scripting** toggle. The local-control mode defaults to enabled on internal dogfood builds (e.g., WarpDev) and disabled on public channels (Stable, Preview, OSS). On any channel, the final gate is the **Settings > Scripting** toggle. The installed `{{warpctrl_binary_name}}` wrapper invokes the matching channel-specific Warp executable.
 
-If `warpctrl instance list` is empty, confirm that a compatible Warp app is running and Scripting is enabled. If a command reports multiple instances, rerun it with `--instance <instance_id>`.
+If `{{warpctrl_binary_name}} instance list` is empty, confirm that a compatible same-channel Warp app is running and Scripting is enabled. If a command reports multiple instances, rerun it with `--instance <instance_id>`.
 
-If the wrapper is missing from the bundle or is not on `PATH`, use the matching direct-executable or full-bundle invocation documented in **How to invoke Warp Control**.
+If the symlink is not on `PATH`, follow the confirmation-gated setup flow in **How to invoke Warp Control** or use `{{warpctrl_wrapper_path}}` directly.

--- a/script/macos/bundle
+++ b/script/macos/bundle
@@ -557,21 +557,19 @@ EOF
   chmod +x "$CLI_SCRIPT_PATH"
 
   if [[ ",$FEATURES," =~ ",warp_control_cli," ]]; then
+    # Each value must match `Channel::warpctrl_command_name` in the Rust source.
     if [[ $RELEASE_CHANNEL = "stable" ]]; then
-      WARPCTRL_SCRIPT_PATH="$BUNDLED_RESOURCES_DIR/bin/warpctrl"
+      WARPCTRL_COMMAND_NAME="warpctrl"
     elif [[ $RELEASE_CHANNEL = "oss" ]]; then
-      WARPCTRL_SCRIPT_PATH="$BUNDLED_RESOURCES_DIR/bin/warpctrl-oss"
+      WARPCTRL_COMMAND_NAME="warpctrl-oss"
     else
-      WARPCTRL_SCRIPT_PATH="$BUNDLED_RESOURCES_DIR/bin/warpctrl-$RELEASE_CHANNEL"
+      WARPCTRL_COMMAND_NAME="warpctrl-$RELEASE_CHANNEL"
     fi
+    WARPCTRL_SCRIPT_PATH="$BUNDLED_RESOURCES_DIR/bin/$WARPCTRL_COMMAND_NAME"
     echo "Creating warpctrl wrapper script at $WARPCTRL_SCRIPT_PATH..."
-    cat > "$WARPCTRL_SCRIPT_PATH" << 'EOF'
-#!/bin/bash
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec -a "$0" "$script_dir/../../MacOS/WARP_BIN_PLACEHOLDER" --warpctrl "$@"
-EOF
-    sed -i '' "s/WARP_BIN_PLACEHOLDER/$WARP_BIN/" "$WARPCTRL_SCRIPT_PATH"
-    chmod +x "$WARPCTRL_SCRIPT_PATH"
+    "$WORKSPACE_ROOT_DIR/script/macos/create_warpctrl_wrapper" \
+      "$WARPCTRL_SCRIPT_PATH" \
+      "../../MacOS/$WARP_BIN"
   fi
 
   # Store the built artifact locations for GitHub Actions outputs.
@@ -611,13 +609,9 @@ elif [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
     fi
     WARPCTRL_SCRIPT_PATH="$OUT_DIR/warpctrl"
     echo "Creating warpctrl wrapper script at $WARPCTRL_SCRIPT_PATH"
-    cat > "$WARPCTRL_SCRIPT_PATH" << 'EOF'
-#!/bin/bash
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec -a "$0" "$script_dir/WARP_BIN_PLACEHOLDER" --warpctrl "$@"
-EOF
-    sed -i '' "s/WARP_BIN_PLACEHOLDER/$WARP_BIN/" "$WARPCTRL_SCRIPT_PATH"
-    chmod +x "$WARPCTRL_SCRIPT_PATH"
+    "$WORKSPACE_ROOT_DIR/script/macos/create_warpctrl_wrapper" \
+      "$WARPCTRL_SCRIPT_PATH" \
+      "$WARP_BIN"
   fi
 
   if [[ -n "$TARGET_ARCH" && -e "target/$DEFAULT_TARGET/$TARGET_PROFILE_DIR/$WARP_BIN.dSYM" ]]; then

--- a/script/macos/bundle
+++ b/script/macos/bundle
@@ -286,6 +286,8 @@ elif [[ $RELEASE_CHANNEL = "dev" ]]; then
     FEATURES="$FEATURES,agent_mode_debug"
     # Enable heap usage tracking & profiling using jemalloc through pprof.
     FEATURES="$FEATURES,jemalloc_pprof,heap_usage_tracking"
+    # Enable the Warp Control CLI wrapper for local scripting/automation.
+    FEATURES="$FEATURES,warp_control_cli"
     # For dev builds, use different versions of our bundled frameworks (e.g.:
     # Sentry).  This needs to be exported so it can be referenced by
     # app/build.rs later, while running `cargo bundle`.
@@ -555,8 +557,14 @@ EOF
   chmod +x "$CLI_SCRIPT_PATH"
 
   if [[ ",$FEATURES," =~ ",warp_control_cli," ]]; then
-    WARPCTRL_SCRIPT_PATH="$BUNDLED_RESOURCES_DIR/bin/warpctrl"
-    echo "Creating warpctrl wrapper script..."
+    if [[ $RELEASE_CHANNEL = "stable" ]]; then
+      WARPCTRL_SCRIPT_PATH="$BUNDLED_RESOURCES_DIR/bin/warpctrl"
+    elif [[ $RELEASE_CHANNEL = "oss" ]]; then
+      WARPCTRL_SCRIPT_PATH="$BUNDLED_RESOURCES_DIR/bin/warpctrl-oss"
+    else
+      WARPCTRL_SCRIPT_PATH="$BUNDLED_RESOURCES_DIR/bin/warpctrl-$RELEASE_CHANNEL"
+    fi
+    echo "Creating warpctrl wrapper script at $WARPCTRL_SCRIPT_PATH..."
     cat > "$WARPCTRL_SCRIPT_PATH" << 'EOF'
 #!/bin/bash
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/script/macos/create_warpctrl_wrapper
+++ b/script/macos/create_warpctrl_wrapper
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <wrapper-path> <binary-relative-path>" >&2
+  exit 1
+fi
+
+WRAPPER_PATH="$1"
+BINARY_RELATIVE_PATH="$2"
+
+mkdir -p "$(dirname "$WRAPPER_PATH")"
+cat > "$WRAPPER_PATH" << EOF
+#!/bin/bash
+script_dir="\$(cd "\$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
+exec -a "\$0" "\$script_dir/$BINARY_RELATIVE_PATH" --warpctrl "\$@"
+EOF
+chmod +x "$WRAPPER_PATH"

--- a/script/macos/create_warpctrl_wrapper
+++ b/script/macos/create_warpctrl_wrapper
@@ -13,7 +13,21 @@ BINARY_RELATIVE_PATH="$2"
 mkdir -p "$(dirname "$WRAPPER_PATH")"
 cat > "$WRAPPER_PATH" << EOF
 #!/bin/bash
-script_dir="\$(cd "\$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
+# This wrapper may be installed through a symlink in /usr/local/bin. Resolve
+# symlinks before locating the Warp executable relative to the bundled wrapper.
+wrapper_path="\${BASH_SOURCE[0]}"
+while [[ -L "\$wrapper_path" ]]; do
+  wrapper_dir="\$(cd -P "\$(dirname "\$wrapper_path")" && pwd)"
+  wrapper_path="\$(readlink "\$wrapper_path")"
+  if [[ "\$wrapper_path" != /* ]]; then
+    wrapper_path="\$wrapper_dir/\$wrapper_path"
+  fi
+done
+script_dir="\$(cd -P "\$(dirname "\$wrapper_path")" && pwd)"
+
+# Warp Control has a separate argument parser from the normal Warp/Oz parser.
+# The hidden flag selects it before normal CLI parsing or GUI startup.
+# Replace the wrapper process while preserving its invocation name as argv[0].
 exec -a "\$0" "\$script_dir/$BINARY_RELATIVE_PATH" --warpctrl "\$@"
 EOF
 chmod +x "$WRAPPER_PATH"

--- a/script/macos/run
+++ b/script/macos/run
@@ -135,6 +135,20 @@ if [[ ",$FEATURES," =~ ",heap_usage_tracking," ]]; then
   "${REPO_ROOT}/script/prepare_bundled_pprof" "$HELPERS_DIR"
 fi
 
+if [[ ",$FEATURES," =~ ",warp_control_cli," ]]; then
+  WARPCTRL_RESOURCES_DIR="$WARP_APP_PATH/Contents/Resources/bin"
+  echo "Creating warpctrl wrapper script for local run..."
+  mkdir -p "$WARPCTRL_RESOURCES_DIR"
+  WARPCTRL_SCRIPT_PATH="$WARPCTRL_RESOURCES_DIR/warpctrl"
+  cat > "$WARPCTRL_SCRIPT_PATH" << 'EOF'
+#!/bin/bash
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec -a "$0" "$script_dir/../../MacOS/WARP_BIN_PLACEHOLDER" --warpctrl "$@"
+EOF
+  sed -i '' "s/WARP_BIN_PLACEHOLDER/$WARP_BIN_NAME/" "$WARPCTRL_SCRIPT_PATH"
+  chmod +x "$WARPCTRL_SCRIPT_PATH"
+fi
+
 echo "Codesigning app..."
 SIGNING_CERT="$(security find-identity -p codesigning -v | grep "Apple Development" | awk '{print $2}' | head -1)"
 codesign --force --deep --options runtime --sign "${SIGNING_CERT:--}" "$WARP_APP_PATH" --entitlements script/Debug-Entitlements.plist

--- a/script/macos/run
+++ b/script/macos/run
@@ -136,17 +136,11 @@ if [[ ",$FEATURES," =~ ",heap_usage_tracking," ]]; then
 fi
 
 if [[ ",$FEATURES," =~ ",warp_control_cli," ]]; then
-  WARPCTRL_RESOURCES_DIR="$WARP_APP_PATH/Contents/Resources/bin"
-  echo "Creating warpctrl wrapper script for local run..."
-  mkdir -p "$WARPCTRL_RESOURCES_DIR"
-  WARPCTRL_SCRIPT_PATH="$WARPCTRL_RESOURCES_DIR/warpctrl"
-  cat > "$WARPCTRL_SCRIPT_PATH" << 'EOF'
-#!/bin/bash
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec -a "$0" "$script_dir/../../MacOS/WARP_BIN_PLACEHOLDER" --warpctrl "$@"
-EOF
-  sed -i '' "s/WARP_BIN_PLACEHOLDER/$WARP_BIN_NAME/" "$WARPCTRL_SCRIPT_PATH"
-  chmod +x "$WARPCTRL_SCRIPT_PATH"
+  WARPCTRL_SCRIPT_PATH="$WARP_APP_PATH/Contents/Resources/bin/warpctrl-$WARP_CHANNEL"
+  echo "Creating warpctrl wrapper script at $WARPCTRL_SCRIPT_PATH..."
+  "${REPO_ROOT}/script/macos/create_warpctrl_wrapper" \
+    "$WARPCTRL_SCRIPT_PATH" \
+    "../../MacOS/$WARP_BIN_NAME"
 fi
 
 echo "Codesigning app..."

--- a/script/macos/test_create_warpctrl_wrapper
+++ b/script/macos/test_create_warpctrl_wrapper
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+workspace_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "$temp_dir"' EXIT
+
+bundle_dir="$temp_dir/WarpDev.app/Contents"
+wrapper_path="$bundle_dir/Resources/bin/warpctrl-dev"
+binary_path="$bundle_dir/MacOS/dev"
+installed_path="$temp_dir/usr/local/bin/warpctrl-dev"
+forwarded_args_file="$temp_dir/forwarded-args"
+expected_args_file="$temp_dir/expected-args"
+
+mkdir -p "$(dirname "$binary_path")" "$(dirname "$installed_path")"
+cat > "$binary_path" << 'EOF'
+#!/bin/bash
+printf '%s\n' "$@" > "$FORWARDED_ARGS_FILE"
+EOF
+chmod +x "$binary_path"
+
+"$workspace_root/script/macos/create_warpctrl_wrapper" \
+  "$wrapper_path" \
+  "../../MacOS/dev"
+
+cat > "$expected_args_file" << 'EOF'
+--warpctrl
+tab
+create
+--instance
+inst 123
+EOF
+
+FORWARDED_ARGS_FILE="$forwarded_args_file" \
+  "$wrapper_path" tab create --instance "inst 123"
+cmp "$expected_args_file" "$forwarded_args_file"
+
+ln -s "$wrapper_path" "$installed_path"
+FORWARDED_ARGS_FILE="$forwarded_args_file" \
+  "$installed_path" tab create --instance "inst 123"
+cmp "$expected_args_file" "$forwarded_args_file"

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -25,6 +25,12 @@
       "skillPath": ".agents/skills/create-pr/SKILL.md",
       "computedHash": "d9f06f0219b3d402cf1ff3b0ee3a4d6d38f259a0dcf6103a99b1815c2b81d95b"
     },
+    "cross-critique": {
+      "source": "warpdotdev/common-skills",
+      "sourceType": "github",
+      "skillPath": ".agents/skills/cross-critique/SKILL.md",
+      "computedHash": "eba85912da3e1fba5e698aed0932de110deb9ef8af71ba8bdd7161cba97c8471"
+    },
     "diagnose-ci-failures": {
       "source": "warpdotdev/common-skills",
       "sourceType": "github",
@@ -54,6 +60,12 @@
       "sourceType": "github",
       "skillPath": ".agents/skills/reproduce-bug-report/SKILL.md",
       "computedHash": "a906c867389e3ee76d9196cad893fb3ba7e5f0e27248373b53e30358aac5fe44"
+    },
+    "research": {
+      "source": "warpdotdev/common-skills",
+      "sourceType": "github",
+      "skillPath": ".agents/skills/research/SKILL.md",
+      "computedHash": "3be91fef9f9dea2bf6f9af84914dabd4719a5dea35fefeb46174fc0714ed5b47"
     },
     "resolve-merge-conflicts": {
       "source": "warpdotdev/common-skills",

--- a/specs/warp-control-cli/PRODUCT.md
+++ b/specs/warp-control-cli/PRODUCT.md
@@ -26,16 +26,17 @@ Warp has rich interactive actions reachable through UI, keybindings, menus, and 
 3. **Deterministic demos and walkthroughs.** A script puts Warp into a known presentation state: theme, zoom, windows, tabs, panes, focused targets, panels, and surfaces. The walkthrough advances using structured target IDs and recovers from stale or missing targets.
 4. **Personalization and preference migration.** An agent inspects settings, proposes Warp equivalents from other tools, applies allowlisted changes, and reports unsupported mappings explicitly.
 ## Behavior
-1. The CLI operates only on running local Warp app processes. If no compatible process is available, it exits non-zero with a structured error.
+1. The CLI operates only on running local Warp app processes from the same channel as the channel-specific CLI binary. If no compatible same-channel process is available, it exits non-zero with a structured error.
 2. The CLI exposes only the 84 explicitly allowlisted actions. Unknown, unsupported, or non-allowlisted requests fail with structured errors and are never forwarded to arbitrary internal dispatch.
 3. Every successful mutating request identifies the Warp process instance, resolved target, and a success payload suitable for JSON output.
 4. Every failure identifies a stable machine-readable error code, a human-readable explanation, and any selector that was ambiguous, missing, stale, or invalid.
 5. The CLI supports human-readable output by default and JSON output for scripts with stable field names.
 6. Process discovery and instance selection:
-   - `warpctrl instance list` returns all reachable local Warp app processes.
+   - `warpctrl instance list` returns all reachable local Warp app processes from the CLI binary's channel.
    - Each process has an opaque `instance_id`, channel/build identity, and display metadata.
    - If exactly one compatible process is available, commands target it implicitly.
    - If multiple compatible processes are available and no single clearly active instance exists, the CLI fails and asks for an explicit `--instance` selector.
+   - Explicit `--instance` and `--pid` selectors cannot target a process from another channel.
 7. Target introspection:
    - `warpctrl window list`, `warpctrl tab list`, `warpctrl pane list`, `warpctrl session list`, `warpctrl app active`.
    - These return opaque protocol-facing IDs and metadata for subsequent commands.
@@ -61,7 +62,7 @@ The two input commands (`input.insert`, `input.replace`) only stage or edit text
 The public catalog contains exactly 84 actions. The Block, Auth, Drive, and History families are entirely absent. Input is limited to `input.insert` and `input.replace`. Actions are organized by noun and use the exact dotted names from the authoritative `ActionKind` catalog.
 ### Instance (2 actions)
 All default-authorized.
-- `instance.list` — list reachable Warp app processes.
+- `instance.list` — list reachable Warp app processes from the CLI binary's channel.
 - `instance.inspect` — metadata for one instance.
 ### App (4 actions)
 All default-authorized.

--- a/specs/warp-control-cli/README.md
+++ b/specs/warp-control-cli/README.md
@@ -35,7 +35,7 @@ Installer helper creation and release-artifact wiring still need a later packagi
 Use matching app and CLI bits from the same branch or release artifact so the protocol version and action catalog agree.
 1. Start Warp and leave at least one window open.
 2. Open **Settings > Scripting**. Local control is enabled by default on internal dogfood builds and disabled by default on public channels (Stable, Preview, OSS). Verify that the Scripting toggle is set to **Enabled**, and enable it if needed. Enabling scripting allows for programmatic and agentic control of Warp; refer to the docs for more info.
-3. Confirm that the local-control server registered the running process:
+3. Confirm that the local-control server registered the running same-channel process:
    ```bash
    warpctrl instance list
    ```
@@ -45,11 +45,11 @@ Use matching app and CLI bits from the same branch or release artifact so the pr
    warpctrl app version
    warpctrl surface list
    ```
-5. If exactly one compatible instance is listed, create a new terminal tab:
+5. If exactly one compatible same-channel instance is listed, create a new terminal tab:
    ```bash
    warpctrl tab create
    ```
-6. If multiple compatible instances are listed, copy the desired `instance_id` and target it explicitly:
+6. If multiple compatible same-channel instances are listed, copy the desired `instance_id` and target it explicitly:
    ```bash
    warpctrl app ping --instance <instance_id>
    warpctrl app version --instance <instance_id>
@@ -64,6 +64,7 @@ Expected failures:
 - `warpctrl instance list` with no running compatible app: exits zero with an empty list;
 - a command that needs a selected app when no compatible app is running: exits non-zero with a no-instance error;
 - multiple ambiguous instances: exits non-zero and asks for `--instance`;
+- an explicit instance or PID from another channel: exits non-zero with a no-instance error;
 - unsupported app build or stale discovery record: exits non-zero with a protocol, stale-target, or transport error;
 ## Security model
 The local-control protocol is designed for same-user scripting, not cross-user or network access. The trust boundary is the local user account.
@@ -71,7 +72,8 @@ The local-control protocol is designed for same-user scripting, not cross-user o
 - **Brokered scoped credentials.** Discovery records contain instance metadata, loopback control-endpoint information, and an instance-bound Unix-domain-socket broker reference when Scripting is enabled. The broker authenticates the connecting OS user with kernel peer credentials before decoding the credential request or issuing an action-scoped credential. Records do not contain bearer tokens or reusable full-access credentials.
 - **Short-lived grants.** `warpctrl` requests an action-scoped credential over the owner-authenticated broker socket for the selected instance, then presents that credential to `/v1/control`. Grants are instance-bound, expired entries are pruned, and the in-memory grant set is capped. Missing, invalid, expired, revoked, or wrong-instance credentials are rejected before request decoding. After decoding identifies the requested action, insufficient-scope credentials are rejected before selector resolution or handler dispatch.
 - **Protected local state.** The authoritative Scripting setting uses platform secure storage, never imports a value from ordinary or private preferences, and defaults to enabled only on internal dogfood channels (disabled by default on public channels). On POSIX platforms, discovery records and broker sockets use owner-only permissions. On Windows, local-control publication remains disabled until equivalent ACL and broker protections are implemented.
-- **Stale-record pruning.** On each `instance list` or implicit discovery call, records whose PID is no longer alive are deleted automatically. Candidates are also health-probed and accepted only when the live app reports the expected instance identity.
+- **Channel-scoped discovery.** Each channel-specific CLI considers only records from its own Warp channel. Listing, implicit selection, and explicit instance or PID selection cannot target another channel.
+- **Stale-record pruning.** On each `instance list` or implicit discovery call, same-channel records whose PID is no longer alive are deleted automatically. Candidates are also health-probed and accepted only when the live app reports the expected instance identity.
 - **No CORS.** The control endpoints do not set permissive CORS headers, so browser-origin JavaScript cannot read responses even if it guesses the port. The credential requirement provides a second layer since browsers cannot read the brokered credential material.
 ```mermaid
 sequenceDiagram

--- a/specs/warp-control-cli/TECH.md
+++ b/specs/warp-control-cli/TECH.md
@@ -75,7 +75,7 @@ Design:
 - Each process writes a discovery record into a secure per-user directory when Scripting is enabled.
 - The record contains: `instance_id`, PID, channel/build metadata, control-listener endpoint, protocol version, start timestamp, and the filename of its instance-bound broker socket.
 - The record does not contain bearer tokens, raw credentials, or control authority.
-- The CLI loads records, rejects records whose endpoint is not exactly `127.0.0.1` or whose broker socket is not the expected filename, prunes stale records after health checks, and selects an instance using product selector rules.
+- The CLI passes its compiled channel into the shared discovery scan. The scan excludes records from other channels before returning candidates, rejects records whose endpoint is not exactly `127.0.0.1` or whose broker socket is not the expected filename, prunes stale same-channel records after health checks, and selects an instance using product selector rules. This same-channel boundary applies to listing, implicit selection, and explicit instance or PID selection.
 - When Scripting is disabled, no discovery record is published.
 Default discovery directory: `~/.warp/local-control/`. `$XDG_RUNTIME_DIR/warp/local-control` is preferred when available. On Unix, the directory is restricted to `0700` and records/sockets to `0600`.
 ### 3. Credential broker
@@ -206,7 +206,7 @@ sequenceDiagram
     participant BRIDGE as App bridge
     participant UI as Warp app state
 
-    CLI->>REG: Read instance discovery records
+    CLI->>REG: Read same-channel instance discovery records
     CLI->>HTTP: Health/protocol check (app.ping)
     HTTP-->>CLI: Instance metadata
     CLI->>CLI: Resolve instance selector
@@ -230,6 +230,7 @@ sequenceDiagram
 - **Scripting gate:** Disabled state rejects all credential requests and control requests. Enabled state allows them. Toggling invalidates outstanding credentials.
 - **Credential model:** Raw credentials never appear in discovery records. Credentials are instance-bound, action-bound, and short-lived. A credential for one action fails with `insufficient_permissions` for any other action.
 - **Selector resolution:** Tests for active, explicit ID, index, stale target, ambiguous target, missing target, and target-state-conflict cases.
+- **Channel isolation:** Discovery tests prove that a CLI scan excludes records published by other Warp channels.
 - **Input staging:** Only `input.insert` and `input.replace` exist. No `input.run`, `input.get`, `input.clear`, or `input.mode.set`. Tests prove no buffer submission occurs.
 - **Excluded families:** The Block, Auth, Drive, and History families are entirely absent. The CLI rejects their command routes at parse time, the protocol rejects their action names at deserialization (`invalid_request`), and `action.inspect`/`capability.inspect` report non-catalog names as `not_allowlisted`.
 - **Unsupported platforms:** Windows fails closed with no fallback.


### PR DESCRIPTION
## Description

Ships channel-specific Warp Control wrappers and a complete macOS install flow.

- Packages the correct wrapper for each channel and makes installed wrappers reliably dispatch back into their app bundle.
- Adds safe install/uninstall actions plus an installed-status control under **Settings > Scripting**.
- Templates the bundled Warp Control skill with the active channel's command and wrapper path, including confirmation-gated symlink setup and serial execution guidance.
- Scopes discovery and action selection to the CLI's channel, atomically publishes records, and prunes stale or malformed registry artifacts.

## Linked Issue

None.

## Testing

- [x] `./script/format`
- [x] `cargo check -p warp --features warp_control_cli`
- [x] `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- [x] Focused bundled-skill, CLI install-status, and local-control discovery nextest tests
- [x] `./script/macos/test_create_warpctrl_wrapper`
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was updated via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>