### PR TITLE
feat(agents): write glab config for GitLab credentials in cloud sandboxes

### DIFF
--- a/app/src/ai/agent_sdk/driver/git_credentials.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials.rs
@@ -27,6 +27,8 @@ const DEFAULT_GIT_NAME: &str = "Oz";
 const DEFAULT_GIT_EMAIL: &str = "oz-agent@warp.dev";
 const GITHUB_HOST: &str = "github.com";
 const GH_HOSTS_FILENAME: &str = "hosts.yml";
+const GLAB_HOST: &str = "gitlab.com";
+const GLAB_CONFIG_FILENAME: &str = "config.yml";
 
 fn home_dir() -> Result<PathBuf> {
     dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))
@@ -149,6 +151,53 @@ fn write_gh_hosts_yml(credentials: &[GitCredential], home: &std::path::Path) -> 
     Ok(())
 }
 
+/// Write `~/.config/glab-cli/config.yml` so the `glab` CLI is authenticated.
+///
+/// The YAML format for glab is:
+/// ```yaml
+/// hosts:
+///     gitlab.com:
+///         token: TOKEN
+///         git_protocol: https
+///         api_protocol: https
+/// ```
+///
+/// The write is atomic: a temporary file is written then renamed.
+fn write_glab_config(credentials: &[GitCredential], home: &std::path::Path) -> Result<()> {
+    let gitlab_credentials = credentials
+        .iter()
+        .filter(|credential| credential.host == GLAB_HOST)
+        .collect::<Vec<_>>();
+    if gitlab_credentials.is_empty() {
+        return Ok(());
+    }
+    let glab_config_dir = home.join(".config").join("glab-cli");
+    std::fs::create_dir_all(&glab_config_dir)
+        .with_context(|| format!("Failed to create {}", glab_config_dir.display()))?;
+    let path = glab_config_dir.join(GLAB_CONFIG_FILENAME);
+    let tmp_path = glab_config_dir.join(format!("{GLAB_CONFIG_FILENAME}.tmp"));
+
+    let mut yaml = String::new();
+    yaml.push_str("hosts:\n");
+    for cred in gitlab_credentials {
+        yaml.push_str(&format!("    {}:\n", cred.host));
+        yaml.push_str(&format!("        token: {}\n", cred.token));
+        yaml.push_str("        git_protocol: https\n");
+        yaml.push_str("        api_protocol: https\n");
+    }
+
+    write_secret_file(&tmp_path, &yaml)?;
+    std::fs::rename(&tmp_path, &path).with_context(|| {
+        format!(
+            "Failed to rename {} to {}",
+            tmp_path.display(),
+            path.display()
+        )
+    })?;
+
+    Ok(())
+}
+
 /// Formats non-sensitive metadata for verifying local credential injection.
 pub(crate) fn credential_diagnostics(credentials: &[GitCredential]) -> String {
     credentials
@@ -172,6 +221,7 @@ pub(crate) fn write_git_credentials(credentials: &[GitCredential]) -> Result<()>
     write_git_credentials_file(credentials)?;
     let home = home_dir()?;
     write_gh_hosts_yml(credentials, &home)?;
+    write_glab_config(credentials, &home)?;
     log::info!(
         "Wrote {} git credential(s) to the local credential store: {}",
         credentials.len(),

--- a/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials_tests.rs
@@ -121,3 +121,84 @@ fn credential_diagnostics_reports_presence_without_values() {
     assert!(!diagnostics.contains("oauth2"));
     assert!(!diagnostics.contains("user@example.com"));
 }
+
+#[test]
+fn write_glab_config_uses_glab_cli_filename() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let glab_config_dir = temp_dir.path().join(".config").join("glab-cli");
+
+    write_glab_config(
+        &[GitCredential {
+            token: "gitlab-token".to_string(),
+            username: Some("oauth2".to_string()),
+            email: Some("user@example.com".to_string()),
+            host: "gitlab.com".to_string(),
+        }],
+        temp_dir.path(),
+    )?;
+
+    let config_path = glab_config_dir.join(GLAB_CONFIG_FILENAME);
+    assert!(config_path.exists());
+    assert!(!glab_config_dir
+        .join(format!("{GLAB_CONFIG_FILENAME}.tmp"))
+        .exists());
+
+    let config = std::fs::read_to_string(config_path)?;
+    assert!(config.contains("hosts:"));
+    assert!(config.contains("    gitlab.com:"));
+    assert!(config.contains("        token: gitlab-token"));
+    assert!(config.contains("        git_protocol: https"));
+    assert!(config.contains("        api_protocol: https"));
+
+    Ok(())
+}
+
+#[test]
+fn write_glab_config_excludes_github_credentials() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let glab_config_dir = temp_dir.path().join(".config").join("glab-cli");
+
+    write_glab_config(
+        &[
+            GitCredential {
+                token: "github-token".to_string(),
+                username: Some("octocat".to_string()),
+                email: None,
+                host: "github.com".to_string(),
+            },
+            GitCredential {
+                token: "gitlab-token".to_string(),
+                username: Some("oauth2".to_string()),
+                email: None,
+                host: "gitlab.com".to_string(),
+            },
+        ],
+        temp_dir.path(),
+    )?;
+
+    let config = std::fs::read_to_string(glab_config_dir.join(GLAB_CONFIG_FILENAME))?;
+    assert!(config.contains("gitlab.com:"));
+    assert!(!config.contains("github.com:"));
+    assert!(!config.contains("github-token"));
+
+    Ok(())
+}
+
+#[test]
+fn write_glab_config_skips_github_only_credentials() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+
+    write_glab_config(
+        &[GitCredential {
+            token: "github-token".to_string(),
+            username: Some("octocat".to_string()),
+            email: None,
+            host: "github.com".to_string(),
+        }],
+        temp_dir.path(),
+    )?;
+
+    assert!(!temp_dir.path().join(".config").join("glab-cli").exists());
+
+    Ok(())
+}


### PR DESCRIPTION
## Description
Adds `glab` CLI configuration to the cloud-agent credential bootstrap and refresh path. When the server returns `gitlab.com` credentials via `taskGitCredentials`, the driver now writes `~/.config/glab-cli/config.yml` with the refreshed token, `git_protocol: https`, and `api_protocol: https`. This is the final client-side piece that lets long-running GitLab-backed agents use the `glab` CLI without relying on injected `GITLAB_TOKEN` env vars.

Complements:
- GitLab repo cloning support in #12659
- `glab` CLI installation in the Docker sandbox image via warpdotdev/warp-agent-docker#127
- Server-side GitLab credential issuance in REMOTE-1857

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Testing
- Added unit tests covering the new `write_glab_config` function, GitHub credential filtering, and skip behavior when no GitLab credentials are present.
- Ran `cargo test -p warp git_credentials::tests` — all 8 tests pass.

### Screenshots / Videos
N/A — this is a credentials-file writing change in cloud sandboxes.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

---
_Conversation: https://warpc.app/chat/1781729440.429739_
_This PR was generated with [Oz](https://warp.dev/oz)._
