### PR TITLE
Hide share copy link until a session exists

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -16747,9 +16747,11 @@ impl TerminalView {
                             .block_at(tail_block_index)
                             .is_none_or(|b| b.is_restored());
 
-                    items.extend(
-                        self.session_sharing_context_menu_items(&model, is_share_session_disabled),
-                    );
+                    items.extend(self.session_sharing_context_menu_items(
+                        &model,
+                        is_share_session_disabled,
+                        ctx,
+                    ));
                 }
 
                 if WarpDriveSettings::is_warp_drive_enabled(ctx) {
@@ -16951,7 +16953,7 @@ impl TerminalView {
                 if FeatureFlag::CreatingSharedSessions.is_enabled()
                     && ContextFlag::CreateSharedSession.is_enabled()
                 {
-                    items.extend(self.session_sharing_context_menu_items(&model, false));
+                    items.extend(self.session_sharing_context_menu_items(&model, false, ctx));
                 }
 
                 items
@@ -17420,7 +17422,7 @@ impl TerminalView {
         if FeatureFlag::CreatingSharedSessions.is_enabled()
             && ContextFlag::CreateSharedSession.is_enabled()
         {
-            items.extend(self.session_sharing_context_menu_items(&model, false));
+            items.extend(self.session_sharing_context_menu_items(&model, false, ctx));
         }
 
         // Section 2: AI Command Search, Ask Warp AI
@@ -17658,7 +17660,7 @@ impl TerminalView {
         if FeatureFlag::CreatingSharedSessions.is_enabled()
             && ContextFlag::CreateSharedSession.is_enabled()
         {
-            menu_items.extend(self.session_sharing_context_menu_items(&model, false));
+            menu_items.extend(self.session_sharing_context_menu_items(&model, false, ctx));
         }
         let current_shell = model.shell_launch_state().available_shell();
         let mut pane_context_menu_items = self.pane_context_menu_items(current_shell, ctx);

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -1566,6 +1566,11 @@ impl TerminalView {
         send_telemetry_from_ctx!(TelemetryEvent::CopiedSharedSessionLink { source }, ctx);
     }
 
+    fn has_copyable_shared_session_link(&self, ctx: &AppContext) -> bool {
+        let manager = Manager::as_ref(ctx);
+        manager.session_id(&self.id()).is_some() || manager.ended_session_id(&self.id()).is_some()
+    }
+
     pub fn open_shared_session_qr_code(&mut self, ctx: &mut ViewContext<Self>) {
         self.pane_configuration.update(ctx, |pane_config, ctx| {
             pane_config.open_sharing_qr_code(SharingDialogSource::StartedSessionShare, ctx);
@@ -1895,6 +1900,7 @@ impl TerminalView {
         &self,
         model: &TerminalModel,
         is_share_session_disabled: bool,
+        ctx: &AppContext,
     ) -> Vec<MenuItem<TerminalAction>> {
         let mut items = Vec::new();
 
@@ -1917,7 +1923,7 @@ impl TerminalView {
             );
         }
 
-        if model.shared_session_status().is_sharer_or_viewer() {
+        if self.has_copyable_shared_session_link(ctx) {
             items.push(
                 MenuItemFields::new("Copy session sharing link")
                     .with_on_select_action(TerminalAction::CopySharedSessionLink {

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -82,6 +82,55 @@ fn test_prompt_context_menu_items_shared_session_viewer_no_edit_prompt() {
 }
 
 #[test]
+fn test_share_pending_context_menu_hides_copy_link_without_session_id() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        app.add_singleton_model(Manager::new);
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        terminal.update(&mut app, |view, ctx| {
+            let mut model = view.model.lock();
+            model.set_shared_session_status(SharedSessionStatus::SharePending);
+
+            let items = view.session_sharing_context_menu_items(&model, false, ctx);
+
+            assert!(!items.iter().any(|item| {
+                item.fields()
+                    .is_some_and(|fields| fields.label() == "Copy session sharing link")
+            }));
+        });
+    })
+}
+
+#[test]
+fn test_active_shared_context_menu_shows_copy_link_with_session_id() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        app.add_singleton_model(Manager::new);
+        let terminal = add_window_with_terminal(&mut app, None);
+        let terminal_weak = terminal.downgrade();
+
+        terminal.update(&mut app, |view, ctx| {
+            let session_id = SessionId::new();
+            let window_id = ctx.window_id();
+            Manager::handle(ctx).update(ctx, |manager, ctx| {
+                manager.started_share(terminal_weak.clone(), session_id, window_id, ctx);
+            });
+
+            let mut model = view.model.lock();
+            model.set_shared_session_status(SharedSessionStatus::ActiveSharer);
+
+            let items = view.session_sharing_context_menu_items(&model, false, ctx);
+
+            assert!(items.iter().any(|item| {
+                item.fields()
+                    .is_some_and(|fields| fields.label() == "Copy session sharing link")
+            }));
+        });
+    })
+}
+
+#[test]
 fn test_on_ambient_agent_execution_ended_enables_followup_input_for_editable_non_owner_finished_view(
 ) {
     let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);


### PR DESCRIPTION
Fixes #9736

## Summary
- only show `Copy session sharing link` when the shared-session manager has an active or ended session id for the terminal view
- keep pending share states from exposing a copy-link action before a share URL can exist
- add regression coverage for pending share menus without a session id and active shared menus with a session id

## Testing
- `cargo fmt --check`
- `git diff --check`
- `PATH=/tmp/warp-fake-xcrun:$PATH cargo check -p warp` (passes; wrapper only bypasses my local missing Xcode Metal Toolchain shader compiler)
- `PATH=/tmp/warp-fake-xcrun:$PATH cargo test -p warp test_share_pending_context_menu_hides_copy_link_without_session_id --lib` (not completed locally; app test target compilation did not finish in a reasonable time before I interrupted it)

CHANGELOG-BUG-FIX: Hide the shared-session copy-link menu item until a session link exists.