### PR TITLE
Keep htab position consistent when collapsing/expanding groups

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -19312,8 +19312,14 @@ impl Workspace {
         let positioned_container =
             SavePosition::new(positioned_container, &htab_group_position_id(group_id)).finish();
 
-        // Flex from member count (not collapse state) so layout doesn't shift when the group expands/collapses.
-        let group_flex = 1.0 + run_len as f32;
+        // Flex = header + one per member so the group shrinks proportionally
+        // with sibling tabs. A collapsed group renders only its header, so it
+        // should claim a single slot's worth of flex.
+        let group_flex = if is_collapsed {
+            1.0
+        } else {
+            1.0 + run_len as f32
+        };
         Shrinkable::new(group_flex, positioned_container).finish()
     }
 
@@ -20236,8 +20242,25 @@ impl Workspace {
             }
         }
 
-        // Placeholder to make sure the flex row expands across the entire width of the app.
-        tab_bar.add_child(Shrinkable::new(0.5, Empty::new().finish()).finish());
+        // Trailing spacer fills leftover width. We also re-add the flex that
+        // collapsed groups give up (one per hidden member): parking it at the far
+        // end keeps the bar's total flex constant across collapse/expand — so group
+        // headers don't shift — without collapsed groups stealing width from the
+        // tabs to their left. Mirrors the group flex in render_horizontal_tab_group.
+        let collapsed_member_flex: f32 = if FeatureFlag::GroupedTabs.is_enabled() {
+            self.tabs
+                .iter()
+                .filter(|tab| {
+                    tab.group_id
+                        .and_then(|gid| self.tab_groups.get(&gid))
+                        .is_some_and(|group| group.collapsed)
+                })
+                .count() as f32
+        } else {
+            0.0
+        };
+        tab_bar
+            .add_child(Shrinkable::new(0.5 + collapsed_member_flex, Empty::new().finish()).finish());
 
         self.add_configurable_right_side_tab_bar_controls(
             &mut tab_bar,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -20259,8 +20259,9 @@ impl Workspace {
         } else {
             0.0
         };
-        tab_bar
-            .add_child(Shrinkable::new(0.5 + collapsed_member_flex, Empty::new().finish()).finish());
+        tab_bar.add_child(
+            Shrinkable::new(0.5 + collapsed_member_flex, Empty::new().finish()).finish(),
+        );
 
         self.add_configurable_right_side_tab_bar_controls(
             &mut tab_bar,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -19230,14 +19230,23 @@ impl Workspace {
             && member_range.contains(&self.active_tab_index);
 
         let mut row = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
-        row.add_child(self.render_horizontal_tab_group_header(
-            group,
-            &mouse_states,
-            is_collapsed,
-            any_member_active,
-            appearance,
-            ctx,
-        ));
+        // The header is one flex slot, exactly like each member tab, so a
+        // long group name is cutt off within its own slot instead of stealing
+        // width from the members and making them non-uniform.
+        row.add_child(
+            Shrinkable::new(
+                1.0,
+                self.render_horizontal_tab_group_header(
+                    group,
+                    &mouse_states,
+                    is_collapsed,
+                    any_member_active,
+                    appearance,
+                    ctx,
+                ),
+            )
+            .finish(),
+        );
 
         if !is_collapsed {
             let close_button_position = if FeatureFlag::TabCloseButtonOnLeft.is_enabled() {
@@ -19363,11 +19372,11 @@ impl Workspace {
                 .name
                 .clone()
                 .unwrap_or_else(|| "New Group".to_string());
-            // Cap width so long names ellipsize and the tab bar's unbounded
-            // measurement stays finite.
+            // Cap width so long names fade out at the end (matching tabs) and the
+            // tab bar's unbounded measurement stays finite.
             ConstrainedBox::new(
                 Text::new_inline(title, font_family, 12.)
-                    .with_clip(ClipConfig::ellipsis())
+                    .with_clip(ClipConfig::end())
                     .with_color(main_text_color.into())
                     .finish(),
             )
@@ -19379,7 +19388,9 @@ impl Workspace {
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_spacing(6.)
             .with_child(icon_circle)
-            .with_child(name_element);
+            // Name takes the flexible remainder so it fades out when the header
+            // slot is tight, while the icon collage keeps its fixed size.
+            .with_child(Shrinkable::new(1.0, name_element).finish());
         // Collapsed + pinned: pin indicator to the right of the name, where an
         // ungrouped tab would show its close button. Expanded groups show the
         // pin after their last member instead.

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -19312,14 +19312,8 @@ impl Workspace {
         let positioned_container =
             SavePosition::new(positioned_container, &htab_group_position_id(group_id)).finish();
 
-        // Flex = header + one per member so the group shrinks proportionally
-        // with sibling tabs. A collapsed group renders only its header, so it
-        // should claim a single slot's worth of flex.
-        let group_flex = if is_collapsed {
-            1.0
-        } else {
-            1.0 + run_len as f32
-        };
+        // Flex from member count (not collapse state) so layout doesn't shift when the group expands/collapses.
+        let group_flex = 1.0 + run_len as f32;
         Shrinkable::new(group_flex, positioned_container).finish()
     }
 

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -19231,7 +19231,7 @@ impl Workspace {
 
         let mut row = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
         // The header is one flex slot, exactly like each member tab, so a
-        // long group name is cutt off within its own slot instead of stealing
+        // long group name is cut off within its own slot instead of stealing
         // width from the members and making them non-uniform.
         row.add_child(
             Shrinkable::new(


### PR DESCRIPTION
## Description

When collapsing/expanding horizontal tab groups, the group would shift positions due to giving different flex when groups are expanded vs collapsed. This made double clicking to rename a htab group difficult in some scenarios since the group would shift on the first click. 

The fix: the placeholder at the end of the tab bar now accounts for collapsed groups, and expands accordingly so tabs keep their size.

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4768/htab-groups-move-when-expandedcollapsed

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo of bug 1](https://www.loom.com/share/5f66f6bd52344d22bddb68c7fcab97dc)

[Demo of fix ](https://www.loom.com/share/c2016d12ed1d4a7cb0b3437eb19d3539?from_recorder=1&focus_title=1)
