### PR TITLE
Client side fix for malform LLM request

### DIFF
--- a/app/src/ai/agent/api/convert_conversation.rs
+++ b/app/src/ai/agent/api/convert_conversation.rs
@@ -1800,6 +1800,137 @@ fn create_cancelled_result_for_tool_call(
     })
 }
 
+/// Ensures every `tool_use` recorded in the outgoing task history is paired with a result, so
+/// the client can never send a dangling `tool_use` to the server.
+pub(crate) fn reconcile_unfinished_tool_calls(tasks: &mut [api::Task], inputs: &[AIAgentInput]) {
+    use api::message::Message;
+
+    // A tool call is "resolved" if a result for it already exists, either among the new inputs
+    // (an action result) or anywhere in the task history (a tool-call-result message).
+    let mut resolved_tool_call_ids: HashSet<String> = inputs
+        .iter()
+        .filter_map(|input| {
+            if let AIAgentInput::ActionResult { result, .. } = input {
+                Some(result.id.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+    for task in tasks.iter() {
+        for message in &task.messages {
+            if let Some(Message::ToolCallResult(result)) = &message.message {
+                resolved_tool_call_ids.insert(result.tool_call_id.clone());
+            }
+        }
+    }
+
+    // Decide which unfinished tool calls need a synthetic result.
+    // `create_cancelled_result_for_tool_call` is the single source of truth for which tool
+    // types receive one (it returns `None` for server-side, subagent, and deprecated/no-result
+    // tools), so we reuse it purely as an eligibility check and discard the returned
+    // input-form result.
+    let tool_call_map: HashMap<String, &api::message::ToolCall> = tasks
+        .iter()
+        .flat_map(|task| &task.messages)
+        .filter_map(|message| match &message.message {
+            Some(Message::ToolCall(tool_call)) => Some((tool_call.tool_call_id.clone(), tool_call)),
+            _ => None,
+        })
+        .collect();
+    let mut tool_call_ids_to_cancel: HashSet<String> = HashSet::new();
+    for task in tasks.iter() {
+        for message in &task.messages {
+            let Some(Message::ToolCall(tool_call)) = &message.message else {
+                continue;
+            };
+            if resolved_tool_call_ids.contains(&tool_call.tool_call_id)
+                || tool_call_ids_to_cancel.contains(&tool_call.tool_call_id)
+            {
+                continue;
+            }
+            let is_cancellable = create_cancelled_result_for_tool_call(
+                &TaskId::new(message.task_id.clone()),
+                &tool_call.tool_call_id,
+                &tool_call_map,
+                Arc::new([]),
+            )
+            .is_some();
+            if is_cancellable {
+                tool_call_ids_to_cancel.insert(tool_call.tool_call_id.clone());
+            }
+        }
+    }
+    // Release the immutable borrows held by `tool_call_map` before mutating the tasks below.
+    drop(tool_call_map);
+
+    if tool_call_ids_to_cancel.is_empty() {
+        return;
+    }
+
+    // Splice a `Cancel` result in immediately after each unfinished tool call so the synthetic
+    // result stays adjacent to its `tool_use`, keeping the reconstructed provider turns valid.
+    for task in tasks.iter_mut() {
+        let has_unfinished_tool_call = task.messages.iter().any(|message| {
+            matches!(
+                &message.message,
+                Some(Message::ToolCall(tool_call))
+                    if tool_call_ids_to_cancel.contains(&tool_call.tool_call_id)
+            )
+        });
+        if !has_unfinished_tool_call {
+            continue;
+        }
+
+        let task_id = task.id.clone();
+        let mut reconciled_messages = Vec::with_capacity(task.messages.len() + 1);
+        for message in std::mem::take(&mut task.messages) {
+            let synthetic_result = match &message.message {
+                Some(Message::ToolCall(tool_call))
+                    if tool_call_ids_to_cancel.contains(&tool_call.tool_call_id) =>
+                {
+                    log::warn!(
+                        "Synthesizing a cancelled result for unfinished tool call '{}' to avoid \
+                         sending a dangling tool_use to the server.",
+                        tool_call.tool_call_id
+                    );
+                    Some(cancelled_tool_call_result_message(
+                        &task_id,
+                        &tool_call.tool_call_id,
+                    ))
+                }
+                _ => None,
+            };
+            reconciled_messages.push(message);
+            if let Some(synthetic_result) = synthetic_result {
+                reconciled_messages.push(synthetic_result);
+            }
+        }
+        task.messages = reconciled_messages;
+    }
+}
+
+/// Builds a synthetic message-history `ToolCallResult` carrying the canonical `Cancel` marker
+/// for the given tool call. Used by [`reconcile_unfinished_tool_calls`] to pair a dangling
+/// `tool_use` with a result before the request is sent.
+fn cancelled_tool_call_result_message(task_id: &str, tool_call_id: &str) -> api::Message {
+    api::Message {
+        id: uuid::Uuid::new_v4().to_string(),
+        task_id: task_id.to_string(),
+        request_id: String::new(),
+        timestamp: None,
+        server_message_data: String::new(),
+        citations: Vec::new(),
+        message: Some(api::message::Message::ToolCallResult(
+            api::message::ToolCallResult {
+                tool_call_id: tool_call_id.to_string(),
+                context: None,
+                result: Some(api::message::tool_call_result::Result::Cancel(())),
+            },
+        )),
+    }
+}
+
 fn create_exchange_from_messages(
     inputs: &[AIAgentInput],
     outputs: &[AIAgentOutputMessage],

--- a/app/src/ai/agent/api/convert_conversation_tests.rs
+++ b/app/src/ai/agent/api/convert_conversation_tests.rs
@@ -2137,3 +2137,255 @@ fn test_handoff_rehydration_system_query_is_hidden() {
         "Agent output should still be rendered"
     );
 }
+
+// ----- reconcile_unfinished_tool_calls -----
+
+fn unfinished_run_shell_tool() -> api::message::tool_call::Tool {
+    api::message::tool_call::Tool::RunShellCommand(api::message::tool_call::RunShellCommand {
+        command: "echo hi".to_string(),
+        is_read_only: false,
+        uses_pager: false,
+        citations: vec![],
+        is_risky: false,
+        wait_until_complete_value: None,
+        risk_category: 0,
+    })
+}
+
+fn unfinished_server_tool() -> api::message::tool_call::Tool {
+    api::message::tool_call::Tool::Server(api::message::tool_call::Server {
+        payload: String::new(),
+    })
+}
+
+fn unfinished_tool_call_message(
+    message_id: &str,
+    task_id: &str,
+    tool_call_id: &str,
+    tool: api::message::tool_call::Tool,
+) -> api::Message {
+    api::Message {
+        id: message_id.to_string(),
+        task_id: task_id.to_string(),
+        request_id: String::new(),
+        timestamp: None,
+        server_message_data: String::new(),
+        citations: vec![],
+        message: Some(api::message::Message::ToolCall(api::message::ToolCall {
+            tool_call_id: tool_call_id.to_string(),
+            tool: Some(tool),
+        })),
+    }
+}
+
+fn unfinished_success_result_message(
+    message_id: &str,
+    task_id: &str,
+    tool_call_id: &str,
+) -> api::Message {
+    api::Message {
+        id: message_id.to_string(),
+        task_id: task_id.to_string(),
+        request_id: String::new(),
+        timestamp: None,
+        server_message_data: String::new(),
+        citations: vec![],
+        message: Some(api::message::Message::ToolCallResult(
+            api::message::ToolCallResult {
+                tool_call_id: tool_call_id.to_string(),
+                context: None,
+                result: Some(api::message::tool_call_result::Result::RunShellCommand(
+                    #[allow(deprecated)]
+                    api::RunShellCommandResult {
+                        command: "echo hi".to_string(),
+                        output: String::new(),
+                        exit_code: 0,
+                        result: Some(api::run_shell_command_result::Result::CommandFinished(
+                            api::ShellCommandFinished {
+                                command_id: "cmd".to_string(),
+                                output: "ok".to_string(),
+                                exit_code: 0,
+                                start_ts: None,
+                                finish_ts: None,
+                            },
+                        )),
+                    },
+                )),
+            },
+        )),
+    }
+}
+
+fn unfinished_task(id: &str, messages: Vec<api::Message>) -> api::Task {
+    api::Task {
+        id: id.to_string(),
+        messages,
+        dependencies: None,
+        description: String::new(),
+        summary: String::new(),
+        server_data: String::new(),
+    }
+}
+
+/// Returns the `tool_call_id`s carrying a `Cancel` tool-call result anywhere in `tasks`.
+fn collect_cancel_result_ids(tasks: &[api::Task]) -> Vec<String> {
+    let mut ids = vec![];
+    for task in tasks {
+        for message in &task.messages {
+            if let Some(api::message::Message::ToolCallResult(result)) = &message.message {
+                if matches!(
+                    result.result,
+                    Some(api::message::tool_call_result::Result::Cancel(()))
+                ) {
+                    ids.push(result.tool_call_id.clone());
+                }
+            }
+        }
+    }
+    ids
+}
+
+#[test]
+fn test_reconcile_synthesizes_cancel_for_unfinished_tool_call() {
+    let mut tasks = vec![unfinished_task(
+        "task1",
+        vec![unfinished_tool_call_message(
+            "tc1",
+            "task1",
+            "call_1",
+            unfinished_run_shell_tool(),
+        )],
+    )];
+
+    reconcile_unfinished_tool_calls(&mut tasks, &[]);
+
+    // The cancel result must be spliced in immediately after its tool call.
+    assert_eq!(tasks[0].messages.len(), 2);
+    assert!(matches!(
+        &tasks[0].messages[0].message,
+        Some(api::message::Message::ToolCall(tc)) if tc.tool_call_id == "call_1"
+    ));
+    match &tasks[0].messages[1].message {
+        Some(api::message::Message::ToolCallResult(result)) => {
+            assert_eq!(result.tool_call_id, "call_1");
+            assert!(matches!(
+                result.result,
+                Some(api::message::tool_call_result::Result::Cancel(()))
+            ));
+        }
+        other => panic!("Expected a cancel tool-call result, got {other:?}"),
+    }
+    // The synthetic message gets its own non-empty id and inherits the task id.
+    assert!(!tasks[0].messages[1].id.is_empty());
+    assert_eq!(tasks[0].messages[1].task_id, "task1");
+}
+
+#[test]
+fn test_reconcile_leaves_tool_call_resolved_by_result_message_untouched() {
+    let mut tasks = vec![unfinished_task(
+        "task1",
+        vec![
+            unfinished_tool_call_message("tc1", "task1", "call_1", unfinished_run_shell_tool()),
+            unfinished_success_result_message("res1", "task1", "call_1"),
+        ],
+    )];
+
+    reconcile_unfinished_tool_calls(&mut tasks, &[]);
+
+    assert_eq!(tasks[0].messages.len(), 2, "no message should be added");
+    assert!(collect_cancel_result_ids(&tasks).is_empty());
+}
+
+#[test]
+fn test_reconcile_leaves_tool_call_resolved_by_input_untouched() {
+    let mut tasks = vec![unfinished_task(
+        "task1",
+        vec![unfinished_tool_call_message(
+            "tc1",
+            "task1",
+            "call_1",
+            unfinished_run_shell_tool(),
+        )],
+    )];
+
+    // An action result for `call_1` is being sent as a new input this turn.
+    let action_result_input = convert_tool_call_result_to_input(
+        &crate::ai::agent::task::TaskId::new("task1".to_string()),
+        &api::message::ToolCallResult {
+            tool_call_id: "call_1".to_string(),
+            context: None,
+            result: Some(api::message::tool_call_result::Result::Cancel(())),
+        },
+        &HashMap::new(),
+        &mut HashMap::new(),
+    )
+    .expect("cancel result should convert to an input");
+
+    reconcile_unfinished_tool_calls(&mut tasks, &[action_result_input]);
+
+    assert_eq!(tasks[0].messages.len(), 1, "no message should be added");
+    assert!(collect_cancel_result_ids(&tasks).is_empty());
+}
+
+#[test]
+fn test_reconcile_skips_server_tool_calls() {
+    let mut tasks = vec![unfinished_task(
+        "task1",
+        vec![unfinished_tool_call_message(
+            "tc1",
+            "task1",
+            "server_call",
+            unfinished_server_tool(),
+        )],
+    )];
+
+    reconcile_unfinished_tool_calls(&mut tasks, &[]);
+
+    assert_eq!(
+        tasks[0].messages.len(),
+        1,
+        "server tool calls are resolved by the server and must not be cancelled"
+    );
+    assert!(collect_cancel_result_ids(&tasks).is_empty());
+}
+
+#[test]
+fn test_reconcile_handles_mixed_tool_calls_and_is_idempotent() {
+    let mut tasks = vec![unfinished_task(
+        "task1",
+        vec![
+            // Resolved by an explicit success result.
+            unfinished_tool_call_message("tc1", "task1", "call_1", unfinished_run_shell_tool()),
+            // Unfinished and cancellable.
+            unfinished_tool_call_message("tc2", "task1", "call_2", unfinished_run_shell_tool()),
+            // Unfinished but server-managed (skipped).
+            unfinished_tool_call_message("tc3", "task1", "server_call", unfinished_server_tool()),
+            unfinished_success_result_message("res1", "task1", "call_1"),
+        ],
+    )];
+
+    reconcile_unfinished_tool_calls(&mut tasks, &[]);
+
+    // Only `call_2` should receive a synthetic cancel result...
+    assert_eq!(
+        collect_cancel_result_ids(&tasks),
+        vec!["call_2".to_string()]
+    );
+    // ...spliced immediately after `call_2`'s tool call (originally at index 1).
+    match &tasks[0].messages[2].message {
+        Some(api::message::Message::ToolCallResult(result)) => {
+            assert_eq!(result.tool_call_id, "call_2");
+        }
+        other => panic!("Expected cancel result right after call_2, got {other:?}"),
+    }
+
+    let len_after_first = tasks[0].messages.len();
+
+    // Running again must not add a second cancel result for the same tool call.
+    reconcile_unfinished_tool_calls(&mut tasks, &[]);
+    assert_eq!(tasks[0].messages.len(), len_after_first);
+    assert_eq!(
+        collect_cancel_result_ids(&tasks),
+        vec!["call_2".to_string()]
+    );
+}

--- a/app/src/ai/agent/api/impl.rs
+++ b/app/src/ai/agent/api/impl.rs
@@ -16,6 +16,11 @@ pub async fn generate_multi_agent_output(
     mut params: RequestParams,
     cancellation_rx: futures::channel::oneshot::Receiver<()>,
 ) -> Result<ResponseStream, ConvertToAPITypeError> {
+    // Guarantee that every tool_use in the task history is paired with a result before the
+    // request leaves the client, so a turn that ended abnormally can never produce a dangling
+    // tool_use that the server would turn into a malformed (e.g. Anthropic 400) provider request.
+    super::convert_conversation::reconcile_unfinished_tool_calls(&mut params.tasks, &params.input);
+
     let supported_tools = params
         .supported_tools_override
         .take()


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->
In benchmark eval runs, we observed agent runtime error caused by malformed request from dangling tool calls.
This is the client fix: client will synthesize tool result, if it's dangling before sending to server; 
There's server side fix before server send request to anthropic in this PR https://github.com/warpdotdev/warp-server/pull/12135
## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
