### PR TITLE
warpui_core(tui): build TUI element primitives on ratatui-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8893,12 +8893,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
-name = "numtoa"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
-
-[[package]]
 name = "oauth2"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10904,7 +10898,6 @@ dependencies = [
  "ratatui-core",
  "ratatui-crossterm",
  "ratatui-macros",
- "ratatui-termion",
  "ratatui-termwiz",
  "ratatui-widgets",
  "serde",
@@ -10953,17 +10946,6 @@ checksum = "80fac59720679490d89d200df411faa249be728681adcabed3d047ae72c48f1d"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
-]
-
-[[package]]
-name = "ratatui-termion"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c16cc35a9d9114e0b2bb4b22018b96ae7f5fe60e2595dc73e622b4e78624835"
-dependencies = [
- "instability",
- "ratatui-core",
- "termion",
 ]
 
 [[package]]
@@ -13510,16 +13492,6 @@ dependencies = [
  "nom 7.1.3",
  "phf",
  "phf_codegen",
-]
-
-[[package]]
-name = "termion"
-version = "4.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44138a9ae08f0f502f24104d82517ef4da7330c35acd638f1f29d3cd5475ecb"
-dependencies = [
- "libc",
- "numtoa",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -46,7 +46,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "base64 0.22.1",
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "bytes",
  "bytestring",
  "derive_more 2.0.1",
@@ -361,8 +361,8 @@ dependencies = [
  "streaming-iterator",
  "string-offset",
  "strsim 0.11.1",
- "strum",
- "strum_macros",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "syntax_tree",
  "tempfile",
  "thiserror 2.0.17",
@@ -439,7 +439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c88dbbce13b232b26250e1e2e6ac18b6a891a646b8148285036ebce260ac5c3"
 dependencies = [
  "alsa-sys",
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "cfg-if",
  "libc",
 ]
@@ -461,7 +461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
 dependencies = [
  "android-properties",
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "cc",
  "cesu8",
  "jni",
@@ -609,7 +609,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -1438,6 +1438,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2079,7 +2088,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.11.0",
@@ -2102,7 +2111,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -2175,11 +2184,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2188,7 +2197,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b64e60c28b6d25ad92e8b367801ff9aa12b41d05fc8798055d296bace4a60cc"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "serde",
 ]
 
@@ -2392,6 +2401,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "byte-unit"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2516,7 +2531,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "log",
  "polling",
  "rustix 0.38.44",
@@ -2657,9 +2672,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -2982,7 +2997,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f79398230a6e2c08f5c9760610eb6924b52aa9e7950a619602baba59dcbbdbb2"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "block",
  "cocoa-foundation 0.2.1",
  "core-foundation 0.10.1",
@@ -3012,7 +3027,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "block",
  "core-foundation 0.10.1",
  "core-graphics-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3079,7 +3094,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3315,7 +3330,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-graphics-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.5.0",
@@ -3327,7 +3342,7 @@ name = "core-graphics"
 version = "0.25.0"
 source = "git+https://github.com/servo/core-foundation-rs?rev=6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff#6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-graphics-types 0.2.0 (git+https://github.com/servo/core-foundation-rs?rev=6f844cf1a1a18e25b70fcdf1bcdc458555bd2eff)",
  "foreign-types 0.5.0",
@@ -3351,7 +3366,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -3411,7 +3426,7 @@ name = "cosmic-text"
 version = "0.12.0"
 source = "git+https://github.com/warpdotdev/cosmic-text.git?rev=15198beba692162201c0ea8b15222cf5643ea068#15198beba692162201c0ea8b15222cf5643ea068"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "fontdb",
  "log",
  "rangemap",
@@ -3588,6 +3603,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3633,7 +3654,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more 2.0.1",
  "document-features",
@@ -3690,6 +3711,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
 ]
 
 [[package]]
@@ -4362,7 +4393,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.3",
@@ -4396,7 +4427,7 @@ checksum = "6738d2e996274e499bc7b0d693c858b7720b9cd2543a0643a3087e6cb0a4fa16"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4701,7 +4732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4797,6 +4828,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
 name = "fastdivide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4882,6 +4919,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.63",
+ "winapi",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4921,12 +4969,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
 name = "firebase"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "serde",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixedbitset"
@@ -5014,7 +5074,7 @@ name = "font-kit"
 version = "0.12.0"
 source = "git+https://github.com/warpdotdev/font-kit?rev=a04b225ecb639bb850f21d05212cfdc7465000f3#a04b225ecb639bb850f21d05212cfdc7465000f3"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "byteorder",
  "core-foundation 0.10.1",
  "core-graphics 0.25.0",
@@ -5634,7 +5694,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -5859,7 +5919,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "gpu-descriptor-types",
  "hashbrown 0.15.2",
 ]
@@ -5870,7 +5930,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6076,6 +6136,17 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
  "serde",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -6422,7 +6493,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6718,6 +6789,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "infer"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6732,7 +6812,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -6792,12 +6872,25 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2628910d0114e9139056161d8644a2026be7b117f8498943f9437748b04c9e0a"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "crossterm",
  "dyn-clone",
  "fuzzy-matcher",
  "unicode-segmentation",
  "unicode-width 0.2.1",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6841,8 +6934,8 @@ dependencies = [
  "serde_json",
  "settings",
  "simplelog",
- "strum",
- "strum_macros",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "sum_tree",
  "sysinfo",
  "version-compare",
@@ -6964,7 +7057,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7158,7 +7251,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7272,12 +7365,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
+dependencies = [
+ "hashbrown 0.16.0",
+ "portable-atomic",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "serde",
  "unicode-segmentation",
 ]
@@ -7305,7 +7409,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9f1da1000eb32cea537203e5ea121eb06e66c5e5f3420a1e9f11a57676f55b"
 dependencies = [
- "palette",
+ "palette 0.6.1",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
 ]
@@ -7340,6 +7444,12 @@ dependencies = [
  "euclid",
  "smallvec 1.15.1",
 ]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lalrpop-util"
@@ -7459,7 +7569,7 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "libc",
  "redox_syscall 0.4.1",
 ]
@@ -7470,7 +7580,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "libc",
  "redox_syscall 0.5.7",
 ]
@@ -7496,6 +7606,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -7677,6 +7796,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7710,8 +7838,8 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "simple_logger",
- "strum",
- "strum_macros",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "tokio",
  "url",
  "warp_core",
@@ -7784,6 +7912,16 @@ dependencies = [
  "objc2 0.6.3",
  "objc2-foundation 0.3.2",
  "time",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "winapi",
 ]
 
 [[package]]
@@ -8009,6 +8147,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
 name = "memo-map"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8089,7 +8233,7 @@ version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c4d14bcca0fd3ed165a03000480aaa364c6860c34e900cb2dafdf3b95340e77"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "debugid",
  "num-derive",
  "num-traits",
@@ -8104,7 +8248,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abcd9c8a1e6e1e9d56ce3627851f39a17ea83e17c96bc510f29d7e43d78a7d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "byteorder",
  "cfg-if",
  "crash-context",
@@ -8300,7 +8444,7 @@ checksum = "aa2630921705b9b01dcdd0b6864b9562ca3c1951eecd0f0c4f5f04f61e412647"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "codespan-reporting",
@@ -8397,7 +8541,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -8445,10 +8589,23 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+ "memoffset 0.9.0",
 ]
 
 [[package]]
@@ -8457,7 +8614,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -8470,7 +8627,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -8528,7 +8685,7 @@ name = "notify"
 version = "8.0.0"
 source = "git+https://github.com/warpdotdev/notify?rev=91b719849bc04ef251bcb2cc61076b099204e970#91b719849bc04ef251bcb2cc61076b099204e970"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "filetime",
  "fsevent-sys",
  "inotify",
@@ -8736,6 +8893,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "numtoa"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
+
+[[package]]
 name = "oauth2"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8804,7 +8967,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -8820,7 +8983,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "objc2 0.6.3",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -8834,7 +8997,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6c2736f2e27584ca5c75640186542e772ce550a3c5182fc358526dea242c068"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "libc",
  "objc2 0.6.3",
  "objc2-core-audio",
@@ -8849,7 +9012,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "objc2 0.6.3",
  "objc2-foundation 0.3.2",
 ]
@@ -8870,7 +9033,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -8907,7 +9070,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "objc2 0.6.3",
 ]
 
@@ -8917,7 +9080,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -8929,7 +9092,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "dispatch2",
  "libc",
@@ -8942,7 +9105,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "dispatch2",
  "libc",
@@ -8988,7 +9151,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "dispatch",
  "libc",
@@ -9001,7 +9164,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.3",
@@ -9024,7 +9187,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "objc2 0.6.3",
  "objc2-core-foundation",
 ]
@@ -9047,7 +9210,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -9059,7 +9222,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "dispatch2",
  "objc2 0.6.3",
@@ -9072,7 +9235,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -9085,7 +9248,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "objc2 0.6.3",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -9108,7 +9271,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
@@ -9140,7 +9303,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -9179,8 +9342,8 @@ dependencies = [
  "rust-embed 8.7.2",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "ui_components",
  "uuid",
  "warp_core",
@@ -9213,7 +9376,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -9279,7 +9442,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -9414,6 +9577,15 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
@@ -9480,7 +9652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9552,7 +9724,19 @@ checksum = "8f9cd68f7112581033f157e56c77ac4a5538ec5836a2e39284e65bd7d7275e49"
 dependencies = [
  "approx",
  "num-traits",
- "palette_derive",
+ "palette_derive 0.6.1",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive 0.7.6",
 ]
 
 [[package]]
@@ -9565,6 +9749,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9694,12 +9890,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "hashbrown 0.15.2",
  "indexmap 2.12.0",
  "serde",
@@ -9721,6 +9960,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros",
  "phf_shared",
 ]
 
@@ -9742,6 +9982,19 @@ checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9883,7 +10136,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -10175,7 +10428,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "hex",
 ]
 
@@ -10214,8 +10467,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.11.0",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -10234,7 +10487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10479,7 +10732,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10642,6 +10895,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "977b1e897f9d764566891689e642653e5ed90c6895106acd005eb4c1d0203991"
 
 [[package]]
+name = "ratatui"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termion",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
+dependencies = [
+ "bitflags 2.13.0",
+ "compact_str",
+ "critical-section",
+ "hashbrown 0.17.1",
+ "indoc",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru 0.18.0",
+ "palette 0.7.6",
+ "serde",
+ "strum 0.28.0",
+ "thiserror 2.0.17",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.1",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80fac59720679490d89d200df411faa249be728681adcabed3d047ae72c48f1d"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termion"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c16cc35a9d9114e0b2bb4b22018b96ae7f5fe60e2595dc73e622b4e78624835"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termion",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "386b8ff8f74ed749509391c56d549761a2fcdb408e1f42e467286bcb7dac8967"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum 0.28.0",
+ "time",
+ "unicode-segmentation",
+ "unicode-width 0.2.1",
+]
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10697,7 +11052,7 @@ version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -10810,7 +11165,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -10973,8 +11328,8 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "tempfile",
  "thiserror 2.0.17",
  "virtual-fs",
@@ -11365,11 +11720,11 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11378,11 +11733,11 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11450,7 +11805,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 1.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11483,7 +11838,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "bytemuck",
  "core_maths",
  "log",
@@ -11685,7 +12040,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -11826,7 +12181,7 @@ version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "235865e639f1d72414fa5d35374e105c292e2ee3a2f90919d961bbb486626ee6"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "log",
  "sentry-core",
 ]
@@ -11847,7 +12202,7 @@ version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27701acc51e68db5281802b709010395bfcbcb128b1d0a4e5873680d3b47ff0c"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "sentry-backtrace",
  "sentry-core",
  "tracing-core",
@@ -12434,7 +12789,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
@@ -12517,7 +12872,7 @@ version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -12656,6 +13011,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12665,6 +13029,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -12849,7 +13225,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -12878,7 +13254,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -12932,7 +13308,7 @@ dependencies = [
  "itertools 0.14.0",
  "levenshtein_automata",
  "log",
- "lru",
+ "lru 0.16.3",
  "lz4_flex 0.13.0",
  "measure_time",
  "memmap2 0.9.7",
@@ -13101,7 +13477,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13125,10 +13501,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom 7.1.3",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termion"
+version = "4.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44138a9ae08f0f502f24104d82517ef4da7330c35acd638f1f29d3cd5475ecb"
+dependencies = [
+ "libc",
+ "numtoa",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "termwiz"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed32af792ae81937cb8640b03eaef737408e5c8feee47b35e8b80c49bcb64524"
+dependencies = [
+ "anyhow",
+ "base64 0.21.7",
+ "bitflags 2.13.0",
+ "fancy-regex 0.11.0",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset 0.4.2",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix 0.28.0",
+ "num-derive",
+ "num-traits",
+ "ordered-float 4.6.0",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2 0.10.9",
+ "signal-hook",
+ "siphasher 0.3.11",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.63",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
 
 [[package]]
 name = "thiserror"
@@ -13730,7 +14179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -13986,6 +14435,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "uds"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14109,6 +14564,17 @@ name = "unicode-segmentation"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools 0.14.0",
+ "unicode-segmentation",
+ "unicode-width 0.2.1",
+]
 
 [[package]]
 name = "unicode-vo"
@@ -14306,6 +14772,7 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
+ "atomic",
  "getrandom 0.3.4",
  "js-sys",
  "serde_core",
@@ -14487,6 +14954,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse 0.2.2",
+]
+
+[[package]]
 name = "waker-fn"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14543,7 +15019,7 @@ dependencies = [
  "base64 0.22.1",
  "bimap",
  "bincode",
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "bitflags-serde-legacy",
  "block",
  "blocking",
@@ -14676,7 +15152,7 @@ dependencies = [
  "opentelemetry_sdk",
  "ordered-float 3.9.2",
  "os_info",
- "palette",
+ "palette 0.6.1",
  "parking_lot",
  "pathfinder_color",
  "pathfinder_geometry",
@@ -14731,8 +15207,8 @@ dependencies = [
  "smol_str",
  "static_assertions",
  "string-offset",
- "strum",
- "strum_macros",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "sum_tree",
  "syntax_tree",
  "syntect",
@@ -14973,8 +15449,8 @@ dependencies = [
  "settings_value",
  "shellexpand",
  "string-offset",
- "strum",
- "strum_macros",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "sysinfo",
  "tempfile",
  "thiserror 2.0.17",
@@ -15232,8 +15708,8 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "string-offset",
- "strum",
- "strum_macros",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "tantivy",
  "warp_core",
  "warpui_core",
@@ -15304,7 +15780,7 @@ name = "warp_terminal"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "bitflags-serde-legacy",
  "cfg-if",
  "channel_versions",
@@ -15491,7 +15967,6 @@ dependencies = [
  "chrono",
  "command",
  "concat-idents",
- "crossterm",
  "ctor",
  "ctrlc",
  "dashmap",
@@ -15523,6 +15998,7 @@ dependencies = [
  "pathfinder_geometry",
  "rand 0.8.6",
  "rangemap",
+ "ratatui",
  "raw-window-handle 0.6.2",
  "resvg",
  "rstar",
@@ -15536,8 +16012,8 @@ dependencies = [
  "simplelog",
  "smallvec 1.15.1",
  "string-offset",
- "strum",
- "strum_macros",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "sum_tree",
  "tempfile",
  "thiserror 2.0.17",
@@ -15545,8 +16021,6 @@ dependencies = [
  "tokio",
  "tracing",
  "trait-set",
- "unicode-segmentation",
- "unicode-width 0.1.14",
  "vec1",
  "warp_util",
  "warpui_core",
@@ -15708,7 +16182,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "hashbrown 0.15.2",
  "indexmap 2.12.0",
  "semver",
@@ -15746,7 +16220,7 @@ version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "rustix 1.1.2",
  "wayland-backend",
  "wayland-scanner",
@@ -15758,7 +16232,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -15780,7 +16254,7 @@ version = "0.32.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -15792,7 +16266,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a07a14257c077ab3279987c4f8bb987851bf57081b93710381daea94f2c2c032"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -15805,7 +16279,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -15941,6 +16415,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2 0.10.9",
+ "thiserror 1.0.63",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float 4.6.0",
+ "strsim 0.11.1",
+ "thiserror 1.0.63",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
 name = "wfd"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15957,7 +16502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c239a9a747bbd379590985bac952c2e53cb19873f7072b3370c6a6a8e06837"
 dependencies = [
  "arrayvec",
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg-if",
  "cfg_aliases 0.2.1",
@@ -15988,7 +16533,7 @@ dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
  "bit-vec 0.9.1",
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg_aliases 0.2.1",
  "document-features",
@@ -16059,7 +16604,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set 0.9.1",
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "bytemuck",
  "cfg-if",
@@ -16118,7 +16663,7 @@ version = "29.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec2675540fb1a5cfa5ef122d3d5f390e2c75711a0b946410f2d6ac3a0f77d1f6"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "bytemuck",
  "js-sys",
  "log",
@@ -16191,7 +16736,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -16614,7 +17159,7 @@ dependencies = [
  "ahash 0.8.11",
  "android-activity",
  "atomic-waker",
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "bytemuck",
  "calloop",
@@ -16762,7 +17307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "indexmap 2.12.0",
  "log",
  "serde",
@@ -16933,7 +17478,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.13.0",
  "dlib",
  "log",
  "once_cell",

--- a/crates/warpui_core/Cargo.toml
+++ b/crates/warpui_core/Cargo.toml
@@ -8,10 +8,6 @@ license = "MIT"
 
 [features]
 traces = []
-# Purely additive: enables the TUI backend (views, elements, presenter,
-# runtime) alongside the always-compiled GUI machinery. The default (GUI)
-# build is unaffected, and enabling this feature anywhere in a dependency
-# graph does not change GUI consumers (feature unification is harmless).
 tui = ["dep:ratatui"]
 # Feature enabled only when app is compiled for integration tests.
 integration_tests = ["dep:minimp4", "dep:openh264"]

--- a/crates/warpui_core/Cargo.toml
+++ b/crates/warpui_core/Cargo.toml
@@ -8,7 +8,11 @@ license = "MIT"
 
 [features]
 traces = []
-tui = ["dep:crossterm", "dep:unicode-segmentation", "dep:unicode-width"]
+# Purely additive: enables the TUI backend (views, elements, presenter,
+# runtime) alongside the always-compiled GUI machinery. The default (GUI)
+# build is unaffected, and enabling this feature anywhere in a dependency
+# graph does not change GUI consumers (feature unification is harmless).
+tui = ["dep:ratatui"]
 # Feature enabled only when app is compiled for integration tests.
 integration_tests = ["dep:minimp4", "dep:openh264"]
 # When enabled, skip eager scene building from the window-invalidation callback
@@ -33,7 +37,6 @@ bounded-vec-deque.workspace = true
 bytes.workspace = true
 cfg-if.workspace = true
 chrono = "0.4"
-crossterm = { version = "0.29.0", optional = true }
 dashmap.workspace = true
 derivative.workspace = true
 derive_more.workspace = true
@@ -63,6 +66,12 @@ pathfinder_color.workspace = true
 pathfinder_geometry.workspace = true
 rand.workspace = true
 rangemap.workspace = true
+ratatui = { version = "0.30", optional = true, features = [
+    "scrolling-regions",
+    "unstable-backend-writer",
+    "unstable-rendered-line-info",
+    "unstable-widget-ref",
+] }
 raw-window-handle = "0.6.2"
 resvg.workspace = true
 rstar = "0.12.2"
@@ -81,8 +90,6 @@ titlecase = "1.0"
 tokio.workspace = true
 tracing.workspace = true
 trait-set = "0.3.0"
-unicode-segmentation = { version = "1.11.0", optional = true }
-unicode-width = { workspace = true, optional = true }
 vec1.workspace = true
 warp_util.workspace = true
 

--- a/crates/warpui_core/Cargo.toml
+++ b/crates/warpui_core/Cargo.toml
@@ -63,10 +63,7 @@ pathfinder_geometry.workspace = true
 rand.workspace = true
 rangemap.workspace = true
 ratatui = { version = "0.30", optional = true, features = [
-    "scrolling-regions",
-    "unstable-backend-writer",
     "unstable-rendered-line-info",
-    "unstable-widget-ref",
 ] }
 raw-window-handle = "0.6.2"
 resvg.workspace = true

--- a/crates/warpui_core/src/elements/tui/buffer.rs
+++ b/crates/warpui_core/src/elements/tui/buffer.rs
@@ -1,300 +1,47 @@
-//! The in-memory cell grid that elements paint into and the renderer flushes to
-//! the terminal.
+//! The styled cell grid the element tree paints into.
 //!
-//! [`TuiBuffer`] is the headless assertion surface for the whole TUI backend:
-//! every element/presenter test paints into a buffer and compares
-//! [`to_lines`](TuiBuffer::to_lines) (and, where style matters, individual
-//! [`get`](TuiBuffer::get) cells) against expected values. All writes are
-//! clipped to the buffer bounds and are wide- and combining-grapheme aware, so
-//! callers never have to bounds-check or measure text themselves.
+//! This is ratatui's `Buffer` (re-exported as [`TuiBuffer`]) with `Style`
+//! re-exported as [`TuiStyle`] and `Cell` re-exported for convenience. Elements
+//! paint with the buffer's own grapheme-aware writers (`set_string`,
+//! `cell_mut`, `set_style`); the diff/flush to the terminal is the ratatui
+//! `Terminal`'s job, wired up by the runtime.
+//!
+//! [`TuiBufferExt::to_lines`] is the headless assertion hook used throughout the
+//! element tests: it renders each row to a `String`, skipping the trailing
+//! columns of wide graphemes so every glyph appears exactly once (mirroring how
+//! ratatui's own `Buffer` debug output collapses multi-width cells).
 
-use crossterm::style::Color;
-use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::UnicodeWidthStr;
+use ratatui::buffer::CellWidth;
+pub use ratatui::buffer::{Buffer as TuiBuffer, Cell};
+pub use ratatui::style::Style as TuiStyle;
 
-use super::{TuiRect, TuiSize};
-
-/// The visual styling applied to a [`Cell`]. Cheap to copy; equality is exact,
-/// which is what makes style-sensitive buffer assertions possible.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct TuiStyle {
-    pub foreground: Option<Color>,
-    pub background: Option<Color>,
-    pub bold: bool,
-    pub dim: bool,
-    pub italic: bool,
-    pub underline: bool,
-    pub reversed: bool,
+/// Headless rendering of a [`TuiBuffer`] to one `String` per row.
+pub trait TuiBufferExt {
+    /// Renders the buffer to one `String` per row, emitting each grapheme once
+    /// by skipping the trailing columns a wide grapheme occupies.
+    fn to_lines(&self) -> Vec<String>;
 }
 
-impl TuiStyle {
-    pub fn with_foreground(mut self, color: Color) -> Self {
-        self.foreground = Some(color);
-        self
-    }
-
-    pub fn with_background(mut self, color: Color) -> Self {
-        self.background = Some(color);
-        self
-    }
-
-    pub fn with_bold(mut self, bold: bool) -> Self {
-        self.bold = bold;
-        self
-    }
-
-    pub fn with_dim(mut self, dim: bool) -> Self {
-        self.dim = dim;
-        self
-    }
-
-    pub fn with_italic(mut self, italic: bool) -> Self {
-        self.italic = italic;
-        self
-    }
-
-    pub fn with_underline(mut self, underline: bool) -> Self {
-        self.underline = underline;
-        self
-    }
-
-    pub fn with_reversed(mut self, reversed: bool) -> Self {
-        self.reversed = reversed;
-        self
-    }
-}
-
-/// A single terminal cell: one grapheme cluster plus its style.
-///
-/// A grapheme that occupies more than one column (e.g. a CJK character) is
-/// stored as a leading cell holding the symbol followed by one or more
-/// *continuation* cells; the renderer skips continuation cells so the wide
-/// glyph is emitted exactly once. Construct printable cells with [`Cell::new`];
-/// continuation cells are produced internally by the buffer.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Cell {
-    symbol: String,
-    continuation: bool,
-    style: TuiStyle,
-}
-
-impl Cell {
-    /// A printable cell holding `symbol` (a single grapheme cluster) styled
-    /// with `style`.
-    pub fn new(symbol: impl Into<String>, style: TuiStyle) -> Self {
-        Self {
-            symbol: symbol.into(),
-            continuation: false,
-            style,
-        }
-    }
-
-    /// A blank (space) cell with default styling. This is the fill value of a
-    /// freshly constructed buffer.
-    pub fn blank() -> Self {
-        Self {
-            symbol: " ".to_owned(),
-            continuation: false,
-            style: TuiStyle::default(),
-        }
-    }
-
-    pub fn symbol(&self) -> &str {
-        &self.symbol
-    }
-
-    pub fn style(&self) -> TuiStyle {
-        self.style
-    }
-
-    /// Whether this cell is the trailing column of a preceding wide grapheme.
-    /// The renderer emits nothing for continuation cells.
-    pub fn is_continuation(&self) -> bool {
-        self.continuation
-    }
-
-    fn continuation(style: TuiStyle) -> Self {
-        Self {
-            symbol: String::new(),
-            continuation: true,
-            style,
-        }
-    }
-}
-
-impl Default for Cell {
-    fn default() -> Self {
-        Self::blank()
-    }
-}
-
-/// A fixed-size grid of [`Cell`]s addressed by `(x, y)` in column/row order.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct TuiBuffer {
-    size: TuiSize,
-    cells: Vec<Cell>,
-}
-
-impl TuiBuffer {
-    /// A blank buffer of the given size.
-    pub fn new(size: TuiSize) -> Self {
-        Self {
-            size,
-            cells: vec![Cell::default(); size.area()],
-        }
-    }
-
-    pub fn size(&self) -> TuiSize {
-        self.size
-    }
-
-    /// The cell at `(x, y)`, or `None` if out of bounds.
-    pub fn get(&self, x: u16, y: u16) -> Option<&Cell> {
-        self.index(x, y).map(|index| &self.cells[index])
-    }
-
-    /// Writes a single printable cell at `(x, y)`. Out-of-bounds positions are
-    /// silently ignored. Continuation/empty cells are ignored, since the buffer
-    /// manages continuations itself; use [`set_str`](TuiBuffer::set_str) for
-    /// wide graphemes.
-    pub fn set_cell(&mut self, x: u16, y: u16, cell: Cell) {
-        if cell.continuation || cell.symbol.is_empty() {
-            return;
-        }
-        self.write_grapheme(x, y, &cell.symbol, cell.style);
-    }
-
-    /// Writes `text` starting at `(x, y)`, clipped to the lesser of `max_width`
-    /// columns and the buffer's right edge. Grapheme clusters that would cross
-    /// the limit are dropped whole (a wide glyph is never split). Returns the
-    /// number of columns actually advanced.
-    pub fn set_str(&mut self, x: u16, y: u16, max_width: u16, text: &str, style: TuiStyle) -> u16 {
-        if y >= self.size.height || x >= self.size.width {
-            return 0;
-        }
-        let limit = x.saturating_add(max_width).min(self.size.width);
-        let mut column = x;
-        for grapheme in text.graphemes(true) {
-            let width = grapheme_width(grapheme);
-            if column.saturating_add(width) > limit {
-                break;
-            }
-            self.write_grapheme(column, y, grapheme, style);
-            column = column.saturating_add(width);
-        }
-        column - x
-    }
-
-    /// Fills every cell of `rect` (intersected with the buffer) with a clone of
-    /// `cell`. Typically used to paint a styled background.
-    pub fn fill(&mut self, rect: TuiRect, cell: Cell) {
-        for y in rect.y..rect.bottom().min(self.size.height) {
-            for x in rect.x..rect.right().min(self.size.width) {
-                self.set_cell(x, y, cell.clone());
-            }
-        }
-    }
-
-    /// Renders the buffer to one `String` per row, omitting continuation cells
-    /// so wide glyphs appear once. This is the primary headless assertion hook.
-    pub fn to_lines(&self) -> Vec<String> {
-        (0..self.size.height)
-            .map(|y| {
+impl TuiBufferExt for TuiBuffer {
+    fn to_lines(&self) -> Vec<String> {
+        let area = self.area;
+        (0..area.height)
+            .map(|row| {
                 let mut line = String::new();
-                for x in 0..self.size.width {
-                    if let Some(cell) = self.get(x, y) {
-                        if !cell.is_continuation() {
-                            line.push_str(cell.symbol());
-                        }
+                let mut skip = 0u16;
+                for column in 0..area.width {
+                    let cell = &self[(area.x + column, area.y + row)];
+                    if skip == 0 {
+                        line.push_str(cell.symbol());
+                        skip = cell.cell_width().max(1) - 1;
+                    } else {
+                        skip -= 1;
                     }
                 }
                 line
             })
             .collect()
     }
-
-    fn write_grapheme(&mut self, x: u16, y: u16, grapheme: &str, style: TuiStyle) {
-        let width = grapheme_width(grapheme);
-        if x >= self.size.width
-            || y >= self.size.height
-            || x.saturating_add(width) > self.size.width
-        {
-            return;
-        }
-
-        // Clear any wide grapheme we are about to partially overwrite, both at
-        // the head and across the columns the new grapheme will occupy.
-        self.clear_grapheme_at(x, y);
-        for continuation_x in (x + 1)..(x + width) {
-            self.clear_grapheme_at(continuation_x, y);
-        }
-
-        if let Some(index) = self.index(x, y) {
-            self.cells[index] = Cell {
-                symbol: grapheme.to_owned(),
-                continuation: false,
-                style,
-            };
-        }
-        for continuation_x in (x + 1)..(x + width) {
-            if let Some(index) = self.index(continuation_x, y) {
-                self.cells[index] = Cell::continuation(style);
-            }
-        }
-    }
-
-    /// Blanks the full grapheme covering `(x, y)`, walking left to the leading
-    /// cell if `(x, y)` is a continuation, then clearing its trailing cells.
-    fn clear_grapheme_at(&mut self, x: u16, y: u16) {
-        let Some(index) = self.index(x, y) else {
-            return;
-        };
-
-        if self.cells[index].is_continuation() {
-            let mut start_x = x;
-            while start_x > 0 {
-                let previous_x = start_x - 1;
-                let Some(previous_index) = self.index(previous_x, y) else {
-                    break;
-                };
-                start_x = previous_x;
-                if !self.cells[previous_index].is_continuation() {
-                    break;
-                }
-            }
-            self.clear_grapheme_at(start_x, y);
-            return;
-        }
-
-        self.cells[index] = Cell::blank();
-        let mut continuation_x = x.saturating_add(1);
-        while continuation_x < self.size.width {
-            let Some(continuation_index) = self.index(continuation_x, y) else {
-                break;
-            };
-            if !self.cells[continuation_index].is_continuation() {
-                break;
-            }
-            self.cells[continuation_index] = Cell::blank();
-            continuation_x += 1;
-        }
-    }
-
-    fn index(&self, x: u16, y: u16) -> Option<usize> {
-        if x >= self.size.width || y >= self.size.height {
-            return None;
-        }
-        Some(usize::from(y) * usize::from(self.size.width) + usize::from(x))
-    }
-}
-
-/// The column width of a grapheme cluster, floored at 1 so zero-width clusters
-/// (e.g. a lone combining mark) still occupy a cell.
-fn grapheme_width(grapheme: &str) -> u16 {
-    UnicodeWidthStr::width(grapheme)
-        .max(1)
-        .try_into()
-        .unwrap_or(u16::MAX)
 }
 
 #[cfg(test)]

--- a/crates/warpui_core/src/elements/tui/buffer_tests.rs
+++ b/crates/warpui_core/src/elements/tui/buffer_tests.rs
@@ -1,138 +1,57 @@
-use super::*;
+use ratatui::style::{Color, Style};
 
-#[test]
-fn writes_ascii_text_and_pads_with_blanks() {
-    let mut buffer = TuiBuffer::new(TuiSize::new(5, 1));
+use crate::elements::tui::{TuiBuffer, TuiBufferExt, TuiRect};
 
-    let advanced = buffer.set_str(0, 0, 5, "abc", TuiStyle::default());
-
-    assert_eq!(advanced, 3);
-    assert_eq!(buffer.to_lines(), vec!["abc  "]);
+fn buffer(width: u16, height: u16) -> TuiBuffer {
+    TuiBuffer::empty(TuiRect::new(0, 0, width, height))
 }
 
 #[test]
-fn writes_text_at_an_offset() {
-    let mut buffer = TuiBuffer::new(TuiSize::new(5, 2));
-
-    buffer.set_str(2, 1, 5, "hi", TuiStyle::default());
-
-    assert_eq!(
-        buffer.to_lines(),
-        vec!["     ".to_owned(), "  hi ".to_owned()]
-    );
+fn to_lines_renders_rows_and_pads_with_blanks() {
+    let mut b = buffer(5, 1);
+    b.set_string(0, 0, "abc", Style::default());
+    assert_eq!(b.to_lines(), vec!["abc  "]);
 }
 
 #[test]
-fn out_of_bounds_writes_are_clipped_not_panicking() {
-    let mut buffer = TuiBuffer::new(TuiSize::new(3, 2));
-
-    // Entirely out of bounds in x, y: no-ops.
-    assert_eq!(buffer.set_str(9, 0, 5, "xx", TuiStyle::default()), 0);
-    assert_eq!(buffer.set_str(0, 9, 5, "xx", TuiStyle::default()), 0);
-    buffer.set_cell(9, 9, Cell::new("z", TuiStyle::default()));
-    assert!(buffer.get(9, 9).is_none());
-
-    // Partially off the right edge: only what fits is written.
-    let advanced = buffer.set_str(1, 0, 5, "world", TuiStyle::default());
-    assert_eq!(advanced, 2);
-    assert_eq!(buffer.to_lines(), vec![" wo".to_owned(), "   ".to_owned()]);
+fn to_lines_reads_text_written_at_an_offset() {
+    let mut b = buffer(5, 2);
+    b.set_string(2, 1, "hi", Style::default());
+    assert_eq!(b.to_lines(), vec!["     ".to_owned(), "  hi ".to_owned()]);
 }
 
 #[test]
-fn max_width_clips_before_the_buffer_edge() {
-    let mut buffer = TuiBuffer::new(TuiSize::new(10, 1));
+fn to_lines_collapses_a_wide_grapheme_trailing_column() {
+    let mut b = buffer(4, 1);
+    b.set_string(0, 0, "界a", Style::default());
 
-    let advanced = buffer.set_str(0, 0, 3, "abcdef", TuiStyle::default());
-
-    assert_eq!(advanced, 3);
-    assert_eq!(buffer.to_lines(), vec!["abc       "]);
+    assert_eq!(b.to_lines(), vec!["界a "]);
+    assert_eq!(b[(0, 0)].symbol(), "界");
+    assert_eq!(b[(2, 0)].symbol(), "a");
 }
 
 #[test]
-fn set_cell_writes_one_glyph_and_get_reads_it_back() {
-    let mut buffer = TuiBuffer::new(TuiSize::new(2, 1));
-    let style = TuiStyle::default().with_foreground(Color::Red);
+fn to_lines_keeps_a_combining_grapheme_in_one_cell() {
+    let mut b = buffer(4, 1);
+    b.set_string(0, 0, "e\u{301}x", Style::default());
 
-    buffer.set_cell(0, 0, Cell::new("x", style));
-
-    assert_eq!(buffer.get(0, 0).unwrap().symbol(), "x");
-    assert_eq!(buffer.get(0, 0).unwrap().style(), style);
-    assert_eq!(buffer.get(1, 0).unwrap(), &Cell::blank());
+    assert_eq!(b.to_lines(), vec!["e\u{301}x  "]);
+    assert_eq!(b[(0, 0)].symbol(), "e\u{301}");
+    assert_eq!(b[(1, 0)].symbol(), "x");
 }
 
 #[test]
-fn fill_paints_a_styled_background_over_a_rect() {
-    let mut buffer = TuiBuffer::new(TuiSize::new(4, 3));
-    let style = TuiStyle::default().with_background(Color::Blue);
-
-    buffer.fill(TuiRect::new(1, 1, 2, 1), Cell::new(" ", style));
-
-    assert_eq!(buffer.get(0, 1).unwrap().style(), TuiStyle::default());
-    assert_eq!(buffer.get(1, 1).unwrap().style(), style);
-    assert_eq!(buffer.get(2, 1).unwrap().style(), style);
-    assert_eq!(buffer.get(3, 1).unwrap().style(), TuiStyle::default());
+fn set_string_drops_a_wide_grapheme_that_would_cross_the_edge() {
+    let mut b = buffer(3, 1);
+    b.set_string(0, 0, "ab界", Style::default());
+    assert_eq!(b.to_lines(), vec!["ab "]);
 }
 
 #[test]
-fn buffers_compare_equal_iff_contents_and_styles_match() {
-    let mut a = TuiBuffer::new(TuiSize::new(3, 1));
-    let mut b = TuiBuffer::new(TuiSize::new(3, 1));
-    a.set_str(0, 0, 3, "ab", TuiStyle::default());
-    b.set_str(0, 0, 3, "ab", TuiStyle::default());
-    assert_eq!(a, b);
+fn styled_writes_round_trip_through_cells() {
+    let mut b = buffer(2, 1);
+    b.set_string(0, 0, "x", Style::default().fg(Color::Red));
 
-    // Same glyphs, different style => not equal.
-    let mut c = TuiBuffer::new(TuiSize::new(3, 1));
-    c.set_str(0, 0, 3, "ab", TuiStyle::default().with_bold(true));
-    assert_ne!(a, c);
-
-    // Different size => not equal.
-    let d = TuiBuffer::new(TuiSize::new(3, 2));
-    assert_ne!(a, d);
-}
-
-#[test]
-fn combining_grapheme_occupies_a_single_cell() {
-    let mut buffer = TuiBuffer::new(TuiSize::new(4, 1));
-
-    buffer.set_str(0, 0, 4, "e\u{301}x", TuiStyle::default());
-
-    assert_eq!(buffer.to_lines(), vec!["e\u{301}x  "]);
-    assert_eq!(buffer.get(0, 0).unwrap().symbol(), "e\u{301}");
-    assert!(!buffer.get(0, 0).unwrap().is_continuation());
-    assert_eq!(buffer.get(1, 0).unwrap().symbol(), "x");
-}
-
-#[test]
-fn wide_grapheme_spans_two_columns_with_a_continuation_cell() {
-    let mut buffer = TuiBuffer::new(TuiSize::new(4, 1));
-
-    buffer.set_str(0, 0, 4, "界a", TuiStyle::default());
-
-    assert_eq!(buffer.to_lines(), vec!["界a "]);
-    assert_eq!(buffer.get(0, 0).unwrap().symbol(), "界");
-    assert!(buffer.get(1, 0).unwrap().is_continuation());
-    assert_eq!(buffer.get(2, 0).unwrap().symbol(), "a");
-}
-
-#[test]
-fn a_wide_grapheme_that_would_cross_the_edge_is_dropped_whole() {
-    let mut buffer = TuiBuffer::new(TuiSize::new(3, 1));
-
-    buffer.set_str(0, 0, 3, "ab界", TuiStyle::default());
-
-    assert_eq!(buffer.to_lines(), vec!["ab "]);
-}
-
-#[test]
-fn overwriting_a_wide_grapheme_clears_its_continuation_cell() {
-    let mut buffer = TuiBuffer::new(TuiSize::new(4, 1));
-    buffer.set_str(0, 0, 4, "界a", TuiStyle::default());
-
-    buffer.set_str(0, 0, 1, "b", TuiStyle::default());
-
-    assert_eq!(buffer.to_lines(), vec!["b a "]);
-    assert_eq!(buffer.get(0, 0).unwrap().symbol(), "b");
-    assert!(!buffer.get(1, 0).unwrap().is_continuation());
-    assert_eq!(buffer.get(1, 0).unwrap().symbol(), " ");
+    assert_eq!(b[(0, 0)].symbol(), "x");
+    assert_eq!(b[(0, 0)].fg, Color::Red);
 }

--- a/crates/warpui_core/src/elements/tui/child_view_tests.rs
+++ b/crates/warpui_core/src/elements/tui/child_view_tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use super::TuiChildView;
 use crate::elements::tui::{
-    TuiBuffer, TuiElement, TuiPresentationContext, TuiRect, TuiSize, TuiText,
+    TuiBuffer, TuiBufferExt, TuiElement, TuiPresentationContext, TuiRect, TuiText,
 };
 use crate::EntityId;
 
@@ -10,7 +10,7 @@ use crate::EntityId;
 fn embeds_and_renders_the_stub_at_the_given_area() {
     let view = TuiChildView::from_rendered(EntityId::from_usize(1), Box::new(TuiText::new("Z")));
 
-    let mut buffer = TuiBuffer::new(TuiSize::new(3, 1));
+    let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, 3, 1));
     // Render offset one column in: the embedded glyph must land at x = 1.
     view.render(TuiRect::new(1, 0, 2, 1), &mut buffer);
     assert_eq!(buffer.to_lines(), vec![" Z "]);

--- a/crates/warpui_core/src/elements/tui/column.rs
+++ b/crates/warpui_core/src/elements/tui/column.rs
@@ -17,7 +17,8 @@
 //! available height are clipped.
 
 use super::{
-    TuiBuffer, TuiConstraint, TuiElement, TuiEventContext, TuiPresentationContext, TuiRect, TuiSize,
+    TuiBuffer, TuiConstraint, TuiElement, TuiEventContext, TuiPresentationContext, TuiRect,
+    TuiRectExt, TuiSize,
 };
 use crate::{AppContext, Event};
 

--- a/crates/warpui_core/src/elements/tui/column_tests.rs
+++ b/crates/warpui_core/src/elements/tui/column_tests.rs
@@ -4,16 +4,16 @@ use std::rc::Rc;
 
 use super::TuiColumn;
 use crate::elements::tui::{
-    TuiBuffer, TuiChildView, TuiConstraint, TuiElement, TuiEventContext, TuiEventHandler,
-    TuiParentElement, TuiPresentationContext, TuiRect, TuiSize, TuiText,
+    TuiBuffer, TuiBufferExt, TuiChildView, TuiConstraint, TuiElement, TuiEventContext,
+    TuiEventHandler, TuiParentElement, TuiPresentationContext, TuiRect, TuiSize, TuiText,
 };
 use crate::event::KeyEventDetails;
 use crate::keymap::Keystroke;
 use crate::{App, EntityId, Event};
 
 fn render_to_lines(element: &dyn TuiElement, size: TuiSize) -> Vec<String> {
-    let mut buffer = TuiBuffer::new(size);
-    element.render(TuiRect::from_size(size), &mut buffer);
+    let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, size.width, size.height));
+    element.render(TuiRect::new(0, 0, size.width, size.height), &mut buffer);
     buffer.to_lines()
 }
 

--- a/crates/warpui_core/src/elements/tui/container.rs
+++ b/crates/warpui_core/src/elements/tui/container.rs
@@ -17,11 +17,11 @@
 //! to the constraint), so the child occupies exactly the area left inside the
 //! frame and padding.
 
-use crossterm::style::Color;
+use ratatui::style::Color;
 
 use super::{
-    Cell, TuiBuffer, TuiConstraint, TuiElement, TuiEventContext, TuiPresentationContext, TuiRect,
-    TuiSize, TuiStyle,
+    TuiBuffer, TuiConstraint, TuiElement, TuiEventContext, TuiPresentationContext, TuiRect,
+    TuiRectExt, TuiSize, TuiStyle,
 };
 use crate::{AppContext, Event};
 
@@ -74,8 +74,8 @@ impl TuiContainer {
     /// the frame sits seamlessly on the filled area.
     fn painted_border_style(&self) -> TuiStyle {
         let mut style = self.border_style;
-        if style.background.is_none() {
-            style.background = self.background;
+        if style.bg.is_none() {
+            style.bg = self.background;
         }
         style
     }
@@ -102,10 +102,7 @@ impl TuiElement for TuiContainer {
         }
 
         if let Some(background) = self.background {
-            buffer.fill(
-                area,
-                Cell::new(" ", TuiStyle::default().with_background(background)),
-            );
+            buffer.set_style(area, TuiStyle::default().bg(background));
         }
 
         if self.border {
@@ -148,27 +145,34 @@ fn draw_border(area: TuiRect, buffer: &mut TuiBuffer, style: TuiStyle) {
     let multi_row = area.height > 1;
 
     for x in area.x..area.right() {
-        buffer.set_cell(x, area.y, Cell::new("─", style));
+        put(buffer, x, area.y, "─", style);
         if multi_row {
-            buffer.set_cell(x, bottom, Cell::new("─", style));
+            put(buffer, x, bottom, "─", style);
         }
     }
     for y in area.y..area.bottom() {
-        buffer.set_cell(area.x, y, Cell::new("│", style));
+        put(buffer, area.x, y, "│", style);
         if multi_column {
-            buffer.set_cell(right, y, Cell::new("│", style));
+            put(buffer, right, y, "│", style);
         }
     }
 
-    buffer.set_cell(area.x, area.y, Cell::new("┌", style));
+    put(buffer, area.x, area.y, "┌", style);
     if multi_column {
-        buffer.set_cell(right, area.y, Cell::new("┐", style));
+        put(buffer, right, area.y, "┐", style);
     }
     if multi_row {
-        buffer.set_cell(area.x, bottom, Cell::new("└", style));
+        put(buffer, area.x, bottom, "└", style);
     }
     if multi_column && multi_row {
-        buffer.set_cell(right, bottom, Cell::new("┘", style));
+        put(buffer, right, bottom, "┘", style);
+    }
+}
+
+/// Writes a single styled glyph at `(x, y)`, ignoring out-of-bounds positions.
+fn put(buffer: &mut TuiBuffer, x: u16, y: u16, symbol: &str, style: TuiStyle) {
+    if let Some(cell) = buffer.cell_mut((x, y)) {
+        cell.set_symbol(symbol).set_style(style);
     }
 }
 

--- a/crates/warpui_core/src/elements/tui/container_tests.rs
+++ b/crates/warpui_core/src/elements/tui/container_tests.rs
@@ -2,20 +2,20 @@ use std::cell::Cell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use crossterm::style::Color;
+use ratatui::style::Color;
 
 use super::TuiContainer;
 use crate::elements::tui::{
-    TuiBuffer, TuiChildView, TuiConstraint, TuiElement, TuiEventContext, TuiEventHandler,
-    TuiPresentationContext, TuiRect, TuiSize, TuiText,
+    TuiBuffer, TuiBufferExt, TuiChildView, TuiConstraint, TuiElement, TuiEventContext,
+    TuiEventHandler, TuiPresentationContext, TuiRect, TuiSize, TuiText,
 };
 use crate::event::KeyEventDetails;
 use crate::keymap::Keystroke;
 use crate::{App, EntityId, Event};
 
 fn render_to_lines(element: &dyn TuiElement, size: TuiSize) -> Vec<String> {
-    let mut buffer = TuiBuffer::new(size);
-    element.render(TuiRect::from_size(size), &mut buffer);
+    let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, size.width, size.height));
+    element.render(TuiRect::new(0, 0, size.width, size.height), &mut buffer);
     buffer.to_lines()
 }
 
@@ -60,16 +60,13 @@ fn background_fills_the_padding_area() {
         .with_padding(1)
         .with_background(Color::Blue);
 
-    let mut buffer = TuiBuffer::new(TuiSize::new(3, 3));
+    let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, 3, 3));
     container.render(TuiRect::new(0, 0, 3, 3), &mut buffer);
 
     // A padding cell carries the background fill...
-    assert_eq!(
-        buffer.get(0, 0).expect("cell in bounds").style().background,
-        Some(Color::Blue),
-    );
+    assert_eq!(buffer[(0, 0)].bg, Color::Blue);
     // ...and the child glyph lands in the center.
-    assert_eq!(buffer.get(1, 1).expect("cell in bounds").symbol(), "X");
+    assert_eq!(buffer[(1, 1)].symbol(), "X");
 }
 
 #[test]

--- a/crates/warpui_core/src/elements/tui/geometry.rs
+++ b/crates/warpui_core/src/elements/tui/geometry.rs
@@ -1,151 +1,16 @@
-//! Integer cell-grid geometry shared across the TUI rendering layers.
+//! Integer cell-grid geometry for the TUI rendering layers.
 //!
-//! All dimensions are in terminal cells (`u16`). The geometry deliberately
-//! mirrors a small slice of the GUI geometry vocabulary but stays integral,
-//! since a terminal grid has no sub-cell positions.
+//! Sizes and rectangles are ratatui's own `Size`/`Rect` (re-exported as
+//! [`TuiSize`]/[`TuiRect`]) so the element tree measures and paints in the same
+//! coordinate types the ratatui `Buffer` uses, with no conversions.
+//!
+//! [`TuiConstraint`] is a local min/max measure box. It is deliberately *not*
+//! ratatui's `Constraint`, which is the input to ratatui's layout *solver*
+//! (Length/Min/Max/Fill/…), not a bound an element clamps its natural size
+//! against. [`TuiRectExt`] adds the few slicing helpers the hand-rolled
+//! column/container layout needs that ratatui's `Rect` does not provide.
 
-use crate::geometry::vector::Vector2F;
-
-/// A width/height pair in terminal cells.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct TuiSize {
-    pub width: u16,
-    pub height: u16,
-}
-
-impl TuiSize {
-    pub const ZERO: Self = Self {
-        width: 0,
-        height: 0,
-    };
-
-    pub const fn new(width: u16, height: u16) -> Self {
-        Self { width, height }
-    }
-
-    /// The number of cells covered by a region of this size.
-    pub fn area(self) -> usize {
-        usize::from(self.width) * usize::from(self.height)
-    }
-}
-
-/// An axis-aligned rectangle of terminal cells. The covered columns are
-/// `x .. x + width` and rows `y .. y + height` (half-open).
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct TuiRect {
-    pub x: u16,
-    pub y: u16,
-    pub width: u16,
-    pub height: u16,
-}
-
-impl TuiRect {
-    pub const fn new(x: u16, y: u16, width: u16, height: u16) -> Self {
-        Self {
-            x,
-            y,
-            width,
-            height,
-        }
-    }
-
-    /// Builds a rect at the origin with the given size.
-    pub const fn from_size(size: TuiSize) -> Self {
-        Self::new(0, 0, size.width, size.height)
-    }
-
-    pub const fn size(self) -> TuiSize {
-        TuiSize::new(self.width, self.height)
-    }
-
-    /// The first column past the right edge (saturating).
-    pub fn right(self) -> u16 {
-        self.x.saturating_add(self.width)
-    }
-
-    /// The first row past the bottom edge (saturating).
-    pub fn bottom(self) -> u16 {
-        self.y.saturating_add(self.height)
-    }
-
-    pub fn is_empty(self) -> bool {
-        self.width == 0 || self.height == 0
-    }
-
-    /// Shrinks the rect by `inset` cells on every side, saturating at zero. A
-    /// rect too small to inset collapses to zero width/height (never wraps).
-    ///
-    /// ```
-    /// # use warpui_core::elements::tui::TuiRect;
-    /// assert_eq!(
-    ///     TuiRect::new(2, 2, 10, 6).inset(1),
-    ///     TuiRect::new(3, 3, 8, 4),
-    /// );
-    /// assert_eq!(TuiRect::new(0, 0, 1, 1).inset(2), TuiRect::new(2, 2, 0, 0));
-    /// ```
-    pub fn inset(self, inset: u16) -> Self {
-        let shrink = inset.saturating_mul(2);
-        Self {
-            x: self.x.saturating_add(inset),
-            y: self.y.saturating_add(inset),
-            width: self.width.saturating_sub(shrink),
-            height: self.height.saturating_sub(shrink),
-        }
-    }
-
-    /// Splits off the top `height` rows, returning `(top, remainder)`. `height`
-    /// is clamped to this rect's height, so the two halves always tile the
-    /// original rect exactly.
-    ///
-    /// ```
-    /// # use warpui_core::elements::tui::TuiRect;
-    /// let (top, rest) = TuiRect::new(0, 0, 8, 5).split_top(2);
-    /// assert_eq!(top, TuiRect::new(0, 0, 8, 2));
-    /// assert_eq!(rest, TuiRect::new(0, 2, 8, 3));
-    /// ```
-    pub fn split_top(self, height: u16) -> (Self, Self) {
-        let top_height = height.min(self.height);
-        let top = Self::new(self.x, self.y, self.width, top_height);
-        let remainder = Self::new(
-            self.x,
-            self.y.saturating_add(top_height),
-            self.width,
-            self.height - top_height,
-        );
-        (top, remainder)
-    }
-
-    /// Splits off the left `width` columns, returning `(left, remainder)`.
-    /// `width` is clamped to this rect's width, so the two halves always tile
-    /// the original rect exactly.
-    ///
-    /// ```
-    /// # use warpui_core::elements::tui::TuiRect;
-    /// let (left, rest) = TuiRect::new(0, 0, 8, 5).split_left(3);
-    /// assert_eq!(left, TuiRect::new(0, 0, 3, 5));
-    /// assert_eq!(rest, TuiRect::new(3, 0, 5, 5));
-    /// ```
-    pub fn split_left(self, width: u16) -> (Self, Self) {
-        let left_width = width.min(self.width);
-        let left = Self::new(self.x, self.y, left_width, self.height);
-        let remainder = Self::new(
-            self.x.saturating_add(left_width),
-            self.y,
-            self.width - left_width,
-            self.height,
-        );
-        (left, remainder)
-    }
-
-    /// Whether a (sub-cell) point falls inside this rect, used for mouse
-    /// hit-testing against crossterm's pixel-free cell coordinates.
-    pub fn contains_position(self, position: Vector2F) -> bool {
-        position.x() >= f32::from(self.x)
-            && position.x() < f32::from(self.right())
-            && position.y() >= f32::from(self.y)
-            && position.y() < f32::from(self.bottom())
-    }
-}
+pub use ratatui::layout::{Rect as TuiRect, Size as TuiSize};
 
 /// A layout constraint: an element handed a `TuiConstraint` must return a
 /// [`TuiSize`] with `min.width <= width <= max.width` and
@@ -203,6 +68,61 @@ impl TuiConstraint {
     /// Clamps a height into `[min.height, max.height]`.
     pub fn constrain_height(self, height: u16) -> u16 {
         height.clamp(self.min.height, self.max.height)
+    }
+}
+
+/// Slicing helpers for [`TuiRect`] used by the hand-rolled stacking layout.
+///
+/// ratatui's `Rect` already provides `is_empty`/`right`/`bottom`/`area`; this
+/// trait adds the symmetric inset and the top/left splits the column and
+/// container rely on. Each split clamps to the rect's extent, so the two halves
+/// always tile the original rect exactly.
+pub trait TuiRectExt: Sized {
+    /// Shrinks the rect by `inset` cells on every side, saturating at zero. A
+    /// rect too small to inset advances its origin but collapses to zero
+    /// width/height (it never wraps).
+    fn inset(self, inset: u16) -> Self;
+
+    /// Splits off the top `height` rows, returning `(top, remainder)`.
+    fn split_top(self, height: u16) -> (Self, Self);
+
+    /// Splits off the left `width` columns, returning `(left, remainder)`.
+    fn split_left(self, width: u16) -> (Self, Self);
+}
+
+impl TuiRectExt for TuiRect {
+    fn inset(self, inset: u16) -> Self {
+        let shrink = inset.saturating_mul(2);
+        Self {
+            x: self.x.saturating_add(inset),
+            y: self.y.saturating_add(inset),
+            width: self.width.saturating_sub(shrink),
+            height: self.height.saturating_sub(shrink),
+        }
+    }
+
+    fn split_top(self, height: u16) -> (Self, Self) {
+        let top_height = height.min(self.height);
+        let top = Self::new(self.x, self.y, self.width, top_height);
+        let remainder = Self::new(
+            self.x,
+            self.y.saturating_add(top_height),
+            self.width,
+            self.height - top_height,
+        );
+        (top, remainder)
+    }
+
+    fn split_left(self, width: u16) -> (Self, Self) {
+        let left_width = width.min(self.width);
+        let left = Self::new(self.x, self.y, left_width, self.height);
+        let remainder = Self::new(
+            self.x.saturating_add(left_width),
+            self.y,
+            self.width - left_width,
+            self.height,
+        );
+        (left, remainder)
     }
 }
 

--- a/crates/warpui_core/src/elements/tui/mod.rs
+++ b/crates/warpui_core/src/elements/tui/mod.rs
@@ -35,13 +35,13 @@ mod geometry;
 mod parent;
 mod text;
 
-pub use buffer::{Cell, TuiBuffer, TuiStyle};
+pub use buffer::{Cell, TuiBuffer, TuiBufferExt, TuiStyle};
 pub use child_view::TuiChildView;
 pub use column::TuiColumn;
 pub use container::TuiContainer;
 pub use event::{TuiDispatchEventResult, TuiEventContext, TuiEventDispatchResult};
 pub use event_handler::TuiEventHandler;
-pub use geometry::{TuiConstraint, TuiRect, TuiSize};
+pub use geometry::{TuiConstraint, TuiRect, TuiRectExt, TuiSize};
 pub use parent::TuiParentElement;
 pub use text::TuiText;
 

--- a/crates/warpui_core/src/elements/tui/text.rs
+++ b/crates/warpui_core/src/elements/tui/text.rs
@@ -1,29 +1,27 @@
 //! [`TuiText`]: a styled run of text that wraps (or truncates) to the width it
-//! is laid out at.
+//! is laid out at, built on ratatui's `Paragraph`.
 //!
 //! # Construction
 //! Build with [`TuiText::new`] and chain builders:
 //! - [`with_style`](TuiText::with_style) sets the [`TuiStyle`] applied to every
 //!   glyph.
 //! - [`truncate`](TuiText::truncate) switches from the default word-wrapping
-//!   policy to single-row-per-line truncation.
+//!   policy to single-row-per-hard-line truncation.
 //!
 //! # Layout policy
-//! The text is first split into *hard lines* on `'\n'`. Each hard line is then
-//! laid out against the available width in one of two modes:
+//! Wrapping and measurement defer to `Paragraph`, so layout, render, and
+//! `desired_height` always agree:
+//! - **Wrap** (default): word-wrapped with whitespace preserved
+//!   (`Wrap { trim: false }`); a word wider than the row is broken at grapheme
+//!   boundaries.
+//! - **Truncate**: each hard line becomes one row, clipped to the width.
 //!
-//! - **Wrap** (default): tokens (space-separated words) are packed greedily,
-//!   separated by a single space, starting a new row whenever the next token
-//!   would overflow. A token wider than the whole width is hard-broken at
-//!   grapheme boundaries. Runs of spaces collapse to a single separator.
-//! - **Truncate**: each hard line becomes exactly one row; glyphs past the
-//!   width are dropped by the buffer when painted.
-//!
-//! Column widths are measured with `unicode-width`, so a wide (CJK) glyph
-//! occupies two columns and is never split across rows.
+//! Height is `Paragraph::line_count` and the natural width is
+//! `Paragraph::line_width`; both are column-accurate for wide (CJK) glyphs, so a
+//! wide glyph occupies two columns and is never split across rows. An empty
+//! string occupies no rows.
 
-use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::UnicodeWidthStr;
+use ratatui::widgets::{Paragraph, Widget, Wrap};
 
 use super::{TuiBuffer, TuiConstraint, TuiElement, TuiRect, TuiSize, TuiStyle};
 
@@ -54,30 +52,25 @@ impl TuiText {
         self
     }
 
-    /// The rows this text occupies when laid out at `width` columns, under the
-    /// active wrap/truncate policy. This is the single source of truth shared by
-    /// [`layout`](TuiElement::layout), [`render`](TuiElement::render), and
-    /// [`desired_height`](TuiElement::desired_height).
-    fn rows(&self, width: u16) -> Vec<String> {
-        if self.text.is_empty() {
-            return Vec::new();
-        }
+    /// The ratatui `Paragraph` backing this element's measure and paint.
+    fn paragraph(&self) -> Paragraph<'_> {
+        let paragraph = Paragraph::new(self.text.as_str()).style(self.style);
         if self.wrap {
-            self.text
-                .split('\n')
-                .flat_map(|line| wrap_hard_line(line, width))
-                .collect()
+            paragraph.wrap(Wrap { trim: false })
         } else {
-            self.text.split('\n').map(str::to_owned).collect()
+            paragraph
         }
     }
 }
 
 impl TuiElement for TuiText {
     fn layout(&mut self, constraint: TuiConstraint) -> TuiSize {
-        let rows = self.rows(constraint.max.width);
-        let content_width = rows.iter().map(|row| text_width(row)).max().unwrap_or(0);
-        let height = u16::try_from(rows.len()).unwrap_or(u16::MAX);
+        if self.text.is_empty() {
+            return constraint.clamp(TuiSize::ZERO);
+        }
+        let paragraph = self.paragraph();
+        let height = u16::try_from(paragraph.line_count(constraint.max.width)).unwrap_or(u16::MAX);
+        let content_width = u16::try_from(paragraph.line_width()).unwrap_or(u16::MAX);
         TuiSize::new(
             constraint.constrain_width(content_width),
             constraint.constrain_height(height),
@@ -88,109 +81,15 @@ impl TuiElement for TuiText {
         if area.is_empty() {
             return;
         }
-        for (offset, row) in self.rows(area.width).iter().enumerate() {
-            let Ok(offset) = u16::try_from(offset) else {
-                break;
-            };
-            if offset >= area.height {
-                break;
-            }
-            buffer.set_str(area.x, area.y + offset, area.width, row, self.style);
-        }
+        Widget::render(self.paragraph(), area, buffer);
     }
 
     fn desired_height(&self, width: u16) -> u16 {
-        u16::try_from(self.rows(width).len()).unwrap_or(u16::MAX)
-    }
-}
-
-/// Greedily wraps a single newline-free line to `width` columns. Returns one
-/// `String` per visual row (empty when `width` is zero).
-fn wrap_hard_line(line: &str, width: u16) -> Vec<String> {
-    if width == 0 {
-        return Vec::new();
-    }
-
-    let mut rows = Vec::new();
-    let mut current = String::new();
-    let mut current_width = 0;
-
-    for token in line.split(' ').filter(|token| !token.is_empty()) {
-        let token_width = text_width(token);
-
-        if !current.is_empty() && current_width + 1 + token_width <= width {
-            current.push(' ');
-            current.push_str(token);
-            current_width += 1 + token_width;
-            continue;
+        if self.text.is_empty() {
+            return 0;
         }
-
-        if !current.is_empty() {
-            rows.push(std::mem::take(&mut current));
-            current_width = 0;
-        }
-
-        if token_width <= width {
-            current = token.to_owned();
-            current_width = token_width;
-            continue;
-        }
-
-        // The token is wider than a full row: hard-break it at grapheme
-        // boundaries, carrying the final fragment into `current`.
-        let chunks = hard_break(token, width);
-        let last = chunks.len().saturating_sub(1);
-        for (index, chunk) in chunks.into_iter().enumerate() {
-            if index == last {
-                current_width = text_width(&chunk);
-                current = chunk;
-            } else {
-                rows.push(chunk);
-            }
-        }
+        u16::try_from(self.paragraph().line_count(width)).unwrap_or(u16::MAX)
     }
-
-    if !current.is_empty() {
-        rows.push(current);
-    }
-    if rows.is_empty() {
-        rows.push(String::new());
-    }
-    rows
-}
-
-/// Splits `token` into fragments each at most `width` columns wide, breaking
-/// only on grapheme boundaries (a single glyph wider than `width` is kept whole
-/// and clipped later by the buffer).
-fn hard_break(token: &str, width: u16) -> Vec<String> {
-    let mut chunks = Vec::new();
-    let mut current = String::new();
-    let mut current_width = 0;
-
-    for grapheme in token.graphemes(true) {
-        let glyph_width = grapheme_width(grapheme);
-        if !current.is_empty() && current_width + glyph_width > width {
-            chunks.push(std::mem::take(&mut current));
-            current_width = 0;
-        }
-        current.push_str(grapheme);
-        current_width += glyph_width;
-    }
-
-    if !current.is_empty() {
-        chunks.push(current);
-    }
-    chunks
-}
-
-fn text_width(text: &str) -> u16 {
-    u16::try_from(UnicodeWidthStr::width(text)).unwrap_or(u16::MAX)
-}
-
-/// The column width of a single grapheme, floored at 1 to mirror the buffer's
-/// own measurement of zero-width clusters.
-fn grapheme_width(grapheme: &str) -> u16 {
-    u16::try_from(UnicodeWidthStr::width(grapheme).max(1)).unwrap_or(u16::MAX)
 }
 
 #[cfg(test)]

--- a/crates/warpui_core/src/elements/tui/text_tests.rs
+++ b/crates/warpui_core/src/elements/tui/text_tests.rs
@@ -1,11 +1,11 @@
-use crossterm::style::Color;
+use ratatui::style::{Color, Modifier, Style};
 
 use super::TuiText;
-use crate::elements::tui::{TuiBuffer, TuiConstraint, TuiElement, TuiRect, TuiSize, TuiStyle};
+use crate::elements::tui::{TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiRect, TuiSize};
 
 fn render_to_lines(element: &dyn TuiElement, size: TuiSize) -> Vec<String> {
-    let mut buffer = TuiBuffer::new(size);
-    element.render(TuiRect::from_size(size), &mut buffer);
+    let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, size.width, size.height));
+    element.render(TuiRect::new(0, 0, size.width, size.height), &mut buffer);
     buffer.to_lines()
 }
 
@@ -51,7 +51,7 @@ fn wide_glyphs_occupy_two_columns_and_are_never_split() {
     // A wide glyph painted with one trailing column to spare drops whole: only
     // the leading "日" lands, proving it claimed two columns.
     let truncated = TuiText::new("日本").truncate();
-    assert_eq!(render_to_lines(&truncated, TuiSize::new(3, 1)), vec!["日 "],);
+    assert_eq!(render_to_lines(&truncated, TuiSize::new(3, 1)), vec!["日 "]);
 
     // Given exactly four columns both wide glyphs fit.
     assert_eq!(
@@ -59,28 +59,28 @@ fn wide_glyphs_occupy_two_columns_and_are_never_split() {
         vec!["日本"],
     );
 
-    // Wrapping a wide pair into a three-column row splits between glyphs.
+    // Wrapping a wide pair into a two-column row puts one glyph per row
+    // (ratatui only breaks once the row's width is reached).
     let wrapped = TuiText::new("日本");
-    assert_eq!(wrapped.desired_height(3), 2);
+    assert_eq!(wrapped.desired_height(2), 2);
     assert_eq!(
-        render_to_lines(&wrapped, TuiSize::new(3, 2)),
-        vec!["日 ", "本 "],
+        render_to_lines(&wrapped, TuiSize::new(2, 2)),
+        vec!["日", "本"],
     );
 }
 
 #[test]
-fn applies_its_style_to_every_painted_cell() {
-    let style = TuiStyle::default()
-        .with_foreground(Color::Red)
-        .with_bold(true);
+fn applies_its_style_to_painted_cells() {
+    let style = Style::default().fg(Color::Red).add_modifier(Modifier::BOLD);
     let text = TuiText::new("a").with_style(style);
 
-    let mut buffer = TuiBuffer::new(TuiSize::new(1, 1));
+    let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, 1, 1));
     text.render(TuiRect::new(0, 0, 1, 1), &mut buffer);
 
-    let cell = buffer.get(0, 0).expect("cell in bounds");
+    let cell = &buffer[(0, 0)];
     assert_eq!(cell.symbol(), "a");
-    assert_eq!(cell.style(), style);
+    assert_eq!(cell.fg, Color::Red);
+    assert!(cell.modifier.contains(Modifier::BOLD));
 }
 
 #[test]


### PR DESCRIPTION
## Description
Swap the prototype TUI element library's hand-rolled primitive layer for **ratatui 0.30** primitives, behind the existing additive `tui` cargo feature. The default (GUI) and wasm builds are unaffected — `tui` is off by default and `ratatui` is an optional dependency.

This is the first step of building a TUI rendering backend for WarpUI (to support a TUI version of the agent harness). It is stacked on the prototype element library (`zb/tui-backend/03b-tui-elements`).

What changed:
- `TuiBuffer` / `TuiStyle` / `Cell` now re-export `ratatui::buffer::Buffer` / `ratatui::style::Style` / `Cell`, plus a `TuiBufferExt::to_lines` headless test helper.
- `TuiSize` / `TuiRect` re-export `ratatui::layout::{Size, Rect}`. A small local `TuiConstraint` is kept (ratatui's `Constraint` is the layout-solver enum, not a min/max measure box), and a `TuiRectExt` keeps the `inset` / `split_top` / `split_left` helpers the hand-rolled column/container rely on.
- `TuiText` wraps and measures via `ratatui::widgets::Paragraph` (`line_count` / `line_width`) instead of the naive splitter.
- `TuiContainer` paints through ratatui's `Buffer` writers (`cell_mut` / `set_style`).
- Depends on the `ratatui` umbrella crate (crossterm 0.29, matching the prototype) with `unstable-rendered-line-info` + `unstable-widget-ref`.

Rationale and the full design (why hybrid / ratatui-core over hand-rolling) are in the plan linked below.

## Linked Issue
No linked issue — internal, WIP infrastructure gated behind the `tui` feature (not user-visible).

## Testing
- `cargo nextest run -p warpui_core --features tui` — all pass (geometry / buffer / text / element tests ported to ratatui).
- `cargo test -p warpui_core --features tui --doc` — pass.
- `cargo build -p warpui_core` (default, no `tui`) — unaffected.
- `./script/format` and `cargo clippy -p warpui_core --features tui --all-targets -- -D warnings` — clean.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

---
Plan: https://staging.warp.dev/drive/notebook/RQNlhRWhQK3Djnr50YbC4G
Conversation: https://staging.warp.dev/conversation/9293e035-3939-42c7-aeee-110a5a131011

CHANGELOG-NONE
