### PR TITLE
Safely reconcile repeated and prompt-only Precmd hooks

### DIFF
--- a/app/src/terminal/event.rs
+++ b/app/src/terminal/event.rs
@@ -44,12 +44,12 @@ pub enum Event {
     },
     /// Sent when a new block is created.
     BlockMetadataReceived(BlockMetadataReceivedEvent),
-    /// Sent when a block's working directory has been updated outside of the
-    /// normal precmd path (e.g. via an OSC 7 escape sequence). Subscribers
-    /// that only care about CWD changes should listen for this in addition to
-    /// `BlockMetadataReceived`; subscribers tied to precmd semantics (such as
-    /// the requested-command finish detector) should keep listening only to
-    /// `BlockMetadataReceived` so they preserve their once-per-block contract.
+    /// Sent when a block's working directory changes independently of the
+    /// once-per-block precmd metadata event, such as via an OSC 7 escape
+    /// sequence or a repeated-prompt refresh. Subscribers that only care about
+    /// CWD changes should listen for this in addition to `BlockMetadataReceived`;
+    /// subscribers tied to once-per-block precmd semantics should keep listening
+    /// only to `BlockMetadataReceived`.
     BlockWorkingDirectoryUpdated(BlockWorkingDirectoryUpdatedEvent),
     /// Sent after a background block is started and added to the block list.
     BackgroundBlockStarted,
@@ -274,17 +274,17 @@ pub struct BlockMetadataReceivedEvent {
 }
 
 #[derive(Clone, Debug)]
-/// A notification that an existing block's working directory has been updated
-/// out-of-band (e.g. by an OSC 7 escape sequence) without a fresh precmd. The
-/// payload mirrors `BlockMetadataReceivedEvent` so CWD-dependent listeners can
-/// reuse the same handling, but listeners that rely on precmd semantics should
-/// keep using `BlockMetadataReceivedEvent`.
+/// A notification that an existing block's working directory has changed
+/// independently of the once-per-block precmd metadata event. The payload
+/// mirrors `BlockMetadataReceivedEvent` so CWD-dependent listeners can reuse
+/// the same handling, but listeners that rely on once-per-block precmd
+/// semantics should keep using `BlockMetadataReceivedEvent`.
 ///
 /// Note: `is_for_in_band_command` here describes the block carrying the update,
 /// while the similarly-spelled `is_after_in_band_command` on
 /// `BlockMetadataReceivedEvent` describes the *previous* block. The semantics
-/// differ because precmd fires after a block runs, while OSC 7 fires while the
-/// block is alive.
+/// differ because the initial precmd fires after a block runs, while this event
+/// describes a change on the still-active block.
 pub struct BlockWorkingDirectoryUpdatedEvent {
     pub block_metadata: BlockMetadata,
     pub block_index: BlockIndex,

--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -2965,6 +2965,58 @@ impl Block {
             }));
     }
 
+    pub(super) fn refresh_prompt(&mut self, data: PromptMetadata) -> bool {
+        record_trace_event!("command_execution:block:refresh_prompt");
+        if !self.header_grid.refresh_prompt(data.clone()) {
+            return false;
+        }
+        self.rprompt_grid.reset_for_prompt_refresh();
+        self.git_branch.clone_from(&data.git_head);
+        self.git_branch_name.clone_from(&data.git_branch);
+        self.virtual_env = data.virtual_env;
+        self.conda_env = data.conda_env;
+        self.node_version = data.node_version;
+        self.session_id = data.session_id.map(Into::into);
+        self.rprompt.clone_from(&data.rprompt);
+
+        if let Some(rprompt) = data.rprompt {
+            self.init_rprompt_grid(&rprompt);
+        }
+
+        self.update_current_working_directory(data.pwd);
+        true
+    }
+
+    fn update_current_working_directory(&mut self, pwd: Option<String>) {
+        if self.pwd == pwd {
+            return;
+        }
+        self.pwd = pwd;
+        // Use a dedicated event variant rather than `BlockMetadataReceived`
+        // because the latter is implicitly contracted to fire once per block
+        // (at precmd) and a number of subscribers rely on that — see e.g.
+        // the requested-command finish detector in
+        // `ai/blocklist/action_model/execute/shell_command.rs`. Subscribers
+        // that genuinely care about CWD changes opt in by also listening to
+        // `BlockWorkingDirectoryUpdated`.
+        self.event_proxy
+            .send_terminal_event(Event::BlockWorkingDirectoryUpdated(
+                BlockWorkingDirectoryUpdatedEvent {
+                    block_metadata: self.metadata(),
+                    block_index: self.block_index,
+                    // Preserve the block's in-band status so listeners can keep
+                    // applying the same in-band guard they apply to precmd-driven
+                    // metadata updates (e.g. skipping repo-detection / chip
+                    // refreshes for in-band command blocks).
+                    is_for_in_band_command: self.is_for_in_band_command,
+                    is_done_bootstrapping: matches!(
+                        self.bootstrap_stage,
+                        BootstrapStage::PostBootstrapPrecmd
+                    ),
+                },
+            ));
+    }
+
     pub(super) fn apply_preexec(&mut self, data: PreexecValue) {
         record_trace_event!("command_execution:block:prexec");
 
@@ -3372,33 +3424,7 @@ impl ansi::Handler for Block {
     }
 
     fn set_current_working_directory(&mut self, path: String) {
-        if self.pwd.as_deref() == Some(path.as_str()) {
-            return;
-        }
-        self.pwd = Some(path);
-        // Use a dedicated event variant rather than `BlockMetadataReceived`
-        // because the latter is implicitly contracted to fire once per block
-        // (at precmd) and a number of subscribers rely on that — see e.g.
-        // the requested-command finish detector in
-        // `ai/blocklist/action_model/execute/shell_command.rs`. Subscribers
-        // that genuinely care about CWD changes opt in by also listening to
-        // `BlockWorkingDirectoryUpdated`.
-        self.event_proxy
-            .send_terminal_event(Event::BlockWorkingDirectoryUpdated(
-                BlockWorkingDirectoryUpdatedEvent {
-                    block_metadata: self.metadata(),
-                    block_index: self.block_index,
-                    // Preserve the block's in-band status so listeners can keep
-                    // applying the same in-band guard they apply to precmd-driven
-                    // metadata updates (e.g. skipping repo-detection / chip
-                    // refreshes for in-band command blocks).
-                    is_for_in_band_command: self.is_for_in_band_command,
-                    is_done_bootstrapping: matches!(
-                        self.bootstrap_stage,
-                        BootstrapStage::PostBootstrapPrecmd
-                    ),
-                },
-            ));
+        self.update_current_working_directory(Some(path));
     }
 
     fn precmd_with_completion_metadata(&mut self, data: PrecmdValue) {

--- a/app/src/terminal/model/block_tests.rs
+++ b/app/src/terminal/model/block_tests.rs
@@ -11,7 +11,7 @@ use super::*;
 use crate::ai::blocklist::agent_view::AgentViewState;
 use crate::terminal::model::ansi::{Attr, Handler};
 use crate::terminal::model::cell::Flags;
-use crate::terminal::model::header_grid::PromptEndPoint;
+use crate::terminal::model::header_grid::{CommandStartPoint, PromptEndPoint};
 use crate::terminal::model::session::SessionInfo;
 use crate::terminal::model::test_utils::{
     create_test_block_with_grids, test_iterm_image, TestBlockBuilder,
@@ -40,6 +40,293 @@ impl float_cmp::ApproxEq for BlockSection {
             (a, b) => std::mem::discriminant(&a) == std::mem::discriminant(&b),
         }
     }
+}
+
+#[test]
+fn refresh_prompt_replaces_prompt_context_and_rprompt_while_preserving_command_and_cursor() {
+    let (event_tx, event_rx) = async_channel::unbounded();
+    let event_proxy = ChannelEventListener::builder_for_test()
+        .with_terminal_events_tx(event_tx)
+        .build();
+    let mut block = TestBlockBuilder::new()
+        .with_honor_ps1(true)
+        .with_size_info(SizeInfo::new_without_font_metrics(4, 40))
+        .with_event_proxy(event_proxy)
+        .build();
+    block.apply_precmd(PromptMetadata {
+        pwd: Some("/old".to_owned()),
+        ps1: Some(hex::encode("old> ")),
+        honor_ps1: Some(true),
+        rprompt: Some(hex::encode("OLD RIGHT")),
+        git_head: Some("old-head".to_owned()),
+        git_branch: Some("old-branch".to_owned()),
+        virtual_env: Some("/old/venv".to_owned()),
+        conda_env: Some("old-conda".to_owned()),
+        node_version: Some("old-node".to_owned()),
+        session_id: Some(1),
+        ..Default::default()
+    });
+    while event_rx.try_recv().is_ok() {}
+
+    for c in "abcdef".chars() {
+        block.input(c);
+    }
+    block.move_backward(2);
+    let old_cursor = block.grid_handler().cursor_point();
+    assert_eq!(old_cursor, Point::new(0, 9));
+
+    assert!(block.refresh_prompt(PromptMetadata {
+        pwd: Some("/new".to_owned()),
+        ps1: Some(hex::encode("new-long> ")),
+        honor_ps1: Some(true),
+        rprompt: Some(hex::encode("NEW RIGHT")),
+        git_head: Some("new-head".to_owned()),
+        git_branch: Some("new-branch".to_owned()),
+        virtual_env: Some("/new/venv".to_owned()),
+        conda_env: Some("new-conda".to_owned()),
+        node_version: Some("new-node".to_owned()),
+        session_id: Some(2),
+        ..Default::default()
+    }));
+
+    assert_eq!(
+        block.header_grid.prompt_contents_to_string(false),
+        "new-long> "
+    );
+    assert_eq!(block.command_to_string(), "abcdef");
+    assert_eq!(
+        block.rprompt_grid().contents_to_string(false, None),
+        "NEW RIGHT"
+    );
+    assert_eq!(block.grid_handler().cursor_point(), Point::new(0, 14));
+    assert_eq!(block.pwd().map(String::as_str), Some("/new"));
+    assert_eq!(block.git_branch().map(String::as_str), Some("new-head"));
+    assert_eq!(
+        block.git_branch_name().map(String::as_str),
+        Some("new-branch")
+    );
+    assert_eq!(block.virtual_env_short_name().as_deref(), Some("venv"));
+    assert_eq!(block.conda_env().map(String::as_str), Some("new-conda"));
+    assert_eq!(block.node_version().map(String::as_str), Some("new-node"));
+    assert_eq!(block.session_id(), Some(2.into()));
+    assert_eq!(block.state(), BlockState::BeforeExecution);
+    assert!(block.has_received_precmd());
+
+    let events: Vec<_> = std::iter::from_fn(|| event_rx.try_recv().ok()).collect();
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event, Event::BlockWorkingDirectoryUpdated(_)))
+            .count(),
+        1
+    );
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event, Event::BlockMetadataReceived(_))));
+
+    assert!(block.refresh_prompt(PromptMetadata::default()));
+    assert_eq!(block.pwd(), None);
+    let events: Vec<_> = std::iter::from_fn(|| event_rx.try_recv().ok()).collect();
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event, Event::BlockWorkingDirectoryUpdated(_)))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn refresh_prompt_preserves_reflowed_wide_and_hard_wrapped_command_cells() {
+    let mut wrapped_block = TestBlockBuilder::new()
+        .with_honor_ps1(true)
+        .with_size_info(SizeInfo::new_without_font_metrics(4, 6))
+        .build();
+    wrapped_block.apply_precmd(PromptMetadata {
+        ps1: Some(hex::encode(">>")),
+        honor_ps1: Some(true),
+        ..Default::default()
+    });
+    for c in "ab界cd  ".chars() {
+        wrapped_block.input(c);
+    }
+    wrapped_block.move_backward(2);
+    assert_eq!(
+        wrapped_block.grid_handler().cursor_point(),
+        Point::new(1, 2)
+    );
+
+    assert!(wrapped_block.refresh_prompt(PromptMetadata {
+        ps1: Some(hex::encode(">>>>")),
+        honor_ps1: Some(true),
+        ..Default::default()
+    }));
+    assert_eq!(wrapped_block.command_to_string(), "ab界cd  ");
+    assert_eq!(
+        wrapped_block.grid_handler().cursor_point(),
+        Point::new(1, 4)
+    );
+
+    let mut hard_wrapped_block = TestBlockBuilder::new()
+        .with_honor_ps1(true)
+        .with_size_info(SizeInfo::new_without_font_metrics(4, 10))
+        .build();
+    hard_wrapped_block.apply_precmd(PromptMetadata {
+        ps1: Some(hex::encode(">")),
+        honor_ps1: Some(true),
+        ..Default::default()
+    });
+    for c in "ab".chars() {
+        hard_wrapped_block.input(c);
+    }
+    hard_wrapped_block.newline();
+    for c in "cd".chars() {
+        hard_wrapped_block.input(c);
+    }
+
+    assert!(hard_wrapped_block.refresh_prompt(PromptMetadata {
+        ps1: Some(hex::encode("long>")),
+        honor_ps1: Some(true),
+        ..Default::default()
+    }));
+    assert_eq!(hard_wrapped_block.command_to_string(), "ab\n   cd");
+    assert_eq!(
+        hard_wrapped_block.grid_handler().cursor_point(),
+        Point::new(1, 5)
+    );
+}
+
+#[test]
+fn refresh_prompt_does_not_copy_an_exact_width_prompt_cell_into_the_command() {
+    let mut block = TestBlockBuilder::new()
+        .with_honor_ps1(true)
+        .with_size_info(SizeInfo::new_without_font_metrics(4, 6))
+        .build();
+    block.apply_precmd(PromptMetadata {
+        ps1: Some(hex::encode("123456")),
+        honor_ps1: Some(true),
+        ..Default::default()
+    });
+    for c in "ab".chars() {
+        block.input(c);
+    }
+
+    assert!(block.refresh_prompt(PromptMetadata {
+        ps1: Some(hex::encode(">")),
+        honor_ps1: Some(true),
+        ..Default::default()
+    }));
+    assert_eq!(block.command_to_string(), "ab");
+    assert_eq!(block.grid_handler().cursor_point(), Point::new(0, 3));
+    let mut wrapped_cursor_block = TestBlockBuilder::new()
+        .with_honor_ps1(true)
+        .with_size_info(SizeInfo::new_without_font_metrics(4, 6))
+        .build();
+    wrapped_cursor_block.apply_precmd(PromptMetadata {
+        ps1: Some(hex::encode(">")),
+        honor_ps1: Some(true),
+        ..Default::default()
+    });
+    for c in "abcde".chars() {
+        wrapped_cursor_block.input(c);
+    }
+    assert!(wrapped_cursor_block.refresh_prompt(PromptMetadata {
+        ps1: Some(hex::encode(">>")),
+        honor_ps1: Some(true),
+        ..Default::default()
+    }));
+    assert_eq!(wrapped_cursor_block.command_to_string(), "abcde");
+    assert_eq!(
+        wrapped_cursor_block.grid_handler().cursor_point(),
+        Point::new(1, 1)
+    );
+
+    let mut marked_block = TestBlockBuilder::new()
+        .with_honor_ps1(true)
+        .with_size_info(SizeInfo::new_without_font_metrics(4, 6))
+        .build();
+    marked_block.prompt_marker(ansi::PromptMarker::StartPrompt {
+        kind: ansi::PromptKind::Initial,
+    });
+    for c in "123456".chars() {
+        marked_block.input(c);
+    }
+    marked_block.prompt_marker(ansi::PromptMarker::EndPrompt);
+    for c in "ab".chars() {
+        marked_block.input(c);
+    }
+
+    assert!(marked_block.refresh_prompt(PromptMetadata {
+        ps1: Some(hex::encode(">")),
+        honor_ps1: Some(true),
+        ..Default::default()
+    }));
+    assert_eq!(marked_block.command_to_string(), "ab");
+    assert_eq!(marked_block.grid_handler().cursor_point(), Point::new(0, 3));
+
+    let mut earlier_row_cursor_block = TestBlockBuilder::new()
+        .with_honor_ps1(true)
+        .with_size_info(SizeInfo::new_without_font_metrics(4, 10))
+        .build();
+    earlier_row_cursor_block.apply_precmd(PromptMetadata {
+        ps1: Some(hex::encode(">")),
+        honor_ps1: Some(true),
+        ..Default::default()
+    });
+    for c in "ab".chars() {
+        earlier_row_cursor_block.input(c);
+    }
+    earlier_row_cursor_block.newline();
+    for c in "cd".chars() {
+        earlier_row_cursor_block.input(c);
+    }
+    earlier_row_cursor_block.goto(VisibleRow(0), 3);
+
+    assert!(earlier_row_cursor_block.refresh_prompt(PromptMetadata {
+        ps1: Some(hex::encode("long>")),
+        honor_ps1: Some(true),
+        ..Default::default()
+    }));
+    assert_eq!(earlier_row_cursor_block.command_to_string(), "ab\n   cd");
+    assert_eq!(
+        earlier_row_cursor_block.grid_handler().cursor_point(),
+        Point::new(0, 7)
+    );
+}
+
+#[test]
+fn refresh_prompt_with_a_stale_command_boundary_does_not_replace_context() {
+    let (event_tx, event_rx) = async_channel::unbounded();
+    let event_proxy = ChannelEventListener::builder_for_test()
+        .with_terminal_events_tx(event_tx)
+        .build();
+    let mut block = TestBlockBuilder::new()
+        .with_honor_ps1(true)
+        .with_event_proxy(event_proxy)
+        .build();
+    block.apply_precmd(PromptMetadata {
+        pwd: Some("/old".to_owned()),
+        ps1: Some(hex::encode("old> ")),
+        honor_ps1: Some(true),
+        git_head: Some("old-head".to_owned()),
+        ..Default::default()
+    });
+    block
+        .header_grid
+        .set_raw_command_start_point(Some(CommandStartPoint::Stale));
+    while event_rx.try_recv().is_ok() {}
+
+    assert!(!block.refresh_prompt(PromptMetadata {
+        pwd: Some("/new".to_owned()),
+        ps1: Some(hex::encode("new> ")),
+        honor_ps1: Some(true),
+        git_head: Some("new-head".to_owned()),
+        ..Default::default()
+    }));
+    assert_eq!(block.pwd().map(String::as_str), Some("/old"));
+    assert_eq!(block.git_branch().map(String::as_str), Some("old-head"));
+    assert!(!std::iter::from_fn(|| event_rx.try_recv().ok())
+        .any(|event| matches!(event, Event::BlockWorkingDirectoryUpdated(_))));
 }
 
 #[test]

--- a/app/src/terminal/model/blockgrid.rs
+++ b/app/src/terminal/model/blockgrid.rs
@@ -376,6 +376,16 @@ impl BlockGrid {
         self.started = true;
         self.start_time = Some(Instant::now());
     }
+    pub(super) fn reset_for_prompt_refresh(&mut self) {
+        ansi::Handler::reset_state(self);
+        self.started = false;
+        self.finished = false;
+        self.start_time = None;
+        self.cached_rightmost_visible_nonempty_cell = Default::default();
+        self.cached_has_visible_chars = Default::default();
+        self.cached_starts_with_input_buffer_sequence = Default::default();
+        self.trim_trailing_blank_rows = false;
+    }
 
     pub(in crate::terminal) fn grid_storage(&self) -> &GridStorage {
         self.grid_handler.grid_storage()

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -3127,6 +3127,19 @@ impl BlockList {
         }
     }
 
+    pub(super) fn refresh_active_prompt(&mut self, data: PromptMetadata) -> bool {
+        if data.was_sent_after_in_band_command() {
+            let mut prompt_metadata = self.last_populated_precmd_payload.clone().unwrap_or(data);
+            prompt_metadata.is_after_in_band_command = true;
+            return self.active_block_mut().refresh_prompt(prompt_metadata);
+        }
+        let refreshed = self.active_block_mut().refresh_prompt(data.clone());
+        if refreshed {
+            self.last_populated_precmd_payload = Some(data);
+        }
+        refreshed
+    }
+
     pub(super) fn apply_preexec_to_active(&mut self, data: PreexecValue) {
         // We don't start handling early output until the session is fully bootstrapped,
         // because the distinction between typeahead and background output only

--- a/app/src/terminal/model/grid/grid_handler.rs
+++ b/app/src/terminal/model/grid/grid_handler.rs
@@ -2416,6 +2416,109 @@ impl GridHandler {
         }
     }
 
+    /// Appends cells at and after `start` from another grid while reflowing soft-wrapped rows.
+    ///
+    /// Returns the destination cursor point and wrap state corresponding to `source_cursor`.
+    pub(in crate::terminal::model) fn append_cells_from_grid_starting_at(
+        &mut self,
+        other: &GridHandler,
+        start: Point,
+        source_cursor: Point,
+        source_cursor_needs_wrap: bool,
+    ) -> (Point, bool) {
+        let max_point = other.grid.max_cursor_point.convert_to_absolute(other);
+        let max_row = max(
+            max(
+                max_point.row,
+                other.bottommost_nonempty_row().unwrap_or(start.row),
+            ),
+            source_cursor.row,
+        );
+        let mut mapped_cursor = None;
+
+        for row_idx in start.row..=max_row {
+            let row = other.row(row_idx).expect("row should exist");
+            let start_col = if row_idx == start.row { start.col } else { 0 };
+            let mut end_col = if row_idx < max_row && other.row_wraps(row_idx) {
+                other.columns()
+            } else {
+                row.line_length()
+            };
+            if row_idx == max_point.row {
+                end_col = max(end_col, max_point.col);
+            }
+            if row_idx == source_cursor.row {
+                end_col = max(end_col, source_cursor.col);
+            }
+            end_col = min(end_col, other.columns());
+
+            for col in start_col..end_col {
+                if self.grid.cursor().input_needs_wrap {
+                    self.wrapline();
+                }
+
+                let source_point = Point::new(row_idx, col);
+                if source_point == source_cursor && !source_cursor_needs_wrap {
+                    mapped_cursor =
+                        Some((self.cursor_point(), self.grid.cursor().input_needs_wrap));
+                }
+
+                let destination = self.grid.cursor_point();
+                let mut cloned_cell = row[col].clone();
+                cloned_cell.flags_mut().insert(Flags::BOLD);
+                self.grid[destination.row][destination.col] = cloned_cell;
+
+                if self.grid.cursor_point().col >= self.columns() - 1 {
+                    self.update_cursor(|cursor| {
+                        cursor.input_needs_wrap = true;
+                    });
+                } else {
+                    self.update_cursor(|cursor| {
+                        cursor.point.col += 1;
+                    });
+                    self.grid.update_max_cursor();
+                }
+
+                if source_point == source_cursor && source_cursor_needs_wrap {
+                    mapped_cursor =
+                        Some((self.cursor_point(), self.grid.cursor().input_needs_wrap));
+                }
+            }
+
+            if mapped_cursor.is_none()
+                && row_idx == source_cursor.row
+                && source_cursor.col == end_col
+            {
+                mapped_cursor = Some((self.cursor_point(), self.grid.cursor().input_needs_wrap));
+            }
+
+            if !other.row_wraps(row_idx) && row_idx < max_row {
+                self.linefeed();
+                self.carriage_return();
+            }
+        }
+
+        mapped_cursor.unwrap_or_else(|| (self.cursor_point(), self.grid.cursor().input_needs_wrap))
+    }
+
+    pub(in crate::terminal::model) fn restore_cursor_after_grid_copy(
+        &mut self,
+        source_cursor: &Cursor,
+        destination_point: Point,
+        destination_input_needs_wrap: bool,
+    ) {
+        let visible_row = destination_point
+            .row
+            .saturating_sub(self.history_size())
+            .min(self.visible_rows().saturating_sub(1));
+        let destination_col = destination_point.col.min(self.columns().saturating_sub(1));
+        self.update_cursor(|cursor| {
+            *cursor = source_cursor.clone();
+            cursor.point.row = VisibleRow(visible_row);
+            cursor.point.col = destination_col;
+            cursor.input_needs_wrap = destination_input_needs_wrap;
+        });
+    }
     /// Marks a location in the grid as being the end of a shell prompt (and
     /// the start of the user's command).
     pub(in crate::terminal::model) fn mark_end_of_prompt(

--- a/app/src/terminal/model/header_grid.rs
+++ b/app/src/terminal/model/header_grid.rs
@@ -220,6 +220,11 @@ impl HeaderGrid {
         self.cached_prompt_end_point = point;
     }
 
+    #[cfg(test)]
+    pub(super) fn set_raw_command_start_point(&mut self, point: Option<CommandStartPoint>) {
+        self.cached_command_start_point = point;
+    }
+
     fn command_to_string_internal(
         &self,
         include_esc_sequences: bool,
@@ -558,6 +563,74 @@ impl HeaderGrid {
 
     pub fn command_to_string_with_max_rows(&self, max_rows: Option<usize>) -> String {
         self.command_to_string_internal(false, max_rows, RespectObfuscatedSecrets::Yes, false)
+    }
+    fn command_start_point_for_prompt_refresh(&self) -> Option<Point> {
+        match self.command_start_point() {
+            Some(CommandStartPoint::CommandStart { point }) => {
+                let prompt_ends_at_command_start = matches!(
+                    self.prompt_end_point(),
+                    Some(PromptEndPoint::PromptEnd {
+                        point: prompt_end_point,
+                        ..
+                    }) if prompt_end_point == point
+                );
+                Some(if prompt_ends_at_command_start {
+                    point.wrapping_add(self.prompt_and_command_grid.grid_handler().columns(), 1)
+                } else {
+                    point
+                })
+            }
+            Some(CommandStartPoint::Stale) => None,
+            None if self.honor_ps1 => {
+                let point = self.prompt_grid.grid_handler().cursor_point();
+                Some(
+                    if self.prompt_grid.grid_storage().cursor().input_needs_wrap {
+                        point.wrapping_add(self.prompt_grid.grid_handler().columns(), 1)
+                    } else {
+                        point
+                    },
+                )
+            }
+            None => Some(Point::new(0, 0)),
+        }
+    }
+
+    pub(super) fn refresh_prompt(&mut self, data: PromptMetadata) -> bool {
+        let Some(command_start_point) = self.command_start_point_for_prompt_refresh() else {
+            log::warn!("Skipped prompt-grid refresh because the command boundary was stale.");
+            return false;
+        };
+        let old_prompt_and_command_grid = self.prompt_and_command_grid.clone();
+        let source_cursor = old_prompt_and_command_grid.grid_storage().cursor().clone();
+        let source_cursor_point = old_prompt_and_command_grid.grid_handler().cursor_point();
+
+        self.prompt_grid.reset_for_prompt_refresh();
+        self.prompt_and_command_grid.reset_for_prompt_refresh();
+        self.receiving_chars_for_prompt = None;
+        self.ignore_next_prompt_preview = false;
+        self.cached_prompt_end_point = None;
+        self.cached_command_start_point = None;
+
+        self.legacy_precmd(data);
+        self.prompt_and_command_grid.start();
+        self.mark_and_cache_end_of_prompt();
+        let (destination_cursor_point, destination_input_needs_wrap) = self
+            .prompt_and_command_grid
+            .grid_handler_mut()
+            .append_cells_from_grid_starting_at(
+                old_prompt_and_command_grid.grid_handler(),
+                command_start_point,
+                source_cursor_point,
+                source_cursor.input_needs_wrap,
+            );
+        self.prompt_and_command_grid
+            .grid_handler_mut()
+            .restore_cursor_after_grid_copy(
+                &source_cursor,
+                destination_cursor_point,
+                destination_input_needs_wrap,
+            );
+        true
     }
 
     pub fn prompt_start_blockgrid_point(&self) -> BlockGridPoint {

--- a/app/src/terminal/model/header_grid.rs
+++ b/app/src/terminal/model/header_grid.rs
@@ -611,7 +611,7 @@ impl HeaderGrid {
         self.cached_prompt_end_point = None;
         self.cached_command_start_point = None;
 
-        self.legacy_precmd(data);
+        self.prompt_only_precmd(data);
         self.prompt_and_command_grid.start();
         self.mark_and_cache_end_of_prompt();
         let (destination_cursor_point, destination_input_needs_wrap) = self

--- a/app/src/terminal/model/lifecycle/mod.rs
+++ b/app/src/terminal/model/lifecycle/mod.rs
@@ -15,6 +15,7 @@ pub(in crate::terminal) use transition::{
     CommandStartKind, IgnoreReason, LifecycleAction, LifecycleInput, LifecyclePhase,
     LifecycleSnapshot, LifecycleTransition, NextBlockIdDisposition, PreexecObservation,
 };
+use warp_core::features::FeatureFlag;
 
 /// Describes whether a command-start intent was accepted or conservatively ignored.
 ///
@@ -73,8 +74,18 @@ impl BlockLifecycleCoordinator {
         input: LifecycleInput,
     ) -> LifecycleTransition {
         let previous_phase = transition::reconcile_phase(self.phase, snapshot);
-        let (next_phase, action) = transition::plan(previous_phase, input, snapshot);
+        let (next_phase, planned_action) = transition::plan(previous_phase, input, snapshot);
+        let action = if matches!(
+            planned_action,
+            LifecycleAction::RefreshPrecmd | LifecycleAction::ReconcileCompletionThenApplyPrecmd
+        ) && !FeatureFlag::TerminalLifecycleRecovery.is_enabled()
+        {
+            LifecycleAction::Ignore(IgnoreReason::RecoveryDisabled)
+        } else {
+            planned_action
+        };
         let should_record = action.is_ignored()
+            || matches!(action, LifecycleAction::RefreshPrecmd)
             || matches!(
                 (previous_phase, input),
                 (

--- a/app/src/terminal/model/lifecycle/mod_test.rs
+++ b/app/src/terminal/model/lifecycle/mod_test.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 
 use instant::Instant;
+use warp_core::features::FeatureFlag;
 use warp_core::telemetry::TelemetryEvent;
 
 use super::telemetry::{
@@ -152,7 +153,7 @@ fn transition_matrix_preserves_normal_flow_and_rejects_unsafe_completion() {
             AtPrompt,
             PrecmdWithCompletionMetadata(ActiveDuplicate),
             AtPrompt,
-            Ignore(IgnoreReason::RepeatedPrecmd),
+            RefreshPrecmd,
         ),
         (
             Submitted,
@@ -179,12 +180,7 @@ fn transition_matrix_preserves_normal_flow_and_rejects_unsafe_completion() {
             Ignore(IgnoreReason::IgnoredTerminated),
         ),
         (AwaitingPrecmd, PromptOnlyPrecmd, AtPrompt, ApplyPrecmd),
-        (
-            AtPrompt,
-            PromptOnlyPrecmd,
-            AtPrompt,
-            Ignore(IgnoreReason::RepeatedPrecmd),
-        ),
+        (AtPrompt, PromptOnlyPrecmd, AtPrompt, RefreshPrecmd),
         (
             Submitted,
             PromptOnlyPrecmd,
@@ -413,6 +409,7 @@ fn lifecycle_phase_reconciliation_requires_compatible_live_evidence() {
 fn lifecycle_coordinator_records_only_conservative_or_recovery_transitions() {
     use LifecycleAction::*;
     use LifecycleInput::*;
+    let _recovery_enabled = FeatureFlag::TerminalLifecycleRecovery.override_enabled(true);
 
     let before_execution = LifecycleSnapshot {
         active_block_id: "active".to_owned(),
@@ -470,7 +467,41 @@ fn lifecycle_coordinator_records_only_conservative_or_recovery_transitions() {
         &at_prompt,
         PrecmdWithCompletionMetadata(NextBlockIdDisposition::ActiveDuplicate),
     );
-    assert_eq!(transition.action, Ignore(IgnoreReason::RepeatedPrecmd));
+    assert_eq!(transition.action, RefreshPrecmd);
+    assert!(transition.recovery_record.is_some());
+}
+
+#[test]
+fn lifecycle_coordinator_gates_prompt_refresh_recovery() {
+    let _recovery_disabled = FeatureFlag::TerminalLifecycleRecovery.override_enabled(false);
+    let snapshot = LifecycleSnapshot {
+        active_block_id: "active".to_owned(),
+        active_session_id: Some(1),
+        supplied_next_block_id: Some("active".to_owned()),
+        hook_session_id: Some(1),
+        block_state: BlockState::BeforeExecution,
+        started: false,
+        finished: false,
+        received_precmd: true,
+        is_in_band: false,
+        is_bootstrapped: true,
+        is_bootstrap_done: true,
+        is_alt_screen_active: false,
+    };
+    let mut coordinator = super::BlockLifecycleCoordinator {
+        phase: LifecyclePhase::AtPrompt,
+        ..Default::default()
+    };
+
+    let transition = coordinator.plan(
+        &snapshot,
+        LifecycleInput::CorrelatedPrecmd(NextBlockIdDisposition::ActiveDuplicate),
+    );
+    assert_eq!(
+        transition.action,
+        LifecycleAction::Ignore(IgnoreReason::RecoveryDisabled)
+    );
+    assert_eq!(transition.next_phase, LifecyclePhase::AtPrompt);
     assert!(transition.recovery_record.is_some());
 }
 

--- a/app/src/terminal/model/lifecycle/mod_test.rs
+++ b/app/src/terminal/model/lifecycle/mod_test.rs
@@ -495,7 +495,7 @@ fn lifecycle_coordinator_gates_prompt_refresh_recovery() {
 
     let transition = coordinator.plan(
         &snapshot,
-        LifecycleInput::CorrelatedPrecmd(NextBlockIdDisposition::ActiveDuplicate),
+        LifecycleInput::PrecmdWithCompletionMetadata(NextBlockIdDisposition::ActiveDuplicate),
     );
     assert_eq!(
         transition.action,

--- a/app/src/terminal/model/lifecycle/transition.rs
+++ b/app/src/terminal/model/lifecycle/transition.rs
@@ -138,7 +138,6 @@ pub(in crate::terminal) enum IgnoreReason {
     CollidingCompletion,
     RepeatedPreexec,
     RepeatedPreexecDifferentCommand,
-    RepeatedPrecmd,
     UnsupportedPromptOnlyPrecmd,
     RecoveryDisabled,
 }
@@ -280,7 +279,7 @@ pub(super) fn plan(
         },
         PrecmdWithCompletionMetadata(ActiveDuplicate) => match previous_phase {
             AwaitingPrecmd => (AtPrompt, ApplyPrecmd),
-            AtPrompt => (AtPrompt, Ignore(RepeatedPrecmd)),
+            AtPrompt => (AtPrompt, RefreshPrecmd),
             Submitted | Executing | Unknown => (previous_phase, Ignore(RecoveryDisabled)),
             Terminated => (Terminated, Ignore(IgnoredTerminated)),
         },
@@ -288,7 +287,7 @@ pub(super) fn plan(
         // cannot prove completion or advance the block list by itself.
         PromptOnlyPrecmd => match previous_phase {
             AwaitingPrecmd => (AtPrompt, ApplyPrecmd),
-            AtPrompt => (AtPrompt, Ignore(RepeatedPrecmd)),
+            AtPrompt => (AtPrompt, RefreshPrecmd),
             Submitted | Executing | Unknown => {
                 (previous_phase, Ignore(UnsupportedPromptOnlyPrecmd))
             }

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -2308,6 +2308,26 @@ impl TerminalModel {
             session_id: session_id.map(|id| id.into()),
             handled_after_inband,
             env_vars,
+            disposition: PrecmdDisposition::AppliedToFreshBlock,
+        });
+    }
+
+    fn refresh_current_prompt(&mut self, data: PromptMetadata) {
+        let session_id = data.session_id;
+        let mut env_vars = HashMap::new();
+        if let Some(kube_config) = data.kube_config.clone() {
+            env_vars.insert("KUBECONFIG".to_string(), kube_config);
+        }
+        let handled_after_inband = data.was_sent_after_in_band_command();
+        if !self.block_list.refresh_active_prompt(data) {
+            return;
+        }
+
+        self.emit_handler_event(HandlerEvent::Precmd {
+            session_id: session_id.map(Into::into),
+            handled_after_inband,
+            env_vars,
+            disposition: PrecmdDisposition::RefreshedActivePrompt,
         });
     }
 
@@ -2460,6 +2480,11 @@ pub enum CommandType {
     User,
     Bootstrap,
 }
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PrecmdDisposition {
+    AppliedToFreshBlock,
+    RefreshedActivePrompt,
+}
 
 #[derive(Clone, Debug)]
 pub enum HandlerEvent {
@@ -2471,6 +2496,7 @@ pub enum HandlerEvent {
         session_id: Option<SessionId>,
         handled_after_inband: bool,
         env_vars: HashMap<String, String>,
+        disposition: PrecmdDisposition,
     },
     Preexec,
     CommandFinished {
@@ -2898,8 +2924,16 @@ impl ansi::Handler for TerminalModel {
             Some(&data.completion_metadata.next_block_id),
             data.prompt_metadata.session_id,
         );
-        if matches!(transition.action, LifecycleAction::ApplyPrecmd) {
-            self.apply_precmd_to_fresh_block(data.prompt_metadata);
+        match transition.action {
+            LifecycleAction::ApplyPrecmd => self.apply_precmd_to_fresh_block(data.prompt_metadata),
+            LifecycleAction::RefreshPrecmd => self.refresh_current_prompt(data.prompt_metadata),
+            LifecycleAction::StartActiveBlock
+            | LifecycleAction::ApplyPreexec
+            | LifecycleAction::AcceptCommandFinished
+            | LifecycleAction::ReconcileCompletionThenApplyPrecmd
+            | LifecycleAction::BeginEpoch
+            | LifecycleAction::Terminate
+            | LifecycleAction::Ignore(_) => {}
         }
         self.commit_lifecycle_transition(&transition);
     }
@@ -2907,8 +2941,16 @@ impl ansi::Handler for TerminalModel {
     fn prompt_only_precmd(&mut self, data: PromptMetadata) {
         let transition =
             self.plan_lifecycle_transition(LifecycleInput::PromptOnlyPrecmd, None, data.session_id);
-        if matches!(transition.action, LifecycleAction::ApplyPrecmd) {
-            self.apply_precmd_to_fresh_block(data);
+        match transition.action {
+            LifecycleAction::ApplyPrecmd => self.apply_precmd_to_fresh_block(data),
+            LifecycleAction::RefreshPrecmd => self.refresh_current_prompt(data),
+            LifecycleAction::StartActiveBlock
+            | LifecycleAction::ApplyPreexec
+            | LifecycleAction::AcceptCommandFinished
+            | LifecycleAction::ReconcileCompletionThenApplyPrecmd
+            | LifecycleAction::BeginEpoch
+            | LifecycleAction::Terminate
+            | LifecycleAction::Ignore(_) => {}
         }
         self.commit_lifecycle_transition(&transition);
     }

--- a/app/src/terminal/model/terminal_model_tests.rs
+++ b/app/src/terminal/model/terminal_model_tests.rs
@@ -765,7 +765,7 @@ fn set_custom_title() {
         .with_terminal_events_tx(event_tx)
         .build();
     let mut terminal = TerminalModel::mock(None, Some(event_proxy));
-    terminal.legacy_precmd(PromptMetadata::default());
+    terminal.prompt_only_precmd(PromptMetadata::default());
 
     // Empty all the events that could've been sent to this channel prior to us changing the
     // title for tests.
@@ -1061,14 +1061,15 @@ fn normal_lifecycle_pipeline_emits_completion_and_prompt_side_effects_once() {
 }
 
 #[test]
-fn repeated_correlated_and_legacy_precmd_refresh_only_the_active_prompt() {
+fn repeated_precmd_with_completion_metadata_and_prompt_only_precmd_refresh_only_the_active_prompt()
+{
     let _recovery_enabled = FeatureFlag::TerminalLifecycleRecovery.override_enabled(true);
     let (event_tx, event_rx) = async_channel::unbounded();
     let event_proxy = ChannelEventListener::builder_for_test()
         .with_terminal_events_tx(event_tx)
         .build();
     let mut terminal = TerminalModel::mock(None, Some(event_proxy));
-    terminal.legacy_precmd(PromptMetadata::default());
+    terminal.prompt_only_precmd(PromptMetadata::default());
     while event_rx.try_recv().is_ok() {}
 
     for c in "typed".chars() {
@@ -1081,13 +1082,13 @@ fn repeated_correlated_and_legacy_precmd_refresh_only_the_active_prompt() {
     let active_block_id = terminal.active_block_id().clone();
     let active_block_count = terminal.block_list().blocks().len();
 
-    terminal.precmd(PrecmdValue {
+    terminal.precmd_with_completion_metadata(PrecmdValue {
         completion_metadata: CompletionMetadata {
             exit_code: ExitCode::from(7),
             next_block_id: active_block_id.clone(),
         },
         prompt_metadata: PromptMetadata {
-            pwd: Some("/correlated".to_owned()),
+            pwd: Some("/with-completion-metadata".to_owned()),
             session_id: Some(123),
             ..Default::default()
         },
@@ -1113,7 +1114,7 @@ fn repeated_correlated_and_legacy_precmd_refresh_only_the_active_prompt() {
             .active_block()
             .pwd()
             .map(String::as_str),
-        Some("/correlated")
+        Some("/with-completion-metadata")
     );
 
     let events: Vec<_> = std::iter::from_fn(|| event_rx.try_recv().ok()).collect();
@@ -1152,8 +1153,8 @@ fn repeated_correlated_and_legacy_precmd_refresh_only_the_active_prompt() {
         )
     }));
 
-    terminal.legacy_precmd(PromptMetadata {
-        pwd: Some("/legacy".to_owned()),
+    terminal.prompt_only_precmd(PromptMetadata {
+        pwd: Some("/prompt-only".to_owned()),
         session_id: Some(123),
         ..Default::default()
     });
@@ -1169,11 +1170,11 @@ fn repeated_correlated_and_legacy_precmd_refresh_only_the_active_prompt() {
             .active_block()
             .pwd()
             .map(String::as_str),
-        Some("/legacy")
+        Some("/prompt-only")
     );
 
     terminal.start_command_execution();
-    terminal.legacy_precmd(PromptMetadata {
+    terminal.prompt_only_precmd(PromptMetadata {
         pwd: Some("/ignored-submitted".to_owned()),
         session_id: Some(123),
         ..Default::default()
@@ -1184,13 +1185,13 @@ fn repeated_correlated_and_legacy_precmd_refresh_only_the_active_prompt() {
             .active_block()
             .pwd()
             .map(String::as_str),
-        Some("/legacy")
+        Some("/prompt-only")
     );
     terminal.preexec(PreexecValue {
         command: "typed".to_owned(),
         session_id: Some(123),
     });
-    terminal.legacy_precmd(PromptMetadata {
+    terminal.prompt_only_precmd(PromptMetadata {
         pwd: Some("/ignored-executing".to_owned()),
         session_id: Some(123),
         ..Default::default()
@@ -1201,14 +1202,14 @@ fn repeated_correlated_and_legacy_precmd_refresh_only_the_active_prompt() {
             .active_block()
             .pwd()
             .map(String::as_str),
-        Some("/legacy")
+        Some("/prompt-only")
     );
 
     let mut unknown_terminal = TerminalModel::mock(None, None);
     unknown_terminal.lifecycle_coordinator.reset_unknown();
     let unknown_active_block_id = unknown_terminal.active_block_id().clone();
     let unknown_block_count = unknown_terminal.block_list().blocks().len();
-    unknown_terminal.legacy_precmd(PromptMetadata {
+    unknown_terminal.prompt_only_precmd(PromptMetadata {
         pwd: Some("/ignored-unknown".to_owned()),
         ..Default::default()
     });
@@ -1226,7 +1227,7 @@ fn repeated_precmd_refresh_is_disabled_by_default() {
     let mut terminal = TerminalModel::mock(None, None);
     let active_block_id = terminal.active_block_id().clone();
 
-    terminal.legacy_precmd(PromptMetadata {
+    terminal.prompt_only_precmd(PromptMetadata {
         pwd: Some("/new".to_owned()),
         ..Default::default()
     });

--- a/app/src/terminal/model/terminal_model_tests.rs
+++ b/app/src/terminal/model/terminal_model_tests.rs
@@ -5,6 +5,7 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use chrono::{DateTime, Local};
 use vec1::vec1;
 use warp_core::command::ExitCode;
+use warp_core::features::FeatureFlag;
 use warp_terminal::model::ansi::ClearMode;
 use warpui::r#async::executor::Background;
 use warpui::text::{str_to_byte_vec, SelectionType};
@@ -764,6 +765,7 @@ fn set_custom_title() {
         .with_terminal_events_tx(event_tx)
         .build();
     let mut terminal = TerminalModel::mock(None, Some(event_proxy));
+    terminal.legacy_precmd(PromptMetadata::default());
 
     // Empty all the events that could've been sent to this channel prior to us changing the
     // title for tests.
@@ -1056,6 +1058,188 @@ fn normal_lifecycle_pipeline_emits_completion_and_prompt_side_effects_once() {
         Ok(OrderedTerminalEventType::CommandExecutionFinished { .. })
     ));
     assert!(ordered_rx.try_recv().is_err());
+}
+
+#[test]
+fn repeated_correlated_and_legacy_precmd_refresh_only_the_active_prompt() {
+    let _recovery_enabled = FeatureFlag::TerminalLifecycleRecovery.override_enabled(true);
+    let (event_tx, event_rx) = async_channel::unbounded();
+    let event_proxy = ChannelEventListener::builder_for_test()
+        .with_terminal_events_tx(event_tx)
+        .build();
+    let mut terminal = TerminalModel::mock(None, Some(event_proxy));
+    terminal.legacy_precmd(PromptMetadata::default());
+    while event_rx.try_recv().is_ok() {}
+
+    for c in "typed".chars() {
+        terminal.block_list_mut().active_block_for_test().input(c);
+    }
+    terminal
+        .block_list_mut()
+        .active_block_for_test()
+        .move_backward(2);
+    let active_block_id = terminal.active_block_id().clone();
+    let active_block_count = terminal.block_list().blocks().len();
+
+    terminal.precmd(PrecmdValue {
+        completion_metadata: CompletionMetadata {
+            exit_code: ExitCode::from(7),
+            next_block_id: active_block_id.clone(),
+        },
+        prompt_metadata: PromptMetadata {
+            pwd: Some("/correlated".to_owned()),
+            session_id: Some(123),
+            ..Default::default()
+        },
+    });
+
+    assert_eq!(terminal.active_block_id(), &active_block_id);
+    assert_eq!(terminal.block_list().blocks().len(), active_block_count);
+    assert_eq!(
+        terminal.block_list().active_block().command_to_string(),
+        "typed"
+    );
+    assert_eq!(
+        terminal
+            .block_list()
+            .active_block()
+            .grid_handler()
+            .cursor_point(),
+        Point::new(0, 3)
+    );
+    assert_eq!(
+        terminal
+            .block_list()
+            .active_block()
+            .pwd()
+            .map(String::as_str),
+        Some("/correlated")
+    );
+
+    let events: Vec<_> = std::iter::from_fn(|| event_rx.try_recv().ok()).collect();
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event, Event::BlockWorkingDirectoryUpdated(_)))
+            .count(),
+        1
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    Event::Handler(HandlerEvent::Precmd {
+                        disposition: PrecmdDisposition::RefreshedActivePrompt,
+                        ..
+                    })
+                )
+            })
+            .count(),
+        1
+    );
+    assert!(!events.iter().any(|event| {
+        matches!(
+            event,
+            Event::BlockCompleted(_)
+                | Event::AfterBlockCompleted(_)
+                | Event::BlockMetadataReceived(_)
+                | Event::Handler(HandlerEvent::Precmd {
+                    disposition: PrecmdDisposition::AppliedToFreshBlock,
+                    ..
+                })
+        )
+    }));
+
+    terminal.legacy_precmd(PromptMetadata {
+        pwd: Some("/legacy".to_owned()),
+        session_id: Some(123),
+        ..Default::default()
+    });
+    assert_eq!(terminal.active_block_id(), &active_block_id);
+    assert_eq!(terminal.block_list().blocks().len(), active_block_count);
+    assert_eq!(
+        terminal.block_list().active_block().command_to_string(),
+        "typed"
+    );
+    assert_eq!(
+        terminal
+            .block_list()
+            .active_block()
+            .pwd()
+            .map(String::as_str),
+        Some("/legacy")
+    );
+
+    terminal.start_command_execution();
+    terminal.legacy_precmd(PromptMetadata {
+        pwd: Some("/ignored-submitted".to_owned()),
+        session_id: Some(123),
+        ..Default::default()
+    });
+    assert_eq!(
+        terminal
+            .block_list()
+            .active_block()
+            .pwd()
+            .map(String::as_str),
+        Some("/legacy")
+    );
+    terminal.preexec(PreexecValue {
+        command: "typed".to_owned(),
+        session_id: Some(123),
+    });
+    terminal.legacy_precmd(PromptMetadata {
+        pwd: Some("/ignored-executing".to_owned()),
+        session_id: Some(123),
+        ..Default::default()
+    });
+    assert_eq!(
+        terminal
+            .block_list()
+            .active_block()
+            .pwd()
+            .map(String::as_str),
+        Some("/legacy")
+    );
+
+    let mut unknown_terminal = TerminalModel::mock(None, None);
+    unknown_terminal.lifecycle_coordinator.reset_unknown();
+    let unknown_active_block_id = unknown_terminal.active_block_id().clone();
+    let unknown_block_count = unknown_terminal.block_list().blocks().len();
+    unknown_terminal.legacy_precmd(PromptMetadata {
+        pwd: Some("/ignored-unknown".to_owned()),
+        ..Default::default()
+    });
+    assert_eq!(unknown_terminal.active_block_id(), &unknown_active_block_id);
+    assert_eq!(
+        unknown_terminal.block_list().blocks().len(),
+        unknown_block_count
+    );
+    assert_eq!(unknown_terminal.block_list().active_block().pwd(), None);
+}
+
+#[test]
+fn repeated_precmd_refresh_is_disabled_by_default() {
+    let _recovery_disabled = FeatureFlag::TerminalLifecycleRecovery.override_enabled(false);
+    let mut terminal = TerminalModel::mock(None, None);
+    let active_block_id = terminal.active_block_id().clone();
+
+    terminal.legacy_precmd(PromptMetadata {
+        pwd: Some("/new".to_owned()),
+        ..Default::default()
+    });
+
+    assert_eq!(terminal.active_block_id(), &active_block_id);
+    assert_eq!(
+        terminal
+            .block_list()
+            .active_block()
+            .pwd()
+            .map(String::as_str),
+        None
+    );
 }
 
 #[test]

--- a/app/src/terminal/model_events.rs
+++ b/app/src/terminal/model_events.rs
@@ -480,3 +480,7 @@ pub enum AnsiHandlerEvent {
 impl Entity for ModelEventDispatcher {
     type Event = ModelEvent;
 }
+
+#[cfg(test)]
+#[path = "model_events_tests.rs"]
+mod tests;

--- a/app/src/terminal/model_events.rs
+++ b/app/src/terminal/model_events.rs
@@ -10,7 +10,7 @@ use super::model::block::BlockId;
 use super::model::completions::ShellCompletion;
 use super::model::lifecycle::LifecycleTelemetryEvent;
 use super::model::session::{IsSSHWrapperSession, SessionId, SessionInfo};
-use super::model::terminal_model::{CommandType, ExitReason, HandlerEvent};
+use super::model::terminal_model::{CommandType, ExitReason, HandlerEvent, PrecmdDisposition};
 use crate::features::FeatureFlag;
 use crate::remote_server::manager::RemoteServerManager;
 use crate::server::telemetry::ImageProtocol;
@@ -133,6 +133,7 @@ impl ModelEventDispatcher {
                 session_id,
                 handled_after_inband,
                 env_vars,
+                disposition,
             }) => {
                 // Update the active session to the one that corresponds to the received SessionId.
                 self.active_session_id = session_id;
@@ -151,7 +152,12 @@ impl ModelEventDispatcher {
                     }
                 }
 
-                ModelEvent::Handler(AnsiHandlerEvent::Precmd)
+                match disposition {
+                    PrecmdDisposition::AppliedToFreshBlock => {
+                        ModelEvent::Handler(AnsiHandlerEvent::Precmd)
+                    }
+                    PrecmdDisposition::RefreshedActivePrompt => return,
+                }
             }
             Event::Handler(HandlerEvent::Preexec) => ModelEvent::Handler(AnsiHandlerEvent::Preexec),
             Event::Handler(HandlerEvent::CommandFinished { command_type }) => match command_type {
@@ -357,8 +363,8 @@ pub enum ModelEvent {
     },
     /// Sent when a new block is created.
     BlockMetadataReceived(BlockMetadataReceivedEvent),
-    /// Sent when an existing block's working directory has been updated
-    /// outside of the precmd path (e.g. via an OSC 7 escape sequence).
+    /// Sent when an existing block's working directory changes independently
+    /// of the once-per-block precmd metadata event.
     BlockWorkingDirectoryUpdated(BlockWorkingDirectoryUpdatedEvent),
     /// Sent after a background block is started and added to the block list.
     BackgroundBlockStarted,

--- a/app/src/terminal/model_events_tests.rs
+++ b/app/src/terminal/model_events_tests.rs
@@ -1,0 +1,66 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use warpui::App;
+
+use super::{AnsiHandlerEvent, ModelEvent, ModelEventDispatcher};
+use crate::terminal::event::Event;
+use crate::terminal::model::session::Sessions;
+use crate::terminal::model::terminal_model::{HandlerEvent, PrecmdDisposition};
+
+#[test]
+fn refreshed_precmd_updates_active_session_without_emitting_public_precmd_event() {
+    App::test((), |mut app| async move {
+        let sessions = app.add_model(|_| Sessions::new_for_test());
+        let (_events_tx, events_rx) = async_channel::unbounded();
+        let dispatcher =
+            app.add_model(|ctx| ModelEventDispatcher::new(events_rx, sessions.clone(), ctx));
+
+        let precmd_event_count = Arc::new(AtomicUsize::new(0));
+        let precmd_event_count_for_subscription = precmd_event_count.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_model(&dispatcher, move |_, event, _| {
+                if matches!(event, ModelEvent::Handler(AnsiHandlerEvent::Precmd)) {
+                    precmd_event_count_for_subscription.fetch_add(1, Ordering::Relaxed);
+                }
+            });
+        });
+
+        let fresh_session_id = 123.into();
+        dispatcher.update(&mut app, |dispatcher, ctx| {
+            dispatcher.handle_terminal_model_event(
+                Event::Handler(HandlerEvent::Precmd {
+                    session_id: Some(fresh_session_id),
+                    handled_after_inband: true,
+                    env_vars: HashMap::new(),
+                    disposition: PrecmdDisposition::AppliedToFreshBlock,
+                }),
+                ctx,
+            );
+        });
+        assert_eq!(precmd_event_count.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            dispatcher.read(&app, |dispatcher, _| dispatcher.active_session_id()),
+            Some(fresh_session_id)
+        );
+
+        let refreshed_session_id = 456.into();
+        dispatcher.update(&mut app, |dispatcher, ctx| {
+            dispatcher.handle_terminal_model_event(
+                Event::Handler(HandlerEvent::Precmd {
+                    session_id: Some(refreshed_session_id),
+                    handled_after_inband: true,
+                    env_vars: HashMap::new(),
+                    disposition: PrecmdDisposition::RefreshedActivePrompt,
+                }),
+                ctx,
+            );
+        });
+        assert_eq!(precmd_event_count.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            dispatcher.read(&app, |dispatcher, _| dispatcher.active_session_id()),
+            Some(refreshed_session_id)
+        );
+    });
+}


### PR DESCRIPTION
## Description

Stack PR 6/8; depends on #12856.

### Context

`Precmd` is not always a one-time event. Shells can repaint or resend a prompt, and a newer shared-session viewer can receive prompt-only hooks from an older sharer. Re-running the original prompt path against an already populated active block can overwrite command/input state, move the cursor, mutate a finished prompt grid, or repeat once-per-block events. Ignoring every repeat is safer, but it also discards legitimate newer prompt, session, and environment context.

Prompt-only `Precmd` hooks need a separate policy: they are useful when the model is already safely awaiting or displaying a prompt, but they cannot prove that an executing command completed or identify the next block.

### Approach

This PR adds an explicit safe refresh path. A same-active-ID `Precmd` with completion metadata applies normally when the active block is fresh; if that block already has a prompt, it refreshes the active prompt and context while preserving the current command content, input, and cursor position. A prompt disposition tells downstream dispatch whether this was the first application or a refresh, allowing session/environment state to update without re-emitting public once-per-block prompt events.

Prompt-only evidence is accepted only in the safe prompt phases defined by the coordinator and is ignored elsewhere with diagnostics. It never completes or advances a block. State-mutating repeated-prompt reconciliation remains selected by the recovery gate, while rejection of unsafe prompt-only transitions is unconditional.

### Review guidance

- Can a refresh alter command/input content, cursor position, block lifecycle state, or emit completion/prompt side effects a second time?
- Does refreshed context still reach downstream session/environment tracking without a duplicate public `Precmd` event?
- Is prompt-only evidence restricted to phases where no completion inference is required?

## Testing

- Added repeated and prompt-only `Precmd` coverage for prompt-grid, input, and cursor preservation plus exact once-per-block event counts.
- Added a dispatcher regression proving a refreshed `Precmd` updates the active session without emitting a duplicate public `Precmd` event.
- Final-stack validation: `cargo check -p warp --tests`, `./script/format`, and `git diff --check`.
