### PR TITLE
Promote CodexPlugin to stable

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -664,6 +664,7 @@ default = [
     "hoa_onboarding_flow",
     "hoa_remote_control",
     "codex_notifications",
+    "codex_plugin",
     "trim_trailing_blank_lines",
     "open_warp_new_settings_modes",
     "skip_firebase_anonymous_user",

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -940,7 +940,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::EditableMarkdownMermaid,
     FeatureFlag::CodeReviewScrollPreservation,
     FeatureFlag::RememberFastForwardState,
-    FeatureFlag::CodexPlugin,
     FeatureFlag::GeminiNotifications,
     FeatureFlag::LocalDockerSandbox,
     #[cfg(not(windows))]


### PR DESCRIPTION
Promotes the CodexPlugin feature flag from dogfood to stable so that the codex Warp plugin is available:
- For providing notifications to users using `codex` interactively
- For use in Oz cloud agents with codex multi-harness on stable

CHANGELOG-IMPROVEMENT: A richer notifications plugin for Codex is now supported.

Co-Authored-By: Oz <oz-agent@warp.dev>