### PR TITLE
[POC] App-level soft line wrapping in code editor & diff views

### DIFF
--- a/app/src/code/editor/diff.rs
+++ b/app/src/code/editor/diff.rs
@@ -16,7 +16,7 @@ use warp_core::ui::theme::{AnsiColorIdentifier, Fill};
 use warp_editor::content::edit::TemporaryBlock;
 use warp_editor::content::version::BufferVersion;
 use warp_editor::multiline::{AnyMultilineString, MultilineStr, MultilineString, LF};
-use warp_editor::render::model::{Decoration, LineCount, LineDecoration};
+use warp_editor::render::model::{Decoration, LineCount, LineDecoration, LogicalLineCount};
 use warpui::{Entity, ModelContext};
 
 use super::super::DiffResult;
@@ -275,7 +275,7 @@ impl DiffModel {
 
                     removed_lines.push(TemporaryBlock {
                         content,
-                        insert_before: LineCount::from(range.start),
+                        insert_before: LogicalLineCount::from(range.start),
                         line_decoration: Some(remove_overlay_color(appearance).into()),
                         inline_text_decorations: Vec::new(),
                     });
@@ -329,7 +329,7 @@ impl DiffModel {
 
                             removed_lines.push(TemporaryBlock {
                                 content,
-                                insert_before: LineCount::from(range.start),
+                                insert_before: LogicalLineCount::from(range.start),
                                 line_decoration: Some(remove_overlay_color(appearance).into()),
                                 inline_text_decorations,
                             });

--- a/app/src/code/editor/element.rs
+++ b/app/src/code/editor/element.rs
@@ -16,7 +16,8 @@ use warp_editor::editor::EditorView;
 use warp_editor::render::element::lens_element::RichTextElementLens;
 use warp_editor::render::element::{RenderableBlock, RichTextElement, VerticalExpansionBehavior};
 use warp_editor::render::model::{
-    gutter_expansion_button_types, BlockLocation, ExpansionType, LineCount, RenderState,
+    gutter_expansion_button_types, BlockLocation, ExpansionType, LineCount, LogicalLineCount,
+    RenderState,
 };
 use warpui::elements::new_scrollable::{NewScrollableElement, ScrollableAxis};
 use warpui::elements::{
@@ -618,20 +619,28 @@ impl<V: EditorView> EditorWrapper<V> {
                 .into_pixels(),
                 InnerEditor::FullEditor(_) => block.viewport_item().viewport_offset,
             };
-            let diff_hunk = self.diff_status.diff_hunk(line_count, appearance);
+            // Diff hunks/decorations are keyed by logical (source) lines, and the gutter should
+            // display logical line numbers, so derive a logical line index. `line_count` (visual
+            // rows) is retained only for visual-row positioning, like the hidden-section hover
+            // checks below.
+            let logical_line_count = model
+                .start_logical_line_index(&**block)
+                .map(|logical| LineCount::from(logical.as_usize()))
+                .unwrap_or(line_count);
+            let diff_hunk = self.diff_status.diff_hunk(logical_line_count, appearance);
             let is_removal = matches!(diff_hunk, Some(DiffHunkDisplay::Remove(_)));
 
             let current_line = if self.should_display_relative_line_number() {
-                line_number_config.display_line_number(line_count)
+                line_number_config.display_line_number(logical_line_count)
             } else {
-                line_number_config.absolute_line_number(line_count)
+                line_number_config.absolute_line_number(logical_line_count)
             };
 
             // If the block is temporary, don't render line number.
             // Currently, all temporary blocks are removal hunks, either from a deleted section,
             // or the old lines from a replacement hunk.
             if block.is_temporary() {
-                let diff_range = self.diff_status.removed_diff_range(line_count);
+                let diff_range = self.diff_status.removed_diff_range(logical_line_count);
                 let range_already_clicked = diff_range
                     .as_ref()
                     .is_some_and(|range| self.state_handle.is_range_clicked(range));
@@ -643,11 +652,11 @@ impl<V: EditorView> EditorWrapper<V> {
                         || matches!(diff_hunk, Some(DiffHunkDisplay::Replacement { .. })))
                 {
                     // Track the index for this removal line
-                    if removed_hunk_line_number == Some(line_count) {
+                    if removed_hunk_line_number == Some(logical_line_count) {
                         removed_hunk_line_index += 1;
                     } else {
                         removed_hunk_line_index = 0;
-                        removed_hunk_line_number = Some(line_count);
+                        removed_hunk_line_number = Some(logical_line_count);
                     }
 
                     let height = block.viewport_item().content_size.y();
@@ -656,8 +665,8 @@ impl<V: EditorView> EditorWrapper<V> {
                     let first_line_height = model.first_line_height(&**block).unwrap_or(height);
 
                     let line = EditorLineLocation::Removed {
-                        line_number: line_count,
-                        line_range: diff_range.unwrap_or(line_count..line_count),
+                        line_number: logical_line_count,
+                        line_range: diff_range.unwrap_or(logical_line_count..logical_line_count),
                         index: removed_hunk_line_index,
                     };
                     // Show comment button only on the specific hovered line with matching index
@@ -808,7 +817,7 @@ impl<V: EditorView> EditorWrapper<V> {
 
                 continue;
             }
-            let diff_range = self.diff_status.added_diff_range(line_count);
+            let diff_range = self.diff_status.added_diff_range(logical_line_count);
             let range_already_clicked = diff_range
                 .as_ref()
                 .is_some_and(|range| self.state_handle.is_range_clicked(range));
@@ -818,7 +827,9 @@ impl<V: EditorView> EditorWrapper<V> {
             // given this is a wrapper specific to our code pane implementation.
             let overlay = line_decorations
                 .iter()
-                .filter(|decoration| decoration.start <= line_count && decoration.end > line_count)
+                .filter(|decoration| {
+                    decoration.start <= logical_line_count && decoration.end > logical_line_count
+                })
                 .map(|decoration| decoration.overlay)
                 .next();
 
@@ -1386,8 +1397,12 @@ impl<V: EditorView> Element for EditorWrapper<V> {
                 InnerEditor::FullEditor(_) => model.viewport().scroll_top(),
             };
             for decoration in model.decorations().line_decoration_ranges() {
-                let start_y = content.y_offset_at_line(decoration.start);
-                let end_y = content.y_offset_at_line(decoration.end);
+                // Decoration ranges are in logical (source) line space, so map them to Y via the
+                // logical-line dimension; otherwise they drift against soft-wrapped content.
+                let start_y = content
+                    .y_offset_at_logical_line(LogicalLineCount::from(decoration.start.as_usize()));
+                let end_y = content
+                    .y_offset_at_logical_line(LogicalLineCount::from(decoration.end.as_usize()));
                 ctx.scene
                     .draw_rect_without_hit_recording(RectF::new(
                         origin + vec2f(0., (start_y - y_adjustment).as_f32()),

--- a/app/src/code/editor/model.rs
+++ b/app/src/code/editor/model.rs
@@ -311,6 +311,9 @@ pub struct CodeEditorModel {
     lazy_layout_initialized: bool,
     /// Whether syntax parsing should be bootstrapped from the latest full buffer content.
     pending_syntax_tree_bootstrap: bool,
+    /// Whether lines soft-wrap to the viewport width. When set, the editor re-lays out its
+    /// content on viewport resize so wrapping tracks the available width.
+    soft_wrap: bool,
 }
 
 impl CodeEditorModel {
@@ -318,6 +321,7 @@ impl CodeEditorModel {
         text_styles: RichTextStyles,
         session_platform: Option<SessionPlatform>,
         lazy_layout: bool,
+        soft_wrap: bool,
         buffer: Option<ModelHandle<Buffer>>, // Whether the editor is using an underlying shared buffer.
         ctx: &mut ModelContext<Self>,
     ) -> Self {
@@ -334,16 +338,24 @@ impl CodeEditorModel {
             buffer.set_session_platform(session_platform);
         });
 
+        // Soft-wrapping lays out to the viewport width; otherwise the editor lays out at infinite
+        // width and scrolls horizontally.
+        let width_setting = if soft_wrap {
+            WidthSetting::FitViewport
+        } else {
+            WidthSetting::InfiniteWidth
+        };
         Self::from_content(
             content,
             true,        // show_current_line_highlights
             lazy_layout, // lazy_layout_enabled
             false,       // lazy_layout_initialized
+            soft_wrap,
             ctx,
             |hidden_lines, ctx| {
                 ctx.add_model(|ctx| {
                     RenderState::new(text_styles, lazy_layout, Some(hidden_lines.clone()), ctx)
-                        .with_width_setting(WidthSetting::InfiniteWidth)
+                        .with_width_setting(width_setting)
                 })
             },
         )
@@ -370,6 +382,7 @@ impl CodeEditorModel {
             false, // show_current_line_highlights: no GPU rendering in TUI
             false, // lazy_layout_enabled: no lazy layout in TUI
             true,  // lazy_layout_initialized: no lazy layout in TUI
+            false, // soft_wrap: TUI uses char-cell layout, never soft-wraps
             ctx,
             |_hidden_lines, ctx| {
                 // CharCell layout never consults `RichTextStyles`, so pass a stub.
@@ -393,6 +406,7 @@ impl CodeEditorModel {
         show_current_line_highlights: bool,
         lazy_layout_enabled: bool,
         lazy_layout_initialized: bool,
+        soft_wrap: bool,
         ctx: &mut ModelContext<Self>,
         build_render_state: impl FnOnce(
             &ModelHandle<HiddenLinesModel>,
@@ -460,6 +474,7 @@ impl CodeEditorModel {
             lazy_layout_enabled,
             lazy_layout_initialized,
             pending_syntax_tree_bootstrap: false,
+            soft_wrap,
         }
     }
 
@@ -589,7 +604,13 @@ impl CodeEditorModel {
             RenderEvent::LayoutUpdated => {
                 ctx.emit(CodeEditorModelEvent::LayoutInvalidated);
             }
-            RenderEvent::NeedsResize => {}
+            RenderEvent::NeedsResize => {
+                // When soft-wrapping, a viewport width change must re-wrap the content.
+                // Non-wrapping editors lay out at infinite width and ignore resizes (current behavior).
+                if self.soft_wrap {
+                    self.rebuild_layout_and_refresh_diff(ctx);
+                }
+            }
         }
     }
 

--- a/app/src/code/editor/model.rs
+++ b/app/src/code/editor/model.rs
@@ -6,6 +6,7 @@ use std::ops::Range;
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::time::Duration;
 use std::{cmp, mem};
 
 use ai::diff_validation::DiffDelta;
@@ -27,6 +28,7 @@ use vim::{
     vim_a_quote, vim_a_word, vim_find_char_on_line, vim_find_matching_bracket, vim_inner_block,
     vim_inner_paragraph, vim_inner_quote, vim_inner_word, vim_word_iterator_from_offset,
 };
+use warp_core::r#async::debounce;
 use warp_core::platform::SessionPlatform;
 use warp_core::semantic_selection::SemanticSelection;
 use warp_core::ui::theme::Fill;
@@ -314,7 +316,14 @@ pub struct CodeEditorModel {
     /// Whether lines soft-wrap to the viewport width. When set, the editor re-lays out its
     /// content on viewport resize so wrapping tracks the available width.
     soft_wrap: bool,
+    /// Debounced channel that coalesces viewport-resize relayouts. Only fed when `soft_wrap` is
+    /// set (see the `NeedsResize` handler).
+    resize_tx: async_channel::Sender<()>,
 }
+
+/// How long to wait for viewport-width changes to settle before re-laying out soft-wrapped
+/// content, so a window/pane drag triggers a single rebuild rather than one per frame.
+const DEBOUNCED_RESIZE_PERIOD: Duration = Duration::from_millis(5);
 
 impl CodeEditorModel {
     pub fn new(
@@ -455,6 +464,16 @@ impl CodeEditorModel {
             pending_comment: PendingComment::Closed,
         });
 
+        // Coalesce viewport-resize relayouts: `NeedsResize` (only emitted when soft-wrapping)
+        // pushes here, and we rebuild once the width settles instead of once per drag frame.
+        // A full-buffer relayout is expensive, so debouncing avoids doing it every frame.
+        let (resize_tx, resize_rx) = async_channel::unbounded();
+        ctx.spawn_stream_local(
+            debounce(DEBOUNCED_RESIZE_PERIOD, resize_rx),
+            |me, _, ctx| me.rebuild_layout_and_refresh_diff(ctx),
+            |_, _| {},
+        );
+
         Self {
             render_state,
             diff,
@@ -475,6 +494,7 @@ impl CodeEditorModel {
             lazy_layout_initialized,
             pending_syntax_tree_bootstrap: false,
             soft_wrap,
+            resize_tx,
         }
     }
 
@@ -605,10 +625,12 @@ impl CodeEditorModel {
                 ctx.emit(CodeEditorModelEvent::LayoutInvalidated);
             }
             RenderEvent::NeedsResize => {
-                // When soft-wrapping, a viewport width change must re-wrap the content.
-                // Non-wrapping editors lay out at infinite width and ignore resizes (current behavior).
+                // When soft-wrapping, a viewport width change must re-wrap the content. Route it
+                // through the debounced channel so a window/pane drag triggers a single rebuild
+                // once the width settles, rather than a full-buffer relayout every frame.
+                // Non-wrapping editors lay out at infinite width and ignore resizes.
                 if self.soft_wrap {
-                    self.rebuild_layout_and_refresh_diff(ctx);
+                    let _ = self.resize_tx.try_send(());
                 }
             }
         }

--- a/app/src/code/editor/model_tests.rs
+++ b/app/src/code/editor/model_tests.rs
@@ -21,7 +21,7 @@ fn initialize_deps(app: &mut App) {
 fn mock_model(app: &mut App, text: &str, version: ContentVersion) -> ModelHandle<CodeEditorModel> {
     app.add_model(|ctx| {
         let styles = code_text_styles(Appearance::as_ref(ctx), FontSettings::as_ref(ctx), None);
-        let mut model = CodeEditorModel::new(styles, None, false, None, ctx);
+        let mut model = CodeEditorModel::new(styles, None, false, false, None, ctx);
         let state = InitialBufferState::plain_text(text).with_version(version);
         model.reset_content(state, ctx);
         model.set_language_with_local_path(Path::new("/test.rs"), ctx);
@@ -37,7 +37,7 @@ fn mock_model_with_diff(
 ) -> ModelHandle<CodeEditorModel> {
     app.add_model(|ctx| {
         let styles = code_text_styles(Appearance::as_ref(ctx), FontSettings::as_ref(ctx), None);
-        let mut model = CodeEditorModel::new(styles, None, false, None, ctx);
+        let mut model = CodeEditorModel::new(styles, None, false, false, None, ctx);
         let state = InitialBufferState::plain_text(current_text).with_version(version);
         model.reset_content(state, ctx);
         model.set_language_with_local_path(Path::new("/test.rs"), ctx);

--- a/app/src/code/editor/view.rs
+++ b/app/src/code/editor/view.rs
@@ -214,6 +214,7 @@ pub struct CodeEditorRenderOptions {
     vertical_expansion_behavior: VerticalExpansionBehavior,
     line_height_override: Option<f32>,
     lazy_layout: bool,
+    soft_wrap: bool,
     show_comment_editor_provider: Box<dyn ShowCommentEditorProvider>,
     show_find_references_provider: Box<dyn ShowFindReferencesCardProvider>,
 }
@@ -224,9 +225,16 @@ impl CodeEditorRenderOptions {
             vertical_expansion_behavior,
             line_height_override: None,
             lazy_layout: false,
+            soft_wrap: false,
             show_comment_editor_provider: Box::new(NoopCommentEditorProvider),
             show_find_references_provider: Box::new(NoopFindReferencesCardProvider),
         }
+    }
+
+    /// Lay out lines wrapped to the viewport width instead of scrolling horizontally.
+    pub fn with_soft_wrap(mut self, soft_wrap: bool) -> Self {
+        self.soft_wrap = soft_wrap;
+        self
     }
 
     pub fn lazy_layout(mut self) -> Self {
@@ -318,6 +326,7 @@ impl CodeEditorView {
                 initial_styles,
                 session_platform,
                 render_options.lazy_layout,
+                render_options.soft_wrap,
                 buffer,
                 ctx,
             )

--- a/app/src/code/view.rs
+++ b/app/src/code/view.rs
@@ -384,7 +384,8 @@ impl CodeView {
                         CodeEditorView::new(
                             None,
                             Some(buffer_state.buffer),
-                            CodeEditorRenderOptions::new(VerticalExpansionBehavior::FillMaxHeight),
+                            CodeEditorRenderOptions::new(VerticalExpansionBehavior::FillMaxHeight)
+                                .with_soft_wrap(true),
                             ctx,
                         )
                         .with_horizontal_scrollbar_appearance(
@@ -428,7 +429,8 @@ impl CodeView {
             CodeEditorView::new(
                 None,
                 None,
-                CodeEditorRenderOptions::new(VerticalExpansionBehavior::FillMaxHeight),
+                CodeEditorRenderOptions::new(VerticalExpansionBehavior::FillMaxHeight)
+                    .with_soft_wrap(true),
                 ctx,
             )
             .with_horizontal_scrollbar_appearance(

--- a/app/src/code_review/code_review_view.rs
+++ b/app/src/code_review/code_review_view.rs
@@ -3031,6 +3031,7 @@ impl CodeReviewView {
                                     VerticalExpansionBehavior::InfiniteHeight,
                                 )
                                 .lazy_layout()
+                                .with_soft_wrap(true)
                                 .line_height_override(CODE_REVIEW_EDITOR_LINE_HEIGHT_RATIO)
                                 .with_show_comment_editor_provider(ShowCommentEditor {
                                     comment_list_save_position_id: self

--- a/crates/editor/src/content/edit.rs
+++ b/crates/editor/src/content/edit.rs
@@ -34,7 +34,7 @@ use crate::render::layout::{InlineTextLayoutInput, TextLayout, add_link_to_style
 use crate::render::model::{
     BlockItem, BlockLocation, BlockSpacing, CellLayout, Cursor, Decoration, FrameOffset,
     HiddenBlockConfig, HorizontalRuleConfig, ImageBlockConfig, LaidOutEmbeddedItem, LaidOutTable,
-    LineCount, OffsetMap, Paragraph, ParagraphBlock, ParagraphStyles, RenderLayoutOptions,
+    LogicalLineCount, OffsetMap, Paragraph, ParagraphBlock, ParagraphStyles, RenderLayoutOptions,
     SelectableTextRun, TableBlockConfig, TableStyle, gutter_expansion_button_types,
 };
 use crate::render::{TABLE_BASELINE_RATIO, TABLE_LINE_HEIGHT_RATIO};
@@ -135,7 +135,9 @@ const MAX_TABLE_CELL_CONTENT_WIDTH_PX: f32 = 500.0;
 #[derive(Debug, Clone, PartialEq)]
 pub struct TemporaryBlock {
     pub content: String,
-    pub insert_before: LineCount,
+    /// The *logical* (source) line this removed-content block is anchored before. Logical, not
+    /// visual, so the anchor survives soft-wrapping of surrounding lines.
+    pub insert_before: LogicalLineCount,
     pub line_decoration: Option<ThemeFill>,
     pub inline_text_decorations: Vec<Decoration>,
 }
@@ -613,7 +615,7 @@ impl EditDelta {
 pub fn layout_temporary_blocks(
     blocks: Vec<TemporaryBlock>,
     layout: &TextLayout,
-) -> HashMap<LineCount, Vec<BlockItem>> {
+) -> HashMap<LogicalLineCount, Vec<BlockItem>> {
     let layout_tasks = blocks
         .into_iter()
         .map(|block| {
@@ -633,7 +635,7 @@ pub fn layout_temporary_blocks(
     let results: Vec<_> = layout_tasks
         .into_par_iter()
         .enumerate()
-        .filter_map(|(idx, (task, line_count))| {
+        .filter_map(|(idx, (task, insert_before))| {
             let location = if idx == 0 {
                 BlockLocation::Start
             } else if idx >= last_task {
@@ -643,7 +645,7 @@ pub fn layout_temporary_blocks(
             };
 
             match task.run(layout, location, false) {
-                Ok(result) => Some((line_count, result.0)),
+                Ok(result) => Some((insert_before, result.0)),
                 Err(e) => {
                     log::error!("Failed to lay out temporary blocks: {e:?}");
                     None

--- a/crates/editor/src/render/model/mod.rs
+++ b/crates/editor/src/render/model/mod.rs
@@ -379,6 +379,32 @@ impl<'a> RenderContentTreeRef<'a> {
         cursor.seek_clamped(&line, SeekBias::Right);
         (cursor.start().height as f32).into_pixels()
     }
+
+    /// Returns the cumulative Y offset (in content-space pixels) at the top of the given *logical*
+    /// (source) line. Mirrors [`Self::y_offset_at_line`] but seeks the logical-line dimension, so
+    /// it stays correct under soft-wrap. When `line >= total logical lines`, returns the total
+    /// content height.
+    pub fn y_offset_at_logical_line(&self, line: LogicalLineCount) -> Pixels {
+        let summary = self.0.summary();
+        if line >= summary.logical_lines {
+            return (summary.height as f32).into_pixels();
+        }
+        let mut cursor = self.0.cursor::<LogicalLineCount, LayoutSummary>();
+        cursor.seek_clamped(&line, SeekBias::Right);
+        (cursor.start().height as f32).into_pixels()
+    }
+
+    /// The *logical* (source) line index at the start of the block containing `offset`. Mirrors the
+    /// seek in [`Self::block_at_offset`] but accumulates the logical-line dimension, so the result
+    /// is a source-line index rather than a wrapped-row index.
+    pub fn logical_line_at_offset(&self, offset: CharOffset) -> Option<LogicalLineCount> {
+        let mut cursor = self.0.cursor::<CharOffset, LogicalLineCount>();
+        if cursor.seek(&offset, SeekBias::Right) {
+            Some(*cursor.start())
+        } else {
+            None
+        }
+    }
 }
 
 /// All state specific to the TUI char-cell rendering path.
@@ -740,6 +766,7 @@ pub struct LayoutSummary {
     height: f64,
     width: Pixels,
     lines: LineCount,
+    logical_lines: LogicalLineCount,
     item_count: usize,
 }
 
@@ -839,6 +866,15 @@ impl ColumnUnit {
         }
     }
 }
+
+/// A count of *logical* source lines (newline-separated), as opposed to [`LineCount`], which
+/// counts *visual* rows after soft-wrapping. The two diverge only when a line soft-wraps. Used to
+/// drive the code-editor gutter (line numbers and diff decorations) so they track source lines
+/// rather than wrapped rows.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LogicalLineCount(usize);
+
+impl_offset!(LogicalLineCount);
 
 /// A character offset within a [`TextFrame`]. These offsets count characters in the Rust string
 /// passed to [`warpui_core::text_layout::LayoutCache::layout_text()`].
@@ -2848,13 +2884,16 @@ impl RenderState {
     }
 
     /// Replace all temporary blocks in the BlockItem cache with a new set of temporary
-    fn reset_temporary_block(&self, mut blocks: HashMap<LineCount, Vec<BlockItem>>) {
+    fn reset_temporary_block(&self, mut blocks: HashMap<LogicalLineCount, Vec<BlockItem>>) {
         let mut new_tree = SumTree::new();
         {
             let content = self.content.borrow();
-            let mut cursor = content.cursor::<LineCount, CharOffset>();
+            // Temporary (removed-line) blocks are anchored by *logical* source line, so seek the
+            // logical dimension here. Seeking the visual `LineCount` would mis-anchor them once any
+            // preceding line soft-wraps (visual rows > logical lines).
+            let mut cursor = content.cursor::<LogicalLineCount, CharOffset>();
 
-            if let Some(items) = blocks.remove(&LineCount::zero()) {
+            if let Some(items) = blocks.remove(&LogicalLineCount::zero()) {
                 for item in items {
                     new_tree.push(item);
                 }
@@ -3542,6 +3581,18 @@ impl RenderState {
         Some(content.block_at_offset(offset)?.start_line)
     }
 
+    /// The *logical* (source) line index at which `block` starts. Mirrors [`Self::start_line_index`]
+    /// but returns a source-line index instead of a wrapped-row index, so callers (the gutter) can
+    /// label lines and look up diff hunks in logical-line space.
+    pub fn start_logical_line_index(
+        &self,
+        block: &dyn RenderableBlock,
+    ) -> Option<LogicalLineCount> {
+        let content = self.content();
+        let offset = block.viewport_item().block_offset();
+        content.logical_line_at_offset(offset)
+    }
+
     /// The line height of the first line. Different from `first_line_bounds`, this does not
     /// return the viewport origin.
     pub fn first_line_height(&self, block: &dyn RenderableBlock) -> Option<f32> {
@@ -3750,6 +3801,7 @@ impl AddAssign<&LayoutSummary> for LayoutSummary {
         self.content_length += rhs.content_length;
         self.width = self.width.max(rhs.width);
         self.lines += rhs.lines;
+        self.logical_lines += rhs.logical_lines;
         self.item_count += rhs.item_count;
     }
 }
@@ -3930,6 +3982,41 @@ impl BlockItem {
             | BlockItem::Image { .. } => LineCount(1),
             BlockItem::Table(laid_out_table) => laid_out_table.lines(),
             BlockItem::Hidden(config) => config.line_count(),
+        }
+    }
+
+    /// The number of *logical* source lines this block represents, as opposed to [`Self::lines`],
+    /// which counts visual rows after soft-wrapping. The two diverge when a source line soft-wraps
+    /// (one logical line, several visual rows). This is what the code-editor gutter uses so line
+    /// numbers and diff decorations track source lines rather than wrapped rows.
+    pub fn logical_lines(&self) -> LogicalLineCount {
+        match self {
+            // Single-source-line blocks: each renders one source line, and only its visual row
+            // count grows when it soft-wraps.
+            BlockItem::Paragraph(_)
+            | BlockItem::Header { .. }
+            | BlockItem::UnorderedList { .. }
+            | BlockItem::OrderedList { .. }
+            | BlockItem::TaskList { .. }
+            | BlockItem::MermaidDiagram { .. }
+            | BlockItem::TrailingNewLine(_)
+            | BlockItem::Embedded(_)
+            | BlockItem::HorizontalRule(_)
+            | BlockItem::Image { .. } => LogicalLineCount(1),
+            // Text/code blocks hold one `Paragraph` per source line, so the logical line count is
+            // the paragraph count — independent of how many visual rows each paragraph wraps to.
+            BlockItem::TextBlock { paragraph_block }
+            | BlockItem::RunnableCodeBlock {
+                paragraph_block, ..
+            } => LogicalLineCount(paragraph_block.paragraphs().len()),
+            // Removed-line diff placeholders are not lines in the current buffer, so they must not
+            // advance the logical line counter (matches their visual `lines()` of 0).
+            BlockItem::TemporaryBlock { .. } => LogicalLineCount(0),
+            // Tables and collapsed sections don't soft-wrap their row count, so logical == visual.
+            BlockItem::Table(laid_out_table) => {
+                LogicalLineCount(laid_out_table.lines().as_usize())
+            }
+            BlockItem::Hidden(config) => LogicalLineCount(config.line_count().as_usize()),
         }
     }
 
@@ -4239,6 +4326,7 @@ impl sum_tree::Item for BlockItem {
             height: self.height().as_f32() as f64,
             width: self.width(),
             lines: self.lines(),
+            logical_lines: self.logical_lines(),
             item_count: 1,
         }
     }
@@ -4816,6 +4904,12 @@ impl<'a> sum_tree::Dimension<'a, LayoutSummary> for LayoutSummary {
 impl<'a> sum_tree::Dimension<'a, LayoutSummary> for LineCount {
     fn add_summary(&mut self, summary: &'a LayoutSummary) {
         *self += summary.lines;
+    }
+}
+
+impl<'a> sum_tree::Dimension<'a, LayoutSummary> for LogicalLineCount {
+    fn add_summary(&mut self, summary: &'a LayoutSummary) {
+        *self += summary.logical_lines;
     }
 }
 

--- a/crates/editor/src/render/model/mod_tests.rs
+++ b/crates/editor/src/render/model/mod_tests.rs
@@ -1,4 +1,5 @@
 use std::cell::Cell;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use markdown_parser::{FormattedTextStyles, Hyperlink};
@@ -28,7 +29,8 @@ use crate::content::text::{
 };
 use crate::render::model::test_utils::{TEST_STYLES, laid_out_paragraph, mock_paragraph};
 use crate::render::model::{
-    ColumnUnit, Height, LayoutSummary, LineCount, RenderedSelection, SoftWrapPoint, TEXT_SPACING,
+    ColumnUnit, Height, LayoutSummary, LineCount, LogicalLineCount, RenderedSelection,
+    SoftWrapPoint, TEXT_SPACING,
 };
 
 #[test]
@@ -69,6 +71,7 @@ fn test_height() {
             height: 48. + 24. + 24. + 32.,
             width: (17.).into_pixels(),
             lines: LineCount(4),
+            logical_lines: LogicalLineCount(4),
             item_count: 4,
         }
     );
@@ -144,9 +147,85 @@ fn test_width() {
             height: 24.,
             width: (26.).into_pixels(),
             lines: LineCount(1),
+            logical_lines: LogicalLineCount(1),
             item_count: 1,
         }
     );
+}
+
+#[test]
+fn test_logical_line_dimension_ignores_soft_wrap() {
+    let mut content = SumTree::new();
+    // "ABCDEFG" soft-wraps to 2 visual rows at this width but is a single source line.
+    content.push(laid_out_paragraph("ABCDEFG\n", &TEST_STYLES, 40.));
+    // "ABCD" fits on a single visual row.
+    content.push(laid_out_paragraph("ABCD\n", &TEST_STYLES, 40.));
+
+    let summary = content.summary();
+    // Two source lines, but more than two visual rows because the first paragraph wrapped.
+    assert_eq!(summary.logical_lines, LogicalLineCount(2));
+    assert!(summary.lines > LineCount(2));
+
+    // Seeking to logical line 1 lands at the start of the second block (after the first block's
+    // 8 characters: "ABCDEFG\n"), even though that position is a wrapped visual row.
+    let mut cursor = content.cursor::<LogicalLineCount, CharOffset>();
+    cursor.seek_clamped(&LogicalLineCount(1), sum_tree::SeekBias::Right);
+    assert_eq!(*cursor.start(), CharOffset::from(8));
+}
+
+#[test]
+fn test_logical_lines_counts_paragraphs_for_multi_line_blocks() {
+    // A TextBlock holds one Paragraph per source line, so its logical line count is the paragraph
+    // count regardless of soft-wrapping. (The earlier implementation incorrectly returned 1 here.)
+    let paragraph_block = ParagraphBlock::new(layout_paragraphs(
+        "alpha\nbeta\ngamma",
+        &TEST_STYLES,
+        &BufferBlockStyle::PlainText,
+        40.,
+    ));
+    let block = BlockItem::TextBlock { paragraph_block };
+    assert_eq!(block.logical_lines(), LogicalLineCount(3));
+    // Sanity: it really is a multi-row block (at least one visual row per source line).
+    assert!(block.lines() >= LineCount(3));
+}
+
+#[test]
+fn test_temporary_block_anchors_to_logical_line_under_wrap() {
+    // Regression: removed-line (temporary) blocks are anchored by *logical* source line. When a
+    // preceding line soft-wraps to several visual rows, anchoring by visual rows finds no matching
+    // block boundary, so the block is silently dropped — that is why removed-line decorations
+    // vanished in narrow (more-wrapped) panes. Seeking the logical dimension keeps it anchored.
+    let mut model =
+        RenderState::new_for_test(TEST_STYLES.clone(), 40.0.into_pixels(), 60.0.into_pixels());
+    let mut content = SumTree::new();
+    // Source line 0 soft-wraps to 2 visual rows at this width; source line 1 fits on one row.
+    content.push(laid_out_paragraph("ABCDEFG\n", &TEST_STYLES, 40.));
+    content.push(laid_out_paragraph("ABCD\n", &TEST_STYLES, 40.));
+    model.set_content(content);
+
+    // A removed-line placeholder anchored before logical source line 1 (i.e. after line 0).
+    let removed = layout_paragraph("removed\n", &TEST_STYLES, &BufferBlockStyle::PlainText, 40.);
+    let temporary_block = BlockItem::TemporaryBlock {
+        paragraph_block: ParagraphBlock::new(vec1![removed]),
+        text_decoration: Vec::new(),
+        decoration: None,
+    };
+    let mut blocks = HashMap::new();
+    blocks.insert(LogicalLineCount(1), vec![temporary_block]);
+    model.reset_temporary_block(blocks);
+
+    // The placeholder lands right after source line 0 (index 1) and is not dropped, even though
+    // line 0 wrapped to two visual rows. Visual-row seeking would have produced an empty list.
+    let temporary_positions: Vec<usize> = model
+        .content
+        .borrow()
+        .items()
+        .iter()
+        .enumerate()
+        .filter(|(_, item)| matches!(item, BlockItem::TemporaryBlock { .. }))
+        .map(|(index, _)| index)
+        .collect();
+    assert_eq!(temporary_positions, vec![1]);
 }
 
 #[test]


### PR DESCRIPTION
## Description

**POC: soft line wrapping in the code editor & diff view.** Long lines wrap to the viewport width instead of forcing horizontal scroll, in the full-pane **code editor** (including the markdown Raw view) and the **code-review diff view**. Draft to gather feedback before the spec.

> [!IMPORTANT]
> Wrapping is **hard-coded on** for these two surfaces just to demo it. The shipping version will be an **app-level setting** across all editors/diff views — designed in a follow-up spec.

## Videos

**V1 — Markdown source wraps** (Raw view; Rendered unaffected)

https://github.com/user-attachments/assets/d8b78803-2608-4215-91a7-5517fb0294c2

**V2 — Code editor: long lines wrap, consecutive gutter numbers, syntax survives the wrap**

https://github.com/user-attachments/assets/9967f8c1-c092-4393-8719-f5abe16fcda2

**V3 — Diff view: change-bar stays aligned; a removed line keeps its decoration as the pane narrows**

https://github.com/user-attachments/assets/0743471c-5bc8-4a24-8176-6d910eb5247b

**V4 — Cursor & selection treat a wrapped line as one logical line**

https://github.com/user-attachments/assets/1b7fde17-890e-4080-8c83-6c89ac9e9732

**V5 — Scope proof: the MCP config editor uses the same widget without soft-wrap, so it still horizontal-scrolls**

https://github.com/user-attachments/assets/8914d43e-9049-4373-9b1e-64025a7c1cfe

<details>
<summary>Implementation notes</summary>

- `CodeEditorRenderOptions::with_soft_wrap` (default `false`) → `FitViewport` instead of `InfiniteWidth`. Only the two surfaces opt in; the other ~13 surfaces on the shared `CodeEditorModel` are unchanged at `InfiniteWidth`.
- Debounced resize relayout (5 ms) — the `NeedsResize` handler was a no-op, so wrapped text never re-flowed.
- Added a `LogicalLineCount` layout dimension (distinct from visual `LineCount`) so gutter numbers and diff decorations track source lines under wrap.
- Removed-line diff blocks are anchored by logical line, so a deletion keeps its decoration when preceding lines wrap.
</details>

## Linked Issue
Related to #9017 (POC — does **not** close the issue; the shipping work lands via the follow-up spec).
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing
- [x] I have manually tested my changes locally with `./script/run`
- [x] `cargo nextest run -p warp_editor` is green

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

