### PR TITLE
Fix StoredView missing child_view_ids delegation (build break)

### DIFF
--- a/crates/warpui_core/src/core/view/tui.rs
+++ b/crates/warpui_core/src/core/view/tui.rs
@@ -41,6 +41,16 @@ pub trait TuiView: Entity {
         ctx.set.insert(Self::ui_name());
         ctx
     }
+
+    /// Returns the ids of child views this view directly owns via
+    /// [`ViewHandle`]s that are not registered in the structural parent/child
+    /// graph, regardless of whether they are currently being rendered.
+    ///
+    /// See [`View::child_view_ids`](crate::View::child_view_ids) for the full
+    /// contract. The semantics are identical for TUI views.
+    fn child_view_ids(&self, _app: &AppContext) -> Vec<EntityId> {
+        Vec::new()
+    }
 }
 
 /// The object-safe, type-erased TUI view object stored per window: the TUI
@@ -66,6 +76,7 @@ pub trait AnyTuiView {
         view_id: EntityId,
     );
     fn keymap_context(&self, app: &AppContext) -> keymap::Context;
+    fn child_view_ids(&self, app: &AppContext) -> Vec<EntityId>;
 }
 
 impl<T> AnyTuiView for T
@@ -112,5 +123,9 @@ where
 
     fn keymap_context(&self, app: &AppContext) -> keymap::Context {
         TuiView::keymap_context(self, app)
+    }
+
+    fn child_view_ids(&self, app: &AppContext) -> Vec<EntityId> {
+        TuiView::child_view_ids(self, app)
     }
 }

--- a/crates/warpui_core/src/core/window.rs
+++ b/crates/warpui_core/src/core/window.rs
@@ -200,7 +200,7 @@ impl StoredView {
         match self {
             StoredView::Gui(view) => view.child_view_ids(app),
             #[cfg(feature = "tui")]
-            StoredView::Tui(_) => Vec::new(),
+            StoredView::Tui(view) => view.child_view_ids(app),
         }
     }
 }

--- a/crates/warpui_core/src/core/window.rs
+++ b/crates/warpui_core/src/core/window.rs
@@ -195,4 +195,12 @@ impl StoredView {
             StoredView::Tui(_) => None,
         }
     }
+
+    pub fn child_view_ids(&self, app: &AppContext) -> Vec<EntityId> {
+        match self {
+            StoredView::Gui(view) => view.child_view_ids(app),
+            #[cfg(feature = "tui")]
+            StoredView::Tui(_) => Vec::new(),
+        }
+    }
 }


### PR DESCRIPTION
## Description

Fixes a build break caused by a semantic merge conflict between #12633 and #12746, and makes the fix properly extensible for TUI views.

**Root cause:** `#12633` ("Add TUI API surface to AppContext under `tui`") introduced `StoredView` — a `Gui`/`Tui` enum replacing `Box<dyn AnyView>` as the value type of `Window.views`. It forwarded every neutral hook to the inner view except `child_view_ids`. `#12746` ("Cross Window Tab Dragging Bug Fixes") had already added a call to `view.child_view_ids(self)` in `collect_transferable_subtree` (`app.rs:3306`), which compiled fine against `Box<dyn AnyView>` but broke once the map type changed. Because #12633 was not rebased on #12746, its CI was green; the breakage only surfaced on the dev release branch after both landed.

**Changes:**

1. `StoredView` (`window.rs`): delegates `child_view_ids` to the inner view for both `Gui` and `Tui` arms, mirroring every other hook already present.

2. `TuiView` / `AnyTuiView` (`view/tui.rs`): threads `child_view_ids` through the full TUI trait stack — added to `TuiView` (defaulting to `Vec::new()`), to the `AnyTuiView` object-safe interface, and to the `impl<T: TuiView> AnyTuiView for T` blanket impl. TUI views participate in the same structural parent/child graph as GUI views and could in principle hold out-of-graph child `ViewHandle`s; any `TuiView` that does so can now override `child_view_ids` and have those children picked up correctly by `collect_transferable_subtree` during window transfer.

## Linked Issue

N/A — this is a build-break hotfix.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

`cargo check -p warpui_core` and `cargo clippy -p warpui_core --lib --all-features -- -D warnings` both pass.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

_Conversation: https://staging.warp.dev/conversation/edb30580-4cd8-4ca3-a230-a93f61bbc1f8_
_Run: https://oz.staging.warp.dev/runs/019eeaba-5589-7288-9a8f-4176d7a90cf2_
_This PR was generated with [Oz](https://warp.dev/oz)._
