### PR TITLE
Fix LRC auto-resume after Ctrl-C takeover

### DIFF
--- a/app/src/ai/blocklist/block/cli_controller.rs
+++ b/app/src/ai/blocklist/block/cli_controller.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use instant::Instant;
 use parking_lot::FairMutex;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use warp_core::send_telemetry_from_ctx;
 use warpui::{Entity, EntityId, ModelContext, ModelHandle, SingletonEntity};
 
@@ -25,16 +25,65 @@ use crate::terminal::model_events::{ModelEvent, ModelEventDispatcher};
 use crate::terminal::TerminalModel;
 use crate::BlocklistAIHistoryModel;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub enum UserTakeOverReason {
     Manual,
-    Stop,
+    /// The user interrupted the command and took control. `should_auto_resume` is `true` for a
+    /// live interrupt (e.g. Ctrl-C) that keeps the conversation alive so it resumes once the
+    /// command completes, and `false` for teardown flows (stop/rewind) that have cancelled it.
+    Stop {
+        should_auto_resume: bool,
+    },
     /// The agent explicitly transferred control to the user via the
     /// TransferShellCommandControlToUser tool call.
     TransferFromAgent {
         /// The reason the agent gave for transferring control.
         reason: String,
     },
+}
+
+impl<'de> Deserialize<'de> for UserTakeOverReason {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // `Current` mirrors the derived shape so serde can parse it without recursing back into
+        // this impl. `LegacyStop` accepts the bare `"Stop"` persisted before `should_auto_resume`
+        // existed: an externally tagged enum can't accept `Stop` as both a unit (legacy) and a
+        // struct (current) variant, and `#[serde(default)]` can't bridge the two, so the forms are
+        // unioned as `untagged`.
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Wire {
+            Current(Current),
+            LegacyStop(LegacyStop),
+        }
+
+        #[derive(Deserialize)]
+        enum Current {
+            Manual,
+            Stop { should_auto_resume: bool },
+            TransferFromAgent { reason: String },
+        }
+
+        #[derive(Deserialize)]
+        enum LegacyStop {
+            Stop,
+        }
+
+        Ok(match Wire::deserialize(deserializer)? {
+            Wire::Current(Current::Manual) => Self::Manual,
+            Wire::Current(Current::Stop { should_auto_resume }) => {
+                Self::Stop { should_auto_resume }
+            }
+            Wire::Current(Current::TransferFromAgent { reason }) => {
+                Self::TransferFromAgent { reason }
+            }
+            Wire::LegacyStop(LegacyStop::Stop) => Self::Stop {
+                should_auto_resume: false,
+            },
+        })
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -45,11 +94,20 @@ struct ActiveCLISubagentState {
 
 impl UserTakeOverReason {
     pub fn is_stop(&self) -> bool {
-        matches!(self, Self::Stop)
+        matches!(self, Self::Stop { .. })
     }
 
     pub fn is_transfer_from_agent(&self) -> bool {
         matches!(self, Self::TransferFromAgent { .. })
+    }
+
+    /// Returns `true` if the conversation should resume once the user-controlled command
+    /// completes. Only a teardown `Stop` opts out.
+    pub fn should_auto_resume(&self) -> bool {
+        match self {
+            Self::Manual | Self::TransferFromAgent { .. } => true,
+            Self::Stop { should_auto_resume } => *should_auto_resume,
+        }
     }
 
     pub fn transfer_reason(&self) -> Option<&str> {
@@ -93,6 +151,14 @@ impl LongRunningCommandControlState {
 
     pub fn is_user_in_control(&self) -> bool {
         matches!(self, Self::User { .. })
+    }
+
+    /// Returns `true` if a completing user-controlled command should auto-resume the conversation.
+    pub fn should_auto_resume(&self) -> bool {
+        match self {
+            Self::Agent { .. } => false,
+            Self::User { reason } => reason.should_auto_resume(),
+        }
     }
 
     pub fn should_hide_responses(&self) -> bool {
@@ -635,3 +701,7 @@ fn snapshot_block_id_for_action_result(result: &AIAgentActionResultType) -> Opti
         _ => None,
     }
 }
+
+#[cfg(test)]
+#[path = "cli_controller_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/block/cli_controller_tests.rs
+++ b/app/src/ai/blocklist/block/cli_controller_tests.rs
@@ -1,0 +1,38 @@
+use super::{LongRunningCommandControlState, UserTakeOverReason};
+
+// Blocks persisted before `should_auto_resume` stored `Stop` as a bare unit variant. These must
+// still deserialize (with resume disabled) so restoring an older session doesn't drop the block's
+// AI metadata wholesale.
+#[test]
+fn legacy_stop_reason_deserializes_with_resume_disabled() {
+    let reason: UserTakeOverReason = serde_json::from_str("\"Stop\"").unwrap();
+    assert_eq!(
+        reason,
+        UserTakeOverReason::Stop {
+            should_auto_resume: false
+        }
+    );
+
+    let state: LongRunningCommandControlState =
+        serde_json::from_str(r#"{"User":{"reason":"Stop"}}"#).unwrap();
+    assert_eq!(
+        state,
+        LongRunningCommandControlState::User {
+            reason: UserTakeOverReason::Stop {
+                should_auto_resume: false
+            }
+        }
+    );
+}
+
+#[test]
+fn stop_reason_round_trips() {
+    for should_auto_resume in [true, false] {
+        let reason = UserTakeOverReason::Stop { should_auto_resume };
+        let json = serde_json::to_string(&reason).unwrap();
+        assert_eq!(
+            serde_json::from_str::<UserTakeOverReason>(&json).unwrap(),
+            reason
+        );
+    }
+}

--- a/app/src/ai/blocklist/inline_action/requested_command.rs
+++ b/app/src/ai/blocklist/inline_action/requested_command.rs
@@ -1318,7 +1318,7 @@ pub(crate) fn header_message_for_user_take_over_reason(
 ) -> &'static str {
     match reason {
         UserTakeOverReason::Manual => USER_TOOK_CONTROL_COMMAND_MESSAGE,
-        UserTakeOverReason::Stop => USER_STOPPED_CLI_SUBAGENT_COMMAND_MESSAGE,
+        UserTakeOverReason::Stop { .. } => USER_STOPPED_CLI_SUBAGENT_COMMAND_MESSAGE,
         UserTakeOverReason::TransferFromAgent { .. } => {
             AGENT_REQUESTED_USER_TAKE_CONTROL_COMMAND_MESSAGE
         }

--- a/app/src/terminal/model/block/interaction_mode.rs
+++ b/app/src/terminal/model/block/interaction_mode.rs
@@ -156,15 +156,16 @@ impl Block {
         }
     }
 
-    /// Hands control to the user with the `Stop` reason and suppresses auto-resume of the
-    /// conversation once the command completes. Used by teardown paths (rewind, stop) where
-    /// the conversation has been cancelled and should not resume on its own.
-    pub fn set_user_control_and_suppress_auto_resume(&mut self) {
+    /// Hands control to the user with a non-resuming `Stop`. Used by teardown paths (rewind,
+    /// stop) where the conversation has been cancelled and must not resume when the command
+    /// completes.
+    pub fn set_user_control_for_teardown(&mut self) {
         if let InteractionMode::Agent(metadata) = &mut self.interaction_mode {
-            metadata.suppress_auto_resume = true;
             if let Some(state) = &mut metadata.long_running_control_state {
                 *state = LongRunningCommandControlState::User {
-                    reason: UserTakeOverReason::Stop,
+                    reason: UserTakeOverReason::Stop {
+                        should_auto_resume: false,
+                    },
                 };
             }
         }
@@ -231,7 +232,6 @@ impl Block {
             long_running_control_state: None,
             has_agent_written_to_block: false,
             should_hide_block: true,
-            suppress_auto_resume: false,
         })
     }
 
@@ -363,7 +363,6 @@ impl InteractionMode {
             }),
             has_agent_written_to_block: false,
             should_hide_block: false,
-            suppress_auto_resume: false,
         }))
     }
 
@@ -488,10 +487,6 @@ pub struct AgentInteractionMetadata {
     /// `true` if this block should be hidden from the user (as is the case with AI-requested
     /// commands, for example).
     should_hide_block: bool,
-
-    /// `true` if the conversation must not auto-resume when this command completes, even though
-    /// the user is in control. Set by teardown paths (rewind, stop) that cancel the conversation.
-    suppress_auto_resume: bool,
 }
 
 impl AgentInteractionMetadata {
@@ -511,7 +506,6 @@ impl AgentInteractionMetadata {
             long_running_control_state,
             has_agent_written_to_block,
             should_hide_block,
-            suppress_auto_resume: false,
         }
     }
 
@@ -558,14 +552,6 @@ impl AgentInteractionMetadata {
 
     pub fn should_hide_block(&self) -> bool {
         self.should_hide_block
-    }
-
-    pub fn should_suppress_auto_resume(&self) -> bool {
-        self.suppress_auto_resume
-    }
-
-    pub fn set_suppress_auto_resume(&mut self) {
-        self.suppress_auto_resume = true;
     }
 }
 

--- a/app/src/terminal/model/block/interaction_mode.rs
+++ b/app/src/terminal/model/block/interaction_mode.rs
@@ -156,16 +156,17 @@ impl Block {
         }
     }
 
-    /// Sets control to user with Stop reason if a long-running control state exists.
-    pub fn set_user_control_with_stop_reason(&mut self) {
-        if let InteractionMode::Agent(AgentInteractionMetadata {
-            long_running_control_state: Some(ref mut state),
-            ..
-        }) = self.interaction_mode
-        {
-            *state = LongRunningCommandControlState::User {
-                reason: UserTakeOverReason::Stop,
-            };
+    /// Hands control to the user with the `Stop` reason and suppresses auto-resume of the
+    /// conversation once the command completes. Used by teardown paths (rewind, stop) where
+    /// the conversation has been cancelled and should not resume on its own.
+    pub fn set_user_control_and_suppress_auto_resume(&mut self) {
+        if let InteractionMode::Agent(metadata) = &mut self.interaction_mode {
+            metadata.suppress_auto_resume = true;
+            if let Some(state) = &mut metadata.long_running_control_state {
+                *state = LongRunningCommandControlState::User {
+                    reason: UserTakeOverReason::Stop,
+                };
+            }
         }
     }
 
@@ -230,6 +231,7 @@ impl Block {
             long_running_control_state: None,
             has_agent_written_to_block: false,
             should_hide_block: true,
+            suppress_auto_resume: false,
         })
     }
 
@@ -361,6 +363,7 @@ impl InteractionMode {
             }),
             has_agent_written_to_block: false,
             should_hide_block: false,
+            suppress_auto_resume: false,
         }))
     }
 
@@ -485,6 +488,10 @@ pub struct AgentInteractionMetadata {
     /// `true` if this block should be hidden from the user (as is the case with AI-requested
     /// commands, for example).
     should_hide_block: bool,
+
+    /// `true` if the conversation must not auto-resume when this command completes, even though
+    /// the user is in control. Set by teardown paths (rewind, stop) that cancel the conversation.
+    suppress_auto_resume: bool,
 }
 
 impl AgentInteractionMetadata {
@@ -504,6 +511,7 @@ impl AgentInteractionMetadata {
             long_running_control_state,
             has_agent_written_to_block,
             should_hide_block,
+            suppress_auto_resume: false,
         }
     }
 
@@ -550,6 +558,14 @@ impl AgentInteractionMetadata {
 
     pub fn should_hide_block(&self) -> bool {
         self.should_hide_block
+    }
+
+    pub fn should_suppress_auto_resume(&self) -> bool {
+        self.suppress_auto_resume
+    }
+
+    pub fn set_suppress_auto_resume(&mut self) {
+        self.suppress_auto_resume = true;
     }
 }
 

--- a/app/src/terminal/model/block/serialized_block.rs
+++ b/app/src/terminal/model/block/serialized_block.rs
@@ -113,9 +113,6 @@ pub struct SerializedAIMetadata {
     /// commands, for example).
     #[serde(default = "default_as_true", skip)]
     should_hide_block: bool,
-
-    #[serde(default)]
-    suppress_auto_resume: bool,
 }
 
 impl From<AgentInteractionMetadata> for SerializedAIMetadata {
@@ -127,25 +124,20 @@ impl From<AgentInteractionMetadata> for SerializedAIMetadata {
             long_running_control_state: value.long_running_control_state().cloned(),
             has_agent_written_to_block: value.has_agent_written_to_block(),
             should_hide_block: value.should_hide_block(),
-            suppress_auto_resume: value.should_suppress_auto_resume(),
         }
     }
 }
 
 impl From<SerializedAIMetadata> for AgentInteractionMetadata {
     fn from(value: SerializedAIMetadata) -> Self {
-        let mut metadata = AgentInteractionMetadata::new(
+        AgentInteractionMetadata::new(
             value.requested_command_action_id,
             value.conversation_id,
             value.subagent_task_id,
             value.long_running_control_state,
             value.has_agent_written_to_block,
             value.should_hide_block,
-        );
-        if value.suppress_auto_resume {
-            metadata.set_suppress_auto_resume();
-        }
-        metadata
+        )
     }
 }
 

--- a/app/src/terminal/model/block/serialized_block.rs
+++ b/app/src/terminal/model/block/serialized_block.rs
@@ -113,6 +113,9 @@ pub struct SerializedAIMetadata {
     /// commands, for example).
     #[serde(default = "default_as_true", skip)]
     should_hide_block: bool,
+
+    #[serde(default)]
+    suppress_auto_resume: bool,
 }
 
 impl From<AgentInteractionMetadata> for SerializedAIMetadata {
@@ -124,20 +127,25 @@ impl From<AgentInteractionMetadata> for SerializedAIMetadata {
             long_running_control_state: value.long_running_control_state().cloned(),
             has_agent_written_to_block: value.has_agent_written_to_block(),
             should_hide_block: value.should_hide_block(),
+            suppress_auto_resume: value.should_suppress_auto_resume(),
         }
     }
 }
 
 impl From<SerializedAIMetadata> for AgentInteractionMetadata {
     fn from(value: SerializedAIMetadata) -> Self {
-        AgentInteractionMetadata::new(
+        let mut metadata = AgentInteractionMetadata::new(
             value.requested_command_action_id,
             value.conversation_id,
             value.subagent_task_id,
             value.long_running_control_state,
             value.has_agent_written_to_block,
             value.should_hide_block,
-        )
+        );
+        if value.suppress_auto_resume {
+            metadata.set_suppress_auto_resume();
+        }
+        metadata
     }
 }
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -8444,7 +8444,7 @@ impl TerminalView {
                 || active_block.is_active_and_long_running();
 
             if active_block_matches && command_is_running {
-                active_block.set_user_control_and_suppress_auto_resume();
+                active_block.set_user_control_for_teardown();
                 true
             } else {
                 false
@@ -8648,7 +8648,12 @@ impl TerminalView {
     ) {
         if active_block_state.is_agent_in_control_of_command {
             self.cli_subagent_controller.update(ctx, |controller, ctx| {
-                controller.switch_control_to_user(UserTakeOverReason::Stop, ctx);
+                controller.switch_control_to_user(
+                    UserTakeOverReason::Stop {
+                        should_auto_resume: true,
+                    },
+                    ctx,
+                );
             });
         } else if active_block_state.is_long_running {
             // A second Ctrl+C after Stop takeover should cancel both the command and conversation.
@@ -10868,10 +10873,9 @@ impl TerminalView {
             match ai_metadata {
                 Some(ai_metadata)
                     if ai_metadata.requested_command_action_id().is_some()
-                        && !ai_metadata.should_suppress_auto_resume()
                         && ai_metadata
                             .long_running_control_state()
-                            .is_some_and(|state| state.user_take_over_reason().is_some()) =>
+                            .is_some_and(|state| state.should_auto_resume()) =>
                 {
                     Some(*ai_metadata.conversation_id())
                 }
@@ -24595,7 +24599,7 @@ impl TerminalView {
                 && active_block.ai_conversation_id() == Some(conversation_id);
 
             if is_from_this_conversation {
-                active_block.set_user_control_and_suppress_auto_resume();
+                active_block.set_user_control_for_teardown();
             }
 
             is_from_this_conversation

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -8444,7 +8444,7 @@ impl TerminalView {
                 || active_block.is_active_and_long_running();
 
             if active_block_matches && command_is_running {
-                active_block.set_user_control_with_stop_reason();
+                active_block.set_user_control_and_suppress_auto_resume();
                 true
             } else {
                 false
@@ -10868,13 +10868,10 @@ impl TerminalView {
             match ai_metadata {
                 Some(ai_metadata)
                     if ai_metadata.requested_command_action_id().is_some()
+                        && !ai_metadata.should_suppress_auto_resume()
                         && ai_metadata
                             .long_running_control_state()
-                            .is_some_and(|state| {
-                                state
-                                    .user_take_over_reason()
-                                    .is_some_and(|reason| !reason.is_stop())
-                            }) =>
+                            .is_some_and(|state| state.user_take_over_reason().is_some()) =>
                 {
                     Some(*ai_metadata.conversation_id())
                 }
@@ -24589,7 +24586,7 @@ impl TerminalView {
         });
 
         // If the active block is a running command from this conversation, stop it and
-        // set the take-over reason to Stop to prevent automatic conversation resume.
+        // suppress automatic conversation resume when the command completes.
         let should_stop_running_command = {
             let mut model = self.model.lock();
             let active_block = model.block_list_mut().active_block_mut();
@@ -24598,7 +24595,7 @@ impl TerminalView {
                 && active_block.ai_conversation_id() == Some(conversation_id);
 
             if is_from_this_conversation {
-                active_block.set_user_control_with_stop_reason();
+                active_block.set_user_control_and_suppress_auto_resume();
             }
 
             is_from_this_conversation

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -5247,7 +5247,12 @@ fn ctrl_c_after_stop_takeover_cancels_conversation() {
                 .expect("command should become agent monitored");
 
             view.cli_subagent_controller.update(ctx, |controller, ctx| {
-                controller.switch_control_to_user(UserTakeOverReason::Stop, ctx);
+                controller.switch_control_to_user(
+                    UserTakeOverReason::Stop {
+                        should_auto_resume: true,
+                    },
+                    ctx,
+                );
             });
 
             conversation_id
@@ -5362,7 +5367,9 @@ fn completed_user_controlled_lrc_resumes_when_not_suppressed() {
                     )
                     .expect("command should become agent monitored");
                 active_block
-                    .take_over_control_for_user(UserTakeOverReason::Stop)
+                    .take_over_control_for_user(UserTakeOverReason::Stop {
+                        should_auto_resume: true,
+                    })
                     .expect("user takeover should succeed");
                 active_block.id().clone()
             };
@@ -5416,7 +5423,7 @@ fn completed_user_controlled_lrc_skips_resume_when_suppressed() {
                     )
                     .expect("command should become agent monitored");
                 // Mirrors rewind / stop_local_agent_conversation tearing down the conversation.
-                active_block.set_user_control_and_suppress_auto_resume();
+                active_block.set_user_control_for_teardown();
                 active_block.id().clone()
             };
 

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -19,7 +19,8 @@ use super::*;
 use crate::ai::agent::conversation::{AIConversation, ConversationStatus};
 use crate::ai::agent::task::TaskId;
 use crate::ai::agent::{
-    AIAgentExchange, AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus, UserQueryMode,
+    AIAgentActionId, AIAgentExchange, AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus,
+    UserQueryMode,
 };
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::agent_view::toolbar_item::AgentToolbarItemKind;
@@ -5325,6 +5326,106 @@ fn ctrl_c_after_transfer_takeover_does_not_cancel_conversation() {
             // completion to the agent, so Ctrl-C should interrupt the command without
             // cancelling the conversation.
             assert_eq!(conversation.status(), &ConversationStatus::InProgress);
+        });
+    })
+}
+
+#[test]
+fn completed_user_controlled_lrc_resumes_when_not_suppressed() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        FeatureFlag::AgentView.set_enabled(true);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            let conversation_id =
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                    history.start_new_conversation(view.view_id, false, false, false, ctx)
+                });
+
+            view.model
+                .lock()
+                .simulate_long_running_block("sleep 20", "running");
+            let task_id = TaskId::new("test-cli-subagent".to_owned());
+            let block_id = {
+                let mut model = view.model.lock();
+                let active_block = model.block_list_mut().active_block_mut();
+                active_block.set_agent_interaction_mode_for_requested_command(
+                    AIAgentActionId::from("requested-command".to_owned()),
+                    Some(task_id.clone()),
+                    conversation_id,
+                );
+                active_block
+                    .set_agent_interaction_mode_for_agent_monitored_command(
+                        &task_id,
+                        conversation_id,
+                    )
+                    .expect("command should become agent monitored");
+                active_block
+                    .take_over_control_for_user(UserTakeOverReason::Stop)
+                    .expect("user takeover should succeed");
+                active_block.id().clone()
+            };
+
+            assert!(!view
+                .ai_controller
+                .as_ref(ctx)
+                .has_active_stream_for_conversation(conversation_id, ctx));
+
+            view.on_user_block_completed(&block_id, ctx);
+
+            // A Ctrl-C takeover (Stop) without an explicit teardown should resume the
+            // conversation once the command completes, just like a manual takeover.
+            assert!(view
+                .ai_controller
+                .as_ref(ctx)
+                .has_active_stream_for_conversation(conversation_id, ctx));
+        });
+    })
+}
+
+#[test]
+fn completed_user_controlled_lrc_skips_resume_when_suppressed() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        FeatureFlag::AgentView.set_enabled(true);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            let conversation_id =
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                    history.start_new_conversation(view.view_id, false, false, false, ctx)
+                });
+
+            view.model
+                .lock()
+                .simulate_long_running_block("sleep 20", "running");
+            let task_id = TaskId::new("test-cli-subagent".to_owned());
+            let block_id = {
+                let mut model = view.model.lock();
+                let active_block = model.block_list_mut().active_block_mut();
+                active_block.set_agent_interaction_mode_for_requested_command(
+                    AIAgentActionId::from("requested-command".to_owned()),
+                    Some(task_id.clone()),
+                    conversation_id,
+                );
+                active_block
+                    .set_agent_interaction_mode_for_agent_monitored_command(
+                        &task_id,
+                        conversation_id,
+                    )
+                    .expect("command should become agent monitored");
+                // Mirrors rewind / stop_local_agent_conversation tearing down the conversation.
+                active_block.set_user_control_and_suppress_auto_resume();
+                active_block.id().clone()
+            };
+
+            view.on_user_block_completed(&block_id, ctx);
+
+            assert!(!view
+                .ai_controller
+                .as_ref(ctx)
+                .has_active_stream_for_conversation(conversation_id, ctx));
         });
     })
 }


### PR DESCRIPTION
## Description

This fixes a long-running-command Agent Mode regression where a conversation could remain stuck showing `Warping...` after a Ctrl-C takeover.

Repro flow:
1. Ask the agent to start a long-running command, e.g. `sleep 5`.
2. Press Ctrl-C while the CLI subagent is monitoring the command. This switches control back to the user.
3. Let the command complete normally.

Before this PR, the first Ctrl-C takeover used `UserTakeOverReason::Stop`, and `switch_control_to_user` intentionally cancelled only the CLI subagent monitoring stream with `CancellationReason::CLISubagentUserTakeover`. That cancellation preserves the primary conversation's `InProgress` state because the primary agent is expected to resume once the command completes.

The bug was that `on_user_block_completed` decided whether to resume by checking that the takeover reason was **not** `Stop`. That meant the Ctrl-C takeover path left the primary conversation `InProgress`, but skipped the completion-time resume, resulting in an infinite `Warping...` state. The `cmd+i` manual takeover path did not hit the bug because it uses `UserTakeOverReason::Manual`, which passed the old `!reason.is_stop()` gate.

This PR decouples auto-resume suppression from the takeover reason:

- Adds an explicit `suppress_auto_resume` bit to `AgentInteractionMetadata`, including serialized block metadata.
- Sets that bit only in the genuine teardown paths (`stop_local_agent_conversation` and `rewind_ai_conversation`) through `set_user_control_and_suppress_auto_resume`.
- Updates `on_user_block_completed` to resume user-controlled requested-command LRCs unless `suppress_auto_resume` is set.

### Takeover reason semantics preserved

This intentionally keeps `UserTakeOverReason::Stop` rather than collapsing it into `Manual`:

- `Manual` still represents an explicit manual/user-control takeover (e.g. `cmd+i`). It does not suppress auto-resume, so the primary conversation resumes when the command completes.
- `Stop` still represents Ctrl-C takeover of an agent-controlled long-running command. It remains the sentinel used by the #12623 flow: after the first Ctrl-C takes control, a second Ctrl-C cancels the whole conversation and interrupts the command.
- `Stop` no longer inherently means "do not resume when the command completes." A plain Ctrl-C takeover now has `Stop` with `suppress_auto_resume = false`, so it resumes on natural command completion.
- Teardown flows still suppress resume explicitly. When the user stops or rewinds the conversation, the block is marked with `Stop` and `suppress_auto_resume = true`, so a later command completion cannot resurrect a cancelled or rewound conversation. @MaggieShan lemme know if this is confusing, happy to chat sync. The issue here was that previously, `UserTakeOverReason::Stop` conflated two intents: suppressing auto-resume after command completion (which should only apply in the case that a conversation is rewinded/explicitly killed to avoid a stray "Resume conversation"), and cancelling the active subagent conversation (the normal Ctrl-C case).
- `TransferFromAgent` behavior is unchanged: if the agent explicitly transfers control to the user, Ctrl-C interrupts the command without cancelling the conversation.

## Testing

Tested manually; demo/explainer [here](https://www.loom.com/share/085080576cd4457996058674788f6e64).

- [x] `cargo nextest run -p warp -E 'test(completed_user_controlled_lrc) | test(ctrl_c_after_stop_takeover_cancels_conversation) | test(ctrl_c_after_transfer_takeover_does_not_cancel_conversation)'`
  - `completed_user_controlled_lrc_resumes_when_not_suppressed`
  - `completed_user_controlled_lrc_skips_resume_when_suppressed`
  - `ctrl_c_after_stop_takeover_cancels_conversation`
  - `ctrl_c_after_transfer_takeover_does_not_cancel_conversation`
- [x] `./script/format`
- [x] `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Agent Context

- Conversation: https://staging.warp.dev/conversation/1a1573ce-4822-4c1b-8992-c99840689000
- Plan: https://staging.warp.dev/drive/notebook/hzKaQ4fSha6yU1LXyDrQFN

CHANGELOG-BUG-FIX: Fixed a case where taking over an agent-monitored long-running command with Ctrl-C could leave the conversation stuck showing `Warping...` after the command completed.

Co-Authored-By: Oz <oz-agent@warp.dev>
