### PR TITLE
Re-add Metal Toolchain download step after setup-xcode in CI

### DIFF
--- a/.github/actions/prepare_environment/action.yml
+++ b/.github/actions/prepare_environment/action.yml
@@ -179,3 +179,8 @@ runs:
       if: ${{ inputs.target_os == 'macos' && inputs.is_self_hosted != 'true' }}
       with:
         xcode-version: '26'
+
+    - name: Download Metal Toolchain
+      if: ${{ inputs.target_os == 'macos' && inputs.is_self_hosted != 'true' }}
+      shell: bash
+      run: xcodebuild -downloadComponent MetalToolchain


### PR DESCRIPTION
## Description

Note from Kevin: We had moved this step to fix a local bootstrapping issue. However, in CI, that bootstrapping script is run before we set the xcode version. There must have been recent version drift between our required xcode version, and the default version on certain runners.

In [#24766](https://github.com/warpdotdev/warp/pull/24766) (commit eab2b36538), the standalone "Download Metal Toolchain" step was removed from `prepare_environment/action.yml` and consolidated into `script/macos/install_build_deps`, which is called via `install_cargo_build_deps`.

The problem is that `install_cargo_build_deps` runs during the "Install dependencies" step, which executes **before** the `setup-xcode` action. This means the Metal Toolchain is downloaded for whatever Xcode version is the runner's default, not for the version that `setup-xcode` subsequently selects. When the runner's default Xcode and the selected Xcode diverge (as happened when GitHub updated the x86_64 runner image to include Xcode 26.6 RC2), the downloaded toolchain doesn't match and the build fails with:

```
error compiling metal shaders to .air; error: cannot execute tool 'metal' due to missing Metal Toolchain; use: xcodebuild -downloadComponent MetalToolchain
```

This PR re-adds the Metal Toolchain download as a dedicated step **after** `setup-xcode`, matching the original ordering. The download in `install_cargo_build_deps` is kept for local development (`script/bootstrap`).

## Linked Issue

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

CI-only change — the fix ensures the Metal Toolchain is downloaded for the correct Xcode version on GitHub-hosted macOS runners. The [most recent "Cut New Releases" run](https://github.com/warpdotdev/warp-internal/actions/runs/28159873161) failed on the macOS x86_64 builder due to this issue; the arm64 (self-hosted) builder was unaffected since `setup-xcode` doesn't run on self-hosted runners.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

Co-Authored-By: Oz <oz-agent@warp.dev>
