### PR TITLE
feat: add oz-local-dev binary for local development agent runs

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -23,6 +23,11 @@ path = "src/bin/oss.rs"
 test = false
 
 [[bin]]
+name = "oz-local-dev"
+path = "src/bin/oz_local_dev.rs"
+test = false
+
+[[bin]]
 name = "warp"
 path = "src/bin/local.rs"
 test = false

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -1003,7 +1003,10 @@ impl AgentDriverRunner {
 
                 let task_id = args.task_id.as_ref().and_then(|s| s.parse().ok());
                 let should_share = (args.share.is_shared() || args.task_id.is_some())
-                    && FeatureFlag::AgentSharedSessions.is_enabled();
+                    && FeatureFlag::AgentSharedSessions.is_enabled()
+                    // Only try session sharing if a session-sharing server is configured.
+                    // Without a server, sharing would always fail and block the agent from starting.
+                    && warp_core::channel::ChannelState::session_sharing_server_url().is_some();
 
                 let third_party_harness_model_config = merged_config
                     .harness

--- a/app/src/bin/oz_local_dev.rs
+++ b/app/src/bin/oz_local_dev.rs
@@ -1,0 +1,60 @@
+// Local development binary for Oz agent runs.
+// Uses Channel::Local which allows --server-root-url overrides, enabling
+// the oz binary to authenticate against a local warp-server instance.
+//
+// Build with: cargo build --bin oz-local-dev
+// Use with:   oz-local-dev agent run --task-id <id> --sandboxed
+//             --server-root-url http://localhost:8080
+
+use anyhow::Result;
+use warp_core::channel::{
+    Channel, ChannelConfig, ChannelState, OzConfig, WarpServerConfig,
+};
+use warp_core::AppId;
+use warp_core::features::FeatureFlag;
+
+fn main() -> Result<()> {
+    let mut state = ChannelState::new(
+        Channel::Local,
+        ChannelConfig {
+            app_id: AppId::new("dev", "warp", "OzLocalDev"),
+            logfile_name: "oz-local-dev.log".into(),
+            server_config: WarpServerConfig {
+                // Default to the local main server. Can be overridden via
+                // --server-root-url or WARP_SERVER_ROOT_URL.
+                server_root_url: "http://localhost:8080".into(),
+                rtc_server_url: "ws://localhost:8080/graphql/v2".into(),
+                // No session sharing server — tasks run in headless/sandboxed mode
+                // without interactive session sharing.
+                session_sharing_server_url: None,
+                // Firebase API key — used for token refresh; in sandboxed/API-key
+                // mode this path is not exercised so any non-empty string is fine.
+                firebase_auth_api_key: "local-dev-no-firebase".into(),
+                iap_config: None,
+            },
+            oz_config: OzConfig {
+                oz_root_url: "http://localhost:8082".into(),
+                // Use the staging workload audience so Namespace can issue a valid
+                // JWT for this binary (nsc only allows known audiences). The local
+                // server accepts it because IGNORE_WORKLOAD_TOKEN_VERIFICATION=true.
+                workload_audience_url: Some("https://staging.warp.dev".into()),
+            },
+            telemetry_config: None,
+            crash_reporting_config: None,
+            autoupdate_config: None,
+            mcp_static_config: None,
+        },
+    );
+
+    // Enable debug and dogfood flags for local development.
+    state = state.with_additional_features(warp_core::features::DEBUG_FLAGS);
+    state = state.with_additional_features(warp_core::features::DOGFOOD_FLAGS);
+    ChannelState::set(state);
+
+    // Disable session sharing — there is no session-sharing server running
+    // in this local dev environment.
+    FeatureFlag::AgentSharedSessions.set_enabled(false);
+    FeatureFlag::CreatingSharedSessions.set_enabled(false);
+
+    warp::run()
+}


### PR DESCRIPTION
## oz-local-dev binary for local development agent runs

This PR adds a new `oz-local-dev` binary entry point to the Warp client codebase that enables end-to-end local Oz agent development without requiring `warp-channel-config` (internal binary) or Firebase authentication.

### Changes

**`app/src/bin/oz_local_dev.rs` (new file)**
- Uses `Channel::Local` which allows `--server-root-url` overrides  
- Configured with localhost server URLs (overridable via env)
- Uses staging workload audience URL for Namespace token compatibility
- No session sharing server configured (disabled for headless runs)
- Disables `AgentSharedSessions` and `CreatingSharedSessions` feature flags

**`app/Cargo.toml`**
- Registers `oz-local-dev` as a new binary target

**`app/src/ai/agent_sdk/mod.rs`**
- Adds a guard: skip session sharing when `session_sharing_server_url` is `None`
- Prevents agent startup failure when no session sharing server is running

### Usage

```bash
# Build the local dev binary
cargo build --bin oz-local-dev

# Use as --oz-path in oz-agent-worker config
backend:
  direct:
    oz_path: "/path/to/warp/target/debug/oz-local-dev"
    workspace_root: "/tmp/oz-workspaces"
```

### What was validated

- Full end-to-end run completed with **SUCCEEDED** state using LLM mock
- Run created via API → claimed by selfhosted worker → oz binary launched → mock LLM → `finish_task` called → SUCCEEDED
- Screenshots uploaded showing the SUCCEEDED run in the Ambient Agent Debugger

_Conversation: https://staging.warp.dev/conversation/8e85620d-b1e1-4d1e-93fc-2dbe72b58e2e_
_Run: https://oz.staging.warp.dev/runs/019ef231-2a7a-7d8b-a505-e0fbf53057b8_

_This PR was generated with [Oz](https://warp.dev/oz)._
