### PR TITLE
Don't log warnings on ping frames

### DIFF
--- a/app/src/terminal/shared_session/sharer/network.rs
+++ b/app/src/terminal/shared_session/sharer/network.rs
@@ -1254,10 +1254,11 @@ impl Network {
     }
 
     fn process_websocket_message(&mut self, message: Message, ctx: &mut ModelContext<Self>) {
-        let Some(downstream_message) = message
-            .text()
-            .and_then(|t| DownstreamMessage::from_json(t).ok())
-        else {
+        // Ignore non-text frames (e.g. ping frames sent by the server).
+        let Some(text) = message.text() else {
+            return;
+        };
+        let Some(downstream_message) = DownstreamMessage::from_json(text).ok() else {
             sharer_warn!(
                 self,
                 "Received unexpected message from shared session websocket as sharer"

--- a/app/src/terminal/shared_session/viewer/network.rs
+++ b/app/src/terminal/shared_session/viewer/network.rs
@@ -520,10 +520,11 @@ impl Network {
     }
 
     fn process_websocket_message(&mut self, message: Message, ctx: &mut ModelContext<Self>) {
-        let Some(msg) = message
-            .text()
-            .and_then(|t| DownstreamMessage::from_json(t).ok())
-        else {
+        // Ignore non-text frames (e.g. ping frames sent by the server).
+        let Some(text) = message.text() else {
+            return;
+        };
+        let Some(msg) = DownstreamMessage::from_json(text).ok() else {
             log::warn!("Got unexpected message from shared session viewer websocket");
             return;
         };


### PR DESCRIPTION
## Description

Was seeing these logs from server pings. Pings are expected so don't need to log