### PR TITLE
Onboarding: remove post-agent no-AI buttons, inline dots, simplify no-AI modal

### DIFF
--- a/crates/onboarding/src/agent_onboarding_view.rs
+++ b/crates/onboarding/src/agent_onboarding_view.rs
@@ -446,8 +446,8 @@ impl AgentOnboardingView {
             appearance,
             FeatureOptOutDialog {
                 title: "Are you sure you don't want AI?",
-                body: "Warp is better with AI. By continuing without it, you'll miss out on the \
-                       best of what Warp has to offer.",
+                body: "Without AI, you'll still get Warp's terminal experience, but you'll miss \
+                       our agentic features like automatic fixes for terminal errors.",
                 features: &[],
                 close_button,
                 cancel_button,

--- a/crates/onboarding/src/agent_onboarding_view.rs
+++ b/crates/onboarding/src/agent_onboarding_view.rs
@@ -20,7 +20,6 @@ use crate::slides::{
     ThemePickerSlide, ThemePickerSlideEvent, ThirdPartySlide,
 };
 use crate::telemetry::OnboardingEvent;
-use crate::AI_FEATURES;
 
 const APP_BECAME_ACTIVE_DEBOUNCE: Duration = Duration::from_secs(15);
 
@@ -447,9 +446,9 @@ impl AgentOnboardingView {
             appearance,
             FeatureOptOutDialog {
                 title: "Are you sure you don't want AI?",
-                body: "Warp is better with AI. By continuing, you won't have access to any of the \
-                       following features:",
-                features: AI_FEATURES,
+                body: "Warp is better with AI. By continuing without it, you'll miss out on the \
+                       best of what Warp has to offer.",
+                features: &[],
                 close_button,
                 cancel_button,
                 confirm_button,

--- a/crates/onboarding/src/components/feature_optout_dialog.rs
+++ b/crates/onboarding/src/components/feature_optout_dialog.rs
@@ -50,42 +50,48 @@ pub fn render_feature_optout_dialog(
         .with_line_height_ratio(1.2)
         .finish();
 
-    let feature_row_color: ColorU = theme.foreground().into();
-    let feature_x_fill = Fill::Solid(theme.ansi_fg_red());
-    let mut feature_list = Flex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
-    for &item in dialog.features {
-        let icon_el = ConstrainedBox::new(Icon::X.to_warpui_icon(feature_x_fill).finish())
-            .with_width(16.)
-            .with_height(16.)
-            .finish();
-        let text_el = FormattedTextElement::from_str(item, appearance.ui_font_family(), 14.)
-            .with_color(feature_row_color)
-            .with_weight(Weight::Normal)
-            .with_alignment(TextAlignment::Left)
-            .with_line_height_ratio(1.0)
-            .finish();
-        let row = Flex::row()
-            .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_child(icon_el)
-            .with_child(Container::new(text_el).with_margin_left(4.).finish())
-            .finish();
-        feature_list = feature_list.with_child(
-            Container::new(row)
-                .with_padding_top(4.)
-                .with_padding_bottom(4.)
+    let mut body_section = Flex::column()
+        .with_cross_axis_alignment(CrossAxisAlignment::Start)
+        .with_child(body_text);
+
+    // The list is optional: callers that only want a warning (e.g. the no-AI
+    // onboarding modal) pass an empty slice, in which case we skip it entirely.
+    if !dialog.features.is_empty() {
+        let feature_row_color: ColorU = theme.foreground().into();
+        let feature_x_fill = Fill::Solid(theme.ansi_fg_red());
+        let mut feature_list =
+            Flex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+        for &item in dialog.features {
+            let icon_el = ConstrainedBox::new(Icon::X.to_warpui_icon(feature_x_fill).finish())
+                .with_width(16.)
+                .with_height(16.)
+                .finish();
+            let text_el = FormattedTextElement::from_str(item, appearance.ui_font_family(), 14.)
+                .with_color(feature_row_color)
+                .with_weight(Weight::Normal)
+                .with_alignment(TextAlignment::Left)
+                .with_line_height_ratio(1.0)
+                .finish();
+            let row = Flex::row()
+                .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                .with_child(icon_el)
+                .with_child(Container::new(text_el).with_margin_left(4.).finish())
+                .finish();
+            feature_list = feature_list.with_child(
+                Container::new(row)
+                    .with_padding_top(4.)
+                    .with_padding_bottom(4.)
+                    .finish(),
+            );
+        }
+        body_section = body_section.with_child(
+            Container::new(feature_list.finish())
+                .with_margin_top(12.)
                 .finish(),
         );
     }
 
-    let body_section = Flex::column()
-        .with_cross_axis_alignment(CrossAxisAlignment::Start)
-        .with_child(body_text)
-        .with_child(
-            Container::new(feature_list.finish())
-                .with_margin_top(12.)
-                .finish(),
-        )
-        .finish();
+    let body_section = body_section.finish();
 
     let footer = Container::new(
         Flex::row()

--- a/crates/onboarding/src/model.rs
+++ b/crates/onboarding/src/model.rs
@@ -164,10 +164,6 @@ impl std::fmt::Display for AiAccessChoice {
 pub(crate) enum NoAiConfirmationSource {
     /// Triggered from the intention slide via "Just use the terminal" + Next.
     Intention,
-    /// Triggered from the AI-setup slide via "I don't want AI".
-    AiSetup,
-    /// Triggered from the "Customize your Warp Agent" slide via "I don't want AI".
-    Agent,
     /// Triggered from the "Choose how to access AI" slide via "I don't want AI".
     AiAccess,
 }
@@ -389,7 +385,7 @@ impl OnboardingStateModel {
     }
 
     /// "Give me AI features": abort the opt-out. From the intention slide this is
-    /// an explicit request for AI, so route onto the AI path; from the AI-setup
+    /// an explicit request for AI, so route onto the AI path; from the AI-access
     /// slide the user is already on the AI path, so just close the modal.
     pub(crate) fn cancel_no_ai(&mut self, ctx: &mut ModelContext<Self>) {
         send_telemetry_from_ctx!(OnboardingEvent::NoAiConfirmationCancelled, ctx);
@@ -398,10 +394,7 @@ impl OnboardingStateModel {
                 self.set_intention(OnboardingIntention::AgentDrivenDevelopment, ctx);
                 self.set_step(OnboardingStep::AiSetup, ctx);
             }
-            Some(NoAiConfirmationSource::AiSetup)
-            | Some(NoAiConfirmationSource::Agent)
-            | Some(NoAiConfirmationSource::AiAccess)
-            | None => {
+            Some(NoAiConfirmationSource::AiAccess) | None => {
                 ctx.emit(OnboardingStateEvent::NoAiConfirmationChanged);
                 ctx.notify();
             }

--- a/crates/onboarding/src/model_tests.rs
+++ b/crates/onboarding/src/model_tests.rs
@@ -95,16 +95,16 @@ fn confirm_no_ai_switches_to_terminal_path() {
 
         model.update(&mut app, |model, ctx| {
             model.next(ctx); // Intro → Intention
-            model.next(ctx); // Intention → AiSetup
-            model.request_no_ai_confirmation(NoAiConfirmationSource::AiSetup, ctx);
+            model.set_intention_terminal(ctx);
+            model.request_no_ai_confirmation(NoAiConfirmationSource::Intention, ctx);
         });
 
-        // The confirmation modal is shown without leaving the AI-setup slide yet.
-        assert_eq!(step(&app, &model), OnboardingStep::AiSetup);
+        // The confirmation modal is shown without leaving the intention slide yet.
+        assert_eq!(step(&app, &model), OnboardingStep::Intention);
         model.read(&app, |model, _| {
             assert_eq!(
                 model.no_ai_confirmation(),
-                Some(NoAiConfirmationSource::AiSetup)
+                Some(NoAiConfirmationSource::Intention)
             );
         });
 
@@ -173,31 +173,6 @@ fn cancel_no_ai_from_intention_routes_to_ai_setup() {
 }
 
 #[test]
-fn cancel_no_ai_from_ai_setup_stays_on_slide() {
-    let _flag = FeatureFlag::OpenWarpNewSettingsModes.override_enabled(true);
-    App::test((), |mut app| async move {
-        let model = add_test_model(&mut app);
-
-        model.update(&mut app, |model, ctx| {
-            model.next(ctx); // Intro → Intention
-            model.next(ctx); // Intention → AiSetup
-            model.request_no_ai_confirmation(NoAiConfirmationSource::AiSetup, ctx);
-            model.cancel_no_ai(ctx);
-        });
-
-        // Already on the AI path, so cancelling just closes the modal in place.
-        assert_eq!(step(&app, &model), OnboardingStep::AiSetup);
-        model.read(&app, |model, _| {
-            assert_eq!(model.no_ai_confirmation(), None);
-            assert_eq!(
-                *model.intention(),
-                OnboardingIntention::AgentDrivenDevelopment
-            );
-        });
-    });
-}
-
-#[test]
 fn dismiss_no_ai_closes_without_changing_path() {
     let _flag = FeatureFlag::OpenWarpNewSettingsModes.override_enabled(true);
     App::test((), |mut app| async move {
@@ -205,18 +180,15 @@ fn dismiss_no_ai_closes_without_changing_path() {
 
         model.update(&mut app, |model, ctx| {
             model.next(ctx); // Intro → Intention
-            model.next(ctx); // Intention → AiSetup
-            model.request_no_ai_confirmation(NoAiConfirmationSource::AiSetup, ctx);
+            model.set_intention_terminal(ctx);
+            model.request_no_ai_confirmation(NoAiConfirmationSource::Intention, ctx);
             model.dismiss_no_ai(ctx);
         });
 
-        assert_eq!(step(&app, &model), OnboardingStep::AiSetup);
+        assert_eq!(step(&app, &model), OnboardingStep::Intention);
         model.read(&app, |model, _| {
             assert_eq!(model.no_ai_confirmation(), None);
-            assert_eq!(
-                *model.intention(),
-                OnboardingIntention::AgentDrivenDevelopment
-            );
+            assert_eq!(*model.intention(), OnboardingIntention::Terminal);
         });
     });
 }

--- a/crates/onboarding/src/slides/agent_slide.rs
+++ b/crates/onboarding/src/slides/agent_slide.rs
@@ -25,7 +25,7 @@ use warpui_core::{
 
 use super::two_line_button::{render_two_line_button, TwoLineButtonSpec};
 use super::OnboardingSlide;
-use crate::model::{NoAiConfirmationSource, OnboardingStateEvent, OnboardingStateModel};
+use crate::model::{OnboardingStateEvent, OnboardingStateModel};
 use crate::slides::{bottom_nav, layout, slide_content};
 use crate::visuals::agent_visual;
 
@@ -96,7 +96,6 @@ pub enum AgentSlideAction {
     SelectAutonomy(AgentAutonomy),
     ToggleDisableOz,
     BackClicked,
-    NoAiClicked,
     NextClicked,
 }
 
@@ -114,7 +113,6 @@ pub struct AgentSlide {
     autonomy_none_mouse_state: MouseStateHandle,
 
     back_button: button::Button,
-    no_ai_button: button::Button,
     next_button: button::Button,
     scroll_state: ClippedScrollStateHandle,
     dropdown_scroll_state: ClippedScrollStateHandle,
@@ -171,7 +169,6 @@ impl AgentSlide {
             autonomy_partial_mouse_state: MouseStateHandle::default(),
             autonomy_none_mouse_state: MouseStateHandle::default(),
             back_button: button::Button::default(),
-            no_ai_button: button::Button::default(),
             next_button: button::Button::default(),
             scroll_state: ClippedScrollStateHandle::new(),
             dropdown_scroll_state: ClippedScrollStateHandle::new(),
@@ -812,22 +809,6 @@ impl AgentSlide {
             },
         );
 
-        let no_ai_keystroke = Keystroke::parse("cmdorctrl-enter").unwrap_or_default();
-        let no_ai_button = self.no_ai_button.render(
-            appearance,
-            button::Params {
-                content: button::Content::Label("I don't want AI".into()),
-                theme: &button::themes::Naked,
-                options: button::Options {
-                    keystroke: Some(no_ai_keystroke),
-                    on_click: Some(Box::new(|ctx, _app, _pos| {
-                        ctx.dispatch_typed_action(AgentSlideAction::NoAiClicked);
-                    })),
-                    ..button::Options::default(appearance)
-                },
-            },
-        );
-
         let enter = Keystroke::parse("enter").unwrap_or_default();
         let next_button = self.next_button.render(
             appearance,
@@ -844,20 +825,13 @@ impl AgentSlide {
             },
         );
 
-        let right_buttons = Flex::row()
-            .with_main_axis_size(MainAxisSize::Min)
-            .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_child(no_ai_button)
-            .with_child(Container::new(next_button).with_margin_left(8.).finish())
-            .finish();
-
         let (step_index, step_count) = self.onboarding_state.as_ref(app).progress();
         bottom_nav::onboarding_bottom_nav(
             appearance,
             step_index,
             step_count,
             Some(back_button),
-            Some(right_buttons),
+            Some(next_button),
         )
     }
 
@@ -1066,12 +1040,6 @@ impl OnboardingSlide for AgentSlide {
             self.set_model_list_expanded(false, ctx);
         }
     }
-
-    fn on_cmd_or_ctrl_enter(&mut self, ctx: &mut ViewContext<Self>) {
-        self.onboarding_state.update(ctx, |model, ctx| {
-            model.request_no_ai_confirmation(NoAiConfirmationSource::Agent, ctx);
-        });
-    }
 }
 
 impl TypedActionView for AgentSlide {
@@ -1119,11 +1087,6 @@ impl TypedActionView for AgentSlide {
             AgentSlideAction::BackClicked => {
                 self.onboarding_state.update(ctx, |state, ctx| {
                     state.back(ctx);
-                });
-            }
-            AgentSlideAction::NoAiClicked => {
-                self.onboarding_state.update(ctx, |model, ctx| {
-                    model.request_no_ai_confirmation(NoAiConfirmationSource::Agent, ctx);
                 });
             }
             AgentSlideAction::NextClicked => {

--- a/crates/onboarding/src/slides/ai_setup_slide.rs
+++ b/crates/onboarding/src/slides/ai_setup_slide.rs
@@ -20,7 +20,7 @@ use warpui_core::{
 };
 
 use super::OnboardingSlide;
-use crate::model::{AiSetupChoice, NoAiConfirmationSource, OnboardingStateModel};
+use crate::model::{AiSetupChoice, OnboardingStateModel};
 use crate::slides::{bottom_nav, layout, slide_content};
 
 /// Checklist shown on the "Use Warp agent" card.
@@ -37,20 +37,17 @@ pub enum AiSetupSlideAction {
     SelectThirdParty,
     BackClicked,
     NextClicked,
-    NoAiClicked,
 }
 
 /// The "Choose your AI setup" slide (DES-816 V3), shown on the AI-first path for
 /// users enrolled in the FREE_AI_REMOVAL experiment arm. Forks between the Warp
-/// agent (paid-plan path) and third-party agents (works on Free), with an
-/// "I don't want AI" escape onto the terminal-only path.
+/// agent (paid-plan path) and third-party agents (works on Free).
 pub struct AiSetupSlide {
     onboarding_state: ModelHandle<OnboardingStateModel>,
     warp_agent_mouse_state: MouseStateHandle,
     third_party_mouse_state: MouseStateHandle,
     back_button: button::Button,
     next_button: button::Button,
-    no_ai_button: button::Button,
     scroll_state: ClippedScrollStateHandle,
 }
 
@@ -62,7 +59,6 @@ impl AiSetupSlide {
             third_party_mouse_state: MouseStateHandle::default(),
             back_button: button::Button::default(),
             next_button: button::Button::default(),
-            no_ai_button: button::Button::default(),
             scroll_state: ClippedScrollStateHandle::new(),
         }
     }
@@ -410,22 +406,6 @@ impl AiSetupSlide {
             },
         );
 
-        let no_ai_keystroke = Keystroke::parse("cmdorctrl-enter").unwrap_or_default();
-        let no_ai_button = self.no_ai_button.render(
-            appearance,
-            button::Params {
-                content: button::Content::Label("I don't want AI".into()),
-                theme: &button::themes::Naked,
-                options: button::Options {
-                    keystroke: Some(no_ai_keystroke),
-                    on_click: Some(Box::new(|ctx, _app, _pos| {
-                        ctx.dispatch_typed_action(AiSetupSlideAction::NoAiClicked);
-                    })),
-                    ..button::Options::default(appearance)
-                },
-            },
-        );
-
         let enter = Keystroke::parse("enter").unwrap_or_default();
         let next_button = self.next_button.render(
             appearance,
@@ -442,20 +422,13 @@ impl AiSetupSlide {
             },
         );
 
-        let right_buttons = Flex::row()
-            .with_main_axis_size(MainAxisSize::Min)
-            .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_child(no_ai_button)
-            .with_child(Container::new(next_button).with_margin_left(8.).finish())
-            .finish();
-
         let (step_index, step_count) = self.onboarding_state.as_ref(app).progress();
         bottom_nav::onboarding_bottom_nav(
             appearance,
             step_index,
             step_count,
             Some(back_button),
-            Some(right_buttons),
+            Some(next_button),
         )
     }
 
@@ -521,12 +494,6 @@ impl OnboardingSlide for AiSetupSlide {
     fn on_enter(&mut self, ctx: &mut ViewContext<Self>) {
         self.next(ctx);
     }
-
-    fn on_cmd_or_ctrl_enter(&mut self, ctx: &mut ViewContext<Self>) {
-        self.onboarding_state.update(ctx, |model, ctx| {
-            model.request_no_ai_confirmation(NoAiConfirmationSource::AiSetup, ctx);
-        });
-    }
 }
 
 impl TypedActionView for AiSetupSlide {
@@ -547,11 +514,6 @@ impl TypedActionView for AiSetupSlide {
             }
             AiSetupSlideAction::NextClicked => {
                 self.next(ctx);
-            }
-            AiSetupSlideAction::NoAiClicked => {
-                self.onboarding_state.update(ctx, |model, ctx| {
-                    model.request_no_ai_confirmation(NoAiConfirmationSource::AiSetup, ctx);
-                });
             }
         }
     }

--- a/crates/onboarding/src/slides/bottom_nav.rs
+++ b/crates/onboarding/src/slides/bottom_nav.rs
@@ -1,6 +1,6 @@
 use warp_core::ui::appearance::Appearance;
 use warpui_core::elements::{
-    Align, Container, CrossAxisAlignment, Empty, Flex, MainAxisSize, ParentElement, Shrinkable,
+    Align, CrossAxisAlignment, Empty, Flex, MainAxisSize, ParentElement, Shrinkable,
 };
 use warpui_core::Element;
 
@@ -14,29 +14,20 @@ pub fn onboarding_bottom_nav(
     next_button: Option<Box<dyn Element>>,
 ) -> Box<dyn Element> {
     let dots = progress_dots::progress_dots(step_count, step_index, appearance);
-    let dots_row = Container::new(Align::new(dots).finish())
-        .with_margin_bottom(16.)
-        .finish();
 
     let back_button = back_button.unwrap_or_else(|| Empty::new().finish());
     let next_button = next_button.unwrap_or_else(|| Empty::new().finish());
 
+    // Equal-weight side slots push Back to the far left and Next to the far
+    // right, leaving the natural-width dots centered between them on one row.
     let left = Shrinkable::new(1., Align::new(back_button).left().finish()).finish();
     let right = Shrinkable::new(1., Align::new(next_button).right().finish()).finish();
-    let buttons_row = Flex::row()
+
+    Flex::row()
         .with_main_axis_size(MainAxisSize::Max)
         .with_cross_axis_alignment(CrossAxisAlignment::Center)
         .with_child(left)
+        .with_child(dots)
         .with_child(right)
-        .finish();
-
-    Container::new(
-        Flex::column()
-            .with_main_axis_size(MainAxisSize::Min)
-            .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
-            .with_child(dots_row)
-            .with_child(buttons_row)
-            .finish(),
-    )
-    .finish()
+        .finish()
 }


### PR DESCRIPTION
## Description
PR-B of the agent-onboarding cleanup (4 coordinated PRs). All changes are gated behind the existing `OpenWarpNewSettingsModes` feature flag.

This PR covers **items 1 + 6**:

- **Remove the post-agent "I don't want AI" escape hatches (item 1).** Removed the "I don't want AI" button — along with its `NoAiClicked` action, `on_cmd_or_ctrl_enter` handler, and `no_ai_button` field — from the "Choose your AI setup" and "Customize your Warp Agent" slides. The right side of the bottom nav is now just **Next**.
- **Inline the progress dots (item 1).** The bottom nav renders the dots on the same row as the buttons — **Back** on the left, dots centered, **Next** on the right — instead of stacking the dots in their own row above the buttons. `onboarding_bottom_nav`'s signature is unchanged, so sibling slides keep compiling.
- **Simplify the no-AI confirmation source.** Collapsed `NoAiConfirmationSource` (dropped the `AiSetup` and `Agent` variants) and simplified `cancel_no_ai`, so the intention slide's "Just use the terminal" is the only remaining trigger.
- **Reword the "Are you sure you don't want AI?" modal (item 6).** Dropped the feature value-props list and reworded the body into a concise warning. `feature_optout_dialog` now renders without a list when `features` is empty, without changing the struct's public fields — so the login-slide usages are unaffected.

> [!NOTE]
> `NoAiConfirmationSource::AiAccess` is intentionally retained: `ai_access_slide.rs` (owned by PR-C) still constructs it, and that file is out of scope for this PR. Once PR-C removes that slide's "I don't want AI" button, the `AiAccess` variant and its `cancel_no_ai` arm can be dropped. This was coordinated with the orchestrator; integration order is B → C → D.

Artifacts:
- Conversation: https://staging.warp.dev/conversation/173cc064-62da-410d-ad73-d11f94d419a8
- Run: https://oz.staging.warp.dev/runs/019efa09-395e-7dc2-bc0d-f6103c810d56

## Linked Issue
N/A — internal onboarding refactor, part of a multi-PR effort tracked by the orchestrator.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `./script/format` — clean.
- `cargo clippy -p onboarding --all-targets --all-features --tests -- -D warnings` — no warnings.
- `cargo nextest run -p onboarding` — 12 passed, 0 failed. Updated the affected `model_tests.rs` cases (`confirm_no_ai_switches_to_terminal_path` and `dismiss_no_ai_closes_without_changing_path` now use the `Intention` source; removed `cancel_no_ai_from_ai_setup_stays_on_slide`, whose scenario no longer exists and whose remaining case is already covered by `cancel_no_ai_from_intention_routes_to_ai_setup`).

- [ ] I have manually tested my changes locally with `./script/run` (not run in this headless agent environment; recommend UI verification after the four PRs are integrated)

### Screenshots / Videos
Not captured in this environment.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Streamlined the new agent-onboarding flow — removed the post-setup "I don't want AI" buttons, moved the progress dots inline with the Back/Next controls, and simplified the "don't want AI" confirmation dialog.
