### PR TITLE
[QUALITY-884] Hide custom models from inline model picker in cloud agent panes

### DIFF
--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -3399,6 +3399,7 @@ impl Input {
         let inline_model_selector_view = ctx.add_view(|ctx| {
             InlineModelSelectorView::new(
                 terminal_view_id,
+                ambient_agent_view_model.clone(),
                 suggestions_mode_model.clone(),
                 agent_view_controller.clone(),
                 &buffer_model,

--- a/app/src/terminal/input/models/data_source.rs
+++ b/app/src/terminal/input/models/data_source.rs
@@ -16,7 +16,7 @@ use warpui::platform::{Cursor, OperatingSystem};
 use warpui::text_layout::ClipConfig;
 use warpui::ui_components::button::ButtonVariant;
 use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
-use warpui::{AppContext, Element, Entity, EntityId, SingletonEntity as _};
+use warpui::{AppContext, Element, Entity, EntityId, ModelHandle, SingletonEntity as _};
 
 use super::model_spec_scores::{
     render_model_spec_header, render_model_spec_scores, CostRow, CostRowTooltip,
@@ -41,6 +41,7 @@ use crate::terminal::input::inline_menu::{
     InlineMenuAction, InlineMenuMessageArgs, InlineMenuType,
 };
 use crate::terminal::input::message_bar::{Message, MessageItem};
+use crate::terminal::view::ambient_agent::AmbientAgentViewModel;
 use crate::workspace::WorkspaceAction;
 use crate::workspaces::user_workspaces::UserWorkspaces;
 
@@ -133,11 +134,25 @@ fn model_specs_width(app: &AppContext) -> f32 {
 
 pub struct ModelSelectorDataSource {
     terminal_view_id: EntityId,
+    ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
 }
 
 impl ModelSelectorDataSource {
-    pub fn new(terminal_view_id: EntityId) -> Self {
-        Self { terminal_view_id }
+    pub fn new(
+        terminal_view_id: EntityId,
+        ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
+    ) -> Self {
+        Self {
+            terminal_view_id,
+            ambient_agent_view_model,
+        }
+    }
+
+    /// Returns whether a model should appear in the inline picker.
+    /// Custom-endpoint models are suppressed in Oz cloud agent panes because
+    /// they cannot route through Warp's cloud inference infrastructure.
+    pub(crate) fn include_model_in_picker(is_cloud_pane: bool, is_custom_endpoint: bool) -> bool {
+        !is_cloud_pane || !is_custom_endpoint
     }
 
     fn order_model_choices<'a>(
@@ -195,11 +210,22 @@ impl SyncDataSource for ModelSelectorDataSource {
                 .clone()
         };
 
+        let is_cloud_pane = self.ambient_agent_view_model.is_some();
         let choices = if is_full_terminal {
-            llm_preferences.get_cli_agent_llm_choices(app).collect_vec()
+            llm_preferences
+                .get_cli_agent_llm_choices(app)
+                .filter(|llm| {
+                    let is_custom = llm_preferences.custom_llm_info_for_id(&llm.id).is_some();
+                    Self::include_model_in_picker(is_cloud_pane, is_custom)
+                })
+                .collect_vec()
         } else {
             llm_preferences
                 .get_base_llm_choices_for_agent_mode(app)
+                .filter(|llm| {
+                    let is_custom = llm_preferences.custom_llm_info_for_id(&llm.id).is_some();
+                    Self::include_model_in_picker(is_cloud_pane, is_custom)
+                })
                 .collect_vec()
         };
         let choices = Self::order_model_choices(llm_preferences, choices);

--- a/app/src/terminal/input/models/view.rs
+++ b/app/src/terminal/input/models/view.rs
@@ -29,6 +29,7 @@ use crate::terminal::input::models::data_source::{AcceptModel, ModelSelectorData
 use crate::terminal::input::suggestions_mode_model::{
     InputSuggestionsModeEvent, InputSuggestionsModeModel,
 };
+use crate::terminal::view::ambient_agent::AmbientAgentViewModel;
 use crate::ui_components::icons::Icon;
 use crate::view_components::action_button::{ActionButton, ActionButtonTheme, ButtonSize};
 use crate::view_components::alert::{Alert, AlertConfig};
@@ -113,8 +114,10 @@ pub struct InlineModelSelectorView {
 }
 
 impl InlineModelSelectorView {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         terminal_view_id: EntityId,
+        ambient_agent_view_model: Option<ModelHandle<AmbientAgentViewModel>>,
         suggestions_mode_model: ModelHandle<InputSuggestionsModeModel>,
         agent_view_controller: ModelHandle<AgentViewController>,
         input_buffer_model: &ModelHandle<InputBufferModel>,
@@ -122,7 +125,9 @@ impl InlineModelSelectorView {
         positioner: &ModelHandle<InlineMenuPositioner>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
-        let data_source = ctx.add_model(|_| ModelSelectorDataSource::new(terminal_view_id));
+        let data_source = ctx.add_model(|_| {
+            ModelSelectorDataSource::new(terminal_view_id, ambient_agent_view_model)
+        });
 
         let tab_configs = TAB_CONFIGS.clone();
         let initial_filters = tab_configs


### PR DESCRIPTION
## Description

Custom endpoint models (e.g. locally-configured custom LLM endpoints) were incorrectly appearing in the inline `/MODEL` picker when the user was in a cloud agent pane. Custom models cannot route through Warp's cloud inference infrastructure, so they should not be selectable there.

The root cause: `ModelSelectorDataSource::run_query` — which powers the inline `/MODEL` tabbed picker — had no awareness of whether its pane was an Oz cloud agent pane. It fetched all models including custom endpoints unconditionally.

**Fix:** Thread `ambient_agent_view_model` through `InlineModelSelectorView` and into `ModelSelectorDataSource`. In `run_query`, derive `is_cloud_pane` from whether the model handle is `Some`, and filter out any model where `custom_llm_info_for_id` returns `Some` when in a cloud pane. 

### Screenshots / Videos

Loom showing the fix in action: https://www.loom.com/share/2317394c09a4468b956da64a6dac7217

## Linked Issue

Loom showing the buggy behaviour is in here as well --> https://linear.app/warpdotdev/issue/QUALITY-884/custom-models-are-selectable-for-cloud-agent-requests-when-changing

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Custom models no longer appear in the model picker when using a cloud agent pane.
-->

Co-Authored-By: Oz <oz-agent@warp.dev>
