### PR TITLE
prevent trying to use 0-byte corrupted installer file in auto-update

### DIFF
--- a/app/src/autoupdate/windows.rs
+++ b/app/src/autoupdate/windows.rs
@@ -46,10 +46,7 @@ pub(super) async fn download_update_and_cleanup(
         .suffix(&format!("{}-{}", version_info.version, installer_file_name))
         .make(|path| {
             // Treat a 0-byte file as missing.
-            let non_empty = path
-                .metadata()
-                .map(|m| m.len() > 0)
-                .unwrap_or(false);
+            let non_empty = path.metadata().map(|m| m.len() > 0).unwrap_or(false);
             already_exists = non_empty;
             if already_exists {
                 File::open(path)

--- a/app/src/autoupdate/windows.rs
+++ b/app/src/autoupdate/windows.rs
@@ -45,7 +45,12 @@ pub(super) async fn download_update_and_cleanup(
         .rand_bytes(0)
         .suffix(&format!("{}-{}", version_info.version, installer_file_name))
         .make(|path| {
-            already_exists = path.is_file();
+            // Treat a 0-byte file as missing.
+            let non_empty = path
+                .metadata()
+                .map(|m| m.len() > 0)
+                .unwrap_or(false);
+            already_exists = non_empty;
             if already_exists {
                 File::open(path)
             } else {


### PR DESCRIPTION
## Description

Windows auto-update was failing on my machine. When I click "update and restart" button, Warp would exit and then... no installer would take over! I found this line in the Warp logs:

```
2026-06-18T22:30:59Z [ERROR] Error relaunching app after autoupdate: %1 is not a valid Win32 application. (os error 193)
```

I inspected the installer inside %TEMP% and the installer was 0 bytes long. Unfortunately, the file was corrupted (probably a network error) and Warp doesn't try re-downloading if the file exists.

This PR adds a simple validation to make sure the file isn't empty and try re-downloading if it is. There are definitely better validations to add here but this is a good stop-gap for now.