### PR TITLE
Center text editor for grouped tab renaming

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -1194,18 +1194,16 @@ impl<'a> TabComponent<'a> {
                         .set_border_width(0.),
                 )
                 .with_style(UiComponentStyles {
-                    margin: Some(Coords::default().top(
-                        if self.grouped_member {
-                            // Reduce the top margin for grouped tabs to make it appear centered.
-                            2.
-                        } else if FeatureFlag::NewTabStyling.is_enabled() {
-                            // With the larger tabs in the new ui, we need to give the editor some extra top margin
-                            // to make it appear centered
-                            8.
-                        } else {
-                            3.
-                        },
-                    )),
+                    margin: Some(Coords::default().top(if self.grouped_member {
+                        // Reduce the top margin for grouped tabs to make it appear centered.
+                        2.
+                    } else if FeatureFlag::NewTabStyling.is_enabled() {
+                        // With the larger tabs in the new ui, we need to give the editor some extra top margin
+                        // to make it appear centered
+                        8.
+                    } else {
+                        3.
+                    })),
                     ..Default::default()
                 })
                 .build()

--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -1195,7 +1195,10 @@ impl<'a> TabComponent<'a> {
                 )
                 .with_style(UiComponentStyles {
                     margin: Some(Coords::default().top(
-                        if FeatureFlag::NewTabStyling.is_enabled() {
+                        if self.grouped_member {
+                            // Reduce the top margin for grouped tabs to make it appear centered.
+                            2.
+                        } else if FeatureFlag::NewTabStyling.is_enabled() {
                             // With the larger tabs in the new ui, we need to give the editor some extra top margin
                             // to make it appear centered
                             8.


### PR DESCRIPTION
## Description

The text editor for renaming tabs that are part of groups is not centered vertically. This is because grouped tabs have additional padding above them compared to regular tabs. This PR adds a special case to reduce the top margin of the `TextInput` when a tab is part of a group.

Specific to horizontal tabs.

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4769/renaming-tab-in-group-is-not-centered

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo of bug](https://www.loom.com/share/c54152727bcd4bca8f4ca54c6075c872)

[Demo of fix](https://www.loom.com/share/282be2b11d794b0f8315a1dcf5676cc4)