### PR TITLE
Horizontal tab group rework - several bug fixes

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -19522,6 +19522,10 @@ impl Workspace {
     /// [Header (spacer)(tab1)(tab2)...(spacer)]
     const GROUP_EDGE_SPACER_FLEX: f32 = 0.06;
 
+    /// Upper bound on each edge spacer's rendered width, proportional to
+    /// tab's max width (tabs have flex 1 and max width of 200).
+    const GROUP_EDGE_SPACER_MAX_WIDTH: f32 = Self::GROUP_EDGE_SPACER_FLEX * 200.0;
+
     /// Renders a contiguous run of grouped tabs as one tab-bar slot: header
     /// + (when expanded) member tabs.
     #[allow(clippy::too_many_arguments)]
@@ -19569,9 +19573,16 @@ impl Workspace {
         );
 
         if !is_collapsed {
-            // Edge spacer before the first member (own flex slot, doesn't shrink tabs).
+            // Edge spacer before the first member (own flex slot, doesn't
+            // shrink tabs).
             row.add_child(
-                Expanded::new(Self::GROUP_EDGE_SPACER_FLEX, Empty::new().finish()).finish(),
+                Shrinkable::new(
+                    Self::GROUP_EDGE_SPACER_FLEX,
+                    ConstrainedBox::new(Empty::new().finish())
+                        .with_max_width(Self::GROUP_EDGE_SPACER_MAX_WIDTH)
+                        .finish(),
+                )
+                .finish(),
             );
             let close_button_position = if FeatureFlag::TabCloseButtonOnLeft.is_enabled() {
                 TabSettings::as_ref(ctx).close_button_position
@@ -19611,19 +19622,25 @@ impl Workspace {
             // Matching edge spacer after the last member. The trailing divider
             // lives inside this spacer's own flex slot (drawn at its right edge,
             // which is the group's far edge), so it doesn't steal width from the
-            // members the way a border on the group container would.
+            // members the way a border on the group container would. Same loose
+            // flex cap as the leading spacer so the group shrink-wraps instead
+            // of this spacer ballooning out toward the bar's trailing edge.
             row.add_child(
-                Expanded::new(
+                Shrinkable::new(
                     Self::GROUP_EDGE_SPACER_FLEX,
-                    Container::new(Empty::new().finish())
-                        .with_border(
-                            Border::all(1.)
-                                .with_sides(false, false, false, true)
-                                .with_border_fill(internal_colors::fg_overlay_1(
-                                    appearance.theme(),
-                                )),
-                        )
-                        .finish(),
+                    ConstrainedBox::new(
+                        Container::new(Empty::new().finish())
+                            .with_border(
+                                Border::all(1.)
+                                    .with_sides(false, false, false, true)
+                                    .with_border_fill(internal_colors::fg_overlay_1(
+                                        appearance.theme(),
+                                    )),
+                            )
+                            .finish(),
+                    )
+                    .with_max_width(Self::GROUP_EDGE_SPACER_MAX_WIDTH)
+                    .finish(),
                 )
                 .finish(),
             );

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -19514,6 +19514,14 @@ impl Workspace {
         .finish()
     }
 
+    /// Flex weight of the spacer on each side of an expanded group's members.
+    /// Flex (not fixed px) keeps it a separate slot, so members stay the same
+    /// width as ungrouped tabs and the group shrinks proportionally.
+    /// Approximately equal to 8px when tabs are 150px wide.
+    /// A tab group is now as follows:
+    /// [Header (spacer)(tab1)(tab2)...(spacer)]
+    const GROUP_EDGE_SPACER_FLEX: f32 = 0.06;
+
     /// Renders a contiguous run of grouped tabs as one tab-bar slot: header
     /// + (when expanded) member tabs.
     #[allow(clippy::too_many_arguments)]
@@ -19527,7 +19535,6 @@ impl Workspace {
         appearance: &Appearance,
         ctx: &AppContext,
     ) -> Box<dyn Element> {
-        let theme = appearance.theme();
         let is_collapsed = group.collapsed;
 
         let mouse_states = self
@@ -19542,16 +19549,30 @@ impl Workspace {
             && member_range.contains(&self.active_tab_index);
 
         let mut row = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
-        row.add_child(self.render_horizontal_tab_group_header(
-            group,
-            &mouse_states,
-            is_collapsed,
-            any_member_active,
-            appearance,
-            ctx,
-        ));
+        // Header fills one slot like a member tab capped at the same 200px as a tab.
+        row.add_child(
+            Shrinkable::new(
+                1.0,
+                ConstrainedBox::new(self.render_horizontal_tab_group_header(
+                    group,
+                    &mouse_states,
+                    is_collapsed,
+                    any_member_active,
+                    is_first_in_bar,
+                    appearance,
+                    ctx,
+                ))
+                .with_max_width(200.)
+                .finish(),
+            )
+            .finish(),
+        );
 
         if !is_collapsed {
+            // Edge spacer before the first member (own flex slot, doesn't shrink tabs).
+            row.add_child(
+                Expanded::new(Self::GROUP_EDGE_SPACER_FLEX, Empty::new().finish()).finish(),
+            );
             let close_button_position = if FeatureFlag::TabCloseButtonOnLeft.is_enabled() {
                 TabSettings::as_ref(ctx).close_button_position
             } else {
@@ -19586,19 +19607,30 @@ impl Workspace {
             row.add_child(render_horizontal_group_pin_indicator(appearance));
         }
 
-        // Additional padding on expanded groups,
-        // allowing tabs to be dropped into the last position of the group.
-        const EXPANDED_GROUP_TRAILING_PADDING: f32 = 8.;
-        let mut container = Container::new(row.finish()).with_border(
-            Border::all(1.)
-                // Left border only on the first slot to avoid double borders.
-                .with_sides(false, is_first_in_bar, false, true)
-                .with_border_fill(internal_colors::fg_overlay_1(theme)),
-        );
         if !is_collapsed {
-            container = container.with_padding_right(EXPANDED_GROUP_TRAILING_PADDING);
+            // Matching edge spacer after the last member. The trailing divider
+            // lives inside this spacer's own flex slot (drawn at its right edge,
+            // which is the group's far edge), so it doesn't steal width from the
+            // members the way a border on the group container would.
+            row.add_child(
+                Expanded::new(
+                    Self::GROUP_EDGE_SPACER_FLEX,
+                    Container::new(Empty::new().finish())
+                        .with_border(
+                            Border::all(1.)
+                                .with_sides(false, false, false, true)
+                                .with_border_fill(internal_colors::fg_overlay_1(
+                                    appearance.theme(),
+                                )),
+                        )
+                        .finish(),
+                )
+                .finish(),
+            );
         }
-        let container = container.finish();
+
+        // Collapsed groups draw their divider on the header instead.
+        let container = Container::new(row.finish()).finish();
 
         let group_id = group.id;
         let group_draggable_state = group.draggable_state.clone();
@@ -19624,25 +19656,28 @@ impl Workspace {
         let positioned_container =
             SavePosition::new(positioned_container, &htab_group_position_id(group_id)).finish();
 
-        // Flex = header + one per member so the group shrinks proportionally
-        // with sibling tabs. A collapsed group renders only its header, so it
-        // should claim a single slot's worth of flex.
+        // Flex = header + one per member + a spacer each side, so every tab is
+        // one slot wide. A collapsed group claims one slot; the flex it gives up
+        // is re-added to the bar's trailing spacer (see render_tab_bar_contents)
+        // so total flex stays constant and the header doesn't move.
         let group_flex = if is_collapsed {
             1.0
         } else {
-            1.0 + run_len as f32
+            1.0 + run_len as f32 + 2.0 * Self::GROUP_EDGE_SPACER_FLEX
         };
         Shrinkable::new(group_flex, positioned_container).finish()
     }
 
     /// Header (icon collage + name) for a horizontal tab group. Click
     /// toggles collapse; double-click renames; right-click opens the menu.
+    #[allow(clippy::too_many_arguments)]
     fn render_horizontal_tab_group_header(
         &self,
         group: &TabGroup,
         mouse_states: &HorizontalTabGroupMouseStates,
         is_collapsed: bool,
         any_member_active: bool,
+        is_first_in_bar: bool,
         appearance: &Appearance,
         ctx: &AppContext,
     ) -> Box<dyn Element> {
@@ -19675,23 +19710,23 @@ impl Workspace {
                 .name
                 .clone()
                 .unwrap_or_else(|| "New Group".to_string());
-            // Cap width so long names ellipsize and the tab bar's unbounded
-            // measurement stays finite.
-            ConstrainedBox::new(
-                Text::new_inline(title, font_family, 12.)
-                    .with_clip(ClipConfig::ellipsis())
-                    .with_color(main_text_color.into())
-                    .finish(),
-            )
-            .with_max_width(150.)
-            .finish()
+            // No inner cap: the name fills the header slot and fades like a tab
+            // title; the header's outer `ConstrainedBox` bounds the width and
+            // keeps the tab bar's unbounded measurement finite.
+            Text::new_inline(title, font_family, 12.)
+                .with_clip(ClipConfig::end())
+                .with_color(main_text_color.into())
+                .finish()
         };
 
         let mut row = Flex::row()
+            // Fill the slot and center the icon + title.
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::Center)
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_spacing(6.)
             .with_child(icon_circle)
-            .with_child(name_element);
+            .with_child(Shrinkable::new(1.0, name_element).finish());
         // Collapsed + pinned: pin indicator to the right of the name, where an
         // ungrouped tab would show its close button. Expanded groups show the
         // pin after their last member instead.
@@ -19702,6 +19737,7 @@ impl Workspace {
 
         let header_active_bg = internal_colors::fg_overlay_2(theme);
         let header_hover_bg = internal_colors::fg_overlay_1(theme);
+        let header_border_fill = internal_colors::fg_overlay_1(theme);
         let mut header = Hoverable::new(mouse_states.header.clone(), move |state| {
             let bg: ElementFill = if header_selected {
                 header_active_bg.into()
@@ -19711,10 +19747,20 @@ impl Workspace {
                 ElementFill::None
             };
 
+            // Tab-style border: left edge if first; right edge only when collapsed
+            // (the divider). Expanded, the divider moves to the container's far
+            // edge, so swap that 1px border for 1px right padding so the title
+            // doesn't shift.
             Container::new(row)
-                .with_horizontal_padding(8.)
+                .with_padding_left(8.)
+                .with_padding_right(if is_collapsed { 8. } else { 9. })
                 .with_vertical_padding(6.)
                 .with_background(bg)
+                .with_border(
+                    Border::all(1.)
+                        .with_sides(false, is_first_in_bar, false, is_collapsed)
+                        .with_border_fill(header_border_fill),
+                )
                 .finish()
         })
         .with_cursor(Cursor::PointingHand)
@@ -20544,8 +20590,33 @@ impl Workspace {
             }
         }
 
-        // Placeholder to make sure the flex row expands across the entire width of the app.
-        tab_bar.add_child(Shrinkable::new(0.5, Empty::new().finish()).finish());
+        // Trailing spacer fills leftover width, and re-adds the flex each
+        // collapsed group gives up vs expanded (its members + 2 spacers), so the
+        // bar's total flex stays constant across collapse/expand and headers
+        // don't move.
+        let collapsed_group_flex_giveback: f32 = if FeatureFlag::GroupedTabs.is_enabled() {
+            self.tab_groups
+                .values()
+                .filter(|group| group.collapsed)
+                .map(|group| {
+                    let members = self
+                        .tabs
+                        .iter()
+                        .filter(|tab| tab.group_id == Some(group.id))
+                        .count();
+                    if members == 0 {
+                        0.0
+                    } else {
+                        members as f32 + 2.0 * Self::GROUP_EDGE_SPACER_FLEX
+                    }
+                })
+                .sum()
+        } else {
+            0.0
+        };
+        tab_bar.add_child(
+            Shrinkable::new(0.5 + collapsed_group_flex_giveback, Empty::new().finish()).finish(),
+        );
 
         self.add_configurable_right_side_tab_bar_controls(
             &mut tab_bar,
@@ -27837,16 +27908,17 @@ impl Workspace {
         let groups_enabled = FeatureFlag::GroupedTabs.is_enabled();
 
         if groups_enabled {
-            // Reassign membership when the dragged tab's midpoint enters a
-            // different expanded group. Collapsed groups are handled by the
-            // safety-net hop below so we don't drop into it.
+            // Reassign membership when the dragged tab enters a different
+            // expanded group. Collapsed groups are handled by the safety-net
+            // hop below so we don't drop into it.
             let midpoint_drag = if use_vertical_tabs {
                 (position.min_y() + position.max_y()) / 2.
             } else {
                 (position.min_x() + position.max_x()) / 2.
             };
-            let hovered_group = self.target_group_at_axis(midpoint_drag, use_vertical_tabs, ctx);
             let source_group = self.tabs[current_index].group_id;
+            let hovered_group =
+                self.target_group_at_axis(midpoint_drag, source_group, use_vertical_tabs, ctx);
             let expanded_target =
                 hovered_group.filter(|gid| !self.tab_groups.get(gid).is_some_and(|g| g.collapsed));
             // A pinned tab keeps its individual pin while dragging over a
@@ -28110,35 +28182,74 @@ impl Workspace {
         current_index
     }
 
-    /// Returns the group whose saved container rect contains `cursor` along
-    /// the active axis, if any. Small edge margins exist at each end of the rect
-    /// treated as "between groups" so the cursor can land in the ungrouped zone
-    /// between adjactent groups. The trailing edge margin is larger to account for
-    /// the group header, the leading edge margin makes dropping into the last position
-    /// of a group more reactive. `is_vertical` picks the layout-correct `SavePosition`
-    /// id and the axis to test along.
+    /// Returns the group the dragged tab is over along the active axis so it can
+    /// join it, or `None`. Vertical tabs inset both ends of the group rect by a
+    /// fixed margin (`LEADING_EDGE_MARGIN` / `TRAILING_EDGE_MARGIN`). Horizontal
+    /// tabs use the position of a dynamic spacer, since tab groups resize dynamically.
     fn target_group_at_axis(
         &self,
         cursor: f32,
+        source_group: Option<TabGroupId>,
         is_vertical: bool,
         ctx: &mut ViewContext<Self>,
     ) -> Option<TabGroupId> {
         const LEADING_EDGE_MARGIN: f32 = 4.0;
         const TRAILING_EDGE_MARGIN: f32 = 8.0;
+        // Fallback margin for a collapsed horizontal group (no members/spacer).
+        const EDGE_MARGIN: f32 = 6.0;
         self.tab_groups.keys().copied().find(|group_id| {
             let id = if is_vertical {
                 vtab_group_position_id(*group_id)
             } else {
                 htab_group_position_id(*group_id)
             };
-            ctx.element_position_by_id(id).is_some_and(|rect| {
-                let (min, max) = if is_vertical {
-                    (rect.min_y(), rect.max_y())
-                } else {
-                    (rect.min_x(), rect.max_x())
-                };
-                min + LEADING_EDGE_MARGIN <= cursor && cursor <= max - TRAILING_EDGE_MARGIN
-            })
+            let Some(rect) = ctx.element_position_by_id(id) else {
+                return false;
+            };
+
+            // Vertical tabs: fixed margin at each end of the group rect.
+            if is_vertical {
+                return rect.min_y() + LEADING_EDGE_MARGIN <= cursor
+                    && cursor <= rect.max_y() - TRAILING_EDGE_MARGIN;
+            }
+
+            // An expanded group has a flex spacer on each side of its members
+            // ([header][spacer][members][spacer]); the spacer is used to determine
+            // whether the dragging tab should land at the first/last position of the
+            // group, or just outside the group. The spacer is flex, so we fetch the
+            // the element position below to use it for our bounds calculations.
+            let collapsed = self
+                .tab_groups
+                .get(group_id)
+                .is_some_and(|group| group.collapsed);
+            // The edge of the last member is the right bound of the flex spacer.
+            let last_member_max_x = if collapsed {
+                None
+            } else {
+                group_member_index_range(&self.tabs, *group_id)
+                    .and_then(|(_, last)| ctx.element_position_by_id(tab_position_id(last)))
+                    .map(|last_rect| last_rect.max_x())
+            };
+
+            // Leading: start the accept zone a full spacer in from the header
+            // edge so joining a group from the left is deliberate. This makes
+            // dropping between groups easy.
+            let leading_inset = last_member_max_x
+                .map(|last_max_x| rect.max_x() - last_max_x)
+                .unwrap_or(EDGE_MARGIN);
+
+            // Trailing resolves two opposite needs. Your own group releases at
+            // its inner edge, so the trailing spacer is cushion before the cursor
+            // reaches the next tab (leaving doesn't instantly swap). Any other
+            // group accepts out to its outer edge, so dropping into its last slot
+            // stays easy.
+            let trailing = if Some(*group_id) == source_group {
+                last_member_max_x.unwrap_or(rect.max_x())
+            } else {
+                rect.max_x()
+            };
+
+            rect.min_x() + leading_inset <= cursor && cursor <= trailing
         })
     }
 


### PR DESCRIPTION
## Description

Reworks horizontal tab groups so that group headers are now the same width as tabs, regardless of the tab group title. Also modifies the layout of tab groups so that groups have dynamic flex spacers rather than fixed margins/padding on either side of the member tabs. This allows the tab group to resize dynamically and keeps all tabs in the tab bar the same width.

This change resolves a lot of bugs with horizontal tab groups, and I got the designs for the header change approved.

Bugs can be seen in the demo below.

## What changed

- The group header fills one `tab slot` of flex and is capped at the same 200px max as a tab.
- Each expanded group gets a flex spacer on each side of its members (`[header][spacer][members][spacer]`). Because the spacers are their own flex slots, member tabs stay exactly as wide as ungrouped tabs. 
-`target_group_at_axis` now uses the group's (dynamically resizing) flex spacers for horizontal tabs while keeping fixed-margin logic for vertical tabs. Some special cases were added to make dropping into the last position of a group, dropping between groups and dragging out of a group a bit more seamless.

## Notes

Debugging flex is hard. I finally understand.

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4768/htab-groups-inconsistent-header-sizes-cause-several-bugs-in-the-tab

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->


[Demo before rework](https://www.loom.com/share/84f01d17a7cc418485baab598e251f57)

[Demo after rework ](https://www.loom.com/share/8cce26ce58354adabe116b45ad0e62c4)

