### PR TITLE
Fix: use try_send for block saves to prevent loss when UI is idle before quit

### DIFF
--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -1029,16 +1029,17 @@ fn handle_terminal_view_event(
                                     block: block.clone(),
                                     is_local: *is_local,
                                 });
-
-                                let sender_clone = sender.clone();
-                                let _ = ctx.spawn(async move {
-                                // Sending over a sync sender can block the current thread, so we do this async.
-                                sender_clone.send(block_completed_event)
-                            }, move |_, res, _| {
-                                if let Err(err) = res {
-                                    log::error!("Error sending block completed event for terminal id {terminal_pane_id:?} {err:?}");
+                                // Use try_send to avoid losing the block-save event on shutdown.
+                                // ctx.spawn runs on the foreground executor which is only driven by
+                                // UI events; if the user quits Warp while the UI is idle (e.g.,
+                                // right after exiting an alt-screen app like claude with no further
+                                // interaction), the spawned future is cancelled before the
+                                // SQLite thread receives the SaveBlock message.
+                                // try_send is non-blocking and succeeds as long as the 1024-slot
+                                // channel is not full, which is the case in practice.
+                                if let Err(err) = sender.try_send(block_completed_event) {
+                                    log::error!("Error sending block completed event for terminal id {terminal_pane_id:?}: {err:?}");
                                 }
-                            });
                             }
                         }
                         ctx.emit(pane_group::Event::ActiveSessionChanged);

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -12316,7 +12316,6 @@ impl TerminalView {
                             );
                         });
 
-                        let sender_clone = model_event_sender.clone();
                         let update_finished_command_event =
                             persistence::ModelEvent::UpdateFinishedCommand {
                                 metadata: FinishedCommandMetadata {
@@ -12326,19 +12325,12 @@ impl TerminalView {
                                     session_id: active_session_id,
                                 },
                             };
-                        let _ = ctx.spawn(
-                            async move {
-                                // Sending over a sync sender can block the current thread, so we do this async.
-                                sender_clone.send(update_finished_command_event)
-                            },
-                            move |_, res, _| {
-                                if let Err(err) = res {
-                                    log::error!(
-                                        "Error sending UpdateFinishedCommand event: {err:?}"
-                                    );
-                                }
-                            },
-                        );
+                        // Use try_send to avoid losing the event on shutdown (same reasoning
+                        // as the SaveBlock try_send in terminal_pane.rs).
+                        if let Err(err) = model_event_sender.try_send(update_finished_command_event)
+                        {
+                            log::error!("Error sending UpdateFinishedCommand event: {err:?}");
+                        }
                     }
 
                     #[cfg(not(target_family = "wasm"))]


### PR DESCRIPTION
## Description

Fix a bug where the last block from an alt-screen app (e.g. `claude`, `vim`, `htop`) was missing from session restoration if the user quit Warp without any UI interaction after quitting the app.

### Root Cause

When `AfterBlockCompleted` fires (triggered by the shell's `precmd` hook after a command exits), the `SaveBlock` event was sent via:

```rust
ctx.spawn(async move { sender.send(block_completed_event) }, ...)
```

`ctx.spawn` on a `ViewContext` schedules the future on the **foreground executor**, which is driven only when the UI event loop is processing events. After an alt-screen app exits, if the user quits Warp without any further UI interaction (no keystrokes, no mouse, no PTY output), the foreground executor is never polled again. When `PersistenceWriter::drop()` runs during shutdown, it sends `Terminate` to the SQLite writer thread and joins it — but the thread exits without ever having received the `SaveBlock` event, so the block is lost.

The workaround (typing anything to the Warp agent after quitting claude) worked because that interaction created UI events that drove the foreground executor, causing the pending save task to run before shutdown.

The same pattern existed for `UpdateFinishedCommand` in `view.rs`.

### Fix

Replace `ctx.spawn(async { sender.send(...) })` with `sender.try_send(...)`, which is synchronous and non-blocking. The 1024-slot channel is virtually never full in practice, so `try_send` succeeds immediately and the block is persisted before the shutdown sequence begins.

## Linked Issue

<!-- No linked issue — investigation-driven fix -->

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

Manually tested by:
1. Running `claude` (or `vim`) in a Warp terminal
2. Quitting the app cleanly  
3. **Without typing anything further**, quitting Warp
4. Relaunching Warp and verifying the `claude`/`vim` block appears in the restored session

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!-- CHANGELOG-BUG-FIX: Fixed a bug where the last block from an alt-screen app (e.g. claude, vim) was missing from session restoration if Warp was quit without any further UI interaction after the app exited. -->

_Conversation: https://staging.warp.dev/conversation/b5805634-84d7-40e4-8413-dbc222e11fe5_
_Run: https://oz.staging.warp.dev/runs/019efced-9502-731a-9b9b-71687c6307f4_

_This PR was generated with [Oz](https://warp.dev/oz)._
