### PR TITLE
REMOTE-1936 (client 1/2): tolerate unknown GSO formats in Drive sync

### DIFF
--- a/app/src/server/graphql/schema/mod.rs
+++ b/app/src/server/graphql/schema/mod.rs
@@ -88,6 +88,9 @@ pub fn update_generic_string_object_result_to_update_result(
                                 rejected.conflicting_generic_string_object,
                             )?
                         }
+                        GenericStringObjectFormat::Unknown => {
+                            bail!("conflicting generic string object has unknown format")
+                        }
                     };
                     Ok(UpdateCloudObjectResult::Rejected { object: boxed })
                 }

--- a/app/src/server/server_api/object.rs
+++ b/app/src/server/server_api/object.rs
@@ -836,6 +836,11 @@ impl ObjectClient for ServerApi {
                                     gso,
                                 );
                             }
+                            // GSO formats unknown to this client build (e.g. the
+                            // server-only `JsonRunner`) are skipped so syncing of
+                            // known objects still succeeds instead of failing to
+                            // decode the whole response.
+                            warp_graphql::generic_string_object::GenericStringObjectFormat::Unknown => {}
                         }
                     }
                 }

--- a/crates/cloud_object_models/src/server_cloud_object.rs
+++ b/crates/cloud_object_models/src/server_cloud_object.rs
@@ -318,5 +318,10 @@ fn server_gso_to_cloud_object(
                 GenericServerObject::<GenericStringObjectId, GenericStringModel<ScheduledAmbientAgent, JsonSerializer>>::try_from_gql(gso)?,
             ))
         }
+        // Formats unknown to this client build (e.g. the server-only `JsonRunner`).
+        // Returning an error lets callers skip the object rather than failing.
+        warp_graphql::generic_string_object::GenericStringObjectFormat::Unknown => Err(anyhow::anyhow!(
+            "unsupported generic string object format (unknown to this client build)"
+        )),
     }
 }

--- a/crates/graphql/src/api/generic_string_object.rs
+++ b/crates/graphql/src/api/generic_string_object.rs
@@ -30,6 +30,12 @@ pub enum GenericStringObjectFormat {
     JsonCloudEnvironment,
     #[cynic(rename = "JsonScheduledAmbientAgent")]
     JsonScheduledAmbientAgent,
+    /// Fallback for GSO formats this client build does not recognize (for example
+    /// server-only formats such as `JsonRunner`). Without this, decoding a Drive
+    /// sync response that contains an unknown format fails for the entire response.
+    /// This variant only arises when deserializing; we never serialize it.
+    #[cynic(fallback)]
+    Unknown,
 }
 
 #[derive(cynic::InputObject, Debug)]
@@ -56,6 +62,7 @@ impl std::fmt::Display for GenericStringObjectFormat {
             GenericStringObjectFormat::JsonTemplatableMCPServer => "JsonTemplatableMCPServer",
             GenericStringObjectFormat::JsonCloudEnvironment => "JsonCloudEnvironment",
             GenericStringObjectFormat::JsonScheduledAmbientAgent => "JsonScheduledAmbientAgent",
+            GenericStringObjectFormat::Unknown => "Unknown",
         };
         write!(f, "{s}")
     }


### PR DESCRIPTION
Client-side PR **1/2** for REMOTE-1936 (runner data model + APIs). Base: `master`. Specs live in warp-server (PR #12041, `specs/REMOTE-1936/`).

## What
Makes the client tolerant of generic-string-object (GSO) formats it does not recognize, so Warp Drive sync **skips** them instead of failing to decode the whole response.
- Adds a `#[cynic(fallback)] Unknown` variant to `GenericStringObjectFormat` (cynic enum) and handles it at every match site (`server_cloud_object.rs`, `server_api/object.rs`, `server/graphql/schema/mod.rs`).
- The fallback is only produced when deserializing; it is never serialized.

## Why
Once a `JsonRunner` GSO exists server-side, an older client's Drive sync hard-fails (`unknown variant 'JsonRunner'`), which blocks `agent run-cloud --runner` at its pre-dispatch sync. This is general forward-compat hardening, independent of the runner feature, so it lands first in the stack.

Surfaced by the local end-to-end runner test. Maps to warp-server PRODUCT invariant 24.

Co-Authored-By: Oz <oz-agent@warp.dev>
