### PR TITLE
perf(terminal): use RestoreBlocks stage in insert_restored_block

### DIFF
--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -631,6 +631,7 @@ impl AIConversation {
                 task.reassign_exchange_ids();
             });
         }
+        self.task_store.rebuild_exchange_id_index();
     }
 
     pub fn is_viewing_shared_session(&self) -> bool {

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -1440,12 +1440,7 @@ impl AIConversation {
 
     #[cfg_attr(target_family = "wasm", allow(unused))]
     pub fn exchange_with_id(&self, exchange_id: AIAgentExchangeId) -> Option<&AIAgentExchange> {
-        for task in self.task_store.tasks() {
-            if let Some(exchange) = task.exchanges().find(|exchange| exchange.id == exchange_id) {
-                return Some(exchange);
-            }
-        }
-        None
+        self.task_store.exchange_by_id(exchange_id)
     }
 
     /// Returns the exchange that preceded the exchange with the given id, if there is one.

--- a/app/src/ai/agent/task_store.rs
+++ b/app/src/ai/agent/task_store.rs
@@ -20,8 +20,7 @@ pub struct TaskStore {
     root_task_id: TaskId,
     tasks: HashMap<TaskId, Task>,
     linearized_refs: Vec<ExchangeRef>,
-    /// Map from exchange ID to its position in `linearized_refs` for faster lookup.
-    exchange_id_index: HashMap<AIAgentExchangeId, usize>,
+    exchange_id_index: HashMap<AIAgentExchangeId, ExchangeRef>,
     /// If the root task was upgraded from an optimistic (client-generated) ID
     /// to a server-assigned ID, stores the original optimistic ID so that
     /// deferred event handlers referencing the stale ID can still resolve
@@ -157,8 +156,29 @@ impl TaskStore {
     }
 
     pub fn exchange_by_id(&self, exchange_id: AIAgentExchangeId) -> Option<&AIAgentExchange> {
-        let idx = self.exchange_id_index.get(&exchange_id)?;
-        self.lookup_exchange(self.linearized_refs.get(*idx)?)
+        let exchange_ref = self.exchange_id_index.get(&exchange_id)?;
+        self.lookup_exchange(exchange_ref)
+    }
+
+    pub(super) fn rebuild_exchange_id_index(&mut self) {
+        self.exchange_id_index = self
+            .tasks
+            .values()
+            .flat_map(|task| {
+                let task_id = task.id().clone();
+                task.exchanges()
+                    .enumerate()
+                    .map(move |(exchange_index, exchange)| {
+                        (
+                            exchange.id,
+                            ExchangeRef {
+                                task_id: task_id.clone(),
+                                exchange_index,
+                            },
+                        )
+                    })
+            })
+            .collect();
     }
 
     pub fn first_exchange(&self) -> Option<&AIAgentExchange> {
@@ -295,15 +315,7 @@ impl TaskStore {
     /// Rebuilds the linearized index from scratch using DFS traversal.
     fn rebuild_linearized_refs_index(&mut self) {
         self.linearized_refs = Self::build_linearized_refs(&self.tasks, &self.root_task_id);
-        self.exchange_id_index = self
-            .linearized_refs
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, r)| {
-                let exchange = self.lookup_exchange(r)?;
-                Some((exchange.id, idx))
-            })
-            .collect();
+        self.rebuild_exchange_id_index();
     }
 
     /// Builds linearized exchange refs via DFS traversal without mutating self.

--- a/app/src/ai/agent/task_store.rs
+++ b/app/src/ai/agent/task_store.rs
@@ -111,15 +111,24 @@ impl TaskStore {
         None
     }
 
-    /// Modifies a task via the provided closure and rebuilds the exchange index.
+    /// Modifies a task via the provided closure and rebuilds the exchange index if the exchange
+    /// count changes.
     pub fn modify_task<R>(
         &mut self,
         task_id: &TaskId,
         f: impl FnOnce(&mut Task) -> R,
     ) -> Option<R> {
         let task = self.tasks.get_mut(task_id)?;
+        let exchange_count_before = task.exchanges_len();
         let result = f(task);
-        self.rebuild_linearized_refs_index();
+        let exchange_count_after = self
+            .tasks
+            .get(task_id)
+            .map(|t| t.exchanges_len())
+            .unwrap_or(0);
+        if exchange_count_before != exchange_count_after {
+            self.rebuild_linearized_refs_index();
+        }
         Some(result)
     }
 

--- a/app/src/ai/agent/task_store.rs
+++ b/app/src/ai/agent/task_store.rs
@@ -20,6 +20,8 @@ pub struct TaskStore {
     root_task_id: TaskId,
     tasks: HashMap<TaskId, Task>,
     linearized_refs: Vec<ExchangeRef>,
+    /// Map from exchange ID to its position in `linearized_refs` for faster lookup.
+    exchange_id_index: HashMap<AIAgentExchangeId, usize>,
     /// If the root task was upgraded from an optimistic (client-generated) ID
     /// to a server-assigned ID, stores the original optimistic ID so that
     /// deferred event handlers referencing the stale ID can still resolve
@@ -33,6 +35,7 @@ impl TaskStore {
         let mut store = Self {
             tasks: HashMap::new(),
             linearized_refs: Vec::new(),
+            exchange_id_index: HashMap::new(),
             root_task_id: root_task_id.clone(),
             optimistic_root_task_id: None,
         };
@@ -47,6 +50,7 @@ impl TaskStore {
         let mut store = Self {
             tasks,
             linearized_refs: Vec::new(),
+            exchange_id_index: HashMap::new(),
             root_task_id,
             optimistic_root_task_id: None,
         };
@@ -107,24 +111,15 @@ impl TaskStore {
         None
     }
 
-    /// Modifies a task via the provided closure and rebuilds the exchange index
-    /// if exchanges changed.
+    /// Modifies a task via the provided closure and rebuilds the exchange index.
     pub fn modify_task<R>(
         &mut self,
         task_id: &TaskId,
         f: impl FnOnce(&mut Task) -> R,
     ) -> Option<R> {
-        let exchange_count_before = self.tasks.get(task_id)?.exchanges_len();
         let task = self.tasks.get_mut(task_id)?;
         let result = f(task);
-        let exchange_count_after = self
-            .tasks
-            .get(task_id)
-            .map(|t| t.exchanges_len())
-            .unwrap_or(0);
-        if exchange_count_before != exchange_count_after {
-            self.rebuild_linearized_refs_index();
-        }
+        self.rebuild_linearized_refs_index();
         Some(result)
     }
 
@@ -150,6 +145,11 @@ impl TaskStore {
         }
         self.root_task_id = new_root_id;
         self.insert(root_task);
+    }
+
+    pub fn exchange_by_id(&self, exchange_id: AIAgentExchangeId) -> Option<&AIAgentExchange> {
+        let idx = self.exchange_id_index.get(&exchange_id)?;
+        self.lookup_exchange(self.linearized_refs.get(*idx)?)
     }
 
     pub fn first_exchange(&self) -> Option<&AIAgentExchange> {
@@ -272,7 +272,7 @@ impl TaskStore {
 
     pub fn remove(&mut self, task_id: &TaskId) -> Option<Task> {
         let task = self.tasks.remove(task_id)?;
-        self.linearized_refs.retain(|r| &r.task_id != task_id);
+        self.rebuild_linearized_refs_index();
         Some(task)
     }
 
@@ -286,6 +286,15 @@ impl TaskStore {
     /// Rebuilds the linearized index from scratch using DFS traversal.
     fn rebuild_linearized_refs_index(&mut self) {
         self.linearized_refs = Self::build_linearized_refs(&self.tasks, &self.root_task_id);
+        self.exchange_id_index = self
+            .linearized_refs
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, r)| {
+                let exchange = self.lookup_exchange(r)?;
+                Some((exchange.id, idx))
+            })
+            .collect();
     }
 
     /// Builds linearized exchange refs via DFS traversal without mutating self.

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -2739,7 +2739,7 @@ impl BlockList {
     pub fn insert_restored_block(&mut self, block: &SerializedBlock) {
         let did_active_block_receive_precmd = self.active_block().has_received_precmd();
         let mut processor = Processor::new();
-        self.restore_block(block, BootstrapStage::PostBootstrapPrecmd, &mut processor);
+        self.restore_block(block, BootstrapStage::RestoreBlocks, &mut processor);
         // restore_block consumed the previous active block and made the restored
         // block the new active (finished) block. Create a fresh active block so
         // the terminal can continue accepting input.
@@ -2958,7 +2958,6 @@ impl BlockList {
             self.active_block_mut().start_background(None);
         } else {
             self.active_block_mut().start();
-            self.active_block_mut().disable_reset_grid_checks();
         }
 
         if let Some(serialized_ai_metadata) = block.ai_metadata.as_ref().and_then(|ai_metadata| {


### PR DESCRIPTION
## Description

Part of a stack of performance fixes for [#9799](https://github.com/warpdotdev/warp/issues/9799).

**This PR:** `insert_restored_block` was calling `restore_block` with `BootstrapStage::PostBootstrapPrecmd`, which causes `Block::new` to set `PerformResetGridChecks::Yes` (the Windows ConPTY path). This meant a redundant `disable_reset_grid_checks()` call was needed afterward before parsing the serialized command/output bytes.

Passing `BootstrapStage::RestoreBlocks` instead is semantically correct (these blocks are being restored, not coming in post-bootstrap), and since `RestoreBlocks.is_done() == false`, `Block::new` sets `PerformResetGridChecks::No` automatically. The now-redundant `disable_reset_grid_checks()` call inside `restore_block` is removed.

## Linked Issue

Fixes https://github.com/warpdotdev/warp/issues/9799

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Manually loaded a conversation with 3014 AI exchanges and verified correct rendering of restored blocks.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable
CHANGELOG-NONE
-->
