### PR TITLE
Fix/unix pty error handling

### DIFF
--- a/app/src/terminal/local_tty/unix.rs
+++ b/app/src/terminal/local_tty/unix.rs
@@ -54,8 +54,16 @@ fn make_pty(size: winsize) -> Result<(RawFd, RawFd)> {
     // across duplicated fds, so when we call `libc::dup2()` below, those fds
     // will _not_ be closed when we exec the shell.
     unsafe {
-        libc::fcntl(ends.master, libc::F_SETFD, libc::FD_CLOEXEC);
-        libc::fcntl(ends.slave, libc::F_SETFD, libc::FD_CLOEXEC);
+        let r1 = libc::fcntl(ends.master, libc::F_SETFD, libc::FD_CLOEXEC);
+        if r1 < 0 {
+            return Err(io::Error::last_os_error())
+                .context("fcntl FD_CLOEXEC on master failed");
+        }
+        let r2 = libc::fcntl(ends.slave, libc::F_SETFD, libc::FD_CLOEXEC);
+        if r2 < 0 {
+            return Err(io::Error::last_os_error())
+                .context("fcntl FD_CLOEXEC on slave failed");
+        }
     }
 
     Ok((ends.master, ends.slave))
@@ -98,16 +106,16 @@ fn docker_sandbox_run_args(starter: &DockerSandboxShellStarter) -> Vec<std::ffi:
 }
 
 #[derive(Debug)]
-struct Passwd<'a> {
-    name: &'a str,
-    dir: &'a str,
-    shell: &'a str,
+struct Passwd {
+    name: String,
+    dir: String,
+    shell: String,
 }
 
-pub fn get_pw_shell() -> String {
+pub fn get_pw_shell() -> Result<String, io::Error> {
     let mut buf = [0; 1024];
-    let pw = get_pw_entry(&mut buf);
-    pw.shell.to_string()
+    let pw = get_pw_entry(&mut buf)?;
+    Ok(pw.shell)
 }
 
 /// Return a Passwd struct with pointers into the provided buf.
@@ -115,7 +123,7 @@ pub fn get_pw_shell() -> String {
 /// # Unsafety
 ///
 /// If `buf` is changed while `Passwd` is alive, bad things will almost certainly happen.
-fn get_pw_entry(buf: &mut [i8; 1024]) -> Passwd<'_> {
+fn get_pw_entry(buf: &mut [i8; 1024]) -> Result<Passwd, io::Error> {
     // Create zeroed passwd struct.
     let mut entry: MaybeUninit<libc::passwd> = MaybeUninit::uninit();
 
@@ -132,25 +140,34 @@ fn get_pw_entry(buf: &mut [i8; 1024]) -> Passwd<'_> {
             &mut res,
         )
     };
-    let entry = unsafe { entry.assume_init() };
 
-    if status < 0 {
-        panic!("getpwuid_r failed");
+    if status != 0 {
+        return Err(io::Error::from_raw_os_error(status));
     }
 
     if res.is_null() {
-        panic!("pw not found");
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "passwd entry not found for uid",
+        ));
     }
+
+    let entry = unsafe { entry.assume_init_read() };
 
     // Sanity check.
     assert_eq!(entry.pw_uid, uid);
 
-    // Build a borrowed Passwd struct.
-    Passwd {
-        name: unsafe { CStr::from_ptr(entry.pw_name).to_str().unwrap() },
-        dir: unsafe { CStr::from_ptr(entry.pw_dir).to_str().unwrap() },
-        shell: unsafe { CStr::from_ptr(entry.pw_shell).to_str().unwrap() },
-    }
+    // Build an owned Passwd struct.
+    Ok(Passwd {
+        name: unsafe { CStr::from_ptr(entry.pw_name).to_string_lossy().into_owned() },
+        dir: unsafe { CStr::from_ptr(entry.pw_dir).to_string_lossy().into_owned() },
+        shell: unsafe {
+            CStr::from_ptr(entry.pw_shell)
+                .to_str()
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+                .to_owned()
+        },
+    })
 }
 
 pub struct Pty {
@@ -210,7 +227,7 @@ pub(super) fn spawn(options: PtyOptions) -> Result<PtySpawnInfo> {
         shell_debug_mode,
         honor_ps1,
         node_version_chip_enabled,
-    );
+    )?;
 
     spawn_command_in_pty(command, &size, close_fds)
 }
@@ -231,9 +248,9 @@ fn build_host_shell_command(
     shell_debug_mode: bool,
     honor_ps1: bool,
     node_version_chip_enabled: bool,
-) -> Command {
+) -> Result<Command, io::Error> {
     let mut buf = [0; 1024];
-    let pw = get_pw_entry(&mut buf);
+    let pw = get_pw_entry(&mut buf)?;
 
     log::info!(
         "Starting shell {}",
@@ -387,7 +404,7 @@ fn build_host_shell_command(
     // start of bootstrap.
     builder.current_dir(home_dir);
 
-    builder
+    Ok(builder)
 }
 
 /// Shared PTY setup used by both host-shell and Docker-sandbox sessions.
@@ -742,7 +759,7 @@ fn spawn_docker_sandbox(
         shell_debug_mode,
         honor_ps1,
         node_version_chip_enabled,
-    );
+    )?;
 
     spawn_command_in_pty(command, &size, close_fds)
 }
@@ -763,9 +780,9 @@ fn build_docker_sandbox_command(
     shell_debug_mode: bool,
     honor_ps1: bool,
     node_version_chip_enabled: bool,
-) -> Command {
+) -> Result<Command, io::Error> {
     let mut buf = [0; 1024];
-    let pw = get_pw_entry(&mut buf);
+    let pw = get_pw_entry(&mut buf)?;
 
     log::info!(
         "Starting Docker sandbox via {}",
@@ -853,7 +870,7 @@ fn build_docker_sandbox_command(
 
     builder.current_dir(home_dir);
 
-    builder
+    Ok(builder)
 }
 
 /// Prepare the Docker sandbox before spawning the PTY:
@@ -946,5 +963,5 @@ mod utils {
 #[test]
 fn test_get_pw_entry() {
     let mut buf: [i8; 1024] = [0; 1024];
-    let _pw = get_pw_entry(&mut buf);
+    let _pw = get_pw_entry(&mut buf).expect("get_pw_entry should succeed in test");
 }

--- a/app/src/terminal/local_tty/unix.rs
+++ b/app/src/terminal/local_tty/unix.rs
@@ -112,62 +112,82 @@ struct Passwd {
     shell: String,
 }
 
+#[allow(dead_code)]
 pub fn get_pw_shell() -> Result<String, io::Error> {
-    let mut buf = [0; 1024];
-    let pw = get_pw_entry(&mut buf)?;
+    let pw = get_pw_entry()?;
     Ok(pw.shell)
 }
 
-/// Return a Passwd struct with pointers into the provided buf.
-///
-/// # Unsafety
-///
-/// If `buf` is changed while `Passwd` is alive, bad things will almost certainly happen.
-fn get_pw_entry(buf: &mut [i8; 1024]) -> Result<Passwd, io::Error> {
-    // Create zeroed passwd struct.
-    let mut entry: MaybeUninit<libc::passwd> = MaybeUninit::uninit();
-
-    let mut res: *mut libc::passwd = ptr::null_mut();
-
-    // Try and read the pw file.
+fn get_pw_entry() -> Result<Passwd, io::Error> {
     let uid = unsafe { libc::getuid() };
-    let status = unsafe {
-        libc::getpwuid_r(
-            uid,
-            entry.as_mut_ptr(),
-            buf.as_mut_ptr() as *mut _,
-            buf.len(),
-            &mut res,
-        )
-    };
+    let mut buf_size = 1024usize;
 
-    if status != 0 {
-        return Err(io::Error::from_raw_os_error(status));
+    loop {
+        let mut buf: Vec<libc::c_char> = vec![0; buf_size];
+        let mut entry: MaybeUninit<libc::passwd> = MaybeUninit::uninit();
+        let mut res: *mut libc::passwd = ptr::null_mut();
+
+        let status = unsafe {
+            libc::getpwuid_r(
+                uid,
+                entry.as_mut_ptr(),
+                buf.as_mut_ptr(),
+                buf.len(),
+                &mut res,
+            )
+        };
+
+        if status == libc::ERANGE {
+            if buf_size >= 65536 {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "passwd entry too large for buffer",
+                ));
+            }
+            buf_size = (buf_size * 2).min(65536);
+            continue;
+        }
+
+        if status != 0 {
+            return Err(io::Error::from_raw_os_error(status));
+        }
+
+        if res.is_null() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "passwd entry not found for uid",
+            ));
+        }
+
+        // Strict check: res must point to the caller-supplied entry.
+        if res != entry.as_mut_ptr() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "getpwuid_r returned unexpected entry pointer",
+            ));
+        }
+
+        let entry = unsafe { entry.assume_init_read() };
+
+        if entry.pw_uid != uid {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "uid mismatch in passwd entry",
+            ));
+        }
+
+        // Build an owned Passwd struct.
+        Ok(Passwd {
+            name: unsafe { CStr::from_ptr(entry.pw_name).to_string_lossy().into_owned() },
+            dir: unsafe { CStr::from_ptr(entry.pw_dir).to_string_lossy().into_owned() },
+            shell: unsafe {
+                CStr::from_ptr(entry.pw_shell)
+                    .to_str()
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+                    .to_owned()
+            },
+        })
     }
-
-    if res.is_null() {
-        return Err(io::Error::new(
-            io::ErrorKind::NotFound,
-            "passwd entry not found for uid",
-        ));
-    }
-
-    let entry = unsafe { entry.assume_init_read() };
-
-    // Sanity check.
-    assert_eq!(entry.pw_uid, uid);
-
-    // Build an owned Passwd struct.
-    Ok(Passwd {
-        name: unsafe { CStr::from_ptr(entry.pw_name).to_string_lossy().into_owned() },
-        dir: unsafe { CStr::from_ptr(entry.pw_dir).to_string_lossy().into_owned() },
-        shell: unsafe {
-            CStr::from_ptr(entry.pw_shell)
-                .to_str()
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
-                .to_owned()
-        },
-    })
 }
 
 pub struct Pty {
@@ -249,8 +269,7 @@ fn build_host_shell_command(
     honor_ps1: bool,
     node_version_chip_enabled: bool,
 ) -> Result<Command, io::Error> {
-    let mut buf = [0; 1024];
-    let pw = get_pw_entry(&mut buf)?;
+    let pw = get_pw_entry()?;
 
     log::info!(
         "Starting shell {}",
@@ -781,8 +800,7 @@ fn build_docker_sandbox_command(
     honor_ps1: bool,
     node_version_chip_enabled: bool,
 ) -> Result<Command, io::Error> {
-    let mut buf = [0; 1024];
-    let pw = get_pw_entry(&mut buf)?;
+    let pw = get_pw_entry()?;
 
     log::info!(
         "Starting Docker sandbox via {}",
@@ -962,6 +980,5 @@ mod utils {
 
 #[test]
 fn test_get_pw_entry() {
-    let mut buf: [i8; 1024] = [0; 1024];
-    let _pw = get_pw_entry(&mut buf).expect("get_pw_entry should succeed in test");
+    let _pw = get_pw_entry().expect("get_pw_entry should succeed in test");
 }

--- a/app/src/terminal/local_tty/unix_tests.rs
+++ b/app/src/terminal/local_tty/unix_tests.rs
@@ -23,7 +23,8 @@ fn host_bash_command_sets_history_size_sentinels() {
         false,
         false,
         true,
-    );
+    )
+    .expect("test build_host_shell_command");
 
     assert_eq!(
         env_value(&command, "HISTFILESIZE"),
@@ -55,7 +56,8 @@ fn host_non_bash_command_does_not_set_history_size_sentinels() {
         false,
         false,
         true,
-    );
+    )
+    .expect("test build_host_shell_command zsh");
 
     assert_eq!(env_value(&command, "HISTFILESIZE"), None);
     assert_eq!(env_value(&command, "HISTSIZE"), None);
@@ -76,7 +78,8 @@ fn docker_sandbox_command_sets_history_size_sentinels() {
         false,
         false,
         true,
-    );
+    )
+    .expect("test build_docker_sandbox_command");
 
     assert_eq!(
         env_value(&command, "HISTFILESIZE"),


### PR DESCRIPTION
## Description

Fixes multiple safety and correctness bugs in the Unix PTY/shell-spawn code path in `app/src/terminal/local_tty/unix.rs`. See linked issue for full details.

Changes:
- **UB fix**: Move `assume_init_read()` after `status` and `res` null checks in `get_pw_entry` — previously `assume_init()` was called unconditionally, reading uninitialized memory on failure
- **Correct error check**: Replace `status < 0` with `status != 0` — `getpwuid_r` returns positive errno values on failure, never -1
- **Error propagation**: Replace `panic!("getpwuid_r failed")` / `panic!("pw not found")` / `assert_eq!` with `Result` returns throughout `get_pw_entry`, `get_pw_shell`, `build_host_shell_command`, `build_docker_sandbox_command`, `spawn`, and `spawn_docker_sandbox`
- **ERANGE retry**: Replace fixed 1024-byte buffer with a doubling retry loop (1024 → 65536 bytes) to handle large passwd entries (long home paths, LDAP/NIS/SSSD)
- **Type-correct buffer**: Use `Vec<libc::c_char>` instead of `Vec<i8>` to avoid type mismatch on platforms where `c_char = u8`
- **Owned strings**: Change `Passwd` fields from borrowed `&'a str` to owned `String`, removing the buffer lifetime dependency
- **UTF-8 handling**: Use `to_string_lossy()` for `name`/`dir`, strict `to_str()?` for `shell` (shell path must be valid UTF-8 to exec)
- **`fcntl` return values**: Check both `fcntl(FD_CLOEXEC)` calls in `make_pty` and propagate errors
- **`res` pointer check**: Verify `res == entry.as_mut_ptr()` after `getpwuid_r`
- **Dead code**: Add `#[allow(dead_code)]` to `get_pw_shell` (no external callers)
- **Stale doc comment**: Remove outdated "pointers into buf" safety note from `get_pw_entry`
- **Tests**: Update all call sites in `unix_tests.rs` and `test_get_pw_entry` with `.expect(...)`

## Linked Issue

Closes #12950

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

These are internal code-path changes with no user-visible UI. The existing unit tests in `unix_tests.rs` cover `build_host_shell_command` and `build_docker_sandbox_command`. `test_get_pw_entry` now asserts success with `.expect(...)` rather than silently discarding the `Result`.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

N/A — no UI changes.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

```
CHANGELOG-NONE
```