### PR TITLE
Spec: Droid CLI agent rich status support

### DIFF
--- a/specs/GH12639/product.md
+++ b/specs/GH12639/product.md
@@ -33,6 +33,8 @@ work to advertise whether it is still active, done, or waiting.
 - Warp provides clear manual setup instructions for enabling the Droid hook
   integration.
 - The integration does not require a new Warp protocol.
+- Droid rich-status support follows Warp's existing rich CLI-agent notification
+  rollout gate.
 - Existing rich-status behavior for Claude Code, OpenCode, Codex, Gemini,
   Auggie, and Pi remains unchanged.
 
@@ -47,6 +49,7 @@ work to advertise whether it is still active, done, or waiting.
   rich status model are in scope.
 - Changing the UX of the plugin install modal beyond Droid-specific manual
   instructions.
+- Adding a new Droid-specific rollout flag in this change.
 
 ## Behavior
 
@@ -54,52 +57,64 @@ work to advertise whether it is still active, done, or waiting.
    hook integration, Droid continues to behave as it does today. Basic agent
    recognition still works, and no new rich-status events are produced.
 
-2. When a user opens the plugin instructions for Droid, Warp shows Droid-specific
-   manual setup instructions for installing a hook script and registering that
-   script with Droid's hooks configuration.
+2. When Warp's rich CLI-agent notification infrastructure is disabled, Droid
+   rich-status support is disabled as well: Warp does not register the Droid
+   rich listener and does not show the Droid hook instructions entry point.
 
-3. The Droid setup instructions use Droid's documented hooks system. They do not
+3. When Warp's rich CLI-agent notification infrastructure is enabled and a user
+   opens the plugin instructions for Droid, Warp shows Droid-specific manual
+   setup instructions for installing a hook script and registering that script
+   with Droid's hooks configuration.
+
+4. The Droid setup instructions use Droid's documented hooks system. They do not
    require Warp to install files automatically or modify the user's Droid
    configuration without user action.
 
-4. The setup flow tells the user that the hook emits Warp CLI-agent events only
+5. The setup flow tells the user that the hook emits Warp CLI-agent events only
    when Droid is running inside Warp. Outside Warp, the hook should be inert.
 
-5. After the user completes setup and restarts or starts a Droid session in
+6. After the user completes setup and restarts or starts a Droid session in
    Warp, a Droid prompt submission is reflected as an in-progress/running agent
    status.
 
-6. When Droid finishes responding normally, Warp reflects the session as
+7. When Droid finishes responding normally, Warp reflects the session as
    completed/done using the existing completed status model.
 
-7. When Droid requests permission or otherwise notifies that it needs user
+8. When Droid requests permission or otherwise notifies that it needs user
    input, Warp reflects the session as attention-needed/blocked using the
    existing attention-needed status model.
 
-8. When Droid completes a tool after an attention-needed state, Warp can return
+9. When Droid completes a tool after an attention-needed state, Warp can return
    the session to in-progress if Droid emits a supported tool-complete event.
 
-9. Droid `SessionStart` events can be used to activate the rich listener path,
-   but they do not by themselves mark the session as running, completed, or
-   blocked. This matches the default behavior for agents whose `session_start`
-   event is setup metadata rather than user-visible status.
+10. Droid `SessionStart` events can be used to activate the rich listener path
+    and seed context, but they do not by themselves mark the session as running,
+    completed, or blocked. Registering a listener from a setup-only
+    `SessionStart` must leave the session in a neutral/idle state until Droid
+    emits a status-bearing event such as `prompt_submit`, `permission_request`,
+    `question_asked`, `tool_complete`, or `stop`.
 
-10. Event payloads that declare `agent: "droid"` and use Warp's existing
+11. Event payloads that declare `agent: "droid"` and use Warp's existing
     `warp://cli-agent` OSC 777 payload format are parsed as Droid events, not as
     unknown-agent events.
 
-11. Unsupported or malformed Droid hook payloads are ignored rather than
+12. Unsupported or malformed Droid hook payloads are ignored rather than
     crashing the terminal session or changing the session status incorrectly.
 
-12. Existing rich-status behavior for other CLI agents is unchanged. In
+13. Existing rich-status behavior for other CLI agents is unchanged. In
     particular, Codex's OSC 9 fallback behavior and existing structured
     plugin-event handling continue to work as before.
 
-13. If Droid's hook configuration is present but the hook script cannot emit an
+14. If Droid's hook configuration is present but the hook script cannot emit an
     event, the failure is non-fatal to Droid and to Warp. The user may lose rich
     status updates, but the Droid session itself should continue.
 
-14. The integration applies to local Droid sessions running inside Warp. Remote,
+15. If Droid hook input contains prompt text, notification text, paths, tool
+    names, or any other Droid-controlled field, the hook encodes it safely before
+    writing the OSC 777 notification. Untrusted text cannot inject additional
+    terminal control sequences or malformed JSON into Warp.
+
+16. The integration applies to local Droid sessions running inside Warp. Remote,
     SSH, or tmux-specific notification forwarding behavior is not changed by
     this issue.
 
@@ -133,23 +148,32 @@ a safe attention-needed state rather than reporting completion.
 5. A configured Droid session emits a `PostToolUse` event after an
    attention-needed state and Warp can return the session to in-progress.
 6. A `SessionStart` event with `agent: "droid"` activates the rich listener path
-   but does not create a false running/completed/blocked status on its own.
+   but leaves the session neutral/idle and does not create a false
+   running/completed/blocked status on its own.
 7. A valid structured OSC 777 `warp://cli-agent` payload with `agent: "droid"`
    is parsed as `CLIAgent::Droid`.
 8. Existing Claude Code, OpenCode, Codex, Gemini, Auggie, and Pi session-status
    tests continue to pass.
 9. Droid setup instructions are visible from the same plugin-instructions UI
-   used by other CLI-agent notification integrations.
+   used by other CLI-agent notification integrations when rich CLI-agent
+   notifications are enabled.
 10. The setup instructions are manual-only; Warp does not claim to auto-install
     or auto-update the Droid hook integration.
+11. Droid listener registration and hook instructions are unavailable when the
+    rich CLI-agent notification infrastructure is disabled.
+12. Droid-controlled prompt and notification text is JSON-encoded and stripped
+    or escaped for terminal control bytes before being emitted in OSC 777.
 
 ## Validation
 
 - Unit tests cover Droid support in the rich session listener, including support
-  gating and default forwarding behavior for `stop`, `permission_request`, and
-  other status events.
+  gating, neutral `session_start` registration, and default forwarding behavior
+  for `stop`, `permission_request`, and other status events.
 - Unit tests cover the Droid plugin manager or instructions provider, including
-  manual-only install behavior and presence of the required Droid hook events.
+  rollout gating, manual-only install behavior, and presence of the required
+  Droid hook events.
+- Unit tests cover safe hook payload construction for JSON encoding and terminal
+  control-byte sanitization.
 - Unit or parser tests confirm a structured event with `agent: "droid"` resolves
   to `CLIAgent::Droid`.
 - Manual validation runs Droid in Warp with the documented hooks configured and
@@ -166,6 +190,3 @@ a safe attention-needed state rather than reporting completion.
 - Does Droid expose a more reliable notification field for distinguishing
   permission requests from generic input-needed notifications, beyond inspecting
   the notification message?
-- Should Droid rich-status support be guarded by an existing feature flag such
-  as `HOANotifications`, or is listener support acceptable whenever Droid emits
-  the established Warp CLI-agent protocol?

--- a/specs/GH12639/product.md
+++ b/specs/GH12639/product.md
@@ -92,29 +92,38 @@ work to advertise whether it is still active, done, or waiting.
     completed, or blocked. Registering a listener from a setup-only
     `SessionStart` must leave the session in a neutral/idle state until Droid
     emits a status-bearing event such as `prompt_submit`, `permission_request`,
-    `question_asked`, `tool_complete`, or `stop`.
+    `question_asked`, `tool_complete` after an attention-needed state, or
+    `stop`.
 
-11. Event payloads that declare `agent: "droid"` and use Warp's existing
+11. If Warp has already created a Droid session from command detection before
+    the hook emits `SessionStart`, that setup-only `SessionStart` still clears
+    the false running state and leaves the session neutral/idle. The existing
+    state is preserved only after a status-bearing rich Droid event has already
+    updated the same non-empty Droid `session_id`.
+
+12. Event payloads that declare `agent: "droid"` and use Warp's existing
     `warp://cli-agent` OSC 777 payload format are parsed as Droid events, not as
     unknown-agent events.
 
-12. Unsupported or malformed Droid hook payloads are ignored rather than
+13. Unsupported or malformed Droid hook payloads are ignored rather than
     crashing the terminal session or changing the session status incorrectly.
 
-13. Existing rich-status behavior for other CLI agents is unchanged. In
+14. Existing rich-status behavior for other CLI agents is unchanged. In
     particular, Codex's OSC 9 fallback behavior and existing structured
     plugin-event handling continue to work as before.
 
-14. If Droid's hook configuration is present but the hook script cannot emit an
+15. If Droid's hook configuration is present but the hook script cannot emit an
     event, the failure is non-fatal to Droid and to Warp. The user may lose rich
     status updates, but the Droid session itself should continue.
 
-15. If Droid hook input contains prompt text, notification text, paths, tool
+16. If Droid hook input contains prompt text, notification text, paths, tool
     names, or any other Droid-controlled field, the hook encodes it safely before
     writing the OSC 777 notification. Untrusted text cannot inject additional
-    terminal control sequences or malformed JSON into Warp.
+    terminal control sequences or malformed JSON into Warp. The hook emits only
+    sanitized strings bounded by the technical spec and reduces tool input to a
+    bounded preview rather than forwarding Droid's raw tool input object.
 
-16. The integration applies to local Droid sessions running inside Warp. Remote,
+17. The integration applies to local Droid sessions running inside Warp. Remote,
     SSH, or tmux-specific notification forwarding behavior is not changed by
     this issue.
 
@@ -150,30 +159,38 @@ a safe attention-needed state rather than reporting completion.
 6. A `SessionStart` event with `agent: "droid"` activates the rich listener path
    but leaves the session neutral/idle and does not create a false
    running/completed/blocked status on its own.
-7. A valid structured OSC 777 `warp://cli-agent` payload with `agent: "droid"`
+7. If command detection created a Droid session as in-progress before the first
+   Droid `SessionStart`, that setup-only `SessionStart` changes the session to
+   neutral/idle and removes any running indicator.
+8. A valid structured OSC 777 `warp://cli-agent` payload with `agent: "droid"`
    is parsed as `CLIAgent::Droid`.
-8. Existing Claude Code, OpenCode, Codex, Gemini, Auggie, and Pi session-status
+9. Existing Claude Code, OpenCode, Codex, Gemini, Auggie, and Pi session-status
    tests continue to pass.
-9. Droid setup instructions are visible from the same plugin-instructions UI
+10. Droid setup instructions are visible from the same plugin-instructions UI
    used by other CLI-agent notification integrations when rich CLI-agent
    notifications are enabled.
-10. The setup instructions are manual-only; Warp does not claim to auto-install
+11. The setup instructions are manual-only; Warp does not claim to auto-install
     or auto-update the Droid hook integration.
-11. Droid listener registration and hook instructions are unavailable when the
+12. Droid listener registration and hook instructions are unavailable when the
     rich CLI-agent notification infrastructure is disabled.
-12. Droid-controlled prompt and notification text is JSON-encoded and stripped
-    or escaped for terminal control bytes before being emitted in OSC 777.
+13. Every Droid-controlled string emitted by the hook is sanitized, truncated to
+    the concrete per-field limits in the technical spec, JSON-encoded, and free
+    of raw terminal control bytes before being emitted in OSC 777.
+14. Droid tool input is not forwarded as an unbounded object; the hook emits only
+    a sanitized, bounded preview field that Warp can display.
 
 ## Validation
 
 - Unit tests cover Droid support in the rich session listener, including support
-  gating, neutral `session_start` registration, and default forwarding behavior
-  for `stop`, `permission_request`, and other status events.
+  gating, neutral `session_start` registration for new and command-detected
+  sessions, and default forwarding behavior for `stop`, `permission_request`,
+  and other status events.
 - Unit tests cover the Droid plugin manager or instructions provider, including
   rollout gating, manual-only install behavior, and presence of the required
   Droid hook events.
 - Unit tests cover safe hook payload construction for JSON encoding and terminal
-  control-byte sanitization.
+  control-byte sanitization, concrete per-field truncation limits, final payload
+  size enforcement, and bounded tool-input previews.
 - Unit or parser tests confirm a structured event with `agent: "droid"` resolves
   to `CLIAgent::Droid`.
 - Manual validation runs Droid in Warp with the documented hooks configured and
@@ -182,11 +199,10 @@ a safe attention-needed state rather than reporting completion.
 - Regression validation runs the existing listener and plugin-manager tests for
   other supported CLI agents.
 
-## Open questions
+## Follow-ups
 
-- Should Warp prefer a user-managed hook script in `~/.factory/hooks.json`, or a
-  Droid plugin-based hook package if Droid's plugin hook mechanism is considered
-  stable enough for this integration?
-- Does Droid expose a more reliable notification field for distinguishing
-  permission requests from generic input-needed notifications, beyond inspecting
-  the notification message?
+- Consider a Droid plugin-based hook package in a later version. V1 uses a
+  user-managed hook script registered in `~/.factory/hooks.json`.
+- Revisit permission-vs-question classification if Droid exposes a structured
+  notification type. V1 maps ambiguous notifications to an attention-needed
+  state.

--- a/specs/GH12639/product.md
+++ b/specs/GH12639/product.md
@@ -100,6 +100,8 @@ work to advertise whether it is still active, done, or waiting.
     the false running state and leaves the session neutral/idle. The existing
     state is preserved only after a status-bearing rich Droid event has already
     updated the same non-empty Droid `session_id`.
+    Clearing this false running state is a UI/session refresh only: it must not
+    behave like completion, attention-needed, or resumed-work status.
 
 12. Event payloads that declare `agent: "droid"` and use Warp's existing
     `warp://cli-agent` OSC 777 payload format are parsed as Droid events, not as
@@ -161,7 +163,9 @@ a safe attention-needed state rather than reporting completion.
    running/completed/blocked status on its own.
 7. If command detection created a Droid session as in-progress before the first
    Droid `SessionStart`, that setup-only `SessionStart` changes the session to
-   neutral/idle and removes any running indicator.
+   neutral/idle and removes any running indicator without creating completed,
+   attention-needed, rich-input auto-toggle, desktop notification, or agent task
+   lifecycle side effects.
 8. A valid structured OSC 777 `warp://cli-agent` payload with `agent: "droid"`
    is parsed as `CLIAgent::Droid`.
 9. Existing Claude Code, OpenCode, Codex, Gemini, Auggie, and Pi session-status
@@ -185,6 +189,10 @@ a safe attention-needed state rather than reporting completion.
   gating, neutral `session_start` registration for new and command-detected
   sessions, and default forwarding behavior for `stop`, `permission_request`,
   and other status events.
+- Unit or integration tests cover the command-detected `session_start` reset as a
+  non-status update: the running indicator clears, but no completed/blocked
+  conversation status, rich-input auto-toggle, desktop notification, agent
+  notification, or local task lifecycle update is produced.
 - Unit tests cover the Droid plugin manager or instructions provider, including
   rollout gating, manual-only install behavior, and presence of the required
   Droid hook events.

--- a/specs/GH12639/product.md
+++ b/specs/GH12639/product.md
@@ -1,0 +1,171 @@
+# Product Spec: Support rich CLI agent status for Droid
+
+**Issue:** [warpdotdev/warp#12639](https://github.com/warpdotdev/warp/issues/12639)
+**Figma:** none provided
+
+## Summary
+
+Droid is already recognized as a CLI agent in Warp, but Droid sessions do not
+currently participate in Warp's rich CLI-agent status flow. When Droid is
+running inside Warp and emits supported Warp CLI-agent notifications, Warp should
+track Droid sessions with the same vertical-tab and agent status model used for
+other supported CLI agents.
+
+## Problem
+
+Today, Droid receives basic CLI-agent treatment in Warp: it has a known command
+prefix, display name, icon, color, and skill providers. However, structured rich
+status events for Droid are not wired into the listener and plugin-instructions
+path that powers in-progress, completed, and attention-needed states.
+
+As a result, a Droid session can be recognized as a Droid CLI-agent session, but
+the user does not get the richer feedback that other supported agents can show
+while work is running or blocked on user input. This is especially noticeable in
+vertical tabs and other status surfaces where users expect long-running agent
+work to advertise whether it is still active, done, or waiting.
+
+## Goals
+
+- Droid sessions can emit Warp's existing structured CLI-agent protocol events
+  and have those events update rich session status in Warp.
+- Droid uses the same status semantics as other supported CLI agents wherever
+  the same Warp CLI-agent events are emitted.
+- Warp provides clear manual setup instructions for enabling the Droid hook
+  integration.
+- The integration does not require a new Warp protocol.
+- Existing rich-status behavior for Claude Code, OpenCode, Codex, Gemini,
+  Auggie, and Pi remains unchanged.
+
+## Non-goals
+
+- Adding a new CLI-agent notification protocol.
+- Adding one-click auto-install or auto-update for Droid hooks in this change.
+- Changing Droid itself or requiring a Droid release.
+- Changing Droid's command detection, display metadata, icon, color, or skill
+  providers.
+- Supporting every Droid hook event. Only events needed for Warp's existing
+  rich status model are in scope.
+- Changing the UX of the plugin install modal beyond Droid-specific manual
+  instructions.
+
+## Behavior
+
+1. When a user runs Droid inside Warp without installing or configuring the Warp
+   hook integration, Droid continues to behave as it does today. Basic agent
+   recognition still works, and no new rich-status events are produced.
+
+2. When a user opens the plugin instructions for Droid, Warp shows Droid-specific
+   manual setup instructions for installing a hook script and registering that
+   script with Droid's hooks configuration.
+
+3. The Droid setup instructions use Droid's documented hooks system. They do not
+   require Warp to install files automatically or modify the user's Droid
+   configuration without user action.
+
+4. The setup flow tells the user that the hook emits Warp CLI-agent events only
+   when Droid is running inside Warp. Outside Warp, the hook should be inert.
+
+5. After the user completes setup and restarts or starts a Droid session in
+   Warp, a Droid prompt submission is reflected as an in-progress/running agent
+   status.
+
+6. When Droid finishes responding normally, Warp reflects the session as
+   completed/done using the existing completed status model.
+
+7. When Droid requests permission or otherwise notifies that it needs user
+   input, Warp reflects the session as attention-needed/blocked using the
+   existing attention-needed status model.
+
+8. When Droid completes a tool after an attention-needed state, Warp can return
+   the session to in-progress if Droid emits a supported tool-complete event.
+
+9. Droid `SessionStart` events can be used to activate the rich listener path,
+   but they do not by themselves mark the session as running, completed, or
+   blocked. This matches the default behavior for agents whose `session_start`
+   event is setup metadata rather than user-visible status.
+
+10. Event payloads that declare `agent: "droid"` and use Warp's existing
+    `warp://cli-agent` OSC 777 payload format are parsed as Droid events, not as
+    unknown-agent events.
+
+11. Unsupported or malformed Droid hook payloads are ignored rather than
+    crashing the terminal session or changing the session status incorrectly.
+
+12. Existing rich-status behavior for other CLI agents is unchanged. In
+    particular, Codex's OSC 9 fallback behavior and existing structured
+    plugin-event handling continue to work as before.
+
+13. If Droid's hook configuration is present but the hook script cannot emit an
+    event, the failure is non-fatal to Droid and to Warp. The user may lose rich
+    status updates, but the Droid session itself should continue.
+
+14. The integration applies to local Droid sessions running inside Warp. Remote,
+    SSH, or tmux-specific notification forwarding behavior is not changed by
+    this issue.
+
+## Event mapping
+
+The Droid hook integration should map Droid lifecycle signals to Warp's existing
+CLI-agent event names:
+
+- `SessionStart` -> `session_start`
+- `UserPromptSubmit` -> `prompt_submit`
+- `Notification` -> `permission_request` or `question_asked`, depending on the
+  notification content available to the hook
+- `Stop` -> `stop`
+- `PostToolUse` -> `tool_complete`
+
+The exact hook script can use conservative heuristics for distinguishing
+permission requests from generic questions when Droid exposes both through
+`Notification`. If the distinction is ambiguous, the implementation should favor
+a safe attention-needed state rather than reporting completion.
+
+## Success criteria
+
+1. A configured Droid session emits a `prompt_submit` event and Warp shows the
+   session as in progress.
+2. A configured Droid session emits a `stop` event and Warp shows the session as
+   completed/done.
+3. A configured Droid session emits a permission-like `Notification` event and
+   Warp shows the session as attention-needed/blocked.
+4. A configured Droid session emits a question-like `Notification` event and
+   Warp shows the session as attention-needed/blocked.
+5. A configured Droid session emits a `PostToolUse` event after an
+   attention-needed state and Warp can return the session to in-progress.
+6. A `SessionStart` event with `agent: "droid"` activates the rich listener path
+   but does not create a false running/completed/blocked status on its own.
+7. A valid structured OSC 777 `warp://cli-agent` payload with `agent: "droid"`
+   is parsed as `CLIAgent::Droid`.
+8. Existing Claude Code, OpenCode, Codex, Gemini, Auggie, and Pi session-status
+   tests continue to pass.
+9. Droid setup instructions are visible from the same plugin-instructions UI
+   used by other CLI-agent notification integrations.
+10. The setup instructions are manual-only; Warp does not claim to auto-install
+    or auto-update the Droid hook integration.
+
+## Validation
+
+- Unit tests cover Droid support in the rich session listener, including support
+  gating and default forwarding behavior for `stop`, `permission_request`, and
+  other status events.
+- Unit tests cover the Droid plugin manager or instructions provider, including
+  manual-only install behavior and presence of the required Droid hook events.
+- Unit or parser tests confirm a structured event with `agent: "droid"` resolves
+  to `CLIAgent::Droid`.
+- Manual validation runs Droid in Warp with the documented hooks configured and
+  records prompt-submit, running, attention-needed, tool-complete, and done
+  states.
+- Regression validation runs the existing listener and plugin-manager tests for
+  other supported CLI agents.
+
+## Open questions
+
+- Should Warp prefer a user-managed hook script in `~/.factory/hooks.json`, or a
+  Droid plugin-based hook package if Droid's plugin hook mechanism is considered
+  stable enough for this integration?
+- Does Droid expose a more reliable notification field for distinguishing
+  permission requests from generic input-needed notifications, beyond inspecting
+  the notification message?
+- Should Droid rich-status support be guarded by an existing feature flag such
+  as `HOANotifications`, or is listener support acceptable whenever Droid emits
+  the established Warp CLI-agent protocol?

--- a/specs/GH12639/product.md
+++ b/specs/GH12639/product.md
@@ -125,9 +125,12 @@ work to advertise whether it is still active, done, or waiting.
     sanitized strings bounded by the technical spec and reduces tool input to a
     bounded preview rather than forwarding Droid's raw tool input object.
 
-17. The integration applies to local Droid sessions running inside Warp. Remote,
-    SSH, or tmux-specific notification forwarding behavior is not changed by
-    this issue.
+17. The v1 supported setup and validation target is local Droid sessions running
+    inside Warp. This issue does not add or change remote, SSH, or tmux-specific
+    notification forwarding behavior. If an existing Warp-managed remote shell
+    already exposes the same CLI-agent protocol environment, any Droid events
+    emitted through that path are treated as existing best-effort protocol
+    behavior rather than a new support guarantee.
 
 ## Event mapping
 

--- a/specs/GH12639/tech.md
+++ b/specs/GH12639/tech.md
@@ -1,0 +1,270 @@
+# Tech Spec: Support rich CLI agent status for Droid
+
+**Issue:** [warpdotdev/warp#12639](https://github.com/warpdotdev/warp/issues/12639)
+**Product spec:** `specs/GH12639/product.md`
+
+## Context
+
+Droid is already modeled as a first-class `CLIAgent`, but rich session-status
+handling currently stops before Droid events can update the shared CLI-agent
+session model.
+
+Relevant current code:
+
+- `app/src/terminal/cli_agent.rs` - defines `CLIAgent::Droid`, the `droid`
+  command prefix, display name, icon, brand color, and Droid skill providers.
+- `app/src/terminal/cli_agent_sessions/event/v1.rs` - parses structured
+  `warp://cli-agent` OSC 777 payloads and resolves the `"agent"` string through
+  `CLIAgent::command_prefix()`. This already allows `"droid"` to resolve to
+  `CLIAgent::Droid`.
+- `app/src/terminal/cli_agent_sessions/listener/mod.rs` - `is_agent_supported`
+  currently allows Claude, OpenCode, Codex, Gemini, Auggie, and Pi. Droid is not
+  included, and `create_handler` explicitly returns `None` for
+  `CLIAgent::Droid`.
+- `app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs` -
+  `plugin_manager_for_with_shell` currently returns `None` for
+  `CLIAgent::Droid`, so the plugin-instructions UI has no Droid-specific setup
+  flow.
+
+Droid's documented hooks system can run user-defined commands for lifecycle
+events such as `SessionStart`, `UserPromptSubmit`, `Notification`, `Stop`, and
+`PostToolUse`. Hook commands receive structured JSON on stdin, including common
+fields such as `session_id`, `transcript_path`, `cwd`, and
+`hook_event_name`. That is enough to bridge Droid hooks to Warp's existing
+structured CLI-agent event protocol without adding a new Warp-side protocol.
+
+## Current state
+
+The structured parser can already parse a payload like this into
+`CLIAgent::Droid`:
+
+```json
+{
+  "v": 1,
+  "agent": "droid",
+  "event": "prompt_submit",
+  "session_id": "abc123"
+}
+```
+
+The event is then blocked by the support gate:
+
+1. A raw OSC 777 notification reaches Warp.
+2. `parse_event` / `event::v1::parse` can resolve `agent: "droid"`.
+3. The listener support check does not include Droid.
+4. `create_handler(CLIAgent::Droid)` returns `None`.
+5. The session listener is not registered, so future Droid rich-status events do
+   not update the session model.
+
+Separately, the plugin manager has no Droid manager. Even if Droid can emit the
+right protocol through hooks, Warp does not show the user Droid-specific manual
+setup instructions from the plugin UI.
+
+## Proposed changes
+
+### 1. Enable Droid in the session listener
+
+Update `app/src/terminal/cli_agent_sessions/listener/mod.rs`:
+
+- Add `CLIAgent::Droid` to `is_agent_supported`.
+- Add `CLIAgent::Droid` to the `DefaultSessionListener` match arm in
+  `create_handler`.
+- Keep `DefaultSessionListener` behavior unchanged: skip `SessionStart`, forward
+  all other structured events to `CLIAgentSessionsModel`.
+
+Droid should use the default listener because its hook integration emits the
+same structured Warp CLI-agent events as other default-listener agents. It does
+not need Codex's OSC 9 fallback handling.
+
+### 2. Add a Droid plugin manager for manual instructions
+
+Add `app/src/terminal/cli_agent_sessions/plugin_manager/droid.rs` and register
+it in `plugin_manager/mod.rs`.
+
+The Droid manager should implement `CliAgentPluginManager` with:
+
+- `minimum_plugin_version() -> "1.0.0"` or another initial version chosen during
+  implementation.
+- `can_auto_install() -> false`.
+- `supports_update() -> false` unless implementation later provides a reliable
+  on-disk version check.
+- `install_instructions()` and `update_instructions()` returning the same manual
+  instruction set.
+- no override for `install()` / `update()`, so the default unsupported
+  auto-install behavior remains in place.
+
+Manual instructions should guide the user to:
+
+1. Create a local hook script that reads Droid's hook JSON from stdin.
+2. Exit without emitting anything when Droid is not running inside Warp, such as
+   when `WARP_CLI_AGENT_PROTOCOL_VERSION` is absent.
+3. Map supported Droid hook events to Warp CLI-agent events.
+4. Write an OSC 777 notification to the terminal in Warp's existing
+   `warp://cli-agent` format.
+5. Register the hook command in Droid's documented hooks configuration.
+6. Restart Droid or start a new Droid session so the hooks are active.
+
+The implementation should align the configuration snippet with Droid's current
+documented hooks schema. As of the referenced Factory docs, user hooks live in
+`~/.factory/hooks.json` and are structured under a top-level `"hooks"` object,
+with event names such as `UserPromptSubmit`, `Notification`, `Stop`, and
+`PostToolUse` under that object. Events that do not use matchers can omit the
+`matcher` field.
+
+### 3. Event mapping and payload shape
+
+The hook script should emit Warp event names using this mapping:
+
+- `SessionStart` -> `session_start`
+- `UserPromptSubmit` -> `prompt_submit`
+- `Notification` -> `permission_request` or `question_asked`
+- `Stop` -> `stop`
+- `PostToolUse` -> `tool_complete`
+
+The emitted JSON payload should include:
+
+- `v`: the supported protocol version, clamped or defaulted to `1`
+- `agent`: `"droid"`
+- `event`: the mapped Warp event name
+- `session_id`: Droid `session_id`, when present
+- `cwd`: Droid `cwd`, when present
+- `project`: best-effort project name derived from `cwd`, when present
+- `plugin_version`: the Droid hook bridge version
+
+Event-specific fields should be populated conservatively:
+
+- `prompt_submit`: include a bounded `query` from Droid's `prompt`, when
+  present.
+- `permission_request` / `question_asked`: include a `summary` from Droid's
+  notification `message`, when present.
+- `tool_complete`: include `tool_name` and a tool-input preview when useful and
+  already supported by the parser.
+- `stop`: no additional payload is required.
+
+For `Stop`, the hook should respect Droid's `stop_hook_active` field and avoid
+emitting recursive or misleading stop notifications when Droid is continuing as
+part of a stop-hook flow.
+
+### 4. Keep other agents unchanged
+
+Do not change:
+
+- Codex's `CodexSessionHandler` and OSC 9 fallback behavior.
+- Existing plugin managers for Claude, OpenCode, Codex, or Gemini.
+- Auggie and Pi listener-only support.
+- Droid command detection, display metadata, skill providers, or bash-mode
+  support.
+
+## End-to-end flow
+
+1. User installs/configures the Droid hook integration from Warp's manual
+   instructions.
+2. User starts Droid inside Warp.
+3. Droid invokes `SessionStart`; the hook emits a structured OSC 777
+   `session_start` payload with `agent: "droid"`.
+4. Warp parses the event, recognizes `CLIAgent::Droid`, and creates a Droid
+   default session listener.
+5. `DefaultSessionListener` drops the setup-only `SessionStart` event.
+6. User submits a prompt. Droid invokes `UserPromptSubmit`; the hook emits
+   `prompt_submit`.
+7. Warp forwards the event to `CLIAgentSessionsModel`, and the Droid session is
+   shown as in progress.
+8. If Droid needs input or permission, Droid invokes `Notification`; the hook
+   emits either `permission_request` or `question_asked`, and Warp shows
+   attention needed.
+9. If Droid completes a tool, Droid invokes `PostToolUse`; the hook emits
+   `tool_complete`, and Warp can return the session to in-progress.
+10. When Droid finishes, Droid invokes `Stop`; the hook emits `stop`, and Warp
+    shows the session as done.
+
+## Testing and validation
+
+Implementation tests should include:
+
+1. `app/src/terminal/cli_agent_sessions/listener/mod_tests.rs`
+   - `droid_is_supported`: `is_agent_supported(&CLIAgent::Droid)` is true.
+   - Droid with `DefaultSessionListener` skips `SessionStart`.
+   - Droid with `DefaultSessionListener` forwards `Stop`.
+   - Droid with `DefaultSessionListener` forwards `PermissionRequest`.
+   - Optionally cover `QuestionAsked` or `ToolComplete` if local test helpers
+     make that clearer than relying on existing default-listener coverage.
+
+2. `app/src/terminal/cli_agent_sessions/plugin_manager/mod_tests.rs`
+   - `plugin_manager_for(CLIAgent::Droid)` returns `Some`.
+   - Droid is removed from the unsupported-agents assertion.
+
+3. `app/src/terminal/cli_agent_sessions/plugin_manager/droid_tests.rs`
+   - `can_auto_install()` is false.
+   - `supports_update()` is false.
+   - minimum version is stable and explicit.
+   - install instructions contain the required Droid hook events:
+     `SessionStart`, `UserPromptSubmit`, `Notification`, `Stop`, and
+     `PostToolUse`.
+   - install instructions mention or encode the documented hooks configuration
+     shape.
+   - install instructions mention required dependencies such as `jq`, if the
+     hook script uses them.
+
+4. Parser coverage, if not already covered elsewhere:
+   - A structured v1 payload with `agent: "droid"` resolves to
+     `CLIAgent::Droid`.
+   - A malformed or unsupported Droid payload is ignored or treated as unknown
+     without panicking.
+
+Recommended commands before opening the implementation for review:
+
+```bash
+cargo fmt --check
+cargo test -p warp --lib terminal::cli_agent_sessions::listener::tests
+cargo test -p warp --lib terminal::cli_agent_sessions::plugin_manager::tests
+cargo test -p warp --lib terminal::cli_agent_sessions::plugin_manager::droid::tests
+```
+
+Manual validation:
+
+- Run WarpOss locally.
+- Configure the Droid hook integration from the instructions.
+- Start Droid inside Warp.
+- Submit a prompt and confirm the vertical tab enters the running state.
+- Trigger a permission/input notification and confirm the tab indicates
+  attention needed.
+- Allow Droid to complete a tool and continue.
+- Let Droid finish and confirm the tab returns to done/completed.
+- Attach a short screen recording to the implementation PR.
+
+## Risks and mitigations
+
+- Risk: Droid's hooks configuration schema changes or differs across versions.
+  Mitigation: keep setup instructions aligned with Droid's documented
+  `~/.factory/hooks.json` schema and include manual validation in the
+  implementation PR.
+
+- Risk: `Notification` does not expose a perfect machine-readable distinction
+  between permission requests and generic input-needed prompts. Mitigation: use
+  conservative heuristics and map ambiguous notifications to an attention-needed
+  state rather than completion. Revisit the distinction if Droid adds a more
+  specific field.
+
+- Risk: the hook script fails because `jq` is unavailable or `/dev/tty` cannot
+  be written. Mitigation: document the dependency, fail non-fatally, and avoid
+  breaking the Droid session when rich status cannot be emitted.
+
+- Risk: adding Droid to the default listener forwards unexpected event types.
+  Mitigation: the event parser already normalizes known event names, and the
+  default listener behavior is shared by other structured-event agents. Add
+  Droid-specific listener tests for key status events.
+
+- Risk: users expect one-click install because other agents support it.
+  Mitigation: `can_auto_install()` remains false and the UI presents this as a
+  manual setup flow.
+
+## Follow-ups
+
+- Consider a Droid plugin package if Droid's plugin hook mechanism is preferred
+  over user-managed hook scripts.
+- Add version detection and update prompts if the hook bridge becomes
+  auto-installable or has a stable on-disk location.
+- Revisit permission-vs-question classification if Droid exposes a structured
+  notification type.
+- Evaluate remote, SSH, and tmux behavior separately from this local Droid hook
+  integration.

--- a/specs/GH12639/tech.md
+++ b/specs/GH12639/tech.md
@@ -72,6 +72,12 @@ session as `InProgress`, while `DefaultSessionListener` and
 `CLIAgentSession::apply_event` both treat `SessionStart` as setup metadata. Droid
 must not inherit a false running state from listener registration alone.
 
+Command detection can also create a Droid session before the hook emits its
+first structured notification. Those command-detected sessions are currently
+`InProgress`, have no listener, and have not received any status-bearing rich
+event. A setup-only Droid `SessionStart` must clear that false running state
+rather than preserve it.
+
 ## Proposed changes
 
 ### 1. Enable Droid in the session listener
@@ -102,22 +108,50 @@ status-bearing event for the current turn.
 
 Required behavior:
 
-- When `register_listener` is triggered by `SessionStart`, a new Droid session is
-  created with `CLIAgentSessionStatus::Idle` instead of `InProgress`.
-- When a `SessionStart` updates an existing Droid session, the update attaches
-  listener/plugin context but preserves the existing status. Only a newly
-  created setup-only session starts in `Idle`.
+- Track whether the current Droid session has already applied a status-bearing
+  rich event. This can be a new boolean such as
+  `has_received_status_bearing_rich_event`; it must be separate from the
+  existing `received_rich_notification` concept because `SessionStart` is a rich
+  notification but is not status-bearing.
+- Status-bearing rich events are the events that produce an
+  `InProgress`, `Blocked`, or `Success` session status after
+  `CLIAgentSession::apply_event`: `PromptSubmit`, `PermissionRequest`,
+  `QuestionAsked`, `PermissionReplied` after blocked, `ToolComplete` after
+  blocked, and `Stop`. `SessionStart`, `IdlePrompt`, malformed events, and
+  ignored unknown events do not set the status-bearing marker.
+- When `register_listener` is triggered by Droid `SessionStart`, a new Droid
+  session is created with `CLIAgentSessionStatus::Idle` instead of
+  `InProgress`.
+- When Droid `SessionStart` updates an existing command-detected Droid session,
+  it attaches listener/plugin context and changes the session to `Idle`, even if
+  the existing status is `InProgress`.
+- An existing status may be preserved on Droid `SessionStart` only when the
+  stored session already applied a status-bearing rich event for the same Droid
+  session. The same-session check requires both stored and incoming
+  `session_id` values to be present and equal. If either side lacks a
+  `session_id`, or if the ids differ, treat the `SessionStart` as setup for a
+  fresh session: reset the status-bearing marker and set the status to `Idle`.
+  No other existing status, including command-detected `InProgress`, may be
+  preserved across a setup-only `SessionStart`.
 - `SessionStart` continues to seed `cwd`, `project`, `session_id`, and
   `plugin_version`.
-- `SessionStart` does not emit `StatusChanged` and does not update agent
-  conversation history to `ConversationStatus::InProgress`.
-- Vertical tabs and other status surfaces render an idle listener registration
-  without the running spinner. If they need a conversation-status projection,
-  `Idle` should project to no status (`None`) rather than to
+- Droid `SessionStart` never emits an `InProgress`, `Blocked`, or `Success`
+  status and never updates agent conversation history to
   `ConversationStatus::InProgress`.
+- If a setup-only `SessionStart` changes an existing command-detected session
+  from `InProgress` to `Idle`, the model must notify status surfaces so the
+  running spinner is cleared. This can be done with `StatusChanged(Idle)` or an
+  equivalent `SessionUpdated` notification, but the UI projection for `Idle`
+  must be no conversation status (`None`), not
+  `ConversationStatus::InProgress`.
+- Update the projection used by status surfaces, such as
+  `CLIAgentSessionStatus::to_conversation_status` or a wrapper around it, so
+  `Idle` returns `None`. Do not map `Idle` to `InProgress`, `Blocked`, or
+  `Success`.
 - `PromptSubmit`, `ToolComplete` after blocked, `PermissionReplied` after
   blocked, `PermissionRequest`, `QuestionAsked`, and `Stop` remain
-  status-bearing and move the session out of `Idle`.
+  status-bearing and move the session out of `Idle`. The status-bearing marker
+  is set only after one of these events actually changes the session status.
 
 This is intentionally a model/UI change, not just a listener change. Dropping
 `SessionStart` inside `DefaultSessionListener` is not sufficient because the
@@ -148,7 +182,9 @@ rich CLI-agent notification rollout gate.
 
 Manual instructions should guide the user to:
 
-1. Create a local hook script that reads Droid's hook JSON from stdin.
+1. Create a local POSIX shell hook script that reads Droid's hook JSON from
+   stdin and uses `jq` for JSON parsing, sanitization, truncation, and payload
+   construction.
 2. Exit without emitting anything when Droid is not running inside Warp, such as
    when `WARP_CLI_AGENT_PROTOCOL_VERSION` is absent.
 3. Map supported Droid hook events to Warp CLI-agent events.
@@ -186,12 +222,13 @@ The emitted JSON payload should include:
 
 Event-specific fields should be populated conservatively:
 
-- `prompt_submit`: include a bounded `query` from Droid's `prompt`, when
-  present.
-- `permission_request` / `question_asked`: include a `summary` from Droid's
+- `prompt_submit`: include `query` from Droid's `prompt`, when present.
+- `permission_request` / `question_asked`: include `summary` from Droid's
   notification `message`, when present.
-- `tool_complete`: include `tool_name` and a tool-input preview when useful and
-  already supported by the parser.
+- `tool_complete`: include `tool_name` and a bounded tool-input preview when
+  useful. Do not forward Droid's raw `tool_input` object. If a preview is
+  available, emit a small `tool_input` object with only one parser-supported
+  string key, preferring `command` and falling back to `file_path`.
 - `stop`: no additional payload is required.
 
 For `Stop`, the hook should respect Droid's `stop_hook_active` field and avoid
@@ -201,15 +238,56 @@ part of a stop-hook flow.
 The hook bridge must treat all Droid-provided strings and JSON fields as
 untrusted input:
 
-- Build the OSC 777 payload with a JSON encoder such as `jq`, not with
+- Build the v1 manual hook's OSC 777 payload with `jq`, not with
   hand-concatenated JSON strings.
-- Bound long string fields such as `query` and `summary` before including them
-  in the payload.
-- Strip or escape terminal control bytes from every string that can reach the
-  OSC 777 output, including prompt text, notification messages, paths, project
+- Remove terminal control characters from every string that can reach the OSC
+  777 output, including prompt text, notification messages, paths, project
   names, tool names, and tool-input previews.
 - Ensure the final write to `/dev/tty` cannot emit extra BEL/ST terminators or
   nested escape sequences sourced from Droid-controlled fields.
+
+Use this exact sanitization and bounding policy for every string emitted by the
+hook:
+
+1. Convert only the known fields below to strings. Do not serialize arbitrary
+   Droid objects into the Warp payload.
+2. Remove Unicode control characters in `U+0000..U+001F` and `U+007F..U+009F`
+   before truncation. This specifically removes raw ESC, BEL, and C1 string
+   terminator characters from Droid-controlled data.
+3. Truncate at the last complete Unicode scalar value at or before the listed
+   limit. Do not append an ellipsis or other marker after truncation.
+4. JSON-encode the sanitized values with compact `jq -c` output, using
+   `jq --arg` and `jq --argjson` for value injection.
+5. After JSON encoding, the body portion of the OSC 777 notification must be at
+   most 8192 UTF-8 bytes. If the body is larger, drop optional fields in this
+   order and re-encode after each step: `tool_input`, `transcript_path`, then
+   event-specific text (`query` or `summary`). If the required fields still do
+   not fit, skip emitting that notification rather than writing an oversized
+   payload.
+
+Per-field limits:
+
+| Payload field | Source | Limit |
+| --- | --- | --- |
+| `session_id` | Droid `session_id` | 128 Unicode scalar values |
+| `cwd` | Droid `cwd` or `FACTORY_PROJECT_DIR` | 1024 Unicode scalar values |
+| `project` | basename derived from sanitized `cwd` | 128 Unicode scalar values |
+| `transcript_path` | Droid `transcript_path` | 1024 Unicode scalar values |
+| `plugin_version` | hook bridge constant | 32 Unicode scalar values |
+| `query` | Droid `prompt` | 2048 Unicode scalar values |
+| `summary` | Droid notification `message` | 2048 Unicode scalar values |
+| `tool_name` | Droid `tool_name` | 128 Unicode scalar values |
+| `tool_input.command` or `tool_input.file_path` | bounded preview extracted from Droid tool input | 2048 Unicode scalar values |
+
+`agent` and `event` are fixed hook-generated constants, not Droid-controlled
+strings. The hook should not emit `response` in v1.
+
+The final terminal write must contain raw ESC and BEL only as the OSC wrapper
+delimiters: `ESC ] 777 ; notify ; warp://cli-agent ; <json> BEL`. The encoded
+JSON body must not contain raw bytes in `0x00..0x1F` or `0x7F`. JSON escape
+sequences such as `\u001b` are not sufficient by themselves; Droid-controlled
+control characters must be removed before encoding so Warp never stores or
+renders those controls after JSON parsing.
 
 ### 5. Keep other agents unchanged
 
@@ -227,12 +305,13 @@ Do not change:
    instructions.
 2. User starts Droid inside Warp.
 3. Droid invokes `SessionStart`; the hook emits a safely encoded structured OSC
-   777
-   `session_start` payload with `agent: "droid"`.
+   777 `session_start` payload with `agent: "droid"`.
 4. Warp parses the event, recognizes `CLIAgent::Droid`, and creates a Droid
    default session listener.
 5. Warp registers the listener in `Idle` state, seeds context from
-   `SessionStart`, and does not show the running spinner.
+   `SessionStart`, and does not show the running spinner. If command detection
+   had already created an `InProgress` Droid session for the same terminal, this
+   step changes that session to `Idle` and clears the spinner.
 6. User submits a prompt. Droid invokes `UserPromptSubmit`; the hook emits
    `prompt_submit`.
 7. Warp forwards the event to `CLIAgentSessionsModel`, and the Droid session is
@@ -265,16 +344,29 @@ Implementation tests should include:
 2. `app/src/terminal/cli_agent_sessions/mod_tests.rs`
    - Registering a listener from a Droid `SessionStart` creates or upgrades a
      session in `Idle`, not `InProgress`.
+   - If command detection already created an `InProgress` Droid session with no
+     status-bearing rich event, registering from Droid `SessionStart` changes it
+     to `Idle` and notifies status surfaces so the running spinner clears.
+   - If the stored session has already applied a status-bearing rich event with
+     the same non-empty `session_id`, a later duplicate Droid `SessionStart`
+     keeps that status for that same session.
+   - If a Droid `SessionStart` has a different `session_id` from the stored
+     session, the status-bearing marker resets and the session becomes `Idle`.
    - Applying that same `SessionStart` seeds context/plugin version but emits no
-     `StatusChanged` and does not project to `ConversationStatus::InProgress`.
+     `InProgress`, `Blocked`, or `Success` status and does not project to
+     `ConversationStatus::InProgress`.
    - A later `PromptSubmit` moves the session from `Idle` to `InProgress`.
    - A later `PermissionRequest` or `QuestionAsked` moves the session from
      `Idle` or `InProgress` to `Blocked`.
+   - The status-bearing marker remains false for `SessionStart` and `IdlePrompt`
+     and becomes true only after an applied rich event changes status.
 
 3. `app/src/terminal/view_tests.rs`
    - A Droid `SessionStart` with rich notifications enabled creates the listener
      but leaves the vertical-tab status indicator without an in-progress
      spinner.
+   - A command-detected Droid session that was showing an in-progress spinner
+     clears that spinner when the first rich event is setup-only `SessionStart`.
    - A later Droid `prompt_submit` shows the in-progress spinner.
 
 4. `app/src/terminal/cli_agent_sessions/plugin_manager/mod_tests.rs`
@@ -293,10 +385,24 @@ Implementation tests should include:
      `PostToolUse`.
    - install instructions mention or encode the documented hooks configuration
      shape.
-   - install instructions mention required dependencies such as `jq`, if the
-     hook script uses them.
-   - hook payload construction uses a JSON encoder and sanitizes terminal
-     control bytes from Droid-controlled strings before writing OSC 777.
+   - install instructions mention the required `jq` dependency and the hook
+     script exits non-fatally when `jq` is unavailable.
+   - hook payload construction uses compact JSON encoder output and sanitizes
+     terminal control bytes from Droid-controlled strings before writing OSC 777.
+   - hook payload tests cover the exact per-field limits for `session_id`, `cwd`,
+     `project`, `transcript_path`, `query`, `summary`, `tool_name`, and
+     tool-input preview.
+   - hook payload tests verify truncation happens at a complete Unicode scalar
+     boundary and does not append an ellipsis.
+   - hook payload tests verify the final encoded JSON body is at most 8192 UTF-8
+     bytes or no notification is emitted.
+   - hook payload tests verify raw Droid `tool_input` objects are not forwarded;
+     only a sanitized bounded preview under `tool_input.command` or
+     `tool_input.file_path` is emitted.
+   - hook payload tests inject ESC, BEL, C1 controls, and embedded OSC
+     terminators into prompt text, notification text, paths, tool names, and
+     tool input, then assert the final bytes written to `/dev/tty` contain no raw
+     terminal control bytes except the required OSC wrapper delimiters.
 
 6. Parser coverage, if not already covered elsewhere:
    - A structured v1 payload with `agent: "droid"` resolves to
@@ -346,12 +452,15 @@ Manual validation:
 
 - Risk: Droid-controlled text could inject malformed JSON or terminal control
   sequences into OSC 777 output. Mitigation: build payloads with a JSON encoder,
-  bound long fields, and strip or escape terminal control bytes before writing
-  the notification.
+  apply the per-field limits above, remove terminal control characters before
+  encoding, avoid forwarding raw `tool_input`, enforce the 8192-byte JSON body
+  cap, and test the final bytes written to `/dev/tty`.
 
 - Risk: a setup-only `SessionStart` could make Warp display Droid as running.
-  Mitigation: add an explicit idle registration state and tests proving
-  `SessionStart` does not produce an in-progress conversation status.
+  Mitigation: add an explicit idle registration state, track whether a
+  status-bearing rich event has actually applied to the current Droid
+  `session_id`, and test both new sessions and command-detected `InProgress`
+  sessions being reset to `Idle` by setup-only `SessionStart`.
 
 - Risk: adding Droid to the default listener forwards unexpected event types.
   Mitigation: the event parser already normalizes known event names, and the

--- a/specs/GH12639/tech.md
+++ b/specs/GH12639/tech.md
@@ -78,6 +78,13 @@ first structured notification. Those command-detected sessions are currently
 event. A setup-only Droid `SessionStart` must clear that false running state
 rather than preserve it.
 
+A second eventing detail matters: `CLIAgentSessionsModelEvent::StatusChanged`
+is consumed as a lifecycle status, not as a generic refresh signal. Current
+consumers update conversation status, auto-toggle rich input, create or clear
+agent notifications, drive ambient CLI harness completion, and sync local task
+state from `StatusChanged`. `CLIAgentSessionsModelEvent::SessionUpdated` is the
+existing non-status session refresh/save signal.
+
 ## Proposed changes
 
 ### 1. Enable Droid in the session listener
@@ -140,14 +147,22 @@ Required behavior:
   `ConversationStatus::InProgress`.
 - If a setup-only `SessionStart` changes an existing command-detected session
   from `InProgress` to `Idle`, the model must notify status surfaces so the
-  running spinner is cleared. This can be done with `StatusChanged(Idle)` or an
-  equivalent `SessionUpdated` notification, but the UI projection for `Idle`
-  must be no conversation status (`None`), not
-  `ConversationStatus::InProgress`.
-- Update the projection used by status surfaces, such as
-  `CLIAgentSessionStatus::to_conversation_status` or a wrapper around it, so
-  `Idle` returns `None`. Do not map `Idle` to `InProgress`, `Blocked`, or
-  `Success`.
+  running spinner is cleared. This must use `SessionUpdated` or another
+  explicitly non-status update event, not `StatusChanged(Idle)`.
+- Keep `StatusChanged` reserved for status-bearing session transitions that
+  lifecycle consumers should process: `InProgress`, `Blocked`, and `Success`.
+  Setup-only `SessionStart` must not trigger conversation-status updates,
+  rich-input auto-toggle, desktop notifications, agent notifications, ambient
+  harness completion, or local task lifecycle sync.
+- Update the projection used by status surfaces so `Idle` returns no
+  conversation status (`None`). This can be an `Option<ConversationStatus>`
+  replacement for `CLIAgentSessionStatus::to_conversation_status` or a wrapper
+  used by vertical tabs and detail sidecars. Do not map `Idle` to
+  `InProgress`, `Blocked`, or `Success`.
+- If `Idle` is added as a `CLIAgentSessionStatus` variant, every direct match on
+  `CLIAgentSessionStatus` in lifecycle consumers must handle `Idle` as a no-op
+  or unreachable non-status case. It must not fall through to the existing
+  success/completed or blocked/attention-needed behavior.
 - `PromptSubmit`, `ToolComplete` after blocked, `PermissionReplied` after
   blocked, `PermissionRequest`, `QuestionAsked`, and `Stop` remain
   status-bearing and move the session out of `Idle`. The status-bearing marker
@@ -346,15 +361,16 @@ Implementation tests should include:
      session in `Idle`, not `InProgress`.
    - If command detection already created an `InProgress` Droid session with no
      status-bearing rich event, registering from Droid `SessionStart` changes it
-     to `Idle` and notifies status surfaces so the running spinner clears.
+     to `Idle` and emits `SessionUpdated` or another non-status refresh event so
+     the running spinner clears.
    - If the stored session has already applied a status-bearing rich event with
      the same non-empty `session_id`, a later duplicate Droid `SessionStart`
      keeps that status for that same session.
    - If a Droid `SessionStart` has a different `session_id` from the stored
      session, the status-bearing marker resets and the session becomes `Idle`.
    - Applying that same `SessionStart` seeds context/plugin version but emits no
-     `InProgress`, `Blocked`, or `Success` status and does not project to
-     `ConversationStatus::InProgress`.
+     `StatusChanged`, emits no `InProgress`, `Blocked`, or `Success` lifecycle
+     status, and does not project to any `ConversationStatus`.
    - A later `PromptSubmit` moves the session from `Idle` to `InProgress`.
    - A later `PermissionRequest` or `QuestionAsked` moves the session from
      `Idle` or `InProgress` to `Blocked`.
@@ -367,16 +383,29 @@ Implementation tests should include:
      spinner.
    - A command-detected Droid session that was showing an in-progress spinner
      clears that spinner when the first rich event is setup-only `SessionStart`.
+   - That setup-only `SessionStart` does not call
+     `BlocklistAIHistoryModel::update_conversation_status`, does not auto-open or
+     auto-close rich input, and does not send a desktop notification.
    - A later Droid `prompt_submit` shows the in-progress spinner.
 
-4. `app/src/terminal/cli_agent_sessions/plugin_manager/mod_tests.rs`
+4. Lifecycle consumer coverage, in the most local existing test suites:
+   - `app/src/ai/agent_management/agent_management_model.rs` treats `Idle` or a
+     setup-only non-status update as no-op: no complete/request notification is
+     added and no existing notification is cleared as resumed work.
+   - `app/src/ai/agent_sdk/driver.rs` does not schedule ambient CLI harness
+     completion or cancel an idle timeout for `Idle`.
+   - `app/src/ai/blocklist/local_agent_task_sync_model.rs` does not map `Idle` to
+     `Succeeded`, `Blocked`, or `InProgress` and does not emit a local task
+     lifecycle update for setup-only `SessionStart`.
+
+5. `app/src/terminal/cli_agent_sessions/plugin_manager/mod_tests.rs`
    - `plugin_manager_for(CLIAgent::Droid)` returns `Some` when
      `FeatureFlag::HOANotifications` is enabled.
    - `plugin_manager_for(CLIAgent::Droid)` returns `None` when
      `FeatureFlag::HOANotifications` is disabled.
    - Droid is removed from the unsupported-agents assertion.
 
-5. `app/src/terminal/cli_agent_sessions/plugin_manager/droid_tests.rs`
+6. `app/src/terminal/cli_agent_sessions/plugin_manager/droid_tests.rs`
    - `can_auto_install()` is false.
    - `supports_update()` is false.
    - minimum version is stable and explicit.
@@ -404,7 +433,7 @@ Implementation tests should include:
      tool input, then assert the final bytes written to `/dev/tty` contain no raw
      terminal control bytes except the required OSC wrapper delimiters.
 
-6. Parser coverage, if not already covered elsewhere:
+7. Parser coverage, if not already covered elsewhere:
    - A structured v1 payload with `agent: "droid"` resolves to
      `CLIAgent::Droid`.
    - A malformed or unsupported Droid payload is ignored or treated as unknown
@@ -459,8 +488,16 @@ Manual validation:
 - Risk: a setup-only `SessionStart` could make Warp display Droid as running.
   Mitigation: add an explicit idle registration state, track whether a
   status-bearing rich event has actually applied to the current Droid
-  `session_id`, and test both new sessions and command-detected `InProgress`
-  sessions being reset to `Idle` by setup-only `SessionStart`.
+  `session_id`, clear command-detected `InProgress` with a non-status
+  `SessionUpdated` refresh, and test that setup-only `SessionStart` does not
+  enter `StatusChanged` lifecycle consumers.
+
+- Risk: an `Idle` status could be treated as completed, blocked, or resumed work
+  by existing `StatusChanged` consumers. Mitigation: do not emit
+  `StatusChanged(Idle)` for setup-only `SessionStart`; require no-op handling in
+  any direct `CLIAgentSessionStatus` matches that must compile after adding
+  `Idle`; and add tests for conversation status, rich input auto-toggle,
+  desktop/agent notifications, ambient harness completion, and local task sync.
 
 - Risk: adding Droid to the default listener forwards unexpected event types.
   Mitigation: the event parser already normalizes known event names, and the

--- a/specs/GH12639/tech.md
+++ b/specs/GH12639/tech.md
@@ -197,16 +197,26 @@ rich CLI-agent notification rollout gate.
 
 Manual instructions should guide the user to:
 
-1. Create a local POSIX shell hook script that reads Droid's hook JSON from
-   stdin and uses `jq` for JSON parsing, sanitization, truncation, and payload
-   construction.
-2. Exit without emitting anything when Droid is not running inside Warp, such as
-   when `WARP_CLI_AGENT_PROTOCOL_VERSION` is absent.
+1. Create a user-managed POSIX shell hook script that reads Droid's hook JSON
+   from stdin and uses `jq` for JSON parsing, sanitization, truncation, and
+   payload construction.
+2. Exit without emitting anything when Warp has not advertised the rich
+   CLI-agent protocol, such as when `WARP_CLI_AGENT_PROTOCOL_VERSION` is absent.
 3. Map supported Droid hook events to Warp CLI-agent events.
-4. Write an OSC 777 notification to the terminal in Warp's existing
-   `warp://cli-agent` format.
+4. Write an OSC 777 notification to `/dev/tty` in Warp's existing
+   `warp://cli-agent` format, rather than writing the notification to hook
+   stdout.
 5. Register the hook command in Droid's documented hooks configuration.
 6. Restart Droid or start a new Droid session so the hooks are active.
+
+`WARP_CLI_AGENT_PROTOCOL_VERSION` is a protocol capability gate, not a
+local-session proof. The v1 instructions and manual validation target local
+Droid sessions. Do not add Droid-specific SSH or tmux forwarding logic, and do
+not claim first-class remote/tmux support in this issue. If an existing
+Warp-managed remote shell already forwards the CLI-agent protocol environment,
+the hook may emit through that existing path; Warp should treat that as
+best-effort existing protocol behavior, with `remote_host` derived by the
+terminal session model, not as a new support guarantee from this spec.
 
 The implementation should align the configuration snippet with Droid's current
 documented hooks schema. As of the referenced Factory docs, user hooks live in
@@ -231,8 +241,12 @@ The emitted JSON payload should include:
 - `agent`: `"droid"`
 - `event`: the mapped Warp event name
 - `session_id`: Droid `session_id`, when present
-- `cwd`: Droid `cwd`, when present
+- `cwd`: Droid `cwd`, or `FACTORY_PROJECT_DIR` when `cwd` is absent
 - `project`: best-effort project name derived from `cwd`, when present
+- `transcript_path`: Droid `transcript_path`, when present in the hook input
+  for any mapped event. This is optional payload metadata; v1 does not require
+  storing it in `CLIAgentSessionContext`, and it must not drive status
+  transitions.
 - `plugin_version`: the Droid hook bridge version
 
 Event-specific fields should be populated conservatively:
@@ -516,5 +530,5 @@ Manual validation:
   auto-installable or has a stable on-disk location.
 - Revisit permission-vs-question classification if Droid exposes a structured
   notification type.
-- Evaluate remote, SSH, and tmux behavior separately from this local Droid hook
-  integration.
+- Evaluate first-class remote, SSH, and tmux support separately from this v1
+  Droid hook integration.

--- a/specs/GH12639/tech.md
+++ b/specs/GH12639/tech.md
@@ -21,6 +21,11 @@ Relevant current code:
   currently allows Claude, OpenCode, Codex, Gemini, Auggie, and Pi. Droid is not
   included, and `create_handler` explicitly returns `None` for
   `CLIAgent::Droid`.
+- `app/src/terminal/view.rs` - `handle_cli_agent_notification` parses
+  `warp://cli-agent` notifications, registers a listener from the first
+  structured event, then applies that event to the sessions model.
+- `app/src/terminal/cli_agent_sessions/mod.rs` - `register_listener` currently
+  creates or upgrades sessions with `CLIAgentSessionStatus::InProgress`.
 - `app/src/terminal/cli_agent_sessions/plugin_manager/mod.rs` -
   `plugin_manager_for_with_shell` currently returns `None` for
   `CLIAgent::Droid`, so the plugin-instructions UI has no Droid-specific setup
@@ -60,13 +65,21 @@ Separately, the plugin manager has no Droid manager. Even if Droid can emit the
 right protocol through hooks, Warp does not show the user Droid-specific manual
 setup instructions from the plugin UI.
 
+One additional registration detail matters for this implementation:
+`handle_cli_agent_notification` registers the listener before it calls
+`update_from_event`. `register_listener` currently initializes or upgrades the
+session as `InProgress`, while `DefaultSessionListener` and
+`CLIAgentSession::apply_event` both treat `SessionStart` as setup metadata. Droid
+must not inherit a false running state from listener registration alone.
+
 ## Proposed changes
 
 ### 1. Enable Droid in the session listener
 
 Update `app/src/terminal/cli_agent_sessions/listener/mod.rs`:
 
-- Add `CLIAgent::Droid` to `is_agent_supported`.
+- Add `CLIAgent::Droid` to `is_agent_supported` behind the existing
+  `FeatureFlag::HOANotifications` check.
 - Add `CLIAgent::Droid` to the `DefaultSessionListener` match arm in
   `create_handler`.
 - Keep `DefaultSessionListener` behavior unchanged: skip `SessionStart`, forward
@@ -76,7 +89,42 @@ Droid should use the default listener because its hook integration emits the
 same structured Warp CLI-agent events as other default-listener agents. It does
 not need Codex's OSC 9 fallback handling.
 
-### 2. Add a Droid plugin manager for manual instructions
+### 2. Keep `SessionStart` registration neutral
+
+Update `app/src/terminal/cli_agent_sessions/mod.rs` and the
+`handle_cli_agent_notification` registration path so listener registration can
+distinguish setup-only `SessionStart` from status-bearing events.
+
+The implementation should add a non-running state to the CLI-agent session
+model, named `CLIAgentSessionStatus::Idle` in this spec. `Idle` means a rich
+listener is registered and context may be known, but the agent has not emitted a
+status-bearing event for the current turn.
+
+Required behavior:
+
+- When `register_listener` is triggered by `SessionStart`, a new Droid session is
+  created with `CLIAgentSessionStatus::Idle` instead of `InProgress`.
+- When a `SessionStart` updates an existing Droid session, the update attaches
+  listener/plugin context but preserves the existing status. Only a newly
+  created setup-only session starts in `Idle`.
+- `SessionStart` continues to seed `cwd`, `project`, `session_id`, and
+  `plugin_version`.
+- `SessionStart` does not emit `StatusChanged` and does not update agent
+  conversation history to `ConversationStatus::InProgress`.
+- Vertical tabs and other status surfaces render an idle listener registration
+  without the running spinner. If they need a conversation-status projection,
+  `Idle` should project to no status (`None`) rather than to
+  `ConversationStatus::InProgress`.
+- `PromptSubmit`, `ToolComplete` after blocked, `PermissionReplied` after
+  blocked, `PermissionRequest`, `QuestionAsked`, and `Stop` remain
+  status-bearing and move the session out of `Idle`.
+
+This is intentionally a model/UI change, not just a listener change. Dropping
+`SessionStart` inside `DefaultSessionListener` is not sufficient because the
+initial registration path runs before the default listener observes future
+events.
+
+### 3. Add a Droid plugin manager for manual instructions
 
 Add `app/src/terminal/cli_agent_sessions/plugin_manager/droid.rs` and register
 it in `plugin_manager/mod.rs`.
@@ -92,6 +140,11 @@ The Droid manager should implement `CliAgentPluginManager` with:
   instruction set.
 - no override for `install()` / `update()`, so the default unsupported
   auto-install behavior remains in place.
+
+`plugin_manager_for_with_shell` should return `Some(DroidPluginManager)` only
+when `FeatureFlag::HOANotifications` is enabled. Do not add a new
+Droid-specific feature flag for this first version; Droid shares the existing
+rich CLI-agent notification rollout gate.
 
 Manual instructions should guide the user to:
 
@@ -111,7 +164,7 @@ with event names such as `UserPromptSubmit`, `Notification`, `Stop`, and
 `PostToolUse` under that object. Events that do not use matchers can omit the
 `matcher` field.
 
-### 3. Event mapping and payload shape
+### 4. Event mapping, payload shape, and output safety
 
 The hook script should emit Warp event names using this mapping:
 
@@ -145,7 +198,20 @@ For `Stop`, the hook should respect Droid's `stop_hook_active` field and avoid
 emitting recursive or misleading stop notifications when Droid is continuing as
 part of a stop-hook flow.
 
-### 4. Keep other agents unchanged
+The hook bridge must treat all Droid-provided strings and JSON fields as
+untrusted input:
+
+- Build the OSC 777 payload with a JSON encoder such as `jq`, not with
+  hand-concatenated JSON strings.
+- Bound long string fields such as `query` and `summary` before including them
+  in the payload.
+- Strip or escape terminal control bytes from every string that can reach the
+  OSC 777 output, including prompt text, notification messages, paths, project
+  names, tool names, and tool-input previews.
+- Ensure the final write to `/dev/tty` cannot emit extra BEL/ST terminators or
+  nested escape sequences sourced from Droid-controlled fields.
+
+### 5. Keep other agents unchanged
 
 Do not change:
 
@@ -160,11 +226,13 @@ Do not change:
 1. User installs/configures the Droid hook integration from Warp's manual
    instructions.
 2. User starts Droid inside Warp.
-3. Droid invokes `SessionStart`; the hook emits a structured OSC 777
+3. Droid invokes `SessionStart`; the hook emits a safely encoded structured OSC
+   777
    `session_start` payload with `agent: "droid"`.
 4. Warp parses the event, recognizes `CLIAgent::Droid`, and creates a Droid
    default session listener.
-5. `DefaultSessionListener` drops the setup-only `SessionStart` event.
+5. Warp registers the listener in `Idle` state, seeds context from
+   `SessionStart`, and does not show the running spinner.
 6. User submits a prompt. Droid invokes `UserPromptSubmit`; the hook emits
    `prompt_submit`.
 7. Warp forwards the event to `CLIAgentSessionsModel`, and the Droid session is
@@ -182,18 +250,41 @@ Do not change:
 Implementation tests should include:
 
 1. `app/src/terminal/cli_agent_sessions/listener/mod_tests.rs`
-   - `droid_is_supported`: `is_agent_supported(&CLIAgent::Droid)` is true.
+   - `droid_is_supported_when_hoa_notifications_enabled`:
+     `is_agent_supported(&CLIAgent::Droid)` is true when
+     `FeatureFlag::HOANotifications` is enabled.
+   - `droid_is_unsupported_when_hoa_notifications_disabled`:
+     `is_agent_supported(&CLIAgent::Droid)` is false when
+     `FeatureFlag::HOANotifications` is disabled.
    - Droid with `DefaultSessionListener` skips `SessionStart`.
    - Droid with `DefaultSessionListener` forwards `Stop`.
    - Droid with `DefaultSessionListener` forwards `PermissionRequest`.
    - Optionally cover `QuestionAsked` or `ToolComplete` if local test helpers
      make that clearer than relying on existing default-listener coverage.
 
-2. `app/src/terminal/cli_agent_sessions/plugin_manager/mod_tests.rs`
-   - `plugin_manager_for(CLIAgent::Droid)` returns `Some`.
+2. `app/src/terminal/cli_agent_sessions/mod_tests.rs`
+   - Registering a listener from a Droid `SessionStart` creates or upgrades a
+     session in `Idle`, not `InProgress`.
+   - Applying that same `SessionStart` seeds context/plugin version but emits no
+     `StatusChanged` and does not project to `ConversationStatus::InProgress`.
+   - A later `PromptSubmit` moves the session from `Idle` to `InProgress`.
+   - A later `PermissionRequest` or `QuestionAsked` moves the session from
+     `Idle` or `InProgress` to `Blocked`.
+
+3. `app/src/terminal/view_tests.rs`
+   - A Droid `SessionStart` with rich notifications enabled creates the listener
+     but leaves the vertical-tab status indicator without an in-progress
+     spinner.
+   - A later Droid `prompt_submit` shows the in-progress spinner.
+
+4. `app/src/terminal/cli_agent_sessions/plugin_manager/mod_tests.rs`
+   - `plugin_manager_for(CLIAgent::Droid)` returns `Some` when
+     `FeatureFlag::HOANotifications` is enabled.
+   - `plugin_manager_for(CLIAgent::Droid)` returns `None` when
+     `FeatureFlag::HOANotifications` is disabled.
    - Droid is removed from the unsupported-agents assertion.
 
-3. `app/src/terminal/cli_agent_sessions/plugin_manager/droid_tests.rs`
+5. `app/src/terminal/cli_agent_sessions/plugin_manager/droid_tests.rs`
    - `can_auto_install()` is false.
    - `supports_update()` is false.
    - minimum version is stable and explicit.
@@ -204,8 +295,10 @@ Implementation tests should include:
      shape.
    - install instructions mention required dependencies such as `jq`, if the
      hook script uses them.
+   - hook payload construction uses a JSON encoder and sanitizes terminal
+     control bytes from Droid-controlled strings before writing OSC 777.
 
-4. Parser coverage, if not already covered elsewhere:
+6. Parser coverage, if not already covered elsewhere:
    - A structured v1 payload with `agent: "droid"` resolves to
      `CLIAgent::Droid`.
    - A malformed or unsupported Droid payload is ignored or treated as unknown
@@ -216,8 +309,10 @@ Recommended commands before opening the implementation for review:
 ```bash
 cargo fmt --check
 cargo test -p warp --lib terminal::cli_agent_sessions::listener::tests
+cargo test -p warp --lib terminal::cli_agent_sessions::tests
 cargo test -p warp --lib terminal::cli_agent_sessions::plugin_manager::tests
 cargo test -p warp --lib terminal::cli_agent_sessions::plugin_manager::droid::tests
+cargo test -p warp --lib terminal::view::tests
 ```
 
 Manual validation:
@@ -248,6 +343,15 @@ Manual validation:
 - Risk: the hook script fails because `jq` is unavailable or `/dev/tty` cannot
   be written. Mitigation: document the dependency, fail non-fatally, and avoid
   breaking the Droid session when rich status cannot be emitted.
+
+- Risk: Droid-controlled text could inject malformed JSON or terminal control
+  sequences into OSC 777 output. Mitigation: build payloads with a JSON encoder,
+  bound long fields, and strip or escape terminal control bytes before writing
+  the notification.
+
+- Risk: a setup-only `SessionStart` could make Warp display Droid as running.
+  Mitigation: add an explicit idle registration state and tests proving
+  `SessionStart` does not produce an in-progress conversation status.
 
 - Risk: adding Droid to the default listener forwards unexpected event types.
   Mitigation: the event parser already normalizes known event names, and the


### PR DESCRIPTION
## Description

Adds a product and technical spec for Droid rich CLI agent status support.

The spec covers:
- enabling Droid in the existing rich CLI-agent session listener path
- adding manual Droid hook setup instructions
- mapping Droid hook events to Warp's existing OSC 777 `warp://cli-agent` protocol
- validation and regression coverage for listener/plugin-manager behavior

This is a spec-only PR. Implementation will follow in this PR after spec review.

## Linked Issue

Closes #12639 (spec-only; implementation will follow in this PR after spec review)

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Screenshots/videos are not applicable for this spec-only PR.

## Testing

- [x] `git diff --check`
- [x] Reviewed against existing spec examples in `specs/GH408/` and `specs/GH1063/`

No code changes in this PR. The spec's Testing and validation sections enumerate the unit, regression, and manual validation coverage required for the implementation.

- [ ] I have manually tested my changes locally with `./script/run` (N/A - spec-only change)

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE
