### PR TITLE
Don't let unclosed `<u>` markers pair via the emphasis algorithm

### DIFF
--- a/crates/markdown_parser/src/markdown_parser.rs
+++ b/crates/markdown_parser/src/markdown_parser.rs
@@ -1784,6 +1784,14 @@ impl Delimiter {
             return false;
         }
 
+        // `<u>` (UnderlineStart) is only ever resolved by an explicit `</u>` via
+        // `parse_underline`. It must never pair with another `<u>` through the
+        // emphasis algorithm, which would consume both markers and delete the text
+        // around them. An unclosed `<u>` should round-trip to literal text instead.
+        if self.kind == DelimiterKind::UnderlineStart {
+            return false;
+        }
+
         // For strikethrough, the delimiter counts must match.
         if self.kind == DelimiterKind::Strikethrough {
             return self.count == other.count;

--- a/crates/markdown_parser/src/markdown_parser_tests.rs
+++ b/crates/markdown_parser/src/markdown_parser_tests.rs
@@ -1918,6 +1918,31 @@ fn test_parse_empty_underline() {
 }
 
 #[test]
+fn test_unclosed_underline_markers_are_literal() {
+    // Regression: two unclosed `<u>` markers must not pair with each other through the
+    // emphasis algorithm (which would delete the surrounding text). Without a closing
+    // `</u>`, each `<u>` should round-trip to literal text, like an unclosed `*`.
+    assert_eq!(
+        test_parse_markdown("<u><u>"),
+        vec![FormattedTextLine::Line(vec![
+            FormattedTextFragment::plain_text("<u><u>"),
+        ])]
+    );
+    assert_eq!(
+        test_parse_markdown("<u>a<u>"),
+        vec![FormattedTextLine::Line(vec![
+            FormattedTextFragment::plain_text("<u>a<u>"),
+        ])]
+    );
+    assert_eq!(
+        test_parse_markdown("a <u>word<u> b"),
+        vec![FormattedTextLine::Line(vec![
+            FormattedTextFragment::plain_text("a <u>word<u> b"),
+        ])]
+    );
+}
+
+#[test]
 fn test_unordered_list_indentation_level_relative() {
     // Test that both 2-space and 4-space relative indentation produce the same structure
     let source_2space = "- top level\n  - sublevel\n    - subsublevel";


### PR DESCRIPTION
## Description

`parse_markdown` silently **deletes text** when a `<u>` underline marker is left unclosed and another `<u>` appears later in the same line. The two `<u>` markers get matched as an emphasis pair and consumed, taking the surrounding text with them:

| Input | Expected | Before this PR |
|---|---|---|
| `<u><u>` | `<u><u>` | **empty line — all text gone** |
| `<u>a<u>` | `<u>a<u>` | `a` |
| `a <u>word<u> b` | `a <u>word<u> b` | `a word b` |

### Root cause

`<u>` is tokenized as an `UnderlineStart` delimiter and pushed onto the shared delimiter stack with `can_close` set from the right-flanking rules. `process_emphasis` therefore treats two `<u>` markers as a matchable opener/closer pair (`can_open_for` passes since they share `kind`), consuming both and deleting their text nodes. Underline is only ever meant to be closed by an explicit `</u>`, which is handled separately by `parse_underline` and never relies on `can_open_for`.

### Fix

Make `can_open_for` reject `UnderlineStart`, so an unclosed `<u>` round-trips to literal text (like an unclosed `*`). Legitimate `<u>…</u>` is unaffected — it's resolved by `parse_underline`.

```diff
         if !self.can_open || self.kind != other.kind {
             return false;
         }
+
+        // `<u>` (UnderlineStart) is only ever resolved by an explicit `</u>` via
+        // `parse_underline`. It must never pair with another `<u>` through the
+        // emphasis algorithm, which would consume both markers and delete the text
+        // around them. An unclosed `<u>` should round-trip to literal text instead.
+        if self.kind == DelimiterKind::UnderlineStart {
+            return false;
+        }
```

## Linked Issue

Closes #12863

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing

Added regression tests `test_unclosed_underline_markers_are_literal` covering `<u><u>`, `<u>a<u>`, and `a <u>word<u> b`. They fail before this change (text deleted) and pass after. All **139** `markdown_parser` tests pass — including every existing underline test (`<u>…</u>`, mixed, multi-line, empty) — so legitimate underline is unaffected. `cargo fmt --check` and `cargo clippy` are clean.

This is pure parser logic, fully covered by unit tests, so there is no UI behavior to record.

- [x] I have manually tested my changes locally (unit tests in `markdown_parser`).

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed Markdown rendering silently dropping text when an unclosed `<u>` underline marker was followed by another `<u>`.
-->
CHANGELOG-BUG-FIX: Fixed Markdown rendering silently dropping text around unclosed `<u>` underline markers.