### PR TITLE
Reduce active-path (typing/scroll) GPU on Linux/Wayland iGPUs

### DIFF
--- a/app/src/editor/view/element.rs
+++ b/app/src/editor/view/element.rs
@@ -1828,6 +1828,12 @@ impl Element for EditorElement {
                 rect: bounds,
                 origin: Point::from_vec2f(origin, ctx.scene.z_index()),
             });
+            // Record this editor's bounds so a text-edit-only frame (see
+            // ViewContext::notify_region / SceneDamage::Partial, e.g. typing into
+            // the prompt) can repaint just this region instead of the whole
+            // window. The renderer falls back to a full repaint if these bounds
+            // change between frames (a layout change that moves sibling content).
+            ctx.scene.record_damage_rect(bounds);
             let view_snapshot = &self.view_snapshot;
             let cursor_height =
                 Self::cursor_height(view_snapshot.font_size, view_snapshot.line_height_ratio);

--- a/app/src/editor/view/element.rs
+++ b/app/src/editor/view/element.rs
@@ -853,6 +853,10 @@ impl EditorElement {
                 .draw_rect_with_hit_recording(cursor_rect)
                 .with_background(cursor.color)
                 .with_corner_radius(CornerRadius::with_all(cursor_corner_radius));
+            // Record the cursor bounds so the renderer can compute a small damage
+            // region and repaint just the cursor on a blink instead of the whole
+            // window (see SceneDamage::CursorOnly).
+            ctx.scene.record_cursor_rect(cursor_rect);
 
             // Draw cursor avatars for remote selections
             if !is_local {

--- a/app/src/editor/view/mod.rs
+++ b/app/src/editor/view/mod.rs
@@ -7468,7 +7468,9 @@ impl EditorView {
             )
         {
             self.cursors_visible = !self.cursors_visible;
-            ctx.notify();
+            // Only the cursor changed: let the renderer repaint just the cursor
+            // region instead of re-rasterizing the whole window every 500ms.
+            ctx.notify_cursor_only();
 
             let epoch = self.next_blink_epoch();
             let _ = ctx.spawn(

--- a/app/src/editor/view/mod.rs
+++ b/app/src/editor/view/mod.rs
@@ -7508,6 +7508,13 @@ impl EditorView {
         event: &EditorModelEvent,
         ctx: &mut ViewContext<Self>,
     ) {
+        // Whether this change is confined to this editor's own rendered content
+        // (e.g. typing into the prompt) and so can request a partial,
+        // region-only repaint instead of re-rasterizing the whole window. Any
+        // other view that changes this frame issues its own `notify()`, which
+        // forces a full repaint; and the renderer falls back to full if this
+        // editor's bounds change (a layout change). Both keep this safe.
+        let mut region_only = false;
         match event {
             EditorModelEvent::Edited { edit_origin } => {
                 // Update the autosuggestion state after an edit.
@@ -7515,6 +7522,7 @@ impl EditorView {
                 self.vim_maybe_enforce_cursor_line_cap(ctx);
                 self.accept_autosuggestion_keybinding_view
                     .update(ctx, |view, ctx| view.close_menu(ctx));
+                region_only = true;
                 ctx.emit(Event::Edited(*edit_origin))
             }
             EditorModelEvent::BufferReplaced => ctx.emit(Event::BufferReplaced),
@@ -7545,7 +7553,11 @@ impl EditorView {
             self.reset_cursor_blink_timer(ctx);
         }
         *self.autoscroll_requested.lock() = true;
-        ctx.notify();
+        if region_only {
+            ctx.notify_region();
+        } else {
+            ctx.notify();
+        }
     }
 
     /// When in Vim mode, specifically normal mode, the block cursor cannot go past the last

--- a/crates/warpui/src/rendering/wgpu/renderer.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer.rs
@@ -103,7 +103,51 @@ impl Renderer {
 
         let mut encoder = device.create_command_encoder(&ENCODER_DESCRIPTOR);
         let (_, error) = with_error_scope(device, || {
-            frame.draw(resources, &mut encoder, &surface_texture);
+            let surface_width = surface_texture.texture.width();
+            let surface_height = surface_texture.texture.height();
+            let surface_size = Vector2F::new(surface_width as f32, surface_height as f32);
+
+            match resources.offscreen_target(surface_width, surface_height) {
+                Some((offscreen_texture, offscreen_view)) => {
+                    // Render the scene into the persistent offscreen target, then
+                    // copy it into the swapchain image. The copy is a cheap GPU
+                    // blit (not a re-rasterization); keeping the offscreen target
+                    // between frames is what will let damage frames re-rasterize
+                    // and copy only the changed region.
+                    frame.draw(resources, &mut encoder, &offscreen_view, surface_size);
+                    encoder.copy_texture_to_texture(
+                        wgpu::TexelCopyTextureInfo {
+                            texture: &offscreen_texture,
+                            mip_level: 0,
+                            origin: wgpu::Origin3d::ZERO,
+                            aspect: wgpu::TextureAspect::All,
+                        },
+                        wgpu::TexelCopyTextureInfo {
+                            texture: &surface_texture.texture,
+                            mip_level: 0,
+                            origin: wgpu::Origin3d::ZERO,
+                            aspect: wgpu::TextureAspect::All,
+                        },
+                        wgpu::Extent3d {
+                            width: surface_width,
+                            height: surface_height,
+                            depth_or_array_layers: 1,
+                        },
+                    );
+                }
+                None => {
+                    // Surface can't be a copy destination; render straight to it.
+                    let view =
+                        surface_texture
+                            .texture
+                            .create_view(&wgpu::TextureViewDescriptor {
+                                format: Some(surface_texture.texture.format()),
+                                ..Default::default()
+                            });
+                    frame.draw(resources, &mut encoder, &view, surface_size);
+                }
+            }
+
             queue.submit(Some(encoder.finish()));
         });
 

--- a/crates/warpui/src/rendering/wgpu/renderer.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer.rs
@@ -5,7 +5,8 @@ mod rect;
 mod util;
 
 use frame::Frame;
-use pathfinder_geometry::vector::Vector2F;
+use pathfinder_geometry::rect::RectF;
+use pathfinder_geometry::vector::{vec2f, Vector2F};
 use util::with_error_scope;
 use warpui_core::platform::CapturedFrame;
 use wgpu::wgc::device::DeviceError;
@@ -15,6 +16,7 @@ pub use super::resources::{GetSurfaceTextureError, SurfaceConfigureError};
 use crate::r#async::block_on;
 use crate::rendering::wgpu::Resources;
 use crate::rendering::{GlyphConfig, GlyphRasterBoundsFn, RasterizeGlyphFn};
+use crate::scene::SceneDamage;
 use crate::Scene;
 
 const ENCODER_DESCRIPTOR: wgpu::CommandEncoderDescriptor = wgpu::CommandEncoderDescriptor {
@@ -25,6 +27,15 @@ pub struct Renderer {
     rect_pipeline: rect::Pipeline,
     glyph_pipeline: glyph::Pipeline,
     image_pipeline: image::Pipeline,
+    /// Whether the offscreen target currently holds a valid full render at
+    /// `offscreen_size`. Only then can a cursor-only frame `Load`+scissor onto it.
+    offscreen_valid: bool,
+    /// Surface size (device px) the offscreen target was last fully rendered at.
+    offscreen_size: Option<(u32, u32)>,
+    /// Device-space cursor rects from the previous frame. Unioned with the
+    /// current frame's cursor rects to form the damage region for a cursor-only
+    /// repaint (so the region the cursor just vacated is also repainted).
+    prev_cursor_rects: Vec<RectF>,
 }
 
 impl Renderer {
@@ -58,6 +69,9 @@ impl Renderer {
             rect_pipeline,
             glyph_pipeline,
             image_pipeline,
+            offscreen_valid: false,
+            offscreen_size: None,
+            prev_cursor_rects: Vec::new(),
         }
     }
 
@@ -100,24 +114,58 @@ impl Renderer {
         };
 
         let surface_texture = resources.get_surface_texture()?;
+        let surface_width = surface_texture.texture.width();
+        let surface_height = surface_texture.texture.height();
+        let surface_size = Vector2F::new(surface_width as f32, surface_height as f32);
+
+        // Cursor rects painted this frame, converted to device space.
+        let scale = scene.scale_factor();
+        let cur_cursor_rects: Vec<RectF> =
+            scene.cursor_rects().iter().map(|r| *r * scale).collect();
+
+        let offscreen = resources.offscreen_target(surface_width, surface_height);
+        let size_unchanged = self.offscreen_size == Some((surface_width, surface_height));
+
+        // A cursor-only frame may repaint just the damage region (the union of the
+        // previous and current cursor rects), but only if we have a valid prior
+        // full render of the offscreen target at this exact size to Load onto.
+        let damage_rect = if matches!(scene.damage(), SceneDamage::CursorOnly)
+            && self.offscreen_valid
+            && size_unchanged
+            && offscreen.is_some()
+        {
+            union_bounds(self.prev_cursor_rects.iter().chain(cur_cursor_rects.iter()))
+                .map(|rect| expand_and_clamp(rect, surface_size, 4.0))
+        } else {
+            None
+        };
+        let do_partial = damage_rect.is_some();
+        let load_op = if do_partial {
+            wgpu::LoadOp::Load
+        } else {
+            wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT)
+        };
 
         let mut encoder = device.create_command_encoder(&ENCODER_DESCRIPTOR);
         let (_, error) = with_error_scope(device, || {
-            let surface_width = surface_texture.texture.width();
-            let surface_height = surface_texture.texture.height();
-            let surface_size = Vector2F::new(surface_width as f32, surface_height as f32);
-
-            match resources.offscreen_target(surface_width, surface_height) {
+            match &offscreen {
                 Some((offscreen_texture, offscreen_view)) => {
-                    // Render the scene into the persistent offscreen target, then
-                    // copy it into the swapchain image. The copy is a cheap GPU
-                    // blit (not a re-rasterization); keeping the offscreen target
-                    // between frames is what will let damage frames re-rasterize
-                    // and copy only the changed region.
-                    frame.draw(resources, &mut encoder, &offscreen_view, surface_size);
+                    // Render into the persistent offscreen target (full `Clear`, or
+                    // `Load`+scissor for a partial cursor repaint), then copy the
+                    // whole offscreen into the swapchain image. The copy is a cheap
+                    // GPU blit; the win is that a partial frame only re-rasterizes
+                    // the small damage region instead of the entire window.
+                    frame.draw(
+                        resources,
+                        &mut encoder,
+                        offscreen_view,
+                        surface_size,
+                        load_op,
+                        damage_rect,
+                    );
                     encoder.copy_texture_to_texture(
                         wgpu::TexelCopyTextureInfo {
-                            texture: &offscreen_texture,
+                            texture: offscreen_texture,
                             mip_level: 0,
                             origin: wgpu::Origin3d::ZERO,
                             aspect: wgpu::TextureAspect::All,
@@ -137,19 +185,40 @@ impl Renderer {
                 }
                 None => {
                     // Surface can't be a copy destination; render straight to it.
-                    let view =
-                        surface_texture
-                            .texture
-                            .create_view(&wgpu::TextureViewDescriptor {
-                                format: Some(surface_texture.texture.format()),
-                                ..Default::default()
-                            });
-                    frame.draw(resources, &mut encoder, &view, surface_size);
+                    let view = surface_texture
+                        .texture
+                        .create_view(&wgpu::TextureViewDescriptor {
+                            format: Some(surface_texture.texture.format()),
+                            ..Default::default()
+                        });
+                    frame.draw(
+                        resources,
+                        &mut encoder,
+                        &view,
+                        surface_size,
+                        wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        None,
+                    );
                 }
             }
 
             queue.submit(Some(encoder.finish()));
         });
+
+        // Update offscreen/cursor bookkeeping for the next frame.
+        if offscreen.is_some() {
+            if !do_partial {
+                // A full render populated the offscreen target; it's now valid to
+                // Load onto for a subsequent partial cursor repaint.
+                self.offscreen_valid = true;
+                self.offscreen_size = Some((surface_width, surface_height));
+            }
+            // A partial frame Loaded onto the existing offscreen, so it stays valid.
+        } else {
+            self.offscreen_valid = false;
+            self.offscreen_size = None;
+        }
+        self.prev_cursor_rects = cur_cursor_rects;
 
         if let Some(callback) = capture_callback {
             if let Err(err) =
@@ -178,6 +247,37 @@ impl Renderer {
             }
         }
     }
+}
+
+/// Bounding box of an iterator of rects, or `None` if the iterator is empty.
+fn union_bounds<'a>(rects: impl Iterator<Item = &'a RectF>) -> Option<RectF> {
+    let mut rects = rects;
+    let first = rects.next()?;
+    let mut min_x = first.min_x();
+    let mut min_y = first.min_y();
+    let mut max_x = first.max_x();
+    let mut max_y = first.max_y();
+    for rect in rects {
+        min_x = min_x.min(rect.min_x());
+        min_y = min_y.min(rect.min_y());
+        max_x = max_x.max(rect.max_x());
+        max_y = max_y.max(rect.max_y());
+    }
+    Some(RectF::new(
+        vec2f(min_x, min_y),
+        vec2f(max_x - min_x, max_y - min_y),
+    ))
+}
+
+/// Expands `rect` by `pad` device pixels on each side and clamps it to the
+/// `[0, size]` window bounds. The padding absorbs anti-aliasing / rounding so a
+/// partial repaint fully covers the cursor.
+fn expand_and_clamp(rect: RectF, size: Vector2F, pad: f32) -> RectF {
+    let x0 = (rect.min_x() - pad).max(0.0);
+    let y0 = (rect.min_y() - pad).max(0.0);
+    let x1 = (rect.max_x() + pad).min(size.x());
+    let y1 = (rect.max_y() + pad).min(size.y());
+    RectF::new(vec2f(x0, y0), vec2f((x1 - x0).max(0.0), (y1 - y0).max(0.0)))
 }
 
 /// Errors that can occur while rendering a scene.

--- a/crates/warpui/src/rendering/wgpu/renderer.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer.rs
@@ -145,16 +145,23 @@ impl Renderer {
                     union_bounds(self.prev_cursor_rects.iter().chain(cur_cursor_rects.iter()))
                 }
                 SceneDamage::Partial => {
-                    // A region repaint is only safe if the damaged element kept
-                    // the same bounds. If its extent changed (e.g. the prompt
-                    // grew a line), sibling content was re-laid-out outside the
-                    // damage rect, so the Load would show stale pixels -- fall
-                    // back to a full repaint for this frame.
+                    // Damage the union of the previous and current frame's
+                    // changed-view bounds, so a view that moved repaints both its
+                    // old and new position. Fall back to a full repaint only on a
+                    // VERTICAL shift: the input growing/shrinking a line can
+                    // re-lay-out sibling content (e.g. scrollback) that didn't
+                    // itself re-render, which a partial frame would leave stale.
+                    // Horizontal reflow (autosuggestion width, chips) within a
+                    // stable vertical band is safe to damage partially.
                     match (
                         union_bounds(self.prev_damage_rects.iter()),
                         union_bounds(cur_damage_rects.iter()),
                     ) {
-                        (Some(prev), Some(cur)) if rects_approx_eq(prev, cur) => Some(cur),
+                        (Some(prev), Some(cur)) if vertical_extent_stable(prev, cur) => {
+                            union_bounds(
+                                self.prev_damage_rects.iter().chain(cur_damage_rects.iter()),
+                            )
+                        }
                         _ => None,
                     }
                 }
@@ -295,15 +302,14 @@ fn union_bounds<'a>(rects: impl Iterator<Item = &'a RectF>) -> Option<RectF> {
     ))
 }
 
-/// Whether two rects are equal within half a device pixel, used to detect that a
-/// partially-damaged element kept the same bounds between frames (so scissoring
-/// to it is safe). A change means the layout shifted and we must repaint fully.
-fn rects_approx_eq(a: RectF, b: RectF) -> bool {
-    const EPS: f32 = 0.5;
-    (a.min_x() - b.min_x()).abs() < EPS
-        && (a.min_y() - b.min_y()).abs() < EPS
-        && (a.max_x() - b.max_x()).abs() < EPS
-        && (a.max_y() - b.max_y()).abs() < EPS
+/// Whether two damage regions occupy the same vertical band (within a few device
+/// pixels). A vertical change means content was re-laid-out and sibling views may
+/// have moved without re-rendering, so the frame must repaint fully. Horizontal
+/// changes (e.g. autosuggestion ghost-text width) stay within the input band and
+/// are safe to damage partially.
+fn vertical_extent_stable(a: RectF, b: RectF) -> bool {
+    const V_EPS: f32 = 8.0; // less than one line height
+    (a.min_y() - b.min_y()).abs() < V_EPS && (a.max_y() - b.max_y()).abs() < V_EPS
 }
 
 /// Expands `rect` by `pad` device pixels on each side and clamps it to the

--- a/crates/warpui/src/rendering/wgpu/renderer.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer.rs
@@ -36,6 +36,10 @@ pub struct Renderer {
     /// current frame's cursor rects to form the damage region for a cursor-only
     /// repaint (so the region the cursor just vacated is also repainted).
     prev_cursor_rects: Vec<RectF>,
+    /// Device-space partial-damage rects from the previous frame. Unioned with
+    /// the current frame's damage rects to form the damage region for a
+    /// [`SceneDamage::Partial`] repaint (e.g. typing into the prompt).
+    prev_damage_rects: Vec<RectF>,
 }
 
 impl Renderer {
@@ -72,6 +76,7 @@ impl Renderer {
             offscreen_valid: false,
             offscreen_size: None,
             prev_cursor_rects: Vec::new(),
+            prev_damage_rects: Vec::new(),
         }
     }
 
@@ -118,24 +123,44 @@ impl Renderer {
         let surface_height = surface_texture.texture.height();
         let surface_size = Vector2F::new(surface_width as f32, surface_height as f32);
 
-        // Cursor rects painted this frame, converted to device space.
+        // Cursor and partial-damage rects painted this frame, in device space.
         let scale = scene.scale_factor();
         let cur_cursor_rects: Vec<RectF> =
             scene.cursor_rects().iter().map(|r| *r * scale).collect();
+        let cur_damage_rects: Vec<RectF> =
+            scene.damage_rects().iter().map(|r| *r * scale).collect();
 
         let offscreen = resources.offscreen_target(surface_width, surface_height);
         let size_unchanged = self.offscreen_size == Some((surface_width, surface_height));
 
-        // A cursor-only frame may repaint just the damage region (the union of the
-        // previous and current cursor rects), but only if we have a valid prior
-        // full render of the offscreen target at this exact size to Load onto.
-        let damage_rect = if matches!(scene.damage(), SceneDamage::CursorOnly)
-            && self.offscreen_valid
-            && size_unchanged
-            && offscreen.is_some()
-        {
-            union_bounds(self.prev_cursor_rects.iter().chain(cur_cursor_rects.iter()))
-                .map(|rect| expand_and_clamp(rect, surface_size, 4.0))
+        // A partial frame (cursor blink or a bounded region edit such as typing)
+        // may repaint just the damage region: the union of the previous and
+        // current rects of the relevant kind (so the area just vacated is also
+        // repainted). This is only safe with a valid prior full render of the
+        // offscreen target at this exact size to Load onto.
+        let partial_eligible = self.offscreen_valid && size_unchanged && offscreen.is_some();
+        let damage_rect = if partial_eligible {
+            match scene.damage() {
+                SceneDamage::CursorOnly => {
+                    union_bounds(self.prev_cursor_rects.iter().chain(cur_cursor_rects.iter()))
+                }
+                SceneDamage::Partial => {
+                    // A region repaint is only safe if the damaged element kept
+                    // the same bounds. If its extent changed (e.g. the prompt
+                    // grew a line), sibling content was re-laid-out outside the
+                    // damage rect, so the Load would show stale pixels -- fall
+                    // back to a full repaint for this frame.
+                    match (
+                        union_bounds(self.prev_damage_rects.iter()),
+                        union_bounds(cur_damage_rects.iter()),
+                    ) {
+                        (Some(prev), Some(cur)) if rects_approx_eq(prev, cur) => Some(cur),
+                        _ => None,
+                    }
+                }
+                SceneDamage::Full => None,
+            }
+            .map(|rect| expand_and_clamp(rect, surface_size, 4.0))
         } else {
             None
         };
@@ -219,6 +244,7 @@ impl Renderer {
             self.offscreen_size = None;
         }
         self.prev_cursor_rects = cur_cursor_rects;
+        self.prev_damage_rects = cur_damage_rects;
 
         if let Some(callback) = capture_callback {
             if let Err(err) =
@@ -267,6 +293,17 @@ fn union_bounds<'a>(rects: impl Iterator<Item = &'a RectF>) -> Option<RectF> {
         vec2f(min_x, min_y),
         vec2f(max_x - min_x, max_y - min_y),
     ))
+}
+
+/// Whether two rects are equal within half a device pixel, used to detect that a
+/// partially-damaged element kept the same bounds between frames (so scissoring
+/// to it is safe). A change means the layout shifted and we must repaint fully.
+fn rects_approx_eq(a: RectF, b: RectF) -> bool {
+    const EPS: f32 = 0.5;
+    (a.min_x() - b.min_x()).abs() < EPS
+        && (a.min_y() - b.min_y()).abs() < EPS
+        && (a.max_x() - b.max_x()).abs() < EPS
+        && (a.max_y() - b.max_y()).abs() < EPS
 }
 
 /// Expands `rect` by `pad` device pixels on each side and clamps it to the

--- a/crates/warpui/src/rendering/wgpu/renderer/frame.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer/frame.rs
@@ -1,6 +1,6 @@
 use pathfinder_geometry::rect::RectF;
 use pathfinder_geometry::vector::Vector2F;
-use wgpu::{CommandEncoder, RenderPass, SurfaceTexture};
+use wgpu::{CommandEncoder, RenderPass};
 
 use crate::rendering::wgpu::renderer::{glyph, image, rect, WGPUContext};
 use crate::rendering::wgpu::Resources;
@@ -85,23 +85,14 @@ impl<'a> Frame<'a> {
         self,
         resources: &Resources,
         encoder: &mut CommandEncoder,
-        surface_texture: &SurfaceTexture,
+        target_view: &wgpu::TextureView,
+        target_size: Vector2F,
     ) {
-        let surface_size = Vector2F::new(
-            surface_texture.texture.width() as f32,
-            surface_texture.texture.height() as f32,
-        );
-
-        let view = surface_texture
-            .texture
-            .create_view(&wgpu::TextureViewDescriptor {
-                format: Some(surface_texture.texture.format()),
-                ..Default::default()
-            });
+        let surface_size = target_size;
 
         let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                view: &view,
+                view: target_view,
                 depth_slice: None,
                 resolve_target: None,
                 ops: wgpu::Operations {

--- a/crates/warpui/src/rendering/wgpu/renderer/frame.rs
+++ b/crates/warpui/src/rendering/wgpu/renderer/frame.rs
@@ -87,6 +87,8 @@ impl<'a> Frame<'a> {
         encoder: &mut CommandEncoder,
         target_view: &wgpu::TextureView,
         target_size: Vector2F,
+        load_op: wgpu::LoadOp<wgpu::Color>,
+        damage_scissor: Option<RectF>,
     ) {
         let surface_size = target_size;
 
@@ -96,7 +98,9 @@ impl<'a> Frame<'a> {
                 depth_slice: None,
                 resolve_target: None,
                 ops: wgpu::Operations {
-                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    // `Clear` for a normal full frame; `Load` for a partial
+                    // (damage) repaint that preserves the rest of the target.
+                    load: load_op,
                     store: wgpu::StoreOp::Store,
                 },
             })],
@@ -107,20 +111,31 @@ impl<'a> Frame<'a> {
         let device_bounds = RectF::new(Vector2F::zero(), surface_size);
 
         for layer_state in &self.layer_state {
-            if let Some(bounds) = layer_state.layer.clip_bounds {
-                // Make sure the scissor rect doesn't extend beyond the boundaries
-                // of the window.
-                let bounds = (bounds * self.scene.scale_factor()).intersection(device_bounds);
-                let Some(intersection) = bounds else {
-                    // The layer's clip bounds don't intersect the window bounds
-                    // at all; we can skip drawing anything in this layer.
-                    continue;
-                };
+            // Per-layer scissor: the layer's clip bounds (clamped to the window),
+            // or the whole window if the layer has no clip.
+            let layer_bounds = match layer_state.layer.clip_bounds {
+                Some(bounds) => {
+                    match (bounds * self.scene.scale_factor()).intersection(device_bounds) {
+                        Some(intersection) => intersection,
+                        // The layer's clip bounds don't intersect the window at
+                        // all; skip drawing anything in this layer.
+                        None => continue,
+                    }
+                }
+                None => device_bounds,
+            };
 
-                Self::set_scissor_rect(&mut render_pass, intersection);
-            } else {
-                Self::set_scissor_rect(&mut render_pass, device_bounds);
-            }
+            // For a partial (cursor-only) repaint, further constrain the scissor
+            // to the damage region so only those pixels are re-rasterized.
+            let scissor = match damage_scissor {
+                Some(damage) => match layer_bounds.intersection(damage) {
+                    Some(intersection) => intersection,
+                    None => continue,
+                },
+                None => layer_bounds,
+            };
+
+            Self::set_scissor_rect(&mut render_pass, scissor);
 
             if let Some(rect_layer_state) = &layer_state.rect_layer_state {
                 self.rect_pipeline.draw(

--- a/crates/warpui/src/rendering/wgpu/resources.rs
+++ b/crates/warpui/src/rendering/wgpu/resources.rs
@@ -68,6 +68,21 @@ pub struct Resources {
     pub supported_backends: Vec<wgpu::Backend>,
     uniforms: uniforms::Uniforms,
     quad: quad::Resources,
+    /// Persistent offscreen color target that the scene is rendered into before
+    /// being copied to the swapchain. Retaining it between frames is what makes
+    /// partial/damage rendering possible (we can keep the previous frame's
+    /// pixels and only re-rasterize a damaged sub-rectangle). `None` until first
+    /// use or when the surface doesn't support `COPY_DST`.
+    offscreen: RefCell<Option<OffscreenTarget>>,
+}
+
+/// A reusable offscreen color texture sized to the current surface.
+struct OffscreenTarget {
+    texture: wgpu::Texture,
+    view: wgpu::TextureView,
+    width: u32,
+    height: u32,
+    format: wgpu::TextureFormat,
 }
 
 impl Resources {
@@ -133,12 +148,71 @@ impl Resources {
                 supported_backends: supported_backends.into_iter().collect(),
                 uniforms,
                 quad,
+                offscreen: RefCell::new(None),
             })
         })
     }
 
     pub fn uniform_bind_group_layout(&self) -> &wgpu::BindGroupLayout {
         self.uniforms.bind_group_layout()
+    }
+
+    /// Returns the persistent offscreen render target (texture + view) sized to
+    /// `width`x`height`, creating or recreating it on size/format changes.
+    ///
+    /// Returns `None` when the surface can't be a copy destination, in which
+    /// case the caller should render directly to the swapchain. The returned
+    /// `Texture`/`TextureView` are cheap (Arc-backed) clones.
+    pub fn offscreen_target(
+        &self,
+        width: u32,
+        height: u32,
+    ) -> Option<(wgpu::Texture, wgpu::TextureView)> {
+        let format = {
+            let config = self.surface_config.borrow();
+            if !config.usage.contains(wgpu::TextureUsages::COPY_DST) {
+                return None;
+            }
+            config.format
+        };
+        if width == 0 || height == 0 {
+            return None;
+        }
+
+        let mut slot = self.offscreen.borrow_mut();
+        let needs_new = match slot.as_ref() {
+            Some(target) => {
+                target.width != width || target.height != height || target.format != format
+            }
+            None => true,
+        };
+        if needs_new {
+            let texture = self.device.create_texture(&wgpu::TextureDescriptor {
+                label: Some("Offscreen render target"),
+                size: wgpu::Extent3d {
+                    width,
+                    height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+                view_formats: &[],
+            });
+            let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+            *slot = Some(OffscreenTarget {
+                texture,
+                view,
+                width,
+                height,
+                format,
+            });
+        }
+
+        slot.as_ref()
+            .map(|target| (target.texture.clone(), target.view.clone()))
     }
 
     pub fn configure_render_pass<'a>(
@@ -840,6 +914,15 @@ fn create_surface_config(
     #[cfg(feature = "integration_tests")]
     if caps.usages.contains(wgpu::TextureUsages::COPY_SRC) {
         config.usage |= wgpu::TextureUsages::COPY_SRC;
+    }
+
+    // COPY_DST lets us copy a persistent offscreen render target into the
+    // swapchain image, which is the basis for partial/damage rendering (only
+    // re-rasterizing and copying the changed region, e.g. a blinking cursor,
+    // instead of the whole window). If the surface doesn't support it, we fall
+    // back to rendering directly to the swapchain.
+    if caps.usages.contains(wgpu::TextureUsages::COPY_DST) {
+        config.usage |= wgpu::TextureUsages::COPY_DST;
     }
 
     // Use a non-vsync presentation mode for reduced input delay.  This could

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -59,8 +59,8 @@ use crate::{
     AnyModelHandle, ApplicationBundleInfo, Clipboard, CursorInfo, Effect, Element, Entity,
     EntityId, Event, GetSingletonModelHandle, ModelAsRef, ModelContext, ModelHandle,
     NextNewWindowsHasThisWindowsBoundsUponClose, Presenter, ReadModel, ReadView, Scene,
-    SingletonEntity, SpawnedFuture, TaskId, TypedActionView, UpdateModel, UpdateView, View,
-    ViewAsRef, ViewContext, ViewHandle, WindowId, WindowInvalidation, ZoomFactor,
+    SceneDamage, SingletonEntity, SpawnedFuture, TaskId, TypedActionView, UpdateModel, UpdateView,
+    View, ViewAsRef, ViewContext, ViewHandle, WindowId, WindowInvalidation, ZoomFactor,
 };
 
 #[cfg(feature = "tui")]
@@ -1007,9 +1007,15 @@ impl AppContext {
             .window_invalidations
             .remove(&window_id)
             .unwrap_or_default();
-        invalidations
-            .updated
-            .extend(autotracking::take_invalidations_for_window(window_id));
+        let auto: Vec<_> = autotracking::take_invalidations_for_window(window_id)
+            .into_iter()
+            .collect();
+        if !auto.is_empty() {
+            // Autotracked invalidations are outside the cursor-only fast path, so
+            // force a full repaint to stay correct.
+            invalidations.full_repaint_requested = true;
+        }
+        invalidations.updated.extend(auto);
         invalidations
     }
 
@@ -2890,8 +2896,25 @@ impl AppContext {
                 break;
             }
 
+            // A frame can be a partial cursor-only repaint only when the very
+            // first iteration's sole signal is a cursor blink. Any later
+            // iteration (e.g. a synthetic MouseMoved that actually changed
+            // something), a full notification, an explicit redraw request, or a
+            // structural change forces a full repaint.
+            let damage = if iter == 1
+                && invalidation.cursor_damage
+                && !invalidation.full_repaint_requested
+                && !invalidation.redraw_requested
+                && invalidation.removed.is_empty()
+            {
+                SceneDamage::CursorOnly
+            } else {
+                SceneDamage::Full
+            };
+
             {
                 let mut presenter = presenter.borrow_mut();
+                presenter.set_next_scene_damage(damage);
                 presenter.invalidate(invalidation, self);
 
                 // Skip rendering if a dimension is 0. This must happen after
@@ -3428,6 +3451,9 @@ impl AppContext {
                     Effect::ModelNotification { model_id } => self.notify_model_observers(model_id),
                     Effect::ViewNotification { window_id, view_id } => {
                         self.notify_view_observers(window_id, view_id)
+                    }
+                    Effect::ViewCursorNotification { window_id, view_id } => {
+                        self.notify_view_observers_cursor(window_id, view_id)
                     }
                     Effect::Focus { window_id, view_id } => {
                         self.focus(window_id, view_id);
@@ -4055,11 +4081,20 @@ impl AppContext {
     }
 
     fn notify_view_observers(&mut self, window_id: WindowId, view_id: EntityId) {
-        self.window_invalidations
-            .entry(window_id)
-            .or_default()
-            .updated
-            .insert(view_id);
+        let invalidation = self.window_invalidations.entry(window_id).or_default();
+        invalidation.updated.insert(view_id);
+        // A normal notification can change anything in the view tree, so this
+        // frame must repaint fully (it cannot be a cursor-only partial repaint).
+        invalidation.full_repaint_requested = true;
+    }
+
+    /// Records a cursor-blink-only invalidation: the view is still re-rendered,
+    /// but unless a full repaint is also requested this frame, the renderer may
+    /// repaint just the cursor region (see [`Scene::damage`]).
+    fn notify_view_observers_cursor(&mut self, window_id: WindowId, view_id: EntityId) {
+        let invalidation = self.window_invalidations.entry(window_id).or_default();
+        invalidation.updated.insert(view_id);
+        invalidation.cursor_damage = true;
     }
 
     fn focus(&mut self, window_id: WindowId, focused_id: EntityId) {

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -4934,23 +4934,37 @@ impl AppContext {
 }
 
 /// Decides how much of a window to repaint for a given invalidation, on a given
-/// scene-build iteration. A partial repaint is only allowed on the first
-/// iteration when nothing forces a full repaint (no normal `notify()`, no redraw
-/// request, no removed views), and the sole signal is a bounded region edit
-/// ([`SceneDamage::Partial`], e.g. typing) or a cursor blink
-/// ([`SceneDamage::CursorOnly`]). Region damage takes precedence over cursor
-/// damage because the damaged region encloses the cursor.
+/// scene-build iteration.
+///
+/// Damage is keyed off *what actually re-rendered this frame*, not off per-view
+/// opt-in, so it also covers views that are re-created (e.g. context chips) which
+/// have no `notify()` to convert. A partial repaint is attempted whenever the
+/// change is non-structural (first iteration, no removed views, no explicit
+/// redraw request); the renderer then damages the union of the re-rendered
+/// views' bounds and **falls back to a full repaint** if that union is unstable
+/// between frames, unavailable, or window-sized -- so anything non-local
+/// degrades safely to a full repaint.
+///
+/// A pure cursor blink keeps its dedicated [`SceneDamage::CursorOnly`] path.
 fn scene_damage_for(invalidation: &WindowInvalidation, is_first_iteration: bool) -> SceneDamage {
-    let partial_eligible = is_first_iteration
+    // Structural changes (removed views, explicit redraw, or a later coalescing
+    // iteration that may have changed layout) always repaint fully.
+    if !is_first_iteration || invalidation.redraw_requested || !invalidation.removed.is_empty() {
+        return SceneDamage::Full;
+    }
+    // A pure cursor blink (only the cursor changed) uses the cheap cursor path.
+    if invalidation.cursor_damage
+        && !invalidation.region_damage
         && !invalidation.full_repaint_requested
-        && !invalidation.redraw_requested
-        && invalidation.removed.is_empty();
-    if partial_eligible && invalidation.region_damage {
-        SceneDamage::Partial
-    } else if partial_eligible && invalidation.cursor_damage {
-        SceneDamage::CursorOnly
-    } else {
+    {
+        return SceneDamage::CursorOnly;
+    }
+    // Otherwise, if anything re-rendered, attempt a partial repaint damaged to
+    // the union of those views' bounds (the renderer verifies/falls back).
+    if invalidation.updated.is_empty() {
         SceneDamage::Full
+    } else {
+        SceneDamage::Partial
     }
 }
 
@@ -4958,61 +4972,69 @@ fn scene_damage_for(invalidation: &WindowInvalidation, is_first_iteration: bool)
 mod scene_damage_tests {
     use super::*;
 
-    #[test]
-    fn region_only_first_iteration_is_partial() {
+    /// An invalidation where `n` views re-rendered (the common, non-structural case).
+    fn updated(n: usize) -> WindowInvalidation {
         let mut inv = WindowInvalidation::default();
-        inv.region_damage = true;
+        for i in 0..n {
+            inv.updated.insert(EntityId::from_usize(i));
+        }
+        inv
+    }
+
+    #[test]
+    fn re_rendered_views_first_iteration_are_partial() {
+        // Any non-structural frame that re-rendered views attempts a partial
+        // repaint, regardless of which notify kind was used (the renderer then
+        // damages their bounds / falls back to full).
+        assert_eq!(scene_damage_for(&updated(3), true), SceneDamage::Partial);
+    }
+
+    #[test]
+    fn full_notify_with_updated_views_is_partial() {
+        // A plain notify() no longer forces a full repaint by itself; with
+        // re-rendered views it's partial and the renderer decides the region.
+        let mut inv = updated(2);
+        inv.full_repaint_requested = true;
         assert_eq!(scene_damage_for(&inv, true), SceneDamage::Partial);
     }
 
     #[test]
-    fn cursor_only_first_iteration_is_cursor_only() {
-        let mut inv = WindowInvalidation::default();
+    fn pure_cursor_blink_is_cursor_only() {
+        let mut inv = updated(1);
         inv.cursor_damage = true;
         assert_eq!(scene_damage_for(&inv, true), SceneDamage::CursorOnly);
     }
 
     #[test]
-    fn region_damage_takes_precedence_over_cursor() {
-        let mut inv = WindowInvalidation::default();
-        inv.region_damage = true;
+    fn cursor_blink_with_other_full_change_is_partial() {
+        // If something else also changed this frame, it's not a pure blink.
+        let mut inv = updated(2);
         inv.cursor_damage = true;
+        inv.full_repaint_requested = true;
         assert_eq!(scene_damage_for(&inv, true), SceneDamage::Partial);
     }
 
     #[test]
-    fn full_repaint_request_forces_full() {
-        let mut inv = WindowInvalidation::default();
-        inv.region_damage = true;
-        inv.full_repaint_requested = true;
-        assert_eq!(scene_damage_for(&inv, true), SceneDamage::Full);
-    }
-
-    #[test]
     fn redraw_request_forces_full() {
-        let mut inv = WindowInvalidation::default();
-        inv.region_damage = true;
+        let mut inv = updated(2);
         inv.redraw_requested = true;
         assert_eq!(scene_damage_for(&inv, true), SceneDamage::Full);
     }
 
     #[test]
     fn removed_views_force_full() {
-        let mut inv = WindowInvalidation::default();
-        inv.region_damage = true;
-        inv.removed.insert(EntityId::from_usize(1));
+        let mut inv = updated(2);
+        inv.removed.insert(EntityId::from_usize(99));
         assert_eq!(scene_damage_for(&inv, true), SceneDamage::Full);
     }
 
     #[test]
     fn later_iteration_forces_full() {
-        let mut inv = WindowInvalidation::default();
-        inv.region_damage = true;
-        assert_eq!(scene_damage_for(&inv, false), SceneDamage::Full);
+        assert_eq!(scene_damage_for(&updated(2), false), SceneDamage::Full);
     }
 
     #[test]
-    fn no_damage_signal_is_full() {
+    fn nothing_re_rendered_is_full() {
         assert_eq!(
             scene_damage_for(&WindowInvalidation::default(), true),
             SceneDamage::Full

--- a/crates/warpui_core/src/core/app.rs
+++ b/crates/warpui_core/src/core/app.rs
@@ -2896,21 +2896,12 @@ impl AppContext {
                 break;
             }
 
-            // A frame can be a partial cursor-only repaint only when the very
-            // first iteration's sole signal is a cursor blink. Any later
-            // iteration (e.g. a synthetic MouseMoved that actually changed
-            // something), a full notification, an explicit redraw request, or a
-            // structural change forces a full repaint.
-            let damage = if iter == 1
-                && invalidation.cursor_damage
-                && !invalidation.full_repaint_requested
-                && !invalidation.redraw_requested
-                && invalidation.removed.is_empty()
-            {
-                SceneDamage::CursorOnly
-            } else {
-                SceneDamage::Full
-            };
+            // A frame can be a partial repaint only when the very first
+            // iteration's sole signal is a cursor blink or a bounded region edit.
+            // Any later iteration (e.g. a synthetic MouseMoved that actually
+            // changed something), a full notification, an explicit redraw
+            // request, or a structural change forces a full repaint.
+            let damage = scene_damage_for(&invalidation, iter == 1);
 
             {
                 let mut presenter = presenter.borrow_mut();
@@ -3454,6 +3445,9 @@ impl AppContext {
                     }
                     Effect::ViewCursorNotification { window_id, view_id } => {
                         self.notify_view_observers_cursor(window_id, view_id)
+                    }
+                    Effect::ViewRegionNotification { window_id, view_id } => {
+                        self.notify_view_observers_region(window_id, view_id)
                     }
                     Effect::Focus { window_id, view_id } => {
                         self.focus(window_id, view_id);
@@ -4095,6 +4089,16 @@ impl AppContext {
         let invalidation = self.window_invalidations.entry(window_id).or_default();
         invalidation.updated.insert(view_id);
         invalidation.cursor_damage = true;
+    }
+
+    /// Records a region-only invalidation (e.g. typing into the prompt): the view
+    /// is still re-rendered, but unless a full repaint is also requested this
+    /// frame, the renderer may repaint just the scene's `damage_rects` (see
+    /// [`Scene::damage`] / [`SceneDamage::Partial`]).
+    fn notify_view_observers_region(&mut self, window_id: WindowId, view_id: EntityId) {
+        let invalidation = self.window_invalidations.entry(window_id).or_default();
+        invalidation.updated.insert(view_id);
+        invalidation.region_damage = true;
     }
 
     fn focus(&mut self, window_id: WindowId, focused_id: EntityId) {
@@ -4926,5 +4930,92 @@ impl AppContext {
                 );
             }
         }
+    }
+}
+
+/// Decides how much of a window to repaint for a given invalidation, on a given
+/// scene-build iteration. A partial repaint is only allowed on the first
+/// iteration when nothing forces a full repaint (no normal `notify()`, no redraw
+/// request, no removed views), and the sole signal is a bounded region edit
+/// ([`SceneDamage::Partial`], e.g. typing) or a cursor blink
+/// ([`SceneDamage::CursorOnly`]). Region damage takes precedence over cursor
+/// damage because the damaged region encloses the cursor.
+fn scene_damage_for(invalidation: &WindowInvalidation, is_first_iteration: bool) -> SceneDamage {
+    let partial_eligible = is_first_iteration
+        && !invalidation.full_repaint_requested
+        && !invalidation.redraw_requested
+        && invalidation.removed.is_empty();
+    if partial_eligible && invalidation.region_damage {
+        SceneDamage::Partial
+    } else if partial_eligible && invalidation.cursor_damage {
+        SceneDamage::CursorOnly
+    } else {
+        SceneDamage::Full
+    }
+}
+
+#[cfg(test)]
+mod scene_damage_tests {
+    use super::*;
+
+    #[test]
+    fn region_only_first_iteration_is_partial() {
+        let mut inv = WindowInvalidation::default();
+        inv.region_damage = true;
+        assert_eq!(scene_damage_for(&inv, true), SceneDamage::Partial);
+    }
+
+    #[test]
+    fn cursor_only_first_iteration_is_cursor_only() {
+        let mut inv = WindowInvalidation::default();
+        inv.cursor_damage = true;
+        assert_eq!(scene_damage_for(&inv, true), SceneDamage::CursorOnly);
+    }
+
+    #[test]
+    fn region_damage_takes_precedence_over_cursor() {
+        let mut inv = WindowInvalidation::default();
+        inv.region_damage = true;
+        inv.cursor_damage = true;
+        assert_eq!(scene_damage_for(&inv, true), SceneDamage::Partial);
+    }
+
+    #[test]
+    fn full_repaint_request_forces_full() {
+        let mut inv = WindowInvalidation::default();
+        inv.region_damage = true;
+        inv.full_repaint_requested = true;
+        assert_eq!(scene_damage_for(&inv, true), SceneDamage::Full);
+    }
+
+    #[test]
+    fn redraw_request_forces_full() {
+        let mut inv = WindowInvalidation::default();
+        inv.region_damage = true;
+        inv.redraw_requested = true;
+        assert_eq!(scene_damage_for(&inv, true), SceneDamage::Full);
+    }
+
+    #[test]
+    fn removed_views_force_full() {
+        let mut inv = WindowInvalidation::default();
+        inv.region_damage = true;
+        inv.removed.insert(EntityId::from_usize(1));
+        assert_eq!(scene_damage_for(&inv, true), SceneDamage::Full);
+    }
+
+    #[test]
+    fn later_iteration_forces_full() {
+        let mut inv = WindowInvalidation::default();
+        inv.region_damage = true;
+        assert_eq!(scene_damage_for(&inv, false), SceneDamage::Full);
+    }
+
+    #[test]
+    fn no_damage_signal_is_full() {
+        assert_eq!(
+            scene_damage_for(&WindowInvalidation::default(), true),
+            SceneDamage::Full
+        );
     }
 }

--- a/crates/warpui_core/src/core/mod.rs
+++ b/crates/warpui_core/src/core/mod.rs
@@ -207,6 +207,11 @@ pub struct WindowInvalidation {
     /// [`crate::ViewContext::notify_cursor_only`]). On its own this enables a
     /// partial cursor repaint; combined with `full_repaint_requested` it does not.
     pub cursor_damage: bool,
+    /// Set when a region-only notification occurred this frame (see
+    /// [`crate::ViewContext::notify_region`]), e.g. typing into the prompt. On
+    /// its own this enables a partial repaint of the scene's `damage_rects`;
+    /// combined with `full_repaint_requested` it does not.
+    pub region_damage: bool,
 }
 
 pub enum Effect {
@@ -225,6 +230,13 @@ pub enum Effect {
     /// changed is the text cursor (e.g. a 500ms blink toggle), which lets the
     /// renderer repaint just the cursor region instead of the whole window.
     ViewCursorNotification {
+        window_id: WindowId,
+        view_id: EntityId,
+    },
+    /// Like [`Effect::ViewNotification`], but signals that only a bounded region
+    /// changed (e.g. the prompt input line while typing), which lets the
+    /// renderer repaint just that region instead of the whole window.
+    ViewRegionNotification {
         window_id: WindowId,
         view_id: EntityId,
     },

--- a/crates/warpui_core/src/core/mod.rs
+++ b/crates/warpui_core/src/core/mod.rs
@@ -199,6 +199,14 @@ pub struct WindowInvalidation {
     /// only store a boolean. In the future we can extend this to store entity ids
     /// for specific views that need to be redrawn once we have that capability.
     pub redraw_requested: bool,
+    /// Set when a normal (full) view notification occurred this frame. When this
+    /// is false and `cursor_damage` is true, the renderer may repaint only the
+    /// cursor region instead of re-rasterizing the whole window.
+    pub full_repaint_requested: bool,
+    /// Set when a cursor-blink-only notification occurred this frame (see
+    /// [`crate::ViewContext::notify_cursor_only`]). On its own this enables a
+    /// partial cursor repaint; combined with `full_repaint_requested` it does not.
+    pub cursor_damage: bool,
 }
 
 pub enum Effect {
@@ -210,6 +218,13 @@ pub enum Effect {
         model_id: EntityId,
     },
     ViewNotification {
+        window_id: WindowId,
+        view_id: EntityId,
+    },
+    /// Like [`Effect::ViewNotification`], but signals that the only thing that
+    /// changed is the text cursor (e.g. a 500ms blink toggle), which lets the
+    /// renderer repaint just the cursor region instead of the whole window.
+    ViewCursorNotification {
         window_id: WindowId,
         view_id: EntityId,
     },

--- a/crates/warpui_core/src/core/view/context.rs
+++ b/crates/warpui_core/src/core/view/context.rs
@@ -458,6 +458,20 @@ impl<'a, T: Entity> ViewContext<'a, T> {
             });
     }
 
+    /// Like [`Self::notify`], but signals that the *only* thing that changed is
+    /// the text cursor (e.g. a 500ms blink toggle). If this is the sole
+    /// invalidation in a frame, the renderer repaints just the cursor region
+    /// instead of re-rasterizing the whole window. If any normal `notify()` also
+    /// occurs in the same frame, the frame falls back to a full repaint.
+    pub fn notify_cursor_only(&mut self) {
+        self.app
+            .pending_effects
+            .push_back(Effect::ViewCursorNotification {
+                window_id: self.window_id,
+                view_id: self.view_id,
+            });
+    }
+
     /// Requests permissions to send desktop notifications. The `on_completion callback` can be invoked to
     /// propagate the outcome of the request (accepted/denied/other) back to the app.
     ///

--- a/crates/warpui_core/src/core/view/context.rs
+++ b/crates/warpui_core/src/core/view/context.rs
@@ -472,6 +472,23 @@ impl<'a, T: Entity> ViewContext<'a, T> {
             });
     }
 
+    /// Like [`Self::notify`], but signals that the *only* thing that changed is a
+    /// bounded region of this view (e.g. the prompt input line while typing). If
+    /// this is the sole invalidation in a frame, the renderer repaints just the
+    /// scene's `damage_rects` instead of re-rasterizing the whole window. If any
+    /// normal `notify()` also occurs in the same frame, the frame falls back to a
+    /// full repaint. Callers must record the changed region via
+    /// [`crate::Scene::record_damage_rect`] during paint, and should only use
+    /// this when the edit does not change the view's layout (height/line count).
+    pub fn notify_region(&mut self) {
+        self.app
+            .pending_effects
+            .push_back(Effect::ViewRegionNotification {
+                window_id: self.window_id,
+                view_id: self.view_id,
+            });
+    }
+
     /// Requests permissions to send desktop notifications. The `on_completion callback` can be invoked to
     /// propagate the outcome of the request (accepted/denied/other) back to the app.
     ///

--- a/crates/warpui_core/src/lib.rs
+++ b/crates/warpui_core/src/lib.rs
@@ -49,7 +49,7 @@ pub use pathfinder_geometry as geometry;
 pub use presenter::{
     AfterLayoutContext, EventContext, LayoutContext, PaintContext, Presenter, SizeConstraint,
 };
-pub use scene::{ClipBounds, Scene};
+pub use scene::{ClipBounds, Scene, SceneDamage};
 pub use zoom::ZoomFactor;
 
 pub use crate::core::*;

--- a/crates/warpui_core/src/presenter.rs
+++ b/crates/warpui_core/src/presenter.rs
@@ -37,6 +37,11 @@ pub struct Presenter {
     /// Damage to stamp onto the next scene built by [`Self::build_scene`], then
     /// reset to [`SceneDamage::Full`]. Set via [`Self::set_next_scene_damage`].
     pending_damage: SceneDamage,
+    /// Views invalidated this frame (updated minus removed), captured in
+    /// [`Self::invalidate`]. On a [`SceneDamage::Partial`] frame their painted
+    /// bounds become the scene's damage region so the renderer can scissor to
+    /// just the changed views instead of repainting the whole window.
+    partial_damage_views: HashSet<EntityId>,
 }
 
 pub struct LayoutContext<'a> {
@@ -316,6 +321,7 @@ impl Presenter {
             position_cache: PositionCache::default(),
             highlighted_view: None,
             pending_damage: SceneDamage::Full,
+            partial_damage_views: HashSet::new(),
         }
     }
 
@@ -326,6 +332,13 @@ impl Presenter {
     }
 
     pub fn invalidate(&mut self, invalidation: WindowInvalidation, app: &AppContext) {
+        // Remember which views actually changed this frame so a partial repaint
+        // can damage just their bounds (see build_scene).
+        self.partial_damage_views = invalidation
+            .updated
+            .difference(&invalidation.removed)
+            .copied()
+            .collect();
         // Don't try to update views that were also removed
         for &view_id in invalidation.updated.difference(&invalidation.removed) {
             match app.render_view(self.window_id, view_id) {
@@ -377,6 +390,16 @@ impl Presenter {
             max_texture_dimension_2d,
             ctx,
         );
+        // On a partial frame, damage just the bounds of the views that actually
+        // changed this frame. The renderer scissors to the union of these (and
+        // falls back to a full repaint if that union shifts between frames).
+        if self.pending_damage == SceneDamage::Partial {
+            for view_id in &self.partial_damage_views {
+                if let Some(bounds) = self.rendered_views.get(view_id).and_then(|el| el.bounds()) {
+                    scene.record_damage_rect(bounds);
+                }
+            }
+        }
         scene.set_damage(std::mem::take(&mut self.pending_damage));
         // After paint, collect a delayed repaint if it exists and start the timer.
         if let Some(repaint_at) = repaint_at {

--- a/crates/warpui_core/src/presenter.rs
+++ b/crates/warpui_core/src/presenter.rs
@@ -17,7 +17,7 @@ use crate::elements::{DropTargetPosition, Point, Selection};
 use crate::event::DispatchedEvent;
 use crate::fonts::Cache as FontCache;
 use crate::platform::Cursor;
-use crate::scene::{Scene, ZIndex};
+use crate::scene::{Scene, SceneDamage, ZIndex};
 use crate::text_layout::LayoutCache;
 use crate::zoom::Scale;
 use crate::{
@@ -34,6 +34,9 @@ pub struct Presenter {
     text_layout_cache: LayoutCache,
     position_cache: PositionCache,
     highlighted_view: Option<EntityId>,
+    /// Damage to stamp onto the next scene built by [`Self::build_scene`], then
+    /// reset to [`SceneDamage::Full`]. Set via [`Self::set_next_scene_damage`].
+    pending_damage: SceneDamage,
 }
 
 pub struct LayoutContext<'a> {
@@ -312,7 +315,14 @@ impl Presenter {
             text_layout_cache: LayoutCache::new(),
             position_cache: PositionCache::default(),
             highlighted_view: None,
+            pending_damage: SceneDamage::Full,
         }
+    }
+
+    /// Sets the damage stamped onto the next scene built by [`Self::build_scene`].
+    /// It is reset to [`SceneDamage::Full`] after that build.
+    pub fn set_next_scene_damage(&mut self, damage: SceneDamage) {
+        self.pending_damage = damage;
     }
 
     pub fn invalidate(&mut self, invalidation: WindowInvalidation, app: &AppContext) {
@@ -361,12 +371,13 @@ impl Presenter {
         // * Decouple after_layout from the presenter so it can take a AppContext
         // * Extend the AfterLayoutContext API to allow state updates, but not other effects
         self.after_layout(ctx);
-        let (scene, repaint_at, pending_assets) = self.paint(
+        let (mut scene, repaint_at, pending_assets) = self.paint(
             zoomed_scale_factor,
             zoomed_window_size,
             max_texture_dimension_2d,
             ctx,
         );
+        scene.set_damage(std::mem::take(&mut self.pending_damage));
         // After paint, collect a delayed repaint if it exists and start the timer.
         if let Some(repaint_at) = repaint_at {
             ctx.manage_delayed_repaint_timers(self.window_id, repaint_at);

--- a/crates/warpui_core/src/scene.rs
+++ b/crates/warpui_core/src/scene.rs
@@ -21,9 +21,29 @@ pub struct Scene {
     active_layer_index_stack: Vec1<ZIndex>,
     layers: Vec1<Layer>,
     overlay_layers: Vec<Layer>,
+    /// Window-space (logical, pre-scale) bounds of any text cursors painted this
+    /// frame. The renderer uses these to compute a small damage region so a
+    /// cursor blink can repaint just the cursor instead of the whole window.
+    cursor_rects: Vec<RectF>,
+    /// What changed since the previous frame. Defaults to [`SceneDamage::Full`]
+    /// (repaint everything); set to [`SceneDamage::CursorOnly`] when the only
+    /// invalidation was a cursor blink so the renderer can do a partial repaint.
+    damage: SceneDamage,
     #[cfg(debug_assertions)]
     /// Custom panic location, set with [`Scene::set_location_for_panic_logging`]
     panic_location: Option<&'static std::panic::Location<'static>>,
+}
+
+/// Describes how much of the window changed in a frame, so the renderer can
+/// limit GPU re-rasterization to a damaged region when possible.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum SceneDamage {
+    /// The whole window may have changed; repaint everything (the safe default).
+    #[default]
+    Full,
+    /// Only the text cursor(s) changed (e.g. a 500ms blink toggle); the renderer
+    /// may repaint just the union of the scene's `cursor_rects`.
+    CursorOnly,
 }
 
 #[derive(Clone, Default)]
@@ -391,6 +411,8 @@ impl Scene {
             active_layer_index_stack: vec1![ZIndex::Normal(0)],
             layers: vec1![Layer::default()],
             overlay_layers: Vec::new(),
+            cursor_rects: Vec::new(),
+            damage: SceneDamage::Full,
             #[cfg(debug_assertions)]
             panic_location: None,
         }
@@ -686,6 +708,27 @@ impl Scene {
 
     pub fn rendering_config(&self) -> &rendering::Config {
         &self.rendering_config
+    }
+
+    /// Records the window-space (logical) bounds of a text cursor painted this
+    /// frame, used to compute a damage region for cheap cursor-blink repaints.
+    pub fn record_cursor_rect(&mut self, rect: RectF) {
+        self.cursor_rects.push(rect);
+    }
+
+    /// Window-space (logical) bounds of all text cursors painted this frame.
+    pub fn cursor_rects(&self) -> &[RectF] {
+        &self.cursor_rects
+    }
+
+    /// Sets how much of the window changed this frame (see [`SceneDamage`]).
+    pub fn set_damage(&mut self, damage: SceneDamage) {
+        self.damage = damage;
+    }
+
+    /// How much of the window changed this frame (see [`SceneDamage`]).
+    pub fn damage(&self) -> SceneDamage {
+        self.damage
     }
 }
 

--- a/crates/warpui_core/src/scene.rs
+++ b/crates/warpui_core/src/scene.rs
@@ -25,6 +25,10 @@ pub struct Scene {
     /// frame. The renderer uses these to compute a small damage region so a
     /// cursor blink can repaint just the cursor instead of the whole window.
     cursor_rects: Vec<RectF>,
+    /// Window-space (logical, pre-scale) bounds of regions that changed this
+    /// frame when the damage is [`SceneDamage::Partial`] (e.g. the prompt input
+    /// line while typing). The renderer repaints just the union of these.
+    damage_rects: Vec<RectF>,
     /// What changed since the previous frame. Defaults to [`SceneDamage::Full`]
     /// (repaint everything); set to [`SceneDamage::CursorOnly`] when the only
     /// invalidation was a cursor blink so the renderer can do a partial repaint.
@@ -44,6 +48,10 @@ pub enum SceneDamage {
     /// Only the text cursor(s) changed (e.g. a 500ms blink toggle); the renderer
     /// may repaint just the union of the scene's `cursor_rects`.
     CursorOnly,
+    /// Only a bounded region changed (e.g. the prompt input line while typing);
+    /// the renderer may repaint just the union of the scene's `damage_rects`
+    /// instead of re-rasterizing the whole window.
+    Partial,
 }
 
 #[derive(Clone, Default)]
@@ -412,6 +420,7 @@ impl Scene {
             layers: vec1![Layer::default()],
             overlay_layers: Vec::new(),
             cursor_rects: Vec::new(),
+            damage_rects: Vec::new(),
             damage: SceneDamage::Full,
             #[cfg(debug_assertions)]
             panic_location: None,
@@ -719,6 +728,18 @@ impl Scene {
     /// Window-space (logical) bounds of all text cursors painted this frame.
     pub fn cursor_rects(&self) -> &[RectF] {
         &self.cursor_rects
+    }
+
+    /// Records the window-space (logical) bounds of a region that changed this
+    /// frame, used to compute a damage region for a [`SceneDamage::Partial`]
+    /// repaint (e.g. the prompt input line while typing).
+    pub fn record_damage_rect(&mut self, rect: RectF) {
+        self.damage_rects.push(rect);
+    }
+
+    /// Window-space (logical) bounds of all partial-damage regions this frame.
+    pub fn damage_rects(&self) -> &[RectF] {
+        &self.damage_rects
     }
 
     /// Sets how much of the window changed this frame (see [`SceneDamage`]).

--- a/script/gpu_idle_test/METHODOLOGY.md
+++ b/script/gpu_idle_test/METHODOLOGY.md
@@ -1,0 +1,105 @@
+# Active-path GPU methodology (Linux / Intel i915)
+
+How the **active** (typing / scrolling / output) GPU cost was measured and
+attributed on Linux + Intel integrated graphics, and the reasoning behind the
+partial-repaint fix. Companion to `README.md` (which covers the idle path).
+
+Hardware this was developed on: Intel Iris Xe (i7-1270P), Wayland (GNOME/mutter),
+**3840×2400** display.
+
+## Tools
+
+| Script | Measures | Source |
+|---|---|---|
+| `gpu_pmu_sampler.py` | whole-GPU render-engine busy % (system-wide) | i915 PMU (`perf_event_open`), same source as btop |
+| `cpu_thread_profile.py` | warp's per-thread CPU % | `/proc/<pid>/task/*/stat` |
+| `gpu_split_probe.py` | per-process GPU render % (Warp vs compositor) | `/proc/<pid>/fdinfo` `drm-engine-render` |
+| `profile_active.sh` | drives a regime (type/scroll/flood) + samples the above | ydotool |
+
+## Methodology lessons (each one cost real debugging time)
+
+1. **Measure release, never debug.** A debug build is CPU-starved under
+   key-mash; it stutters and *under*-reports GPU because the GPU is starved
+   waiting on the CPU. Every number below is from a `--release` build.
+
+2. **Sample at ≤100 ms, or you will lie to yourself.** The i915 busy counter is
+   integrated over the sample window, so a coarse interval averages activity
+   with idle:
+   - At **100 ms**, GPU drops to idle within ~0.1 s of input stopping (matches
+     btop), and peaks read true (~82%).
+   - At **2000–5000 ms**, the window straddling input-stop blends busy+idle and
+     reports ~20–35% for *seconds* after you stop — a phantom "tail" that does
+     not exist — while peaks get smoothed down to ~55%.
+
+   A long-perceived "GPU keeps working after I stop typing" turned out to be
+   purely this averaging artifact. Re-aggregating one fine trace into coarse
+   windows reproduces it exactly.
+
+3. **Gate on a focus check.** ydotool input goes to the *focused* window; a
+   missed focus silently produces a no-load run. `profile_active.sh` aborts if
+   the GPU stays < 5% during a workload.
+
+4. **A/B same-commit release binaries.** Absolute numbers depend on
+   hardware/compositor/resolution; only same-commit base-vs-candidate deltas are
+   attributable. See `build_release_pair.sh`.
+
+## Findings (release, Iris Xe, 3840×2400, 100 ms PMU)
+
+**Per regime — different bottlenecks:**
+
+| Regime | GPU render (rcs0) | Hottest warp thread | Bound by |
+|---|---|---|---|
+| Typing at prompt | ~60% avg / ~82% peak | main ~14% (CPU ~20%) | **GPU rasterization** |
+| Scrolling scrollback | ~46% avg / ~74% peak | main ~5% | **GPU rasterization** |
+| Output flood (`seq`) | ~32% avg / ~64% peak | **PTY reader ~64%** | **CPU — terminal parsing** |
+
+**GPU attribution during typing** (`gpu_split_probe.py`, fdinfo, debug split but
+the ratio is frame-rate-independent): Warp's own rasterization ≈ **76%** of the
+render-engine time, GNOME Shell (compositor) ≈ **24%**. The split closes against
+the system PMU total, so the dominant cost is Warp re-rasterizing its own window
+— not the compositor.
+
+**Frame-rate is not the lever.** Halving the terminal wakeup throttle (60→30 Hz)
+left active GPU unchanged (same-commit release A/B: 40.6% vs 40.6%). The render
+rate already sits below the cap because each full-window frame is expensive; vsync
+pacing (#13119) is the same dead lever for the same reason.
+
+**Root cause of the typing cost:** every keystroke invalidates ~10 input-bar
+views (`EditorView`, `PromptDisplay`, `AgentMessageBar`, `AgentViewFooter`,
+`TerminalInputMessageBar`, `DisplayChip`×N, `ActionButton`,
+`AcceptAutosuggestionKeybinding`), each forcing a full-window repaint. The
+architecture re-rasterizes the whole window on any change, which is ~free on the
+Apple-Silicon target but expensive on a 4K iGPU.
+
+## The fix and its measured effect
+
+Damage the frame to the bounds of the views that actually re-rendered (keyed off
+the invalidated set, so it also covers re-created views like context chips), and
+scissor the rasterization to that region. Same-commit release A/B, typing:
+
+```
+render(rcs0)  avg 54.8% -> 46.5%   peak 75.1% -> 63.4%
+```
+
+**Ceiling / follow-up:** this only shrinks Warp's *own* scene raster. The
+per-frame full offscreen→swapchain copy and the compositor's full-surface present
+(~24%) are unaffected — a further drop needs `wl_surface` buffer damage on the
+present path.
+
+## Running it
+
+```bash
+# one release binary, one regime
+PROFILE_S=8 ./profile_active.sh /path/to/warp-oss type     # or: scroll | flood
+
+# same-commit A/B (base = no fix, candidate = fix)
+./build_release_pair.sh
+PROFILE_S=8 ./profile_active.sh target/.../warp-oss-rel-base      type
+PROFILE_S=8 ./profile_active.sh target/.../warp-oss-rel-candidate type
+
+# attribute the GPU during a workload (run while a flood/scroll is going)
+./gpu_split_probe.py 8
+```
+
+Do not run the input-injecting scripts while using the machine — they take over
+the focused window.

--- a/script/gpu_idle_test/README.md
+++ b/script/gpu_idle_test/README.md
@@ -63,7 +63,8 @@ The intended iteration cycle:
 4. **Read the summary** — focus on **IDLE** avg/peak (ACTIVE is expected ~50% on
    4K integrated GPUs and is unchanged by the idle blink fix).
 
-5. **Optional human sanity check** — launch one binary at a time in btop:
+5. **Optional human sanity check** — launch one binary at a time; watch the GPU
+   graph in **Mission Center** (or btop render-engine %) for ~20s while idle:
 
    ```bash
    WARP_ENABLE_WAYLAND=1 target/gpu_idle_test/bin/warp-oss-rel-base
@@ -126,7 +127,7 @@ session restore, and UI settings. The **delta** is what matters.
 | Measurement | rel-base | rel-candidate |
 |-------------|----------|---------------|
 | Harness IDLE avg | ~12.4% | ~9.6% |
-| Manual IDLE (btop) | ~6% | ~3% |
+| Manual IDLE (Mission Center graph) | ~6% | ~3% |
 
 Active key-mash / scroll GPU (~50%) and **responsiveness** should match between
 base and candidate in release builds.

--- a/script/gpu_idle_test/README.md
+++ b/script/gpu_idle_test/README.md
@@ -1,0 +1,156 @@
+# GPU idle utilization testing (Linux / Intel i915)
+
+This directory contains scripts used to measure **GPU utilization** (not VRAM)
+for Warp on Linux with Intel integrated graphics. It was developed while
+debugging high idle GPU usage when a terminal window is focused but otherwise
+idle (cursor blinking).
+
+## Prerequisites
+
+- **Linux** with Intel i915 GPU and PMU events under `/sys/bus/event_source/devices/i915/`
+- **`perf_event_paranoid`** low enough to read PMU counters (often `0`; btop works ⇒ you are fine)
+- **`ydotool` + `ydotoold`** for autonomous keyboard input during harness runs
+- **`python3`** (stdlib only for `gpu_pmu_sampler.py`)
+- **Wayland** (set `WARP_ENABLE_WAYLAND=1` when launching test binaries)
+
+Install on Arch:
+
+```bash
+sudo pacman -S ydotool
+ydotoold --socket-path "$XDG_RUNTIME_DIR/.ydotool_socket" --socket-own "$(id -u):$(id -g)" &
+```
+
+## Important: use **release** builds for meaningful results
+
+`cargo build` (debug) produces an unoptimized binary that is **CPU-bound** under
+key-mash workloads and will **stutter** even when GPU numbers look lower. Always
+compare **release** binaries for responsiveness and for idle GPU measurements
+that reflect real usage.
+
+Release builds of the full `warp` crate can peak at **~12GB RSS** during
+compilation. On 32GB machines, use the provided build flags:
+
+```bash
+export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=256
+export CARGO_PROFILE_RELEASE_DEBUG=0
+```
+
+Optional: run `bash script/gpu_idle_test/mem_watchdog.sh 2500000` in another
+terminal during builds to kill cargo before the OOM killer takes down your session.
+
+## Fast feedback loop
+
+The intended iteration cycle:
+
+1. **Change code** on your branch (e.g. cursor-blink damage rendering).
+2. **Build release pair** (base + candidate at same merge-base):
+
+   ```bash
+   ./script/gpu_idle_test/build_release_pair.sh
+   ```
+
+   Outputs:
+   - `target/gpu_idle_test/bin/warp-oss-rel-base` (merge-base, no fix)
+   - `target/gpu_idle_test/bin/warp-oss-rel-candidate` (HEAD, with fix)
+
+3. **Run automated A/B** (~2 minutes, hands-off):
+
+   ```bash
+   cd script/gpu_idle_test
+   IDLE_S=25 ACTIVE_S=12 ./compare_base_vs_candidate.sh 4000
+   ```
+
+4. **Read the summary** — focus on **IDLE** avg/peak (ACTIVE is expected ~50% on
+   4K integrated GPUs and is unchanged by the idle blink fix).
+
+5. **Optional human sanity check** — launch one binary at a time in btop:
+
+   ```bash
+   WARP_ENABLE_WAYLAND=1 target/gpu_idle_test/bin/warp-oss-rel-base
+   WARP_ENABLE_WAYLAND=1 target/gpu_idle_test/bin/warp-oss-rel-candidate
+   ```
+
+   Focus the window, do not type, watch GPU for ~20s (cursor blinking only).
+
+## What the harness measures
+
+`gpu_pmu_sampler.py` reads i915 **`*-busy`** perf counters (same family as btop /
+Mission Center render engine). Each sample computes:
+
+```text
+util% = delta(busy_ns) / delta(time_enabled_ns) * 100
+```
+
+`verify_idle_vs_active.sh`:
+
+1. Launches Warp (Wayland), dismisses startup modal with Escape
+2. Samples **IDLE** GPU for `IDLE_S` seconds (no input)
+3. Optionally floods scrollback (`seq 1 N`), then runs an **ACTIVE** workload
+   (typing + PageUp/PageDown) while sampling
+
+`compare_base_vs_candidate.sh` runs verify on base then candidate and prints:
+
+```text
+IDLE    base avg= ...  ->  cand avg= ...
+ACTIVE  base avg= ...  ->  cand avg= ...
+```
+
+Use **IDLE** delta for the blink-fix validation. ACTIVE validates no regression.
+
+## Reproduce from a PR checkout (`gh` CLI)
+
+```bash
+# 1. Check out the PR branch
+gh pr checkout <PR_NUMBER>
+cd warp   # if gh cloned elsewhere, cd to your checkout
+
+# 2. Build release base + candidate (~15–25 min first time; reuse cached deps after)
+./script/gpu_idle_test/build_release_pair.sh
+
+# 3. Run automated comparison (leave machine alone ~2 min; uses ydotool keyboard)
+cd script/gpu_idle_test
+chmod +x *.sh *.py
+IDLE_S=25 ACTIVE_S=12 ./compare_base_vs_candidate.sh 4000
+
+# 4. Manual idle check (optional)
+WARP_ENABLE_WAYLAND=1 ../../target/gpu_idle_test/bin/warp-oss-rel-base
+# quit, then:
+WARP_ENABLE_WAYLAND=1 ../../target/gpu_idle_test/bin/warp-oss-rel-candidate
+```
+
+### Expected results (Intel Iris Xe, Wayland, 3840×2400, release, warp-oss config)
+
+These are **reference numbers** from one machine; absolute % varies with focus,
+session restore, and UI settings. The **delta** is what matters.
+
+| Measurement | rel-base | rel-candidate |
+|-------------|----------|---------------|
+| Harness IDLE avg | ~12.4% | ~9.6% |
+| Manual IDLE (btop) | ~6% | ~3% |
+
+Active key-mash / scroll GPU (~50%) and **responsiveness** should match between
+base and candidate in release builds.
+
+## Caveats
+
+- **Not VRAM / #2319**: this measures GPU **utilization** (render engine busy %).
+- **warp-oss vs stable**: dev `warp-oss` uses `~/.config/warp-oss/` and
+  `~/.local/state/warp-oss/`. Shipped stable uses `warp-terminal` paths and
+  often has more UI enabled (vertical tabs, AI, etc.) — do not compare absolute
+  idle % across channels without matching config.
+- **Session restore**: Warp restores blocks from `warp.sqlite` on launch. Set
+  `RESET_SESSION=1` when calling verify to start from an empty terminal.
+- **Process cleanup**: release test binaries named `warp-oss-rel-*` truncate to
+  15 chars in `/proc/comm`; scripts kill by path pattern under `TEST_BIN_DIR`.
+- **Do not use absolute ydotool mousemove** on GNOME without care — it can hit
+  the top-left hot corner and open Overview. The harness uses keyboard only.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `gpu_pmu_sampler.py` | i915 PMU sampler → CSV |
+| `verify_idle_vs_active.sh` | Single-binary idle + active run |
+| `compare_base_vs_candidate.sh` | Same-commit A/B comparison |
+| `build_release_pair.sh` | Build rel-base + rel-candidate |
+| `mem_watchdog.sh` | Optional OOM guard during `cargo build --release` |

--- a/script/gpu_idle_test/build_release_pair.sh
+++ b/script/gpu_idle_test/build_release_pair.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Build release BASE (merge-base, no fix) and CANDIDATE (HEAD, with fix) binaries
+# for same-commit GPU idle A/B testing.
+#
+# Uses memory-friendly release flags (codegen-units=256, debug=0) so the warp
+# crate fits in ~12GB peak RSS instead of OOMing on 32GB machines.
+#
+# Usage: build_release_pair.sh [BASE_COMMIT]
+#   BASE_COMMIT defaults to the merge-base with origin/master.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+OUT_DIR="${TEST_BIN_DIR:-$REPO_ROOT/target/gpu_idle_test/bin}"
+BASE_COMMIT="${1:-$(git -C "$REPO_ROOT" merge-base HEAD origin/master)}"
+BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)"
+
+export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=256
+export CARGO_PROFILE_RELEASE_DEBUG=0
+BUILD_FLAGS=(--release --bin warp-oss -j "${BUILD_JOBS:-16}")
+
+mkdir -p "$OUT_DIR"
+
+echo "Building CANDIDATE (HEAD) -> $OUT_DIR/warp-oss-rel-candidate"
+cd "$REPO_ROOT"
+cargo build "${BUILD_FLAGS[@]}"
+cp -f target/release/warp-oss "$OUT_DIR/warp-oss-rel-candidate"
+
+echo "Building BASE ($BASE_COMMIT) -> $OUT_DIR/warp-oss-rel-base"
+git checkout "$BASE_COMMIT"
+cargo build "${BUILD_FLAGS[@]}"
+cp -f target/release/warp-oss "$OUT_DIR/warp-oss-rel-base"
+
+if [ "$BRANCH" != "HEAD" ]; then
+  git checkout "$BRANCH"
+fi
+
+echo "Done."
+ls -la "$OUT_DIR/warp-oss-rel-base" "$OUT_DIR/warp-oss-rel-candidate"

--- a/script/gpu_idle_test/compare_base_vs_candidate.sh
+++ b/script/gpu_idle_test/compare_base_vs_candidate.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Same-commit A/B: run idle/active verification on BASE (no fix) and CANDIDATE
+# (with fix), then print a side-by-side comparison.
+#
+# Usage: compare_base_vs_candidate.sh [SCROLLBACK]
+#   env: BASE=<control binary> CAND=<candidate binary>
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+TEST_BIN_DIR="${TEST_BIN_DIR:-$REPO_ROOT/target/gpu_idle_test/bin}"
+BASE="${BASE:-$TEST_BIN_DIR/warp-oss-rel-base}"
+CAND="${CAND:-$TEST_BIN_DIR/warp-oss-rel-candidate}"
+SCROLLBACK="${1:-4000}"
+
+[ -x "$BASE" ] || { echo "missing BASE binary: $BASE"; exit 1; }
+[ -x "$CAND" ] || { echo "missing CANDIDATE binary: $CAND"; exit 1; }
+
+echo "############ BASE / control ############"
+"$HERE/verify_idle_vs_active.sh" "$BASE" base "$SCROLLBACK"
+echo
+echo "############ CANDIDATE ############"
+"$HERE/verify_idle_vs_active.sh" "$CAND" cand "$SCROLLBACK"
+
+stat() {
+  awk -F, -v which="$2" '
+    NR>1{ v=$2; if($3>v)v=$3; if($4>v)v=$4; if($5>v)v=$5; s+=v; n++; if(v>p)p=v }
+    END{ if(n){ printf "%.1f", (which=="avg")? s/n : p } else printf "0.0" }' "$1"
+}
+
+IB_A=$(stat /tmp/gpu_idle_base.csv avg);   IB_P=$(stat /tmp/gpu_idle_base.csv peak)
+IC_A=$(stat /tmp/gpu_idle_cand.csv avg);   IC_P=$(stat /tmp/gpu_idle_cand.csv peak)
+AB_A=$(stat /tmp/gpu_active_base.csv avg); AB_P=$(stat /tmp/gpu_active_base.csv peak)
+AC_A=$(stat /tmp/gpu_active_cand.csv avg); AC_P=$(stat /tmp/gpu_active_cand.csv peak)
+
+echo
+echo "================= BASE vs CANDIDATE (btop-equiv max-engine, scrollback=$SCROLLBACK) ================="
+printf "  IDLE    base avg=%5s%% peak=%5s%%   ->   cand avg=%5s%% peak=%5s%%\n" "$IB_A" "$IB_P" "$IC_A" "$IC_P"
+printf "  ACTIVE  base avg=%5s%% peak=%5s%%   ->   cand avg=%5s%% peak=%5s%%\n" "$AB_A" "$AB_P" "$AC_A" "$AC_P"
+echo "==================================================================================================="
+
+pkill -x warp-oss >/dev/null 2>&1
+pkill -x warp-oss-base >/dev/null 2>&1
+pkill -f "${TEST_BIN_DIR}/warp-oss-rel-" >/dev/null 2>&1

--- a/script/gpu_idle_test/cpu_thread_profile.py
+++ b/script/gpu_idle_test/cpu_thread_profile.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Per-thread CPU sampler for all warp-oss* processes, read straight from /proc
+(no perf/pidstat needed). Pair with gpu_pmu_sampler.py to decide whether the
+render pipeline is CPU-bound (a thread pegged ~100% while GPU has headroom) or
+GPU-bound (render engine near 100%).
+
+CPU% is per-core: 100% = one full core. Thread comm names hint at the role
+(main/render/tokio worker/pty reader).
+
+Usage: cpu_thread_profile.py <duration_s>
+"""
+import os, sys, glob, time
+
+DURATION = float(sys.argv[1]) if len(sys.argv) > 1 else 10.0
+CLK = os.sysconf("SC_CLK_TCK")
+NCPU = os.cpu_count() or 1
+
+
+def warp_pids():
+    pids = []
+    for d in glob.glob("/proc/[0-9]*"):
+        try:
+            comm = open(f"{d}/comm").read().strip()
+        except OSError:
+            continue
+        if comm.startswith("warp-oss"):
+            pids.append(int(d.split("/")[-1]))
+    return pids
+
+
+def snapshot(pids):
+    """{(pid,tid): (name, jiffies)} across all threads of all pids."""
+    snap = {}
+    for pid in pids:
+        for t in glob.glob(f"/proc/{pid}/task/*"):
+            tid = t.split("/")[-1]
+            try:
+                name = open(f"{t}/comm").read().strip()
+                st = open(f"{t}/stat").read()
+                after = st[st.rfind(")") + 2:].split()
+                utime, stime = int(after[11]), int(after[12])  # fields 14,15
+            except (OSError, IndexError, ValueError):
+                continue
+            snap[(pid, tid)] = (name, utime + stime)
+    return snap
+
+
+def main():
+    pids = warp_pids()
+    if not pids:
+        print("no warp-oss processes found")
+        sys.exit(1)
+    print(f"profiling {len(pids)} warp-oss pid(s): {sorted(pids)}  "
+          f"({NCPU} cores; 100% = one full core)\n")
+    s0 = snapshot(pids)
+    time.sleep(DURATION)
+    s1 = snapshot(pids)
+
+    rows = []
+    per_pid = {}
+    for key, (name, j1) in s1.items():
+        if key in s0:
+            dj = j1 - s0[key][1]
+            pct = dj / (DURATION * CLK) * 100.0
+            if pct >= 0.5:
+                rows.append((pct, key[0], key[1], name))
+                per_pid[key[0]] = per_pid.get(key[0], 0.0) + pct
+
+    rows.sort(reverse=True)
+    print("Top threads by CPU% (>=0.5%):")
+    print(f"  {'CPU%':>7}  {'pid':>8}  {'tid':>8}  comm")
+    for pct, pid, tid, name in rows[:18]:
+        print(f"  {pct:>6.1f}%  {pid:>8}  {tid:>8}  {name}")
+
+    print("\nPer-process total CPU%:")
+    for pid in sorted(per_pid, key=lambda p: -per_pid[p]):
+        print(f"  pid {pid:>8}: {per_pid[pid]:>6.1f}%")
+    total = sum(per_pid.values())
+    print(f"\n  ALL warp-oss CPU% = {total:.1f}%  "
+          f"(= {total/100:.2f} cores of {NCPU})")
+    hottest = rows[0] if rows else None
+    if hottest:
+        print(f"  hottest single thread = {hottest[0]:.1f}% ({hottest[3]})")
+        print("  -> near 100% on one thread while GPU has headroom == CPU-bound")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/gpu_idle_test/gpu_pmu_sampler.py
+++ b/script/gpu_idle_test/gpu_pmu_sampler.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+Whole-GPU utilization sampler via the i915 PMU -- the same source btop and
+intel_gpu_top use. Reads per-engine *-busy perf counters (nanoseconds the
+engine was busy) and normalizes by PERF_FORMAT_TOTAL_TIME_ENABLED:
+
+    engine_util% = delta(busy_ns) / delta(time_enabled_ns) * 100
+
+This measures the GPU system-wide (pid=-1), so it includes warp's rendering
+AND the GNOME compositor compositing warp's frames -- matching btop.
+
+Requires CAP_PERFMON or root on systems with perf_event_paranoid >= 2
+(that's why btop ships with cap_perfmon). Run with sudo if it errors EACCES.
+
+Usage: gpu_pmu_sampler.py <duration_s> <interval_ms> <out_csv>
+"""
+import ctypes
+import ctypes.util
+import os
+import struct
+import sys
+import time
+
+DURATION = float(sys.argv[1]) if len(sys.argv) > 1 else 20.0
+INTERVAL = (float(sys.argv[2]) if len(sys.argv) > 2 else 200.0) / 1000.0
+OUT = sys.argv[3] if len(sys.argv) > 3 else "/tmp/gpu_pmu.csv"
+
+PMU = "/sys/bus/event_source/devices/i915"
+PERF_FORMAT_TOTAL_TIME_ENABLED = 1 << 0
+__NR_perf_event_open = 298  # x86_64
+
+libc = ctypes.CDLL(ctypes.util.find_library("c") or "libc.so.6", use_errno=True)
+
+
+class perf_event_attr(ctypes.Structure):
+    _fields_ = [
+        ("type", ctypes.c_uint32),
+        ("size", ctypes.c_uint32),
+        ("config", ctypes.c_uint64),
+        ("sample_period", ctypes.c_uint64),
+        ("sample_type", ctypes.c_uint64),
+        ("read_format", ctypes.c_uint64),
+        ("flags", ctypes.c_uint64),
+        ("wakeup_events", ctypes.c_uint32),
+        ("bp_type", ctypes.c_uint32),
+        ("config1", ctypes.c_uint64),
+        ("config2", ctypes.c_uint64),
+        ("branch_sample_type", ctypes.c_uint64),
+        ("sample_regs_user", ctypes.c_uint64),
+        ("sample_stack_user", ctypes.c_uint32),
+        ("clockid", ctypes.c_int32),
+        ("sample_regs_intr", ctypes.c_uint64),
+        ("aux_watermark", ctypes.c_uint32),
+        ("sample_max_stack", ctypes.c_uint16),
+        ("__reserved_2", ctypes.c_uint16),
+        ("aux_sample_size", ctypes.c_uint32),
+        ("__reserved_3", ctypes.c_uint32),
+    ]
+
+
+def perf_type():
+    return int(open(f"{PMU}/type").read().strip())
+
+
+def event_config(name):
+    txt = open(f"{PMU}/events/{name}").read().strip()
+    for part in txt.split(","):
+        if part.startswith("config="):
+            return int(part.split("=")[1], 0)
+    return int(txt, 0)
+
+
+def perf_open(ptype, config):
+    attr = perf_event_attr()
+    attr.size = ctypes.sizeof(perf_event_attr)
+    attr.type = ptype
+    attr.config = config
+    attr.read_format = PERF_FORMAT_TOTAL_TIME_ENABLED
+    nr_cpus = os.cpu_count() or 1
+    for cpu in range(nr_cpus):
+        fd = libc.syscall(__NR_perf_event_open, ctypes.byref(attr), -1, cpu, -1, 0)
+        if fd >= 0:
+            return fd
+        err = ctypes.get_errno()
+        if err != 22:
+            raise OSError(err, f"perf_event_open failed: {os.strerror(err)}")
+    raise OSError(err, f"perf_event_open failed on all cpus: {os.strerror(err)}")
+
+
+def read_counter(fd):
+    buf = os.read(fd, 16)
+    value, time_enabled = struct.unpack("QQ", buf)
+    return value, time_enabled
+
+
+def main():
+    ptype = perf_type()
+    engines = []
+    for name in ["rcs0-busy", "bcs0-busy", "vcs0-busy", "vecs0-busy"]:
+        path = f"{PMU}/events/{name}"
+        if not os.path.exists(path):
+            continue
+        try:
+            fd = perf_open(ptype, event_config(name))
+        except OSError as e:
+            print(
+                f"error opening {name}: {e}\n"
+                f"  -> i915 PMU needs CAP_PERFMON/root here. Re-run with sudo.",
+                file=sys.stderr,
+            )
+            sys.exit(13)
+        engines.append((name.replace("-busy", ""), fd))
+
+    if not engines:
+        print("no i915 busy engines found", file=sys.stderr)
+        sys.exit(1)
+
+    labels = [e[0] for e in engines]
+    prev = {lab: read_counter(fd) for lab, fd in engines}
+    samples = {lab: [] for lab in labels}
+
+    with open(OUT, "w") as f:
+        f.write("t_ms," + ",".join(f"{l}_pct" for l in labels) + "\n")
+        end = time.monotonic() + DURATION
+        while time.monotonic() < end:
+            time.sleep(INTERVAL)
+            row = [str(int(time.monotonic() * 1000))]
+            for lab, fd in engines:
+                v, t = read_counter(fd)
+                pv, pt = prev[lab]
+                dt = t - pt or 1
+                util = max(0.0, min(100.0, (v - pv) * 100.0 / dt))
+                samples[lab].append(util)
+                row.append(f"{util:.1f}")
+                prev[lab] = (v, t)
+            f.write(",".join(row) + "\n")
+
+    print("  whole-GPU (i915 PMU, like btop):")
+    for lab in labels:
+        s = samples[lab]
+        if not s:
+            continue
+        print(f"    {lab:6s}  avg={sum(s)/len(s):5.1f}%  peak={max(s):5.1f}%")
+    rcs = samples.get("rcs0", [])
+    if rcs:
+        print(f"  -> render(rcs0) avg={sum(rcs)/len(rcs):.1f}%  peak={max(rcs):.1f}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/gpu_idle_test/gpu_split_probe.py
+++ b/script/gpu_idle_test/gpu_split_probe.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Attribute i915 render-engine busy time to processes via /proc/<pid>/fdinfo
+(drm-engine-render, cumulative ns per DRM client). Reports Warp's own GPU
+render % vs GNOME Shell's (the compositor) over a window, so we can tell whether
+the cost is Warp's rasterization or mutter re-compositing Warp's full surface.
+
+Compare these against the system-wide i915 PMU (gpu_pmu_sampler.py) run over the
+same window.
+
+Usage: gpu_split_probe.py <duration_s>
+"""
+import os, sys, glob, time
+
+DURATION = float(sys.argv[1]) if len(sys.argv) > 1 else 8.0
+
+
+def is_drm_fd(pid, fd):
+    try:
+        return "/dev/dri/" in os.readlink(f"/proc/{pid}/fd/{fd}")
+    except OSError:
+        return False
+
+
+def proc_render_ns(pid, sample_keys=None):
+    """Sum drm-engine-render ns across distinct DRM clients of this pid.
+    If sample_keys is a set, also records which drm-engine-* keys were seen."""
+    clients = {}
+    try:
+        fds = os.listdir(f"/proc/{pid}/fd")
+    except OSError:
+        return 0
+    for fd in fds:
+        if not is_drm_fd(pid, fd):
+            continue
+        try:
+            txt = open(f"/proc/{pid}/fdinfo/{fd}").read()
+        except OSError:
+            continue
+        cid, render_ns = None, None
+        for line in txt.splitlines():
+            if line.startswith("drm-client-id:"):
+                cid = line.split(":", 1)[1].strip()
+            elif line.startswith("drm-engine-") and sample_keys is not None:
+                sample_keys.add(line.split(":", 1)[0])
+            if line.startswith("drm-engine-render:"):
+                parts = line.split(":", 1)[1].split()
+                if parts and parts[0].isdigit():
+                    render_ns = int(parts[0])
+        if render_ns is not None:
+            clients[cid if cid is not None else f"{pid}:{fd}"] = render_ns
+    return sum(clients.values())
+
+
+def pids(prefix=None, exact=None):
+    out = []
+    for d in glob.glob("/proc/[0-9]*"):
+        pid = d.split("/")[-1]
+        try:
+            comm = open(f"{d}/comm").read().strip()
+        except OSError:
+            continue
+        if (prefix and comm.startswith(prefix)) or (exact and comm == exact):
+            out.append(int(pid))
+    return out
+
+
+def group_ns(group, sample_keys=None):
+    return sum(proc_render_ns(p, sample_keys) for p in group)
+
+
+def main():
+    warp = pids(prefix="warp-oss")
+    shell = pids(exact="gnome-shell")
+    if not warp:
+        print("no warp-oss processes found")
+        sys.exit(1)
+
+    keys = set()
+    w0 = group_ns(warp, keys)
+    s0 = group_ns(shell)
+    t0 = time.monotonic()
+    time.sleep(DURATION)
+    w1 = group_ns(warp)
+    s1 = group_ns(shell)
+    dt_ns = (time.monotonic() - t0) * 1e9
+
+    wp = (w1 - w0) / dt_ns * 100
+    sp = (s1 - s0) / dt_ns * 100
+    print(f"window={DURATION:.1f}s   (drm-engine-render via fdinfo)")
+    print(f"  Warp        render: {wp:5.1f}%   pids={sorted(warp)}")
+    print(f"  GNOME Shell render: {sp:5.1f}%   pids={sorted(shell)}")
+    print(f"  Warp + GNOME      : {wp + sp:5.1f}%")
+    if w1 - w0 == 0:
+        print(f"  [warn] Warp render delta was 0; drm-engine-* keys seen: {sorted(keys) or 'NONE'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/gpu_idle_test/mem_watchdog.sh
+++ b/script/gpu_idle_test/mem_watchdog.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Optional OOM guard during release builds on memory-constrained machines.
+# Kills cargo/rustc if MemAvailable drops below THRESHOLD_KB (default 2.5GB).
+THRESHOLD_KB="${1:-2500000}"
+LOG=/tmp/mem_watchdog.log
+echo "watchdog started $(date) threshold=${THRESHOLD_KB}kB" > "$LOG"
+while true; do
+  avail=$(awk '/MemAvailable/{print $2}' /proc/meminfo)
+  if [ "${avail:-0}" -lt "$THRESHOLD_KB" ]; then
+    echo "$(date) MemAvailable=${avail}kB < ${THRESHOLD_KB}kB -> KILLING BUILD" >> "$LOG"
+    pkill -f 'cargo build --release' 2>/dev/null
+    pkill -x rustc 2>/dev/null
+    sleep 5
+  fi
+  sleep 2
+done

--- a/script/gpu_idle_test/profile_active.sh
+++ b/script/gpu_idle_test/profile_active.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Profile ACTIVE-path GPU/CPU for a Warp binary in one of three regimes, to
+# attribute where the cost goes (see METHODOLOGY.md):
+#
+#   type   - continuous prompt typing + clear (no command run). Render-bound;
+#            the regime the partial-repaint damage path targets.
+#   scroll - PageUp/PageDown over pre-built scrollback (no new output).
+#            Render-bound (every visible row changes).
+#   flood  - one self-sustaining `seq` flood. PTY-parse-bound (CPU), not render.
+#
+# Samples the whole-GPU i915 PMU (gpu_pmu_sampler.py) and warp's per-thread CPU
+# (cpu_thread_profile.py) over the same window. Use release builds only (debug
+# is CPU-starved and misreports GPU).
+#
+# Usage: profile_active.sh <warp-binary> [type|scroll|flood]
+#   env: PROFILE_S (default 10), SCROLLBACK (default 50000)
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+BIN="${1:?usage: profile_active.sh <warp-binary> [type|scroll|flood]}"
+MODE="${2:-type}"
+PROFILE_S="${PROFILE_S:-10}"
+SCROLLBACK="${SCROLLBACK:-50000}"
+BIN_ABS="$(realpath "$BIN")"
+export YDOTOOL_SOCKET="${YDOTOOL_SOCKET:-$XDG_RUNTIME_DIR/.ydotool_socket}"
+ESC=1; ENTER=28; LCTRL=29; U=22; PAGEUP=104; PAGEDOWN=109
+tap() { ydotool key "$1:1" "$1:0"; }
+
+# Kill the launched warp by its absolute path anchored to the start of the
+# command line: matches the process (argv0 == BIN_ABS) and its self-reexec
+# children, but never this script or shell (they start with `bash`).
+kill_warp() { pkill -f "^${BIN_ABS}" >/dev/null 2>&1; true; }
+
+pgrep -x ydotoold >/dev/null || { echo "ERROR: ydotoold not running"; exit 1; }
+ydotool key 0:0 >/dev/null 2>&1 || { echo "ERROR: ydotool cannot reach ydotoold"; exit 1; }
+[ -x "$BIN_ABS" ] || { echo "ERROR: not executable: $BIN_ABS"; exit 1; }
+
+kill_warp; sleep 1.5
+echo "launching $(basename "$BIN_ABS") [mode=$MODE]..."
+WARP_ENABLE_WAYLAND=1 setsid "$BIN_ABS" >/tmp/warp-oss.active.log 2>&1 &
+sleep 3
+tap $ESC; sleep 0.3
+
+WORKLOAD_PID=""
+case "$MODE" in
+  flood)
+    # One injection, then self-sustaining (hands-free).
+    ydotool type --key-delay 2 "seq 1 30000000"; tap $ENTER; sleep 2.5
+    ;;
+  scroll)
+    echo "building ${SCROLLBACK} lines of scrollback..."
+    ydotool type --key-delay 2 "seq 1 ${SCROLLBACK}"; tap $ENTER; sleep 3
+    END=$(( $(date +%s) + PROFILE_S + 4 ))
+    ( while [ "$(date +%s)" -lt "$END" ]; do
+        for _ in $(seq 1 10); do tap $PAGEUP; done
+        for _ in $(seq 1 10); do tap $PAGEDOWN; done
+      done ) & WORKLOAD_PID=$!
+    sleep 1.5
+    ;;
+  type)
+    ydotool type --key-delay 2 "seq 1 5000"; tap $ENTER; sleep 2
+    END=$(( $(date +%s) + PROFILE_S + 4 ))
+    ( line="the quick brown fox jumps over the lazy dog 0123456789 "
+      while [ "$(date +%s)" -lt "$END" ]; do
+        for _ in 1 2 3; do ydotool type --key-delay 2 "$line"; done
+        ydotool key ${LCTRL}:1 ${U}:1 ${U}:0 ${LCTRL}:0   # clear, no command run
+      done ) & WORKLOAD_PID=$!
+    sleep 1.5
+    ;;
+  *) echo "ERROR: unknown mode '$MODE' (type|scroll|flood)"; kill_warp; exit 2;;
+esac
+
+# Focus-miss / no-load gate: a real active workload drives the GPU up.
+"$HERE/gpu_pmu_sampler.py" 1.5 100 /tmp/gpu_precheck.csv >/dev/null 2>&1
+PRE=$(awk -F, 'NR>1{s+=$2;n++} END{if(n)printf "%.1f",s/n; else printf 0}' /tmp/gpu_precheck.csv)
+echo "  pre-check render avg = ${PRE}%"
+if awk "BEGIN{exit !($PRE < 5)}"; then
+  echo "ABORT: workload did not register (focus miss?). GPU still idle."
+  [ -n "$WORKLOAD_PID" ] && kill "$WORKLOAD_PID" 2>/dev/null
+  kill_warp; exit 3
+fi
+
+echo "profiling ${PROFILE_S}s (i915 PMU @100ms + warp per-thread CPU)..."
+"$HERE/gpu_pmu_sampler.py" "$PROFILE_S" 100 /tmp/gpu_active.csv >/tmp/gpu_active.summary 2>&1 &
+GP=$!
+"$HERE/cpu_thread_profile.py" "$PROFILE_S"
+wait "$GP"
+[ -n "$WORKLOAD_PID" ] && kill "$WORKLOAD_PID" 2>/dev/null
+
+echo
+echo "=== GPU (i915 PMU, whole system incl. compositor) ==="
+awk -F, 'NR>1{s+=$2;n++;if($2>p)p=$2} END{if(n)printf "  render rcs0: avg=%.1f%% peak=%.1f%%\n",s/n,p}' /tmp/gpu_active.csv
+kill_warp

--- a/script/gpu_idle_test/verify_idle_vs_active.sh
+++ b/script/gpu_idle_test/verify_idle_vs_active.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Autonomous idle-vs-active GPU verification for Warp on Linux (Intel i915).
+#
+# Samples GPU utilization while Warp is focused-and-idle (cursor blinking), then
+# while actively typing/scrolling. Uses ydotool for keyboard input; does not
+# move the mouse (Super / absolute mousemove can open GNOME overview).
+#
+# Usage: verify_idle_vs_active.sh [BIN] [LABEL] [SCROLLBACK seq_n]
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+BIN="${1:-$REPO_ROOT/target/release/warp-oss}"
+LABEL="${2:-dev}"
+SCROLLBACK="${3:-4000}"
+TEST_BIN_DIR="${TEST_BIN_DIR:-$REPO_ROOT/target/gpu_idle_test/bin}"
+
+INTERVAL_MS="${INTERVAL_MS:-500}"
+IDLE_S="${IDLE_S:-25}"
+ACTIVE_S="${ACTIVE_S:-12}"
+SAMPLE_ACTIVE_S=$(( ACTIVE_S + 2 ))
+export YDOTOOL_SOCKET="${YDOTOOL_SOCKET:-$XDG_RUNTIME_DIR/.ydotool_socket}"
+
+IDLE_CSV="/tmp/gpu_idle_${LABEL}.csv"
+ACTIVE_CSV="/tmp/gpu_active_${LABEL}.csv"
+
+ESC=1; ENTER=28; LCTRL=29; U=22; PAGEUP=104; PAGEDOWN=109
+
+key() { ydotool key "$@"; }
+tap() { ydotool key "$1:1" "$1:0"; }
+
+kill_warp() {
+  pkill -x warp-oss >/dev/null 2>&1
+  pkill -x warp-oss-base >/dev/null 2>&1
+  pkill -f "${TEST_BIN_DIR}/warp-oss-rel-" >/dev/null 2>&1
+  true
+}
+
+[ -x "$BIN" ] || { echo "ERROR: binary not executable: $BIN"; exit 1; }
+
+if ! pgrep -x ydotoold >/dev/null; then
+  ydotoold --socket-path "$YDOTOOL_SOCKET" --socket-own "$(id -u):$(id -g)" >/tmp/ydotoold.log 2>&1 &
+  sleep 1.5
+fi
+ydotool key 0:0 >/dev/null 2>&1 || { echo "ERROR: ydotool cannot reach ydotoold"; exit 1; }
+
+kill_warp
+sleep 1.5
+if [ "${RESET_SESSION:-0}" = "1" ]; then
+  rm -f ~/.local/state/warp-oss/warp.sqlite ~/.local/state/warp-oss/warp.sqlite-wal ~/.local/state/warp-oss/warp.sqlite-shm 2>/dev/null
+  echo "(reset dev warp-oss session -> empty terminal on launch)"
+fi
+
+echo "launching $BIN (WARP_ENABLE_WAYLAND=1)..."
+WARP_ENABLE_WAYLAND=1 setsid "$BIN" >/tmp/warp-oss.verify.log 2>&1 &
+sleep 3
+tap $ESC; sleep 0.3
+
+echo "IDLE sampling ${IDLE_S}s @ ${INTERVAL_MS}ms (no input)..."
+"$HERE/gpu_pmu_sampler.py" "$IDLE_S" "$INTERVAL_MS" "$IDLE_CSV" >/dev/null 2>&1
+
+if [ "$SCROLLBACK" -gt 0 ]; then
+  ydotool type --key-delay 3 "seq 1 ${SCROLLBACK}"
+  tap $ENTER
+  sleep 1.0
+fi
+
+echo "ACTIVE sampling ${SAMPLE_ACTIVE_S}s @ ${INTERVAL_MS}ms (fast typing + flood + scroll)..."
+"$HERE/gpu_pmu_sampler.py" "$SAMPLE_ACTIVE_S" "$INTERVAL_MS" "$ACTIVE_CSV" >/dev/null 2>&1 &
+SP=$!
+
+line="the quick brown fox jumps over the lazy dog 0123456789 "
+WL_END=$(( $(date +%s) + ACTIVE_S ))
+while [ "$(date +%s)" -lt "$WL_END" ]; do
+  for _ in 1 2 3 4 5 6; do ydotool type --key-delay 3 "$line"; done
+  key ${LCTRL}:1 ${U}:1 ${U}:0 ${LCTRL}:0
+  ydotool type --key-delay 3 "seq 1 4000"
+  tap $ENTER
+  sleep 0.4
+  for _ in $(seq 1 12); do tap $PAGEUP; done
+  for _ in $(seq 1 12); do tap $PAGEDOWN; done
+done
+wait "$SP"
+
+stat() {
+  awk -F, -v metric="$2" -v which="$3" '
+    NR>1{
+      v = (metric=="render") ? $2 : $2;
+      if (metric=="btopmax") { v=$2; if($3>v)v=$3; if($4>v)v=$4; if($5>v)v=$5; }
+      s+=v; n++; if(v>p)p=v;
+    }
+    END{ if(n){ printf "%.1f", (which=="avg")? s/n : p } else printf "0.0" }' "$1"
+}
+IR_AVG=$(stat "$IDLE_CSV" render avg);   IR_PK=$(stat "$IDLE_CSV" render peak)
+IM_AVG=$(stat "$IDLE_CSV" btopmax avg);  IM_PK=$(stat "$IDLE_CSV" btopmax peak)
+AR_AVG=$(stat "$ACTIVE_CSV" render avg); AR_PK=$(stat "$ACTIVE_CSV" render peak)
+AM_AVG=$(stat "$ACTIVE_CSV" btopmax avg);AM_PK=$(stat "$ACTIVE_CSV" btopmax peak)
+
+echo "==================================================================="
+echo "  RESULT ($LABEL, scrollback=$SCROLLBACK, interval=${INTERVAL_MS}ms)"
+echo "  --- btop-equivalent (max engine = btop gpu-totals) ---"
+echo "  IDLE    avg=${IM_AVG}%  peak=${IM_PK}%"
+echo "  ACTIVE  avg=${AM_AVG}%  peak=${AM_PK}%"
+echo "  --- render engine (rcs0) only ---"
+echo "  IDLE    avg=${IR_AVG}%  peak=${IR_PK}%"
+echo "  ACTIVE  avg=${AR_AVG}%  peak=${AR_PK}%"
+echo "==================================================================="
+
+kill_warp


### PR DESCRIPTION
## Reduce active-path (typing/scroll) GPU on Linux/Wayland iGPUs

Addresses the **active** typing/scrolling part of #13158 (high GPU on Linux + Intel Iris Xe @ 3840×2400). The **idle** cursor-blink part is #13159; this PR builds on that work, so its diff currently includes those commits — **review the commits from `60147e4f` onward** (the idle commits collapse out once #13159 merges).

> Opened as a **draft**: it stacks on the unmerged #13159, and I'd value maintainer input on the approach (see "Open question" below) before calling it ready.

### What it does

Warp re-rasterizes the **whole window** on any change. That's ~free on the Apple-Silicon/Metal target (the [how-warp-works](https://www.warp.dev/blog/how-warp-works) post measures ~1.9 ms to redraw the screen), but on a low-power iGPU driving a 4K panel a full redraw is ~16–33 ms, so typing pegs the GPU (~60%).

This adds **damage-tracked partial repaints** for active frames, building on the offscreen-target + `SceneDamage` machinery from the idle fix:

- **`SceneDamage::Partial`** + a unit-tested decision (`scene_damage_for`): a non-structural frame that re-rendered some views is partial; a pure cursor blink keeps the `CursorOnly` path; removed views / explicit redraw / later coalescing iterations force a full repaint.
- **Presenter** records the painted bounds of every view invalidated this frame as the damage region. Keying off *what actually re-rendered* (rather than per-view opt-in) is important: typing re-renders ~10 input-bar views, several of which are **re-created** each frame (context chips) and have no `notify()` to convert.
- **Renderer** scissors rasterization to the union of the previous and current frame's changed-view bounds, falling back to a full repaint on a vertical layout shift (input growing a line can move untracked siblings such as scrollback).

### Measured effect

Same-commit **release** A/B on Iris Xe / Wayland / 3840×2400, active typing, i915 PMU @100 ms:

```
render(rcs0)  avg 54.8% -> 46.5%   peak 75.1% -> 63.4%
```

### Ceiling / follow-up

This shrinks Warp's **own** scene rasterization. Two fixed per-frame costs remain: the full offscreen→swapchain copy, and the **compositor's full-surface present** (≈24% of render-engine time during typing, measured via `/proc/<pid>/fdinfo`). Cutting those needs `wl_surface` buffer damage on the present path — a separate, larger change.

### Harness + methodology

`script/gpu_idle_test/` gains the active-path tooling and a write-up:
- `profile_active.sh` (type/scroll/flood regimes), `cpu_thread_profile.py` (per-thread CPU), `gpu_split_probe.py` (per-process GPU attribution via fdinfo), and `METHODOLOGY.md` documenting the measurement approach (release-only, sample ≤100 ms to avoid the averaging artifact, per-regime findings, the Warp-vs-compositor split, why frame-rate/vsync is not the lever).

### Open question for the rendering folks

The damage is computed automatically in the presenter from the invalidated set. Does that direction fit your reactivity model, or would you prefer the per-view route / something else? Happy to adapt — flagged because this touches the render path you're actively evolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
