### PR TITLE
Improve tracing for parallel fetch that blocks cloud agent init.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15169,6 +15169,7 @@ dependencies = [
  "tink-core",
  "tink-hybrid",
  "tink-proto",
+ "tracing",
  "vec1",
  "warp_core",
  "warp_graphql",

--- a/app/src/ai/agent_sdk/driver/attachments.rs
+++ b/app/src/ai/agent_sdk/driver/attachments.rs
@@ -31,6 +31,7 @@ pub const MAX_ATTACHMENT_COUNT_FOR_CLOUD_QUERY: usize = 25;
 ///
 /// Makes a best-effort attempt to download all attachments.
 /// Individual download failures are logged but don't cause the entire function to fail.
+#[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
 pub(crate) async fn fetch_and_download_attachments(
     ai_client: Arc<dyn AIClient>,
     http_client: Arc<ServerApi>,
@@ -66,6 +67,7 @@ pub(crate) async fn fetch_and_download_attachments(
 /// logged at WARN level inside this function; per-file errors are not surfaced to callers.
 ///
 /// Fatal failures (listing the attachments, creating the handoff dir) return `Err`.
+#[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
 pub(crate) async fn fetch_and_download_handoff_snapshot_attachments(
     ai_client: Arc<dyn AIClient>,
     http_client: &http_client::Client,
@@ -220,13 +222,20 @@ async fn download_handoff_entry(
 /// Shared download primitive: GET `download_url`, write the body to `file_path`, and retry
 /// transient HTTP failures on the shared bounded-backoff schedule. Non-2xx responses surface
 /// an [`HttpStatusError`] so the retry classifier can decide whether to retry.
+#[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
 async fn download_attachment(
     http_client: &http_client::Client,
     download_url: &str,
     file_path: &Path,
 ) -> anyhow::Result<()> {
     let operation = format!("download attachment '{}'", file_path.display());
-    with_bounded_retry(&operation, || async {
+
+    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
+    async fn attempt(
+        http_client: &http_client::Client,
+        download_url: &str,
+        file_path: &Path,
+    ) -> anyhow::Result<()> {
         let response = http_client
             .get(download_url)
             .send()
@@ -255,6 +264,10 @@ async fn download_attachment(
             .context("Failed to write file")?;
 
         Ok(())
+    }
+    
+    with_bounded_retry(&operation, || async {
+        attempt(http_client, download_url, file_path).await
     })
     .await
 }

--- a/app/src/ai/agent_sdk/driver/attachments.rs
+++ b/app/src/ai/agent_sdk/driver/attachments.rs
@@ -265,7 +265,7 @@ async fn download_attachment(
 
         Ok(())
     }
-    
+
     with_bounded_retry(&operation, || async {
         attempt(http_client, download_url, file_path).await
     })

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -2021,6 +2021,7 @@ impl AIClient for ServerApi {
         Ok(response)
     }
 
+    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
     async fn get_ambient_agent_task(
         &self,
         task_id: &AmbientAgentTaskId,
@@ -2354,6 +2355,7 @@ impl AIClient for ServerApi {
         }
     }
 
+    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
     async fn get_task_attachments(
         &self,
         task_id: String,
@@ -2515,6 +2517,7 @@ impl AIClient for ServerApi {
         Ok(response)
     }
 
+    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
     async fn get_handoff_snapshot_attachments(
         &self,
         task_id: &AmbientAgentTaskId,

--- a/crates/managed_secrets/Cargo.toml
+++ b/crates/managed_secrets/Cargo.toml
@@ -19,6 +19,7 @@ thiserror.workspace = true
 tink-core = "0.3"
 tink-proto = "0.3"
 tink-hybrid = "0.3"
+tracing.workspace = true
 zeroize = "1.8"
 warpui_core.workspace = true
 warp_core.workspace = true

--- a/crates/managed_secrets/src/manager.rs
+++ b/crates/managed_secrets/src/manager.rs
@@ -161,8 +161,9 @@ impl ManagedSecretManager {
         &self,
         task_id: String,
     ) -> impl Future<Output = anyhow::Result<HashMap<String, ManagedSecretValue>>> + use<> {
-        let client = self.client.clone();
-        async move {
+        // Define and invoke an inner async function to simplify tracing instrumentation.
+        #[tracing::instrument(name = "get_task_secrets", skip_all, err, fields(tags.cloud_agent = true))]
+        async fn inner(client: Arc<dyn ManagedSecretsClient>, task_id: String) -> anyhow::Result<HashMap<String, ManagedSecretValue>> {
             // We only need the workload token for the duration of the request.
             let workload_token =
                 warp_isolation_platform::issue_workload_token(Some(Duration::from_mins(5))).await?;
@@ -209,6 +210,8 @@ impl ManagedSecretManager {
             }
             Ok(secrets)
         }
+
+        inner(self.client.clone(), task_id)
     }
 
     /// Issue a short-lived OIDC identity token for the current task.

--- a/crates/managed_secrets/src/manager.rs
+++ b/crates/managed_secrets/src/manager.rs
@@ -163,7 +163,10 @@ impl ManagedSecretManager {
     ) -> impl Future<Output = anyhow::Result<HashMap<String, ManagedSecretValue>>> + use<> {
         // Define and invoke an inner async function to simplify tracing instrumentation.
         #[tracing::instrument(name = "get_task_secrets", skip_all, err, fields(tags.cloud_agent = true))]
-        async fn inner(client: Arc<dyn ManagedSecretsClient>, task_id: String) -> anyhow::Result<HashMap<String, ManagedSecretValue>> {
+        async fn inner(
+            client: Arc<dyn ManagedSecretsClient>,
+            task_id: String,
+        ) -> anyhow::Result<HashMap<String, ManagedSecretValue>> {
             // We only need the workload token for the duration of the request.
             let workload_token =
                 warp_isolation_platform::issue_workload_token(Some(Duration::from_mins(5))).await?;


### PR DESCRIPTION
## Description

I found a couple traces on staging where cloud agent initialization fails during a span that currently covers four parallel async fetches of various things the agent needs before it can start running.

Example 1: [trace](https://console.cloud.google.com/traces/explorer;query=%7B%22timeSeriesQuery%22:%7B%22traceQuery%22:%7B%22resourceContainer%22:%22projects%2Fwarp-server-staging%2Flocations%2Fglobal%2FtraceScopes%2F_Default%22,%22spanDataValue%22:%22SPAN_DURATION%22,%22spanFilters%22:%7B%22services%22:%5B%22warp-cloud-agent%22%5D,%22displayNames%22:%5B%5D,%22status%22:%5B%22STATUS_CODE_ERROR%22%5D,%22kinds%22:%5B%5D,%22attributes%22:%5B%5D,%22isRootSpan%22:false,%22applicationIds%22:%5B%5D,%22apphubServices%22:%5B%5D,%22apphubWorkloads%22:%5B%5D%7D%7D%7D,%22plotType%22:%22HEATMAP%22%7D;traceId=56f6f213b6d8dfed809bb63a72fdfb93;spanId=c8e8e7f831c063d4;duration=P2D?project=warp-server-staging)
Example 2: [trace](https://console.cloud.google.com/traces/explorer;query=%7B%22timeSeriesQuery%22:%7B%22traceQuery%22:%7B%22resourceContainer%22:%22projects%2Fwarp-server-staging%2Flocations%2Fglobal%2FtraceScopes%2F_Default%22,%22spanDataValue%22:%22SPAN_DURATION%22,%22spanFilters%22:%7B%22services%22:%5B%22warp-cloud-agent%22%5D,%22displayNames%22:%5B%5D,%22status%22:%5B%22STATUS_CODE_ERROR%22%5D,%22kinds%22:%5B%5D,%22attributes%22:%5B%5D,%22isRootSpan%22:false,%22applicationIds%22:%5B%5D,%22apphubServices%22:%5B%5D,%22apphubWorkloads%22:%5B%5D%7D%7D%7D,%22plotType%22:%22HEATMAP%22%7D;traceId=22f18943127f8cb3471430f19a10ee6b;spanId=7a8de15c7edc73cc;duration=P2D?project=warp-server-staging)

In order to better understand exactly what's going wrong here, I've added additional trace spans so we can see the contribution of each of these components, and get better insight into what's slow and what fails.