### PR TITLE
Promote inline model selector search flag

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -638,6 +638,7 @@ default = [
     "inline_repo_menu",
     "kitty_keyboard_protocol",
     "inline_menu_headers",
+    "restore_prompt_on_inline_model_selector_search",
     "github_pr_prompt_chip",
     "conversations_as_context",
     "markdown_tables",

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -948,7 +948,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::RemoteCodebaseIndexing,
     FeatureFlag::AsyncFind,
     FeatureFlag::GPTConfigurableContextWindow,
-    FeatureFlag::RestorePromptOnInlineModelSelectorSearch,
     FeatureFlag::WarpControlCli,
 ];
 


### PR DESCRIPTION
## Summary
- Promote `FeatureFlag::RestorePromptOnInlineModelSelectorSearch` to stable/prod by enabling `restore_prompt_on_inline_model_selector_search` in the default Cargo features.
- Remove the flag from `DOGFOOD_FLAGS` now that stable builds compile it in by default.

## Validation
- `/workspace/warp/script/format`
- `cargo check --manifest-path /workspace/warp/app/Cargo.toml`

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://staging.warp.dev/conversation/4d92efb9-88e1-4904-a770-aec1240ffe89_
_Run: https://oz.staging.warp.dev/runs/019ed70d-0356-706a-be05-8df069b67454_
_This PR was generated with [Oz](https://warp.dev/oz)._
