### PR TITLE
Fix Vim `Ngg` ignoring the count (jump to line N like `NG`)

### DIFF
--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1073,7 +1073,10 @@ impl VimFSA {
                     bound: WordBound::End,
                     word_type: WordType::from(c),
                 })),
-                'g' => VimEventType::Navigate(VimMotion::JumpToFirstLine),
+                'g' => match self.get_action_count() {
+                    Some(line_number) => VimEventType::Navigate(VimMotion::JumpToLine(line_number)),
+                    None => VimEventType::Navigate(VimMotion::JumpToFirstLine),
+                },
                 'd' => VimEventType::GotoDefinition,
                 'h' => VimEventType::ShowHover,
                 'r' => VimEventType::FindReferences,
@@ -1331,7 +1334,10 @@ impl VimFSA {
                 'g' => self.create_operation(
                     operator,
                     VimOperand::Motion {
-                        motion: VimMotion::JumpToFirstLine,
+                        motion: match self.get_operand_count() {
+                            Some(line_number) => VimMotion::JumpToLine(line_number),
+                            None => VimMotion::JumpToFirstLine,
+                        },
                         motion_type: MotionType::Linewise,
                     },
                 ),
@@ -1557,7 +1563,10 @@ impl VimFSA {
                     bound: WordBound::End,
                     word_type: WordType::from(c),
                 })),
-                'g' => VimEventType::Navigate(VimMotion::JumpToFirstLine),
+                'g' => match self.get_action_count() {
+                    Some(line_number) => VimEventType::Navigate(VimMotion::JumpToLine(line_number)),
+                    None => VimEventType::Navigate(VimMotion::JumpToFirstLine),
+                },
                 'c' => {
                     let motion_type = match self.mode {
                         VimMode::Visual(mt) => mt,
@@ -2062,3 +2071,7 @@ pub trait VimHandler {
     /// Move the cursor up `count` half-pages and scroll the viewport (`<C-u>`).
     fn scroll_half_page_up(&mut self, _count: u32, _ctx: &mut ViewContext<Self>) {}
 }
+
+#[cfg(test)]
+#[path = "vim_tests.rs"]
+mod tests;

--- a/crates/vim/src/vim_tests.rs
+++ b/crates/vim/src/vim_tests.rs
@@ -1,0 +1,97 @@
+use super::*;
+
+/// Feed a sequence of characters to a fresh state machine and return the last
+/// event it emitted, mirroring how keystrokes arrive one at a time.
+fn last_event(keys: &str) -> Option<VimEvent> {
+    let mut fsa = VimFSA::new();
+    fsa.mode = VimMode::Normal;
+    let mut last = None;
+    for c in keys.chars() {
+        if let Some(event) = fsa.typed_character(c) {
+            last = Some(event);
+        }
+    }
+    last
+}
+
+#[test]
+fn gg_without_a_count_jumps_to_the_first_line() {
+    let event = last_event("gg").expect("gg should emit an event");
+    assert!(
+        matches!(
+            event.event_type,
+            VimEventType::Navigate(VimMotion::JumpToFirstLine)
+        ),
+        "expected `gg` to jump to the first line, got {:?}",
+        event.event_type
+    );
+}
+
+#[test]
+fn count_gg_jumps_to_that_line_in_normal_mode() {
+    let event = last_event("5gg").expect("5gg should emit an event");
+    assert!(
+        matches!(
+            event.event_type,
+            VimEventType::Navigate(VimMotion::JumpToLine(5))
+        ),
+        "expected `5gg` to jump to line 5, got {:?}",
+        event.event_type
+    );
+}
+
+#[test]
+fn count_gg_and_count_g_agree() {
+    // `Ngg` and `NG` are the same motion in Vim; they should produce the same event.
+    let gg = last_event("12gg").expect("12gg should emit an event");
+    let g = last_event("12G").expect("12G should emit an event");
+    assert!(
+        matches!(
+            gg.event_type,
+            VimEventType::Navigate(VimMotion::JumpToLine(12))
+        ),
+        "expected `12gg` to jump to line 12, got {:?}",
+        gg.event_type
+    );
+    assert!(
+        matches!(
+            g.event_type,
+            VimEventType::Navigate(VimMotion::JumpToLine(12))
+        ),
+        "expected `12G` to jump to line 12, got {:?}",
+        g.event_type
+    );
+}
+
+#[test]
+fn count_gg_jumps_to_that_line_in_visual_mode() {
+    let event = last_event("v5gg").expect("v5gg should emit an event");
+    assert!(
+        matches!(
+            event.event_type,
+            VimEventType::Navigate(VimMotion::JumpToLine(5))
+        ),
+        "expected `v5gg` to extend the selection to line 5, got {:?}",
+        event.event_type
+    );
+}
+
+#[test]
+fn operator_count_gg_uses_that_line_as_the_motion() {
+    // `d3gg` deletes linewise from the cursor to line 3.
+    let event = last_event("d3gg").expect("d3gg should emit an event");
+    assert!(
+        matches!(
+            event.event_type,
+            VimEventType::Operation {
+                operand: VimOperand::Motion {
+                    motion: VimMotion::JumpToLine(3),
+                    ..
+                },
+                ..
+            }
+        ),
+        "expected `d3gg` to delete to line 3, got {:?}",
+        event.event_type
+    );
+}


### PR DESCRIPTION
## Description

In Vim mode, a count before `gg` was being dropped: `5gg` jumped to the first line instead of line 5, even though `5G` correctly jumps to line 5. The same applied to the operator-pending and visual variants (`d5gg`, `v5gg`).

The `gg` arms in the normal, operator-pending, and visual handlers always emitted `JumpToFirstLine` and never read the pending count, while the matching `G` arms right next to them already branch on the count (`get_action_count()` / `get_operand_count()`) and emit `JumpToLine(n)`. This makes the three `gg` arms mirror their `G` siblings: with a count they emit `JumpToLine(n)`, and with no count they keep emitting `JumpToFirstLine`.

## Linked Issue

Closes #13132

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

Added `crates/vim/src/vim_tests.rs`, which drives the state machine through key sequences and checks the event it emits:

- `5gg` / `12gg` → `JumpToLine(n)`, and `12gg` produces the same motion as `12G`
- `v5gg` → `JumpToLine(5)`
- `d3gg` → a delete operation with a `JumpToLine(3)` motion
- bare `gg` (no count) → still `JumpToFirstLine`

I confirmed these tests fail on `master` (they emit `JumpToFirstLine` for the counted cases) and pass with the fix. `cargo test -p vim`, `cargo fmt -p vim`, and `cargo clippy -p vim` are all clean.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed a count before `gg` being ignored in the Vim code editor — `5gg` now jumps to line 5, matching `5G`.
