### PR TITLE
Link remote Markdown files from SSH output

### DIFF
--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -35,7 +35,6 @@ use crate::ai::conversation_utils;
 use crate::ai::llms::LLMPreferences;
 use crate::ai::skills::SkillManager;
 use crate::app_state::{AmbientAgentPaneSnapshot, LeafContents, TerminalPaneSnapshot};
-use crate::code::buffer_location::LocalOrRemotePath;
 use crate::pane_group::child_agent::{
     create_error_child_agent_conversation, ErrorChildAgentConversationRequest,
 };
@@ -1106,7 +1105,7 @@ fn handle_terminal_view_event(
             }
             Event::OpenFileInWarp { path, session } => {
                 ctx.emit(pane_group::Event::OpenFileInWarp {
-                    path: LocalOrRemotePath::Local(path.clone()),
+                    path: path.clone(),
                     session: session.clone(),
                 });
             }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -1726,7 +1726,7 @@ pub enum Event {
     },
     /// Tell the pane group to open a file within Warp.
     OpenFileInWarp {
-        path: PathBuf,
+        path: LocalOrRemotePath,
         /// The session that the file belongs to.
         session: Arc<Session>,
     },
@@ -18332,7 +18332,7 @@ impl TerminalView {
         position: &WithinModel<Point>,
         ctx: &mut ViewContext<Self>,
     ) {
-        let Some(link) = self.highlighted_link.as_ref() else {
+        let Some(link) = self.highlighted_link.clone() else {
             return;
         };
         send_telemetry_from_ctx!(
@@ -18346,15 +18346,12 @@ impl TerminalView {
         match link {
             #[cfg(feature = "local_fs")]
             GridHighlightedLink::File(link) if link.contains(position) => {
-                let link = link.get_inner();
-                if let Some(path) = link.absolute_path() {
-                    self.open_file_path(path, link.line_and_column_num, ctx);
-                }
+                self.open_file_link(&link, ctx);
             }
             GridHighlightedLink::Url(url) if url.contains(position) => {
                 let model = self.model.lock();
                 ctx.notify();
-                ctx.open_url(&model.link_at_range(url, RespectObfuscatedSecrets::No));
+                ctx.open_url(&model.link_at_range(&url, RespectObfuscatedSecrets::No));
             }
             _ => (),
         }
@@ -18392,7 +18389,10 @@ impl TerminalView {
             .active_block_session_id()
             .and_then(|session_id| self.sessions.as_ref(ctx).get(session_id))
         {
-            ctx.emit(Event::OpenFileInWarp { path, session })
+            ctx.emit(Event::OpenFileInWarp {
+                path: LocalOrRemotePath::Local(path),
+                session,
+            })
         }
     }
 

--- a/app/src/terminal/view/link_detection.rs
+++ b/app/src/terminal/view/link_detection.rs
@@ -20,7 +20,7 @@ cfg_if::cfg_if! {
             terminal::model::session::{SessionId, SessionType},
             terminal::ShellLaunchData,
             util::file::{FileLink, absolute_path_if_valid, ShellPathType},
-            util::openable_file_type::{is_markdown_file, FileTarget},
+            util::openable_file_type::FileTarget,
         };
         use std::path::PathBuf;
         use warp_util::remote_path::RemotePath;
@@ -42,6 +42,12 @@ const PREFIXES_TO_REMOVE: [&str; 2] = ["a/", "b/"];
 const SUFFIXES_TO_REMOVE: [&str; 1] = ["@"];
 
 #[cfg(feature = "local_fs")]
+const MARKDOWN_EXTENSIONS: [&str; 2] = ["md", "markdown"];
+
+#[cfg(feature = "local_fs")]
+const MARKDOWN_FILE_NAMES: [&str; 3] = ["README", "CHANGELOG", "LICENSE"];
+
+#[cfg(feature = "local_fs")]
 #[derive(Clone)]
 enum FileLinkScanContext {
     Local {
@@ -52,6 +58,42 @@ enum FileLinkScanContext {
         working_directory: String,
         host_id: warp_core::HostId,
     },
+}
+
+#[cfg(feature = "local_fs")]
+fn is_standardized_markdown_file(path: &StandardizedPath) -> bool {
+    match path.extension() {
+        Some(extension) => MARKDOWN_EXTENSIONS
+            .iter()
+            .any(|markdown_extension| extension.eq_ignore_ascii_case(markdown_extension)),
+        None => path.file_name().is_some_and(|file_name| {
+            MARKDOWN_FILE_NAMES
+                .iter()
+                .any(|markdown_file_name| file_name.eq_ignore_ascii_case(markdown_file_name))
+        }),
+    }
+}
+
+#[cfg(feature = "local_fs")]
+fn remote_markdown_location(
+    clean_path_result: &CleanPathResult,
+    working_directory: &str,
+    host_id: &warp_core::HostId,
+) -> Option<LocalOrRemotePath> {
+    let standardized = StandardizedPath::try_new(&clean_path_result.path)
+        .or_else(|_| {
+            StandardizedPath::try_new(working_directory)
+                .map(|working_directory| working_directory.join(&clean_path_result.path))
+        })
+        .ok()?;
+    if !is_standardized_markdown_file(&standardized) {
+        return None;
+    }
+
+    Some(LocalOrRemotePath::Remote(RemotePath::new(
+        host_id.clone(),
+        standardized,
+    )))
 }
 
 /// Highlighted link within a terminal model grid.
@@ -686,24 +728,7 @@ impl super::TerminalView {
             FileLinkScanContext::RemoteMarkdown {
                 working_directory,
                 host_id,
-            } => {
-                if !is_markdown_file(std::path::Path::new(&clean_path_result.path)) {
-                    return None;
-                }
-
-                let path = std::path::Path::new(&clean_path_result.path);
-                let absolute_path = if path.is_absolute() {
-                    path.to_path_buf()
-                } else {
-                    PathBuf::from(working_directory).join(path)
-                };
-                let standardized =
-                    StandardizedPath::try_new(absolute_path.to_string_lossy().as_ref()).ok()?;
-                Some(LocalOrRemotePath::Remote(RemotePath::new(
-                    host_id.clone(),
-                    standardized,
-                )))
-            }
+            } => remote_markdown_location(clean_path_result, working_directory, host_id),
         }
     }
 
@@ -746,5 +771,92 @@ impl super::TerminalView {
             ctx.set_cursor_shape(Cursor::PointingHand);
             ctx.notify();
         }
+    }
+}
+
+#[cfg(all(test, feature = "local_fs"))]
+mod tests {
+    use super::*;
+
+    fn remote_markdown_path(raw_path: &str, working_directory: &str) -> Option<String> {
+        let host_id = warp_core::HostId::new("test-host".to_string());
+        let clean_path_result = CleanPathResult {
+            path: raw_path.to_string(),
+            line_and_column_num: None,
+        };
+        let scan_context = FileLinkScanContext::RemoteMarkdown {
+            working_directory: working_directory.to_string(),
+            host_id: host_id.clone(),
+        };
+
+        let location = super::super::TerminalView::valid_file_link_location(
+            &clean_path_result,
+            &scan_context,
+        )?;
+        match location {
+            LocalOrRemotePath::Remote(remote) => {
+                assert_eq!(remote.host_id, host_id);
+                Some(remote.path.as_str().to_string())
+            }
+            LocalOrRemotePath::Local(_) => None,
+        }
+    }
+
+    #[test]
+    fn remote_markdown_absolute_unix_path_is_not_joined_to_pwd() {
+        assert_eq!(
+            remote_markdown_path("/home/alice/repo/README.md", "/tmp/current").as_deref(),
+            Some("/home/alice/repo/README.md")
+        );
+    }
+
+    #[test]
+    fn remote_markdown_absolute_windows_path_is_not_joined_to_pwd() {
+        assert_eq!(
+            remote_markdown_path(r"D:\Users\alice\docs\README.md", r"C:\Users\alice\repo")
+                .as_deref(),
+            Some(r"D:\Users\alice\docs\README.md")
+        );
+    }
+
+    #[test]
+    fn remote_markdown_relative_unix_path_uses_remote_pwd() {
+        assert_eq!(
+            remote_markdown_path("docs/README.md", "/home/alice/repo").as_deref(),
+            Some("/home/alice/repo/docs/README.md")
+        );
+    }
+
+    #[test]
+    fn remote_markdown_relative_windows_path_uses_remote_pwd() {
+        assert_eq!(
+            remote_markdown_path(r"..\README.md", r"C:\Users\alice\repo\docs").as_deref(),
+            Some(r"C:\Users\alice\repo\README.md")
+        );
+    }
+
+    #[test]
+    fn remote_markdown_extensionless_windows_file_name_is_detected() {
+        assert_eq!(
+            remote_markdown_path(r"C:\Users\alice\repo\README", r"C:\Users\alice\repo").as_deref(),
+            Some(r"C:\Users\alice\repo\README")
+        );
+    }
+
+    #[test]
+    fn remote_markdown_extensionless_unix_file_name_is_detected() {
+        assert_eq!(
+            remote_markdown_path("/home/alice/repo/CHANGELOG", "/home/alice/repo").as_deref(),
+            Some("/home/alice/repo/CHANGELOG")
+        );
+    }
+
+    #[test]
+    fn remote_markdown_non_markdown_path_is_ignored() {
+        assert_eq!(
+            remote_markdown_path("src/main.rs", "/home/alice/repo"),
+            None
+        );
+        assert_eq!(remote_markdown_path("notes.txt", "/home/alice/repo"), None);
     }
 }

--- a/app/src/terminal/view/link_detection.rs
+++ b/app/src/terminal/view/link_detection.rs
@@ -15,12 +15,16 @@ use crate::terminal::TerminalModel;
 cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
         use crate::{
+            code::buffer_location::LocalOrRemotePath,
             terminal::model::grid::grid_handler,
+            terminal::model::session::{SessionId, SessionType},
             terminal::ShellLaunchData,
             util::file::{FileLink, absolute_path_if_valid, ShellPathType},
-            util::openable_file_type::FileTarget,
+            util::openable_file_type::{is_markdown_file, FileTarget},
         };
         use std::path::PathBuf;
+        use warp_util::remote_path::RemotePath;
+        use warp_util::standardized_path::StandardizedPath;
         use warp_util::path::CleanPathResult;
         use warp_util::path::LineAndColumnArg;
     }
@@ -36,6 +40,19 @@ const PREFIXES_TO_REMOVE: [&str; 2] = ["a/", "b/"];
 /// for `ls`.
 #[cfg(feature = "local_fs")]
 const SUFFIXES_TO_REMOVE: [&str; 1] = ["@"];
+
+#[cfg(feature = "local_fs")]
+#[derive(Clone)]
+enum FileLinkScanContext {
+    Local {
+        working_directory: String,
+        shell_launch_data: Option<ShellLaunchData>,
+    },
+    RemoteMarkdown {
+        working_directory: String,
+        host_id: warp_core::HostId,
+    },
+}
 
 /// Highlighted link within a terminal model grid.
 #[derive(Debug, Clone)]
@@ -377,10 +394,7 @@ impl super::TerminalView {
         match link {
             #[cfg(feature = "local_fs")]
             GridHighlightedLink::File(link) => {
-                let link = link.get_inner();
-                if let Some(path) = link.absolute_path() {
-                    self.open_file_path(path.clone(), link.line_and_column_num, ctx);
-                }
+                self.open_file_link(link, ctx);
             }
             GridHighlightedLink::Url(url) => {
                 let model = self.model.lock();
@@ -427,6 +441,45 @@ impl super::TerminalView {
 // where we can spawn a local tty.
 #[cfg(feature = "local_fs")]
 impl super::TerminalView {
+    fn session_for_file_link(
+        &self,
+        link: &WithinModel<FileLink>,
+        ctx: &mut ViewContext<Self>,
+    ) -> Option<std::sync::Arc<crate::terminal::model::session::Session>> {
+        let session_id = match link {
+            WithinModel::AltScreen(_) => self.active_block_session_id(),
+            WithinModel::BlockList(inner) => self
+                .model
+                .lock()
+                .block_list()
+                .block_at(inner.block_index)
+                .and_then(|block| block.session_id()),
+        }?;
+
+        self.sessions.as_ref(ctx).get(session_id)
+    }
+
+    pub(super) fn open_file_link(
+        &mut self,
+        link: &WithinModel<FileLink>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let file_link = link.get_inner();
+        match file_link.location() {
+            LocalOrRemotePath::Local(path) => {
+                self.open_file_path(path.clone(), file_link.line_and_column_num, ctx);
+            }
+            LocalOrRemotePath::Remote(_) => {
+                if let Some(session) = self.session_for_file_link(link, ctx) {
+                    ctx.emit(super::Event::OpenFileInWarp {
+                        path: file_link.location().clone(),
+                        session,
+                    });
+                }
+            }
+        }
+    }
+
     /// Scans the terminal model at the given position to see if it is
     /// contained within a path that should be linkified.
     fn scan_for_file_path(
@@ -435,29 +488,46 @@ impl super::TerminalView {
         from_editor: TerminalEditor,
         ctx: &mut ViewContext<Self>,
     ) {
-        // For AltScreen we scan for relative path with the current working directory.
-        // For BlockList we scan for relative path with the pwd of the hovered block.
-        let pwd_to_scan_for = match position {
-            WithinModel::AltScreen(_) => self.pwd_if_local(ctx),
-            WithinModel::BlockList(inner) => self
-                .model
-                .lock()
-                .block_list()
-                .block_at(inner.block_index)
-                .filter(|block| !self.is_block_considered_remote(block.session_id(), None, ctx)) // Don't scan for file links if the block is on remote sessions
-                .and_then(|block| block.pwd().map(String::from)),
+        // For AltScreen we scan relative paths with the active working directory. For BlockList we
+        // scan relative paths with the pwd and session of the hovered block.
+        let scan_context = match position {
+            WithinModel::AltScreen(_) => {
+                self.pwd_if_local(ctx)
+                    .map(|working_directory| FileLinkScanContext::Local {
+                        working_directory,
+                        shell_launch_data: self
+                            .active_block_session_id()
+                            .and_then(|active_session_id| {
+                                self.sessions.as_ref(ctx).get(active_session_id)
+                            })
+                            .and_then(|active_session| active_session.launch_data().cloned()),
+                    })
+            }
+            WithinModel::BlockList(inner) => {
+                let block_context = {
+                    let model = self.model.lock();
+                    model
+                        .block_list()
+                        .block_at(inner.block_index)
+                        .and_then(|block| Some((block.pwd()?.clone(), block.session_id())))
+                };
+
+                block_context.and_then(|(working_directory, session_id)| {
+                    Self::file_link_scan_context_for_session(
+                        working_directory,
+                        session_id,
+                        self.sessions.as_ref(ctx),
+                    )
+                })
+            }
         };
 
-        match pwd_to_scan_for {
+        match scan_context {
             // Check if we are hovering on any file path. Don't scan for file path
             // if user is hovering from an editor like vim or nano.
-            Some(path) if matches!(from_editor, TerminalEditor::No) => {
+            Some(scan_context) if matches!(from_editor, TerminalEditor::No) => {
                 let possible_paths = self.model.lock().possible_file_paths_at_point(position);
                 let max_columns = self.size_info.columns;
-                let shell_launch_data = self
-                    .active_block_session_id()
-                    .and_then(|active_session_id| self.sessions.as_ref(ctx).get(active_session_id))
-                    .and_then(|active_session| active_session.launch_data().cloned());
 
                 // Using the thread builder instead of ctx.spawn here so that the previous
                 // scanning job will be dropped once there is a new scanning job created.
@@ -465,12 +535,8 @@ impl super::TerminalView {
                 self.file_link_scanning_join_handle = std::thread::Builder::new()
                     .name("Compute file paths".into())
                     .spawn(move || {
-                        let paths = Self::compute_valid_paths(
-                            &path,
-                            possible_paths,
-                            max_columns,
-                            shell_launch_data,
-                        );
+                        let paths =
+                            Self::compute_valid_paths(scan_context, possible_paths, max_columns);
                         let _ = tx.send(paths);
                     })
                     .map_err(|e| {
@@ -491,26 +557,49 @@ impl super::TerminalView {
         };
     }
 
+    fn file_link_scan_context_for_session(
+        working_directory: String,
+        session_id: Option<SessionId>,
+        sessions: &crate::terminal::model::session::Sessions,
+    ) -> Option<FileLinkScanContext> {
+        let Some(session_id) = session_id else {
+            return Some(FileLinkScanContext::Local {
+                working_directory,
+                shell_launch_data: None,
+            });
+        };
+
+        let session = sessions.get(session_id)?;
+        match session.session_type() {
+            SessionType::Local => Some(FileLinkScanContext::Local {
+                working_directory,
+                shell_launch_data: session.launch_data().cloned(),
+            }),
+            SessionType::WarpifiedRemote {
+                host_id: Some(host_id),
+            } => Some(FileLinkScanContext::RemoteMarkdown {
+                working_directory,
+                host_id,
+            }),
+            SessionType::WarpifiedRemote { host_id: None } => None,
+        }
+    }
+
     fn compute_valid_paths(
-        working_directory: &str,
+        scan_context: FileLinkScanContext,
         possible_paths: impl Iterator<Item = WithinModel<grid_handler::PossiblePath>>,
         max_columns: usize,
-        shell_launch_data: Option<ShellLaunchData>,
     ) -> Option<GridHighlightedLink> {
         let mut link = None;
         'path_loop: for within_model_possible_path in possible_paths {
             let possible_path = within_model_possible_path.get_inner();
             // We want to check if the clean path result is a valid path and get the canonical
             // absolute path back.
-            let absolute_path = absolute_path_if_valid(
-                &possible_path.path,
-                ShellPathType::ShellNative(working_directory.to_string()),
-                shell_launch_data.as_ref(),
-            );
+            let location = Self::valid_file_link_location(&possible_path.path, &scan_context);
 
-            if let Some(absolute_path) = absolute_path {
+            if let Some(location) = location {
                 link = Some(Self::create_valid_link(
-                    absolute_path,
+                    location,
                     possible_path.path.line_and_column_num,
                     possible_path.range.clone(),
                     &within_model_possible_path,
@@ -524,21 +613,18 @@ impl super::TerminalView {
                         path: new_possible_path.into(),
                         line_and_column_num: possible_path.path.line_and_column_num,
                     };
-                    let absolute_path = absolute_path_if_valid(
-                        &new_possible_cleaned_path,
-                        ShellPathType::ShellNative(working_directory.to_string()),
-                        shell_launch_data.as_ref(),
-                    );
+                    let location =
+                        Self::valid_file_link_location(&new_possible_cleaned_path, &scan_context);
 
                     // check if new_possible_path is valid
-                    if let Some(absolute_path) = absolute_path {
+                    if let Some(location) = location {
                         let new_start_point = possible_path
                             .range
                             .start()
                             .wrapping_add(max_columns, prefix.len());
 
                         link = Some(Self::create_valid_link(
-                            absolute_path,
+                            location,
                             new_possible_cleaned_path.line_and_column_num,
                             new_start_point..=*possible_path.range.end(),
                             &within_model_possible_path,
@@ -556,21 +642,18 @@ impl super::TerminalView {
                         path: new_possible_path.into(),
                         line_and_column_num: possible_path.path.line_and_column_num,
                     };
-                    let absolute_path = absolute_path_if_valid(
-                        &new_possible_cleaned_path,
-                        ShellPathType::ShellNative(working_directory.to_string()),
-                        shell_launch_data.as_ref(),
-                    );
+                    let location =
+                        Self::valid_file_link_location(&new_possible_cleaned_path, &scan_context);
 
                     // check if new_possible_path is valid
-                    if let Some(absolute_path) = absolute_path {
+                    if let Some(location) = location {
                         let new_end_point = possible_path
                             .range
                             .end()
                             .wrapping_sub(max_columns, suffix.len());
 
                         link = Some(Self::create_valid_link(
-                            absolute_path,
+                            location,
                             new_possible_cleaned_path.line_and_column_num,
                             *possible_path.range.start()..=new_end_point,
                             &within_model_possible_path,
@@ -586,8 +669,46 @@ impl super::TerminalView {
         link.map(GridHighlightedLink::File)
     }
 
+    fn valid_file_link_location(
+        clean_path_result: &CleanPathResult,
+        scan_context: &FileLinkScanContext,
+    ) -> Option<LocalOrRemotePath> {
+        match scan_context {
+            FileLinkScanContext::Local {
+                working_directory,
+                shell_launch_data,
+            } => absolute_path_if_valid(
+                clean_path_result,
+                ShellPathType::ShellNative(working_directory.to_string()),
+                shell_launch_data.as_ref(),
+            )
+            .map(LocalOrRemotePath::Local),
+            FileLinkScanContext::RemoteMarkdown {
+                working_directory,
+                host_id,
+            } => {
+                if !is_markdown_file(std::path::Path::new(&clean_path_result.path)) {
+                    return None;
+                }
+
+                let path = std::path::Path::new(&clean_path_result.path);
+                let absolute_path = if path.is_absolute() {
+                    path.to_path_buf()
+                } else {
+                    PathBuf::from(working_directory).join(path)
+                };
+                let standardized =
+                    StandardizedPath::try_new(absolute_path.to_string_lossy().as_ref()).ok()?;
+                Some(LocalOrRemotePath::Remote(RemotePath::new(
+                    host_id.clone(),
+                    standardized,
+                )))
+            }
+        }
+    }
+
     fn create_valid_link(
-        absolute_path: PathBuf,
+        location: LocalOrRemotePath,
         line_and_column_num: Option<LineAndColumnArg>,
         path_range: std::ops::RangeInclusive<Point>,
         possible_path: &WithinModel<grid_handler::PossiblePath>,
@@ -597,7 +718,7 @@ impl super::TerminalView {
                 range: path_range,
                 is_empty: false,
             },
-            absolute_path,
+            location,
             line_and_column_num,
         };
 

--- a/app/src/terminal/view/open_in_warp.rs
+++ b/app/src/terminal/view/open_in_warp.rs
@@ -159,7 +159,9 @@ impl TerminalView {
                     match banner_state.target.file_type {
                         OpenableFileType::Markdown => {
                             ctx.emit(Event::OpenFileInWarp {
-                                path: banner_state.target.path,
+                                path: warp_util::local_or_remote_path::LocalOrRemotePath::Local(
+                                    banner_state.target.path,
+                                ),
                                 session: banner_state.session,
                             });
                         }

--- a/app/src/util/file.rs
+++ b/app/src/util/file.rs
@@ -2,6 +2,7 @@ pub mod external_editor;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
+use warp_util::local_or_remote_path::LocalOrRemotePath;
 #[cfg(windows)]
 use warp_util::path::is_network_resource;
 use warp_util::path::{CleanPathResult, LineAndColumnArg};
@@ -106,14 +107,18 @@ impl FilePathType {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FileLink {
     pub link: Link,
-    /// This path has been converted (if needed) into a native path from the shell.
-    pub absolute_path: PathBuf,
+    /// This path has been resolved in the session it came from.
+    pub location: LocalOrRemotePath,
     pub line_and_column_num: Option<LineAndColumnArg>,
 }
 
 impl FileLink {
     pub fn absolute_path(&self) -> Option<PathBuf> {
-        Some(self.absolute_path.clone())
+        self.location.to_local_path().map(Path::to_path_buf)
+    }
+
+    pub fn location(&self) -> &LocalOrRemotePath {
+        &self.location
     }
 }
 


### PR DESCRIPTION
Fixes #9091

## Summary
- allow terminal file-link scanning to consider warpified remote blocks that have a connected host id
- resolve Markdown-looking remote candidates against the block pwd as `LocalOrRemotePath::Remote`
- route remote Markdown file links through the existing OpenFileInWarp remote path flow while preserving local file link behavior

## Testing
- `cargo fmt --check`
- `./script/format --check`
- `git diff --check`
- `PATH=/tmp/warp-fake-xcrun:$PATH cargo check -p warp` (passes; wrapper only bypasses my local missing Xcode Metal Toolchain shader compiler)
- `cargo check -p warp` (blocked locally by missing Xcode Metal Toolchain: `cannot execute tool 'metal' due to missing Metal Toolchain`)\n\nCHANGELOG-BUG-FIX: Link Markdown files from warpified SSH output so they can open in Warp.