### PR TITLE
fix issue where input dissappeared on sharing completion

### DIFF
--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -128,6 +128,17 @@ impl TerminalView {
             {
                 return None;
             }
+
+            let is_cloud_conversation_surface = model.is_shared_ambient_agent_session()
+                || model.is_conversation_transcript_viewer()
+                || self
+                    .ambient_agent_view_model
+                    .as_ref()
+                    .is_some_and(|model| model.as_ref(ctx).is_ambient_agent());
+            if !is_cloud_conversation_surface {
+                return None;
+            }
+
             self.ambient_agent_task_id_for_details_panel_from_model(&model, ctx)
         };
         let Some(task_id) = task_id else {

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -505,6 +505,53 @@ fn test_on_session_share_ended_does_not_insert_tombstone_for_ambient_session_und
     });
 }
 
+#[test]
+fn test_on_session_share_ended_skips_cloud_continuation_for_user_share_with_task_id() {
+    let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(true);
+    let _setup_v2_flag = FeatureFlag::CloudModeSetupV2.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        let task = create_cloud_mode_task_for_user("another-user");
+        let task_id = task.task_id;
+
+        AgentConversationsModel::handle(&app).update(&mut app, |model, _| {
+            model.insert_task_for_test(task);
+        });
+        let initial_block_height_items = terminal.read(&app, |view, _| {
+            view.model.lock().block_list().block_heights().items().len()
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            view.model
+                .lock()
+                .set_shared_session_source(SharedSessionSource::user(Some(task_id.to_string())));
+
+            view.on_session_share_ended(ctx);
+        });
+
+        terminal.read(&app, |view, ctx| {
+            let model = view.model.lock();
+            assert_eq!(
+                model.block_list().block_heights().items().len(),
+                initial_block_height_items + 1
+            );
+            assert!(view.conversation_ended_tombstone_view_id.is_none());
+            assert_eq!(view.pending_cloud_followup_task_id, None);
+            assert!(view.is_input_box_visible(&model, ctx));
+            assert_eq!(
+                view.input()
+                    .as_ref(ctx)
+                    .editor()
+                    .as_ref(ctx)
+                    .interaction_state(ctx),
+                InteractionState::Editable
+            );
+        });
+    });
+}
+
 fn create_cloud_mode_task_for_user(creator_uid: &str) -> AmbientAgentTask {
     let now = chrono::Utc::now();
     AmbientAgentTask {


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

A user reported an issue where the input disappeared when they stopped /remote-control as a sharer. This should not happen. This originally regressed in [this PR](https://github.com/warpdotdev/warp/pull/11465) that got session sharing working for orchestration (and made it so we return a task id from `ambient_agent_task_id_for_details_panel_from_model` for local agents, which changed some code assumptions around that fn only returning task ids for cloud agents).

The fix here is to check that the given session is actually a cloud agent session before showing the tombstone.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see WARP.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/de923a49594640ac83692ca735089546

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode