### PR TITLE
fix(modal): propagate body view keymap context so editor bindings work inside modals (#13067)

### DIFF
--- a/app/src/modal.rs
+++ b/app/src/modal.rs
@@ -6,7 +6,7 @@ use warpui::elements::{
     ParentElement, ParentOffsetBounds, Radius, Shrinkable, Stack, Text,
 };
 use warpui::fonts::{Properties, Weight};
-use warpui::keymap::{FixedBinding, Keystroke};
+use warpui::keymap::{Context, FixedBinding, Keystroke};
 use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
 use warpui::{
     AppContext, Entity, FocusContext, ModelHandle, SingletonEntity, TypedActionView, View,
@@ -452,6 +452,12 @@ impl<T: View> View for Modal<T> {
             ctx.focus(&self.body);
             ctx.notify();
         }
+    }
+
+    fn keymap_context(&self, ctx: &AppContext) -> Context {
+        let mut context = Self::default_keymap_context();
+        context.extend(self.body.keymap_context(ctx));
+        context
     }
 
     fn render(&self, app: &AppContext) -> Box<dyn Element> {


### PR DESCRIPTION
## Description

Modal-hosted text fields (e.g. the Add Custom Endpoint dialog, API key fields in agent settings) do not support Ctrl+V / Cmd+V paste, Ctrl+C / Cmd+C copy, or right-click context menu operations.

## Root cause

The generic `Modal<T>` wrapper did not override the `keymap_context` method on its `View` impl. The default trait implementation returns only `{"Modal"}`, which means keybindings gated on identifiers from child views (e.g. `id!("EditorView")` for paste/copy/cut) can never match when an EditorView is focused inside a modal.

This affects both:
- **Custom keybindings** (`CustomAction::Paste`, `CustomAction::Copy`, `CustomAction::Cut`) — registered with `id!("EditorView") & !id!("IMEOpen")`
- **Standard paste** (`StandardAction::Paste`) — also gated on `id!("EditorView")`

## Fix

Added a `keymap_context` override to `Modal<T>` that extends the modal's own context (`"Modal"`) with the body view's context (e.g. `"CustomEndpointModal"`, `"EditorView"`, etc.). This preserves the modal's Escape-to-close binding (gated on `"Modal"`) while also exposing child view identifiers for their keybindings.

```rust
fn keymap_context(&self, ctx: &AppContext) -> Context {
    let mut context = Self::default_keymap_context();
    context.extend(self.body.keymap_context(ctx));
    context
}
```

## Testing

- [x] `cargo check -p warp_app` passes
- [x] Manual verification on Linux

### Manual verification

1. Open Warp Settings → Agents / AI → Add Custom Endpoint
2. Type text into a field, select it, press Ctrl+C
3. Press Ctrl+V — text is pasted correctly
4. Right-click in a field — context menu shows Copy/Paste options

### Screenshots / Videos

Before: Ctrl+V in endpoint name field inserts only the 'v' character
After: Ctrl+V pastes the full clipboard content

Tested on: Linux (X11/Wayland)

## Linked Issue

- [x] The linked issue is labeled `ready-to-implement`.

Closes #13067
Related: #7694

## Changelog

CHANGELOG-BUG-FIX: Fixed paste and copy not working in settings modal text fields