### PR TITLE
Extract a `warp_multi_agent_client` crate from the `warp` crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14783,6 +14783,7 @@ dependencies = [
  "warp_logging",
  "warp_managed_secrets",
  "warp_multi_agent_api",
+ "warp_multi_agent_client",
  "warp_ripgrep",
  "warp_search_core",
  "warp_server_auth",
@@ -15191,6 +15192,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "warp_multi_agent_client"
+version = "0.1.0"
+dependencies = [
+ "aha-reqwest-eventsource",
+ "anyhow",
+ "base64 0.22.1",
+ "cfg-if",
+ "futures",
+ "prost",
+ "thiserror 2.0.17",
+ "tracing",
+ "tracing-futures",
+ "warp_core",
+ "warp_multi_agent_api",
+ "warp_server_client",
+]
+
+[[package]]
 name = "warp_ripgrep"
 version = "0.1.0"
 dependencies = [
@@ -15294,6 +15313,7 @@ dependencies = [
  "oauth2",
  "parking_lot",
  "pathfinder_geometry",
+ "rand 0.8.6",
  "reqwest",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ warp_isolation_platform = { path = "crates/isolation_platform" }
 warp_js = { path = "crates/warp_js" }
 warp_logging = { path = "crates/warp_logging" }
 warp_managed_secrets = { path = "crates/managed_secrets" }
+warp_multi_agent_client = { path = "crates/warp_multi_agent_client" }
 warp_ripgrep = { path = "crates/warp_ripgrep" }
 warp_search_core = { path = "crates/warp_search_core" }
 warp_server_auth = { path = "crates/warp_server_auth" }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -269,6 +269,7 @@ rmcp.workspace = true
 warp_isolation_platform.workspace = true
 warp_ripgrep.workspace = true
 warp_managed_secrets.workspace = true
+warp_multi_agent_client.workspace = true
 local_control.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -737,6 +738,8 @@ agent_mode_evals = [
     "rust-embed/debug-embed",
     "warpui/log_named_telemetry_events",
     "warp_logging/agent_mode_evals",
+    "warp_multi_agent_client/agent_mode_evals",
+    "warp_server_client/agent_mode_evals",
 ]
 ambient_agents_command_line = []
 ambient_agents_image_upload = []

--- a/app/src/ai/agent/api/impl.rs
+++ b/app/src/ai/agent/api/impl.rs
@@ -8,7 +8,7 @@ use warp_multi_agent_api as api;
 use super::convert_to::convert_input;
 use super::{ConvertToAPITypeError, RequestParams, ResponseStream};
 use crate::ai::agent::redaction;
-use crate::server::server_api::ServerApi;
+use crate::server::server_api::{AIApiError, ServerApi};
 use crate::terminal::model::session::SessionType;
 
 pub async fn generate_multi_agent_output(
@@ -135,18 +135,47 @@ pub async fn generate_multi_agent_output(
         mcp_context: params.mcp_context.map(Into::into),
     };
 
-    let response_stream = server_api.generate_multi_agent_output(&request).await;
+    let response_stream =
+        warp_multi_agent_client::generate_multi_agent_output(server_api.as_ref(), &request).await;
     match response_stream {
         Ok(stream) => {
-            let output_stream = stream.take_until(cancellation_rx);
+            let output_stream = stream
+                .then(|result| async {
+                    match result {
+                        Ok(event) => Ok(event),
+                        Err(error) => Err(convert_multi_agent_client_error(error).await),
+                    }
+                })
+                .take_until(cancellation_rx);
             Ok(Box::pin(output_stream))
         }
         Err(e) => {
             let (tx, rx) = async_channel::unbounded();
-            let _ = tx.send(Err(e)).await;
+            let _ = tx
+                .send(Err(convert_multi_agent_client_error(e).await))
+                .await;
             Ok(Box::pin(rx))
         }
     }
+}
+
+async fn convert_multi_agent_client_error(
+    error: warp_multi_agent_client::Error,
+) -> Arc<AIApiError> {
+    let error = match error {
+        warp_multi_agent_client::Error::Authentication(error)
+        | warp_multi_agent_client::Error::AmbientHeaders(error) => AIApiError::Other(error),
+        warp_multi_agent_client::Error::Base64Decode(error) => {
+            AIApiError::Other(anyhow::Error::from(error))
+        }
+        warp_multi_agent_client::Error::ProtobufDecode(error) => {
+            AIApiError::Other(anyhow::Error::from(error))
+        }
+        warp_multi_agent_client::Error::EventSource(error) => {
+            AIApiError::from_stream_error("GenerateMultiAgentOutput", *error).await
+        }
+    };
+    Arc::new(error)
 }
 
 fn api_keys_with_warp_credit_fallback_setting(

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -22,22 +22,17 @@ use ::http::header::CONTENT_LENGTH;
 use ai::AIClient;
 use anyhow::{anyhow, Context, Result};
 use auth::AuthClient;
-use base64::prelude::BASE64_URL_SAFE;
-use base64::Engine;
 use block::BlockClient;
 use channel_versions::ChannelVersions;
 use chrono::{DateTime, FixedOffset};
-use futures::StreamExt;
 use instant::Instant;
 use managed_mcp::ManagedMcpClient;
 use object::ObjectClient;
 use parking_lot::Mutex;
-use prost::Message;
 use referral::ReferralsClient;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use team::TeamClient;
-use tracing_futures::Instrument as _;
 use url::Url;
 use warp_core::context_flag::ContextFlag;
 use warp_core::errors::{register_error, AnyhowErrorExt, ErrorExt};
@@ -82,22 +77,6 @@ const WARP_ERROR_CODE_OUT_OF_CREDITS: &str = "OUT_OF_CREDITS";
 
 /// Error code indicating the user has reached their cloud agent concurrency limit.
 const WARP_ERROR_CODE_AT_CAPACITY: &str = "AT_CLOUD_AGENT_CAPACITY";
-
-#[cfg(feature = "agent_mode_evals")]
-pub const EVAL_USER_ID_HEADER: &str = "X-Eval-User-ID";
-
-/// IDs in the staging database that were created specifically for evals.
-/// These users have a clean state where they haven't been referred nor have referred anyone (which causes a popup in the client).
-/// DO NOT REMOVE OR CHANGE THESE USERS!
-///
-/// Keep this list in sync with `script/populate_agent_mode_eval_user.sql`
-/// in warp-server. Those rows need to exist in the DB so the authz user loader
-/// can resolve these IDs during task creation; otherwise the server will 500
-/// on every eval request with a nil-deref in `UserIDFromUser`.
-#[cfg(feature = "agent_mode_evals")]
-const EVAL_USER_IDS: [i32; 11] = [
-    2162, 2164, 2165, 2166, 2167, 2168, 2169, 2172, 2173, 2174, 2175,
-];
 
 /// ResponseType received by Client
 #[derive(thiserror::Error, Debug, Serialize, Deserialize)]
@@ -291,7 +270,10 @@ impl AIApiError {
 
     /// Format a stream error into a human-readable error message. This will read the response
     /// body if there is one.
-    async fn from_stream_error(stream_type: &'static str, err: reqwest_eventsource::Error) -> Self {
+    pub(crate) async fn from_stream_error(
+        stream_type: &'static str,
+        err: reqwest_eventsource::Error,
+    ) -> Self {
         match err {
             reqwest_eventsource::Error::InvalidStatusCode(
                 http::StatusCode::TOO_MANY_REQUESTS,
@@ -379,18 +361,6 @@ pub enum TranscribeError {
     Other(#[from] anyhow::Error),
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(target_family = "wasm")] {
-        // The WASM version of this type has no bound on `Send`, which is not implemented on
-        // `wasm_bindgen::JsValue`, which is ultimately used in reqwest_eventsource::Error. Furthermore,
-        // `Send` is an unnecessary bound when targeting wasm because the browser is single-threaded (and
-        // we don't leverage WebWorkers for async execution in WoW).
-        pub type AIOutputStream<T> = futures::stream::LocalBoxStream<'static, Result<T, Arc<AIApiError>>>;
-    } else {
-        pub type AIOutputStream<T> = futures::stream::BoxStream<'static, Result<T, Arc<AIApiError>>>;
-    }
-}
-
 /// An API wrapper struct with methods to requests to warp-server.
 ///
 /// Prefer NOT adding new methods directly on this struct; instead, add to one of the existing
@@ -401,9 +371,6 @@ pub struct ServerApi {
     // TODO(jeff): Make `TelemetryApi` another type of client, and move it off `ServerApi`.
     telemetry_api: TelemetryApi,
     last_server_time: Arc<Mutex<Option<ServerTime>>>,
-
-    #[cfg(feature = "agent_mode_evals")]
-    eval_user_id: Option<i32>,
 }
 
 impl ServerApi {
@@ -443,29 +410,13 @@ impl ServerApi {
         iap_token_provider: Option<Arc<dyn http_client::iap::IapTokenProvider>>,
         telemetry_api: TelemetryApi,
     ) -> Self {
-        // We generate a random user ID for evals so we can run evals in parallel.
-        #[cfg(feature = "agent_mode_evals")]
-        let eval_user_id = {
-            use rand::Rng;
-            Some(EVAL_USER_IDS[rand::thread_rng().gen_range(0..EVAL_USER_IDS.len())])
-        };
-
         let graphql_routing = GraphqlRoutingConfig {
             #[cfg(feature = "agent_mode_evals")]
             path_prefix: Some("/agent-mode-evals".to_string()),
             #[cfg(not(feature = "agent_mode_evals"))]
             path_prefix: None,
         };
-        #[cfg(feature = "agent_mode_evals")]
-        let mut authenticated_graphql = AuthenticatedGraphqlConfig::default();
-        #[cfg(not(feature = "agent_mode_evals"))]
         let authenticated_graphql = AuthenticatedGraphqlConfig::default();
-        #[cfg(feature = "agent_mode_evals")]
-        if let Some(eval_user_id) = eval_user_id {
-            authenticated_graphql
-                .headers
-                .insert(EVAL_USER_ID_HEADER.to_string(), eval_user_id.to_string());
-        }
         let base_client = Arc::new(BaseClient::new(
             client,
             auth_state,
@@ -480,8 +431,6 @@ impl ServerApi {
             base_client,
             telemetry_api,
             last_server_time: Arc::new(Mutex::new(None)),
-            #[cfg(feature = "agent_mode_evals")]
-            eval_user_id,
         }
     }
 
@@ -1129,136 +1078,6 @@ impl ServerApi {
             Err(e) => {
                 log::warn!("Error while sending request: {e:?}");
                 Err(TranscribeError::Transport)
-            }
-        }
-    }
-
-    pub async fn generate_multi_agent_output(
-        &self,
-        request: &warp_multi_agent_api::Request,
-    ) -> std::result::Result<AIOutputStream<warp_multi_agent_api::ResponseEvent>, Arc<AIApiError>>
-    {
-        let auth_token = self
-            .get_or_refresh_access_token()
-            .await
-            .map_err(Into::into)
-            .map_err(Arc::new)?;
-
-        let is_passive = request.input.as_ref().is_some_and(|input| {
-            matches!(
-                input.r#type,
-                Some(warp_multi_agent_api::request::input::Type::GeneratePassiveSuggestions(_))
-            )
-        });
-        let is_evals = cfg!(feature = "agent_mode_evals");
-        let url = format!(
-            "{}/{}/{}",
-            ChannelState::server_root_url(),
-            if is_evals { "agent-mode-evals" } else { "ai" },
-            if is_passive {
-                "passive-suggestions"
-            } else {
-                "multi-agent"
-            }
-        );
-
-        let ambient_policy = if is_passive {
-            // Do not include cloud agent workload metadata in passive suggestion requests - they
-            // read from the main conversation, but cannot modify it.
-            AmbientHeaderPolicy::omit_all()
-        } else {
-            AmbientHeaderPolicy::workload_only()
-        };
-
-        let mut request_builder = self
-            .base_client
-            .http_client()
-            .post(url)
-            .proto(request)
-            .prevent_sleep("Agent Mode request in-progress");
-        if let Some(token) = auth_token.as_bearer_token() {
-            request_builder = request_builder.bearer_auth(token);
-        }
-
-        for (name, value) in self
-            .ambient_headers(ambient_policy)
-            .await
-            .map_err(Into::into)
-            .map_err(Arc::new)?
-        {
-            request_builder = request_builder.header(name, value);
-        }
-
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "agent_mode_evals")] {
-                let mut request = request_builder;
-                if let Some(eval_user_id) = self.eval_user_id {
-                    request = request.header(EVAL_USER_ID_HEADER, eval_user_id.to_string());
-                }
-            } else {
-                let request = request_builder;
-            }
-        }
-
-        let raw_stream = self.wrap_eventsource_with_iap_detection(request.eventsource());
-        let output_stream = raw_stream.filter_map(|event| async {
-            let result = match event {
-                Ok(reqwest_eventsource::Event::Message(message_event)) => {
-                    match BASE64_URL_SAFE.decode(message_event.data.trim_matches('"')) {
-                        Ok(decoded_data) => {
-                            let action = warp_multi_agent_api::ResponseEvent::decode(
-                                decoded_data.as_slice(),
-                            );
-                            Some(action.map_err(|e| AIApiError::Other(anyhow::Error::from(e))))
-                        }
-                        Err(e) => Some(Err(AIApiError::Other(anyhow::Error::from(e)))),
-                    }
-                }
-                Ok(reqwest_eventsource::Event::Open) => None,
-                Err(err) => Some(Err(AIApiError::from_stream_error(
-                    "GenerateMultiAgentOutput",
-                    err,
-                )
-                .await)),
-            }
-            // Wrap errors in an Arc so that they're cloneable by downstream event
-            // handlers.
-            .map(|item| item.map_err(Arc::new));
-            result
-        });
-
-        // Once we get the init event, add some identifiers to the trace span.
-        let output_stream = output_stream.inspect(|event| {
-            if let Ok(event) = &event {
-                match &event.r#type {
-                    Some(warp_multi_agent_api::response_event::Type::Init(init)) => {
-                        tracing::info!("StreamInit");
-                        tracing::Span::current().record("conversation_id", &init.conversation_id);
-                        tracing::Span::current().record("request_id", &init.request_id);
-                        tracing::Span::current().record("run_id", &init.run_id);
-                    }
-                    Some(warp_multi_agent_api::response_event::Type::Finished(_finished)) => {
-                        tracing::info!("StreamFinished");
-                    }
-                    _ => {}
-                }
-            }
-        });
-
-        // Wrap the output stream with a trace span.
-        let output_stream = output_stream.instrument(tracing::info_span!(
-            "generate_multi_agent_output",
-            tags.cloud_agent = true,
-            conversation_id = tracing::field::Empty,
-            request_id = tracing::field::Empty,
-            run_id = tracing::field::Empty,
-        ));
-
-        cfg_if::cfg_if! {
-            if #[cfg(target_family = "wasm")] {
-                Ok(output_stream.boxed_local())
-            } else {
-                Ok(output_stream.boxed())
             }
         }
     }

--- a/crates/warp_multi_agent_client/Cargo.toml
+++ b/crates/warp_multi_agent_client/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "warp_multi_agent_client"
+version = "0.1.0"
+edition = "2024"
+authors.workspace = true
+publish.workspace = true
+license.workspace = true
+
+[features]
+agent_mode_evals = ["warp_server_client/agent_mode_evals"]
+
+[dependencies]
+anyhow.workspace = true
+base64.workspace = true
+cfg-if.workspace = true
+futures.workspace = true
+prost.workspace = true
+reqwest-eventsource.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+tracing-futures.workspace = true
+warp_core.workspace = true
+warp_multi_agent_api.workspace = true
+warp_server_client.workspace = true

--- a/crates/warp_multi_agent_client/src/lib.rs
+++ b/crates/warp_multi_agent_client/src/lib.rs
@@ -1,0 +1,170 @@
+use base64::Engine as _;
+use base64::prelude::BASE64_URL_SAFE;
+use futures::StreamExt as _;
+use prost::Message as _;
+use tracing_futures::Instrument as _;
+use warp_core::channel::ChannelState;
+#[cfg(feature = "agent_mode_evals")]
+use warp_server_client::base_client::EVAL_USER_ID_HEADER;
+use warp_server_client::base_client::{AmbientHeaderPolicy, BaseClient};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Failed to authenticate multi-agent request")]
+    Authentication(#[source] anyhow::Error),
+
+    #[error("Failed to resolve ambient headers for multi-agent request")]
+    AmbientHeaders(#[source] anyhow::Error),
+
+    #[error("Failed to decode base64 multi-agent response event")]
+    Base64Decode(#[source] base64::DecodeError),
+
+    #[error("Failed to decode protobuf multi-agent response event")]
+    ProtobufDecode(#[source] prost::DecodeError),
+
+    #[error("Multi-agent eventsource stream failed: {0:?}")]
+    EventSource(Box<reqwest_eventsource::Error>),
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(target_family = "wasm")] {
+        /// A multi-agent response event stream without an unnecessary `Send` bound on WASM.
+        pub type OutputStream = futures::stream::LocalBoxStream<
+            'static,
+            Result<warp_multi_agent_api::ResponseEvent, Error>,
+        >;
+    } else {
+        /// A multi-agent response event stream that can be sent between native threads.
+        pub type OutputStream = futures::stream::BoxStream<
+            'static,
+            Result<warp_multi_agent_api::ResponseEvent, Error>,
+        >;
+    }
+}
+
+/// Opens a decoded multi-agent response event stream.
+pub async fn generate_multi_agent_output(
+    client: &BaseClient,
+    request: &warp_multi_agent_api::Request,
+) -> Result<OutputStream, Error> {
+    let auth_token = client
+        .get_or_refresh_access_token()
+        .await
+        .map_err(Error::Authentication)?;
+    let is_passive = is_passive_suggestion_request(request);
+    let url = endpoint_url(is_passive);
+
+    let mut request_builder = client
+        .http_client()
+        .post(url)
+        .proto(request)
+        .prevent_sleep("Agent Mode request in-progress");
+    if let Some(token) = auth_token.as_bearer_token() {
+        request_builder = request_builder.bearer_auth(token);
+    }
+
+    for (name, value) in client
+        .ambient_headers(ambient_policy(is_passive))
+        .await
+        .map_err(Error::AmbientHeaders)?
+    {
+        request_builder = request_builder.header(name, value);
+    }
+
+    #[cfg(feature = "agent_mode_evals")]
+    if let Some(eval_user_id) = client.eval_user_id() {
+        request_builder = request_builder.header(EVAL_USER_ID_HEADER, eval_user_id.to_string());
+    }
+
+    let raw_stream = client.wrap_eventsource_with_iap_detection(request_builder.eventsource());
+    let output_stream = raw_stream.filter_map(|event| async {
+        match event {
+            Ok(reqwest_eventsource::Event::Message(message_event)) => {
+                Some(decode_response_event(&message_event.data))
+            }
+            Ok(reqwest_eventsource::Event::Open) => None,
+            Err(error) => Some(Err(Error::EventSource(Box::new(error)))),
+        }
+    });
+
+    // Once we get the init event, add some identifiers to the trace span.
+    let output_stream = output_stream.inspect(|event| {
+        if let Ok(event) = &event {
+            match &event.r#type {
+                Some(warp_multi_agent_api::response_event::Type::Init(init)) => {
+                    tracing::info!("StreamInit");
+                    tracing::Span::current().record("conversation_id", &init.conversation_id);
+                    tracing::Span::current().record("request_id", &init.request_id);
+                    tracing::Span::current().record("run_id", &init.run_id);
+                }
+                Some(warp_multi_agent_api::response_event::Type::Finished(_finished)) => {
+                    tracing::info!("StreamFinished");
+                }
+                _ => {}
+            }
+        }
+    });
+    // Wrap the output stream with a trace span.
+    let output_stream = output_stream.instrument(tracing::info_span!(
+        "generate_multi_agent_output",
+        tags.cloud_agent = true,
+        conversation_id = tracing::field::Empty,
+        request_id = tracing::field::Empty,
+        run_id = tracing::field::Empty,
+    ));
+
+    cfg_if::cfg_if! {
+        if #[cfg(target_family = "wasm")] {
+            Ok(output_stream.boxed_local())
+        } else {
+            Ok(output_stream.boxed())
+        }
+    }
+}
+
+fn is_passive_suggestion_request(request: &warp_multi_agent_api::Request) -> bool {
+    request.input.as_ref().is_some_and(|input| {
+        matches!(
+            input.r#type,
+            Some(warp_multi_agent_api::request::input::Type::GeneratePassiveSuggestions(_))
+        )
+    })
+}
+
+fn endpoint_url(is_passive: bool) -> String {
+    format!(
+        "{}/{}/{}",
+        ChannelState::server_root_url(),
+        if cfg!(feature = "agent_mode_evals") {
+            "agent-mode-evals"
+        } else {
+            "ai"
+        },
+        if is_passive {
+            "passive-suggestions"
+        } else {
+            "multi-agent"
+        }
+    )
+}
+
+fn ambient_policy(is_passive: bool) -> AmbientHeaderPolicy {
+    if is_passive {
+        // Passive suggestions read from the main conversation, but cannot modify it.
+        AmbientHeaderPolicy::omit_all()
+    } else {
+        AmbientHeaderPolicy::workload_only()
+    }
+}
+
+fn decode_response_event(data: &str) -> Result<warp_multi_agent_api::ResponseEvent, Error> {
+    let decoded_data = BASE64_URL_SAFE
+        .decode(data.trim_matches('"'))
+        .map_err(Error::Base64Decode)?;
+    warp_multi_agent_api::ResponseEvent::decode(decoded_data.as_slice())
+        .map_err(Error::ProtobufDecode)
+}
+
+#[cfg(test)]
+#[path = "lib_tests.rs"]
+mod tests;

--- a/crates/warp_multi_agent_client/src/lib_tests.rs
+++ b/crates/warp_multi_agent_client/src/lib_tests.rs
@@ -1,0 +1,77 @@
+use base64::Engine as _;
+use base64::prelude::BASE64_URL_SAFE;
+use prost::Message as _;
+use warp_server_client::base_client::AmbientHeaderPolicy;
+
+use super::{
+    Error, ambient_policy, decode_response_event, endpoint_url, is_passive_suggestion_request,
+};
+
+#[test]
+fn detects_passive_suggestion_requests() {
+    let regular = warp_multi_agent_api::Request::default();
+    let passive = warp_multi_agent_api::Request {
+        input: Some(warp_multi_agent_api::request::Input {
+            r#type: Some(
+                warp_multi_agent_api::request::input::Type::GeneratePassiveSuggestions(
+                    Default::default(),
+                ),
+            ),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    assert!(!is_passive_suggestion_request(&regular));
+    assert!(is_passive_suggestion_request(&passive));
+}
+
+#[test]
+fn routes_regular_and_passive_requests_to_distinct_endpoints() {
+    let prefix = if cfg!(feature = "agent_mode_evals") {
+        "agent-mode-evals"
+    } else {
+        "ai"
+    };
+
+    assert!(endpoint_url(false).ends_with(&format!("/{prefix}/multi-agent")));
+    assert!(endpoint_url(true).ends_with(&format!("/{prefix}/passive-suggestions")));
+}
+
+#[test]
+fn selects_endpoint_specific_ambient_header_policies() {
+    assert_eq!(ambient_policy(false), AmbientHeaderPolicy::workload_only());
+    assert_eq!(ambient_policy(true), AmbientHeaderPolicy::omit_all());
+}
+
+#[test]
+fn decodes_quoted_base64_protobuf_response_event() {
+    let expected = warp_multi_agent_api::ResponseEvent::default();
+    let encoded = BASE64_URL_SAFE.encode(expected.encode_to_vec());
+
+    let decoded = decode_response_event(&format!("\"{encoded}\"")).unwrap();
+
+    assert_eq!(decoded, expected);
+}
+
+#[test]
+fn distinguishes_base64_and_protobuf_decode_errors() {
+    assert!(matches!(
+        decode_response_event("%"),
+        Err(Error::Base64Decode(_))
+    ));
+
+    let invalid_protobuf = BASE64_URL_SAFE.encode([0xff]);
+    assert!(matches!(
+        decode_response_event(&invalid_protobuf),
+        Err(Error::ProtobufDecode(_))
+    ));
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[test]
+fn native_output_stream_is_send() {
+    fn assert_send<T: Send>() {}
+
+    assert_send::<super::OutputStream>();
+}

--- a/crates/warp_server_client/Cargo.toml
+++ b/crates/warp_server_client/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 license.workspace = true
 
 [features]
+agent_mode_evals = ["dep:rand"]
 integration_tests = ["warp_server_auth/integration_tests"]
 skip_login = ["warp_server_auth/skip_login"]
 test-util = ["cloud_object_client/test-util", "cloud_objects/test-util", "dep:mockall"]
@@ -41,6 +42,7 @@ parking_lot.workspace = true
 pathfinder_geometry.workspace = true
 reqwest.workspace = true
 reqwest-eventsource.workspace = true
+rand = { workspace = true, optional = true }
 schemars = { version = "1", features = ["uuid1"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/warp_server_client/src/base_client.rs
+++ b/crates/warp_server_client/src/base_client.rs
@@ -19,6 +19,16 @@ pub const CLOUD_AGENT_ID_HEADER: &str = "X-Warp-Cloud-Agent-ID";
 
 /// Header used to communicate the source of an agent run.
 pub const AGENT_SOURCE_HEADER: &str = "X-Oz-Api-Source";
+/// Header used to route agent-mode eval requests to a selected eval user.
+pub const EVAL_USER_ID_HEADER: &str = "X-Eval-User-ID";
+
+/// IDs in the staging database that were created specifically for evals.
+///
+/// Keep this list in sync with `script/populate_agent_mode_eval_user.sql` in warp-server.
+#[cfg(feature = "agent_mode_evals")]
+const EVAL_USER_IDS: [i32; 11] = [
+    2162, 2164, 2165, 2166, 2167, 2168, 2169, 2172, 2173, 2174, 2175,
+];
 
 /// Duration for which an ambient agent workload token is valid.
 const AMBIENT_WORKLOAD_TOKEN_DURATION: Duration = Duration::from_secs(3 * 60 * 60);
@@ -106,6 +116,8 @@ pub struct BaseClient {
     graphql_routing: GraphqlRoutingConfig,
     authenticated_graphql: AuthenticatedGraphqlConfig,
     iap_token_provider: Option<Arc<dyn http_client::iap::IapTokenProvider>>,
+    #[cfg(feature = "agent_mode_evals")]
+    eval_user_id: Option<i32>,
 }
 
 impl BaseClient {
@@ -126,6 +138,19 @@ impl BaseClient {
                 true
             }
         });
+        // We generate one random user ID per client so evals can run in parallel.
+        #[cfg(feature = "agent_mode_evals")]
+        let eval_user_id = {
+            use rand::Rng as _;
+
+            Some(EVAL_USER_IDS[rand::thread_rng().gen_range(0..EVAL_USER_IDS.len())])
+        };
+        #[cfg(feature = "agent_mode_evals")]
+        if let Some(eval_user_id) = eval_user_id {
+            authenticated_graphql
+                .headers
+                .insert(EVAL_USER_ID_HEADER.to_string(), eval_user_id.to_string());
+        }
         let auth_session = Arc::new(AuthSession::new(
             client.clone(),
             auth_state.clone(),
@@ -142,11 +167,17 @@ impl BaseClient {
             graphql_routing,
             authenticated_graphql,
             iap_token_provider,
+            #[cfg(feature = "agent_mode_evals")]
+            eval_user_id,
         }
     }
 
     /// Returns whether authenticated GraphQL decoration would override BaseClient-owned headers.
     fn is_reserved_authenticated_graphql_header(name: &str) -> bool {
+        #[cfg(feature = "agent_mode_evals")]
+        if name.eq_ignore_ascii_case(EVAL_USER_ID_HEADER) {
+            return true;
+        }
         [
             http::header::AUTHORIZATION.as_str(),
             http::header::CONTENT_TYPE.as_str(),
@@ -180,6 +211,18 @@ impl BaseClient {
 
     pub fn user_id(&self) -> Option<UserUid> {
         self.auth_state.user_id()
+    }
+
+    /// Returns the eval user selected for this client, if eval routing is enabled.
+    pub fn eval_user_id(&self) -> Option<i32> {
+        #[cfg(feature = "agent_mode_evals")]
+        {
+            self.eval_user_id
+        }
+        #[cfg(not(feature = "agent_mode_evals"))]
+        {
+            None
+        }
     }
 
     pub fn access_token_ignoring_validity(&self) -> Option<String> {

--- a/crates/warp_server_client/src/base_client_tests.rs
+++ b/crates/warp_server_client/src/base_client_tests.rs
@@ -9,6 +9,9 @@ use super::{
     AuthenticatedGraphqlConfig, BaseClient, CLOUD_AGENT_ID_HEADER, GraphqlRoutingConfig,
     HeaderOverride,
 };
+#[cfg(feature = "agent_mode_evals")]
+use super::{EVAL_USER_ID_HEADER, EVAL_USER_IDS};
+
 struct StaticIapTokenProvider;
 
 impl http_client::iap::IapTokenProvider for StaticIapTokenProvider {
@@ -55,6 +58,26 @@ fn iap_proxy_auth_header_uses_configured_provider() {
             http_client::iap::IAP_PROXY_AUTH_HEADER,
             "Bearer iap-token".to_string()
         ))
+    );
+}
+
+#[cfg(feature = "agent_mode_evals")]
+#[test]
+fn eval_user_id_is_selected_once_and_used_for_authenticated_graphql() {
+    let client = client();
+    let eval_user_id = client.eval_user_id().unwrap();
+
+    assert!(EVAL_USER_IDS.contains(&eval_user_id));
+
+    let options = block_on(client.graphql_request_options(None)).unwrap();
+    let eval_user_id = eval_user_id.to_string();
+    assert_eq!(
+        options.headers.get(EVAL_USER_ID_HEADER).map(String::as_str),
+        Some(eval_user_id.as_str())
+    );
+    assert_eq!(
+        client.eval_user_id().map(|id| id.to_string()),
+        Some(eval_user_id)
     );
 }
 
@@ -152,7 +175,7 @@ fn authenticated_graphql_configuration_cannot_override_base_client_owned_headers
         CLOUD_AGENT_ID_HEADER.to_ascii_lowercase(),
         "malicious".to_string(),
     );
-    headers.insert("X-Eval-User-ID".to_string(), "1234".to_string());
+    headers.insert("x-eval-user-id".to_string(), "1234".to_string());
     let client = BaseClient::new(
         Arc::new(http_client::Client::new()),
         Arc::new(AuthState::new_for_test()),
@@ -178,8 +201,18 @@ fn authenticated_graphql_configuration_cannot_override_base_client_owned_headers
             .headers
             .contains_key(&CLOUD_AGENT_ID_HEADER.to_ascii_lowercase())
     );
+    #[cfg(feature = "agent_mode_evals")]
+    {
+        let eval_user_id = client.eval_user_id().unwrap().to_string();
+        assert!(!options.headers.contains_key("x-eval-user-id"));
+        assert_eq!(
+            options.headers.get(EVAL_USER_ID_HEADER).map(String::as_str),
+            Some(eval_user_id.as_str())
+        );
+    }
+    #[cfg(not(feature = "agent_mode_evals"))]
     assert_eq!(
-        options.headers.get("X-Eval-User-ID").map(String::as_str),
+        options.headers.get("x-eval-user-id").map(String::as_str),
         Some("1234")
     );
 }


### PR DESCRIPTION
## Description
Extracts multi-agent request and response transport from `ServerApi` into a dedicated `warp_multi_agent_client` crate. This gives multi-agent networking a reusable lower-level boundary instead of coupling it to the `warp` app crate.

The new client owns endpoint routing, authentication, ambient and eval headers, IAP-aware SSE setup, and response decoding. It exposes typed transport and decoding errors; the `warp` crate converts those errors into `AIApiError`, preserving the existing asynchronous status-body and 429/out-of-credits handling. Eval-user selection also moves into `BaseClient` so lower-level clients can access the selected identity consistently.

> [!NOTE]
> note from dstern: this should also slightly help with compilation times - by pushing this function into a separate crate, we'll now be doing monomorphizing of/codegen for serialization code (for the proto messages) in that crates, and not in `warp`. 

## Testing
- `./script/format`
- `cargo nextest run -p warp_multi_agent_client --features agent_mode_evals --no-tests=pass`
- Focused `warp_server_client` eval and non-eval header-ownership tests
- `cargo check -p warp --tests --features agent_mode_evals`
- Full WASM clippy with warnings denied

Not manually tested; this is a behavior-preserving internal extraction covered by unit tests and native/WASM compilation.

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>