### PR TITLE
Buffer input updates when not connected to shared session

### DIFF
--- a/app/src/terminal/shared_session/sharer/network.rs
+++ b/app/src/terminal/shared_session/sharer/network.rs
@@ -644,8 +644,14 @@ impl Network {
 
         let update = InputUpdate { id, ops };
         if matches!(self.stage, Stage::StartedSuccessfully { .. }) {
-            if let Err(e) = self.ws_proxy_tx.try_send(UpstreamMessage::UpdateInput(update)) {
-                sharer_warn!(self, "Failed to send input update over ws_proxy channel: {e}");
+            if let Err(e) = self
+                .ws_proxy_tx
+                .try_send(UpstreamMessage::UpdateInput(update))
+            {
+                sharer_warn!(
+                    self,
+                    "Failed to send input update over ws_proxy channel: {e}"
+                );
             }
         } else {
             // Not connected; buffer the update to be flushed on reconnect.
@@ -1663,14 +1669,17 @@ impl Network {
     }
 
     /// Sends all input updates buffered during disconnection to the server, then clears the buffer.
-    /// This is more a best-effort attempt because these events are not critical - that's why they are not ordered terminal events. 
+    /// This is more a best-effort attempt because these events are not critical - that's why they are not ordered terminal events.
     /// With ordered terminal events we require an ack from the server before the client can remove them from the buffer, but we don't do that for these events.
     fn flush_pending_input_updates_to_server(&mut self) {
         // Take the updates out of self to avoid a borrow conflict with sharer_warn!, which
         // borrows all of self while drain() holds a mutable borrow on pending_input_updates.
         let updates = std::mem::take(&mut self.pending_input_updates);
         for update in updates {
-            if let Err(e) = self.ws_proxy_tx.try_send(UpstreamMessage::UpdateInput(update)) {
+            if let Err(e) = self
+                .ws_proxy_tx
+                .try_send(UpstreamMessage::UpdateInput(update))
+            {
                 sharer_warn!(
                     self,
                     "Failed to send pending input update over ws_proxy channel: {e}"

--- a/app/src/terminal/shared_session/sharer/network.rs
+++ b/app/src/terminal/shared_session/sharer/network.rs
@@ -291,6 +291,9 @@ pub struct Network {
 
     /// The parameters for the next input operation to send.
     next_buffer_seq_no: (BlockId, InputOperationSeqNo),
+
+    /// Input updates buffered while disconnected, to be flushed on reconnect.
+    pending_input_updates: Vec<InputUpdate>,
 }
 
 impl Network {
@@ -337,6 +340,7 @@ impl Network {
             source: SharedSessionSource::default(),
             unacked_terminal_events: HashMap::new(),
             next_buffer_seq_no: (init_block_id, InputOperationSeqNo::zero()),
+            pending_input_updates: Vec::new(),
         };
         let sharer_firebase_uid = UserUid::new("mock_firebase_uid");
         ctx.emit(NetworkEvent::SharedSessionCreatedSuccessfully {
@@ -431,6 +435,7 @@ impl Network {
             source,
             unacked_terminal_events: HashMap::new(),
             next_buffer_seq_no: (init_block_id.clone(), InputOperationSeqNo::zero()),
+            pending_input_updates: Vec::new(),
         };
 
         // We should validate the scrollback is under the limit before creating the Network, but check here just to be safe.
@@ -611,6 +616,8 @@ impl Network {
         // with are monotonically increasing.
         if block_id != &self.next_buffer_seq_no.0 {
             self.next_buffer_seq_no = (block_id.clone(), InputOperationSeqNo::zero());
+            // Clear buffered ops for the old block since they're now stale.
+            self.pending_input_updates.clear();
         }
 
         let operations = operations
@@ -635,7 +642,15 @@ impl Network {
         };
         self.next_buffer_seq_no.1.advance();
 
-        self.send_message_to_server(UpstreamMessage::UpdateInput(InputUpdate { id, ops }));
+        let update = InputUpdate { id, ops };
+        if matches!(self.stage, Stage::StartedSuccessfully { .. }) {
+            if let Err(e) = self.ws_proxy_tx.try_send(UpstreamMessage::UpdateInput(update)) {
+                sharer_warn!(self, "Failed to send input update over ws_proxy channel: {e}");
+            }
+        } else {
+            // Not connected; buffer the update to be flushed on reconnect.
+            self.pending_input_updates.push(update);
+        }
     }
 
     pub fn send_command_execution_rejection(
@@ -1333,6 +1348,7 @@ impl Network {
                 let start_event_no = last_received_event_no
                     .map_or(0, |last_received_event_no| last_received_event_no + 1);
                 self.flush_terminal_events_to_server(start_event_no);
+                self.flush_pending_input_updates_to_server();
                 // Non terminal events where we only care about the latest value were dropped while disconnected.
                 self.send_latest_state_to_server();
                 ctx.emit(NetworkEvent::ReconnectedSuccessfully);
@@ -1645,6 +1661,23 @@ impl Network {
         );
         self.send_message_to_server(UpstreamMessage::ExtendSessionRetention { reason });
     }
+
+    /// Sends all input updates buffered during disconnection to the server, then clears the buffer.
+    fn flush_pending_input_updates_to_server(&mut self) {
+        // Take the updates out of self to avoid a borrow conflict with sharer_warn!, which
+        // borrows all of self while drain() holds a mutable borrow on pending_input_updates.
+        let updates = std::mem::take(&mut self.pending_input_updates);
+        for update in updates {
+            if let Err(e) = self.ws_proxy_tx.try_send(UpstreamMessage::UpdateInput(update)) {
+                sharer_warn!(
+                    self,
+                    "Failed to send pending input update over ws_proxy channel: {e}"
+                );
+                return;
+            }
+        }
+    }
+
     /// Send all stored terminal events from [start_event_no, ...) to the server
     /// The events are not removed from memory.
     fn flush_terminal_events_to_server(&self, start_event_no: usize) {

--- a/app/src/terminal/shared_session/sharer/network.rs
+++ b/app/src/terminal/shared_session/sharer/network.rs
@@ -1663,6 +1663,8 @@ impl Network {
     }
 
     /// Sends all input updates buffered during disconnection to the server, then clears the buffer.
+    /// This is more a best-effort attempt because these events are not critical - that's why they are not ordered terminal events. 
+    /// With ordered terminal events we require an ack from the server before the client can remove them from the buffer, but we don't do that for these events.
     fn flush_pending_input_updates_to_server(&mut self) {
         // Take the updates out of self to avoid a borrow conflict with sharer_warn!, which
         // borrows all of self while drain() holds a mutable borrow on pending_input_updates.

--- a/app/src/terminal/shared_session/viewer/network.rs
+++ b/app/src/terminal/shared_session/viewer/network.rs
@@ -873,8 +873,13 @@ impl Network {
 
         let update = InputUpdate { id, ops };
         if matches!(self.stage, Stage::JoinedSuccessfully) {
-            if let Err(e) = self.ws_proxy_tx.try_send(UpstreamMessage::UpdateInput(update)) {
-                log::warn!("Failed to send input update over ws_proxy channel in viewer network: {e}");
+            if let Err(e) = self
+                .ws_proxy_tx
+                .try_send(UpstreamMessage::UpdateInput(update))
+            {
+                log::warn!(
+                    "Failed to send input update over ws_proxy channel in viewer network: {e}"
+                );
             }
         } else {
             // Not connected; buffer the update to be flushed on reconnect.
@@ -983,7 +988,10 @@ impl Network {
     /// Sends all input updates buffered during disconnection to the server, then clears the buffer.
     fn flush_pending_input_updates_to_server(&mut self) {
         for update in self.pending_input_updates.drain(..) {
-            if let Err(e) = self.ws_proxy_tx.try_send(UpstreamMessage::UpdateInput(update)) {
+            if let Err(e) = self
+                .ws_proxy_tx
+                .try_send(UpstreamMessage::UpdateInput(update))
+            {
                 log::warn!(
                     "Failed to send pending input update over ws_proxy channel in viewer network: {e}"
                 );

--- a/app/src/terminal/shared_session/viewer/network.rs
+++ b/app/src/terminal/shared_session/viewer/network.rs
@@ -143,6 +143,9 @@ pub struct Network {
     /// The next event number to use when sending a write to pty request to the server.
     write_to_pty_event_no: WriteToPtySeqNo,
     pty_bytes_batch_status: PtyBytesBatchStatus,
+
+    /// Input updates buffered while disconnected, to be flushed on reconnect.
+    pending_input_updates: Vec<InputUpdate>,
 }
 
 impl Network {
@@ -184,6 +187,7 @@ impl Network {
             pty_bytes_batch_status: PtyBytesBatchStatus::NotBatching {
                 last_sent_at: Instant::now(),
             },
+            pending_input_updates: Vec::new(),
         };
 
         model.start_write_to_pty_events_listener(write_to_pty_events_rx, ctx);
@@ -245,6 +249,7 @@ impl Network {
             pty_bytes_batch_status: PtyBytesBatchStatus::NotBatching {
                 last_sent_at: Instant::now(),
             },
+            pending_input_updates: Vec::new(),
         };
 
         ctx.emit(NetworkEvent::JoinedSuccessfully {
@@ -595,6 +600,7 @@ impl Network {
                 }
                 log::info!("Successfully reconnected to shared session as viewer.");
                 self.stage = Stage::JoinedSuccessfully;
+                self.flush_pending_input_updates_to_server();
                 // Events where we only care about the latest value were dropped before we reconnected.
                 self.send_latest_state_to_server();
                 ctx.emit(NetworkEvent::ReconnectedSuccessfully);
@@ -842,6 +848,8 @@ impl Network {
         // with are monotonically increasing.
         if block_id != &self.next_buffer_seq_no.0 {
             self.next_buffer_seq_no = (block_id.to_owned(), InputOperationSeqNo::zero());
+            // Clear buffered ops for the old block since they're now stale.
+            self.pending_input_updates.clear();
         }
 
         let operations = operations
@@ -863,7 +871,15 @@ impl Network {
         };
         self.next_buffer_seq_no.1.advance();
 
-        self.send_message_to_server(UpstreamMessage::UpdateInput(InputUpdate { id, ops }));
+        let update = InputUpdate { id, ops };
+        if matches!(self.stage, Stage::JoinedSuccessfully) {
+            if let Err(e) = self.ws_proxy_tx.try_send(UpstreamMessage::UpdateInput(update)) {
+                log::warn!("Failed to send input update over ws_proxy channel in viewer network: {e}");
+            }
+        } else {
+            // Not connected; buffer the update to be flushed on reconnect.
+            self.pending_input_updates.push(update);
+        }
     }
 
     pub fn send_write_to_pty(&mut self) {
@@ -962,6 +978,18 @@ impl Network {
 
     pub fn send_report_terminal_size(&mut self, window_size: WindowSize) {
         self.send_message_to_server(UpstreamMessage::ReportTerminalSize { window_size });
+    }
+
+    /// Sends all input updates buffered during disconnection to the server, then clears the buffer.
+    fn flush_pending_input_updates_to_server(&mut self) {
+        for update in self.pending_input_updates.drain(..) {
+            if let Err(e) = self.ws_proxy_tx.try_send(UpstreamMessage::UpdateInput(update)) {
+                log::warn!(
+                    "Failed to send pending input update over ws_proxy channel in viewer network: {e}"
+                );
+                return;
+            }
+        }
     }
 
     /// Send everything in `self.cached_latest_state` to the server.


### PR DESCRIPTION
## Description

Input updates made while not connected to the server were lost. They should be buffered and sent on reconnection so state catches up for all participants on reconnection

This is more a best-effort attempt because these events are not critical - that's why they are not ordered terminal events. With ordered terminal events we require an ack from the server before the client can remove them from the buffer, but we don't do that for these events.

## Testing
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

Tested input updates are applied on reconnection

https://www.loom.com/share/602d53fb14a5415d9eeeefbdd6e8bb77

There is a separate issue with input buffer not being cleared when sending an agent prompt for viewers who join later (only clears for live viewers). Fixed in stacked PR