### PR TITLE
Collapsing htab groups gives flex to remaining tab bar items

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -20607,33 +20607,9 @@ impl Workspace {
             }
         }
 
-        // Trailing spacer fills leftover width, and re-adds the flex each
-        // collapsed group gives up vs expanded (its members + 2 spacers), so the
-        // bar's total flex stays constant across collapse/expand and headers
-        // don't move.
-        let collapsed_group_flex_giveback: f32 = if FeatureFlag::GroupedTabs.is_enabled() {
-            self.tab_groups
-                .values()
-                .filter(|group| group.collapsed)
-                .map(|group| {
-                    let members = self
-                        .tabs
-                        .iter()
-                        .filter(|tab| tab.group_id == Some(group.id))
-                        .count();
-                    if members == 0 {
-                        0.0
-                    } else {
-                        members as f32 + 2.0 * Self::GROUP_EDGE_SPACER_FLEX
-                    }
-                })
-                .sum()
-        } else {
-            0.0
-        };
-        tab_bar.add_child(
-            Shrinkable::new(0.5 + collapsed_group_flex_giveback, Empty::new().finish()).finish(),
-        );
+        // Trailing spacer fills only the leftover width. When groups are collapsed
+        // the freed flex is distributed accross the remaining flex items in the tab bar.
+        tab_bar.add_child(Shrinkable::new(0.5, Empty::new().finish()).finish());
 
         self.add_configurable_right_side_tab_bar_controls(
             &mut tab_bar,


### PR DESCRIPTION
## Description

When a horizontal tab group collapses, give the space it frees back to the other tabs so they grow to fill it (Chrome-style), instead of parking that space at the end of the bar.

## How it works

In `render_tab_bar_contents`, removed the `collapsed_group_flex_giveback` that re-added each collapsed group's freed flex (its members + 2 edge spacers) to the trailing spacer. The trailing spacer is now just `Shrinkable::new(0.5, …)`, so when a collapsed group drops from `header + members + 2 spacers` of flex down to a single header slot, the freed flex redistributes across the remaining flex children — the other tabs widen to reclaim it.

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4788/give-back-flex-to-other-tabs-when-a-tab-group-is-collapsed

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

[Demo of before](https://www.loom.com/share/6f6226b5583643bba1501cfb053f154b)

[Demo of after](https://www.loom.com/share/c270e24984654594a3072bae636668e1)