### PR TITLE
fix(vim): respect count before gg (e.g. 5gg jumps to line 5)

### DIFF
--- a/app/src/code/editor/view/vim_handler.rs
+++ b/app/src/code/editor/view/vim_handler.rs
@@ -235,7 +235,7 @@ impl VimHandler for CodeEditorView {
                                 let current_selections = selection_model.selection_offsets();
 
                                 let max_row = buffer.max_point().row;
-                                let row = (*line_number).saturating_sub(1).min(max_row);
+                                let row = (*line_number).min(max_row);
 
                                 let new_selections = current_selections.mapped(|selection| {
                                     let cursor_pos = selection.head;
@@ -669,7 +669,7 @@ impl VimHandler for CodeEditorView {
         self.model.update(ctx, |model, ctx| {
             let buffer = model.content().as_ref(ctx);
             let max_row = buffer.max_point().row;
-            let row = line_number.saturating_sub(1).min(max_row);
+            let row = line_number.min(max_row);
             model.jump_to_line_column(row as usize, None, ctx);
         });
     }

--- a/app/src/code/editor/view/vim_handler.rs
+++ b/app/src/code/editor/view/vim_handler.rs
@@ -234,10 +234,13 @@ impl VimHandler for CodeEditorView {
                                 let selection_model = model.buffer_selection_model().as_ref(ctx);
                                 let current_selections = selection_model.selection_offsets();
 
+                                let max_row = buffer.max_point().row;
+                                let row = (*line_number).saturating_sub(1).min(max_row);
+
                                 let new_selections = current_selections.mapped(|selection| {
                                     let cursor_pos = selection.head;
                                     let target_pos =
-                                        Point::new(*line_number, 0).to_buffer_char_offset(buffer);
+                                        Point::new(row, 0).to_buffer_char_offset(buffer);
 
                                     SelectionOffsets {
                                         head: target_pos,

--- a/app/src/code/editor/view/vim_handler.rs
+++ b/app/src/code/editor/view/vim_handler.rs
@@ -235,7 +235,7 @@ impl VimHandler for CodeEditorView {
                                 let current_selections = selection_model.selection_offsets();
 
                                 let max_row = buffer.max_point().row;
-                                let row = (*line_number).saturating_sub(1).min(max_row);
+                                let row = (*line_number).min(max_row);
 
                                 let new_selections = current_selections.mapped(|selection| {
                                     let cursor_pos = selection.head;
@@ -667,10 +667,7 @@ impl VimHandler for CodeEditorView {
 
     fn jump_to_line(&mut self, line_number: u32, ctx: &mut ViewContext<Self>) {
         self.model.update(ctx, |model, ctx| {
-            let buffer = model.content().as_ref(ctx);
-            let max_row = buffer.max_point().row as usize;
-            let row = (line_number as usize).saturating_sub(1).min(max_row);
-            model.jump_to_line_column(row, None, ctx);
+            model.jump_to_line_column(line_number as usize, None, ctx);
         });
     }
 

--- a/app/src/code/editor/view/vim_handler.rs
+++ b/app/src/code/editor/view/vim_handler.rs
@@ -235,7 +235,7 @@ impl VimHandler for CodeEditorView {
                                 let current_selections = selection_model.selection_offsets();
 
                                 let max_row = buffer.max_point().row;
-                                let row = (*line_number).min(max_row);
+                                let row = (*line_number).saturating_sub(1).min(max_row);
 
                                 let new_selections = current_selections.mapped(|selection| {
                                     let cursor_pos = selection.head;
@@ -669,7 +669,7 @@ impl VimHandler for CodeEditorView {
         self.model.update(ctx, |model, ctx| {
             let buffer = model.content().as_ref(ctx);
             let max_row = buffer.max_point().row;
-            let row = line_number.min(max_row);
+            let row = line_number.saturating_sub(1).min(max_row);
             model.jump_to_line_column(row as usize, None, ctx);
         });
     }

--- a/app/src/code/editor/view/vim_handler.rs
+++ b/app/src/code/editor/view/vim_handler.rs
@@ -667,7 +667,10 @@ impl VimHandler for CodeEditorView {
 
     fn jump_to_line(&mut self, line_number: u32, ctx: &mut ViewContext<Self>) {
         self.model.update(ctx, |model, ctx| {
-            model.jump_to_line_column(line_number as usize, None, ctx);
+            let buffer = model.content().as_ref(ctx);
+            let max_row = buffer.max_point().row;
+            let row = line_number.min(max_row);
+            model.jump_to_line_column(row as usize, None, ctx);
         });
     }
 

--- a/app/src/code/editor/view/vim_handler.rs
+++ b/app/src/code/editor/view/vim_handler.rs
@@ -664,7 +664,10 @@ impl VimHandler for CodeEditorView {
 
     fn jump_to_line(&mut self, line_number: u32, ctx: &mut ViewContext<Self>) {
         self.model.update(ctx, |model, ctx| {
-            model.jump_to_line_column(line_number as usize, None, ctx);
+            let buffer = model.content().as_ref(ctx);
+            let max_row = buffer.max_point().row as usize;
+            let row = (line_number as usize).saturating_sub(1).min(max_row);
+            model.jump_to_line_column(row, None, ctx);
         });
     }
 

--- a/app/src/editor/view/mod.rs
+++ b/app/src/editor/view/mod.rs
@@ -2446,8 +2446,14 @@ impl VimHandler for EditorView {
         });
     }
 
-    fn jump_to_line(&mut self, _line_number: u32, _ctx: &mut ViewContext<Self>) {
-        // Jumping to line number not supported
+    fn jump_to_line(&mut self, line_number: u32, ctx: &mut ViewContext<Self>) {
+        self.change_selections(ctx, |editor_model, ctx| {
+            let buffer = editor_model.buffer(ctx);
+            let max_row = buffer.max_point().row;
+            let row = (line_number.saturating_sub(1)).min(max_row);
+            let point = Point::new(row, 0);
+            editor_model.reset_selections_to_point(&point, ctx);
+        });
     }
 
     fn jump_to_matching_bracket(&mut self, ctx: &mut ViewContext<Self>) {

--- a/app/src/editor/view/mod.rs
+++ b/app/src/editor/view/mod.rs
@@ -2281,8 +2281,19 @@ impl VimHandler for EditorView {
                                     editor_model.extend_selection_linewise(include_newline, ctx);
                                 }
                             }
-                            VimMotion::JumpToLine(_line_number) => {
-                                // Jumping to line number not supported
+                            VimMotion::JumpToLine(line_number) => {
+                                let buffer = editor_model.buffer(ctx);
+                                let max_row = buffer.max_point().row;
+                                let row = (*line_number).saturating_sub(1).min(max_row);
+                                editor_model.move_cursor(
+                                    /* keep_selection */ true,
+                                    |_, _| Point::new(row, 0),
+                                    ctx,
+                                );
+                                if *motion_type == MotionType::Linewise {
+                                    let include_newline = *operator != VimOperator::Change;
+                                    editor_model.extend_selection_linewise(include_newline, ctx);
+                                }
                             }
                         }
                     }

--- a/app/src/editor/view/mod.rs
+++ b/app/src/editor/view/mod.rs
@@ -2282,12 +2282,9 @@ impl VimHandler for EditorView {
                                 }
                             }
                             VimMotion::JumpToLine(line_number) => {
-                                let buffer = editor_model.buffer(ctx);
-                                let max_row = buffer.max_point().row;
-                                let row = (*line_number).saturating_sub(1).min(max_row);
                                 editor_model.move_cursor(
                                     /* keep_selection */ true,
-                                    |_, _| Point::new(row, 0),
+                                    |_, _| Point::new(*line_number, 0),
                                     ctx,
                                 );
                                 if *motion_type == MotionType::Linewise {
@@ -2459,10 +2456,7 @@ impl VimHandler for EditorView {
 
     fn jump_to_line(&mut self, line_number: u32, ctx: &mut ViewContext<Self>) {
         self.change_selections(ctx, |editor_model, ctx| {
-            let buffer = editor_model.buffer(ctx);
-            let max_row = buffer.max_point().row;
-            let row = (line_number.saturating_sub(1)).min(max_row);
-            let point = Point::new(row, 0);
+            let point = Point::new(line_number, 0);
             editor_model.reset_selections_to_point(&point, ctx);
         });
     }

--- a/app/src/editor/view/mod.rs
+++ b/app/src/editor/view/mod.rs
@@ -2282,9 +2282,11 @@ impl VimHandler for EditorView {
                                 }
                             }
                             VimMotion::JumpToLine(line_number) => {
+                                let max_row = editor_model.buffer(ctx).max_point().row;
+                                let row = line_number.saturating_sub(1).min(max_row);
                                 editor_model.move_cursor(
                                     /* keep_selection */ true,
-                                    |_, _| Point::new(*line_number, 0),
+                                    move |_, _| Point::new(row, 0),
                                     ctx,
                                 );
                                 if *motion_type == MotionType::Linewise {
@@ -2456,7 +2458,9 @@ impl VimHandler for EditorView {
 
     fn jump_to_line(&mut self, line_number: u32, ctx: &mut ViewContext<Self>) {
         self.change_selections(ctx, |editor_model, ctx| {
-            let point = Point::new(line_number, 0);
+            let max_row = editor_model.buffer(ctx).max_point().row;
+            let row = line_number.saturating_sub(1).min(max_row);
+            let point = Point::new(row, 0);
             editor_model.reset_selections_to_point(&point, ctx);
         });
     }

--- a/app/src/editor/view/mod.rs
+++ b/app/src/editor/view/mod.rs
@@ -2283,7 +2283,7 @@ impl VimHandler for EditorView {
                             }
                             VimMotion::JumpToLine(line_number) => {
                                 let max_row = editor_model.buffer(ctx).max_point().row;
-                                let row = (*line_number).min(max_row);
+                                let row = (*line_number).saturating_sub(1).min(max_row);
                                 editor_model.move_cursor(
                                     /* keep_selection */ true,
                                     move |_, _| Point::new(row, 0),
@@ -2459,7 +2459,7 @@ impl VimHandler for EditorView {
     fn jump_to_line(&mut self, line_number: u32, ctx: &mut ViewContext<Self>) {
         self.change_selections(ctx, |editor_model, ctx| {
             let max_row = editor_model.buffer(ctx).max_point().row;
-            let row = line_number.min(max_row);
+            let row = line_number.saturating_sub(1).min(max_row);
             let point = Point::new(row, 0);
             editor_model.reset_selections_to_point(&point, ctx);
         });

--- a/app/src/editor/view/mod.rs
+++ b/app/src/editor/view/mod.rs
@@ -2283,7 +2283,7 @@ impl VimHandler for EditorView {
                             }
                             VimMotion::JumpToLine(line_number) => {
                                 let max_row = editor_model.buffer(ctx).max_point().row;
-                                let row = line_number.saturating_sub(1).min(max_row);
+                                let row = (*line_number).min(max_row);
                                 editor_model.move_cursor(
                                     /* keep_selection */ true,
                                     move |_, _| Point::new(row, 0),
@@ -2459,7 +2459,7 @@ impl VimHandler for EditorView {
     fn jump_to_line(&mut self, line_number: u32, ctx: &mut ViewContext<Self>) {
         self.change_selections(ctx, |editor_model, ctx| {
             let max_row = editor_model.buffer(ctx).max_point().row;
-            let row = line_number.saturating_sub(1).min(max_row);
+            let row = line_number.min(max_row);
             let point = Point::new(row, 0);
             editor_model.reset_selections_to_point(&point, ctx);
         });

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -308,7 +308,7 @@ pub enum VimMotion {
     FindChar(FindCharMotion),
     JumpToFirstLine,
     JumpToLastLine,
-    /// Jump to a specific line number (1-based). See ":help gg" and ":help G" in Vim.
+    /// Jump to a specific line number. See ":help gg" and ":help G" in Vim.
     JumpToLine(u32),
     /// See ":help %" in Vim.
     JumpToMatchingBracket,

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -2071,3 +2071,7 @@ pub trait VimHandler {
     /// Move the cursor up `count` half-pages and scroll the viewport (`<C-u>`).
     fn scroll_half_page_up(&mut self, _count: u32, _ctx: &mut ViewContext<Self>) {}
 }
+
+#[cfg(test)]
+#[path = "vim_tests.rs"]
+mod tests;

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -2073,5 +2073,6 @@ pub trait VimHandler {
 }
 
 #[cfg(test)]
+#[allow(non_snake_case)]
 #[path = "vim_tests.rs"]
 mod tests;

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1073,7 +1073,10 @@ impl VimFSA {
                     bound: WordBound::End,
                     word_type: WordType::from(c),
                 })),
-                'g' => VimEventType::Navigate(VimMotion::JumpToFirstLine),
+                'g' => match self.get_action_count() {
+                    Some(line_number) => VimEventType::Navigate(VimMotion::JumpToLine(line_number)),
+                    None => VimEventType::Navigate(VimMotion::JumpToFirstLine),
+                },
                 'd' => VimEventType::GotoDefinition,
                 'h' => VimEventType::ShowHover,
                 'r' => VimEventType::FindReferences,
@@ -1331,7 +1334,10 @@ impl VimFSA {
                 'g' => self.create_operation(
                     operator,
                     VimOperand::Motion {
-                        motion: VimMotion::JumpToFirstLine,
+                        motion: match self.get_operand_count() {
+                            Some(line_number) => VimMotion::JumpToLine(line_number),
+                            None => VimMotion::JumpToFirstLine,
+                        },
                         motion_type: MotionType::Linewise,
                     },
                 ),
@@ -1557,7 +1563,10 @@ impl VimFSA {
                     bound: WordBound::End,
                     word_type: WordType::from(c),
                 })),
-                'g' => VimEventType::Navigate(VimMotion::JumpToFirstLine),
+                'g' => match self.get_action_count() {
+                    Some(line_number) => VimEventType::Navigate(VimMotion::JumpToLine(line_number)),
+                    None => VimEventType::Navigate(VimMotion::JumpToFirstLine),
+                },
                 'c' => {
                     let motion_type = match self.mode {
                         VimMode::Visual(mt) => mt,

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -308,7 +308,7 @@ pub enum VimMotion {
     FindChar(FindCharMotion),
     JumpToFirstLine,
     JumpToLastLine,
-    /// Jump to a specific line number. See ":help G" in Vim.
+    /// Jump to a specific line number (1-based). See ":help gg" and ":help G" in Vim.
     JumpToLine(u32),
     /// See ":help %" in Vim.
     JumpToMatchingBracket,

--- a/crates/vim/src/vim_tests.rs
+++ b/crates/vim/src/vim_tests.rs
@@ -1,0 +1,305 @@
+use super::*;
+
+fn type_chars(fsa: &mut VimFSA, chars: &str) -> Vec<VimEvent> {
+    chars
+        .chars()
+        .filter_map(|c| fsa.typed_character(c))
+        .collect()
+}
+
+fn enter_normal_mode() -> VimFSA {
+    let mut fsa = VimFSA::new();
+    fsa.mode = VimMode::Normal;
+    fsa
+}
+
+fn enter_visual_mode(motion_type: MotionType) -> VimFSA {
+    let mut fsa = enter_normal_mode();
+    fsa.mode = VimMode::Visual(motion_type);
+    fsa
+}
+
+fn assert_navigate_jump_to_line(event: &VimEvent, expected_line: u32) {
+    match &event.event_type {
+        VimEventType::Navigate(VimMotion::JumpToLine(line)) => {
+            assert_eq!(*line, expected_line, "expected JumpToLine({expected_line})");
+        }
+        other => panic!("expected Navigate(JumpToLine({expected_line})), got {other:?}"),
+    }
+}
+
+fn assert_navigate_jump_to_first_line(event: &VimEvent) {
+    match &event.event_type {
+        VimEventType::Navigate(VimMotion::JumpToFirstLine) => {}
+        other => panic!("expected Navigate(JumpToFirstLine), got {other:?}"),
+    }
+}
+
+fn assert_navigate_jump_to_last_line(event: &VimEvent) {
+    match &event.event_type {
+        VimEventType::Navigate(VimMotion::JumpToLastLine) => {}
+        other => panic!("expected Navigate(JumpToLastLine), got {other:?}"),
+    }
+}
+
+fn assert_operation_motion(
+    event: &VimEvent,
+    expected_operator: VimOperator,
+    expected_motion: &VimMotion,
+    expected_motion_type: MotionType,
+) {
+    match &event.event_type {
+        VimEventType::Operation {
+            operator,
+            operand: VimOperand::Motion { motion, motion_type },
+            register_name: _,
+            replacement_text: _,
+        } => {
+            assert_eq!(*operator, expected_operator, "operator mismatch");
+            assert_eq!(*motion_type, expected_motion_type, "motion_type mismatch");
+            match (motion, expected_motion) {
+                (VimMotion::JumpToLine(actual), VimMotion::JumpToLine(expected)) => {
+                    assert_eq!(*actual, *expected, "line number mismatch");
+                }
+                (VimMotion::JumpToFirstLine, VimMotion::JumpToFirstLine) => {}
+                (VimMotion::JumpToLastLine, VimMotion::JumpToLastLine) => {}
+                _ => {
+                    assert_eq!(
+                        std::mem::discriminant(motion),
+                        std::mem::discriminant(expected_motion),
+                        "motion variant mismatch: expected {expected_motion:?}, got {motion:?}"
+                    );
+                }
+            }
+        }
+        other => panic!("expected Operation with Motion, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_normal_mode_gg_jumps_to_first_line() {
+    let mut fsa = enter_normal_mode();
+    let events = type_chars(&mut fsa, "gg");
+    assert_eq!(events.len(), 1, "gg should produce exactly one event");
+    assert_navigate_jump_to_first_line(&events[0]);
+    assert_eq!(fsa.mode, VimMode::Normal);
+}
+
+#[test]
+fn test_normal_mode_counted_gg_jumps_to_specific_line() {
+    let mut fsa = enter_normal_mode();
+    let events = type_chars(&mut fsa, "5gg");
+    assert_eq!(events.len(), 1, "5gg should produce exactly one event");
+    assert_navigate_jump_to_line(&events[0], 5);
+    assert_eq!(fsa.mode, VimMode::Normal);
+}
+
+#[test]
+fn test_normal_mode_counted_gg_two_digits() {
+    let mut fsa = enter_normal_mode();
+    let events = type_chars(&mut fsa, "42gg");
+    assert_eq!(events.len(), 1, "42gg should produce exactly one event");
+    assert_navigate_jump_to_line(&events[0], 42);
+    assert_eq!(fsa.mode, VimMode::Normal);
+}
+
+#[test]
+fn test_normal_mode_G_jumps_to_last_line() {
+    let mut fsa = enter_normal_mode();
+    let events = type_chars(&mut fsa, "G");
+    assert_eq!(events.len(), 1, "G should produce exactly one event");
+    assert_navigate_jump_to_last_line(&events[0]);
+    assert_eq!(fsa.mode, VimMode::Normal);
+}
+
+#[test]
+fn test_normal_mode_counted_G_jumps_to_specific_line() {
+    let mut fsa = enter_normal_mode();
+    let events = type_chars(&mut fsa, "3G");
+    assert_eq!(events.len(), 1, "3G should produce exactly one event");
+    assert_navigate_jump_to_line(&events[0], 3);
+    assert_eq!(fsa.mode, VimMode::Normal);
+}
+
+#[test]
+fn test_operator_pending_dgg_deletes_to_first_line() {
+    let mut fsa = enter_normal_mode();
+    let events = type_chars(&mut fsa, "dgg");
+    assert_eq!(events.len(), 1, "dgg should produce exactly one event");
+    assert_operation_motion(
+        &events[0],
+        VimOperator::Delete,
+        &VimMotion::JumpToFirstLine,
+        MotionType::Linewise,
+    );
+    assert_eq!(fsa.mode, VimMode::Normal);
+}
+
+#[test]
+fn test_operator_pending_d5gg_deletes_to_specific_line() {
+    let mut fsa = enter_normal_mode();
+    let events = type_chars(&mut fsa, "d5gg");
+    assert_eq!(events.len(), 1, "d5gg should produce exactly one event");
+    assert_operation_motion(
+        &events[0],
+        VimOperator::Delete,
+        &VimMotion::JumpToLine(5),
+        MotionType::Linewise,
+    );
+    assert_eq!(fsa.mode, VimMode::Normal);
+}
+
+#[test]
+fn test_operator_pending_cgg_changes_to_first_line() {
+    let mut fsa = enter_normal_mode();
+    let events = type_chars(&mut fsa, "cgg");
+    assert_eq!(events.len(), 1, "cgg should produce exactly one event");
+    assert_operation_motion(
+        &events[0],
+        VimOperator::Change,
+        &VimMotion::JumpToFirstLine,
+        MotionType::Linewise,
+    );
+    assert_eq!(fsa.mode, VimMode::Insert);
+}
+
+#[test]
+fn test_operator_pending_c3gg_changes_to_specific_line() {
+    let mut fsa = enter_normal_mode();
+    let events = type_chars(&mut fsa, "c3gg");
+    assert_eq!(events.len(), 1, "c3gg should produce exactly one event");
+    assert_operation_motion(
+        &events[0],
+        VimOperator::Change,
+        &VimMotion::JumpToLine(3),
+        MotionType::Linewise,
+    );
+    assert_eq!(fsa.mode, VimMode::Insert);
+}
+
+#[test]
+fn test_operator_pending_ygg_yanks_to_first_line() {
+    let mut fsa = enter_normal_mode();
+    let events = type_chars(&mut fsa, "ygg");
+    assert_eq!(events.len(), 1, "ygg should produce exactly one event");
+    assert_operation_motion(
+        &events[0],
+        VimOperator::Yank,
+        &VimMotion::JumpToFirstLine,
+        MotionType::Linewise,
+    );
+    assert_eq!(fsa.mode, VimMode::Normal);
+}
+
+#[test]
+fn test_operator_pending_y7gg_yanks_to_specific_line() {
+    let mut fsa = enter_normal_mode();
+    let events = type_chars(&mut fsa, "y7gg");
+    assert_eq!(events.len(), 1, "y7gg should produce exactly one event");
+    assert_operation_motion(
+        &events[0],
+        VimOperator::Yank,
+        &VimMotion::JumpToLine(7),
+        MotionType::Linewise,
+    );
+    assert_eq!(fsa.mode, VimMode::Normal);
+}
+
+#[test]
+fn test_operator_pending_dG_deletes_to_last_line() {
+    let mut fsa = enter_normal_mode();
+    let events = type_chars(&mut fsa, "dG");
+    assert_eq!(events.len(), 1, "dG should produce exactly one event");
+    assert_operation_motion(
+        &events[0],
+        VimOperator::Delete,
+        &VimMotion::JumpToLastLine,
+        MotionType::Linewise,
+    );
+    assert_eq!(fsa.mode, VimMode::Normal);
+}
+
+#[test]
+fn test_operator_pending_d4G_deletes_to_specific_line() {
+    let mut fsa = enter_normal_mode();
+    let events = type_chars(&mut fsa, "d4G");
+    assert_eq!(events.len(), 1, "d4G should produce exactly one event");
+    assert_operation_motion(
+        &events[0],
+        VimOperator::Delete,
+        &VimMotion::JumpToLine(4),
+        MotionType::Linewise,
+    );
+    assert_eq!(fsa.mode, VimMode::Normal);
+}
+
+#[test]
+fn test_visual_linewise_mode_gg_selects_to_first_line() {
+    let mut fsa = enter_visual_mode(MotionType::Linewise);
+    let events = type_chars(&mut fsa, "gg");
+    assert_eq!(events.len(), 1, "gg in visual linewise should produce exactly one event");
+    assert_navigate_jump_to_first_line(&events[0]);
+}
+
+#[test]
+fn test_visual_linewise_mode_5gg_selects_to_specific_line() {
+    let mut fsa = enter_visual_mode(MotionType::Linewise);
+    let events = type_chars(&mut fsa, "5gg");
+    assert_eq!(events.len(), 1, "5gg in visual linewise should produce exactly one event");
+    assert_navigate_jump_to_line(&events[0], 5);
+}
+
+#[test]
+fn test_visual_charwise_mode_gg_selects_to_first_line() {
+    let mut fsa = enter_visual_mode(MotionType::Charwise);
+    let events = type_chars(&mut fsa, "gg");
+    assert_eq!(events.len(), 1, "gg in visual charwise should produce exactly one event");
+    assert_navigate_jump_to_first_line(&events[0]);
+}
+
+#[test]
+fn test_visual_charwise_mode_10gg_selects_to_specific_line() {
+    let mut fsa = enter_visual_mode(MotionType::Charwise);
+    let events = type_chars(&mut fsa, "10gg");
+    assert_eq!(events.len(), 1, "10gg in visual charwise should produce exactly one event");
+    assert_navigate_jump_to_line(&events[0], 10);
+}
+
+#[test]
+fn test_visual_linewise_mode_G_selects_to_last_line() {
+    let mut fsa = enter_visual_mode(MotionType::Linewise);
+    let events = type_chars(&mut fsa, "G");
+    assert_eq!(events.len(), 1, "G in visual linewise should produce exactly one event");
+    assert_navigate_jump_to_last_line(&events[0]);
+}
+
+#[test]
+fn test_visual_linewise_mode_3G_selects_to_specific_line() {
+    let mut fsa = enter_visual_mode(MotionType::Linewise);
+    let events = type_chars(&mut fsa, "3G");
+    assert_eq!(events.len(), 1, "3G in visual linewise should produce exactly one event");
+    assert_navigate_jump_to_line(&events[0], 3);
+}
+
+#[test]
+fn test_normal_mode_1gg_jumps_to_line_1() {
+    let mut fsa = enter_normal_mode();
+    let events = type_chars(&mut fsa, "1gg");
+    assert_eq!(events.len(), 1, "1gg should produce exactly one event");
+    assert_navigate_jump_to_line(&events[0], 1);
+    assert_eq!(fsa.mode, VimMode::Normal);
+}
+
+#[test]
+fn test_operator_pending_d1gg_deletes_to_line_1() {
+    let mut fsa = enter_normal_mode();
+    let events = type_chars(&mut fsa, "d1gg");
+    assert_eq!(events.len(), 1, "d1gg should produce exactly one event");
+    assert_operation_motion(
+        &events[0],
+        VimOperator::Delete,
+        &VimMotion::JumpToLine(1),
+        MotionType::Linewise,
+    );
+    assert_eq!(fsa.mode, VimMode::Normal);
+}

--- a/crates/vim/src/vim_tests.rs
+++ b/crates/vim/src/vim_tests.rs
@@ -51,7 +51,11 @@ fn assert_operation_motion(
     match &event.event_type {
         VimEventType::Operation {
             operator,
-            operand: VimOperand::Motion { motion, motion_type },
+            operand:
+                VimOperand::Motion {
+                    motion,
+                    motion_type,
+                },
             register_name: _,
             replacement_text: _,
         } => {
@@ -237,7 +241,11 @@ fn test_operator_pending_d4G_deletes_to_specific_line() {
 fn test_visual_linewise_mode_gg_selects_to_first_line() {
     let mut fsa = enter_visual_mode(MotionType::Linewise);
     let events = type_chars(&mut fsa, "gg");
-    assert_eq!(events.len(), 1, "gg in visual linewise should produce exactly one event");
+    assert_eq!(
+        events.len(),
+        1,
+        "gg in visual linewise should produce exactly one event"
+    );
     assert_navigate_jump_to_first_line(&events[0]);
 }
 
@@ -245,7 +253,11 @@ fn test_visual_linewise_mode_gg_selects_to_first_line() {
 fn test_visual_linewise_mode_5gg_selects_to_specific_line() {
     let mut fsa = enter_visual_mode(MotionType::Linewise);
     let events = type_chars(&mut fsa, "5gg");
-    assert_eq!(events.len(), 1, "5gg in visual linewise should produce exactly one event");
+    assert_eq!(
+        events.len(),
+        1,
+        "5gg in visual linewise should produce exactly one event"
+    );
     assert_navigate_jump_to_line(&events[0], 5);
 }
 
@@ -253,7 +265,11 @@ fn test_visual_linewise_mode_5gg_selects_to_specific_line() {
 fn test_visual_charwise_mode_gg_selects_to_first_line() {
     let mut fsa = enter_visual_mode(MotionType::Charwise);
     let events = type_chars(&mut fsa, "gg");
-    assert_eq!(events.len(), 1, "gg in visual charwise should produce exactly one event");
+    assert_eq!(
+        events.len(),
+        1,
+        "gg in visual charwise should produce exactly one event"
+    );
     assert_navigate_jump_to_first_line(&events[0]);
 }
 
@@ -261,7 +277,11 @@ fn test_visual_charwise_mode_gg_selects_to_first_line() {
 fn test_visual_charwise_mode_10gg_selects_to_specific_line() {
     let mut fsa = enter_visual_mode(MotionType::Charwise);
     let events = type_chars(&mut fsa, "10gg");
-    assert_eq!(events.len(), 1, "10gg in visual charwise should produce exactly one event");
+    assert_eq!(
+        events.len(),
+        1,
+        "10gg in visual charwise should produce exactly one event"
+    );
     assert_navigate_jump_to_line(&events[0], 10);
 }
 
@@ -269,7 +289,11 @@ fn test_visual_charwise_mode_10gg_selects_to_specific_line() {
 fn test_visual_linewise_mode_G_selects_to_last_line() {
     let mut fsa = enter_visual_mode(MotionType::Linewise);
     let events = type_chars(&mut fsa, "G");
-    assert_eq!(events.len(), 1, "G in visual linewise should produce exactly one event");
+    assert_eq!(
+        events.len(),
+        1,
+        "G in visual linewise should produce exactly one event"
+    );
     assert_navigate_jump_to_last_line(&events[0]);
 }
 
@@ -277,7 +301,11 @@ fn test_visual_linewise_mode_G_selects_to_last_line() {
 fn test_visual_linewise_mode_3G_selects_to_specific_line() {
     let mut fsa = enter_visual_mode(MotionType::Linewise);
     let events = type_chars(&mut fsa, "3G");
-    assert_eq!(events.len(), 1, "3G in visual linewise should produce exactly one event");
+    assert_eq!(
+        events.len(),
+        1,
+        "3G in visual linewise should produce exactly one event"
+    );
     assert_navigate_jump_to_line(&events[0], 3);
 }
 


### PR DESCRIPTION
## Summary

Fixes #13132

In Vim, `Ngg` is equivalent to `NG` — both jump to line N. Previously, the `gg` motion always jumped to line 1 regardless of any preceding count, so:

- `5gg` jumped to line 1 instead of line 5
- `d5gg` deleted up to line 1 instead of line 5
- `v5gg` selected up to line 1 instead of line 5

## Root Cause

In `crates/vim/src/vim.rs`, the `gg` key mapping (second 'g' after a pending G prefix) unconditionally returned `VimMotion::JumpToFirstLine` without checking for a pending count, unlike `G` which correctly uses `get_action_count()` / `get_operand_count()` to decide between `JumpToLine(n)` and `JumpToLastLine`.

## Fix

Added a count check before falling back to `JumpToFirstLine`, matching the existing pattern used for `G`. The fix applies to all three modes where `gg` can appear:

1. **Normal mode** (`handle_normal_pending_action`): uses `get_action_count()`
2. **Operator-pending mode** (`handle_normal_pending_operand`): uses `get_operand_count()` (fixes `d5gg`, `y5gg`, etc.)
3. **Visual mode** (`handle_visual_pending_action`): uses `get_action_count()` (fixes `v5gg`, `V5gg`)

A bare `gg` with no count still jumps to the first line as expected.