### PR TITLE
Show prompt cache expiry as a notification dot instead of yellow chip

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -127,10 +127,6 @@ const START_REMOTE_CONTROL_LOGIN_REQUIRED_TOOLTIP: &str = "Log in to use /remote
 
 const CLOUD_MODE_V2_FOOTER_GAP: f32 = 4.;
 
-/// Diameter of the yellow notification dot shown on the context-window chip
-/// when the active conversation's prompt cache has expired.
-const PROMPT_CACHE_EXPIRY_DOT_SIZE: f32 = 6.;
-
 /// Voice input state for the CLI agent footer. Unlike the editor-based voice
 /// flow (which goes through Input → EditorView), this state is self-contained
 /// so that transcribed text can be written directly to the PTY.
@@ -2150,11 +2146,37 @@ impl AgentInputFooter {
                         .is_some();
                 has_conversation.then(|| {
                     let chip = ChildView::new(&self.context_window_button).finish();
-                    if self.prompt_cache_expired {
-                        render_prompt_cache_expiry_dot(chip, app)
-                    } else {
-                        chip
+                    if !self.prompt_cache_expired {
+                        return chip;
                     }
+
+                    let appearance = Appearance::as_ref(app);
+                    let dot = Container::new(
+                        ConstrainedBox::new(Empty::new().finish())
+                            .with_width(6.)
+                            .with_height(6.)
+                            .finish(),
+                    )
+                    .with_corner_radius(CornerRadius::with_all(Radius::Percentage(50.)))
+                    .with_background(Fill::Solid(
+                        AnsiColorIdentifier::Yellow
+                            .to_ansi_color(&appearance.theme().terminal_colors().normal)
+                            .into(),
+                    ))
+                    .finish();
+
+                    let mut stack = Stack::new();
+                    stack.add_child(chip);
+                    stack.add_positioned_overlay_child(
+                        dot,
+                        OffsetPositioning::offset_from_parent(
+                            vec2f(3., -3.),
+                            ParentOffsetBounds::WindowByPosition,
+                            ParentAnchor::TopRight,
+                            ChildAnchor::TopRight,
+                        ),
+                    );
+                    stack.finish()
                 })
             }
             AgentToolbarItemKind::ShareSession => {
@@ -2362,42 +2384,6 @@ impl View for AgentInputFooter {
             container.finish()
         }
     }
-}
-
-/// Overlays a small yellow notification dot on the top-right corner of `element`
-/// to flag that the active conversation's prompt cache has expired.
-///
-/// Uses `add_positioned_overlay_child` so the dot renders in an overlay layer
-/// (`ClipBounds::None`), escaping the parent `Wrap`'s `BoundedByActiveLayerAnd`
-/// clip without needing a `SavePosition` + footer-level anchor.
-fn render_prompt_cache_expiry_dot(element: Box<dyn Element>, app: &AppContext) -> Box<dyn Element> {
-    let appearance = Appearance::as_ref(app);
-    let dot = Container::new(
-        ConstrainedBox::new(Empty::new().finish())
-            .with_width(PROMPT_CACHE_EXPIRY_DOT_SIZE)
-            .with_height(PROMPT_CACHE_EXPIRY_DOT_SIZE)
-            .finish(),
-    )
-    .with_corner_radius(CornerRadius::with_all(Radius::Percentage(50.)))
-    .with_background(Fill::Solid(
-        AnsiColorIdentifier::Yellow
-            .to_ansi_color(&appearance.theme().terminal_colors().normal)
-            .into(),
-    ))
-    .finish();
-
-    let mut stack = Stack::new();
-    stack.add_child(element);
-    stack.add_positioned_overlay_child(
-        dot,
-        OffsetPositioning::offset_from_parent(
-            vec2f(3., -3.),
-            ParentOffsetBounds::WindowByPosition,
-            ParentAnchor::TopRight,
-            ChildAnchor::TopRight,
-        ),
-    );
-    stack.finish()
 }
 
 /// Render a message bubble calling out that the model has switched now that we're in FTU mode.

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -32,13 +32,12 @@ use warp_core::ui::theme::color::internal_colors;
 use warp_core::ui::theme::{AnsiColorIdentifier, Fill};
 use warpui::elements::{
     Border, ChildAnchor, ChildView, Clipped, ConstrainedBox, Container, CornerRadius,
-    CrossAxisAlignment, DispatchEventResult, Element, EventHandler, Expanded, Flex,
+    CrossAxisAlignment, DispatchEventResult, Element, Empty, EventHandler, Expanded, Flex,
     MainAxisAlignment, MainAxisSize, OffsetPositioning, ParentElement, PositionedElementAnchor,
-    PositionedElementOffsetBounds, Radius, Shrinkable, Stack, Text, Wrap, WrapFill,
+    PositionedElementOffsetBounds, Radius, SavePosition, Shrinkable, Stack, Text, Wrap, WrapFill,
     WrapFillEntireRun, DEFAULT_UI_LINE_HEIGHT_RATIO,
 };
 use warpui::r#async::{SpawnedFutureHandle, Timer};
-use warpui::ui_components::components::UiComponentStyles;
 use warpui::{
     AppContext, Entity, EntityId, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
     ViewHandle,
@@ -102,7 +101,6 @@ use crate::terminal::view::TerminalAction;
 use crate::terminal::ShellLaunchData;
 use crate::terminal::{CLIAgent, TerminalModel};
 use crate::ui_components::icons::Icon;
-use crate::ui_components::red_notification_dot::RedNotificationDot;
 use crate::view_components::action_button::{
     ActionButton, ActionButtonTheme, AdjoinedSide, ButtonSize, KeystrokeSource, NakedTheme,
     TooltipAlignment,
@@ -132,6 +130,10 @@ const CLOUD_MODE_V2_FOOTER_GAP: f32 = 4.;
 /// Diameter of the yellow notification dot shown on the context-window chip
 /// when the active conversation's prompt cache has expired.
 const PROMPT_CACHE_EXPIRY_DOT_SIZE: f32 = 6.;
+
+/// `SavePosition` ID for the context-window chip so the dot overlay can be
+/// anchored to it at the footer level, bypassing parent container clipping.
+const CONTEXT_WINDOW_CHIP_SAVE_ID: &str = "context_window_chip_badge_anchor";
 
 /// Voice input state for the CLI agent footer. Unlike the editor-based voice
 /// flow (which goes through Input → EditorView), this state is self-contained
@@ -2150,13 +2152,15 @@ impl AgentInputFooter {
                     && BlocklistAIHistoryModel::as_ref(app)
                         .active_conversation(self.terminal_view_id)
                         .is_some();
+                // SavePosition records the chip's bounds each frame so the
+                // footer-level overlay child can anchor the dot to it without
+                // being clipped by the intervening Flex/Wrap containers.
                 has_conversation.then(|| {
-                    let chip = ChildView::new(&self.context_window_button).finish();
-                    if self.prompt_cache_expired {
-                        render_prompt_cache_expiry_dot(chip, app)
-                    } else {
-                        chip
-                    }
+                    SavePosition::new(
+                        ChildView::new(&self.context_window_button).finish(),
+                        CONTEXT_WINDOW_CHIP_SAVE_ID,
+                    )
+                    .finish()
                 })
             }
             AgentToolbarItemKind::ShareSession => {
@@ -2345,19 +2349,41 @@ impl View for AgentInputFooter {
                 .block_list()
                 .active_block()
                 .is_agent_in_control_or_tagged_in();
-        if showing_ftu_model_picker && self.render_ftu_callout {
+
+        // Collect any overlay children that need to render above the footer
+        // without being clipped by the intervening Flex/Wrap containers.
+        let needs_overlays =
+            (showing_ftu_model_picker && self.render_ftu_callout) || self.prompt_cache_expired;
+        if needs_overlays {
             let mut stack = Stack::new();
             stack.add_child(container.finish());
-            stack.add_positioned_overlay_child(
-                render_ftu_callout(&self.ftu_callout_close_button, app),
-                OffsetPositioning::offset_from_save_position_element(
-                    "profile_model_selector_model_button",
-                    vec2f(8., -8.),
-                    PositionedElementOffsetBounds::WindowByPosition,
-                    PositionedElementAnchor::TopRight,
-                    ChildAnchor::BottomRight,
-                ),
-            );
+            if showing_ftu_model_picker && self.render_ftu_callout {
+                stack.add_positioned_overlay_child(
+                    render_ftu_callout(&self.ftu_callout_close_button, app),
+                    OffsetPositioning::offset_from_save_position_element(
+                        "profile_model_selector_model_button",
+                        vec2f(8., -8.),
+                        PositionedElementOffsetBounds::WindowByPosition,
+                        PositionedElementAnchor::TopRight,
+                        ChildAnchor::BottomRight,
+                    ),
+                );
+            }
+            if self.prompt_cache_expired {
+                // Render the dot as a window-level overlay anchored to the chip's
+                // saved position so it straddles the chip corner without being
+                // clipped by the Flex/Wrap containers between them.
+                stack.add_positioned_overlay_child(
+                    render_prompt_cache_expiry_dot(app),
+                    OffsetPositioning::offset_from_save_position_element(
+                        CONTEXT_WINDOW_CHIP_SAVE_ID,
+                        vec2f(3., -3.),
+                        PositionedElementOffsetBounds::WindowByPosition,
+                        PositionedElementAnchor::TopRight,
+                        ChildAnchor::TopRight,
+                    ),
+                );
+            }
             stack.finish()
         } else {
             container.finish()
@@ -2365,30 +2391,26 @@ impl View for AgentInputFooter {
     }
 }
 
-/// Overlays a small yellow notification dot on the top-right corner of `element`
-/// to flag that the active conversation's prompt cache has expired.
+/// Renders the yellow notification dot that signals prompt cache expiry.
 ///
-/// `render_with_offset` applies a built-in `(width/2, -height/2)` offset that would place
-/// the dot outside the element's logical bounds, causing it to be clipped by the parent
-/// flex container. We counteract that with `(-width/2, height/2)` so the dot's top-right
-/// corner lands exactly at the chip's top-right corner and the dot extends inward.
-fn render_prompt_cache_expiry_dot(element: Box<dyn Element>, app: &AppContext) -> Box<dyn Element> {
+/// This is placed as a positioned overlay child on the footer-level Stack
+/// (anchored via `SavePosition` on the context-window chip), so it can straddle
+/// the chip's corner without being clipped by the intervening Flex/Wrap layout.
+fn render_prompt_cache_expiry_dot(app: &AppContext) -> Box<dyn Element> {
     let appearance = Appearance::as_ref(app);
-    let half = PROMPT_CACHE_EXPIRY_DOT_SIZE / 2.;
-    RedNotificationDot::render_with_offset(
-        element,
-        &UiComponentStyles {
-            width: Some(PROMPT_CACHE_EXPIRY_DOT_SIZE),
-            height: Some(PROMPT_CACHE_EXPIRY_DOT_SIZE),
-            background: Some(warpui::elements::Fill::Solid(
-                AnsiColorIdentifier::Yellow
-                    .to_ansi_color(&appearance.theme().terminal_colors().normal)
-                    .into(),
-            )),
-            ..RedNotificationDot::default_styles(appearance)
-        },
-        (-half, half),
+    Container::new(
+        ConstrainedBox::new(Empty::new().finish())
+            .with_width(PROMPT_CACHE_EXPIRY_DOT_SIZE)
+            .with_height(PROMPT_CACHE_EXPIRY_DOT_SIZE)
+            .finish(),
     )
+    .with_corner_radius(CornerRadius::with_all(Radius::Percentage(50.)))
+    .with_background(Fill::Solid(
+        AnsiColorIdentifier::Yellow
+            .to_ansi_color(&appearance.theme().terminal_colors().normal)
+            .into(),
+    ))
+    .finish()
 }
 
 /// Render a message bubble calling out that the model has switched now that we're in FTU mode.

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -38,6 +38,7 @@ use warpui::elements::{
     WrapFillEntireRun, DEFAULT_UI_LINE_HEIGHT_RATIO,
 };
 use warpui::r#async::{SpawnedFutureHandle, Timer};
+use warpui::ui_components::components::UiComponentStyles;
 use warpui::{
     AppContext, Entity, EntityId, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
     ViewHandle,
@@ -101,6 +102,7 @@ use crate::terminal::view::TerminalAction;
 use crate::terminal::ShellLaunchData;
 use crate::terminal::{CLIAgent, TerminalModel};
 use crate::ui_components::icons::Icon;
+use crate::ui_components::red_notification_dot::RedNotificationDot;
 use crate::view_components::action_button::{
     ActionButton, ActionButtonTheme, AdjoinedSide, ButtonSize, KeystrokeSource, NakedTheme,
     TooltipAlignment,
@@ -126,6 +128,10 @@ const START_REMOTE_CONTROL_TOOLTIP: &str = "Start remote control";
 const START_REMOTE_CONTROL_LOGIN_REQUIRED_TOOLTIP: &str = "Log in to use /remote-control";
 
 const CLOUD_MODE_V2_FOOTER_GAP: f32 = 4.;
+
+/// Diameter of the yellow notification dot shown on the context-window chip
+/// when the active conversation's prompt cache has expired.
+const PROMPT_CACHE_EXPIRY_DOT_SIZE: f32 = 6.;
 
 /// Voice input state for the CLI agent footer. Unlike the editor-based voice
 /// flow (which goes through Input → EditorView), this state is self-contained
@@ -249,8 +255,13 @@ pub struct AgentInputFooter {
     v2_model_selector: Option<ViewHandle<ModelSelector>>,
 
     /// Pending one-shot timer that refreshes the context-window button at the
-    /// prompt-cache expiry instant so the yellow tint appears while idle.
+    /// prompt-cache expiry instant so the notification dot appears while idle.
     prompt_cache_expiry_timer_handle: Option<SpawnedFutureHandle>,
+
+    /// Whether the active conversation's prompt cache has expired. Drives the
+    /// yellow notification dot on the context-window chip when the
+    /// `PromptCacheExpiryWarning` flag is enabled.
+    prompt_cache_expired: bool,
 }
 
 impl AgentInputFooter {
@@ -878,6 +889,7 @@ impl AgentInputFooter {
             }),
             v2_model_selector,
             prompt_cache_expiry_timer_handle: None,
+            prompt_cache_expired: false,
         };
         me.sync_fast_forward_button(ctx);
         me.sync_remote_control_button(ctx);
@@ -2033,13 +2045,9 @@ impl AgentInputFooter {
                 context_remaining_tooltip
             };
 
+            self.prompt_cache_expired = is_cache_expired;
             self.context_window_button.update(ctx, |button, ctx| {
                 button.set_icon(Some(icon), ctx);
-                if is_cache_expired {
-                    button.set_theme(WarningAgentInputButtonTheme, ctx);
-                } else {
-                    button.set_theme(AgentInputButtonTheme, ctx);
-                }
                 button.set_tooltip(Some(tooltip), ctx);
             });
 
@@ -2048,7 +2056,7 @@ impl AgentInputFooter {
     }
 
     /// Schedules a refresh of the context-window button at the prompt-cache
-    /// expiry instant so the yellow tint appears while the conversation is idle.
+    /// expiry instant so the notification dot appears while the conversation is idle.
     fn reschedule_prompt_cache_expiry_timer(
         &mut self,
         expiry: Option<DateTime<Local>>,
@@ -2142,7 +2150,14 @@ impl AgentInputFooter {
                     && BlocklistAIHistoryModel::as_ref(app)
                         .active_conversation(self.terminal_view_id)
                         .is_some();
-                has_conversation.then(|| ChildView::new(&self.context_window_button).finish())
+                has_conversation.then(|| {
+                    let chip = ChildView::new(&self.context_window_button).finish();
+                    if self.prompt_cache_expired {
+                        render_prompt_cache_expiry_dot(chip, app)
+                    } else {
+                        chip
+                    }
+                })
             }
             AgentToolbarItemKind::ShareSession => {
                 if is_conversation_transcript_context {
@@ -2348,6 +2363,26 @@ impl View for AgentInputFooter {
             container.finish()
         }
     }
+}
+
+/// Overlays a small yellow notification dot on the top-right corner of `element`
+/// to flag that the active conversation's prompt cache has expired.
+fn render_prompt_cache_expiry_dot(element: Box<dyn Element>, app: &AppContext) -> Box<dyn Element> {
+    let appearance = Appearance::as_ref(app);
+    RedNotificationDot::render_with_offset(
+        element,
+        &UiComponentStyles {
+            width: Some(PROMPT_CACHE_EXPIRY_DOT_SIZE),
+            height: Some(PROMPT_CACHE_EXPIRY_DOT_SIZE),
+            background: Some(warpui::elements::Fill::Solid(
+                AnsiColorIdentifier::Yellow
+                    .to_ansi_color(&appearance.theme().terminal_colors().normal)
+                    .into(),
+            )),
+            ..RedNotificationDot::default_styles(appearance)
+        },
+        (-1., 1.),
+    )
 }
 
 /// Render a message bubble calling out that the model has switched now that we're in FTU mode.
@@ -2868,43 +2903,6 @@ impl ActionButtonTheme for InstallPluginButtonTheme {
 
     fn should_opt_out_of_contrast_adjustment(&self) -> bool {
         true
-    }
-}
-
-/// Yellow-tinted variant of [`AgentInputButtonTheme`] used to flag a warning
-/// state on an input chip (e.g. expired prompt cache); slightly darker on hover.
-struct WarningAgentInputButtonTheme;
-
-impl ActionButtonTheme for WarningAgentInputButtonTheme {
-    fn background(&self, hovered: bool, appearance: &Appearance) -> Option<Fill> {
-        let yellow = appearance.theme().ansi_fg_yellow();
-        let base = appearance.theme().surface_1();
-        Some(if hovered {
-            base.blend(&Fill::Solid(yellow).with_opacity(45))
-        } else {
-            base.blend(&Fill::Solid(yellow).with_opacity(30))
-        })
-    }
-
-    fn text_color(
-        &self,
-        hovered: bool,
-        background: Option<Fill>,
-        appearance: &Appearance,
-    ) -> ColorU {
-        AgentInputButtonTheme.text_color(hovered, background, appearance)
-    }
-
-    fn border(&self, appearance: &Appearance) -> Option<ColorU> {
-        AgentInputButtonTheme.border(appearance)
-    }
-
-    fn should_opt_out_of_contrast_adjustment(&self) -> bool {
-        AgentInputButtonTheme.should_opt_out_of_contrast_adjustment()
-    }
-
-    fn font_properties(&self) -> Option<warpui::fonts::Properties> {
-        AgentInputButtonTheme.font_properties()
     }
 }
 

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -2367,8 +2367,14 @@ impl View for AgentInputFooter {
 
 /// Overlays a small yellow notification dot on the top-right corner of `element`
 /// to flag that the active conversation's prompt cache has expired.
+///
+/// `render_with_offset` applies a built-in `(width/2, -height/2)` offset that would place
+/// the dot outside the element's logical bounds, causing it to be clipped by the parent
+/// flex container. We counteract that with `(-width/2, height/2)` so the dot's top-right
+/// corner lands exactly at the chip's top-right corner and the dot extends inward.
 fn render_prompt_cache_expiry_dot(element: Box<dyn Element>, app: &AppContext) -> Box<dyn Element> {
     let appearance = Appearance::as_ref(app);
+    let half = PROMPT_CACHE_EXPIRY_DOT_SIZE / 2.;
     RedNotificationDot::render_with_offset(
         element,
         &UiComponentStyles {
@@ -2381,7 +2387,7 @@ fn render_prompt_cache_expiry_dot(element: Box<dyn Element>, app: &AppContext) -
             )),
             ..RedNotificationDot::default_styles(appearance)
         },
-        (-1., 1.),
+        (-half, half),
     )
 }
 

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -33,9 +33,9 @@ use warp_core::ui::theme::{AnsiColorIdentifier, Fill};
 use warpui::elements::{
     Border, ChildAnchor, ChildView, Clipped, ConstrainedBox, Container, CornerRadius,
     CrossAxisAlignment, DispatchEventResult, Element, Empty, EventHandler, Expanded, Flex,
-    MainAxisAlignment, MainAxisSize, OffsetPositioning, ParentElement, PositionedElementAnchor,
-    PositionedElementOffsetBounds, Radius, SavePosition, Shrinkable, Stack, Text, Wrap, WrapFill,
-    WrapFillEntireRun, DEFAULT_UI_LINE_HEIGHT_RATIO,
+    MainAxisAlignment, MainAxisSize, OffsetPositioning, ParentAnchor, ParentElement,
+    ParentOffsetBounds, PositionedElementAnchor, PositionedElementOffsetBounds, Radius, Shrinkable,
+    Stack, Text, Wrap, WrapFill, WrapFillEntireRun, DEFAULT_UI_LINE_HEIGHT_RATIO,
 };
 use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::{
@@ -130,10 +130,6 @@ const CLOUD_MODE_V2_FOOTER_GAP: f32 = 4.;
 /// Diameter of the yellow notification dot shown on the context-window chip
 /// when the active conversation's prompt cache has expired.
 const PROMPT_CACHE_EXPIRY_DOT_SIZE: f32 = 6.;
-
-/// `SavePosition` ID for the context-window chip so the dot overlay can be
-/// anchored to it at the footer level, bypassing parent container clipping.
-const CONTEXT_WINDOW_CHIP_SAVE_ID: &str = "context_window_chip_badge_anchor";
 
 /// Voice input state for the CLI agent footer. Unlike the editor-based voice
 /// flow (which goes through Input → EditorView), this state is self-contained
@@ -2152,15 +2148,13 @@ impl AgentInputFooter {
                     && BlocklistAIHistoryModel::as_ref(app)
                         .active_conversation(self.terminal_view_id)
                         .is_some();
-                // SavePosition records the chip's bounds each frame so the
-                // footer-level overlay child can anchor the dot to it without
-                // being clipped by the intervening Flex/Wrap containers.
                 has_conversation.then(|| {
-                    SavePosition::new(
-                        ChildView::new(&self.context_window_button).finish(),
-                        CONTEXT_WINDOW_CHIP_SAVE_ID,
-                    )
-                    .finish()
+                    let chip = ChildView::new(&self.context_window_button).finish();
+                    if self.prompt_cache_expired {
+                        render_prompt_cache_expiry_dot(chip, app)
+                    } else {
+                        chip
+                    }
                 })
             }
             AgentToolbarItemKind::ShareSession => {
@@ -2350,40 +2344,19 @@ impl View for AgentInputFooter {
                 .active_block()
                 .is_agent_in_control_or_tagged_in();
 
-        // Collect any overlay children that need to render above the footer
-        // without being clipped by the intervening Flex/Wrap containers.
-        let needs_overlays =
-            (showing_ftu_model_picker && self.render_ftu_callout) || self.prompt_cache_expired;
-        if needs_overlays {
+        if showing_ftu_model_picker && self.render_ftu_callout {
             let mut stack = Stack::new();
             stack.add_child(container.finish());
-            if showing_ftu_model_picker && self.render_ftu_callout {
-                stack.add_positioned_overlay_child(
-                    render_ftu_callout(&self.ftu_callout_close_button, app),
-                    OffsetPositioning::offset_from_save_position_element(
-                        "profile_model_selector_model_button",
-                        vec2f(8., -8.),
-                        PositionedElementOffsetBounds::WindowByPosition,
-                        PositionedElementAnchor::TopRight,
-                        ChildAnchor::BottomRight,
-                    ),
-                );
-            }
-            if self.prompt_cache_expired {
-                // Render the dot as a window-level overlay anchored to the chip's
-                // saved position so it straddles the chip corner without being
-                // clipped by the Flex/Wrap containers between them.
-                stack.add_positioned_overlay_child(
-                    render_prompt_cache_expiry_dot(app),
-                    OffsetPositioning::offset_from_save_position_element(
-                        CONTEXT_WINDOW_CHIP_SAVE_ID,
-                        vec2f(3., -3.),
-                        PositionedElementOffsetBounds::WindowByPosition,
-                        PositionedElementAnchor::TopRight,
-                        ChildAnchor::TopRight,
-                    ),
-                );
-            }
+            stack.add_positioned_overlay_child(
+                render_ftu_callout(&self.ftu_callout_close_button, app),
+                OffsetPositioning::offset_from_save_position_element(
+                    "profile_model_selector_model_button",
+                    vec2f(8., -8.),
+                    PositionedElementOffsetBounds::WindowByPosition,
+                    PositionedElementAnchor::TopRight,
+                    ChildAnchor::BottomRight,
+                ),
+            );
             stack.finish()
         } else {
             container.finish()
@@ -2391,14 +2364,15 @@ impl View for AgentInputFooter {
     }
 }
 
-/// Renders the yellow notification dot that signals prompt cache expiry.
+/// Overlays a small yellow notification dot on the top-right corner of `element`
+/// to flag that the active conversation's prompt cache has expired.
 ///
-/// This is placed as a positioned overlay child on the footer-level Stack
-/// (anchored via `SavePosition` on the context-window chip), so it can straddle
-/// the chip's corner without being clipped by the intervening Flex/Wrap layout.
-fn render_prompt_cache_expiry_dot(app: &AppContext) -> Box<dyn Element> {
+/// Uses `add_positioned_overlay_child` so the dot renders in an overlay layer
+/// (`ClipBounds::None`), escaping the parent `Wrap`'s `BoundedByActiveLayerAnd`
+/// clip without needing a `SavePosition` + footer-level anchor.
+fn render_prompt_cache_expiry_dot(element: Box<dyn Element>, app: &AppContext) -> Box<dyn Element> {
     let appearance = Appearance::as_ref(app);
-    Container::new(
+    let dot = Container::new(
         ConstrainedBox::new(Empty::new().finish())
             .with_width(PROMPT_CACHE_EXPIRY_DOT_SIZE)
             .with_height(PROMPT_CACHE_EXPIRY_DOT_SIZE)
@@ -2410,7 +2384,20 @@ fn render_prompt_cache_expiry_dot(app: &AppContext) -> Box<dyn Element> {
             .to_ansi_color(&appearance.theme().terminal_colors().normal)
             .into(),
     ))
-    .finish()
+    .finish();
+
+    let mut stack = Stack::new();
+    stack.add_child(element);
+    stack.add_positioned_overlay_child(
+        dot,
+        OffsetPositioning::offset_from_parent(
+            vec2f(3., -3.),
+            ParentOffsetBounds::WindowByPosition,
+            ParentAnchor::TopRight,
+            ChildAnchor::TopRight,
+        ),
+    );
+    stack.finish()
 }
 
 /// Render a message bubble calling out that the model has switched now that we're in FTU mode.


### PR DESCRIPTION
## Description

The context window color is going to be used for a different token transparency effort, so we need to switch the prompt cache expiration indicator to use a different mechanism. @dagmfactory had a good idea to use an indicator dot in the top right corner of the chip instead, which is what this PR adds.

## Testing
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

![image.png](https://app.graphite.com/user-attachments/assets/6a294ace-1816-42b1-8de4-e03b898cf354.png)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/ae0e4f10-5c24-4fcd-abed-098195676a44_
_Run: https://oz.staging.warp.dev/runs/019ef5e3-96a5-7d7b-a821-3199bbbb285b_

_This PR was generated with [Oz](https://warp.dev/oz)._
