### PR TITLE
Initial TUI crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15347,6 +15347,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "warp_tui"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "warp",
+ "warp_core",
+]
+
+[[package]]
 name = "warp_util"
 version = "0.1.0"
 dependencies = [

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -461,6 +461,10 @@ embed-resource = "3.0"
 
 # Note that we support channel-specific enables for these features
 [features]
+# Headless terminal-UI front-end. Gates the `tui` module + `run_tui()` entry in
+# this crate; the `warp-tui` binary itself lives in the `warp_tui` crate. Empty
+# for now (step 1 is auth + stdout only; no warpui_core TUI backend yet).
+tui = []
 ai_resume_button = []
 autoupdate = []
 figma_detection = []

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -461,9 +461,6 @@ embed-resource = "3.0"
 
 # Note that we support channel-specific enables for these features
 [features]
-# Headless terminal-UI front-end. Gates the `tui` module + `run_tui()` entry in
-# this crate; the `warp-tui` binary itself lives in the `warp_tui` crate. Empty
-# for now (step 1 is auth + stdout only; no warpui_core TUI backend yet).
 tui = []
 ai_resume_button = []
 autoupdate = []

--- a/app/src/ai/execution_profiles/profiles.rs
+++ b/app/src/ai/execution_profiles/profiles.rs
@@ -157,19 +157,23 @@ impl AIExecutionProfilesModel {
                 }
 
                 let default_profile_state = match launch_mode {
-                    LaunchMode::App { .. } | LaunchMode::Test { .. } => match default_profile_from_cloud {
-                        Some(p) => {
-                            let execution_profile_id = ClientProfileId::new();
-                            profile_id_to_sync_id.insert(execution_profile_id, p.id);
-                            DefaultProfileState::Synced {
-                                id: execution_profile_id,
+                    // The TUI front-end is an app-style client, so it shares the
+                    // GUI app's cloud-synced default execution profile.
+                    LaunchMode::App { .. } | LaunchMode::Test { .. } | LaunchMode::Tui => {
+                        match default_profile_from_cloud {
+                            Some(p) => {
+                                let execution_profile_id = ClientProfileId::new();
+                                profile_id_to_sync_id.insert(execution_profile_id, p.id);
+                                DefaultProfileState::Synced {
+                                    id: execution_profile_id,
+                                }
                             }
+                            None => DefaultProfileState::Unsynced {
+                                id: ClientProfileId::new(),
+                                profile: super::create_default_from_legacy_settings(ctx),
+                            },
                         }
-                        None => DefaultProfileState::Unsynced {
-                            id: ClientProfileId::new(),
-                            profile: super::create_default_from_legacy_settings(ctx),
-                        },
-                    },
+                    }
                     // When running as a CLI, we ignore the GUI default and use a more permissive default.
                     LaunchMode::CommandLine { is_sandboxed, computer_use_override, .. } => {
                         DefaultProfileState::Cli {
@@ -178,13 +182,10 @@ impl AIExecutionProfilesModel {
                         }
                     }
                     // RemoteServerProxy and RemoteServerDaemon don't use AI
-                    // execution profiles and never reach this path (they skip
-                    // initialize_app). The TUI front-end does run
-                    // initialize_app, so it reaches here; give it the same
-                    // unsynced local default.
-                    LaunchMode::RemoteServerProxy
-                    | LaunchMode::RemoteServerDaemon { .. }
-                    | LaunchMode::Tui => DefaultProfileState::Unsynced {
+                    // execution profiles. They never reach this code path
+                    // since they don't go through initialize_app, but handle
+                    // exhaustively.
+                    LaunchMode::RemoteServerProxy | LaunchMode::RemoteServerDaemon { .. } => DefaultProfileState::Unsynced {
                         id: ClientProfileId::new(),
                         profile: super::create_default_from_legacy_settings(ctx),
                     },

--- a/app/src/ai/execution_profiles/profiles.rs
+++ b/app/src/ai/execution_profiles/profiles.rs
@@ -178,10 +178,13 @@ impl AIExecutionProfilesModel {
                         }
                     }
                     // RemoteServerProxy and RemoteServerDaemon don't use AI
-                    // execution profiles. They never reach this code path
-                    // since they don't go through initialize_app, but handle
-                    // exhaustively.
-                    LaunchMode::RemoteServerProxy | LaunchMode::RemoteServerDaemon { .. } => DefaultProfileState::Unsynced {
+                    // execution profiles and never reach this path (they skip
+                    // initialize_app). The TUI front-end does run
+                    // initialize_app, so it reaches here; give it the same
+                    // unsynced local default.
+                    LaunchMode::RemoteServerProxy
+                    | LaunchMode::RemoteServerDaemon { .. }
+                    | LaunchMode::Tui => DefaultProfileState::Unsynced {
                         id: ClientProfileId::new(),
                         profile: super::create_default_from_legacy_settings(ctx),
                     },

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -82,6 +82,8 @@ mod test_util;
 mod throttle;
 mod tips;
 mod tracing;
+#[cfg(feature = "tui")]
+mod tui;
 mod ui_components;
 mod undo_close;
 mod uri;
@@ -335,8 +337,11 @@ fn determine_agent_source(
             Some(crate::ai::ambient_agents::AgentSource::CloudMode)
         }
         // RemoteServerProxy and RemoteServerDaemon are headless server
-        // processes that don't use the agent subsystem.
-        LaunchMode::RemoteServerProxy | LaunchMode::RemoteServerDaemon { .. } => None,
+        // processes that don't use the agent subsystem; the TUI front-end has
+        // no agent harness wired up yet.
+        LaunchMode::RemoteServerProxy | LaunchMode::RemoteServerDaemon { .. } | LaunchMode::Tui => {
+            None
+        }
     }
 }
 
@@ -353,7 +358,8 @@ fn daemon_codebase_index_snapshot_storage(launch_mode: &LaunchMode) -> Option<Sn
         LaunchMode::App { .. }
         | LaunchMode::CommandLine { .. }
         | LaunchMode::RemoteServerProxy
-        | LaunchMode::Test { .. } => None,
+        | LaunchMode::Test { .. }
+        | LaunchMode::Tui => None,
     }
 }
 
@@ -395,6 +401,11 @@ pub enum LaunchMode {
         /// directory on the remote host.
         identity_key: String,
     },
+
+    /// Run the headless TUI front-end (the `warp-tui` binary in the `warp_tui`
+    /// crate). Boots the real headless app so auth/agent state can be reused,
+    /// but prints to stdout instead of opening a GUI window.
+    Tui,
 }
 
 impl LaunchMode {
@@ -404,7 +415,8 @@ impl LaunchMode {
             LaunchMode::CommandLine { .. }
             | LaunchMode::Test { .. }
             | LaunchMode::RemoteServerProxy
-            | LaunchMode::RemoteServerDaemon { .. } => Cow::Owned(warp_cli::AppArgs::default()),
+            | LaunchMode::RemoteServerDaemon { .. }
+            | LaunchMode::Tui => Cow::Owned(warp_cli::AppArgs::default()),
         }
     }
 
@@ -418,7 +430,8 @@ impl LaunchMode {
             LaunchMode::App { .. }
             | LaunchMode::CommandLine { .. }
             | LaunchMode::RemoteServerProxy
-            | LaunchMode::RemoteServerDaemon { .. } => false,
+            | LaunchMode::RemoteServerDaemon { .. }
+            | LaunchMode::Tui => false,
         }
     }
 
@@ -428,7 +441,8 @@ impl LaunchMode {
             LaunchMode::App { .. }
             | LaunchMode::CommandLine { .. }
             | LaunchMode::RemoteServerProxy
-            | LaunchMode::RemoteServerDaemon { .. } => None,
+            | LaunchMode::RemoteServerDaemon { .. }
+            | LaunchMode::Tui => None,
         }
     }
 
@@ -445,6 +459,8 @@ impl LaunchMode {
             LaunchMode::App { .. } => ExecutionMode::App,
             LaunchMode::CommandLine { .. } => ExecutionMode::Sdk,
             LaunchMode::Test { .. } => ExecutionMode::App,
+            // The TUI front-end is an app-style client, not the SDK.
+            LaunchMode::Tui => ExecutionMode::App,
             // RemoteServerProxy is a thin byte bridge; Sdk is the closest match.
             LaunchMode::RemoteServerProxy => ExecutionMode::Sdk,
             // RemoteServerDaemon gets its own mode for distinct Sentry tagging.
@@ -458,7 +474,8 @@ impl LaunchMode {
             LaunchMode::App { .. }
             | LaunchMode::Test { .. }
             | LaunchMode::RemoteServerProxy
-            | LaunchMode::RemoteServerDaemon { .. } => false,
+            | LaunchMode::RemoteServerDaemon { .. }
+            | LaunchMode::Tui => false,
         }
     }
 
@@ -470,6 +487,8 @@ impl LaunchMode {
                 _ => true,
             },
             LaunchMode::RemoteServerProxy | LaunchMode::RemoteServerDaemon { .. } => true,
+            // The TUI front-end renders to the terminal, with no GUI window.
+            LaunchMode::Tui => true,
             LaunchMode::App { .. } | LaunchMode::Test { .. } => false,
         }
     }
@@ -485,6 +504,8 @@ impl LaunchMode {
             }
             LaunchMode::App { .. } | LaunchMode::Test { .. } => true,
             LaunchMode::RemoteServerProxy => false,
+            // No agent harness is wired up for the TUI front-end yet.
+            LaunchMode::Tui => false,
         }
     }
 
@@ -496,7 +517,8 @@ impl LaunchMode {
             LaunchMode::CommandLine { .. }
             | LaunchMode::Test { .. }
             | LaunchMode::RemoteServerProxy
-            | LaunchMode::RemoteServerDaemon { .. } => false,
+            | LaunchMode::RemoteServerDaemon { .. }
+            | LaunchMode::Tui => false,
         }
     }
 
@@ -508,7 +530,8 @@ impl LaunchMode {
             | LaunchMode::CommandLine { .. }
             | LaunchMode::Test { .. }
             | LaunchMode::RemoteServerDaemon { .. }
-            | LaunchMode::RemoteServerProxy => true,
+            | LaunchMode::RemoteServerProxy
+            | LaunchMode::Tui => true,
         }
     }
 
@@ -519,7 +542,8 @@ impl LaunchMode {
             | LaunchMode::CommandLine { .. }
             | LaunchMode::Test { .. }
             | LaunchMode::RemoteServerDaemon { .. }
-            | LaunchMode::RemoteServerProxy => true,
+            | LaunchMode::RemoteServerProxy
+            | LaunchMode::Tui => true,
         }
     }
 
@@ -536,6 +560,9 @@ impl LaunchMode {
             // Proxy must log to stderr because stdout is the protocol channel.
             LaunchMode::RemoteServerProxy => Some(LogDestination::Stderr),
             LaunchMode::RemoteServerDaemon { .. } => Some(LogDestination::File),
+            // A TUI owns the terminal, so logs go to a file; stdout/stderr would
+            // corrupt the rendered output and the device-code prompt.
+            LaunchMode::Tui => Some(LogDestination::File),
             LaunchMode::App { .. } | LaunchMode::Test { .. } => None,
         }
     }
@@ -547,6 +574,7 @@ impl LaunchMode {
             LaunchMode::Test { .. } => "test",
             LaunchMode::RemoteServerDaemon { .. } => "remote_server_daemon",
             LaunchMode::RemoteServerProxy => "remote_server_proxy",
+            LaunchMode::Tui => "tui",
         }
     }
 
@@ -781,6 +809,13 @@ pub fn run_integration_test(driver: TestDriver) -> Result<()> {
     run_internal(launch)
 }
 
+/// Runs the headless TUI front-end (the `warp-tui` binary in the `warp_tui`
+/// crate). Bootstraps the real (headless) app and runs the step-1 auth flow.
+#[cfg(feature = "tui")]
+pub fn run_tui() -> Result<()> {
+    run_internal(LaunchMode::Tui)
+}
+
 /// Runs the app (or CLI / daemon).
 fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
     let mut timer = IntervalTimer::new();
@@ -966,14 +1001,32 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
     // ensure that the process is in the cleanest possible state (minimal opened
     // files, modified signal handlers, etc.) to avoid unexpected effects on
     // spawned ptys.
+    //
+    // The TUI front-end has no PTYs, so it skips this entirely. This is also
+    // load-bearing: the terminal server is spawned by re-exec'ing the current
+    // binary, but the `warp-tui` binary always runs the TUI (it doesn't dispatch
+    // worker subcommands), so spawning a server here would recursively launch
+    // more TUIs — a fork bomb.
     #[cfg(feature = "local_tty")]
-    let pty_spawner =
-        terminal::local_tty::spawner::PtySpawner::new().context("Failed to create pty spawner")?;
+    let pty_spawner = if matches!(launch_mode, LaunchMode::Tui) {
+        None
+    } else {
+        Some(
+            terminal::local_tty::spawner::PtySpawner::new()
+                .context("Failed to create pty spawner")?,
+        )
+    };
 
-    let callbacks = app_callbacks(
-        launch_mode.is_integration_test(),
-        tracing_initialization.take(),
-    );
+    // The TUI front-end skips the GUI lifecycle callbacks (which reach for
+    // singletons/windows it never creates), so it uses empty callbacks.
+    let callbacks = if matches!(launch_mode, LaunchMode::Tui) {
+        warpui::platform::AppCallbacks::default()
+    } else {
+        app_callbacks(
+            launch_mode.is_integration_test(),
+            tracing_initialization.take(),
+        )
+    };
     let mut app_builder = if launch_mode.is_headless() {
         warpui::platform::AppBuilder::new_headless(
             callbacks,
@@ -1076,9 +1129,13 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
         #[cfg(feature = "crash_reporting")]
         crate::crash_reporting::set_client_type_tag(launch_mode.execution_mode().client_id());
 
-        // Add the terminal server singleton to the application.
+        // Add the terminal server singleton to the application. The TUI
+        // front-end sets `pty_spawner` to `None` (fork-bomb avoidance), so only
+        // register it when present.
         #[cfg(feature = "local_tty")]
-        ctx.add_singleton_model(move |_ctx| pty_spawner);
+        if let Some(pty_spawner) = pty_spawner {
+            ctx.add_singleton_model(move |_ctx| pty_spawner);
+        }
 
         // Register user preferences.  This must be done before initializing
         // feature flags or experiments, both of which check user preferences for
@@ -1104,6 +1161,15 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
 
         if ImprovedPaletteSearch::improved_search_enabled(ctx) {
             FeatureFlag::UseTantivySearch.set_enabled(true);
+        }
+
+        // The TUI front-end reuses the full `initialize_app` bootstrap above (so
+        // auth/`AuthManager` exist), but runs its own init instead of the
+        // GUI/CLI `launch()` path.
+        #[cfg(feature = "tui")]
+        if matches!(launch_mode, LaunchMode::Tui) {
+            crate::tui::init(ctx);
+            return;
         }
 
         launch(ctx, app_state, launch_mode);
@@ -1246,7 +1312,8 @@ pub(crate) fn initialize_app(
         LaunchMode::App { .. }
         | LaunchMode::CommandLine { .. }
         | LaunchMode::RemoteServerProxy
-        | LaunchMode::Test { .. } => persistence::PersistenceScope::App,
+        | LaunchMode::Test { .. }
+        | LaunchMode::Tui => persistence::PersistenceScope::App,
     };
     let (sqlite_data, writer_handles) = persistence::initialize(ctx, persistence_scope);
     timer.mark_interval_end("SQLITE_INITIALIZED");
@@ -2652,6 +2719,9 @@ fn launch(ctx: &mut warpui::AppContext, app_state: Option<AppState>, launch_mode
     ctx.set_fallback_font_fn(font_fallback::fallback_font_fn);
 
     match launch_mode {
+        // The TUI front-end runs its own init in the run closure and returns
+        // before reaching launch().
+        LaunchMode::Tui => unreachable!("LaunchMode::Tui is handled before launch()"),
         LaunchMode::App { .. } | LaunchMode::Test { .. } => {
             let should_skip_restore = launch_mode
                 .args()

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -337,8 +337,9 @@ fn determine_agent_source(
             Some(crate::ai::ambient_agents::AgentSource::CloudMode)
         }
         // RemoteServerProxy and RemoteServerDaemon are headless server
-        // processes that don't use the agent subsystem; the TUI front-end has
-        // no agent harness wired up yet.
+        // processes that don't use the agent subsystem.
+        // TODO: the TUI front-end has no agent harness wired up yet; give it an
+        // appropriate `AgentSource` once that lands.
         LaunchMode::RemoteServerProxy | LaunchMode::RemoteServerDaemon { .. } | LaunchMode::Tui => {
             None
         }
@@ -504,7 +505,8 @@ impl LaunchMode {
             }
             LaunchMode::App { .. } | LaunchMode::Test { .. } => true,
             LaunchMode::RemoteServerProxy => false,
-            // No agent harness is wired up for the TUI front-end yet.
+            // TODO: no agent harness is wired up for the TUI front-end yet;
+            // enable indexing once it is.
             LaunchMode::Tui => false,
         }
     }

--- a/app/src/tui.rs
+++ b/app/src/tui.rs
@@ -1,0 +1,97 @@
+//! The headless `warp-tui` front-end's app-side entry point.
+//!
+//! For this first step the TUI only proves out auth reuse. The `warp_tui` crate
+//! boots the real (headless) Warp app via [`crate::run_tui`], which runs the
+//! full `initialize_app` (so `AuthManager` and the auth state exist) and then
+//! calls [`init`]. [`init`] logs the user in when needed (reusing the OAuth
+//! device-authorization flow that `oz login` uses), auto-opens the browser,
+//! prints the authenticated user's ID, and exits. No terminal UI is rendered
+//! yet.
+
+use warpui::platform::TerminationMode;
+use warpui::{AppContext, SingletonEntity};
+
+use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
+use crate::auth::AuthStateProvider;
+
+/// Entry point invoked from `run_internal` once the headless app is initialized.
+///
+/// If the user is already logged in, prints their ID immediately. Otherwise it
+/// starts the OAuth device-authorization flow, opens the browser (printing the
+/// URL/code as a fallback), and prints the ID once login completes. Terminates
+/// the app when done.
+pub fn init(ctx: &mut AppContext) {
+    let auth_state = AuthStateProvider::as_ref(ctx).get();
+    if auth_state.is_logged_in() {
+        print_user_id_and_exit(ctx);
+        return;
+    }
+
+    println!("Welcome to Warp TUI. Let's get you logged in.");
+
+    // Reuses the same device-authorization flow as `oz login` (see
+    // `app/src/ai/agent_sdk/admin.rs`). The browser handles login and control
+    // returns here once the device code is approved.
+    ctx.subscribe_to_model(&AuthManager::handle(ctx), move |_, event, ctx| match event {
+        AuthManagerEvent::ReceivedDeviceAuthorizationCode {
+            verification_url,
+            verification_url_complete,
+            user_code,
+        } => {
+            // Prefer the "complete" URL (device code pre-filled) for opening.
+            let url_to_open = verification_url_complete
+                .as_deref()
+                .unwrap_or(verification_url.as_str());
+
+            // Auto-open the browser (works in headless mode too), and also print
+            // the URL/code as a fallback for remote/SSH sessions where a local
+            // browser can't be opened.
+            if verification_url_complete.is_some() {
+                println!("Opening your browser to log in.\nIf it doesn't open, visit:\n{url_to_open}");
+            } else {
+                println!(
+                    "Opening your browser to log in.\nIf it doesn't open, visit {verification_url} and enter this code: {user_code}"
+                );
+            }
+            ctx.open_url(url_to_open);
+        }
+        AuthManagerEvent::AuthComplete => {
+            print_user_id_and_exit(ctx);
+        }
+        AuthManagerEvent::AuthFailed(err) => {
+            ctx.terminate_app(
+                TerminationMode::ForceTerminate,
+                Some(Err(anyhow::anyhow!("Authentication failed: {err:#}"))),
+            );
+        }
+        _ => {}
+    });
+
+    AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| {
+        auth_manager.authorize_device(ctx);
+    });
+}
+
+/// Prints the authenticated user's ID to stdout, then terminates the app.
+fn print_user_id_and_exit(ctx: &mut AppContext) {
+    let auth_state = AuthStateProvider::as_ref(ctx).get();
+    match auth_state.user_id() {
+        Some(user_id) => {
+            // Strip the service-account prefix the same way `oz whoami` does.
+            let uid_full = user_id.as_string();
+            let uid = uid_full
+                .strip_prefix("serviceAccount:")
+                .unwrap_or(uid_full.as_str());
+            println!("Logged in. User ID: {uid}");
+            ctx.terminate_app(TerminationMode::ForceTerminate, None);
+        }
+        None => {
+            ctx.terminate_app(
+                TerminationMode::ForceTerminate,
+                Some(Err(anyhow::anyhow!(
+                    "Could not determine user ID after login."
+                ))),
+            );
+        }
+    }
+}

--- a/crates/warp_tui/Cargo.toml
+++ b/crates/warp_tui/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "warp_tui"
+edition = "2021"
+description = "Headless terminal-UI front-end for Warp"
+authors.workspace = true
+publish.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "warp-tui"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+warp = { workspace = true, features = ["tui"] }
+warp_core.workspace = true

--- a/crates/warp_tui/src/main.rs
+++ b/crates/warp_tui/src/main.rs
@@ -1,0 +1,33 @@
+//! Entry point for `warp-tui`, the headless terminal-UI front-end.
+//!
+//! This crate is the driver for the TUI: it configures the channel and then
+//! hands off to [`warp::run_tui`], which boots the real (headless) Warp app and
+//! runs the TUI init flow (see `app/src/tui.rs`). It is a console application
+//! (no GUI window, no app bundle), so unlike the GUI binaries it sets no
+//! `windows_subsystem` attribute and embeds no `Info.plist`.
+
+use anyhow::Result;
+use warp_core::channel::{Channel, ChannelConfig, ChannelState, OzConfig, WarpServerConfig};
+use warp_core::AppId;
+
+fn main() -> Result<()> {
+    let mut state = ChannelState::new(
+        Channel::Oss,
+        ChannelConfig {
+            app_id: AppId::new("dev", "warp", "WarpTui"),
+            logfile_name: "warp-tui.log".into(),
+            server_config: WarpServerConfig::production(),
+            oz_config: OzConfig::production(),
+            telemetry_config: None,
+            crash_reporting_config: None,
+            autoupdate_config: None,
+            mcp_static_config: None,
+        },
+    );
+    if cfg!(debug_assertions) {
+        state = state.with_additional_features(warp_core::features::DEBUG_FLAGS);
+    }
+    ChannelState::set(state);
+
+    warp::run_tui()
+}

--- a/crates/warp_tui/src/main.rs
+++ b/crates/warp_tui/src/main.rs
@@ -11,6 +11,13 @@ use warp_core::channel::{Channel, ChannelConfig, ChannelState, OzConfig, WarpSer
 use warp_core::AppId;
 
 fn main() -> Result<()> {
+    // TODO(follow-up): mirror the GUI app's per-channel setup. The GUI ships
+    // separate binaries (`app/src/bin/{local,dev,preview,stable,oss}.rs`), each
+    // selecting a `Channel` + channel-specific `ChannelConfig`, feature-flag set
+    // (LOCAL/DOGFOOD/PREVIEW flags), and build profile, with `cargo run`
+    // defaulting to the local channel. The TUI currently hardcodes a single
+    // production `Oss` channel; give it the same local/dev/preview/stable
+    // channels (e.g. per-channel `warp_tui` binaries or a `--channel` flag).
     let mut state = ChannelState::new(
         Channel::Oss,
         ChannelConfig {


### PR DESCRIPTION
## Description
Sets up the barebone TUI crate that calls into the app crate's initialize_app method

This also wires the logic to setup basic auth following the oz CLI approach

Currenly we hardcode the channel version for now. But will follow-up with adding proper channel setup to mirror the app crate