### PR TITLE
Fix Windows Codex image clipboard paste in CLI agents

### DIFF
--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -157,6 +157,17 @@ pub enum CLIAgent {
 }
 
 impl CLIAgent {
+    /// Bytes that simulate a "paste image from clipboard" keystroke for the foreground
+    /// CLI agent. Claude Code on Windows uses Alt+V for native image paste; other
+    /// agents, including Codex, use the regular terminal Ctrl+V path.
+    pub fn image_paste_keystroke_bytes(&self) -> Vec<u8> {
+        if cfg!(windows) && matches!(self, CLIAgent::Claude) {
+            vec![0x1b, b'v']
+        } else {
+            vec![0x16]
+        }
+    }
+
     /// The command prefix used to invoke this CLI agent.
     pub fn command_prefix(&self) -> &'static str {
         match self {

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -16386,24 +16386,12 @@ impl TerminalView {
             let clipboard_content = ctx.clipboard().read();
 
             if is_cli_agent_paste && clipboard_content.has_image_data() {
-                if !cfg!(windows) {
-                    self.write_user_bytes_to_pty(vec![escape_sequences::C0::SYN], ctx);
-                    return;
-                }
-
-                // On Windows, Claude Code uses Alt+V for native image paste.
-                let is_claude = CLIAgentSessionsModel::as_ref(ctx)
+                let paste_keystroke = CLIAgentSessionsModel::as_ref(ctx)
                     .session(self.view_id)
-                    .is_some_and(|s| s.agent == CLIAgent::Claude);
-                if is_claude {
-                    self.write_user_bytes_to_pty(vec![escape_sequences::C0::ESC, b'v'], ctx);
-                    return;
-                }
-
-                // For all other agents on Windows, fall through to the normal paste path. When
-                // bracketed paste is enabled (true for TUI-based CLI agents), the empty-text paste
-                // sends \x1b[200~\x1b[201~ to the PTY. The agent interprets this as a "paste
-                // happened" signal and reads the Windows clipboard directly for image data.
+                    .map(|session| session.agent.image_paste_keystroke_bytes())
+                    .unwrap_or_else(|| vec![escape_sequences::C0::SYN]);
+                self.write_user_bytes_to_pty(paste_keystroke, ctx);
+                return;
             }
 
             clipboard_content_with_escaped_paths(clipboard_content, shell_family, false)

--- a/app/src/terminal/view/use_agent_footer/mod.rs
+++ b/app/src/terminal/view/use_agent_footer/mod.rs
@@ -88,15 +88,9 @@ const CLI_AGENT_IMAGE_PASTE_DELAY: Duration = Duration::from_millis(300);
 const CLI_AGENT_MODE_SWITCH_PREFIXES: &[u8] = &[b'!', b'&'];
 
 /// Bytes that simulate a "paste image from clipboard" keystroke for the
-/// foreground CLI agent. `0x16` is `Ctrl+V` (SYN); on Windows Claude Code
-/// listens for `Alt+V` (`ESC` + `'v'`) instead. Mirrored from the equivalent
-/// branch in `TerminalView::paste`.
-fn cli_agent_paste_keystroke_bytes() -> Vec<u8> {
-    if cfg!(windows) {
-        vec![0x1b, b'v']
-    } else {
-        vec![0x16]
-    }
+/// foreground CLI agent. Mirrored from `TerminalView::paste`.
+fn cli_agent_paste_keystroke_bytes(agent: CLIAgent) -> Vec<u8> {
+    agent.image_paste_keystroke_bytes()
 }
 
 /// How rich input delivers text + Enter to the CLI agent's PTY.
@@ -782,6 +776,13 @@ impl TerminalView {
                             if !me.has_active_cli_agent_input_session(ctx) {
                                 return false;
                             }
+                            let Some(session) =
+                                CLIAgentSessionsModel::as_ref(ctx).session(me.view_id)
+                            else {
+                                return false;
+                            };
+                            let paste_keystroke = cli_agent_paste_keystroke_bytes(session.agent);
+
                             ctx.clipboard().write(ClipboardContent {
                                 images: Some(vec![ImageData {
                                     data: raw_bytes,
@@ -790,7 +791,7 @@ impl TerminalView {
                                 }]),
                                 ..Default::default()
                             });
-                            me.write_user_bytes_to_pty(cli_agent_paste_keystroke_bytes(), ctx);
+                            me.write_user_bytes_to_pty(paste_keystroke, ctx);
                             true
                         })
                         .await;
@@ -892,6 +893,13 @@ impl TerminalView {
                             if !still_long_running {
                                 return false;
                             }
+                            let Some(session) =
+                                CLIAgentSessionsModel::as_ref(ctx).session(me.view_id)
+                            else {
+                                return false;
+                            };
+                            let paste_keystroke = cli_agent_paste_keystroke_bytes(session.agent);
+
                             ctx.clipboard().write(ClipboardContent {
                                 images: Some(vec![ImageData {
                                     data: bytes,
@@ -900,7 +908,7 @@ impl TerminalView {
                                 }]),
                                 ..Default::default()
                             });
-                            me.write_user_bytes_to_pty(cli_agent_paste_keystroke_bytes(), ctx);
+                            me.write_user_bytes_to_pty(paste_keystroke, ctx);
                             true
                         })
                         .await;

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -6271,15 +6271,8 @@ fn paste_raw_image_clipboard_in_cli_agent_sends_correct_bytes() {
                 writes.len()
             );
 
-            if cfg!(windows) {
-                if agent == CLIAgent::Claude {
-                    assert_eq!(writes[0], vec![C0::ESC, b'v']);
-                } else {
-                    let mut expected = Vec::new();
-                    expected.extend_from_slice(BRACKETED_PASTE_START);
-                    expected.extend_from_slice(BRACKETED_PASTE_END);
-                    assert_eq!(writes[0], expected);
-                }
+            if cfg!(windows) && agent == CLIAgent::Claude {
+                assert_eq!(writes[0], vec![C0::ESC, b'v']);
             } else {
                 assert_eq!(writes[0], vec![C0::SYN]);
             }


### PR DESCRIPTION
## Description

Fixes the Windows CLI-agent image paste path for built-in screenshot clipboard data by routing image-only clipboard paste through the active agent's native paste keystroke instead of letting non-Claude agents fall through to an empty bracketed paste.

The previous fix in #11627 intentionally kept Windows Claude Code on `Alt+V` and used an empty bracketed paste signal for other agents. That still leaves Codex unable to attach Windows screenshot clipboard images in the TUI. This change centralizes the agent-specific image paste keystroke:

- Claude Code on Windows still receives `Alt+V` (`ESC`, `v`).
- Codex and other CLI agents receive the regular terminal paste keystroke (`Ctrl+V` / `SYN`).
- The same helper is used by `TerminalView::paste` and the agent footer image paste/drop paths.

I originally opened this against #12248 because it was an existing `ready-to-implement` issue in the same code path, but that issue is specifically about WeChat screenshot clipboard data. I filed #12997 to track the Windows built-in screenshot (`Win+Shift+S` / Snipping Tool) repro that was manually verified with this patch.

## Linked Issue

Closes #12997

- [ ] The linked issue is labeled `ready-to-implement` or this PR is being submitted to make the tested patch available for maintainer review despite the newly filed issue not yet being triaged.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Related: #11973, #12248, #7069, #11627

## Testing

- [x] I have manually tested my changes locally with a debug build of Warp.

Manual tests performed on Windows with a debug build from this branch:

1. Built and launched `target/debug/warp-oss.exe`.
2. Opened Codex CLI inside Warp.
3. Copied a Windows screenshot to the clipboard.
4. Pasted into the Codex TUI.
5. Confirmed the image attachment appears successfully.
6. Repeated the same screenshot clipboard paste flow in Claude Code.
7. Confirmed Claude Code image paste still works successfully.

Automated checks:

- `RUSTC_BOOTSTRAP=1 cargo fmt -- --config imports_granularity=Module --config group_imports=StdExternalCrate --check`
- `cargo nextest run -p warp paste_raw_image_clipboard_in_cli_agent_sends_correct_bytes`
- `cargo clippy -p warp --tests -- -D warnings`

### Screenshots / Videos


https://github.com/user-attachments/assets/98cf4e99-cb8e-4bd2-bc00-800bc01e6ee7



## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: [Windows] Fixed pasting clipboard screenshots into Codex and other CLI agents.
-->