### PR TITLE
Support setting colors for tab groups

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -234,6 +234,11 @@ impl TabData {
             Self::save_config_menu_items(index),
             self.color_option_menu_items(index, terminal_colors),
         ] {
+            // Skip empty sections so we don't emit a trailing separator (e.g.
+            // when a grouped tab hides the color picker).
+            if section_items.is_empty() {
+                continue;
+            }
             if menu_items
                 .last()
                 .is_some_and(|item| !matches!(item, MenuItem::Separator))
@@ -617,88 +622,19 @@ impl TabData {
         index: usize,
         terminal_colors: AnsiColors,
     ) -> Vec<MenuItem<WorkspaceAction>> {
+        // Tabs inside a group have their color controlled by the group.
+        if self.group_id.is_some() {
+            return vec![];
+        }
         if FeatureFlag::DirectoryTabColors.is_enabled() {
-            self.dot_color_option_menu_items(index, terminal_colors)
+            color_picker_menu_items(
+                self.color(),
+                terminal_colors,
+                ColorPickerTarget::Tab { tab_index: index },
+            )
         } else {
             self.legacy_color_option_menu_items(index, terminal_colors)
         }
-    }
-
-    /// New dot-based color picker: default (no-color) + color options.
-    /// Rendered as a single custom menu item with individually clickable dots.
-    fn dot_color_option_menu_items(
-        &self,
-        index: usize,
-        terminal_colors: AnsiColors,
-    ) -> Vec<MenuItem<WorkspaceAction>> {
-        let effective_color = self.color();
-        let mouse_states: Vec<MouseStateHandle> = (0..TAB_COLOR_OPTIONS.len() + 1)
-            .map(|_| MouseStateHandle::default())
-            .collect();
-
-        vec![MenuItem::Item(
-            MenuItemFields::new_with_custom_label(
-                Arc::new(move |_is_selected, _is_hovered, appearance, _app| {
-                    let theme = appearance.theme();
-                    let ring_color: ColorU = theme.accent().into();
-
-                    let mut row = Flex::row()
-                        .with_main_axis_alignment(MainAxisAlignment::SpaceEvenly)
-                        .with_cross_axis_alignment(CrossAxisAlignment::Center)
-                        .with_main_axis_size(MainAxisSize::Max);
-
-                    for (ansi_id, mouse_state) in std::iter::once(None)
-                        .chain(TAB_COLOR_OPTIONS.iter().copied().map(Some))
-                        .zip(mouse_states.iter().cloned())
-                    {
-                        let is_selected = match ansi_id {
-                            None => effective_color.is_none(),
-                            Some(id) => effective_color == Some(id),
-                        };
-                        let dot_color: ColorU = match ansi_id {
-                            None => ColorU::transparent_black(),
-                            Some(id) => id.to_ansi_color(&terminal_colors).into(),
-                        };
-                        let tooltip = match ansi_id {
-                            None => "Default (no color)".to_string(),
-                            Some(id) => id.to_string(),
-                        };
-
-                        let dot = render_color_dot(
-                            mouse_state,
-                            dot_color,
-                            is_selected,
-                            ring_color,
-                            ansi_id.is_none(),
-                            theme.foreground(),
-                            tooltip,
-                            appearance,
-                        )
-                        .on_click(move |ctx, _, _| {
-                            if let Some(color) = ansi_id {
-                                ctx.dispatch_typed_action(WorkspaceAction::ToggleTabColor {
-                                    color,
-                                    tab_index: index,
-                                });
-                            } else if let Some(color) = effective_color {
-                                ctx.dispatch_typed_action(WorkspaceAction::ToggleTabColor {
-                                    color,
-                                    tab_index: index,
-                                });
-                            }
-                            ctx.dispatch_typed_action(MenuAction::Close(true));
-                        });
-
-                        row.add_child(dot.finish());
-                    }
-
-                    row.finish()
-                }),
-                None,
-            )
-            .no_highlight_on_hover()
-            .with_no_interaction_on_hover(),
-        )]
     }
 
     /// Legacy icon-based color picker with toggle behavior.
@@ -730,6 +666,101 @@ impl TabData {
                 .collect(),
         }]
     }
+}
+
+/// Identifies what a color-picker selection recolors: a single tab or a whole
+/// tab group. Used by [`color_picker_menu_items`] to choose the toggle action
+/// dispatched when a dot is clicked.
+#[derive(Clone, Copy)]
+pub(crate) enum ColorPickerTarget {
+    Tab { tab_index: usize },
+    Group { group_id: TabGroupId },
+}
+
+impl ColorPickerTarget {
+    fn toggle_action(self, color: AnsiColorIdentifier) -> WorkspaceAction {
+        match self {
+            ColorPickerTarget::Tab { tab_index } => {
+                WorkspaceAction::ToggleTabColor { color, tab_index }
+            }
+            ColorPickerTarget::Group { group_id } => {
+                WorkspaceAction::ToggleTabGroupColor { color, group_id }
+            }
+        }
+    }
+}
+
+/// Builds the shared dot-based color picker menu section (a single custom row)
+/// used by both the per-tab and per-group color selectors. The leading dot clears
+/// the color; the rest are the `TAB_COLOR_OPTIONS`. `current_color` drives the
+/// selected-dot ring and the clear dot's toggle-off; `target` selects which toggle
+/// action is dispatched on click, either tab or group color selection.
+pub(crate) fn color_picker_menu_items(
+    current_color: Option<AnsiColorIdentifier>,
+    terminal_colors: AnsiColors,
+    target: ColorPickerTarget,
+) -> Vec<MenuItem<WorkspaceAction>> {
+    let mouse_states: Vec<MouseStateHandle> = (0..TAB_COLOR_OPTIONS.len() + 1)
+        .map(|_| MouseStateHandle::default())
+        .collect();
+
+    vec![MenuItem::Item(
+        MenuItemFields::new_with_custom_label(
+            Arc::new(move |_is_selected, _is_hovered, appearance, _app| {
+                let theme = appearance.theme();
+                let ring_color: ColorU = theme.accent().into();
+
+                let mut row = Flex::row()
+                    .with_main_axis_alignment(MainAxisAlignment::SpaceEvenly)
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_main_axis_size(MainAxisSize::Max);
+
+                for (ansi_id, mouse_state) in std::iter::once(None)
+                    .chain(TAB_COLOR_OPTIONS.iter().copied().map(Some))
+                    .zip(mouse_states.iter().cloned())
+                {
+                    let is_selected = match ansi_id {
+                        None => current_color.is_none(),
+                        Some(id) => current_color == Some(id),
+                    };
+                    let dot_color: ColorU = match ansi_id {
+                        None => ColorU::transparent_black(),
+                        Some(id) => id.to_ansi_color(&terminal_colors).into(),
+                    };
+                    let tooltip = match ansi_id {
+                        None => "Default (no color)".to_string(),
+                        Some(id) => id.to_string(),
+                    };
+
+                    let dot = render_color_dot(
+                        mouse_state,
+                        dot_color,
+                        is_selected,
+                        ring_color,
+                        ansi_id.is_none(),
+                        theme.foreground(),
+                        tooltip,
+                        appearance,
+                    )
+                    .on_click(move |ctx, _, _| {
+                        if let Some(color) = ansi_id {
+                            ctx.dispatch_typed_action(target.toggle_action(color));
+                        } else if let Some(color) = current_color {
+                            ctx.dispatch_typed_action(target.toggle_action(color));
+                        }
+                        ctx.dispatch_typed_action(MenuAction::Close(true));
+                    });
+
+                    row.add_child(dot.finish());
+                }
+
+                row.finish()
+            }),
+            None,
+        )
+        .no_highlight_on_hover()
+        .with_no_interaction_on_hover(),
+    )]
 }
 
 /// Stores the state of the tab bar—info related to the entire list of tabs rather than any one
@@ -1000,6 +1031,13 @@ impl<'a> TabComponent<'a> {
     pub fn for_grouped_member(mut self, is_sole_member: bool) -> Self {
         self.grouped_member = true;
         self.sole_grouped_member = is_sole_member;
+        self
+    }
+
+    /// Overrides the effective color used to build tab styles. Used when the
+    /// tab's color should be driven by its group rather than its own data.
+    pub fn with_effective_color(mut self, color: Option<AnsiColorIdentifier>) -> Self {
+        self.styles = TabStyles::default(self.appearance, color);
         self
     }
 
@@ -1483,21 +1521,37 @@ impl<'a> TabComponent<'a> {
         let (background_color, border_fill) = if FeatureFlag::NewTabStyling.is_enabled() {
             // If there is a custom tab background, we overlay it with varying opacities.
             let bg = if let Some(custom_background) = self.styles.background {
-                let base_opacity = if is_active || is_in_multi_tab_selection {
+                let base_opacity = if is_active || (is_in_multi_tab_selection && is_hovered) {
                     60
                 } else if is_hovered {
                     40
+                } else if is_in_multi_tab_selection {
+                    // A saturated color reads louder than the neutral multi-select
+                    // overlay regular tabs use, so keep multi-selection to just a
+                    // tiny bump above the resting color rather than the hover tier.
+                    25
+                } else if self.grouped_member {
+                    // Member of a colored group: the group container paints the
+                    // idle color behind this tab, so stay transparent at rest.
+                    // Painting the color again here would double-tint and make
+                    // the member look a shade lighter than the container.
+                    0
                 } else {
                     20
                 };
-                let opacity = (base_opacity as f32 * self.background_opacity as f32 / 100.) as u8;
-                match custom_background {
-                    ThemeFill::Solid(color) => coloru_with_opacity(color, opacity).into(),
-                    ThemeFill::VerticalGradient(gradient) => {
-                        coloru_with_opacity(gradient.get_most_opaque(), opacity).into()
-                    }
-                    ThemeFill::HorizontalGradient(gradient) => {
-                        coloru_with_opacity(gradient.get_most_opaque(), opacity).into()
+                if base_opacity == 0 {
+                    Fill::None
+                } else {
+                    let opacity =
+                        (base_opacity as f32 * self.background_opacity as f32 / 100.) as u8;
+                    match custom_background {
+                        ThemeFill::Solid(color) => coloru_with_opacity(color, opacity).into(),
+                        ThemeFill::VerticalGradient(gradient) => {
+                            coloru_with_opacity(gradient.get_most_opaque(), opacity).into()
+                        }
+                        ThemeFill::HorizontalGradient(gradient) => {
+                            coloru_with_opacity(gradient.get_most_opaque(), opacity).into()
+                        }
                     }
                 }
             } else if is_active {
@@ -1527,13 +1581,20 @@ impl<'a> TabComponent<'a> {
             };
 
             let bg = if let Some(custom_background) = self.styles.background {
-                match custom_background {
-                    ThemeFill::Solid(color) => coloru_with_opacity(color, tab_opacity).into(),
-                    ThemeFill::VerticalGradient(gradient) => {
-                        coloru_with_opacity(gradient.get_most_opaque(), tab_opacity).into()
-                    }
-                    ThemeFill::HorizontalGradient(gradient) => {
-                        coloru_with_opacity(gradient.get_most_opaque(), tab_opacity).into()
+                if self.grouped_member && !is_active && !is_hovered {
+                    // Member of a colored group: the group container paints the
+                    // idle color behind this tab, so stay transparent at rest to
+                    // avoid double-tinting.
+                    Fill::None
+                } else {
+                    match custom_background {
+                        ThemeFill::Solid(color) => coloru_with_opacity(color, tab_opacity).into(),
+                        ThemeFill::VerticalGradient(gradient) => {
+                            coloru_with_opacity(gradient.get_most_opaque(), tab_opacity).into()
+                        }
+                        ThemeFill::HorizontalGradient(gradient) => {
+                            coloru_with_opacity(gradient.get_most_opaque(), tab_opacity).into()
+                        }
                     }
                 }
             } else {

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -330,6 +330,12 @@ pub enum WorkspaceAction {
         color: AnsiColorIdentifier,
         tab_index: usize,
     },
+    /// Toggles the color for a tab group. Clears the color if it was already
+    /// set to `color`; otherwise applies `color` as the uniform group color.
+    ToggleTabGroupColor {
+        color: AnsiColorIdentifier,
+        group_id: TabGroupId,
+    },
     OpenLaunchConfigSaveModal,
     SelectTabConfig(TabConfig),
     DispatchToSettingsTab(SettingsTabAction),
@@ -948,6 +954,7 @@ impl WorkspaceAction {
             | PinActiveTabGroup
             | UnpinActiveTabGroup
             | ToggleTabColor { .. }
+            | ToggleTabGroupColor { .. }
             | AddDefaultTab
             | AddTerminalTab { .. }
             | AddTabWithShell { .. }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -75,7 +75,7 @@ use warp_core::semantic_selection::SemanticSelection;
 use warp_core::ui::color::coloru_with_opacity;
 use warp_core::ui::theme::color::internal_colors;
 use warp_core::ui::theme::phenomenon::PhenomenonStyle;
-use warp_core::ui::theme::Fill;
+use warp_core::ui::theme::{AnsiColors, Fill};
 use warp_core::ui::Icon;
 use warp_core::user_preferences::GetUserPreferences as _;
 use warp_editor::editor::NavigationKey;
@@ -353,9 +353,10 @@ use crate::settings_view::{flags, SettingsSection, SettingsView, SettingsViewEve
 #[cfg(all(target_os = "windows", feature = "local_tty"))]
 use crate::shell_indicator::ShellIndicatorType;
 use crate::tab::{
-    tab_position_id, uses_vertical_tabs, NewSessionMenuItem, PaneNameMenuTarget, SelectedTabColor,
-    TabBarState, TabComponent, TabData, TabTelemetryAction, COMPACT_TAB_WIDTH_THRESHOLD,
-    MOVE_TO_GROUP_LABEL, TAB_BAR_BORDER_HEIGHT, TAB_INDICATOR_HEIGHT, TAB_PIN_INDICATOR_ICON_SIZE,
+    color_picker_menu_items, tab_position_id, uses_vertical_tabs, ColorPickerTarget,
+    NewSessionMenuItem, PaneNameMenuTarget, SelectedTabColor, TabBarState, TabComponent, TabData,
+    TabTelemetryAction, COMPACT_TAB_WIDTH_THRESHOLD, MOVE_TO_GROUP_LABEL, TAB_BAR_BORDER_HEIGHT,
+    TAB_INDICATOR_HEIGHT, TAB_PIN_INDICATOR_ICON_SIZE,
 };
 use crate::tab_configs::action_sidecar::SidecarItemKind;
 use crate::tab_configs::remove_confirmation_dialog::{
@@ -5152,6 +5153,18 @@ impl Workspace {
         self.tabs.get(index).and_then(|tab| tab.color())
     }
 
+    /// Returns the effective render color for a tab. A tab in a group is fully
+    /// colored by that group: the group's color applies, and a group with no
+    /// color (the default for a fresh group) renders the member with no color,
+    /// ignoring the tab's own selected/directory color. Ungrouped tabs use their
+    /// own color.
+    fn effective_tab_color(&self, tab: &TabData) -> Option<AnsiColorIdentifier> {
+        if let Some(group) = tab.group_id.and_then(|gid| self.tab_groups.get(&gid)) {
+            return group.color.resolve(None);
+        }
+        tab.color()
+    }
+
     /// Finds the pane containing a terminal viewing the given ambient agent conversation,
     /// returning None if the ambient conversation is not open in any tab.
     fn find_pane_with_ambient_agent_conversation(
@@ -5534,6 +5547,48 @@ impl Workspace {
             SelectedTabColor::Color(color)
         };
         self.set_tab_color(index, next, ctx);
+    }
+
+    /// Sets a tab group's color. The group fully owns its members' color, so:
+    /// - `Color(c)` — every member renders with `c`.
+    /// - `Cleared` / `Unset` — every member renders with no color (a fresh group
+    ///   is `Unset`; the picker sets `Cleared` when you toggle the current color
+    ///   off). A member's own tab/directory color is ignored while it's grouped.
+    fn set_tab_group_color(
+        &mut self,
+        group_id: TabGroupId,
+        color: SelectedTabColor,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(group) = self.tab_groups.get_mut(&group_id) else {
+            return;
+        };
+        if group.color == color {
+            return;
+        }
+        group.color = color;
+        ctx.dispatch_global_action("workspace:save_app", ());
+        ctx.notify();
+    }
+
+    /// Toggles the color for a tab group: applies `color` if not already set to it,
+    /// otherwise clears it.
+    fn toggle_tab_group_color(
+        &mut self,
+        group_id: TabGroupId,
+        color: AnsiColorIdentifier,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let current = self
+            .tab_groups
+            .get(&group_id)
+            .and_then(|g| g.color.resolve(None));
+        let next = if current == Some(color) {
+            SelectedTabColor::Cleared
+        } else {
+            SelectedTabColor::Color(color)
+        };
+        self.set_tab_group_color(group_id, next, ctx);
     }
 
     /// Syncs the tab color for the given tab based on the active terminal's CWD.
@@ -7581,7 +7636,9 @@ impl Workspace {
             return;
         }
 
-        let menu_items = self.tab_group_menu_items(group_id, uses_vertical_tabs(ctx));
+        let terminal_colors = Appearance::as_ref(ctx).theme().terminal_colors().normal;
+        let menu_items =
+            self.tab_group_menu_items(group_id, uses_vertical_tabs(ctx), terminal_colors);
         ctx.update_view(&self.tab_right_click_menu, |context_menu, view_ctx| {
             context_menu.set_items(menu_items, view_ctx);
         });
@@ -9646,6 +9703,7 @@ impl Workspace {
         &self,
         group_id: TabGroupId,
         is_vertical: bool,
+        terminal_colors: AnsiColors,
     ) -> Vec<MenuItem<WorkspaceAction>> {
         let Some((first, last)) = group_member_index_range(&self.tabs, group_id) else {
             return vec![];
@@ -9739,6 +9797,20 @@ impl Workspace {
             vec![]
         };
 
+        // Color picker: same dot-based selector as individual tabs.
+        let color_section = {
+            // Resolve the group's currently selected color for highlighting the active dot.
+            let effective_color = self
+                .tab_groups
+                .get(&group_id)
+                .and_then(|g| g.color.resolve(None));
+            color_picker_menu_items(
+                effective_color,
+                terminal_colors,
+                ColorPickerTarget::Group { group_id },
+            )
+        };
+
         let mut menu_items = vec![];
         for section_items in [
             pin_section,
@@ -9755,6 +9827,7 @@ impl Workspace {
                 .with_on_select_action(WorkspaceAction::RenameTabGroup(group_id))
                 .into_item()],
             close_section,
+            color_section,
         ] {
             if section_items.is_empty() {
                 continue;
@@ -19539,7 +19612,13 @@ impl Workspace {
         appearance: &Appearance,
         ctx: &AppContext,
     ) -> Box<dyn Element> {
+        let theme = appearance.theme();
         let is_collapsed = group.collapsed;
+
+        let group_color: Option<ColorU> = group
+            .color
+            .resolve(None)
+            .map(|c| c.to_ansi_color(&theme.terminal_colors().normal).into());
 
         let mouse_states = self
             .horizontal_tab_group_mouse_states
@@ -19563,6 +19642,7 @@ impl Workspace {
                     is_collapsed,
                     any_member_active,
                     is_first_in_bar,
+                    group_color,
                     appearance,
                     ctx,
                 ))
@@ -19595,6 +19675,7 @@ impl Workspace {
             let is_sole_member = group_has_single_member(&self.tabs, group.id);
             for idx in member_range {
                 let tab = &self.tabs[idx];
+                let effective_color = self.effective_tab_color(tab);
                 let member = TabComponent::new(
                     idx,
                     tab_bar_state,
@@ -19604,6 +19685,7 @@ impl Workspace {
                     false,
                     ctx,
                 )
+                .with_effective_color(effective_color)
                 .for_grouped_member(is_sole_member)
                 .with_multi_tab_selection(self.is_tab_in_multi_tab_selection(idx))
                 .build()
@@ -19646,8 +19728,24 @@ impl Workspace {
             );
         }
 
-        // Collapsed groups draw their divider on the header instead.
-        let container = Container::new(row.finish()).finish();
+        // Collapsed groups draw their divider on the header instead. When the
+        // group is colored, back the whole container with the group color at the
+        // same idle opacity a member tab uses, so the member tabs blend into the
+        // container and the group reads as one colored block.
+        let mut container = Container::new(row.finish());
+        if let Some(color) = group_color {
+            container = container.with_background(coloru_with_opacity(color, 20));
+        }
+        let container = container.finish();
+        // While dragging, back the floating chip with an opaque color so it
+        // doesn't render translucently like the resting group background.
+        let container: Box<dyn Element> = if group.draggable_state.is_dragging() {
+            Container::new(container)
+                .with_background_color(theme.background().into_solid_bias_top_color())
+                .finish()
+        } else {
+            container
+        };
 
         let group_id = group.id;
         let group_draggable_state = group.draggable_state.clone();
@@ -19695,6 +19793,7 @@ impl Workspace {
         is_collapsed: bool,
         any_member_active: bool,
         is_first_in_bar: bool,
+        group_color: Option<ColorU>,
         appearance: &Appearance,
         ctx: &AppContext,
     ) -> Box<dyn Element> {
@@ -19789,9 +19888,22 @@ impl Workspace {
         let header_hover_bg = internal_colors::fg_overlay_1(theme);
         let header_border_fill = internal_colors::fg_overlay_1(theme);
         let mut header = Hoverable::new(mouse_states.header.clone(), move |state| {
-            let bg: ElementFill = if header_selected {
+            let hovered = state.is_hovered();
+            // Tint the header with the group's color on hover/active (40/60), and
+            // stay transparent at idle so the colored group container shows
+            // through. Fall back to the neutral overlay when the group has no
+            // color.
+            let bg: ElementFill = if let Some(color) = group_color {
+                if header_selected {
+                    coloru_with_opacity(color, 60).into()
+                } else if hovered {
+                    coloru_with_opacity(color, 40).into()
+                } else {
+                    ElementFill::None
+                }
+            } else if header_selected {
                 header_active_bg.into()
-            } else if state.is_hovered() {
+            } else if hovered {
                 header_hover_bg.into()
             } else {
                 ElementFill::None
@@ -19903,6 +20015,7 @@ impl Workspace {
             // outer `SavePosition`, `Draggable`, and `DropTarget` wrappers
             // so the chip overlay doesn't pollute the target window's
             // position cache (see `TabComponent::for_drag_ghost`).
+            let effective_color = self.effective_tab_color(tab);
             TabComponent::new(
                 tab_index,
                 tab_bar_state,
@@ -19912,6 +20025,8 @@ impl Workspace {
                 false,
                 ctx,
             )
+            // Show the tab groups color on this tab while it is dragging and part of a group.
+            .with_effective_color(effective_color)
             .for_drag_ghost()
             .build()
             .finish()
@@ -23402,7 +23517,20 @@ impl TypedActionView for Workspace {
                 );
             }
             SetActiveTabName(name) => self.set_active_tab_name(name, ctx),
-            SetActiveTabColor(color) => self.set_tab_color(self.active_tab_index, *color, ctx),
+            SetActiveTabColor(color) => {
+                // When the active tab is in a group, redirect to the group's color.
+                // The tab color selection menu is hidden when a tab is part of a group
+                // this handles the case where a tab color is set via a slash command.
+                let active_group_id = self
+                    .tabs
+                    .get(self.active_tab_index)
+                    .and_then(|t| t.group_id);
+                if let Some(group_id) = active_group_id {
+                    self.set_tab_group_color(group_id, *color, ctx);
+                } else {
+                    self.set_tab_color(self.active_tab_index, *color, ctx);
+                }
+            }
             ToggleTabRightClickMenu { tab_index, anchor } => {
                 self.toggle_tab_right_click_menu(*tab_index, *anchor, ctx)
             }
@@ -23862,6 +23990,9 @@ impl TypedActionView for Workspace {
             SetA11yVerbosityLevel(verbosity) => self.set_a11y_verbosity(*verbosity, ctx),
             ToggleNotifications => self.toggle_notifications(ctx),
             ToggleTabColor { color, tab_index } => self.toggle_tab_color(*tab_index, *color, ctx),
+            ToggleTabGroupColor { color, group_id } => {
+                self.toggle_tab_group_color(*group_id, *color, ctx)
+            }
             DispatchToSettingsTab(action) => {
                 let window_id = ctx.window_id();
                 ctx.dispatch_typed_action_for_view(window_id, self.settings_pane.id(), action)

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -342,10 +342,18 @@ fn pane_row_background(
     is_in_multi_selection: bool,
     is_hovered: bool,
     is_being_dragged: bool,
+    in_colored_group: bool,
     theme: &WarpTheme,
 ) -> Option<ThemeFill> {
     if let Some(color) = pane_color {
-        let opacity = if is_selected || is_hovered || is_in_multi_selection {
+        let is_highlighted = is_selected || is_hovered || is_in_multi_selection;
+        // Member of a colored group: the group container already paints this
+        // color behind the row at idle, so stay transparent at rest to avoid
+        // double-tinting that makes the row look lighter than the container.
+        if in_colored_group && !is_highlighted {
+            return None;
+        }
+        let opacity = if is_highlighted {
             TAB_COLOR_HOVER_OPACITY
         } else {
             TAB_COLOR_OPACITY
@@ -396,6 +404,7 @@ fn render_pane_row_element(
         is_in_multi_selection,
         is_in_multi_tab_selection,
         pane_color,
+        in_colored_group,
         badge_mouse_states: _,
         detail_hover_state,
         display_granularity: _,
@@ -428,6 +437,7 @@ fn render_pane_row_element(
             is_in_multi_selection,
             state.is_hovered(),
             is_being_dragged,
+            in_colored_group,
             theme,
         ) {
             container = container.with_background(background);
@@ -834,6 +844,10 @@ struct PaneProps<'a> {
     /// otherwise the single-pane menu.
     is_in_multi_tab_selection: bool,
     pane_color: Option<ThemeFill>,
+    /// True when this row is a member of a colored group whose container paints
+    /// the group color behind it. Suppresses the row's own idle color tint so it
+    /// blends into the container instead of double-tinting at rest.
+    in_colored_group: bool,
     badge_mouse_states: PaneRowBadgeMouseStates,
     detail_hover_state: VerticalTabsDetailHoverState,
     display_granularity: VerticalTabsDisplayGranularity,
@@ -2084,8 +2098,23 @@ fn render_tab_group_internal(
     // Captured into row/group right-click closures so they can pick between
     // the single-pane menu and the multi-tab selection menu.
     let is_in_multi_tab_selection = workspace.is_tab_in_multi_tab_selection(tab_index);
-    let color_mode = compute_tab_group_color_mode(tab, pane_group, &visible_pane_ids, theme, app);
+    let tab_group_for_color = tab.group_id.and_then(|gid| workspace.tab_groups.get(&gid));
+    let color_mode = compute_tab_group_color_mode(
+        tab,
+        pane_group,
+        &visible_pane_ids,
+        theme,
+        tab_group_for_color,
+        app,
+    );
     let per_pane_colors = color_mode.into_per_pane_colors(&visible_pane_ids);
+    // Members of a colored group blend into the group container's colored
+    // background; suppress each member row's own idle color tint so it doesn't
+    // double-tint on top of the container at rest.
+    let in_colored_group = in_tab_group
+        && tab_group_for_color
+            .and_then(|group| group.color.resolve(None))
+            .is_some();
     let is_being_renamed = is_active && workspace.current_workspace_state.is_tab_being_renamed();
     let rename_editor = workspace.tab_rename_editor.clone();
     let has_custom_title = pane_group.custom_title(app).is_some();
@@ -2158,7 +2187,7 @@ fn render_tab_group_internal(
                     }
                     handles[..branch_line_count].to_vec()
                 };
-                let Some(pane_props) = PaneProps::new(
+                let Some(mut pane_props) = PaneProps::new(
                     pane_group,
                     *pane_id,
                     pane_group_id,
@@ -2187,6 +2216,7 @@ fn render_tab_group_internal(
                 ) else {
                     return Empty::new().finish();
                 };
+                pane_props.in_colored_group = in_colored_group;
                 rows.add_child(render_summary_tab_item(
                     pane_props,
                     summary
@@ -2252,6 +2282,7 @@ fn render_tab_group_internal(
                         is_last: row_idx + 1 == total_rows,
                     };
                 }
+                pane_props.in_colored_group = in_colored_group;
                 let view_mode = *TabSettings::as_ref(app).vertical_tabs_view_mode.value();
                 let row = match view_mode {
                     VerticalTabsViewMode::Compact => render_compact_pane_row(pane_props, app),
@@ -2809,6 +2840,12 @@ fn render_grouped_tabs_header(
         .with_child(action_buttons)
         .finish();
 
+    // Resolve the group's color so the header tints to match its member tabs.
+    let group_color_fill: Option<ThemeFill> = group
+        .color
+        .resolve(None)
+        .map(|c| c.to_ansi_color(&theme.terminal_colors().normal).into());
+
     let mut hoverable = Hoverable::new(mouse_states.header.clone(), move |state| {
         let border_fill = if is_header_selected {
             internal_colors::fg_overlay_3(theme)
@@ -2819,7 +2856,15 @@ fn render_grouped_tabs_header(
             .with_padding(Padding::uniform(GROUP_HORIZONTAL_PADDING))
             .with_corner_radius(CornerRadius::with_all(Radius::Pixels(ROW_CORNER_RADIUS)))
             .with_border(Border::all(1.).with_border_fill(border_fill));
-        if is_header_selected || state.is_hovered() {
+        if let Some(color) = group_color_fill {
+            // Colored group: the group container paints the idle color behind the
+            // header, so only tint on hover/selected. Painting the idle color
+            // here too would double-tint and make the header look a shade lighter
+            // than the container.
+            if is_header_selected || state.is_hovered() {
+                container = container.with_background(color.with_opacity(TAB_COLOR_HOVER_OPACITY));
+            }
+        } else if is_header_selected || state.is_hovered() {
             container = container.with_background(internal_colors::fg_overlay_2(theme));
         }
         let header = container.finish();
@@ -2874,8 +2919,9 @@ fn render_grouped_tabs_header(
     hoverable.finish()
 }
 
-/// Renders a tab group: pane-like header followed by indented member rows. Background only paints
-/// on hover or when a member is active.
+/// Renders a tab group: pane-like header followed by indented member rows. A colored group fills
+/// the container with the group color so the header and member rows blend into one colored block; an
+/// uncolored group only paints its background on hover or when a member is active.
 fn render_grouped_tab_container(
     state: &VerticalTabsPanelState,
     workspace: &Workspace,
@@ -2984,7 +3030,17 @@ fn render_grouped_tab_container(
             }
         }
 
-        let background = if hover_state.is_hovered() || any_member_active {
+        // When the group is colored, back the container with the group color at
+        // the same idle opacity a member row uses, so member rows blend into the
+        // container and the group reads as one colored block. Fall back to the
+        // neutral hover/active highlight when the group has no color.
+        let group_color_fill: Option<ThemeFill> = group
+            .color
+            .resolve(None)
+            .map(|c| c.to_ansi_color(&theme.terminal_colors().normal).into());
+        let background = if let Some(color) = group_color_fill {
+            color.with_opacity(TAB_COLOR_OPACITY)
+        } else if hover_state.is_hovered() || any_member_active {
             internal_colors::fg_overlay_1(theme)
         } else {
             ThemeFill::Solid(ColorU::transparent_black())
@@ -3678,6 +3734,7 @@ impl<'a> PaneProps<'a> {
             is_in_multi_selection,
             is_in_multi_tab_selection,
             pane_color: pane_row_state.pane_color,
+            in_colored_group: false,
             badge_mouse_states: pane_row_state.badge_mouse_states,
             detail_hover_state,
             display_granularity,
@@ -5319,16 +5376,33 @@ fn render_pull_request_badge_content(label: &str, appearance: &Appearance) -> Bo
         .finish()
 }
 
+/// Resolves the rendered color mode for a tab's panes. A tab in a `tab_group`
+/// is fully colored by that group: the group's color applies uniformly, and a
+/// group with no color (the default for a fresh group) renders its members with
+/// no color, ignoring each member's own selected/directory color. An ungrouped
+/// tab uses its own `selected_color`, falling through to per-pane directory
+/// colors when unset.
 fn compute_tab_group_color_mode(
     tab: &TabData,
     pane_group: &PaneGroup,
     visible_pane_ids: &[PaneId],
     theme: &WarpTheme,
+    tab_group: Option<&TabGroup>,
     app: &AppContext,
 ) -> TabGroupColorMode {
-    // Manual override applies to the whole group.
-    if tab.selected_color != SelectedTabColor::Unset {
-        return match tab.color() {
+    // A grouped tab's color is fully owned by its group.
+    if let Some(group) = tab_group {
+        return match group.color.resolve(None) {
+            Some(color) => TabGroupColorMode::Uniform(
+                color.to_ansi_color(&theme.terminal_colors().normal).into(),
+            ),
+            None => TabGroupColorMode::None,
+        };
+    }
+
+    // Ungrouped tab: a manual color override applies to the whole tab.
+    if !matches!(tab.selected_color, SelectedTabColor::Unset) {
+        return match tab.selected_color.resolve(tab.default_directory_color) {
             Some(color) => TabGroupColorMode::Uniform(
                 color.to_ansi_color(&theme.terminal_colors().normal).into(),
             ),


### PR DESCRIPTION
## Description

Adds the ability to color an entire tab group. Assigning a color tints the whole group, the header and every member tab, in both horizontal and vertical tab layouts. The color is set from the same dot color picker already used for individual tabs, now also surfaced in the tab-group right-click menu. 

Tabs within a group can not be given individual colors, this is intentional.

## How it works 

A group's color is resolved at render time rather than written onto its member tabs. A grouped tab's effective color comes from its group, so members inherit the group color (and an uncolored group renders its members neutrally, ignoring their own colors).

The bulk of the change is in how a colored group is rendered. The group container is filled with the group color at the normal resting-tab opacity, and the header and member tabs add no tint of their own — so the group reads as a single uniform color — and only layer their hover/selected highlight on top. The same model is applied to both horizontal and vertical tabs

To avoid duplicating the color picker, the existing dot-based color selector was pulled out of the per-tab menu into a single shared menu builder parameterized by what it's coloring (a tab vs. a group). Both the per-tab and per-group menus now use it and dispatch the appropriate toggle action.

It also includes two small polish fixes that came out of the above: colored tabs in a multi-selection are no longer over-highlighted (a saturated fill reads much brighter than the neutral highlight regular tabs use, so this highlighting was reduced), and a horizontal group background is now filled while being dragged instead of translucent.

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4671/allow-modifying-colors-for-tab-groups

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo Video](https://www.loom.com/share/31c29a0edb1e45d080037ff4c6383f36)