### PR TITLE
Show tab color and lead with title in Ctrl+Tab switcher

### DIFF
--- a/app/src/search/command_palette/tabs/search_item.rs
+++ b/app/src/search/command_palette/tabs/search_item.rs
@@ -36,7 +36,15 @@ impl SearchItemTrait for SearchItem {
         highlight_state: ItemHighlightState,
         appearance: &Appearance,
     ) -> Box<dyn Element> {
-        let color = highlight_state.icon_fill(appearance).into_solid();
+        // Tint the icon with the tab's color-coding so colored tabs are
+        // distinguishable in the switcher; fall back to the default icon fill
+        // for uncolored tabs. Contrast against the row is handled downstream.
+        let color = match self.tab.color {
+            Some(id) => id
+                .to_ansi_color(&appearance.theme().terminal_colors().normal)
+                .into(),
+            None => highlight_state.icon_fill(appearance).into_solid(),
+        };
         render_search_item_icon(appearance, Icon::Navigation, color, highlight_state)
     }
 
@@ -54,7 +62,7 @@ impl SearchItemTrait for SearchItem {
         let appearance = Appearance::as_ref(app);
 
         let title_text = Text::new_inline(
-            format!("[Tab {}] {}", self.tab.tab_index, self.tab.title),
+            format!("{}  ·  Tab {}", self.tab.title, self.tab.tab_index),
             appearance.ui_font_family(),
             appearance.monospace_font_size(),
         )

--- a/app/src/session_management.rs
+++ b/app/src/session_management.rs
@@ -7,6 +7,7 @@ use crate::context_chips::prompt_snapshot::PromptSnapshot;
 use crate::pane_group::{PaneGroup, PaneId};
 use crate::terminal::model::blockgrid::BlockGrid;
 use crate::terminal::shared_session::SharedSessionStatus;
+use crate::themes::theme::AnsiColorIdentifier;
 use crate::workspace::{PaneViewLocator, Workspace};
 
 /// Contains session metadata, including a prompt and running command (if there is one).
@@ -240,4 +241,6 @@ pub struct TabNavigationData {
     pub window_id: WindowId,
     /// 1-based left-to-right tab index for display disambiguation.
     pub tab_index: usize,
+    /// The tab's color-coding, mirrored from the tab bar, if any.
+    pub color: Option<AnsiColorIdentifier>,
 }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5056,6 +5056,7 @@ impl Workspace {
                     subtitle,
                     window_id,
                     tab_index: tab_index + 1,
+                    color: tab.color(),
                 })
             })
             .collect()


### PR DESCRIPTION
## Description

The Ctrl+Tab switcher (the MRU palette for cycling through recent tabs/sessions) doesn't reflect tab color-coding, and each row starts with `[Tab N]` before the title. With a few colored, renamed tabs open, the rows all look the same and the index gets read before the name you actually recognize.

This carries the tab color into the switcher and leads each row with the title:

- Added a `color` field to `TabNavigationData`, populated from `tab.color()` in `Workspace::tab_navigation_data()`.
- `render_icon` now tints the row icon with the tab color (same `to_ansi_color(...).into()` conversion the rest of the tab UI uses), falling back to the default fill when a tab has no color. Contrast against the row background is still handled by `render_search_item_icon`.
- Changed the row label from `[Tab N] title` to `title  ·  Tab N`.

## Linked Issue

Fixes #12692

- [x] The linked issue is labeled `ready-to-implement`.
- [ ] Screenshots of the implementation are included below.

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

`./script/presubmit` passes (fmt + clippy). Before/after screenshots of the switcher with colored, renamed tabs to follow.

### Screenshots / Videos

_Pending._

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: The Ctrl+Tab tab switcher now shows each tab's color-coding and leads with the tab title instead of the tab index.
