### PR TITLE
Fix file saves on a remote session

### DIFF
--- a/app/src/code/global_buffer_model.rs
+++ b/app/src/code/global_buffer_model.rs
@@ -265,6 +265,7 @@ pub enum GlobalBufferModelEvent {
     },
     FileSaved {
         file_id: FileId,
+        content_version: ContentVersion,
     },
     FailedToSave {
         file_id: FileId,
@@ -272,9 +273,7 @@ pub enum GlobalBufferModelEvent {
     },
     /// A remote buffer update conflicted with local edits.
     /// The UI should present a resolution dialog.
-    RemoteBufferConflict {
-        file_id: FileId,
-    },
+    RemoteBufferConflict { file_id: FileId },
     /// A server-local buffer was updated from a file-watcher event.
     /// Carries the incremental diff edits for the ServerModel to push
     /// to connected clients as `BufferUpdatedPush`.
@@ -778,7 +777,10 @@ impl GlobalBufferModel {
                 if let Some(state) = self.buffers.get_mut(id) {
                     state.set_base_content_version(*version);
                 }
-                ctx.emit(GlobalBufferModelEvent::FileSaved { file_id: *id });
+                ctx.emit(GlobalBufferModelEvent::FileSaved {
+                    file_id: *id,
+                    content_version: *version,
+                });
             }
             FileModelEvent::FailedToSave { id, error } => {
                 ctx.emit(GlobalBufferModelEvent::FailedToSave {
@@ -834,7 +836,10 @@ impl GlobalBufferModel {
                     async move { handle.save_buffer(path).await },
                     move |_me, result, ctx| match result {
                         Ok(()) => {
-                            ctx.emit(GlobalBufferModelEvent::FileSaved { file_id });
+                            ctx.emit(GlobalBufferModelEvent::FileSaved {
+                                file_id,
+                                content_version: version,
+                            });
                         }
                         Err(error) => {
                             log::warn!("Remote save failed: {error}");

--- a/app/src/code/local_code_editor.rs
+++ b/app/src/code/local_code_editor.rs
@@ -1518,7 +1518,6 @@ impl LocalCodeEditorView {
             if event.file_id() != file_id {
                 return;
             }
-            me.update_diff_hunk_gutter_buttons(ctx);
             match event {
                 GlobalBufferModelEvent::BufferLoaded {
                     content_version, ..
@@ -1530,13 +1529,13 @@ impl LocalCodeEditorView {
                     if me.base_content_version.is_some() {
                         me.base_content_version = Some(*content_version);
                         ctx.notify();
-                        return;
+                    } else {
+                        me.base_content_version = Some(*content_version);
+                        me.subscribe_to_lsp_manager_updates(ctx);
+                        me.try_connect_lsp_server(ctx);
+                        me.on_file_loaded(ctx);
+                        ctx.emit(LocalCodeEditorEvent::FileLoaded);
                     }
-                    me.base_content_version = Some(*content_version);
-                    me.subscribe_to_lsp_manager_updates(ctx);
-                    me.try_connect_lsp_server(ctx);
-                    me.on_file_loaded(ctx);
-                    ctx.emit(LocalCodeEditorEvent::FileLoaded);
                 }
                 GlobalBufferModelEvent::FailedToLoad { error, .. } => {
                     me.is_new_file = true;
@@ -1556,7 +1555,10 @@ impl LocalCodeEditorView {
                         me.base_content_version = Some(*content_version);
                     }
                 }
-                GlobalBufferModelEvent::FileSaved { .. } => {
+                GlobalBufferModelEvent::FileSaved {
+                    content_version, ..
+                } => {
+                    me.base_content_version = Some(*content_version);
                     me.has_remote_conflict = false;
                     ctx.emit(LocalCodeEditorEvent::FileSaved);
                 }
@@ -1574,6 +1576,8 @@ impl LocalCodeEditorView {
                     // Not relevant for local code editors.
                 }
             }
+
+            me.update_diff_hunk_gutter_buttons(ctx);
         });
     }
 

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -3206,6 +3206,7 @@ impl CodeReviewView {
                     },
                     ctx
                 );
+                ctx.notify();
             }
             LocalCodeEditorEvent::FailedToSave { .. } => {}
             LocalCodeEditorEvent::DelayedRenderingFlushed

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -529,7 +529,7 @@ impl ServerModel {
                         );
                     }
                 }
-                GlobalBufferModelEvent::FileSaved { file_id } => {
+                GlobalBufferModelEvent::FileSaved { file_id, .. } => {
                     for req in me.buffers.take_pending_by_kind(
                         file_id,
                         PendingBufferRequestKind::SaveBuffer,


### PR DESCRIPTION
## Description 
* Bug: editing a remote file from one view would cause other editors to that same file marking the file as "dirty" incorrectly. 
* Root cause: the `FileSaved` event from `GlobalBufferModel` dropped `content_version` so sibling editor views sharing a remote file's buffer couldn't refresh their unsaved baseline and showed stale changes; the fix adds the saved `ContentVersion` to the event so all views update.
* Key changes include:
  *   Updated `GlobalBufferModelEvent::FileSaved` to carry the `content_version`.
  *   Modified `GlobalBufferModel` to emit the version during both local and remote save flows.
  *   Updated `LocalCodeEditorView` to update `base_content_version` upon receiving a `FileSaved` event.
  *   Refactored `LocalCodeEditorView` event handling to ensure gutter buttons are updated consistently.

## Linked issue
[APP-4531](https://linear.app/warpdotdev/issue/APP-4531/bug-code-review-marks-file-as-changeddirty-incorrectly)

## Testing
Repro steps:
1. SSH into a remote machine (with the ssh extension) 
2. Make a change to a file with the file editor and save
3. See that the file rendered in the code review view as "unsaved changes" 

Before:
https://www.loom.com/share/1a808f39a10c459795e2fb10fc017de4

After:
https://www.loom.com/share/e4e841ca4fde401baf36f6059c9c1e7a

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode