### PR TITLE
fix: Prevent RowIterator crash after clear resize truncates wide-character spacer

### DIFF
--- a/app/src/terminal/model/grid/grid_handler_tests.rs
+++ b/app/src/terminal/model/grid/grid_handler_tests.rs
@@ -2279,6 +2279,40 @@ fn test_full_grid_clear_resize_narrower_then_scroll_does_not_panic() {
 }
 
 #[test]
+fn test_full_grid_clear_split_wide_char_boundary_does_not_panic_on_materialization() {
+    let old_cols = 6;
+    let new_cols = 5;
+    let num_rows = 1;
+
+    let mut grid =
+        GridHandler::new_for_test_with_scroll_limit(num_rows, old_cols, MAX_SCROLL_LIMIT);
+    for c in ['a', 'b', 'c', 'd', 'Ｗ'] {
+        grid.input(c);
+    }
+
+    assert!(grid.grid_storage()[VisibleRow(0)][new_cols - 1]
+        .flags
+        .contains(Flags::WIDE_CHAR));
+    assert!(grid.grid_storage()[VisibleRow(0)][new_cols]
+        .flags
+        .contains(Flags::WIDE_CHAR_SPACER));
+
+    grid.enable_full_grid_clear_behavior();
+    grid.resize(SizeInfo::new_without_font_metrics(num_rows, new_cols));
+
+    let retained_row = grid.grid_storage()[VisibleRow(0)].clone();
+    grid.flat_storage.push_rows([&retained_row]);
+    let materialized_rows = grid.flat_storage.pop_rows(1);
+
+    assert_eq!(materialized_rows.len(), 1);
+    assert_eq!(
+        grid.grid_storage()[VisibleRow(0)][new_cols - 1],
+        Cell::default()
+    );
+    assert_eq!(materialized_rows[0][new_cols - 1], Cell::default());
+}
+
+#[test]
 fn test_full_grid_clear_resize_then_bounds_to_string_does_not_panic() {
     // End-to-end repro via the same code path as block_snapshot:
     // bounds_to_string → line_to_string → row() → RowIterator::next.

--- a/app/src/terminal/model/grid/grid_handler_tests.rs
+++ b/app/src/terminal/model/grid/grid_handler_tests.rs
@@ -2279,7 +2279,7 @@ fn test_full_grid_clear_resize_narrower_then_scroll_does_not_panic() {
 }
 
 #[test]
-fn test_full_grid_clear_split_wide_char_boundary_does_not_panic_on_materialization() {
+fn test_full_grid_clear_shrink_cols_does_not_orphan_wide_char_at_boundary() {
     let old_cols = 6;
     let new_cols = 5;
     let num_rows = 1;
@@ -2289,6 +2289,7 @@ fn test_full_grid_clear_split_wide_char_boundary_does_not_panic_on_materializati
     for c in ['a', 'b', 'c', 'd', 'Ｗ'] {
         grid.input(c);
     }
+    grid.grid_storage_mut()[VisibleRow(0)][new_cols - 1].bg = Color::Named(NamedColor::Red);
 
     assert!(grid.grid_storage()[VisibleRow(0)][new_cols - 1]
         .flags
@@ -2300,6 +2301,8 @@ fn test_full_grid_clear_split_wide_char_boundary_does_not_panic_on_materializati
     grid.enable_full_grid_clear_behavior();
     grid.resize(SizeInfo::new_without_font_metrics(num_rows, new_cols));
 
+    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+
     let retained_row = grid.grid_storage()[VisibleRow(0)].clone();
     grid.flat_storage.push_rows([&retained_row]);
     let materialized_rows = grid.flat_storage.pop_rows(1);
@@ -2307,9 +2310,12 @@ fn test_full_grid_clear_split_wide_char_boundary_does_not_panic_on_materializati
     assert_eq!(materialized_rows.len(), 1);
     assert_eq!(
         grid.grid_storage()[VisibleRow(0)][new_cols - 1],
-        Cell::default()
+        Cell::from(Color::Named(NamedColor::Red))
     );
-    assert_eq!(materialized_rows[0][new_cols - 1], Cell::default());
+    assert_eq!(
+        materialized_rows[0][new_cols - 1],
+        Cell::from(Color::Named(NamedColor::Red))
+    );
 }
 
 #[test]

--- a/app/src/terminal/model/grid/grid_storage/resize.rs
+++ b/app/src/terminal/model/grid/grid_storage/resize.rs
@@ -340,7 +340,12 @@ impl GridStorage {
 
             loop {
                 // Remove all cells which require reflowing.
-                let mut wrapped = match row.shrink(columns) {
+                let shrunk = row.shrink(columns);
+                if !reflow {
+                    reset_discarded_wide_char_boundary(&mut row, shrunk.as_deref(), columns);
+                }
+
+                let mut wrapped = match shrunk {
                     Some(wrapped) if reflow => wrapped,
                     _ => {
                         let cursor_buffer_line =
@@ -474,5 +479,27 @@ impl GridStorage {
 
         // Clamp the saved cursor to the grid.
         self.saved_cursor.point.col = min(self.saved_cursor.point.col, columns - 1);
+    }
+}
+
+fn reset_discarded_wide_char_boundary(
+    row: &mut Row,
+    discarded_cells: Option<&[Cell]>,
+    columns: usize,
+) {
+    if columns == 0 {
+        return;
+    }
+
+    let Some(first_discarded_cell) = discarded_cells.and_then(|cells| cells.first()) else {
+        return;
+    };
+
+    if row[columns - 1].flags().contains(Flags::WIDE_CHAR)
+        && first_discarded_cell
+            .flags()
+            .contains(Flags::WIDE_CHAR_SPACER)
+    {
+        row[columns - 1] = Cell::default();
     }
 }

--- a/app/src/terminal/model/grid/grid_storage/resize.rs
+++ b/app/src/terminal/model/grid/grid_storage/resize.rs
@@ -342,7 +342,7 @@ impl GridStorage {
                 // Remove all cells which require reflowing.
                 let shrunk = row.shrink(columns);
                 if !reflow {
-                    reset_discarded_wide_char_boundary(&mut row, shrunk.as_deref(), columns);
+                    reset_invalid_trailing_wide_char(&mut row, columns);
                 }
 
                 let mut wrapped = match shrunk {
@@ -482,24 +482,10 @@ impl GridStorage {
     }
 }
 
-fn reset_discarded_wide_char_boundary(
-    row: &mut Row,
-    discarded_cells: Option<&[Cell]>,
-    columns: usize,
-) {
-    if columns == 0 {
+fn reset_invalid_trailing_wide_char(row: &mut Row, columns: usize) {
+    if columns == 0 || !row[columns - 1].flags().contains(Flags::WIDE_CHAR) {
         return;
     }
-
-    let Some(first_discarded_cell) = discarded_cells.and_then(|cells| cells.first()) else {
-        return;
-    };
-
-    if row[columns - 1].flags().contains(Flags::WIDE_CHAR)
-        && first_discarded_cell
-            .flags()
-            .contains(Flags::WIDE_CHAR_SPACER)
-    {
-        row[columns - 1] = Cell::default();
-    }
+    let bg = row[columns - 1].bg;
+    row[columns - 1] = bg.into();
 }

--- a/app/src/terminal/model/grid/tests.rs
+++ b/app/src/terminal/model/grid/tests.rs
@@ -1234,6 +1234,49 @@ fn test_empty_row_with_leading_wide_char_spacer_resize_panic() {
     grid.resize(SizeInfo::new_without_font_metrics(2, 4));
 }
 
+#[test]
+fn test_shrink_cols_reflow_preserves_split_wide_char_as_wrapped_content() {
+    let mut grid = GridStorage::new(2, 6, 0, ObfuscateSecrets::No);
+    let mut wide_char = cell('Ｗ');
+    wide_char.flags.insert(Flags::WIDE_CHAR);
+    let mut spacer = Cell::default();
+    spacer.flags.insert(Flags::WIDE_CHAR_SPACER);
+
+    grid.set_stored_rows(
+        vec![
+            row::Row::new(6),
+            row::Row::from_vec(
+                vec![
+                    cell('a'),
+                    cell('b'),
+                    cell('c'),
+                    cell('d'),
+                    wide_char,
+                    spacer,
+                ],
+                6,
+            ),
+        ],
+        2,
+        6,
+    );
+
+    grid.resize(true, 2, 5, false);
+
+    let retained_boundary = &grid[VisibleRow(0)][4];
+    assert!(retained_boundary
+        .flags
+        .contains(Flags::LEADING_WIDE_CHAR_SPACER));
+    assert!(!retained_boundary.flags.contains(Flags::WIDE_CHAR));
+
+    let wrapped_wide_char = &grid[VisibleRow(1)][0];
+    assert_eq!(wrapped_wide_char.c, 'Ｗ');
+    assert!(wrapped_wide_char.flags.contains(Flags::WIDE_CHAR));
+    assert!(grid[VisibleRow(1)][1]
+        .flags
+        .contains(Flags::WIDE_CHAR_SPACER));
+}
+
 fn cell(c: char) -> Cell {
     let mut cell = Cell::default();
     cell.c = c;

--- a/specs/GH12243/product.md
+++ b/specs/GH12243/product.md
@@ -17,12 +17,12 @@ Non-goals:
 ## Behavior
 1. When Warp receives a full-grid clear sequence and the terminal is resized before the command is finished, the active grid resizes without reflowing old terminal output into scrollback.
 2. If that no-reflow resize shrinks the terminal width and the first discarded cell is the spacer for a wide character retained at the new final column, the resulting row remains valid for later rendering, scrolling, and scrollback-like storage. Warp must not leave a final-column wide character that requires a spacer outside the row bounds.
-3. For that truncated boundary pair, Warp keeps the retained final cell's character, style, and other unrelated attributes, but removes its impossible double-width claim. Warp does not clear the retained final cell entirely, and the single-cell degradation applies only to the split boundary pair.
+3. For that truncated boundary pair, Warp resets the retained final cell to the resize-empty cell instead of preserving the leading glyph as a single-cell character. This matches existing clear/overwrite behavior for the spacer half of a wide-character pair and applies only to the split boundary pair.
 4. Valid wide-character pairs wholly inside the new width remain unchanged. A wide character whose spacer is still retained continues to occupy two cells and must still materialize with its matching spacer.
-5. Wide-character spacers wholly outside the new width are discarded with the rest of the overflow content. Discarding overflow content must not mutate unrelated retained cells.
+5. Wide-character spacers wholly outside the new width are discarded with the rest of the overflow content. If the first discarded spacer belongs to the retained final cell, that retained leading cell is reset; otherwise discarding overflow content must not mutate unrelated retained cells.
 6. Rows produced by this clear-driven no-reflow resize path must not contain:
    - a `WIDE_CHAR` marker without a following `WIDE_CHAR_SPACER` in the same row, or
    - a `WIDE_CHAR_SPACER` marker without a preceding `WIDE_CHAR` in the same row.
-7. Ordinary reflowing resize behavior is unchanged. When resize is allowed to reflow content, valid wide characters that cross a wrap boundary continue to use the existing leading-spacer semantics for wrapped rows rather than being flattened or silently narrowed.
+7. Ordinary reflowing resize behavior is unchanged. When resize is allowed to reflow content, valid wide characters that cross a wrap boundary continue to use the existing leading-spacer semantics for wrapped rows rather than being cleared, flattened, or silently narrowed.
 8. Screen-mode routing is unchanged. Unfinished primary grids with full-grid clear behavior continue to use the no-reflow clear path; finished primary grids continue to use normal scrollback behavior; alt-screen grids continue to resize without flat-storage scrollback.
 9. The existing clear-resize scrollback-width regression remains fixed. Resizing under full-grid clear behavior continues to keep active grid width and flat-storage width in sync.

--- a/specs/GH12243/product.md
+++ b/specs/GH12243/product.md
@@ -1,0 +1,28 @@
+# GH12243: Prevent RowIterator crash after clear resize truncates wide characters
+Issue: https://github.com/warpdotdev/warp/issues/12243
+## Summary
+Warp Preview must not crash when terminal output containing wide characters is resized during a full-grid clear flow. Terminal rows produced by a clear-driven no-reflow resize must remain valid when later rendered, scrolled, or restored from scrollback-like storage.
+## Problem
+The reported crash happens after a command-enter / clear-hook / resize sequence. The terminal grid can be shrunk at a column boundary that splits a wide character from its spacer, leaving a retained row that later cannot be safely restored for rendering or scrolling.
+This is a crash fix, not a user-facing feature. The user-visible requirement is that Warp continues to render, resize, and scroll terminal output without aborting, even when CJK or other double-width characters sit exactly at a resize boundary.
+## Goals / Non-goals
+Goals:
+- Preserve terminal stability during clear-driven resize flows that truncate wide-character pairs.
+- Preserve the invariant that rows produced by the clear-driven no-reflow resize path do not contain an orphaned trailing wide-character marker.
+- Keep existing reflow behavior for ordinary terminal resize, line wrapping, scrollback, and wide-character continuation rows.
+Non-goals:
+- Reworking all terminal wide-character handling.
+- Claiming to fix every public `RowIterator::next` crash report unless the same producer path is proven.
+- Changing the visual semantics of valid wrapped wide characters.
+## Behavior
+1. When Warp receives a full-grid clear sequence and the terminal is resized before the command is finished, the active grid resizes without reflowing old terminal output into scrollback.
+2. If that no-reflow resize shrinks the terminal width and the first discarded cell is the spacer for a wide character retained at the new final column, the resulting row remains valid for later rendering, scrolling, and scrollback-like storage. Warp must not leave a final-column wide character that requires a spacer outside the row bounds.
+3. For that truncated boundary pair, Warp keeps the retained final cell's character, style, and other unrelated attributes, but removes its impossible double-width claim. Warp does not clear the retained final cell entirely, and the single-cell degradation applies only to the split boundary pair.
+4. Valid wide-character pairs wholly inside the new width remain unchanged. A wide character whose spacer is still retained continues to occupy two cells and must still materialize with its matching spacer.
+5. Wide-character spacers wholly outside the new width are discarded with the rest of the overflow content. Discarding overflow content must not mutate unrelated retained cells.
+6. Rows produced by this clear-driven no-reflow resize path must not contain:
+   - a `WIDE_CHAR` marker without a following `WIDE_CHAR_SPACER` in the same row, or
+   - a `WIDE_CHAR_SPACER` marker without a preceding `WIDE_CHAR` in the same row.
+7. Ordinary reflowing resize behavior is unchanged. When resize is allowed to reflow content, valid wide characters that cross a wrap boundary continue to use the existing leading-spacer semantics for wrapped rows rather than being flattened or silently narrowed.
+8. Screen-mode routing is unchanged. Unfinished primary grids with full-grid clear behavior continue to use the no-reflow clear path; finished primary grids continue to use normal scrollback behavior; alt-screen grids continue to resize without flat-storage scrollback.
+9. The existing clear-resize scrollback-width regression remains fixed. Resizing under full-grid clear behavior continues to keep active grid width and flat-storage width in sync.

--- a/specs/GH12243/product.md
+++ b/specs/GH12243/product.md
@@ -16,10 +16,10 @@ Non-goals:
 - Changing the visual semantics of valid wrapped wide characters.
 ## Behavior
 1. When Warp receives a full-grid clear sequence and the terminal is resized before the command is finished, the active grid resizes without reflowing old terminal output into scrollback.
-2. If that no-reflow resize shrinks the terminal width and the first discarded cell is the spacer for a wide character retained at the new final column, the resulting row remains valid for later rendering, scrolling, and scrollback-like storage. Warp must not leave a final-column wide character that requires a spacer outside the row bounds.
-3. For that truncated boundary pair, Warp resets the retained final cell to the resize-empty cell instead of preserving the leading glyph as a single-cell character. This matches existing clear/overwrite behavior for the spacer half of a wide-character pair and applies only to the split boundary pair.
+2. If that no-reflow resize shrinks the terminal width and the retained final cell is a wide character, the resulting row remains valid for later rendering, scrolling, and scrollback-like storage. Warp must not leave a final-column wide character that requires a spacer outside the row bounds.
+3. For that invalid trailing wide character, Warp resets the retained final cell's foreground/content state instead of preserving the leading glyph as a single-cell character. The reset preserves the cell background, matching existing clear/overwrite behavior for wide-character boundary repairs.
 4. Valid wide-character pairs wholly inside the new width remain unchanged. A wide character whose spacer is still retained continues to occupy two cells and must still materialize with its matching spacer.
-5. Wide-character spacers wholly outside the new width are discarded with the rest of the overflow content. If the first discarded spacer belongs to the retained final cell, that retained leading cell is reset; otherwise discarding overflow content must not mutate unrelated retained cells.
+5. Wide-character spacers wholly outside the new width are discarded with the rest of the overflow content. If discarding overflow leaves the retained row ending in `WIDE_CHAR`, that retained leading cell is reset; otherwise discarding overflow content must not mutate unrelated retained cells.
 6. Rows produced by this clear-driven no-reflow resize path must not contain:
    - a `WIDE_CHAR` marker without a following `WIDE_CHAR_SPACER` in the same row, or
    - a `WIDE_CHAR_SPACER` marker without a preceding `WIDE_CHAR` in the same row.

--- a/specs/GH12243/tech.md
+++ b/specs/GH12243/tech.md
@@ -12,6 +12,8 @@ Relevant current code:
 - [`app/src/terminal/model/grid/grid_handler.rs:490-492 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/grid_handler.rs#L490-L492) — `enable_full_grid_clear_behavior` switches a grid handler to the clear path.
 - [`app/src/terminal/model/grid/resize.rs:57-82 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/resize.rs#L57-L82) — `GridHandler::resize_storage` takes the alt-screen / `FullGridClearBehavior::Clear` early path and delegates to `self.grid.resize(false, ...)`, then syncs flat-storage columns.
 - [`app/src/terminal/model/grid/resize.rs:98-158 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/resize.rs#L98-L158) — the normal resize path pushes rows into flat storage, changes flat-storage width, then materializes rows back with `pop_rows`.
+- [`app/src/terminal/model/grid/ansi_handler.rs:1500-1534 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/ansi_handler.rs#L1500-L1534) — existing wide-character boundary helpers reset both halves when an overwrite or clear boundary splits a wide-character pair.
+- [`app/src/terminal/model/grid/ansi_handler.rs:1536-1582 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/ansi_handler.rs#L1536-L1582) — `write_at_cursor` resets the paired cell before writing when the cursor lands on either half of a wide-character pair.
 - [`app/src/terminal/model/grid/grid_storage/resize.rs:308-363 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/grid_storage/resize.rs#L308-L363) — `GridStorage::shrink_cols` calls `row.shrink(columns)` and, when `reflow` is false, pushes the shortened row without processing wrapped cells.
 - [`app/src/terminal/model/grid/grid_storage/resize.rs:365-390 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/grid_storage/resize.rs#L365-L390) — the `reflow=true` branch already has special wide-character handling: a trailing `WIDE_CHAR` is replaced with `LEADING_WIDE_CHAR_SPACER` and moved into wrapped content.
 - [`crates/warp_terminal/src/model/grid/row.rs:66-92 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/crates/warp_terminal/src/model/grid/row.rs#L66-L92) — `Row::shrink` splits off cells beyond the new column count and returns non-empty discarded cells. It is a low-level primitive and does not know whether the caller will discard overflow or reflow it.
@@ -19,6 +21,7 @@ Relevant current code:
 - [`crates/warp_terminal/src/model/grid/flat_storage/mod.rs:124-140 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/crates/warp_terminal/src/model/grid/flat_storage/mod.rs#L124-L140) — `FlatStorage::pop_rows` materializes stored rows through `rows_from`.
 - [`crates/warp_terminal/src/model/grid/flat_storage/row_iterator.rs:86-133 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/crates/warp_terminal/src/model/grid/flat_storage/row_iterator.rs#L86-L133) — `RowIterator::next` fills row cells from grapheme runs and marks `row[idx + 1]` as `WIDE_CHAR_SPACER` for width-2 graphemes. If `idx` is the final row cell, this panics.
 - [`app/src/terminal/model/grid/grid_handler_tests.rs:1511-1530 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/grid_handler_tests.rs#L1511-L1530) — existing helper asserts there are no orphaned `WIDE_CHAR` or `WIDE_CHAR_SPACER` flags in a visible row.
+- [`app/src/terminal/model/grid/grid_handler_tests.rs:1533-1563 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/grid_handler_tests.rs#L1533-L1563) — existing tests assert that overwriting either half of a wide-character pair clears the paired cell.
 - [`app/src/terminal/model/grid/grid_handler_tests.rs:1769-1774 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/grid_handler_tests.rs#L1769-L1774) — existing test covers finished primary-grid behavior with full-grid clear enabled.
 - [`app/src/terminal/model/grid/grid_handler_tests.rs:2001-2022 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/grid_handler_tests.rs#L2001-L2022) — existing wide-character wrap test protects `LEADING_WIDE_CHAR_SPACER` semantics.
 - [`app/src/terminal/model/grid/grid_handler_tests.rs:2208-2247 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/grid_handler_tests.rs#L2208-L2247) — existing full-grid clear resize tests guard the earlier flat-storage column-sync regression.
@@ -28,14 +31,14 @@ The important ownership boundary is that `RowIterator::next` is the panic site, 
 In `app/src/terminal/model/grid/grid_storage/resize.rs`, keep the fix localized to the branch where `GridStorage::shrink_cols` has just called `row.shrink(columns)`.
 After `row.shrink(columns)` returns discarded cells, handle the no-reflow split-wide-character case before the non-reflow branch pushes the shortened row into `new_raw`:
 - Capture the discarded cells returned by `row.shrink(columns)` instead of matching and discarding them immediately.
-- If `!reflow`, `columns > 0`, the retained final cell has `WIDE_CHAR`, and the first discarded cell has `WIDE_CHAR_SPACER`, remove only `WIDE_CHAR` from the retained final cell.
+- If `!reflow`, `columns > 0`, the retained final cell has `WIDE_CHAR`, and the first discarded cell has `WIDE_CHAR_SPACER`, reset the retained final cell to the resize-empty cell.
 - Continue to pass the captured discarded cells into the existing `reflow=true` branch unchanged.
-This satisfies `product.md` behavior 2-6 by repairing exactly the row whose spacer was discarded. It keeps the retained cell content and styling, but no longer advertises that the final retained cell occupies a missing second cell.
-The alternative of clearing the retained cell entirely is more visually conservative, but it loses user content even though a valid single-cell representation is available. Removing only `WIDE_CHAR` is the preferred default because no-reflow clear resize has already discarded the overflow spacer; preserving the glyph while removing the impossible two-cell claim maintains stability with the least data loss.
+This satisfies `product.md` behavior 2-6 by repairing exactly the row whose spacer was discarded. Resetting the retained leading cell matches the existing overwrite/clear behavior for a spacer-half operation and avoids pretending that a width-2 glyph has a valid one-cell representation.
+This intentionally discards the boundary glyph. That is consistent with this no-reflow path: right-side overflow cells are already discarded, and once the spacer half has been discarded the retained leading half is no longer independently renderable.
 ### 2. Do not move this fix into `Row::shrink`
 `Row::shrink` only knows that cells were split off. It does not know whether the caller will discard those cells, reflow them into wrapped rows, or transform them with leading-spacer semantics. Its return value should preserve the original discarded cell flags so callers can decide how to handle a split wide-character pair. A generic `Row::shrink` cleanup that removes `WIDE_CHAR` whenever the first discarded cell is a spacer would also affect callers that still intend to preserve or reflow the wide character.
 Keeping the fix in `GridStorage::shrink_cols` preserves the caller-specific distinction:
-- `reflow=false`: overflow is discarded, so the retained final cell must be made materializable on its own.
+- `reflow=false`: overflow is discarded, so a retained final `WIDE_CHAR` whose spacer was discarded must be reset rather than materialized as a one-cell glyph.
 - `reflow=true`: overflow is wrapped, and the existing code moves a trailing `WIDE_CHAR` into wrapped content while placing a `LEADING_WIDE_CHAR_SPACER` in the retained row.
 This directly protects `product.md` behavior 7.
 ### 3. Do not use `RowIterator::next` as the primary repair
@@ -51,11 +54,11 @@ Add a focused test next to the existing full-grid clear resize tests:
 The test should:
 1. Create a `GridHandler` with a wider initial column count than the final resized width.
 2. Enable `FullGridClearBehavior::Clear`.
-3. Build a valid wide-character pair exactly at the shrink boundary, with `WIDE_CHAR` at the final retained column and `WIDE_CHAR_SPACER` as the first discarded cell.
+3. Build a valid wide-character pair exactly at the shrink boundary, preferably through the normal grid input path so `WIDE_CHAR` and `WIDE_CHAR_SPACER` are produced by terminal writing rather than hand-set flags.
 4. Resize through the real `grid.resize(SizeInfo::new_without_font_metrics(...))` API so the test exercises `GridHandler::resize_storage` and `GridStorage::shrink_cols`.
 5. Use `assert_no_orphaned_wide_chars` to assert the row invariant.
-6. Assert the exact boundary postcondition: the final retained cell keeps its original character, foreground color, background color, and unrelated style flags; it no longer contains `WIDE_CHAR`; and no retained cell contains an orphaned `WIDE_CHAR_SPACER`.
-7. Push the post-resize retained row through a `FlatStorage` whose column count matches the resized grid width, then call `flat_storage.pop_rows(1)` and assert one row materializes without panic and preserves the retained boundary cell's character/style.
+6. Assert the exact boundary postcondition: the final retained cell is reset to the resize-empty cell and no retained cell contains an orphaned `WIDE_CHAR` or `WIDE_CHAR_SPACER`.
+7. Push the post-resize retained row through a `FlatStorage` whose column count matches the resized grid width, then call `flat_storage.pop_rows(1)` and assert one row materializes without panic and keeps the boundary cell reset.
 This is slightly stronger than only asserting "does not panic" because it proves the producer invariant before flat storage gets involved.
 ### 5. Add a resize-specific `reflow=true` guard
 Add a focused `GridStorage` / `GridHandler` resize regression for the ordinary reflow path:
@@ -65,7 +68,7 @@ The test should:
 2. Resize narrower through the real resize API so `GridStorage::shrink_cols(reflow=true, ...)` handles the split pair.
 3. Assert the retained row uses the existing `LEADING_WIDE_CHAR_SPACER` representation rather than narrowing the retained cell.
 4. Assert the wrapped content still contains the original `WIDE_CHAR` cell followed by its `WIDE_CHAR_SPACER`.
-5. Assert the no-reflow boundary narrowing rule from change 1 does not run when `reflow=true`.
+5. Assert the no-reflow boundary reset rule from change 1 does not run when `reflow=true`.
 This protects `product.md` behavior 7 and proves the producer-side fix is scoped to discarded overflow, not ordinary wrapped wide-character content.
 ### 6. Preserve existing regression coverage
 Do not remove or weaken the existing clear-resize tests. In particular:
@@ -109,11 +112,12 @@ Map tests to `product.md` behavior:
   ./script/presubmit
   ```
   If unrelated local failures appear, record the failing test names and explain why they are unrelated to grid storage / row materialization.
-Manual validation is secondary for this issue because the original UI timing is unstable. Still, the implementation PR should include proof that `./script/run` builds and launches locally, then manually exercise terminal resize / clear activity with wide-character output. A screenshot is not meaningful for the core non-visual crash fix; a short screen recording is useful only if maintainers request manual evidence.
+Manual validation is secondary to the deterministic regression tests, but the implementation PR should still exercise the known clear-resize repro locally: emit an OSC 777 CLI-agent session start, print multiple rows whose full-width glyph targets adjacent shrink widths, open find on a repeated character, slowly shrink the pane or window, then finish the command if needed. The fixed build should not log a `row_iterator.rs:132` panic during resize, find rerun, or command-finished block serialization.
 ## Parallelization
 Parallel sub-agents are not proposed for the implementation itself. The code change is narrow and the implementation/test files are tightly coupled:
 - `app/src/terminal/model/grid/grid_storage/resize.rs`
 - `app/src/terminal/model/grid/grid_handler_tests.rs`
+- `app/src/terminal/model/grid/tests.rs`
 Splitting these across agents would likely create more coordination overhead than saved time. A useful parallel review pattern is possible after the first implementation draft: one reviewer can inspect the producer/consumer tradeoff while another runs the focused regression tests, but the patch should be authored as one coherent change.
 ## Risks and mitigations
 ### Risk: accidentally changing reflow semantics
@@ -125,9 +129,9 @@ Mitigation: repair the confirmed producer and rely on deterministic invariant te
 ### Risk: overclaiming coverage for related RowIterator issues
 Public issues such as #11471 and #12459 share a `RowIterator::next` crash shape, but their public reports do not prove the same no-reflow clear-resize producer.
 Mitigation: describe this spec as fixing the deterministic producer in #12243. Do not claim it fixes every RowIterator bounds-check crash unless further evidence ties those reports to the same producer.
-### Risk: preserving a damaged glyph as narrow content is visually imperfect
-When no-reflow resize discards the spacer cell, the retained character can no longer be represented as a valid two-cell wide character in that row.
-Mitigation: this only happens at the discard boundary. Preserving content while removing the impossible width marker is preferable to retaining an unmaterializable row, and valid pairs inside the retained width are unchanged.
+### Risk: resetting the boundary glyph is user-visible
+When no-reflow resize discards the spacer cell, the retained leading cell can no longer be represented as a valid two-cell wide character in that row. Resetting that leading cell means the boundary glyph is not displayed.
+Mitigation: this only happens at the discard boundary in a path that already discards right-side overflow rather than restoring it after resize. Valid pairs inside the retained width are unchanged, and ordinary reflowing resize still preserves split wide characters through `LEADING_WIDE_CHAR_SPACER`.
 ## Follow-ups
 - If more RowIterator crashes appear with different producer paths, consider a broader audit of all row producers that can create or mutate wide-character pairs.
 - Consider adding debug-only invariant checks around row transitions into flat storage if future failures show more malformed-row producers.

--- a/specs/GH12243/tech.md
+++ b/specs/GH12243/tech.md
@@ -29,16 +29,15 @@ The important ownership boundary is that `RowIterator::next` is the panic site, 
 ## Proposed changes
 ### 1. Repair the confirmed producer path in `GridStorage::shrink_cols`
 In `app/src/terminal/model/grid/grid_storage/resize.rs`, keep the fix localized to the branch where `GridStorage::shrink_cols` has just called `row.shrink(columns)`.
-After `row.shrink(columns)` returns discarded cells, handle the no-reflow split-wide-character case before the non-reflow branch pushes the shortened row into `new_raw`:
-- Capture the discarded cells returned by `row.shrink(columns)` instead of matching and discarding them immediately.
-- If `!reflow`, `columns > 0`, the retained final cell has `WIDE_CHAR`, and the first discarded cell has `WIDE_CHAR_SPACER`, reset the retained final cell to the resize-empty cell.
-- Continue to pass the captured discarded cells into the existing `reflow=true` branch unchanged.
-This satisfies `product.md` behavior 2-6 by repairing exactly the row whose spacer was discarded. Resetting the retained leading cell matches the existing overwrite/clear behavior for a spacer-half operation and avoids pretending that a width-2 glyph has a valid one-cell representation.
-This intentionally discards the boundary glyph. That is consistent with this no-reflow path: right-side overflow cells are already discarded, and once the spacer half has been discarded the retained leading half is no longer independently renderable.
+After `row.shrink(columns)` returns, handle the no-reflow split-wide-character case before the non-reflow branch pushes the shortened row into `new_raw`:
+- If `!reflow`, `columns > 0`, and the retained final cell has `WIDE_CHAR`, reset that cell to an empty cell with the same background.
+- Continue to pass the discarded cells returned by `row.shrink(columns)` into the existing `reflow=true` branch unchanged.
+This satisfies `product.md` behavior 2-6 by repairing rows that would otherwise end with an orphaned `WIDE_CHAR`. Resetting the retained leading cell matches the existing overwrite/clear behavior for wide-character boundary operations and avoids pretending that a width-2 glyph has a valid one-cell representation.
+This intentionally discards the boundary glyph. That is consistent with this no-reflow path: right-side overflow cells are already discarded, and once the spacer half is not present in the retained row the retained leading half is no longer independently renderable. The reset preserves the cell background so resize does not create a visual hole in applications that paint non-default backgrounds.
 ### 2. Do not move this fix into `Row::shrink`
 `Row::shrink` only knows that cells were split off. It does not know whether the caller will discard those cells, reflow them into wrapped rows, or transform them with leading-spacer semantics. Its return value should preserve the original discarded cell flags so callers can decide how to handle a split wide-character pair. A generic `Row::shrink` cleanup that removes `WIDE_CHAR` whenever the first discarded cell is a spacer would also affect callers that still intend to preserve or reflow the wide character.
 Keeping the fix in `GridStorage::shrink_cols` preserves the caller-specific distinction:
-- `reflow=false`: overflow is discarded, so a retained final `WIDE_CHAR` whose spacer was discarded must be reset rather than materialized as a one-cell glyph.
+- `reflow=false`: overflow is discarded, so a retained final `WIDE_CHAR` must be reset rather than materialized as a one-cell glyph.
 - `reflow=true`: overflow is wrapped, and the existing code moves a trailing `WIDE_CHAR` into wrapped content while placing a `LEADING_WIDE_CHAR_SPACER` in the retained row.
 This directly protects `product.md` behavior 7.
 ### 3. Do not use `RowIterator::next` as the primary repair
@@ -57,7 +56,7 @@ The test should:
 3. Build a valid wide-character pair exactly at the shrink boundary, preferably through the normal grid input path so `WIDE_CHAR` and `WIDE_CHAR_SPACER` are produced by terminal writing rather than hand-set flags.
 4. Resize through the real `grid.resize(SizeInfo::new_without_font_metrics(...))` API so the test exercises `GridHandler::resize_storage` and `GridStorage::shrink_cols`.
 5. Use `assert_no_orphaned_wide_chars` to assert the row invariant.
-6. Assert the exact boundary postcondition: the final retained cell is reset to the resize-empty cell and no retained cell contains an orphaned `WIDE_CHAR` or `WIDE_CHAR_SPACER`.
+6. Assert the exact boundary postcondition: the final retained cell is reset to an empty cell preserving the original background, and no retained cell contains an orphaned `WIDE_CHAR` or `WIDE_CHAR_SPACER`.
 7. Push the post-resize retained row through a `FlatStorage` whose column count matches the resized grid width, then call `flat_storage.pop_rows(1)` and assert one row materializes without panic and keeps the boundary cell reset.
 This is slightly stronger than only asserting "does not panic" because it proves the producer invariant before flat storage gets involved.
 ### 5. Add a resize-specific `reflow=true` guard

--- a/specs/GH12243/tech.md
+++ b/specs/GH12243/tech.md
@@ -1,0 +1,133 @@
+# GH12243: Tech Spec — Prevent RowIterator crash after clear resize truncates wide characters
+Product spec: `specs/GH12243/product.md`
+Issue: https://github.com/warpdotdev/warp/issues/12243
+Code references inspected at commit: `55b411ec694a5c16a01929bcaef1d8f971677ca2`
+## Context
+The issue is a producer-side row-invariant break that later appears as a consumer-side panic. The observed crash is in flat-storage row materialization, but the malformed row is produced earlier when the active terminal grid is resized without reflow under full-grid clear behavior.
+Relevant current code:
+- [`CONTRIBUTING.md:90-107 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/CONTRIBUTING.md#L90-L107) — spec PR requirements for `specs/GH<issue-number>/product.md` and `tech.md`.
+- [`app/src/terminal/view.rs:12935-12955 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/view.rs#L12935-L12955) — terminal view handles CLI-agent OSC notifications that start the clear-style redraw behavior.
+- [`app/src/terminal/model/block.rs:1100-1102 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/block.rs#L1100-L1102) — block-level entry point enables full-grid clear behavior on the output grid.
+- [`app/src/terminal/model/grid/grid_handler.rs:330-340 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/grid_handler.rs#L330-L340) — `FullGridClearBehavior` distinguishes in-place redraw behavior from normal scrollback preservation.
+- [`app/src/terminal/model/grid/grid_handler.rs:490-492 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/grid_handler.rs#L490-L492) — `enable_full_grid_clear_behavior` switches a grid handler to the clear path.
+- [`app/src/terminal/model/grid/resize.rs:57-82 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/resize.rs#L57-L82) — `GridHandler::resize_storage` takes the alt-screen / `FullGridClearBehavior::Clear` early path and delegates to `self.grid.resize(false, ...)`, then syncs flat-storage columns.
+- [`app/src/terminal/model/grid/resize.rs:98-158 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/resize.rs#L98-L158) — the normal resize path pushes rows into flat storage, changes flat-storage width, then materializes rows back with `pop_rows`.
+- [`app/src/terminal/model/grid/grid_storage/resize.rs:308-363 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/grid_storage/resize.rs#L308-L363) — `GridStorage::shrink_cols` calls `row.shrink(columns)` and, when `reflow` is false, pushes the shortened row without processing wrapped cells.
+- [`app/src/terminal/model/grid/grid_storage/resize.rs:365-390 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/grid_storage/resize.rs#L365-L390) — the `reflow=true` branch already has special wide-character handling: a trailing `WIDE_CHAR` is replaced with `LEADING_WIDE_CHAR_SPACER` and moved into wrapped content.
+- [`crates/warp_terminal/src/model/grid/row.rs:66-92 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/crates/warp_terminal/src/model/grid/row.rs#L66-L92) — `Row::shrink` splits off cells beyond the new column count and returns non-empty discarded cells. It is a low-level primitive and does not know whether the caller will discard overflow or reflow it.
+- [`crates/warp_terminal/src/model/grid/flat_storage/mod.rs:185-217 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/crates/warp_terminal/src/model/grid/flat_storage/mod.rs#L185-L217) — flat storage skips wide-character spacer cells when serializing rows and records leading-spacer metadata separately.
+- [`crates/warp_terminal/src/model/grid/flat_storage/mod.rs:124-140 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/crates/warp_terminal/src/model/grid/flat_storage/mod.rs#L124-L140) — `FlatStorage::pop_rows` materializes stored rows through `rows_from`.
+- [`crates/warp_terminal/src/model/grid/flat_storage/row_iterator.rs:86-133 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/crates/warp_terminal/src/model/grid/flat_storage/row_iterator.rs#L86-L133) — `RowIterator::next` fills row cells from grapheme runs and marks `row[idx + 1]` as `WIDE_CHAR_SPACER` for width-2 graphemes. If `idx` is the final row cell, this panics.
+- [`app/src/terminal/model/grid/grid_handler_tests.rs:1511-1530 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/grid_handler_tests.rs#L1511-L1530) — existing helper asserts there are no orphaned `WIDE_CHAR` or `WIDE_CHAR_SPACER` flags in a visible row.
+- [`app/src/terminal/model/grid/grid_handler_tests.rs:1769-1774 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/grid_handler_tests.rs#L1769-L1774) — existing test covers finished primary-grid behavior with full-grid clear enabled.
+- [`app/src/terminal/model/grid/grid_handler_tests.rs:2001-2022 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/grid_handler_tests.rs#L2001-L2022) — existing wide-character wrap test protects `LEADING_WIDE_CHAR_SPACER` semantics.
+- [`app/src/terminal/model/grid/grid_handler_tests.rs:2208-2247 @ 55b411ec`](https://github.com/warpdotdev/warp/blob/55b411ec694a5c16a01929bcaef1d8f971677ca2/app/src/terminal/model/grid/grid_handler_tests.rs#L2208-L2247) — existing full-grid clear resize tests guard the earlier flat-storage column-sync regression.
+The important ownership boundary is that `RowIterator::next` is the panic site, not the best primary fix site. The producer creates a row that violates the wide-character invariant described in `product.md`; flat storage then faithfully serializes and rematerializes that malformed row until the missing spacer becomes an out-of-bounds write.
+## Proposed changes
+### 1. Repair the confirmed producer path in `GridStorage::shrink_cols`
+In `app/src/terminal/model/grid/grid_storage/resize.rs`, keep the fix localized to the branch where `GridStorage::shrink_cols` has just called `row.shrink(columns)`.
+After `row.shrink(columns)` returns discarded cells, handle the no-reflow split-wide-character case before the non-reflow branch pushes the shortened row into `new_raw`:
+- Capture the discarded cells returned by `row.shrink(columns)` instead of matching and discarding them immediately.
+- If `!reflow`, `columns > 0`, the retained final cell has `WIDE_CHAR`, and the first discarded cell has `WIDE_CHAR_SPACER`, remove only `WIDE_CHAR` from the retained final cell.
+- Continue to pass the captured discarded cells into the existing `reflow=true` branch unchanged.
+This satisfies `product.md` behavior 2-6 by repairing exactly the row whose spacer was discarded. It keeps the retained cell content and styling, but no longer advertises that the final retained cell occupies a missing second cell.
+The alternative of clearing the retained cell entirely is more visually conservative, but it loses user content even though a valid single-cell representation is available. Removing only `WIDE_CHAR` is the preferred default because no-reflow clear resize has already discarded the overflow spacer; preserving the glyph while removing the impossible two-cell claim maintains stability with the least data loss.
+### 2. Do not move this fix into `Row::shrink`
+`Row::shrink` only knows that cells were split off. It does not know whether the caller will discard those cells, reflow them into wrapped rows, or transform them with leading-spacer semantics. Its return value should preserve the original discarded cell flags so callers can decide how to handle a split wide-character pair. A generic `Row::shrink` cleanup that removes `WIDE_CHAR` whenever the first discarded cell is a spacer would also affect callers that still intend to preserve or reflow the wide character.
+Keeping the fix in `GridStorage::shrink_cols` preserves the caller-specific distinction:
+- `reflow=false`: overflow is discarded, so the retained final cell must be made materializable on its own.
+- `reflow=true`: overflow is wrapped, and the existing code moves a trailing `WIDE_CHAR` into wrapped content while placing a `LEADING_WIDE_CHAR_SPACER` in the retained row.
+This directly protects `product.md` behavior 7.
+### 3. Do not use `RowIterator::next` as the primary repair
+`RowIterator::next` should not silently paper over this producer bug by dropping or narrowing width-2 graphemes whenever `idx + 1 == row.len()`. That would prevent this specific panic but would make corrupted flat-storage rows harder to diagnose and could hide unrelated producers.
+If implementation review identifies a producer path that cannot be repaired before flat-storage materialization and requires extra consumer hardening, keep it secondary and explicit:
+- It must log enough context to identify the producer path.
+- It must have a dedicated test that proves the fallback does not corrupt valid rows.
+- It must not replace the producer-side regression test.
+Do not add consumer fallback for this issue by default.
+### 4. Regression test in `grid_handler_tests.rs`
+Add a focused test next to the existing full-grid clear resize tests:
+`test_full_grid_clear_shrink_cols_does_not_orphan_wide_char_at_boundary`
+The test should:
+1. Create a `GridHandler` with a wider initial column count than the final resized width.
+2. Enable `FullGridClearBehavior::Clear`.
+3. Build a valid wide-character pair exactly at the shrink boundary, with `WIDE_CHAR` at the final retained column and `WIDE_CHAR_SPACER` as the first discarded cell.
+4. Resize through the real `grid.resize(SizeInfo::new_without_font_metrics(...))` API so the test exercises `GridHandler::resize_storage` and `GridStorage::shrink_cols`.
+5. Use `assert_no_orphaned_wide_chars` to assert the row invariant.
+6. Assert the exact boundary postcondition: the final retained cell keeps its original character, foreground color, background color, and unrelated style flags; it no longer contains `WIDE_CHAR`; and no retained cell contains an orphaned `WIDE_CHAR_SPACER`.
+7. Push the post-resize retained row through a `FlatStorage` whose column count matches the resized grid width, then call `flat_storage.pop_rows(1)` and assert one row materializes without panic and preserves the retained boundary cell's character/style.
+This is slightly stronger than only asserting "does not panic" because it proves the producer invariant before flat storage gets involved.
+### 5. Add a resize-specific `reflow=true` guard
+Add a focused `GridStorage` / `GridHandler` resize regression for the ordinary reflow path:
+`test_shrink_cols_reflow_preserves_split_wide_char_as_wrapped_content`
+The test should:
+1. Build a valid wide-character pair at the shrink boundary in a normal reflowing resize path, without enabling `FullGridClearBehavior::Clear`.
+2. Resize narrower through the real resize API so `GridStorage::shrink_cols(reflow=true, ...)` handles the split pair.
+3. Assert the retained row uses the existing `LEADING_WIDE_CHAR_SPACER` representation rather than narrowing the retained cell.
+4. Assert the wrapped content still contains the original `WIDE_CHAR` cell followed by its `WIDE_CHAR_SPACER`.
+5. Assert the no-reflow boundary narrowing rule from change 1 does not run when `reflow=true`.
+This protects `product.md` behavior 7 and proves the producer-side fix is scoped to discarded overflow, not ordinary wrapped wide-character content.
+### 6. Preserve existing regression coverage
+Do not remove or weaken the existing clear-resize tests. In particular:
+- `test_full_grid_clear_resize_then_scroll_does_not_panic_on_row_iteration`
+- `test_full_grid_clear_resize_narrower_then_scroll_does_not_panic`
+- `test_full_grid_clear_resize_then_bounds_to_string_does_not_panic`
+- `test_resize_finished_primary_with_full_grid_clear_behavior_uses_scrollback`
+- `test_wide_char_wrap_preserves_own_leading_spacer`
+Those tests protect the earlier flat-storage column-sync behavior, finished primary-grid routing, and normal wrapped wide-character semantics. They also prevent this issue from being conflated with #10305-style width mismatches.
+## Testing and validation
+Map tests to `product.md` behavior:
+- Behavior 1, 8, 9: run the existing full-grid clear resize and routing tests:
+  ```bash
+  cargo nextest run --package warp terminal::model::grid::grid_handler::tests::test_full_grid_clear_resize_then_scroll_does_not_panic_on_row_iteration
+  cargo nextest run --package warp terminal::model::grid::grid_handler::tests::test_full_grid_clear_resize_narrower_then_scroll_does_not_panic
+  cargo nextest run --package warp terminal::model::grid::grid_handler::tests::test_full_grid_clear_resize_then_bounds_to_string_does_not_panic
+  cargo nextest run --package warp terminal::model::grid::grid_handler::tests::test_resize_finished_primary_with_full_grid_clear_behavior_uses_scrollback
+  ```
+- Behavior 2-6: add and run:
+  ```bash
+  cargo nextest run --package warp terminal::model::grid::grid_handler::tests::test_full_grid_clear_shrink_cols_does_not_orphan_wide_char_at_boundary
+  ```
+  This test should fail before the producer fix by detecting an orphaned `WIDE_CHAR` at the final retained column or by panicking during flat-storage materialization. It is the accepted deterministic proof for the original crash, which is difficult to reproduce manually because it depends on command timing, clear-hook handling, resize timing, and a wide-character boundary.
+- Behavior 4, 7: add and run the resize-specific `reflow=true` regression, and keep running the existing wrap guard:
+  ```bash
+  cargo nextest run --package warp terminal::model::grid::tests::test_shrink_cols_reflow_preserves_split_wide_char_as_wrapped_content
+  cargo nextest run --package warp terminal::model::grid::grid_handler::tests::test_wide_char_wrap_preserves_own_leading_spacer
+  ```
+- Behavior 4, 6, 7: run the existing wide-character editing and wrapping tests around `assert_no_orphaned_wide_chars`. At minimum, run the full grid-handler test module if time permits:
+  ```bash
+  cargo nextest run --package warp terminal::model::grid::grid_handler::tests
+  ```
+  If a narrower subset is needed, include the tests whose names mention wide char, spacer, wrap, erase, delete, insert, and clear.
+- General formatting and linting:
+  ```bash
+  ./script/format --check
+  cargo clippy --workspace --all-targets --all-features --tests -- -D warnings
+  ```
+- PR-level validation before final review:
+  ```bash
+  ./script/presubmit
+  ```
+  If unrelated local failures appear, record the failing test names and explain why they are unrelated to grid storage / row materialization.
+Manual validation is secondary for this issue because the original UI timing is unstable. Still, the implementation PR should include proof that `./script/run` builds and launches locally, then manually exercise terminal resize / clear activity with wide-character output. A screenshot is not meaningful for the core non-visual crash fix; a short screen recording is useful only if maintainers request manual evidence.
+## Parallelization
+Parallel sub-agents are not proposed for the implementation itself. The code change is narrow and the implementation/test files are tightly coupled:
+- `app/src/terminal/model/grid/grid_storage/resize.rs`
+- `app/src/terminal/model/grid/grid_handler_tests.rs`
+Splitting these across agents would likely create more coordination overhead than saved time. A useful parallel review pattern is possible after the first implementation draft: one reviewer can inspect the producer/consumer tradeoff while another runs the focused regression tests, but the patch should be authored as one coherent change.
+## Risks and mitigations
+### Risk: accidentally changing reflow semantics
+A too-low-level fix in `Row::shrink` could remove `WIDE_CHAR` before the `reflow=true` branch has a chance to preserve wrapped wide-character semantics.
+Mitigation: keep the mutation in `GridStorage::shrink_cols` and gate it on `!reflow`.
+### Risk: hiding malformed rows in `RowIterator`
+A broad consumer guard in `RowIterator::next` could stop panics while making future producer bugs invisible.
+Mitigation: repair the confirmed producer and rely on deterministic invariant tests. Add consumer hardening only if it is explicitly justified and separately tested.
+### Risk: overclaiming coverage for related RowIterator issues
+Public issues such as #11471 and #12459 share a `RowIterator::next` crash shape, but their public reports do not prove the same no-reflow clear-resize producer.
+Mitigation: describe this spec as fixing the deterministic producer in #12243. Do not claim it fixes every RowIterator bounds-check crash unless further evidence ties those reports to the same producer.
+### Risk: preserving a damaged glyph as narrow content is visually imperfect
+When no-reflow resize discards the spacer cell, the retained character can no longer be represented as a valid two-cell wide character in that row.
+Mitigation: this only happens at the discard boundary. Preserving content while removing the impossible width marker is preferable to retaining an unmaterializable row, and valid pairs inside the retained width are unchanged.
+## Follow-ups
+- If more RowIterator crashes appear with different producer paths, consider a broader audit of all row producers that can create or mutate wide-character pairs.
+- Consider adding debug-only invariant checks around row transitions into flat storage if future failures show more malformed-row producers.


### PR DESCRIPTION
## Description

The crash happens when `FullGridClearBehavior::Clear` resizes the active grid without reflow and `GridStorage::shrink_cols` truncates the spacer half of a wide-character pair. The retained final cell can still claim `WIDE_CHAR`, but its required `WIDE_CHAR_SPACER` has been discarded, so later flat-storage materialization can hit the reported `RowIterator::next` bounds panic.

- `GridStorage::shrink_cols` captures the discarded overflow cells from `Row::shrink`.
- When `reflow=false`, the retained final cell has `WIDE_CHAR`, and the first discarded cell has `WIDE_CHAR_SPACER`, Warp resets the retained final cell to the resize-empty cell.
- `Row::shrink` remains a context-free split primitive.
- `RowIterator::next` is not changed into a broad fallback.
- The `reflow=true` path continues to preserve wrapped wide characters with `LEADING_WIDE_CHAR_SPACER`.

## Linked Issue

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Closes #12243

## Testing

- Red/green no-reflow materialization regression:
  - Red commit: `fcf295ea test: add GH12243 wide char resize regression`
  - Red command:
    ```bash
    cargo nextest run --package warp terminal::model::grid::grid_handler::tests::test_full_grid_clear_split_wide_char_boundary_does_not_panic_on_materialization
    ```
  - Red result: failed as expected with `crates/warp_terminal/src/model/grid/flat_storage/row_iterator.rs:132:20: index out of bounds: the len is 5 but the index is 5`.
  - Green commit: `990afbca fix: reset split wide char on no-reflow resize`
  - Green command:
    ```bash
    cargo nextest run --package warp terminal::model::grid::grid_handler::tests::test_full_grid_clear_split_wide_char_boundary_does_not_panic_on_materialization
    ```
  - Green result: passed.

- Reflow guard:
  ```bash
  cargo nextest run --package warp terminal::model::grid::tests::test_shrink_cols_reflow_preserves_split_wide_char_as_wrapped_content
  ```
  Result: passed in local draft validation.

- Existing wrapped-wide-character guard:
  ```bash
  cargo nextest run --package warp terminal::model::grid::grid_handler::tests::test_wide_char_wrap_preserves_own_leading_spacer
  ```
  Result: passed.

Manual validation:

- Repro/validation procedure from the PR discussion:
  1. Run the command below in Warp.
  2. Press Cmd-F and search for `a`.
  3. Grab the right edge of the window and slowly shrink the window.
  4. On the unfixed build, this can reproduce the `row_iterator.rs:132` / `index out of bounds` panic.
  5. On the fixed build, the same flow should not produce a `row_iterator.rs:132` / `index out of bounds` panic during resize, find rerun, or command finish.

<details>
<summary>Manual repro command</summary>

  ```shell
  python3 <<'PY'
  import os, sys, time

  body = '{"v":1,"agent":"claude","event":"session_start","session_id":"manual-gh12243-highprob","cwd":"/tmp","project":"manual","plugin_version":"manual"}'
  sys.stdout.write(f'\033]777;notify;warp://cli-agent;{body}\a')
  sys.stdout.flush()

  wide = 'Ｗ'

  def emit_targets():
      cols = os.get_terminal_size().columns
      sys.stdout.write(f'\ncols={cols}; slowly shrink by 1..30 cols, then use Cmd-F or Ctrl-C\n')
      for delta in range(1, min(30, cols - 2) + 1):
          target_cols = cols - delta
          sys.stdout.write('a' * max(0, target_cols - 1) + wide + '\r\n')
      sys.stdout.flush()

  emit_targets()

  last_cols = os.get_terminal_size().columns
  while True:
      cols = os.get_terminal_size().columns
      if cols != last_cols:
          sys.stdout.write(f'\nresize {last_cols}->{cols}\n')
          emit_targets()
          last_cols = cols
      time.sleep(0.1)
  PY
  ```
</details>
  
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

- Before: run the repro command, search for `a`, slowly shrink the window, and show the crash/panic.

https://github.com/user-attachments/assets/2e7800cb-5420-4e7f-a16c-f2ce641af36e

- After: run the same flow on the fixed build and show that resize/find/command finish no longer logs `row_iterator.rs:132` / `index out of bounds`.

https://github.com/user-attachments/assets/819bada1-570b-423c-8c35-ed364fd7058d

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed a terminal crash when a clear-driven resize truncates the spacer half of a wide character.