### PR TITLE
spec(GH11963): custom-endpoint model config & capability parity

### DIFF
--- a/specs/GH11963/audit.md
+++ b/specs/GH11963/audit.md
@@ -1,0 +1,161 @@
+# GH11963: Context & Capability Parity Audit — Hosted vs. Custom-Endpoint Models
+
+> Evidence-backed audit answering the question: *"Is the context sent to Warp's
+> hosted agent the same context sent to custom (BYO) endpoint models, and where
+> do open models get a penalty?"* All references are `file:line` against the
+> tree this audit was written from. Read this before the product/tech specs.
+
+## TL;DR
+
+The hypothesis is **half true, and the wrong half matters**:
+
+- ✅ **The context *body* is already unified.** Files, git, project rules,
+  codebase index, MCP, skills, attachments, environment — every `InputContext`
+  element is assembled and serialized identically regardless of model type. The
+  request goes to **one** server endpoint chosen by *request type*, never by
+  model. There is no client-side context-trimming branch for custom models.
+- ⚠️ **The penalty is real but lives in two other layers:**
+  1. **Model metadata is stubbed** for custom models (zeroed context window,
+     no reasoning level, `provider: Unknown`, empty host configs).
+  2. **Capability flags** in the request are partly hardcoded and are being
+     *forked* per-model-type by in-flight PRs — the opposite of consolidation.
+
+So "consolidate so there's no penalty for open models" is best framed not as
+"send the same context" (already done) but as **"give custom models real
+capability metadata and derive request capabilities from that metadata uniformly,
+instead of stubbing the model and hardcoding/branching the flags."**
+
+## 1. The request is built once and routed by type, not model
+
+`app/src/ai/agent/api/impl.rs:61-136` constructs a single `api::Request`. The
+`InputContext` (`input`), `mcp_context`, `task_context`, rules toggle, Warp Drive
+toggle, and web-context toggle are all set unconditionally:
+
+- `impl.rs:65` — `input: Some(convert_input(params.input)?)`
+- `impl.rs:74-76` — `rules_enabled`, `warp_drive_context_enabled`,
+  `web_context_retrieval_enabled` — no model branch
+- `impl.rs:135` — `mcp_context: params.mcp_context.map(Into::into)`
+
+`app/src/ai/agent/api/convert_to.rs` → `convert_context()` walks every
+`AIAgentContext` variant (shell commands, dir, selection, env, time, images,
+codebases, project rules, files, git, repos, PRs, skills) with **no** conditional
+on model, provider, or capability. Likewise `convert_input()`.
+
+Dispatch: `app/src/server/server_api.rs` → `generate_multi_agent_output()`
+selects the URL purely from `is_evals` and `is_passive`
+(`.../ai/multi-agent` vs `.../ai/passive-suggestions`). **Model type never enters
+URL selection.** Custom-endpoint requests traverse the identical client path and
+hit the same Warp backend, which then forwards to the user's endpoint (confirmed
+by the data-flow spec in PR #12003 / issue #11681: keys are stored locally, the
+request is routed in-flight through Warp's backend).
+
+**Conclusion for layer 1:** the context payload is already at parity. Nothing to
+"consolidate" here beyond documenting it.
+
+## 2. Custom-model metadata is stubbed — the real penalty source
+
+`app/src/ai/llms.rs:1338` `custom_llm_info_from()` builds the `LLMInfo` for every
+custom-endpoint model:
+
+```rust
+reasoning_level: None,                      // :1344
+provider: LLMProvider::Unknown,             // :1353
+host_configs: HashMap::new(),               // :1354
+context_window: LLMContextWindow::default() // :1356  -> all zeros
+```
+
+`LLMContextWindow` (`app/src/ai/llms.rs:150-159`) defaults every field to `0`
+(`is_configurable=false, min=0, max=0, default_max=0`).
+
+This zeroed window flows straight into the request:
+
+- `app/src/ai/execution_profiles/mod.rs:145-156`
+  `context_window_limit_for_request()` returns **`None`** for any model whose
+  `LLMContextWindow` is not configurable (`has_configurable_context_window` is
+  false because the window is all zeros).
+- `app/src/ai/agent/api.rs:343-355` reads that `None` into
+  `context_window_limit`.
+- `app/src/ai/agent/api/impl.rs:71`
+  `base_model_context_window_limit: params.context_window_limit.unwrap_or(0)`
+  → the server receives **`0`** ("unknown") for every custom model.
+
+Downstream consequences (all driven by the stub, not by intent):
+
+- Warp's context-window management / truncation / summarization heuristics have
+  no real bound for custom models (this is exactly what issue **#11963**
+  describes).
+- Reasoning features key off `reasoning_level` / model spec — `None` disables
+  them for custom models even when the underlying model supports thinking
+  (issues **#11810**, **#11587**).
+- The long-context pricing warning keys off `provider` + threshold; `Unknown` +
+  `None` implicitly excludes custom models (made explicit by PR #12808).
+
+## 3. Capability flags are hardcoded and being forked per model type
+
+In `app/src/ai/agent/api/impl.rs:66-106`, the `Settings.supports_*` flags are a
+mix of hardcoded `true`, feature-flag reads, and request params — but they are
+**not** derived from the selected model's `LLMInfo`:
+
+- `impl.rs:89` — `supports_reasoning_message: true` (hardcoded)
+- `impl.rs:77` — `supports_parallel_tool_calls: true` (hardcoded)
+- `impl.rs:80,82,84` — `supports_create_files`, `supports_long_running_commands`,
+  `supports_todos_ui` (hardcoded)
+- `impl.rs:104` — `custom_model_providers: params.custom_model_providers`
+  (the only model-aware field, gated upstream)
+
+Custom-model providers are gated separately in
+`crates/ai/src/api_keys.rs:382-420` `custom_model_providers_for_request()` —
+returns `None` when `!include_custom_models` (`:386`), where the flag derives
+from workspace policy (`is_custom_inference_enabled`) + `FeatureFlag::CustomInferenceEndpoints`.
+
+**The divergence trend:** rather than driving these flags from model capabilities,
+in-flight PRs add ad-hoc per-model-type branches:
+
+- **PR #11812** (open) — flips `supports_reasoning_message` *off* for custom
+  endpoints (adds a `supports_reasoning_messages` capability gate). Closes #11810
+  by *removing* a capability rather than modeling it.
+- **PR #12808** (open) — adds `is_custom_endpoint` to `LongContextWarningState`
+  to short-circuit the warning for custom models.
+
+Each is locally reasonable but each adds another scattered `is_custom_endpoint`
+branch. That's the pattern the parity work should replace with a single
+capability source.
+
+## 4. Where consolidation actually belongs
+
+| Layer | State today | Parity action |
+|-------|-------------|---------------|
+| Context body (`InputContext`) | Already unified | Document & regression-test it |
+| Model metadata (`LLMInfo` for custom) | Stubbed/zeroed (`llms.rs:1338`) | Carry real context window + reasoning (issue #11963) |
+| Request capability flags (`impl.rs:66-106`) | Hardcoded + per-type branches | Derive from effective model's `LLMInfo` capabilities |
+| Generation params (temperature, max tokens) | No wire field at all | Needs `warp-proto-apis` change first (deferred) |
+| Server routing/translation | Out of this repo | N/A (Warp backend) |
+
+**Wire check** (`warp-proto-apis` rev `97d1b36`, `request.proto`):
+`ModelConfig.base_model_context_window_limit` (field 6) and
+`Settings.supports_reasoning_message` (field 17) both exist → context-window and
+reasoning parity are wire-supported today. `CustomModel` carries only `slug` +
+`config_key`, and no `temperature`/`max_output_tokens` exists anywhere → generation
+params require a proto change before any client work.
+
+## 5. Related PRs and issues
+
+**PRs — consolidating / metadata:**
+- #12003 — spec: Custom Inference data flow disclosure (local key vs. in-flight routing) — read first
+- #9620 — Spec OpenAI-compatible BYOK endpoints (argues for real custom metadata, not server-approved-only)
+- #12783 — Replace `CustomInferenceEndpoints` flag with `BYO_ENDPOINT` billing policy (gating consolidation)
+- #11731 — auto-discover models from `/v1/models` (would populate real metadata; issue #11514)
+- #12227 (closed) — make long-context pricing warnings *server-driven* (preferred "derive, don't hardcode" pattern)
+- #12775 — Custom Auto Models client request building (touches `api.rs` + `api/impl.rs` — conflict watch)
+
+**PRs — diverging (counter to parity):**
+- #11812 — disable reasoning messages for custom endpoints (closes #11810 by removal)
+- #12808 — gate long-context warning to non-custom endpoints
+
+**Issues:**
+- #11963 — model configuration for custom endpoints (context window, temperature, params) — **primary anchor**
+- #11810 / #11587 — custom/DeepSeek thinking-mode errors / reasoning_content round-trip
+- #11947 — configure max input/output tokens on custom model
+- #11514 — auto-discover models from `/v1/models`
+- #11805 — Anthropic-compatible BYOK endpoints
+- #9303 (closed) / #4339 — original BYO endpoint / local-LLM (Ollama) support

--- a/specs/GH11963/product.md
+++ b/specs/GH11963/product.md
@@ -1,0 +1,111 @@
+# GH11963: Model configuration & capability parity for custom endpoints
+
+## Summary
+Give custom (bring-your-own) endpoint models real, user-configurable metadata —
+context window size and reasoning/thinking capability — and make Warp's Agent Mode
+derive request behavior from that metadata the same way it does for Warp-hosted
+models. (Generation parameters like temperature are part of issue #11963 but are
+deferred here pending a wire/proto change — see Goals.) Today custom models are
+registered
+with a stubbed, all-zero metadata record, so context management, reasoning, and
+context-window features silently degrade. This is the source of the perceived
+"penalty for open models." The context *payload itself* is already identical for
+hosted and custom models (see `specs/GH11963/audit.md`); this spec closes the
+remaining metadata and capability gap.
+
+## Problem
+Custom endpoints are configured GUI-only and expose essentially no model
+settings. As a result (per issue #11963 and confirmed in the audit):
+
+1. **Context window is unknown to Warp.** Custom models register with a zeroed
+   context window, so Warp sends `base_model_context_window_limit = 0` and cannot
+   make informed truncation / summarization / conversation-length decisions.
+2. **Reasoning/thinking is off by default.** Custom models carry no reasoning
+   level, so thinking-capable models (e.g. DeepSeek via OpenRouter) either lose
+   reasoning or error out (issues #11810, #11587). In-flight PR #11812 responds by
+   *disabling* reasoning for all custom endpoints — a regression for models that
+   do support it.
+3. **No generation parameters.** There is no way to set temperature, max output
+   tokens, or provider-specific parameters (issue #11947).
+4. **Capabilities are guessed, not declared.** Because metadata is stubbed,
+   several Warp features fall back to ad-hoc per-model-type branches
+   (`is_custom_endpoint` checks) instead of reading a capability from the model.
+
+## Goals
+1. Let users declare a context window size for each custom model, and have Warp
+   use it for context management exactly as it does for hosted models.
+2. Let users declare whether a custom model supports reasoning/thinking, and route
+   reasoning behavior from that declaration rather than a blanket on/off.
+3. Make custom-model metadata representable in `settings.toml`, not GUI-only, so
+   it is version-controllable and shareable.
+4. Drive Agent Mode request capabilities from the effective model's metadata, so
+   custom and hosted models share one code path and there is no implicit penalty.
+
+> **Generation parameters (temperature, max output tokens) are deferred.** The
+> current request wire (`warp-proto-apis` rev `97d1b36`) has no field for them on
+> `ModelConfig` or the custom-model message (it carries only `slug` +
+> `config_key`). Delivering issue #11963's temperature/param request requires a
+> proto change in the external `warp-proto-apis` repo first; see tech spec
+> "Follow-ups". Context window and reasoning *are* already wire-supported and are
+> the deliverable scope here.
+
+## Non-goals
+1. Do not change the network routing model. Requests continue to flow through
+   Warp's backend; this spec does not propose direct client→endpoint connections
+   (that is issue #12142).
+2. Do not change the context *payload* assembly — it is already unified (audit §1).
+3. Do not implement `/v1/models` auto-discovery here; this spec defines the
+   metadata model that discovery (issue #11514 / PR #11731) can later populate.
+4. Do not redesign the custom-endpoint modal beyond the fields needed for the new
+   metadata.
+5. Do not add server-side provider translation logic (out of this repo).
+
+## Behavior
+1. When adding or editing a custom endpoint model, the user can optionally set:
+   - **Context window** (max tokens the model accepts). Optional; if unset, Warp
+     behaves as today (treats the window as unknown / server default).
+   - **Supports reasoning** (toggle). Default off. When on, Warp keeps the
+     reasoning-message capability enabled for that model.
+
+   (Temperature / max output tokens are deferred pending a wire change — see the
+   Goals note above.)
+2. These fields are persisted with the rest of the custom-endpoint configuration
+   and are also expressible in `settings.toml` under the existing custom-endpoint
+   structure, so they round-trip through settings sync and version control.
+3. With a context window set, Warp uses it for the same context-management,
+   long-context, and configurable-window behaviors available to hosted models —
+   no `is_custom_endpoint` special-casing.
+4. With **Supports reasoning** on, reasoning works for that custom model. With it
+   off, reasoning is suppressed for that model only — not for all custom models,
+   and not for hosted models in the same workspace.
+5. Existing custom models with no configured metadata keep today's behavior
+   exactly (unknown window, reasoning off): this change is additive and
+   backward-compatible.
+6. The custom-endpoint fields are discoverable in settings search via terms like
+   `context window`, `reasoning`, `thinking`, `custom model`.
+7. Invalid values (e.g. a non-numeric context window) fall
+   back to "unset" using the existing settings validation/error behavior rather
+   than blocking the agent.
+
+## Success criteria
+1. A user configures a custom model's context window and Warp's context management
+   respects it (verifiable: the request carries the configured
+   `base_model_context_window_limit` instead of `0`).
+2. A user enables reasoning on a thinking-capable custom model and uses it without
+   the errors reported in #11810 / #11587; a user with reasoning off sees it
+   suppressed for that model only.
+3. Custom-model metadata set in the GUI appears in `settings.toml` and survives a
+   restart and a settings-sync round trip.
+4. Hosted models are unaffected; existing custom models with no new metadata
+   behave exactly as before.
+5. The number of `is_custom_endpoint` / custom-vs-hosted branches in Agent Mode
+   request building does not grow — capability decisions read from model metadata.
+
+## Relationship to other work
+- **Anchors** issue #11963; partially addresses #11810, #11587, #11947.
+- **Supersedes the approach of** PR #11812 (blanket reasoning disable) and PR
+  #12808 (per-type long-context gate) by replacing per-type branches with declared
+  capability. Those PRs can become trivial once metadata drives the flags.
+- **Complements** PR #11731 / issue #11514 (auto-discovery can populate this
+  metadata) and PR #12783 (billing-policy gating).
+- **Builds on** the data-flow disclosure in PR #12003 / issue #11681.

--- a/specs/GH11963/tech.md
+++ b/specs/GH11963/tech.md
@@ -1,0 +1,153 @@
+# GH11963: Tech Spec — Model configuration & capability parity for custom endpoints
+
+## Context
+Product behavior is in `specs/GH11963/product.md`; the evidence audit is in
+`specs/GH11963/audit.md`. This spec adds optional per-model metadata to the
+custom-endpoint config and threads it through the existing model-info and request
+paths so custom and hosted models share one capability code path. **No change to
+the context payload** (already unified — audit §1) and **no change to network
+routing**.
+
+Key existing paths (verified `file:line`):
+
+- `crates/ai/src/api_keys.rs:42-60` — `CustomEndpoint { name, url, api_key, models }`
+  and `CustomEndpointModel { name, alias, config_key }`. Both derive
+  `Serialize/Deserialize` with `#[serde(default)]`, so adding optional fields is
+  backward-compatible and round-trips through the persisted blob.
+- `crates/ai/src/api_keys.rs:382-420` — `custom_model_providers_for_request()`
+  builds the `CustomModelProviders` wire payload from these structs; gated by
+  `include_custom_models` (`:386`).
+- `app/src/ai/llms.rs:1338-1358` — `custom_llm_info_from()` constructs the
+  `LLMInfo` for each custom model. This is where the stub lives:
+  `reasoning_level: None` (`:1344`), `provider: LLMProvider::Unknown` (`:1353`),
+  `host_configs: HashMap::new()` (`:1354`),
+  `context_window: LLMContextWindow::default()` (`:1356`).
+- `app/src/ai/llms.rs:1324-1336` — `build_custom_llm_infos()` iterates endpoints×
+  models and calls `custom_llm_info_from`.
+- `app/src/ai/llms.rs:150-159` — `LLMContextWindow { is_configurable, min, max,
+  default_max }` (all `0` by default).
+- `app/src/ai/execution_profiles/mod.rs:129-156` — `configurable_context_window()`
+  and `context_window_limit_for_request()`; the latter returns `None` unless
+  `has_configurable_context_window(llm, ...)` is true, then
+  `self.context_window_limit.map(|l| l.clamp(min, max))`.
+- `app/src/ai/agent/api.rs:343-355` — reads `context_window_limit_for_request(app)`
+  into `RequestParams.context_window_limit`.
+- `app/src/ai/agent/api/impl.rs:66-106` — the `Settings` block: `model_config`
+  (`:67-73`, incl. `base_model_context_window_limit: ...unwrap_or(0)` at `:71`),
+  hardcoded `supports_reasoning_message: true` (`:89`), and other `supports_*`
+  flags; `custom_model_providers` (`:104`).
+- `app/src/settings_view/ai_page.rs:8062` — `render_custom_endpoints_list` and the
+  custom-endpoint modal (add/edit/save handlers around `:2119-2200`,
+  `crates/ai/src/api_keys.rs:257-330`).
+
+**Wire/proto verification** (`warp_multi_agent_api` = `warpdotdev/warp-proto-apis`
+rev `97d1b367b955c562812e0a1315a6ec7ee6a5389e`, `apis/multi_agent/v1/request.proto`):
+- `Settings.ModelConfig.base_model_context_window_limit` (uint32, field 6) exists —
+  *"Zero or unset means use the model's default max."* Context-window parity is
+  wire-supported; we populate this field instead of sending `0`.
+- `Settings.supports_reasoning_message` (bool, field 17) exists at the request
+  level — reasoning parity is wire-supported by driving this flag from the model.
+- `Settings.ApiKeys.CustomModelProviders.CustomModel` carries only `slug` and
+  `config_key`. There is **no** `temperature`, `top_p`, `max_output_tokens`, or
+  `max_tokens` anywhere in the request. Per-model generation parameters therefore
+  require a `warp-proto-apis` change first — out of scope here (see Follow-ups).
+
+## Proposed changes
+
+### 1. Add optional metadata to the custom-model config (`crates/ai/src/api_keys.rs`)
+Extend `CustomEndpointModel` (`:51-60`) with optional, defaulted fields so existing
+persisted blobs deserialize unchanged:
+
+```rust
+pub struct CustomEndpointModel {
+    pub name: String,
+    pub alias: Option<String>,
+    pub config_key: String,
+    #[serde(default)] pub context_window: Option<u32>,     // max input tokens
+    #[serde(default)] pub supports_reasoning: bool,        // default false
+}
+```
+
+Only fields that are expressible on the current wire are persisted. Temperature /
+max output tokens are intentionally omitted until the proto carries them (see
+Follow-ups) — persisting a field the client cannot send would be dead state.
+
+Because the struct already round-trips through the `ApiKeys` blob, this is the
+`settings.toml`-representable surface product goal 4 asks for. Keep validation
+permissive (product behavior §7): drop invalid values to `None`/default at parse
+or save time using the existing settings-validation path.
+
+### 2. Populate real `LLMInfo` from the metadata (`app/src/ai/llms.rs:1338`)
+In `custom_llm_info_from()`, map the new fields instead of stubbing:
+- `context_window`: when `model.context_window` is `Some(n)`, build an
+  `LLMContextWindow { is_configurable: false, min: n, max: n, default_max: n }`
+  (or `is_configurable: true` with a sensible min if we want the configurable-window
+  UI). When `None`, keep `LLMContextWindow::default()` (today's behavior →
+  backward compatible).
+- `reasoning_level`: derive a non-`None` level when `model.supports_reasoning` is
+  true (reuse the same representation hosted reasoning models use; exact string/enum
+  TBD against `LLMSpec`).
+- Leave `provider: LLMProvider::Unknown` unless we add a declared provider later;
+  parity does not require a real provider, only real capabilities.
+
+This makes `has_configurable_context_window` / `context_window_limit_for_request`
+(`execution_profiles/mod.rs:145-156`) return the configured window for custom
+models, so `impl.rs:71` sends the real `base_model_context_window_limit` instead of
+`0` — satisfying success criterion 1 with no change to those call sites.
+
+### 3. Derive request capabilities from the effective model (`app/src/ai/agent/api/impl.rs`)
+Replace the hardcoded `supports_reasoning_message: true` (`:89`) with a value
+derived from the effective base model's `LLMInfo` (e.g. a
+`model_supports_reasoning(&effective_model)` helper that reads `reasoning_level`/
+spec). Thread the effective `LLMInfo` (or a small extracted `ModelCapabilities`
+struct) into `RequestParams` so `generate_multi_agent_output` reads capabilities
+from one source. This is the consolidation: one capability source for hosted and
+custom models, replacing the per-type branches PR #11812 / #12808 introduce.
+
+Generation params (temperature / max output tokens) are **not** built here: the
+wire has no field for them (see Wire/proto verification). They are deferred to a
+follow-up that first adds fields to `warp-proto-apis`.
+
+### 4. Settings UI (`app/src/settings_view/ai_page.rs`)
+Add the optional fields to the custom-endpoint add/edit modal next to the model
+name/alias inputs: a numeric "Context window" and a "Supports reasoning" toggle.
+Wire them through the existing `add_custom_endpoint` / `save_custom_endpoint`
+handlers (`crates/ai/src/api_keys.rs:257-330`). Add settings-search terms per
+product §6.
+
+## Testing and validation
+- Unit: `custom_llm_info_from` maps a configured window/reasoning into `LLMInfo`;
+  `None`/false reproduces today's stub (backward-compat). Add to `llms_tests.rs`.
+- Unit: `context_window_limit_for_request` returns the configured window for a
+  custom model and `None` when unset (extend
+  `execution_profiles/editor/mod_tests.rs`).
+- Unit: capability helper drives `supports_reasoning_message` on/off per model;
+  hosted models unchanged (extend `app/src/ai/agent/api/impl_tests.rs` — same file
+  PR #11812 touches).
+- Serde round-trip: `CustomEndpointModel` with and without new fields
+  (`api_keys_tests.rs`).
+- Manual: configure a custom model window, confirm request carries it (not `0`);
+  toggle reasoning and confirm per-model effect.
+
+## Risks & coordination
+- **Merge conflicts**: PR #12775 (Custom Auto Models) edits `api.rs` + `api/impl.rs`;
+  PR #11812 edits `impl.rs` + `impl_tests.rs`; PR #12808 edits the usage/footer
+  paths. Coordinate ordering — ideally land the capability-source refactor (step 3)
+  so #11812/#12808 simplify into it rather than conflict.
+- **Reasoning representation**: needs to match what hosted reasoning models and the
+  server expect; underspecified models (DeepSeek round-trip, #11587) may need
+  server-side support beyond this client change — keep the toggle conservative.
+- **Server contract**: sending a real `base_model_context_window_limit` for custom
+  models assumes the backend honors it for forwarded endpoints; verify against the
+  data-flow described in PR #12003 before shipping.
+
+## Follow-ups
+- **Generation parameters (issue #11963, #11947)**: temperature / max output tokens
+  need new fields on `warp-proto-apis`
+  (`Settings.ApiKeys.CustomModelProviders.CustomModel` and/or `ModelConfig`) before
+  any client work. Sequence: proto PR → bump the `warp_multi_agent_api` rev in
+  `Cargo.toml:338` → persist + send the values → modal UI.
+- **`/v1/models` auto-discovery (issue #11514 / PR #11731)** can populate
+  `context_window` / reasoning automatically once this metadata model exists.
+- **Per-model reasoning protocol (issue #11587)**: DeepSeek-style
+  `reasoning_content` round-trips may need server support beyond the client flag.


### PR DESCRIPTION
## Description

Spec PR (product + tech spec, plus an evidence audit) for giving custom
(bring-your-own) endpoint models real, user-configurable metadata and deriving
Agent Mode request capabilities from it the same way Warp-hosted models do.

Motivation: investigating whether custom/open models get a "context penalty"
versus Warp's hosted agent. The audit (`specs/GH11963/audit.md`) shows the
**context payload is already unified** — the divergence is in (a) stubbed custom
model metadata (`app/src/ai/llms.rs:1338` → zeroed `context_window`,
`reasoning_level: None`, `provider: Unknown`) and (b) hardcoded / per-model-type
capability flags (`app/src/ai/agent/api/impl.rs:89`). The spec consolidates these
onto one capability source.

Scope was verified against the request wire (`warp-proto-apis` rev `97d1b36`):
- ✅ `ModelConfig.base_model_context_window_limit` and
  `Settings.supports_reasoning_message` exist → context-window + reasoning parity
  are wire-supported and in scope.
- ⏭️ No `temperature` / `max_output_tokens` field exists anywhere →
  generation params are deferred to a proto-first follow-up (documented in the
  tech spec).

This approach intentionally supersedes the per-model-type branches added in
#11812 (disable reasoning for custom) and #12808 (gate long-context warning),
folding them into declared model capability.

Files:
- `specs/GH11963/product.md` — behavior invariants, goals/non-goals
- `specs/GH11963/tech.md` — implementation plan grounded in code + wire verification
- `specs/GH11963/audit.md` — supporting evidence (file:line) for the parity claim

## Linked Issue

Fixes #11963 after spec approval + implementation. Related: #11810, #11587,
#11947, #11514.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

> Note: #11963 is currently `enhancement`/`triaged`, not yet `ready-to-spec`.
> Opening as a **draft** to give maintainers concrete scope to accept, edit, or
> reject before implementation — mirroring the approach in #9620. @oss-maintainers
> for readiness re-evaluation.

## Testing

Spec-only change (Markdown under `specs/`). No application code changed.
- `git diff --cached --check` — clean (no whitespace errors).
- No automated tests apply; no manual app testing required for a docs-only spec PR.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->
