### PR TITLE
Defer cmdlet loading in PowerShell bootstrap

### DIFF
--- a/app/assets/bundled/bootstrap/pwsh.ps1
+++ b/app/assets/bundled/bootstrap/pwsh.ps1
@@ -162,7 +162,7 @@ $null = New-Module -Name Warp-Module -ScriptBlock {
             Where-Object { -not $_.Name.StartsWith('Warp') } |
             Select-Object -ExpandProperty Name
         $functionNames = $functionNamesRaw -join [Environment]::NewLine
-        $builtinsRaw = Get-Command -CommandType Cmdlet | Select-Object -ExpandProperty Name
+        $builtinsRaw = Get-Command -CommandType Cmdlet -Module $corePsModules | Select-Object -ExpandProperty Name
         $builtins = $builtinsRaw -join [Environment]::NewLine
         $shellVersion = $PSVersionTable.PSVersion.ToString()
         # PowerShell wasn't cross-platform until version 6. Anything before that is definitely on Windows.

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -1571,8 +1571,8 @@ impl Session {
     }
 
     #[cfg(feature = "integration_tests")]
-    pub fn external_commands(&self) -> Arc<OnceCell<HashSet<SmolStr>>> {
-        self.external_commands.clone()
+    pub fn external_commands(&self) -> &OnceCell<HashSet<SmolStr>> {
+        &self.external_commands
     }
 
     /// Returns a reference to the session's command executor for integration

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -900,14 +900,17 @@ impl From<BootstrapSessionType> for SessionType {
 #[derive(Debug)]
 pub struct Session {
     info: SessionInfo,
-    external_commands: Arc<OnceCell<HashSet<SmolStr>>>,
+    external_commands: OnceCell<HashSet<SmolStr>>,
     /// Function names collected asynchronously after bootstrap via an in-band command.
-    additional_function_names: Arc<OnceCell<HashSet<SmolStr>>>,
+    additional_function_names: OnceCell<HashSet<SmolStr>>,
+    /// builtin/cmdlet names collected asynchronously after bootstrap via an in-band command.
+    additional_builtin_names: OnceCell<HashSet<SmolStr>>,
     /// The command executor for this session. Behind a `RwLock` so it can be
     /// swapped after a remote server reconnect (via `set_command_executor`).
     command_executor: RwLock<Arc<dyn CommandExecutor>>,
     load_external_commands_future: OnceCell<Shared<BoxFuture<'static, ()>>>,
     load_all_function_names_future: OnceCell<Shared<BoxFuture<'static, ()>>>,
+    load_all_builtins_future: OnceCell<Shared<BoxFuture<'static, ()>>>,
     command_case_sensitivity: TopLevelCommandCaseSensitivity,
     /// The authoritative session type, initially derived from the
     /// [`BootstrapSessionType`] in `SessionInfo` and updated by [`Sessions`]
@@ -931,11 +934,13 @@ impl Session {
         let session_type = SessionType::from(session_info.session_type.clone());
         Self {
             info: session_info,
-            external_commands: Arc::new(OnceCell::new()),
-            additional_function_names: Arc::new(OnceCell::new()),
+            external_commands: OnceCell::new(),
+            additional_function_names: OnceCell::new(),
+            additional_builtin_names: OnceCell::new(),
             command_executor: RwLock::new(command_executor),
             load_external_commands_future: Default::default(),
             load_all_function_names_future: Default::default(),
+            load_all_builtins_future: Default::default(),
             command_case_sensitivity,
             session_type: Mutex::new(session_type),
         }
@@ -1050,7 +1055,11 @@ impl Session {
     }
 
     pub fn builtin_names(&self) -> impl Iterator<Item = &str> {
-        self.info.builtins.iter().map(Deref::deref)
+        self.info
+            .builtins
+            .iter()
+            .chain(self.additional_builtin_names.get().into_iter().flatten())
+            .map(Deref::deref)
     }
 
     pub fn function_names(&self) -> impl Iterator<Item = &str> {
@@ -1134,11 +1143,46 @@ impl Session {
         else {
             return;
         };
+        self.load_deferred_name_set(
+            command,
+            &self.info.function_names,
+            &self.additional_function_names,
+            &self.load_all_function_names_future,
+            "function",
+        )
+        .await;
+    }
 
+    /// Asynchronously collects all builtin (cmdlet) names via an in-band shell command.
+    pub async fn load_all_builtins(&self) {
+        let Some(command) = self
+            .info
+            .shell
+            .shell_type()
+            .shell_command_to_get_all_builtins()
+        else {
+            return;
+        };
+        self.load_deferred_name_set(
+            command,
+            &self.info.builtins,
+            &self.additional_builtin_names,
+            &self.load_all_builtins_future,
+            "builtin",
+        )
+        .await;
+    }
+
+    /// Shared helper for [`Self::load_all_function_names`] and [`Self::load_all_builtins`].
+    async fn load_deferred_name_set(
+        &self,
+        command: &'static str,
+        existing: &HashSet<SmolStr>,
+        storage: &OnceCell<HashSet<SmolStr>>,
+        future_cell: &OnceCell<Shared<BoxFuture<'static, ()>>>,
+        label: &'static str,
+    ) {
         let (load_future, receiver) = (async {
-            let additional_function_names = self.additional_function_names.clone();
-            let existing = &self.info.function_names;
-
             let result = self
                 .execute_command(command, None, None, ExecuteCommandOptions::default())
                 .await;
@@ -1152,33 +1196,28 @@ impl Session {
                             .map(Into::into)
                             .collect(),
                         Err(e) => {
-                            log::warn!("Failed to decode all function names output: {e:#}");
+                            log::warn!("Failed to decode {label} names output: {e:#}");
                             HashSet::new()
                         }
                     }
                 }
                 Ok(_) => {
-                    log::warn!(
-                        "In-band command for all function names returned non-success status"
-                    );
+                    log::warn!("In-band command for {label} names returned non-success status");
                     HashSet::new()
                 }
                 Err(e) => {
-                    log::warn!("Failed to load all function names: {e:#}");
+                    log::warn!("Failed to load {label} names: {e:#}");
                     HashSet::new()
                 }
             };
 
-            if additional_function_names.set(new_names).is_err() {
-                log::warn!("Additional function names were already set for this session.");
+            if storage.set(new_names).is_err() {
+                log::warn!("Additional {label} names were already set for this session.");
             }
         })
         .remote_handle();
 
-        match self
-            .load_all_function_names_future
-            .try_insert(receiver.boxed().shared())
-        {
+        match future_cell.try_insert(receiver.boxed().shared()) {
             Ok(_) => load_future.await,
             Err((existing_receiver, _)) => existing_receiver.clone().await,
         };
@@ -1198,7 +1237,6 @@ impl Session {
     pub async fn load_external_commands(&self) {
         let (load_future, receiver) = (async {
             let shell = self.info.shell.clone();
-            let external_commands = self.external_commands.clone();
             let shell_command_to_get_executables =
                 shell.shell_type().shell_command_to_get_executables();
             let env_vars = self
@@ -1256,7 +1294,7 @@ impl Session {
                     .executables_from_shell_command_output(result, is_msys2)
                     .into_iter(),
             );
-            if external_commands.set(new_commands).is_err() {
+            if self.external_commands.set(new_commands).is_err() {
                 log::warn!("External commands should only be loaded once per session.");
             }
         })
@@ -1283,6 +1321,7 @@ impl Session {
             .chain(self.info.aliases.keys())
             .chain(self.info.abbreviations.keys())
             .chain(&self.info.builtins)
+            .chain(self.additional_builtin_names.get().into_iter().flatten())
             .chain(&self.info.keywords)
             .map(Deref::deref)
     }
@@ -1833,6 +1872,8 @@ pub mod testing {
                 session_type: Mutex::new(session_type),
                 additional_function_names: Default::default(),
                 load_all_function_names_future: Default::default(),
+                additional_builtin_names: Default::default(),
+                load_all_builtins_future: Default::default(),
             }
         }
 
@@ -1850,6 +1891,8 @@ pub mod testing {
                 session_type: Mutex::new(session_type),
                 additional_function_names: Default::default(),
                 load_all_function_names_future: Default::default(),
+                additional_builtin_names: Default::default(),
+                load_all_builtins_future: Default::default(),
             }
         }
 

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -13449,6 +13449,7 @@ impl TerminalView {
         // underlines to valid commands.
         let input = self.input().clone();
         let session_clone = session.clone();
+        let session_clone2 = session.clone();
         ctx.spawn(
             async move { session.load_external_commands().await },
             move |me, _, ctx| {
@@ -13464,6 +13465,10 @@ impl TerminalView {
 
         ctx.background_executor()
             .spawn(async move { session_clone.load_all_function_names().await })
+            .detach();
+
+        ctx.background_executor()
+            .spawn(async move { session_clone2.load_all_builtins().await })
             .detach();
 
         // If we were waiting for a successful warpification, it's come. Stop the timeout.

--- a/crates/warp_terminal/src/shell/mod.rs
+++ b/crates/warp_terminal/src/shell/mod.rs
@@ -753,6 +753,18 @@ impl ShellType {
         }
     }
 
+    pub fn shell_command_to_get_all_builtins(&self) -> Option<&'static str> {
+        match self {
+            ShellType::PowerShell => Some(
+                "$names = Get-Command -CommandType Cmdlet | Select-Object -ExpandProperty Name; \
+                $text = [string]::Join([Environment]::NewLine, $names); \
+                $bytes = [System.Text.UTF8Encoding]::new($false).GetBytes($text); \
+                [Console]::OpenStandardOutput().Write($bytes, 0, $bytes.Length)",
+            ),
+            _ => None,
+        }
+    }
+
     pub fn force_in_band_command_executor(&self) -> bool {
         // TODO: Remove this function once we have confidence in using a local executor in
         // powershell.


### PR DESCRIPTION
## Linked Issue

Closes #12801

## Description

This fix is a continuation of #12764.

PowerShell bootstrap is slow if the [PowerShell AWS Tools](https://docs.aws.amazon.com/powershell/v5/userguide/ps-installing-awstools.html) are installed. On my machine, it includes almost 10k cmdlets and they take a couple seconds to fully enumerate.

This PR brings the PowerShell bootstrap time on my machine down from 3 sec to about 0.8 sec. The fix is essentially the same. Loading only a "core" set of cmdlets synchronously blocking the bootstrap event and loading the rest using an in-band command later.

## Testing

Tested using `cargo r --features log_named_telemetry_events` and then looking at the "warp attributed bootstrap time" in the "Bootstrapping Succeeded" event.


<!--
## Changelog Entries for Stable

CHANGELOG-IMPROVEMENT: Speed up PowerShell startup when a lot of cmdlets are installed via plugins.
-->
