### PR TITLE
Add ai_access field to onboarding_slides_completed telemetry

### DIFF
--- a/crates/onboarding/src/model.rs
+++ b/crates/onboarding/src/model.rs
@@ -740,12 +740,13 @@ impl OnboardingStateModel {
     }
 
     fn send_completion_telemetry(&self, ctx: &mut ModelContext<Self>) {
-        let (intention, model, autonomy) = match &self.intention {
-            OnboardingIntention::Terminal => (self.intention.to_string(), None, None),
+        let (intention, model, autonomy, ai_access) = match &self.intention {
+            OnboardingIntention::Terminal => (self.intention.to_string(), None, None, None),
             OnboardingIntention::AgentDrivenDevelopment => (
                 self.intention.to_string(),
                 Some(self.agent_settings.selected_model_id.to_string()),
                 self.agent_settings.autonomy.map(|x| x.to_string()),
+                Some(self.ai_setup_choice.to_string()),
             ),
         };
 
@@ -760,6 +761,7 @@ impl OnboardingStateModel {
                 model,
                 autonomy,
                 has_project_path,
+                ai_access,
             },
             ctx
         );

--- a/crates/onboarding/src/telemetry.rs
+++ b/crates/onboarding/src/telemetry.rs
@@ -20,6 +20,9 @@ pub enum OnboardingEvent {
         model: Option<String>,
         autonomy: Option<String>,
         has_project_path: bool,
+        /// How the user is accessing AI when intention is agent_driven:
+        /// "warp_agent" or "third_party". None when intention is not agent_driven.
+        ai_access: Option<String>,
     },
     /// The user clicked the "Get Started" button.
     GetStartedClicked,
@@ -87,11 +90,13 @@ impl TelemetryEvent for OnboardingEvent {
                 model,
                 autonomy,
                 has_project_path,
+                ai_access,
             } => Some(json!({
                 "intention": intention,
                 "model": model,
                 "autonomy": autonomy,
                 "has_project_path": has_project_path,
+                "ai_access": ai_access,
             })),
             OnboardingEvent::GetStartedClicked => None,
             OnboardingEvent::FolderSelectionStarted => None,


### PR DESCRIPTION
## Description

Adds an `ai_access` field to the `onboarding_slides_completed` telemetry event so we can track how users intend to access AI during onboarding.

**Values:**
- `"warp_agent"` — user chose Warp Agent (the default path)
- `"third_party"` — user chose to bring their own agent/client
- `null` — user's intention was not `agent_driven` (terminal mode)

The value is derived from the existing `AiSetupChoice` enum. No new state is introduced; the field is populated by `ai_setup_choice` when the intention is `agent_driven`, and `None` otherwise.

**Example payload after this change:**
```json
{"intention":"agent_driven","model":"auto-genius","autonomy":"partial","has_project_path":false,"ai_access":"warp_agent"}
```

## Linked Issue

N/A — telemetry instrumentation requested via Slack (#data channel).

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

Verified `cargo check` and `cargo clippy` pass with no warnings.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

_Conversation: https://staging.warp.dev/conversation/26a7f1fe-b1d1-4810-95af-45affcf1df72_
_Run: https://oz.staging.warp.dev/runs/019f04a5-a37f-71f1-a4ab-8d7c816f7359_

_This PR was generated with [Oz](https://warp.dev/oz)._
