### PR TITLE
Add keyboard shortcut to toggle Markdown rendered/raw view

### DIFF
--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -123,6 +123,17 @@ pub fn init(app: &mut AppContext) {
         .with_context_predicate(id!("CodeEditorView"))
         .with_key_binding("cmdorctrl-r u"),
     ]);
+
+    // Toggle a markdown code pane back to its rendered preview. Mirrors the
+    // `FileNotebookView` binding so the same shortcut toggles both directions.
+    #[cfg(feature = "local_fs")]
+    app.register_editable_bindings([EditableBinding::new(
+        "code_view:toggle_markdown_display_mode",
+        "Toggle Markdown rendered/raw view",
+        CodeViewAction::RenderMarkdown,
+    )
+    .with_context_predicate(text_entry)
+    .with_key_binding("cmdorctrl-e")]);
 }
 
 const PADDING: f32 = 4.;
@@ -2337,9 +2348,13 @@ impl TypedActionView for CodeView {
             }
             #[cfg(feature = "local_fs")]
             CodeViewAction::RenderMarkdown => {
+                // The keybinding is registered for all code panes, but only markdown
+                // files have a rendered preview to switch to. Drop the path otherwise so
+                // the action is a no-op (the context-menu entry is already markdown-gated).
                 let lor_path = self
                     .tab_at(self.active_tab_index)
-                    .and_then(|t| t.location.clone());
+                    .and_then(|t| t.location.clone())
+                    .filter(|p| is_markdown_file(std::path::Path::new(&p.display_path())));
 
                 if let Some(lor_path) = lor_path {
                     let source = self.source.clone();

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -2351,10 +2351,17 @@ impl TypedActionView for CodeView {
                 // The keybinding is registered for all code panes, but only markdown
                 // files have a rendered preview to switch to. Drop the path otherwise so
                 // the action is a no-op (the context-menu entry is already markdown-gated).
+                //
+                // Detect markdown via the standardized path component (always
+                // `/`-separated) instead of display_path() + Path::new, which assumes
+                // local-OS encoding and would misparse a remote file's path on a
+                // cross-OS session.
                 let lor_path = self
                     .tab_at(self.active_tab_index)
                     .and_then(|t| t.location.clone())
-                    .filter(|p| is_markdown_file(std::path::Path::new(&p.display_path())));
+                    .filter(|p| {
+                        is_markdown_file(std::path::Path::new(p.path_component().as_str()))
+                    });
 
                 if let Some(lor_path) = lor_path {
                     let source = self.source.clone();

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -2352,15 +2352,18 @@ impl TypedActionView for CodeView {
                 // files have a rendered preview to switch to. Drop the path otherwise so
                 // the action is a no-op (the context-menu entry is already markdown-gated).
                 //
-                // Detect markdown via the standardized path component (always
-                // `/`-separated) instead of display_path() + Path::new, which assumes
-                // local-OS encoding and would misparse a remote file's path on a
-                // cross-OS session.
+                // Detect markdown from the standardized path component (always
+                // `/`-separated) rather than display_path(), which is local-OS
+                // oriented and would misparse a remote file's path on a cross-OS
+                // session. is_markdown_file takes impl AsRef<Path> and only inspects
+                // the extension/file name, so feed it the standardized &str directly.
                 let lor_path = self
                     .tab_at(self.active_tab_index)
                     .and_then(|t| t.location.clone())
                     .filter(|p| {
-                        is_markdown_file(std::path::Path::new(p.path_component().as_str()))
+                        crate::util::openable_file_type::is_markdown_file(
+                            p.path_component().as_str(),
+                        )
                     });
 
                 if let Some(lor_path) = lor_path {

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -2348,20 +2348,23 @@ impl TypedActionView for CodeView {
             }
             #[cfg(feature = "local_fs")]
             CodeViewAction::RenderMarkdown => {
-                // The keybinding is registered for all code panes, but only markdown
-                // files have a rendered preview to switch to. Drop the path otherwise so
-                // the action is a no-op (the context-menu entry is already markdown-gated).
+                // The keybinding is registered for all code panes, but only files that
+                // render in the notebook viewer have a rendered preview to switch to.
+                // Drop the path otherwise so the action is a no-op. This is the same
+                // predicate the header segmented control and the "View Markdown preview"
+                // context-menu entry use, so those existing entry points (including
+                // Jupyter notebooks) keep working unchanged.
                 //
-                // Detect markdown from the standardized path component (always
+                // Detect the file type from the standardized path component (always
                 // `/`-separated) rather than display_path(), which is local-OS
                 // oriented and would misparse a remote file's path on a cross-OS
-                // session. is_markdown_file takes impl AsRef<Path> and only inspects
-                // the extension/file name, so feed it the standardized &str directly.
+                // session. The predicate takes impl AsRef<Path> and only inspects the
+                // extension/file name, so feed it the standardized &str directly.
                 let lor_path = self
                     .tab_at(self.active_tab_index)
                     .and_then(|t| t.location.clone())
                     .filter(|p| {
-                        crate::util::openable_file_type::is_markdown_file(
+                        crate::util::openable_file_type::renders_in_warp_notebook_viewer(
                             p.path_component().as_str(),
                         )
                     });

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -237,6 +237,13 @@ pub fn init(app: &mut AppContext) {
             FileNotebookAction::ReloadFile,
         )
         .with_context_predicate(id!("FileNotebookView")),
+        EditableBinding::new(
+            "notebookview:toggle_markdown_display_mode",
+            "Toggle Markdown rendered/raw view",
+            FileNotebookAction::ToggleMarkdownDisplayMode(MarkdownDisplayMode::Raw),
+        )
+        .with_context_predicate(id!("FileNotebookView"))
+        .with_key_binding("cmdorctrl-e"),
     ])
 }
 
@@ -1084,6 +1091,12 @@ impl TypedActionView for FileNotebookView {
                 self.context_menu.handle_action(action, ctx);
             }
             FileNotebookAction::ToggleMarkdownDisplayMode(mode) => {
+                // The rendered/raw toggle only applies to markdown files (its segmented
+                // control is only shown for them). The keybinding is registered view-wide,
+                // so ignore it on non-markdown panes.
+                if !self.is_markdown_file() {
+                    return;
+                }
                 self.markdown_display_mode = *mode;
                 self.display_mode_segmented_control
                     .update(ctx, |control, ctx| {

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -1091,10 +1091,12 @@ impl TypedActionView for FileNotebookView {
                 self.context_menu.handle_action(action, ctx);
             }
             FileNotebookAction::ToggleMarkdownDisplayMode(mode) => {
-                // The rendered/raw toggle only applies to markdown files (its segmented
-                // control is only shown for them). The keybinding is registered view-wide,
-                // so ignore it on non-markdown panes.
-                if !self.is_markdown_file() {
+                // The keybinding is registered view-wide, but only panes that actually
+                // expose the rendered/raw toggle have something to switch to. Reuse the
+                // exact predicate that gates the header segmented control (markdown, plus
+                // Jupyter notebooks when their feature flag is on) so this action behaves
+                // identically for every entry point that dispatches it.
+                if !self.shows_markdown_toggle() {
                     return;
                 }
                 self.markdown_display_mode = *mode;

--- a/app/src/notebooks/file/mod_tests.rs
+++ b/app/src/notebooks/file/mod_tests.rs
@@ -13,9 +13,9 @@ use warp_editor::render::model::BlockItem;
 #[cfg(feature = "local_fs")]
 use warp_files::FileModel;
 use warpui::platform::WindowStyle;
-use warpui::{App, SingletonEntity, View};
+use warpui::{App, SingletonEntity, TypedActionView, View};
 
-use super::{FileNotebookView, FileState, MarkdownDisplayMode, SourceFile};
+use super::{FileNotebookAction, FileNotebookView, FileState, MarkdownDisplayMode, SourceFile};
 use crate::auth::AuthStateProvider;
 use crate::auth::auth_manager::AuthManager;
 use crate::cloud_object::model::persistence::CloudModel;
@@ -375,6 +375,75 @@ fn test_markdown_file_detection() {
     assert!(!is_markdown_file("README.txt"));
     assert!(!is_markdown_file("main.rs"));
     assert!(!is_markdown_file("notes"));
+}
+
+#[test]
+fn test_markdown_toggle_is_noop_for_non_markdown_pane() {
+    App::test((), |mut app| async move {
+        init_app(&mut app);
+        let (_, handle) = app.add_window(WindowStyle::NotStealFocus, FileNotebookView::new);
+
+        // A static pane has no backing file path, so `is_markdown_file()` is false.
+        // The toggle keybinding is registered view-wide, so firing it here must not
+        // switch display modes (only markdown panes expose the rendered/raw toggle).
+        handle.update(&mut app, |file_notebook, ctx| {
+            file_notebook.open_static("Plain pane", "just some text", ctx);
+            file_notebook.handle_action(
+                &FileNotebookAction::ToggleMarkdownDisplayMode(MarkdownDisplayMode::Raw),
+                ctx,
+            );
+        });
+
+        let mode = handle.read(&app, |view, _ctx| view.markdown_display_mode);
+        assert_eq!(
+            mode,
+            MarkdownDisplayMode::Rendered,
+            "toggling display mode must be a no-op when the pane is not a markdown file"
+        );
+    });
+}
+
+#[test]
+fn test_markdown_toggle_switches_markdown_pane_to_raw() {
+    App::test((), |mut app| async move {
+        init_app(&mut app);
+        let (_, handle) = app.add_window(WindowStyle::NotStealFocus, FileNotebookView::new);
+        let session = Arc::new(Session::test());
+        handle
+            .update(&mut app, |file_notebook, ctx| {
+                file_notebook.open_local("../README.md", Some(session), ctx);
+
+                let file_id = file_notebook
+                    .file_id
+                    .expect("File should be opened and have a file_id");
+
+                let future_handle = FileModel::as_ref(ctx)
+                    .get_future_handle(file_id)
+                    .expect("Loading future should be present");
+
+                ctx.await_spawned_future(future_handle.future_id())
+            })
+            .await;
+
+        // A markdown pane honors the toggle keybinding and switches to raw mode.
+        handle.update(&mut app, |file_notebook, ctx| {
+            assert!(
+                file_notebook.is_markdown_file(),
+                "README.md should be detected as a markdown file"
+            );
+            file_notebook.handle_action(
+                &FileNotebookAction::ToggleMarkdownDisplayMode(MarkdownDisplayMode::Raw),
+                ctx,
+            );
+        });
+
+        let mode = handle.read(&app, |view, _ctx| view.markdown_display_mode);
+        assert_eq!(
+            mode,
+            MarkdownDisplayMode::Raw,
+            "toggling a markdown pane should switch it to raw mode"
+        );
+    });
 }
 
 #[test]

--- a/app/src/notebooks/file/mod_tests.rs
+++ b/app/src/notebooks/file/mod_tests.rs
@@ -383,9 +383,9 @@ fn test_markdown_toggle_is_noop_for_non_markdown_pane() {
         init_app(&mut app);
         let (_, handle) = app.add_window(WindowStyle::NotStealFocus, FileNotebookView::new);
 
-        // A static pane has no backing file path, so `is_markdown_file()` is false.
+        // A static pane has no backing file path, so `shows_markdown_toggle()` is false.
         // The toggle keybinding is registered view-wide, so firing it here must not
-        // switch display modes (only markdown panes expose the rendered/raw toggle).
+        // switch display modes (only panes that expose the rendered/raw toggle do).
         handle.update(&mut app, |file_notebook, ctx| {
             file_notebook.open_static("Plain pane", "just some text", ctx);
             file_notebook.handle_action(
@@ -442,6 +442,73 @@ fn test_markdown_toggle_switches_markdown_pane_to_raw() {
             mode,
             MarkdownDisplayMode::Raw,
             "toggling a markdown pane should switch it to raw mode"
+        );
+    });
+}
+
+#[test]
+fn test_markdown_toggle_switches_jupyter_notebook_pane_to_raw() {
+    App::test((), |mut app| async move {
+        init_app(&mut app);
+        let _flag = FeatureFlag::JupyterNotebookRendering.override_enabled(true);
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("analysis.ipynb");
+        std::fs::write(
+            &path,
+            r##"{
+                "nbformat": 4,
+                "nbformat_minor": 5,
+                "metadata": {"language_info": {"name": "python"}},
+                "cells": [
+                    {"cell_type": "markdown", "source": ["# Notebook heading"]}
+                ]
+            }"##,
+        )
+        .unwrap();
+
+        let (_, handle) = app.add_window(WindowStyle::NotStealFocus, FileNotebookView::new);
+        let session = Arc::new(Session::test());
+        handle
+            .update(&mut app, |file_notebook, ctx| {
+                file_notebook.open_local(&path, Some(session), ctx);
+
+                let file_id = file_notebook
+                    .file_id
+                    .expect("File should be opened and have a file_id");
+
+                let future_handle = FileModel::as_ref(ctx)
+                    .get_future_handle(file_id)
+                    .expect("Loading future should be present");
+
+                ctx.await_spawned_future(future_handle.future_id())
+            })
+            .await;
+
+        // A rendered .ipynb pane is not a markdown file, but it does expose the
+        // rendered/raw toggle (PRODUCT invariant 14), so the shared action must keep
+        // switching it to raw — this is the existing header segmented control's path,
+        // not just the new keybinding.
+        handle.update(&mut app, |file_notebook, ctx| {
+            assert!(
+                !file_notebook.is_markdown_file(),
+                "an .ipynb pane is not a markdown file"
+            );
+            assert!(
+                file_notebook.shows_markdown_toggle(),
+                "a rendered notebook should expose the Rendered/Raw toggle"
+            );
+            file_notebook.handle_action(
+                &FileNotebookAction::ToggleMarkdownDisplayMode(MarkdownDisplayMode::Raw),
+                ctx,
+            );
+        });
+
+        let mode = handle.read(&app, |view, _ctx| view.markdown_display_mode);
+        assert_eq!(
+            mode,
+            MarkdownDisplayMode::Raw,
+            "toggling a notebook pane should switch it to raw mode"
         );
     });
 }


### PR DESCRIPTION
## Description

Add a keyboard shortcut to toggle a Markdown file pane between its rendered preview and its raw/source view, as requested in #11786.

Warp already exposes this toggle through the pane-header segmented control (rendered side) and the **View Markdown preview** context-menu entry (raw side), but there was no way to trigger it from the keyboard. This adds an editable keybinding that does so.

The shortcut defaults to **Cmd/Ctrl+E** — the Obsidian default called out in the issue. (VS Code's Cmd+Shift+V is already bound to paste in Warp, so it is intentionally avoided.) Because it is a normal editable binding, users can rebind it from the keybindings settings, which also satisfies the issue's "configurable" option.

Rendered Markdown lives in `FileNotebookView` and the raw/source view lives in `CodeView`, so the toggle is implemented as two single-direction bindings on the same key — one per view — that together form the round trip:

- `FileNotebookView` (rendered) → `ToggleMarkdownDisplayMode(Raw)` → swaps in the code pane
- `CodeView` (raw markdown) → `RenderMarkdown` → swaps back to the rendered file pane

Both bindings are registered view-wide, so each action handler is guarded to no-op on non-markdown panes (the existing segmented control and context-menu entries are already markdown-gated, so this keeps behavior consistent).

## Linked Issue
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

Closes #11786

## Testing
- [x] `cargo check -p warp --features local_fs`
- [x] `cargo clippy -p warp --features local_fs --all-targets -- -D warnings`
- [x] `cargo nextest run -p warp --features local_fs -E 'test(notebooks::file)'`
- [x] I have manually tested my changes locally with `./script/run`

Added two regression tests in `app/src/notebooks/file/mod_tests.rs`:

- `test_markdown_toggle_is_noop_for_non_markdown_pane` — a pane with no markdown file ignores the toggle action.
- `test_markdown_toggle_switches_markdown_pane_to_raw` — a markdown pane switches to raw mode when the action fires.

### Screenshots / Videos

https://github.com/user-attachments/assets/06aa230e-8d71-4005-8671-e36a5e91df2d

The recording shows pressing **Cmd+E** in a Markdown file pane to switch from the rendered preview to the raw/source view, and pressing it again to switch back.

There is no separate "before" clip on purpose: this change only adds a keyboard path to the *existing* rendered/raw toggle (already reachable via the pane-header segmented control and the "View Markdown preview" context-menu entry). The panes themselves are unchanged — the new behavior is the Cmd+E shortcut itself, which the recording demonstrates.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: Add a keyboard shortcut (Cmd/Ctrl+E by default) to toggle Markdown panes between rendered and raw view
-->