### PR TITLE
Add a smooth scrolling option for mouse wheel scrolling

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1513,6 +1513,10 @@ pub(crate) fn initialize_app(
         apply_scroll_multiplier(event, ctx);
     });
 
+    // Initialize the windowing layer's smooth-scrolling flag from the persisted setting. Live
+    // toggles keep it in sync from the Settings UI (see FeaturesPageAction::ToggleSmoothScrolling).
+    warpui::set_smooth_scroll_enabled(*ScrollSettings::as_ref(ctx).smooth_scrolling);
+
     // Rewrite recognized Warp web URLs (sessions, Drive, settings, home) into local
     // intent URLs when possible so they open directly in the desktop app.
     ctx.set_before_open_url(|url_str, _ctx| {

--- a/app/src/settings/scroll.rs
+++ b/app/src/settings/scroll.rs
@@ -11,4 +11,13 @@ define_settings_group!(ScrollSettings, settings: [
         toml_path: "general.mouse_scroll_multiplier",
         description: "The scroll speed multiplier for mouse scroll events.",
     },
+    smooth_scrolling: SmoothScrolling {
+        type: bool,
+        default: true,
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Never,
+        private: false,
+        toml_path: "general.smooth_scrolling",
+        description: "Animate mouse-wheel scrolling instead of jumping line-by-line.",
+    },
 ]);

--- a/app/src/settings_view/features_page.rs
+++ b/app/src/settings_view/features_page.rs
@@ -72,7 +72,7 @@ use crate::settings::{
     MouseScrollMultiplier, OutlineCodebaseSymbolsForAtContextMenu, PreferLowPowerGPU,
     PreferredGraphicsBackend, QuakeModeSettings, ScrollSettings, ScrollSettingsChangedEvent,
     SelectionSettings, ShowAutosuggestionIgnoreButton, ShowChangelogAfterUpdate,
-    ShowTerminalInputMessageBar, SshSettings, SyntaxHighlighting, TabBehavior,
+    ShowTerminalInputMessageBar, SmoothScrolling, SshSettings, SyntaxHighlighting, TabBehavior,
     UserNativeRedirectPreference, VimModeEnabled, VimStatusBar, VimUnnamedSystemClipboard,
     DEFAULT_QUAKE_MODE_SIZE_PERCENTAGES, QUAKE_WINDOW_AUTOHIDE_SUPPORTED,
 };
@@ -735,6 +735,7 @@ pub enum FeaturesPageAction {
     ToggleSshReuseControlMaster,
     ToggleSnackbar,
     ToggleLinkTooltip,
+    ToggleSmoothScrolling,
     ToggleCompletionsOpenWhileTyping,
     ToggleCommandCorrections,
     ToggleErrorUnderlining,
@@ -936,6 +937,10 @@ impl FeaturesPageAction {
             Self::ToggleLinkTooltip => TelemetryEvent::FeaturesPageAction {
                 action: "ToggleLinkTooltip".to_string(),
                 value: to_string(*GeneralSettings::as_ref(ctx).link_tooltip),
+            },
+            Self::ToggleSmoothScrolling => TelemetryEvent::FeaturesPageAction {
+                action: "ToggleSmoothScrolling".to_string(),
+                value: to_string(*ScrollSettings::as_ref(ctx).smooth_scrolling),
             },
             Self::ToggleCompletionsOpenWhileTyping => TelemetryEvent::FeaturesPageAction {
                 action: "ToggleCompletionsOpenWhileTyping".to_string(),
@@ -1858,6 +1863,13 @@ impl TypedActionView for FeaturesPageView {
                     report_if_error!(settings.link_tooltip.toggle_and_save_value(ctx));
                 });
             }
+            ToggleSmoothScrolling => {
+                ScrollSettings::handle(ctx).update(ctx, |scroll_settings, ctx| {
+                    report_if_error!(scroll_settings.smooth_scrolling.toggle_and_save_value(ctx));
+                });
+                // Keep the windowing layer's flag in sync so the change takes effect immediately.
+                warpui::set_smooth_scroll_enabled(*ScrollSettings::as_ref(ctx).smooth_scrolling);
+            }
             ToggleShowWarningBeforeQuitting => {
                 GeneralSettings::handle(ctx).update(ctx, |warning_settings, ctx| {
                     report_if_error!(warning_settings
@@ -2683,6 +2695,7 @@ impl FeaturesPageView {
 
         general_widgets.push(Box::new(SnackbarHeaderWidget::default()));
         general_widgets.push(Box::new(LinkTooltipWidget::default()));
+        general_widgets.push(Box::new(SmoothScrollingWidget::default()));
 
         #[cfg(feature = "local_fs")]
         {
@@ -4679,6 +4692,52 @@ impl SettingsWidget for SnackbarHeaderWidget {
                 .build()
                 .on_click(move |ctx, _, _| {
                     ctx.dispatch_typed_action(FeaturesPageAction::ToggleSnackbar)
+                })
+                .finish(),
+            None,
+        )
+    }
+}
+
+#[derive(Default)]
+struct SmoothScrollingWidget {
+    switch_state: SwitchStateHandle,
+}
+
+impl SettingsWidget for SmoothScrollingWidget {
+    type View = FeaturesPageView;
+
+    fn search_terms(&self) -> &str {
+        "smooth scrolling animate scroll wheel momentum"
+    }
+
+    fn render(
+        &self,
+        view: &Self::View,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let ui_builder = appearance.ui_builder();
+        render_body_item::<FeaturesPageAction>(
+            "Smooth scrolling".into(),
+            None,
+            LocalOnlyIconState::for_setting(
+                SmoothScrolling::storage_key(),
+                SmoothScrolling::sync_to_cloud(),
+                &mut view
+                    .button_mouse_states
+                    .local_only_icon_tooltip_states
+                    .borrow_mut(),
+                app,
+            ),
+            ToggleState::Enabled,
+            appearance,
+            ui_builder
+                .switch(self.switch_state.clone())
+                .check(*ScrollSettings::as_ref(app).smooth_scrolling)
+                .build()
+                .on_click(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(FeaturesPageAction::ToggleSmoothScrolling);
                 })
                 .finish(),
             None,

--- a/crates/warpui/src/windowing/winit/app.rs
+++ b/crates/warpui/src/windowing/winit/app.rs
@@ -101,6 +101,10 @@ pub enum CustomEvent {
     MomentumScroll {
         window_id: winit::window::WindowId,
     },
+    /// Smooth (animated) mouse-wheel scrolling animation frame.
+    SmoothScroll {
+        window_id: winit::window::WindowId,
+    },
 }
 
 #[derive(Debug)]

--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -73,6 +73,15 @@ const MOMENTUM_MIN_VELOCITY: f32 = 1.0; // When velocity falls below this, scrol
 const MOMENTUM_MAX_VELOCITY: f32 = 2000.0; // Hard cap on momentum initial velocity (px/s)
 const MIN_VELOCITY_TIME_DELTA: f32 = 0.004; // Floor for time deltas to prevent spikes from batched events
 
+/// Smooth (animated) mouse-wheel scrolling configuration. When enabled, each discrete wheel
+/// notch's delta is accumulated into a remaining distance and emitted over several frames using
+/// an exponential ease-out: every tick we dispatch `SMOOTH_SCROLL_FACTOR` of whatever distance is
+/// left, so the motion starts quickly and settles gently. This only affects non-precise (mouse
+/// wheel) scrolling; precise trackpad scrolling is already smooth and has its own momentum.
+const SMOOTH_SCROLL_FRAME_INTERVAL: Duration = Duration::from_millis(8); // ~125Hz animation tick.
+const SMOOTH_SCROLL_FACTOR: f32 = 0.25; // Fraction of the remaining distance emitted each tick.
+const SMOOTH_SCROLL_MIN_DELTA: f32 = 0.05; // Below this remaining distance (lines), finish and stop.
+
 /// TryFrom implementation for converting winit's `KeyCode` to
 /// `crate::platform::keyboard::KeyCode`.
 /// Only converts modifier keys and fails for all other keys.
@@ -159,6 +168,13 @@ struct WindowState {
     scroll_velocity: Option<ScrollVelocity>,
     /// Abort handle for momentum scrolling timer. Present only during the momentum phase.
     momentum_scroll_abort: Option<AbortHandle>,
+    /// Remaining (not-yet-emitted) mouse-wheel scroll distance, in line units, that the
+    /// smooth-scroll animation is easing out. New wheel events add to this mid-animation so
+    /// rapid scrolling stays responsive.
+    smooth_scroll_remaining: Vector2F,
+    /// Abort handle for the smooth-scroll animation timer. Present only while a smooth
+    /// mouse-wheel animation is in flight.
+    smooth_scroll_abort: Option<AbortHandle>,
     /// For touch events, stores whether soft keyboard was requested during LeftMouseDown.
     /// This is needed because touch keyboard updates are deferred to LeftMouseUp, but the
     /// UI element only requests the keyboard during LeftMouseDown.
@@ -181,6 +197,8 @@ impl WindowState {
             last_touch_purpose: None,
             scroll_velocity: None,
             momentum_scroll_abort: None,
+            smooth_scroll_remaining: Vector2F::default(),
+            smooth_scroll_abort: None,
             #[cfg(target_family = "wasm")]
             pending_soft_keyboard_request: false,
         }
@@ -192,6 +210,15 @@ impl WindowState {
             abort_handle.abort();
         }
         self.scroll_velocity = None;
+    }
+
+    /// Cancels an in-flight smooth mouse-wheel scroll, clearing both the animation timer
+    /// and any remaining distance.
+    fn cancel_smooth_scroll(&mut self) {
+        if let Some(abort_handle) = self.smooth_scroll_abort.take() {
+            abort_handle.abort();
+        }
+        self.smooth_scroll_remaining = Vector2F::default();
     }
 
     /// When a mouse button is pressed, save it to [`Self::current_mouse_button_pressed`] so that
@@ -828,6 +855,26 @@ impl EventLoop {
                         modifiers: ModifiersState::default(),
                     },
                 );
+            }
+            Event::UserEvent(CustomEvent::SmoothScroll { window_id }) => {
+                let step = {
+                    let Some(window_state) = self.state.windows.get_mut(&window_id) else {
+                        return;
+                    };
+                    let remaining = window_state.smooth_scroll_remaining;
+                    if remaining.length() <= SMOOTH_SCROLL_MIN_DELTA {
+                        // Close enough: emit whatever is left and stop animating.
+                        window_state.cancel_smooth_scroll();
+                        remaining
+                    } else {
+                        let step = remaining * SMOOTH_SCROLL_FACTOR;
+                        window_state.smooth_scroll_remaining = remaining - step;
+                        step
+                    }
+                };
+                if step.length() > 0.0 {
+                    self.dispatch_smooth_scroll_step(window_id, step);
+                }
             }
             Event::WindowEvent {
                 window_id,
@@ -1569,6 +1616,24 @@ impl EventLoop {
         window_id: winit::window::WindowId,
         event: crate::Event,
     ) {
+        // Smooth scrolling: intercept discrete (non-precise) mouse-wheel deltas and animate them
+        // toward their target instead of applying the whole jump at once. Precise (trackpad)
+        // deltas are already smooth and have their own momentum handling, so they pass through
+        // untouched. Animation steps are re-dispatched via `dispatch_smooth_scroll_step` (which
+        // calls the window callbacks directly), so they don't re-enter this interception.
+        if warpui_core::smooth_scroll_enabled() {
+            if let crate::Event::ScrollWheel {
+                delta,
+                precise: false,
+                ..
+            } = &event
+            {
+                let delta = *delta;
+                self.enqueue_smooth_scroll(window_id, delta);
+                return;
+            }
+        }
+
         let Some(window_state) = self.state.windows.get_mut(&window_id) else {
             return;
         };
@@ -1753,6 +1818,74 @@ impl EventLoop {
             loop {
                 Timer::after(MOMENTUM_FRAME_INTERVAL).await;
                 let _ = proxy.send_event(CustomEvent::MomentumScroll { window_id });
+            }
+        });
+
+        self.ui_app.read(|ctx| {
+            ctx.foreground_executor()
+                .spawn(async move {
+                    let _ = future.await;
+                })
+                .detach();
+        });
+
+        abort_handle
+    }
+
+    /// Accumulates a discrete mouse-wheel delta into the smooth-scroll animation for the given
+    /// window, starting the animation timer if one isn't already running.
+    fn enqueue_smooth_scroll(&mut self, window_id: winit::window::WindowId, delta: Vector2F) {
+        let need_start = match self.state.windows.get_mut(&window_id) {
+            Some(window_state) => {
+                window_state.smooth_scroll_remaining += delta;
+                window_state.smooth_scroll_abort.is_none()
+            }
+            None => return,
+        };
+
+        if need_start {
+            let abort_handle = self.start_smooth_scroll(window_id);
+            if let Some(window_state) = self.state.windows.get_mut(&window_id) {
+                window_state.smooth_scroll_abort = Some(abort_handle);
+            }
+        }
+    }
+
+    /// Dispatches a single eased smooth-scroll step to the window as a non-precise scroll-wheel
+    /// event. This goes straight to the window callbacks rather than back through
+    /// [`Self::handle_converted_warpui_event`], so the app's scroll-speed multiplier still applies
+    /// per step while avoiding re-entering (and re-accumulating in) the smooth-scroll interception.
+    fn dispatch_smooth_scroll_step(&mut self, window_id: winit::window::WindowId, delta: Vector2F) {
+        let Some(window_state) = self.state.windows.get(&window_id) else {
+            return;
+        };
+        let position = window_state.last_cursor_position.to_vec2f();
+        let modifiers = from_winit_modifiers_state(window_state.modifiers);
+        let Some(window) = self
+            .ui_app
+            .read(|ctx| ctx.windows().platform_window(window_state.window_id))
+        else {
+            return;
+        };
+        let winit_window = downcast_window(window.as_ref());
+        self.callbacks
+            .for_window(winit_window)
+            .dispatch_event(crate::event::Event::ScrollWheel {
+                position,
+                delta,
+                precise: false,
+                modifiers,
+            });
+    }
+
+    /// Starts a timer that triggers SmoothScroll animation frames at a fixed interval.
+    fn start_smooth_scroll(&self, window_id: winit::window::WindowId) -> AbortHandle {
+        let proxy = self.proxy.clone();
+        // Abortable so we can stop the animation once the remaining distance is depleted.
+        let (future, abort_handle) = futures::future::abortable(async move {
+            loop {
+                Timer::after(SMOOTH_SCROLL_FRAME_INTERVAL).await;
+                let _ = proxy.send_event(CustomEvent::SmoothScroll { window_id });
             }
         });
 

--- a/crates/warpui_core/src/lib.rs
+++ b/crates/warpui_core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod prelude;
 pub mod presenter;
 pub mod rendering;
 pub mod scene;
+pub mod smooth_scroll;
 pub mod telemetry;
 #[cfg(test)]
 mod test;
@@ -48,6 +49,7 @@ pub use presenter::{
     AfterLayoutContext, EventContext, LayoutContext, PaintContext, Presenter, SizeConstraint,
 };
 pub use scene::{ClipBounds, Scene};
+pub use smooth_scroll::{set_smooth_scroll_enabled, smooth_scroll_enabled};
 pub use zoom::ZoomFactor;
 
 pub use crate::core::*;

--- a/crates/warpui_core/src/smooth_scroll.rs
+++ b/crates/warpui_core/src/smooth_scroll.rs
@@ -1,0 +1,23 @@
+//! Global toggle for animated ("smooth") mouse-wheel scrolling.
+//!
+//! The setting that backs this lives in the `app` crate
+//! (`general.smooth_scrolling`), but the code that animates wheel scrolling
+//! lives in the lower-level `warpui` windowing layer, which cannot depend on
+//! `app`. This module is the small, dependency-free bridge between the two:
+//! the app pushes the current setting value here, and the windowing layer
+//! reads it when deciding whether to animate a discrete wheel delta.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static SMOOTH_SCROLL_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Enables or disables animated mouse-wheel scrolling. Called by the app
+/// whenever the `general.smooth_scrolling` setting is loaded or changed.
+pub fn set_smooth_scroll_enabled(enabled: bool) {
+    SMOOTH_SCROLL_ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+/// Whether animated mouse-wheel scrolling is currently enabled.
+pub fn smooth_scroll_enabled() -> bool {
+    SMOOTH_SCROLL_ENABLED.load(Ordering::Relaxed)
+}


### PR DESCRIPTION
## Description

This adds a smooth scrolling option for the terminal.

Right now scrolling with a normal mouse wheel jumps line by line, which feels pretty snappy. Trackpads are already smooth since they send pixel-precise scroll deltas, but a regular mouse wheel only sends discrete notches, so every notch lands instantly.

So I added a "Smooth scrolling" toggle under Settings → Features → General (on by default). With it on, each mouse wheel notch gets eased out over a few frames instead of jumping, so scrolling feels smooth. Trackpad scrolling is left exactly how it was since it's already smooth and has its own momentum handling.

How it works: there's already momentum-scroll code for trackpads in the winit event loop, so I reused that pattern. Non-precise (mouse wheel) deltas get intercepted and eased toward their target with an exponential ease-out (~8ms ticks) instead of being applied all at once. The setting is `general.smooth_scrolling` and drives a small flag in `warpui_core` that the windowing layer reads — the windowing layer can't depend on the app crate, so that's the bridge between the setting and the scroll code.

## Linked Issue

Closes #6169

One thing to call out: this issue isn't labeled `ready-to-spec` / `ready-to-implement` yet. I'm putting this up as a proposed fix since it's a small, self-contained QoL change, but I'm happy to take it through the spec flow first if you'd prefer.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Screenshots or a short video of the implementation are included below.

## Testing

- [x] I have manually tested my changes locally

Built and ran it locally on Windows. Toggling it on/off persists straight away and changes the behavior immediately — with it on, mouse wheel scrolling glides; with it off it's back to the old line-by-line jump. Trackpad scrolling stays smooth either way.

### Screenshots / Videos

Short screen recording of the on vs off difference to follow.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Add a "Smooth scrolling" setting that animates mouse wheel scrolling instead of jumping line by line.
