### PR TITLE
Ceate a key bindings for tab group and pinning actions 

### DIFF
--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -208,12 +208,20 @@ pub enum WorkspaceAction {
     ClearTabMultiSelection,
     /// Creates a new tab group from the current tab multi-selection.
     NewTabGroupFromSelectedTabs,
+    /// Context-aware "create group" entry point for the keybinding: groups
+    /// the multi-selection when 2+ tabs are selected, otherwise groups the
+    /// active tab.
+    NewTabGroupFromSelection,
     /// Moves every selected tab into `group_id`.
     MoveSelectedTabsToGroup {
         group_id: TabGroupId,
     },
     /// Removes every selected tab from its group (requires a single shared group).
     RemoveSelectedTabsFromGroup,
+    /// Context-aware "remove from group" entry point for the keybinding:
+    /// removes the multi-selection from its shared group when 2+ tabs are
+    /// selected, otherwise removes the active tab.
+    RemoveSelectionFromGroup,
     ToggleTabGroupRightClickMenu {
         group_id: TabGroupId,
         anchor: TabContextMenuAnchor,
@@ -230,12 +238,20 @@ pub enum WorkspaceAction {
     PinTab(usize),
     /// Unpins the tab at the given index.
     UnpinTab(usize),
+    /// Pins the active tab.
+    PinActiveTab,
+    /// Unpins the active tab.
+    UnpinActiveTab,
     /// Pins the entire tab group: sets the group as pinned
     /// and moves the group block to the end of the pinned region.
     PinTabGroup(TabGroupId),
     /// Unpins the entire tab group: clears the pinned flag on the group
     /// and moves the group block to the start of the unpinned region.
     UnpinTabGroup(TabGroupId),
+    /// Pins the active tab's group.
+    PinActiveTabGroup,
+    /// Unpins the active tab's group.
+    UnpinActiveTabGroup,
     AddDefaultTab,
     AddTerminalTab {
         hide_homepage: bool,
@@ -888,8 +904,10 @@ impl WorkspaceAction {
             | MoveTabToGroup { .. }
             | RemoveTabFromGroup(_)
             | NewTabGroupFromSelectedTabs
+            | NewTabGroupFromSelection
             | MoveSelectedTabsToGroup { .. }
             | RemoveSelectedTabsFromGroup
+            | RemoveSelectionFromGroup
             | UngroupTabs(_)
             | NewTabInGroup(_)
             | MoveTabGroupUp(_)
@@ -899,8 +917,12 @@ impl WorkspaceAction {
             | CloseTabsBelowGroup(_)
             | PinTab(_)
             | UnpinTab(_)
+            | PinActiveTab
+            | UnpinActiveTab
             | PinTabGroup(_)
             | UnpinTabGroup(_)
+            | PinActiveTabGroup
+            | UnpinActiveTabGroup
             | ToggleTabColor { .. }
             | AddDefaultTab
             | AddTerminalTab { .. }

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -211,7 +211,7 @@ pub enum WorkspaceAction {
     /// Context-aware "create group" entry point for the keybinding: groups
     /// the multi-selection when 2+ tabs are selected, otherwise groups the
     /// active tab.
-    NewTabGroupFromSelection,
+    NewTabGroupFromActiveOrSelectedTabs,
     /// Moves every selected tab into `group_id`.
     MoveSelectedTabsToGroup {
         group_id: TabGroupId,
@@ -221,7 +221,7 @@ pub enum WorkspaceAction {
     /// Context-aware "remove from group" entry point for the keybinding:
     /// removes the multi-selection from its shared group when 2+ tabs are
     /// selected, otherwise removes the active tab.
-    RemoveSelectionFromGroup,
+    RemoveActiveOrSelectedTabsFromGroup,
     ToggleTabGroupRightClickMenu {
         group_id: TabGroupId,
         anchor: TabContextMenuAnchor,
@@ -904,10 +904,10 @@ impl WorkspaceAction {
             | MoveTabToGroup { .. }
             | RemoveTabFromGroup(_)
             | NewTabGroupFromSelectedTabs
-            | NewTabGroupFromSelection
+            | NewTabGroupFromActiveOrSelectedTabs
             | MoveSelectedTabsToGroup { .. }
             | RemoveSelectedTabsFromGroup
-            | RemoveSelectionFromGroup
+            | RemoveActiveOrSelectedTabsFromGroup
             | UngroupTabs(_)
             | NewTabInGroup(_)
             | MoveTabGroupUp(_)

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -949,9 +949,9 @@ pub fn init(app: &mut AppContext) {
         .with_group(bindings::BindingGroup::Navigation.as_str())
         .with_context_predicate(id!("Workspace") & !id!("Workspace_PaneDragging")),
         EditableBinding::new(
-            "workspace:new_tab_group_from_selection",
+            "workspace:new_tab_group_from_active_or_selected_tabs",
             "Create tab group from active or selected tab(s)",
-            WorkspaceAction::NewTabGroupFromSelection,
+            WorkspaceAction::NewTabGroupFromActiveOrSelectedTabs,
         )
         .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
         .with_group(bindings::BindingGroup::Navigation.as_str())
@@ -959,9 +959,9 @@ pub fn init(app: &mut AppContext) {
         // Gated on the active tab being grouped: the remove from group option is only
         // available when all selected tabs (including the active tab) are in a group.
         EditableBinding::new(
-            "workspace:remove_selection_from_group",
+            "workspace:remove_active_or_selected_tabs_from_group",
             "Remove active or selected tab(s) from group",
-            WorkspaceAction::RemoveSelectionFromGroup,
+            WorkspaceAction::RemoveActiveOrSelectedTabsFromGroup,
         )
         .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
         .with_group(bindings::BindingGroup::Navigation.as_str())

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -51,7 +51,7 @@ use crate::palette::PaletteMode;
 use crate::pane_group::TabBarHoverIndex;
 use crate::server::telemetry::{AgentModeEntrypoint, PaletteSource};
 use crate::settings_view::{self, flags, SettingsSection};
-use crate::tab::uses_vertical_tabs;
+use crate::tab::{uses_vertical_tabs, NewSessionMenuItem};
 use crate::util::bindings::{self, cmd_or_ctrl_shift, is_binding_pty_compliant, CustomAction};
 use crate::{code, modal, notebooks, tab_configs};
 
@@ -936,6 +936,95 @@ pub fn init(app: &mut AppContext) {
     )
     .with_group(bindings::BindingGroup::Settings.as_str())
     .with_context_predicate(id!("Workspace"))]);
+
+    // Tab grouping bindings (keyless by default; gated on `GroupedTabs`).
+    app.register_editable_bindings([
+        EditableBinding::new(
+            "workspace:new_tab_group",
+            "Create new tab group",
+            // Reuse the new-session dropdown's action, not a dedicated variant.
+            WorkspaceAction::SelectNewSessionMenuItem(NewSessionMenuItem::CreateNewTabGroup),
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_group(bindings::BindingGroup::Navigation.as_str())
+        .with_context_predicate(id!("Workspace") & !id!("Workspace_PaneDragging")),
+        EditableBinding::new(
+            "workspace:new_tab_group_from_selection",
+            "Create tab group from active or selected tab(s)",
+            WorkspaceAction::NewTabGroupFromSelection,
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_group(bindings::BindingGroup::Navigation.as_str())
+        .with_context_predicate(id!("Workspace") & !id!("Workspace_PaneDragging")),
+        // Gated on the active tab being grouped: the remove from group option is only
+        // available when all selected tabs (including the active tab) are in a group.
+        EditableBinding::new(
+            "workspace:remove_selection_from_group",
+            "Remove active or selected tab(s) from group",
+            WorkspaceAction::RemoveSelectionFromGroup,
+        )
+        .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
+        .with_group(bindings::BindingGroup::Navigation.as_str())
+        .with_context_predicate(
+            id!("Workspace") & id!("Workspace_ActiveTabInGroup") & !id!("Workspace_PaneDragging"),
+        ),
+    ]);
+
+    // Tab/group pinning bindings (keyless by default; gated on `PinnedTabs`).
+    // Pin/unpin are split into separate entries so the palette label tracks
+    // the active tab/group's current state.
+    app.register_editable_bindings([
+        EditableBinding::new(
+            "workspace:pin_active_tab",
+            "Pin current tab",
+            WorkspaceAction::PinActiveTab,
+        )
+        .with_enabled(|| FeatureFlag::PinnedTabs.is_enabled())
+        .with_group(bindings::BindingGroup::Navigation.as_str())
+        .with_context_predicate(
+            id!("Workspace") & !id!("Workspace_ActiveTabPinned") & !id!("Workspace_PaneDragging"),
+        ),
+        EditableBinding::new(
+            "workspace:unpin_active_tab",
+            "Unpin current tab",
+            WorkspaceAction::UnpinActiveTab,
+        )
+        .with_enabled(|| FeatureFlag::PinnedTabs.is_enabled())
+        .with_group(bindings::BindingGroup::Navigation.as_str())
+        .with_context_predicate(
+            id!("Workspace") & id!("Workspace_ActiveTabPinned") & !id!("Workspace_PaneDragging"),
+        ),
+        EditableBinding::new(
+            "workspace:pin_active_tab_group",
+            "Pin current tab group",
+            WorkspaceAction::PinActiveTabGroup,
+        )
+        .with_enabled(|| {
+            FeatureFlag::PinnedTabs.is_enabled() && FeatureFlag::GroupedTabs.is_enabled()
+        })
+        .with_group(bindings::BindingGroup::Navigation.as_str())
+        .with_context_predicate(
+            id!("Workspace")
+                & id!("Workspace_ActiveTabInGroup")
+                & !id!("Workspace_ActiveTabGroupPinned")
+                & !id!("Workspace_PaneDragging"),
+        ),
+        EditableBinding::new(
+            "workspace:unpin_active_tab_group",
+            "Unpin current tab group",
+            WorkspaceAction::UnpinActiveTabGroup,
+        )
+        .with_enabled(|| {
+            FeatureFlag::PinnedTabs.is_enabled() && FeatureFlag::GroupedTabs.is_enabled()
+        })
+        .with_group(bindings::BindingGroup::Navigation.as_str())
+        .with_context_predicate(
+            id!("Workspace")
+                & id!("Workspace_ActiveTabInGroup")
+                & id!("Workspace_ActiveTabGroupPinned")
+                & !id!("Workspace_PaneDragging"),
+        ),
+    ]);
 
     app.register_editable_bindings([
         EditableBinding::new(

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -956,8 +956,10 @@ pub fn init(app: &mut AppContext) {
         .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
         .with_group(bindings::BindingGroup::Navigation.as_str())
         .with_context_predicate(id!("Workspace") & !id!("Workspace_PaneDragging")),
-        // Gated on the active tab being grouped: the remove from group option is only
-        // available when all selected tabs (including the active tab) are in a group.
+        // Gated on `Workspace_ActiveOrSelectedTabsInGroup`: offered only when
+        // there's an unambiguous group to leave — a single-group multi-selection,
+        // or (with no selection) a grouped active tab. Mixed selections aren't
+        // offered, matching the multi-tab right-click menu.
         EditableBinding::new(
             "workspace:remove_active_or_selected_tabs_from_group",
             "Remove active or selected tab(s) from group",
@@ -966,7 +968,9 @@ pub fn init(app: &mut AppContext) {
         .with_enabled(|| FeatureFlag::GroupedTabs.is_enabled())
         .with_group(bindings::BindingGroup::Navigation.as_str())
         .with_context_predicate(
-            id!("Workspace") & id!("Workspace_ActiveTabInGroup") & !id!("Workspace_PaneDragging"),
+            id!("Workspace")
+                & id!("Workspace_ActiveOrSelectedTabsInGroup")
+                & !id!("Workspace_PaneDragging"),
         ),
     ]);
 

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -23017,12 +23017,16 @@ impl TypedActionView for Workspace {
             ToggleTabMultiSelection { locator } => self.toggle_tab_multi_selection(*locator, ctx),
             ClearTabMultiSelection => self.clear_tab_multi_selection(ctx),
             NewTabGroupFromSelectedTabs => self.new_tab_group_from_selected_tabs(ctx),
-            NewTabGroupFromSelection => self.new_tab_group_from_selection(ctx),
+            NewTabGroupFromActiveOrSelectedTabs => {
+                self.new_tab_group_from_active_or_selected_tabs(ctx)
+            }
             MoveSelectedTabsToGroup { group_id } => {
                 self.move_selected_tabs_to_group(*group_id, ctx)
             }
             RemoveSelectedTabsFromGroup => self.remove_selected_tabs_from_group(ctx),
-            RemoveSelectionFromGroup => self.remove_selection_from_group(ctx),
+            RemoveActiveOrSelectedTabsFromGroup => {
+                self.remove_active_or_selected_tabs_from_group(ctx)
+            }
             ToggleTabGroupRightClickMenu { group_id, anchor } => {
                 self.toggle_tab_group_right_click_menu(*group_id, *anchor, ctx)
             }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -23017,10 +23017,12 @@ impl TypedActionView for Workspace {
             ToggleTabMultiSelection { locator } => self.toggle_tab_multi_selection(*locator, ctx),
             ClearTabMultiSelection => self.clear_tab_multi_selection(ctx),
             NewTabGroupFromSelectedTabs => self.new_tab_group_from_selected_tabs(ctx),
+            NewTabGroupFromSelection => self.new_tab_group_from_selection(ctx),
             MoveSelectedTabsToGroup { group_id } => {
                 self.move_selected_tabs_to_group(*group_id, ctx)
             }
             RemoveSelectedTabsFromGroup => self.remove_selected_tabs_from_group(ctx),
+            RemoveSelectionFromGroup => self.remove_selection_from_group(ctx),
             ToggleTabGroupRightClickMenu { group_id, anchor } => {
                 self.toggle_tab_group_right_click_menu(*group_id, *anchor, ctx)
             }
@@ -23033,8 +23035,28 @@ impl TypedActionView for Workspace {
             CloseTabsBelowGroup(group_id) => self.close_tabs_below_group(*group_id, ctx),
             PinTab(tab_index) => self.pin_tab(*tab_index, ctx),
             UnpinTab(tab_index) => self.unpin_tab(*tab_index, ctx),
+            PinActiveTab => self.pin_tab(self.active_tab_index, ctx),
+            UnpinActiveTab => self.unpin_tab(self.active_tab_index, ctx),
             PinTabGroup(group_id) => self.pin_tab_group(*group_id, ctx),
             UnpinTabGroup(group_id) => self.unpin_tab_group(*group_id, ctx),
+            PinActiveTabGroup => {
+                if let Some(group_id) = self
+                    .tabs
+                    .get(self.active_tab_index)
+                    .and_then(|tab| tab.group_id)
+                {
+                    self.pin_tab_group(group_id, ctx);
+                }
+            }
+            UnpinActiveTabGroup => {
+                if let Some(group_id) = self
+                    .tabs
+                    .get(self.active_tab_index)
+                    .and_then(|tab| tab.group_id)
+                {
+                    self.unpin_tab_group(group_id, ctx);
+                }
+            }
             AddDefaultTab => {
                 let effective_mode = AISettings::as_ref(ctx).default_session_mode(ctx);
                 match effective_mode {
@@ -25260,6 +25282,27 @@ impl View for Workspace {
                 }
             }
         };
+
+        // Surface the active tab's group/pin state to the keymap so the
+        // tab-grouping/pinning bindings can gate themselves to the contexts
+        // where they're actually meaningful (e.g. "Unpin tab" only when the
+        // active tab is pinned, "Pin tab group" only when the active tab is
+        // grouped, etc.).
+        if let Some(active_tab) = self.tabs.get(self.active_tab_index) {
+            if let Some(group_id) = active_tab.group_id {
+                context.set.insert("Workspace_ActiveTabInGroup");
+                if self
+                    .tab_groups
+                    .get(&group_id)
+                    .is_some_and(|group| group.pinned)
+                {
+                    context.set.insert("Workspace_ActiveTabGroupPinned");
+                }
+            }
+            if active_tab.pinned {
+                context.set.insert("Workspace_ActiveTabPinned");
+            }
+        }
 
         if WarpDriveSettings::is_warp_drive_enabled(app) {
             context.set.insert(flags::ENABLE_WARP_DRIVE);

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -25308,6 +25308,22 @@ impl View for Workspace {
             }
         }
 
+        // "Remove from group" is valid when there's an unambiguous target: a
+        // 2+ multi-selection that shares one group, or—failing that—an active
+        // tab that's in a group. Mirrors the multi-tab right-click menu, which
+        // only offers "Remove from group" for a single-group selection.
+        let selected = self.selected_tab_indices();
+        let removable_from_group = if selected.len() >= 2 {
+            self.selection_shared_group().is_some()
+        } else {
+            self.tabs
+                .get(self.active_tab_index)
+                .is_some_and(|tab| tab.group_id.is_some())
+        };
+        if removable_from_group {
+            context.set.insert("Workspace_ActiveOrSelectedTabsInGroup");
+        }
+
         if WarpDriveSettings::is_warp_drive_enabled(app) {
             context.set.insert(flags::ENABLE_WARP_DRIVE);
         }

--- a/app/src/workspace/view/tab_grouping.rs
+++ b/app/src/workspace/view/tab_grouping.rs
@@ -159,12 +159,15 @@ impl Workspace {
     }
 
     /// Context-aware "create group" entry point used by the
-    /// `workspace:new_tab_group_from_selection` keybinding. When the
-    /// multi-selection covers 2+ tabs, groups the selection; otherwise groups
-    /// just the active tab. `selected_tab_indices` already folds the active
-    /// tab into the selection, so a lone flagged active tab (or no selection
-    /// at all) takes the single-tab path.
-    pub(super) fn new_tab_group_from_selection(&mut self, ctx: &mut ViewContext<Self>) {
+    /// `workspace:new_tab_group_from_active_or_selected_tabs` keybinding. When
+    /// the multi-selection covers 2+ tabs, groups the selection; otherwise
+    /// groups just the active tab. `selected_tab_indices` already folds the
+    /// active tab into the selection, so a lone flagged active tab (or no
+    /// selection at all) takes the single-tab path.
+    pub(super) fn new_tab_group_from_active_or_selected_tabs(
+        &mut self,
+        ctx: &mut ViewContext<Self>,
+    ) {
         if !FeatureFlag::GroupedTabs.is_enabled() {
             return;
         }
@@ -176,11 +179,14 @@ impl Workspace {
     }
 
     /// Context-aware "remove from group" entry point used by the
-    /// `workspace:remove_selection_from_group` keybinding. When the
-    /// multi-selection covers 2+ tabs, removes the selection from its shared
-    /// group; otherwise removes just the active tab. Mirrors
-    /// `new_tab_group_from_selection` on the create side.
-    pub(super) fn remove_selection_from_group(&mut self, ctx: &mut ViewContext<Self>) {
+    /// `workspace:remove_active_or_selected_tabs_from_group` keybinding. When
+    /// the multi-selection covers 2+ tabs, removes the selection from its
+    /// shared group; otherwise removes just the active tab. Mirrors
+    /// `new_tab_group_from_active_or_selected_tabs` on the create side.
+    pub(super) fn remove_active_or_selected_tabs_from_group(
+        &mut self,
+        ctx: &mut ViewContext<Self>,
+    ) {
         if !FeatureFlag::GroupedTabs.is_enabled() {
             return;
         }

--- a/app/src/workspace/view/tab_grouping.rs
+++ b/app/src/workspace/view/tab_grouping.rs
@@ -158,6 +158,39 @@ impl Workspace {
         }
     }
 
+    /// Context-aware "create group" entry point used by the
+    /// `workspace:new_tab_group_from_selection` keybinding. When the
+    /// multi-selection covers 2+ tabs, groups the selection; otherwise groups
+    /// just the active tab. `selected_tab_indices` already folds the active
+    /// tab into the selection, so a lone flagged active tab (or no selection
+    /// at all) takes the single-tab path.
+    pub(super) fn new_tab_group_from_selection(&mut self, ctx: &mut ViewContext<Self>) {
+        if !FeatureFlag::GroupedTabs.is_enabled() {
+            return;
+        }
+        if self.selected_tab_indices().len() >= 2 {
+            self.new_tab_group_from_selected_tabs(ctx);
+        } else {
+            self.new_tab_group_from_tab(self.active_tab_index, ctx);
+        }
+    }
+
+    /// Context-aware "remove from group" entry point used by the
+    /// `workspace:remove_selection_from_group` keybinding. When the
+    /// multi-selection covers 2+ tabs, removes the selection from its shared
+    /// group; otherwise removes just the active tab. Mirrors
+    /// `new_tab_group_from_selection` on the create side.
+    pub(super) fn remove_selection_from_group(&mut self, ctx: &mut ViewContext<Self>) {
+        if !FeatureFlag::GroupedTabs.is_enabled() {
+            return;
+        }
+        if self.selected_tab_indices().len() >= 2 {
+            self.remove_selected_tabs_from_group(ctx);
+        } else {
+            self.remove_tab_from_group(self.active_tab_index, ctx);
+        }
+    }
+
     /// "Create group from tabs" menu action. Group membership requires
     /// tabs to be contiguous in the bar, so we gather the selected tabs into
     /// a single block anchored at the earliest selected tab's position before

--- a/app/src/workspace/view/tab_grouping.rs
+++ b/app/src/workspace/view/tab_grouping.rs
@@ -105,7 +105,7 @@ impl Workspace {
     /// The active tab index is always included if any other tab is marked
     /// as selected. This is to handle the edge case where we only mark other
     /// tabs as selected via command click.
-    fn selected_tab_indices(&self) -> Vec<usize> {
+    pub(super) fn selected_tab_indices(&self) -> Vec<usize> {
         let any_flagged = self.tabs.iter().any(|tab| tab.in_multi_selection);
         // If no tab is part of the multi selection, return empty list.
         if !any_flagged {
@@ -133,7 +133,7 @@ impl Workspace {
 
     /// Gates the "Remove from group" menu item. All selected tabs
     /// must be in the same group in order to display this option.
-    fn selection_shared_group(&self) -> Option<TabGroupId> {
+    pub(super) fn selection_shared_group(&self) -> Option<TabGroupId> {
         let indices = self.selected_tab_indices();
         let mut group_ids = indices
             .iter()
@@ -179,10 +179,9 @@ impl Workspace {
     }
 
     /// Context-aware "remove from group" entry point used by the
-    /// `workspace:remove_active_or_selected_tabs_from_group` keybinding. When
-    /// the multi-selection covers 2+ tabs, removes the selection from its
-    /// shared group; otherwise removes just the active tab. Mirrors
-    /// `new_tab_group_from_active_or_selected_tabs` on the create side.
+    /// `workspace:remove_active_or_selected_tabs_from_group` keybinding. With a
+    /// 2+ multi-selection, removes the whole selection from its group;
+    /// otherwise removes just the active tab.
     pub(super) fn remove_active_or_selected_tabs_from_group(
         &mut self,
         ctx: &mut ViewContext<Self>,


### PR DESCRIPTION
## Description

Adds keyboard-shortcut entries for tab grouping and tab/group pinning so these actions are reachable from the Command Palette and assignable in Settings → Keyboard Shortcuts. Previously they existed only in the right-click menus. The bindings ship keyless (no default keystrokes) and are gated behind the GroupedTabs / PinnedTabs feature flags.

## How it works

Changes follow all the same patterns as our current keybinds:
- Bindings are registered as EditableBindings  gated  on the respective feature flag and .with_context_predicate(...) so each is only active in a meaningful state (e.g. unpin only when the active tab is pinned, remove only when it's grouped). All exclude pane-dragging, matching the existing tab-create/move bindings.
- Created new workspace actions that mirror existing actions but are context aware or act on the active tab (i.e `NewTabGroupFromActiveOrSelectedTabs` can create a tab group from the active tab or from multiple selected tabs if multiple are selected. Another example is `PinActiveTab` which is the keybind action equivalent of `PinTab(usize)` which pins the active tab rather than pinning the tab at a provided index)
- Added new helper functions `new_tab_group_from_selection()` and `remove_selection_from_group()` for the new context aware actions. They branch on the multi-selection count — 2+ selected routes to the existing selected-tabs helpers, otherwise it acts on the active tab. So one binding covers both the single-tab and multi-tab cases.
-  New keymap context flags (`Workspace_ActiveTabInGroup`, `Workspace_ActiveTabPinned`, etc) so keybinds are only available when the action is actually possible (ie, can only unpin a tab if its pinned)

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4669/create-a-key-binding-for-tab-group-creation

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/94a12865d1ee4e5bac011e9f9025bede
