### PR TITLE
Disable handoff while child agents are running

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -50,9 +50,7 @@ pub(crate) use self::environment_selector::{
 };
 use crate::ai::blocklist::agent_view::is_in_cloud_context;
 use crate::ai::blocklist::history_model::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
-use crate::ai::blocklist::orchestration_topology::{
-    has_in_progress_descendant_conversation, is_descendant_conversation_id,
-};
+use crate::ai::blocklist::orchestration_topology::has_in_progress_descendant_conversation;
 use crate::ai::blocklist::prompt::prompt_alert::{PromptAlertEvent, PromptAlertView};
 use crate::ai::blocklist::usage::icon_for_context_window_usage;
 use crate::ai::blocklist::BlocklistAIInputModel;
@@ -783,12 +781,20 @@ impl AgentInputFooter {
         ctx.subscribe_to_model(
             &BlocklistAIHistoryModel::handle(ctx),
             |me, _, event, ctx| {
-                let is_relevant_child_event = me.is_relevant_orchestration_child_event(event, ctx);
-                if !event
+                if event
                     .terminal_view_id()
-                    .is_some_and(|id| id == me.terminal_view_id)
-                    && !is_relevant_child_event
+                    .is_some_and(|id| id != me.terminal_view_id)
                 {
+                    if matches!(
+                        event,
+                        BlocklistAIHistoryEvent::StartedNewConversation { .. }
+                            | BlocklistAIHistoryEvent::UpdatedConversationStatus { .. }
+                            | BlocklistAIHistoryEvent::RemoveConversation { .. }
+                            | BlocklistAIHistoryEvent::DeletedConversation { .. }
+                            | BlocklistAIHistoryEvent::RestoredConversations { .. }
+                    ) {
+                        me.sync_handoff_to_cloud_button(ctx);
+                    }
                     return;
                 }
                 me.update_ftu_callout_render_state(ctx);
@@ -800,19 +806,28 @@ impl AgentInputFooter {
                     | BlocklistAIHistoryEvent::ClearedConversationsInTerminalView { .. }
                     | BlocklistAIHistoryEvent::RemoveConversation { .. }
                     | BlocklistAIHistoryEvent::DeletedConversation { .. }
-                    | BlocklistAIHistoryEvent::RestoredConversations { .. }
-                    | BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. } => {
+                    | BlocklistAIHistoryEvent::RestoredConversations { .. } => {
                         me.sync_fast_forward_button(ctx);
                         me.sync_handoff_to_cloud_button(ctx);
                         me.update_context_window_button(ctx);
                         me.model_selector.update(ctx, |_, ctx| ctx.notify());
                         ctx.notify();
                     }
+                    BlocklistAIHistoryEvent::UpdatedConversationStatus { .. } => {
+                        me.sync_handoff_to_cloud_button(ctx);
+                        me.update_context_window_button(ctx);
+                        me.model_selector.update(ctx, |_, ctx| ctx.notify());
+                        ctx.notify();
+                    }
+                    BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. } => {
+                        me.sync_fast_forward_button(ctx);
+                        me.update_context_window_button(ctx);
+                        me.model_selector.update(ctx, |_, ctx| ctx.notify());
+                        ctx.notify();
+                    }
                     BlocklistAIHistoryEvent::UpdatedTodoList { .. }
-                    | BlocklistAIHistoryEvent::UpdatedConversationStatus { .. }
                     | BlocklistAIHistoryEvent::AppendedExchange { .. }
                     | BlocklistAIHistoryEvent::UpdatedStreamingExchange { .. } => {
-                        me.sync_handoff_to_cloud_button(ctx);
                         me.update_context_window_button(ctx);
                         me.model_selector.update(ctx, |_, ctx| ctx.notify());
                         ctx.notify();
@@ -2042,45 +2057,12 @@ impl AgentInputFooter {
             })
     }
 
-    /// Returns true when a child event should refresh this parent's handoff chip.
-    fn is_relevant_orchestration_child_event(
-        &self,
-        event: &BlocklistAIHistoryEvent,
-        app: &AppContext,
-    ) -> bool {
-        let history = BlocklistAIHistoryModel::as_ref(app);
-        let Some(active_conversation_id) = history.active_conversation_id(self.terminal_view_id)
-        else {
-            return false;
-        };
-        let is_descendant = |conversation_id| {
-            is_descendant_conversation_id(history, active_conversation_id, conversation_id)
-        };
-
-        match event {
-            BlocklistAIHistoryEvent::StartedNewConversation {
-                new_conversation_id,
-                ..
-            } => is_descendant(*new_conversation_id),
-            BlocklistAIHistoryEvent::UpdatedConversationStatus {
-                conversation_id, ..
-            }
-            | BlocklistAIHistoryEvent::RemoveConversation {
-                conversation_id, ..
-            }
-            | BlocklistAIHistoryEvent::DeletedConversation {
-                conversation_id, ..
-            } => is_descendant(*conversation_id),
-            BlocklistAIHistoryEvent::RestoredConversations {
-                conversation_ids, ..
-            } => conversation_ids.iter().copied().any(is_descendant),
-            _ => false,
-        }
-    }
-
     /// Updates the handoff chip disabled state and tooltip from child-agent status.
     fn sync_handoff_to_cloud_button(&self, ctx: &mut ViewContext<Self>) {
         let disabled = self.active_conversation_has_in_progress_children(ctx);
+        if self.handoff_to_cloud_button.as_ref(ctx).is_disabled() == disabled {
+            return;
+        }
         let tooltip = if disabled {
             HANDOFF_CHILD_AGENTS_IN_PROGRESS_TOOLTIP
         } else {

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -51,7 +51,7 @@ pub(crate) use self::environment_selector::{
 use crate::ai::blocklist::agent_view::is_in_cloud_context;
 use crate::ai::blocklist::history_model::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::ai::blocklist::orchestration_topology::{
-    descendant_conversation_ids_in_spawn_order, has_in_progress_descendant_conversation,
+    has_in_progress_descendant_conversation, is_descendant_conversation_id,
 };
 use crate::ai::blocklist::prompt::prompt_alert::{PromptAlertEvent, PromptAlertView};
 use crate::ai::blocklist::usage::icon_for_context_window_usage;
@@ -782,10 +782,11 @@ impl AgentInputFooter {
         ctx.subscribe_to_model(
             &BlocklistAIHistoryModel::handle(ctx),
             |me, _, event, ctx| {
-                if event
+                let is_relevant_child_event = me.is_relevant_orchestration_child_event(event, ctx);
+                if !event
                     .terminal_view_id()
-                    .is_some_and(|id| id != me.terminal_view_id)
-                    && !me.is_relevant_orchestration_child_event(event, ctx)
+                    .is_some_and(|id| id == me.terminal_view_id)
+                    && !is_relevant_child_event
                 {
                     return;
                 }
@@ -797,6 +798,7 @@ impl AgentInputFooter {
                     | BlocklistAIHistoryEvent::ClearedActiveConversation { .. }
                     | BlocklistAIHistoryEvent::ClearedConversationsInTerminalView { .. }
                     | BlocklistAIHistoryEvent::RemoveConversation { .. }
+                    | BlocklistAIHistoryEvent::DeletedConversation { .. }
                     | BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. } => {
                         me.sync_fast_forward_button(ctx);
                         me.sync_handoff_to_cloud_button(ctx);
@@ -2044,28 +2046,95 @@ impl AgentInputFooter {
         event: &BlocklistAIHistoryEvent,
         app: &AppContext,
     ) -> bool {
-        let child_conversation_id = match event {
-            BlocklistAIHistoryEvent::UpdatedConversationStatus {
-                conversation_id, ..
-            }
-            | BlocklistAIHistoryEvent::RemoveConversation {
-                conversation_id, ..
-            }
-            | BlocklistAIHistoryEvent::DeletedConversation {
-                conversation_id, ..
-            }
-            | BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { conversation_id } => {
-                *conversation_id
-            }
-            _ => return false,
-        };
         let history = BlocklistAIHistoryModel::as_ref(app);
         let Some(active_conversation_id) = history.active_conversation_id(self.terminal_view_id)
         else {
             return false;
         };
-        descendant_conversation_ids_in_spawn_order(history, active_conversation_id)
-            .contains(&child_conversation_id)
+        let is_descendant = |conversation_id| {
+            is_descendant_conversation_id(history, active_conversation_id, conversation_id)
+        };
+
+        match event {
+            BlocklistAIHistoryEvent::StartedNewConversation {
+                new_conversation_id,
+                ..
+            } => is_descendant(*new_conversation_id),
+            BlocklistAIHistoryEvent::CreatedSubtask {
+                conversation_id, ..
+            } => is_descendant(*conversation_id),
+            BlocklistAIHistoryEvent::AppendedExchange {
+                conversation_id, ..
+            } => is_descendant(*conversation_id),
+            BlocklistAIHistoryEvent::ReassignedExchange {
+                new_conversation_id,
+                ..
+            } => is_descendant(*new_conversation_id),
+            BlocklistAIHistoryEvent::UpdatedStreamingExchange {
+                conversation_id, ..
+            } => is_descendant(*conversation_id),
+            BlocklistAIHistoryEvent::UpdatedConversationStatus {
+                conversation_id, ..
+            } => is_descendant(*conversation_id),
+            BlocklistAIHistoryEvent::SetActiveConversation {
+                conversation_id, ..
+            } => is_descendant(*conversation_id),
+            BlocklistAIHistoryEvent::ClearedActiveConversation {
+                conversation_id, ..
+            } => is_descendant(*conversation_id),
+            BlocklistAIHistoryEvent::ClearedConversationsInTerminalView {
+                active_conversation_id,
+                cleared_conversation_ids,
+                ..
+            } => {
+                active_conversation_id.is_some_and(is_descendant)
+                    || cleared_conversation_ids.iter().copied().any(is_descendant)
+            }
+            BlocklistAIHistoryEvent::SplitConversation {
+                old_conversation_id,
+                new_conversation_id,
+                ..
+            } => is_descendant(*old_conversation_id) || is_descendant(*new_conversation_id),
+            BlocklistAIHistoryEvent::RemoveConversation {
+                conversation_id, ..
+            } => is_descendant(*conversation_id),
+            BlocklistAIHistoryEvent::DeletedConversation {
+                conversation_id, ..
+            } => is_descendant(*conversation_id),
+            BlocklistAIHistoryEvent::RestoredConversations {
+                conversation_ids, ..
+            } => conversation_ids.iter().copied().any(is_descendant),
+            BlocklistAIHistoryEvent::UpdatedConversationMetadata {
+                conversation_id, ..
+            } => is_descendant(*conversation_id),
+            BlocklistAIHistoryEvent::UpdatedConversationTitle {
+                conversation_id, ..
+            } => is_descendant(*conversation_id),
+            BlocklistAIHistoryEvent::UpdatedConversationArtifacts {
+                conversation_id, ..
+            } => is_descendant(*conversation_id),
+            BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
+                conversation_id, ..
+            } => is_descendant(*conversation_id),
+            BlocklistAIHistoryEvent::ConversationOwnershipTransferred {
+                conversation_id, ..
+            } => is_descendant(*conversation_id),
+            BlocklistAIHistoryEvent::NewConversationRequestComplete {
+                conversation_id, ..
+            } => is_descendant(*conversation_id),
+            BlocklistAIHistoryEvent::OrchestrationConfigUpdated {
+                conversation_id, ..
+            } => is_descendant(*conversation_id),
+            BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { conversation_id } => {
+                is_descendant(*conversation_id)
+            }
+            BlocklistAIHistoryEvent::LocalSharedSessionEstablished {
+                conversation_id, ..
+            } => is_descendant(*conversation_id),
+            BlocklistAIHistoryEvent::UpgradedTask { .. }
+            | BlocklistAIHistoryEvent::UpdatedTodoList { .. }
+            | BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. } => false,
+        }
     }
 
     /// Updates the handoff chip disabled state and tooltip from child-agent status.

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -388,6 +388,7 @@ impl AgentInputFooter {
                 .with_tooltip(HANDOFF_TO_CLOUD_TOOLTIP)
                 .with_size(button_size)
                 .with_tooltip_alignment(TooltipAlignment::Left)
+                .with_disabled_theme(AgentInputButtonTheme)
                 .on_click(|ctx| {
                     ctx.dispatch_typed_action(AgentInputFooterAction::HandoffChipClicked);
                 })

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -799,6 +799,7 @@ impl AgentInputFooter {
                     | BlocklistAIHistoryEvent::ClearedConversationsInTerminalView { .. }
                     | BlocklistAIHistoryEvent::RemoveConversation { .. }
                     | BlocklistAIHistoryEvent::DeletedConversation { .. }
+                    | BlocklistAIHistoryEvent::RestoredConversations { .. }
                     | BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. } => {
                         me.sync_fast_forward_button(ctx);
                         me.sync_handoff_to_cloud_button(ctx);
@@ -2060,80 +2061,19 @@ impl AgentInputFooter {
                 new_conversation_id,
                 ..
             } => is_descendant(*new_conversation_id),
-            BlocklistAIHistoryEvent::CreatedSubtask {
-                conversation_id, ..
-            } => is_descendant(*conversation_id),
-            BlocklistAIHistoryEvent::AppendedExchange {
-                conversation_id, ..
-            } => is_descendant(*conversation_id),
-            BlocklistAIHistoryEvent::ReassignedExchange {
-                new_conversation_id,
-                ..
-            } => is_descendant(*new_conversation_id),
-            BlocklistAIHistoryEvent::UpdatedStreamingExchange {
-                conversation_id, ..
-            } => is_descendant(*conversation_id),
             BlocklistAIHistoryEvent::UpdatedConversationStatus {
                 conversation_id, ..
-            } => is_descendant(*conversation_id),
-            BlocklistAIHistoryEvent::SetActiveConversation {
-                conversation_id, ..
-            } => is_descendant(*conversation_id),
-            BlocklistAIHistoryEvent::ClearedActiveConversation {
-                conversation_id, ..
-            } => is_descendant(*conversation_id),
-            BlocklistAIHistoryEvent::ClearedConversationsInTerminalView {
-                active_conversation_id,
-                cleared_conversation_ids,
-                ..
-            } => {
-                active_conversation_id.is_some_and(is_descendant)
-                    || cleared_conversation_ids.iter().copied().any(is_descendant)
             }
-            BlocklistAIHistoryEvent::SplitConversation {
-                old_conversation_id,
-                new_conversation_id,
-                ..
-            } => is_descendant(*old_conversation_id) || is_descendant(*new_conversation_id),
-            BlocklistAIHistoryEvent::RemoveConversation {
+            | BlocklistAIHistoryEvent::RemoveConversation {
                 conversation_id, ..
-            } => is_descendant(*conversation_id),
-            BlocklistAIHistoryEvent::DeletedConversation {
+            }
+            | BlocklistAIHistoryEvent::DeletedConversation {
                 conversation_id, ..
             } => is_descendant(*conversation_id),
             BlocklistAIHistoryEvent::RestoredConversations {
                 conversation_ids, ..
             } => conversation_ids.iter().copied().any(is_descendant),
-            BlocklistAIHistoryEvent::UpdatedConversationMetadata {
-                conversation_id, ..
-            } => is_descendant(*conversation_id),
-            BlocklistAIHistoryEvent::UpdatedConversationTitle {
-                conversation_id, ..
-            } => is_descendant(*conversation_id),
-            BlocklistAIHistoryEvent::UpdatedConversationArtifacts {
-                conversation_id, ..
-            } => is_descendant(*conversation_id),
-            BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
-                conversation_id, ..
-            } => is_descendant(*conversation_id),
-            BlocklistAIHistoryEvent::ConversationOwnershipTransferred {
-                conversation_id, ..
-            } => is_descendant(*conversation_id),
-            BlocklistAIHistoryEvent::NewConversationRequestComplete {
-                conversation_id, ..
-            } => is_descendant(*conversation_id),
-            BlocklistAIHistoryEvent::OrchestrationConfigUpdated {
-                conversation_id, ..
-            } => is_descendant(*conversation_id),
-            BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { conversation_id } => {
-                is_descendant(*conversation_id)
-            }
-            BlocklistAIHistoryEvent::LocalSharedSessionEstablished {
-                conversation_id, ..
-            } => is_descendant(*conversation_id),
-            BlocklistAIHistoryEvent::UpgradedTask { .. }
-            | BlocklistAIHistoryEvent::UpdatedTodoList { .. }
-            | BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. } => false,
+            _ => false,
         }
     }
 

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -50,6 +50,9 @@ pub(crate) use self::environment_selector::{
 };
 use crate::ai::blocklist::agent_view::is_in_cloud_context;
 use crate::ai::blocklist::history_model::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
+use crate::ai::blocklist::orchestration_topology::{
+    descendant_conversation_ids_in_spawn_order, has_in_progress_descendant_conversation,
+};
 use crate::ai::blocklist::prompt::prompt_alert::{PromptAlertEvent, PromptAlertView};
 use crate::ai::blocklist::usage::icon_for_context_window_usage;
 use crate::ai::blocklist::BlocklistAIInputModel;
@@ -124,6 +127,9 @@ const FAST_FORWARD_LOCKED_TOOLTIP: &str =
 
 const START_REMOTE_CONTROL_TOOLTIP: &str = "Start remote control";
 const START_REMOTE_CONTROL_LOGIN_REQUIRED_TOOLTIP: &str = "Log in to use /remote-control";
+const HANDOFF_TO_CLOUD_TOOLTIP: &str = "Hand off to cloud (or type &)";
+const HANDOFF_CHILD_AGENTS_IN_PROGRESS_TOOLTIP: &str =
+    "Hand off is disabled while child agents are in progress.";
 
 const CLOUD_MODE_V2_FOOTER_GAP: f32 = 4.;
 
@@ -379,7 +385,7 @@ impl AgentInputFooter {
         let handoff_to_cloud_button = ctx.add_typed_action_view(|_ctx| {
             ActionButton::new("", AgentInputButtonTheme)
                 .with_icon(Icon::UploadCloud)
-                .with_tooltip("Hand off to cloud (or type &)")
+                .with_tooltip(HANDOFF_TO_CLOUD_TOOLTIP)
                 .with_size(button_size)
                 .with_tooltip_alignment(TooltipAlignment::Left)
                 .on_click(|ctx| {
@@ -779,6 +785,7 @@ impl AgentInputFooter {
                 if event
                     .terminal_view_id()
                     .is_some_and(|id| id != me.terminal_view_id)
+                    && !me.is_relevant_orchestration_child_event(event, ctx)
                 {
                     return;
                 }
@@ -792,6 +799,7 @@ impl AgentInputFooter {
                     | BlocklistAIHistoryEvent::RemoveConversation { .. }
                     | BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. } => {
                         me.sync_fast_forward_button(ctx);
+                        me.sync_handoff_to_cloud_button(ctx);
                         me.update_context_window_button(ctx);
                         me.model_selector.update(ctx, |_, ctx| ctx.notify());
                         ctx.notify();
@@ -800,6 +808,7 @@ impl AgentInputFooter {
                     | BlocklistAIHistoryEvent::UpdatedConversationStatus { .. }
                     | BlocklistAIHistoryEvent::AppendedExchange { .. }
                     | BlocklistAIHistoryEvent::UpdatedStreamingExchange { .. } => {
+                        me.sync_handoff_to_cloud_button(ctx);
                         me.update_context_window_button(ctx);
                         me.model_selector.update(ctx, |_, ctx| ctx.notify());
                         ctx.notify();
@@ -887,6 +896,7 @@ impl AgentInputFooter {
         };
         me.sync_fast_forward_button(ctx);
         me.sync_remote_control_button(ctx);
+        me.sync_handoff_to_cloud_button(ctx);
         me.update_context_window_button(ctx);
         me.update_display_chips(&prompt, ctx);
         me.update_ftu_callout_render_state(ctx);
@@ -2018,6 +2028,60 @@ impl AgentInputFooter {
         });
     }
 
+    /// Returns true when this footer's active conversation has running child agents.
+    fn active_conversation_has_in_progress_children(&self, app: &AppContext) -> bool {
+        let history = BlocklistAIHistoryModel::as_ref(app);
+        history
+            .active_conversation_id(self.terminal_view_id)
+            .is_some_and(|conversation_id| {
+                has_in_progress_descendant_conversation(history, conversation_id)
+            })
+    }
+
+    /// Returns true when a child event should refresh this parent's handoff chip.
+    fn is_relevant_orchestration_child_event(
+        &self,
+        event: &BlocklistAIHistoryEvent,
+        app: &AppContext,
+    ) -> bool {
+        let child_conversation_id = match event {
+            BlocklistAIHistoryEvent::UpdatedConversationStatus {
+                conversation_id, ..
+            }
+            | BlocklistAIHistoryEvent::RemoveConversation {
+                conversation_id, ..
+            }
+            | BlocklistAIHistoryEvent::DeletedConversation {
+                conversation_id, ..
+            }
+            | BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { conversation_id } => {
+                *conversation_id
+            }
+            _ => return false,
+        };
+        let history = BlocklistAIHistoryModel::as_ref(app);
+        let Some(active_conversation_id) = history.active_conversation_id(self.terminal_view_id)
+        else {
+            return false;
+        };
+        descendant_conversation_ids_in_spawn_order(history, active_conversation_id)
+            .contains(&child_conversation_id)
+    }
+
+    /// Updates the handoff chip disabled state and tooltip from child-agent status.
+    fn sync_handoff_to_cloud_button(&self, ctx: &mut ViewContext<Self>) {
+        let disabled = self.active_conversation_has_in_progress_children(ctx);
+        let tooltip = if disabled {
+            HANDOFF_CHILD_AGENTS_IN_PROGRESS_TOOLTIP
+        } else {
+            HANDOFF_TO_CLOUD_TOOLTIP
+        };
+        self.handoff_to_cloud_button.update(ctx, |button, ctx| {
+            button.set_disabled(disabled, ctx);
+            button.set_tooltip(Some(tooltip), ctx);
+        });
+    }
+
     fn update_context_window_button(&mut self, ctx: &mut ViewContext<Self>) {
         if let Some(conversation) =
             BlocklistAIHistoryModel::as_ref(ctx).active_conversation(self.terminal_view_id)
@@ -2692,6 +2756,9 @@ impl TypedActionView for AgentInputFooter {
                 });
             }
             AgentInputFooterAction::HandoffChipClicked => {
+                if self.active_conversation_has_in_progress_children(ctx) {
+                    return;
+                }
                 if FeatureFlag::OzHandoff.is_enabled()
                     && FeatureFlag::HandoffLocalCloud.is_enabled()
                     && cfg!(all(feature = "local_fs", not(target_family = "wasm")))

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -61,14 +61,28 @@ pub fn has_in_progress_descendant_conversation(
     history: &BlocklistAIHistoryModel,
     parent_id: AIConversationId,
 ) -> bool {
-    descendant_conversation_ids_in_spawn_order(history, parent_id)
-        .into_iter()
-        .filter_map(|id| history.conversation(&id))
-        .any(|conversation| {
-            matches!(
-                conversation.status(),
-                ConversationStatus::InProgress | ConversationStatus::TransientError
-            )
+    history
+        .child_conversation_ids_of(&parent_id)
+        .iter()
+        .any(|child_id| {
+            history.conversation(child_id).is_some_and(|conversation| {
+                conversation.status().is_in_progress() || conversation.status().is_transient_error()
+            }) || has_in_progress_descendant_conversation(history, *child_id)
+        })
+}
+
+/// Returns true when `candidate_id` is a known descendant of `parent_id`.
+pub fn is_descendant_conversation_id(
+    history: &BlocklistAIHistoryModel,
+    parent_id: AIConversationId,
+    candidate_id: AIConversationId,
+) -> bool {
+    history
+        .child_conversation_ids_of(&parent_id)
+        .iter()
+        .any(|child_id| {
+            *child_id == candidate_id
+                || is_descendant_conversation_id(history, *child_id, candidate_id)
         })
 }
 

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -5,6 +5,7 @@
 //! orchestration pill bar so other surfaces (e.g. keyboard navigation and
 //! the agent-mode usage footer's credit rollup) can walk and order the same
 //! tree without duplicating the logic.
+use std::collections::HashSet;
 
 use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
 use crate::ai::blocklist::BlocklistAIHistoryModel;
@@ -64,31 +65,38 @@ pub fn has_in_progress_descendant_conversation(
     history: &BlocklistAIHistoryModel,
     parent_id: AIConversationId,
 ) -> bool {
-    descendant_conversation_ids_in_spawn_order(history, parent_id)
-        .into_iter()
-        .any(|descendant_id| {
-            history
-                .conversation(&descendant_id)
-                .is_some_and(|conversation| {
-                    conversation.status().is_in_progress()
-                        || conversation.status().is_transient_error()
-                })
-        })
+    if history.child_conversation_ids_of(&parent_id).is_empty() {
+        return false;
+    }
+    any_descendant_conversation_id(history, parent_id, |descendant_id| {
+        history
+            .conversation(&descendant_id)
+            .is_some_and(|conversation| {
+                conversation.status().is_in_progress() || conversation.status().is_transient_error()
+            })
+    })
 }
 
-/// Returns true when `candidate_id` is a known descendant of `parent_id`.
-pub fn is_descendant_conversation_id(
+/// Returns whether any descendant matches `predicate`, stopping at the first match.
+fn any_descendant_conversation_id(
     history: &BlocklistAIHistoryModel,
     parent_id: AIConversationId,
-    candidate_id: AIConversationId,
+    mut predicate: impl FnMut(AIConversationId) -> bool,
 ) -> bool {
-    history
-        .child_conversation_ids_of(&parent_id)
-        .iter()
-        .any(|child_id| {
-            *child_id == candidate_id
-                || is_descendant_conversation_id(history, *child_id, candidate_id)
-        })
+    let mut pending = vec![parent_id];
+    let mut visited = HashSet::from([parent_id]);
+    while let Some(current_id) = pending.pop() {
+        for descendant_id in history.child_conversation_ids_of(&current_id) {
+            if !visited.insert(*descendant_id) {
+                continue;
+            }
+            if predicate(*descendant_id) {
+                return true;
+            }
+            pending.push(*descendant_id);
+        }
+    }
+    false
 }
 
 /// Recursive worker for [`descendant_conversation_ids_in_spawn_order`]. Kept

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -56,6 +56,22 @@ pub fn descendant_conversation_ids_in_spawn_order(
     descendants
 }
 
+/// Returns true when any loaded descendant of `parent_id` is actively running.
+pub fn has_in_progress_descendant_conversation(
+    history: &BlocklistAIHistoryModel,
+    parent_id: AIConversationId,
+) -> bool {
+    descendant_conversation_ids_in_spawn_order(history, parent_id)
+        .into_iter()
+        .filter_map(|id| history.conversation(&id))
+        .any(|conversation| {
+            matches!(
+                conversation.status(),
+                ConversationStatus::InProgress | ConversationStatus::TransientError
+            )
+        })
+}
+
 /// Recursive worker for [`descendant_conversation_ids_in_spawn_order`]. Kept
 /// separate so it can be invoked from existing call sites that already own a
 /// buffer.

--- a/app/src/ai/blocklist/orchestration_topology.rs
+++ b/app/src/ai/blocklist/orchestration_topology.rs
@@ -57,17 +57,22 @@ pub fn descendant_conversation_ids_in_spawn_order(
 }
 
 /// Returns true when any loaded descendant of `parent_id` is actively running.
+///
+/// Unlike [`aggregated_orchestrator_status`], this excludes `parent_id` and
+/// ignores display-specific status precedence.
 pub fn has_in_progress_descendant_conversation(
     history: &BlocklistAIHistoryModel,
     parent_id: AIConversationId,
 ) -> bool {
-    history
-        .child_conversation_ids_of(&parent_id)
-        .iter()
-        .any(|child_id| {
-            history.conversation(child_id).is_some_and(|conversation| {
-                conversation.status().is_in_progress() || conversation.status().is_transient_error()
-            }) || has_in_progress_descendant_conversation(history, *child_id)
+    descendant_conversation_ids_in_spawn_order(history, parent_id)
+        .into_iter()
+        .any(|descendant_id| {
+            history
+                .conversation(&descendant_id)
+                .is_some_and(|conversation| {
+                    conversation.status().is_in_progress()
+                        || conversation.status().is_transient_error()
+                })
         })
 }
 

--- a/app/src/ai/blocklist/orchestration_topology_tests.rs
+++ b/app/src/ai/blocklist/orchestration_topology_tests.rs
@@ -223,38 +223,34 @@ fn orchestration_aware_status_uses_aggregated_status_for_known_parent() {
     });
 }
 
+/// Verifies the handoff predicate terminates if the parent-child index contains a cycle.
 #[test]
-fn is_descendant_conversation_id_matches_nested_children() {
+fn has_in_progress_descendant_conversation_terminates_on_cycles() {
     App::test((), |mut app| async move {
         initialize_history_persistence_for_tests(&mut app);
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
         let (terminal_view_id, orchestrator_id, child_a, child_b) =
             build_orchestrator_with_two_children(&mut app, &history_model);
-        let grandchild = history_model.update(&mut app, |history_model, ctx| {
-            history_model.start_new_child_conversation(
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.update_conversation_status(
                 terminal_view_id,
-                "grandchild".to_string(),
                 child_a,
-                None,
+                ConversationStatus::Success,
                 ctx,
-            )
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_b,
+                ConversationStatus::Success,
+                ctx,
+            );
+            history_model.set_parent_for_conversation(orchestrator_id, child_a);
         });
 
         history_model.read(&app, |history_model, _| {
-            assert!(is_descendant_conversation_id(
+            assert!(!has_in_progress_descendant_conversation(
                 history_model,
                 orchestrator_id,
-                child_a,
-            ));
-            assert!(is_descendant_conversation_id(
-                history_model,
-                orchestrator_id,
-                grandchild,
-            ));
-            assert!(!is_descendant_conversation_id(
-                history_model,
-                child_b,
-                grandchild,
             ));
         });
     });
@@ -516,6 +512,48 @@ fn has_in_progress_descendant_conversation_matches_running_children_only() {
 
         history_model.read(&app, |history_model, _| {
             assert!(has_in_progress_descendant_conversation(
+                history_model,
+                orchestrator_id,
+            ));
+        });
+    });
+}
+
+/// Verifies removed running children no longer block handoff.
+#[test]
+fn has_in_progress_descendant_conversation_ignores_removed_children() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let (terminal_view_id, orchestrator_id, child_a, child_b) =
+            build_orchestrator_with_two_children(&mut app, &history_model);
+
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_a,
+                ConversationStatus::InProgress,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_b,
+                ConversationStatus::Success,
+                ctx,
+            );
+        });
+        history_model.read(&app, |history_model, _| {
+            assert!(has_in_progress_descendant_conversation(
+                history_model,
+                orchestrator_id,
+            ));
+        });
+
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.remove_conversation(child_a, terminal_view_id, ctx);
+        });
+        history_model.read(&app, |history_model, _| {
+            assert!(!has_in_progress_descendant_conversation(
                 history_model,
                 orchestrator_id,
             ));

--- a/app/src/ai/blocklist/orchestration_topology_tests.rs
+++ b/app/src/ai/blocklist/orchestration_topology_tests.rs
@@ -224,6 +224,42 @@ fn orchestration_aware_status_uses_aggregated_status_for_known_parent() {
 }
 
 #[test]
+fn is_descendant_conversation_id_matches_nested_children() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let (terminal_view_id, orchestrator_id, child_a, child_b) =
+            build_orchestrator_with_two_children(&mut app, &history_model);
+        let grandchild = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_child_conversation(
+                terminal_view_id,
+                "grandchild".to_string(),
+                child_a,
+                None,
+                ctx,
+            )
+        });
+
+        history_model.read(&app, |history_model, _| {
+            assert!(is_descendant_conversation_id(
+                history_model,
+                orchestrator_id,
+                child_a,
+            ));
+            assert!(is_descendant_conversation_id(
+                history_model,
+                orchestrator_id,
+                grandchild,
+            ));
+            assert!(!is_descendant_conversation_id(
+                history_model,
+                child_b,
+                grandchild,
+            ));
+        });
+    });
+}
+#[test]
 fn orchestration_aware_status_uses_direct_status_for_non_parent() {
     App::test((), |mut app| async move {
         initialize_history_persistence_for_tests(&mut app);

--- a/app/src/ai/blocklist/orchestration_topology_tests.rs
+++ b/app/src/ai/blocklist/orchestration_topology_tests.rs
@@ -416,6 +416,63 @@ fn build_orchestrator_with_two_children(
 }
 
 #[test]
+/// Verifies the handoff predicate only treats actively running children as blockers.
+fn has_in_progress_descendant_conversation_matches_running_children_only() {
+    App::test((), |mut app| async move {
+        initialize_history_persistence_for_tests(&mut app);
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let (terminal_view_id, orchestrator_id, child_a, child_b) =
+            build_orchestrator_with_two_children(&mut app, &history_model);
+
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.update_conversation_status(
+                terminal_view_id,
+                orchestrator_id,
+                ConversationStatus::Success,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_a,
+                ConversationStatus::Success,
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_b,
+                ConversationStatus::Blocked {
+                    blocked_action: "approve_command".to_string(),
+                },
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |history_model, _| {
+            assert!(!has_in_progress_descendant_conversation(
+                history_model,
+                orchestrator_id,
+            ));
+        });
+
+        history_model.update(&mut app, |history_model, ctx| {
+            history_model.update_conversation_status(
+                terminal_view_id,
+                child_b,
+                ConversationStatus::TransientError,
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |history_model, _| {
+            assert!(has_in_progress_descendant_conversation(
+                history_model,
+                orchestrator_id,
+            ));
+        });
+    });
+}
+
+#[test]
 fn aggregated_status_is_in_progress_when_any_descendant_is_running() {
     App::test((), |mut app| async move {
         initialize_history_persistence_for_tests(&mut app);

--- a/app/src/ai/blocklist/orchestration_topology_tests.rs
+++ b/app/src/ai/blocklist/orchestration_topology_tests.rs
@@ -459,18 +459,27 @@ fn has_in_progress_descendant_conversation_matches_running_children_only() {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
         let (terminal_view_id, orchestrator_id, child_a, child_b) =
             build_orchestrator_with_two_children(&mut app, &history_model);
+        let grandchild = history_model.update(&mut app, |history_model, ctx| {
+            history_model.start_new_child_conversation(
+                terminal_view_id,
+                "grandchild".to_string(),
+                child_a,
+                None,
+                ctx,
+            )
+        });
 
         history_model.update(&mut app, |history_model, ctx| {
             history_model.update_conversation_status(
                 terminal_view_id,
                 orchestrator_id,
-                ConversationStatus::Success,
+                ConversationStatus::InProgress,
                 ctx,
             );
             history_model.update_conversation_status(
                 terminal_view_id,
                 child_a,
-                ConversationStatus::Success,
+                ConversationStatus::WaitingForEvents,
                 ctx,
             );
             history_model.update_conversation_status(
@@ -479,6 +488,12 @@ fn has_in_progress_descendant_conversation_matches_running_children_only() {
                 ConversationStatus::Blocked {
                     blocked_action: "approve_command".to_string(),
                 },
+                ctx,
+            );
+            history_model.update_conversation_status(
+                terminal_view_id,
+                grandchild,
+                ConversationStatus::Success,
                 ctx,
             );
         });
@@ -493,7 +508,7 @@ fn has_in_progress_descendant_conversation_matches_running_children_only() {
         history_model.update(&mut app, |history_model, ctx| {
             history_model.update_conversation_status(
                 terminal_view_id,
-                child_b,
+                grandchild,
                 ConversationStatus::TransientError,
                 ctx,
             );

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -168,6 +168,8 @@ use crate::ai::blocklist::handoff::touched_repos::{
 };
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::blocklist::handoff::{HandoffLaunchAttachments, PendingCloudLaunch};
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use crate::ai::blocklist::orchestration_topology::has_in_progress_descendant_conversation;
 use crate::ai::blocklist::prompt::prompt_alert::{PromptAlertEvent, PromptAlertView};
 use crate::ai::blocklist::telemetry_banner::should_collect_ai_ugc_telemetry;
 use crate::ai::blocklist::{
@@ -4262,6 +4264,33 @@ impl Input {
     }
 
     #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+    /// Returns true when this input's active conversation has running child agents.
+    fn active_conversation_has_in_progress_children(&self, ctx: &AppContext) -> bool {
+        let history = BlocklistAIHistoryModel::as_ref(ctx);
+        history
+            .active_conversation_id(self.terminal_view_id)
+            .is_some_and(|conversation_id| {
+                has_in_progress_descendant_conversation(history, conversation_id)
+            })
+    }
+
+    #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+    /// Shows the handoff-blocked toast without mutating the current draft.
+    fn show_handoff_child_agents_in_progress_toast(&self, ctx: &mut ViewContext<Self>) {
+        let window_id = ctx.window_id();
+        ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+            toast_stack.add_ephemeral_toast(
+                DismissibleToast::error(
+                    "Hand off is disabled while child agents are in progress. Wait for them to finish, then try again."
+                        .to_owned(),
+                ),
+                window_id,
+                ctx,
+            );
+        });
+    }
+
+    #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
     fn maybe_launch_cloud_handoff_request(&mut self, ctx: &mut ViewContext<Self>) -> bool {
         use crate::cloud_object::CloudObjectLookup as _;
 
@@ -4271,6 +4300,10 @@ impl Input {
             || self.prefix_mode(ctx) != InputPrefixMode::CloudHandoff
         {
             return false;
+        }
+        if self.active_conversation_has_in_progress_children(ctx) {
+            self.show_handoff_child_agents_in_progress_toast(ctx);
+            return true;
         }
 
         let prompt = self.editor.as_ref(ctx).buffer_text(ctx).trim().to_owned();

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -807,6 +807,24 @@ impl LocalToCloudHandoffIntent {
     }
 }
 
+/// Collects snapshot paths from the source conversation and loaded descendants.
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+fn handoff_snapshot_paths_for_conversation_workset(
+    history_model: &BlocklistAIHistoryModel,
+    source_conversation: &AIConversation,
+) -> Vec<StandardizedPath> {
+    let mut paths = extract_paths_from_conversation(source_conversation);
+    for descendant_id in
+        descendant_conversation_ids_in_spawn_order(history_model, source_conversation.id())
+    {
+        let Some(descendant_conversation) = history_model.conversation(&descendant_id) else {
+            continue;
+        };
+        paths.extend(extract_paths_from_conversation(descendant_conversation));
+    }
+    paths
+}
+
 /// Categorization of how the tab bar should be rendered.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum ShowTabBar {
@@ -15701,17 +15719,10 @@ impl Workspace {
             .as_ref(ctx)
             .active_block_session_id()
             .unwrap_or_default();
-        let mut paths = extract_paths_from_conversation(&source_conversation);
-        {
-            let history_model = history_model.as_ref(ctx);
-            for child_id in
-                descendant_conversation_ids_in_spawn_order(history_model, source_conversation.id())
-            {
-                if let Some(child_conversation) = history_model.conversation(&child_id) {
-                    paths.extend(extract_paths_from_conversation(child_conversation));
-                }
-            }
-        }
+        let mut paths = handoff_snapshot_paths_for_conversation_workset(
+            history_model.as_ref(ctx),
+            &source_conversation,
+        );
         if let Some(ref pwd) = source_pwd {
             if let Ok(sp) = StandardizedPath::try_new(pwd) {
                 paths.push(sp);

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -194,6 +194,10 @@ use crate::ai::blocklist::handoff::touched_repos::extract_paths_from_conversatio
 use crate::ai::blocklist::handoff::{HandoffLaunchAttachments, PendingCloudLaunch};
 use crate::ai::blocklist::history_model::{load_conversation_from_server, CloudConversationData};
 use crate::ai::blocklist::inline_action::code_diff_view::CodeDiffView;
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use crate::ai::blocklist::orchestration_topology::{
+    descendant_conversation_ids_in_spawn_order, has_in_progress_descendant_conversation,
+};
 use crate::ai::blocklist::suggested_agent_mode_workflow_modal::{
     SuggestedAgentModeWorkflowAndId, SuggestedAgentModeWorkflowModal,
     SuggestedAgentModeWorkflowModalEvent,
@@ -15326,6 +15330,31 @@ impl Workspace {
             }
         };
 
+        if source_conversation.as_ref().is_some_and(|conversation| {
+            has_in_progress_descendant_conversation(
+                BlocklistAIHistoryModel::as_ref(ctx),
+                conversation.id(),
+            )
+        }) {
+            if show_user_feedback {
+                Self::restore_source_handoff_draft(&source_view, launch, environment_id, ctx);
+                let window_id = ctx.window_id();
+                WorkspaceToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                    toast_stack.add_ephemeral_toast(
+                        DismissibleToast::error(
+                            "Hand off is disabled while child agents are in progress. Wait for them to finish, then try again."
+                                .to_owned(),
+                        ),
+                        window_id,
+                        ctx,
+                    );
+                });
+            } else {
+                Self::record_automatic_handoff_failed(intent, ctx);
+            }
+            return;
+        }
+
         // Chip, `&` Enter, and `/handoff` with no arg dispatch `launch: None`;
         // synthesize an empty `PendingCloudLaunch` so auto-submit fires. The
         // empty-prompt substitution happens in `build_handoff_spawn_request`.
@@ -15673,6 +15702,16 @@ impl Workspace {
             .active_block_session_id()
             .unwrap_or_default();
         let mut paths = extract_paths_from_conversation(&source_conversation);
+        {
+            let history_model = history_model.as_ref(ctx);
+            for child_id in
+                descendant_conversation_ids_in_spawn_order(history_model, source_conversation.id())
+            {
+                if let Some(child_conversation) = history_model.conversation(&child_id) {
+                    paths.extend(extract_paths_from_conversation(child_conversation));
+                }
+            }
+        }
         if let Some(ref pwd) = source_pwd {
             if let Ok(sp) = StandardizedPath::try_new(pwd) {
                 paths.push(sp);

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -1,7 +1,11 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use ai::agent::action::FileEdit;
 use ai::index::full_source_code_embedding::manager::CodebaseIndexManager;
 use ai::project_context::model::ProjectContextModel;
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use chrono::Local;
 use pane_group::{NotebookPane, PaneState, SplitPaneState, TerminalPaneId};
 use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::watcher::DirectoryWatcher;
@@ -17,12 +21,22 @@ use terminal::view::ActiveSessionState;
 use warp_editor::editor::NavigationKey;
 #[cfg(feature = "local_fs")]
 use warp_files::FileModel;
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use warp_util::standardized_path::StandardizedPath;
 use warpui::platform::WindowStyle;
-use warpui::{AddSingletonModel, App, ViewHandle};
+use warpui::{AddSingletonModel, App, EntityId, ViewHandle};
 use watcher::HomeDirectoryWatcher;
 
 use super::*;
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use crate::ai::agent::task::TaskId;
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use crate::ai::agent::{
+    AIAgentAction, AIAgentActionId, AIAgentActionType, AIAgentExchange, AIAgentExchangeId,
+    AIAgentOutput, AIAgentOutputMessage, AIAgentOutputMessageType, AIAgentOutputStatus,
+    FinishedAIAgentOutput, MessageId, Shared,
+};
 use crate::ai::agent_conversations_model::AgentConversationsModel;
 use crate::ai::agent_tips::AITipModel;
 use crate::ai::ambient_agents::github_auth_notifier::GitHubAuthNotifier;
@@ -32,6 +46,8 @@ use crate::ai::document::ai_document_model::AIDocumentModel;
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::ai::facts::manager::AIFactManager;
 use crate::ai::harness_availability::HarnessAvailabilityModel;
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+use crate::ai::llms::LLMId;
 use crate::ai::llms::LLMPreferences;
 use crate::ai::mcp::gallery::MCPGalleryManager;
 use crate::ai::mcp::templatable_manager::TemplatableMCPServerManager;
@@ -323,6 +339,93 @@ fn transferred_tab_workspace(
         )
     });
     workspace
+}
+
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+fn create_file_exchange(action_id: &str, path: &str) -> AIAgentExchange {
+    let action = AIAgentAction {
+        id: AIAgentActionId::from(action_id.to_string()),
+        task_id: TaskId::new(format!("task-{action_id}")),
+        action: AIAgentActionType::RequestFileEdits {
+            file_edits: vec![FileEdit::Create {
+                file: Some(path.to_string()),
+                content: Some(String::new()),
+            }],
+            title: None,
+        },
+        requires_result: false,
+    };
+    let output = AIAgentOutput {
+        messages: vec![AIAgentOutputMessage {
+            id: MessageId::new(format!("message-{action_id}")),
+            message: AIAgentOutputMessageType::Action(action),
+            citations: vec![],
+        }],
+        ..Default::default()
+    };
+
+    AIAgentExchange {
+        id: AIAgentExchangeId::new(),
+        input: vec![],
+        output_status: AIAgentOutputStatus::Finished {
+            finished_output: FinishedAIAgentOutput::Success {
+                output: Shared::new(output),
+            },
+        },
+        added_message_ids: HashSet::new(),
+        start_time: Local::now(),
+        finish_time: None,
+        time_to_first_token_ms: None,
+        working_directory: None,
+        model_id: LLMId::from("test-model"),
+        request_cost: None,
+        coding_model_id: LLMId::from("test-coding-model"),
+        cli_agent_model_id: LLMId::from("test-cli-agent-model"),
+        computer_use_model_id: LLMId::from("test-computer-use-model"),
+        response_initiator: None,
+    }
+}
+
+#[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
+#[test]
+fn handoff_snapshot_paths_include_loaded_child_conversations() {
+    App::test((), |mut app| async move {
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let terminal_view_id = EntityId::new();
+        let parent_path = "/tmp/warp-parent-workset/src/lib.rs";
+        let child_path = "/tmp/warp-child-workset/src/main.rs";
+
+        let snapshot_paths = history_model.update(&mut app, |history_model, ctx| {
+            let parent_id =
+                history_model.start_new_conversation(terminal_view_id, false, false, false, ctx);
+            let child_id =
+                history_model.start_new_conversation(terminal_view_id, false, false, false, ctx);
+            history_model.set_parent_for_conversation(child_id, parent_id);
+            history_model
+                .conversation_mut(&parent_id)
+                .expect("parent conversation exists")
+                .append_root_exchange_for_test(create_file_exchange("parent", parent_path));
+            history_model
+                .conversation_mut(&child_id)
+                .expect("child conversation exists")
+                .append_root_exchange_for_test(create_file_exchange("child", child_path));
+
+            let source_conversation = history_model
+                .conversation(&parent_id)
+                .expect("parent conversation exists")
+                .clone();
+            handoff_snapshot_paths_for_conversation_workset(history_model, &source_conversation)
+        });
+        let snapshot_paths = snapshot_paths.into_iter().collect::<HashSet<_>>();
+
+        assert_eq!(
+            snapshot_paths,
+            HashSet::from([
+                StandardizedPath::try_new(parent_path).expect("valid parent path"),
+                StandardizedPath::try_new(child_path).expect("valid child path"),
+            ])
+        );
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary
local to cloud handoff is not amazing for orchestrated conversations, as we don't bring the child or parent agents into the cloud conversation. We make the agent aware of this in the cloud handoff prompt, but it's still a bit borked in some cases.

The case where it's the most borked is when the child agent is still in progress, but the parent agent is moved to the cloud while the child agent is still trying to interact w/ it. The fix here is to disable handoff while child agents are in progress.

The other change bundled in here is to make sure we snapshot changes from all participants in the given orchestrated set of conversations (instead of just the parent) when handing off, so that any child agent work is preserved.

## Demo

https://www.loom.com/share/aa66467f088a4540b20b82f359731e9d
