### PR TITLE
REMOTE-1936: client runner_id + --runner cloud flag (draft)

### DIFF
--- a/app/src/ai/agent_sdk/ambient.rs
+++ b/app/src/ai/agent_sdk/ambient.rs
@@ -423,6 +423,7 @@ impl AmbientAgentRunner {
                 AgentConfigSnapshot {
                     name: args.name,
                     environment_id,
+                    runner_id: args.runner,
                     model_id: args.model.model.clone(),
                     base_prompt: None,
                     mcp_servers: cli_mcp_servers,

--- a/app/src/ai/agent_sdk/config_file.rs
+++ b/app/src/ai/agent_sdk/config_file.rs
@@ -20,6 +20,8 @@ pub struct AgentConfigSnapshotFile {
     #[serde(default)]
     pub environment_id: Option<String>,
     #[serde(default)]
+    pub runner_id: Option<String>,
+    #[serde(default)]
     pub model_id: Option<String>,
     #[serde(default)]
     pub base_prompt: Option<String>,
@@ -93,7 +95,7 @@ fn parse_yaml(input: &str) -> anyhow::Result<AgentConfigSnapshotFile> {
 }
 
 fn supported_keys_context() -> String {
-    "Supported keys: name, environment_id, model_id, base_prompt, mcp_servers, host, computer_use_enabled".to_string()
+    "Supported keys: name, environment_id, runner_id, model_id, base_prompt, mcp_servers, host, computer_use_enabled".to_string()
 }
 
 /// Convert an unwrapped `mcp_servers` map into runtime MCP specs for AgentDriver.
@@ -148,6 +150,7 @@ pub fn merge_with_precedence(
 
     let name = cli.name.or_else(|| file.name.clone());
     let environment_id = cli.environment_id.or_else(|| file.environment_id.clone());
+    let runner_id = cli.runner_id.or_else(|| file.runner_id.clone());
     let model_id = cli.model_id.or_else(|| file.model_id.clone());
     let base_prompt = cli.base_prompt.or_else(|| file.base_prompt.clone());
 
@@ -158,6 +161,7 @@ pub fn merge_with_precedence(
     AgentConfigSnapshot {
         name,
         environment_id,
+        runner_id,
         model_id,
         base_prompt,
         mcp_servers,

--- a/app/src/ai/agent_sdk/integration.rs
+++ b/app/src/ai/agent_sdk/integration.rs
@@ -103,6 +103,8 @@ impl IntegrationCommandRunner {
                 crate::ai::ambient_agents::AgentConfigSnapshot {
                     name: None,
                     environment_id: args.environment.environment.clone(),
+                    // TODO(REMOTE-1936): support a runner for integrations.
+                    runner_id: None,
                     model_id: args.model.model.clone(),
                     base_prompt: args.prompt.clone(),
                     mcp_servers: cli_mcp_servers,
@@ -415,6 +417,8 @@ impl IntegrationCommandRunner {
                 crate::ai::ambient_agents::AgentConfigSnapshot {
                     name: None,
                     environment_id: args.environment.environment.clone(),
+                    // TODO(REMOTE-1936): support a runner for integrations.
+                    runner_id: None,
                     model_id: args.model.model.clone(),
                     base_prompt: args.prompt.clone(),
                     mcp_servers: cli_mcp_servers,

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -387,6 +387,7 @@ fn build_merged_config_and_task(
         // CLI name > skill name > file name
         name: args.name.clone().or(skill_name).or(file_merged.name),
         environment_id: args.environment.clone().or(file_merged.environment_id),
+        runner_id: file_merged.runner_id,
         model_id: oz_model,
         // Skill base_prompt takes precedence over file base_prompt
         base_prompt: runtime_base_prompt.clone().or(file_merged.base_prompt),
@@ -486,6 +487,7 @@ fn build_server_side_task(
     let config = AgentConfigSnapshot {
         name: args.name.clone().or(skill_name),
         environment_id: environment.clone(),
+        runner_id: None,
         model_id: model_id_string,
         base_prompt: None,
         mcp_servers: cli_mcp_servers,

--- a/app/src/ai/agent_sdk/schedule.rs
+++ b/app/src/ai/agent_sdk/schedule.rs
@@ -113,6 +113,8 @@ fn create(ctx: &mut AppContext, args: CreateScheduleArgs) -> anyhow::Result<()> 
                 crate::ai::ambient_agents::AgentConfigSnapshot {
                     name: None,
                     environment_id,
+                    // TODO(REMOTE-1936): support --runner for scheduled agents.
+                    runner_id: None,
                     model_id: args.model.model.clone(),
                     base_prompt: None,
                     mcp_servers: cli_mcp_servers,

--- a/app/src/server/graphql/schema/mod.rs
+++ b/app/src/server/graphql/schema/mod.rs
@@ -88,6 +88,9 @@ pub fn update_generic_string_object_result_to_update_result(
                                 rejected.conflicting_generic_string_object,
                             )?
                         }
+                        GenericStringObjectFormat::Unknown => {
+                            bail!("conflicting generic string object has unknown format")
+                        }
                     };
                     Ok(UpdateCloudObjectResult::Rejected { object: boxed })
                 }

--- a/app/src/server/server_api/object.rs
+++ b/app/src/server/server_api/object.rs
@@ -836,6 +836,11 @@ impl ObjectClient for ServerApi {
                                     gso,
                                 );
                             }
+                            // GSO formats unknown to this client build (e.g. the
+                            // server-only `JsonRunner`) are skipped so syncing of
+                            // known objects still succeeds instead of failing to
+                            // decode the whole response.
+                            warp_graphql::generic_string_object::GenericStringObjectFormat::Unknown => {}
                         }
                     }
                 }

--- a/crates/cloud_object_models/src/cloud_agent_config.rs
+++ b/crates/cloud_object_models/src/cloud_agent_config.rs
@@ -34,6 +34,7 @@ impl AgentConfig {
         AgentConfigSnapshot {
             name: Some(self.name.clone()),
             environment_id: None,
+            runner_id: None,
             model_id: self.base_model_id.clone(),
             base_prompt: self.base_prompt.clone(),
             mcp_servers: self.mcp_servers.clone().map(|m| m.into_iter().collect()),

--- a/crates/cloud_object_models/src/scheduled_ambient_agent.rs
+++ b/crates/cloud_object_models/src/scheduled_ambient_agent.rs
@@ -22,6 +22,10 @@ pub struct AgentConfigSnapshot {
     pub name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub environment_id: Option<String>,
+    /// Runner ID (JsonRunner GSO) used to override the environment's compute
+    /// config (docker image, instance shape, setup commands).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -130,6 +134,7 @@ impl AgentConfigSnapshot {
         let Self {
             name,
             environment_id,
+            runner_id,
             model_id,
             base_prompt,
             mcp_servers,
@@ -143,6 +148,7 @@ impl AgentConfigSnapshot {
 
         name.is_none()
             && environment_id.is_none()
+            && runner_id.is_none()
             && model_id.is_none()
             && base_prompt.is_none()
             && mcp_servers.is_none()

--- a/crates/cloud_object_models/src/server_cloud_object.rs
+++ b/crates/cloud_object_models/src/server_cloud_object.rs
@@ -318,5 +318,10 @@ fn server_gso_to_cloud_object(
                 GenericServerObject::<GenericStringObjectId, GenericStringModel<ScheduledAmbientAgent, JsonSerializer>>::try_from_gql(gso)?,
             ))
         }
+        // Formats unknown to this client build (e.g. the server-only `JsonRunner`).
+        // Returning an error lets callers skip the object rather than failing.
+        warp_graphql::generic_string_object::GenericStringObjectFormat::Unknown => Err(anyhow::anyhow!(
+            "unsupported generic string object format (unknown to this client build)"
+        )),
     }
 }

--- a/crates/graphql/src/api/generic_string_object.rs
+++ b/crates/graphql/src/api/generic_string_object.rs
@@ -30,6 +30,12 @@ pub enum GenericStringObjectFormat {
     JsonCloudEnvironment,
     #[cynic(rename = "JsonScheduledAmbientAgent")]
     JsonScheduledAmbientAgent,
+    /// Fallback for GSO formats this client build does not recognize (for example
+    /// server-only formats such as `JsonRunner`). Without this, decoding a Drive
+    /// sync response that contains an unknown format fails for the entire response.
+    /// This variant only arises when deserializing; we never serialize it.
+    #[cynic(fallback)]
+    Unknown,
 }
 
 #[derive(cynic::InputObject, Debug)]
@@ -56,6 +62,7 @@ impl std::fmt::Display for GenericStringObjectFormat {
             GenericStringObjectFormat::JsonTemplatableMCPServer => "JsonTemplatableMCPServer",
             GenericStringObjectFormat::JsonCloudEnvironment => "JsonCloudEnvironment",
             GenericStringObjectFormat::JsonScheduledAmbientAgent => "JsonScheduledAmbientAgent",
+            GenericStringObjectFormat::Unknown => "Unknown",
         };
         write!(f, "{s}")
     }

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -483,6 +483,12 @@ pub struct RunCloudArgs {
     /// The environment to run this ambient agent in.
     #[command(flatten)]
     pub environment: EnvironmentCreateArgs,
+
+    /// Runner to use for this agent's compute (docker image, instance size,
+    /// setup commands), identified by ID. Overrides the environment's default runner.
+    #[arg(long = "runner", value_name = "ID")]
+    pub runner: Option<String>,
+
     /// Open the agent's session in Warp once it's available.
     #[arg(long = "open")]
     pub open: bool,


### PR DESCRIPTION
> **Draft / prototype — not for review.** Client counterpart to the REMOTE-1936 Runner server work (warpdotdev/warp-server `advait/remote-1936-runner-prototype`). Will be split into properly-scoped, reviewable PRs.

## Summary
Adds client support for selecting a **Runner** when dispatching a cloud agent (REMOTE-1936). A runner carries the compute config (Docker image, instance shape / SKU, setup commands) that the server resolves at dispatch.

## What's here
- `AgentConfigSnapshot` (`cloud_object_models`) gains `runner_id`, serialized as `runner_id` to match the server's agent-config snapshot; `is_empty` updated.
- Config-file support: `AgentConfigSnapshotFile.runner_id`, `merge_with_precedence` (CLI > file), and the supported-keys message.
- New CLI flag: **`oz agent run-cloud --runner <ID>`**, threaded into the cloud spawn config.
- All explicit `AgentConfigSnapshot` constructors updated. Integration / scheduled / local-run paths set `runner_id: None` (integration + scheduled runner support is a follow-up).

## Verification
- `cargo check -p warp` passes (production build, lib + bin).
- `cargo check -p cloud_object_models` passes in isolation.
- `cargo fmt` clean (only the edited files changed).

## Notes
- A real CLI → server → sandbox run with the runner's image still needs the Namespace + ngrok + custom-sidecar-image local setup (infra only, no further code). The wire format is in place: `--runner` emits `runner_id` in the agent-config-snapshot JSON the server already resolves.

## Artifacts
- Plan: https://staging.warp.dev/drive/notebook/3xsIYPAKpUXvEgGrU5QoQY
- Conversation: https://staging.warp.dev/conversation/b25bb4d7-e99c-44e4-83d1-d6713b1954ea
- Linear: https://linear.app/warpdotdev/issue/REMOTE-1936

Co-Authored-By: Oz <oz-agent@warp.dev>
