### PR TITLE
fix(markdown_parser): prevent unclosed <u> tags from pairing via emphasis algorithm

### DIFF
--- a/crates/markdown_parser/src/markdown_parser.rs
+++ b/crates/markdown_parser/src/markdown_parser.rs
@@ -1758,7 +1758,7 @@ impl Delimiter {
                 right_flanking && (!left_flanking || followed_by_punctuation)
             }
             DelimiterKind::Strikethrough => right_flanking,
-            DelimiterKind::UnderlineStart => right_flanking,
+            DelimiterKind::UnderlineStart => false,
         };
 
         Self {
@@ -1781,6 +1781,13 @@ impl Delimiter {
     fn can_open_for(&self, other: &Delimiter) -> bool {
         // Base rules that apply to all styling.
         if !self.can_open || self.kind != other.kind {
+            return false;
+        }
+
+        // Underline start (`<u>`) is only ever closed by an explicit `</u>` tag,
+        // handled separately by `parse_underline`. It must never be paired with
+        // another `<u>` through the emphasis algorithm.
+        if self.kind == DelimiterKind::UnderlineStart {
             return false;
         }
 

--- a/crates/markdown_parser/src/markdown_parser_tests.rs
+++ b/crates/markdown_parser/src/markdown_parser_tests.rs
@@ -1918,6 +1918,24 @@ fn test_parse_empty_underline() {
 }
 
 #[test]
+fn test_unclosed_underline_roundtrips_literal() {
+    assert_eq!(
+        parse_all("<u><u>", parse_inline),
+        vec![FormattedTextFragment::plain_text("<u><u>")]
+    );
+    assert_eq!(
+        parse_all("<u>a<u>", parse_inline),
+        vec![FormattedTextFragment::plain_text("<u>a<u>")]
+    );
+    assert_eq!(
+        parse_all("a <u>word<u> b", parse_inline),
+        vec![
+            FormattedTextFragment::plain_text("a <u>word<u> b"),
+        ]
+    );
+}
+
+#[test]
 fn test_unordered_list_indentation_level_relative() {
     // Test that both 2-space and 4-space relative indentation produce the same structure
     let source_2space = "- top level\n  - sublevel\n    - subsublevel";


### PR DESCRIPTION
## Summary

When two `<u>` underline start tags appear without closing `</u>` tags, they were incorrectly paired as an opener/closer pair through the emphasis algorithm, causing the literal `<u>` markers and surrounding text to be silently deleted.

## Root Cause

`<u>` was tokenized as `UnderlineStart` with `can_close` set from right-flanking rules, allowing `process_emphasis` to match two `<u>` openers as a pair. Underline is only meant to be closed by an explicit `</u>` tag (handled by `parse_underline`), never by another `<u>`.

## Fix

1. Set `can_close = false` for `UnderlineStart` delimiters so `<u>` is never treated as a closing delimiter by `process_emphasis`
2. Add a guard in `can_open_for` to reject `UnderlineStart` pairs (defense in depth)

## Regression Tests

Added tests covering the cases from the issue:
- `<u><u>` round-trips as literal text (was: empty line, all text deleted)
- `<u>a<u>` preserves both `<u>` markers (was: `a`, both markers deleted)
- `a <u>word<u> b` does not delete text (was: `a word b`, markers deleted)

Fixes #12863