### PR TITLE
Fix repo picker footer hover states

### DIFF
--- a/app/src/menu.rs
+++ b/app/src/menu.rs
@@ -1812,6 +1812,7 @@ impl<A: Action + Clone> SubMenu<A> {
     pub fn reset_selection(&mut self, ctx: &mut ViewContext<Menu<A>>) {
         self.selected_row_index = None;
         self.selected_item_index = None;
+        self.hovered_row_index = None;
         self.last_selection_source = None;
         ctx.notify();
     }

--- a/app/src/menu_tests.rs
+++ b/app/src/menu_tests.rs
@@ -1,4 +1,5 @@
 use warp_core::ui::appearance::Appearance;
+use warpui::geometry::vector::vec2f;
 use warpui::platform::WindowStyle;
 use warpui::{App, TypedActionView};
 
@@ -229,6 +230,44 @@ fn test_right_is_a_noop_for_leaf_items() {
                 menu.selected_item().unwrap().fields().unwrap().label(),
                 "root"
             );
+        });
+    })
+}
+
+#[test]
+fn test_reset_selection_clears_hovered_row() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+
+        let items = vec![
+            MenuItemFields::<()>::new("item1").into_item(),
+            MenuItemFields::<()>::new("item2").into_item(),
+        ];
+
+        let (_, menu) = app.add_window(WindowStyle::NotStealFocus, |ctx| {
+            let mut menu = Menu::<()>::new();
+            menu.set_items(items, ctx);
+            menu
+        });
+
+        menu.update(&mut app, |menu, ctx| {
+            menu.set_selected_by_index(0, ctx);
+            menu.handle_action(
+                &MenuAction::HoverSubmenuLeafNode {
+                    depth: 0,
+                    row_index: 1,
+                    position: vec2f(0., 0.),
+                },
+                ctx,
+            );
+
+            assert_eq!(menu.selected_index(), Some(0));
+            assert_eq!(menu.hovered_index(), Some(1));
+
+            menu.reset_selection(ctx);
+
+            assert_eq!(menu.selected_index(), None);
+            assert_eq!(menu.hovered_index(), None);
         });
     })
 }

--- a/app/src/tab_configs/repo_picker.rs
+++ b/app/src/tab_configs/repo_picker.rs
@@ -1,7 +1,10 @@
 use std::path::PathBuf;
 
 use warp_util::path::user_friendly_path;
-use warpui::elements::{Border, ChildView, Container, Hoverable, MouseStateHandle, Text};
+use warpui::elements::{
+    Border, ChildView, ConstrainedBox, Container, CrossAxisAlignment, Flex, Hoverable,
+    MainAxisSize, MouseStateHandle, Text,
+};
 use warpui::platform::Cursor;
 use warpui::text_layout::ClipConfig;
 use warpui::ui_components::components::UiComponentStyles;
@@ -37,6 +40,7 @@ pub struct RepoPicker {
 pub enum RepoPickerAction {
     Select(String),
     AddNewRepo,
+    HoverAddNewRepo,
 }
 
 pub enum RepoPickerEvent {
@@ -111,16 +115,35 @@ impl RepoPicker {
                     let border_fill = theme.outline();
                     let mouse_state_clone = mouse_state.clone();
                     Hoverable::new(mouse_state_clone, move |_| {
-                        Container::new(
-                            Text::new_inline(ADD_NEW_REPO_LABEL, font_family, font_size)
-                                .with_color(text_color.into())
-                                .finish(),
+                        ConstrainedBox::new(
+                            Container::new(
+                                Flex::row()
+                                    .with_main_axis_size(MainAxisSize::Max)
+                                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                                    .with_child(
+                                        Text::new_inline(
+                                            ADD_NEW_REPO_LABEL,
+                                            font_family,
+                                            font_size,
+                                        )
+                                        .with_color(text_color.into())
+                                        .finish(),
+                                    )
+                                    .finish(),
+                            )
+                            .with_horizontal_padding(8.)
+                            .with_vertical_padding(6.)
+                            .with_background(bg)
+                            .with_border(Border::top(1.).with_border_fill(border_fill))
+                            .finish(),
                         )
-                        .with_horizontal_padding(8.)
-                        .with_vertical_padding(6.)
-                        .with_background(bg)
-                        .with_border(Border::top(1.).with_border_fill(border_fill))
+                        .with_width(width)
                         .finish()
+                    })
+                    .on_hover(|is_hovered, ctx, _, _| {
+                        if is_hovered {
+                            ctx.dispatch_typed_action(RepoPickerAction::HoverAddNewRepo);
+                        }
                     })
                     .on_click(|ctx, _, _| {
                         ctx.dispatch_typed_action(RepoPickerAction::AddNewRepo);
@@ -241,6 +264,11 @@ impl TypedActionView for RepoPicker {
                     dropdown.close(ctx);
                 });
                 ctx.emit(RepoPickerEvent::RequestAddRepo);
+            }
+            RepoPickerAction::HoverAddNewRepo => {
+                self.dropdown.update(ctx, |dropdown, ctx| {
+                    dropdown.reset_selection(ctx);
+                });
             }
         }
     }

--- a/app/src/view_components/filterable_dropdown.rs
+++ b/app/src/view_components/filterable_dropdown.rs
@@ -255,7 +255,6 @@ where
         self.items.len()
     }
 
-    #[expect(dead_code)]
     pub fn reset_selection(&mut self, ctx: &mut ViewContext<Self>) {
         self.dropdown.update(ctx, |dropdown, ctx| {
             dropdown.reset_selection(ctx);


### PR DESCRIPTION
Fixes #9453

## Summary
- make the tab config repo picker `+ Add new repo...` footer hover background span the full dropdown width
- clear the menu selection and hovered row when the sticky footer is hovered so repo rows do not remain highlighted behind the footer state
- add focused menu coverage for clearing the hovered row on selection reset

## Testing
- `cargo fmt --check`
- `./script/format --check`
- `git diff --check`
- `cargo test -p warp menu_tests::test_reset_selection_clears_hovered_row` attempted, but blocked before tests by missing local Xcode Metal Toolchain: `cannot execute tool 'metal' due to missing Metal Toolchain; use: xcodebuild -downloadComponent MetalToolchain`

## Changelog
CHANGELOG-BUG-FIX: Fix repo selector footer hover states in tab config modals.