### PR TITLE
Change "Settings" label to "More Settings" in user-visible UI

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/toolbar_item.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/toolbar_item.rs
@@ -125,7 +125,7 @@ impl AgentToolbarItemKind {
             Self::FileExplorer => "File Explorer",
             Self::RichInput => "Rich Input",
             Self::ShareSession => "/remote-control",
-            Self::Settings => "Settings",
+            Self::Settings => "More Settings",
             Self::FastForwardToggle => "Fast Forward",
             Self::HandoffToCloud => "Hand off to cloud",
         }

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -2793,7 +2793,7 @@ impl BackingView for SettingsView {
         _ctx: &view::HeaderRenderContext<'_>,
         _app: &AppContext,
     ) -> view::HeaderContent {
-        view::HeaderContent::simple("Settings")
+        view::HeaderContent::simple("More Settings")
     }
 
     fn set_focus_handle(&mut self, focus_handle: PaneFocusHandle, _ctx: &mut ViewContext<Self>) {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -8206,7 +8206,7 @@ impl Workspace {
         self.add_tab_with_pane_layout(
             panes_layout,
             Arc::new(HashMap::new()),
-            Some("Settings".to_owned()),
+            Some("More Settings".to_owned()),
             ctx,
         );
     }
@@ -9311,7 +9311,7 @@ impl Workspace {
             MenuItemFields::new("What's new")
                 .with_on_select_action(WorkspaceAction::ViewLatestChangelog)
                 .into_item(),
-            MenuItemFields::new("Settings")
+            MenuItemFields::new("More Settings")
                 .with_on_select_action(WorkspaceAction::ShowSettings)
                 .into_item(),
             MenuItemFields::new("Keyboard shortcuts")
@@ -20903,7 +20903,7 @@ impl Workspace {
                 icons::Icon::Gear,
                 &self.mouse_states.settings_icon,
                 WorkspaceAction::ShowSettings,
-                "Settings".to_string(),
+                "More Settings".to_string(),
                 self.cached_keybindings[SHOW_SETTINGS_KEYBINDING_NAME].clone(),
                 false,
                 false,

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -3359,7 +3359,7 @@ impl TypedPane<'_> {
             TypedPane::File => "File",
             TypedPane::Notebook { .. } => "Notebook",
             TypedPane::Workflow { .. } => "Workflow",
-            TypedPane::Settings => "Settings",
+            TypedPane::Settings => "More Settings",
             TypedPane::EnvVarCollection => "Environment Variables",
             TypedPane::EnvironmentManagement => "Environments",
             TypedPane::AIFact => "Rules",


### PR DESCRIPTION
## Description

Changes the user-visible "Settings" label to "More Settings" across the Warp UI.

Affected locations:
- Tab title when opening the settings pane
- User dropdown menu item
- Settings gear button tooltip in the tab bar  
- Pane header title
- Vertical tabs kind label
- CLI agent toolbar item display label

## Linked Issue

N/A

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/5ff83627-7722-4088-be2f-b434f2c59f8b_
_Run: https://oz.staging.warp.dev/runs/019ed684-88d4-7027-8bc7-fda6ecb10adb_

_This PR was generated with [Oz](https://warp.dev/oz)._
