### PR TITLE
remove strong model handle captures in subscriptions

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1248,12 +1248,11 @@ impl AgentDriver {
         let failed_for_subscription = Arc::clone(&failed);
 
         let templatable_mcp_manager = TemplatableMCPServerManager::handle(ctx);
-        let manager_clone = templatable_mcp_manager.clone();
 
         // Clear any stale subscription left behind by a previous wait that
         // timed out, so it can't tear down this wait's subscription.
         ctx.unsubscribe_from_model(&templatable_mcp_manager);
-        ctx.subscribe_to_model(&templatable_mcp_manager, move |_me, _, event, ctx| {
+        ctx.subscribe_to_model(&templatable_mcp_manager, move |_me, manager, event, ctx| {
             let TemplatableMCPServerManagerEvent::StateChanged { uuid, state } = event else {
                 return;
             };
@@ -1290,7 +1289,7 @@ impl AgentDriver {
                 if let Some(sender) = tx.take() {
                     let _ = sender.send(());
                 }
-                ctx.unsubscribe_from_model(&manager_clone);
+                ctx.unsubscribe_from_model(&manager);
             }
         });
 
@@ -1533,9 +1532,8 @@ impl AgentDriver {
         let mut collected_wait_uuids = Vec::<Uuid>::new();
 
         let file_based_mcp_manager = FileBasedMCPManager::handle(ctx);
-        let manager_clone = file_based_mcp_manager.clone();
 
-        ctx.subscribe_to_model(&file_based_mcp_manager, move |_me, _, event, ctx| {
+        ctx.subscribe_to_model(&file_based_mcp_manager, move |_me, manager, event, ctx| {
             if let FileBasedMCPManagerEvent::CloudEnvMcpScanComplete {
                 repo_path,
                 wait_server_uuids,
@@ -1555,7 +1553,7 @@ impl AgentDriver {
                             );
                             let _ = sender.send(uuids);
                         }
-                        ctx.unsubscribe_from_model(&manager_clone);
+                        ctx.unsubscribe_from_model(&manager);
                     }
                 }
             }
@@ -1641,10 +1639,9 @@ impl AgentDriver {
         let mut tx = Some(tx);
 
         let templatable_manager_handle = TemplatableMCPServerManager::handle(ctx);
-        let manager_clone = templatable_manager_handle.clone();
         let pending_state_details_for_subscription = Arc::clone(&pending_state_details);
 
-        ctx.subscribe_to_model(&templatable_manager_handle, move |_me, _, event, ctx| {
+        ctx.subscribe_to_model(&templatable_manager_handle, move |_me, manager, event, ctx| {
             if let TemplatableMCPServerManagerEvent::StateChanged { uuid, state } = event {
                 if !pending_uuids.contains(uuid) {
                     return;
@@ -1676,7 +1673,7 @@ impl AgentDriver {
                     if let Some(sender) = tx.take() {
                         let _ = sender.send(());
                     }
-                    ctx.unsubscribe_from_model(&manager_clone);
+                    ctx.unsubscribe_from_model(&manager);
                 }
             }
         });

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1641,42 +1641,47 @@ impl AgentDriver {
         let templatable_manager_handle = TemplatableMCPServerManager::handle(ctx);
         let pending_state_details_for_subscription = Arc::clone(&pending_state_details);
 
-        ctx.subscribe_to_model(&templatable_manager_handle, move |_me, manager, event, ctx| {
-            if let TemplatableMCPServerManagerEvent::StateChanged { uuid, state } = event {
-                if !pending_uuids.contains(uuid) {
-                    return;
-                }
-                let server_name = file_based_mcp_names
-                    .get(uuid)
-                    .map(String::as_str)
-                    .unwrap_or("<unknown>");
-                let error = TemplatableMCPServerManager::as_ref(ctx)
-                    .get_server_error_message(*uuid)
-                    .map(|message| format!(", error={message}"))
-                    .unwrap_or_default();
-                if let Ok(mut details) = pending_state_details_for_subscription.lock() {
-                    details.insert(*uuid, format!("{server_name} ({uuid}): {state:?}{error}"));
-                }
-                match state {
-                    MCPServerState::Running | MCPServerState::FailedToStart => {
-                        pending_uuids.remove(uuid);
-                        if let Ok(mut details) = pending_state_details_for_subscription.lock() {
-                            details.remove(uuid);
-                        }
-                    }
-                    _ => {
+        ctx.subscribe_to_model(
+            &templatable_manager_handle,
+            move |_me, manager, event, ctx| {
+                if let TemplatableMCPServerManagerEvent::StateChanged { uuid, state } = event {
+                    if !pending_uuids.contains(uuid) {
                         return;
                     }
-                }
-                if pending_uuids.is_empty() {
-                    log::info!("All file-based MCP servers reached a terminal state; proceeding");
-                    if let Some(sender) = tx.take() {
-                        let _ = sender.send(());
+                    let server_name = file_based_mcp_names
+                        .get(uuid)
+                        .map(String::as_str)
+                        .unwrap_or("<unknown>");
+                    let error = TemplatableMCPServerManager::as_ref(ctx)
+                        .get_server_error_message(*uuid)
+                        .map(|message| format!(", error={message}"))
+                        .unwrap_or_default();
+                    if let Ok(mut details) = pending_state_details_for_subscription.lock() {
+                        details.insert(*uuid, format!("{server_name} ({uuid}): {state:?}{error}"));
                     }
-                    ctx.unsubscribe_from_model(&manager);
+                    match state {
+                        MCPServerState::Running | MCPServerState::FailedToStart => {
+                            pending_uuids.remove(uuid);
+                            if let Ok(mut details) = pending_state_details_for_subscription.lock() {
+                                details.remove(uuid);
+                            }
+                        }
+                        _ => {
+                            return;
+                        }
+                    }
+                    if pending_uuids.is_empty() {
+                        log::info!(
+                            "All file-based MCP servers reached a terminal state; proceeding"
+                        );
+                        if let Some(sender) = tx.take() {
+                            let _ = sender.send(());
+                        }
+                        ctx.unsubscribe_from_model(&manager);
+                    }
                 }
-            }
-        });
+            },
+        );
 
         Either::Left(async move {
             match rx.with_timeout(MCP_SERVER_STARTUP_TIMEOUT).await {

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -2468,15 +2468,14 @@ impl BlocklistAIController {
             )
         });
         let response_stream_id = response_stream.as_ref(ctx).id().clone();
-        let response_stream_clone = response_stream.clone();
         let input_contains_user_query = request_input
             .all_inputs()
             .any(|input| input.is_user_query());
-        ctx.subscribe_to_model(&response_stream, move |me, _, event, ctx| {
+        ctx.subscribe_to_model(&response_stream, move |me, response_stream, event, ctx| {
             me.handle_response_stream_event(
                 input_contains_user_query,
                 event,
-                &response_stream_clone,
+                &response_stream,
                 ctx,
             );
         });

--- a/app/src/terminal/view/ambient_agent/mod.rs
+++ b/app/src/terminal/view/ambient_agent/mod.rs
@@ -100,9 +100,8 @@ pub fn create_cloud_mode_view(
                     // conversation on chip click. Use append-mode scrollback
                     // + replay suppression so the cloud agent's replay doesn't
                     // duplicate the blocks we already have.
-                    let append_followup_scrollback = view_model
-                        .as_ref(ctx)
-                        .is_local_to_cloud_handoff();
+                    let append_followup_scrollback =
+                        view_model.as_ref(ctx).is_local_to_cloud_handoff();
                     if manager.connect_to_session(*session_id, append_followup_scrollback, ctx) {
                         manager.start_cloud_mode_setup_command_tracking();
                     }

--- a/app/src/terminal/view/ambient_agent/mod.rs
+++ b/app/src/terminal/view/ambient_agent/mod.rs
@@ -86,9 +86,8 @@ pub fn create_cloud_mode_view(
         log::warn!("Cloud mode view was created without an ambient agent view model");
         return (terminal_view, terminal_manager);
     };
-    let view_model_for_subscription = view_model.clone();
     terminal_manager.update(ctx, |_, ctx| {
-        ctx.subscribe_to_model(&view_model, move |manager, _, event, ctx| {
+        ctx.subscribe_to_model(&view_model, move |manager, view_model, event, ctx| {
             let Some(manager) = manager
                 .as_any_mut()
                 .downcast_mut::<shared_session::viewer::TerminalManager>()
@@ -101,7 +100,7 @@ pub fn create_cloud_mode_view(
                     // conversation on chip click. Use append-mode scrollback
                     // + replay suppression so the cloud agent's replay doesn't
                     // duplicate the blocks we already have.
-                    let append_followup_scrollback = view_model_for_subscription
+                    let append_followup_scrollback = view_model
                         .as_ref(ctx)
                         .is_local_to_cloud_handoff();
                     if manager.connect_to_session(*session_id, append_followup_scrollback, ctx) {


### PR DESCRIPTION
## Description

This PR is part of an effort to prevent future memory leaks. It is a follow-up to #12767 where we added a new param to `ModelContext::subscribe_to_model`. This PR actually utilizes that new param. This is to prevent scenarios _a. la._ #12355.

## Linked Issue

None. This is structural improvements to memory hygiene.
