### PR TITLE
Add command palette action to write heap profile to disk

### DIFF
--- a/app/src/profiling.rs
+++ b/app/src/profiling.rs
@@ -61,6 +61,27 @@ pub fn dump_dhat_heap_profile() {
     let _ = HEAP_PROFILER.lock().take();
 }
 
+/// Writes a heap profile to disk and returns the generated path.
+pub async fn dump_heap_profile_to_disk() -> anyhow::Result<std::path::PathBuf> {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "dhat_heap_profiling")] {
+            let path = heap_profile_path();
+            dump_dhat_heap_profile();
+            Ok(path)
+        } else if #[cfg(feature = "heap_usage_tracking")] {
+            use anyhow::Context as _;
+
+            let path = heap_profile_path();
+            let profile_data = dump_jemalloc_heap_profile_inner().await?;
+            std::fs::write(&path, profile_data)
+                .with_context(|| format!("Failed to write heap profile to {}", path.display()))?;
+            Ok(path)
+        } else {
+            anyhow::bail!("heap profiling is not enabled in this build");
+        }
+    }
+}
+
 /// Dumps a jemalloc heap profile and sends it to Sentry.
 ///
 /// On Linux the profile is produced in-process via the `jemalloc_pprof` crate
@@ -195,9 +216,15 @@ fn pprof_binary_path() -> anyhow::Result<std::path::PathBuf> {
 }
 
 /// Returns the path at which heap profiles will be written.
-#[cfg(feature = "dhat_heap_profiling")]
+#[cfg(any(feature = "dhat_heap_profiling", feature = "heap_usage_tracking"))]
 pub fn heap_profile_path() -> std::path::PathBuf {
-    profile_output_dir().join("dhat-heap.json")
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "dhat_heap_profiling")] {
+            profile_output_dir().join("dhat-heap.json")
+        } else {
+            profile_output_dir().join("heap-profile.pb")
+        }
+    }
 }
 
 /// Uninitializes the profiling subsystem, writing reports to disk as-needed.
@@ -229,7 +256,11 @@ fn write_pprof_report(report: pprof::Report) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(any(feature = "dhat_heap_profiling", feature = "pprof_cpu_profiling"))]
+#[cfg(any(
+    feature = "dhat_heap_profiling",
+    feature = "heap_usage_tracking",
+    feature = "pprof_cpu_profiling"
+))]
 fn profile_output_dir() -> std::path::PathBuf {
     cfg_if::cfg_if! {
         if #[cfg(feature = "release_bundle")] {

--- a/app/src/profiling.rs
+++ b/app/src/profiling.rs
@@ -73,7 +73,7 @@ pub async fn dump_heap_profile_to_disk() -> anyhow::Result<std::path::PathBuf> {
 
             let path = heap_profile_path();
             let profile_data = dump_jemalloc_heap_profile_inner().await?;
-            std::fs::write(&path, profile_data)
+            async_fs::write(&path, profile_data).await
                 .with_context(|| format!("Failed to write heap profile to {}", path.display()))?;
             Ok(path)
         } else {

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -405,8 +405,7 @@ pub enum WorkspaceAction {
     /// An action only registered in dev and local builds, which triggers a
     /// panic immediately when called.
     Panic,
-    /// Stops the heap profiler (if one is running) and writes the profiling
-    /// data to disk.
+    /// Writes a heap profile to disk.
     DumpHeapProfile,
     ShowAIAssistantWarmWelcome,
     ClickedAIAssistantWarmWelcome,

--- a/app/src/workspace/mod.rs
+++ b/app/src/workspace/mod.rs
@@ -286,11 +286,11 @@ pub fn init(app: &mut AppContext) {
     )
     .with_context_predicate(id!("Workspace"))]);
 
-    #[cfg(feature = "dhat_heap_profiling")]
+    #[cfg(any(feature = "dhat_heap_profiling", feature = "heap_usage_tracking"))]
     {
         app.register_editable_bindings([EditableBinding::new(
             "workspace:dump_heap_profile",
-            "Dump heap profile (can only be done once)",
+            "Write heap profile to disk",
             WorkspaceAction::DumpHeapProfile,
         )
         .with_context_predicate(id!("Workspace"))]);

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -2770,6 +2770,28 @@ impl Workspace {
         });
     }
 
+    fn show_heap_profile_result(
+        &mut self,
+        result: anyhow::Result<PathBuf>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let toast = match result {
+            Ok(path) => {
+                ctx.open_file_path_in_explorer(&path);
+                DismissibleToast::success(format!("Wrote heap profile to {}", path.display()))
+                    .with_link(
+                        ToastLink::new("Show in file explorer".to_string())
+                            .with_onclick_action(WorkspaceAction::OpenInExplorer { path }),
+                    )
+            }
+            Err(err) => DismissibleToast::error(format!("Failed to write heap profile: {err:#}")),
+        };
+
+        self.toast_stack.update(ctx, |toast_stack, ctx| {
+            toast_stack.add_ephemeral_toast(toast, ctx)
+        });
+    }
+
     fn on_tips_model_changed(
         &mut self,
         _: ModelHandle<TipsCompleted>,
@@ -24426,8 +24448,12 @@ impl TypedActionView for Workspace {
                 panic!("WorkspaceAction::Panic triggered from command palette");
             }
             DumpHeapProfile => {
-                #[cfg(feature = "dhat_heap_profiling")]
-                crate::profiling::dump_dhat_heap_profile();
+                ctx.spawn(
+                    crate::profiling::dump_heap_profile_to_disk(),
+                    |me, result, ctx| {
+                        me.show_heap_profile_result(result, ctx);
+                    },
+                );
             }
             OpenViewTreeDebugWindow => {
                 let window_id = ctx.window_id();


### PR DESCRIPTION
## Description
Adds a command palette action for profiling-enabled builds that writes a heap profile to disk.

For `heap_usage_tracking` builds, the action writes `heap-profile.pb` using the existing jemalloc pprof dump path. For `dhat_heap_profiling` builds, it preserves the existing `dhat-heap.json` behavior. The action opens the containing folder and shows a success or error toast.

## Linked Issue
Closes #9752

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo fmt`
- [x] `cargo check -p warp --tests`
- [x] `cargo check -p warp --tests --features heap_usage_tracking`
- [x] `cargo clippy -p warp --tests --features heap_usage_tracking -- -D warnings`
- [x] `cargo build --bin warp-oss --features heap_usage_tracking`
- [x] Manual smoke test with `target/debug/warp-oss` built using `--features heap_usage_tracking`: opened the command palette, ran `Write heap profile to disk`, confirmed the containing folder opened and `heap-profile.pb` was written locally.
- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Command palette action:

<img width="820" height="104" alt="warp-13107-command-palette" src="https://github.com/user-attachments/assets/1d737957-8926-44db-9137-10cb36bf066d" />


Success toast after writing `heap-profile.pb`:

<img width="900" height="130" alt="warp-13107-success-toast" src="https://github.com/user-attachments/assets/547a4244-8532-40cf-91bd-e5dac9762f75" />


## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Add a command palette action to write a heap profile to disk.
