### PR TITLE
Rendering updates to tab groups in pane view

### DIFF
--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -3059,11 +3059,23 @@ fn render_grouped_tab_container(
             padding = padding.with_bottom(TAB_GROUP_CONTENT_INSET);
         }
 
-        Container::new(content.finish())
+        let mut container = Container::new(content.finish())
             .with_padding(padding)
-            .with_background(background)
-            .with_corner_radius(CornerRadius::with_all(Radius::Pixels(ROW_CORNER_RADIUS)))
-            .finish()
+            .with_background(background);
+        if needs_outer_horizontal_padding {
+            // Pane view: match regular tab containers — flat corners with a top
+            // divider (plus a bottom divider when this is the last item) rather
+            // than a rounded card.
+            container = container.with_border(
+                Border::new(1.)
+                    .with_sides(true, false, last_member_after_index.is_some(), false)
+                    .with_border_fill(internal_colors::fg_overlay_1(theme)),
+            );
+        } else {
+            container = container
+                .with_corner_radius(CornerRadius::with_all(Radius::Pixels(ROW_CORNER_RADIUS)));
+        }
+        container.finish()
     })
     // Right-click on group chrome (not member rows) opens the group menu.
     .on_right_click(move |ctx, _, position| {


### PR DESCRIPTION
## Description

Two small UI fixes for tab groups in the vertical tabs panel's **Panes** view, so a group reads as a first-class list item — visually consistent with regular (ungrouped) tab containers:
- Group containers now render with **flat corners** instead of a rounded card.
- Group containers now get the same **divider lines** that separate regular tabs (a top divider always, plus a bottom divider when the group is the last item in the list).

## How it works

Basic rendering changes to tab groups when in pane view. Prevents rounded corners and adds a divider above like regular tabs do in pane view (also adds separator below when its the last item).

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4781/vtab-group-small-ui-fixes

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo before](https://www.loom.com/share/bc3419a7c9ad44af979fe9885ae18e87)

[Demo after ](https://www.loom.com/share/97f1d3b1218c43398368f2b9367389cf)