### PR TITLE
remove reset grid assertion on conversation restore

### DIFF
--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -2740,6 +2740,8 @@ impl BlockList {
                 .flatten(),
             None,
         );
+
+        self.active_block_mut().disable_reset_grid_checks();
     }
 
     /// Splice a background block into the blocklist. This is called once the


### PR DESCRIPTION
## Description

This PR fixes this dev-only crash: https://warpdev.slack.com/archives/C0755SJ43GB/p1781723895031219?thread_ts=1778778633.524249&cid=C0755SJ43GB

Reset grid OSC never received if we're inserting a block as part of a restored conversation.

## Linked Issue

None. Dev-only fix.

## Testing

How to repro the bug:

Open WarpDev on Windows. Restore an old conversation with at least one block/command. It will crash.

On this branch, that no longer occurs.
