### PR TITLE
Add UI for configuring custom model routers in Warp Agent settings

### DIFF
--- a/app/src/ai/custom_model_router_editor.rs
+++ b/app/src/ai/custom_model_router_editor.rs
@@ -100,6 +100,7 @@ pub struct CustomRouterEditorView {
     save_button: ViewHandle<ActionButton>,
     cancel_button: ViewHandle<ActionButton>,
     delete_button: ViewHandle<ActionButton>,
+    add_rule_button: ViewHandle<ActionButton>,
 
     upgrade_footer_mouse_state: MouseStateHandle,
     save_error: Option<String>,
@@ -261,6 +262,11 @@ impl CustomRouterEditorView {
                 .with_size(ButtonSize::Small)
                 .on_click(|ctx| ctx.dispatch_typed_action(CustomRouterEditorAction::Delete))
         });
+        let add_rule_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("+ Add rule", SecondaryTheme)
+                .with_size(ButtonSize::Small)
+                .on_click(|ctx| ctx.dispatch_typed_action(CustomRouterEditorAction::AddPromptRule))
+        });
 
         let view = Self {
             existing,
@@ -284,6 +290,7 @@ impl CustomRouterEditorView {
             save_button,
             cancel_button,
             delete_button,
+            add_rule_button,
             upgrade_footer_mouse_state,
             save_error: None,
         };
@@ -583,19 +590,11 @@ impl CustomRouterEditorView {
             }
         }
 
-        // "+ Add rule" inline text button
-        let accent = warp_core::ui::theme::color::internal_colors::accent_fg(appearance.theme());
-        let add_rule = Hoverable::new(MouseStateHandle::default(), move |_| {
-            Text::new("+ Add rule", appearance.ui_font_family(), 12.)
-                .with_color(accent.into())
-                .finish()
-        })
-        .on_click(|ctx, _app, _pos| {
-            ctx.dispatch_typed_action(CustomRouterEditorAction::AddPromptRule);
-        })
-        .finish();
-
-        column.add_child(Container::new(add_rule).with_margin_top(4.).finish());
+        column.add_child(
+            Container::new(ChildView::new(&self.add_rule_button).finish())
+                .with_margin_top(4.)
+                .finish(),
+        );
         column.finish()
     }
 

--- a/app/src/ai/custom_model_router_editor.rs
+++ b/app/src/ai/custom_model_router_editor.rs
@@ -1,0 +1,1088 @@
+//! Editor view for creating and editing local custom model routers.
+//!
+//! Opened as a side-pane from the Warp Agent settings page when the user clicks
+//! "Add router" or "Edit" on an existing router card. Writes changes to
+//! `~/.warp/custom_model_routers/` via [`WarpConfig::save_custom_model_router`].
+
+use warpui::elements::{
+    Border, ChildView, ClippedScrollStateHandle, ClippedScrollable, ConstrainedBox, Container,
+    CrossAxisAlignment, Expanded, Flex, Hoverable, MainAxisSize, MouseStateHandle, ParentElement,
+    ScrollbarWidth, Text,
+};
+use warpui::fonts::{Properties, Weight};
+use warpui::{
+    AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle,
+};
+
+use crate::ai::custom_model_routers::{
+    is_auto_target, ComplexityRouting, CustomModelRouter, CustomModelRouting, PromptRouting,
+    PromptRule,
+};
+use crate::ai::llms::{LLMPreferences, LLMPreferencesEvent};
+use crate::appearance::Appearance;
+use crate::editor::{EditorView, SingleLineEditorOptions, TextOptions};
+use crate::pane_group::focus_state::PaneFocusHandle;
+use crate::pane_group::pane::view;
+use crate::pane_group::{BackingView, PaneConfiguration, PaneEvent};
+use crate::ui_components::icons::Icon;
+use crate::user_config::WarpConfig;
+use crate::view_components::action_button::{
+    ActionButton, ButtonSize, DangerSecondaryTheme, PrimaryTheme, SecondaryTheme,
+};
+use crate::view_components::{Dropdown, DropdownItem};
+
+pub const HEADER_TEXT: &str = "Router Editor";
+
+const EDITOR_CONTENT_WIDTH: f32 = 340.;
+
+/// Sentinel used as the dropdown selection for "inherit default" in optional
+/// complexity-bucket dropdowns.
+const INHERIT_DEFAULT: &str = "__inherit_default__";
+
+#[derive(Debug, Clone)]
+pub enum CustomRouterEditorEvent {
+    Pane(PaneEvent),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CustomRouterEditorAction {
+    Close,
+    Save,
+    Delete,
+    SetRouterType(RouterEditorType),
+    SetComplexityDefault(String),
+    SetComplexityEasy(String),
+    SetComplexityMedium(String),
+    SetComplexityHard(String),
+    SetPromptDefault(String),
+    SetPromptRuleModel { index: usize, model_id: String },
+    AddPromptRule,
+    RemovePromptRule(usize),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouterEditorType {
+    Complexity,
+    Prompt,
+}
+
+struct PromptRuleRow {
+    description_editor: ViewHandle<EditorView>,
+    model_dropdown: ViewHandle<Dropdown<CustomRouterEditorAction>>,
+    remove_mouse_state: MouseStateHandle,
+    current_model: String,
+}
+
+pub struct CustomRouterEditorView {
+    existing: Option<CustomModelRouter>,
+    pane_configuration: warpui::ModelHandle<PaneConfiguration>,
+    focus_handle: Option<PaneFocusHandle>,
+    scroll_state: ClippedScrollStateHandle,
+
+    name_editor: ViewHandle<EditorView>,
+    router_type: RouterEditorType,
+    type_dropdown: ViewHandle<Dropdown<CustomRouterEditorAction>>,
+
+    complexity_default_dropdown: ViewHandle<Dropdown<CustomRouterEditorAction>>,
+    complexity_easy_dropdown: ViewHandle<Dropdown<CustomRouterEditorAction>>,
+    complexity_medium_dropdown: ViewHandle<Dropdown<CustomRouterEditorAction>>,
+    complexity_hard_dropdown: ViewHandle<Dropdown<CustomRouterEditorAction>>,
+
+    complexity_default: String,
+    complexity_easy: Option<String>,
+    complexity_medium: Option<String>,
+    complexity_hard: Option<String>,
+
+    prompt_default_dropdown: ViewHandle<Dropdown<CustomRouterEditorAction>>,
+    prompt_default_model: String,
+    prompt_rules: Vec<PromptRuleRow>,
+
+    save_button: ViewHandle<ActionButton>,
+    cancel_button: ViewHandle<ActionButton>,
+    delete_button: ViewHandle<ActionButton>,
+
+    save_error: Option<String>,
+}
+
+impl CustomRouterEditorView {
+    /// Create the editor.
+    ///
+    /// `existing = None` → creating a new router.
+    /// `existing = Some(router)` → editing an existing router.
+    pub fn new(existing: Option<CustomModelRouter>, ctx: &mut ViewContext<Self>) -> Self {
+        let title = existing
+            .as_ref()
+            .map(|r| r.info.display_name.clone())
+            .unwrap_or_else(|| "New Router".to_string());
+        let pane_configuration = ctx.add_model(|_ctx| PaneConfiguration::new(&title));
+
+        let router_type = match existing.as_ref().map(|r| &r.routing) {
+            Some(CustomModelRouting::Prompt(_)) => RouterEditorType::Prompt,
+            _ => RouterEditorType::Complexity,
+        };
+
+        let (init_cdefault, init_ceasy, init_cmedium, init_chard) =
+            match existing.as_ref().map(|r| &r.routing) {
+                Some(CustomModelRouting::Complexity(c)) => (
+                    c.default.clone(),
+                    c.easy.clone(),
+                    c.medium.clone(),
+                    c.hard.clone(),
+                ),
+                _ => (String::new(), None, None, None),
+            };
+
+        let (init_pdefault, init_prules) = match existing.as_ref().map(|r| &r.routing) {
+            Some(CustomModelRouting::Prompt(p)) => (p.default_model.clone(), p.rules.clone()),
+            _ => (String::new(), Vec::new()),
+        };
+
+        // Name editor
+        let initial_name = existing
+            .as_ref()
+            .map(|r| r.info.display_name.clone())
+            .unwrap_or_default();
+        let is_editing = existing.is_some();
+        let name_editor = ctx.add_view(move |ctx| {
+            let font_size = Appearance::as_ref(ctx).ui_font_size();
+            let mut editor = EditorView::single_line(
+                SingleLineEditorOptions {
+                    text: TextOptions {
+                        font_size_override: Some(font_size),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ctx,
+            );
+            editor.set_placeholder_text("e.g. \"my-router\"", ctx);
+            if !initial_name.is_empty() {
+                editor.set_buffer_text(&initial_name, ctx);
+            }
+            if is_editing {
+                // Make read-only: Selectable = can navigate/copy but not edit
+                editor.set_interaction_state(crate::editor::InteractionState::Selectable, ctx);
+            }
+            editor
+        });
+        let font_family = Appearance::as_ref(ctx).ui_font_family();
+        let font_size = Appearance::as_ref(ctx).ui_font_size();
+        name_editor.update(ctx, |editor, ctx| {
+            editor.set_font_size(font_size, ctx);
+            editor.set_font_family(font_family, ctx);
+        });
+
+        // Type dropdown
+        let init_type = router_type;
+        let type_dropdown = ctx.add_typed_action_view(move |ctx| {
+            let mut d = Dropdown::new(ctx);
+            d.set_items(
+                vec![
+                    DropdownItem::new(
+                        "Complexity",
+                        CustomRouterEditorAction::SetRouterType(RouterEditorType::Complexity),
+                    ),
+                    DropdownItem::new(
+                        "Prompt",
+                        CustomRouterEditorAction::SetRouterType(RouterEditorType::Prompt),
+                    ),
+                ],
+                ctx,
+            );
+            match init_type {
+                RouterEditorType::Complexity => d.set_selected_by_name("Complexity", ctx),
+                RouterEditorType::Prompt => d.set_selected_by_name("Prompt", ctx),
+            }
+            d
+        });
+
+        // Model choices (concrete, non-auto)
+        let choices = concrete_model_choices(ctx);
+
+        let complexity_default_dropdown = make_model_dropdown(
+            &choices,
+            false,
+            &init_cdefault,
+            CustomRouterEditorAction::SetComplexityDefault,
+            ctx,
+        );
+        let complexity_easy_dropdown = make_model_dropdown(
+            &choices,
+            true,
+            init_ceasy.as_deref().unwrap_or(INHERIT_DEFAULT),
+            CustomRouterEditorAction::SetComplexityEasy,
+            ctx,
+        );
+        let complexity_medium_dropdown = make_model_dropdown(
+            &choices,
+            true,
+            init_cmedium.as_deref().unwrap_or(INHERIT_DEFAULT),
+            CustomRouterEditorAction::SetComplexityMedium,
+            ctx,
+        );
+        let complexity_hard_dropdown = make_model_dropdown(
+            &choices,
+            true,
+            init_chard.as_deref().unwrap_or(INHERIT_DEFAULT),
+            CustomRouterEditorAction::SetComplexityHard,
+            ctx,
+        );
+        let prompt_default_dropdown = make_model_dropdown(
+            &choices,
+            false,
+            &init_pdefault,
+            CustomRouterEditorAction::SetPromptDefault,
+            ctx,
+        );
+
+        let prompt_rules = init_prules
+            .iter()
+            .enumerate()
+            .map(|(i, rule)| make_prompt_rule_row(i, &rule.description, &rule.model, &choices, ctx))
+            .collect();
+
+        let save_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("Save", PrimaryTheme)
+                .with_size(ButtonSize::Small)
+                .on_click(|ctx| ctx.dispatch_typed_action(CustomRouterEditorAction::Save))
+        });
+        let cancel_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("Cancel", SecondaryTheme)
+                .with_size(ButtonSize::Small)
+                .on_click(|ctx| ctx.dispatch_typed_action(CustomRouterEditorAction::Close))
+        });
+        let delete_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("Delete router", DangerSecondaryTheme)
+                .with_icon(Icon::Trash)
+                .with_size(ButtonSize::Small)
+                .on_click(|ctx| ctx.dispatch_typed_action(CustomRouterEditorAction::Delete))
+        });
+
+        let view = Self {
+            existing,
+            pane_configuration,
+            focus_handle: None,
+            scroll_state: Default::default(),
+            name_editor,
+            router_type,
+            type_dropdown,
+            complexity_default_dropdown,
+            complexity_easy_dropdown,
+            complexity_medium_dropdown,
+            complexity_hard_dropdown,
+            complexity_default: init_cdefault,
+            complexity_easy: init_ceasy,
+            complexity_medium: init_cmedium,
+            complexity_hard: init_chard,
+            prompt_default_dropdown,
+            prompt_default_model: init_pdefault,
+            prompt_rules,
+            save_button,
+            cancel_button,
+            delete_button,
+            save_error: None,
+        };
+
+        ctx.subscribe_to_model(&LLMPreferences::handle(ctx), |me, _, event, ctx| {
+            if matches!(event, LLMPreferencesEvent::UpdatedAvailableLLMs) {
+                me.refresh_all_model_dropdowns(ctx);
+            }
+        });
+
+        view
+    }
+
+    pub fn pane_configuration(&self) -> warpui::ModelHandle<PaneConfiguration> {
+        self.pane_configuration.clone()
+    }
+
+    pub fn focus(&mut self, ctx: &mut ViewContext<Self>) {
+        ctx.focus(&self.name_editor);
+    }
+
+    // ------------------------------------------------------------------
+
+    fn refresh_all_model_dropdowns(&mut self, ctx: &mut ViewContext<Self>) {
+        let choices = concrete_model_choices(ctx);
+        repopulate(
+            &self.complexity_default_dropdown,
+            &choices,
+            false,
+            &self.complexity_default,
+            CustomRouterEditorAction::SetComplexityDefault,
+            ctx,
+        );
+        let easy = self
+            .complexity_easy
+            .as_deref()
+            .unwrap_or(INHERIT_DEFAULT)
+            .to_string();
+        repopulate(
+            &self.complexity_easy_dropdown,
+            &choices,
+            true,
+            &easy,
+            CustomRouterEditorAction::SetComplexityEasy,
+            ctx,
+        );
+        let med = self
+            .complexity_medium
+            .as_deref()
+            .unwrap_or(INHERIT_DEFAULT)
+            .to_string();
+        repopulate(
+            &self.complexity_medium_dropdown,
+            &choices,
+            true,
+            &med,
+            CustomRouterEditorAction::SetComplexityMedium,
+            ctx,
+        );
+        let hard = self
+            .complexity_hard
+            .as_deref()
+            .unwrap_or(INHERIT_DEFAULT)
+            .to_string();
+        repopulate(
+            &self.complexity_hard_dropdown,
+            &choices,
+            true,
+            &hard,
+            CustomRouterEditorAction::SetComplexityHard,
+            ctx,
+        );
+        repopulate(
+            &self.prompt_default_dropdown,
+            &choices,
+            false,
+            &self.prompt_default_model,
+            CustomRouterEditorAction::SetPromptDefault,
+            ctx,
+        );
+        for (i, row) in self.prompt_rules.iter_mut().enumerate() {
+            let sel = row.current_model.clone();
+            repopulate(
+                &row.model_dropdown,
+                &choices,
+                false,
+                &sel,
+                move |id| CustomRouterEditorAction::SetPromptRuleModel {
+                    index: i,
+                    model_id: id,
+                },
+                ctx,
+            );
+        }
+        ctx.notify();
+    }
+
+    fn router_name(&self, ctx: &AppContext) -> String {
+        self.name_editor
+            .as_ref(ctx)
+            .buffer_text(ctx)
+            .trim()
+            .to_string()
+    }
+
+    fn try_save(&mut self, ctx: &mut ViewContext<Self>) {
+        let name = self.router_name(ctx);
+        if name.is_empty() {
+            self.save_error = Some("Router name is required.".to_string());
+            ctx.notify();
+            return;
+        }
+
+        let routing = match self.router_type {
+            RouterEditorType::Complexity => {
+                if self.complexity_default.is_empty() {
+                    self.save_error = Some("A default model is required.".to_string());
+                    ctx.notify();
+                    return;
+                }
+                CustomModelRouting::Complexity(ComplexityRouting {
+                    default: self.complexity_default.clone(),
+                    easy: self.complexity_easy.clone(),
+                    medium: self.complexity_medium.clone(),
+                    hard: self.complexity_hard.clone(),
+                })
+            }
+            RouterEditorType::Prompt => {
+                if self.prompt_default_model.is_empty() {
+                    self.save_error = Some("A default model is required.".to_string());
+                    ctx.notify();
+                    return;
+                }
+                let rules: Vec<PromptRule> = self
+                    .prompt_rules
+                    .iter()
+                    .filter_map(|row| {
+                        let desc = row
+                            .description_editor
+                            .as_ref(ctx)
+                            .buffer_text(ctx)
+                            .trim()
+                            .to_string();
+                        if desc.is_empty() || row.current_model.is_empty() {
+                            return None;
+                        }
+                        Some(PromptRule {
+                            description: desc,
+                            model: row.current_model.clone(),
+                        })
+                    })
+                    .collect();
+                CustomModelRouting::Prompt(PromptRouting {
+                    default_model: self.prompt_default_model.clone(),
+                    rules,
+                })
+            }
+        };
+
+        let existing_path = self
+            .existing
+            .as_ref()
+            .and_then(|r| r.source_path.as_deref());
+        let router = CustomModelRouter::new_local(name.clone(), routing, existing_path);
+        if let Err(e) = router.validate() {
+            self.save_error = Some(format!("Validation: {e}"));
+            ctx.notify();
+            return;
+        }
+
+        let yaml = match router.to_yaml_string() {
+            Ok(y) => y,
+            Err(e) => {
+                self.save_error = Some(format!("Serialization: {e}"));
+                ctx.notify();
+                return;
+            }
+        };
+
+        #[cfg(feature = "local_fs")]
+        {
+            let ep = self.existing.as_ref().and_then(|r| r.source_path.clone());
+            if let Err(e) = WarpConfig::save_custom_model_router(&name, &yaml, ep.as_deref()) {
+                self.save_error = Some(format!("Write error: {e}"));
+                ctx.notify();
+                return;
+            }
+        }
+
+        self.save_error = None;
+        ctx.emit(CustomRouterEditorEvent::Pane(PaneEvent::Close));
+    }
+
+    fn try_delete(&mut self, ctx: &mut ViewContext<Self>) {
+        if let Some(path) = self.existing.as_ref().and_then(|r| r.source_path.as_ref()) {
+            #[cfg(feature = "local_fs")]
+            if let Err(e) = WarpConfig::delete_custom_model_router(path) {
+                self.save_error = Some(format!("Delete error: {e}"));
+                ctx.notify();
+                return;
+            }
+        }
+        ctx.emit(CustomRouterEditorEvent::Pane(PaneEvent::Close));
+    }
+
+    fn add_prompt_rule(&mut self, ctx: &mut ViewContext<Self>) {
+        let choices = concrete_model_choices(ctx);
+        let index = self.prompt_rules.len();
+        let row = make_prompt_rule_row(index, "", "", &choices, ctx);
+        self.prompt_rules.push(row);
+        ctx.notify();
+    }
+
+    fn remove_prompt_rule(&mut self, index: usize, ctx: &mut ViewContext<Self>) {
+        if index < self.prompt_rules.len() {
+            self.prompt_rules.remove(index);
+        }
+        ctx.notify();
+    }
+
+    // ------------------------------------------------------------------
+    // Rendering
+    // ------------------------------------------------------------------
+
+    fn section_label(label: impl Into<String>, appearance: &Appearance) -> Box<dyn Element> {
+        Container::new(
+            Text::new(label.into(), appearance.ui_font_family(), 11.)
+                .with_style(Properties::default().weight(Weight::Medium))
+                .with_color(
+                    appearance
+                        .theme()
+                        .sub_text_color(appearance.theme().surface_1())
+                        .into(),
+                )
+                .finish(),
+        )
+        .with_margin_bottom(4.)
+        .finish()
+    }
+
+    fn render_complexity_section(&self, appearance: &Appearance) -> Box<dyn Element> {
+        Flex::column()
+            .with_child(Self::section_label("MODELS", appearance))
+            .with_child(labeled_dropdown(
+                "Default (required)",
+                &self.complexity_default_dropdown,
+                appearance,
+            ))
+            .with_child(
+                Container::new(labeled_dropdown(
+                    "Easy (optional)",
+                    &self.complexity_easy_dropdown,
+                    appearance,
+                ))
+                .with_margin_top(8.)
+                .finish(),
+            )
+            .with_child(
+                Container::new(labeled_dropdown(
+                    "Medium (optional)",
+                    &self.complexity_medium_dropdown,
+                    appearance,
+                ))
+                .with_margin_top(8.)
+                .finish(),
+            )
+            .with_child(
+                Container::new(labeled_dropdown(
+                    "Hard (optional)",
+                    &self.complexity_hard_dropdown,
+                    appearance,
+                ))
+                .with_margin_top(8.)
+                .finish(),
+            )
+            .finish()
+    }
+
+    fn render_prompt_section(
+        &self,
+        appearance: &Appearance,
+        _app: &AppContext,
+    ) -> Box<dyn Element> {
+        let _sub = appearance
+            .theme()
+            .sub_text_color(appearance.theme().surface_1());
+
+        let mut column = Flex::column()
+            .with_child(Self::section_label("DEFAULT MODEL", appearance))
+            .with_child(
+                ConstrainedBox::new(ChildView::new(&self.prompt_default_dropdown).finish())
+                    .with_width(EDITOR_CONTENT_WIDTH)
+                    .finish(),
+            );
+
+        if !self.prompt_rules.is_empty() {
+            column.add_child(
+                Container::new(Self::section_label("RULES".to_string(), appearance))
+                    .with_margin_top(12.)
+                    .finish(),
+            );
+            for (i, row) in self.prompt_rules.iter().enumerate() {
+                column.add_child(
+                    Container::new(render_rule_row(i, row, appearance))
+                        .with_margin_bottom(8.)
+                        .finish(),
+                );
+            }
+        }
+
+        // "+ Add rule" inline text button
+        let accent = warp_core::ui::theme::color::internal_colors::accent_fg(appearance.theme());
+        let add_rule = Hoverable::new(MouseStateHandle::default(), move |_| {
+            Text::new("+ Add rule", appearance.ui_font_family(), 12.)
+                .with_color(accent.into())
+                .finish()
+        })
+        .on_click(|ctx, _app, _pos| {
+            ctx.dispatch_typed_action(CustomRouterEditorAction::AddPromptRule);
+        })
+        .finish();
+
+        column.add_child(Container::new(add_rule).with_margin_top(4.).finish());
+        column.finish()
+    }
+
+    fn render_content(&self, appearance: &Appearance, app: &AppContext) -> Box<dyn Element> {
+        let mut col = Flex::column();
+
+        // Name
+        let name_label = if self.existing.is_some() {
+            "NAME (read-only)"
+        } else {
+            "NAME"
+        };
+        col.add_child(
+            Container::new(
+                Flex::column()
+                    .with_child(Self::section_label(name_label, appearance))
+                    .with_child(editor_row(&self.name_editor, appearance))
+                    .finish(),
+            )
+            .with_margin_bottom(16.)
+            .finish(),
+        );
+
+        // Type
+        col.add_child(
+            Container::new(
+                Flex::column()
+                    .with_child(Self::section_label("ROUTING TYPE", appearance))
+                    .with_child(
+                        ConstrainedBox::new(ChildView::new(&self.type_dropdown).finish())
+                            .with_width(EDITOR_CONTENT_WIDTH)
+                            .finish(),
+                    )
+                    .finish(),
+            )
+            .with_margin_bottom(16.)
+            .finish(),
+        );
+
+        // Routing section
+        match self.router_type {
+            RouterEditorType::Complexity => {
+                col.add_child(
+                    Container::new(self.render_complexity_section(appearance))
+                        .with_margin_bottom(16.)
+                        .finish(),
+                );
+            }
+            RouterEditorType::Prompt => {
+                col.add_child(
+                    Container::new(self.render_prompt_section(appearance, app))
+                        .with_margin_bottom(16.)
+                        .finish(),
+                );
+            }
+        }
+
+        // Buttons
+        let mut btn_row = Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(
+                Container::new(ChildView::new(&self.save_button).finish())
+                    .with_margin_right(8.)
+                    .finish(),
+            )
+            .with_child(ChildView::new(&self.cancel_button).finish());
+        if self.existing.is_some() {
+            btn_row.add_child(
+                Container::new(ChildView::new(&self.delete_button).finish())
+                    .with_margin_left(16.)
+                    .finish(),
+            );
+        }
+        col.add_child(btn_row.finish());
+
+        // Error
+        if let Some(msg) = &self.save_error {
+            let err_color = warp_core::ui::theme::Fill::Solid(appearance.theme().ui_error_color());
+            col.add_child(
+                Container::new(
+                    Text::new(msg.clone(), appearance.ui_font_family(), 12.)
+                        .with_color(err_color.into())
+                        .finish(),
+                )
+                .with_margin_top(8.)
+                .finish(),
+            );
+        }
+
+        col.finish()
+    }
+}
+
+// ------------------------------------------------------------------
+// Entity / View / TypedActionView / BackingView
+// ------------------------------------------------------------------
+
+impl Entity for CustomRouterEditorView {
+    type Event = CustomRouterEditorEvent;
+}
+
+impl View for CustomRouterEditorView {
+    fn ui_name() -> &'static str {
+        "CustomRouterEditorView"
+    }
+
+    fn render(&self, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let content = Container::new(self.render_content(appearance, app))
+            .with_padding_top(24.)
+            .with_padding_bottom(24.)
+            .with_padding_left(24.)
+            .with_padding_right(24.)
+            .finish();
+        ClippedScrollable::vertical(
+            self.scroll_state.clone(),
+            content,
+            ScrollbarWidth::Auto,
+            appearance.theme().nonactive_ui_detail().into(),
+            appearance.theme().active_ui_detail().into(),
+            warpui::elements::Fill::None,
+        )
+        .finish()
+    }
+}
+
+impl TypedActionView for CustomRouterEditorView {
+    type Action = CustomRouterEditorAction;
+
+    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        match action {
+            CustomRouterEditorAction::Close => {
+                ctx.emit(CustomRouterEditorEvent::Pane(PaneEvent::Close));
+            }
+            CustomRouterEditorAction::Save => self.try_save(ctx),
+            CustomRouterEditorAction::Delete => self.try_delete(ctx),
+            CustomRouterEditorAction::SetRouterType(t) => {
+                self.router_type = *t;
+                ctx.notify();
+            }
+            CustomRouterEditorAction::SetComplexityDefault(id) => {
+                self.complexity_default = id.clone();
+            }
+            CustomRouterEditorAction::SetComplexityEasy(id) => {
+                self.complexity_easy = if id == INHERIT_DEFAULT {
+                    None
+                } else {
+                    Some(id.clone())
+                };
+            }
+            CustomRouterEditorAction::SetComplexityMedium(id) => {
+                self.complexity_medium = if id == INHERIT_DEFAULT {
+                    None
+                } else {
+                    Some(id.clone())
+                };
+            }
+            CustomRouterEditorAction::SetComplexityHard(id) => {
+                self.complexity_hard = if id == INHERIT_DEFAULT {
+                    None
+                } else {
+                    Some(id.clone())
+                };
+            }
+            CustomRouterEditorAction::SetPromptDefault(id) => {
+                self.prompt_default_model = id.clone();
+            }
+            CustomRouterEditorAction::SetPromptRuleModel { index, model_id } => {
+                if let Some(row) = self.prompt_rules.get_mut(*index) {
+                    row.current_model = model_id.clone();
+                }
+            }
+            CustomRouterEditorAction::AddPromptRule => self.add_prompt_rule(ctx),
+            CustomRouterEditorAction::RemovePromptRule(i) => self.remove_prompt_rule(*i, ctx),
+        }
+    }
+}
+
+impl BackingView for CustomRouterEditorView {
+    type PaneHeaderOverflowMenuAction = CustomRouterEditorAction;
+    type CustomAction = ();
+    type AssociatedData = ();
+
+    fn handle_pane_header_overflow_menu_action(
+        &mut self,
+        action: &Self::PaneHeaderOverflowMenuAction,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.handle_action(action, ctx);
+    }
+
+    fn close(&mut self, ctx: &mut ViewContext<Self>) {
+        ctx.emit(CustomRouterEditorEvent::Pane(PaneEvent::Close));
+    }
+
+    fn focus_contents(&mut self, ctx: &mut ViewContext<Self>) {
+        self.focus(ctx);
+    }
+
+    fn render_header_content(
+        &self,
+        _ctx: &view::HeaderRenderContext<'_>,
+        _app: &AppContext,
+    ) -> view::HeaderContent {
+        view::HeaderContent::Standard(view::StandardHeader {
+            title: HEADER_TEXT.into(),
+            title_secondary: None,
+            title_style: None,
+            title_clip_config: warpui::text_layout::ClipConfig::start(),
+            title_max_width: None,
+            left_of_title: None,
+            right_of_title: None,
+            left_of_overflow: None,
+            options: view::StandardHeaderOptions {
+                always_show_icons: true,
+                ..Default::default()
+            },
+        })
+    }
+
+    fn set_focus_handle(&mut self, focus_handle: PaneFocusHandle, _ctx: &mut ViewContext<Self>) {
+        self.focus_handle = Some(focus_handle);
+    }
+}
+
+// ------------------------------------------------------------------
+// Module-level helper functions
+// ------------------------------------------------------------------
+
+fn concrete_model_choices(ctx: &mut ViewContext<CustomRouterEditorView>) -> Vec<String> {
+    LLMPreferences::as_ref(ctx)
+        .get_base_llm_choices_for_agent_mode(ctx)
+        .filter(|llm| !is_auto_target(llm.id.as_str()))
+        .map(|llm| llm.id.to_string())
+        .collect()
+}
+
+fn make_model_dropdown<F>(
+    choices: &[String],
+    optional: bool,
+    selected: &str,
+    make_action: F,
+    ctx: &mut ViewContext<CustomRouterEditorView>,
+) -> ViewHandle<Dropdown<CustomRouterEditorAction>>
+where
+    F: Fn(String) -> CustomRouterEditorAction + 'static + Clone,
+{
+    let choices_owned = choices.to_vec();
+    let selected_owned = selected.to_string();
+    ctx.add_typed_action_view(move |ctx| {
+        let mut d = Dropdown::new(ctx);
+        fill_dropdown_items(
+            &mut d,
+            &choices_owned,
+            optional,
+            &selected_owned,
+            make_action.clone(),
+            ctx,
+        );
+        d
+    })
+}
+
+fn repopulate<F>(
+    dropdown: &ViewHandle<Dropdown<CustomRouterEditorAction>>,
+    choices: &[String],
+    optional: bool,
+    selected: &str,
+    make_action: F,
+    ctx: &mut ViewContext<CustomRouterEditorView>,
+) where
+    F: Fn(String) -> CustomRouterEditorAction + Clone,
+{
+    let choices_owned = choices.to_vec();
+    let selected_owned = selected.to_string();
+    dropdown.update(ctx, move |d, ctx| {
+        fill_dropdown_items(
+            d,
+            &choices_owned,
+            optional,
+            &selected_owned,
+            make_action.clone(),
+            ctx,
+        );
+    });
+}
+
+fn fill_dropdown_items<F>(
+    dropdown: &mut Dropdown<CustomRouterEditorAction>,
+    choices: &[String],
+    optional: bool,
+    selected: &str,
+    make_action: F,
+    ctx: &mut warpui::ViewContext<Dropdown<CustomRouterEditorAction>>,
+) where
+    F: Fn(String) -> CustomRouterEditorAction,
+{
+    let mut items: Vec<DropdownItem<CustomRouterEditorAction>> = Vec::new();
+    if optional {
+        items.push(DropdownItem::new(
+            "Inherit default",
+            make_action(INHERIT_DEFAULT.to_string()),
+        ));
+    }
+    for id in choices {
+        items.push(DropdownItem::new(id.clone(), make_action(id.clone())));
+    }
+    dropdown.set_items(items, ctx);
+    if selected.is_empty() || (optional && selected == INHERIT_DEFAULT) {
+        dropdown.set_selected_by_name("Inherit default", ctx);
+    } else {
+        dropdown.set_selected_by_name(selected, ctx);
+    }
+}
+
+fn make_prompt_rule_row(
+    index: usize,
+    description: &str,
+    model: &str,
+    choices: &[String],
+    ctx: &mut ViewContext<CustomRouterEditorView>,
+) -> PromptRuleRow {
+    let desc_owned = description.to_string();
+    let description_editor = ctx.add_view(move |ctx| {
+        let font_size = Appearance::as_ref(ctx).ui_font_size();
+        let mut editor = EditorView::single_line(
+            SingleLineEditorOptions {
+                text: TextOptions {
+                    font_size_override: Some(font_size),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ctx,
+        );
+        editor.set_placeholder_text("Describe when to use this model…", ctx);
+        if !desc_owned.is_empty() {
+            editor.set_buffer_text(&desc_owned, ctx);
+        }
+        editor
+    });
+
+    let model_dropdown = make_model_dropdown(
+        choices,
+        false,
+        model,
+        move |id| CustomRouterEditorAction::SetPromptRuleModel {
+            index,
+            model_id: id,
+        },
+        ctx,
+    );
+
+    PromptRuleRow {
+        description_editor,
+        model_dropdown,
+        remove_mouse_state: Default::default(),
+        current_model: model.to_string(),
+    }
+}
+
+fn editor_row(editor: &ViewHandle<EditorView>, appearance: &Appearance) -> Box<dyn Element> {
+    Container::new(ChildView::new(editor).finish())
+        .with_background(appearance.theme().surface_2())
+        .with_border(Border::new(1.).with_border_fill(appearance.theme().outline()))
+        .with_corner_radius(warpui::elements::CornerRadius::with_all(
+            warpui::elements::Radius::Pixels(4.),
+        ))
+        .with_horizontal_padding(8.)
+        .with_vertical_padding(6.)
+        .finish()
+}
+
+fn labeled_dropdown(
+    label: impl Into<String>,
+    dropdown: &ViewHandle<Dropdown<CustomRouterEditorAction>>,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    let sub = appearance
+        .theme()
+        .sub_text_color(appearance.theme().surface_1());
+    Flex::column()
+        .with_child(
+            Container::new(
+                Text::new(label.into(), appearance.ui_font_family(), 11.)
+                    .with_color(sub.into())
+                    .finish(),
+            )
+            .with_margin_bottom(2.)
+            .finish(),
+        )
+        .with_child(
+            ConstrainedBox::new(ChildView::new(dropdown).finish())
+                .with_width(EDITOR_CONTENT_WIDTH)
+                .finish(),
+        )
+        .finish()
+}
+
+fn render_rule_row(index: usize, row: &PromptRuleRow, appearance: &Appearance) -> Box<dyn Element> {
+    let sub = appearance
+        .theme()
+        .sub_text_color(appearance.theme().surface_2());
+    let icon_color = sub;
+    let idx = index;
+    let remove_state = row.remove_mouse_state.clone();
+
+    let remove_btn = Hoverable::new(remove_state, move |_| {
+        ConstrainedBox::new(Icon::X.to_warpui_icon(icon_color).finish())
+            .with_width(14.)
+            .with_height(14.)
+            .finish()
+    })
+    .on_click(move |ctx, _app, _pos| {
+        ctx.dispatch_typed_action(CustomRouterEditorAction::RemovePromptRule(idx));
+    })
+    .finish();
+
+    let desc_label_str = "Description".to_string();
+    let model_label_str = "Model".to_string();
+
+    Flex::row()
+        .with_main_axis_size(MainAxisSize::Max)
+        .with_cross_axis_alignment(CrossAxisAlignment::Start)
+        .with_child(
+            Expanded::new(
+                1.,
+                Flex::column()
+                    .with_child(
+                        Container::new(
+                            Flex::column()
+                                .with_child(
+                                    Container::new(
+                                        Text::new(
+                                            desc_label_str.clone(),
+                                            appearance.ui_font_family(),
+                                            11.,
+                                        )
+                                        .with_color(sub.into())
+                                        .finish(),
+                                    )
+                                    .with_margin_bottom(2.)
+                                    .finish(),
+                                )
+                                .with_child(editor_row(&row.description_editor, appearance))
+                                .finish(),
+                        )
+                        .with_margin_bottom(4.)
+                        .finish(),
+                    )
+                    .with_child(
+                        Flex::column()
+                            .with_child(
+                                Container::new(
+                                    Text::new(
+                                        model_label_str.clone(),
+                                        appearance.ui_font_family(),
+                                        11.,
+                                    )
+                                    .with_color(sub.into())
+                                    .finish(),
+                                )
+                                .with_margin_bottom(2.)
+                                .finish(),
+                            )
+                            .with_child(
+                                ConstrainedBox::new(ChildView::new(&row.model_dropdown).finish())
+                                    .with_width(EDITOR_CONTENT_WIDTH)
+                                    .finish(),
+                            )
+                            .finish(),
+                    )
+                    .finish(),
+            )
+            .finish(),
+        )
+        .with_child(
+            Container::new(remove_btn)
+                .with_margin_left(8.)
+                .with_margin_top(20.)
+                .finish(),
+        )
+        .finish()
+}

--- a/app/src/ai/custom_model_router_editor.rs
+++ b/app/src/ai/custom_model_router_editor.rs
@@ -378,10 +378,20 @@ impl CustomRouterEditorView {
 
         let routing = match self.router_type {
             RouterEditorType::Complexity => {
-                if self.complexity_default.is_empty() {
-                    self.save_error = Some("A default model is required.".to_string());
-                    ctx.notify();
-                    return;
+                for (field, val) in [
+                    ("Default", self.complexity_default.as_str()),
+                    ("Easy", self.complexity_easy.as_deref().unwrap_or_default()),
+                    (
+                        "Medium",
+                        self.complexity_medium.as_deref().unwrap_or_default(),
+                    ),
+                    ("Hard", self.complexity_hard.as_deref().unwrap_or_default()),
+                ] {
+                    if val.is_empty() {
+                        self.save_error = Some(format!("{field} model is required."));
+                        ctx.notify();
+                        return;
+                    }
                 }
                 CustomModelRouting::Complexity(ComplexityRouting {
                     default: self.complexity_default.clone(),
@@ -513,7 +523,7 @@ impl CustomRouterEditorView {
             ))
             .with_child(
                 Container::new(labeled_dropdown(
-                    "Easy (optional)",
+                    "Easy (required)",
                     &self.complexity_easy_dropdown,
                     appearance,
                 ))
@@ -522,7 +532,7 @@ impl CustomRouterEditorView {
             )
             .with_child(
                 Container::new(labeled_dropdown(
-                    "Medium (optional)",
+                    "Medium (required)",
                     &self.complexity_medium_dropdown,
                     appearance,
                 ))
@@ -531,7 +541,7 @@ impl CustomRouterEditorView {
             )
             .with_child(
                 Container::new(labeled_dropdown(
-                    "Hard (optional)",
+                    "Hard (required)",
                     &self.complexity_hard_dropdown,
                     appearance,
                 ))

--- a/app/src/ai/custom_model_router_editor.rs
+++ b/app/src/ai/custom_model_router_editor.rs
@@ -10,7 +10,6 @@ use warpui::elements::{
     CrossAxisAlignment, Expanded, Flex, Hoverable, MainAxisAlignment, MainAxisSize,
     MouseStateHandle, ParentElement, ScrollbarWidth, Text,
 };
-use warpui::fonts::{Properties, Weight};
 use warpui::platform::Cursor;
 use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
 use warpui::{
@@ -24,6 +23,7 @@ use crate::ai::custom_model_routers::{
 use crate::ai::execution_profiles::model_menu_items::available_model_menu_items;
 use crate::ai::llms::{LLMPreferences, LLMPreferencesEvent};
 use crate::appearance::Appearance;
+use crate::auth::AuthStateProvider;
 use crate::editor::{EditorView, SingleLineEditorOptions, TextOptions};
 use crate::pane_group::focus_state::PaneFocusHandle;
 use crate::pane_group::pane::view;
@@ -31,7 +31,7 @@ use crate::pane_group::{BackingView, PaneConfiguration, PaneEvent};
 use crate::ui_components::icons::Icon;
 use crate::user_config::WarpConfig;
 use crate::view_components::action_button::{
-    ActionButton, ButtonSize, DangerSecondaryTheme, PrimaryTheme, SecondaryTheme,
+    ActionButton, ButtonSize, PrimaryTheme, SecondaryTheme,
 };
 use crate::view_components::dropdown::DropdownAction;
 use crate::view_components::{Dropdown, DropdownItem, FilterableDropdown};
@@ -63,7 +63,6 @@ pub enum CustomRouterEditorEvent {
 pub enum CustomRouterEditorAction {
     Close,
     Save,
-    Delete,
     SetRouterType(RouterEditorType),
     SetComplexityDefault(String),
     SetComplexityEasy(String),
@@ -118,7 +117,6 @@ pub struct CustomRouterEditorView {
 
     save_button: ViewHandle<ActionButton>,
     cancel_button: ViewHandle<ActionButton>,
-    delete_button: ViewHandle<ActionButton>,
     add_rule_button: ViewHandle<ActionButton>,
 
     upgrade_footer_mouse_state: MouseStateHandle,
@@ -163,7 +161,16 @@ impl CustomRouterEditorView {
             .as_ref()
             .map(|r| r.info.display_name.clone())
             .unwrap_or_default();
-        let is_editing = existing.is_some();
+        // Personalize the placeholder with the user's first name (derived from
+        // their display name), falling back to a generic placeholder when no
+        // name is available.
+        let name_placeholder = AuthStateProvider::as_ref(ctx)
+            .get()
+            .display_name()
+            .as_deref()
+            .and_then(|name| name.split_whitespace().next())
+            .map(|first_name| format!("{first_name}'s new model"))
+            .unwrap_or_else(|| "My new model".to_string());
         let name_editor = ctx.add_view(move |ctx| {
             let font_size = Appearance::as_ref(ctx).ui_font_size();
             let mut editor = EditorView::single_line(
@@ -176,13 +183,9 @@ impl CustomRouterEditorView {
                 },
                 ctx,
             );
-            editor.set_placeholder_text("e.g. \"my-router\"", ctx);
+            editor.set_placeholder_text(&name_placeholder, ctx);
             if !initial_name.is_empty() {
                 editor.set_buffer_text(&initial_name, ctx);
-            }
-            if is_editing {
-                // Make read-only: Selectable = can navigate/copy but not edit
-                editor.set_interaction_state(crate::editor::InteractionState::Selectable, ctx);
             }
             editor
         });
@@ -281,15 +284,10 @@ impl CustomRouterEditorView {
                 .with_size(ButtonSize::Small)
                 .on_click(|ctx| ctx.dispatch_typed_action(CustomRouterEditorAction::Close))
         });
-        let delete_button = ctx.add_typed_action_view(|_| {
-            ActionButton::new("Delete router", DangerSecondaryTheme)
-                .with_icon(Icon::Trash)
-                .with_size(ButtonSize::Small)
-                .on_click(|ctx| ctx.dispatch_typed_action(CustomRouterEditorAction::Delete))
-        });
         let add_rule_button = ctx.add_typed_action_view(|_| {
             ActionButton::new("+ Add rule", SecondaryTheme)
                 .with_size(ButtonSize::Small)
+                .with_full_width(true)
                 .on_click(|ctx| ctx.dispatch_typed_action(CustomRouterEditorAction::AddPromptRule))
         });
 
@@ -314,7 +312,6 @@ impl CustomRouterEditorView {
             prompt_rules,
             save_button,
             cancel_button,
-            delete_button,
             add_rule_button,
             upgrade_footer_mouse_state,
             save_error: None,
@@ -505,18 +502,6 @@ impl CustomRouterEditorView {
         ctx.emit(CustomRouterEditorEvent::Pane(PaneEvent::Close));
     }
 
-    fn try_delete(&mut self, ctx: &mut ViewContext<Self>) {
-        if let Some(path) = self.existing.as_ref().and_then(|r| r.source_path.as_ref()) {
-            #[cfg(feature = "local_fs")]
-            if let Err(e) = WarpConfig::delete_custom_model_router(path) {
-                self.save_error = Some(format!("Delete error: {e}"));
-                ctx.notify();
-                return;
-            }
-        }
-        ctx.emit(CustomRouterEditorEvent::Pane(PaneEvent::Close));
-    }
-
     fn add_prompt_rule(&mut self, ctx: &mut ViewContext<Self>) {
         let index = self.prompt_rules.len();
         let ms = self.upgrade_footer_mouse_state.clone();
@@ -573,16 +558,12 @@ impl CustomRouterEditorView {
     // Rendering
     // ------------------------------------------------------------------
 
+    /// A section header label, styled to match the field headers in the
+    /// execution profile editor (sentence case, active text color).
     fn section_label(label: impl Into<String>, appearance: &Appearance) -> Box<dyn Element> {
         Container::new(
-            Text::new(label.into(), appearance.ui_font_family(), 11.)
-                .with_style(Properties::default().weight(Weight::Medium))
-                .with_color(
-                    appearance
-                        .theme()
-                        .sub_text_color(appearance.theme().surface_1())
-                        .into(),
-                )
+            Text::new(label.into(), appearance.ui_font_family(), 13.)
+                .with_color(appearance.theme().active_ui_text_color().into())
                 .finish(),
         )
         .with_margin_bottom(4.)
@@ -591,7 +572,7 @@ impl CustomRouterEditorView {
 
     fn render_complexity_section(&self, appearance: &Appearance) -> Box<dyn Element> {
         Flex::column()
-            .with_child(Self::section_label("MODELS", appearance))
+            .with_child(Self::section_label("Models", appearance))
             .with_child(labeled_dropdown(
                 "Default (required)",
                 &self.complexity_default_dropdown,
@@ -637,7 +618,7 @@ impl CustomRouterEditorView {
             .sub_text_color(appearance.theme().surface_1());
 
         let mut column = Flex::column()
-            .with_child(Self::section_label("DEFAULT MODEL", appearance))
+            .with_child(Self::section_label("Default model", appearance))
             .with_child(
                 ConstrainedBox::new(ChildView::new(&self.prompt_default_dropdown).finish())
                     .with_width(EDITOR_CONTENT_WIDTH)
@@ -646,7 +627,7 @@ impl CustomRouterEditorView {
 
         if !self.prompt_rules.is_empty() {
             column.add_child(
-                Container::new(Self::section_label("RULES".to_string(), appearance))
+                Container::new(Self::section_label("Rules".to_string(), appearance))
                     .with_margin_top(12.)
                     .finish(),
             );
@@ -679,10 +660,17 @@ impl CustomRouterEditorView {
             }
         }
 
+        // The add-rule button spans the full width of the rule rows above it.
         column.add_child(
-            Container::new(ChildView::new(&self.add_rule_button).finish())
-                .with_margin_top(8.)
-                .finish(),
+            Container::new(
+                Flex::row()
+                    .with_main_axis_size(MainAxisSize::Max)
+                    .with_child(
+                        Expanded::new(1., ChildView::new(&self.add_rule_button).finish()).finish(),
+                    )
+                    .finish(),
+            )
+            .finish(),
         );
         column.finish()
     }
@@ -691,15 +679,10 @@ impl CustomRouterEditorView {
         let mut col = Flex::column();
 
         // Name
-        let name_label = if self.existing.is_some() {
-            "NAME (read-only)"
-        } else {
-            "NAME"
-        };
         col.add_child(
             Container::new(
                 Flex::column()
-                    .with_child(Self::section_label(name_label, appearance))
+                    .with_child(Self::section_label("Name", appearance))
                     .with_child(
                         ConstrainedBox::new(editor_row(&self.name_editor, None, appearance))
                             .with_width(EDITOR_CONTENT_WIDTH)
@@ -726,7 +709,20 @@ impl CustomRouterEditorView {
         col.add_child(
             Container::new(
                 Flex::column()
-                    .with_child(Self::section_label("ROUTING TYPE", appearance))
+                    .with_child(Self::section_label("Routing type", appearance))
+                    .with_child(
+                        Container::new(
+                            Text::new(
+                                "Choose how you want your custom model router to work.",
+                                appearance.ui_font_family(),
+                                11.,
+                            )
+                            .with_color(desc_color.into())
+                            .finish(),
+                        )
+                        .with_margin_bottom(6.)
+                        .finish(),
+                    )
                     .with_child(
                         ConstrainedBox::new(ChildView::new(&self.type_dropdown).finish())
                             .with_width(EDITOR_CONTENT_WIDTH)
@@ -765,22 +761,17 @@ impl CustomRouterEditorView {
             }
         }
 
-        // Buttons
-        let mut btn_row = Flex::row()
+        // Buttons: right-aligned, with Cancel to the left of Save.
+        let btn_row = Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::End)
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_child(
-                Container::new(ChildView::new(&self.save_button).finish())
+                Container::new(ChildView::new(&self.cancel_button).finish())
                     .with_margin_right(8.)
                     .finish(),
             )
-            .with_child(ChildView::new(&self.cancel_button).finish());
-        if self.existing.is_some() {
-            btn_row.add_child(
-                Container::new(ChildView::new(&self.delete_button).finish())
-                    .with_margin_left(16.)
-                    .finish(),
-            );
-        }
+            .with_child(ChildView::new(&self.save_button).finish());
         col.add_child(btn_row.finish());
 
         // Error
@@ -843,7 +834,6 @@ impl TypedActionView for CustomRouterEditorView {
                 ctx.emit(CustomRouterEditorEvent::Pane(PaneEvent::Close));
             }
             CustomRouterEditorAction::Save => self.try_save(ctx),
-            CustomRouterEditorAction::Delete => self.try_delete(ctx),
             CustomRouterEditorAction::SetRouterType(t) => {
                 self.router_type = *t;
                 // Prompt routing requires at least one rule; ensure a row exists

--- a/app/src/ai/custom_model_router_editor.rs
+++ b/app/src/ai/custom_model_router_editor.rs
@@ -4,6 +4,7 @@
 //! "Add router" or "Edit" on an existing router card. Writes changes to
 //! `~/.warp/custom_model_routers/` via [`WarpConfig::save_custom_model_router`].
 
+use itertools::Itertools;
 use warpui::elements::{
     Border, ChildView, ClippedScrollStateHandle, ClippedScrollable, ConstrainedBox, Container,
     CrossAxisAlignment, Expanded, Flex, Hoverable, MainAxisSize, MouseStateHandle, ParentElement,
@@ -18,6 +19,7 @@ use crate::ai::custom_model_routers::{
     is_auto_target, ComplexityRouting, CustomModelRouter, CustomModelRouting, PromptRouting,
     PromptRule,
 };
+use crate::ai::execution_profiles::model_menu_items::available_model_menu_items;
 use crate::ai::llms::{LLMPreferences, LLMPreferencesEvent};
 use crate::appearance::Appearance;
 use crate::editor::{EditorView, SingleLineEditorOptions, TextOptions};
@@ -29,15 +31,13 @@ use crate::user_config::WarpConfig;
 use crate::view_components::action_button::{
     ActionButton, ButtonSize, DangerSecondaryTheme, PrimaryTheme, SecondaryTheme,
 };
-use crate::view_components::{Dropdown, DropdownItem};
+use crate::view_components::dropdown::DropdownAction;
+use crate::view_components::{Dropdown, DropdownItem, FilterableDropdown};
 
 pub const HEADER_TEXT: &str = "Router Editor";
 
 const EDITOR_CONTENT_WIDTH: f32 = 340.;
-
-/// Sentinel used as the dropdown selection for "inherit default" in optional
-/// complexity-bucket dropdowns.
-const INHERIT_DEFAULT: &str = "__inherit_default__";
+const MODEL_MENU_WIDTH: f32 = 340.;
 
 #[derive(Debug, Clone)]
 pub enum CustomRouterEditorEvent {
@@ -68,7 +68,7 @@ pub enum RouterEditorType {
 
 struct PromptRuleRow {
     description_editor: ViewHandle<EditorView>,
-    model_dropdown: ViewHandle<Dropdown<CustomRouterEditorAction>>,
+    model_dropdown: ViewHandle<FilterableDropdown<CustomRouterEditorAction>>,
     remove_mouse_state: MouseStateHandle,
     current_model: String,
 }
@@ -83,17 +83,17 @@ pub struct CustomRouterEditorView {
     router_type: RouterEditorType,
     type_dropdown: ViewHandle<Dropdown<CustomRouterEditorAction>>,
 
-    complexity_default_dropdown: ViewHandle<Dropdown<CustomRouterEditorAction>>,
-    complexity_easy_dropdown: ViewHandle<Dropdown<CustomRouterEditorAction>>,
-    complexity_medium_dropdown: ViewHandle<Dropdown<CustomRouterEditorAction>>,
-    complexity_hard_dropdown: ViewHandle<Dropdown<CustomRouterEditorAction>>,
+    complexity_default_dropdown: ViewHandle<FilterableDropdown<CustomRouterEditorAction>>,
+    complexity_easy_dropdown: ViewHandle<FilterableDropdown<CustomRouterEditorAction>>,
+    complexity_medium_dropdown: ViewHandle<FilterableDropdown<CustomRouterEditorAction>>,
+    complexity_hard_dropdown: ViewHandle<FilterableDropdown<CustomRouterEditorAction>>,
 
     complexity_default: String,
     complexity_easy: Option<String>,
     complexity_medium: Option<String>,
     complexity_hard: Option<String>,
 
-    prompt_default_dropdown: ViewHandle<Dropdown<CustomRouterEditorAction>>,
+    prompt_default_dropdown: ViewHandle<FilterableDropdown<CustomRouterEditorAction>>,
     prompt_default_model: String,
     prompt_rules: Vec<PromptRuleRow>,
 
@@ -101,6 +101,7 @@ pub struct CustomRouterEditorView {
     cancel_button: ViewHandle<ActionButton>,
     delete_button: ViewHandle<ActionButton>,
 
+    upgrade_footer_mouse_state: MouseStateHandle,
     save_error: Option<String>,
 }
 
@@ -196,49 +197,52 @@ impl CustomRouterEditorView {
             d
         });
 
-        // Model choices (concrete, non-auto)
-        let choices = concrete_model_choices(ctx);
+        // Model dropdowns — searchable, with icons and display names.
+        let upgrade_footer_mouse_state = MouseStateHandle::default();
 
-        let complexity_default_dropdown = make_model_dropdown(
-            &choices,
-            false,
+        let complexity_default_dropdown = make_filterable_model_dropdown(
             &init_cdefault,
             CustomRouterEditorAction::SetComplexityDefault,
+            &upgrade_footer_mouse_state,
             ctx,
         );
-        let complexity_easy_dropdown = make_model_dropdown(
-            &choices,
-            true,
-            init_ceasy.as_deref().unwrap_or(INHERIT_DEFAULT),
+        let complexity_easy_dropdown = make_filterable_model_dropdown(
+            init_ceasy.as_deref().unwrap_or_default(),
             CustomRouterEditorAction::SetComplexityEasy,
+            &upgrade_footer_mouse_state,
             ctx,
         );
-        let complexity_medium_dropdown = make_model_dropdown(
-            &choices,
-            true,
-            init_cmedium.as_deref().unwrap_or(INHERIT_DEFAULT),
+        let complexity_medium_dropdown = make_filterable_model_dropdown(
+            init_cmedium.as_deref().unwrap_or_default(),
             CustomRouterEditorAction::SetComplexityMedium,
+            &upgrade_footer_mouse_state,
             ctx,
         );
-        let complexity_hard_dropdown = make_model_dropdown(
-            &choices,
-            true,
-            init_chard.as_deref().unwrap_or(INHERIT_DEFAULT),
+        let complexity_hard_dropdown = make_filterable_model_dropdown(
+            init_chard.as_deref().unwrap_or_default(),
             CustomRouterEditorAction::SetComplexityHard,
+            &upgrade_footer_mouse_state,
             ctx,
         );
-        let prompt_default_dropdown = make_model_dropdown(
-            &choices,
-            false,
+        let prompt_default_dropdown = make_filterable_model_dropdown(
             &init_pdefault,
             CustomRouterEditorAction::SetPromptDefault,
+            &upgrade_footer_mouse_state,
             ctx,
         );
 
         let prompt_rules = init_prules
             .iter()
             .enumerate()
-            .map(|(i, rule)| make_prompt_rule_row(i, &rule.description, &rule.model, &choices, ctx))
+            .map(|(i, rule)| {
+                make_prompt_rule_row(
+                    i,
+                    &rule.description,
+                    &rule.model,
+                    &upgrade_footer_mouse_state,
+                    ctx,
+                )
+            })
             .collect();
 
         let save_button = ctx.add_typed_action_view(|_| {
@@ -280,6 +284,7 @@ impl CustomRouterEditorView {
             save_button,
             cancel_button,
             delete_button,
+            upgrade_footer_mouse_state,
             save_error: None,
         };
 
@@ -303,73 +308,52 @@ impl CustomRouterEditorView {
     // ------------------------------------------------------------------
 
     fn refresh_all_model_dropdowns(&mut self, ctx: &mut ViewContext<Self>) {
-        let choices = concrete_model_choices(ctx);
-        repopulate(
+        let ms = self.upgrade_footer_mouse_state.clone();
+        repopulate_filterable(
             &self.complexity_default_dropdown,
-            &choices,
-            false,
             &self.complexity_default,
             CustomRouterEditorAction::SetComplexityDefault,
+            &ms,
             ctx,
         );
-        let easy = self
-            .complexity_easy
-            .as_deref()
-            .unwrap_or(INHERIT_DEFAULT)
-            .to_string();
-        repopulate(
+        repopulate_filterable(
             &self.complexity_easy_dropdown,
-            &choices,
-            true,
-            &easy,
+            self.complexity_easy.as_deref().unwrap_or_default(),
             CustomRouterEditorAction::SetComplexityEasy,
+            &ms,
             ctx,
         );
-        let med = self
-            .complexity_medium
-            .as_deref()
-            .unwrap_or(INHERIT_DEFAULT)
-            .to_string();
-        repopulate(
+        repopulate_filterable(
             &self.complexity_medium_dropdown,
-            &choices,
-            true,
-            &med,
+            self.complexity_medium.as_deref().unwrap_or_default(),
             CustomRouterEditorAction::SetComplexityMedium,
+            &ms,
             ctx,
         );
-        let hard = self
-            .complexity_hard
-            .as_deref()
-            .unwrap_or(INHERIT_DEFAULT)
-            .to_string();
-        repopulate(
+        repopulate_filterable(
             &self.complexity_hard_dropdown,
-            &choices,
-            true,
-            &hard,
+            self.complexity_hard.as_deref().unwrap_or_default(),
             CustomRouterEditorAction::SetComplexityHard,
+            &ms,
             ctx,
         );
-        repopulate(
+        repopulate_filterable(
             &self.prompt_default_dropdown,
-            &choices,
-            false,
             &self.prompt_default_model,
             CustomRouterEditorAction::SetPromptDefault,
+            &ms,
             ctx,
         );
         for (i, row) in self.prompt_rules.iter_mut().enumerate() {
             let sel = row.current_model.clone();
-            repopulate(
+            repopulate_filterable(
                 &row.model_dropdown,
-                &choices,
-                false,
                 &sel,
                 move |id| CustomRouterEditorAction::SetPromptRuleModel {
                     index: i,
                     model_id: id,
                 },
+                &ms,
                 ctx,
             );
         }
@@ -485,9 +469,9 @@ impl CustomRouterEditorView {
     }
 
     fn add_prompt_rule(&mut self, ctx: &mut ViewContext<Self>) {
-        let choices = concrete_model_choices(ctx);
         let index = self.prompt_rules.len();
-        let row = make_prompt_rule_row(index, "", "", &choices, ctx);
+        let ms = self.upgrade_footer_mouse_state.clone();
+        let row = make_prompt_rule_row(index, "", "", &ms, ctx);
         self.prompt_rules.push(row);
         ctx.notify();
     }
@@ -746,25 +730,13 @@ impl TypedActionView for CustomRouterEditorView {
                 self.complexity_default = id.clone();
             }
             CustomRouterEditorAction::SetComplexityEasy(id) => {
-                self.complexity_easy = if id == INHERIT_DEFAULT {
-                    None
-                } else {
-                    Some(id.clone())
-                };
+                self.complexity_easy = Some(id.clone());
             }
             CustomRouterEditorAction::SetComplexityMedium(id) => {
-                self.complexity_medium = if id == INHERIT_DEFAULT {
-                    None
-                } else {
-                    Some(id.clone())
-                };
+                self.complexity_medium = Some(id.clone());
             }
             CustomRouterEditorAction::SetComplexityHard(id) => {
-                self.complexity_hard = if id == INHERIT_DEFAULT {
-                    None
-                } else {
-                    Some(id.clone())
-                };
+                self.complexity_hard = Some(id.clone());
             }
             CustomRouterEditorAction::SetPromptDefault(id) => {
                 self.prompt_default_model = id.clone();
@@ -831,97 +803,82 @@ impl BackingView for CustomRouterEditorView {
 // Module-level helper functions
 // ------------------------------------------------------------------
 
-fn concrete_model_choices(ctx: &mut ViewContext<CustomRouterEditorView>) -> Vec<String> {
-    LLMPreferences::as_ref(ctx)
-        .get_base_llm_choices_for_agent_mode(ctx)
-        .filter(|llm| !is_auto_target(llm.id.as_str()))
-        .map(|llm| llm.id.to_string())
-        .collect()
-}
-
-fn make_model_dropdown<F>(
-    choices: &[String],
-    optional: bool,
-    selected: &str,
+/// Creates and populates a [`FilterableDropdown`] for model selection.
+///
+/// Items are built via [`available_model_menu_items`] so they carry provider
+/// icons and display names. The current selection is restored by action.
+fn make_filterable_model_dropdown<F>(
+    selected_id: &str,
     make_action: F,
+    upgrade_mouse_state: &MouseStateHandle,
     ctx: &mut ViewContext<CustomRouterEditorView>,
-) -> ViewHandle<Dropdown<CustomRouterEditorAction>>
+) -> ViewHandle<FilterableDropdown<CustomRouterEditorAction>>
 where
     F: Fn(String) -> CustomRouterEditorAction + 'static + Clone,
 {
-    let choices_owned = choices.to_vec();
-    let selected_owned = selected.to_string();
+    let selected_owned = selected_id.to_string();
+    let ms = upgrade_mouse_state.clone();
     ctx.add_typed_action_view(move |ctx| {
-        let mut d = Dropdown::new(ctx);
-        fill_dropdown_items(
-            &mut d,
-            &choices_owned,
-            optional,
-            &selected_owned,
-            make_action.clone(),
-            ctx,
-        );
+        let mut d = FilterableDropdown::new(ctx);
+        d.set_menu_width(MODEL_MENU_WIDTH, ctx);
+        fill_filterable_dropdown(ctx, &mut d, &selected_owned, make_action.clone(), &ms);
         d
     })
 }
 
-fn repopulate<F>(
-    dropdown: &ViewHandle<Dropdown<CustomRouterEditorAction>>,
-    choices: &[String],
-    optional: bool,
-    selected: &str,
+/// Repopulates an existing [`FilterableDropdown`] after model choices change.
+fn repopulate_filterable<F>(
+    dropdown: &ViewHandle<FilterableDropdown<CustomRouterEditorAction>>,
+    selected_id: &str,
     make_action: F,
+    upgrade_mouse_state: &MouseStateHandle,
     ctx: &mut ViewContext<CustomRouterEditorView>,
 ) where
     F: Fn(String) -> CustomRouterEditorAction + Clone,
 {
-    let choices_owned = choices.to_vec();
-    let selected_owned = selected.to_string();
+    let selected_owned = selected_id.to_string();
+    let ms = upgrade_mouse_state.clone();
     dropdown.update(ctx, move |d, ctx| {
-        fill_dropdown_items(
-            d,
-            &choices_owned,
-            optional,
-            &selected_owned,
-            make_action.clone(),
-            ctx,
-        );
+        fill_filterable_dropdown(ctx, d, &selected_owned, make_action.clone(), &ms);
     });
 }
 
-fn fill_dropdown_items<F>(
-    dropdown: &mut Dropdown<CustomRouterEditorAction>,
-    choices: &[String],
-    optional: bool,
-    selected: &str,
+/// Inner helper: fills a [`FilterableDropdown`] with rich model items.
+fn fill_filterable_dropdown<F>(
+    ctx: &mut warpui::ViewContext<FilterableDropdown<CustomRouterEditorAction>>,
+    dropdown: &mut FilterableDropdown<CustomRouterEditorAction>,
+    selected_id: &str,
     make_action: F,
-    ctx: &mut warpui::ViewContext<Dropdown<CustomRouterEditorAction>>,
+    upgrade_mouse_state: &MouseStateHandle,
 ) where
-    F: Fn(String) -> CustomRouterEditorAction,
+    F: Fn(String) -> CustomRouterEditorAction + Clone,
 {
-    let mut items: Vec<DropdownItem<CustomRouterEditorAction>> = Vec::new();
-    if optional {
-        items.push(DropdownItem::new(
-            "Inherit default",
-            make_action(INHERIT_DEFAULT.to_string()),
-        ));
+    let items = available_model_menu_items(
+        LLMPreferences::as_ref(ctx)
+            .get_base_llm_choices_for_agent_mode(ctx)
+            .filter(|llm| !is_auto_target(llm.id.as_str()))
+            .collect_vec(),
+        |llm| DropdownAction::select_action_and_close(make_action(llm.id.to_string())),
+        None,
+        None,
+        false,
+        false,
+        ctx,
+    );
+    dropdown.set_rich_items(items, ctx);
+    dropdown.clear_footer(ctx);
+
+    if !selected_id.is_empty() {
+        dropdown.set_selected_by_action(make_action(selected_id.to_string()), ctx);
     }
-    for id in choices {
-        items.push(DropdownItem::new(id.clone(), make_action(id.clone())));
-    }
-    dropdown.set_items(items, ctx);
-    if selected.is_empty() || (optional && selected == INHERIT_DEFAULT) {
-        dropdown.set_selected_by_name("Inherit default", ctx);
-    } else {
-        dropdown.set_selected_by_name(selected, ctx);
-    }
+    let _ = upgrade_mouse_state; // reserved for future upgrade footer
 }
 
 fn make_prompt_rule_row(
     index: usize,
     description: &str,
     model: &str,
-    choices: &[String],
+    upgrade_mouse_state: &MouseStateHandle,
     ctx: &mut ViewContext<CustomRouterEditorView>,
 ) -> PromptRuleRow {
     let desc_owned = description.to_string();
@@ -937,21 +894,20 @@ fn make_prompt_rule_row(
             },
             ctx,
         );
-        editor.set_placeholder_text("Describe when to use this model…", ctx);
+        editor.set_placeholder_text("Describe when to use this model\u{2026}", ctx);
         if !desc_owned.is_empty() {
             editor.set_buffer_text(&desc_owned, ctx);
         }
         editor
     });
 
-    let model_dropdown = make_model_dropdown(
-        choices,
-        false,
+    let model_dropdown = make_filterable_model_dropdown(
         model,
         move |id| CustomRouterEditorAction::SetPromptRuleModel {
             index,
             model_id: id,
         },
+        upgrade_mouse_state,
         ctx,
     );
 
@@ -977,7 +933,7 @@ fn editor_row(editor: &ViewHandle<EditorView>, appearance: &Appearance) -> Box<d
 
 fn labeled_dropdown(
     label: impl Into<String>,
-    dropdown: &ViewHandle<Dropdown<CustomRouterEditorAction>>,
+    dropdown: &ViewHandle<FilterableDropdown<CustomRouterEditorAction>>,
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     let sub = appearance

--- a/app/src/ai/custom_model_router_editor.rs
+++ b/app/src/ai/custom_model_router_editor.rs
@@ -29,6 +29,7 @@ use crate::pane_group::focus_state::PaneFocusHandle;
 use crate::pane_group::pane::view;
 use crate::pane_group::{BackingView, PaneConfiguration, PaneEvent};
 use crate::ui_components::icons::Icon;
+#[cfg(feature = "local_fs")]
 use crate::user_config::WarpConfig;
 use crate::view_components::action_button::{
     ActionButton, ButtonSize, PrimaryTheme, SecondaryTheme,
@@ -479,17 +480,16 @@ impl CustomRouterEditorView {
             return;
         }
 
-        let yaml = match router.to_yaml_string() {
-            Ok(y) => y,
-            Err(e) => {
-                self.save_error = Some(format!("Serialization: {e}"));
-                ctx.notify();
-                return;
-            }
-        };
-
         #[cfg(feature = "local_fs")]
         {
+            let yaml = match router.to_yaml_string() {
+                Ok(y) => y,
+                Err(e) => {
+                    self.save_error = Some(format!("Serialization: {e}"));
+                    ctx.notify();
+                    return;
+                }
+            };
             let ep = self.existing.as_ref().and_then(|r| r.source_path.clone());
             if let Err(e) = WarpConfig::save_custom_model_router(&name, &yaml, ep.as_deref()) {
                 self.save_error = Some(format!("Write error: {e}"));

--- a/app/src/ai/custom_model_router_editor.rs
+++ b/app/src/ai/custom_model_router_editor.rs
@@ -6,11 +6,13 @@
 
 use itertools::Itertools;
 use warpui::elements::{
-    Border, ChildView, ClippedScrollStateHandle, ClippedScrollable, ConstrainedBox, Container,
-    CrossAxisAlignment, Expanded, Flex, Hoverable, MainAxisSize, MouseStateHandle, ParentElement,
-    ScrollbarWidth, Text,
+    ChildView, ClippedScrollStateHandle, ClippedScrollable, ConstrainedBox, Container,
+    CrossAxisAlignment, Expanded, Flex, Hoverable, MainAxisAlignment, MainAxisSize,
+    MouseStateHandle, ParentElement, ScrollbarWidth, Text,
 };
 use warpui::fonts::{Properties, Weight};
+use warpui::platform::Cursor;
+use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
 use warpui::{
     AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext, ViewHandle,
 };
@@ -39,6 +41,19 @@ pub const HEADER_TEXT: &str = "Router Editor";
 const EDITOR_CONTENT_WIDTH: f32 = 340.;
 const MODEL_MENU_WIDTH: f32 = 340.;
 
+/// Empty placeholder shown in a model dropdown when no model has been chosen
+/// yet, so new routers start blank instead of defaulting to the first available
+/// model. The empty string prevents auto-selection of the first item while
+/// preserving the blank appearance.
+const MODEL_PLACEHOLDER: &str = "";
+
+/// Height of the description input and model dropdown within a prompt rule row.
+/// Both fields are forced to this exact height so they line up visually.
+const RULE_FIELD_HEIGHT: f32 = 34.;
+
+/// Size (width/height) of the reorder/remove icon buttons in a rule row.
+const RULE_ICON_BUTTON_SIZE: f32 = 14.;
+
 #[derive(Debug, Clone)]
 pub enum CustomRouterEditorEvent {
     Pane(PaneEvent),
@@ -58,6 +73,8 @@ pub enum CustomRouterEditorAction {
     SetPromptRuleModel { index: usize, model_id: String },
     AddPromptRule,
     RemovePromptRule(usize),
+    MovePromptRuleUp(usize),
+    MovePromptRuleDown(usize),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,6 +86,8 @@ pub enum RouterEditorType {
 struct PromptRuleRow {
     description_editor: ViewHandle<EditorView>,
     model_dropdown: ViewHandle<FilterableDropdown<CustomRouterEditorAction>>,
+    move_up_mouse_state: MouseStateHandle,
+    move_down_mouse_state: MouseStateHandle,
     remove_mouse_state: MouseStateHandle,
     current_model: String,
 }
@@ -232,7 +251,7 @@ impl CustomRouterEditorView {
             ctx,
         );
 
-        let prompt_rules = init_prules
+        let mut prompt_rules: Vec<PromptRuleRow> = init_prules
             .iter()
             .enumerate()
             .map(|(i, rule)| {
@@ -245,6 +264,12 @@ impl CustomRouterEditorView {
                 )
             })
             .collect();
+        // Prompt routing requires at least one rule, so always start with one
+        // (empty) rule row when none were loaded.
+        if prompt_rules.is_empty() {
+            let row = make_prompt_rule_row(0, "", "", &upgrade_footer_mouse_state, ctx);
+            prompt_rules.push(row);
+        }
 
         let save_button = ctx.add_typed_action_view(|_| {
             ActionButton::new("Save", PrimaryTheme)
@@ -432,6 +457,13 @@ impl CustomRouterEditorView {
                         })
                     })
                     .collect();
+                if rules.is_empty() {
+                    self.save_error = Some(
+                        "At least one rule with a description and model is required.".to_string(),
+                    );
+                    ctx.notify();
+                    return;
+                }
                 CustomModelRouting::Prompt(PromptRouting {
                     default_model: self.prompt_default_model.clone(),
                     rules,
@@ -494,9 +526,46 @@ impl CustomRouterEditorView {
     }
 
     fn remove_prompt_rule(&mut self, index: usize, ctx: &mut ViewContext<Self>) {
+        // Prompt routing requires at least one rule; never remove the last row.
+        if self.prompt_rules.len() <= 1 {
+            return;
+        }
         if index < self.prompt_rules.len() {
             self.prompt_rules.remove(index);
         }
+        ctx.notify();
+    }
+
+    /// Swaps the rule at `index` with the one at `target`, preserving each
+    /// rule's description text and selected model.
+    ///
+    /// The rows are fully rebuilt (rather than swapped in place) because each
+    /// model dropdown captures its row index in its on-select action; rebuilding
+    /// keeps those captured indices in sync with the new ordering.
+    fn move_prompt_rule(&mut self, index: usize, target: usize, ctx: &mut ViewContext<Self>) {
+        let len = self.prompt_rules.len();
+        if index >= len || target >= len {
+            return;
+        }
+        // Snapshot each row's current content in order, then swap.
+        let mut data: Vec<(String, String)> = self
+            .prompt_rules
+            .iter()
+            .map(|row| {
+                (
+                    row.description_editor.as_ref(ctx).buffer_text(ctx),
+                    row.current_model.clone(),
+                )
+            })
+            .collect();
+        data.swap(index, target);
+
+        let ms = self.upgrade_footer_mouse_state.clone();
+        self.prompt_rules = data
+            .iter()
+            .enumerate()
+            .map(|(i, (desc, model))| make_prompt_rule_row(i, desc, model, &ms, ctx))
+            .collect();
         ctx.notify();
     }
 
@@ -581,10 +650,30 @@ impl CustomRouterEditorView {
                     .with_margin_top(12.)
                     .finish(),
             );
+            // Explain rule precedence: rules are matched top-to-bottom.
+            column.add_child(
+                Container::new(
+                    Text::new(
+                        "Rules are matched top to bottom \u{2014} rules higher in the list take precedence over those below.",
+                        appearance.ui_font_family(),
+                        11.,
+                    )
+                    .with_color(
+                        appearance
+                            .theme()
+                            .sub_text_color(appearance.theme().surface_1())
+                            .into(),
+                    )
+                    .finish(),
+                )
+                .with_margin_bottom(12.)
+                .finish(),
+            );
+            let rule_count = self.prompt_rules.len();
             for (i, row) in self.prompt_rules.iter().enumerate() {
                 column.add_child(
-                    Container::new(render_rule_row(i, row, appearance))
-                        .with_margin_bottom(8.)
+                    Container::new(render_rule_row(i, row, rule_count, appearance))
+                        .with_margin_bottom(16.)
                         .finish(),
                 );
             }
@@ -592,7 +681,7 @@ impl CustomRouterEditorView {
 
         column.add_child(
             Container::new(ChildView::new(&self.add_rule_button).finish())
-                .with_margin_top(4.)
+                .with_margin_top(8.)
                 .finish(),
         );
         column.finish()
@@ -611,7 +700,11 @@ impl CustomRouterEditorView {
             Container::new(
                 Flex::column()
                     .with_child(Self::section_label(name_label, appearance))
-                    .with_child(editor_row(&self.name_editor, appearance))
+                    .with_child(
+                        ConstrainedBox::new(editor_row(&self.name_editor, None, appearance))
+                            .with_width(EDITOR_CONTENT_WIDTH)
+                            .finish(),
+                    )
                     .finish(),
             )
             .with_margin_bottom(16.)
@@ -753,6 +846,11 @@ impl TypedActionView for CustomRouterEditorView {
             CustomRouterEditorAction::Delete => self.try_delete(ctx),
             CustomRouterEditorAction::SetRouterType(t) => {
                 self.router_type = *t;
+                // Prompt routing requires at least one rule; ensure a row exists
+                // when switching into prompt mode.
+                if *t == RouterEditorType::Prompt && self.prompt_rules.is_empty() {
+                    self.add_prompt_rule(ctx);
+                }
                 ctx.notify();
             }
             CustomRouterEditorAction::SetComplexityDefault(id) => {
@@ -777,6 +875,14 @@ impl TypedActionView for CustomRouterEditorView {
             }
             CustomRouterEditorAction::AddPromptRule => self.add_prompt_rule(ctx),
             CustomRouterEditorAction::RemovePromptRule(i) => self.remove_prompt_rule(*i, ctx),
+            CustomRouterEditorAction::MovePromptRuleUp(i) => {
+                if *i > 0 {
+                    self.move_prompt_rule(*i, *i - 1, ctx);
+                }
+            }
+            CustomRouterEditorAction::MovePromptRuleDown(i) => {
+                self.move_prompt_rule(*i, *i + 1, ctx);
+            }
         }
     }
 }
@@ -882,6 +988,10 @@ fn fill_filterable_dropdown<F>(
 ) where
     F: Fn(String) -> CustomRouterEditorAction + Clone,
 {
+    // Set the placeholder before populating items so the initial
+    // `set_filtered_items` keeps an empty selection blank rather than
+    // auto-selecting the first model.
+    dropdown.set_placeholder(MODEL_PLACEHOLDER, ctx);
     let items = available_model_menu_items(
         LLMPreferences::as_ref(ctx)
             .get_base_llm_choices_for_agent_mode(ctx)
@@ -924,6 +1034,10 @@ fn make_prompt_rule_row(
             ctx,
         );
         editor.set_placeholder_text("Describe when to use this model\u{2026}", ctx);
+        // Use the UI font (rather than the editor's default mono font) so the
+        // input matches the rest of the editor's text inputs.
+        let font_family = Appearance::as_ref(ctx).ui_font_family();
+        editor.set_font_family(font_family, ctx);
         if !desc_owned.is_empty() {
             editor.set_buffer_text(&desc_owned, ctx);
         }
@@ -939,24 +1053,47 @@ fn make_prompt_rule_row(
         upgrade_mouse_state,
         ctx,
     );
+    // Match the dropdown's bar height to the description input and drop its
+    // default vertical margin so the two fields align flush within the row.
+    model_dropdown.update(ctx, |dropdown, ctx| {
+        dropdown.set_vertical_margin(0., ctx);
+        dropdown.set_top_bar_height(RULE_FIELD_HEIGHT, ctx);
+    });
 
     PromptRuleRow {
         description_editor,
         model_dropdown,
+        move_up_mouse_state: Default::default(),
+        move_down_mouse_state: Default::default(),
         remove_mouse_state: Default::default(),
         current_model: model.to_string(),
     }
 }
 
-fn editor_row(editor: &ViewHandle<EditorView>, appearance: &Appearance) -> Box<dyn Element> {
-    Container::new(ChildView::new(editor).finish())
-        .with_background(appearance.theme().surface_2())
-        .with_border(Border::new(1.).with_border_fill(appearance.theme().outline()))
-        .with_corner_radius(warpui::elements::CornerRadius::with_all(
-            warpui::elements::Radius::Pixels(4.),
-        ))
-        .with_horizontal_padding(8.)
-        .with_vertical_padding(6.)
+/// Renders an `EditorView` as a text input styled like the AI settings API-key
+/// inputs. The returned element has no width constraint, so callers should wrap
+/// it (e.g. in a `ConstrainedBox` or `Expanded`) to size it. Pass `height` to
+/// force an exact box height (used so rule inputs match the model dropdown).
+fn editor_row(
+    editor: &ViewHandle<EditorView>,
+    height: Option<f32>,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    appearance
+        .ui_builder()
+        .text_input(editor.clone())
+        .with_style(UiComponentStyles {
+            padding: Some(Coords {
+                top: 8.,
+                bottom: 8.,
+                left: 12.,
+                right: 12.,
+            }),
+            background: Some(appearance.theme().surface_2().into()),
+            height,
+            ..Default::default()
+        })
+        .build()
         .finish()
 }
 
@@ -986,88 +1123,174 @@ fn labeled_dropdown(
         .finish()
 }
 
-fn render_rule_row(index: usize, row: &PromptRuleRow, appearance: &Appearance) -> Box<dyn Element> {
+/// A label stacked above a field (input/dropdown), matching the spacing used by
+/// the AI settings API-key inputs.
+fn labeled_field(
+    label: impl Into<String>,
+    field: Box<dyn Element>,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
     let sub = appearance
         .theme()
-        .sub_text_color(appearance.theme().surface_2());
-    let icon_color = sub;
-    let idx = index;
-    let remove_state = row.remove_mouse_state.clone();
-
-    let remove_btn = Hoverable::new(remove_state, move |_| {
-        ConstrainedBox::new(Icon::X.to_warpui_icon(icon_color).finish())
-            .with_width(14.)
-            .with_height(14.)
-            .finish()
-    })
-    .on_click(move |ctx, _app, _pos| {
-        ctx.dispatch_typed_action(CustomRouterEditorAction::RemovePromptRule(idx));
-    })
-    .finish();
-
-    let desc_label_str = "Description".to_string();
-    let model_label_str = "Model".to_string();
-
-    Flex::row()
-        .with_main_axis_size(MainAxisSize::Max)
-        .with_cross_axis_alignment(CrossAxisAlignment::Start)
+        .sub_text_color(appearance.theme().surface_1());
+    Flex::column()
         .with_child(
-            Expanded::new(
-                1.,
-                Flex::column()
-                    .with_child(
-                        Container::new(
-                            Flex::column()
-                                .with_child(
-                                    Container::new(
-                                        Text::new(
-                                            desc_label_str.clone(),
-                                            appearance.ui_font_family(),
-                                            11.,
-                                        )
-                                        .with_color(sub.into())
-                                        .finish(),
-                                    )
-                                    .with_margin_bottom(2.)
-                                    .finish(),
-                                )
-                                .with_child(editor_row(&row.description_editor, appearance))
-                                .finish(),
-                        )
-                        .with_margin_bottom(4.)
-                        .finish(),
-                    )
-                    .with_child(
-                        Flex::column()
-                            .with_child(
-                                Container::new(
-                                    Text::new(
-                                        model_label_str.clone(),
-                                        appearance.ui_font_family(),
-                                        11.,
-                                    )
-                                    .with_color(sub.into())
-                                    .finish(),
-                                )
-                                .with_margin_bottom(2.)
-                                .finish(),
-                            )
-                            .with_child(
-                                ConstrainedBox::new(ChildView::new(&row.model_dropdown).finish())
-                                    .with_width(EDITOR_CONTENT_WIDTH)
-                                    .finish(),
-                            )
-                            .finish(),
-                    )
+            Container::new(
+                Text::new(label.into(), appearance.ui_font_family(), 11.)
+                    .with_color(sub.into())
                     .finish(),
             )
+            .with_margin_bottom(4.)
+            .finish(),
+        )
+        .with_child(field)
+        .finish()
+}
+
+/// A small icon button for the per-rule reorder/remove controls. When `enabled`
+/// is false it renders greyed out and is non-interactive; when enabled it shows
+/// a pointing-hand cursor and dispatches `action` on click.
+fn rule_icon_button(
+    icon: Icon,
+    enabled: bool,
+    mouse_state: MouseStateHandle,
+    action: CustomRouterEditorAction,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    let color = if enabled {
+        appearance
+            .theme()
+            .sub_text_color(appearance.theme().surface_1())
+    } else {
+        appearance.theme().disabled_ui_text_color()
+    };
+    // Inline the builder closure (rather than binding it to a `let`) so the
+    // compiler infers the higher-ranked closure lifetime `Hoverable` requires.
+    let hoverable = Hoverable::new(mouse_state, move |_| {
+        ConstrainedBox::new(icon.to_warpui_icon(color).finish())
+            .with_width(RULE_ICON_BUTTON_SIZE)
+            .with_height(RULE_ICON_BUTTON_SIZE)
+            .finish()
+    });
+    if enabled {
+        hoverable
+            .with_cursor(Cursor::PointingHand)
+            .on_click(move |ctx, _app, _pos| {
+                ctx.dispatch_typed_action(action.clone());
+            })
+            .finish()
+    } else {
+        hoverable.finish()
+    }
+}
+
+/// Renders the reorder (up/down) and remove controls for a rule, vertically
+/// centered against the input/dropdown fields (not the labels above them).
+fn render_rule_controls(
+    index: usize,
+    row: &PromptRuleRow,
+    rule_count: usize,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    let buttons = Flex::row()
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .with_child(rule_icon_button(
+            Icon::ChevronUp,
+            index > 0,
+            row.move_up_mouse_state.clone(),
+            CustomRouterEditorAction::MovePromptRuleUp(index),
+            appearance,
+        ))
+        .with_child(
+            Container::new(rule_icon_button(
+                Icon::ChevronDown,
+                index + 1 < rule_count,
+                row.move_down_mouse_state.clone(),
+                CustomRouterEditorAction::MovePromptRuleDown(index),
+                appearance,
+            ))
+            .with_margin_left(6.)
             .finish(),
         )
         .with_child(
-            Container::new(remove_btn)
-                .with_margin_left(8.)
-                .with_margin_top(20.)
-                .finish(),
+            Container::new(rule_icon_button(
+                Icon::X,
+                true,
+                row.remove_mouse_state.clone(),
+                CustomRouterEditorAction::RemovePromptRule(index),
+                appearance,
+            ))
+            .with_margin_left(6.)
+            .finish(),
+        )
+        .finish();
+
+    // Spacer matching the label height + gap so the controls line up with the
+    // fields below the labels rather than the labels themselves.
+    let label_spacer = Container::new(
+        Text::new(" ", appearance.ui_font_family(), 11.)
+            .with_color(
+                appearance
+                    .theme()
+                    .sub_text_color(appearance.theme().surface_1())
+                    .into(),
+            )
+            .finish(),
+    )
+    .with_margin_bottom(4.)
+    .finish();
+
+    Flex::column()
+        .with_child(label_spacer)
+        .with_child(
+            ConstrainedBox::new(
+                Flex::column()
+                    .with_main_axis_size(MainAxisSize::Max)
+                    .with_main_axis_alignment(MainAxisAlignment::Center)
+                    .with_child(buttons)
+                    .finish(),
+            )
+            .with_height(RULE_FIELD_HEIGHT)
+            .finish(),
         )
         .finish()
+}
+
+fn render_rule_row(
+    index: usize,
+    row: &PromptRuleRow,
+    rule_count: usize,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    const MODEL_WIDTH: f32 = 170.;
+
+    let description_field = labeled_field(
+        "Description",
+        editor_row(&row.description_editor, Some(RULE_FIELD_HEIGHT), appearance),
+        appearance,
+    );
+    let model_field = labeled_field(
+        "Model",
+        ConstrainedBox::new(ChildView::new(&row.model_dropdown).finish())
+            .with_width(MODEL_WIDTH)
+            .finish(),
+        appearance,
+    );
+
+    let mut rule_row = Flex::row()
+        .with_main_axis_size(MainAxisSize::Max)
+        .with_cross_axis_alignment(CrossAxisAlignment::Start)
+        .with_child(Expanded::new(1., description_field).finish())
+        .with_child(Container::new(model_field).with_margin_left(8.).finish());
+
+    // Reorder + remove controls are only meaningful when there are multiple
+    // rules (prompt routing always keeps at least one rule).
+    if rule_count > 1 {
+        rule_row.add_child(
+            Container::new(render_rule_controls(index, row, rule_count, appearance))
+                .with_margin_left(8.)
+                .finish(),
+        );
+    }
+    rule_row.finish()
 }

--- a/app/src/ai/custom_model_router_editor.rs
+++ b/app/src/ai/custom_model_router_editor.rs
@@ -609,7 +609,18 @@ impl CustomRouterEditorView {
             .finish(),
         );
 
-        // Type
+        // Type + description
+        let type_description = match self.router_type {
+            RouterEditorType::Complexity => {
+                "Routes each request to a model based on task complexity. Warp classifies the task as easy, medium, or hard and picks the corresponding model, falling back to the default when a bucket is unset."
+            }
+            RouterEditorType::Prompt => {
+                "Routes each request based on the prompt's content. You write natural-language rules describing when a model should be used; the first matching rule wins, otherwise the default model is used."
+            }
+        };
+        let desc_color = appearance
+            .theme()
+            .sub_text_color(appearance.theme().surface_1());
         col.add_child(
             Container::new(
                 Flex::column()
@@ -618,6 +629,15 @@ impl CustomRouterEditorView {
                         ConstrainedBox::new(ChildView::new(&self.type_dropdown).finish())
                             .with_width(EDITOR_CONTENT_WIDTH)
                             .finish(),
+                    )
+                    .with_child(
+                        Container::new(
+                            Text::new(type_description, appearance.ui_font_family(), 11.)
+                                .with_color(desc_color.into())
+                                .finish(),
+                        )
+                        .with_margin_top(6.)
+                        .finish(),
                     )
                     .finish(),
             )

--- a/app/src/ai/custom_model_routers.rs
+++ b/app/src/ai/custom_model_routers.rs
@@ -21,8 +21,17 @@ use warp_multi_agent_api as api;
 
 use super::llms::{LLMContextWindow, LLMId, LLMInfo, LLMProvider, LLMUsageMetadata};
 
+/// The shared `config_key` namespace prefix for all custom model routers.
+/// Both local (YAML-authored) and cloud/team (server-synced) routers live under
+/// this prefix: local routers use `custom-router:local:` and cloud/team routers
+/// use `custom-router:cloud:`. Use [`is_custom_router_id`] to match either.
+pub const CUSTOM_ROUTER_PREFIX: &str = "custom-router:";
+
 /// The `config_key` prefix for local (YAML-authored) custom model routers.
 pub const LOCAL_CUSTOM_ROUTER_PREFIX: &str = "custom-router:local:";
+
+/// The `config_key` prefix for cloud/team (server-synced) custom model routers.
+pub const CLOUD_CUSTOM_ROUTER_PREFIX: &str = "custom-router:cloud:";
 
 /// The routing strategy for a custom model router.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -84,14 +93,21 @@ impl CustomModelRouter {
     /// picker [`LLMInfo`] inline so callers never need to call a separate
     /// `to_llm_info()` step.
     ///
-    /// `source_path` is the file the router was loaded from; when provided it
-    /// appears in the description so the user knows where to edit the config.
+    /// `source_path` is the file the router was loaded from. It serves two
+    /// purposes: it appears in the description so the user knows where to edit
+    /// the config, and its file name (without extension) is the router's stable
+    /// identity. Deriving the `config_key`/[`LLMId`] from the file name (rather
+    /// than the display `name`) lets a user rename a router without breaking
+    /// persisted selections (execution profiles, terminal overrides) that
+    /// reference it. Path-less parses (e.g. tests) fall back to the display
+    /// `name`, which reproduces the legacy id.
     pub fn new_local(
         name: String,
         routing: CustomModelRouting,
         source_path: Option<&Path>,
     ) -> Self {
-        let config_key = format!("{LOCAL_CUSTOM_ROUTER_PREFIX}{name}");
+        let id = local_id_from_path(source_path, &name);
+        let config_key = format!("{LOCAL_CUSTOM_ROUTER_PREFIX}{id}");
         let routing_kind = match &routing {
             CustomModelRouting::Complexity(_) => "Routes by task complexity",
             CustomModelRouting::Prompt(_) => "Routes by prompt content",
@@ -227,6 +243,19 @@ impl CustomModelRouter {
     }
 }
 
+/// Derives a local router's stable id from its source file name (without
+/// extension). The file name is the router's durable identity, so changing the
+/// display name never changes the `config_key`. Falls back to `fallback` (the
+/// display name) when no path is available, preserving the legacy name-based id
+/// for path-less parses.
+fn local_id_from_path(source_path: Option<&Path>, fallback: &str) -> String {
+    source_path
+        .and_then(|path| path.file_stem())
+        .and_then(|stem| stem.to_str())
+        .map(str::to_owned)
+        .unwrap_or_else(|| fallback.to_owned())
+}
+
 /// Validates a single routing target id: non-empty and concrete.
 fn validate_target(model_id: &str) -> Result<(), String> {
     let trimmed = model_id.trim();
@@ -252,15 +281,28 @@ pub fn is_auto_target(model_id: &str) -> bool {
         || is_custom_router_id(id)
 }
 
-/// Returns whether an id is the `config_key`/`LLMId` of a local custom model router.
+/// Returns whether an id is the `config_key`/`LLMId` of any custom model
+/// router, local (`custom-router:local:`) or cloud/team (`custom-router:cloud:`).
+/// Use this for picker behavior shared by all routers: the Dataflow icon,
+/// top-of-picker ordering, and the routing sidecar instead of model specs.
 pub fn is_custom_router_id(id: &str) -> bool {
+    id.starts_with(CUSTOM_ROUTER_PREFIX)
+}
+
+/// Returns whether an id is the `config_key` of a *local* (YAML-authored)
+/// custom model router specifically. Use this only for logic scoped to local
+/// file-backed routers (e.g. reconciling a stale local selection after its file
+/// is deleted); prefer [`is_custom_router_id`] for behavior shared by all
+/// routers, including cloud/team ones.
+pub fn is_local_custom_router_id(id: &str) -> bool {
     id.starts_with(LOCAL_CUSTOM_ROUTER_PREFIX)
 }
 
-/// Returns whether an id is the `config_key` of a local custom model router.
-/// Alias for [`is_custom_router_id`]; prefer that in new call sites.
-pub fn is_local_custom_router_id(id: &str) -> bool {
-    is_custom_router_id(id)
+/// Returns whether an id is the `config_key` of a *cloud/team* (server-synced)
+/// custom model router specifically. Used to gate cloud routers behind the same
+/// feature flag as local routers so the whole feature is controlled by one flag.
+pub fn is_cloud_custom_router_id(id: &str) -> bool {
+    id.starts_with(CLOUD_CUSTOM_ROUTER_PREFIX)
 }
 
 // ── Serialization back to YAML ───────────────────────────────────────────────

--- a/app/src/ai/custom_model_routers.rs
+++ b/app/src/ai/custom_model_routers.rs
@@ -263,6 +263,95 @@ pub fn is_local_custom_router_id(id: &str) -> bool {
     is_custom_router_id(id)
 }
 
+// ── Serialization back to YAML ───────────────────────────────────────────────
+
+/// A serialisable mirror of [`YamlCustomModelRouter`] used when writing a
+/// router back to disk via [`CustomModelRouter::to_yaml_string`].
+#[derive(Serialize)]
+struct YamlOutputRouter<'a> {
+    name: &'a str,
+    #[serde(rename = "type")]
+    model_type: &'static str,
+    default: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    routing: Option<serde_yaml::Value>,
+}
+
+/// A serialisable mirror of [`YamlComplexityRouting`] used by
+/// [`CustomModelRouter::to_yaml_string`].
+#[derive(Serialize)]
+struct YamlOutputComplexityRouting<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    easy: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    medium: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hard: Option<&'a str>,
+}
+
+/// A serialisable mirror of [`YamlPromptRule`] used by
+/// [`CustomModelRouter::to_yaml_string`].
+#[derive(Serialize)]
+struct YamlOutputPromptRule<'a> {
+    description: &'a str,
+    model: &'a str,
+}
+
+impl CustomModelRouter {
+    /// Serialises this router back to the YAML file format understood by
+    /// [`parse_model_config_yaml`]. The output is suitable for writing to a
+    /// `custom_model_routers/*.yaml` file.
+    pub fn to_yaml_string(&self) -> Result<String, serde_yaml::Error> {
+        let name = self.info.display_name.as_str();
+        match &self.routing {
+            CustomModelRouting::Complexity(c) => {
+                // Only emit a `routing:` block when at least one optional
+                // bucket is set; omit it entirely otherwise so the file stays
+                // as simple as possible.
+                let routing = if c.easy.is_some() || c.medium.is_some() || c.hard.is_some() {
+                    let complexity = YamlOutputComplexityRouting {
+                        easy: c.easy.as_deref(),
+                        medium: c.medium.as_deref(),
+                        hard: c.hard.as_deref(),
+                    };
+                    Some(serde_yaml::to_value(complexity)?)
+                } else {
+                    None
+                };
+                let out = YamlOutputRouter {
+                    name,
+                    model_type: "complexity",
+                    default: &c.default,
+                    routing,
+                };
+                serde_yaml::to_string(&out)
+            }
+            CustomModelRouting::Prompt(p) => {
+                let rules: Vec<YamlOutputPromptRule<'_>> = p
+                    .rules
+                    .iter()
+                    .map(|r| YamlOutputPromptRule {
+                        description: &r.description,
+                        model: &r.model,
+                    })
+                    .collect();
+                let routing = if rules.is_empty() {
+                    None
+                } else {
+                    Some(serde_yaml::to_value(&rules)?)
+                };
+                let out = YamlOutputRouter {
+                    name,
+                    model_type: "prompt",
+                    default: &p.default_model,
+                    routing,
+                };
+                serde_yaml::to_string(&out)
+            }
+        }
+    }
+}
+
 /// Describes a `custom_model_routers/` YAML file that failed to parse or validate.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ModelConfigError {

--- a/app/src/ai/execution_profiles/model_menu_items.rs
+++ b/app/src/ai/execution_profiles/model_menu_items.rs
@@ -9,6 +9,7 @@ use warpui::elements::{
 use warpui::fonts::{Properties, Style};
 use warpui::{Action, AppContext, Element, SingletonEntity as _};
 
+use crate::ai::custom_model_routers::is_custom_router_id;
 use crate::ai::llms::{
     is_using_api_key_for_provider, should_show_bedrock_icon_for_model, DisableReason, LLMId,
     LLMInfo, LLMPreferences,
@@ -87,8 +88,11 @@ fn make_item_fields<A: Action + Clone>(
         .is_some();
     let is_using_bedrock = should_show_bedrock_icon_for_model(llm, app);
     let is_using_api_key = is_custom_endpoint || is_using_api_key_for_provider(&llm.provider, app);
+    let is_custom_router = is_custom_router_id(llm.id.as_str());
     let leading_icon = if is_using_bedrock {
         Icon::Aws
+    } else if is_custom_router {
+        Icon::Dataflow
     } else {
         llm.provider.icon().unwrap_or(Icon::Oz)
     };

--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -680,12 +680,10 @@ impl LLMPreferences {
         if let Some(terminal_view_id) = terminal_view_id {
             let raw_override = self.base_llm_for_terminal_view.get(&terminal_view_id);
             if let Some(llm_id) = raw_override {
-                if let Some(llm_info) = self
-                    .models_by_feature
-                    .agent_mode
-                    .info_for_id(llm_id)
-                    .or_else(|| self.custom_llm_info_for_id_if_enabled(llm_id, app))
-                    .or_else(|| self.custom_router_llm_info_for_id_if_enabled(llm_id))
+                if let Some(llm_info) =
+                    Self::server_info_for_id_router_gated(&self.models_by_feature.agent_mode, llm_id)
+                        .or_else(|| self.custom_llm_info_for_id_if_enabled(llm_id, app))
+                        .or_else(|| self.custom_router_llm_info_for_id_if_enabled(llm_id))
                 {
                     return llm_info;
                 }
@@ -699,9 +697,7 @@ impl LLMPreferences {
             .base_model
             .clone()
             .and_then(|id| {
-                self.models_by_feature
-                    .agent_mode
-                    .info_for_id(&id)
+                Self::server_info_for_id_router_gated(&self.models_by_feature.agent_mode, &id)
                     .or_else(|| self.custom_llm_info_for_id_if_enabled(&id, app))
                     .or_else(|| self.custom_router_llm_info_for_id_if_enabled(&id))
             })
@@ -729,13 +725,29 @@ impl LLMPreferences {
             .coding_model
             .clone()
             .and_then(|id| {
-                self.models_by_feature
-                    .coding
-                    .info_for_id(&id)
+                Self::server_info_for_id_router_gated(&self.models_by_feature.coding, &id)
                     .or_else(|| self.custom_llm_info_for_id_if_enabled(&id, app))
                     .or_else(|| self.custom_router_llm_info_for_id_if_enabled(&id))
             })
             .unwrap_or_else(|| self.models_by_feature.coding.default_llm_info())
+    }
+
+    /// Resolves `id` against a server-provided model list, but hides cloud/team
+    /// custom routers when the custom-router feature flag is off. Mirrors the
+    /// gating applied to local routers (see
+    /// [`Self::custom_router_llm_info_for_id_if_enabled`]) so the whole
+    /// custom-router feature is controlled by a single client flag.
+    fn server_info_for_id_router_gated<'a>(
+        available: &'a AvailableLLMs,
+        id: &LLMId,
+    ) -> Option<&'a LLMInfo> {
+        let info = available.info_for_id(id)?;
+        if !FeatureFlag::CustomModelRouters.is_enabled()
+            && custom_model_routers::is_cloud_custom_router_id(info.id.as_str())
+        {
+            return None;
+        }
+        Some(info)
     }
 
     /// Returns the set of LLMs available for Agent Mode use.
@@ -744,11 +756,18 @@ impl LLMPreferences {
         app: &AppContext,
     ) -> impl Iterator<Item = &LLMInfo> {
         // Don't show admin-disabled models in the dropdown
+        let routers_enabled = FeatureFlag::CustomModelRouters.is_enabled();
         self.models_by_feature
             .agent_mode
             .choices
             .iter()
             .filter(|llm| !matches!(llm.disable_reason, Some(DisableReason::AdminDisabled)))
+            // Gate cloud/team routers behind the same flag as local routers so
+            // the entire custom-router feature is controlled by one flag.
+            .filter(move |llm| {
+                routers_enabled
+                    || !custom_model_routers::is_cloud_custom_router_id(llm.id.as_str())
+            })
             .chain(self.custom_llm_choices(app))
             .chain(self.custom_router_choices())
     }
@@ -756,11 +775,17 @@ impl LLMPreferences {
     /// Returns the set of LLMs available for coding.
     pub fn get_coding_llm_choices(&self, app: &AppContext) -> impl Iterator<Item = &LLMInfo> {
         // Don't show admin-disabled models in the dropdown
+        let routers_enabled = FeatureFlag::CustomModelRouters.is_enabled();
         self.models_by_feature
             .coding
             .choices
             .iter()
             .filter(|llm| !matches!(llm.disable_reason, Some(DisableReason::AdminDisabled)))
+            // Gate cloud/team routers behind the same flag as local routers.
+            .filter(move |llm| {
+                routers_enabled
+                    || !custom_model_routers::is_cloud_custom_router_id(llm.id.as_str())
+            })
             .chain(self.custom_llm_choices(app))
             .chain(self.custom_router_choices())
     }

--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -680,10 +680,12 @@ impl LLMPreferences {
         if let Some(terminal_view_id) = terminal_view_id {
             let raw_override = self.base_llm_for_terminal_view.get(&terminal_view_id);
             if let Some(llm_id) = raw_override {
-                if let Some(llm_info) =
-                    Self::server_info_for_id_router_gated(&self.models_by_feature.agent_mode, llm_id)
-                        .or_else(|| self.custom_llm_info_for_id_if_enabled(llm_id, app))
-                        .or_else(|| self.custom_router_llm_info_for_id_if_enabled(llm_id))
+                if let Some(llm_info) = Self::server_info_for_id_router_gated(
+                    &self.models_by_feature.agent_mode,
+                    llm_id,
+                )
+                .or_else(|| self.custom_llm_info_for_id_if_enabled(llm_id, app))
+                .or_else(|| self.custom_router_llm_info_for_id_if_enabled(llm_id))
                 {
                     return llm_info;
                 }
@@ -765,8 +767,7 @@ impl LLMPreferences {
             // Gate cloud/team routers behind the same flag as local routers so
             // the entire custom-router feature is controlled by one flag.
             .filter(move |llm| {
-                routers_enabled
-                    || !custom_model_routers::is_cloud_custom_router_id(llm.id.as_str())
+                routers_enabled || !custom_model_routers::is_cloud_custom_router_id(llm.id.as_str())
             })
             .chain(self.custom_llm_choices(app))
             .chain(self.custom_router_choices())
@@ -783,8 +784,7 @@ impl LLMPreferences {
             .filter(|llm| !matches!(llm.disable_reason, Some(DisableReason::AdminDisabled)))
             // Gate cloud/team routers behind the same flag as local routers.
             .filter(move |llm| {
-                routers_enabled
-                    || !custom_model_routers::is_cloud_custom_router_id(llm.id.as_str())
+                routers_enabled || !custom_model_routers::is_cloud_custom_router_id(llm.id.as_str())
             })
             .chain(self.custom_llm_choices(app))
             .chain(self.custom_router_choices())

--- a/app/src/ai/mod.rs
+++ b/app/src/ai/mod.rs
@@ -28,6 +28,7 @@ pub(crate) mod conversation_navigation;
 pub(crate) mod conversation_rename;
 pub(crate) mod conversation_status_ui;
 pub(crate) mod conversation_utils;
+pub(crate) mod custom_model_router_editor;
 pub(crate) mod custom_model_routers;
 pub(crate) mod document;
 #[cfg(not(target_family = "wasm"))]

--- a/app/src/app_state.rs
+++ b/app/src/app_state.rs
@@ -143,6 +143,7 @@ pub enum LeafContents {
     Workflow(WorkflowPaneSnapshot),
     Settings(SettingsPaneSnapshot),
     AIFact(AIFactPaneSnapshot),
+    CustomRouterEditor,
     ExecutionProfileEditor,
     CodeReview(CodeReviewPaneSnapshot),
     AmbientAgent(AmbientAgentPaneSnapshot),
@@ -181,6 +182,7 @@ impl LeafContents {
             | LeafContents::Workflow(_)
             | LeafContents::Settings(_)
             | LeafContents::AIFact(_)
+            | LeafContents::CustomRouterEditor
             | LeafContents::ExecutionProfileEditor
             | LeafContents::CodeReview(_)
             | LeafContents::AmbientAgent(_)

--- a/app/src/launch_configs/launch_config.rs
+++ b/app/src/launch_configs/launch_config.rs
@@ -153,6 +153,7 @@ impl TryFrom<PaneNodeSnapshot> for PaneTemplateType {
                 | LeafContents::Settings(_)
                 | LeafContents::AIFact(_)
                 | LeafContents::CodeReview(_)
+                | LeafContents::CustomRouterEditor
                 | LeafContents::ExecutionProfileEditor
                 | LeafContents::GetStarted
                 | LeafContents::NetworkLog

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -179,6 +179,7 @@ pub use pane::ai_document_pane::AIDocumentPane;
 pub use pane::ai_fact_pane::AIFactPane;
 pub use pane::code_diff_pane::CodeDiffPane;
 pub use pane::code_pane::CodePane;
+pub use pane::custom_router_editor_pane::CustomRouterEditorPane;
 pub use pane::env_var_collection_pane::EnvVarCollectionPane;
 pub use pane::environment_management_pane::EnvironmentManagementPane;
 pub use pane::execution_profile_editor_pane::ExecutionProfileEditorPane;
@@ -1925,11 +1926,9 @@ impl PaneGroup {
             LeafContents::CodeReview(_) => {
                 Err(anyhow::anyhow!("Code review panes are no longer supported"))
             }
-            LeafContents::ExecutionProfileEditor => {
-                // We don't yet support restoring execution profile editor panes.
-                Err(anyhow::anyhow!(
-                    "Can't restore execution profile editor panes"
-                ))
+            LeafContents::ExecutionProfileEditor | LeafContents::CustomRouterEditor => {
+                // Editor panes are not restored from persistence.
+                Err(anyhow::anyhow!("Can't restore editor panes"))
             }
             LeafContents::NetworkLog => {
                 // Network log panes are intentionally not restored. Two

--- a/app/src/pane_group/pane/custom_router_editor_pane.rs
+++ b/app/src/pane_group/pane/custom_router_editor_pane.rs
@@ -1,0 +1,118 @@
+use warpui::{AppContext, ModelHandle, View, ViewContext, ViewHandle};
+
+use super::view::PaneView;
+use super::{
+    DetachType, PaneConfiguration, PaneContent, PaneGroup, PaneId, ShareableLink,
+    ShareableLinkError,
+};
+use crate::ai::custom_model_router_editor::{CustomRouterEditorEvent, CustomRouterEditorView};
+use crate::ai::custom_model_routers::CustomModelRouter;
+use crate::app_state::LeafContents;
+use crate::pane_group::focus_state::PaneFocusHandle;
+
+pub struct CustomRouterEditorPane {
+    view: ViewHandle<PaneView<CustomRouterEditorView>>,
+    pane_configuration: ModelHandle<PaneConfiguration>,
+}
+
+impl CustomRouterEditorPane {
+    /// Create a new router editor pane.
+    ///
+    /// Pass `existing = None` for creating a new router, or
+    /// `existing = Some(router)` for editing an existing one.
+    pub fn new<V: View>(existing: Option<CustomModelRouter>, ctx: &mut ViewContext<V>) -> Self {
+        let editor_view =
+            ctx.add_typed_action_view(|ctx| CustomRouterEditorView::new(existing, ctx));
+        Self::from_view(editor_view, ctx)
+    }
+
+    pub fn from_view(
+        editor_view: ViewHandle<CustomRouterEditorView>,
+        ctx: &mut AppContext,
+    ) -> Self {
+        let pane_configuration = editor_view.as_ref(ctx).pane_configuration();
+
+        let view = ctx.add_typed_action_view(editor_view.window_id(ctx), |ctx| {
+            let pane_id = PaneId::from_custom_router_editor_pane_ctx(ctx);
+            PaneView::new(pane_id, editor_view, (), pane_configuration.clone(), ctx)
+        });
+
+        Self {
+            view,
+            pane_configuration,
+        }
+    }
+
+    pub fn custom_router_editor_view(
+        &self,
+        ctx: &AppContext,
+    ) -> ViewHandle<CustomRouterEditorView> {
+        self.view.as_ref(ctx).child(ctx)
+    }
+}
+
+impl PaneContent for CustomRouterEditorPane {
+    fn id(&self) -> PaneId {
+        PaneId::from_custom_router_editor_pane_view(&self.view)
+    }
+
+    fn attach(
+        &self,
+        _group: &PaneGroup,
+        focus_handle: PaneFocusHandle,
+        ctx: &mut ViewContext<PaneGroup>,
+    ) {
+        self.view
+            .update(ctx, |view, ctx| view.set_focus_handle(focus_handle, ctx));
+
+        let editor_view = self.custom_router_editor_view(ctx);
+        let pane_id = self.id();
+
+        ctx.subscribe_to_view(&editor_view, move |pane_group, _, event, ctx| {
+            let CustomRouterEditorEvent::Pane(pane_event) = event;
+            pane_group.handle_pane_event(pane_id, pane_event, ctx);
+        });
+        ctx.subscribe_to_view(&self.view, move |group, _, event, ctx| {
+            group.handle_pane_view_event(pane_id, event, ctx);
+        });
+    }
+
+    fn detach(
+        &self,
+        _group: &PaneGroup,
+        _detach_type: DetachType,
+        ctx: &mut ViewContext<PaneGroup>,
+    ) {
+        let editor_view = self.custom_router_editor_view(ctx);
+        ctx.unsubscribe_to_view(&editor_view);
+        ctx.unsubscribe_to_view(&self.view);
+    }
+
+    fn snapshot(&self, _app: &AppContext) -> LeafContents {
+        LeafContents::CustomRouterEditor
+    }
+
+    fn has_application_focus(&self, ctx: &mut ViewContext<PaneGroup>) -> bool {
+        self.view.is_self_or_child_focused(ctx)
+    }
+
+    fn focus(&self, ctx: &mut ViewContext<PaneGroup>) {
+        self.custom_router_editor_view(ctx)
+            .update(ctx, |view, ctx| view.focus(ctx));
+    }
+
+    fn shareable_link(
+        &self,
+        _ctx: &mut ViewContext<PaneGroup>,
+    ) -> Result<ShareableLink, ShareableLinkError> {
+        Ok(ShareableLink::Base)
+    }
+
+    fn pane_configuration(&self) -> ModelHandle<PaneConfiguration> {
+        self.pane_configuration.clone()
+    }
+
+    fn is_pane_being_dragged(&self, ctx: &AppContext) -> bool {
+        self.view.as_ref(ctx).is_being_dragged()
+    }
+}

--- a/app/src/pane_group/pane/mod.rs
+++ b/app/src/pane_group/pane/mod.rs
@@ -13,6 +13,7 @@ pub(super) mod ai_fact_pane;
 pub(super) mod code_diff_pane;
 pub(super) mod code_diff_pane_model;
 pub(super) mod code_pane;
+pub(super) mod custom_router_editor_pane;
 pub(super) mod env_var_collection_pane;
 pub(crate) mod environment_management_pane;
 pub(super) mod execution_profile_editor_pane;
@@ -141,6 +142,7 @@ pub(crate) enum IPaneType {
     Settings,
     AIFact,
     AIDocument,
+    CustomRouterEditor,
     ExecutionProfileEditor,
     GetStarted,
     NetworkLog,
@@ -164,6 +166,7 @@ impl Display for IPaneType {
             IPaneType::Settings => write!(f, "Settings"),
             IPaneType::AIFact => write!(f, "AI Fact"),
             IPaneType::AIDocument => write!(f, "AI Document"),
+            IPaneType::CustomRouterEditor => write!(f, "Custom Router Editor"),
             IPaneType::ExecutionProfileEditor => write!(f, "Execution Profile Editor"),
             IPaneType::GetStarted => write!(f, "GetStarted"),
             IPaneType::NetworkLog => write!(f, "Network Log"),
@@ -246,6 +249,13 @@ impl PaneId {
     /// Creates a [`PaneId`] from a [`ViewContext<PaneView<AIDocumentView>>`]
     pub fn from_ai_document_pane_ctx(ctx: &ViewContext<PaneView<AIDocumentView>>) -> Self {
         Self::new_from_ctx(IPaneType::AIDocument, ctx)
+    }
+
+    /// Creates a [`PaneId`] from a [`ViewContext<PaneView<CustomRouterEditorView>>`]
+    pub fn from_custom_router_editor_pane_ctx(
+        ctx: &ViewContext<PaneView<crate::ai::custom_model_router_editor::CustomRouterEditorView>>,
+    ) -> Self {
+        Self::new_from_ctx(IPaneType::CustomRouterEditor, ctx)
     }
 
     /// Creates a [`PaneId`] from a [`ViewContext<PaneView<ExecutionProfileEditorView>>`]
@@ -336,6 +346,13 @@ impl PaneId {
         ai_document_pane_view: &ViewHandle<PaneView<AIDocumentView>>,
     ) -> Self {
         Self::new(IPaneType::AIDocument, ai_document_pane_view)
+    }
+
+    /// Creates a [`PaneId`] from a [`PaneView<CustomRouterEditorView>`] entity ID.
+    pub fn from_custom_router_editor_pane_view(
+        view: &ViewHandle<PaneView<crate::ai::custom_model_router_editor::CustomRouterEditorView>>,
+    ) -> Self {
+        Self::new(IPaneType::CustomRouterEditor, view)
     }
 
     /// Creates a [`PaneId`] from a [`PaneView<ExecutionProfileEditorView>`] entity ID.
@@ -466,6 +483,10 @@ impl PaneId {
             IPaneType::AIDocument => {
                 ChildView::<PaneView<AIDocumentView>>::with_id(self.0.pane_view_id).finish()
             }
+            IPaneType::CustomRouterEditor => ChildView::<
+                PaneView<crate::ai::custom_model_router_editor::CustomRouterEditorView>,
+            >::with_id(self.0.pane_view_id)
+            .finish(),
             IPaneType::ExecutionProfileEditor => {
                 ChildView::<PaneView<ExecutionProfileEditorView>>::with_id(self.0.pane_view_id)
                     .finish()

--- a/app/src/persistence/sqlite.rs
+++ b/app/src/persistence/sqlite.rs
@@ -1131,7 +1131,9 @@ fn save_pane_state(
         LeafContents::AIFact(_) => AI_FACT_PANE_KIND,
         LeafContents::CodeReview(_) => CODE_REVIEW_PANE_KIND,
         LeafContents::AmbientAgent(_) => AMBIENT_AGENT_PANE_KIND,
-        LeafContents::ExecutionProfileEditor => EXECUTION_PROFILE_EDITOR_PANE_KIND,
+        LeafContents::ExecutionProfileEditor | LeafContents::CustomRouterEditor => {
+            EXECUTION_PROFILE_EDITOR_PANE_KIND
+        }
         LeafContents::GetStarted => GET_STARTED_PANE_KIND,
         LeafContents::AIDocument(_) => AI_DOCUMENT_PANE_KIND,
         LeafContents::EnvironmentManagement(_) | LeafContents::NetworkLog => {
@@ -1325,8 +1327,8 @@ fn save_pane_state(
                 .values(code_review)
                 .execute(conn)?;
         }
-        LeafContents::ExecutionProfileEditor => {
-            // TODO: Implement execution profile editor pane saving.
+        LeafContents::ExecutionProfileEditor | LeafContents::CustomRouterEditor => {
+            // Editor panes: no pane-specific data to save.
         }
         LeafContents::GetStarted => {
             // Stateless

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -9117,7 +9117,7 @@ impl SettingsWidget for CustomModelRoutersWidget {
                 }
                 #[cfg(not(feature = "local_fs"))]
                 {
-                    warpui::elements::Empty.finish()
+                    warpui::elements::Empty::finish()
                 }
             })
             .finish();

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -712,6 +712,12 @@ pub struct AISettingsPageView {
     profile_views: Vec<ViewHandle<ExecutionProfileView>>,
     add_profile_button: ViewHandle<ActionButton>,
 
+    // Custom model router views (gated on FeatureFlag::CustomModelRouters)
+    #[cfg(feature = "local_fs")]
+    router_views: Vec<ViewHandle<super::custom_router_view::CustomRouterView>>,
+    #[cfg(feature = "local_fs")]
+    add_router_button: ViewHandle<ActionButton>,
+
     // Custom inference (custom endpoints)
     custom_endpoint_modal_state: CustomEndpointModalViewState,
     remove_custom_endpoint_confirmation_dialog: ViewHandle<RemoveCustomEndpointConfirmationDialog>,
@@ -1679,6 +1685,26 @@ impl AISettingsPageView {
 
         let profile_views = Self::create_profile_views(ctx);
 
+        // Custom model router views
+        #[cfg(feature = "local_fs")]
+        let router_views = Self::create_router_views(ctx);
+        #[cfg(feature = "local_fs")]
+        let add_router_button = ctx.add_typed_action_view(|_| {
+            ActionButton::new("+ Add router", SecondaryTheme)
+                .with_size(ButtonSize::Small)
+                .on_click(|ctx| {
+                    ctx.dispatch_typed_action(AISettingsPageAction::OpenAddCustomRouter);
+                })
+        });
+        #[cfg(feature = "local_fs")]
+        {
+            let is_enabled = warp_core::features::FeatureFlag::CustomModelRouters.is_enabled()
+                && is_any_ai_enabled;
+            add_router_button.update(ctx, |button, ctx| {
+                button.set_disabled(!is_enabled, ctx);
+            });
+        }
+
         let add_profile_button = ctx.add_typed_action_view(|_| {
             ActionButton::new("Add Profile", SecondaryTheme)
                 .with_icon(Icon::Plus)
@@ -1832,6 +1858,19 @@ impl AISettingsPageView {
                 }
             });
         }
+        // Subscribe to WarpConfig to refresh router views when files change.
+        #[cfg(feature = "local_fs")]
+        ctx.subscribe_to_model(
+            &crate::user_config::WarpConfig::handle(ctx),
+            |me, _, event, ctx| {
+                use crate::user_config::WarpConfigUpdateEvent;
+                if matches!(event, WarpConfigUpdateEvent::ModelConfigs) {
+                    me.router_views = Self::create_router_views(ctx);
+                    ctx.notify();
+                }
+            },
+        );
+
         Self {
             page: Self::build_page(None, ctx),
             active_subpage: None,
@@ -1881,6 +1920,10 @@ impl AISettingsPageView {
             conversation_layout_dropdown,
             profile_views,
             add_profile_button,
+            #[cfg(feature = "local_fs")]
+            router_views,
+            #[cfg(feature = "local_fs")]
+            add_router_button,
             custom_endpoint_modal_state,
             remove_custom_endpoint_confirmation_dialog,
             pending_remove_custom_endpoint_index: None,
@@ -2519,6 +2562,9 @@ impl AISettingsPageView {
                 widgets.push(Box::new(CloudHandoffWidget::default()));
                 widgets.push(Box::new(ApiKeysWidget::new(ctx)));
                 widgets.push(Box::new(AwsBedrockWidget::new(ctx)));
+                if FeatureFlag::CustomModelRouters.is_enabled() {
+                    widgets.push(Box::new(CustomModelRoutersWidget));
+                }
                 widgets.push(Box::new(AgentAttributionWidget::default()));
                 widgets.push(Box::new(OtherAIWidget::default()));
                 if FeatureFlag::AgentModeComputerUse.is_enabled() {
@@ -3046,6 +3092,47 @@ impl AISettingsPageView {
         Self::refresh_menu_dropdown(menu, AISettingsPageAction::AddToMCPAllowlist, ctx);
     }
 
+    #[cfg(feature = "local_fs")]
+    fn create_router_views(
+        ctx: &mut ViewContext<Self>,
+    ) -> Vec<ViewHandle<super::custom_router_view::CustomRouterView>> {
+        use super::custom_router_view::{CustomRouterView, CustomRouterViewEvent};
+        use crate::user_config::WarpConfig;
+        if !warp_core::features::FeatureFlag::CustomModelRouters.is_enabled() {
+            return Vec::new();
+        }
+        let routers: Vec<crate::ai::custom_model_routers::CustomModelRouter> =
+            WarpConfig::as_ref(ctx).custom_model_routers().clone();
+        routers
+            .into_iter()
+            .map(|router| {
+                let router_clone = router.clone();
+                let view = ctx.add_typed_action_view(|ctx| CustomRouterView::new(router, ctx));
+                ctx.subscribe_to_view(&view, move |me, _, event, ctx| match event {
+                    CustomRouterViewEvent::Edit => {
+                        let r = router_clone.clone();
+                        ctx.emit(AISettingsPageEvent::OpenCustomRouterEditor(Some(r)));
+                    }
+                    CustomRouterViewEvent::Delete => {
+                        if let Some(path) = &router_clone.source_path {
+                            #[cfg(feature = "local_fs")]
+                            {
+                                if let Err(e) =
+                                    crate::user_config::WarpConfig::delete_custom_model_router(path)
+                                {
+                                    log::warn!("Failed to delete custom router: {e:?}");
+                                }
+                            }
+                            me.router_views = Self::create_router_views(ctx);
+                            ctx.notify();
+                        }
+                    }
+                });
+                view
+            })
+            .collect()
+    }
+
     fn create_profile_views(ctx: &mut ViewContext<Self>) -> Vec<ViewHandle<ExecutionProfileView>> {
         let profiles_model = AIExecutionProfilesModel::as_ref(ctx);
         let profile_ids = profiles_model.get_all_profile_ids();
@@ -3165,10 +3252,12 @@ impl View for AISettingsPageView {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 pub enum AISettingsPageEvent {
     FocusModal,
     OpenAIFactCollection,
     OpenMCPServerCollection,
+    OpenCustomRouterEditor(Option<crate::ai::custom_model_routers::CustomModelRouter>),
     OpenExecutionProfileEditor(ClientProfileId),
     SignupAnonymousUser,
     ShowModal,
@@ -3249,6 +3338,10 @@ pub enum AISettingsPageAction {
     ToggleFileBasedMcp,
     ToggleIncludeAgentCommandsInHistory,
     ToggleAgentAttribution,
+
+    // Custom model routers
+    #[cfg(feature = "local_fs")]
+    OpenAddCustomRouter,
 
     // Custom inference
     OpenAddCustomEndpointModal,
@@ -4033,6 +4126,10 @@ impl TypedActionView for AISettingsPageView {
                         .toggle_and_save_value(ctx));
                 });
                 ctx.notify();
+            }
+            #[cfg(feature = "local_fs")]
+            AISettingsPageAction::OpenAddCustomRouter => {
+                ctx.emit(AISettingsPageEvent::OpenCustomRouterEditor(None));
             }
             AISettingsPageAction::OpenAddCustomEndpointModal => {
                 self.show_add_custom_endpoint_modal(ctx);
@@ -8965,6 +9062,103 @@ impl SettingsWidget for AwsBedrockWidget {
         Container::new(column.finish())
             .with_margin_bottom(HEADER_PADDING)
             .finish()
+    }
+}
+
+#[derive(Default)]
+struct CustomModelRoutersWidget;
+
+impl SettingsWidget for CustomModelRoutersWidget {
+    type View = AISettingsPageView;
+
+    fn search_terms(&self) -> &str {
+        "custom model router complexity prompt auto model routing"
+    }
+
+    fn should_render(&self, _app: &AppContext) -> bool {
+        FeatureFlag::CustomModelRouters.is_enabled()
+    }
+
+    fn render(
+        &self,
+        view: &Self::View,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        use super::custom_router_view::render_router_error_card;
+        use crate::user_config::WarpConfig;
+
+        let is_any_ai_enabled = AISettings::as_ref(app).is_any_ai_enabled(app);
+        let header_color = styles::header_font_color(is_any_ai_enabled, app);
+
+        // Header row: "Custom Model Routers" + add button
+        let header_row = Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(
+                warpui::elements::Shrinkable::new(
+                    1.,
+                    build_sub_header(appearance, "Custom Model Routers", Some(header_color))
+                        .finish(),
+                )
+                .finish(),
+            )
+            .with_child({
+                #[cfg(feature = "local_fs")]
+                {
+                    warpui::elements::Container::new(view.add_router_button.as_ref(app).render(app))
+                        .with_margin_left(16.)
+                        .finish()
+                }
+                #[cfg(not(feature = "local_fs"))]
+                {
+                    warpui::elements::Empty.finish()
+                }
+            })
+            .finish();
+
+        let mut column = Flex::column()
+            .with_child(render_separator(appearance))
+            .with_child(
+                Container::new(header_row)
+                    .with_padding_bottom(HEADER_PADDING)
+                    .finish(),
+            )
+            .with_child(render_ai_setting_description(
+                "Create named model routers that automatically pick the right model based on task complexity or prompt content.",
+                is_any_ai_enabled,
+                app,
+            ));
+
+        // Error cards (files that failed to parse) — shown first
+        #[cfg(feature = "local_fs")]
+        {
+            let errors = WarpConfig::as_ref(app).custom_model_router_errors();
+            for error in errors.iter() {
+                column.add_child(
+                    Container::new(render_router_error_card(
+                        &error.file_name,
+                        &error.error_message,
+                        appearance,
+                    ))
+                    .with_margin_top(8.)
+                    .finish(),
+                );
+            }
+        }
+
+        // Router summary cards
+        #[cfg(feature = "local_fs")]
+        for view_handle in &view.router_views {
+            column.add_child(
+                Container::new(warpui::elements::ChildView::new(view_handle).finish())
+                    .with_margin_top(8.)
+                    .finish(),
+            );
+        }
+
+        column.finish()
     }
 }
 

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -3260,7 +3260,9 @@ pub enum AISettingsPageEvent {
     FocusModal,
     OpenAIFactCollection,
     OpenMCPServerCollection,
+    #[cfg(feature = "local_fs")]
     OpenCustomRouterEditor(Option<crate::ai::custom_model_routers::CustomModelRouter>),
+    #[cfg(feature = "local_fs")]
     OpenCustomRouterFile(PathBuf),
     OpenExecutionProfileEditor(ClientProfileId),
     SignupAnonymousUser,
@@ -9083,15 +9085,13 @@ impl SettingsWidget for CustomModelRoutersWidget {
         FeatureFlag::CustomModelRouters.is_enabled()
     }
 
+    #[cfg_attr(not(feature = "local_fs"), allow(unused_variables))]
     fn render(
         &self,
         view: &Self::View,
         appearance: &Appearance,
         app: &AppContext,
     ) -> Box<dyn Element> {
-        use super::custom_router_view::render_router_error_card;
-        use crate::user_config::WarpConfig;
-
         let is_any_ai_enabled = AISettings::as_ref(app).is_any_ai_enabled(app);
         let header_color = styles::header_font_color(is_any_ai_enabled, app);
 
@@ -9117,12 +9117,12 @@ impl SettingsWidget for CustomModelRoutersWidget {
                 }
                 #[cfg(not(feature = "local_fs"))]
                 {
-                    warpui::elements::Empty::finish()
+                    warpui::elements::Empty::new().finish()
                 }
             })
             .finish();
 
-        let mut column = Flex::column()
+        let column = Flex::column()
             .with_child(render_separator(appearance))
             .with_child(
                 Container::new(header_row)
@@ -9135,12 +9135,16 @@ impl SettingsWidget for CustomModelRoutersWidget {
                 app,
             ));
 
-        // Error cards (files that failed to parse) — shown first
+        // Error cards and router summary cards (local_fs only)
         #[cfg(feature = "local_fs")]
-        {
+        let column = {
+            use super::custom_router_view::render_router_error_card;
+            use crate::user_config::WarpConfig;
+            let mut c = column;
+            // Error cards (files that failed to parse) — shown first
             let errors = WarpConfig::as_ref(app).custom_model_router_errors();
             for error in errors.iter() {
-                column.add_child(
+                c.add_child(
                     Container::new(render_router_error_card(
                         &error.file_name,
                         &error.error_message,
@@ -9150,17 +9154,16 @@ impl SettingsWidget for CustomModelRoutersWidget {
                     .finish(),
                 );
             }
-        }
-
-        // Router summary cards
-        #[cfg(feature = "local_fs")]
-        for view_handle in &view.router_views {
-            column.add_child(
-                Container::new(warpui::elements::ChildView::new(view_handle).finish())
-                    .with_margin_top(8.)
-                    .finish(),
-            );
-        }
+            // Router summary cards
+            for view_handle in &view.router_views {
+                c.add_child(
+                    Container::new(warpui::elements::ChildView::new(view_handle).finish())
+                        .with_margin_top(8.)
+                        .finish(),
+                );
+            }
+            c
+        };
 
         column.finish()
     }

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -3109,6 +3109,9 @@ impl AISettingsPageView {
                 let router_clone = router.clone();
                 let view = ctx.add_typed_action_view(|ctx| CustomRouterView::new(router, ctx));
                 ctx.subscribe_to_view(&view, move |me, _, event, ctx| match event {
+                    CustomRouterViewEvent::OpenFile(path) => {
+                        ctx.emit(AISettingsPageEvent::OpenCustomRouterFile(path.clone()));
+                    }
                     CustomRouterViewEvent::Edit => {
                         let r = router_clone.clone();
                         ctx.emit(AISettingsPageEvent::OpenCustomRouterEditor(Some(r)));
@@ -3258,6 +3261,7 @@ pub enum AISettingsPageEvent {
     OpenAIFactCollection,
     OpenMCPServerCollection,
     OpenCustomRouterEditor(Option<crate::ai::custom_model_routers::CustomModelRouter>),
+    OpenCustomRouterFile(PathBuf),
     OpenExecutionProfileEditor(ClientProfileId),
     SignupAnonymousUser,
     ShowModal,

--- a/app/src/settings_view/custom_router_view.rs
+++ b/app/src/settings_view/custom_router_view.rs
@@ -1,0 +1,358 @@
+use warpui::elements::{
+    ConstrainedBox, Container, CrossAxisAlignment, Flex, MainAxisAlignment, MainAxisSize,
+    ParentElement, Text,
+};
+use warpui::fonts::{Properties, Weight};
+use warpui::{AppContext, Element, Entity, SingletonEntity, View, ViewContext, ViewHandle};
+
+use crate::ai::custom_model_routers::{CustomModelRouter, CustomModelRouting};
+use crate::appearance::Appearance;
+use crate::settings::AISettings;
+use crate::ui_components::icons::Icon;
+use crate::view_components::action_button::{
+    ActionButton, ButtonSize, DangerSecondaryTheme, SecondaryTheme,
+};
+
+#[derive(Debug, Clone)]
+pub enum CustomRouterViewAction {
+    Edit,
+    Delete,
+}
+
+pub enum CustomRouterViewEvent {
+    Edit,
+    Delete,
+}
+
+pub struct CustomRouterView {
+    router: CustomModelRouter,
+    edit_button: ViewHandle<ActionButton>,
+    delete_button: ViewHandle<ActionButton>,
+}
+
+impl CustomRouterView {
+    pub fn new(router: CustomModelRouter, ctx: &mut ViewContext<Self>) -> Self {
+        let is_any_ai_enabled = AISettings::as_ref(ctx).is_any_ai_enabled(ctx);
+
+        let edit_button = ctx.add_typed_action_view(|_ctx| {
+            ActionButton::new("Edit", SecondaryTheme)
+                .with_icon(Icon::Pencil)
+                .with_size(ButtonSize::Small)
+                .on_click(|ctx| {
+                    ctx.dispatch_typed_action(CustomRouterViewAction::Edit);
+                })
+        });
+        edit_button.update(ctx, |button, ctx| {
+            button.set_disabled(!is_any_ai_enabled, ctx);
+        });
+
+        let delete_button = ctx.add_typed_action_view(|_ctx| {
+            ActionButton::new("Delete", DangerSecondaryTheme)
+                .with_icon(Icon::Trash)
+                .with_size(ButtonSize::Small)
+                .on_click(|ctx| {
+                    ctx.dispatch_typed_action(CustomRouterViewAction::Delete);
+                })
+        });
+        delete_button.update(ctx, |button, ctx| {
+            button.set_disabled(!is_any_ai_enabled, ctx);
+        });
+
+        ctx.subscribe_to_model(&AISettings::handle(ctx), |me, _, _, ctx| {
+            let enabled = AISettings::as_ref(ctx).is_any_ai_enabled(ctx);
+            me.edit_button.update(ctx, |button, ctx| {
+                button.set_disabled(!enabled, ctx);
+            });
+            me.delete_button.update(ctx, |button, ctx| {
+                button.set_disabled(!enabled, ctx);
+            });
+            ctx.notify();
+        });
+
+        Self {
+            router,
+            edit_button,
+            delete_button,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn router(&self) -> &CustomModelRouter {
+        &self.router
+    }
+
+    #[allow(dead_code)]
+    pub fn update_router(&mut self, router: CustomModelRouter, ctx: &mut ViewContext<Self>) {
+        self.router = router;
+        ctx.notify();
+    }
+}
+
+impl Entity for CustomRouterView {
+    type Event = CustomRouterViewEvent;
+}
+
+impl View for CustomRouterView {
+    fn ui_name() -> &'static str {
+        "CustomRouterView"
+    }
+
+    fn render(&self, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let is_any_ai_enabled = AISettings::as_ref(app).is_any_ai_enabled(app);
+
+        let text_color = if is_any_ai_enabled {
+            appearance.theme().active_ui_text_color()
+        } else {
+            appearance.theme().disabled_ui_text_color()
+        };
+        let sub_color = if is_any_ai_enabled {
+            appearance
+                .theme()
+                .sub_text_color(appearance.theme().surface_2())
+        } else {
+            appearance.theme().disabled_ui_text_color()
+        };
+
+        // Header row: name + buttons
+        let name_row = Flex::row()
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(
+                Text::new(
+                    self.router.info.display_name.clone(),
+                    appearance.ui_font_family(),
+                    14.,
+                )
+                .with_style(Properties::default().weight(Weight::Medium))
+                .with_color(text_color.into())
+                .finish(),
+            )
+            .with_child(
+                Flex::row()
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_child(
+                        Container::new(self.edit_button.as_ref(app).render(app))
+                            .with_margin_right(8.)
+                            .finish(),
+                    )
+                    .with_child(self.delete_button.as_ref(app).render(app))
+                    .finish(),
+            )
+            .finish();
+
+        // Type label row
+        let type_label = match &self.router.routing {
+            CustomModelRouting::Complexity(_) => "Complexity-based routing",
+            CustomModelRouting::Prompt(_) => "Prompt-based routing",
+        };
+        let type_row = Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(
+                Container::new(
+                    ConstrainedBox::new(Icon::Dataflow.to_warpui_icon(sub_color).finish())
+                        .with_width(12.)
+                        .with_height(12.)
+                        .finish(),
+                )
+                .with_margin_right(6.)
+                .finish(),
+            )
+            .with_child(
+                Text::new(type_label, appearance.ui_font_family(), 12.)
+                    .with_color(sub_color.into())
+                    .finish(),
+            )
+            .finish();
+
+        // Targets summary
+        let targets_row = render_targets_row(
+            &self.router.routing,
+            appearance,
+            sub_color,
+            is_any_ai_enabled,
+        );
+
+        Container::new(
+            Flex::column()
+                .with_child(Container::new(name_row).with_margin_bottom(8.).finish())
+                .with_child(Container::new(type_row).with_margin_bottom(4.).finish())
+                .with_child(targets_row)
+                .finish(),
+        )
+        .with_background(appearance.theme().surface_2())
+        .with_border(
+            warpui::elements::Border::new(1.).with_border_fill(appearance.theme().outline()),
+        )
+        .with_corner_radius(warpui::elements::CornerRadius::with_all(
+            warpui::elements::Radius::Pixels(4.),
+        ))
+        .with_horizontal_padding(16.)
+        .with_vertical_padding(12.)
+        .finish()
+    }
+}
+
+impl warpui::TypedActionView for CustomRouterView {
+    type Action = CustomRouterViewAction;
+
+    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        match action {
+            CustomRouterViewAction::Edit => ctx.emit(CustomRouterViewEvent::Edit),
+            CustomRouterViewAction::Delete => ctx.emit(CustomRouterViewEvent::Delete),
+        }
+    }
+}
+
+fn render_targets_row(
+    routing: &CustomModelRouting,
+    appearance: &Appearance,
+    sub_color: warp_core::ui::theme::Fill,
+    _is_ai_enabled: bool,
+) -> Box<dyn Element> {
+    let mut flex = Flex::column();
+    match routing {
+        CustomModelRouting::Complexity(c) => {
+            flex.add_child(render_model_line(
+                "Default:", &c.default, appearance, sub_color,
+            ));
+            if let Some(easy) = &c.easy {
+                flex.add_child(
+                    Container::new(render_model_line("Easy:", easy, appearance, sub_color))
+                        .with_margin_top(2.)
+                        .finish(),
+                );
+            }
+            if let Some(medium) = &c.medium {
+                flex.add_child(
+                    Container::new(render_model_line("Medium:", medium, appearance, sub_color))
+                        .with_margin_top(2.)
+                        .finish(),
+                );
+            }
+            if let Some(hard) = &c.hard {
+                flex.add_child(
+                    Container::new(render_model_line("Hard:", hard, appearance, sub_color))
+                        .with_margin_top(2.)
+                        .finish(),
+                );
+            }
+        }
+        CustomModelRouting::Prompt(p) => {
+            flex.add_child(render_model_line(
+                "Default:",
+                &p.default_model,
+                appearance,
+                sub_color,
+            ));
+            let rule_count = p.rules.len();
+            if rule_count > 0 {
+                let label = if rule_count == 1 {
+                    "1 rule".to_string()
+                } else {
+                    format!("{rule_count} rules")
+                };
+                flex.add_child(
+                    Container::new(
+                        Text::new(label, appearance.ui_font_family(), 12.)
+                            .with_color(sub_color.into())
+                            .finish(),
+                    )
+                    .with_margin_top(2.)
+                    .finish(),
+                );
+            }
+        }
+    }
+    flex.finish()
+}
+
+fn render_model_line(
+    label: impl Into<String>,
+    model_id: impl Into<String>,
+    appearance: &Appearance,
+    sub_color: warp_core::ui::theme::Fill,
+) -> Box<dyn Element> {
+    Flex::row()
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .with_child(
+            Container::new(
+                Text::new(label.into(), appearance.ui_font_family(), 12.)
+                    .with_color(sub_color.into())
+                    .finish(),
+            )
+            .with_margin_right(6.)
+            .finish(),
+        )
+        .with_child(
+            Text::new(model_id.into(), appearance.ui_font_family(), 12.)
+                .with_color(appearance.theme().active_ui_text_color().into())
+                .finish(),
+        )
+        .finish()
+}
+
+/// A card rendering a file that failed to parse as a custom model router.
+pub fn render_router_error_card(
+    file_name: impl Into<String>,
+    error_message: impl Into<String>,
+    appearance: &Appearance,
+) -> Box<dyn Element> {
+    use warpui::elements::Shrinkable;
+    let theme = appearance.theme();
+    let error_fill = warp_core::ui::theme::Fill::Solid(theme.ui_error_color());
+    let sub = theme.sub_text_color(theme.surface_2());
+    let file_name = file_name.into();
+    let error_message = error_message.into();
+
+    let name_row = Flex::row()
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .with_child(
+            Container::new(
+                ConstrainedBox::new(Icon::AlertTriangle.to_warpui_icon(error_fill).finish())
+                    .with_width(14.)
+                    .with_height(14.)
+                    .finish(),
+            )
+            .with_margin_right(8.)
+            .finish(),
+        )
+        .with_child(
+            Text::new(file_name, appearance.ui_font_family(), 13.)
+                .with_style(Properties::default().weight(Weight::Medium))
+                .with_color(theme.active_ui_text_color().into())
+                .finish(),
+        )
+        .finish();
+
+    // Truncate long error messages to keep the card readable.
+    let truncated = if error_message.len() > 200 {
+        format!("{}…", &error_message[..200])
+    } else {
+        error_message.to_string()
+    };
+
+    let error_row = Shrinkable::new(
+        1.,
+        Text::new(truncated, appearance.ui_font_family(), 11.)
+            .with_color(sub.into())
+            .finish(),
+    )
+    .finish();
+
+    Container::new(
+        Flex::column()
+            .with_child(Container::new(name_row).with_margin_bottom(6.).finish())
+            .with_child(error_row)
+            .finish(),
+    )
+    .with_background(theme.surface_2())
+    .with_border(warpui::elements::Border::new(1.).with_border_fill(error_fill))
+    .with_corner_radius(warpui::elements::CornerRadius::with_all(
+        warpui::elements::Radius::Pixels(4.),
+    ))
+    .with_horizontal_padding(16.)
+    .with_vertical_padding(10.)
+    .finish()
+}

--- a/app/src/settings_view/custom_router_view.rs
+++ b/app/src/settings_view/custom_router_view.rs
@@ -1,31 +1,37 @@
+use std::path::PathBuf;
 use warpui::elements::{
-    ConstrainedBox, Container, CrossAxisAlignment, Flex, MainAxisAlignment, MainAxisSize,
-    ParentElement, Text,
+    ChildView, ConstrainedBox, Container, CrossAxisAlignment, Flex, MainAxisAlignment,
+    MainAxisSize, ParentElement, Text,
 };
 use warpui::fonts::{Properties, Weight};
 use warpui::{AppContext, Element, Entity, SingletonEntity, View, ViewContext, ViewHandle};
 
 use crate::ai::custom_model_routers::{CustomModelRouter, CustomModelRouting};
+use crate::ai::llms::{LLMId, LLMPreferences};
 use crate::appearance::Appearance;
 use crate::settings::AISettings;
 use crate::ui_components::icons::Icon;
 use crate::view_components::action_button::{
     ActionButton, ButtonSize, DangerSecondaryTheme, SecondaryTheme,
 };
+const HEADER_BUTTON_HEIGHT: f32 = 28.;
 
 #[derive(Debug, Clone)]
 pub enum CustomRouterViewAction {
+    OpenFile,
     Edit,
     Delete,
 }
 
 pub enum CustomRouterViewEvent {
+    OpenFile(PathBuf),
     Edit,
     Delete,
 }
 
 pub struct CustomRouterView {
     router: CustomModelRouter,
+    open_file_button: ViewHandle<ActionButton>,
     edit_button: ViewHandle<ActionButton>,
     delete_button: ViewHandle<ActionButton>,
 }
@@ -33,11 +39,24 @@ pub struct CustomRouterView {
 impl CustomRouterView {
     pub fn new(router: CustomModelRouter, ctx: &mut ViewContext<Self>) -> Self {
         let is_any_ai_enabled = AISettings::as_ref(ctx).is_any_ai_enabled(ctx);
+        let open_file_button = ctx.add_typed_action_view(|_ctx| {
+            ActionButton::new("Open file", SecondaryTheme)
+                .with_icon(Icon::File)
+                .with_size(ButtonSize::Small)
+                .with_height(HEADER_BUTTON_HEIGHT)
+                .on_click(|ctx| {
+                    ctx.dispatch_typed_action(CustomRouterViewAction::OpenFile);
+                })
+        });
+        open_file_button.update(ctx, |button, ctx| {
+            button.set_disabled(router.source_path.is_none(), ctx);
+        });
 
         let edit_button = ctx.add_typed_action_view(|_ctx| {
             ActionButton::new("Edit", SecondaryTheme)
                 .with_icon(Icon::Pencil)
                 .with_size(ButtonSize::Small)
+                .with_height(HEADER_BUTTON_HEIGHT)
                 .on_click(|ctx| {
                     ctx.dispatch_typed_action(CustomRouterViewAction::Edit);
                 })
@@ -50,6 +69,7 @@ impl CustomRouterView {
             ActionButton::new("Delete", DangerSecondaryTheme)
                 .with_icon(Icon::Trash)
                 .with_size(ButtonSize::Small)
+                .with_height(HEADER_BUTTON_HEIGHT)
                 .on_click(|ctx| {
                     ctx.dispatch_typed_action(CustomRouterViewAction::Delete);
                 })
@@ -71,6 +91,7 @@ impl CustomRouterView {
 
         Self {
             router,
+            open_file_button,
             edit_button,
             delete_button,
         }
@@ -133,11 +154,16 @@ impl View for CustomRouterView {
                 Flex::row()
                     .with_cross_axis_alignment(CrossAxisAlignment::Center)
                     .with_child(
-                        Container::new(self.edit_button.as_ref(app).render(app))
+                        Container::new(ChildView::new(&self.open_file_button).finish())
                             .with_margin_right(8.)
                             .finish(),
                     )
-                    .with_child(self.delete_button.as_ref(app).render(app))
+                    .with_child(
+                        Container::new(ChildView::new(&self.edit_button).finish())
+                            .with_margin_right(8.)
+                            .finish(),
+                    )
+                    .with_child(ChildView::new(&self.delete_button).finish())
                     .finish(),
             )
             .finish();
@@ -172,6 +198,7 @@ impl View for CustomRouterView {
             appearance,
             sub_color,
             is_any_ai_enabled,
+            app,
         );
 
         Container::new(
@@ -199,6 +226,11 @@ impl warpui::TypedActionView for CustomRouterView {
 
     fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
         match action {
+            CustomRouterViewAction::OpenFile => {
+                if let Some(path) = self.router.source_path.clone() {
+                    ctx.emit(CustomRouterViewEvent::OpenFile(path));
+                }
+            }
             CustomRouterViewAction::Edit => ctx.emit(CustomRouterViewEvent::Edit),
             CustomRouterViewAction::Delete => ctx.emit(CustomRouterViewEvent::Delete),
         }
@@ -210,39 +242,58 @@ fn render_targets_row(
     appearance: &Appearance,
     sub_color: warp_core::ui::theme::Fill,
     _is_ai_enabled: bool,
+    app: &AppContext,
 ) -> Box<dyn Element> {
     let mut flex = Flex::column();
     match routing {
         CustomModelRouting::Complexity(c) => {
             flex.add_child(render_model_line(
-                "Default:", &c.default, appearance, sub_color,
+                "Default:",
+                model_display_name(&c.default, app),
+                appearance,
+                sub_color,
             ));
             if let Some(easy) = &c.easy {
                 flex.add_child(
-                    Container::new(render_model_line("Easy:", easy, appearance, sub_color))
-                        .with_margin_top(2.)
-                        .finish(),
+                    Container::new(render_model_line(
+                        "Easy:",
+                        model_display_name(easy, app),
+                        appearance,
+                        sub_color,
+                    ))
+                    .with_margin_top(2.)
+                    .finish(),
                 );
             }
             if let Some(medium) = &c.medium {
                 flex.add_child(
-                    Container::new(render_model_line("Medium:", medium, appearance, sub_color))
-                        .with_margin_top(2.)
-                        .finish(),
+                    Container::new(render_model_line(
+                        "Medium:",
+                        model_display_name(medium, app),
+                        appearance,
+                        sub_color,
+                    ))
+                    .with_margin_top(2.)
+                    .finish(),
                 );
             }
             if let Some(hard) = &c.hard {
                 flex.add_child(
-                    Container::new(render_model_line("Hard:", hard, appearance, sub_color))
-                        .with_margin_top(2.)
-                        .finish(),
+                    Container::new(render_model_line(
+                        "Hard:",
+                        model_display_name(hard, app),
+                        appearance,
+                        sub_color,
+                    ))
+                    .with_margin_top(2.)
+                    .finish(),
                 );
             }
         }
         CustomModelRouting::Prompt(p) => {
             flex.add_child(render_model_line(
                 "Default:",
-                &p.default_model,
+                model_display_name(&p.default_model, app),
                 appearance,
                 sub_color,
             ));
@@ -266,6 +317,16 @@ fn render_targets_row(
         }
     }
     flex.finish()
+}
+
+/// Resolves a concrete model id (e.g. `claude-4-5-haiku`) to its display
+/// name/alias (e.g. `claude 4.5 haiku`), falling back to the raw id when the
+/// model isn't known to the client.
+fn model_display_name(model_id: &str, app: &AppContext) -> String {
+    LLMPreferences::as_ref(app)
+        .get_llm_info(&LLMId::from(model_id))
+        .map(|info| info.display_name.clone())
+        .unwrap_or_else(|| model_id.to_string())
 }
 
 fn render_model_line(

--- a/app/src/settings_view/custom_router_view.rs
+++ b/app/src/settings_view/custom_router_view.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+
 use warpui::elements::{
     ChildView, ConstrainedBox, Container, CrossAxisAlignment, Flex, MainAxisAlignment,
     MainAxisSize, ParentElement, Text,
@@ -388,8 +389,8 @@ pub fn render_router_error_card(
         .finish();
 
     // Truncate long error messages to keep the card readable.
-    let truncated = if error_message.len() > 200 {
-        format!("{}…", &error_message[..200])
+    let truncated = if error_message.chars().count() > 200 {
+        format!("{}…", error_message.chars().take(200).collect::<String>())
     } else {
         error_message.to_string()
     };

--- a/app/src/settings_view/custom_router_view.rs
+++ b/app/src/settings_view/custom_router_view.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "local_fs")]
 use std::path::PathBuf;
 
 use warpui::elements::{
@@ -12,11 +13,13 @@ use crate::ai::llms::{LLMId, LLMPreferences};
 use crate::appearance::Appearance;
 use crate::settings::AISettings;
 use crate::ui_components::icons::Icon;
-use crate::view_components::action_button::{
-    ActionButton, ButtonSize, DangerSecondaryTheme, SecondaryTheme,
-};
+use crate::view_components::action_button::ActionButton;
+#[cfg(feature = "local_fs")]
+use crate::view_components::action_button::{ButtonSize, DangerSecondaryTheme, SecondaryTheme};
+#[cfg(feature = "local_fs")]
 const HEADER_BUTTON_HEIGHT: f32 = 28.;
 
+#[cfg(feature = "local_fs")]
 #[derive(Debug, Clone)]
 pub enum CustomRouterViewAction {
     OpenFile,
@@ -25,8 +28,11 @@ pub enum CustomRouterViewAction {
 }
 
 pub enum CustomRouterViewEvent {
+    #[cfg(feature = "local_fs")]
     OpenFile(PathBuf),
+    #[cfg(feature = "local_fs")]
     Edit,
+    #[cfg(feature = "local_fs")]
     Delete,
 }
 
@@ -38,6 +44,7 @@ pub struct CustomRouterView {
 }
 
 impl CustomRouterView {
+    #[cfg(feature = "local_fs")]
     pub fn new(router: CustomModelRouter, ctx: &mut ViewContext<Self>) -> Self {
         let is_any_ai_enabled = AISettings::as_ref(ctx).is_any_ai_enabled(ctx);
         let open_file_button = ctx.add_typed_action_view(|_ctx| {
@@ -222,6 +229,7 @@ impl View for CustomRouterView {
     }
 }
 
+#[cfg(feature = "local_fs")]
 impl warpui::TypedActionView for CustomRouterView {
     type Action = CustomRouterViewAction;
 
@@ -356,6 +364,7 @@ fn render_model_line(
 }
 
 /// A card rendering a file that failed to parse as a custom model router.
+#[cfg(feature = "local_fs")]
 pub fn render_router_error_card(
     file_name: impl Into<String>,
     error_message: impl Into<String>,

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -49,6 +49,7 @@ use warpui::{
 };
 
 use self::telemetry::SettingsTelemetryEvent;
+use crate::ai::custom_model_routers::CustomModelRouter;
 use crate::ai::execution_profiles::profiles::ClientProfileId;
 use crate::appearance::Appearance;
 use crate::editor::{
@@ -82,6 +83,7 @@ mod billing_and_usage_page;
 mod billing_and_usage_page_v2;
 mod code_page;
 pub(crate) mod custom_inference_modal;
+mod custom_router_view;
 mod delete_environment_confirmation_dialog;
 mod directory_color_add_picker;
 pub(crate) mod environments_page;
@@ -212,7 +214,7 @@ pub(super) fn render_model_chips(
     chips.finish()
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq)]
 pub enum SettingsViewEvent {
     Pane(PaneEvent),
     StartResize,
@@ -226,6 +228,7 @@ pub enum SettingsViewEvent {
     },
     OpenAIFactCollection,
     OpenMCPServerCollection,
+    OpenCustomRouterEditor(Option<CustomModelRouter>),
     OpenExecutionProfileEditor(ClientProfileId),
     OpenLspLogs {
         log_path: PathBuf,
@@ -1919,6 +1922,9 @@ impl SettingsView {
             }
             AISettingsPageEvent::OpenMCPServerCollection => {
                 ctx.emit(SettingsViewEvent::OpenMCPServerCollection)
+            }
+            AISettingsPageEvent::OpenCustomRouterEditor(router) => {
+                ctx.emit(SettingsViewEvent::OpenCustomRouterEditor(router.clone()));
             }
             AISettingsPageEvent::OpenExecutionProfileEditor(profile_id) => {
                 ctx.emit(SettingsViewEvent::OpenExecutionProfileEditor(*profile_id));

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -229,6 +229,7 @@ pub enum SettingsViewEvent {
     OpenAIFactCollection,
     OpenMCPServerCollection,
     OpenCustomRouterEditor(Option<CustomModelRouter>),
+    OpenCustomRouterFile(PathBuf),
     OpenExecutionProfileEditor(ClientProfileId),
     OpenLspLogs {
         log_path: PathBuf,
@@ -1925,6 +1926,9 @@ impl SettingsView {
             }
             AISettingsPageEvent::OpenCustomRouterEditor(router) => {
                 ctx.emit(SettingsViewEvent::OpenCustomRouterEditor(router.clone()));
+            }
+            AISettingsPageEvent::OpenCustomRouterFile(path) => {
+                ctx.emit(SettingsViewEvent::OpenCustomRouterFile(path.clone()));
             }
             AISettingsPageEvent::OpenExecutionProfileEditor(profile_id) => {
                 ctx.emit(SettingsViewEvent::OpenExecutionProfileEditor(*profile_id));

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -1924,9 +1924,11 @@ impl SettingsView {
             AISettingsPageEvent::OpenMCPServerCollection => {
                 ctx.emit(SettingsViewEvent::OpenMCPServerCollection)
             }
+            #[cfg(feature = "local_fs")]
             AISettingsPageEvent::OpenCustomRouterEditor(router) => {
                 ctx.emit(SettingsViewEvent::OpenCustomRouterEditor(router.clone()));
             }
+            #[cfg(feature = "local_fs")]
             AISettingsPageEvent::OpenCustomRouterFile(path) => {
                 ctx.emit(SettingsViewEvent::OpenCustomRouterFile(path.clone()));
             }

--- a/app/src/terminal/input/models/data_source.rs
+++ b/app/src/terminal/input/models/data_source.rs
@@ -285,6 +285,8 @@ impl ModelSearchItem {
             is_custom_endpoint || is_using_api_key_for_provider(&llm.provider, app);
         let leading_icon = if is_using_bedrock {
             Icon::Aws
+        } else if is_custom_router {
+            Icon::Dataflow
         } else {
             llm.provider.icon().unwrap_or(Icon::Oz)
         };

--- a/app/src/terminal/view/ambient_agent/model_selector.rs
+++ b/app/src/terminal/view/ambient_agent/model_selector.rs
@@ -18,6 +18,7 @@ use warpui::{
 
 use crate::ai::blocklist::agent_view::agent_input_footer::AgentInputButtonTheme;
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
+use crate::ai::custom_model_routers::is_custom_router_id;
 use crate::ai::execution_profiles::model_menu_items::is_auto;
 use crate::ai::harness_availability::{HarnessAvailabilityEvent, HarnessAvailabilityModel};
 use crate::ai::harness_display::icon_for as harness_icon_for;
@@ -490,8 +491,13 @@ impl ModelSelector {
             .chain(other_choices)
             .map(|llm| {
                 let display_name = llm.menu_display_name();
+                let leading_icon = if is_custom_router_id(llm.id.as_str()) {
+                    Icon::Dataflow
+                } else {
+                    llm.provider.icon().unwrap_or(Icon::Oz)
+                };
                 let fields = MenuItemFields::new(display_name)
-                    .with_icon(llm.provider.icon().unwrap_or(Icon::Oz))
+                    .with_icon(leading_icon)
                     .with_icon_size_override(ITEM_ICON_SIZE)
                     .with_font_size_override(ITEM_FONT_SIZE)
                     .with_padding_override(ITEM_VERTICAL_PADDING, MENU_HORIZONTAL_PADDING)

--- a/app/src/user_config/mod.rs
+++ b/app/src/user_config/mod.rs
@@ -137,6 +137,12 @@ impl WarpConfig {
         &self.custom_model_routers
     }
 
+    /// Parse errors for `custom_model_routers/` files that failed to load.
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
+    pub fn custom_model_router_errors(&self) -> &Vec<ModelConfigError> {
+        &self.custom_model_router_errors
+    }
+
     /// Saving the newly created launch configuration to the WarpConfig that we currently
     /// have.
     pub fn append_launch_config(

--- a/app/src/user_config/native.rs
+++ b/app/src/user_config/native.rs
@@ -166,6 +166,39 @@ impl super::WarpConfig {
         }
     }
 
+    /// Writes a custom model router to disk as a YAML file.
+    ///
+    /// When `existing_path` is provided (editing) the file at that path is
+    /// overwritten; otherwise a new file named `<name>.yaml` is created under
+    /// `custom_model_routers_dir()`. Returns the path written to.
+    #[cfg(feature = "local_fs")]
+    pub fn save_custom_model_router(
+        name: &str,
+        yaml: &str,
+        existing_path: Option<&std::path::Path>,
+    ) -> anyhow::Result<std::path::PathBuf> {
+        let dir = custom_model_routers_dir();
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| anyhow::anyhow!("could not create custom_model_routers dir: {e}"))?;
+        let path = if let Some(p) = existing_path {
+            p.to_path_buf()
+        } else {
+            dir.join(format!("{name}.yaml"))
+        };
+        std::fs::write(&path, yaml)
+            .map_err(|e| anyhow::anyhow!("could not write router file: {e}"))?;
+        Ok(path)
+    }
+
+    /// Deletes a custom model router file from disk.
+    /// The filesystem watcher in [`Self::handle_warp_managed_paths_event`] will
+    /// pick up the deletion and reload `custom_model_routers`.
+    #[cfg(feature = "local_fs")]
+    pub fn delete_custom_model_router(source_path: &std::path::Path) -> anyhow::Result<()> {
+        std::fs::remove_file(source_path)
+            .map_err(|e| anyhow::anyhow!("could not delete router file: {e}"))
+    }
+
     /// This method takes a file name candidate (appends .yaml if missing) and a LaunchConfig as
     /// arguments. It saves the file and returns the filename used if successful.
     #[cfg(feature = "local_fs")]

--- a/app/src/view_components/filterable_dropdown.rs
+++ b/app/src/view_components/filterable_dropdown.rs
@@ -59,6 +59,12 @@ pub struct FilterableDropdown<A: DropdownItemAction = ()> {
     style_override: Option<UiComponentStyles>,
     hovered_style_override: Option<UiComponentStyles>,
     menu_header_text_override: Option<MenuHeaderTextFormatter>,
+    /// Optional placeholder shown in the closed top bar when no item is
+    /// selected. Setting a placeholder also opts the dropdown into allowing an
+    /// empty selection: `set_filtered_items` will not auto-highlight the first
+    /// item when nothing has been selected yet, so the top bar stays blank
+    /// instead of leaking the first item as a phantom selection.
+    placeholder: Option<String>,
     /// True when a pinned footer has been registered via `set_footer`.
     /// When true, the footer lives inside the `Menu`'s own `Dismiss` (via
     /// `Menu::set_pinned_footer_builder`), so clicks on it never trigger the
@@ -130,6 +136,7 @@ where
             style_override: None,
             hovered_style_override: None,
             menu_header_text_override: None,
+            placeholder: None,
             has_pinned_footer: false,
             menu_width: None,
             vertical_margin: DROPDOWN_PADDING,
@@ -155,11 +162,28 @@ where
         ctx.notify();
     }
 
+    /// Override the vertical margin applied above and below the dropdown's top
+    /// bar (default [`DROPDOWN_PADDING`]). Set to `0.` when the caller manages
+    /// its own spacing and needs the bar to align flush with sibling inputs.
+    pub fn set_vertical_margin(&mut self, vertical_margin: f32, ctx: &mut ViewContext<Self>) {
+        self.vertical_margin = vertical_margin;
+        ctx.notify();
+    }
+
     pub fn set_menu_header_text_override<F>(&mut self, formatter: F)
     where
         F: Fn(&str) -> String + 'static,
     {
         self.menu_header_text_override = Some(Box::new(formatter));
+    }
+
+    /// Sets placeholder text shown (greyed) in the closed top bar when no item
+    /// is selected, and opts the dropdown into allowing an empty selection so
+    /// the placeholder is preserved rather than being replaced by the first
+    /// item after filtering.
+    pub fn set_placeholder(&mut self, placeholder: impl Into<String>, ctx: &mut ViewContext<Self>) {
+        self.placeholder = Some(placeholder.into());
+        ctx.notify();
     }
 
     pub fn set_footer<F>(&mut self, builder: F, ctx: &mut ViewContext<Self>)
@@ -427,8 +451,8 @@ where
     }
 
     fn render_closed_top_bar(&self, appearance: &Appearance) -> Box<dyn Element> {
-        let (selected_item_text, font_family_id) = match self.static_menu_header {
-            Some(header) => (header.to_string(), None),
+        let (selected_item_text, font_family_id, is_placeholder) = match self.static_menu_header {
+            Some(header) => (header.to_string(), None, false),
             None => match self.selected_item.clone() {
                 Some(MenuItem::Item(fields)) => {
                     let label = fields.label();
@@ -437,11 +461,32 @@ where
                     } else {
                         label.to_string()
                     };
-                    (text, fields.override_font_family())
+                    (text, fields.override_font_family(), false)
                 }
-                _ => (String::new(), None),
+                _ => match &self.placeholder {
+                    Some(placeholder) => (placeholder.clone(), None, true),
+                    None => (String::new(), None, false),
+                },
             },
         };
+
+        let mut base_style = self.style_override.unwrap_or(UiComponentStyles {
+            padding: Some(Coords {
+                top: 5.,
+                bottom: 5.,
+                left: 8.,
+                right: 8.,
+            }),
+            ..Default::default()
+        });
+        if is_placeholder {
+            base_style.font_color = Some(
+                appearance
+                    .theme()
+                    .sub_text_color(appearance.theme().surface_1())
+                    .into(),
+            );
+        }
 
         let mut top_bar = appearance
             .ui_builder()
@@ -458,15 +503,7 @@ where
                 )
                 .with_inner_padding(10.),
             )
-            .with_style(self.style_override.unwrap_or(UiComponentStyles {
-                padding: Some(Coords {
-                    top: 5.,
-                    bottom: 5.,
-                    left: 8.,
-                    right: 8.,
-                }),
-                ..Default::default()
-            }))
+            .with_style(base_style)
             .set_clicked_styles(None);
 
         if let Some(hovered_style) = self.hovered_style_override {
@@ -675,6 +712,11 @@ where
         // If it isn't, we set the selected element to the first index of
         // the new elements such that there's always a candidate element to select.
         let current_label = self.current_selected_item_label().to_string();
+        // When a placeholder is configured and nothing is selected yet, don't
+        // auto-highlight the first item: doing so emits `ItemSelected`, which
+        // the subscription would cache as a phantom selection and surface in
+        // the top bar (defeating the blank/placeholder state).
+        let allow_empty_selection = self.placeholder.is_some() && current_label.is_empty();
         let mut current_label_not_visible = true;
         self.dropdown.update(ctx, |dropdown, ctx| {
             dropdown.set_items(
@@ -694,7 +736,11 @@ where
             );
 
             if current_label_not_visible && !dropdown.is_empty() {
-                dropdown.set_selected_by_index(0, ctx);
+                if allow_empty_selection {
+                    dropdown.reset_selection(ctx);
+                } else {
+                    dropdown.set_selected_by_index(0, ctx);
+                }
             } else {
                 dropdown.set_selected_by_name(&current_label, ctx);
             }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -456,7 +456,9 @@ use crate::util::file::external_editor::EditorSettings;
 use crate::util::links;
 use crate::util::openable_file_type::FileTarget;
 #[cfg(feature = "local_fs")]
-use crate::util::openable_file_type::{resolve_file_target_with_editor_choice, EditorLayout};
+use crate::util::openable_file_type::{
+    resolve_file_target_to_open_in_warp, resolve_file_target_with_editor_choice, EditorLayout,
+};
 use crate::util::traffic_lights::{traffic_light_data, TrafficLightMouseStates, TrafficLightSide};
 use crate::util::truncation::truncate_from_end;
 #[cfg(target_family = "wasm")]
@@ -14770,6 +14772,12 @@ impl Workspace {
                 #[cfg(not(feature = "local_fs"))]
                 let _ = rule_paths;
             }
+            SettingsViewEvent::OpenCustomRouterFile(path) => {
+                #[cfg(feature = "local_fs")]
+                self.open_custom_router_file(path, ctx);
+                #[cfg(not(feature = "local_fs"))]
+                let _ = path;
+            }
         }
     }
 
@@ -17479,6 +17487,28 @@ impl Workspace {
             let tail_command = tail_command_for_shell(shell_family, log_path);
             terminal.set_pending_command(&tail_command, ctx);
         });
+    }
+
+    /// Opens a custom model router's YAML config file in Warp's own editor.
+    ///
+    /// Unlike most "open file" flows, this always uses the Warp code editor
+    /// rather than honoring the user's external/system editor preference, since
+    /// the button is specifically for editing the router config inside Warp.
+    #[cfg(feature = "local_fs")]
+    fn open_custom_router_file(&mut self, path: &Path, ctx: &mut ViewContext<Self>) {
+        let settings = EditorSettings::as_ref(ctx);
+        let target = resolve_file_target_to_open_in_warp(path, settings, None);
+        self.open_file_with_target(
+            path.to_path_buf(),
+            target,
+            None,
+            CodeSource::Link {
+                path: path.to_path_buf(),
+                range_start: None,
+                range_end: None,
+            },
+            ctx,
+        );
     }
 
     fn run_tab_config_skill(&mut self, path: &Path, ctx: &mut ViewContext<Self>) {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -289,7 +289,7 @@ use crate::pane_group::pane::ActionOrigin;
 use crate::pane_group::FilePane;
 use crate::pane_group::{
     self, AIFactPane, AnyPaneContent, ChildAgentOrigin, CodeDiffPane, CodePane, CodeReviewPanelArg,
-    Direction as PaneGroupDirection, Direction, EnvironmentManagementPane,
+    CustomRouterEditorPane, Direction as PaneGroupDirection, Direction, EnvironmentManagementPane,
     ExecutionProfileEditorPane, NetworkLogPane, NewTerminalOptions, PaneGroup, PaneId, PanesLayout,
     TabBarHoverIndex, TerminalPaneId,
 };
@@ -8653,6 +8653,23 @@ impl Workspace {
         });
     }
 
+    /// Opens a custom model router editor pane in a right-split.
+    ///
+    /// Pass `existing = None` to create a new router or `existing = Some(router)` to edit one.
+    pub fn open_custom_router_editor_pane(
+        &mut self,
+        direction: Option<Direction>,
+        existing: Option<crate::ai::custom_model_routers::CustomModelRouter>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let pane = CustomRouterEditorPane::new(existing, ctx);
+        let direction = direction.unwrap_or(Direction::Right);
+        self.active_tab_pane_group().update(ctx, |pane_group, ctx| {
+            pane_group
+                .add_pane_with_direction(direction, pane, true /* focus_new_pane */, ctx);
+        });
+    }
+
     /// Open the Environment Management pane in a split pane (default direction is right).
     pub fn open_environment_management_pane(
         &mut self,
@@ -14726,6 +14743,9 @@ impl Workspace {
                     },
                     ctx
                 );
+            }
+            SettingsViewEvent::OpenCustomRouterEditor(router) => {
+                self.open_custom_router_editor_pane(None, router.clone(), ctx);
             }
             SettingsViewEvent::OpenExecutionProfileEditor(profile_id) => {
                 self.open_execution_profile_editor_pane(None, *profile_id, ctx);

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -4031,9 +4031,10 @@ impl PaneGroup {
             IPaneType::AIFact => TypedPane::AIFact,
             IPaneType::AIDocument => TypedPane::AIDocument,
             IPaneType::ExecutionProfileEditor => TypedPane::ExecutionProfileEditor,
-            IPaneType::GetStarted | IPaneType::NetworkLog | IPaneType::DeferredPlaceholder => {
-                TypedPane::Other
-            }
+            IPaneType::CustomRouterEditor
+            | IPaneType::GetStarted
+            | IPaneType::NetworkLog
+            | IPaneType::DeferredPlaceholder => TypedPane::Other,
             #[cfg(test)]
             IPaneType::Dummy => TypedPane::Other,
         }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -85,6 +85,12 @@
       "skillPath": ".agents/skills/review-pr/SKILL.md",
       "computedHash": "f27bfc9743fa0d240763a26519b25112a0ad8652c9a2b2b52daeb7af2d2a862c"
     },
+    "saga": {
+      "source": "warpdotdev/common-skills",
+      "sourceType": "github",
+      "skillPath": ".agents/skills/saga/SKILL.md",
+      "computedHash": "52d94bc2b29ba1e8738267c031a1ab4ea8a83d197baae32608014653758b5a7e"
+    },
     "spec-driven-implementation": {
       "source": "warpdotdev/common-skills",
       "sourceType": "github",


### PR DESCRIPTION
https://warpdev.slack.com/archives/C0BBA6U9YAZ/p1782362972222049

## Description

Adds a UI for creating, editing, and deleting local custom model routers directly from the Warp Agent settings page, rather than requiring manual YAML file editing.

**What changed:**
- **YAML serialization**: Added `to_yaml_string()` to `CustomModelRouter` so the UI can write files back to disk in the same format they're read from
- **File operations**: Added `save_custom_model_router()` and `delete_custom_model_router()` static methods to `WarpConfig`, plus a public `custom_model_router_errors()` getter for surfacing parse errors
- **`CustomRouterView`** (`settings_view/custom_router_view.rs`): Summary card showing name, type, and model targets with Edit/Delete buttons; error cards (shown first) for files that failed to parse with filename, truncated message, and styling
- **`CustomRouterEditorView`** (`ai/custom_model_router_editor.rs`): Side-pane editor with name input, Complexity/Prompt type toggle, model dropdowns per complexity class (default required; easy/medium/hard optional with "Inherit default"), prompt rule list with description editor and model dropdown per rule, Add/Remove rule, inline validation errors, and Save/Cancel/Delete buttons
- **`CustomRouterEditorPane`** (`pane_group/pane/custom_router_editor_pane.rs`): Pane wrapper following the `ExecutionProfileEditorPane` pattern
- **Plumbing**: Added `CustomRouterEditor` to `IPaneType`, `PaneId`, and `LeafContents` enums; wired `render()`, persistence match arms, and launch config handling
- **Settings integration** (`settings_view/ai_page.rs`): New `CustomModelRoutersWidget` in the WarpAgent subpage (gated on `FeatureFlag::CustomModelRouters`) with an "+ Add router" button; subscribes to `WarpConfig` to refresh when files change on disk
- **Event routing**: `OpenCustomRouterEditor` wired through `AISettingsPageEvent` → `SettingsViewEvent` → workspace → `CustomRouterEditorPane::new()`

**File sync is bidirectional**: files created outside the UI appear as cards after the fs watcher fires; edits made in the UI write YAML files that the watcher then reloads into `LLMPreferences`.

## Linked Issue

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/a87da454-6430-41d8-ae27-7f3617a0c3f2
Plan: https://staging.warp.dev/drive/notebook/2MHg9XFtowREhC6BsNLQ4z

CHANGELOG-IMPROVEMENT: Custom model routers can now be created and edited directly in Warp Agent settings, without manual YAML file editing.

Co-Authored-By: Oz <oz-agent@warp.dev>