### PR TITLE
Add pinning feature flag to dogfood

### DIFF
--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -950,6 +950,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::RestorePromptOnInlineModelSelectorSearch,
     FeatureFlag::WarpControlCli,
     FeatureFlag::PromptCacheExpiryWarning,
+    FeatureFlag::PinnedTabs,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description
Switches the pinning feature flag to dogfood.

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4771/switch-pinning-flag-to-dogfood

