### PR TITLE
Respect Markdown Viewer preference for file URLs

### DIFF
--- a/app/src/uri/mod.rs
+++ b/app/src/uri/mod.rs
@@ -39,8 +39,8 @@ use crate::settings_view::{
 use crate::tab_configs::TabConfig;
 use crate::user_config::{load_launch_configs, load_tab_configs, tab_configs_dir};
 use crate::util::openable_file_type::{
-    is_file_openable_in_warp, is_runnable_shell_script, renders_in_warp_notebook_viewer,
-    starts_with_shebang,
+    is_file_openable_in_warp, is_markdown_file, is_runnable_shell_script,
+    renders_in_warp_notebook_viewer, starts_with_shebang,
 };
 use crate::view_components::DismissibleToast;
 use crate::workspace::auto_handoff::trigger_auto_handoff_to_cloud;
@@ -1286,8 +1286,16 @@ enum OpenFileAction {
 
 /// Pure routing decision for `open_file`. Extracted so it can be unit-tested without
 /// standing up a full `AppContext`.
-fn classify_open_file_action(path: &Path) -> OpenFileAction {
-    if renders_in_warp_notebook_viewer(path) {
+///
+/// The Markdown Viewer preference is passed in because macOS can hand Markdown
+/// file URLs to Warp via the file type registration in `Info.plist`. Since Warp
+/// cannot easily update that registration when the user toggles the viewer
+/// preference, the URI handler must check the preference before routing a
+/// Markdown file to the in-Warp notebook viewer. Other notebook viewer formats,
+/// such as Jupyter notebooks, are controlled by their own routing checks.
+fn classify_open_file_action(path: &Path, prefer_markdown_viewer: bool) -> OpenFileAction {
+    if renders_in_warp_notebook_viewer(path) && (!is_markdown_file(path) || prefer_markdown_viewer)
+    {
         OpenFileAction::Notebook
     } else if is_runnable_shell_script(path) {
         OpenFileAction::ExecuteInSession
@@ -1306,7 +1314,8 @@ fn can_open_file_editor_path(path: &Path) -> bool {
 }
 
 /// Handle an incoming `file://` URL.
-/// * Markdown and Jupyter notebook files are opened as notebook panes.
+/// * Markdown files are opened as notebook panes when the viewer preference is enabled.
+/// * Jupyter notebook files are opened as notebook panes when their feature flag is enabled.
 /// * For directories, open a new session at the directory path.
 /// * For other files, open a new session at the parent directory path, then possibly execute the
 ///   file.
@@ -1316,7 +1325,15 @@ fn open_file(window_id: Option<WindowId>, path: PathBuf, ctx: &mut AppContext) {
             .map(|view_id| (window_id, view_id))
     });
 
-    let action = classify_open_file_action(&path);
+    #[cfg(feature = "local_fs")]
+    let prefer_markdown_viewer = {
+        use crate::util::file::external_editor::EditorSettings;
+        *EditorSettings::as_ref(ctx).prefer_markdown_viewer
+    };
+    #[cfg(not(feature = "local_fs"))]
+    let prefer_markdown_viewer = true;
+
+    let action = classify_open_file_action(&path, prefer_markdown_viewer);
 
     if action == OpenFileAction::Notebook {
         if let Some((primary_window_id, root_view_id)) = primary_window_and_view {

--- a/app/src/uri/uri_tests.rs
+++ b/app/src/uri/uri_tests.rs
@@ -786,7 +786,7 @@ fn test_open_file_executable_sh_routes_to_execute() {
     let p = dir.path().join("run.sh");
     std::fs::write(&p, b"#!/bin/sh\n:\n").unwrap();
     std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
-    let action = classify_open_file_action(&p);
+    let action = classify_open_file_action(&p, true);
     assert_eq!(action, OpenFileAction::ExecuteInSession);
 }
 
@@ -798,7 +798,7 @@ fn test_open_file_non_executable_sh_routes_to_editor() {
     let p = dir.path().join("view.sh");
     std::fs::write(&p, b"#!/bin/sh\n:\n").unwrap();
     std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o644)).unwrap();
-    assert_eq!(classify_open_file_action(&p), OpenFileAction::Editor);
+    assert_eq!(classify_open_file_action(&p, true), OpenFileAction::Editor);
 }
 
 #[test]
@@ -811,7 +811,7 @@ fn test_open_file_executable_bash_zsh_fish_route_to_execute() {
         std::fs::write(&p, b"#!/bin/sh\n:\n").unwrap();
         std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
         assert_eq!(
-            classify_open_file_action(&p),
+            classify_open_file_action(&p, true),
             OpenFileAction::ExecuteInSession,
             "{name} should route to ExecuteInSession",
         );
@@ -819,11 +819,22 @@ fn test_open_file_executable_bash_zsh_fish_route_to_execute() {
 }
 
 #[test]
-fn test_open_file_markdown_unchanged() {
+fn test_open_file_markdown_routes_to_notebook_when_viewer_enabled() {
     let dir = tempfile::tempdir().unwrap();
     let p = dir.path().join("README.md");
     std::fs::write(&p, b"# hi\n").unwrap();
-    assert_eq!(classify_open_file_action(&p), OpenFileAction::Notebook);
+    assert_eq!(
+        classify_open_file_action(&p, true),
+        OpenFileAction::Notebook
+    );
+}
+
+#[test]
+fn test_open_file_markdown_routes_to_editor_when_viewer_disabled() {
+    let dir = tempfile::tempdir().unwrap();
+    let p = dir.path().join("README.md");
+    std::fs::write(&p, b"# hi\n").unwrap();
+    assert_eq!(classify_open_file_action(&p, false), OpenFileAction::Editor);
 }
 
 #[test]
@@ -834,7 +845,10 @@ fn test_open_file_ipynb_routes_to_notebook_when_enabled() {
     let dir = tempfile::tempdir().unwrap();
     let p = dir.path().join("analysis.ipynb");
     std::fs::write(&p, b"{\"nbformat\": 4, \"cells\": []}\n").unwrap();
-    assert_eq!(classify_open_file_action(&p), OpenFileAction::Notebook);
+    assert_eq!(
+        classify_open_file_action(&p, false),
+        OpenFileAction::Notebook
+    );
 }
 
 #[test]
@@ -845,7 +859,7 @@ fn test_open_file_ipynb_opens_in_editor_when_disabled() {
     let dir = tempfile::tempdir().unwrap();
     let p = dir.path().join("analysis.ipynb");
     std::fs::write(&p, b"{\"nbformat\": 4, \"cells\": []}\n").unwrap();
-    assert_eq!(classify_open_file_action(&p), OpenFileAction::Editor);
+    assert_eq!(classify_open_file_action(&p, true), OpenFileAction::Editor);
 }
 
 #[test]
@@ -854,7 +868,7 @@ fn test_open_file_rust_source_still_opens_in_editor() {
     let dir = tempfile::tempdir().unwrap();
     let p = dir.path().join("main.rs");
     std::fs::write(&p, b"fn main() {}\n").unwrap();
-    assert_eq!(classify_open_file_action(&p), OpenFileAction::Editor);
+    assert_eq!(classify_open_file_action(&p, true), OpenFileAction::Editor);
 }
 
 #[test]
@@ -890,7 +904,7 @@ fn test_open_file_editor_binary_file_is_rejected() {
 fn test_open_file_directory_routes_to_session() {
     let dir = tempfile::tempdir().unwrap();
     assert_eq!(
-        classify_open_file_action(dir.path()),
+        classify_open_file_action(dir.path(), true),
         OpenFileAction::ExecuteInSession
     );
 }
@@ -906,7 +920,7 @@ fn test_open_file_non_runnable_shebang_routes_to_editor() {
     let p = dir.path().join("noext");
     std::fs::write(&p, b"#!/bin/sh\necho hi\n").unwrap();
     std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o644)).unwrap();
-    assert_eq!(classify_open_file_action(&p), OpenFileAction::Editor);
+    assert_eq!(classify_open_file_action(&p, true), OpenFileAction::Editor);
 }
 
 #[test]


### PR DESCRIPTION
## Description
Respects the Markdown Viewer preference for incoming `file://` Markdown URLs.

Previously, the URI handler classified every Markdown file as a notebook before reading editor settings. If macOS handed a Markdown file back to Warp through a `file://` URL, Warp opened the internal Markdown Viewer even when `Open Markdown files in Warp's Markdown Viewer by default` was disabled. This now routes Markdown files through the editor path when that preference is disabled.

## Linked Issue
Fixes #8878

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] Added regression coverage for disabled Markdown Viewer routing in `uri_tests.rs`.
- [x] `./script/format`
- [x] `cargo test -p warp test_open_file_markdown_routes_to_editor_when_viewer_disabled` passed after locally applying the equivalent of upstream PRs #12845/#12848 to unblock the current `origin/master` `warpui_core` compile error. That unrelated unblocker is not included in this PR.
- [x] I have manually tested my changes locally with `./script/run`


### Screenshots / Videos

https://github.com/user-attachments/assets/edd0c5a2-7b63-48a0-be9e-5096c0092396


## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fixed Markdown files opening in Warp's Markdown Viewer from macOS file URLs even when the Markdown Viewer preference is disabled.
