### PR TITLE
Tab group coloring

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -219,6 +219,11 @@ impl TabData {
             Self::save_config_menu_items(index),
             self.color_option_menu_items(index, terminal_colors),
         ] {
+            // Skip empty sections so we don't emit a trailing separator (e.g.
+            // when a grouped tab hides the color picker).
+            if section_items.is_empty() {
+                continue;
+            }
             if menu_items
                 .last()
                 .is_some_and(|item| !matches!(item, MenuItem::Separator))
@@ -585,8 +590,12 @@ impl TabData {
         index: usize,
         terminal_colors: AnsiColors,
     ) -> Vec<MenuItem<WorkspaceAction>> {
+        // Tabs inside a group have their color controlled by the group.
+        if self.group_id.is_some() {
+            return vec![];
+        }
         if FeatureFlag::DirectoryTabColors.is_enabled() {
-            self.dot_color_option_menu_items(index, terminal_colors)
+            self.dot_color_option_menu_items(index)
         } else {
             self.legacy_color_option_menu_items(index, terminal_colors)
         }
@@ -594,78 +603,10 @@ impl TabData {
 
     /// New dot-based color picker: default (no-color) + color options.
     /// Rendered as a single custom menu item with individually clickable dots.
-    fn dot_color_option_menu_items(
-        &self,
-        index: usize,
-        terminal_colors: AnsiColors,
-    ) -> Vec<MenuItem<WorkspaceAction>> {
-        let effective_color = self.color();
-        let mouse_states: Vec<MouseStateHandle> = (0..TAB_COLOR_OPTIONS.len() + 1)
-            .map(|_| MouseStateHandle::default())
-            .collect();
-
-        vec![MenuItem::Item(
-            MenuItemFields::new_with_custom_label(
-                Arc::new(move |_is_selected, _is_hovered, appearance, _app| {
-                    let theme = appearance.theme();
-                    let ring_color: ColorU = theme.accent().into();
-
-                    let mut row = Flex::row()
-                        .with_main_axis_alignment(MainAxisAlignment::SpaceEvenly)
-                        .with_cross_axis_alignment(CrossAxisAlignment::Center)
-                        .with_main_axis_size(MainAxisSize::Max);
-
-                    for (ansi_id, mouse_state) in std::iter::once(None)
-                        .chain(TAB_COLOR_OPTIONS.iter().copied().map(Some))
-                        .zip(mouse_states.iter().cloned())
-                    {
-                        let is_selected = match ansi_id {
-                            None => effective_color.is_none(),
-                            Some(id) => effective_color == Some(id),
-                        };
-                        let dot_color: ColorU = match ansi_id {
-                            None => ColorU::transparent_black(),
-                            Some(id) => id.to_ansi_color(&terminal_colors).into(),
-                        };
-                        let tooltip = match ansi_id {
-                            None => "Default (no color)".to_string(),
-                            Some(id) => id.to_string(),
-                        };
-
-                        let dot = render_color_dot(
-                            mouse_state,
-                            dot_color,
-                            is_selected,
-                            ring_color,
-                            ansi_id.is_none(),
-                            theme.foreground(),
-                            tooltip,
-                            appearance,
-                        )
-                        .on_click(move |ctx, _, _| {
-                            if let Some(color) = ansi_id {
-                                ctx.dispatch_typed_action(WorkspaceAction::ToggleTabColor {
-                                    color,
-                                    tab_index: index,
-                                });
-                            } else if let Some(color) = effective_color {
-                                ctx.dispatch_typed_action(WorkspaceAction::ToggleTabColor {
-                                    color,
-                                    tab_index: index,
-                                });
-                            }
-                            ctx.dispatch_typed_action(MenuAction::Close(true));
-                        });
-
-                        row.add_child(dot.finish());
-                    }
-
-                    row.finish()
-                }),
-                None,
-            )
-            .no_highlight_on_hover()
-            .with_no_interaction_on_hover(),
+    fn dot_color_option_menu_items(&self, index: usize) -> Vec<MenuItem<WorkspaceAction>> {
+        vec![color_picker_menu_item(
+            self.color(),
+            ColorPickerTarget::Tab { tab_index: index },
         )]
     }
 
@@ -698,6 +639,99 @@ impl TabData {
                 .collect(),
         }]
     }
+}
+
+/// Identifies what a color-picker selection recolors: a single tab or a whole
+/// tab group. Used by [`color_picker_menu_item`] to choose the toggle action
+/// dispatched when a dot is clicked.
+#[derive(Clone, Copy)]
+pub(crate) enum ColorPickerTarget {
+    Tab { tab_index: usize },
+    Group { group_id: TabGroupId },
+}
+
+impl ColorPickerTarget {
+    fn toggle_action(self, color: AnsiColorIdentifier) -> WorkspaceAction {
+        match self {
+            ColorPickerTarget::Tab { tab_index } => {
+                WorkspaceAction::ToggleTabColor { color, tab_index }
+            }
+            ColorPickerTarget::Group { group_id } => {
+                WorkspaceAction::ToggleTabGroupColor { color, group_id }
+            }
+        }
+    }
+}
+
+/// Builds the shared dot-based color picker menu row used by both the per-tab
+/// and per-group color selectors. The leading dot clears the color; the rest are
+/// the `TAB_COLOR_OPTIONS`. `current_color` drives the selected-dot ring and the
+/// clear dot's toggle-off; `target` selects which toggle action is dispatched on
+/// click.
+pub(crate) fn color_picker_menu_item(
+    current_color: Option<AnsiColorIdentifier>,
+    target: ColorPickerTarget,
+) -> MenuItem<WorkspaceAction> {
+    let mouse_states: Vec<MouseStateHandle> = (0..TAB_COLOR_OPTIONS.len() + 1)
+        .map(|_| MouseStateHandle::default())
+        .collect();
+
+    MenuItem::Item(
+        MenuItemFields::new_with_custom_label(
+            Arc::new(move |_is_selected, _is_hovered, appearance, _app| {
+                let theme = appearance.theme();
+                let terminal_colors = theme.terminal_colors().normal;
+                let ring_color: ColorU = theme.accent().into();
+
+                let mut row = Flex::row()
+                    .with_main_axis_alignment(MainAxisAlignment::SpaceEvenly)
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_main_axis_size(MainAxisSize::Max);
+
+                for (ansi_id, mouse_state) in std::iter::once(None)
+                    .chain(TAB_COLOR_OPTIONS.iter().copied().map(Some))
+                    .zip(mouse_states.iter().cloned())
+                {
+                    let is_selected = match ansi_id {
+                        None => current_color.is_none(),
+                        Some(id) => current_color == Some(id),
+                    };
+                    let dot_color: ColorU = match ansi_id {
+                        None => ColorU::transparent_black(),
+                        Some(id) => id.to_ansi_color(&terminal_colors).into(),
+                    };
+                    let tooltip = match ansi_id {
+                        None => "Default (no color)".to_string(),
+                        Some(id) => id.to_string(),
+                    };
+
+                    let dot = render_color_dot(
+                        mouse_state,
+                        dot_color,
+                        is_selected,
+                        ring_color,
+                        ansi_id.is_none(),
+                        theme.foreground(),
+                        tooltip,
+                        appearance,
+                    )
+                    .on_click(move |ctx, _, _| {
+                        if let Some(color) = ansi_id.or(current_color) {
+                            ctx.dispatch_typed_action(target.toggle_action(color));
+                        }
+                        ctx.dispatch_typed_action(MenuAction::Close(true));
+                    });
+
+                    row.add_child(dot.finish());
+                }
+
+                row.finish()
+            }),
+            None,
+        )
+        .no_highlight_on_hover()
+        .with_no_interaction_on_hover(),
+    )
 }
 
 /// Stores the state of the tab bar—info related to the entire list of tabs rather than any one
@@ -968,6 +1002,13 @@ impl<'a> TabComponent<'a> {
     pub fn for_grouped_member(mut self, is_sole_member: bool) -> Self {
         self.grouped_member = true;
         self.sole_grouped_member = is_sole_member;
+        self
+    }
+
+    /// Overrides the effective color used to build tab styles. Used when the
+    /// tab's color should be driven by its group rather than its own data.
+    pub fn with_effective_color(mut self, color: Option<AnsiColorIdentifier>) -> Self {
+        self.styles = TabStyles::default(self.appearance, color);
         self
     }
 

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -301,6 +301,12 @@ pub enum WorkspaceAction {
         color: AnsiColorIdentifier,
         tab_index: usize,
     },
+    /// Toggles the color for a tab group. Clears the color if it was already
+    /// set to `color`; otherwise applies `color` as the uniform group color.
+    ToggleTabGroupColor {
+        color: AnsiColorIdentifier,
+        group_id: TabGroupId,
+    },
     OpenLaunchConfigSaveModal,
     SelectTabConfig(TabConfig),
     DispatchToSettingsTab(SettingsTabAction),
@@ -873,6 +879,7 @@ impl WorkspaceAction {
             | CloseTabsAboveGroup(_)
             | CloseTabsBelowGroup(_)
             | ToggleTabColor { .. }
+            | ToggleTabGroupColor { .. }
             | AddDefaultTab
             | AddTerminalTab { .. }
             | AddTabWithShell { .. }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -19095,6 +19095,11 @@ impl Workspace {
         let theme = appearance.theme();
         let is_collapsed = group.collapsed;
 
+        let group_color: Option<ColorU> = group
+            .color
+            .resolve(None)
+            .map(|c| c.to_ansi_color(&theme.terminal_colors().normal).into());
+
         let mouse_states = self
             .horizontal_tab_group_mouse_states
             .borrow_mut()
@@ -19106,23 +19111,24 @@ impl Workspace {
         let any_member_active = !self.current_workspace_state.is_agent_management_view_open
             && member_range.contains(&self.active_tab_index);
 
+        // 8px gap to the right of the header (i.e. left of the member tabs) on
+        // expanded groups, matched by the trailing gap after the last member.
         const EXPANDED_GROUP_MEMBER_INSET: f32 = 8.;
 
         let mut row = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
-
         let header = self.render_horizontal_tab_group_header(
             group,
             &mouse_states,
             is_collapsed,
             any_member_active,
+            is_first_in_bar,
+            group_color,
             appearance,
             ctx,
         );
         if is_collapsed {
             row.add_child(header);
         } else {
-            // Space between the header and the first member tab.
-            // Matches the spacing at the end of the expanded group.
             row.add_child(
                 Container::new(header)
                     .with_padding_right(EXPANDED_GROUP_MEMBER_INSET)
@@ -19161,15 +19167,21 @@ impl Workspace {
             }
         }
 
-        let mut container = Container::new(row.finish()).with_border(
-            Border::all(1.)
-                // Left border only on the first slot to avoid double borders.
-                .with_sides(false, is_first_in_bar, false, true)
-                .with_border_fill(internal_colors::fg_overlay_1(theme)),
-        );
+        // The outer container carries no background: a collapsed group's header
+        // paints its own tab-style fill, and an expanded group's member tabs
+        // paint theirs, so there's never a group panel sitting behind the
+        // member tabs.
+        let mut container = Container::new(row.finish());
         if !is_collapsed {
-            // Trailing drop area after the last member.
-            container = container.with_padding_right(EXPANDED_GROUP_MEMBER_INSET);
+            container = container
+                .with_border(
+                    Border::all(1.)
+                        // Left border only on the first slot to avoid double borders.
+                        .with_sides(false, is_first_in_bar, false, true)
+                        .with_border_fill(internal_colors::fg_overlay_1(theme)),
+                )
+                // 8px drop area at the end of the expanded group.
+                .with_padding_right(EXPANDED_GROUP_MEMBER_INSET);
         }
         let container = container.finish();
 
@@ -19210,12 +19222,15 @@ impl Workspace {
 
     /// Header (icon collage + name) for a horizontal tab group. Click
     /// toggles collapse; double-click renames; right-click opens the menu.
+    #[allow(clippy::too_many_arguments)]
     fn render_horizontal_tab_group_header(
         &self,
         group: &TabGroup,
         mouse_states: &HorizontalTabGroupMouseStates,
         is_collapsed: bool,
         any_member_active: bool,
+        is_first_in_bar: bool,
+        group_color: Option<ColorU>,
         appearance: &Appearance,
         ctx: &AppContext,
     ) -> Box<dyn Element> {
@@ -19267,38 +19282,54 @@ impl Workspace {
             .with_child(name_element)
             .finish();
 
-        // Resolve the group's color so the header tints to match its member
-        // tabs in the tab bar.
-        let group_color: Option<ColorU> = group
-            .color
-            .resolve(None)
-            .map(|c| c.to_ansi_color(&theme.terminal_colors().normal).into());
         let header_active_bg = internal_colors::fg_overlay_2(theme);
         let header_hover_bg = internal_colors::fg_overlay_1(theme);
+        let border_fill = internal_colors::fg_overlay_1(theme);
         let mut header = Hoverable::new(mouse_states.header.clone(), move |state| {
-            let bg: ElementFill = if let Some(color) = group_color {
-                // Member tabs render with a vertical gradient from the theme
-                // background to the group color; use the same opacity scheme
-                // so the header reads as the start of that visual run.
-                let opacity = if header_selected || state.is_hovered() {
-                    50
-                } else {
-                    25
-                };
-                coloru_with_opacity(color, opacity).into()
-            } else if header_selected {
-                header_active_bg.into()
-            } else if state.is_hovered() {
-                header_hover_bg.into()
-            } else {
-                ElementFill::None
-            };
-
-            Container::new(row)
+            let hovered = state.is_hovered();
+            let mut container = Container::new(row)
                 .with_horizontal_padding(8.)
-                .with_vertical_padding(6.)
-                .with_background(bg)
-                .finish()
+                .with_vertical_padding(6.);
+
+            if is_collapsed {
+                // A collapsed group is a single tab chip, so it matches the
+                // exact opacity scheme regular colored tabs use (20/40/60 for
+                // idle/hover/active).
+                let bg: ElementFill = if let Some(color) = group_color {
+                    let opacity = if header_selected {
+                        60
+                    } else if hovered {
+                        40
+                    } else {
+                        20
+                    };
+                    coloru_with_opacity(color, opacity).into()
+                } else if header_selected {
+                    header_active_bg.into()
+                } else if hovered {
+                    header_hover_bg.into()
+                } else {
+                    ElementFill::None
+                };
+                container = container.with_background(bg).with_border(
+                    Border::all(1.)
+                        // Left border only on the first slot to avoid double borders.
+                        .with_sides(false, is_first_in_bar, false, true)
+                        .with_border_fill(border_fill),
+                );
+            } else {
+                let bg: ElementFill = if let Some(color) = group_color {
+                    let opacity = if hovered { 50 } else { 25 };
+                    coloru_with_opacity(color, opacity).into()
+                } else if hovered {
+                    header_hover_bg.into()
+                } else {
+                    ElementFill::None
+                };
+                container = container.with_background(bg);
+            }
+
+            container.finish()
         })
         .with_cursor(Cursor::PointingHand)
         .with_defer_events_to_children();

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -341,9 +341,9 @@ use crate::settings_view::{flags, SettingsSection, SettingsView, SettingsViewEve
 #[cfg(all(target_os = "windows", feature = "local_tty"))]
 use crate::shell_indicator::ShellIndicatorType;
 use crate::tab::{
-    tab_position_id, uses_vertical_tabs, NewSessionMenuItem, PaneNameMenuTarget, SelectedTabColor,
-    TabBarState, TabComponent, TabData, TabTelemetryAction, MOVE_TO_GROUP_LABEL,
-    TAB_BAR_BORDER_HEIGHT,
+    color_picker_menu_item, tab_position_id, uses_vertical_tabs, ColorPickerTarget,
+    NewSessionMenuItem, PaneNameMenuTarget, SelectedTabColor, TabBarState, TabComponent, TabData,
+    TabTelemetryAction, MOVE_TO_GROUP_LABEL, TAB_BAR_BORDER_HEIGHT,
 };
 use crate::tab_configs::action_sidecar::SidecarItemKind;
 use crate::tab_configs::remove_confirmation_dialog::{
@@ -5048,6 +5048,18 @@ impl Workspace {
         self.tabs.get(index).and_then(|tab| tab.color())
     }
 
+    /// Returns the effective render color for a tab. A tab in a group is fully
+    /// colored by that group: the group's color applies, and a group with no
+    /// color (the default for a fresh group) renders the member with no color,
+    /// ignoring the tab's own selected/directory color. Ungrouped tabs use their
+    /// own color.
+    fn effective_tab_color(&self, tab: &TabData) -> Option<AnsiColorIdentifier> {
+        if let Some(group) = tab.group_id.and_then(|gid| self.tab_groups.get(&gid)) {
+            return group.color.resolve(None);
+        }
+        tab.color()
+    }
+
     /// Finds the pane containing a terminal viewing the given ambient agent conversation,
     /// returning None if the ambient conversation is not open in any tab.
     fn find_pane_with_ambient_agent_conversation(
@@ -5430,6 +5442,48 @@ impl Workspace {
             SelectedTabColor::Color(color)
         };
         self.set_tab_color(index, next, ctx);
+    }
+
+    /// Sets a tab group's color. The group fully owns its members' color, so:
+    /// - `Color(c)` — every member renders with `c`.
+    /// - `Cleared` / `Unset` — every member renders with no color (a fresh group
+    ///   is `Unset`; the picker sets `Cleared` when you toggle the current color
+    ///   off). A member's own tab/directory color is ignored while it's grouped.
+    fn set_tab_group_color(
+        &mut self,
+        group_id: TabGroupId,
+        color: SelectedTabColor,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(group) = self.tab_groups.get_mut(&group_id) else {
+            return;
+        };
+        if group.color == color {
+            return;
+        }
+        group.color = color;
+        ctx.dispatch_global_action("workspace:save_app", ());
+        ctx.notify();
+    }
+
+    /// Toggles the color for a tab group: applies `color` if not already set to it,
+    /// otherwise clears it.
+    fn toggle_tab_group_color(
+        &mut self,
+        group_id: TabGroupId,
+        color: AnsiColorIdentifier,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let current = self
+            .tab_groups
+            .get(&group_id)
+            .and_then(|g| g.color.resolve(None));
+        let next = if current == Some(color) {
+            SelectedTabColor::Cleared
+        } else {
+            SelectedTabColor::Color(color)
+        };
+        self.set_tab_group_color(group_id, next, ctx);
     }
 
     /// Syncs the tab color for the given tab based on the active terminal's CWD.
@@ -9491,6 +9545,19 @@ impl Workspace {
             items
         };
 
+        // Color picker: same dot-based selector as individual tabs.
+        let color_section = {
+            // Resolve the group's currently selected color for highlighting the active dot.
+            let effective_color = self
+                .tab_groups
+                .get(&group_id)
+                .and_then(|g| g.color.resolve(None));
+            vec![color_picker_menu_item(
+                effective_color,
+                ColorPickerTarget::Group { group_id },
+            )]
+        };
+
         let mut menu_items = vec![];
         for section_items in [
             vec![
@@ -9506,6 +9573,7 @@ impl Workspace {
                 .with_on_select_action(WorkspaceAction::RenameTabGroup(group_id))
                 .into_item()],
             close_section,
+            color_section,
         ] {
             if section_items.is_empty() {
                 continue;
@@ -19038,15 +19106,29 @@ impl Workspace {
         let any_member_active = !self.current_workspace_state.is_agent_management_view_open
             && member_range.contains(&self.active_tab_index);
 
+        const EXPANDED_GROUP_MEMBER_INSET: f32 = 8.;
+
         let mut row = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
-        row.add_child(self.render_horizontal_tab_group_header(
+
+        let header = self.render_horizontal_tab_group_header(
             group,
             &mouse_states,
             is_collapsed,
             any_member_active,
             appearance,
             ctx,
-        ));
+        );
+        if is_collapsed {
+            row.add_child(header);
+        } else {
+            // Space between the header and the first member tab.
+            // Matches the spacing at the end of the expanded group.
+            row.add_child(
+                Container::new(header)
+                    .with_padding_right(EXPANDED_GROUP_MEMBER_INSET)
+                    .finish(),
+            );
+        }
 
         if !is_collapsed {
             let close_button_position = if FeatureFlag::TabCloseButtonOnLeft.is_enabled() {
@@ -19060,6 +19142,7 @@ impl Workspace {
             let is_sole_member = group_has_single_member(&self.tabs, group.id);
             for idx in member_range {
                 let tab = &self.tabs[idx];
+                let effective_color = self.effective_tab_color(tab);
                 let member = TabComponent::new(
                     idx,
                     tab_bar_state,
@@ -19069,6 +19152,7 @@ impl Workspace {
                     false,
                     ctx,
                 )
+                .with_effective_color(effective_color)
                 .for_grouped_member(is_sole_member)
                 .with_multi_tab_selection(self.is_tab_in_multi_tab_selection(idx))
                 .build()
@@ -19077,9 +19161,6 @@ impl Workspace {
             }
         }
 
-        // Additional padding on expanded groups,
-        // allowing tabs to be dropped into the last position of the group.
-        const EXPANDED_GROUP_TRAILING_PADDING: f32 = 8.;
         let mut container = Container::new(row.finish()).with_border(
             Border::all(1.)
                 // Left border only on the first slot to avoid double borders.
@@ -19087,7 +19168,8 @@ impl Workspace {
                 .with_border_fill(internal_colors::fg_overlay_1(theme)),
         );
         if !is_collapsed {
-            container = container.with_padding_right(EXPANDED_GROUP_TRAILING_PADDING);
+            // Trailing drop area after the last member.
+            container = container.with_padding_right(EXPANDED_GROUP_MEMBER_INSET);
         }
         let container = container.finish();
 
@@ -19185,10 +19267,26 @@ impl Workspace {
             .with_child(name_element)
             .finish();
 
+        // Resolve the group's color so the header tints to match its member
+        // tabs in the tab bar.
+        let group_color: Option<ColorU> = group
+            .color
+            .resolve(None)
+            .map(|c| c.to_ansi_color(&theme.terminal_colors().normal).into());
         let header_active_bg = internal_colors::fg_overlay_2(theme);
         let header_hover_bg = internal_colors::fg_overlay_1(theme);
         let mut header = Hoverable::new(mouse_states.header.clone(), move |state| {
-            let bg: ElementFill = if header_selected {
+            let bg: ElementFill = if let Some(color) = group_color {
+                // Member tabs render with a vertical gradient from the theme
+                // background to the group color; use the same opacity scheme
+                // so the header reads as the start of that visual run.
+                let opacity = if header_selected || state.is_hovered() {
+                    50
+                } else {
+                    25
+                };
+                coloru_with_opacity(color, opacity).into()
+            } else if header_selected {
                 header_active_bg.into()
             } else if state.is_hovered() {
                 header_hover_bg.into()
@@ -19295,6 +19393,7 @@ impl Workspace {
             // outer `SavePosition`, `Draggable`, and `DropTarget` wrappers
             // so the chip overlay doesn't pollute the target window's
             // position cache (see `TabComponent::for_drag_ghost`).
+            let effective_color = self.effective_tab_color(tab);
             TabComponent::new(
                 tab_index,
                 tab_bar_state,
@@ -19304,6 +19403,7 @@ impl Workspace {
                 false,
                 ctx,
             )
+            .with_effective_color(effective_color)
             .for_drag_ghost()
             .build()
             .finish()
@@ -22819,7 +22919,20 @@ impl TypedActionView for Workspace {
                 );
             }
             SetActiveTabName(name) => self.set_active_tab_name(name, ctx),
-            SetActiveTabColor(color) => self.set_tab_color(self.active_tab_index, *color, ctx),
+            SetActiveTabColor(color) => {
+                // When the active tab is in a group, redirect to the group's color.
+                // The tab color selection menu is hidden when a tab is part of a group
+                // this handles the case where a tab color is set via a slash command.
+                let active_group_id = self
+                    .tabs
+                    .get(self.active_tab_index)
+                    .and_then(|t| t.group_id);
+                if let Some(group_id) = active_group_id {
+                    self.set_tab_group_color(group_id, *color, ctx);
+                } else {
+                    self.set_tab_color(self.active_tab_index, *color, ctx);
+                }
+            }
             ToggleTabRightClickMenu { tab_index, anchor } => {
                 self.toggle_tab_right_click_menu(*tab_index, *anchor, ctx)
             }
@@ -23250,6 +23363,9 @@ impl TypedActionView for Workspace {
             SetA11yVerbosityLevel(verbosity) => self.set_a11y_verbosity(*verbosity, ctx),
             ToggleNotifications => self.toggle_notifications(ctx),
             ToggleTabColor { color, tab_index } => self.toggle_tab_color(*tab_index, *color, ctx),
+            ToggleTabGroupColor { color, group_id } => {
+                self.toggle_tab_group_color(*group_id, *color, ctx)
+            }
             DispatchToSettingsTab(action) => {
                 let window_id = ctx.window_id();
                 ctx.dispatch_typed_action_for_view(window_id, self.settings_pane.id(), action)

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -2024,7 +2024,15 @@ fn render_tab_group_internal(
     // Captured into row/group right-click closures so they can pick between
     // the single-pane menu and the multi-tab selection menu.
     let is_in_multi_tab_selection = workspace.is_tab_in_multi_tab_selection(tab_index);
-    let color_mode = compute_tab_group_color_mode(tab, pane_group, &visible_pane_ids, theme, app);
+    let tab_group_for_color = tab.group_id.and_then(|gid| workspace.tab_groups.get(&gid));
+    let color_mode = compute_tab_group_color_mode(
+        tab,
+        pane_group,
+        &visible_pane_ids,
+        theme,
+        tab_group_for_color,
+        app,
+    );
     let per_pane_colors = color_mode.into_per_pane_colors(&visible_pane_ids);
     let is_being_renamed = is_active && workspace.current_workspace_state.is_tab_being_renamed();
     let rename_editor = workspace.tab_rename_editor.clone();
@@ -2729,6 +2737,12 @@ fn render_grouped_tabs_header(
         .with_child(action_buttons)
         .finish();
 
+    // Resolve the group's color so the header tints to match its member tabs.
+    let group_color_fill: Option<ThemeFill> = group
+        .color
+        .resolve(None)
+        .map(|c| c.to_ansi_color(&theme.terminal_colors().normal).into());
+
     let mut hoverable = Hoverable::new(mouse_states.header.clone(), move |state| {
         let border_fill = if is_header_selected {
             internal_colors::fg_overlay_3(theme)
@@ -2739,7 +2753,16 @@ fn render_grouped_tabs_header(
             .with_padding(Padding::uniform(GROUP_HORIZONTAL_PADDING))
             .with_corner_radius(CornerRadius::with_all(Radius::Pixels(ROW_CORNER_RADIUS)))
             .with_border(Border::all(1.).with_border_fill(border_fill));
-        if is_header_selected || state.is_hovered() {
+        if let Some(color) = group_color_fill {
+            // Match the per-row color opacity scheme so the header reads as
+            // part of the same group as the colored member rows.
+            let opacity = if is_header_selected || state.is_hovered() {
+                TAB_COLOR_HOVER_OPACITY
+            } else {
+                TAB_COLOR_OPACITY
+            };
+            container = container.with_background(color.with_opacity(opacity));
+        } else if is_header_selected || state.is_hovered() {
             container = container.with_background(internal_colors::fg_overlay_2(theme));
         }
         container.finish()
@@ -5169,16 +5192,33 @@ fn render_pull_request_badge_content(label: &str, appearance: &Appearance) -> Bo
         .finish()
 }
 
+/// Resolves the rendered color mode for a tab's panes. A tab in a `tab_group`
+/// is fully colored by that group: the group's color applies uniformly, and a
+/// group with no color (the default for a fresh group) renders its members with
+/// no color, ignoring each member's own selected/directory color. An ungrouped
+/// tab uses its own `selected_color`, falling through to per-pane directory
+/// colors when unset.
 fn compute_tab_group_color_mode(
     tab: &TabData,
     pane_group: &PaneGroup,
     visible_pane_ids: &[PaneId],
     theme: &WarpTheme,
+    tab_group: Option<&TabGroup>,
     app: &AppContext,
 ) -> TabGroupColorMode {
-    // Manual override applies to the whole group.
+    // A grouped tab's color is fully owned by its group.
+    if let Some(group) = tab_group {
+        return match group.color.resolve(None) {
+            Some(color) => TabGroupColorMode::Uniform(
+                color.to_ansi_color(&theme.terminal_colors().normal).into(),
+            ),
+            None => TabGroupColorMode::None,
+        };
+    }
+
+    // Ungrouped tab: a manual color override applies to the whole tab.
     if !matches!(tab.selected_color, SelectedTabColor::Unset) {
-        return match tab.color() {
+        return match tab.selected_color.resolve(tab.default_directory_color) {
             Some(color) => TabGroupColorMode::Uniform(
                 color.to_ansi_color(&theme.terminal_colors().normal).into(),
             ),


### PR DESCRIPTION
## Description

This PR supports setting a color for tab groups. It also fixes a small rendering bug with htabs that was evident with tab group colors (seen in the first demo). Tab groups now have the color picker menu that regular tabs have. Tabs within a group can not be given a color. Tabs also retain their original color if they are removed from the group in the future.

NOTE: waiting on feedback for UI, but any changes here are small rendering updates, majority of this PR is reusing the color selection menu and updating the groups color accordingly

## How it works 

-  TabGroup.color is the single source of truth for the color of a group and its tabs. `WorkspaceAction::ToggleTabGroupColor` (handled by `set_tab_group_color / toggle_tab_group_color`) sets it. The color is applied at draw time so a member never has its own color overwritten and reverts if it leaves the group.
-  I extracted the color selection menu into a single helper, `color_picker_menu_item(current_color, target)`, with a `ColorPickerTarget::{Tab, Group}` enum that emits the right action. Both the tab menu and the group menu build from it, and `color_option_menu_items` returns empty for grouped tabs so color is only set at the group level.
- Collapsed group renders as a single tab. In `render_horizontal_tab_group_header`, the collapsed branch paints the same idle/hover/active brightness a normal tab uses and gives the header itself both the fill and the border. 


### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo video ](https://www.loom.com/share/6666936bd2114e69b767a305ded946e2)

The above demo has a weird divider between tab groups and other tabs, here is a demo of that fix: 

[video](https://www.loom.com/share/c8d50af146b54aa48b2a40ef17ee9ff4)