### PR TITLE
Fix Windows Ctrl+J key event in ConPTY

### DIFF
--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -1034,6 +1034,7 @@ impl ansi::Handler for GridHandler {
                     .send_terminal_event(Event::CursorBlinkingChange(true));
             }
             ansi::Mode::SyncOutput => {}
+            ansi::Mode::Win32Input => self.ansi_handler_state.mode.insert(TermMode::WIN32_INPUT),
         }
     }
 
@@ -1093,6 +1094,7 @@ impl ansi::Handler for GridHandler {
                     .event_proxy
                     .send_terminal_event(Event::CursorBlinkingChange(false));
             }
+            ansi::Mode::Win32Input => self.ansi_handler_state.mode.remove(TermMode::WIN32_INPUT),
             _ => {}
         }
     }

--- a/crates/warp_terminal/src/model/ansi/control_sequence_parameters.rs
+++ b/crates/warp_terminal/src/model/ansi/control_sequence_parameters.rs
@@ -105,6 +105,9 @@ pub enum Mode {
     /// ?2026
     /// See https://gist.github.com/christianparpart/d8a62cc1ab659194337d73e399004036.
     SyncOutput,
+    /// ?9001
+    /// Windows Terminal private mode for passing Win32 input records through ConPTY.
+    Win32Input,
 }
 
 impl Mode {
@@ -147,6 +150,7 @@ impl Mode {
                 },
                 2004 => Mode::BracketedPaste,
                 2026 => Mode::SyncOutput,
+                9001 => Mode::Win32Input,
                 _ => {
                     trace!("[unimplemented] primitive mode: {num}");
                     return None;
@@ -705,6 +709,19 @@ impl TryFrom<&[u8]> for PromptKind {
             b"r" => Ok(PromptKind::Right),
             _ => Err(Self::Error::UnknownValue),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Mode;
+
+    #[test]
+    fn parses_win32_input_private_mode() {
+        assert_eq!(
+            Mode::from_primitive(Some(&b'?'), 9001),
+            Some(Mode::Win32Input)
+        );
     }
 }
 

--- a/crates/warp_terminal/src/model/escape_sequences.rs
+++ b/crates/warp_terminal/src/model/escape_sequences.rs
@@ -230,6 +230,15 @@ pub struct KeystrokeWithDetails<'a> {
 
 impl<T: ModeProvider> ToEscapeSequence<T> for KeystrokeWithDetails<'_> {
     fn to_escape_sequence(&self, mode_provider: &T) -> Option<Vec<u8>> {
+        if let Some(win32_input) = maybe_convert_keystroke_to_win32_input(
+            self.keystroke,
+            self.key_without_modifiers,
+            self.chars,
+            mode_provider,
+        ) {
+            return Some(win32_input);
+        }
+
         if let Some(csi_u) = maybe_convert_keystroke_to_csi_u(
             self.keystroke,
             self.key_without_modifiers,
@@ -249,6 +258,90 @@ impl<T: ModeProvider> ToEscapeSequence<T> for KeystrokeWithDetails<'_> {
             .or_else(|| meta_keystroke_to_escape_sequence(keystroke, mode_provider))
             .or_else(|| backspace_keystroke_to_escape_sequence(keystroke))
     }
+}
+
+fn maybe_convert_keystroke_to_win32_input(
+    keystroke: &Keystroke,
+    key_without_modifiers: Option<&str>,
+    chars: Option<&str>,
+    mode_provider: &impl ModeProvider,
+) -> Option<Vec<u8>> {
+    if !mode_provider.is_term_mode_set(TermMode::WIN32_INPUT) {
+        return None;
+    }
+
+    if !keystroke.ctrl || keystroke.alt || keystroke.shift || keystroke.meta || keystroke.cmd {
+        return None;
+    }
+
+    let key = key_without_modifiers.unwrap_or(keystroke.key.as_str());
+    let key = key.chars().next()?.to_ascii_lowercase();
+    let (virtual_key, scan_code) = win32_letter_key_codes(key)?;
+    let unicode_char = chars
+        .and_then(|text| text.chars().next())
+        .map(|c| c as u16)
+        .unwrap_or_else(|| virtual_key & 0x1f);
+
+    Some(win32_input_mode_sequence(
+        virtual_key,
+        scan_code,
+        unicode_char,
+        1,
+        win32_control_key_state::LEFT_CTRL_PRESSED,
+        1,
+    ))
+}
+
+fn win32_letter_key_codes(key: char) -> Option<(u16, u16)> {
+    let virtual_key = key.to_ascii_uppercase() as u16;
+    let scan_code = match key {
+        'a' => 0x1e,
+        'b' => 0x30,
+        'c' => 0x2e,
+        'd' => 0x20,
+        'e' => 0x12,
+        'f' => 0x21,
+        'g' => 0x22,
+        'h' => 0x23,
+        'i' => 0x17,
+        'j' => 0x24,
+        'k' => 0x25,
+        'l' => 0x26,
+        'm' => 0x32,
+        'n' => 0x31,
+        'o' => 0x18,
+        'p' => 0x19,
+        'q' => 0x10,
+        'r' => 0x13,
+        's' => 0x1f,
+        't' => 0x14,
+        'u' => 0x16,
+        'v' => 0x2f,
+        'w' => 0x11,
+        'x' => 0x2d,
+        'y' => 0x15,
+        'z' => 0x2c,
+        _ => return None,
+    };
+    Some((virtual_key, scan_code))
+}
+
+fn win32_input_mode_sequence(
+    virtual_key: u16,
+    scan_code: u16,
+    unicode_char: u16,
+    key_down: u8,
+    control_key_state: u32,
+    repeat_count: u16,
+) -> Vec<u8> {
+    format!(
+        "\x1b[{virtual_key};{scan_code};{unicode_char};{key_down};{control_key_state};{repeat_count}_"
+    )
+    .into_bytes()
+}
+
+mod win32_control_key_state {
+    pub const LEFT_CTRL_PRESSED: u32 = 0x0008;
 }
 
 impl<T: ModeProvider> ToEscapeSequence<T> for MouseState {

--- a/crates/warp_terminal/src/model/escape_sequences_tests.rs
+++ b/crates/warp_terminal/src/model/escape_sequences_tests.rs
@@ -71,6 +71,23 @@ fn test_shift_backspace_emits_del_sequence() {
 }
 
 #[test]
+fn test_win32_input_mode_ctrl_j_preserves_virtual_key() {
+    let mut terminal_model_mock = TerminalModelMock::new();
+    terminal_model_mock.set_mode(TermMode::WIN32_INPUT);
+
+    let ctrl_j = Keystroke::parse("ctrl-j").unwrap();
+    assert_eq!(
+        KeystrokeWithDetails {
+            keystroke: &ctrl_j,
+            key_without_modifiers: Some("j"),
+            chars: Some("\n"),
+        }
+        .to_escape_sequence(&terminal_model_mock),
+        Some(b"\x1b[74;36;10;1;8;1_".to_vec())
+    );
+}
+
+#[test]
 fn test_mouse_actions_to_escape_sequence() {
     // Validating we produce the correct escape sequences.
     let test_cases: &[(MouseState, Vec<u8>)] = &[

--- a/crates/warp_terminal/src/model/mode.rs
+++ b/crates/warp_terminal/src/model/mode.rs
@@ -57,6 +57,10 @@ bitflags! {
         /// that want both the semantic key information and the resulting text.
         const KEYBOARD_REPORT_ASSOCIATED_TEXT  = 0b0100_0000_0000_0000_0000_0000;
 
+        /// Windows Terminal's private Win32 input mode (`CSI ? 9001 h`).
+        /// When set, keyboard input should be sent as encoded Win32 input records.
+        const WIN32_INPUT                       = 0b1000_0000_0000_0000_0000_0000;
+
         const KEYBOARD_PROTOCOL = Self::KEYBOARD_DISAMBIGUATE_ESCAPE.bits()
             | Self::KEYBOARD_REPORT_EVENT_TYPES.bits()
             | Self::KEYBOARD_REPORT_ALTERNATE_KEYS.bits()


### PR DESCRIPTION
﻿## Description

Fixes ConPTY input encoding for Ctrl-letter chords when an application enables Windows Terminal's private Win32 input mode (`CSI ? 9001 h`). Warp now tracks that mode and emits Win32 input record sequences for Ctrl+A-Z, preserving the original virtual key.  This keeps Ctrl+J as `VK_J` instead of letting downstream clients infer Enter from the LF control character. 

## Linked Issue

Closes #11688 

- [x] The linked issue is labeled `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below. 

## Testing

- Added parser coverage for private Win32 input mode (`CSI ? 9001 h`).
- Added regression coverage that Ctrl+J emits `VK_J` in Win32 input mode.
- `cargo fmt` - `cargo test -p warp_terminal`
- `cargo check -p warp --tests`
- `cargo clippy -p warp_terminal --tests -- -D warnings` 

- [ ] I have manually tested my changes locally with `./script/run` 

### Screenshots / Videos Ctrl+J validation video:

https://github.com/user-attachments/assets/d1d26ce7-0b49-493e-b501-a63dc31d6588

The PR build reports:
- `wVirtualKeyCode=0x004a` (`VK_J`)
- `uChar=0x000a` (`LF`)
- `PASS: Ctrl+J is reported as VK_J with LF.` 


## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode 
 
CHANGELOG-BUG-FIX: Fixed Ctrl+J in Codex CLI on Windows being reported as Ctrl+Enter.  

