### PR TITLE
Insert /handoff into input buffer instead of executing on selection (REMOTE-2029)

### DIFF
--- a/app/src/search/slash_command_menu/static_commands/commands.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands.rs
@@ -191,11 +191,10 @@ pub static MOVE_TO_CLOUD: LazyLock<StaticCommand> = LazyLock::new(|| StaticComma
         | Availability::AI_ENABLED
         | Availability::NOT_CLOUD_AGENT,
     auto_enter_ai_mode: false,
-    argument: Some(
-        Argument::optional()
-            .with_hint_text("<optional follow-up prompt>")
-            .with_execute_on_selection(),
-    ),
+    // No `with_execute_on_selection`: selecting `/handoff` from the menu should insert
+    // `/handoff ` into the input buffer (like `/fork`) so the user can append an optional
+    // follow-up prompt before executing, rather than firing the handoff immediately.
+    argument: Some(Argument::optional().with_hint_text("<optional follow-up prompt>")),
 });
 
 pub const OPEN_CODE_REVIEW: StaticCommand = StaticCommand {

--- a/app/src/search/slash_command_menu/static_commands/commands_tests.rs
+++ b/app/src/search/slash_command_menu/static_commands/commands_tests.rs
@@ -102,6 +102,23 @@ fn set_tab_color_command_requires_argument() {
 }
 
 #[test]
+fn handoff_command_inserts_into_buffer_on_selection() {
+    // `/handoff` must NOT execute on selection: selecting it from the slash menu should
+    // insert `/handoff ` into the input buffer so the user can append an optional follow-up
+    // prompt before executing (matching how other argument-taking commands like `/fork`
+    // behave). See REMOTE-2029.
+    let argument = MOVE_TO_CLOUD
+        .argument
+        .as_ref()
+        .expect("expected /handoff to declare an argument");
+
+    assert_eq!(MOVE_TO_CLOUD.name, "/handoff");
+    assert!(argument.is_optional);
+    assert!(!argument.should_execute_on_selection);
+    assert_eq!(argument.hint_text, Some("<optional follow-up prompt>"));
+}
+
+#[test]
 fn strip_command_prefix_matches_orchestrate() {
     let result = strip_command_prefix("/orchestrate deploy services", "/orchestrate");
     assert_eq!(result, Some("deploy services".to_string()));


### PR DESCRIPTION
## Description
The `/handoff` slash command was defined with `with_execute_on_selection()`, so typing `/handoff` and pressing Enter (selecting it from the slash-command picker) immediately initiated the cloud handoff flow instead of inserting `/handoff ` into the input buffer. This was inconsistent with other argument-taking slash commands (e.g. `/fork`) and prevented users from appending an optional follow-up prompt before executing.

This PR removes `with_execute_on_selection()` from the `MOVE_TO_CLOUD` command definition (`app/src/search/slash_command_menu/static_commands/commands.rs`). Now selecting `/handoff` from the menu inserts `/handoff ` into the buffer. Pressing Enter again executes via the normal submission path (`maybe_handle_enter_for_slash_command` → `execute_slash_command`), which already handles both:
- `/handoff <prompt>` — auto-submits the handoff with the prompt, and
- empty `/handoff` — dispatches the empty-prompt handoff (continue / snapshot rehydration), or surfaces a toast when there's nothing to hand off.

The fix is purely client-side; the `POST /agent/runs` endpoint already accepts an optional `prompt`, so no API changes are needed.

Root cause was introduced in #9455 and carried over when the command was renamed from `/move-to-cloud` to `/handoff` in #10271.

## Linked Issue
Linear: REMOTE-2029 — `/handoff` slash command executes immediately on Enter instead of inserting into the input buffer.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- Added a regression unit test `handoff_command_inserts_into_buffer_on_selection` in `commands_tests.rs` asserting that `/handoff` declares an optional argument and does **not** execute on selection.
- `cargo check -p warp --lib --tests` passes.
- `cargo clippy -p warp --lib --tests -- -D warnings` passes.
- `cargo fmt` check passes on the changed files.
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A — no visual change; this only changes Enter behavior in the slash-command picker for `/handoff`.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable
-->
CHANGELOG-BUG-FIX: Selecting `/handoff` from the slash-command menu now inserts `/handoff ` into the input buffer (so you can add an optional follow-up prompt) instead of immediately starting the cloud handoff.

_Conversation: https://staging.warp.dev/conversation/7d91bd2d-b125-4665-8500-56e272c1ff9a_
_Run: https://oz.staging.warp.dev/runs/019f137a-dbc2-71c0-b08a-547b9ba94ab3_

_This PR was generated with [Oz](https://warp.dev/oz)._
