### PR TITLE
Refresh the first agent-onboarding card (heading, description, checklist)

### DIFF
--- a/crates/onboarding/src/lib.rs
+++ b/crates/onboarding/src/lib.rs
@@ -28,13 +28,12 @@ pub use callout::{OnboardingCalloutView, OnboardingKeybindings};
 /// Shared by the intention slide's agent card checklist and the login slide's
 /// skip-login confirmation dialog so the two always stay in sync.
 pub const AI_FEATURES: &[&str] = &[
-    "Warp Agent, a state-of-the-art harness",
-    "Oz, a cloud agent orchestration platform",
-    "Prompt suggestions for quick fixes to errors",
-    "AI-powered predictions for shell commands",
-    "Agentic control of any long-running commands or TUIs",
-    "Smarter codebase context",
-    "Remote control with Claude Code, Codex, and other agents",
+    "Use frontier and open-weight models with Warp Agent",
+    "Hand off agent work to cloud agents",
+    "Automatically diagnose and fix terminal errors",
+    "Agentic control of long-running commands and TUIs",
+    "Review code diffs and send comments directly to agents",
+    "Remote control for Claude Code, Codex, and other agents",
 ];
 
 /// User-facing names of the Warp Drive features enabled when the terminal

--- a/crates/onboarding/src/lib.rs
+++ b/crates/onboarding/src/lib.rs
@@ -24,17 +24,17 @@ impl std::fmt::Display for OnboardingIntention {
 
 pub use callout::{OnboardingCalloutView, OnboardingKeybindings};
 
-/// User-facing names of the AI features enabled when the agent intention is selected.
+/// User-facing descriptions of the AI features enabled when the agent intention is selected.
 /// Shared by the intention slide's agent card checklist and the login slide's
 /// skip-login confirmation dialog so the two always stay in sync.
 pub const AI_FEATURES: &[&str] = &[
-    "Warp agents",
-    "Oz Cloud Agents Platform",
-    "Prompt suggestions",
-    "Next command predictions",
-    "Full Terminal Use",
-    "Codebase Context",
-    "Remote Control with Claude Code, Codex, and other agents",
+    "Warp Agent, a state-of-the-art harness",
+    "Oz, a cloud agent orchestration platform",
+    "Prompt suggestions for quick fixes to errors",
+    "AI-powered predictions for shell commands",
+    "Agentic control of any long-running commands or TUIs",
+    "Smarter codebase context",
+    "Remote control with Claude Code, Codex, and other agents",
 ];
 
 /// User-facing names of the Warp Drive features enabled when the terminal

--- a/crates/onboarding/src/slides/intention_slide.rs
+++ b/crates/onboarding/src/slides/intention_slide.rs
@@ -202,7 +202,7 @@ impl IntentionSlide {
         let header_row = {
             let label = appearance
                 .ui_builder()
-                .paragraph("Build faster with AI agents")
+                .paragraph("Build faster with agents")
                 .with_style(UiComponentStyles {
                     font_size: Some(16.),
                     font_weight: Some(Weight::Semibold),
@@ -240,7 +240,7 @@ impl IntentionSlide {
         };
 
         let description = FormattedTextElement::from_str(
-            "An agent-first experience with best in class terminal support. Get terminal and agent driven development AI features like:",
+            "Get AI features to accelerate terminal and agent-driven workflows:",
             appearance.ui_font_family(),
             14.,
         )


### PR DESCRIPTION
## Description
Applies the copywriter's pass to the first onboarding card — the "Build faster with agents" agent card on the intention slide (gated by the existing `OpenWarpNewSettingsModes` feature). Three pieces of copy change:

- **Heading:** "Build faster with AI agents" → **"Build faster with agents"**.
- **Description:** now **"Get AI features to accelerate terminal and agent-driven workflows:"**.
- **Feature checklist:** the shared `AI_FEATURES` constant (`crates/onboarding/src/lib.rs`) is replaced with the copywriter's six items:
  1. Use frontier and open-weight models with Warp Agent
  2. Hand off agent work to cloud agents
  3. Automatically diagnose and fix terminal errors
  4. Agentic control of long-running commands and TUIs
  5. Review code diffs and send comments directly to agents
  6. Remote control for Claude Code, Codex, and other agents

The heading and description live in `crates/onboarding/src/slides/intention_slide.rs`; the checklist lives in `crates/onboarding/src/lib.rs`. `AI_FEATURES` is shared with the login skip dialog on this branch, but sibling PRs remove that usage, leaving the card as the sole consumer once integrated.

This is **PR-A** of a coordinated set of onboarding changes (A–D).

This PR was generated by Oz. Conversation: https://staging.warp.dev/conversation/4dc41e19-636b-4a7b-b720-c6942538c28e — Run: https://oz.staging.warp.dev/runs/019efa09-395f-7ceb-99c9-8332a8437ea5

## Linked Issue
N/A — part of the onboarding refresh tracked by the orchestrating effort.

## Testing
- `./script/format` — clean
- `cargo clippy -p onboarding --all-targets --all-features --tests -- -D warnings` — no warnings
- `cargo nextest run -p onboarding` — passed

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Text-only copy change; the full onboarding flow is best verified after PR-A–D are integrated.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: Refreshed the first agent-onboarding card ("Build faster with agents") with an updated heading, description, and feature checklist.
-->
