### PR TITLE
Fix early Ctrl-C cancellation for requested commands

### DIFF
--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -1054,6 +1054,59 @@ impl BlocklistAIActionModel {
         }
     }
 
+    pub(crate) fn cancel_requested_command_with_id(
+        &mut self,
+        conversation_id: AIConversationId,
+        action_id: &AIAgentActionId,
+        reason: CancellationReason,
+        ctx: &mut ModelContext<Self>,
+    ) -> bool {
+        if self
+            .running_actions
+            .get(&conversation_id)
+            .is_some_and(|running| running.contains(action_id))
+            || self
+                .pending_actions
+                .get(&conversation_id)
+                .is_some_and(|actions| actions.iter().any(|action| action.id == *action_id))
+        {
+            self.cancel_action_with_id(conversation_id, action_id, reason, ctx);
+            return true;
+        }
+
+        let Some(action_result) = self
+            .finished_action_results
+            .get_mut(&conversation_id)
+            .and_then(|results| {
+                results.iter_mut().find(|result| {
+                    result.id == *action_id
+                        && matches!(
+                            result.result,
+                            AIAgentActionResultType::RequestCommandOutput(
+                                RequestCommandOutputResult::LongRunningCommandSnapshot { .. }
+                            )
+                        )
+                })
+            })
+        else {
+            return false;
+        };
+
+        *action_result = Arc::new(AIAgentActionResult {
+            id: action_result.id.clone(),
+            task_id: action_result.task_id.clone(),
+            result: AIAgentActionResultType::RequestCommandOutput(
+                RequestCommandOutputResult::CancelledBeforeExecution,
+            ),
+        });
+        self.sort_finished_results(conversation_id);
+        ctx.emit(BlocklistAIActionEvent::FinishedAction {
+            action_id: action_id.clone(),
+            conversation_id,
+            cancellation_reason: Some(reason),
+        });
+        true
+    }
     /// Cancels any in-flight WaitForEvents action for the given conversation.
     pub fn cancel_wait_for_events_for_conversation(
         &mut self,

--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -1054,6 +1054,7 @@ impl BlocklistAIActionModel {
         }
     }
 
+    /// Cancels a pending/running requested-command action, or marks its buffered snapshot as cancelled.
     pub(crate) fn cancel_requested_command_with_id(
         &mut self,
         conversation_id: AIConversationId,
@@ -1073,7 +1074,9 @@ impl BlocklistAIActionModel {
             self.cancel_action_with_id(conversation_id, action_id, reason, ctx);
             return true;
         }
-
+        // If the command was already classified as long-running, its snapshot can be buffered
+        // before the agent consumes it. Rewrite that result as cancelled so the agent does not
+        // attach to a command the user already interrupted.
         let Some(action_result) = self
             .finished_action_results
             .get_mut(&conversation_id)

--- a/app/src/ai/blocklist/action_model/execute/shell_command.rs
+++ b/app/src/ai/blocklist/action_model/execute/shell_command.rs
@@ -617,22 +617,23 @@ impl ShellCommandExecutor {
     }
 
     pub(super) fn cancel_execution(&mut self, id: &AIAgentActionId, _ctx: &mut ModelContext<Self>) {
-        let terminal_model = self.terminal_model.lock();
-        let active_block = terminal_model.block_list().active_block();
-        if !active_block.is_active_and_long_running() {
-            return;
-        }
+        let requested_command_selector = BlockSelector::RequestedCommandId(id.clone());
+        self.block_finished_senders
+            .remove(&requested_command_selector);
+        self.force_refresh_senders
+            .remove(&requested_command_selector);
 
-        let selector = if active_block
-            .requested_command_action_id()
-            .is_some_and(|requested_command_id| requested_command_id == id)
-        {
-            BlockSelector::RequestedCommandId(id.clone())
-        } else {
-            BlockSelector::Id(active_block.id().clone())
+        let active_block_selector = {
+            let terminal_model = self.terminal_model.lock();
+            let active_block = terminal_model.block_list().active_block();
+            active_block
+                .is_active_and_long_running()
+                .then(|| BlockSelector::Id(active_block.id().clone()))
         };
-        self.block_finished_senders.remove(&selector);
-        self.force_refresh_senders.remove(&selector);
+        if let Some(selector) = active_block_selector {
+            self.block_finished_senders.remove(&selector);
+            self.force_refresh_senders.remove(&selector);
+        }
     }
 
     /// Force any in-flight poll for the given long-running command block to resolve

--- a/app/src/terminal/model/block/interaction_mode.rs
+++ b/app/src/terminal/model/block/interaction_mode.rs
@@ -123,6 +123,7 @@ impl Block {
             .is_some_and(|metadata| {
                 metadata.requested_command_action_id().is_some()
                     && metadata.long_running_control_state().is_none()
+                    && !metadata.should_suppress_auto_resume()
             })
     }
 
@@ -155,13 +156,18 @@ impl Block {
             *is_blocked = new_value;
         }
     }
+    pub fn suppress_agent_auto_resume(&mut self) {
+        if let InteractionMode::Agent(metadata) = &mut self.interaction_mode {
+            metadata.set_suppress_auto_resume();
+        }
+    }
 
     /// Hands control to the user with the `Stop` reason and suppresses auto-resume of the
     /// conversation once the command completes. Used by teardown paths (rewind, stop) where
     /// the conversation has been cancelled and should not resume on its own.
     pub fn set_user_control_and_suppress_auto_resume(&mut self) {
+        self.suppress_agent_auto_resume();
         if let InteractionMode::Agent(metadata) = &mut self.interaction_mode {
-            metadata.suppress_auto_resume = true;
             if let Some(state) = &mut metadata.long_running_control_state {
                 *state = LongRunningCommandControlState::User {
                     reason: UserTakeOverReason::Stop,

--- a/app/src/terminal/model/block/interaction_mode.rs
+++ b/app/src/terminal/model/block/interaction_mode.rs
@@ -156,18 +156,13 @@ impl Block {
             *is_blocked = new_value;
         }
     }
-    pub fn suppress_agent_auto_resume(&mut self) {
-        if let InteractionMode::Agent(metadata) = &mut self.interaction_mode {
-            metadata.set_suppress_auto_resume();
-        }
-    }
 
     /// Hands control to the user with the `Stop` reason and suppresses auto-resume of the
     /// conversation once the command completes. Used by teardown paths (rewind, stop) where
     /// the conversation has been cancelled and should not resume on its own.
     pub fn set_user_control_and_suppress_auto_resume(&mut self) {
-        self.suppress_agent_auto_resume();
         if let InteractionMode::Agent(metadata) = &mut self.interaction_mode {
+            metadata.set_suppress_auto_resume();
             if let Some(state) = &mut metadata.long_running_control_state {
                 *state = LongRunningCommandControlState::User {
                     reason: UserTakeOverReason::Stop,

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -2376,10 +2376,19 @@ pub struct TerminalViewStateChange {
     pub state: TerminalViewState,
     pub timestamp: Instant,
 }
+
+enum ActiveCommandCtrlCAction {
+    CancelRequestedCommand {
+        conversation_id: AIConversationId,
+        action_id: AIAgentActionId,
+    },
+    WriteCtrlCToPty,
+}
 #[derive(Clone, Copy)]
 struct CtrlCActiveBlockState {
     is_long_running: bool,
     is_agent_in_control_of_command: bool,
+    is_executing_agent_requested_command: bool,
     conversation_id_to_stop: Option<AIConversationId>,
 }
 
@@ -7423,6 +7432,9 @@ impl TerminalView {
                         block.on_requested_command_execution_started(action_id.clone(), ctx)
                     });
                 }
+                if ctx.is_self_or_child_focused() {
+                    self.redetermine_global_focus(ctx);
+                }
 
                 // If the command turns out to be long-running, lock the input in agent mode.
                 ctx.spawn(
@@ -7435,7 +7447,10 @@ impl TerminalView {
                             .lock()
                             .block_list()
                             .block_with_id(&block_id)
-                            .is_some_and(|block| block.is_active_and_long_running())
+                            .is_some_and(|block| {
+                                block.is_agent_driving_command()
+                                    && block.is_active_and_long_running()
+                            })
                         {
                             me.input.update(ctx, |input, ctx| {
                                 input.set_input_mode_agent(false, ctx);
@@ -8470,6 +8485,34 @@ impl TerminalView {
     fn user_write_ctrl_c_to_pty(&mut self, ctx: &mut ViewContext<Self>) {
         self.write_user_bytes_to_pty(vec![escape_sequences::C0::ETX], ctx);
     }
+    fn cancel_requested_long_running_command(
+        &mut self,
+        conversation_id: AIConversationId,
+        action_id: AIAgentActionId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let did_cancel_local_action = self.ai_action_model.update(ctx, |action_model, ctx| {
+            action_model.cancel_requested_command_with_id(
+                conversation_id,
+                &action_id,
+                CancellationReason::ManuallyCancelled,
+                ctx,
+            )
+        });
+        if did_cancel_local_action {
+            let mut model = self.model.lock();
+            let active_block = model.block_list_mut().active_block_mut();
+            if active_block.ai_conversation_id() == Some(conversation_id)
+                && active_block.requested_command_action_id() == Some(&action_id)
+            {
+                active_block.suppress_agent_auto_resume();
+            }
+            drop(model);
+            self.user_write_ctrl_c_to_pty(ctx);
+        } else {
+            self.stop_local_agent_conversation(conversation_id, ctx);
+        }
+    }
 
     fn handle_ctrl_c_input_event(
         &mut self,
@@ -8522,6 +8565,11 @@ impl TerminalView {
             let active_block = model.block_list().active_block();
             let is_long_running = active_block.is_active_and_long_running();
             let is_agent_in_control_of_command = active_block.is_agent_in_control();
+            let is_executing_agent_requested_command = !is_long_running
+                && active_block.long_running_control_state().is_none()
+                && active_block.requested_command_action_id().is_some()
+                && active_block.ai_conversation_id().is_some()
+                && (active_block.is_executing() || active_block.is_command_grid_active());
             let conversation_id_to_stop = active_block
                 .long_running_control_state()
                 .and_then(|state| {
@@ -8534,6 +8582,7 @@ impl TerminalView {
             let active_block_state = CtrlCActiveBlockState {
                 is_long_running,
                 is_agent_in_control_of_command,
+                is_executing_agent_requested_command,
                 conversation_id_to_stop,
             };
             (
@@ -8641,6 +8690,24 @@ impl TerminalView {
         self.ctrl_c_to_active_block(active_block_state, ctx);
     }
 
+    fn active_command_ctrl_c_action(&self) -> ActiveCommandCtrlCAction {
+        let model = self.model.lock();
+        let active_block = model.block_list().active_block();
+
+        if active_block.long_running_control_state().is_none() {
+            if let Some((conversation_id, action_id)) = active_block
+                .ai_conversation_id()
+                .zip(active_block.requested_command_action_id().cloned())
+            {
+                return ActiveCommandCtrlCAction::CancelRequestedCommand {
+                    conversation_id,
+                    action_id,
+                };
+            }
+        }
+
+        ActiveCommandCtrlCAction::WriteCtrlCToPty
+    }
     fn ctrl_c_to_active_block(
         &mut self,
         active_block_state: CtrlCActiveBlockState,
@@ -8655,7 +8722,23 @@ impl TerminalView {
             if let Some(conversation_id) = active_block_state.conversation_id_to_stop {
                 self.stop_local_agent_conversation(conversation_id, ctx);
             } else {
-                self.user_write_ctrl_c_to_pty(ctx);
+                match self.active_command_ctrl_c_action() {
+                    ActiveCommandCtrlCAction::CancelRequestedCommand {
+                        conversation_id,
+                        action_id,
+                    } => {
+                        self.cancel_requested_long_running_command(conversation_id, action_id, ctx)
+                    }
+                    ActiveCommandCtrlCAction::WriteCtrlCToPty => self.user_write_ctrl_c_to_pty(ctx),
+                }
+            }
+        } else if active_block_state.is_executing_agent_requested_command {
+            match self.active_command_ctrl_c_action() {
+                ActiveCommandCtrlCAction::CancelRequestedCommand {
+                    conversation_id,
+                    action_id,
+                } => self.cancel_requested_long_running_command(conversation_id, action_id, ctx),
+                ActiveCommandCtrlCAction::WriteCtrlCToPty => self.user_write_ctrl_c_to_pty(ctx),
             }
         } else {
             self.maybe_handle_ctrl_c_in_rich_content_block(ctx);

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -2388,7 +2388,7 @@ enum ActiveCommandCtrlCAction {
 struct CtrlCActiveBlockState {
     is_long_running: bool,
     is_agent_in_control_of_command: bool,
-    is_executing_agent_requested_command: bool,
+    is_agent_requested_command_before_lrc_control: bool,
     conversation_id_to_stop: Option<AIConversationId>,
 }
 
@@ -7432,6 +7432,8 @@ impl TerminalView {
                         block.on_requested_command_execution_started(action_id.clone(), ctx)
                     });
                 }
+                // Requested command approvals focus the blocklist so Enter accepts them. After
+                // acceptance, route input back through the terminal for the running command.
                 if ctx.is_self_or_child_focused() {
                     self.redetermine_global_focus(ctx);
                 }
@@ -7442,6 +7444,8 @@ impl TerminalView {
                     // give some buffer to actually determine if its long running.
                     Timer::after(Duration::from_millis(LONG_RUNNING_COMMAND_DURATION_MS * 2)),
                     move |me, _, ctx| {
+                        // Ctrl-C can suppress agent-driving state before the command crosses the
+                        // long-running threshold; don't re-lock input after that user takeover.
                         if me
                             .model
                             .lock()
@@ -8505,7 +8509,7 @@ impl TerminalView {
             if active_block.ai_conversation_id() == Some(conversation_id)
                 && active_block.requested_command_action_id() == Some(&action_id)
             {
-                active_block.suppress_agent_auto_resume();
+                active_block.set_user_control_and_suppress_auto_resume();
             }
             drop(model);
             self.user_write_ctrl_c_to_pty(ctx);
@@ -8565,7 +8569,7 @@ impl TerminalView {
             let active_block = model.block_list().active_block();
             let is_long_running = active_block.is_active_and_long_running();
             let is_agent_in_control_of_command = active_block.is_agent_in_control();
-            let is_executing_agent_requested_command = !is_long_running
+            let is_agent_requested_command_before_lrc_control = !is_long_running
                 && active_block.long_running_control_state().is_none()
                 && active_block.requested_command_action_id().is_some()
                 && active_block.ai_conversation_id().is_some()
@@ -8582,7 +8586,7 @@ impl TerminalView {
             let active_block_state = CtrlCActiveBlockState {
                 is_long_running,
                 is_agent_in_control_of_command,
-                is_executing_agent_requested_command,
+                is_agent_requested_command_before_lrc_control,
                 conversation_id_to_stop,
             };
             (
@@ -8732,7 +8736,7 @@ impl TerminalView {
                     ActiveCommandCtrlCAction::WriteCtrlCToPty => self.user_write_ctrl_c_to_pty(ctx),
                 }
             }
-        } else if active_block_state.is_executing_agent_requested_command {
+        } else if active_block_state.is_agent_requested_command_before_lrc_control {
             match self.active_command_ctrl_c_action() {
                 ActiveCommandCtrlCAction::CancelRequestedCommand {
                     conversation_id,

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -19,7 +19,8 @@ use super::*;
 use crate::ai::agent::conversation::{AIConversation, ConversationStatus};
 use crate::ai::agent::task::TaskId;
 use crate::ai::agent::{
-    AIAgentActionId, AIAgentExchange, AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus,
+    AIAgentActionId, AIAgentActionResult, AIAgentActionResultType, AIAgentExchange,
+    AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus, RequestCommandOutputResult,
     UserQueryMode,
 };
 use crate::ai::ambient_agents::AmbientAgentTaskId;
@@ -5326,6 +5327,143 @@ fn ctrl_c_after_transfer_takeover_does_not_cancel_conversation() {
             // completion to the agent, so Ctrl-C should interrupt the command without
             // cancelling the conversation.
             assert_eq!(conversation.status(), &ConversationStatus::InProgress);
+        });
+    })
+}
+
+#[test]
+fn ctrl_c_interrupts_requested_command_before_long_running_threshold() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        FeatureFlag::AgentView.set_enabled(true);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        let pty_writes: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+        let writes = pty_writes.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&terminal, move |_, event, _| {
+                if let Event::WriteBytesToPty { bytes } = event {
+                    writes.borrow_mut().push(bytes.to_vec());
+                }
+            });
+        });
+
+        let conversation_id = terminal.update(&mut app, |view, ctx| {
+            let conversation_id =
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                    history.start_new_conversation(view.view_id, false, false, false, ctx)
+                });
+
+            let action_id = AIAgentActionId::from("requested-command".to_owned());
+            let mut model = view.model.lock();
+            model.simulate_cmd("sleep 20");
+            let active_block = model.block_list_mut().active_block_mut();
+            assert!(active_block.is_executing() || active_block.is_command_grid_active());
+            assert!(!active_block.is_active_and_long_running());
+            active_block.set_agent_interaction_mode_for_requested_command(
+                action_id,
+                None,
+                conversation_id,
+            );
+            assert!(active_block.is_agent_driving_command());
+            conversation_id
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            view.handle_action(&TerminalAction::CtrlC, ctx);
+        });
+
+        assert_eq!(*pty_writes.borrow(), vec![vec![C0::ETX]]);
+        terminal.read(&app, |view, ctx| {
+            let model = view.model.lock();
+            let active_block = model.block_list().active_block();
+            assert!(!active_block.is_agent_driving_command());
+            assert!(active_block
+                .agent_interaction_metadata()
+                .is_some_and(|metadata| metadata.should_suppress_auto_resume()));
+            drop(model);
+
+            let conversation = BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(&conversation_id)
+                .expect("conversation should exist");
+            assert_eq!(conversation.status(), &ConversationStatus::Cancelled);
+        });
+    })
+}
+
+#[test]
+fn ctrl_c_cancels_buffered_requested_command_snapshot() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        FeatureFlag::AgentView.set_enabled(true);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        let pty_writes: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+        let writes = pty_writes.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&terminal, move |_, event, _| {
+                if let Event::WriteBytesToPty { bytes } = event {
+                    writes.borrow_mut().push(bytes.to_vec());
+                }
+            });
+        });
+
+        let (conversation_id, action_id) = terminal.update(&mut app, |view, ctx| {
+            let conversation_id =
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                    history.start_new_conversation(view.view_id, false, false, false, ctx)
+                });
+            let action_id = AIAgentActionId::from("requested-command".to_owned());
+            view.model
+                .lock()
+                .simulate_long_running_block("sleep 20", "running");
+            let block_id = {
+                let mut model = view.model.lock();
+                let active_block = model.block_list_mut().active_block_mut();
+                active_block.set_agent_interaction_mode_for_requested_command(
+                    action_id.clone(),
+                    None,
+                    conversation_id,
+                );
+                active_block.id().clone()
+            };
+
+            view.ai_action_model.update(ctx, |action_model, ctx| {
+                action_model.apply_finished_action_result(
+                    conversation_id,
+                    AIAgentActionResult {
+                        id: action_id.clone(),
+                        task_id: TaskId::new("requested-command-task".to_owned()),
+                        result: AIAgentActionResultType::RequestCommandOutput(
+                            RequestCommandOutputResult::LongRunningCommandSnapshot {
+                                block_id,
+                                command: "sleep 20".to_owned(),
+                                grid_contents: "running".to_owned(),
+                                cursor: "<|cursor|>".to_owned(),
+                                is_alt_screen_active: false,
+                            },
+                        ),
+                    },
+                    ctx,
+                );
+            });
+            view.cancel_requested_long_running_command(conversation_id, action_id.clone(), ctx);
+            (conversation_id, action_id)
+        });
+
+        assert_eq!(*pty_writes.borrow(), vec![vec![C0::ETX]]);
+        terminal.read(&app, |view, ctx| {
+            let status = view
+                .ai_action_model
+                .as_ref(ctx)
+                .get_action_status(&action_id)
+                .expect("action result should exist");
+            assert!(status.is_cancelled());
+
+            let model = view.model.lock();
+            let active_block = model.block_list().active_block();
+            assert!(!active_block.is_agent_driving_command());
+            assert_eq!(active_block.ai_conversation_id(), Some(conversation_id));
         });
     })
 }


### PR DESCRIPTION
## Description
Fixes an early Ctrl-C cancellation gap for agent-requested commands. When an agent-requested command starts, there is a window before Warp classifies it as long-running and attaches CLI subagent control state. During that window, Ctrl-C should still interrupt the command and cancel the matching requested-command action, rather than leaving agent-side command state alive.

The solution scope is limited to requested-command cancellation:
- cancel pending/running requested-command actions by requested command id
- if a long-running snapshot is already buffered, rewrite it to `CancelledBeforeExecution` before the agent consumes it
- route Ctrl-C for agent-requested commands before LRC control state through requested-command cancellation plus ETX to the PTY
- avoid re-locking input in agent mode after early Ctrl-C has suppressed agent-driving state
- preserve the stacked idle-completion behavior for LRC takeover auto-resume suppression

Also includes a drive-by fix to refocus the input editor/`TerminalView` once a requested command's been accepted. The tl;dr here is that we focus the blocklist to accept `Enter` actions from users on requested command banners, but don't refocus the terminal view after they've accepted the LRC (so, they need to manually refocus before sending something like Ctrl-C to the subagent window).

## Linked Issue
N/A

## Testing
Manually tested; demo [here](https://www.loom.com/share/408612014396423e9b7dd59717c098ed).

- [x] `./script/format`
- [x] `cargo nextest run -p warp -E 'test(ctrl_c_interrupts_requested_command_before_long_running_threshold) | test(ctrl_c_cancels_buffered_requested_command_snapshot) | test(ctrl_c_after_stop_takeover_cancels_conversation) | test(ctrl_c_after_transfer_takeover_does_not_cancel_conversation) | test(completed_user_controlled_lrc_resumes_when_not_suppressed) | test(completed_user_controlled_lrc_skips_resume_when_suppressed)'`
- [x] `cargo clippy -p warp --all-targets --tests -- -D warnings`
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Conversation: https://staging.warp.dev/conversation/bafc48c3-198f-41f7-be7a-edf2a94095bd
- Plans:
  - Fix infinite "Warping" after Ctrl-C takeover of a long-running command: https://staging.warp.dev/drive/notebook/hzKaQ4fSha6yU1LXyDrQFN
  - Fix early Ctrl-C cancellation for agent-requested commands before LRC classification: https://staging.warp.dev/drive/notebook/cCJT1MuqYoujBgvEqc91ws

CHANGELOG-BUG-FIX: Fixed Ctrl-C cancellation for agent-requested commands before they are classified as long-running.

Co-Authored-By: Oz <oz-agent@warp.dev>
