### PR TITLE
Make the completions ("completions not working") banner permanently dismissible

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -665,6 +665,10 @@ const DEBOUNCE_PERIOD: Duration = Duration::from_millis(40);
 /// clipboard blocked banner.
 const OSC52_CLIPBOARD_BANNER_SUPPRESSED_KEY: &str = "Osc52ClipboardBannerSuppressed";
 
+/// Key used in user preferences to persist the "don't show again" choice for the SSH
+/// ControlMaster / "completions are not working" banner.
+const CONTROL_MASTER_BANNER_SUPPRESSED_KEY: &str = "ControlMasterBannerSuppressed";
+
 /// Which type of OSC 52 clipboard operation was blocked.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum Osc52ClipboardBlockedType {
@@ -2592,6 +2596,8 @@ pub struct TerminalView {
 
     control_master_error_banner: ViewHandle<Banner<TerminalAction>>,
     control_master_error_banner_state: ControlMasterErrorBannerState,
+    /// Whether the user has permanently dismissed the control master error banner.
+    control_master_error_banner_suppressed: bool,
 
     /// Banner to show if we detect a configuration in the user's rc files that
     /// is incompatible with Warp.
@@ -3887,7 +3893,7 @@ impl TerminalView {
         });
 
         let control_master_error_banner = ctx.add_typed_action_view(|_| {
-            Banner::new(BannerTextContent::formatted_text(vec![
+            Banner::new_permanently_dismissible(BannerTextContent::formatted_text(vec![
                 FormattedTextFragment::plain_text("Seems like your completions are not working ("),
                 FormattedTextFragment::hyperlink("more info", CONTROLMASTER_ISSUES_URL),
                 FormattedTextFragment::plain_text("). Enabling the SSH extension in "),
@@ -3991,6 +3997,13 @@ impl TerminalView {
         let osc52_clipboard_banner_suppressed = ctx
             .private_user_preferences()
             .read_value(OSC52_CLIPBOARD_BANNER_SUPPRESSED_KEY)
+            .ok()
+            .flatten()
+            .is_some_and(|v| v == "true");
+
+        let control_master_error_banner_suppressed = ctx
+            .private_user_preferences()
+            .read_value(CONTROL_MASTER_BANNER_SUPPRESSED_KEY)
             .ok()
             .flatten()
             .is_some_and(|v| v == "true");
@@ -4298,6 +4311,7 @@ impl TerminalView {
             is_emacs_bindings_banner_open: false,
             control_master_error_banner,
             control_master_error_banner_state: Default::default(),
+            control_master_error_banner_suppressed,
             osc52_clipboard_blocked_banner,
             osc52_clipboard_blocked_type: None,
             osc52_clipboard_banner_suppressed,
@@ -9508,9 +9522,10 @@ impl TerminalView {
             });
 
             // Don't show the banner when the session already has a remote server
-            // active — the CTA to enable the SSH extension is irrelevant.
+            // active — the CTA to enable the SSH extension is irrelevant — or when
+            // the user has permanently dismissed it.
             self.control_master_error_banner_state = ControlMasterErrorBannerState {
-                is_open: !has_remote_server,
+                is_open: self.should_open_control_master_banner(has_remote_server),
                 associated_session_id: active_session_id,
             };
 
@@ -9521,6 +9536,13 @@ impl TerminalView {
                 ctx
             );
         }
+    }
+
+    /// The control master / completions banner should open only when the session has no
+    /// remote server (the CTA to enable the SSH extension would be irrelevant otherwise)
+    /// and the user has not permanently dismissed it via "Don't show me again".
+    fn should_open_control_master_banner(&self, has_remote_server: bool) -> bool {
+        !has_remote_server && !self.control_master_error_banner_suppressed
     }
 
     fn read_from_clipboard(
@@ -22208,8 +22230,16 @@ impl TerminalView {
         ctx: &mut ViewContext<Self>,
     ) {
         match event {
-            BannerEvent::Dismiss { .. } => {
+            BannerEvent::Dismiss(DismissalType::Temporary) => {
                 self.control_master_error_banner_state.is_open = false;
+                ctx.notify();
+            }
+            BannerEvent::Dismiss(DismissalType::Permanent) => {
+                self.control_master_error_banner_state.is_open = false;
+                self.control_master_error_banner_suppressed = true;
+                let _ = ctx
+                    .private_user_preferences()
+                    .write_value(CONTROL_MASTER_BANNER_SUPPRESSED_KEY, "true".to_owned());
                 ctx.notify();
             }
             BannerEvent::Action(_) => {

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -4446,6 +4446,77 @@ fn test_banner_for_incompatible_plugins() {
     })
 }
 
+// Regression test for GH#3548 / GH#6093: the "Seems like your completions are not
+// working" banner must offer a permanent "Don't show me again" dismissal that is
+// persisted, while the "x" close button keeps its existing per-session behavior.
+#[test]
+fn test_control_master_banner_permanent_dismissal_persists() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal =
+            MockTerminalManager::create_new_terminal_view_window_for_test(&mut app, None);
+
+        terminal.update(&mut app, |view, ctx| {
+            // Temporary dismissal (the "x" button) clears the banner for this session
+            // but must not persist a "don't show again" preference.
+            view.control_master_error_banner_state.is_open = true;
+            view.handle_controlmaster_error_banner_event(
+                &BannerEvent::Dismiss(DismissalType::Temporary),
+                ctx,
+            );
+            assert!(!view.control_master_error_banner_state.is_open);
+            assert!(!view.control_master_error_banner_suppressed);
+            assert_eq!(
+                ctx.private_user_preferences()
+                    .read_value(CONTROL_MASTER_BANNER_SUPPRESSED_KEY)
+                    .unwrap(),
+                None,
+                "temporary dismissal should not persist a preference"
+            );
+
+            // Permanent dismissal ("Don't show me again") clears the banner and persists
+            // the choice so it never reopens.
+            view.control_master_error_banner_state.is_open = true;
+            view.handle_controlmaster_error_banner_event(
+                &BannerEvent::Dismiss(DismissalType::Permanent),
+                ctx,
+            );
+            assert!(!view.control_master_error_banner_state.is_open);
+            assert!(view.control_master_error_banner_suppressed);
+            assert_eq!(
+                ctx.private_user_preferences()
+                    .read_value(CONTROL_MASTER_BANNER_SUPPRESSED_KEY)
+                    .unwrap(),
+                Some("true".to_owned()),
+                "permanent dismissal should persist a preference"
+            );
+        });
+    })
+}
+
+// Regression test for GH#3548 / GH#6093: once the banner has been permanently
+// dismissed it must not reopen on subsequent sessions.
+#[test]
+fn test_control_master_banner_suppressed_does_not_reopen() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal =
+            MockTerminalManager::create_new_terminal_view_window_for_test(&mut app, None);
+
+        terminal.update(&mut app, |view, _ctx| {
+            // With no remote server and no prior dismissal, the banner may open.
+            view.control_master_error_banner_suppressed = false;
+            assert!(view.should_open_control_master_banner(/* has_remote_server */ false));
+            // A remote server makes the CTA irrelevant, so it stays closed.
+            assert!(!view.should_open_control_master_banner(/* has_remote_server */ true));
+
+            // Once permanently dismissed it must never reopen, even without a remote server.
+            view.control_master_error_banner_suppressed = true;
+            assert!(!view.should_open_control_master_banner(false));
+        });
+    })
+}
+
 #[test]
 fn test_bash_vim_banner_already_shown() {
     App::test((), |mut app| async move {


### PR DESCRIPTION
## Description

The SSH ControlMaster / "Seems like your completions are not working…" banner could previously only be closed with the **✕** button, which dismisses it for the current session only. It reappears on every new tab, session, and restart, so users with many tabs have to dismiss it over and over (#6093), and while shown it overlays the first line of content in full-screen apps such as `vim`/`less` (#3548). There was no way to stop it from coming back.

This switches the banner to `Banner::new_permanently_dismissible`, which renders a **"Don't show me again"** button next to the existing **✕**. The permanent choice is persisted in private user preferences (`ControlMasterBannerSuppressed`), mirroring the existing OSC 52 clipboard banner, and the banner no longer opens once it has been permanently dismissed. The **✕** keeps its existing per-session behavior.

Implementation (all in `app/src/terminal/view.rs`):
- Build the banner with `Banner::new_permanently_dismissible(...)`.
- Persist/read a new `ControlMasterBannerSuppressed` preference, and cache it on the view (`control_master_error_banner_suppressed`), exactly as the OSC 52 banner does.
- Gate opening behind a small `should_open_control_master_banner(...)` helper so a permanently dismissed banner never reopens.
- Handle `Dismiss(Permanent)` (persist + suppress) separately from `Dismiss(Temporary)` (session-only, unchanged).

## Linked Issue
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below. 

Fixes #3548
Fixes #6093

## Testing
- [x] I have manually tested my changes locally with `./script/run`

Built `WarpOss.app` via `./script/run` and verified end to end: the completions banner shows the new **"Don't show me again"** button; clicking it closes the banner and persists `ControlMasterBannerSuppressed`, and the banner does **not** return after relaunching. The **✕** still dismisses for the current session only.

Automated regression tests added in `app/src/terminal/view_tests.rs`:
- `test_control_master_banner_permanent_dismissal_persists` — permanent dismissal closes the banner, sets the suppressed flag, and persists the preference; temporary (**✕**) dismissal does neither.
- `test_control_master_banner_suppressed_does_not_reopen` — once suppressed, the banner does not reopen.

Both pass (`cargo test -p warp control_master_banner`). `./script/format --check` and `cargo clippy -p warp --all-targets -- -D warnings` are clean.

### Screenshots / Videos
Before (banner appears on every ssh):
<img width="1086" height="52" alt="before" src="https://github.com/user-attachments/assets/281101b6-1469-40b1-9fdc-65758d4a0454" />

After (`Don't show me again` button added which disables this banner forever):
<img width="843" height="68" alt="after" src="https://github.com/user-attachments/assets/4672e5bc-2ff2-4603-a0e0-3caa1dfa35cf" />

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Added a "Don't show me again" option to the SSH "completions are not working" banner so it can be permanently dismissed.
