### PR TITLE
fix macos version check

### DIFF
--- a/crates/warpui/src/platform/mac/objc/window.m
+++ b/crates/warpui/src/platform/mac/objc/window.m
@@ -464,16 +464,24 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
         // This breaks drag-and-drop for panes and tabs (see CLD-2581), so we work around it with
         // custom dispatching.
         case NSEventTypeLeftMouseUp:
-            if (_leftMouseDownStartedInNativeWindowChrome && @available(macOS 27, *)) {
-                [super sendEvent:event];
+            if (@available(macOS 27, *)) {
+                if (_leftMouseDownStartedInNativeWindowChrome) {
+                    [super sendEvent:event];
+                } else {
+                    [self.contentView mouseUp:event];
+                }
             } else {
                 [self.contentView mouseUp:event];
             }
             _leftMouseDownStartedInNativeWindowChrome = NO;
             break;
         case NSEventTypeLeftMouseDragged:
-            if (_leftMouseDownStartedInNativeWindowChrome && @available(macOS 27, *)) {
-                [super sendEvent:event];
+            if (@available(macOS 27, *)) {
+                if (_leftMouseDownStartedInNativeWindowChrome) {
+                    [super sendEvent:event];
+                } else {
+                    [self.contentView mouseDragged:event];
+                }
             } else {
                 [self.contentView mouseDragged:event];
             }


### PR DESCRIPTION
## Description

Fix for something added in #12557.

The obj-c compiler is emitting this warning:

```
warning: warpui@0.0.0: src/platform/mac/objc/window.m:467:62: warning: @available does not guard availability here; use if (@available) instead [-Wunsupported-availability-guard]
warning: warpui@0.0.0:   467 |             if (_leftMouseDownStartedInNativeWindowChrome && @available(macOS 27, *)) {
warning: warpui@0.0.0:       |                                                              ^
warning: warpui@0.0.0: src/platform/mac/objc/window.m:475:62: warning: @available does not guard availability here; use if (@available) instead [-Wunsupported-availability-guard]
warning: warpui@0.0.0:   475 |             if (_leftMouseDownStartedInNativeWindowChrome && @available(macOS 27, *)) {
warning: warpui@0.0.0:       |                                                              ^
warning: warpui@0.0.0: 2 warnings generated.
```

This doesn't actually affect the runtime behavior at all. It's a quirk of the static analysis tools.
