### PR TITLE
Remove TransientError status and simplify AI error handling

### DIFF
--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -94,8 +94,8 @@ use crate::code_review::context::{
 };
 use crate::code_review::diff_selector::{DiffSelector, DiffSelectorEvent, DiffTarget};
 use crate::code_review::diff_state::{
-    DiffHunk, DiffLineType, DiffMode, DiffState, DiffStateModel, DiffStateModelEvent, DiffStats,
-    FileDiff, FileDiffAndContent, FileStatusInfo, GitDiffWithBaseContent, GitFileStatus,
+    DiffHunk, DiffLineType, DiffMode, DiffSnapshot, DiffState, DiffStateModel, DiffStateModelEvent,
+    DiffStats, FileDiff, FileDiffAndContent, FileStatusInfo, GitDiffWithBaseContent, GitFileStatus,
 };
 use crate::code_review::editor_state::CodeReviewEditorState;
 use crate::code_review::find_model::CodeReviewFindModel;
@@ -1371,7 +1371,7 @@ impl CodeReviewView {
             // Tracked diff loading starts in `on_open`, after this view is
             // subscribed to `diff_state_model`, so the completion event can
             // be observed and logged.
-            view.invalidate_all(None, None, ctx);
+            view.sync_transient_state(ctx);
         }
 
         view
@@ -1599,7 +1599,7 @@ impl CodeReviewView {
             model.set_diff_mode(mode, false, true, preferred_session, ctx);
         });
         self.update_diff_selector_selection(ctx);
-        self.invalidate_all(None, None, ctx);
+        self.sync_transient_state(ctx);
     }
 
     fn handle_find_event(
@@ -2316,10 +2316,10 @@ impl CodeReviewView {
                 self.update_diff_selector_selection(ctx);
             }
             DiffStateModelEvent::NewDiffsComputed {
-                diffs,
+                snapshot,
                 load_duration,
             } => {
-                self.invalidate_all(diffs.as_ref().map(|d| d.as_ref()), *load_duration, ctx);
+                self.apply_diff_snapshot(snapshot, *load_duration, ctx);
                 if FeatureFlag::GitOperationsInCodeReview.is_enabled() {
                     self.update_git_operations_ui(ctx);
                 }
@@ -2466,68 +2466,81 @@ impl CodeReviewView {
         ctx.notify();
     }
 
-    /// Updates state for the view when new git diffs come in.
-    fn invalidate_all(
+    /// Applies an authoritative diff snapshot delivered by a `NewDiffsComputed`
+    /// event. The snapshot is self-describing, so the view acts on it directly
+    /// instead of re-reading the model's (possibly newer, possibly shared)
+    /// live state. A `Loaded` snapshot with no files clears the panel — this is
+    /// what lets a freshly emptied diff (e.g. after the changes are committed
+    /// or pushed) replace a previously rendered diff instead of leaving it
+    /// stale.
+    fn apply_diff_snapshot(
         &mut self,
-        diff_data: Option<&GitDiffWithBaseContent>,
+        snapshot: &DiffSnapshot,
         load_duration: Option<Duration>,
         ctx: &mut ViewContext<Self>,
     ) {
         if self.active_repo.is_none() {
             return;
-        };
+        }
 
-        match self.diff_state(ctx) {
-            DiffState::Loading => {
-                if let Some(repo) = self.active_repo.as_mut() {
-                    log::info!(
-                        "Code Review Panel: Setting state to loading after receiving 'loading' message."
-                    );
-                    repo.state = CodeReviewViewState::None;
-                }
-                ctx.notify();
-                return;
+        // `ConnectionLost` owns the disconnected view and intentionally keeps
+        // the last diff frozen. Events drain off a deferred queue, so a
+        // `NewDiffsComputed` emitted just before the disconnect can arrive after
+        // the model has gone `Disconnected`; applying it here would clobber the
+        // frozen diff with a stale error / no-repo / loading panel. Ignore it —
+        // reconnect re-fetches a fresh snapshot that rebuilds the view.
+        if matches!(self.diff_state(ctx), DiffState::Disconnected) {
+            return;
+        }
+
+        match snapshot {
+            DiffSnapshot::Loaded(diffs) => {
+                self.rebuild_loaded_state(diffs, load_duration, ctx);
             }
-            DiffState::NotInRepository => {
+            DiffSnapshot::NotInRepository => {
                 // `NotInRepository` is a terminal state from the diff model —
                 // the path has been checked and is definitively not inside a
-                // git repository. Show the "no repo found" UI instead of
-                // the loading spinner.
+                // git repository. Show the "no repo found" UI instead of the
+                // loading spinner.
                 if let Some(repo) = self.active_repo.as_mut() {
                     log::info!(
-                        "Code Review Panel: Setting state to no repo found after receiving 'not in repository' message."
+                        "Code Review Panel: Setting state to no repo found after receiving 'not in repository' snapshot."
                     );
                     repo.state = CodeReviewViewState::NoRepoFound;
                 }
                 ctx.notify();
-                return;
             }
-            DiffState::Error(err) => {
+            DiffSnapshot::Error(err) => {
                 if let Some(repo) = self.active_repo.as_mut() {
-                    repo.state = CodeReviewViewState::Error(err);
+                    repo.state = CodeReviewViewState::Error(err.clone());
                 }
                 ctx.notify();
-                return;
             }
-            DiffState::Disconnected => {
-                // Disconnected state is handled via the ConnectionLost event
-                // path, which preserves stale diffs. If invalidate_all is
-                // called while disconnected (e.g. from a stale push), ignore.
-                return;
+            DiffSnapshot::Loading => {
+                // No-flicker rule: a transient loading snapshot must not knock
+                // an already-loaded diff back to the spinner. Only show the
+                // spinner on the initial load, before any diff has rendered.
+                if !matches!(self.state(), CodeReviewViewState::Loaded(_)) {
+                    if let Some(repo) = self.active_repo.as_mut() {
+                        log::info!(
+                            "Code Review Panel: Setting state to loading after receiving 'loading' snapshot."
+                        );
+                        repo.state = CodeReviewViewState::None;
+                    }
+                    ctx.notify();
+                }
             }
-            DiffState::Loaded => (),
-        };
+        }
+    }
 
-        let Some(diff_data) = diff_data else {
-            // Stale event: the model advanced to Loaded via a later snapshot
-            // before this earlier NewDiffsComputed(None) was processed.
-            // Preserve the existing view state rather than clobbering it.
-            log::info!(
-                "Code Review Panel: Ignoring NewDiffsComputed(None) for already-loaded model"
-            );
-            return;
-        };
-
+    /// Rebuilds the view's file list from a freshly loaded diff. An empty
+    /// `diff_data` produces an empty list, clearing any previously shown diff.
+    fn rebuild_loaded_state(
+        &mut self,
+        diff_data: &GitDiffWithBaseContent,
+        load_duration: Option<Duration>,
+        ctx: &mut ViewContext<Self>,
+    ) {
         // Deallocate global buffers that are going to be invalidated.
         if let Some(repo) = self.active_repo.as_mut() {
             repo.state = CodeReviewViewState::None;
@@ -2580,6 +2593,49 @@ impl CodeReviewView {
         }
 
         ctx.notify();
+    }
+
+    /// Reflects the model's current transitional state in the view without
+    /// rebuilding diff content. Called right after kicking off a load (initial
+    /// construction, diff-mode change, base change) so the panel shows the
+    /// loading / no-repo / error state while the new diff loads; the diff
+    /// content itself is rebuilt later from the `NewDiffsComputed` snapshot. A
+    /// `Loaded` or `Disconnected` live state is left untouched so existing
+    /// content is preserved.
+    fn sync_transient_state(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.active_repo.is_none() {
+            return;
+        }
+
+        match self.diff_state(ctx) {
+            DiffState::Loading => {
+                if let Some(repo) = self.active_repo.as_mut() {
+                    log::info!(
+                        "Code Review Panel: Setting state to loading after receiving 'loading' message."
+                    );
+                    repo.state = CodeReviewViewState::None;
+                }
+                ctx.notify();
+            }
+            DiffState::NotInRepository => {
+                if let Some(repo) = self.active_repo.as_mut() {
+                    log::info!(
+                        "Code Review Panel: Setting state to no repo found after receiving 'not in repository' message."
+                    );
+                    repo.state = CodeReviewViewState::NoRepoFound;
+                }
+                ctx.notify();
+            }
+            DiffState::Error(err) => {
+                if let Some(repo) = self.active_repo.as_mut() {
+                    repo.state = CodeReviewViewState::Error(err);
+                }
+                ctx.notify();
+            }
+            // Preserve existing content: the load that was just kicked off will
+            // emit a `NewDiffsComputed` snapshot that rebuilds it.
+            DiffState::Loaded | DiffState::Disconnected => {}
+        }
     }
 
     /// Builds view state for the given file diffs, returning the list of newly created file states.
@@ -5985,7 +6041,7 @@ impl CodeReviewView {
             diff_state_model.set_diff_mode_and_fetch_base(diff_mode, preferred_session, ctx);
         });
         self.update_diff_selector_selection(ctx);
-        self.invalidate_all(None, None, ctx);
+        self.sync_transient_state(ctx);
     }
 
     /// Insert diff hunk as an inline attachment in the terminal input

--- a/app/src/code_review/code_review_view_tests.rs
+++ b/app/src/code_review/code_review_view_tests.rs
@@ -267,7 +267,7 @@ impl TestContext {
         let state =
             create_loaded_state_with_editors(app, window_id, vec![(file_path.into(), editor)]);
 
-        let diff_state_model = app.add_model(DiffStateModel::new_for_test);
+        let diff_state_model = app.add_model(DiffStateModel::new_for_local_test);
 
         let working_directories_model = app.add_model(|_| WorkingDirectoriesModel::new());
         let repo_key = LocalOrRemotePath::Local(repo_path.clone());
@@ -965,6 +965,80 @@ fn test_active_comments_not_marked_outdated() {
             assert_eq!(
                 fallbacks, 0,
                 "Should have no fallbacks when content matches"
+            );
+        });
+    });
+}
+
+#[test]
+fn loading_snapshot_preserves_already_loaded_diff() {
+    App::test((), |mut app| async move {
+        let ctx = TestContext::new(&mut app, "test.txt", "line 1\nline 2");
+
+        ctx.code_review_view.update(&mut app, |view, view_ctx| {
+            // Start from a rendered diff.
+            if let Some(repo) = view.active_repo.as_mut() {
+                repo.state = CodeReviewViewState::Loaded(ctx.state);
+            }
+
+            // A transient Loading snapshot must not knock an already-loaded
+            // diff back to the spinner (no-flicker rule).
+            view.apply_diff_snapshot(&DiffSnapshot::Loading, None, view_ctx);
+
+            assert!(
+                matches!(view.state(), CodeReviewViewState::Loaded(_)),
+                "Loading snapshot should leave an already-loaded diff intact"
+            );
+        });
+    });
+}
+
+#[test]
+fn loading_snapshot_shows_spinner_before_first_diff() {
+    App::test((), |mut app| async move {
+        let ctx = TestContext::new(&mut app, "test.txt", "line 1");
+
+        ctx.code_review_view.update(&mut app, |view, view_ctx| {
+            // No diff has rendered yet.
+            if let Some(repo) = view.active_repo.as_mut() {
+                repo.state = CodeReviewViewState::NoRepoFound;
+            }
+
+            view.apply_diff_snapshot(&DiffSnapshot::Loading, None, view_ctx);
+
+            assert!(
+                matches!(view.state(), CodeReviewViewState::None),
+                "Loading before any diff renders should show the spinner (None state)"
+            );
+        });
+    });
+}
+
+#[test]
+fn snapshot_while_disconnected_does_not_clobber_frozen_diff() {
+    App::test((), |mut app| async move {
+        let ctx = TestContext::new(&mut app, "test.txt", "line 1");
+
+        // Swap in a remote model stuck in `Disconnected` so `diff_state()`
+        // reports it; the local model `TestContext` wires can never be
+        // `Disconnected`.
+        let disconnected = app.add_model(DiffStateModel::new_for_remote_test);
+
+        ctx.code_review_view.update(&mut app, |view, view_ctx| {
+            view.diff_state_model = disconnected;
+
+            // A diff is frozen on screen from before the disconnect.
+            if let Some(repo) = view.active_repo.as_mut() {
+                repo.state = CodeReviewViewState::Loaded(ctx.state);
+            }
+
+            // A late Error snapshot drains after the disconnect; the guard must
+            // preserve the frozen diff rather than render an error panel.
+            view.apply_diff_snapshot(&DiffSnapshot::Error("boom".to_string()), None, view_ctx);
+
+            assert!(
+                matches!(view.state(), CodeReviewViewState::Loaded(_)),
+                "snapshot delivered while Disconnected must not overwrite the frozen diff"
             );
         });
     });

--- a/app/src/code_review/diff_state/local.rs
+++ b/app/src/code_review/diff_state/local.rs
@@ -62,9 +62,9 @@ cfg_if::cfg_if! {
 use super::DiffOperation;
 use super::{
     BackendOrigin, CommitChainMode, DiffHunk, DiffLine, DiffLineType, DiffMetadata,
-    DiffMetadataAgainstBase, DiffMode, DiffState, DiffStateError, DiffStateModelEvent, DiffStats,
-    FileDiff, FileDiffAndContent, FileStatusInfo, GitDiffData, GitDiffWithBaseContent,
-    GitFileStatus, GitOpResult,
+    DiffMetadataAgainstBase, DiffMode, DiffSnapshot, DiffState, DiffStateError,
+    DiffStateModelEvent, DiffStats, FileDiff, FileDiffAndContent, FileStatusInfo, GitDiffData,
+    GitDiffWithBaseContent, GitFileStatus, GitOpResult,
 };
 
 // Unicode bidirectional characters that should be flagged
@@ -314,7 +314,7 @@ impl LocalDiffStateModel {
                 me.state = InternalDiffState::NotInRepository;
                 me.tracked_diff_load_start_time = None;
                 ctx.emit(DiffStateModelEvent::NewDiffsComputed {
-                    diffs: None,
+                    snapshot: DiffSnapshot::NotInRepository,
                     load_duration: None,
                 });
             });
@@ -1701,8 +1701,15 @@ impl LocalDiffStateModel {
         self.state = InternalDiffState::Loaded((&diffs).into());
         // Compute merge base and flush deferred invalidations before emitting.
         self.recompute_merge_base_and_flush(ctx);
+        // A clean tree is `Ok` with an empty `GitDiffWithBaseContent`, so it
+        // rides through as `Loaded` (empty) and clears the panel; only a load
+        // failure becomes `Error`.
+        let snapshot = match diffs.changes {
+            Ok(data) => DiffSnapshot::Loaded(Arc::new(data)),
+            Err(err) => DiffSnapshot::Error(err),
+        };
         ctx.emit(DiffStateModelEvent::NewDiffsComputed {
-            diffs: diffs.changes.ok().map(Arc::new),
+            snapshot,
             load_duration,
         });
     }

--- a/app/src/code_review/diff_state/mod.rs
+++ b/app/src/code_review/diff_state/mod.rs
@@ -378,13 +378,30 @@ impl DiffStats {
     }
 }
 
+/// Self-describing result of a diff (re)load, carried by
+/// [`DiffStateModelEvent::NewDiffsComputed`]. Coupling the state with the
+/// payload makes contradictory combinations (e.g. "loaded but no diffs")
+/// unrepresentable: an empty working tree is `Loaded` with an empty
+/// `GitDiffWithBaseContent`, never absent.
+#[derive(Clone, Debug)]
+pub enum DiffSnapshot {
+    /// Diffs were computed successfully. Empty `files` means no changes.
+    Loaded(Arc<GitDiffWithBaseContent>),
+    /// The path is not inside a git repository.
+    NotInRepository,
+    /// Computing the diff failed; carries the error message.
+    Error(String),
+    /// A (re)load is in progress; no diffs are available yet.
+    Loading,
+}
+
 #[derive(Debug)]
 pub enum DiffStateModelEvent {
     /// Event dispatched when the current branch changes.
     CurrentBranchChanged,
     /// Event dispatched when new diffs are computed (full reload).
     NewDiffsComputed {
-        diffs: Option<Arc<GitDiffWithBaseContent>>,
+        snapshot: DiffSnapshot,
         load_duration: Option<Duration>,
     },
     /// Event dispatched when a single file's diff is updated incrementally.
@@ -485,11 +502,11 @@ impl DiffStateModel {
                 ctx.emit(DiffStateModelEvent::CurrentBranchChanged);
             }
             DiffStateModelEvent::NewDiffsComputed {
-                diffs,
+                snapshot,
                 load_duration,
             } => {
                 ctx.emit(DiffStateModelEvent::NewDiffsComputed {
-                    diffs: diffs.clone(),
+                    snapshot: snapshot.clone(),
                     load_duration: *load_duration,
                 });
             }
@@ -869,12 +886,19 @@ impl DiffStateModel {
 #[cfg(test)]
 impl DiffStateModel {
     /// Test-only constructor that creates a local-backend model without a
-    /// repository. All existing tests exercise local behavior; add a
-    /// `new_for_test_remote` variant when remote-backend tests are needed.
-    pub fn new_for_test(ctx: &mut ModelContext<Self>) -> Self {
+    /// repository. Most tests exercise local behavior; use
+    /// [`Self::new_for_remote_test`] for remote-backend coverage.
+    pub fn new_for_local_test(ctx: &mut ModelContext<Self>) -> Self {
         let local = ctx.add_model(LocalDiffStateModel::new_for_test);
         ctx.subscribe_to_model(&local, Self::forward_event);
         Self::Local(local)
+    }
+
+    /// Test-only constructor wrapping a remote backend.
+    pub fn new_for_remote_test(ctx: &mut ModelContext<Self>) -> Self {
+        let remote = ctx.add_model(|_| RemoteDiffStateModel::new_disconnected_for_test());
+        ctx.subscribe_to_model(&remote, Self::forward_event);
+        Self::Remote(remote)
     }
 }
 

--- a/app/src/code_review/diff_state/mod_tests.rs
+++ b/app/src/code_review/diff_state/mod_tests.rs
@@ -3,7 +3,7 @@ use super::{DiffMode, DiffState, DiffStateModel};
 #[test]
 fn new_for_test_creates_local_variant() {
     warpui::App::test((), |mut app| async move {
-        let handle = app.add_model(DiffStateModel::new_for_test);
+        let handle = app.add_model(DiffStateModel::new_for_local_test);
         handle.read(&app, |model, _ctx| {
             assert!(matches!(model, DiffStateModel::Local(_)));
         });
@@ -13,7 +13,7 @@ fn new_for_test_creates_local_variant() {
 #[test]
 fn get_returns_not_in_repository_for_test_model() {
     warpui::App::test((), |mut app| async move {
-        let handle = app.add_model(DiffStateModel::new_for_test);
+        let handle = app.add_model(DiffStateModel::new_for_local_test);
         let state = handle.read(&app, |model, ctx| model.get(ctx));
         assert!(matches!(state, DiffState::NotInRepository));
     });
@@ -22,7 +22,7 @@ fn get_returns_not_in_repository_for_test_model() {
 #[test]
 fn diff_mode_defaults_to_head() {
     warpui::App::test((), |mut app| async move {
-        let handle = app.add_model(DiffStateModel::new_for_test);
+        let handle = app.add_model(DiffStateModel::new_for_local_test);
         let mode = handle.read(&app, |model, ctx| model.diff_mode(ctx));
         assert!(matches!(mode, DiffMode::Head));
     });
@@ -31,7 +31,7 @@ fn diff_mode_defaults_to_head() {
 #[test]
 fn has_head_false_for_test_model() {
     warpui::App::test((), |mut app| async move {
-        let handle = app.add_model(DiffStateModel::new_for_test);
+        let handle = app.add_model(DiffStateModel::new_for_local_test);
         let has_head = handle.read(&app, |model, ctx| model.has_head(ctx));
         assert!(!has_head);
     });
@@ -40,7 +40,7 @@ fn has_head_false_for_test_model() {
 #[test]
 fn branch_info_none_for_test_model() {
     warpui::App::test((), |mut app| async move {
-        let handle = app.add_model(DiffStateModel::new_for_test);
+        let handle = app.add_model(DiffStateModel::new_for_local_test);
         handle.read(&app, |model, ctx| {
             assert_eq!(model.get_main_branch_name(ctx), None);
             assert_eq!(model.get_current_branch_name(ctx), None);
@@ -56,7 +56,7 @@ fn branch_info_none_for_test_model() {
 #[test]
 fn uncommitted_stats_none_for_test_model() {
     warpui::App::test((), |mut app| async move {
-        let handle = app.add_model(DiffStateModel::new_for_test);
+        let handle = app.add_model(DiffStateModel::new_for_local_test);
         let stats = handle.read(&app, |model, ctx| model.get_uncommitted_stats(ctx));
         assert!(stats.is_none());
     });

--- a/app/src/code_review/diff_state/remote.rs
+++ b/app/src/code_review/diff_state/remote.rs
@@ -18,7 +18,7 @@ use warp_util::standardized_path::StandardizedPath;
 use warpui::{ModelContext, SingletonEntity};
 
 use super::{
-    BackendOrigin, CommitChainMode, DiffMetadata, DiffMode, DiffOperation, DiffState,
+    BackendOrigin, CommitChainMode, DiffMetadata, DiffMode, DiffOperation, DiffSnapshot, DiffState,
     DiffStateError, DiffStateModelEvent, DiffStats, FileDiffAndContent, GitDiffData,
     GitDiffWithBaseContent,
 };
@@ -268,7 +268,7 @@ impl RemoteDiffStateModel {
         });
         self.state = InternalRemoteDiffState::Loading;
         ctx.emit(DiffStateModelEvent::NewDiffsComputed {
-            diffs: None,
+            snapshot: DiffSnapshot::Loading,
             load_duration: None,
         });
     }
@@ -389,14 +389,14 @@ impl RemoteDiffStateModel {
                 self.tracked_diff_load_start_time = None;
                 self.state = InternalRemoteDiffState::NotInRepository;
                 ctx.emit(DiffStateModelEvent::NewDiffsComputed {
-                    diffs: None,
+                    snapshot: DiffSnapshot::NotInRepository,
                     load_duration: None,
                 });
             }
             DiffState::Loading => {
                 self.state = InternalRemoteDiffState::Loading;
                 ctx.emit(DiffStateModelEvent::NewDiffsComputed {
-                    diffs: None,
+                    snapshot: DiffSnapshot::Loading,
                     load_duration: None,
                 });
             }
@@ -417,9 +417,9 @@ impl RemoteDiffStateModel {
                     },
                     ctx
                 );
-                self.state = InternalRemoteDiffState::Error(msg);
+                self.state = InternalRemoteDiffState::Error(msg.clone());
                 ctx.emit(DiffStateModelEvent::NewDiffsComputed {
-                    diffs: None,
+                    snapshot: DiffSnapshot::Error(msg),
                     load_duration: None,
                 });
             }
@@ -443,7 +443,7 @@ impl RemoteDiffStateModel {
                     );
                     self.state = InternalRemoteDiffState::Error(err.to_string());
                     ctx.emit(DiffStateModelEvent::NewDiffsComputed {
-                        diffs: None,
+                        snapshot: DiffSnapshot::Error(err.to_string()),
                         load_duration: None,
                     });
                     return;
@@ -455,7 +455,7 @@ impl RemoteDiffStateModel {
                     .map(|start| start.elapsed());
                 self.state = InternalRemoteDiffState::Loaded(diffs);
                 ctx.emit(DiffStateModelEvent::NewDiffsComputed {
-                    diffs: Some(Arc::new(base_content)),
+                    snapshot: DiffSnapshot::Loaded(Arc::new(base_content)),
                     load_duration,
                 });
             }
@@ -868,6 +868,27 @@ impl RemoteDiffStateModel {
         ctx.emit(DiffStateModelEvent::MetadataRefreshed(Box::new(
             metadata.clone(),
         )));
+    }
+}
+
+#[cfg(test)]
+impl RemoteDiffStateModel {
+    /// Test-only constructor for a model stuck in `Disconnected`, used by the
+    /// code review view tests to exercise the disconnect guard in
+    /// `apply_diff_snapshot` without standing up a `RemoteServerManager`
+    /// subscription.
+    pub(crate) fn new_disconnected_for_test() -> Self {
+        Self {
+            remote_path: RemotePath::new(
+                remote_server::HostId::new("test-host".to_string()),
+                StandardizedPath::try_new("/test/repo")
+                    .expect("test repo path should be valid and absolute"),
+            ),
+            mode: DiffMode::Head,
+            state: InternalRemoteDiffState::Disconnected,
+            metadata: None,
+            tracked_diff_load_start_time: None,
+        }
     }
 }
 

--- a/app/src/code_review/diff_state/remote_tests.rs
+++ b/app/src/code_review/diff_state/remote_tests.rs
@@ -7,9 +7,9 @@ use super::InternalRemoteDiffState;
 use crate::auth::AuthStateProvider;
 use crate::code_review::diff_size_limits::DiffSize;
 use crate::code_review::diff_state::{
-    DiffHunk, DiffLine, DiffLineType, DiffMetadata, DiffMetadataAgainstBase, DiffMode, DiffState,
-    DiffStateModelEvent, DiffStats, FileDiff, FileDiffAndContent, GitDiffData,
-    GitDiffWithBaseContent, GitFileStatus, RemoteDiffStateModel,
+    DiffHunk, DiffLine, DiffLineType, DiffMetadata, DiffMetadataAgainstBase, DiffMode,
+    DiffSnapshot, DiffState, DiffStateModelEvent, DiffStats, FileDiff, FileDiffAndContent,
+    GitDiffData, GitDiffWithBaseContent, GitFileStatus, RemoteDiffStateModel,
 };
 use crate::server::telemetry::context_provider::AppTelemetryContextProvider;
 use crate::util::git::Commit;
@@ -229,7 +229,8 @@ fn apply_snapshot_loaded_preserves_content_at_base_in_event() {
             app.update(|ctx| {
                 ctx.subscribe_to_model(&handle, move |_, event, _| {
                     if let DiffStateModelEvent::NewDiffsComputed {
-                        diffs: Some(diffs), ..
+                        snapshot: DiffSnapshot::Loaded(diffs),
+                        ..
                     } = event
                     {
                         emitted_content
@@ -513,7 +514,8 @@ fn apply_snapshot_emits_event_with_repo_relative_paths() {
             app.update(|ctx| {
                 ctx.subscribe_to_model(&handle, move |_, event, _| {
                     if let DiffStateModelEvent::NewDiffsComputed {
-                        diffs: Some(diffs), ..
+                        snapshot: DiffSnapshot::Loaded(diffs),
+                        ..
                     } = event
                     {
                         emitted_paths

--- a/app/src/code_review/find_model_tests.rs
+++ b/app/src/code_review/find_model_tests.rs
@@ -180,7 +180,7 @@ fn create_find_model_with_query(
 ) -> ModelHandle<CodeReviewFindModel> {
     let (window_id, _) = app.add_window(WindowStyle::NotStealFocus, |_| TestView);
 
-    let diff_state_model = app.add_model(DiffStateModel::new_for_test);
+    let diff_state_model = app.add_model(DiffStateModel::new_for_local_test);
     let repo_path = PathBuf::from("/tmp/test");
     let working_directories_model = app.add_model(|_| WorkingDirectoriesModel::new());
     let repo_key = LocalOrRemotePath::Local(repo_path);

--- a/app/src/remote_server/diff_state_tracker.rs
+++ b/app/src/remote_server/diff_state_tracker.rs
@@ -17,8 +17,8 @@ use warpui::{AppContext, Entity, ModelContext, ModelHandle};
 use super::protocol::RequestId;
 use super::server_model::ConnectionId;
 use crate::code_review::diff_state::{
-    BackendOrigin, DiffMetadata, DiffMode, DiffState, DiffStateModelEvent, FileDiffAndContent,
-    GitDiffWithBaseContent, LocalDiffStateModel,
+    BackendOrigin, DiffMetadata, DiffMode, DiffSnapshot, DiffState, DiffStateModelEvent,
+    FileDiffAndContent, GitDiffWithBaseContent, LocalDiffStateModel,
 };
 
 // ── Key type ────────────────────────────────────────────────────────
@@ -306,10 +306,20 @@ impl RemoteDiffStateManager {
         ctx: &mut ModelContext<Self>,
     ) {
         match event {
-            DiffStateModelEvent::NewDiffsComputed { diffs, .. } => {
+            DiffStateModelEvent::NewDiffsComputed { snapshot, .. } => {
                 let Some((state, metadata)) = self.read_state_and_metadata(key, ctx) else {
                     log::warn!("NewDiffsComputed for absent model key={key:?}");
                     return;
+                };
+
+                // The wire snapshot carries `state` separately; here we only
+                // need the diff payload, which is present iff the snapshot is
+                // `Loaded`.
+                let diffs = match snapshot {
+                    DiffSnapshot::Loaded(diffs) => Some(diffs.clone()),
+                    DiffSnapshot::NotInRepository
+                    | DiffSnapshot::Error(_)
+                    | DiffSnapshot::Loading => None,
                 };
 
                 let pending = self.drain_pending_responses(key);
@@ -331,7 +341,7 @@ impl RemoteDiffStateManager {
                     mode: key.mode.clone(),
                     state,
                     metadata,
-                    diffs: diffs.clone(),
+                    diffs,
                     subscribers,
                 });
             }


### PR DESCRIPTION
This PR refactors the code review diff loading process to rely on authoritative snapshots, ensuring more consistent and reliable diff states. Additionally, it cleans up the AI agent error handling logic by removing the `TransientError` status and consolidating transient network errors into the `Other` error variant.

Key changes include:
*   **Refactored Diff Loading:** Updated the diff loading mechanism to use authoritative snapshots for improved stability.
*   **Simplified Error Handling:** Removed `ConversationStatus::TransientError` and `TransientNetworkError` variants, streamlining the error state machine.
*   **Dependency Cleanup:** Removed the `alphanumeric-sort` crate and associated unused assets.
*   **Code Cleanup:** Removed test-only helpers and deprecated build configurations.