### PR TITLE
Make pane dragging group aware for htabs

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -1769,17 +1769,29 @@ impl<'a> TabComponent<'a> {
         )
         .finish();
 
-        // Grouped member: inset rounded highlight, no side dividers, no
-        // drop target (members can't be dragged currently).
+        // Grouped member: inset rounded highlight, no side dividers. It still
+        // gets its own drop target so a dragged pane can land at this member's
+        // slot (and the member highlights while hovered).
         if self.grouped_member {
             let highlight = Container::new(stack)
                 .with_background(background_color)
                 .with_corner_radius(CornerRadius::with_all(Radius::Pixels(8.0)))
                 .finish();
-            return Container::new(highlight)
+            let member = Container::new(highlight)
                 .with_vertical_padding(3.)
                 .with_horizontal_padding(3.)
                 .finish();
+            return if self.for_drag_ghost {
+                member
+            } else {
+                DropTarget::new(
+                    member,
+                    TabBarDropTargetData {
+                        tab_bar_location: TabBarLocation::TabIndex(self.tab_index),
+                    },
+                )
+                .finish()
+            };
         }
 
         let mut tab = Container::new(stack)

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -19697,8 +19697,7 @@ impl Workspace {
                 let tab = &self.tabs[idx];
                 let effective_color = self.effective_tab_color(tab);
                 // Highlight the member when a drag is hovering directly over it.
-                let is_drag_target =
-                    self.hovered_tab_index == Some(TabBarHoverIndex::OverTab(idx));
+                let is_drag_target = self.hovered_tab_index == Some(TabBarHoverIndex::OverTab(idx));
                 let member = TabComponent::new(
                     idx,
                     tab_bar_state,
@@ -19716,7 +19715,11 @@ impl Workspace {
                 row.add_child(member);
             }
             // Divider after the last member (into the group's last slot).
-            if show_before_indicator(self.hovered_tab_index, first_index + run_len, Some(group.id)) {
+            if show_before_indicator(
+                self.hovered_tab_index,
+                first_index + run_len,
+                Some(group.id),
+            ) {
                 row.add_child(self.render_tab_hover_indicator(appearance));
             }
         }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -19689,15 +19689,23 @@ impl Workspace {
             // instead, dragging the whole group rather than orphaning it.
             let is_sole_member = group_has_single_member(&self.tabs, group.id);
             for idx in member_range {
+                // Insertion divider before this member when a pane drop lands
+                // here (into the group at `idx`).
+                if show_before_indicator(self.hovered_tab_index, idx, Some(group.id)) {
+                    row.add_child(self.render_tab_hover_indicator(appearance));
+                }
                 let tab = &self.tabs[idx];
                 let effective_color = self.effective_tab_color(tab);
+                // Highlight the member when a drag is hovering directly over it.
+                let is_drag_target =
+                    self.hovered_tab_index == Some(TabBarHoverIndex::OverTab(idx));
                 let member = TabComponent::new(
                     idx,
                     tab_bar_state,
                     tab,
                     self.tab_rename_editor.clone(),
                     close_button_position,
-                    false,
+                    is_drag_target,
                     ctx,
                 )
                 .with_effective_color(effective_color)
@@ -19706,6 +19714,10 @@ impl Workspace {
                 .build()
                 .finish();
                 row.add_child(member);
+            }
+            // Divider after the last member (into the group's last slot).
+            if show_before_indicator(self.hovered_tab_index, first_index + run_len, Some(group.id)) {
+                row.add_child(self.render_tab_hover_indicator(appearance));
             }
         }
 
@@ -19758,6 +19770,34 @@ impl Workspace {
             Container::new(container)
                 .with_background_color(theme.background().into_solid_bias_top_color())
                 .finish()
+        } else {
+            container
+        };
+
+        // While a pane is being dragged, the whole group is a drop target.
+        // Members also carry their own, smaller targets, so the framework's
+        // smallest-area hit-test lets a member win wherever they overlap; this
+        // group target effectively just covers the header and the flex spacers
+        // on either side of the members.
+        //
+        // `tab_bar_location` is the input to the shared drag hit-testing, not a
+        // fixed landing slot. `TabIndex(first)` makes the resolver hit-test
+        // the first member's geometry against the cursor, then lets the
+        // workspace (which can see the group's rect) decide whether the drop is
+        // before the group or into it, and at which slot. A collapsed group has
+        // no visible members to drop between, so it uses `AfterTabIndex(first)`,
+        // which resolves straight to "before the group" with no hit-testing.
+        //
+        // (A drop over the trailing spacer resolves toward the group's front via
+        // `first`; in practice the last member's smaller target wins there, so
+        // it's a harmless fallback.)
+        let container = if vertical_tabs::any_workspace_pane_being_dragged(self, ctx) {
+            let tab_bar_location = if is_collapsed {
+                TabBarLocation::AfterTabIndex(first_index)
+            } else {
+                TabBarLocation::TabIndex(first_index)
+            };
+            DropTarget::new(container, TabBarDropTargetData { tab_bar_location }).finish()
         } else {
             container
         };
@@ -20702,6 +20742,11 @@ impl Workspace {
                         first_index,
                         run_len,
                     } => {
+                        // Ungrouped insertion just before the group; a drop into
+                        // the group highlights the group itself instead.
+                        if show_before_indicator(self.hovered_tab_index, *first_index, None) {
+                            tab_bar.add_child(self.render_tab_hover_indicator(appearance));
+                        }
                         // Filtered above; the group must exist in `tab_groups`.
                         let group = self.tab_groups[group_id].clone();
                         tab_bar.add_child(self.render_horizontal_tab_group(
@@ -28340,11 +28385,11 @@ impl Workspace {
     }
 
     /// Resolves the tab group a `BeforeTab` insertion lands in, using the drag
-    /// cursor, for the vertical tabs panel. The header computes the bare
+    /// cursor, for whichever tab bar is active. The header computes the bare
     /// before/over/after from the hovered row's geometry; this fills in the
     /// group from the workspace's own tab-group geometry (which the header can't
-    /// see) and clamps ungrouped insertions out of the pinned region. `OverTab`,
-    /// and any drag over the horizontal bar, are returned unchanged.
+    /// see) and clamps ungrouped insertions out of the pinned region. `OverTab`
+    /// is returned unchanged.
     fn refine_hovered_tab_index(
         &self,
         hovered: TabBarHoverIndex,
@@ -28354,13 +28399,11 @@ impl Workspace {
         let TabBarHoverIndex::BeforeTab { index, .. } = hovered else {
             return hovered;
         };
-        // Group-aware resolution + pinned clamping are scoped to the vertical
-        // tabs panel; the horizontal bar keeps its existing behavior.
-        if !uses_vertical_tabs(ctx) {
-            return hovered;
-        }
+        // Resolve the group along whichever axis the active tab bar uses, then
+        // clamp ungrouped insertions out of the pinned region below.
+        let is_vertical = uses_vertical_tabs(ctx);
         let group = if FeatureFlag::GroupedTabs.is_enabled() {
-            self.insertion_group(index, drag_position.center().y(), ctx)
+            self.insertion_group(index, drag_position.center(), is_vertical, ctx)
         } else {
             None
         };
@@ -28376,15 +28419,16 @@ impl Workspace {
     }
 
     /// Returns the expanded tab group a `BeforeTab` insertion at `index` should
-    /// join in the vertical tabs panel, based on the drag cursor's Y against the
-    /// group's saved container rect. Collapsed groups are excluded (you can't
-    /// drop into one). "Before the group" is only the leading half of the
-    /// header; the in-group zone runs to the group's trailing edge so the last
-    /// slot is easy to hit.
+    /// join, based on the drag cursor against the group's saved container rect
+    /// along the active axis (Y for the vertical panel, X for the horizontal
+    /// bar). Collapsed groups are excluded (you can't drop into one). "Before
+    /// the group" is only the leading half of the header; the in-group zone runs
+    /// to the group's trailing edge so the last slot is easy to hit.
     fn insertion_group(
         &self,
         index: usize,
-        cursor_y: f32,
+        cursor: Vector2F,
+        is_vertical: bool,
         ctx: &mut ViewContext<Self>,
     ) -> Option<TabGroupId> {
         for (group_id, group) in &self.tab_groups {
@@ -28398,20 +28442,35 @@ impl Workspace {
             if index < first || index > last + 1 {
                 continue;
             }
-            let Some(group_rect) = ctx.element_position_by_id(vtab_group_position_id(*group_id))
-            else {
+            let position_id = if is_vertical {
+                vtab_group_position_id(*group_id)
+            } else {
+                htab_group_position_id(*group_id)
+            };
+            let Some(group_rect) = ctx.element_position_by_id(position_id) else {
                 continue;
             };
-            let group_start = group_rect.min_y();
-            let group_end = group_rect.max_y();
+            // Project the group rect and cursor onto the active axis.
+            let (group_start, group_end, cursor_pos) = if is_vertical {
+                (group_rect.min_y(), group_rect.max_y(), cursor.y())
+            } else {
+                (group_rect.min_x(), group_rect.max_x(), cursor.x())
+            };
             // "Before the group" is the leading half of the header (before the
-            // first member's top edge); everything past that, to the group's
-            // bottom edge, joins the group.
+            // first member's leading edge); everything past that, to the group's
+            // trailing edge, joins the group.
             let in_group_start = ctx
                 .element_position_by_id(tab_position_id(first))
-                .map(|first_rect| (group_start + first_rect.min_y()) / 2.)
+                .map(|first_rect| {
+                    let first_start = if is_vertical {
+                        first_rect.min_y()
+                    } else {
+                        first_rect.min_x()
+                    };
+                    (group_start + first_start) / 2.
+                })
                 .unwrap_or(group_start);
-            if cursor_y >= in_group_start && cursor_y <= group_end {
+            if cursor_pos >= in_group_start && cursor_pos <= group_end {
                 return Some(*group_id);
             }
         }

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -1272,7 +1272,7 @@ const COMPACT_ICON_SIZE: f32 = 16.;
 const GROUP_INSERTION_TARGET_HEIGHT: f32 = 6.;
 const GROUP_INSERTION_INDICATOR_HEIGHT: f32 = 3.;
 
-fn any_workspace_pane_being_dragged(workspace: &Workspace, app: &AppContext) -> bool {
+pub(super) fn any_workspace_pane_being_dragged(workspace: &Workspace, app: &AppContext) -> bool {
     workspace
         .tabs
         .iter()


### PR DESCRIPTION
## Description

Group-aware pane dragging worked in the vertical tabs panel but not the horizontal tab bar.This PR extends it to the horizontal bar so panes can be dropped into any position of a group, as well as directly before/after a group.

## How it works

Most of the heavy lifting for this PR was done by the [vtabs equivalent. ](https://github.com/warpdotdev/warp/pull/13056)

This PR adds the insertion strip between grouped tabs, at the end of the tab group (within it) and right before the tab group (outside of it). This insertion strip is the highlight showing to the user where the pane will land, and is already exists between regular tabs. 

Additionally a drop target was added to the group container as well as individual members. 

Finally the `insertion_group()` helper function is updated so it accounts for both vertical and horizontal tab group geometry.


## Linked Issue

https://linear.app/warpdotdev/issue/APP-4754/fix-pane-window-drag-for-horizontal-tabs

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo before changes](https://www.loom.com/share/acb057c57b7f41d49d4f95b7d04451f0)

[Demo after changes](https://www.loom.com/share/1f3b7e7c23574476926cf6faa619bb2a)