### PR TITLE
Surface Anthropic 5xx API errors in Claude Code cloud runs (REMOTE-1997)

### DIFF
--- a/app/src/ai/agent_sdk/driver/error_classification.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification.rs
@@ -346,22 +346,51 @@ pub fn classify_driver_error(error: &AgentDriverError) -> (AgentTaskState, TaskS
             pattern,
             excerpt,
         } => {
-            let message = format!(
-                "Harness '{harness}' could not make a successful API request. \
-                 Matched failure pattern '{pattern}' in harness output: \"{excerpt}\". \
-                 This usually means the API key is invalid, out of credits, or the \
-                 account is misconfigured."
-            );
             log::error!("Runtime failure for {harness}: pattern={pattern}, excerpt={excerpt}");
-            (
-                AgentTaskState::Failed,
-                TaskStatusUpdate::with_error_code(
-                    message,
-                    PlatformErrorCode::AuthenticationRequired,
-                ),
-            )
+            if is_transient_upstream_api_error(pattern) {
+                let message = format!(
+                    "Harness '{harness}' encountered a temporary upstream API error. \
+                     Matched failure pattern '{pattern}' in harness output: \"{excerpt}\". \
+                     This is usually a transient issue — please try running your task again."
+                );
+                (
+                    AgentTaskState::Error,
+                    TaskStatusUpdate::with_error_code(
+                        message,
+                        PlatformErrorCode::InternalError,
+                    ),
+                )
+            } else {
+                let message = format!(
+                    "Harness '{harness}' could not make a successful API request. \
+                     Matched failure pattern '{pattern}' in harness output: \"{excerpt}\". \
+                     This usually means the API key is invalid, out of credits, or the \
+                     account is misconfigured."
+                );
+                (
+                    AgentTaskState::Failed,
+                    TaskStatusUpdate::with_error_code(
+                        message,
+                        PlatformErrorCode::AuthenticationRequired,
+                    ),
+                )
+            }
         }
     }
+}
+
+/// Returns `true` when `pattern` looks like a transient upstream API error
+/// (e.g. HTTP 5xx from the third-party provider) rather than an auth or
+/// billing failure that requires user action.
+///
+/// Used to split `HarnessRuntimeFailureDetected` into two classes:
+/// - Transient upstream errors (500, 529, etc.): task → ERROR, `InternalError` code.
+/// - Auth/billing/config errors: task → FAILED, `AuthenticationRequired` code.
+fn is_transient_upstream_api_error(pattern: &str) -> bool {
+    // Patterns for Anthropic HTTP 5xx errors as Claude Code surfaces them,
+    // e.g. "API Error: 500 Internal server error" or "API Error: 529".
+    let lower = pattern.to_lowercase();
+    lower.starts_with("api error: 5")
 }
 
 #[cfg(test)]

--- a/app/src/ai/agent_sdk/driver/error_classification_tests.rs
+++ b/app/src/ai/agent_sdk/driver/error_classification_tests.rs
@@ -298,3 +298,34 @@ fn harness_runtime_failure_detected_is_failed_with_auth_required() {
     assert!(update.message.contains("credit balance is too low"));
     assert!(update.message.contains("Your credit balance is too low"));
 }
+
+#[test]
+fn harness_runtime_failure_detected_500_is_error_with_internal_error() {
+    // Anthropic 500 server errors are transient and should map to ERROR
+    // (not FAILED) with an InternalError code so users know to retry.
+    let (state, update) = classify_driver_error(&AgentDriverError::HarnessRuntimeFailureDetected {
+        harness: "claude".into(),
+        pattern: "API Error: 500".into(),
+        excerpt: "API Error: 500 Internal server error. This is a server-side issue, usually temporary \u{2013} try again in a moment.".into(),
+    });
+    assert_eq!(state, AgentTaskState::Error);
+    assert_eq!(update.error_code, Some(PlatformErrorCode::InternalError));
+    assert!(update.message.contains("temporary upstream API error"));
+    assert!(update.message.contains("claude"));
+    assert!(update.message.contains("API Error: 500"));
+    assert!(update.message.contains("try running your task again"));
+}
+
+#[test]
+fn harness_runtime_failure_detected_529_is_error_with_internal_error() {
+    // Anthropic 529 overloaded errors are also transient.
+    let (state, update) = classify_driver_error(&AgentDriverError::HarnessRuntimeFailureDetected {
+        harness: "claude".into(),
+        pattern: "API Error: 529".into(),
+        excerpt: "API Error: 529 Overloaded".into(),
+    });
+    assert_eq!(state, AgentTaskState::Error);
+    assert_eq!(update.error_code, Some(PlatformErrorCode::InternalError));
+    assert!(update.message.contains("temporary upstream API error"));
+    assert!(update.message.contains("API Error: 529"));
+}

--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -103,6 +103,13 @@ impl ThirdPartyHarness for ClaudeHarness {
             // Generic upstream API failures Claude Code surfaces verbatim.
             "API Error: Request rejected (429)",
             "authentication_error",
+            // Transient upstream Anthropic server errors. Claude Code displays
+            // these and then waits for user input; in a cloud (non-interactive)
+            // run this causes the task to hang indefinitely as 'Running'.
+            // Matching these lets the harness output monitor detect the stall
+            // and force-exit Claude so the run is marked failed.
+            "API Error: 500",
+            "API Error: 529",
         ]
     }
 


### PR DESCRIPTION
## Description

When a Claude Code cloud run hits an Anthropic API 500 (internal server error) or 529 (overloaded) error on the very first prompt, Claude Code displays the error message in its TUI and then waits for user input. Since cloud runs are non-interactive, no user is present to acknowledge the error, so the run stays stuck in **Running** state indefinitely (with 0 credits consumed).

This PR fixes the observability and reliability gap by:

1. **Detecting 5xx errors**: Adds `"API Error: 500"` and `"API Error: 529"` to `ClaudeHarness::runtime_error_patterns`. The harness output monitor scans the running block for these patterns, waits for the output to stall (confirming Claude is waiting rather than retrying), then sends `/exit` to force-terminate Claude Code and fail the run.

2. **Accurate error state**: Updates `classify_driver_error` in `error_classification.rs` to distinguish transient upstream provider errors from auth/billing failures:
   - **5xx patterns** → `AgentTaskState::Error` + `PlatformErrorCode::InternalError`, with a message directing users to retry.
   - **Auth/billing/config patterns** → `AgentTaskState::Failed` + `PlatformErrorCode::AuthenticationRequired` (unchanged).

Previously, `HarnessRuntimeFailureDetected` always produced `AuthenticationRequired` with a message about invalid API keys — misleading for a temporary Anthropic outage.

## Linked Issue

- [REMOTE-1997](https://linear.app/warpdev/issue/REMOTE-1997)
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] Added unit tests for the new error classification paths (`harness_runtime_failure_detected_500_is_error_with_internal_error`, `harness_runtime_failure_detected_529_is_error_with_internal_error`).
- All 24 `error_classification` tests pass.
- All 8 `harness_output_monitor` tests pass.
- `cargo check` passes cleanly.
- `./script/format` and `cargo clippy` pass with no warnings.

**Note**: Manual end-to-end testing would require an Anthropic outage or a mock that returns 500; the unit tests cover the classification logic. The pattern detection relies on the existing `harness_output_monitor` infrastructure, which is already exercised in production for 429/auth/billing errors.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed Claude Code cloud runs getting stuck as 'Running' when Anthropic returns a 500 or 529 error — the run now transitions to an error state with a message directing users to retry.
-->

_Conversation: https://staging.warp.dev/conversation/7e537db9-79d0-4392-9bf3-272707596af6_
_Run: https://oz.staging.warp.dev/runs/019ef571-380a-7caf-bff5-a33e8772d635_

_This PR was generated with [Oz](https://warp.dev/oz)._
