### PR TITLE
voice_input: report stream errors once per session to stop Sentry flood

### DIFF
--- a/crates/voice_input/src/lib.rs
+++ b/crates/voice_input/src/lib.rs
@@ -203,6 +203,13 @@ impl VoiceInput {
             StartListeningError::Other(anyhow::anyhow!("Resampler construction failed: {e}"))
         })?;
 
+        // Some audio backends (notably ALSA on Linux) fire this error callback
+        // repeatedly in a tight loop when the input device wedges - e.g.
+        // `alsa::poll()` returning POLLERR after a device disconnect. Logging at
+        // error level on every invocation floods Sentry with millions of
+        // identical events, so only report the first error per session at error
+        // level and downgrade the rest to debug.
+        let mut has_logged_stream_error = false;
         let stream = input_device
             .build_input_stream(
                 &stream_config,
@@ -219,8 +226,13 @@ impl VoiceInput {
                     // This is blocking, but we aren't on the main thread.
                     let _ = warpui_core::r#async::block_on(audio_frame_tx.send(mono_samples));
                 },
-                |err| {
-                    log::error!("Error in voice input stream: {err}");
+                move |err| {
+                    if has_logged_stream_error {
+                        log::debug!("Error in voice input stream (suppressed repeat): {err}");
+                    } else {
+                        has_logged_stream_error = true;
+                        log::error!("Error in voice input stream: {err}");
+                    }
                 },
                 Some(STREAM_TIMEOUT),
             )


### PR DESCRIPTION
## Description
cpal's stream error callback in `crates/voice_input/src/lib.rs` logged at `error!` level on every invocation. On Linux/ALSA, a wedged input device — e.g. `alsa::poll()` returning `POLLERR` after a device disconnect — fires this callback in a tight loop indefinitely (or until the 6-minute `STREAM_TIMEOUT`).

Because the Sentry logger turns every `Error`-level log into a Sentry *event* (`sentry_log::default_filter`, and `should_ignore_log_for_sentry` only suppresses the `report_error!` target), this single code path generated ~2.4M events/day from one user and ~35M occurrences total across 26 users.

**Fix:** latch a per-session flag in the error closure so only the *first* error is reported at `error!` level; subsequent errors in the same session drop to `debug!`. A fresh closure is created on each `start_listening`, giving natural once-per-session semantics. This collapses the event count from "poll-loop iterations" to "voice sessions that hit an error" (~5–6 orders of magnitude fewer) while retaining one signal per affected session.

Fixes WARP-CLIENT-BETA-STABLE-512C.

## Linked Issue
Sentry: https://warpdotdev.sentry.io/issues/7314400458/

## Testing
- [x] `./script/format` clean
- [x] `cargo clippy -p voice_input --all-targets -- -D warnings` clean
- [ ] Manual repro requires a Linux/ALSA device disconnect mid-session; the change is logging-only and does not alter stream behavior (cpal's error callback is purely a notification).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->
