### PR TITLE
Fix wasm crashes when viewing conversation search tool calls.

### DIFF
--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -2705,9 +2705,13 @@ impl AIConversation {
                             }
                         }
                         Some(api::message::Message::ToolCallResult(tcr)) => {
-                            // Clean up temp directories from conversation search subagents.
-                            if let Some(api::message::tool_call_result::Result::Subagent(_)) =
-                                &tcr.result
+                            // Shared-session viewers do not own temp directories created by
+                            // conversation search subagents.
+                            if !self.is_viewing_shared_session
+                                && matches!(
+                                    &tcr.result,
+                                    Some(api::message::tool_call_result::Result::Subagent(_))
+                                )
                             {
                                 cleanup_conversation_search_temp_dir(
                                     &tcr.tool_call_id,


### PR DESCRIPTION
## Description

Session-sharing viewers receive the sharing session's conversation-search subagent results, including paths to temporary directories created by the sharing session. Viewers were treating those replicated results as locally owned cleanup state and calling `cleanup_conversation_search_temp_dir`. On WASM, deriving the local cleanup base directory calls `std::env::temp_dir()`, which panics because the platform has no filesystem.

Skip conversation-search temp-directory cleanup when applying client actions in a shared-session viewer. The sharing session still owns and cleans up its temporary directories normally. This also prevents native viewers from attempting to delete filesystem paths owned by another Warp instance.

## Linked Issue

- [Sentry: WARP-CLIENT-DEV-RDJ](https://warpdotdev.sentry.io/issues/WARP-CLIENT-DEV-RDJ/)

## Testing

- [x] `cargo fmt --package warp -- --check`
- [x] `cargo check -p warp --lib`
- [x] Symbolicated the exact staged WASM crash and confirmed the failing path is shared-session client-action processing → conversation-search cleanup → `std::env::temp_dir()`.
- [ ] Manually tested the shared-session conversation-search flow. Not performed; the change was validated from the exact-release stack trace and compile checks.

No automated test was added because this is a simple ownership guard and reproducing the regression requires a WASM shared-session viewer receiving a completed conversation-search subagent result.

### Screenshots / Videos

N/A — no visual changes.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed a crash when viewing shared sessions that used conversation search.

Co-Authored-By: Oz <oz-agent@warp.dev>
