### PR TITLE
Fix missing LC_RPATH in macOS standalone CLI binary causing dyld failure on remote hosts

### DIFF
--- a/app/build.rs
+++ b/app/build.rs
@@ -275,6 +275,14 @@ fn build_and_link_sentry() {
             "cargo:rustc-link-search=all={}",
             swift_library_path.display()
         );
+        // Embed /usr/lib/swift as LC_RPATH so the deployed standalone CLI binary can
+        // find Swift runtime dylibs on the remote host. On macOS 12.3+, Apple ships
+        // the Swift runtime as an OS-level framework at /usr/lib/swift. Without this,
+        // remote macOS hosts fail with:
+        //   dyld: Library not loaded: @rpath/libswiftCore.dylib
+        //   Reason: no LC_RPATH's found
+        // See: https://github.com/warpdotdev/warp/issues/12631
+        println!("cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
     }
 
     compile_sentry_objc_lib(&sentry_framework_path);


### PR DESCRIPTION
## Description

Fixes a bug where the macOS CLI artifact (used as the SSH remote server binary) fails to launch on remote macOS hosts with:

```
dyld: Library not loaded: @rpath/libswiftCore.dylib
  Referenced from: ~/.warp/remote-server/oz-v...
  Reason: no LC_RPATH's found
```

### Root cause

When building the standalone CLI (`--artifact cli`), `build.rs` links against the **static** Sentry xcframework (`Sentry.xcframework`) rather than the dynamic one used for the app bundle. Static Sentry retains dynamic Swift runtime dependencies (`@rpath/libswiftCore.dylib`, etc.).

`build.rs` adds the Xcode toolchain Swift path as a **link-time search path** (so the linker can resolve symbols at build time), but never emits a **runtime rpath**:

```rust
// existing code — link-time only, no LC_RPATH written to binary
let swift_library_path = get_xcode_toolchain().join("usr/lib/swift/macosx");
println!("cargo:rustc-link-search=all={}", swift_library_path.display());
```

For the **app bundle**, the bundle script patches the rpath post-build:
```bash
install_name_tool -add_rpath "@executable_path/../Frameworks" "$BUNDLE_DIR/.../MacOS/$WARP_BIN"
```
The app bundle's `Frameworks/` directory contains the bundled Swift dylibs, so the binary works.

For the **CLI artifact**, no rpath is ever added — so when `dyld` runs the binary on a remote macOS host, it finds `@rpath/libswiftCore.dylib` references but zero `LC_RPATH` entries to search.

### Fix

Add `cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift` in the same `standalone` branch of `build_and_link_sentry()`. On macOS 12.3+, Apple ships the Swift runtime as a system-level framework at `/usr/lib/swift`, so this embeds a valid `LC_RPATH` entry directly at link time — no post-build patching needed.

### Alternatives considered

**Option B — bundle script (`install_name_tool`):** Add `install_name_tool -add_rpath /usr/lib/swift` in `script/macos/bundle` after the binary is copied and before codesigning. Works identically, but is a post-build step that must be kept in the right place relative to codesigning. The `build.rs` approach is cleaner since the rpath is set at the same layer that introduces the Swift dependency.

**Option C (existing branch `oz/swift-dylib-packaging-local`):** Bundle the actual Swift dylibs into the CLI tarball alongside the binary (using `xcrun swift-stdlib-tool`) and add `@executable_path/lib` as a second rpath fallback. This also covers macOS < 12.3 (pre-March 2022), but increases tarball size and requires CI workflow changes. Given macOS 15 is current and < 12.3 is ~4 years old, this is deferred.

**Option D — remove Sentry from standalone builds:** The remote server is a headless daemon; crash reporting via Sentry may not be useful there. Dropping `cocoa_sentry` from standalone CLI builds would eliminate the Swift dependency entirely. Worth a separate PR.

## Linked Issue

Fixes #12631

- [x] The linked issue is labeled `ready-to-implement`.

## Testing

Built the x86_64 CLI binary with the standalone + cocoa_sentry features and confirmed `LC_RPATH: /usr/lib/swift` is now present:

```bash
cargo build -p warp --bin stable \
  --features "release_bundle,cocoa_sentry,extern_plist,standalone" \
  --target x86_64-apple-darwin

otool -l target/x86_64-apple-darwin/debug/stable | grep -A3 LC_RPATH
```

Output:
```
          cmd LC_RPATH
      cmdsize 32
         path /usr/lib/swift (offset 12)
```

Before the fix, the `grep` returns nothing. After the fix, `LC_RPATH: /usr/lib/swift` is embedded. This matches exactly what is needed for `dyld` to resolve `libswiftCore.dylib` on the reporter's macOS 15.7.7 (Sequoia) x86_64 remote host.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed SSH remote server install failing on Intel macOS remote hosts with a dyld Swift runtime error.
-->

Co-Authored-By: Oz <oz-agent@warp.dev>
