### PR TITLE
Apply allowed_tools filtering for MCP servers in agent context

### DIFF
--- a/app/src/ai/agent/api.rs
+++ b/app/src/ai/agent/api.rs
@@ -233,12 +233,25 @@ impl RequestParams {
 
             let servers: Vec<MCPServer> = active_servers
                 .into_iter()
-                .map(|server| MCPServer {
-                    name: server.name().to_string(),
-                    description: server.description().unwrap_or_default().to_string(),
-                    id: server.installation_id().to_string(),
-                    resources: server.resources().to_vec(),
-                    tools: server.tools().to_vec(),
+                .map(|server| {
+                    let installation_id = server.installation_id();
+                    let allowed = templatable_manager
+                        .get_installed_server(&installation_id)
+                        .and_then(|inst| {
+                            crate::ai::mcp::templatable_manager::extract_allowed_tools_from_json(
+                                inst.template_json(),
+                            )
+                        });
+                    MCPServer {
+                        name: server.name().to_string(),
+                        description: server.description().unwrap_or_default().to_string(),
+                        id: installation_id.to_string(),
+                        resources: server.resources().to_vec(),
+                        tools: crate::ai::mcp::templatable_manager::filter_tools(
+                            server.tools(),
+                            allowed.as_ref(),
+                        ),
+                    }
                 })
                 .collect();
 
@@ -259,7 +272,7 @@ impl RequestParams {
                 .resources()
                 .cloned()
                 .collect::<Vec<_>>();
-            let tools = templatable_mcp_manager.tools().cloned().collect::<Vec<_>>();
+            let tools = templatable_mcp_manager.tools_with_allowed_filter();
 
             #[allow(deprecated)]
             (!resources.is_empty() || !tools.is_empty()).then_some(MCPContext {

--- a/app/src/ai/agent_sdk/mcp_config.rs
+++ b/app/src/ai/agent_sdk/mcp_config.rs
@@ -182,6 +182,7 @@ fn validate_server_config(server_name: &str, config: &Value) -> anyhow::Result<(
 
     validate_string_map_field(obj, server_name, "env")?;
     validate_string_map_field(obj, server_name, "headers")?;
+    validate_string_array_field(obj, server_name, "allowed_tools")?;
 
     Ok(())
 }
@@ -202,6 +203,28 @@ fn validate_string_map_field(
     for (key, value) in map {
         if !value.is_string() {
             anyhow::bail!("MCP server '{server_name}' field '{field}.{key}' must be a string");
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_string_array_field(
+    obj: &Map<String, Value>,
+    server_name: &str,
+    field: &str,
+) -> anyhow::Result<()> {
+    let Some(value) = obj.get(field) else {
+        return Ok(());
+    };
+
+    let arr = value.as_array().ok_or_else(|| {
+        anyhow::anyhow!("MCP server '{server_name}' field '{field}' must be an array")
+    })?;
+
+    for (idx, item) in arr.iter().enumerate() {
+        if !item.is_string() {
+            anyhow::bail!("MCP server '{server_name}' field '{field}[{idx}]' must be a string");
         }
     }
 

--- a/app/src/ai/mcp/templatable_manager.rs
+++ b/app/src/ai/mcp/templatable_manager.rs
@@ -7,6 +7,44 @@ use std::collections::{HashMap, HashSet};
 #[cfg(not(target_family = "wasm"))]
 use std::sync::Arc;
 
+/// Extracts the `allowed_tools` list from a server's template JSON.
+///
+/// Template JSON is always wrapped as `{"<server-name>": { ... }}`. Returns
+/// `Some` with the set of allowed tool names when the field is present and
+/// non-empty, or `None` when the field is absent (meaning all tools are
+/// allowed).
+pub fn extract_allowed_tools_from_json(template_json: &str) -> Option<HashSet<String>> {
+    let json: serde_json::Value = serde_json::from_str(template_json).ok()?;
+    let server_config = json.as_object()?.values().next()?;
+    let allowed = server_config.get("allowed_tools")?.as_array()?;
+    if allowed.is_empty() {
+        return None;
+    }
+    Some(
+        allowed
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_owned()))
+            .collect(),
+    )
+}
+
+/// Returns a filtered copy of `tools`, keeping only those whose names appear
+/// in `allowed`. When `allowed` is `None`, all tools are returned unchanged.
+pub fn filter_tools(
+    tools: &[rmcp::model::Tool],
+    allowed: Option<&HashSet<String>>,
+) -> Vec<rmcp::model::Tool> {
+    match allowed {
+        Some(set) => tools
+            .iter()
+            // `t.name` is `Cow<str>`; deref-coerce to `&str` for the lookup.
+            .filter(|t| set.contains(&*t.name))
+            .cloned()
+            .collect(),
+        None => tools.to_vec(),
+    }
+}
+
 #[cfg(not(target_family = "wasm"))]
 use diesel::SqliteConnection;
 use futures_util::stream::AbortHandle;
@@ -179,10 +217,23 @@ impl TemplatableMCPServerManager {
             .flat_map(|server| server.resources().iter())
     }
 
-    pub fn tools(&self) -> impl Iterator<Item = &rmcp::model::Tool> {
+    /// Returns tools from all active servers, applying each server's
+    /// `allowed_tools` filter when configured.
+    ///
+    /// When a server's installation specifies `allowed_tools`, only tools
+    /// whose names appear in that list are included. When `allowed_tools` is
+    /// absent or empty, all tools from that server are included.
+    pub fn tools_with_allowed_filter(&self) -> Vec<rmcp::model::Tool> {
         self.active_servers
-            .values()
-            .flat_map(|server| server.tools().iter())
+            .iter()
+            .flat_map(|(uuid, server)| {
+                let allowed = self
+                    .locally_installed_servers
+                    .get(uuid)
+                    .and_then(|inst| extract_allowed_tools_from_json(inst.template_json()));
+                filter_tools(server.tools(), allowed.as_ref())
+            })
+            .collect()
     }
 
     /// Returns a reconnecting peer for a server that has the given resource.


### PR DESCRIPTION
## Description

Implements client-side `allowed_tools` filtering for MCP servers in agent context builds. When an MCP server config specifies `allowed_tools`, only the listed tool names are presented to the agent. This pairs with the warp-server change that adds `allowed_tools` to `MCPServerConfig`.

**Changes:**
- `app/src/ai/agent_sdk/mcp_config.rs`: Add validation for `allowed_tools` field (array of strings) in MCP server config validation
- `app/src/ai/mcp/templatable_manager.rs`: Add `extract_allowed_tools_from_json` and `filter_tools` helpers; add `tools_with_allowed_filter()` method
- `app/src/ai/agent/api.rs`: Apply `allowed_tools` filtering when building `MCPContext` for agent requests (both grouped server and flat list paths)

**How it works:**
- `allowed_tools` is an optional array in the MCP server config JSON (passed via `--mcp` CLI flag)
- When absent: all tools from the server are available (unchanged behavior)  
- When present and non-empty: only the listed tool names are included in the agent's MCP context
- Filtering happens at request time, when building the `MCPContext` sent to the server

**Limitation:** This filtering applies to `command` and `url` transport MCP servers. For `warp_id`-based (Warp-managed) servers, the `allowed_tools` from the config is not yet applied since they are resolved differently.

## Linked Issue

Addresses Linear REMOTE-2009

## Testing

- `cargo check` passes with no errors or warnings on the library target
- `cargo clippy --lib -- -D warnings` passes

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

_Conversation: https://staging.warp.dev/conversation/bcbef8dd-e033-4f9e-9baf-8673c86e5e9b_
_Run: https://oz.staging.warp.dev/runs/019ef9bc-0748-77e4-acae-b429aefc9dcc_
_This PR was generated with [Oz](https://warp.dev/oz)._
