### PR TITLE
Include `launch_mode` field in `run_internal` spans.

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -172,18 +172,6 @@ use terminal::local_shell::LocalShellState;
 pub use util::bindings::cmd_or_ctrl_shift;
 use voice::transcriber::VoiceTranscriber;
 use warp_cli::agent::AgentCommand;
-use warp_cli::api_key::ApiKeyCommand;
-use warp_cli::artifact::ArtifactCommand;
-use warp_cli::environment::EnvironmentCommand;
-use warp_cli::federate::FederateCommand;
-use warp_cli::harness_support::HarnessSupportCommand;
-use warp_cli::integration::IntegrationCommand;
-use warp_cli::mcp::MCPCommand;
-use warp_cli::model::ModelCommand;
-use warp_cli::provider::ProviderCommand;
-use warp_cli::schedule::ScheduleSubcommand;
-use warp_cli::secret::SecretCommand;
-use warp_cli::task::TaskCommand;
 use warp_cli::{CliCommand, GlobalOptions};
 #[cfg(feature = "local_fs")]
 use watcher::HomeDirectoryWatcher;
@@ -554,93 +542,7 @@ impl LaunchMode {
     fn as_str_for_tracing(&self) -> &'static str {
         match self {
             LaunchMode::App { .. } => "app",
-            LaunchMode::CommandLine { command, .. } => match command {
-                CliCommand::Agent(agent_command) => match agent_command {
-                    AgentCommand::Run(_) => "agent run",
-                    AgentCommand::RunCloud(_) => "agent run-cloud",
-                    AgentCommand::Profile(_) => "agent profile",
-                    AgentCommand::List(_) => "agent list",
-                    AgentCommand::Get(_) => "agent get",
-                    AgentCommand::Create(_) => "agent create",
-                    AgentCommand::Update(_) => "agent update",
-                    AgentCommand::Delete(_) => "agent delete",
-                    AgentCommand::Skills(_) => "agent skills",
-                },
-                CliCommand::Environment(environment_command) => match environment_command {
-                    EnvironmentCommand::List => "environment list",
-                    EnvironmentCommand::Image(_) => "environment image",
-                    EnvironmentCommand::Create { .. } => "environment create",
-                    EnvironmentCommand::Delete { .. } => "environment delete",
-                    EnvironmentCommand::Get { .. } => "environment get",
-                    EnvironmentCommand::Update { .. } => "environment update",
-                },
-                CliCommand::MCP(mcp_command) => match mcp_command {
-                    MCPCommand::List => "mcp list",
-                },
-                CliCommand::Run(task_command) => match task_command {
-                    TaskCommand::List(_) => "run list",
-                    TaskCommand::Get(_) => "run get",
-                    TaskCommand::Conversation(_) => "run conversation",
-                    TaskCommand::Message(_) => "run message",
-                },
-                CliCommand::Model(model_command) => match model_command {
-                    ModelCommand::List => "model list",
-                },
-                CliCommand::Login => "login",
-                CliCommand::Logout => "logout",
-                CliCommand::Whoami => "whoami",
-                CliCommand::Provider(provider_command) => match provider_command {
-                    ProviderCommand::Setup(_) => "provider setup",
-                    ProviderCommand::List => "provider list",
-                },
-                CliCommand::Integration(integration_command) => match integration_command {
-                    IntegrationCommand::Create(_) => "integration create",
-                    IntegrationCommand::Update(_) => "integration update",
-                    IntegrationCommand::List => "integration list",
-                },
-                CliCommand::Schedule(schedule_command) => match schedule_command.subcommand() {
-                    Some(ScheduleSubcommand::Create(_)) | None => "schedule create",
-                    Some(ScheduleSubcommand::List) => "schedule list",
-                    Some(ScheduleSubcommand::Get(_)) => "schedule get",
-                    Some(ScheduleSubcommand::Update(_)) => "schedule update",
-                    Some(ScheduleSubcommand::Pause(_)) => "schedule pause",
-                    Some(ScheduleSubcommand::Unpause(_)) => "schedule unpause",
-                    Some(ScheduleSubcommand::Delete(_)) => "schedule delete",
-                },
-                CliCommand::Secret(secret_command) => match secret_command {
-                    SecretCommand::Create(_) => "secret create",
-                    SecretCommand::Delete(_) => "secret delete",
-                    SecretCommand::Update(_) => "secret update",
-                    SecretCommand::List(_) => "secret list",
-                },
-                CliCommand::Federate(federate_command) => match federate_command {
-                    FederateCommand::IssueToken(_) => "federate issue-token",
-                    FederateCommand::IssueGcpToken(_) => "federate issue-gcp-token",
-                },
-                CliCommand::HarnessSupport(harness_support_args) => {
-                    match &harness_support_args.command {
-                        HarnessSupportCommand::Ping => "harness-support ping",
-                        HarnessSupportCommand::ReportArtifact(_) => {
-                            "harness-support report-artifact"
-                        }
-                        HarnessSupportCommand::NotifyUser(_) => "harness-support notify-user",
-                        HarnessSupportCommand::FinishTask(_) => "harness-support finish-task",
-                        HarnessSupportCommand::ReportShutdown(_) => {
-                            "harness-support report-shutdown"
-                        }
-                    }
-                }
-                CliCommand::Artifact(artifact_command) => match artifact_command {
-                    ArtifactCommand::Upload(_) => "artifact upload",
-                    ArtifactCommand::Get(_) => "artifact get",
-                    ArtifactCommand::Download(_) => "artifact download",
-                },
-                CliCommand::ApiKey(api_key_command) => match api_key_command {
-                    ApiKeyCommand::List(_) => "api-key list",
-                    ApiKeyCommand::Create(_) => "api-key create",
-                    ApiKeyCommand::Expire(_) => "api-key expire",
-                },
-            },
+            LaunchMode::CommandLine { command, .. } => command.as_str_for_tracing(),
             LaunchMode::Test { .. } => "test",
             LaunchMode::RemoteServerDaemon { .. } => "remote_server_daemon",
             LaunchMode::RemoteServerProxy => "remote_server_proxy",

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -172,6 +172,18 @@ use terminal::local_shell::LocalShellState;
 pub use util::bindings::cmd_or_ctrl_shift;
 use voice::transcriber::VoiceTranscriber;
 use warp_cli::agent::AgentCommand;
+use warp_cli::api_key::ApiKeyCommand;
+use warp_cli::artifact::ArtifactCommand;
+use warp_cli::environment::EnvironmentCommand;
+use warp_cli::federate::FederateCommand;
+use warp_cli::harness_support::HarnessSupportCommand;
+use warp_cli::integration::IntegrationCommand;
+use warp_cli::mcp::MCPCommand;
+use warp_cli::model::ModelCommand;
+use warp_cli::provider::ProviderCommand;
+use warp_cli::schedule::ScheduleSubcommand;
+use warp_cli::secret::SecretCommand;
+use warp_cli::task::TaskCommand;
 use warp_cli::{CliCommand, GlobalOptions};
 #[cfg(feature = "local_fs")]
 use watcher::HomeDirectoryWatcher;
@@ -554,21 +566,80 @@ impl LaunchMode {
                     AgentCommand::Delete(_) => "agent delete",
                     AgentCommand::Skills(_) => "agent skills",
                 },
-                CliCommand::Environment(environment_command) => "environment",
-                CliCommand::MCP(mcpcommand) => "mcp",
-                CliCommand::Run(task_command) => "run",
-                CliCommand::Model(model_command) => "model",
+                CliCommand::Environment(environment_command) => match environment_command {
+                    EnvironmentCommand::List => "environment list",
+                    EnvironmentCommand::Image(_) => "environment image",
+                    EnvironmentCommand::Create { .. } => "environment create",
+                    EnvironmentCommand::Delete { .. } => "environment delete",
+                    EnvironmentCommand::Get { .. } => "environment get",
+                    EnvironmentCommand::Update { .. } => "environment update",
+                },
+                CliCommand::MCP(mcp_command) => match mcp_command {
+                    MCPCommand::List => "mcp list",
+                },
+                CliCommand::Run(task_command) => match task_command {
+                    TaskCommand::List(_) => "run list",
+                    TaskCommand::Get(_) => "run get",
+                    TaskCommand::Conversation(_) => "run conversation",
+                    TaskCommand::Message(_) => "run message",
+                },
+                CliCommand::Model(model_command) => match model_command {
+                    ModelCommand::List => "model list",
+                },
                 CliCommand::Login => "login",
                 CliCommand::Logout => "logout",
                 CliCommand::Whoami => "whoami",
-                CliCommand::Provider(provider_command) => "provider",
-                CliCommand::Integration(integration_command) => "integration",
-                CliCommand::Schedule(schedule_command) => "schedule",
-                CliCommand::Secret(secret_command) => "secret",
-                CliCommand::Federate(federate_command) => "federate",
-                CliCommand::HarnessSupport(harness_support_args) => "harness_support",
-                CliCommand::Artifact(artifact_command) => "artifact",
-                CliCommand::ApiKey(api_key_command) => "api_key",
+                CliCommand::Provider(provider_command) => match provider_command {
+                    ProviderCommand::Setup(_) => "provider setup",
+                    ProviderCommand::List => "provider list",
+                },
+                CliCommand::Integration(integration_command) => match integration_command {
+                    IntegrationCommand::Create(_) => "integration create",
+                    IntegrationCommand::Update(_) => "integration update",
+                    IntegrationCommand::List => "integration list",
+                },
+                CliCommand::Schedule(schedule_command) => match schedule_command.subcommand() {
+                    Some(ScheduleSubcommand::Create(_)) | None => "schedule create",
+                    Some(ScheduleSubcommand::List) => "schedule list",
+                    Some(ScheduleSubcommand::Get(_)) => "schedule get",
+                    Some(ScheduleSubcommand::Update(_)) => "schedule update",
+                    Some(ScheduleSubcommand::Pause(_)) => "schedule pause",
+                    Some(ScheduleSubcommand::Unpause(_)) => "schedule unpause",
+                    Some(ScheduleSubcommand::Delete(_)) => "schedule delete",
+                },
+                CliCommand::Secret(secret_command) => match secret_command {
+                    SecretCommand::Create(_) => "secret create",
+                    SecretCommand::Delete(_) => "secret delete",
+                    SecretCommand::Update(_) => "secret update",
+                    SecretCommand::List(_) => "secret list",
+                },
+                CliCommand::Federate(federate_command) => match federate_command {
+                    FederateCommand::IssueToken(_) => "federate issue-token",
+                    FederateCommand::IssueGcpToken(_) => "federate issue-gcp-token",
+                },
+                CliCommand::HarnessSupport(harness_support_args) => {
+                    match &harness_support_args.command {
+                        HarnessSupportCommand::Ping => "harness-support ping",
+                        HarnessSupportCommand::ReportArtifact(_) => {
+                            "harness-support report-artifact"
+                        }
+                        HarnessSupportCommand::NotifyUser(_) => "harness-support notify-user",
+                        HarnessSupportCommand::FinishTask(_) => "harness-support finish-task",
+                        HarnessSupportCommand::ReportShutdown(_) => {
+                            "harness-support report-shutdown"
+                        }
+                    }
+                }
+                CliCommand::Artifact(artifact_command) => match artifact_command {
+                    ArtifactCommand::Upload(_) => "artifact upload",
+                    ArtifactCommand::Get(_) => "artifact get",
+                    ArtifactCommand::Download(_) => "artifact download",
+                },
+                CliCommand::ApiKey(api_key_command) => match api_key_command {
+                    ApiKeyCommand::List(_) => "api-key list",
+                    ApiKeyCommand::Create(_) => "api-key create",
+                    ApiKeyCommand::Expire(_) => "api-key expire",
+                },
             },
             LaunchMode::Test { .. } => "test",
             LaunchMode::RemoteServerDaemon { .. } => "remote_server_daemon",

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -539,6 +539,43 @@ impl LaunchMode {
         }
     }
 
+    fn as_str_for_tracing(&self) -> &'static str {
+        match self {
+            LaunchMode::App { .. } => "app",
+            LaunchMode::CommandLine { command, .. } => match command {
+                CliCommand::Agent(agent_command) => match agent_command {
+                    AgentCommand::Run(_) => "agent run",
+                    AgentCommand::RunCloud(_) => "agent run-cloud",
+                    AgentCommand::Profile(_) => "agent profile",
+                    AgentCommand::List(_) => "agent list",
+                    AgentCommand::Get(_) => "agent get",
+                    AgentCommand::Create(_) => "agent create",
+                    AgentCommand::Update(_) => "agent update",
+                    AgentCommand::Delete(_) => "agent delete",
+                    AgentCommand::Skills(_) => "agent skills",
+                },
+                CliCommand::Environment(environment_command) => "environment",
+                CliCommand::MCP(mcpcommand) => "mcp",
+                CliCommand::Run(task_command) => "run",
+                CliCommand::Model(model_command) => "model",
+                CliCommand::Login => "login",
+                CliCommand::Logout => "logout",
+                CliCommand::Whoami => "whoami",
+                CliCommand::Provider(provider_command) => "provider",
+                CliCommand::Integration(integration_command) => "integration",
+                CliCommand::Schedule(schedule_command) => "schedule",
+                CliCommand::Secret(secret_command) => "secret",
+                CliCommand::Federate(federate_command) => "federate",
+                CliCommand::HarnessSupport(harness_support_args) => "harness_support",
+                CliCommand::Artifact(artifact_command) => "artifact",
+                CliCommand::ApiKey(api_key_command) => "api_key",
+            },
+            LaunchMode::Test { .. } => "test",
+            LaunchMode::RemoteServerDaemon { .. } => "remote_server_daemon",
+            LaunchMode::RemoteServerProxy => "remote_server_proxy",
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn new_for_unit_test() -> Self {
         LaunchMode::Test {
@@ -801,7 +838,11 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
 
     // Start the `run_internal` span here - we can't do it before this point
     // because we need the tracing initialization to be complete first.
-    let span = ::tracing::info_span!("run_internal", tags.cloud_agent = true);
+    let span = ::tracing::info_span!(
+        "run_internal",
+        tags.cloud_agent = true,
+        launch_mode = launch_mode.as_str_for_tracing()
+    );
     let _enter = span.enter();
 
     let log_destination = launch_mode.log_destination();

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -255,6 +255,22 @@ pub enum AgentCommand {
     Skills(ListAgentSkillsArgs),
 }
 
+impl AgentCommand {
+    pub(crate) fn as_str_for_tracing(&self) -> &'static str {
+        match self {
+            AgentCommand::Run(_) => "agent run",
+            AgentCommand::RunCloud(_) => "agent run-cloud",
+            AgentCommand::Profile(_) => "agent profile",
+            AgentCommand::List(_) => "agent list",
+            AgentCommand::Get(_) => "agent get",
+            AgentCommand::Create(_) => "agent create",
+            AgentCommand::Update(_) => "agent update",
+            AgentCommand::Delete(_) => "agent delete",
+            AgentCommand::Skills(_) => "agent skills",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Args)]
 #[command(
     visible_alias = "r",

--- a/crates/warp_cli/src/api_key.rs
+++ b/crates/warp_cli/src/api_key.rs
@@ -17,6 +17,16 @@ pub enum ApiKeyCommand {
     Expire(ExpireApiKeyArgs),
 }
 
+impl ApiKeyCommand {
+    pub(crate) fn as_str_for_tracing(&self) -> &'static str {
+        match self {
+            ApiKeyCommand::List(_) => "api-key list",
+            ApiKeyCommand::Create(_) => "api-key create",
+            ApiKeyCommand::Expire(_) => "api-key expire",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Args)]
 pub struct ListApiKeysArgs {
     /// Sort field.

--- a/crates/warp_cli/src/artifact.rs
+++ b/crates/warp_cli/src/artifact.rs
@@ -14,6 +14,16 @@ pub enum ArtifactCommand {
     Download(DownloadArtifactArgs),
 }
 
+impl ArtifactCommand {
+    pub(crate) fn as_str_for_tracing(&self) -> &'static str {
+        match self {
+            ArtifactCommand::Upload(_) => "artifact upload",
+            ArtifactCommand::Get(_) => "artifact get",
+            ArtifactCommand::Download(_) => "artifact download",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Args)]
 #[command(
     group(

--- a/crates/warp_cli/src/environment.rs
+++ b/crates/warp_cli/src/environment.rs
@@ -101,6 +101,19 @@ pub enum EnvironmentCommand {
     },
 }
 
+impl EnvironmentCommand {
+    pub(crate) fn as_str_for_tracing(&self) -> &'static str {
+        match self {
+            EnvironmentCommand::List => "environment list",
+            EnvironmentCommand::Image(_) => "environment image",
+            EnvironmentCommand::Create { .. } => "environment create",
+            EnvironmentCommand::Delete { .. } => "environment delete",
+            EnvironmentCommand::Get { .. } => "environment get",
+            EnvironmentCommand::Update { .. } => "environment update",
+        }
+    }
+}
+
 /// Common arguments for selecting an environment when creating an integration.
 #[derive(Args, Clone, Debug)]
 #[group(required = false, multiple = false)]

--- a/crates/warp_cli/src/federate.rs
+++ b/crates/warp_cli/src/federate.rs
@@ -15,6 +15,15 @@ pub enum FederateCommand {
     IssueGcpToken(IssueGcpTokenArgs),
 }
 
+impl FederateCommand {
+    pub(crate) fn as_str_for_tracing(&self) -> &'static str {
+        match self {
+            FederateCommand::IssueToken(_) => "federate issue-token",
+            FederateCommand::IssueGcpToken(_) => "federate issue-gcp-token",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Args)]
 #[command(name = "issue-token")]
 pub struct IssueTokenArgs {

--- a/crates/warp_cli/src/harness_support.rs
+++ b/crates/warp_cli/src/harness_support.rs
@@ -14,6 +14,18 @@ pub struct HarnessSupportArgs {
     pub command: HarnessSupportCommand,
 }
 
+impl HarnessSupportCommand {
+    pub(crate) fn as_str_for_tracing(&self) -> &'static str {
+        match self {
+            HarnessSupportCommand::Ping => "harness-support ping",
+            HarnessSupportCommand::ReportArtifact(_) => "harness-support report-artifact",
+            HarnessSupportCommand::NotifyUser(_) => "harness-support notify-user",
+            HarnessSupportCommand::FinishTask(_) => "harness-support finish-task",
+            HarnessSupportCommand::ReportShutdown(_) => "harness-support report-shutdown",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Subcommand)]
 pub enum HarnessSupportCommand {
     /// Verify connectivity by fetching and displaying the current run.

--- a/crates/warp_cli/src/integration.rs
+++ b/crates/warp_cli/src/integration.rs
@@ -18,6 +18,16 @@ pub enum IntegrationCommand {
     List,
 }
 
+impl IntegrationCommand {
+    pub(crate) fn as_str_for_tracing(&self) -> &'static str {
+        match self {
+            IntegrationCommand::Create(_) => "integration create",
+            IntegrationCommand::Update(_) => "integration update",
+            IntegrationCommand::List => "integration list",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Args)]
 pub struct CreateIntegrationArgs {
     /// Provider to create the integration for.

--- a/crates/warp_cli/src/lib.rs
+++ b/crates/warp_cli/src/lib.rs
@@ -554,6 +554,30 @@ pub enum CliCommand {
     ApiKey(crate::api_key::ApiKeyCommand),
 }
 
+impl CliCommand {
+    /// Returns the command path used to identify this invocation in tracing.
+    pub fn as_str_for_tracing(&self) -> &'static str {
+        match self {
+            CliCommand::Agent(command) => command.as_str_for_tracing(),
+            CliCommand::Environment(command) => command.as_str_for_tracing(),
+            CliCommand::MCP(command) => command.as_str_for_tracing(),
+            CliCommand::Run(command) => command.as_str_for_tracing(),
+            CliCommand::Model(command) => command.as_str_for_tracing(),
+            CliCommand::Login => "login",
+            CliCommand::Logout => "logout",
+            CliCommand::Whoami => "whoami",
+            CliCommand::Provider(command) => command.as_str_for_tracing(),
+            CliCommand::Integration(command) => command.as_str_for_tracing(),
+            CliCommand::Schedule(command) => command.as_str_for_tracing(),
+            CliCommand::Secret(command) => command.as_str_for_tracing(),
+            CliCommand::Federate(command) => command.as_str_for_tracing(),
+            CliCommand::HarnessSupport(args) => args.command.as_str_for_tracing(),
+            CliCommand::Artifact(command) => command.as_str_for_tracing(),
+            CliCommand::ApiKey(command) => command.as_str_for_tracing(),
+        }
+    }
+}
+
 /// A subcommand of the main Warp application. This includes all [`WorkerCommand`]s as well as app-specific debugging tools.
 #[derive(Debug, Clone, Subcommand)]
 pub enum Command {

--- a/crates/warp_cli/src/mcp.rs
+++ b/crates/warp_cli/src/mcp.rs
@@ -11,6 +11,14 @@ pub enum MCPCommand {
     List,
 }
 
+impl MCPCommand {
+    pub(crate) fn as_str_for_tracing(&self) -> &'static str {
+        match self {
+            MCPCommand::List => "mcp list",
+        }
+    }
+}
+
 /// Represents an MCP server specification from CLI input.
 ///
 /// This is a lightweight representation - full parsing happens in the app layer

--- a/crates/warp_cli/src/model.rs
+++ b/crates/warp_cli/src/model.rs
@@ -7,6 +7,14 @@ pub enum ModelCommand {
     List,
 }
 
+impl ModelCommand {
+    pub(crate) fn as_str_for_tracing(&self) -> &'static str {
+        match self {
+            ModelCommand::List => "model list",
+        }
+    }
+}
+
 /// Shared CLI args for selecting a base model.
 #[derive(Debug, Clone, Args, Default)]
 pub struct ModelArgs {

--- a/crates/warp_cli/src/provider.rs
+++ b/crates/warp_cli/src/provider.rs
@@ -7,6 +7,15 @@ pub enum ProviderCommand {
     List,
 }
 
+impl ProviderCommand {
+    pub(crate) fn as_str_for_tracing(&self) -> &'static str {
+        match self {
+            ProviderCommand::Setup(_) => "provider setup",
+            ProviderCommand::List => "provider list",
+        }
+    }
+}
+
 // If we want these at the top level, we can also set provider as a top level subcommand:
 #[derive(Debug, Clone, ValueEnum)]
 #[value(rename_all = "snake_case")]

--- a/crates/warp_cli/src/schedule.rs
+++ b/crates/warp_cli/src/schedule.rs
@@ -20,6 +20,17 @@ pub struct ScheduleCommand {
 }
 
 impl ScheduleCommand {
+    pub(crate) fn as_str_for_tracing(&self) -> &'static str {
+        match self.subcommand() {
+            Some(ScheduleSubcommand::Create(_)) | None => "schedule create",
+            Some(ScheduleSubcommand::List) => "schedule list",
+            Some(ScheduleSubcommand::Get(_)) => "schedule get",
+            Some(ScheduleSubcommand::Update(_)) => "schedule update",
+            Some(ScheduleSubcommand::Pause(_)) => "schedule pause",
+            Some(ScheduleSubcommand::Unpause(_)) => "schedule unpause",
+            Some(ScheduleSubcommand::Delete(_)) => "schedule delete",
+        }
+    }
     /// Get the specific scheduling subcommand. Returns `None` if using the `oz schedule` creation shorthand.
     pub fn subcommand(&self) -> Option<&ScheduleSubcommand> {
         self.subcommand.as_ref()

--- a/crates/warp_cli/src/secret.rs
+++ b/crates/warp_cli/src/secret.rs
@@ -24,6 +24,17 @@ pub enum SecretCommand {
     List(ListSecretsArgs),
 }
 
+impl SecretCommand {
+    pub(crate) fn as_str_for_tracing(&self) -> &'static str {
+        match self {
+            SecretCommand::Create(_) => "secret create",
+            SecretCommand::Delete(_) => "secret delete",
+            SecretCommand::Update(_) => "secret update",
+            SecretCommand::List(_) => "secret list",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Args)]
 #[command(args_conflicts_with_subcommands = true)]
 pub struct CreateSecretArgs {

--- a/crates/warp_cli/src/task.rs
+++ b/crates/warp_cli/src/task.rs
@@ -20,6 +20,17 @@ pub enum TaskCommand {
     Message(MessageCommand),
 }
 
+impl TaskCommand {
+    pub(crate) fn as_str_for_tracing(&self) -> &'static str {
+        match self {
+            TaskCommand::List(_) => "run list",
+            TaskCommand::Get(_) => "run get",
+            TaskCommand::Conversation(_) => "run conversation",
+            TaskCommand::Message(_) => "run message",
+        }
+    }
+}
+
 /// Conversation-related subcommands.
 #[derive(Debug, Clone, Subcommand)]
 pub enum ConversationCommand {


### PR DESCRIPTION
## Description
Adds a `launch_mode` field to the root `run_internal` span so startup traces can be filtered by how Warp was started, including the specific Oz CLI command.

Tracing labels are defined exhaustively beside each CLI command enum and delegated through `CliCommand`, keeping `LaunchMode` decoupled from nested command details.

## Testing
- `cargo fmt -p warp -p warp_cli`
- `cargo check -p warp`
- Not manually tested; this only changes tracing metadata.

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>