### PR TITLE
Fix missing block save for alt-screen apps (claude) on session restore

### DIFF
--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -1030,15 +1030,18 @@ fn handle_terminal_view_event(
                                     is_local: *is_local,
                                 });
 
-                                let sender_clone = sender.clone();
-                                let _ = ctx.spawn(async move {
-                                // Sending over a sync sender can block the current thread, so we do this async.
-                                sender_clone.send(block_completed_event)
-                            }, move |_, res, _| {
-                                if let Err(err) = res {
+                                // Send synchronously so the SaveBlock event is guaranteed to be
+                                // queued before app shutdown cancels pending background tasks.
+                                // Using an async background task here caused a race condition
+                                // where the task could be cancelled by shutdown_background()
+                                // before it had a chance to run, causing blocks from alt-screen
+                                // apps (like claude) to not be saved on session restore.
+                                //
+                                // The SyncSender channel has 1024 capacity; in practice it is
+                                // never full during normal operation so blocking is negligible.
+                                if let Err(err) = sender.send(block_completed_event) {
                                     log::error!("Error sending block completed event for terminal id {terminal_pane_id:?} {err:?}");
                                 }
-                            });
                             }
                         }
                         ctx.emit(pane_group::Event::ActiveSessionChanged);

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -12316,7 +12316,6 @@ impl TerminalView {
                             );
                         });
 
-                        let sender_clone = model_event_sender.clone();
                         let update_finished_command_event =
                             persistence::ModelEvent::UpdateFinishedCommand {
                                 metadata: FinishedCommandMetadata {
@@ -12326,19 +12325,12 @@ impl TerminalView {
                                     session_id: active_session_id,
                                 },
                             };
-                        let _ = ctx.spawn(
-                            async move {
-                                // Sending over a sync sender can block the current thread, so we do this async.
-                                sender_clone.send(update_finished_command_event)
-                            },
-                            move |_, res, _| {
-                                if let Err(err) = res {
-                                    log::error!(
-                                        "Error sending UpdateFinishedCommand event: {err:?}"
-                                    );
-                                }
-                            },
-                        );
+                        // Send synchronously to avoid the same race condition as SaveBlock:
+                        // an async background task could be cancelled by shutdown_background()
+                        // before running. The SyncSender channel has 1024 capacity.
+                        if let Err(err) = model_event_sender.send(update_finished_command_event) {
+                            log::error!("Error sending UpdateFinishedCommand event: {err:?}");
+                        }
                     }
 
                     #[cfg(not(target_family = "wasm"))]


### PR DESCRIPTION
## Description

Fixes a race condition where blocks from alt-screen CLI apps (like `claude`) are not saved to the session restoration database when quitting Warp.

**Root Cause:** When `Event::BlockCompleted` fires in the pane group handler, `SaveBlock` was sent to the persistence thread via an async background task (`ctx.spawn`). This created a race condition:

1. The user quits `claude` → `AfterBlockCompleted` fires → `Event::BlockCompleted` fires → async `SaveBlock` task is **queued** in the tokio `Background` executor
2. The user quits Warp → `Background::drop()` calls `runtime.shutdown_background()` which **immediately cancels all queued-but-not-yet-started tasks**
3. If the `SaveBlock` task was still queued (not yet polled by a tokio thread), it is cancelled → the block is never written to SQLite

**Why "hello" block was saved:** It completed long before the user quit, so its background task ran to completion well before shutdown.

**Why "hi" to agent helped:** The additional event processing gave the tokio executor time to run the `SaveBlock` task before the user eventually quit.

**Fix:** Send `SaveBlock` synchronously on the main thread instead of via an async background task. The `SyncSender` channel has 1024 capacity and is never full in practice, so blocking risk is negligible. This matches how `delete_blocks()` already works synchronously.

The same fix is applied to `UpdateFinishedCommand` in `view.rs` which used the identical async pattern.

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Manual reproduction steps:
1. Run a shell command (e.g. `echo hello`) → this block should be saved ✓
2. Run `claude` (Claude Code CLI) → claude uses the alt-screen buffer
3. Exit `claude` cleanly
4. Quit Warp
5. Relaunch Warp → **before fix:** claude block missing; **after fix:** claude block appears

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed session restore missing blocks from alt-screen CLI apps (e.g. claude) when quitting Warp shortly after the app exits.
-->

_Conversation: https://staging.warp.dev/conversation/4ab3a122-8f39-43b3-b9f2-b7fc1e7f3104_
_Run: https://oz.staging.warp.dev/runs/019efced-9512-792b-952b-657c9af3609a_

_This PR was generated with [Oz](https://warp.dev/oz)._
