### PR TITLE
perf(ai): O(1) exchange_with_id via exchange_id_index

### DIFF
--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -631,6 +631,7 @@ impl AIConversation {
                 task.reassign_exchange_ids();
             });
         }
+        self.task_store.rebuild_exchange_id_index();
     }
 
     pub fn is_viewing_shared_session(&self) -> bool {

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -1447,12 +1447,7 @@ impl AIConversation {
 
     #[cfg_attr(target_family = "wasm", allow(unused))]
     pub fn exchange_with_id(&self, exchange_id: AIAgentExchangeId) -> Option<&AIAgentExchange> {
-        for task in self.task_store.tasks() {
-            if let Some(exchange) = task.exchanges().find(|exchange| exchange.id == exchange_id) {
-                return Some(exchange);
-            }
-        }
-        None
+        self.task_store.exchange_by_id(exchange_id)
     }
 
     /// Returns the exchange that preceded the exchange with the given id, if there is one.

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -186,6 +186,35 @@ fn title_falls_back_to_initial_query_when_root_description_is_empty() {
 }
 
 #[test]
+fn reassign_exchange_ids_keeps_exchange_lookup_consistent() {
+    let mut conversation = restored_conversation_with_queries(&["one", "two"]);
+
+    let old_ids: Vec<_> = conversation.all_exchanges().iter().map(|e| e.id).collect();
+    assert!(!old_ids.is_empty());
+
+    // Pre-condition: every original id resolves via the exchange-id index.
+    for id in &old_ids {
+        assert!(conversation.exchange_with_id(*id).is_some());
+    }
+
+    conversation.reassign_exchange_ids();
+
+    // Reassigning regenerates ids without changing the exchange count, so
+    // `modify_task` does not rebuild the index; correctness relies on the
+    // explicit `rebuild_exchange_id_index()` call. The stale ids must be gone.
+    for id in &old_ids {
+        assert!(conversation.exchange_with_id(*id).is_none());
+    }
+
+    // Every current id resolves via the rebuilt index.
+    let new_ids: Vec<_> = conversation.all_exchanges().iter().map(|e| e.id).collect();
+    assert_eq!(new_ids.len(), old_ids.len());
+    for id in &new_ids {
+        assert!(conversation.exchange_with_id(*id).is_some());
+    }
+}
+
+#[test]
 fn restored_conversation_defaults_autoexecute_override_when_not_persisted() {
     let _flag = FeatureFlag::RememberFastForwardState.override_enabled(true);
     let conversation_data: AgentConversationData =

--- a/app/src/ai/agent/task_store.rs
+++ b/app/src/ai/agent/task_store.rs
@@ -20,8 +20,7 @@ pub struct TaskStore {
     root_task_id: TaskId,
     tasks: HashMap<TaskId, Task>,
     linearized_refs: Vec<ExchangeRef>,
-    /// Map from exchange ID to its position in `linearized_refs` for faster lookup.
-    exchange_id_index: HashMap<AIAgentExchangeId, usize>,
+    exchange_id_index: HashMap<AIAgentExchangeId, ExchangeRef>,
     /// If the root task was upgraded from an optimistic (client-generated) ID
     /// to a server-assigned ID, stores the original optimistic ID so that
     /// deferred event handlers referencing the stale ID can still resolve
@@ -157,8 +156,29 @@ impl TaskStore {
     }
 
     pub fn exchange_by_id(&self, exchange_id: AIAgentExchangeId) -> Option<&AIAgentExchange> {
-        let idx = self.exchange_id_index.get(&exchange_id)?;
-        self.lookup_exchange(self.linearized_refs.get(*idx)?)
+        let exchange_ref = self.exchange_id_index.get(&exchange_id)?;
+        self.lookup_exchange(exchange_ref)
+    }
+
+    pub(super) fn rebuild_exchange_id_index(&mut self) {
+        self.exchange_id_index = self
+            .tasks
+            .values()
+            .flat_map(|task| {
+                let task_id = task.id().clone();
+                task.exchanges()
+                    .enumerate()
+                    .map(move |(exchange_index, exchange)| {
+                        (
+                            exchange.id,
+                            ExchangeRef {
+                                task_id: task_id.clone(),
+                                exchange_index,
+                            },
+                        )
+                    })
+            })
+            .collect();
     }
 
     pub fn first_exchange(&self) -> Option<&AIAgentExchange> {
@@ -295,15 +315,7 @@ impl TaskStore {
     /// Rebuilds the linearized index from scratch using DFS traversal.
     fn rebuild_linearized_refs_index(&mut self) {
         self.linearized_refs = Self::build_linearized_refs(&self.tasks, &self.root_task_id);
-        self.exchange_id_index = self
-            .linearized_refs
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, r)| {
-                let exchange = self.lookup_exchange(r)?;
-                Some((exchange.id, idx))
-            })
-            .collect();
+        self.rebuild_exchange_id_index();
     }
 
     /// Builds linearized exchange refs via DFS traversal without mutating self.

--- a/app/src/ai/agent/task_store.rs
+++ b/app/src/ai/agent/task_store.rs
@@ -111,15 +111,24 @@ impl TaskStore {
         None
     }
 
-    /// Modifies a task via the provided closure and rebuilds the exchange index.
+    /// Modifies a task via the provided closure and rebuilds the exchange index if the exchange
+    /// count changes.
     pub fn modify_task<R>(
         &mut self,
         task_id: &TaskId,
         f: impl FnOnce(&mut Task) -> R,
     ) -> Option<R> {
         let task = self.tasks.get_mut(task_id)?;
+        let exchange_count_before = task.exchanges_len();
         let result = f(task);
-        self.rebuild_linearized_refs_index();
+        let exchange_count_after = self
+            .tasks
+            .get(task_id)
+            .map(|t| t.exchanges_len())
+            .unwrap_or(0);
+        if exchange_count_before != exchange_count_after {
+            self.rebuild_linearized_refs_index();
+        }
         Some(result)
     }
 

--- a/app/src/ai/agent/task_store.rs
+++ b/app/src/ai/agent/task_store.rs
@@ -20,6 +20,8 @@ pub struct TaskStore {
     root_task_id: TaskId,
     tasks: HashMap<TaskId, Task>,
     linearized_refs: Vec<ExchangeRef>,
+    /// Map from exchange ID to its position in `linearized_refs` for faster lookup.
+    exchange_id_index: HashMap<AIAgentExchangeId, usize>,
     /// If the root task was upgraded from an optimistic (client-generated) ID
     /// to a server-assigned ID, stores the original optimistic ID so that
     /// deferred event handlers referencing the stale ID can still resolve
@@ -33,6 +35,7 @@ impl TaskStore {
         let mut store = Self {
             tasks: HashMap::new(),
             linearized_refs: Vec::new(),
+            exchange_id_index: HashMap::new(),
             root_task_id: root_task_id.clone(),
             optimistic_root_task_id: None,
         };
@@ -47,6 +50,7 @@ impl TaskStore {
         let mut store = Self {
             tasks,
             linearized_refs: Vec::new(),
+            exchange_id_index: HashMap::new(),
             root_task_id,
             optimistic_root_task_id: None,
         };
@@ -107,24 +111,15 @@ impl TaskStore {
         None
     }
 
-    /// Modifies a task via the provided closure and rebuilds the exchange index
-    /// if exchanges changed.
+    /// Modifies a task via the provided closure and rebuilds the exchange index.
     pub fn modify_task<R>(
         &mut self,
         task_id: &TaskId,
         f: impl FnOnce(&mut Task) -> R,
     ) -> Option<R> {
-        let exchange_count_before = self.tasks.get(task_id)?.exchanges_len();
         let task = self.tasks.get_mut(task_id)?;
         let result = f(task);
-        let exchange_count_after = self
-            .tasks
-            .get(task_id)
-            .map(|t| t.exchanges_len())
-            .unwrap_or(0);
-        if exchange_count_before != exchange_count_after {
-            self.rebuild_linearized_refs_index();
-        }
+        self.rebuild_linearized_refs_index();
         Some(result)
     }
 
@@ -150,6 +145,11 @@ impl TaskStore {
         }
         self.root_task_id = new_root_id;
         self.insert(root_task);
+    }
+
+    pub fn exchange_by_id(&self, exchange_id: AIAgentExchangeId) -> Option<&AIAgentExchange> {
+        let idx = self.exchange_id_index.get(&exchange_id)?;
+        self.lookup_exchange(self.linearized_refs.get(*idx)?)
     }
 
     pub fn first_exchange(&self) -> Option<&AIAgentExchange> {
@@ -272,7 +272,7 @@ impl TaskStore {
 
     pub fn remove(&mut self, task_id: &TaskId) -> Option<Task> {
         let task = self.tasks.remove(task_id)?;
-        self.linearized_refs.retain(|r| &r.task_id != task_id);
+        self.rebuild_linearized_refs_index();
         Some(task)
     }
 
@@ -286,6 +286,15 @@ impl TaskStore {
     /// Rebuilds the linearized index from scratch using DFS traversal.
     fn rebuild_linearized_refs_index(&mut self) {
         self.linearized_refs = Self::build_linearized_refs(&self.tasks, &self.root_task_id);
+        self.exchange_id_index = self
+            .linearized_refs
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, r)| {
+                let exchange = self.lookup_exchange(r)?;
+                Some((exchange.id, idx))
+            })
+            .collect();
     }
 
     /// Builds linearized exchange refs via DFS traversal without mutating self.

--- a/app/src/ai/agent/task_store_tests.rs
+++ b/app/src/ai/agent/task_store_tests.rs
@@ -621,3 +621,119 @@ fn test_all_exchanges_by_task_with_subtasks() {
     assert_eq!(by_task[2].1.len(), 1);
     assert_eq!(by_task[2].1[0].id, root_exchange3_id);
 }
+
+#[test]
+fn test_exchange_by_id_resolves_subtask_exchange() {
+    // The index spans all tasks, not just the root, so exchanges that live in a
+    // subtask must be resolvable by id.
+    let root_task = create_test_task_with_exchanges(1);
+    let root_task_id = root_task.id().clone();
+    let mut store = TaskStore::with_root_task(root_task);
+
+    let subtask = create_test_subtask_with_exchanges(2);
+    let subtask_id = subtask.id().clone();
+    let subtask_exchange_ids: Vec<_> = subtask.exchanges().map(|e| e.id).collect();
+
+    let subagent_exchange = create_exchange_with_subagent_call(&subtask_id);
+    store.append_exchange(&root_task_id, subagent_exchange);
+    store.insert(subtask);
+
+    for id in &subtask_exchange_ids {
+        assert_eq!(store.exchange_by_id(*id).map(|e| e.id), Some(*id));
+    }
+}
+
+#[test]
+fn test_exchange_by_id_after_remove_task() {
+    let root_task = create_test_task_with_exchanges(1);
+    let root_task_id = root_task.id().clone();
+    let root_exchange_id = root_task.exchanges().next().unwrap().id;
+    let mut store = TaskStore::with_root_task(root_task);
+
+    let subtask = create_test_subtask_with_exchanges(2);
+    let subtask_id = subtask.id().clone();
+    let subtask_exchange_ids: Vec<_> = subtask.exchanges().map(|e| e.id).collect();
+
+    let subagent_exchange = create_exchange_with_subagent_call(&subtask_id);
+    store.append_exchange(&root_task_id, subagent_exchange);
+    store.insert(subtask);
+
+    // Sanity: the subtask's exchanges resolve before removal.
+    assert!(store.exchange_by_id(subtask_exchange_ids[0]).is_some());
+
+    store.remove(&subtask_id);
+
+    // The removed task's exchanges are no longer resolvable.
+    for id in &subtask_exchange_ids {
+        assert!(store.exchange_by_id(*id).is_none());
+    }
+    // The surviving root exchange still resolves.
+    assert_eq!(
+        store.exchange_by_id(root_exchange_id).map(|e| e.id),
+        Some(root_exchange_id)
+    );
+}
+
+#[test]
+fn test_exchange_by_id_after_remove_task_exchange_index_shift() {
+    let task = create_test_task_with_exchanges(3);
+    let task_id = task.id().clone();
+    let exchange_ids: Vec<_> = task.exchanges().map(|e| e.id).collect();
+    let mut store = TaskStore::with_root_task(task);
+
+    // Remove the middle exchange, which shifts the index of everything after it.
+    store.remove_task_exchange(&task_id, exchange_ids[1]);
+
+    // The removed id no longer resolves.
+    assert!(store.exchange_by_id(exchange_ids[1]).is_none());
+
+    // The exchange that followed it (now at a different index) still resolves to itself.
+    assert_eq!(
+        store.exchange_by_id(exchange_ids[2]).map(|e| e.id),
+        Some(exchange_ids[2])
+    );
+    // The exchange before it is unaffected.
+    assert_eq!(
+        store.exchange_by_id(exchange_ids[0]).map(|e| e.id),
+        Some(exchange_ids[0])
+    );
+}
+
+#[test]
+fn test_exchange_by_id_after_modify_task_append() {
+    let task = create_test_task_with_exchanges(2);
+    let task_id = task.id().clone();
+    let mut store = TaskStore::with_root_task(task);
+
+    let new_exchange = create_test_exchange();
+    let new_exchange_id = new_exchange.id;
+    store.modify_task(&task_id, |task| {
+        task.append_exchange(new_exchange);
+    });
+
+    // The newly appended exchange is found via the rebuilt index.
+    assert_eq!(
+        store.exchange_by_id(new_exchange_id).map(|e| e.id),
+        Some(new_exchange_id)
+    );
+}
+
+#[test]
+fn test_exchange_by_id_after_set_root_task() {
+    let task1 = create_test_task_with_exchanges(2);
+    let task1_exchange_ids: Vec<_> = task1.exchanges().map(|e| e.id).collect();
+    let mut store = TaskStore::with_root_task(task1);
+
+    let task2 = create_test_task_with_exchanges(3);
+    let task2_exchange_ids: Vec<_> = task2.exchanges().map(|e| e.id).collect();
+    store.set_root_task(task2);
+
+    // The old root's exchanges no longer resolve.
+    for id in &task1_exchange_ids {
+        assert!(store.exchange_by_id(*id).is_none());
+    }
+    // The new root's exchanges resolve.
+    for id in &task2_exchange_ids {
+        assert_eq!(store.exchange_by_id(*id).map(|e| e.id), Some(*id));
+    }
+}


### PR DESCRIPTION
## Description

Part of a stack of performance fixes for [#9799](https://github.com/warpdotdev/warp/issues/9799): opening a large Oz agent conversation (3000+ exchanges) caused a beachball / multi-second load due to several O(n²) hotspots in the restore path.

**This PR:** `AIConversation::exchange_with_id` previously performed a linear scan through every exchange on every call. During conversation restoration this function is called once per exchange to look up command-block metadata, making the restore path O(n²) overall.

Adds `exchange_id_index: HashMap<AIAgentExchangeId, usize>` to `TaskStore`. The index is rebuilt on all structural mutations (append, insert, remove, exchange removal). `exchange_with_id` and the new `exchange_by_id` now return in O(1).

Also fixes `remove()`: previously it retained entries in `linearized_refs` but left stale entries in `exchange_id_index` for the removed task; now it does a full index rebuild.

## Linked Issue

Fixes https://github.com/warpdotdev/warp/issues/9799

## Testing

Manually loaded a conversation with 3014 AI exchanges and confirmed the restore time was significantly reduced.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable
CHANGELOG-NONE
-->
