### PR TITLE
Fix MCP log paths for WSL shells

### DIFF
--- a/app/src/settings_view/mcp_servers/list_page.rs
+++ b/app/src/settings_view/mcp_servers/list_page.rs
@@ -64,7 +64,7 @@ use crate::ui_components::blended_colors;
 use crate::util::truncation::truncate_from_end;
 use crate::view_components::action_button::{ActionButton, NakedTheme};
 use crate::view_components::DismissibleToast;
-use crate::workflows::local_workflows::tail_command_for_shell;
+use crate::workflows::local_workflows::tail_command_for_shell_with_path_converter;
 use crate::workspace::Workspace;
 use crate::workspaces::user_workspaces::UserWorkspaces;
 use crate::ToastStack;
@@ -629,7 +629,11 @@ impl MCPServersListPageView {
 
             terminal_view_handle.update(ctx, |terminal, ctx| {
                 let shell_family = terminal.shell_family(ctx);
-                let tail_command = tail_command_for_shell(shell_family, log_file_path);
+                let tail_command = tail_command_for_shell_with_path_converter(
+                    shell_family,
+                    log_file_path,
+                    terminal.windows_path_converter(ctx),
+                );
                 terminal.set_pending_command(&tail_command, ctx);
             });
         })

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -449,8 +449,9 @@ use crate::terminal::model_events::{AnsiHandlerEvent, ModelEvent, ModelEventDisp
 use crate::terminal::recorder::PtyRecorder;
 use crate::terminal::safe_mode_settings::get_secret_obfuscation_mode;
 use crate::terminal::session_settings::{
-    NotificationsMode, NotificationsSettings, SessionSettings, SessionSettingsChangedEvent,
-    ToolbarChipSelection, DEFAULT_THRESHOLD_FOR_LONG_RUNNING_NOTIFICATION,
+    NewSessionShell, NotificationsMode, NotificationsSettings, SessionSettings,
+    SessionSettingsChangedEvent, ToolbarChipSelection,
+    DEFAULT_THRESHOLD_FOR_LONG_RUNNING_NOTIFICATION,
 };
 use crate::terminal::settings::{TerminalSettings, TerminalSettingsChangedEvent};
 use crate::terminal::shared_session::role_change_modal::{
@@ -16341,6 +16342,38 @@ impl TerminalView {
                         .shell_family()
                 })
             })
+    }
+
+    pub fn windows_path_converter(
+        &self,
+        ctx: &mut ViewContext<Self>,
+    ) -> Option<fn(&str) -> String> {
+        if let Some(converter) = self
+            .active_block_session_id()
+            .and_then(|session_id| self.sessions.as_ref(ctx).get(session_id))
+            .and_then(|session| session.windows_path_converter())
+        {
+            return Some(converter);
+        }
+
+        SessionSettings::handle(ctx).read(ctx, |settings, _| {
+            match settings
+                .new_session_shell_override
+                .value()
+                .clone()
+                .unwrap_or_default()
+            {
+                NewSessionShell::WSL(_) => {
+                    Some(warp_util::path::convert_windows_path_to_wsl as fn(&str) -> String)
+                }
+                NewSessionShell::MSYS2(_) => {
+                    Some(warp_util::path::convert_windows_path_to_msys2 as fn(&str) -> String)
+                }
+                NewSessionShell::SystemDefault
+                | NewSessionShell::Executable(_)
+                | NewSessionShell::Custom(_) => None,
+            }
+        })
     }
 
     fn paste(&mut self, middle_click: bool, ctx: &mut ViewContext<Self>) {

--- a/app/src/workflows/local_workflows.rs
+++ b/app/src/workflows/local_workflows.rs
@@ -193,11 +193,29 @@ pub(super) fn load_project_workflows(path: &Path) -> Vec<Workflow> {
 /// Runs `tail` or equivalent command on the given path.
 /// Note: On Windows this may cause a lossy conversion if the path is not valid UTF-8.
 pub fn tail_command_for_shell(shell_family: ShellFamily, path: &PathBuf) -> String {
+    tail_command_for_shell_with_path_converter(shell_family, path, None)
+}
+
+/// Runs `tail` or equivalent command on the given path, converting Windows host paths when the
+/// target shell expects a guest path such as WSL's `/mnt/c/...`.
+/// Note: On Windows this may cause a lossy conversion if the path is not valid UTF-8.
+pub fn tail_command_for_shell_with_path_converter(
+    shell_family: ShellFamily,
+    path: &PathBuf,
+    windows_path_converter: Option<fn(&str) -> String>,
+) -> String {
     match shell_family {
-        // Use debug formatting for `PathBuf` so that any non-Unicode components of the path get
-        // escaped.  This will also add quotes around the path, so there's no need to add them in
-        // the format string.
-        ShellFamily::Posix => format!("tail -f {path:?}"),
+        ShellFamily::Posix => {
+            if let Some(windows_path_converter) = windows_path_converter {
+                let converted_path = windows_path_converter(&path.to_string_lossy());
+                format!("tail -f {}", ShellFamily::Posix.escape(&converted_path))
+            } else {
+                // Use debug formatting for `PathBuf` so that any non-Unicode components of the
+                // path get escaped. This will also add quotes around the path, so there's no need
+                // to add them in the format string.
+                format!("tail -f {path:?}")
+            }
+        }
         // We avoid the debug formatting here so that backslashes don't get escaped, which is not
         // desirable for PowerShell.  Note that this may be lossy conversion if the path is not
         // valid UTF-8.

--- a/app/src/workflows/local_workflows_tests.rs
+++ b/app/src/workflows/local_workflows_tests.rs
@@ -55,3 +55,36 @@ fn test_workflow_by_command_name() {
         });
     });
 }
+
+#[test]
+fn test_tail_command_converts_windows_path_for_wsl_shell() {
+    let path =
+        std::path::PathBuf::from(r"C:\Users\sheffler\AppData\Local\warp\Warp\data\logs\mcp\a.log");
+
+    let command = tail_command_for_shell_with_path_converter(
+        warp_util::path::ShellFamily::Posix,
+        &path,
+        Some(warp_util::path::convert_windows_path_to_wsl),
+    );
+
+    assert_eq!(
+        command,
+        "tail -f /mnt/c/Users/sheffler/AppData/Local/warp/Warp/data/logs/mcp/a.log"
+    );
+}
+
+#[test]
+fn test_tail_command_escapes_converted_wsl_path() {
+    let path = std::path::PathBuf::from(r"C:\Users\sheffler\App Data\mcp logs\a.log");
+
+    let command = tail_command_for_shell_with_path_converter(
+        warp_util::path::ShellFamily::Posix,
+        &path,
+        Some(warp_util::path::convert_windows_path_to_wsl),
+    );
+
+    assert_eq!(
+        command,
+        r"tail -f /mnt/c/Users/sheffler/App\ Data/mcp\ logs/a.log"
+    );
+}


### PR DESCRIPTION
## Description
Fixes #10169.

When MCP **Show Logs** opens a terminal in a WSL/MSYS2-style shell, convert the Windows host log path before building the `tail -f` command. This keeps existing PowerShell and normal Posix behavior unchanged while letting WSL shells read host-side MCP log files via `/mnt/c/...`.

## Linked Issue
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

Fixes #10169

## Testing
- [x] `./script/format --check`
- [x] `git diff --check`
- [ ] `cargo test -p warp workflows::local_workflows`
  - Attempted locally, but the build fails before reaching these tests because this Xcode install is missing the Metal Toolchain required by `crates/warpui/build.rs`: `cannot execute tool 'metal' due to missing Metal Toolchain`.
  - Also attempted `xcodebuild -downloadComponent MetalToolchain`, but Xcode failed fetching the Apple asset catalog for build `17F42`.
- [ ] I have manually tested my changes locally with `./script/run`
  - Not run locally because the same missing Metal Toolchain blocks building Warp on this machine, and I do not have a Windows + WSL environment here.

Added regression coverage for the command builder:
- Windows host path `C:\Users\...\logs\mcp\a.log` converts to `/mnt/c/Users/.../logs/mcp/a.log` for WSL.
- Converted WSL paths with spaces are escaped for Posix shell execution.

### Screenshots / Videos
Not included; this is command construction behavior for a Windows + WSL-specific path handling bug.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fix MCP Show Logs using Windows host paths inside WSL shells.