### PR TITLE
Add show hidden files toggle to Settings UI + fix backward-compat regression

### DIFF
--- a/app/src/code/file_tree/view/view_tests.rs
+++ b/app/src/code/file_tree/view/view_tests.rs
@@ -6,15 +6,17 @@ use repo_metadata::local_model::IndexedRepoState;
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::watcher::DirectoryWatcher;
 use repo_metadata::RepoMetadataModel;
+use settings::Setting;
 use virtual_fs::{Stub, VirtualFS};
 use warp_core::ui::appearance::Appearance;
 use warpui::platform::WindowStyle;
-use warpui::{App, ModelHandle};
+use warpui::{App, ModelHandle, SingletonEntity};
 
 use super::FileTreeView;
 use crate::auth::AuthStateProvider;
 use crate::server::server_api::team::MockTeamClient;
 use crate::server::server_api::workspace::MockWorkspaceClient;
+use crate::settings::CodeSettings;
 use crate::settings_view::keybindings::KeybindingChangedNotifier;
 use crate::test_util::settings::initialize_settings_for_tests;
 use crate::vim_registers::VimRegisters;
@@ -126,6 +128,13 @@ fn flattened_paths(
         .collect()
 }
 
+fn set_show_hidden_files(app: &mut App, show_hidden_files: bool) {
+    CodeSettings::handle(app).update(app, |settings, ctx| {
+        Setting::set_value(&mut settings.show_hidden_files, show_hidden_files, ctx)
+            .expect("show hidden files setting updates");
+    });
+}
+
 #[test]
 fn hidden_files_are_filtered_until_setting_is_enabled() {
     VirtualFS::test("file_tree_hidden_files_setting", |dirs, mut vfs| {
@@ -141,6 +150,7 @@ fn hidden_files_are_filtered_until_setting_is_enabled() {
 
         App::test((), |mut app| async move {
             let _ = initialize_app(&mut app);
+            set_show_hidden_files(&mut app, false);
             let (_, file_tree_view) = app.add_window(WindowStyle::NotStealFocus, FileTreeView::new);
 
             file_tree_view.update(&mut app, |view, ctx| {
@@ -156,13 +166,7 @@ fn hidden_files_are_filtered_until_setting_is_enabled() {
                 assert!(!paths.contains(&std_path(&hidden_dir)));
             });
 
-            <crate::settings::CodeSettings as warpui::SingletonEntity>::handle(&app).update(
-                &mut app,
-                |settings, ctx| {
-                    settings::Setting::set_value(&mut settings.show_hidden_files, true, ctx)
-                        .expect("show hidden files setting updates");
-                },
-            );
+            set_show_hidden_files(&mut app, true);
 
             file_tree_view.read(&app, |view, _ctx| {
                 let paths = flattened_paths(view, &tree);
@@ -186,6 +190,7 @@ fn hidden_root_directory_is_not_filtered() {
 
         App::test((), |mut app| async move {
             let _ = initialize_app(&mut app);
+            set_show_hidden_files(&mut app, false);
             let (_, file_tree_view) = app.add_window(WindowStyle::NotStealFocus, FileTreeView::new);
 
             file_tree_view.update(&mut app, |view, ctx| {
@@ -217,13 +222,7 @@ fn selected_hidden_file_is_cleared_when_filtered() {
 
             App::test((), |mut app| async move {
                 let _ = initialize_app(&mut app);
-                <crate::settings::CodeSettings as warpui::SingletonEntity>::handle(&app).update(
-                    &mut app,
-                    |settings, ctx| {
-                        settings::Setting::set_value(&mut settings.show_hidden_files, true, ctx)
-                            .expect("show hidden files setting updates");
-                    },
-                );
+                set_show_hidden_files(&mut app, true);
 
                 let (_, file_tree_view) =
                     app.add_window(WindowStyle::NotStealFocus, FileTreeView::new);
@@ -245,13 +244,7 @@ fn selected_hidden_file_is_cleared_when_filtered() {
                     view.select_id(&id, ctx);
                 });
 
-                <crate::settings::CodeSettings as warpui::SingletonEntity>::handle(&app).update(
-                    &mut app,
-                    |settings, ctx| {
-                        settings::Setting::set_value(&mut settings.show_hidden_files, false, ctx)
-                            .expect("show hidden files setting updates");
-                    },
-                );
+                set_show_hidden_files(&mut app, false);
 
                 file_tree_view.read(&app, |view, _ctx| {
                     let paths = flattened_paths(view, &tree);

--- a/app/src/settings/code.rs
+++ b/app/src/settings/code.rs
@@ -62,7 +62,7 @@ define_settings_group!(CodeSettings, settings: [
     // Controls whether hidden files (dotfiles) are shown in the project explorer.
     show_hidden_files: ShowHiddenFiles {
         type: bool,
-        default: false,
+        default: true,
         supported_platforms: SupportedPlatforms::ALL,
         sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
         private: false,

--- a/app/src/settings_view/code_page.rs
+++ b/app/src/settings_view/code_page.rs
@@ -371,6 +371,7 @@ impl CodeSettingsPageView {
                 Box::new(CodeReviewDiffStatsToggleWidget::default()),
                 Box::new(ProjectExplorerToggleWidget::default()),
                 Box::new(GlobalSearchToggleWidget::default()),
+                Box::new(ShowHiddenFilesToggleWidget::default()),
                 Box::new(FormatOnSaveToggleWidget::default()),
             ]);
             let categories = vec![
@@ -455,6 +456,7 @@ impl CodeSettingsPageView {
                             Box::new(CodeReviewDiffStatsToggleWidget::default()),
                             Box::new(ProjectExplorerToggleWidget::default()),
                             Box::new(GlobalSearchToggleWidget::default()),
+                            Box::new(ShowHiddenFilesToggleWidget::default()),
                             Box::new(FormatOnSaveToggleWidget::default()),
                         ]);
                     }
@@ -505,6 +507,7 @@ impl CodeSettingsPageView {
                 Box::new(CodeReviewDiffStatsToggleWidget::default()),
                 Box::new(ProjectExplorerToggleWidget::default()),
                 Box::new(GlobalSearchToggleWidget::default()),
+                Box::new(ShowHiddenFilesToggleWidget::default()),
                 Box::new(FormatOnSaveToggleWidget::default()),
             ]);
             let categories = vec![
@@ -625,6 +628,7 @@ pub enum CodeSettingsPageAction {
     ToggleAutoOpenCodeReviewPane,
     ToggleProjectExplorer,
     ToggleGlobalSearch,
+    ToggleShowHiddenFiles,
     ToggleFormatOnSave,
     /// Install (if needed) and enable a suggested LSP server.
     InstallAndEnableLspServer {
@@ -826,6 +830,12 @@ impl TypedActionView for CodeSettingsPageView {
                 });
                 ctx.notify();
             }
+            CodeSettingsPageAction::ToggleShowHiddenFiles => {
+                CodeSettings::handle(ctx).update(ctx, |settings, ctx| {
+                    report_if_error!(settings.show_hidden_files.toggle_and_save_value(ctx));
+                });
+                ctx.notify();
+            }
             CodeSettingsPageAction::ToggleFormatOnSave => {
                 CodeSettings::handle(ctx).update(ctx, |settings, ctx| {
                     report_if_error!(settings.format_on_save.toggle_and_save_value(ctx));
@@ -985,6 +995,14 @@ pub fn init_actions_from_parent_view<T: Action + Clone>(
                     )),
                     context,
                     flags::SHOW_GLOBAL_SEARCH,
+                ),
+                ToggleSettingActionPair::new(
+                    "show hidden files in project explorer",
+                    builder(SettingsAction::Code(
+                        CodeSettingsPageAction::ToggleShowHiddenFiles,
+                    )),
+                    context,
+                    flags::SHOW_HIDDEN_FILES,
                 ),
             ],
             app,
@@ -2853,6 +2871,48 @@ impl SettingsWidget for GlobalSearchToggleWidget {
                 })
                 .finish(),
             Some("Adds global file search to the left side tools panel.".into()),
+        )
+    }
+}
+
+#[derive(Default)]
+struct ShowHiddenFilesToggleWidget {
+    switch_state: SwitchStateHandle,
+}
+
+impl SettingsWidget for ShowHiddenFilesToggleWidget {
+    type View = CodeSettingsPageView;
+
+    fn search_terms(&self) -> &str {
+        "show hidden files dotfiles project explorer file tree"
+    }
+
+    fn render(
+        &self,
+        _view: &Self::View,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let code_settings = CodeSettings::as_ref(app);
+
+        render_body_item::<CodeSettingsPageAction>(
+            "Show hidden files in project explorer".into(),
+            None,
+            LocalOnlyIconState::Hidden,
+            ToggleState::Enabled,
+            appearance,
+            appearance
+                .ui_builder()
+                .switch(self.switch_state.clone())
+                .check(*code_settings.show_hidden_files)
+                .build()
+                .on_click(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(CodeSettingsPageAction::ToggleShowHiddenFiles);
+                })
+                .finish(),
+            Some(
+                "Show dotfiles and hidden files (starting with .) in the project explorer.".into(),
+            ),
         )
     }
 }

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -598,6 +598,7 @@ pub mod flags {
     pub const SHOW_CONVERSATION_HISTORY: &str = "ShowConversationHistory";
     pub const SHOW_PROJECT_EXPLORER: &str = "ShowProjectExplorer";
     pub const SHOW_GLOBAL_SEARCH: &str = "ShowGlobalSearch";
+    pub const SHOW_HIDDEN_FILES: &str = "ShowHiddenFiles";
 }
 
 pub fn init_actions_from_parent_view<T: Action + Clone>(

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -25322,6 +25322,9 @@ impl View for Workspace {
         if *CodeSettings::as_ref(app).show_global_search {
             context.set.insert(flags::SHOW_GLOBAL_SEARCH);
         }
+        if *CodeSettings::as_ref(app).show_hidden_files {
+            context.set.insert(flags::SHOW_HIDDEN_FILES);
+        }
 
         if self.team_uid(app).is_some() {
             context.set.insert("WarpDrive_BelongsToTeam");


### PR DESCRIPTION
## Description

Addresses two issues from the feedback on PR #9532 (show hidden files toggle):

**1. Backward compatibility fix**: The `show_hidden_files` setting was introduced with a default of `false`, which caused a regression for all existing users — before this feature landed, all files were visible. Users who upgraded suddenly found their hidden dotfiles (`.gitignore`, `.env`, etc.) gone from the project explorer. This PR changes the default to `true` to preserve the pre-existing behavior for users who haven't explicitly configured this setting.

**2. Settings UI toggle**: Adds a "Show hidden files in project explorer" toggle to **Settings → Code → Editor and Code Review**, placed after the Global file search toggle. Previously the only way to change this was via the eye icon in the project explorer header, the `Cmd/Ctrl+Shift+.` keyboard shortcut, or by editing `settings.toml` directly.

The toggle is also discoverable through the Command Palette with "Enable show hidden files in project explorer" / "Disable show hidden files in project explorer" entries.

## Linked Issue

Feedback from Slack (feedback-app channel) on #9532.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
https://github.com/user-attachments/assets/5f5f91a2-e9f2-4e6d-9cd1-94607939aa2d

- [x] I have manually tested my changes locally with `./script/run`

Changes compile without errors (`cargo check` passes, `cargo clippy --lib` passes, `./script/format` passes).

### Files Changed

- `app/src/settings/code.rs` — change `show_hidden_files` default from `false` to `true`
- `app/src/settings_view/code_page.rs` — add `ToggleShowHiddenFiles` action, handler, `ShowHiddenFilesToggleWidget`, Command Palette entry
- `app/src/settings_view/mod.rs` — add `SHOW_HIDDEN_FILES` context flag constant
- `app/src/workspace/view.rs` — set `SHOW_HIDDEN_FILES` context flag in `keymap_context`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: Added a "Show hidden files in project explorer" toggle to Settings → Code → Editor and Code Review.
CHANGELOG-BUG-FIX: Fixed regression from #9532 where existing users lost visibility of hidden dotfiles in the project explorer after updating.
-->

_Conversation: https://staging.warp.dev/conversation/03e6fb6a-e502-4cbd-b5e7-257c3bc21171_
_Run: https://oz.staging.warp.dev/runs/019ed235-46a2-7a29-81df-7d946d50215d_

_This PR was generated with [Oz](https://warp.dev/oz)._
