### PR TITLE
Fix horizontal cross-window tab drag "fuzzy shake" on source re-entry

### DIFF
--- a/app/src/workspace/cross_window_tab_drag.rs
+++ b/app/src/workspace/cross_window_tab_drag.rs
@@ -426,6 +426,46 @@ impl CrossWindowTabDrag {
             .is_some_and(|d| d.source_placeholder_consumed)
     }
 
+    /// Returns the index of the detached-placeholder slot that the source
+    /// window's **horizontal** tab bar should collapse to zero width, or
+    /// `None` to keep every slot at full width.
+    ///
+    /// The placeholder is collapsed only while the dragged tab is actually
+    /// away from `window_id` — floating in the dedicated preview window, or
+    /// ghosted / handed off into another window. While the cursor is back
+    /// over this window's own tab bar (`reordering_in_source`) the placeholder
+    /// is the live drag slot, reordered in place exactly like an in-window
+    /// drag, so it must stay full width. Collapsing it there hides the drop
+    /// zone and, because a zero-width slot makes the adjacent-swap thresholds
+    /// in `Workspace::calculate_updated_tab_index` (`left.max_x` vs
+    /// `right.min_x`) overlap, makes the placeholder oscillate every frame —
+    /// the "fuzzy shake". The vertical tabs panel never collapses the
+    /// placeholder, which is why it does not exhibit this.
+    pub fn collapsed_source_placeholder_index(&self, window_id: WindowId) -> Option<usize> {
+        let drag = self.active_drag.as_ref()?;
+        if drag.source_window_id != window_id || drag.reordering_in_source {
+            return None;
+        }
+        let has_handoff = matches!(drag.phase, DragPhase::InsertedInTarget { .. });
+        if drag.has_dedicated_preview_window() || has_handoff {
+            self.source_placeholder_tab_index()
+        } else {
+            None
+        }
+    }
+
+    /// Test-only override of the in-progress drag's `reordering_in_source`
+    /// flag, which is otherwise only set from within `on_drag` once the cursor
+    /// re-enters the source window's tab bar. Lets unit tests exercise
+    /// [`Self::collapsed_source_placeholder_index`] without driving a full
+    /// multi-window drag.
+    #[cfg(test)]
+    pub(crate) fn set_reordering_in_source_for_test(&mut self, reordering_in_source: bool) {
+        if let Some(drag) = self.active_drag.as_mut() {
+            drag.reordering_in_source = reordering_in_source;
+        }
+    }
+
     pub fn has_dedicated_preview_window(&self) -> bool {
         self.active_drag
             .as_ref()
@@ -1970,3 +2010,7 @@ fn compute_insertion_index_for_window(
         0
     }
 }
+
+#[cfg(test)]
+#[path = "cross_window_tab_drag_tests.rs"]
+mod tests;

--- a/app/src/workspace/cross_window_tab_drag_tests.rs
+++ b/app/src/workspace/cross_window_tab_drag_tests.rs
@@ -1,0 +1,102 @@
+//! Unit tests for [`CrossWindowTabDrag`] placeholder-collapse policy.
+//!
+//! These focus on [`CrossWindowTabDrag::collapsed_source_placeholder_index`],
+//! which decides whether the source window's horizontal tab bar collapses the
+//! detached-placeholder slot to zero width. The regression these guard against
+//! is the horizontal "fuzzy shake": collapsing the placeholder while the cursor
+//! is reordering it back in the source window removed the visible drop zone and
+//! made the slot oscillate every frame.
+
+use warpui::geometry::vector::{vec2f, Vector2F};
+use warpui::WindowId;
+
+use super::CrossWindowTabDrag;
+
+const SOURCE_TAB_INDEX: usize = 2;
+
+fn begin_multi_tab_drag(
+    drag: &mut CrossWindowTabDrag,
+    source_window_id: WindowId,
+    preview_window_id: WindowId,
+) {
+    drag.begin_multi_tab_drag(
+        source_window_id,
+        SOURCE_TAB_INDEX,
+        Vector2F::zero(),
+        vec2f(800.0, 600.0),
+        Vector2F::zero(),
+        preview_window_id,
+        false,
+        vec2f(120.0, 34.0),
+    );
+}
+
+#[test]
+fn no_active_drag_keeps_all_slots_full_width() {
+    let drag = CrossWindowTabDrag::new();
+    assert_eq!(
+        drag.collapsed_source_placeholder_index(WindowId::from_usize(1)),
+        None
+    );
+}
+
+#[test]
+fn multi_tab_drag_collapses_only_the_source_window_placeholder() {
+    let source = WindowId::from_usize(1);
+    let preview = WindowId::from_usize(2);
+    let other = WindowId::from_usize(3);
+
+    let mut drag = CrossWindowTabDrag::new();
+    begin_multi_tab_drag(&mut drag, source, preview);
+
+    // The source window collapses its detached placeholder while the tab is
+    // floating in the preview window.
+    assert_eq!(
+        drag.collapsed_source_placeholder_index(source),
+        Some(SOURCE_TAB_INDEX)
+    );
+    // The preview and unrelated windows never collapse a slot.
+    assert_eq!(drag.collapsed_source_placeholder_index(preview), None);
+    assert_eq!(drag.collapsed_source_placeholder_index(other), None);
+}
+
+#[test]
+fn source_reorder_keeps_placeholder_full_width() {
+    let source = WindowId::from_usize(1);
+    let preview = WindowId::from_usize(2);
+
+    let mut drag = CrossWindowTabDrag::new();
+    begin_multi_tab_drag(&mut drag, source, preview);
+
+    // Cursor returns to the source's own tab bar: the placeholder is reordered
+    // in place like an in-window drag and must stay full width. Collapsing it
+    // here is what produced the horizontal "fuzzy shake".
+    drag.set_reordering_in_source_for_test(true);
+    assert_eq!(drag.collapsed_source_placeholder_index(source), None);
+
+    // Leaving the source again restores the zero-width collapse.
+    drag.set_reordering_in_source_for_test(false);
+    assert_eq!(
+        drag.collapsed_source_placeholder_index(source),
+        Some(SOURCE_TAB_INDEX)
+    );
+}
+
+#[test]
+fn single_tab_drag_never_collapses_a_slot() {
+    let source = WindowId::from_usize(1);
+
+    let mut drag = CrossWindowTabDrag::new();
+    // A single-tab window is its own floating preview; there is no separate
+    // placeholder to collapse.
+    drag.begin_single_tab_drag(
+        source,
+        Vector2F::zero(),
+        vec2f(800.0, 600.0),
+        Vector2F::zero(),
+        false,
+        vec2f(120.0, 34.0),
+    );
+
+    assert_eq!(drag.collapsed_source_placeholder_index(source), None);
+}

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -20399,26 +20399,16 @@ impl Workspace {
                     || is_any_group_dragging,
                 hover_fixed_width,
             };
-            // Collapse the detached-placeholder slot to 0 width while it
-            // exists in this (source) window. After a put-back handoff the
-            // placeholder has been removed and the real tab re-inserted at a
-            // different index, so `source_placeholder_tab_index()` returns
-            // `None` and nothing is hidden — otherwise the stale
-            // `source_tab_index` would collapse an unrelated tab (e.g. the
-            // first tab shifting into that slot after a leftward put-back).
-            let transferred_tab_index = if drag_model.is_active()
-                && drag_model.source_window_id() == Some(self.window_id)
-            {
-                let has_dedicated_preview = drag_model.has_dedicated_preview_window();
-                let has_handoff = drag_model.handed_off_target().is_some();
-                if has_dedicated_preview || has_handoff {
-                    drag_model.source_placeholder_tab_index()
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
+            // The detached-placeholder slot in this (source) window is
+            // collapsed to zero width only while the dragged tab is actually
+            // away (floating in the preview, or ghosted / handed off to
+            // another window). While the cursor is back over this window's own
+            // tab bar the placeholder is reordered in place like an in-window
+            // drag and must stay full width, otherwise the drop zone vanishes
+            // and the slot oscillates ("fuzzy shake"). See
+            // `CrossWindowTabDrag::collapsed_source_placeholder_index`.
+            let transferred_tab_index =
+                drag_model.collapsed_source_placeholder_index(self.window_id);
             // Ghost state for cross-window drag hovering over this tab bar.
             let ghost = drag_model.ghost_state_for_window(self.window_id);
 


### PR DESCRIPTION
## Description
Fixes a cross-window tab dragging bug for **horizontal tabs**. When you drag a tab out of a multi-tab window and then back into that same window without releasing the mouse, there is no visible drop zone and the tabs "fuzzy shake".

### Why it happens
When the drag re-enters its source window, it switches to reordering the tab in place, like an in-window drag. But the horizontal tab bar always collapsed the dragged tab's placeholder slot to zero width whenever a floating preview existed. A zero-width slot means there's no drop zone to show, and it makes the adjacent-swap thresholds overlap so the placeholder oscillates between positions every frame, producing the shake.

The vertical tabs panel never collapses the placeholder, which is why it didn't have this bug.

### Fix
Keep the placeholder full-width while the tab is being reordered back in its source window, restoring the drop zone and stopping the oscillation. The placeholder is still collapsed while the tab is genuinely away (floating in the preview or handed off to another window).

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- Added unit tests
- Manual testing: https://www.loom.com/share/eee488be7ca2483da8545a8707198996

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed a missing drop zone and visual jitter when dragging a horizontal tab out of a window and back into it.

_Conversation: https://app.warp.dev/conversation/80fbd485-382d-4e2d-9569-3f410cb17a1e_

_Run: https://oz.warp.dev/runs/019efaf1-731a-7ed2-8cff-29ae52b76c43_

_This PR was generated with [Oz](https://warp.dev/oz)._
