### PR TITLE
Add idle_timeout_minutes to oz agent create/update CLI

### DIFF
--- a/app/src/ai/agent_sdk/agent_management.rs
+++ b/app/src/ai/agent_sdk/agent_management.rs
@@ -145,6 +145,7 @@ impl AgentManagementRunner {
                 skills: args.skills,
                 base_model: args.base_model,
                 environment_id: args.environment,
+                idle_timeout_minutes: args.idle_timeout_minutes,
             };
             if matches!(output_format, OutputFormat::Json) || json_output.force_json_output() {
                 let response = ai_client.create_agent_raw(request).await?;
@@ -222,6 +223,11 @@ impl AgentManagementRunner {
                     Some(String::new())
                 } else {
                     args.environment
+                },
+                idle_timeout_minutes: if args.remove_idle_timeout {
+                    Some(None)
+                } else {
+                    args.idle_timeout_minutes.map(Some)
                 },
             };
             if request_is_empty(&request) {
@@ -305,6 +311,7 @@ fn request_is_empty(request: &UpdateAgentRequest) -> bool {
         && request.skills.is_none()
         && request.base_model.is_none()
         && request.environment_id.is_none()
+        && request.idle_timeout_minutes.is_none()
 }
 
 fn ensure_json_sort_is_not_requested(
@@ -370,6 +377,7 @@ impl TableFormat for AgentResponse {
             Cell::new("Skills"),
             Cell::new("Base model"),
             Cell::new("Environment"),
+            Cell::new("Idle timeout"),
         ]
     }
 
@@ -385,6 +393,7 @@ impl TableFormat for AgentResponse {
             Cell::new(display_list(self.skills.iter().map(String::as_str))),
             Cell::new(display_optional(self.base_model.as_deref())),
             Cell::new(display_optional(self.environment_id.as_deref())),
+            Cell::new(display_optional_minutes(self.idle_timeout_minutes)),
         ]
     }
 }
@@ -490,6 +499,12 @@ fn display_optional(value: Option<&str>) -> String {
         .filter(|value| !value.is_empty())
         .unwrap_or("-")
         .to_string()
+}
+
+fn display_optional_minutes(value: Option<i32>) -> String {
+    value
+        .map(|minutes| minutes.to_string())
+        .unwrap_or_else(|| "-".to_string())
 }
 
 fn display_list<'a>(values: impl IntoIterator<Item = &'a str>) -> String {

--- a/app/src/ai/agent_sdk/agent_management_tests.rs
+++ b/app/src/ai/agent_sdk/agent_management_tests.rs
@@ -1,4 +1,5 @@
 use chrono::{TimeZone as _, Utc};
+use clap::{Args as _, Command};
 
 use super::*;
 
@@ -25,6 +26,7 @@ fn agent_with_available(
         skills: vec![],
         base_model: None,
         environment_id: None,
+        idle_timeout_minutes: None,
     }
 }
 
@@ -47,9 +49,95 @@ fn table_format_does_not_include_available_column() {
             "Skills",
             "Base model",
             "Environment",
+            "Idle timeout",
         ]
     );
     assert_eq!(row.len(), header.len());
+}
+
+#[test]
+fn idle_timeout_shown_in_agent_row() {
+    let mut agent = agent("1", "agent", 1);
+    agent.idle_timeout_minutes = Some(30);
+
+    let row = agent
+        .row()
+        .into_iter()
+        .map(|cell| cell.content().to_string())
+        .collect::<Vec<_>>();
+
+    assert!(row.contains(&"30".to_string()));
+}
+
+#[test]
+fn idle_timeout_set_serializes() {
+    let create = CreateAgentRequest {
+        name: "agent".to_string(),
+        description: None,
+        secrets: vec![],
+        skills: vec![],
+        base_model: None,
+        environment_id: None,
+        idle_timeout_minutes: Some(15),
+    };
+    let create_json = serde_json::to_value(create).expect("create serializes");
+    assert_eq!(create_json["idle_timeout_minutes"], serde_json::json!(15));
+
+    let update = UpdateAgentRequest {
+        idle_timeout_minutes: Some(Some(15)),
+        ..Default::default()
+    };
+    let update_json = serde_json::to_value(update).expect("update serializes");
+    assert_eq!(
+        update_json,
+        serde_json::json!({ "idle_timeout_minutes": 15 })
+    );
+}
+
+#[test]
+fn idle_timeout_clear_serializes_null() {
+    let request = UpdateAgentRequest {
+        idle_timeout_minutes: Some(None),
+        ..Default::default()
+    };
+
+    let json = serde_json::to_value(request).expect("request serializes");
+
+    assert_eq!(json, serde_json::json!({ "idle_timeout_minutes": null }));
+}
+
+#[test]
+fn idle_timeout_absent_omitted() {
+    let json = serde_json::to_value(UpdateAgentRequest::default()).expect("request serializes");
+
+    assert_eq!(json, serde_json::json!({}));
+}
+
+#[test]
+fn idle_timeout_only_update_is_not_empty() {
+    assert!(!request_is_empty(&UpdateAgentRequest {
+        idle_timeout_minutes: Some(Some(10)),
+        ..Default::default()
+    }));
+    assert!(!request_is_empty(&UpdateAgentRequest {
+        idle_timeout_minutes: Some(None),
+        ..Default::default()
+    }));
+}
+
+#[test]
+fn idle_timeout_flags_mutually_exclusive() {
+    let command = AgentUpdateArgs::augment_args(Command::new("update"));
+
+    let result = command.try_get_matches_from([
+        "update",
+        "agent-uid",
+        "--idle-timeout-minutes",
+        "10",
+        "--remove-idle-timeout",
+    ]);
+
+    assert!(result.is_err());
 }
 
 #[test]

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -956,6 +956,9 @@ pub struct CreateAgentRequest {
     pub base_model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub environment_id: Option<String>,
+    /// Default idle timeout (minutes) for runs executed by this agent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idle_timeout_minutes: Option<i32>,
 }
 
 /// JSON payload sent to `PUT /agent/identities/{uid}`.
@@ -973,6 +976,10 @@ pub struct UpdateAgentRequest {
     pub base_model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub environment_id: Option<String>,
+    /// Three-state update for the agent's default idle timeout (minutes):
+    /// omit to leave unchanged, `Some(None)` to clear, `Some(Some(n))` to set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idle_timeout_minutes: Option<Option<i32>>,
 }
 
 /// Public API representation of a named agent identity.
@@ -988,6 +995,8 @@ pub struct AgentResponse {
     pub base_model: Option<String>,
     #[serde(default)]
     pub environment_id: Option<String>,
+    #[serde(default)]
+    pub idle_timeout_minutes: Option<i32>,
 }
 
 #[derive(serde::Deserialize)]

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -624,6 +624,10 @@ pub struct AgentCreateArgs {
     #[arg(long = "environment", short = 'e', value_name = "ENVIRONMENT_ID")]
     pub environment: Option<String>,
 
+    /// Default idle timeout in minutes for runs executed by this agent.
+    #[arg(long = "idle-timeout-minutes", value_name = "MINUTES")]
+    pub idle_timeout_minutes: Option<i32>,
+
     /// JSON formatting configuration.
     #[command(flatten)]
     pub json_output: JsonOutput,
@@ -717,6 +721,18 @@ pub struct AgentUpdateArgs {
     /// Remove the agent default environment.
     #[arg(long = "remove-environment", conflicts_with = "environment")]
     pub remove_environment: bool,
+
+    /// Replacement default idle timeout in minutes for runs executed by this agent.
+    #[arg(
+        long = "idle-timeout-minutes",
+        value_name = "MINUTES",
+        conflicts_with = "remove_idle_timeout"
+    )]
+    pub idle_timeout_minutes: Option<i32>,
+
+    /// Remove the agent default idle timeout.
+    #[arg(long = "remove-idle-timeout", conflicts_with = "idle_timeout_minutes")]
+    pub remove_idle_timeout: bool,
 
     /// JSON formatting configuration.
     #[command(flatten)]


### PR DESCRIPTION
## Summary
Adds CLI support for the named-agent idle-timeout default, mirroring the server's `/api/v1/agent/identities` contract. Lets terminal users set, clear, and view an agent's default Oz idle timeout via `oz agent create` / `oz agent update`.

(The server API + persistence and the web UI for this field are handled in the warp-server repo.)

## Flags
- `--idle-timeout-minutes <MINUTES>` — set the default (on `oz agent create` and `oz agent update`)
- `--remove-idle-timeout` — clear the default / revert to inherit (on `oz agent update`)
- The two are mutually exclusive (clap `conflicts_with`).

## Serialization (three-state on update)
- `CreateAgentRequest`: `Option<i32>`, omitted when unset.
- `UpdateAgentRequest`: `Option<Option<i32>>` →
  - unchanged: field omitted
  - clear: `{"idle_timeout_minutes": null}`
  - set: `{"idle_timeout_minutes": 15}`
- `AgentResponse`: `Option<i32>`, shown in the agent read/table output.
- `request_is_empty()` updated so an update that only changes the idle timeout is still sent.

## Files
- `app/src/server/server_api/ai.rs`
- `crates/warp_cli/src/agent.rs`
- `app/src/ai/agent_sdk/agent_management.rs`
- `app/src/ai/agent_sdk/agent_management_tests.rs`

## Testing
- `cargo test -p warp --lib agent_sdk::agent_management`: 15 passed (new: set serializes, clear serializes null, absent omitted, idle-only update not empty, flags mutually exclusive, shown in agent row).
- `cargo build -p warp_cli`: ok. `cargo fmt --check`: clean. `cargo clippy -p warp -p warp_cli --all-targets --tests -D warnings`: clean (default features).

Co-Authored-By: Oz <oz-agent@warp.dev>