### PR TITLE
Fix ctrl-c not cancelling stream

### DIFF
--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -2468,14 +2468,15 @@ impl BlocklistAIController {
             )
         });
         let response_stream_id = response_stream.as_ref(ctx).id().clone();
+        let response_stream_clone = response_stream.clone();
         let input_contains_user_query = request_input
             .all_inputs()
             .any(|input| input.is_user_query());
-        ctx.subscribe_to_model(&response_stream, move |me, response_stream, event, ctx| {
+        ctx.subscribe_to_model(&response_stream, move |me, _, event, ctx| {
             me.handle_response_stream_event(
                 input_contains_user_query,
                 event,
-                &response_stream,
+                &response_stream_clone,
                 ctx,
             );
         });


### PR DESCRIPTION
## Description

Fixes the "warping..." indicator getting stuck after pressing Ctrl-C to cancel an in-flight agent request.

### Root Cause

Commit 849d6cfe removed a strong `ModelHandle<ResponseStream>` capture (`response_stream_clone`) from the `subscribe_to_model` closure in `BlocklistAIController::send_request_input`. This introduced a race where the `AfterStreamFinished` event (emitted by `ResponseStream::cancel()`) is silently dropped:

1. `cancel_conversation_progress` → `try_cancel_streams_for_conversation` extracts the stream from `PendingResponseStreams` and calls `cancel()`, which **queues** `AfterStreamFinished` into `pending_effects`.
2. The for-loop ends, the last `ModelHandle<ResponseStream>` is dropped → refcount hits 0.
3. When `flush_effects()` runs, `remove_dropped_items()` fires **before** events are dispatched, removing the model and all its subscriptions from the app.
4. `AfterStreamFinished` is dequeued but has no subscribers → `mark_response_stream_cancelled` never fires → conversation status stays `InProgress` → warping indicator stuck.

The test helper `register_mock_stream_for_test` still used the old clone pattern, so tests did not catch this.

### Fix

Restore the `response_stream_clone` strong capture in the subscription closure, keeping the `ResponseStream` model alive (refcount > 0) until `AfterStreamFinished` is fully processed and `ctx.unsubscribe_from_model` is called.

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

Manually verified: start an agent request, press Ctrl-C — the warping indicator now dismisses correctly.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/c87e5599-58d9-4783-b2e4-c19c89e2e532

<!--
## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed "warping..." indicator getting stuck after pressing Ctrl-C to cancel an agent request.
-->
