### PR TITLE
Fix '?' shortcut firing in queued prompt inline editor

### DIFF
--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -2075,6 +2075,7 @@ pub fn init(app: &mut AppContext) {
                 & id!(flags::EMPTY_INPUT_BUFFER)
                 & id!(flags::ACTIVE_AGENT_VIEW)
                 & !id!("LongRunningCommand")
+                & !id!(QUEUED_PROMPT_INLINE_EDITOR_OPEN_CONTEXT)
                 & !(id!(flags::TERMINAL_MODE_INPUT) & id!(flags::LOCKED_INPUT)),
         )]);
     }


### PR DESCRIPTION
## Description

When editing a queued prompt inline (clicking the edit button on a queued prompt row), typing `?` would trigger the inline help/shortcuts menu instead of being typed into the editor.

**Root cause:** The `shift-?` keybinding for `ToggleAgentViewShortcuts` had a context predicate that checked `EMPTY_INPUT_BUFFER` (the main input buffer) and `ACTIVE_AGENT_VIEW`, but did not exclude the case where a queued prompt is being edited inline. Since the main input buffer is empty while editing a queued prompt, the predicate matched and the shortcut fired.

**Fix:** Add `& !id!(QUEUED_PROMPT_INLINE_EDITOR_OPEN_CONTEXT)` to the keybinding predicate, matching the same guard already used for the `Up` key to prevent history navigation while editing a queued prompt.

## Linked Issue

N/A (reported via Slack)

## Testing

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

To reproduce (before fix):
1. Enable queue mode and submit a prompt while another is in progress to queue a second prompt
2. Ensure the regular input is empty
3. Click the edit button on the queued prompt
4. Type `?` → inline help menu opens (bug)

After fix: `?` is typed into the queued prompt editor as expected.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed typing `?` in the queued prompt inline editor opening the shortcuts help menu instead of being inserted as text.
-->

_Conversation: https://staging.warp.dev/conversation/05897014-71bb-41c9-aab7-e58159497a16_
_Run: https://oz.staging.warp.dev/runs/019ef677-af02-731f-bf21-ccc58d8dca69_

_This PR was generated with [Oz](https://warp.dev/oz)._
