### PR TITLE
Exclude fullwidth punctuation from detected links

### DIFF
--- a/app/src/terminal/model/grid/grid_handler.rs
+++ b/app/src/terminal/model/grid/grid_handler.rs
@@ -117,6 +117,31 @@ lazy_static! {
     static ref URL_SEPARATORS: HashSet<char> = HashSet::from([' ', '<', '>', '"', '{', '}', '|', '\\', '^', '`']);
 }
 
+/// Returns true when `c` should terminate a clickable URL.
+///
+/// URL detection allows non-ASCII letters so internationalized paths remain
+/// clickable, but non-ASCII whitespace and punctuation usually indicate prose
+/// around the URL (for example, CJK punctuation like `，` or `。`).
+pub fn is_url_link_separator(c: char) -> bool {
+    if URL_SEPARATORS.contains(&c) {
+        return true;
+    }
+    if c.is_ascii() {
+        return false;
+    }
+    if c.is_whitespace() {
+        return true;
+    }
+    matches!(
+        get_general_category(c),
+        GeneralCategory::OpenPunctuation
+            | GeneralCategory::ClosePunctuation
+            | GeneralCategory::InitialPunctuation
+            | GeneralCategory::FinalPunctuation
+            | GeneralCategory::OtherPunctuation
+    )
+}
+
 /// Returns true when `c` should terminate a clickable file path.
 ///
 /// Beyond the explicit set in [`FILE_LINK_SEPARATORS`] (ASCII punctuation
@@ -711,7 +736,7 @@ impl GridHandler {
             !cell
                 .flags
                 .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
-                && URL_SEPARATORS.contains(&cell.c)
+                && is_url_link_separator(cell.c)
         };
         // If the point is on a separator, return directly because this can't be
         // part of a url.
@@ -778,6 +803,10 @@ impl GridHandler {
 
             if current_point >= original_point {
                 passed_point = true;
+            }
+
+            if is_at_boundary(item.cell()) {
+                break;
             }
 
             let last_state = mem::replace(&mut state, locator.advance(item.cell().c));

--- a/app/src/terminal/model/grid/grid_handler_tests.rs
+++ b/app/src/terminal/model/grid/grid_handler_tests.rs
@@ -685,6 +685,23 @@ fn test_find_url_with_delimiter() {
         })
     );
 
+    let blockgrid = mock_blockgrid("https://google.com，");
+    assert_eq!(
+        blockgrid
+            .grid_handler
+            .url_at_point(Point { row: 0, col: 0 }),
+        Some(Link {
+            range: Point { row: 0, col: 0 }..=Point { row: 0, col: 17 },
+            is_empty: false
+        })
+    );
+    assert_eq!(
+        blockgrid
+            .grid_handler
+            .url_at_point(Point { row: 0, col: 18 }),
+        None
+    );
+
     let blockgrid = mock_blockgrid("https://google.com/search?q=warp");
     assert_eq!(
         blockgrid

--- a/app/src/terminal/view/link_detection.rs
+++ b/app/src/terminal/view/link_detection.rs
@@ -21,6 +21,8 @@ cfg_if::cfg_if! {
             util::openable_file_type::FileTarget,
         };
         use std::path::PathBuf;
+        use unicode_general_category::{get_general_category, GeneralCategory};
+        use unicode_width::UnicodeWidthChar;
         use warp_util::path::CleanPathResult;
         use warp_util::path::LineAndColumnArg;
     }
@@ -37,29 +39,76 @@ const PREFIXES_TO_REMOVE: [&str; 2] = ["a/", "b/"];
 #[cfg(feature = "local_fs")]
 const SUFFIXES_TO_REMOVE: [&str; 1] = ["@"];
 
-/// Strips a single trailing sentence period from a captured path token when the
-/// period is sentence punctuation rather than a meaningful path component.
+#[cfg(feature = "local_fs")]
+struct TrimmedSentencePunctuation<'a> {
+    path: &'a str,
+    removed_width: usize,
+}
+
+#[cfg(feature = "local_fs")]
+fn is_trailing_sentence_punctuation(c: char) -> bool {
+    if c == '.' {
+        return true;
+    }
+    if c.is_ascii() {
+        return false;
+    }
+    matches!(
+        get_general_category(c),
+        GeneralCategory::ClosePunctuation
+            | GeneralCategory::FinalPunctuation
+            | GeneralCategory::OtherPunctuation
+    )
+}
+
+/// Strips trailing sentence punctuation from a captured path token when the
+/// punctuation is prose around the path rather than a meaningful path component.
 ///
 /// File paths written at the end of a sentence frequently capture the trailing
-/// period (e.g. `notes/README.md.`). No real file name ends in `.`, and on
-/// Windows the NT path normalizer silently strips a trailing `.` during path
-/// resolution — so without trimming, the captured token keeps the period in both
-/// the highlight range and the file extension, defeating extension-based
-/// classification (e.g. opening markdown in the viewer instead of as raw text).
+/// punctuation (e.g. `notes/README.md.` or `notes/README.md，`). On Windows the
+/// NT path normalizer silently strips a trailing `.` during path resolution, so
+/// without trimming, the captured token keeps the period in both the highlight
+/// range and the file extension, defeating extension-based classification (e.g.
+/// opening markdown in the viewer instead of as raw text).
 ///
-/// Returns `None` when there is no trailing period, or when the trailing period
-/// is part of a `.`/`..` path component (e.g. `.`, `..`, `foo/.`, `foo/..`),
-/// which are legitimate path segments and must be preserved.
+/// Returns `None` when there is no trailing sentence punctuation, or when a
+/// trailing period is part of a `.`/`..` path component (e.g. `.`, `..`, `foo/.`,
+/// `foo/..`), which are legitimate path segments and must be preserved.
 #[cfg(feature = "local_fs")]
-fn path_without_trailing_sentence_period(path: &str) -> Option<&str> {
-    let trimmed = path.strip_suffix('.')?;
-    match trimmed.chars().next_back() {
-        // Empty (`.`) or a dot/separator immediately before the trailing `.`
-        // means the period is a real path component (`..`, `foo/.`, `foo\.`),
-        // not sentence punctuation.
-        None | Some('.') | Some('/') | Some('\\') => None,
-        _ => Some(trimmed),
+fn path_without_trailing_sentence_punctuation(
+    path: &str,
+) -> Option<TrimmedSentencePunctuation<'_>> {
+    let mut trimmed = path;
+    let mut removed_width = 0;
+
+    while let Some(c) = trimmed.chars().next_back() {
+        if !is_trailing_sentence_punctuation(c) {
+            break;
+        }
+
+        let new_trimmed = trimmed.strip_suffix(c)?;
+        if new_trimmed.is_empty() {
+            break;
+        }
+
+        if c == '.' {
+            match new_trimmed.chars().next_back() {
+                // Empty (`.`) or a dot/separator immediately before the trailing
+                // `.` means the period is a real path component (`..`, `foo/.`,
+                // `foo\.`), not sentence punctuation.
+                None | Some('.') | Some('/') | Some('\\') => break,
+                _ => {}
+            }
+        }
+
+        trimmed = new_trimmed;
+        removed_width += UnicodeWidthChar::width(c).unwrap_or(1);
     }
+
+    (removed_width > 0).then_some(TrimmedSentencePunctuation {
+        path: trimmed,
+        removed_width,
+    })
 }
 
 /// Highlighted link within a terminal model grid.
@@ -526,18 +575,18 @@ impl super::TerminalView {
         'path_loop: for within_model_possible_path in possible_paths {
             let possible_path = within_model_possible_path.get_inner();
 
-            // A file path at the end of a sentence often captures the trailing
-            // sentence period (e.g. `notes/README.md.`). Try the period-trimmed
-            // candidate first so the resolved file, the highlight range, and
-            // extension-based classification all exclude it. This must run before
-            // the untrimmed lookup because on Windows the NT path normalizer
-            // strips trailing dots, so the untrimmed path would otherwise resolve
-            // and leave the period inside the captured link.
+            // A file path at the end of a sentence often captures trailing prose
+            // punctuation (e.g. `notes/README.md.` or `notes/README.md，`). Try the
+            // punctuation-trimmed candidate first so the resolved file, highlight
+            // range, and extension-based classification all exclude it. This must
+            // run before the untrimmed lookup because on Windows the NT path
+            // normalizer strips trailing dots, so the untrimmed path would
+            // otherwise resolve and leave the period inside the captured link.
             if let Some(trimmed_path) =
-                path_without_trailing_sentence_period(&possible_path.path.path)
+                path_without_trailing_sentence_punctuation(&possible_path.path.path)
             {
                 let trimmed_cleaned_path = CleanPathResult {
-                    path: trimmed_path.into(),
+                    path: trimmed_path.path.into(),
                     line_and_column_num: possible_path.path.line_and_column_num,
                 };
                 if let Some(absolute_path) = absolute_path_if_valid(
@@ -545,7 +594,10 @@ impl super::TerminalView {
                     ShellPathType::ShellNative(working_directory.to_string()),
                     shell_launch_data.as_ref(),
                 ) {
-                    let new_end_point = possible_path.range.end().wrapping_sub(max_columns, 1);
+                    let new_end_point = possible_path
+                        .range
+                        .end()
+                        .wrapping_sub(max_columns, trimmed_path.removed_width);
                     link = Some(Self::create_valid_link(
                         absolute_path,
                         trimmed_cleaned_path.line_and_column_num,

--- a/app/src/terminal/view/link_detection_tests.rs
+++ b/app/src/terminal/view/link_detection_tests.rs
@@ -3,7 +3,7 @@ use std::iter;
 use warp_util::path::CleanPathResult;
 
 use super::super::TerminalView;
-use super::{path_without_trailing_sentence_period, GridHighlightedLink};
+use super::{path_without_trailing_sentence_punctuation, GridHighlightedLink};
 use crate::terminal::model::grid::grid_handler::PossiblePath;
 use crate::terminal::model::index::Point;
 use crate::terminal::model::terminal_model::WithinModel;
@@ -12,30 +12,59 @@ use crate::terminal::model::terminal_model::WithinModel;
 fn strips_only_sentence_periods() {
     // A trailing period after a real file name is sentence punctuation.
     assert_eq!(
-        path_without_trailing_sentence_period("notes/README.md."),
+        path_without_trailing_sentence_punctuation("notes/README.md.").map(|trimmed| trimmed.path),
         Some("notes/README.md")
     );
     assert_eq!(
-        path_without_trailing_sentence_period(".gitignore."),
+        path_without_trailing_sentence_punctuation(".gitignore.").map(|trimmed| trimmed.path),
         Some(".gitignore")
     );
     assert_eq!(
-        path_without_trailing_sentence_period("C:/Users/c/warp-md-test.md."),
+        path_without_trailing_sentence_punctuation("C:/Users/c/warp-md-test.md.")
+            .map(|trimmed| trimmed.path),
         Some("C:/Users/c/warp-md-test.md")
     );
 
     // No trailing period -> nothing to trim.
     assert_eq!(
-        path_without_trailing_sentence_period("notes/README.md"),
+        path_without_trailing_sentence_punctuation("notes/README.md").map(|trimmed| trimmed.path),
         None
     );
 
     // `.`/`..` path components must be preserved, not treated as punctuation.
-    assert_eq!(path_without_trailing_sentence_period("."), None);
-    assert_eq!(path_without_trailing_sentence_period(".."), None);
-    assert_eq!(path_without_trailing_sentence_period("foo/."), None);
-    assert_eq!(path_without_trailing_sentence_period("foo/.."), None);
-    assert_eq!(path_without_trailing_sentence_period("foo.."), None);
+    assert_eq!(
+        path_without_trailing_sentence_punctuation(".").map(|trimmed| trimmed.path),
+        None
+    );
+    assert_eq!(
+        path_without_trailing_sentence_punctuation("..").map(|trimmed| trimmed.path),
+        None
+    );
+    assert_eq!(
+        path_without_trailing_sentence_punctuation("foo/.").map(|trimmed| trimmed.path),
+        None
+    );
+    assert_eq!(
+        path_without_trailing_sentence_punctuation("foo/..").map(|trimmed| trimmed.path),
+        None
+    );
+    assert_eq!(
+        path_without_trailing_sentence_punctuation("foo..").map(|trimmed| trimmed.path),
+        None
+    );
+}
+
+#[test]
+fn strips_trailing_fullwidth_sentence_punctuation() {
+    let trimmed = path_without_trailing_sentence_punctuation("notes/README.md，")
+        .expect("fullwidth comma should be stripped");
+    assert_eq!(trimmed.path, "notes/README.md");
+    assert_eq!(trimmed.removed_width, 2);
+
+    let trimmed = path_without_trailing_sentence_punctuation("notes/README.md。！？")
+        .expect("CJK sentence punctuation should be stripped");
+    assert_eq!(trimmed.path, "notes/README.md");
+    assert_eq!(trimmed.removed_width, 6);
 }
 
 // Regression test for https://github.com/warpdotdev/warp/issues/11477:
@@ -86,6 +115,97 @@ fn compute_valid_paths_excludes_trailing_sentence_period() {
         Point {
             row: 0,
             col: end_col - 1,
+        }
+    );
+}
+
+#[test]
+fn compute_valid_paths_excludes_trailing_fullwidth_sentence_punctuation() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("warp-md-test.md");
+    std::fs::write(&file, "# Hello\n").unwrap();
+
+    let token = format!("{}，", file.to_string_lossy());
+    let punctuation_width = 2;
+    let end_col = token.chars().count();
+    let candidate = WithinModel::AltScreen(PossiblePath {
+        path: CleanPathResult {
+            path: token,
+            line_and_column_num: None,
+        },
+        range: Point { row: 0, col: 0 }..=Point {
+            row: 0,
+            col: end_col,
+        },
+    });
+
+    let link = TerminalView::compute_valid_paths(
+        dir.path().to_str().unwrap(),
+        iter::once(candidate),
+        1000,
+        None,
+    )
+    .expect("the markdown file should be detected as a link");
+
+    let GridHighlightedLink::File(file_link) = link else {
+        panic!("expected a file link");
+    };
+    let file_link = file_link.get_inner();
+
+    assert_eq!(
+        file_link.absolute_path.file_name().unwrap(),
+        "warp-md-test.md"
+    );
+    assert_eq!(
+        *file_link.link.range().end(),
+        Point {
+            row: 0,
+            col: end_col - punctuation_width,
+        }
+    );
+}
+
+#[test]
+fn compute_valid_paths_keeps_trailing_fullwidth_punctuation_when_it_is_the_filename() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("warp-md-test.md，");
+    std::fs::write(&file, "# Hello\n").unwrap();
+
+    let token = file.to_string_lossy().to_string();
+    let end_col = token.chars().count();
+    let candidate = WithinModel::AltScreen(PossiblePath {
+        path: CleanPathResult {
+            path: token,
+            line_and_column_num: None,
+        },
+        range: Point { row: 0, col: 0 }..=Point {
+            row: 0,
+            col: end_col,
+        },
+    });
+
+    let link = TerminalView::compute_valid_paths(
+        dir.path().to_str().unwrap(),
+        iter::once(candidate),
+        1000,
+        None,
+    )
+    .expect("the file with fullwidth punctuation should be detected as a link");
+
+    let GridHighlightedLink::File(file_link) = link else {
+        panic!("expected a file link");
+    };
+    let file_link = file_link.get_inner();
+
+    assert_eq!(
+        file_link.absolute_path.file_name().unwrap(),
+        "warp-md-test.md，"
+    );
+    assert_eq!(
+        *file_link.link.range().end(),
+        Point {
+            row: 0,
+            col: end_col,
         }
     );
 }

--- a/app/src/util/link_detection.rs
+++ b/app/src/util/link_detection.rs
@@ -12,7 +12,7 @@ use crate::ai::agent::{AIAgentActionType, AIAgentOutput, AIAgentTextSection, Rea
 use crate::ai::blocklist::block::view_impl::output::LinkActionConstructors;
 use crate::ai::blocklist::block::TextLocation;
 use crate::terminal::links::should_directly_open_link;
-use crate::terminal::model::grid::grid_handler::is_file_link_separator;
+use crate::terminal::model::grid::grid_handler::{is_file_link_separator, is_url_link_separator};
 use crate::terminal::ShellLaunchData;
 
 cfg_if::cfg_if! {
@@ -179,10 +179,37 @@ pub(crate) fn add_link_detection_mouse_interactions<T: PartialClickableElement, 
 
 /// Returns the char ranges of detected URLs in the given text.
 fn detect_urls(text: &str) -> Vec<Range<usize>> {
+    fn push_url_range(
+        url_ranges: &mut Vec<Range<usize>>,
+        text: &str,
+        start: Option<usize>,
+        end: Option<usize>,
+    ) {
+        let Some((start, mut end)) = start.zip(end) else {
+            return;
+        };
+
+        while end > start && text.chars().nth(end - 1).is_some_and(is_url_link_separator) {
+            end -= 1;
+        }
+
+        if start < end {
+            url_ranges.push(start..end);
+        }
+    }
+
     let mut locator = UrlLocator::new();
     let mut url_ranges = vec![];
     let (mut start, mut end) = (None, None);
     for (i, c) in text.chars().enumerate() {
+        if is_url_link_separator(c) {
+            push_url_range(&mut url_ranges, text, start, end);
+            start = None;
+            end = None;
+            locator = UrlLocator::new();
+            continue;
+        }
+
         // Reference to https://docs.rs/urlocator/latest/urlocator/#example-url-boundaries
         // We know we have fully parsed an url when the locator advances from the `UrlLocation::Url`
         // to the `UrlLocation::Reset` stage.
@@ -192,9 +219,7 @@ fn detect_urls(text: &str) -> Vec<Range<usize>> {
                 start = Some(end.unwrap() - length as usize);
             }
             UrlLocation::Reset => {
-                if let Some((start, end)) = start.zip(end) {
-                    url_ranges.push(start..end)
-                }
+                push_url_range(&mut url_ranges, text, start, end);
                 start = None;
                 end = None;
             }
@@ -202,9 +227,7 @@ fn detect_urls(text: &str) -> Vec<Range<usize>> {
         }
     }
     // If the last character completes a valid URL, add it.
-    if let Some((start, end)) = start.zip(end) {
-        url_ranges.push(start..end)
-    }
+    push_url_range(&mut url_ranges, text, start, end);
     url_ranges
 }
 

--- a/app/src/util/link_detection_tests.rs
+++ b/app/src/util/link_detection_tests.rs
@@ -63,6 +63,36 @@ fn test_detect_urls_stops_at_fullwidth_punctuation() {
     assert_eq!(detect_urls("go https://example.com。"), vec![3..22]);
 }
 
+#[cfg(feature = "local_fs")]
+#[test]
+fn test_detect_file_paths_stops_at_fullwidth_punctuation() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("warp-rich-content.md");
+    std::fs::write(&file, "# Hello\n").unwrap();
+
+    let text = "see warp-rich-content.md， and warp-rich-content.md。";
+    let detected_paths = detect_file_paths(dir.path().to_str().unwrap(), text, None);
+
+    let link_ranges = detected_paths.keys().cloned().collect_vec();
+    assert!(link_ranges.contains(&(4..24)));
+    assert!(link_ranges.contains(&(30..50)));
+    assert!(!link_ranges.contains(&(4..25)));
+    assert!(!link_ranges.contains(&(30..51)));
+}
+
+#[cfg(feature = "local_fs")]
+#[test]
+fn test_detect_file_paths_keeps_fullwidth_punctuation_when_it_is_the_filename() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("warp-rich-content.md，");
+    std::fs::write(&file, "# Hello\n").unwrap();
+
+    let text = "see warp-rich-content.md，";
+    let detected_paths = detect_file_paths(dir.path().to_str().unwrap(), text, None);
+
+    assert!(detected_paths.contains_key(&(4..25)));
+}
+
 #[test]
 fn test_possible_file_paths_in_word_multibyte() {
     let word = "/path/音楽/テストファイル.txt:16:ḧeĹḹo";

--- a/app/src/util/link_detection_tests.rs
+++ b/app/src/util/link_detection_tests.rs
@@ -58,6 +58,12 @@ fn test_possible_file_paths_in_word() {
 }
 
 #[test]
+fn test_detect_urls_stops_at_fullwidth_punctuation() {
+    assert_eq!(detect_urls("go https://example.com，next"), vec![3..22]);
+    assert_eq!(detect_urls("go https://example.com。"), vec![3..22]);
+}
+
+#[test]
 fn test_possible_file_paths_in_word_multibyte() {
     let word = "/path/音楽/テストファイル.txt:16:ḧeĹḹo";
     let possible_paths = possible_file_paths_in_word(word).collect_vec();


### PR DESCRIPTION
## Description
Fix link detection so fullwidth/CJK punctuation adjacent to URLs and file paths is treated as surrounding prose instead of part of the clickable link.

This updates terminal URL detection, AI/rich-text URL detection, and terminal file-path hover detection. File paths now try a punctuation-trimmed candidate first, but still fall back to the original candidate so real filenames ending in fullwidth punctuation remain openable.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

Automated testing:
- `./script/format`
- `cargo test -p warp terminal::view::link_detection::tests`
- `cargo test -p warp terminal::model::grid::grid_handler::tests::test_find_url`
- `cargo test -p warp util::link_detection::tests`
- `git diff --check`

### Screenshots / Videos

1. File paths followed by fullwidth punctuation

   https://github.com/user-attachments/assets/d330c12e-057a-4074-a18f-039840330f69

2. URLs followed by fullwidth punctuation

   https://github.com/user-attachments/assets/545b947b-773c-404c-a517-59d5db17762b

3. Exact file path whose filename ends in fullwidth punctuation

   https://github.com/user-attachments/assets/89dee023-f28c-443c-914c-efcbd63a4d4d

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed link detection incorrectly including fullwidth/CJK punctuation after URLs and file paths.


Closes #13088
