### PR TITLE
fix(settings): wrap custom-endpoint model chips so the Edit button stays visible

### DIFF
--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -37,9 +37,9 @@ use warpify_page::{WarpifyPageAction, WarpifyPageView};
 use warpui::elements::{
     Align, Border, ChildAnchor, ChildView, Clipped, ClippedScrollStateHandle, ClippedScrollable,
     ConstrainedBox, Container, CornerRadius, CrossAxisAlignment, DispatchEventResult, Empty,
-    EventHandler, Expanded, Fill, Flex, MainAxisSize, OffsetPositioning, ParentAnchor,
-    ParentElement, ParentOffsetBounds, Radius, SavePosition, ScrollbarWidth, Shrinkable, Stack,
-    Text,
+    EventHandler, Expanded, Fill, Flex, MainAxisAlignment, MainAxisSize, OffsetPositioning,
+    ParentAnchor, ParentElement, ParentOffsetBounds, Radius, SavePosition, ScrollbarWidth,
+    Shrinkable, Stack, Text, Wrap,
 };
 use warpui::fonts::{Properties, Weight};
 use warpui::keymap::{ContextPredicate, EnabledPredicate, FixedBinding};
@@ -205,7 +205,17 @@ pub(super) fn render_model_chips(
         ..Default::default()
     };
 
-    let mut chips = Flex::row().with_spacing(8.);
+    // Wrap so a long list of chips flows onto additional rows instead of
+    // overflowing the parent row and pushing siblings (the per-endpoint
+    // "Edit" button) off-screen (#11996). `with_run_spacing` adds vertical
+    // gap between wrapped rows; `with_spacing` keeps the existing
+    // horizontal gap between chips. MainAxisSize::Min lets the wrap shrink
+    // to the available width rather than always claiming the full row.
+    let mut chips = Wrap::row()
+        .with_spacing(8.)
+        .with_run_spacing(8.)
+        .with_main_axis_alignment(MainAxisAlignment::Start)
+        .with_main_axis_size(MainAxisSize::Min);
     for label in labels {
         chips.add_child(Chip::new(label, chip_style).build().finish());
     }


### PR DESCRIPTION
Closes #11996

## Summary

When a Custom Inference endpoint has enough models that the chip list overflows the row width, the chips don't wrap — they extend horizontally and push the per-endpoint **Edit** button off-screen. The reporter's screenshot shows the chips clipped at the card's right edge with no Edit affordance visible.

Root cause: `render_model_chips` in [\`app/src/settings_view/mod.rs\`](app/src/settings_view/mod.rs) used \`Flex::row\` for the chip container. Flex doesn't wrap.

Fix: switch to \`Wrap::row\` so additional chips flow onto subsequent rows inside the same card slot instead of overflowing horizontally. The outer \`Flex::row\` (chip-column on the left, Edit button on the right, \`SpaceBetween\` alignment) then sees a column of bounded width, and the Edit button stays in its slot.

- \`with_spacing(8.)\` keeps the existing horizontal gap between chips
- \`with_run_spacing(8.)\` matches it vertically between wrapped rows
- \`MainAxisSize::Min\` keeps the wrap from claiming the full row width when only a few chips are present, preserving prior visual density for small endpoints

Touched file: [\`app/src/settings_view/mod.rs\`](app/src/settings_view/mod.rs) (+14/-4).

## Test plan

- [x] \`cargo check -p warp --bin warp-oss\` — clean
- [x] \`cargo fmt -p warp\`
- [ ] Manual repro per #11996: Settings → AI → Custom Inference Endpoints, add an endpoint with 8+ models, verify chips wrap onto multiple rows and the Edit button is clickable at all viewport widths

Happy to record a before/after if useful.