### PR TITLE
Render a proper error state for web search/fetch inline actions

### DIFF
--- a/app/src/ai/blocklist/inline_action/search_codebase.rs
+++ b/app/src/ai/blocklist/inline_action/search_codebase.rs
@@ -324,7 +324,7 @@ impl SearchCodebaseView {
         icon: warpui::elements::Icon,
         app: &AppContext,
     ) -> Box<dyn Element> {
-        super::search_results_common::render_loading_header(text, icon, app)
+        super::search_results_common::render_status_header(text, icon, app)
     }
 
     pub fn clear_link_tooltip(&mut self, ctx: &mut ViewContext<Self>) {

--- a/app/src/ai/blocklist/inline_action/search_results_common.rs
+++ b/app/src/ai/blocklist/inline_action/search_results_common.rs
@@ -113,10 +113,8 @@ pub fn render_results_body_container(body: Box<dyn Element>, app: &AppContext) -
         .finish()
 }
 
-/// Renders a non-collapsible single-line header (status icon + title) used to
-/// represent a transient or terminal status — e.g. loading, cancelled, or error.
-/// The icon conveys the status; pass the appropriate one (e.g. `yellow_running_icon`,
-/// `cancelled_icon`, `failed_icon`).
+/// Renders a single-line status header (icon + title) for a loading, cancelled, or
+/// error state; the caller-supplied icon conveys the status.
 pub fn render_status_header(
     text: String,
     icon: warpui::elements::Icon,

--- a/app/src/ai/blocklist/inline_action/search_results_common.rs
+++ b/app/src/ai/blocklist/inline_action/search_results_common.rs
@@ -113,7 +113,11 @@ pub fn render_results_body_container(body: Box<dyn Element>, app: &AppContext) -
         .finish()
 }
 
-pub fn render_loading_header(
+/// Renders a non-collapsible single-line header (status icon + title) used to
+/// represent a transient or terminal status — e.g. loading, cancelled, or error.
+/// The icon conveys the status; pass the appropriate one (e.g. `yellow_running_icon`,
+/// `cancelled_icon`, `failed_icon`).
+pub fn render_status_header(
     text: String,
     icon: warpui::elements::Icon,
     app: &AppContext,

--- a/app/src/ai/blocklist/inline_action/web_fetch.rs
+++ b/app/src/ai/blocklist/inline_action/web_fetch.rs
@@ -5,7 +5,7 @@ use warpui::{AppContext, Entity, SingletonEntity, TypedActionView, View, ViewCon
 use super::search_results_common::{
     render_collapsible_search_results, CollapsibleSearchResultsState,
 };
-use crate::ai::agent::icons::yellow_running_icon;
+use crate::ai::agent::icons::{failed_icon, yellow_running_icon};
 use crate::ai::agent::WebFetchStatus;
 use crate::ai::blocklist::block::view_impl::WithContentItemSpacing;
 
@@ -39,7 +39,7 @@ impl WebFetchView {
 
         let text = format!("Fetching {} web pages...", urls.len());
 
-        super::search_results_common::render_loading_header(text, loading_icon, app)
+        super::search_results_common::render_status_header(text, loading_icon, app)
     }
 
     fn render_success(
@@ -169,10 +169,14 @@ impl View for WebFetchView {
                 .with_agent_output_item_spacing(app)
                 .finish(),
             WebFetchStatus::Error => {
-                // Render as if fetch completed with no results
-                self.render_success(&[], app)
-                    .with_agent_output_item_spacing(app)
-                    .finish()
+                let appearance = Appearance::as_ref(app);
+                super::search_results_common::render_status_header(
+                    "Web page fetch failed".to_string(),
+                    failed_icon(appearance),
+                    app,
+                )
+                .with_agent_output_item_spacing(app)
+                .finish()
             }
         }
     }

--- a/app/src/ai/blocklist/inline_action/web_search.rs
+++ b/app/src/ai/blocklist/inline_action/web_search.rs
@@ -5,7 +5,7 @@ use warpui::{AppContext, Entity, SingletonEntity, TypedActionView, View, ViewCon
 use super::search_results_common::{
     render_collapsible_search_results, CollapsibleSearchResultsState,
 };
-use crate::ai::agent::icons::yellow_running_icon;
+use crate::ai::agent::icons::{failed_icon, yellow_running_icon};
 use crate::ai::agent::WebSearchStatus;
 use crate::ai::blocklist::block::view_impl::WithContentItemSpacing;
 
@@ -32,7 +32,22 @@ impl WebSearchView {
     }
 
     pub fn set_status(&mut self, status: &WebSearchStatus) {
-        self.status = status.clone();
+        // The proto error status carries no query, so preserve the query from a prior
+        // Searching/Success state to keep the failed header informative in live sessions.
+        self.status = match status {
+            WebSearchStatus::Error { query } if query.is_empty() => WebSearchStatus::Error {
+                query: self.current_query(),
+            },
+            other => other.clone(),
+        };
+    }
+
+    fn current_query(&self) -> String {
+        match &self.status {
+            WebSearchStatus::Searching { query } => query.clone().unwrap_or_default(),
+            WebSearchStatus::Success { query, .. } => query.clone(),
+            WebSearchStatus::Error { query } => query.clone(),
+        }
     }
 
     fn render_loading(&self, query: &Option<String>, app: &AppContext) -> Box<dyn Element> {
@@ -45,7 +60,7 @@ impl WebSearchView {
             "Searching the web".to_string()
         };
 
-        super::search_results_common::render_loading_header(text, loading_icon, app)
+        super::search_results_common::render_status_header(text, loading_icon, app)
     }
 
     fn render_success(
@@ -159,11 +174,19 @@ impl View for WebSearchView {
                 .with_agent_output_item_spacing(app)
                 .finish(),
             WebSearchStatus::Error { query } => {
-                // For now, render as if search completed with no results
-                // TODO(advait): Add proper error rendering
-                self.render_success(query, &[], app)
-                    .with_agent_output_item_spacing(app)
-                    .finish()
+                let appearance = Appearance::as_ref(app);
+                let text = if query.is_empty() {
+                    "Web search failed".to_string()
+                } else {
+                    format!("Web search failed for \"{query}\"")
+                };
+                super::search_results_common::render_status_header(
+                    text,
+                    failed_icon(appearance),
+                    app,
+                )
+                .with_agent_output_item_spacing(app)
+                .finish()
             }
         }
     }

--- a/app/src/ai/blocklist/inline_action/web_search.rs
+++ b/app/src/ai/blocklist/inline_action/web_search.rs
@@ -32,8 +32,7 @@ impl WebSearchView {
     }
 
     pub fn set_status(&mut self, status: &WebSearchStatus) {
-        // The proto error status carries no query, so preserve the query from a prior
-        // Searching/Success state to keep the failed header informative in live sessions.
+        // The proto error status carries no query; preserve the prior one for the header.
         self.status = match status {
             WebSearchStatus::Error { query } if query.is_empty() => WebSearchStatus::Error {
                 query: self.current_query(),


### PR DESCRIPTION
Related server PR: https://github.com/warpdotdev/warp-server/pull/12188

## Description
Renders a proper error state for the web search / web fetch inline actions.

**What:** When a web search (`exa_web_search`) or web page fetch (`fetch_web_pages`) fails, the inline action previously rendered identically to an empty success — "Searched the web / 0 URLs / No URLs found" (and "Fetched 0 web pages / No URLs fetched"). This made a genuine failure indistinguishable from a search/fetch that legitimately returned nothing (there was a `TODO(advait)` placeholder for it).

**Why:** Paired with a server-side fix (warp-server #12188) that stops leaving failed Exa tool calls dangling and instead marks the web search/fetch message as `error`. The client now needs to actually render that error state.

**How:**
- `web_search.rs` / `web_fetch.rs`: the `Error` status now renders the house failure style — the red `failed_icon` plus a single-line status header ("Web search failed" / "Web page fetch failed") instead of a fake empty-success.
- `WebSearchView::set_status` preserves the query from the prior `Searching`/`Success` state (the proto `error` variant carries no query), so a live failure can show "Web search failed for "{query}"". On history reload the query isn't available, so it falls back to the generic text.
- Renamed the shared `render_loading_header` → `render_status_header` (it now backs loading, cancelled, and error states; the icon conveys the status). Updated all call sites (`search_results_common`, `search_codebase`, `web_search`, `web_fetch`). The unrelated `AgentManagementView::render_loading_header` is left as-is.

## Testing
- `cargo fmt` and `cargo clippy -p warp --lib --features local_fs -- -D warnings` pass.
- Manually exercised by forcing the Exa failure path locally and confirming the inline action renders the error header instead of "0 URLs / No URLs found".

### Screenshots / Videos
<img width="1018" height="365" alt="image" src="https://github.com/user-attachments/assets/ab9609ca-ed7a-47db-b28b-cd7f91dcd654" />



CHANGELOG-BUG-FIX: Web search and web page fetch now show a clear failed state instead of appearing as an empty "0 results" when the search/fetch errors.

Co-Authored-By: Oz <oz-agent@warp.dev>
