### PR TITLE
Constrain feature popup width

### DIFF
--- a/app/src/view_components/feature_popup.rs
+++ b/app/src/view_components/feature_popup.rs
@@ -1,12 +1,14 @@
 use warpui::elements::{
-    ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Flex, Hoverable, MouseStateHandle,
-    ParentElement, Radius, Text,
+    ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, Expanded, Flex, Hoverable,
+    MouseStateHandle, ParentElement, Radius, Text,
 };
 use warpui::platform::Cursor;
 use warpui::{AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext};
 
 use crate::appearance::Appearance;
 use crate::ui_components::icons::Icon;
+
+const FEATURE_POPUP_MAX_WIDTH: f32 = 280.;
 
 pub enum NewFeaturePopupLabel {
     /// A static label.
@@ -109,16 +111,21 @@ impl View for FeaturePopup {
                     .with_cross_axis_alignment(CrossAxisAlignment::Center)
                     .with_child(Container::new(new_badge).with_margin_right(4.).finish())
                     .with_child(
-                        Container::new(
-                            Text::new(
-                                label,
-                                appearance.ui_font_family(),
-                                appearance.ui_font_size(),
+                        Expanded::new(
+                            1.,
+                            Container::new(
+                                Text::new(
+                                    label,
+                                    appearance.ui_font_family(),
+                                    appearance.ui_font_size(),
+                                )
+                                .soft_wrap(true)
+                                .with_color(background.into())
+                                .finish(),
                             )
-                            .with_color(background.into())
+                            .with_horizontal_padding(4.)
                             .finish(),
                         )
-                        .with_horizontal_padding(4.)
                         .finish(),
                     )
                     .with_child(
@@ -148,6 +155,7 @@ impl View for FeaturePopup {
             .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
             .finish(),
         )
+        .with_max_width(FEATURE_POPUP_MAX_WIDTH)
         .finish()
     }
 }


### PR DESCRIPTION
Fixes #11684

## Summary
- Add a max width to the shared `FeaturePopup` so long new-model labels cannot grow past a narrow viewport
- Let the popup label soft-wrap inside an expanded text region
- Keep the dismiss icon outside the wrapping label so it remains reachable even when model names are long

## Visual Evidence
Long model labels wrap within the constrained popup width, and the dismiss icon remains visible/reachable:

![feature_popup_long_label_wrapped.png](https://github.com/user-attachments/assets/d1a7058b-befb-4f1b-a859-41d7798ca2a8)

## Testing
- `cargo fmt --check`
- `./script/format --check`
- `git diff --check`
- `cargo check -p warp`
- `WARP_INTEGRATION_TEST_ARTIFACTS_DIR=/tmp/warp-pr-12898-feature-popup-evidence WARPUI_USE_REAL_DISPLAY_IN_INTEGRATION_TESTS=1 cargo run -p integration --bin integration -- test_feature_popup_width_visual_evidence`
