### PR TITLE
Fix text selection not starting over markdown tables

### DIFF
--- a/crates/warpui_core/src/elements/gui/table/mod.rs
+++ b/crates/warpui_core/src/elements/gui/table/mod.rs
@@ -1212,6 +1212,7 @@ impl Element for Table {
         // Start clipping layer for body content
         ctx.scene
             .start_layer(ClipBounds::BoundedByActiveLayerAnd(body_clip_rect));
+        ctx.scene.set_active_layer_click_through();
 
         // In scrolling mode, paint header INSIDE the clip so it gets clipped at table bounds
         if !uses_fixed_header && header_visible {


### PR DESCRIPTION
## Description
Fixes being unable to start a text selection inside a rendered Markdown table in agent output (e.g. clicking and dragging within a table no longer does nothing).

**Root cause:** The WarpUI `Table` paints its row/header backgrounds and dividers with `draw_rect_with_hit_recording`, in a paint layer above the enclosing `SelectableArea`. On `LeftMouseDown`, `SelectableArea` bails when the point is "covered" (`event.at_z_index(...).is_none()`), so a mouse-down that originates over the table never starts a selection. Drag events aren't subject to that coverage check, which is exactly why starting a selection *outside* the table and dragging in worked, but starting *inside* the table did nothing.

**Fix:** Mark the `Table`'s body paint layer click-through (`set_active_layer_click_through`) so its decorative chrome no longer makes the underlying `SelectableArea` treat the point as covered. This mirrors the notebook/editor table renderer (`crates/editor/src/render/element/table.rs`), which already marks its paint layer click-through.

https://www.loom.com/share/7dd109b714324afb82d08c88adb758e1

## Linked Issue
https://github.com/warpdotdev/warp/issues/12751
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing
- `cargo fmt` and `cargo clippy -p warpui_core -- -D warnings` pass.
- Verified the behavior with computer use using the `table-sample` example's selection demo (screenshot below): a click-drag that starts inside the table now selects text.
- Follow-up: a deterministic regression test can be added in `crates/warpui_core/src/elements/table/mod_tests.rs` (App::test harness) asserting that a `LeftMouseDown` over a `Table` inside a `SelectableArea` starts a selection.

- [x] I have manually tested my changes locally

### Screenshots / Videos
_Computer-use verification screenshot attached in the originating Oz conversation._

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed being unable to select text in a rendered Markdown table in agent output when the selection starts inside the table.
-->

_Conversation: https://staging.warp.dev/conversation/9b55249d-1f57-4c94-87d0-c696c19628bf_
_Run: https://oz.staging.warp.dev/runs/019ed67b-be88-7b9d-94f4-24714fca3f2e_

_This PR was generated with [Oz](https://warp.dev/oz)._


<!-- factory-client: {"source":"factory-client","slack_channel":"C0BCE7AELJ2","slack_thread_ts":"1784048233.627109","slack_permalink":"https://warpdev.slack.com/archives/C0BCE7AELJ2/p1784048233627109?thread_ts=1784048233.627109&cid=C0BCE7AELJ2","oz_run_id":"019f618f-b178-7f03-b31e-b4310e934104","repo":"warpdotdev/warp","pr_url":"https://github.com/warpdotdev/warp/pull/12841"} -->
