### PR TITLE
Fix some release workflow inefficiencies.

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -158,6 +158,7 @@ jobs:
       - uses: ./.github/actions/prepare_environment
         with:
           target_os: macos
+          cache_key: ${{ matrix.arch }}
           is_self_hosted: false
           ref: ${{ needs.prepare_release.outputs.release_branch }}
           install_release_deps: true
@@ -425,6 +426,7 @@ jobs:
       - uses: ./.github/actions/prepare_environment
         with:
           target_os: macos
+          cache_key: ${{ matrix.arch }}
           is_self_hosted: false
           ref: ${{ needs.prepare_release.outputs.release_branch }}
           install_release_deps: true

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1160,6 +1160,13 @@ jobs:
 
       # Bundle the CLI packages
 
+      # Clear the settings schema cache so that the next build will regenerate it.
+      # This is necessary because the set of features enabled for the CLI build
+      # may be different from the app build.
+      - name: Reset settings schema cache
+        run: |
+          rm -f $SETTINGS_SCHEMA_CACHE
+
       - name: Download CLI build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/script/linux/bundle
+++ b/script/linux/bundle
@@ -279,7 +279,7 @@ fi
 if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
   echo "Preparing CLI resources directory"
   BUNDLED_RESOURCES_DIR="$OUT_DIR/resources"
-  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE"
+  CARGO_FEATURES="$FEATURES" "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE"
 fi
 
 

--- a/script/linux/bundle
+++ b/script/linux/bundle
@@ -219,6 +219,7 @@ fi
 if [[ -n "$EXTRA_FEATURES" ]]; then
   FEATURES="$FEATURES,$EXTRA_FEATURES"
 fi
+export CARGO_FEATURES="$FEATURES"
 
 BUNDLE_ID="dev.warp.$APP_NAME"
 EXECUTABLE_PATH="$CARGO_TARGET_OUTPUT_DIR/$WARP_BIN"
@@ -279,7 +280,7 @@ fi
 if [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
   echo "Preparing CLI resources directory"
   BUNDLED_RESOURCES_DIR="$OUT_DIR/resources"
-  CARGO_FEATURES="$FEATURES" "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE"
+  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE"
 fi
 
 

--- a/script/macos/bundle
+++ b/script/macos/bundle
@@ -521,7 +521,7 @@ if [[ "$ARTIFACT" == "app" ]]; then
 
   BUNDLED_RESOURCES_DIR="$BUNDLE_DIR/$WARP_APP_NAME.app/Contents/Resources"
   echo "Preparing bundled resources..."
-  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE"
+  CARGO_FEATURES="$FEATURES" "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE"
 
   "$WORKSPACE_ROOT_DIR/script/compile_icon" "$RELEASE_CHANNEL" "$BUNDLE_DIR/$WARP_APP_NAME.app"
 

--- a/script/macos/bundle
+++ b/script/macos/bundle
@@ -621,7 +621,7 @@ elif [[ "$ARTIFACT" == "cli" || "$ARTIFACT" == "warpctrl" ]]; then
 
   echo "Preparing CLI resources directory"
   BUNDLED_RESOURCES_DIR="$OUT_DIR/resources"
-  "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE"
+  CARGO_FEATURES="$FEATURES" "$WORKSPACE_ROOT_DIR/script/prepare_bundled_resources" "$BUNDLED_RESOURCES_DIR" "$RELEASE_CHANNEL" "$CARGO_PROFILE"
 
 
   # Set the primary binary path to output.

--- a/script/prepare_bundled_resources
+++ b/script/prepare_bundled_resources
@@ -141,6 +141,9 @@ if [ "${SKIP_SETTINGS_SCHEMA:-}" != "1" ]; then
     if [ -n "$CARGO_PROFILE" ]; then
       SCHEMA_CMD+=(--profile "$CARGO_PROFILE")
     fi
+    if [ -n "$CARGO_FEATURES" ]; then
+      SCHEMA_CMD+=(--features "$CARGO_FEATURES")
+    fi
     SCHEMA_CMD+=(--manifest-path "$REPO_ROOT/Cargo.toml" --bin generate_settings_schema --)
     if [ -n "$CHANNEL" ]; then
       SCHEMA_CMD+=(--channel "$CHANNEL")

--- a/script/windows/bundle.ps1
+++ b/script/windows/bundle.ps1
@@ -179,10 +179,10 @@ Write-Output "Built for $ARCH with executable at $BINARY_PATH"
 
 # Prepare bundled resources
 $BUNDLED_RESOURCES_DIR = "$CARGO_TARGET_OUTPUT_DIR\resources"
-Write-Output "Preparing bundled resources..."
-& "$WINDOWS_INSTALLER_DIR\prepare_bundled_resources.ps1" -DestinationDir "$BUNDLED_RESOURCES_DIR" -Channel "$CHANNEL" -CargoProfile "$CARGO_PROFILE"
+Write-Output 'Preparing bundled resources...'
+& "$WINDOWS_INSTALLER_DIR\prepare_bundled_resources.ps1" -DestinationDir "$BUNDLED_RESOURCES_DIR" -Channel "$CHANNEL" -CargoProfile "$CARGO_PROFILE" -CargoFeatures "$FEATURES"
 if (-Not $?) {
-    Write-Error "Failed to prepare bundled resources"
+    Write-Error 'Failed to prepare bundled resources'
     exit 1
 }
 

--- a/script/windows/prepare_bundled_resources.ps1
+++ b/script/windows/prepare_bundled_resources.ps1
@@ -20,7 +20,10 @@ Param(
     [String]$Channel = '',
 
     [Parameter(Mandatory = $false)]
-    [String]$CargoProfile = ''
+    [String]$CargoProfile = '',
+
+    [Parameter(Mandatory = $false)]
+    [String]$CargoFeatures = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -167,6 +170,9 @@ if ($env:SKIP_SETTINGS_SCHEMA -ne '1') {
     $SchemaCmd = @('run')
     if ($CargoProfile) {
         $SchemaCmd += @('--profile', $CargoProfile)
+    }
+    if ($CargoFeatures) {
+        $SchemaCmd += @('--features', $CargoFeatures)
     }
     $SchemaCmd += @('--manifest-path', (Join-Path $RepoRoot 'Cargo.toml'), '--bin', 'generate_settings_schema', '--')
     if ($Channel) {


### PR DESCRIPTION
## Description

Release builds were doing avoidable recompilation because some same-host cross-compilation jobs shared the default Rust cache key, and settings schema generation did not use the feature set from the primary Warp build.

This adds target-architecture cache keys to the macOS release matrices and forwards selected Cargo features through the bundled-resource preparation paths used by macOS, Linux, and Windows release bundles. That lets compatible release jobs restore the correct cache and reuse existing `warp` library artifacts while generating the settings schema.

## Testing

- `git diff --check origin/master...HEAD`
- `bash -n script/linux/bundle script/linux/bundle_install script/macos/bundle script/prepare_bundled_resources`
- Parsed `script/windows/bundle.ps1` and `script/windows/prepare_bundled_resources.ps1` with the PowerShell parser
- `actionlint .github/workflows/create_release.yml` *(reports existing ShellCheck warnings and unknown custom runner labels unrelated to this diff)*

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
