### PR TITLE
Prevent system sleep while a terminal command is running

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -168,6 +168,7 @@ persistence.workspace = true
 pin-project.workspace = true
 plist = "1"
 pprof = { workspace = true, optional = true, features = ["protobuf-codec"] }
+prevent_sleep.workspace = true
 prost.workspace = true
 prost-types.workspace = true
 qrcode.workspace = true

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -520,6 +520,14 @@ pub struct TerminalModel {
     /// bootstrap init scripts. Used to validate DCS hook integrity: hooks
     /// carrying an unrecognized session_id are rejected.
     registered_session_ids: HashSet<SessionId>,
+
+    /// Held while a foreground command is executing in this terminal. Acquired in
+    /// `start_command_execution` and dropped in `command_finished`, which keeps the
+    /// system awake for the lifetime of every command without needing a long-running
+    /// threshold (short commands acquire and release within milliseconds and never
+    /// block sleep in practice). Mirrors the Agent Mode pattern in
+    /// `warp_multi_agent_client`. See issue #9056.
+    running_command_sleep_guard: Option<prevent_sleep::Guard>,
 }
 
 #[derive(Clone, Debug)]
@@ -1089,6 +1097,7 @@ impl TerminalModel {
             // Start mid-way through the u32 range to avoid collisions
             next_kitty_image_id: 2147483647,
             registered_session_ids: HashSet::new(),
+            running_command_sleep_guard: None,
         }
     }
 
@@ -1638,6 +1647,10 @@ impl TerminalModel {
     /// the user's behalf, we consider the active block started.
     pub fn start_command_execution(&mut self) {
         self.block_list.start_active_block();
+        // Keep the system awake for the duration of the command. Replaces any
+        // previous guard (start without a matching finish would otherwise stack).
+        self.running_command_sleep_guard =
+            Some(prevent_sleep::prevent_sleep("Terminal command in-progress"));
     }
 
     pub fn start_command_execution_from_env_var_collection(
@@ -2694,6 +2707,12 @@ impl ansi::Handler for TerminalModel {
     }
 
     fn command_finished(&mut self, data: CommandFinishedValue) {
+        // Release the sleep guard acquired in `start_command_execution`. Done
+        // before the rest of the handler so the system is free to idle as soon
+        // as the command is observed finished, even if downstream work below
+        // takes a moment.
+        self.running_command_sleep_guard = None;
+
         // If we ssh from a doesn't-understand-bracketed-paste shell into one
         // that enables it, then get disconnected, we'll be stuck in a state
         // of bracketed paste being enabled, but the local shell doesn't know

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -522,11 +522,11 @@ pub struct TerminalModel {
     registered_session_ids: HashSet<SessionId>,
 
     /// Held while a foreground command is executing in this terminal. Acquired in
-    /// `start_command_execution` and dropped in `command_finished`, which keeps the
-    /// system awake for the lifetime of every command without needing a long-running
-    /// threshold (short commands acquire and release within milliseconds and never
-    /// block sleep in practice). Mirrors the Agent Mode pattern in
-    /// `warp_multi_agent_client`. See issue #9056.
+    /// `on_command_started` (called from the PTY controller on real command writes only,
+    /// not from EOT / non-command writes) and dropped in the `command_finished` ANSI
+    /// handler. Short commands acquire and release within milliseconds and never block
+    /// sleep in practice; long-running commands hold for their full lifetime. Mirrors
+    /// the Agent Mode pattern in `warp_multi_agent_client`. See issue #9056.
     running_command_sleep_guard: Option<prevent_sleep::Guard>,
 }
 
@@ -1647,8 +1647,16 @@ impl TerminalModel {
     /// the user's behalf, we consider the active block started.
     pub fn start_command_execution(&mut self) {
         self.block_list.start_active_block();
-        // Keep the system awake for the duration of the command. Replaces any
-        // previous guard (start without a matching finish would otherwise stack).
+    }
+
+    /// Called by the PTY controller after a real command write (User / AI / SharedSession /
+    /// EnvVarCollection) — distinct from `start_command_execution`, which is also fired by
+    /// non-command writes like EOT and which therefore can't be trusted to be paired with a
+    /// matching `command_finished`. Holds a `PreventUserIdleSystemSleep` assertion for the
+    /// duration of the command. RAII (Drop) releases it when `command_finished` clears the
+    /// field. Replaces any prior guard so a missed finish doesn't permanently stack assertions.
+    /// See issue #9056.
+    pub fn on_command_started(&mut self) {
         self.running_command_sleep_guard =
             Some(prevent_sleep::prevent_sleep("Terminal command in-progress"));
     }

--- a/app/src/terminal/model/terminal_model_tests.rs
+++ b/app/src/terminal/model/terminal_model_tests.rs
@@ -1194,3 +1194,50 @@ fn cloud_mode_setup_phase_ended_does_not_emit_when_not_sharing() {
     let events: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
     assert!(events.is_empty());
 }
+
+// Regression coverage for issue #9056: the terminal must keep the system awake while
+// a foreground command is running, and release the assertion as soon as the shell
+// reports the command finished.
+#[test]
+fn prevent_sleep_guard_is_acquired_on_start_and_released_on_finish() {
+    let mut terminal: TerminalModel = TerminalModel::mock(None, None);
+    // `mock`/`new_for_test` calls `command_finished` to land in a quiescent state,
+    // so the guard should be clear before we begin.
+    assert!(terminal.running_command_sleep_guard.is_none());
+
+    terminal.start_command_execution();
+    assert!(
+        terminal.running_command_sleep_guard.is_some(),
+        "start_command_execution must take a sleep-prevention assertion"
+    );
+
+    terminal.command_finished(CommandFinishedValue {
+        exit_code: ExitCode::from(0),
+        next_block_id: BlockId::new(),
+        session_id: None,
+    });
+    assert!(
+        terminal.running_command_sleep_guard.is_none(),
+        "command_finished must release the sleep-prevention assertion"
+    );
+}
+
+#[test]
+fn prevent_sleep_guard_is_reset_when_start_called_twice() {
+    // Defensive: if the shell ever signals start without an intervening finish, the
+    // previous guard is replaced rather than leaked. Drop runs on the replaced value.
+    let mut terminal: TerminalModel = TerminalModel::mock(None, None);
+
+    terminal.start_command_execution();
+    assert!(terminal.running_command_sleep_guard.is_some());
+
+    terminal.start_command_execution();
+    assert!(terminal.running_command_sleep_guard.is_some());
+
+    terminal.command_finished(CommandFinishedValue {
+        exit_code: ExitCode::from(0),
+        next_block_id: BlockId::new(),
+        session_id: None,
+    });
+    assert!(terminal.running_command_sleep_guard.is_none());
+}

--- a/app/src/terminal/model/terminal_model_tests.rs
+++ b/app/src/terminal/model/terminal_model_tests.rs
@@ -1199,16 +1199,16 @@ fn cloud_mode_setup_phase_ended_does_not_emit_when_not_sharing() {
 // a foreground command is running, and release the assertion as soon as the shell
 // reports the command finished.
 #[test]
-fn prevent_sleep_guard_is_acquired_on_start_and_released_on_finish() {
+fn prevent_sleep_guard_is_acquired_on_command_started_and_released_on_finish() {
     let mut terminal: TerminalModel = TerminalModel::mock(None, None);
     // `mock`/`new_for_test` calls `command_finished` to land in a quiescent state,
     // so the guard should be clear before we begin.
     assert!(terminal.running_command_sleep_guard.is_none());
 
-    terminal.start_command_execution();
+    terminal.on_command_started();
     assert!(
         terminal.running_command_sleep_guard.is_some(),
-        "start_command_execution must take a sleep-prevention assertion"
+        "on_command_started must take a sleep-prevention assertion"
     );
 
     terminal.command_finished(CommandFinishedValue {
@@ -1223,15 +1223,15 @@ fn prevent_sleep_guard_is_acquired_on_start_and_released_on_finish() {
 }
 
 #[test]
-fn prevent_sleep_guard_is_reset_when_start_called_twice() {
-    // Defensive: if the shell ever signals start without an intervening finish, the
-    // previous guard is replaced rather than leaked. Drop runs on the replaced value.
+fn prevent_sleep_guard_is_reset_when_on_command_started_called_twice() {
+    // Defensive: if the PTY controller ever signals start without an intervening finish,
+    // the previous guard is replaced rather than leaked. Drop runs on the replaced value.
     let mut terminal: TerminalModel = TerminalModel::mock(None, None);
 
-    terminal.start_command_execution();
+    terminal.on_command_started();
     assert!(terminal.running_command_sleep_guard.is_some());
 
-    terminal.start_command_execution();
+    terminal.on_command_started();
     assert!(terminal.running_command_sleep_guard.is_some());
 
     terminal.command_finished(CommandFinishedValue {
@@ -1240,4 +1240,20 @@ fn prevent_sleep_guard_is_reset_when_start_called_twice() {
         session_id: None,
     });
     assert!(terminal.running_command_sleep_guard.is_none());
+}
+
+#[test]
+fn prevent_sleep_guard_not_acquired_by_start_command_execution_alone() {
+    // EOT (Ctrl-D) and other non-command writes call `start_command_execution` to mark the
+    // active block as started, but no matching `command_finished` follows. The sleep guard
+    // must therefore NOT be acquired by that path — only by `on_command_started`, which the
+    // PTY controller calls only on real command writes. See PR review on issue #9056.
+    let mut terminal: TerminalModel = TerminalModel::mock(None, None);
+    assert!(terminal.running_command_sleep_guard.is_none());
+
+    terminal.start_command_execution();
+    assert!(
+        terminal.running_command_sleep_guard.is_none(),
+        "start_command_execution alone must not take a sleep-prevention assertion"
+    );
 }

--- a/app/src/terminal/writeable_pty/pty_controller.rs
+++ b/app/src/terminal/writeable_pty/pty_controller.rs
@@ -536,6 +536,12 @@ impl<T: EventLoopSender> PtyController<T> {
                 }
             }
 
+            // Hold a sleep-prevention assertion for the duration of the command. Distinct from
+            // `start_command_execution` because that path is also reachable from non-command
+            // writes (e.g. EOT in `write_end_of_transmission_char`) that have no matching
+            // `command_finished` — see issue #9056.
+            model.on_command_started();
+
             // Ensure that the `TerminalModel` doesn't interpret any of the PTY output from the
             // following commands as in-band command output. If the in-band command output is not
             // currently being received by the `TerminalModel`, this is a no-op.


### PR DESCRIPTION
## Description

The terminal would let macOS idle into sleep mid-command (e.g. `aws configure sso`, a long build, anything that left the user away from the keyboard) because nothing in the terminal lifecycle was holding the user-initiated activity assertion. Agent Mode already does this via `prevent_sleep::prevent_sleep("Agent Mode request in-progress")` in `warp_multi_agent_client`, so the pattern is established.

`TerminalModel` now holds an `Option<prevent_sleep::Guard>` acquired in `start_command_execution` and dropped in the `command_finished` ANSI handler. RAII releases the assertion on drop, so short commands acquire and release within milliseconds without blocking sleep in practice; long-running commands hold the assertion for their full lifetime. The `Guard` type is `Send + Sync`, and on non-mac/non-windows targets it no-ops via the existing `crates/prevent_sleep/src/noop.rs` impl.

Fixes #9056.

## Testing

Added two unit tests in `app/src/terminal/model/terminal_model_tests.rs`:

- `prevent_sleep_guard_is_acquired_on_start_and_released_on_finish` covers the happy-path state transition: clear at construction, `Some` after `start_command_execution`, back to `None` after `command_finished`.
- `prevent_sleep_guard_is_reset_when_start_called_twice` covers a defensive case where the shell ever signals start without an intervening finish: the previous guard is replaced (not leaked), and a single `command_finished` drops the active one.

`cargo fmt`, `cargo clippy -p warp --tests --all-targets -- -D warnings`, and `cargo nextest run -p warp 'terminal::model::terminal_model_tests::prevent_sleep'` all pass cleanly.

Manually verified on macOS: started `sleep 600` in the patched dev build, then from a separate shell:

```
$ pmset -g assertions | grep -c "Terminal command in-progress"
1

$ pmset -g assertions | grep -B 1 -A 2 "Terminal command in-progress"
Listed by owning process:
   pid 88270(warp-oss): [0x00082252000197b7] 00:01:14 PreventUserIdleSystemSleep named: "Terminal command in-progress"
```

Confirms the correct assertion type (`PreventUserIdleSystemSleep`, exactly what the issue title names) is held by the `warp-oss` process for the lifetime of the command. Once the command finishes, the count drops back to 0.

## Agent Mode

- [ ] Warp Agent Mode — This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: The terminal now keeps macOS awake while a foreground command is running, so long jobs like \`aws configure sso\` or slow builds no longer idle the system to sleep mid-execution.