### PR TITLE
fix: sync DockTilePlugin icon to NSApp for Stage Manager

### DIFF
--- a/app/DockTilePlugin/WarpDockTilePlugin.m
+++ b/app/DockTilePlugin/WarpDockTilePlugin.m
@@ -68,6 +68,7 @@
             [self logMessage:@"User has default icon, resetting dock tile to system default"];
             [tile setContentView:nil];
             [tile display];
+            [NSApp setApplicationIconImage:nil];
             return;
         }
 
@@ -84,7 +85,10 @@
         [imageView setImageScaling:NSImageScaleProportionallyUpOrDown];
         [tile setContentView:imageView];
         [tile display];
-        
+        if (currentImage) {
+            [NSApp setApplicationIconImage:currentImage];
+        }
+
         [self logMessage:[NSString stringWithFormat:@"Dock tile updated with icon: %@", iconFileName]];
     } @catch (NSException *exception) {
         [self logMessage:[NSString stringWithFormat:@"Exception updating dock tile icon: %@\nStack trace: %@\nTile: %@", 


### PR DESCRIPTION
## Description

Stage Manager reads the app icon from `NSApplication.applicationIconImage`, not from `NSDockTile`. The docktile plugin only updated the dock tile view via `setContentView:`, so Stage Manager always showed the bundled default icon regardless of the user's custom selection.

This fix adds `setApplicationIconImage:` calls alongside the existing `setContentView:` calls so both the Dock and Stage Manager display the correct icon.

## Linked Issue

Closes #12730

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

**Before:** Dock shows the custom icon, Stage Manager shows the default icon.
**After:** Both Dock and Stage Manager show the custom icon.

<!-- TODO: Add before/after screenshots showing the Dock and Stage Manager side by side -->

CHANGELOG-BUG-FIX: Stage Manager now shows the correct custom app icon instead of always showing the default icon.
