### PR TITLE
perf(terminal): O(1) is_any_ai_block_focused via ancestor set

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -8701,10 +8701,18 @@ impl TerminalView {
     /// Returns `true` if focus is inside any AI block (e.g. the user is arrowing
     /// through a code diff's hunks).
     fn is_any_ai_block_focused(&self, ctx: &mut ViewContext<Self>) -> bool {
+        let window_id = ctx.window_id();
+        let Some(focused_id) = ctx.focused_view_id(window_id) else {
+            return false;
+        };
+        let ancestors: HashSet<_> = ctx
+            .view_ancestors(window_id, focused_id)
+            .into_iter()
+            .collect();
         self.rich_content_views.iter().any(|rich_content| {
             rich_content
                 .ai_block_metadata()
-                .is_some_and(|metadata| metadata.ai_block_handle.is_self_or_child_focused(ctx))
+                .is_some_and(|metadata| ancestors.contains(&metadata.ai_block_handle.id()))
         })
     }
 


### PR DESCRIPTION
## Description

Part of a stack of performance fixes for [#9799](https://github.com/warpdotdev/warp/issues/9799).

**This PR:** `is_any_ai_block_focused` in `terminal/view.rs` was called on every render of a terminal view that contains AI blocks. It iterated all N AI block IDs and called `is_self_or_child_focused` on each, which internally called `view_ancestors()` — an O(depth) walk of the view tree — each time. With 3000+ AI blocks, this was O(N × depth) per render.

Now computes `view_ancestors` once into a `HashSet<EntityId>`, then checks each AI block ID against the set in O(1), making the function O(N) total (and dominated by the O(depth) setup, which is constant relative to N).

## Linked Issue

Fixes https://github.com/warpdotdev/warp/issues/9799


## Testing

Manually loaded a conversation with 3014 AI exchanges and confirmed smoother scrolling/rendering.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable
CHANGELOG-NONE
-->
