### PR TITLE
Retoggle group collapse on group rename

### DIFF
--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -2829,6 +2829,10 @@ fn render_grouped_tabs_header(
         ctx.dispatch_typed_action(WorkspaceAction::ToggleTabGroupCollapsed(group_id));
     });
     hoverable = hoverable.on_double_click(move |ctx, _, _| {
+        // The first click of a double-click already toggled the group's collapsed
+        // state via `on_click`. Undo that toggle so double-clicking to rename leaves
+        // the group's expanded/collapsed state unchanged.
+        ctx.dispatch_typed_action(WorkspaceAction::ToggleTabGroupCollapsed(group_id));
         ctx.dispatch_typed_action(WorkspaceAction::RenameTabGroup(group_id));
     });
     hoverable = hoverable.on_right_click(move |ctx, _, position| {


### PR DESCRIPTION
## Description

Double clicking on a tab group header prompts rename. The first click causes the group to open/close. Currently on double click, only the first click toggles the groups collapsed/expanded state.

What this PR changes: On double click, we now open/close on the second click as well so the tab group is back in the original state when the rename was prompted.

## How it works

Dispatching the toggle tab group collapsed action on double click of the header. 

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4691/renaming-tab-group-closesexpands-the-group

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo before fix](https://www.loom.com/share/fe56ea247c534ed697ac7f176dab4f37)

[Demo after fix](https://www.loom.com/share/3b753c69e8ea4e1e87262bfb5f68b132)
