### PR TITLE
downrank Intel(R) UHD Graphics 770 adapter on Windows

### DIFF
--- a/crates/warpui/src/rendering/wgpu/resources.rs
+++ b/crates/warpui/src/rendering/wgpu/resources.rs
@@ -499,6 +499,17 @@ fn is_intel_uhd_620_adapter_on_windows_with_vulkan_backend(
             || adapter_info.name.contains("Intel(R) HD Graphics 620"))
 }
 
+/// Returns true if this is an Intel UHD Graphics 770 integrated GPU on Windows, using either the
+/// DX12 or Vulkan backend.
+///
+/// TODO link public reports of bugs with this driver.
+fn is_intel_uhd_770_adapter_on_windows(adapter_info: &wgpu::AdapterInfo) -> bool {
+    cfg!(windows)
+        && matches!(adapter_info.backend, Backend::Dx12 | Backend::Vulkan)
+        && adapter_info.device_type == DeviceType::IntegratedGpu
+        && adapter_info.name.contains("Intel(R) UHD Graphics 770")
+}
+
 /// Returns whether the given adapter is known to have a rendering offset bug on Windows.
 ///
 /// Certain Intel integrated GPU drivers using the GL backend render the scene at an offset from
@@ -736,6 +747,11 @@ fn adapter_stability_sort_func(
 
     if is_intel_uhd_620_adapter_on_windows_with_vulkan_backend(&adapter_info) {
         log::warn!("Deprioritizing Vulkan-backed Intel UHD 620 adapter");
+        return AdapterSupport::SupportedWithIssues;
+    }
+
+    if is_intel_uhd_770_adapter_on_windows(&adapter_info) {
+        log::warn!("Deprioritizing Intel UHD 770 integrated GPU on Windows");
         return AdapterSupport::SupportedWithIssues;
     }
 


### PR DESCRIPTION
## Description

This PR downranks another known buggy driver.

## Linked Issue

Closes #4856. Note that issue kind of drifted from what OP was describing, which was on Linux. A bunch of other users responded from Windows and from the few logs we got, this was the culprit. There were 2 other issues which I marked as dups of that one that were this driver. Separately, I got an email implicating this driver. At this point the signal is pretty strong that we need to downrank it.

## Testing

I don't have the hardware to repro myself. However, the email thread I mentioned above the user has confirmed that switching to discrete GPU fixed it for them.



<!--
## Changelog Entries for Stable

CHANGELOG-BUG-FIX: [Windows] Fix lag from integrated Intel UHD Graphics 770
-->
