### PR TITLE
Parallelize work done by the shell for the precmd hook.

### DIFF
--- a/app/assets/bundled/bootstrap/bash_body.sh
+++ b/app/assets/bundled/bootstrap/bash_body.sh
@@ -426,6 +426,19 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
     warp_git () {
       GIT_OPTIONAL_LOCKS=0 command git "$@"
     }
+    # Reads process substitution outputs into caller-local variables. Passing all
+    # process substitutions in one function call starts their commands in parallel
+    # before this function begins reading.
+    warp_read_parallel_outputs () {
+      local output_var
+      local output_path
+      while (( $# > 0 )); do
+        output_var=$1
+        output_path=$2
+        IFS= read -r -d '' "$output_var" < "$output_path" || true
+        shift 2
+      done
+    }
 
     # Note that this is very performance sensitive code, so try not to
     # invoke any external commands in here.
@@ -562,19 +575,14 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
         local escaped_git_branch=""
         local git_head=""
         local git_branch=""
+        local node_cache_key=""
+        local escaped_git_values=""
 
         # Only fill these fields once we've finished bootstrapping, as the
         # blocks created during the bootstrap process don't have visible
         # prompts, and we don't want to invoke `git` before we've sourced the
         # user's rcfiles and have a fully-populated PATH.
         if [[ -n "$WARP_BOOTSTRAPPED" ]]; then
-          if [[ -n "$VIRTUAL_ENV" ]] && [ "$WARP_IN_MSYS2" = false ]; then
-              escaped_virtual_env=$(warp_escape_json "$VIRTUAL_ENV")
-          fi
-
-          if [[ -n "$CONDA_DEFAULT_ENV" ]] && [ "$WARP_IN_MSYS2" = false ]; then
-              escaped_conda_env=$(warp_escape_json "$CONDA_DEFAULT_ENV")
-          fi
 
           # Get the Node.js version, but only when the Node.js Version chip is enabled.
           # Warp sets WARP_PROMPT_NODE_VERSION_ENABLED to "0" when the chip is not in the
@@ -616,17 +624,7 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
                       # `node --version` when the directory or PATH changes (PATH changes
                       # on `nvm use`). The cache vars are global (no `local`) so they
                       # persist across precmd invocations.
-                      local node_cache_key="$PWD:$PATH"
-                      if [[ "$node_cache_key" == "$_WARP_NODE_VERSION_CACHE_KEY" ]]; then
-                          escaped_node_version="$_WARP_NODE_VERSION_CACHE_VALUE"
-                      else
-                          local node_version=$(node --version 2>/dev/null)
-                          if [[ -n "$node_version" ]]; then
-                              escaped_node_version=$(warp_escape_json "$node_version")
-                          fi
-                          _WARP_NODE_VERSION_CACHE_KEY="$node_cache_key"
-                          _WARP_NODE_VERSION_CACHE_VALUE="$escaped_node_version"
-                      fi
+                      node_cache_key="$PWD:$PATH"
                   fi
               fi
           fi
@@ -636,14 +634,42 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
           # default PATH. Instead, we rely on the active PATH, as if the user doesn't have git
           # available to their session, it is unlikely they will be looking for git branch
           # information from the prompt.
-          if command -v git >/dev/null 2>&1; then
+          if [ "$WARP_IN_MSYS2" = true ] && command -v git >/dev/null 2>&1; then
             git_branch=$(warp_git symbolic-ref --short HEAD 2> /dev/null)
             # The git branch the user is on, or the git commit hash if they're not on a branch.
             git_head="${git_branch:-$(warp_git rev-parse --short HEAD 2> /dev/null)}"
           fi
           if [ "$WARP_IN_MSYS2" = false ]; then
-            escaped_git_head=$(warp_escape_json "$git_head")
-            escaped_git_branch=$(warp_escape_json "$git_branch")
+            warp_read_parallel_outputs \
+              escaped_virtual_env <(warp_escape_json_if_nonempty "${VIRTUAL_ENV:-}") \
+              escaped_conda_env <(warp_escape_json_if_nonempty "${CONDA_DEFAULT_ENV:-}") \
+              escaped_node_version <(
+                if [[ -n $node_cache_key ]]; then
+                  if [[ "$node_cache_key" == "$_WARP_NODE_VERSION_CACHE_KEY" ]]; then
+                    printf '%s' "$_WARP_NODE_VERSION_CACHE_VALUE"
+                  else
+                    warp_escape_json_if_nonempty "$(node --version 2>/dev/null)"
+                  fi
+                fi
+              ) \
+              escaped_git_values <(
+                git_branch=""
+                git_head=""
+                if command -v git >/dev/null 2>&1; then
+                  git_branch=$(warp_git symbolic-ref --short HEAD 2> /dev/null)
+                  # The git branch the user is on, or the git commit hash if they're not on a branch.
+                  git_head="${git_branch:-$(warp_git rev-parse --short HEAD 2> /dev/null)}"
+                fi
+                warp_escape_json_if_nonempty "$git_head"
+                printf '\n'
+                warp_escape_json_if_nonempty "$git_branch"
+              )
+            if [[ -n $node_cache_key ]]; then
+              _WARP_NODE_VERSION_CACHE_KEY="$node_cache_key"
+              _WARP_NODE_VERSION_CACHE_VALUE="$escaped_node_version"
+            fi
+            escaped_git_head=${escaped_git_values%%$'\n'*}
+            escaped_git_branch=${escaped_git_values#*$'\n'}
           fi
         fi
 
@@ -723,6 +749,11 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
         #
         # We also use 'command sed' to ensure that we aren't accidentally executing an alias or function named 'sed'
         command -p sed -E 's/(["\\])/\\\1/g; s/'$'\b''/\\b/g; s/'$'\t''/\\t/g; s/'$'\f''/\\f/g; s/'$'\r''/\\r/g; $!s/$/\\n/' <<<"$*" | command -p tr -d '\n'
+    }
+    warp_escape_json_if_nonempty () {
+      if [[ -n $1 ]]; then
+        warp_escape_json "$1"
+      fi
     }
 
     # Turns out that the processed prompt is a complicated data structure that includes lots of 

--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -380,19 +380,13 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
       local escaped_git_head=""
       local escaped_git_branch=""
       local escaped_kube_config=""
+      local node_cache_key=""
 
       # Only fill these fields once we've finished bootstrapping, as the
       # blocks created during the bootstrap process don't have visible
       # prompts, and we don't want to invoke `git` before we've sourced the
       # user's rcfiles and have a fully-populated PATH.
       if [[ -n $WARP_BOOTSTRAPPED ]]; then
-        if [[ -n ${VIRTUAL_ENV:-} ]]; then
-          escaped_virtual_env=$(warp_escape_json $VIRTUAL_ENV)
-        fi
-
-        if [[ -n ${CONDA_DEFAULT_ENV:-} ]]; then
-          escaped_conda_env=$(warp_escape_json $CONDA_DEFAULT_ENV)
-        fi
 
           # Get the Node.js version, but only when the Node.js Version chip is enabled.
           # Warp sets WARP_PROMPT_NODE_VERSION_ENABLED to "0" when the chip is not in the
@@ -434,39 +428,64 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
                       # `node --version` when the directory or PATH changes (PATH changes
                       # on `nvm use`). The cache vars are global (no `local`) so they
                       # persist across precmd invocations.
-                      local node_cache_key="$PWD:$PATH"
-                      if [[ "$node_cache_key" == "$_WARP_NODE_VERSION_CACHE_KEY" ]]; then
-                          escaped_node_version="$_WARP_NODE_VERSION_CACHE_VALUE"
-                      else
-                          local node_version=$(node --version 2>/dev/null)
-                          if [[ -n "$node_version" ]]; then
-                              escaped_node_version=$(warp_escape_json "$node_version")
-                          fi
-                          _WARP_NODE_VERSION_CACHE_KEY="$node_cache_key"
-                          _WARP_NODE_VERSION_CACHE_VALUE="$escaped_node_version"
-                      fi
+                      node_cache_key="$PWD:$PATH"
                   fi
               fi
           fi
 
-        if [[ -n ${KUBECONFIG:-} ]]; then
-          escaped_kube_config=$(warp_escape_json $KUBECONFIG)
-        fi
 
         # Note: We explicitly do _not_ use command -p here, as `git` is a command that can be
         # installed in non-standard locations and so is not always available on the shell's
         # default PATH. Instead, we rely on the active PATH, as if the user doesn't have git
         # available to their session, it is unlikely they will be looking for git branch
         # information from the prompt.
-        local git_branch=""
-        local git_head=""
-        if command -v git >/dev/null 2>&1; then
-          git_branch=$(warp_git symbolic-ref --short HEAD 2> /dev/null)
-          # The git branch the user is on, or the git commit hash if they're not on a branch.
-          git_head="${git_branch:-$(warp_git rev-parse --short HEAD 2> /dev/null)}"
+
+        # Starting every process substitution before reading any of them lets
+        # the independent prompt-context commands run in parallel.
+        local virtual_env_fd
+        local conda_env_fd
+        local node_version_fd
+        local git_fd
+        local kube_config_fd
+        exec {virtual_env_fd}< <(warp_escape_json_if_nonempty "${VIRTUAL_ENV:-}")
+        exec {conda_env_fd}< <(warp_escape_json_if_nonempty "${CONDA_DEFAULT_ENV:-}")
+        exec {node_version_fd}< <(
+          if [[ -n $node_cache_key ]]; then
+            if [[ "$node_cache_key" == "$_WARP_NODE_VERSION_CACHE_KEY" ]]; then
+              printf '%s' "$_WARP_NODE_VERSION_CACHE_VALUE"
+            else
+              warp_escape_json_if_nonempty "$(node --version 2>/dev/null)"
+            fi
+          fi
+        )
+        exec {git_fd}< <(
+          local git_branch=""
+          local git_head=""
+          if command -v git >/dev/null 2>&1; then
+            git_branch=$(warp_git symbolic-ref --short HEAD 2> /dev/null)
+            # The git branch the user is on, or the git commit hash if they're not on a branch.
+            git_head="${git_branch:-$(warp_git rev-parse --short HEAD 2> /dev/null)}"
+          fi
+          warp_escape_json_if_nonempty "$git_head"
+          printf '\n'
+          warp_escape_json_if_nonempty "$git_branch"
+        )
+        exec {kube_config_fd}< <(warp_escape_json_if_nonempty "${KUBECONFIG:-}")
+        escaped_virtual_env=$(<&$virtual_env_fd)
+        exec {virtual_env_fd}<&-
+        escaped_conda_env=$(<&$conda_env_fd)
+        exec {conda_env_fd}<&-
+        escaped_node_version=$(<&$node_version_fd)
+        exec {node_version_fd}<&-
+        if [[ -n $node_cache_key ]]; then
+          _WARP_NODE_VERSION_CACHE_KEY="$node_cache_key"
+          _WARP_NODE_VERSION_CACHE_VALUE="$escaped_node_version"
         fi
-        escaped_git_head=$(warp_escape_json "$git_head")
-        escaped_git_branch=$(warp_escape_json "$git_branch")
+        IFS= read -r escaped_git_head <&$git_fd || true
+        escaped_git_branch=$(<&$git_fd)
+        exec {git_fd}<&-
+        escaped_kube_config=$(<&$kube_config_fd)
+        exec {kube_config_fd}<&-
       fi
 
 
@@ -521,6 +540,11 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
       #
       # We also use 'command sed' to ensure that we aren't accidentally executing an alias or function named 'sed'
       command -p sed -E 's/(["\\])/\\\1/g; s/'$'\b''/\\b/g; s/'$'\t''/\\t/g; s/'$'\f''/\\f/g; s/'$'\r''/\\r/g; $!s/$/\\n/' <<<"$*" | command -p tr -d '\n'
+  }
+  warp_escape_json_if_nonempty () {
+    if [[ -n $1 ]]; then
+      warp_escape_json "$1"
+    fi
   }
 
   warp_escape_ps1 () {

--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -295,6 +295,19 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
   warp_git () {
     GIT_OPTIONAL_LOCKS=0 command git "$@"
   }
+  # Reads process substitution outputs into caller-local variables. Passing all
+  # process substitutions in one function call starts their commands in parallel
+  # before this function begins reading.
+  warp_read_parallel_outputs () {
+    local output_var
+    local output_path
+    while (( $# > 0 )); do
+      output_var=$1
+      output_path=$2
+      IFS= read -r -d '' "$output_var" < "$output_path" || true
+      shift 2
+    done
+  }
 
   # Note that this is very performance sensitive code, so try not to
   # invoke any external commands in here.
@@ -381,6 +394,7 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
       local escaped_git_branch=""
       local escaped_kube_config=""
       local node_cache_key=""
+      local escaped_git_values=""
 
       # Only fill these fields once we've finished bootstrapping, as the
       # blocks created during the bootstrap process don't have visible
@@ -442,50 +456,37 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
 
         # Starting every process substitution before reading any of them lets
         # the independent prompt-context commands run in parallel.
-        local virtual_env_fd
-        local conda_env_fd
-        local node_version_fd
-        local git_fd
-        local kube_config_fd
-        exec {virtual_env_fd}< <(warp_escape_json_if_nonempty "${VIRTUAL_ENV:-}")
-        exec {conda_env_fd}< <(warp_escape_json_if_nonempty "${CONDA_DEFAULT_ENV:-}")
-        exec {node_version_fd}< <(
-          if [[ -n $node_cache_key ]]; then
-            if [[ "$node_cache_key" == "$_WARP_NODE_VERSION_CACHE_KEY" ]]; then
-              printf '%s' "$_WARP_NODE_VERSION_CACHE_VALUE"
-            else
-              warp_escape_json_if_nonempty "$(node --version 2>/dev/null)"
+        warp_read_parallel_outputs \
+          escaped_virtual_env <(warp_escape_json_if_nonempty "${VIRTUAL_ENV:-}") \
+          escaped_conda_env <(warp_escape_json_if_nonempty "${CONDA_DEFAULT_ENV:-}") \
+          escaped_node_version <(
+            if [[ -n $node_cache_key ]]; then
+              if [[ "$node_cache_key" == "$_WARP_NODE_VERSION_CACHE_KEY" ]]; then
+                printf '%s' "$_WARP_NODE_VERSION_CACHE_VALUE"
+              else
+                warp_escape_json_if_nonempty "$(node --version 2>/dev/null)"
+              fi
             fi
-          fi
-        )
-        exec {git_fd}< <(
-          local git_branch=""
-          local git_head=""
-          if command -v git >/dev/null 2>&1; then
-            git_branch=$(warp_git symbolic-ref --short HEAD 2> /dev/null)
-            # The git branch the user is on, or the git commit hash if they're not on a branch.
-            git_head="${git_branch:-$(warp_git rev-parse --short HEAD 2> /dev/null)}"
-          fi
-          warp_escape_json_if_nonempty "$git_head"
-          printf '\n'
-          warp_escape_json_if_nonempty "$git_branch"
-        )
-        exec {kube_config_fd}< <(warp_escape_json_if_nonempty "${KUBECONFIG:-}")
-        escaped_virtual_env=$(<&$virtual_env_fd)
-        exec {virtual_env_fd}<&-
-        escaped_conda_env=$(<&$conda_env_fd)
-        exec {conda_env_fd}<&-
-        escaped_node_version=$(<&$node_version_fd)
-        exec {node_version_fd}<&-
+          ) \
+          escaped_git_values <(
+            local git_branch=""
+            local git_head=""
+            if command -v git >/dev/null 2>&1; then
+              git_branch=$(warp_git symbolic-ref --short HEAD 2> /dev/null)
+              # The git branch the user is on, or the git commit hash if they're not on a branch.
+              git_head="${git_branch:-$(warp_git rev-parse --short HEAD 2> /dev/null)}"
+            fi
+            warp_escape_json_if_nonempty "$git_head"
+            printf '\n'
+            warp_escape_json_if_nonempty "$git_branch"
+          ) \
+          escaped_kube_config <(warp_escape_json_if_nonempty "${KUBECONFIG:-}")
         if [[ -n $node_cache_key ]]; then
           _WARP_NODE_VERSION_CACHE_KEY="$node_cache_key"
           _WARP_NODE_VERSION_CACHE_VALUE="$escaped_node_version"
         fi
-        IFS= read -r escaped_git_head <&$git_fd || true
-        escaped_git_branch=$(<&$git_fd)
-        exec {git_fd}<&-
-        escaped_kube_config=$(<&$kube_config_fd)
-        exec {kube_config_fd}<&-
+        escaped_git_head=${escaped_git_values%%$'\n'*}
+        escaped_git_branch=${escaped_git_values#*$'\n'}
       fi
 
 


### PR DESCRIPTION
## Description

`precmd` previously collected and JSON-escaped each prompt-context field serially, adding the latency of every independent operation before the next prompt could render.

Bash and Zsh now start the independent virtualenv, Conda, Node version, Git, and Zsh `KUBECONFIG` work concurrently through process substitutions, then drain their outputs into caller-local variables with a shared `warp_read_parallel_outputs` helper. This avoids temporary files and remains compatible with Bash 3.2.

Fish cannot run shell functions concurrently, so it uses a Fish-specific approach: an uncached Node version pipeline starts before the grouped Git lookup, then independent JSON-escaping pipelines run concurrently and write into a private per-shell directory that is removed on exit. Fish falls back to serial collection if that directory cannot be created.

Across all three shells, Git head and branch stay grouped to avoid duplicate Git commands, while the Node eligibility directory walk and cache updates remain in the parent shell so cache state persists across prompts. Benchmarking the directory walk inside the Node worker showed no measurable benefit, so it remains serial. The MSYS2-specific Bash path is unchanged.

### Performance

Measured against the original serial prompt-context collection with all fields non-empty:

| Shell | Node cache | Serial | Parallel | Speedup | CPU overhead |
|---|---:|---:|---:|---:|---:|
| Bash 3.2 | Cold | 62.4 ms | 34.9 ms | 1.79x (44% lower latency) | +7% |
| Bash 3.2 | Warm | 32.1 ms | 23.0 ms | 1.39x (28% lower latency) | +13% |
| Zsh 5.9 | Cold | 55.7 ms | 29.7 ms | 1.88x (47% lower latency) | +12% |
| Zsh 5.9 | Warm | 29.1 ms | 17.3 ms | 1.68x (40% lower latency) | +14% |
| Fish 4.2 | Cold | 34.9 ms | 23.3 ms | 1.50x (33% lower latency) | +5% |
| Fish 4.2 | Warm | 11.2 ms | 7.5 ms | 1.48x (33% lower latency) | +1% |

A separate end-to-end Fish benchmark of the full `precmd` hook measured cold latency improving from 58.5 ms to 47.1 ms (1.24x / 19.5% lower, +4.6% CPU) and warm latency improving from 35.3 ms to 31.7 ms (1.11x / 10.2% lower, +1.0% CPU).

The collection benchmark ran from a package-containing checkout with a real `.git` directory, using Node v22.13.1 and Hyperfine. Each result is the per-hook mean from batches of 20 collections, with 5 warmups and 25–30 measured runs. The Fish full-hook benchmark used batches of 30 collections, with 3 warmups and 20 measured runs. CPU overhead is combined user and system time relative to the serial baseline.

## Linked Issue

N/A

## Testing

- `/bin/bash -n app/assets/bundled/bootstrap/bash_body.sh`
- `/bin/zsh -n app/assets/bundled/bootstrap/zsh_body.sh`
- `fish -n app/assets/bundled/bootstrap/fish.sh`
- Parsed generated/minified Bash, Zsh, and Fish bootstrap forms.
- Verified caller-local output assignment on Bash 3.2 and Zsh 5.9, including Git-value splitting with Zsh `KSH_ARRAYS` enabled.
- Verified byte-identical serial/parallel Fish `precmd` payloads for named and detached Git HEADs with cold and warm Node caches.
- Verified Fish's serial fallback and shared JSON escaping behavior.
- Ran the Hyperfine benchmarks documented above.

No new automated tests were added because this is performance-sensitive shell bootstrap behavior validated directly in all three target shells and through comparative benchmarks.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
