### PR TITLE
Reduce flakiness of windows local_tty test.

### DIFF
--- a/app/src/terminal/local_tty/windows/child_tests.rs
+++ b/app/src/terminal/local_tty/windows/child_tests.rs
@@ -2,13 +2,14 @@ use std::os::windows::io::AsRawHandle;
 use std::time::Duration;
 
 use command::blocking::Command;
+use instant::Instant;
 
 use super::*;
 use crate::terminal::local_tty::event_loop::CHANNEL_TOKEN;
 
 #[test]
 pub fn test_event_is_emitted_when_child_exits() {
-    const WAIT_TIMEOUT: Duration = Duration::from_millis(200);
+    const WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 
     let mut poll = mio::Poll::new().unwrap();
 
@@ -28,10 +29,27 @@ pub fn test_event_is_emitted_when_child_exits() {
 
     child.kill().unwrap();
 
-    // Poll for the event or fail with timeout if nothing has been sent.
+    // Poll until the event arrives or the overall timeout elapses.
     let mut events = mio::Events::with_capacity(10);
-    poll.poll(&mut events, Some(WAIT_TIMEOUT)).unwrap();
-    assert_eq!(events.iter().next().unwrap().token(), CHANNEL_TOKEN);
+    let deadline = Instant::now() + WAIT_TIMEOUT;
+    loop {
+        events.clear();
+        poll.poll(
+            &mut events,
+            Some(deadline.saturating_duration_since(Instant::now())),
+        )
+        .unwrap();
+
+        if events.iter().any(|event| event.token() == CHANNEL_TOKEN) {
+            break;
+        }
+
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for child-exit event; receiver state: {:?}",
+            rx.try_recv()
+        );
+    }
     // Verify that at least one `ChildEvent::Exited` was received.
     assert!(matches!(rx.try_recv(), Ok(Message::ChildExited)));
 }


### PR DESCRIPTION
## Description

The Windows child-exit test used a one-shot 200 ms Mio poll after asynchronously terminating `cmd.exe`. Under load, Windows can take longer to signal the process handle, run the registered wait callback, and wake Mio, causing the test to unwrap an empty event set.

Use a generous overall deadline and repeatedly poll until the channel token is observed. Successful runs still return immediately, while timeout failures now report the receiver state to distinguish delayed callback delivery from a lost Mio wake.

## Linked Issue

N/A — test-only CI flake reduction.

## Testing

- `cargo fmt --all -- --check`
- `cargo check -p warp --tests`
- `git diff --check`
- Not run locally: `cargo nextest run -p warp -E 'test(test_event_is_emitted_when_child_exits)'` because the test is Windows-only and the current host is macOS.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
