### PR TITLE
Make authenticated Warp launch reliable: loud api-key warning + test-warp-ui hardening

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1259,7 +1259,7 @@ pub(crate) fn initialize_app(
     {
         let channel = ChannelState::channel();
         let warning = format!(
-            "WARNING: --api-key/WARP_API_KEY was provided but IGNORED on the '{channel}' channel — Warp is starting LOGGED OUT. API-key auth requires a dogfood build; relaunch with `cargo run --bin warp`."
+            "WARNING: --api-key/WARP_API_KEY was provided but IGNORED on the '{channel}' channel — Warp is starting LOGGED OUT. API-key auth is only available on internal (dogfood) builds."
         );
         eprintln!("{warning}");
     }

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1246,6 +1246,24 @@ pub(crate) fn initialize_app(
         None
     };
 
+    // A key supplied to an App launch but dropped here means Warp will start logged out
+    // (non-dogfood channel or feature disabled). Surface this loudly so it isn't silent.
+    if api_key.is_none()
+        && matches!(
+            launch_mode,
+            LaunchMode::App {
+                api_key: Some(_),
+                ..
+            }
+        )
+    {
+        let channel = ChannelState::channel();
+        let warning = format!(
+            "WARNING: --api-key/WARP_API_KEY was provided but IGNORED on the '{channel}' channel — Warp is starting LOGGED OUT. API-key auth requires a dogfood build; relaunch with `cargo run --bin warp`."
+        );
+        eprintln!("{warning}");
+    }
+
     let auth_state = Arc::new(AuthState::initialize(ctx, api_key));
     timer.mark_interval_end("AUTH_MANAGER_SET_USER");
 

--- a/resources/channel-gated-skills/dogfood/test-warp-ui/SKILL.md
+++ b/resources/channel-gated-skills/dogfood/test-warp-ui/SKILL.md
@@ -33,6 +33,15 @@ Authenticating this way starts the app directly without interactive login prompt
 
 Initial builds may take several minutes; subsequent incremental builds are faster.
 
+### Verify the launch is authenticated
+
+After launching, confirm both of the following before testing:
+
+- Warp is **authenticated** — it opens straight to the terminal, NOT the logged-out onboarding/sign-in screen.
+- The `cargo run` stderr/terminal output does **not** contain the substring `provided but IGNORED`.
+
+If that warning appears (or the app is logged out), the wrong binary/channel was launched — stop and relaunch with `cargo run --bin warp`.
+
 ## Testing Workflow
 
 ### 1. Hardcode or Mock Data (When Needed)


### PR DESCRIPTION
## Description
Authenticated Warp launches for computer-use agents were failing silently. `app/Cargo.toml` sets `default-run = "warp-oss"`, so a bare `cargo run` builds the OSS channel (`src/bin/oss.rs`), which drops `--api-key`/`WARP_API_KEY` and starts Warp logged out; only `cargo run --bin warp` (the Local/dogfood channel) honors the key. This PR makes that silent drop loud, and teaches the agent-facing skill to detect it.

Two changes:
- **`app/src/lib.rs`**: After API-key resolution (immediately before `AuthState::initialize`), if an `App` launch was given a key but it was dropped — non-dogfood channel, or API-key auth disabled — print a one-line warning to **stderr** via `eprintln!`, including the active channel via `ChannelState::channel()`. Scoped to the App launch path only; CommandLine mode is unaffected.
  - **Why `eprintln!` and nothing else:** this message exists purely to show up in the command output a human or agent reads. `log::*` is the wrong tool here — when the process's stdout is not a TTY (e.g. an agent capturing `cargo run` through a pipe), the logger routes records to the on-disk log file instead of the captured stream, so the message wouldn't be seen. `log::error!` would additionally be captured as a Sentry event and carries false "something failed" semantics. `eprintln!` always lands on stderr (which the skill greps for `provided but IGNORED`) and keeps Sentry out of it.
- **`resources/channel-gated-skills/dogfood/test-warp-ui/SKILL.md`**: Adds a "Verify the launch is authenticated" step — after launching, confirm Warp opened authenticated (not the logged-out onboarding/sign-in screen) and that the `cargo run` stderr does not contain `provided but IGNORED`; if it does (or the app is logged out), relaunch with `cargo run --bin warp`.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
`cargo check -p warp --lib` from the worktree root succeeds with no errors or warnings. The skill change is markdown-only.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

Conversation: https://staging.warp.dev/conversation/b217489b-c8d2-4d7b-be84-839df2b1f167
Run: https://oz.staging.warp.dev/runs/019effad-34c2-7a02-a246-d8df3a3c521e

Co-Authored-By: Oz <oz-agent@warp.dev>