### PR TITLE
feat(session-nav): match sessions by custom tab and pane name

### DIFF
--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -2445,8 +2445,15 @@ impl PaneGroup {
         window_id: WindowId,
         app: &'a AppContext,
     ) -> impl Iterator<Item = SessionNavigationData> + 'a {
-        self.panes_of::<TerminalPane>()
-            .map(move |pane| pane.session_navigation_data(pane_group_id, window_id, app))
+        // The custom tab title lives on the pane group, so stamp it onto each
+        // session here. This lets the session navigation palette match sessions
+        // by their user-assigned tab name, not just cwd/command/status.
+        let tab_name = self.custom_title(app);
+        self.panes_of::<TerminalPane>().map(move |pane| {
+            let mut session = pane.session_navigation_data(pane_group_id, window_id, app);
+            session.set_tab_name(tab_name.clone());
+            session
+        })
     }
 
     /// Send prompt change bindkey events to all terminal sessions in this pane group. This

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -259,7 +259,16 @@ impl TerminalPane {
         app: &AppContext,
     ) -> SessionNavigationData {
         let view = self.terminal_view(app).as_ref(app);
-        SessionNavigationData::new(
+        // The user's custom pane name (set via rename-pane) is stored as the
+        // vertical-tabs title. We only carry the *custom* name (not the
+        // auto-generated terminal title) so it is both searchable and worth
+        // displaying in the palette row.
+        let pane_title = self
+            .pane_configuration()
+            .as_ref(app)
+            .custom_vertical_tabs_title()
+            .map(|title| title.to_string());
+        let mut session = SessionNavigationData::new(
             view.full_prompt(app),
             view.prompt_elements(app),
             view.session_command_context(app),
@@ -271,7 +280,9 @@ impl TerminalPane {
             view.is_read_only(),
             window_id,
             view.model.lock().shared_session_status().clone(),
-        )
+        );
+        session.set_pane_title(pane_title);
+        session
     }
 
     pub fn terminal_pane_id(&self) -> TerminalPaneId {

--- a/app/src/search/command_palette/navigation/render.rs
+++ b/app/src/search/command_palette/navigation/render.rs
@@ -65,6 +65,29 @@ fn render_session_label(
 ) -> Flex {
     let mut navigation_palette_item = Flex::column();
 
+    // Surface the user-assigned tab/pane name as the top line of the row, so a
+    // session matched by its custom name is recognizable (the prompt below only
+    // shows the working directory).
+    if let Some(name) = session.display_name() {
+        let name_color = item_highlight_state.main_text_fill(appearance).into_solid();
+        let name_label = appearance
+            .ui_builder()
+            .span(name.to_string())
+            .with_style(UiComponentStyles {
+                font_family_id: Some(appearance.monospace_font_family()),
+                font_size: Some(appearance.monospace_font_size() - 2.),
+                font_color: Some(name_color),
+                ..Default::default()
+            })
+            .build()
+            .finish();
+        navigation_palette_item.add_child(
+            Container::new(name_label)
+                .with_margin_right(styles::NAVIGATION_PALETTE_ROW_HORIZONTAL_SPACING)
+                .finish(),
+        );
+    }
+
     let prompt = if let Some(ps1_grid) = &session.prompt_elements().ps1_prompt_grid {
         render_prompt_ps1(ps1_grid, appearance, app)
     } else if let Some(snapshot) = &session.prompt_elements().prompt_chip_snapshot {

--- a/app/src/search/command_palette/navigation/search.rs
+++ b/app/src/search/command_palette/navigation/search.rs
@@ -124,8 +124,12 @@ where
         })
 }
 
-/// The searchable string format is: [prompt] [command] [hint text],
-/// where [command] may or may not be present.
+/// The searchable string format is: [prompt] [command] [hint text] [tab name]
+/// [pane name], where every part except the prompt may be absent. The custom
+/// tab and pane names are appended (when set) so sessions can be found by the
+/// name the user assigned them, not just their directory/command. Only the
+/// command and hint-text ranges are tracked for highlighting; the trailing
+/// names are matchable but not range-highlighted.
 fn searchable_session_string_and_ranges(
     session: &SessionNavigationData,
 ) -> (String, SearchableSessionStringRanges) {
@@ -181,6 +185,17 @@ fn searchable_session_string_and_ranges(
             start..end
         }
     };
+
+    // Append the custom tab name (if any) so sessions can be found by the tab
+    // the user assigned them, e.g. searching "meetings" surfaces the "Meetings"
+    // tab. The tab name is not highlighted in the row, so no range is tracked.
+    for name in [session.tab_name(), session.pane_title()]
+        .into_iter()
+        .flatten()
+    {
+        searchable_string.push(' ');
+        searchable_string.push_str(name);
+    }
 
     (
         searchable_string,

--- a/app/src/session_management.rs
+++ b/app/src/session_management.rs
@@ -28,6 +28,15 @@ pub struct SessionNavigationData {
     is_read_only: bool,
     /// The sharing status of the session.
     shared_session_status: SharedSessionStatus,
+    /// The custom name of the tab (pane group) that owns this session, if the
+    /// user has renamed it. Stamped in by `PaneGroup::pane_sessions` so the
+    /// session navigation palette can match against the tab name.
+    tab_name: Option<String>,
+    /// The pane's own title (`pane_configuration().title()`), which is what the
+    /// tab strip / vertical tabs panel actually displays when no tab-level
+    /// custom title is set. Stamped in by `TerminalPane::session_navigation_data`
+    /// so the palette can match against the visible pane name.
+    pane_title: Option<String>,
 }
 
 impl SessionNavigationData {
@@ -110,11 +119,43 @@ impl SessionNavigationData {
             is_read_only,
             window_id,
             shared_session_status,
+            tab_name: None,
+            pane_title: None,
         }
     }
 
     pub fn prompt(&self) -> &str {
         &self.prompt
+    }
+
+    /// Returns the custom tab name owning this session, if one is set.
+    pub fn tab_name(&self) -> Option<&str> {
+        self.tab_name.as_deref()
+    }
+
+    /// Sets the custom tab name owning this session. Called by
+    /// `PaneGroup::pane_sessions`, which is the level that has access to the
+    /// owning pane group's custom title.
+    pub fn set_tab_name(&mut self, tab_name: Option<String>) {
+        self.tab_name = tab_name.filter(|name| !name.is_empty());
+    }
+
+    /// Returns the pane's own displayed title, if one is set.
+    pub fn pane_title(&self) -> Option<&str> {
+        self.pane_title.as_deref()
+    }
+
+    /// Sets the pane's displayed title. Called by
+    /// `TerminalPane::session_navigation_data`.
+    pub fn set_pane_title(&mut self, pane_title: Option<String>) {
+        self.pane_title = pane_title.filter(|name| !name.is_empty());
+    }
+
+    /// The user-assigned name to surface in the palette row, if any. Prefers the
+    /// custom pane name, falling back to the custom tab name. Returns `None` when
+    /// the session has no custom name (only its directory/command identify it).
+    pub fn display_name(&self) -> Option<&str> {
+        self.pane_title().or_else(|| self.tab_name())
     }
 
     pub fn prompt_elements(&self) -> &SessionNavigationPromptElements {

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -1269,6 +1269,51 @@ fn test_workspace_sessions_retrieves_panes() {
     });
 }
 
+#[test]
+fn test_workspace_sessions_carry_custom_tab_and_pane_names() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+
+        workspace.update(&mut app, |workspace, ctx| {
+            // Rename the tab (pane group), then grab its first pane's id.
+            let pane_id = {
+                let tab_view = workspace
+                    .get_pane_group_view(0)
+                    .expect("tab pane group should exist");
+                tab_view.update(ctx, |pane_group, ctx| {
+                    pane_group.set_title("deploy logs", ctx);
+                    pane_group.pane_id_by_index(0).unwrap()
+                })
+            };
+
+            // The session for that pane carries the custom tab name, and the
+            // display name falls back to it when the pane has no custom name.
+            let session = workspace
+                .workspace_sessions(ctx.window_id(), ctx)
+                .find(|session| session.pane_view_locator().pane_id == pane_id)
+                .expect("session for the renamed tab should exist");
+            assert_eq!(session.tab_name(), Some("deploy logs"));
+            assert_eq!(session.pane_title(), None);
+            assert_eq!(session.display_name(), Some("deploy logs"));
+
+            // Give the pane its own custom name; it should now be carried too,
+            // and the display name prefers the more-specific pane name.
+            let locator = session.pane_view_locator();
+            workspace.set_custom_pane_name(locator, "build output".to_string(), ctx);
+
+            let session = workspace
+                .workspace_sessions(ctx.window_id(), ctx)
+                .find(|session| session.pane_view_locator().pane_id == pane_id)
+                .expect("session after renaming the pane should exist");
+            assert_eq!(session.tab_name(), Some("deploy logs"));
+            assert_eq!(session.pane_title(), Some("build output"));
+            assert_eq!(session.display_name(), Some("build output"));
+        });
+    });
+}
+
 fn number_of_shared_sessions_in_tab(
     workspace: &Workspace,
     index: usize,

--- a/specs/GH9155/product.md
+++ b/specs/GH9155/product.md
@@ -1,0 +1,79 @@
+# Product Spec: Search sessions by renamed tab and pane name
+
+**Issue:** [warpdotdev/warp#9155](https://github.com/warpdotdev/warp/issues/9155)
+**Figma:** none provided
+
+## Summary
+
+The session navigation palette (`Cmd+P`) should let users find a session by the
+name they assigned its tab or pane. Today the palette matches only on working
+directory, running/last command, and status, so a session a user renamed to
+`deploy` is not findable by typing `deploy` unless its directory or command also
+contains that text. This makes renaming sessions far less useful for navigation,
+which is the main reason users rename them.
+
+## Problem
+
+Users with many open sessions rename tabs and panes to meaningful labels
+(`meetings`, `frontend`, `deploy`) precisely so they can jump back to them. The
+tab strip and vertical-tabs sidebar display those names, but the `Cmd+P` session
+navigation palette does not search them: typing a custom name returns
+"No Results Found" when the directory/command do not also match. Users fall back
+to `Cmd+1/2/3` positional switching or visual scanning, defeating the purpose of
+naming.
+
+A custom name is also not shown in the palette result row, so even when a session
+appears, there is nothing tying it to the name the user remembers.
+
+## Goals
+
+- A session is findable in the navigation palette by its custom **tab** name
+  (set via rename-tab).
+- A session is findable by its custom **pane** name (set via rename-pane).
+- The palette row shows the user-assigned name so a name-matched result is
+  recognizable next to its directory.
+- Sessions without a custom name behave exactly as before.
+
+## Non-goals
+
+- The sidebar "Search tabs…" Panes-mode filter (tracked separately in #9666).
+- Auto-generated terminal titles (e.g. `user@host:~`) becoming searchable — only
+  user-assigned names are added.
+- Highlighting the matched characters within the name (the directory/command
+  highlight behavior is unchanged; the name is matchable and displayed but not
+  range-highlighted).
+- Renaming UX, persistence, or where names are stored — unchanged.
+
+## User experience
+
+### Current behavior
+
+1. User renames a tab to `deploy` (its directory is `~/project`).
+2. User opens the navigation palette and types `deploy`.
+3. "No Results Found" — the name is not searched.
+
+### Expected behavior
+
+1. User renames a tab to `deploy`.
+2. User opens the navigation palette and types `deploy`.
+3. The session under the `deploy` tab appears, with `deploy` shown on its row.
+4. The same holds for a pane renamed to `deploy`.
+
+## Behavior invariants
+
+1. Typing a substring of a session's custom **tab** name surfaces that session
+   in the navigation palette.
+2. Typing a substring of a session's custom **pane** name surfaces that session.
+3. A matched session's row displays the user-assigned name: the custom pane name
+   if set, otherwise the custom tab name.
+4. When both a custom tab name and a custom pane name are set, both are
+   searchable, and the displayed name is the pane name (more specific).
+5. A session with no custom tab or pane name shows no extra name line, and its
+   matching behavior (prompt/command/status) is unchanged from today.
+6. Renaming a tab or pane updates what is searchable/displayed without requiring
+   the palette to be reopened from scratch (the palette reads live session data
+   each query).
+7. The change applies regardless of which session-search backend is active
+   (fuzzy or full-text), so results are consistent across configurations.
+8. Empty custom names (e.g. cleared back to default) are treated as no custom
+   name (invariant 5 applies).

--- a/specs/GH9155/tech.md
+++ b/specs/GH9155/tech.md
@@ -1,0 +1,114 @@
+# Tech Spec: Search sessions by renamed tab and pane name
+
+**Issue:** [warpdotdev/warp#9155](https://github.com/warpdotdev/warp/issues/9155)
+
+## Context
+
+The session navigation palette builds the text it matches a query against from a
+single function shared by both search backends. Custom tab and pane names are
+stored on different models and are not part of that text or of the
+`SessionNavigationData` the palette consumes.
+
+Relevant code:
+
+- `app/src/search/command_palette/navigation/search.rs` — `searchable_session_string_and_ranges()` builds the searchable string (`[prompt] [command] [hint text]`). Both `FuzzySessionSearcher` and `FullTextSessionSearcher` (Tantivy) call it, so it is the single place that determines what is matchable. `render` of a row happens in `render.rs`.
+- `app/src/session_management.rs` — `SessionNavigationData` is the per-session record the palette consumes (`prompt`, `command_context`, `pane_view_locator`, status, etc.). It carries no custom tab/pane name. `all_sessions()` → `Workspace::workspace_sessions` is the data source.
+- `app/src/workspace/view.rs` — `workspace_sessions()` iterates tabs and calls `PaneGroup::pane_sessions()` per tab.
+- `app/src/pane_group/mod.rs` — `pane_sessions()` (the level with the owning pane group) maps panes to `SessionNavigationData`. `PaneGroup::custom_title` holds the rename-tab title; `set_title()` (rename-tab via `Workspace::rename_tab`) writes it.
+- `app/src/pane_group/pane/terminal_pane.rs` — `session_navigation_data()` constructs each `SessionNavigationData` from the terminal view.
+- `app/src/pane_group/pane/mod.rs` — `PaneConfiguration::custom_vertical_tabs_title` holds the rename-pane name; `set_custom_vertical_tabs_title()` writes it (via `Workspace::set_custom_pane_name` / rename-pane). `title()` is the auto terminal title and is **not** what we want.
+- `app/src/search/command_palette/navigation/render.rs` — `render_session_label()` lays out a row as a column (prompt, then command/status).
+
+## Current state
+
+`searchable_session_string_and_ranges()` reads only `prompt`, `command_context`,
+and the status hint from `SessionNavigationData`. The custom tab name lives on
+`PaneGroup` and the custom pane name on `PaneConfiguration`; neither is threaded
+into `SessionNavigationData`, so the palette can neither match nor display them.
+
+## Proposed changes
+
+### 1. Carry the names on `SessionNavigationData` (`session_management.rs`)
+
+Add two optional fields with getters/setters that drop empty strings:
+
+```rust
+tab_name: Option<String>,   // PaneGroup::custom_title (rename-tab)
+pane_title: Option<String>, // PaneConfiguration::custom_vertical_tabs_title (rename-pane)
+```
+
+Add a `display_name()` helper returning `pane_title().or_else(|| tab_name())`
+(pane name preferred, then tab name) for the render layer. Both fields default to
+`None` in `new()`; they are stamped after construction by the two call sites that
+have the respective data.
+
+### 2. Stamp the tab name in `PaneGroup::pane_sessions` (`pane_group/mod.rs`)
+
+`pane_sessions` is the level that owns the pane group, so it reads
+`self.custom_title(app)` once and sets it on each session:
+
+```rust
+let tab_name = self.custom_title(app);
+self.panes_of::<TerminalPane>().map(move |pane| {
+    let mut session = pane.session_navigation_data(pane_group_id, window_id, app);
+    session.set_tab_name(tab_name.clone());
+    session
+})
+```
+
+### 3. Stamp the pane name in `TerminalPane::session_navigation_data` (`terminal_pane.rs`)
+
+Read the custom (not auto) pane title and set it on the session:
+
+```rust
+let pane_title = self
+    .pane_configuration()
+    .as_ref(app)
+    .custom_vertical_tabs_title()
+    .map(|t| t.to_string());
+// ...build session...
+session.set_pane_title(pane_title);
+```
+
+### 4. Append both to the searchable string (`search.rs`)
+
+After the existing prompt/command/hint assembly, append each present name so
+both backends match it. No highlight range is tracked for the names (matchable,
+not range-highlighted):
+
+```rust
+for name in [session.tab_name(), session.pane_title()].into_iter().flatten() {
+    searchable_string.push(' ');
+    searchable_string.push_str(name);
+}
+```
+
+### 5. Show the name in the row (`render.rs`)
+
+In `render_session_label`, when `session.display_name()` is `Some`, add it as the
+top line of the row (monospace, themed text color), above the prompt.
+
+## Testing and validation
+
+- **Unit/integration** (`app/src/workspace/view_tests.rs`): added
+  `test_workspace_sessions_carry_custom_tab_and_pane_names`, which renames a tab
+  and a pane and asserts the resulting `SessionNavigationData` carries
+  `tab_name`/`pane_title` and that `display_name` prefers the pane name. Covers
+  invariants 1–5 and 8 at the data-source level (the searchable string and row
+  render are pure functions of these fields).
+- **Backend coverage** (invariant 7): the names feed
+  `searchable_session_string_and_ranges`, which both `FuzzySessionSearcher` and
+  `FullTextSessionSearcher` consume, so a single change covers both.
+- **Manual** (invariants 1–6): `./script/run`, rename tabs/panes, open the
+  navigation palette, confirm name matches surface the session and the name is
+  shown on the row; confirm un-named sessions are unchanged. Before/after
+  screenshots attached to the PR.
+- **Lint/format**: `cargo clippy -p warp --all-targets --tests -- -D warnings`
+  and the project formatter pass.
+
+## Risks / tradeoffs
+
+- Including names in the matched text slightly broadens matches; scoped to
+  user-assigned names only (not auto titles) to avoid noise.
+- The names are matchable but not range-highlighted in the row; highlighting
+  could be a follow-up if desired.


### PR DESCRIPTION
## Description

The session navigation palette (`Cmd+P`) matched sessions by working directory, running/last command and status, but not by the name the user assigned a tab or pane. So a session you think of as `deploy` was only findable by its directory, defeating the point of naming it.

This change:
- Carries the pane group's custom tab title (`PaneGroup::custom_title`) on `SessionNavigationData`, stamped in `PaneGroup::pane_sessions`.
- Carries the pane's custom name (`PaneConfiguration::custom_vertical_tabs_title`) on `SessionNavigationData`, stamped in `TerminalPane::session_navigation_data`.
- Appends both to the searchable string built by `searchable_session_string_and_ranges`, so the fuzzy and Tantivy full-text backends both match them.
- Renders the user-assigned name (pane name, else tab name) as the row's top line via a new `display_name` helper.

Sessions without a custom name are unchanged.

This issue is labeled `ready-to-spec`, so this PR includes the spec under [`specs/GH9155/`](specs/GH9155/) (`product.md` + `tech.md`) alongside the implementation.

## Linked Issue

Closes #9155

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. (`ready-to-spec` — spec included in this PR.)
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

Automated: added `test_workspace_sessions_carry_custom_tab_and_pane_names` in `app/src/workspace/view_tests.rs`, which renames a tab and a pane and asserts the resulting `SessionNavigationData` carries `tab_name` / `pane_title` and that `display_name` prefers the pane name. `cargo clippy -p warp --all-targets --tests -- -D warnings` and the `workspace_sessions` tests pass.

Manual: in a local `./script/run` build, renamed tabs/panes (e.g. `meetings`, `learnings`), opened the navigation palette, and confirmed typing the name surfaces the session and the name shows in the row. Before: "No Results Found". After: the session appears with its name.

### Screenshots / Videos
<img width="2714" height="1288" alt="CleanShot 2026-06-19 at 12 58 13@2x" src="https://github.com/user-attachments/assets/ae2ee6de-fccf-4e7a-88e8-84715ab633d0" />
<img width="2714" height="1288" alt="CleanShot 2026-06-19 at 12 58 22@2x" src="https://github.com/user-attachments/assets/dabbf4df-a342-4960-bb28-6bda0724de91" />
<img width="2714" height="1288" alt="CleanShot 2026-06-19 at 12 58 30@2x" src="https://github.com/user-attachments/assets/e740186f-f569-4f74-92f4-8db0cbba4d67" />



## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: The session navigation palette now matches sessions by their custom tab and pane names, and shows the name in the result row.
-->