### PR TITLE
Fix cursor not changing to pointing hand on file chip hover

### DIFF
--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -481,6 +481,12 @@ pub(super) struct AIBlockStateHandles {
     /// ReadSkill and ReadFiles action banners. Keyed by action id so that
     /// multiple skill banners in the same block don't share hover/click state.
     skill_button_handles: HashMap<AIAgentActionId, MouseStateHandle>,
+
+    /// Per-image-attachment `MouseStateHandle`s used to set a pointing-hand
+    /// cursor on clickable image chips in the query section. One handle per
+    /// image attachment, in order. Must be pre-allocated (not inline during
+    /// render) so that `Hoverable`'s hover state persists across frames.
+    pub(super) attachment_chip_handles: Vec<MouseStateHandle>,
 }
 
 #[derive(Default, Clone, Debug)]
@@ -1516,6 +1522,16 @@ impl AIBlock {
             terminal_view_handle,
             ask_user_question_view: None,
         };
+        // Pre-allocate one handle per image attachment so that the `Hoverable`
+        // wrapping each clickable chip sees the same handle across frames.
+        if FeatureFlag::ImageAsContext.is_enabled() {
+            me.state_handles.attachment_chip_handles =
+                attachment_names(me.model.inputs_to_render(ctx))
+                    .into_iter()
+                    .filter(|(attachment_type, _)| matches!(attachment_type, AttachmentType::Image))
+                    .map(|_| MouseStateHandle::default())
+                    .collect();
+        }
         me.run_secret_redaction_on_user_query(me.client_ids.conversation_id, ctx);
         me.spawn_link_detection(ctx);
 

--- a/app/src/ai/blocklist/block/view_impl.rs
+++ b/app/src/ai/blocklist/block/view_impl.rs
@@ -1006,6 +1006,7 @@ impl View for AIBlock {
                         .pending_context_selected_text()
                         .is_some(),
                     attachments: &attachment_name_list,
+                    attachment_chip_handles: &self.state_handles.attachment_chip_handles,
                     find_context: self.find_model.as_ref(app).is_find_bar_open().then_some(
                         FindContext {
                             model: self.find_model.as_ref(app),

--- a/app/src/ai/blocklist/block/view_impl/query.rs
+++ b/app/src/ai/blocklist/block/view_impl/query.rs
@@ -6,10 +6,11 @@ use pathfinder_color::ColorU;
 use warp_core::features::FeatureFlag;
 use warp_core::ui::theme::color::internal_colors;
 use warpui::elements::{
-    Container, CornerRadius, DispatchEventResult, EventHandler, Flex, MainAxisAlignment,
-    MainAxisSize, ParentElement, Radius, Shrinkable, Wrap,
+    Container, CornerRadius, Flex, Hoverable, MainAxisAlignment, MainAxisSize, MouseStateHandle,
+    ParentElement, Radius, Shrinkable, Wrap,
 };
 use warpui::fonts::{Properties, Style, Weight};
+use warpui::platform::Cursor;
 use warpui::ui_components::chip::Chip;
 use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
 use warpui::{AppContext, Element, SingletonEntity};
@@ -35,6 +36,10 @@ pub(super) struct Props<'a> {
     pub(super) is_selecting_text: bool,
     pub(super) is_ai_input_enabled: bool,
     pub(super) attachments: &'a [(AttachmentType, String)],
+    /// Pre-allocated mouse-state handles for image attachment chips, one per
+    /// image attachment in order. Used to set the pointing-hand cursor on
+    /// hover without creating new handles each render frame.
+    pub(super) attachment_chip_handles: &'a [MouseStateHandle],
     pub(super) find_context: Option<FindContext<'a>>,
 }
 
@@ -52,6 +57,7 @@ pub(super) fn maybe_render(props: Props, app: &AppContext) -> Option<Box<dyn Ele
             props.is_selecting_text,
             props.is_ai_input_enabled,
             props.attachments,
+            props.attachment_chip_handles,
             props.find_context,
             app,
         )
@@ -71,6 +77,7 @@ pub(crate) fn render_query(
     is_selecting: bool,
     is_ai_input_enabled: bool,
     attachments: &[(AttachmentType, String)],
+    attachment_chip_handles: &[MouseStateHandle],
     find_context: Option<FindContext>,
     app: &AppContext,
 ) -> Box<dyn Element> {
@@ -107,7 +114,11 @@ pub(crate) fn render_query(
     let mut query = Flex::column().with_child(text_element.finish());
 
     if FeatureFlag::ImageAsContext.is_enabled() {
-        query = query.with_child(render_attachments(attachments, appearance));
+        query = query.with_child(render_attachments(
+            attachments,
+            attachment_chip_handles,
+            appearance,
+        ));
     }
 
     Flex::row()
@@ -119,6 +130,7 @@ pub(crate) fn render_query(
 
 fn render_attachments(
     attachments: &[(AttachmentType, String)],
+    image_chip_handles: &[MouseStateHandle],
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     let mut image_index = 0;
@@ -156,15 +168,21 @@ fn render_attachments(
 
         if matches!(attachment_type, AttachmentType::Image) {
             let clicked_image_index = image_index;
+            // Use a pre-allocated handle so hover state persists across render frames.
+            let handle = image_chip_handles.get(image_index).cloned();
             image_index += 1;
-            EventHandler::new(chip)
-                .on_left_mouse_down(move |ctx, _, _| {
-                    ctx.dispatch_typed_action(AIBlockAction::OpenSubmittedAttachmentLightbox {
-                        image_index: clicked_image_index,
-                    });
-                    DispatchEventResult::StopPropagation
-                })
-                .finish()
+            if let Some(handle) = handle {
+                Hoverable::new(handle, |_| chip)
+                    .with_cursor(Cursor::PointingHand)
+                    .on_click(move |ctx, _, _| {
+                        ctx.dispatch_typed_action(AIBlockAction::OpenSubmittedAttachmentLightbox {
+                            image_index: clicked_image_index,
+                        });
+                    })
+                    .finish()
+            } else {
+                chip
+            }
         } else {
             chip
         }

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -82,14 +82,15 @@ use warpui::color::ColorU;
 use warpui::elements::{
     resizable_state_handle, Align, AnchorPair, ChildAnchor, Clipped, ConstrainedBox, Container,
     CornerRadius, CrossAxisAlignment, DispatchEventResult, DropTargetData, Element, EventHandler,
-    Flex, MainAxisAlignment, MainAxisSize, MouseStateHandle, OffsetPositioning, OffsetType,
-    ParentAnchor, ParentElement, PositionedElementOffsetBounds, PositioningAxis, Radius,
-    ResizableStateHandle, SavePosition, SelectionHandle, Text, Wrap, XAxisAnchor, YAxisAnchor,
+    Flex, Hoverable, MainAxisAlignment, MainAxisSize, MouseStateHandle, OffsetPositioning,
+    OffsetType, ParentAnchor, ParentElement, PositionedElementOffsetBounds, PositioningAxis,
+    Radius, ResizableStateHandle, SavePosition, SelectionHandle, Text, Wrap, XAxisAnchor,
+    YAxisAnchor,
 };
 pub use warpui::elements::{ParentElement as _, Stack};
 pub use warpui::geometry::vector::{vec2f, Vector2F};
 use warpui::keymap::{BindingDescription, EditableBinding, FixedBinding, Keystroke};
-use warpui::platform::OperatingSystem;
+use warpui::platform::{Cursor, OperatingSystem};
 use warpui::presenter::ChildView;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use warpui::r#async::FutureExt as _;
@@ -1764,7 +1765,11 @@ impl AmbientAgentViewState {
 #[derive(Clone)]
 struct AttachmentChip {
     file_name: String,
+    /// Mouse state handle for the close (delete) button on the chip.
     mouse_state_handle: MouseStateHandle,
+    /// Mouse state handle for the chip body itself, used to set the pointing-hand
+    /// cursor when hovering over a clickable (image) chip.
+    body_mouse_state_handle: MouseStateHandle,
     attachment_type: AttachmentType,
     /// Index into the unified pending_attachments list for deletion.
     index: usize,
@@ -3256,6 +3261,7 @@ impl Input {
                         .map(|(i, attachment)| AttachmentChip {
                             file_name: attachment.file_name().to_string(),
                             mouse_state_handle: Default::default(),
+                            body_mouse_state_handle: Default::default(),
                             attachment_type: attachment.attachment_type(),
                             index: i,
                         })
@@ -15324,14 +15330,16 @@ impl Input {
 
         if matches!(chip.attachment_type, AttachmentType::Image) {
             let preview_chip_index = chip.index;
-            EventHandler::new(attachment_chip.finish())
-                .on_left_mouse_down(move |ctx, _, _| {
-                    ctx.dispatch_typed_action(TerminalAction::OpenAttachmentLightbox {
-                        index: preview_chip_index,
-                    });
-                    DispatchEventResult::StopPropagation
-                })
-                .finish()
+            Hoverable::new(chip.body_mouse_state_handle.clone(), |_| {
+                attachment_chip.finish()
+            })
+            .with_cursor(Cursor::PointingHand)
+            .on_click(move |ctx, _, _| {
+                ctx.dispatch_typed_action(TerminalAction::OpenAttachmentLightbox {
+                    index: preview_chip_index,
+                });
+            })
+            .finish()
         } else {
             attachment_chip.finish()
         }


### PR DESCRIPTION
## Description

When hovering over an attachment chip in the agent prompt input or in previous agent conversation blocks, the cursor now correctly changes to a pointing hand to indicate interactivity.

**Root cause:** Attachment chips were rendered using `EventHandler` (which handles events but does not control cursor) rather than `Hoverable` (which can set the cursor). Since `MouseStateHandle` must be created at construction time and not during rendering, we needed pre-allocated handles stored on the view's state.

**Changes:**
- `input.rs`: Added `body_mouse_state_handle` to `AttachmentChip` and wrapped clickable image chips in `Hoverable::with_cursor(Cursor::PointingHand)` (replacing `EventHandler + on_left_mouse_down`).
- `block.rs`: Added `attachment_chip_handles: Vec<MouseStateHandle>` to `AIBlockStateHandles`; one handle per image attachment is pre-allocated in `AIBlock::new()` so hover state persists across render frames.
- `view_impl.rs`: Threads `attachment_chip_handles` through `query::Props`.
- `query.rs`: Accepts and uses the handles in `render_attachments`; image chips are now wrapped with `Hoverable + PointingHand` cursor.

## Linked Issue

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/a473c989-54b2-4ca3-81a4-8229ffdb9214

Co-Authored-By: Oz <oz-agent@warp.dev>

<!--
CHANGELOG-BUG-FIX: File chips in the agent prompt and previous agent blocks now show a pointing-hand cursor on hover.
-->
