### PR TITLE
add unit test for WarpifySettings self subscription

### DIFF
--- a/app/src/terminal/warpify/settings.rs
+++ b/app/src/terminal/warpify/settings.rs
@@ -308,7 +308,7 @@ impl WarpifySettings {
         // flag that we should show them a one-time deprecation notice on their next SSH, then
         // reset the opt-in. Because we only act when the value is still `true`, resetting it to
         // `false` ensures this migration does not run again.
-        handle.clone().update(ctx, |me, ctx| {
+        handle.update(ctx, |me, ctx| {
             if me.use_ssh_tmux_wrapper.is_value_explicitly_set() && *me.use_ssh_tmux_wrapper.value()
             {
                 if let Err(e) = me.ssh_tmux_deprecation_notice_pending.set_value(true, ctx) {

--- a/app/src/terminal/warpify/settings_tests.rs
+++ b/app/src/terminal/warpify/settings_tests.rs
@@ -10,11 +10,9 @@ fn test_parsed_subshell_commands_updated_via_self_subscription() {
         initialize_settings_for_tests(&mut app);
 
         app.read(|ctx| {
-            assert!(
-                WarpifySettings::as_ref(ctx)
-                    .parsed_added_subshell_commands
-                    .is_empty()
-            );
+            assert!(WarpifySettings::as_ref(ctx)
+                .parsed_added_subshell_commands
+                .is_empty());
         });
 
         WarpifySettings::handle(&app).update(&mut app, |settings, ctx| {
@@ -27,7 +25,11 @@ fn test_parsed_subshell_commands_updated_via_self_subscription() {
         // The parsed field must now contain the compiled regex.
         app.read(|ctx| {
             let parsed = &WarpifySettings::as_ref(ctx).parsed_added_subshell_commands;
-            assert_eq!(parsed.len(), 1, "self-subscription should have updated parsed field");
+            assert_eq!(
+                parsed.len(),
+                1,
+                "self-subscription should have updated parsed field"
+            );
             let regex = parsed[0].as_ref().expect("regex should compile");
             assert!(
                 regex.is_match("my-custom-shell"),

--- a/app/src/terminal/warpify/settings_tests.rs
+++ b/app/src/terminal/warpify/settings_tests.rs
@@ -1,5 +1,41 @@
-#[cfg(windows)]
+use settings::Setting;
+use warpui::{App, SingletonEntity};
+
 use super::WarpifySettings;
+use crate::test_util::settings::initialize_settings_for_tests;
+
+#[test]
+fn test_parsed_subshell_commands_updated_via_self_subscription() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+
+        app.read(|ctx| {
+            assert!(
+                WarpifySettings::as_ref(ctx)
+                    .parsed_added_subshell_commands
+                    .is_empty()
+            );
+        });
+
+        WarpifySettings::handle(&app).update(&mut app, |settings, ctx| {
+            settings
+                .added_subshell_commands
+                .set_value(vec!["^my-custom-shell$".to_string()], ctx)
+                .unwrap();
+        });
+
+        // The parsed field must now contain the compiled regex.
+        app.read(|ctx| {
+            let parsed = &WarpifySettings::as_ref(ctx).parsed_added_subshell_commands;
+            assert_eq!(parsed.len(), 1, "self-subscription should have updated parsed field");
+            let regex = parsed[0].as_ref().expect("regex should compile");
+            assert!(
+                regex.is_match("my-custom-shell"),
+                "compiled regex should match the command pattern"
+            );
+        });
+    });
+}
 
 #[cfg(windows)]
 #[test]


### PR DESCRIPTION
## Description

This just adds a unit test for something that I think we need coverage for, a model subscribing to itself. It is also just an important bit of behavior to test.

## Linked Issue

None, improving test coversage.
