### PR TITLE
Fix SSH mux helpers with canonicalized configs

### DIFF
--- a/app/src/terminal/model/session/command_executor/remote_command_executor.rs
+++ b/app/src/terminal/model/session/command_executor/remote_command_executor.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use command::r#async::Command;
 use itertools::Itertools as _;
+use remote_server::ssh::ssh_args;
 
 use super::shared::shell_escape_single_quotes;
 use super::{CommandExecutor, CommandOutput, ExecuteCommandOptions};
@@ -65,25 +66,8 @@ impl CommandExecutor for RemoteCommandExecutor {
         }
         command_str.push_str(command);
 
-        let ssh_args = [
-            "-q",
-            "-o",
-            "PasswordAuthentication=no",
-            // Disable X11 forwarding, as none of our background commands
-            // should need it, and it can cause warnings to appear in the
-            // user's session.
-            "-o",
-            "ForwardX11=no",
-            "-o",
-            &format!(
-                "ControlPath={}",
-                self.control_socket_path
-                    .to_str()
-                    .ok_or_else(|| anyhow!("socket path must exist"))?
-            ),
-            "placeholder@placeholder",
-            command_str.as_str(),
-        ];
+        let mut ssh_args = ssh_args(&self.control_socket_path);
+        ssh_args.push(command_str);
 
         // If the SSH session originated from WSL, the ControlPath also exists inside WSL.
         // Therefore, SSH commands directly from the Windows host will not work. They must be run
@@ -97,7 +81,7 @@ impl CommandExecutor for RemoteCommandExecutor {
             }
         };
 
-        command.args(ssh_args);
+        command.args(&ssh_args);
         command
             .kill_on_drop(true)
             .output()

--- a/crates/remote_server/src/ssh.rs
+++ b/crates/remote_server/src/ssh.rs
@@ -33,6 +33,7 @@ pub enum SshCommandError {
 /// immediately; if it doesn't, we'd rather give up than block
 /// teardown.
 const STOP_CONTROL_MASTER_TIMEOUT: Duration = Duration::from_secs(5);
+const MUX_PLACEHOLDER_TARGET: &str = "placeholder@placeholder";
 
 /// Builds the common SSH argument list for multiplexed connections through
 /// an existing ControlMaster socket.
@@ -44,8 +45,12 @@ pub fn ssh_args(socket_path: &Path) -> Vec<String> {
         "-o".to_string(),
         "ForwardX11=no".to_string(),
         "-o".to_string(),
+        // Keep the placeholder target from being rewritten by user configs, but
+        // do not make it resolvable: stale ControlPath values should fail fast.
+        "CanonicalizeHostname=no".to_string(),
+        "-o".to_string(),
         format!("ControlPath={}", socket_path.display()),
-        "placeholder@placeholder".to_string(),
+        MUX_PLACEHOLDER_TARGET.to_string(),
     ]
 }
 
@@ -220,11 +225,13 @@ pub async fn scp_upload(
             .arg("-o")
             .arg(format!("ControlPath={}", socket_path.display()))
             .arg("-o")
+            .arg("CanonicalizeHostname=no")
+            .arg("-o")
             .arg("ControlMaster=no")
             .arg("-o")
             .arg("ConnectTimeout=15")
             .arg(local_path.as_os_str())
-            .arg(format!("placeholder@placeholder:{remote_path}"))
+            .arg(format!("{MUX_PLACEHOLDER_TARGET}:{remote_path}"))
             .kill_on_drop(true)
             .output()
             .await
@@ -243,5 +250,27 @@ pub async fn scp_upload(
             output.status.code(),
             stderr
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ssh_args_disable_canonicalization_without_resolving_placeholder() {
+        let args = ssh_args(Path::new("/tmp/control.sock"));
+
+        assert!(args
+            .windows(2)
+            .any(|pair| pair == ["-o", "CanonicalizeHostname=no"]));
+        assert!(!args.iter().any(|arg| arg.starts_with("HostName=")));
+        assert!(args
+            .windows(2)
+            .any(|pair| pair == ["-o", "ControlPath=/tmp/control.sock"]));
+        assert_eq!(
+            args.last().map(String::as_str),
+            Some(MUX_PLACEHOLDER_TARGET)
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Keep SSH ControlMaster helper commands from canonicalizing Warp's internal `placeholder@placeholder` mux target.
- Apply the same canonicalization guard to the SCP fallback path.
- Reuse the shared helper argument builder in the legacy remote command executor so fallback remote commands use the same SSH options.

Fixes #12137.

## Why
Some OpenSSH configs canonicalize or resolve the destination before the client reaches an existing `ControlPath` mux. Warp helpers use `placeholder@placeholder`, which can fail DNS resolution before muxing even though the live ControlMaster socket works for the real target.

This change disables hostname canonicalization for the helper commands while intentionally leaving `placeholder@placeholder` non-resolvable. If the ControlPath is stale or missing, ssh/scp should fail cleanly instead of falling back to a direct localhost connection.

## Testing
- `cargo fmt --check`
- `./script/format --check`
- `git diff --check`
- `cargo test -p remote_server ssh_args_disable_canonicalization_without_resolving_placeholder`
- `PATH="/tmp/warp-fake-xcrun:$PATH" cargo check -p warp`

Note: this machine does not have the normal Xcode Metal shader toolchain available, so the `cargo check -p warp` command used the existing local fake `xcrun` shim only for shader compilation.