### PR TITLE
Add command completion metadata to Precmd

### DIFF
--- a/app/assets/bundled/bootstrap/bash_body.sh
+++ b/app/assets/bundled/bootstrap/bash_body.sh
@@ -435,14 +435,15 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
         # executed within this block instead of the actual last
         # command that was run.
         local exit_code=$?
+        local next_block_id="precmd-$WARP_SESSION_ID-$((block_id++))"
         if [ "$WARP_IN_MSYS2" = true ]; then
           warp_send_hook_via_kv_pairs_start "CommandFinished"
           warp_send_hook_kv_pair "exit_code" "$exit_code"
-          warp_send_hook_kv_pair "next_block_id" "precmd-$WARP_SESSION_ID-$((block_id++))"
+          warp_send_hook_kv_pair "next_block_id" "$next_block_id"
           warp_send_hook_kv_pair "session_id" "$WARP_SESSION_ID"
           warp_send_hook_via_kv_pairs_end
         else
-          warp_send_json_message "{\"hook\": \"CommandFinished\", \"value\": {\"exit_code\": $exit_code, \"next_block_id\": \"precmd-$WARP_SESSION_ID-$((block_id++))\", \"session_id\": $WARP_SESSION_ID}}"
+          warp_send_json_message "{\"hook\": \"CommandFinished\", \"value\": {\"exit_code\": $exit_code, \"next_block_id\": \"$next_block_id\", \"session_id\": $WARP_SESSION_ID}}"
         fi
 
         warp_maybe_send_reset_grid_osc
@@ -465,6 +466,8 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
 
             unset _WARP_GENERATOR_COMMAND
             warp_send_json_message "{\"hook\": \"Precmd\", \"value\": {
+            \"exit_code\": $exit_code,
+            \"next_block_id\": \"$next_block_id\",
             \"pwd\": \"\",
             \"ps1\": \"\",
             \"git_head\": \"\",
@@ -670,6 +673,8 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
         # We send the escaped PS1, if we are in active Warp prompt mode, for prompt preview rendering (note the shell's PS1 is unset in this case).
         if [ "$WARP_IN_MSYS2" = true ]; then
           warp_send_hook_via_kv_pairs_start "Precmd"
+          warp_send_hook_kv_pair "exit_code" "$exit_code"
+          warp_send_hook_kv_pair "next_block_id" "$next_block_id"
           warp_send_hook_kv_pair "pwd" "$PWD"
           warp_send_hook_kv_pair_escaped "ps1" "$deref_ps1"
           warp_send_hook_kv_pair "ps1_is_encoded" "false"
@@ -683,6 +688,8 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
           warp_send_hook_via_kv_pairs_end
         else
           local escaped_json="{\"hook\": \"Precmd\", \"value\": {
+          \"exit_code\": $exit_code,
+          \"next_block_id\": \"$next_block_id\",
           \"pwd\": \"$escaped_pwd\",
           \"ps1\": \"$escaped_ps1\",
           \"honor_ps1\": $honor_ps1,

--- a/app/assets/bundled/bootstrap/fish.sh
+++ b/app/assets/bundled/bootstrap/fish.sh
@@ -278,7 +278,8 @@ function warp_precmd --on-event fish_prompt --on-event fish_posterror
         set exit_code 1
     end
 
-    warp_send_json_message "{\"hook\": \"CommandFinished\", \"value\": {\"exit_code\": $exit_code, \"next_block_id\": \"precmd-$WARP_SESSION_ID-$block_id\", \"session_id\": $WARP_SESSION_ID}}"
+    set -l next_block_id "precmd-$WARP_SESSION_ID-$block_id"
+    warp_send_json_message "{\"hook\": \"CommandFinished\", \"value\": {\"exit_code\": $exit_code, \"next_block_id\": \"$next_block_id\", \"session_id\": $WARP_SESSION_ID}}"
     warp_maybe_send_reset_grid_osc
 
     set block_id (math $block_id + 1)
@@ -286,6 +287,8 @@ function warp_precmd --on-event fish_prompt --on-event fish_posterror
     if ! test -z $_WARP_GENERATOR_COMMAND
         set -e _WARP_GENERATOR_COMMAND
         set -l escaped_json "{\"hook\": \"Precmd\", \"value\": {
+        \"exit_code\": $exit_code,
+        \"next_block_id\": \"$next_block_id\",
         \"pwd\": \"\",
         \"ps1\": \"\",
         \"git_head\": \"\",
@@ -440,6 +443,8 @@ function warp_precmd --on-event fish_prompt --on-event fish_posterror
     if test "$WARP_HONOR_PS1" = "1"
       # Don't send lprompt or rprompt in this case - we'll use prompt markers for both directly!
       set escaped_json "{\"hook\": \"Precmd\", \"value\": {
+      \"exit_code\": $exit_code,
+      \"next_block_id\": \"$next_block_id\",
       \"pwd\": \"$escaped_pwd\",
       \"ps1\": \"\",
       \"rprompt\": \"\",
@@ -453,6 +458,8 @@ function warp_precmd --on-event fish_prompt --on-event fish_posterror
     else
       # We send an lprompt to use for prompt preview purposes only (we still use prompt markers for active prompts).
       set escaped_json "{\"hook\": \"Precmd\", \"value\": {
+      \"exit_code\": $exit_code,
+      \"next_block_id\": \"$next_block_id\",
       \"pwd\": \"$escaped_pwd\",
       \"ps1\": \"$escaped_prompt\",
       \"rprompt\": \"\",

--- a/app/assets/bundled/bootstrap/pwsh.ps1
+++ b/app/assets/bundled/bootstrap/pwsh.ps1
@@ -456,12 +456,13 @@ $null = New-Module -Name Warp-Module -ScriptBlock {
         $HOST.UI.RawUI.WindowTitle = $newTitle
 
         $blockId = $script:nextBlockId++
+        $nextBlockId = "precmd-${global:_warpSessionId}-$blockId"
         $commandFinishedMsg = @{
             hook = 'CommandFinished'
             value = @{
                 session_id = $global:_warpSessionId
                 exit_code = $exitCode
-                next_block_id = "precmd-${global:_warpSessionId}-$blockId"
+                next_block_id = $nextBlockId
             }
         }
         Warp-Send-JsonMessage $commandFinishedMsg
@@ -480,6 +481,8 @@ $null = New-Module -Name Warp-Module -ScriptBlock {
             $precmdMsg = @{
                 hook = 'Precmd'
                 value = @{
+                    exit_code = $exitCode
+                    next_block_id = $nextBlockId
                     pwd = ''
                     ps1 = ''
                     git_head = ''
@@ -594,6 +597,8 @@ $null = New-Module -Name Warp-Module -ScriptBlock {
             $precmdMsg = @{
                 hook = 'Precmd'
                 value = @{
+                    exit_code = $exitCode
+                    next_block_id = $nextBlockId
                     pwd = (Get-Location).Path
                     # TODO(PLAT-687) - honor the PS1
                     ps1 = ''

--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -306,8 +306,9 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
       # previously run user command (as opposed to any of the commands executed
       # in this function below).
       local exit_code=$?
+      local next_block_id="precmd-$WARP_SESSION_ID-$((block_id++))"
 
-      warp_send_json_message "{\"hook\": \"CommandFinished\", \"value\": {\"exit_code\": $exit_code, \"next_block_id\": \"precmd-$WARP_SESSION_ID-$((block_id++))\", \"session_id\": $WARP_SESSION_ID}}"
+      warp_send_json_message "{\"hook\": \"CommandFinished\", \"value\": {\"exit_code\": $exit_code, \"next_block_id\": \"$next_block_id\", \"session_id\": $WARP_SESSION_ID}}"
       warp_maybe_send_reset_grid_osc
 
       # If this is being called for a generator command, short circuit and send an unpopulated
@@ -320,6 +321,8 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
 
         _WARP_GENERATOR_COMMAND=""
         warp_send_json_message "{\"hook\": \"Precmd\", \"value\": {
+        \"exit_code\": $exit_code,
+        \"next_block_id\": \"$next_block_id\",
         \"pwd\": \"\",
         \"ps1\": \"\",
         \"git_head\": \"\",
@@ -480,6 +483,8 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
       fi
 
       local escaped_json="{\"hook\": \"Precmd\", \"value\": {
+      \"exit_code\": $exit_code,
+      \"next_block_id\": \"$next_block_id\",
       \"pwd\": \"$escaped_pwd\",
       \"ps1\": \"\",
       \"honor_ps1\": $honor_ps1,

--- a/app/src/terminal/model/ansi/dcs_hooks.rs
+++ b/app/src/terminal/model/ansi/dcs_hooks.rs
@@ -239,6 +239,7 @@ impl DProtoHook {
                 "kube_config" => {
                     value.kube_config = map_empty_to_none(v);
                 }
+                "exit_code" | "next_block_id" => {}
                 "session_id" => value.session_id = v.parse::<u64>().ok(),
                 _ => {
                     log::warn!("Tried to add unknown field {key} to Precmd");

--- a/app/src/terminal/model/ansi/mod_tests.rs
+++ b/app/src/terminal/model/ansi/mod_tests.rs
@@ -569,7 +569,7 @@ fn parse_dcs_ssh_with_external_control_master() {
 }
 
 #[test]
-fn parse_dcs_precmd() {
+fn parse_dcs_precmd_ignores_completion_fields() {
     let bytes = hex_encoded_dcs_string(
         r#"{
                 "hook": "Precmd",
@@ -582,6 +582,7 @@ fn parse_dcs_precmd() {
                     "virtual_env": "",
                     "conda_env": "numpy",
                     "exit_code": 0,
+                    "next_block_id": "block_id",
                     "session_id": 167303092612201
                 }
             }"#,
@@ -610,6 +611,21 @@ fn parse_dcs_precmd() {
         ),
         _ => panic!("incorrect dcs value"),
     };
+}
+
+#[test]
+fn pending_precmd_ignores_completion_fields() {
+    let mut hook = PendingHook::create("Precmd").unwrap();
+    hook.update("exit_code".to_owned(), "127".to_owned());
+    hook.update("next_block_id".to_owned(), "block_id".to_owned());
+    hook.update("session_id".to_owned(), "167303092612201".to_owned());
+
+    match hook.finish() {
+        DProtoHook::Precmd { value } => {
+            assert_eq!(value.session_id, Some(167303092612201));
+        }
+        _ => panic!("incorrect dcs value"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Description

Stack PR 2/7; depends on #12852.

### Context

`CommandFinished` is Warp's early completion signal, while `Precmd` arrives later when the shell is ready to display the next prompt. If `CommandFinished` is lost but `Precmd` still arrives, the current `Precmd` payload does not carry enough information to prove which command completed, preserve its real exit code, or identify the exact next block. Recovery must not guess any of those values.

This matters especially for shared sessions: viewers parse the raw shell hooks emitted by the sharer's installed client. When recovery eventually launches, it will only be useful for sessions whose sharers already emit the additional completion metadata fields.

### Approach and sequencing

Each supported shell now captures the previous command's exit code and allocates the next block ID once, then sends that exact pair in both `CommandFinished` and `Precmd`. The fields are redundant by design: normal clients continue using the earlier `CommandFinished`, while a later `Precmd` can serve as trustworthy reconciliation evidence if the earlier hook was dropped.

This is intentionally a standalone, behavior-preserving PR so it can reach stable ahead of the recovery implementation. That lead time increases the population of shared-session sharers sending `Precmd` hooks with completion metadata before newer viewers begin acting on them. Existing clients continue ignoring unknown JSON fields, and the current key-value decoder accepts these two fields without changing lifecycle behavior.

### Review guidance

- Do all bash, zsh, fish, and PowerShell emission paths reuse the same exit code and next block ID for both hooks?
- Does this remain protocol-only, with no client-side lifecycle behavior change?
- Will older clients and version-skewed shared-session viewers continue to parse or ignore the additional fields safely?

## Testing

- Added parser compatibility coverage proving the current decoder accepts and ignores the extra `Precmd` fields.
- Final-stack validation: `cargo check -p warp --tests`, `./script/format`, and `git diff --check`.
