### PR TITLE
Publish remote Agent Mode context snapshots

### DIFF
--- a/app/src/ai/skills/bundled.rs
+++ b/app/src/ai/skills/bundled.rs
@@ -308,7 +308,7 @@ impl BundledSkill {
 
     /// Iterates the catalog's definitions as `(id, skill, activation)`.
     /// Used by the daemon to serialize its catalog for the
-    /// `BundledSkillsSnapshot` push.
+    /// aggregate remote Agent Mode context snapshot.
     pub(crate) fn iter_definitions(
         &self,
     ) -> impl Iterator<Item = (&str, &ParsedSkill, &BundledSkillActivation)> {

--- a/app/src/ai/skills/dummy_skill_manager.rs
+++ b/app/src/ai/skills/dummy_skill_manager.rs
@@ -2,7 +2,9 @@ use ai::skills::{ParsedSkill, SkillPathOrigin, SkillProvider, SkillReference};
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warpui::{AppContext, Entity, ModelContext, SingletonEntity};
 
-use crate::ai::skills::{ActiveSkillLookupError, SkillDescriptor, SkillPathQuery};
+use crate::ai::skills::{
+    ActiveSkillLookupError, SkillDescriptor, SkillManagerEvent, SkillPathQuery,
+};
 
 pub struct SkillManager {}
 
@@ -86,7 +88,7 @@ impl SkillManager {
 }
 
 impl Entity for SkillManager {
-    type Event = ();
+    type Event = SkillManagerEvent;
 }
 
 impl SingletonEntity for SkillManager {}

--- a/app/src/ai/skills/mod.rs
+++ b/app/src/ai/skills/mod.rs
@@ -8,7 +8,7 @@ pub use telemetry::{SkillOpenOrigin, SkillTelemetryEvent};
 #[cfg(all(not(target_family = "wasm"), feature = "local_fs"))]
 mod remote;
 #[cfg(all(not(target_family = "wasm"), feature = "local_fs"))]
-pub(crate) use remote::{bundled_skills_snapshot_protos, wire_remote_bundled_skills};
+pub(crate) use remote::{bundled_skill_snapshot_protos, wire_remote_bundled_skills};
 #[cfg(feature = "local_fs")]
 mod bundled;
 #[cfg(all(not(target_family = "wasm"), feature = "local_fs"))]
@@ -24,6 +24,11 @@ cfg_if::cfg_if! {
 }
 
 pub use ai::skills::SkillReference;
+
+#[cfg_attr(target_family = "wasm", allow(dead_code))]
+pub enum SkillManagerEvent {
+    HomeSkillsChanged,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ActiveSkillLookupError {

--- a/app/src/ai/skills/remote.rs
+++ b/app/src/ai/skills/remote.rs
@@ -1,6 +1,6 @@
 use ai::skills::{parse_skill_content_at_location, SkillProvider, SkillScope};
 use remote_server::manager::{RemoteServerManager, RemoteServerManagerEvent};
-use remote_server::proto::BundledSkillProto;
+use remote_server::proto::{remote_skill_proto, BundledSkillMetadata, RemoteSkillProto};
 use warp_core::features::FeatureFlag;
 use warp_core::safe_warn;
 use warp_util::host_id::HostId;
@@ -23,7 +23,7 @@ impl SkillManager {
     fn subscribe_to_remote_bundled_skills(&mut self, ctx: &mut ModelContext<Self>) {
         let remote_server_manager = RemoteServerManager::handle(ctx);
         ctx.subscribe_to_model(&remote_server_manager, |me, _, event, _ctx| match event {
-            RemoteServerManagerEvent::BundledSkillsSnapshot { host_id, skills } => {
+            RemoteServerManagerEvent::RemoteAgentContextSnapshot { host_id, snapshot } => {
                 if !FeatureFlag::BundledSkills.is_enabled() {
                     return;
                 }
@@ -31,7 +31,7 @@ impl SkillManager {
                 // host (e.g. after a reconnect following a daemon upgrade).
                 me.set_remote_bundled_skill(
                     host_id.clone(),
-                    bundled_skill_from_protos(host_id, skills),
+                    bundled_skill_from_protos(host_id, &snapshot.skills),
                 );
             }
             RemoteServerManagerEvent::HostDisconnected { host_id } => {
@@ -74,7 +74,7 @@ impl SkillManager {
     }
 }
 
-/// Stable wire identifier for an MCP integration in [`BundledSkillProto`].
+/// Stable wire identifier for an MCP integration in [`BundledSkillMetadata`].
 fn mcp_integration_wire_id(integration: McpIntegration) -> &'static str {
     match integration {
         McpIntegration::Figma => "figma",
@@ -90,14 +90,17 @@ fn mcp_integration_from_wire_id(wire_id: &str) -> Option<McpIntegration> {
 
 /// Converts a daemon-pushed snapshot into a catalog whose skill paths are
 /// remote paths on `host_id`.
-fn bundled_skill_from_protos(host_id: &HostId, skills: &[BundledSkillProto]) -> BundledSkill {
+fn bundled_skill_from_protos(host_id: &HostId, skills: &[RemoteSkillProto]) -> BundledSkill {
     let definitions = skills.iter().filter_map(|proto| {
+        let remote_skill_proto::Source::Bundled(metadata) = proto.source.as_ref()? else {
+            return None;
+        };
         let path = match StandardizedPath::try_new(&proto.path) {
             Ok(path) => LocalOrRemotePath::Remote(RemotePath::new(host_id.clone(), path)),
             Err(_) => {
                 safe_warn!(
                     safe: ("Skipping bundled skill with an invalid remote path"),
-                    full: ("Skipping bundled skill {} with an invalid remote path: {}", proto.id, proto.path)
+                    full: ("Skipping bundled skill {} with an invalid remote path: {}", metadata.id, proto.path)
                 );
                 return None;
             }
@@ -114,12 +117,12 @@ fn bundled_skill_from_protos(host_id: &HostId, skills: &[BundledSkillProto]) -> 
             Err(err) => {
                 safe_warn!(
                     safe: ("Skipping bundled skill that failed to parse"),
-                    full: ("Skipping bundled skill {} that failed to parse: {err:#}", proto.id)
+                    full: ("Skipping bundled skill {} that failed to parse: {err:#}", metadata.id)
                 );
                 return None;
             }
         };
-        let activation = match proto.requires_mcp.as_deref() {
+        let activation = match metadata.requires_mcp.as_deref() {
             None => BundledSkillActivation::Always,
             Some(wire_id) => match mcp_integration_from_wire_id(wire_id) {
                 Some(integration) => BundledSkillActivation::RequiresMcp(integration),
@@ -128,25 +131,25 @@ fn bundled_skill_from_protos(host_id: &HostId, skills: &[BundledSkillProto]) -> 
                     // cannot evaluate the condition, so skip the skill.
                     safe_warn!(
                         safe: ("Skipping bundled skill with an unknown MCP integration"),
-                        full: ("Skipping bundled skill {} with an unknown MCP integration: {wire_id}", proto.id)
+                        full: ("Skipping bundled skill {} with an unknown MCP integration: {wire_id}", metadata.id)
                     );
                     return None;
                 }
             },
         };
-        Some((proto.id.clone(), skill, activation))
+        Some((metadata.id.clone(), skill, activation))
     });
     BundledSkill::from_definitions(definitions)
 }
 
-/// Serializes a daemon-side catalog for the `BundledSkillsSnapshot` push.
+/// Serializes a daemon-side bundled catalog for the aggregate remote Agent Mode snapshot.
 ///
 /// `RequiresFile` activations are evaluated here — the daemon owns the
 /// files — so the client only ever receives `Always` or `RequiresMcp`
-/// conditions. The result is sorted by skill ID so pushes are
+/// conditions. The result is sorted by skill path so pushes are
 /// deterministic across daemon restarts.
-pub(crate) fn bundled_skills_snapshot_protos(catalog: &BundledSkill) -> Vec<BundledSkillProto> {
-    let mut protos: Vec<BundledSkillProto> = catalog
+pub(crate) fn bundled_skill_snapshot_protos(catalog: &BundledSkill) -> Vec<RemoteSkillProto> {
+    let mut protos: Vec<RemoteSkillProto> = catalog
         .iter_definitions()
         .filter_map(|(id, skill, activation)| {
             let requires_mcp = match activation {
@@ -167,17 +170,17 @@ pub(crate) fn bundled_skills_snapshot_protos(catalog: &BundledSkill) -> Vec<Bund
                     None
                 }
             };
-            Some(BundledSkillProto {
-                id: id.to_owned(),
-                name: skill.name.clone(),
-                description: skill.description.clone(),
+            Some(RemoteSkillProto {
                 path: skill.path.display_path(),
                 content: skill.content.clone(),
-                requires_mcp,
+                source: Some(remote_skill_proto::Source::Bundled(BundledSkillMetadata {
+                    id: id.to_owned(),
+                    requires_mcp,
+                })),
             })
         })
         .collect();
-    protos.sort_by(|a, b| a.id.cmp(&b.id));
+    protos.sort_by(|a, b| a.path.cmp(&b.path));
     protos
 }
 

--- a/app/src/ai/skills/remote_tests.rs
+++ b/app/src/ai/skills/remote_tests.rs
@@ -15,6 +15,28 @@ fn daemon_skill(id: &str, content: &str) -> ParsedSkill {
     }
 }
 
+fn bundled_metadata(proto: &RemoteSkillProto) -> &BundledSkillMetadata {
+    let Some(remote_skill_proto::Source::Bundled(metadata)) = proto.source.as_ref() else {
+        panic!("expected bundled skill metadata");
+    };
+    metadata
+}
+
+fn bundled_skill_proto(
+    id: &str,
+    path: &str,
+    content: &str,
+    requires_mcp: Option<&str>,
+) -> RemoteSkillProto {
+    RemoteSkillProto {
+        path: path.to_string(),
+        content: content.to_string(),
+        source: Some(remote_skill_proto::Source::Bundled(BundledSkillMetadata {
+            id: id.to_string(),
+            requires_mcp: requires_mcp.map(str::to_string),
+        })),
+    }
+}
 #[test]
 fn snapshot_protos_serialize_activation_conditions() {
     let temp_dir = TempDir::new().unwrap();
@@ -45,26 +67,35 @@ fn snapshot_protos_serialize_activation_conditions() {
         ),
     ]);
 
-    let mut protos = bundled_skills_snapshot_protos(&catalog);
-    protos.sort_by(|a, b| a.id.cmp(&b.id));
+    let protos = bundled_skill_snapshot_protos(&catalog);
 
     // `RequiresFile` is evaluated daemon-side: the missing-file skill is
     // dropped, the present-file skill ships as unconditionally active.
-    let ids: Vec<&str> = protos.iter().map(|proto| proto.id.as_str()).collect();
+    let mut ids: Vec<&str> = protos
+        .iter()
+        .map(|proto| bundled_metadata(proto).id.as_str())
+        .collect();
+    ids.sort_unstable();
     assert_eq!(ids, ["always-skill", "figma-skill", "file-present-skill"]);
 
     let figma = protos
         .iter()
-        .find(|proto| proto.id == "figma-skill")
+        .find(|proto| bundled_metadata(proto).id == "figma-skill")
         .unwrap();
-    assert_eq!(figma.requires_mcp.as_deref(), Some("figma"));
-    for proto in protos.iter().filter(|proto| proto.id != "figma-skill") {
-        assert_eq!(proto.requires_mcp, None);
+    assert_eq!(
+        bundled_metadata(figma).requires_mcp.as_deref(),
+        Some("figma")
+    );
+    for proto in protos
+        .iter()
+        .filter(|proto| bundled_metadata(proto).id != "figma-skill")
+    {
+        assert_eq!(bundled_metadata(proto).requires_mcp, None);
     }
 
     let always = protos
         .iter()
-        .find(|proto| proto.id == "always-skill")
+        .find(|proto| bundled_metadata(proto).id == "always-skill")
         .unwrap();
     assert_eq!(always.path, "/daemon/bundled/skills/always-skill/SKILL.md");
     assert_eq!(always.content, "# always");
@@ -74,41 +105,28 @@ fn snapshot_protos_serialize_activation_conditions() {
 fn bundled_skill_from_protos_builds_host_scoped_catalog() {
     let host_id = HostId::new("remote-host".to_string());
     let protos = vec![
-        BundledSkillProto {
-            id: "test-skill".to_string(),
-            name: "ignored".to_string(),
-            description: "ignored".to_string(),
-            path: "/remote/bundled/skills/test-skill/SKILL.md".to_string(),
-            content: "---\nname: test-skill\ndescription: A test skill\n---\nbody".to_string(),
-            requires_mcp: None,
-        },
-        BundledSkillProto {
-            id: "figma-skill".to_string(),
-            name: "figma-skill".to_string(),
-            description: "Figma helper".to_string(),
-            path: "/remote/bundled/skills/figma-skill/SKILL.md".to_string(),
-            content: "# figma".to_string(),
-            requires_mcp: Some("figma".to_string()),
-        },
+        bundled_skill_proto(
+            "test-skill",
+            "/remote/bundled/skills/test-skill/SKILL.md",
+            "---\nname: test-skill\ndescription: A test skill\n---\nbody",
+            None,
+        ),
+        bundled_skill_proto(
+            "figma-skill",
+            "/remote/bundled/skills/figma-skill/SKILL.md",
+            "# figma",
+            Some("figma"),
+        ),
         // Unknown integration (e.g. a newer daemon): the client cannot
         // evaluate the condition, so the skill is skipped.
-        BundledSkillProto {
-            id: "unknown-mcp-skill".to_string(),
-            name: "unknown-mcp-skill".to_string(),
-            description: "Unknown".to_string(),
-            path: "/remote/bundled/skills/unknown-mcp-skill/SKILL.md".to_string(),
-            content: "# unknown".to_string(),
-            requires_mcp: Some("not-a-real-integration".to_string()),
-        },
+        bundled_skill_proto(
+            "unknown-mcp-skill",
+            "/remote/bundled/skills/unknown-mcp-skill/SKILL.md",
+            "# unknown",
+            Some("not-a-real-integration"),
+        ),
         // Invalid (relative) path: skipped.
-        BundledSkillProto {
-            id: "bad-path-skill".to_string(),
-            name: "bad-path-skill".to_string(),
-            description: "Bad path".to_string(),
-            path: "relative/SKILL.md".to_string(),
-            content: "# bad".to_string(),
-            requires_mcp: None,
-        },
+        bundled_skill_proto("bad-path-skill", "relative/SKILL.md", "# bad", None),
     ];
 
     let catalog = bundled_skill_from_protos(&host_id, &protos);

--- a/app/src/ai/skills/skill_manager.rs
+++ b/app/src/ai/skills/skill_manager.rs
@@ -3,7 +3,9 @@ mod file_watchers;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use ai::skills::{provider_rank, ParsedSkill, SkillPathOrigin, SkillProvider, SkillReference};
+use ai::skills::{
+    provider_rank, ParsedSkill, SkillPathOrigin, SkillProvider, SkillReference, SkillScope,
+};
 pub use file_watchers::{
     extract_skill_parent_directory, read_skills_from_directories, SkillWatcher, SkillWatcherEvent,
 };
@@ -18,7 +20,7 @@ use super::bundled::{
     BundledSkillActivation,
 };
 use super::bundled::{BundledSkill, BundledSkills};
-use super::{ActiveSkillLookupError, SkillDescriptor, SkillPathQuery};
+use super::{ActiveSkillLookupError, SkillDescriptor, SkillManagerEvent, SkillPathQuery};
 use crate::ai::skills::skill_utils::unique_skills;
 
 pub struct SkillManager {
@@ -55,8 +57,8 @@ impl SkillManager {
 
         ctx.spawn_stream_local(
             skill_watcher_rx,
-            |me, message, _ctx| {
-                me.handle_skill_watcher_event(message);
+            |me, message, ctx| {
+                me.handle_skill_watcher_event(message, ctx);
             },
             |_, _| {}, // No cleanup needed when stream ends
         );
@@ -202,6 +204,16 @@ impl SkillManager {
             .get(&LocalOrRemotePath::Local(home_dir))
             .map(|skills| skills.iter().cloned().collect())
             .unwrap_or_default()
+    }
+
+    /// Returns the parsed home skills currently cached by the local watcher.
+    pub fn home_skills(&self) -> impl Iterator<Item = &ParsedSkill> + '_ {
+        dirs::home_dir()
+            .map(LocalOrRemotePath::Local)
+            .into_iter()
+            .filter_map(|home_dir| self.directory_skills.get(&home_dir))
+            .flatten()
+            .filter_map(|path| self.skills_by_path.get(path))
     }
 
     /// Returns the currently-known directories which have skills registered.
@@ -406,7 +418,22 @@ impl SkillManager {
         self.bundled_skills.remove_remote(host_id);
     }
 
-    fn handle_skill_watcher_event(&mut self, event: SkillWatcherEvent) {
+    fn handle_skill_watcher_event(
+        &mut self,
+        event: SkillWatcherEvent,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let home_skills_changed = match &event {
+            SkillWatcherEvent::SkillsAdded { skills } => {
+                skills.iter().any(|skill| skill.scope == SkillScope::Home)
+            }
+            SkillWatcherEvent::SkillsDeleted { paths } => paths.iter().any(|path| {
+                self.skills_by_path.values().any(|skill| {
+                    skill.scope == SkillScope::Home
+                        && (skill.path.starts_with(path) || path.starts_with(&skill.path))
+                })
+            }),
+        };
         match event {
             SkillWatcherEvent::SkillsAdded { skills } => {
                 self.handle_skills_added(skills);
@@ -414,6 +441,9 @@ impl SkillManager {
             SkillWatcherEvent::SkillsDeleted { paths } => {
                 self.handle_skills_deleted(paths);
             }
+        }
+        if home_skills_changed {
+            ctx.emit(SkillManagerEvent::HomeSkillsChanged);
         }
     }
 
@@ -523,7 +553,7 @@ fn is_home_directory(path: &LocalOrRemotePath) -> bool {
 }
 
 impl Entity for SkillManager {
-    type Event = ();
+    type Event = SkillManagerEvent;
 }
 
 impl SingletonEntity for SkillManager {}

--- a/app/src/remote_server/codebase_index_model.rs
+++ b/app/src/remote_server/codebase_index_model.rs
@@ -451,7 +451,7 @@ impl RemoteCodebaseIndexModel {
             RemoteServerManagerEvent::SessionConnecting { .. }
             | RemoteServerManagerEvent::SessionConnectionFailed { .. }
             | RemoteServerManagerEvent::HostConnected { .. }
-            | RemoteServerManagerEvent::BundledSkillsSnapshot { .. }
+            | RemoteServerManagerEvent::RemoteAgentContextSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
             | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }

--- a/app/src/remote_server/server_model.rs
+++ b/app/src/remote_server/server_model.rs
@@ -10,6 +10,7 @@ use ::ai::index::full_source_code_embedding::manager::{
 use ::ai::index::full_source_code_embedding::{
     ContentHash, FragmentMetadata as LocalFragmentMetadata, NodeHash,
 };
+use ::ai::project_context::model::{ProjectContextModel, ProjectContextModelEvent};
 use remote_server::proto::OpenBufferSuccess;
 use repo_metadata::repositories::{DetectedRepositories, RepoDetectionSource};
 use repo_metadata::{RepoMetadataEvent, RepoMetadataModel, RepositoryIdentifier};
@@ -36,15 +37,14 @@ use super::proto::{
     client_message, delete_file_response, discard_files_response, get_diff_state_response,
     get_fragment_metadata_from_hash_response, git_commit_chain_response, git_create_pr_response,
     git_generate_commit_message_response, git_get_committed_branch_files_response,
-    git_push_response, host_scoped_request, notification, resolve_conflict_response,
-    run_command_response, save_buffer_response, server_message, session_scoped_request,
-    write_file_response, Abort, Authenticate, BranchInfo, BufferEdit, BufferUpdatedPush,
-    BundledSkillProto, BundledSkillsSnapshot, ClientMessage, CloseBuffer, CodebaseIndexLimits,
-    CodebaseIndexStatus, CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot,
-    CodebaseResyncMode, DeleteFile, DeleteFileResponse, DeleteFileSuccess, DiscardFilesError,
-    DiscardFilesResponse, DiscardFilesSuccess, DropCodebaseIndex, ErrorCode, ErrorResponse,
-    FailedFileRead, FileContextProto, FileOperationError,
-    FragmentMetadata as ProtoFragmentMetadata,
+    git_push_response, host_scoped_request, notification, remote_skill_proto,
+    resolve_conflict_response, run_command_response, save_buffer_response, server_message,
+    session_scoped_request, write_file_response, Abort, Authenticate, BranchInfo, BufferEdit,
+    BufferUpdatedPush, ClientMessage, CloseBuffer, CodebaseIndexLimits, CodebaseIndexStatus,
+    CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, CodebaseResyncMode, DeleteFile,
+    DeleteFileResponse, DeleteFileSuccess, DiscardFilesError, DiscardFilesResponse,
+    DiscardFilesSuccess, DropCodebaseIndex, ErrorCode, ErrorResponse, FailedFileRead,
+    FileContextProto, FileOperationError, FragmentMetadata as ProtoFragmentMetadata,
     FragmentMetadataLookupError as ProtoFragmentMetadataLookupError,
     FragmentMetadataLookupErrorCode, GetBranchesError, GetBranchesResponse, GetBranchesSuccess,
     GetDiffStateResponse, GetFragmentMetadataFromHash, GetFragmentMetadataFromHashResponse,
@@ -53,14 +53,15 @@ use super::proto::{
     GitGenerateCommitMessageRequest, GitGenerateCommitMessageResponse,
     GitGetCommittedBranchFilesRequest, GitGetCommittedBranchFilesResponse,
     GitGetCommittedBranchFilesSuccess, GitHubPrInfoPush, GitHubRepositoryInfoPush, GitOpDelta,
-    GitOpError, GitPushRequest, GitPushResponse, GitStatusPush, IndexCodebase, Initialize,
-    InitializeResponse, MissingFragmentMetadata, NavigatedToDirectory,
+    GitOpError, GitPushRequest, GitPushResponse, GitStatusPush, HomeSkillMetadata, IndexCodebase,
+    Initialize, InitializeResponse, MissingFragmentMetadata, NavigatedToDirectory,
     NavigatedToDirectoryResponse, OpenBuffer, OpenBufferResponse, ReadFileContextResponse,
-    ResolveConflict, ResolveConflictResponse, ResolveConflictSuccess, ResyncCodebase,
-    RipgrepSearchRequest, RunCommandError, RunCommandErrorCode, RunCommandRequest,
-    RunCommandResponse, RunCommandSuccess, SaveBuffer, SaveBufferResponse, SaveBufferSuccess,
-    ServerMessage, SessionBootstrapped, TextEdit, UpdateGitHubPrInfo, UpdateGitHubRepoInfo,
-    UpdateGitStatus, UploadHandoffSnapshot, WriteFile, WriteFileResponse, WriteFileSuccess,
+    RemoteAgentContextSnapshot, RemoteContextFileProto, RemoteSkillProto, ResolveConflict,
+    ResolveConflictResponse, ResolveConflictSuccess, ResyncCodebase, RipgrepSearchRequest,
+    RunCommandError, RunCommandErrorCode, RunCommandRequest, RunCommandResponse, RunCommandSuccess,
+    SaveBuffer, SaveBufferResponse, SaveBufferSuccess, ServerMessage, SessionBootstrapped,
+    TextEdit, UpdateGitHubPrInfo, UpdateGitHubRepoInfo, UpdateGitStatus, UploadHandoffSnapshot,
+    WriteFile, WriteFileResponse, WriteFileSuccess,
 };
 use super::server_buffer_tracker::{PendingBufferRequestKind, ServerBufferTracker};
 use super::{diff_state_proto, ripgrep_search};
@@ -86,7 +87,9 @@ use super::protocol::RequestId;
 use crate::ai::agent::FileLocations;
 use crate::ai::blocklist::handoff::snapshot::upload_result_to_proto;
 use crate::ai::blocklist::{read_local_file_context, ReadFileContextResult};
-use crate::ai::skills::{bundled_skills_snapshot_protos, BundledSkill};
+use crate::ai::skills::{
+    bundled_skill_snapshot_protos, BundledSkill, SkillManager, SkillManagerEvent,
+};
 use crate::auth::auth_state::{AuthState, AuthStateProvider};
 use crate::code_review::git_actions;
 use crate::features::FeatureFlag;
@@ -109,6 +112,40 @@ fn daemon_bundled_resources_dir() -> Option<PathBuf> {
     let suffix = dir.strip_prefix("~/")?;
     let dir = dirs::home_dir()?.join(suffix);
     dir.is_dir().then_some(dir)
+}
+fn remote_agent_context_snapshot(
+    revision: u64,
+    bundled_skills: &[RemoteSkillProto],
+    ctx: &warpui::AppContext,
+) -> RemoteAgentContextSnapshot {
+    let home_dir = dirs::home_dir()
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let mut skills = bundled_skills.to_vec();
+    skills.extend(
+        SkillManager::as_ref(ctx)
+            .home_skills()
+            .map(|skill| RemoteSkillProto {
+                path: skill.path.display_path(),
+                content: skill.content.clone(),
+                source: Some(remote_skill_proto::Source::Home(HomeSkillMetadata {})),
+            }),
+    );
+    skills.sort_by(|a, b| a.path.cmp(&b.path));
+    let mut global_rules = ProjectContextModel::as_ref(ctx)
+        .global_rules()
+        .map(|rule| RemoteContextFileProto {
+            path: rule.path.display_path(),
+            content: rule.content,
+        })
+        .collect::<Vec<_>>();
+    global_rules.sort_by(|a, b| a.path.cmp(&b.path));
+    RemoteAgentContextSnapshot {
+        revision,
+        home_dir,
+        skills,
+        global_rules,
+    }
 }
 
 /// Outcome of dispatching a request-style `ClientMessage`.
@@ -251,16 +288,12 @@ pub struct ServerModel {
     /// Returned in every `InitializeResponse` so clients can deduplicate
     /// host-scoped models.
     host_id: String,
-    /// The bundled skill catalog, pre-parsed and serialized for the
-    /// `BundledSkillsSnapshot` push. `None` until startup parsing completes
-    /// (or forever, when the global resources directory is absent).
-    bundled_skills: Option<Vec<BundledSkillProto>>,
-    /// Connections that have already received the `BundledSkillsSnapshot`
-    /// push, either from the parse-completion broadcast or during their
-    /// `Initialize` handshake. Prevents a duplicate push when parsing
-    /// completes between a connection registering its sender and its
-    /// `Initialize` being handled.
-    bundled_skills_sent: HashSet<ConnectionId>,
+    /// Bundled skill source entries detected and rendered on the daemon.
+    bundled_skills: Vec<RemoteSkillProto>,
+    /// Latest revisioned full replacement of all daemon-host Agent Mode context.
+    remote_agent_context_snapshot: RemoteAgentContextSnapshot,
+    /// Connections that have already received the current snapshot revision.
+    remote_agent_context_snapshot_sent: HashSet<ConnectionId>,
     /// Per-session command executors created from `SessionBootstrapped` notifications.
     executors: HashMap<SessionId, Arc<LocalCommandExecutor>>,
     /// Tracks in-flight file write/delete operations and handles cleanup.
@@ -311,14 +344,17 @@ impl ServerModel {
             std::process::id(),
             host_id
         );
+        let bundled_skills = Vec::new();
+        let remote_agent_context_snapshot = remote_agent_context_snapshot(1, &bundled_skills, ctx);
         let mut model = Self {
             connection_senders: HashMap::new(),
             snapshot_sent_roots_by_connection: HashMap::new(),
             grace_timer_cancel: None,
             in_progress: HashMap::new(),
             host_id,
-            bundled_skills: None,
-            bundled_skills_sent: HashSet::new(),
+            bundled_skills,
+            remote_agent_context_snapshot,
+            remote_agent_context_snapshot_sent: HashSet::new(),
             executors: HashMap::new(),
             pending_file_ops: PendingFileOps::new(),
             auth_state: AuthStateProvider::as_ref(ctx).get().clone(),
@@ -648,6 +684,24 @@ impl ServerModel {
                 }
             });
         }
+        {
+            let skill_manager = SkillManager::handle(ctx);
+            ctx.subscribe_to_model(&skill_manager, |me, _, event, ctx| match event {
+                SkillManagerEvent::HomeSkillsChanged => {
+                    me.refresh_remote_agent_context_snapshot(ctx);
+                }
+            });
+        }
+        {
+            let project_context = ProjectContextModel::handle(ctx);
+            ctx.subscribe_to_model(&project_context, |me, _, event, ctx| match event {
+                ProjectContextModelEvent::GlobalRulesChanged(_) => {
+                    me.refresh_remote_agent_context_snapshot(ctx);
+                }
+                ProjectContextModelEvent::PathIndexed
+                | ProjectContextModelEvent::KnownRulesChanged(_) => {}
+            });
+        }
         // Subscribe to diff state manager events — convert domain dispatches
         // to proto messages and send them to connected clients.
         {
@@ -666,11 +720,11 @@ impl ServerModel {
         if let Some(resources_dir) = daemon_bundled_resources_dir() {
             ctx.spawn(
                 BundledSkill::detect_in_resources_dir(resources_dir),
-                |me, catalog, _| {
-                    let skills = bundled_skills_snapshot_protos(&catalog);
+                |me, catalog, ctx| {
+                    let skills = bundled_skill_snapshot_protos(&catalog);
                     log::info!("Daemon parsed {} bundled skills", skills.len());
-                    me.bundled_skills = Some(skills);
-                    me.broadcast_bundled_skills_snapshot();
+                    me.bundled_skills = skills;
+                    me.refresh_remote_agent_context_snapshot(ctx);
                 },
             );
         } else {
@@ -688,38 +742,40 @@ impl ServerModel {
         model
     }
 
-    /// Broadcasts the parsed bundled skill catalog to all connections.
-    /// No-op until startup parsing has completed.
-    fn broadcast_bundled_skills_snapshot(&mut self) {
-        let Some(skills) = self.bundled_skills.clone() else {
-            return;
-        };
+    fn refresh_remote_agent_context_snapshot(&mut self, ctx: &warpui::AppContext) {
+        let revision = self
+            .remote_agent_context_snapshot
+            .revision
+            .saturating_add(1);
+        self.remote_agent_context_snapshot =
+            remote_agent_context_snapshot(revision, &self.bundled_skills, ctx);
+        self.broadcast_remote_agent_context_snapshot();
+    }
+
+    fn broadcast_remote_agent_context_snapshot(&mut self) {
         self.send_server_message(
             None,
             None,
-            server_message::Message::BundledSkillsSnapshot(BundledSkillsSnapshot { skills }),
+            server_message::Message::RemoteAgentContextSnapshot(
+                self.remote_agent_context_snapshot.clone(),
+            ),
         );
-        self.bundled_skills_sent
+        self.remote_agent_context_snapshot_sent
             .extend(self.connection_senders.keys().copied());
     }
 
-    /// Pushes the parsed bundled skill catalog to a single connection.
-    /// No-op until startup parsing has completed, or when the catalog was
-    /// already delivered to this connection (e.g. it registered before the
-    /// parse-completion broadcast fired).
-    fn send_bundled_skills_snapshot_to_connection(&mut self, conn_id: ConnectionId) {
-        if self.bundled_skills_sent.contains(&conn_id) {
+    fn send_remote_agent_context_snapshot_to_connection(&mut self, conn_id: ConnectionId) {
+        if self.remote_agent_context_snapshot_sent.contains(&conn_id) {
             return;
         }
-        let Some(skills) = self.bundled_skills.clone() else {
-            return;
-        };
         self.send_server_message(
             Some(conn_id),
             None,
-            server_message::Message::BundledSkillsSnapshot(BundledSkillsSnapshot { skills }),
+            server_message::Message::RemoteAgentContextSnapshot(
+                self.remote_agent_context_snapshot.clone(),
+            ),
         );
-        self.bundled_skills_sent.insert(conn_id);
+        self.remote_agent_context_snapshot_sent.insert(conn_id);
     }
 
     /// Called when a proxy connects.  Inserts `conn_tx` into the connection
@@ -749,7 +805,7 @@ impl ServerModel {
     /// and starts the grace timer if no connections remain.
     pub fn deregister_connection(&mut self, conn_id: ConnectionId, ctx: &mut ModelContext<Self>) {
         self.snapshot_sent_roots_by_connection.remove(&conn_id);
-        self.bundled_skills_sent.remove(&conn_id);
+        self.remote_agent_context_snapshot_sent.remove(&conn_id);
         // Guard against double-deregister (reader and writer tasks both call
         // this on connection close; the second call must be a safe no-op).
         if self.connection_senders.remove(&conn_id).is_none() {
@@ -1563,11 +1619,9 @@ impl ServerModel {
 
     /// Handles `Initialize` by returning the server version and host id.
     ///
-    /// Also configures Sentry crash reporting based on the user's identity
-    /// and preferences supplied by the connecting client, and sends the
-    /// bundled skill catalog to the initializing connection when startup
-    /// parsing has already completed (otherwise the parse-completion
-    /// broadcast delivers it).
+    /// Also configures Sentry crash reporting based on the user's identity and
+    /// preferences supplied by the connecting client, and sends the latest
+    /// remote Agent Mode context snapshot to the initializing connection.
     #[cfg_attr(not(feature = "crash_reporting"), allow(unused_variables))]
     fn handle_initialize(
         &mut self,
@@ -1593,13 +1647,9 @@ impl ServerModel {
             }
         }
 
-        // Push the bundled skill catalog to this connection if it is already
-        // parsed and the parse-completion broadcast didn't already deliver it
-        // (parsing can complete between this connection registering its
-        // sender and its `Initialize` being handled). Enqueued on the same
-        // channel as the response below, so the client buffers it as a push
-        // event during the handshake.
-        self.send_bundled_skills_snapshot_to_connection(conn_id);
+        // Enqueued on the same channel as the response below, so the client
+        // buffers it as a push event during the handshake.
+        self.send_remote_agent_context_snapshot_to_connection(conn_id);
 
         let server_version = ChannelState::app_version().unwrap_or("").to_string();
         HandlerOutcome::Sync(server_message::Message::InitializeResponse(

--- a/app/src/remote_server/server_model_tests.rs
+++ b/app/src/remote_server/server_model_tests.rs
@@ -6,8 +6,9 @@ use warpui::App;
 
 use super::super::diff_state_tracker::RemoteDiffStateManager;
 use super::super::proto::{
-    server_message, write_file_response, Authenticate, BundledSkillProto, Initialize,
-    ServerMessage, WriteFileResponse, WriteFileSuccess,
+    remote_skill_proto, server_message, write_file_response, Authenticate, BundledSkillMetadata,
+    HomeSkillMetadata, Initialize, RemoteAgentContextSnapshot, RemoteContextFileProto,
+    RemoteSkillProto, ServerMessage, WriteFileResponse, WriteFileSuccess,
 };
 use super::super::protocol::RequestId;
 use super::super::server_buffer_tracker::ServerBufferTracker;
@@ -23,8 +24,14 @@ fn test_model(app: &mut App) -> ServerModel {
         grace_timer_cancel: None,
         in_progress: HashMap::new(),
         host_id: "test-host-id".to_string(),
-        bundled_skills: None,
-        bundled_skills_sent: HashSet::new(),
+        bundled_skills: Vec::new(),
+        remote_agent_context_snapshot: RemoteAgentContextSnapshot {
+            revision: 1,
+            home_dir: "/home/user".to_string(),
+            skills: Vec::new(),
+            global_rules: Vec::new(),
+        },
+        remote_agent_context_snapshot_sent: HashSet::new(),
         executors: HashMap::new(),
         pending_file_ops: PendingFileOps::new(),
         auth_state: Arc::new(AuthState::new_logged_out_for_test()),
@@ -47,96 +54,76 @@ fn test_key(repo: &str, mode: DiffMode) -> DiffModelKey {
     }
 }
 
-fn test_bundled_skill_proto(id: &str) -> BundledSkillProto {
-    BundledSkillProto {
-        id: id.to_string(),
-        name: id.to_string(),
-        description: format!("{id} description"),
+fn test_bundled_skill_proto(id: &str) -> RemoteSkillProto {
+    RemoteSkillProto {
         path: format!(
             "/home/user/.warp/remote-server/bundled_resources/bundled/skills/{id}/SKILL.md"
         ),
         content: format!("# {id}"),
-        requires_mcp: None,
+        source: Some(remote_skill_proto::Source::Bundled(BundledSkillMetadata {
+            id: id.to_string(),
+            requires_mcp: None,
+        })),
     }
 }
 
-/// Parse completion broadcasts the catalog to every connection.
 #[test]
-fn bundled_skills_broadcast_reaches_all_connections() {
-    App::test((), |mut app| async move {
-        let mut model = test_model(&mut app);
-        let (first_tx, first_rx) = async_channel::unbounded();
-        let (second_tx, second_rx) = async_channel::unbounded();
-        model
-            .connection_senders
-            .insert(uuid::Uuid::new_v4(), first_tx);
-        model
-            .connection_senders
-            .insert(uuid::Uuid::new_v4(), second_tx);
-
-        // Before parsing completes the broadcast is a no-op.
-        model.broadcast_bundled_skills_snapshot();
-        assert!(first_rx.try_recv().is_err());
-
-        model.bundled_skills = Some(vec![test_bundled_skill_proto("test-skill")]);
-        model.broadcast_bundled_skills_snapshot();
-
-        for rx in [first_rx, second_rx] {
-            let msg = rx.try_recv().expect("connection should receive snapshot");
-            assert!(msg.request_id.is_empty(), "snapshot must be a push message");
-            match msg.message {
-                Some(server_message::Message::BundledSkillsSnapshot(snapshot)) => {
-                    assert_eq!(snapshot.skills.len(), 1);
-                    assert_eq!(snapshot.skills[0].id, "test-skill");
-                }
-                other => panic!("expected BundledSkillsSnapshot, got {other:?}"),
-            }
-        }
-    });
-}
-
-/// A connection can register its sender before its `Initialize` is handled.
-/// When parsing completes in that window, the parse-completion broadcast
-/// delivers the catalog; the `Initialize` push must not deliver it again.
-#[test]
-fn initialize_after_broadcast_does_not_resend_bundled_skills() {
+fn remote_agent_context_snapshot_broadcasts_replacements_and_initializes_once() {
     App::test((), |mut app| async move {
         let mut model = test_model(&mut app);
         let conn = uuid::Uuid::new_v4();
         let (tx, rx) = async_channel::unbounded();
         model.connection_senders.insert(conn, tx);
 
-        // Initialize handled before parsing completes: nothing to send.
-        model.send_bundled_skills_snapshot_to_connection(conn);
-        assert!(rx.try_recv().is_err());
-
-        // Parsing completes and the broadcast reaches the registered connection.
-        model.bundled_skills = Some(vec![test_bundled_skill_proto("test-skill")]);
-        model.broadcast_bundled_skills_snapshot();
+        model.send_remote_agent_context_snapshot_to_connection(conn);
         assert!(matches!(
             rx.try_recv().map(|msg| msg.message),
-            Ok(Some(server_message::Message::BundledSkillsSnapshot(_)))
+            Ok(Some(server_message::Message::RemoteAgentContextSnapshot(_)))
         ));
+        model.send_remote_agent_context_snapshot_to_connection(conn);
+        assert!(rx.try_recv().is_err());
 
-        // The connection's Initialize is handled after the broadcast: the
-        // catalog must not be delivered a second time.
-        model.send_bundled_skills_snapshot_to_connection(conn);
-        assert!(
-            rx.try_recv().is_err(),
-            "snapshot must not be re-sent to a connection that already received the broadcast"
-        );
+        model.remote_agent_context_snapshot = RemoteAgentContextSnapshot {
+            revision: 2,
+            home_dir: "/home/user".to_string(),
+            skills: vec![
+                test_bundled_skill_proto("test-skill"),
+                RemoteSkillProto {
+                    path: "/home/user/.agents/skills/test/SKILL.md".to_string(),
+                    content: "skill content".to_string(),
+                    source: Some(remote_skill_proto::Source::Home(HomeSkillMetadata {})),
+                },
+            ],
+            global_rules: vec![RemoteContextFileProto {
+                path: "/home/user/.agents/AGENTS.md".to_string(),
+                content: "rule content".to_string(),
+            }],
+        };
+        model.broadcast_remote_agent_context_snapshot();
 
-        // A connection that initializes after the broadcast still receives
-        // the catalog exactly once.
+        match rx
+            .try_recv()
+            .expect("remote Agent Mode context replacement")
+            .message
+        {
+            Some(server_message::Message::RemoteAgentContextSnapshot(snapshot)) => {
+                assert_eq!(snapshot.revision, 2);
+                assert_eq!(snapshot.skills.len(), 2);
+                assert_eq!(snapshot.skills[1].content, "skill content");
+                assert_eq!(snapshot.global_rules[0].content, "rule content");
+            }
+            other => panic!("expected RemoteAgentContextSnapshot, got {other:?}"),
+        }
+
         let late_conn = uuid::Uuid::new_v4();
         let (late_tx, late_rx) = async_channel::unbounded();
         model.connection_senders.insert(late_conn, late_tx);
-        model.send_bundled_skills_snapshot_to_connection(late_conn);
+        model.send_remote_agent_context_snapshot_to_connection(late_conn);
         assert!(matches!(
             late_rx.try_recv().map(|msg| msg.message),
-            Ok(Some(server_message::Message::BundledSkillsSnapshot(_)))
+            Ok(Some(server_message::Message::RemoteAgentContextSnapshot(_)))
         ));
-        model.send_bundled_skills_snapshot_to_connection(late_conn);
+        model.send_remote_agent_context_snapshot_to_connection(late_conn);
         assert!(late_rx.try_recv().is_err());
     });
 }

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -169,7 +169,7 @@ impl Sessions {
                 | RemoteServerManagerEvent::SessionConnectionFailed { .. }
                 | RemoteServerManagerEvent::HostConnected { .. }
                 | RemoteServerManagerEvent::HostDisconnected { .. }
-                | RemoteServerManagerEvent::BundledSkillsSnapshot { .. }
+                | RemoteServerManagerEvent::RemoteAgentContextSnapshot { .. }
                 | RemoteServerManagerEvent::NavigatedToDirectory { .. }
                 | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
                 | RemoteServerManagerEvent::RepoMetadataUpdated { .. }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4733,7 +4733,7 @@ impl TerminalView {
                     }
                     RemoteServerManagerEvent::SessionConnecting { .. }
                     | RemoteServerManagerEvent::HostConnected { .. }
-                    | RemoteServerManagerEvent::BundledSkillsSnapshot { .. }
+                    | RemoteServerManagerEvent::RemoteAgentContextSnapshot { .. }
                     | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
                     | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
                     | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }

--- a/app/src/terminal/writeable_pty/remote_server_controller.rs
+++ b/app/src/terminal/writeable_pty/remote_server_controller.rs
@@ -138,7 +138,7 @@ impl<T: EventLoopSender> RemoteServerController<T> {
             | RemoteServerManagerEvent::SessionDeregistered { .. }
             | RemoteServerManagerEvent::HostConnected { .. }
             | RemoteServerManagerEvent::HostDisconnected { .. }
-            | RemoteServerManagerEvent::BundledSkillsSnapshot { .. }
+            | RemoteServerManagerEvent::RemoteAgentContextSnapshot { .. }
             | RemoteServerManagerEvent::NavigatedToDirectory { .. }
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }

--- a/crates/ai/src/project_context/model.rs
+++ b/crates/ai/src/project_context/model.rs
@@ -609,6 +609,11 @@ impl ProjectContextModel {
         self.global_rules.paths()
     }
 
+    /// Returns every indexed global rule with its cached content, sorted by path.
+    pub fn global_rules(&self) -> impl Iterator<Item = ProjectRule> + '_ {
+        self.global_rules.active_rules()
+    }
+
     /// Returns the rule file paths associated with a specific workspace root path.
     pub fn rules_for_workspace(&self, workspace_path: &Path) -> Vec<PathBuf> {
         self.path_to_rules

--- a/crates/remote_server/proto/remote_server.proto
+++ b/crates/remote_server/proto/remote_server.proto
@@ -120,11 +120,11 @@ message ServerMessage {
     GitCreatePrResponse git_create_pr_response = 29;
     GitGenerateCommitMessageResponse git_generate_commit_message_response = 31;
     GitGetCommittedBranchFilesResponse git_get_committed_branch_files_response = 32;
-    BundledSkillsSnapshot bundled_skills_snapshot = 33;
     GitStatusPush git_status_push = 34;
     GitHubPrInfoPush github_pr_info_push = 35;
     GitHubRepositoryInfoPush github_repository_info_push = 36;
     RipgrepSearchResponse ripgrep_search_response = 37;
+    RemoteAgentContextSnapshot remote_agent_context_snapshot = 33;
   }
 }
 
@@ -246,31 +246,45 @@ message ErrorResponse {
   string message = 2;
 }
 
-// ── Bundled skills ────────────────────────────────────────────────
+// ── Remote Agent Mode context ─────────────────────────────────────
 
-// One bundled skill, pre-parsed and handlebars-rendered by the daemon
-// against its own filesystem. Named with the `Proto` suffix (like
-// `FileContextProto`) to avoid colliding with the app's `BundledSkill`.
-message BundledSkillProto {
-  // Directory-based skill ID (unique within the bundled catalog).
+// Metadata specific to a skill bundled with Warp.
+message BundledSkillMetadata {
+  // Directory-based skill ID, unique within the bundled catalog.
   string id = 1;
-  string name = 2;
-  string description = 3;
-  // Absolute path to the skill's SKILL.md on this host.
-  string path = 4;
-  // Skill content with handlebars variables rendered for this host.
-  string content = 5;
   // When set, the skill is only active while the named MCP integration
   // is running on the client (e.g. "figma"). Evaluated client-side.
-  optional string requires_mcp = 6;
+  optional string requires_mcp = 2;
 }
 
-// Server → client push: the daemon's bundled skill catalog. Sent to a
-// connection after its Initialize completes (when parsing has already
-// finished) and broadcast to all connections when parsing completes.
-// Never blocks the initialize handshake.
-message BundledSkillsSnapshot {
-  repeated BundledSkillProto skills = 1;
+// Marker metadata for a file-based skill from the daemon host's home directory.
+message HomeSkillMetadata {}
+
+// One already-read remote skill published by the daemon.
+message RemoteSkillProto {
+  // Absolute path to the file on this host.
+  string path = 1;
+  string content = 2;
+  oneof source {
+    BundledSkillMetadata bundled = 3;
+    HomeSkillMetadata home = 4;
+  }
+}
+
+// One already-read remote context file published by the daemon.
+message RemoteContextFileProto {
+  // Absolute path to the file on this host.
+  string path = 1;
+  string content = 2;
+}
+
+// Revisioned full replacement of the daemon host's Agent Mode context. Source
+// discovery and reading happen daemon-side before this snapshot is published.
+message RemoteAgentContextSnapshot {
+  uint64 revision = 1;
+  string home_dir = 2;
+  repeated RemoteSkillProto skills = 3;
+  repeated RemoteContextFileProto global_rules = 4;
 }
 
 // ── Shared repo metadata sub-messages ─────────────────────────────

--- a/crates/remote_server/src/client/mod.rs
+++ b/crates/remote_server/src/client/mod.rs
@@ -15,10 +15,10 @@ use crate::codebase_index_proto::{
 };
 use crate::proto::{
     notification, server_message, session_scoped_request, Abort, Authenticate, BufferEdit,
-    BundledSkillProto, ClientMessage, CloseBuffer, CodebaseIndexLimits, DiffMode,
-    DiffStateFileDelta, DiffStateMetadataUpdate, DiffStateSnapshot, ErrorCode, GitStatusMetadata,
-    Initialize, InitializeResponse, LoadRepoMetadataDirectoryResponse,
-    NavigatedToDirectoryResponse, PrInfo, RepositoryInfo, RunCommandRequest, RunCommandResponse,
+    ClientMessage, CloseBuffer, CodebaseIndexLimits, DiffMode, DiffStateFileDelta,
+    DiffStateMetadataUpdate, DiffStateSnapshot, ErrorCode, GitStatusMetadata, Initialize,
+    InitializeResponse, LoadRepoMetadataDirectoryResponse, NavigatedToDirectoryResponse, PrInfo,
+    RemoteAgentContextSnapshot, RepositoryInfo, RunCommandRequest, RunCommandResponse,
     ServerMessage, SessionBootstrapped, TextEdit, UnsubscribeDiffState, UpdateGitHubPrInfo,
     UpdateGitHubRepoInfo, UpdateGitStatus,
 };
@@ -127,8 +127,10 @@ pub enum ClientEvent {
         mode: DiffMode,
         delta: DiffStateFileDelta,
     },
-    /// The daemon pushed its pre-parsed bundled skill catalog.
-    BundledSkillsSnapshotReceived { skills: Vec<BundledSkillProto> },
+    /// The daemon pushed a revisioned full replacement of its Agent Mode context.
+    RemoteAgentContextSnapshotReceived {
+        snapshot: RemoteAgentContextSnapshot,
+    },
     /// An aggregate git status push (branch + diff stats) was pushed by the
     /// server for the tab / prompt chips.
     GitStatusPushReceived {
@@ -688,10 +690,8 @@ impl RemoteServerClient {
                     delta,
                 })
             }
-            server_message::Message::BundledSkillsSnapshot(snapshot) => {
-                Some(ClientEvent::BundledSkillsSnapshotReceived {
-                    skills: snapshot.skills,
-                })
+            server_message::Message::RemoteAgentContextSnapshot(snapshot) => {
+                Some(ClientEvent::RemoteAgentContextSnapshotReceived { snapshot })
             }
             server_message::Message::GitStatusPush(push) => {
                 let Some(repo_path) = StandardizedPath::try_new(&push.repo_path).ok() else {

--- a/crates/remote_server/src/client_tests.rs
+++ b/crates/remote_server/src/client_tests.rs
@@ -6,10 +6,10 @@ use warpui_core::r#async::executor;
 use super::*;
 use crate::proto::{
     client_message, host_scoped_request, notification, run_command_response, server_message,
-    session_scoped_request, BundledSkillsSnapshot, ClientMessage, CodebaseIndexStatus,
-    CodebaseIndexStatusState, CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, ErrorCode,
-    GetDiffStateResponse, InitializeResponse, OpenBufferResponse, RunCommandResponse,
-    RunCommandSuccess, ServerMessage, WriteFile,
+    session_scoped_request, ClientMessage, CodebaseIndexStatus, CodebaseIndexStatusState,
+    CodebaseIndexStatusUpdated, CodebaseIndexStatusesSnapshot, ErrorCode, GetDiffStateResponse,
+    InitializeResponse, OpenBufferResponse, RemoteAgentContextSnapshot, RemoteContextFileProto,
+    RunCommandResponse, RunCommandSuccess, ServerMessage, WriteFile,
 };
 use crate::protocol;
 
@@ -18,6 +18,55 @@ fn unwrap_session_scoped(msg: &ClientMessage) -> &session_scoped_request::Messag
     match &msg.message {
         Some(client_message::Message::SessionScoped(w)) => w.message.as_ref().unwrap(),
         other => panic!("Expected SessionScoped, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn remote_agent_context_snapshot_push_becomes_client_event() {
+    let (client_stream, server_stream) = tokio::io::duplex(4096);
+    let (server_read, server_write) = tokio::io::split(server_stream);
+    let (client_read, client_write) = tokio::io::split(client_stream);
+    drop(server_read);
+
+    let executor = executor::Background::default();
+    let (_client, event_rx, _failure_rx, _host_rx) =
+        RemoteServerClient::new(client_read.compat(), client_write.compat_write(), &executor);
+    let mut writer = server_write.compat_write();
+
+    protocol::write_server_message(
+        &mut writer,
+        &ServerMessage {
+            request_id: String::new(),
+            message: Some(server_message::Message::RemoteAgentContextSnapshot(
+                RemoteAgentContextSnapshot {
+                    revision: 7,
+                    home_dir: "/home/user".to_string(),
+                    skills: vec![crate::proto::RemoteSkillProto {
+                        path: "/home/user/.agents/skills/test/SKILL.md".to_string(),
+                        content: "skill content".to_string(),
+                        source: Some(crate::proto::remote_skill_proto::Source::Home(
+                            crate::proto::HomeSkillMetadata {},
+                        )),
+                    }],
+                    global_rules: vec![RemoteContextFileProto {
+                        path: "/home/user/.agents/AGENTS.md".to_string(),
+                        content: "rule content".to_string(),
+                    }],
+                },
+            )),
+        },
+    )
+    .await
+    .unwrap();
+    writer.flush().await.unwrap();
+
+    match event_rx.recv().await.unwrap() {
+        ClientEvent::RemoteAgentContextSnapshotReceived { snapshot } => {
+            assert_eq!(snapshot.revision, 7);
+            assert_eq!(snapshot.skills[0].content, "skill content");
+            assert_eq!(snapshot.global_rules[0].content, "rule content");
+        }
+        other => panic!("Expected RemoteAgentContextSnapshotReceived, got {other:?}"),
     }
 }
 
@@ -127,49 +176,6 @@ async fn codebase_index_push_messages_become_client_events() {
             assert_eq!(status.repo_path, "/repo");
         }
         other => panic!("Expected CodebaseIndexStatusUpdated, got {other:?}"),
-    }
-}
-
-#[tokio::test]
-async fn bundled_skills_snapshot_push_becomes_client_event() {
-    let (client_stream, server_stream) = tokio::io::duplex(4096);
-    let (server_read, server_write) = tokio::io::split(server_stream);
-    let (client_read, client_write) = tokio::io::split(client_stream);
-    drop(server_read);
-
-    let executor = executor::Background::default();
-    let (_client, event_rx, _failure_rx, _host_rx) =
-        RemoteServerClient::new(client_read.compat(), client_write.compat_write(), &executor);
-    let mut writer = server_write.compat_write();
-
-    protocol::write_server_message(
-        &mut writer,
-        &ServerMessage {
-            request_id: String::new(),
-            message: Some(server_message::Message::BundledSkillsSnapshot(
-                BundledSkillsSnapshot {
-                    skills: vec![crate::proto::BundledSkillProto {
-                        id: "test-skill".to_string(),
-                        name: "test-skill".to_string(),
-                        description: "A test skill".to_string(),
-                        path: "/remote/SKILL.md".to_string(),
-                        content: "body".to_string(),
-                        requires_mcp: None,
-                    }],
-                },
-            )),
-        },
-    )
-    .await
-    .unwrap();
-    writer.flush().await.unwrap();
-
-    match event_rx.recv().await.unwrap() {
-        ClientEvent::BundledSkillsSnapshotReceived { skills } => {
-            assert_eq!(skills.len(), 1);
-            assert_eq!(skills[0].id, "test-skill");
-        }
-        other => panic!("Expected BundledSkillsSnapshotReceived, got {other:?}"),
     }
 }
 

--- a/crates/remote_server/src/manager.rs
+++ b/crates/remote_server/src/manager.rs
@@ -283,7 +283,7 @@ fn client_event_kind(event: &ClientEvent) -> &'static str {
         ClientEvent::DiffStateSnapshotReceived { .. } => "diff_state_snapshot",
         ClientEvent::DiffStateMetadataUpdateReceived { .. } => "diff_state_metadata_update",
         ClientEvent::DiffStateFileDeltaReceived { .. } => "diff_state_file_delta",
-        ClientEvent::BundledSkillsSnapshotReceived { .. } => "bundled_skills_snapshot",
+        ClientEvent::RemoteAgentContextSnapshotReceived { .. } => "remote_agent_context_snapshot",
         ClientEvent::GitStatusPushReceived { .. } => "git_status_push",
         ClientEvent::GitHubPrInfoPushReceived { .. } => "github_pr_info_push",
         ClientEvent::GitHubRepositoryInfoPushReceived { .. } => "github_repository_info_push",
@@ -466,13 +466,10 @@ pub enum RemoteServerManagerEvent {
     /// The last session for this host was disconnected or deregistered.
     /// Downstream features should tear down per-host models.
     HostDisconnected { host_id: HostId },
-    /// The daemon pushed its pre-parsed bundled skill catalog. Sent after
-    /// a connection initializes (when the daemon has already parsed) and
-    /// broadcast when daemon-side parsing completes; a newer snapshot for
-    /// the same host replaces the previous one.
-    BundledSkillsSnapshot {
+    /// A newer full Agent Mode context snapshot published by the daemon host.
+    RemoteAgentContextSnapshot {
         host_id: HostId,
-        skills: Vec<crate::proto::BundledSkillProto>,
+        snapshot: crate::proto::RemoteAgentContextSnapshot,
     },
 
     // --- Repo metadata events (forwarded from ClientEvent push channel) ---
@@ -700,7 +697,7 @@ impl RemoteServerManagerEvent {
             | RemoteServerManagerEvent::GetBranchesResponse { session_id, .. } => Some(*session_id),
             RemoteServerManagerEvent::HostConnected { .. }
             | RemoteServerManagerEvent::HostDisconnected { .. }
-            | RemoteServerManagerEvent::BundledSkillsSnapshot { .. }
+            | RemoteServerManagerEvent::RemoteAgentContextSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataSnapshot { .. }
             | RemoteServerManagerEvent::RepoMetadataUpdated { .. }
             | RemoteServerManagerEvent::RepoMetadataDirectoryLoaded { .. }
@@ -1332,6 +1329,8 @@ pub struct RemoteServerManager {
     /// `host_response_rx`, or failed when all sessions for the host
     /// disconnect.
     pending_host_requests: HashMap<crate::protocol::RequestId, PendingHostRequest>,
+    /// Highest Agent Mode context snapshot revision accepted for each connected host.
+    remote_agent_context_snapshot_revisions: HashMap<HostId, u64>,
     /// Background executor used to schedule host-scoped request timeouts.
     /// Only used off-wasm (timers and detached tasks aren't available on
     /// wasm), so the field is allowed to be dead there.
@@ -1358,6 +1357,7 @@ impl RemoteServerManager {
             session_platforms: HashMap::new(),
             codebase_index_limits: None,
             pending_host_requests: HashMap::new(),
+            remote_agent_context_snapshot_revisions: HashMap::new(),
             executor: ctx.background_executor().clone(),
         }
     }
@@ -3539,8 +3539,15 @@ impl RemoteServerManager {
                     delta,
                 });
             }
-            ClientEvent::BundledSkillsSnapshotReceived { skills } => {
-                ctx.emit(RemoteServerManagerEvent::BundledSkillsSnapshot { host_id, skills });
+            ClientEvent::RemoteAgentContextSnapshotReceived { snapshot } => {
+                if !self.accept_remote_agent_context_snapshot_revision(&host_id, snapshot.revision)
+                {
+                    return;
+                }
+                ctx.emit(RemoteServerManagerEvent::RemoteAgentContextSnapshot {
+                    host_id,
+                    snapshot,
+                });
             }
             ClientEvent::GitStatusPushReceived {
                 repo_path,
@@ -3573,6 +3580,24 @@ impl RemoteServerManager {
                 // Handled by the drain loop's completion callback.
             }
         }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn accept_remote_agent_context_snapshot_revision(
+        &mut self,
+        host_id: &HostId,
+        revision: u64,
+    ) -> bool {
+        if self
+            .remote_agent_context_snapshot_revisions
+            .get(host_id)
+            .is_some_and(|current| *current >= revision)
+        {
+            return false;
+        }
+        self.remote_agent_context_snapshot_revisions
+            .insert(host_id.clone(), revision);
+        true
     }
 
     /// Transitions a session from `Initializing` to `Connected`. Stores the
@@ -4068,6 +4093,7 @@ impl RemoteServerManager {
     /// fails any pending host-scoped requests that targeted this host.
     fn handle_host_disconnected(&mut self, host_id: &HostId, ctx: &mut ModelContext<Self>) {
         if !self.host_to_sessions.contains_key(host_id) {
+            self.remote_agent_context_snapshot_revisions.remove(host_id);
             ctx.emit(RemoteServerManagerEvent::HostDisconnected {
                 host_id: host_id.clone(),
             });

--- a/crates/remote_server/src/manager_tests.rs
+++ b/crates/remote_server/src/manager_tests.rs
@@ -3,8 +3,11 @@ use warp_core::SessionId;
 use warp_util::standardized_path::StandardizedPath;
 use warpui_core::App;
 
-use super::{HostRequestError, PendingHostRequest, RemoteServerManager, RipgrepSearchParams};
-use crate::proto::{host_scoped_request, ClientMessage, WriteFile};
+use super::{
+    HostRequestError, PendingHostRequest, RemoteServerManager, RemoteServerManagerEvent,
+    RipgrepSearchParams,
+};
+use crate::proto::{host_scoped_request, ClientMessage, RemoteAgentContextSnapshot, WriteFile};
 use crate::protocol::RequestId;
 use crate::HostId;
 
@@ -42,6 +45,41 @@ fn abort_host_request_removes_pending_request_and_resolves_caller() {
             result_rx.await.expect("manager should resolve caller"),
             Err(HostRequestError::Aborted)
         ));
+    });
+}
+
+#[test]
+fn remote_agent_context_snapshot_is_a_host_scoped_manager_event() {
+    let host_id = HostId::new("test-host".to_string());
+    let event = RemoteServerManagerEvent::RemoteAgentContextSnapshot {
+        host_id,
+        snapshot: RemoteAgentContextSnapshot {
+            revision: 1,
+            home_dir: "/home/user".to_string(),
+            skills: Vec::new(),
+            global_rules: Vec::new(),
+        },
+    };
+    assert!(event.session_id().is_none());
+}
+
+#[test]
+fn remote_agent_context_snapshot_revisions_are_deduplicated_per_host() {
+    App::test((), |mut app| async move {
+        let manager = app.add_model(RemoteServerManager::new);
+        let host_id = HostId::new("test-host".to_string());
+        let other_host_id = HostId::new("other-host".to_string());
+
+        manager.update(&mut app, |manager, ctx| {
+            assert!(manager.accept_remote_agent_context_snapshot_revision(&host_id, 2));
+            assert!(!manager.accept_remote_agent_context_snapshot_revision(&host_id, 2));
+            assert!(!manager.accept_remote_agent_context_snapshot_revision(&host_id, 1));
+            assert!(manager.accept_remote_agent_context_snapshot_revision(&host_id, 3));
+            assert!(manager.accept_remote_agent_context_snapshot_revision(&other_host_id, 1));
+
+            manager.handle_host_disconnected(&host_id, ctx);
+            assert!(manager.accept_remote_agent_context_snapshot_revision(&host_id, 3));
+        });
     });
 }
 

--- a/crates/remote_server/src/protocol_tests.rs
+++ b/crates/remote_server/src/protocol_tests.rs
@@ -2,8 +2,9 @@ use prost::Message;
 
 use super::*;
 use crate::proto::{
-    client_message, server_message, session_scoped_request, BundledSkillProto,
-    BundledSkillsSnapshot, ClientMessage, Initialize, InitializeResponse, ServerMessage,
+    client_message, remote_skill_proto, server_message, session_scoped_request,
+    BundledSkillMetadata, ClientMessage, HomeSkillMetadata, Initialize, InitializeResponse,
+    RemoteAgentContextSnapshot, RemoteContextFileProto, RemoteSkillProto, ServerMessage,
 };
 
 #[tokio::test]
@@ -33,6 +34,73 @@ async fn round_trip_client_message() {
 }
 
 #[tokio::test]
+async fn round_trip_remote_agent_context_snapshot() {
+    let mut buf = Vec::new();
+    write_server_message(
+        &mut buf,
+        &ServerMessage {
+            request_id: String::new(),
+            message: Some(server_message::Message::RemoteAgentContextSnapshot(
+                RemoteAgentContextSnapshot {
+                    revision: 7,
+                    home_dir: "/home/user".to_string(),
+                    skills: vec![
+                        RemoteSkillProto {
+                            path: "/bundled/pr-comments/SKILL.md".to_string(),
+                            content: "bundled content".to_string(),
+                            source: Some(remote_skill_proto::Source::Bundled(
+                                BundledSkillMetadata {
+                                    id: "pr-comments".to_string(),
+                                    requires_mcp: Some("figma".to_string()),
+                                },
+                            )),
+                        },
+                        RemoteSkillProto {
+                            path: "/home/user/.agents/skills/test/SKILL.md".to_string(),
+                            content: "home skill content".to_string(),
+                            source: Some(remote_skill_proto::Source::Home(HomeSkillMetadata {})),
+                        },
+                    ],
+                    global_rules: vec![RemoteContextFileProto {
+                        path: "/home/user/.agents/AGENTS.md".to_string(),
+                        content: "rule content".to_string(),
+                    }],
+                },
+            )),
+        },
+    )
+    .await
+    .unwrap();
+
+    let decoded = read_server_message(&mut &buf[..]).await.unwrap();
+    match decoded.message {
+        Some(server_message::Message::RemoteAgentContextSnapshot(snapshot)) => {
+            assert_eq!(snapshot.revision, 7);
+            assert_eq!(snapshot.home_dir, "/home/user");
+            assert_eq!(snapshot.skills.len(), 2);
+            let Some(remote_skill_proto::Source::Bundled(bundled)) =
+                snapshot.skills[0].source.as_ref()
+            else {
+                panic!("expected bundled skill source");
+            };
+            assert_eq!(bundled.id, "pr-comments");
+            assert_eq!(bundled.requires_mcp.as_deref(), Some("figma"));
+            assert!(matches!(
+                snapshot.skills[1].source,
+                Some(remote_skill_proto::Source::Home(_))
+            ));
+            assert_eq!(snapshot.skills[1].content, "home skill content");
+            assert_eq!(
+                snapshot.global_rules[0].path,
+                "/home/user/.agents/AGENTS.md"
+            );
+            assert_eq!(snapshot.global_rules[0].content, "rule content");
+        }
+        other => panic!("unexpected message variant: {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn round_trip_server_message() {
     let msg = ServerMessage {
         request_id: "resp-456".to_string(),
@@ -55,48 +123,6 @@ async fn round_trip_server_message() {
         Some(server_message::Message::InitializeResponse(resp)) => {
             assert_eq!(resp.server_version, "0.1.0");
             assert_eq!(resp.host_id, "test-host");
-        }
-        other => panic!("unexpected message variant: {other:?}"),
-    }
-}
-
-#[tokio::test]
-async fn round_trip_bundled_skills_snapshot() {
-    let msg = ServerMessage {
-        request_id: String::new(),
-        message: Some(server_message::Message::BundledSkillsSnapshot(
-            BundledSkillsSnapshot {
-                skills: vec![BundledSkillProto {
-                    id: "pr-comments".to_string(),
-                    name: "pr-comments".to_string(),
-                    description: "Fetch PR comments".to_string(),
-                    path: "/home/user/.warp/remote-server/bundled_resources/bundled/skills/pr-comments/SKILL.md".to_string(),
-                    content: "---\nname: pr-comments\n---\nbody".to_string(),
-                    requires_mcp: None,
-                }, BundledSkillProto {
-                    id: "figma-skill".to_string(),
-                    name: "figma-skill".to_string(),
-                    description: "Figma helper".to_string(),
-                    path: "/path/SKILL.md".to_string(),
-                    content: "body".to_string(),
-                    requires_mcp: Some("figma".to_string()),
-                }],
-            },
-        )),
-    };
-
-    let mut buf = Vec::new();
-    write_server_message(&mut buf, &msg).await.unwrap();
-
-    let mut cursor = &buf[..];
-    let decoded: ServerMessage = read_server_message(&mut cursor).await.unwrap();
-
-    match decoded.message {
-        Some(server_message::Message::BundledSkillsSnapshot(snapshot)) => {
-            assert_eq!(snapshot.skills.len(), 2);
-            assert_eq!(snapshot.skills[0].id, "pr-comments");
-            assert_eq!(snapshot.skills[0].requires_mcp, None);
-            assert_eq!(snapshot.skills[1].requires_mcp, Some("figma".to_string()));
         }
         other => panic!("unexpected message variant: {other:?}"),
     }


### PR DESCRIPTION
## Description

This is the lower PR in the remote Agent Mode context snapshot stack and the parent of #12669.

The remote daemon still discovers each context source independently: bundled skills come from the binary, while home skills and file-based global rules come from the daemon filesystem. Once discovered, this PR publishes them through one full-replacement `RemoteAgentContextSnapshot` that preserves the remote home directory and per-skill source metadata.

`ServerModel` now owns one deterministic cached snapshot and one refresh, initialization-send, broadcast, and sent-set lifecycle. `RemoteServerManager` likewise exposes one aggregate event and keeps one newest-revision guard per host, rejecting duplicate or older snapshots and resetting revision state after the final session for a host disconnects. This removes the parallel bundled-skills and home-context publication and transport pipelines.

The child PR #12669 synchronously reconciles each aggregate snapshot into Agent Mode's separate bundled-skill, home-skill, and remote-global-rule catalogs. PR #12750 remains an independent no-op refactor for remote project-context hydration.

![Screenshot 2026-06-17 at 5.04.24 PM.png](https://app.graphite.com/user-attachments/assets/548cab4d-940d-4e2e-a168-730043ba1270.png)

## Linked Issue

N/A

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `./script/format` — completed successfully
- `cargo check -p remote_server -p warp --tests` — passed
- `cargo nextest run -p remote_server` — 99 passed
- Focused publisher Warp tests — 3 passed
- Additional tests and Clippy were skipped at the author's explicit request
- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/89179655-5018-4b4f-86ae-486ef46590ce

CHANGELOG-NONE

Co-Authored-By: Oz [oz-agent@warp.dev](mailto:oz-agent@warp.dev)