### PR TITLE
Run tab-level commands from launch config URIs

### DIFF
--- a/app/src/launch_configs/launch_config.rs
+++ b/app/src/launch_configs/launch_config.rs
@@ -183,8 +183,49 @@ pub struct TabTemplate {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub title: Option<String>,
     pub layout: PaneTemplateType,
+    #[serde(skip_serializing, default)]
+    pub commands: Vec<CommandTemplate>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub color: Option<AnsiColorIdentifier>,
+}
+
+impl TabTemplate {
+    pub fn layout_with_tab_commands(&self) -> PaneTemplateType {
+        let mut layout = self.layout.clone();
+        if !self.commands.is_empty() {
+            layout.add_commands_to_startup_pane(self.commands.clone());
+        }
+        layout
+    }
+}
+
+impl PaneTemplateType {
+    fn add_commands_to_startup_pane(&mut self, tab_commands: Vec<CommandTemplate>) -> bool {
+        match self {
+            PaneTemplateType::PaneTemplate { commands, .. } => {
+                commands.extend(tab_commands);
+                true
+            }
+            PaneTemplateType::PaneBranchTemplate { panes, .. } => {
+                if let Some(focused_pane) = panes.iter_mut().find(|pane| pane.is_focused_pane()) {
+                    focused_pane.add_commands_to_startup_pane(tab_commands)
+                } else if let Some(first_pane) = panes.first_mut() {
+                    first_pane.add_commands_to_startup_pane(tab_commands)
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    fn is_focused_pane(&self) -> bool {
+        match self {
+            PaneTemplateType::PaneTemplate { is_focused, .. } => is_focused.unwrap_or_default(),
+            PaneTemplateType::PaneBranchTemplate { panes, .. } => {
+                panes.iter().any(Self::is_focused_pane)
+            }
+        }
+    }
 }
 
 impl TryFrom<TabSnapshot> for TabTemplate {
@@ -195,6 +236,7 @@ impl TryFrom<TabSnapshot> for TabTemplate {
         Ok(Self {
             title: snapshot.custom_title,
             layout: snapshot.root.try_into()?,
+            commands: Vec::new(),
             color,
         })
     }
@@ -246,6 +288,7 @@ pub fn make_mock_single_window_launch_config() -> LaunchConfig {
                         pane_mode: PaneMode::Terminal,
                         shell: None,
                     },
+                    commands: Vec::new(),
                     color: None,
                 },
                 TabTemplate {
@@ -257,6 +300,7 @@ pub fn make_mock_single_window_launch_config() -> LaunchConfig {
                         pane_mode: PaneMode::Terminal,
                         shell: None,
                     },
+                    commands: Vec::new(),
                     color: None,
                 },
             ],

--- a/app/src/launch_configs/launch_config_tests.rs
+++ b/app/src/launch_configs/launch_config_tests.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::{LaunchConfig, PaneMode, PaneTemplateType};
+use super::{CommandTemplate, LaunchConfig, PaneMode, PaneTemplateType};
 use crate::app_state::{
     AppState, BranchSnapshot, LeafContents, LeafSnapshot, NotebookPaneSnapshot, PaneFlex,
     PaneNodeSnapshot, SplitDirection, TabSnapshot, TerminalPaneSnapshot, WindowSnapshot,
@@ -224,6 +224,85 @@ fn test_config_from_snapshot_filters_tabs() {
 
     let template = LaunchConfig::from_snapshot("Test".into(), &state);
     assert!(template.windows[0].tabs.is_empty())
+}
+
+#[test]
+fn test_tab_level_commands_are_applied_to_leaf_layout() {
+    let config: LaunchConfig = serde_yaml::from_str(
+        r#"
+name: Legacy Commands
+windows:
+  - tabs:
+      - layout:
+          cwd: /tmp
+        commands:
+          - exec: echo hello
+"#,
+    )
+    .expect("launch config should parse");
+
+    let layout = config.windows[0].tabs[0].layout_with_tab_commands();
+
+    assert_eq!(
+        layout,
+        PaneTemplateType::PaneTemplate {
+            cwd: PathBuf::from("/tmp"),
+            commands: vec![CommandTemplate {
+                exec: "echo hello".to_string()
+            }],
+            is_focused: None,
+            pane_mode: PaneMode::Terminal,
+            shell: None,
+        }
+    );
+}
+
+#[test]
+fn test_tab_level_commands_are_applied_to_focused_pane_in_branch_layout() {
+    let config: LaunchConfig = serde_yaml::from_str(
+        r#"
+name: Legacy Commands
+windows:
+  - tabs:
+      - layout:
+          split_direction: horizontal
+          panes:
+            - cwd: /tmp/left
+              is_focused: false
+            - cwd: /tmp/right
+              is_focused: true
+        commands:
+          - exec: echo focused
+"#,
+    )
+    .expect("launch config should parse");
+
+    let layout = config.windows[0].tabs[0].layout_with_tab_commands();
+
+    assert_eq!(
+        layout,
+        PaneTemplateType::PaneBranchTemplate {
+            split_direction: SplitDirection::Horizontal.into(),
+            panes: vec![
+                PaneTemplateType::PaneTemplate {
+                    cwd: PathBuf::from("/tmp/left"),
+                    commands: vec![],
+                    is_focused: Some(false),
+                    pane_mode: PaneMode::Terminal,
+                    shell: None,
+                },
+                PaneTemplateType::PaneTemplate {
+                    cwd: PathBuf::from("/tmp/right"),
+                    commands: vec![CommandTemplate {
+                        exec: "echo focused".to_string()
+                    }],
+                    is_focused: Some(true),
+                    pane_mode: PaneMode::Terminal,
+                    shell: None,
+                },
+            ],
+        }
+    );
 }
 
 #[test]

--- a/app/src/launch_configs/launch_config_tests.rs
+++ b/app/src/launch_configs/launch_config_tests.rs
@@ -306,6 +306,52 @@ windows:
 }
 
 #[test]
+fn test_tab_level_commands_are_applied_to_first_pane_without_focused_pane() {
+    let config: LaunchConfig = serde_yaml::from_str(
+        r#"
+name: Legacy Commands
+windows:
+  - tabs:
+      - layout:
+          split_direction: horizontal
+          panes:
+            - cwd: /tmp/left
+            - cwd: /tmp/right
+        commands:
+          - exec: echo first
+"#,
+    )
+    .expect("launch config should parse");
+
+    let layout = config.windows[0].tabs[0].layout_with_tab_commands();
+
+    assert_eq!(
+        layout,
+        PaneTemplateType::PaneBranchTemplate {
+            split_direction: SplitDirection::Horizontal.into(),
+            panes: vec![
+                PaneTemplateType::PaneTemplate {
+                    cwd: PathBuf::from("/tmp/left"),
+                    commands: vec![CommandTemplate {
+                        exec: "echo first".to_string()
+                    }],
+                    is_focused: None,
+                    pane_mode: PaneMode::Terminal,
+                    shell: None,
+                },
+                PaneTemplateType::PaneTemplate {
+                    cwd: PathBuf::from("/tmp/right"),
+                    commands: vec![],
+                    is_focused: None,
+                    pane_mode: PaneMode::Terminal,
+                    shell: None,
+                },
+            ],
+        }
+    );
+}
+
+#[test]
 fn test_config_with_active_tab_index() {
     let state = multi_tab_snapshot(
         1,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -3812,7 +3812,7 @@ impl Workspace {
             .enumerate()
             .for_each(|(tab_index, tab_template)| {
                 self.add_tab_with_pane_layout(
-                    PanesLayout::Template(tab_template.layout.clone()),
+                    PanesLayout::Template(tab_template.layout_with_tab_commands()),
                     Arc::new(HashMap::new()),
                     tab_template.title.clone(),
                     ctx,

--- a/crates/integration/src/test/launch_configs.rs
+++ b/crates/integration/src/test/launch_configs.rs
@@ -182,6 +182,7 @@ pub fn test_launch_config_single_child_branch() -> Builder {
                             shell: None,
                         }],
                     },
+                    commands: Vec::new(),
                     color: None,
                 }],
             }],
@@ -311,6 +312,7 @@ pub fn test_with_launch_config_with_active_tab_index() -> Builder {
                                 shell: None,
                             }],
                         },
+                        commands: Vec::new(),
                         color: None,
                     };
                     3
@@ -390,6 +392,7 @@ pub fn test_with_launch_config_with_active_pane() -> Builder {
                             },
                         ],
                     },
+                    commands: Vec::new(),
                     color: None,
                 }],
             }],
@@ -468,6 +471,7 @@ pub fn test_with_launch_config_with_no_active_pane() -> Builder {
                             },
                         ],
                     },
+                    commands: Vec::new(),
                     color: None,
                 }],
             }],


### PR DESCRIPTION
## Description
Launch configuration tabs can include a top-level `commands:` block. When opening a launch config through `warp://launch/<name>`, Warp preserved the tab layout/cwd but dropped those tab-level commands because only pane-level commands were applied to the pane layout.

This normalizes tab-level commands into the startup pane before opening the tab. For split layouts, commands are applied to the focused pane, falling back to the first pane if no pane is focused.

## Linked Issue
Closes #9007

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing
- [x] I have manually tested my changes locally with `./script/run`

Automated:
- `cargo fmt`
- `cargo test -p warp launch_config --lib`
- `cargo check -p warp --lib`
- `cargo check -p integration`
- `cargo clippy -p warp --tests -- -D warnings`

Manual:
- Before: master opens `warposs://launch/warptest`, but `cat /tmp/warp-9007-uri-command.txt` reports no such file.
- After: this branch opens the same URI and automatically runs `echo after > /tmp/warp-9007-uri-command.txt`; `cat` prints `after`.
- Multi-pane: this branch opens a split-pane launch config and runs the tab-level command in the focused pane; `cat /tmp/warp-9007-uri-multipane-command.txt` prints `multipane-after`.

### Screenshots / Videos
- Before: https://github.com/user-attachments/assets/e74a4f8c-1f8e-4121-ae34-e279542f2ba2
- After: https://github.com/user-attachments/assets/38f650bd-ce5b-409d-963c-7272a527238c
- Multi-pane: https://github.com/user-attachments/assets/88f6a72e-7bea-466d-a9a9-10a76f12523d

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed launch configuration tab-level commands not running when opened through `warp://launch/<name>`.
