### PR TITLE
Activate next tab (below) after closing the active vertical tab

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -11720,14 +11720,12 @@ impl Workspace {
 
         match index.cmp(&self.active_tab_index) {
             Ordering::Equal => {
-                // Horizontal tabs should activate the tab that was immediately to the
-                // right of the closed tab. After removal, that tab has the same index.
-                // If the closed tab was the last tab, fall back to the previous tab.
-                let active_index = if uses_vertical_tabs(ctx) {
-                    index.saturating_sub(1)
-                } else {
-                    index.min(self.tabs.len() - 1)
-                };
+                // Activate the tab that was immediately after the closed one — to the
+                // right for horizontal tabs, below for vertical tabs. After removal that
+                // tab occupies the same index. If the closed tab was the last one, fall
+                // back to the new last tab (the previous neighbor). This matches the
+                // browser / macOS convention for both layouts.
+                let active_index = index.min(self.tabs.len() - 1);
                 self.activate_tab_internal(active_index, ctx);
             }
             Ordering::Less => {

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -1449,6 +1449,63 @@ fn test_close_last_horizontal_tab_activates_tab_to_left() {
         });
     });
 }
+
+#[test]
+fn test_close_active_vertical_tab_activates_tab_below() {
+    let _vertical_tabs_guard = FeatureFlag::VerticalTabs.override_enabled(true);
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        app.update(|ctx| {
+            TabSettings::handle(ctx).update(ctx, |settings, ctx| {
+                report_if_error!(settings.use_vertical_tabs.set_value(true, ctx));
+            });
+        });
+
+        let workspace = mock_workspace(&mut app);
+
+        workspace.update(&mut app, |workspace, ctx| {
+            workspace.add_terminal_tab(false, ctx);
+            workspace.add_terminal_tab(false, ctx);
+            let tab_below_id = workspace.get_pane_group_view(2).unwrap().id();
+
+            workspace.activate_tab(1, ctx);
+            workspace.close_tab(1, true, true, ctx);
+
+            assert_eq!(workspace.tab_count(), 2);
+            assert_eq!(workspace.active_tab_index(), 1);
+            assert_eq!(workspace.active_tab_pane_group().id(), tab_below_id);
+        });
+    });
+}
+
+#[test]
+fn test_close_last_vertical_tab_activates_tab_above() {
+    let _vertical_tabs_guard = FeatureFlag::VerticalTabs.override_enabled(true);
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        app.update(|ctx| {
+            TabSettings::handle(ctx).update(ctx, |settings, ctx| {
+                report_if_error!(settings.use_vertical_tabs.set_value(true, ctx));
+            });
+        });
+
+        let workspace = mock_workspace(&mut app);
+
+        workspace.update(&mut app, |workspace, ctx| {
+            workspace.add_terminal_tab(false, ctx);
+            workspace.add_terminal_tab(false, ctx);
+            let tab_above_id = workspace.get_pane_group_view(1).unwrap().id();
+
+            workspace.activate_tab(2, ctx);
+            workspace.close_tab(2, true, true, ctx);
+
+            assert_eq!(workspace.tab_count(), 2);
+            assert_eq!(workspace.active_tab_index(), 1);
+            assert_eq!(workspace.active_tab_pane_group().id(), tab_above_id);
+        });
+    });
+}
+
 #[test]
 fn test_close_pane_confirmation_dialog() {
     let _guard = FeatureFlag::CreatingSharedSessions.override_enabled(true);


### PR DESCRIPTION
## Summary

Closing the active tab should move focus to the **next** tab — the tab to the
right (horizontal) or below (vertical) — falling back to the previous neighbor
only when you close the last tab. This is the standard convention set by
browsers and macOS apps.

Today the behavior is **inconsistent between layouts**:

- **Horizontal tabs** already do the right thing. PR #11197 ("Activate right
  horizontal tab after close") changed the post-close selection from
  `index.saturating_sub(1)` (previous tab) to `index.min(self.tabs.len() - 1)`
  (next tab).
- **Vertical tabs** still activate the **previous (up)** tab after a close.

This is the part that confused us: PR #11197 *explicitly* scoped its fix to
horizontal mode and called out that it would "preserve existing vertical tab
behavior." It did so by gating the new logic behind `uses_vertical_tabs(ctx)`:

```rust
let active_index = if uses_vertical_tabs(ctx) {
    index.saturating_sub(1)         // vertical: previous/up tab
} else {
    index.min(self.tabs.len() - 1)  // horizontal: next/right tab
};
```

We couldn't find a reason vertical tabs should intentionally focus the
*previous* tab while horizontal focuses the *next* one — it breaks the same
convention #11197 set out to fix, just in the other layout. If there is a
deliberate reason for the asymmetry, please flag it on this PR.

## Change

Drop the layout branch in `Workspace::remove_tab` and always use the
next-neighbor rule for both layouts:

```rust
// Activate the tab that was immediately after the closed one — to the right
// for horizontal tabs, below for vertical tabs. After removal that tab
// occupies the same index. If the closed tab was the last one, fall back to
// the new last tab (the previous neighbor).
let active_index = index.min(self.tabs.len() - 1);
self.activate_tab_internal(active_index, ctx);
```

`remove_tab` is the single point all close paths funnel through (keyboard, the
tab "X" button, the vertical-tabs panel, and tab-group closes), so this fixes
every entry point. Horizontal behavior is unchanged; only vertical tabs change
(previous → next).

## Tests

- Existing horizontal tests still pass (no regression):
  `test_close_active_horizontal_tab_activates_tab_to_right`,
  `test_close_last_horizontal_tab_activates_tab_to_left`.
- Added vertical coverage mirroring them:
  `test_close_active_vertical_tab_activates_tab_below` (would have failed before
  this change), `test_close_last_vertical_tab_activates_tab_above` (fallback).
- `cargo check -p warp --tests` clean; the four `*_tab_activates_tab_*` tests
  pass.


Closes #13143
