### PR TITLE
Conversation streaming for the TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15842,13 +15842,18 @@ name = "warp_tui"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "command",
+ "log",
  "num-traits",
+ "parking_lot",
+ "pathfinder_geometry",
  "string-offset",
  "vec1",
  "warp",
  "warp_channel_config",
  "warp_core",
  "warp_editor",
+ "warpui",
  "warpui_core",
 ]
 

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -900,17 +900,17 @@ impl AIConversation {
     pub fn update_status(
         &mut self,
         status: ConversationStatus,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<BlocklistAIHistoryModel>,
     ) {
-        self.update_status_with_error_message(status, None, terminal_view_id, ctx);
+        self.update_status_with_error_message(status, None, terminal_surface_id, ctx);
     }
 
     pub fn update_status_with_error_message(
         &mut self,
         status: ConversationStatus,
         error_message: Option<String>,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<BlocklistAIHistoryModel>,
     ) {
         self.status_error_message = if matches!(
@@ -926,7 +926,7 @@ impl AIConversation {
         self.status = status;
         ctx.emit(BlocklistAIHistoryEvent::UpdatedConversationStatus {
             conversation_id: self.id,
-            terminal_view_id,
+            terminal_surface_id,
             update: ConversationStatusUpdate::Changed { prev_status },
             new_status,
         });
@@ -1380,7 +1380,7 @@ impl AIConversation {
         &mut self,
         exchange_id: AIAgentExchangeId,
         is_hidden: bool,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<BlocklistAIHistoryModel>,
     ) {
         // If the status is not being modified, return.
@@ -1395,11 +1395,11 @@ impl AIConversation {
         }
 
         // If the status is being toggled, set the persisted exchange hidden status.
-        // Find the exchange and the terminal view ID for the exchange and emit an event to update
+        // Find the exchange and its terminal surface ID, then emit an event to update
         // the exchange hidden state.
         ctx.emit(BlocklistAIHistoryEvent::UpdatedStreamingExchange {
             exchange_id,
-            terminal_view_id,
+            terminal_surface_id,
             conversation_id: self.id,
             is_hidden,
         });
@@ -1547,13 +1547,13 @@ impl AIConversation {
     pub fn add_artifact(
         &mut self,
         artifact: Artifact,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<BlocklistAIHistoryModel>,
     ) {
         self.artifacts.push(artifact.clone());
         self.write_updated_conversation_state(ctx);
         ctx.emit(BlocklistAIHistoryEvent::UpdatedConversationArtifacts {
-            terminal_view_id,
+            terminal_surface_id,
             conversation_id: self.id,
             artifact,
         });
@@ -1564,7 +1564,7 @@ impl AIConversation {
         &mut self,
         document_uid: AIDocumentId,
         notebook_uid: NotebookId,
-        terminal_view_id: Option<EntityId>,
+        terminal_surface_id: Option<EntityId>,
         ctx: &mut ModelContext<BlocklistAIHistoryModel>,
     ) {
         let document_uid = document_uid.to_string();
@@ -1579,9 +1579,9 @@ impl AIConversation {
                     *nb_uid = Some(notebook_uid);
                     let updated_artifact = artifact.clone();
                     self.write_updated_conversation_state(ctx);
-                    if let Some(terminal_view_id) = terminal_view_id {
+                    if let Some(terminal_surface_id) = terminal_surface_id {
                         ctx.emit(BlocklistAIHistoryEvent::UpdatedConversationArtifacts {
-                            terminal_view_id,
+                            terminal_surface_id,
                             conversation_id: self.id,
                             artifact: updated_artifact,
                         });
@@ -1704,7 +1704,7 @@ impl AIConversation {
         &mut self,
         request_input: RequestInput,
         stream_id: ResponseStreamId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<BlocklistAIHistoryModel>,
     ) -> Result<(), UpdateConversationError> {
         if let Some(request_info) = self.added_exchanges_by_response.remove(&stream_id) {
@@ -1767,7 +1767,7 @@ impl AIConversation {
             ctx.emit(BlocklistAIHistoryEvent::AppendedExchange {
                 exchange_id: new_exchange_id,
                 task_id,
-                terminal_view_id,
+                terminal_surface_id,
                 conversation_id: self.id,
                 is_hidden: should_hide,
                 response_stream_id: Some(stream_id.clone()),
@@ -1780,7 +1780,7 @@ impl AIConversation {
         &mut self,
         response_stream_id: &ResponseStreamId,
         exchange: AIAgentExchange,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<BlocklistAIHistoryModel>,
     ) -> Result<(), UpdateConversationError> {
         let root_task_id = self.task_store.root_task_id().clone();
@@ -1808,7 +1808,7 @@ impl AIConversation {
 
         ctx.emit(BlocklistAIHistoryEvent::ReassignedExchange {
             exchange_id,
-            terminal_view_id,
+            terminal_surface_id,
             new_task_id: root_task_id,
             new_conversation_id: self.id,
         });
@@ -1885,7 +1885,7 @@ impl AIConversation {
         &mut self,
         stream_id: &ResponseStreamId,
         init_event: warp_multi_agent_api::response_event::StreamInit,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<BlocklistAIHistoryModel>,
     ) -> Result<(), UpdateConversationError> {
         let Some(new_exchanges) = self.added_exchanges_by_response.get(stream_id).cloned() else {
@@ -1898,7 +1898,7 @@ impl AIConversation {
                 .init_output(ServerOutputId::new(request_id.clone()))?;
             ctx.emit(BlocklistAIHistoryEvent::UpdatedStreamingExchange {
                 exchange_id: new_exchange_info.exchange_id,
-                terminal_view_id,
+                terminal_surface_id,
                 conversation_id: self.id,
                 is_hidden: self
                     .hidden_exchanges
@@ -1992,7 +1992,7 @@ impl AIConversation {
     pub fn mark_request_completed(
         &mut self,
         stream_id: &ResponseStreamId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<BlocklistAIHistoryModel>,
     ) -> Result<(), UpdateConversationError> {
         let Some(new_exchanges) = self.added_exchanges_by_response.get(stream_id).cloned() else {
@@ -2029,7 +2029,7 @@ impl AIConversation {
 
             ctx.emit(BlocklistAIHistoryEvent::UpdatedStreamingExchange {
                 exchange_id,
-                terminal_view_id,
+                terminal_surface_id,
                 conversation_id: self.id,
                 is_hidden: self.is_exchange_hidden(exchange_id),
             });
@@ -2038,7 +2038,7 @@ impl AIConversation {
 
         if !has_new_actions {
             // Update conversation-level status to success if the output has no actions.
-            self.update_status(ConversationStatus::Success, terminal_view_id, ctx);
+            self.update_status(ConversationStatus::Success, terminal_surface_id, ctx);
         }
 
         Ok(())
@@ -2047,7 +2047,7 @@ impl AIConversation {
     pub fn mark_completed_after_successful_split(
         &mut self,
         stream_id: &ResponseStreamId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<BlocklistAIHistoryModel>,
     ) -> Result<(), UpdateConversationError> {
         // Remove the mapping between the response stream and this conversation, as the response stream is
@@ -2080,7 +2080,7 @@ impl AIConversation {
 
                 ctx.emit(BlocklistAIHistoryEvent::UpdatedStreamingExchange {
                     exchange_id,
-                    terminal_view_id,
+                    terminal_surface_id,
                     conversation_id: self.id,
                     is_hidden: self.is_exchange_hidden(exchange_id),
                 });
@@ -2089,14 +2089,14 @@ impl AIConversation {
         self.write_updated_conversation_state(ctx);
 
         // Update conversation-level status to success if the output has no actions.
-        self.update_status(ConversationStatus::Success, terminal_view_id, ctx);
+        self.update_status(ConversationStatus::Success, terminal_surface_id, ctx);
         Ok(())
     }
 
     pub fn mark_request_cancelled(
         &mut self,
         stream_id: &ResponseStreamId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         reason: CancellationReason,
         ctx: &mut ModelContext<BlocklistAIHistoryModel>,
     ) -> Result<(), UpdateConversationError> {
@@ -2156,7 +2156,7 @@ impl AIConversation {
             let is_hidden = self.is_exchange_hidden(exchange_id);
             ctx.emit(BlocklistAIHistoryEvent::UpdatedStreamingExchange {
                 exchange_id,
-                terminal_view_id,
+                terminal_surface_id,
                 conversation_id: self.id,
                 is_hidden,
             });
@@ -2169,20 +2169,20 @@ impl AIConversation {
         // user manually took over the long-running command (the conversation remains in progress
         // and will resume once the command finishes or control is handed back).
         if !reason.should_preserve_in_progress_status() {
-            self.update_status(ConversationStatus::Cancelled, terminal_view_id, ctx);
+            self.update_status(ConversationStatus::Cancelled, terminal_surface_id, ctx);
         }
         Ok(())
     }
 
     pub fn mark_request_cancelled_due_to_revert(
         &mut self,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<BlocklistAIHistoryModel>,
     ) -> Result<(), UpdateConversationError> {
         if self.transaction.is_some() {
             self.commit_transaction();
         }
-        self.update_status(ConversationStatus::Success, terminal_view_id, ctx);
+        self.update_status(ConversationStatus::Success, terminal_surface_id, ctx);
         Ok(())
     }
 
@@ -2196,7 +2196,7 @@ impl AIConversation {
         stream_id: &ResponseStreamId,
         error: RenderableAIError,
         recovery_pending: bool,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<BlocklistAIHistoryModel>,
     ) -> Result<(), UpdateConversationError> {
         let Some(added_exchanges) = self.added_exchanges_by_response.get(stream_id).cloned() else {
@@ -2275,7 +2275,7 @@ impl AIConversation {
             let is_hidden = self.is_exchange_hidden(exchange_id);
             ctx.emit(BlocklistAIHistoryEvent::UpdatedStreamingExchange {
                 exchange_id,
-                terminal_view_id,
+                terminal_surface_id,
                 conversation_id: self.id,
                 is_hidden,
             });
@@ -2290,7 +2290,7 @@ impl AIConversation {
         self.update_status_with_error_message(
             status,
             Some(error.to_string()),
-            terminal_view_id,
+            terminal_surface_id,
             ctx,
         );
         Ok(())
@@ -2380,7 +2380,7 @@ impl AIConversation {
     pub fn apply_client_action(
         &mut self,
         response_stream_id: &ResponseStreamId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         action: warp_multi_agent_api::client_action::Action,
         skill_path_origin: &SkillPathOrigin,
         ctx: &mut ModelContext<BlocklistAIHistoryModel>,
@@ -2436,7 +2436,7 @@ impl AIConversation {
                         ctx.emit(BlocklistAIHistoryEvent::UpgradedTask {
                             optimistic_id: optimistic_id.clone(),
                             server_id: server_subtask.id().clone(),
-                            terminal_view_id,
+                            terminal_surface_id,
                         });
 
                         for new_exchange in self
@@ -2531,7 +2531,7 @@ impl AIConversation {
                         self.task_store.insert(subtask);
                         ctx.emit(BlocklistAIHistoryEvent::CreatedSubtask {
                             conversation_id: self.id,
-                            terminal_view_id,
+                            terminal_surface_id,
                             task_id: task_id.clone(),
                         });
 
@@ -2540,7 +2540,7 @@ impl AIConversation {
                             ctx.emit(BlocklistAIHistoryEvent::AppendedExchange {
                                 exchange_id,
                                 task_id: task_id.clone(),
-                                terminal_view_id,
+                                terminal_surface_id,
                                 conversation_id: self.id,
                                 is_hidden,
                                 response_stream_id: Some(response_stream_id.clone()),
@@ -2561,7 +2561,7 @@ impl AIConversation {
                         ctx.emit(BlocklistAIHistoryEvent::UpgradedTask {
                             optimistic_id: old_id,
                             server_id: root_task.id().clone(),
-                            terminal_view_id,
+                            terminal_surface_id,
                         });
 
                         for AddedExchange {
@@ -2600,7 +2600,7 @@ impl AIConversation {
                                     todos_op.clone(),
                                 );
                                 ctx.emit(BlocklistAIHistoryEvent::UpdatedTodoList {
-                                    terminal_view_id,
+                                    terminal_surface_id,
                                 });
                             }
                         }
@@ -2637,7 +2637,7 @@ impl AIConversation {
                                         ) => {
                                             self.add_artifact(
                                                 Artifact::from(pr.clone()),
-                                                terminal_view_id,
+                                                terminal_surface_id,
                                                 ctx,
                                             );
                                         }
@@ -2646,7 +2646,7 @@ impl AIConversation {
                                         ) => {
                                             self.add_artifact(
                                                 Artifact::from(screenshot.clone()),
-                                                terminal_view_id,
+                                                terminal_surface_id,
                                                 ctx,
                                             );
                                         }
@@ -2655,7 +2655,7 @@ impl AIConversation {
                                         ) => {
                                             self.add_artifact(
                                                 Artifact::from(file.clone()),
-                                                terminal_view_id,
+                                                terminal_surface_id,
                                                 ctx,
                                             );
                                         }
@@ -2671,7 +2671,7 @@ impl AIConversation {
                                         else {
                                             continue;
                                         };
-                                        self.add_artifact(artifact, terminal_view_id, ctx);
+                                        self.add_artifact(artifact, terminal_surface_id, ctx);
                                     }
                                 }
                                 None => {}
@@ -2819,14 +2819,14 @@ impl AIConversation {
                         response_stream_id: Some(response_stream_id.clone()),
                         exchange_id,
                         task_id: task_id.clone(),
-                        terminal_view_id,
+                        terminal_surface_id,
                         conversation_id: self.id,
                         is_hidden,
                     });
                 }
                 ctx.emit(BlocklistAIHistoryEvent::UpdatedStreamingExchange {
                     exchange_id,
-                    terminal_view_id,
+                    terminal_surface_id,
                     conversation_id: self.id,
                     is_hidden: self.is_exchange_hidden(exchange_id),
                 });
@@ -2912,11 +2912,13 @@ impl AIConversation {
                 // Update todo list if needed
                 if let Some(todos_op) = todos_op {
                     update_todo_list_from_todo_op(&mut self.todo_lists, todos_op);
-                    ctx.emit(BlocklistAIHistoryEvent::UpdatedTodoList { terminal_view_id });
+                    ctx.emit(BlocklistAIHistoryEvent::UpdatedTodoList {
+                        terminal_surface_id,
+                    });
                 }
                 ctx.emit(BlocklistAIHistoryEvent::UpdatedStreamingExchange {
                     exchange_id,
-                    terminal_view_id,
+                    terminal_surface_id,
                     conversation_id: self.id,
                     is_hidden: self.is_exchange_hidden(exchange_id),
                 });
@@ -2959,11 +2961,13 @@ impl AIConversation {
                 // Update todo list if needed
                 if let Some(todos_op) = todos_op {
                     update_todo_list_from_todo_op(&mut self.todo_lists, todos_op);
-                    ctx.emit(BlocklistAIHistoryEvent::UpdatedTodoList { terminal_view_id });
+                    ctx.emit(BlocklistAIHistoryEvent::UpdatedTodoList {
+                        terminal_surface_id,
+                    });
                 }
                 ctx.emit(BlocklistAIHistoryEvent::UpdatedStreamingExchange {
                     exchange_id,
-                    terminal_view_id,
+                    terminal_surface_id,
                     conversation_id: self.id,
                     is_hidden: self.is_exchange_hidden(exchange_id),
                 });
@@ -2979,7 +2983,7 @@ impl AIConversation {
                 exchange_to_update.update_suggestions(suggestions);
                 ctx.emit(BlocklistAIHistoryEvent::UpdatedStreamingExchange {
                     exchange_id,
-                    terminal_view_id,
+                    terminal_surface_id,
                     conversation_id: self.id,
                     is_hidden: self.is_exchange_hidden(exchange_id),
                 });
@@ -3082,7 +3086,7 @@ impl AIConversation {
     pub fn create_optimistic_cli_subagent_task(
         &mut self,
         block_id: &BlockId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<BlocklistAIHistoryModel>,
     ) -> TaskId {
         if self.optimistic_cli_subagent_subtask_id.take().is_some() {
@@ -3097,7 +3101,7 @@ impl AIConversation {
         self.task_store.insert(new_task);
         ctx.emit(BlocklistAIHistoryEvent::CreatedSubtask {
             conversation_id: self.id,
-            terminal_view_id,
+            terminal_surface_id,
             task_id: new_task_id.clone(),
         });
         new_task_id

--- a/app/src/ai/agent/todos/popup.rs
+++ b/app/src/ai/agent/todos/popup.rs
@@ -83,8 +83,11 @@ impl AgentTodosPopupView {
         event: &BlocklistAIHistoryEvent,
         ctx: &mut ViewContext<Self>,
     ) {
-        if let BlocklistAIHistoryEvent::UpdatedTodoList { terminal_view_id } = event {
-            if *terminal_view_id == self.terminal_view_id {
+        if let BlocklistAIHistoryEvent::UpdatedTodoList {
+            terminal_surface_id,
+        } = event
+        {
+            if *terminal_surface_id == self.terminal_view_id {
                 ctx.notify();
             }
         }

--- a/app/src/ai/agent_conversations_model.rs
+++ b/app/src/ai/agent_conversations_model.rs
@@ -1499,8 +1499,9 @@ impl AgentConversationsModel {
             | BlocklistAIHistoryEvent::RestoredConversations { .. }
             | BlocklistAIHistoryEvent::RemoveConversation { .. }
             | BlocklistAIHistoryEvent::DeletedConversation { .. }
-            | BlocklistAIHistoryEvent::ClearedConversationsInTerminalView { .. }
-            | BlocklistAIHistoryEvent::ClearedActiveConversation { .. } => {
+            | BlocklistAIHistoryEvent::ClearedConversationsForTerminalSurface { .. }
+            | BlocklistAIHistoryEvent::ClearedActiveConversation { .. }
+            => {
                 self.sync_conversations(ctx);
             }
 
@@ -1577,7 +1578,7 @@ impl AgentConversationsModel {
             // doesn't change any ConversationNavigationData fields (title comes from
             // UpdateTaskDescription, last_updated uses exchange.start_time which is set at append time).
             | BlocklistAIHistoryEvent::UpdatedStreamingExchange { .. }
-            | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. }
+            | BlocklistAIHistoryEvent::ConversationTransferredBetweenTerminalSurfaces { .. }
             | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. }
             | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. }
             | BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. }

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -122,7 +122,7 @@ fn test_restored_conversation_emits_restored_kind() {
             model.handle_history_event(
                 &BlocklistAIHistoryEvent::UpdatedConversationStatus {
                     conversation_id: AIConversationId::new(),
-                    terminal_view_id: EntityId::new(),
+                    terminal_surface_id: EntityId::new(),
                     update: ConversationStatusUpdate::Restored,
                     new_status: ConversationStatus::Success,
                 },
@@ -147,7 +147,7 @@ fn test_status_transition_emits_status_set_with_filter_buckets() {
             model.handle_history_event(
                 &BlocklistAIHistoryEvent::UpdatedConversationStatus {
                     conversation_id: AIConversationId::new(),
-                    terminal_view_id: EntityId::new(),
+                    terminal_surface_id: EntityId::new(),
                     update: ConversationStatusUpdate::Changed {
                         prev_status: ConversationStatus::InProgress,
                     },
@@ -180,7 +180,7 @@ fn test_same_bucket_re_emission_emits_status_set_with_equal_filters() {
             model.handle_history_event(
                 &BlocklistAIHistoryEvent::UpdatedConversationStatus {
                     conversation_id: AIConversationId::new(),
-                    terminal_view_id: EntityId::new(),
+                    terminal_surface_id: EntityId::new(),
                     update: ConversationStatusUpdate::Changed {
                         prev_status: ConversationStatus::InProgress,
                     },
@@ -259,7 +259,7 @@ fn test_title_update_refreshes_shadowing_task_title() {
         agent_model.update(&mut app, |model, ctx| {
             model.handle_history_event(
                 &BlocklistAIHistoryEvent::UpdatedConversationTitle {
-                    terminal_view_id: Some(terminal_view_id),
+                    terminal_surface_id: Some(terminal_view_id),
                     conversation_id,
                     title: "Renamed conversation".to_string(),
                 },
@@ -1522,7 +1522,7 @@ fn test_server_token_assignment_updates_copy_link_resolution() {
             model.handle_history_event(
                 &BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
                     conversation_id,
-                    terminal_view_id,
+                    terminal_surface_id: terminal_view_id,
                 },
                 ctx,
             );

--- a/app/src/ai/agent_management/agent_management_model.rs
+++ b/app/src/ai/agent_management/agent_management_model.rs
@@ -246,7 +246,7 @@ impl AgentNotificationsModel {
         }
 
         let BlocklistAIHistoryEvent::UpdatedConversationStatus {
-            terminal_view_id,
+            terminal_surface_id,
             conversation_id,
             // We shouldn't trigger toasts when restoring conversations on startup.
             update: ConversationStatusUpdate::Changed { .. },
@@ -272,7 +272,7 @@ impl AgentNotificationsModel {
                 &status,
                 *conversation_id,
                 latest_query,
-                *terminal_view_id,
+                *terminal_surface_id,
                 ctx,
             );
             // The new mailbox path handled the event — skip the legacy toast path below.
@@ -283,7 +283,7 @@ impl AgentNotificationsModel {
             return;
         }
 
-        if is_terminal_view_visible(*terminal_view_id, ctx) {
+        if is_terminal_view_visible(*terminal_surface_id, ctx) {
             return;
         }
 
@@ -296,7 +296,7 @@ impl AgentNotificationsModel {
         ctx.emit(AgentManagementEvent::ConversationNeedsAttention {
             window_id,
             tab_index,
-            terminal_view_id: *terminal_view_id,
+            terminal_view_id: *terminal_surface_id,
             conversation_id: *conversation_id,
         });
     }

--- a/app/src/ai/agent_management/agent_management_model_tests.rs
+++ b/app/src/ai/agent_management/agent_management_model_tests.rs
@@ -60,7 +60,7 @@ fn artifact_event_accumulates_into_pending() {
 
         history.update(&mut app, |_: &mut BlocklistAIHistoryModel, ctx| {
             ctx.emit(BlocklistAIHistoryEvent::UpdatedConversationArtifacts {
-                terminal_view_id,
+                terminal_surface_id: terminal_view_id,
                 conversation_id,
                 artifact: make_pr_artifact("https://github.com/org/repo/pull/42", "feature-branch"),
             });
@@ -85,14 +85,14 @@ fn multiple_artifacts_accumulated_across_turns() {
 
         history.update(&mut app, |_: &mut BlocklistAIHistoryModel, ctx| {
             ctx.emit(BlocklistAIHistoryEvent::UpdatedConversationArtifacts {
-                terminal_view_id,
+                terminal_surface_id: terminal_view_id,
                 conversation_id,
                 artifact: make_plan_artifact("doc-1", "My Plan"),
             });
         });
         history.update(&mut app, |_: &mut BlocklistAIHistoryModel, ctx| {
             ctx.emit(BlocklistAIHistoryEvent::UpdatedConversationArtifacts {
-                terminal_view_id,
+                terminal_surface_id: terminal_view_id,
                 conversation_id,
                 artifact: make_pr_artifact("https://github.com/org/repo/pull/1", "main"),
             });
@@ -158,7 +158,7 @@ fn flush_drains_pending_artifacts() {
 
         history.update(&mut app, |_: &mut BlocklistAIHistoryModel, ctx| {
             ctx.emit(BlocklistAIHistoryEvent::UpdatedConversationArtifacts {
-                terminal_view_id,
+                terminal_surface_id: terminal_view_id,
                 conversation_id,
                 artifact: make_pr_artifact("https://github.com/org/repo/pull/1", "branch-1"),
             });
@@ -202,7 +202,7 @@ fn deletion_cleans_up_pending_artifacts() {
 
         history.update(&mut app, |_: &mut BlocklistAIHistoryModel, ctx| {
             ctx.emit(BlocklistAIHistoryEvent::UpdatedConversationArtifacts {
-                terminal_view_id,
+                terminal_surface_id: terminal_view_id,
                 conversation_id,
                 artifact: make_pr_artifact("https://github.com/org/repo/pull/1", "branch-1"),
             });
@@ -210,7 +210,7 @@ fn deletion_cleans_up_pending_artifacts() {
 
         history.update(&mut app, |_: &mut BlocklistAIHistoryModel, ctx| {
             ctx.emit(BlocklistAIHistoryEvent::DeletedConversation {
-                terminal_view_id,
+                terminal_surface_id: terminal_view_id,
                 conversation_id,
                 conversation_title: None,
                 run_id: None,
@@ -235,14 +235,14 @@ fn separate_conversations_have_independent_pending_artifacts() {
 
         history.update(&mut app, |_: &mut BlocklistAIHistoryModel, ctx| {
             ctx.emit(BlocklistAIHistoryEvent::UpdatedConversationArtifacts {
-                terminal_view_id,
+                terminal_surface_id: terminal_view_id,
                 conversation_id: conv_a,
                 artifact: make_pr_artifact("https://github.com/org/repo/pull/1", "branch-a"),
             });
         });
         history.update(&mut app, |_: &mut BlocklistAIHistoryModel, ctx| {
             ctx.emit(BlocklistAIHistoryEvent::UpdatedConversationArtifacts {
-                terminal_view_id,
+                terminal_surface_id: terminal_view_id,
                 conversation_id: conv_b,
                 artifact: make_plan_artifact("doc-b", "Plan B"),
             });

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -2980,7 +2980,7 @@ impl AgentDriver {
         let mut written_conversation_id = false;
 
         ctx.subscribe_to_model(&history_model_handle, move |me, _, event, ctx| {
-            if event.terminal_view_id().is_some_and(|id| id != terminal_id) {
+            if event.terminal_surface_id().is_some_and(|id| id != terminal_id) {
                 return;
             }
 
@@ -3091,7 +3091,7 @@ impl AgentDriver {
 
                 }
 
-                BlocklistAIHistoryEvent::UpdatedConversationStatus { terminal_view_id: conversation_terminal_id, conversation_id, .. } => {
+                BlocklistAIHistoryEvent::UpdatedConversationStatus { terminal_surface_id: conversation_terminal_id, conversation_id, .. } => {
                     if *conversation_terminal_id != terminal_id {
                         return;
                     }
@@ -3210,7 +3210,7 @@ impl AgentDriver {
                 }
                 BlocklistAIHistoryEvent::StartedNewConversation { .. }
                 | BlocklistAIHistoryEvent::ReassignedExchange { .. }
-                | BlocklistAIHistoryEvent::ClearedConversationsInTerminalView { .. }
+                | BlocklistAIHistoryEvent::ClearedConversationsForTerminalSurface { .. }
                 | BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. }
                 | BlocklistAIHistoryEvent::SplitConversation { .. }
                 | BlocklistAIHistoryEvent::RemoveConversation { .. }
@@ -3223,7 +3223,7 @@ impl AgentDriver {
                 | BlocklistAIHistoryEvent::ClearedActiveConversation { .. }
                 | BlocklistAIHistoryEvent::UpdatedConversationArtifacts { .. }
                 | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. }
-                | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. }
+                | BlocklistAIHistoryEvent::ConversationTransferredBetweenTerminalSurfaces { .. }
                 | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. }
                 | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. }
                 | BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. }

--- a/app/src/ai/ai_document_view.rs
+++ b/app/src/ai/ai_document_view.rs
@@ -262,21 +262,26 @@ impl AIDocumentView {
                 use crate::ai::blocklist::BlocklistAIHistoryEvent;
                 match event {
                     BlocklistAIHistoryEvent::UpdatedConversationStatus {
-                        terminal_view_id, ..
+                        terminal_surface_id,
+                        ..
                     } => {
                         // Check if this is our terminal view
                         if let Some(tv) = &me.original_terminal_view {
-                            if tv.id() == *terminal_view_id {
+                            if tv.id() == *terminal_surface_id {
                                 me.update_header_buttons(ctx);
                             }
                         }
                     }
                     BlocklistAIHistoryEvent::RestoredConversations {
-                        terminal_view_id,
+                        terminal_surface_id,
                         conversation_ids,
                     } => {
                         // Try to populate terminal view if conversations were restored
-                        me.maybe_populate_terminal_view(*terminal_view_id, conversation_ids, ctx);
+                        me.maybe_populate_terminal_view(
+                            *terminal_surface_id,
+                            conversation_ids,
+                            ctx,
+                        );
                     }
                     BlocklistAIHistoryEvent::OrchestrationConfigUpdated {
                         conversation_id: cid,

--- a/app/src/ai/blocklist/action_model/execute/start_agent.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_agent.rs
@@ -290,7 +290,7 @@ impl StartAgentExecutor {
             | BlocklistAIHistoryEvent::UpdatedStreamingExchange { .. }
             | BlocklistAIHistoryEvent::SetActiveConversation { .. }
             | BlocklistAIHistoryEvent::ClearedActiveConversation { .. }
-            | BlocklistAIHistoryEvent::ClearedConversationsInTerminalView { .. }
+            | BlocklistAIHistoryEvent::ClearedConversationsForTerminalSurface { .. }
             | BlocklistAIHistoryEvent::UpdatedTodoList { .. }
             | BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. }
             | BlocklistAIHistoryEvent::SplitConversation { .. }
@@ -300,7 +300,7 @@ impl StartAgentExecutor {
             | BlocklistAIHistoryEvent::UpdatedConversationTitle { .. }
             | BlocklistAIHistoryEvent::UpdatedConversationMetadata { .. }
             | BlocklistAIHistoryEvent::UpdatedConversationArtifacts { .. }
-            | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. } => {}
+            | BlocklistAIHistoryEvent::ConversationTransferredBetweenTerminalSurfaces { .. } => {}
             BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. }
             | BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. }
             | BlocklistAIHistoryEvent::LocalSharedSessionEstablished { .. } => {}

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -769,7 +769,7 @@ impl AgentInputFooter {
             &BlocklistAIHistoryModel::handle(ctx),
             |me, _, event, ctx| {
                 if event
-                    .terminal_view_id()
+                    .terminal_surface_id()
                     .is_some_and(|id| id != me.terminal_view_id)
                 {
                     return;
@@ -779,7 +779,7 @@ impl AgentInputFooter {
                     BlocklistAIHistoryEvent::StartedNewConversation { .. }
                     | BlocklistAIHistoryEvent::SetActiveConversation { .. }
                     | BlocklistAIHistoryEvent::ClearedActiveConversation { .. }
-                    | BlocklistAIHistoryEvent::ClearedConversationsInTerminalView { .. }
+                    | BlocklistAIHistoryEvent::ClearedConversationsForTerminalSurface { .. }
                     | BlocklistAIHistoryEvent::RemoveConversation { .. }
                     | BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. } => {
                         me.sync_fast_forward_button(ctx);

--- a/app/src/ai/blocklist/agent_view/conversation_selection.rs
+++ b/app/src/ai/blocklist/agent_view/conversation_selection.rs
@@ -1,0 +1,176 @@
+use warpui::{AppContext, EntityId, ModelContext, ModelHandle, SingletonEntity};
+
+use super::{
+    AgentViewController, AgentViewControllerEvent, AgentViewEntryOrigin, EnterAgentViewError,
+};
+use crate::ai::agent::conversation::{AIConversationAutoexecuteMode, AIConversationId};
+use crate::ai::blocklist::conversation_selection::{
+    ConversationSelection, ConversationSelectionEvent,
+};
+use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
+
+/// GUI conversation selection backed unconditionally by Agent View.
+pub(crate) struct AgentViewConversationSelection {
+    terminal_surface_id: EntityId,
+    agent_view_controller: ModelHandle<AgentViewController>,
+}
+
+impl AgentViewConversationSelection {
+    /// Creates GUI conversation selection for a terminal view.
+    pub(crate) fn new(
+        terminal_surface_id: warpui::EntityId,
+        agent_view_controller: ModelHandle<AgentViewController>,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    ) -> Self {
+        ctx.subscribe_to_model(&agent_view_controller, |_, _, event, ctx| match event {
+            AgentViewControllerEvent::EnteredAgentView {
+                display_mode,
+                origin,
+                ..
+            } => {
+                ctx.emit(ConversationSelectionEvent::Changed);
+                ctx.emit(ConversationSelectionEvent::Activated {
+                    is_fullscreen: display_mode.is_fullscreen(),
+                    origin: origin.clone(),
+                });
+            }
+            AgentViewControllerEvent::ExitedAgentView {
+                conversation_id,
+                final_exchange_count,
+                is_exit_before_new_entrance,
+                ..
+            } => {
+                ctx.emit(ConversationSelectionEvent::Changed);
+                ctx.emit(ConversationSelectionEvent::Deactivated {
+                    conversation_id: *conversation_id,
+                    final_exchange_count: *final_exchange_count,
+                    is_exit_before_new_entrance: *is_exit_before_new_entrance,
+                });
+            }
+            AgentViewControllerEvent::ExitConfirmed { .. } => {}
+        });
+        ctx.subscribe_to_model(
+            &BlocklistAIHistoryModel::handle(ctx),
+            |selection, _, event, ctx| selection.handle_history_event(event, ctx),
+        );
+        Self {
+            terminal_surface_id,
+            agent_view_controller,
+        }
+    }
+}
+
+impl ConversationSelection for AgentViewConversationSelection {
+    fn selected_conversation_id(&self, app: &AppContext) -> Option<AIConversationId> {
+        self.agent_view_controller
+            .as_ref(app)
+            .agent_view_state()
+            .active_conversation_id()
+    }
+
+    fn is_conversation_active(&self, app: &AppContext) -> bool {
+        self.agent_view_controller.as_ref(app).is_active()
+    }
+
+    fn is_conversation_fullscreen(&self, app: &AppContext) -> bool {
+        self.agent_view_controller.as_ref(app).is_fullscreen()
+    }
+
+    fn select_existing_conversation(
+        &mut self,
+        conversation_id: AIConversationId,
+        origin: AgentViewEntryOrigin,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    ) {
+        if let Err(error) = self.agent_view_controller.update(ctx, |controller, ctx| {
+            controller.try_enter_agent_view(Some(conversation_id), origin, ctx)
+        }) {
+            log::error!("Failed to enter agent view for existing conversation: {error}");
+        }
+    }
+
+    fn select_new_conversation(
+        &mut self,
+        origin: AgentViewEntryOrigin,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    ) {
+        if let Err(error) = self.agent_view_controller.update(ctx, |controller, ctx| {
+            controller.try_enter_agent_view(None, origin, ctx)
+        }) {
+            log::error!("Failed to enter agent view for new conversation: {error}");
+        }
+    }
+
+    fn try_start_new_conversation(
+        &mut self,
+        origin: AgentViewEntryOrigin,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    ) -> Result<AIConversationId, EnterAgentViewError> {
+        self.agent_view_controller.update(ctx, |controller, ctx| {
+            controller.try_enter_agent_view(None, origin, ctx)
+        })
+    }
+
+    fn pending_query_autoexecute_override(
+        &self,
+        app: &AppContext,
+    ) -> AIConversationAutoexecuteMode {
+        self.selected_conversation_id(app)
+            .as_ref()
+            .and_then(|conversation_id| {
+                BlocklistAIHistoryModel::as_ref(app).conversation(conversation_id)
+            })
+            .map(|conversation| conversation.autoexecute_override())
+            .unwrap_or_default()
+    }
+
+    fn toggle_pending_query_autoexecute(
+        &mut self,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    ) {
+        if let Some(conversation_id) = self.selected_conversation_id(ctx) {
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                history.toggle_autoexecute_override(
+                    &conversation_id,
+                    self.terminal_surface_id,
+                    ctx,
+                );
+            });
+        }
+    }
+
+    fn handle_history_event(
+        &mut self,
+        event: &BlocklistAIHistoryEvent,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    ) {
+        if event
+            .terminal_surface_id()
+            .is_some_and(|id| id != self.terminal_surface_id)
+        {
+            return;
+        }
+        match event {
+            BlocklistAIHistoryEvent::ClearedConversationsForTerminalSurface { .. } => {
+                self.agent_view_controller
+                    .update(ctx, |controller, ctx| controller.exit_agent_view(ctx));
+            }
+            BlocklistAIHistoryEvent::SplitConversation {
+                old_conversation_id,
+                new_conversation_id,
+                ..
+            } if self.selected_conversation_id(ctx) == Some(*old_conversation_id) => {
+                self.select_existing_conversation(
+                    *new_conversation_id,
+                    AgentViewEntryOrigin::AgentRequestedNewConversation,
+                    ctx,
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "conversation_selection_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/agent_view/conversation_selection_tests.rs
+++ b/app/src/ai/blocklist/agent_view/conversation_selection_tests.rs
@@ -1,0 +1,68 @@
+use std::sync::Arc;
+
+use parking_lot::FairMutex;
+use warpui::r#async::executor::Background;
+use warpui::{App, EntityId};
+
+use super::AgentViewConversationSelection;
+use crate::ai::blocklist::agent_view::{
+    AgentViewController, AgentViewEntryOrigin, EphemeralMessageModel,
+};
+use crate::ai::blocklist::{BlocklistAIHistoryModel, ConversationSelection};
+use crate::terminal::color::{self, Colors};
+use crate::terminal::event_listener::ChannelEventListener;
+use crate::terminal::model::test_utils::block_size;
+use crate::terminal::TerminalModel;
+use crate::test_util::settings::initialize_settings_for_tests;
+
+#[test]
+fn gui_selection_delegates_to_agent_view() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let terminal_surface_id = EntityId::new();
+        let terminal_model = Arc::new(FairMutex::new(TerminalModel::new_for_test(
+            block_size(),
+            color::List::from(&Colors::default()),
+            ChannelEventListener::new_for_test(),
+            Arc::new(Background::default()),
+            false,
+            None,
+            false,
+            false,
+            None,
+        )));
+        let ephemeral_message_model = app.add_model(|_| EphemeralMessageModel::new());
+        let agent_view_controller = app.add_model(|_| {
+            AgentViewController::new(terminal_model, terminal_surface_id, ephemeral_message_model)
+        });
+        let selection = app.add_model(|ctx| {
+            Box::new(AgentViewConversationSelection::new(
+                terminal_surface_id,
+                agent_view_controller.clone(),
+                ctx,
+            )) as Box<dyn ConversationSelection>
+        });
+        let conversation_id = history.update(&mut app, |history, ctx| {
+            history.start_new_conversation(terminal_surface_id, false, false, false, ctx)
+        });
+
+        selection.update(&mut app, |selection, ctx| {
+            selection.select_existing_conversation(
+                conversation_id,
+                AgentViewEntryOrigin::ConversationSelector,
+                ctx,
+            );
+        });
+
+        selection.read(&app, |selection, ctx| {
+            assert_eq!(
+                selection.selected_conversation_id(ctx),
+                Some(conversation_id)
+            );
+        });
+        agent_view_controller.read(&app, |controller, _| {
+            assert!(controller.is_active());
+        });
+    });
+}

--- a/app/src/ai/blocklist/agent_view/inline_agent_view_header.rs
+++ b/app/src/ai/blocklist/agent_view/inline_agent_view_header.rs
@@ -45,7 +45,7 @@ impl InlineAgentViewHeader {
         let history_model = BlocklistAIHistoryModel::handle(ctx);
         ctx.subscribe_to_model(&history_model, move |me, _, event, ctx| {
             if event
-                .terminal_view_id()
+                .terminal_surface_id()
                 .is_some_and(|id| id != me.terminal_view_id)
             {
                 return;

--- a/app/src/ai/blocklist/agent_view/mod.rs
+++ b/app/src/ai/blocklist/agent_view/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod agent_input_footer;
 mod agent_message_bar;
 mod agent_view_block;
 mod controller;
+mod conversation_selection;
 mod ephemeral_message_model;
 mod inline_agent_view_header;
 // TODO: Move orchestration_conversation_links module import elsewhere.
@@ -18,6 +19,7 @@ pub use agent_input_footer::*;
 pub use agent_message_bar::*;
 pub use agent_view_block::*;
 pub use controller::*;
+pub(crate) use conversation_selection::AgentViewConversationSelection;
 pub use ephemeral_message_model::*;
 pub use inline_agent_view_header::*;
 pub use orchestration_pill_bar::{render_orchestration_breadcrumbs, OrchestrationPillBar};

--- a/app/src/ai/blocklist/agent_view/orchestration_conversation_links.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_conversation_links.rs
@@ -47,7 +47,7 @@ pub(crate) fn is_conversation_open_in_other_visible_view(
     app: &AppContext,
 ) -> bool {
     let Some(owner) =
-        BlocklistAIHistoryModel::as_ref(app).terminal_view_id_for_conversation(&conversation_id)
+        BlocklistAIHistoryModel::as_ref(app).terminal_surface_id_for_conversation(&conversation_id)
     else {
         return false;
     };
@@ -89,7 +89,7 @@ pub(crate) fn dispatch_focus_or_open_child_agent_pane(
     app: &AppContext,
 ) {
     if let Some(owner_view_id) =
-        BlocklistAIHistoryModel::as_ref(app).terminal_view_id_for_conversation(&conversation_id)
+        BlocklistAIHistoryModel::as_ref(app).terminal_surface_id_for_conversation(&conversation_id)
     {
         if owner_view_id != self_terminal_view_id {
             if let Some(owner_pane_group_id) =

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -819,7 +819,7 @@ impl OrchestrationPillBar {
     /// the `FocusOpenedConversation` handler so the `PillClicked`
     /// handler can reuse the same nav logic without emitting the
     /// menu-driven `FocusOpenedConversation` telemetry event.
-    fn navigate_to_owner_pane(&self, id: AIConversationId, ctx: &mut ViewContext<Self>) {
+    fn navigate_to_conversation_pane(&self, id: AIConversationId, ctx: &mut ViewContext<Self>) {
         // "Focus pane" is purely a focus operation: the conversation
         // already lives in some other visible terminal view (verified
         // by `is_conversation_open_in_other_visible_view` at the call
@@ -828,15 +828,15 @@ impl OrchestrationPillBar {
         // `RestoreOrNavigateToConversation`: that path calls
         // `set_active_conversation_id` with whichever
         // `terminal_view_id` it receives, which would either
-        // re-transfer ownership to a stale id pulled from
+        // reassign the terminal surface to a stale id pulled from
         // `AgentConversationsModel::nav_data` or, worse, blank out
-        // the real owner pane while the conversation pops back into
+        // the real conversation pane while the conversation pops back into
         // the orchestrator.
         //
-        // Resolve the canonical owner directly from
+        // Resolve the canonical terminal surface directly from
         // `BlocklistAIHistoryModel` (the single source of truth) and
         // pick the appropriate focus action based on whether the
-        // owner pane lives in the same pane group as us:
+        // conversation pane lives in the same pane group as us:
         //   * Same pane group (sibling pane in this tab) —
         //     dispatch `TerminalAction::RevealChildAgent`. The pane
         //     group's handler walks visible terminal panes and calls
@@ -850,11 +850,11 @@ impl OrchestrationPillBar {
         //     dispatch `WorkspaceAction::FocusTerminalViewInWorkspace`,
         //     which walks all tabs/windows and activates the
         //     containing tab as needed.
-        let owner_view_id =
-            BlocklistAIHistoryModel::as_ref(ctx).terminal_view_id_for_conversation(&id);
-        let Some(owner_view_id) = owner_view_id else {
+        let conversation_view_id =
+            BlocklistAIHistoryModel::as_ref(ctx).terminal_surface_id_for_conversation(&id);
+        let Some(conversation_view_id) = conversation_view_id else {
             log::warn!(
-                "navigate_to_owner_pane: no canonical owner for {id:?}; falling back to switch-in-place"
+                "navigate_to_conversation_pane: no canonical terminal surface for {id:?}; falling back to switch-in-place"
             );
             ctx.dispatch_typed_action(
                 &PaneHeaderAction::<TerminalAction, TerminalAction>::CustomAction(
@@ -866,8 +866,10 @@ impl OrchestrationPillBar {
             return;
         };
         let self_pane_group_id = self.agent_view_controller.as_ref(ctx).pane_group_id();
-        let owner_pane_group_id = pane_group_id_containing_terminal_view(owner_view_id, ctx);
-        if owner_pane_group_id.is_some() && owner_pane_group_id == self_pane_group_id {
+        let conversation_pane_group_id =
+            pane_group_id_containing_terminal_view(conversation_view_id, ctx);
+        if conversation_pane_group_id.is_some() && conversation_pane_group_id == self_pane_group_id
+        {
             ctx.dispatch_typed_action(
                 &PaneHeaderAction::<TerminalAction, TerminalAction>::CustomAction(
                     TerminalAction::RevealChildAgent {
@@ -877,7 +879,7 @@ impl OrchestrationPillBar {
             );
         } else {
             ctx.dispatch_typed_action(&WorkspaceAction::FocusTerminalViewInWorkspace {
-                terminal_view_id: owner_view_id,
+                terminal_view_id: conversation_view_id,
             });
         }
     }
@@ -1022,7 +1024,7 @@ impl TypedActionView for OrchestrationPillBar {
                 };
                 self.emit_pill_switch(pill_kind.telemetry_kind(), id, outcome, ctx);
                 if is_open_elsewhere {
-                    self.navigate_to_owner_pane(id, ctx);
+                    self.navigate_to_conversation_pane(id, ctx);
                 } else {
                     ctx.dispatch_typed_action(
                         &PaneHeaderAction::<TerminalAction, TerminalAction>::CustomAction(
@@ -1039,7 +1041,7 @@ impl TypedActionView for OrchestrationPillBar {
                     ctx,
                 );
                 self.close_menu(ctx);
-                self.navigate_to_owner_pane(*id, ctx);
+                self.navigate_to_conversation_pane(*id, ctx);
             }
         }
     }
@@ -2431,7 +2433,7 @@ fn render_crumb(
         // rather than switching this (split-off child) pane to it.
         //
         // Pick the focus path based on where the parent's canonical
-        // owner pane lives, mirroring the orchestration pill bar's
+        // conversation pane lives, mirroring the orchestration pill bar's
         // "Focus pane" handler:
         //   * Same pane group as us (sibling pane in this tab) —
         //     dispatch `TerminalAction::RevealChildAgent`, which the
@@ -2444,17 +2446,20 @@ fn render_crumb(
         //     `WorkspaceAction::FocusTerminalViewInWorkspace`, which
         //     walks all tabs/windows and activates the containing tab
         //     as needed.
-        //   * No canonical owner anywhere — fall back to
+        //   * No canonical terminal surface anywhere — fall back to
         //     `SwitchAgentViewToConversation` so the breadcrumb stays
         //     useful even after the orchestrator pane has been closed
         //     and the parent conversation only persists in history.
-        if let Some(owner_view_id) =
-            BlocklistAIHistoryModel::as_ref(app).terminal_view_id_for_conversation(&conversation_id)
+        if let Some(conversation_view_id) = BlocklistAIHistoryModel::as_ref(app)
+            .terminal_surface_id_for_conversation(&conversation_id)
         {
             let self_pane_group_id =
                 pane_group_id_containing_terminal_view(self_terminal_view_id, app);
-            let owner_pane_group_id = pane_group_id_containing_terminal_view(owner_view_id, app);
-            if owner_pane_group_id.is_some() && owner_pane_group_id == self_pane_group_id {
+            let conversation_pane_group_id =
+                pane_group_id_containing_terminal_view(conversation_view_id, app);
+            if conversation_pane_group_id.is_some()
+                && conversation_pane_group_id == self_pane_group_id
+            {
                 ctx.dispatch_typed_action(
                     PaneHeaderAction::<TerminalAction, TerminalAction>::CustomAction(
                         TerminalAction::RevealChildAgent { conversation_id },
@@ -2463,7 +2468,7 @@ fn render_crumb(
                 return;
             }
             ctx.dispatch_typed_action(WorkspaceAction::FocusTerminalViewInWorkspace {
-                terminal_view_id: owner_view_id,
+                terminal_view_id: conversation_view_id,
             });
             return;
         }

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -1272,7 +1272,7 @@ impl AIBlock {
             &BlocklistAIHistoryModel::handle(ctx),
             |me, _, event, ctx| {
                 if event
-                    .terminal_view_id()
+                    .terminal_surface_id()
                     .is_none_or(|id| id == me.terminal_view_id)
                 {
                     match event {

--- a/app/src/ai/blocklist/block/cli_controller.rs
+++ b/app/src/ai/blocklist/block/cli_controller.rs
@@ -483,7 +483,7 @@ impl CLISubagentController {
         ctx: &mut ModelContext<Self>,
     ) {
         if event
-            .terminal_view_id()
+            .terminal_surface_id()
             .is_some_and(|id| id != self.terminal_view_id)
         {
             return;

--- a/app/src/ai/blocklist/block/status_bar.rs
+++ b/app/src/ai/blocklist/block/status_bar.rs
@@ -150,7 +150,7 @@ impl BlocklistAIStatusBar {
         let history_model = BlocklistAIHistoryModel::handle(ctx);
         ctx.subscribe_to_model(&history_model, move |me, _, event, ctx| {
             if event
-                .terminal_view_id()
+                .terminal_surface_id()
                 .is_some_and(|id| id != terminal_view_id)
             {
                 return;
@@ -167,7 +167,7 @@ impl BlocklistAIStatusBar {
                     }
                     me.reset_model_for_exchange(*exchange_id, *conversation_id, ctx);
                 }
-                BlocklistAIHistoryEvent::ClearedConversationsInTerminalView { .. } => {
+                BlocklistAIHistoryEvent::ClearedConversationsForTerminalSurface { .. } => {
                     me.active_exchange_model = None;
                     ctx.notify();
                 }

--- a/app/src/ai/blocklist/context_model.rs
+++ b/app/src/ai/blocklist/context_model.rs
@@ -13,10 +13,9 @@ use warpui::{
     AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonEntity, WeakModelHandle,
 };
 
-use super::agent_view::{AgentViewController, AgentViewEntryOrigin, EnterAgentViewError};
+use super::agent_view::{AgentViewEntryOrigin, EnterAgentViewError};
 use super::block::DirectoryContext;
-use super::history_model::BlocklistAIHistoryModel;
-use super::BlocklistAIHistoryEvent;
+use super::{ConversationSelectionEvent, ConversationSelectionHandle};
 use crate::ai::agent::conversation::{
     AIConversation, AIConversationAutoexecuteMode, AIConversationId, ConversationStatus,
 };
@@ -73,32 +72,6 @@ impl PendingAttachment {
         }
     }
 }
-
-/// The state the pending query is in.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub enum PendingQueryState {
-    /// The next query will continue an existing conversation.
-    Existing { conversation_id: AIConversationId },
-    New {
-        /// Autoexecute override for the new conversation to be started.
-        autoexecute_override: AIConversationAutoexecuteMode,
-    },
-}
-
-impl Default for PendingQueryState {
-    fn default() -> Self {
-        Self::New {
-            autoexecute_override: AIConversationAutoexecuteMode::default(),
-        }
-    }
-}
-
-impl PendingQueryState {
-    pub fn targets_existing_conversation(&self) -> bool {
-        matches!(self, PendingQueryState::Existing { .. })
-    }
-}
-
 /// Model responsible for keeping track of session context to be attached to the next AI query.
 pub struct BlocklistAIContextModel {
     terminal_model: Arc<FairMutex<TerminalModel>>,
@@ -117,22 +90,14 @@ pub struct BlocklistAIContextModel {
     /// Storage for diff hunk attachments that can be referenced in queries
     pending_inline_diff_hunk_attachments: HashMap<String, AIAgentAttachment>,
 
-    /// The pending query could be new, which means it starts a new conversation, or follow-up, which means
-    /// it continues the selected conversation.
-    ///
-    /// Note that this is intentionally decoupled from the active conversation in the HistoryModel.
-    /// The active conversation (the one that agent outputs are being streamed to) can be different from the
-    /// conversation we're following up in for the next query.
-    pending_query_state: PendingQueryState,
+    conversation_selection: ConversationSelectionHandle,
 
-    /// The ID of the terminal view this controller is associated with.
-    terminal_view_id: EntityId,
+    /// The ID of the terminal surface this model is associated with.
+    terminal_surface_id: EntityId,
 
     /// AI document ID to be included as context with the next AI query.
     /// When set, the document content will be attached as plain text context.
     pending_document_id: Option<AIDocumentId>,
-
-    agent_view_controller: ModelHandle<AgentViewController>,
 
     /// Block IDs of user-executed commands to be auto-attached as context.
     /// When `AgentViewBlockContext` is enabled, completed user commands are tracked here
@@ -174,12 +139,13 @@ pub fn block_context_from_terminal_model(
 }
 
 impl BlocklistAIContextModel {
+    /// Creates pending context state for a terminal surface.
     pub fn new(
         sessions: ModelHandle<Sessions>,
         model_event_dispatcher: &ModelHandle<ModelEventDispatcher>,
         terminal_model: Arc<FairMutex<TerminalModel>>,
-        terminal_view_id: EntityId,
-        agent_view_controller: ModelHandle<AgentViewController>,
+        terminal_surface_id: EntityId,
+        conversation_selection: ConversationSelectionHandle,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         ctx.subscribe_to_model(
@@ -193,7 +159,10 @@ impl BlocklistAIContextModel {
                     // If AgentViewBlockContext is enabled and we're in agent view, track user-executed
                     // blocks for auto-attachment as context.
                     if FeatureFlag::AgentViewBlockContext.is_enabled()
-                        && me.agent_view_controller.as_ref(ctx).is_fullscreen()
+                        && me
+                            .conversation_selection
+                            .as_ref(ctx)
+                            .is_conversation_fullscreen(ctx)
                         && !user_block_completed.was_part_of_agent_interaction
                     {
                         me.auto_attached_agent_view_user_block_ids
@@ -218,72 +187,26 @@ impl BlocklistAIContextModel {
             },
         );
 
-        ctx.subscribe_to_model(
-            &BlocklistAIHistoryModel::handle(ctx),
-            |me, _, event, ctx| {
-                if event
-                    .terminal_view_id()
-                    .is_some_and(|id| id != me.terminal_view_id)
-                {
-                    return;
-                }
-
-                match event {
-                    BlocklistAIHistoryEvent::ClearedConversationsInTerminalView { .. } => {
-                        me.set_pending_query_state(PendingQueryState::default(), ctx);
-                        if FeatureFlag::AgentView.is_enabled() {
-                            me.agent_view_controller.update(ctx, |controller, ctx| {
-                                controller.exit_agent_view(ctx);
-                            });
-                        }
-                    }
-                    BlocklistAIHistoryEvent::SplitConversation {
-                        new_conversation_id,
-                        ..
-                    } => {
-                        me.set_pending_query_state_for_existing_conversation(
-                            *new_conversation_id,
-                            AgentViewEntryOrigin::AgentRequestedNewConversation,
-                            ctx,
-                        );
-                    }
-                    _ => {}
-                }
-            },
-        );
-
         ctx.subscribe_to_model(&LLMPreferences::handle(ctx), |me, _, event, ctx| {
             if let LLMPreferencesEvent::UpdatedActiveAgentModeLLM = event {
                 let llm_prefs = LLMPreferences::as_ref(ctx);
-                let vision_supported = llm_prefs.vision_supported(ctx, Some(me.terminal_view_id));
+                let vision_supported =
+                    llm_prefs.vision_supported(ctx, Some(me.terminal_surface_id));
                 if !vision_supported {
                     me.clear_pending_images(ctx);
                 }
             }
         });
 
-        // Clear auto-attached blocks when exiting agent view or switching conversations
-        ctx.subscribe_to_model(&agent_view_controller, |me, _, event, _ctx| {
-            use super::agent_view::AgentViewControllerEvent;
-            match event {
-                AgentViewControllerEvent::ExitedAgentView { .. }
-                | AgentViewControllerEvent::EnteredAgentView { .. } => {
-                    me.auto_attached_agent_view_user_block_ids.clear();
-                }
-                AgentViewControllerEvent::ExitConfirmed { .. } => {}
+        ctx.subscribe_to_model(&conversation_selection, |me, _, event, ctx| match event {
+            ConversationSelectionEvent::Changed => {
+                ctx.emit(BlocklistAIContextEvent::PendingQueryStateUpdated);
+            }
+            ConversationSelectionEvent::Activated { .. }
+            | ConversationSelectionEvent::Deactivated { .. } => {
+                me.auto_attached_agent_view_user_block_ids.clear();
             }
         });
-
-        // In sandboxed/autonomous mode (SDK mode with --sandboxed flag), automatically set
-        // conversations to RunToCompletion mode so they don't wait for user confirmation.
-        let pending_query_state =
-            if warp_core::execution_mode::AppExecutionMode::as_ref(ctx).is_sandboxed() {
-                PendingQueryState::New {
-                    autoexecute_override: AIConversationAutoexecuteMode::RunToCompletion,
-                }
-            } else {
-                Default::default()
-            };
 
         Self {
             terminal_model,
@@ -292,26 +215,20 @@ impl BlocklistAIContextModel {
             pending_context_block_ids: HashSet::new(),
             pending_context_selected_text: None,
             pending_attachments: Default::default(),
-            pending_query_state,
-            terminal_view_id,
-            agent_view_controller,
+            conversation_selection,
+            terminal_surface_id,
             pending_inline_diff_hunk_attachments: Default::default(),
             pending_document_id: None,
             auto_attached_agent_view_user_block_ids: Vec::new(),
         }
     }
 
-    /// Test-only constructor that skips every subscription and singleton lookup performed by
-    /// [`Self::new`], so unit tests can build a [`BlocklistAIContextModel`] without registering
-    /// `BlocklistAIHistoryModel`, `LLMPreferences`, `ModelEventDispatcher`, `Sessions`, or
-    /// `AppExecutionMode`. Callers still pass real [`TerminalModel`] and [`AgentViewController`]
-    /// handles to populate the struct fields, but neither needs to be functional for the
-    /// methods exercised by these tests.
+    /// Test-only constructor that skips production subscriptions and singleton lookups.
     #[cfg(test)]
     pub(crate) fn new_for_test(
         terminal_model: Arc<FairMutex<TerminalModel>>,
-        terminal_view_id: EntityId,
-        agent_view_controller: ModelHandle<AgentViewController>,
+        terminal_surface_id: EntityId,
+        conversation_selection: ConversationSelectionHandle,
     ) -> Self {
         Self {
             terminal_model,
@@ -320,9 +237,8 @@ impl BlocklistAIContextModel {
             pending_context_block_ids: HashSet::new(),
             pending_context_selected_text: None,
             pending_attachments: Default::default(),
-            pending_query_state: PendingQueryState::default(),
-            terminal_view_id,
-            agent_view_controller,
+            conversation_selection,
+            terminal_surface_id,
             pending_inline_diff_hunk_attachments: Default::default(),
             pending_document_id: None,
             auto_attached_agent_view_user_block_ids: Vec::new(),
@@ -718,10 +634,6 @@ impl BlocklistAIContextModel {
         to_remove
     }
 
-    pub fn pending_query_state(&self) -> &PendingQueryState {
-        &self.pending_query_state
-    }
-
     /// Convenience function to set pending query state to continue an existing conversation by ID.
     pub fn set_pending_query_state_for_existing_conversation(
         &mut self,
@@ -729,14 +641,9 @@ impl BlocklistAIContextModel {
         origin: AgentViewEntryOrigin,
         ctx: &mut ModelContext<Self>,
     ) {
-        self.set_pending_query_state(PendingQueryState::Existing { conversation_id }, ctx);
-        if FeatureFlag::AgentView.is_enabled() {
-            if let Err(e) = self.agent_view_controller.update(ctx, |controller, ctx| {
-                controller.try_enter_agent_view(Some(conversation_id), origin, ctx)
-            }) {
-                log::error!("Failed to enter agent view for existing conversation: {e}");
-            }
-        }
+        self.conversation_selection.update(ctx, |selection, ctx| {
+            selection.select_existing_conversation(conversation_id, origin, ctx);
+        });
     }
 
     /// Sets the pending query state to the defaults for a *new* conversation (i.e. not a
@@ -746,40 +653,20 @@ impl BlocklistAIContextModel {
         origin: AgentViewEntryOrigin,
         ctx: &mut ModelContext<Self>,
     ) {
-        self.set_pending_query_state(PendingQueryState::default(), ctx);
-
-        if FeatureFlag::AgentView.is_enabled() {
-            if let Err(e) = self.agent_view_controller.update(ctx, |controller, ctx| {
-                controller.try_enter_agent_view(None, origin, ctx)
-            }) {
-                log::error!("Failed to enter agent view for new conversation: {e}");
-            }
-        }
+        self.conversation_selection.update(ctx, |selection, ctx| {
+            selection.select_new_conversation(origin, ctx);
+        });
     }
 
-    /// Attempts to enter agent view for a new conversation and returns the conversation ID.
-    /// This should be used when a slash command needs to create a new conversation
-    /// and the AgentView feature flag is enabled.
-    ///
-    /// Returns `Ok(conversation_id)` on success, or `Err` if entry is blocked.
-    pub fn try_enter_agent_view_for_new_conversation(
+    /// Starts and selects a new conversation, entering Agent View when this is a GUI selection.
+    pub(crate) fn try_start_new_conversation(
         &mut self,
         origin: AgentViewEntryOrigin,
         ctx: &mut ModelContext<Self>,
     ) -> Result<AIConversationId, EnterAgentViewError> {
-        let conversation_id = self.agent_view_controller.update(ctx, |controller, ctx| {
-            controller.try_enter_agent_view(None, origin, ctx)
-        })?;
-        self.set_pending_query_state(PendingQueryState::default(), ctx);
-        Ok(conversation_id)
-    }
-
-    /// Sets the value of `pending_query_state`, emitting an event if it changed.
-    fn set_pending_query_state(&mut self, state: PendingQueryState, ctx: &mut ModelContext<Self>) {
-        if self.pending_query_state != state {
-            self.pending_query_state = state;
-            ctx.emit(BlocklistAIContextEvent::PendingQueryStateUpdated);
-        }
+        self.conversation_selection.update(ctx, |selection, ctx| {
+            selection.try_start_new_conversation(origin, ctx)
+        })
     }
 
     /// Returns `true` if a new conversation may be created.
@@ -801,28 +688,15 @@ impl BlocklistAIContextModel {
     /// Returns the conversation ID the pending query is following up for, if any.
     /// None if the pending query should start a new conversation.
     pub fn selected_conversation_id(&self, ctx: &AppContext) -> Option<AIConversationId> {
-        if FeatureFlag::AgentView.is_enabled() {
-            return self
-                .agent_view_controller
-                .as_ref(ctx)
-                .agent_view_state()
-                .active_conversation_id();
-        }
-
-        match self.pending_query_state {
-            PendingQueryState::Existing {
-                conversation_id, ..
-            } => Some(conversation_id),
-            PendingQueryState::New { .. } => None,
-        }
+        self.conversation_selection
+            .as_ref(ctx)
+            .selected_conversation_id(ctx)
     }
 
     pub fn selected_conversation<'a>(&self, ctx: &'a AppContext) -> Option<&'a AIConversation> {
-        self.selected_conversation_id(ctx)
-            .as_ref()
-            .and_then(|conversation_id| {
-                BlocklistAIHistoryModel::as_ref(ctx).conversation(conversation_id)
-            })
+        self.conversation_selection
+            .as_ref(ctx)
+            .selected_conversation(ctx)
     }
 
     pub fn selected_conversation_todolist<'a>(
@@ -845,72 +719,24 @@ impl BlocklistAIContextModel {
         &self,
         ctx: &AppContext,
     ) -> AIConversationAutoexecuteMode {
-        match &self.pending_query_state {
-            PendingQueryState::New {
-                autoexecute_override,
-            } => *autoexecute_override,
-            PendingQueryState::Existing {
-                conversation_id, ..
-            } => BlocklistAIHistoryModel::as_ref(ctx)
-                .conversation(conversation_id)
-                .map(|conversation| conversation.autoexecute_override())
-                .unwrap_or_default(),
-        }
+        self.conversation_selection
+            .as_ref(ctx)
+            .pending_query_autoexecute_override(ctx)
     }
 
     pub fn toggle_pending_query_autoexecute(&mut self, ctx: &mut ModelContext<Self>) {
-        // When AgentView is enabled, the autoexecution toggle should apply to the active agent view
-        // conversation -- even when starting a new conversation, the agent view always has a conversation
-        // ID.
-        if FeatureFlag::AgentView.is_enabled() {
-            if let Some(conversation_id) = self
-                .agent_view_controller
-                .as_ref(ctx)
-                .agent_view_state()
-                .active_conversation_id()
-            {
-                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
-                    history.toggle_autoexecute_override(
-                        &conversation_id,
-                        self.terminal_view_id,
-                        ctx,
-                    );
-                });
-            }
-            return;
-        }
-
-        match &mut self.pending_query_state {
-            PendingQueryState::New {
-                autoexecute_override,
-            } => {
-                *autoexecute_override = if *autoexecute_override
-                    == AIConversationAutoexecuteMode::RespectUserSettings
-                {
-                    AIConversationAutoexecuteMode::RunToCompletion
-                } else {
-                    AIConversationAutoexecuteMode::RespectUserSettings
-                };
-                ctx.emit(BlocklistAIContextEvent::PendingQueryStateUpdated);
-            }
-            PendingQueryState::Existing {
-                conversation_id, ..
-            } => {
-                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
-                    history.toggle_autoexecute_override(
-                        conversation_id,
-                        self.terminal_view_id,
-                        ctx,
-                    );
-                });
-            }
-        }
+        self.conversation_selection.update(ctx, |selection, ctx| {
+            selection.toggle_pending_query_autoexecute(ctx);
+        });
     }
 
     /// Returns true if the pending query targets an existing conversation
     /// (as opposed to starting a new one).
-    pub fn is_targeting_existing_conversation(&self) -> bool {
-        self.pending_query_state.targets_existing_conversation()
+    pub fn is_targeting_existing_conversation(&self, ctx: &AppContext) -> bool {
+        self.conversation_selection
+            .as_ref(ctx)
+            .selected_conversation_id(ctx)
+            .is_some()
     }
 
     /// Returns the status of the selected conversation for purposes of rendering the input hint

--- a/app/src/ai/blocklist/context_model_tests.rs
+++ b/app/src/ai/blocklist/context_model_tests.rs
@@ -1,10 +1,7 @@
 //! Unit tests for [`BlocklistAIContextModel`].
 //!
-//! These tests deliberately bypass the production [`BlocklistAIContextModel::new`] constructor
-//! (which subscribes to several singletons) and instead use [`BlocklistAIContextModel::new_for_test`]
-//! together with [`super::agent_view::AgentViewController::new`]. That keeps the fixture small
-//! enough to focus on context logic without standing up `BlocklistAIHistoryModel`,
-//! `LLMPreferences`, `CloudModel`, `UpdateManager`, or `AppExecutionMode`.
+//! These tests use [`BlocklistAIContextModel::new_for_test`] and a small conversation-selection
+//! fake to avoid unrelated subscriptions while exercising context behavior.
 
 use std::sync::Arc;
 
@@ -14,14 +11,18 @@ use repo_metadata::DirectoryWatcher;
 #[cfg(feature = "local_fs")]
 use warp_util::standardized_path::StandardizedPath;
 use warpui::r#async::executor::Background;
-use warpui::{App, EntityId, ModelHandle};
+use warpui::{App, EntityId, ModelHandle, SingletonEntity};
 
 use super::{BlocklistAIContextModel, PendingAttachment, PendingFile};
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent::{AIAgentContext, ImageContext};
-use crate::ai::blocklist::agent_view::{AgentViewController, EphemeralMessageModel};
+use crate::ai::blocklist::agent_view::{AgentViewEntryOrigin, EnterAgentViewError};
+use crate::ai::blocklist::conversation_selection::{
+    ConversationSelection, ConversationSelectionEvent,
+};
 use crate::ai::blocklist::{
-    BlocklistAIHistoryModel, QueuedQuery, QueuedQueryModel, QueuedQueryOrigin,
+    BlocklistAIHistoryEvent, BlocklistAIHistoryModel, QueuedQuery, QueuedQueryModel,
+    QueuedQueryOrigin,
 };
 #[cfg(feature = "local_fs")]
 use crate::code_review::git_repo_model::GitRepoStatusModel;
@@ -48,6 +49,106 @@ impl BlocklistAIContextModel {
 
     pub(crate) fn set_pending_selected_text_for_test(&mut self, text: Option<String>) {
         self.pending_context_selected_text = text;
+    }
+}
+
+struct TestConversationSelection {
+    terminal_surface_id: EntityId,
+    selected_conversation_id: Option<AIConversationId>,
+}
+
+impl TestConversationSelection {
+    fn new(
+        terminal_surface_id: EntityId,
+        _: &mut warpui::ModelContext<Box<dyn ConversationSelection>>,
+    ) -> Self {
+        Self {
+            terminal_surface_id,
+            selected_conversation_id: None,
+        }
+    }
+}
+
+impl ConversationSelection for TestConversationSelection {
+    fn selected_conversation_id(&self, _: &warpui::AppContext) -> Option<AIConversationId> {
+        self.selected_conversation_id
+    }
+
+    fn is_conversation_active(&self, _: &warpui::AppContext) -> bool {
+        self.selected_conversation_id.is_some()
+    }
+
+    fn is_conversation_fullscreen(&self, _: &warpui::AppContext) -> bool {
+        self.selected_conversation_id.is_some()
+    }
+
+    fn select_existing_conversation(
+        &mut self,
+        conversation_id: AIConversationId,
+        _: AgentViewEntryOrigin,
+        ctx: &mut warpui::ModelContext<Box<dyn ConversationSelection>>,
+    ) {
+        if self.selected_conversation_id != Some(conversation_id) {
+            self.selected_conversation_id = Some(conversation_id);
+            ctx.emit(ConversationSelectionEvent::Changed);
+        }
+    }
+
+    fn select_new_conversation(
+        &mut self,
+        _: AgentViewEntryOrigin,
+        ctx: &mut warpui::ModelContext<Box<dyn ConversationSelection>>,
+    ) {
+        if self.selected_conversation_id.take().is_some() {
+            ctx.emit(ConversationSelectionEvent::Changed);
+        }
+    }
+
+    fn try_start_new_conversation(
+        &mut self,
+        _: AgentViewEntryOrigin,
+        ctx: &mut warpui::ModelContext<Box<dyn ConversationSelection>>,
+    ) -> Result<AIConversationId, EnterAgentViewError> {
+        let conversation_id = BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+            history.start_new_conversation(self.terminal_surface_id, false, false, false, ctx)
+        });
+        self.select_existing_conversation(conversation_id, AgentViewEntryOrigin::Cli, ctx);
+        Ok(conversation_id)
+    }
+
+    fn pending_query_autoexecute_override(
+        &self,
+        app: &warpui::AppContext,
+    ) -> crate::ai::agent::conversation::AIConversationAutoexecuteMode {
+        self.selected_conversation_id
+            .as_ref()
+            .and_then(|conversation_id| {
+                BlocklistAIHistoryModel::as_ref(app).conversation(conversation_id)
+            })
+            .map(|conversation| conversation.autoexecute_override())
+            .unwrap_or_default()
+    }
+
+    fn toggle_pending_query_autoexecute(
+        &mut self,
+        ctx: &mut warpui::ModelContext<Box<dyn ConversationSelection>>,
+    ) {
+        if let Some(conversation_id) = self.selected_conversation_id {
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                history.toggle_autoexecute_override(
+                    &conversation_id,
+                    self.terminal_surface_id,
+                    ctx,
+                );
+            });
+        }
+    }
+
+    fn handle_history_event(
+        &mut self,
+        _: &BlocklistAIHistoryEvent,
+        _: &mut warpui::ModelContext<Box<dyn ConversationSelection>>,
+    ) {
     }
 }
 
@@ -108,6 +209,8 @@ fn repository_context_reads_github_repo_model() {
 /// Builds a [`BlocklistAIContextModel`] with stub dependencies. None of the dependencies are
 /// exercised by the methods under test; they only need to satisfy the struct's field types.
 fn build_test_context_model(app: &mut App) -> ModelHandle<BlocklistAIContextModel> {
+    initialize_history_persistence_for_tests(app);
+    app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
     let terminal_model = Arc::new(FairMutex::new(TerminalModel::new_for_test(
         block_size(),
         color::List::from(&Colors::default()),
@@ -121,22 +224,101 @@ fn build_test_context_model(app: &mut App) -> ModelHandle<BlocklistAIContextMode
     )));
     let terminal_view_id = EntityId::new();
 
-    let ephemeral_message_model = app.add_model(|_| EphemeralMessageModel::new());
-    let agent_view_controller = app.add_model(|_| {
-        AgentViewController::new(
-            terminal_model.clone(),
-            terminal_view_id,
-            ephemeral_message_model,
-        )
+    let conversation_selection = app.add_model(|ctx| {
+        Box::new(TestConversationSelection::new(terminal_view_id, ctx))
+            as Box<dyn ConversationSelection>
     });
 
     app.add_model(|_| {
         BlocklistAIContextModel::new_for_test(
             terminal_model,
             terminal_view_id,
-            agent_view_controller,
+            conversation_selection,
         )
     })
+}
+
+/// Builds context state for a TUI conversation surface.
+fn build_tui_context_model(app: &mut App) -> (ModelHandle<BlocklistAIContextModel>, EntityId) {
+    initialize_history_persistence_for_tests(app);
+    app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+    let terminal_model = Arc::new(FairMutex::new(TerminalModel::new_for_test(
+        block_size(),
+        color::List::from(&Colors::default()),
+        ChannelEventListener::new_for_test(),
+        Arc::new(Background::default()),
+        false,
+        None,
+        false,
+        false,
+        None,
+    )));
+    let terminal_surface_id = EntityId::new();
+    let conversation_selection = app.add_model(|ctx| {
+        Box::new(TestConversationSelection::new(terminal_surface_id, ctx))
+            as Box<dyn ConversationSelection>
+    });
+    let model = app.add_model(|_| {
+        BlocklistAIContextModel::new_for_test(
+            terminal_model,
+            terminal_surface_id,
+            conversation_selection,
+        )
+    });
+    (model, terminal_surface_id)
+}
+
+#[test]
+fn tui_context_tracks_selected_conversation() {
+    App::test((), |mut app| async move {
+        let (model, _) = build_tui_context_model(&mut app);
+        let conversation_id = AIConversationId::new();
+
+        model.update(&mut app, |model, ctx| {
+            model.set_pending_query_state_for_existing_conversation(
+                conversation_id,
+                AgentViewEntryOrigin::Cli,
+                ctx,
+            );
+        });
+        model.read(&app, |model, ctx| {
+            assert_eq!(model.selected_conversation_id(ctx), Some(conversation_id));
+        });
+
+        model.update(&mut app, |model, ctx| {
+            model.set_pending_query_state_for_new_conversation(AgentViewEntryOrigin::Cli, ctx);
+        });
+        model.read(&app, |model, ctx| {
+            assert_eq!(model.selected_conversation_id(ctx), None);
+        });
+    });
+}
+
+#[test]
+fn tui_new_conversation_is_selected_and_terminal_surface_scoped() {
+    App::test((), |mut app| async move {
+        let (model, terminal_surface_id) = build_tui_context_model(&mut app);
+        let history = BlocklistAIHistoryModel::handle(&app);
+
+        let conversation_id = model
+            .update(&mut app, |model, ctx| {
+                model.try_start_new_conversation(AgentViewEntryOrigin::Cli, ctx)
+            })
+            .expect("TUI conversation creation should succeed");
+
+        model.read(&app, |model, ctx| {
+            assert_eq!(model.selected_conversation_id(ctx), Some(conversation_id));
+        });
+        history.read(&app, |history, _| {
+            assert_eq!(
+                history
+                    .all_live_conversations_for_terminal_surface(terminal_surface_id)
+                    .map(|conversation| conversation.id())
+                    .collect::<Vec<_>>(),
+                vec![conversation_id]
+            );
+        });
+    });
 }
 
 fn make_image_attachment(file_name: &str) -> PendingAttachment {
@@ -384,10 +566,8 @@ fn enqueue_moves_staged_attachments_onto_the_row_and_clears_input() {
     // staging and the drained set is stored on the queued row via `new_with_attachments`, leaving
     // no attachments behind in the input.
     App::test((), |mut app| async move {
-        initialize_history_persistence_for_tests(&mut app);
-        app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
-        let queued = app.add_singleton_model(QueuedQueryModel::new);
         let model = build_test_context_model(&mut app);
+        let queued = app.add_singleton_model(QueuedQueryModel::new);
         let conv = AIConversationId::new();
 
         model.update(&mut app, |m, _| {

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -30,16 +30,15 @@ use warpui::{AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonE
 
 use self::response_stream::{ResponseStream, ResponseStreamEvent};
 use super::action_model::{BlocklistAIActionEvent, BlocklistAIActionModel};
-use super::agent_view::{AgentViewController, AgentViewControllerEvent, AgentViewEntryOrigin};
 use super::context_model::{BlocklistAIContextModel, PendingAttachment, PendingFile};
+use super::conversation_selection::{ConversationSelectionEvent, ConversationSelectionHandle};
 use super::history_model::BlocklistAIHistoryModel;
-use super::input_model::InputConfig;
 use super::orchestration_event_streamer::{
     OrchestrationEventStreamer, OrchestrationEventStreamerEvent,
 };
 use super::orchestration_events::{OrchestrationEventService, OrchestrationEventServiceEvent};
 use super::queued_query::{QueuedQueryId, QueuedQueryModel};
-use super::{BlocklistAIInputModel, InputType, ResponseStreamId};
+use super::{BlocklistAIInputModel, ResponseStreamId};
 use crate::ai::agent::api::{self, ServerConversationToken};
 use crate::ai::agent::conversation::{AIConversation, AIConversationId, ConversationStatus};
 use crate::ai::agent::task::TaskId;
@@ -214,14 +213,14 @@ impl RequestInput {
         active_session: &ModelHandle<ActiveSession>,
         shared_session_response_initiator: Option<ParticipantId>,
         conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         app: &AppContext,
     ) -> Self {
         let mut me = Self::new_with_common_fields(
             conversation_id,
             active_session,
             shared_session_response_initiator,
-            terminal_view_id,
+            terminal_surface_id,
             app,
         );
         me.input_messages.insert(task_id, inputs);
@@ -234,14 +233,14 @@ impl RequestInput {
         active_session: &ModelHandle<ActiveSession>,
         shared_session_response_initiator: Option<ParticipantId>,
         conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         app: &AppContext,
     ) -> Self {
         let mut me = Self::new_with_common_fields(
             conversation_id,
             active_session,
             shared_session_response_initiator,
-            terminal_view_id,
+            terminal_surface_id,
             app,
         );
         for result in action_results.into_iter() {
@@ -269,24 +268,24 @@ impl RequestInput {
         conversation_id: AIConversationId,
         active_session: &ModelHandle<ActiveSession>,
         shared_session_response_initiator: Option<ParticipantId>,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         app: &AppContext,
     ) -> Self {
         let llm_prefs = LLMPreferences::as_ref(app);
         let model_id = llm_prefs
-            .get_active_base_model(app, Some(terminal_view_id))
+            .get_active_base_model(app, Some(terminal_surface_id))
             .id
             .clone();
         let coding_model_id = llm_prefs
-            .get_active_coding_model(app, Some(terminal_view_id))
+            .get_active_coding_model(app, Some(terminal_surface_id))
             .id
             .clone();
         let cli_agent_model_id = llm_prefs
-            .get_active_cli_agent_model(app, Some(terminal_view_id))
+            .get_active_cli_agent_model(app, Some(terminal_surface_id))
             .id
             .clone();
         let computer_use_model_id = llm_prefs
-            .get_active_computer_use_model(app, Some(terminal_view_id))
+            .get_active_computer_use_model(app, Some(terminal_surface_id))
             .id
             .clone();
         let working_directory = active_session
@@ -311,7 +310,7 @@ impl RequestInput {
 
 /// Controller for Blocklist AI.
 ///
-/// This is responsible for managing and updating blocklist AI state in a single terminal pane.
+/// This is responsible for managing and updating blocklist AI state for a single terminal surface.
 pub struct BlocklistAIController {
     active_session: ModelHandle<ActiveSession>,
     input_model: ModelHandle<BlocklistAIInputModel>,
@@ -321,8 +320,8 @@ pub struct BlocklistAIController {
 
     in_flight_response_streams: PendingResponseStreams,
 
-    /// The ID of the terminal view this controller is associated with.
-    terminal_view_id: EntityId,
+    /// The ID of the terminal surface this controller is associated with.
+    terminal_surface_id: EntityId,
 
     should_refresh_available_llms_on_stream_finish: bool,
 
@@ -377,11 +376,6 @@ enum WhichTask {
     },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum FollowUpTrigger {
-    Auto,
-    UserRequested,
-}
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum LocalClaudeWakeTrigger {
     PendingEvents,
@@ -428,15 +422,16 @@ impl BlocklistAIController {
         SessionContext::from_session(self.active_session.as_ref(ctx), ctx).skill_path_origin()
     }
 
+    /// Creates a controller for a terminal surface.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         input_model: ModelHandle<BlocklistAIInputModel>,
         context_model: ModelHandle<BlocklistAIContextModel>,
+        conversation_selection: ConversationSelectionHandle,
         action_model: ModelHandle<BlocklistAIActionModel>,
         active_session: ModelHandle<ActiveSession>,
-        agent_view_controller: ModelHandle<AgentViewController>,
         terminal_model: Arc<FairMutex<TerminalModel>>,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         ctx.subscribe_to_model(&action_model, move |me, _, event, ctx| {
@@ -540,7 +535,7 @@ impl BlocklistAIController {
                     };
                     history_model.update(ctx, |history_model, ctx| {
                         history_model.update_conversation_status(
-                            me.terminal_view_id,
+                            me.terminal_surface_id,
                             *conversation_id,
                             updated_conversation_status,
                             ctx,
@@ -549,46 +544,28 @@ impl BlocklistAIController {
                 }
                 return;
             }
-            let trigger = if has_manual_follow_up {
-                FollowUpTrigger::UserRequested
-            } else {
-                FollowUpTrigger::Auto
-            };
-            me.send_follow_up_for_conversation(*conversation_id, trigger, ctx);
+            me.send_follow_up_for_conversation(*conversation_id, ctx);
         });
 
-        ctx.subscribe_to_model(&agent_view_controller, |me, _, event, ctx| {
-            let AgentViewControllerEvent::ExitedAgentView {
+        ctx.subscribe_to_model(&conversation_selection, |me, _, event, ctx| {
+            let ConversationSelectionEvent::Deactivated {
                 conversation_id,
                 final_exchange_count,
                 is_exit_before_new_entrance,
-                ..
             } = event
             else {
                 return;
             };
-
-            // Skip if this exit is part of an in-place switch — cancelling here
-            // would kill an in-flight stream every time the user navigates.
-            if *is_exit_before_new_entrance {
+            if *is_exit_before_new_entrance || *final_exchange_count == 0 {
                 return;
             }
-
-            // If we exited a brand-new empty conversation, there's nothing meaningful to cancel.
-            if *final_exchange_count == 0 {
-                return;
-            }
-
             let history = BlocklistAIHistoryModel::handle(ctx);
             let Some(conversation) = history.as_ref(ctx).conversation(conversation_id) else {
                 return;
             };
-
-            // Viewer sessions should not send cancellations.
             if conversation.is_viewing_shared_session() {
                 return;
             }
-
             if conversation.status().is_in_progress() {
                 me.cancel_conversation_progress(
                     *conversation_id,
@@ -597,7 +574,6 @@ impl BlocklistAIController {
                 );
             }
         });
-
         // Subscribe to the orchestration event service to inject events
         // (e.g. MessagesReceivedFromAgents) into conversations that receive inter-agent messages.
         let svc = OrchestrationEventService::handle(ctx);
@@ -624,7 +600,7 @@ impl BlocklistAIController {
             active_session,
             terminal_model,
             in_flight_response_streams: PendingResponseStreams::new(),
-            terminal_view_id,
+            terminal_surface_id,
             should_refresh_available_llms_on_stream_finish: false,
             shared_session_state: shared_session::SharedSessionState::default(),
             ambient_agent_task_id: None,
@@ -680,7 +656,8 @@ impl BlocklistAIController {
             .unwrap_or_default();
 
         let ai_history_model = BlocklistAIHistoryModel::as_ref(ctx);
-        let active_conversation_id = ai_history_model.active_conversation_id(self.terminal_view_id);
+        let active_conversation_id =
+            ai_history_model.active_conversation_id(self.terminal_surface_id);
         let cancellation_reason = CancellationReason::FollowUpSubmitted {
             is_for_same_conversation: active_conversation_id
                 .is_some_and(|id| id == conversation_id),
@@ -840,7 +817,7 @@ impl BlocklistAIController {
                 &self.active_session,
                 self.get_current_response_initiator(),
                 conversation_id,
-                self.terminal_view_id,
+                self.terminal_surface_id,
                 ctx,
             ),
             Some(RequestMetadata {
@@ -848,7 +825,6 @@ impl BlocklistAIController {
                 entrypoint: entrypoint_type,
                 is_auto_resume_after_error: false,
             }),
-            /*default_to_follow_up_on_success*/ true,
             /*can_attempt_resume_on_error*/ true,
             is_queued_prompt,
             ctx,
@@ -1007,7 +983,7 @@ impl BlocklistAIController {
                 history_model.create_cli_subagent_task_for_conversation(
                     running_command.block_id.clone(),
                     conversation_id,
-                    self.terminal_view_id,
+                    self.terminal_surface_id,
                     ctx,
                 )
             }) {
@@ -1223,7 +1199,7 @@ impl BlocklistAIController {
                     history_model.create_cli_subagent_task_for_conversation(
                         running_command.block_id.clone(),
                         conversation_id,
-                        self.terminal_view_id,
+                        self.terminal_surface_id,
                         ctx,
                     )
                 }) {
@@ -1410,11 +1386,7 @@ impl BlocklistAIController {
             .as_ref(ctx)
             .get_finished_action_results(conversation_id);
         if finished_action_results.is_some_and(|results| !results.is_empty()) {
-            self.send_follow_up_for_conversation(
-                conversation_id,
-                FollowUpTrigger::UserRequested,
-                ctx,
-            );
+            self.send_follow_up_for_conversation(conversation_id, ctx);
         }
     }
 
@@ -1516,7 +1488,6 @@ impl BlocklistAIController {
     fn send_follow_up_for_conversation(
         &mut self,
         conversation_id: AIConversationId,
-        trigger: FollowUpTrigger,
         ctx: &mut ModelContext<Self>,
     ) {
         if self
@@ -1527,20 +1498,8 @@ impl BlocklistAIController {
         }
 
         BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
-            history.mark_active_conversation_id(conversation_id, self.terminal_view_id, ctx);
+            history.mark_active_conversation_id(conversation_id, self.terminal_surface_id, ctx);
         });
-
-        if !FeatureFlag::AgentView.is_enabled() && trigger == FollowUpTrigger::Auto {
-            // If `AgentView` is enabled, the conversation is guaranteed to be active while the
-            // conversation is in-progress and thus while actions are executing/finishing.
-            self.context_model.update(ctx, |context_model, ctx| {
-                context_model.set_pending_query_state_for_existing_conversation(
-                    conversation_id,
-                    AgentViewEntryOrigin::AutoFollowUp,
-                    ctx,
-                );
-            });
-        }
 
         let finished_results = self.action_model.update(ctx, |action_model, _| {
             action_model.drain_finished_action_results(conversation_id)
@@ -1574,7 +1533,7 @@ impl BlocklistAIController {
             &self.active_session,
             self.get_current_response_initiator(),
             conversation_id,
-            self.terminal_view_id,
+            self.terminal_surface_id,
             ctx,
         );
 
@@ -1609,7 +1568,6 @@ impl BlocklistAIController {
         let result = self.send_request_input(
             request_input,
             None,
-            /*default_to_follow_up_on_success*/ false,
             /*can_attempt_resume_on_error*/ true,
             /*is_queued_prompt*/ false,
             ctx,
@@ -1630,7 +1588,7 @@ impl BlocklistAIController {
         ctx: &ModelContext<Self>,
     ) -> bool {
         let owns = BlocklistAIHistoryModel::as_ref(ctx)
-            .all_live_conversations_for_terminal_view(self.terminal_view_id)
+            .all_live_conversations_for_terminal_surface(self.terminal_surface_id)
             .any(|conversation| conversation.id() == conversation_id);
         let has_active_stream = self
             .in_flight_response_streams
@@ -1761,7 +1719,7 @@ impl BlocklistAIController {
                             ctx,
                             |history_model, ctx| {
                                 history_model.update_conversation_status(
-                                    me.terminal_view_id,
+                                    me.terminal_surface_id,
                                     conversation_id,
                                     ConversationStatus::InProgress,
                                     ctx,
@@ -1876,11 +1834,10 @@ impl BlocklistAIController {
                     &self.active_session,
                     self.get_current_response_initiator(),
                     conversation_id,
-                    self.terminal_view_id,
+                    self.terminal_surface_id,
                     ctx,
                 ),
                 None,
-                /*default_to_follow_up_on_success*/ true,
                 /*can_attempt_resume_on_error*/ true,
                 /*is_queued_prompt*/ false,
                 ctx,
@@ -1998,11 +1955,10 @@ impl BlocklistAIController {
                 &self.active_session,
                 self.get_current_response_initiator(),
                 conversation_id,
-                self.terminal_view_id,
+                self.terminal_surface_id,
                 ctx,
             ),
             metadata,
-            /*default_to_follow_up_on_success*/ true,
             can_attempt_resume_on_error,
             /*is_queued_prompt*/ false,
             ctx,
@@ -2074,7 +2030,7 @@ impl BlocklistAIController {
                 &self.active_session,
                 self.get_current_response_initiator(),
                 new_conversation.id(),
-                self.terminal_view_id,
+                self.terminal_surface_id,
                 ctx,
             ),
             Some(RequestMetadata {
@@ -2085,7 +2041,6 @@ impl BlocklistAIController {
                 },
                 is_auto_resume_after_error: false,
             }),
-            /*default_to_follow_up_on_success=*/ false,
             /*can_attempt_resume_on_error*/ true,
             /*is_queued_prompt*/ false,
             ctx,
@@ -2187,7 +2142,7 @@ impl BlocklistAIController {
             &self.active_session,
             self.get_current_response_initiator(),
             conversation_id,
-            self.terminal_view_id,
+            self.terminal_surface_id,
             ctx,
         )
         .with_supported_tools(supported_tools);
@@ -2201,7 +2156,7 @@ impl BlocklistAIController {
         });
 
         let request_params = api::RequestParams::new(
-            Some(self.terminal_view_id),
+            Some(self.terminal_surface_id),
             SessionContext::from_session(self.active_session.as_ref(ctx), ctx),
             &request_input,
             conversation_data,
@@ -2241,7 +2196,7 @@ impl BlocklistAIController {
                 &self.active_session,
                 self.get_current_response_initiator(),
                 new_conversation.id(),
-                self.terminal_view_id,
+                self.terminal_surface_id,
                 ctx,
             ),
             Some(RequestMetadata {
@@ -2251,7 +2206,6 @@ impl BlocklistAIController {
                 },
                 is_auto_resume_after_error: false,
             }),
-            /*default_to_follow_up_on_success*/ false,
             /*can_attempt_resume_on_error*/ true,
             /*is_queued_prompt*/ false,
             ctx,
@@ -2293,7 +2247,7 @@ impl BlocklistAIController {
         let id = history_model.update(ctx, |history_model, ctx| {
             // We don't mark passive conversations as "the active conversation" (at least when they first appear).
             history_model.start_new_conversation(
-                self.terminal_view_id,
+                self.terminal_surface_id,
                 is_autoexecute_override,
                 false,
                 false,
@@ -2321,7 +2275,6 @@ impl BlocklistAIController {
         &mut self,
         request_input: RequestInput,
         query_metadata: Option<RequestMetadata>,
-        default_to_follow_up_on_success: bool,
         can_attempt_resume_on_error: bool,
         is_queued_prompt: bool,
         ctx: &mut ModelContext<Self>,
@@ -2438,7 +2391,7 @@ impl BlocklistAIController {
         }
 
         let mut request_params = api::RequestParams::new(
-            Some(self.terminal_view_id),
+            Some(self.terminal_surface_id),
             SessionContext::from_session(self.active_session.as_ref(ctx), ctx),
             &request_input,
             conversation_data.clone(),
@@ -2499,12 +2452,12 @@ impl BlocklistAIController {
             match history_model.update_conversation_for_new_request_input(
                 request_input,
                 response_stream_id.clone(),
-                self.terminal_view_id,
+                self.terminal_surface_id,
                 ctx,
             ) {
                 Ok(_) => {
                     history_model.update_conversation_status(
-                        self.terminal_view_id,
+                        self.terminal_surface_id,
                         conversation_data.id,
                         ConversationStatus::InProgress,
                         ctx,
@@ -2556,9 +2509,9 @@ impl BlocklistAIController {
             history_model.update(ctx, |history_model, ctx| {
                 history_model.mark_active_conversation_id(
                     conversation_data.id,
-                    self.terminal_view_id,
+                    self.terminal_surface_id,
                     ctx,
-                )
+                );
             });
         }
 
@@ -2566,29 +2519,6 @@ impl BlocklistAIController {
         // This ensures the agent view is restored if the app restarts.
         if input_contains_user_query {
             ctx.dispatch_global_action("workspace:save_app", ());
-        }
-
-        // If `AgentView` is enabled, the agent view is guaranteed to be active when the agent
-        // input is sent, so logic to ensure follow-ups is redundant.
-        if !FeatureFlag::AgentView.is_enabled() && default_to_follow_up_on_success {
-            // Set the input mode to AI but allow autodetection to run
-            self.input_model.update(ctx, |input_model, ctx| {
-                input_model.set_input_config_for_classic_mode(
-                    InputConfig {
-                        input_type: InputType::AI,
-                        is_locked: false,
-                    },
-                    ctx,
-                );
-            });
-            // After making an AI query, default to asking a follow up.
-            self.context_model.update(ctx, |context_model, ctx| {
-                context_model.set_pending_query_state_for_existing_conversation(
-                    conversation_data.id,
-                    AgentViewEntryOrigin::AutoFollowUp,
-                    ctx,
-                )
-            });
         }
 
         Ok((conversation_data.id, response_stream_id))
@@ -2673,7 +2603,7 @@ impl BlocklistAIController {
                 if is_recovering {
                     history_model.update(ctx, |history_model, ctx| {
                         history_model.update_conversation_status(
-                            self.terminal_view_id,
+                            self.terminal_surface_id,
                             conversation_id,
                             ConversationStatus::Cancelled,
                             ctx,
@@ -2781,7 +2711,7 @@ impl BlocklistAIController {
                                     history_model.initialize_output_for_response_stream(
                                         &stream_id,
                                         conversation_id,
-                                        self.terminal_view_id,
+                                        self.terminal_surface_id,
                                         init_event,
                                         ctx,
                                     );
@@ -2821,7 +2751,7 @@ impl BlocklistAIController {
                                             &stream_id,
                                             client_actions,
                                             conversation_id,
-                                            self.terminal_view_id,
+                                            self.terminal_surface_id,
                                             &skill_path_origin,
                                             ctx,
                                         )
@@ -2883,7 +2813,7 @@ impl BlocklistAIController {
                                 recovery_pending,
                                 &stream_id,
                                 conversation_id,
-                                self.terminal_view_id,
+                                self.terminal_surface_id,
                                 ctx,
                             );
                         });
@@ -2909,7 +2839,7 @@ impl BlocklistAIController {
                 };
                 BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
                     history_model.update_conversation_status(
-                        self.terminal_view_id,
+                        self.terminal_surface_id,
                         conversation_id,
                         status,
                         ctx,
@@ -2978,7 +2908,7 @@ impl BlocklistAIController {
                         history_model.mark_response_stream_cancelled(
                             &stream_id,
                             conversation_id,
-                            self.terminal_view_id,
+                            self.terminal_surface_id,
                             stream_cancellation.reason,
                             ctx,
                         );
@@ -3008,7 +2938,7 @@ impl BlocklistAIController {
                             /*recovery_pending*/ false,
                             &stream_id,
                             conversation_id,
-                            self.terminal_view_id,
+                            self.terminal_surface_id,
                             ctx,
                         );
                     });
@@ -3144,7 +3074,7 @@ impl BlocklistAIController {
                     history_model.mark_response_stream_completed_successfully(
                         stream_id,
                         conversation_id,
-                        self.terminal_view_id,
+                        self.terminal_surface_id,
                         ctx,
                     );
                 });
@@ -3162,7 +3092,7 @@ impl BlocklistAIController {
                         /*recovery_pending*/ false,
                         stream_id,
                         conversation_id,
-                        self.terminal_view_id,
+                        self.terminal_surface_id,
                         ctx,
                     );
                 });
@@ -3175,7 +3105,7 @@ impl BlocklistAIController {
                         /*recovery_pending*/ false,
                         stream_id,
                         conversation_id,
-                        self.terminal_view_id,
+                        self.terminal_surface_id,
                         ctx,
                     );
                 });
@@ -3189,7 +3119,7 @@ impl BlocklistAIController {
                         /*recovery_pending*/ false,
                         stream_id,
                         conversation_id,
-                        self.terminal_view_id,
+                        self.terminal_surface_id,
                         ctx,
                     );
                 });
@@ -3207,7 +3137,7 @@ impl BlocklistAIController {
                         /*recovery_pending*/ false,
                         stream_id,
                         conversation_id,
-                        self.terminal_view_id,
+                        self.terminal_surface_id,
                         ctx,
                     );
                 });
@@ -3245,7 +3175,7 @@ impl BlocklistAIController {
                         /*recovery_pending*/ false,
                         stream_id,
                         conversation_id,
-                        self.terminal_view_id,
+                        self.terminal_surface_id,
                         ctx,
                     );
                 });
@@ -3266,7 +3196,7 @@ impl BlocklistAIController {
                         /*recovery_pending*/ false,
                         stream_id,
                         conversation_id,
-                        self.terminal_view_id,
+                        self.terminal_surface_id,
                         ctx,
                     );
                 });
@@ -3279,7 +3209,7 @@ impl BlocklistAIController {
                         /*recovery_pending*/ false,
                         stream_id,
                         conversation_id,
-                        self.terminal_view_id,
+                        self.terminal_surface_id,
                         ctx,
                     );
                 });

--- a/app/src/ai/blocklist/controller/response_stream.rs
+++ b/app/src/ai/blocklist/controller/response_stream.rs
@@ -132,6 +132,17 @@ pub struct ResponseStream {
 }
 
 impl ResponseStream {
+    /// Emits a synthetic successful response event through the normal controller subscription.
+    #[cfg(test)]
+    pub fn emit_response_event_for_test(
+        &mut self,
+        event: warp_multi_agent_api::ResponseEvent,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        ctx.emit(ResponseStreamEvent::ReceivedEvent(Consumable::new(Ok(
+            event,
+        ))));
+    }
     #[cfg(test)]
     pub fn new_for_test(id: ResponseStreamId) -> Self {
         let (cancellation_tx, _rx) = oneshot::channel();

--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -116,7 +116,7 @@ impl BlocklistAIController {
         self.shared_session_state.current_response_id = None;
         self.shared_session_state
             .should_skip_current_replayed_response = false;
-        let terminal_view_id = self.terminal_view_id;
+        let terminal_surface_id = self.terminal_surface_id;
         let history = BlocklistAIHistoryModel::handle(ctx);
 
         // If the server conversation already exists locally (matched by server_conversation_token), reuse it.
@@ -161,7 +161,7 @@ impl BlocklistAIController {
             })
             .unwrap_or_else(|| {
                 history.update(ctx, |h, ctx| {
-                    h.start_new_conversation(terminal_view_id, false, true, false, ctx)
+                    h.start_new_conversation(terminal_surface_id, false, true, false, ctx)
                 })
             });
         if self.should_skip_replayed_response_for_existing_conversation(
@@ -205,30 +205,34 @@ impl BlocklistAIController {
                     &self.active_session,
                     self.get_current_response_initiator(),
                     conversation_id,
-                    self.terminal_view_id,
+                    self.terminal_surface_id,
                     ctx,
                 ),
                 stream_id.clone(),
-                self.terminal_view_id,
+                self.terminal_surface_id,
                 ctx,
             );
 
             history_model.initialize_output_for_response_stream(
                 &stream_id,
                 conversation_id,
-                self.terminal_view_id,
+                self.terminal_surface_id,
                 init_event.clone(),
                 ctx,
             );
 
             // Mark conversation as in progress and active/selected
             history_model.update_conversation_status(
-                self.terminal_view_id,
+                self.terminal_surface_id,
                 conversation_id,
                 ConversationStatus::InProgress,
                 ctx,
             );
-            history_model.set_active_conversation_id(conversation_id, self.terminal_view_id, ctx);
+            history_model.set_active_conversation_id(
+                conversation_id,
+                self.terminal_surface_id,
+                ctx,
+            );
         });
         self.context_model.update(ctx, |context_model, ctx| {
             context_model.set_pending_query_state_for_existing_conversation(
@@ -320,7 +324,7 @@ impl BlocklistAIController {
                 &stream_id,
                 actions.actions,
                 conversation_id,
-                self.terminal_view_id,
+                self.terminal_surface_id,
                 &skill_path_origin,
                 ctx,
             ) {
@@ -467,7 +471,7 @@ impl BlocklistAIController {
     }
 
     /// Finds an existing client conversation whose server_conversation_token matches `server_token`.
-    /// Searches only live conversations for this terminal view. Returns None if no match is found.
+    /// Searches only live conversations for this terminal surface. Returns None if no match is found.
     pub fn find_existing_conversation_by_server_token(
         &self,
         server_token: &str,
@@ -476,7 +480,7 @@ impl BlocklistAIController {
         let history = BlocklistAIHistoryModel::handle(ctx);
         history
             .as_ref(ctx)
-            .all_live_conversations_for_terminal_view(self.terminal_view_id)
+            .all_live_conversations_for_terminal_surface(self.terminal_surface_id)
             .find_map(|conv| {
                 conv.server_conversation_token()
                     .and_then(|t| (t.as_str() == server_token).then_some(conv.id()))
@@ -854,9 +858,7 @@ impl BlocklistAIController {
                     })
                     .or_else(|| {
                         self.context_model.update(ctx, |context_model, ctx| {
-                            context_model
-                                .try_enter_agent_view_for_new_conversation(origin, ctx)
-                                .ok()
+                            context_model.try_start_new_conversation(origin, ctx).ok()
                         })
                     })
                 else {

--- a/app/src/ai/blocklist/controller/slash_command.rs
+++ b/app/src/ai/blocklist/controller/slash_command.rs
@@ -127,7 +127,7 @@ impl SlashCommandRequest {
             return;
         }
         let active_conversation_id = BlocklistAIHistoryModel::as_ref(ctx)
-            .active_conversation_id(controller.terminal_view_id);
+            .active_conversation_id(controller.terminal_surface_id);
 
         // If no existing conversation, create a new one.
         // When AgentView is enabled, enter agent view which creates the conversation
@@ -136,7 +136,7 @@ impl SlashCommandRequest {
             if FeatureFlag::AgentView.is_enabled() {
                 controller.context_model.update(ctx, |context_model, ctx| {
                     context_model
-                        .try_enter_agent_view_for_new_conversation(
+                        .try_start_new_conversation(
                             AgentViewEntryOrigin::SlashCommand {
                                 trigger: SlashCommandTrigger::input(),
                             },
@@ -176,7 +176,7 @@ impl SlashCommandRequest {
             &controller.active_session,
             controller.get_current_response_initiator(),
             conversation_id,
-            controller.terminal_view_id,
+            controller.terminal_surface_id,
             ctx,
         );
         let model_id = request_input.model_id.clone();
@@ -188,7 +188,6 @@ impl SlashCommandRequest {
                 entrypoint,
                 is_auto_resume_after_error: false,
             }),
-            /*default_to_follow_up_on_success*/ true,
             /*can_attempt_resume_on_error*/ true,
             is_queued_prompt,
             ctx,

--- a/app/src/ai/blocklist/controller_tests.rs
+++ b/app/src/ai/blocklist/controller_tests.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
+use chrono::Local;
 use uuid::Uuid;
+use warp_multi_agent_api::response_event;
 use warpui::{App, SingletonEntity};
 
 use crate::ai::agent::conversation::AIConversationId;
@@ -10,7 +13,11 @@ use crate::ai::agent::{
     PassiveSuggestionTrigger, UserQueryMode,
 };
 use crate::ai::ambient_agents::AmbientAgentTaskId;
-use crate::ai::blocklist::{BlocklistAIHistoryModel, PendingAttachment, PendingFile};
+use crate::ai::blocklist::{
+    BlocklistAIHistoryEvent, BlocklistAIHistoryModel, PendingAttachment, PendingFile, RequestInput,
+    ResponseStream, ResponseStreamId,
+};
+use crate::ai::llms::LLMId;
 use crate::test_util::terminal::{add_window_with_terminal, initialize_app_for_terminal_view};
 
 fn new_ambient_agent_task_id() -> AmbientAgentTaskId {
@@ -201,5 +208,121 @@ fn cancelling_conversation_aborts_pending_auto_resume() {
                     .contains_key(&conversation_id));
             });
         });
+    });
+}
+
+#[test]
+fn mock_response_stream_updates_history_through_controller() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+        let captured_events = Arc::new(Mutex::new(Vec::new()));
+        let events_for_subscription = Arc::clone(&captured_events);
+        app.update(|ctx| {
+            ctx.subscribe_to_model(&BlocklistAIHistoryModel::handle(ctx), move |_, event, _| {
+                events_for_subscription.lock().unwrap().push(event.clone())
+            });
+        });
+
+        let (conversation_id, stream) = terminal.update(&mut app, |view, ctx| {
+            let terminal_surface_id = view.id();
+            let stream_id = ResponseStreamId::new_for_test();
+            let conversation_id =
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                    let conversation_id = history.start_new_conversation(
+                        terminal_surface_id,
+                        false,
+                        false,
+                        false,
+                        ctx,
+                    );
+                    let task_id = history
+                        .conversation(&conversation_id)
+                        .unwrap()
+                        .get_root_task_id()
+                        .clone();
+                    history
+                        .update_conversation_for_new_request_input(
+                            RequestInput {
+                                conversation_id,
+                                input_messages: HashMap::from([(task_id, vec![])]),
+                                working_directory: None,
+                                model_id: LLMId::from("test-model"),
+                                coding_model_id: LLMId::from("test-coding-model"),
+                                cli_agent_model_id: LLMId::from("test-cli-agent-model"),
+                                computer_use_model_id: LLMId::from("test-computer-use-model"),
+                                shared_session_response_initiator: None,
+                                request_start_ts: Local::now(),
+                                supported_tools_override: None,
+                            },
+                            stream_id.clone(),
+                            terminal_surface_id,
+                            ctx,
+                        )
+                        .unwrap();
+                    conversation_id
+                });
+            let stream = ctx.add_model(|_| ResponseStream::new_for_test(stream_id.clone()));
+            view.ai_controller().update(ctx, |controller, ctx| {
+                controller.register_mock_stream_for_test(
+                    stream_id,
+                    conversation_id,
+                    stream.clone(),
+                    ctx,
+                );
+            });
+            (conversation_id, stream)
+        });
+
+        stream.update(&mut app, |stream, ctx| {
+            stream.emit_response_event_for_test(
+                warp_multi_agent_api::ResponseEvent {
+                    r#type: Some(response_event::Type::Init(response_event::StreamInit {
+                        request_id: "test-request".to_string(),
+                        conversation_id: "test-server-conversation".to_string(),
+                        run_id: String::new(),
+                    })),
+                },
+                ctx,
+            );
+            stream.emit_response_event_for_test(
+                warp_multi_agent_api::ResponseEvent {
+                    r#type: Some(response_event::Type::Finished(
+                        response_event::StreamFinished {
+                            reason: Some(response_event::stream_finished::Reason::Done(
+                                response_event::stream_finished::Done {},
+                            )),
+                            conversation_usage_metadata: None,
+                            token_usage: vec![],
+                            should_refresh_model_config: false,
+                            request_cost: None,
+                        },
+                    )),
+                },
+                ctx,
+            );
+        });
+
+        BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
+            assert_eq!(
+                history.conversation(&conversation_id).map(|c| c.status()),
+                Some(&crate::ai::agent::conversation::ConversationStatus::Success)
+            );
+        });
+        let events = captured_events.lock().unwrap();
+        assert!(events.iter().any(|event| matches!(
+            event,
+            BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
+                conversation_id: id,
+                ..
+            } if *id == conversation_id
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            BlocklistAIHistoryEvent::UpdatedStreamingExchange {
+                conversation_id: id,
+                ..
+            } if *id == conversation_id
+        )));
     });
 }

--- a/app/src/ai/blocklist/conversation_selection.rs
+++ b/app/src/ai/blocklist/conversation_selection.rs
@@ -1,0 +1,116 @@
+//! Generic next-prompt conversation-selection behavior.
+
+use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
+
+use super::agent_view::{AgentViewEntryOrigin, EnterAgentViewError};
+use super::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
+use crate::ai::agent::conversation::{
+    AIConversation, AIConversationAutoexecuteMode, AIConversationId,
+};
+
+/// Handle to a terminal surface's conversation-selection implementation.
+pub type ConversationSelectionHandle = ModelHandle<Box<dyn ConversationSelection>>;
+
+/// The conversation targeted by the next query from a terminal surface.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum PendingQueryState {
+    /// The next query will continue an existing conversation.
+    Existing { conversation_id: AIConversationId },
+    New {
+        /// Autoexecute override for the new conversation to be started.
+        autoexecute_override: AIConversationAutoexecuteMode,
+    },
+}
+
+impl Default for PendingQueryState {
+    fn default() -> Self {
+        Self::New {
+            autoexecute_override: AIConversationAutoexecuteMode::default(),
+        }
+    }
+}
+
+/// Events emitted when a surface's conversation selection or presentation changes.
+#[derive(Clone, Debug)]
+pub enum ConversationSelectionEvent {
+    /// The conversation targeted by the next query or its configuration changed.
+    Changed,
+    /// The surface began presenting a selected conversation.
+    Activated {
+        is_fullscreen: bool,
+        origin: AgentViewEntryOrigin,
+    },
+    /// The surface stopped presenting a selected conversation.
+    Deactivated {
+        conversation_id: AIConversationId,
+        final_exchange_count: usize,
+        is_exit_before_new_entrance: bool,
+    },
+}
+/// Coordinates the next-query target and conversation presentation for one terminal surface.
+///
+/// A selected conversation receives the surface's next query; without one, the next query starts a
+/// new conversation. Implementations also describe whether that selection is actively presented
+/// and whether it occupies the full surface, without exposing surface-specific presentation state.
+pub trait ConversationSelection {
+    /// Returns the conversation targeted by the next query.
+    fn selected_conversation_id(&self, app: &AppContext) -> Option<AIConversationId>;
+
+    /// Returns whether this surface presents a selected conversation as active.
+    fn is_conversation_active(&self, app: &AppContext) -> bool;
+
+    /// Returns whether an active conversation occupies the entire terminal surface.
+    fn is_conversation_fullscreen(&self, app: &AppContext) -> bool;
+
+    /// Selects an existing conversation for the next query.
+    fn select_existing_conversation(
+        &mut self,
+        conversation_id: AIConversationId,
+        origin: AgentViewEntryOrigin,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    );
+
+    /// Selects the new-conversation state for the next query.
+    fn select_new_conversation(
+        &mut self,
+        origin: AgentViewEntryOrigin,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    );
+
+    /// Starts and selects a new conversation for this surface.
+    fn try_start_new_conversation(
+        &mut self,
+        origin: AgentViewEntryOrigin,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    ) -> Result<AIConversationId, EnterAgentViewError>;
+
+    /// Returns the autoexecute override for the pending query.
+    fn pending_query_autoexecute_override(&self, app: &AppContext)
+        -> AIConversationAutoexecuteMode;
+
+    /// Toggles the autoexecute override for the pending query.
+    fn toggle_pending_query_autoexecute(
+        &mut self,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    );
+
+    /// Reconciles selection after a terminal-surface-scoped history event.
+    fn handle_history_event(
+        &mut self,
+        event: &BlocklistAIHistoryEvent,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    );
+
+    /// Returns the selected conversation, if it is loaded.
+    fn selected_conversation<'a>(&self, app: &'a AppContext) -> Option<&'a AIConversation> {
+        self.selected_conversation_id(app)
+            .as_ref()
+            .and_then(|conversation_id| {
+                BlocklistAIHistoryModel::as_ref(app).conversation(conversation_id)
+            })
+    }
+}
+
+impl Entity for Box<dyn ConversationSelection> {
+    type Event = ConversationSelectionEvent;
+}

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -206,43 +206,41 @@ struct InFlightConversationRename {
 /// Responsible for managing the history of user and AI exchanges.
 #[derive(Default)]
 pub struct BlocklistAIHistoryModel {
-    /// A [`HashMap`] mapping [`crate::terminal::TerminalView`] [`EntityId`]s to a [`Vec`] of
-    /// live [`AIConversationId`] in that `TerminalView`.
+    /// Live conversations for each terminal surface.
     ///
-    /// "Live" conversations are still visible and in the terminal view and selectable in the session, so
-    /// clearing the blocklist removes the conversation from here.
-    ///
-    /// Note that when a terminal view is closed, we do not remove it from this map, so that it can be restored.
-    live_conversation_ids_for_terminal_view: HashMap<EntityId, Vec<AIConversationId>>,
+    /// "Live" conversations are still visible/selectable for that terminal surface. Clearing
+    /// a terminal surface moves those IDs out of this map, but closing a GUI view does not
+    /// immediately remove its entry so the conversations can be restored.
+    live_conversation_ids_for_terminal_surface: HashMap<EntityId, Vec<AIConversationId>>,
 
-    /// A [`HashMap`] mapping [`crate::terminal::TerminalView`] [`EntityId`]s to a [`Vec`] of
-    /// [`AIConversationId`] that were once live in that session, but were cleared from the blocklist.
+    /// Conversations that were once live for a terminal surface, but were cleared from the blocklist.
     ///
     /// This is used to preserve queries for up-arrow history after clearing the blocklist.
-    cleared_conversation_ids_for_terminal_view: HashMap<EntityId, Vec<AIConversationId>>,
+    cleared_conversation_ids_for_terminal_surface: HashMap<EntityId, Vec<AIConversationId>>,
 
     /// A [`HashMap`] mapping a [`AIConversationId`] to the [`AIConversation`] itself.
     /// Conversations may or may not be live in any open session. They will exist in this map if they
     /// have ever been loaded into memory.
     conversations_by_id: HashMap<AIConversationId, AIConversation>,
 
-    /// The active conversation ID for a given terminal view.
-    /// The active conversation is the one we're currently or have most recently streamed outputs for.
-    /// If you want to get the conversation the next query will follow up in / what is selected in the input selector,
-    /// use `context_model.selected_conversation_id` instead.
-    active_conversation_for_terminal_view: HashMap<EntityId, AIConversationId>,
+    /// The active conversation ID for a given terminal surface.
+    ///
+    /// The active conversation is the terminal surface's current or most recent progress
+    /// target, such as a response stream or follow-up action flow. Selection
+    /// lives in the surface's context/controller models.
+    active_conversation_for_terminal_surface: HashMap<EntityId, AIConversationId>,
 
-    /// The time at which each [`TerminalView`] was created. Note that this has no bearing on when
-    /// any [`AIConversation`]s take place in the terminal view.
-    terminal_view_created_at: HashMap<EntityId, DateTime<Local>>,
+    /// The time at which each terminal surface was created. Note that this
+    /// has no bearing on when any [`AIConversation`]s take place for that terminal surface.
+    terminal_surface_created_at: HashMap<EntityId, DateTime<Local>>,
 
-    /// A set of terminal views that are shared ambient agent sessions.
-    ambient_agent_terminal_view_ids: HashSet<EntityId>,
+    /// A set of terminal surfaces that are shared ambient agent sessions.
+    ambient_agent_terminal_surface_ids: HashSet<EntityId>,
 
-    /// A set of terminal views that are read-only conversation transcript viewers.
+    /// A set of terminal surfaces that are read-only conversation transcript viewers.
     /// This is view/UI state (not conversation state) and is used to filter transcript viewer
     /// conversations out of local history and navigation.
-    conversation_transcript_viewer_terminal_view_ids: HashSet<EntityId>,
+    conversation_transcript_viewer_terminal_surface_ids: HashSet<EntityId>,
 
     /// AI queries that were read from the SQLite DB. These exchanges do not contain as much
     /// information as the other exchanges we store because they are only used for display in
@@ -312,14 +310,14 @@ impl BlocklistAIHistoryModel {
         Self::default()
     }
 
-    /// Returns a flattened and ordered (oldest first) list of live conversations (not cleared) for the given terminal view ID.
-    /// This works for terminal views that have been closed.
-    pub fn all_live_conversations_for_terminal_view(
+    /// Returns a flattened and ordered (oldest first) list of live conversations for a terminal surface.
+    /// This works for terminal surfaces that have been closed.
+    pub fn all_live_conversations_for_terminal_surface(
         &self,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
     ) -> impl Iterator<Item = &AIConversation> {
-        self.live_conversation_ids_for_terminal_view
-            .get(&terminal_view_id)
+        self.live_conversation_ids_for_terminal_surface
+            .get(&terminal_surface_id)
             .into_iter()
             .flat_map(|conversation_ids| {
                 conversation_ids
@@ -328,15 +326,14 @@ impl BlocklistAIHistoryModel {
             })
     }
 
-    /// Returns a flattened and ordered (oldest first) list of exchanges from live conversations (not cleared)
-    /// in the given terminal view ID.
-    /// This works for terminal views that have been closed.
-    pub fn all_live_root_task_exchanges_for_terminal_view(
+    /// Returns a flattened and ordered (oldest first) list of exchanges from a terminal surface's live conversations.
+    /// This works for terminal surfaces that have been closed.
+    pub fn all_live_root_task_exchanges_for_terminal_surface(
         &self,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
     ) -> impl Iterator<Item = &AIAgentExchange> {
-        self.live_conversation_ids_for_terminal_view
-            .get(&terminal_view_id)
+        self.live_conversation_ids_for_terminal_surface
+            .get(&terminal_surface_id)
             .into_iter()
             .flat_map(|conversation_ids| {
                 conversation_ids.iter().flat_map(|conversation_id| {
@@ -349,13 +346,13 @@ impl BlocklistAIHistoryModel {
     }
 
     /// Returns a flattened and ordered (oldest first) list of exchanges from conversations
-    /// that were cleared in the given terminal view ID, but are no longer live/visible.
-    pub fn all_cleared_root_task_exchanges_for_terminal_view(
+    /// that were cleared for a terminal surface, but are no longer live/visible.
+    pub fn all_cleared_root_task_exchanges_for_terminal_surface(
         &self,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
     ) -> impl Iterator<Item = &AIAgentExchange> {
-        self.cleared_conversation_ids_for_terminal_view
-            .get(&terminal_view_id)
+        self.cleared_conversation_ids_for_terminal_surface
+            .get(&terminal_surface_id)
             .into_iter()
             .flat_map(|conversation_ids| {
                 conversation_ids.iter().flat_map(|conversation_id| {
@@ -367,31 +364,30 @@ impl BlocklistAIHistoryModel {
             .flatten()
     }
 
-    /// Returns a list of all conversations that have been cleared across all terminal views.
+    /// Returns a list of all conversations that have been cleared across all terminal surfaces.
     pub fn all_cleared_conversations(&self) -> Vec<(EntityId, &AIConversation)> {
-        self.cleared_conversation_ids_for_terminal_view
+        self.cleared_conversation_ids_for_terminal_surface
             .iter()
-            .flat_map(|(terminal_view_id, conversation_ids)| {
+            .flat_map(|(terminal_surface_id, conversation_ids)| {
                 conversation_ids.iter().filter_map(|conversation_id| {
                     self.conversations_by_id
                         .get(conversation_id)
-                        .map(|conversation| (*terminal_view_id, conversation))
+                        .map(|conversation| (*terminal_surface_id, conversation))
                 })
             })
             .collect::<Vec<_>>()
     }
 
-    /// Returns a list of all live (not cleared) conversations across all terminal views,
-    /// paired with the terminal view ID they belong to.
-    /// This includes terminal views that have been closed.
+    /// Returns all live conversations paired with their terminal surface IDs.
+    /// This includes terminal surfaces that have been closed.
     pub fn all_live_conversations(&self) -> Vec<(EntityId, &AIConversation)> {
-        self.live_conversation_ids_for_terminal_view
+        self.live_conversation_ids_for_terminal_surface
             .iter()
-            .flat_map(|(terminal_view_id, conversation_ids)| {
+            .flat_map(|(terminal_surface_id, conversation_ids)| {
                 conversation_ids.iter().filter_map(|conversation_id| {
                     self.conversations_by_id
                         .get(conversation_id)
-                        .map(|conversation| (*terminal_view_id, conversation))
+                        .map(|conversation| (*terminal_surface_id, conversation))
                 })
             })
             .collect::<Vec<_>>()
@@ -468,7 +464,7 @@ impl BlocklistAIHistoryModel {
     /// Creates a new child agent conversation.
     pub fn start_new_child_conversation(
         &mut self,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         name: String,
         parent_conversation_id: AIConversationId,
         orchestration_harness: Option<Harness>,
@@ -486,7 +482,7 @@ impl BlocklistAIHistoryModel {
 
         let auto_execute = true; // Child auto-executes by default.
         let conversation_id =
-            self.start_new_conversation(terminal_view_id, auto_execute, false, false, ctx);
+            self.start_new_conversation(terminal_surface_id, auto_execute, false, false, ctx);
         {
             let conversation = self
                 .conversation_mut(&conversation_id)
@@ -640,7 +636,7 @@ impl BlocklistAIHistoryModel {
             return;
         };
 
-        let terminal_view_id = self.terminal_view_id_for_conversation(&conversation_id);
+        let terminal_surface_id = self.terminal_surface_id_for_conversation(&conversation_id);
 
         let mut updated = false;
         if let Some(conversation) = self.conversations_by_id.get_mut(&conversation_id) {
@@ -677,7 +673,7 @@ impl BlocklistAIHistoryModel {
         }
 
         ctx.emit(BlocklistAIHistoryEvent::UpdatedConversationTitle {
-            terminal_view_id,
+            terminal_surface_id,
             conversation_id,
             title,
         });
@@ -690,7 +686,7 @@ impl BlocklistAIHistoryModel {
         title: String,
         ctx: &mut ModelContext<Self>,
     ) {
-        let terminal_view_id = self.terminal_view_id_for_conversation(&conversation_id);
+        let terminal_surface_id = self.terminal_surface_id_for_conversation(&conversation_id);
 
         let mut updated = false;
         if let Some(conversation) = self.conversations_by_id.get_mut(&conversation_id) {
@@ -715,7 +711,7 @@ impl BlocklistAIHistoryModel {
         }
 
         ctx.emit(BlocklistAIHistoryEvent::UpdatedConversationTitle {
-            terminal_view_id,
+            terminal_surface_id,
             conversation_id,
             title,
         });
@@ -831,15 +827,15 @@ impl BlocklistAIHistoryModel {
             return;
         }
         self.persist_conversation_state(conversation_id, ctx);
-        let terminal_view_id = self.terminal_view_id_for_conversation(&conversation_id);
+        let terminal_surface_id = self.terminal_surface_id_for_conversation(&conversation_id);
         ctx.emit(BlocklistAIHistoryEvent::UpdatedConversationMetadata {
-            terminal_view_id,
+            terminal_surface_id,
             conversation_id,
         });
-        if let Some(terminal_view_id) = terminal_view_id {
+        if let Some(terminal_surface_id) = terminal_surface_id {
             ctx.emit(BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
                 conversation_id,
-                terminal_view_id,
+                terminal_surface_id,
             });
         }
     }
@@ -853,12 +849,12 @@ impl BlocklistAIHistoryModel {
         metadata: ServerAIConversationMetadata,
         ctx: &mut ModelContext<Self>,
     ) {
-        let terminal_view_id;
+        let terminal_surface_id;
 
         // Update in-memory conversation if it exists
         if let Some(conversation) = self.conversations_by_id.get_mut(&conversation_id) {
             conversation.set_server_metadata(metadata);
-            terminal_view_id = self.terminal_view_id_for_conversation(&conversation_id);
+            terminal_surface_id = self.terminal_surface_id_for_conversation(&conversation_id);
         } else if let Some(conversation_metadata) =
             self.all_conversations_metadata.get_mut(&conversation_id)
         {
@@ -866,7 +862,7 @@ impl BlocklistAIHistoryModel {
             // This is needed because we might update permissions from share dialog in
             // conversation list view when we only have metadata.
             conversation_metadata.server_conversation_metadata = Some(metadata);
-            terminal_view_id = None;
+            terminal_surface_id = None;
         } else {
             // Conversation not found anywhere
             return;
@@ -874,7 +870,7 @@ impl BlocklistAIHistoryModel {
 
         // Emit event so sharing dialog and other listeners can refresh.
         ctx.emit(BlocklistAIHistoryEvent::UpdatedConversationMetadata {
-            terminal_view_id,
+            terminal_surface_id,
             conversation_id,
         });
     }
@@ -908,26 +904,25 @@ impl BlocklistAIHistoryModel {
             .map(|conversation| conversation.status())
     }
 
-    /// Returns the terminal view ID that owns the given conversation, if any.
-    pub fn terminal_view_id_for_conversation(
+    /// Returns the terminal surface ID for the given conversation, if any.
+    pub fn terminal_surface_id_for_conversation(
         &self,
         conversation_id: &AIConversationId,
     ) -> Option<EntityId> {
-        self.live_conversation_ids_for_terminal_view
+        self.live_conversation_ids_for_terminal_surface
             .iter()
             .find(|(_, conversation_ids)| conversation_ids.contains(conversation_id))
-            .map(|(terminal_view_id, _)| *terminal_view_id)
+            .map(|(terminal_surface_id, _)| *terminal_surface_id)
     }
 
-    /// Returns the conversation ID from the terminal view's history corresponding to the action,
-    /// if any.
+    /// Returns the conversation ID from the terminal surface's history corresponding to the action, if any.
     pub fn conversation_id_for_action(
         &self,
         action_id: &AIAgentActionId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
     ) -> Option<AIConversationId> {
-        self.live_conversation_ids_for_terminal_view
-            .get(&terminal_view_id)?
+        self.live_conversation_ids_for_terminal_surface
+            .get(&terminal_surface_id)?
             .iter()
             .rev()
             .find(|conversation_id| {
@@ -950,8 +945,8 @@ impl BlocklistAIHistoryModel {
     /// The active conversation is the one we're currently or have most recently streamed outputs for.
     /// If you want to get the conversation the next query will follow up in / what is selected in the input selector,
     /// use `context_model.selected_conversation` instead.
-    pub fn active_conversation(&self, terminal_view_id: EntityId) -> Option<&AIConversation> {
-        self.active_conversation_id(terminal_view_id)
+    pub fn active_conversation(&self, terminal_surface_id: EntityId) -> Option<&AIConversation> {
+        self.active_conversation_id(terminal_surface_id)
             .and_then(|id| self.conversation(&id))
     }
 
@@ -977,7 +972,7 @@ impl BlocklistAIHistoryModel {
         &mut self,
         request_input: RequestInput,
         stream_id: ResponseStreamId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) -> Result<(), UpdateHistoryError> {
         let conversation = self
@@ -989,7 +984,7 @@ impl BlocklistAIHistoryModel {
         conversation.update_for_new_request_input(
             request_input,
             stream_id,
-            terminal_view_id,
+            terminal_surface_id,
             ctx,
         )?;
         Ok(())
@@ -997,20 +992,20 @@ impl BlocklistAIHistoryModel {
 
     pub fn restore_conversations(
         &mut self,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         conversations: Vec<AIConversation>,
         ctx: &mut ModelContext<Self>,
     ) {
-        self.terminal_view_created_at
-            .insert(terminal_view_id, Local::now());
+        self.terminal_surface_created_at
+            .insert(terminal_surface_id, Local::now());
 
         let mut conversation_ids = Vec::new();
         for conversation in conversations.into_iter() {
             let conversation_id = conversation.id();
             conversation_ids.push(conversation_id);
             let live_conversation_ids = self
-                .live_conversation_ids_for_terminal_view
-                .entry(terminal_view_id)
+                .live_conversation_ids_for_terminal_surface
+                .entry(terminal_surface_id)
                 .or_default();
             if !live_conversation_ids.contains(&conversation_id) {
                 live_conversation_ids.push(conversation_id);
@@ -1041,124 +1036,127 @@ impl BlocklistAIHistoryModel {
             // the workspace can set tab indicators appropriately
             ctx.emit(BlocklistAIHistoryEvent::UpdatedConversationStatus {
                 conversation_id,
-                terminal_view_id,
+                terminal_surface_id,
                 update: ConversationStatusUpdate::Restored,
                 new_status,
             });
         }
 
-        // Emit event so AI document views can populate their terminal view references
+        // Emit event so consumers can populate their associated view references.
         ctx.emit(BlocklistAIHistoryEvent::RestoredConversations {
-            terminal_view_id,
+            terminal_surface_id,
             conversation_ids,
         });
     }
 
-    /// Sets the active conversation ID for a terminal view and transfers ownership
-    /// from any other terminal view that currently holds it.
+    /// Sets the active conversation ID for a terminal surface and moves the conversation
+    /// from any other terminal surface that currently contains it.
     ///
     /// For automatic follow-ups and request-stream bookkeeping, use
     /// [`Self::mark_active_conversation_id`] instead.
     pub fn set_active_conversation_id(
         &mut self,
         conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) {
         if !self
-            .live_conversation_ids_for_terminal_view
-            .get(&terminal_view_id)
+            .live_conversation_ids_for_terminal_surface
+            .get(&terminal_surface_id)
             .is_some_and(|conversation_ids| conversation_ids.contains(&conversation_id))
         {
             log::error!(
-                "Attempted to set active conversation ID for terminal view ID that does not own that conversation."
+                "Attempted to set active conversation ID for a terminal surface that does not contain that conversation."
             );
             return;
         }
 
-        // Track previous owners we removed the conversation from so we can
-        // emit ownership-transfer events outside of the borrow of
-        // `live_conversation_ids_for_terminal_view`. The conversation rendering
-        // model assumes a single canonical owner per conversation, so each
-        // previous owner needs a chance to drop its now-stale rendered AI
+        // Track previous terminal surfaces we removed the conversation from so we can
+        // emit terminal-surface-transfer events outside of the borrow of
+        // `live_conversation_ids_for_terminal_surface`. The conversation rendering
+        // model assumes a single canonical terminal surface per conversation, so each
+        // previous terminal surface needs a chance to drop its now-stale rendered AI
         // blocks.
-        let mut previous_owners: Vec<EntityId> = Vec::new();
-        for (other_terminal_view, other_terminal_view_live_conversation_ids) in self
-            .live_conversation_ids_for_terminal_view
+        let mut previous_terminal_surfaces: Vec<EntityId> = Vec::new();
+        for (other_terminal_surface, other_terminal_surface_live_conversation_ids) in self
+            .live_conversation_ids_for_terminal_surface
             .iter_mut()
-            .filter(|(other_terminal_view_id, _)| **other_terminal_view_id != terminal_view_id)
+            .filter(|(other_terminal_surface_id, _)| {
+                **other_terminal_surface_id != terminal_surface_id
+            })
         {
-            let previous_len = other_terminal_view_live_conversation_ids.len();
-            other_terminal_view_live_conversation_ids.retain(|id| *id != conversation_id);
-            if other_terminal_view_live_conversation_ids.len() != previous_len {
-                previous_owners.push(*other_terminal_view);
+            let previous_len = other_terminal_surface_live_conversation_ids.len();
+            other_terminal_surface_live_conversation_ids.retain(|id| *id != conversation_id);
+            if other_terminal_surface_live_conversation_ids.len() != previous_len {
+                previous_terminal_surfaces.push(*other_terminal_surface);
             }
 
             if self
-                .active_conversation_for_terminal_view
-                .get(other_terminal_view)
+                .active_conversation_for_terminal_surface
+                .get(other_terminal_surface)
                 .is_some_and(|id| *id == conversation_id)
             {
-                self.active_conversation_for_terminal_view
-                    .remove(other_terminal_view);
+                self.active_conversation_for_terminal_surface
+                    .remove(other_terminal_surface);
                 ctx.emit(BlocklistAIHistoryEvent::ClearedActiveConversation {
                     conversation_id,
-                    terminal_view_id: *other_terminal_view,
+                    terminal_surface_id: *other_terminal_surface,
                 });
             }
         }
-        for previous_terminal_view_id in previous_owners {
-            ctx.emit(BlocklistAIHistoryEvent::ConversationOwnershipTransferred {
-                conversation_id,
-                previous_terminal_view_id,
-                new_terminal_view_id: terminal_view_id,
-            });
+        for previous_terminal_surface_id in previous_terminal_surfaces {
+            ctx.emit(
+                BlocklistAIHistoryEvent::ConversationTransferredBetweenTerminalSurfaces {
+                    conversation_id,
+                    previous_terminal_surface_id,
+                    new_terminal_surface_id: terminal_surface_id,
+                },
+            );
         }
 
-        self.active_conversation_for_terminal_view
-            .insert(terminal_view_id, conversation_id);
+        self.active_conversation_for_terminal_surface
+            .insert(terminal_surface_id, conversation_id);
 
         ctx.emit(BlocklistAIHistoryEvent::SetActiveConversation {
             conversation_id,
-            terminal_view_id,
+            terminal_surface_id,
         });
     }
 
-    /// Marks a conversation as the active conversation for a terminal view
-    /// without removing it from other views.
+    /// Marks a conversation as active for a terminal surface without removing it from other terminal surfaces.
     ///
     /// This is the non-transferring counterpart to [`Self::set_active_conversation_id`].
     /// Use this during automatic follow-ups and request sending where the
-    /// conversation already belongs to this view and we only need to update
+    /// conversation already belongs to this terminal surface and we only need to update
     /// the "most recently streamed" pointer.
     pub fn mark_active_conversation_id(
         &mut self,
         conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) {
         if !self
-            .live_conversation_ids_for_terminal_view
-            .get(&terminal_view_id)
+            .live_conversation_ids_for_terminal_surface
+            .get(&terminal_surface_id)
             .is_some_and(|conversation_ids| conversation_ids.contains(&conversation_id))
         {
             log::warn!(
                 "mark_active_conversation_id: conversation {conversation_id:?} is not in \
-                 terminal view {terminal_view_id:?} live list, skipping"
+                 terminal surface {terminal_surface_id:?} live list, skipping"
             );
             return;
         }
 
-        self.active_conversation_for_terminal_view
-            .insert(terminal_view_id, conversation_id);
+        self.active_conversation_for_terminal_surface
+            .insert(terminal_surface_id, conversation_id);
 
         ctx.emit(BlocklistAIHistoryEvent::SetActiveConversation {
             conversation_id,
-            terminal_view_id,
+            terminal_surface_id,
         });
     }
 
-    /// Starts a new conversation in the given terminal view's history, effectively marking the
+    /// Starts a new conversation in the given terminal surface's history, effectively marking the
     /// existing conversation (if any) as completed.
     ///
     /// Returns the ID of the created conversation.
@@ -1167,7 +1165,7 @@ impl BlocklistAIHistoryModel {
     /// element in the `conversations` vector.
     pub fn start_new_conversation(
         &mut self,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         is_autoexecute_override: bool,
         is_viewing_shared_session: bool,
         is_cli_agent_transcript: bool,
@@ -1179,8 +1177,8 @@ impl BlocklistAIHistoryModel {
             new_conversation.toggle_autoexecute_override();
         }
         let new_conversation_id = new_conversation.id();
-        self.live_conversation_ids_for_terminal_view
-            .entry(terminal_view_id)
+        self.live_conversation_ids_for_terminal_surface
+            .entry(terminal_surface_id)
             .or_default()
             .push(new_conversation_id);
         self.conversations_by_id
@@ -1188,7 +1186,7 @@ impl BlocklistAIHistoryModel {
 
         ctx.emit(BlocklistAIHistoryEvent::StartedNewConversation {
             new_conversation_id,
-            terminal_view_id,
+            terminal_surface_id,
         });
 
         new_conversation_id
@@ -1198,25 +1196,25 @@ impl BlocklistAIHistoryModel {
         &mut self,
         block_id: BlockId,
         conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) -> Result<TaskId, UpdateHistoryError> {
         let conversation = self
             .conversations_by_id
             .get_mut(&conversation_id)
             .ok_or(UpdateHistoryError::ConversationNotFound(conversation_id))?;
-        Ok(conversation.create_optimistic_cli_subagent_task(&block_id, terminal_view_id, ctx))
+        Ok(conversation.create_optimistic_cli_subagent_task(&block_id, terminal_surface_id, ctx))
     }
 
     pub fn update_conversation_status(
         &mut self,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         conversation_id: AIConversationId,
         status: ConversationStatus,
         ctx: &mut ModelContext<Self>,
     ) {
         self.update_conversation_status_with_error_message(
-            terminal_view_id,
+            terminal_surface_id,
             conversation_id,
             status,
             None,
@@ -1226,7 +1224,7 @@ impl BlocklistAIHistoryModel {
 
     pub fn update_conversation_status_with_error_message(
         &mut self,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         conversation_id: AIConversationId,
         status: ConversationStatus,
         error_message: Option<String>,
@@ -1236,7 +1234,7 @@ impl BlocklistAIHistoryModel {
             conversation.update_status_with_error_message(
                 status,
                 error_message,
-                terminal_view_id,
+                terminal_surface_id,
                 ctx,
             );
         }
@@ -1245,10 +1243,10 @@ impl BlocklistAIHistoryModel {
     pub fn on_forked_conversation(
         &mut self,
         conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) {
-        // When a conversation is forked and restored into a new terminal view,
+        // When a conversation is forked and restored for a new terminal surface,
         // we want to emit UpdatedStreamingExchange events for every exchange
         // to ensure that all of the existing exchanges are persisted correctly.
         if let Some(conversation) = self.conversations_by_id.get(&conversation_id) {
@@ -1256,7 +1254,7 @@ impl BlocklistAIHistoryModel {
                 let is_hidden = conversation.is_exchange_hidden(exchange.id);
                 ctx.emit(BlocklistAIHistoryEvent::UpdatedStreamingExchange {
                     exchange_id: exchange.id,
-                    terminal_view_id,
+                    terminal_surface_id,
                     conversation_id,
                     is_hidden,
                 });
@@ -1268,7 +1266,7 @@ impl BlocklistAIHistoryModel {
         &mut self,
         stream_id: &ResponseStreamId,
         conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         init_event: warp_multi_agent_api::response_event::StreamInit,
         ctx: &mut ModelContext<Self>,
     ) {
@@ -1280,7 +1278,7 @@ impl BlocklistAIHistoryModel {
             if let Err(e) = conversation.initialize_output_for_response_stream(
                 stream_id,
                 init_event,
-                terminal_view_id,
+                terminal_surface_id,
                 ctx,
             ) {
                 log::warn!("Failed to update conversation with updated streamed output: {e}");
@@ -1307,7 +1305,7 @@ impl BlocklistAIHistoryModel {
         if should_emit_server_token_assigned {
             ctx.emit(BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
                 conversation_id,
-                terminal_view_id,
+                terminal_surface_id,
             });
         }
     }
@@ -1321,7 +1319,7 @@ impl BlocklistAIHistoryModel {
         conversation_id: AIConversationId,
         run_id: String,
         task_id: Option<crate::ai::ambient_agents::AmbientAgentTaskId>,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) {
         let (agent_key, server_token) = {
@@ -1353,7 +1351,7 @@ impl BlocklistAIHistoryModel {
         self.persist_conversation_state(conversation_id, ctx);
         ctx.emit(BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
             conversation_id,
-            terminal_view_id,
+            terminal_surface_id,
         });
     }
 
@@ -1377,7 +1375,7 @@ impl BlocklistAIHistoryModel {
         old_conversation_id: AIConversationId,
         response_stream_id: &ResponseStreamId,
         start_from_message_id: MessageId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) -> Result<AIConversationId, UpdateHistoryError> {
         let exchange_ids_to_transfer: Vec<AIAgentExchangeId> = self
@@ -1403,7 +1401,7 @@ impl BlocklistAIHistoryModel {
         );
 
         let new_conversation_id =
-            self.start_new_conversation(terminal_view_id, false, false, false, ctx);
+            self.start_new_conversation(terminal_surface_id, false, false, false, ctx);
         for exchange_id in exchange_ids_to_transfer {
             let old_conversation = self
                 .conversations_by_id
@@ -1422,7 +1420,7 @@ impl BlocklistAIHistoryModel {
             new_conversation.append_reassigned_exchange(
                 response_stream_id,
                 exchange,
-                terminal_view_id,
+                terminal_surface_id,
                 ctx,
             )?;
         }
@@ -1436,14 +1434,14 @@ impl BlocklistAIHistoryModel {
             ))?;
         old_conversation.mark_completed_after_successful_split(
             response_stream_id,
-            terminal_view_id,
+            terminal_surface_id,
             ctx,
         )?;
 
-        self.set_active_conversation_id(new_conversation_id, terminal_view_id, ctx);
+        self.set_active_conversation_id(new_conversation_id, terminal_surface_id, ctx);
 
         ctx.emit(BlocklistAIHistoryEvent::SplitConversation {
-            terminal_view_id,
+            terminal_surface_id,
             old_conversation_id,
             new_conversation_id,
         });
@@ -1718,7 +1716,7 @@ impl BlocklistAIHistoryModel {
         response_stream_id: &ResponseStreamId,
         client_actions: Vec<warp_multi_agent_api::ClientAction>,
         conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         skill_path_origin: &SkillPathOrigin,
         ctx: &mut ModelContext<Self>,
     ) -> Result<(), UpdateHistoryError> {
@@ -1732,7 +1730,7 @@ impl BlocklistAIHistoryModel {
                         current_conversation_id,
                         response_stream_id,
                         MessageId::new(start_from_message_id),
-                        terminal_view_id,
+                        terminal_surface_id,
                         ctx,
                     )?;
                     current_conversation_id = new_conversation_id;
@@ -1746,7 +1744,7 @@ impl BlocklistAIHistoryModel {
                     ))?;
                     conversation.apply_client_action(
                         response_stream_id,
-                        terminal_view_id,
+                        terminal_surface_id,
                         action,
                         skill_path_origin,
                         ctx,
@@ -1802,13 +1800,13 @@ impl BlocklistAIHistoryModel {
         &mut self,
         stream_id: &ResponseStreamId,
         conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) {
         let Some(conversation) = self.conversations_by_id.get_mut(&conversation_id) else {
             return;
         };
-        if let Err(e) = conversation.mark_request_completed(stream_id, terminal_view_id, ctx) {
+        if let Err(e) = conversation.mark_request_completed(stream_id, terminal_surface_id, ctx) {
             log::warn!("Failed to mark exchange as completed: {e}");
         }
 
@@ -1873,19 +1871,19 @@ impl BlocklistAIHistoryModel {
         &mut self,
         stream_id: &ResponseStreamId,
         conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         reason: CancellationReason,
         ctx: &mut ModelContext<Self>,
     ) {
         if let Some(conversation) = self.conversations_by_id.get_mut(&conversation_id) {
             if reason.is_reverted() {
                 if let Err(e) =
-                    conversation.mark_request_cancelled_due_to_revert(terminal_view_id, ctx)
+                    conversation.mark_request_cancelled_due_to_revert(terminal_surface_id, ctx)
                 {
                     log::warn!("Failed to mark exchange as cancelled: {e}");
                 }
             } else if let Err(e) =
-                conversation.mark_request_cancelled(stream_id, terminal_view_id, reason, ctx)
+                conversation.mark_request_cancelled(stream_id, terminal_surface_id, reason, ctx)
             {
                 log::warn!("Failed to mark exchange as cancelled: {e}");
             }
@@ -1902,7 +1900,7 @@ impl BlocklistAIHistoryModel {
         recovery_pending: bool,
         stream_id: &ResponseStreamId,
         conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) {
         if let Some(conversation) = self.conversations_by_id.get_mut(&conversation_id) {
@@ -1910,7 +1908,7 @@ impl BlocklistAIHistoryModel {
                 stream_id,
                 error.clone(),
                 recovery_pending,
-                terminal_view_id,
+                terminal_surface_id,
                 ctx,
             ) {
                 log::warn!("Failed to mark exchange as completed with error: {e}");
@@ -1918,41 +1916,31 @@ impl BlocklistAIHistoryModel {
         }
     }
 
-    /// Handle clearing the blocklist for the terminal view.
-    /// The terminal view will also cancel the active stream on processing the event emitted here.
-    pub(crate) fn clear_conversations_in_terminal_view(
+    /// Handle clearing the blocklist for a terminal surface.
+    /// The terminal surface will also cancel the active stream on processing the event emitted here.
+    pub(crate) fn clear_conversations_for_terminal_surface(
         &mut self,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) {
-        // Cancel the active stream when we clear conversations in this terminal view.
+        // Cancel the active stream when we clear conversations for this terminal surface.
         let active_conversation_id = self
-            .active_conversation_for_terminal_view
-            .remove(&terminal_view_id);
+            .active_conversation_for_terminal_surface
+            .remove(&terminal_surface_id);
         let mut cleared_conversation_ids: Vec<AIConversationId> = Vec::new();
         if let Some(ids) = self
-            .live_conversation_ids_for_terminal_view
-            .remove(&terminal_view_id)
+            .live_conversation_ids_for_terminal_surface
+            .remove(&terminal_surface_id)
         {
             cleared_conversation_ids.extend(ids.iter().copied());
-            self.cleared_conversation_ids_for_terminal_view
-                .entry(terminal_view_id)
-                .and_modify(|existing| existing.extend(ids.clone()))
-                .or_insert(ids);
-        }
-        if let Some(ids) = self
-            .live_conversation_ids_for_terminal_view
-            .remove(&terminal_view_id)
-        {
-            cleared_conversation_ids.extend(ids.iter().copied());
-            self.cleared_conversation_ids_for_terminal_view
-                .entry(terminal_view_id)
+            self.cleared_conversation_ids_for_terminal_surface
+                .entry(terminal_surface_id)
                 .and_modify(|existing| existing.extend(ids.clone()))
                 .or_insert(ids);
         }
         ctx.emit(
-            BlocklistAIHistoryEvent::ClearedConversationsInTerminalView {
-                terminal_view_id,
+            BlocklistAIHistoryEvent::ClearedConversationsForTerminalSurface {
+                terminal_surface_id,
                 active_conversation_id,
                 cleared_conversation_ids,
             },
@@ -1963,17 +1951,17 @@ impl BlocklistAIHistoryModel {
     pub fn remove_conversation(
         &mut self,
         conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) {
-        self.remove_conversation_from_memory(conversation_id, Some(terminal_view_id), ctx);
+        self.remove_conversation_from_memory(conversation_id, Some(terminal_surface_id), ctx);
     }
 
     /// Permanently delete a conversation.
     pub fn delete_conversation(
         &mut self,
         conversation_id: AIConversationId,
-        terminal_view_id: Option<EntityId>,
+        terminal_surface_id: Option<EntityId>,
         ctx: &mut ModelContext<Self>,
     ) {
         let conversation_title = self
@@ -1987,7 +1975,7 @@ impl BlocklistAIHistoryModel {
             .get(&conversation_id)
             .and_then(|c| c.run_id());
 
-        self.remove_conversation_from_memory(conversation_id, terminal_view_id, ctx);
+        self.remove_conversation_from_memory(conversation_id, terminal_surface_id, ctx);
 
         // Delete persisted conversation from sqlite.
         let model_event_sender = GlobalResourceHandlesProvider::as_ref(ctx)
@@ -2013,11 +2001,11 @@ impl BlocklistAIHistoryModel {
             |_, _, _| {},
         );
 
-        // Only emit the event if we have a terminal_view_id, since the event is
-        // filtered by terminal_view_id in handlers.
-        if let Some(terminal_view_id) = terminal_view_id {
+        // Only emit the event if we have a terminal_surface_id, since the event is
+        // filtered by terminal_surface_id in handlers.
+        if let Some(terminal_surface_id) = terminal_surface_id {
             ctx.emit(BlocklistAIHistoryEvent::DeletedConversation {
-                terminal_view_id,
+                terminal_surface_id,
                 conversation_id,
                 conversation_title,
                 run_id,
@@ -2029,7 +2017,7 @@ impl BlocklistAIHistoryModel {
     fn remove_conversation_from_memory(
         &mut self,
         conversation_id: AIConversationId,
-        terminal_view_id: Option<EntityId>,
+        terminal_surface_id: Option<EntityId>,
         ctx: &mut ModelContext<Self>,
     ) {
         // Capture the run_id BEFORE the in-memory record is dropped so the
@@ -2067,93 +2055,102 @@ impl BlocklistAIHistoryModel {
         self.all_conversations_metadata.remove(&conversation_id);
         self.conversations_by_id.remove(&conversation_id);
 
-        if let Some(terminal_view_id) = terminal_view_id {
+        if let Some(terminal_surface_id) = terminal_surface_id {
             if self
-                .active_conversation_for_terminal_view
-                .get(&terminal_view_id)
+                .active_conversation_for_terminal_surface
+                .get(&terminal_surface_id)
                 .is_some_and(|id| *id == conversation_id)
             {
-                self.active_conversation_for_terminal_view
-                    .remove(&terminal_view_id);
+                self.active_conversation_for_terminal_surface
+                    .remove(&terminal_surface_id);
             }
             if let Some(vec) = self
-                .live_conversation_ids_for_terminal_view
-                .get_mut(&terminal_view_id)
+                .live_conversation_ids_for_terminal_surface
+                .get_mut(&terminal_surface_id)
             {
                 vec.retain(|&id| id != conversation_id);
             }
             if let Some(vec) = self
-                .cleared_conversation_ids_for_terminal_view
-                .get_mut(&terminal_view_id)
+                .cleared_conversation_ids_for_terminal_surface
+                .get_mut(&terminal_surface_id)
             {
                 vec.retain(|&id| id != conversation_id);
             }
             ctx.emit(BlocklistAIHistoryEvent::RemoveConversation {
-                terminal_view_id,
+                terminal_surface_id,
                 conversation_id,
                 run_id,
             });
         }
     }
 
-    /// Returns true if the conversation is live in any terminal view.
+    /// Returns true if the conversation is live for any terminal surface.
     pub fn is_conversation_live(&self, conversation_id: AIConversationId) -> bool {
-        self.live_conversation_ids_for_terminal_view
+        self.live_conversation_ids_for_terminal_surface
             .values()
             .any(|conversation_ids| conversation_ids.contains(&conversation_id))
     }
 
-    pub fn mark_terminal_view_as_ambient_agent_session_view(&mut self, terminal_view_id: EntityId) {
-        self.ambient_agent_terminal_view_ids
-            .insert(terminal_view_id);
-    }
-
-    pub fn mark_terminal_view_as_conversation_transcript_viewer(
+    pub fn mark_terminal_surface_as_ambient_agent_session_view(
         &mut self,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
     ) {
-        self.conversation_transcript_viewer_terminal_view_ids
-            .insert(terminal_view_id);
+        self.ambient_agent_terminal_surface_ids
+            .insert(terminal_surface_id);
     }
 
-    pub fn is_terminal_view_conversation_transcript_viewer(
+    pub fn mark_terminal_surface_as_conversation_transcript_viewer(
+        &mut self,
+        terminal_surface_id: EntityId,
+    ) {
+        self.conversation_transcript_viewer_terminal_surface_ids
+            .insert(terminal_surface_id);
+    }
+
+    pub fn is_terminal_surface_conversation_transcript_viewer(
         &self,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
     ) -> bool {
-        self.conversation_transcript_viewer_terminal_view_ids
-            .contains(&terminal_view_id)
+        self.conversation_transcript_viewer_terminal_surface_ids
+            .contains(&terminal_surface_id)
     }
 
     /// Returns [`AIQueryHistory`]s from all sources: live conversations, cleared conversations,
     /// and persisted queries from conversations not loaded in memory.
     ///
-    /// When `terminal_view_id` is provided, queries from that terminal view are categorized as
+    /// When `terminal_surface_id` is provided, queries from that terminal surface are categorized as
     /// `CurrentSession` and all others as `DifferentSession`. When `None`, all queries are
     /// categorized as `DifferentSession`.
     ///
     /// Ambient agent sessions are always excluded.
     pub(crate) fn all_ai_queries(
         &self,
-        terminal_view_id: Option<EntityId>,
+        terminal_surface_id: Option<EntityId>,
     ) -> impl Iterator<Item = AIQueryHistory> + '_ {
         // Collect all conversation IDs that are already in memory (live or cleared)
         // and build query vectors in the same loops
         let mut loaded_conversation_ids: HashSet<AIConversationId> = HashSet::new();
 
         let mut live_queries_vec = Vec::new();
-        for (tv_id, conversation_ids) in self.live_conversation_ids_for_terminal_view.iter() {
+        for (conversation_terminal_surface_id, conversation_ids) in
+            self.live_conversation_ids_for_terminal_surface.iter()
+        {
             loaded_conversation_ids.extend(conversation_ids);
 
             // Skip shared ambient agent sessions
-            if self.ambient_agent_terminal_view_ids.contains(tv_id) {
+            if self
+                .ambient_agent_terminal_surface_ids
+                .contains(conversation_terminal_surface_id)
+            {
                 continue;
             }
 
-            let history_order = if terminal_view_id.is_some_and(|id| id == *tv_id) {
-                HistoryOrder::CurrentSession
-            } else {
-                HistoryOrder::DifferentSession
-            };
+            let history_order =
+                if terminal_surface_id.is_some_and(|id| id == *conversation_terminal_surface_id) {
+                    HistoryOrder::CurrentSession
+                } else {
+                    HistoryOrder::DifferentSession
+                };
 
             for conversation_id in conversation_ids {
                 if let Some(conversation) = self.conversations_by_id.get(conversation_id) {
@@ -2177,14 +2174,17 @@ impl BlocklistAIHistoryModel {
         }
 
         let mut cleared_queries_vec = Vec::new();
-        for (tv_id, conversation_ids) in self.cleared_conversation_ids_for_terminal_view.iter() {
+        for (conversation_terminal_surface_id, conversation_ids) in
+            self.cleared_conversation_ids_for_terminal_surface.iter()
+        {
             loaded_conversation_ids.extend(conversation_ids);
 
-            let history_order = if terminal_view_id.is_some_and(|id| id == *tv_id) {
-                HistoryOrder::CurrentSession
-            } else {
-                HistoryOrder::DifferentSession
-            };
+            let history_order =
+                if terminal_surface_id.is_some_and(|id| id == *conversation_terminal_surface_id) {
+                    HistoryOrder::CurrentSession
+                } else {
+                    HistoryOrder::DifferentSession
+                };
 
             for conversation_id in conversation_ids {
                 if let Some(conversation) = self.conversations_by_id.get(conversation_id) {
@@ -2218,28 +2218,26 @@ impl BlocklistAIHistoryModel {
             .chain(live_queries_vec)
     }
 
-    /// Returns `Some` with the [`AIConversationId`] of the active conversation inside the
-    /// [`crate::terminal::TerminalView`] with the given [`EntityId`] if there is one. Returns
-    /// `None` otherwise.
+    /// Returns the active conversation ID for a terminal surface, if one exists.
     /// The active conversation is the one we're currently or have most recently streamed outputs for.
     /// If you want to check what conversation the next query will follow up in / what is selected in the input selector,
     /// use `context_model.selected_conversation_id` instead.
     pub(crate) fn active_conversation_id(
         &self,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
     ) -> Option<AIConversationId> {
         let active_conversation_id = self
-            .active_conversation_for_terminal_view
-            .get(&terminal_view_id)
+            .active_conversation_for_terminal_surface
+            .get(&terminal_surface_id)
             .copied()?;
 
-        let conversation_ids_for_terminal_view = self
-            .live_conversation_ids_for_terminal_view
-            .get(&terminal_view_id)?;
+        let conversation_ids_for_terminal_surface = self
+            .live_conversation_ids_for_terminal_surface
+            .get(&terminal_surface_id)?;
 
-        if !conversation_ids_for_terminal_view.contains(&active_conversation_id) {
+        if !conversation_ids_for_terminal_surface.contains(&active_conversation_id) {
             log::warn!(
-                "The active conversation ID {active_conversation_id:?} was not found in the list of conversation IDs for terminal view {terminal_view_id:?}. Conversation IDs: {conversation_ids_for_terminal_view:?}"
+                "The active conversation ID {active_conversation_id:?} was not found in the list of conversation IDs for terminal surface {terminal_surface_id:?}. Conversation IDs: {conversation_ids_for_terminal_surface:?}"
             );
             return None;
         }
@@ -2247,16 +2245,14 @@ impl BlocklistAIHistoryModel {
         Some(active_conversation_id)
     }
 
-    /// Returns `Some` with the [`AIConversationId`] of the last conversation created for a given
-    /// [`crate::terminal::TerminalView`] with the given [`EntityId`] if there is one. Returns
-    /// `None` otherwise.
+    /// Returns the last conversation ID created for a terminal surface, if one exists.
     #[cfg_attr(target_family = "wasm", allow(unused))]
     pub(crate) fn last_conversation_id(
         &self,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
     ) -> Option<AIConversationId> {
-        self.live_conversation_ids_for_terminal_view
-            .get(&terminal_view_id)?
+        self.live_conversation_ids_for_terminal_surface
+            .get(&terminal_surface_id)?
             .last()
             .copied()
     }
@@ -2264,7 +2260,7 @@ impl BlocklistAIHistoryModel {
     /// Set the hidden status of the exchange with the given ID.
     pub fn set_exchange_hidden_status(
         &mut self,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         conversation_id: AIConversationId,
         exchange_id: AIAgentExchangeId,
         is_hidden: bool,
@@ -2273,7 +2269,7 @@ impl BlocklistAIHistoryModel {
         let Some(conversation) = self.conversations_by_id.get_mut(&conversation_id) else {
             return;
         };
-        conversation.set_is_exchange_hidden(exchange_id, is_hidden, terminal_view_id, ctx);
+        conversation.set_is_exchange_hidden(exchange_id, is_hidden, terminal_surface_id, ctx);
     }
 
     pub fn set_viewing_shared_session_for_conversation(
@@ -2295,7 +2291,7 @@ impl BlocklistAIHistoryModel {
     pub fn toggle_autoexecute_override(
         &mut self,
         conversation_id: &AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) {
         let Some(conversation) = self.conversations_by_id.get_mut(conversation_id) else {
@@ -2304,7 +2300,9 @@ impl BlocklistAIHistoryModel {
 
         conversation.toggle_autoexecute_override();
         conversation.write_updated_conversation_state(ctx);
-        ctx.emit(BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { terminal_view_id });
+        ctx.emit(BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride {
+            terminal_surface_id,
+        });
     }
 
     /// Truncates a conversation from the given exchange ID, removing all exchanges
@@ -2327,27 +2325,27 @@ impl BlocklistAIHistoryModel {
         Ok(removed_exchange_ids)
     }
 
-    /// Returns the latest exchange across all conversations in the terminal view.
+    /// Returns the latest exchange across all conversations for a terminal surface.
     /// This is useful for determining if a specific exchange is the most recent one.
     /// Excludes passive code generation exchanges from consideration.
     pub fn latest_exchange_across_all_conversations(
         &self,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
     ) -> Option<&AIAgentExchange> {
-        self.all_live_root_task_exchanges_for_terminal_view(terminal_view_id)
+        self.all_live_root_task_exchanges_for_terminal_surface(terminal_surface_id)
             .filter(|exchange| !exchange.has_passive_request())
             .max_by_key(|exchange| exchange.start_time)
     }
 
     /// Returns the conversation ID that contains the given exchange ID, if any.
-    /// Searches through all conversations for a given terminal view.
+    /// Searches through all conversations for a terminal surface.
     pub fn conversation_id_for_exchange(
         &self,
         exchange_id: AIAgentExchangeId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
     ) -> Option<AIConversationId> {
-        self.live_conversation_ids_for_terminal_view
-            .get(&terminal_view_id)?
+        self.live_conversation_ids_for_terminal_surface
+            .get(&terminal_surface_id)?
             .iter()
             .find(|conversation_id| {
                 self.conversations_by_id
@@ -2486,8 +2484,11 @@ impl BlocklistAIHistoryModel {
     /// Mark conversations as historical
     /// Historical conversations consist of non-live conversations that were read from the disk or server on startup,
     /// and conversations (recorded here) that were live this session but have now been cleared.
-    pub fn mark_conversations_historical_for_terminal_view(&mut self, terminal_view_id: EntityId) {
-        if self.is_terminal_view_conversation_transcript_viewer(terminal_view_id) {
+    pub fn mark_conversations_historical_for_terminal_surface(
+        &mut self,
+        terminal_surface_id: EntityId,
+    ) {
+        if self.is_terminal_surface_conversation_transcript_viewer(terminal_surface_id) {
             // We don't mark conversation transcript viewer conversations as historical,
             // as they are stored separately and should not be persisted/displayed as regular user conversations.
             return;
@@ -2498,7 +2499,7 @@ impl BlocklistAIHistoryModel {
         // In the future it might be worthwhile to check that these conversations exist in the database before marking them as historical,
         // but for now this is an edge case that we don't need to worry about too much.
         let conversations_to_mark_historical: Vec<AIConversationMetadata> = self
-            .all_live_conversations_for_terminal_view(terminal_view_id)
+            .all_live_conversations_for_terminal_surface(terminal_surface_id)
             .filter_map(|conversation| {
                 let conversation_id = conversation.id();
                 if !self.conversations_by_id.contains_key(&conversation_id)
@@ -2617,12 +2618,12 @@ impl BlocklistAIHistoryModel {
     /// Clears all stored conversation-related data in memory.
     /// This is used when logging out to ensure no AI history persists across users.
     pub(crate) fn reset(&mut self) {
-        self.live_conversation_ids_for_terminal_view.clear();
-        self.cleared_conversation_ids_for_terminal_view.clear();
+        self.live_conversation_ids_for_terminal_surface.clear();
+        self.cleared_conversation_ids_for_terminal_surface.clear();
         self.conversations_by_id.clear();
-        self.active_conversation_for_terminal_view.clear();
-        self.ambient_agent_terminal_view_ids.clear();
-        self.conversation_transcript_viewer_terminal_view_ids
+        self.active_conversation_for_terminal_surface.clear();
+        self.ambient_agent_terminal_surface_ids.clear();
+        self.conversation_transcript_viewer_terminal_surface_ids
             .clear();
         self.persisted_queries.clear();
         self.all_conversations_metadata.clear();
@@ -2716,7 +2717,7 @@ fn agent_id_key_from_persisted_data(conversation_data: &AgentConversationData) -
 }
 
 /// Whether an `UpdatedConversationStatus` event represents a restoration
-/// (the conversation was re-loaded into a terminal view; the underlying
+/// (the conversation was re-loaded for a terminal surface; the underlying
 /// `ConversationStatus` did not change) or a real status set, in which case
 /// the previous status is included.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2730,12 +2731,12 @@ pub enum BlocklistAIHistoryEvent {
     /// A new conversation was started.
     StartedNewConversation {
         new_conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
     },
 
     CreatedSubtask {
         conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         task_id: TaskId,
     },
 
@@ -2744,13 +2745,13 @@ pub enum BlocklistAIHistoryEvent {
     UpgradedTask {
         optimistic_id: TaskId,
         server_id: TaskId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
     },
 
     AppendedExchange {
         exchange_id: AIAgentExchangeId,
         task_id: TaskId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         conversation_id: AIConversationId,
         is_hidden: bool,
 
@@ -2760,24 +2761,24 @@ pub enum BlocklistAIHistoryEvent {
 
     ReassignedExchange {
         exchange_id: AIAgentExchangeId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         new_task_id: TaskId,
         new_conversation_id: AIConversationId,
     },
 
-    /// Includes the terminal view's [`EntityId`] so we can disambiguate the source of the event
+    /// Includes the terminal surface's [`EntityId`] so we can disambiguate the source of the event
     /// because this [`BlocklistAIHistoryModel`] is global.
     #[cfg_attr(not(feature = "local_fs"), allow(dead_code))]
     UpdatedStreamingExchange {
         exchange_id: AIAgentExchangeId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         conversation_id: AIConversationId,
         is_hidden: bool,
     },
 
     UpdatedConversationStatus {
         conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         /// Distinguishes a restoration from a real status set.
         update: ConversationStatusUpdate,
         /// The conversation's status after this update.
@@ -2787,34 +2788,34 @@ pub enum BlocklistAIHistoryEvent {
     /// The active conversation was set to another conversation in the history.
     SetActiveConversation {
         conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
     },
 
-    /// `conversation_id` is no longer marked as active for the given terminal view.
+    /// `conversation_id` is no longer marked as active for the given terminal surface.
     ClearedActiveConversation {
         conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
     },
 
-    ClearedConversationsInTerminalView {
-        terminal_view_id: EntityId,
+    ClearedConversationsForTerminalSurface {
+        terminal_surface_id: EntityId,
         active_conversation_id: Option<AIConversationId>,
-        /// All conversation ids that were live in `terminal_view_id` before the clear.
+        /// All conversation ids that were live in `terminal_surface_id` before the clear.
         /// Subscribers (e.g. `QueuedQueryModel`) use this to drop per-conversation state.
         cleared_conversation_ids: Vec<AIConversationId>,
     },
 
     UpdatedTodoList {
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
     },
 
     UpdatedAutoexecuteOverride {
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
     },
 
     /// Emitted when a conversation is split into two (on suggest starting new conversation)
     SplitConversation {
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         old_conversation_id: AIConversationId,
         new_conversation_id: AIConversationId,
     },
@@ -2825,7 +2826,7 @@ pub enum BlocklistAIHistoryEvent {
     /// (captured before the in-memory record was dropped) so subscribers can
     /// still act on it without a history-model lookup.
     RemoveConversation {
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         conversation_id: AIConversationId,
         run_id: Option<String>,
     },
@@ -2834,35 +2835,35 @@ pub enum BlocklistAIHistoryEvent {
     /// `run_id` is captured before the in-memory record was dropped — see
     /// the note on [`Self::RemoveConversation`].
     DeletedConversation {
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         conversation_id: AIConversationId,
         conversation_title: Option<String>,
         run_id: Option<String>,
     },
 
-    /// Emitted when conversations are restored in a terminal view.
+    /// Emitted when conversations are restored for a terminal surface.
     RestoredConversations {
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         conversation_ids: Vec<AIConversationId>,
     },
 
     /// Emitted when conversation metadata is updated.
-    /// `terminal_view_id` is None when updating historical-only conversations.
+    /// `terminal_surface_id` is None when updating historical-only conversations.
     UpdatedConversationMetadata {
-        terminal_view_id: Option<EntityId>,
+        terminal_surface_id: Option<EntityId>,
         conversation_id: AIConversationId,
     },
 
     /// Emitted when a conversation title changes.
     UpdatedConversationTitle {
-        terminal_view_id: Option<EntityId>,
+        terminal_surface_id: Option<EntityId>,
         conversation_id: AIConversationId,
         title: String,
     },
 
     /// Emitted when conversation artifacts are updated (plans, PRs, etc.)
     UpdatedConversationArtifacts {
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         conversation_id: AIConversationId,
         artifact: Artifact,
     },
@@ -2872,21 +2873,21 @@ pub enum BlocklistAIHistoryEvent {
     /// actions for child agent conversations.
     ConversationServerTokenAssigned {
         conversation_id: AIConversationId,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
     },
 
-    /// Emitted when a conversation moves between terminal views — i.e. when
+    /// Emitted when a conversation moves between terminal surfaces — i.e. when
     /// `set_active_conversation_id` removes the conversation from the live
-    /// list of one or more `previous_terminal_view_id`s. The previous owners
+    /// list of one or more `previous_terminal_surface_id`s. The previous terminal surfaces
     /// must drop any rendered AI blocks for this conversation so the new
-    /// owner is the sole renderer; otherwise we end up with a transcript
+    /// terminal surface is the sole renderer; otherwise we end up with a transcript
     /// split across panes (some blocks in the old view, new exchanges in the
-    /// new view). The `terminal_view_id()` accessor returns the previous
-    /// owner so existing per-view event filters do the right thing.
-    ConversationOwnershipTransferred {
+    /// new view). The `terminal_surface_id()` accessor returns the previous
+    /// terminal surface so existing per-view event filters do the right thing.
+    ConversationTransferredBetweenTerminalSurfaces {
         conversation_id: AIConversationId,
-        previous_terminal_view_id: EntityId,
-        new_terminal_view_id: EntityId,
+        previous_terminal_surface_id: EntityId,
+        new_terminal_surface_id: EntityId,
     },
 
     /// Links an executor-minted request to a freshly-created
@@ -2922,86 +2923,105 @@ pub enum BlocklistAIHistoryEvent {
 }
 
 impl BlocklistAIHistoryEvent {
-    /// Returns the terminal view ID associated with this event, if any.
+    /// Returns the terminal surface ID associated with this event, if any.
     /// Returns `None` for events that apply globally (e.g., historical conversation metadata updates).
-    pub fn terminal_view_id(&self) -> Option<EntityId> {
+    pub fn terminal_surface_id(&self) -> Option<EntityId> {
         match self {
             BlocklistAIHistoryEvent::StartedNewConversation {
-                terminal_view_id, ..
+                terminal_surface_id,
+                ..
             }
             | BlocklistAIHistoryEvent::AppendedExchange {
-                terminal_view_id, ..
+                terminal_surface_id,
+                ..
             }
             | BlocklistAIHistoryEvent::UpdatedStreamingExchange {
-                terminal_view_id, ..
+                terminal_surface_id,
+                ..
             }
             | BlocklistAIHistoryEvent::UpdatedConversationStatus {
-                terminal_view_id, ..
+                terminal_surface_id,
+                ..
             }
             | BlocklistAIHistoryEvent::SetActiveConversation {
-                terminal_view_id, ..
+                terminal_surface_id,
+                ..
             }
             | BlocklistAIHistoryEvent::ClearedActiveConversation {
-                terminal_view_id, ..
+                terminal_surface_id,
+                ..
             }
-            | BlocklistAIHistoryEvent::ClearedConversationsInTerminalView {
-                terminal_view_id,
+            | BlocklistAIHistoryEvent::ClearedConversationsForTerminalSurface {
+                terminal_surface_id,
                 ..
             }
             | BlocklistAIHistoryEvent::ReassignedExchange {
-                terminal_view_id, ..
+                terminal_surface_id,
+                ..
             }
             | BlocklistAIHistoryEvent::UpdatedTodoList {
-                terminal_view_id, ..
+                terminal_surface_id,
+                ..
             }
             | BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride {
-                terminal_view_id, ..
+                terminal_surface_id,
+                ..
             }
             | BlocklistAIHistoryEvent::SplitConversation {
-                terminal_view_id, ..
+                terminal_surface_id,
+                ..
             }
             | BlocklistAIHistoryEvent::RemoveConversation {
-                terminal_view_id, ..
+                terminal_surface_id,
+                ..
             }
             | BlocklistAIHistoryEvent::DeletedConversation {
-                terminal_view_id, ..
+                terminal_surface_id,
+                ..
             }
             | BlocklistAIHistoryEvent::CreatedSubtask {
-                terminal_view_id, ..
+                terminal_surface_id,
+                ..
             }
             | BlocklistAIHistoryEvent::RestoredConversations {
-                terminal_view_id, ..
+                terminal_surface_id,
+                ..
             }
             | BlocklistAIHistoryEvent::UpgradedTask {
-                terminal_view_id, ..
+                terminal_surface_id,
+                ..
             }
-            | BlocklistAIHistoryEvent::ConversationOwnershipTransferred {
-                previous_terminal_view_id: terminal_view_id,
+            | BlocklistAIHistoryEvent::ConversationTransferredBetweenTerminalSurfaces {
+                previous_terminal_surface_id: terminal_surface_id,
                 ..
             }
             | BlocklistAIHistoryEvent::UpdatedConversationArtifacts {
-                terminal_view_id, ..
+                terminal_surface_id,
+                ..
             }
             | BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
-                terminal_view_id, ..
-            } => Some(*terminal_view_id),
+                terminal_surface_id,
+                ..
+            } => Some(*terminal_surface_id),
             // UpdatedConversationMetadata can have None when updating historical-only conversations
             BlocklistAIHistoryEvent::UpdatedConversationMetadata {
-                terminal_view_id, ..
+                terminal_surface_id,
+                ..
             }
             | BlocklistAIHistoryEvent::UpdatedConversationTitle {
-                terminal_view_id, ..
-            } => *terminal_view_id,
+                terminal_surface_id,
+                ..
+            } => *terminal_surface_id,
             // NewConversationRequestComplete is executor-scoped and has no
-            // terminal_view_id.
+            // terminal_surface_id.
             BlocklistAIHistoryEvent::NewConversationRequestComplete { .. } => None,
             // OrchestrationConfigUpdated is conversation-scoped and has no
-            // terminal_view_id.
+            // terminal_surface_id.
             BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. } => None,
             // ConversationUsageMetadataUpdated is conversation-scoped and
-            // has no terminal_view_id. Cross-pane consumers (e.g. the
+            // has no terminal_surface_id. Cross-pane consumers (e.g. the
             // orchestrator footer reading descendant credits) can't be
-            // disambiguated by a single owner pane.
+            // disambiguated by a single terminal surface pane.
             BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. } => None,
             // Conversation-scoped; subscribers resolve the owning view via conversation_id.
             BlocklistAIHistoryEvent::LocalSharedSessionEstablished { .. } => None,

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -975,7 +975,7 @@ fn test_ai_queries_for_terminal_view_up_arrow_history() {
 
         // Clear the blocklist
         history_model.update(&mut app, |history_model, ctx| {
-            history_model.clear_conversations_in_terminal_view(terminal_view_id, ctx);
+            history_model.clear_conversations_for_terminal_surface(terminal_view_id, ctx);
         });
 
         // Test state after clearing - should remain the same
@@ -1471,8 +1471,8 @@ fn test_transcript_viewer_terminal_view_is_not_marked_historical() {
         });
 
         history_model.update(&mut app, |history_model, _| {
-            history_model.mark_terminal_view_as_conversation_transcript_viewer(terminal_view_id);
-            history_model.mark_conversations_historical_for_terminal_view(terminal_view_id);
+            history_model.mark_terminal_surface_as_conversation_transcript_viewer(terminal_view_id);
+            history_model.mark_conversations_historical_for_terminal_surface(terminal_view_id);
         });
 
         let historical_count = history_model.read(&app, |history_model, _| {
@@ -1812,7 +1812,7 @@ fn test_all_cleared_conversations_includes_terminal_view_id() {
         });
 
         history_model.update(&mut app, |history_model, ctx| {
-            history_model.clear_conversations_in_terminal_view(terminal_view_id, ctx);
+            history_model.clear_conversations_for_terminal_surface(terminal_view_id, ctx);
         });
 
         let has_cleared = history_model.read(&app, |history_model, _| {
@@ -2963,7 +2963,7 @@ fn test_find_by_token_after_insert_forked_conversation_from_tasks() {
 }
 
 #[test]
-fn test_find_by_token_after_mark_conversations_historical_for_terminal_view() {
+fn test_find_by_token_after_mark_conversations_historical_for_terminal_surface() {
     use crate::ai::agent::conversation::AIConversation;
 
     App::test((), |mut app| async move {
@@ -3019,7 +3019,7 @@ fn test_find_by_token_after_mark_conversations_historical_for_terminal_view() {
         });
 
         history_model.update(&mut app, |model, _| {
-            model.mark_conversations_historical_for_terminal_view(terminal_view_id);
+            model.mark_conversations_historical_for_terminal_surface(terminal_view_id);
         });
 
         // Token still resolves via the metadata-side index entry.
@@ -3383,7 +3383,7 @@ fn test_fork_then_bind_handoff_token_updates_cached_metadata_and_emits_refresh_e
             events.iter().any(|event| matches!(
                 event,
                 BlocklistAIHistoryEvent::UpdatedConversationMetadata {
-                    terminal_view_id: Some(id),
+                    terminal_surface_id: Some(id),
                     conversation_id,
                 } if *id == fork_terminal_view_id && *conversation_id == forked_id
             )),
@@ -3393,7 +3393,7 @@ fn test_fork_then_bind_handoff_token_updates_cached_metadata_and_emits_refresh_e
             events.iter().any(|event| matches!(
                 event,
                 BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
-                    terminal_view_id: id,
+                    terminal_surface_id: id,
                     conversation_id,
                 } if *id == fork_terminal_view_id && *conversation_id == forked_id
             )),

--- a/app/src/ai/blocklist/input_model.rs
+++ b/app/src/ai/blocklist/input_model.rs
@@ -1,6 +1,6 @@
 //! Model-layer AI input state management logic.
 //!
-//! The primary export of this module is `BlocklistAIInputModel`, which is a terminal pane-scoped
+//! The primary export of this module is `BlocklistAIInputModel`, which is a terminal-surface-scoped
 //! model managing input "type" state (whether the input is in AI or shell mode). This model also
 //! exposes methods for running query autodetection, where an algorithm determines if the current
 //! input contents are an AI query or shell command, which is then used to update the input mode.
@@ -86,9 +86,10 @@ impl From<InputClassifierDecisionSource> for InputTypeAutoDetectionSource {
     }
 }
 
-use super::agent_view::{AgentViewController, AgentViewControllerEvent, AgentViewEntryOrigin};
+use super::agent_view::AgentViewEntryOrigin;
 use super::context_model::BlocklistAIContextModel;
 use super::telemetry_banner::should_collect_ai_ugc_telemetry;
+use super::{ConversationSelectionEvent, ConversationSelectionHandle};
 use crate::input_classifier::InputClassifierModel;
 use crate::settings::{AISettings, AISettingsChangedEvent, InputBoxType, InputSettings};
 use crate::terminal::cli_agent_sessions::{
@@ -190,7 +191,7 @@ impl From<InputConfig> for InputMode {
     }
 }
 
-/// Terminal pane-scoped model responsible for managing AI input state.
+/// Terminal-surface-scoped model responsible for managing AI input state.
 #[derive(Clone)]
 pub struct BlocklistAIInputModel {
     input_config: InputConfig,
@@ -208,25 +209,26 @@ pub struct BlocklistAIInputModel {
     /// if a persistent lock is in place and a buffer is submitted.
     was_lock_set_with_empty_buffer: bool,
 
-    agent_view_controller: ModelHandle<AgentViewController>,
+    conversation_selection: ConversationSelectionHandle,
 
-    /// Handle to the per-pane context model. Used to read pending image / file attachments
+    /// Handle to the per-surface context model. Used to read pending image / file attachments
     /// when deciding whether to force-lock the input to AI mode (see
     /// [`BlocklistAIContextModel::has_locking_attachment`]).
     ai_context_model: ModelHandle<BlocklistAIContextModel>,
 
-    terminal_view_id: EntityId,
+    terminal_surface_id: EntityId,
 
     autodetect_abort_handle: Option<AbortHandle>,
     model: Arc<FairMutex<TerminalModel>>,
 }
 
 impl BlocklistAIInputModel {
+    /// Creates input state for a terminal surface.
     pub fn new(
         model: Arc<FairMutex<TerminalModel>>,
-        agent_view_controller: ModelHandle<AgentViewController>,
+        conversation_selection: ConversationSelectionHandle,
         ai_context_model: ModelHandle<BlocklistAIContextModel>,
-        terminal_view_id: EntityId,
+        terminal_surface_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         // Reactively restore input config when CLI agent rich input closes.
@@ -241,7 +243,9 @@ impl BlocklistAIInputModel {
                 else {
                     return;
                 };
-                if *event_view_id != terminal_view_id {
+                // CLI agent sessions are keyed by terminal view id; GUI surfaces use the
+                // view id as their surface id, so this filters events to our surface.
+                if *event_view_id != terminal_surface_id {
                     return;
                 }
                 if let CLIAgentInputState::Open {
@@ -264,7 +268,7 @@ impl BlocklistAIInputModel {
                 AISettingsChangedEvent::AIAutoDetectionEnabled { .. }
                     if FeatureFlag::AgentView.is_enabled() =>
                 {
-                    if me.agent_view_controller.as_ref(ctx).is_fullscreen() {
+                    if me.is_conversation_fullscreen(ctx) {
                         // Use context-specific check to determine if autodetection should be enabled
                         let is_nld_enabled =
                             AISettings::as_ref(ctx).is_ai_autodetection_enabled(ctx);
@@ -296,8 +300,7 @@ impl BlocklistAIInputModel {
                     );
                 }
                 AISettingsChangedEvent::NLDInTerminalEnabled { .. }
-                    if FeatureFlag::AgentView.is_enabled()
-                        && !me.agent_view_controller.as_ref(ctx).is_active() =>
+                    if FeatureFlag::AgentView.is_enabled() && !me.is_conversation_active(ctx) =>
                 {
                     let is_nld_enabled = AISettings::as_ref(ctx).is_nld_in_terminal_enabled(ctx);
                     me.set_input_config_internal(
@@ -313,89 +316,75 @@ impl BlocklistAIInputModel {
             }
         });
 
-        if FeatureFlag::AgentView.is_enabled() {
-            ctx.subscribe_to_model(&agent_view_controller, |me, _, event, ctx| match event {
-                AgentViewControllerEvent::EnteredAgentView {
-                    display_mode,
-                    origin,
-                    ..
-                } => {
-                    if display_mode.is_inline() {
-                        me.set_input_config_internal(
-                            InputConfig {
-                                input_type: InputType::AI,
-                                is_locked: true,
-                            },
-                            Some(InputTypeAutoDetectionSource::InlineAgentViewEntry),
-                            ctx,
-                        );
-                    } else if matches!(origin, AgentViewEntryOrigin::ClearBuffer) {
-                        let is_autodetection_enabled =
-                            AISettings::as_ref(ctx).is_ai_autodetection_enabled(ctx);
-                        me.set_input_config_internal(
-                            InputConfig {
-                                input_type: me.input_config().input_type,
-                                is_locked: !is_autodetection_enabled,
-                            },
-                            None,
-                            ctx,
-                        );
-                    } else if me.has_locking_attachment(ctx) {
-                        // Interaction patterns that should fully bypass NLD on
-                        // entry: image / file attachment in progress / attached.
-                        // Force-lock to AI regardless of the user's NLD setting so the
-                        // classifier never gets a chance to drop the buffer back to shell.
-                        me.set_input_config_internal(
-                            InputConfig {
-                                input_type: InputType::AI,
-                                is_locked: true,
-                            },
-                            Some(InputTypeAutoDetectionSource::AttachmentForcedAi),
-                            ctx,
-                        );
-                    } else {
-                        let is_autodetection_enabled =
-                            AISettings::as_ref(ctx).is_ai_autodetection_enabled(ctx);
-                        if is_autodetection_enabled {
-                            // Upon entering the agent view, temporarily disable autodetection as
-                            // the existing buffer contents, if any are now most likely intended to
-                            // be sent to the agent, and if the input would otherwise trigger a
-                            // false-negative classification, we'd drop the user right into shell
-                            // mode.
-                            me.temporarily_disable_autodetection();
-                        }
-                        me.set_input_config_internal(
-                            InputConfig {
-                                input_type: InputType::AI,
-                                is_locked: !is_autodetection_enabled,
-                            },
-                            None,
-                            ctx,
-                        );
+        ctx.subscribe_to_model(&conversation_selection, |me, _, event, ctx| match event {
+            ConversationSelectionEvent::Activated {
+                is_fullscreen,
+                origin,
+            } => {
+                if !*is_fullscreen {
+                    me.set_input_config_internal(
+                        InputConfig {
+                            input_type: InputType::AI,
+                            is_locked: true,
+                        },
+                        Some(InputTypeAutoDetectionSource::InlineAgentViewEntry),
+                        ctx,
+                    );
+                } else if matches!(origin, AgentViewEntryOrigin::ClearBuffer) {
+                    let is_autodetection_enabled =
+                        AISettings::as_ref(ctx).is_ai_autodetection_enabled(ctx);
+                    me.set_input_config_internal(
+                        InputConfig {
+                            input_type: me.input_config().input_type,
+                            is_locked: !is_autodetection_enabled,
+                        },
+                        None,
+                        ctx,
+                    );
+                } else if me.has_locking_attachment(ctx) {
+                    me.set_input_config_internal(
+                        InputConfig {
+                            input_type: InputType::AI,
+                            is_locked: true,
+                        },
+                        Some(InputTypeAutoDetectionSource::AttachmentForcedAi),
+                        ctx,
+                    );
+                } else {
+                    let is_autodetection_enabled =
+                        AISettings::as_ref(ctx).is_ai_autodetection_enabled(ctx);
+                    if is_autodetection_enabled {
+                        me.temporarily_disable_autodetection();
                     }
+                    me.set_input_config_internal(
+                        InputConfig {
+                            input_type: InputType::AI,
+                            is_locked: !is_autodetection_enabled,
+                        },
+                        None,
+                        ctx,
+                    );
                 }
-                AgentViewControllerEvent::ExitedAgentView {
-                    is_exit_before_new_entrance,
-                    ..
-                } => {
-                    if !is_exit_before_new_entrance {
-                        // When truly exiting agent view, use the terminal-specific NLD setting
-                        // since the user is returning to terminal mode.
-                        let is_nld_in_terminal_enabled =
-                            AISettings::as_ref(ctx).is_nld_in_terminal_enabled(ctx);
-                        me.set_input_config_internal(
-                            InputConfig {
-                                input_type: InputType::Shell,
-                                is_locked: !is_nld_in_terminal_enabled,
-                            },
-                            None,
-                            ctx,
-                        );
-                    }
+            }
+            ConversationSelectionEvent::Deactivated {
+                is_exit_before_new_entrance,
+                ..
+            } => {
+                if !is_exit_before_new_entrance {
+                    let is_nld_in_terminal_enabled =
+                        AISettings::as_ref(ctx).is_nld_in_terminal_enabled(ctx);
+                    me.set_input_config_internal(
+                        InputConfig {
+                            input_type: InputType::Shell,
+                            is_locked: !is_nld_in_terminal_enabled,
+                        },
+                        None,
+                        ctx,
+                    );
                 }
-                _ => (),
-            });
-        }
+            }
+            ConversationSelectionEvent::Changed => {}
+        });
 
         let is_autodetection_enabled = if FeatureFlag::AgentView.is_enabled() {
             AISettings::as_ref(ctx).is_nld_in_terminal_enabled(ctx)
@@ -408,9 +397,9 @@ impl BlocklistAIInputModel {
                 input_type: InputType::Shell,
                 is_locked: !is_autodetection_enabled,
             },
-            agent_view_controller,
+            conversation_selection,
             ai_context_model,
-            terminal_view_id,
+            terminal_surface_id,
             last_ai_autodetection_ts: None,
             last_ai_autodetection_source: initial_decision_source,
             last_explicit_input_type_set_at: None,
@@ -418,6 +407,20 @@ impl BlocklistAIInputModel {
             autodetect_abort_handle: None,
             model,
         }
+    }
+
+    /// Returns whether the surface presents a selected conversation as active.
+    fn is_conversation_active(&self, app: &AppContext) -> bool {
+        self.conversation_selection
+            .as_ref(app)
+            .is_conversation_active(app)
+    }
+
+    /// Returns whether the surface presents a selected conversation fullscreen.
+    fn is_conversation_fullscreen(&self, app: &AppContext) -> bool {
+        self.conversation_selection
+            .as_ref(app)
+            .is_conversation_fullscreen(app)
     }
 
     /// Convenience wrapper around `BlocklistAIContextModel::has_locking_attachment`.
@@ -459,8 +462,7 @@ impl BlocklistAIInputModel {
     ) {
         // When agent view is active, the input should behave like Universal mode
         // even if Classic mode is selected (e.g. when PS1 is enabled).
-        if FeatureFlag::AgentView.is_enabled() && self.agent_view_controller.as_ref(ctx).is_active()
-        {
+        if FeatureFlag::AgentView.is_enabled() && self.is_conversation_active(ctx) {
             return;
         }
 
@@ -506,10 +508,10 @@ impl BlocklistAIInputModel {
         // agent rich input case, the input must be in AI mode to suppress shell decorations
         // (syntax highlighting, error underlining).
         if FeatureFlag::AgentView.is_enabled()
-            && !self.agent_view_controller.as_ref(ctx).is_active()
+            && !self.is_conversation_active(ctx)
             && new_config.input_type.is_ai()
             && new_config.is_locked
-            && !CLIAgentSessionsModel::as_ref(ctx).is_input_open(self.terminal_view_id)
+            && !CLIAgentSessionsModel::as_ref(ctx).is_input_open(self.terminal_surface_id)
         {
             return false;
         }
@@ -606,7 +608,7 @@ impl BlocklistAIInputModel {
 
         // Defense in depth: while there is a pending image / file attachment, the classifier
         // must never have a chance to flip the input back to shell mode, even per-keystroke.
-        // The `EnteredAgentView` subscriber and `set_input_mode_agent` already lock at entry;
+        // The conversation-activation subscriber and `set_input_mode_agent` already lock at entry;
         // this guard protects the window if any future caller forgets.
         if self.has_locking_attachment(app) {
             return false;
@@ -614,7 +616,7 @@ impl BlocklistAIInputModel {
 
         let ai_settings = AISettings::as_ref(app);
         if FeatureFlag::AgentView.is_enabled() {
-            if self.agent_view_controller.as_ref(app).is_fullscreen() {
+            if self.is_conversation_fullscreen(app) {
                 ai_settings.is_ai_autodetection_enabled(app)
             } else {
                 ai_settings.is_nld_in_terminal_enabled(app)
@@ -664,10 +666,8 @@ impl BlocklistAIInputModel {
         } else {
             // If NLD is enabled and input is currently locked, unlock it, as we want to
             // resume autodetection for the next input.
-            self.input_config.unlocked_if_autodetection_enabled(
-                self.agent_view_controller.as_ref(ctx).is_fullscreen(),
-                ctx,
-            )
+            self.input_config
+                .unlocked_if_autodetection_enabled(self.is_conversation_fullscreen(ctx), ctx)
         };
 
         self.set_input_config(

--- a/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
@@ -639,7 +639,7 @@ fn conversation_server_token_assigned_fires_update_with_conversation_id() {
         history_model.update(&mut app, |_, ctx| {
             ctx.emit(BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
                 conversation_id,
-                terminal_view_id,
+                terminal_surface_id: terminal_view_id,
             });
         });
 
@@ -668,7 +668,7 @@ fn conversation_server_token_assigned_skips_viewer_conversations() {
         history_model.update(&mut app, |_, ctx| {
             ctx.emit(BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
                 conversation_id,
-                terminal_view_id,
+                terminal_surface_id: terminal_view_id,
             });
         });
 
@@ -702,7 +702,7 @@ fn conversation_server_token_assigned_skips_remote_child_conversations() {
         history_model.update(&mut app, |_, ctx| {
             ctx.emit(BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
                 conversation_id,
-                terminal_view_id,
+                terminal_surface_id: terminal_view_id,
             });
         });
 
@@ -734,7 +734,7 @@ fn conversation_server_token_assigned_skips_without_task_id() {
         history_model.update(&mut app, |_, ctx| {
             ctx.emit(BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
                 conversation_id,
-                terminal_view_id,
+                terminal_surface_id: terminal_view_id,
             });
         });
 

--- a/app/src/ai/blocklist/mod.rs
+++ b/app/src/ai/blocklist/mod.rs
@@ -5,6 +5,7 @@ pub mod block;
 pub mod code_block;
 mod context_model;
 mod controller;
+pub(crate) mod conversation_selection;
 pub(crate) mod handoff;
 
 pub(crate) mod local_agent_task_sync_model;
@@ -31,10 +32,11 @@ pub(crate) mod codebase_index_speedbump_banner;
 pub(crate) mod telemetry_banner;
 pub(super) mod view_util;
 
+pub use action_model::BlocklistAIActionModel;
 #[cfg_attr(target_family = "wasm", allow(unused_imports))]
 pub(crate) use action_model::{
-    apply_edits, read_local_file_context, BlocklistAIActionEvent, BlocklistAIActionModel,
-    FileReadResult, ReadFileContextResult, RequestFileEditsFormatKind, ShellCommandExecutor,
+    apply_edits, read_local_file_context, BlocklistAIActionEvent, FileReadResult,
+    ReadFileContextResult, RequestFileEditsFormatKind, ShellCommandExecutor,
     ShellCommandExecutorEvent, StartAgentExecutor, StartAgentExecutorEvent, StartAgentRequest,
     StartAgentRequestId,
 };
@@ -42,9 +44,10 @@ pub(crate) use action_model::{
 pub(crate) use block::model::testing::FakeAIBlockModel;
 pub(crate) use block::{init, model, AIBlock, AIBlockEvent, RequestedEditResolution};
 pub use block::{keyboard_navigable_buttons, toggleable_items};
+pub use context_model::BlocklistAIContextModel;
 pub(crate) use context_model::{
-    block_context_from_terminal_model, AttachmentType, BlocklistAIContextEvent,
-    BlocklistAIContextModel, PendingAttachment, PendingFile, PendingQueryState,
+    block_context_from_terminal_model, AttachmentType, BlocklistAIContextEvent, PendingAttachment,
+    PendingFile,
 };
 pub use controller::input_context::{
     BLOCK_CONTEXT_ATTACHMENT_REGEX, DIFF_HUNK_ATTACHMENT_REGEX, DRIVE_OBJECT_ATTACHMENT_REGEX,
@@ -52,18 +55,22 @@ pub use controller::input_context::{
 #[cfg(test)]
 pub(crate) use controller::response_stream::ResponseStream;
 pub(crate) use controller::response_stream::ResponseStreamId;
+pub use controller::BlocklistAIController;
 pub(crate) use controller::{
-    BlocklistAIController, BlocklistAIControllerEvent, ClientIdentifiers, SessionContext,
-    SlashCommandRequest,
+    BlocklistAIControllerEvent, ClientIdentifiers, SessionContext, SlashCommandRequest,
+};
+pub(crate) use conversation_selection::{
+    ConversationSelection, ConversationSelectionEvent, ConversationSelectionHandle,
+    PendingQueryState,
 };
 pub(crate) use history_model::{
     AIQueryHistory, AIQueryHistoryOutputStatus, BeginConversationRenameError,
     BlocklistAIHistoryEvent, BlocklistAIHistoryModel, ConversationStatusUpdate, FORK_PREFIX,
     PRE_REWIND_PREFIX,
 };
+pub use input_model::BlocklistAIInputModel;
 pub(crate) use input_model::{
-    BlocklistAIInputEvent, BlocklistAIInputModel, InputConfig, InputType,
-    InputTypeAutoDetectionSource,
+    BlocklistAIInputEvent, InputConfig, InputType, InputTypeAutoDetectionSource,
 };
 pub(crate) use passive_suggestions::{
     LegacyPassiveSuggestionsEvent, LegacyPassiveSuggestionsModel, MaaPassiveSuggestionsEvent,

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -1034,13 +1034,13 @@ impl OrchestrationEventStreamer {
             | BlocklistAIHistoryEvent::ReassignedExchange { .. }
             | BlocklistAIHistoryEvent::SetActiveConversation { .. }
             | BlocklistAIHistoryEvent::ClearedActiveConversation { .. }
-            | BlocklistAIHistoryEvent::ClearedConversationsInTerminalView { .. }
+            | BlocklistAIHistoryEvent::ClearedConversationsForTerminalSurface { .. }
             | BlocklistAIHistoryEvent::UpdatedTodoList { .. }
             | BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. }
             | BlocklistAIHistoryEvent::SplitConversation { .. }
             | BlocklistAIHistoryEvent::UpdatedConversationTitle { .. }
             | BlocklistAIHistoryEvent::UpdatedConversationArtifacts { .. }
-            | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. }
+            | BlocklistAIHistoryEvent::ConversationTransferredBetweenTerminalSurfaces { .. }
             | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. }
             | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. }
             | BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. }

--- a/app/src/ai/blocklist/prompt/plan_and_todo_list.rs
+++ b/app/src/ai/blocklist/prompt/plan_and_todo_list.rs
@@ -97,7 +97,7 @@ impl PlanAndTodoListView {
             &BlocklistAIHistoryModel::handle(ctx),
             |me, _, event, ctx| {
                 if event
-                    .terminal_view_id()
+                    .terminal_surface_id()
                     .is_some_and(|id| id != me.terminal_view_id)
                 {
                     return;
@@ -108,7 +108,7 @@ impl PlanAndTodoListView {
                 match event.clone() {
                     BlocklistAIHistoryEvent::StartedNewConversation { .. }
                     | BlocklistAIHistoryEvent::SetActiveConversation { .. }
-                    | BlocklistAIHistoryEvent::ClearedConversationsInTerminalView { .. }
+                    | BlocklistAIHistoryEvent::ClearedConversationsForTerminalSurface { .. }
                     | BlocklistAIHistoryEvent::AppendedExchange { .. }
                     | BlocklistAIHistoryEvent::UpdatedTodoList { .. } => {
                         ctx.notify();

--- a/app/src/ai/blocklist/queued_query.rs
+++ b/app/src/ai/blocklist/queued_query.rs
@@ -281,7 +281,7 @@ impl QueuedQueryModel {
             } => {
                 self.drop_conversation(*conversation_id, ctx);
             }
-            BlocklistAIHistoryEvent::ClearedConversationsInTerminalView {
+            BlocklistAIHistoryEvent::ClearedConversationsForTerminalSurface {
                 cleared_conversation_ids,
                 ..
             } => {
@@ -360,7 +360,7 @@ impl QueuedQueryModel {
         history_model: &BlocklistAIHistoryModel,
     ) -> Option<AIConversationId> {
         history_model
-            .all_live_conversations_for_terminal_view(terminal_view_id)
+            .all_live_conversations_for_terminal_surface(terminal_view_id)
             .find_map(|conversation| {
                 self.has_command_in_flight(conversation.id())
                     .then_some(conversation.id())

--- a/app/src/ai/blocklist/queued_query_tests.rs
+++ b/app/src/ai/blocklist/queued_query_tests.rs
@@ -899,8 +899,8 @@ fn delete_conversation_clears_in_flight_command() {
 }
 
 #[test]
-fn clear_conversations_in_terminal_view_drops_every_listed_conversation() {
-    // ClearedConversationsInTerminalView with multiple ids must drop each listed conversation's queue.
+fn clear_conversations_for_terminal_surface_drops_every_listed_conversation() {
+    // ClearedConversationsForTerminalSurface with multiple ids must drop each listed conversation's queue.
     with_model(|mut app, model, _events| {
         let history = BlocklistAIHistoryModel::handle(&app);
         let terminal_view_id = warpui::EntityId::new();
@@ -914,7 +914,7 @@ fn clear_conversations_in_terminal_view_drops_every_listed_conversation() {
         append_user(&model, &mut app, conv_b, "b1");
 
         history.update(&mut app, |h, ctx| {
-            h.clear_conversations_in_terminal_view(terminal_view_id, ctx)
+            h.clear_conversations_for_terminal_surface(terminal_view_id, ctx)
         });
 
         model.read(&app, |m, _| {

--- a/app/src/ai/conversation_navigation/mod.rs
+++ b/app/src/ai/conversation_navigation/mod.rs
@@ -186,7 +186,7 @@ impl ConversationNavigationData {
                     // Skip conversation transcript viewers, as they are stored elsewhere
                     // and should not be presented as regular user conversations.
                     if history_model
-                        .is_terminal_view_conversation_transcript_viewer(terminal_view_id)
+                        .is_terminal_surface_conversation_transcript_viewer(terminal_view_id)
                     {
                         continue;
                     }
@@ -199,7 +199,7 @@ impl ConversationNavigationData {
 
                     // Get all continuable conversations for this terminal view
                     for conversation in
-                        history_model.all_live_conversations_for_terminal_view(terminal_view_id)
+                        history_model.all_live_conversations_for_terminal_surface(terminal_view_id)
                     {
                         if !all_conversation_ids.contains(&conversation.id()) {
                             if conversation.should_exclude_from_navigation() {
@@ -256,7 +256,8 @@ impl ConversationNavigationData {
             .iter()
             .for_each(|(terminal_id, conversation)| {
                 if conversation.should_exclude_from_navigation()
-                    || history_model.is_terminal_view_conversation_transcript_viewer(*terminal_id)
+                    || history_model
+                        .is_terminal_surface_conversation_transcript_viewer(*terminal_id)
                     || !blocklist_filter::conversation_would_render_in_blocklist(conversation)
                 {
                     // Track the ID so the historical loop below doesn't re-add it.
@@ -287,7 +288,8 @@ impl ConversationNavigationData {
             .iter()
             .for_each(|(terminal_id, conversation)| {
                 if conversation.should_exclude_from_navigation()
-                    || history_model.is_terminal_view_conversation_transcript_viewer(*terminal_id)
+                    || history_model
+                        .is_terminal_surface_conversation_transcript_viewer(*terminal_id)
                     || !blocklist_filter::conversation_would_render_in_blocklist(conversation)
                 {
                     // Track the ID so the historical loop below doesn't re-add it.

--- a/app/src/ai/document/ai_document_model.rs
+++ b/app/src/ai/document/ai_document_model.rs
@@ -454,7 +454,7 @@ impl AIDocumentModel {
         };
         BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
             let terminal_view_id =
-                history_model.terminal_view_id_for_conversation(&conversation_id);
+                history_model.terminal_surface_id_for_conversation(&conversation_id);
             if let Some(conversation) = history_model.conversation_mut(&conversation_id) {
                 conversation.update_plan_notebook_uid(
                     document_id,

--- a/app/src/ai/execution_profiles/profiles.rs
+++ b/app/src/ai/execution_profiles/profiles.rs
@@ -159,7 +159,9 @@ impl AIExecutionProfilesModel {
                 let default_profile_state = match launch_mode {
                     // The TUI front-end is an app-style client, so it shares the
                     // GUI app's cloud-synced default execution profile.
-                    LaunchMode::App { .. } | LaunchMode::Test { .. } | LaunchMode::Tui => {
+                    LaunchMode::App { .. }
+                    | LaunchMode::Test { .. }
+                    | LaunchMode::Tui { .. } => {
                         match default_profile_from_cloud {
                             Some(p) => {
                                 let execution_profile_id = ClientProfileId::new();

--- a/app/src/ai/persisted_workspace.rs
+++ b/app/src/ai/persisted_workspace.rs
@@ -261,14 +261,14 @@ impl PersistedWorkspace {
                 &BlocklistAIHistoryModel::handle(ctx),
                 |me, _, event, ctx| {
                     if let BlocklistAIHistoryEvent::StartedNewConversation {
-                        terminal_view_id,
+                        terminal_surface_id,
                         ..
                     } = event
                     {
                         #[cfg(feature = "local_fs")]
                         me.clean_up_deleted_indices(ctx);
 
-                        me.trigger_incremental_sync_for_conversation(*terminal_view_id, ctx);
+                        me.trigger_incremental_sync_for_conversation(*terminal_surface_id, ctx);
                     }
                 },
             );

--- a/app/src/context_chips/display.rs
+++ b/app/src/context_chips/display.rs
@@ -126,8 +126,11 @@ impl PromptDisplay {
         ctx.subscribe_to_model(
             &BlocklistAIHistoryModel::handle(ctx),
             |me, _, event, ctx| {
-                if let BlocklistAIHistoryEvent::UpdatedTodoList { terminal_view_id } = event {
-                    if *terminal_view_id != me.terminal_view_id {
+                if let BlocklistAIHistoryEvent::UpdatedTodoList {
+                    terminal_surface_id,
+                } = event
+                {
+                    if *terminal_surface_id != me.terminal_view_id {
                         return;
                     }
                     ctx.notify();

--- a/app/src/integration_testing/agent_mode/assertions.rs
+++ b/app/src/integration_testing/agent_mode/assertions.rs
@@ -522,7 +522,7 @@ pub fn assert_no_suggested_prompt() -> AssertionCallback {
         let terminal_view = terminal_view(app, window_id, 0, 0);
         BlocklistAIHistoryModel::handle(app).update(app, |history_model, _| {
             let mut exchanges =
-                history_model.all_live_root_task_exchanges_for_terminal_view(terminal_view.id());
+                history_model.all_live_root_task_exchanges_for_terminal_surface(terminal_view.id());
 
             if exchanges.any(|exchange| {
                 let AIAgentOutputStatus::Finished { finished_output } = &exchange.output_status
@@ -647,7 +647,7 @@ fn get_conversation(
         ConversationTarget::Only => {
             // Get all conversations (including passive ones)
             let mut conversations: Vec<_> = history_model
-                .all_live_conversations_for_terminal_view(terminal_view_id)
+                .all_live_conversations_for_terminal_surface(terminal_view_id)
                 .collect();
             match conversations.len() {
                 1 => conversations.pop().ok_or(AssertionOutcome::failure(
@@ -1102,7 +1102,7 @@ pub fn assert_no_exchanges() -> AssertionCallback {
         let terminal_view = terminal_view(app, window_id, 0, 0);
         BlocklistAIHistoryModel::handle(app).update(app, |history_model, _| {
             let exchange_count = history_model
-                .all_live_root_task_exchanges_for_terminal_view(terminal_view.id())
+                .all_live_root_task_exchanges_for_terminal_surface(terminal_view.id())
                 .count();
 
             if exchange_count == 0 {

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -84,6 +84,8 @@ mod tips;
 mod tracing;
 #[cfg(feature = "tui")]
 mod tui;
+#[cfg(feature = "tui")]
+pub mod tui_export;
 mod ui_components;
 mod undo_close;
 mod uri;
@@ -340,9 +342,9 @@ fn determine_agent_source(
         // processes that don't use the agent subsystem.
         // TODO: the TUI front-end has no agent harness wired up yet; give it an
         // appropriate `AgentSource` once that lands.
-        LaunchMode::RemoteServerProxy | LaunchMode::RemoteServerDaemon { .. } | LaunchMode::Tui => {
-            None
-        }
+        LaunchMode::RemoteServerProxy
+        | LaunchMode::RemoteServerDaemon { .. }
+        | LaunchMode::Tui { .. } => None,
     }
 }
 
@@ -360,13 +362,13 @@ fn daemon_codebase_index_snapshot_storage(launch_mode: &LaunchMode) -> Option<Sn
         | LaunchMode::CommandLine { .. }
         | LaunchMode::RemoteServerProxy
         | LaunchMode::Test { .. }
-        | LaunchMode::Tui => None,
+        | LaunchMode::Tui { .. } => None,
     }
 }
 
 /// Launch mode for how to start up Warp.
 #[allow(clippy::large_enum_variant)]
-pub enum LaunchMode {
+pub(crate) enum LaunchMode {
     /// Run the regular GUI application.
     App {
         args: warp_cli::AppArgs,
@@ -393,10 +395,12 @@ pub enum LaunchMode {
 
     /// Remote server proxy — bridges SSH stdio to the daemon's Unix socket.
     /// This is a short-lived process that runs for the lifetime of an SSH session.
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     RemoteServerProxy,
 
     /// Remote server daemon — long-lived headless process serving remote
     /// connections via a Unix domain socket.
+    #[cfg_attr(not(unix), allow(dead_code))]
     RemoteServerDaemon {
         /// Stable identity key used to partition the daemon's socket/PID
         /// directory on the remote host.
@@ -406,8 +410,15 @@ pub enum LaunchMode {
     /// Run the headless TUI front-end (the `warp-tui` binary in the `warp_tui`
     /// crate). Boots the real headless app so auth/agent state can be reused,
     /// but prints to stdout instead of opening a GUI window.
-    Tui,
+    #[cfg_attr(not(feature = "tui"), allow(dead_code))]
+    Tui {
+        #[cfg(feature = "tui")]
+        frontend: Option<TuiFrontend>,
+    },
 }
+
+#[cfg(feature = "tui")]
+type TuiFrontend = Box<dyn FnOnce(&mut AppContext) -> bool + Send + 'static>;
 
 impl LaunchMode {
     fn args(&self) -> Cow<'_, warp_cli::AppArgs> {
@@ -417,7 +428,7 @@ impl LaunchMode {
             | LaunchMode::Test { .. }
             | LaunchMode::RemoteServerProxy
             | LaunchMode::RemoteServerDaemon { .. }
-            | LaunchMode::Tui => Cow::Owned(warp_cli::AppArgs::default()),
+            | LaunchMode::Tui { .. } => Cow::Owned(warp_cli::AppArgs::default()),
         }
     }
 
@@ -432,7 +443,7 @@ impl LaunchMode {
             | LaunchMode::CommandLine { .. }
             | LaunchMode::RemoteServerProxy
             | LaunchMode::RemoteServerDaemon { .. }
-            | LaunchMode::Tui => false,
+            | LaunchMode::Tui { .. } => false,
         }
     }
 
@@ -443,7 +454,7 @@ impl LaunchMode {
             | LaunchMode::CommandLine { .. }
             | LaunchMode::RemoteServerProxy
             | LaunchMode::RemoteServerDaemon { .. }
-            | LaunchMode::Tui => None,
+            | LaunchMode::Tui { .. } => None,
         }
     }
 
@@ -461,7 +472,7 @@ impl LaunchMode {
             LaunchMode::CommandLine { .. } => ExecutionMode::Sdk,
             LaunchMode::Test { .. } => ExecutionMode::App,
             // The TUI front-end is an app-style client, not the SDK.
-            LaunchMode::Tui => ExecutionMode::App,
+            LaunchMode::Tui { .. } => ExecutionMode::App,
             // RemoteServerProxy is a thin byte bridge; Sdk is the closest match.
             LaunchMode::RemoteServerProxy => ExecutionMode::Sdk,
             // RemoteServerDaemon gets its own mode for distinct Sentry tagging.
@@ -476,7 +487,7 @@ impl LaunchMode {
             | LaunchMode::Test { .. }
             | LaunchMode::RemoteServerProxy
             | LaunchMode::RemoteServerDaemon { .. }
-            | LaunchMode::Tui => false,
+            | LaunchMode::Tui { .. } => false,
         }
     }
 
@@ -489,7 +500,7 @@ impl LaunchMode {
             },
             LaunchMode::RemoteServerProxy | LaunchMode::RemoteServerDaemon { .. } => true,
             // The TUI front-end renders to the terminal, with no GUI window.
-            LaunchMode::Tui => true,
+            LaunchMode::Tui { .. } => true,
             LaunchMode::App { .. } | LaunchMode::Test { .. } => false,
         }
     }
@@ -507,7 +518,7 @@ impl LaunchMode {
             LaunchMode::RemoteServerProxy => false,
             // TODO: no agent harness is wired up for the TUI front-end yet;
             // enable indexing once it is.
-            LaunchMode::Tui => false,
+            LaunchMode::Tui { .. } => false,
         }
     }
 
@@ -520,7 +531,7 @@ impl LaunchMode {
             | LaunchMode::Test { .. }
             | LaunchMode::RemoteServerProxy
             | LaunchMode::RemoteServerDaemon { .. }
-            | LaunchMode::Tui => false,
+            | LaunchMode::Tui { .. } => false,
         }
     }
 
@@ -533,7 +544,7 @@ impl LaunchMode {
             | LaunchMode::Test { .. }
             | LaunchMode::RemoteServerDaemon { .. }
             | LaunchMode::RemoteServerProxy
-            | LaunchMode::Tui => true,
+            | LaunchMode::Tui { .. } => true,
         }
     }
 
@@ -545,7 +556,7 @@ impl LaunchMode {
             | LaunchMode::Test { .. }
             | LaunchMode::RemoteServerDaemon { .. }
             | LaunchMode::RemoteServerProxy
-            | LaunchMode::Tui => true,
+            | LaunchMode::Tui { .. } => true,
         }
     }
 
@@ -564,7 +575,7 @@ impl LaunchMode {
             LaunchMode::RemoteServerDaemon { .. } => Some(LogDestination::File),
             // A TUI owns the terminal, so logs go to a file; stdout/stderr would
             // corrupt the rendered output and the device-code prompt.
-            LaunchMode::Tui => Some(LogDestination::File),
+            LaunchMode::Tui { .. } => Some(LogDestination::File),
             LaunchMode::App { .. } | LaunchMode::Test { .. } => None,
         }
     }
@@ -576,7 +587,7 @@ impl LaunchMode {
             LaunchMode::Test { .. } => "test",
             LaunchMode::RemoteServerDaemon { .. } => "remote_server_daemon",
             LaunchMode::RemoteServerProxy => "remote_server_proxy",
-            LaunchMode::Tui => "tui",
+            LaunchMode::Tui { .. } => "tui",
         }
     }
 
@@ -674,83 +685,7 @@ pub fn run() -> Result<()> {
             warp_util::windows::attach_to_parent_console();
         }
         match command {
-            #[cfg(all(feature = "local_tty", unix))]
-            warp_cli::Command::Worker(warp_cli::WorkerCommand::TerminalServer(args)) => {
-                // If we were asked to run as a terminal server (as opposed to the main
-                // GUI application), do so immediately.  Ideally, the terminal server would
-                // be a separate binary, but it's much easier to distribute a single binary,
-                // so starting the terminal server event loop immediately is the closest
-                // approximation we can get to running a separate binary.
-                crate::terminal::local_tty::server::run_terminal_server(args);
-                return Ok(());
-            }
-            #[cfg(feature = "plugin_host")]
-            warp_cli::Command::Worker(warp_cli::WorkerCommand::PluginHost { .. }) => {
-                return crate::run_plugin_host();
-            }
-            #[cfg(feature = "local_tty")]
-            warp_cli::Command::Worker(warp_cli::WorkerCommand::MinidumpServer { socket_name }) => {
-                cfg_if::cfg_if! {
-                    if #[cfg(all(linux_or_windows, feature = "crash_reporting"))] {
-                        return crate::crash_reporting::run_minidump_server(socket_name);
-                    } else {
-                        let _ = socket_name;
-                        panic!("The minidump server is not supported on this platform");
-                    }
-                }
-            }
-            #[cfg(not(target_family = "wasm"))]
-            warp_cli::Command::Worker(warp_cli::WorkerCommand::RemoteServerProxy(args)) => {
-                // Proxy is a thin byte bridge (stdin/stdout ↔ Unix socket).
-                // It only needs logging to stderr since stdout is the protocol
-                // channel. No crash reporting, no initialize_app.
-                let launch_mode = LaunchMode::RemoteServerProxy;
-                let mut tracing_initialization = tracing::init()?;
-                warp_logging::init(warp_logging::LogConfig {
-                    is_cli: true,
-                    log_destination: launch_mode.log_destination(),
-                    ..Default::default()
-                })?;
-                tracing_initialization.log_initialization_warning();
-                return crate::remote_server::run_proxy(args.identity_key.clone());
-            }
-            #[cfg(not(target_family = "wasm"))]
-            warp_cli::Command::Worker(warp_cli::WorkerCommand::RemoteServerDaemon(args)) => {
-                // Daemon handles its own full initialization (including
-                // initialize_app and crash reporting) inside run_daemon_app.
-                return crate::remote_server::run_daemon(args.identity_key.clone());
-            }
-            #[cfg(not(target_family = "wasm"))]
-            warp_cli::Command::Worker(warp_cli::WorkerCommand::RipgrepSearch {
-                parent,
-                ignore_case,
-                multiline,
-                pattern,
-                paths,
-            }) => {
-                warp_ripgrep::search::run_search_subprocess(
-                    std::slice::from_ref(pattern),
-                    paths.clone(),
-                    *ignore_case,
-                    *multiline,
-                    parent.pid,
-                )
-                .map_err(|err| anyhow!(err.to_string()))?;
-                return Ok(());
-            }
-            #[cfg(not(any(
-                feature = "local_tty",
-                feature = "plugin_host",
-                not(target_family = "wasm")
-            )))]
-            warp_cli::Command::Worker(worker) => {
-                // Need this case to handle platforms where there are no enum variants in
-                // warp_cli::WorkerCommand, as we still need to check Command::Worker.
-
-                // On wasm, specifically, we should fail spectacularly if we get here.
-                #[cfg(target_family = "wasm")]
-                panic!("Worker process not supported on WASM: {worker:?}")
-            }
+            warp_cli::Command::Worker(worker) => return run_worker_command(worker),
             warp_cli::Command::Completions { shell } => {
                 return warp_cli::completions::generate_to_stdout(*shell);
             }
@@ -801,6 +736,79 @@ pub fn run() -> Result<()> {
     })
 }
 
+/// Runs a parsed Warp worker command.
+fn run_worker_command(worker: &warp_cli::WorkerCommand) -> Result<()> {
+    match worker {
+        #[cfg(all(feature = "local_tty", unix))]
+        warp_cli::WorkerCommand::TerminalServer(args) => {
+            crate::terminal::local_tty::server::run_terminal_server(args);
+            Ok(())
+        }
+        #[cfg(feature = "plugin_host")]
+        warp_cli::WorkerCommand::PluginHost { .. } => crate::run_plugin_host(),
+        #[cfg(feature = "local_tty")]
+        warp_cli::WorkerCommand::MinidumpServer { socket_name } => {
+            cfg_if::cfg_if! {
+                if #[cfg(all(linux_or_windows, feature = "crash_reporting"))] {
+                    crate::crash_reporting::run_minidump_server(socket_name)
+                } else {
+                    let _ = socket_name;
+                    panic!("The minidump server is not supported on this platform");
+                }
+            }
+        }
+        #[cfg(not(target_family = "wasm"))]
+        warp_cli::WorkerCommand::RemoteServerProxy(args) => {
+            // Proxy is a thin byte bridge (stdin/stdout ↔ Unix socket).
+            // It only needs logging to stderr since stdout is the protocol
+            // channel. No crash reporting, no initialize_app.
+            let launch_mode = LaunchMode::RemoteServerProxy;
+            let mut tracing_initialization = tracing::init()?;
+            warp_logging::init(warp_logging::LogConfig {
+                is_cli: true,
+                log_destination: launch_mode.log_destination(),
+                ..Default::default()
+            })?;
+            tracing_initialization.log_initialization_warning();
+            crate::remote_server::run_proxy(args.identity_key.clone())
+        }
+        #[cfg(not(target_family = "wasm"))]
+        warp_cli::WorkerCommand::RemoteServerDaemon(args) => {
+            // Daemon handles its own full initialization (including
+            // initialize_app and crash reporting) inside run_daemon_app.
+            crate::remote_server::run_daemon(args.identity_key.clone())
+        }
+        #[cfg(not(target_family = "wasm"))]
+        warp_cli::WorkerCommand::RipgrepSearch {
+            parent,
+            ignore_case,
+            multiline,
+            pattern,
+            paths,
+        } => {
+            warp_ripgrep::search::run_search_subprocess(
+                std::slice::from_ref(pattern),
+                paths.clone(),
+                *ignore_case,
+                *multiline,
+                parent.pid,
+            )
+            .map_err(|err| anyhow!(err.to_string()))?;
+            Ok(())
+        }
+        #[cfg(not(any(
+            feature = "local_tty",
+            feature = "plugin_host",
+            not(target_family = "wasm")
+        )))]
+        worker => {
+            // On wasm, specifically, we should fail spectacularly if we get here.
+            #[cfg(target_family = "wasm")]
+            panic!("Worker process not supported on WASM: {worker:?}")
+        }
+    }
+}
+
 /// Runs an integration test using the provided test driver.
 pub fn run_integration_test(driver: TestDriver) -> Result<()> {
     let is_integration_test = std::env::var("WARP_INTEGRATION").is_ok();
@@ -811,11 +819,34 @@ pub fn run_integration_test(driver: TestDriver) -> Result<()> {
     run_internal(launch)
 }
 
-/// Runs the headless TUI front-end (the `warp-tui` binary in the `warp_tui`
-/// crate). Bootstraps the real (headless) app and runs the step-1 auth flow.
+/// Boots the app and invokes a headless TUI frontend after authentication.
 #[cfg(feature = "tui")]
-pub fn run_tui() -> Result<()> {
-    run_internal(LaunchMode::Tui)
+pub fn run_tui(frontend: impl FnOnce(&mut AppContext) -> bool + Send + 'static) -> Result<()> {
+    run_internal(LaunchMode::Tui {
+        frontend: Some(Box::new(frontend)),
+    })
+}
+
+/// Dispatches a worker command when the current executable was re-invoked for one.
+#[cfg(feature = "tui")]
+pub fn run_tui_worker_if_requested() -> Option<Result<()>> {
+    // Worker spawners always put the worker mode in argv[1]. Do not scan later
+    // arguments because a TUI prompt value may legitimately match a worker name.
+    let is_worker = std::env::args()
+        .nth(1)
+        .is_some_and(|arg| warp_cli::is_worker_invocation(&arg));
+    if !is_worker {
+        return None;
+    }
+
+    features::init_feature_flags();
+    let args = warp_cli::Args::from_env();
+    let Some(warp_cli::Command::Worker(worker)) = args.command() else {
+        return Some(Err(anyhow!(
+            "Recognized a Warp worker invocation, but failed to parse its worker command"
+        )));
+    };
+    Some(run_worker_command(worker))
 }
 
 /// Runs the app (or CLI / daemon).
@@ -1004,24 +1035,13 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
     // files, modified signal handlers, etc.) to avoid unexpected effects on
     // spawned ptys.
     //
-    // The TUI front-end has no PTYs, so it skips this entirely. This is also
-    // load-bearing: the terminal server is spawned by re-exec'ing the current
-    // binary, but the `warp-tui` binary always runs the TUI (it doesn't dispatch
-    // worker subcommands), so spawning a server here would recursively launch
-    // more TUIs — a fork bomb.
     #[cfg(feature = "local_tty")]
-    let pty_spawner = if matches!(launch_mode, LaunchMode::Tui) {
-        None
-    } else {
-        Some(
-            terminal::local_tty::spawner::PtySpawner::new()
-                .context("Failed to create pty spawner")?,
-        )
-    };
+    let pty_spawner =
+        terminal::local_tty::spawner::PtySpawner::new().context("Failed to create pty spawner")?;
 
     // The TUI front-end skips the GUI lifecycle callbacks (which reach for
     // singletons/windows it never creates), so it uses empty callbacks.
-    let callbacks = if matches!(launch_mode, LaunchMode::Tui) {
+    let callbacks = if matches!(launch_mode, LaunchMode::Tui { .. }) {
         warpui::platform::AppCallbacks::default()
     } else {
         app_callbacks(
@@ -1131,13 +1151,9 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
         #[cfg(feature = "crash_reporting")]
         crate::crash_reporting::set_client_type_tag(launch_mode.execution_mode().client_id());
 
-        // Add the terminal server singleton to the application. The TUI
-        // front-end sets `pty_spawner` to `None` (fork-bomb avoidance), so only
-        // register it when present.
+        // Add the terminal server singleton to the application.
         #[cfg(feature = "local_tty")]
-        if let Some(pty_spawner) = pty_spawner {
-            ctx.add_singleton_model(move |_ctx| pty_spawner);
-        }
+        ctx.add_singleton_model(move |_ctx| pty_spawner);
 
         // Register user preferences.  This must be done before initializing
         // feature flags or experiments, both of which check user preferences for
@@ -1169,8 +1185,13 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
         // auth/`AuthManager` exist), but runs its own init instead of the
         // GUI/CLI `launch()` path.
         #[cfg(feature = "tui")]
-        if matches!(launch_mode, LaunchMode::Tui) {
-            crate::tui::init(ctx);
+        if let LaunchMode::Tui { frontend } = &mut launch_mode {
+            crate::tui::init(
+                frontend
+                    .take()
+                    .expect("TUI frontend must be initialized exactly once"),
+                ctx,
+            );
             return;
         }
 
@@ -1333,7 +1354,7 @@ pub(crate) fn initialize_app(
         | LaunchMode::CommandLine { .. }
         | LaunchMode::RemoteServerProxy
         | LaunchMode::Test { .. }
-        | LaunchMode::Tui => persistence::PersistenceScope::App,
+        | LaunchMode::Tui { .. } => persistence::PersistenceScope::App,
     };
     let (sqlite_data, writer_handles) = persistence::initialize(ctx, persistence_scope);
     timer.mark_interval_end("SQLITE_INITIALIZED");
@@ -2754,7 +2775,7 @@ fn launch(ctx: &mut warpui::AppContext, app_state: Option<AppState>, launch_mode
     match launch_mode {
         // The TUI front-end runs its own init in the run closure and returns
         // before reaching launch().
-        LaunchMode::Tui => unreachable!("LaunchMode::Tui is handled before launch()"),
+        LaunchMode::Tui { .. } => unreachable!("LaunchMode::Tui is handled before launch()"),
         LaunchMode::App { .. } | LaunchMode::Test { .. } => {
             let should_skip_restore = launch_mode
                 .args()

--- a/app/src/pane_group/child_agent/restoration.rs
+++ b/app/src/pane_group/child_agent/restoration.rs
@@ -78,12 +78,9 @@ impl PaneGroup {
             .terminal_view_from_pane_id(terminal_pane_id, ctx)
             .and_then(|terminal_view| {
                 let terminal_view = terminal_view.as_ref(ctx);
-                let agent_view_state = terminal_view
-                    .agent_view_controller()
-                    .as_ref(ctx)
-                    .agent_view_state();
-                if agent_view_state.is_fullscreen() {
-                    agent_view_state.active_conversation_id()
+                let controller = terminal_view.agent_view_controller().as_ref(ctx);
+                if controller.is_fullscreen() {
+                    controller.agent_view_state().active_conversation_id()
                 } else {
                     None
                 }

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -2347,7 +2347,7 @@ impl PaneGroup {
 
         // Find terminal view via document -> conversation -> terminal view.
         let terminal_view = BlocklistAIHistoryModel::as_ref(ctx)
-            .terminal_view_id_for_conversation(&conversation_id)
+            .terminal_surface_id_for_conversation(&conversation_id)
             .and_then(|terminal_view_id| {
                 // Find the pane containing this terminal view.
                 self.pane_contents.keys().find_map(|pane_id| {
@@ -3150,7 +3150,7 @@ impl PaneGroup {
         conversation_id: AIConversationId,
         ctx: &AppContext,
     ) -> Option<EntityId> {
-        BlocklistAIHistoryModel::as_ref(ctx).terminal_view_id_for_conversation(&conversation_id)
+        BlocklistAIHistoryModel::as_ref(ctx).terminal_surface_id_for_conversation(&conversation_id)
     }
 
     fn pane_id_for_owned_conversation(
@@ -3597,7 +3597,7 @@ impl PaneGroup {
 
             BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, _ctx| {
                 history_model
-                    .mark_terminal_view_as_conversation_transcript_viewer(terminal_view.id());
+                    .mark_terminal_surface_as_conversation_transcript_viewer(terminal_view.id());
             });
 
             Self::terminal_pane_data(
@@ -3690,7 +3690,8 @@ impl PaneGroup {
         }
 
         BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, _ctx| {
-            history_model.mark_terminal_view_as_conversation_transcript_viewer(terminal_view.id());
+            history_model
+                .mark_terminal_surface_as_conversation_transcript_viewer(terminal_view.id());
         });
 
         if let Some(ref terminal_manager) = terminal_manager {
@@ -4458,7 +4459,7 @@ impl PaneGroup {
 
             // Preserve conversations from terminal views before cleaning up the pane
             BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, _| {
-                history_model.mark_conversations_historical_for_terminal_view(terminal_view_id);
+                history_model.mark_conversations_historical_for_terminal_surface(terminal_view_id);
             });
         }
 
@@ -4482,12 +4483,12 @@ impl PaneGroup {
         let history_handle = BlocklistAIHistoryModel::handle(ctx);
         let transfers: Vec<(AIConversationId, EntityId)> = history_handle
             .as_ref(ctx)
-            .all_live_conversations_for_terminal_view(closing_view_id)
+            .all_live_conversations_for_terminal_surface(closing_view_id)
             .filter_map(|conversation| {
                 let parent_id = conversation.parent_conversation_id()?;
                 let parent_owner = history_handle
                     .as_ref(ctx)
-                    .terminal_view_id_for_conversation(&parent_id)?;
+                    .terminal_surface_id_for_conversation(&parent_id)?;
                 if parent_owner == closing_view_id {
                     return None;
                 }
@@ -4562,7 +4563,7 @@ impl PaneGroup {
                     .conversation(conv_id)
                     .and_then(|c| c.parent_conversation_id())
                     .and_then(|parent_id| {
-                        history_model.terminal_view_id_for_conversation(&parent_id)
+                        history_model.terminal_surface_id_for_conversation(&parent_id)
                     })
                     .is_some_and(|tv_id| tv_id == parent_terminal_view_id)
             })
@@ -6101,7 +6102,8 @@ impl PaneGroup {
         });
 
         BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, _ctx| {
-            history_model.mark_terminal_view_as_conversation_transcript_viewer(terminal_view.id());
+            history_model
+                .mark_terminal_surface_as_conversation_transcript_viewer(terminal_view.id());
         });
 
         // Register the transcript viewer as an ambient session so it appears in the Active section
@@ -6901,7 +6903,7 @@ impl PaneGroup {
         ctx: &AppContext,
     ) -> Option<PaneId> {
         let owner_view_id = BlocklistAIHistoryModel::as_ref(ctx)
-            .terminal_view_id_for_conversation(&conversation_id)?;
+            .terminal_surface_id_for_conversation(&conversation_id)?;
         for pane_id in self.pane_contents.keys() {
             if let Some(terminal_view) = self.terminal_view_from_pane_id(*pane_id, ctx) {
                 if terminal_view.id() == owner_view_id {
@@ -6931,7 +6933,7 @@ impl PaneGroup {
             // No owning pane in this group (e.g. the conversation lives
             // in another tab). Fall back to workspace-level navigation.
             if let Some(owner_view_id) = BlocklistAIHistoryModel::as_ref(ctx)
-                .terminal_view_id_for_conversation(&conversation_id)
+                .terminal_surface_id_for_conversation(&conversation_id)
             {
                 ctx.dispatch_typed_action(&WorkspaceAction::FocusTerminalViewInWorkspace {
                     terminal_view_id: owner_view_id,
@@ -7236,7 +7238,7 @@ impl PaneGroup {
     ) {
         let history_model = BlocklistAIHistoryModel::as_ref(ctx);
         let history_owner_view_id =
-            history_model.terminal_view_id_for_conversation(&conversation_id);
+            history_model.terminal_surface_id_for_conversation(&conversation_id);
         let conversation_in_memory = history_model.conversation(&conversation_id).is_some();
         let parent_id = history_model
             .conversation(&conversation_id)

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -2019,7 +2019,7 @@ fn test_ensure_hidden_child_agent_pane_skips_child_owned_by_another_pane_group()
             assert_eq!(panes.pane_count(), initial_pane_count);
             assert_eq!(
                 BlocklistAIHistoryModel::as_ref(ctx)
-                    .terminal_view_id_for_conversation(&child_conversation_id),
+                    .terminal_surface_id_for_conversation(&child_conversation_id),
                 Some(child_owner_terminal_view_id)
             );
         });
@@ -2065,7 +2065,7 @@ fn test_entering_parent_agent_view_skips_child_owned_by_another_pane_group() {
             assert_eq!(panes.pane_count(), initial_pane_count);
             assert_eq!(
                 BlocklistAIHistoryModel::as_ref(ctx)
-                    .terminal_view_id_for_conversation(&child_conversation_id),
+                    .terminal_surface_id_for_conversation(&child_conversation_id),
                 Some(child_owner_terminal_view_id)
             );
         });

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -424,7 +424,7 @@ impl PaneContent for TerminalPane {
             // permanently closed.
             BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
                 history_model
-                    .clear_conversations_in_terminal_view(self.terminal_view(ctx).id(), ctx);
+                    .clear_conversations_for_terminal_surface(self.terminal_view(ctx).id(), ctx);
             });
             self.delete_blocks(ctx);
         }
@@ -558,7 +558,7 @@ impl PaneContent for TerminalPane {
 
             // Collect all conversation IDs for this terminal view
             let conversation_ids_to_restore = BlocklistAIHistoryModel::as_ref(app)
-                .all_live_conversations_for_terminal_view(self.terminal_view(app).id())
+                .all_live_conversations_for_terminal_surface(self.terminal_view(app).id())
                 .map(|conversation| conversation.id())
                 .collect();
 
@@ -619,7 +619,7 @@ impl PaneContent for TerminalPane {
             // TODO(roland): store conversation id or server conversation token on the model ConversationTranscriptViewerStatus
             if let Some(conversation) = history_model
                 .as_ref(ctx)
-                .all_live_conversations_for_terminal_view(terminal_view_id)
+                .all_live_conversations_for_terminal_surface(terminal_view_id)
                 .next()
             {
                 if let Some(token) = conversation.server_conversation_token() {
@@ -689,7 +689,7 @@ fn agent_conversation_action_state(
     let history_model = BlocklistAIHistoryModel::as_ref(ctx);
     let conversation = history_model.conversation(&conversation_id)?;
     let owner_terminal_view_id =
-        history_model.terminal_view_id_for_conversation(&conversation_id)?;
+        history_model.terminal_surface_id_for_conversation(&conversation_id)?;
     Some(AgentConversationActionState {
         owner_terminal_view_id,
         task_id: conversation.task_id(),
@@ -2130,7 +2130,7 @@ fn handle_ai_history_event(
     };
 
     if event
-        .terminal_view_id()
+        .terminal_surface_id()
         .is_some_and(|id| id != terminal_view_id)
     {
         return;
@@ -2219,7 +2219,7 @@ fn handle_ai_history_event(
                 },
             );
         }
-        BlocklistAIHistoryEvent::ClearedConversationsInTerminalView { .. }
+        BlocklistAIHistoryEvent::ClearedConversationsForTerminalSurface { .. }
         | BlocklistAIHistoryEvent::ClearedActiveConversation { .. } => {
             ctx.emit(pane_group::Event::InvalidatedActiveConversation);
         }
@@ -2260,7 +2260,7 @@ fn handle_ai_history_event(
         | BlocklistAIHistoryEvent::UpdatedConversationMetadata { .. }
         | BlocklistAIHistoryEvent::UpdatedConversationArtifacts { .. }
         | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. }
-        | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. }
+        | BlocklistAIHistoryEvent::ConversationTransferredBetweenTerminalSurfaces { .. }
         | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. }
         | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. }
         | BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. }

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -3187,7 +3187,7 @@ impl Input {
                     BlocklistAIHistoryEvent::UpdatedConversationStatus { .. }
                         | BlocklistAIHistoryEvent::SetActiveConversation { .. }
                         | BlocklistAIHistoryEvent::ClearedActiveConversation { .. }
-                        | BlocklistAIHistoryEvent::ClearedConversationsInTerminalView { .. }
+                        | BlocklistAIHistoryEvent::ClearedConversationsForTerminalSurface { .. }
                         | BlocklistAIHistoryEvent::StartedNewConversation { .. }
                         | BlocklistAIHistoryEvent::SplitConversation { .. }
                         | BlocklistAIHistoryEvent::AppendedExchange { .. }
@@ -3199,7 +3199,7 @@ impl Input {
                 if !affects_hint {
                     return;
                 }
-                if event.terminal_view_id() != Some(terminal_view_id) {
+                if event.terminal_surface_id() != Some(terminal_view_id) {
                     return;
                 }
                 me.set_zero_state_hint_text(ctx);
@@ -11396,7 +11396,7 @@ impl Input {
         if self
             .ai_context_model
             .as_ref(ctx)
-            .is_targeting_existing_conversation()
+            .is_targeting_existing_conversation(ctx)
         {
             self.ai_context_model.update(ctx, |ai_context_model, ctx| {
                 ai_context_model.set_pending_query_state_for_new_conversation(
@@ -16051,7 +16051,7 @@ impl View for Input {
         }
 
         if BlocklistAIHistoryModel::as_ref(app)
-            .all_live_conversations_for_terminal_view(self.terminal_view_id)
+            .all_live_conversations_for_terminal_surface(self.terminal_view_id)
             .any(|conversation| conversation.initial_user_query().is_some())
         {
             ctx.set.insert("ActiveAIConversationHasHistory");
@@ -16301,7 +16301,7 @@ fn maybe_render_ai_input_indicators(
 
     let all_icons = if ai_context_model
         .as_ref(app)
-        .is_targeting_existing_conversation()
+        .is_targeting_existing_conversation(app)
     {
         let reply_icon = render_ai_follow_up_icon(ai_follow_up_icon_mouse_state, app);
         Flex::row()

--- a/app/src/terminal/input/inline_history/data_source.rs
+++ b/app/src/terminal/input/inline_history/data_source.rs
@@ -155,7 +155,7 @@ impl InlineHistoryMenuDataSource {
         let mut conversation_entries: Vec<MenuEntry> = Vec::new();
         let history_model = BlocklistAIHistoryModel::handle(app).as_ref(app);
         for conversation in
-            history_model.all_live_conversations_for_terminal_view(self.terminal_view_id)
+            history_model.all_live_conversations_for_terminal_surface(self.terminal_view_id)
         {
             if conversation.is_entirely_passive() || conversation.exchange_count() == 0 {
                 continue;

--- a/app/src/terminal/input/models/view.rs
+++ b/app/src/terminal/input/models/view.rs
@@ -342,11 +342,11 @@ impl InlineModelSelectorView {
             &BlocklistAIHistoryModel::handle(ctx),
             move |me, _, event, ctx| {
                 if let BlocklistAIHistoryEvent::UpdatedConversationStatus {
-                    terminal_view_id: event_terminal_view_id,
+                    terminal_surface_id: event_terminal_surface_id,
                     ..
                 } = event
                 {
-                    if *event_terminal_view_id == terminal_view_id {
+                    if *event_terminal_surface_id == terminal_view_id {
                         me.menu_view.update(ctx, |_, ctx| ctx.notify());
                     }
                 }

--- a/app/src/terminal/input/slash_commands/data_source/mod.rs
+++ b/app/src/terminal/input/slash_commands/data_source/mod.rs
@@ -424,8 +424,12 @@ impl SlashCommandDataSource {
     /// command. Conversations without a `task_id` are local and never qualify.
     #[cfg(not(target_family = "wasm"))]
     fn active_conversation_is_cloud_oz(&self, ctx: &AppContext) -> bool {
-        let agent_view_state = self.agent_view_controller.as_ref(ctx).agent_view_state();
-        let conversation_id = match agent_view_state.active_conversation_id() {
+        let conversation_id = match self
+            .agent_view_controller
+            .as_ref(ctx)
+            .agent_view_state()
+            .active_conversation_id()
+        {
             Some(id) => id,
             None => match BlocklistAIHistoryModel::as_ref(ctx)
                 .active_conversation(self.terminal_view_id)

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -1673,6 +1673,9 @@ fn simulate_agent_requested_lrc(
     terminal: &ViewHandle<TerminalView>,
 ) -> AIConversationId {
     let conversation_id = seed_in_progress_conversation(app, terminal);
+    // Mirror production: the conversation is selected (agent view entered) before the agent
+    // requests the command. Selecting after the LRC is active would be rejected.
+    select_conversation(app, terminal, conversation_id);
 
     terminal.update(app, |view, _ctx| {
         let mut model = view.model.lock();
@@ -1699,6 +1702,8 @@ fn simulate_user_tagged_agent_controlled_lrc(
     terminal: &ViewHandle<TerminalView>,
 ) -> AIConversationId {
     let conversation_id = seed_in_progress_conversation(app, terminal);
+    // Mirror production: the conversation is selected before the command becomes long-running.
+    select_conversation(app, terminal, conversation_id);
     terminal.update(app, |view, _ctx| {
         let mut model = view.model.lock();
         model.simulate_long_running_block("sleep 10", "running");
@@ -1714,9 +1719,10 @@ fn simulate_user_tagged_agent_controlled_lrc(
     conversation_id
 }
 
-/// Selects `conversation_id` for the input via the pending-query state. AgentView must be
-/// disabled so `selected_conversation_id` resolves from this state directly.
-fn select_conversation_via_pending_query_state(
+/// Selects `conversation_id` for the input so `selected_conversation_id` resolves to it.
+/// Routes through the context model, which enters agent view for the conversation. The
+/// conversation must already exist in history and no long-running command may be active.
+fn select_conversation(
     app: &mut App,
     terminal: &ViewHandle<TerminalView>,
     conversation_id: AIConversationId,
@@ -1745,7 +1751,6 @@ fn prompt_submission_auto_queues_during_agent_requested_lrc() {
 
         let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
         let conversation_id = simulate_agent_requested_lrc(&mut app, &terminal);
-        select_conversation_via_pending_query_state(&mut app, &terminal, conversation_id);
         let input = terminal.read(&app, |view, _| view.input().clone());
 
         input.update(&mut app, |input, ctx| {
@@ -1777,7 +1782,6 @@ fn prompt_submission_during_lrc_with_non_lrc_queue_head_uses_generic_origin() {
 
         let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
         let conversation_id = simulate_agent_requested_lrc(&mut app, &terminal);
-        select_conversation_via_pending_query_state(&mut app, &terminal, conversation_id);
         QueuedQueryModel::handle(&app).update(&mut app, |model, ctx| {
             model.append(
                 conversation_id,
@@ -1832,7 +1836,6 @@ fn prompt_submission_during_lrc_with_lrc_queue_head_uses_lrc_origin() {
 
         let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
         let conversation_id = simulate_agent_requested_lrc(&mut app, &terminal);
-        select_conversation_via_pending_query_state(&mut app, &terminal, conversation_id);
         QueuedQueryModel::handle(&app).update(&mut app, |model, ctx| {
             model.append(
                 conversation_id,
@@ -1887,7 +1890,6 @@ fn prompt_submission_does_not_auto_queue_for_user_tagged_lrc() {
 
         let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
         let conversation_id = simulate_user_tagged_agent_controlled_lrc(&mut app, &terminal);
-        select_conversation_via_pending_query_state(&mut app, &terminal, conversation_id);
         let input = terminal.read(&app, |view, _| view.input().clone());
 
         input.update(&mut app, |input, ctx| {
@@ -1912,7 +1914,6 @@ fn prompt_submission_is_not_queued_during_lrc_when_set_to_send_immediately() {
 
         let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
         let conversation_id = simulate_agent_requested_lrc(&mut app, &terminal);
-        select_conversation_via_pending_query_state(&mut app, &terminal, conversation_id);
         AISettings::handle(&app).update(&mut app, |settings, ctx| {
             let _ = settings
                 .long_running_command_submission_mode
@@ -1944,7 +1945,6 @@ fn prompt_submission_during_lrc_with_queue_default_uses_generic_origin() {
 
         let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
         let conversation_id = simulate_agent_requested_lrc(&mut app, &terminal);
-        select_conversation_via_pending_query_state(&mut app, &terminal, conversation_id);
         AISettings::handle(&app).update(&mut app, |settings, ctx| {
             let _ = settings
                 .default_prompt_submission_mode
@@ -2030,8 +2030,7 @@ fn ghost_text_shows_queue_hint_during_agent_requested_lrc() {
         initialize_app(&mut app);
 
         let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
-        let conversation_id = simulate_agent_requested_lrc(&mut app, &terminal);
-        select_conversation_via_pending_query_state(&mut app, &terminal, conversation_id);
+        simulate_agent_requested_lrc(&mut app, &terminal);
         let input = terminal.read(&app, |view, _| view.input().clone());
 
         let hint = input.update(&mut app, |input, ctx| {
@@ -2049,8 +2048,7 @@ fn ghost_text_shows_queue_hint_during_agent_requested_lrc() {
 fn shell_submission_queues_as_command_row_when_gated_under_v2() {
     // A shell-mode submission while a queued command is already in flight is captured as a
     // command row (not executed and not interrupting the queue), carries no attachments, and
-    // clears the editor. AgentView is disabled so `selected_conversation_id` resolves from the
-    // pending-query state we set directly.
+    // clears the editor.
     App::test((), |mut app| async move {
         let _agent_view = FeatureFlag::AgentView.override_enabled(false);
         let _queue_slash_command = FeatureFlag::QueueSlashCommand.override_enabled(true);
@@ -2060,20 +2058,11 @@ fn shell_submission_queues_as_command_row_when_gated_under_v2() {
         let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
         let input = terminal.read(&app, |view, _| view.input().clone());
 
-        // Select a conversation (pending-query state), turn on auto-queue, and mark a command as
-        // in flight so the gate keeps queueing while the agent is idle.
-        let conversation_id = AIConversationId::new();
-        terminal.update(&mut app, |view, ctx| {
-            view.ai_context_model().update(ctx, |context_model, ctx| {
-                context_model.set_pending_query_state_for_existing_conversation(
-                    conversation_id,
-                    AgentViewEntryOrigin::Input {
-                        was_prompt_autodetected: false,
-                    },
-                    ctx,
-                );
-            });
-        });
+        // Select a conversation, turn on auto-queue, and mark a command as in flight so the gate
+        // keeps queueing while the agent is idle.
+        let terminal_view_id = terminal.read(&app, |view, _| view.id());
+        let conversation_id = seed_active_conversation(&mut app, terminal_view_id);
+        select_conversation(&mut app, &terminal, conversation_id);
         QueuedQueryModel::handle(&app).update(&mut app, |model, ctx| {
             model.toggle_queue_next_prompt(conversation_id, ctx);
             model.arm_command_in_flight(conversation_id);
@@ -2111,18 +2100,9 @@ fn shell_submission_is_not_queued_when_v2_disabled() {
         let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
         let input = terminal.read(&app, |view, _| view.input().clone());
 
-        let conversation_id = AIConversationId::new();
-        terminal.update(&mut app, |view, ctx| {
-            view.ai_context_model().update(ctx, |context_model, ctx| {
-                context_model.set_pending_query_state_for_existing_conversation(
-                    conversation_id,
-                    AgentViewEntryOrigin::Input {
-                        was_prompt_autodetected: false,
-                    },
-                    ctx,
-                );
-            });
-        });
+        let terminal_view_id = terminal.read(&app, |view, _| view.id());
+        let conversation_id = seed_active_conversation(&mut app, terminal_view_id);
+        select_conversation(&mut app, &terminal, conversation_id);
         QueuedQueryModel::handle(&app).update(&mut app, |model, ctx| {
             model.toggle_queue_next_prompt(conversation_id, ctx);
             model.arm_command_in_flight(conversation_id);

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -2132,7 +2132,7 @@ fn slash_fork_bypasses_prompt_queue_while_in_progress() {
 
         let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
         let conversation_id = seed_in_progress_conversation(&mut app, &terminal);
-        select_conversation_via_pending_query_state(&mut app, &terminal, conversation_id);
+        select_conversation(&mut app, &terminal, conversation_id);
         QueuedQueryModel::handle(&app).update(&mut app, |model, ctx| {
             model.toggle_queue_next_prompt(conversation_id, ctx);
         });
@@ -2167,7 +2167,7 @@ fn slash_compact_still_queues_while_in_progress() {
 
         let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
         let conversation_id = seed_in_progress_conversation(&mut app, &terminal);
-        select_conversation_via_pending_query_state(&mut app, &terminal, conversation_id);
+        select_conversation(&mut app, &terminal, conversation_id);
         QueuedQueryModel::handle(&app).update(&mut app, |model, ctx| {
             model.toggle_queue_next_prompt(conversation_id, ctx);
         });

--- a/app/src/terminal/local_tty/mod.rs
+++ b/app/src/terminal/local_tty/mod.rs
@@ -30,6 +30,8 @@ use serde::{Deserialize, Serialize};
 use shell::ShellStarter;
 
 pub use self::terminal_manager::{get_shell_starter, TerminalManager};
+#[cfg(feature = "tui")]
+pub use self::terminal_manager::{TerminalManagerInit, TerminalSurfaceInit, TerminalSurfaceResult};
 #[cfg(windows)]
 pub use self::terminal_view_adaptor::shutdown_all_pty_event_loops;
 pub(crate) use self::terminal_view_adaptor::{

--- a/app/src/terminal/local_tty/terminal_manager.rs
+++ b/app/src/terminal/local_tty/terminal_manager.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ffi::OsString;
@@ -110,19 +111,19 @@ pub struct TerminalManager<S> {
 }
 
 /// Shared inputs needed to construct a terminal surface for a local PTY.
-pub(crate) struct TerminalSurfaceInit {
-    pub(super) wakeups_rx: async_channel::Receiver<()>,
-    pub(super) model_events: ModelHandle<ModelEventDispatcher>,
-    pub(super) model: Arc<FairMutex<TerminalModel>>,
-    pub(super) sessions: ModelHandle<Sessions>,
-    pub(super) size_info: SizeInfo,
-    pub(super) colors: ColorList,
-    pub(super) inactive_pty_reads_rx: InactiveReceiver<Arc<Vec<u8>>>,
+pub struct TerminalSurfaceInit {
+    pub wakeups_rx: async_channel::Receiver<()>,
+    pub model_events: ModelHandle<ModelEventDispatcher>,
+    pub model: Arc<FairMutex<TerminalModel>>,
+    pub sessions: ModelHandle<Sessions>,
+    pub size_info: SizeInfo,
+    pub colors: ColorList,
+    pub inactive_pty_reads_rx: InactiveReceiver<Arc<Vec<u8>>>,
 }
 /// A newly constructed terminal surface and its manager post-wiring callback.
-pub(crate) struct TerminalSurfaceResult<S, PostWire> {
-    pub(super) surface: ViewHandle<S>,
-    pub(super) post_wire: PostWire,
+pub struct TerminalSurfaceResult<S, PostWire> {
+    pub surface: ViewHandle<S>,
+    pub post_wire: PostWire,
 }
 
 /// One-shot resources consumed when the shell is determined and the PTY starts.
@@ -134,9 +135,24 @@ struct ShellStartupResources {
 }
 
 /// Handles created for a local terminal manager and its surface.
-pub(crate) struct TerminalManagerInit<S> {
-    pub(crate) manager: ModelHandle<Box<dyn TerminalManagerTrait>>,
-    pub(crate) surface: ViewHandle<S>,
+pub struct TerminalManagerInit<S> {
+    pub manager: ModelHandle<Box<dyn TerminalManagerTrait>>,
+    pub surface: ViewHandle<S>,
+}
+/// Adapts a TUI-owned surface manager to Warp's type-erased manager contract.
+struct TuiTerminalManager<S>(TerminalManager<S>);
+
+impl<S: 'static> TerminalManagerTrait for TuiTerminalManager<S> {
+    fn model(&self) -> Arc<FairMutex<TerminalModel>> {
+        self.0.model()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        &self.0
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        &mut self.0
+    }
 }
 
 impl<S> Drop for TerminalManager<S> {
@@ -168,6 +184,82 @@ impl<S> TerminalManager<S> {
         <S as Entity>::Event: PtyIntentEvent,
         Self: TerminalManagerTrait,
         PostWire: FnOnce(&mut Self, &ViewHandle<S>, &mut AppContext),
+    {
+        Self::create_model_with_manager(
+            startup_directory,
+            env_vars,
+            is_shared_session_creator,
+            all_restored_blocks,
+            user_default_shell_unsupported_banner_model_handle,
+            initial_size,
+            model_event_sender,
+            chosen_shell,
+            ctx,
+            create_surface,
+            |manager| Box::new(manager),
+        )
+    }
+
+    /// Creates a local terminal manager for a TUI-owned terminal surface.
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_tui_model<PostWire>(
+        startup_directory: Option<PathBuf>,
+        env_vars: HashMap<OsString, OsString>,
+        is_shared_session_creator: IsSharedSessionCreator,
+        all_restored_blocks: Option<&Vec<SerializedBlockListItem>>,
+        user_default_shell_unsupported_banner_model_handle: ModelHandle<BannerState>,
+        initial_size: Vector2F,
+        model_event_sender: Option<SyncSender<ModelEvent>>,
+        chosen_shell: Option<AvailableShell>,
+        ctx: &mut AppContext,
+        create_surface: impl FnOnce(
+            TerminalSurfaceInit,
+            &mut AppContext,
+        ) -> TerminalSurfaceResult<S, PostWire>,
+    ) -> TerminalManagerInit<S>
+    where
+        S: TerminalSurface,
+        <S as Entity>::Event: PtyIntentEvent,
+        PostWire: FnOnce(&mut Self, &ViewHandle<S>, &mut AppContext),
+    {
+        Self::create_model_with_manager(
+            startup_directory,
+            env_vars,
+            is_shared_session_creator,
+            all_restored_blocks,
+            user_default_shell_unsupported_banner_model_handle,
+            initial_size,
+            model_event_sender,
+            chosen_shell,
+            ctx,
+            create_surface,
+            |manager| Box::new(TuiTerminalManager(manager)),
+        )
+    }
+
+    /// Creates a manager using the supplied type-erasure adapter.
+    #[allow(clippy::too_many_arguments)]
+    fn create_model_with_manager<PostWire, BoxManager>(
+        startup_directory: Option<PathBuf>,
+        env_vars: HashMap<OsString, OsString>,
+        is_shared_session_creator: IsSharedSessionCreator,
+        all_restored_blocks: Option<&Vec<SerializedBlockListItem>>,
+        user_default_shell_unsupported_banner_model_handle: ModelHandle<BannerState>,
+        initial_size: Vector2F,
+        model_event_sender: Option<SyncSender<ModelEvent>>,
+        chosen_shell: Option<AvailableShell>,
+        ctx: &mut AppContext,
+        create_surface: impl FnOnce(
+            TerminalSurfaceInit,
+            &mut AppContext,
+        ) -> TerminalSurfaceResult<S, PostWire>,
+        box_manager: BoxManager,
+    ) -> TerminalManagerInit<S>
+    where
+        S: TerminalSurface,
+        <S as Entity>::Event: PtyIntentEvent,
+        PostWire: FnOnce(&mut Self, &ViewHandle<S>, &mut AppContext),
+        BoxManager: FnOnce(Self) -> Box<dyn TerminalManagerTrait> + 'static,
     {
         let (wakeups_tx, wakeups_rx) = async_channel::unbounded();
         let (events_tx, events_rx) = async_channel::unbounded();
@@ -318,8 +410,7 @@ impl<S> TerminalManager<S> {
         };
 
         let terminal_manager_model = ctx.add_model(|ctx| {
-            let terminal_manager: Box<dyn TerminalManagerTrait> = Box::new(terminal_manager);
-
+            let terminal_manager = box_manager(terminal_manager);
             ctx.spawn(
                 async move {
                     match wsl_name_or_shell_starter {
@@ -359,7 +450,7 @@ impl<S> TerminalManager<S> {
     }
 
     /// Returns the terminal model owned by this manager.
-    pub(super) fn model(&self) -> Arc<FairMutex<TerminalModel>> {
+    pub(crate) fn model(&self) -> Arc<FairMutex<TerminalModel>> {
         self.model.clone()
     }
 

--- a/app/src/terminal/local_tty/terminal_view_adaptor.rs
+++ b/app/src/terminal/local_tty/terminal_view_adaptor.rs
@@ -476,11 +476,11 @@ fn wire_up_terminal_view_session_sharing(
         move |_, event, ctx| {
             match event {
                 BlocklistAIHistoryEvent::UpdatedStreamingExchange {
-                    terminal_view_id,
+                    terminal_surface_id,
                     conversation_id,
                     ..
                 } => {
-                    if *terminal_view_id != view_id_for_stream_init {
+                    if *terminal_surface_id != view_id_for_stream_init {
                         return;
                     }
 
@@ -517,8 +517,10 @@ fn wire_up_terminal_view_session_sharing(
                         ctx,
                     );
                 }
-                BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { terminal_view_id } => {
-                    if *terminal_view_id != view_id_for_stream_init {
+                BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride {
+                    terminal_surface_id,
+                } => {
+                    if *terminal_surface_id != view_id_for_stream_init {
                         return;
                     }
 
@@ -555,10 +557,10 @@ fn wire_up_terminal_view_session_sharing(
                 // `UpdateSourceType` upstream message) until they
                 // reconnect.
                 BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
-                    terminal_view_id,
+                    terminal_surface_id,
                     conversation_id,
                 } => {
-                    if *terminal_view_id != view_id_for_stream_init {
+                    if *terminal_surface_id != view_id_for_stream_init {
                         return;
                     }
 
@@ -626,7 +628,7 @@ impl TerminalManager<TerminalView> {
         // Get all conversations for this terminal view
         // Any conversation could be continued during session sharing
         let conversations: Vec<AIConversation> = BlocklistAIHistoryModel::as_ref(ctx)
-            .all_live_conversations_for_terminal_view(terminal_view.id())
+            .all_live_conversations_for_terminal_surface(terminal_view.id())
             .filter(|conv| conv.exchange_count() > 0)
             .cloned()
             .collect();
@@ -715,7 +717,7 @@ impl TerminalManager<TerminalView> {
         if matches!(source.source_type, SessionSourceType::AmbientAgent { .. }) {
             let terminal_view_id = terminal_view.id();
             BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, _ctx| {
-                history.mark_terminal_view_as_ambient_agent_session_view(terminal_view_id);
+                history.mark_terminal_surface_as_ambient_agent_session_view(terminal_view_id);
             });
         }
 

--- a/app/src/terminal/mod.rs
+++ b/app/src/terminal/mod.rs
@@ -82,6 +82,8 @@ pub mod view;
 pub mod warpify;
 mod waterfall_gap_element;
 mod writeable_pty;
+#[cfg(feature = "tui")]
+pub use writeable_pty::{PtyIntent, PtyIntentEvent, TerminalSurface};
 #[cfg(windows)]
 pub mod wsl;
 

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -1623,6 +1623,11 @@ impl BlockList {
         &self.agent_view_state
     }
 
+    /// Returns the selected conversation cached in the terminal render snapshot.
+    pub fn active_conversation_id(&self) -> Option<AIConversationId> {
+        self.agent_view_state.active_conversation_id()
+    }
+
     /// Sets the agent view state for this blocklist.
     ///
     /// With `FeatureFlag::AgentView` enabled, if the state is active, only blocks corresponding to

--- a/app/src/terminal/shared_session/share_modal/body.rs
+++ b/app/src/terminal/shared_session/share_modal/body.rs
@@ -81,7 +81,7 @@ impl Body {
         ctx: &ViewContext<Self>,
     ) -> Byte {
         let conversations: Vec<_> = BlocklistAIHistoryModel::as_ref(ctx)
-            .all_live_conversations_for_terminal_view(terminal_view_id)
+            .all_live_conversations_for_terminal_surface(terminal_view_id)
             .filter(|conv| conv.exchange_count() > 0)
             .cloned()
             .collect();
@@ -121,7 +121,7 @@ impl Body {
         // Check if agent shared sessions is enabled and there are active conversations
         self.has_agent_conversations = if FeatureFlag::AgentSharedSessions.is_enabled() {
             BlocklistAIHistoryModel::as_ref(ctx)
-                .all_live_conversations_for_terminal_view(terminal_view_id)
+                .all_live_conversations_for_terminal_surface(terminal_view_id)
                 .any(|conv| conv.exchange_count() > 0)
         } else {
             false

--- a/app/src/terminal/shared_session/shared_handlers.rs
+++ b/app/src/terminal/shared_session/shared_handlers.rs
@@ -209,8 +209,11 @@ pub(crate) fn apply_selected_conversation_update(
                 view.ai_context_model().update(ctx, |context_model, ctx| {
                     if FeatureFlag::AgentView.is_enabled() {
                         // Check if we're already in an empty agent view to avoid feedback loop.
-                        let agent_view_state = agent_view_controller.as_ref(ctx).agent_view_state();
-                        if let Some(conversation_id) = agent_view_state.active_conversation_id() {
+                        if let Some(conversation_id) = agent_view_controller
+                            .as_ref(ctx)
+                            .agent_view_state()
+                            .active_conversation_id()
+                        {
                             let history_model = BlocklistAIHistoryModel::handle(ctx);
                             let is_empty = history_model
                                 .as_ref(ctx)
@@ -315,11 +318,13 @@ fn build_selected_conversation_update_agent_view_enabled(
     history_model: &ModelHandle<BlocklistAIHistoryModel>,
     ctx: &mut AppContext,
 ) -> Option<UniversalDeveloperInputContextUpdate> {
-    let agent_view_state = agent_view_controller.as_ref(ctx).agent_view_state();
-
-    let selected_conversation = if !agent_view_state.is_active() {
+    let agent_view_controller = agent_view_controller.as_ref(ctx);
+    let selected_conversation = if !agent_view_controller.is_active() {
         SelectedConversation::NoConversation
-    } else if let Some(conversation_id) = agent_view_state.active_conversation_id() {
+    } else if let Some(conversation_id) = agent_view_controller
+        .agent_view_state()
+        .active_conversation_id()
+    {
         let conversation = history_model.as_ref(ctx).conversation(&conversation_id);
         let server_token_opt = conversation
             .and_then(|c| c.server_conversation_token().cloned())

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
@@ -175,11 +175,13 @@ impl OrchestrationViewerModel {
 
         match event {
             BlocklistAIHistoryEvent::SetActiveConversation {
-                terminal_view_id, ..
+                terminal_surface_id,
+                ..
             }
             | BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
-                terminal_view_id, ..
-            } if *terminal_view_id == self.terminal_view_id => {
+                terminal_surface_id,
+                ..
+            } if *terminal_surface_id == self.terminal_view_id => {
                 self.register_viewer_mode_consumer_if_possible(ctx);
             }
             _ => {}

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
@@ -720,7 +720,7 @@ fn child_status_changed_with_unknown_run_id_is_silently_dropped() {
         history.read(&app, |history, _| {
             assert!(
                 history
-                    .all_live_conversations_for_terminal_view(terminal_view_id)
+                    .all_live_conversations_for_terminal_surface(terminal_view_id)
                     .filter(|conversation| conversation.is_viewing_shared_session())
                     .count()
                     == 0,
@@ -1199,7 +1199,7 @@ fn b2_backfills_parent_agent_id_on_orchestrator_token_assigned() {
         });
         let synthetic_event = BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
             conversation_id: parent_conv_id,
-            terminal_view_id,
+            terminal_surface_id: terminal_view_id,
         };
         model_handle.update(&mut app, |model, ctx| {
             model.maybe_backfill_parent_agent_ids(&synthetic_event, ctx);
@@ -1263,7 +1263,7 @@ fn b2_does_not_overwrite_existing_parent_agent_id() {
         // Now fire a backfill: the existing `parent_agent_id` must stay.
         let synthetic_event = BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
             conversation_id: parent_conv_id,
-            terminal_view_id,
+            terminal_surface_id: terminal_view_id,
         };
         model_handle.update(&mut app, |model, ctx| {
             model.maybe_backfill_parent_agent_ids(&synthetic_event, ctx);
@@ -1305,7 +1305,7 @@ fn b2_ignores_token_assigned_for_unrelated_conversation() {
         // backfill handler must short-circuit on the parent-mismatch check.
         let unrelated_event = BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
             conversation_id: AIConversationId::new(),
-            terminal_view_id,
+            terminal_surface_id: terminal_view_id,
         };
         model_handle.update(&mut app, |model, ctx| {
             model.maybe_backfill_parent_agent_ids(&unrelated_event, ctx);
@@ -1315,7 +1315,7 @@ fn b2_ignores_token_assigned_for_unrelated_conversation() {
         // the orchestrator id is still unknown.
         let still_no_parent_id = BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
             conversation_id: parent_conv_id,
-            terminal_view_id,
+            terminal_surface_id: terminal_view_id,
         };
         model_handle.update(&mut app, |model, ctx| {
             model.maybe_backfill_parent_agent_ids(&still_no_parent_id, ctx);
@@ -1350,7 +1350,7 @@ fn make_appended_exchange_event(
     BlocklistAIHistoryEvent::AppendedExchange {
         exchange_id: AIAgentExchangeId::new(),
         task_id: TaskId::new("test-task".to_string()),
-        terminal_view_id,
+        terminal_surface_id: terminal_view_id,
         conversation_id,
         is_hidden: false,
         response_stream_id: None,

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -668,9 +668,9 @@ impl TerminalManager {
                     #[allow(clippy::single_match)]
                     match event {
                         BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride {
-                            terminal_view_id,
+                            terminal_surface_id,
                         } => {
-                            if *terminal_view_id != view_id_for_auto {
+                            if *terminal_surface_id != view_id_for_auto {
                                 return;
                             }
 
@@ -828,7 +828,7 @@ impl TerminalManager {
                 if matches!(&source.source_type, SessionSourceType::AmbientAgent { .. }) {
                     let terminal_view_id = view.id();
                     BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, _ctx| {
-                        history.mark_terminal_view_as_ambient_agent_session_view(terminal_view_id);
+                        history.mark_terminal_surface_as_ambient_agent_session_view(terminal_view_id);
                     });
 
                     // Register this ambient session as active for conversation list tracking.
@@ -1715,7 +1715,7 @@ impl TerminalManager {
         // When a shared session ends for a viewer, cancel any in-progress conversations.
         BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
             history_model
-                .all_live_conversations_for_terminal_view(terminal_view_id)
+                .all_live_conversations_for_terminal_surface(terminal_view_id)
                 .filter(|conversation| conversation.status().is_in_progress())
                 .map(|conversation| conversation.id())
                 .collect::<Vec<_>>()

--- a/app/src/terminal/universal_developer_input.rs
+++ b/app/src/terminal/universal_developer_input.rs
@@ -557,7 +557,7 @@ impl UniversalDeveloperInputButtonBar {
             &BlocklistAIHistoryModel::handle(ctx),
             |me, _, event, ctx| {
                 if event
-                    .terminal_view_id()
+                    .terminal_surface_id()
                     .is_some_and(|id| id != me.terminal_view_id)
                 {
                     return;

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -220,9 +220,9 @@ use crate::ai::blocklist::agent_view::agent_input_footer::toolbar_item::AgentToo
 use crate::ai::blocklist::agent_view::{
     agent_view_bg_fill, fork_from_last_known_good_state_exchange_id,
     get_agent_view_entry_block_position_id, is_in_cloud_context, AgentViewController,
-    AgentViewControllerEvent, AgentViewDisplayMode, AgentViewEntryBlockParams,
-    AgentViewEntryOrigin, AgentViewHeaderDisabledTheme, AgentViewHeaderTheme,
-    AgentViewZeroStateBlock, AgentViewZeroStateEvent, EphemeralMessageModel,
+    AgentViewControllerEvent, AgentViewConversationSelection, AgentViewDisplayMode,
+    AgentViewEntryBlockParams, AgentViewEntryOrigin, AgentViewHeaderDisabledTheme,
+    AgentViewHeaderTheme, AgentViewZeroStateBlock, AgentViewZeroStateEvent, EphemeralMessageModel,
     ExitConfirmationTrigger, InlineAgentViewHeader, OrchestrationPillBar,
     ENTER_OR_EXIT_CONFIRMATION_WINDOW,
 };
@@ -254,13 +254,13 @@ use crate::ai::blocklist::{
     BlocklistAIActionModel, BlocklistAIContextEvent, BlocklistAIContextModel,
     BlocklistAIController, BlocklistAIControllerEvent, BlocklistAIHistoryEvent,
     BlocklistAIHistoryModel, BlocklistAIInputEvent, BlocklistAIInputModel, ClientIdentifiers,
-    ConversationStatusUpdate, InputConfig, InputType, InputTypeAutoDetectionSource,
-    LegacyPassiveSuggestionsEvent, LegacyPassiveSuggestionsModel, MaaPassiveSuggestionsEvent,
-    MaaPassiveSuggestionsModel, PassiveSuggestionsModels, PendingAttachment, PendingQueryState,
-    QueuedQuery, QueuedQueryId, QueuedQueryModel, QueuedQueryOrigin, RequestFileEditsFormatKind,
-    ShellCommandExecutor, ShellCommandExecutorEvent, SlashCommandRequest, StartAgentExecutor,
-    StartAgentExecutorEvent, StartAgentRequest, ATTACH_AS_AGENT_MODE_CONTEXT_TEXT,
-    PRE_REWIND_PREFIX,
+    ConversationSelection, ConversationStatusUpdate, InputConfig, InputType,
+    InputTypeAutoDetectionSource, LegacyPassiveSuggestionsEvent, LegacyPassiveSuggestionsModel,
+    MaaPassiveSuggestionsEvent, MaaPassiveSuggestionsModel, PassiveSuggestionsModels,
+    PendingAttachment, PendingQueryState, QueuedQuery, QueuedQueryId, QueuedQueryModel,
+    QueuedQueryOrigin, RequestFileEditsFormatKind, ShellCommandExecutor, ShellCommandExecutorEvent,
+    SlashCommandRequest, StartAgentExecutor, StartAgentExecutorEvent, StartAgentRequest,
+    ATTACH_AS_AGENT_MODE_CONTEXT_TEXT, PRE_REWIND_PREFIX,
 };
 use crate::ai::conversation_details_panel::ConversationDetailsPanelEvent;
 use crate::ai::conversation_utils;
@@ -3444,20 +3444,27 @@ impl TerminalView {
             ctx.notify();
         });
 
+        let conversation_selection = ctx.add_model(|ctx| {
+            Box::new(AgentViewConversationSelection::new(
+                terminal_view_id,
+                agent_view_controller.clone(),
+                ctx,
+            )) as Box<dyn ConversationSelection>
+        });
         let ai_context_model = ctx.add_model(|ctx| {
             BlocklistAIContextModel::new(
                 sessions.clone(),
                 &model_events_handle,
                 model.clone(),
                 terminal_view_id,
-                agent_view_controller.clone(),
+                conversation_selection.clone(),
                 ctx,
             )
         });
         let ai_input_model = ctx.add_model(|ctx| {
             let mut model = BlocklistAIInputModel::new(
                 model.clone(),
-                agent_view_controller.clone(),
+                conversation_selection.clone(),
                 ai_context_model.clone(),
                 terminal_view_id,
                 ctx,
@@ -3488,9 +3495,9 @@ impl TerminalView {
             BlocklistAIController::new(
                 ai_input_model.clone(),
                 ai_context_model.clone(),
+                conversation_selection.clone(),
                 ai_action_model.clone(),
                 active_session.clone(),
-                agent_view_controller.clone(),
                 model.clone(),
                 terminal_view_id,
                 ctx,
@@ -4835,7 +4842,7 @@ impl TerminalView {
         let Some(parent_id) = parent_id else {
             return false;
         };
-        let parent_terminal_view_id = history.terminal_view_id_for_conversation(&parent_id);
+        let parent_terminal_view_id = history.terminal_surface_id_for_conversation(&parent_id);
 
         if let Some(parent_terminal_view_id) = parent_terminal_view_id {
             // Defer so it runs after in-flight event handling completes.
@@ -5984,20 +5991,20 @@ impl TerminalView {
             }
             | BlocklistAIHistoryEvent::UpdatedConversationTitle {
                 conversation_id, ..
-            } => history_model.terminal_view_id_for_conversation(conversation_id),
+            } => history_model.terminal_surface_id_for_conversation(conversation_id),
             BlocklistAIHistoryEvent::ReassignedExchange {
                 new_conversation_id,
                 ..
-            } => history_model.terminal_view_id_for_conversation(new_conversation_id),
+            } => history_model.terminal_surface_id_for_conversation(new_conversation_id),
             BlocklistAIHistoryEvent::UpdatedConversationMetadata {
                 conversation_id, ..
-            } => history_model.terminal_view_id_for_conversation(conversation_id),
+            } => history_model.terminal_surface_id_for_conversation(conversation_id),
             BlocklistAIHistoryEvent::StartedNewConversation { .. }
             | BlocklistAIHistoryEvent::CreatedSubtask { .. }
             | BlocklistAIHistoryEvent::UpgradedTask { .. }
             | BlocklistAIHistoryEvent::SetActiveConversation { .. }
             | BlocklistAIHistoryEvent::ClearedActiveConversation { .. }
-            | BlocklistAIHistoryEvent::ClearedConversationsInTerminalView { .. }
+            | BlocklistAIHistoryEvent::ClearedConversationsForTerminalSurface { .. }
             | BlocklistAIHistoryEvent::UpdatedTodoList { .. }
             | BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. }
             | BlocklistAIHistoryEvent::SplitConversation { .. }
@@ -6005,7 +6012,7 @@ impl TerminalView {
             | BlocklistAIHistoryEvent::DeletedConversation { .. }
             | BlocklistAIHistoryEvent::RestoredConversations { .. }
             | BlocklistAIHistoryEvent::ConversationServerTokenAssigned { .. }
-            | BlocklistAIHistoryEvent::ConversationOwnershipTransferred { .. }
+            | BlocklistAIHistoryEvent::ConversationTransferredBetweenTerminalSurfaces { .. }
             | BlocklistAIHistoryEvent::NewConversationRequestComplete { .. }
             | BlocklistAIHistoryEvent::OrchestrationConfigUpdated { .. }
             | BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. }
@@ -6023,7 +6030,7 @@ impl TerminalView {
         let should_handle = match self.render_owner_for_ai_history_event(history_model_ref, event) {
             Some(owner_terminal_view_id) => owner_terminal_view_id == self.view_id,
             None => event
-                .terminal_view_id()
+                .terminal_surface_id()
                 .is_none_or(|terminal_view_id| terminal_view_id == self.view_id),
         };
         if !should_handle {
@@ -6455,7 +6462,7 @@ impl TerminalView {
             BlocklistAIHistoryEvent::UpdatedConversationTitle { .. } => {
                 self.update_pane_configuration(ctx);
             }
-            BlocklistAIHistoryEvent::ClearedConversationsInTerminalView {
+            BlocklistAIHistoryEvent::ClearedConversationsForTerminalSurface {
                 active_conversation_id,
                 ..
             } => {
@@ -6477,9 +6484,9 @@ impl TerminalView {
                 });
                 self.is_using_conversation_for_pane_header_title = false;
             }
-            BlocklistAIHistoryEvent::ConversationOwnershipTransferred {
+            BlocklistAIHistoryEvent::ConversationTransferredBetweenTerminalSurfaces {
                 conversation_id,
-                previous_terminal_view_id,
+                previous_terminal_surface_id,
                 ..
             } => {
                 // The conversation has moved to another terminal view. We are
@@ -6488,7 +6495,7 @@ impl TerminalView {
                 // rendered blocks tagged to this conversation. Leave the
                 // agent-view entry in place so the user can click it to
                 // navigate to the current owner pane later.
-                if *previous_terminal_view_id != self.view_id {
+                if *previous_terminal_surface_id != self.view_id {
                     return;
                 }
                 let view_ids_to_remove = self
@@ -13175,7 +13182,7 @@ impl TerminalView {
         }
 
         let mut child_conversation_ids = BlocklistAIHistoryModel::as_ref(ctx)
-            .all_live_conversations_for_terminal_view(self.view_id)
+            .all_live_conversations_for_terminal_surface(self.view_id)
             .filter(|conversation| conversation.is_child_agent_conversation())
             .map(|conversation| conversation.id());
         let child_conversation_id = child_conversation_ids.next()?;
@@ -18819,7 +18826,7 @@ impl TerminalView {
         // When we clear the blocklist, the user can't see past AI exchanges anymore, so these conversations should no longer
         // appear active for the terminal view anymore.
         BlocklistAIHistoryModel::handle(ctx).update(ctx, |ai_history_model, ctx| {
-            ai_history_model.clear_conversations_in_terminal_view(self.view_id, ctx)
+            ai_history_model.clear_conversations_for_terminal_surface(self.view_id, ctx)
         });
 
         // No more restored blocks, since we just cleared the buffer

--- a/app/src/terminal/view/agent_view.rs
+++ b/app/src/terminal/view/agent_view.rs
@@ -133,7 +133,7 @@ impl TerminalView {
             let in_memory_conversation = history_model_ref.conversation(&conversation_id).cloned();
             let is_live = in_memory_conversation.is_some()
                 && history_model_ref
-                    .all_live_conversations_for_terminal_view(self.view_id)
+                    .all_live_conversations_for_terminal_surface(self.view_id)
                     .any(|conversation| conversation.id() == conversation_id);
             (in_memory_conversation, is_live)
         };

--- a/app/src/terminal/view/queued_prompts_panel.rs
+++ b/app/src/terminal/view/queued_prompts_panel.rs
@@ -456,7 +456,7 @@ impl QueuedPromptsPanelView {
         ctx: &mut ViewContext<Self>,
     ) {
         let is_for_this_view = event
-            .terminal_view_id()
+            .terminal_surface_id()
             .is_some_and(|id| id == self.terminal_view_id);
         if !is_for_this_view {
             return;

--- a/app/src/terminal/view/queued_prompts_tests.rs
+++ b/app/src/terminal/view/queued_prompts_tests.rs
@@ -567,7 +567,7 @@ fn terminal_cloud_status_transition_drains_once_through_cloud_followup_input_eve
                 history_model.clone(),
                 &BlocklistAIHistoryEvent::UpdatedConversationStatus {
                     conversation_id,
-                    terminal_view_id,
+                    terminal_surface_id: terminal_view_id,
                     update: ConversationStatusUpdate::Changed {
                         prev_status: ConversationStatus::InProgress,
                     },
@@ -579,7 +579,7 @@ fn terminal_cloud_status_transition_drains_once_through_cloud_followup_input_eve
                 history_model,
                 &BlocklistAIHistoryEvent::UpdatedConversationStatus {
                     conversation_id,
-                    terminal_view_id,
+                    terminal_surface_id: terminal_view_id,
                     update: ConversationStatusUpdate::Changed {
                         prev_status: ConversationStatus::Success,
                     },

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
@@ -254,11 +254,11 @@ pub(in crate::terminal::view) fn conversation_failed_before_task_creation(
     terminal_view_id: EntityId,
     history_model: &BlocklistAIHistoryModel,
 ) -> bool {
-    if history_model.is_terminal_view_conversation_transcript_viewer(terminal_view_id) {
+    if history_model.is_terminal_surface_conversation_transcript_viewer(terminal_view_id) {
         return false;
     }
     history_model
-        .all_live_conversations_for_terminal_view(terminal_view_id)
+        .all_live_conversations_for_terminal_surface(terminal_view_id)
         .next()
         .and_then(conversation_output_status_from_conversation)
         .is_some_and(|status| matches!(status, AmbientConversationStatus::Error { .. }))
@@ -270,7 +270,7 @@ fn local_conversation_id_for_local_continuation(
     history_model: &BlocklistAIHistoryModel,
 ) -> Option<AIConversationId> {
     history_model
-        .all_live_conversations_for_terminal_view(terminal_view_id)
+        .all_live_conversations_for_terminal_surface(terminal_view_id)
         .find(|conversation| conversation.server_conversation_token() == Some(conversation_token))
         .map(|conversation| conversation.id())
         .or_else(|| history_model.find_conversation_id_by_server_token(conversation_token))

--- a/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
+++ b/app/src/terminal/view/shared_session/conversation_ended_tombstone_view.rs
@@ -69,10 +69,10 @@ impl TombstoneDisplayData {
         let conversation_is_transcript = !has_task_id
             && history_model
                 .as_ref(ctx)
-                .is_terminal_view_conversation_transcript_viewer(terminal_view_id);
+                .is_terminal_surface_conversation_transcript_viewer(terminal_view_id);
         let conversation = history_model
             .as_ref(ctx)
-            .all_live_conversations_for_terminal_view(terminal_view_id)
+            .all_live_conversations_for_terminal_surface(terminal_view_id)
             .find(|c| c.id() == conversation_id);
 
         let Some(conversation) = conversation else {
@@ -175,7 +175,7 @@ impl ConversationEndedTombstoneView {
     ) -> Self {
         let conversation_id = BlocklistAIHistoryModel::handle(ctx)
             .as_ref(ctx)
-            .all_live_conversations_for_terminal_view(terminal_view_id)
+            .all_live_conversations_for_terminal_surface(terminal_view_id)
             .next()
             .map(|c| c.id());
 

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -129,13 +129,13 @@ impl TerminalView {
                 return None;
             }
 
-            let is_cloud_conversation_surface = model.is_shared_ambient_agent_session()
+            let is_cloud_conversation_selection = model.is_shared_ambient_agent_session()
                 || model.is_conversation_transcript_viewer()
                 || self
                     .ambient_agent_view_model
                     .as_ref()
                     .is_some_and(|model| model.as_ref(ctx).is_ambient_agent());
-            if !is_cloud_conversation_surface {
+            if !is_cloud_conversation_selection {
                 return None;
             }
 
@@ -569,7 +569,7 @@ impl TerminalView {
             && scrollback_type == SharedSessionScrollbackType::None
         {
             let has_conversations = BlocklistAIHistoryModel::as_ref(ctx)
-                .all_live_conversations_for_terminal_view(ctx.handle().id())
+                .all_live_conversations_for_terminal_surface(ctx.handle().id())
                 .any(|conv| conv.exchange_count() > 0);
 
             if has_conversations {

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -105,6 +105,52 @@ fn has_pending_user_query_block(view: &TerminalView) -> bool {
 }
 
 #[test]
+fn agent_view_lifecycle_updates_input_mode() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        FeatureFlag::AgentView.set_enabled(true);
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        terminal.read(&app, |view, ctx| {
+            assert_eq!(
+                view.ai_input_model().as_ref(ctx).input_type(),
+                InputType::Shell
+            );
+        });
+        terminal.update(&mut app, |view, ctx| {
+            view.agent_view_controller().update(ctx, |controller, ctx| {
+                controller
+                    .try_enter_agent_view(
+                        None,
+                        AgentViewEntryOrigin::Input {
+                            was_prompt_autodetected: false,
+                        },
+                        ctx,
+                    )
+                    .expect("agent view entry should succeed");
+            });
+        });
+        terminal.read(&app, |view, ctx| {
+            assert_eq!(
+                view.ai_input_model().as_ref(ctx).input_type(),
+                InputType::AI
+            );
+        });
+        terminal.update(&mut app, |view, ctx| {
+            view.agent_view_controller().update(ctx, |controller, ctx| {
+                controller.exit_agent_view_without_confirmation(ctx)
+            });
+        });
+        terminal.read(&app, |view, ctx| {
+            assert_eq!(
+                view.ai_input_model().as_ref(ctx).input_type(),
+                InputType::Shell
+            );
+        });
+    });
+}
+
+#[test]
 fn focus_reporting_writes_focus_events_in_normal_screen() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
@@ -227,7 +273,7 @@ fn append_exchange_with_inputs_and_handle_event(
         &BlocklistAIHistoryEvent::AppendedExchange {
             exchange_id,
             task_id: task_id.clone(),
-            terminal_view_id: view.view_id,
+            terminal_surface_id: view.view_id,
             conversation_id,
             is_hidden: false,
             response_stream_id: Some(response_stream_id.clone()),
@@ -263,7 +309,7 @@ fn update_exchange_input_and_handle_event(
         history_model,
         &BlocklistAIHistoryEvent::UpdatedStreamingExchange {
             exchange_id,
-            terminal_view_id: view.view_id,
+            terminal_surface_id: view.view_id,
             conversation_id,
             is_hidden: false,
         },
@@ -394,7 +440,7 @@ fn updated_conversation_metadata_refreshes_selected_conversation_pane_title() {
             view.handle_ai_history_model_event(
                 BlocklistAIHistoryModel::handle(ctx),
                 &BlocklistAIHistoryEvent::UpdatedConversationTitle {
-                    terminal_view_id: Some(view.view_id),
+                    terminal_surface_id: Some(view.view_id),
                     conversation_id,
                     title: "Renamed title".to_string(),
                 },
@@ -762,13 +808,13 @@ fn jump_to_latest_agent_message_enters_agent_view_and_records_pending_scroll() {
         });
 
         terminal.read(&app, |view, ctx| {
-            match view.agent_view_controller().as_ref(ctx).agent_view_state() {
-                AgentViewState::Active {
-                    conversation_id: active_conversation_id,
-                    origin,
-                    ..
-                } => {
-                    assert_eq!(*active_conversation_id, conversation_id);
+            let controller = view.agent_view_controller().as_ref(ctx);
+            match controller.agent_view_state() {
+                AgentViewState::Active { origin, .. } => {
+                    assert_eq!(
+                        controller.agent_view_state().active_conversation_id(),
+                        Some(conversation_id)
+                    );
                     assert_eq!(*origin, AgentViewEntryOrigin::JumpToLatestAgentMessage);
                 }
                 state => panic!("expected an active agent view, got {state:?}"),
@@ -860,18 +906,18 @@ fn jump_to_latest_agent_message_scrolls_without_re_entering_when_already_in_view
 }
 
 #[test]
-fn restoring_conversation_to_new_pane_transfers_blocks_from_previous_owner() {
+fn restoring_conversation_to_new_pane_transfers_blocks_from_previous_terminal_surface() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
-        let original_owner = add_window_with_terminal(&mut app, None);
+        let original_view = add_window_with_terminal(&mut app, None);
         let restored_view = add_window_with_terminal(&mut app, None);
 
-        let original_owner_view_id = original_owner.read(&app, |view, _| view.view_id);
+        let original_view_id = original_view.read(&app, |view, _| view.view_id);
         let restored_view_id = restored_view.read(&app, |view, _| view.view_id);
 
-        let conversation_id = original_owner.update(&mut app, |view, ctx| {
+        let conversation_id = original_view.update(&mut app, |view, ctx| {
             let (conversation_id, _, _, _) = append_exchange_with_inputs_and_handle_event(
                 view,
                 vec![AIAgentInput::UserQuery {
@@ -908,7 +954,7 @@ fn restoring_conversation_to_new_pane_transfers_blocks_from_previous_owner() {
             conversation_id
         });
 
-        original_owner.read(&app, |view, _| {
+        original_view.read(&app, |view, _| {
             assert_eq!(ai_block_count(view), 1);
             assert_eq!(
                 agent_view_entry_count_for_conversation(view, conversation_id),
@@ -938,23 +984,23 @@ fn restoring_conversation_to_new_pane_transfers_blocks_from_previous_owner() {
         });
 
         BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
-            let original_owner_live_conversation_ids = history
-                .all_live_conversations_for_terminal_view(original_owner_view_id)
+            let original_view_live_conversation_ids = history
+                .all_live_conversations_for_terminal_surface(original_view_id)
                 .map(|conversation| conversation.id())
                 .collect::<Vec<_>>();
             let restored_view_live_conversation_ids = history
-                .all_live_conversations_for_terminal_view(restored_view_id)
+                .all_live_conversations_for_terminal_surface(restored_view_id)
                 .map(|conversation| conversation.id())
                 .collect::<Vec<_>>();
             assert_eq!(
-                history.terminal_view_id_for_conversation(&conversation_id),
+                history.terminal_surface_id_for_conversation(&conversation_id),
                 Some(restored_view_id)
             );
-            assert!(original_owner_live_conversation_ids.is_empty());
+            assert!(original_view_live_conversation_ids.is_empty());
             assert_eq!(restored_view_live_conversation_ids, vec![conversation_id]);
         });
 
-        original_owner.read(&app, |view, _| {
+        original_view.read(&app, |view, _| {
             assert_eq!(ai_block_count(view), 0);
             assert_eq!(
                 agent_view_entry_count_for_conversation(view, conversation_id),
@@ -972,19 +1018,20 @@ fn restoring_conversation_to_new_pane_transfers_blocks_from_previous_owner() {
 }
 
 #[test]
-fn clicking_old_banner_for_open_conversation_focuses_current_owner_without_transferring_blocks() {
+fn clicking_old_banner_for_open_conversation_focuses_current_terminal_surface_without_transferring_blocks(
+) {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
-        let original_owner = add_window_with_terminal(&mut app, None);
+        let original_view = add_window_with_terminal(&mut app, None);
         let restored_view = add_window_with_terminal(&mut app, None);
 
-        let original_owner_window_id = app.read(|ctx| original_owner.window_id(ctx));
-        let original_owner_view_id = original_owner.read(&app, |view, _| view.view_id);
+        let original_window_id = app.read(|ctx| original_view.window_id(ctx));
+        let original_view_id = original_view.read(&app, |view, _| view.view_id);
         let restored_view_id = restored_view.read(&app, |view, _| view.view_id);
 
-        let conversation_id = original_owner.update(&mut app, |view, ctx| {
+        let conversation_id = original_view.update(&mut app, |view, ctx| {
             let (conversation_id, _, _, _) = append_exchange_with_inputs_and_handle_event(
                 view,
                 vec![AIAgentInput::UserQuery {
@@ -1065,7 +1112,7 @@ fn clicking_old_banner_for_open_conversation_focuses_current_owner_without_trans
                 Some(restored_view_id)
             );
         });
-        original_owner.read(&app, |view, _| {
+        original_view.read(&app, |view, _| {
             assert_eq!(ai_block_count(view), 0);
             assert_eq!(
                 agent_view_entry_count_for_conversation(view, conversation_id),
@@ -1077,7 +1124,7 @@ fn clicking_old_banner_for_open_conversation_focuses_current_owner_without_trans
         });
 
         let entry_blocks = app
-            .views_of_type::<AgentViewEntryBlock>(original_owner_window_id)
+            .views_of_type::<AgentViewEntryBlock>(original_window_id)
             .expect("original window should contain agent entry block");
         assert_eq!(entry_blocks.len(), 1);
         entry_blocks[0].update(&mut app, |block, ctx| {
@@ -1089,15 +1136,15 @@ fn clicking_old_banner_for_open_conversation_focuses_current_owner_without_trans
 
         BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
             assert_eq!(
-                history.terminal_view_id_for_conversation(&conversation_id),
+                history.terminal_surface_id_for_conversation(&conversation_id),
                 Some(restored_view_id)
             );
             assert!(history
-                .all_live_conversations_for_terminal_view(original_owner_view_id)
+                .all_live_conversations_for_terminal_surface(original_view_id)
                 .next()
                 .is_none());
         });
-        original_owner.read(&app, |view, _| {
+        original_view.read(&app, |view, _| {
             assert_eq!(ai_block_count(view), 0);
             assert_eq!(
                 agent_view_entry_count_for_conversation(view, conversation_id),
@@ -1111,18 +1158,18 @@ fn clicking_old_banner_for_open_conversation_focuses_current_owner_without_trans
 }
 
 #[test]
-fn appended_exchange_renders_in_current_owner_after_conversation_transfer() {
+fn appended_exchange_renders_in_current_terminal_surface_after_conversation_transfer() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         let _agent_view = FeatureFlag::AgentView.override_enabled(true);
 
-        let original_owner = add_window_with_terminal(&mut app, None);
-        let transferred_owner = add_window_with_terminal(&mut app, None);
+        let original_view = add_window_with_terminal(&mut app, None);
+        let transferred_view = add_window_with_terminal(&mut app, None);
 
-        let original_owner_view_id = original_owner.read(&app, |view, _| view.view_id);
-        let transferred_owner_view_id = transferred_owner.read(&app, |view, _| view.view_id);
+        let original_view_id = original_view.read(&app, |view, _| view.view_id);
+        let transferred_view_id = transferred_view.read(&app, |view, _| view.view_id);
 
-        let conversation_id = original_owner.update(&mut app, |view, ctx| {
+        let conversation_id = original_view.update(&mut app, |view, ctx| {
             let (conversation_id, _, _, _) = append_exchange_with_inputs_and_handle_event(
                 view,
                 vec![AIAgentInput::UserQuery {
@@ -1147,7 +1194,7 @@ fn appended_exchange_renders_in_current_owner_after_conversation_transfer() {
                     .expect("conversation should exist")
             });
 
-        transferred_owner.update(&mut app, |view, ctx| {
+        transferred_view.update(&mut app, |view, ctx| {
             view.restore_conversation_after_view_creation(
                 RestoredAIConversation::new(restored_conversation),
                 true,
@@ -1158,16 +1205,16 @@ fn appended_exchange_renders_in_current_owner_after_conversation_transfer() {
 
         BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
             assert_eq!(
-                history.terminal_view_id_for_conversation(&conversation_id),
-                Some(transferred_owner_view_id)
+                history.terminal_surface_id_for_conversation(&conversation_id),
+                Some(transferred_view_id)
             );
         });
 
-        let original_owner_block_count_after_restore =
-            original_owner.read(&app, |view, _| ai_block_count(view));
-        let transferred_owner_block_count_after_restore =
-            transferred_owner.read(&app, |view, _| ai_block_count(view));
-        assert_eq!(transferred_owner_block_count_after_restore, 1);
+        let original_view_block_count_after_restore =
+            original_view.read(&app, |view, _| ai_block_count(view));
+        let transferred_view_block_count_after_restore =
+            transferred_view.read(&app, |view, _| ai_block_count(view));
+        assert_eq!(transferred_view_block_count_after_restore, 1);
 
         let (task_id, exchange_id, response_stream_id) = BlocklistAIHistoryModel::handle(&app)
             .update(&mut app, |history, ctx| {
@@ -1190,20 +1237,20 @@ fn appended_exchange_renders_in_current_owner_after_conversation_transfer() {
                     .append_reassigned_exchange(
                         &response_stream_id,
                         exchange,
-                        original_owner_view_id,
+                        original_view_id,
                         ctx,
                     )
                     .expect("exchange should append");
                 (task_id, exchange_id, response_stream_id)
             });
 
-        original_owner.update(&mut app, |view, ctx| {
+        original_view.update(&mut app, |view, ctx| {
             view.handle_ai_history_model_event(
                 BlocklistAIHistoryModel::handle(ctx),
                 &BlocklistAIHistoryEvent::AppendedExchange {
                     exchange_id,
                     task_id: task_id.clone(),
-                    terminal_view_id: original_owner_view_id,
+                    terminal_surface_id: original_view_id,
                     conversation_id,
                     is_hidden: false,
                     response_stream_id: Some(response_stream_id.clone()),
@@ -1212,13 +1259,13 @@ fn appended_exchange_renders_in_current_owner_after_conversation_transfer() {
             );
         });
 
-        transferred_owner.update(&mut app, |view, ctx| {
+        transferred_view.update(&mut app, |view, ctx| {
             view.handle_ai_history_model_event(
                 BlocklistAIHistoryModel::handle(ctx),
                 &BlocklistAIHistoryEvent::AppendedExchange {
                     exchange_id,
                     task_id,
-                    terminal_view_id: original_owner_view_id,
+                    terminal_surface_id: original_view_id,
                     conversation_id,
                     is_hidden: false,
                     response_stream_id: Some(response_stream_id),
@@ -1227,16 +1274,16 @@ fn appended_exchange_renders_in_current_owner_after_conversation_transfer() {
             );
         });
 
-        original_owner.read(&app, |view, _| {
+        original_view.read(&app, |view, _| {
             assert_eq!(
                 ai_block_count(view),
-                original_owner_block_count_after_restore
+                original_view_block_count_after_restore
             );
         });
-        transferred_owner.read(&app, |view, _| {
+        transferred_view.read(&app, |view, _| {
             assert_eq!(
                 ai_block_count(view),
-                transferred_owner_block_count_after_restore + 1
+                transferred_view_block_count_after_restore + 1
             );
         });
     })
@@ -1650,13 +1697,13 @@ fn shared_third_party_viewer_sync_enters_agent_view_and_retags_existing_block() 
                 .expect("sync should be idempotent");
             assert_eq!(conversation_id, idempotent_conversation_id);
 
-            match view.agent_view_controller().as_ref(ctx).agent_view_state() {
-                AgentViewState::Active {
-                    conversation_id: active_conversation_id,
-                    origin,
-                    ..
-                } => {
-                    assert_eq!(*active_conversation_id, conversation_id);
+            let controller = view.agent_view_controller().as_ref(ctx);
+            match controller.agent_view_state() {
+                AgentViewState::Active { origin, .. } => {
+                    assert_eq!(
+                        controller.agent_view_state().active_conversation_id(),
+                        Some(conversation_id)
+                    );
                     assert_eq!(*origin, AgentViewEntryOrigin::ThirdPartyCloudAgent);
                 }
                 state => panic!("expected active agent view, got {state:?}"),
@@ -1722,14 +1769,14 @@ fn shared_third_party_viewer_syncs_from_viewer_harness_updated_when_harness_unch
                 ctx,
             );
 
-            let AgentViewState::Active {
-                conversation_id,
-                origin,
-                ..
-            } = view.agent_view_controller().as_ref(ctx).agent_view_state()
-            else {
+            let controller = view.agent_view_controller().as_ref(ctx);
+            let AgentViewState::Active { origin, .. } = controller.agent_view_state() else {
                 panic!("expected active agent view");
             };
+            let conversation_id = controller
+                .agent_view_state()
+                .active_conversation_id()
+                .expect("active agent view should select a conversation");
             assert_eq!(*origin, AgentViewEntryOrigin::ThirdPartyCloudAgent);
 
             let model = view.model.lock();
@@ -1744,7 +1791,7 @@ fn shared_third_party_viewer_syncs_from_viewer_harness_updated_when_harness_unch
                     pending_conversation_ids,
                 } => {
                     assert!(pending_conversation_ids.is_empty());
-                    assert!(conversation_ids.contains(conversation_id));
+                    assert!(conversation_ids.contains(&conversation_id));
                 }
                 visibility => panic!("expected terminal block visibility, got {visibility:?}"),
             }
@@ -1793,14 +1840,14 @@ fn shared_third_party_viewer_syncs_from_cli_agent_state_without_ambient_model() 
         });
 
         terminal.read(&app, |view, ctx| {
-            let AgentViewState::Active {
-                conversation_id,
-                origin,
-                ..
-            } = view.agent_view_controller().as_ref(ctx).agent_view_state()
-            else {
+            let controller = view.agent_view_controller().as_ref(ctx);
+            let AgentViewState::Active { origin, .. } = controller.agent_view_state() else {
                 panic!("expected active agent view");
             };
+            let conversation_id = controller
+                .agent_view_state()
+                .active_conversation_id()
+                .expect("active agent view should select a conversation");
             assert_eq!(*origin, AgentViewEntryOrigin::ThirdPartyCloudAgent);
 
             let model = view.model.lock();
@@ -1815,7 +1862,7 @@ fn shared_third_party_viewer_syncs_from_cli_agent_state_without_ambient_model() 
                     pending_conversation_ids,
                 } => {
                     assert!(pending_conversation_ids.is_empty());
-                    assert!(conversation_ids.contains(conversation_id));
+                    assert!(conversation_ids.contains(&conversation_id));
                 }
                 visibility => panic!("expected terminal block visibility, got {visibility:?}"),
             }
@@ -2152,8 +2199,7 @@ fn cmd_enter_from_terminal_with_selected_block_enters_agent_view_with_context() 
             let conversation_id = view
                 .agent_view_controller()
                 .as_ref(ctx)
-                .agent_view_state()
-                .active_conversation_id()
+                .agent_view_state().active_conversation_id()
                 .expect("agent view should be active");
 
             let model = view.model.lock();

--- a/app/src/terminal/writeable_pty/mod.rs
+++ b/app/src/terminal/writeable_pty/mod.rs
@@ -10,4 +10,4 @@ pub(crate) mod terminal_surface;
 
 pub use message::Message;
 pub use pty_controller::{PtyController, PtyControllerEvent};
-pub(crate) use terminal_surface::{PtyIntent, PtyIntentEvent, TerminalSurface};
+pub use terminal_surface::{PtyIntent, PtyIntentEvent, TerminalSurface};

--- a/app/src/terminal/writeable_pty/terminal_surface.rs
+++ b/app/src/terminal/writeable_pty/terminal_surface.rs
@@ -20,7 +20,7 @@ use crate::terminal::{ShellLaunchData, SizeUpdate};
 /// without knowing the concrete UI implementation. It only contains actions
 /// meaningful to the PTY/session boundary: process control, byte writes,
 /// resizing, command execution, and native shell completions.
-pub(crate) enum PtyIntent {
+pub enum PtyIntent {
     CtrlD,
     ShutdownPty,
     WriteBytes(Cow<'static, [u8]>),
@@ -37,7 +37,7 @@ pub(crate) enum PtyIntent {
 }
 
 /// Event types that can be projected into an [`Option<PtyIntent>`].
-pub(crate) trait PtyIntentEvent {
+pub trait PtyIntentEvent {
     /// Projects this event into a PTY/session intent, or `None` if it is not a
     /// PTY-driving event.
     fn pty_intent(&self) -> Option<PtyIntent>;
@@ -46,7 +46,7 @@ pub(crate) trait PtyIntentEvent {
 /// A terminal frontend surface driven by `TerminalManager`.
 ///
 /// Each surface defines how its own event type collapses into a PTY/session intent.
-pub(crate) trait TerminalSurface: View + 'static
+pub trait TerminalSurface: View + 'static
 where
     <Self as Entity>::Event: PtyIntentEvent,
 {

--- a/app/src/tui/mod.rs
+++ b/app/src/tui/mod.rs
@@ -1,33 +1,31 @@
 //! The headless `warp-tui` front-end's app-side entry point.
 //!
-//! For this first step the TUI only proves out auth reuse. The `warp_tui` crate
-//! boots the real (headless) Warp app via [`crate::run_tui`], which runs the
-//! full `initialize_app` (so `AuthManager` and the auth state exist) and then
-//! calls [`init`]. [`init`] logs the user in when needed (reusing the OAuth
-//! device-authorization flow that `oz login` uses), auto-opens the browser,
-//! prints the authenticated user's ID, and exits. No terminal UI is rendered
-//! yet.
+//! The `warp_tui` crate boots the real headless Warp app via [`crate::run_tui`].
+//! After shared app initialization and authentication complete, this module
+//! invokes the frontend callback supplied by `warp_tui`.
 
+use std::sync::Arc;
+
+use parking_lot::Mutex;
 use warpui::platform::TerminationMode;
 use warpui::{AppContext, SingletonEntity};
 
 use crate::auth::auth_manager::{AuthManager, AuthManagerEvent};
 use crate::auth::AuthStateProvider;
+use crate::TuiFrontend;
 
 /// Entry point invoked from `run_internal` once the headless app is initialized.
 ///
-/// If the user is already logged in, prints their ID immediately. Otherwise it
-/// starts the OAuth device-authorization flow, opens the browser (printing the
-/// URL/code as a fallback), and prints the ID once login completes. Terminates
-/// the app when done.
-pub fn init(ctx: &mut AppContext) {
+/// Authenticates the user when needed, then dispatches the requested TUI operation.
+pub(crate) fn init(frontend: TuiFrontend, ctx: &mut AppContext) {
     let auth_state = AuthStateProvider::as_ref(ctx).get();
     if auth_state.is_logged_in() {
-        print_user_id_and_exit(ctx);
+        finish_initialization(frontend, ctx);
         return;
     }
 
     println!("Welcome to Warp TUI. Let's get you logged in.");
+    let frontend = Arc::new(Mutex::new(Some(frontend)));
 
     // Reuses the same device-authorization flow as `oz login` (see
     // `app/src/ai/agent_sdk/admin.rs`). The browser handles login and control
@@ -56,7 +54,9 @@ pub fn init(ctx: &mut AppContext) {
             ctx.open_url(url_to_open);
         }
         AuthManagerEvent::AuthComplete => {
-            print_user_id_and_exit(ctx);
+            if let Some(frontend) = frontend.lock().take() {
+                finish_initialization(frontend, ctx);
+            }
         }
         AuthManagerEvent::AuthFailed(err) => {
             ctx.terminate_app(
@@ -70,6 +70,13 @@ pub fn init(ctx: &mut AppContext) {
     AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| {
         auth_manager.authorize_device(ctx);
     });
+}
+
+/// Runs the requested TUI operation after authentication is ready.
+fn finish_initialization(frontend: TuiFrontend, ctx: &mut AppContext) {
+    if !frontend(ctx) {
+        print_user_id_and_exit(ctx);
+    }
 }
 
 /// Prints the authenticated user's ID to stdout, then terminates the app.

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -1,0 +1,35 @@
+//! Public app APIs used by the `warp_tui` frontend.
+
+pub use crate::ai::agent::api::ServerConversationToken;
+pub use crate::ai::agent::conversation::{
+    AIConversationAutoexecuteMode, AIConversationId, ConversationStatus,
+};
+pub use crate::ai::agent::AIAgentTextSection;
+pub use crate::ai::blocklist::agent_view::{
+    AgentViewDisplayMode, AgentViewEntryOrigin, EnterAgentViewError,
+};
+pub use crate::ai::blocklist::conversation_selection::{
+    ConversationSelection, ConversationSelectionEvent, ConversationSelectionHandle,
+    PendingQueryState,
+};
+pub use crate::ai::blocklist::history_model::{
+    BlocklistAIHistoryEvent, BlocklistAIHistoryModel, CloudConversationData,
+    ConversationStatusUpdate,
+};
+pub use crate::ai::blocklist::{
+    BlocklistAIActionModel, BlocklistAIContextModel, BlocklistAIController, BlocklistAIInputModel,
+};
+pub use crate::ai::get_relevant_files::controller::GetRelevantFilesController;
+pub use crate::banner::BannerState;
+pub use crate::terminal::event::AfterBlockCompletedEvent;
+pub use crate::terminal::local_tty::{
+    TerminalManager as LocalTtyTerminalManager, TerminalManagerInit, TerminalSurfaceInit,
+    TerminalSurfaceResult,
+};
+pub use crate::terminal::model::session::active_session::ActiveSession;
+pub use crate::terminal::model::terminal_model::BlockIndex;
+pub use crate::terminal::shared_session::IsSharedSessionCreator;
+pub use crate::terminal::{
+    PtyIntent, PtyIntentEvent, ShellLaunchData, TerminalManager as TerminalManagerTrait,
+    TerminalModel, TerminalSurface,
+};

--- a/app/src/undo_close/stack.rs
+++ b/app/src/undo_close/stack.rs
@@ -129,7 +129,8 @@ impl ClosedItem {
 
             for terminal_view_id in terminal_view_ids {
                 history_model.update(ctx, |history_model, _| {
-                    history_model.mark_conversations_historical_for_terminal_view(terminal_view_id);
+                    history_model
+                        .mark_conversations_historical_for_terminal_surface(terminal_view_id);
                 });
             }
         }

--- a/app/src/workspace/auto_handoff.rs
+++ b/app/src/workspace/auto_handoff.rs
@@ -367,7 +367,7 @@ impl AutoCloudHandoffController {
         // handoff flow validates against — then the agent-view registry, and
         // only fall back to the last-focused id.
         let terminal_view_id = BlocklistAIHistoryModel::as_ref(ctx)
-            .terminal_view_id_for_conversation(&conversation_id)
+            .terminal_surface_id_for_conversation(&conversation_id)
             .or_else(|| {
                 active_agent_views.get_terminal_view_id_for_conversation(conversation_id, ctx)
             })

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3597,7 +3597,7 @@ impl Workspace {
             );
 
             if is_relevant_update
-                && event.terminal_view_id().is_some_and(|event_id| {
+                && event.terminal_surface_id().is_some_and(|event_id| {
                     focused_terminal_view_id.is_some_and(|id| id == event_id)
                 })
             {
@@ -3642,12 +3642,12 @@ impl Workspace {
                 | BlocklistAIHistoryEvent::UpdatedStreamingExchange { .. }
                 | BlocklistAIHistoryEvent::SetActiveConversation { .. }
                 | BlocklistAIHistoryEvent::ClearedActiveConversation { .. }
-                | BlocklistAIHistoryEvent::ClearedConversationsInTerminalView { .. }
+                | BlocklistAIHistoryEvent::ClearedConversationsForTerminalSurface { .. }
                 | BlocklistAIHistoryEvent::SplitConversation { .. }
                 | BlocklistAIHistoryEvent::RestoredConversations { .. }
                 | BlocklistAIHistoryEvent::UpdatedConversationTitle { .. }
                 | BlocklistAIHistoryEvent::UpdatedConversationMetadata { .. }
-        ) && event.terminal_view_id().is_some_and(|terminal_view_id| {
+        ) && event.terminal_surface_id().is_some_and(|terminal_view_id| {
             self.workspace_contains_terminal_view(terminal_view_id, ctx)
         })
     }
@@ -12974,7 +12974,7 @@ impl Workspace {
             let history_model = BlocklistAIHistoryModel::as_ref(ctx);
             history_model.conversation(&conversation_id).is_some()
                 && history_model
-                    .all_live_conversations_for_terminal_view(terminal_view_id)
+                    .all_live_conversations_for_terminal_surface(terminal_view_id)
                     .any(|conversation| conversation.id() == conversation_id)
         };
         if already_exists_in_active_pane {
@@ -13343,7 +13343,7 @@ impl Workspace {
             .all_live_conversations()
             .into_iter()
             .find(|(_, convo)| convo.id() == conversation_id)
-            .map(|(terminal_view_id, _)| terminal_view_id);
+            .map(|(terminal_surface_id, _)| terminal_surface_id);
 
         // An empty prompt should not be provided as a query for the new forked conversation.
         let initial_prompt = initial_prompt.and_then(|prompt| {

--- a/crates/warp_cli/src/lib.rs
+++ b/crates/warp_cli/src/lib.rs
@@ -66,6 +66,17 @@ pub struct ParentOpts {
     pub handle: Option<process_handle::ProcessHandle>,
 }
 
+/// Returns whether an argument requests one of Warp's hidden worker modes.
+pub fn is_worker_invocation(arg: &str) -> bool {
+    let command = WorkerCommand::augment_subcommands(clap::Command::new("worker"));
+    command.find_subcommand(arg).is_some()
+        || arg.strip_prefix("--").is_some_and(|long_flag| {
+            command
+                .get_subcommands()
+                .any(|subcommand| subcommand.get_long_flag() == Some(long_flag))
+        })
+}
+
 /// Hidden worker args used to scope remote-server proxy/daemon sockets by
 /// Warp identity without exposing credentials.
 #[derive(Debug, Clone, Default, clap::Args)]

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -12,6 +12,16 @@ use crate::schedule::ScheduleSubcommand;
 use crate::secret::{CodexMethod, CreateProvider, SecretCommand};
 use crate::task::{MessageCommand, TaskCommand};
 
+#[test]
+fn identifies_worker_subcommands() {
+    assert!(is_worker_invocation("minidump-server"));
+    #[cfg(unix)]
+    assert!(is_worker_invocation(&terminal_server_subcommand()));
+    #[cfg(feature = "plugin_host")]
+    assert!(is_worker_invocation("--plugin-host"));
+    assert!(!is_worker_invocation("--prompt"));
+}
+
 fn set_env_var(name: &str, value: &str) -> Option<OsString> {
     let previous = std::env::var_os(name);
     // Safety: tests that mutate process environment are marked `serial` so we

--- a/crates/warp_tui/Cargo.toml
+++ b/crates/warp_tui/Cargo.toml
@@ -9,9 +9,9 @@ autobins = false
 default-run = "warp-tui-oss"
 
 # One binary per channel, mirroring the GUI app's `app/src/bin/*` layout. The
-# OSS bin is the `default-run` so bare `cargo run -p warp_tui` builds without the
-# internal `warp-channel-config` generator; `./script/run-tui` selects the local
-# bin when the generator is available.
+# OSS bin is the `default-run` so bare `cargo run -p warp_tui` builds without
+# the internal `warp-channel-config` generator; `./script/run-tui` selects the
+# local bin when the generator is available.
 [[bin]]
 name = "warp-tui-oss"
 path = "src/bin/oss.rs"
@@ -34,19 +34,25 @@ path = "src/bin/stable.rs"
 
 [dependencies]
 anyhow.workspace = true
+log.workspace = true
 num-traits.workspace = true
+parking_lot.workspace = true
+pathfinder_geometry.workspace = true
 string-offset.workspace = true
 vec1.workspace = true
 warp = { workspace = true, features = ["tui"] }
 warp_channel_config.workspace = true
 warp_core.workspace = true
 warp_editor.workspace = true
+warpui.workspace = true
 warpui_core = { workspace = true, features = ["tui"] }
 
 [dev-dependencies]
 # `test-util` exposes `Appearance::mock()`, used to register the `Appearance`
 # singleton that the editor-backed TUI input view depends on in tests/examples.
 warp_core = { workspace = true, features = ["test-util"] }
+# Process-level worker-dispatch regression test.
+command.workspace = true
 
 [[example]]
 name = "tui_input_demo"

--- a/crates/warp_tui/src/args.rs
+++ b/crates/warp_tui/src/args.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use warp::tui_export::ServerConversationToken;
+
+/// Arguments accepted by the TUI frontend after worker dispatch.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct TuiArgs {
+    pub(super) prompt: Option<String>,
+    pub(super) server_conversation_token: Option<ServerConversationToken>,
+}
+
+impl TuiArgs {
+    /// Parses TUI frontend arguments from the current process environment.
+    pub(crate) fn from_env() -> Result<Self> {
+        Self::parse(std::env::args().skip(1))
+    }
+
+    /// Parses TUI frontend arguments.
+    fn parse(args: impl IntoIterator<Item = String>) -> Result<Self> {
+        let mut parsed = Self::default();
+        let mut args = args.into_iter();
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--prompt" => {
+                    parsed.prompt = Some(
+                        args.next()
+                            .ok_or_else(|| anyhow::anyhow!("--prompt requires a value"))?,
+                    );
+                }
+                "--conversation-id" => {
+                    let server_conversation_token = args
+                        .next()
+                        .ok_or_else(|| anyhow::anyhow!("--conversation-id requires a value"))?;
+                    parsed.server_conversation_token =
+                        Some(ServerConversationToken::new(server_conversation_token));
+                }
+                other => return Err(anyhow::anyhow!("Unknown argument: {other}")),
+            }
+        }
+        Ok(parsed)
+    }
+}
+
+#[cfg(test)]
+#[path = "args_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/args_tests.rs
+++ b/crates/warp_tui/src/args_tests.rs
@@ -1,0 +1,52 @@
+use warp::tui_export::ServerConversationToken;
+
+use super::TuiArgs;
+
+/// Parses a prompt and server conversation token.
+#[test]
+fn parses_prompt_and_conversation_id() {
+    let server_conversation_token = ServerConversationToken::new("server-token".to_owned());
+    assert_eq!(
+        TuiArgs::parse([
+            "--conversation-id".to_owned(),
+            server_conversation_token.as_str().to_owned(),
+            "--prompt".to_owned(),
+            "hello".to_owned(),
+        ],)
+        .unwrap(),
+        TuiArgs {
+            prompt: Some("hello".to_owned()),
+            server_conversation_token: Some(server_conversation_token),
+        }
+    );
+}
+
+/// Rejects flags whose values are missing.
+#[test]
+fn rejects_missing_argument_value() {
+    let error = TuiArgs::parse(["--prompt".to_owned()]).unwrap_err();
+    assert_eq!(error.to_string(), "--prompt requires a value");
+}
+
+/// Accepts opaque server conversation tokens.
+#[test]
+fn accepts_opaque_conversation_id() {
+    let args = TuiArgs::parse([
+        "--conversation-id".to_owned(),
+        "not-a-local-uuid".to_owned(),
+    ])
+    .unwrap();
+    assert_eq!(
+        args.server_conversation_token
+            .as_ref()
+            .map(ServerConversationToken::as_str),
+        Some("not-a-local-uuid")
+    );
+}
+
+/// Rejects unsupported TUI frontend arguments.
+#[test]
+fn rejects_unknown_argument() {
+    let error = TuiArgs::parse(["--unknown".to_owned()]).unwrap_err();
+    assert_eq!(error.to_string(), "Unknown argument: --unknown");
+}

--- a/crates/warp_tui/src/bin/dev.rs
+++ b/crates/warp_tui/src/bin/dev.rs
@@ -15,5 +15,5 @@ fn main() -> Result<()> {
             .with_additional_features(features::PREVIEW_FLAGS),
     );
 
-    warp::run_tui()
+    warp_tui::run()
 }

--- a/crates/warp_tui/src/bin/local.rs
+++ b/crates/warp_tui/src/bin/local.rs
@@ -19,5 +19,5 @@ fn main() -> Result<()> {
             .with_additional_features(features::LOCAL_FLAGS),
     );
 
-    warp::run_tui()
+    warp_tui::run()
 }

--- a/crates/warp_tui/src/bin/oss.rs
+++ b/crates/warp_tui/src/bin/oss.rs
@@ -29,5 +29,5 @@ fn main() -> Result<()> {
     }
     ChannelState::set(state);
 
-    warp::run_tui()
+    warp_tui::run()
 }

--- a/crates/warp_tui/src/bin/preview.rs
+++ b/crates/warp_tui/src/bin/preview.rs
@@ -18,5 +18,5 @@ fn main() -> Result<()> {
         .with_additional_features(&[features::FeatureFlag::ForceLogin]),
     );
 
-    warp::run_tui()
+    warp_tui::run()
 }

--- a/crates/warp_tui/src/bin/stable.rs
+++ b/crates/warp_tui/src/bin/stable.rs
@@ -12,5 +12,5 @@ fn main() -> Result<()> {
         warp_channel_config::load_config!("stable"),
     ));
 
-    warp::run_tui()
+    warp_tui::run()
 }

--- a/crates/warp_tui/src/conversation_model.rs
+++ b/crates/warp_tui/src/conversation_model.rs
@@ -1,0 +1,244 @@
+//! Reusable per-surface TUI conversation coordination.
+
+use anyhow::anyhow;
+use warp::tui_export::{
+    AIConversationId, AgentViewEntryOrigin, BlocklistAIController, BlocklistAIHistoryEvent,
+    BlocklistAIHistoryModel, CloudConversationData, ConversationSelectionEvent,
+    ConversationSelectionHandle, ConversationStatus, ConversationStatusUpdate,
+    ServerConversationToken,
+};
+use warpui::{AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonEntity};
+
+/// Events emitted by a TUI conversation model for presentation layers.
+#[derive(Clone, Debug)]
+pub(super) enum TuiConversationModelEvent {
+    SelectedConversationChanged {
+        conversation_id: Option<AIConversationId>,
+    },
+    ConversationStarted {
+        conversation_id: AIConversationId,
+    },
+    ConversationUpdated {
+        conversation_id: AIConversationId,
+    },
+    ConversationStatusChanged {
+        conversation_id: AIConversationId,
+        status: ConversationStatus,
+        update: ConversationStatusUpdate,
+    },
+    Error {
+        message: String,
+    },
+}
+
+/// Per-surface conversation/composer model for a future interactive TUI.
+///
+/// This model deliberately contains no transcript widgets. It coordinates selected
+/// conversation state, conversation restore/create operations, prompt
+/// submission, and history-backed stream events for one TUI selection.
+pub(super) struct TuiConversationModel {
+    terminal_surface_id: EntityId,
+    conversation_selection: ConversationSelectionHandle,
+    ai_controller: ModelHandle<BlocklistAIController>,
+}
+
+impl TuiConversationModel {
+    /// Creates a TUI conversation model around the shared production AI models.
+    pub(super) fn new(
+        terminal_surface_id: EntityId,
+        conversation_selection: ConversationSelectionHandle,
+        ai_controller: ModelHandle<BlocklistAIController>,
+        ctx: &mut ModelContext<Self>,
+    ) -> Self {
+        ctx.subscribe_to_model(&conversation_selection, |model, _, event, ctx| {
+            if matches!(event, ConversationSelectionEvent::Changed) {
+                ctx.emit(TuiConversationModelEvent::SelectedConversationChanged {
+                    conversation_id: model.selected_conversation_id(ctx),
+                });
+            }
+        });
+        ctx.subscribe_to_model(
+            &BlocklistAIHistoryModel::handle(ctx),
+            |model, _, event, ctx| model.handle_history_event(event, ctx),
+        );
+        Self {
+            terminal_surface_id,
+            conversation_selection,
+            ai_controller,
+        }
+    }
+
+    /// Returns this surface's currently selected next-prompt target.
+    fn selected_conversation_id(&self, ctx: &AppContext) -> Option<AIConversationId> {
+        self.conversation_selection
+            .as_ref(ctx)
+            .selected_conversation_id(ctx)
+    }
+
+    /// Selects a live conversation as this surface's next-prompt target.
+    fn select_conversation(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<()> {
+        let is_live = BlocklistAIHistoryModel::as_ref(ctx)
+            .all_live_conversations_for_terminal_surface(self.terminal_surface_id)
+            .any(|conversation| conversation.id() == conversation_id);
+        if !is_live {
+            return Err(anyhow!(
+                "Conversation {conversation_id} is not live for TUI surface {}",
+                self.terminal_surface_id
+            ));
+        }
+        self.conversation_selection.update(ctx, |selection, ctx| {
+            selection.select_existing_conversation(conversation_id, AgentViewEntryOrigin::Cli, ctx);
+        });
+        Ok(())
+    }
+
+    /// Creates and selects an empty conversation for this TUI selection.
+    fn start_new_conversation(
+        &mut self,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<AIConversationId> {
+        self.conversation_selection
+            .update(ctx, |selection, ctx| {
+                selection.try_start_new_conversation(AgentViewEntryOrigin::Cli, ctx)
+            })
+            .map_err(Into::into)
+    }
+
+    /// Sends a prompt to this surface's selected conversation, creating one if needed.
+    pub(super) fn send_prompt(&mut self, prompt: String, ctx: &mut ModelContext<Self>) {
+        let conversation_id = match self.selected_conversation_id(ctx) {
+            Some(conversation_id) => conversation_id,
+            None => match self.start_new_conversation(ctx) {
+                Ok(conversation_id) => conversation_id,
+                Err(error) => {
+                    ctx.emit(TuiConversationModelEvent::Error {
+                        message: format!("{error:#}"),
+                    });
+                    return;
+                }
+            },
+        };
+        self.ai_controller.update(ctx, |controller, ctx| {
+            controller.send_user_query_in_conversation(prompt, conversation_id, None, ctx);
+        });
+    }
+
+    /// Restores, selects, and sends a prompt to a conversation identified by its server token.
+    pub(super) fn restore_conversation_by_server_token_and_send_prompt(
+        &mut self,
+        prompt: String,
+        server_conversation_token: ServerConversationToken,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let history = BlocklistAIHistoryModel::handle(ctx);
+        if let Some(conversation_id) = history
+            .as_ref(ctx)
+            .find_conversation_id_by_server_token(&server_conversation_token)
+        {
+            let is_live = history
+                .as_ref(ctx)
+                .all_live_conversations_for_terminal_surface(self.terminal_surface_id)
+                .any(|conversation| conversation.id() == conversation_id);
+            if is_live {
+                if let Err(error) = self.select_conversation(conversation_id, ctx) {
+                    ctx.emit(TuiConversationModelEvent::Error {
+                        message: format!("{error:#}"),
+                    });
+                    return;
+                }
+                self.send_prompt(prompt, ctx);
+                return;
+            }
+            if let Some(conversation) = history.as_ref(ctx).conversation(&conversation_id).cloned()
+            {
+                history.update(ctx, |history, ctx| {
+                    history.restore_conversations(
+                        self.terminal_surface_id,
+                        vec![conversation],
+                        ctx,
+                    );
+                });
+                if let Err(error) = self.select_conversation(conversation_id, ctx) {
+                    ctx.emit(TuiConversationModelEvent::Error {
+                        message: format!("{error:#}"),
+                    });
+                    return;
+                }
+                self.send_prompt(prompt, ctx);
+                return;
+            }
+        }
+
+        let token_for_error = server_conversation_token.as_str().to_owned();
+        let future = history.update(ctx, |history, ctx| {
+            history.load_conversation_by_server_token(&server_conversation_token, ctx)
+        });
+        ctx.spawn(future, move |model, conversation, ctx| {
+            let Some(CloudConversationData::Oz(conversation)) = conversation else {
+                ctx.emit(TuiConversationModelEvent::Error {
+                    message: format!(
+                        "Failed to load conversation with server token {token_for_error}"
+                    ),
+                });
+                return;
+            };
+            let conversation_id = conversation.id();
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                history.restore_conversations(model.terminal_surface_id, vec![*conversation], ctx);
+            });
+            if let Err(error) = model.select_conversation(conversation_id, ctx) {
+                ctx.emit(TuiConversationModelEvent::Error {
+                    message: format!("{error:#}"),
+                });
+                return;
+            }
+            model.send_prompt(prompt, ctx);
+        });
+    }
+
+    /// Converts terminal-surface-scoped history events into TUI presentation events.
+    fn handle_history_event(
+        &mut self,
+        event: &BlocklistAIHistoryEvent,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if event
+            .terminal_surface_id()
+            .is_some_and(|terminal_surface_id| terminal_surface_id != self.terminal_surface_id)
+        {
+            return;
+        }
+        match event {
+            BlocklistAIHistoryEvent::StartedNewConversation {
+                new_conversation_id,
+                ..
+            } => ctx.emit(TuiConversationModelEvent::ConversationStarted {
+                conversation_id: *new_conversation_id,
+            }),
+            BlocklistAIHistoryEvent::UpdatedStreamingExchange {
+                conversation_id, ..
+            } => ctx.emit(TuiConversationModelEvent::ConversationUpdated {
+                conversation_id: *conversation_id,
+            }),
+            BlocklistAIHistoryEvent::UpdatedConversationStatus {
+                conversation_id,
+                new_status,
+                update,
+                ..
+            } => ctx.emit(TuiConversationModelEvent::ConversationStatusChanged {
+                conversation_id: *conversation_id,
+                status: new_status.clone(),
+                update: update.clone(),
+            }),
+            _ => {}
+        }
+    }
+}
+
+impl Entity for TuiConversationModel {
+    type Event = TuiConversationModelEvent;
+}

--- a/crates/warp_tui/src/conversation_selection.rs
+++ b/crates/warp_tui/src/conversation_selection.rs
@@ -1,0 +1,250 @@
+use warp::tui_export::{
+    AIConversationAutoexecuteMode, AIConversationId, AgentViewEntryOrigin, BlocklistAIHistoryEvent,
+    BlocklistAIHistoryModel, ConversationSelection, ConversationSelectionEvent,
+    EnterAgentViewError, PendingQueryState,
+};
+use warpui::{AppContext, EntityId, ModelContext, SingletonEntity};
+
+/// TUI-owned next-prompt conversation selection.
+pub(super) struct TuiConversationSelection {
+    terminal_surface_id: EntityId,
+    pending_query_state: PendingQueryState,
+}
+
+impl TuiConversationSelection {
+    /// Creates TUI conversation selection for a terminal surface.
+    pub(super) fn new(
+        terminal_surface_id: EntityId,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    ) -> Self {
+        ctx.subscribe_to_model(
+            &BlocklistAIHistoryModel::handle(ctx),
+            |selection, _, event, ctx| selection.handle_history_event(event, ctx),
+        );
+        let pending_query_state =
+            if warp_core::execution_mode::AppExecutionMode::as_ref(ctx).is_sandboxed() {
+                PendingQueryState::New {
+                    autoexecute_override: AIConversationAutoexecuteMode::RunToCompletion,
+                }
+            } else {
+                PendingQueryState::default()
+            };
+        Self {
+            terminal_surface_id,
+            pending_query_state,
+        }
+    }
+
+    /// Returns the selected existing conversation ID.
+    fn selected_id(&self) -> Option<AIConversationId> {
+        match self.pending_query_state {
+            PendingQueryState::Existing { conversation_id } => Some(conversation_id),
+            PendingQueryState::New { .. } => None,
+        }
+    }
+
+    /// Updates pending state and emits only when the value changes.
+    fn set_pending_query_state(
+        &mut self,
+        state: PendingQueryState,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    ) {
+        if self.pending_query_state != state {
+            self.pending_query_state = state;
+            ctx.emit(ConversationSelectionEvent::Changed);
+        }
+    }
+
+    /// Emits activation for a selected TUI conversation.
+    fn emit_activated(
+        origin: AgentViewEntryOrigin,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    ) {
+        ctx.emit(ConversationSelectionEvent::Activated {
+            is_fullscreen: true,
+            origin,
+        });
+    }
+
+    /// Emits deactivation for a previously selected TUI conversation.
+    fn emit_deactivated(
+        conversation_id: AIConversationId,
+        is_exit_before_new_entrance: bool,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    ) {
+        let final_exchange_count = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&conversation_id)
+            .map(|conversation| conversation.exchange_count())
+            .unwrap_or(0);
+        ctx.emit(ConversationSelectionEvent::Deactivated {
+            conversation_id,
+            final_exchange_count,
+            is_exit_before_new_entrance,
+        });
+    }
+}
+
+impl ConversationSelection for TuiConversationSelection {
+    fn selected_conversation_id(&self, _: &AppContext) -> Option<AIConversationId> {
+        self.selected_id()
+    }
+
+    fn is_conversation_active(&self, _: &AppContext) -> bool {
+        self.selected_id().is_some()
+    }
+    /// The TUI has no terminal/Agent View split, so every selected conversation is fullscreen.
+    fn is_conversation_fullscreen(&self, _: &AppContext) -> bool {
+        self.selected_id().is_some()
+    }
+
+    fn select_existing_conversation(
+        &mut self,
+        conversation_id: AIConversationId,
+        origin: AgentViewEntryOrigin,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    ) {
+        let previous_conversation_id = self.selected_id();
+        if previous_conversation_id == Some(conversation_id) {
+            return;
+        }
+        if let Some(previous_conversation_id) = previous_conversation_id {
+            Self::emit_deactivated(previous_conversation_id, true, ctx);
+        }
+        self.set_pending_query_state(PendingQueryState::Existing { conversation_id }, ctx);
+        Self::emit_activated(origin, ctx);
+    }
+
+    fn select_new_conversation(
+        &mut self,
+        _: AgentViewEntryOrigin,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    ) {
+        let previous_conversation_id = self.selected_id();
+        self.set_pending_query_state(PendingQueryState::default(), ctx);
+        if let Some(previous_conversation_id) = previous_conversation_id {
+            Self::emit_deactivated(previous_conversation_id, false, ctx);
+        }
+    }
+
+    fn try_start_new_conversation(
+        &mut self,
+        origin: AgentViewEntryOrigin,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    ) -> Result<AIConversationId, EnterAgentViewError> {
+        if let Some(previous_conversation_id) = self.selected_id() {
+            Self::emit_deactivated(previous_conversation_id, true, ctx);
+        }
+        let is_autoexecute_override = matches!(
+            self.pending_query_state,
+            PendingQueryState::New {
+                autoexecute_override: AIConversationAutoexecuteMode::RunToCompletion,
+            }
+        );
+        let conversation_id = BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+            history.start_new_conversation(
+                self.terminal_surface_id,
+                is_autoexecute_override,
+                false,
+                false,
+                ctx,
+            )
+        });
+        self.set_pending_query_state(PendingQueryState::Existing { conversation_id }, ctx);
+        Self::emit_activated(origin, ctx);
+        Ok(conversation_id)
+    }
+
+    fn pending_query_autoexecute_override(
+        &self,
+        app: &AppContext,
+    ) -> AIConversationAutoexecuteMode {
+        match &self.pending_query_state {
+            PendingQueryState::New {
+                autoexecute_override,
+            } => *autoexecute_override,
+            PendingQueryState::Existing { conversation_id } => BlocklistAIHistoryModel::as_ref(app)
+                .conversation(conversation_id)
+                .map(|conversation| conversation.autoexecute_override())
+                .unwrap_or_default(),
+        }
+    }
+
+    fn toggle_pending_query_autoexecute(
+        &mut self,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    ) {
+        match self.pending_query_state.clone() {
+            PendingQueryState::New {
+                autoexecute_override,
+            } => {
+                let autoexecute_override =
+                    if autoexecute_override == AIConversationAutoexecuteMode::RespectUserSettings {
+                        AIConversationAutoexecuteMode::RunToCompletion
+                    } else {
+                        AIConversationAutoexecuteMode::RespectUserSettings
+                    };
+                self.set_pending_query_state(
+                    PendingQueryState::New {
+                        autoexecute_override,
+                    },
+                    ctx,
+                );
+            }
+            PendingQueryState::Existing { conversation_id } => {
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                    history.toggle_autoexecute_override(
+                        &conversation_id,
+                        self.terminal_surface_id,
+                        ctx,
+                    );
+                });
+            }
+        }
+    }
+
+    fn handle_history_event(
+        &mut self,
+        event: &BlocklistAIHistoryEvent,
+        ctx: &mut ModelContext<Box<dyn ConversationSelection>>,
+    ) {
+        if event
+            .terminal_surface_id()
+            .is_some_and(|id| id != self.terminal_surface_id)
+        {
+            return;
+        }
+        match event {
+            BlocklistAIHistoryEvent::ClearedConversationsForTerminalSurface { .. } => {
+                self.select_new_conversation(AgentViewEntryOrigin::Cli, ctx);
+            }
+            BlocklistAIHistoryEvent::SplitConversation {
+                old_conversation_id,
+                new_conversation_id,
+                ..
+            } if self.selected_id() == Some(*old_conversation_id) => {
+                self.select_existing_conversation(
+                    *new_conversation_id,
+                    AgentViewEntryOrigin::AgentRequestedNewConversation,
+                    ctx,
+                );
+            }
+            BlocklistAIHistoryEvent::RemoveConversation {
+                conversation_id, ..
+            }
+            | BlocklistAIHistoryEvent::DeletedConversation {
+                conversation_id, ..
+            }
+            | BlocklistAIHistoryEvent::ConversationTransferredBetweenTerminalSurfaces {
+                conversation_id,
+                ..
+            } if self.selected_id() == Some(*conversation_id) => {
+                self.select_new_conversation(AgentViewEntryOrigin::Cli, ctx);
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "conversation_selection_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/conversation_selection_tests.rs
+++ b/crates/warp_tui/src/conversation_selection_tests.rs
@@ -1,0 +1,150 @@
+use warp::tui_export::{
+    AIConversationId, AgentViewEntryOrigin, BlocklistAIHistoryEvent, BlocklistAIHistoryModel,
+    ConversationSelection, ConversationSelectionHandle,
+};
+use warp_core::execution_mode::{AppExecutionMode, ExecutionMode};
+use warpui::{App, EntityId, ModelHandle};
+
+use super::TuiConversationSelection;
+
+fn build_tui_selection(
+    app: &mut App,
+) -> (
+    ModelHandle<BlocklistAIHistoryModel>,
+    ConversationSelectionHandle,
+    EntityId,
+) {
+    app.add_singleton_model(|ctx| AppExecutionMode::new(ExecutionMode::App, false, ctx));
+    let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::default());
+    let terminal_surface_id = EntityId::new();
+    let selection = app.add_model(|ctx| {
+        Box::new(TuiConversationSelection::new(terminal_surface_id, ctx))
+            as Box<dyn ConversationSelection>
+    });
+    (history, selection, terminal_surface_id)
+}
+
+#[test]
+fn tui_selection_owns_next_prompt_selection() {
+    App::test((), |mut app| async move {
+        let (_, selection, _) = build_tui_selection(&mut app);
+        let conversation_id = AIConversationId::new();
+
+        selection.update(&mut app, |selection, ctx| {
+            selection.select_existing_conversation(conversation_id, AgentViewEntryOrigin::Cli, ctx);
+        });
+        selection.read(&app, |selection, ctx| {
+            assert_eq!(
+                selection.selected_conversation_id(ctx),
+                Some(conversation_id)
+            );
+            assert!(selection.is_conversation_active(ctx));
+            assert!(selection.is_conversation_fullscreen(ctx));
+        });
+
+        selection.update(&mut app, |selection, ctx| {
+            selection.select_new_conversation(AgentViewEntryOrigin::Cli, ctx);
+        });
+        selection.read(&app, |selection, ctx| {
+            assert_eq!(selection.selected_conversation_id(ctx), None);
+            assert!(!selection.is_conversation_active(ctx));
+            assert!(!selection.is_conversation_fullscreen(ctx));
+        });
+    });
+}
+
+#[test]
+fn tui_selection_creates_and_selects_terminal_surface_scoped_conversation() {
+    App::test((), |mut app| async move {
+        let (history, selection, terminal_surface_id) = build_tui_selection(&mut app);
+
+        let conversation_id = selection
+            .update(&mut app, |selection, ctx| {
+                selection.try_start_new_conversation(AgentViewEntryOrigin::Cli, ctx)
+            })
+            .expect("TUI conversation creation should succeed");
+
+        selection.read(&app, |selection, ctx| {
+            assert_eq!(
+                selection.selected_conversation_id(ctx),
+                Some(conversation_id)
+            );
+        });
+        history.read(&app, |history, _| {
+            assert_eq!(
+                history
+                    .all_live_conversations_for_terminal_surface(terminal_surface_id)
+                    .map(|conversation| conversation.id())
+                    .collect::<Vec<_>>(),
+                vec![conversation_id]
+            );
+        });
+    });
+}
+
+#[test]
+fn tui_selection_reconciles_split_and_removed_selection() {
+    App::test((), |mut app| async move {
+        let (history, selection, terminal_surface_id) = build_tui_selection(&mut app);
+        let old_conversation_id = AIConversationId::new();
+        let new_conversation_id = AIConversationId::new();
+
+        selection.update(&mut app, |selection, ctx| {
+            selection.select_existing_conversation(
+                old_conversation_id,
+                AgentViewEntryOrigin::Cli,
+                ctx,
+            );
+        });
+        history.update(&mut app, |_, ctx| {
+            ctx.emit(BlocklistAIHistoryEvent::SplitConversation {
+                terminal_surface_id,
+                old_conversation_id,
+                new_conversation_id,
+            });
+        });
+        selection.read(&app, |selection, ctx| {
+            assert_eq!(
+                selection.selected_conversation_id(ctx),
+                Some(new_conversation_id)
+            );
+        });
+
+        history.update(&mut app, |_, ctx| {
+            ctx.emit(BlocklistAIHistoryEvent::RemoveConversation {
+                terminal_surface_id,
+                conversation_id: new_conversation_id,
+                run_id: None,
+            });
+        });
+        selection.read(&app, |selection, ctx| {
+            assert_eq!(selection.selected_conversation_id(ctx), None);
+        });
+    });
+}
+
+#[test]
+fn tui_new_conversation_preserves_pending_autoexecute_override() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|ctx| AppExecutionMode::new(ExecutionMode::App, true, ctx));
+        let history = app.add_singleton_model(|_| BlocklistAIHistoryModel::default());
+        let terminal_surface_id = EntityId::new();
+        let selection = app.add_model(|ctx| {
+            Box::new(TuiConversationSelection::new(terminal_surface_id, ctx))
+                as Box<dyn ConversationSelection>
+        });
+
+        let conversation_id = selection
+            .update(&mut app, |selection, ctx| {
+                selection.try_start_new_conversation(AgentViewEntryOrigin::Cli, ctx)
+            })
+            .expect("TUI conversation creation should succeed");
+
+        history.read(&app, |history, _| {
+            assert!(history
+                .conversation(&conversation_id)
+                .expect("conversation should exist")
+                .autoexecute_any_action());
+        });
+    });
+}

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -2,6 +2,25 @@
 //!
 //! This crate contains:
 //! - [`input`] — the editor-backed TUI input view (`TuiEditorModel` + `TuiInputView`).
+//! - Conversation streaming modules (`conversation_model`, `conversation_selection`, `prompt_stream`).
 //! - Binary entry points under `src/bin/`.
 
+use anyhow::Result;
+
 pub mod input;
+
+mod args;
+mod conversation_model;
+mod conversation_selection;
+mod prompt_stream;
+
+use args::TuiArgs;
+
+/// Runs the TUI frontend or dispatches a Warp worker invocation.
+pub fn run() -> Result<()> {
+    if let Some(result) = warp::run_tui_worker_if_requested() {
+        return result;
+    }
+    let args = TuiArgs::from_env()?;
+    warp::run_tui(move |ctx| prompt_stream::start(args, ctx))
+}

--- a/crates/warp_tui/src/prompt_stream.rs
+++ b/crates/warp_tui/src/prompt_stream.rs
@@ -1,0 +1,432 @@
+//! One-shot TUI prompt streaming to stdout.
+
+use std::io::{self, Write};
+
+use anyhow::anyhow;
+use pathfinder_geometry::vector::Vector2F;
+use warp::tui_export::{
+    AIAgentTextSection, AIConversationId, ActiveSession, BannerState, BlocklistAIActionModel,
+    BlocklistAIContextModel, BlocklistAIController, BlocklistAIHistoryModel, BlocklistAIInputModel,
+    ConversationSelection, ConversationStatus, ConversationStatusUpdate,
+    GetRelevantFilesController, IsSharedSessionCreator, LocalTtyTerminalManager, PtyIntent,
+    PtyIntentEvent, ServerConversationToken, ShellLaunchData, TerminalManagerTrait,
+    TerminalSurface, TerminalSurfaceInit, TerminalSurfaceResult,
+};
+#[cfg(unix)]
+use warp::tui_export::{AfterBlockCompletedEvent, BlockIndex};
+use warpui::elements::Empty;
+use warpui::platform::{TerminationMode, WindowStyle};
+use warpui::{
+    AddWindowOptions, AppContext, Element, Entity, EntityId, ModelHandle, SingletonEntity,
+    TypedActionView, View, ViewContext, ViewHandle,
+};
+
+use super::args::TuiArgs;
+use super::conversation_model::{TuiConversationModel, TuiConversationModelEvent};
+use super::conversation_selection::TuiConversationSelection;
+
+struct PromptStreamHostView;
+
+impl Entity for PromptStreamHostView {
+    type Event = ();
+}
+
+impl View for PromptStreamHostView {
+    fn ui_name() -> &'static str {
+        "PromptStreamHostView"
+    }
+
+    fn render(&self, _app: &AppContext) -> Box<dyn Element> {
+        Empty::new().finish()
+    }
+}
+
+impl TypedActionView for PromptStreamHostView {
+    type Action = ();
+}
+
+struct PromptStreamSurface {
+    conversation_model: ModelHandle<TuiConversationModel>,
+    last_output: String,
+    is_terminating: bool,
+}
+/// Event type for the prompt-stream terminal surface.
+struct PromptStreamEvent;
+
+/// Writes only the newly appended portion of a stream snapshot.
+fn write_stream_snapshot_delta<W: Write>(
+    last_output: &mut String,
+    text: &str,
+    output: &mut W,
+) -> io::Result<()> {
+    if text == last_output {
+        return Ok(());
+    }
+
+    let delta = text.strip_prefix(last_output.as_str()).unwrap_or(text);
+    output.write_all(delta.as_bytes())?;
+    output.flush()?;
+    last_output.clear();
+    last_output.push_str(text);
+    Ok(())
+}
+
+impl PromptStreamSurface {
+    /// Builds the conversation-capable surface from manager-provided terminal session handles.
+    fn new(surface_init: TerminalSurfaceInit, ctx: &mut ViewContext<Self>) -> Self {
+        let TerminalSurfaceInit {
+            model,
+            sessions,
+            model_events,
+            ..
+        } = surface_init;
+        let terminal_surface_id: EntityId = ctx.view_id();
+        let active_session =
+            ctx.add_model(|ctx| ActiveSession::new(sessions.clone(), model_events.clone(), ctx));
+        let conversation_selection = ctx.add_model(|ctx| {
+            Box::new(TuiConversationSelection::new(terminal_surface_id, ctx))
+                as Box<dyn ConversationSelection>
+        });
+        let context_model = ctx.add_model(|ctx| {
+            BlocklistAIContextModel::new(
+                sessions,
+                &model_events,
+                model.clone(),
+                terminal_surface_id,
+                conversation_selection.clone(),
+                ctx,
+            )
+        });
+        let input_model = ctx.add_model(|ctx| {
+            BlocklistAIInputModel::new(
+                model.clone(),
+                conversation_selection.clone(),
+                context_model.clone(),
+                terminal_surface_id,
+                ctx,
+            )
+        });
+        let get_relevant_files_controller = ctx.add_model(GetRelevantFilesController::new);
+        let action_model = ctx.add_model(|ctx| {
+            BlocklistAIActionModel::new(
+                model.clone(),
+                active_session.clone(),
+                &model_events,
+                get_relevant_files_controller,
+                terminal_surface_id,
+                ctx,
+            )
+        });
+        let ai_controller = ctx.add_model(|ctx| {
+            BlocklistAIController::new(
+                input_model,
+                context_model.clone(),
+                conversation_selection.clone(),
+                action_model,
+                active_session,
+                model,
+                terminal_surface_id,
+                ctx,
+            )
+        });
+        let conversation_model = ctx.add_model(|ctx| {
+            TuiConversationModel::new(
+                terminal_surface_id,
+                conversation_selection,
+                ai_controller,
+                ctx,
+            )
+        });
+        ctx.subscribe_to_model(&conversation_model, |surface, _, event, ctx| {
+            surface.handle_conversation_event(event, ctx)
+        });
+        Self {
+            conversation_model,
+            last_output: String::new(),
+            is_terminating: false,
+        }
+    }
+
+    /// Prints the server conversation token and final status.
+    fn print_final_status(
+        &self,
+        conversation_id: AIConversationId,
+        status: &ConversationStatus,
+        ctx: &AppContext,
+    ) {
+        if !self.last_output.is_empty() && !self.last_output.ends_with('\n') {
+            println!();
+        }
+        if let Some(server_conversation_token) = BlocklistAIHistoryModel::as_ref(ctx)
+            .conversation(&conversation_id)
+            .and_then(|conversation| conversation.server_conversation_token())
+        {
+            println!("conversation_id={}", server_conversation_token.as_str());
+        }
+        println!("status={status:?}");
+    }
+
+    /// Submits a new prompt or restores and follows up in an existing conversation.
+    fn submit_prompt(
+        &mut self,
+        prompt: String,
+        server_conversation_token: Option<ServerConversationToken>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.conversation_model.update(ctx, |model, ctx| {
+            if let Some(server_conversation_token) = server_conversation_token {
+                model.restore_conversation_by_server_token_and_send_prompt(
+                    prompt,
+                    server_conversation_token,
+                    ctx,
+                );
+            } else {
+                model.send_prompt(prompt, ctx);
+            }
+        });
+    }
+
+    /// Adapts production model events to the one-shot stdout output.
+    fn handle_conversation_event(
+        &mut self,
+        event: &TuiConversationModelEvent,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if self.is_terminating {
+            return;
+        }
+        match event {
+            TuiConversationModelEvent::SelectedConversationChanged { conversation_id } => {
+                let _ = conversation_id;
+                self.last_output.clear();
+            }
+            TuiConversationModelEvent::ConversationStarted { conversation_id } => {
+                let _ = conversation_id;
+            }
+            TuiConversationModelEvent::ConversationUpdated { conversation_id } => {
+                self.print_stream_snapshot(*conversation_id, ctx);
+            }
+            TuiConversationModelEvent::ConversationStatusChanged {
+                conversation_id,
+                status,
+                update: ConversationStatusUpdate::Changed { .. },
+            } => {
+                self.print_stream_snapshot(*conversation_id, ctx);
+                if self.is_terminating {
+                    return;
+                }
+                match status {
+                    ConversationStatus::InProgress
+                    | ConversationStatus::TransientError
+                    | ConversationStatus::WaitingForEvents => {}
+                    ConversationStatus::Success => {
+                        self.print_final_status(*conversation_id, status, ctx);
+                        self.is_terminating = true;
+                        ctx.terminate_app(TerminationMode::ForceTerminate, None);
+                    }
+                    ConversationStatus::Error
+                    | ConversationStatus::Cancelled
+                    | ConversationStatus::Blocked { .. } => {
+                        self.print_final_status(*conversation_id, status, ctx);
+                        self.terminate_with_error(
+                            anyhow!("TUI prompt streaming ended with status {status:?}"),
+                            ctx,
+                        );
+                    }
+                }
+            }
+            TuiConversationModelEvent::ConversationStatusChanged {
+                update: ConversationStatusUpdate::Restored,
+                ..
+            } => {}
+            TuiConversationModelEvent::Error { message } => {
+                self.terminate_with_error(anyhow!("{message}"), ctx);
+            }
+        }
+    }
+    /// Prints the latest plain-text output when it changes.
+    fn print_stream_snapshot(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some((has_actions, text)) = (|| {
+            let exchange = BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(&conversation_id)
+                .and_then(|conversation| conversation.latest_exchange())?;
+            let output = exchange.output_status.output()?;
+            let output = output.get();
+            let has_actions = output.actions().next().is_some();
+            let text = output
+                .text_from_agent_output()
+                .flat_map(|text| text.sections.iter())
+                .filter_map(|section| match section {
+                    AIAgentTextSection::PlainText { text } => Some(text.text()),
+                    AIAgentTextSection::Code { .. }
+                    | AIAgentTextSection::Table { .. }
+                    | AIAgentTextSection::Image { .. }
+                    | AIAgentTextSection::MermaidDiagram { .. } => None,
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            Some((has_actions, text))
+        })() else {
+            return;
+        };
+        if has_actions {
+            self.terminate_with_error(
+                anyhow!("TUI prompt streaming does not support tool actions"),
+                ctx,
+            );
+            return;
+        }
+        let mut stdout = io::stdout().lock();
+        if let Err(error) = write_stream_snapshot_delta(&mut self.last_output, &text, &mut stdout) {
+            self.terminate_with_error(anyhow!("Failed to write TUI stream output: {error}"), ctx);
+        }
+    }
+
+    /// Terminates prompt streaming with a user-visible error.
+    fn terminate_with_error(&mut self, error: anyhow::Error, ctx: &mut ViewContext<Self>) {
+        if self.is_terminating {
+            return;
+        }
+        self.is_terminating = true;
+        ctx.terminate_app(TerminationMode::ForceTerminate, Some(Err(error)));
+    }
+}
+
+impl Entity for PromptStreamSurface {
+    type Event = PromptStreamEvent;
+}
+
+impl PtyIntentEvent for PromptStreamEvent {
+    fn pty_intent(&self) -> Option<PtyIntent> {
+        None
+    }
+}
+
+impl TerminalSurface for PromptStreamSurface {
+    #[cfg(unix)]
+    fn should_start_password_prompt_polling(&self, _command: &str, _ctx: &AppContext) -> bool {
+        false
+    }
+
+    #[cfg(unix)]
+    fn should_stop_password_prompt_polling(&self, _completed: &AfterBlockCompletedEvent) -> bool {
+        false
+    }
+
+    fn on_shell_determined(&mut self, _ctx: &mut ViewContext<Self>) {}
+
+    fn on_active_shell_launch_data_updated(
+        &mut self,
+        _shell_launch_data: Option<ShellLaunchData>,
+        _ctx: &mut ViewContext<Self>,
+    ) {
+    }
+
+    fn on_pty_spawn_failed(&mut self, error: anyhow::Error, _ctx: &mut ViewContext<Self>) {
+        log::warn!("PTY spawn failed for the TUI prompt-streaming surface: {error:#}");
+    }
+
+    #[cfg(unix)]
+    fn on_possible_password_prompt(
+        &mut self,
+        _block_index: Option<BlockIndex>,
+        _ctx: &mut ViewContext<Self>,
+    ) {
+    }
+
+    #[cfg(unix)]
+    fn on_polled_block_completed(
+        &mut self,
+        _completed: &AfterBlockCompletedEvent,
+        _ctx: &mut ViewContext<Self>,
+    ) {
+    }
+}
+
+impl View for PromptStreamSurface {
+    fn ui_name() -> &'static str {
+        "PromptStreamSurface"
+    }
+
+    fn render(&self, _app: &AppContext) -> Box<dyn Element> {
+        Empty::new().finish()
+    }
+}
+
+impl TypedActionView for PromptStreamSurface {
+    type Action = ();
+}
+
+struct PromptStreamSession {
+    _manager: ModelHandle<Box<dyn TerminalManagerTrait>>,
+    _surface: ViewHandle<PromptStreamSurface>,
+}
+
+impl Entity for PromptStreamSession {
+    type Event = ();
+}
+
+impl SingletonEntity for PromptStreamSession {}
+/// Starts prompt streaming when the TUI frontend received a prompt.
+pub(super) fn start(args: TuiArgs, ctx: &mut AppContext) -> bool {
+    let Some(prompt) = args.prompt else {
+        return false;
+    };
+    start_prompt_stream(prompt, args.server_conversation_token, ctx);
+    true
+}
+
+/// Builds a manager-backed terminal session and submits the prompt.
+fn start_prompt_stream(
+    prompt: String,
+    server_conversation_token: Option<ServerConversationToken>,
+    ctx: &mut AppContext,
+) {
+    let (window_id, _) = ctx.add_window(
+        AddWindowOptions {
+            window_style: WindowStyle::NotStealFocus,
+            ..Default::default()
+        },
+        |_ctx| PromptStreamHostView,
+    );
+    let banner = ctx.add_model(|_| BannerState::default());
+    let terminal_manager = LocalTtyTerminalManager::<PromptStreamSurface>::create_tui_model(
+        std::env::current_dir().ok(),
+        std::env::vars_os().collect(),
+        IsSharedSessionCreator::No,
+        None,
+        banner,
+        Vector2F::new(120., 24.),
+        None,
+        None,
+        ctx,
+        move |surface_init, ctx| {
+            let surface = ctx.add_typed_action_view(window_id, |ctx| {
+                PromptStreamSurface::new(surface_init, ctx)
+            });
+            TerminalSurfaceResult {
+                surface,
+                post_wire: |_manager: &mut LocalTtyTerminalManager<PromptStreamSurface>,
+                            _surface: &ViewHandle<PromptStreamSurface>,
+                            _ctx: &mut AppContext| {},
+            }
+        },
+    );
+    let manager = terminal_manager.manager;
+    let surface = terminal_manager.surface;
+    surface.update(ctx, |surface, ctx| {
+        surface.submit_prompt(prompt, server_conversation_token, ctx);
+    });
+    ctx.add_singleton_model(|_| PromptStreamSession {
+        _manager: manager,
+        _surface: surface,
+    });
+}
+
+#[cfg(test)]
+#[path = "prompt_stream_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/prompt_stream_tests.rs
+++ b/crates/warp_tui/src/prompt_stream_tests.rs
@@ -1,0 +1,14 @@
+use super::write_stream_snapshot_delta;
+
+#[test]
+fn stream_snapshots_write_only_appended_text() {
+    let mut last_output = String::new();
+    let mut output = Vec::new();
+
+    for snapshot in ["h", "he", "hello", "hello", "hello world"] {
+        write_stream_snapshot_delta(&mut last_output, snapshot, &mut output).unwrap();
+    }
+
+    assert_eq!(String::from_utf8(output).unwrap(), "hello world");
+    assert_eq!(last_output, "hello world");
+}

--- a/crates/warp_tui/tests/worker_dispatch.rs
+++ b/crates/warp_tui/tests/worker_dispatch.rs
@@ -1,0 +1,27 @@
+use command::blocking::Command;
+
+/// Verifies a worker invocation exits through worker dispatch without starting the TUI frontend.
+#[test]
+fn dispatches_worker_invocation_instead_of_tui_frontend() {
+    let empty_file =
+        std::env::temp_dir().join(format!("warp-tui-worker-dispatch-{}", std::process::id()));
+    std::fs::write(&empty_file, []).expect("failed to create empty worker-dispatch fixture");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_warp-tui-oss"))
+        .arg("ripgrep-search")
+        .arg("__warp_tui_worker_dispatch_probe__")
+        .arg(&empty_file)
+        .output()
+        .expect("failed to invoke warp-tui worker");
+    let _ = std::fs::remove_file(empty_file);
+
+    assert!(
+        output.status.success(),
+        "worker invocation failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !String::from_utf8_lossy(&output.stdout).contains("Welcome to Warp TUI"),
+        "worker invocation started the TUI frontend"
+    );
+}

--- a/specs/conversation-streaming-for-tui/TECH.md
+++ b/specs/conversation-streaming-for-tui/TECH.md
@@ -1,0 +1,100 @@
+# TUI conversation streaming — TECH
+## Context
+This change adds a one-shot TUI path that sends a prompt through Warp's production AI controller and streams plain-text output to stdout. The reusable coordination model is designed to support a future interactive TUI without introducing an alternate request or response-stream implementation.
+`BlocklistAIHistoryModel` stores conversations and active/progress state per terminal surface. Active conversation means the current or most recent stream/progress target; it remains distinct from the conversation selected for the next prompt (`app/src/ai/blocklist/history_model.rs:206`, `app/src/ai/blocklist/conversation_selection.rs`).
+Every terminal surface constructs its own implementation of the object-safe `ConversationSelection` contract and passes a type-erased `ConversationSelectionHandle` into shared AI models. The GUI implementation delegates selected-conversation behavior to `AgentViewController`; the TUI implementation owns selection without constructing Agent View UI state.
+## Design
+### Conversation selection boundary
+GUI and TUI composition roots explicitly construct their own `ConversationSelection` implementations and erase them behind `ConversationSelectionHandle = ModelHandle<Box<dyn ConversationSelection>>` (`app/src/terminal/view.rs`, `crates/warp_tui/src/prompt_stream.rs`). The contract centralizes:
+- selected/next-prompt conversation lookup
+- new and existing conversation targeting
+- surface-owned pending-query behavior and effective autoexecute behavior
+- selection reconciliation for clear, split, remove, delete, and transfer history events
+
+The generic blocklist module defines only the trait, fixed selection/presentation event contract, type-erased handle, and shared value types; it does not contain either surface implementation, selection state, or GUI/TUI branching. `AgentViewConversationSelection` lives beside Agent View code and is an unconditional thin adapter over the GUI's `AgentViewController`. `TuiConversationSelection` lives in the TUI frontend and owns its pending selection directly.
+
+`BlocklistAIContextModel`, `BlocklistAIInputModel`, and `BlocklistAIController` require a `ConversationSelectionHandle`; none accepts an optional `AgentViewController` or knows which surface implementation is inside the handle. Context owns pending attachments and request context, input owns input-mode behavior, and the controller owns request/action/stream behavior.
+
+The contract intentionally includes selected-conversation behavior together with conversation-presentation state and lifecycle events. It exposes active/fullscreen queries and entry/exit events because shared input/context/controller behavior must derive that information from the surface rather than duplicate it. Selection-mutating methods continue carrying `AgentViewEntryOrigin` and `EnterAgentViewError`; the GUI implementation forwards those values unchanged to `AgentViewController`, while the TUI implementation forwards origins through the shared lifecycle event contract without interpreting GUI-only origin behavior and never returns GUI-only entry failures.
+
+### Conversation presentation lifecycle
+The GUI selection implementation assumes Agent View is enabled, derives selected/active/fullscreen state directly from `AgentViewController`, and translates `AgentViewControllerEvent` into `ConversationSelectionEvent` for shared models. It does not preserve a second pending-selection state machine for the legacy AgentView-disabled path. The TUI implementation treats any selected conversation as active and fullscreen; it has no separate terminal-versus-Agent-View presentation state.
+
+`BlocklistAIInputModel` and `BlocklistAIContextModel` derive active/fullscreen state synchronously from `ConversationSelectionHandle` and subscribe to its lifecycle events for transition side effects. `BlocklistAIController` subscribes to exit events for cancellation behavior. Shared models never store presentation state and never hold `AgentViewController`.
+### Terminal-surface-scoped history
+WarpUI `EntityId` is the routing key for a terminal surface. History fields, methods, and events use `terminal_surface_id` terminology consistently:
+- live, cleared, and active conversation IDs are keyed by terminal surface
+- clear, restore, selection-transfer, and streaming events carry terminal surface IDs
+- GUI-local APIs retain terminal-view terminology when they specifically address `TerminalView`
+Moving a conversation between surfaces emits `ConversationTransferredBetweenTerminalSurfaces`, allowing the previous surface to discard rendered blocks while the destination becomes canonical (`app/src/ai/blocklist/history_model.rs:1047`, `app/src/ai/blocklist/history_model.rs:2855`).
+### TUI conversation coordination
+`TuiConversationModel` is the reusable TUI presentation coordinator (`crates/warp_tui/src/conversation_model.rs`). It contains no transcript widgets and coordinates:
+- the TUI-owned `ConversationSelection` implementation
+- creation and selection of a new conversation
+- restore and selection of an existing conversation
+- prompt submission through `BlocklistAIController`
+- terminal-surface-filtered history events for conversation start, stream updates, status changes, selection changes, and errors
+`send_prompt(...)` targets the current selection or creates a conversation when none is selected. `restore_conversation_by_server_token_and_send_prompt(...)` resolves a supplied server conversation token to the canonical local conversation ID, restores and selects that conversation, then delegates to `send_prompt(...)` (`crates/warp_tui/src/conversation_model.rs`).
+### One-shot prompt streaming
+`PromptStreamSurface` adapts `TuiConversationModel` events to stdout and application termination (`crates/warp_tui/src/prompt_stream.rs`). It is named for its actual behavior rather than as a test fixture.
+TUI initialization always completes authentication before dispatching either prompt streaming or the default user-ID command (`app/src/tui.rs:23`). Prompt streaming uses the normal local terminal-manager and PTY lifecycle; there is no surface-specific PTY startup switch.
+`PtySpawner` can safely use the standard terminal-server subprocess from a `warp-tui` executable. `warp_tui::run()` asks `warp::run_tui_worker_if_requested()` to dispatch Warp worker invocations before parsing frontend arguments, then passes the TUI initializer into `warp::run_tui(...)` for app bootstrap and authentication (`crates/warp_tui/src/lib.rs`, `app/src/lib.rs`, `app/src/tui.rs`). This lets TUI launches register the same early `PtySpawner` singleton as other Warp launches without recursively starting more TUI frontends, and preserves dispatch for other current-executable workers.
+The adapter prints changed plain-text snapshots, then the server conversation token and final status when the stream completes. Tool actions fail clearly because this phase does not provide approval or action UI.
+### Channel-specific binaries
+The `warp_tui` package mirrors GUI channel binaries. Each channel-specific binary only configures `ChannelState` and calls `warp_tui::run()`. The `warp_tui` library owns frontend argument parsing, TUI conversation coordination, selection, and prompt-stream presentation; the `warp` app crate owns worker dispatch, shared app bootstrap, authentication, AI models, and terminal-manager internals. The TUI frontend accepts:
+- `--prompt <text>`
+- `--conversation-id <server-conversation-token>`
+Bare `cargo run -p warp_tui` uses the OSS/production channel; `./script/run-tui -- --prompt ...` selects the internal local channel when its channel config is available.
+## End-to-end flow
+```mermaid
+flowchart TD
+  Init["TUI initialization"] --> Auth["Authentication ready"]
+  Auth --> Manager["TerminalManager<PromptStreamSurface>"]
+  Manager --> Cluster["TUI-surface AI models"]
+  Cluster --> Model["TuiConversationModel"]
+  Model --> Select{"selected conversation?"}
+  Select -->|none| New["Create and select conversation"]
+  Select -->|server token| Restore["Restore and select conversation"]
+  New --> Send["BlocklistAIController request"]
+  Restore --> Send
+  Send --> Stream["ResponseStream events"]
+  Stream --> History["Terminal-surface-scoped history"]
+  History --> Model
+  Model --> Output["Stream plain text to stdout"]
+```
+## Testing and validation
+Automated coverage verifies:
+- terminal-surface-scoped history maps and active/progress state
+- the generic conversation-selection contract and TUI-owned pending-selection state
+- GUI implementation delegation to Agent View and TUI-owned selection behavior
+- GUI Agent View lifecycle effects remain behaviorally equivalent through the trait adapter
+- creating a TUI conversation selects it for the correct terminal surface
+- split and removal events reconcile TUI selection
+- selecting a new conversation, restoring an existing conversation by server token, and sending a follow-up retain the same canonical local conversation ID
+- mock response-stream events flow through `BlocklistAIController` into filtered history/model events
+- TUI-owned frontend parsing accepts prompt-streaming CLI arguments
+- Warp worker invocations dispatch before TUI frontend argument parsing
+Manual validation:
+- `cargo run -p warp_tui -- --prompt "Reply with exactly: hello from tui"` emits streamed text, the server conversation token as `conversation_id=...`, and `status=Success`
+- a separate process using that server token with `--conversation-id` restores the conversation and recalls the previous response
+- prompts requiring tools terminate with an unsupported-action error rather than hanging
+Run:
+- `./script/format`
+- `cargo check -p warp -p warp_tui`
+- `cargo check -p warp --tests`
+- `cargo check -p warp --features integration_tests --tests`
+- `cargo clippy -p warp -p warp_tui --all-targets -- -D warnings`
+- focused nextest filters for history, context selection, TUI model, and controller response-stream tests
+## Out of scope
+- Transcript/rich-content TUI widgets
+- TUI workspace/root orchestration UI
+- TUI tool/action execution, approval UI, shell execution, or autoexecute policy
+- A shared cross-surface `AgentConversationSession`
+- A raw server-stream client that bypasses `BlocklistAIController`
+- A stable external stdout protocol
+## Risks and mitigations
+- **GUI behavior regresses.** `AgentViewConversationSelection` delegates selection to the existing `AgentViewController` and translates its lifecycle events without duplicating state. Pin entry/exit ordering and side effects with focused GUI tests.
+- **The contract accumulates GUI vocabulary.** Keep the surface implementations responsible for interpreting presentation state and `AgentViewEntryOrigin`; shared models consume the common contract without branching on GUI versus TUI.
+- **Active/progress and selected/next-prompt semantics blur.** Keep active state in history and selected/next-prompt behavior behind `ConversationSelection`.
+- **A TUI selection becomes invalid.** Reconcile selection from removal, deletion, transfer, clear, and split events.
+- **One-shot presentation policy leaks into reusable models.** Keep stdout, termination, and unsupported-action behavior in `crates/warp_tui/src/prompt_stream.rs`.


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

This PR changes it so that the main cluster of conversation models (i.e. the `BlocklistAIContextModel`, `BlocklistAIInputModel`, `BlocklistAIController`, and `BlocklistAIHistoryModel`) necessary for conversation streaming and basic conversation management can be re-used by the `TUI` w/ no `TUI` or `GUI` specific code within said models (i.e. the models are not concerned w/ whether they are associated with a `TUI` or `GUI` surface).

Luckily enough, there's actually not much that needs to be changed within these models to get them working for the TUI and GUI in a surface-agnostic way. The major things that change are:
* the models stop referencing a `terminal_view_id: EntityId`, replaced with `terminal_surface_id: EntityId`. This is where the majority of the LOC changed come from in this PR, and it should be a behavior no-op. Just want to make sure we're clear on our naming here.
* the shared models no longer hold an `AgentViewController`, as this controller is GUI specific. What makes this a little tricky is that the `AgentViewController` was doing several jobs: it was telling the models whether an agent view was open or not, telling the models what conversation was currently selected, and emitting presentation lifecycle events consumed by the shared models. To handle these jobs, this PR adds an object-safe `ConversationSelection` abstraction that each surface implements and passes to the shared models behind a `ConversationSelectionHandle`. For `GUI` surfaces, `AgentViewConversationSelection` delegates presentation operations to `AgentViewController` and translates Agent View lifecycle events into events consumed by shared models. For `TUI` surfaces, `TuiConversationSelection` owns the pending conversation selection directly.

The history model also now distinguishes between transferring a conversation to a new terminal surface and simply marking an already-owned conversation as the active streaming target. This ensures automatic follow-ups don't accidentally transfer conversations between surfaces, while explicit transfers still clean up the previous renderer and selection.

Finally, this PR adds a one-shot `--prompt` runtime path to `warp_tui`, which streams a response directly back as output. I would just delete this as "testing code", but I actually think it's worthwhile to keep given our long-term plan of replacing the portion of the Oz CLI responsible for handling prompt submission with the TUI. The reusable conversation coordination lives in `TuiConversationModel`, while the one-shot stdout behavior lives in `PromptStreamSurface`.

This PR also adds a `--conversation-id` flag so that you can continue an existing conversation. This flag accepts a server conversation token, allowing the TUI to restore the corresponding conversation and test that follow-ups are WAI.

The TUI now uses the normal backing terminal server. To prevent this from recursively starting more TUI frontends, worker invocations are dispatched before TUI frontend arguments are parsed.

## Reviewing this PR
A lot of this PR is no-op field name changes or simple call structure changes that aren't worth reading. The files worth digging into are:

1. The tech spec for an over-arching tech implementation guide
◦ `specs/conversation-streaming-for-tui/TECH.md`

2. The new `ConversationSelection` abstraction and its GUI/TUI implementations
◦ `app/src/ai/blocklist/conversation_selection.rs`
◦ `app/src/ai/blocklist/agent_view/conversation_selection.rs`
◦ `crates/warp_tui/src/conversation_selection.rs`

3. The existing models migrated onto that abstraction. These are skim-able IMO but worth looking at just to see how the abstractions introduced in this PR are used in action.
◦ `app/src/ai/blocklist/context_model.rs`
◦ `app/src/ai/blocklist/input_model.rs`
◦ `app/src/ai/blocklist/controller.rs`

4. The history-model behavioral portions (again, skim-able)
◦ `app/src/ai/blocklist/history_model.rs`
◦ Do not read all of the changed lines sequentially; most are renames. Focus on:
   ▪ `set_active_conversation_id`
   ▪ `mark_active_conversation_id`
   ▪ `restore_conversations`
   ▪ clear/remove/delete behavior
   ▪ `terminal_surface_id_for_conversation`
   ▪ `ConversationTransferredBetweenTerminalSurfaces`
   ▪ `BlocklistAIHistoryEvent::terminal_surface_id`
◦ The important behavior is conversation transfer between surfaces and ensuring the previous renderer/selection is cleaned up.

5. The TUI conversation model
◦ `crates/warp_tui/src/conversation_model.rs`

6. The TUI presentation streaming adapter
◦ `crates/warp_tui/src/prompt_stream.rs`
◦ Focus on:
▪ model cluster construction
▪ retained surface/manager lifetimes
▪ stdout snapshot behavior
▪ tool-action failure behavior
▪ final-status and error termination

7. The bug fix around preventing a fork bomb while allowing us to spin up a backing terminal server
◦ `app/src/lib.rs`
◦ `app/src/tui.rs`
◦ `crates/warp_tui/src/lib.rs`
◦ `crates/warp_cli/src/lib.rs` — `is_worker_invocation`
◦ `crates/warp_tui/tests/worker_dispatch.rs`

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/2ecdc7fa6ee54bcab0b4183a237d12af

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode