### PR TITLE
Extend pane dragging to support tab groups - vertical tabs

### DIFF
--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -55,7 +55,7 @@ use crate::pane_group::pane::view::header::render_pane_header_draggable;
 use crate::pane_group::pane::{view, ActionOrigin, PaneHeaderAction};
 use crate::pane_group::{
     BackingView, CodePane, PaneConfiguration, PaneConfigurationEvent, PaneDragDropLocation,
-    PaneEvent,
+    PaneEvent, TabBarAxis,
 };
 use crate::quit_warning::UnsavedStateSummary;
 use crate::search::files::icon::icon_from_file_path;
@@ -1614,7 +1614,7 @@ impl CodeView {
                         origin: ActionOrigin::EditorTab(index),
                         drag_location: PaneDragDropLocation::TabBar(data.tab_bar_location),
                         drag_position,
-                        precomputed_tab_hover_index: None,
+                        tab_bar_axis: Some(TabBarAxis::Horizontal),
                     },
                 );
             } else {

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -162,6 +162,7 @@ use crate::util::openable_file_type::FileTarget;
 use crate::view_components::ToastFlavor;
 use crate::workflows::workflow::Workflow;
 use crate::workflows::{WorkflowSelectionSource, WorkflowSource, WorkflowType};
+use crate::workspace::tab_group::TabGroupId;
 use crate::workspace::{
     self, CommandSearchOptions, PaneViewLocator, TabBarLocation, WorkspaceAction,
 };
@@ -620,6 +621,9 @@ pub enum Event {
     /// as a header is dragged
     UpdateHoveredTabIndex {
         tab_hover_index: TabBarHoverIndex,
+        /// Drag cursor rect. The workspace uses it to resolve which tab group a
+        /// `BeforeTab` insertion lands.
+        drag_position: RectF,
     },
     /// Clears the hovered tab index so it no longer appears as highlighted drop target
     ClearHoveredTabIndex,
@@ -765,8 +769,24 @@ pub enum Event {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TabBarHoverIndex {
-    BeforeTab(usize),
+    /// Insert the dragged pane as a new tab at `index`. `group` is the tab
+    /// group the insertion lands inside, so the new tab can inherit that
+    /// group's membership. `None` for an ungrouped insertion or a group
+    /// boundary (before/after a group). This is used to differentiate a drop
+    /// right before/after a group from a drop inside the group at its boundaries.
+    BeforeTab {
+        index: usize,
+        group: Option<TabGroupId>,
+    },
     OverTab(usize),
+}
+
+/// Axis of the tab bar a pane is being dragged over. Selects horizontal vs
+/// vertical-axis geometry when resolving the hovered insertion point.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TabBarAxis {
+    Horizontal,
+    Vertical,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1208,13 +1228,14 @@ impl PaneGroup {
                     origin,
                     tab_hover_index,
                     hidden_pane_preview_direction,
+                    drag_position,
                 } => {
                     if matches!(origin, ActionOrigin::Pane) {
                         // Clear hidden closed panes since dragging invalidates undo functionality
                         self.clear_hidden_closed_panes(ctx);
 
                         match tab_hover_index {
-                            TabBarHoverIndex::BeforeTab(_) => {
+                            TabBarHoverIndex::BeforeTab { .. } => {
                                 self.hide_pane_for_move(pane_id, ctx);
                             }
                             TabBarHoverIndex::OverTab(tab_idx) => {
@@ -1230,6 +1251,7 @@ impl PaneGroup {
 
                     ctx.emit(Event::UpdateHoveredTabIndex {
                         tab_hover_index: *tab_hover_index,
+                        drag_position: *drag_position,
                     })
                 }
 

--- a/app/src/pane_group/pane/view/header/mod.rs
+++ b/app/src/pane_group/pane/view/header/mod.rs
@@ -324,78 +324,61 @@ impl<P: BackingView> PaneHeader<P> {
         self.is_visible_in_pane_group
     }
 
-    /// Based on the drag position and tab bar location, returns whether or not the given drag
-    /// is over a tab, or between two tabs. This is done by splitting the tabs into quadrants and seeing
-    /// what quadrant the center of the dragged element lives.
+    /// Based on the drag position and tab bar location, returns whether the drag
+    /// is over a tab or between two tabs, by splitting the hovered tab into
+    /// quarters along the active axis (X for the horizontal bar, Y for the
+    /// vertical panel): the leading quarter inserts before, the middle half
+    /// merges onto the tab, and the trailing quarter inserts after.
     fn calculate_tab_focus_hover_index(
         drag_position: &RectF,
         tab_bar_location: &TabBarLocation,
+        axis: TabBarAxis,
         ctx: &ViewContext<Self>,
     ) -> TabBarHoverIndex {
+        let is_vertical = matches!(axis, TabBarAxis::Vertical);
         match tab_bar_location {
             TabBarLocation::TabIndex(idx) => {
-                if let Some(tab_rect) = ctx.element_position_by_id(tab_position_id(*idx)) {
-                    let tab_center_x = tab_rect.center().x();
-                    let tab_quarter_x = (tab_center_x + tab_rect.lower_left().x()) / 2.;
-                    let tab_three_quarters_x = (tab_center_x + tab_rect.lower_right().x()) / 2.;
-                    if drag_position.center().x() < tab_quarter_x {
+                let Some(tab_rect) = ctx.element_position_by_id(tab_position_id(*idx)) else {
+                    // If for some reason we can't retrieve the tab position, fall
+                    // back to the per-axis default: the vertical panel inserts
+                    // before the tab, the horizontal bar merges onto it.
+                    return if is_vertical {
                         TabBarHoverIndex::BeforeTab {
                             index: *idx,
                             group: None,
                         }
-                    } else if drag_position.center().x() < tab_three_quarters_x {
-                        TabBarHoverIndex::OverTab(*idx)
                     } else {
-                        TabBarHoverIndex::BeforeTab {
-                            index: *idx + 1,
-                            group: None,
-                        }
-                    }
-                } else {
-                    // If for some reason we can't retrieve the tab position, just default to the index
-                    TabBarHoverIndex::OverTab(*idx)
-                }
-            }
-            TabBarLocation::AfterTabIndex(tab_count) => TabBarHoverIndex::BeforeTab {
-                index: *tab_count,
-                group: None,
-            },
-        }
-    }
-
-    /// Vertical-tabs variant of [`Self::calculate_tab_focus_hover_index`]:
-    /// splits the hovered tab row into quarters along the Y axis (top quarter
-    /// inserts before, middle half merges onto the tab, bottom quarter inserts
-    /// after).
-    fn calculate_vertical_tab_focus_hover_index(
-        drag_position: &RectF,
-        tab_bar_location: &TabBarLocation,
-        ctx: &ViewContext<Self>,
-    ) -> TabBarHoverIndex {
-        match tab_bar_location {
-            TabBarLocation::TabIndex(idx) => {
-                if let Some(tab_rect) = ctx.element_position_by_id(tab_position_id(*idx)) {
-                    let tab_center_y = tab_rect.center().y();
-                    let tab_quarter_y = (tab_center_y + tab_rect.min_y()) / 2.;
-                    let tab_three_quarters_y = (tab_center_y + tab_rect.max_y()) / 2.;
-                    let drag_y = drag_position.center().y();
-                    if drag_y < tab_quarter_y {
-                        TabBarHoverIndex::BeforeTab {
-                            index: *idx,
-                            group: None,
-                        }
-                    } else if drag_y < tab_three_quarters_y {
                         TabBarHoverIndex::OverTab(*idx)
-                    } else {
-                        TabBarHoverIndex::BeforeTab {
-                            index: *idx + 1,
-                            group: None,
-                        }
-                    }
+                    };
+                };
+                // Project the tab rect and drag cursor onto the active axis.
+                let (drag, center, near, far) = if is_vertical {
+                    (
+                        drag_position.center().y(),
+                        tab_rect.center().y(),
+                        tab_rect.min_y(),
+                        tab_rect.max_y(),
+                    )
                 } else {
-                    // Default to index if we can not find the tab position.
+                    (
+                        drag_position.center().x(),
+                        tab_rect.center().x(),
+                        tab_rect.min_x(),
+                        tab_rect.max_x(),
+                    )
+                };
+                let tab_quarter = (center + near) / 2.;
+                let tab_three_quarters = (center + far) / 2.;
+                if drag < tab_quarter {
                     TabBarHoverIndex::BeforeTab {
                         index: *idx,
+                        group: None,
+                    }
+                } else if drag < tab_three_quarters {
+                    TabBarHoverIndex::OverTab(*idx)
+                } else {
+                    TabBarHoverIndex::BeforeTab {
+                        index: *idx + 1,
                         group: None,
                     }
                 }
@@ -955,18 +938,12 @@ impl<P: BackingView> TypedActionView for PaneHeader<P> {
                         self.is_visible_in_pane_group = false;
                     }
                     let axis = tab_bar_axis.unwrap_or(TabBarAxis::Horizontal);
-                    let tab_hover_index = match axis {
-                        TabBarAxis::Horizontal => Self::calculate_tab_focus_hover_index(
-                            drag_position,
-                            tab_bar_location,
-                            ctx,
-                        ),
-                        TabBarAxis::Vertical => Self::calculate_vertical_tab_focus_hover_index(
-                            drag_position,
-                            tab_bar_location,
-                            ctx,
-                        ),
-                    };
+                    let tab_hover_index = Self::calculate_tab_focus_hover_index(
+                        drag_position,
+                        tab_bar_location,
+                        axis,
+                        ctx,
+                    );
                     ctx.emit(Event::DraggedOverTabBar {
                         origin: *origin,
                         tab_hover_index,

--- a/app/src/pane_group/pane/view/header/mod.rs
+++ b/app/src/pane_group/pane/view/header/mod.rs
@@ -28,7 +28,9 @@ use crate::pane_group::pane::{
     ActionOrigin, PaneConfiguration, PaneConfigurationEvent, PaneStack, PaneStackEvent,
     ToolbeltButton,
 };
-use crate::pane_group::{BackingView, Direction, PaneDragDropLocation, PaneId, TabBarHoverIndex};
+use crate::pane_group::{
+    BackingView, Direction, PaneDragDropLocation, PaneId, TabBarAxis, TabBarHoverIndex,
+};
 use crate::send_telemetry_from_ctx;
 use crate::server::telemetry::{SharingDialogSource, TelemetryEvent};
 use crate::settings::CodeSettings;
@@ -67,6 +69,9 @@ pub enum Event<A: ActionPayload, B: ActionPayload> {
         origin: ActionOrigin,
         tab_hover_index: TabBarHoverIndex,
         hidden_pane_preview_direction: Direction,
+        /// Drag cursor rect, forwarded to the workspace so it can resolve which
+        /// tab group a `BeforeTab` insertion lands in.
+        drag_position: RectF,
     },
     /// The pane header was dragged over some part of the terminal that is not the pane group
     /// or tab bar
@@ -100,10 +105,10 @@ pub enum PaneHeaderAction<A: ActionPayload, B: ActionPayload> {
         origin: ActionOrigin,
         drag_location: PaneDragDropLocation,
         drag_position: RectF,
-        /// Precomputed by drop targets that already know the exact hover state,
-        /// such as vertical tabs. When absent, the hover index is derived from
-        /// the drag geometry and tab bar location.
-        precomputed_tab_hover_index: Option<TabBarHoverIndex>,
+        /// Axis for a tab-bar drag, so the header derives the hover index from
+        /// cursor geometry along the right axis. `None` for non-tab-bar drag
+        /// locations.
+        tab_bar_axis: Option<TabBarAxis>,
     },
     PaneHeaderDropped {
         origin: ActionOrigin,
@@ -334,18 +339,71 @@ impl<P: BackingView> PaneHeader<P> {
                     let tab_quarter_x = (tab_center_x + tab_rect.lower_left().x()) / 2.;
                     let tab_three_quarters_x = (tab_center_x + tab_rect.lower_right().x()) / 2.;
                     if drag_position.center().x() < tab_quarter_x {
-                        TabBarHoverIndex::BeforeTab(*idx)
+                        TabBarHoverIndex::BeforeTab {
+                            index: *idx,
+                            group: None,
+                        }
                     } else if drag_position.center().x() < tab_three_quarters_x {
                         TabBarHoverIndex::OverTab(*idx)
                     } else {
-                        TabBarHoverIndex::BeforeTab(*idx + 1)
+                        TabBarHoverIndex::BeforeTab {
+                            index: *idx + 1,
+                            group: None,
+                        }
                     }
                 } else {
                     // If for some reason we can't retrieve the tab position, just default to the index
                     TabBarHoverIndex::OverTab(*idx)
                 }
             }
-            TabBarLocation::AfterTabIndex(tab_count) => TabBarHoverIndex::BeforeTab(*tab_count),
+            TabBarLocation::AfterTabIndex(tab_count) => TabBarHoverIndex::BeforeTab {
+                index: *tab_count,
+                group: None,
+            },
+        }
+    }
+
+    /// Vertical-tabs variant of [`Self::calculate_tab_focus_hover_index`]:
+    /// splits the hovered tab row into quarters along the Y axis (top quarter
+    /// inserts before, middle half merges onto the tab, bottom quarter inserts
+    /// after).
+    fn calculate_vertical_tab_focus_hover_index(
+        drag_position: &RectF,
+        tab_bar_location: &TabBarLocation,
+        ctx: &ViewContext<Self>,
+    ) -> TabBarHoverIndex {
+        match tab_bar_location {
+            TabBarLocation::TabIndex(idx) => {
+                if let Some(tab_rect) = ctx.element_position_by_id(tab_position_id(*idx)) {
+                    let tab_center_y = tab_rect.center().y();
+                    let tab_quarter_y = (tab_center_y + tab_rect.min_y()) / 2.;
+                    let tab_three_quarters_y = (tab_center_y + tab_rect.max_y()) / 2.;
+                    let drag_y = drag_position.center().y();
+                    if drag_y < tab_quarter_y {
+                        TabBarHoverIndex::BeforeTab {
+                            index: *idx,
+                            group: None,
+                        }
+                    } else if drag_y < tab_three_quarters_y {
+                        TabBarHoverIndex::OverTab(*idx)
+                    } else {
+                        TabBarHoverIndex::BeforeTab {
+                            index: *idx + 1,
+                            group: None,
+                        }
+                    }
+                } else {
+                    // Default to index if we can not find the tab position.
+                    TabBarHoverIndex::BeforeTab {
+                        index: *idx,
+                        group: None,
+                    }
+                }
+            }
+            TabBarLocation::AfterTabIndex(tab_count) => TabBarHoverIndex::BeforeTab {
+                index: *tab_count,
+                group: None,
+            },
         }
     }
 }
@@ -890,26 +948,33 @@ impl<P: BackingView> TypedActionView for PaneHeader<P> {
                 origin,
                 drag_location,
                 drag_position,
-                precomputed_tab_hover_index,
+                tab_bar_axis,
             } => match drag_location {
                 PaneDragDropLocation::TabBar(tab_bar_location) => {
                     if matches!(origin, ActionOrigin::Pane) {
                         self.is_visible_in_pane_group = false;
                     }
+                    let axis = tab_bar_axis.unwrap_or(TabBarAxis::Horizontal);
+                    let tab_hover_index = match axis {
+                        TabBarAxis::Horizontal => Self::calculate_tab_focus_hover_index(
+                            drag_position,
+                            tab_bar_location,
+                            ctx,
+                        ),
+                        TabBarAxis::Vertical => Self::calculate_vertical_tab_focus_hover_index(
+                            drag_position,
+                            tab_bar_location,
+                            ctx,
+                        ),
+                    };
                     ctx.emit(Event::DraggedOverTabBar {
                         origin: *origin,
-                        tab_hover_index: precomputed_tab_hover_index.unwrap_or_else(|| {
-                            Self::calculate_tab_focus_hover_index(
-                                drag_position,
-                                tab_bar_location,
-                                ctx,
-                            )
-                        }),
-                        hidden_pane_preview_direction: if precomputed_tab_hover_index.is_some() {
-                            Direction::Up
-                        } else {
-                            Direction::Left
+                        tab_hover_index,
+                        hidden_pane_preview_direction: match axis {
+                            TabBarAxis::Vertical => Direction::Up,
+                            TabBarAxis::Horizontal => Direction::Left,
                         },
+                        drag_position: *drag_position,
                     });
                 }
                 PaneDragDropLocation::PaneGroup(target_id) => {
@@ -1036,7 +1101,7 @@ pub fn render_pane_header_draggable<P: BackingView>(
                     origin: ActionOrigin::Pane,
                     drag_location: PaneDragDropLocation::PaneGroup(pane_drop_data.id),
                     drag_position,
-                    precomputed_tab_hover_index: None,
+                    tab_bar_axis: None,
                 });
             } else if let Some(data) =
                 data.and_then(|data| data.as_any().downcast_ref::<TabBarDropTargetData>())
@@ -1048,7 +1113,7 @@ pub fn render_pane_header_draggable<P: BackingView>(
                     origin: ActionOrigin::Pane,
                     drag_location: PaneDragDropLocation::TabBar(data.tab_bar_location),
                     drag_position,
-                    precomputed_tab_hover_index: None,
+                    tab_bar_axis: Some(TabBarAxis::Horizontal),
                 })
             } else if let Some(data) = data.and_then(|data| {
                 data.as_any()
@@ -1061,7 +1126,7 @@ pub fn render_pane_header_draggable<P: BackingView>(
                     origin: ActionOrigin::Pane,
                     drag_location: PaneDragDropLocation::TabBar(data.tab_bar_location),
                     drag_position,
-                    precomputed_tab_hover_index: Some(data.tab_hover_index),
+                    tab_bar_axis: Some(TabBarAxis::Vertical),
                 })
             } else {
                 ctx.dispatch_typed_action(PaneHeaderAction::<
@@ -1071,7 +1136,7 @@ pub fn render_pane_header_draggable<P: BackingView>(
                     origin: ActionOrigin::Pane,
                     drag_location: PaneDragDropLocation::Other,
                     drag_position,
-                    precomputed_tab_hover_index: None,
+                    tab_bar_axis: None,
                 })
             }
         })

--- a/app/src/pane_group/pane/view/mod.rs
+++ b/app/src/pane_group/pane/view/mod.rs
@@ -7,6 +7,7 @@ pub use header::PaneHeaderAction::CustomAction as PaneHeaderCustomAction;
 pub use header_content::{
     HeaderContent, HeaderRenderContext, StandardHeader, StandardHeaderOptions,
 };
+use pathfinder_geometry::rect::RectF;
 use warpui::elements::{
     Border, Container, DropTarget, DropTargetData, Flex, MainAxisSize, ParentElement, SavePosition,
     Shrinkable,
@@ -55,6 +56,7 @@ pub enum PaneViewEvent {
         origin: ActionOrigin,
         tab_hover_index: TabBarHoverIndex,
         hidden_pane_preview_direction: Direction,
+        drag_position: RectF,
     },
     PaneDraggedOutsideTabBarOrPaneGroup,
     PaneDragEnded,
@@ -314,6 +316,7 @@ impl<P: BackingView> PaneView<P> {
                 origin,
                 tab_hover_index,
                 hidden_pane_preview_direction,
+                drag_position,
             } => {
                 // Adds a neutral background to the pane if it's being dragged over the workspace tab group.
                 if matches!(origin, ActionOrigin::Pane) {
@@ -324,6 +327,7 @@ impl<P: BackingView> PaneView<P> {
                     origin: *origin,
                     tab_hover_index: *tab_hover_index,
                     hidden_pane_preview_direction: *hidden_pane_preview_direction,
+                    drag_position: *drag_position,
                 });
                 ctx.notify();
             }

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -48,7 +48,6 @@ use crate::ai::blocklist::NEW_AGENT_PANE_LABEL;
 use crate::channel::{Channel, ChannelState};
 use crate::features::FeatureFlag;
 use crate::palette::PaletteMode;
-use crate::pane_group::TabBarHoverIndex;
 use crate::server::telemetry::{AgentModeEntrypoint, PaletteSource};
 use crate::settings_view::{self, flags, SettingsSection};
 use crate::tab::{uses_vertical_tabs, NewSessionMenuItem};
@@ -1683,7 +1682,6 @@ pub struct TabBarDropTargetData {
 #[derive(PartialEq, Copy, Clone, Debug)]
 pub struct VerticalTabsPaneDropTargetData {
     pub tab_bar_location: TabBarLocation,
-    pub tab_hover_index: TabBarHoverIndex,
 }
 
 #[derive(PartialEq, Copy, Clone, Debug, Serialize, Deserialize)]

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -119,8 +119,8 @@ use warpui::{
 use self::vertical_tabs::telemetry::{VerticalTabsDisplayOption, VerticalTabsTelemetryEvent};
 use self::vertical_tabs::{
     htab_group_position_id, pane_summary_kind, render_detail_sidecar, render_settings_popup,
-    render_summary_pane_kind_icons, vtab_group_position_id, SummaryPaneKind, SummaryPaneKindIcons,
-    VerticalTabsPanelState, VERTICAL_TABS_SETTINGS_BUTTON_POSITION_ID,
+    render_summary_pane_kind_icons, show_before_indicator, vtab_group_position_id, SummaryPaneKind,
+    SummaryPaneKindIcons, VerticalTabsPanelState, VERTICAL_TABS_SETTINGS_BUTTON_POSITION_ID,
 };
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use super::action::AutoCloudHandoffTrigger;
@@ -16347,7 +16347,10 @@ impl Workspace {
             pane_group::Event::DroppedOnTabBar { origin, pane_id } => {
                 if let Some(hovered_tab_index) = self.hovered_tab_index {
                     match hovered_tab_index {
-                        TabBarHoverIndex::BeforeTab(workspace_tab_index) => {
+                        TabBarHoverIndex::BeforeTab {
+                            index: workspace_tab_index,
+                            group,
+                        } => {
                             // If an editor tab is dropped into a new position in the workspace tab group,
                             // create a new pane and insert it into the group.
                             let pane = if let ActionOrigin::EditorTab(editor_tab_index) = origin {
@@ -16366,11 +16369,19 @@ impl Workspace {
                             };
 
                             if let Some(pane) = pane {
-                                // TODO(johnturcoo) inherit the tab group on pane drop.
+                                // `index`/`group` are already resolved by
+                                // `refine_hovered_tab_index` (group inheritance +
+                                // pinned clamping for vertical tabs), so use them
+                                // as-is. Grouping off => never inherit a group.
+                                let inherited_group = if FeatureFlag::GroupedTabs.is_enabled() {
+                                    group
+                                } else {
+                                    None
+                                };
                                 self.add_tab_from_existing_pane(
                                     pane,
                                     workspace_tab_index,
-                                    None,
+                                    inherited_group,
                                     ctx,
                                 );
 
@@ -16579,8 +16590,12 @@ impl Workspace {
                     });
                 }
             }
-            pane_group::Event::UpdateHoveredTabIndex { tab_hover_index } => {
-                self.hovered_tab_index = Some(*tab_hover_index);
+            pane_group::Event::UpdateHoveredTabIndex {
+                tab_hover_index,
+                drag_position,
+            } => {
+                self.hovered_tab_index =
+                    Some(self.refine_hovered_tab_index(*tab_hover_index, *drag_position, ctx));
                 ctx.notify();
             }
             pane_group::Event::ClearHoveredTabIndex => self.hovered_tab_index = None,
@@ -19570,7 +19585,7 @@ impl Workspace {
             .as_ref()
             .is_some_and(|hovered_index| match hovered_index {
                 TabBarHoverIndex::OverTab(idx) => *idx == tab_index,
-                TabBarHoverIndex::BeforeTab(_) => false,
+                TabBarHoverIndex::BeforeTab { .. } => false,
             });
 
         TabComponent::new(
@@ -20702,14 +20717,9 @@ impl Workspace {
                     TabBarSlot::Single { index } => {
                         let i = *index;
                         let is_transferred = transferred_tab_index == Some(i);
-                        if !is_transferred
-                            && self
-                                .hovered_tab_index
-                                .as_ref()
-                                .is_some_and(|hovered_index| match hovered_index {
-                                    TabBarHoverIndex::BeforeTab(idx) => i == *idx,
-                                    TabBarHoverIndex::OverTab(_) => false,
-                                })
+                        // Single tabs are ungrouped, so their before-indicator
+                        // only matches an ungrouped insertion.
+                        if !is_transferred && show_before_indicator(self.hovered_tab_index, i, None)
                         {
                             tab_bar.add_child(self.render_tab_hover_indicator(appearance));
                         }
@@ -20736,14 +20746,7 @@ impl Workspace {
                 .is_some_and(|g| g.insertion_index == self.tabs.len())
             {
                 tab_bar.add_child(self.render_ghost_tab_slot(appearance, ctx));
-            } else if self
-                .hovered_tab_index
-                .as_ref()
-                .is_some_and(|hovered_index| match hovered_index {
-                    TabBarHoverIndex::BeforeTab(idx) => self.tabs.len() == *idx,
-                    TabBarHoverIndex::OverTab(_) => false,
-                })
-            {
+            } else if show_before_indicator(self.hovered_tab_index, self.tabs.len(), None) {
                 tab_bar.add_child(self.render_tab_hover_indicator(appearance));
             }
 
@@ -28334,6 +28337,85 @@ impl Workspace {
         }
 
         current_index
+    }
+
+    /// Resolves the tab group a `BeforeTab` insertion lands in, using the drag
+    /// cursor, for the vertical tabs panel. The header computes the bare
+    /// before/over/after from the hovered row's geometry; this fills in the
+    /// group from the workspace's own tab-group geometry (which the header can't
+    /// see) and clamps ungrouped insertions out of the pinned region. `OverTab`,
+    /// and any drag over the horizontal bar, are returned unchanged.
+    fn refine_hovered_tab_index(
+        &self,
+        hovered: TabBarHoverIndex,
+        drag_position: RectF,
+        ctx: &mut ViewContext<Self>,
+    ) -> TabBarHoverIndex {
+        let TabBarHoverIndex::BeforeTab { index, .. } = hovered else {
+            return hovered;
+        };
+        // Group-aware resolution + pinned clamping are scoped to the vertical
+        // tabs panel; the horizontal bar keeps its existing behavior.
+        if !uses_vertical_tabs(ctx) {
+            return hovered;
+        }
+        let group = if FeatureFlag::GroupedTabs.is_enabled() {
+            self.insertion_group(index, drag_position.center().y(), ctx)
+        } else {
+            None
+        };
+        // An ungrouped insertion can't land in the pinned region, so clamp it to
+        // the first unpinned slot so the indicator stays in sync with where the
+        // pane lands. A drop into a group inherits that group's pinned status.
+        let index = if FeatureFlag::PinnedTabs.is_enabled() && group.is_none() {
+            self.clamp_to_unpinned_region(&self.tabs, index)
+        } else {
+            index
+        };
+        TabBarHoverIndex::BeforeTab { index, group }
+    }
+
+    /// Returns the expanded tab group a `BeforeTab` insertion at `index` should
+    /// join in the vertical tabs panel, based on the drag cursor's Y against the
+    /// group's saved container rect. Collapsed groups are excluded (you can't
+    /// drop into one). "Before the group" is only the leading half of the
+    /// header; the in-group zone runs to the group's trailing edge so the last
+    /// slot is easy to hit.
+    fn insertion_group(
+        &self,
+        index: usize,
+        cursor_y: f32,
+        ctx: &mut ViewContext<Self>,
+    ) -> Option<TabGroupId> {
+        for (group_id, group) in &self.tab_groups {
+            if group.collapsed {
+                continue;
+            }
+            let Some((first, last)) = group_member_index_range(&self.tabs, *group_id) else {
+                continue;
+            };
+            // The insertion index must fall within this group's slots to join.
+            if index < first || index > last + 1 {
+                continue;
+            }
+            let Some(group_rect) = ctx.element_position_by_id(vtab_group_position_id(*group_id))
+            else {
+                continue;
+            };
+            let group_start = group_rect.min_y();
+            let group_end = group_rect.max_y();
+            // "Before the group" is the leading half of the header (before the
+            // first member's top edge); everything past that, to the group's
+            // bottom edge, joins the group.
+            let in_group_start = ctx
+                .element_position_by_id(tab_position_id(first))
+                .map(|first_rect| (group_start + first_rect.min_y()) / 2.)
+                .unwrap_or(group_start);
+            if cursor_y >= in_group_start && cursor_y <= group_end {
+                return Some(*group_id);
+            }
+        }
+        None
     }
 
     /// Returns the group the dragged tab is over along the active axis so it can

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -1327,12 +1327,62 @@ fn render_vertical_tab_hover_indicator(theme: &WarpTheme) -> Box<dyn Element> {
     .finish()
 }
 
-fn render_vertical_tab_insertion_target_content(content: Box<dyn Element>) -> Box<dyn Element> {
+/// Whether the active drag resolves to an insertion at `insert_index` joining
+/// `expected_group`. Each boundary renders its own indicator with the group it
+/// represents, so the before-group (`None`), into-group (`Some`), and
+/// after-group indicators never collide even though several share an index.
+/// Shared by the vertical and horizontal tab bars.
+pub(super) fn show_before_indicator(
+    hovered_tab_index: Option<TabBarHoverIndex>,
+    insert_index: usize,
+    expected_group: Option<TabGroupId>,
+) -> bool {
+    hovered_tab_index
+        == Some(TabBarHoverIndex::BeforeTab {
+            index: insert_index,
+            group: expected_group,
+        })
+}
+
+/// Wraps `element` in a 1px border that is always laid out (reserving the
+/// space) and only changes color: the theme accent when this row is the active
+/// drop target, transparent otherwise. Reserving the space avoids the reflow a
+/// conditionally-added border causes, which flickered at the over/before-tab
+/// boundary.
+fn with_reserved_drag_border(
+    element: Box<dyn Element>,
+    is_drag_target: bool,
+    theme: &WarpTheme,
+) -> Box<dyn Element> {
+    let border_color = if is_drag_target {
+        ThemeFill::Solid(theme.accent().into())
+    } else {
+        ThemeFill::Solid(ColorU::transparent_black())
+    };
+    Container::new(element)
+        .with_border(Border::all(1.).with_border_fill(border_color))
+        .finish()
+}
+
+/// Insertion indicator line shown between rows during a pane drag. `group`
+/// insets it to the group's member indentation so an in-group drop reads
+/// differently from an ungrouped drop between tabs/groups. Indicator only: drop
+/// hit-testing is handled by the per-row, group-header, and panel catch-all
+/// `DropTarget`s, with the insertion point resolved from cursor geometry.
+fn render_vertical_tab_insertion_target(
+    group: Option<TabGroupId>,
+    theme: &WarpTheme,
+) -> Box<dyn Element> {
+    let left_padding = if group.is_some() {
+        GROUP_HORIZONTAL_PADDING + TAB_GROUP_MEMBER_INDENT
+    } else {
+        GROUP_HORIZONTAL_PADDING
+    };
     ConstrainedBox::new(
-        Container::new(content)
+        Container::new(render_vertical_tab_hover_indicator(theme))
             .with_padding(
                 Padding::uniform(0.)
-                    .with_left(GROUP_HORIZONTAL_PADDING)
+                    .with_left(left_padding)
                     .with_right(GROUP_HORIZONTAL_PADDING),
             )
             .finish(),
@@ -1341,39 +1391,15 @@ fn render_vertical_tab_insertion_target_content(content: Box<dyn Element>) -> Bo
     .finish()
 }
 
-fn render_vertical_tab_insertion_target(
-    insert_index: usize,
-    tab_count: usize,
-    is_drag_target: bool,
-    theme: &WarpTheme,
-) -> Box<dyn Element> {
-    let content = if is_drag_target {
-        render_vertical_tab_hover_indicator(theme)
-    } else {
-        Empty::new().finish()
-    };
-
-    DropTarget::new(
-        render_vertical_tab_insertion_target_content(content),
-        VerticalTabsPaneDropTargetData {
-            tab_bar_location: vertical_tabs_tab_bar_location(insert_index, tab_count),
-            tab_hover_index: TabBarHoverIndex::BeforeTab(insert_index),
-        },
-    )
-    .finish()
-}
-
 fn add_vertical_tab_insertion_target_overlay(
     stack: &mut Stack,
-    insert_index: usize,
-    tab_count: usize,
-    is_drag_target: bool,
+    group: Option<TabGroupId>,
     parent_anchor: ParentAnchor,
     child_anchor: ChildAnchor,
     theme: &WarpTheme,
 ) {
     stack.add_positioned_overlay_child(
-        render_vertical_tab_insertion_target(insert_index, tab_count, is_drag_target, theme),
+        render_vertical_tab_insertion_target(group, theme),
         OffsetPositioning::offset_from_parent(
             vec2f(0., 0.),
             ParentOffsetBounds::ParentBySize,
@@ -1680,6 +1706,24 @@ fn render_vertical_tabs_panel(
         .with_child(Shrinkable::new(1., scrollable_groups).finish())
         .finish();
 
+    // Catch-all drop target so a pane dragged into any gap not covered by a
+    // row, group-header, or member target (between groups, below the last tab)
+    // resolves to "after the last tab" instead of no target (which un-hides the
+    // dragged pane and reflows the list). The framework's smallest-area
+    // hit-test keeps the inner row targets winning where they overlap.
+    let panel_content: Box<dyn Element> = if any_workspace_pane_being_dragged(workspace, app) {
+        let tab_count = workspace.tabs.len();
+        DropTarget::new(
+            panel_content,
+            VerticalTabsPaneDropTargetData {
+                tab_bar_location: vertical_tabs_tab_bar_location(tab_count, tab_count),
+            },
+        )
+        .finish()
+    } else {
+        panel_content
+    };
+
     // The settings popup is rendered at the workspace level (with Dismiss for click-outside-
     // to-close). Rendering it here again shares MouseStateHandle instances across two Hoverable
     // trees; click_count.take() is consumed by this copy first, leaving the workspace copy
@@ -1931,7 +1975,10 @@ fn render_groups(
             }
             None => {
                 let insert_before_index = tab_index;
-                let insert_after_index = (i == total_visible - 1).then_some(tab_index + 1);
+                // Gaps between tabs are covered by the next tab's before-indicator,
+                // and the area after the last tab by the trailing indicator below,
+                // so an ungrouped row doesn't render its own "after" indicator.
+                let insert_after_index = None;
                 groups.add_child(render_tab_group(
                     state,
                     workspace,
@@ -1953,6 +2000,14 @@ fn render_groups(
     // Ghost after all tab groups (fencepost).
     if ghost_insertion_index == Some(workspace.tabs.len()) {
         groups.add_child(render_ghost_vertical_tab_slot(workspace, app));
+    }
+
+    // Trailing indicator for an ungrouped insertion after the last tab/group
+    // (the drop itself is resolved by the panel catch-all).
+    if is_any_pane_dragging
+        && show_before_indicator(workspace.hovered_tab_index, workspace.tabs.len(), None)
+    {
+        groups.add_child(render_vertical_tab_insertion_target(None, theme));
     }
 
     // Prune stale badge mouse states for panes that no longer exist.
@@ -2331,18 +2386,14 @@ fn render_tab_group_internal(
                 ThemeFill::Solid(ColorU::transparent_black())
             };
             let mut container = Container::new(group.finish()).with_background(background);
-            if is_drag_target {
-                container = container.with_border(
-                    Border::all(1.).with_border_fill(ThemeFill::Solid(theme.accent().into())),
-                );
-            } else if has_top_border || is_first_tab || is_last_tab {
+            if has_top_border || is_first_tab || is_last_tab {
                 container = container.with_border(
                     Border::new(1.)
                         .with_sides(has_top_border || is_first_tab, false, is_last_tab, false)
                         .with_border_fill(internal_colors::fg_overlay_1(theme)),
                 );
             }
-            container.finish()
+            with_reserved_drag_border(container.finish(), is_drag_target, theme)
         } else {
             // Inside a tab group the surrounding container already paints
             // hover/active state for the whole group, so suppress the
@@ -2370,15 +2421,10 @@ fn render_tab_group_internal(
                 container = container
                     .with_corner_radius(CornerRadius::with_all(Radius::Pixels(ROW_CORNER_RADIUS)));
             }
-            if is_drag_target {
-                container = container.with_border(
-                    Border::all(1.).with_border_fill(ThemeFill::Solid(theme.accent().into())),
-                );
-            }
             if needs_action_button_band {
                 container = container.with_margin_top(action_button_band);
             }
-            container.finish()
+            with_reserved_drag_border(container.finish(), is_drag_target, theme)
         };
 
         // Show the action buttons when the group OR the buttons themselves
@@ -2402,27 +2448,36 @@ fn render_tab_group_internal(
         };
         let mut stack = Stack::new().with_child(group_content);
         if drag_state.is_any_pane_dragging {
-            add_vertical_tab_insertion_target_overlay(
-                &mut stack,
+            // This row only shows indicators for insertions joining its own group
+            // (`tab.group_id`); the before-group indicator (group `None`) is
+            // rendered above the group container instead.
+            if show_before_indicator(
+                workspace.hovered_tab_index,
                 drag_state.insert_before_index,
-                workspace.tabs.len(),
-                workspace.hovered_tab_index
-                    == Some(TabBarHoverIndex::BeforeTab(drag_state.insert_before_index)),
-                ParentAnchor::TopLeft,
-                ChildAnchor::TopLeft,
-                theme,
-            );
-            if let Some(insert_after_index) = drag_state.insert_after_index {
+                tab.group_id,
+            ) {
                 add_vertical_tab_insertion_target_overlay(
                     &mut stack,
-                    insert_after_index,
-                    workspace.tabs.len(),
-                    workspace.hovered_tab_index
-                        == Some(TabBarHoverIndex::BeforeTab(insert_after_index)),
-                    ParentAnchor::BottomLeft,
-                    ChildAnchor::BottomLeft,
+                    tab.group_id,
+                    ParentAnchor::TopLeft,
+                    ChildAnchor::TopLeft,
                     theme,
                 );
+            }
+            if let Some(insert_after_index) = drag_state.insert_after_index {
+                if show_before_indicator(
+                    workspace.hovered_tab_index,
+                    insert_after_index,
+                    tab.group_id,
+                ) {
+                    add_vertical_tab_insertion_target_overlay(
+                        &mut stack,
+                        tab.group_id,
+                        ParentAnchor::BottomLeft,
+                        ChildAnchor::BottomLeft,
+                        theme,
+                    );
+                }
             }
         }
         // Pane view inside a tab group: the group container adds
@@ -2551,7 +2606,6 @@ fn render_tab_group_internal(
             draggable,
             VerticalTabsPaneDropTargetData {
                 tab_bar_location: TabBarLocation::TabIndex(tab_index),
-                tab_hover_index: TabBarHoverIndex::OverTab(tab_index),
             },
         )
         .finish()
@@ -2948,6 +3002,7 @@ fn render_grouped_tab_container(
         .iter()
         .any(|(tab_index, _)| *tab_index == workspace.active_tab_index);
     let is_collapsed = group.collapsed;
+    let first_member_index = members.first().map(|(index, _)| *index).unwrap_or(0);
 
     let resolved_mode = resolve_vertical_tabs_mode(app);
     let needs_outer_horizontal_padding = uses_outer_group_container(match resolved_mode {
@@ -2980,7 +3035,7 @@ fn render_grouped_tab_container(
         // rendered then, so this skips the per-tab pane walk when expanded.
         let collapsed_member_kinds =
             is_collapsed.then(|| workspace.compute_group_member_kinds(group.id, app));
-        content.add_child(render_grouped_tabs_header(
+        let header = render_grouped_tabs_header(
             &group,
             member_count,
             &mouse_states,
@@ -2991,7 +3046,38 @@ fn render_grouped_tab_container(
             rename_editor.as_ref(),
             collapsed_member_kinds.as_deref(),
             app,
-        ));
+        );
+        // While a pane is being dragged, the group header is a drop zone for the
+        // space above the first member. What a drop there does depends on whether
+        // the group is collapsed:
+        //
+        // - Collapsed: the members are hidden, so there's nothing to drop *into*.
+        //   The only sensible result is to land the pane just above the whole
+        //   group, so `AfterTabIndex(first)` always inserts at the group's first
+        //   slot (directly above it), no matter where in the header the cursor is.
+        //   Dropping just below a collapsed group is the next tab/group's job, so
+        //   we don't handle it here.
+        // - Expanded: the first member is visible, so the drop should follow the
+        //   cursor: above the group near the top of the header, or into the group
+        //   as its new first member lower down. `TabIndex(first)` enables that by
+        //   testing the cursor against the first member's row.
+        let header = if is_any_pane_dragging {
+            let header_location = if is_collapsed {
+                TabBarLocation::AfterTabIndex(first_member_index)
+            } else {
+                TabBarLocation::TabIndex(first_member_index)
+            };
+            DropTarget::new(
+                header,
+                VerticalTabsPaneDropTargetData {
+                    tab_bar_location: header_location,
+                },
+            )
+            .finish()
+        } else {
+            header
+        };
+        content.add_child(header);
 
         // Collapsed groups hide member rows in the panel chrome; the members remain in `workspace.tabs`.
         if !is_collapsed {
@@ -3075,7 +3161,26 @@ fn render_grouped_tab_container(
             container = container
                 .with_corner_radius(CornerRadius::with_all(Radius::Pixels(ROW_CORNER_RADIUS)));
         }
-        container.finish()
+        let container = container.finish();
+        // Before-group indicator: above the header when an ungrouped pane is
+        // inserted before this group (between groups / before the first group).
+        // Distinct from the into-group indicator above the first tab in the group,
+        // which carries this group's id instead of `None`.
+        if is_any_pane_dragging
+            && show_before_indicator(workspace.hovered_tab_index, first_member_index, None)
+        {
+            let mut stack = Stack::new().with_child(container);
+            add_vertical_tab_insertion_target_overlay(
+                &mut stack,
+                None,
+                ParentAnchor::TopLeft,
+                ChildAnchor::TopLeft,
+                theme,
+            );
+            stack.finish()
+        } else {
+            container
+        }
     })
     // Right-click on group chrome (not member rows) opens the group menu.
     .on_right_click(move |ctx, _, position| {

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -1344,26 +1344,6 @@ pub(super) fn show_before_indicator(
         })
 }
 
-/// Wraps `element` in a 1px border that is always laid out (reserving the
-/// space) and only changes color: the theme accent when this row is the active
-/// drop target, transparent otherwise. Reserving the space avoids the reflow a
-/// conditionally-added border causes, which flickered at the over/before-tab
-/// boundary.
-fn with_reserved_drag_border(
-    element: Box<dyn Element>,
-    is_drag_target: bool,
-    theme: &WarpTheme,
-) -> Box<dyn Element> {
-    let border_color = if is_drag_target {
-        ThemeFill::Solid(theme.accent().into())
-    } else {
-        ThemeFill::Solid(ColorU::transparent_black())
-    };
-    Container::new(element)
-        .with_border(Border::all(1.).with_border_fill(border_color))
-        .finish()
-}
-
 /// Insertion indicator line shown between rows during a pane drag. `group`
 /// insets it to the group's member indentation so an in-group drop reads
 /// differently from an ungrouped drop between tabs/groups. Indicator only: drop
@@ -2393,7 +2373,12 @@ fn render_tab_group_internal(
                         .with_border_fill(internal_colors::fg_overlay_1(theme)),
                 );
             }
-            with_reserved_drag_border(container.finish(), is_drag_target, theme)
+            if is_drag_target {
+                container = container.with_foreground_border(
+                    Border::all(1.).with_border_fill(ThemeFill::Solid(theme.accent().into())),
+                );
+            }
+            container.finish()
         } else {
             // Inside a tab group the surrounding container already paints
             // hover/active state for the whole group, so suppress the
@@ -2424,7 +2409,12 @@ fn render_tab_group_internal(
             if needs_action_button_band {
                 container = container.with_margin_top(action_button_band);
             }
-            with_reserved_drag_border(container.finish(), is_drag_target, theme)
+            if is_drag_target {
+                container = container.with_foreground_border(
+                    Border::all(1.).with_border_fill(ThemeFill::Solid(theme.accent().into())),
+                );
+            }
+            container.finish()
         };
 
         // Show the action buttons when the group OR the buttons themselves

--- a/crates/warpui_core/src/elements/gui/container.rs
+++ b/crates/warpui_core/src/elements/gui/container.rs
@@ -22,6 +22,7 @@ pub struct Container {
     corner_radius: CornerRadius,
     drop_shadow: Option<DropShadow>,
     foreground_overlay: Option<Fill>,
+    foreground_border: Option<Border>,
     child: Box<dyn Element>,
     size: Option<Vector2F>,
     origin: Option<Point>,
@@ -41,6 +42,7 @@ impl Container {
             border: Border::default(),
             corner_radius: CornerRadius::default(),
             foreground_overlay: None,
+            foreground_border: None,
             drop_shadow: None,
             child,
             size: None,
@@ -60,6 +62,14 @@ impl Container {
         F: Into<Fill>,
     {
         self.foreground_overlay = Some(overlay.into());
+        self
+    }
+
+    /// Draws a border on top of the container without reserving layout space
+    /// (unlike [`Self::with_border`], which insets the child by the border
+    /// width).
+    pub fn with_foreground_border(mut self, border: impl Into<Border>) -> Self {
+        self.foreground_border = Some(border.into());
         self
     }
 
@@ -326,6 +336,22 @@ impl Element for Container {
             ctx.scene
                 .draw_rect_with_hit_recording(RectF::new(origin, size))
                 .with_background(overlay)
+                .with_corner_radius(self.corner_radius);
+            ctx.scene.stop_layer();
+        }
+
+        // Draw a foreground border on top of the container.
+        if let Some(foreground_border) = self.foreground_border {
+            ctx.scene.start_layer(ClipBounds::ActiveLayer);
+            ctx.scene.set_active_layer_click_through();
+
+            #[cfg(debug_assertions)]
+            ctx.scene
+                .set_location_for_panic_logging(self.construction_location);
+
+            ctx.scene
+                .draw_rect_with_hit_recording(RectF::new(origin, size))
+                .with_border(foreground_border)
                 .with_corner_radius(self.corner_radius);
             ctx.scene.stop_layer();
         }


### PR DESCRIPTION
## Description

This PR fixes several bugs associated with pane dragging (shown in demo below) and now handles pane dragging interactions with tab groups + pinned items. 

This PR reworks vertical tab pane dragging to:
- Decide the drop position from the cursor instead of overlapping tab drop targets (mirroring the pattern for pane dragging in htabs)
- Make pane dragging group aware (by using the cursor position to 'hit test' groups, similar to tab dragging patterns)
- Change rendering of tab highlights and add a `catch all` drop target to the whole tab panel to prevent flickering bugs

I suggest watching the demo of bugs for more context, but existing bugs: 
- dragging below all tabs in vtab bar causes flickering 
- dragging on the border of a "Over tab" / "Above tab" boundary causes flickering
- dragging over tab groups cause flickering and it is not possible to drop into groups


NOTE: This has no interaction with cross window dragging, as pane dragging is a completely different system than tab dragging.

## How it works

The main idea is to route the cursor position to the workspace, where the tabs and tab groups live. A pane header and the per-tab drop targets only know their own local geometry, they have no access to where tab groups are laid out. So the header emits the raw drag-cursor rect (`drag_position`) and forwards it to the workspace. The workspace takes that `drag_position` and the hovered tab and, using each group's laid-out rect, resolves a `BeforeTab { index, group }`  which captures both the index the new tab should land at and the group it's a part of (so we can differentiate dropping into a group's first/last slot vs. right before/after the group itself)


Something to understand here is the meaning of the `TabBarDropTargetData` that is on our drop targets: 
- `TabBarLocation::TabIndex(index)` means that the resolver will test the cursor against the tab and tab group geometry to determine where this pane should land
- `TabBarLocation::AfterTabIndex(index)` means that the resolver will place the pane right at tab index without any hit testing (we know this pane can not land in a group)


What is added in this PR and why:
- **Group hit-testing** — `insertion_group()` compares the cursor against each group's saved container rect to tell "inside a group" from "between groups". `refine_hovered_tab_index()` uses this helper function and also clamps past the pinned region.
- **Group-header drop target** — during a drag the group header becomes a drop target so you can drop above a group or into it as the first member. Expanded groups use a splittable target (the cursor position determines if the pane will land in the group). A collapsed group uses a plain target that always resolves to "before the group".
-  **Catch-all drop target** — the whole panel is a fallback target so the gaps between/below groups aren't dead zones. Without it, dragging into empty space hit no target and reflowed the pane in its last dragged-over tab (the end-of-bar flicker).
- **Tab-bar axis** — the drag carries a `TabBarAxis` so the header knows whether we are dealing with vertical or horizontal tabs
- **New indicators for tab groups** — tab groups now render an above indicator, allowing panes to be dropped above collapsed/expanded groups
- **Framework change** — added `Container::with_foreground_border`  this paints a border on top of a container without changing the layout. This prevents the existing flickering bug when dragging over a boundary, since a moving layout can cause mouse position to repeatedly swap between two states. Visually this keeps the same desired border highlight without the flickering bugs.








 

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4724/update-tab-groups-to-support-dragging-a-pane-into-them

## Testing
- [x] I have manually tested my changes locally with `./script/run`
- [x] Verified that pane dragging within a window remains unchanged
- [x] Verified pane dragging into tab groups behaves as expected

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo of bugs](https://www.loom.com/share/6d8fecde93d6469498c7a83157902666)

[Demo of fix](https://www.loom.com/share/ef9be076a6cb4991a220d353079c1d12)