### PR TITLE
Fix claude preflight commands preventing task status updates.

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -873,6 +873,12 @@ impl AgentDriver {
                 }
                 let result = Self::run_internal(task, foreground.clone()).await;
 
+                // Stop accepting CLI session status updates now that the run
+                // is done. Already accepted task updates remain queued until
+                // delivery finishes.
+                let _ = foreground
+                    .spawn(|me, ctx| me.unregister_cli_agent_task_sync(ctx))
+                    .await;
                 // Unregister the driver consumer now that the run is done.
                 // The streamer will tear down the SSE if no other consumer
                 // remains and the conversation isn't a child.
@@ -3454,6 +3460,14 @@ impl AgentDriver {
                 | CLIAgentSessionsModelEvent::InputSessionChanged { .. }
                 | CLIAgentSessionsModelEvent::Ended { .. } => {}
             });
+    }
+
+    /// Removes the task mapping registered for CLI agent session status updates.
+    fn unregister_cli_agent_task_sync(&self, ctx: &mut ModelContext<Self>) {
+        let terminal_view_id = self.terminal_driver.as_ref(ctx).terminal_view().id();
+        LocalAgentTaskSyncModel::handle(ctx).update(ctx, |model, _| {
+            model.unregister_cli_session(terminal_view_id);
+        });
     }
 
     /// Handle events re-emitted by the `TerminalDriver`.

--- a/app/src/ai/blocklist/local_agent_task_sync_model.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model.rs
@@ -132,6 +132,16 @@ impl LocalAgentTaskSyncModel {
         );
     }
 
+    /// Stops reporting CLI agent status changes for a completed driver run.
+    /// Task updates accepted before unregistration remain queued until delivery
+    /// finishes.
+    #[cfg_attr(target_family = "wasm", expect(dead_code))]
+    pub fn unregister_cli_session(&mut self, terminal_view_id: EntityId) {
+        if let Some(task_id) = self.cli_session_task_ids.remove(&terminal_view_id) {
+            self.update_queue.remove_task(&task_id);
+        }
+    }
+
     fn remove_queued_update_state_for_run_id(&mut self, run_id: Option<&str>) {
         let Some(task_id) = run_id.and_then(|run_id| run_id.parse::<AmbientAgentTaskId>().ok())
         else {

--- a/app/src/ai/blocklist/local_agent_task_sync_model.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model.rs
@@ -38,8 +38,10 @@ use crate::terminal::cli_agent_sessions::{
 /// a `terminal_view_id → task_id` mapping via `register_cli_session`.
 pub struct LocalAgentTaskSyncModel {
     ai_client: Arc<dyn AIClient>,
-    /// Maps terminal view IDs to task IDs for third-party harness sessions
-    /// that don't have conversations in `BlocklistAIHistoryModel`.
+    /// Maps terminal view IDs to task IDs for third-party harness runs that
+    /// don't have conversations in `BlocklistAIHistoryModel`. These mappings
+    /// live for the process-scoped `AgentDriver` run, which can span multiple
+    /// pane-scoped CLI agent sessions.
     cli_session_task_ids: HashMap<EntityId, AmbientAgentTaskId>,
     /// Serializes and coalesces model-owned updates independently per task.
     update_queue: LocalTaskUpdateQueue,
@@ -189,14 +191,12 @@ impl LocalAgentTaskSyncModel {
             } => {
                 self.on_cli_session_status_changed(*terminal_view_id, status, ctx);
             }
-            CLIAgentSessionsModelEvent::Ended {
-                terminal_view_id, ..
-            } => {
-                if let Some(task_id) = self.cli_session_task_ids.remove(terminal_view_id) {
-                    self.update_queue.remove_task(&task_id);
-                }
-            }
-            _ => {}
+            // Pane-scoped CLI agent sessions can end between preflight, the
+            // harness, and follow-ups, but the mapping belongs to the driver run.
+            CLIAgentSessionsModelEvent::Started { .. }
+            | CLIAgentSessionsModelEvent::InputSessionChanged { .. }
+            | CLIAgentSessionsModelEvent::Ended { .. }
+            | CLIAgentSessionsModelEvent::SessionUpdated { .. } => {}
         }
     }
 

--- a/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
@@ -19,7 +19,10 @@ use crate::ai::agent::{
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::llms::LLMId;
 use crate::server::server_api::ai::{AIClient, MockAIClient, TaskStatusUpdate};
-use crate::terminal::cli_agent_sessions::{CLIAgentSessionStatus, CLIAgentSessionsModel};
+use crate::terminal::cli_agent_sessions::{
+    CLIAgentSessionStatus, CLIAgentSessionsModel, CLIAgentSessionsModelEvent,
+};
+use crate::terminal::CLIAgent;
 
 /// Helper to assert a (state, Option<TaskStatusUpdate>) tuple.
 fn assert_update(
@@ -387,6 +390,56 @@ fn install_model_with_call_counter(
 /// that instantiate the model must register it first.
 fn register_cli_agent_sessions_model(app: &mut App) {
     app.add_singleton_model(|_| CLIAgentSessionsModel::new());
+}
+
+/// A pane-scoped CLI session can end during setup without ending the driver run.
+#[test]
+fn cli_task_mapping_survives_cli_session_end() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        let cli_sessions_model = app.add_singleton_model(|_| CLIAgentSessionsModel::new());
+        let succeeded_updates = Arc::new(AtomicUsize::new(0));
+        let succeeded_updates_for_mock = succeeded_updates.clone();
+        let mut mock = MockAIClient::new();
+        mock.expect_update_agent_task()
+            .returning(move |_, task_state, _, _, _| {
+                if task_state == Some(AgentTaskState::Succeeded) {
+                    succeeded_updates_for_mock.fetch_add(1, Ordering::SeqCst);
+                }
+                Ok(())
+            });
+        let ai_client: Arc<dyn AIClient> = Arc::new(mock);
+        let model = app.add_singleton_model(|ctx| {
+            LocalAgentTaskSyncModel::new_with_ai_client_for_test(ai_client, ctx)
+        });
+        let terminal_view_id = warpui::EntityId::new();
+
+        model.update(&mut app, |model, ctx| {
+            model.register_cli_session(terminal_view_id, fixed_task_id(), ctx);
+        });
+        cli_sessions_model.update(&mut app, |_, ctx| {
+            ctx.emit(CLIAgentSessionsModelEvent::Ended {
+                terminal_view_id,
+                agent: CLIAgent::Claude,
+            });
+        });
+        cli_sessions_model.update(&mut app, |_, ctx| {
+            ctx.emit(CLIAgentSessionsModelEvent::StatusChanged {
+                terminal_view_id,
+                agent: CLIAgent::Claude,
+                status: CLIAgentSessionStatus::Success,
+                session_context: Box::default(),
+            });
+        });
+
+        pump_spawned_tasks().await;
+
+        assert_eq!(
+            succeeded_updates.load(Ordering::SeqCst),
+            1,
+            "a pane-scoped session ending must not prevent the driver run from reporting success"
+        );
+    });
 }
 
 #[test]

--- a/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
@@ -392,7 +392,8 @@ fn register_cli_agent_sessions_model(app: &mut App) {
     app.add_singleton_model(|_| CLIAgentSessionsModel::new());
 }
 
-/// A pane-scoped CLI session can end during setup without ending the driver run.
+/// A pane-scoped CLI session can end during setup without ending the driver run,
+/// while explicit driver cleanup prevents later status updates.
 #[test]
 fn cli_task_mapping_survives_cli_session_end() {
     App::test((), |mut app| async move {
@@ -431,13 +432,24 @@ fn cli_task_mapping_survives_cli_session_end() {
                 session_context: Box::default(),
             });
         });
+        model.update(&mut app, |model, _| {
+            model.unregister_cli_session(terminal_view_id);
+        });
+        cli_sessions_model.update(&mut app, |_, ctx| {
+            ctx.emit(CLIAgentSessionsModelEvent::StatusChanged {
+                terminal_view_id,
+                agent: CLIAgent::Claude,
+                status: CLIAgentSessionStatus::Success,
+                session_context: Box::default(),
+            });
+        });
 
         pump_spawned_tasks().await;
 
         assert_eq!(
             succeeded_updates.load(Ordering::SeqCst),
             1,
-            "a pane-scoped session ending must not prevent the driver run from reporting success"
+            "the accepted success must drain, but a status emitted after unregister must be ignored"
         );
     });
 }


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Claude Code cloud agents register their terminal-view-to-task mapping before running the `claude auth status --json` preflight command. If that command is detected as a pane-scoped CLI agent session, its `Ended` event removes the mapping before the actual Claude harness starts. The real harness can then report `Success` and update the pane icon, but the task sync model no longer knows which server task to update.

Keep the task mapping for the process-scoped `AgentDriver` run instead of tying it to individual pane-scoped CLI agent sessions. This allows preflight commands and follow-up sessions to end without preventing later status updates. A regression test covers an incidental `Ended` event followed by `Success` and verifies that `Succeeded` is still uploaded.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
N/A

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] `rustfmt --check` on the changed Rust files
- [x] `git diff --check`
- [x] `cargo nextest run -p warp -E 'test(cli_task_mapping_survives_cli_session_end)'`
- [x] `cargo check -p warp`
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

N/A — task lifecycle synchronization change with no UI changes.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- [Agent conversation](https://staging.warp.dev/conversation/c90defcb-277e-4613-b2ff-bfe10c002332)

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->

CHANGELOG-BUG-FIX: Fixed Claude Code cloud agents not reporting successful completion.

