### PR TITLE
feat(ai): Add custom base URL support for OpenAI BYOK

### DIFF
--- a/app/src/ai/agent/api.rs
+++ b/app/src/ai/agent/api.rs
@@ -289,10 +289,19 @@ impl RequestParams {
             geap_binding,
         );
         let is_custom_inference_enabled = user_workspaces.is_custom_inference_enabled(app);
+        let openai_models: Vec<String> = LLMPreferences::as_ref(app)
+            .get_base_llm_choices_for_agent_mode(app)
+            .filter(|llm| llm.provider == crate::ai::llms::LLMProvider::OpenAI)
+            .map(|llm| llm.id.to_string())
+            .collect();
         let custom_model_providers = FeatureFlag::CustomInferenceEndpoints
             .is_enabled()
             .then(|| {
-                api_key_manager.custom_model_providers_for_request(is_custom_inference_enabled)
+                api_key_manager.custom_model_providers_for_request(
+                    is_custom_inference_enabled,
+                    is_byo_enabled,
+                    openai_models,
+                )
             })
             .flatten();
         let custom_model_routers = FeatureFlag::CustomModelRouters.is_enabled().then(|| {

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -7780,6 +7780,7 @@ impl SettingsWidget for CloudHandoffWidget {
 
 struct ApiKeysWidget {
     openai_api_key_editor: ViewHandle<EditorView>,
+    openai_api_url_editor: ViewHandle<EditorView>,
     anthropic_api_key_editor: ViewHandle<EditorView>,
     google_api_key_editor: ViewHandle<EditorView>,
     /// Buttons for the SuperGrok (xAI) subscription row; which one renders
@@ -7806,6 +7807,7 @@ impl ApiKeysWidget {
 
         let ApiKeys {
             openai: openai_key,
+            openai_api_url: openai_url,
             anthropic: anthropic_key,
             google: google_key,
             ..
@@ -7814,11 +7816,11 @@ impl ApiKeysWidget {
         // A helper macro to create and configure an API key editor.  This avoids a lot
         // of code duplication and ensures consistency between the editors.
         macro_rules! create_api_key_editor {
-            ($editor:ident, $key:ident, $set_func:ident, $placeholder:literal) => {
+            ($editor:ident, $key:ident, $set_func:ident, $placeholder:literal, $is_password:expr) => {
                 let $editor = ctx.add_typed_action_view(move |ctx| {
                     let appearance = Appearance::handle(ctx).as_ref(ctx);
                     let options = SingleLineEditorOptions {
-                        is_password: true,
+                        is_password: $is_password,
                         text: TextOptions {
                             font_size_override: Some(appearance.ui_font_size()),
                             font_family_override: Some(appearance.monospace_font_family()),
@@ -7882,24 +7884,34 @@ impl ApiKeysWidget {
             };
         }
 
-        create_api_key_editor!(openai_api_key_editor, openai_key, set_openai_key, "sk-...");
+        create_api_key_editor!(openai_api_key_editor, openai_key, set_openai_key, "sk-...", true);
+        create_api_key_editor!(
+            openai_api_url_editor,
+            openai_url,
+            set_openai_api_url,
+            "e.g. https://api.openai.com/v1",
+            false
+        );
         create_api_key_editor!(
             anthropic_api_key_editor,
             anthropic_key,
             set_anthropic_key,
-            "sk-ant-..."
+            "sk-ant-...",
+            true
         );
         create_api_key_editor!(
             google_api_key_editor,
             google_key,
             set_google_key,
-            "AIzaSy..."
+            "AIzaSy...",
+            true
         );
 
         // Editor text colors are snapshotted at construction via
         // `text_colors_override`, so refresh them whenever the theme changes.
         let api_key_editors = [
             openai_api_key_editor.clone(),
+            openai_api_url_editor.clone(),
             anthropic_api_key_editor.clone(),
             google_api_key_editor.clone(),
         ];
@@ -7967,6 +7979,7 @@ impl ApiKeysWidget {
 
         Self {
             openai_api_key_editor,
+            openai_api_url_editor,
             anthropic_api_key_editor,
             google_api_key_editor,
 
@@ -8032,6 +8045,13 @@ impl ApiKeysWidget {
             appearance,
             "OpenAI API key",
             self.openai_api_key_editor.clone(),
+            is_enabled,
+            app,
+        ));
+        column.add_child(self.render_api_key_input(
+            appearance,
+            "OpenAI API base URL (optional)",
+            self.openai_api_url_editor.clone(),
             is_enabled,
             app,
         ));

--- a/crates/ai/src/api_keys.rs
+++ b/crates/ai/src/api_keys.rs
@@ -35,6 +35,7 @@ pub struct ApiKeys {
     pub google: Option<String>,
     pub anthropic: Option<String>,
     pub openai: Option<String>,
+    pub openai_api_url: Option<String>,
     pub open_router: Option<String>,
     pub custom_endpoints: Vec<CustomEndpoint>,
 }
@@ -258,6 +259,12 @@ impl ApiKeyManager {
         self.write_keys_to_secure_storage(ctx);
     }
 
+    pub fn set_openai_api_url(&mut self, url: Option<String>, ctx: &mut ModelContext<Self>) {
+        self.keys.openai_api_url = url;
+        ctx.emit(ApiKeyManagerEvent::KeysUpdated);
+        self.write_keys_to_secure_storage(ctx);
+    }
+
     pub fn set_open_router_key(&mut self, key: Option<String>, ctx: &mut ModelContext<Self>) {
         self.keys.open_router = key;
         ctx.emit(ApiKeyManagerEvent::KeysUpdated);
@@ -392,35 +399,67 @@ impl ApiKeyManager {
     pub fn custom_model_providers_for_request(
         &self,
         include_custom_models: bool,
+        is_byo_enabled: bool,
+        openai_models: Vec<String>,
     ) -> Option<api::request::settings::CustomModelProviders> {
-        if !include_custom_models {
-            return None;
+        let mut providers = Vec::new();
+
+        if include_custom_models {
+            let custom_providers = self
+                .keys
+                .custom_endpoints
+                .iter()
+                .filter(|endpoint| !endpoint.url.trim().is_empty() && !endpoint.api_key.is_empty())
+                .map(
+                    |endpoint| api::request::settings::custom_model_providers::CustomModelProvider {
+                        base_url: endpoint.url.clone(),
+                        api_key: endpoint.api_key.clone(),
+                        models: endpoint
+                            .models
+                            .iter()
+                            .filter(|m| !m.name.trim().is_empty() && !m.config_key.is_empty())
+                            .map(
+                                |m| api::request::settings::custom_model_providers::CustomModel {
+                                    slug: m.name.clone(),
+                                    config_key: m.config_key.clone(),
+                                },
+                            )
+                            .collect(),
+                    },
+                )
+                .filter(|provider| !provider.models.is_empty());
+            providers.extend(custom_providers);
         }
 
-        let providers: Vec<_> = self
-            .keys
-            .custom_endpoints
-            .iter()
-            .filter(|endpoint| !endpoint.url.trim().is_empty() && !endpoint.api_key.is_empty())
-            .map(
-                |endpoint| api::request::settings::custom_model_providers::CustomModelProvider {
-                    base_url: endpoint.url.clone(),
-                    api_key: endpoint.api_key.clone(),
-                    models: endpoint
-                        .models
-                        .iter()
-                        .filter(|m| !m.name.trim().is_empty() && !m.config_key.is_empty())
-                        .map(
-                            |m| api::request::settings::custom_model_providers::CustomModel {
-                                slug: m.name.clone(),
-                                config_key: m.config_key.clone(),
-                            },
-                        )
-                        .collect(),
-                },
-            )
-            .filter(|provider| !provider.models.is_empty())
-            .collect();
+        if is_byo_enabled {
+            if let Some(ref custom_url) = self.keys.openai_api_url {
+                let trimmed_url = custom_url.trim();
+                if !trimmed_url.is_empty() {
+                    if let Some(ref api_key) = self.keys.openai {
+                        if !api_key.trim().is_empty() {
+                            let models: Vec<_> = openai_models
+                                .into_iter()
+                                .map(|model_id| {
+                                    api::request::settings::custom_model_providers::CustomModel {
+                                        slug: model_id.clone(),
+                                        config_key: model_id,
+                                    }
+                                })
+                                .collect();
+                            if !models.is_empty() {
+                                providers.push(
+                                    api::request::settings::custom_model_providers::CustomModelProvider {
+                                        base_url: trimmed_url.to_owned(),
+                                        api_key: api_key.clone(),
+                                        models,
+                                    },
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
         if providers.is_empty() {
             None

--- a/crates/ai/src/api_keys_tests.rs
+++ b/crates/ai/src/api_keys_tests.rs
@@ -126,6 +126,22 @@ fn serde_round_trip_empty() {
 fn serde_round_trip_with_provider_keys() {
     let keys = ApiKeys {
         openai: Some("sk-openai".into()),
+        openai_api_url: None,
+        anthropic: Some("sk-ant-abc".into()),
+        google: Some("AIzaSy123".into()),
+        open_router: Some("sk-or-xxx".into()),
+        custom_endpoints: vec![],
+    };
+    let json = serde_json::to_string(&keys).unwrap();
+    let deser: ApiKeys = serde_json::from_str(&json).unwrap();
+    assert_eq!(keys, deser);
+}
+
+#[test]
+fn serde_round_trip_with_openai_api_url() {
+    let keys = ApiKeys {
+        openai: Some("sk-openai".into()),
+        openai_api_url: Some("https://api.githubcopilot.com".into()),
         anthropic: Some("sk-ant-abc".into()),
         google: Some("AIzaSy123".into()),
         open_router: Some("sk-or-xxx".into()),
@@ -140,6 +156,7 @@ fn serde_round_trip_with_provider_keys() {
 fn serde_round_trip_with_custom_endpoints() {
     let keys = ApiKeys {
         openai: None,
+        openai_api_url: None,
         anthropic: None,
         google: None,
         open_router: None,
@@ -211,6 +228,7 @@ fn provider_key_count_zero_when_empty() {
 fn provider_key_count_counts_each_provider_key() {
     let keys = ApiKeys {
         openai: Some("sk-o".into()),
+        openai_api_url: None,
         anthropic: Some("sk-a".into()),
         google: Some("AIza".into()),
         open_router: Some("sk-or".into()),
@@ -223,6 +241,7 @@ fn provider_key_count_counts_each_provider_key() {
 fn provider_key_count_ignores_blank_keys_and_endpoints() {
     let keys = ApiKeys {
         openai: Some("sk-o".into()),
+        openai_api_url: None,
         anthropic: Some("   ".into()),
         google: None,
         open_router: None,
@@ -238,7 +257,7 @@ fn provider_key_count_ignores_blank_keys_and_endpoints() {
 #[test]
 fn custom_model_providers_none_when_empty() {
     let mgr = make_manager(ApiKeys::default());
-    assert!(mgr.custom_model_providers_for_request(true).is_none());
+    assert!(mgr.custom_model_providers_for_request(true, true, vec![]).is_none());
 }
 
 #[test]
@@ -247,7 +266,7 @@ fn custom_model_providers_none_when_byo_disabled() {
         custom_endpoints: vec![endpoint("ep", "https://a.io", "k", &[("m", None)])],
         ..Default::default()
     });
-    assert!(mgr.custom_model_providers_for_request(false).is_none());
+    assert!(mgr.custom_model_providers_for_request(false, true, vec![]).is_none());
 }
 
 #[test]
@@ -261,7 +280,7 @@ fn custom_model_providers_populates_single_endpoint() {
         )],
         ..Default::default()
     });
-    let result = mgr.custom_model_providers_for_request(true).unwrap();
+    let result = mgr.custom_model_providers_for_request(true, true, vec![]).unwrap();
     assert_eq!(result.providers.len(), 1);
     let p = &result.providers[0];
     assert_eq!(p.base_url, "https://custom.io/v1");
@@ -293,7 +312,7 @@ fn multiple_endpoints_all_serialize() {
         ],
         ..Default::default()
     });
-    let result = mgr.custom_model_providers_for_request(true).unwrap();
+    let result = mgr.custom_model_providers_for_request(true, true, vec![]).unwrap();
     assert_eq!(result.providers.len(), 2);
     assert_eq!(result.providers[0].base_url, "https://a.io");
     assert_eq!(result.providers[0].models[0].config_key, "uuid-a");
@@ -310,7 +329,7 @@ fn byok_disabled_returns_none_even_with_endpoints() {
         custom_endpoints: vec![endpoint("ep", "https://a.io", "k", &[("m", None)])],
         ..Default::default()
     });
-    assert!(mgr.custom_model_providers_for_request(false).is_none());
+    assert!(mgr.custom_model_providers_for_request(true, false, vec![]).is_none());
 }
 
 #[test]
@@ -322,7 +341,7 @@ fn empty_api_key_endpoints_are_skipped() {
         ],
         ..Default::default()
     });
-    let result = mgr.custom_model_providers_for_request(true).unwrap();
+    let result = mgr.custom_model_providers_for_request(true, true, vec![]).unwrap();
     assert_eq!(result.providers.len(), 1);
     assert_eq!(result.providers[0].base_url, "https://b.io");
 }
@@ -338,7 +357,38 @@ fn endpoints_with_only_empty_models_are_skipped() {
         )],
         ..Default::default()
     });
-    assert!(mgr.custom_model_providers_for_request(true).is_none());
+    assert!(mgr.custom_model_providers_for_request(true, true, vec![]).is_none());
+}
+
+#[test]
+fn custom_model_providers_includes_openai_override() {
+    let mgr = make_manager(ApiKeys {
+        openai: Some("sk-openai".to_string()),
+        openai_api_url: Some("https://api.githubcopilot.com".to_string()),
+        ..Default::default()
+    });
+    let result = mgr
+        .custom_model_providers_for_request(true, true, vec!["gpt-4o".to_string()])
+        .unwrap();
+    assert_eq!(result.providers.len(), 1);
+    let p = &result.providers[0];
+    assert_eq!(p.base_url, "https://api.githubcopilot.com");
+    assert_eq!(p.api_key, "sk-openai");
+    assert_eq!(p.models.len(), 1);
+    assert_eq!(p.models[0].slug, "gpt-4o");
+    assert_eq!(p.models[0].config_key, "gpt-4o");
+}
+
+#[test]
+fn custom_model_providers_excludes_openai_override_when_byo_disabled() {
+    let mgr = make_manager(ApiKeys {
+        openai: Some("sk-openai".to_string()),
+        openai_api_url: Some("https://api.githubcopilot.com".to_string()),
+        ..Default::default()
+    });
+    assert!(mgr
+        .custom_model_providers_for_request(true, false, vec!["gpt-4o".to_string()])
+        .is_none());
 }
 
 // ── display_label fallback ─────────────────────────────────────


### PR DESCRIPTION
## Description
This PR adds support for configuring a custom OpenAI base URL under the Bring Your Own Key (BYOK) settings in the AI settings page. 

Currently, BYOK is limited to the default OpenAI endpoint (`api.openai.com`). By introducing this custom base URL configuration, users can route standard OpenAI models (like `gpt-4o`) to custom OpenAI-compatible endpoints—such as GitHub Copilot (`https://api.githubcopilot.com`), regional endpoints, or local proxies—directly from the built-in model picker.

## Linked Issue
Closes https://github.com/warpdotdev/warp/issues/12251

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Added unit tests in `crates/ai/src/api_keys_tests.rs`:
- `serde_round_trip_with_openai_api_url` to verify serialization and deserialization of the new `openai_api_url` field.
- `custom_model_providers_includes_openai_override` to verify that custom model providers correctly inject and route the OpenAI models when the custom base URL is enabled.
- `custom_model_providers_excludes_openai_override_when_byo_disabled` to verify the security boundary remains intact when BYOK is disabled.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Add support for custom base URL configuration to OpenAI Bring Your Own Key (BYOK) settings, enabling third-party OpenAI-compatible endpoints like GitHub Copilot.