### PR TITLE
Hedge against stale cursors leading to grid panics.

### DIFF
--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -729,6 +729,8 @@ impl ansi::Handler for GridHandler {
     fn restore_cursor_position(&mut self) {
         log::trace!("Restoring cursor position");
 
+        // A saved cursor can outlive a geometry change, so validate it before restoring.
+        self.grid.clamp_cursors_to_visible_region();
         let saved_cursor = self.grid.saved_cursor.clone();
         self.update_cursor(|cursor| {
             *cursor = saved_cursor;

--- a/app/src/terminal/model/grid/grid_storage.rs
+++ b/app/src/terminal/model/grid/grid_storage.rs
@@ -500,9 +500,22 @@ impl GridStorage {
         self.cursor.point.col
     }
 
+    /// Clamps the active and saved cursors to the visible grid region.
+    pub(super) fn clamp_cursors_to_visible_region(&mut self) {
+        let last_row = VisibleRow(self.rows.saturating_sub(1));
+        let last_col = self.columns.saturating_sub(1);
+
+        self.cursor.point.row = min(self.cursor.point.row, last_row);
+        self.cursor.point.col = min(self.cursor.point.col, last_col);
+        self.saved_cursor.point.row = min(self.saved_cursor.point.row, last_row);
+        self.saved_cursor.point.col = min(self.saved_cursor.point.col, last_col);
+    }
+
     /// Truncate all rows after the cursor's row from the Grid.
     #[inline]
     pub(super) fn truncate_to_cursor_rows(&mut self) {
+        // Clamp before using the cursor to compute truncation boundaries.
+        self.clamp_cursors_to_visible_region();
         let cursor_absolute_row = self.rows_to_cursor();
 
         // We want to include the line _with_ the cursor, so add one here.
@@ -518,6 +531,8 @@ impl GridStorage {
         // by truncating the content after the cursor.
         let cursor_position_shift = cursor_absolute_row.saturating_sub(self.rows_to_cursor());
         self.cursor.point.row += cursor_position_shift;
+        // Clamp again in case truncation shrank the visible region.
+        self.clamp_cursors_to_visible_region();
 
         // Reset the max cursor to be the value of the cursor, since the the max cursor isn't
         // guaranteed to be in the grid anymore.

--- a/app/src/terminal/model/terminal_model_tests.rs
+++ b/app/src/terminal/model/terminal_model_tests.rs
@@ -1072,6 +1072,53 @@ fn sharer_rejects_dcs_hook_with_unregistered_session_id() {
         None
     );
 }
+#[test]
+fn out_of_order_precmd_pty_hook_cannot_restore_cursor_outside_finished_header_grid() {
+    let mut terminal = TerminalModel::mock(None, None);
+    terminal.start_command_execution();
+    let active_block_id = terminal.active_block_id().clone();
+
+    // Move to the second row, save the cursor, then move back to the first row.
+    terminal.process_bytes(&b"\x1b[2;1H\x1b7\x1b[1;1H"[..]);
+    let preexec = hex_encoded_json_dcs(
+        r#"{
+                "hook": "Preexec",
+                "value": {
+                    "command": "exit",
+                    "session_id": 123
+                }
+            }"#,
+    );
+    terminal.process_bytes(preexec.as_slice());
+    assert!(terminal.block_list().active_block().is_command_finished());
+
+    // A registered, out-of-order precmd hook is accepted for the same active block and parses its
+    // PS1 into the already-finished header grid.
+    let precmd = hex_encoded_json_dcs(
+        r#"{
+                "hook": "Precmd",
+                "value": {
+                    "ps1": "\u001b8",
+                    "ps1_is_encoded": false,
+                    "honor_ps1": true,
+                    "session_id": 123
+                }
+            }"#,
+    );
+    terminal.process_bytes(precmd.as_slice());
+    assert_eq!(terminal.active_block_id(), &active_block_id);
+    assert!(terminal.block_list().active_block().is_command_finished());
+
+    terminal.exit(ExitReason::ShellProcessExited);
+
+    let grid = terminal
+        .block_list()
+        .active_block()
+        .prompt_and_command_grid()
+        .grid_handler();
+    assert!(grid.grid_storage().cursor().point.row.0 < grid.visible_rows());
+    assert!(grid.grid_storage().saved_cursor.point.row.0 < grid.visible_rows());
+}
 
 #[test]
 fn test_synchronized_output_sharing_session() {


### PR DESCRIPTION
## Description

Paired terminal panics in `WARP-CLIENT-BETA-STABLE-4SZZ` and `WARP-CLIENT-BETA-STABLE-4FQW` showed that a saved cursor can outlive grid truncation and point outside the visible region. Restoring that cursor, or later finishing the affected grid, can then index invalid storage and panic.

Keep both the active and saved cursors within the visible grid before and after truncation, and validate the saved cursor before restoring it. The regression test reproduces the production path by feeding an out-of-order `Precmd` hook and PS1 cursor sequences through `TerminalModel`.

This is intentionally a narrow defensive invariant fix; additional lifecycle-hook and PTY teardown hardening is out of scope for this PR.

## Testing

- `cargo nextest run --manifest-path /Users/david/src/warp/Cargo.toml -p warp -E 'test(out_of_order_precmd_pty_hook_cannot_restore_cursor_outside_finished_header_grid) | test(test_truncate_cursor_middle_no_scrollback) | test(test_truncate_cursor_middle_partial_scrollback) | test(test_truncate_cursor_middle_scrollback) | test(test_truncate_cursor_bottom_no_scrollback)'` — 5 passed
- `cargo fmt --manifest-path /Users/david/src/warp/Cargo.toml --all -- --check`
- `cargo check --manifest-path /Users/david/src/warp/Cargo.toml -p warp --lib`
- `git diff --check`

Manual testing was not performed because the failure requires a precisely out-of-order shell-hook sequence and stale saved cursor; the model-layer regression drives that sequence entirely through parsed PTY bytes.

CHANGELOG-BUG-FIX: Prevented terminal grid panics caused by stale saved cursor positions.