### PR TITLE
Add "Copy file path" to file viewer pane right-click menu

### DIFF
--- a/app/src/notebooks/context_menu.rs
+++ b/app/src/notebooks/context_menu.rs
@@ -2,6 +2,7 @@
 
 use pathfinder_geometry::vector::Vector2F;
 use warp_core::context_flag::ContextFlag;
+use warpui::clipboard::ClipboardContent;
 use warpui::elements::{ChildAnchor, OffsetPositioning, ParentAnchor, ParentOffsetBounds, Stack};
 use warpui::keymap::Trigger;
 use warpui::presenter::ChildView;
@@ -33,6 +34,10 @@ where
     menu: ViewHandle<Menu<V::Action>>,
     /// Focus state of the pane containing this context menu.
     focus_handle: Option<PaneFocusHandle>,
+    /// The display path of the file backing this pane, if any. When set, the menu offers a
+    /// "Copy file path" item. Only file-backed views (e.g. the file viewer) set this; for other
+    /// notebooks it stays `None` and the item is hidden.
+    copy_file_path: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -71,11 +76,18 @@ where
             source: None,
             menu,
             focus_handle: None,
+            copy_file_path: None,
         }
     }
 
     pub(super) fn set_focus_handle(&mut self, focus_handle: PaneFocusHandle) {
         self.focus_handle = Some(focus_handle);
+    }
+
+    /// Set the display path used by the "Copy file path" menu item. Pass `None` to hide the item
+    /// (e.g. for notebooks not backed by a file).
+    pub(super) fn set_copy_file_path(&mut self, path: Option<String>) {
+        self.copy_file_path = path;
     }
 
     /// Renders the context menu, if it's open.
@@ -132,6 +144,18 @@ where
                 .with_on_select_action(V::Action::from(ContextMenuAction::Paste))
                 .with_key_shortcut_label(custom_action_to_display(CustomAction::Paste));
             items.push(item.into_item());
+        }
+
+        // Section 1b: Copy file path (only for file-backed panes).
+        if self.copy_file_path.is_some() {
+            if !items.is_empty() {
+                items.push(MenuItem::Separator);
+            }
+            items.push(
+                MenuItemFields::new("Copy file path")
+                    .with_on_select_action(V::Action::from(ContextMenuAction::CopyFilePath))
+                    .into_item(),
+            );
         }
 
         // Section 2: Split-pane actions
@@ -297,6 +321,11 @@ where
                 }
                 None => (),
             },
+            ContextMenuAction::CopyFilePath => {
+                if let Some(path) = self.copy_file_path.clone() {
+                    ctx.clipboard().write(ClipboardContent::plain_text(path));
+                }
+            }
             ContextMenuAction::EmitPaneEvent(event) => ctx.emit(V::Event::from(event.clone())),
         }
     }
@@ -347,5 +376,6 @@ pub enum ContextMenuAction {
     CopySelectedText,
     CutSelectedText,
     Paste,
+    CopyFilePath,
     EmitPaneEvent(PaneEvent),
 }

--- a/app/src/notebooks/context_menu_tests.rs
+++ b/app/src/notebooks/context_menu_tests.rs
@@ -254,3 +254,85 @@ fn test_split_pane_actions() {
         });
     });
 }
+
+#[test]
+fn test_copy_file_path_action() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let (_window_id, notebook) = app.add_window(WindowStyle::NotStealFocus, NotebookView::new);
+
+        // When a path is set, "Copy file path" appears as its own section, separated from the
+        // text-action section (here "Paste") and the split-pane section.
+        notebook.update(&mut app, |notebook, ctx| {
+            notebook
+                .context_menu()
+                .set_copy_file_path(Some("/tmp/notes.md".to_string()));
+            let source = MenuSource::RichTextEditor {
+                parent_offset: vec2f(0., 0.),
+                editor: notebook.input_editor(),
+            };
+            notebook.context_menu().show_context_menu(source, ctx);
+            assert_eq!(
+                notebook.context_menu().item_names(ctx),
+                vec![
+                    "Paste",
+                    "----",
+                    "Copy file path",
+                    "----",
+                    "Split pane right",
+                    "Split pane left",
+                    "Split pane down",
+                    "Split pane up",
+                ]
+            );
+        });
+
+        // With an empty text-action section (read-only, no selection), "Copy file path" leads the
+        // menu with no separator before it.
+        notebook.update(&mut app, |notebook, ctx| {
+            notebook.input_editor().update(ctx, |editor, ctx| {
+                editor.set_interaction_state(InteractionState::Selectable, ctx)
+            });
+            notebook
+                .context_menu()
+                .set_copy_file_path(Some("/tmp/notes.md".to_string()));
+            let source = MenuSource::RichTextEditor {
+                parent_offset: vec2f(0., 0.),
+                editor: notebook.input_editor(),
+            };
+            notebook.context_menu().show_context_menu(source, ctx);
+            assert_eq!(
+                notebook.context_menu().item_names(ctx),
+                vec![
+                    "Copy file path",
+                    "----",
+                    "Split pane right",
+                    "Split pane left",
+                    "Split pane down",
+                    "Split pane up",
+                ]
+            );
+        });
+
+        // When no path is set, the item is absent (the default for non-file notebooks). The
+        // editor is still read-only from above, so only the split-pane items remain.
+        notebook.update(&mut app, |notebook, ctx| {
+            notebook.context_menu().set_copy_file_path(None);
+            let source = MenuSource::RichTextEditor {
+                parent_offset: vec2f(0., 0.),
+                editor: notebook.input_editor(),
+            };
+            notebook.context_menu().show_context_menu(source, ctx);
+            assert_eq!(
+                notebook.context_menu().item_names(ctx),
+                vec![
+                    "Split pane right",
+                    "Split pane left",
+                    "Split pane down",
+                    "Split pane up",
+                ]
+            );
+        });
+    });
+}

--- a/app/src/notebooks/file/mod.rs
+++ b/app/src/notebooks/file/mod.rs
@@ -1047,6 +1047,8 @@ impl TypedActionView for FileNotebookView {
             FileNotebookAction::ContextMenu(action) => {
                 if matches!(action, ContextMenuAction::Open(_)) {
                     self.send_telemetry_action(NotebookTelemetryAction::OpenContextMenu, ctx);
+                    let copy_file_path = self.file_state.path().map(|p| p.display_path());
+                    self.context_menu.set_copy_file_path(copy_file_path);
                 }
                 self.context_menu.handle_action(action, ctx);
             }


### PR DESCRIPTION
Closes #8974

## What

Right-clicking inside a file opened in Warp's rendered file viewer (`FileNotebookView`, e.g. a markdown file) previously only offered the four split-pane options. This PR adds a **"Copy file path"** entry to that right-click context menu — the right-click portion requested in #8974 (the overflow-menu "Copy file path" already exists).

- Matches the wording already used in the pane's header overflow menu and copies the same `display_path()` string, so it works for both local and remote files.
- Scoped to file-backed panes: `FileNotebookView` sets the current file's path when the menu opens; regular notebooks never set it, so the item stays hidden there.

## How

- `app/src/notebooks/context_menu.rs` — added `copy_file_path` state + setter to the shared `ContextMenuState`, the new menu item (inserted between the text-action and split-pane sections with correct separator handling), a `ContextMenuAction::CopyFilePath` variant, and a clipboard-write handler.
- `app/src/notebooks/file/mod.rs` — sets the open file's `display_path()` on the menu when it's opened.
- `app/src/notebooks/context_menu_tests.rs` — added `test_copy_file_path_action` covering: item present + separated when a text section exists, item leading the menu when the text section is empty, and item absent when no path is set.

## Testing

- `cargo check -p warp --lib` → passes, no errors.
- `cargo test -p warp --lib test_copy_file_path_action` → passes.
