### PR TITLE
Increase contrast on horizontal tab bar dividers

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -1600,9 +1600,9 @@ impl<'a> TabComponent<'a> {
             };
 
             let border = if is_active {
-                internal_colors::fg_overlay_2(theme)
+                internal_colors::fg_overlay_4(theme)
             } else {
-                internal_colors::fg_overlay_1(theme)
+                internal_colors::fg_overlay_3(theme)
             };
 
             (bg, border)

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -19770,7 +19770,7 @@ impl Workspace {
                             .with_border(
                                 Border::all(1.)
                                     .with_sides(false, false, false, true)
-                                    .with_border_fill(internal_colors::fg_overlay_1(
+                                    .with_border_fill(internal_colors::fg_overlay_3(
                                         appearance.theme(),
                                     )),
                             )
@@ -19969,7 +19969,11 @@ impl Workspace {
 
         let header_active_bg = internal_colors::fg_overlay_2(theme);
         let header_hover_bg = internal_colors::fg_overlay_1(theme);
-        let header_border_fill = internal_colors::fg_overlay_1(theme);
+        let header_border_fill = if header_selected {
+            internal_colors::fg_overlay_4(theme)
+        } else {
+            internal_colors::fg_overlay_3(theme)
+        };
         let mut header = Hoverable::new(mouse_states.header.clone(), move |state| {
             let hovered = state.is_hovered();
             // Tint the header with the group's color on hover/active (40/60), and


### PR DESCRIPTION
## Description

It can be a bit hard to tell which tabs are part of a group in the horizontal tab bar. This is because, the only differentiator between a grouped and an ungrouped tab is the divider border between them.

This PR just increases the contrast between a tab and the divider by raising the overlay color of the divider border.

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4799/increase-contrast-on-horizontal-tab-bar-dividers

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Before and After comparison video](https://www.loom.com/share/56c67614c192499ca2ced83314c0e757)

In this video I am switching between the before and after to show the difference in the htab dividers