### PR TITLE
Fix silently-dropped Oz viewer prompts after network disconnect

### DIFF
--- a/app/src/terminal/shared_session/viewer/network.rs
+++ b/app/src/terminal/shared_session/viewer/network.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use anyhow::bail;
 use async_channel::Receiver;
-use futures_util::stream::AbortHandle;
+use futures_util::stream::{abortable, AbortHandle};
 use futures_util::{SinkExt, StreamExt};
 use instant::Instant;
 use parking_lot::FairMutex;
@@ -38,9 +38,11 @@ use websocket::{Message, Sink, Stream, WebsocketMessage as _};
 use crate::auth::auth_state::AuthState;
 use crate::auth::{AuthStateProvider, UserUid};
 use crate::editor::{CrdtOperation, ReplicaId};
+use crate::network::{NetworkStatus, NetworkStatusEvent, NetworkStatusKind};
 use crate::server::server_api::auth::AuthClient;
 use crate::server::server_api::ServerApiProvider;
 use crate::server::telemetry::telemetry_context;
+use crate::system::{SystemStats, SystemStatsEvent};
 use crate::terminal::event_listener::ChannelEventListener;
 use crate::terminal::model::block::BlockId;
 use crate::terminal::shared_session::shared_handlers::RemoteUpdateGuard;
@@ -143,6 +145,14 @@ pub struct Network {
     /// The next event number to use when sending a write to pty request to the server.
     write_to_pty_event_no: WriteToPtySeqNo,
     pty_bytes_batch_status: PtyBytesBatchStatus,
+
+    /// Abort handle for the currently-live websocket receive task. Stored so a hung or dead
+    /// socket can be torn down deterministically (e.g. on CPU sleep, network loss, or a
+    /// proactive reconnect) instead of relying on the graceful-close cascade, which never
+    /// runs for a connection whose TCP died silently (no FIN). Mirrors
+    /// [`crate::server::cloud_objects::listener::Listener`]'s
+    /// `current_subscription_abort_handle`.
+    live_stream_abort_handle: Option<AbortHandle>,
 }
 
 impl Network {
@@ -184,10 +194,12 @@ impl Network {
             pty_bytes_batch_status: PtyBytesBatchStatus::NotBatching {
                 last_sent_at: Instant::now(),
             },
+            live_stream_abort_handle: None,
         };
 
         model.start_write_to_pty_events_listener(write_to_pty_events_rx, ctx);
         model.start_websocket(session_id, ws_proxy_rx, ctx);
+        Self::subscribe_to_connectivity_signals(ctx);
         ctx.spawn_stream_local(
             selection_throttled_rx,
             |network, selection, _ctx| {
@@ -245,7 +257,10 @@ impl Network {
             pty_bytes_batch_status: PtyBytesBatchStatus::NotBatching {
                 last_sent_at: Instant::now(),
             },
+            live_stream_abort_handle: None,
         };
+
+        Self::subscribe_to_connectivity_signals(ctx);
 
         ctx.emit(NetworkEvent::JoinedSuccessfully {
             active_prompt,
@@ -310,6 +325,14 @@ impl Network {
         stream: impl Stream,
         ctx: &mut ModelContext<Self>,
     ) {
+        // Wrap the inbound stream so we can deterministically tear it down (e.g. on CPU sleep,
+        // network loss, or a proactive reconnect) instead of relying on the graceful-close
+        // cascade, which never runs for a socket whose TCP died silently. Each connection gets
+        // its own abort handle: aborting one only suppresses that connection's completion
+        // handler, so a stale socket can't tear down a connection that has since been replaced.
+        let (stream, live_stream_abort_handle) = abortable(stream);
+        self.live_stream_abort_handle = Some(live_stream_abort_handle.clone());
+
         // Receive messages from the server.
         ctx.spawn_stream_local(
             stream,
@@ -321,8 +344,15 @@ impl Network {
                     log::error!("Got error from shared session viewer websocket: {e}");
                 }
             },
-            |network, ctx| {
+            move |network, ctx| {
                 log::info!("Websocket to session sharing server ended");
+                if live_stream_abort_handle.is_aborted() {
+                    // We deliberately tore this socket down (proactive reconnect, CPU sleep, or
+                    // network loss). The path that aborted it owns the reconnect decision, so do
+                    // nothing here. This also prevents a stale socket's completion handler from
+                    // tearing down a connection that has since been replaced by a healthy one.
+                    return;
+                }
                 if matches!(network.stage, Stage::JoinedSuccessfully) {
                     // The connection may have timed out or the server restarted.
                     log::info!("Viewer reconnecting: websocket closed by server");
@@ -517,6 +547,88 @@ impl Network {
                 }
             },
         );
+    }
+
+    /// Subscribe to OS-level connectivity signals so we can proactively detect that the
+    /// underlying socket may have silently died (laptop sleep, Wi-Fi change, NAT rebind) and
+    /// replace it. Without this, the viewer only reconnects when the websocket stream itself
+    /// ends, which never happens for a dead/hung TCP connection that received no FIN — leaving
+    /// `stage` stuck at `JoinedSuccessfully` and silently dropping follow-up prompts.
+    ///
+    /// Mirrors the proven pattern in
+    /// [`crate::server::cloud_objects::listener::Listener`] (CLD-172).
+    fn subscribe_to_connectivity_signals(ctx: &mut ModelContext<Self>) {
+        ctx.subscribe_to_model(&SystemStats::handle(ctx), Self::handle_cpu_event);
+        ctx.subscribe_to_model(
+            &NetworkStatus::handle(ctx),
+            Self::handle_network_status_changed_event,
+        );
+    }
+
+    fn handle_cpu_event(
+        &mut self,
+        _: ModelHandle<SystemStats>,
+        event: &SystemStatsEvent,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        match event {
+            SystemStatsEvent::CpuWasAwakened => self.reconnect_after_possible_disconnect(ctx),
+            SystemStatsEvent::CpuWillSleep => self.abort_live_connection(),
+        }
+    }
+
+    fn handle_network_status_changed_event(
+        &mut self,
+        _: ModelHandle<NetworkStatus>,
+        event: &NetworkStatusEvent,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        match event {
+            NetworkStatusEvent::NetworkStatusChanged { new_status } => match new_status {
+                NetworkStatusKind::Online => self.reconnect_after_possible_disconnect(ctx),
+                NetworkStatusKind::Offline => self.abort_live_connection(),
+            },
+        }
+    }
+
+    /// Triggered by an OS signal (CPU wake / network online) that indicates the underlying
+    /// socket may have silently died while we were away. Proactively replaces it with a fresh
+    /// rejoin so follow-up prompts aren't written into a dead sink.
+    fn reconnect_after_possible_disconnect(&mut self, ctx: &mut ModelContext<Self>) {
+        match &self.stage {
+            Stage::JoinedSuccessfully => {
+                log::info!("Viewer proactively reconnecting after CPU wake / network online");
+                self.reconnect_websocket(ctx);
+            }
+            Stage::Reconnecting { abort_handle } => {
+                // A reconnect is already in flight, but it may be stalled on a long backoff
+                // against a dead socket. Abort it and start a fresh attempt so the wake/online
+                // signal takes effect immediately. Clear the `Reconnecting` stage first so
+                // `reconnect_websocket` (which no-ops while reconnecting) proceeds.
+                log::info!("Viewer restarting in-flight reconnect after CPU wake / network online");
+                let abort_handle = abort_handle.clone();
+                abort_handle.abort();
+                self.stage = Stage::JoinedSuccessfully;
+                self.reconnect_websocket(ctx);
+            }
+            // Nothing to reconnect: we either haven't joined yet (the initial connect will
+            // surface its own failure) or the session has ended.
+            Stage::BeforeJoined | Stage::Finished => {}
+        }
+    }
+
+    /// Triggered by an OS signal (CPU will sleep / network offline) that indicates the socket
+    /// is about to die. Tears the live connection down so we stop writing into a soon-to-be-dead
+    /// sink; a paired wake/online signal then triggers a fresh reconnect. Stage is intentionally
+    /// left unchanged — we rely on the wake/online signal (or the existing reconnect handlers)
+    /// to re-establish the connection.
+    fn abort_live_connection(&mut self) {
+        if matches!(self.stage, Stage::JoinedSuccessfully) {
+            log::info!(
+                "Viewer tearing down live shared-session socket ahead of CPU sleep / network offline"
+            );
+            self.close();
+        }
     }
 
     fn process_websocket_message(&mut self, message: Message, ctx: &mut ModelContext<Self>) {
@@ -789,6 +901,14 @@ impl Network {
     /// Close the websocket to the session-sharing-server.
     pub fn close(&mut self) {
         if let Stage::Reconnecting { abort_handle } = &self.stage {
+            abort_handle.abort();
+        }
+        // Abort the live receive task so a hung/dead socket is torn down deterministically,
+        // rather than relying on the graceful-close cascade (send loop ends -> sink.close() ->
+        // server closes read half -> stream ends) which never runs for a connection whose TCP
+        // died silently. The aborted task's completion handler checks `is_aborted()` and so
+        // will not trigger another reconnect.
+        if let Some(abort_handle) = self.live_stream_abort_handle.take() {
             abort_handle.abort();
         }
         // Closing this channel will close the websocket.

--- a/app/src/terminal/shared_session/viewer/network_tests.rs
+++ b/app/src/terminal/shared_session/viewer/network_tests.rs
@@ -5,12 +5,19 @@ use async_channel::Sender;
 use async_io::Timer;
 use instant::Instant;
 use parking_lot::FairMutex;
+use session_sharing_protocol::common::{Scrollback, WindowSize};
 use session_sharing_protocol::viewer::UpstreamMessage;
-use warpui::{App, ModelHandle};
+use warpui::{App, ModelHandle, SingletonEntity};
 
 use super::{Network, PtyBytesBatchStatus, Stage};
+use crate::network::NetworkStatus;
+use crate::system::SystemStats;
 use crate::terminal::event_listener::ChannelEventListener;
 use crate::terminal::shared_session::shared_handlers::RemoteUpdateGuard;
+use crate::terminal::shared_session::viewer::event_loop::{
+    EventLoop, SharedSessionInitialLoadMode,
+};
+use crate::terminal::shared_session::SharedSessionStatus;
 use crate::terminal::TerminalModel;
 use crate::test_util::add_window_with_terminal;
 use crate::test_util::terminal::initialize_app_for_terminal_view;
@@ -38,6 +45,91 @@ fn create_network(app: &mut App) -> (ModelHandle<Network>, Sender<Vec<u8>>) {
     });
 
     (network, write_to_pty_events_tx)
+}
+
+/// Drives the network into a fully-joined state with a live [`EventLoop`], which
+/// [`Network::reconnect_websocket`] requires in order to actually attempt a reconnect.
+fn join_network_with_event_loop(app: &mut App, network: &ModelHandle<Network>) {
+    network.update(app, |network, ctx| {
+        // `EventLoop::new` loads scrollback into the terminal model, which debug-asserts the
+        // model is a viewer, so mark it as one first.
+        network.terminal_model.lock().set_shared_session_status(
+            SharedSessionStatus::ActiveViewer {
+                role: Default::default(),
+            },
+        );
+        let event_loop = ctx.add_model(|ctx| {
+            EventLoop::new(
+                network.terminal_model.clone(),
+                network.terminal_view.clone(),
+                network.channel_event_proxy.clone(),
+                WindowSize::default(),
+                Scrollback {
+                    blocks: vec![],
+                    is_alt_screen_active: false,
+                },
+                None,
+                SharedSessionInitialLoadMode::ReplaceFromSessionScrollback,
+                network.remote_update_guard.clone(),
+                ctx,
+            )
+        });
+        network.event_loop = Some(event_loop);
+        network.stage = Stage::JoinedSuccessfully;
+    });
+}
+
+#[test]
+fn test_cpu_wake_triggers_reconnect_when_joined() {
+    App::test((), |mut app| async move {
+        let (network, _) = create_network(&mut app);
+        join_network_with_event_loop(&mut app, &network);
+
+        // Sanity check: we start out joined, not reconnecting.
+        network.read(&app, |network, _| {
+            assert!(matches!(network.stage, Stage::JoinedSuccessfully));
+        });
+
+        // A CPU wake signal indicates the socket may have silently died while asleep, so the
+        // viewer should proactively replace it (transitioning into `Reconnecting`).
+        let system_stats = SystemStats::handle(&app);
+        system_stats.update(&mut app, |system_stats, ctx| {
+            system_stats.dispatch_cpu_was_awakened(ctx);
+        });
+
+        network.read(&app, |network, _| {
+            assert!(
+                matches!(network.stage, Stage::Reconnecting { .. }),
+                "CpuWasAwakened while joined should trigger a reconnect"
+            );
+        });
+    });
+}
+
+#[test]
+fn test_network_online_triggers_reconnect_when_joined() {
+    App::test((), |mut app| async move {
+        let (network, _) = create_network(&mut app);
+        join_network_with_event_loop(&mut app, &network);
+
+        // Take the network offline (this tears down the live socket) and then back online.
+        // Coming back online indicates connectivity was restored, so the viewer should
+        // proactively reconnect rather than keep writing into a possibly-dead socket.
+        let network_status = NetworkStatus::handle(&app);
+        network_status.update(&mut app, |network_status, ctx| {
+            network_status.reachability_changed(false, ctx);
+        });
+        network_status.update(&mut app, |network_status, ctx| {
+            network_status.reachability_changed(true, ctx);
+        });
+
+        network.read(&app, |network, _| {
+            assert!(
+                matches!(network.stage, Stage::Reconnecting { .. }),
+                "NetworkStatusKind::Online while joined should trigger a reconnect"
+            );
+        });
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Description
**Bug:** On an Oz (cloud) shared session, follow-up agent prompts were silently dropped after a network disconnect (laptop sleep, Wi-Fi change, NAT rebind) — no freeze, no error, the prompt just never reached the agent.

**Why:** The viewer's shared-session `Network` only reconnected when the websocket stream itself ended. If the TCP connection died silently (no FIN), nothing detected it: the session stayed marked as connected and follow-ups were written into a dead socket. Unlike `CloudObjects::Listener`, the viewer had no proactive liveness detection.

**Fix:** Mirror the `CloudObjects::Listener` pattern. The viewer now subscribes to OS connectivity signals (`SystemStats` sleep/wake, `NetworkStatus` online/offline): it tears down the live socket when the connection is about to drop, and proactively reconnects when it likely came back. A supporting change makes socket teardown deterministic so a dead/hung socket is replaced reliably (and a stale socket can't tear down a healthy replacement).

**Out of scope:** No message queuing/replay — a proactive reconnect keeps the dead window short enough to be acceptable. Sharer-side subscriptions are a possible follow-up.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Added unit tests covering CPU-wake and offline→online reconnect triggers while joined. `format --check`, `clippy`, and `cargo test -p warp shared_session::viewer::network` all pass.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed shared session (Oz) viewer follow-up prompts being silently dropped after a network disconnection or laptop sleep by proactively detecting the dead connection and reconnecting.

_Conversation: https://app.warp.dev/conversation/e990098e-326b-4dd2-90fe-fef95e54a62f_
_Run: https://oz.warp.dev/runs/019efb3d-820e-791e-8945-c54fb43380da_

_This PR was generated with [Oz](https://warp.dev/oz)._