### PR TITLE
fix(blocklist): enable soft wrap for lengthy requested command text in header

### DIFF
--- a/app/src/ai/blocklist/inline_action/requested_command.rs
+++ b/app/src/ai/blocklist/inline_action/requested_command.rs
@@ -1173,7 +1173,9 @@ impl RequestedCommandView {
         }
 
         if let Some(font_override) = font_override {
-            config = config.with_font_family(font_override);
+            config = config
+                .with_font_family(font_override)
+                .with_soft_wrap_title();
         }
         if let Some(font_color_override) = font_color_override {
             config = config.with_font_color(font_color_override);


### PR DESCRIPTION
## Description

Enable soft wrapping for lengthy requested command text in the inline action header.

When an agent uses the `requested_command` tool with a lengthy single-line command, the command text was being visually clipped/truncated in the header UI block. The `format_command_text` function correctly handles multi-line commands (truncating at the first newline with `…`), but for single-line commands of any length, the full text was returned unchanged and then visually clipped by the `Clipped` wrapper around the header element.

The fix adds `.with_soft_wrap_title()` to the `HeaderConfig` whenever command text is being displayed (indicated by `font_override` being set to the monospace font family). This allows long commands to wrap to multiple lines in the header rather than being cut off, making the full command visible to users.

The fix only applies when showing actual command text (Queued, Preprocessing, and Finished states), not when showing status messages like "Generating command..." or "OK if I run this command and read the output?".

## Linked Issue

- Fixes https://github.com/warpdotdev/warp/issues/12707
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

All existing unit tests for `format_command_text` continue to pass (7/7).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/ef59e611-0bae-4b6b-8c34-c5efd9c1df98
Run: https://oz.staging.warp.dev/runs/019ed2ac-3382-7d07-8e3c-bc18f2f9cd26

<!--
CHANGELOG-BUG-FIX: Fixed lengthy single-line agent commands being truncated/clipped in the requested command header UI.
-->
