### PR TITLE
[MCP][8/9] Resolve managed MCPs in agent run CLI

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -68,6 +68,7 @@ use crate::ai::mcp::parsing::{normalize_mcp_json, resolve_json, ParsedTemplatabl
 use crate::ai::mcp::templatable_manager::TemplatableMCPServerManagerEvent;
 use crate::ai::mcp::{
     JSONMCPServer, MCPServerState, TemplatableMCPServerInstallation, TemplatableMCPServerManager,
+    VariableType, VariableValue,
 };
 use crate::ai::skills::{
     filter_skills_by_spec, read_skills_from_directories, resolve_skill_repos, SkillManager,
@@ -81,6 +82,7 @@ use crate::server::server_api::ai::{AIClient, TaskStatusUpdate};
 use crate::server::server_api::harness_support::{
     HarnessSupportClient, ResolvePromptAttachedSkill, ResolvePromptRequest,
 };
+use crate::server::server_api::managed_mcp::ManagedMcpClient;
 use crate::server::server_api::ServerApiProvider;
 use crate::terminal::cli_agent_sessions::plugin_manager::{
     plugin_manager_for, CliAgentPluginManager,
@@ -465,6 +467,8 @@ pub enum AgentDriverError {
     InvalidRuntimeState,
     #[error("Requested MCP server not found: {0}")]
     MCPServerNotFound(uuid::Uuid),
+    #[error("Failed to resolve managed MCP server {uid}: {message}")]
+    ManagedMcpResolutionFailed { uid: Uuid, message: String },
     #[error("Failed to start MCP servers: {}", .details.join("; "))]
     MCPStartupFailed {
         /// One line per unavailable server (e.g. "'datadog' failed to start:
@@ -574,6 +578,12 @@ pub enum AgentDriverError {
         /// Matching row(s) from the harness block, trimmed and capped.
         excerpt: String,
     },
+}
+
+#[derive(Debug, Default)]
+struct ResolvedMcpSpecs {
+    local_uuids: Vec<Uuid>,
+    ephemeral_installations: Vec<TemplatableMCPServerInstallation>,
 }
 
 impl From<warpui::ModelDropped> for AgentDriverError {
@@ -972,31 +982,41 @@ impl AgentDriver {
     /// Resolve MCP specs into a map of MCP name to `JSONMCPServer` for use in
     /// third-party harnesses. Each spec is fully resolved (secrets applied, templates
     /// rendered) so harnesses can serialize directly into their native config format.
-    fn resolve_mcp_specs_to_json(
+    async fn resolve_mcp_specs_to_json(
         specs: &[MCPSpec],
-        secrets: &HashMap<String, ManagedSecretValue>,
-        ctx: &ModelContext<Self>,
+        secrets: Arc<HashMap<String, ManagedSecretValue>>,
+        managed_mcp_client: Arc<dyn ManagedMcpClient>,
+        foreground: &ModelSpawner<Self>,
     ) -> Result<HashMap<String, JSONMCPServer>, AgentDriverError> {
-        let (existing_uuids, mut ephemeral_installations) = Self::resolve_mcp_specs(specs)?;
+        let resolved_specs = Self::resolve_mcp_specs(specs, managed_mcp_client, foreground).await?;
+
+        let local_uuids = resolved_specs.local_uuids;
+        let mut installations = foreground
+            .spawn(move |_, ctx| -> Result<Vec<_>, AgentDriverError> {
+                let manager = TemplatableMCPServerManager::as_ref(ctx);
+                local_uuids
+                    .iter()
+                    .map(|uuid| {
+                        manager
+                            .get_installed_server(uuid)
+                            .cloned()
+                            .ok_or(AgentDriverError::MCPServerNotFound(*uuid))
+                    })
+                    .collect()
+            })
+            .await??;
+        installations.extend(resolved_specs.ephemeral_installations);
+
+        Self::mcp_installations_to_json(installations, secrets.as_ref())
+    }
+
+    fn mcp_installations_to_json(
+        mut installations: Vec<TemplatableMCPServerInstallation>,
+        secrets: &HashMap<String, ManagedSecretValue>,
+    ) -> Result<HashMap<String, JSONMCPServer>, AgentDriverError> {
         let mut result = HashMap::new();
 
-        // Resolve UUID-referenced servers from the TemplatableMCPServerManager.
-        let manager = TemplatableMCPServerManager::as_ref(ctx);
-        for uuid in &existing_uuids {
-            let installation = manager
-                .get_installed_server(uuid)
-                .ok_or(AgentDriverError::MCPServerNotFound(*uuid))?
-                .clone();
-            let mut installation = installation;
-            installation.apply_secrets(secrets);
-            let resolved = resolve_json(&installation);
-            let servers: HashMap<String, JSONMCPServer> = serde_json::from_str(&resolved)
-                .map_err(|e| AgentDriverError::MCPJsonParseError(e.to_string()))?;
-            result.extend(servers);
-        }
-
-        // Resolve ephemeral (inline JSON) servers.
-        for installation in ephemeral_installations.iter_mut() {
+        for installation in installations.iter_mut() {
             installation.apply_secrets(secrets);
             let resolved = resolve_json(installation);
             let servers: HashMap<String, JSONMCPServer> = serde_json::from_str(&resolved)
@@ -1007,42 +1027,119 @@ impl AgentDriver {
         Ok(result)
     }
 
-    /// Resolve MCP specs into UUIDs for existing servers and ephemeral installations for inline specs.
-    ///
-    /// Returns (existing_server_uuids, ephemeral_installations)
-    fn resolve_mcp_specs(
+    /// Resolve MCP specs into local UUIDs and ephemeral installations. UUIDs
+    /// are local-first; only non-local UUIDs call managed MCP GraphQL.
+    async fn resolve_mcp_specs(
         specs: &[MCPSpec],
-    ) -> Result<(Vec<Uuid>, Vec<TemplatableMCPServerInstallation>), AgentDriverError> {
-        let mut existing_uuids = Vec::new();
-        let mut ephemeral_installations = Vec::new();
+        managed_mcp_client: Arc<dyn ManagedMcpClient>,
+        foreground: &ModelSpawner<Self>,
+    ) -> Result<ResolvedMcpSpecs, AgentDriverError> {
+        let local_installed_uuids = foreground
+            .spawn(|_, ctx| {
+                TemplatableMCPServerManager::as_ref(ctx)
+                    .get_installed_templatable_servers()
+                    .keys()
+                    .copied()
+                    .collect::<HashSet<_>>()
+            })
+            .await?;
+
+        Self::resolve_mcp_specs_with_local_uuids(specs, &local_installed_uuids, managed_mcp_client)
+            .await
+    }
+
+    async fn resolve_mcp_specs_with_local_uuids(
+        specs: &[MCPSpec],
+        local_installed_uuids: &HashSet<Uuid>,
+        managed_mcp_client: Arc<dyn ManagedMcpClient>,
+    ) -> Result<ResolvedMcpSpecs, AgentDriverError> {
+        let mut resolved = ResolvedMcpSpecs::default();
 
         for spec in specs {
             match spec {
+                MCPSpec::Uuid(uuid) if local_installed_uuids.contains(uuid) => {
+                    resolved.local_uuids.push(*uuid);
+                }
                 MCPSpec::Uuid(uuid) => {
-                    existing_uuids.push(*uuid);
+                    let client_config = managed_mcp_client
+                        .create_managed_mcp_client_config(*uuid)
+                        .await
+                        .map_err(|err| AgentDriverError::ManagedMcpResolutionFailed {
+                            uid: *uuid,
+                            message: format!("{err:#}"),
+                        })?;
+                    let installations = Self::installations_from_managed_client_config_json(
+                        &client_config.mcp_config_json,
+                    )
+                    .map_err(|err| {
+                        AgentDriverError::ManagedMcpResolutionFailed {
+                            uid: *uuid,
+                            message: err.to_string(),
+                        }
+                    })?;
+                    resolved.ephemeral_installations.extend(installations);
                 }
                 MCPSpec::Json(json_str) => {
-                    // Normalize the JSON - if it's a single server definition (has command or url
-                    // at top level), wrap it with a generated name.
-                    let normalized_json = normalize_mcp_json(json_str)
-                        .map_err(|e| AgentDriverError::MCPJsonParseError(e.to_string()))?;
-
-                    // Parse as inline MCP server configuration
-                    let parsed_results =
-                        ParsedTemplatableMCPServerResult::from_user_json(&normalized_json)
-                            .map_err(|e| AgentDriverError::MCPJsonParseError(e.to_string()))?;
-
-                    for result in parsed_results {
-                        let installation = result
-                            .templatable_mcp_server_installation
-                            .ok_or(AgentDriverError::MCPMissingVariables)?;
-                        ephemeral_installations.push(installation);
-                    }
+                    resolved
+                        .ephemeral_installations
+                        .extend(Self::installations_from_user_mcp_json(json_str)?);
                 }
             }
         }
 
-        Ok((existing_uuids, ephemeral_installations))
+        Ok(resolved)
+    }
+
+    fn installations_from_user_mcp_json(
+        json_str: &str,
+    ) -> Result<Vec<TemplatableMCPServerInstallation>, AgentDriverError> {
+        let normalized_json = normalize_mcp_json(json_str)
+            .map_err(|e| AgentDriverError::MCPJsonParseError(e.to_string()))?;
+        let parsed_results = ParsedTemplatableMCPServerResult::from_user_json(&normalized_json)
+            .map_err(|e| AgentDriverError::MCPJsonParseError(e.to_string()))?;
+
+        parsed_results
+            .into_iter()
+            .map(|result| {
+                result
+                    .templatable_mcp_server_installation
+                    .ok_or(AgentDriverError::MCPMissingVariables)
+            })
+            .collect()
+    }
+
+    fn installations_from_managed_client_config_json(
+        json_str: &str,
+    ) -> Result<Vec<TemplatableMCPServerInstallation>, AgentDriverError> {
+        let normalized_json = normalize_mcp_json(json_str)
+            .map_err(|e| AgentDriverError::MCPJsonParseError(e.to_string()))?;
+        let parsed_results = ParsedTemplatableMCPServerResult::from_user_json(&normalized_json)
+            .map_err(|e| AgentDriverError::MCPJsonParseError(e.to_string()))?;
+
+        parsed_results
+            .into_iter()
+            .map(|result| {
+                if let Some(installation) = result.templatable_mcp_server_installation {
+                    return Ok(installation);
+                }
+
+                let mut variable_values = result.variable_values;
+                for variable in result.templatable_mcp_server.template.variables.iter() {
+                    variable_values
+                        .entry(variable.key.clone())
+                        .or_insert_with(|| VariableValue {
+                            variable_type: VariableType::Text,
+                            value: format!("{{{{{}}}}}", variable.key),
+                        });
+                }
+
+                Ok(TemplatableMCPServerInstallation::new(
+                    uuid::Uuid::new_v4(),
+                    result.templatable_mcp_server,
+                    variable_values,
+                ))
+            })
+            .collect()
     }
 
     /// Start MCP servers from profile allowlist for the terminal.
@@ -1902,21 +1999,25 @@ impl AgentDriver {
 
         // For the Oz harness only: set up MCP servers, model overrides, and profile information.
         if matches!(&task.harness, HarnessKind::Oz) {
-            // Resolve MCP specs into existing server UUIDs and ephemeral installations.
             let mcp_specs = task.mcp_specs.clone();
-            let (existing_uuids, ephemeral_installations) = foreground
-                .spawn(move |_, _| Self::resolve_mcp_specs(&mcp_specs))
-                .await??;
-
-            // Start any requested existing MCP servers first.
-            log::info!(
-                "Starting {} existing and {} ephemeral MCP servers",
-                existing_uuids.len(),
-                ephemeral_installations.len()
-            );
+            let managed_mcp_client = foreground
+                .spawn(|_, ctx| ServerApiProvider::as_ref(ctx).get_managed_mcp_client())
+                .await?;
 
             let mcp_startup_result = setup_events
                 .record_result(SetupStep::McpServerStartup, async {
+                    let resolved_mcp_specs =
+                        Self::resolve_mcp_specs(&mcp_specs, managed_mcp_client, &foreground)
+                            .await?;
+                    let existing_uuids = resolved_mcp_specs.local_uuids;
+                    let ephemeral_installations = resolved_mcp_specs.ephemeral_installations;
+
+                    log::info!(
+                        "Starting {} existing and {} ephemeral MCP servers",
+                        existing_uuids.len(),
+                        ephemeral_installations.len()
+                    );
+
                     // Run both startup phases even when one degrades, collecting
                     // degradation details so non-strict runs can continue with
                     // whichever servers did start.
@@ -2447,7 +2548,7 @@ impl AgentDriver {
         harness: &dyn ThirdPartyHarness,
         foreground: &ModelSpawner<Self>,
     ) -> Result<Arc<dyn harness::HarnessRunner>, AgentDriverError> {
-        let (working_dir, task_id, server_api, terminal_driver) = foreground
+        let (working_dir, task_id, server_api, managed_mcp_client, terminal_driver) = foreground
             .spawn(|me, ctx| {
                 if me.harness.is_some() {
                     log::error!(
@@ -2460,6 +2561,7 @@ impl AgentDriver {
                     me.working_dir.clone(),
                     me.task_id,
                     ServerApiProvider::as_ref(ctx).get(),
+                    ServerApiProvider::as_ref(ctx).get_managed_mcp_client(),
                     me.terminal_driver.clone(),
                 ))
             })
@@ -2518,11 +2620,9 @@ impl AgentDriver {
 
         // Resolve MCP specs into harness-native JSON format.
         let mcp_specs = mcp_specs.to_vec();
-        let resolved_mcp_servers = foreground
-            .spawn(move |_, ctx| Self::resolve_mcp_specs_to_json(&mcp_specs, &secrets, ctx))
-            .await
-            .map_err(|_| AgentDriverError::InvalidRuntimeState)?;
-        let resolved_mcp_servers = resolved_mcp_servers?;
+        let resolved_mcp_servers =
+            Self::resolve_mcp_specs_to_json(&mcp_specs, secrets, managed_mcp_client, foreground)
+                .await?;
         if !resolved_mcp_servers.is_empty() {
             log::info!(
                 "Resolved {} MCP server(s) for third-party harness",

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -15,6 +15,7 @@ use anyhow::{anyhow, Context as _};
 use futures::channel::oneshot;
 use futures::future::{self, join_all, Either};
 use futures::FutureExt as _;
+use handlebars::get_arguments;
 use itertools::Itertools as _;
 use oneshot::{Canceled, Receiver};
 use repo_metadata::local_model::IndexedRepoState;
@@ -1119,12 +1120,32 @@ impl AgentDriver {
         parsed_results
             .into_iter()
             .map(|result| {
-                if let Some(installation) = result.templatable_mcp_server_installation {
-                    return Ok(installation);
-                }
+                let ParsedTemplatableMCPServerResult {
+                    mut templatable_mcp_server,
+                    mut variable_values,
+                    ..
+                } = result;
 
-                let mut variable_values = result.variable_values;
-                for variable in result.templatable_mcp_server.template.variables.iter() {
+                // Server-rendered literal values (no `{{...}}` ref) must be preserved verbatim.
+                // Drop them from the template's variable list so `apply_secrets` never sees them —
+                // its implicit key-name matching would otherwise let a colliding local secret
+                // (e.g. one named `Authorization`) overwrite a server-issued proxy header.
+                // They stay in `variable_values`, so `resolve_json` still renders them into the
+                // config.
+                templatable_mcp_server
+                    .template
+                    .variables
+                    .retain(|variable| {
+                        let is_literal = variable_values
+                            .get(&variable.key)
+                            .is_some_and(|v| get_arguments(&v.value).is_empty());
+                        !is_literal
+                    });
+
+                // Remaining variables are explicit `{{...}}` placeholders the client fills from
+                // local secrets via `apply_secrets`. Synthesize a placeholder value for any not
+                // captured from env/headers (e.g. command-arg refs like `--token={{API_TOKEN}}`).
+                for variable in templatable_mcp_server.template.variables.iter() {
                     variable_values
                         .entry(variable.key.clone())
                         .or_insert_with(|| VariableValue {
@@ -1135,7 +1156,7 @@ impl AgentDriver {
 
                 Ok(TemplatableMCPServerInstallation::new(
                     uuid::Uuid::new_v4(),
-                    result.templatable_mcp_server,
+                    templatable_mcp_server,
                     variable_values,
                 ))
             })

--- a/app/src/ai/agent_sdk/driver/error_classification.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification.rs
@@ -100,6 +100,13 @@ pub fn classify_driver_error(error: &AgentDriverError) -> (AgentTaskState, TaskS
                 PlatformErrorCode::EnvironmentSetupFailed,
             ),
         ),
+        AgentDriverError::ManagedMcpResolutionFailed { uid, message } => (
+            AgentTaskState::Failed,
+            TaskStatusUpdate::with_error_code(
+                format!("Managed MCP server {uid} could not be resolved: {message}"),
+                PlatformErrorCode::EnvironmentSetupFailed,
+            ),
+        ),
         AgentDriverError::MCPStartupFailed { details } => {
             let server_lines = details
                 .iter()

--- a/app/src/ai/agent_sdk/driver/error_classification_tests.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification_tests.rs
@@ -73,6 +73,18 @@ fn mcp_server_not_found_is_failed_with_env_setup() {
 }
 
 #[test]
+fn managed_mcp_resolution_failed_is_failed_with_env_setup() {
+    assert_state_and_code(
+        AgentDriverError::ManagedMcpResolutionFailed {
+            uid: uuid::Uuid::nil(),
+            message: "not active".into(),
+        },
+        AgentTaskState::Failed,
+        Some(PlatformErrorCode::EnvironmentSetupFailed),
+    );
+}
+
+#[test]
 fn mcp_startup_failed_is_failed_with_env_setup_and_per_server_details() {
     let (state, update) = classify_driver_error(&AgentDriverError::MCPStartupFailed {
         details: vec![

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -282,6 +282,52 @@ fn managed_url_config_preserves_proxy_url_and_header() {
 }
 
 #[test]
+fn managed_url_config_preserves_header_despite_colliding_local_secret() {
+    // A server-rendered proxy header must not be overwritten by a local secret that
+    // happens to share the header's key name (`apply_secrets` implicit key-name match).
+    let installations = AgentDriver::installations_from_managed_client_config_json(
+        r#"{"mcpServers":{"GitHub MCP":{"url":"https://proxy.example/mcp","headers":{"Authorization":"Bearer proxy-token"}}}}"#,
+    )
+    .unwrap();
+    let rendered = render_installations(
+        installations,
+        HashMap::from([("Authorization".to_string(), raw_secret("local-secret"))]),
+    );
+
+    match &rendered["GitHub MCP"].transport_type {
+        JSONTransportType::SSEServer { url, headers } => {
+            assert_eq!(url, "https://proxy.example/mcp");
+            assert_eq!(
+                headers.get("Authorization").map(String::as_str),
+                Some("Bearer proxy-token")
+            );
+        }
+        other => panic!("expected SSE server, got {other:?}"),
+    }
+}
+
+#[test]
+fn managed_command_config_preserves_literal_env_despite_colliding_local_secret() {
+    // A literal env value rendered by the server must survive even when a local secret
+    // shares the env key name.
+    let installations = AgentDriver::installations_from_managed_client_config_json(
+        r#"{"mcpServers":{"GitHub MCP":{"command":"npx","env":{"LOG_LEVEL":"info"}}}}"#,
+    )
+    .unwrap();
+    let rendered = render_installations(
+        installations,
+        HashMap::from([("LOG_LEVEL".to_string(), raw_secret("debug"))]),
+    );
+
+    match &rendered["GitHub MCP"].transport_type {
+        JSONTransportType::CLIServer { env, .. } => {
+            assert_eq!(env.get("LOG_LEVEL").map(String::as_str), Some("info"));
+        }
+        other => panic!("expected CLI server, got {other:?}"),
+    }
+}
+
+#[test]
 fn managed_command_config_missing_secret_leaves_placeholder() {
     let installations = AgentDriver::installations_from_managed_client_config_json(
         r#"{"mcpServers":{"GitHub MCP":{"command":"npx","args":["--token={{API_TOKEN}}"]}}}"#,

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::fs;
 use std::path::Path;
@@ -7,21 +7,27 @@ use std::time::Duration;
 
 use cloud_object_models::CodeForge;
 use futures::channel::oneshot;
+use futures::executor::block_on;
 use repo_metadata::{DirectoryWatcher, RepoMetadataEvent, RepoMetadataModel, RepositoryIdentifier};
 use tempfile::TempDir;
 use warp_cli::agent::Harness;
+use warp_cli::mcp::MCPSpec;
 use warp_cli::skill::SkillSpec;
 use warp_cli::{
     OZ_CLI_ENV, OZ_HARNESS_ENV, OZ_PARENT_RUN_ID_ENV, OZ_RUN_ID_ENV, SERVER_ROOT_URL_OVERRIDE_ENV,
     SESSION_SHARING_SERVER_URL_OVERRIDE_ENV, WS_SERVER_URL_OVERRIDE_ENV,
 };
 use warp_core::channel::ChannelState;
+use warp_graphql::mutations::create_managed_mcp_client_config::{
+    CreateManagedMcpClientConfigOutput, ManagedMcpTransportKind,
+};
+use warp_graphql::response_context::ResponseContext;
 use warp_managed_secrets::ManagedSecretValue;
 use warp_util::standardized_path::StandardizedPath;
 use warpui::{App, SingletonEntity as _};
 
 use super::{
-    build_secret_env_vars, AgentDriver, IdleTimeoutSender,
+    build_secret_env_vars, AgentDriver, AgentDriverError, IdleTimeoutSender,
     LEGACY_OZ_PARENT_LISTENER_MANAGED_EXTERNALLY_ENV, LEGACY_OZ_PARENT_STATE_ROOT_ENV,
     OZ_MESSAGE_LISTENER_MANAGED_EXTERNALLY_ENV, OZ_MESSAGE_LISTENER_STATE_ROOT_ENV,
 };
@@ -34,7 +40,9 @@ use crate::ai::agent_sdk::task_env_vars;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::cloud_environments::{GithubRepo, SourceRepo};
 use crate::ai::mcp::parsing::normalize_mcp_json;
+use crate::ai::mcp::JSONTransportType;
 use crate::ai::skills::SkillManager;
+use crate::server::server_api::managed_mcp::MockManagedMcpClient;
 use crate::test_util::terminal::{add_window_with_terminal, initialize_app_for_terminal_view};
 
 #[test]
@@ -124,6 +132,193 @@ fn test_normalize_sse_server_with_headers() {
         server["headers"]["Authorization"].as_str().unwrap(),
         "Bearer token"
     );
+}
+
+fn managed_client_config_output(mcp_config_json: &str) -> CreateManagedMcpClientConfigOutput {
+    CreateManagedMcpClientConfigOutput {
+        transport_kind: ManagedMcpTransportKind::Command,
+        mcp_config_json: mcp_config_json.to_string(),
+        proxy_url: None,
+        proxy_token: None,
+        authorization_header_name: None,
+        authorization_header_value: None,
+        expires_at: None,
+        response_context: ResponseContext {
+            server_version: None,
+        },
+    }
+}
+
+fn raw_secret(value: &str) -> ManagedSecretValue {
+    ManagedSecretValue::RawValue {
+        value: value.to_string(),
+    }
+}
+
+fn render_installations(
+    installations: Vec<crate::ai::mcp::TemplatableMCPServerInstallation>,
+    secrets: HashMap<String, ManagedSecretValue>,
+) -> HashMap<String, crate::ai::mcp::JSONMCPServer> {
+    AgentDriver::mcp_installations_to_json(installations, &secrets).unwrap()
+}
+
+#[test]
+fn managed_resolver_local_uuid_does_not_call_managed_client() {
+    let uuid = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+    let mock = MockManagedMcpClient::new();
+    let local_installed_uuids = HashSet::from([uuid]);
+
+    let resolved = block_on(AgentDriver::resolve_mcp_specs_with_local_uuids(
+        &[MCPSpec::Uuid(uuid)],
+        &local_installed_uuids,
+        Arc::new(mock),
+    ))
+    .unwrap();
+
+    assert_eq!(resolved.local_uuids, vec![uuid]);
+    assert!(resolved.ephemeral_installations.is_empty());
+}
+
+#[test]
+fn managed_resolver_non_local_uuid_calls_managed_client() {
+    let uuid = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+    let config_json =
+        r#"{"mcpServers":{"GitHub MCP":{"command":"npx","env":{"API_TOKEN":"{{API_TOKEN}}"}}}}"#;
+    let mut mock = MockManagedMcpClient::new();
+    mock.expect_create_managed_mcp_client_config()
+        .times(1)
+        .returning(move |requested_uid| {
+            assert_eq!(requested_uid, uuid);
+            Ok(managed_client_config_output(config_json))
+        });
+
+    let resolved = block_on(AgentDriver::resolve_mcp_specs_with_local_uuids(
+        &[MCPSpec::Uuid(uuid)],
+        &HashSet::new(),
+        Arc::new(mock),
+    ))
+    .unwrap();
+
+    assert!(resolved.local_uuids.is_empty());
+    assert_eq!(resolved.ephemeral_installations.len(), 1);
+}
+
+#[test]
+fn managed_command_config_env_placeholder_uses_local_secret() {
+    let installations = AgentDriver::installations_from_managed_client_config_json(
+        r#"{"mcpServers":{"GitHub MCP":{"command":"npx","env":{"API_TOKEN":"{{API_TOKEN}}"}}}}"#,
+    )
+    .unwrap();
+    let rendered = render_installations(
+        installations,
+        HashMap::from([("API_TOKEN".to_string(), raw_secret("real"))]),
+    );
+
+    match &rendered["GitHub MCP"].transport_type {
+        JSONTransportType::CLIServer { env, .. } => {
+            assert_eq!(env.get("API_TOKEN").map(String::as_str), Some("real"));
+        }
+        other => panic!("expected CLI server, got {other:?}"),
+    }
+}
+
+#[test]
+fn managed_command_config_arg_placeholder_uses_local_secret() {
+    let installations = AgentDriver::installations_from_managed_client_config_json(
+        r#"{"mcpServers":{"GitHub MCP":{"command":"npx","args":["--token={{API_TOKEN}}"]}}}"#,
+    )
+    .unwrap();
+    let rendered = render_installations(
+        installations,
+        HashMap::from([("API_TOKEN".to_string(), raw_secret("real"))]),
+    );
+
+    match &rendered["GitHub MCP"].transport_type {
+        JSONTransportType::CLIServer { args, .. } => {
+            assert_eq!(args, &vec!["--token=real".to_string()]);
+        }
+        other => panic!("expected CLI server, got {other:?}"),
+    }
+}
+
+#[test]
+fn managed_command_config_preserves_literal_env_when_synthesizing_arg_placeholder() {
+    let installations = AgentDriver::installations_from_managed_client_config_json(
+        r#"{"mcpServers":{"GitHub MCP":{"command":"npx","args":["--token={{API_TOKEN}}"],"env":{"LOG_LEVEL":"info"}}}}"#,
+    )
+    .unwrap();
+    let rendered = render_installations(
+        installations,
+        HashMap::from([("API_TOKEN".to_string(), raw_secret("real"))]),
+    );
+
+    match &rendered["GitHub MCP"].transport_type {
+        JSONTransportType::CLIServer { args, env, .. } => {
+            assert_eq!(args, &vec!["--token=real".to_string()]);
+            assert_eq!(env.get("LOG_LEVEL").map(String::as_str), Some("info"));
+        }
+        other => panic!("expected CLI server, got {other:?}"),
+    }
+}
+
+#[test]
+fn managed_url_config_preserves_proxy_url_and_header() {
+    let installations = AgentDriver::installations_from_managed_client_config_json(
+        r#"{"mcpServers":{"GitHub MCP":{"url":"https://proxy.example/mcp","headers":{"Authorization":"Bearer proxy-token"}}}}"#,
+    )
+    .unwrap();
+    let rendered = render_installations(installations, HashMap::new());
+
+    match &rendered["GitHub MCP"].transport_type {
+        JSONTransportType::SSEServer { url, headers } => {
+            assert_eq!(url, "https://proxy.example/mcp");
+            assert_eq!(
+                headers.get("Authorization").map(String::as_str),
+                Some("Bearer proxy-token")
+            );
+        }
+        other => panic!("expected SSE server, got {other:?}"),
+    }
+}
+
+#[test]
+fn managed_command_config_missing_secret_leaves_placeholder() {
+    let installations = AgentDriver::installations_from_managed_client_config_json(
+        r#"{"mcpServers":{"GitHub MCP":{"command":"npx","args":["--token={{API_TOKEN}}"]}}}"#,
+    )
+    .unwrap();
+    let rendered = render_installations(installations, HashMap::new());
+
+    match &rendered["GitHub MCP"].transport_type {
+        JSONTransportType::CLIServer { args, .. } => {
+            assert_eq!(args, &vec!["--token={{API_TOKEN}}".to_string()]);
+        }
+        other => panic!("expected CLI server, got {other:?}"),
+    }
+}
+
+#[test]
+fn managed_resolution_failure_includes_uid_and_message() {
+    let uuid = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+    let mut mock = MockManagedMcpClient::new();
+    mock.expect_create_managed_mcp_client_config()
+        .times(1)
+        .returning(|_| Err(anyhow::anyhow!("not active")));
+
+    let err = block_on(AgentDriver::resolve_mcp_specs_with_local_uuids(
+        &[MCPSpec::Uuid(uuid)],
+        &HashSet::new(),
+        Arc::new(mock),
+    ))
+    .unwrap_err();
+
+    match err {
+        AgentDriverError::ManagedMcpResolutionFailed { uid, message } => {
+            assert_eq!(uid, uuid);
+            assert!(message.contains("not active"));
+        }
+        other => panic!("expected managed MCP resolution failure, got {other:?}"),
+    }
 }
 
 // ── IdleTimeoutSender tests ──────────────────────────────────────────────────────

--- a/app/src/ai/mcp/mod.rs
+++ b/app/src/ai/mcp/mod.rs
@@ -433,12 +433,13 @@ impl MCPServerExt for MCPServer {
             Some(TemplatableMCPServerInstallation::new(
                 uuid::Uuid::new_v4(),
                 templatable_mcp_server.clone(),
-                variable_values,
+                variable_values.clone(),
             ));
 
         ParsedTemplatableMCPServerResult {
             templatable_mcp_server,
             templatable_mcp_server_installation,
+            variable_values,
         }
     }
 

--- a/app/src/ai/mcp/parsing.rs
+++ b/app/src/ai/mcp/parsing.rs
@@ -190,6 +190,7 @@ pub(crate) fn normalize_codex_toml_to_json(file_contents: &str) -> Result<String
 pub struct ParsedTemplatableMCPServerResult {
     pub templatable_mcp_server: TemplatableMCPServer,
     pub templatable_mcp_server_installation: Option<TemplatableMCPServerInstallation>,
+    pub variable_values: HashMap<String, VariableValue>,
 }
 
 /// Extracts a field from JSON as a HashMap<String, String>.
@@ -343,33 +344,32 @@ impl ParsedTemplatableMCPServerResult {
             .iter()
             .all(|variable| combined_values.contains_key(&variable.key));
 
-        let templatable_mcp_server_installation = match all_variables_present {
-            true => {
-                let variable_values = combined_values
-                    .into_iter()
-                    .map(|(key, value)| {
-                        (
-                            key,
-                            VariableValue {
-                                variable_type: VariableType::Text,
-                                value,
-                            },
-                        )
-                    })
-                    .collect();
+        let variable_values: HashMap<String, VariableValue> = combined_values
+            .into_iter()
+            .map(|(key, value)| {
+                (
+                    key,
+                    VariableValue {
+                        variable_type: VariableType::Text,
+                        value,
+                    },
+                )
+            })
+            .collect();
 
-                Some(TemplatableMCPServerInstallation::new(
-                    uuid::Uuid::new_v4(),
-                    templatable_mcp_server.clone(),
-                    variable_values,
-                ))
-            }
+        let templatable_mcp_server_installation = match all_variables_present {
+            true => Some(TemplatableMCPServerInstallation::new(
+                uuid::Uuid::new_v4(),
+                templatable_mcp_server.clone(),
+                variable_values.clone(),
+            )),
             false => None,
         };
 
         ParsedTemplatableMCPServerResult {
             templatable_mcp_server,
             templatable_mcp_server_installation,
+            variable_values,
         }
     }
 }

--- a/app/src/ai/mcp/parsing.rs
+++ b/app/src/ai/mcp/parsing.rs
@@ -190,6 +190,7 @@ pub(crate) fn normalize_codex_toml_to_json(file_contents: &str) -> Result<String
 pub struct ParsedTemplatableMCPServerResult {
     pub templatable_mcp_server: TemplatableMCPServer,
     pub templatable_mcp_server_installation: Option<TemplatableMCPServerInstallation>,
+    #[cfg_attr(target_family = "wasm", expect(dead_code))]
     pub variable_values: HashMap<String, VariableValue>,
 }
 

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -1504,6 +1504,7 @@ impl TemplatableMCPServerManager {
         let ParsedTemplatableMCPServerResult {
             templatable_mcp_server,
             templatable_mcp_server_installation,
+            ..
         } = parsed_result.clone();
         let template_uuid = templatable_mcp_server.uuid;
         self.create_templatable_mcp_server(templatable_mcp_server, space, initiated_by, ctx);

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -1671,6 +1671,7 @@ impl ServerApiProvider {
         self.server_api.clone()
     }
 
+    #[cfg_attr(target_family = "wasm", expect(dead_code))]
     pub fn get_managed_mcp_client(&self) -> Arc<dyn ManagedMcpClient> {
         self.server_api.clone()
     }

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -4,6 +4,7 @@ mod base_client;
 pub mod block;
 pub mod harness_support;
 pub mod integrations;
+pub mod managed_mcp;
 pub mod managed_secrets;
 pub mod object;
 pub(crate) mod presigned_upload;
@@ -27,6 +28,7 @@ use channel_versions::ChannelVersions;
 use chrono::{DateTime, FixedOffset};
 use futures::StreamExt;
 use instant::Instant;
+use managed_mcp::ManagedMcpClient;
 use object::ObjectClient;
 use parking_lot::{Mutex, RwLock};
 use prost::Message;
@@ -1666,6 +1668,10 @@ impl ServerApiProvider {
     }
 
     pub fn get_managed_secrets_client(&self) -> Arc<dyn ManagedSecretsClient> {
+        self.server_api.clone()
+    }
+
+    pub fn get_managed_mcp_client(&self) -> Arc<dyn ManagedMcpClient> {
         self.server_api.clone()
     }
 

--- a/app/src/server/server_api/managed_mcp.rs
+++ b/app/src/server/server_api/managed_mcp.rs
@@ -1,0 +1,54 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use cynic::MutationBuilder;
+#[cfg(test)]
+use mockall::automock;
+use uuid::Uuid;
+use warp_graphql::mutations::create_managed_mcp_client_config::{
+    CreateManagedMcpClientConfig, CreateManagedMcpClientConfigInput,
+    CreateManagedMcpClientConfigOutput, CreateManagedMcpClientConfigResult,
+    CreateManagedMcpClientConfigVariables,
+};
+
+use super::ServerApi;
+use crate::server::graphql::{get_request_context, get_user_facing_error_message};
+
+#[cfg_attr(test, automock)]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+pub trait ManagedMcpClient: 'static + Send + Sync {
+    async fn create_managed_mcp_client_config(
+        &self,
+        uid: Uuid,
+    ) -> Result<CreateManagedMcpClientConfigOutput>;
+}
+
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+impl ManagedMcpClient for ServerApi {
+    async fn create_managed_mcp_client_config(
+        &self,
+        uid: Uuid,
+    ) -> Result<CreateManagedMcpClientConfigOutput> {
+        let variables = CreateManagedMcpClientConfigVariables {
+            input: CreateManagedMcpClientConfigInput {
+                uid: cynic::Id::new(uid.to_string()),
+            },
+            request_context: get_request_context(),
+        };
+        let operation = CreateManagedMcpClientConfig::build(variables);
+        let response = self.send_graphql_request(operation, None).await?;
+
+        match response.create_managed_mcp_client_config {
+            CreateManagedMcpClientConfigResult::CreateManagedMcpClientConfigOutput(output) => {
+                Ok(output)
+            }
+            CreateManagedMcpClientConfigResult::UserFacingError(error) => {
+                Err(anyhow!(get_user_facing_error_message(error)))
+            }
+            CreateManagedMcpClientConfigResult::Unknown => Err(anyhow!(
+                "Unknown error while creating managed MCP client config"
+            )),
+        }
+    }
+}

--- a/app/src/server/server_api/managed_mcp.rs
+++ b/app/src/server/server_api/managed_mcp.rs
@@ -1,3 +1,6 @@
+// We don't resolve managed MCPs from agent run CLI flows on WASM, so this code is unused there.
+#![cfg_attr(target_family = "wasm", expect(dead_code))]
+
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use cynic::MutationBuilder;

--- a/crates/graphql/src/api/mutations/create_managed_mcp_client_config.rs
+++ b/crates/graphql/src/api/mutations/create_managed_mcp_client_config.rs
@@ -1,0 +1,59 @@
+use crate::error::UserFacingError;
+use crate::request_context::RequestContext;
+use crate::response_context::ResponseContext;
+use crate::scalars::Time;
+use crate::schema;
+
+#[derive(cynic::QueryVariables, Debug)]
+pub struct CreateManagedMcpClientConfigVariables {
+    pub input: CreateManagedMcpClientConfigInput,
+    pub request_context: RequestContext,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    graphql_type = "RootMutation",
+    variables = "CreateManagedMcpClientConfigVariables"
+)]
+pub struct CreateManagedMcpClientConfig {
+    #[arguments(input: $input, requestContext: $request_context)]
+    pub create_managed_mcp_client_config: CreateManagedMcpClientConfigResult,
+}
+
+crate::client::define_operation! {
+    create_managed_mcp_client_config(CreateManagedMcpClientConfigVariables) -> CreateManagedMcpClientConfig;
+}
+
+#[derive(cynic::InputObject, Debug)]
+pub struct CreateManagedMcpClientConfigInput {
+    pub uid: cynic::Id,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+pub struct CreateManagedMcpClientConfigOutput {
+    pub transport_kind: ManagedMcpTransportKind,
+    pub mcp_config_json: String,
+    pub proxy_url: Option<String>,
+    pub proxy_token: Option<String>,
+    pub authorization_header_name: Option<String>,
+    pub authorization_header_value: Option<String>,
+    pub expires_at: Option<Time>,
+    pub response_context: ResponseContext,
+}
+
+#[derive(cynic::InlineFragments, Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum CreateManagedMcpClientConfigResult {
+    CreateManagedMcpClientConfigOutput(CreateManagedMcpClientConfigOutput),
+    UserFacingError(UserFacingError),
+    #[cynic(fallback)]
+    Unknown,
+}
+
+#[derive(cynic::Enum, Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ManagedMcpTransportKind {
+    #[cynic(rename = "URL")]
+    Url,
+    #[cynic(rename = "COMMAND")]
+    Command,
+}

--- a/crates/graphql/src/api/mutations/mod.rs
+++ b/crates/graphql/src/api/mutations/mod.rs
@@ -7,6 +7,7 @@ pub mod create_anonymous_user;
 pub mod create_file_artifact_upload_target;
 pub mod create_folder;
 pub mod create_generic_string_object;
+pub mod create_managed_mcp_client_config;
 pub mod create_managed_secret;
 pub mod create_notebook;
 pub mod create_simple_integration;

--- a/crates/warp_graphql_schema/api/client-schema.ts
+++ b/crates/warp_graphql_schema/api/client-schema.ts
@@ -12,6 +12,7 @@ const clientMutations = [
   'createFileArtifactUploadTarget',
   'createFolder',
   'createGenericStringObject',
+  'createManagedMcpClientConfig',
   'createManagedSecret',
   'createNotebook',
   'createTeam',

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -919,6 +919,23 @@ type CreateManagedSecretOutput implements Response {
 
 union CreateManagedSecretResult = CreateManagedSecretOutput | UserFacingError
 
+input CreateManagedMcpClientConfigInput {
+  uid: ID!
+}
+
+type CreateManagedMcpClientConfigOutput implements Response {
+  transportKind: ManagedMcpTransportKind!
+  mcpConfigJson: String!
+  proxyUrl: String
+  proxyToken: String
+  authorizationHeaderName: String
+  authorizationHeaderValue: String
+  expiresAt: Time
+  responseContext: ResponseContext!
+}
+
+union CreateManagedMcpClientConfigResult = CreateManagedMcpClientConfigOutput | UserFacingError
+
 input CreateNotebookInput {
   aiDocumentId: String
   conversationId: String
@@ -2236,6 +2253,11 @@ type ManagedSecretRawValue {
   value: String!
 }
 
+enum ManagedMcpTransportKind {
+  URL
+  COMMAND
+}
+
 """Type of Warp-managed secret values."""
 enum ManagedSecretType {
   ANTHROPIC_API_KEY
@@ -2858,6 +2880,7 @@ type RootMutation {
   createFileArtifactUploadTarget(input: CreateFileArtifactUploadTargetInput!, requestContext: RequestContext!): CreateFileArtifactUploadTargetResult!
   createFolder(input: CreateFolderInput!, requestContext: RequestContext!): CreateFolderResult!
   createGenericStringObject(input: CreateGenericStringObjectInput!, requestContext: RequestContext!): CreateGenericStringObjectResult!
+  createManagedMcpClientConfig(input: CreateManagedMcpClientConfigInput!, requestContext: RequestContext!): CreateManagedMcpClientConfigResult!
   createManagedSecret(input: CreateManagedSecretInput!, requestContext: RequestContext!): CreateManagedSecretResult!
   createNotebook(input: CreateNotebookInput!, requestContext: RequestContext!): CreateNotebookResult!
   createSimpleIntegration(input: CreateSimpleIntegrationInput!, requestContext: RequestContext!): CreateSimpleIntegrationResult!

--- a/specs/managed-mcp-cli-resolution/TECH.md
+++ b/specs/managed-mcp-cli-resolution/TECH.md
@@ -1,0 +1,200 @@
+# Managed MCP Resolution for CLI Agent Runs - Tech Spec
+
+## Context
+
+This spec covers the Warp client work needed for CLI-based agent runs to consume managed MCP servers. The authoritative server-side behavior is documented in `../warp-server/specs/oauth-managed-mcp`; this client spec focuses on how `agent run --mcp` resolves a `warp_id` that may refer to a managed MCP installation and turns it into runtime MCP config without persisting resolved secrets, proxy headers, or rendered command config. There is intentionally no sibling `PRODUCT.md` for this spec.
+
+References were inspected at:
+
+- `warp` commit `1cdb4794e6d30f9c60d76167ec9b4ee823bc6a10`
+- `warp-server` commit `b2149361735cc756d54f26522287e79200f37f07`
+
+Relevant current client flow:
+
+- [`crates/warp_cli/src/mcp.rs:14-24 @ 1cdb4794`](https://github.com/warpdotdev/warp/blob/1cdb4794e6d30f9c60d76167ec9b4ee823bc6a10/crates/warp_cli/src/mcp.rs#L14-L24) defines `MCPSpec` as either `Uuid` or raw JSON, and [`crates/warp_cli/src/mcp.rs:51-70 @ 1cdb4794`](https://github.com/warpdotdev/warp/blob/1cdb4794e6d30f9c60d76167ec9b4ee823bc6a10/crates/warp_cli/src/mcp.rs#L51-L70) parses UUID-looking `--mcp` values before falling back to file/inline JSON.
+- [`app/src/ai/agent_sdk/mcp_config.rs:7-60 @ 1cdb4794`](https://github.com/warpdotdev/warp/blob/1cdb4794e6d30f9c60d76167ec9b4ee823bc6a10/app/src/ai/agent_sdk/mcp_config.rs#L7-L60) builds the `mcp_servers` map sent to the ambient-agent API. UUID specs become `{"warp_id": "<uuid>"}`; JSON specs are unpacked and validated.
+- [`app/src/ai/agent_sdk/config_file.rs:99-136 @ 1cdb4794`](https://github.com/warpdotdev/warp/blob/1cdb4794e6d30f9c60d76167ec9b4ee823bc6a10/app/src/ai/agent_sdk/config_file.rs#L99-L136) converts persisted `mcp_servers` back into runtime `MCPSpec`s. Any entry with `warp_id` becomes `MCPSpec::Uuid`, so the driver sees the same UUID shape whether the input came from CLI, config file, or server task metadata.
+- [`app/src/ai/agent_sdk/driver.rs:971-1045 @ 1cdb4794`](https://github.com/warpdotdev/warp/blob/1cdb4794e6d30f9c60d76167ec9b4ee823bc6a10/app/src/ai/agent_sdk/driver.rs#L971-L1045) resolves runtime MCP specs. UUIDs are treated only as local templatable MCP installations today; JSON specs become ephemeral installations.
+- [`app/src/ai/agent_sdk/driver.rs:1310-1387 @ 1cdb4794`](https://github.com/warpdotdev/warp/blob/1cdb4794e6d30f9c60d76167ec9b4ee823bc6a10/app/src/ai/agent_sdk/driver.rs#L1310-L1387) starts local installed MCPs separately from ephemeral MCPs.
+- [`app/src/ai/agent_sdk/driver.rs:1897-1942 @ 1cdb4794`](https://github.com/warpdotdev/warp/blob/1cdb4794e6d30f9c60d76167ec9b4ee823bc6a10/app/src/ai/agent_sdk/driver.rs#L1897-L1942) wires the Oz harness startup path through that split.
+- [`app/src/ai/agent_sdk/driver.rs:2440-2526 @ 1cdb4794`](https://github.com/warpdotdev/warp/blob/1cdb4794e6d30f9c60d76167ec9b4ee823bc6a10/app/src/ai/agent_sdk/driver.rs#L2440-L2526) resolves MCP specs for third-party harnesses into `JSONMCPServer` values after applying local secrets.
+- [`app/src/ai/mcp/parsing.rs:256-374 @ 1cdb4794`](https://github.com/warpdotdev/warp/blob/1cdb4794e6d30f9c60d76167ec9b4ee823bc6a10/app/src/ai/mcp/parsing.rs#L256-L374) parses user JSON into templatable MCP installations. It only derives install variable values from `env` and `headers`; placeholders elsewhere in the config become template variables without values and currently produce `MCPMissingVariables`.
+- [`app/src/ai/mcp/templatable_installation.rs:100-155 @ 1cdb4794`](https://github.com/warpdotdev/warp/blob/1cdb4794e6d30f9c60d76167ec9b4ee823bc6a10/app/src/ai/mcp/templatable_installation.rs#L100-L155) applies local raw managed secrets to MCP install variables, including explicit `{{secret_name}}` references.
+- [`app/src/server/server_api.rs:1630-1680 @ 1cdb4794`](https://github.com/warpdotdev/warp/blob/1cdb4794e6d30f9c60d76167ec9b4ee823bc6a10/app/src/server/server_api.rs#L1630-L1680) exposes domain-specific GraphQL-backed clients from `ServerApiProvider`; managed MCP should follow this pattern rather than passing raw `ServerApi` around new call sites.
+
+Relevant server contract:
+
+- [`graphql/v2/mutations/managed_mcp.graphqls:69-77 @ b2149361`](https://github.com/warpdotdev/warp-server/blob/b2149361735cc756d54f26522287e79200f37f07/graphql/v2/mutations/managed_mcp.graphqls#L69-L77) defines `CreateManagedMcpClientConfigOutput` with `transportKind`, `mcpConfigJson`, proxy fields, and expiry.
+- [`graphql/v2/mutations/managed_mcp.graphqls:119-122 @ b2149361`](https://github.com/warpdotdev/warp-server/blob/b2149361735cc756d54f26522287e79200f37f07/graphql/v2/mutations/managed_mcp.graphqls#L119-L122) exposes the `createManagedMcpClientConfig` mutation.
+- [`logic/ai/ambient_agents/managed_mcp/client_config.go:26-30 @ b2149361`](https://github.com/warpdotdev/warp-server/blob/b2149361735cc756d54f26522287e79200f37f07/logic/ai/ambient_agents/managed_mcp/client_config.go#L26-L30) states the use-time contract: URL-backed rows use proxy sessions, command-backed rows raw-render command config while preserving managed-secret placeholders for local client resolution.
+- [`logic/ai/ambient_agents/managed_mcp/client_config.go:51-74 @ b2149361`](https://github.com/warpdotdev/warp-server/blob/b2149361735cc756d54f26522287e79200f37f07/logic/ai/ambient_agents/managed_mcp/client_config.go#L51-L74) implements URL vs command behavior.
+- [`logic/ai/ambient_agents/managed_mcp/client_config.go:92-110 @ b2149361`](https://github.com/warpdotdev/warp-server/blob/b2149361735cc756d54f26522287e79200f37f07/logic/ai/ambient_agents/managed_mcp/client_config.go#L92-L110) returns canonical portable MCP JSON in the `{"mcpServers": {...}}` shape.
+
+The core client bug today is that a managed MCP `warp_id` reaches `AgentDriver` as a UUID, then fails as `MCPServerNotFound` unless a local templatable installation with the same UUID exists. The client needs a runtime fallback that asks the server to resolve that UUID as a managed MCP installation.
+
+## Proposed Changes
+
+### GraphQL schema and client API
+
+1. Sync `crates/warp_graphql_schema/api/schema.graphql` with the server schema needed for `createManagedMcpClientConfig`.
+2. Add `crates/graphql/src/api/mutations/create_managed_mcp_client_config.rs` with Cynic types for:
+   - `CreateManagedMcpClientConfigVariables`
+   - `CreateManagedMcpClientConfigInput { uid: cynic::Id }`
+   - `CreateManagedMcpClientConfig`
+   - `CreateManagedMcpClientConfigOutput`
+   - `CreateManagedMcpClientConfigResult`
+   - `ManagedMcpTransportKind`
+3. Register the mutation module in `crates/graphql/src/api/mutations/mod.rs`.
+4. Add `app/src/server/server_api/managed_mcp.rs` with a `ManagedMcpClient` trait:
+   - `async fn create_managed_mcp_client_config(&self, uid: uuid::Uuid) -> anyhow::Result<ManagedMcpClientConfigOutput>`
+   - map `UserFacingError` through `get_user_facing_error_message`
+   - return an explicit error for `Unknown` so schema drift is visible.
+5. Add `pub mod managed_mcp;` and `ServerApiProvider::get_managed_mcp_client()` returning `Arc<dyn ManagedMcpClient>`.
+
+### Runtime resolution model
+
+Replace `AgentDriver::resolve_mcp_specs` and `resolve_mcp_specs_to_json` with a managed-aware resolver. Keep the current local/ephemeral split, but make it capable of async GraphQL calls.
+
+Recommended domain shape:
+
+```rust
+struct ResolvedMcpSpecs {
+    local_uuids: Vec<Uuid>,
+    ephemeral_installations: Vec<TemplatableMCPServerInstallation>,
+}
+```
+
+Resolution rules:
+
+1. Parse `MCPSpec::Json` exactly as today and append resulting ephemeral installations.
+2. For each `MCPSpec::Uuid`:
+   - If `TemplatableMCPServerManager::get_installed_server(&uuid).is_some()`, append it to `local_uuids`.
+   - Otherwise call `ManagedMcpClient::create_managed_mcp_client_config(uuid)`.
+   - Parse returned `mcpConfigJson` as portable MCP config and append it as ephemeral installation(s).
+3. Preserve local-first behavior. This avoids changing existing offline/local MCP flows and keeps backwards compatibility with UUIDs that refer to local templatable MCP installs.
+4. Do not write the returned `mcpConfigJson`, proxy token, authorization header, or rendered command/env values back to `AgentConfigSnapshot`, task config, config files, or logs.
+5. Treat GraphQL user-facing failures as fatal setup errors for that managed UUID. Add:
+
+```rust
+#[error("Failed to resolve managed MCP server {uid}: {message}")]
+ManagedMcpResolutionFailed { uid: Uuid, message: String }
+```
+
+to `AgentDriverError`.
+
+### Managed returned config parsing
+
+The server returns `mcpConfigJson` in the same portable wrapper shape the client already accepts for user JSON. That should be parsed through the same MCP templating machinery where possible, but managed config requires one additional helper because command-backed managed installs may preserve placeholders outside `env` and `headers`.
+
+Add a helper near the existing MCP parsing/resolution code:
+
+```rust
+fn installations_from_managed_client_config_json(
+    json: &str,
+) -> Result<Vec<TemplatableMCPServerInstallation>, AgentDriverError>
+```
+
+Behavior:
+
+1. Normalize and parse the JSON using `ParsedTemplatableMCPServerResult::from_user_json`.
+2. If `templatable_mcp_server_installation` is present, use it.
+3. If it is missing because the template has variables that were not captured from env/headers, preserve any captured env/header variable values and synthesize only missing variable values as `VariableValue { variable_type: Text, value: format!("{{{{{key}}}}}") }`.
+4. Construct a `TemplatableMCPServerInstallation` from the parsed template, preserved captured values, and synthesized missing values.
+5. Let the existing `apply_secrets` step resolve `{{secret_name}}` placeholders against local/task raw managed secrets before `resolve_json`.
+
+This keeps hardcoded JSON and managed JSON on the same launch path while filling the parser gap for managed command args such as `["--token={{API_TOKEN}}"]`.
+
+### Oz harness path
+
+Update the Oz setup section to resolve MCP specs asynchronously before startup:
+
+1. Retrieve `Arc<dyn ManagedMcpClient>` from `ServerApiProvider`.
+2. Spawn the resolver with access to:
+   - raw `task.mcp_specs`
+   - `TemplatableMCPServerManager`
+   - managed MCP client
+3. Start `ResolvedMcpSpecs.local_uuids` through `start_mcp_servers`.
+4. Start `ResolvedMcpSpecs.ephemeral_installations` through `start_ephemeral_mcp_servers`.
+5. Preserve existing strict/degraded MCP startup behavior after resolution. Resolution failures are not degraded startup; they are invalid setup because the requested MCP could not be materialized.
+
+### Third-party harness path
+
+Update `prepare_harness` so the third-party path uses the same managed-aware resolver:
+
+1. Resolve MCP specs into `ResolvedMcpSpecs`.
+2. For `local_uuids`, load each local installation from `TemplatableMCPServerManager`, apply secrets, render JSON, deserialize to `JSONMCPServer`, and extend the harness config map.
+3. For managed/inline ephemeral installations, apply secrets, render JSON, deserialize to `JSONMCPServer`, and extend the harness config map.
+4. Duplicate names should continue to behave like existing map extension semantics unless the implementation finds an existing helper that can produce better diagnostics without changing current behavior.
+
+### Preserved invariants
+
+- `agent run --mcp <uuid>` still stores and sends `{"warp_id":"<uuid>"}` in agent/task config.
+- Managed MCP resolution is use-time only and run-scoped.
+- Existing direct JSON `command` and `url` configs behave unchanged.
+- Existing local templatable MCP UUIDs behave unchanged.
+- Server-side task launches that pass stored `warp_id` values through CLI automatically get the same resolution path because `mcp_specs_from_mcp_servers` already converts `warp_id` entries into `MCPSpec::Uuid`.
+
+## Testing and Validation
+
+Add targeted unit tests around the new helpers and driver resolution path:
+
+1. `build_mcp_servers_from_specs` and `mcp_specs_from_mcp_servers` continue to serialize/deserialize UUID specs as `warp_id`; update existing tests only if schema names move.
+2. Managed resolver with a locally installed UUID returns that UUID in `local_uuids` and does not call `ManagedMcpClient`.
+3. Managed resolver with a non-local UUID calls `create_managed_mcp_client_config` and turns returned command config into an ephemeral installation.
+4. Managed command config with env placeholder:
+   - input `{"mcpServers":{"GitHub MCP":{"command":"npx","env":{"API_TOKEN":"{{API_TOKEN}}"}}}}`
+   - with secret `API_TOKEN=real`
+   - rendered JSON contains `API_TOKEN=real`.
+5. Managed command config with arg placeholder:
+   - input `{"mcpServers":{"GitHub MCP":{"command":"npx","args":["--token={{API_TOKEN}}"]}}}`
+   - with secret `API_TOKEN=real`
+   - rendered JSON contains `--token=real`.
+6. Managed URL config returned from server:
+   - input includes proxy `url` and `Authorization` header
+   - third-party harness JSON contains the proxy URL and header value unchanged.
+7. Missing managed secret leaves the placeholder in the rendered command config, matching existing `apply_secrets` behavior.
+8. GraphQL `UserFacingError` maps to `AgentDriverError::ManagedMcpResolutionFailed` with the UID and message.
+9. `Unknown` GraphQL response also fails with a clear managed MCP resolution error, not `MCPServerNotFound`.
+
+Run targeted validation:
+
+- `cargo test -p warp_graphql`
+- `cargo test -p warp mcp_config_tests`
+- `cargo test -p warp driver_tests`
+- `cargo check -p warp` if Cynic/schema changes touch generated schema usage broadly.
+
+Manual smoke validation once implementation exists:
+
+1. Use `agent run --mcp <managed-command-uid>` with a command-backed managed MCP whose env/args reference a managed secret. Confirm the MCP starts and the secret is substituted locally.
+2. Use `agent run --mcp <managed-url-uid>` with a URL-backed managed MCP. Confirm the server mints proxy config and the local run can see the MCP tools.
+3. Use a local templatable MCP UUID. Confirm no managed GraphQL resolution is attempted and the MCP starts as before.
+4. Start from an existing server-side task whose stored config has `mcp_servers.<name>.warp_id`. Confirm the CLI worker path resolves the same way as direct CLI input.
+
+## Parallelization
+
+Parallelization is optional for implementation but not useful for this spec itself. If implementation is split, use two local agents in separate worktrees so schema/client changes and runtime driver changes can progress independently:
+
+- Agent A: GraphQL client wiring
+  - Execution mode: local.
+  - Worktree: `/Users/bens/Desktop/warp-managed-mcp-graphql`.
+  - Branch: `managed-mcp-cli-resolution-graphql`.
+  - Owns `crates/warp_graphql_schema`, `crates/graphql`, and `app/src/server/server_api/managed_mcp.rs`.
+- Agent B: Driver/runtime resolution
+  - Execution mode: local.
+  - Worktree: `/Users/bens/Desktop/warp-managed-mcp-driver`.
+  - Branch: `managed-mcp-cli-resolution-driver`.
+  - Owns `app/src/ai/agent_sdk/driver.rs`, MCP parsing helpers, and driver tests.
+
+Merge Agent A first because Agent B needs the `ManagedMcpClient` trait and GraphQL output type. Land as one combined PR after both branches are reconciled and targeted tests pass.
+
+## Risks and Mitigations
+
+- **Secret leakage:** server-returned config can contain proxy headers or unresolved placeholders. Keep all resolution in memory, avoid logging `mcpConfigJson`, and do not write resolved config back to snapshots or config files.
+- **Parser mismatch:** managed command configs can contain placeholders outside env/headers. Add the managed-specific synthesis helper instead of weakening the general user-json parser behavior.
+- **UUID ambiguity:** a UUID could theoretically exist both locally and as a managed MCP. Resolve local first to preserve current behavior and avoid surprising users with network-dependent resolution for existing local installs.
+- **Proxy token expiry:** this change mints proxy config once per run. Do not add token refresh in v1; document failures as MCP startup/runtime failures and revisit if long-running managed URL MCPs need refresh.
+
+## Follow-ups
+
+- Consider a future `MCPSpec::ManagedUuid` or config-level discriminator only if local-first UUID ambiguity becomes a real issue.
+- Consider shared parsing utilities between user JSON and managed returned config if more server-produced MCP config shapes appear.


### PR DESCRIPTION
## Description

Adds runtime resolution of managed MCP servers for CLI agent runs. Previously, a `warp_id` UUID passed via `--mcp` would fail with `MCPServerNotFound` unless a local templatable installation with that exact UUID existed. This change introduces a local-first fallback: if the UUID is not found locally, the client calls the new `createManagedMcpClientConfig` GraphQL mutation to retrieve server-rendered MCP config and materializes it as an ephemeral installation for the duration of the run.

Key changes:

- Adds the `createManagedMcpClientConfig` GraphQL mutation to the schema and a corresponding `ManagedMcpClient` trait backed by `ServerApi`, exposed via `ServerApiProvider::get_managed_mcp_client()`.
- Introduces `ResolvedMcpSpecs` to carry both local UUIDs and ephemeral installations through the resolution pipeline.
- `resolve_mcp_specs` is now async and checks local installations first; only non-local UUIDs trigger a GraphQL call.
- Adds `installations_from_managed_client_config_json`, a managed-specific parsing helper that synthesizes `{{key}}` placeholder variable values for template variables not captured from `env`/`headers`, enabling command args like `["--token={{API_TOKEN}}"]` to resolve correctly via the existing `apply_secrets` path.
- Adds `AgentDriverError::ManagedMcpResolutionFailed` with UID and message, classified as `EnvironmentSetupFailed`.
- Resolved managed config is kept in memory only and is never written back to config files, snapshots, or logs.
- `ParsedTemplatableMCPServerResult` now exposes `variable_values` so the managed parsing helper can access captured values without re-parsing.

## Testing

New unit tests cover:

- Local UUID resolves without calling `ManagedMcpClient`.
- Non-local UUID calls `create_managed_mcp_client_config` and produces an ephemeral installation.
- Command config with an env placeholder resolves the secret correctly.
- Command config with an arg placeholder resolves the secret correctly.
- Env and arg placeholders coexist with literal env values.
- URL config preserves proxy URL and `Authorization` header unchanged.
- Missing secret leaves the placeholder in rendered output, matching existing `apply_secrets` behavior.
- GraphQL failure maps to `ManagedMcpResolutionFailed` with the correct UID and message.
- `ManagedMcpResolutionFailed` is classified as `AgentTaskState::Failed` with `PlatformErrorCode::EnvironmentSetupFailed`.
- [x] I have manually tested my changes locally with `./script/run`

## 