### PR TITLE
fix focus stealing

### DIFF
--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -3863,6 +3863,13 @@ impl Input {
         self.queued_prompts_panel.as_ref()
     }
 
+    /// Returns whether this input's queued-prompt inline editor is currently focused.
+    pub(crate) fn is_queued_prompt_inline_editor_focused(&self, ctx: &AppContext) -> bool {
+        self.queued_prompts_panel
+            .as_ref()
+            .is_some_and(|panel| panel.as_ref(ctx).is_inline_edit_editor_focused(ctx))
+    }
+
     /// Returns whether the active queued prompt is being edited inline.
     fn is_editing_queued_prompt(&self, ctx: &AppContext) -> bool {
         let Some(conversation_id) =

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -8675,7 +8675,9 @@ impl TerminalView {
     /// (e.g. another session).
     ///
     /// Skips the steal when the user is navigating another AI block / code diff
-    /// (e.g. arrowing diff hunks), unless the target block is blocked on user input.
+    /// (e.g. arrowing diff hunks), unless the target block is blocked on user input. Also skips
+    /// while the queued-prompt inline editor is focused so async AI/tool updates don't commit and
+    /// close the edit by blurring it.
     ///
     /// Warning: this should not be called when focusing the [`TerminalView`]. It could
     /// lead to a focus cycle because [`AIBlock::try_focus`] conditionally yields focus
@@ -8686,6 +8688,9 @@ impl TerminalView {
         ctx: &mut ViewContext<Self>,
     ) {
         if !ctx.is_self_or_child_focused() {
+            return;
+        }
+        if self.is_queued_prompt_inline_editor_focused(ctx) {
             return;
         }
         let target_needs_attention = block.as_ref(ctx).is_blocked_on_user_confirmation(ctx);
@@ -8702,6 +8707,12 @@ impl TerminalView {
                 .ai_block_metadata()
                 .is_some_and(|metadata| metadata.ai_block_handle.is_self_or_child_focused(ctx))
         })
+    }
+
+    fn is_queued_prompt_inline_editor_focused(&self, ctx: &AppContext) -> bool {
+        self.input
+            .as_ref(ctx)
+            .is_queued_prompt_inline_editor_focused(ctx)
     }
 
     #[cfg(not(windows))]
@@ -10858,11 +10869,12 @@ impl TerminalView {
         ctx: &mut ViewContext<Self>,
     ) -> bool {
         // Only reset focus if this terminal is focused; don't steal it from another part
-        // of the app, or from an AI block / code diff the user is navigating.
+        // of the app, or from an interactive child the user is navigating/editing.
         let reset_focus = ctx.is_self_or_child_focused()
             && !self.find_bar.is_self_or_child_focused(ctx)
             && !self.block_filter_editor.is_self_or_child_focused(ctx)
-            && !self.is_any_ai_block_focused(ctx);
+            && !self.is_any_ai_block_focused(ctx)
+            && !self.is_queued_prompt_inline_editor_focused(ctx);
         if reset_focus {
             self.redetermine_global_focus_with_policy(selection_focus_policy, ctx);
         }

--- a/app/src/terminal/view/queued_prompts_panel.rs
+++ b/app/src/terminal/view/queued_prompts_panel.rs
@@ -330,6 +330,13 @@ impl QueuedPromptsPanelView {
                 .is_some_and(|row| !row.is_locked())
     }
 
+    /// Returns whether the reusable inline edit editor is currently holding focus for an active
+    /// queued prompt row. Parent views use this to avoid stealing focus during async AI/tool
+    /// updates.
+    pub fn is_inline_edit_editor_focused(&self, ctx: &AppContext) -> bool {
+        self.editing_row_id(ctx).is_some() && self.edit_editor.is_focused(ctx)
+    }
+
     /// Re-renders when the host input transitions between empty and non-empty, so the header
     /// hint tracks whether Enter would send.
     fn handle_host_editor_event(&mut self, event: &EditorEvent, ctx: &mut ViewContext<Self>) {
@@ -686,6 +693,7 @@ impl QueuedPromptsPanelView {
         self.should_show_enter_hint(ctx)
     }
 
+    /// Test helper: replaces the inline edit editor buffer.
     pub(super) fn set_edit_buffer_text_for_test(
         &mut self,
         text: &str,
@@ -694,6 +702,11 @@ impl QueuedPromptsPanelView {
         self.edit_editor.update(ctx, |editor, ctx| {
             editor.set_buffer_text(text, ctx);
         });
+    }
+
+    /// Test accessor: whether the inline edit editor currently owns focus.
+    pub(super) fn inline_edit_editor_focused_for_test(&self, ctx: &AppContext) -> bool {
+        self.is_inline_edit_editor_focused(ctx)
     }
 }
 

--- a/app/src/terminal/view/queued_prompts_panel.rs
+++ b/app/src/terminal/view/queued_prompts_panel.rs
@@ -333,7 +333,7 @@ impl QueuedPromptsPanelView {
     /// Returns whether the reusable inline edit editor is currently holding focus for an active
     /// queued prompt row. Parent views use this to avoid stealing focus during async AI/tool
     /// updates.
-    pub fn is_inline_edit_editor_focused(&self, ctx: &AppContext) -> bool {
+    pub(in crate::terminal) fn is_inline_edit_editor_focused(&self, ctx: &AppContext) -> bool {
         self.editing_row_id(ctx).is_some() && self.edit_editor.is_focused(ctx)
     }
 
@@ -702,11 +702,6 @@ impl QueuedPromptsPanelView {
         self.edit_editor.update(ctx, |editor, ctx| {
             editor.set_buffer_text(text, ctx);
         });
-    }
-
-    /// Test accessor: whether the inline edit editor currently owns focus.
-    pub(super) fn inline_edit_editor_focused_for_test(&self, ctx: &AppContext) -> bool {
-        self.is_inline_edit_editor_focused(ctx)
     }
 }
 

--- a/app/src/terminal/view/queued_prompts_tests.rs
+++ b/app/src/terminal/view/queued_prompts_tests.rs
@@ -1451,6 +1451,57 @@ fn build_panel_with_active_conversation(
 }
 
 #[test]
+fn redetermine_terminal_focus_preserves_focused_queued_prompt_editor() {
+    App::test((), |mut app| async move {
+        let _queue_flag = FeatureFlag::QueueSlashCommand.override_enabled(true);
+        initialize_app_for_terminal_view(&mut app);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        let terminal_view_id = terminal.read(&app, |view, _| view.view_id);
+        let conversation_id =
+            BlocklistAIHistoryModel::handle(&app).update(&mut app, |history, ctx| {
+                let id = history.start_new_conversation(
+                    terminal_view_id,
+                    false,
+                    false,
+                    false,
+                    ctx,
+                );
+                history.set_active_conversation_id(id, terminal_view_id, ctx);
+                id
+            });
+        let input = terminal.read(&app, |view, _| view.input.clone());
+        let panel = input
+            .read(&app, |input, _| input.queued_prompts_panel().cloned())
+            .expect("queue flag should create a queued prompts panel");
+        let row_id = QueuedQueryModel::handle(&app).update(&mut app, |model, ctx| {
+            model.append(conversation_id, user_query("edit me"), ctx)
+        });
+
+        panel.update(&mut app, |panel, ctx| {
+            panel.handle_action(&QueuedPromptsPanelAction::StartEditingRow(row_id), ctx);
+        });
+        panel.read(&app, |panel, ctx| {
+            assert!(panel.inline_edit_editor_focused_for_test(ctx));
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            assert!(
+                !view.redetermine_terminal_focus(ctx),
+                "focused queued-prompt edits should hold focus during async focus reconciliation"
+            );
+        });
+
+        panel.read(&app, |panel, ctx| {
+            assert!(panel.inline_edit_editor_focused_for_test(ctx));
+        });
+        QueuedQueryModel::handle(&app).read(&app, |model, _| {
+            assert_eq!(model.editing_row(conversation_id), Some(row_id));
+        });
+    });
+}
+
+#[test]
 fn can_send_prompt_gates_buttons_and_hint_while_nonempty_input_gates_only_the_hint() {
     // When the host reports prompts cannot be sent (read-only shared-session viewer), every
     // row's send-now button is disabled and the enter hint hides. A non-empty input hides the

--- a/app/src/terminal/view/queued_prompts_tests.rs
+++ b/app/src/terminal/view/queued_prompts_tests.rs
@@ -1460,13 +1460,7 @@ fn redetermine_terminal_focus_preserves_focused_queued_prompt_editor() {
         let terminal_view_id = terminal.read(&app, |view, _| view.view_id);
         let conversation_id =
             BlocklistAIHistoryModel::handle(&app).update(&mut app, |history, ctx| {
-                let id = history.start_new_conversation(
-                    terminal_view_id,
-                    false,
-                    false,
-                    false,
-                    ctx,
-                );
+                let id = history.start_new_conversation(terminal_view_id, false, false, false, ctx);
                 history.set_active_conversation_id(id, terminal_view_id, ctx);
                 id
             });
@@ -1482,7 +1476,7 @@ fn redetermine_terminal_focus_preserves_focused_queued_prompt_editor() {
             panel.handle_action(&QueuedPromptsPanelAction::StartEditingRow(row_id), ctx);
         });
         panel.read(&app, |panel, ctx| {
-            assert!(panel.inline_edit_editor_focused_for_test(ctx));
+            assert!(panel.is_inline_edit_editor_focused(ctx));
         });
 
         terminal.update(&mut app, |view, ctx| {
@@ -1493,7 +1487,7 @@ fn redetermine_terminal_focus_preserves_focused_queued_prompt_editor() {
         });
 
         panel.read(&app, |panel, ctx| {
-            assert!(panel.inline_edit_editor_focused_for_test(ctx));
+            assert!(panel.is_inline_edit_editor_focused(ctx));
         });
         QueuedQueryModel::handle(&app).read(&app, |model, _| {
             assert_eq!(model.editing_row(conversation_id), Some(row_id));


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

There was an issue where, whenever the agent executed a tool call, the queued prompt editor would close. This was because the editor closes on-blur, but there's some refocus events that happen in the course of a normal conversation that we need to explicitly ignore (the regular input already does this).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/f43ace3fd18e4239a24f114d53443761

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode