### PR TITLE
Release custom model router to Stable

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -687,6 +687,7 @@ default = [
     "remote_codebase_indexing",
     "solo_user_byok",
     "custom_inference_endpoints",
+    "custom_model_routers",
     "supergrok",
     "billing_and_usage_page_v2",
     "remote_code_review",
@@ -1000,6 +1001,7 @@ open_code_notifications = []
 transfer_control_tool = []
 skip_firebase_anonymous_user = []
 custom_inference_endpoints = []
+custom_model_routers = []
 solo_user_byok = []
 billing_and_usage_page_v2 = []
 gpt_configurable_context_window = []

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -497,6 +497,8 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::RemoteCodeReview,
         #[cfg(feature = "custom_inference_endpoints")]
         FeatureFlag::CustomInferenceEndpoints,
+        #[cfg(feature = "custom_model_routers")]
+        FeatureFlag::CustomModelRouters,
         #[cfg(feature = "supergrok")]
         FeatureFlag::SuperGrok,
         #[cfg(feature = "gemini_enterprise")]

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -957,7 +957,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::GPTConfigurableContextWindow,
     FeatureFlag::RestorePromptOnInlineModelSelectorSearch,
     FeatureFlag::WarpControlCli,
-    FeatureFlag::CustomModelRouters,
     FeatureFlag::PromptCacheExpiryWarning,
     FeatureFlag::PinnedTabs,
     FeatureFlag::ContextWindowUsageBreakdown,


### PR DESCRIPTION
## Description
Promotes the custom model router feature (`FeatureFlag::CustomModelRouters`) from Dogfood to Stable so it ships to all users.

**What & how**
- Add a `custom_model_routers` Cargo feature and include it in the `default` feature set in `app/Cargo.toml`.
- Bridge the Cargo feature to `FeatureFlag::CustomModelRouters` in `enabled_features()` (`app/src/features.rs`).
- Remove `FeatureFlag::CustomModelRouters` from `DOGFOOD_FLAGS` in `crates/warp_features/src/lib.rs`; it now compiles in for all builds via `default`.

This follows the standard staged-promotion approach (preferring the `default` array over `RELEASE_FLAGS`), so rollback is a one-line change (remove from `default`). The flag is intentionally kept for 1-2 release cycles before cleanup.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `./script/format` - clean
- [x] `cargo clippy -p warp --lib -- -D warnings` - clean
- [ ] I have manually tested my changes locally with `./script/run`

Feature-flag promotion only (no logic changes); the feature was exercised during the Dogfood period.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NEW-FEATURE: Custom model routers - define your own routing rules to send agent requests to different models.

---
Conversation: https://staging.warp.dev/conversation/d7a14651-2a99-4560-93b0-ae11db0208a4

Co-Authored-By: Oz <oz-agent@warp.dev>