### PR TITLE
Fix macOS Window menu registration

### DIFF
--- a/crates/warpui/src/platform/mac/objc/window.m
+++ b/crates/warpui/src/platform/mac/objc/window.m
@@ -39,6 +39,11 @@ dispatch_once_t fullscreenQueueOnce;
 - (void)enqueueFullscreenTransition;
 @end
 
+static void refresh_windows_menu_item(NSWindow *window) {
+    if (![window isVisible]) return;
+    [NSApp changeWindowsItem:window title:[window title] filename:NO];
+}
+
 @implementation NSWindow (Fullscreen)
 - (void)enqueueFullscreenTransition {
     // If the queue doesn't already exist, allocate it.
@@ -52,6 +57,7 @@ dispatch_once_t fullscreenQueueOnce;
       [fullscreenManager enqueueWindow:self];
     });
 }
+
 @end
 
 @protocol WarpWindowProtocol
@@ -1109,14 +1115,8 @@ void set_window_alpha(WarpWindow<WarpWindowProtocol> *window, double alpha) {
 }
 
 void set_window_title(id window, NSString *title) {
-    if ([window isKindOfClass:[WarpPanel class]] && [window isVisible]) {
-        // For the hotkey window (which is an NSPanel), we need to explicitly
-        // add the panel to the windows list.  `changeWindowsItem` will add the
-        // panel to the list if it isn't already there.
-        [NSApp changeWindowsItem:window title:title filename:NO];
-    }
-
     [window setTitle:title];
+    refresh_windows_menu_item(window);
 }
 
 void set_titlebar_height(id window, CGFloat height) {
@@ -1144,6 +1144,7 @@ void position_and_order_front(WarpWindow<WarpWindowProtocol> *window) {
     }
 
     [window makeKeyAndOrderFront:nil];
+    refresh_windows_menu_item(window);
 }
 
 void position_at_given_location(WarpWindow<WarpWindowProtocol> *window, NSPoint origin) {
@@ -1152,9 +1153,11 @@ void position_at_given_location(WarpWindow<WarpWindowProtocol> *window, NSPoint 
     NSPoint topLeft = NSMakePoint(origin.x, origin.y + [window frame].size.height);
     [window setFrameTopLeftPoint:topLeft];
     [window makeKeyAndOrderFront:nil];
+    refresh_windows_menu_item(window);
 }
 
 void order_front_without_focus(WarpWindow<WarpWindowProtocol> *window, NSPoint origin) {
     [window setFrameOrigin:origin];
     [window orderFront:nil];
+    refresh_windows_menu_item(window);
 }

--- a/crates/warpui/src/platform/mac/window.rs
+++ b/crates/warpui/src/platform/mac/window.rs
@@ -646,6 +646,9 @@ impl Window {
 
             // SAFETY: these call into the hand-written Objective-C positioning helpers.
             unsafe {
+                if let Some(title) = options.title.as_deref() {
+                    set_window_title(native_window_ref, &NSString::from_str(title));
+                }
                 match options.style {
                     WindowStyle::Normal | WindowStyle::Pin => {
                         match options.bounds {


### PR DESCRIPTION
## Description
Fixes macOS Window menu registration for newly opened Warp windows.

The macOS custom window path now:
- applies the initial `WindowOptions.title` to the native `NSWindow` before ordering it front
- refreshes the AppKit Window menu item after a Warp window is ordered front or retitled

This keeps new Warp windows visible in the system Window menu before any tab/title change occurs.

## Linked Issue
Fixes #12928

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `./script/format`
- `cargo check -p warpui --lib`
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` *(blocked in this sandbox by missing generated `preview_config.json`, `local_config.json`, and `dev_config.json` under `target/debug/build/warp-*/out` before reaching these changes)*

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not captured in this Linux sandbox because the issue is macOS AppKit-specific.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed newly opened Warp windows not appearing in the macOS Window menu until a tab title changed.

_Conversation: https://staging.warp.dev/conversation/ed82716c-9e7e-4dc7-a8a3-991475b12f77_
_Run: https://oz.staging.warp.dev/runs/019ef188-e3a1-76f9-a2f2-c29a78dac78b_
_This PR was generated with [Oz](https://warp.dev/oz)._
