### PR TITLE
fix: improve context window exceeded error messages (REMOTE-2016)

### DIFF
--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -3168,7 +3168,7 @@ impl BlocklistAIController {
                 });
             }
             Some(warp_multi_agent_api::response_event::stream_finished::Reason::ContextWindowExceeded(_)) => {
-                let error_message = "Input exceeded context window limit.";
+                let error_message = "The conversation history is too large for the model's context window. Use /compact to summarize the conversation, or start a new one.";
                 history_model.update(ctx, |history_model, ctx| {
                     history_model.mark_response_stream_completed_with_error(
                         RenderableAIError::ContextWindowExceeded(error_message.to_owned()),

--- a/app/src/ai/blocklist/local_agent_task_sync_model.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model.rs
@@ -446,11 +446,11 @@ pub(crate) fn classify_renderable_error(
                 PlatformErrorCode::InternalError,
             )),
         ),
-        RenderableAIError::ContextWindowExceeded(msg) => (
+        RenderableAIError::ContextWindowExceeded(_) => (
             AgentTaskState::Failed,
             Some(TaskStatusUpdate::with_error_code(
-                format!("Context window exceeded: {msg}"),
-                PlatformErrorCode::InternalError,
+                "The conversation history exceeded the model's context window limit. Start a new run with a shorter prompt or less context.",
+                PlatformErrorCode::InvalidRequest,
             )),
         ),
         RenderableAIError::InvalidApiKey { provider, .. } => (

--- a/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
@@ -85,8 +85,8 @@ fn context_window_exceeded_is_failed() {
     assert_update(
         classify_renderable_error(&RenderableAIError::ContextWindowExceeded("too big".into())),
         AgentTaskState::Failed,
-        Some(PlatformErrorCode::InternalError),
-        Some("Context window exceeded"),
+        Some(PlatformErrorCode::InvalidRequest),
+        Some("context window limit"),
     );
 }
 


### PR DESCRIPTION
## Summary

Improves the error experience when a cloud Oz run fails because the conversation history exceeds the model's context window limit.

### Problem

When a cloud Oz run hits the context window limit, users saw:
- **Message**: `"Context window exceeded: Input exceeded context window limit."` — not actionable
- **Error code**: `INTERNAL_ERROR` — incorrect; this is a user-side constraint, not a Warp infrastructure error

### Changes

**Error message for cloud task status (Oz webapp):**
> The conversation history exceeded the model's context window limit. Start a new run with a shorter prompt or less context.

**Error message for local Warp UI:**
> The conversation history is too large for the model's context window. Use /compact to summarize the conversation, or start a new one.

**Error code:** `INVALID_REQUEST` (was `INTERNAL_ERROR`) — correctly classifies this as a user-side constraint, resulting in `FAILED` state (not `ERROR`).

### Root cause

The `ContextWindowExceeded` stream finished event from the server was mapped to `PlatformErrorCode::InternalError` in `classify_renderable_error`, which is incorrect. A context-window overflow is not a Warp infrastructure failure — it's a consequence of the conversation history being too large. Using `INVALID_REQUEST` correctly signals to the user that they need to take action (start a new run, reduce context) rather than waiting for Warp to retry.

This PR fixes both the classification and the user-facing messages to be actionable.

Fixes: [REMOTE-2016](https://linear.app/warpdotdev/issue/REMOTE-2016)

---

_Conversation: https://staging.warp.dev/conversation/3c486cea-38ea-4795-a6ca-4d50aeae16e8_
_Run: https://oz.staging.warp.dev/runs/019effbe-86cc-7a79-870f-5089f5725d02_
_This PR was generated with [Oz](https://warp.dev/oz)._
