### PR TITLE
Hide "New group with tab" on tabs that are already in a group

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -595,9 +595,18 @@ impl TabData {
         if !FeatureFlag::GroupedTabs.is_enabled() {
             return vec![];
         }
-        let mut menu_items = vec![MenuItemFields::new("New group with tab")
-            .with_on_select_action(WorkspaceAction::NewTabGroupFromTab(index))
-            .into_item()];
+        let mut menu_items: Vec<MenuItem<WorkspaceAction>> = vec![];
+        // Only offer "New group with tab" for an ungrouped tab. On a tab that is
+        // already in a group this created a confusing one-member "New Group" header
+        // (the user reads it as overwriting the current tab). Regrouping a grouped
+        // tab is still reachable via drag / multi-select.
+        if self.group_id.is_none() {
+            menu_items.push(
+                MenuItemFields::new("New group with tab")
+                    .with_on_select_action(WorkspaceAction::NewTabGroupFromTab(index))
+                    .into_item(),
+            );
+        }
         let has_other_groups = tab_groups.keys().any(|gid| Some(*gid) != self.group_id);
         if has_other_groups {
             menu_items.push(MenuItemFields::new_submenu(MOVE_TO_GROUP_LABEL).into_item());
@@ -2048,3 +2057,7 @@ impl UiComponent for TabComponent<'_> {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "tab_tests.rs"]
+mod tests;

--- a/app/src/tab_tests.rs
+++ b/app/src/tab_tests.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+
+use warpui::App;
+
+use super::TabData;
+use crate::features::FeatureFlag;
+use crate::menu::MenuItem;
+use crate::workspace::tab_group::{TabGroup, TabGroupId};
+use crate::workspace::view::tests::{initialize_app, mock_workspace};
+use crate::workspace::WorkspaceAction;
+
+const NEW_GROUP_WITH_TAB_LABEL: &str = "New group with tab";
+
+/// True when `items` contains the "New group with tab" affordance, recognised by
+/// both its `NewTabGroupFromTab` action and its label.
+fn contains_new_group_with_tab(items: &[MenuItem<WorkspaceAction>]) -> bool {
+    items.iter().any(|item| {
+        matches!(
+            item.item_on_select_action(),
+            Some(WorkspaceAction::NewTabGroupFromTab(_))
+        )
+    })
+}
+
+/// True when any menu item is labelled "New group with tab", regardless of its
+/// action. Used to double-check the label-side affordance is gone too.
+fn contains_new_group_with_tab_label(items: &[MenuItem<WorkspaceAction>]) -> bool {
+    items.iter().any(|item| match item {
+        MenuItem::Item(fields) => fields.label() == NEW_GROUP_WITH_TAB_LABEL,
+        _ => false,
+    })
+}
+
+/// Regression test for the vertical-tab context menu offering "New group with
+/// tab" on a tab that is already in a group (see the gate added in
+/// `TabData::tab_group_menu_items`).
+///
+/// - A grouped tab (`group_id` is `Some`) must NOT offer "New group with tab".
+/// - An ungrouped tab (`group_id` is `None`) must still offer it.
+///
+/// The ungrouped assertion is the one that fails against the old, unconditional
+/// code; the grouped assertion guards the fix.
+#[test]
+fn new_group_with_tab_hidden_when_tab_already_grouped() {
+    // `tab_group_menu_items` early-returns empty unless this flag is on, so we
+    // must hold the override for the duration of the test to exercise the real
+    // path rather than the disabled-feature short circuit.
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+
+        workspace.update(&mut app, |workspace, _ctx| {
+            // A real pane group from the mock workspace's first tab. Only
+            // `group_id` is read by `tab_group_menu_items`; the pane group is
+            // just what `TabData::new` needs to exist.
+            let pane_group = workspace
+                .get_pane_group_view(0)
+                .expect("mock workspace should have a tab at index 0")
+                .clone();
+
+            // No other groups exist, so "Move to group" stays absent and the
+            // only group-related entry under test is "New group with tab".
+            let tab_groups: HashMap<TabGroupId, TabGroup> = HashMap::new();
+
+            // Ungrouped tab: the item must be present.
+            let mut tab = TabData::new(pane_group.clone());
+            tab.group_id = None;
+            let ungrouped_items = tab.tab_group_menu_items(0, &tab_groups);
+            assert!(
+                contains_new_group_with_tab(&ungrouped_items),
+                "an ungrouped tab should still offer \"New group with tab\""
+            );
+            assert!(
+                contains_new_group_with_tab_label(&ungrouped_items),
+                "the ungrouped \"New group with tab\" item should carry its label"
+            );
+
+            // Grouped tab: the item must be hidden (the regression).
+            let group_id = TabGroupId::new();
+            tab.group_id = Some(group_id);
+            let grouped_items = tab.tab_group_menu_items(0, &tab_groups);
+            assert!(
+                !contains_new_group_with_tab(&grouped_items),
+                "a tab already in a group must not offer \"New group with tab\""
+            );
+            assert!(
+                !contains_new_group_with_tab_label(&grouped_items),
+                "a grouped tab must not carry the \"New group with tab\" label either"
+            );
+        });
+    });
+}


### PR DESCRIPTION
## Description

The vertical-tab context menu offered **"New group with tab"** unconditionally. On a tab that is **already in a group**, selecting it spun the tab into a confusing one-member "New Group" that read as overwriting the current tab. This gates the menu item on `self.group_id.is_none()`, mirroring the sibling **"Remove from group"** item which is already gated on the tab being in a group. Regrouping a grouped tab stays reachable via drag / multi-select.

(The grouped-tabs UI is behind the `GroupedTabs` feature flag.)

## Linked Issue

Fixes #13073

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
  <!-- Oz triaged #13073, confirmed the bug via code inspection, and agreed with this exact fix approach ("gate the menu affordance for grouped tabs rather than change the grouping action"). Formal label pending a maintainer. -->
- [x] Screenshots are included below.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

Added a regression test — `app/src/tab_tests.rs` (`tab::tests::new_group_with_tab_hidden_when_tab_already_grouped`): with `GroupedTabs` enabled it asserts `tab_group_menu_items` omits "New group with tab" for a grouped tab and still offers it for an ungrouped tab. The grouped-tab assertion fails against the old unconditional code.

### Screenshots / Videos

Right-click context menu with `GroupedTabs` enabled:

**Tab already in a group** — the menu no longer offers "New group with tab" (only "Remove from group", etc.):

<img width="332" height="505" alt="Screenshot 2026-06-26 at 6 32 18 PM" src="https://github.com/user-attachments/assets/d0f0cf03-1390-426d-9eaa-2aeadc305e39" />

**Ungrouped tab (for contrast)** — still offers "New group with tab":

<img width="295" height="598" alt="Screenshot 2026-06-26 at 6 32 35 PM" src="https://github.com/user-attachments/assets/1b0174cd-9d93-4fb6-8e4e-6cf9546d7409" />


_(Before this fix, the grouped-tab menu also offered "New group with tab" — see #13073.)_

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!-- CHANGELOG-BUG-FIX: Vertical tabs: "New group with tab" is no longer offered on a tab that is already in a group. -->
