### PR TITLE
Use the public claude platform plugin.

### DIFF
--- a/app/src/terminal/cli_agent_sessions/plugin_manager/claude.rs
+++ b/app/src/terminal/cli_agent_sessions/plugin_manager/claude.rs
@@ -14,12 +14,10 @@ use crate::terminal::model::session::LocalCommandExecutor;
 use crate::terminal::shell::ShellType;
 
 const PLUGIN_KEY: &str = "warp@claude-code-warp";
+const PLATFORM_PLUGIN_KEY: &str = "oz-harness-support@claude-code-warp";
+
 const MARKETPLACE_REPO: &str = "warpdotdev/claude-code-warp";
 const MARKETPLACE_NAME: &str = "claude-code-warp";
-
-const PLATFORM_PLUGIN_KEY: &str = "oz-harness-support@claude-code-warp";
-// Note: we will eventually publish this to the same marketplace repo, but are using the internal one as we build out multi-harness.
-const PLATFORM_MARKETPLACE_REPO: &str = "warpdotdev/claude-code-warp-internal";
 
 // Keep in sync with the plugin version in warpdotdev/claude-code-warp.
 // (See the Versioning section of that repo's README.)
@@ -176,7 +174,7 @@ impl CliAgentPluginManager for ClaudeCodePluginManager {
     async fn install_platform_plugin(&self) -> Result<(), PluginInstallError> {
         let mut log = String::new();
         self.run_logged(
-            &["plugin", "marketplace", "add", PLATFORM_MARKETPLACE_REPO],
+            &["plugin", "marketplace", "add", MARKETPLACE_REPO],
             &mut log,
         )
         .await?;

--- a/app/src/terminal/cli_agent_sessions/plugin_manager/claude.rs
+++ b/app/src/terminal/cli_agent_sessions/plugin_manager/claude.rs
@@ -348,10 +348,16 @@ fn is_local_marketplace_path(source: &str) -> bool {
         || source.starts_with("file://")
 }
 
-/// Checks `CLAUDE_HOME` env var first, falls back to `~/.claude`.
+/// Resolves the dir the Claude CLI reads/writes its state from.
+///
+/// Honors `CLAUDE_CONFIG_DIR` (respected by the Claude CLI, and set by the Oz
+/// worker to a per-task dir), falling back to `~/.claude`. Must match where
+/// `claude plugin install` writes, else install/verify checks read the wrong dir.
 fn claude_home_dir() -> io::Result<PathBuf> {
-    if let Ok(claude_home) = env::var("CLAUDE_HOME") {
-        return Ok(PathBuf::from(claude_home));
+    if let Ok(dir) = env::var("CLAUDE_CONFIG_DIR") {
+        if !dir.is_empty() {
+            return Ok(PathBuf::from(dir));
+        }
     }
     dirs::home_dir()
         .map(|home| home.join(".claude"))

--- a/app/src/terminal/cli_agent_sessions/plugin_manager/claude.rs
+++ b/app/src/terminal/cli_agent_sessions/plugin_manager/claude.rs
@@ -22,8 +22,8 @@ const MARKETPLACE_NAME: &str = "claude-code-warp";
 // Keep in sync with the plugin version in warpdotdev/claude-code-warp.
 // (See the Versioning section of that repo's README.)
 const MINIMUM_PLUGIN_VERSION: &str = "2.1.0";
-// Keep in sync with the oz-harness-support plugin version in warpdotdev/claude-code-warp-internal.
-const MINIMUM_PLATFORM_PLUGIN_VERSION: &str = "1.1.3";
+// Keep in sync with the oz-harness-support plugin version in warpdotdev/claude-code-warp.
+const MINIMUM_PLATFORM_PLUGIN_VERSION: &str = "1.1.2";
 
 pub(super) struct ClaudeCodePluginManager {
     executor: LocalCommandExecutor,

--- a/app/src/terminal/cli_agent_sessions/plugin_manager/claude.rs
+++ b/app/src/terminal/cli_agent_sessions/plugin_manager/claude.rs
@@ -186,7 +186,7 @@ impl CliAgentPluginManager for ClaudeCodePluginManager {
     async fn update_platform_plugin(&self) -> Result<(), PluginInstallError> {
         let mut log = String::new();
         self.run_logged(
-            &["plugin", "marketplace", "add", PLATFORM_MARKETPLACE_REPO],
+            &["plugin", "marketplace", "add", MARKETPLACE_REPO],
             &mut log,
         )
         .await?;

--- a/app/src/terminal/cli_agent_sessions/plugin_manager/claude_tests.rs
+++ b/app/src/terminal/cli_agent_sessions/plugin_manager/claude_tests.rs
@@ -69,7 +69,7 @@ fn local_marketplace_override_ignores_repo_source() {
 
 #[test]
 #[serial_test::serial]
-fn local_marketplace_override_via_trait_uses_claude_home() {
+fn local_marketplace_override_via_trait_uses_claude_config_dir() {
     let dir = tempfile::tempdir().unwrap();
     let settings = serde_json::json!({
         "extraKnownMarketplaces": {
@@ -87,9 +87,9 @@ fn local_marketplace_override_via_trait_uses_claude_home() {
     )
     .unwrap();
 
-    std::env::set_var("CLAUDE_HOME", dir.path());
+    std::env::set_var("CLAUDE_CONFIG_DIR", dir.path());
     let result = ClaudeCodePluginManager::new(None, None, None).has_local_marketplace_override();
-    std::env::remove_var("CLAUDE_HOME");
+    std::env::remove_var("CLAUDE_CONFIG_DIR");
 
     assert!(result);
 }
@@ -155,9 +155,9 @@ fn platform_plugin_needs_update_via_trait_when_version_below_minimum() {
     )
     .unwrap();
 
-    std::env::set_var("CLAUDE_HOME", dir.path());
+    std::env::set_var("CLAUDE_CONFIG_DIR", dir.path());
     let result = ClaudeCodePluginManager::new(None, None, None).platform_plugin_needs_update();
-    std::env::remove_var("CLAUDE_HOME");
+    std::env::remove_var("CLAUDE_CONFIG_DIR");
 
     assert!(result);
 }
@@ -180,9 +180,9 @@ fn platform_plugin_does_not_need_update_via_trait_when_current() {
     )
     .unwrap();
 
-    std::env::set_var("CLAUDE_HOME", dir.path());
+    std::env::set_var("CLAUDE_CONFIG_DIR", dir.path());
     let result = ClaudeCodePluginManager::new(None, None, None).platform_plugin_needs_update();
-    std::env::remove_var("CLAUDE_HOME");
+    std::env::remove_var("CLAUDE_CONFIG_DIR");
 
     assert!(!result);
 }
@@ -205,9 +205,9 @@ fn platform_plugin_needs_update_via_trait_when_installed_without_version() {
     )
     .unwrap();
 
-    std::env::set_var("CLAUDE_HOME", dir.path());
+    std::env::set_var("CLAUDE_CONFIG_DIR", dir.path());
     let result = ClaudeCodePluginManager::new(None, None, None).platform_plugin_needs_update();
-    std::env::remove_var("CLAUDE_HOME");
+    std::env::remove_var("CLAUDE_CONFIG_DIR");
 
     assert!(result);
 }
@@ -305,10 +305,10 @@ fn not_installed_when_plugins_key_missing() {
 }
 
 /// Tests `ClaudeCodePluginManager::is_installed` end-to-end by pointing
-/// `CLAUDE_HOME` at a temp directory with a valid installed_plugins.json.
+/// `CLAUDE_CONFIG_DIR` at a temp directory with a valid installed_plugins.json.
 #[test]
 #[serial_test::serial]
-fn is_installed_via_trait_with_claude_home_env() {
+fn is_installed_via_trait_with_claude_config_dir_env() {
     let dir = tempfile::tempdir().unwrap();
     let plugins_dir = dir.path().join("plugins");
     fs::create_dir_all(&plugins_dir).unwrap();
@@ -324,21 +324,21 @@ fn is_installed_via_trait_with_claude_home_env() {
     )
     .unwrap();
 
-    std::env::set_var("CLAUDE_HOME", dir.path());
+    std::env::set_var("CLAUDE_CONFIG_DIR", dir.path());
     let result = ClaudeCodePluginManager::new(None, None, None).is_installed();
-    std::env::remove_var("CLAUDE_HOME");
+    std::env::remove_var("CLAUDE_CONFIG_DIR");
 
     assert!(result);
 }
 
 #[test]
 #[serial_test::serial]
-fn not_installed_via_trait_when_claude_home_empty() {
+fn not_installed_via_trait_when_claude_config_dir_empty() {
     let dir = tempfile::tempdir().unwrap();
 
-    std::env::set_var("CLAUDE_HOME", dir.path());
+    std::env::set_var("CLAUDE_CONFIG_DIR", dir.path());
     let result = ClaudeCodePluginManager::new(None, None, None).is_installed();
-    std::env::remove_var("CLAUDE_HOME");
+    std::env::remove_var("CLAUDE_CONFIG_DIR");
 
     assert!(!result);
 }

--- a/app/src/terminal/cli_agent_sessions/plugin_manager/claude_tests.rs
+++ b/app/src/terminal/cli_agent_sessions/plugin_manager/claude_tests.rs
@@ -3,8 +3,25 @@ use std::fs;
 use super::{
     check_installed, check_platform_plugin_installed, claude_code_marketplace_has_local_override,
     installed_platform_plugin_version, installed_version, ClaudeCodePluginManager,
-    CliAgentPluginManager,
+    CliAgentPluginManager, MINIMUM_PLATFORM_PLUGIN_VERSION,
 };
+
+/// A version strictly below `version`, so below-minimum tests track the
+/// constant instead of a hardcoded literal. Assumes `version` > "0.0.0".
+fn version_below(version: &str) -> String {
+    let mut parts: Vec<u64> = version.split('.').map(|p| p.parse().unwrap_or(0)).collect();
+    for part in parts.iter_mut().rev() {
+        if *part > 0 {
+            *part -= 1;
+            break;
+        }
+    }
+    parts
+        .iter()
+        .map(|p| p.to_string())
+        .collect::<Vec<_>>()
+        .join(".")
+}
 
 #[test]
 fn installed_when_plugin_present() {
@@ -102,7 +119,7 @@ fn installed_platform_plugin_version_returns_version_when_present() {
 
     let json = serde_json::json!({
         "plugins": {
-            "oz-harness-support@claude-code-warp": [{"version": "1.1.3"}]
+            "oz-harness-support@claude-code-warp": [{"version": MINIMUM_PLATFORM_PLUGIN_VERSION}]
         }
     });
     fs::write(
@@ -113,7 +130,7 @@ fn installed_platform_plugin_version_returns_version_when_present() {
 
     assert_eq!(
         installed_platform_plugin_version(dir.path()).as_deref(),
-        Some("1.1.3")
+        Some(MINIMUM_PLATFORM_PLUGIN_VERSION)
     );
 }
 
@@ -125,7 +142,7 @@ fn platform_plugin_installed_when_platform_plugin_present() {
 
     let json = serde_json::json!({
         "plugins": {
-            "oz-harness-support@claude-code-warp": [{"version": "1.1.3"}]
+            "oz-harness-support@claude-code-warp": [{"version": MINIMUM_PLATFORM_PLUGIN_VERSION}]
         }
     });
     fs::write(
@@ -146,7 +163,7 @@ fn platform_plugin_needs_update_via_trait_when_version_below_minimum() {
 
     let json = serde_json::json!({
         "plugins": {
-            "oz-harness-support@claude-code-warp": [{"version": "1.1.2"}]
+            "oz-harness-support@claude-code-warp": [{"version": version_below(MINIMUM_PLATFORM_PLUGIN_VERSION)}]
         }
     });
     fs::write(
@@ -171,7 +188,7 @@ fn platform_plugin_does_not_need_update_via_trait_when_current() {
 
     let json = serde_json::json!({
         "plugins": {
-            "oz-harness-support@claude-code-warp": [{"version": "1.1.3"}]
+            "oz-harness-support@claude-code-warp": [{"version": MINIMUM_PLATFORM_PLUGIN_VERSION}]
         }
     });
     fs::write(


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
After we update `claude-code-warp` to include the platform plugin for multi-harness runs, we need to update the driver to pull that version of the plugin in: https://github.com/warpdotdev/claude-code-warp/pull/69.

I also noticed that the minimum plugin version asserted in this repo was too high given the version we have set in `claude-code-warp-internal`, meaning that the platform will always fail to start the driver since it tries to update to a version that doesn't exist.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

I will test with `oz-local` once the other PR lands.
