### PR TITLE
Centralize terminal lifecycle mutations

### DIFF
--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -2936,7 +2936,7 @@ impl Block {
     pub(super) fn apply_precmd(&mut self, data: PromptMetadata) {
         record_trace_event!("command_execution:block:precmd");
         let is_after_in_band_command = data.was_sent_after_in_band_command();
-        self.header_grid.legacy_precmd(data.clone());
+        self.header_grid.prompt_only_precmd(data.clone());
 
         self.state = BlockState::BeforeExecution;
         self.pwd = data.pwd;

--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -52,7 +52,9 @@ use crate::terminal::event::{
     BlockWorkingDirectoryUpdatedEvent, Event, UserBlockCompleted,
 };
 use crate::terminal::event_listener::ChannelEventListener;
-use crate::terminal::model::ansi::{self, PrecmdValue, PreexecValue, Processor, PromptMetadata};
+use crate::terminal::model::ansi::{
+    self, Handler, PrecmdValue, PreexecValue, Processor, PromptMetadata,
+};
 use crate::terminal::model::blockgrid::BlockGrid;
 use crate::terminal::model::grid::grid_handler::TermMode;
 use crate::terminal::model::index::{Point, VisibleRow};
@@ -2930,6 +2932,79 @@ impl Block {
         }
         self.output_grid.clear_marked_text();
     }
+
+    pub(super) fn apply_precmd(&mut self, data: PromptMetadata) {
+        record_trace_event!("command_execution:block:precmd");
+        let is_after_in_band_command = data.was_sent_after_in_band_command();
+        self.header_grid.legacy_precmd(data.clone());
+
+        self.state = BlockState::BeforeExecution;
+        self.pwd = data.pwd;
+        self.git_branch.clone_from(&data.git_head);
+        self.git_branch_name.clone_from(&data.git_branch);
+        self.virtual_env = data.virtual_env;
+        self.conda_env = data.conda_env;
+        self.node_version = data.node_version;
+        self.session_id = data.session_id.map(Into::into);
+        self.rprompt.clone_from(&data.rprompt);
+
+        if let Some(rprompt) = data.rprompt {
+            self.init_rprompt_grid(&rprompt);
+        }
+
+        self.precmd_state = PrecmdState::AfterPrecmd;
+        self.event_proxy
+            .send_terminal_event(Event::BlockMetadataReceived(BlockMetadataReceivedEvent {
+                block_metadata: self.metadata(),
+                block_index: self.block_index,
+                is_after_in_band_command,
+                is_done_bootstrapping: matches!(
+                    self.bootstrap_stage,
+                    BootstrapStage::PostBootstrapPrecmd
+                ),
+            }));
+    }
+
+    pub(super) fn apply_preexec(&mut self, data: PreexecValue) {
+        record_trace_event!("command_execution:block:prexec");
+
+        self.ensure_started_for_preexec();
+        self.header_grid.preexec(data.clone());
+
+        let is_for_in_band_command = command_executor::is_in_band_command(data.command.as_str());
+        if self.bootstrap_stage() == BootstrapStage::PostBootstrapPrecmd {
+            self.event_proxy
+                .send_terminal_event(Event::AfterBlockStarted {
+                    block_id: self.id.clone(),
+                    command: self.command_to_string(),
+                    is_for_in_band_command,
+                });
+        }
+
+        self.leading_linefeeds_ignored = 0;
+        self.output_grid.start();
+        self.state = BlockState::Executing;
+        self.is_for_in_band_command = is_for_in_band_command;
+
+        self.wakeup_after_delay();
+    }
+
+    /// Starts the block when `Preexec` is the first observed start evidence.
+    pub(super) fn ensure_started_for_preexec(&mut self) {
+        // This condition is a hack to fix a bug with shells that don't support bracketed paste,
+        // e.g. legacy Bash versions, 4.4 or earlier.
+        // https://lists.gnu.org/archive/html/info-gnu/2016-09/msg00012.html
+        // The bug happens when multi-line commands are submitted, see CORE-1698. Without bracketed
+        // paste, we get multiple blocks per [`crate::terminal::input::Event::ExecuteCommand`]. We
+        // generally assume the code path on ExecuteCommand is responsible for starting the active
+        // block. So, `self.started()` should always be true by this point. However, this assumption
+        // is violated if we get multiple blocks per ExecuteCommand event. So, as a fallback, we
+        // start the block here if it hasn't happened already. Note: the displayed command duration
+        // in the "block label" may be under-estimated in this case.
+        if !self.started() && self.state == BlockState::BeforeExecution {
+            self.start();
+        }
+    }
 }
 
 /// Used in the ansi::Handler implementation for Block below. Performs
@@ -3327,76 +3402,15 @@ impl ansi::Handler for Block {
     }
 
     fn precmd_with_completion_metadata(&mut self, data: PrecmdValue) {
-        self.prompt_only_precmd(data.prompt_metadata);
+        self.apply_precmd(data.prompt_metadata);
     }
 
     fn prompt_only_precmd(&mut self, data: PromptMetadata) {
-        record_trace_event!("command_execution:block:precmd");
-        let is_after_in_band_command = data.was_sent_after_in_band_command();
-        self.header_grid.prompt_only_precmd(data.clone());
-
-        self.state = BlockState::BeforeExecution;
-        self.pwd = data.pwd;
-        self.git_branch.clone_from(&data.git_head);
-        self.git_branch_name.clone_from(&data.git_branch);
-        self.virtual_env = data.virtual_env;
-        self.conda_env = data.conda_env;
-        self.node_version = data.node_version;
-        self.session_id = data.session_id.map(Into::into);
-        self.rprompt.clone_from(&data.rprompt);
-
-        if let Some(rprompt) = data.rprompt {
-            self.init_rprompt_grid(&rprompt);
-        }
-
-        self.precmd_state = PrecmdState::AfterPrecmd;
-        self.event_proxy
-            .send_terminal_event(Event::BlockMetadataReceived(BlockMetadataReceivedEvent {
-                block_metadata: self.metadata(),
-                block_index: self.block_index,
-                is_after_in_band_command,
-                is_done_bootstrapping: matches!(
-                    self.bootstrap_stage,
-                    BootstrapStage::PostBootstrapPrecmd
-                ),
-            }));
+        self.apply_precmd(data);
     }
 
     fn preexec(&mut self, data: PreexecValue) {
-        record_trace_event!("command_execution:block:prexec");
-
-        // This condition is a hack to fix a bug with shells that don't support bracketed paste,
-        // e.g. legacy Bash versions, 4.4 or earlier.
-        // https://lists.gnu.org/archive/html/info-gnu/2016-09/msg00012.html
-        // The bug happens when multi-line commands are submitted, see CORE-1698. Without bracketed
-        // paste, we get multiple blocks per [`crate::terminal::input::Event::ExecuteCommand`]. We
-        // generally assume the code path on ExecuteCommand is responsible for starting the active
-        // block. So, `self.started()` should always be true by this point. However, this assumption
-        // is violated if we get multiple blocks per ExecuteCommand event. So, as a fallback, we
-        // start the block here if it hasn't happened already. Note: the displayed command duration
-        // in the "block label" may be under-estimated in this case.
-        if !self.started() && self.state == BlockState::BeforeExecution {
-            self.start();
-        }
-
-        self.header_grid.preexec(data.clone());
-
-        let is_for_in_band_command = command_executor::is_in_band_command(data.command.as_str());
-        if self.bootstrap_stage() == BootstrapStage::PostBootstrapPrecmd {
-            self.event_proxy
-                .send_terminal_event(Event::AfterBlockStarted {
-                    block_id: self.id.clone(),
-                    command: self.command_to_string(),
-                    is_for_in_band_command,
-                });
-        }
-
-        self.leading_linefeeds_ignored = 0;
-        self.output_grid.start();
-        self.state = BlockState::Executing;
-        self.is_for_in_band_command = is_for_in_band_command;
-
-        self.wakeup_after_delay();
+        self.apply_preexec(data);
     }
 
     fn on_finish_byte_processing(&mut self, input: &ansi::ProcessorInput<'_>) {

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -41,9 +41,9 @@ use crate::terminal::event::{AfterBlockCompletedEvent, BlockType, Event as Termi
 use crate::terminal::event_listener::ChannelEventListener;
 use crate::terminal::model::ansi;
 use crate::terminal::model::ansi::{
-    Attr, BootstrappedValue, CharsetIndex, ClearMode, CommandFinishedValue, CursorShape,
-    CursorStyle, LineClearMode, Mode, PrecmdValue, PreexecValue, Processor, PromptMetadata,
-    StandardCharset, TabulationClearMode,
+    Attr, BootstrappedValue, CharsetIndex, ClearMode, CommandFinishedValue, CompletionMetadata,
+    CursorShape, CursorStyle, LineClearMode, Mode, PrecmdValue, PreexecValue, Processor,
+    PromptMetadata, StandardCharset, TabulationClearMode,
 };
 use crate::terminal::model::block::{AgentViewVisibility, Block, SerializedBlock};
 use crate::terminal::model::blockgrid::BlockGrid;
@@ -205,6 +205,12 @@ pub struct CachedPromptData {
     pub rprompt_grid: BlockGrid,
     /// The time at which the block containing these prompts was created.
     pub block_creation_time: DateTime<Local>,
+}
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum NextBlockIdDisposition {
+    Novel,
+    ActiveDuplicate,
+    ExistingCollision,
 }
 
 /// Data about a particular scroll position relative to a block.
@@ -599,16 +605,16 @@ impl BlockList {
     ///
     /// 1. Create the block list.
     /// 2. Add any restored blocks via `restore_block`. Note that this works
-    /// in a different way from the `finalize_block_and_advance_list` function. `restore_block` will take
+    /// in a different way from the `complete_active_block_and_advance` function. `restore_block` will take
     /// the block as the input and consider that one whole block to create,
-    /// feed input into, and finish whereas `finalize_block_and_advance_list` will create the _subsequent_
+    /// feed input into, and finish whereas `complete_active_block_and_advance` will create the _subsequent_
     /// block.
     /// 3. Create the `BootstrapStage::WarpInput` block through
     /// `create_warp_input_block`. From here on, there is always a default
     /// block which is hidden while it is empty.
-    /// 4. We progress through the bootstrap stages with the `finalize_block_and_advance_list` function.
+    /// 4. We progress through the bootstrap stages with the `complete_active_block_and_advance` function.
     /// 5. After we hit `BootstrapStage::PostBootstrapPrecmd`, it's normal
-    /// execution. `finalize_block_and_advance_list` is still the main function to advance the block list.
+    /// execution. `complete_active_block_and_advance` is still the main function to advance the block list.
     /// 6. If `reinit_shell` is called, we are bootstrapping another shell
     /// session. We would revert back to step 3. The invariant of the default
     /// block always being there is unchanged.
@@ -858,6 +864,15 @@ impl BlockList {
 
     pub fn active_block_id(&self) -> &BlockId {
         self.active_block().id()
+    }
+    pub(super) fn classify_next_block_id(&self, next_block_id: &BlockId) -> NextBlockIdDisposition {
+        if self.active_block_id() == next_block_id {
+            NextBlockIdDisposition::ActiveDuplicate
+        } else if self.block_index_for_id(next_block_id).is_some() {
+            NextBlockIdDisposition::ExistingCollision
+        } else {
+            NextBlockIdDisposition::Novel
+        }
     }
 
     fn next_gap_height(&self) -> Option<Lines> {
@@ -2817,25 +2832,26 @@ impl BlockList {
     ///
     /// This should usually not be called directly. Call start_command_execution in [`super::TerminalModel`] instead so relevant terminal events are emitted.
     pub(super) fn start_active_block(&mut self) {
-        // Cache the prompt in preexec. By the time preexec is called, the shell should have
-        // emitted the prompt (either via precmd or in between precmd and preexec).
-        let active_block = self.active_block();
-        let previous_prompt_grid = active_block.prompt_grid().clone();
-        let previous_rprompt_grid = active_block.rprompt_grid().clone();
-        self.cached_prompt_data = Some(CachedPromptData {
-            prompt_grid: previous_prompt_grid,
-            rprompt_grid: previous_rprompt_grid,
-            block_creation_time: *active_block.creation_ts(),
-        });
+        self.cache_active_prompt_data();
 
         self.active_block_mut().start();
         self.early_output.reset_user_input();
     }
+    /// Prepares an active block whose command start was not observed.
+    pub(super) fn ensure_active_block_started(&mut self) {
+        self.active_block_mut().ensure_started_for_preexec();
+    }
 
     /// Increments `self.in_flight_in_band_command_count` and starts the active block as usual.
     pub fn start_active_block_for_in_band_command(&mut self) {
-        // Cache the prompt in preexec. By the time preexec is called, the shell should have
-        // emitted the prompt (either via precmd or in between precmd and preexec).
+        self.cache_active_prompt_data();
+
+        self.in_flight_in_band_command_count += 1;
+        self.active_block_mut().start_for_in_band_command();
+    }
+    fn cache_active_prompt_data(&mut self) {
+        // Cache the prompt before command execution. By the time preexec is called, the shell
+        // should have emitted the prompt either via precmd or between precmd and preexec.
         let active_block = self.active_block();
         let previous_prompt_grid = active_block.prompt_grid().clone();
         let previous_rprompt_grid = active_block.rprompt_grid().clone();
@@ -2844,9 +2860,6 @@ impl BlockList {
             rprompt_grid: previous_rprompt_grid,
             block_creation_time: *active_block.creation_ts(),
         });
-
-        self.in_flight_in_band_command_count += 1;
-        self.active_block_mut().start_for_in_band_command();
     }
 
     /// Sets the shell host for the active block.
@@ -3036,14 +3049,22 @@ impl BlockList {
         }
     }
 
-    /// This is the main function that marks the end of a block, and the beginning of a new block.
+    /// Marks the end of the active block and creates the next block.
     /// 1. Increment stage if we should.
     /// 2. Finish the active block.
     /// 3. Update block heights.
     /// 4. Adjust selection based on changed heights.
     /// 5. Create a new block.
-    fn finalize_block_and_advance_list(&mut self, data: CommandFinishedValue) {
-        record_trace_event!("command_execution:blocks:finalize_block_and_advance_list");
+    pub(super) fn complete_active_block_and_advance(&mut self, data: CompletionMetadata) {
+        record_trace_event!("command_execution:blocks:complete_active_block_and_advance");
+        let next_block_id_disposition = self.classify_next_block_id(&data.next_block_id);
+        log::trace!(
+            "Completing active block with next ID disposition {next_block_id_disposition:?}"
+        );
+        if self.active_block().is_for_in_band_command {
+            self.in_flight_in_band_command_count =
+                self.in_flight_in_band_command_count.saturating_sub(1);
+        }
         let next_bootstrap_stage = if !self.bootstrap_stage.is_done() {
             self.bootstrap_stage.next_stage()
         } else {
@@ -3054,13 +3075,12 @@ impl BlockList {
             self.finish_background_block();
         }
 
-        self.active_block_mut()
-            .finish(data.completion_metadata.exit_code);
+        self.active_block_mut().finish(data.exit_code);
         self.update_active_block_height();
 
         self.update_selection_after_height_change();
         self.create_new_block(
-            data.completion_metadata.next_block_id,
+            data.next_block_id,
             next_bootstrap_stage,
             None, /* prompt_metadata */
             None, /* restored_block_was_local */
@@ -3077,6 +3097,69 @@ impl BlockList {
             );
             self.bootstrap_stage = next_bootstrap_stage;
         }
+        self.latest_block_finished_time = Some(instant::SystemTime::now());
+    }
+
+    /// Applies normal prompt metadata to the active block and finalizes the previous block's
+    /// deferred completion work.
+    pub(super) fn apply_precmd_to_active(&mut self, data: PromptMetadata) {
+        let latest_block_finished_time = self.latest_block_finished_time.take();
+        // We don't need to log this delay during the bootstrapping process, since these
+        // are not blocks that the user has created. The delay here also can be very high
+        // and skews the metrics.
+        let block_finished_to_precmd_delay = if self.bootstrap_stage.is_done() {
+            latest_block_finished_time.and_then(|instant| instant.elapsed().ok())
+        } else {
+            None
+        };
+
+        // Since typeahead is only generated by user input, we don't start collecting
+        // it (or separating it from background output) until the session is fully bootstrapped.
+        if self.is_bootstrapping_precmd_done() {
+            self.early_output.precmd();
+        }
+
+        // If this is the Precmd following an in-band command, the payload is not populated. If the payload
+        // is not populated, use the last populated Precmd payload to initialize the new active block.
+        //
+        // In-band commands are guaranteed not to modify the context for which information is sent
+        // in the Precmd payload, so it's not necessary to recompute the precmd payload after an
+        // in-band command runs. Thus we send an unpopulated precmd payload for in-band commands to
+        // make their execution as fast as possible.
+        if data.was_sent_after_in_band_command() {
+            let mut prompt_metadata = self.last_populated_precmd_payload.clone().unwrap_or(data);
+            prompt_metadata.is_after_in_band_command = true;
+            self.active_block_mut().apply_precmd(prompt_metadata);
+        } else {
+            self.active_block_mut().apply_precmd(data.clone());
+            self.last_populated_precmd_payload = Some(data);
+        }
+
+        // Depending on whether or not there's a background block active, the previous
+        // completed block is at blocks.len - 2 or blocks.len - 3.
+        let previous_block = [2usize, 3usize]
+            .into_iter()
+            .flat_map(|offset| self.blocks.len().checked_sub(offset))
+            .map(|idx| &self.blocks[idx])
+            .find(|block| !block.is_background());
+        if let Some(previous_block) = previous_block {
+            self.send_after_block_completed_event(previous_block, block_finished_to_precmd_delay);
+        } else {
+            self.event_proxy
+                .send_terminal_event(TerminalEvent::BootstrapPrecmdDone);
+        }
+    }
+
+    pub(super) fn apply_preexec_to_active(&mut self, data: PreexecValue) {
+        // We don't start handling early output until the session is fully bootstrapped,
+        // because the distinction between typeahead and background output only
+        // matters for user input.
+        if self.is_bootstrapping_precmd_done() {
+            EarlyOutput::preexec(self);
+        }
+        self.ensure_active_block_started();
+
+        self.active_block_mut().apply_preexec(data);
     }
 
     /// Sends the `AfterBlockCompleted` event to the view.
@@ -3736,12 +3819,7 @@ impl ansi::Handler for BlockList {
     /// possible. Anything that could be costly should be handled in
     /// precmd / `AfterBlockCompleted` instead.
     fn command_finished(&mut self, data: CommandFinishedValue) {
-        if self.active_block().is_for_in_band_command {
-            self.in_flight_in_band_command_count =
-                self.in_flight_in_band_command_count.saturating_sub(1);
-        }
-        self.finalize_block_and_advance_list(data);
-        self.latest_block_finished_time = Some(instant::SystemTime::now());
+        self.complete_active_block_and_advance(data.completion_metadata);
     }
 
     fn set_current_working_directory(&mut self, path: String) {
@@ -3753,66 +3831,15 @@ impl ansi::Handler for BlockList {
     /// the view. This is where we want to perform any costly
     /// operations relevant to the _previous_ block.
     fn precmd_with_completion_metadata(&mut self, data: PrecmdValue) {
-        self.prompt_only_precmd(data.prompt_metadata);
+        self.apply_precmd_to_active(data.prompt_metadata);
     }
 
     fn prompt_only_precmd(&mut self, data: PromptMetadata) {
-        let latest_block_finished_time = self.latest_block_finished_time.take();
-        // We don't need to log this delay during the bootstrapping process, since these
-        // are not blocks that the user has created. The delay here also can be very high
-        // and skews the metrics.
-        let block_finished_to_precmd_delay = if self.bootstrap_stage.is_done() {
-            latest_block_finished_time.and_then(|instant| instant.elapsed().ok())
-        } else {
-            None
-        };
-
-        // Since typeahead is only generated by user input, we don't start collecting
-        // it (or separating it from background output) until the session is fully bootstrapped.
-        if self.is_bootstrapping_precmd_done() {
-            self.early_output.precmd();
-        }
-
-        // If this is the Precmd following an in-band command, the payload is not populated. If the payload
-        // is not populated, use the last populated Precmd payload to initialize the new active block.
-        //
-        // In-band commands are guaranteed not to modify the context for which information is sent
-        // in the Precmd payload, so it's not necessary to recompute the precmd payload after an
-        // in-band command runs. Thus we send an unpopulated precmd payload for in-band commands to
-        // make their execution as fast as possible.
-        if data.was_sent_after_in_band_command() {
-            let mut prompt_metadata = self.last_populated_precmd_payload.clone().unwrap_or(data);
-            prompt_metadata.is_after_in_band_command = true;
-            delegate_to_block!(self.prompt_only_precmd(prompt_metadata));
-        } else {
-            delegate_to_block!(self.prompt_only_precmd(data.clone()));
-            self.last_populated_precmd_payload = Some(data);
-        }
-
-        // Depending on whether or not there's a background block active, the previous
-        // completed block is at blocks.len - 2 or blocks.len - 3.
-        let previous_block = [2usize, 3usize]
-            .into_iter()
-            .flat_map(|offset| self.blocks.len().checked_sub(offset))
-            .map(|idx| &self.blocks[idx])
-            .find(|block| !block.is_background());
-        if let Some(previous_block) = previous_block {
-            self.send_after_block_completed_event(previous_block, block_finished_to_precmd_delay);
-        } else {
-            self.event_proxy
-                .send_terminal_event(TerminalEvent::BootstrapPrecmdDone);
-        }
+        self.apply_precmd_to_active(data);
     }
 
     fn preexec(&mut self, data: PreexecValue) {
-        // We don't start handling early output until the session is fully bootstrapped,
-        // because the distinction between typeahead and background output only
-        // matters for user input.
-        if self.is_bootstrapping_precmd_done() {
-            EarlyOutput::preexec(self);
-        }
-
-        delegate_to_block!(self.preexec(data));
+        self.apply_preexec_to_active(data);
     }
 
     fn bootstrapped(&mut self, _data: BootstrappedValue) {

--- a/app/src/terminal/model/blocks_tests.rs
+++ b/app/src/terminal/model/blocks_tests.rs
@@ -132,6 +132,37 @@ pub fn command_finished_and_precmd(block_list: &mut BlockList) {
         prompt_metadata: PromptMetadata::default(),
     });
 }
+
+#[test]
+fn classifies_next_block_ids_relative_to_the_active_block() {
+    let mut block_list =
+        new_bootstrapped_block_list(None, None, ChannelEventListener::new_for_test());
+    let previous_active_id = block_list.active_block_id().clone();
+    let next_block_id = BlockId::new();
+
+    assert_eq!(
+        block_list.classify_next_block_id(&previous_active_id),
+        NextBlockIdDisposition::ActiveDuplicate
+    );
+    assert_eq!(
+        block_list.classify_next_block_id(&next_block_id),
+        NextBlockIdDisposition::Novel
+    );
+
+    block_list.complete_active_block_and_advance(ansi::CompletionMetadata {
+        exit_code: 0.into(),
+        next_block_id: next_block_id.clone(),
+    });
+
+    assert_eq!(
+        block_list.classify_next_block_id(&previous_active_id),
+        NextBlockIdDisposition::ExistingCollision
+    );
+    assert_eq!(
+        block_list.classify_next_block_id(&next_block_id),
+        NextBlockIdDisposition::ActiveDuplicate
+    );
+}
 fn drain_terminal_events(events_rx: &async_channel::Receiver<Event>) -> Vec<Event> {
     let mut events = Vec::new();
     while let Ok(event) = events_rx.try_recv() {

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -57,9 +57,9 @@ use crate::terminal::event_listener::ChannelEventListener;
 pub use crate::terminal::history::HistoryEntry;
 use crate::terminal::model::ansi;
 use crate::terminal::model::ansi::{
-    ClearValue, CommandFinishedValue, ExitShellValue, Handler, InitShellValue, InitSubshellValue,
-    PreInteractiveSSHSessionValue, PrecmdValue, PreexecValue, PromptMetadata, SSHValue,
-    SourcedRcFileForWarpValue,
+    ClearValue, CommandFinishedValue, CompletionMetadata, ExitShellValue, Handler, InitShellValue,
+    InitSubshellValue, PreInteractiveSSHSessionValue, PrecmdValue, PreexecValue, PromptMetadata,
+    SSHValue, SourcedRcFileForWarpValue,
 };
 use crate::terminal::model::bootstrap::BootstrapStage;
 use crate::terminal::model::completions::{
@@ -2158,6 +2158,73 @@ impl TerminalModel {
     fn emit_handler_event(&mut self, event: HandlerEvent) {
         self.event_proxy.send_handler_event(event);
     }
+    /// Applies the normal command-completion pipeline and its once-per-command side effects.
+    fn complete_command(&mut self, data: CompletionMetadata) {
+        // If we ssh from a doesn't-understand-bracketed-paste shell into one
+        // that enables it, then get disconnected, we'll be stuck in a state
+        // of bracketed paste being enabled, but the local shell doesn't know
+        // how to turn it off (and will never do so).  We forcibly unset the
+        // mode to avoid getting stuck in this state.
+        self.unset_mode(Mode::BracketedPaste);
+
+        // Similar to bracketed paste, above, make sure we quit out of the
+        // alt screen if we're currently in it.  This prevents issues where we
+        // remain in the alt screen after disconnect when we should return to
+        // the blocklist (for the local shell).
+        self.exit_alt_screen(true);
+
+        let block_id = data.next_block_id.to_string();
+        let is_for_in_band_command = self.block_list().active_block().is_in_band_command_block();
+        let finished_block_bootstrap_stage = self.block_list().active_block().bootstrap_stage();
+        self.block_list.complete_active_block_and_advance(data);
+
+        if let Some(tx) = &self.ordered_terminal_events_for_shared_session_tx {
+            if let Err(e) = tx.try_send(OrderedTerminalEventType::CommandExecutionFinished {
+                next_block_id: block_id.into(),
+            }) {
+                log::warn!("Failed to send OrderedTerminalEventType::CommandFinished: {e}");
+            }
+        }
+
+        self.emit_handler_event(HandlerEvent::CommandFinished {
+            command_type: if is_for_in_band_command {
+                CommandType::InBandCommand
+            } else if finished_block_bootstrap_stage == BootstrapStage::PostBootstrapPrecmd {
+                CommandType::User
+            } else {
+                CommandType::Bootstrap
+            },
+        });
+    }
+
+    /// Applies prompt metadata through the normal once-per-block path.
+    fn apply_precmd_to_fresh_block(&mut self, data: PromptMetadata) {
+        self.ignore_bootstrapping_messages = false;
+        let session_id = data.session_id;
+        let mut env_vars = HashMap::new();
+        if let Some(kube_config) = data.kube_config.clone() {
+            env_vars.insert("KUBECONFIG".to_string(), kube_config);
+        }
+        let handled_after_inband = data.was_sent_after_in_band_command();
+        // Preserve the existing alternate-screen no-op until lifecycle acceptance is centralized.
+        if !self.alt_screen_active {
+            self.block_list.apply_precmd_to_active(data);
+        }
+
+        self.emit_handler_event(HandlerEvent::Precmd {
+            session_id: session_id.map(|id| id.into()),
+            handled_after_inband,
+            env_vars,
+        });
+    }
+
+    fn apply_preexec(&mut self, data: PreexecValue) {
+        // Preserve the existing alternate-screen no-op until lifecycle acceptance is centralized.
+        if !self.alt_screen_active {
+            self.block_list.apply_preexec_to_active(data);
+        }
+        self.emit_handler_event(HandlerEvent::Preexec);
+    }
 
     pub fn set_env_var_collection_name(&mut self, value: Option<String>) {
         self.env_var_collection_name = value;
@@ -2699,41 +2766,7 @@ impl ansi::Handler for TerminalModel {
     }
 
     fn command_finished(&mut self, data: CommandFinishedValue) {
-        // If we ssh from a doesn't-understand-bracketed-paste shell into one
-        // that enables it, then get disconnected, we'll be stuck in a state
-        // of bracketed paste being enabled, but the local shell doesn't know
-        // how to turn it off (and will never do so).  We forcibly unset the
-        // mode to avoid getting stuck in this state.
-        self.unset_mode(Mode::BracketedPaste);
-
-        // Similar to bracketed paste, above, make sure we quit out of the
-        // alt screen if we're currently in it.  This prevents issues where we
-        // remain in the alt screen after disconnect when we should return to
-        // the blocklist (for the local shell).
-        self.exit_alt_screen(true);
-
-        let block_id = data.completion_metadata.next_block_id.to_string();
-        let is_for_in_band_command = self.block_list().active_block().is_in_band_command_block();
-        let finished_block_bootstrap_stage = self.block_list().active_block().bootstrap_stage();
-        delegate!(self.command_finished(data));
-
-        if let Some(tx) = &self.ordered_terminal_events_for_shared_session_tx {
-            if let Err(e) = tx.try_send(OrderedTerminalEventType::CommandExecutionFinished {
-                next_block_id: block_id.into(),
-            }) {
-                log::warn!("Failed to send OrderedTerminalEventType::CommandFinished: {e}");
-            }
-        }
-
-        self.emit_handler_event(HandlerEvent::CommandFinished {
-            command_type: if is_for_in_band_command {
-                CommandType::InBandCommand
-            } else if finished_block_bootstrap_stage == BootstrapStage::PostBootstrapPrecmd {
-                CommandType::User
-            } else {
-                CommandType::Bootstrap
-            },
-        });
+        self.complete_command(data.completion_metadata);
     }
 
     fn set_current_working_directory(&mut self, path: String) {
@@ -2756,29 +2789,15 @@ impl ansi::Handler for TerminalModel {
     }
 
     fn precmd_with_completion_metadata(&mut self, data: PrecmdValue) {
-        self.prompt_only_precmd(data.prompt_metadata);
+        self.apply_precmd_to_fresh_block(data.prompt_metadata);
     }
 
     fn prompt_only_precmd(&mut self, data: PromptMetadata) {
-        self.ignore_bootstrapping_messages = false;
-        let session_id = data.session_id;
-        let mut env_vars = HashMap::new();
-        if let Some(kube_config) = data.kube_config.clone() {
-            env_vars.insert("KUBECONFIG".to_string(), kube_config);
-        }
-        let handled_after_inband = data.was_sent_after_in_band_command();
-        delegate!(self.prompt_only_precmd(data));
-
-        self.emit_handler_event(HandlerEvent::Precmd {
-            session_id: session_id.map(|id| id.into()),
-            handled_after_inband,
-            env_vars,
-        });
+        self.apply_precmd_to_fresh_block(data);
     }
 
     fn preexec(&mut self, data: PreexecValue) {
-        delegate!(self.preexec(data));
-        self.emit_handler_event(HandlerEvent::Preexec);
+        self.apply_preexec(data);
     }
 
     fn bootstrapped(&mut self, value: BootstrappedValue) {

--- a/app/src/terminal/model/terminal_model_tests.rs
+++ b/app/src/terminal/model/terminal_model_tests.rs
@@ -869,6 +869,45 @@ fn test_exit_alt_screen_on_command_finished() {
 }
 
 #[test]
+fn precmd_and_preexec_remain_noops_while_the_alt_screen_is_active() {
+    let mut terminal = TerminalModel::mock(None, None);
+    let active_block_id = terminal.active_block_id().clone();
+    let active_block_state = terminal.block_list().active_block().state();
+    let active_block_started = terminal.block_list().active_block().started();
+    terminal.enter_alt_screen(true);
+
+    terminal.precmd(PrecmdValue {
+        completion_metadata: CompletionMetadata::default(),
+        prompt_metadata: PromptMetadata {
+            pwd: Some("/unexpected".to_owned()),
+            ..Default::default()
+        },
+    });
+    terminal.preexec(PreexecValue {
+        command: "unexpected".to_owned(),
+        session_id: None,
+    });
+
+    assert_eq!(terminal.active_block_id(), &active_block_id);
+    assert_eq!(
+        terminal.block_list().active_block().state(),
+        active_block_state
+    );
+    assert_eq!(
+        terminal.block_list().active_block().started(),
+        active_block_started
+    );
+    assert_ne!(
+        terminal
+            .block_list()
+            .active_block()
+            .pwd()
+            .map(String::as_str),
+        Some("/unexpected")
+    );
+}
+
+#[test]
 fn test_unset_bracketed_paste_mode_on_command_finished() {
     let mut terminal: TerminalModel = TerminalModel::mock(None, None);
 
@@ -885,6 +924,114 @@ fn test_unset_bracketed_paste_mode_on_command_finished() {
     assert!(!terminal.is_term_mode_set(TermMode::BRACKETED_PASTE));
 }
 
+#[test]
+fn normal_lifecycle_pipeline_emits_completion_and_prompt_side_effects_once() {
+    let (event_tx, event_rx) = async_channel::unbounded();
+    let event_proxy = ChannelEventListener::builder_for_test()
+        .with_terminal_events_tx(event_tx)
+        .build();
+    let mut terminal = TerminalModel::mock(None, Some(event_proxy));
+    while event_rx.try_recv().is_ok() {}
+
+    let (ordered_tx, ordered_rx) = async_channel::unbounded();
+    terminal.set_ordered_terminal_events_for_shared_session_tx(ordered_tx);
+
+    let completed_block_id = terminal.active_block_id().clone();
+    let next_block_id = BlockId::new();
+    let completion_metadata = CompletionMetadata {
+        exit_code: ExitCode::from(7),
+        next_block_id: next_block_id.clone(),
+    };
+    terminal.start_command_execution();
+    terminal.preexec(PreexecValue {
+        command: "false".to_owned(),
+        session_id: None,
+    });
+    terminal.command_finished(CommandFinishedValue {
+        completion_metadata: completion_metadata.clone(),
+        session_id: None,
+    });
+    terminal.precmd(PrecmdValue {
+        completion_metadata,
+        prompt_metadata: PromptMetadata {
+            pwd: Some("/normal-lifecycle".to_owned()),
+            ..Default::default()
+        },
+    });
+
+    let completed_block = terminal
+        .block_list()
+        .block_with_id(&completed_block_id)
+        .expect("The completed block should remain in the block list.");
+    assert_eq!(completed_block.state(), BlockState::DoneWithExecution);
+    assert_eq!(completed_block.exit_code(), ExitCode::from(7));
+    assert_eq!(terminal.active_block_id(), &next_block_id);
+    assert_eq!(
+        terminal
+            .block_list()
+            .active_block()
+            .pwd()
+            .map(String::as_str),
+        Some("/normal-lifecycle")
+    );
+
+    let events: Vec<_> = std::iter::from_fn(|| event_rx.try_recv().ok()).collect();
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event, Event::BlockCompleted(_)))
+            .count(),
+        1
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event, Event::AfterBlockCompleted(_)))
+            .count(),
+        1
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event, Event::BlockMetadataReceived(_)))
+            .count(),
+        1
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event, Event::Handler(HandlerEvent::Preexec)))
+            .count(),
+        1
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    Event::Handler(HandlerEvent::CommandFinished {
+                        command_type: CommandType::User
+                    })
+                )
+            })
+            .count(),
+        1
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event, Event::Handler(HandlerEvent::Precmd { .. })))
+            .count(),
+        1
+    );
+
+    assert!(matches!(
+        ordered_rx.try_recv(),
+        Ok(OrderedTerminalEventType::CommandExecutionFinished { .. })
+    ));
+    assert!(ordered_rx.try_recv().is_err());
+}
 #[test]
 fn test_alt_screen_selection_tracks_scroll() {
     let mut terminal: TerminalModel = TerminalModel::mock(None, None);

--- a/app/src/terminal/model/terminal_model_tests.rs
+++ b/app/src/terminal/model/terminal_model_tests.rs
@@ -151,6 +151,7 @@ fn hex_encoded_json_dcs(payload: &str) -> Vec<u8> {
     bytes.push(0x9c);
     bytes
 }
+
 fn command_finished_and_precmd(terminal: &mut TerminalModel) {
     let completion_metadata = CompletionMetadata::default();
     terminal.command_finished(CommandFinishedValue {
@@ -876,7 +877,7 @@ fn precmd_and_preexec_remain_noops_while_the_alt_screen_is_active() {
     let active_block_started = terminal.block_list().active_block().started();
     terminal.enter_alt_screen(true);
 
-    terminal.precmd(PrecmdValue {
+    terminal.precmd_with_completion_metadata(PrecmdValue {
         completion_metadata: CompletionMetadata::default(),
         prompt_metadata: PromptMetadata {
             pwd: Some("/unexpected".to_owned()),
@@ -951,7 +952,7 @@ fn normal_lifecycle_pipeline_emits_completion_and_prompt_side_effects_once() {
         completion_metadata: completion_metadata.clone(),
         session_id: None,
     });
-    terminal.precmd(PrecmdValue {
+    terminal.precmd_with_completion_metadata(PrecmdValue {
         completion_metadata,
         prompt_metadata: PromptMetadata {
             pwd: Some("/normal-lifecycle".to_owned()),


### PR DESCRIPTION
## Description

Stack PR 4/7; depends on #12854.

### Context

Normal command completion is not a single block mutation. It also cleans up terminal-wide state, finalizes background and in-band bookkeeping, advances the block list, emits ordered shared-session state, and notifies downstream handlers. Prompt and pre-execution hooks have similarly coupled side effects spread across `TerminalModel`, `BlockList`, and `Block`.

Adding recovery directly to those existing paths would require duplicating that behavior for every exceptional sequence. That would make it easy for recovered commands to miss cleanup, emit events in a different order, or complete the same block twice.

### Approach

This PR is a behavior-preserving refactor that establishes one normal lifecycle mutation pipeline before any coordinator or recovery policy is added. `BlockList` and `Block` gain focused primitives for classifying next-block IDs, ensuring a block is started, completing and advancing the active block, applying a prompt, and applying pre-execution evidence. `TerminalModel` becomes the single place that composes those primitives with model-wide completion, prompt, and handler side effects.

Normal `CommandFinished`, `Precmd`, and `Preexec` hooks are routed through the new helpers, but exceptional sequences are not recovered yet. Keeping this slice policy-free makes normal-flow parity independently reviewable before later PRs reuse the same pipeline for recovery.

### Review guidance

- Does the centralized path preserve the previous ordering and exactly-once behavior of cleanup, block events, ordered shared-session events, and handler notifications?
- Are the new block-level helpers mutation primitives rather than places that independently decide lifecycle policy?
- Does this PR avoid changing how exceptional or out-of-order hooks behave?

## Testing

- Added normal lifecycle parity coverage for completion and prompt side effects, bootstrap, user, in-band, background-finalization, alternate-screen, and shared ordered-completion paths.
- Final-stack validation: `cargo check -p warp --tests`, `./script/format`, and `git diff --check`.
