### PR TITLE
Distinguish Precmd hooks with completion metadata from prompt-only hooks

### DIFF
--- a/app/src/ai/blocklist/agent_view/zero_state_block_tests.rs
+++ b/app/src/ai/blocklist/agent_view/zero_state_block_tests.rs
@@ -7,7 +7,7 @@ use super::{display_working_directory, format_session_location, should_render_oz
 use crate::ai::blocklist::agent_view::zero_state_block::current_working_directory_for_zero_state;
 use crate::terminal::color::{self, Colors};
 use crate::terminal::event_listener::ChannelEventListener;
-use crate::terminal::model::ansi::{Handler, InitShellValue, PrecmdValue, SSHValue};
+use crate::terminal::model::ansi::{Handler, InitShellValue, PromptMetadata, SSHValue};
 use crate::terminal::model::session::Session;
 use crate::terminal::model::test_utils::block_size;
 use crate::terminal::model::TerminalModel;
@@ -78,7 +78,7 @@ fn display_working_directory_abbreviates_subdirectory_under_home() {
 #[test]
 fn cwd_for_recent_conversations_prefers_active_block_pwd() {
     let mut terminal = prebootstrap_terminal_with_startup_path("/startup/path");
-    terminal.precmd(PrecmdValue {
+    terminal.legacy_precmd(PromptMetadata {
         pwd: Some("/active/path".to_owned()),
         session_id: Some(123),
         ..Default::default()

--- a/app/src/ai/blocklist/agent_view/zero_state_block_tests.rs
+++ b/app/src/ai/blocklist/agent_view/zero_state_block_tests.rs
@@ -78,7 +78,7 @@ fn display_working_directory_abbreviates_subdirectory_under_home() {
 #[test]
 fn cwd_for_recent_conversations_prefers_active_block_pwd() {
     let mut terminal = prebootstrap_terminal_with_startup_path("/startup/path");
-    terminal.legacy_precmd(PromptMetadata {
+    terminal.prompt_only_precmd(PromptMetadata {
         pwd: Some("/active/path".to_owned()),
         session_id: Some(123),
         ..Default::default()

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -88,7 +88,7 @@ use crate::terminal::input::slash_commands::SlashCommandsEvent;
 use crate::terminal::keys::TerminalKeybindings;
 use crate::terminal::local_shell::LocalShellState;
 use crate::terminal::local_tty::shell::ShellStarter;
-use crate::terminal::model::ansi::{Handler, PrecmdValue};
+use crate::terminal::model::ansi::{Handler, PromptMetadata};
 use crate::terminal::model::block::{BlockId, SerializedBlock};
 use crate::terminal::model::blocks::{insert_block, BlockListPoint};
 use crate::terminal::model::grid::Dimensions as _;
@@ -461,7 +461,7 @@ pub fn simulate_directory_for_completion<A, S>(
         let block_metadata = BlockMetadata::new(Some(session_id), Some(directory.clone()));
         let block_index = {
             let mut model = terminal.model.lock();
-            model.block_list_mut().precmd(PrecmdValue {
+            model.block_list_mut().legacy_precmd(PromptMetadata {
                 pwd: Some(directory.clone()),
                 session_id: Some(session_id.into()),
                 ..Default::default()

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -461,7 +461,7 @@ pub fn simulate_directory_for_completion<A, S>(
         let block_metadata = BlockMetadata::new(Some(session_id), Some(directory.clone()));
         let block_index = {
             let mut model = terminal.model.lock();
-            model.block_list_mut().legacy_precmd(PromptMetadata {
+            model.block_list_mut().prompt_only_precmd(PromptMetadata {
                 pwd: Some(directory.clone()),
                 session_id: Some(session_id.into()),
                 ..Default::default()

--- a/app/src/terminal/model/alt_screen.rs
+++ b/app/src/terminal/model/alt_screen.rs
@@ -623,7 +623,7 @@ impl ansi::Handler for AltScreen {
 
     fn command_finished(&mut self, _: CommandFinishedValue) {}
 
-    fn precmd(&mut self, _: PrecmdValue) {}
+    fn precmd_with_completion_metadata(&mut self, _: PrecmdValue) {}
 
     fn preexec(&mut self, _: PreexecValue) {}
 

--- a/app/src/terminal/model/ansi/dcs_hooks.rs
+++ b/app/src/terminal/model/ansi/dcs_hooks.rs
@@ -41,7 +41,7 @@ pub(super) enum DProtoHook {
         value: CommandFinishedValue,
     },
     Precmd {
-        value: PrecmdValue,
+        value: PrecmdHookValue,
     },
     Preexec {
         value: PreexecValue,
@@ -104,7 +104,7 @@ impl DProtoHook {
     pub fn session_id(&self) -> Option<SessionId> {
         match self {
             DProtoHook::InitShell { value } => Some(value.session_id),
-            DProtoHook::Precmd { value } => value.session_id.map(SessionId::from),
+            DProtoHook::Precmd { value } => value.session_id().map(SessionId::from),
             DProtoHook::ExitShell { value } => Some(value.session_id),
             DProtoHook::Preexec { value } => value.session_id.map(SessionId::from),
             DProtoHook::CommandFinished { value } => value.session_id.map(SessionId::from),
@@ -144,9 +144,6 @@ impl DProtoHook {
     pub fn default_from_name(hook: &str) -> Option<Self> {
         match hook {
             "CommandFinished" => Some(DProtoHook::CommandFinished {
-                value: Default::default(),
-            }),
-            "Precmd" => Some(DProtoHook::Precmd {
                 value: Default::default(),
             }),
             "Preexec" => Some(DProtoHook::Preexec {
@@ -203,46 +200,16 @@ impl DProtoHook {
         };
         match self {
             DProtoHook::CommandFinished { value } => match key.as_ref() {
-                "exit_code" => value.exit_code = v.parse::<i32>().unwrap_or_default().into(),
+                "exit_code" => {
+                    value.completion_metadata.exit_code =
+                        v.parse::<i32>().unwrap_or_default().into()
+                }
                 "next_block_id" => {
-                    value.next_block_id = v.to_string().into();
+                    value.completion_metadata.next_block_id = v.to_string().into();
                 }
                 "session_id" => value.session_id = v.parse::<u64>().ok(),
                 _ => {
                     log::warn!("Tried to add unknown field to CommandFinished");
-                }
-            },
-            DProtoHook::Precmd { value } => match key.as_ref() {
-                "pwd" => {
-                    value.pwd = map_empty_to_none(v);
-                }
-                "ps1" => {
-                    value.ps1 = map_empty_to_none(v);
-                }
-                "ps1_is_encoded" => value.ps1_is_encoded = v.parse::<bool>().ok(),
-                "honor_ps1" => value.honor_ps1 = v.parse::<bool>().ok(),
-                "rprompt" => {
-                    value.rprompt = map_empty_to_none(v);
-                }
-                "git_head" => {
-                    value.git_head = map_empty_to_none(v);
-                }
-                "git_branch" => {
-                    value.git_branch = map_empty_to_none(v);
-                }
-                "virtual_env" => {
-                    value.virtual_env = map_empty_to_none(v);
-                }
-                "conda_env" => {
-                    value.conda_env = map_empty_to_none(v);
-                }
-                "kube_config" => {
-                    value.kube_config = map_empty_to_none(v);
-                }
-                "exit_code" | "next_block_id" => {}
-                "session_id" => value.session_id = v.parse::<u64>().ok(),
-                _ => {
-                    log::warn!("Tried to add unknown field {key} to Precmd");
                 }
             },
             DProtoHook::InitShell { value } => match key.as_ref() {
@@ -412,18 +379,142 @@ impl DProtoHook {
     }
 }
 
+/// Canonical correlated payload received from the pty at precmd.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PrecmdValue {
+    #[serde(flatten)]
+    pub completion_metadata: CompletionMetadata,
+    #[serde(flatten)]
+    pub prompt_metadata: PromptMetadata,
+}
+
+/// A decoded precmd payload, classified according to its completion evidence.
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub(super) enum PrecmdHookValue {
+    Correlated(PrecmdValue),
+    Legacy(PromptMetadata),
+}
+
+impl PrecmdHookValue {
+    fn session_id(&self) -> HookSessionId {
+        match self {
+            Self::Correlated(value) => value.prompt_metadata.session_id,
+            Self::Legacy(value) => value.session_id,
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawPrecmdValue {
+    #[serde(flatten)]
+    prompt_metadata: PromptMetadata,
+    #[serde(default)]
+    exit_code: RawPrecmdField<ExitCode>,
+    #[serde(default)]
+    next_block_id: RawPrecmdField<BlockId>,
+}
+
+#[derive(Debug, Default)]
+enum RawPrecmdField<T> {
+    #[default]
+    Missing,
+    Present(Option<T>),
+}
+
+impl<'de, T> Deserialize<'de> for RawPrecmdField<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<T>::deserialize(deserializer).map(Self::Present)
+    }
+}
+
+impl RawPrecmdValue {
+    fn populate_field(&mut self, key: String, value: String) {
+        let map_empty_to_none = |value: String| {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        };
+        match key.as_str() {
+            "pwd" => self.prompt_metadata.pwd = map_empty_to_none(value),
+            "ps1" => self.prompt_metadata.ps1 = map_empty_to_none(value),
+            "ps1_is_encoded" => self.prompt_metadata.ps1_is_encoded = value.parse::<bool>().ok(),
+            "honor_ps1" => self.prompt_metadata.honor_ps1 = value.parse::<bool>().ok(),
+            "rprompt" => self.prompt_metadata.rprompt = map_empty_to_none(value),
+            "git_head" => self.prompt_metadata.git_head = map_empty_to_none(value),
+            "git_branch" => self.prompt_metadata.git_branch = map_empty_to_none(value),
+            "virtual_env" => self.prompt_metadata.virtual_env = map_empty_to_none(value),
+            "conda_env" => self.prompt_metadata.conda_env = map_empty_to_none(value),
+            "kube_config" => self.prompt_metadata.kube_config = map_empty_to_none(value),
+            "session_id" => self.prompt_metadata.session_id = value.parse::<u64>().ok(),
+            "exit_code" => {
+                self.exit_code = RawPrecmdField::Present(value.parse::<i32>().ok().map(Into::into));
+            }
+            "next_block_id" => {
+                self.next_block_id = RawPrecmdField::Present(Some(value.into()));
+            }
+            _ => {
+                log::warn!("Tried to add unknown field {key} to Precmd");
+            }
+        }
+    }
+    fn classify(self) -> Result<PrecmdHookValue, &'static str> {
+        match (self.exit_code, self.next_block_id) {
+            (
+                RawPrecmdField::Present(Some(exit_code)),
+                RawPrecmdField::Present(Some(next_block_id)),
+            ) => Ok(PrecmdHookValue::Correlated(PrecmdValue {
+                completion_metadata: CompletionMetadata {
+                    exit_code,
+                    next_block_id,
+                },
+                prompt_metadata: self.prompt_metadata,
+            })),
+            (RawPrecmdField::Missing, RawPrecmdField::Missing) => {
+                Ok(PrecmdHookValue::Legacy(self.prompt_metadata))
+            }
+            _ => Err("Precmd payload must contain both exit_code and next_block_id"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for PrecmdHookValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        RawPrecmdValue::deserialize(deserializer)?
+            .classify()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
 /// Received from the pty when a command has finished executing.
-#[derive(Debug, Deserialize, Default, Serialize, PartialEq, Eq)]
-pub struct CommandFinishedValue {
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct CompletionMetadata {
     pub exit_code: ExitCode,
     pub next_block_id: BlockId,
+}
+
+/// Received from the pty when a command has finished executing.
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct CommandFinishedValue {
+    #[serde(flatten)]
+    pub completion_metadata: CompletionMetadata,
     #[serde(default)]
     pub session_id: HookSessionId,
 }
-
-/// Received from the pty at precmd.
+/// Prompt and shell context received from the pty at precmd.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct PrecmdValue {
+pub struct PromptMetadata {
     #[serde(deserialize_with = "empty_string_is_none", default)]
     pub pwd: Option<String>,
 
@@ -457,13 +548,13 @@ pub struct PrecmdValue {
 
     pub session_id: HookSessionId,
 
-    /// Whether this PrecmdValue was emitted after the completion of an in-band command.
+    /// Whether this prompt metadata was emitted after the completion of an in-band command.
     #[serde(default)]
     pub is_after_in_band_command: bool,
 }
 
-impl PrecmdValue {
-    /// Returns `true` if this PrecmdValue was emitted after the completion of an in-band command.
+impl PromptMetadata {
+    /// Returns `true` if this prompt metadata was emitted after the completion of an in-band command.
     ///
     /// This relies on the assumption that the warp_precmd shell function (responsible for writing
     /// this to the PTY from the shell) does not populate `pwd` or `ps1` when the previous command
@@ -473,7 +564,7 @@ impl PrecmdValue {
     }
 }
 
-impl Default for PrecmdValue {
+impl Default for PromptMetadata {
     fn default() -> Self {
         Self {
             pwd: Default::default(),
@@ -773,14 +864,25 @@ fn parse_shell_options_list(s: String) -> HashSet<String> {
 }
 
 /// Represents a shell hook that will be constructed over time by receiving key-value pairs.
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub struct PendingHook {
-    hook: DProtoHook,
+    value: PendingHookValue,
+}
+
+#[derive(Debug)]
+enum PendingHookValue {
+    Precmd(RawPrecmdValue),
+    Other(DProtoHook),
 }
 
 impl PendingHook {
     pub fn create(hook_name: &str) -> Option<Self> {
-        DProtoHook::default_from_name(hook_name).map(|hook| Self { hook })
+        let value = if hook_name == "Precmd" {
+            PendingHookValue::Precmd(RawPrecmdValue::default())
+        } else {
+            PendingHookValue::Other(DProtoHook::default_from_name(hook_name)?)
+        };
+        Some(Self { value })
     }
 
     /// Updates the field on the hook according to the given key-value pair.
@@ -788,10 +890,18 @@ impl PendingHook {
         if super::is_ansi_c_quoted(&value) {
             value = super::parse_ansi_c_quoted_string(value);
         }
-        self.hook.populate_field(key, value);
+        match &mut self.value {
+            PendingHookValue::Precmd(precmd) => precmd.populate_field(key, value),
+            PendingHookValue::Other(hook) => hook.populate_field(key, value),
+        }
     }
 
-    pub(super) fn finish(self) -> DProtoHook {
-        self.hook
+    pub(super) fn finish(self) -> Result<DProtoHook, &'static str> {
+        match self.value {
+            PendingHookValue::Precmd(precmd) => {
+                precmd.classify().map(|value| DProtoHook::Precmd { value })
+            }
+            PendingHookValue::Other(hook) => Ok(hook),
+        }
     }
 }

--- a/app/src/terminal/model/ansi/dcs_hooks.rs
+++ b/app/src/terminal/model/ansi/dcs_hooks.rs
@@ -379,7 +379,7 @@ impl DProtoHook {
     }
 }
 
-/// Canonical correlated payload received from the pty at precmd.
+/// Payload with completion metadata received from the PTY at precmd.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PrecmdValue {
     #[serde(flatten)]
@@ -392,15 +392,15 @@ pub struct PrecmdValue {
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub(super) enum PrecmdHookValue {
-    Correlated(PrecmdValue),
-    Legacy(PromptMetadata),
+    WithCompletionMetadata(PrecmdValue),
+    PromptOnly(PromptMetadata),
 }
 
 impl PrecmdHookValue {
     fn session_id(&self) -> HookSessionId {
         match self {
-            Self::Correlated(value) => value.prompt_metadata.session_id,
-            Self::Legacy(value) => value.session_id,
+            Self::WithCompletionMetadata(value) => value.prompt_metadata.session_id,
+            Self::PromptOnly(value) => value.session_id,
         }
     }
 }
@@ -471,7 +471,7 @@ impl RawPrecmdValue {
             (
                 RawPrecmdField::Present(Some(exit_code)),
                 RawPrecmdField::Present(Some(next_block_id)),
-            ) => Ok(PrecmdHookValue::Correlated(PrecmdValue {
+            ) => Ok(PrecmdHookValue::WithCompletionMetadata(PrecmdValue {
                 completion_metadata: CompletionMetadata {
                     exit_code,
                     next_block_id,
@@ -479,7 +479,7 @@ impl RawPrecmdValue {
                 prompt_metadata: self.prompt_metadata,
             })),
             (RawPrecmdField::Missing, RawPrecmdField::Missing) => {
-                Ok(PrecmdHookValue::Legacy(self.prompt_metadata))
+                Ok(PrecmdHookValue::PromptOnly(self.prompt_metadata))
             }
             _ => Err("Precmd payload must contain both exit_code and next_block_id"),
         }

--- a/app/src/terminal/model/ansi/handler.rs
+++ b/app/src/terminal/model/ansi/handler.rs
@@ -258,6 +258,9 @@ pub trait Handler {
     /// Callback for the Warp precmd hook.
     fn precmd(&mut self, _data: PrecmdValue) {}
 
+    /// Callback for a legacy Warp precmd hook without correlated completion metadata.
+    fn legacy_precmd(&mut self, _data: PromptMetadata) {}
+
     /// Update the active block's current working directory, independent of the
     /// prompt cycle. Invoked from OSC 7 (`\e]7;file://host/path`) so external
     /// tools can notify the terminal of CWD changes mid-command, without

--- a/app/src/terminal/model/ansi/handler.rs
+++ b/app/src/terminal/model/ansi/handler.rs
@@ -255,11 +255,11 @@ pub trait Handler {
     /// Process a prompt marker control sequence.
     fn prompt_marker(&mut self, _marker: PromptMarker) {}
 
-    /// Callback for the Warp precmd hook.
-    fn precmd(&mut self, _data: PrecmdValue) {}
+    /// Callback for a Warp precmd hook with completion metadata.
+    fn precmd_with_completion_metadata(&mut self, _data: PrecmdValue) {}
 
-    /// Callback for a legacy Warp precmd hook without correlated completion metadata.
-    fn legacy_precmd(&mut self, _data: PromptMetadata) {}
+    /// Callback for a prompt-only Warp precmd hook.
+    fn prompt_only_precmd(&mut self, _data: PromptMetadata) {}
 
     /// Update the active block's current working directory, independent of the
     /// prompt cycle. Invoked from OSC 7 (`\e]7;file://host/path`) so external

--- a/app/src/terminal/model/ansi/mod.rs
+++ b/app/src/terminal/model/ansi/mod.rs
@@ -585,7 +585,10 @@ impl<'a, H: Handler + 'a, W: io::Write> Performer<'a, H, W> {
         }
         match hook {
             Ok(DProtoHook::CommandFinished { value }) => self.handler.command_finished(value),
-            Ok(DProtoHook::Precmd { value }) => self.handler.precmd(value),
+            Ok(DProtoHook::Precmd { value }) => match value {
+                PrecmdHookValue::Correlated(value) => self.handler.precmd(value),
+                PrecmdHookValue::Legacy(value) => self.handler.legacy_precmd(value),
+            },
             Ok(DProtoHook::Preexec { value }) => self.handler.preexec(value),
             Ok(DProtoHook::Bootstrapped { value }) => self.handler.bootstrapped(*value),
             Ok(DProtoHook::PreInteractiveSSHSession { value }) => {
@@ -679,7 +682,13 @@ impl<'a, H: Handler + 'a, W: io::Write> Performer<'a, H, W> {
                 let Some(pending_shell_hook) = self.handler.finish_receiving_hook() else {
                     return;
                 };
-                let hook = pending_shell_hook.finish();
+                let hook = match pending_shell_hook.finish() {
+                    Ok(hook) => hook,
+                    Err(error) => {
+                        log::warn!("Rejected malformed key-value hook: {error}");
+                        return;
+                    }
+                };
                 safe_debug!(
                     safe: ("Decoded payload"),
                     full: ("Decoded payload string: {:?}", serde_json::to_string(&hook))

--- a/app/src/terminal/model/ansi/mod.rs
+++ b/app/src/terminal/model/ansi/mod.rs
@@ -586,8 +586,10 @@ impl<'a, H: Handler + 'a, W: io::Write> Performer<'a, H, W> {
         match hook {
             Ok(DProtoHook::CommandFinished { value }) => self.handler.command_finished(value),
             Ok(DProtoHook::Precmd { value }) => match value {
-                PrecmdHookValue::Correlated(value) => self.handler.precmd(value),
-                PrecmdHookValue::Legacy(value) => self.handler.legacy_precmd(value),
+                PrecmdHookValue::WithCompletionMetadata(value) => {
+                    self.handler.precmd_with_completion_metadata(value)
+                }
+                PrecmdHookValue::PromptOnly(value) => self.handler.prompt_only_precmd(value),
             },
             Ok(DProtoHook::Preexec { value }) => self.handler.preexec(value),
             Ok(DProtoHook::Bootstrapped { value }) => self.handler.bootstrapped(*value),

--- a/app/src/terminal/model/ansi/mod_tests.rs
+++ b/app/src/terminal/model/ansi/mod_tests.rs
@@ -188,7 +188,15 @@ impl Handler for MockHandler {
     }
 
     fn precmd(&mut self, data: PrecmdValue) {
-        self.d_proto_hooks.push(DProtoHook::Precmd { value: data });
+        self.d_proto_hooks.push(DProtoHook::Precmd {
+            value: PrecmdHookValue::Correlated(data),
+        });
+    }
+
+    fn legacy_precmd(&mut self, data: PromptMetadata) {
+        self.d_proto_hooks.push(DProtoHook::Precmd {
+            value: PrecmdHookValue::Legacy(data),
+        });
     }
 
     fn preexec(&mut self, data: PreexecValue) {
@@ -569,7 +577,7 @@ fn parse_dcs_ssh_with_external_control_master() {
 }
 
 #[test]
-fn parse_dcs_precmd_ignores_completion_fields() {
+fn parse_dcs_precmd_classifies_correlated_payload() {
     let bytes = hex_encoded_dcs_string(
         r#"{
                 "hook": "Precmd",
@@ -593,38 +601,118 @@ fn parse_dcs_precmd_ignores_completion_fields() {
     match handler.d_proto_hooks.first().unwrap() {
         DProtoHook::Precmd { value } => assert_eq!(
             *value,
-            PrecmdValue {
-                pwd: Some("/Users".to_string()),
-                ps1: Some("$>".to_string()),
-                honor_ps1: Some(true),
-                rprompt: None,
-                git_head: None,
-                git_branch: None,
-                virtual_env: None,
-                conda_env: Some("numpy".to_string()),
-                node_version: None,
-                kube_config: None,
-                session_id: Some(167303092612201),
-                ps1_is_encoded: None,
-                is_after_in_band_command: false,
-            }
+            PrecmdHookValue::Correlated(PrecmdValue {
+                completion_metadata: CompletionMetadata {
+                    exit_code: ExitCode::from(0),
+                    next_block_id: "block_id".to_owned().into(),
+                },
+                prompt_metadata: PromptMetadata {
+                    pwd: Some("/Users".to_string()),
+                    ps1: Some("$>".to_string()),
+                    honor_ps1: Some(true),
+                    rprompt: None,
+                    git_head: None,
+                    git_branch: None,
+                    virtual_env: None,
+                    conda_env: Some("numpy".to_string()),
+                    node_version: None,
+                    kube_config: None,
+                    session_id: Some(167303092612201),
+                    ps1_is_encoded: None,
+                    is_after_in_band_command: false,
+                },
+            })
         ),
         _ => panic!("incorrect dcs value"),
     };
 }
 
 #[test]
-fn pending_precmd_ignores_completion_fields() {
+fn pending_precmd_classifies_correlated_payload() {
     let mut hook = PendingHook::create("Precmd").unwrap();
     hook.update("exit_code".to_owned(), "127".to_owned());
     hook.update("next_block_id".to_owned(), "block_id".to_owned());
     hook.update("session_id".to_owned(), "167303092612201".to_owned());
 
-    match hook.finish() {
-        DProtoHook::Precmd { value } => {
+    match hook.finish().unwrap() {
+        DProtoHook::Precmd {
+            value: PrecmdHookValue::Correlated(value),
+        } => {
+            assert_eq!(
+                value.completion_metadata,
+                CompletionMetadata {
+                    exit_code: ExitCode::from(127),
+                    next_block_id: "block_id".to_owned().into(),
+                }
+            );
+            assert_eq!(value.prompt_metadata.session_id, Some(167303092612201));
+        }
+        _ => panic!("incorrect dcs value"),
+    }
+}
+
+#[test]
+fn parse_dcs_precmd_classifies_legacy_payload() {
+    let bytes = hex_encoded_dcs_string(
+        r#"{
+                "hook": "Precmd",
+                "value": {
+                    "pwd": "/Users",
+                    "session_id": 167303092612201
+                }
+            }"#,
+    );
+    let (_, handler) = parse_bytes(&bytes);
+
+    assert_eq!(handler.d_proto_hooks.len(), 1);
+    match handler.d_proto_hooks.first().unwrap() {
+        DProtoHook::Precmd {
+            value: PrecmdHookValue::Legacy(value),
+        } => {
+            assert_eq!(value.pwd.as_deref(), Some("/Users"));
             assert_eq!(value.session_id, Some(167303092612201));
         }
         _ => panic!("incorrect dcs value"),
+    }
+}
+
+#[test]
+fn parse_dcs_precmd_rejects_partial_completion_metadata() {
+    for partial_completion_metadata in [
+        r#""exit_code": 0"#,
+        r#""next_block_id": "block_id""#,
+        r#""exit_code": null"#,
+        r#""exit_code": null, "next_block_id": "block_id""#,
+    ] {
+        let bytes = hex_encoded_dcs_string(&format!(
+            r#"{{
+                "hook": "Precmd",
+                "value": {{
+                    "pwd": "/Users",
+                    {partial_completion_metadata},
+                    "session_id": 167303092612201
+                }}
+            }}"#
+        ));
+        let (_, handler) = parse_bytes(&bytes);
+
+        assert!(handler.d_proto_hooks.is_empty());
+    }
+}
+
+#[test]
+fn pending_precmd_rejects_partial_or_invalid_completion_metadata() {
+    for fields in [
+        vec![("exit_code", "0")],
+        vec![("next_block_id", "block_id")],
+        vec![("exit_code", "invalid"), ("next_block_id", "block_id")],
+    ] {
+        let mut hook = PendingHook::create("Precmd").unwrap();
+        for (key, value) in fields {
+            hook.update(key.to_owned(), value.to_owned());
+        }
+
+        assert!(hook.finish().is_err());
     }
 }
 
@@ -659,7 +747,9 @@ fn parse_dcs_unregistered_session_id_allowed_when_validation_disabled() {
 
     assert_eq!(handler.d_proto_hooks.len(), 1);
     match handler.d_proto_hooks.first().unwrap() {
-        DProtoHook::Precmd { value } => assert_eq!(value.session_id, Some(167303092612201)),
+        DProtoHook::Precmd {
+            value: PrecmdHookValue::Legacy(value),
+        } => assert_eq!(value.session_id, Some(167303092612201)),
         _ => panic!("incorrect dcs value"),
     };
 }
@@ -684,8 +774,10 @@ fn parse_dcs_command_finished() {
             assert_eq!(
                 *value,
                 CommandFinishedValue {
-                    exit_code: ExitCode::from(127),
-                    next_block_id: "block_id".to_owned().into(),
+                    completion_metadata: CompletionMetadata {
+                        exit_code: ExitCode::from(127),
+                        next_block_id: "block_id".to_owned().into(),
+                    },
                     session_id: Some(167303092612201)
                 }
             )

--- a/app/src/terminal/model/ansi/mod_tests.rs
+++ b/app/src/terminal/model/ansi/mod_tests.rs
@@ -187,15 +187,15 @@ impl Handler for MockHandler {
             .push(DProtoHook::CommandFinished { value: data });
     }
 
-    fn precmd(&mut self, data: PrecmdValue) {
+    fn precmd_with_completion_metadata(&mut self, data: PrecmdValue) {
         self.d_proto_hooks.push(DProtoHook::Precmd {
-            value: PrecmdHookValue::Correlated(data),
+            value: PrecmdHookValue::WithCompletionMetadata(data),
         });
     }
 
-    fn legacy_precmd(&mut self, data: PromptMetadata) {
+    fn prompt_only_precmd(&mut self, data: PromptMetadata) {
         self.d_proto_hooks.push(DProtoHook::Precmd {
-            value: PrecmdHookValue::Legacy(data),
+            value: PrecmdHookValue::PromptOnly(data),
         });
     }
 
@@ -577,7 +577,7 @@ fn parse_dcs_ssh_with_external_control_master() {
 }
 
 #[test]
-fn parse_dcs_precmd_classifies_correlated_payload() {
+fn parse_dcs_precmd_classifies_payload_with_completion_metadata() {
     let bytes = hex_encoded_dcs_string(
         r#"{
                 "hook": "Precmd",
@@ -601,7 +601,7 @@ fn parse_dcs_precmd_classifies_correlated_payload() {
     match handler.d_proto_hooks.first().unwrap() {
         DProtoHook::Precmd { value } => assert_eq!(
             *value,
-            PrecmdHookValue::Correlated(PrecmdValue {
+            PrecmdHookValue::WithCompletionMetadata(PrecmdValue {
                 completion_metadata: CompletionMetadata {
                     exit_code: ExitCode::from(0),
                     next_block_id: "block_id".to_owned().into(),
@@ -628,7 +628,7 @@ fn parse_dcs_precmd_classifies_correlated_payload() {
 }
 
 #[test]
-fn pending_precmd_classifies_correlated_payload() {
+fn pending_precmd_classifies_payload_with_completion_metadata() {
     let mut hook = PendingHook::create("Precmd").unwrap();
     hook.update("exit_code".to_owned(), "127".to_owned());
     hook.update("next_block_id".to_owned(), "block_id".to_owned());
@@ -636,7 +636,7 @@ fn pending_precmd_classifies_correlated_payload() {
 
     match hook.finish().unwrap() {
         DProtoHook::Precmd {
-            value: PrecmdHookValue::Correlated(value),
+            value: PrecmdHookValue::WithCompletionMetadata(value),
         } => {
             assert_eq!(
                 value.completion_metadata,
@@ -652,7 +652,7 @@ fn pending_precmd_classifies_correlated_payload() {
 }
 
 #[test]
-fn parse_dcs_precmd_classifies_legacy_payload() {
+fn parse_dcs_precmd_classifies_prompt_only_payload() {
     let bytes = hex_encoded_dcs_string(
         r#"{
                 "hook": "Precmd",
@@ -667,7 +667,7 @@ fn parse_dcs_precmd_classifies_legacy_payload() {
     assert_eq!(handler.d_proto_hooks.len(), 1);
     match handler.d_proto_hooks.first().unwrap() {
         DProtoHook::Precmd {
-            value: PrecmdHookValue::Legacy(value),
+            value: PrecmdHookValue::PromptOnly(value),
         } => {
             assert_eq!(value.pwd.as_deref(), Some("/Users"));
             assert_eq!(value.session_id, Some(167303092612201));
@@ -748,7 +748,7 @@ fn parse_dcs_unregistered_session_id_allowed_when_validation_disabled() {
     assert_eq!(handler.d_proto_hooks.len(), 1);
     match handler.d_proto_hooks.first().unwrap() {
         DProtoHook::Precmd {
-            value: PrecmdHookValue::Legacy(value),
+            value: PrecmdHookValue::PromptOnly(value),
         } => assert_eq!(value.session_id, Some(167303092612201)),
         _ => panic!("incorrect dcs value"),
     };

--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -52,7 +52,7 @@ use crate::terminal::event::{
     BlockWorkingDirectoryUpdatedEvent, Event, UserBlockCompleted,
 };
 use crate::terminal::event_listener::ChannelEventListener;
-use crate::terminal::model::ansi::{self, PrecmdValue, PreexecValue, Processor};
+use crate::terminal::model::ansi::{self, PrecmdValue, PreexecValue, Processor, PromptMetadata};
 use crate::terminal::model::blockgrid::BlockGrid;
 use crate::terminal::model::grid::grid_handler::TermMode;
 use crate::terminal::model::index::{Point, VisibleRow};
@@ -3327,10 +3327,13 @@ impl ansi::Handler for Block {
     }
 
     fn precmd(&mut self, data: PrecmdValue) {
+        self.legacy_precmd(data.prompt_metadata);
+    }
+
+    fn legacy_precmd(&mut self, data: PromptMetadata) {
         record_trace_event!("command_execution:block:precmd");
         let is_after_in_band_command = data.was_sent_after_in_band_command();
-
-        self.header_grid.precmd(data.clone());
+        self.header_grid.legacy_precmd(data.clone());
 
         self.state = BlockState::BeforeExecution;
         self.pwd = data.pwd;

--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -3326,14 +3326,14 @@ impl ansi::Handler for Block {
             ));
     }
 
-    fn precmd(&mut self, data: PrecmdValue) {
-        self.legacy_precmd(data.prompt_metadata);
+    fn precmd_with_completion_metadata(&mut self, data: PrecmdValue) {
+        self.prompt_only_precmd(data.prompt_metadata);
     }
 
-    fn legacy_precmd(&mut self, data: PromptMetadata) {
+    fn prompt_only_precmd(&mut self, data: PromptMetadata) {
         record_trace_event!("command_execution:block:precmd");
         let is_after_in_band_command = data.was_sent_after_in_band_command();
-        self.header_grid.legacy_precmd(data.clone());
+        self.header_grid.prompt_only_precmd(data.clone());
 
         self.state = BlockState::BeforeExecution;
         self.pwd = data.pwd;

--- a/app/src/terminal/model/block_tests.rs
+++ b/app/src/terminal/model/block_tests.rs
@@ -46,7 +46,7 @@ impl float_cmp::ApproxEq for BlockSection {
 pub fn test_find() {
     let mut block = TestBlockBuilder::new().build();
 
-    block.precmd(PrecmdValue::default());
+    block.legacy_precmd(PromptMetadata::default());
     block.start();
     assert_lines_approx_eq!(block.height(&AgentViewState::Inactive), 3.);
 
@@ -236,7 +236,7 @@ pub fn test_find() {
 
     let mut block = TestBlockBuilder::new().build();
 
-    block.precmd(PrecmdValue::default());
+    block.legacy_precmd(PromptMetadata::default());
     block.start();
 
     block.header_grid.command_grid_linefeed();
@@ -266,7 +266,7 @@ pub fn test_long_running_block_bottom_padding() {
     warpui::r#async::block_on(async {
         let mut block = TestBlockBuilder::new().build();
 
-        block.precmd(Default::default());
+        block.legacy_precmd(PromptMetadata::default());
         block.start();
         for c in "command".chars() {
             block.input(c);
@@ -326,7 +326,7 @@ pub fn non_empty_pre_bootstrap_block_can_be_long_running() {
 pub fn test_precmd_no_preexec() {
     let mut block = TestBlockBuilder::new().build();
     block.start();
-    block.precmd(PrecmdValue::default());
+    block.legacy_precmd(PromptMetadata::default());
 
     for c in "command".chars() {
         block.input(c);
@@ -401,7 +401,7 @@ pub fn test_image_completion_drops_in_warp_input_stage() {
 pub fn test_command_grid_bold() {
     let mut block = TestBlockBuilder::new().build();
     block.start();
-    block.precmd(PrecmdValue::default());
+    block.legacy_precmd(PromptMetadata::default());
 
     // We should have the BOLD flag enabled for commands, once we've started the command grid.
     assert!(block
@@ -423,7 +423,7 @@ pub fn test_command_grid_bold() {
 pub fn test_command_grid_bold_after_reset() {
     let mut block = TestBlockBuilder::new().build();
     block.start();
-    block.precmd(PrecmdValue::default());
+    block.legacy_precmd(PromptMetadata::default());
 
     // We should have the BOLD flag enabled for commands, once we've started the command grid.
     assert!(block
@@ -452,7 +452,7 @@ pub fn test_command_grid_bold_after_reset() {
 pub fn test_empty_command() {
     let mut block = TestBlockBuilder::new().build();
     block.start();
-    block.precmd(PrecmdValue::default());
+    block.legacy_precmd(PromptMetadata::default());
 
     block.finish(0);
 
@@ -463,14 +463,14 @@ pub fn test_empty_command() {
 pub fn test_failed_block() {
     let mut block = TestBlockBuilder::new().build();
 
-    block.precmd(PrecmdValue::default());
+    block.legacy_precmd(PromptMetadata::default());
     block.preexec(Default::default());
 
     block.finish(1 /* exit_code */);
     assert!(block.has_failed());
 
     let mut block = TestBlockBuilder::new().build();
-    block.precmd(PrecmdValue::default());
+    block.legacy_precmd(PromptMetadata::default());
     block.finish(1 /* exit_code */);
 
     // The block should not be marked as failed since execution never started.
@@ -481,7 +481,7 @@ pub fn test_failed_block() {
 fn test_non_error_exit_codes() {
     let mut block = TestBlockBuilder::new().build();
 
-    block.precmd(Default::default());
+    block.legacy_precmd(PromptMetadata::default());
     block.preexec(Default::default());
 
     block.finish(130 /* exit_code */);
@@ -490,7 +490,7 @@ fn test_non_error_exit_codes() {
 
     let mut block = TestBlockBuilder::new().build();
 
-    block.precmd(Default::default());
+    block.legacy_precmd(PromptMetadata::default());
     block.preexec(Default::default());
 
     block.finish(141 /* exit_code */);
@@ -634,7 +634,7 @@ pub fn test_set_current_working_directory_updates_pwd_and_emits_cwd_event() {
 pub fn test_elapsed_duration_rounds_down_to_whole_seconds() {
     let mut block = TestBlockBuilder::new().build();
     // Move the block into the Executing state so `elapsed_duration` returns a value.
-    block.precmd(PrecmdValue::default());
+    block.legacy_precmd(PromptMetadata::default());
     block.preexec(Default::default());
 
     let start = chrono::Local.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
@@ -678,7 +678,7 @@ pub fn test_elapsed_duration_requires_executing_state() {
     assert!(!block.is_duration_live());
 
     // `precmd` alone leaves the block in `BeforeExecution`; the duration is not yet live.
-    block.precmd(PrecmdValue::default());
+    block.legacy_precmd(PromptMetadata::default());
     block.override_start_ts(start);
     assert_eq!(block.elapsed_duration_whole_secs_at(now), None);
     assert!(!block.is_duration_live());
@@ -724,7 +724,7 @@ pub fn test_block_emits_block_completed_event_for_in_band_command() {
         .build();
 
     block.start_for_in_band_command();
-    block.precmd(Default::default());
+    block.legacy_precmd(PromptMetadata::default());
     block.preexec(PreexecValue {
         command: "warp_run_generator_command 1234 foo".to_owned(),
         session_id: None,
@@ -1453,7 +1453,7 @@ fn test_top_level_command() {
         .with_size_info(SizeInfo::new_without_font_metrics(1, 20))
         .build();
     block.start();
-    block.precmd(PrecmdValue {
+    block.legacy_precmd(PromptMetadata {
         session_id: Some(0),
         ..Default::default()
     });
@@ -1467,7 +1467,7 @@ fn test_top_level_command() {
         .with_size_info(SizeInfo::new_without_font_metrics(1, 20))
         .build();
     block.start();
-    block.precmd(PrecmdValue {
+    block.legacy_precmd(PromptMetadata {
         session_id: Some(0),
         ..Default::default()
     });
@@ -1493,7 +1493,7 @@ fn test_top_level_command_with_aliases() {
         .with_size_info(SizeInfo::new_without_font_metrics(1, 20))
         .build();
     block.start();
-    block.precmd(PrecmdValue {
+    block.legacy_precmd(PromptMetadata {
         session_id: Some(0),
         ..Default::default()
     });
@@ -1506,7 +1506,7 @@ fn test_top_level_command_with_aliases() {
         .with_size_info(SizeInfo::new_without_font_metrics(1, 20))
         .build();
     block.start();
-    block.precmd(PrecmdValue {
+    block.legacy_precmd(PromptMetadata {
         session_id: Some(0),
         ..Default::default()
     });
@@ -1519,7 +1519,7 @@ fn test_top_level_command_with_aliases() {
         .with_size_info(SizeInfo::new_without_font_metrics(1, 20))
         .build();
     block.start();
-    block.precmd(PrecmdValue {
+    block.legacy_precmd(PromptMetadata {
         session_id: Some(0),
         ..Default::default()
     });
@@ -1540,7 +1540,7 @@ fn test_mark_end_of_prompt_with_some_rows_in_flat_storage() {
         .with_honor_ps1(true)
         .build();
 
-    block.precmd(PrecmdValue {
+    block.legacy_precmd(PromptMetadata {
         ps1: Some(hex::encode("prompt1\r\n")),
         honor_ps1: Some(true),
         ..Default::default()

--- a/app/src/terminal/model/block_tests.rs
+++ b/app/src/terminal/model/block_tests.rs
@@ -46,7 +46,7 @@ impl float_cmp::ApproxEq for BlockSection {
 pub fn test_find() {
     let mut block = TestBlockBuilder::new().build();
 
-    block.legacy_precmd(PromptMetadata::default());
+    block.prompt_only_precmd(PromptMetadata::default());
     block.start();
     assert_lines_approx_eq!(block.height(&AgentViewState::Inactive), 3.);
 
@@ -236,7 +236,7 @@ pub fn test_find() {
 
     let mut block = TestBlockBuilder::new().build();
 
-    block.legacy_precmd(PromptMetadata::default());
+    block.prompt_only_precmd(PromptMetadata::default());
     block.start();
 
     block.header_grid.command_grid_linefeed();
@@ -266,7 +266,7 @@ pub fn test_long_running_block_bottom_padding() {
     warpui::r#async::block_on(async {
         let mut block = TestBlockBuilder::new().build();
 
-        block.legacy_precmd(PromptMetadata::default());
+        block.prompt_only_precmd(PromptMetadata::default());
         block.start();
         for c in "command".chars() {
             block.input(c);
@@ -326,7 +326,7 @@ pub fn non_empty_pre_bootstrap_block_can_be_long_running() {
 pub fn test_precmd_no_preexec() {
     let mut block = TestBlockBuilder::new().build();
     block.start();
-    block.legacy_precmd(PromptMetadata::default());
+    block.prompt_only_precmd(PromptMetadata::default());
 
     for c in "command".chars() {
         block.input(c);
@@ -401,7 +401,7 @@ pub fn test_image_completion_drops_in_warp_input_stage() {
 pub fn test_command_grid_bold() {
     let mut block = TestBlockBuilder::new().build();
     block.start();
-    block.legacy_precmd(PromptMetadata::default());
+    block.prompt_only_precmd(PromptMetadata::default());
 
     // We should have the BOLD flag enabled for commands, once we've started the command grid.
     assert!(block
@@ -423,7 +423,7 @@ pub fn test_command_grid_bold() {
 pub fn test_command_grid_bold_after_reset() {
     let mut block = TestBlockBuilder::new().build();
     block.start();
-    block.legacy_precmd(PromptMetadata::default());
+    block.prompt_only_precmd(PromptMetadata::default());
 
     // We should have the BOLD flag enabled for commands, once we've started the command grid.
     assert!(block
@@ -452,7 +452,7 @@ pub fn test_command_grid_bold_after_reset() {
 pub fn test_empty_command() {
     let mut block = TestBlockBuilder::new().build();
     block.start();
-    block.legacy_precmd(PromptMetadata::default());
+    block.prompt_only_precmd(PromptMetadata::default());
 
     block.finish(0);
 
@@ -463,14 +463,14 @@ pub fn test_empty_command() {
 pub fn test_failed_block() {
     let mut block = TestBlockBuilder::new().build();
 
-    block.legacy_precmd(PromptMetadata::default());
+    block.prompt_only_precmd(PromptMetadata::default());
     block.preexec(Default::default());
 
     block.finish(1 /* exit_code */);
     assert!(block.has_failed());
 
     let mut block = TestBlockBuilder::new().build();
-    block.legacy_precmd(PromptMetadata::default());
+    block.prompt_only_precmd(PromptMetadata::default());
     block.finish(1 /* exit_code */);
 
     // The block should not be marked as failed since execution never started.
@@ -481,7 +481,7 @@ pub fn test_failed_block() {
 fn test_non_error_exit_codes() {
     let mut block = TestBlockBuilder::new().build();
 
-    block.legacy_precmd(PromptMetadata::default());
+    block.prompt_only_precmd(PromptMetadata::default());
     block.preexec(Default::default());
 
     block.finish(130 /* exit_code */);
@@ -490,7 +490,7 @@ fn test_non_error_exit_codes() {
 
     let mut block = TestBlockBuilder::new().build();
 
-    block.legacy_precmd(PromptMetadata::default());
+    block.prompt_only_precmd(PromptMetadata::default());
     block.preexec(Default::default());
 
     block.finish(141 /* exit_code */);
@@ -634,7 +634,7 @@ pub fn test_set_current_working_directory_updates_pwd_and_emits_cwd_event() {
 pub fn test_elapsed_duration_rounds_down_to_whole_seconds() {
     let mut block = TestBlockBuilder::new().build();
     // Move the block into the Executing state so `elapsed_duration` returns a value.
-    block.legacy_precmd(PromptMetadata::default());
+    block.prompt_only_precmd(PromptMetadata::default());
     block.preexec(Default::default());
 
     let start = chrono::Local.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
@@ -678,7 +678,7 @@ pub fn test_elapsed_duration_requires_executing_state() {
     assert!(!block.is_duration_live());
 
     // `precmd` alone leaves the block in `BeforeExecution`; the duration is not yet live.
-    block.legacy_precmd(PromptMetadata::default());
+    block.prompt_only_precmd(PromptMetadata::default());
     block.override_start_ts(start);
     assert_eq!(block.elapsed_duration_whole_secs_at(now), None);
     assert!(!block.is_duration_live());
@@ -724,7 +724,7 @@ pub fn test_block_emits_block_completed_event_for_in_band_command() {
         .build();
 
     block.start_for_in_band_command();
-    block.legacy_precmd(PromptMetadata::default());
+    block.prompt_only_precmd(PromptMetadata::default());
     block.preexec(PreexecValue {
         command: "warp_run_generator_command 1234 foo".to_owned(),
         session_id: None,
@@ -1453,7 +1453,7 @@ fn test_top_level_command() {
         .with_size_info(SizeInfo::new_without_font_metrics(1, 20))
         .build();
     block.start();
-    block.legacy_precmd(PromptMetadata {
+    block.prompt_only_precmd(PromptMetadata {
         session_id: Some(0),
         ..Default::default()
     });
@@ -1467,7 +1467,7 @@ fn test_top_level_command() {
         .with_size_info(SizeInfo::new_without_font_metrics(1, 20))
         .build();
     block.start();
-    block.legacy_precmd(PromptMetadata {
+    block.prompt_only_precmd(PromptMetadata {
         session_id: Some(0),
         ..Default::default()
     });
@@ -1493,7 +1493,7 @@ fn test_top_level_command_with_aliases() {
         .with_size_info(SizeInfo::new_without_font_metrics(1, 20))
         .build();
     block.start();
-    block.legacy_precmd(PromptMetadata {
+    block.prompt_only_precmd(PromptMetadata {
         session_id: Some(0),
         ..Default::default()
     });
@@ -1506,7 +1506,7 @@ fn test_top_level_command_with_aliases() {
         .with_size_info(SizeInfo::new_without_font_metrics(1, 20))
         .build();
     block.start();
-    block.legacy_precmd(PromptMetadata {
+    block.prompt_only_precmd(PromptMetadata {
         session_id: Some(0),
         ..Default::default()
     });
@@ -1519,7 +1519,7 @@ fn test_top_level_command_with_aliases() {
         .with_size_info(SizeInfo::new_without_font_metrics(1, 20))
         .build();
     block.start();
-    block.legacy_precmd(PromptMetadata {
+    block.prompt_only_precmd(PromptMetadata {
         session_id: Some(0),
         ..Default::default()
     });
@@ -1540,7 +1540,7 @@ fn test_mark_end_of_prompt_with_some_rows_in_flat_storage() {
         .with_honor_ps1(true)
         .build();
 
-    block.legacy_precmd(PromptMetadata {
+    block.prompt_only_precmd(PromptMetadata {
         ps1: Some(hex::encode("prompt1\r\n")),
         honor_ps1: Some(true),
         ..Default::default()

--- a/app/src/terminal/model/blockgrid.rs
+++ b/app/src/terminal/model/blockgrid.rs
@@ -952,7 +952,7 @@ impl ansi::Handler for BlockGrid {
         self.ansi_handler().text_area_size_chars(writer);
     }
 
-    fn precmd(&mut self, _: PrecmdValue) {
+    fn precmd_with_completion_metadata(&mut self, _: PrecmdValue) {
         unreachable!("Handled at block layer");
     }
 

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -42,8 +42,8 @@ use crate::terminal::event_listener::ChannelEventListener;
 use crate::terminal::model::ansi;
 use crate::terminal::model::ansi::{
     Attr, BootstrappedValue, CharsetIndex, ClearMode, CommandFinishedValue, CursorShape,
-    CursorStyle, LineClearMode, Mode, PrecmdValue, PreexecValue, Processor, StandardCharset,
-    TabulationClearMode,
+    CursorStyle, LineClearMode, Mode, PrecmdValue, PreexecValue, Processor, PromptMetadata,
+    StandardCharset, TabulationClearMode,
 };
 use crate::terminal::model::block::{AgentViewVisibility, Block, SerializedBlock};
 use crate::terminal::model::blockgrid::BlockGrid;
@@ -311,7 +311,7 @@ pub struct BlockList {
     /// necessary to recompute the precmd payload after an in-band command runs. Thus we send an
     /// unpopulated precmd payload for in-band commands to make their execution as fast as
     /// possible.
-    last_populated_precmd_payload: Option<PrecmdValue>,
+    last_populated_precmd_payload: Option<PromptMetadata>,
 
     /// Cached data about the prompt that was visible in the input the last time
     /// the user submitted a command.  Some prompt tools update the prompt just
@@ -2610,18 +2610,18 @@ impl BlockList {
         &mut self,
         block_id: BlockId,
         bootstrap_stage: BootstrapStage,
-        precmd_value: Option<PrecmdValue>,
+        prompt_metadata: Option<PromptMetadata>,
         restored_block_was_local: bool,
     ) {
         self.create_new_block(
             block_id,
             bootstrap_stage,
-            precmd_value,
+            prompt_metadata,
             Some(restored_block_was_local),
         );
     }
 
-    /// If a precmd_value is provided, then we delegate the precmd
+    /// If prompt metadata is provided, then we delegate the precmd
     /// message to the block. In normal execution, we don't have
     /// this data here because it comes from a different hook dedicated
     /// to precmd itself. One place we provide the value is session
@@ -2631,7 +2631,7 @@ impl BlockList {
         &mut self,
         block_id: BlockId,
         bootstrap_stage: BootstrapStage,
-        precmd_value: Option<PrecmdValue>,
+        prompt_metadata: Option<PromptMetadata>,
         restored_block_was_local: Option<bool>,
     ) {
         let honor_ps1 = self.honor_ps1;
@@ -2679,8 +2679,8 @@ impl BlockList {
             .insert(block.id().clone(), block.index());
         self.blocks.push(block);
 
-        if let Some(precmd_value) = precmd_value {
-            delegate_to_block!(self.precmd(precmd_value));
+        if let Some(prompt_metadata) = prompt_metadata {
+            delegate_to_block!(self.legacy_precmd(prompt_metadata));
         }
     }
 
@@ -2921,7 +2921,7 @@ impl BlockList {
         bootstrap_stage: BootstrapStage,
         processor: &mut Processor,
     ) {
-        let precmd_value = PrecmdValue {
+        let prompt_metadata = PromptMetadata {
             pwd: block.pwd.clone(),
             git_head: block.git_head.clone(),
             git_branch: block.git_branch_name.clone(),
@@ -2940,7 +2940,7 @@ impl BlockList {
         self.create_new_block(
             block.id.clone(),
             bootstrap_stage,
-            Some(precmd_value),
+            Some(prompt_metadata),
             block.is_local,
         );
         if let Some(shell_host) = &block.shell_host {
@@ -3054,14 +3054,15 @@ impl BlockList {
             self.finish_background_block();
         }
 
-        self.active_block_mut().finish(data.exit_code);
+        self.active_block_mut()
+            .finish(data.completion_metadata.exit_code);
         self.update_active_block_height();
 
         self.update_selection_after_height_change();
         self.create_new_block(
-            data.next_block_id,
+            data.completion_metadata.next_block_id,
             next_bootstrap_stage,
-            None, /*precmd_value*/
+            None, /* prompt_metadata */
             None, /* restored_block_was_local */
         );
         if next_bootstrap_stage == BootstrapStage::ScriptExecution {
@@ -3752,6 +3753,10 @@ impl ansi::Handler for BlockList {
     /// the view. This is where we want to perform any costly
     /// operations relevant to the _previous_ block.
     fn precmd(&mut self, data: PrecmdValue) {
+        self.legacy_precmd(data.prompt_metadata);
+    }
+
+    fn legacy_precmd(&mut self, data: PromptMetadata) {
         let latest_block_finished_time = self.latest_block_finished_time.take();
         // We don't need to log this delay during the bootstrapping process, since these
         // are not blocks that the user has created. The delay here also can be very high
@@ -3776,11 +3781,11 @@ impl ansi::Handler for BlockList {
         // in-band command runs. Thus we send an unpopulated precmd payload for in-band commands to
         // make their execution as fast as possible.
         if data.was_sent_after_in_band_command() {
-            let mut precmd_value = self.last_populated_precmd_payload.clone().unwrap_or(data);
-            precmd_value.is_after_in_band_command = true;
-            delegate_to_block!(self.precmd(precmd_value));
+            let mut prompt_metadata = self.last_populated_precmd_payload.clone().unwrap_or(data);
+            prompt_metadata.is_after_in_band_command = true;
+            delegate_to_block!(self.legacy_precmd(prompt_metadata));
         } else {
-            delegate_to_block!(self.precmd(data.clone()));
+            delegate_to_block!(self.legacy_precmd(data.clone()));
             self.last_populated_precmd_payload = Some(data);
         }
 

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -2680,7 +2680,7 @@ impl BlockList {
         self.blocks.push(block);
 
         if let Some(prompt_metadata) = prompt_metadata {
-            delegate_to_block!(self.legacy_precmd(prompt_metadata));
+            delegate_to_block!(self.prompt_only_precmd(prompt_metadata));
         }
     }
 
@@ -3752,11 +3752,11 @@ impl ansi::Handler for BlockList {
     /// responsible for sending the `AfterBlockCompleted` event to
     /// the view. This is where we want to perform any costly
     /// operations relevant to the _previous_ block.
-    fn precmd(&mut self, data: PrecmdValue) {
-        self.legacy_precmd(data.prompt_metadata);
+    fn precmd_with_completion_metadata(&mut self, data: PrecmdValue) {
+        self.prompt_only_precmd(data.prompt_metadata);
     }
 
-    fn legacy_precmd(&mut self, data: PromptMetadata) {
+    fn prompt_only_precmd(&mut self, data: PromptMetadata) {
         let latest_block_finished_time = self.latest_block_finished_time.take();
         // We don't need to log this delay during the bootstrapping process, since these
         // are not blocks that the user has created. The delay here also can be very high
@@ -3783,9 +3783,9 @@ impl ansi::Handler for BlockList {
         if data.was_sent_after_in_band_command() {
             let mut prompt_metadata = self.last_populated_precmd_payload.clone().unwrap_or(data);
             prompt_metadata.is_after_in_band_command = true;
-            delegate_to_block!(self.legacy_precmd(prompt_metadata));
+            delegate_to_block!(self.prompt_only_precmd(prompt_metadata));
         } else {
-            delegate_to_block!(self.legacy_precmd(data.clone()));
+            delegate_to_block!(self.prompt_only_precmd(data.clone()));
             self.last_populated_precmd_payload = Some(data);
         }
 

--- a/app/src/terminal/model/blocks_tests.rs
+++ b/app/src/terminal/model/blocks_tests.rs
@@ -91,7 +91,7 @@ pub fn insert_block_with_prompt(
     command: &str,
     output: &str,
 ) -> BlockIndex {
-    block_list.precmd(PrecmdValue {
+    block_list.legacy_precmd(PromptMetadata {
         ps1: Some(hex::encode(prompt)),
         honor_ps1: Some(true),
         ..Default::default()
@@ -122,8 +122,15 @@ pub fn insert_block_with_prompt(
 /// block list, the bootstrapped state). Tests that check for messages sent to the
 /// view need to also call `precmd`.
 pub fn command_finished_and_precmd(block_list: &mut BlockList) {
-    block_list.command_finished(Default::default());
-    block_list.precmd(Default::default());
+    let completion_metadata = ansi::CompletionMetadata::default();
+    block_list.command_finished(CommandFinishedValue {
+        completion_metadata: completion_metadata.clone(),
+        ..Default::default()
+    });
+    block_list.precmd(PrecmdValue {
+        completion_metadata,
+        prompt_metadata: PromptMetadata::default(),
+    });
 }
 fn drain_terminal_events(events_rx: &async_channel::Receiver<Event>) -> Vec<Event> {
     let mut events = Vec::new();

--- a/app/src/terminal/model/blocks_tests.rs
+++ b/app/src/terminal/model/blocks_tests.rs
@@ -91,7 +91,7 @@ pub fn insert_block_with_prompt(
     command: &str,
     output: &str,
 ) -> BlockIndex {
-    block_list.legacy_precmd(PromptMetadata {
+    block_list.prompt_only_precmd(PromptMetadata {
         ps1: Some(hex::encode(prompt)),
         honor_ps1: Some(true),
         ..Default::default()
@@ -120,14 +120,14 @@ pub fn insert_block_with_prompt(
 /// Calling `command_finished` is all that's necessary for tests that only
 /// advance the block list and check the state (e.g. like the length of the
 /// block list, the bootstrapped state). Tests that check for messages sent to the
-/// view need to also call `precmd`.
+/// view need to also call `precmd_with_completion_metadata`.
 pub fn command_finished_and_precmd(block_list: &mut BlockList) {
     let completion_metadata = ansi::CompletionMetadata::default();
     block_list.command_finished(CommandFinishedValue {
         completion_metadata: completion_metadata.clone(),
         ..Default::default()
     });
-    block_list.precmd(PrecmdValue {
+    block_list.precmd_with_completion_metadata(PrecmdValue {
         completion_metadata,
         prompt_metadata: PromptMetadata::default(),
     });

--- a/app/src/terminal/model/early_output.rs
+++ b/app/src/terminal/model/early_output.rs
@@ -423,8 +423,10 @@ impl ansi::Handler for EarlyOutputHandler<'_> {
         );
     }
 
-    fn precmd(&mut self, _data: ansi::PrecmdValue) {
-        panic!("Called EarlyOutput::precmd handler method instead of Block::precmd");
+    fn precmd_with_completion_metadata(&mut self, _data: ansi::PrecmdValue) {
+        panic!(
+            "Called EarlyOutput::precmd_with_completion_metadata handler method instead of Block::precmd_with_completion_metadata"
+        );
     }
 
     /*

--- a/app/src/terminal/model/early_output.rs
+++ b/app/src/terminal/model/early_output.rs
@@ -429,6 +429,12 @@ impl ansi::Handler for EarlyOutputHandler<'_> {
         );
     }
 
+    fn prompt_only_precmd(&mut self, _data: ansi::PromptMetadata) {
+        panic!(
+            "Called EarlyOutput::prompt_only_precmd handler method instead of Block::prompt_only_precmd"
+        );
+    }
+
     /*
      * Handler methods only relevant to background output.
      */

--- a/app/src/terminal/model/early_output_tests.rs
+++ b/app/src/terminal/model/early_output_tests.rs
@@ -42,7 +42,7 @@ fn new_block_list(event_proxy: ChannelEventListener, mode: TypeaheadMode) -> Blo
     assert_eq!(block_list.early_output_mut().mode, mode);
 
     block_list.command_finished(Default::default());
-    block_list.precmd(Default::default());
+    block_list.legacy_precmd(Default::default());
     assert!(block_list.is_bootstrapping_precmd_done());
     block_list
 }
@@ -128,7 +128,7 @@ fn test_queued_typeahead_input_matching() {
     });
     assert_eq!(block_list.active_block().command_to_string(), "first");
     block_list.command_finished(Default::default());
-    block_list.precmd(Default::default());
+    block_list.legacy_precmd(Default::default());
 
     // Once the second line of typeahead is echoed, it should be recognized as typeahead.
     block_list.input('s');
@@ -174,7 +174,7 @@ fn test_queued_typeahead_shell_reported() {
     assert!(block_list.background_block_mut().is_none());
 
     block_list.command_finished(Default::default());
-    block_list.precmd(Default::default());
+    block_list.legacy_precmd(Default::default());
 
     // Now, when the second line is echoed, it should be recognized as typeahead.
     block_list.input('s');

--- a/app/src/terminal/model/early_output_tests.rs
+++ b/app/src/terminal/model/early_output_tests.rs
@@ -42,7 +42,7 @@ fn new_block_list(event_proxy: ChannelEventListener, mode: TypeaheadMode) -> Blo
     assert_eq!(block_list.early_output_mut().mode, mode);
 
     block_list.command_finished(Default::default());
-    block_list.legacy_precmd(Default::default());
+    block_list.prompt_only_precmd(Default::default());
     assert!(block_list.is_bootstrapping_precmd_done());
     block_list
 }
@@ -128,7 +128,7 @@ fn test_queued_typeahead_input_matching() {
     });
     assert_eq!(block_list.active_block().command_to_string(), "first");
     block_list.command_finished(Default::default());
-    block_list.legacy_precmd(Default::default());
+    block_list.prompt_only_precmd(Default::default());
 
     // Once the second line of typeahead is echoed, it should be recognized as typeahead.
     block_list.input('s');
@@ -174,7 +174,7 @@ fn test_queued_typeahead_shell_reported() {
     assert!(block_list.background_block_mut().is_none());
 
     block_list.command_finished(Default::default());
-    block_list.legacy_precmd(Default::default());
+    block_list.prompt_only_precmd(Default::default());
 
     // Now, when the second line is echoed, it should be recognized as typeahead.
     block_list.input('s');

--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -1211,7 +1211,7 @@ impl ansi::Handler for GridHandler {
         let _ = write!(writer, "\x1b[8;{};{}t", self.visible_rows(), self.columns());
     }
 
-    fn precmd(&mut self, _: PrecmdValue) {
+    fn precmd_with_completion_metadata(&mut self, _: PrecmdValue) {
         unreachable!("Precmd hook is handled at block layer")
     }
 

--- a/app/src/terminal/model/header_grid.rs
+++ b/app/src/terminal/model/header_grid.rs
@@ -9,7 +9,7 @@ use pathfinder_color::ColorU;
 use warp_terminal::model::{KeyboardModes, KeyboardModesApplyBehavior};
 use warpui::units::{IntoLines as _, Lines};
 
-use super::ansi::{self, Attr, Handler, PrecmdValue, PreexecValue, Processor};
+use super::ansi::{self, Attr, Handler, PrecmdValue, PreexecValue, Processor, PromptMetadata};
 use super::block::{BlockGridPoint, BlockSize};
 use super::blockgrid::BlockGrid;
 use super::bootstrap::BootstrapStage;
@@ -1142,6 +1142,10 @@ impl ansi::Handler for HeaderGrid {
     }
 
     fn precmd(&mut self, data: PrecmdValue) {
+        self.legacy_precmd(data.prompt_metadata);
+    }
+
+    fn legacy_precmd(&mut self, data: PromptMetadata) {
         if let Some(honor_ps1) = data.honor_ps1 {
             if honor_ps1 != self.honor_ps1 {
                 log::debug!(

--- a/app/src/terminal/model/header_grid.rs
+++ b/app/src/terminal/model/header_grid.rs
@@ -1141,11 +1141,11 @@ impl ansi::Handler for HeaderGrid {
         delegate_with_writer!(self.text_area_size_chars(writer));
     }
 
-    fn precmd(&mut self, data: PrecmdValue) {
-        self.legacy_precmd(data.prompt_metadata);
+    fn precmd_with_completion_metadata(&mut self, data: PrecmdValue) {
+        self.prompt_only_precmd(data.prompt_metadata);
     }
 
-    fn legacy_precmd(&mut self, data: PromptMetadata) {
+    fn prompt_only_precmd(&mut self, data: PromptMetadata) {
         if let Some(honor_ps1) = data.honor_ps1 {
             if honor_ps1 != self.honor_ps1 {
                 log::debug!(

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -58,7 +58,8 @@ pub use crate::terminal::history::HistoryEntry;
 use crate::terminal::model::ansi;
 use crate::terminal::model::ansi::{
     ClearValue, CommandFinishedValue, ExitShellValue, Handler, InitShellValue, InitSubshellValue,
-    PreInteractiveSSHSessionValue, PrecmdValue, PreexecValue, SSHValue, SourcedRcFileForWarpValue,
+    PreInteractiveSSHSessionValue, PrecmdValue, PreexecValue, PromptMetadata, SSHValue,
+    SourcedRcFileForWarpValue,
 };
 use crate::terminal::model::bootstrap::BootstrapStage;
 use crate::terminal::model::completions::{
@@ -997,13 +998,17 @@ impl TerminalModel {
             shell: "zsh".to_string(),
             ..Default::default()
         });
+        let completion_metadata = ansi::CompletionMetadata::default();
         terminal_model.command_finished(CommandFinishedValue {
+            completion_metadata: completion_metadata.clone(),
             session_id: Some(session_id.as_u64()),
-            ..Default::default()
         });
         terminal_model.precmd(PrecmdValue {
-            session_id: Some(session_id.as_u64()),
-            ..Default::default()
+            completion_metadata,
+            prompt_metadata: PromptMetadata {
+                session_id: Some(session_id.as_u64()),
+                ..Default::default()
+            },
         });
         terminal_model
     }
@@ -2707,7 +2712,7 @@ impl ansi::Handler for TerminalModel {
         // the blocklist (for the local shell).
         self.exit_alt_screen(true);
 
-        let block_id = data.next_block_id.to_string();
+        let block_id = data.completion_metadata.next_block_id.to_string();
         let is_for_in_band_command = self.block_list().active_block().is_in_band_command_block();
         let finished_block_bootstrap_stage = self.block_list().active_block().bootstrap_stage();
         delegate!(self.command_finished(data));
@@ -2751,6 +2756,10 @@ impl ansi::Handler for TerminalModel {
     }
 
     fn precmd(&mut self, data: PrecmdValue) {
+        self.legacy_precmd(data.prompt_metadata);
+    }
+
+    fn legacy_precmd(&mut self, data: PromptMetadata) {
         self.ignore_bootstrapping_messages = false;
         let session_id = data.session_id;
         let mut env_vars = HashMap::new();
@@ -2758,7 +2767,7 @@ impl ansi::Handler for TerminalModel {
             env_vars.insert("KUBECONFIG".to_string(), kube_config);
         }
         let handled_after_inband = data.was_sent_after_in_band_command();
-        delegate!(self.precmd(data));
+        delegate!(self.legacy_precmd(data));
 
         self.emit_handler_event(HandlerEvent::Precmd {
             session_id: session_id.map(|id| id.into()),

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -1003,7 +1003,7 @@ impl TerminalModel {
             completion_metadata: completion_metadata.clone(),
             session_id: Some(session_id.as_u64()),
         });
-        terminal_model.precmd(PrecmdValue {
+        terminal_model.precmd_with_completion_metadata(PrecmdValue {
             completion_metadata,
             prompt_metadata: PromptMetadata {
                 session_id: Some(session_id.as_u64()),
@@ -2755,11 +2755,11 @@ impl ansi::Handler for TerminalModel {
         self.block_list.set_current_working_directory(path);
     }
 
-    fn precmd(&mut self, data: PrecmdValue) {
-        self.legacy_precmd(data.prompt_metadata);
+    fn precmd_with_completion_metadata(&mut self, data: PrecmdValue) {
+        self.prompt_only_precmd(data.prompt_metadata);
     }
 
-    fn legacy_precmd(&mut self, data: PromptMetadata) {
+    fn prompt_only_precmd(&mut self, data: PromptMetadata) {
         self.ignore_bootstrapping_messages = false;
         let session_id = data.session_id;
         let mut env_vars = HashMap::new();
@@ -2767,7 +2767,7 @@ impl ansi::Handler for TerminalModel {
             env_vars.insert("KUBECONFIG".to_string(), kube_config);
         }
         let handled_after_inband = data.was_sent_after_in_band_command();
-        delegate!(self.legacy_precmd(data));
+        delegate!(self.prompt_only_precmd(data));
 
         self.emit_handler_event(HandlerEvent::Precmd {
             session_id: session_id.map(|id| id.into()),

--- a/app/src/terminal/model/terminal_model_tests.rs
+++ b/app/src/terminal/model/terminal_model_tests.rs
@@ -12,7 +12,7 @@ use warpui::text::{str_to_byte_vec, SelectionType};
 use super::*;
 use crate::terminal::color;
 use crate::terminal::event_listener::ChannelEventListener;
-use crate::terminal::model::ansi::{Handler, Processor};
+use crate::terminal::model::ansi::{CompletionMetadata, Handler, Processor};
 use crate::terminal::model::block::BlockId;
 use crate::terminal::model::bootstrap::BootstrapStage;
 use crate::terminal::model::grid::Dimensions as _;
@@ -151,6 +151,17 @@ fn hex_encoded_json_dcs(payload: &str) -> Vec<u8> {
     bytes.push(0x9c);
     bytes
 }
+fn command_finished_and_precmd(terminal: &mut TerminalModel) {
+    let completion_metadata = CompletionMetadata::default();
+    terminal.command_finished(CommandFinishedValue {
+        completion_metadata: completion_metadata.clone(),
+        ..Default::default()
+    });
+    terminal.precmd(PrecmdValue {
+        completion_metadata,
+        prompt_metadata: PromptMetadata::default(),
+    });
+}
 
 #[test]
 fn ignores_non_inline_iterm_file_payload_without_overwriting_cwd_file() {
@@ -161,7 +172,7 @@ fn ignores_non_inline_iterm_file_payload_without_overwriting_cwd_file() {
     fs::write(&target_path, original_bytes).unwrap();
 
     let mut terminal = TerminalModel::mock(None, None);
-    terminal.precmd(PrecmdValue {
+    terminal.legacy_precmd(PromptMetadata {
         pwd: Some(temp_dir.path().to_string_lossy().to_string()),
         ..Default::default()
     });
@@ -182,7 +193,7 @@ fn ignores_multipart_non_inline_iterm_file_payload_without_overwriting_cwd_file(
     fs::write(&target_path, original_bytes).unwrap();
 
     let mut terminal = TerminalModel::mock(None, None);
-    terminal.precmd(PrecmdValue {
+    terminal.legacy_precmd(PromptMetadata {
         pwd: Some(temp_dir.path().to_string_lossy().to_string()),
         ..Default::default()
     });
@@ -220,10 +231,8 @@ fn handles_inline_iterm_image_payload() {
 #[test]
 fn ssh_bootstraps_if_blocklist_empty() {
     let mut terminal = TerminalModel::mock(None, None);
-    terminal.command_finished(Default::default());
-    terminal.precmd(Default::default());
-    terminal.command_finished(Default::default());
-    terminal.precmd(Default::default());
+    command_finished_and_precmd(&mut terminal);
+    command_finished_and_precmd(&mut terminal);
 
     let bootstrapped_value = BootstrappedValue {
         session_id: None,
@@ -252,7 +261,10 @@ fn ssh_bootstraps_if_blocklist_empty() {
     };
     terminal.bootstrapped(bootstrapped_value.clone());
     terminal.command_finished(Default::default());
-    terminal.block_list_mut().precmd(Default::default());
+    terminal.block_list_mut().precmd(PrecmdValue {
+        completion_metadata: CompletionMetadata::default(),
+        prompt_metadata: PromptMetadata::default(),
+    });
 
     assert!(terminal.is_active_block_bootstrapped());
 
@@ -271,13 +283,10 @@ fn ssh_bootstraps_if_blocklist_empty() {
     // The active block should no longer be considered bootstrapped after the init shell call.
     assert!(!terminal.is_active_block_bootstrapped());
 
-    terminal.command_finished(Default::default());
-    terminal.precmd(PrecmdValue::default());
-    terminal.command_finished(Default::default());
-    terminal.precmd(Default::default());
+    command_finished_and_precmd(&mut terminal);
+    command_finished_and_precmd(&mut terminal);
     terminal.bootstrapped(bootstrapped_value);
-    terminal.command_finished(Default::default());
-    terminal.precmd(Default::default());
+    command_finished_and_precmd(&mut terminal);
 
     assert!(terminal.is_active_block_bootstrapped());
 }
@@ -847,8 +856,10 @@ fn test_exit_alt_screen_on_command_finished() {
     terminal.enter_alt_screen(true);
 
     terminal.command_finished(CommandFinishedValue {
-        exit_code: ExitCode::from(0),
-        next_block_id: BlockId::new(),
+        completion_metadata: CompletionMetadata {
+            exit_code: ExitCode::from(0),
+            next_block_id: BlockId::new(),
+        },
         session_id: None,
     });
 
@@ -862,8 +873,10 @@ fn test_unset_bracketed_paste_mode_on_command_finished() {
     terminal.set_mode(Mode::BracketedPaste);
 
     terminal.command_finished(CommandFinishedValue {
-        exit_code: ExitCode::from(0),
-        next_block_id: BlockId::new(),
+        completion_metadata: CompletionMetadata {
+            exit_code: ExitCode::from(0),
+            next_block_id: BlockId::new(),
+        },
         session_id: None,
     });
 

--- a/app/src/terminal/model/terminal_model_tests.rs
+++ b/app/src/terminal/model/terminal_model_tests.rs
@@ -157,7 +157,7 @@ fn command_finished_and_precmd(terminal: &mut TerminalModel) {
         completion_metadata: completion_metadata.clone(),
         ..Default::default()
     });
-    terminal.precmd(PrecmdValue {
+    terminal.precmd_with_completion_metadata(PrecmdValue {
         completion_metadata,
         prompt_metadata: PromptMetadata::default(),
     });
@@ -172,7 +172,7 @@ fn ignores_non_inline_iterm_file_payload_without_overwriting_cwd_file() {
     fs::write(&target_path, original_bytes).unwrap();
 
     let mut terminal = TerminalModel::mock(None, None);
-    terminal.legacy_precmd(PromptMetadata {
+    terminal.prompt_only_precmd(PromptMetadata {
         pwd: Some(temp_dir.path().to_string_lossy().to_string()),
         ..Default::default()
     });
@@ -193,7 +193,7 @@ fn ignores_multipart_non_inline_iterm_file_payload_without_overwriting_cwd_file(
     fs::write(&target_path, original_bytes).unwrap();
 
     let mut terminal = TerminalModel::mock(None, None);
-    terminal.legacy_precmd(PromptMetadata {
+    terminal.prompt_only_precmd(PromptMetadata {
         pwd: Some(temp_dir.path().to_string_lossy().to_string()),
         ..Default::default()
     });
@@ -261,10 +261,12 @@ fn ssh_bootstraps_if_blocklist_empty() {
     };
     terminal.bootstrapped(bootstrapped_value.clone());
     terminal.command_finished(Default::default());
-    terminal.block_list_mut().precmd(PrecmdValue {
-        completion_metadata: CompletionMetadata::default(),
-        prompt_metadata: PromptMetadata::default(),
-    });
+    terminal
+        .block_list_mut()
+        .precmd_with_completion_metadata(PrecmdValue {
+            completion_metadata: CompletionMetadata::default(),
+            prompt_metadata: PromptMetadata::default(),
+        });
 
     assert!(terminal.is_active_block_bootstrapped());
 

--- a/app/src/terminal/model/test_utils.rs
+++ b/app/src/terminal/model/test_utils.rs
@@ -14,7 +14,10 @@ use pathfinder_geometry::vector::Vector2F;
 use warp_core::command::ExitCode;
 use warpui::r#async::executor::Background;
 
-use super::ansi::{CommandFinishedValue, Handler, PrecmdValue, PreexecValue, Processor};
+use super::ansi::{
+    CommandFinishedValue, CompletionMetadata, Handler, PrecmdValue, PreexecValue, Processor,
+    PromptMetadata,
+};
 use super::block::{Block, BlockId, BlockSize};
 use super::blocks::BlockList;
 use super::bootstrap::BootstrapStage;
@@ -373,25 +376,20 @@ impl TerminalModel {
     /// Simulates the completion of a block.
     /// Assumes that a block was running to begin with.
     pub fn finish_block(&mut self) {
-        self.command_finished(CommandFinishedValue {
+        let completion_metadata = CompletionMetadata {
             exit_code: ExitCode::from(0),
             next_block_id: BlockId::new(),
+        };
+        self.command_finished(CommandFinishedValue {
+            completion_metadata: completion_metadata.clone(),
             session_id: None,
         });
         self.precmd(PrecmdValue {
-            pwd: None,
-            git_head: None,
-            git_branch: None,
-            virtual_env: None,
-            conda_env: None,
-            node_version: None,
-            session_id: Some(0),
-            kube_config: None,
-            ps1: None,
-            honor_ps1: None,
-            rprompt: None,
-            ps1_is_encoded: Some(true),
-            is_after_in_band_command: false,
+            completion_metadata,
+            prompt_metadata: PromptMetadata {
+                session_id: Some(0),
+                ..Default::default()
+            },
         });
     }
 

--- a/app/src/terminal/model/test_utils.rs
+++ b/app/src/terminal/model/test_utils.rs
@@ -384,7 +384,7 @@ impl TerminalModel {
             completion_metadata: completion_metadata.clone(),
             session_id: None,
         });
-        self.precmd(PrecmdValue {
+        self.precmd_with_completion_metadata(PrecmdValue {
             completion_metadata,
             prompt_metadata: PromptMetadata {
                 session_id: Some(0),

--- a/app/src/terminal/shared_session/presence_manager_tests.rs
+++ b/app/src/terminal/shared_session/presence_manager_tests.rs
@@ -9,7 +9,9 @@ use warp_core::command::ExitCode;
 use warpui::App;
 
 use crate::auth::UserUid;
-use crate::terminal::model::ansi::{CommandFinishedValue, Handler};
+use crate::terminal::model::ansi::{
+    CommandFinishedValue, CompletionMetadata, Handler, PrecmdValue, PromptMetadata,
+};
 use crate::terminal::model::blocks::BlockList;
 use crate::terminal::model::test_utils::TestBlockListBuilder;
 use crate::terminal::shared_session::presence_manager::{PresenceManager, PRESET_COLORS};
@@ -309,12 +311,18 @@ fn block_list_for_test(max_block_index: usize) -> BlockList {
 
     // Block 0 already exists as part of creating the blocklist
     for i in 1..max_block_index {
-        block_list.command_finished(CommandFinishedValue {
+        let completion_metadata = CompletionMetadata {
             exit_code: ExitCode::from(0),
             next_block_id: i.to_string().into(),
+        };
+        block_list.command_finished(CommandFinishedValue {
+            completion_metadata: completion_metadata.clone(),
             session_id: None,
         });
-        block_list.precmd(Default::default());
+        block_list.precmd(PrecmdValue {
+            completion_metadata,
+            prompt_metadata: PromptMetadata::default(),
+        });
     }
     block_list
 }

--- a/app/src/terminal/shared_session/presence_manager_tests.rs
+++ b/app/src/terminal/shared_session/presence_manager_tests.rs
@@ -319,7 +319,7 @@ fn block_list_for_test(max_block_index: usize) -> BlockList {
             completion_metadata: completion_metadata.clone(),
             session_id: None,
         });
-        block_list.precmd(PrecmdValue {
+        block_list.precmd_with_completion_metadata(PrecmdValue {
             completion_metadata,
             prompt_metadata: PromptMetadata::default(),
         });


### PR DESCRIPTION
## Description

Stack PR 3/7; depends on #12853.

### Context

Once the new fields begin reaching clients, the parser must distinguish three meaningfully different inputs. A new sharer's `Precmd` contains a complete completion identity; an older sharer's `Precmd` contains prompt metadata only; and a payload containing just one completion field is malformed. Treating those cases as one partially optional value would spread ambiguity into the model and risk using incomplete or prompt-only evidence as proof that a command completed.

### Approach

This PR makes the distinction explicit at the parser boundary. A canonical `PrecmdValue` contains non-optional `CompletionMetadata` plus reusable `PromptMetadata`; a prompt with neither completion field becomes a separate prompt-only event; and a prompt with exactly one completion field is rejected. Both JSON and key-value decoding follow the same classification rule.

The prompt-only portion is also separated so `BlockList`, `Block`, `HeaderGrid`, restoration, and cached prompt paths do not need to know about completion evidence. Canonical completion metadata reaches `TerminalModel`, but this PR intentionally sends `Precmd` hooks with completion metadata and prompt-only `Precmd` hooks through the existing prompt behavior. Recovery is deferred until the normal mutation pipeline and lifecycle gate exist.

### Review guidance

- Is the both/neither/partial classification exhaustive and consistent across JSON and key-value hooks?
- Can malformed or prompt-only payloads accidentally acquire default completion evidence?
- Does the broad `PromptMetadata` refactor preserve current prompt and lifecycle behavior despite changing many call sites?

## Testing

- Added parser coverage for payloads with completion metadata, prompt-only payloads, malformed partial payloads, invalid payloads, and unknown-field payloads.
- Updated affected block, terminal-model, restoration, and shared-session coverage for the typed prompt metadata refactor.
- Final-stack validation: `cargo check -p warp --tests`, `./script/format`, and `git diff --check`.
