### PR TITLE
Add 'Copy focus link' to pane and tab menus

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -689,6 +689,7 @@ default = [
     "billing_and_usage_page_v2",
     "remote_code_review",
     "git_operations_in_code_review",
+    "copy_pane_focus_link",
 ]
 # Enable this feature to automatically perform heap profiling.  NOTE: This will
 # substantially slow down program execution.

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -496,6 +496,7 @@ crash_reporting = [
     "warp_logging/crash_reporting",
     "ai/crash_reporting",
 ]
+copy_pane_focus_link = []
 creating_shared_sessions = []
 cross_repo_context = []
 codebase_index_persistence = ["full_source_code_embedding"]

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -51,6 +51,8 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::ViewingSharedSessions,
         #[cfg(feature = "creating_shared_sessions")]
         FeatureFlag::CreatingSharedSessions,
+        #[cfg(feature = "copy_pane_focus_link")]
+        FeatureFlag::CopyPaneFocusLink,
         #[cfg(feature = "agent_mode")]
         FeatureFlag::AgentMode,
         #[cfg(feature = "shared_session_long_running_commands")]

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -2553,8 +2553,9 @@ impl PaneGroup {
         _source: SharedSessionActionSource,
         ctx: &mut ViewContext<Self>,
     ) {
-        use crate::view_components::DismissibleToast;
         use warpui::clipboard::ClipboardContent;
+
+        use crate::view_components::DismissibleToast;
 
         let pane_id: PaneId = terminal_pane_id.into();
         let Some(uuid) = self

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -2543,6 +2543,45 @@ impl PaneGroup {
         ctx.notify();
     }
 
+    /// Copies a `warp://session/{uuid}` URL for the given terminal pane to
+    /// the clipboard. Used by the "Copy focus link" pane menu item; the URL
+    /// can be opened later (e.g. from AppleScript) to refocus this exact
+    /// pane.
+    fn copy_pane_focus_link(
+        &self,
+        terminal_pane_id: TerminalPaneId,
+        _source: SharedSessionActionSource,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        use crate::view_components::DismissibleToast;
+        use warpui::clipboard::ClipboardContent;
+
+        let pane_id: PaneId = terminal_pane_id.into();
+        let Some(uuid) = self
+            .panes_of::<TerminalPane>()
+            .find(|p| p.id() == pane_id)
+            .map(|p| p.session_uuid())
+        else {
+            log::warn!("CopyPaneFocusLink: terminal pane not found");
+            return;
+        };
+        let Some(hex) = crate::uri::encode_uuid_hex(&uuid) else {
+            log::warn!("CopyPaneFocusLink: session UUID was not 16 bytes");
+            return;
+        };
+        // Use the running channel's scheme so the URL routes back to this
+        // build (warposs:// for OSS, warplocal:// for local dev, warp:// for
+        // stable, etc.) rather than to the commercial Warp install.
+        let url = format!("{}://session/{hex}", ChannelState::url_scheme());
+        ctx.clipboard().write(ClipboardContent::plain_text(url));
+
+        let window_id = ctx.window_id();
+        crate::workspace::ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+            let toast = DismissibleToast::default("Copied focus link".to_string());
+            toast_stack.add_ephemeral_toast(toast, window_id, ctx);
+        });
+    }
+
     fn open_share_session_denied_modal(
         &mut self,
         terminal_pane_id: TerminalPaneId,

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -1171,6 +1171,9 @@ fn handle_terminal_view_event(
             Event::StopSharingCurrentSession { .. } => {
                 group.stop_transitively_shared_child_shares(pane_id, ctx);
             }
+            Event::CopyPaneFocusLink { source } => {
+                group.copy_pane_focus_link(terminal_pane_id, *source, ctx);
+            }
             Event::OpenShareSessionDeniedModal => {
                 group.open_share_session_denied_modal(terminal_pane_id, ctx);
             }

--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -229,6 +229,7 @@ impl TabData {
             self.tab_group_menu_items(index, tab_groups),
             self.session_sharing_menu_items(index, ctx),
             self.copy_metadata_menu_items(pane_name_target, ctx),
+            Self::copy_focus_link_menu_items(index),
             self.modify_tab_menu_items(index, can_move_left, can_move_right, pane_name_target, ctx),
             self.close_tab_menu_items(index, tabs_len, ctx),
             Self::save_config_menu_items(index),
@@ -408,6 +409,18 @@ impl TabData {
         }
 
         menu_items
+    }
+
+    /// "Copy focus link" item for the tab right-click menu. Mirrors the
+    /// per-pane menu item but targets the tab's focused pane, so it's
+    /// reachable for single-pane tabs that don't render a pane header.
+    fn copy_focus_link_menu_items(index: usize) -> Vec<MenuItem<WorkspaceAction>> {
+        if !FeatureFlag::CopyPaneFocusLink.is_enabled() {
+            return vec![];
+        }
+        vec![MenuItemFields::new("Copy focus link")
+            .with_on_select_action(WorkspaceAction::CopyTabFocusLink { tab_index: index })
+            .into_item()]
     }
 
     fn push_copy_metadata_menu_item(

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -1779,6 +1779,12 @@ pub enum Event {
     OpenShareSessionModal {
         open_source: SharedSessionActionSource,
     },
+    /// Emitted from a TerminalView to request its containing PaneGroup
+    /// resolve the pane's session UUID and copy a `warp://session/{uuid}`
+    /// link to the clipboard.
+    CopyPaneFocusLink {
+        source: SharedSessionActionSource,
+    },
     OpenShareSessionDeniedModal,
     /// Used to focus and bring this session to the foreground.
     FocusSession,
@@ -25968,6 +25974,7 @@ impl TypedActionView for TerminalView {
             | OpenShareSessionModal { .. }
             | OpenSharedSessionViewerRoleMenu
             | CopySharedSessionLink { .. }
+            | CopyPaneFocusLink { .. }
             | OpenSharedSessionOnDesktop { .. }
             | MakeAllParticipantsReaders { .. }
             | AskAIAssistant { .. }
@@ -26463,6 +26470,9 @@ impl TypedActionView for TerminalView {
                 self.toggle_block_filter_on_selected_or_last_block(*source, ctx);
             }
             CopySharedSessionLink { source } => self.copy_shared_session_link(*source, ctx),
+            CopyPaneFocusLink { source } => {
+                ctx.emit(Event::CopyPaneFocusLink { source: *source });
+            }
             ToggleSnackbarInActivePane => self.toggle_snackbar_in_active_pane(ctx),
             MakeAllParticipantsReaders { reason } => {
                 self.make_all_shared_session_participants_readers(*reason, ctx)

--- a/app/src/terminal/view/action.rs
+++ b/app/src/terminal/view/action.rs
@@ -307,6 +307,12 @@ pub enum TerminalAction {
     CopySharedSessionLink {
         source: SharedSessionActionSource,
     },
+    /// Copies a `warp://session/{uuid}` URL for the focused pane to the
+    /// clipboard. Used for external automation (AppleScript, Stream Deck) —
+    /// purely local, no server involvement, unrelated to session sharing.
+    CopyPaneFocusLink {
+        source: SharedSessionActionSource,
+    },
     VimModeBanner(VimModeBannerAction),
     ToggleSnackbarInActivePane,
     MakeAllParticipantsReaders {
@@ -638,6 +644,7 @@ impl fmt::Debug for TerminalAction {
             }
             OpenShareSessionModal { source } => write!(f, "OpenShareSessionModal({source:?})"),
             CopySharedSessionLink { .. } => f.write_str("CopySharedSessionLink"),
+            CopyPaneFocusLink { .. } => f.write_str("CopyPaneFocusLink"),
             VimModeBanner(action) => write!(f, "VimModeBanner({action:?})"),
             ToggleSnackbarInActivePane => write!(f, "ToggleSnackbarInActivePane"),
             MakeAllParticipantsReaders { reason } => {

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -689,6 +689,14 @@ impl BackingView for TerminalView {
             );
         }
 
+        if FeatureFlag::CopyPaneFocusLink.is_enabled() {
+            items.push(
+                MenuItemFields::new("Copy focus link")
+                    .with_on_select_action(TerminalAction::CopyPaneFocusLink { source })
+                    .into_item(),
+            );
+        }
+
         // Split-pane related items.
         if self.split_pane_state(ctx).is_in_split_pane() {
             if !items.is_empty() {

--- a/app/src/uri/mod.rs
+++ b/app/src/uri/mod.rs
@@ -1638,6 +1638,20 @@ fn decode_uuid_hex(hex: &str) -> Option<Vec<u8>> {
         .collect()
 }
 
+/// Lowercase hex-encode a 16-byte UUID. Inverse of `decode_uuid_hex`.
+/// Returns `None` if the input isn't exactly 16 bytes.
+pub(crate) fn encode_uuid_hex(bytes: &[u8]) -> Option<String> {
+    if bytes.len() != 16 {
+        return None;
+    }
+    let mut out = String::with_capacity(32);
+    for b in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{b:02x}");
+    }
+    Some(out)
+}
+
 #[cfg(test)]
 #[path = "uri_tests.rs"]
 mod tests;

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -435,6 +435,12 @@ pub enum WorkspaceAction {
     OpenSharedSessionQrCode {
         session_id: SessionId,
     },
+    /// Copies a `<channel-scheme>://session/{uuid}` focus URL for the tab's
+    /// focused pane to the clipboard. Reachable from the tab right-click
+    /// menu so it works even when no pane header is visible.
+    CopyTabFocusLink {
+        tab_index: usize,
+    },
     AddWindow,
     AddWindowWithShell {
         shell: AvailableShell,
@@ -1050,6 +1056,7 @@ impl WorkspaceAction {
             | StopSharingAllSessionsInTab { .. }
             | CopySharedSessionLinkFromTab { .. }
             | OpenSharedSessionQrCode { .. }
+            | CopyTabFocusLink { .. }
             | ReopenClosedSession
             | FocusLeftPanel
             | FocusRightPanel

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -4408,6 +4408,23 @@ impl Workspace {
         });
     }
 
+    /// Copies a focus-link URL for the focused terminal pane in the given
+    /// tab. Emits the same event the per-pane menu uses, so the pane group
+    /// resolves the UUID and writes to the clipboard via the existing path.
+    fn copy_tab_focus_link(&mut self, tab_index: usize, ctx: &mut ViewContext<Self>) {
+        let Some(pane_group) = self.tabs.get(tab_index).map(|tab| tab.pane_group.clone()) else {
+            return;
+        };
+        let Some(terminal_view) = pane_group.as_ref(ctx).focused_session_view(ctx) else {
+            return;
+        };
+        terminal_view.update(ctx, |_view, ctx| {
+            ctx.emit(terminal::view::Event::CopyPaneFocusLink {
+                source: SharedSessionActionSource::Tab,
+            });
+        });
+    }
+
     fn subscribe_to_shared_session_manager(ctx: &mut ViewContext<Self>) {
         use terminal::shared_session::manager::{Manager, ManagerEvent};
 
@@ -24231,6 +24248,7 @@ impl TypedActionView for Workspace {
                     });
                 }
             }
+            CopyTabFocusLink { tab_index } => self.copy_tab_focus_link(*tab_index, ctx),
             AddWindow => {
                 ctx.dispatch_global_action("root_view:open_new", ());
             }

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -914,7 +914,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::LogExpensiveFramesInSentry,
     FeatureFlag::ToggleBootstrapBlock,
     FeatureFlag::CreatingSharedSessions,
-    FeatureFlag::CopyPaneFocusLink,
     FeatureFlag::RemoveAutosuggestionDuringTabCompletions,
     FeatureFlag::ResizeFix,
     FeatureFlag::AgentModeWorkflows,

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -54,6 +54,13 @@ pub enum FeatureFlag {
     /// killswitch for abuse prevention.
     CreatingSharedSessions,
 
+    /// Adds a "Copy focus link" item to the per-pane overflow menu that
+    /// writes a `warp://session/{uuid}` URL for the pane to the clipboard.
+    /// Used for AppleScript / Stream Deck automation to focus a specific
+    /// pane externally. Independent of session sharing — uses the pane's
+    /// local persistent UUID, no server involvement.
+    CopyPaneFocusLink,
+
     /// Enables the joining / viewing of shared sessions (_not_ creation).
     ViewingSharedSessions,
 
@@ -907,6 +914,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::LogExpensiveFramesInSentry,
     FeatureFlag::ToggleBootstrapBlock,
     FeatureFlag::CreatingSharedSessions,
+    FeatureFlag::CopyPaneFocusLink,
     FeatureFlag::RemoveAutosuggestionDuringTabCompletions,
     FeatureFlag::ResizeFix,
     FeatureFlag::AgentModeWorkflows,


### PR DESCRIPTION
## Description

Adds a "Copy focus link" item to both the per-pane overflow (⋮) menu and the tab right-click menu. Clicking it writes a `<channel-scheme>://session/{uuid}` URL for the focused pane to the clipboard. The URL routes through the existing `warp://session/{uuid}` deeplink handler, so opening it later (e.g. from AppleScript, macOS Shortcuts, or a Stream Deck button) jumps Warp back to that exact pane.

Independent of session sharing — uses only the pane's local persistent UUID, no server involvement. Available on both menus so it works for single-pane tabs that don't render a pane header (`should_render_header` only returns true for split panes, shared sessions, or fullscreen agent views).

The URL scheme is taken from `ChannelState::url_scheme()`, so it matches the running build (`warposs://` for OSS, `warplocal://` for local dev, `warp://` for stable, etc.).

Gated by a new `copy_pane_focus_link` cargo feature, enabled by default.

### Architecture
- New `TerminalAction::CopyPaneFocusLink { source }` on the pane menu dispatches an `Event::CopyPaneFocusLink` from `TerminalView`.
- `TerminalPane` (in `pane_group/pane/terminal_pane.rs`) catches the event and calls `PaneGroup::copy_pane_focus_link`, which has direct access to the pane's `session_uuid()`.
- `PaneGroup::copy_pane_focus_link` formats `{scheme}://session/{hex}` via the new `encode_uuid_hex` helper in `uri/mod.rs` (inverse of the existing `decode_uuid_hex`), writes to the clipboard, and shows a "Copied focus link" toast.
- The tab-menu entry point dispatches `WorkspaceAction::CopyTabFocusLink(tab_index)`, which resolves the tab's focused terminal view and re-emits the same event — so the clipboard/toast path is shared.

## Linked Issue
<!-- This PR was opened without a linked issue; happy to open one if the team prefers the ready-to-spec → ready-to-implement flow first. -->
- [ ] The linked issue is labeled \`ready-to-spec\` or \`ready-to-implement\`.

## Testing

- [x] \`cargo check -p warp\` with and without \`--features copy_pane_focus_link\`
- [x] \`cargo check -p warp --tests\`
- [x] \`./script/presubmit\` — fmt, clippy, full test suite. The only failures are 5 SSH integration tests (\`shell_integration_tests::test_ssh_into_*\`, \`ui_tests::test_ssh_with_shell_override\`) which require gcloud auth to the internal \`warp-ssh-integration-testing\` GCP project and have nothing to do with this change.
- [x] Manual UI verification on an earlier revision of the branch (right-click tab/pane → "Copy focus link" → paste URL → reopens correct pane). Worth re-confirming on the rebased version before merge.
- [ ] I have manually tested my changes locally with \`./script/run\`

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!-- This PR was developed with Claude Code (Anthropic's CLI), not Warp's Agent Mode. -->

CHANGELOG-NEW-FEATURE: Added "Copy focus link" to the pane and tab menus, which copies a URL that re-focuses that specific pane — useful for external automation (AppleScript, macOS Shortcuts, Stream Deck).