### PR TITLE
APP-2527 Phase 3: MCP JSON tree rendering

### DIFF
--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -1272,7 +1272,7 @@ impl AIBlock {
             &BlocklistAIHistoryModel::handle(ctx),
             |me, _, event, ctx| {
                 if event
-                    .terminal_surface_id()
+                    .terminal_view_id()
                     .is_none_or(|id| id == me.terminal_view_id)
                 {
                     match event {
@@ -1734,13 +1734,10 @@ impl AIBlock {
                         for source in image_sources {
                             resolved_image_sources.insert(
                                 source.clone(),
-                                Some(
-                                    resolve_asset_source_relative_to_directory(
-                                        &source,
-                                        cwd.as_deref().map(Path::new),
-                                    )
-                                    .with_local_file_content_version(),
-                                ),
+                                Some(resolve_asset_source_relative_to_directory(
+                                    &source,
+                                    cwd.as_deref().map(Path::new),
+                                )),
                             );
                         }
 
@@ -2082,7 +2079,6 @@ impl AIBlock {
                     self.handle_mcp_tool_stream_update(
                         action_id,
                         &command_text,
-                        name.to_string(),
                         display_input,
                         ctx,
                     );
@@ -2154,30 +2150,6 @@ impl AIBlock {
                 .footer_citation_chip_handles
                 .entry(citation.clone())
                 .or_default();
-        }
-        // Also register handles for memory citations derived from fetched_memories,
-        // which are synthesized at render time and never go through output.citations.
-        // Only register for the first exchange since that's the only one that shows them.
-        if let Some(conversation) = self.model.conversation(ctx) {
-            let is_first_exchange = conversation
-                .first_exchange()
-                .map(|e| Some(e.id) == self.model.exchange_id(ctx))
-                .unwrap_or(false);
-            if is_first_exchange {
-                for memory in conversation.fetched_memories() {
-                    if memory.memory_store_id.is_empty() || memory.memory_id.is_empty() {
-                        continue;
-                    }
-                    self.state_handles
-                        .footer_citation_chip_handles
-                        .entry(AIAgentCitation::AgentMemory {
-                            memory_store_id: memory.memory_store_id.clone(),
-                            memory_id: memory.memory_id.clone(),
-                            content: memory.content.clone(),
-                        })
-                        .or_default();
-                }
-            }
         }
 
         // Register element state for reasoning messages and track summarization timing.
@@ -3471,7 +3443,6 @@ impl AIBlock {
                         ctx,
                     );
                 });
-                self.yield_requested_action_focus_if_focused(&view, ctx);
                 ctx.notify();
             }
             RequestedCommandViewEvent::EnableAutoexecuteMode => {
@@ -3479,7 +3450,6 @@ impl AIBlock {
             }
             RequestedCommandViewEvent::Rejected => {
                 self.cancel_action(action_id, ctx);
-                self.yield_requested_action_focus_if_focused(&view, ctx);
             }
             RequestedCommandViewEvent::UpdatedExpansionState { is_expanded } => {
                 // We only care about expansion state updates when the command
@@ -3556,7 +3526,6 @@ impl AIBlock {
         &mut self,
         action_id: &AIAgentActionId,
         command_text: &str,
-        mcp_name: String,
         mcp_args: serde_json::Value,
         ctx: &mut ViewContext<Self>,
     ) {
@@ -3564,7 +3533,7 @@ impl AIBlock {
             Some(requested_mcp_tool) => {
                 requested_mcp_tool.view.update(ctx, |view, ctx| {
                     view.apply_streamed_update(command_text, ctx);
-                    view.update_mcp_request(mcp_name, mcp_args);
+                    view.update_mcp_request(mcp_args);
                     ctx.notify();
                 });
             }
@@ -3585,7 +3554,7 @@ impl AIBlock {
                         ctx,
                     );
                     view.apply_streamed_update(command_text, ctx);
-                    view.update_mcp_request(mcp_name, mcp_args);
+                    view.update_mcp_request(mcp_args);
                     view
                 });
                 let action_id_clone = action_id.clone();
@@ -3615,12 +3584,10 @@ impl AIBlock {
                 self.action_model.update(ctx, |action_model, ctx| {
                     action_model.execute_action(action_id, self.client_ids.conversation_id, ctx);
                 });
-                self.yield_requested_action_focus_if_focused(&view, ctx);
                 ctx.notify();
             }
             RequestedCommandViewEvent::Rejected => {
                 self.cancel_action(action_id, ctx);
-                self.yield_requested_action_focus_if_focused(&view, ctx);
             }
             RequestedCommandViewEvent::TextSelected => {
                 // If there's an ongoing text selection, clear all other selections within the
@@ -4794,15 +4761,6 @@ impl AIBlock {
         });
     }
 
-    fn yield_requested_action_focus_if_focused(
-        &self,
-        view: &ViewHandle<RequestedCommandView>,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        if view.is_self_or_child_focused(ctx) {
-            ctx.emit(AIBlockEvent::FocusTerminal);
-        }
-    }
     /// Tries to focus the AI block or one of its parts, if applicable.
     /// If the block doesn't need to be focused, focus is yielded
     /// back to the owning [`TerminalView`].
@@ -4934,32 +4892,6 @@ impl AIBlock {
                     .find_map(|comment| comment.rich_text_editor.as_ref(ctx).selected_text(ctx))
             })
             .or_else(|| self.selected_text.read().clone())
-            .filter(|selection| !selection.is_empty())
-    }
-
-    /// Test-only helper to set the block-level text selection, which is normally
-    /// written by the `SelectableArea` selection callback during a drag.
-    #[cfg(any(test, feature = "integration_tests"))]
-    pub fn set_block_level_selected_text_for_test(&self, text: Option<String>) {
-        *self.selected_text.write() = text;
-    }
-
-    /// Test-only helper that simulates a block-level text selection in this AI
-    /// block: it writes the selected text and emits the same
-    /// [`AIBlockEvent::SelectionChanged`] signal that
-    /// [`AIBlockAction::SelectText`] does, so the terminal view mirrors it into
-    /// the model's rich content selection (which the copy/insert paths read).
-    ///
-    /// This lets integration tests exercise the in-AI-block copy path without
-    /// depending on layout-sensitive pixel coordinates.
-    #[cfg(any(test, feature = "integration_tests"))]
-    pub fn simulate_text_selection_for_test(
-        &mut self,
-        text: Option<String>,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        *self.selected_text.write() = text;
-        ctx.emit(AIBlockEvent::SelectionChanged);
     }
 
     /// Start a selection at the top left corner of the block's SelectableArea.
@@ -6019,12 +5951,6 @@ pub enum AIBlockEvent {
     /// important because selecting across multiple blocks only supports text selections at the
     /// `AIBlock` level.
     ChildViewTextSelected,
-    /// Emitted when the `AIBlock`'s own (block-level) text selection state may
-    /// have changed. The terminal view uses this to keep the model's record of
-    /// which rich content block has an active selection in sync, so copy/insert
-    /// paths can find the selected text. Rich content selections are not tied to
-    /// the point-based model selection, so this signal is required.
-    SelectionChanged,
     CopiedEmptyText,
     OpenSettings,
     #[cfg(feature = "local_fs")]
@@ -6291,10 +6217,6 @@ impl TypedActionView for AIBlock {
                 // If we have a selection, we should use the default cursor, even if it's over a link.
                 ctx.reset_cursor();
                 self.dismiss_ai_tooltips(ctx);
-                // Notify the terminal view so it can keep the model's record of which rich
-                // content block has an active selection in sync (rich content selections are
-                // not tied to the point-based model selection used for regular blocks).
-                ctx.emit(AIBlockEvent::SelectionChanged);
             }
             AIBlockAction::CopyAIBlockCodeSnippet(text) => {
                 ctx.clipboard()

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -41,8 +41,8 @@ use secret_redaction::*;
 use serde::Serialize;
 use settings::Setting as _;
 use warp_core::features::FeatureFlag;
-use warp_core::ui::theme::color::internal_colors;
 use warp_core::ui::theme::Fill;
+use warp_core::ui::theme::color::internal_colors;
 use warp_editor::content::buffer::InitialBufferState;
 #[cfg(feature = "local_fs")]
 use warp_editor::content::edit::resolve_asset_source_relative_to_directory;
@@ -50,14 +50,14 @@ use warp_editor::render::element::VerticalExpansionBehavior;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::path::ShellFamily;
 use warpui::assets::asset_cache::AssetCache;
+use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::clipboard::ClipboardContent;
 use warpui::elements::{
-    get_rich_content_position_id, ClippedScrollStateHandle, MainAxisAlignment, MainAxisSize,
-    MouseStateHandle, SecretRange, SelectionBound, SelectionHandle, TableStateHandle,
+    ClippedScrollStateHandle, MainAxisAlignment, MainAxisSize, MouseStateHandle, SecretRange,
+    SelectionBound, SelectionHandle, TableStateHandle, get_rich_content_position_id,
 };
 use warpui::image_cache::ImageType;
 use warpui::keymap::FixedBinding;
-use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::text::SelectionType;
 use warpui::ui_components::button::{ButtonVariant, TextAndIcon, TextAndIconAlignment};
 use warpui::ui_components::components::{UiComponent, UiComponentStyles};
@@ -154,13 +154,13 @@ use crate::cloud_object::model::persistence::CloudModel;
 use crate::code::editor::comment_editor::create_readonly_comment_markdown_editor;
 use crate::code::editor::view::{CodeEditorEvent, CodeEditorRenderOptions, CodeEditorView};
 use crate::code::editor_management::CodeSource;
+use crate::code_review::CodeReviewTelemetryEvent;
 use crate::code_review::comment_rendering::{CommentViewCard, HeaderClickHandler};
 use crate::code_review::comments::{
-    attach_pending_imported_comments, convert_insert_review_comments, AttachedReviewComment,
-    CommentId, CommentOrigin,
+    AttachedReviewComment, CommentId, CommentOrigin, attach_pending_imported_comments,
+    convert_insert_review_comments,
 };
 use crate::code_review::telemetry_event::CodeReviewPaneEntrypoint;
-use crate::code_review::CodeReviewTelemetryEvent;
 use crate::editor::InteractionState;
 use crate::notebooks::editor::model::FileLinkResolutionContext;
 use crate::notebooks::editor::view::{EditorViewEvent, RichTextEditorView};
@@ -175,12 +175,12 @@ use crate::settings::{
 };
 use crate::settings_view::SettingsSection;
 use crate::terminal::find::TerminalFindModel;
+use crate::terminal::model::BlockId;
 use crate::terminal::model::secrets::RichContentSecretTooltipInfo;
 use crate::terminal::model::session::active_session::{ActiveSession, ActiveSessionEvent};
-use crate::terminal::model::BlockId;
 use crate::terminal::model_events::{ModelEvent, ModelEventDispatcher};
 use crate::terminal::safe_mode_settings::{
-    get_secret_obfuscation_mode, SafeModeSettings, SafeModeSettingsChangedEvent,
+    SafeModeSettings, SafeModeSettingsChangedEvent, get_secret_obfuscation_mode,
 };
 use crate::terminal::view::ambient_agent::{AmbientAgentViewModel, AmbientAgentViewModelEvent};
 use crate::terminal::view::{
@@ -190,20 +190,20 @@ use crate::terminal::{ShellLaunchData, TerminalModel, TerminalView};
 use crate::ui_components::icons::Icon;
 use crate::util::link_detection::*;
 #[cfg(feature = "local_fs")]
-use crate::util::openable_file_type::{is_supported_image_file, FileTarget};
+use crate::util::openable_file_type::{FileTarget, is_supported_image_file};
+use crate::view_components::DismissibleToast;
 use crate::view_components::action_button::{
     ActionButton, ActionButtonTheme, ButtonSize, KeystrokeSource, NakedTheme, PrimaryTheme,
     SecondaryTheme,
 };
 use crate::view_components::compactible_action_button::CompactibleActionButton;
 use crate::view_components::find::FindEvent;
-use crate::view_components::DismissibleToast;
 use crate::workspace::{ForkAIConversationParams, ForkedConversationDestination, WorkspaceAction};
 use crate::workspaces::user_profiles::{UserProfileWithUID, UserProfiles};
 use crate::workspaces::user_workspaces::UserWorkspaces;
 use crate::{
-    report_error, report_if_error, send_telemetry_from_ctx, AIAgentTodoList, Appearance, FileEdit,
-    LLMPreferences, PrivacySettings, ToastStack,
+    AIAgentTodoList, Appearance, FileEdit, LLMPreferences, PrivacySettings, ToastStack,
+    report_error, report_if_error, send_telemetry_from_ctx,
 };
 
 /// The default display name used for the user if they have no associated display name.
@@ -1272,7 +1272,7 @@ impl AIBlock {
             &BlocklistAIHistoryModel::handle(ctx),
             |me, _, event, ctx| {
                 if event
-                    .terminal_view_id()
+                    .terminal_surface_id()
                     .is_none_or(|id| id == me.terminal_view_id)
                 {
                     match event {
@@ -4433,8 +4433,10 @@ impl AIBlock {
                             ..
                         } if speedbump_action_id == action_id && *shown.lock() => {
                             BlocklistAIPermissions::handle(ctx).update(ctx, |permissions, ctx| {
-                                report_if_error!(permissions
-                                    .set_should_autoexecute_readonly_commands(*checked, ctx));
+                                report_if_error!(
+                                    permissions
+                                        .set_should_autoexecute_readonly_commands(*checked, ctx)
+                                );
                             });
                         }
                         AutonomySettingSpeedbump::ShouldShowForFileAccess {
@@ -4486,8 +4488,12 @@ impl AIBlock {
                                     permission,
                                     AgentModeCodingPermissionsType::AllowReadingSpecificFiles
                                 ) {
-                                    report_if_error!(permissions
-                                        .add_filepath_to_code_read_allowlist(root_repo_path, ctx));
+                                    report_if_error!(
+                                        permissions.add_filepath_to_code_read_allowlist(
+                                            root_repo_path,
+                                            ctx
+                                        )
+                                    );
                                 }
                             });
                         }
@@ -5951,6 +5957,8 @@ pub enum AIBlockEvent {
     /// important because selecting across multiple blocks only supports text selections at the
     /// `AIBlock` level.
     ChildViewTextSelected,
+    /// Emitted when the `AIBlock`'s own block-level text selection state may have changed.
+    SelectionChanged,
     CopiedEmptyText,
     OpenSettings,
     #[cfg(feature = "local_fs")]
@@ -6217,6 +6225,7 @@ impl TypedActionView for AIBlock {
                 // If we have a selection, we should use the default cursor, even if it's over a link.
                 ctx.reset_cursor();
                 self.dismiss_ai_tooltips(ctx);
+                ctx.emit(AIBlockEvent::SelectionChanged);
             }
             AIBlockAction::CopyAIBlockCodeSnippet(text) => {
                 ctx.clipboard()
@@ -6387,9 +6396,11 @@ impl TypedActionView for AIBlock {
                     }
                 });
                 AISettings::handle(ctx).update(ctx, |settings, ctx| {
-                    report_if_error!(settings
-                        .rule_suggestions_enabled_internal
-                        .set_value(false, ctx));
+                    report_if_error!(
+                        settings
+                            .rule_suggestions_enabled_internal
+                            .set_value(false, ctx)
+                    );
                 });
                 ctx.notify();
             }

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -41,8 +41,8 @@ use secret_redaction::*;
 use serde::Serialize;
 use settings::Setting as _;
 use warp_core::features::FeatureFlag;
-use warp_core::ui::theme::Fill;
 use warp_core::ui::theme::color::internal_colors;
+use warp_core::ui::theme::Fill;
 use warp_editor::content::buffer::InitialBufferState;
 #[cfg(feature = "local_fs")]
 use warp_editor::content::edit::resolve_asset_source_relative_to_directory;
@@ -50,14 +50,14 @@ use warp_editor::render::element::VerticalExpansionBehavior;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::path::ShellFamily;
 use warpui::assets::asset_cache::AssetCache;
-use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::clipboard::ClipboardContent;
 use warpui::elements::{
-    ClippedScrollStateHandle, MainAxisAlignment, MainAxisSize, MouseStateHandle, SecretRange,
-    SelectionBound, SelectionHandle, TableStateHandle, get_rich_content_position_id,
+    get_rich_content_position_id, ClippedScrollStateHandle, MainAxisAlignment, MainAxisSize,
+    MouseStateHandle, SecretRange, SelectionBound, SelectionHandle, TableStateHandle,
 };
 use warpui::image_cache::ImageType;
 use warpui::keymap::FixedBinding;
+use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::text::SelectionType;
 use warpui::ui_components::button::{ButtonVariant, TextAndIcon, TextAndIconAlignment};
 use warpui::ui_components::components::{UiComponent, UiComponentStyles};
@@ -154,13 +154,13 @@ use crate::cloud_object::model::persistence::CloudModel;
 use crate::code::editor::comment_editor::create_readonly_comment_markdown_editor;
 use crate::code::editor::view::{CodeEditorEvent, CodeEditorRenderOptions, CodeEditorView};
 use crate::code::editor_management::CodeSource;
-use crate::code_review::CodeReviewTelemetryEvent;
 use crate::code_review::comment_rendering::{CommentViewCard, HeaderClickHandler};
 use crate::code_review::comments::{
-    AttachedReviewComment, CommentId, CommentOrigin, attach_pending_imported_comments,
-    convert_insert_review_comments,
+    attach_pending_imported_comments, convert_insert_review_comments, AttachedReviewComment,
+    CommentId, CommentOrigin,
 };
 use crate::code_review::telemetry_event::CodeReviewPaneEntrypoint;
+use crate::code_review::CodeReviewTelemetryEvent;
 use crate::editor::InteractionState;
 use crate::notebooks::editor::model::FileLinkResolutionContext;
 use crate::notebooks::editor::view::{EditorViewEvent, RichTextEditorView};
@@ -175,12 +175,12 @@ use crate::settings::{
 };
 use crate::settings_view::SettingsSection;
 use crate::terminal::find::TerminalFindModel;
-use crate::terminal::model::BlockId;
 use crate::terminal::model::secrets::RichContentSecretTooltipInfo;
 use crate::terminal::model::session::active_session::{ActiveSession, ActiveSessionEvent};
+use crate::terminal::model::BlockId;
 use crate::terminal::model_events::{ModelEvent, ModelEventDispatcher};
 use crate::terminal::safe_mode_settings::{
-    SafeModeSettings, SafeModeSettingsChangedEvent, get_secret_obfuscation_mode,
+    get_secret_obfuscation_mode, SafeModeSettings, SafeModeSettingsChangedEvent,
 };
 use crate::terminal::view::ambient_agent::{AmbientAgentViewModel, AmbientAgentViewModelEvent};
 use crate::terminal::view::{
@@ -190,20 +190,20 @@ use crate::terminal::{ShellLaunchData, TerminalModel, TerminalView};
 use crate::ui_components::icons::Icon;
 use crate::util::link_detection::*;
 #[cfg(feature = "local_fs")]
-use crate::util::openable_file_type::{FileTarget, is_supported_image_file};
-use crate::view_components::DismissibleToast;
+use crate::util::openable_file_type::{is_supported_image_file, FileTarget};
 use crate::view_components::action_button::{
     ActionButton, ActionButtonTheme, ButtonSize, KeystrokeSource, NakedTheme, PrimaryTheme,
     SecondaryTheme,
 };
 use crate::view_components::compactible_action_button::CompactibleActionButton;
 use crate::view_components::find::FindEvent;
+use crate::view_components::DismissibleToast;
 use crate::workspace::{ForkAIConversationParams, ForkedConversationDestination, WorkspaceAction};
 use crate::workspaces::user_profiles::{UserProfileWithUID, UserProfiles};
 use crate::workspaces::user_workspaces::UserWorkspaces;
 use crate::{
-    AIAgentTodoList, Appearance, FileEdit, LLMPreferences, PrivacySettings, ToastStack,
-    report_error, report_if_error, send_telemetry_from_ctx,
+    report_error, report_if_error, send_telemetry_from_ctx, AIAgentTodoList, Appearance, FileEdit,
+    LLMPreferences, PrivacySettings, ToastStack,
 };
 
 /// The default display name used for the user if they have no associated display name.
@@ -1734,10 +1734,13 @@ impl AIBlock {
                         for source in image_sources {
                             resolved_image_sources.insert(
                                 source.clone(),
-                                Some(resolve_asset_source_relative_to_directory(
-                                    &source,
-                                    cwd.as_deref().map(Path::new),
-                                )),
+                                Some(
+                                    resolve_asset_source_relative_to_directory(
+                                        &source,
+                                        cwd.as_deref().map(Path::new),
+                                    )
+                                    .with_local_file_content_version(),
+                                ),
                             );
                         }
 
@@ -2150,6 +2153,30 @@ impl AIBlock {
                 .footer_citation_chip_handles
                 .entry(citation.clone())
                 .or_default();
+        }
+        // Also register handles for memory citations derived from fetched_memories,
+        // which are synthesized at render time and never go through output.citations.
+        // Only register for the first exchange since that's the only one that shows them.
+        if let Some(conversation) = self.model.conversation(ctx) {
+            let is_first_exchange = conversation
+                .first_exchange()
+                .map(|e| Some(e.id) == self.model.exchange_id(ctx))
+                .unwrap_or(false);
+            if is_first_exchange {
+                for memory in conversation.fetched_memories() {
+                    if memory.memory_store_id.is_empty() || memory.memory_id.is_empty() {
+                        continue;
+                    }
+                    self.state_handles
+                        .footer_citation_chip_handles
+                        .entry(AIAgentCitation::AgentMemory {
+                            memory_store_id: memory.memory_store_id.clone(),
+                            memory_id: memory.memory_id.clone(),
+                            content: memory.content.clone(),
+                        })
+                        .or_default();
+                }
+            }
         }
 
         // Register element state for reasoning messages and track summarization timing.
@@ -3443,6 +3470,7 @@ impl AIBlock {
                         ctx,
                     );
                 });
+                self.yield_requested_action_focus_if_focused(&view, ctx);
                 ctx.notify();
             }
             RequestedCommandViewEvent::EnableAutoexecuteMode => {
@@ -3450,6 +3478,7 @@ impl AIBlock {
             }
             RequestedCommandViewEvent::Rejected => {
                 self.cancel_action(action_id, ctx);
+                self.yield_requested_action_focus_if_focused(&view, ctx);
             }
             RequestedCommandViewEvent::UpdatedExpansionState { is_expanded } => {
                 // We only care about expansion state updates when the command
@@ -3584,10 +3613,12 @@ impl AIBlock {
                 self.action_model.update(ctx, |action_model, ctx| {
                     action_model.execute_action(action_id, self.client_ids.conversation_id, ctx);
                 });
+                self.yield_requested_action_focus_if_focused(&view, ctx);
                 ctx.notify();
             }
             RequestedCommandViewEvent::Rejected => {
                 self.cancel_action(action_id, ctx);
+                self.yield_requested_action_focus_if_focused(&view, ctx);
             }
             RequestedCommandViewEvent::TextSelected => {
                 // If there's an ongoing text selection, clear all other selections within the
@@ -4433,10 +4464,8 @@ impl AIBlock {
                             ..
                         } if speedbump_action_id == action_id && *shown.lock() => {
                             BlocklistAIPermissions::handle(ctx).update(ctx, |permissions, ctx| {
-                                report_if_error!(
-                                    permissions
-                                        .set_should_autoexecute_readonly_commands(*checked, ctx)
-                                );
+                                report_if_error!(permissions
+                                    .set_should_autoexecute_readonly_commands(*checked, ctx));
                             });
                         }
                         AutonomySettingSpeedbump::ShouldShowForFileAccess {
@@ -4488,12 +4517,8 @@ impl AIBlock {
                                     permission,
                                     AgentModeCodingPermissionsType::AllowReadingSpecificFiles
                                 ) {
-                                    report_if_error!(
-                                        permissions.add_filepath_to_code_read_allowlist(
-                                            root_repo_path,
-                                            ctx
-                                        )
-                                    );
+                                    report_if_error!(permissions
+                                        .add_filepath_to_code_read_allowlist(root_repo_path, ctx));
                                 }
                             });
                         }
@@ -4767,6 +4792,15 @@ impl AIBlock {
         });
     }
 
+    fn yield_requested_action_focus_if_focused(
+        &self,
+        view: &ViewHandle<RequestedCommandView>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if view.is_self_or_child_focused(ctx) {
+            ctx.emit(AIBlockEvent::FocusTerminal);
+        }
+    }
     /// Tries to focus the AI block or one of its parts, if applicable.
     /// If the block doesn't need to be focused, focus is yielded
     /// back to the owning [`TerminalView`].
@@ -4898,6 +4932,32 @@ impl AIBlock {
                     .find_map(|comment| comment.rich_text_editor.as_ref(ctx).selected_text(ctx))
             })
             .or_else(|| self.selected_text.read().clone())
+            .filter(|selection| !selection.is_empty())
+    }
+
+    /// Test-only helper to set the block-level text selection, which is normally
+    /// written by the `SelectableArea` selection callback during a drag.
+    #[cfg(any(test, feature = "integration_tests"))]
+    pub fn set_block_level_selected_text_for_test(&self, text: Option<String>) {
+        *self.selected_text.write() = text;
+    }
+
+    /// Test-only helper that simulates a block-level text selection in this AI
+    /// block: it writes the selected text and emits the same
+    /// [`AIBlockEvent::SelectionChanged`] signal that
+    /// [`AIBlockAction::SelectText`] does, so the terminal view mirrors it into
+    /// the model's rich content selection (which the copy/insert paths read).
+    ///
+    /// This lets integration tests exercise the in-AI-block copy path without
+    /// depending on layout-sensitive pixel coordinates.
+    #[cfg(any(test, feature = "integration_tests"))]
+    pub fn simulate_text_selection_for_test(
+        &mut self,
+        text: Option<String>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        *self.selected_text.write() = text;
+        ctx.emit(AIBlockEvent::SelectionChanged);
     }
 
     /// Start a selection at the top left corner of the block's SelectableArea.
@@ -5957,7 +6017,11 @@ pub enum AIBlockEvent {
     /// important because selecting across multiple blocks only supports text selections at the
     /// `AIBlock` level.
     ChildViewTextSelected,
-    /// Emitted when the `AIBlock`'s own block-level text selection state may have changed.
+    /// Emitted when the `AIBlock`'s own (block-level) text selection state may
+    /// have changed. The terminal view uses this to keep the model's record of
+    /// which rich content block has an active selection in sync, so copy/insert
+    /// paths can find the selected text. Rich content selections are not tied to
+    /// the point-based model selection, so this signal is required.
     SelectionChanged,
     CopiedEmptyText,
     OpenSettings,
@@ -6225,6 +6289,9 @@ impl TypedActionView for AIBlock {
                 // If we have a selection, we should use the default cursor, even if it's over a link.
                 ctx.reset_cursor();
                 self.dismiss_ai_tooltips(ctx);
+                // Notify the terminal view so it can keep the model's record of which rich
+                // content block has an active selection in sync (rich content selections are
+                // not tied to the point-based model selection used for regular blocks).
                 ctx.emit(AIBlockEvent::SelectionChanged);
             }
             AIBlockAction::CopyAIBlockCodeSnippet(text) => {
@@ -6396,11 +6463,9 @@ impl TypedActionView for AIBlock {
                     }
                 });
                 AISettings::handle(ctx).update(ctx, |settings, ctx| {
-                    report_if_error!(
-                        settings
-                            .rule_suggestions_enabled_internal
-                            .set_value(false, ctx)
-                    );
+                    report_if_error!(settings
+                        .rule_suggestions_enabled_internal
+                        .set_value(false, ctx));
                 });
                 ctx.notify();
             }

--- a/app/src/ai/blocklist/inline_action/requested_command.rs
+++ b/app/src/ai/blocklist/inline_action/requested_command.rs
@@ -9,17 +9,17 @@ use parking_lot::FairMutex;
 use pathfinder_geometry::vector::vec2f;
 use settings::Setting as _;
 use warp_core::features::FeatureFlag;
-use warp_core::ui::Icon;
 use warp_core::ui::appearance::Appearance;
+use warp_core::ui::Icon;
 use warp_editor::render::element::VerticalExpansionBehavior;
 use warpui::clipboard::ClipboardContent;
 use warpui::elements::{
+    new_scrollable::{NewScrollable, ScrollableAppearance, SingleAxisConfig},
     Align, Border, ChildAnchor, ChildView, Clipped, ClippedScrollStateHandle, ConstrainedBox,
     Container, CornerRadius, CrossAxisAlignment, Dismiss, Empty, Expanded, Flex, MainAxisSize,
     MouseStateHandle, OffsetPositioning, ParentElement, PositionedElementAnchor,
     PositionedElementOffsetBounds, Radius, ScrollbarWidth, SelectableArea, SelectionHandle, Stack,
     Text,
-    new_scrollable::{NewScrollable, ScrollableAppearance, SingleAxisConfig},
 };
 use warpui::keymap::{Context, EditableBinding, FixedBinding, Keystroke};
 use warpui::ui_components::components::UiComponent as _;
@@ -31,9 +31,8 @@ use warpui::{
 use super::inline_action_icons::{self, icon_size};
 use crate::ai::agent::conversation::ConversationStatus;
 use crate::ai::agent::{
-    AIAgentActionId, AIAgentActionResult, AIAgentActionResultType, AIAgentActionType,
+    icons, AIAgentActionId, AIAgentActionResult, AIAgentActionResultType, AIAgentActionType,
     AIAgentCitation, AIAgentOutputMessageType, CallMCPToolResult, RequestCommandOutputResult,
-    icons,
 };
 use crate::ai::blocklist::action_model::AIActionStatus;
 use crate::ai::blocklist::block::cli_controller::{
@@ -41,13 +40,13 @@ use crate::ai::blocklist::block::cli_controller::{
 };
 use crate::ai::blocklist::block::view_impl::output::action_icon;
 use crate::ai::blocklist::block::view_impl::{
-    CONTENT_HORIZONTAL_PADDING, CONTENT_ITEM_VERTICAL_MARGIN,
     render_autonomy_checkbox_setting_speedbump_footer, render_citation, render_citation_chips,
+    CONTENT_HORIZONTAL_PADDING, CONTENT_ITEM_VERTICAL_MARGIN,
 };
 use crate::ai::blocklist::block::{AIBlockAction, AutonomySettingSpeedbump};
 use crate::ai::blocklist::inline_action::inline_action_header::{
-    ExpandedConfig, HeaderConfig, INLINE_ACTION_HORIZONTAL_PADDING, InteractionMode,
-    RightClickConfig,
+    ExpandedConfig, HeaderConfig, InteractionMode, RightClickConfig,
+    INLINE_ACTION_HORIZONTAL_PADDING,
 };
 use crate::ai::blocklist::model::{AIBlockModel, AIBlockModelHelper};
 use crate::ai::blocklist::{
@@ -59,18 +58,18 @@ use crate::code::editor::view::{CodeEditorEvent, CodeEditorRenderOptions, CodeEd
 use crate::editor::InteractionState;
 use crate::menu::{Event as MenuEvent, Menu, MenuItem, MenuItemFields, MenuVariant};
 use crate::settings::InputModeSettings;
-use crate::terminal::TerminalModel;
 use crate::terminal::block_list_viewport::InputMode;
 use crate::terminal::model::block::Block;
+use crate::terminal::TerminalModel;
 use crate::ui_components::blended_colors;
 use crate::ui_components::json_tree::{
-    JsonTreeColors, JsonTreeState, PathSegment, TREE_FONT_SIZE, render_json_tree,
+    render_json_tree, JsonTreeColors, JsonTreeState, PathSegment, TREE_FONT_SIZE,
 };
 use crate::util::bindings::keybinding_name_to_keystroke;
 use crate::view_components::action_button::{ButtonSize, KeystrokeSource, NakedTheme};
 use crate::view_components::compactible_action_button::{
-    CompactibleActionButton, LARGE_SIZE_SWITCH_THRESHOLD, MEDIUM_SIZE_SWITCH_THRESHOLD,
-    RenderCompactibleActionButton, SMALL_SIZE_SWITCH_THRESHOLD,
+    CompactibleActionButton, RenderCompactibleActionButton, LARGE_SIZE_SWITCH_THRESHOLD,
+    MEDIUM_SIZE_SWITCH_THRESHOLD, SMALL_SIZE_SWITCH_THRESHOLD,
 };
 use crate::view_components::compactible_split_action_button::CompactibleSplitActionButton;
 

--- a/app/src/ai/blocklist/inline_action/requested_command.rs
+++ b/app/src/ai/blocklist/inline_action/requested_command.rs
@@ -8,13 +8,18 @@ use lazy_static::lazy_static;
 use parking_lot::FairMutex;
 use pathfinder_geometry::vector::vec2f;
 use settings::Setting as _;
-use warp_core::ui::appearance::Appearance;
+use warp_core::features::FeatureFlag;
 use warp_core::ui::Icon;
+use warp_core::ui::appearance::Appearance;
 use warp_editor::render::element::VerticalExpansionBehavior;
+use warpui::clipboard::ClipboardContent;
 use warpui::elements::{
-    Align, Border, ChildView, Clipped, ConstrainedBox, Container, CornerRadius, CrossAxisAlignment,
-    Expanded, Flex, MainAxisSize, MouseStateHandle, OffsetPositioning, ParentElement, Radius,
-    ScrollbarWidth, SelectableArea, SelectionHandle, Stack, Text,
+    Align, Border, ChildAnchor, ChildView, Clipped, ClippedScrollStateHandle, ConstrainedBox,
+    Container, CornerRadius, CrossAxisAlignment, Dismiss, Empty, Expanded, Flex, MainAxisSize,
+    MouseStateHandle, OffsetPositioning, ParentElement, PositionedElementAnchor,
+    PositionedElementOffsetBounds, Radius, ScrollbarWidth, SelectableArea, SelectionHandle, Stack,
+    Text,
+    new_scrollable::{NewScrollable, ScrollableAppearance, SingleAxisConfig},
 };
 use warpui::keymap::{Context, EditableBinding, FixedBinding, Keystroke};
 use warpui::ui_components::components::UiComponent as _;
@@ -26,8 +31,9 @@ use warpui::{
 use super::inline_action_icons::{self, icon_size};
 use crate::ai::agent::conversation::ConversationStatus;
 use crate::ai::agent::{
-    icons, AIAgentActionId, AIAgentActionResult, AIAgentActionResultType, AIAgentActionType,
+    AIAgentActionId, AIAgentActionResult, AIAgentActionResultType, AIAgentActionType,
     AIAgentCitation, AIAgentOutputMessageType, CallMCPToolResult, RequestCommandOutputResult,
+    icons,
 };
 use crate::ai::blocklist::action_model::AIActionStatus;
 use crate::ai::blocklist::block::cli_controller::{
@@ -35,13 +41,13 @@ use crate::ai::blocklist::block::cli_controller::{
 };
 use crate::ai::blocklist::block::view_impl::output::action_icon;
 use crate::ai::blocklist::block::view_impl::{
-    render_autonomy_checkbox_setting_speedbump_footer, render_citation, render_citation_chips,
     CONTENT_HORIZONTAL_PADDING, CONTENT_ITEM_VERTICAL_MARGIN,
+    render_autonomy_checkbox_setting_speedbump_footer, render_citation, render_citation_chips,
 };
 use crate::ai::blocklist::block::{AIBlockAction, AutonomySettingSpeedbump};
 use crate::ai::blocklist::inline_action::inline_action_header::{
-    ExpandedConfig, HeaderConfig, InteractionMode, RightClickConfig,
-    INLINE_ACTION_HORIZONTAL_PADDING,
+    ExpandedConfig, HeaderConfig, INLINE_ACTION_HORIZONTAL_PADDING, InteractionMode,
+    RightClickConfig,
 };
 use crate::ai::blocklist::model::{AIBlockModel, AIBlockModelHelper};
 use crate::ai::blocklist::{
@@ -51,18 +57,20 @@ use crate::ai::blocklist::{
 use crate::cmd_or_ctrl_shift;
 use crate::code::editor::view::{CodeEditorEvent, CodeEditorRenderOptions, CodeEditorView};
 use crate::editor::InteractionState;
-use crate::menu::{Event as MenuEvent, Menu, MenuItemFields, MenuVariant};
+use crate::menu::{Event as MenuEvent, Menu, MenuItem, MenuItemFields, MenuVariant};
 use crate::settings::InputModeSettings;
+use crate::terminal::TerminalModel;
 use crate::terminal::block_list_viewport::InputMode;
 use crate::terminal::model::block::Block;
-use crate::terminal::TerminalModel;
 use crate::ui_components::blended_colors;
-use crate::ui_components::json_tree::{JsonTreeState, PathSegment};
+use crate::ui_components::json_tree::{
+    JsonTreeColors, JsonTreeState, PathSegment, TREE_FONT_SIZE, render_json_tree,
+};
 use crate::util::bindings::keybinding_name_to_keystroke;
 use crate::view_components::action_button::{ButtonSize, KeystrokeSource, NakedTheme};
 use crate::view_components::compactible_action_button::{
-    CompactibleActionButton, RenderCompactibleActionButton, LARGE_SIZE_SWITCH_THRESHOLD,
-    MEDIUM_SIZE_SWITCH_THRESHOLD, SMALL_SIZE_SWITCH_THRESHOLD,
+    CompactibleActionButton, LARGE_SIZE_SWITCH_THRESHOLD, MEDIUM_SIZE_SWITCH_THRESHOLD,
+    RenderCompactibleActionButton, SMALL_SIZE_SWITCH_THRESHOLD,
 };
 use crate::view_components::compactible_split_action_button::CompactibleSplitActionButton;
 
@@ -90,7 +98,6 @@ const VIEWING_MCP_TOOL_DETAIL_MESSAGE: &str = "Viewing MCP tool call detail";
 const EDIT_COMMAND_ACTION_NAME: &str = "requested_command:edit";
 
 const EDIT_MODE_OPEN_KEYMAP_CONTEXT: &str = "RequestedCommandViewEditModeOpen";
-const REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT: &str = "RequestedActionBlocked";
 
 const SCROLLBAR_WIDTH: ScrollbarWidth = ScrollbarWidth::Auto;
 const MAX_EDITOR_HEIGHT: f32 = 500.0;
@@ -121,42 +128,32 @@ pub fn init(app: &mut AppContext) {
         FixedBinding::new(
             "ctrl-c",
             RequestedCommandViewAction::Reject,
-            id!(RequestedCommandView::ui_name()) & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT),
+            id!(RequestedCommandView::ui_name()),
         ),
         FixedBinding::new(
             "enter",
             RequestedCommandViewAction::Accept,
-            id!(RequestedCommandView::ui_name())
-                & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT)
-                & !id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
+            id!(RequestedCommandView::ui_name()) & !id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
         ),
         FixedBinding::new(
             "numpadenter",
             RequestedCommandViewAction::Accept,
-            id!(RequestedCommandView::ui_name())
-                & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT)
-                & !id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
+            id!(RequestedCommandView::ui_name()) & !id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
         ),
         FixedBinding::new(
             "cmdorctrl-enter",
             RequestedCommandViewAction::Accept,
-            id!(RequestedCommandView::ui_name())
-                & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT)
-                & id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
+            id!(RequestedCommandView::ui_name()) & id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
         ),
         FixedBinding::new(
             "escape",
             RequestedCommandViewAction::CloseEditMode,
-            id!(RequestedCommandView::ui_name())
-                & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT)
-                & id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
+            id!(RequestedCommandView::ui_name()) & id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
         ),
         FixedBinding::new(
             "tab",
             RequestedCommandViewAction::FocusEditor,
-            id!(RequestedCommandView::ui_name())
-                & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT)
-                & id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
+            id!(RequestedCommandView::ui_name()) & id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
         ),
     ]);
 
@@ -167,28 +164,18 @@ pub fn init(app: &mut AppContext) {
     )
     .with_key_binding(cmd_or_ctrl_shift("e"))
     .with_context_predicate(
-        id!(RequestedCommandView::ui_name())
-            & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT)
-            & !id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
+        id!(RequestedCommandView::ui_name()) & !id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
     )]);
 }
 
-/// Structured representation of an MCP tool call request, held so the
-/// detail view can render it as a JSON tree rather than a flat string.
-// Fields are consumed by the MCP tree-rendering layer.
-#[allow(dead_code)]
+/// Structured representation of an MCP tool call request for JSON tree rendering.
+///
+/// The tool name is derivable from `command_text` and is not duplicated here.
 pub struct McpRequest {
-    pub name: String,
     pub args: serde_json::Value,
 }
 
 /// The normalized, renderable form of a `CallMCPToolResult`.
-///
-/// Converts the raw result (which may carry text content, structured JSON, an
-/// error message, or a cancellation signal) into a form the tree-rendering
-/// layer can act on without further conditionals.
-// Consumed by the MCP tree-rendering layer.
-#[allow(dead_code)]
 pub(crate) enum McpRenderable {
     Tree(serde_json::Value),
     Error(String),
@@ -198,10 +185,7 @@ pub(crate) enum McpRenderable {
 /// Normalizes a `CallMCPToolResult` into a `McpRenderable` for display.
 ///
 /// Prefers `structured_content` when present; otherwise tries to parse joined
-/// text content as JSON; falls back to wrapping the raw text as a JSON
-/// string value so the tree renderer always receives a `serde_json::Value`.
-// Called by the MCP tree-rendering layer.
-#[allow(dead_code)]
+/// text content as JSON; falls back to wrapping the raw text as a JSON string value.
 pub(crate) fn mcp_result_to_renderable(result: &CallMCPToolResult) -> McpRenderable {
     match result {
         CallMCPToolResult::Success { result } => {
@@ -290,6 +274,21 @@ pub enum RequestedCommandViewAction {
         path: Vec<PathSegment>,
         tree: McpTree,
     },
+    /// Write the given JSON text to the system clipboard.
+    CopyJsonToClipboard {
+        text: String,
+    },
+    /// Opens the right-click context menu for an MCP JSON tree row, carrying
+    /// the serialized subtree JSON and the position anchor ID of the clicked
+    /// row so the menu can be positioned below it.
+    ShowMcpContextMenu {
+        json_text: String,
+        anchor_id: String,
+    },
+    /// Copy the currently selected MCP tree text to the clipboard.
+    CopyMcpSelection,
+    /// Dismiss the MCP JSON tree right-click context menu.
+    CloseMcpContextMenu,
 }
 
 pub struct RequestedCommandView {
@@ -343,6 +342,14 @@ pub struct RequestedCommandView {
     mcp_request: Option<McpRequest>,
     mcp_request_tree_state: JsonTreeState,
     mcp_response_tree_state: JsonTreeState,
+    // Scroll state for the MCP JSON tree body, shared across renders to preserve scroll position.
+    mcp_scroll_state: ClippedScrollStateHandle,
+    // Right-click context menu for MCP JSON tree rows (Copy / Copy JSON items).
+    mcp_context_menu: ViewHandle<Menu<RequestedCommandViewAction>>,
+    mcp_context_menu_open: bool,
+    // The SavePosition anchor ID of the row that was last right-clicked, used
+    // to position the context menu below the correct row.
+    mcp_context_menu_anchor_id: Option<String>,
 }
 
 impl RequestedCommandView {
@@ -549,6 +556,21 @@ impl RequestedCommandView {
             MenuEvent::ItemSelected | MenuEvent::ItemHovered => {}
         });
 
+        let mcp_context_menu = ctx.add_typed_action_view(|ctx| {
+            let theme = Appearance::as_ref(ctx).theme();
+            Menu::new()
+                .with_menu_variant(MenuVariant::Fixed)
+                .with_border(Border::all(1.).with_border_fill(theme.outline()))
+                .prevent_interaction_with_other_elements()
+        });
+        ctx.subscribe_to_view(&mcp_context_menu, |me, _menu, event, ctx| match event {
+            MenuEvent::Close { .. } => {
+                me.mcp_context_menu_open = false;
+                ctx.notify();
+            }
+            MenuEvent::ItemSelected | MenuEvent::ItemHovered => {}
+        });
+
         Self {
             command_text: String::new(),
             editor: None,
@@ -580,6 +602,10 @@ impl RequestedCommandView {
             mcp_request: None,
             mcp_request_tree_state: Default::default(),
             mcp_response_tree_state: Default::default(),
+            mcp_scroll_state: Default::default(),
+            mcp_context_menu,
+            mcp_context_menu_open: false,
+            mcp_context_menu_anchor_id: None,
         }
     }
 
@@ -721,13 +747,6 @@ impl RequestedCommandView {
         format!("RequestedCommandView-{prefix}-accept-split")
     }
 
-    fn is_waiting_for_user_confirmation(&self, app: &AppContext) -> bool {
-        self.action_model
-            .as_ref(app)
-            .get_action_status(&self.action_id)
-            .is_some_and(|status| status.is_blocked())
-    }
-
     pub fn is_header_expanded(&self) -> bool {
         self.is_header_expanded
     }
@@ -750,7 +769,9 @@ impl RequestedCommandView {
             let Some(mouse_state_handle) =
                 self.citation_state_handles.get(copied_citation).cloned()
             else {
-                log::warn!("Tried to retrieve mouse state handle for citation, but no mouse state handle exists.");
+                log::warn!(
+                    "Tried to retrieve mouse state handle for citation, but no mouse state handle exists."
+                );
                 return None;
             };
             render_citation(
@@ -1082,11 +1103,8 @@ impl RequestedCommandView {
     }
 
     /// Stores the structured MCP tool request data for JSON tree rendering.
-    ///
-    /// Called each time a stream update arrives so the view always reflects
-    /// the latest known arguments.
-    pub(crate) fn update_mcp_request(&mut self, name: String, args: serde_json::Value) {
-        self.mcp_request = Some(McpRequest { name, args });
+    pub(crate) fn update_mcp_request(&mut self, args: serde_json::Value) {
+        self.mcp_request = Some(McpRequest { args });
     }
 
     /// Extracts the tool name from MCP tool command text, removing parameters.
@@ -1545,59 +1563,283 @@ impl View for RequestedCommandView {
         }
 
         if should_render_mcp_content {
-            let command_text = self.command_text();
-            let content_text = if let Some(AIAgentActionResultType::CallMCPTool(result)) =
-                action_status
-                    .as_ref()
-                    .and_then(|status| status.finished_result().map(|result| &result.result))
-            {
-                // If we have a result, show the JSON response.
-                let result_text = match result {
-                    CallMCPToolResult::Success { result } => serde_json::to_string_pretty(result)
-                        .unwrap_or_else(|_| "Error formatting JSON".to_string()),
-                    CallMCPToolResult::Error(error) => {
-                        format!("Error: {error}")
-                    }
-                    CallMCPToolResult::Cancelled => "Tool call was cancelled".to_string(),
+            if FeatureFlag::McpJsonTreeView.is_enabled() {
+                let colors = JsonTreeColors::from_theme(theme);
+                let font_family = appearance.ui_font_family();
+
+                let mut tree_column =
+                    Flex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+
+                // Request section: show the tree if args are known, or a placeholder.
+                let request_section: Box<dyn Element> = if let Some(mcp_request) = &self.mcp_request
+                {
+                    let on_toggle_req: Arc<
+                        dyn Fn(&mut EventContext, Vec<PathSegment>, usize) + Send + Sync,
+                    > = Arc::new(|ctx, path, _depth| {
+                        ctx.dispatch_typed_action(RequestedCommandViewAction::ToggleJsonNode {
+                            path,
+                            tree: McpTree::Request,
+                        });
+                    });
+                    let on_copy_req: Arc<
+                        dyn Fn(&mut EventContext, Vec<PathSegment>, serde_json::Value, String)
+                            + Send
+                            + Sync,
+                    > = Arc::new(|ctx, _path, value, anchor_id| {
+                        let json_text = serde_json::to_string_pretty(&value).unwrap_or_default();
+                        ctx.dispatch_typed_action(RequestedCommandViewAction::ShowMcpContextMenu {
+                            json_text,
+                            anchor_id,
+                        });
+                    });
+                    let on_toggle_string_req: Arc<
+                        dyn Fn(&mut EventContext, Vec<PathSegment>) + Send + Sync,
+                    > = Arc::new(|ctx, path| {
+                        ctx.dispatch_typed_action(RequestedCommandViewAction::ToggleJsonString {
+                            path,
+                            tree: McpTree::Request,
+                        });
+                    });
+                    render_json_tree(
+                        &mcp_request.args,
+                        Some("Request"),
+                        &self.mcp_request_tree_state,
+                        &colors,
+                        &format!("{}-req", self.position_id_prefix),
+                        on_toggle_req,
+                        on_toggle_string_req,
+                        on_copy_req,
+                        appearance,
+                    )
+                } else {
+                    let mut col =
+                        Flex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+                    col.add_child(
+                        Text::new_inline("Request".to_string(), font_family, TREE_FONT_SIZE)
+                            .with_color(colors.annotation)
+                            .soft_wrap(false)
+                            .finish(),
+                    );
+                    col.add_child(
+                        Text::new_inline("(no arguments)".to_string(), font_family, TREE_FONT_SIZE)
+                            .with_color(colors.annotation)
+                            .soft_wrap(false)
+                            .finish(),
+                    );
+                    col.finish()
                 };
-                format!("{command_text}\n\nResponse: {result_text}")
-            } else if self.is_header_expanded {
-                command_text.to_string()
+                tree_column.add_child(request_section);
+
+                // Response section: present only when a finished result exists.
+                if let Some(AIAgentActionResultType::CallMCPTool(result)) = action_status
+                    .as_ref()
+                    .and_then(|status| status.finished_result().map(|r| &r.result))
+                {
+                    tree_column.add_child(
+                        Container::new(Empty::new().finish())
+                            .with_padding_top(8.)
+                            .finish(),
+                    );
+
+                    let renderable = mcp_result_to_renderable(result);
+                    let response_element: Box<dyn Element> = match renderable {
+                        McpRenderable::Tree(value) => {
+                            let on_toggle_resp: Arc<
+                                dyn Fn(&mut EventContext, Vec<PathSegment>, usize) + Send + Sync,
+                            > = Arc::new(|ctx, path, _depth| {
+                                ctx.dispatch_typed_action(
+                                    RequestedCommandViewAction::ToggleJsonNode {
+                                        path,
+                                        tree: McpTree::Response,
+                                    },
+                                );
+                            });
+                            let on_copy_resp: Arc<
+                                dyn Fn(
+                                        &mut EventContext,
+                                        Vec<PathSegment>,
+                                        serde_json::Value,
+                                        String,
+                                    ) + Send
+                                    + Sync,
+                            > = Arc::new(|ctx, _path, value, anchor_id| {
+                                let json_text =
+                                    serde_json::to_string_pretty(&value).unwrap_or_default();
+                                ctx.dispatch_typed_action(
+                                    RequestedCommandViewAction::ShowMcpContextMenu {
+                                        json_text,
+                                        anchor_id,
+                                    },
+                                );
+                            });
+                            let on_toggle_string_resp: Arc<
+                                dyn Fn(&mut EventContext, Vec<PathSegment>) + Send + Sync,
+                            > = Arc::new(|ctx, path| {
+                                ctx.dispatch_typed_action(
+                                    RequestedCommandViewAction::ToggleJsonString {
+                                        path,
+                                        tree: McpTree::Response,
+                                    },
+                                );
+                            });
+                            render_json_tree(
+                                &value,
+                                Some("Response"),
+                                &self.mcp_response_tree_state,
+                                &colors,
+                                &format!("{}-resp", self.position_id_prefix),
+                                on_toggle_resp,
+                                on_toggle_string_resp,
+                                on_copy_resp,
+                                appearance,
+                            )
+                        }
+                        McpRenderable::Error(e) => {
+                            let mut col = Flex::column()
+                                .with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+                            col.add_child(
+                                Text::new_inline(
+                                    "Response".to_string(),
+                                    font_family,
+                                    TREE_FONT_SIZE,
+                                )
+                                .with_color(colors.annotation)
+                                .soft_wrap(false)
+                                .finish(),
+                            );
+                            col.add_child(
+                                Text::new(format!("Error: {e}"), font_family, TREE_FONT_SIZE)
+                                    .with_color(theme.ui_error_color())
+                                    .with_selectable(true)
+                                    .finish(),
+                            );
+                            col.finish()
+                        }
+                        McpRenderable::Cancelled => {
+                            let mut col = Flex::column()
+                                .with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+                            col.add_child(
+                                Text::new_inline(
+                                    "Response".to_string(),
+                                    font_family,
+                                    TREE_FONT_SIZE,
+                                )
+                                .with_color(colors.annotation)
+                                .soft_wrap(false)
+                                .finish(),
+                            );
+                            col.add_child(
+                                Text::new_inline(
+                                    "Cancelled".to_string(),
+                                    font_family,
+                                    TREE_FONT_SIZE,
+                                )
+                                .with_color(colors.annotation)
+                                .soft_wrap(false)
+                                .finish(),
+                            );
+                            col.finish()
+                        }
+                    };
+                    tree_column.add_child(response_element);
+                }
+
+                // Height cap prevents a large tree from pushing subsequent blocks off-screen.
+                // Padding is on the outer Container so it applies outside the scrollable viewport.
+                let scrollable = NewScrollable::vertical(
+                    SingleAxisConfig::Clipped {
+                        handle: self.mcp_scroll_state.clone(),
+                        child: tree_column.finish(),
+                    },
+                    theme.nonactive_ui_detail().into(),
+                    theme.active_ui_detail().into(),
+                    warpui::elements::Fill::None,
+                )
+                .with_vertical_scrollbar(ScrollableAppearance::new(ScrollbarWidth::Auto, false))
+                .with_propagate_mousewheel_if_not_handled(true)
+                .finish();
+
+                let constrained = ConstrainedBox::new(scrollable)
+                    .with_max_height(MAX_EDITOR_HEIGHT)
+                    .finish();
+
+                // SelectableArea enables text drag-selection across the tree rows.
+                // Per-row Hoverables receive LeftMouseDown before SelectableArea sees it
+                // (depth-first dispatch), so click handlers are unaffected.
+                let mcp_selected_text = self.mcp_content_selected_text.clone();
+                let selectable_content = SelectableArea::new(
+                    self.mcp_content_selection_handle.clone(),
+                    #[allow(clippy::unwrap_used)]
+                    move |selection_args, _, _| {
+                        *mcp_selected_text.write().unwrap() = selection_args.selection;
+                    },
+                    constrained,
+                )
+                .on_selection_updated(|ctx, _| {
+                    ctx.dispatch_typed_action(RequestedCommandViewAction::SelectText);
+                })
+                .finish();
+
+                content.add_child(
+                    Container::new(selectable_content)
+                        .with_horizontal_padding(INLINE_ACTION_HORIZONTAL_PADDING)
+                        .with_vertical_padding(REQUESTED_COMMAND_BODY_VERTICAL_PADDING)
+                        .with_background(theme.background())
+                        .with_corner_radius(CornerRadius::with_bottom(Radius::Pixels(8.)))
+                        .finish(),
+                );
             } else {
-                self.extract_mcp_tool_name(command_text)
-            };
-
-            let text_element = Text::new(
-                content_text,
-                appearance.monospace_font_family(),
-                appearance.monospace_font_size(),
-            )
-            .with_color(blended_colors::text_main(theme, theme.background()))
-            .with_selectable(true)
-            .finish();
-
-            let mcp_selected_text = self.mcp_content_selected_text.clone();
-            let selectable_text = SelectableArea::new(
-                self.mcp_content_selection_handle.clone(),
-                #[allow(clippy::unwrap_used)]
-                move |selection_args, _, _| {
-                    *mcp_selected_text.write().unwrap() = selection_args.selection;
-                },
-                text_element,
-            )
-            .on_selection_updated(|ctx, _| {
-                ctx.dispatch_typed_action(RequestedCommandViewAction::SelectText);
-            })
-            .finish();
-
-            content.add_child(
-                Container::new(selectable_text)
-                    .with_horizontal_padding(INLINE_ACTION_HORIZONTAL_PADDING)
-                    .with_vertical_padding(REQUESTED_COMMAND_BODY_VERTICAL_PADDING)
-                    .with_background(theme.background())
-                    .with_corner_radius(CornerRadius::with_bottom(Radius::Pixels(8.)))
-                    .finish(),
-            );
+                // Fallback: flat pretty-printed JSON.
+                let command_text = self.command_text();
+                let content_text = if let Some(AIAgentActionResultType::CallMCPTool(result)) =
+                    action_status
+                        .as_ref()
+                        .and_then(|status| status.finished_result().map(|result| &result.result))
+                {
+                    let result_text = match result {
+                        CallMCPToolResult::Success { result } => {
+                            serde_json::to_string_pretty(result)
+                                .unwrap_or_else(|_| "Error formatting JSON".to_string())
+                        }
+                        CallMCPToolResult::Error(error) => format!("Error: {error}"),
+                        CallMCPToolResult::Cancelled => "Tool call was cancelled".to_string(),
+                    };
+                    format!("{command_text}\n\nResponse: {result_text}")
+                } else if self.is_header_expanded {
+                    command_text.to_string()
+                } else {
+                    self.extract_mcp_tool_name(command_text)
+                };
+                let text_element = Text::new(
+                    content_text,
+                    appearance.monospace_font_family(),
+                    appearance.monospace_font_size(),
+                )
+                .with_color(blended_colors::text_main(theme, theme.background()))
+                .with_selectable(true)
+                .finish();
+                let mcp_selected_text = self.mcp_content_selected_text.clone();
+                let selectable_text = SelectableArea::new(
+                    self.mcp_content_selection_handle.clone(),
+                    #[allow(clippy::unwrap_used)]
+                    move |selection_args, _, _| {
+                        *mcp_selected_text.write().unwrap() = selection_args.selection;
+                    },
+                    text_element,
+                )
+                .on_selection_updated(|ctx, _| {
+                    ctx.dispatch_typed_action(RequestedCommandViewAction::SelectText);
+                })
+                .finish();
+                content.add_child(
+                    Container::new(selectable_text)
+                        .with_horizontal_padding(INLINE_ACTION_HORIZONTAL_PADDING)
+                        .with_vertical_padding(REQUESTED_COMMAND_BODY_VERTICAL_PADDING)
+                        .with_background(theme.background())
+                        .with_corner_radius(CornerRadius::with_bottom(Radius::Pixels(8.)))
+                        .finish(),
+                );
+            }
         }
 
         if let Some(footer) = self.maybe_render_footer(app) {
@@ -1679,21 +1921,40 @@ impl View for RequestedCommandView {
                 OffsetPositioning::offset_from_save_position_element(
                     Self::get_position_id_for_accept_split_button(&self.position_id_prefix),
                     vec2f(0., 8.),
-                    warpui::elements::PositionedElementOffsetBounds::WindowByPosition,
-                    warpui::elements::PositionedElementAnchor::BottomRight,
-                    warpui::elements::ChildAnchor::TopRight,
+                    PositionedElementOffsetBounds::WindowByPosition,
+                    PositionedElementAnchor::BottomRight,
+                    ChildAnchor::TopRight,
                 ),
             );
+        }
+
+        if self.mcp_context_menu_open {
+            if let Some(anchor_id) = &self.mcp_context_menu_anchor_id {
+                root_stack.add_positioned_child(
+                    Dismiss::new(ChildView::new(&self.mcp_context_menu).finish())
+                        .on_dismiss(|ctx, _app| {
+                            ctx.dispatch_typed_action(
+                                RequestedCommandViewAction::CloseMcpContextMenu,
+                            );
+                        })
+                        .prevent_interaction_with_other_elements()
+                        .finish(),
+                    OffsetPositioning::offset_from_save_position_element(
+                        anchor_id.as_str(),
+                        vec2f(0., 0.),
+                        PositionedElementOffsetBounds::WindowByPosition,
+                        PositionedElementAnchor::BottomLeft,
+                        ChildAnchor::TopLeft,
+                    ),
+                );
+            }
         }
 
         root_stack.finish()
     }
 
-    fn keymap_context(&self, app: &AppContext) -> Context {
+    fn keymap_context(&self, _app: &AppContext) -> Context {
         let mut context = Self::default_keymap_context();
-        if self.is_waiting_for_user_confirmation(app) {
-            context.set.insert(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT);
-        }
 
         if self.is_editing {
             context.set.insert(EDIT_MODE_OPEN_KEYMAP_CONTEXT);
@@ -1706,19 +1967,6 @@ impl TypedActionView for RequestedCommandView {
     type Action = RequestedCommandViewAction;
 
     fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
-        if matches!(
-            action,
-            RequestedCommandViewAction::Accept
-                | RequestedCommandViewAction::AcceptAndAutoExecute
-                | RequestedCommandViewAction::ToggleAcceptMenu
-                | RequestedCommandViewAction::Reject
-                | RequestedCommandViewAction::OpenEditMode
-                | RequestedCommandViewAction::CloseEditMode
-                | RequestedCommandViewAction::FocusEditor
-        ) && !self.is_waiting_for_user_confirmation(ctx)
-        {
-            return;
-        }
         match action {
             RequestedCommandViewAction::Accept => {
                 self.commit_editor_contents(ctx);
@@ -1750,6 +1998,8 @@ impl TypedActionView for RequestedCommandView {
                 ctx.emit(RequestedCommandViewEvent::TextSelected);
             }
             RequestedCommandViewAction::ToggleJsonNode { path, tree } => {
+                // A node's depth in the tree always equals its path length: the root
+                // has an empty path (depth 0) and each level down adds one segment.
                 let depth = path.len();
                 match tree {
                     McpTree::Request => self.mcp_request_tree_state.toggle(path, depth),
@@ -1762,6 +2012,60 @@ impl TypedActionView for RequestedCommandView {
                     McpTree::Request => self.mcp_request_tree_state.toggle_string(path),
                     McpTree::Response => self.mcp_response_tree_state.toggle_string(path),
                 }
+                ctx.notify();
+            }
+            RequestedCommandViewAction::CopyJsonToClipboard { text } => {
+                ctx.clipboard()
+                    .write(ClipboardContent::plain_text(text.clone()));
+            }
+            RequestedCommandViewAction::ShowMcpContextMenu {
+                json_text,
+                anchor_id,
+            } => {
+                // Determine whether the Copy item should be enabled based on whether
+                // there is currently a non-empty text selection in the MCP section.
+                #[allow(clippy::unwrap_used)]
+                let has_selection = self
+                    .mcp_content_selected_text
+                    .read()
+                    .unwrap()
+                    .as_deref()
+                    .is_some_and(|t| !t.is_empty());
+
+                let copy_item: MenuItem<RequestedCommandViewAction> = MenuItemFields::new("Copy")
+                    .with_on_select_action(RequestedCommandViewAction::CopyMcpSelection)
+                    .with_disabled(!has_selection)
+                    .into_item();
+
+                let json_for_menu = json_text.clone();
+                let copy_json_item: MenuItem<RequestedCommandViewAction> =
+                    MenuItemFields::new("Copy JSON")
+                        .with_on_select_action(RequestedCommandViewAction::CopyJsonToClipboard {
+                            text: json_for_menu,
+                        })
+                        .into_item();
+
+                self.mcp_context_menu.update(ctx, move |menu, ctx| {
+                    menu.set_items(vec![copy_item, copy_json_item], ctx);
+                });
+                self.mcp_context_menu_anchor_id = Some(anchor_id.clone());
+                self.mcp_context_menu_open = true;
+                ctx.notify();
+            }
+            RequestedCommandViewAction::CopyMcpSelection => {
+                #[allow(clippy::unwrap_used)]
+                if let Some(text) = self
+                    .mcp_content_selected_text
+                    .read()
+                    .unwrap()
+                    .clone()
+                    .filter(|t| !t.is_empty())
+                {
+                    ctx.clipboard().write(ClipboardContent::plain_text(text));
+                }
+            }
+            RequestedCommandViewAction::CloseMcpContextMenu => {
+                self.mcp_context_menu_open = false;
                 ctx.notify();
             }
         }

--- a/app/src/ai/blocklist/inline_action/requested_command.rs
+++ b/app/src/ai/blocklist/inline_action/requested_command.rs
@@ -63,7 +63,8 @@ use crate::terminal::model::block::Block;
 use crate::terminal::TerminalModel;
 use crate::ui_components::blended_colors;
 use crate::ui_components::json_tree::{
-    render_json_tree, JsonTreeColors, JsonTreeState, PathSegment, TREE_FONT_SIZE,
+    render_json_tree, CopyJsonFn, JsonTreeColors, JsonTreeState, PathSegment, ToggleFn,
+    ToggleStringFn, TREE_FONT_SIZE,
 };
 use crate::util::bindings::keybinding_name_to_keystroke;
 use crate::view_components::action_button::{ButtonSize, KeystrokeSource, NakedTheme};
@@ -1465,10 +1466,6 @@ impl RequestedCommandView {
             .get_action_status(&self.action_id)
             .is_some_and(|status| status.is_blocked())
     }
-
-    fn get_mcp_section_position_id(prefix: &str) -> String {
-        format!("RequestedCommandView-{prefix}-mcp-section")
-    }
 }
 
 pub(crate) fn header_message_for_user_take_over_reason(
@@ -1596,28 +1593,20 @@ impl View for RequestedCommandView {
                 // Request section: show the tree if args are known, or a placeholder.
                 let request_section: Box<dyn Element> = if let Some(mcp_request) = &self.mcp_request
                 {
-                    let on_toggle_req: Arc<
-                        dyn Fn(&mut EventContext, Vec<PathSegment>, usize) + Send + Sync,
-                    > = Arc::new(|ctx, path, _depth| {
+                    let on_toggle_req: Arc<ToggleFn> = Arc::new(|ctx, path, _depth| {
                         ctx.dispatch_typed_action(RequestedCommandViewAction::ToggleJsonNode {
                             path,
                             tree: McpTree::Request,
                         });
                     });
-                    let on_copy_req: Arc<
-                        dyn Fn(&mut EventContext, Vec<PathSegment>, serde_json::Value, String)
-                            + Send
-                            + Sync,
-                    > = Arc::new(|ctx, _path, value, anchor_id| {
+                    let on_copy_req: Arc<CopyJsonFn> = Arc::new(|ctx, _path, value, anchor_id| {
                         let json_text = serde_json::to_string_pretty(&value).unwrap_or_default();
                         ctx.dispatch_typed_action(RequestedCommandViewAction::ShowMcpContextMenu {
                             json_text,
                             anchor_id,
                         });
                     });
-                    let on_toggle_string_req: Arc<
-                        dyn Fn(&mut EventContext, Vec<PathSegment>) + Send + Sync,
-                    > = Arc::new(|ctx, path| {
+                    let on_toggle_string_req: Arc<ToggleStringFn> = Arc::new(|ctx, path| {
                         ctx.dispatch_typed_action(RequestedCommandViewAction::ToggleJsonString {
                             path,
                             tree: McpTree::Request,
@@ -1667,9 +1656,7 @@ impl View for RequestedCommandView {
                     let renderable = mcp_result_to_renderable(result);
                     let response_element: Box<dyn Element> = match renderable {
                         McpRenderable::Tree(value) => {
-                            let on_toggle_resp: Arc<
-                                dyn Fn(&mut EventContext, Vec<PathSegment>, usize) + Send + Sync,
-                            > = Arc::new(|ctx, path, _depth| {
+                            let on_toggle_resp: Arc<ToggleFn> = Arc::new(|ctx, path, _depth| {
                                 ctx.dispatch_typed_action(
                                     RequestedCommandViewAction::ToggleJsonNode {
                                         path,
@@ -1677,34 +1664,26 @@ impl View for RequestedCommandView {
                                     },
                                 );
                             });
-                            let on_copy_resp: Arc<
-                                dyn Fn(
-                                        &mut EventContext,
-                                        Vec<PathSegment>,
-                                        serde_json::Value,
-                                        String,
-                                    ) + Send
-                                    + Sync,
-                            > = Arc::new(|ctx, _path, value, anchor_id| {
-                                let json_text =
-                                    serde_json::to_string_pretty(&value).unwrap_or_default();
-                                ctx.dispatch_typed_action(
-                                    RequestedCommandViewAction::ShowMcpContextMenu {
-                                        json_text,
-                                        anchor_id,
-                                    },
-                                );
-                            });
-                            let on_toggle_string_resp: Arc<
-                                dyn Fn(&mut EventContext, Vec<PathSegment>) + Send + Sync,
-                            > = Arc::new(|ctx, path| {
-                                ctx.dispatch_typed_action(
-                                    RequestedCommandViewAction::ToggleJsonString {
-                                        path,
-                                        tree: McpTree::Response,
-                                    },
-                                );
-                            });
+                            let on_copy_resp: Arc<CopyJsonFn> =
+                                Arc::new(|ctx, _path, value, anchor_id| {
+                                    let json_text =
+                                        serde_json::to_string_pretty(&value).unwrap_or_default();
+                                    ctx.dispatch_typed_action(
+                                        RequestedCommandViewAction::ShowMcpContextMenu {
+                                            json_text,
+                                            anchor_id,
+                                        },
+                                    );
+                                });
+                            let on_toggle_string_resp: Arc<ToggleStringFn> =
+                                Arc::new(|ctx, path| {
+                                    ctx.dispatch_typed_action(
+                                        RequestedCommandViewAction::ToggleJsonString {
+                                            path,
+                                            tree: McpTree::Response,
+                                        },
+                                    );
+                                });
                             render_json_tree(
                                 &value,
                                 Some("Response"),

--- a/app/src/ai/blocklist/inline_action/requested_command.rs
+++ b/app/src/ai/blocklist/inline_action/requested_command.rs
@@ -98,6 +98,7 @@ const VIEWING_MCP_TOOL_DETAIL_MESSAGE: &str = "Viewing MCP tool call detail";
 const EDIT_COMMAND_ACTION_NAME: &str = "requested_command:edit";
 
 const EDIT_MODE_OPEN_KEYMAP_CONTEXT: &str = "RequestedCommandViewEditModeOpen";
+const REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT: &str = "RequestedActionBlocked";
 
 const SCROLLBAR_WIDTH: ScrollbarWidth = ScrollbarWidth::Auto;
 const MAX_EDITOR_HEIGHT: f32 = 500.0;
@@ -128,32 +129,42 @@ pub fn init(app: &mut AppContext) {
         FixedBinding::new(
             "ctrl-c",
             RequestedCommandViewAction::Reject,
-            id!(RequestedCommandView::ui_name()),
+            id!(RequestedCommandView::ui_name()) & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT),
         ),
         FixedBinding::new(
             "enter",
             RequestedCommandViewAction::Accept,
-            id!(RequestedCommandView::ui_name()) & !id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
+            id!(RequestedCommandView::ui_name())
+                & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT)
+                & !id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
         ),
         FixedBinding::new(
             "numpadenter",
             RequestedCommandViewAction::Accept,
-            id!(RequestedCommandView::ui_name()) & !id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
+            id!(RequestedCommandView::ui_name())
+                & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT)
+                & !id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
         ),
         FixedBinding::new(
             "cmdorctrl-enter",
             RequestedCommandViewAction::Accept,
-            id!(RequestedCommandView::ui_name()) & id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
+            id!(RequestedCommandView::ui_name())
+                & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT)
+                & id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
         ),
         FixedBinding::new(
             "escape",
             RequestedCommandViewAction::CloseEditMode,
-            id!(RequestedCommandView::ui_name()) & id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
+            id!(RequestedCommandView::ui_name())
+                & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT)
+                & id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
         ),
         FixedBinding::new(
             "tab",
             RequestedCommandViewAction::FocusEditor,
-            id!(RequestedCommandView::ui_name()) & id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
+            id!(RequestedCommandView::ui_name())
+                & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT)
+                & id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
         ),
     ]);
 
@@ -164,7 +175,9 @@ pub fn init(app: &mut AppContext) {
     )
     .with_key_binding(cmd_or_ctrl_shift("e"))
     .with_context_predicate(
-        id!(RequestedCommandView::ui_name()) & !id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
+        id!(RequestedCommandView::ui_name())
+            & id!(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT)
+            & !id!(EDIT_MODE_OPEN_KEYMAP_CONTEXT),
     )]);
 }
 
@@ -1446,6 +1459,17 @@ impl RequestedCommandView {
         }
         expansion_config
     }
+
+    fn is_waiting_for_user_confirmation(&self, app: &AppContext) -> bool {
+        self.action_model
+            .as_ref(app)
+            .get_action_status(&self.action_id)
+            .is_some_and(|status| status.is_blocked())
+    }
+
+    fn get_mcp_section_position_id(prefix: &str) -> String {
+        format!("RequestedCommandView-{prefix}-mcp-section")
+    }
 }
 
 pub(crate) fn header_message_for_user_take_over_reason(
@@ -1953,8 +1977,11 @@ impl View for RequestedCommandView {
         root_stack.finish()
     }
 
-    fn keymap_context(&self, _app: &AppContext) -> Context {
+    fn keymap_context(&self, app: &AppContext) -> Context {
         let mut context = Self::default_keymap_context();
+        if self.is_waiting_for_user_confirmation(app) {
+            context.set.insert(REQUESTED_ACTION_BLOCKED_KEYMAP_CONTEXT);
+        }
 
         if self.is_editing {
             context.set.insert(EDIT_MODE_OPEN_KEYMAP_CONTEXT);

--- a/app/src/ai/blocklist/inline_action/requested_command.rs
+++ b/app/src/ai/blocklist/inline_action/requested_command.rs
@@ -13,8 +13,8 @@ use warp_core::ui::appearance::Appearance;
 use warp_core::ui::Icon;
 use warp_editor::render::element::VerticalExpansionBehavior;
 use warpui::clipboard::ClipboardContent;
+use warpui::elements::new_scrollable::{NewScrollable, ScrollableAppearance, SingleAxisConfig};
 use warpui::elements::{
-    new_scrollable::{NewScrollable, ScrollableAppearance, SingleAxisConfig},
     Align, Border, ChildAnchor, ChildView, Clipped, ClippedScrollStateHandle, ConstrainedBox,
     Container, CornerRadius, CrossAxisAlignment, Dismiss, Empty, Expanded, Flex, MainAxisSize,
     MouseStateHandle, OffsetPositioning, ParentElement, PositionedElementAnchor,

--- a/app/src/ui_components/json_tree.rs
+++ b/app/src/ui_components/json_tree.rs
@@ -235,9 +235,8 @@ pub fn format_number(n: &serde_json::Number) -> String {
 ///                          collapsible node. The caller should dispatch an action
 ///                          (e.g. `ctx.dispatch_typed_action(...)`) to update state.
 /// - `on_copy_json`       — called with the event context, path, value, and the
-///                          anchor position ID of the row when "Copy JSON" is
-///                          activated via right-click. The anchor ID can be used to
-///                          position a context menu below the right-clicked row.
+///   anchor position ID of the row when "Copy JSON" is activated via right-click.
+///   The anchor ID can be used to position a context menu below the clicked row.
 /// - `appearance`         — provides font families and sizes.
 pub fn render_json_tree(
     root: &serde_json::Value,

--- a/app/src/ui_components/json_tree.rs
+++ b/app/src/ui_components/json_tree.rs
@@ -8,8 +8,8 @@ use std::sync::{Arc, Mutex};
 
 use pathfinder_color::ColorU;
 use warp_core::ui::icons::Icon;
-use warp_core::ui::theme::WarpTheme;
 use warp_core::ui::theme::color::internal_colors;
+use warp_core::ui::theme::WarpTheme;
 use warpui::elements::{
     ConstrainedBox, CrossAxisAlignment, Empty, Flex, Hoverable, MainAxisSize, MouseState,
     MouseStateHandle, ParentElement, SavePosition, Shrinkable, Text,

--- a/app/src/ui_components/json_tree.rs
+++ b/app/src/ui_components/json_tree.rs
@@ -2,20 +2,19 @@
 //!
 //! Renders a `serde_json::Value` as an interactive, collapsible tree with
 //! theme-driven colors.
-// Callers are wired in later phases; suppress until then.
-#![allow(dead_code)]
+use std::cell::RefCell;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use pathfinder_color::ColorU;
 use warp_core::ui::icons::Icon;
-use warp_core::ui::theme::color::internal_colors;
 use warp_core::ui::theme::WarpTheme;
+use warp_core::ui::theme::color::internal_colors;
 use warpui::elements::{
-    ConstrainedBox, CrossAxisAlignment, Empty, Flex, Hoverable, MainAxisSize, MouseStateHandle,
-    ParentElement, Shrinkable, Text,
+    ConstrainedBox, CrossAxisAlignment, Empty, Flex, Hoverable, MainAxisSize, MouseState,
+    MouseStateHandle, ParentElement, SavePosition, Shrinkable, Text,
 };
-use warpui::Element;
+use warpui::{Element, EventContext};
 
 use crate::appearance::Appearance;
 
@@ -30,7 +29,7 @@ const INDENT_PX: f32 = 12.;
 const CHEVRON_SIZE: f32 = 12.;
 
 /// The font size used for all tree rows.
-const TREE_FONT_SIZE: f32 = 12.;
+pub const TREE_FONT_SIZE: f32 = 12.;
 
 /// Strings longer than this character count, or containing `\n`, are elided
 /// by default and can be expanded in place.
@@ -64,23 +63,34 @@ pub enum PathSegment {
 /// as long as the surrounding JSON structure is unchanged.
 #[derive(Debug, Default, Clone)]
 pub struct JsonTreeState {
-    /// Expansion state for object/array nodes. Absent = default (expanded at
-    /// depth 0, collapsed deeper).
+    /// Expansion state for object/array nodes. Absent = expanded at depth 0,
+    /// collapsed at depth 1+. An explicit entry always takes precedence.
     node_expansion: HashMap<Vec<PathSegment>, bool>,
     /// Expansion state for long string values. Absent = collapsed (elided).
     string_expansion: HashMap<Vec<PathSegment>, bool>,
+    /// Per-node `MouseStateHandle`s used by the `Hoverable` elements in each
+    /// rendered row.
+    ///
+    /// WarpUI requires that `MouseStateHandle`s be created once and reused
+    /// across renders: creating `MouseStateHandle::default()` inline during
+    /// render discards the `click_count` set during `LeftMouseDown` before
+    /// `LeftMouseUp` fires, so click handlers never trigger. Storing handles
+    /// here (keyed by node path) gives each row a stable handle that persists
+    /// across re-renders triggered by `ctx.notify()`.
+    ///
+    /// A single map covers both container nodes and long-string rows. The same
+    /// path cannot appear in both roles at once — a node is either a container
+    /// or a scalar string, never both — so one handle per path is sufficient.
+    mouse_states: RefCell<HashMap<Vec<PathSegment>, MouseStateHandle>>,
 }
 
 impl JsonTreeState {
-    /// Returns whether the node at `path` and `depth` should be expanded.
+    /// Returns whether the node at `path` should be expanded.
     ///
-    /// Default behaviour: expanded at depth 0, collapsed at depth 1+. An
-    /// explicit entry in the state map always takes precedence.
+    /// Root nodes (depth 0) are expanded by default; all deeper nodes start
+    /// collapsed. An explicit toggle entry always takes precedence.
     pub fn is_expanded(&self, path: &[PathSegment], depth: usize) -> bool {
-        if let Some(&explicit) = self.node_expansion.get(path) {
-            return explicit;
-        }
-        depth == 0
+        self.node_expansion.get(path).copied().unwrap_or(depth == 0)
     }
 
     /// Returns whether the long string at `path` should be expanded.
@@ -88,11 +98,18 @@ impl JsonTreeState {
         self.string_expansion.get(path).copied().unwrap_or(false)
     }
 
+    /// Returns the stable `MouseStateHandle` for the row at `path`, creating
+    /// one on first access. The handle is reused across renders so that
+    /// click-state (press → notify → re-render → release) is preserved.
+    pub fn mouse_state_for(&self, path: &[PathSegment]) -> MouseStateHandle {
+        self.mouse_states
+            .borrow_mut()
+            .entry(path.to_vec())
+            .or_insert_with(|| Arc::new(Mutex::new(MouseState::default())))
+            .clone()
+    }
+
     /// Toggles the expansion state of the node at `path`.
-    ///
-    /// If no explicit state exists, the new state is the inverse of the
-    /// default (derived from depth). Callers must pass `depth` so we know
-    /// what the default would have been.
     pub fn toggle(&mut self, path: &[PathSegment], depth: usize) {
         let current = self.is_expanded(path, depth);
         self.node_expansion.insert(path.to_vec(), !current);
@@ -207,21 +224,32 @@ pub fn format_number(n: &serde_json::Number) -> String {
 /// collapsible JSON tree.
 ///
 /// # Parameters
-/// - `root`         — the JSON value to render.
-/// - `root_label`   — optional label printed above the tree (e.g. "Request").
-/// - `state`        — current expansion state; queried on every render.
-/// - `colors`       — pre-resolved theme colors.
-/// - `on_toggle`    — called with the path of a clicked collapsible node.
-/// - `on_copy_json` — called with the path and value when "Copy JSON" is
-///   activated via right-click on a row in the tree.
-/// - `appearance`   — provides font families and sizes.
+/// - `root`               — the JSON value to render.
+/// - `root_label`         — optional label printed above the tree (e.g. "Request").
+/// - `state`              — current expansion state; queried on every render.
+/// - `colors`             — pre-resolved theme colors.
+/// - `position_id_prefix` — stable prefix for per-row `SavePosition` IDs used to
+///                          anchor the right-click context menu to the clicked row.
+///                          Must be unique per tree instance in the same window.
+/// - `on_toggle`          — called with the event context and path of a clicked
+///                          collapsible node. The caller should dispatch an action
+///                          (e.g. `ctx.dispatch_typed_action(...)`) to update state.
+/// - `on_copy_json`       — called with the event context, path, value, and the
+///                          anchor position ID of the row when "Copy JSON" is
+///                          activated via right-click. The anchor ID can be used to
+///                          position a context menu below the right-clicked row.
+/// - `appearance`         — provides font families and sizes.
 pub fn render_json_tree(
     root: &serde_json::Value,
     root_label: Option<&str>,
     state: &JsonTreeState,
     colors: &JsonTreeColors,
-    on_toggle: Arc<dyn Fn(Vec<PathSegment>, usize) + Send + Sync>,
-    on_copy_json: Arc<dyn Fn(Vec<PathSegment>, serde_json::Value) + Send + Sync>,
+    position_id_prefix: &str,
+    on_toggle: Arc<dyn Fn(&mut EventContext, Vec<PathSegment>, usize) + Send + Sync>,
+    on_toggle_string: Arc<dyn Fn(&mut EventContext, Vec<PathSegment>) + Send + Sync>,
+    on_copy_json: Arc<
+        dyn Fn(&mut EventContext, Vec<PathSegment>, serde_json::Value, String) + Send + Sync,
+    >,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     let font_family = appearance.ui_font_family();
@@ -244,7 +272,9 @@ pub fn render_json_tree(
         None,
         state,
         colors,
+        position_id_prefix,
         &on_toggle,
+        &on_toggle_string,
         &on_copy_json,
         font_family,
         &mut column,
@@ -266,8 +296,12 @@ fn render_value(
     label: Option<String>,
     state: &JsonTreeState,
     colors: &JsonTreeColors,
-    on_toggle: &Arc<dyn Fn(Vec<PathSegment>, usize) + Send + Sync>,
-    on_copy_json: &Arc<dyn Fn(Vec<PathSegment>, serde_json::Value) + Send + Sync>,
+    position_id_prefix: &str,
+    on_toggle: &Arc<dyn Fn(&mut EventContext, Vec<PathSegment>, usize) + Send + Sync>,
+    on_toggle_string: &Arc<dyn Fn(&mut EventContext, Vec<PathSegment>) + Send + Sync>,
+    on_copy_json: &Arc<
+        dyn Fn(&mut EventContext, Vec<PathSegment>, serde_json::Value, String) + Send + Sync,
+    >,
     font_family: warpui::fonts::FamilyId,
     column: &mut Flex,
 ) {
@@ -282,6 +316,7 @@ fn render_value(
                 label,
                 state,
                 colors,
+                position_id_prefix,
                 on_toggle,
                 on_copy_json,
                 font_family,
@@ -302,7 +337,9 @@ fn render_value(
                         Some(key.clone()),
                         state,
                         colors,
+                        position_id_prefix,
                         on_toggle,
+                        on_toggle_string,
                         on_copy_json,
                         font_family,
                         column,
@@ -321,6 +358,7 @@ fn render_value(
                 label,
                 state,
                 colors,
+                position_id_prefix,
                 on_toggle,
                 on_copy_json,
                 font_family,
@@ -341,7 +379,9 @@ fn render_value(
                         Some(idx.to_string()),
                         state,
                         colors,
+                        position_id_prefix,
                         on_toggle,
+                        on_toggle_string,
                         on_copy_json,
                         font_family,
                         column,
@@ -351,17 +391,41 @@ fn render_value(
         }
 
         serde_json::Value::String(s) => {
-            render_scalar_row(
-                path,
-                depth,
-                label,
-                build_string_value_text(s, colors, font_family),
-                value.clone(),
-                colors,
-                on_copy_json,
-                font_family,
-                column,
-            );
+            if is_long_string(s) {
+                render_long_string_row(
+                    path,
+                    depth,
+                    label,
+                    s,
+                    value.clone(),
+                    state,
+                    colors,
+                    position_id_prefix,
+                    on_toggle_string,
+                    on_copy_json,
+                    font_family,
+                    column,
+                );
+            } else {
+                let display = format!("\"{}\"", s);
+                let text = Text::new_inline(display, font_family, TREE_FONT_SIZE)
+                    .with_color(colors.string)
+                    .soft_wrap(false)
+                    .finish();
+                render_scalar_row(
+                    path,
+                    depth,
+                    label,
+                    text,
+                    value.clone(),
+                    state,
+                    colors,
+                    position_id_prefix,
+                    on_copy_json,
+                    font_family,
+                    column,
+                );
+            }
         }
 
         serde_json::Value::Number(n) => {
@@ -375,7 +439,9 @@ fn render_value(
                 label,
                 text,
                 value.clone(),
+                state,
                 colors,
+                position_id_prefix,
                 on_copy_json,
                 font_family,
                 column,
@@ -394,7 +460,9 @@ fn render_value(
                 label,
                 text,
                 value.clone(),
+                state,
                 colors,
+                position_id_prefix,
                 on_copy_json,
                 font_family,
                 column,
@@ -412,7 +480,9 @@ fn render_value(
                 label,
                 text,
                 value.clone(),
+                state,
                 colors,
+                position_id_prefix,
                 on_copy_json,
                 font_family,
                 column,
@@ -421,29 +491,115 @@ fn render_value(
     }
 }
 
-/// Builds the value text for a string, applying long-string elision if needed.
-/// Elided strings show a truncated preview with an ellipsis.
-fn build_string_value_text(
+/// Renders an expandable/collapsible long string row.
+///
+/// Collapsed: shows first-line preview with ellipsis + right-pointing chevron.
+/// Expanded: shows the full string with word-wrap + down-pointing chevron.
+/// The chevron position mirrors container nodes so the column aligns consistently.
+#[allow(clippy::too_many_arguments)]
+fn render_long_string_row(
+    path: Vec<PathSegment>,
+    depth: usize,
+    label: Option<String>,
     s: &str,
+    value_for_copy: serde_json::Value,
+    state: &JsonTreeState,
     colors: &JsonTreeColors,
+    position_id_prefix: &str,
+    on_toggle_string: &Arc<dyn Fn(&mut EventContext, Vec<PathSegment>) + Send + Sync>,
+    on_copy_json: &Arc<
+        dyn Fn(&mut EventContext, Vec<PathSegment>, serde_json::Value, String) + Send + Sync,
+    >,
     font_family: warpui::fonts::FamilyId,
-) -> Box<dyn Element> {
-    if is_long_string(s) {
-        // Show a preview: first line, capped at threshold characters.
+    column: &mut Flex,
+) {
+    let anchor_id = format!("{position_id_prefix}:row:{path:?}");
+    let is_expanded = state.is_string_expanded(&path);
+
+    let icon = if is_expanded {
+        Icon::ChevronDown
+    } else {
+        Icon::ChevronRight
+    };
+
+    let mut row = Flex::row()
+        .with_main_axis_size(MainAxisSize::Max)
+        .with_cross_axis_alignment(CrossAxisAlignment::Center);
+
+    // Indent spacer.
+    row.add_child(indent_spacer(depth));
+
+    // Chevron in the standard left position.
+    row.add_child(
+        ConstrainedBox::new(
+            icon.to_warpui_icon(warp_core::ui::theme::Fill::Solid(colors.annotation))
+                .finish(),
+        )
+        .with_width(CHEVRON_SIZE)
+        .with_height(CHEVRON_SIZE)
+        .finish(),
+    );
+
+    // Key/index label (if inside an object or array).
+    if let Some(ref key) = label {
+        let key_text = Text::new_inline(format!("{}:  ", key), font_family, TREE_FONT_SIZE)
+            .with_color(colors.key)
+            .soft_wrap(false)
+            .finish();
+        row.add_child(key_text);
+    }
+
+    // String value: preview when collapsed, full text when expanded.
+    let string_element: Box<dyn Element> = if is_expanded {
+        let display = format!("\"{}\"", s);
+        Shrinkable::new(
+            1.,
+            Text::new(display, font_family, TREE_FONT_SIZE)
+                .with_color(colors.string)
+                .with_selectable(true)
+                .finish(),
+        )
+        .finish()
+    } else {
         let first_line = s.lines().next().unwrap_or("");
         let preview: String = first_line.chars().take(LONG_STRING_THRESHOLD).collect();
-        let display = format!("\"{}…\"", preview);
-        Text::new_inline(display, font_family, TREE_FONT_SIZE)
-            .with_color(colors.string)
-            .soft_wrap(false)
-            .finish()
-    } else {
-        let display = format!("\"{}\"", s);
-        Text::new_inline(display, font_family, TREE_FONT_SIZE)
-            .with_color(colors.string)
-            .soft_wrap(false)
-            .finish()
-    }
+        let display = format!("\"{}\u{2026}\"", preview);
+        Shrinkable::new(
+            1.,
+            Text::new_inline(display, font_family, TREE_FONT_SIZE)
+                .with_color(colors.string)
+                .soft_wrap(false)
+                .finish(),
+        )
+        .finish()
+    };
+    row.add_child(string_element);
+
+    let row_element = row.finish();
+
+    let on_toggle_clone = on_toggle_string.clone();
+    let path_for_toggle = path.clone();
+    let on_copy_clone = on_copy_json.clone();
+    let path_for_copy = path.clone();
+    let anchor_for_copy = anchor_id.clone();
+    // Stable handle reused across renders so click-state survives re-notify.
+    let state_handle = state.mouse_state_for(&path);
+
+    let hoverable = Hoverable::new(state_handle, move |_| row_element)
+        .on_click(move |ctx, _app, _pos| {
+            on_toggle_clone(ctx, path_for_toggle.clone());
+        })
+        .on_right_click(move |ctx, _app, _pos| {
+            on_copy_clone(
+                ctx,
+                path_for_copy.clone(),
+                value_for_copy.clone(),
+                anchor_for_copy.clone(),
+            );
+        })
+        .finish();
+
+    column.add_child(SavePosition::new(hoverable, &anchor_id).finish());
 }
 
 /// Renders a collapsible object/array node row with a chevron expander.
@@ -459,8 +615,11 @@ fn render_container_node(
     label: Option<String>,
     state: &JsonTreeState,
     colors: &JsonTreeColors,
-    on_toggle: &Arc<dyn Fn(Vec<PathSegment>, usize) + Send + Sync>,
-    on_copy_json: &Arc<dyn Fn(Vec<PathSegment>, serde_json::Value) + Send + Sync>,
+    position_id_prefix: &str,
+    on_toggle: &Arc<dyn Fn(&mut EventContext, Vec<PathSegment>, usize) + Send + Sync>,
+    on_copy_json: &Arc<
+        dyn Fn(&mut EventContext, Vec<PathSegment>, serde_json::Value, String) + Send + Sync,
+    >,
     font_family: warpui::fonts::FamilyId,
     column: &mut Flex,
 ) {
@@ -530,23 +689,31 @@ fn render_container_node(
         // Non-interactive.
         column.add_child(row_element);
     } else {
+        let anchor_id = format!("{position_id_prefix}:row:{path:?}");
         let on_toggle_clone = on_toggle.clone();
         let path_for_toggle = path.clone();
         let on_copy_clone = on_copy_json.clone();
         let path_for_copy = path.clone();
-        let state_handle = MouseStateHandle::default();
+        let anchor_for_copy = anchor_id.clone();
+        // Stable handle keyed by path — see `JsonTreeState::mouse_state_for`.
+        let state_handle = state.mouse_state_for(&path);
 
         let row_for_hover = row_element;
         let hoverable = Hoverable::new(state_handle, move |_| row_for_hover)
-            .on_click(move |_ctx, _app, _pos| {
-                on_toggle_clone(path_for_toggle.clone(), depth);
+            .on_click(move |ctx, _app, _pos| {
+                on_toggle_clone(ctx, path_for_toggle.clone(), depth);
             })
-            .on_right_click(move |_ctx, _app, _pos| {
-                on_copy_clone(path_for_copy.clone(), value_for_copy.clone());
+            .on_right_click(move |ctx, _app, _pos| {
+                on_copy_clone(
+                    ctx,
+                    path_for_copy.clone(),
+                    value_for_copy.clone(),
+                    anchor_for_copy.clone(),
+                );
             })
             .finish();
 
-        column.add_child(hoverable);
+        column.add_child(SavePosition::new(hoverable, &anchor_id).finish());
     }
 }
 
@@ -558,11 +725,17 @@ fn render_scalar_row(
     label: Option<String>,
     value_element: Box<dyn Element>,
     value_for_copy: serde_json::Value,
+    state: &JsonTreeState,
     colors: &JsonTreeColors,
-    on_copy_json: &Arc<dyn Fn(Vec<PathSegment>, serde_json::Value) + Send + Sync>,
+    position_id_prefix: &str,
+    on_copy_json: &Arc<
+        dyn Fn(&mut EventContext, Vec<PathSegment>, serde_json::Value, String) + Send + Sync,
+    >,
     font_family: warpui::fonts::FamilyId,
     column: &mut Flex,
 ) {
+    let anchor_id = format!("{position_id_prefix}:row:{path:?}");
+
     let mut row = Flex::row()
         .with_main_axis_size(MainAxisSize::Max)
         .with_cross_axis_alignment(CrossAxisAlignment::Center);
@@ -593,16 +766,23 @@ fn render_scalar_row(
     // Wrap in a Hoverable for right-click (copy JSON).
     let on_copy_clone = on_copy_json.clone();
     let path_for_copy = path.clone();
-    let state_handle = MouseStateHandle::default();
+    let anchor_for_copy = anchor_id.clone();
+    // Stable handle keyed by path — see `JsonTreeState::mouse_state_for`.
+    let state_handle = state.mouse_state_for(&path);
     let row_element = row.finish();
 
     let hoverable = Hoverable::new(state_handle, move |_| row_element)
-        .on_right_click(move |_ctx, _app, _pos| {
-            on_copy_clone(path_for_copy.clone(), value_for_copy.clone());
+        .on_right_click(move |ctx, _app, _pos| {
+            on_copy_clone(
+                ctx,
+                path_for_copy.clone(),
+                value_for_copy.clone(),
+                anchor_for_copy.clone(),
+            );
         })
         .finish();
 
-    column.add_child(hoverable);
+    column.add_child(SavePosition::new(hoverable, &anchor_id).finish());
 }
 
 /// Returns a fixed-width transparent spacer for the given indentation depth.

--- a/app/src/ui_components/json_tree.rs
+++ b/app/src/ui_components/json_tree.rs
@@ -19,6 +19,18 @@ use warpui::{Element, EventContext};
 use crate::appearance::Appearance;
 
 // ---------------------------------------------------------------------------
+// Callback type aliases
+// ---------------------------------------------------------------------------
+
+/// Callback invoked when a collapsible container node is toggled.
+pub type ToggleFn = dyn Fn(&mut EventContext, Vec<PathSegment>, usize) + Send + Sync;
+/// Callback invoked when a long-string value is toggled.
+pub type ToggleStringFn = dyn Fn(&mut EventContext, Vec<PathSegment>) + Send + Sync;
+/// Callback invoked when "Copy JSON" is activated via right-click on a row.
+pub type CopyJsonFn =
+    dyn Fn(&mut EventContext, Vec<PathSegment>, serde_json::Value, String) + Send + Sync;
+
+// ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
@@ -229,26 +241,24 @@ pub fn format_number(n: &serde_json::Number) -> String {
 /// - `state`              — current expansion state; queried on every render.
 /// - `colors`             — pre-resolved theme colors.
 /// - `position_id_prefix` — stable prefix for per-row `SavePosition` IDs used to
-///                          anchor the right-click context menu to the clicked row.
-///                          Must be unique per tree instance in the same window.
+///   anchor the right-click context menu to the clicked row.
+///   Must be unique per tree instance in the same window.
 /// - `on_toggle`          — called with the event context and path of a clicked
-///                          collapsible node. The caller should dispatch an action
-///                          (e.g. `ctx.dispatch_typed_action(...)`) to update state.
+///   collapsible node; dispatch an action to update state.
 /// - `on_copy_json`       — called with the event context, path, value, and the
 ///   anchor position ID of the row when "Copy JSON" is activated via right-click.
 ///   The anchor ID can be used to position a context menu below the clicked row.
 /// - `appearance`         — provides font families and sizes.
+#[allow(clippy::too_many_arguments)]
 pub fn render_json_tree(
     root: &serde_json::Value,
     root_label: Option<&str>,
     state: &JsonTreeState,
     colors: &JsonTreeColors,
     position_id_prefix: &str,
-    on_toggle: Arc<dyn Fn(&mut EventContext, Vec<PathSegment>, usize) + Send + Sync>,
-    on_toggle_string: Arc<dyn Fn(&mut EventContext, Vec<PathSegment>) + Send + Sync>,
-    on_copy_json: Arc<
-        dyn Fn(&mut EventContext, Vec<PathSegment>, serde_json::Value, String) + Send + Sync,
-    >,
+    on_toggle: Arc<ToggleFn>,
+    on_toggle_string: Arc<ToggleStringFn>,
+    on_copy_json: Arc<CopyJsonFn>,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     let font_family = appearance.ui_font_family();
@@ -296,11 +306,9 @@ fn render_value(
     state: &JsonTreeState,
     colors: &JsonTreeColors,
     position_id_prefix: &str,
-    on_toggle: &Arc<dyn Fn(&mut EventContext, Vec<PathSegment>, usize) + Send + Sync>,
-    on_toggle_string: &Arc<dyn Fn(&mut EventContext, Vec<PathSegment>) + Send + Sync>,
-    on_copy_json: &Arc<
-        dyn Fn(&mut EventContext, Vec<PathSegment>, serde_json::Value, String) + Send + Sync,
-    >,
+    on_toggle: &Arc<ToggleFn>,
+    on_toggle_string: &Arc<ToggleStringFn>,
+    on_copy_json: &Arc<CopyJsonFn>,
     font_family: warpui::fonts::FamilyId,
     column: &mut Flex,
 ) {
@@ -505,10 +513,8 @@ fn render_long_string_row(
     state: &JsonTreeState,
     colors: &JsonTreeColors,
     position_id_prefix: &str,
-    on_toggle_string: &Arc<dyn Fn(&mut EventContext, Vec<PathSegment>) + Send + Sync>,
-    on_copy_json: &Arc<
-        dyn Fn(&mut EventContext, Vec<PathSegment>, serde_json::Value, String) + Send + Sync,
-    >,
+    on_toggle_string: &Arc<ToggleStringFn>,
+    on_copy_json: &Arc<CopyJsonFn>,
     font_family: warpui::fonts::FamilyId,
     column: &mut Flex,
 ) {
@@ -615,10 +621,8 @@ fn render_container_node(
     state: &JsonTreeState,
     colors: &JsonTreeColors,
     position_id_prefix: &str,
-    on_toggle: &Arc<dyn Fn(&mut EventContext, Vec<PathSegment>, usize) + Send + Sync>,
-    on_copy_json: &Arc<
-        dyn Fn(&mut EventContext, Vec<PathSegment>, serde_json::Value, String) + Send + Sync,
-    >,
+    on_toggle: &Arc<ToggleFn>,
+    on_copy_json: &Arc<CopyJsonFn>,
     font_family: warpui::fonts::FamilyId,
     column: &mut Flex,
 ) {
@@ -727,9 +731,7 @@ fn render_scalar_row(
     state: &JsonTreeState,
     colors: &JsonTreeColors,
     position_id_prefix: &str,
-    on_copy_json: &Arc<
-        dyn Fn(&mut EventContext, Vec<PathSegment>, serde_json::Value, String) + Send + Sync,
-    >,
+    on_copy_json: &Arc<CopyJsonFn>,
     font_family: warpui::fonts::FamilyId,
     column: &mut Flex,
 ) {

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
-use enum_iterator::{cardinality, Sequence};
+use enum_iterator::{Sequence, cardinality};
 #[cfg(feature = "test-util")]
 pub use overrides::{get_overrides, set_overrides};
 
@@ -512,10 +512,6 @@ pub enum FeatureFlag {
     /// Enables v2 of the context window usage UI.
     ContextWindowUsageV2,
 
-    /// Dev-only: enables the expandable per-segment context window usage
-    /// breakdown in the conversation usage card.
-    ContextWindowUsageBreakdown,
-
     /// Enables global search
     GlobalSearch,
 
@@ -712,11 +708,6 @@ pub enum FeatureFlag {
     /// Uses a parent-family ancestor stream for owner-side orchestrator event delivery.
     OwnerOrchestrationAncestorStreamer,
 
-    /// On `wait_for_events`, confirms parent status against the server and
-    /// registers an orchestrator for the owner-side ancestor stream so it
-    /// receives events for children created out-of-band (Oz CLI / web API).
-    WaitForEventsParentRegistration,
-
     /// Shows a pending user query indicator during summarization when a follow-up
     /// prompt is queued via `/fork-and-compact` or `/compact-and`.
     PendingUserQueryIndicator,
@@ -894,17 +885,10 @@ pub enum FeatureFlag {
     /// route eliglible models to GEAP instead of Warp-managed inference.
     GeminiEnterprise,
 
-    /// Gates the custom model router feature, which allows users to define
-    /// their own model routers.
-    CustomModelRouters,
-
-    /// Shows a warning in the agent view when the active conversation's
-    /// provider-side prompt cache has expired.
-    PromptCacheExpiryWarning,
-
-    /// Enables the `--runner` flag on `run-cloud`, which overrides an agent's
-    /// compute (docker image, instance shape, setup commands) by runner ID.
-    CloudRunners,
+    /// Renders MCP tool-call request and response JSON as an interactive
+    /// collapsible tree with typed colors and per-row Copy JSON, instead of
+    /// a flat pretty-printed blob.
+    McpJsonTreeView,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =
@@ -962,6 +946,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::EditableMarkdownMermaid,
     FeatureFlag::CodeReviewScrollPreservation,
     FeatureFlag::RememberFastForwardState,
+    FeatureFlag::CodexPlugin,
     FeatureFlag::GeminiNotifications,
     FeatureFlag::LocalDockerSandbox,
     #[cfg(not(windows))]
@@ -976,14 +961,15 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::ContextWindowUsageBreakdown,
     FeatureFlag::CloudRunners,
     FeatureFlag::WaitForEventsParentRegistration,
+    FeatureFlag::McpJsonTreeView,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).
 /// All PREVIEW_FLAGS are also automatically added to dogfood builds (WarpDev).
 pub const PREVIEW_FLAGS: &[FeatureFlag] = &[
+    #[cfg(target_os = "macos")]
+    FeatureFlag::GroupedTabs,
     FeatureFlag::AsyncFind,
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    FeatureFlag::DragTabsToWindows,
 ];
 
 /// Features enabled for all release builds (i.e.: everything but WarpLocal).
@@ -999,6 +985,8 @@ pub const RELEASE_FLAGS: &[FeatureFlag] = &[
     // Remote server binary is not yet supported on Windows.
     #[cfg(not(windows))]
     FeatureFlag::SshRemoteServer,
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    FeatureFlag::DragTabsToWindows,
 ];
 
 /// Flags that we want to allow to switch at runtime (assuming RuntimeFeatureFlags is set)
@@ -1090,6 +1078,7 @@ impl FeatureFlag {
             GitOperationsInCodeReview => Some(
                 "Enables commit, push, and create-PR actions directly from the code review panel.",
             ),
+            GroupedTabs => Some("Enables organizing tabs into named, collapsible groups."),
             AsyncFind => Some(
                 "Runs terminal find on a background thread to keep the UI responsive while searching large outputs.",
             ),

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
-use enum_iterator::{Sequence, cardinality};
+use enum_iterator::{cardinality, Sequence};
 #[cfg(feature = "test-util")]
 pub use overrides::{get_overrides, set_overrides};
 

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -512,6 +512,10 @@ pub enum FeatureFlag {
     /// Enables v2 of the context window usage UI.
     ContextWindowUsageV2,
 
+    /// Dev-only: enables the expandable per-segment context window usage
+    /// breakdown in the conversation usage card.
+    ContextWindowUsageBreakdown,
+
     /// Enables global search
     GlobalSearch,
 
@@ -708,6 +712,11 @@ pub enum FeatureFlag {
     /// Uses a parent-family ancestor stream for owner-side orchestrator event delivery.
     OwnerOrchestrationAncestorStreamer,
 
+    /// On `wait_for_events`, confirms parent status against the server and
+    /// registers an orchestrator for the owner-side ancestor stream so it
+    /// receives events for children created out-of-band (Oz CLI / web API).
+    WaitForEventsParentRegistration,
+
     /// Shows a pending user query indicator during summarization when a follow-up
     /// prompt is queued via `/fork-and-compact` or `/compact-and`.
     PendingUserQueryIndicator,
@@ -885,6 +894,18 @@ pub enum FeatureFlag {
     /// route eliglible models to GEAP instead of Warp-managed inference.
     GeminiEnterprise,
 
+    /// Gates the custom model router feature, which allows users to define
+    /// their own model routers.
+    CustomModelRouters,
+
+    /// Shows a warning in the agent view when the active conversation's
+    /// provider-side prompt cache has expired.
+    PromptCacheExpiryWarning,
+
+    /// Enables the `--runner` flag on `run-cloud`, which overrides an agent's
+    /// compute (docker image, instance shape, setup commands) by runner ID.
+    CloudRunners,
+
     /// Renders MCP tool-call request and response JSON as an interactive
     /// collapsible tree with typed colors and per-row Copy JSON, instead of
     /// a flat pretty-printed blob.
@@ -946,7 +967,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::EditableMarkdownMermaid,
     FeatureFlag::CodeReviewScrollPreservation,
     FeatureFlag::RememberFastForwardState,
-    FeatureFlag::CodexPlugin,
     FeatureFlag::GeminiNotifications,
     FeatureFlag::LocalDockerSandbox,
     #[cfg(not(windows))]
@@ -967,9 +987,9 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).
 /// All PREVIEW_FLAGS are also automatically added to dogfood builds (WarpDev).
 pub const PREVIEW_FLAGS: &[FeatureFlag] = &[
-    #[cfg(target_os = "macos")]
-    FeatureFlag::GroupedTabs,
     FeatureFlag::AsyncFind,
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    FeatureFlag::DragTabsToWindows,
 ];
 
 /// Features enabled for all release builds (i.e.: everything but WarpLocal).
@@ -985,8 +1005,6 @@ pub const RELEASE_FLAGS: &[FeatureFlag] = &[
     // Remote server binary is not yet supported on Windows.
     #[cfg(not(windows))]
     FeatureFlag::SshRemoteServer,
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    FeatureFlag::DragTabsToWindows,
 ];
 
 /// Flags that we want to allow to switch at runtime (assuming RuntimeFeatureFlags is set)
@@ -1078,7 +1096,6 @@ impl FeatureFlag {
             GitOperationsInCodeReview => Some(
                 "Enables commit, push, and create-PR actions directly from the code review panel.",
             ),
-            GroupedTabs => Some("Enables organizing tabs into named, collapsible groups."),
             AsyncFind => Some(
                 "Runs terminal find on a background thread to keep the UI responsive while searching large outputs.",
             ),

--- a/specs/APP-2527/PRODUCT.md
+++ b/specs/APP-2527/PRODUCT.md
@@ -57,8 +57,8 @@ Long string elision (collapsed → expanded):
 12. An empty object renders as `{} 0 keys` and an empty array as `[] 0 items`; they have no chevron and do not respond to click, and never expand to an empty body.
 
 ### Default expansion state
-13. All nodes in the tree default to expanded on first render. The MCP tool call detail block is scrollable and height-capped, so a fully-open tree does not push content off-screen. Users can collapse individual nodes by clicking their chevrons.
-14. No auto-collapse threshold is applied. The tree renders fully open regardless of depth or node count.
+13. On first render of a tool call's detail, all nodes in the tree are expanded by default so the user immediately sees the full structure. The tree body is scrollable and height-capped, so a large tree does not push subsequent blocks off-screen.
+14. There is no auto-collapse cap based on node count: the tree is fully open by default regardless of size.
 15. Expansion state is per tool-call-detail view state. It persists while the conversation stays open (collapsing and re-expanding the action header restores the user's last per-node expansion state for that tool call rather than resetting to defaults). It does not need to persist across app restarts or conversation reloads.
 16. If a tool call response arrives while the action header is collapsed, the response data is retained; expanding the header shows both the request and response trees. No data is lost due to the header being collapsed at the time of response arrival.
 17. The tree body scrolls vertically when the expanded tree exceeds the height of the action detail container. A maximum height cap is applied to the tree body (consistent with the existing max-height cap used for command editor bodies) so that a fully expanded tree does not push subsequent blocks off-screen. Scrolling the tree does not interfere with scrolling the outer block list.
@@ -89,7 +89,7 @@ Long string elision (collapsed → expanded):
     - A cancelled tool call renders a clear "cancelled" indication rather than an empty tree.
 29. If the request arguments are absent or null (a tool called with no arguments), the request tree renders an empty/`null` indication rather than a broken node.
 30. Values that are valid JSON but unusual — empty string, very large numbers, numbers that are whole-valued floats, unicode, nested arrays of objects — all render without panicking and without losing data. Whole-number integer arguments display as integers (e.g. `5`, not `5.0`), consistent with how the tool call is actually dispatched.
-31. **Known limitation — duplicate object keys:** `serde_json::Value::Object` normalizes duplicate keys before rendering, retaining only the last value for any given key. Truly duplicate-keyed JSON objects cannot be represented in the implementation's chosen data structure. In practice MCP tool results do not produce duplicate keys.
+31. Duplicate object keys (possible in raw JSON) all render; none are silently dropped.
 
 ### Streaming
 32. While the tool-call request arguments are still streaming in, the request tree may update as more of the structure arrives; partial/in-progress structure renders without flicker that resets the user's expansion state for already-rendered nodes.

--- a/specs/APP-2527/TECH.md
+++ b/specs/APP-2527/TECH.md
@@ -143,8 +143,6 @@ Cons:
 **Option E1 — Custom right-click handler with `warpui` Menu (recommended)**
 Use `Hoverable::with_on_right_click` (already used in other inline actions) to show a `Menu` element containing "Copy" and "Copy JSON" items. Each row in the tree registers its own right-click handler, capturing the `JsonPath` of that row.
 
-**Note on toggle disambiguation:** The expansion-state API uses two separate `HashMap<Vec<PathSegment>, bool>` maps — one for container node toggle state and one for long-string toggle state — along with two corresponding action variants (`ToggleJsonNode` and `ToggleJsonString`). This provides the independent persistence required between object/array expansion and long-string expansion. Implemented in Phase 2.
-
 Pros:
 - Consistent with existing right-click menus elsewhere in the app.
 - Per-row context (the path captured in the handler) allows "Copy JSON" to copy exactly the subtree at that row.


### PR DESCRIPTION
## What

Replace the flat pretty-printed JSON text in the MCP tool call detail view with an interactive, collapsible JSON tree rendered by the `JsonTreeView` component built in Phases 1 and 2.

**json_tree.rs:** Updated `render_json_tree`, `render_value`, `render_container_node`, and `render_scalar_row` callback signatures to accept `&mut EventContext` as first argument, allowing callers to dispatch typed actions from Hoverable click handlers.

**requested_command.rs:**
- Added `CopyJsonToClipboard { text: String }` to `RequestedCommandViewAction` to bridge EventContext right-click handlers (which lack clipboard access) to `ViewContext::clipboard()` in `handle_action`
- Added `mcp_scroll_state: ClippedScrollStateHandle` field to preserve scroll position across renders
- Replaced `should_render_mcp_content` body: request section renders `render_json_tree` with `mcp_request_tree_state` (or a "(no arguments)" placeholder), response section renders tree/error/cancelled once a finished result is available, all wrapped in a `NewScrollable` + `ConstrainedBox::with_max_height(MAX_EDITOR_HEIGHT)` + `SelectableArea`

## Why

Replaces an unformatted flat JSON blob with an interactive tree that lets users collapse uninteresting subtrees and expand long strings on demand.

## Agent Mode

- [x] This PR was created by Warp Agent Mode

## Manual Validation Checklist (from TECH.md Phase 3)

- [ ] Configure a local MCP server (e.g. filesystem) and expand a tool call: root expanded, nested collapsed, chevrons toggle independently, indentation per level
- [ ] Large/nested response: Request/Response labels visible, typed colors for all value types, light↔dark theme switch recolors without restart
- [ ] Long string (file contents): elision preview + chevron, expands/collapses in place without disturbing siblings
- [ ] Very tall expanded tree: tree scrolls, does not push subsequent blocks off-screen
- [ ] Response arrives while header is collapsed: expand header to confirm both request and response trees are shown
- [ ] Error and cancelled tool calls show labeled messages
- [ ] Right-click → Copy JSON on a collapsed container copies complete JSON
- [ ] Right-click → Copy JSON on the Request label copies the full request JSON
- [ ] Copy with no selection is a no-op
- [ ] Text selection and copy across key/value rows works
- [ ] Collapsed header, accept/reject, and a non-MCP action (shell command) are visually unchanged

---

_Conversation: https://staging.warp.dev/conversation/3a48e515-b541-4d6d-bc95-0bd50f8b9124_
_Run: https://oz.staging.warp.dev/runs/019edff8-41ce-7cf2-891d-3e1c4bcd4608_
_This PR was generated with [Oz](https://warp.dev/oz)._

---

**Demo:** https://www.loom.com/share/e36af183098c4ae392869ab39ee93796