### PR TITLE
Add Copy as Markdown for AI documents

### DIFF
--- a/app/src/ai/ai_document_view.rs
+++ b/app/src/ai/ai_document_view.rs
@@ -97,6 +97,7 @@ pub enum AIDocumentAction {
     Close,
     SelectVersion(AIDocumentVersion),
     Export,
+    CopyAsMarkdown,
     OpenVersionMenu,
     CreateWarpDriveNotebook,
     RevertToDocumentVersion,
@@ -1132,6 +1133,20 @@ impl TypedActionView for AIDocumentView {
                 self.refresh(ctx);
             }
             AIDocumentAction::Export => self.export(ctx),
+            AIDocumentAction::CopyAsMarkdown => {
+                let markdown = self.editor.as_ref(ctx).markdown_unescaped(ctx);
+                ctx.clipboard()
+                    .write(ClipboardContent::plain_text(markdown));
+
+                let window_id = ctx.window_id();
+                ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
+                    toast_stack.add_ephemeral_toast(
+                        DismissibleToast::success("Copied to clipboard as Markdown".to_string()),
+                        window_id,
+                        ctx,
+                    );
+                });
+            }
             AIDocumentAction::CreateWarpDriveNotebook => self.create_warp_drive_notebook(ctx),
             AIDocumentAction::CopyLink(link) => {
                 send_telemetry_from_ctx!(
@@ -1319,6 +1334,13 @@ impl BackingView for AIDocumentView {
                     .into_item(),
             );
         }
+
+        menu_items.push(
+            MenuItemFields::new("Copy as Markdown")
+                .with_on_select_action(AIDocumentAction::CopyAsMarkdown)
+                .with_icon(Icon::Copy)
+                .into_item(),
+        );
 
         #[cfg(feature = "local_fs")]
         {

--- a/app/src/ai/document/ai_document_model_tests.rs
+++ b/app/src/ai/document/ai_document_model_tests.rs
@@ -821,3 +821,33 @@ fn test_streamed_agent_update_matches_reset_with_markdown_for_code_block() {
         }
     });
 }
+
+#[test]
+fn test_plan_markdown_content_preserves_copyable_structure() {
+    App::test((), |mut app| async move {
+        initialize_app_for_ai_document_tests(&mut app);
+        let model_handle = app.add_model(|_ctx| AIDocumentModel::new_for_test());
+
+        let plan_markdown = "# Migration Plan\n\n## Steps\n\n1. Audit the call sites\n   - Inventory each module\n   - Note breaking changes\n2. Land the refactor\n3. Verify with `cargo test`\n\n```rust path=null start=null\nfn migrate() {\n    println!(\"done\");\n}\n```";
+
+        let doc_id = model_handle.update(&mut app, |model, ctx| {
+            model.create_document(
+                "Migration Plan",
+                plan_markdown,
+                AIConversationId::new(),
+                None,
+                ctx,
+            )
+        });
+
+        let expected_markdown = "# Migration Plan\n\n## Steps\n\n1. Audit the call sites\n    * Inventory each module\n    * Note breaking changes\n2. Land the refactor\n3. Verify with `cargo test`\n\n```rust\nfn migrate() {\n    println!(\"done\");\n}\n```\n";
+
+        model_handle.update(&mut app, |model, ctx| {
+            let content = model
+                .get_document_content(&doc_id, ctx)
+                .expect("plan should expose its markdown content");
+
+            assert_eq!(content, expected_markdown);
+        });
+    });
+}

--- a/app/src/integration_testing/ai_document.rs
+++ b/app/src/integration_testing/ai_document.rs
@@ -1,0 +1,81 @@
+use warpui::integration::{AssertionCallback, TestStep};
+use warpui::{async_assert, App, SingletonEntity, TypedActionView, WindowId};
+
+use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
+use crate::ai::document::ai_document_model::{AIDocumentModel, AIDocumentVersion};
+use crate::integration_testing::view_getters::{
+    pane_group_view, single_terminal_view_for_tab, workspace_view,
+};
+use crate::workspace::WorkspaceAction;
+
+pub fn create_and_open_ai_document(title: &'static str, markdown: &'static str) -> TestStep {
+    TestStep::new("Create and open AI document").with_action(move |app, window_id, _| {
+        let terminal_view_id = single_terminal_view_for_tab(app, window_id, 0).id();
+        let document_id = app.update(|ctx| {
+            let conversation_id = BlocklistAIHistoryModel::handle(ctx).update(ctx, |model, ctx| {
+                let conversation_id =
+                    model.start_new_conversation(terminal_view_id, false, false, false, ctx);
+                model.set_active_conversation_id(conversation_id, terminal_view_id, ctx);
+                conversation_id
+            });
+
+            AIDocumentModel::handle(ctx).update(ctx, |model, ctx| {
+                model.create_document(title, markdown, conversation_id, None, ctx)
+            })
+        });
+
+        let workspace = workspace_view(app, window_id);
+        workspace.update(app, |workspace, ctx| {
+            workspace.handle_action(
+                &WorkspaceAction::OpenAIDocumentPane {
+                    document_id,
+                    document_version: AIDocumentVersion::default(),
+                },
+                ctx,
+            );
+        });
+
+        let pane_group = pane_group_view(app, window_id, 0);
+        pane_group.update(app, |pane_group, ctx| {
+            let pane_id = pane_group
+                .ai_document_panes()
+                .next()
+                .expect("AI document pane should be open");
+            let pane_configuration = pane_group
+                .pane_by_id(pane_id)
+                .expect("AI document pane should exist")
+                .pane_configuration();
+            pane_configuration.update(ctx, |pane_configuration, ctx| {
+                pane_configuration.refresh_pane_header_overflow_menu_items(ctx);
+            });
+        });
+    })
+}
+
+pub fn ai_document_overflow_button_position_id(app: &mut App, window_id: WindowId) -> String {
+    let pane_group = pane_group_view(app, window_id, 0);
+    pane_group.read(app, |pane_group, _| {
+        let pane_id = pane_group
+            .ai_document_panes()
+            .next()
+            .expect("AI document pane should be open");
+        let pane_configuration_id = pane_group
+            .pane_by_id(pane_id)
+            .expect("AI document pane should exist")
+            .pane_configuration()
+            .id();
+        format!("pane_header_overflow_button:{pane_configuration_id}")
+    })
+}
+
+pub fn assert_ai_document_overflow_button_position_exists() -> AssertionCallback {
+    Box::new(|app, window_id| {
+        let position_id = ai_document_overflow_button_position_id(app, window_id);
+        let presenter = app.presenter(window_id).expect("presenter should exist");
+        let presenter = presenter.borrow();
+        async_assert!(presenter
+            .position_cache()
+            .get_position(position_id)
+            .is_some())
+    })
+}

--- a/app/src/integration_testing/mod.rs
+++ b/app/src/integration_testing/mod.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use warpui::{App, AssetProvider, View, ViewHandle, WindowId};
 
 pub mod agent_mode;
+pub mod ai_document;
 pub mod assertions;
 pub mod block;
 pub mod block_filtering;

--- a/crates/integration/src/bin/integration.rs
+++ b/crates/integration/src/bin/integration.rs
@@ -456,6 +456,9 @@ fn register_tests() -> HashMap<&'static str, BoxedBuilderFn> {
     register_test!(test_code_editor_line_numbers_default_to_absolute);
     register_test!(test_code_editor_relative_line_numbers_follow_cursor);
 
+    // AI document tests
+    register_test!(test_copy_ai_document_as_markdown_from_overflow_menu);
+
     // Keyboard protocol tests
     register_test!(test_keyboard_protocol_disabled_shift_enter);
     register_test!(test_keyboard_protocol_enabled_shift_enter);

--- a/crates/integration/src/test.rs
+++ b/crates/integration/src/test.rs
@@ -4,6 +4,7 @@
 
 mod agent_mode;
 mod ai_assistant;
+mod ai_document;
 mod block_filtering;
 mod bootstrapping;
 mod code_review;
@@ -44,6 +45,7 @@ use std::time::Duration;
 
 pub use agent_mode::*;
 pub use ai_assistant::*;
+pub use ai_document::*;
 use anyhow::{anyhow, Result};
 pub use block_filtering::*;
 pub use bootstrapping::*;

--- a/crates/integration/src/test/ai_document.rs
+++ b/crates/integration/src/test/ai_document.rs
@@ -1,0 +1,38 @@
+use std::time::Duration;
+
+use warp::integration_testing::ai_document::{
+    ai_document_overflow_button_position_id, assert_ai_document_overflow_button_position_exists,
+    create_and_open_ai_document,
+};
+use warp::integration_testing::clipboard::assert_clipboard_contains_string;
+use warp::integration_testing::step::new_step_with_default_assertions;
+use warp::integration_testing::terminal::wait_until_bootstrapped_single_pane_for_tab;
+
+use super::new_builder;
+use crate::Builder;
+
+const PLAN_MARKDOWN: &str = "# Migration Plan\n\n## Steps\n\n1. Audit the call sites\n   - Inventory each module\n   - Note breaking changes\n2. Land the refactor\n3. Verify with `cargo test`\n\n```rust path=null start=null\nfn migrate() {\n    println!(\"done\");\n}\n```";
+
+const EXPECTED_CLIPBOARD: &str = "# Migration Plan\n\n## Steps\n\n1. Audit the call sites\n    * Inventory each module\n    * Note breaking changes\n2. Land the refactor\n3. Verify with `cargo test`\n\n```rust\nfn migrate() {\n    println!(\"done\");\n}\n```\n";
+
+pub fn test_copy_ai_document_as_markdown_from_overflow_menu() -> Builder {
+    new_builder()
+        .with_step(wait_until_bootstrapped_single_pane_for_tab(0))
+        .with_step(create_and_open_ai_document("Migration Plan", PLAN_MARKDOWN))
+        .with_step(
+            new_step_with_default_assertions("Wait for AI document overflow menu button")
+                .set_timeout(Duration::from_secs(10))
+                .add_assertion(assert_ai_document_overflow_button_position_exists()),
+        )
+        .with_step(
+            new_step_with_default_assertions("Open AI document overflow menu")
+                .with_click_on_saved_position_fn(ai_document_overflow_button_position_id),
+        )
+        .with_step(
+            new_step_with_default_assertions("Copy AI document as Markdown")
+                .with_click_on_saved_position("Copy as Markdown")
+                .add_assertion(assert_clipboard_contains_string(
+                    EXPECTED_CLIPBOARD.to_string(),
+                )),
+        )
+}

--- a/crates/integration/tests/integration/ui_tests.rs
+++ b/crates/integration/tests/integration/ui_tests.rs
@@ -332,6 +332,9 @@ integration_tests! {
     test_code_editor_line_numbers_default_to_absolute,
     test_code_editor_relative_line_numbers_follow_cursor,
 
+    // AI document tests
+    test_copy_ai_document_as_markdown_from_overflow_menu,
+
     // Keyboard protocol tests
     test_keyboard_protocol_disabled_shift_enter,
     test_keyboard_protocol_enabled_shift_enter,


### PR DESCRIPTION
## Description
Adds a `Copy as Markdown` action to the AI document overflow menu. The action reuses the same `markdown_unescaped` serializer used by Markdown export, writes the result to the clipboard, and shows a success toast.

## Linked Issue
Closes #9214

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `./script/format --check`
- [x] `./script/check_no_inline_test_modules`
- [x] `cargo test -p warp test_plan_markdown_content_preserves_copyable_structure --lib`
- [x] `cargo run -p integration --bin integration -- test_copy_ai_document_as_markdown_from_overflow_menu`
- [x] `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- [x] `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Real-display integration run showing the AI document overflow menu action and clipboard assertion:

- [copy-as-markdown-recording.mp4](https://github.com/SkyNotSilent/warp/raw/codex-pr-9214-evidence/copy-as-markdown-recording.mp4)
- [recording.log](https://github.com/SkyNotSilent/warp/blob/codex-pr-9214-evidence/copy-as-markdown-recording.log)

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Add a Copy as Markdown action to AI planning document menus.