### PR TITLE
Fix /open-file re-inserting lone file when clearing the argument

### DIFF
--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -2084,11 +2084,7 @@ pub fn init(app: &mut AppContext) {
 pub enum CompletionsTrigger {
     Keybinding,
     AsYouType,
-    /// Completions opened automatically by a slash command (e.g. `/open-file` with an empty
-    /// argument), rather than by an explicit user keybinding. These generate results like
-    /// [`CompletionsTrigger::Keybinding`] (including the file-path fallback) but must not
-    /// auto-insert a lone result, otherwise the user can never clear the argument when only a
-    /// single completion is available.
+    /// Completions opened automatically by a slash command.
     SlashCommandAutoOpen,
 }
 

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -2084,6 +2084,12 @@ pub fn init(app: &mut AppContext) {
 pub enum CompletionsTrigger {
     Keybinding,
     AsYouType,
+    /// Completions opened automatically by a slash command (e.g. `/open-file` with an empty
+    /// argument), rather than by an explicit user keybinding. These generate results like
+    /// [`CompletionsTrigger::Keybinding`] (including the file-path fallback) but must not
+    /// auto-insert a lone result, otherwise the user can never clear the argument when only a
+    /// single completion is available.
+    SlashCommandAutoOpen,
 }
 
 /// Represents whether the input editor should render the subshell flag.
@@ -11864,7 +11870,9 @@ impl Input {
             && !buffer_text.contains('\n');
 
         let fallback_strategy = match completions_trigger {
-            CompletionsTrigger::Keybinding if !use_native_shell_completions => {
+            CompletionsTrigger::Keybinding | CompletionsTrigger::SlashCommandAutoOpen
+                if !use_native_shell_completions =>
+            {
                 CompletionsFallbackStrategy::FilePaths
             }
             _ => CompletionsFallbackStrategy::None,

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -269,7 +269,14 @@ impl Input {
                         .is_some_and(|argument| argument.is_empty())
                     && self.suggestions_mode_model.as_ref(ctx).is_closed()
                 {
-                    self.open_completion_suggestions(CompletionsTrigger::Keybinding, ctx);
+                    // Use `SlashCommandAutoOpen` rather than `Keybinding` here: this open is
+                    // triggered automatically by detecting an empty `/open-file` argument, not by
+                    // an explicit user keybinding. With `Keybinding`, a directory containing a
+                    // single file would have that file immediately re-inserted as the user
+                    // backspaces the argument back to empty, making it impossible to clear (see
+                    // #12990). `SlashCommandAutoOpen` still generates file-path completions but
+                    // shows them in the menu instead of force-inserting a lone result.
+                    self.open_completion_suggestions(CompletionsTrigger::SlashCommandAutoOpen, ctx);
                 }
             }
             SlashCommandEntryState::SkillCommand(detected_skill) => {

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -269,13 +269,6 @@ impl Input {
                         .is_some_and(|argument| argument.is_empty())
                     && self.suggestions_mode_model.as_ref(ctx).is_closed()
                 {
-                    // Use `SlashCommandAutoOpen` rather than `Keybinding` here: this open is
-                    // triggered automatically by detecting an empty `/open-file` argument, not by
-                    // an explicit user keybinding. With `Keybinding`, a directory containing a
-                    // single file would have that file immediately re-inserted as the user
-                    // backspaces the argument back to empty, making it impossible to clear (see
-                    // #12990). `SlashCommandAutoOpen` still generates file-path completions but
-                    // shows them in the menu instead of force-inserting a lone result.
                     self.open_completion_suggestions(CompletionsTrigger::SlashCommandAutoOpen, ctx);
                 }
             }

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -3507,12 +3507,6 @@ fn test_open_slash_command_triggers_completions_on_space() {
 
 #[test]
 fn test_open_slash_command_does_not_autofill_single_file_completion() {
-    // Regression test for #12990: when `/open-file` auto-opens completions because its argument
-    // is empty and the current directory contains exactly one file, that lone file must NOT be
-    // inserted automatically. Otherwise the user can never backspace the argument back to empty,
-    // because clearing it re-triggers the auto-open which immediately re-inserts the only file.
-    // The fix distinguishes the system-initiated open (`SlashCommandAutoOpen`, which shows the
-    // menu) from an explicit user keybinding (`Keybinding`, which still inserts a lone result).
     App::test((), |mut app| async move {
         initialize_app(&mut app);
 
@@ -3530,8 +3524,6 @@ fn test_open_slash_command_does_not_autofill_single_file_completion() {
             });
         });
 
-        // A `/open-file`-driven auto-open with a single file suggestion must leave the empty
-        // argument untouched.
         input.update(&mut app, |input, ctx| {
             input.handle_completion_suggestions_results(
                 build_suggestion_results(
@@ -3548,8 +3540,6 @@ fn test_open_slash_command_does_not_autofill_single_file_completion() {
             assert_eq!(input.buffer_text(ctx), "/open-file ");
         });
 
-        // By contrast, an explicit user keybinding with a single prefix suggestion still inserts
-        // it, preserving normal tab-completion behavior.
         input.update(&mut app, |input, ctx| {
             input.handle_completion_suggestions_results(
                 build_suggestion_results(

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -3506,6 +3506,69 @@ fn test_open_slash_command_triggers_completions_on_space() {
 }
 
 #[test]
+fn test_open_slash_command_does_not_autofill_single_file_completion() {
+    // Regression test for #12990: when `/open-file` auto-opens completions because its argument
+    // is empty and the current directory contains exactly one file, that lone file must NOT be
+    // inserted automatically. Otherwise the user can never backspace the argument back to empty,
+    // because clearing it re-triggers the auto-open which immediately re-inserts the only file.
+    // The fix distinguishes the system-initiated open (`SlashCommandAutoOpen`, which shows the
+    // menu) from an explicit user keybinding (`Keybinding`, which still inserts a lone result).
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let terminal = add_window_with_bootstrapped_terminal(
+            &mut app, None, /* history_file_commands */
+            None,
+        )
+        .await;
+        let input = terminal.read(&app, |terminal, _| terminal.input().clone());
+
+        input.update(&mut app, |input, ctx| {
+            input.clear_buffer_and_reset_undo_stack(ctx);
+            input.editor.update(ctx, |editor, ctx| {
+                editor.set_buffer_text("/open-file ", ctx)
+            });
+        });
+
+        // A `/open-file`-driven auto-open with a single file suggestion must leave the empty
+        // argument untouched.
+        input.update(&mut app, |input, ctx| {
+            input.handle_completion_suggestions_results(
+                build_suggestion_results(
+                    vec![file_suggestion("test.md")],
+                    (11, 11),
+                    MatchStrategy::CaseInsensitive,
+                ),
+                CompletionsTrigger::SlashCommandAutoOpen,
+                editor_model_snapshot(input, ctx),
+                ctx,
+            );
+        });
+        input.read(&app, |input, ctx| {
+            assert_eq!(input.buffer_text(ctx), "/open-file ");
+        });
+
+        // By contrast, an explicit user keybinding with a single prefix suggestion still inserts
+        // it, preserving normal tab-completion behavior.
+        input.update(&mut app, |input, ctx| {
+            input.handle_completion_suggestions_results(
+                build_suggestion_results(
+                    vec![file_suggestion("test.md")],
+                    (11, 11),
+                    MatchStrategy::CaseInsensitive,
+                ),
+                CompletionsTrigger::Keybinding,
+                editor_model_snapshot(input, ctx),
+                ctx,
+            );
+        });
+        input.read(&app, |input, ctx| {
+            assert_eq!(input.buffer_text(ctx), "/open-file test.md ");
+        });
+    });
+}
+
+#[test]
 fn test_open_slash_command_triggers_completions_when_selected() {
     App::test((), |mut app| async move {
         initialize_app(&mut app);


### PR DESCRIPTION
## Description

When the current directory contains exactly one file, the `/open-file` slash command would not let you delete the argument back to empty. Backspacing the auto-filled filename to empty re-triggered the auto-opened completions, which immediately re-inserted the only file — so you could never clear the field to type a different path (e.g. a dotfile or a path in another directory).

Root cause: the empty-argument auto-open used `CompletionsTrigger::Keybinding`, which treats a single prefix suggestion as an immediate insertion. That's correct for an explicit user keybinding (Tab) but wrong for a system-initiated open. This PR adds a dedicated `CompletionsTrigger::SlashCommandAutoOpen` variant that still generates file-path completions (same fallback strategy as `Keybinding`) but shows them in the menu instead of force-inserting a lone result.

## Linked Issue

Closes #12990

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

Added a regression test, `test_open_slash_command_does_not_autofill_single_file_completion`, asserting that a `SlashCommandAutoOpen` open with a single file suggestion leaves the `/open-file ` argument empty, while a `Keybinding` open still inserts the lone result. Manually verified before/after on a Linux `warp-oss` build in a directory containing a single file.

### Screenshots / Videos

**Before** (argument can't be cleared — the file snaps back):


https://github.com/user-attachments/assets/1d657cf2-3ea5-4720-a550-ca4f060bc5d5

After 

https://github.com/user-attachments/assets/a88f5d45-4e0d-4a8e-b109-244013781e7e


## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed `/open-file` not allowing the argument to be cleared when the current directory contains a single file.
