### PR TITLE
feat(diff-viewer): skip collapsed sections on vertical arrow navigation

### DIFF
--- a/crates/editor/src/selection.rs
+++ b/crates/editor/src/selection.rs
@@ -157,27 +157,70 @@ impl SelectionModel {
         offset: CharOffset,
         ctx: &impl ModelAsRef,
     ) -> CharOffset {
-        if !self.has_rendered_mermaid(ctx) {
+        // Normalize for Mermaid code blocks (existing behavior).
+        let offset = if self.has_rendered_mermaid(ctx) {
+            let content = self.content.as_ref(ctx);
+            let max_offset = content.max_charoffset();
+            match direction {
+                TextDirection::Forwards
+                    if offset < max_offset && self.is_mermaid_code_block_offset(offset, ctx) =>
+                {
+                    content.block_or_line_end(offset).min(max_offset)
+                }
+                TextDirection::Backwards
+                    if offset > CharOffset::from(1)
+                        && self.is_mermaid_code_block_offset(offset, ctx) =>
+                {
+                    content.block_or_line_start(offset)
+                }
+                _ => offset,
+            }
+        } else {
+            offset
+        };
+
+        // Skip over collapsed hidden sections so the cursor lands on the first
+        // visible line on the far side rather than getting stuck inside them.
+        self.skip_hidden_ranges(direction, offset, ctx)
+    }
+
+    /// If `offset` falls inside a hidden range, advance to the nearest visible
+    /// offset in `direction`. Loops to handle back-to-back hidden ranges.
+    fn skip_hidden_ranges(
+        &self,
+        direction: TextDirection,
+        mut offset: CharOffset,
+        ctx: &impl ModelAsRef,
+    ) -> CharOffset {
+        let Some(hidden_lines) = &self.hidden_lines else {
             return offset;
-        }
+        };
+        let buffer_version = self.content.as_ref(ctx).buffer_version();
+        let hidden_ranges = hidden_lines
+            .as_ref(ctx)
+            .hidden_ranges_at_version(buffer_version);
 
-        let content = self.content.as_ref(ctx);
-        let max_offset = content.max_charoffset();
-
-        match direction {
-            TextDirection::Forwards
-                if offset < max_offset && self.is_mermaid_code_block_offset(offset, ctx) =>
-            {
-                content.block_or_line_end(offset).min(max_offset)
+        loop {
+            let in_hidden = hidden_ranges
+                .iter()
+                .find(|r| offset >= r.start && offset < r.end);
+            match (in_hidden, direction) {
+                (Some(range), TextDirection::Forwards) => {
+                    offset = range.end;
+                }
+                (Some(range), TextDirection::Backwards) => {
+                    // Jump to just before the hidden range. range.start is the first hidden
+                    // offset; subtracting one lands on the last visible character above.
+                    if range.start > CharOffset::from(1) {
+                        offset = range.start.saturating_sub(&CharOffset::from(1));
+                    } else {
+                        break;
+                    }
+                }
+                (None, _) => break,
             }
-            TextDirection::Backwards
-                if offset > CharOffset::from(1)
-                    && self.is_mermaid_code_block_offset(offset, ctx) =>
-            {
-                content.block_or_line_start(offset)
-            }
-            _ => offset,
         }
+        offset
     }
 
     fn normalize_selection_offsets(


### PR DESCRIPTION
## Description
Down/up arrow in the diff viewer now jumps over collapsed context sections to the first visible line on the far side, matching VSCode's behavior. Previously, vertical navigation that would land inside a hidden range was silently dropped as a no-op.

**How it works:**
- `SelectionModel::normalize_line_navigation_offset` (which already snaps the cursor out of Mermaid code blocks after line navigation) now also calls a new `skip_hidden_ranges` step.
- `skip_hidden_ranges` detects when the computed landing offset is inside a hidden range and advances to `hidden_range.end` (forward) or `hidden_range.start - 1` (backward), looping to handle back-to-back hidden ranges.
- Uses `hidden_ranges_at_version` (context-free) to avoid needing `&AppContext` from the `&impl ModelAsRef` call site.
- Selection-extend across hidden sections (Shift+Down) remains blocked by the existing `validate_select_action` guard — the selection range would span hidden content, which the validator rejects. Extend-selection support is a follow-up.

**TODO follow-up:**
- Shift+Down (extend selection) across collapsed sections — needs a product decision on whether the selection silently includes hidden lines (like VSCode does), and `validate_select_action` changes accordingly.

## Linked Issue
N/A (feedback from internal Slack)

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

Tested: `cargo check --package warp_editor` ✅, `cargo clippy --package warp_editor` ✅, `./script/format` ✅

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: Down and up arrow keys in the diff viewer now jump over collapsed context sections to the nearest visible line, instead of doing nothing.
-->

_Conversation: https://staging.warp.dev/conversation/0ed1eda5-e823-4209-9dd2-b1caf3a373eb_
_Run: https://oz.staging.warp.dev/runs/019edb66-d378-7189-8a76-1ddcce496e3e_
_This PR was generated with [Oz](https://warp.dev/oz)._
