### PR TITLE
Statically compile the CLI and warpctl binaries on Linux.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,3 +16,9 @@ git-fetch-with-cli = true
 
 [target.'cfg(target_family = "wasm")']
 rustflags = ["--cfg=web_sys_unstable_apis"]
+
+[target.x86_64-unknown-linux-musl]
+linker = "musl-gcc"
+
+[target.aarch64-unknown-linux-musl]
+linker = "musl-gcc"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,8 +18,6 @@ git-fetch-with-cli = true
 [target.'cfg(all())']
 rustflags = ["-C", "symbol-mangling-version=v0"]
 
-# `-headerpad_max_install_names` is an Apple ld64 linker flag, so it is only
-# applicable on macOS.
 [target.'cfg(target_os = "macos")']
 rustflags = ["-C", "link-args=-Wl,-headerpad_max_install_names"]
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,11 +8,20 @@
 # `script/bundle`.
 MACOSX_DEPLOYMENT_TARGET = "10.14"
 
-[build]
-rustflags = ["-C", "symbol-mangling-version=v0", "-C", "link-args=-Wl,-headerpad_max_install_names"]
-
 [net]
 git-fetch-with-cli = true
+
+# Use the v0 symbol mangling scheme on every target. It encodes generic
+# instantiations (which the legacy scheme hashes away irreversibly), improving
+# demangled names in backtraces and Sentry symbolication. On wasm the shipped
+# bundle strips symbol names, so this only enriches the split-off debug artifact.
+[target.'cfg(all())']
+rustflags = ["-C", "symbol-mangling-version=v0"]
+
+# `-headerpad_max_install_names` is an Apple ld64 linker flag, so it is only
+# applicable on macOS.
+[target.'cfg(target_os = "macos")']
+rustflags = ["-C", "link-args=-Wl,-headerpad_max_install_names"]
 
 [target.'cfg(target_family = "wasm")']
 rustflags = ["--cfg=web_sys_unstable_apis"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -23,9 +23,3 @@ rustflags = ["-C", "link-args=-Wl,-headerpad_max_install_names"]
 
 [target.'cfg(target_family = "wasm")']
 rustflags = ["--cfg=web_sys_unstable_apis"]
-
-[target.x86_64-unknown-linux-musl]
-linker = "musl-gcc"
-
-[target.aarch64-unknown-linux-musl]
-linker = "musl-gcc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,19 +501,10 @@ jobs:
         shell: bash
         run: |
           sudo apt-get install -y curl sshpass xz-utils
-          MUSL_CROSS_TAG="20250929"
           MUSL_CROSS_TARGET="x86_64-unknown-linux-musl"
-          MUSL_CROSS_SHA256="6534870abd7dc327fd2e14cc53972d0552b21f47db5769505534f788537e3544"
-          MUSL_CROSS_ARCHIVE="$MUSL_CROSS_TARGET.tar.xz"
-          curl -fsSLO "https://github.com/cross-tools/musl-cross/releases/download/$MUSL_CROSS_TAG/$MUSL_CROSS_ARCHIVE"
-          echo "$MUSL_CROSS_SHA256  $MUSL_CROSS_ARCHIVE" | sha256sum -c -
-          sudo mkdir -p /opt/x-tools
-          sudo tar -xf "$MUSL_CROSS_ARCHIVE" -C /opt/x-tools
-          MUSL_CROSS_BIN="/opt/x-tools/$MUSL_CROSS_TARGET/bin"
+          source script/linux/configure_musl_toolchain "$MUSL_CROSS_TARGET"
+          MUSL_CROSS_BIN="$(dirname "$WARP_MUSL_CC")"
           echo "$MUSL_CROSS_BIN" >> "$GITHUB_PATH"
-          export PATH="$MUSL_CROSS_BIN:$PATH"
-          command -v "$MUSL_CROSS_TARGET-gcc"
-          command -v "$MUSL_CROSS_TARGET-g++"
           rustup target add x86_64-unknown-linux-musl
 
       - name: Deploy remote server binary to test VM

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -707,9 +707,9 @@ jobs:
           config_file: ${{ env.CONFIG_FILE }}
           channel: ${{ inputs.channel }}
 
-      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        with:
-          credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+      # - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+      #   with:
+      #     credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
 
       - name: Load PGP signing key and passphrase
         run: |
@@ -975,9 +975,9 @@ jobs:
           config_file: ${{ env.CONFIG_FILE }}
           channel: ${{ inputs.channel }}
 
-      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        with:
-          credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+      # - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+      #   with:
+      #     credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
 
       # Namespace's User Bundled Cache persists target/ between jobs on the same profile, which can
       # leave stale packages from a previous channel's build in the linux bundle output dir.

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -748,7 +748,10 @@ jobs:
       # Namespace's User Bundled Cache persists target/ between jobs on the same profile, which can
       # leave stale packages from a previous channel's build in the linux bundle output dir.
       - name: Clean stale bundle output
-        run: rm -rf target/*/bundle/linux
+        run: |
+          if [[ -d target ]]; then
+            find target -path '*/bundle/linux' -type d -prune -exec rm -rf {} +
+          fi
         shell: bash
 
       - name: Bundle CLI

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -707,9 +707,9 @@ jobs:
           config_file: ${{ env.CONFIG_FILE }}
           channel: ${{ inputs.channel }}
 
-      # - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-      #   with:
-      #     credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
 
       - name: Load PGP signing key and passphrase
         run: |
@@ -975,9 +975,9 @@ jobs:
           config_file: ${{ env.CONFIG_FILE }}
           channel: ${{ inputs.channel }}
 
-      # - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-      #   with:
-      #     credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
 
       # Namespace's User Bundled Cache persists target/ between jobs on the same profile, which can
       # leave stale packages from a previous channel's build in the linux bundle output dir.

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -671,7 +671,7 @@ jobs:
 
   release_linux_cli_x86:
     name: Build Release (Linux CLI x86_64)
-    runs-on: namespace-profile-ubuntu-20-04
+    runs-on: namespace-profile-ubuntu-22-04
     needs: prepare_release
     if: ${{ inputs.build_linux != false }}
     timeout-minutes: 90

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -594,7 +594,10 @@ jobs:
       # Namespace's User Bundled Cache persists target/ between jobs on the same profile, which can
       # leave stale packages from a previous channel's build in the linux bundle output dir.
       - name: Clean stale bundle output
-        run: rm -rf target/*/bundle/linux
+        run: |
+          if [[ -d target ]]; then
+            find target -path '*/bundle/linux' -type d -prune -exec rm -rf {} +
+          fi
         shell: bash
 
       - name: Bundle app

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -943,7 +943,7 @@ jobs:
 
   build_linux_cli_arm_binaries:
     name: Build Release (Linux CLI ARM)
-    runs-on: namespace-profile-ubuntu-20-04-arm
+    runs-on: namespace-profile-ubuntu-22-04
     needs: prepare_release
     if: ${{ inputs.build_linux != false }}
     timeout-minutes: 90
@@ -989,7 +989,7 @@ jobs:
         id: build_cli
         run: |
           # Build the CLI only
-          script/bundle --channel $CHANNEL --artifact cli --packages none
+          script/bundle --channel $CHANNEL --artifact cli --packages none --arch aarch64
         shell: bash
         env:
           CHANNEL: ${{ steps.get-config.outputs.channel }}

--- a/script/deploy_remote_server
+++ b/script/deploy_remote_server
@@ -77,12 +77,8 @@ case "$PROFILE_MODE" in
     ;;
 esac
 
-# Check for musl-cross linker
-if ! command -v x86_64-linux-musl-gcc &>/dev/null; then
-  echo "Error: x86_64-linux-musl-gcc not found." >&2
-  echo "Install it with: brew install filosottile/musl-cross/musl-cross" >&2
-  exit 1
-fi
+TARGET="x86_64-unknown-linux-musl"
+source "$SCRIPT_DIR/linux/configure_musl_toolchain" "$TARGET"
 
 # Check for musl target
 if ! rustup target list --installed 2>/dev/null | grep -q x86_64-unknown-linux-musl; then
@@ -91,9 +87,7 @@ if ! rustup target list --installed 2>/dev/null | grep -q x86_64-unknown-linux-m
   exit 1
 fi
 
-# Determine build parameters
-TARGET="x86_64-unknown-linux-musl"
-
+# Select the requested Cargo build profile.
 case "$PROFILE_MODE" in
   dev-remote)
     CARGO_PROFILE="dev-remote"
@@ -135,9 +129,7 @@ echo "    Binary: $WARP_BIN -> $BINARY_NAME"
 echo "    Features: $FEATURES"
 echo ""
 
-# Build with linker and rustflags overrides to avoid macOS-specific flags
-# from .cargo/config.toml
-CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-gcc \
+# Override the target rustflags to avoid macOS-specific flags from .cargo/config.toml.
 CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-C symbol-mangling-version=v0" \
   cargo build \
     -p warp \

--- a/script/deploy_remote_server
+++ b/script/deploy_remote_server
@@ -129,9 +129,7 @@ echo "    Binary: $WARP_BIN -> $BINARY_NAME"
 echo "    Features: $FEATURES"
 echo ""
 
-# Override the target rustflags to avoid macOS-specific flags from .cargo/config.toml.
-CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-C symbol-mangling-version=v0" \
-  cargo build \
+cargo build \
     -p warp \
     --bin "$WARP_BIN" \
     --target "$TARGET" \

--- a/script/deploy_remote_server_to_test_vm
+++ b/script/deploy_remote_server_to_test_vm
@@ -10,8 +10,7 @@
 # Integration channel's `check_binary` looks.
 #
 # Prerequisites (same as script/deploy_remote_server):
-#   Linux: install an x86_64 musl cross toolchain that includes gcc and g++
-#          (CI uses cross-tools/musl-cross) and sudo apt-get install sshpass
+#   On Linux, install curl, sha256sum, tar, and sshpass.
 #   rustup target add x86_64-unknown-linux-musl
 #   gcloud CLI authenticated for the warp-ssh-integration-testing project
 #
@@ -47,59 +46,6 @@ REMOTE_HOST="ssh-remote-server-testing"
 REMOTE_PORT="22"
 PROXY_COMMAND="gcloud compute start-iap-tunnel ssh-remote-server-testing ${REMOTE_PORT} --listen-on-stdin --project=warp-ssh-integration-testing --zone=us-east4-b"
 
-# ── Helpers ───────────────────────────────────────────────────────
-
-install_musl_help() {
-  case "$(uname -s)" in
-    Linux)
-      echo "Install a musl cross toolchain that includes gcc and g++." >&2
-      ;;
-    *)
-      echo "Install an x86_64 musl C compiler for $TARGET." >&2
-      ;;
-  esac
-}
-
-detect_musl_linker() {
-  if command -v x86_64-linux-musl-gcc &>/dev/null; then
-    echo "x86_64-linux-musl-gcc"
-    return
-  fi
-  if command -v x86_64-unknown-linux-musl-gcc &>/dev/null; then
-    echo "x86_64-unknown-linux-musl-gcc"
-    return
-  fi
-
-  if command -v musl-gcc &>/dev/null; then
-    echo "musl-gcc"
-    return
-  fi
-
-  echo "Error: no musl linker found." >&2
-  install_musl_help
-  exit 1
-}
-detect_musl_cxx() {
-  local linker_cxx="${MUSL_LINKER%gcc}g++"
-  if [[ "$linker_cxx" != "$MUSL_LINKER" ]] && command -v "$linker_cxx" &>/dev/null; then
-    echo "$linker_cxx"
-    return
-  fi
-
-  if command -v x86_64-linux-musl-g++ &>/dev/null; then
-    echo "x86_64-linux-musl-g++"
-    return
-  fi
-
-  if command -v x86_64-unknown-linux-musl-g++ &>/dev/null; then
-    echo "x86_64-unknown-linux-musl-g++"
-    return
-  fi
-
-  echo "Error: no musl C++ compiler found." >&2
-  install_musl_help
-  exit 1
-}
 
 app_version() {
   if [[ -n "${GIT_RELEASE_TAG:-}" ]]; then
@@ -112,9 +58,7 @@ app_version() {
 }
 
 # ── Preflight checks ──────────────────────────────────────────────
-
-MUSL_LINKER="$(detect_musl_linker)"
-MUSL_CXX="$(detect_musl_cxx)"
+source "$SCRIPT_DIR/linux/configure_musl_toolchain" "$TARGET"
 
 if ! rustup target list --installed 2>/dev/null | grep -q "$TARGET"; then
   echo "Error: $TARGET target not installed." >&2
@@ -136,10 +80,7 @@ LOCAL_BUNDLE_TARBALL="$OUTPUT_DIR/remote-server-integration-bundle.tar.gz"
 
 echo "==> Building Integration-channel Oz CLI for $TARGET (profile=$CARGO_PROFILE)"
 
-CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="$MUSL_LINKER" \
 CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-C symbol-mangling-version=v0" \
-CC_x86_64_unknown_linux_musl="$MUSL_LINKER" \
-CXX_x86_64_unknown_linux_musl="$MUSL_CXX" \
   cargo build \
     -p warp \
     --bin "$WARP_BIN" \

--- a/script/deploy_remote_server_to_test_vm
+++ b/script/deploy_remote_server_to_test_vm
@@ -80,8 +80,7 @@ LOCAL_BUNDLE_TARBALL="$OUTPUT_DIR/remote-server-integration-bundle.tar.gz"
 
 echo "==> Building Integration-channel Oz CLI for $TARGET (profile=$CARGO_PROFILE)"
 
-CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-C symbol-mangling-version=v0" \
-  cargo build \
+cargo build \
     -p warp \
     --bin "$WARP_BIN" \
     --target "$TARGET" \

--- a/script/linux/bundle
+++ b/script/linux/bundle
@@ -123,10 +123,14 @@ eval set -- "$PARAMS"
 # Statically compile the CLI and warpctrl artifacts so they can run on older Linux distros.
 if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
   TARGET_TRIPLE="${BUILD_ARCH}-unknown-linux-musl"
+  source "$WORKSPACE_ROOT_DIR/script/linux/configure_musl_toolchain" "$TARGET_TRIPLE"
+  # Make sure we have the rust musl target available.
+  rustup target add "$TARGET_TRIPLE"
 fi
-CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$WORKSPACE_ROOT_DIR/target${TARGET_TRIPLE:+/$TARGET_TRIPLE}}"
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$WORKSPACE_ROOT_DIR/target}"
+CARGO_TARGET_OUTPUT_ROOT="$CARGO_TARGET_DIR${TARGET_TRIPLE:+/$TARGET_TRIPLE}"
 
-DIST_DIR="$CARGO_TARGET_DIR/dist"
+DIST_DIR="$CARGO_TARGET_OUTPUT_ROOT/dist"
 
 if [[ $DEBUG = true ]]; then
   CARGO_PROFILE="dev"
@@ -148,9 +152,9 @@ else
 fi
 
 if [[ "$CARGO_PROFILE" == "dev" ]]; then
-  CARGO_TARGET_OUTPUT_DIR="$CARGO_TARGET_DIR/debug"
+  CARGO_TARGET_OUTPUT_DIR="$CARGO_TARGET_OUTPUT_ROOT/debug"
 else
-  CARGO_TARGET_OUTPUT_DIR="$CARGO_TARGET_DIR/$CARGO_PROFILE"
+  CARGO_TARGET_OUTPUT_DIR="$CARGO_TARGET_OUTPUT_ROOT/$CARGO_PROFILE"
 fi
 # NOTE: if you change this path, update the "Clean stale bundle output"
 # steps in .github/workflows/create_release.yml so they continue to wipe
@@ -239,14 +243,17 @@ export APPIMAGE_NAME="$APP_NAME-$BUILD_ARCH.AppImage"
 # then exit.  We use this script to invoke `cargo check` to ensure that we are
 # using the same feature flags and profile that we would be using in production.
 if [[ "$CHECK_ONLY" == "true" ]]; then
-  cargo check -p warp --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --features "$FEATURES"
+  cargo check -p warp --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --features "$FEATURES" ${TARGET_TRIPLE:+--target $TARGET_TRIPLE}
   exit 0
 fi
 
 # Build the binary.
 if [[ "$BUILD" == "true" ]]; then
   echo "Building and bundling Warp for channel $RELEASE_CHANNEL and bundle id $BUNDLE_ID"
-  cargo build -p warp --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --features "$FEATURES"
+  cargo build -p warp --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --features "$FEATURES" ${TARGET_TRIPLE:+--target $TARGET_TRIPLE}
+
+  exit 0
+
   echo "Making debug copy of '$EXECUTABLE_PATH' at '$DEBUG_EXECUTABLE_PATH'"
   cp "$EXECUTABLE_PATH" "$DEBUG_EXECUTABLE_PATH"
 

--- a/script/linux/bundle
+++ b/script/linux/bundle
@@ -5,8 +5,6 @@
 set -e
 
 WORKSPACE_ROOT_DIR="$(pwd)"
-CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$WORKSPACE_ROOT_DIR/target}"
-DIST_DIR="$CARGO_TARGET_DIR/dist"
 
 cleanup() {
   # Delete the directory that was used as a staging area during the bundling
@@ -121,6 +119,14 @@ while (( "$#" )); do
 done
 # set positional arguments in their proper place
 eval set -- "$PARAMS"
+
+# Statically compile the CLI and warpctrl artifacts so they can run on older Linux distros.
+if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
+  TARGET_TRIPLE="${BUILD_ARCH}-unknown-linux-musl"
+fi
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$WORKSPACE_ROOT_DIR/target${TARGET_TRIPLE:+/$TARGET_TRIPLE}}"
+
+DIST_DIR="$CARGO_TARGET_DIR/dist"
 
 if [[ $DEBUG = true ]]; then
   CARGO_PROFILE="dev"

--- a/script/linux/bundle
+++ b/script/linux/bundle
@@ -252,8 +252,6 @@ if [[ "$BUILD" == "true" ]]; then
   echo "Building and bundling Warp for channel $RELEASE_CHANNEL and bundle id $BUNDLE_ID"
   cargo build -p warp --profile "$CARGO_PROFILE" --bin "$WARP_BIN" --features "$FEATURES" ${TARGET_TRIPLE:+--target $TARGET_TRIPLE}
 
-  exit 0
-
   echo "Making debug copy of '$EXECUTABLE_PATH' at '$DEBUG_EXECUTABLE_PATH'"
   cp "$EXECUTABLE_PATH" "$DEBUG_EXECUTABLE_PATH"
 
@@ -261,11 +259,11 @@ if [[ "$BUILD" == "true" ]]; then
   if [[ $RELEASE_CHANNEL = "dev" ]]; then
     # For dev builds, only strip debug symbols, as we want to keep some
     # symbols for profiling purposes.
-    strip --strip-debug "$EXECUTABLE_PATH"
+    "${WARP_MUSL_STRIP:-strip}" --strip-debug "$EXECUTABLE_PATH"
   else
     # For production builds, strip all symbols, to keep the binary size
     # smaller.
-    strip --strip-all "$EXECUTABLE_PATH"
+    "${WARP_MUSL_STRIP:-strip}" --strip-all "$EXECUTABLE_PATH"
   fi
 else
   echo 'Skipping `cargo build` step due to --skip-build argument'

--- a/script/linux/bundle
+++ b/script/linux/bundle
@@ -123,9 +123,15 @@ eval set -- "$PARAMS"
 # Statically compile the CLI and warpctrl artifacts so they can run on older Linux distros.
 if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
   TARGET_TRIPLE="${BUILD_ARCH}-unknown-linux-musl"
-  source "$WORKSPACE_ROOT_DIR/script/linux/configure_musl_toolchain" "$TARGET_TRIPLE"
-  # Make sure we have the rust musl target available.
-  rustup target add "$TARGET_TRIPLE"
+  # Only configure the musl toolchain when we are actually compiling.  Packaging-only
+  # runs (--skip-build) just need TARGET_TRIPLE to locate the prebuilt binary, and
+  # configuring the toolchain there would force an unnecessary (and potentially
+  # failing) musl-cross download on hosts that never compile.
+  if [[ "$BUILD" == "true" ]]; then
+    source "$WORKSPACE_ROOT_DIR/script/linux/configure_musl_toolchain" "$TARGET_TRIPLE"
+    # Make sure we have the rust musl target available.
+    rustup target add "$TARGET_TRIPLE"
+  fi
 fi
 CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$WORKSPACE_ROOT_DIR/target}"
 CARGO_TARGET_OUTPUT_ROOT="$CARGO_TARGET_DIR${TARGET_TRIPLE:+/$TARGET_TRIPLE}"

--- a/script/linux/configure_musl_toolchain
+++ b/script/linux/configure_musl_toolchain
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# This script configures a complete musl C and C++ toolchain for a Rust target.
+# Source this script so it can update the caller's environment.
+
+configure_musl_toolchain() {
+  local target="${1:-$(uname -m)-unknown-linux-musl}"
+  local musl_cross_tag="20250929"
+  local musl_cross_sha256
+
+  case "$target" in
+    aarch64-unknown-linux-musl)
+      musl_cross_sha256="28a1d26f14f8ddc3aed31f20705fe696777400eb5952d90470a7e6e2dd1175bb"
+      ;;
+    x86_64-unknown-linux-musl)
+      musl_cross_sha256="6534870abd7dc327fd2e14cc53972d0552b21f47db5769505534f788537e3544"
+      ;;
+    *)
+      echo "Error: unsupported musl target '$target'." >&2
+      return 1
+      ;;
+  esac
+
+  local compiler_prefix
+  local musl_cc=""
+  local musl_cxx=""
+  for compiler_prefix in "$target" "${target/unknown-/}"; do
+    if command -v "$compiler_prefix-gcc" &>/dev/null \
+      && command -v "$compiler_prefix-g++" &>/dev/null; then
+      musl_cc="$(command -v "$compiler_prefix-gcc")"
+      musl_cxx="$(command -v "$compiler_prefix-g++")"
+      break
+    fi
+  done
+
+  if [[ -z "$musl_cc" && "$target" == "$(uname -m)-unknown-linux-musl" ]] \
+    && command -v musl-gcc &>/dev/null \
+    && command -v musl-g++ &>/dev/null; then
+    musl_cc="$(command -v musl-gcc)"
+    musl_cxx="$(command -v musl-g++)"
+  fi
+
+  local musl_cross_root="${WARP_MUSL_CROSS_ROOT:-/tmp/warp-musl-cross}"
+  local install_root="$musl_cross_root/$musl_cross_tag"
+  local toolchain_dir="$install_root/$target"
+  local toolchain_bin="$toolchain_dir/bin"
+
+  if [[ -z "$musl_cc" && -x "$toolchain_bin/$target-gcc" && -x "$toolchain_bin/$target-g++" ]]; then
+    case ":$PATH:" in
+      *":$toolchain_bin:"*) ;;
+      *) export PATH="$toolchain_bin:$PATH" ;;
+    esac
+    musl_cc="$(command -v "$target-gcc")"
+    musl_cxx="$(command -v "$target-g++")"
+  fi
+
+  if [[ -z "$musl_cc" ]]; then
+    if [[ "$(uname -s)" != "Linux" ]]; then
+      echo "Error: no complete C and C++ toolchain for '$target' was found on PATH." >&2
+      echo "Automatic musl-cross installation is only supported on Linux." >&2
+      return 1
+    fi
+
+    local required_command
+    for required_command in curl sha256sum tar; do
+      if ! command -v "$required_command" &>/dev/null; then
+        echo "Error: '$required_command' is required to install the musl toolchain." >&2
+        return 1
+      fi
+    done
+
+    local archive_name="$target.tar.xz"
+    local archive_url="https://github.com/cross-tools/musl-cross/releases/download/$musl_cross_tag/$archive_name"
+    if ! (
+      download_dir=""
+      cleanup_download() {
+        if [[ -n "$download_dir" && -d "$download_dir" ]]; then
+          chmod -R u+w "$download_dir" 2>/dev/null || true
+          rm -rf "$download_dir"
+        fi
+      }
+      trap cleanup_download EXIT
+
+      mkdir -p "$musl_cross_root" || exit 1
+      download_dir="$(mktemp -d "$musl_cross_root/.download-$target.XXXXXX")" || exit 1
+
+      echo "Downloading the $target C and C++ toolchain to $toolchain_dir"
+      curl -fsSL --retry 3 "$archive_url" -o "$download_dir/$archive_name" || exit 1
+      printf '%s  %s\n' "$musl_cross_sha256" "$download_dir/$archive_name" | sha256sum -c - || exit 1
+      tar -xf "$download_dir/$archive_name" -C "$download_dir" || exit 1
+      if [[ ! -x "$download_dir/$target/bin/$target-gcc" \
+        || ! -x "$download_dir/$target/bin/$target-g++" ]]; then
+        echo "Error: the downloaded archive does not contain the expected C and C++ compilers." >&2
+        exit 1
+      fi
+
+      chmod u+w "$download_dir/$target" || exit 1
+      mkdir -p "$install_root" || exit 1
+      if [[ -x "$toolchain_bin/$target-gcc" && -x "$toolchain_bin/$target-g++" ]]; then
+        exit 0
+      fi
+      if [[ -e "$toolchain_dir" ]]; then
+        chmod -R u+w "$toolchain_dir" || exit 1
+        rm -rf "$toolchain_dir" || exit 1
+      fi
+      mv "$download_dir/$target" "$toolchain_dir" || exit 1
+    ); then
+      return 1
+    fi
+
+    case ":$PATH:" in
+      *":$toolchain_bin:"*) ;;
+      *) export PATH="$toolchain_bin:$PATH" ;;
+    esac
+    musl_cc="$(command -v "$target-gcc")"
+    musl_cxx="$(command -v "$target-g++")"
+  fi
+
+  local target_env="${target//-/_}"
+  local cargo_target_env
+  cargo_target_env="$(printf '%s' "$target" | tr '[:lower:]-' '[:upper:]_')"
+
+  export "CC_$target_env=$musl_cc"
+  export "CXX_$target_env=$musl_cxx"
+  export "CARGO_TARGET_${cargo_target_env}_LINKER=$musl_cc"
+  export WARP_MUSL_TARGET="$target"
+  export WARP_MUSL_CC="$musl_cc"
+  export WARP_MUSL_CXX="$musl_cxx"
+
+  echo "Configured the $target toolchain with $musl_cc and $musl_cxx"
+}
+
+if [[ -n "${BASH_VERSION:-}" && "${BASH_SOURCE[0]}" == "$0" ]]; then
+  echo "Error: source this script so it can configure the caller's environment." >&2
+  exit 1
+fi
+if [[ -n "${ZSH_VERSION:-}" && "${ZSH_EVAL_CONTEXT:-}" != *:file ]]; then
+  echo "Error: source this script so it can configure the caller's environment." >&2
+  exit 1
+fi
+
+configure_musl_toolchain "$@"

--- a/script/linux/configure_musl_toolchain
+++ b/script/linux/configure_musl_toolchain
@@ -45,22 +45,87 @@ configure_musl_toolchain() {
     musl_strip="$(command -v strip)"
   fi
 
-  local musl_cross_root="${WARP_MUSL_CROSS_ROOT:-/tmp/warp-musl-cross}"
+  local default_musl_cross_root
+  if [[ -z "${WARP_MUSL_CROSS_ROOT:-}" && "${GITHUB_ACTIONS:-}" == "true" && -n "${RUNNER_TEMP:-}" ]]; then
+    default_musl_cross_root="$RUNNER_TEMP/warp-musl-cross"
+  elif [[ -n "${HOME:-}" ]]; then
+    default_musl_cross_root="${XDG_CACHE_HOME:-$HOME/.cache}/warp-musl-cross"
+  else
+    default_musl_cross_root="${TMPDIR:-/tmp}/warp-musl-cross-${UID:-$(id -u)}"
+  fi
+
+  local musl_cross_root="${WARP_MUSL_CROSS_ROOT:-$default_musl_cross_root}"
   local install_root="$musl_cross_root/$musl_cross_tag"
   local toolchain_dir="$install_root/$target"
   local toolchain_bin="$toolchain_dir/bin"
+  local verified_marker="$toolchain_dir/.warp-musl-cross-verified"
+  local verified_marker_contents="$musl_cross_tag $target $musl_cross_sha256"
 
-  if [[ -z "$musl_cc" \
-    && -x "$toolchain_bin/$target-gcc" \
-    && -x "$toolchain_bin/$target-g++" \
-    && -x "$toolchain_bin/$target-strip" ]]; then
-    case ":$PATH:" in
-      *":$toolchain_bin:"*) ;;
-      *) export PATH="$toolchain_bin:$PATH" ;;
-    esac
-    musl_cc="$(command -v "$target-gcc")"
-    musl_cxx="$(command -v "$target-g++")"
-    musl_strip="$(command -v "$target-strip")"
+  ensure_private_cache_dir() {
+    local dir="$1"
+
+    if [[ -L "$dir" ]]; then
+      echo "Error: musl toolchain cache directory '$dir' must not be a symlink." >&2
+      return 1
+    fi
+    if [[ -e "$dir" && ! -d "$dir" ]]; then
+      echo "Error: musl toolchain cache path '$dir' exists but is not a directory." >&2
+      return 1
+    fi
+
+    mkdir -p "$dir" || return 1
+    chmod 700 "$dir" || return 1
+    if [[ ! -O "$dir" ]]; then
+      echo "Error: musl toolchain cache directory '$dir' must be owned by the current user." >&2
+      return 1
+    fi
+
+    local mode
+    if mode="$(stat -c '%a' "$dir" 2>/dev/null)"; then
+      :
+    elif mode="$(stat -f '%Lp' "$dir" 2>/dev/null)"; then
+      :
+    else
+      echo "Error: could not determine permissions for musl toolchain cache directory '$dir'." >&2
+      return 1
+    fi
+    if (( (8#$mode & 0022) != 0 )); then
+      echo "Error: musl toolchain cache directory '$dir' must not be writable by group or others." >&2
+      return 1
+    fi
+  }
+
+  cached_toolchain_is_verified() {
+    [[ -r "$verified_marker" ]] && [[ "$(cat "$verified_marker")" == "$verified_marker_contents" ]]
+  }
+
+  if [[ -z "$musl_cc" ]]; then
+    ensure_private_cache_dir "$musl_cross_root" || return 1
+    ensure_private_cache_dir "$install_root" || return 1
+  fi
+
+  if [[ -z "$musl_cc" && -L "$toolchain_dir" ]]; then
+    echo "Error: cached musl toolchain path '$toolchain_dir' must not be a symlink." >&2
+    return 1
+  fi
+
+  if [[ -z "$musl_cc" ]]; then
+    if [[ -d "$toolchain_dir" ]] && ! cached_toolchain_is_verified; then
+      echo "Ignoring unverified cached musl toolchain at '$toolchain_dir'." >&2
+    fi
+
+    if cached_toolchain_is_verified \
+      && [[ -x "$toolchain_bin/$target-gcc" ]] \
+      && [[ -x "$toolchain_bin/$target-g++" ]] \
+      && [[ -x "$toolchain_bin/$target-strip" ]]; then
+      case ":$PATH:" in
+        *":$toolchain_bin:"*) ;;
+        *) export PATH="$toolchain_bin:$PATH" ;;
+      esac
+      musl_cc="$(command -v "$target-gcc")"
+      musl_cxx="$(command -v "$target-g++")"
+      musl_strip="$(command -v "$target-strip")"
+    fi
   fi
 
   if [[ -z "$musl_cc" ]]; then
@@ -94,7 +159,8 @@ configure_musl_toolchain() {
       }
       trap cleanup_download EXIT
 
-      mkdir -p "$musl_cross_root" || exit 1
+      ensure_private_cache_dir "$musl_cross_root" || exit 1
+      ensure_private_cache_dir "$install_root" || exit 1
       download_dir="$(mktemp -d "$musl_cross_root/.download-$target.XXXXXX")" || exit 1
 
       echo "Downloading the $target C and C++ toolchain to $toolchain_dir"
@@ -108,11 +174,13 @@ configure_musl_toolchain() {
         exit 1
       fi
 
-      chmod u+w "$download_dir/$target" || exit 1
-      mkdir -p "$install_root" || exit 1
+      chmod -R u+w,go-w "$download_dir/$target" || exit 1
+      printf '%s\n' "$verified_marker_contents" > "$download_dir/$target/.warp-musl-cross-verified" || exit 1
       if [[ -x "$toolchain_bin/$target-gcc" \
         && -x "$toolchain_bin/$target-g++" \
-        && -x "$toolchain_bin/$target-strip" ]]; then
+        && -x "$toolchain_bin/$target-strip" \
+        && -r "$verified_marker" \
+        && "$(cat "$verified_marker")" == "$verified_marker_contents" ]]; then
         exit 0
       fi
       if [[ -e "$toolchain_dir" ]]; then

--- a/script/linux/configure_musl_toolchain
+++ b/script/linux/configure_musl_toolchain
@@ -24,20 +24,25 @@ configure_musl_toolchain() {
   local compiler_prefix
   local musl_cc=""
   local musl_cxx=""
+  local musl_strip=""
   for compiler_prefix in "$target" "${target/unknown-/}"; do
     if command -v "$compiler_prefix-gcc" &>/dev/null \
-      && command -v "$compiler_prefix-g++" &>/dev/null; then
+      && command -v "$compiler_prefix-g++" &>/dev/null \
+      && command -v "$compiler_prefix-strip" &>/dev/null; then
       musl_cc="$(command -v "$compiler_prefix-gcc")"
       musl_cxx="$(command -v "$compiler_prefix-g++")"
+      musl_strip="$(command -v "$compiler_prefix-strip")"
       break
     fi
   done
 
   if [[ -z "$musl_cc" && "$target" == "$(uname -m)-unknown-linux-musl" ]] \
     && command -v musl-gcc &>/dev/null \
-    && command -v musl-g++ &>/dev/null; then
+    && command -v musl-g++ &>/dev/null \
+    && command -v strip &>/dev/null; then
     musl_cc="$(command -v musl-gcc)"
     musl_cxx="$(command -v musl-g++)"
+    musl_strip="$(command -v strip)"
   fi
 
   local musl_cross_root="${WARP_MUSL_CROSS_ROOT:-/tmp/warp-musl-cross}"
@@ -45,19 +50,27 @@ configure_musl_toolchain() {
   local toolchain_dir="$install_root/$target"
   local toolchain_bin="$toolchain_dir/bin"
 
-  if [[ -z "$musl_cc" && -x "$toolchain_bin/$target-gcc" && -x "$toolchain_bin/$target-g++" ]]; then
+  if [[ -z "$musl_cc" \
+    && -x "$toolchain_bin/$target-gcc" \
+    && -x "$toolchain_bin/$target-g++" \
+    && -x "$toolchain_bin/$target-strip" ]]; then
     case ":$PATH:" in
       *":$toolchain_bin:"*) ;;
       *) export PATH="$toolchain_bin:$PATH" ;;
     esac
     musl_cc="$(command -v "$target-gcc")"
     musl_cxx="$(command -v "$target-g++")"
+    musl_strip="$(command -v "$target-strip")"
   fi
 
   if [[ -z "$musl_cc" ]]; then
     if [[ "$(uname -s)" != "Linux" ]]; then
       echo "Error: no complete C and C++ toolchain for '$target' was found on PATH." >&2
       echo "Automatic musl-cross installation is only supported on Linux." >&2
+      return 1
+    fi
+    if [[ "$(uname -m)" != "x86_64" ]]; then
+      echo "Error: automatic musl-cross installation is only supported on x86_64 hosts." >&2
       return 1
     fi
 
@@ -89,14 +102,17 @@ configure_musl_toolchain() {
       printf '%s  %s\n' "$musl_cross_sha256" "$download_dir/$archive_name" | sha256sum -c - || exit 1
       tar -xf "$download_dir/$archive_name" -C "$download_dir" || exit 1
       if [[ ! -x "$download_dir/$target/bin/$target-gcc" \
-        || ! -x "$download_dir/$target/bin/$target-g++" ]]; then
-        echo "Error: the downloaded archive does not contain the expected C and C++ compilers." >&2
+        || ! -x "$download_dir/$target/bin/$target-g++" \
+        || ! -x "$download_dir/$target/bin/$target-strip" ]]; then
+        echo "Error: the downloaded archive does not contain the expected C, C++, and strip tools." >&2
         exit 1
       fi
 
       chmod u+w "$download_dir/$target" || exit 1
       mkdir -p "$install_root" || exit 1
-      if [[ -x "$toolchain_bin/$target-gcc" && -x "$toolchain_bin/$target-g++" ]]; then
+      if [[ -x "$toolchain_bin/$target-gcc" \
+        && -x "$toolchain_bin/$target-g++" \
+        && -x "$toolchain_bin/$target-strip" ]]; then
         exit 0
       fi
       if [[ -e "$toolchain_dir" ]]; then
@@ -114,7 +130,16 @@ configure_musl_toolchain() {
     esac
     musl_cc="$(command -v "$target-gcc")"
     musl_cxx="$(command -v "$target-g++")"
+    musl_strip="$(command -v "$target-strip")"
   fi
+
+  local tool
+  for tool in "$musl_cc" "$musl_cxx" "$musl_strip"; do
+    if ! "$tool" --version &>/dev/null; then
+      echo "Error: musl tool '$tool' cannot execute on this host." >&2
+      return 1
+    fi
+  done
 
   local target_env="${target//-/_}"
   local cargo_target_env
@@ -126,8 +151,9 @@ configure_musl_toolchain() {
   export WARP_MUSL_TARGET="$target"
   export WARP_MUSL_CC="$musl_cc"
   export WARP_MUSL_CXX="$musl_cxx"
+  export WARP_MUSL_STRIP="$musl_strip"
 
-  echo "Configured the $target toolchain with $musl_cc and $musl_cxx"
+  echo "Configured the $target toolchain with $musl_cc, $musl_cxx, and $musl_strip"
 }
 
 if [[ -n "${BASH_VERSION:-}" && "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/script/linux/install_build_deps
+++ b/script/linux/install_build_deps
@@ -41,6 +41,8 @@ if [[ "$(source /etc/os-release; echo $ID $ID_LIKE)" = *"debian"* ]]; then
     libclang-dev
     # Required by script/presubmit's clang-format check on C/C++/Obj-C sources.
     clang-format
+    # Required to build statically-linked binaries for Linux.
+    musl-tools
   )
   warp_sudo apt-get install -y "${PACKAGES[@]}"
 

--- a/script/linux/test_bundle_warpctrl
+++ b/script/linux/test_bundle_warpctrl
@@ -11,6 +11,20 @@ cat > "$temp_dir/bin/cargo" <<'EOF'
 printf '%s\n' "$@" > "$CARGO_ARGS_FILE"
 EOF
 chmod +x "$temp_dir/bin/cargo"
+cat > "$temp_dir/bin/rustup" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$temp_dir/bin/rustup"
+
+target="$(uname -m)-unknown-linux-musl"
+for compiler in "$target-gcc" "$target-g++"; do
+  cat > "$temp_dir/bin/$compiler" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$temp_dir/bin/$compiler"
+done
 
 PATH="$temp_dir/bin:$PATH" \
   CARGO_ARGS_FILE="$temp_dir/cargo-args" \
@@ -21,9 +35,9 @@ PATH="$temp_dir/bin:$PATH" \
   --features smoke_feature
 
 grep -qx -- '--features' "$temp_dir/cargo-args"
-grep -qx -- 'release_bundle,crash_reporting,agent_mode_debug,jemalloc_pprof,standalone,warp_control_cli,smoke_feature' "$temp_dir/cargo-args"
+grep -qx -- 'release_bundle,crash_reporting,agent_mode_debug,jemalloc_pprof,heap_usage_tracking,standalone,warp_control_cli,smoke_feature' "$temp_dir/cargo-args"
 
-profile_dir="$temp_dir/target/release-cli-debug_assertions"
+profile_dir="$temp_dir/target/$target/release-cli-debug_assertions"
 mkdir -p "$profile_dir"
 cat > "$profile_dir/dev" <<'EOF'
 #!/usr/bin/env bash
@@ -31,7 +45,8 @@ printf '%s\n' "$@" > "$FORWARDED_ARGS_FILE"
 EOF
 chmod +x "$profile_dir/dev"
 
-CARGO_TARGET_DIR="$temp_dir/target" \
+PATH="$temp_dir/bin:$PATH" \
+  CARGO_TARGET_DIR="$temp_dir/target" \
   NO_LICENSES=1 \
   SKIP_SETTINGS_SCHEMA=1 \
   "$workspace_root/script/linux/bundle" \

--- a/script/linux/test_bundle_warpctrl
+++ b/script/linux/test_bundle_warpctrl
@@ -18,7 +18,7 @@ EOF
 chmod +x "$temp_dir/bin/rustup"
 
 target="$(uname -m)-unknown-linux-musl"
-for compiler in "$target-gcc" "$target-g++"; do
+for compiler in "$target-gcc" "$target-g++" "$target-strip"; do
   cat > "$temp_dir/bin/$compiler" <<'EOF'
 #!/usr/bin/env bash
 exit 0

--- a/script/linux/test_bundle_warpctrl
+++ b/script/linux/test_bundle_warpctrl
@@ -17,7 +17,19 @@ exit 0
 EOF
 chmod +x "$temp_dir/bin/rustup"
 
-target="$(uname -m)-unknown-linux-musl"
+case "$(uname -m)" in
+  arm64|aarch64)
+    arch="aarch64"
+    ;;
+  x86_64|amd64)
+    arch="x86_64"
+    ;;
+  *)
+    echo "Unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+target="$arch-unknown-linux-musl"
 for compiler in "$target-gcc" "$target-g++" "$target-strip"; do
   cat > "$temp_dir/bin/$compiler" <<'EOF'
 #!/usr/bin/env bash
@@ -32,6 +44,7 @@ PATH="$temp_dir/bin:$PATH" \
   "$workspace_root/script/linux/bundle" \
   --check-only \
   --artifact warpctrl \
+  --arch "$arch" \
   --features smoke_feature
 
 grep -qx -- '--features' "$temp_dir/cargo-args"
@@ -51,7 +64,8 @@ PATH="$temp_dir/bin:$PATH" \
   SKIP_SETTINGS_SCHEMA=1 \
   "$workspace_root/script/linux/bundle" \
   --skip-build \
-  --artifact warpctrl
+  --artifact warpctrl \
+  --arch "$arch"
 
 FORWARDED_ARGS_FILE="$temp_dir/forwarded-args" \
   "$profile_dir/bundle/linux/warpctrl" tab create --instance "inst 123"


### PR DESCRIPTION
## Description

This changes how we build the Linux CLI binaries to use `musl` instead of `glibc` as the standard library, which avoids:
1. glibc versioning issues
2. the need for glibc to be present in the runtime environment, allowing the binary to be run on alpine base images.

## Testing

Tested the release workflow here: https://github.com/warpdotdev/warp-internal/actions/runs/28291927500

Confirmed that the aarch64 binary built there runs properly in an aarch64 alpine Docker image: `docker run --rm --platform linux/arm64 -v /Users/david/Downloads/target/aarch64-unknown-linux-musl/release-cli-debug_assertions/dev:/mnt/warp-dev:ro alpine:3.20 /mnt/warp-dev --help`

Also double-checked with a local build that the changes to the cargo config toml file don't break compilation on macOS.