### PR TITLE
QUALITY-887: spec for Enter-to-send on the top queued prompt

### DIFF
--- a/specs/QUALITY-887/PRODUCT.md
+++ b/specs/QUALITY-887/PRODUCT.md
@@ -1,0 +1,31 @@
+# Enter on empty input sends the top queued prompt
+
+Linear: [QUALITY-887](https://linear.app/warpdotdev/issue/QUALITY-887/add-enter-to-send-now-action-for-queued-prompts-copy)
+
+## Summary
+When the queued prompts panel is showing and the terminal input is empty, pressing Enter sends the top queued row immediately — exactly as if the user clicked that row's Send-now button, instead of waiting for the queue to drain on its own. The panel header advertises this with a "⏎ to send" hint that appears only when Enter would actually send.
+Figma: none provided. Reference is Cursor's queue UI, which shows an Enter-to-send hint next to its "N Queued" header label; we copy that placement in our panel header.
+## Problem
+Queued prompts only release when the running exchange finishes (or via each row's Send-now button). A user who has emptied the input and wants the next queued prompt to go out now has to reach for the mouse and click Send-now. Enter — the natural "send" key — does nothing useful on an empty buffer in this state, so the fastest keyboard path to release a queued prompt is missing.
+## Behavior
+1. With the queued prompts panel visible, the input buffer completely empty, and the top queued row sendable (see 5), pressing Enter in the terminal input sends the top row immediately. This is identical to clicking that row's Send-now button:
+   - An agent prompt row is submitted to the same target Send-now would use (running conversation follow-up, cloud follow-up, shared-session viewer send, or full-terminal-use agent when one is in control), carrying the row's own queued attachments.
+   - A command row (`!` prefix) executes as a shell command.
+   - The row is removed from the queue after dispatch; remaining rows shift up.
+2. This applies regardless of the input's mode. In shell mode, an empty-buffer Enter that previously produced a fresh prompt line instead sends the top queued row while the panel is showing a sendable top row.
+3. Enter sends exactly one row per press. Pressing Enter again re-evaluates: if the new top row is sendable and the buffer is still empty, it sends that row next.
+4. The behavior works the same whether the panel body is expanded or collapsed (the header is visible either way).
+5. Enter mirrors Send-now availability for the top row. While the top row's Send-now is disabled — the locked initial cloud-mode prompt while cloud environment setup is in progress — Enter does nothing and the hint is hidden.
+   - The same applies whenever prompt sending is unavailable for the pane as a whole, e.g. the user is a read-only (non-executor) viewer in a shared session. In that state the rows' Send-now buttons are also disabled (with a tooltip explaining why), Enter does nothing, and the hint is hidden — button and Enter availability are bundled and may not disagree.
+   - Pane-level unavailability only affects sending: it does not disable a row's edit/delete buttons, and it does not stop new prompts from being queued.
+   - Enter-only conditions (non-empty buffer, CLI-agent rich input open) hide the hint and suppress Enter but do not disable the Send-now buttons.
+6. If the buffer contains any content (including whitespace-only content), Enter behaves exactly as it does today and the hint is hidden.
+7. Header hint:
+   - The panel header shows an ⏎ keycap followed by "to send" next to the "N queued" label, matching the look and spacing of Warp's existing keystroke hints (e.g. "? for help"). The "to send" text uses the same color as the "N queued" label; the keycap glyph is dimmer (disabled-text styling) so it reads as a secondary affordance.
+   - The hint is visible exactly when an empty-buffer Enter would send the top row, and hidden otherwise (non-empty buffer, no sendable top row, sending unavailable per 5, panel hidden, or any case in 8–10). The hint and the Enter behavior must never disagree.
+8. Whenever the panel is not rendered (no queue, inline menu like slash commands or the model selector is open, feature flag off), Enter keeps its existing behavior and no hint is shown.
+9. While a queued row is in inline edit mode, Enter commits that edit as today (focus is in the row's editor, not the input). The header hint is hidden during an inline edit.
+10. When the CLI-agent rich input is open, Enter keeps its existing submit-to-CLI-agent behavior and the hint is hidden. (The `submit_on_ctrl_enter` setting only affects the CLI-agent rich input, so it never changes which key sends a queued row.)
+11. Sending via Enter does not touch the input buffer, its pending attachments, or focus: the buffer stays empty, attachments staged in the input are not consumed (the queued row carries its own), and focus remains in the input afterward. One pre-existing exception, shared with the Send-now button: on the shared-session viewer path an empty input temporarily shows the standard "<prompt> ◌" loading affordance until the sharer acknowledges the send.
+12. When the last queued row is sent, the panel disappears (existing behavior); a subsequent Enter behaves as it did before this feature.
+13. Sending a queued row records telemetry distinguishing the trigger: Send-now button click vs. Enter on empty input.

--- a/specs/QUALITY-887/TECH.md
+++ b/specs/QUALITY-887/TECH.md
@@ -1,0 +1,25 @@
+# QUALITY-887 — Enter on empty input sends the top queued prompt
+
+See `specs/QUALITY-887/PRODUCT.md` for behavior. QUALITY-887 is a copy of [APP-4717](https://linear.app/warpdotdev/issue/APP-4717); the behavior it asks for is already implemented and shipped under the existing `QueueSlashCommand` gate. This spec documents where that behavior lives, mapped to the current tree at commit `4c39fe77364abb5297a6076dc0338c83ef3bdba6`.
+
+## Context
+The queued prompts panel and its host input are the two surfaces involved. The panel owns the "would Enter send?" decision and the header hint; the host input owns the Enter dispatch chain and the shared send helper.
+- `app/src/terminal/input.rs` — `Input::input_enter`. The else-if chain that routes Enter has a dedicated branch (before `maybe_launch_cloud_handoff_request` / `maybe_queue_input_for_in_progress_conversation`) that, when `panel.enter_sends_queued_prompt(ctx)` holds, looks up the head row of the active conversation's queue (`BlocklistAIHistoryModel::active_conversation_id` + `QueuedQueryModel::queue(...).first()`, skipping a `is_locked()` head) and dispatches it. A locked head means Enter does nothing.
+- `app/src/terminal/input.rs` — `Input::send_queued_row_immediately`: the shared dispatch helper used by both the panel's `SendNow` event arm (`handle_queued_prompts_panel_event`) and the Enter path. It reads the row origin, dispatches (`execute_queued_command` for command rows, `submit_queued_prompt_for_active_pane` for prompts), emits the `QueuedPromptSentNow` telemetry event with the trigger, removes the fired row via `QueuedQueryModel::remove_fired_row`, and refocuses the input.
+- `app/src/terminal/view/queued_prompts_panel.rs` — `QueuedPromptsPanelView`:
+  - `enter_sends_queued_prompt(ctx)` = `should_render` + `can_send_prompt` + host editor empty (read live from the held `host_editor` handle) + CLI-agent rich input closed (`CLIAgentSessionsModel::is_input_open`).
+  - `should_show_enter_hint(ctx)` = `enter_sends_queued_prompt` + no row in inline edit (`editing_row`) + head row sendable (`!row.is_locked()`), so the hint can never advertise an Enter that wouldn't fire.
+  - `can_send_prompt` is host-pushed via `set_can_send_prompt` (false for read-only shared-session viewers); it gates the Send-now buttons (`update_send_now_availability`), empty-Enter sends, and the hint. Host-input emptiness is not pushed — a subscription to the host editor's `Edited`/`BufferReplaced` events (`handle_host_editor_event`, damped by `host_editor_was_empty`) only re-renders on empty↔non-empty transitions; decisions always read the editor live.
+- `app/src/terminal/input.rs` — at panel construction, `Input` seeds `can_send_prompt` from `model.lock().shared_session_status().is_reader()` and passes the host editor handle into the panel. `TerminalView::on_self_role_updated` pushes `set_can_send_prompt(role.can_execute())` when the shared-session role changes (panel reached via `Input::queued_prompts_panel()`).
+- `app/src/server/telemetry/events.rs` — `QueuedPromptSentNow { origin, trigger }` with `QueuedPromptSendNowTrigger { SendNowButton, EnterOnEmptyInput }`. Gated on `FeatureFlag::QueueSlashCommand`; serialized as `"QueuedPrompt.SentNow"`.
+
+No new feature flag: the behavior ships under the existing `QueueSlashCommand` gate the panel already requires.
+
+## Testing and validation
+This behavior is already covered by tests; QUALITY-887 adds no new code, so the existing coverage is the validation baseline:
+- `app/src/terminal/input_tests.rs` — `send_now_event_submits_through_active_pane_and_preserves_draft` and `send_now_command_event_executes_command_and_arms_in_flight` exercise the shared dispatch helper (prompt and command rows) including row removal and untouched draft buffer.
+- `app/src/terminal/view/queued_prompts_tests.rs` — `can_send_prompt_gates_buttons_and_hint_while_nonempty_input_gates_only_the_hint` and `enter_hint_hidden_during_inline_edit_and_for_locked_head` cover the hint/Enter gating (read-only viewer, non-empty buffer, inline edit, locked head).
+- Build/lint per repo workflow: `cargo check`, `./script/format`, and `cargo clippy` before any PR.
+
+## Parallelization
+Not beneficial: this is a documentation-only spec for an already-implemented feature. A single agent authors the spec.


### PR DESCRIPTION
## Description
Adds a spec for **QUALITY-887** ("Add enter to send now action for queued prompts"), documenting the behavior where pressing Enter on an empty input sends the top queued prompt immediately instead of waiting for the queue to drain.

QUALITY-887 is a copy of [APP-4717](https://linear.app/warpdotdev/issue/APP-4717), and that behavior is **already implemented and shipped** under the existing `QueueSlashCommand` gate. This PR is documentation-only: it adds `specs/QUALITY-887/PRODUCT.md` and `specs/QUALITY-887/TECH.md`, with the TECH spec mapping each behavior to the current implementation:

- `Input::input_enter` Enter-dispatch branch + `Input::send_queued_row_immediately` (host) in `app/src/terminal/input.rs`
- `QueuedPromptsPanelView::enter_sends_queued_prompt` / `should_show_enter_hint` / `can_send_prompt` in `app/src/terminal/view/queued_prompts_panel.rs`
- `QueuedPromptSentNow { origin, trigger }` telemetry in `app/src/server/telemetry/events.rs`

No application code is changed.

## Linked Issue
QUALITY-887 (labeled `needs-spec`).

## Testing
No code changes; behavior is covered by existing tests referenced in the TECH spec (`input_tests.rs`, `queued_prompts_tests.rs`).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!-- CHANGELOG-NONE -->

_Conversation: https://staging.warp.dev/conversation/c4ce3e22-61c5-4a06-9188-9a2de80fc4c1_
_Run: https://oz.staging.warp.dev/runs/019f005a-ac77-76a7-ac41-26e721e165d9_

_This PR was generated with [Oz](https://warp.dev/oz)._
