### PR TITLE
Improve oz login error message when server returns empty/non-JSON response

### DIFF
--- a/crates/warp_server_client/src/auth/session.rs
+++ b/crates/warp_server_client/src/auth/session.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use anyhow::{Context as _, Result, bail};
 use firebase::FetchAccessTokenResponse;
 use instant::Duration;
-use oauth2::TokenResponse as _;
+use oauth2::{RequestTokenError, TokenResponse as _};
 use url::Url;
 use warp_core::channel::ChannelState;
 use warp_server_auth::auth_state::AuthState;
@@ -166,8 +166,25 @@ impl AuthSession {
             .exchange_device_code()
             .request_async(self.client.as_ref())
             .await
-            .context("Failed to generate device code")
-            .map_err(UserAuthenticationError::Unexpected)
+            .map_err(|err| {
+                // For parse errors, include the response body to aid diagnostics.
+                // An empty body ("expected value at line 1 column 1") most often indicates
+                // the server returned a non-JSON error (e.g. a timeout or panic response).
+                let context = match &err {
+                    RequestTokenError::Parse(_, body) if body.is_empty() => {
+                        "Failed to generate device code: server returned an empty response body"
+                            .to_string()
+                    }
+                    RequestTokenError::Parse(_, body) => {
+                        format!(
+                            "Failed to generate device code: server returned non-JSON response: {:.200}",
+                            String::from_utf8_lossy(body)
+                        )
+                    }
+                    _ => "Failed to generate device code".to_string(),
+                };
+                UserAuthenticationError::Unexpected(anyhow::Error::from(err).context(context))
+            })
     }
 
     pub async fn exchange_device_access_token(


### PR DESCRIPTION
## What

Improve the `oz login` device code error message to include the server's response body when the response can't be parsed as JSON.

**Changed file:** `crates/warp_server_client/src/auth/session.rs`

Before (when server returns empty body):
```
Authentication failed: unexpected error occurred when fetching an ID token:
Failed to generate device code: Failed to parse server response: expected value at line 1 column 1
```

After:
```
Authentication failed: unexpected error occurred when fetching an ID token:
Failed to generate device code: server returned an empty response body:
Failed to parse server response: expected value at line 1 column 1
```

Or if the server returned non-JSON (e.g. an HTML error page):
```
Failed to generate device code: server returned non-JSON response: <!DOCTYPE html>...
```

## Why

When `oz login` fails with "Failed to parse server response: expected value at line 1 column 1", there's no way to know from the error message what the server actually returned. "Expected value at line 1 column 1" is serde_json's error for an **empty byte slice** — meaning the server returned an HTTP response with no body.

This could happen when:
- The server hits a request timeout (408) and uses `AbortWithStatus` with no body
- A panic is caught by gin Recovery middleware and returns 500 with no body
- A CDN/WAF intercepts the request and returns an empty response

By matching on `RequestTokenError::Parse` and inspecting the response body bytes, we can now surface:
- "server returned an empty response body" → clearly identifies the empty-body scenario
- "server returned non-JSON response: ..." → shows the first 200 chars for non-JSON content

This makes REMOTE-2011-type issues significantly easier to diagnose.

## Agent Mode
- [x] This PR was created by Warp Agent Mode

_Conversation: https://staging.warp.dev/conversation/3e8e006f-5b99-4345-8e8e-e90391cf553d_
_Run: https://oz.staging.warp.dev/runs/019efb05-db08-7bde-b8f9-4f665ed91362_
_This PR was generated with [Oz](https://warp.dev/oz)._
