### PR TITLE
Fix cross window dragging splitting groups

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -26915,7 +26915,6 @@ impl Workspace {
                     ..
                 } => {
                     if let Some(container_rect) = group_container_rect(window_id, group_id, ctx) {
-        
                         if container_rect.width() > MIN_VISIBLE_TAB_WIDTH
                             && rect_is_within_tab_bar(container_rect, &tab_bar_rects)
                         {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -20149,40 +20149,10 @@ impl Workspace {
             // Ghost state for cross-window drag hovering over this tab bar.
             let ghost = drag_model.ghost_state_for_window(self.window_id);
 
-            // Build a slot list: each ungrouped tab is a `Single`, and each
-            // contiguous run of same-group tabs collapses into one `Group`.
-            let grouped_tabs_enabled = FeatureFlag::GroupedTabs.is_enabled();
-            let mut slots: Vec<TabBarSlot> = Vec::with_capacity(self.tabs.len());
-            for (idx, tab) in self.tabs.iter().enumerate() {
-                let group_id = if grouped_tabs_enabled {
-                    tab.group_id.filter(|gid| self.tab_groups.contains_key(gid))
-                } else {
-                    None
-                };
-                match group_id {
-                    Some(group_id) => {
-                        if let Some(TabBarSlot::Group {
-                            group_id: last_gid,
-                            run_len,
-                            ..
-                        }) = slots.last_mut()
-                        {
-                            if *last_gid == group_id {
-                                *run_len += 1;
-                                continue;
-                                // Current tab is part of the last existing group,
-                                // continue building this groups 'slot'.
-                            }
-                        }
-                        slots.push(TabBarSlot::Group {
-                            group_id,
-                            first_index: idx,
-                            run_len: 1,
-                        });
-                    }
-                    None => slots.push(TabBarSlot::Single { index: idx }),
-                }
-            }
+            // Collapse tabs into render slots: each ungrouped tab is a
+            // `Single`, and each contiguous run of same-group tabs is one
+            // `Group`.
+            let slots = self.tab_bar_slots();
 
             // Render each slot in the tab bar, either an individual tab or tab group.
             for slot in &slots {
@@ -26780,12 +26750,42 @@ impl Workspace {
         let index = insertion_index.min(self.tabs.len());
         // Safety net to ensure the tab lands after all pinned items.
         let index = self.clamp_to_unpinned_region(&self.tabs, index);
+        // Never split a group: a drop that resolves to the middle of a group's
+        // run is pushed past the group's last member instead.
+        let index = self.clamp_past_group(index);
         let mut tab_data = TabData::new(pane_group);
         tab_data.selected_color = color.map_or(SelectedTabColor::Unset, SelectedTabColor::Color);
         tab_data.draggable_state = draggable_state;
         self.tabs.insert(index, tab_data);
         self.activate_tab_internal(index, ctx);
         ctx.notify();
+    }
+
+    /// If an insertion at `index` would land strictly inside a group's
+    /// contiguous run (i.e. between two members of the same group), pushes it
+    /// just past that group's last member so a cross-window drop can't split
+    /// the group. Mirrors `clamp_to_unpinned_region`'s "push past the
+    /// boundary" behavior; drops at a group's outer edges are left untouched.
+    fn clamp_past_group(&self, index: usize) -> usize {
+        // Record the group of the tab before our insertion.
+        let Some(before) = index
+            .checked_sub(1)
+            .and_then(|i| self.tabs.get(i))
+            .and_then(|tab| tab.group_id)
+        else {
+            return index;
+        };
+        // Record the group of the tab after our insertion.
+        let Some(after) = self.tabs.get(index).and_then(|tab| tab.group_id) else {
+            return index;
+        };
+        // If the group of the tabs before/after our insertion are the same
+        // we are landing in the middle of the group and must jump past this
+        // group.
+        if before != after {
+            return index;
+        }
+        group_member_index_range(&self.tabs, before).map_or(index, |(_, last)| last + 1)
     }
 
     /// Returns the tab-bar index where a dragged tab would be inserted for
@@ -26802,14 +26802,63 @@ impl Workspace {
     ) -> usize {
         let raw_index =
             self.raw_tab_insertion_index_for_cursor(window_id, cursor_position_on_screen, ctx);
-        self.clamp_to_unpinned_region(&self.tabs, raw_index)
+        let index = self.clamp_to_unpinned_region(&self.tabs, raw_index);
+        // Keep the ghost slot and the eventual drop out of the middle of a
+        // group so neither splits it.
+        self.clamp_past_group(index)
+    }
+
+    /// Collapses `self.tabs` into layout slots: each ungrouped tab is a `Single`,
+    /// and each contiguous run of same-group tabs becomes one `Group`. Shared by
+    /// tab/group rendering and insertion index calculations.
+    fn tab_bar_slots(&self) -> Vec<TabBarSlot> {
+        let grouped_tabs_enabled = FeatureFlag::GroupedTabs.is_enabled();
+        let mut slots: Vec<TabBarSlot> = Vec::with_capacity(self.tabs.len());
+        for (idx, tab) in self.tabs.iter().enumerate() {
+            let group_id = if grouped_tabs_enabled {
+                tab.group_id.filter(|gid| self.tab_groups.contains_key(gid))
+            } else {
+                None
+            };
+            match group_id {
+                Some(group_id) => {
+                    if let Some(TabBarSlot::Group {
+                        group_id: last_gid,
+                        run_len,
+                        ..
+                    }) = slots.last_mut()
+                    {
+                        if *last_gid == group_id {
+                            // Current tab continues the last group's run.
+                            *run_len += 1;
+                            continue;
+                        }
+                    }
+                    // We hav reached the last tab in a group.
+                    // Push this as a "Group" slot.
+                    slots.push(TabBarSlot::Group {
+                        group_id,
+                        first_index: idx,
+                        run_len: 1,
+                    });
+                }
+                // This tab is not part of a group. Push a "Single" slot.
+                None => slots.push(TabBarSlot::Single { index: idx }),
+            }
+        }
+        slots
     }
 
     /// Computes the tab-bar insertion index purely from cursor geometry,
-    /// independent of pinning. Skips tabs clipped by the overflow area
-    /// (width below `MIN_VISIBLE_TAB_WIDTH`), and picks between horizontal
-    /// and vertical layout by comparing the spread of tab centers on each
-    /// axis.
+    /// independent of pinning. Walks the same layout slots the tab bar renders
+    /// (`tab_bar_slots`): each ungrouped tab is one row, and each group —
+    /// collapsed or expanded — is a single row at its container rect, so a
+    /// drop can only target the slot before or after the whole group. Skips
+    /// tabs/groups clipped by the overflow area (width below `MIN_VISIBLE_TAB_WIDTH`)
+    /// and picks between horizontal and vertical layout by comparing the
+    /// spread of row centers on each axis. A result that still resolves into a
+    /// group's range (e.g. the fallback past a trailing group) is pushed clear
+    /// by `clamp_past_group` in `tab_insertion_index_for_cursor`.
     fn raw_tab_insertion_index_for_cursor(
         &self,
         window_id: WindowId,
@@ -26823,39 +26872,57 @@ impl Workspace {
         };
 
         // Pre-compute the bounding rects of the tab bar / vertical tabs panel
-        // so we can defensively reject `tab_position_<index>` cache entries
-        // that don't lie within either of them. This guards
-        // `tab_insertion_index_for_cursor` against any future overlay /
-        // chip / preview that accidentally shares a SavePosition key with
-        // a real tab — see the `for_drag_ghost` flag on `TabComponent` and
-        // `vertical_tabs::render_tab_group_internal` for the original
-        // offender (the cross-window drag ghost chip).
+        // so we can defensively reject `tab_position_<index>` / group cache
+        // entries that don't lie within either of them. This guards
+        // `tab_insertion_index_for_cursor` against any future overlay / chip /
+        // preview that accidentally shares a SavePosition key with a real tab
+        // — see the `for_drag_ghost` flag on `TabComponent` and
+        // `vertical_tabs::render_tab_group_internal` for the original offender
+        // (the cross-window drag ghost chip).
         let tab_bar_rects = tab_bar_rects_for_window(window_id, ctx);
 
         let cursor_in_window = cursor_position_on_screen - window_bounds.origin();
-        let mut visible_tabs = Vec::new();
-        for index in 0..self.tabs.len() {
-            if let Some(tab_position) =
-                ctx.element_position_by_id_at_last_frame(window_id, tab_position_id(index))
-            {
-                if tab_position.width() <= MIN_VISIBLE_TAB_WIDTH {
-                    continue;
+
+        // Resolve each layout slot to the (index, on-screen rect)
+        // it occupies. A group — collapsed or expanded — is one row at its
+        // container rect, so a drop can only land before or after the whole
+        // group, never inside; each ungrouped tab keeps its own row. Rects
+        // clipped by overflow or outside the tab bar are dropped.
+        let mut visible_tabs: Vec<(usize, RectF)> = Vec::with_capacity(self.tabs.len());
+        for slot in self.tab_bar_slots() {
+            match slot {
+                TabBarSlot::Single { index } => {
+                    if let Some(tab_position) =
+                        ctx.element_position_by_id_at_last_frame(window_id, tab_position_id(index))
+                    {
+                        // If we have at least one tab-bar-equivalent rect, require
+                        // that the candidate tab position be (mostly) inside one of
+                        // them. Use the rect center as the membership test — a tab
+                        // that's been rendered partway off-screen due to overflow
+                        // is fine to keep, but a rect that has nothing to do with
+                        // the tab bar (e.g. the floating chip that follows the
+                        // cursor anywhere in the window) gets rejected.
+                        if tab_position.width() > MIN_VISIBLE_TAB_WIDTH
+                            && rect_is_within_tab_bar(tab_position, &tab_bar_rects)
+                        {
+                            visible_tabs.push((index, tab_position));
+                        }
+                    }
                 }
-                // If we have at least one tab-bar-equivalent rect, require
-                // that the candidate tab position be (mostly) inside one of
-                // them. Use the rect center as the membership test — a tab
-                // that's been rendered partway off-screen due to overflow
-                // is fine to keep, but a rect that has nothing to do with
-                // the tab bar (e.g. the floating chip that follows the
-                // cursor anywhere in the window) gets rejected.
-                if !tab_bar_rects.is_empty()
-                    && !tab_bar_rects
-                        .iter()
-                        .any(|tb| tb.contains_point(tab_position.center()))
-                {
-                    continue;
+                TabBarSlot::Group {
+                    group_id,
+                    first_index,
+                    ..
+                } => {
+                    if let Some(container_rect) = group_container_rect(window_id, group_id, ctx) {
+        
+                        if container_rect.width() > MIN_VISIBLE_TAB_WIDTH
+                            && rect_is_within_tab_bar(container_rect, &tab_bar_rects)
+                        {
+                            visible_tabs.push((first_index, container_rect));
+                        }
+                    }
                 }
-                visible_tabs.push((index, tab_position));
             }
         }
 
@@ -26863,10 +26930,10 @@ impl Workspace {
             return self.tabs.len();
         }
 
-        // Detect orientation from the axis with the larger spread between
-        // first and last tab centers (vertical panels stack along Y).
-        // With only one tab there is no spread to compare, so fall back to
-        // whether the vertical-tabs panel is open.
+        // Detect orientation from the axis with the larger spread between the
+        // first and last row centers (vertical panels stack along Y). With
+        // only one row there is no spread to compare, so fall back to whether
+        // the vertical-tabs panel is open.
         let is_vertical = if visible_tabs.len() >= 2 {
             let first = visible_tabs[0].1.center();
             let last = visible_tabs.last().expect("non-empty").1.center();
@@ -27896,6 +27963,31 @@ pub(crate) fn tab_bar_rects_for_window(window_id: WindowId, app: &AppContext) ->
         rects.push(rect);
     }
     rects
+}
+
+// Checks that the tab/group rect is not clipped by overflow area
+// (width below `MIN_VISIBLE_TAB_WIDTH`) and that the rect position
+// is inside at least one of the tab-bar-equivalent rects.
+fn rect_is_within_tab_bar(rect: RectF, tab_bar_rects: &[RectF]) -> bool {
+    tab_bar_rects.is_empty()
+        || tab_bar_rects
+            .iter()
+            .any(|tb| tb.contains_point(rect.center()))
+}
+
+/// Last-frame container rect for a tab group (collapsed or expanded). Reads the
+/// id for the current layout.
+fn group_container_rect(
+    window_id: WindowId,
+    group_id: TabGroupId,
+    app: &AppContext,
+) -> Option<RectF> {
+    let position_id = if uses_vertical_tabs(app) {
+        vtab_group_position_id(group_id)
+    } else {
+        htab_group_position_id(group_id)
+    };
+    app.element_position_by_id_at_last_frame(window_id, position_id)
 }
 
 /// Renders the floating chip shown in the target window during a cross-window


### PR DESCRIPTION
## Description

Fixes two main bugs with interactions between cross window tab dragging and tab groups. 
1. When dropping a cross window tab in the middle of a tab group, it could cause the tab group to split. Now, we only allow dropping before or after a tab group, and trying to drop in the middle anchors it past the tab group. 
2. When a tab group was collapsed, the tab list was incorrectly rendering the insertion position for the cross window tab landing position. Now the index is calculated correctly and renders the landing position accordingly. 

I think I will do a follow up PR that actually allows dropping a cross window tab into an existing tab group, however IMO this is non blocking and not high priority given the additional complexity. **Please let me know what you think.**  (This is complicated because we need to do some more calculations for group bounds, and can't just infer the group based on insertion index (inserting into the index before and after a group could mean first/last position in the group or just outside the group, also need to modify group rendering).

## How it works 

- Created a helper function `tab_bar_slots()` that converts the tab list into a list of Tab bar slots which is essentially an enum representing a group or an individual tab.  This was previously used for rendering the tab/groups in the tab list but is now also used for computing the insertion index for the cross window tab
- Created a helper function `clamp_past_group()` that clamps the `ghost tab` and the insertion index past a group, so that tabs can not land inside of groups and split them.
- Updated insertion calculations to use the group rects when applicable rather than solely the tab rects 

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo of bug ](https://www.loom.com/share/53318faf76e849308c91b69b25cfb59e)

[Demo of correct functionality vtabs](https://www.loom.com/share/a6e3845e5adb41e7ae12239f4209c3cd)

[Demo of correct functionality htabs ](https://www.loom.com/share/1deecc5e85b145ea96832975e29fda86)
