### PR TITLE
Fix crash when rejecting then confirming a requested command

### DIFF
--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -1218,7 +1218,7 @@ impl BlocklistAIActionModel {
         }
 
         let Some(conversation_id) = found_conversation_id else {
-            debug_assert!(false, "Expected action to be requested command.");
+            log::warn!("Ignoring acceptance for non-pending requested command: {action_id:?}");
             return;
         };
 

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -3438,6 +3438,7 @@ impl AIBlock {
                         ctx,
                     );
                 });
+                self.yield_requested_action_focus_if_focused(&view, ctx);
                 ctx.notify();
             }
             RequestedCommandViewEvent::EnableAutoexecuteMode => {
@@ -3445,6 +3446,7 @@ impl AIBlock {
             }
             RequestedCommandViewEvent::Rejected => {
                 self.cancel_action(action_id, ctx);
+                self.yield_requested_action_focus_if_focused(&view, ctx);
             }
             RequestedCommandViewEvent::UpdatedExpansionState { is_expanded } => {
                 // We only care about expansion state updates when the command
@@ -3576,10 +3578,12 @@ impl AIBlock {
                 self.action_model.update(ctx, |action_model, ctx| {
                     action_model.execute_action(action_id, self.client_ids.conversation_id, ctx);
                 });
+                self.yield_requested_action_focus_if_focused(&view, ctx);
                 ctx.notify();
             }
             RequestedCommandViewEvent::Rejected => {
                 self.cancel_action(action_id, ctx);
+                self.yield_requested_action_focus_if_focused(&view, ctx);
             }
             RequestedCommandViewEvent::TextSelected => {
                 // If there's an ongoing text selection, clear all other selections within the
@@ -4753,6 +4757,15 @@ impl AIBlock {
         });
     }
 
+    fn yield_requested_action_focus_if_focused(
+        &self,
+        view: &ViewHandle<RequestedCommandView>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if view.is_self_or_child_focused(ctx) {
+            ctx.emit(AIBlockEvent::FocusTerminal);
+        }
+    }
     /// Tries to focus the AI block or one of its parts, if applicable.
     /// If the block doesn't need to be focused, focus is yielded
     /// back to the owning [`TerminalView`].

--- a/app/src/ai/blocklist/inline_action/requested_command.rs
+++ b/app/src/ai/blocklist/inline_action/requested_command.rs
@@ -89,6 +89,7 @@ const VIEWING_MCP_TOOL_DETAIL_MESSAGE: &str = "Viewing MCP tool call detail";
 const EDIT_COMMAND_ACTION_NAME: &str = "requested_command:edit";
 
 const EDIT_MODE_OPEN_KEYMAP_CONTEXT: &str = "RequestedCommandViewEditModeOpen";
+const REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT: &str = "RequestedActionBlocked";
 
 const SCROLLBAR_WIDTH: ScrollbarWidth = ScrollbarWidth::Auto;
 const MAX_EDITOR_HEIGHT: f32 = 500.0;
@@ -119,32 +120,42 @@ pub fn init(app: &mut AppContext) {
         FixedBinding::new(
             "ctrl-c",
             RequestedCommandViewAction::Reject,
-            id!(RequestedCommandView::ui_name()),
+            id!(RequestedCommandView::ui_name()) & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT),
         ),
         FixedBinding::new(
             "enter",
             RequestedCommandViewAction::Accept,
-            id!(RequestedCommandView::ui_name()) & !id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
+            id!(RequestedCommandView::ui_name())
+                & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT)
+                & !id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
         ),
         FixedBinding::new(
             "numpadenter",
             RequestedCommandViewAction::Accept,
-            id!(RequestedCommandView::ui_name()) & !id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
+            id!(RequestedCommandView::ui_name())
+                & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT)
+                & !id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
         ),
         FixedBinding::new(
             "cmdorctrl-enter",
             RequestedCommandViewAction::Accept,
-            id!(RequestedCommandView::ui_name()) & id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
+            id!(RequestedCommandView::ui_name())
+                & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT)
+                & id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
         ),
         FixedBinding::new(
             "escape",
             RequestedCommandViewAction::CloseEditMode,
-            id!(RequestedCommandView::ui_name()) & id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
+            id!(RequestedCommandView::ui_name())
+                & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT)
+                & id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
         ),
         FixedBinding::new(
             "tab",
             RequestedCommandViewAction::FocusEditor,
-            id!(RequestedCommandView::ui_name()) & id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
+            id!(RequestedCommandView::ui_name())
+                & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT)
+                & id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
         ),
     ]);
 
@@ -155,7 +166,9 @@ pub fn init(app: &mut AppContext) {
     )
     .with_key_binding(cmd_or_ctrl_shift("e"))
     .with_context_predicate(
-        id!(RequestedCommandView::ui_name()) & !id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
+        id!(RequestedCommandView::ui_name())
+            & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT)
+            & !id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
     )]);
 }
 
@@ -617,6 +630,13 @@ impl RequestedCommandView {
 
     fn get_position_id_for_accept_split_button(prefix: &str) -> String {
         format!("RequestedCommandView-{prefix}-accept-split")
+    }
+
+    fn is_waiting_for_user_confirmation(&self, app: &AppContext) -> bool {
+        self.action_model
+            .as_ref(app)
+            .get_action_status(&self.action_id)
+            .is_some_and(|status| status.is_blocked())
     }
 
     pub fn is_header_expanded(&self) -> bool {
@@ -1572,8 +1592,11 @@ impl View for RequestedCommandView {
         root_stack.finish()
     }
 
-    fn keymap_context(&self, _app: &AppContext) -> Context {
+    fn keymap_context(&self, app: &AppContext) -> Context {
         let mut context = Self::default_keymap_context();
+        if self.is_waiting_for_user_confirmation(app) {
+            context.set.insert(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT);
+        }
 
         if self.is_editing {
             context.set.insert(EDIT_MODE_OPEN_KEYMAP_CONTEXT);
@@ -1586,6 +1609,19 @@ impl TypedActionView for RequestedCommandView {
     type Action = RequestedCommandViewAction;
 
     fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        if matches!(
+            action,
+            RequestedCommandViewAction::Accept
+                | RequestedCommandViewAction::AcceptAndAutoExecute
+                | RequestedCommandViewAction::ToggleAcceptMenu
+                | RequestedCommandViewAction::Reject
+                | RequestedCommandViewAction::OpenEditMode
+                | RequestedCommandViewAction::CloseEditMode
+                | RequestedCommandViewAction::FocusEditor
+        ) && !self.is_waiting_for_user_confirmation(ctx)
+        {
+            return;
+        }
         match action {
             RequestedCommandViewAction::Accept => {
                 self.commit_editor_contents(ctx);


### PR DESCRIPTION
## Description

### The issue
When a requested-command approval card (the card Agent Mode shows when it asks for permission before running a shell command) had keyboard focus, the reject + confirm sequence could crash the app in debug builds.

Repro:
1. In Agent Mode, ask the agent to run a command and have it request approval (e.g. `sleep 5`).
2. With the approval card focused, press `Ctrl-C` to reject it.
3. Immediately press `Enter`.

Two problems combined to cause this:
- After the card was rejected (or accepted), keyboard focus stayed on the now-resolved card instead of returning to the terminal.
- The card's key bindings (`enter` → Accept, `ctrl-c` → Reject, etc.) were always active for a focused `RequestedCommandView`, regardless of whether the underlying action was still pending. So the stray `Enter` re-fired `Accept` against an action that was no longer pending, which tripped `debug_assert!(false, "Expected action to be requested command.")` in `BlocklistAIActionModel` and panicked debug builds.

### The fix
- **Scope the card's key bindings to when it is actually awaiting confirmation.** Added a new `RequestedActionBlocked` keymap context that is only set while the action's status `is_blocked()` (waiting for the user). Accept / reject / edit-mode bindings now require this context, and `handle_action` short-circuits those actions when the card is no longer blocked, so a late keypress is ignored.
- **Yield focus back to the terminal after a card resolves.** Added `yield_requested_action_focus_if_focused`, which emits `AIBlockEvent::FocusTerminal` when the resolved card (or a child) currently holds focus, called after both Accept and Reject. This prevents a stray `Enter` from landing on a stale card.
- **Make the action model defensive.** Downgraded the acceptance `debug_assert!(false, ...)` to a `log::warn!` so that a late acceptance for a non-pending command is logged and ignored rather than crashing.

## Linked Issue
<!-- N/A -->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Manually tested and things work as expected (no app crash). Happy to share a demo as-needed, but think the code here is pretty self-explanatory.

- [x] I have manually tested my changes locally with `./script/run`

Manual repro before the fix: reject a focused approval card with `Ctrl-C`, then press `Enter` → debug build panics on the `debug_assert!`. After the fix, focus returns to the terminal on reject, the stale `Enter` is ignored, and no crash occurs.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed a crash that could occur when rejecting an Agent Mode command-approval card and then pressing Enter.
-->