### PR TITLE
Suppress transient "lost connection" banner during auto-recovery

### DIFF
--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -34,6 +34,7 @@ use session_sharing_protocol::common::ParticipantId;
 use task::TaskId;
 pub use telemetry::AIIdentifiers;
 use uuid::Uuid;
+use warp_core::channel::ChannelState;
 use warp_core::features::FeatureFlag;
 use warp_editor::render::model::LineCount;
 use warp_multi_agent_api::{diff_hunk as diff_hunk_api, AgentEvent, AgentType};
@@ -719,6 +720,14 @@ impl RenderableAIError {
                 ..
             }
         )
+    }
+
+    /// Whether the failed-output UI should be suppressed while an automatic resume is in
+    /// flight. Release builds stay quiet so transient blips that recover on their own
+    /// don't surface an alarming error; dogfood builds (Local/Dev) keep the old, more
+    /// aggressive behavior so developers still see every transport failure.
+    pub fn should_suppress_during_recovery(&self) -> bool {
+        self.will_attempt_resume() && !ChannelState::channel().is_dogfood()
     }
 }
 

--- a/app/src/ai/blocklist/block/cli.rs
+++ b/app/src/ai/blocklist/block/cli.rs
@@ -1190,9 +1190,9 @@ impl View for CLISubagentView {
             // While an automatic resume is still in flight, keep the failed exchange
             // quiet: don't switch to the error border, and skip the banner, the "won't
             // count towards usage" notice, and the debug footer. The full failure UI is
-            // surfaced only once recovery has actually failed (`will_attempt_resume` is
-            // false).
-            if !error.will_attempt_resume() {
+            // surfaced only once recovery has actually failed. Dogfood builds (Local/Dev)
+            // opt out so developers still see every transport failure aggressively.
+            if !error.should_suppress_during_recovery() {
                 output_border = Border::all(1.).with_border_color(theme.ui_error_color());
                 output_items.add_child(render_failed_output(
                     FailedOutputProps {

--- a/app/src/ai/blocklist/block/cli.rs
+++ b/app/src/ai/blocklist/block/cli.rs
@@ -1187,57 +1187,64 @@ impl View for CLISubagentView {
 
         let mut output_border = Border::all(1.).with_border_fill(internal_colors::neutral_3(theme));
         if let AIBlockOutputStatus::Failed { error, .. } = &status {
-            output_border = Border::all(1.).with_border_color(theme.ui_error_color());
-            output_items.add_child(render_failed_output(
-                FailedOutputProps {
-                    error,
-                    is_ai_input_enabled: false,
-                    invalid_api_key_button_handle: &self
-                        .state_handles
-                        .invalid_api_key_button_handle,
-                    aws_bedrock_credentials_error_view: None,
-                    icon_right_margin: AVATAR_RIGHT_MARGIN,
-                },
-                app,
-            ));
+            // While an automatic resume is still in flight, keep the failed exchange
+            // quiet: don't switch to the error border, and skip the banner, the "won't
+            // count towards usage" notice, and the debug footer. The full failure UI is
+            // surfaced only once recovery has actually failed (`will_attempt_resume` is
+            // false).
+            if !error.will_attempt_resume() {
+                output_border = Border::all(1.).with_border_color(theme.ui_error_color());
+                output_items.add_child(render_failed_output(
+                    FailedOutputProps {
+                        error,
+                        is_ai_input_enabled: false,
+                        invalid_api_key_button_handle: &self
+                            .state_handles
+                            .invalid_api_key_button_handle,
+                        aws_bedrock_credentials_error_view: None,
+                        icon_right_margin: AVATAR_RIGHT_MARGIN,
+                    },
+                    app,
+                ));
 
-            if !self.model.is_restored() && !error.is_invalid_api_key() {
-                output_items.add_child(
-                    Container::new(render_informational_footer(
-                        app,
-                        "This response won't count towards your usage. \"Take over\" to continue."
-                            .to_string(),
-                    ))
-                    .with_margin_top(8.)
-                    .with_margin_left(icon_size(app) + AVATAR_RIGHT_MARGIN)
-                    .finish(),
-                );
+                if !self.model.is_restored() && !error.is_invalid_api_key() {
+                    output_items.add_child(
+                        Container::new(render_informational_footer(
+                            app,
+                            "This response won't count towards your usage. \"Take over\" to continue."
+                                .to_string(),
+                        ))
+                        .with_margin_top(8.)
+                        .with_margin_left(icon_size(app) + AVATAR_RIGHT_MARGIN)
+                        .finish(),
+                    );
 
-                output_items.add_child(
-                    Container::new(render_debug_footer(
-                        DebugFooterProps {
-                            conversation: self.model.conversation(app),
-                            model: self.model.as_ref(),
-                            debug_copy_button_handle: self
-                                .state_handles
-                                .debug_copy_button_handle
-                                .clone(),
-                            submit_issue_button_handle: self
-                                .state_handles
-                                .submit_issue_button_handle
-                                .clone(),
-                            should_render_feedback_below: true,
-                        },
-                        |debug_id, ctx| {
-                            ctx.dispatch_typed_action(CLISubagentAction::CopyDebugId(debug_id))
-                        },
-                        |ctx| ctx.dispatch_typed_action(CLISubagentAction::OpenFeedbackDocs),
-                        app,
-                    ))
-                    .with_margin_top(8.)
-                    .with_margin_left(icon_size(app) + AVATAR_RIGHT_MARGIN)
-                    .finish(),
-                );
+                    output_items.add_child(
+                        Container::new(render_debug_footer(
+                            DebugFooterProps {
+                                conversation: self.model.conversation(app),
+                                model: self.model.as_ref(),
+                                debug_copy_button_handle: self
+                                    .state_handles
+                                    .debug_copy_button_handle
+                                    .clone(),
+                                submit_issue_button_handle: self
+                                    .state_handles
+                                    .submit_issue_button_handle
+                                    .clone(),
+                                should_render_feedback_below: true,
+                            },
+                            |debug_id, ctx| {
+                                ctx.dispatch_typed_action(CLISubagentAction::CopyDebugId(debug_id))
+                            },
+                            |ctx| ctx.dispatch_typed_action(CLISubagentAction::OpenFeedbackDocs),
+                            app,
+                        ))
+                        .with_margin_top(8.)
+                        .with_margin_left(icon_size(app) + AVATAR_RIGHT_MARGIN)
+                        .finish(),
+                    );
+                }
             }
         }
 

--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -3036,6 +3036,25 @@ pub struct FailedOutputProps<'a> {
 pub fn render_failed_output(props: FailedOutputProps, app: &AppContext) -> Box<dyn Element> {
     let appearance = Appearance::as_ref(app);
 
+    // While an automatic retry/resume is still in flight, don't surface the underlying
+    // transport failure at all. These are typically transient and recover on their own,
+    // so showing the alarming "Warp lost connection" banner (plus debug info) for every
+    // blip is noisy and misleading. Render nothing during in-flight recovery; the full
+    // error banner is only shown once recovery has actually failed (i.e.
+    // `will_attempt_resume` is false).
+    if matches!(
+        props.error,
+        RenderableAIError::TransientNetworkError {
+            will_attempt_resume: true,
+            ..
+        } | RenderableAIError::Other {
+            will_attempt_resume: true,
+            ..
+        }
+    ) {
+        return Empty::new().finish();
+    }
+
     let error_text = match props.error {
         RenderableAIError::QuotaLimit {
             user_display_message,
@@ -3060,31 +3079,16 @@ pub fn render_failed_output(props: FailedOutputProps, app: &AppContext) -> Box<d
         RenderableAIError::InternalWarpError => {
             format!("{ERROR_APOLOGY_TEXT}\n\n{INTERNAL_WARP_ERROR}")
         }
-        RenderableAIError::Other {
-            error_message,
-            will_attempt_resume,
-            waiting_for_network,
-            ..
-        } => {
-            if *will_attempt_resume {
-                with_resume_status(error_message.clone(), *waiting_for_network)
-            } else {
-                format!("{ERROR_APOLOGY_TEXT}\n\n{error_message}")
-            }
+        RenderableAIError::Other { error_message, .. } => {
+            // A still-recovering `Other` error is handled by the early return above; once we
+            // reach here recovery has failed, so surface the error directly.
+            format!("{ERROR_APOLOGY_TEXT}\n\n{error_message}")
         }
-        RenderableAIError::TransientNetworkError {
-            will_attempt_resume,
-            waiting_for_network,
-            ..
-        } => {
-            // Transient network errors carry their own complete user-facing copy (plus
-            // debug info), so the apology prefix adds nothing.
-            let error_message = props.error.to_string();
-            if *will_attempt_resume {
-                with_resume_status(error_message, *waiting_for_network)
-            } else {
-                error_message
-            }
+        RenderableAIError::TransientNetworkError { .. } => {
+            // Recovering transient errors are handled by the early return above; once we
+            // reach here recovery has failed. These carry their own complete user-facing
+            // copy (plus debug info), so the apology prefix adds nothing.
+            props.error.to_string()
         }
         RenderableAIError::InvalidApiKey {
             provider,
@@ -3159,17 +3163,6 @@ pub fn render_failed_output(props: FailedOutputProps, app: &AppContext) -> Box<d
             .finish(),
         )
         .finish()
-}
-
-/// Appends the pending auto-resume status line to a failed-output error message.
-fn with_resume_status(error_message: String, waiting_for_network: bool) -> String {
-    if waiting_for_network {
-        format!(
-            "{error_message}\n\nWill resume conversation when network connectivity is restored..."
-        )
-    } else {
-        format!("{error_message}\n\nAttempting to resume conversation...")
-    }
 }
 
 fn render_invalid_api_key_error(

--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -3040,18 +3040,9 @@ pub fn render_failed_output(props: FailedOutputProps, app: &AppContext) -> Box<d
     // transport failure at all. These are typically transient and recover on their own,
     // so showing the alarming "Warp lost connection" banner (plus debug info) for every
     // blip is noisy and misleading. Render nothing during in-flight recovery; the full
-    // error banner is only shown once recovery has actually failed (i.e.
-    // `will_attempt_resume` is false).
-    if matches!(
-        props.error,
-        RenderableAIError::TransientNetworkError {
-            will_attempt_resume: true,
-            ..
-        } | RenderableAIError::Other {
-            will_attempt_resume: true,
-            ..
-        }
-    ) {
+    // error banner is only shown once recovery has actually failed. Dogfood builds
+    // (Local/Dev) opt out so developers still see every transport failure aggressively.
+    if props.error.should_suppress_during_recovery() {
         return Empty::new().finish();
     }
 

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -1141,62 +1141,68 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
 
     if request_type.is_active() {
         if let AIBlockOutputStatus::Failed { error, .. } = &status {
-            output_items.add_child(
-                render_failed_output(
-                    FailedOutputProps {
-                        error,
-                        is_ai_input_enabled: props.is_ai_input_enabled,
-                        invalid_api_key_button_handle: &props
-                            .state_handles
-                            .invalid_api_key_button_handle,
-                        aws_bedrock_credentials_error_view: props
-                            .aws_bedrock_credentials_error_view,
-                        icon_right_margin: 16.,
-                    },
-                    app,
-                )
-                .with_content_item_spacing()
-                .finish(),
-            );
-
-            if props.model.is_latest_visible_exchange_in_root_task(app)
-                && !has_expanded_last_requested_command
-                && !props.model.is_restored()
-                && !error.is_invalid_api_key()
-            {
+            // While an automatic resume is still in flight, keep the failed exchange
+            // quiet: skip the error banner, the "won't count towards usage" notice, and
+            // the debug footer. The full failure UI is surfaced only once recovery has
+            // actually failed (`will_attempt_resume` is false).
+            if !error.will_attempt_resume() {
                 output_items.add_child(
-                    render_informational_footer(
+                    render_failed_output(
+                        FailedOutputProps {
+                            error,
+                            is_ai_input_enabled: props.is_ai_input_enabled,
+                            invalid_api_key_button_handle: &props
+                                .state_handles
+                                .invalid_api_key_button_handle,
+                            aws_bedrock_credentials_error_view: props
+                                .aws_bedrock_credentials_error_view,
+                            icon_right_margin: 16.,
+                        },
                         app,
-                        "This response won't count towards your usage.".to_string(),
                     )
-                    .with_agent_output_item_spacing(app)
+                    .with_content_item_spacing()
                     .finish(),
                 );
 
-                output_items.add_child(
-                    render_debug_footer(
-                        DebugFooterProps {
-                            conversation: props.model.conversation(app),
-                            model: props.model,
-                            debug_copy_button_handle: props
-                                .state_handles
-                                .debug_copy_button_handle
-                                .clone(),
-                            submit_issue_button_handle: props
-                                .state_handles
-                                .submit_issue_button_handle
-                                .clone(),
-                            should_render_feedback_below: false,
-                        },
-                        |debug_id, ctx| {
-                            ctx.dispatch_typed_action(AIBlockAction::CopyDebugId(debug_id))
-                        },
-                        |ctx| ctx.dispatch_typed_action(AIBlockAction::OpenFeedbackDocs),
-                        app,
-                    )
-                    .with_agent_output_item_spacing(app)
-                    .finish(),
-                );
+                if props.model.is_latest_visible_exchange_in_root_task(app)
+                    && !has_expanded_last_requested_command
+                    && !props.model.is_restored()
+                    && !error.is_invalid_api_key()
+                {
+                    output_items.add_child(
+                        render_informational_footer(
+                            app,
+                            "This response won't count towards your usage.".to_string(),
+                        )
+                        .with_agent_output_item_spacing(app)
+                        .finish(),
+                    );
+
+                    output_items.add_child(
+                        render_debug_footer(
+                            DebugFooterProps {
+                                conversation: props.model.conversation(app),
+                                model: props.model,
+                                debug_copy_button_handle: props
+                                    .state_handles
+                                    .debug_copy_button_handle
+                                    .clone(),
+                                submit_issue_button_handle: props
+                                    .state_handles
+                                    .submit_issue_button_handle
+                                    .clone(),
+                                should_render_feedback_below: false,
+                            },
+                            |debug_id, ctx| {
+                                ctx.dispatch_typed_action(AIBlockAction::CopyDebugId(debug_id))
+                            },
+                            |ctx| ctx.dispatch_typed_action(AIBlockAction::OpenFeedbackDocs),
+                            app,
+                        )
+                        .with_agent_output_item_spacing(app)
+                        .finish(),
+                    );
+                }
             }
         }
     }

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -1144,8 +1144,9 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
             // While an automatic resume is still in flight, keep the failed exchange
             // quiet: skip the error banner, the "won't count towards usage" notice, and
             // the debug footer. The full failure UI is surfaced only once recovery has
-            // actually failed (`will_attempt_resume` is false).
-            if !error.will_attempt_resume() {
+            // actually failed. Dogfood builds (Local/Dev) opt out so developers still see
+            // every transport failure aggressively.
+            if !error.should_suppress_during_recovery() {
                 output_items.add_child(
                     render_failed_output(
                         FailedOutputProps {

--- a/app/src/ai/blocklist/controller/response_stream.rs
+++ b/app/src/ai/blocklist/controller/response_stream.rs
@@ -374,6 +374,13 @@ impl ResponseStream {
                         return;
                     }
                     RecoveryAction::Resume => {
+                        // Recoverable failure after client actions: we'll resume the
+                        // conversation once the stream finishes rather than surface the
+                        // error, so the UI suppresses the banner. Log it so the
+                        // auto-recovery isn't completely silent.
+                        log::warn!(
+                            "MultiAgent request failed after client actions; resuming conversation after stream finishes - Error: {e:?}"
+                        );
                         // The resume spawn itself waits for connectivity.
                         self.should_resume_conversation_after_stream_finished = true;
                     }
@@ -441,6 +448,13 @@ impl ResponseStream {
                     return;
                 }
                 RecoveryAction::Resume => {
+                    // Recoverable truncation after client actions: we'll resume the
+                    // conversation once the stream finishes rather than surface the
+                    // error, so the UI suppresses the banner. Log it so the
+                    // auto-recovery isn't completely silent.
+                    log::warn!(
+                        "MultiAgent request truncated after client actions; resuming conversation after stream finishes - Error: {unexpected_eof:?}"
+                    );
                     self.should_resume_conversation_after_stream_finished = true;
                     self.error_event_emitted = true;
                     self.report_request_failure(&unexpected_eof, is_online);


### PR DESCRIPTION
## Description
While an automatic retry/resume is in flight after a transient transport failure, `render_failed_output` no longer surfaces the alarming **"Warp lost connection"** banner (plus raw debug info). Instead it renders nothing until recovery has actually failed, at which point the full error banner is shown as before.

Context: #12431 started synthesizing/surfacing transient transport errors (e.g. `UnexpectedEof` on a stream cut) and rendered them as "Warp lost connection… Attempting to resume" even when the auto-resume subsequently succeeded. For runs that recover on their own (the common case), this banner can be noisy and misleading.

Changes:
- `app/src/ai/blocklist/block/view_impl/common.rs`: early-return `Empty` from `render_failed_output` for `TransientNetworkError`/`Other` errors with `will_attempt_resume: true`. Simplified the now terminal-only match arms and removed the dead `with_resume_status` helper.
- `app/src/ai/blocklist/controller/response_stream.rs`: added a `log::warn!` to both `RecoveryAction::Resume` paths so auto-recovery isn't completely silent in the logs, matching the existing `RetryNow`/`RetryWhenOnline` logging. This is a one-time event (not the per-frame render path).

The full error banner (including debug info) is still shown once `will_attempt_resume` is `false` (recovery exhausted/failed).

Co-Authored-By: Oz <oz-agent@warp.dev>
