### PR TITLE
Fix Ctrl+Tab switcher: carry tab color to icon and lead with title

### DIFF
--- a/app/src/search/command_palette/tabs/search_item.rs
+++ b/app/src/search/command_palette/tabs/search_item.rs
@@ -36,7 +36,13 @@ impl SearchItemTrait for SearchItem {
         highlight_state: ItemHighlightState,
         appearance: &Appearance,
     ) -> Box<dyn Element> {
-        let color = highlight_state.icon_fill(appearance).into_solid();
+        let color = if let Some(tab_color) = self.tab.color {
+            tab_color
+                .to_ansi_color(&appearance.theme().terminal_colors().normal)
+                .into()
+        } else {
+            highlight_state.icon_fill(appearance).into_solid()
+        };
         render_search_item_icon(appearance, Icon::Navigation, color, highlight_state)
     }
 
@@ -54,7 +60,7 @@ impl SearchItemTrait for SearchItem {
         let appearance = Appearance::as_ref(app);
 
         let title_text = Text::new_inline(
-            format!("[Tab {}] {}", self.tab.tab_index, self.tab.title),
+            format!("{} · Tab {}", self.tab.title, self.tab.tab_index),
             appearance.ui_font_family(),
             appearance.monospace_font_size(),
         )

--- a/app/src/session_management.rs
+++ b/app/src/session_management.rs
@@ -7,6 +7,7 @@ use crate::context_chips::prompt_snapshot::PromptSnapshot;
 use crate::pane_group::{PaneGroup, PaneId};
 use crate::terminal::model::blockgrid::BlockGrid;
 use crate::terminal::shared_session::SharedSessionStatus;
+use crate::themes::theme::AnsiColorIdentifier;
 use crate::workspace::{PaneViewLocator, Workspace};
 
 /// Contains session metadata, including a prompt and running command (if there is one).
@@ -240,4 +241,6 @@ pub struct TabNavigationData {
     pub window_id: WindowId,
     /// 1-based left-to-right tab index for display disambiguation.
     pub tab_index: usize,
+    /// The tab's color, if one has been set by the user.
+    pub color: Option<AnsiColorIdentifier>,
 }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5056,6 +5056,7 @@ impl Workspace {
                     subtitle,
                     window_id,
                     tab_index: tab_index + 1,
+                    color: tab.color(),
                 })
             })
             .collect()


### PR DESCRIPTION
## Description
This PR improves the usability and visual hierarchy of the `Ctrl+Tab` MRU switcher. 

Specifically:
1. **Ignores Tab Colors:** The MRU switcher previously ignored custom tab color-coding. This change ensures that if a tab has a custom color (either manual override or directory default), the switcher icon is tinted with that color.
2. **Text Formatting:** Changed the layout format of switcher rows from `[Tab N] Title` to `Title · Tab N` so that the actual tab name is prioritized and easier to scan.

## Changes
- Added a `color` field (`Option<AnsiColorIdentifier>`) to `TabNavigationData` and populated it in `Workspace::tab_navigation_data()`.
- Updated `SearchItem::render_icon` to use the tab color if available, falling back to the standard highlight fill.
- Updated `SearchItem::render_item` to display labels in the `Title · Tab N` format.

## Linked Issue
Fixes #12692

## Visual Proof
<img width="1024" height="1024" alt="ctrl_tab_switcher_demo_1781770421433" src="https://github.com/user-attachments/assets/9cf5d38c-d39c-4d02-8ba2-59949206d524" />


## Testing
- [x] Verified switcher renders tab icons with correct user-defined or default directory colors.
- [x] Verified tab titles are correctly displayed first, followed by the index as a trailing detail.
