### PR TITLE
perf(terminal): bulk_insert_restored_blocks to amortise BlockMetadataReceived

### DIFF
--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -1267,6 +1267,21 @@ impl Block {
         self.output_grid.disable_reset_grid_checks();
     }
 
+    /// Apply precmd metadata without emitting `Event::BlockMetadataReceived` and without rendering
+    /// the PS1 or rprompt into the block's grids.
+    pub(super) fn set_precmd_metadata(&mut self, data: &PrecmdValue) {
+        self.state = BlockState::BeforeExecution;
+        self.pwd.clone_from(&data.pwd);
+        self.git_branch.clone_from(&data.git_head);
+        self.git_branch_name.clone_from(&data.git_branch);
+        self.virtual_env.clone_from(&data.virtual_env);
+        self.conda_env.clone_from(&data.conda_env);
+        self.node_version.clone_from(&data.node_version);
+        self.session_id = data.session_id.map(Into::into);
+        self.rprompt.clone_from(&data.rprompt);
+        self.precmd_state = PrecmdState::AfterPrecmd;
+    }
+
     /// Method used in tests to finish the BlockGrid containing the command WITHOUT a linefeed in the empty command
     /// case.
     #[cfg(test)]

--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -1267,21 +1267,6 @@ impl Block {
         self.output_grid.disable_reset_grid_checks();
     }
 
-    /// Apply precmd metadata without emitting `Event::BlockMetadataReceived` and without rendering
-    /// the PS1 or rprompt into the block's grids.
-    pub(super) fn set_precmd_metadata(&mut self, data: &PrecmdValue) {
-        self.state = BlockState::BeforeExecution;
-        self.pwd.clone_from(&data.pwd);
-        self.git_branch.clone_from(&data.git_head);
-        self.git_branch_name.clone_from(&data.git_branch);
-        self.virtual_env.clone_from(&data.virtual_env);
-        self.conda_env.clone_from(&data.conda_env);
-        self.node_version.clone_from(&data.node_version);
-        self.session_id = data.session_id.map(Into::into);
-        self.rprompt.clone_from(&data.rprompt);
-        self.precmd_state = PrecmdState::AfterPrecmd;
-    }
-
     /// Method used in tests to finish the BlockGrid containing the command WITHOUT a linefeed in the empty command
     /// case.
     #[cfg(test)]

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -2880,28 +2880,16 @@ impl BlockList {
         let mut processor = Processor::new();
 
         for block in blocks {
-            let did_active_block_receive_precmd = self.active_block().has_received_precmd();
-            let precmd_payload = did_active_block_receive_precmd
-                .then(|| self.last_populated_precmd_payload.clone())
-                .flatten();
-
             self.restore_block(block, BootstrapStage::RestoreBlocks, &mut processor);
-            // Create the placeholder without a precmd_value so `Block::precmd` is not called and
-            // no event is emitted.
-            self.create_new_block(BlockId::new(), self.bootstrap_stage, None, None);
-            if let Some(precmd_value) = precmd_payload {
-                self.active_block_mut().set_precmd_metadata(&precmd_value);
-            }
-            self.active_block_mut().disable_reset_grid_checks();
         }
 
-        // Fire a single BlockMetadataReceived for the final active block, triggering one
-        // refresh_warp_prompt + git repo detection.
-        if initial_received_precmd {
-            if let Some(precmd_value) = self.last_populated_precmd_payload.clone() {
-                delegate_to_block!(self.precmd(precmd_value));
-            }
-        }
+        // Create a single final placeholder, matching the initialize() pattern.
+        // Only fire BlockMetadataReceived if the original active block had received precmd.
+        let precmd_payload = initial_received_precmd
+            .then(|| self.last_populated_precmd_payload.clone())
+            .flatten();
+        self.create_new_block(BlockId::new(), self.bootstrap_stage, precmd_payload, None);
+        self.active_block_mut().disable_reset_grid_checks();
     }
 
     /// Splice a background block into the blocklist. This is called once the

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -2873,6 +2873,8 @@ impl BlockList {
             return;
         }
 
+        let initial_received_precmd = self.active_block().has_received_precmd();
+
         // Share one Processor across all blocks — more efficient than creating a new one per block
         // as `insert_restored_block` does.
         let mut processor = Processor::new();
@@ -2895,8 +2897,10 @@ impl BlockList {
 
         // Fire a single BlockMetadataReceived for the final active block, triggering one
         // refresh_warp_prompt + git repo detection.
-        if let Some(precmd_value) = self.last_populated_precmd_payload.clone() {
-            delegate_to_block!(self.precmd(precmd_value));
+        if initial_received_precmd {
+            if let Some(precmd_value) = self.last_populated_precmd_payload.clone() {
+                delegate_to_block!(self.precmd(precmd_value));
+            }
         }
     }
 

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -2865,6 +2865,41 @@ impl BlockList {
         self.active_block_mut().disable_reset_grid_checks();
     }
 
+    /// Bulk-inserts fully serialized blocks into the block list without firing
+    /// [`Event::BlockMetadataReceived`] for each intermediate block. A single event is fired after
+    /// all blocks have been inserted.
+    pub fn bulk_insert_restored_blocks(&mut self, blocks: &[&SerializedBlock]) {
+        if blocks.is_empty() {
+            return;
+        }
+
+        // Share one Processor across all blocks — more efficient than creating a new one per block
+        // as `insert_restored_block` does.
+        let mut processor = Processor::new();
+
+        for block in blocks {
+            let did_active_block_receive_precmd = self.active_block().has_received_precmd();
+            let precmd_payload = did_active_block_receive_precmd
+                .then(|| self.last_populated_precmd_payload.clone())
+                .flatten();
+
+            self.restore_block(block, BootstrapStage::RestoreBlocks, &mut processor);
+            // Create the placeholder without a precmd_value so `Block::precmd` is not called and
+            // no event is emitted.
+            self.create_new_block(BlockId::new(), self.bootstrap_stage, None, None);
+            if let Some(precmd_value) = precmd_payload {
+                self.active_block_mut().set_precmd_metadata(&precmd_value);
+            }
+            self.active_block_mut().disable_reset_grid_checks();
+        }
+
+        // Fire a single BlockMetadataReceived for the final active block, triggering one
+        // refresh_warp_prompt + git repo detection.
+        if let Some(precmd_value) = self.last_populated_precmd_payload.clone() {
+            delegate_to_block!(self.precmd(precmd_value));
+        }
+    }
+
     /// Splice a background block into the blocklist. This is called once the
     /// block has meaningful output.
     pub(super) fn insert_background_block(&mut self, block: Block) {

--- a/app/src/terminal/view/load_ai_conversation.rs
+++ b/app/src/terminal/view/load_ai_conversation.rs
@@ -32,7 +32,7 @@ use crate::ai::blocklist::history_model::{
 use crate::ai::blocklist::model::AIBlockModelImpl;
 use crate::ai::blocklist::{
     AIBlock, BlocklistAIActionModel, BlocklistAIContextModel, BlocklistAIController,
-    ClientIdentifiers,
+    ClientIdentifiers, SerializedBlockListItem,
 };
 use crate::ai::document::ai_document_model::AIDocumentModel;
 use crate::ai::get_relevant_files::controller::GetRelevantFilesController;


### PR DESCRIPTION
## Description

Part of a stack of performance fixes for [#9799](https://github.com/warpdotdev/warp/issues/9799).

**This PR:** restoring a conversation called `insert_restored_block` in a loop, and each call emitted a `BlockMetadataReceived` event. Each event triggered `refresh_warp_prompt` + git repository detection. With 1091 command blocks in the test conversation, this meant 1091 sequential prompt refreshes and git queries during restore — a dominant source of latency. Each `insert_restored_block` call also constructed a fresh ANSI `Processor`.

Adds `BlockList::bulk_insert_restored_blocks`, which restores all blocks while sharing a single `Processor` across them (instead of allocating one per block) and emits only a single `BlockMetadataReceived` at the end — and only when the original active block had already received precmd. `restore_conversation_after_view_creation` now uses this bulk path instead of calling `insert_restored_block` in a loop.

Also includes a small optimization to `Block::precmd` that uses `clone_from` to reuse existing allocations when populating metadata fields.

## Linked Issue

Fixes https://github.com/warpdotdev/warp/issues/9799


## Testing

Manually loaded a conversation with 3014 AI exchanges / 1091 command blocks. The beachball / multi-second delay on open is no longer present.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable
CHANGELOG-IMPROVEMENT: Significantly reduced loading time when opening large Oz agent conversations
-->
