### PR TITLE
Show Maximize/Minimize pane shortcut in pane menu

### DIFF
--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -466,7 +466,7 @@ pub fn init(app: &mut AppContext) {
         .with_enabled(|| ContextFlag::CreateNewSession.is_enabled()),
         EditableBinding::new(
             "pane_group:toggle_maximize_pane",
-            "Maximize / minimize active pane",
+            "Toggle Maximize / Minimize Active Pane",
             PaneGroupAction::ToggleMaximizePane,
         )
         .with_context_predicate(id!("PaneGroup") & !id!("PaneGroup_PaneDragging"))

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -466,7 +466,7 @@ pub fn init(app: &mut AppContext) {
         .with_enabled(|| ContextFlag::CreateNewSession.is_enabled()),
         EditableBinding::new(
             "pane_group:toggle_maximize_pane",
-            "Toggle Maximize Active Pane",
+            "Maximize / minimize active pane",
             PaneGroupAction::ToggleMaximizePane,
         )
         .with_context_predicate(id!("PaneGroup") & !id!("PaneGroup_PaneDragging"))

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -198,6 +198,10 @@ pub use working_directories::{WorkingDirectoriesEvent, WorkingDirectoriesModel};
 use self::pane::{DetachType, PaneViewEvent};
 pub use crate::code_review::CodeReviewPanelArg;
 
+/// Binding name for the action that toggles maximizing the active pane. Shared so
+/// the pane header menu item can surface the same shortcut the binding resolves to.
+pub const TOGGLE_MAXIMIZE_PANE_BINDING_NAME: &str = "pane_group:toggle_maximize_pane";
+
 lazy_static! {
     // The value to use as the initial window bounds if we are unable to
     // determine them for any reason.
@@ -465,8 +469,8 @@ pub fn init(app: &mut AppContext) {
         .with_custom_action(CustomAction::SplitPaneRight)
         .with_enabled(|| ContextFlag::CreateNewSession.is_enabled()),
         EditableBinding::new(
-            "pane_group:toggle_maximize_pane",
-            "Toggle Maximize / Minimize Active Pane",
+            TOGGLE_MAXIMIZE_PANE_BINDING_NAME,
+            "Toggle Maximize Active Pane",
             PaneGroupAction::ToggleMaximizePane,
         )
         .with_context_predicate(id!("PaneGroup") & !id!("PaneGroup_PaneDragging"))

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -51,6 +51,7 @@ use crate::ui_components::agent_icon::terminal_view_agent_icon_variant;
 use crate::ui_components::buttons::icon_button_with_color;
 use crate::ui_components::icon_with_status::render_icon_with_status;
 use crate::ui_components::{blended_colors, icons};
+use crate::util::bindings::keybinding_name_to_display_string;
 use crate::workspace::tab_settings::TabSettings;
 
 /// Total size of the agent icon-with-status component rendered in the pane header.
@@ -699,6 +700,10 @@ impl BackingView for TerminalView {
             items.push(
                 MenuItemFields::toggle_pane_action(is_maximized)
                     .with_on_select_action(TerminalAction::ToggleMaximizePane)
+                    .with_key_shortcut_label(keybinding_name_to_display_string(
+                        "pane_group:toggle_maximize_pane",
+                        ctx,
+                    ))
                     .into_item(),
             );
         }

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -38,7 +38,7 @@ use crate::pane_group::pane::view::header::components::{
 use crate::pane_group::pane::view::header::{render_pane_header_draggable, PANE_HEADER_HEIGHT};
 use crate::pane_group::pane::view::PaneHeaderAction;
 use crate::pane_group::pane::{view, PaneStack};
-use crate::pane_group::{BackingView, SplitPaneState};
+use crate::pane_group::{BackingView, SplitPaneState, TOGGLE_MAXIMIZE_PANE_BINDING_NAME};
 use crate::settings::app_installation_detection::{
     UserAppInstallDetectionSettings, UserAppInstallStatus,
 };
@@ -701,7 +701,7 @@ impl BackingView for TerminalView {
                 MenuItemFields::toggle_pane_action(is_maximized)
                     .with_on_select_action(TerminalAction::ToggleMaximizePane)
                     .with_key_shortcut_label(keybinding_name_to_display_string(
-                        "pane_group:toggle_maximize_pane",
+                        TOGGLE_MAXIMIZE_PANE_BINDING_NAME,
                         ctx,
                     ))
                     .into_item(),

--- a/app/src/util/bindings_tests.rs
+++ b/app/src/util/bindings_tests.rs
@@ -113,8 +113,7 @@ fn test_toggle_maximize_pane_binding_is_editable() {
             // It ships with a mac-only default shortcut (cmd-shift-enter) via its custom
             // action; other platforms have no default until the user assigns one. Either
             // way, whatever resolves here is what the pane header menu item surfaces.
-            let default =
-                keybinding_name_to_display_string(TOGGLE_MAXIMIZE_PANE_BINDING_NAME, ctx);
+            let default = keybinding_name_to_display_string(TOGGLE_MAXIMIZE_PANE_BINDING_NAME, ctx);
             if OperatingSystem::get().is_mac() {
                 assert_eq!(Some("⇧⌘⏎"), default.as_deref());
             } else {

--- a/app/src/util/bindings_tests.rs
+++ b/app/src/util/bindings_tests.rs
@@ -100,19 +100,21 @@ fn test_toggle_maximize_pane_binding_is_editable() {
         app.update(crate::pane_group::init);
 
         app.update(|ctx| {
-            // The maximize / minimize pane action is registered as an editable binding so
+            use crate::pane_group::TOGGLE_MAXIMIZE_PANE_BINDING_NAME;
+
+            // The toggle-maximize-pane action is registered as an editable binding so
             // it can be assigned a shortcut in Settings → Keyboard shortcuts.
             assert!(
                 ctx.editable_bindings()
-                    .any(|binding| binding.name == "pane_group:toggle_maximize_pane"),
-                "pane_group:toggle_maximize_pane should be registered as an editable binding"
+                    .any(|binding| binding.name == TOGGLE_MAXIMIZE_PANE_BINDING_NAME),
+                "{TOGGLE_MAXIMIZE_PANE_BINDING_NAME} should be registered as an editable binding"
             );
 
             // It ships with a mac-only default shortcut (cmd-shift-enter) via its custom
             // action; other platforms have no default until the user assigns one. Either
             // way, whatever resolves here is what the pane header menu item surfaces.
             let default =
-                keybinding_name_to_display_string("pane_group:toggle_maximize_pane", ctx);
+                keybinding_name_to_display_string(TOGGLE_MAXIMIZE_PANE_BINDING_NAME, ctx);
             if OperatingSystem::get().is_mac() {
                 assert_eq!(Some("⇧⌘⏎"), default.as_deref());
             } else {
@@ -121,7 +123,7 @@ fn test_toggle_maximize_pane_binding_is_editable() {
 
             // A reassigned shortcut resolves to its display string on every platform.
             ctx.set_custom_trigger(
-                "pane_group:toggle_maximize_pane".to_owned(),
+                TOGGLE_MAXIMIZE_PANE_BINDING_NAME.to_owned(),
                 Trigger::Keystrokes(vec![Keystroke::parse("cmd-shift-M").unwrap()]),
             );
 
@@ -132,7 +134,7 @@ fn test_toggle_maximize_pane_binding_is_editable() {
             };
             assert_eq!(
                 Some(displayed_keybinding),
-                keybinding_name_to_display_string("pane_group:toggle_maximize_pane", ctx)
+                keybinding_name_to_display_string(TOGGLE_MAXIMIZE_PANE_BINDING_NAME, ctx)
                     .as_deref()
             );
         });

--- a/app/src/util/bindings_tests.rs
+++ b/app/src/util/bindings_tests.rs
@@ -95,6 +95,48 @@ fn test_orchestration_cycle_bindings_are_editable() {
 }
 
 #[test]
+fn test_toggle_maximize_pane_binding_is_editable() {
+    App::test((), |mut app| async move {
+        app.update(crate::pane_group::init);
+
+        app.update(|ctx| {
+            // The maximize / minimize pane action is registered as an editable binding so
+            // it can be assigned a shortcut in Settings → Keyboard shortcuts.
+            assert!(
+                ctx.editable_bindings()
+                    .any(|binding| binding.name == "pane_group:toggle_maximize_pane"),
+                "pane_group:toggle_maximize_pane should be registered as an editable binding"
+            );
+
+            // It ships without a default keystroke, so nothing is shown next to the menu
+            // item until the user assigns one.
+            assert_eq!(
+                None,
+                keybinding_name_to_display_string("pane_group:toggle_maximize_pane", ctx)
+            );
+
+            // Once a shortcut is assigned, it resolves to a display string that the pane
+            // header menu item surfaces.
+            ctx.set_custom_trigger(
+                "pane_group:toggle_maximize_pane".to_owned(),
+                Trigger::Keystrokes(vec![Keystroke::parse("cmd-shift-m").unwrap()]),
+            );
+
+            let displayed_keybinding = if OperatingSystem::get().is_mac() {
+                "⇧⌘M"
+            } else {
+                "Shift Logo M"
+            };
+            assert_eq!(
+                Some(displayed_keybinding),
+                keybinding_name_to_display_string("pane_group:toggle_maximize_pane", ctx)
+                    .as_deref()
+            );
+        });
+    });
+}
+
+#[test]
 fn test_terminal_page_scroll_bindings_are_editable() {
     App::test((), |mut app| async move {
         app.update(terminal::init);

--- a/app/src/util/bindings_tests.rs
+++ b/app/src/util/bindings_tests.rs
@@ -108,18 +108,21 @@ fn test_toggle_maximize_pane_binding_is_editable() {
                 "pane_group:toggle_maximize_pane should be registered as an editable binding"
             );
 
-            // It ships without a default keystroke, so nothing is shown next to the menu
-            // item until the user assigns one.
-            assert_eq!(
-                None,
-                keybinding_name_to_display_string("pane_group:toggle_maximize_pane", ctx)
-            );
+            // It ships with a mac-only default shortcut (cmd-shift-enter) via its custom
+            // action; other platforms have no default until the user assigns one. Either
+            // way, whatever resolves here is what the pane header menu item surfaces.
+            let default =
+                keybinding_name_to_display_string("pane_group:toggle_maximize_pane", ctx);
+            if OperatingSystem::get().is_mac() {
+                assert_eq!(Some("⇧⌘⏎"), default.as_deref());
+            } else {
+                assert_eq!(None, default);
+            }
 
-            // Once a shortcut is assigned, it resolves to a display string that the pane
-            // header menu item surfaces.
+            // A reassigned shortcut resolves to its display string on every platform.
             ctx.set_custom_trigger(
                 "pane_group:toggle_maximize_pane".to_owned(),
-                Trigger::Keystrokes(vec![Keystroke::parse("cmd-shift-m").unwrap()]),
+                Trigger::Keystrokes(vec![Keystroke::parse("cmd-shift-M").unwrap()]),
             );
 
             let displayed_keybinding = if OperatingSystem::get().is_mac() {


### PR DESCRIPTION
## Description

The **Maximize pane** / **Minimize pane** action is a single toggle (`pane_group:toggle_maximize_pane`) that is already keyboard-bindable in **Settings → Keyboard shortcuts** and ships with a mac-only default of `cmd-shift-enter` (`⇧⌘↩`), wired via `CustomAction::ToggleMaximizePane`. That shortcut is already shown next to the item in several menus — the terminal context menu (`terminal/view.rs`), the env-vars pane menu (`env_vars/view/menus.rs`), and the notebook context menu.

The **pane-header overflow (three-dot) menu**, however, rendered the "Maximize pane" / "Minimize pane" item with **no shortcut hint** — the lone inconsistent menu. This PR closes that gap.

| File | Change |
|---|---|
| `app/src/terminal/view/pane_impl.rs` | Surface the shortcut next to the overflow-menu item via `keybinding_name_to_display_string(TOGGLE_MAXIMIZE_PANE_BINDING_NAME, ctx)`, matching the existing pattern in `terminal/view.rs`. |
| `app/src/pane_group/mod.rs` | Extract the binding name `"pane_group:toggle_maximize_pane"` into a shared `pub const TOGGLE_MAXIMIZE_PANE_BINDING_NAME`, referenced by both the binding registration and the pane-header menu item so the name lives in one place. |
| `app/src/util/bindings_tests.rs` | Add `test_toggle_maximize_pane_binding_is_editable`: asserts the binding is registered as editable, surfaces its mac default (`⇧⌘↩`) / no default on other platforms, and resolves a reassigned keystroke to its display string. |

No behavior change to the toggle itself — this only surfaces the existing action's shortcut in the menu shown in the screenshots.

## Linked Issue

Closes #12814.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. (Awaiting a maintainer to apply the readiness label.)

## Testing

- Added `test_toggle_maximize_pane_binding_is_editable` in `bindings_tests.rs`, following the existing `test_orchestration_cycle_bindings_are_editable` / `test_terminal_page_scroll_bindings_are_editable` patterns.
- Built and ran locally on macOS (aarch64): `cargo check -p warp` succeeds, and `cargo test -p warp --lib test_toggle_maximize_pane_binding_is_editable` passes.

### Screenshots / Videos

Captured on the local `warp-oss` debug build (macOS). The shortcut shown is the mac default `⇧⌘↩` (`cmd-shift-enter`).

**1. Pane-header overflow menu — "Maximize pane" now shows the shortcut** (the gap this PR fixes):
<img width="216" height="148" alt="Screenshot 2026-06-19 at 2 33 28 PM" src="https://github.com/user-attachments/assets/bf4186d7-5c8c-4fba-8abc-0175dfd4d41a" />

**2. The same item reads "Minimize pane" with the shortcut once the pane is maximized:**

<img width="229" height="168" alt="Screenshot 2026-06-19 at 2 34 41 PM" src="https://github.com/user-attachments/assets/9c84040c-0dd7-41a7-b1d0-700edf8e8a1f" />

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: The Maximize / Minimize pane action now shows its keyboard shortcut in the pane-header overflow menu.
-->
CHANGELOG-IMPROVEMENT: The Maximize / Minimize pane action now shows its keyboard shortcut in the pane-header overflow menu.

https://claude.ai/code/session_01Nu4FCRTUdycRci42gDGkh2
