### PR TITLE
Enable terminal lifecycle recovery in dogfood

### DIFF
--- a/crates/warp_features/src/features_tests.rs
+++ b/crates/warp_features/src/features_tests.rs
@@ -18,3 +18,10 @@ fn local_child_harnesses_are_local_only_by_default() {
     assert!(!DEBUG_FLAGS.contains(&FeatureFlag::LocalClaudeCodexChildHarnesses));
     assert!(!DOGFOOD_FLAGS.contains(&FeatureFlag::LocalClaudeCodexChildHarnesses));
 }
+
+#[test]
+fn terminal_lifecycle_recovery_is_dogfood_only_by_default() {
+    assert!(DOGFOOD_FLAGS.contains(&FeatureFlag::TerminalLifecycleRecovery));
+    assert!(!PREVIEW_FLAGS.contains(&FeatureFlag::TerminalLifecycleRecovery));
+    assert!(!RELEASE_FLAGS.contains(&FeatureFlag::TerminalLifecycleRecovery));
+}

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -973,6 +973,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::GPTConfigurableContextWindow,
     FeatureFlag::RestorePromptOnInlineModelSelectorSearch,
     FeatureFlag::WarpControlCli,
+    FeatureFlag::TerminalLifecycleRecovery,
     FeatureFlag::PromptCacheExpiryWarning,
     FeatureFlag::BackgroundComputerUse,
     FeatureFlag::ContextWindowUsageBreakdown,


### PR DESCRIPTION
## Description

Stack PR 7/7; depends on #12858.

### Context

The preceding PRs land the coordinator and recovery behavior with `TerminalLifecycleRecovery` disabled by default. That protects production while the new `Precmd` completion metadata fields propagate through stable clients, but it also means the recovery path will not receive real-world exercise or diagnostics unless it is enabled for a narrower population first.

Shared-session version skew is the main reason to separate internal enablement from broad rollout: newer viewers recover most reliably once more sharers have reached a stable version that emits the completion metadata added in #12853.

### Approach and rollout boundary

This PR enables `TerminalLifecycleRecovery` only in `DOGFOOD_FLAGS`. Preview and release defaults remain disabled, so the stack can collect internal telemetry and manual validation without changing behavior for broader channels. Production promotion is intentionally outside this stack and should happen only after the protocol fields have had sufficient stable-release soak time and dogfood diagnostics show the transition policy is behaving as intended.

There are no recovery implementation changes in this PR; it changes only the default audience for the already-gated behavior.

### Review guidance

- Is the flag enabled only for dogfood and explicitly absent from preview and release defaults?
- Does this PR avoid changing recovery logic or broadening the rollout beyond the intended internal soak?
- Are the remaining production-promotion criteria clear and intentionally deferred?

## Testing

- Added a feature-flag regression verifying recovery is dogfood-enabled but absent from preview and release defaults.
- Final-stack validation: focused lifecycle tests, `cargo check -p warp --tests`, `./script/format`, and `git diff --check`.
