### PR TITLE
Downgrade cross-window tab drag to preview

### DIFF
--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -973,6 +973,8 @@ pub const PREVIEW_FLAGS: &[FeatureFlag] = &[
     #[cfg(target_os = "macos")]
     FeatureFlag::GroupedTabs,
     FeatureFlag::AsyncFind,
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    FeatureFlag::DragTabsToWindows,
 ];
 
 /// Features enabled for all release builds (i.e.: everything but WarpLocal).
@@ -988,8 +990,6 @@ pub const RELEASE_FLAGS: &[FeatureFlag] = &[
     // Remote server binary is not yet supported on Windows.
     #[cfg(not(windows))]
     FeatureFlag::SshRemoteServer,
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    FeatureFlag::DragTabsToWindows,
 ];
 
 /// Flags that we want to allow to switch at runtime (assuming RuntimeFeatureFlags is set)


### PR DESCRIPTION
This is causing issues in Sentry, the safe option is to revert and fix in this week's release

Slack: https://warpdev.slack.com/archives/C04Q810825D/p1782708667557779

Sentry: https://warpdotdev.sentry.io/issues/7553556464/?project=5658526&query=release%3A%22v0.2026.06.24.09.19.stable_02%22&referrer=release-issue-stream