### PR TITLE
Fix IME popup position in TUI mode (alt screen) - issue #9145

### DIFF
--- a/app/src/terminal/alt_screen/alt_screen_element.rs
+++ b/app/src/terminal/alt_screen/alt_screen_element.rs
@@ -767,6 +767,24 @@ impl Element for AltScreenElement {
         );
         record_trace_event!("alt_screen_element:paint:grid_rendered");
 
+        // Always cache the cursor position for IME (input method editor) popup
+        // positioning, as long as the CLI rich input overlay is not active. When
+        // the rich input overlay is open it manages its own cursor position.
+        // Caching unconditionally (regardless of `cursor_visible`) ensures the
+        // IME popup appears at the correct location even when the TUI app
+        // temporarily hides the cursor during screen updates (e.g. via \e[?25l).
+        if !self.grid_render_params.hide_cursor_cell {
+            grid_renderer::cache_cursor_position_for_ime(
+                &self.grid_render_params,
+                grid.cursor_render_point(),
+                grid.is_cursor_on_wide_char(),
+                padding_x,
+                adjusted_grid_origin,
+                ctx,
+                self.terminal_view_id,
+            );
+        }
+
         // Render cursor if the escape sequence is set.
         // Also suppress the cursor when hide_cursor_cell is active (CLI agent rich input is open).
         if cursor_visible && !self.grid_render_params.hide_cursor_cell {

--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -2340,6 +2340,43 @@ fn calculate_cursor_origin(
         )
 }
 
+/// Caches the alt-screen cursor position for IME (input method editor) popup
+/// positioning without rendering the cursor visually. Call this whenever the
+/// cursor is hidden (e.g. because the TUI app issued `\e[?25l`) so that
+/// `TerminalView::active_cursor_position` always has a current value for
+/// `firstRectForCharacterRange:`, even between frames where the cursor is not
+/// drawn.
+#[allow(clippy::too_many_arguments)]
+pub fn cache_cursor_position_for_ime(
+    grid_render_params: &GridRenderParams,
+    cursor_point: Point,
+    is_cursor_on_wide_char: bool,
+    padding_x: Pixels,
+    grid_origin: Vector2F,
+    ctx: &mut PaintContext,
+    terminal_view_id: EntityId,
+) {
+    let line_top_origin = grid_origin
+        + vec2f(padding_x.as_f32(), 0.)
+        + grid_render_params.cell_size * vec2f(cursor_point.col as f32, cursor_point.row as f32);
+
+    let cursor_top_origin = calculate_cursor_origin(grid_render_params, line_top_origin, ctx);
+    let cell_width = if is_cursor_on_wide_char {
+        grid_render_params.cell_size.x() * 2.
+    } else {
+        grid_render_params.cell_size.x()
+    };
+    let cursor_block_size = vec2f(
+        cell_width,
+        grid_render_params.font_size * DEFAULT_UI_LINE_HEIGHT_RATIO,
+    );
+
+    ctx.position_cache.cache_position_indefinitely(
+        format!("terminal_view:cursor_{terminal_view_id}"),
+        RectF::new(cursor_top_origin, cursor_block_size),
+    );
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn render_cursor(
     grid_render_params: &GridRenderParams,


### PR DESCRIPTION
## Description

Fix Japanese/Chinese IME popup positioning when typing inside TUI-based AI coding sessions (Claude Code, Gemini CLI, etc.) running in the alt screen.

When a TUI app is running in the alt screen, the IME candidate window appears far above the actual cursor position. The fix ensures the alt-screen cursor position is always cached for IME positioning, even when the cursor is temporarily hidden by the TUI app during screen updates.

## Linked Issue

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Fixes https://github.com/warpdotdev/warp/issues/9145

## Root Cause

macOS calls `firstRectForCharacterRange:` to determine where to position the IME candidate window. Warp's `warp_ime_position()` reads the cursor location from the render position cache (`terminal_view:cursor_<id>`).

This cache is only updated inside `render_cursor()`, which is only called when `cursor_visible = true` (i.e. when `TermMode::SHOW_CURSOR` is set). TUI apps frequently hide the cursor while drawing their UI (using `ESC[?25l`) and then show it at the input prompt (using `ESC[?25h`). If a Warp render frame happens while the cursor is hidden, `render_cursor()` is skipped and the position cache retains a stale value—often from row 0 at session start. When the user then activates IME, `firstRectForCharacterRange:` reads the stale position and places the candidate window near the top of the window, far from the actual input prompt.

## Fix

Added `cache_cursor_position_for_ime()` in `grid_renderer.rs` that computes and caches the cursor position without doing any visual rendering. `AltScreenElement::paint` now always calls this function when the CLI rich-input overlay is not active (`hide_cursor_cell = false`), regardless of `cursor_visible`. The existing `render_cursor()` call (which handles both caching and visual rendering) remains gated on `cursor_visible`, so cursor blink/hide behavior is unchanged.

This mirrors how `BlockGrid::draw_cursor` already handles `CursorShape::Hidden` cursors in the block list renderer—it always caches the position even for hidden cursors.

When the rich-input overlay is open (`hide_cursor_cell = true`), the focused view is the overlay's `EditorView`, which manages its own cursor position for IME—so we correctly skip the alt-screen caching in that case.

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

This fix is macOS-only (Japanese/Chinese IME on macOS), but the code change is cross-platform safe. The `cache_cursor_position_for_ime` function only writes to the position cache and does no rendering.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed Japanese and Chinese IME popup appearing far above the cursor when typing in TUI-based sessions (Claude Code, Gemini CLI, etc.).

_Conversation: https://staging.warp.dev/conversation/b20f9e65-e68e-463f-8b58-27837852835c_
_Run: https://oz.staging.warp.dev/runs/019ef055-d8ee-71ea-9f71-4ba1fbdcbae0_
_This PR was generated with [Oz](https://warp.dev/oz)._
