### PR TITLE
Fix /test-warp-ui skill

### DIFF
--- a/resources/channel-gated-skills/dogfood/test-warp-ui/SKILL.md
+++ b/resources/channel-gated-skills/dogfood/test-warp-ui/SKILL.md
@@ -13,13 +13,23 @@ Use the `computer_use` tool to visually test that Warp looks and behaves as inte
 
 ## Running Warp
 
-Launch Warp from the repository root with:
+Launch Warp from the repository root. The exact command depends on which environment variable holds the API key:
 
-```bash
-cargo run -- --api-key $STAGING_USER_WARP_API_KEY
-```
+- If `WARP_API_KEY` is already set, omit the flag entirely — the `--api-key` flag is bound to `WARP_API_KEY`, so Warp reads it automatically:
 
-The `--api-key` flag authenticates using the API key from the `STAGING_USER_WARP_API_KEY` environment variable, so the app starts directly without interactive login prompts.
+  ```bash
+  cargo run --bin warp
+  ```
+
+- If the key is in `STAGING_USER_WARP_API_KEY` instead, pass it explicitly via the flag:
+
+  ```bash
+  cargo run --bin warp -- --api-key $STAGING_USER_WARP_API_KEY
+  ```
+
+Always pass `--bin warp` explicitly. That target builds the internal (dogfood) channel, which is the only channel that honors `--api-key` for the GUI app. A plain `cargo run` builds the OSS channel, which ignores the key and falls back to interactive onboarding.
+
+Authenticating this way starts the app directly without interactive login prompts.
 
 Initial builds may take several minutes; subsequent incremental builds are faster.
 
@@ -41,7 +51,7 @@ Keep mocked changes minimal and focused — only change what's necessary to reac
 
 Call the `computer_use` tool with a task description that includes:
 
-- The command to build and launch Warp (typically `cargo run -- --api-key $STAGING_USER_WARP_API_KEY` from the repo root)
+- The command to build and launch Warp from the repo root: `cargo run --bin warp` when `WARP_API_KEY` is set in the environment, or `cargo run --bin warp -- --api-key $STAGING_USER_WARP_API_KEY` when the key is in `STAGING_USER_WARP_API_KEY` instead
 - Step-by-step instructions for navigating to the UI being tested
 - **Specific observations to report**: describe exactly what elements, text, colors, layout, or states the tool should observe and describe back
 - Do **not** include expected values in the task — the tool should report what it sees, not judge correctness


### PR DESCRIPTION
## Description

Context in slack: https://warpdev.slack.com/archives/C09E37H1NMA/p1781684833377009?thread_ts=1781683153.529629&cid=C09E37H1NMA

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->