### PR TITLE
Detect slash commands after multiline edits

### DIFF
--- a/app/src/terminal/input/slash_command_model.rs
+++ b/app/src/terminal/input/slash_command_model.rs
@@ -26,9 +26,9 @@ pub struct DetectedCommand {
     /// The command in the input.
     pub command: StaticCommand,
 
-    /// The space-delimited argument to the command, if any. Does not include the leading space.
+    /// The whitespace-delimited argument to the command, if any. Does not include the leading delimiter.
     ///
-    /// If there is no trailing space after the command, then `None`.
+    /// If there is no trailing whitespace after the command, then `None`.
     pub argument: Option<String>,
 }
 
@@ -41,7 +41,7 @@ pub struct DetectedSkillCommand {
     /// The skill name (without the leading '/').
     pub name: String,
 
-    /// The space-delimited argument to the skill command (the user's prompt).
+    /// The whitespace-delimited argument to the skill command (the user's prompt).
     pub argument: Option<String>,
 }
 
@@ -239,12 +239,7 @@ impl SlashCommandModel {
     /// Detects whether `buffer` matches a known skill command.
     /// Accepts `&AppContext` so it can be called outside a model update.
     fn detect_skill_command(&self, buffer: &str, ctx: &AppContext) -> Option<DetectedSkillCommand> {
-        let (possible_command, possible_argument) =
-            if let Some((command, argument)) = buffer.split_once(" ") {
-                (command, Some(argument.to_owned()))
-            } else {
-                (buffer, None)
-            };
+        let (possible_command, possible_argument) = split_command_and_argument(buffer);
 
         let skill_name = possible_command.strip_prefix('/')?;
 
@@ -396,8 +391,8 @@ impl SlashCommandModel {
                 }
 
                 if pending_command
-                    .split_once(' ')
-                    .map_or(pending_command, |(command, _)| command)
+                    .find(char::is_whitespace)
+                    .map_or(pending_command, |index| &pending_command[..index])
                     .contains('/')
                 {
                     // If the user typed a second '/' in the command token (e.g., /foo/bar),
@@ -422,22 +417,32 @@ impl Entity for SlashCommandModel {
     type Event = UpdatedSlashCommandModel;
 }
 
+fn split_command_and_argument(buffer: &str) -> (&str, Option<String>) {
+    if let Some(delimiter_start) = buffer.find(char::is_whitespace) {
+        let delimiter_len = buffer[delimiter_start..]
+            .chars()
+            .next()
+            .map_or(0, char::len_utf8);
+        (
+            &buffer[..delimiter_start],
+            Some(buffer[delimiter_start + delimiter_len..].to_owned()),
+        )
+    } else {
+        (buffer, None)
+    }
+}
+
 impl SlashCommandDataSource {
     // Matches `buffer` against active slash commands, returning the detected command and
-    // space-delimited argument (if provided).
+    // whitespace-delimited argument (if provided).
     //
     // If a slash command has no argument, it matches only if its an exact match or the
     // suffix is all whitespace.
     //
     // If the slash command has an argument, it matches only if its an exact match, or if the argument
-    // is space-delimited.
+    // is whitespace-delimited.
     fn parse_slash_command(&self, buffer: &str) -> Option<DetectedCommand> {
-        let (possible_command, possible_argument) =
-            if let Some((command, argument)) = buffer.split_once(" ") {
-                (command, Some(argument.to_owned()))
-            } else {
-                (buffer, None)
-            };
+        let (possible_command, possible_argument) = split_command_and_argument(buffer);
 
         let is_matching_command = |command: &StaticCommand| -> bool {
             if command.name != possible_command {

--- a/app/src/terminal/input/slash_command_model_tests.rs
+++ b/app/src/terminal/input/slash_command_model_tests.rs
@@ -106,6 +106,14 @@ fn test_parse_rename_tab_slash_command_arguments() {
                 .parse_slash_command("/rename-tab ")
                 .expect("expected /rename-tab to parse once the required argument is started");
             assert_eq!(detected_with_empty_argument.argument.as_deref(), Some(""));
+
+            let detected_with_multiline_argument = data_source
+                .parse_slash_command("/rename-tab\nBackend API")
+                .expect("expected /rename-tab to parse when its argument starts on the next line");
+            assert_eq!(
+                detected_with_multiline_argument.argument.as_deref(),
+                Some("Backend API")
+            );
         });
     });
 }
@@ -392,6 +400,36 @@ fn test_detect_command_matches_buffer_driven_detection() {
                 buffer_is_slash, detect_is_slash,
                 "detect_command and buffer-driven detection should agree for '{command_name}'"
             );
+        });
+    });
+}
+
+#[test]
+fn test_buffer_redetects_slash_command_after_multiline_edit() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
+        let input = terminal.read(&app, |terminal, _| terminal.input().clone());
+
+        input.update(&mut app, |input, ctx| {
+            input.set_input_mode_natural_language_detection(ctx);
+            input.user_insert("/plan\nwrite a product spec", ctx);
+        });
+
+        input.update(&mut app, |input, ctx| {
+            input.user_replace_editor_text("/rename-tab\nBackend API", ctx);
+        });
+
+        input.read(&app, |input, ctx| {
+            let state = input.slash_command_model.as_ref(ctx).state();
+            match state {
+                SlashCommandEntryState::SlashCommand(detected) => {
+                    assert_eq!(detected.command.name, commands::RENAME_TAB.name);
+                    assert_eq!(detected.argument.as_deref(), Some("Backend API"));
+                }
+                other => panic!("expected edited multiline input to detect /rename-tab: {other:?}"),
+            }
         });
     });
 }

--- a/crates/integration/src/bin/integration.rs
+++ b/crates/integration/src/bin/integration.rs
@@ -392,6 +392,7 @@ fn register_tests() -> HashMap<&'static str, BoxedBuilderFn> {
 
     register_test!(test_autosuggestions_are_hidden_when_opening_tab_completions);
     register_test!(test_latest_buffer_operations);
+    register_test!(test_multiline_slash_command_edit_is_re_detected);
 
     register_test!(test_pass_control_sequences_to_long_running_block);
     register_test!(test_settings_file_migration_from_native_store);

--- a/crates/integration/src/test/input.rs
+++ b/crates/integration/src/test/input.rs
@@ -223,6 +223,33 @@ pub fn test_latest_buffer_operations() -> Builder {
         )
 }
 
+pub fn test_multiline_slash_command_edit_is_re_detected() -> Builder {
+    new_builder()
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(0))
+        .with_step(
+            new_step_with_default_assertions("Type initial multiline slash command")
+                .with_typed_characters(&["/plan\nwrite a product spec"])
+                .add_named_assertion(
+                    "Initial multiline slash command is in the input",
+                    input_contains_string(0, "/plan\nwrite a product spec".to_owned()),
+                ),
+        )
+        .with_step(
+            TestStep::new("Replace with another multiline slash command")
+                .with_action(|app, window_id, _step_data| {
+                    let input = single_input_view_for_tab(app, window_id, 0);
+                    input.update(app, |input, ctx| {
+                        input.user_replace_editor_text("/rename-tab\nBackend API", ctx);
+                    });
+                })
+                .add_named_assertion(
+                    "Edited multiline slash command is visible",
+                    input_contains_string(0, "/rename-tab\nBackend API".to_owned()),
+                )
+                .with_take_screenshot("multiline_slash_command_detected.png"),
+        )
+}
+
 pub fn test_middle_click_paste() -> Builder {
     new_builder()
         .with_step(wait_until_bootstrapped_single_pane_for_tab(0))

--- a/crates/integration/tests/integration/ui_tests.rs
+++ b/crates/integration/tests/integration/ui_tests.rs
@@ -256,6 +256,7 @@ integration_tests! {
     test_block_filtering_clear_blocklist,
     test_autosuggestions_are_hidden_when_opening_tab_completions,
     test_latest_buffer_operations,
+    test_multiline_slash_command_edit_is_re_detected,
 
     test_pass_control_sequences_to_long_running_block,
     test_settings_file_migration_from_native_store,


### PR DESCRIPTION
## Description
Allow slash command parsing to split the command token from its argument on any whitespace, not only a literal space. This lets edited multi-line inputs like `/rename-tab\nBackend API` or a replaced leading slash command be detected the same way as single-line slash command inputs.

The same helper is used for built-in slash commands and skill commands so both command surfaces keep consistent parsing behavior.

## Linked Issue
Closes #12425

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo test -p warp slash_command_model --lib`
- [x] `cargo run -p integration --bin integration -- test_multiline_slash_command_edit_is_re_detected`
- [x] `cargo test -p integration test_multiline_slash_command_edit_is_re_detected -- --nocapture`
- [x] `WARPUI_USE_REAL_DISPLAY_IN_INTEGRATION_TESTS=1 WARP_INTEGRATION_TEST_VIDEO=test_multiline_slash_command_edit_is_re_detected WARP_INTEGRATION_TEST_ARTIFACTS_DIR=/tmp/warp-12425-artifacts cargo run -p integration --bin integration -- test_multiline_slash_command_edit_is_re_detected`
- [x] `git diff --check`
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Recorded integration test evidence for the multiline slash command edit flow:

- [Recording MP4](https://raw.githubusercontent.com/SkyNotSilent/warp/codex-pr-12425-evidence/multiline-slash-command-recording.mp4)
- [Screenshot PNG](https://raw.githubusercontent.com/SkyNotSilent/warp/codex-pr-12425-evidence/multiline-slash-command-detected.png)
- [Recording log](https://raw.githubusercontent.com/SkyNotSilent/warp/codex-pr-12425-evidence/multiline-slash-command-recording.log)

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Re-detect slash commands when edited multi-line input starts with a different command.
