### PR TITLE
Hide inactive slash command hints

### DIFF
--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -298,6 +298,7 @@ use crate::terminal::input::slash_command_model::{SlashCommandEntryState, SlashC
 use crate::terminal::input::slash_commands::{
     slash_command_is_submitted_as_prompt, CloudModeV2SlashCommandView, GuiSlashCommandDataSource,
     InlineSlashCommandView, SlashCommandDataSource as _, SlashCommandTrigger,
+    UpdatedActiveCommands,
 };
 use crate::terminal::input::suggestions_mode_model::{
     InputSuggestionsModeEvent, InputSuggestionsModeModel,
@@ -3465,6 +3466,13 @@ impl Input {
             };
             GuiSlashCommandDataSource::new(args, ctx)
         });
+        ctx.subscribe_to_model(
+            &slash_command_data_source,
+            |me, _, _: &UpdatedActiveCommands, ctx| {
+                me.set_zero_state_hint_text(ctx);
+                ctx.notify();
+            },
+        );
 
         let cloud_mode_composer_slash_command_data_source =
             if FeatureFlag::CloudModeInputV2.is_enabled() {
@@ -6900,6 +6908,24 @@ impl Input {
     }
 
     pub fn set_zero_state_hint_text(&mut self, ctx: &mut ViewContext<Self>) {
+        let slash_command_hint_prefixes = COMMAND_REGISTRY
+            .all_commands()
+            .filter(|command| {
+                command
+                    .argument
+                    .as_ref()
+                    .and_then(|argument| argument.hint_text)
+                    .is_some()
+            })
+            .map(|command| format!("{} ", command.name))
+            .collect_vec();
+
+        self.editor.update(ctx, |editor, ctx| {
+            for prefix in slash_command_hint_prefixes {
+                editor.clear_placeholder_text_with_prefix(&prefix, ctx);
+            }
+        });
+
         if CLIAgentSessionsModel::as_ref(ctx).is_input_open(self.terminal_view_id) {
             let hint = self.cli_agent_rich_input_hint_text(ctx);
             self.editor.update(ctx, |editor, ctx| {
@@ -6954,12 +6980,23 @@ impl Input {
 
         let toggled_on = *InputSettings::as_ref(ctx).show_hint_text;
 
-        // Loop through all static commands and set placeholders for those with hint text
+        let slash_command_placeholders = self
+            .slash_command_data_source
+            .as_ref(ctx)
+            .active_commands()
+            .filter_map(|(_, command)| {
+                command
+                    .argument
+                    .as_ref()
+                    .and_then(|argument| argument.hint_text)
+                    .map(|hint_text| (command.name, hint_text))
+            })
+            .collect_vec();
+
+        // Loop through active static commands and set placeholders for those with hint text
         self.editor.update(ctx, |editor, ctx| {
-            for command in COMMAND_REGISTRY.all_commands() {
-                if let Some(hint) = command.argument_hint() {
-                    editor.set_placeholder_text_with_prefix(hint.input_prefix, hint.text, ctx);
-                }
+            for (command_name, hint_text) in slash_command_placeholders {
+                editor.set_placeholder_text_with_prefix(format!("{command_name} "), hint_text, ctx);
             }
         });
 

--- a/app/src/terminal/input/slash_commands/data_source/core.rs
+++ b/app/src/terminal/input/slash_commands/data_source/core.rs
@@ -278,17 +278,17 @@ pub trait SlashCommandDataSource {
         }
     }
 
-    /// Replace the active command set. Returns whether the number of active commands changed.
-    ///
-    /// This is an imperfect heuristic, but better than re-firing unnecessarily. If it actually
-    /// matters, we can update it.
+    /// Replace the active command set. Returns whether the active commands changed.
     fn replace_active_commands(
         &mut self,
         commands: HashMap<SlashCommandId, StaticCommand>,
     ) -> bool {
-        let changed = commands.len() != self.state().active_commands_by_id.len();
-        self.state_mut().active_commands_by_id = commands;
-        changed
+        if self.state().active_commands_by_id == commands {
+            false
+        } else {
+            self.state_mut().active_commands_by_id = commands;
+            true
+        }
     }
 
     /// Availability bits derived only from state shared by both surfaces.

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -20,6 +20,7 @@ use warp_completer::completer::{
     SuggestionResults, SuggestionType,
 };
 use warp_completer::meta::Span;
+use warp_util::standardized_path::StandardizedPath;
 use warp_util::user_input::UserInput;
 use warpui::platform::WindowStyle;
 use warpui::text::SelectionType;
@@ -57,6 +58,7 @@ use crate::input_suggestions::{HistoryOrder, Item};
 use crate::network::NetworkStatus;
 use crate::pricing::PricingInfoModel;
 use crate::search::files::model::FileSearchModel;
+use crate::search::slash_command_menu::static_commands::commands;
 use crate::server::cloud_objects::listener::Listener;
 use crate::server::cloud_objects::update_manager::UpdateManager;
 use crate::server::server_api::ServerApiProvider;
@@ -715,6 +717,87 @@ fn test_input_tab() {
         input.read(&app, |input, ctx| {
             assert_eq!(input.buffer_text(ctx), "    cd so");
         });
+    });
+}
+
+#[test]
+fn zero_state_hint_text_only_registers_active_slash_command_placeholders() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let session_info = SessionInfo::new_for_test();
+        let session_id = session_info.session_id;
+        let terminal = add_window_with_bootstrapped_terminal(
+            &mut app,
+            None, /* history_file_commands */
+            Some(session_info),
+        )
+        .await;
+        let input = terminal.read(&app, |terminal, _| terminal.input().clone());
+
+        input.update(&mut app, |input, ctx| {
+            input.set_zero_state_hint_text(ctx);
+        });
+
+        let editor = input.read(&app, |input, _| input.editor().clone());
+        let rename_tab_prefix = format!("{} ", commands::RENAME_TAB.name);
+        let continue_locally_prefix = format!("{} ", commands::CONTINUE_LOCALLY.name);
+
+        editor.update(&mut app, |editor, ctx| {
+            editor.set_placeholder_text_with_prefix(
+                continue_locally_prefix.clone(),
+                "stale hint",
+                ctx,
+            );
+        });
+        input.update(&mut app, |input, ctx| {
+            input.set_zero_state_hint_text(ctx);
+        });
+
+        assert!(
+            editor.read(&app, |editor, _| editor
+                .placeholder_text(&rename_tab_prefix)
+                .is_some()),
+            "always-active slash command placeholders should still be registered"
+        );
+        assert!(
+            editor.read(&app, |editor, _| editor
+                .placeholder_text(&continue_locally_prefix)
+                .is_none()),
+            "/continue-locally should not be registered outside cloud conversation context"
+        );
+
+        editor.update(&mut app, |editor, ctx| {
+            editor.set_placeholder_text_with_prefix(
+                continue_locally_prefix.clone(),
+                "stale hint",
+                ctx,
+            );
+        });
+
+        let repo_dir = tempfile::TempDir::new().expect("repo temp dir");
+        let repo_path = repo_dir.path().to_path_buf();
+        simulate_directory_for_completion(
+            session_id,
+            &terminal,
+            &mut app,
+            repo_path.to_string_lossy().into_owned(),
+        );
+        DetectedRepositories::handle(&app).update(&mut app, |repos, _| {
+            let root = StandardizedPath::from_local_canonicalized(&repo_path)
+                .expect("canonicalized repo root");
+            repos.insert_test_repo_root(root);
+        });
+        input.update(&mut app, |input, ctx| {
+            input.update_repo_path(Some(repo_path), ctx);
+        });
+
+        assert!(
+            editor.read(&app, |editor, _| editor
+                .placeholder_text(&continue_locally_prefix)
+                .is_none()),
+            "active slash-command data source updates should refresh stale placeholders"
+        );
     });
 }
 


### PR DESCRIPTION
Fixes #12519

## Summary
- Register slash command placeholder hints from the active command data source instead of the global command registry.
- Clear previously registered slash-command hint prefixes before applying the current active set, so stale prefixes do not persist after context changes.
- Refresh zero-state hint placeholders when the slash-command data source emits active-command changes, including task-data, settings, or repo-context updates.
- Keeps `/continue-locally` from showing its input hint outside a cloud conversation context.
- Adds a regression test that verifies active command hints still register while stale `/continue-locally` placeholders are removed both on direct hint refresh and after active slash-command data-source updates.

## Visual Evidence
Active slash-command placeholder still renders for `/rename-tab`:

![rename_tab_hint.png](https://github.com/user-attachments/assets/3b192f03-a4f6-4543-bb96-fba7a91aa91b)

Inactive `/continue-locally` no longer renders a slash-command placeholder in a local terminal context. The gray `Library/` text is the normal shell/path autosuggestion after the inactive command is treated as terminal input, not a slash-command placeholder:

![continue_locally_no_hint.png](https://github.com/user-attachments/assets/a44adc75-c70a-4405-82d3-b7d69f9b8e00)

## Testing
- `cargo fmt --check`
- `./script/format --check`
- `git diff --check`
- `cargo test -p warp zero_state_hint_text_only_registers_active_slash_command_placeholders`
- `WARP_INTEGRATION_TEST_ARTIFACTS_DIR=/tmp/warp-pr-evidence WARPUI_USE_REAL_DISPLAY_IN_INTEGRATION_TESTS=1 cargo run -p integration --bin integration -- test_slash_command_hint_visual_evidence`

Note: the focused app test completed successfully after compiling the `warp` test binary. The visual evidence integration run completed successfully on macOS after installing the Xcode Metal Toolchain component.