### PR TITLE
perf: reduce O(n) re-renders in AIBlock on AppendedExchange for long conversations

### DIFF
--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -1266,13 +1266,9 @@ impl AIBlock {
             }
         });
 
-        // Note: UpdatedStreamingExchange is handled by the dedicated on_updated_output()
-        // callback in model_impl.rs, so we don't need to respond to it here.
-        //
-        // Note: AppendedExchange is handled by the TerminalView, which directly notifies
-        // the previous last AIBlock in the conversation instead of broadcasting to all
-        // AIBlocks. This avoids O(n) re-renders when a new exchange is appended to a
-        // conversation with many exchanges.
+        // Note: UpdatedStreamingExchange is handled by on_updated_output() in model_impl.rs.
+        // AppendedExchange is handled by TerminalView, which notifies only the previous last
+        // AIBlock directly (avoids O(n) re-renders on every new exchange).
         ctx.subscribe_to_model(
             &BlocklistAIHistoryModel::handle(ctx),
             |me, _, event, ctx| {

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -1268,6 +1268,11 @@ impl AIBlock {
 
         // Note: UpdatedStreamingExchange is handled by the dedicated on_updated_output()
         // callback in model_impl.rs, so we don't need to respond to it here.
+        //
+        // Note: AppendedExchange is handled by the TerminalView, which directly notifies
+        // the previous last AIBlock in the conversation instead of broadcasting to all
+        // AIBlocks. This avoids O(n) re-renders when a new exchange is appended to a
+        // conversation with many exchanges.
         ctx.subscribe_to_model(
             &BlocklistAIHistoryModel::handle(ctx),
             |me, _, event, ctx| {
@@ -1276,8 +1281,7 @@ impl AIBlock {
                     .is_none_or(|id| id == me.terminal_view_id)
                 {
                     match event {
-                        BlocklistAIHistoryEvent::AppendedExchange { .. }
-                        | BlocklistAIHistoryEvent::UpdatedTodoList { .. }
+                        BlocklistAIHistoryEvent::UpdatedTodoList { .. }
                         | BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. }
                         | BlocklistAIHistoryEvent::StartedNewConversation { .. }
                         | BlocklistAIHistoryEvent::SetActiveConversation { .. } => {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -6134,6 +6134,18 @@ impl TerminalView {
                     return;
                 }
 
+                // Record the current last AIBlock for this conversation before inserting the
+                // new one. After insertion we'll notify it directly so it re-renders to update
+                // state that depends on being the latest exchange (e.g.,
+                // `is_latest_visible_exchange_in_root_task`). This avoids broadcasting an
+                // O(n) re-render to every AIBlock via the history model subscription.
+                let conversation_id_for_prev_notify = *conversation_id;
+                let prev_last_ai_block = self.rich_content_views.iter().rev().find_map(|rc| {
+                    let ai_metadata = rc.ai_block_metadata()?;
+                    (ai_metadata.conversation_id == conversation_id_for_prev_notify)
+                        .then(|| ai_metadata.ai_block_handle.clone())
+                });
+
                 let ai_block_model = match AIBlockModelImpl::<AIBlock>::new(
                     *exchange_id,
                     *conversation_id,
@@ -6213,6 +6225,15 @@ impl TerminalView {
                     },
                     ctx,
                 );
+
+                // Notify the previous last AIBlock for this conversation so it can update
+                // state that depends on `is_latest_visible_exchange_in_root_task` (e.g.,
+                // hiding the last-block-only footer). This is a targeted O(1) notification
+                // that replaces the O(n) broadcast that previously fired via the
+                // `AppendedExchange` subscription in each `AIBlock`.
+                if let Some(prev_last) = prev_last_ai_block {
+                    prev_last.update(ctx, |_, ctx| ctx.notify());
+                }
 
                 if !is_hidden && !is_passive_conversation {
                     // Clear agent mode query banners and hidden blocks when a new AI block is created.

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -6134,11 +6134,9 @@ impl TerminalView {
                     return;
                 }
 
-                // Record the current last AIBlock for this conversation before inserting the
-                // new one. After insertion we'll notify it directly so it re-renders to update
-                // state that depends on being the latest exchange (e.g.,
-                // `is_latest_visible_exchange_in_root_task`). This avoids broadcasting an
-                // O(n) re-render to every AIBlock via the history model subscription.
+                // Capture the current last AIBlock before inserting the new one. After
+                // insertion we notify it directly so it can update its last-block footer
+                // state (is_latest_visible_exchange_in_root_task).
                 let conversation_id_for_prev_notify = *conversation_id;
                 let prev_last_ai_block = self.rich_content_views.iter().rev().find_map(|rc| {
                     let ai_metadata = rc.ai_block_metadata()?;
@@ -6226,11 +6224,7 @@ impl TerminalView {
                     ctx,
                 );
 
-                // Notify the previous last AIBlock for this conversation so it can update
-                // state that depends on `is_latest_visible_exchange_in_root_task` (e.g.,
-                // hiding the last-block-only footer). This is a targeted O(1) notification
-                // that replaces the O(n) broadcast that previously fired via the
-                // `AppendedExchange` subscription in each `AIBlock`.
+                // Notify the previous last AIBlock to update its footer state.
                 if let Some(prev_last) = prev_last_ai_block {
                     prev_last.update(ctx, |_, ctx| ctx.notify());
                 }


### PR DESCRIPTION
## Description

In a long agent conversation with N exchanges, every `AIBlock` subscribed to `AppendedExchange` and called `ctx.notify()`, causing N re-renders every time a new message was sent. Each `AIBlock.render()` is expensive (markdown, code blocks, tool calls, etc.).

The fix: remove `AppendedExchange` from the broadcast subscription. Instead, `TerminalView` directly notifies only the *previous* last `AIBlock` after inserting the new one — that's the only block that actually needs to update (its `is_latest_visible_exchange_in_root_task` footer state changed). O(n) → O(1).

## Linked Issue

Investigated from an internal Slack report about scrolling lag in long orchestrator conversations. No existing issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

Pure perf optimization, no behavior change. `cargo check`, `./script/format`, and `cargo clippy -p warp` all pass.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

_Conversation: https://staging.warp.dev/conversation/56d3dd3a-1f06-4a39-b039-1e8bb6138954_
_Run: https://oz.staging.warp.dev/runs/019ef075-76f5-7db2-aae1-1d62e870943f_
_This PR was generated with [Oz](https://warp.dev/oz)._
