### PR TITLE
Defer function name loading in PowerShell bootstrap

### DIFF
--- a/app/assets/bundled/bootstrap/pwsh.ps1
+++ b/app/assets/bundled/bootstrap/pwsh.ps1
@@ -142,7 +142,26 @@ $null = New-Module -Name Warp-Module -ScriptBlock {
         (Get-Variable | Select-Object -ExpandProperty Name) -join ' '
         $aliasesRaw = Get-Command -CommandType Alias | Select-Object -ExpandProperty DisplayName
         $aliases = $aliasesRaw -join [Environment]::NewLine
-        $functionNamesRaw = Get-Command -CommandType Function | Where-Object { -not $_.Name.StartsWith('Warp') } | Select-Object -ExpandProperty Name
+        # Only query modules that ship with PowerShell itself. This keeps bootstrap fast by
+        # avoiding Windows system modules, third-party modules, and large module families
+        # like Microsoft.Graph (~20k functions). Everything else is collected asynchronously
+        # after bootstrap via Warp-Send-AllFunctionNames.
+        $corePsModules = @(
+            'Microsoft.PowerShell.*', # All built-in PS modules (cross-platform)
+            'Microsoft.WSMan.*',       # WS-Management (Windows PS)
+            'CimCmdlets',              # CIM/WMI (Windows)
+            'PackageManagement',       # Package management
+            'PowerShellGet',           # Package get
+            'PSReadLine',              # Line editor bundled with PS
+            'ThreadJob',               # Thread jobs (PS 7)
+            'PSDiagnostics',           # PS diagnostics
+            'PSDesiredStateConfiguration', # DSC (Windows PS)
+            'PSWorkflow',              # Legacy workflow (Windows PS 5)
+            'PSWorkflowUtility'        # Legacy workflow utility (Windows PS 5)
+        )
+        $functionNamesRaw = Get-Command -CommandType Function -Module $corePsModules |
+            Where-Object { -not $_.Name.StartsWith('Warp') } |
+            Select-Object -ExpandProperty Name
         $functionNames = $functionNamesRaw -join [Environment]::NewLine
         $builtinsRaw = Get-Command -CommandType Cmdlet | Select-Object -ExpandProperty Name
         $builtins = $builtinsRaw -join [Environment]::NewLine

--- a/app/assets/bundled/bootstrap/pwsh.ps1
+++ b/app/assets/bundled/bootstrap/pwsh.ps1
@@ -143,11 +143,10 @@ $null = New-Module -Name Warp-Module -ScriptBlock {
         $aliasesRaw = Get-Command -CommandType Alias | Select-Object -ExpandProperty DisplayName
         $aliases = $aliasesRaw -join [Environment]::NewLine
         # Only query modules that ship with PowerShell itself. This keeps bootstrap fast by
-        # avoiding Windows system modules, third-party modules, and large module families
-        # like Microsoft.Graph (~20k functions). Everything else is collected asynchronously
-        # after bootstrap via Warp-Send-AllFunctionNames.
+        # avoiding Windows system modules and third-party modules from the Gallery. The rest are
+        # loaded asynchronously later.
         $corePsModules = @(
-            'Microsoft.PowerShell.*', # All built-in PS modules (cross-platform)
+            'Microsoft.PowerShell.*',  # All built-in PS modules (cross-platform)
             'Microsoft.WSMan.*',       # WS-Management (Windows PS)
             'CimCmdlets',              # CIM/WMI (Windows)
             'PackageManagement',       # Package management

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -1831,6 +1831,8 @@ pub mod testing {
                 load_external_commands_future: Default::default(),
                 command_case_sensitivity: TopLevelCommandCaseSensitivity::CaseSensitive,
                 session_type: Mutex::new(session_type),
+                additional_function_names: Default::default(),
+                load_all_function_names_future: Default::default(),
             }
         }
 
@@ -1846,6 +1848,8 @@ pub mod testing {
                 load_external_commands_future: Default::default(),
                 command_case_sensitivity: TopLevelCommandCaseSensitivity::CaseSensitive,
                 session_type: Mutex::new(session_type),
+                additional_function_names: Default::default(),
+                load_all_function_names_future: Default::default(),
             }
         }
 

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -902,9 +902,6 @@ pub struct Session {
     info: SessionInfo,
     external_commands: Arc<OnceCell<HashSet<SmolStr>>>,
     /// Function names collected asynchronously after bootstrap via an in-band command.
-    /// Only populated for shells (currently PowerShell) that restrict their sync bootstrap
-    /// to a core subset to avoid blocking on large third-party modules like Microsoft.Graph.
-    /// Names already present in `info.function_names` are excluded to avoid duplicates.
     additional_function_names: Arc<OnceCell<HashSet<SmolStr>>>,
     /// The command executor for this session. Behind a `RwLock` so it can be
     /// swapped after a remote server reconnect (via `set_command_executor`).
@@ -1127,12 +1124,13 @@ impl Session {
         self.external_commands.get().is_some()
     }
 
-    /// Asynchronously collects all function names via an in-band shell command, for shells
-    /// where the sync bootstrap only collected a core subset (currently PowerShell only).
-    /// Names already present in `info.function_names` are excluded to avoid duplicates.
-    /// No-op for shells that already collect all functions synchronously at bootstrap.
+    /// Asynchronously collects all function names via an in-band shell command.
     pub async fn load_all_function_names(&self) {
-        let Some(command) = self.info.shell.shell_type().shell_command_to_get_all_functions()
+        let Some(command) = self
+            .info
+            .shell
+            .shell_type()
+            .shell_command_to_get_all_functions()
         else {
             return;
         };

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -901,10 +901,16 @@ impl From<BootstrapSessionType> for SessionType {
 pub struct Session {
     info: SessionInfo,
     external_commands: Arc<OnceCell<HashSet<SmolStr>>>,
+    /// Function names collected asynchronously after bootstrap via an in-band command.
+    /// Only populated for shells (currently PowerShell) that restrict their sync bootstrap
+    /// to a core subset to avoid blocking on large third-party modules like Microsoft.Graph.
+    /// Names already present in `info.function_names` are excluded to avoid duplicates.
+    additional_function_names: Arc<OnceCell<HashSet<SmolStr>>>,
     /// The command executor for this session. Behind a `RwLock` so it can be
     /// swapped after a remote server reconnect (via `set_command_executor`).
     command_executor: RwLock<Arc<dyn CommandExecutor>>,
     load_external_commands_future: OnceCell<Shared<BoxFuture<'static, ()>>>,
+    load_all_function_names_future: OnceCell<Shared<BoxFuture<'static, ()>>>,
     command_case_sensitivity: TopLevelCommandCaseSensitivity,
     /// The authoritative session type, initially derived from the
     /// [`BootstrapSessionType`] in `SessionInfo` and updated by [`Sessions`]
@@ -929,8 +935,10 @@ impl Session {
         Self {
             info: session_info,
             external_commands: Arc::new(OnceCell::new()),
+            additional_function_names: Arc::new(OnceCell::new()),
             command_executor: RwLock::new(command_executor),
             load_external_commands_future: Default::default(),
+            load_all_function_names_future: Default::default(),
             command_case_sensitivity,
             session_type: Mutex::new(session_type),
         }
@@ -1049,7 +1057,11 @@ impl Session {
     }
 
     pub fn function_names(&self) -> impl Iterator<Item = &str> {
-        self.info.function_names.iter().map(Deref::deref)
+        self.info
+            .function_names
+            .iter()
+            .chain(self.additional_function_names.get().into_iter().flatten())
+            .map(Deref::deref)
     }
 
     pub fn executable_names(&self) -> impl Iterator<Item = &str> {
@@ -1113,6 +1125,65 @@ impl Session {
     /// Returns `true` if external commands have finished loading for this `Session`.
     pub fn has_loaded_external_commands(&self) -> bool {
         self.external_commands.get().is_some()
+    }
+
+    /// Asynchronously collects all function names via an in-band shell command, for shells
+    /// where the sync bootstrap only collected a core subset (currently PowerShell only).
+    /// Names already present in `info.function_names` are excluded to avoid duplicates.
+    /// No-op for shells that already collect all functions synchronously at bootstrap.
+    pub async fn load_all_function_names(&self) {
+        let Some(command) = self.info.shell.shell_type().shell_command_to_get_all_functions()
+        else {
+            return;
+        };
+
+        let (load_future, receiver) = (async {
+            let additional_function_names = self.additional_function_names.clone();
+            let existing = &self.info.function_names;
+
+            let result = self
+                .execute_command(command, None, None, ExecuteCommandOptions::default())
+                .await;
+
+            let new_names: HashSet<SmolStr> = match result {
+                Ok(output) if output.status == CommandExitStatus::Success => {
+                    match output.to_string() {
+                        Ok(output_string) => output_string
+                            .lines()
+                            .filter(|name| !name.is_empty() && !existing.contains(*name))
+                            .map(Into::into)
+                            .collect(),
+                        Err(e) => {
+                            log::warn!("Failed to decode all function names output: {e:#}");
+                            HashSet::new()
+                        }
+                    }
+                }
+                Ok(_) => {
+                    log::warn!(
+                        "In-band command for all function names returned non-success status"
+                    );
+                    HashSet::new()
+                }
+                Err(e) => {
+                    log::warn!("Failed to load all function names: {e:#}");
+                    HashSet::new()
+                }
+            };
+
+            if additional_function_names.set(new_names).is_err() {
+                log::warn!("Additional function names were already set for this session.");
+            }
+        })
+        .remote_handle();
+
+        match self
+            .load_all_function_names_future
+            .try_insert(receiver.boxed().shared())
+        {
+            Ok(_) => load_future.await,
+            Err((existing_receiver, _)) => existing_receiver.clone().await,
+        };
     }
 
     /// Asynchronously loads the external commands.
@@ -1210,6 +1281,7 @@ impl Session {
             .into_iter()
             .flatten()
             .chain(&self.info.function_names)
+            .chain(self.additional_function_names.get().into_iter().flatten())
             .chain(self.info.aliases.keys())
             .chain(self.info.abbreviations.keys())
             .chain(&self.info.builtins)

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -13370,7 +13370,7 @@ impl TerminalView {
         // doing the decoration to ensure we don't erroneously apply error
         // underlines to valid commands.
         let input = self.input().clone();
-        let session_for_fn = session.clone();
+        let session_clone = session.clone();
         ctx.spawn(
             async move { session.load_external_commands().await },
             move |me, _, ctx| {
@@ -13384,11 +13384,8 @@ impl TerminalView {
             },
         );
 
-        // For shells that restrict their sync bootstrap to a core subset (currently PowerShell
-        // only), collect the full function list asynchronously via an in-band command so it
-        // doesn't block startup. No-op for other shells.
         ctx.background_executor()
-            .spawn(async move { session_for_fn.load_all_function_names().await })
+            .spawn(async move { session_clone.load_all_function_names().await })
             .detach();
 
         // If we were waiting for a successful warpification, it's come. Stop the timeout.

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -13370,6 +13370,7 @@ impl TerminalView {
         // doing the decoration to ensure we don't erroneously apply error
         // underlines to valid commands.
         let input = self.input().clone();
+        let session_for_fn = session.clone();
         ctx.spawn(
             async move { session.load_external_commands().await },
             move |me, _, ctx| {
@@ -13382,6 +13383,13 @@ impl TerminalView {
                 me.refresh_warp_prompt(ctx);
             },
         );
+
+        // For shells that restrict their sync bootstrap to a core subset (currently PowerShell
+        // only), collect the full function list asynchronously via an in-band command so it
+        // doesn't block startup. No-op for other shells.
+        ctx.background_executor()
+            .spawn(async move { session_for_fn.load_all_function_names().await })
+            .detach();
 
         // If we were waiting for a successful warpification, it's come. Stop the timeout.
         self.warpify_state.abort_ssh_warpify_timeout();

--- a/crates/warp_terminal/src/shell/mod.rs
+++ b/crates/warp_terminal/src/shell/mod.rs
@@ -743,11 +743,11 @@ impl ShellType {
     pub fn shell_command_to_get_all_functions(&self) -> Option<&'static str> {
         match self {
             ShellType::PowerShell => Some(
-                r#"$names = Get-Command -CommandType Function | Where-Object { \
+                "$names = Get-Command -CommandType Function | Where-Object { \
                 -not $_.Name.StartsWith('Warp') } | Select-Object -ExpandProperty Name; \
                 $text = [string]::Join([Environment]::NewLine, $names); \
                 $bytes = [System.Text.UTF8Encoding]::new($false).GetBytes($text); \
-                [Console]::OpenStandardOutput().Write($bytes, 0, $bytes.Length)"#,
+                [Console]::OpenStandardOutput().Write($bytes, 0, $bytes.Length)",
             ),
             _ => None,
         }

--- a/crates/warp_terminal/src/shell/mod.rs
+++ b/crates/warp_terminal/src/shell/mod.rs
@@ -740,6 +740,22 @@ impl ShellType {
         }
     }
 
+    /// Returns the shell command used to asynchronously collect all function names after bootstrap,
+    /// for shells where the sync bootstrap collects only a core subset. Returns `None` for shells
+    /// that already collect all functions synchronously.
+    pub fn shell_command_to_get_all_functions(&self) -> Option<&'static str> {
+        match self {
+            // Other shells collect all functions synchronously at bootstrap; only PowerShell
+            // restricts its sync collection to core modules to avoid blocking on large
+            // third-party modules like Microsoft.Graph.
+            ShellType::Bash | ShellType::Zsh | ShellType::Fish => None,
+            ShellType::PowerShell => {
+                // Write as explicit UTF-8 bytes, matching the executables command pattern.
+                Some(r#"$names = Get-Command -CommandType Function | Where-Object { -not $_.Name.StartsWith('Warp') } | Select-Object -ExpandProperty Name; $text = [string]::Join([Environment]::NewLine, $names); $bytes = [System.Text.UTF8Encoding]::new($false).GetBytes($text); [Console]::OpenStandardOutput().Write($bytes, 0, $bytes.Length)"#)
+            }
+        }
+    }
+
     pub fn force_in_band_command_executor(&self) -> bool {
         // TODO: Remove this function once we have confidence in using a local executor in
         // powershell.

--- a/crates/warp_terminal/src/shell/mod.rs
+++ b/crates/warp_terminal/src/shell/mod.rs
@@ -740,19 +740,16 @@ impl ShellType {
         }
     }
 
-    /// Returns the shell command used to asynchronously collect all function names after bootstrap,
-    /// for shells where the sync bootstrap collects only a core subset. Returns `None` for shells
-    /// that already collect all functions synchronously.
     pub fn shell_command_to_get_all_functions(&self) -> Option<&'static str> {
         match self {
-            // Other shells collect all functions synchronously at bootstrap; only PowerShell
-            // restricts its sync collection to core modules to avoid blocking on large
-            // third-party modules like Microsoft.Graph.
-            ShellType::Bash | ShellType::Zsh | ShellType::Fish => None,
-            ShellType::PowerShell => {
-                // Write as explicit UTF-8 bytes, matching the executables command pattern.
-                Some(r#"$names = Get-Command -CommandType Function | Where-Object { -not $_.Name.StartsWith('Warp') } | Select-Object -ExpandProperty Name; $text = [string]::Join([Environment]::NewLine, $names); $bytes = [System.Text.UTF8Encoding]::new($false).GetBytes($text); [Console]::OpenStandardOutput().Write($bytes, 0, $bytes.Length)"#)
-            }
+            ShellType::PowerShell => Some(
+                r#"$names = Get-Command -CommandType Function | Where-Object { \
+                -not $_.Name.StartsWith('Warp') } | Select-Object -ExpandProperty Name; \
+                $text = [string]::Join([Environment]::NewLine, $names); \
+                $bytes = [System.Text.UTF8Encoding]::new($false).GetBytes($text); \
+                [Console]::OpenStandardOutput().Write($bytes, 0, $bytes.Length)"#,
+            ),
+            _ => None,
         }
     }
 


### PR DESCRIPTION
## Description

This PR speeds up PowerShell bootstrap on my machine taking the latency from ~3sec to ~1.3sec.[^1]

[^1]: The benefit is proportional to the number of modules (plugins) the user has installed, e.g. from Microsoft's [PowerShell Gallery](https://www.powershellgallery.com/). Some users won't have any benefit, some users may have more.

### Background

PowerShell lets you install extra modules from registries. The most popular registry is Microsoft's official [PowerShell Gallery](https://www.powershellgallery.com/). They are easy to install with the `Install-Module` cmdlet. When you install a module, it lives on the filesystem somewhere. The directories containing all installed modules is exposed via `$env:PSModulePath`, very similar concept to `$PATH` on UNIX.

These modules are lazily loaded. They aren't actually initialized unless you call one of their exported cmdlets or functions. (You _can_ explicitly call `Import-Module $moduleName` but that usually isn't necessary.) Of course, PowerShell hides the fact that these are lazy. It needs to offer the cmdlet and function names exported by the module as tab-completion candidates even if they aren't loaded. In order to do this, the list of exported members are usually listed in a separate file (extension `.psd1`) which are much lighter to load for the purpose of completions. They are also used for introspection things like `Get-Command -Type function` will output function names.

Our bootstrapping code does actually run `Get-Command -Type function` in order to collect the function names and offer them for our completions menu. That is ultimately the correct behavior, as we do need to offer all functions in our completions. The problem is that it's slow and it blocks bootstrap. For example, I have [`Microsoft.Graph`](https://www.powershellgallery.com/packages/Microsoft.Graph) installed, a very popular module. It exports about 10,000 functions. Enumerating and stringifying all those takes PowerShell about 1 sec. That's a tax Warp pays even though Microsoft.Graph isn't explicitly loaded.

### The Fix

We need to collect these functions without blocking bootstrap, same as we do for loading external commands. This PR does that. It uses a 2-phase approach to loading the function names. For UNIX shells the change is a no-op. For PowerShell, we only load "core" functions initially. We use an in-band command later to load the rest.

## Linked Issue

(partly) fixes #12485 

## Testing

I run this before and after this change:

```pwsh
cargo r --features log_named_telemetry_events
```

Look at the `Bootstrapping Succeeded` event for the bootstrap time. On my machine I see a 57% reduction in bootstrap latency.


<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-IMPROVEMENT: PowerShell startup times improved if you have additional modules installed.
-->
