### PR TITLE
fix IME position when using claude code on MacOS

### DIFF
--- a/app/src/editor/view/element.rs
+++ b/app/src/editor/view/element.rs
@@ -1061,15 +1061,16 @@ impl EditorElement {
                     // Ensure cursor position is always cached when local
                     if is_local_replica {
                         let cursor_size = vec2f(block_cursor_width, line_parameters.cursor_height);
+                        let cursor_rect = RectF::new(cursor_origin, cursor_size);
                         ctx.position_cache.cache_position_indefinitely(
                             position_id_for_cursor(view_snapshot.view_id),
-                            RectF::new(cursor_origin, cursor_size),
+                            cursor_rect,
                         );
 
                         if i == 0 {
                             ctx.position_cache.cache_position_indefinitely(
                                 position_id_for_first_cursor(view_snapshot.view_id),
-                                RectF::new(cursor_origin, cursor_size),
+                                cursor_rect,
                             );
                         }
                     }

--- a/app/src/terminal/block_list_element.rs
+++ b/app/src/terminal/block_list_element.rs
@@ -2607,24 +2607,31 @@ impl BlockListElement {
             // Only render the cursor in the command grid if the command grid is active and if it's
             // long running. This is to avoid jitter where a cursor just flickers while the pty is
             // initializing.
-            if block.is_active_and_long_running()
-                && block.is_command_grid_active()
-                // Check if the "hide cursor" escape sequence is present.
-                && block.is_mode_set(TermMode::SHOW_CURSOR)
-            {
-                block.prompt_and_command_grid().draw_cursor(
-                    command_origin,
-                    &block_grid_params.grid_render_params,
-                    ctx,
-                    terminal_view_id,
-                    None,
-                    block_grid_params
-                        .grid_render_params
-                        .warp_theme
-                        .cursor()
-                        .into(),
-                    app,
-                );
+            if block.is_active_and_long_running() && block.is_command_grid_active() {
+                if block.is_mode_set(TermMode::SHOW_CURSOR) {
+                    block.prompt_and_command_grid().draw_cursor(
+                        command_origin,
+                        &block_grid_params.grid_render_params,
+                        ctx,
+                        terminal_view_id,
+                        None,
+                        block_grid_params
+                            .grid_render_params
+                            .warp_theme
+                            .cursor()
+                            .into(),
+                        app,
+                    );
+                } else {
+                    // Keep IME position cache current even when cursor is hidden.
+                    block.prompt_and_command_grid().cache_cursor_ime_position(
+                        command_origin,
+                        &block_grid_params.grid_render_params,
+                        ctx,
+                        terminal_view_id,
+                        app,
+                    );
+                }
             }
 
             // Update grid_origin & draw output
@@ -2707,41 +2714,53 @@ impl BlockListElement {
                 app,
             );
 
-            if block.is_active_and_long_running()
-            // Check if the "hide cursor" escape sequence is present.
-            && block.is_mode_set(TermMode::SHOW_CURSOR)
-            // Don't draw the Warp cursor when rich input is hiding
-            // the CLI agent's cursor cell — agents like OpenCode and Codex
-            // rely on Warp's cursor, so we suppress it here too.
-            && !block_grid_params.grid_render_params.hide_cursor_cell
-            {
-                block.output_grid().draw_cursor(
-                    *grid_origin,
-                    &block_grid_params.grid_render_params,
-                    ctx,
-                    terminal_view_id,
-                    cursor_hint_text,
-                    if block.is_agent_blocked() {
-                        AnsiColorIdentifier::Yellow
-                            .to_ansi_color(
-                                &block_grid_params
-                                    .grid_render_params
-                                    .warp_theme
-                                    .terminal_colors()
-                                    .normal,
-                            )
-                            .into()
-                    } else if block.is_agent_in_control() {
-                        ai_brand_color(&block_grid_params.grid_render_params.warp_theme)
-                    } else {
-                        block_grid_params
-                            .grid_render_params
-                            .warp_theme
-                            .cursor()
-                            .into()
-                    },
-                    app,
-                );
+            if block.is_active_and_long_running() {
+                let show_cursor = block.is_mode_set(TermMode::SHOW_CURSOR);
+                // Don't draw the Warp cursor when rich input is hiding
+                // the CLI agent's cursor cell — agents like OpenCode and Codex
+                // rely on Warp's cursor, so we suppress it here too.
+                let hide_for_rich_input = block_grid_params.grid_render_params.hide_cursor_cell;
+                if show_cursor && !hide_for_rich_input {
+                    block.output_grid().draw_cursor(
+                        *grid_origin,
+                        &block_grid_params.grid_render_params,
+                        ctx,
+                        terminal_view_id,
+                        cursor_hint_text,
+                        if block.is_agent_blocked() {
+                            AnsiColorIdentifier::Yellow
+                                .to_ansi_color(
+                                    &block_grid_params
+                                        .grid_render_params
+                                        .warp_theme
+                                        .terminal_colors()
+                                        .normal,
+                                )
+                                .into()
+                        } else if block.is_agent_in_control() {
+                            ai_brand_color(&block_grid_params.grid_render_params.warp_theme)
+                        } else {
+                            block_grid_params
+                                .grid_render_params
+                                .warp_theme
+                                .cursor()
+                                .into()
+                        },
+                        app,
+                    );
+                } else if !hide_for_rich_input {
+                    // The terminal program has hidden its cursor (e.g., via `?25l`) but we
+                    // still need to keep the position cache updated for IME candidate window
+                    // positioning. When the rich input is open, IME position comes from
+                    // EditorView instead, so we skip this in that case.
+                    block.output_grid().cache_cursor_ime_position(
+                        *grid_origin,
+                        &block_grid_params.grid_render_params,
+                        ctx,
+                        terminal_view_id,
+                        app,
+                    );
+                }
             }
 
             // Offset the origin by the height of the output grid.

--- a/app/src/terminal/block_list_element.rs
+++ b/app/src/terminal/block_list_element.rs
@@ -2623,13 +2623,13 @@ impl BlockListElement {
                         app,
                     );
                 } else {
-                    // Keep IME position cache current even when cursor is hidden.
-                    block.prompt_and_command_grid().cache_cursor_ime_position(
+                    // Keep position cache current even when cursor is hidden. IME position depends
+                    // on it.
+                    block.prompt_and_command_grid().cache_cursor_position(
                         command_origin,
                         &block_grid_params.grid_render_params,
                         ctx,
                         terminal_view_id,
-                        app,
                     );
                 }
             }
@@ -2716,9 +2716,8 @@ impl BlockListElement {
 
             if block.is_active_and_long_running() {
                 let show_cursor = block.is_mode_set(TermMode::SHOW_CURSOR);
-                // Don't draw the Warp cursor when rich input is hiding
-                // the CLI agent's cursor cell — agents like OpenCode and Codex
-                // rely on Warp's cursor, so we suppress it here too.
+                // Don't draw the Warp cursor when rich input is hiding the CLI agent's cursor cell.
+                // Agents like OpenCode and Codex rely on Warp's cursor, so we suppress it here too.
                 let hide_for_rich_input = block_grid_params.grid_render_params.hide_cursor_cell;
                 if show_cursor && !hide_for_rich_input {
                     block.output_grid().draw_cursor(
@@ -2749,16 +2748,13 @@ impl BlockListElement {
                         app,
                     );
                 } else if !hide_for_rich_input {
-                    // The terminal program has hidden its cursor (e.g., via `?25l`) but we
-                    // still need to keep the position cache updated for IME candidate window
-                    // positioning. When the rich input is open, IME position comes from
-                    // EditorView instead, so we skip this in that case.
-                    block.output_grid().cache_cursor_ime_position(
+                    // The terminal program has hidden its cursor, i.e. [`TermMode::SHOW_CURSOR`]
+                    // is false. We still need to keep the position cache updated, e.g. for the IME
+                    block.output_grid().cache_cursor_position(
                         *grid_origin,
                         &block_grid_params.grid_render_params,
                         ctx,
                         terminal_view_id,
-                        app,
                     );
                 }
             }

--- a/app/src/terminal/blockgrid_renderer.rs
+++ b/app/src/terminal/blockgrid_renderer.rs
@@ -152,6 +152,43 @@ impl BlockGrid {
         )
     }
 
+    /// Updates the cursor position cache for IME positioning without visually rendering the cursor.
+    ///
+    /// Some terminal programs (like Claude Code) hide the terminal cursor via `?25l` while
+    /// rendering their TUI, clearing `SHOW_CURSOR`. This prevents `draw_cursor` from being called,
+    /// leaving the position cache stale. Calling this method keeps the IME candidate window
+    /// anchored to the actual cursor location even when the cursor is visually hidden.
+    pub fn cache_cursor_ime_position(
+        &self,
+        grid_origin: Vector2F,
+        grid_render_params: &GridRenderParams,
+        ctx: &mut PaintContext,
+        terminal_view_id: EntityId,
+        app: &AppContext,
+    ) {
+        let cursor_display_point = match self.cursor_display_point() {
+            Some(CursorDisplayPoint::Visible(pt) | CursorDisplayPoint::HiddenCache(pt)) => pt,
+            None => return,
+        };
+        let cursor_style = CursorStyle {
+            shape: CursorShape::Hidden,
+            ..self.cursor_style()
+        };
+        render_cursor(
+            grid_render_params,
+            cursor_display_point,
+            false, // is_cursor_on_wide_char doesn't affect the position origin
+            cursor_style,
+            grid_render_params.size_info.padding_x_px(),
+            grid_origin,
+            ColorU::default(),
+            ctx,
+            terminal_view_id,
+            None,
+            app,
+        )
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn draw_cursor(
         &self,

--- a/app/src/terminal/blockgrid_renderer.rs
+++ b/app/src/terminal/blockgrid_renderer.rs
@@ -12,7 +12,9 @@ use super::model::grid::RespectDisplayedOutput;
 use super::model::image_map::StoredImageMetadata;
 use super::model::SecretHandle;
 use crate::settings::EnforceMinimumContrast;
-use crate::terminal::grid_renderer::{render_cursor, render_grid, CellGlyphCache};
+use crate::terminal::grid_renderer::{
+    cache_cursor_position, render_cursor, render_grid, CellGlyphCache,
+};
 use crate::terminal::model::blockgrid::{BlockGrid, CursorDisplayPoint};
 use crate::terminal::model::grid::grid_handler::Link;
 use crate::terminal::model::index::Point;
@@ -152,41 +154,30 @@ impl BlockGrid {
         )
     }
 
-    /// Updates the cursor position cache for IME positioning without visually rendering the cursor.
+    /// Updates the cursor position cache without visually rendering the cursor.
     ///
-    /// Some terminal programs (like Claude Code) hide the terminal cursor via `?25l` while
-    /// rendering their TUI, clearing `SHOW_CURSOR`. This prevents `draw_cursor` from being called,
-    /// leaving the position cache stale. Calling this method keeps the IME candidate window
-    /// anchored to the actual cursor location even when the cursor is visually hidden.
-    pub fn cache_cursor_ime_position(
+    /// Cursor position cache is still depended upon for some things even when the cursor is hidden,
+    /// i.e. when [`TermMode::SHOW_CURSOR`] is false.
+    pub fn cache_cursor_position(
         &self,
         grid_origin: Vector2F,
         grid_render_params: &GridRenderParams,
         ctx: &mut PaintContext,
         terminal_view_id: EntityId,
-        app: &AppContext,
     ) {
         let cursor_display_point = match self.cursor_display_point() {
             Some(CursorDisplayPoint::Visible(pt) | CursorDisplayPoint::HiddenCache(pt)) => pt,
             None => return,
         };
-        let cursor_style = CursorStyle {
-            shape: CursorShape::Hidden,
-            ..self.cursor_style()
-        };
-        render_cursor(
+        cache_cursor_position(
             grid_render_params,
             cursor_display_point,
-            false, // is_cursor_on_wide_char doesn't affect the position origin
-            cursor_style,
+            self.grid_handler().is_cursor_on_wide_char(),
             grid_render_params.size_info.padding_x_px(),
             grid_origin,
-            ColorU::default(),
             ctx,
             terminal_view_id,
-            None,
-            app,
-        )
+        );
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -2340,7 +2340,16 @@ fn calculate_cursor_origin(
         )
 }
 
-/// Computes the cursor's rect (origin + size) in window coordinates from grid-space inputs.
+/// The geometry of a rendered terminal cursor.
+struct CursorGeometry {
+    /// The cursor's bounding rect in window coordinates (baseline-adjusted origin, character-cell size).
+    rect: RectF,
+    /// The un-baseline-adjusted top of the cell row. Needed by the `Underline` cursor shape,
+    /// which draws from the raw cell top rather than the adjusted cursor origin.
+    line_top_origin: Vector2F,
+}
+
+/// Computes the cursor's geometry in window coordinates from grid-space inputs.
 fn compute_cursor_rect(
     grid_render_params: &GridRenderParams,
     cursor_point: Point,
@@ -2348,7 +2357,7 @@ fn compute_cursor_rect(
     padding_x: Pixels,
     grid_origin: Vector2F,
     ctx: &mut PaintContext,
-) -> RectF {
+) -> CursorGeometry {
     let line_top_origin = grid_origin
         + vec2f(padding_x.as_f32(), 0.)
         + grid_render_params.cell_size * vec2f(cursor_point.col as f32, cursor_point.row as f32);
@@ -2362,7 +2371,10 @@ fn compute_cursor_rect(
         cell_width,
         grid_render_params.font_size * DEFAULT_UI_LINE_HEIGHT_RATIO,
     );
-    RectF::new(cursor_top_origin, cursor_block_size)
+    CursorGeometry {
+        rect: RectF::new(cursor_top_origin, cursor_block_size),
+        line_top_origin,
+    }
 }
 
 /// Updates the position cache with the terminal cursor's location in window coordinates.
@@ -2375,7 +2387,7 @@ pub(super) fn cache_cursor_position(
     ctx: &mut PaintContext,
     terminal_view_id: EntityId,
 ) {
-    let rect = compute_cursor_rect(
+    let CursorGeometry { rect, .. } = compute_cursor_rect(
         grid_render_params,
         cursor_point,
         is_cursor_on_wide_char,
@@ -2401,7 +2413,7 @@ pub fn render_cursor(
     hint_text: Option<&mut Box<dyn Element>>,
     app: &AppContext,
 ) {
-    let cursor_rect = compute_cursor_rect(
+    let CursorGeometry { rect: cursor_rect, line_top_origin } = compute_cursor_rect(
         grid_render_params,
         cursor_point,
         is_cursor_on_wide_char,
@@ -2416,11 +2428,6 @@ pub fn render_cursor(
 
     let cursor_top_origin = cursor_rect.origin();
     let cursor_block_size = cursor_rect.size();
-    // line_top_origin is needed for the Underline cursor shape (which draws from the
-    // un-baseline-adjusted top of the line, not from cursor_top_origin).
-    let line_top_origin = grid_origin
-        + vec2f(padding_x.as_f32(), 0.)
-        + grid_render_params.cell_size * vec2f(cursor_point.col as f32, cursor_point.row as f32);
 
     let thickness =
         CURSOR_THICKNESS_SCALE_FACTOR * grid_render_params.cell_size.x().round().max(1.);

--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -2413,7 +2413,10 @@ pub fn render_cursor(
     hint_text: Option<&mut Box<dyn Element>>,
     app: &AppContext,
 ) {
-    let CursorGeometry { rect: cursor_rect, line_top_origin } = compute_cursor_rect(
+    let CursorGeometry {
+        rect: cursor_rect,
+        line_top_origin,
+    } = compute_cursor_rect(
         grid_render_params,
         cursor_point,
         is_cursor_on_wide_char,

--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -2340,6 +2340,53 @@ fn calculate_cursor_origin(
         )
 }
 
+/// Computes the cursor's rect (origin + size) in window coordinates from grid-space inputs.
+fn compute_cursor_rect(
+    grid_render_params: &GridRenderParams,
+    cursor_point: Point,
+    is_cursor_on_wide_char: bool,
+    padding_x: Pixels,
+    grid_origin: Vector2F,
+    ctx: &mut PaintContext,
+) -> RectF {
+    let line_top_origin = grid_origin
+        + vec2f(padding_x.as_f32(), 0.)
+        + grid_render_params.cell_size * vec2f(cursor_point.col as f32, cursor_point.row as f32);
+    let cursor_top_origin = calculate_cursor_origin(grid_render_params, line_top_origin, ctx);
+    let cell_width = if is_cursor_on_wide_char {
+        grid_render_params.cell_size.x() * 2.
+    } else {
+        grid_render_params.cell_size.x()
+    };
+    let cursor_block_size = vec2f(
+        cell_width,
+        grid_render_params.font_size * DEFAULT_UI_LINE_HEIGHT_RATIO,
+    );
+    RectF::new(cursor_top_origin, cursor_block_size)
+}
+
+/// Updates the position cache with the terminal cursor's location in window coordinates.
+pub(super) fn cache_cursor_position(
+    grid_render_params: &GridRenderParams,
+    cursor_point: Point,
+    is_cursor_on_wide_char: bool,
+    padding_x: Pixels,
+    grid_origin: Vector2F,
+    ctx: &mut PaintContext,
+    terminal_view_id: EntityId,
+) {
+    let rect = compute_cursor_rect(
+        grid_render_params,
+        cursor_point,
+        is_cursor_on_wide_char,
+        padding_x,
+        grid_origin,
+        ctx,
+    );
+    ctx.position_cache
+        .cache_position_indefinitely(format!("terminal_view:cursor_{terminal_view_id}"), rect);
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn render_cursor(
     grid_render_params: &GridRenderParams,
@@ -2354,25 +2401,26 @@ pub fn render_cursor(
     hint_text: Option<&mut Box<dyn Element>>,
     app: &AppContext,
 ) {
+    let cursor_rect = compute_cursor_rect(
+        grid_render_params,
+        cursor_point,
+        is_cursor_on_wide_char,
+        padding_x,
+        grid_origin,
+        ctx,
+    );
+    ctx.position_cache.cache_position_indefinitely(
+        format!("terminal_view:cursor_{terminal_view_id}"),
+        cursor_rect,
+    );
+
+    let cursor_top_origin = cursor_rect.origin();
+    let cursor_block_size = cursor_rect.size();
+    // line_top_origin is needed for the Underline cursor shape (which draws from the
+    // un-baseline-adjusted top of the line, not from cursor_top_origin).
     let line_top_origin = grid_origin
         + vec2f(padding_x.as_f32(), 0.)
         + grid_render_params.cell_size * vec2f(cursor_point.col as f32, cursor_point.row as f32);
-
-    let cursor_top_origin = calculate_cursor_origin(grid_render_params, line_top_origin, ctx);
-    let cell_width = if is_cursor_on_wide_char {
-        grid_render_params.cell_size.x() * 2.
-    } else {
-        grid_render_params.cell_size.x()
-    };
-    let cursor_block_size = vec2f(
-        cell_width,
-        grid_render_params.font_size * DEFAULT_UI_LINE_HEIGHT_RATIO,
-    );
-
-    ctx.position_cache.cache_position_indefinitely(
-        format!("terminal_view:cursor_{terminal_view_id}"),
-        RectF::new(cursor_top_origin, cursor_block_size),
-    );
 
     let thickness =
         CURSOR_THICKNESS_SCALE_FACTOR * grid_render_params.cell_size.x().round().max(1.);
@@ -2387,7 +2435,7 @@ pub fn render_cursor(
             ctx.scene
                 .draw_rect_with_hit_recording(RectF::new(
                     line_top_origin + vec2f(0., height - thickness),
-                    vec2f(cell_width, thickness),
+                    vec2f(cursor_block_size.x(), thickness),
                 ))
                 .with_background(Fill::Solid(color));
         }


### PR DESCRIPTION
## Linked Issue

Fixes #9145

## Testing

To repro the bug. Open `claude` CLI on MacOS and then open the IME. The IME will be in the top-left corner of the grid, i.e. position (0, 0).

On this branch, the position is correct:

<img width="1282" height="800" alt="Screenshot 2026-06-23 at 11 22 59 AM" src="https://github.com/user-attachments/assets/1793ffc2-8021-4f49-b4c6-eb5f1d737c6b" />

## Description

The bug is due to the cached cursor position (in [`PaintContext::position_cache`](https://github.com/warpdotdev/warp/blob/7f0a121cf526bf6f97951c5218084b4d7701e276/crates/warpui_core/src/presenter.rs#L54-L54) being incorrect). The IME uses the cached cursor position to decide where to render. The bug was occurring because the position was stale at (0, 0).

When you run `claude`, it tries to prevent visual flickering using the [synchronized update protocol](https://github.com/contour-terminal/vt-extensions/blob/master/synchronized-output.md). It emits escape codes like this:

```
# on one "frame" where "frame" is a step in claude's update cycle that outputs text to the terminal model. not WarpUI's idea of a "frame" or a "rendered scene"

\e[?2026h    ← begin sync
\e[?25l      ← hide cursor
print a bunch of output, the "frame" content
\e[?25h      ← show cursor
\e[?2026l    ← end sync / render 

# next "frame"

\e[?2026h    ← begin sync
\e[?25l      ← hide cursor
print a bunch of output, the "frame" content
\e[?25h      ← show cursor
\e[?2026l    ← end sync / render 
```

This is from inspecting PTY recordings BTW

<img width="578" height="413" alt="Screenshot 2026-06-23 at 2 06 57 PM" src="https://github.com/user-attachments/assets/4fbc820d-b5b9-4e19-8b8f-8334adcd6add" />


It wraps each "frame" in synchronized output as well as hiding and then showing the cursor. I presume this is to ensure the cursor doesn't jump around at all during the update cycle. They want to maintain the user's idea of the cursor position even though updating the screen means the _actual_ cursor needs to fully traverse the grid to update each cell. Hiding it during the update ensures that the user won't notice that.

So why does this go wrong?

We do implement this sync output protocol. However, we do not actually paint the scene (Warp's idea of a frame) synchronously. We send a wakeup event, but wakeup events are buffered and coalesced, i.e. [throttled](https://github.com/warpdotdev/warp/blob/8d3baf91b0e9655f9623ee60924d2f7b622487e9/app/src/terminal/view.rs#L3697-L3697). When `\e[?2026l` (end sync) is received, we correctly send a wakeup event and the cursor is SHOWN. But soon the `\e[?25l` (hide cursor) for the next update comes in and gets applied to the terminal model and coalesces with the last wakeup event. Now we get a deferred render where cursor is HIDDEN.

Finally rendering the scene happens and `BlockListElement::draw_block` is called. It checks `TermMode::SHOW_CURSOR`. If that is on, it calls `fn render_cursor` which is the function responsible for [setting the cached cursor position](https://github.com/warpdotdev/warp/blob/8d3baf91b0e9655f9623ee60924d2f7b622487e9/app/src/terminal/grid_renderer.rs#L2372) which the IME depends on. If _not_, no position is cached and the IME will not have an up-to-date position.

I think in an ideal world, 

<!--
## Changelog Entries for Stable

CHANGELOG-BUG-FIX: [MacOS] Fix IME positioning in Claude Code.
-->
