### PR TITLE
Update htab group pinning behavior for new layout

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -55,7 +55,7 @@ use crate::workspace::{
 use crate::BlocklistAIHistoryModel;
 
 pub const TAB_BAR_BORDER_HEIGHT: f32 = 1.0;
-const TAB_INDICATOR_HEIGHT: f32 = 14.0;
+pub(crate) const TAB_INDICATOR_HEIGHT: f32 = 14.0;
 
 /// Label for the tab right-click menu's "Move to group" submenu parent.
 pub const MOVE_TO_GROUP_LABEL: &str = "Move to group";
@@ -77,7 +77,7 @@ pub(crate) const TAB_PIN_INDICATOR_ICON_SIZE: f32 = 16.0;
 const TAB_INDICATOR_SYNCED_COLOR: u32 = 0x4A93FFFF;
 
 // Width threshold (in px) below which we render an icon-only tab
-const COMPACT_TAB_WIDTH_THRESHOLD: f32 = 42.0;
+pub(crate) const COMPACT_TAB_WIDTH_THRESHOLD: f32 = 42.0;
 // Horizontal inset for the tab close button
 const TAB_CLOSE_BUTTON_HORIZONTAL_INSET: f32 = 2.0;
 

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -19481,6 +19481,10 @@ impl Workspace {
     /// [Header (spacer)(tab1)(tab2)...(spacer)]
     const GROUP_EDGE_SPACER_FLEX: f32 = 0.06;
 
+    /// Upper bound on each edge spacer's rendered width, proportional to
+    /// tab's max width (tabs have flex 1 and max width of 200).
+    const GROUP_EDGE_SPACER_MAX_WIDTH: f32 = Self::GROUP_EDGE_SPACER_FLEX * 200.0;
+
     /// Renders a contiguous run of grouped tabs as one tab-bar slot: header
     /// + (when expanded) member tabs.
     #[allow(clippy::too_many_arguments)]
@@ -19528,9 +19532,16 @@ impl Workspace {
         );
 
         if !is_collapsed {
-            // Edge spacer before the first member (own flex slot, doesn't shrink tabs).
+            // Edge spacer before the first member (own flex slot, doesn't
+            // shrink tabs).
             row.add_child(
-                Expanded::new(Self::GROUP_EDGE_SPACER_FLEX, Empty::new().finish()).finish(),
+                Shrinkable::new(
+                    Self::GROUP_EDGE_SPACER_FLEX,
+                    ConstrainedBox::new(Empty::new().finish())
+                        .with_max_width(Self::GROUP_EDGE_SPACER_MAX_WIDTH)
+                        .finish(),
+                )
+                .finish(),
             );
             let close_button_position = if FeatureFlag::TabCloseButtonOnLeft.is_enabled() {
                 TabSettings::as_ref(ctx).close_button_position
@@ -19570,19 +19581,25 @@ impl Workspace {
             // Matching edge spacer after the last member. The trailing divider
             // lives inside this spacer's own flex slot (drawn at its right edge,
             // which is the group's far edge), so it doesn't steal width from the
-            // members the way a border on the group container would.
+            // members the way a border on the group container would. Same loose
+            // flex cap as the leading spacer so the group shrink-wraps instead
+            // of this spacer ballooning out toward the bar's trailing edge.
             row.add_child(
-                Expanded::new(
+                Shrinkable::new(
                     Self::GROUP_EDGE_SPACER_FLEX,
-                    Container::new(Empty::new().finish())
-                        .with_border(
-                            Border::all(1.)
-                                .with_sides(false, false, false, true)
-                                .with_border_fill(internal_colors::fg_overlay_1(
-                                    appearance.theme(),
-                                )),
-                        )
-                        .finish(),
+                    ConstrainedBox::new(
+                        Container::new(Empty::new().finish())
+                            .with_border(
+                                Border::all(1.)
+                                    .with_sides(false, false, false, true)
+                                    .with_border_fill(internal_colors::fg_overlay_1(
+                                        appearance.theme(),
+                                    )),
+                            )
+                            .finish(),
+                    )
+                    .with_max_width(Self::GROUP_EDGE_SPACER_MAX_WIDTH)
+                    .finish(),
                 )
                 .finish(),
             );

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -96,7 +96,7 @@ use warpui::elements::{
     Highlight, Hoverable, Icon as WarpUiIcon, Image, MainAxisAlignment, MainAxisSize,
     MouseInBehavior, MouseStateHandle, OffsetPositioning, ParentAnchor, ParentElement,
     ParentOffsetBounds, PositionedElementAnchor, PositionedElementOffsetBounds, Radius, Rect,
-    SavePosition, Shrinkable, Stack, Text,
+    SavePosition, Shrinkable, SizeConstraintCondition, SizeConstraintSwitch, Stack, Text,
 };
 use warpui::fonts::{Properties, Weight};
 use warpui::geometry::vector::{vec2f, Vector2F};
@@ -354,8 +354,8 @@ use crate::settings_view::{flags, SettingsSection, SettingsView, SettingsViewEve
 use crate::shell_indicator::ShellIndicatorType;
 use crate::tab::{
     tab_position_id, uses_vertical_tabs, NewSessionMenuItem, PaneNameMenuTarget, SelectedTabColor,
-    TabBarState, TabComponent, TabData, TabTelemetryAction, MOVE_TO_GROUP_LABEL,
-    TAB_BAR_BORDER_HEIGHT, TAB_PIN_INDICATOR_ICON_SIZE,
+    TabBarState, TabComponent, TabData, TabTelemetryAction, COMPACT_TAB_WIDTH_THRESHOLD,
+    MOVE_TO_GROUP_LABEL, TAB_BAR_BORDER_HEIGHT, TAB_INDICATOR_HEIGHT, TAB_PIN_INDICATOR_ICON_SIZE,
 };
 use crate::tab_configs::action_sidecar::SidecarItemKind;
 use crate::tab_configs::remove_confirmation_dialog::{
@@ -19667,8 +19667,6 @@ impl Workspace {
         let header_selected = is_collapsed && any_member_active;
 
         let member_kinds = self.compute_group_member_kinds(group.id, ctx);
-        let icon_circle =
-            render_group_member_icon_collage(&member_kinds, GROUP_ICON_COLLAGE_SIZE, appearance);
 
         let is_being_renamed = self
             .current_workspace_state
@@ -19695,21 +19693,56 @@ impl Workspace {
                 .finish()
         };
 
-        let mut row = Flex::row()
+        // Full header: collage + name, with the horizontal padding inside it so
+        // the size switch below measures the full slot width, like a tab.
+        let mut full_row = Flex::row()
             // Fill the slot and center the icon + title.
             .with_main_axis_size(MainAxisSize::Max)
             .with_main_axis_alignment(MainAxisAlignment::Center)
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_spacing(6.)
-            .with_child(icon_circle)
+            .with_child(render_group_member_icon_collage(
+                &member_kinds,
+                GROUP_ICON_COLLAGE_SIZE,
+                appearance,
+            ))
             .with_child(Shrinkable::new(1.0, name_element).finish());
         // Collapsed + pinned: pin indicator to the right of the name, where an
         // ungrouped tab would show its close button. Expanded groups show the
         // pin after their last member instead.
         if FeatureFlag::PinnedTabs.is_enabled() && group.pinned && is_collapsed {
-            row.add_child(render_horizontal_group_pin_indicator(appearance));
+            full_row.add_child(render_horizontal_group_pin_indicator(appearance));
         }
-        let row = row.finish();
+        let full_content = Container::new(full_row.finish())
+            .with_padding_left(8.)
+            .with_padding_right(if is_collapsed { 8. } else { 9. })
+            .finish();
+
+        // Compact header (narrow slot): just the collage at the tab's compact
+        // icon size, centered and clipped, like a tab dropping its title.
+        let compact_content = Clipped::new(
+            Flex::row()
+                .with_main_axis_size(MainAxisSize::Max)
+                .with_main_axis_alignment(MainAxisAlignment::Center)
+                .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                .with_child(render_group_member_icon_collage(
+                    &member_kinds,
+                    TAB_INDICATOR_HEIGHT,
+                    appearance,
+                ))
+                .finish(),
+        )
+        .finish();
+
+        // Go compact at the same width as a tab, so headers and tabs shrink in step.
+        let content = SizeConstraintSwitch::new(
+            full_content,
+            vec![(
+                SizeConstraintCondition::WidthLessThan(COMPACT_TAB_WIDTH_THRESHOLD),
+                compact_content,
+            )],
+        )
+        .finish();
 
         let header_active_bg = internal_colors::fg_overlay_2(theme);
         let header_hover_bg = internal_colors::fg_overlay_1(theme);
@@ -19723,13 +19756,10 @@ impl Workspace {
                 ElementFill::None
             };
 
-            // Tab-style border: left edge if first; right edge only when collapsed
-            // (the divider). Expanded, the divider moves to the container's far
-            // edge, so swap that 1px border for 1px right padding so the title
-            // doesn't shift.
-            Container::new(row)
-                .with_padding_left(8.)
-                .with_padding_right(if is_collapsed { 8. } else { 9. })
+            // Tab-style border: left edge if first, right edge only when
+            // collapsed (the divider). Expanded swaps that right border for
+            // padding so the title doesn't shift on collapse/expand.
+            Container::new(content)
                 .with_vertical_padding(6.)
                 .with_background(bg)
                 .with_border(

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -27798,9 +27798,15 @@ impl Workspace {
                 // Hop into the target group's contiguous block so the group
                 // stays one rendered container. Vertical tab rendering only
                 // groups consecutive tabs, so leaving `current_index` outside
-                // the block would split the group across the panel.
+                // the block would split the group across the panel. Land at the
+                // near edge: the front when entering from above/left, the end
+                // when entering from below/right.
                 if let Some((first, last)) = target_group_range {
-                    let insert_at = if current_index < first { first } else { last };
+                    let insert_at = if current_index < first {
+                        first - 1
+                    } else {
+                        last + 1
+                    };
                     if insert_at != current_index {
                         self.hop_tab_to_index(current_index, insert_at, ctx);
                     }
@@ -28011,17 +28017,20 @@ impl Workspace {
     }
 
     /// Returns the group whose saved container rect contains `cursor` along
-    /// the active axis, if any. A small edge margin at each end of the rect
-    /// is treated as "between groups" so the cursor can land in the
-    /// ungrouped zone between adjacent groups. `is_vertical` picks the
-    /// layout-correct `SavePosition` id and the axis to test along.
+    /// the active axis, if any. Small edge margins exist at each end of the rect
+    /// treated as "between groups" so the cursor can land in the ungrouped zone
+    /// between adjactent groups. The trailing edge margin is larger to account for
+    /// the group header, the leading edge margin makes dropping into the last position
+    /// of a group more reactive. `is_vertical` picks the layout-correct `SavePosition`
+    /// id and the axis to test along.
     fn target_group_at_axis(
         &self,
         cursor: f32,
         is_vertical: bool,
         ctx: &mut ViewContext<Self>,
     ) -> Option<TabGroupId> {
-        const EDGE_MARGIN: f32 = 6.0;
+        const LEADING_EDGE_MARGIN: f32 = 4.0;
+        const TRAILING_EDGE_MARGIN: f32 = 8.0;
         self.tab_groups.keys().copied().find(|group_id| {
             let id = if is_vertical {
                 vtab_group_position_id(*group_id)
@@ -28034,7 +28043,7 @@ impl Workspace {
                 } else {
                     (rect.min_x(), rect.max_x())
                 };
-                min + EDGE_MARGIN <= cursor && cursor <= max - EDGE_MARGIN
+                min + LEADING_EDGE_MARGIN <= cursor && cursor <= max - TRAILING_EDGE_MARGIN
             })
         })
     }
@@ -28071,13 +28080,40 @@ impl Workspace {
         ctx.element_position_by_id(tab_position_id(neighbor_index))
     }
 
+    /// Threshold rect for a group-drag swap against the neighbor at
+    /// `neighbor_index`. When that neighbor belongs to a group, the dragged
+    /// block hops past the whole neighbor group (see `move_group_block`), so
+    /// the swap must trigger on the whole group's rect rather than the single
+    /// adjacent member. Comparing against the near member instead causes flickering.
+    /// Falls back to the per-member rect when the group rect is missing.
+    fn group_swap_threshold_rect(
+        &self,
+        neighbor_index: usize,
+        is_vertical: bool,
+        ctx: &mut ViewContext<Self>,
+    ) -> Option<RectF> {
+        if let Some(group_id) = self.tabs.get(neighbor_index).and_then(|t| t.group_id) {
+            let id = if is_vertical {
+                vtab_group_position_id(group_id)
+            } else {
+                htab_group_position_id(group_id)
+            };
+            if let Some(rect) = ctx.element_position_by_id(id) {
+                return Some(rect);
+            }
+        }
+        self.neighbor_drag_rect(neighbor_index, is_vertical, ctx)
+    }
+
     /// Swaps the group's entire member block with its preceding/following
-    /// neighbor when the drag midpoint crosses the appropriate threshold on
-    /// the active axis. Per-axis thresholds match the per-tab swap logic:
-    /// vertical compares against the neighbor's midpoint (mirrors
-    /// `calculate_updated_tab_index_vertical`); horizontal compares against
-    /// the neighbor's leading/trailing edge (mirrors
-    /// `calculate_updated_tab_index`).
+    /// neighbor when the dragged group's center crosses a per-axis threshold.
+    ///
+    /// Vertical compares against the neighbor's midpoint. Horizontal compares
+    /// against the neighbor's near edge (matching per-tab dragging) except when
+    /// the neighbor is itself a group, where it uses the group's midpoint.
+    ///
+    /// Comparing against the group's midpoint prevents oscilation when the
+    /// neighbouring group is larger than the group being dragged.
     pub(crate) fn on_group_drag(
         &mut self,
         group_id: TabGroupId,
@@ -28097,24 +28133,23 @@ impl Workspace {
         } else {
             (position.min_x() + position.max_x()) / 2.
         };
-        // Threshold for swapping toward the start of the bar (compared
-        // against the previous neighbor's rect). Vertical uses the
-        // neighbor's midpoint; horizontal uses its trailing edge so the
-        // swap fires as soon as the drag midpoint crosses into the
-        // neighbor, matching the per-tab horizontal swap rule.
-        let swap_before_threshold = |rect: RectF| -> f32 {
+        // Horizontal swaps fire as soon as the dragged group's center reaches
+        // the neighbor's near edge (matching per-tab dragging), except when the
+        // neighbor is itself a group. Vertical always uses the midpoint.
+        let swap_before_threshold = |rect: RectF, neighbor_is_group: bool| -> f32 {
             if is_vertical {
                 (rect.min_y() + rect.max_y()) / 2.
+            } else if neighbor_is_group {
+                (rect.min_x() + rect.max_x()) / 2.
             } else {
                 rect.max_x()
             }
         };
-        // Threshold for swapping toward the end of the bar (compared
-        // against the next neighbor's rect). Vertical uses the neighbor's
-        // midpoint; horizontal uses its leading edge.
-        let swap_after_threshold = |rect: RectF| -> f32 {
+        let swap_after_threshold = |rect: RectF, neighbor_is_group: bool| -> f32 {
             if is_vertical {
                 (rect.min_y() + rect.max_y()) / 2.
+            } else if neighbor_is_group {
+                (rect.min_x() + rect.max_x()) / 2.
             } else {
                 rect.min_x()
             }
@@ -28125,8 +28160,9 @@ impl Workspace {
         // states do not match.
         if first > 0 && self.is_tab_effectively_pinned(&self.tabs[first - 1]) == group_pinned {
             let before_index = first - 1;
-            if let Some(rect) = self.neighbor_drag_rect(before_index, is_vertical, ctx) {
-                if midpoint_drag < swap_before_threshold(rect) {
+            let neighbor_is_group = self.tabs[before_index].group_id.is_some();
+            if let Some(rect) = self.group_swap_threshold_rect(before_index, is_vertical, ctx) {
+                if midpoint_drag < swap_before_threshold(rect, neighbor_is_group) {
                     let target = if let Some(other_gid) = self.tabs[before_index].group_id {
                         group_member_index_range(&self.tabs, other_gid)
                             .map(|(f, _)| f)
@@ -28149,8 +28185,9 @@ impl Workspace {
             && self.is_tab_effectively_pinned(&self.tabs[last + 1]) == group_pinned
         {
             let after_index = last + 1;
-            if let Some(rect) = self.neighbor_drag_rect(after_index, is_vertical, ctx) {
-                if midpoint_drag > swap_after_threshold(rect) {
+            let neighbor_is_group = self.tabs[after_index].group_id.is_some();
+            if let Some(rect) = self.group_swap_threshold_rect(after_index, is_vertical, ctx) {
+                if midpoint_drag > swap_after_threshold(rect, neighbor_is_group) {
                     let after_block_last = if let Some(other_gid) = self.tabs[after_index].group_id
                     {
                         group_member_index_range(&self.tabs, other_gid)

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -19485,6 +19485,16 @@ impl Workspace {
     /// tab's max width (tabs have flex 1 and max width of 200).
     const GROUP_EDGE_SPACER_MAX_WIDTH: f32 = Self::GROUP_EDGE_SPACER_FLEX * 200.0;
 
+    /// Flex of the trailing slot when a group is pinned (it holds the divider
+    /// and the pin). Icon-width / compact-threshold, so the slot reaches the
+    /// icon size right as members go icon-only and the pin hides in step.
+    const GROUP_PIN_FLEX: f32 = TAB_PIN_INDICATOR_ICON_SIZE / COMPACT_TAB_WIDTH_THRESHOLD;
+    /// Cap on the pinned trailing slot, mirroring the edge spacer's cap.
+    const GROUP_PIN_MAX_WIDTH: f32 = Self::GROUP_PIN_FLEX * 200.0;
+    /// Trailing room on a collapsed pinned header so the name fades before the
+    /// right-justified pin overlay.
+    const GROUP_HEADER_PIN_RESERVED_WIDTH: f32 = 20.0;
+
     /// Renders a contiguous run of grouped tabs as one tab-bar slot: header
     /// + (when expanded) member tabs.
     #[allow(clippy::too_many_arguments)]
@@ -19571,24 +19581,38 @@ impl Workspace {
             }
         }
 
-        // Pinned + expanded: trailing pin indicator after the last member.
         let group_pinned = FeatureFlag::PinnedTabs.is_enabled() && group.pinned;
-        if group_pinned && !is_collapsed {
-            row.add_child(render_horizontal_group_pin_indicator(appearance));
-        }
 
         if !is_collapsed {
-            // Matching edge spacer after the last member. The trailing divider
-            // lives inside this spacer's own flex slot (drawn at its right edge,
-            // which is the group's far edge), so it doesn't steal width from the
-            // members the way a border on the group container would. Same loose
-            // flex cap as the leading spacer so the group shrink-wraps instead
-            // of this spacer ballooning out toward the bar's trailing edge.
+            // Trailing slot carrying the group's divider (right border at the
+            // group's far edge). When pinned it also holds the pin it reserves
+            // extra flex and hides once it is too narrow to render the icon.
+            let (trailing_flex, trailing_max, trailing_inner): (f32, f32, Box<dyn Element>) =
+                if group_pinned {
+                    (
+                        Self::GROUP_PIN_FLEX,
+                        Self::GROUP_PIN_MAX_WIDTH,
+                        SizeConstraintSwitch::new(
+                            Align::new(render_horizontal_group_pin_indicator(appearance)).finish(),
+                            vec![(
+                                SizeConstraintCondition::WidthLessThan(TAB_PIN_INDICATOR_ICON_SIZE),
+                                Empty::new().finish(),
+                            )],
+                        )
+                        .finish(),
+                    )
+                } else {
+                    (
+                        Self::GROUP_EDGE_SPACER_FLEX,
+                        Self::GROUP_EDGE_SPACER_MAX_WIDTH,
+                        Empty::new().finish(),
+                    )
+                };
             row.add_child(
                 Shrinkable::new(
-                    Self::GROUP_EDGE_SPACER_FLEX,
+                    trailing_flex,
                     ConstrainedBox::new(
-                        Container::new(Empty::new().finish())
+                        Container::new(trailing_inner)
                             .with_border(
                                 Border::all(1.)
                                     .with_sides(false, false, false, true)
@@ -19598,7 +19622,7 @@ impl Workspace {
                             )
                             .finish(),
                     )
-                    .with_max_width(Self::GROUP_EDGE_SPACER_MAX_WIDTH)
+                    .with_max_width(trailing_max)
                     .finish(),
                 )
                 .finish(),
@@ -19639,7 +19663,13 @@ impl Workspace {
         let group_flex = if is_collapsed {
             1.0
         } else {
-            1.0 + run_len as f32 + 2.0 * Self::GROUP_EDGE_SPACER_FLEX
+            // leading spacer + trailing slot (pin flex when pinned, else spacer).
+            let trailing_flex = if group_pinned {
+                Self::GROUP_PIN_FLEX
+            } else {
+                Self::GROUP_EDGE_SPACER_FLEX
+            };
+            1.0 + run_len as f32 + Self::GROUP_EDGE_SPACER_FLEX + trailing_flex
         };
         Shrinkable::new(group_flex, positioned_container).finish()
     }
@@ -19695,7 +19725,7 @@ impl Workspace {
 
         // Full header: collage + name, with the horizontal padding inside it so
         // the size switch below measures the full slot width, like a tab.
-        let mut full_row = Flex::row()
+        let full_row = Flex::row()
             // Fill the slot and center the icon + title.
             .with_main_axis_size(MainAxisSize::Max)
             .with_main_axis_alignment(MainAxisAlignment::Center)
@@ -19707,15 +19737,18 @@ impl Workspace {
                 appearance,
             ))
             .with_child(Shrinkable::new(1.0, name_element).finish());
-        // Collapsed + pinned: pin indicator to the right of the name, where an
-        // ungrouped tab would show its close button. Expanded groups show the
-        // pin after their last member instead.
-        if FeatureFlag::PinnedTabs.is_enabled() && group.pinned && is_collapsed {
-            full_row.add_child(render_horizontal_group_pin_indicator(appearance));
-        }
+        // Collapsed + pinned: the pin is a right-justified overlay (added at the
+        // end), not inline with the collage + name.
+        let header_pin = FeatureFlag::PinnedTabs.is_enabled() && group.pinned && is_collapsed;
         let full_content = Container::new(full_row.finish())
             .with_padding_left(8.)
-            .with_padding_right(if is_collapsed { 8. } else { 9. })
+            .with_padding_right(if header_pin {
+                8. + Self::GROUP_HEADER_PIN_RESERVED_WIDTH
+            } else if is_collapsed {
+                8.
+            } else {
+                9.
+            })
             .finish();
 
         // Compact header (narrow slot): just the collage at the tab's compact
@@ -19785,7 +19818,24 @@ impl Workspace {
                 anchor: TabContextMenuAnchor::Pointer(position),
             });
         });
-        header.finish()
+
+        let header = header.finish();
+        if header_pin {
+            // Right-justify the pin like a regular tab's close-button slot.
+            let mut stack = Stack::new().with_child(header);
+            stack.add_positioned_child(
+                render_horizontal_group_pin_indicator(appearance),
+                OffsetPositioning::offset_from_parent(
+                    vec2f(-8.0, 0.0),
+                    ParentOffsetBounds::ParentByPosition,
+                    ParentAnchor::MiddleRight,
+                    ChildAnchor::MiddleRight,
+                ),
+            );
+            stack.finish()
+        } else {
+            header
+        }
     }
 
     /// Returns up to 4 distinct pane-kind icons for the group's collage.
@@ -20623,7 +20673,14 @@ impl Workspace {
                     if members == 0 {
                         0.0
                     } else {
-                        members as f32 + 2.0 * Self::GROUP_EDGE_SPACER_FLEX
+                        // Pinned groups' trailing slot is the pin slot, not a spacer.
+                        let trailing_flex =
+                            if FeatureFlag::PinnedTabs.is_enabled() && group.pinned {
+                                Self::GROUP_PIN_FLEX
+                            } else {
+                                Self::GROUP_EDGE_SPACER_FLEX
+                            };
+                        members as f32 + Self::GROUP_EDGE_SPACER_FLEX + trailing_flex
                     }
                 })
                 .sum()

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -19473,6 +19473,14 @@ impl Workspace {
         .finish()
     }
 
+    /// Flex weight of the spacer on each side of an expanded group's members.
+    /// Flex (not fixed px) keeps it a separate slot, so members stay the same
+    /// width as ungrouped tabs and the group shrinks proportionally.
+    /// Approximately equal to 8px when tabs are 150px wide.
+    /// A tab group is now as follows:
+    /// [Header (spacer)(tab1)(tab2)...(spacer)]
+    const GROUP_EDGE_SPACER_FLEX: f32 = 0.06;
+
     /// Renders a contiguous run of grouped tabs as one tab-bar slot: header
     /// + (when expanded) member tabs.
     #[allow(clippy::too_many_arguments)]
@@ -19486,7 +19494,6 @@ impl Workspace {
         appearance: &Appearance,
         ctx: &AppContext,
     ) -> Box<dyn Element> {
-        let theme = appearance.theme();
         let is_collapsed = group.collapsed;
 
         let mouse_states = self
@@ -19501,16 +19508,30 @@ impl Workspace {
             && member_range.contains(&self.active_tab_index);
 
         let mut row = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
-        row.add_child(self.render_horizontal_tab_group_header(
-            group,
-            &mouse_states,
-            is_collapsed,
-            any_member_active,
-            appearance,
-            ctx,
-        ));
+        // Header fills one slot like a member tab capped at the same 200px as a tab.
+        row.add_child(
+            Shrinkable::new(
+                1.0,
+                ConstrainedBox::new(self.render_horizontal_tab_group_header(
+                    group,
+                    &mouse_states,
+                    is_collapsed,
+                    any_member_active,
+                    is_first_in_bar,
+                    appearance,
+                    ctx,
+                ))
+                .with_max_width(200.)
+                .finish(),
+            )
+            .finish(),
+        );
 
         if !is_collapsed {
+            // Edge spacer before the first member (own flex slot, doesn't shrink tabs).
+            row.add_child(
+                Expanded::new(Self::GROUP_EDGE_SPACER_FLEX, Empty::new().finish()).finish(),
+            );
             let close_button_position = if FeatureFlag::TabCloseButtonOnLeft.is_enabled() {
                 TabSettings::as_ref(ctx).close_button_position
             } else {
@@ -19545,19 +19566,30 @@ impl Workspace {
             row.add_child(render_horizontal_group_pin_indicator(appearance));
         }
 
-        // Additional padding on expanded groups,
-        // allowing tabs to be dropped into the last position of the group.
-        const EXPANDED_GROUP_TRAILING_PADDING: f32 = 8.;
-        let mut container = Container::new(row.finish()).with_border(
-            Border::all(1.)
-                // Left border only on the first slot to avoid double borders.
-                .with_sides(false, is_first_in_bar, false, true)
-                .with_border_fill(internal_colors::fg_overlay_1(theme)),
-        );
         if !is_collapsed {
-            container = container.with_padding_right(EXPANDED_GROUP_TRAILING_PADDING);
+            // Matching edge spacer after the last member. The trailing divider
+            // lives inside this spacer's own flex slot (drawn at its right edge,
+            // which is the group's far edge), so it doesn't steal width from the
+            // members the way a border on the group container would.
+            row.add_child(
+                Expanded::new(
+                    Self::GROUP_EDGE_SPACER_FLEX,
+                    Container::new(Empty::new().finish())
+                        .with_border(
+                            Border::all(1.)
+                                .with_sides(false, false, false, true)
+                                .with_border_fill(internal_colors::fg_overlay_1(
+                                    appearance.theme(),
+                                )),
+                        )
+                        .finish(),
+                )
+                .finish(),
+            );
         }
-        let container = container.finish();
+
+        // Collapsed groups draw their divider on the header instead.
+        let container = Container::new(row.finish()).finish();
 
         let group_id = group.id;
         let group_draggable_state = group.draggable_state.clone();
@@ -19583,25 +19615,28 @@ impl Workspace {
         let positioned_container =
             SavePosition::new(positioned_container, &htab_group_position_id(group_id)).finish();
 
-        // Flex = header + one per member so the group shrinks proportionally
-        // with sibling tabs. A collapsed group renders only its header, so it
-        // should claim a single slot's worth of flex.
+        // Flex = header + one per member + a spacer each side, so every tab is
+        // one slot wide. A collapsed group claims one slot; the flex it gives up
+        // is re-added to the bar's trailing spacer (see render_tab_bar_contents)
+        // so total flex stays constant and the header doesn't move.
         let group_flex = if is_collapsed {
             1.0
         } else {
-            1.0 + run_len as f32
+            1.0 + run_len as f32 + 2.0 * Self::GROUP_EDGE_SPACER_FLEX
         };
         Shrinkable::new(group_flex, positioned_container).finish()
     }
 
     /// Header (icon collage + name) for a horizontal tab group. Click
     /// toggles collapse; double-click renames; right-click opens the menu.
+    #[allow(clippy::too_many_arguments)]
     fn render_horizontal_tab_group_header(
         &self,
         group: &TabGroup,
         mouse_states: &HorizontalTabGroupMouseStates,
         is_collapsed: bool,
         any_member_active: bool,
+        is_first_in_bar: bool,
         appearance: &Appearance,
         ctx: &AppContext,
     ) -> Box<dyn Element> {
@@ -19634,23 +19669,23 @@ impl Workspace {
                 .name
                 .clone()
                 .unwrap_or_else(|| "New Group".to_string());
-            // Cap width so long names ellipsize and the tab bar's unbounded
-            // measurement stays finite.
-            ConstrainedBox::new(
-                Text::new_inline(title, font_family, 12.)
-                    .with_clip(ClipConfig::ellipsis())
-                    .with_color(main_text_color.into())
-                    .finish(),
-            )
-            .with_max_width(150.)
-            .finish()
+            // No inner cap: the name fills the header slot and fades like a tab
+            // title; the header's outer `ConstrainedBox` bounds the width and
+            // keeps the tab bar's unbounded measurement finite.
+            Text::new_inline(title, font_family, 12.)
+                .with_clip(ClipConfig::end())
+                .with_color(main_text_color.into())
+                .finish()
         };
 
         let mut row = Flex::row()
+            // Fill the slot and center the icon + title.
+            .with_main_axis_size(MainAxisSize::Max)
+            .with_main_axis_alignment(MainAxisAlignment::Center)
             .with_cross_axis_alignment(CrossAxisAlignment::Center)
             .with_spacing(6.)
             .with_child(icon_circle)
-            .with_child(name_element);
+            .with_child(Shrinkable::new(1.0, name_element).finish());
         // Collapsed + pinned: pin indicator to the right of the name, where an
         // ungrouped tab would show its close button. Expanded groups show the
         // pin after their last member instead.
@@ -19661,6 +19696,7 @@ impl Workspace {
 
         let header_active_bg = internal_colors::fg_overlay_2(theme);
         let header_hover_bg = internal_colors::fg_overlay_1(theme);
+        let header_border_fill = internal_colors::fg_overlay_1(theme);
         let mut header = Hoverable::new(mouse_states.header.clone(), move |state| {
             let bg: ElementFill = if header_selected {
                 header_active_bg.into()
@@ -19670,10 +19706,20 @@ impl Workspace {
                 ElementFill::None
             };
 
+            // Tab-style border: left edge if first; right edge only when collapsed
+            // (the divider). Expanded, the divider moves to the container's far
+            // edge, so swap that 1px border for 1px right padding so the title
+            // doesn't shift.
             Container::new(row)
-                .with_horizontal_padding(8.)
+                .with_padding_left(8.)
+                .with_padding_right(if is_collapsed { 8. } else { 9. })
                 .with_vertical_padding(6.)
                 .with_background(bg)
+                .with_border(
+                    Border::all(1.)
+                        .with_sides(false, is_first_in_bar, false, is_collapsed)
+                        .with_border_fill(header_border_fill),
+                )
                 .finish()
         })
         .with_cursor(Cursor::PointingHand)
@@ -20513,8 +20559,33 @@ impl Workspace {
             }
         }
 
-        // Placeholder to make sure the flex row expands across the entire width of the app.
-        tab_bar.add_child(Shrinkable::new(0.5, Empty::new().finish()).finish());
+        // Trailing spacer fills leftover width, and re-adds the flex each
+        // collapsed group gives up vs expanded (its members + 2 spacers), so the
+        // bar's total flex stays constant across collapse/expand and headers
+        // don't move.
+        let collapsed_group_flex_giveback: f32 = if FeatureFlag::GroupedTabs.is_enabled() {
+            self.tab_groups
+                .values()
+                .filter(|group| group.collapsed)
+                .map(|group| {
+                    let members = self
+                        .tabs
+                        .iter()
+                        .filter(|tab| tab.group_id == Some(group.id))
+                        .count();
+                    if members == 0 {
+                        0.0
+                    } else {
+                        members as f32 + 2.0 * Self::GROUP_EDGE_SPACER_FLEX
+                    }
+                })
+                .sum()
+        } else {
+            0.0
+        };
+        tab_bar.add_child(
+            Shrinkable::new(0.5 + collapsed_group_flex_giveback, Empty::new().finish()).finish(),
+        );
 
         self.add_configurable_right_side_tab_bar_controls(
             &mut tab_bar,
@@ -27743,16 +27814,17 @@ impl Workspace {
         let groups_enabled = FeatureFlag::GroupedTabs.is_enabled();
 
         if groups_enabled {
-            // Reassign membership when the dragged tab's midpoint enters a
-            // different expanded group. Collapsed groups are handled by the
-            // safety-net hop below so we don't drop into it.
+            // Reassign membership when the dragged tab enters a different
+            // expanded group. Collapsed groups are handled by the safety-net
+            // hop below so we don't drop into it.
             let midpoint_drag = if use_vertical_tabs {
                 (position.min_y() + position.max_y()) / 2.
             } else {
                 (position.min_x() + position.max_x()) / 2.
             };
-            let hovered_group = self.target_group_at_axis(midpoint_drag, use_vertical_tabs, ctx);
             let source_group = self.tabs[current_index].group_id;
+            let hovered_group =
+                self.target_group_at_axis(midpoint_drag, source_group, use_vertical_tabs, ctx);
             let expanded_target =
                 hovered_group.filter(|gid| !self.tab_groups.get(gid).is_some_and(|g| g.collapsed));
             // A pinned tab keeps its individual pin while dragging over a
@@ -28016,35 +28088,74 @@ impl Workspace {
         current_index
     }
 
-    /// Returns the group whose saved container rect contains `cursor` along
-    /// the active axis, if any. Small edge margins exist at each end of the rect
-    /// treated as "between groups" so the cursor can land in the ungrouped zone
-    /// between adjactent groups. The trailing edge margin is larger to account for
-    /// the group header, the leading edge margin makes dropping into the last position
-    /// of a group more reactive. `is_vertical` picks the layout-correct `SavePosition`
-    /// id and the axis to test along.
+    /// Returns the group the dragged tab is over along the active axis so it can
+    /// join it, or `None`. Vertical tabs inset both ends of the group rect by a
+    /// fixed margin (`LEADING_EDGE_MARGIN` / `TRAILING_EDGE_MARGIN`). Horizontal
+    /// tabs use the position of a dynamic spacer, since tab groups resize dynamically.
     fn target_group_at_axis(
         &self,
         cursor: f32,
+        source_group: Option<TabGroupId>,
         is_vertical: bool,
         ctx: &mut ViewContext<Self>,
     ) -> Option<TabGroupId> {
         const LEADING_EDGE_MARGIN: f32 = 4.0;
         const TRAILING_EDGE_MARGIN: f32 = 8.0;
+        // Fallback margin for a collapsed horizontal group (no members/spacer).
+        const EDGE_MARGIN: f32 = 6.0;
         self.tab_groups.keys().copied().find(|group_id| {
             let id = if is_vertical {
                 vtab_group_position_id(*group_id)
             } else {
                 htab_group_position_id(*group_id)
             };
-            ctx.element_position_by_id(id).is_some_and(|rect| {
-                let (min, max) = if is_vertical {
-                    (rect.min_y(), rect.max_y())
-                } else {
-                    (rect.min_x(), rect.max_x())
-                };
-                min + LEADING_EDGE_MARGIN <= cursor && cursor <= max - TRAILING_EDGE_MARGIN
-            })
+            let Some(rect) = ctx.element_position_by_id(id) else {
+                return false;
+            };
+
+            // Vertical tabs: fixed margin at each end of the group rect.
+            if is_vertical {
+                return rect.min_y() + LEADING_EDGE_MARGIN <= cursor
+                    && cursor <= rect.max_y() - TRAILING_EDGE_MARGIN;
+            }
+
+            // An expanded group has a flex spacer on each side of its members
+            // ([header][spacer][members][spacer]); the spacer is used to determine
+            // whether the dragging tab should land at the first/last position of the
+            // group, or just outside the group. The spacer is flex, so we fetch the
+            // the element position below to use it for our bounds calculations.
+            let collapsed = self
+                .tab_groups
+                .get(group_id)
+                .is_some_and(|group| group.collapsed);
+            // The edge of the last member is the right bound of the flex spacer.
+            let last_member_max_x = if collapsed {
+                None
+            } else {
+                group_member_index_range(&self.tabs, *group_id)
+                    .and_then(|(_, last)| ctx.element_position_by_id(tab_position_id(last)))
+                    .map(|last_rect| last_rect.max_x())
+            };
+
+            // Leading: start the accept zone a full spacer in from the header
+            // edge so joining a group from the left is deliberate. This makes
+            // dropping between groups easy.
+            let leading_inset = last_member_max_x
+                .map(|last_max_x| rect.max_x() - last_max_x)
+                .unwrap_or(EDGE_MARGIN);
+
+            // Trailing resolves two opposite needs. Your own group releases at
+            // its inner edge, so the trailing spacer is cushion before the cursor
+            // reaches the next tab (leaving doesn't instantly swap). Any other
+            // group accepts out to its outer edge, so dropping into its last slot
+            // stays easy.
+            let trailing = if Some(*group_id) == source_group {
+                last_member_max_x.unwrap_or(rect.max_x())
+            } else {
+                rect.max_x()
+            };
+
+            rect.min_x() + leading_inset <= cursor && cursor <= trailing
         })
     }
 

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -2988,9 +2988,13 @@ fn render_grouped_tab_container(
 
         // Pane view: uniform `GROUP_HORIZONTAL_PADDING` matches ungrouped-tab body padding.
         // Tab view: only apply bottom padding when expanded so a collapsed group has no trailing band.
+        // Expanded tab grou[s] have equal padding on the bottom and right edge.
         let mut padding = Padding::uniform(0.);
         if needs_outer_horizontal_padding {
             padding = Padding::uniform(GROUP_HORIZONTAL_PADDING);
+            if !is_collapsed {
+                padding = padding.with_bottom(GROUP_HORIZONTAL_PADDING + TAB_GROUP_CONTENT_INSET);
+            }
         } else if !is_collapsed {
             padding = padding.with_bottom(TAB_GROUP_CONTENT_INSET);
         }


### PR DESCRIPTION
## Description

Gotta think about this one 

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4790/tab-groups-pinned-state-needs-to-update-to-match-new-htab-pattern

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo before](https://www.loom.com/share/57da3b35f50444529ccb038d6295f314)

Demo after