### PR TITLE
[gh-8226] Spec: open dir in external editor from tab + file tree menus

### DIFF
--- a/specs/gh-8226-open-with-editor/PRODUCT.md
+++ b/specs/gh-8226-open-with-editor/PRODUCT.md
@@ -1,0 +1,137 @@
+# gh-8226: Open with $EDITOR from tab and file-tree context menus
+
+## Summary
+
+Add an "Open with <Editor>" item to two existing right-click context menus —
+session tabs and file-tree directories — that launches the user's configured
+external editor on the directory in question. The menu label is rendered from
+the editor that the user has already chosen in `Settings → Code → External
+editor`; no editor is hardcoded.
+
+## Problem
+
+[Issue #8226](https://github.com/warpdotdev/warp/issues/8226) asks for a way to
+open a directory in `$EDITOR` from Warp. Today Warp's "Open in editor" plumbing
+([docs](https://docs.warp.dev/terminal/more-features/files-and-links)) only
+opens *files*. There is no fast path from "this tab represents a project I'm
+working on" or "this is a folder in the file tree" to "open this folder in my
+editor."
+
+Users currently fall back to typing `code .`, `cursor .`, or alt-tabbing into
+the editor and using its recent-projects list. Both break flow.
+
+The original issue's screenshot shows the request applied to a path printed in
+terminal output (CLI agent output). That is a third entry point with its own
+hit-testing and disambiguation cost; this spec does **not** attempt it. A
+prompt-area "Open in IDE" chip explored by @ATERCATES on a fork (see
+[issue #8226](https://github.com/warpdotdev/warp/issues/8226) discussion)
+is also out of scope here. The three entry points are complementary and can
+ship independently; this spec covers only the two right-click menus.
+
+## Non-goals
+
+- Hijacking clicks on directory paths printed inside terminal output (the
+  original #8226 request). Tracked separately.
+- Adding an "Open in IDE" chip to the prompt area (ATERCATES's prototype on his
+  fork).
+- Adding the menu item to the Warp Drive workspace switcher
+  (`app/src/drive/index.rs:2466 render_workspace_picker`). Warp Drive workspaces
+  are cloud entities without a local filesystem path; "Open in editor" has no
+  defined target there.
+- Supporting remote / SSH paths in this iteration. The file tree's
+  `is_remote_item` branch and SSH-backed terminal sessions are deferred.
+- Editor selection UX. The user's existing
+  `code.editor.open_file_editor` setting is read as-is; no new picker, no new
+  settings surface, no per-tab override.
+- Line/column positioning. Directories don't have a meaningful caret; the
+  existing `LineAndColumnArg` plumbing for files is irrelevant.
+- Changing the menu when the configured editor is `SystemDefault`, `Warp`, or
+  `EnvEditor` — see Behavior 4 / 5 for what's shown in those modes.
+
+## Figma
+
+None provided. The visible change is a single additional `MenuItem` inserted
+into two existing menus; no layout, color, or icon changes.
+
+## Behavior
+
+1. **Session tab right-click menu (horizontal and vertical tab bar).** When
+   the user right-clicks a tab whose pane has a resolvable local current
+   working directory, the menu shows an additional item labeled
+   "Open with <Editor display name>" (e.g. "Open with VS Code", "Open with
+   Cursor"). The item is grouped with `modify_tab_menu_items` — i.e.
+   immediately after the existing "Move to group / Pin / Rename" cluster and
+   before the close-tab section. Selecting it launches the configured editor
+   with the tab's cwd as the target.
+
+2. **File-tree directory right-click menu.** When the user right-clicks a
+   `DirectoryHeader` in the file tree, an item labeled "Open with <Editor
+   display name>" is inserted immediately after the existing "Reveal in
+   Finder" / "Reveal in Explorer" / "Reveal in file manager" item. Selecting
+   it launches the configured editor with the directory's absolute path as
+   the target.
+
+3. **Menu label is data-driven.** The editor display string comes from
+   `Editor::Display` (`app/src/util/file/external_editor/mod.rs`). The label
+   updates the next time the menu is opened after the user changes the
+   `code.editor.open_file_editor` setting; an open menu is not mutated mid-
+   flight.
+
+4. **`EditorChoice::ExternalEditor(_)` is the only case that shows a named
+   editor.** When the setting is `SystemDefault`, `Warp`, or `EnvEditor`, the
+   item label falls back to "Open in editor", and selecting it uses the
+   corresponding fallback behavior:
+   - `SystemDefault` → platform `open` / `xdg-open` / `start` on the
+     directory.
+   - `Warp` → no-op: directories do not open inside Warp's built-in editor.
+     The menu item is omitted in this mode.
+   - `EnvEditor` → spawn `$EDITOR` with the directory path as the single
+     argument. If `$EDITOR` is empty or unset, the item is omitted.
+
+5. **No menu item when there is no usable target.** The item is omitted (not
+   shown disabled) when any of the following hold:
+   - The tab's pane group has no resolvable cwd (e.g. SSH-only session
+     without a synced local path, agent-only tabs).
+   - The file-tree item is a remote entry (`is_remote_item == true`), matching
+     the existing "Reveal in Finder" treatment that already excludes these.
+   - The configured editor is `Warp` (per Behavior 4), or `EnvEditor` with no
+     `$EDITOR`.
+
+6. **Feature flag gate.** Both menu items are gated behind a single
+   `FeatureFlag::OpenDirectoryInExternalEditor`. When the flag is off, neither
+   menu changes — current behavior is preserved exactly.
+
+7. **Failure modes are non-blocking.** If the editor launch fails (binary not
+   found, permission denied, editor returns non-zero), Warp logs a warning
+   via the existing external-editor error path but does not surface a modal
+   or block the menu close. The same handling that exists today for
+   `open_file_path_in_external_editor` is reused; this spec adds no new
+   user-facing error UI.
+
+8. **Telemetry is unchanged.** No new analytics events. If existing
+   external-editor events are emitted for file opens, the same event family
+   is reused for directory opens with a `target_kind = "directory"` field
+   added (see TECH.md).
+
+## Validation
+
+- A tab with cwd `/Users/x/code/foo`, editor setting `ExternalEditor(VSCode)`:
+  right-click tab → menu shows "Open with VS Code" between the modify-tab and
+  close-tab sections; selecting it spawns VS Code on `/Users/x/code/foo`.
+
+- Same tab, editor setting changed to `ExternalEditor(Cursor)`: reopen the
+  menu, label is now "Open with Cursor".
+
+- Same tab, editor setting is `Warp`: menu does not contain the item.
+
+- Same tab, editor setting is `EnvEditor` with `EDITOR=zed`: label is "Open in
+  editor"; selecting it spawns `zed /Users/x/code/foo`.
+
+- File tree root directory of an indexed local repo: right-click → menu shows
+  "Open with <Editor>" immediately after "Reveal in Finder".
+
+- File tree root directory of a remote (SSH-backed) repo: menu does not
+  contain the item (matches existing "Reveal in Finder" treatment).
+
+- Feature flag off (`OpenDirectoryInExternalEditor = false`): tab and file-
+  tree menus are byte-for-byte unchanged from current master.

--- a/specs/gh-8226-open-with-editor/TECH.md
+++ b/specs/gh-8226-open-with-editor/TECH.md
@@ -1,0 +1,225 @@
+# gh-8226: Tech Spec
+
+## Context
+
+See `PRODUCT.md` for user-visible behavior.
+
+The feature wires a new menu item into two existing right-click context menus
+and adds a single platform-dispatched "open this directory in editor X"
+operation. There is no new view, no new settings surface, and no schema
+change.
+
+Anchors in current code:
+
+- `app/src/util/file/external_editor/mod.rs:293
+  open_file_path_in_external_editor` — existing entry point. Reads
+  `EditorSettings::open_file_editor`, extracts the `Editor` from
+  `EditorChoice::ExternalEditor(_)`, then calls
+  `open_file_path_with_editor` which `cfg_if!` dispatches to
+  `mac::open_file_path_with_line_and_col`,
+  `linux::open_file_path_with_line_and_col`, or
+  `windows::open_file_path_with_line_and_col`. **This path opens files only;
+  there is no equivalent for directories today.**
+- `app/src/util/file/external_editor/{mac,linux,windows}.rs` — per-platform
+  implementations. Each currently takes a `LineAndColumnArg` and a file
+  `&Path`. We add a sibling function that takes a directory path only.
+- `app/src/util/file/external_editor/settings.rs:21 EditorChoice` — the
+  setting variant the menu reads. No change to the enum or the underlying
+  TOML schema; the existing `code.editor.open_file_editor` value drives the
+  new directory open as well.
+- `app/src/util/file/external_editor/mod.rs:60-148 Editor` enum and its
+  `Display` impl — the source of the menu label's human-readable editor
+  name.
+- `app/src/tab.rs:213 menu_items_with_pane_name_target` — composes the tab
+  context menu by chaining section methods (`pin_menu_items`,
+  `tab_group_menu_items`, `session_sharing_menu_items`,
+  `copy_metadata_menu_items`, `modify_tab_menu_items`,
+  `close_tab_menu_items`, `save_config_menu_items`,
+  `color_option_menu_items`). The new menu item is added via a new
+  section method `open_in_editor_menu_items`, slotted between
+  `modify_tab_menu_items` and `close_tab_menu_items`.
+- `app/src/tab.rs:1134-1146` — established pattern for reading the active
+  session's working directory from a `Tab`:
+  `tab.pane_group.as_ref(ctx).focused_session_view(ctx)` →
+  `.model.lock().block_list().active_block().metadata().current_working_directory()`.
+  The same accessor is reused.
+- `app/src/code/file_tree/view.rs:2328 context_menu_items` — file-tree menu
+  builder. The `FileTreeItem::DirectoryHeader` branch is the insertion
+  point. The new item is pushed immediately after the existing
+  "Reveal in Finder" / "Reveal in Explorer" / "Reveal in file manager"
+  item at lines 2395-2406.
+- `app/src/code/file_tree/view.rs:2333 is_remote_item` — the existing
+  remote-suppression check that gates the entire local-only block of menu
+  items. The new item lives inside this branch and inherits the suppression
+  automatically.
+- `app/src/workspace/action.rs` (existing `WorkspaceAction`) and
+  `app/src/code/file_tree/view.rs` (`FileTreeAction`) — both already carry
+  the menu's `on_select` enums. New variants are added in each.
+- `app/src/features.rs` — `FeatureFlag` registry. A new
+  `OpenDirectoryInExternalEditor` variant gates both menu items.
+
+Out of scope for this spec:
+
+- SSH / remote terminal cwd resolution. The current cwd reader returns
+  `Option<String>`; we treat `None` as "no menu item" and defer remote
+  handling.
+- Re-ordering or restyling the existing menu sections. The new item is
+  additive.
+- Touching `app/src/drive/index.rs render_workspace_picker` (Warp Drive cloud
+  workspaces have no local cwd).
+
+## Proposed changes
+
+1. **Add `open_directory_in_external_editor`** in
+   `app/src/util/file/external_editor/mod.rs`, structured to mirror
+   `open_file_path_in_external_editor`:
+
+   ```rust path=null start=null
+   pub fn open_directory_in_external_editor(
+       directory: PathBuf,
+       ctx: &mut AppContext,
+   ) {
+       let editor = match *EditorSettings::as_ref(ctx).open_file_editor {
+           EditorChoice::ExternalEditor(editor) => Some(editor),
+           // SystemDefault, Warp, EnvEditor fall through to the
+           // platform-default open path. Menu callers omit the item for
+           // `Warp` and for `EnvEditor` with no $EDITOR — see PRODUCT.md
+           // Behavior 4 / 5.
+           _ => None,
+       };
+       open_directory_with_editor(directory, editor, ctx);
+   }
+
+   pub fn open_directory_with_editor(
+       directory: PathBuf,
+       editor: Option<Editor>,
+       ctx: &mut AppContext,
+   ) {
+       cfg_if::cfg_if! {
+           if #[cfg(target_os = "macos")] {
+               mac::open_directory(editor, &directory, ctx);
+           } else if #[cfg(any(target_os = "linux", target_os = "freebsd"))] {
+               linux::open_directory(editor, &directory, ctx);
+           } else if #[cfg(windows)] {
+               windows::open_directory(editor, &directory, ctx);
+           } else {
+               ctx.open_file_path(&directory);
+           }
+       }
+   }
+   ```
+
+2. **Per-platform `open_directory` implementations** in
+   `app/src/util/file/external_editor/{mac,linux,windows}.rs`. Each one:
+   - When `editor` is `Some(Editor::*)`, look up the editor's app-id /
+     binary name from the same per-platform table the file path already
+     uses, then `Command::new(...).arg(directory).spawn()` (mac/linux) or
+     the Windows equivalent. Reuse the existing not-found / spawn-error
+     logging path.
+   - When `editor` is `None`, dispatch to the platform default-open call
+     (`open` / `xdg-open` / `start`) on the directory.
+   - Logging on failure matches `open_file_path_with_line_and_col` —
+     warn-level message and graceful return, no panic, no toast.
+
+   Tests live alongside in
+   `external_editor/{mac,linux,windows}_tests.rs` covering the editor
+   resolution → command construction for at least one
+   `Editor::ExternalEditor(_)` and the `None` fallback path.
+
+3. **Feature flag.**
+
+   - Add `FeatureFlag::OpenDirectoryInExternalEditor` to
+     `app/src/features.rs`.
+   - Both menu insertions are gated by
+     `FeatureFlag::OpenDirectoryInExternalEditor.is_enabled()`. When the
+     flag is off, neither menu builder pushes the new item, so the
+     resulting `Vec<MenuItem<_>>` is identical to current master.
+
+4. **Session-tab menu insertion** (`app/src/tab.rs`):
+
+   - Add a new `WorkspaceAction::OpenTabCwdInExternalEditor { tab_index:
+     usize }`.
+   - Add a new section method
+     `fn open_in_editor_menu_items(&self, index: usize, ctx: &AppContext)
+     -> Vec<MenuItem<WorkspaceAction>>` that:
+     - Returns `vec![]` if the feature flag is off.
+     - Returns `vec![]` if the focused session view has no
+       `current_working_directory()`.
+     - Returns `vec![]` if `EditorSettings::open_file_editor` is
+       `EditorChoice::Warp` (no in-app directory open) or `EditorChoice::
+       EnvEditor` with `std::env::var("EDITOR")` empty.
+     - Otherwise builds a single `MenuItemFields` with a label derived from
+       the editor choice (see step 6) and an `on_select_action`
+       `WorkspaceAction::OpenTabCwdInExternalEditor { tab_index: index }`.
+   - Slot the section into `menu_items_with_pane_name_target`'s
+     section list, between `modify_tab_menu_items` and
+     `close_tab_menu_items`. The existing separator-insertion logic at
+     `tab.rs:237-244` handles spacing automatically when the new section
+     returns non-empty.
+
+5. **`WorkspaceAction::OpenTabCwdInExternalEditor` handler** in
+   `app/src/workspace/view.rs`: look up the tab by index, read the
+   focused-session-view's `current_working_directory()`, and call
+   `open_directory_in_external_editor(path, ctx)`. If the cwd is `None`
+   between menu-open and selection (extremely narrow race), drop the
+   action silently — matches the existing pattern for "Copy git branch"
+   when the data is gone.
+
+6. **File-tree menu insertion** (`app/src/code/file_tree/view.rs`):
+
+   - Add a new `FileTreeAction::OpenWithExternalEditor { id:
+     FileTreeIdentifier }`.
+   - In `context_menu_items`, inside the
+     `FileTreeItem::DirectoryHeader { .. }` branch, immediately after the
+     "Reveal in Finder"-family item is pushed (`view.rs:2395-2406`), push a
+     new `MenuItemFields` when:
+     - `FeatureFlag::OpenDirectoryInExternalEditor.is_enabled()`, AND
+     - the same `EditorChoice` gating as the tab menu (not `Warp`, not
+       `EnvEditor` with empty `$EDITOR`).
+     The label comes from the same helper as the tab menu (step 7).
+   - Action handler (in the same `view.rs` action match) resolves the
+     `FileTreeIdentifier` to an absolute local path following the existing
+     `OpenInFinder` action handler's resolution pattern (the same `id →
+     local path` mapping that lookup uses), then calls
+     `open_directory_in_external_editor(path, ctx)`.
+
+7. **Shared label helper.** Both menus compute the label from the same
+   function:
+
+   ```rust path=null start=null
+   fn open_with_editor_menu_label(ctx: &AppContext) -> Option<String> {
+       match *EditorSettings::as_ref(ctx).open_file_editor {
+           EditorChoice::ExternalEditor(editor) =>
+               Some(format!("Open with {editor}")),
+           EditorChoice::SystemDefault => Some("Open in editor".to_string()),
+           EditorChoice::EnvEditor if !std::env::var("EDITOR")
+               .unwrap_or_default().is_empty() =>
+               Some("Open in editor".to_string()),
+           // Warp and EnvEditor-without-$EDITOR have no item.
+           _ => None,
+       }
+   }
+   ```
+
+   The helper lives in `app/src/util/file/external_editor/mod.rs` so both
+   call sites depend on the same place the platform dispatch already lives.
+
+## Testing
+
+- **`external_editor/{mac,linux,windows}_tests.rs`** — extend with
+  directory-open cases matching the existing file-open cases.
+- **`app/src/workspace/view_tests.rs`** — add a tab-context-menu test
+  alongside the existing `test_tab_context_menu_copies_metadata`
+  (`view_tests.rs:2042`) that asserts the new item is present with the
+  expected label when the flag is on and an `Editor::VSCode` is configured,
+  and absent when the flag is off.
+- **`app/src/code/file_tree/view_tests`** (or the existing
+  `file_tree::view` test module) — assert the same for a `DirectoryHeader`
+  context menu, including the remote-suppression case.
+
+## Rollout
+
+- Single feature flag gates both menu items. Default off in `master`.
+- Per `git-workflow` discipline, ship the spec PR first; the
+  implementation PR (with the flag default still off) ships second and is
+  enabled in a follow-up flip after manual verification.


### PR DESCRIPTION
## Summary

Add `PRODUCT.md` and `TECH.md` for a feature-flagged "Open with <Editor>" item on two existing right-click context menus — session tabs and file-tree directory headers. The menu label is rendered from the user's existing `code.editor.open_file_editor` setting; no editor is hardcoded. No code changes in this PR.

## Motivation

[Issue #8226](https://github.com/warpdotdev/warp/issues/8226) asks for a way to open a directory in `$EDITOR` from Warp. Today's "Open in editor" plumbing supports files only; there is no fast path from "this tab represents a project" or "this is a folder in the file tree" to "open this folder in my editor." This spec defines one of three complementary UX entry points discussed on the issue (the other two — click-on-output and prompt-area chip — remain out of scope and are tracked separately).

## What's changed

- `specs/gh-8226-open-with-editor/PRODUCT.md` — Summary / Problem / Non-goals / Behavior (8 numbered points) / Validation.
- `specs/gh-8226-open-with-editor/TECH.md` — Anchors in current code (with file:line refs to `external_editor/mod.rs`, `tab.rs`, `code/file_tree/view.rs`), proposed changes (new `open_directory_in_external_editor` + per-platform impls, new `FeatureFlag::OpenDirectoryInExternalEditor`, two new action variants, shared label helper), testing notes, rollout.

## Out of scope

- Hijacking clicks on directory paths printed inside terminal output (the original ask in this issue).
- Prompt-area "Open in IDE" chip (@ATERCATES's prototype on a fork).
- Warp Drive workspace switcher (`app/src/drive/index.rs render_workspace_picker`) — cloud entities have no local cwd.
- SSH / remote terminal paths.
- Line/column positioning (directories have no caret).

## Validation

Documentation-only PR. The validation cases that the implementation PR will exercise are listed in `PRODUCT.md` § Validation:
- Editor setting changes update the label on next menu open.
- `EditorChoice::Warp` omits the item.
- `EditorChoice::EnvEditor` with empty `\$EDITOR` omits the item.
- File-tree remote entries omit the item (matches existing "Reveal in Finder" treatment).
- Feature flag off → both menus are byte-for-byte unchanged from current `master`.

## Related issues

- Closes part of #8226 (the tab + file-tree right-click UX vector). The other two UX vectors discussed on that issue remain open.