### PR TITLE
Gate long-context warning to non-custom endpoints

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -908,12 +908,16 @@ impl AgentInputFooter {
             None
         };
 
-        let (effective_model_provider, effective_model_threshold) = {
-            let active_base_model =
-                LLMPreferences::as_ref(ctx).get_active_base_model(ctx, Some(terminal_view_id));
+        let (effective_model_provider, effective_model_threshold, is_custom_endpoint) = {
+            let preferences = LLMPreferences::as_ref(ctx);
+            let active_base_model = preferences.get_active_base_model(ctx, Some(terminal_view_id));
+            let is_custom_endpoint = preferences
+                .custom_llm_info_for_id(&active_base_model.id)
+                .is_some();
             (
                 active_base_model.provider.clone(),
                 active_base_model.context_window.long_context_threshold,
+                is_custom_endpoint,
             )
         };
         let total_input_tokens = BlocklistAIHistoryModel::as_ref(ctx)
@@ -941,6 +945,7 @@ impl AgentInputFooter {
             long_context_warning_state: LongContextWarningState::new(
                 effective_model_provider,
                 effective_model_threshold,
+                is_custom_endpoint,
                 total_input_tokens,
             ),
             model_selector: profile_model_selector_full,
@@ -1118,9 +1123,13 @@ impl AgentInputFooter {
         app: &AppContext,
     ) {
         let active_base_model = preferences.get_active_base_model(app, Some(self.terminal_view_id));
+        let is_custom_endpoint = preferences
+            .custom_llm_info_for_id(&active_base_model.id)
+            .is_some();
         self.long_context_warning_state.update_effective_model(
             active_base_model.provider.clone(),
             active_base_model.context_window.long_context_threshold,
+            is_custom_endpoint,
         );
     }
 

--- a/app/src/ai/blocklist/usage/mod.rs
+++ b/app/src/ai/blocklist/usage/mod.rs
@@ -13,6 +13,10 @@ pub(crate) struct LongContextWarningState {
     /// The active model's long-context pricing threshold, in input tokens.
     /// `None` when the model has no long-context pricing tier.
     effective_model_threshold: Option<u32>,
+    /// Whether the active model is a user-configured custom endpoint. The
+    /// warning communicates Warp-priced OpenAI long-context tiers, which don't
+    /// apply to custom endpoints, so it is never surfaced for them.
+    is_custom_endpoint: bool,
     /// Input tokens of the latest primary-agent LLM call in the latest
     /// successfully persisted request, as reported by the server.
     total_input_tokens: u32,
@@ -22,11 +26,13 @@ impl LongContextWarningState {
     pub fn new(
         effective_model_provider: LLMProvider,
         effective_model_threshold: Option<u32>,
+        is_custom_endpoint: bool,
         total_input_tokens: u32,
     ) -> Self {
         Self {
             effective_model_provider,
             effective_model_threshold,
+            is_custom_endpoint,
             total_input_tokens,
         }
     }
@@ -39,18 +45,22 @@ impl LongContextWarningState {
         &mut self,
         effective_model_provider: LLMProvider,
         effective_model_threshold: Option<u32>,
+        is_custom_endpoint: bool,
     ) {
         self.effective_model_provider = effective_model_provider;
         self.effective_model_threshold = effective_model_threshold;
+        self.is_custom_endpoint = is_custom_endpoint;
     }
 
     /// Visible when the latest reported input tokens exceed the active model's
     /// long-context pricing threshold (strictly greater, matching the server's
     /// pricing predicate). The warning communicates OpenAI's long-context
     /// pricing tiers, so it is only surfaced for OpenAI models — even though
-    /// other providers (e.g. Gemini) also expose a threshold.
+    /// other providers (e.g. Gemini) also expose a threshold — and never for
+    /// custom endpoints, whose pricing Warp does not control.
     pub fn is_visible(&self) -> bool {
-        self.effective_model_provider == LLMProvider::OpenAI
+        !self.is_custom_endpoint
+            && self.effective_model_provider == LLMProvider::OpenAI
             && self
                 .effective_model_threshold
                 .is_some_and(|threshold| self.total_input_tokens > threshold)

--- a/app/src/ai/blocklist/usage/mod_tests.rs
+++ b/app/src/ai/blocklist/usage/mod_tests.rs
@@ -7,23 +7,25 @@ const THRESHOLD: u32 = 272_000;
 
 #[test]
 fn visible_only_strictly_above_threshold() {
-    let below = LongContextWarningState::new(LLMProvider::OpenAI, Some(THRESHOLD), THRESHOLD - 1);
+    let below =
+        LongContextWarningState::new(LLMProvider::OpenAI, Some(THRESHOLD), false, THRESHOLD - 1);
     assert!(!below.is_visible());
 
     let at_threshold =
-        LongContextWarningState::new(LLMProvider::OpenAI, Some(THRESHOLD), THRESHOLD);
+        LongContextWarningState::new(LLMProvider::OpenAI, Some(THRESHOLD), false, THRESHOLD);
     assert!(
         !at_threshold.is_visible(),
         "exactly at the threshold must not warn; the server prices long context strictly above it"
     );
 
-    let above = LongContextWarningState::new(LLMProvider::OpenAI, Some(THRESHOLD), THRESHOLD + 1);
+    let above =
+        LongContextWarningState::new(LLMProvider::OpenAI, Some(THRESHOLD), false, THRESHOLD + 1);
     assert!(above.is_visible());
 }
 
 #[test]
 fn sync_from_server_updates_visibility() {
-    let mut state = LongContextWarningState::new(LLMProvider::OpenAI, Some(THRESHOLD), 0);
+    let mut state = LongContextWarningState::new(LLMProvider::OpenAI, Some(THRESHOLD), false, 0);
     assert!(!state.is_visible());
 
     // A qualifying request shows the warning.
@@ -39,7 +41,7 @@ fn sync_from_server_updates_visibility() {
 fn hidden_without_threshold() {
     // Models without a long-context pricing tier (including Auto models, whose
     // underlying model varies) never warn, regardless of context size.
-    let state = LongContextWarningState::new(LLMProvider::OpenAI, None, 1_000_000);
+    let state = LongContextWarningState::new(LLMProvider::OpenAI, None, false, 1_000_000);
     assert!(!state.is_visible());
 }
 
@@ -47,36 +49,51 @@ fn hidden_without_threshold() {
 fn hidden_for_non_openai_provider_even_above_threshold() {
     // Gemini exposes a 200K threshold, but the warning communicates OpenAI's
     // long-context pricing tiers and must not surface for other providers.
-    let google = LongContextWarningState::new(LLMProvider::Google, Some(200_000), 250_000);
+    let google = LongContextWarningState::new(LLMProvider::Google, Some(200_000), false, 250_000);
     assert!(!google.is_visible());
 
-    let anthropic = LongContextWarningState::new(LLMProvider::Anthropic, Some(200_000), 250_000);
+    let anthropic =
+        LongContextWarningState::new(LLMProvider::Anthropic, Some(200_000), false, 250_000);
     assert!(!anthropic.is_visible());
+}
+
+#[test]
+fn hidden_for_custom_endpoint_even_above_threshold() {
+    // Custom endpoints are priced outside Warp's OpenAI long-context tiers, so
+    // the warning must never surface for them — even if the synthetic model
+    // somehow reports the OpenAI provider and a threshold.
+    let state = LongContextWarningState::new(LLMProvider::OpenAI, Some(THRESHOLD), true, 1_000_000);
+    assert!(!state.is_visible());
 }
 
 #[test]
 fn model_switch_recomputes_against_new_threshold() {
     // 250K tokens is below GPT-5.4's 272K threshold...
-    let mut state = LongContextWarningState::new(LLMProvider::OpenAI, Some(272_000), 250_000);
+    let mut state =
+        LongContextWarningState::new(LLMProvider::OpenAI, Some(272_000), false, 250_000);
     assert!(!state.is_visible());
 
     // ...but above a hypothetical lower-threshold OpenAI model.
-    state.update_effective_model(LLMProvider::OpenAI, Some(200_000));
+    state.update_effective_model(LLMProvider::OpenAI, Some(200_000), false);
     assert!(state.is_visible());
 
     // Switching to a higher-threshold model hides it again from the same tokens.
-    state.update_effective_model(LLMProvider::OpenAI, Some(400_000));
+    state.update_effective_model(LLMProvider::OpenAI, Some(400_000), false);
     assert!(!state.is_visible());
 
     // Switching to a non-OpenAI model hides it even when its threshold is exceeded.
-    state.update_effective_model(LLMProvider::Google, Some(200_000));
+    state.update_effective_model(LLMProvider::Google, Some(200_000), false);
+    assert!(!state.is_visible());
+
+    // Switching to a custom endpoint hides it even when above its threshold.
+    state.update_effective_model(LLMProvider::OpenAI, Some(200_000), true);
     assert!(!state.is_visible());
 }
 
 #[test]
 fn zero_tokens_never_warn() {
     // Legacy conversations and old servers report 0; the warning stays hidden.
-    let state = LongContextWarningState::new(LLMProvider::OpenAI, Some(THRESHOLD), 0);
+    let state = LongContextWarningState::new(LLMProvider::OpenAI, Some(THRESHOLD), false, 0);
     assert!(!state.is_visible());
 }
 


### PR DESCRIPTION
## Description
Adds an explicit guard so the OpenAI long-context pricing warning is only eligible to show for **non-custom endpoints**.

**What**: `LongContextWarningState` now carries an `is_custom_endpoint` flag; `is_visible()` short-circuits to `false` for custom endpoints, in addition to the existing OpenAI-provider + strictly-above-threshold checks.

**Why**: The warning communicates Warp-priced OpenAI long-context tiers, which don't apply to user-configured custom endpoints. Custom-endpoint synthetic models already use `provider: Unknown` + `None` threshold (so they were implicitly excluded), but this makes the exclusion explicit and robust against future changes.

**How**: The flag is derived at the footer construction and effective-model sync sites via `LLMPreferences::custom_llm_info_for_id`, then threaded into `LongContextWarningState::{new, update_effective_model}`.

## Testing
- [x] Unit tests in `app/src/ai/blocklist/usage/mod_tests.rs` updated for the new param; added `hidden_for_custom_endpoint_even_above_threshold` and a custom-endpoint case in `model_switch_recomputes_against_new_threshold`.
- Ran `cargo nextest run -p warp -E 'test(/blocklist::usage::/)'` (20 passed), `./script/format`, and `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` (clean).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

Co-Authored-By: Oz <oz-agent@warp.dev>
