### PR TITLE
use the "emitter_handle" parameter instead of cloning strong handle i…

### DIFF
--- a/app/src/settings_view/features/working_directory.rs
+++ b/app/src/settings_view/features/working_directory.rs
@@ -384,12 +384,11 @@ fn create_editor(
     editor.update(ctx, |editor, ctx| {
         editor.set_buffer_text(&initial_value, ctx);
     });
-    let editor_handle = editor.clone();
-    ctx.subscribe_to_view(&editor, move |me, _, event, ctx| match event {
+    ctx.subscribe_to_view(&editor, move |me, editor, event, ctx| match event {
         // If the user presses enter or focus moves out of the editor view,
         // update our configuration to match the current value.
         EditorEvent::Blurred | EditorEvent::Enter => {
-            let editor_contents = editor_handle.as_ref(ctx).buffer_text(ctx);
+            let editor_contents = editor.as_ref(ctx).buffer_text(ctx);
             me.handle_action(
                 &WorkingDirectoryAction::SetCustomWorkingDirectoryValue(source, editor_contents),
                 ctx,


### PR DESCRIPTION
…n EditorView subscription

## Description

This PR removes a strong handle cycle _a. la._ https://github.com/warpdotdev/warp/pull/12355

## Linked Issue

None. This is a misc cleanup.
