### PR TITLE
fix: reject fonts with reserved bit 7 in glyf simple glyph flags

### DIFF
--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -860,10 +860,13 @@ impl TextLayoutSystem {
                             family.font_ids = Vec1::try_from_vec(new_ids).unwrap();
                         }
                     }
-                    for family_id in empty_family_ids {
+                    for &family_id in &empty_family_ids {
                         families.remove(&family_id);
                     }
                     drop(families);
+                    for &family_id in &empty_family_ids {
+                        self.font_selections.retain(|&(fid, _), _| fid != family_id);
+                    }
                     self.font_id_map.write().remove_by_right(&db_id);
                 }
 
@@ -1460,15 +1463,29 @@ impl TextLayoutSystem {
         self.families.read().get(&id).map(|family| family.name.to_owned())
     }
 
+    fn any_valid_font_id(&self) -> FontId {
+        if let Some(family) = self.families.read().values().next() {
+            return *family.font_ids.first();
+        }
+        self.font_id_map
+            .read()
+            .iter()
+            .next()
+            .map(|(font_id, _)| *font_id)
+            .expect("No fonts loaded")
+    }
+
     fn select_font(&self, family_id: FamilyId, properties: Properties) -> FontId {
         match self.font_selections.entry((family_id, properties)) {
             Entry::Occupied(entry) => *entry.get(),
             Entry::Vacant(entry) => {
                 let (family_name, first_font_id) = {
                     let families = self.families.read();
-                    let family = families
-                        .get(&family_id)
-                        .expect("Font family must exist");
+                    let Some(family) = families.get(&family_id) else {
+                        let fallback = self.any_valid_font_id();
+                        entry.insert(fallback);
+                        return fallback;
+                    };
                     (family.name.clone(), *family.font_ids.first())
                 };
 

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -63,7 +63,9 @@ lazy_static! {
 /// Number of font faces in a font file (TTF or TTC).
 fn count_font_faces(data: &[u8]) -> usize {
     if data.len() >= 12 && &data[0..4] == b"ttcf" {
-        u32::from_be_bytes([data[8], data[9], data[10], data[11]]) as usize
+        let header_count = u32::from_be_bytes([data[8], data[9], data[10], data[11]]) as usize;
+        let max_from_data = data.len().saturating_sub(12) / 4;
+        header_count.min(max_from_data)
     } else {
         1
     }
@@ -714,16 +716,22 @@ impl TextLayoutSystem {
                 };
                 if let Source::File(path) = &face_info.source {
                     let key = (path.clone(), face_info.index);
-                    if !BIT7_CHECKED_FONTS.contains_key(&key) {
-                        let corrupted = font_store
-                            .db()
-                            .with_face_data(id, |data, fi| {
-                                has_reserved_bit7_in_glyph_flags(data, fi)
-                            })
-                            .unwrap_or(false);
-                        BIT7_CHECKED_FONTS.insert(key, !corrupted);
-                        if corrupted {
+                    match BIT7_CHECKED_FONTS.get(&key) {
+                        Some(clean) if !*clean => {
                             removed_ids.push(id);
+                        }
+                        Some(_) => {}
+                        None => {
+                            let corrupted = font_store
+                                .db()
+                                .with_face_data(id, |data, fi| {
+                                    has_reserved_bit7_in_glyph_flags(data, fi)
+                                })
+                                .unwrap_or(false);
+                            BIT7_CHECKED_FONTS.insert(key, !corrupted);
+                            if corrupted {
+                                removed_ids.push(id);
+                            }
                         }
                     }
                 }

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -459,26 +459,52 @@ impl TextLayoutSystem {
     /// font.
     /// If the font has already been loaded, the same [`FontId`] from the initial time the font was loaded is returned.
     fn insert_font(&self, font_handle: FontHandle) -> Result<FontId> {
-        let (source, index) = match font_handle.into_data() {
-            FontData::Bytes(face) => (fontdb::Source::Binary(Arc::new(face.into_vec())), 0),
-            FontData::Path { path, index, .. } => (fontdb::Source::File(path.clone()), index),
+        // Check if we've already loaded this font from this path.
+        let pre_loaded_path = match font_handle.data() {
+            FontData::Path { path, index, .. } => {
+                if let Some(id) = self.loaded_fonts.get(&FontKey {
+                    path: path.clone(),
+                    index: *index,
+                }) {
+                    return Ok(*id);
+                }
+                Some(path.clone())
+            }
+            _ => None,
         };
 
-        if let Source::File(path) = &source {
-            // The font we're trying to load has already been loaded into the DB.
-            if let Some(id) = self.loaded_fonts.get(&FontKey {
-                path: path.clone(),
-                index,
-            }) {
-                return Ok(*id);
+        let (source, index) = match font_handle.into_data() {
+            FontData::Bytes(face) => (fontdb::Source::Binary(Arc::new(face.into_vec())), 0),
+            // Defer to fontdb's mmap for file sources; check for corruption below
+            // using the already-loaded data to avoid an extra fs::read on every font.
+            FontData::Path { path, index, .. } => (fontdb::Source::File(path), index),
+        };
+
+        let fontdb_ids = self.font_store.write().db_mut().load_font_source(source);
+
+        // Only for file-based fonts: reuse fontdb's mmap'd data to check for
+        // corrupted glyf tables (reserved bit 7 on simple glyph flags).
+        // Corrupted fonts are removed from the database immediately so they
+        // cannot be matched by future font fallback queries.
+        if let Some(ref path) = pre_loaded_path {
+            if let Some(&first_id) = fontdb_ids.first() {
+                let is_corrupted = self
+                    .font_store
+                    .read()
+                    .db()
+                    .with_face_data(first_id, |data, face_index| {
+                        Self::has_reserved_bit7_in_glyph_flags(data, face_index)
+                    })
+                    .unwrap_or(false);
+
+                if is_corrupted {
+                    for &id in &fontdb_ids {
+                        self.font_store.write().db_mut().remove_face(id);
+                    }
+                    bail!("Font {path:?} has corrupted glyf table (reserved bit 7 set on simple glyph flags)")
+                }
             }
         }
-
-        // TODO(alokedesai): Consider using FontDB's `make_shared_font_data` here. FontDB creates a temporary memory
-        // mapped file every time data is read via a call to `with_face_data`. When rendering text this can
-        // repeatedly cause allocation of a large amount of virtual address space, especially when trying to load
-        // large fonts. See https://github.com/RazrFalcon/fontdb/issues/18 for more details.
-        let fontdb_ids = self.font_store.write().db_mut().load_font_source(source);
 
         if fontdb_ids.is_empty() {
             bail!("Loaded a font source that corresponds to 0 font faces")
@@ -500,7 +526,7 @@ impl TextLayoutSystem {
             #[cfg(feature = "fontkit-rasterizer")]
             self.loaded_font_ids_since_last_raster.write().push(font_id);
 
-            if let Source::File(path) = &face_info.source {
+            if let Some(ref path) = pre_loaded_path {
                 self.loaded_fonts.insert(
                     FontKey {
                         path: path.clone(),
@@ -517,6 +543,94 @@ impl TextLayoutSystem {
 
         font_id_to_return
             .ok_or_else(|| anyhow!("Requested index for the font handle was unable to be loaded"))
+    }
+
+    /// Checks whether reserved bit 7 is set on simple glyph coordinate flags.
+    /// Some fonts (notably DroidSansFallback.ttf) have this corruption, which
+    /// causes skrifa/swash to reject all outline rendering from the font.
+    fn has_reserved_bit7_in_glyph_flags(data: &[u8], face_index: u32) -> bool {
+        let face = match owned_ttf_parser::Face::parse(data, face_index) {
+            Ok(f) => f,
+            Err(_) => return false,
+        };
+
+        let glyf_data = match face.raw_face().table(owned_ttf_parser::Tag::from_bytes(b"glyf")) {
+            Some(d) => d,
+            None => return false,
+        };
+        let loca_data = match face.raw_face().table(owned_ttf_parser::Tag::from_bytes(b"loca")) {
+            Some(d) => d,
+            None => return false,
+        };
+        let head_data = match face.raw_face().table(owned_ttf_parser::Tag::from_bytes(b"head")) {
+            Some(d) => d,
+            None => return false,
+        };
+
+        let index_to_loc = u16::from_be_bytes([head_data[50], head_data[51]]);
+        let num_glyphs = face.number_of_glyphs() as usize;
+
+        let read_loca = |idx: usize| -> Option<usize> {
+            if index_to_loc == 1 {
+                let base = 4 * idx;
+                if base + 4 > loca_data.len() {
+                    return None;
+                }
+                Some(u32::from_be_bytes([
+                    loca_data[base],
+                    loca_data[base + 1],
+                    loca_data[base + 2],
+                    loca_data[base + 3],
+                ]) as usize)
+            } else {
+                let base = 2 * idx;
+                if base + 2 > loca_data.len() {
+                    return None;
+                }
+                Some(u16::from_be_bytes([loca_data[base], loca_data[base + 1]]) as usize * 2)
+            }
+        };
+
+        let mut glyphs_to_check: Vec<u16> = (1..=20).step_by(3).collect();
+        glyphs_to_check.extend_from_slice(&[50, 100, 200, 500, 1000]);
+        if let Ok(last) = u16::try_from(num_glyphs.saturating_sub(1)) {
+            if last >= 1000 {
+                glyphs_to_check.push(last);
+            }
+        }
+
+        for gid in glyphs_to_check {
+            if gid as usize >= num_glyphs {
+                break;
+            }
+            let (Some(offs), Some(offe)) = (read_loca(gid as usize), read_loca(gid as usize + 1))
+            else {
+                break;
+            };
+            if offs + 2 > offe || offs + 2 > glyf_data.len() {
+                continue;
+            }
+            let num_contours = i16::from_be_bytes([glyf_data[offs], glyf_data[offs + 1]]);
+            if num_contours <= 0 {
+                continue;
+            }
+            let end_pts_end = 10 + num_contours as usize * 2;
+            if offs + end_pts_end + 2 > offe || offs + end_pts_end + 2 > glyf_data.len() {
+                continue;
+            }
+            let ins_len = u16::from_be_bytes([
+                glyf_data[offs + end_pts_end],
+                glyf_data[offs + end_pts_end + 1],
+            ]) as usize;
+            let flag_offset = offs + end_pts_end + 2 + ins_len;
+            if flag_offset >= offe || flag_offset >= glyf_data.len() {
+                continue;
+            }
+            if glyf_data[flag_offset] & 0x80 != 0 {
+                return true;
+            }
+        }
+        false
     }
 
     /// Loads all of the fallback fonts for the `font_id` with a given `family_name` and set of `properties`.

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -9,7 +9,6 @@ mod linux;
 
 #[cfg(target_os = "windows")]
 mod windows;
-use lazy_static::lazy_static;
 use std::any::Any;
 use std::collections::HashMap;
 use std::ops::{DerefMut, Range};
@@ -26,6 +25,7 @@ use dashmap::mapref::entry::Entry;
 use dashmap::{DashMap, DashSet};
 use fontdb::Source;
 use itertools::Itertools;
+use lazy_static::lazy_static;
 use parking_lot::RwLock;
 use pathfinder_geometry::rect::{RectF, RectI};
 use pathfinder_geometry::vector::{vec2f, vec2i, Vector2F, Vector2I};
@@ -1460,7 +1460,10 @@ impl TextLayoutSystem {
     }
 
     fn load_family_name_from_id(&self, id: FamilyId) -> Option<String> {
-        self.families.read().get(&id).map(|family| family.name.to_owned())
+        self.families
+            .read()
+            .get(&id)
+            .map(|family| family.name.to_owned())
     }
 
     fn select_font(&self, family_id: FamilyId, properties: Properties) -> FontId {
@@ -1469,9 +1472,7 @@ impl TextLayoutSystem {
             Entry::Vacant(entry) => {
                 let (family_name, first_font_id) = {
                     let families = self.families.read();
-                    let family = families
-                        .get(&family_id)
-                        .expect("Font family must exist");
+                    let family = families.get(&family_id).expect("Font family must exist");
                     (family.name.clone(), *family.font_ids.first())
                 };
 

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -22,7 +22,7 @@ use cosmic_text::{
     Align, Attrs, AttrsList, BidiParagraphs, LayoutGlyph, LayoutLine, ShapeLine, Shaping, Wrap,
 };
 use dashmap::mapref::entry::Entry;
-use dashmap::{DashMap, DashSet};
+use dashmap::DashMap;
 use fontdb::Source;
 use itertools::Itertools;
 use lazy_static::lazy_static;
@@ -53,7 +53,7 @@ lazy_static! {
     static ref BIT7_CHECKED_FONTS: DashMap<(PathBuf, u32), bool> = DashMap::new();
 
     /// Paths whose every face has been scanned by the background scanner.
-    static ref SCANNED_PATHS: DashSet<PathBuf> = DashSet::new();
+    static ref SCANNED_PATHS: dashmap::DashSet<PathBuf> = dashmap::DashSet::new();
 
     /// Paths that the background scanner found corrupted, pending removal from fontdb.
     static ref PENDING_CORRUPTED_FONTS: std::sync::Mutex<Vec<PathBuf>> =

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -23,7 +23,7 @@ use cosmic_text::{
     Align, Attrs, AttrsList, BidiParagraphs, LayoutGlyph, LayoutLine, ShapeLine, Shaping, Wrap,
 };
 use dashmap::mapref::entry::Entry;
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use fontdb::Source;
 use itertools::Itertools;
 use parking_lot::RwLock;
@@ -48,9 +48,12 @@ use crate::rendering::GlyphConfig;
 use crate::text_layout::{CaretPosition, ClipConfig, Line, StyleAndFont, TextAlignment, TextFrame};
 
 lazy_static! {
-    /// Global cache of per-file bit7 glyph corruption check results.
-    /// `true` = clean, `false` = has reserved bit 7 set on simple glyph flags.
-    static ref BIT7_CHECKED_FONTS: DashMap<PathBuf, bool> = DashMap::new();
+    /// Global cache of per-face bit7 glyph corruption check results.
+    /// Key: (path, face_index), value: `true` = clean, `false` = corrupted.
+    static ref BIT7_CHECKED_FONTS: DashMap<(PathBuf, u32), bool> = DashMap::new();
+
+    /// Paths whose every face has been scanned by the background scanner.
+    static ref SCANNED_PATHS: DashSet<PathBuf> = DashSet::new();
 
     /// Paths that the background scanner found corrupted, pending removal from fontdb.
     static ref PENDING_CORRUPTED_FONTS: std::sync::Mutex<Vec<PathBuf>> =
@@ -193,9 +196,10 @@ fn has_reserved_bit7_in_glyph_flags(data: &[u8], face_index: u32) -> bool {
 }
 
 /// Lazily initializes the background font scanner thread and returns a sender.
-/// The scanner reads font files from disk, checks for bit7 glyph corruption,
-/// and caches results in `BIT7_CHECKED_FONTS`. Corrupted paths are queued
-/// for removal from fontdb by `TextLayoutSystem::drain_corrupted_fonts`.
+/// The scanner reads font files from disk, checks for bit7 glyph corruption
+/// in every face, and caches per-face results in `BIT7_CHECKED_FONTS`.
+/// Corrupted paths are queued for removal from fontdb by
+/// `TextLayoutSystem::drain_corrupted_fonts`.
 fn background_scan_tx() -> &'static std::sync::mpsc::Sender<PathBuf> {
     static TX: std::sync::OnceLock<std::sync::mpsc::Sender<PathBuf>> = std::sync::OnceLock::new();
     TX.get_or_init(|| {
@@ -203,7 +207,11 @@ fn background_scan_tx() -> &'static std::sync::mpsc::Sender<PathBuf> {
         std::thread::Builder::new()
             .name("font-bit7-scanner".into())
             .spawn(move || {
+                let mut scanned = std::collections::HashSet::<PathBuf>::new();
                 while let Ok(path) = rx.recv() {
+                    if !scanned.insert(path.clone()) {
+                        continue;
+                    }
                     let data = match std::fs::read(&path) {
                         Ok(d) => d,
                         Err(_) => continue,
@@ -211,12 +219,12 @@ fn background_scan_tx() -> &'static std::sync::mpsc::Sender<PathBuf> {
                     let num_faces = count_font_faces(&data);
                     let mut any_corrupted = false;
                     for face_index in 0..num_faces {
-                        if has_reserved_bit7_in_glyph_flags(&data, face_index as u32) {
-                            any_corrupted = true;
-                            break;
-                        }
+                        let index = face_index as u32;
+                        let corrupted = has_reserved_bit7_in_glyph_flags(&data, index);
+                        BIT7_CHECKED_FONTS.insert((path.clone(), index), !corrupted);
+                        any_corrupted |= corrupted;
                     }
-                    BIT7_CHECKED_FONTS.insert(path.clone(), !any_corrupted);
+                    SCANNED_PATHS.insert(path.clone());
                     if any_corrupted {
                         log::warn!(
                             "Background font scan: found corrupted font at {}",
@@ -660,21 +668,24 @@ impl TextLayoutSystem {
         }
 
         if let Source::File(path) = &source {
-            if BIT7_CHECKED_FONTS.get(path).is_some_and(|r| !*r) {
+            if BIT7_CHECKED_FONTS
+                .get(&(path.clone(), index))
+                .is_some_and(|r| !*r)
+            {
                 log::info!(
-                    "bit7 glyph flag scan: skipped (cached corrupted), path={}",
-                    path.display()
+                    "bit7 glyph flag scan: skipped (cached corrupted), path={}, index={index}",
+                    path.display(),
                 );
-                bail!("Font source has corrupted glyphs (bit 7 set on simple glyph flags)");
+                bail!("Font face has corrupted glyphs (bit 7 set on simple glyph flags)");
             }
         }
 
         // Remove any faces from fontdb that the background scanner found corrupted.
         self.drain_corrupted_fonts();
 
-        // Queue a background scan for uncached file-based fonts.
+        // Queue a background scan for paths not yet fully scanned.
         if let Source::File(path) = &source {
-            if !BIT7_CHECKED_FONTS.contains_key(path) {
+            if !SCANNED_PATHS.contains(path) {
                 background_scan_tx().send(path.clone()).ok();
             }
         }
@@ -691,6 +702,48 @@ impl TextLayoutSystem {
 
         if fontdb_ids.is_empty() {
             bail!("Loaded a font source that corresponds to 0 font faces")
+        }
+
+        // Sync check: verify all uncached faces using fontdb's data, removing corrupted ones.
+        let mut removed_ids = Vec::new();
+        {
+            let font_store = self.font_store.read();
+            for &id in &fontdb_ids {
+                let Some(face_info) = font_store.db().face(id) else {
+                    continue;
+                };
+                if let Source::File(path) = &face_info.source {
+                    let key = (path.clone(), face_info.index);
+                    if !BIT7_CHECKED_FONTS.contains_key(&key) {
+                        let corrupted = font_store
+                            .db()
+                            .with_face_data(id, |data, fi| {
+                                has_reserved_bit7_in_glyph_flags(data, fi)
+                            })
+                            .unwrap_or(false);
+                        BIT7_CHECKED_FONTS.insert(key, !corrupted);
+                        if corrupted {
+                            removed_ids.push(id);
+                        }
+                    }
+                }
+            }
+        }
+        if !removed_ids.is_empty() {
+            let mut font_store = self.font_store.write();
+            let db = font_store.db_mut();
+            for &id in &removed_ids {
+                db.remove_face(id);
+            }
+        }
+
+        let fontdb_ids: Vec<fontdb::ID> = fontdb_ids
+            .into_iter()
+            .filter(|id| !removed_ids.contains(id))
+            .collect();
+
+        if fontdb_ids.is_empty() {
+            bail!("All font faces in the source are corrupted");
         }
 
         let mut font_id_to_return = None;
@@ -731,7 +784,8 @@ impl TextLayoutSystem {
     /// Drains all pending corrupted font paths from the background scanner queue
     /// and removes the corresponding faces from this instance's fontdb, cleaning
     /// up all associated maps (`font_id_map`, `loaded_fonts`, `font_selections`,
-    /// and `fallback_fonts`).
+    /// and `fallback_fonts`). Only removes faces that the per-face cache marks
+    /// as corrupted, so clean siblings in a TTC are not affected.
     fn drain_corrupted_fonts(&self) {
         let paths: Vec<PathBuf> = PENDING_CORRUPTED_FONTS.lock().unwrap().drain(..).collect();
         if paths.is_empty() {
@@ -739,26 +793,38 @@ impl TextLayoutSystem {
         }
 
         for path in &paths {
-            let mut font_store = self.font_store.write();
-            let db = font_store.db_mut();
-
-            let ids: Vec<fontdb::ID> = db
+            let faces: Vec<(fontdb::ID, u32)> = self
+                .font_store
+                .read()
+                .db()
                 .faces()
                 .filter(|f| matches!(&f.source, Source::File(p) if p == path))
-                .map(|f| f.id)
+                .map(|f| (f.id, f.index))
                 .collect();
 
-            if ids.is_empty() {
+            let to_remove: Vec<fontdb::ID> = faces
+                .into_iter()
+                .filter(|(_, face_index)| {
+                    BIT7_CHECKED_FONTS
+                        .get(&(path.clone(), *face_index))
+                        .is_some_and(|v| !*v)
+                })
+                .map(|(id, _)| id)
+                .collect();
+
+            if to_remove.is_empty() {
                 continue;
             }
 
             log::info!(
                 "Removing {} corrupted face(s) for {}",
-                ids.len(),
+                to_remove.len(),
                 path.display(),
             );
 
-            for &db_id in &ids {
+            let mut font_store = self.font_store.write();
+            let db = font_store.db_mut();
+            for &db_id in &to_remove {
                 let mut font_id_map = self.font_id_map.write();
                 if let Some((font_id, _)) = font_id_map.remove_by_right(&db_id) {
                     drop(font_id_map);

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -1462,10 +1462,13 @@ impl TextLayoutSystem {
         match self.font_selections.entry((family_id, properties)) {
             Entry::Occupied(entry) => *entry.get(),
             Entry::Vacant(entry) => {
-                let families = self.families.read();
-                let family = families
-                    .get(&family_id)
-                    .expect("Font family must exist");
+                let (family_name, first_font_id) = {
+                    let families = self.families.read();
+                    let family = families
+                        .get(&family_id)
+                        .expect("Font family must exist");
+                    (family.name.clone(), *family.font_ids.first())
+                };
 
                 let weight = match properties.weight {
                     Weight::Thin => fontdb::Weight::THIN,
@@ -1483,7 +1486,7 @@ impl TextLayoutSystem {
                     Style::Italic => fontdb::Style::Italic,
                 };
                 let best_match = self.font_store.read().db().query(&Query {
-                    families: &[fontdb::Family::Name(family.name.as_str())],
+                    families: &[fontdb::Family::Name(family_name.as_str())],
                     weight,
                     stretch: Default::default(),
                     style,
@@ -1491,9 +1494,9 @@ impl TextLayoutSystem {
 
                 let best_match =
                     best_match.and_then(|id| self.font_id_map.read().get_by_right(&id).copied());
-                let best_match = best_match.unwrap_or(*family.font_ids.first());
+                let best_match = best_match.unwrap_or(first_font_id);
 
-                self.load_fallback_fonts(best_match, family.name.as_str(), properties);
+                self.load_fallback_fonts(best_match, &family_name, properties);
 
                 *entry.insert(best_match)
             }

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -833,9 +833,9 @@ impl TextLayoutSystem {
             let mut font_store = self.font_store.write();
             let db = font_store.db_mut();
             for &db_id in &to_remove {
-                let mut font_id_map = self.font_id_map.write();
-                if let Some((font_id, _)) = font_id_map.remove_by_right(&db_id) {
-                    drop(font_id_map);
+                let font_id = self.font_id_map.read().get_by_right(&db_id).copied();
+
+                if let Some(font_id) = font_id {
                     self.font_selections.retain(|_, v| *v != font_id);
                     #[cfg(not(target_os = "windows"))]
                     {
@@ -863,6 +863,8 @@ impl TextLayoutSystem {
                     for family_id in empty_family_ids {
                         families.remove(&family_id);
                     }
+                    drop(families);
+                    self.font_id_map.write().remove_by_right(&db_id);
                 }
 
                 db.remove_face(db_id);

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -10,7 +10,7 @@ mod linux;
 #[cfg(target_os = "windows")]
 mod windows;
 use std::any::Any;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::ops::{DerefMut, Range};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -203,17 +203,6 @@ pub struct TextLayoutSystem {
     loaded_font_ids_since_last_raster: RwLock<Vec<FontId>>,
     #[cfg(not(target_os = "windows"))]
     fallback_fonts: DashMap<FontId, Vec<FontId>>,
-
-    /// Per-font counter of rasterization failures (e.g., skrifa rejecting
-    /// corrupted glyph outlines). Incremented for non-zero glyph IDs when
-    /// swash cannot rasterize them. When the threshold is reached, the
-    /// font is marked as corrupted and removed from the database.
-    #[cfg_attr(feature = "fontkit-rasterizer", allow(dead_code))]
-    raster_failures: RwLock<HashMap<FontId, u32>>,
-    /// Set of fonts whose glyf tables have been found corrupted at runtime.
-    /// Rasterization short-circuits for these fonts, returning empty bounds.
-    #[cfg_attr(feature = "fontkit-rasterizer", allow(dead_code))]
-    corrupted_fonts: RwLock<HashSet<FontId>>,
 }
 
 pub struct FontDB {
@@ -318,8 +307,6 @@ impl TextLayoutSystem {
             fallback_fonts: Default::default(),
             #[cfg(feature = "fontkit-rasterizer")]
             loaded_font_ids_since_last_raster: Default::default(),
-            raster_failures: Default::default(),
-            corrupted_fonts: Default::default(),
         }
     }
 
@@ -472,40 +459,43 @@ impl TextLayoutSystem {
     /// font.
     /// If the font has already been loaded, the same [`FontId`] from the initial time the font was loaded is returned.
     fn insert_font(&self, font_handle: FontHandle) -> Result<FontId> {
-        // Check if we've already loaded this font from this path.
-        let pre_loaded_path = match font_handle.data() {
-            FontData::Path { path, index, .. } => {
-                if let Some(id) = self.loaded_fonts.get(&FontKey {
-                    path: path.clone(),
-                    index: *index,
-                }) {
-                    return Ok(*id);
-                }
-                Some(path.clone())
-            }
-            _ => None,
-        };
-
         let (source, index) = match font_handle.into_data() {
             FontData::Bytes(face) => (fontdb::Source::Binary(Arc::new(face.into_vec())), 0),
-            // Defer to fontdb's mmap for file sources; check for corruption below
-            // using the already-loaded data to avoid an extra fs::read on every font.
-            FontData::Path { path, index, .. } => (fontdb::Source::File(path), index),
+            FontData::Path { path, index, .. } => (fontdb::Source::File(path.clone()), index),
         };
 
-        let mut fontdb_ids = self.font_store.write().db_mut().load_font_source(source);
+        if let Source::File(path) = &source {
+            // The font we're trying to load has already been loaded into the DB.
+            if let Some(id) = self.loaded_fonts.get(&FontKey {
+                path: path.clone(),
+                index,
+            }) {
+                return Ok(*id);
+            }
+        }
 
-        // Only for file-based fonts: reuse fontdb's mmap'd data to check for
-        // corrupted glyf tables (reserved bit 7 on simple glyph flags).
-        // Corrupted faces are removed from the database immediately so they
-        // cannot be matched by future font fallback queries.
-        if let Some(ref path) = pre_loaded_path {
+        // TODO(alokedesai): Consider using FontDB's `make_shared_font_data` here. FontDB creates a temporary memory
+        // mapped file every time data is read via a call to `with_face_data`. When rendering text this can
+        // repeatedly cause allocation of a large amount of virtual address space, especially when trying to load
+        // large fonts. See https://github.com/RazrFalcon/fontdb/issues/18 for more details.
+        let fontdb_ids = {
+            let mut font_store = self.font_store.write();
+            let db = font_store.db_mut();
+            let mut fontdb_ids = db.load_font_source(source);
+
+            // For file-based fonts: reuse fontdb's mmap'd data to check for
+            // corrupted glyf tables (reserved bit 7 on simple glyph flags).
+            // Corrupted faces are removed from the database immediately so they
+            // cannot be matched by future font fallback queries.
             let mut corrupted_ids = Vec::new();
             for &id in &fontdb_ids {
-                let is_corrupted = self
-                    .font_store
-                    .read()
-                    .db()
+                let is_file_based = db
+                    .face(id)
+                    .is_some_and(|f| matches!(f.source, Source::File(_)));
+                if !is_file_based {
+                    continue;
+                }
+                let is_corrupted = db
                     .with_face_data(id, |data, face_index| {
                         Self::has_reserved_bit7_in_glyph_flags(data, face_index)
                     })
@@ -517,17 +507,19 @@ impl TextLayoutSystem {
             }
 
             for &id in &corrupted_ids {
-                self.font_store.write().db_mut().remove_face(id);
+                db.remove_face(id);
             }
 
             if !corrupted_ids.is_empty() {
                 fontdb_ids.retain(|id| !corrupted_ids.contains(id));
                 log::warn!(
-                    "Removed {} corrupted face(s) from {path:?} (reserved bit 7 set on simple glyph flags)",
+                    "Removed {} corrupted face(s) (reserved bit 7 set on simple glyph flags)",
                     corrupted_ids.len()
                 );
             }
-        }
+
+            fontdb_ids
+        };
 
         if fontdb_ids.is_empty() {
             bail!("Loaded a font source that corresponds to 0 font faces")
@@ -549,7 +541,7 @@ impl TextLayoutSystem {
             #[cfg(feature = "fontkit-rasterizer")]
             self.loaded_font_ids_since_last_raster.write().push(font_id);
 
-            if let Some(ref path) = pre_loaded_path {
+            if let Source::File(path) = &face_info.source {
                 self.loaded_fonts.insert(
                     FontKey {
                         path: path.clone(),
@@ -568,43 +560,10 @@ impl TextLayoutSystem {
             .ok_or_else(|| anyhow!("Requested index for the font handle was unable to be loaded"))
     }
 
-    /// Returns true if this font has been confirmed corrupted at runtime.
-    /// Rasterization callers should short-circuit and return empty bounds.
-    #[cfg_attr(feature = "fontkit-rasterizer", allow(dead_code))]
-    fn is_corrupted(&self, font_id: FontId) -> bool {
-        self.corrupted_fonts.read().contains(&font_id)
-    }
-
-    /// Increments the rasterization failure counter for this font.
-    /// When the threshold is exceeded, the font is removed from fontdb
-    /// so future font fallback queries skip it.
-    #[cfg_attr(feature = "fontkit-rasterizer", allow(dead_code))]
-    fn mark_font_corrupted(&self, font_id: FontId) {
-        const MAX_RASTER_FAILURES: u32 = 3;
-
-        {
-            let mut failures = self.raster_failures.write();
-            let count = failures.entry(font_id).or_insert(0);
-            *count += 1;
-            if *count < MAX_RASTER_FAILURES {
-                return;
-            }
-        }
-
-        if !self.corrupted_fonts.write().insert(font_id) {
-            return;
-        }
-
-        if let Some(&internal_id) = self.font_id_map.read().get_by_left(&font_id) {
-            self.font_store.write().db_mut().remove_face(internal_id);
-            log::warn!(
-                "Font (FontId {font_id:?}, fontdb face {internal_id}) marked as corrupted \
-                 after {MAX_RASTER_FAILURES} rasterization failures",
-            );
-        }
-    }
-
-    /// Checks whether reserved bit 7 is set on simple glyph coordinate flags.
+    /// Checks whether any simple glyph in the `glyf` table has reserved bit 7 set
+    /// on its coordinate flags. Fully parses all flags (respecting the repeat flag)
+    /// for every simple glyph, rather than sampling.
+    ///
     /// Some fonts (notably DroidSansFallback.ttf) have this corruption, which
     /// causes skrifa/swash to reject all outline rendering from the font.
     fn has_reserved_bit7_in_glyph_flags(data: &[u8], face_index: u32) -> bool {
@@ -613,24 +572,33 @@ impl TextLayoutSystem {
             Err(_) => return false,
         };
 
-        let glyf_data = match face.raw_face().table(owned_ttf_parser::Tag::from_bytes(b"glyf")) {
+        let glyf_data = match face
+            .raw_face()
+            .table(owned_ttf_parser::Tag::from_bytes(b"glyf"))
+        {
             Some(d) => d,
             None => return false,
         };
-        let loca_data = match face.raw_face().table(owned_ttf_parser::Tag::from_bytes(b"loca")) {
+        let loca_data = match face
+            .raw_face()
+            .table(owned_ttf_parser::Tag::from_bytes(b"loca"))
+        {
             Some(d) => d,
             None => return false,
         };
-        let head_data = match face.raw_face().table(owned_ttf_parser::Tag::from_bytes(b"head")) {
+        let head_data = match face
+            .raw_face()
+            .table(owned_ttf_parser::Tag::from_bytes(b"head"))
+        {
             Some(d) => d,
             None => return false,
         };
 
-        let index_to_loc = u16::from_be_bytes([head_data[50], head_data[51]]);
+        let index_to_loc_format = u16::from_be_bytes([head_data[50], head_data[51]]);
         let num_glyphs = face.number_of_glyphs() as usize;
 
         let read_loca = |idx: usize| -> Option<usize> {
-            if index_to_loc == 1 {
+            if index_to_loc_format == 1 {
                 let base = 4 * idx;
                 if base + 4 > loca_data.len() {
                     return None;
@@ -650,45 +618,73 @@ impl TextLayoutSystem {
             }
         };
 
-        let mut glyphs_to_check: Vec<u16> = (1..=20).step_by(3).collect();
-        glyphs_to_check.extend_from_slice(&[50, 100, 200, 500, 1000]);
-        if let Ok(last) = u16::try_from(num_glyphs.saturating_sub(1)) {
-            if last >= 1000 {
-                glyphs_to_check.push(last);
-            }
-        }
-
-        for gid in glyphs_to_check {
-            if gid as usize >= num_glyphs {
-                break;
-            }
-            let (Some(offs), Some(offe)) = (read_loca(gid as usize), read_loca(gid as usize + 1))
-            else {
-                break;
+        for glyph_index in 0..num_glyphs {
+            let Some(offset) = read_loca(glyph_index) else {
+                continue;
             };
-            if offs + 2 > offe || offs + 2 > glyf_data.len() {
+            let Some(next_offset) = read_loca(glyph_index + 1) else {
+                continue;
+            };
+
+            if offset + 2 > next_offset || offset + 2 > glyf_data.len() {
                 continue;
             }
-            let num_contours = i16::from_be_bytes([glyf_data[offs], glyf_data[offs + 1]]);
+
+            let num_contours = i16::from_be_bytes([glyf_data[offset], glyf_data[offset + 1]]);
             if num_contours <= 0 {
                 continue;
             }
-            let end_pts_end = 10 + num_contours as usize * 2;
-            if offs + end_pts_end + 2 > offe || offs + end_pts_end + 2 > glyf_data.len() {
+
+            let end_pts_offset = offset + 10;
+            let end_pts_count = num_contours as usize;
+            let end_pts_end = end_pts_offset + end_pts_count * 2;
+            if end_pts_end > next_offset || end_pts_end > glyf_data.len() {
                 continue;
             }
-            let ins_len = u16::from_be_bytes([
-                glyf_data[offs + end_pts_end],
-                glyf_data[offs + end_pts_end + 1],
-            ]) as usize;
-            let flag_offset = offs + end_pts_end + 2 + ins_len;
-            if flag_offset >= offe || flag_offset >= glyf_data.len() {
+
+            let total_points =
+                u16::from_be_bytes([glyf_data[end_pts_end - 2], glyf_data[end_pts_end - 1]])
+                    as usize
+                    + 1;
+
+            let ins_len_offset = end_pts_end;
+            if ins_len_offset + 2 > next_offset || ins_len_offset + 2 > glyf_data.len() {
                 continue;
             }
-            if glyf_data[flag_offset] & 0x80 != 0 {
-                return true;
+            let ins_len =
+                u16::from_be_bytes([glyf_data[ins_len_offset], glyf_data[ins_len_offset + 1]])
+                    as usize;
+
+            let flags_start = ins_len_offset + 2 + ins_len;
+            if flags_start > next_offset || flags_start > glyf_data.len() {
+                continue;
+            }
+
+            let mut flags_pos = flags_start;
+            let mut points_processed = 0;
+            while points_processed < total_points {
+                if flags_pos >= next_offset || flags_pos >= glyf_data.len() {
+                    break;
+                }
+                let flag = glyf_data[flags_pos];
+                flags_pos += 1;
+                points_processed += 1;
+
+                if flag & 0x80 != 0 {
+                    return true;
+                }
+
+                if flag & 0x08 != 0 {
+                    if flags_pos >= next_offset || flags_pos >= glyf_data.len() {
+                        break;
+                    }
+                    let repeat_count = glyf_data[flags_pos];
+                    flags_pos += 1;
+                    points_processed += repeat_count as usize;
+                }
             }
         }
+
         false
     }
 

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -10,7 +10,7 @@ mod linux;
 #[cfg(target_os = "windows")]
 mod windows;
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::{DerefMut, Range};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -203,6 +203,17 @@ pub struct TextLayoutSystem {
     loaded_font_ids_since_last_raster: RwLock<Vec<FontId>>,
     #[cfg(not(target_os = "windows"))]
     fallback_fonts: DashMap<FontId, Vec<FontId>>,
+
+    /// Per-font counter of rasterization failures (e.g., skrifa rejecting
+    /// corrupted glyph outlines). Incremented for non-zero glyph IDs when
+    /// swash cannot rasterize them. When the threshold is reached, the
+    /// font is marked as corrupted and removed from the database.
+    #[cfg_attr(feature = "fontkit-rasterizer", allow(dead_code))]
+    raster_failures: RwLock<HashMap<FontId, u32>>,
+    /// Set of fonts whose glyf tables have been found corrupted at runtime.
+    /// Rasterization short-circuits for these fonts, returning empty bounds.
+    #[cfg_attr(feature = "fontkit-rasterizer", allow(dead_code))]
+    corrupted_fonts: RwLock<HashSet<FontId>>,
 }
 
 pub struct FontDB {
@@ -307,6 +318,8 @@ impl TextLayoutSystem {
             fallback_fonts: Default::default(),
             #[cfg(feature = "fontkit-rasterizer")]
             loaded_font_ids_since_last_raster: Default::default(),
+            raster_failures: Default::default(),
+            corrupted_fonts: Default::default(),
         }
     }
 
@@ -480,29 +493,39 @@ impl TextLayoutSystem {
             FontData::Path { path, index, .. } => (fontdb::Source::File(path), index),
         };
 
-        let fontdb_ids = self.font_store.write().db_mut().load_font_source(source);
+        let mut fontdb_ids = self.font_store.write().db_mut().load_font_source(source);
 
         // Only for file-based fonts: reuse fontdb's mmap'd data to check for
         // corrupted glyf tables (reserved bit 7 on simple glyph flags).
-        // Corrupted fonts are removed from the database immediately so they
+        // Corrupted faces are removed from the database immediately so they
         // cannot be matched by future font fallback queries.
         if let Some(ref path) = pre_loaded_path {
-            if let Some(&first_id) = fontdb_ids.first() {
+            let mut corrupted_ids = Vec::new();
+            for &id in &fontdb_ids {
                 let is_corrupted = self
                     .font_store
                     .read()
                     .db()
-                    .with_face_data(first_id, |data, face_index| {
+                    .with_face_data(id, |data, face_index| {
                         Self::has_reserved_bit7_in_glyph_flags(data, face_index)
                     })
                     .unwrap_or(false);
 
                 if is_corrupted {
-                    for &id in &fontdb_ids {
-                        self.font_store.write().db_mut().remove_face(id);
-                    }
-                    bail!("Font {path:?} has corrupted glyf table (reserved bit 7 set on simple glyph flags)")
+                    corrupted_ids.push(id);
                 }
+            }
+
+            for &id in &corrupted_ids {
+                self.font_store.write().db_mut().remove_face(id);
+            }
+
+            if !corrupted_ids.is_empty() {
+                fontdb_ids.retain(|id| !corrupted_ids.contains(id));
+                log::warn!(
+                    "Removed {} corrupted face(s) from {path:?} (reserved bit 7 set on simple glyph flags)",
+                    corrupted_ids.len()
+                );
             }
         }
 
@@ -543,6 +566,42 @@ impl TextLayoutSystem {
 
         font_id_to_return
             .ok_or_else(|| anyhow!("Requested index for the font handle was unable to be loaded"))
+    }
+
+    /// Returns true if this font has been confirmed corrupted at runtime.
+    /// Rasterization callers should short-circuit and return empty bounds.
+    #[cfg_attr(feature = "fontkit-rasterizer", allow(dead_code))]
+    fn is_corrupted(&self, font_id: FontId) -> bool {
+        self.corrupted_fonts.read().contains(&font_id)
+    }
+
+    /// Increments the rasterization failure counter for this font.
+    /// When the threshold is exceeded, the font is removed from fontdb
+    /// so future font fallback queries skip it.
+    #[cfg_attr(feature = "fontkit-rasterizer", allow(dead_code))]
+    fn mark_font_corrupted(&self, font_id: FontId) {
+        const MAX_RASTER_FAILURES: u32 = 3;
+
+        {
+            let mut failures = self.raster_failures.write();
+            let count = failures.entry(font_id).or_insert(0);
+            *count += 1;
+            if *count < MAX_RASTER_FAILURES {
+                return;
+            }
+        }
+
+        if !self.corrupted_fonts.write().insert(font_id) {
+            return;
+        }
+
+        if let Some(&internal_id) = self.font_id_map.read().get_by_left(&font_id) {
+            self.font_store.write().db_mut().remove_face(internal_id);
+            log::warn!(
+                "Font (FontId {font_id:?}, fontdb face {internal_id}) marked as corrupted \
+                 after {MAX_RASTER_FAILURES} rasterization failures",
+            );
+        }
     }
 
     /// Checks whether reserved bit 7 is set on simple glyph coordinate flags.

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -1463,29 +1463,15 @@ impl TextLayoutSystem {
         self.families.read().get(&id).map(|family| family.name.to_owned())
     }
 
-    fn any_valid_font_id(&self) -> FontId {
-        if let Some(family) = self.families.read().values().next() {
-            return *family.font_ids.first();
-        }
-        self.font_id_map
-            .read()
-            .iter()
-            .next()
-            .map(|(font_id, _)| *font_id)
-            .expect("No fonts loaded")
-    }
-
     fn select_font(&self, family_id: FamilyId, properties: Properties) -> FontId {
         match self.font_selections.entry((family_id, properties)) {
             Entry::Occupied(entry) => *entry.get(),
             Entry::Vacant(entry) => {
                 let (family_name, first_font_id) = {
                     let families = self.families.read();
-                    let Some(family) = families.get(&family_id) else {
-                        let fallback = self.any_valid_font_id();
-                        entry.insert(fallback);
-                        return fallback;
-                    };
+                    let family = families
+                        .get(&family_id)
+                        .expect("Font family must exist");
                     (family.name.clone(), *family.font_ids.first())
                 };
 

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -507,15 +507,19 @@ impl TextLayoutSystem {
             }
 
             for &id in &corrupted_ids {
+                if let Some(face) = db.face(id) {
+                    log::warn!(
+                        "Removed corrupted face (reserved bit 7 set on simple glyph flags): id={}, family={:?}, source={:?}",
+                        id,
+                        face.families.first().map(|(n, _)| n),
+                        face.source,
+                    );
+                }
                 db.remove_face(id);
             }
 
             if !corrupted_ids.is_empty() {
                 fontdb_ids.retain(|id| !corrupted_ids.contains(id));
-                log::warn!(
-                    "Removed {} corrupted face(s) (reserved bit 7 set on simple glyph flags)",
-                    corrupted_ids.len()
-                );
             }
 
             fontdb_ids

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -380,7 +380,7 @@ struct FontKey {
 }
 
 pub struct TextLayoutSystem {
-    families: HashMap<FamilyId, Family>,
+    families: RwLock<HashMap<FamilyId, Family>>,
     /// The internal font database that stores all of our loaded fonts. Since internally,
     /// `cosmic_text` caches font selection, all of its functions to layout text are `&mut`.
     /// However, the `FontDB` trait for text layout is _immutable_ and cannot be easily changed to
@@ -435,7 +435,7 @@ impl FontDB {
         let font_ids = Vec1::try_from_vec(font_ids)?;
 
         let family_id = next_family_id();
-        self.text_layout_system.families.insert(
+        self.text_layout_system.families.write().insert(
             family_id,
             Family {
                 name: font_family.name,
@@ -629,8 +629,8 @@ impl TextLayoutSystem {
         let internal_id = internal_id
             .map(|id| format!("{id}"))
             .unwrap_or("None".to_string());
-        let family_name = self
-            .families
+        let families = self.families.read();
+        let family_name = families
             .values()
             .find(|family| family.font_ids.contains(&font_id))
             .map(|f| f.name.as_str())
@@ -845,6 +845,24 @@ impl TextLayoutSystem {
                         }
                     }
                     self.loaded_fonts.retain(|_, v| *v != font_id);
+                    let mut families = self.families.write();
+                    let mut empty_family_ids = Vec::new();
+                    for (family_id, family) in families.iter_mut() {
+                        let new_ids: Vec<FontId> = family
+                            .font_ids
+                            .iter()
+                            .copied()
+                            .filter(|id| *id != font_id)
+                            .collect();
+                        if new_ids.is_empty() {
+                            empty_family_ids.push(*family_id);
+                        } else {
+                            family.font_ids = Vec1::try_from_vec(new_ids).unwrap();
+                        }
+                    }
+                    for family_id in empty_family_ids {
+                        families.remove(&family_id);
+                    }
                 }
 
                 db.remove_face(db_id);
@@ -1437,15 +1455,15 @@ impl TextLayoutSystem {
     }
 
     fn load_family_name_from_id(&self, id: FamilyId) -> Option<String> {
-        self.families.get(&id).map(|family| family.name.to_owned())
+        self.families.read().get(&id).map(|family| family.name.to_owned())
     }
 
     fn select_font(&self, family_id: FamilyId, properties: Properties) -> FontId {
         match self.font_selections.entry((family_id, properties)) {
             Entry::Occupied(entry) => *entry.get(),
             Entry::Vacant(entry) => {
-                let family = self
-                    .families
+                let families = self.families.read();
+                let family = families
                     .get(&family_id)
                     .expect("Font family must exist");
 
@@ -1557,6 +1575,7 @@ impl TextLayoutSystem {
 
     fn family_id_for_name(&self, name: &str) -> Option<FamilyId> {
         self.families
+            .read()
             .iter()
             .find_map(|(family_id, family)| (family.name == name).then_some(*family_id))
     }

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -9,6 +9,7 @@ mod linux;
 
 #[cfg(target_os = "windows")]
 mod windows;
+use lazy_static::lazy_static;
 use std::any::Any;
 use std::collections::HashMap;
 use std::ops::{DerefMut, Range};
@@ -45,6 +46,190 @@ use crate::fonts::{
 use crate::platform::{self, LineStyle};
 use crate::rendering::GlyphConfig;
 use crate::text_layout::{CaretPosition, ClipConfig, Line, StyleAndFont, TextAlignment, TextFrame};
+
+lazy_static! {
+    /// Global cache of per-file bit7 glyph corruption check results.
+    /// `true` = clean, `false` = has reserved bit 7 set on simple glyph flags.
+    static ref BIT7_CHECKED_FONTS: DashMap<PathBuf, bool> = DashMap::new();
+
+    /// Paths that the background scanner found corrupted, pending removal from fontdb.
+    static ref PENDING_CORRUPTED_FONTS: std::sync::Mutex<Vec<PathBuf>> =
+        std::sync::Mutex::new(Vec::new());
+}
+
+/// Number of font faces in a font file (TTF or TTC).
+fn count_font_faces(data: &[u8]) -> usize {
+    if data.len() >= 12 && &data[0..4] == b"ttcf" {
+        u32::from_be_bytes([data[8], data[9], data[10], data[11]]) as usize
+    } else {
+        1
+    }
+}
+
+/// Checks whether any simple glyph in the `glyf` table has reserved bit 7 set
+/// on its coordinate flags. Fully parses all flags (respecting the repeat flag)
+/// for every simple glyph, rather than sampling.
+///
+/// Some fonts (notably DroidSansFallback.ttf) have this corruption, which
+/// causes skrifa/swash to reject all outline rendering from the font.
+fn has_reserved_bit7_in_glyph_flags(data: &[u8], face_index: u32) -> bool {
+    let face = match owned_ttf_parser::Face::parse(data, face_index) {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
+
+    let glyf_data = match face
+        .raw_face()
+        .table(owned_ttf_parser::Tag::from_bytes(b"glyf"))
+    {
+        Some(d) => d,
+        None => return false,
+    };
+    let loca_data = match face
+        .raw_face()
+        .table(owned_ttf_parser::Tag::from_bytes(b"loca"))
+    {
+        Some(d) => d,
+        None => return false,
+    };
+    let head_data = match face
+        .raw_face()
+        .table(owned_ttf_parser::Tag::from_bytes(b"head"))
+    {
+        Some(d) => d,
+        None => return false,
+    };
+
+    let index_to_loc_format = u16::from_be_bytes([head_data[50], head_data[51]]);
+    let num_glyphs = face.number_of_glyphs() as usize;
+
+    let read_loca = |idx: usize| -> Option<usize> {
+        if index_to_loc_format == 1 {
+            let base = 4 * idx;
+            if base + 4 > loca_data.len() {
+                return None;
+            }
+            Some(u32::from_be_bytes([
+                loca_data[base],
+                loca_data[base + 1],
+                loca_data[base + 2],
+                loca_data[base + 3],
+            ]) as usize)
+        } else {
+            let base = 2 * idx;
+            if base + 2 > loca_data.len() {
+                return None;
+            }
+            Some(u16::from_be_bytes([loca_data[base], loca_data[base + 1]]) as usize * 2)
+        }
+    };
+
+    for glyph_index in 0..num_glyphs {
+        let Some(offset) = read_loca(glyph_index) else {
+            continue;
+        };
+        let Some(next_offset) = read_loca(glyph_index + 1) else {
+            continue;
+        };
+
+        if offset + 2 > next_offset || offset + 2 > glyf_data.len() {
+            continue;
+        }
+
+        let num_contours = i16::from_be_bytes([glyf_data[offset], glyf_data[offset + 1]]);
+        if num_contours <= 0 {
+            continue;
+        }
+
+        let end_pts_offset = offset + 10;
+        let end_pts_count = num_contours as usize;
+        let end_pts_end = end_pts_offset + end_pts_count * 2;
+        if end_pts_end > next_offset || end_pts_end > glyf_data.len() {
+            continue;
+        }
+
+        let total_points =
+            u16::from_be_bytes([glyf_data[end_pts_end - 2], glyf_data[end_pts_end - 1]]) as usize
+                + 1;
+
+        let ins_len_offset = end_pts_end;
+        if ins_len_offset + 2 > next_offset || ins_len_offset + 2 > glyf_data.len() {
+            continue;
+        }
+        let ins_len =
+            u16::from_be_bytes([glyf_data[ins_len_offset], glyf_data[ins_len_offset + 1]]) as usize;
+
+        let flags_start = ins_len_offset + 2 + ins_len;
+        if flags_start > next_offset || flags_start > glyf_data.len() {
+            continue;
+        }
+
+        let mut flags_pos = flags_start;
+        let mut points_processed = 0;
+        while points_processed < total_points {
+            if flags_pos >= next_offset || flags_pos >= glyf_data.len() {
+                break;
+            }
+            let flag = glyf_data[flags_pos];
+            flags_pos += 1;
+            points_processed += 1;
+
+            if flag & 0x80 != 0 {
+                return true;
+            }
+
+            if flag & 0x08 != 0 {
+                if flags_pos >= next_offset || flags_pos >= glyf_data.len() {
+                    break;
+                }
+                let repeat_count = glyf_data[flags_pos];
+                flags_pos += 1;
+                points_processed += repeat_count as usize;
+            }
+        }
+    }
+
+    false
+}
+
+/// Lazily initializes the background font scanner thread and returns a sender.
+/// The scanner reads font files from disk, checks for bit7 glyph corruption,
+/// and caches results in `BIT7_CHECKED_FONTS`. Corrupted paths are queued
+/// for removal from fontdb by `TextLayoutSystem::drain_corrupted_fonts`.
+fn background_scan_tx() -> &'static std::sync::mpsc::Sender<PathBuf> {
+    static TX: std::sync::OnceLock<std::sync::mpsc::Sender<PathBuf>> = std::sync::OnceLock::new();
+    TX.get_or_init(|| {
+        let (tx, rx) = std::sync::mpsc::channel::<PathBuf>();
+        std::thread::Builder::new()
+            .name("font-bit7-scanner".into())
+            .spawn(move || {
+                while let Ok(path) = rx.recv() {
+                    let data = match std::fs::read(&path) {
+                        Ok(d) => d,
+                        Err(_) => continue,
+                    };
+                    let num_faces = count_font_faces(&data);
+                    let mut any_corrupted = false;
+                    for face_index in 0..num_faces {
+                        if has_reserved_bit7_in_glyph_flags(&data, face_index as u32) {
+                            any_corrupted = true;
+                            break;
+                        }
+                    }
+                    BIT7_CHECKED_FONTS.insert(path.clone(), !any_corrupted);
+                    if any_corrupted {
+                        log::warn!(
+                            "Background font scan: found corrupted font at {}",
+                            path.display(),
+                        );
+                        PENDING_CORRUPTED_FONTS.lock().unwrap().push(path);
+                    }
+                }
+            })
+            .ok();
+        tx
+    })
+}
 
 struct FontFamily {
     name: String,
@@ -474,6 +659,26 @@ impl TextLayoutSystem {
             }
         }
 
+        if let Source::File(path) = &source {
+            if BIT7_CHECKED_FONTS.get(path).is_some_and(|r| !*r) {
+                log::info!(
+                    "bit7 glyph flag scan: skipped (cached corrupted), path={}",
+                    path.display()
+                );
+                bail!("Font source has corrupted glyphs (bit 7 set on simple glyph flags)");
+            }
+        }
+
+        // Remove any faces from fontdb that the background scanner found corrupted.
+        self.drain_corrupted_fonts();
+
+        // Queue a background scan for uncached file-based fonts.
+        if let Source::File(path) = &source {
+            if !BIT7_CHECKED_FONTS.contains_key(path) {
+                background_scan_tx().send(path.clone()).ok();
+            }
+        }
+
         // TODO(alokedesai): Consider using FontDB's `make_shared_font_data` here. FontDB creates a temporary memory
         // mapped file every time data is read via a call to `with_face_data`. When rendering text this can
         // repeatedly cause allocation of a large amount of virtual address space, especially when trying to load
@@ -481,48 +686,7 @@ impl TextLayoutSystem {
         let fontdb_ids = {
             let mut font_store = self.font_store.write();
             let db = font_store.db_mut();
-            let mut fontdb_ids = db.load_font_source(source);
-
-            // For file-based fonts: reuse fontdb's mmap'd data to check for
-            // corrupted glyf tables (reserved bit 7 on simple glyph flags).
-            // Corrupted faces are removed from the database immediately so they
-            // cannot be matched by future font fallback queries.
-            let mut corrupted_ids = Vec::new();
-            for &id in &fontdb_ids {
-                let is_file_based = db
-                    .face(id)
-                    .is_some_and(|f| matches!(f.source, Source::File(_)));
-                if !is_file_based {
-                    continue;
-                }
-                let is_corrupted = db
-                    .with_face_data(id, |data, face_index| {
-                        Self::has_reserved_bit7_in_glyph_flags(data, face_index)
-                    })
-                    .unwrap_or(false);
-
-                if is_corrupted {
-                    corrupted_ids.push(id);
-                }
-            }
-
-            for &id in &corrupted_ids {
-                if let Some(face) = db.face(id) {
-                    log::warn!(
-                        "Removed corrupted face (reserved bit 7 set on simple glyph flags): id={}, family={:?}, source={:?}",
-                        id,
-                        face.families.first().map(|(n, _)| n),
-                        face.source,
-                    );
-                }
-                db.remove_face(id);
-            }
-
-            if !corrupted_ids.is_empty() {
-                fontdb_ids.retain(|id| !corrupted_ids.contains(id));
-            }
-
-            fontdb_ids
+            db.load_font_source(source)
         };
 
         if fontdb_ids.is_empty() {
@@ -564,132 +728,54 @@ impl TextLayoutSystem {
             .ok_or_else(|| anyhow!("Requested index for the font handle was unable to be loaded"))
     }
 
-    /// Checks whether any simple glyph in the `glyf` table has reserved bit 7 set
-    /// on its coordinate flags. Fully parses all flags (respecting the repeat flag)
-    /// for every simple glyph, rather than sampling.
-    ///
-    /// Some fonts (notably DroidSansFallback.ttf) have this corruption, which
-    /// causes skrifa/swash to reject all outline rendering from the font.
-    fn has_reserved_bit7_in_glyph_flags(data: &[u8], face_index: u32) -> bool {
-        let face = match owned_ttf_parser::Face::parse(data, face_index) {
-            Ok(f) => f,
-            Err(_) => return false,
-        };
-
-        let glyf_data = match face
-            .raw_face()
-            .table(owned_ttf_parser::Tag::from_bytes(b"glyf"))
-        {
-            Some(d) => d,
-            None => return false,
-        };
-        let loca_data = match face
-            .raw_face()
-            .table(owned_ttf_parser::Tag::from_bytes(b"loca"))
-        {
-            Some(d) => d,
-            None => return false,
-        };
-        let head_data = match face
-            .raw_face()
-            .table(owned_ttf_parser::Tag::from_bytes(b"head"))
-        {
-            Some(d) => d,
-            None => return false,
-        };
-
-        let index_to_loc_format = u16::from_be_bytes([head_data[50], head_data[51]]);
-        let num_glyphs = face.number_of_glyphs() as usize;
-
-        let read_loca = |idx: usize| -> Option<usize> {
-            if index_to_loc_format == 1 {
-                let base = 4 * idx;
-                if base + 4 > loca_data.len() {
-                    return None;
-                }
-                Some(u32::from_be_bytes([
-                    loca_data[base],
-                    loca_data[base + 1],
-                    loca_data[base + 2],
-                    loca_data[base + 3],
-                ]) as usize)
-            } else {
-                let base = 2 * idx;
-                if base + 2 > loca_data.len() {
-                    return None;
-                }
-                Some(u16::from_be_bytes([loca_data[base], loca_data[base + 1]]) as usize * 2)
-            }
-        };
-
-        for glyph_index in 0..num_glyphs {
-            let Some(offset) = read_loca(glyph_index) else {
-                continue;
-            };
-            let Some(next_offset) = read_loca(glyph_index + 1) else {
-                continue;
-            };
-
-            if offset + 2 > next_offset || offset + 2 > glyf_data.len() {
-                continue;
-            }
-
-            let num_contours = i16::from_be_bytes([glyf_data[offset], glyf_data[offset + 1]]);
-            if num_contours <= 0 {
-                continue;
-            }
-
-            let end_pts_offset = offset + 10;
-            let end_pts_count = num_contours as usize;
-            let end_pts_end = end_pts_offset + end_pts_count * 2;
-            if end_pts_end > next_offset || end_pts_end > glyf_data.len() {
-                continue;
-            }
-
-            let total_points =
-                u16::from_be_bytes([glyf_data[end_pts_end - 2], glyf_data[end_pts_end - 1]])
-                    as usize
-                    + 1;
-
-            let ins_len_offset = end_pts_end;
-            if ins_len_offset + 2 > next_offset || ins_len_offset + 2 > glyf_data.len() {
-                continue;
-            }
-            let ins_len =
-                u16::from_be_bytes([glyf_data[ins_len_offset], glyf_data[ins_len_offset + 1]])
-                    as usize;
-
-            let flags_start = ins_len_offset + 2 + ins_len;
-            if flags_start > next_offset || flags_start > glyf_data.len() {
-                continue;
-            }
-
-            let mut flags_pos = flags_start;
-            let mut points_processed = 0;
-            while points_processed < total_points {
-                if flags_pos >= next_offset || flags_pos >= glyf_data.len() {
-                    break;
-                }
-                let flag = glyf_data[flags_pos];
-                flags_pos += 1;
-                points_processed += 1;
-
-                if flag & 0x80 != 0 {
-                    return true;
-                }
-
-                if flag & 0x08 != 0 {
-                    if flags_pos >= next_offset || flags_pos >= glyf_data.len() {
-                        break;
-                    }
-                    let repeat_count = glyf_data[flags_pos];
-                    flags_pos += 1;
-                    points_processed += repeat_count as usize;
-                }
-            }
+    /// Drains all pending corrupted font paths from the background scanner queue
+    /// and removes the corresponding faces from this instance's fontdb, cleaning
+    /// up all associated maps (`font_id_map`, `loaded_fonts`, `font_selections`,
+    /// and `fallback_fonts`).
+    fn drain_corrupted_fonts(&self) {
+        let paths: Vec<PathBuf> = PENDING_CORRUPTED_FONTS.lock().unwrap().drain(..).collect();
+        if paths.is_empty() {
+            return;
         }
 
-        false
+        for path in &paths {
+            let mut font_store = self.font_store.write();
+            let db = font_store.db_mut();
+
+            let ids: Vec<fontdb::ID> = db
+                .faces()
+                .filter(|f| matches!(&f.source, Source::File(p) if p == path))
+                .map(|f| f.id)
+                .collect();
+
+            if ids.is_empty() {
+                continue;
+            }
+
+            log::info!(
+                "Removing {} corrupted face(s) for {}",
+                ids.len(),
+                path.display(),
+            );
+
+            for &db_id in &ids {
+                let mut font_id_map = self.font_id_map.write();
+                if let Some((font_id, _)) = font_id_map.remove_by_right(&db_id) {
+                    drop(font_id_map);
+                    self.font_selections.retain(|_, v| *v != font_id);
+                    #[cfg(not(target_os = "windows"))]
+                    {
+                        self.fallback_fonts.remove(&font_id);
+                        for mut entry in self.fallback_fonts.iter_mut() {
+                            entry.value_mut().retain(|id| *id != font_id);
+                        }
+                    }
+                    self.loaded_fonts.retain(|_, v| *v != font_id);
+                }
+
+                db.remove_face(db_id);
+            }
+        }
     }
 
     /// Loads all of the fallback fonts for the `font_id` with a given `family_name` and set of `properties`.

--- a/crates/warpui/src/windowing/winit/fonts.rs
+++ b/crates/warpui/src/windowing/winit/fonts.rs
@@ -669,10 +669,11 @@ impl TextLayoutSystem {
             }
         }
 
-        if let Source::File(path) = &source {
-            if BIT7_CHECKED_FONTS
-                .get(&(path.clone(), index))
-                .is_some_and(|r| !*r)
+        match &source {
+            Source::File(path)
+                if BIT7_CHECKED_FONTS
+                    .get(&(path.clone(), index))
+                    .is_some_and(|r| !*r) =>
             {
                 log::info!(
                     "bit7 glyph flag scan: skipped (cached corrupted), path={}, index={index}",
@@ -680,16 +681,18 @@ impl TextLayoutSystem {
                 );
                 bail!("Font face has corrupted glyphs (bit 7 set on simple glyph flags)");
             }
+            _ => {}
         }
 
         // Remove any faces from fontdb that the background scanner found corrupted.
         self.drain_corrupted_fonts();
 
         // Queue a background scan for paths not yet fully scanned.
-        if let Source::File(path) = &source {
-            if !SCANNED_PATHS.contains(path) {
+        match &source {
+            Source::File(path) if !SCANNED_PATHS.contains(path) => {
                 background_scan_tx().send(path.clone()).ok();
             }
+            _ => {}
         }
 
         // TODO(alokedesai): Consider using FontDB's `make_shared_font_data` here. FontDB creates a temporary memory

--- a/crates/warpui/src/windowing/winit/fonts/swash_rasterizer.rs
+++ b/crates/warpui/src/windowing/winit/fonts/swash_rasterizer.rs
@@ -20,11 +20,6 @@ impl FontDB {
         scale: Vector2F,
         _glyph_config: &GlyphConfig,
     ) -> Result<RectI> {
-        // Short-circuit for fonts already confirmed corrupted at runtime.
-        if self.text_layout_system.is_corrupted(font_id) {
-            return Ok(RectI::new(Vector2I::zero(), Vector2I::zero()));
-        }
-
         let Ok(_typographic_bounds) = self
             .glyph_typographic_bounds(font_id, glyph_id)
             .map(|bounds| bounds.to_f32())
@@ -56,20 +51,8 @@ impl FontDB {
                 )
                 .0,
             )
-            .clone();
-
-        let image = match image {
-            Some(img) => img,
-            None => {
-                // A non-zero glyph ID that swash cannot rasterize may indicate
-                // a corrupted glyf table. Mark the font for removal after a
-                // threshold of failures.
-                if glyph_id != 0 {
-                    self.text_layout_system.mark_font_corrupted(font_id);
-                }
-                return Err(anyhow!("Failed to get raster image"));
-            }
-        };
+            .clone()
+            .ok_or_else(|| anyhow!("Failed to get raster image"))?;
 
         let origin = vec2i(image.placement.left, -image.placement.top);
         let size = vec2i(image.placement.width as i32, image.placement.height as i32);
@@ -87,12 +70,6 @@ impl FontDB {
         glyph_config: &GlyphConfig,
         requested_format: RasterFormat,
     ) -> Result<RasterizedGlyph> {
-        // Safety net for fonts confirmed corrupted between glyph_raster_bounds
-        // and rasterize_glyph calls.
-        if self.text_layout_system.is_corrupted(font_id) {
-            anyhow::bail!("Font {font_id:?} is corrupted");
-        }
-
         let raster_bounds =
             self.glyph_raster_bounds(font_id, size, glyph_id, scale, glyph_config)?;
 
@@ -117,17 +94,8 @@ impl FontDB {
                 )
                 .0,
             )
-            .clone();
-
-        let image = match image {
-            Some(img) => img,
-            None => {
-                if glyph_id != 0 {
-                    self.text_layout_system.mark_font_corrupted(font_id);
-                }
-                return Err(anyhow!("Failed to get raster image"));
-            }
-        };
+            .clone()
+            .unwrap();
 
         let (original_format, is_color) = match image.content {
             cosmic_text::SwashContent::Mask => (RasterFormat::A8, false),

--- a/crates/warpui/src/windowing/winit/fonts/swash_rasterizer.rs
+++ b/crates/warpui/src/windowing/winit/fonts/swash_rasterizer.rs
@@ -20,6 +20,11 @@ impl FontDB {
         scale: Vector2F,
         _glyph_config: &GlyphConfig,
     ) -> Result<RectI> {
+        // Short-circuit for fonts already confirmed corrupted at runtime.
+        if self.text_layout_system.is_corrupted(font_id) {
+            return Ok(RectI::new(Vector2I::zero(), Vector2I::zero()));
+        }
+
         let Ok(_typographic_bounds) = self
             .glyph_typographic_bounds(font_id, glyph_id)
             .map(|bounds| bounds.to_f32())
@@ -51,8 +56,20 @@ impl FontDB {
                 )
                 .0,
             )
-            .clone()
-            .ok_or_else(|| anyhow!("Failed to get raster image"))?;
+            .clone();
+
+        let image = match image {
+            Some(img) => img,
+            None => {
+                // A non-zero glyph ID that swash cannot rasterize may indicate
+                // a corrupted glyf table. Mark the font for removal after a
+                // threshold of failures.
+                if glyph_id != 0 {
+                    self.text_layout_system.mark_font_corrupted(font_id);
+                }
+                return Err(anyhow!("Failed to get raster image"));
+            }
+        };
 
         let origin = vec2i(image.placement.left, -image.placement.top);
         let size = vec2i(image.placement.width as i32, image.placement.height as i32);
@@ -70,6 +87,12 @@ impl FontDB {
         glyph_config: &GlyphConfig,
         requested_format: RasterFormat,
     ) -> Result<RasterizedGlyph> {
+        // Safety net for fonts confirmed corrupted between glyph_raster_bounds
+        // and rasterize_glyph calls.
+        if self.text_layout_system.is_corrupted(font_id) {
+            anyhow::bail!("Font {font_id:?} is corrupted");
+        }
+
         let raster_bounds =
             self.glyph_raster_bounds(font_id, size, glyph_id, scale, glyph_config)?;
 
@@ -94,8 +117,17 @@ impl FontDB {
                 )
                 .0,
             )
-            .clone()
-            .unwrap();
+            .clone();
+
+        let image = match image {
+            Some(img) => img,
+            None => {
+                if glyph_id != 0 {
+                    self.text_layout_system.mark_font_corrupted(font_id);
+                }
+                return Err(anyhow!("Failed to get raster image"));
+            }
+        };
 
         let (original_format, is_color) = match image.content {
             cosmic_text::SwashContent::Mask => (RasterFormat::A8, false),


### PR DESCRIPTION
## Description

Reject fonts with reserved bit 7 set on simple glyph coordinate flags in the `glyf` table. Some Linux fonts (notably DroidSansFallback.ttf from `ttf-droid`) have this corruption — `skrifa`/`swash` correctly enforces the spec and rejects all outlines, causing CJK glyphs to render as `.notdef` squares.
Detection runs at font-load time using `fontdb::with_face_data` (reuses fontdb's existing mmap; zero extra I/O for healthy fonts). Corrupted faces are removed from the database so they can never be matched by future fallback queries.

## Linked Issue

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Closes #9372.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

Manual verification:
1. Confirmed `has_reserved_bit7_in_glyph_flags` returns `true` for `DroidSansFallback.ttf` and `DroidSansFallbackFull.ttf`, `false` for `DroidSansFallbackLegacy.ttf`.
2. Before fix: CJK characters routed to `DroidSansFallback.ttf` render as empty.
3. After fix: same characters render correctly — the corrupted font is skipped and fontconfig's next fallback is used.

Comparison: <img alt="Image" width="1475" height="839" src="https://private-user-images.githubusercontent.com/55276797/615236233-ab006319-d211-4e00-bf5b-dece1b809504.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3ODI4NjA1NDIsIm5iZiI6MTc4Mjg2MDI0MiwicGF0aCI6Ii81NTI3Njc5Ny82MTUyMzYyMzMtYWIwMDYzMTktZDIxMS00ZTAwLWJmNWItZGVjZTFiODA5NTA0LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA2MzAlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNjMwVDIyNTcyMlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWI2YWUzN2QzMThmZTQ1ZDg0MjUzMjQwMjRjOTJjZDZmYTExMTc5MmUzNjE1OGFhZjdkYzM4ZjJjNjMxNDczNTMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT1pbWFnZSUyRnBuZyJ9.MHTiaqPevSXwACnHt4S8MghnRS2DteYjx4JH856aax0">

### **We can actually use DroidSansFallback.ttf but it requires some hacky patching. If that is allowed then I will refactor this fix.**

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Reject fonts with corrupted glyf table (reserved bit 7 on simple glyph flags) that caused CJK glyphs to render as .notdef squares on Linux