### PR TITLE
fix(osc): guard params[1] access in OSC 1337 arm against missing second param

### DIFF
--- a/app/src/terminal/model/ansi/mod.rs
+++ b/app/src/terminal/model/ansi/mod.rs
@@ -1026,6 +1026,9 @@ where
 
             // iTerm inline image protocol.
             b"1337" => {
+                if params.len() < 2 {
+                    return unhandled(params);
+                }
                 if params[1].starts_with(b"File=") {
                     let metadata = parse_iterm_image_metadata(params);
 

--- a/app/src/terminal/model/ansi/mod_tests.rs
+++ b/app/src/terminal/model/ansi/mod_tests.rs
@@ -1131,3 +1131,13 @@ fn parse_osc7_empty_payload_ignored() {
 
     assert!(handler.cwd_updates.is_empty());
 }
+
+#[test]
+fn parse_osc1337_without_second_param_does_not_panic() {
+    // Regression test for GH #12817: a bare `ESC ] 1337 BEL` (no second parameter)
+    // previously triggered an index-out-of-bounds panic because the 1337 arm
+    // accessed params[1] without a length guard. It must be silently ignored.
+    let bytes: &[u8] = b"\x1b]1337\x07";
+    // Must not panic.
+    let _ = parse_bytes(bytes);
+}


### PR DESCRIPTION
## Description

adds a `params.len() < 2` guard at the top of the `b"1337"` arm in `osc_dispatch` so a parameterless OSC 1337 sequence is treated as unhandled instead of panicking.

## Linked Issue

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

fixes #12817

## Root cause

`app/src/terminal/model/ansi/mod.rs`, `osc_dispatch`, the `b"1337"` arm directly accesses `params[1]` without a length guard. every neighboring OSC arm (`133`, `777`, `52`, `9277`, `9278`) checks `params.len()` before accessing any param beyond index 0 — the 1337 arm was the only exception.

when the sequence has no second parameter (`params == [b"1337"]`), `params[1]` is out of bounds → panic.

## Fix

three lines added at the top of the `b"1337"` arm:

```rust
if params.len() < 2 {
    return unhandled(params);
}
```

this is identical to the guard pattern already used by `b"133"`, `b"777"`, `b"52"`, and others.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

added a regression unit test in `mod_tests.rs`:

```rust
#[test]
fn parse_osc1337_without_second_param_does_not_panic() {
    let bytes: &[u8] = b"\x1b]1337\x07";
    let _ = parse_bytes(bytes); // must not panic
}
```

manual test: `printf '\e]1337\a'` in a running warp session no longer crashes.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: fix panic when receiving a bare OSC 1337 sequence without a second parameter