### PR TITLE
Fix Windows 0xC0000409 crash from CoUninitialize in a thread-local destructor

### DIFF
--- a/app/src/antivirus/windows.rs
+++ b/app/src/antivirus/windows.rs
@@ -1,3 +1,6 @@
+use std::marker::PhantomData;
+use std::rc::Rc;
+
 use warp_core::send_telemetry_from_ctx;
 use warpui::ModelContext;
 use windows::Win32::System::Com::{
@@ -11,9 +14,9 @@ use crate::antivirus::{AntivirusInfo, AntivirusInfoEvent};
 impl AntivirusInfo {
     #[cfg(windows)]
     pub(super) async fn scan() -> anyhow::Result<Option<String>> {
-        unsafe {
-            com_initialized()?;
+        let _com = ComGuard::new()?;
 
+        unsafe {
             // Read out all of the registered antivirus products.
             let pl: IWSCProductList = CoCreateInstance(&WSCProductList, None, CLSCTX_ALL)?;
             pl.Initialize(WSC_SECURITY_PROVIDER_ANTIVIRUS)?;
@@ -68,35 +71,35 @@ impl AntivirusInfo {
     }
 }
 
-/// Helper struct to properly enforce reference counting of the Windows COM library.
+/// RAII guard that initializes the Windows COM library for the current thread and uninitializes it
+/// when dropped.
 ///
 /// Per the Windows docs (https://learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-coinitializeex)
-/// each call to [`CoInitializeEx`] must be paired with a call to [`CoUninitialize`] in order for
-/// the COM library to be gracefully uninitialized.
+/// each successful call to [`CoInitializeEx`] must be paired with a call to [`CoUninitialize`] on
+/// the same thread.
 // TODO(alokedesai): Move this to a shared place in `core` so we can use it in other places in the
 // app.
-struct ComInitialized;
+struct ComGuard {
+    // Tie the guard to its creating thread so `CoUninitialize` only runs there.
+    not_send_or_sync: PhantomData<Rc<()>>,
+}
 
-impl Drop for ComInitialized {
-    fn drop(&mut self) {
-        unsafe { CoUninitialize() };
+impl ComGuard {
+    /// Initializes COM as a single-threaded apartment for the current thread.
+    fn new() -> Result<Self, windows::core::Error> {
+        // SAFETY: balanced by `CoUninitialize` in `Drop`, on the same thread.
+        unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED).ok()? };
+        Ok(Self {
+            not_send_or_sync: PhantomData,
+        })
     }
 }
 
-thread_local! {
-    static COM_INITIALIZED: Result<ComInitialized, windows::core::Error> = {
-        unsafe {
-            CoInitializeEx(None, COINIT_APARTMENTTHREADED).ok()?;
-            Ok(ComInitialized)
-        }
-    };
-}
-
-fn com_initialized() -> Result<(), windows::core::Error> {
-    COM_INITIALIZED.with(|initialized| {
-        initialized
-            .as_ref()
-            .map(|_| ())
-            .map_err(|error| error.clone())
-    })
+impl Drop for ComGuard {
+    fn drop(&mut self) {
+        // SAFETY: `new` succeeded on this thread (otherwise this guard would not exist), and this
+        // runs in the synchronous `scan` scope rather than a TLS destructor, so it is safe to
+        // balance the init here.
+        unsafe { CoUninitialize() };
+    }
 }


### PR DESCRIPTION
## Description

On Windows, Warp aborts with `0xC0000409` (`FAST_FAIL_FATAL_APP_EXIT`, subcode `0x7` — i.e. a Rust abort) shortly after launch / entering Agent Mode. Analysis of the four user-provided minidumps (#13135) shows an identical signature in every crash:

- The faulting thread is always a `background-executor-N` tokio worker.
- The aborting frame is called directly by `ntdll!LdrpCallTlsInitializers` — the Windows loader's TLS callback that runs `thread_local!` destructors at thread teardown.
- Same fault offset (`warp+0x22718a2`) across all dumps and both reported builds.

### Root cause

`app/src/antivirus/windows.rs` initialized COM in a `thread_local!` (`COM_INITIALIZED`) whose `Drop` calls `CoUninitialize()`. The antivirus `scan()` runs on a `background-executor` (tokio) worker via `ctx.spawn`, so COM is initialized on that worker and the guard is stored in the worker's TLS. When that worker / runtime is later torn down, the destructor runs `CoUninitialize()` from inside the loader's TLS callback — i.e. under the **loader lock**, in the same context as `DllMain`.

That context is what makes it unsound. `CoUninitialize()` does far more than free a handle: it releases interface proxies and **unloads the in-process COM servers** that `CoCreateInstance(WSCProductList, …)` pulled in — i.e. it re-enters the loader (`FreeLibrary` / `LdrUnloadDll`) while the TLS callback is **already holding the loader lock**, which deadlocks or runs another module's detach against partially torn-down state. Microsoft documents these hazards for `DllMain`, which runs under the loader lock exactly like a Windows TLS callback (and therefore a Rust `thread_local!` destructor): [Dynamic-Link Library Best Practices](https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-best-practices) states you "cannot call any function in `DllMain` that directly or indirectly tries to acquire the loader lock," and lists both calling `LoadLibrary`/`LoadLibraryEx` "either directly or indirectly" and "Initialize COM threads by using `CoInitializeEx`" among the things you should "never" do; the [`DllMain` reference](https://learn.microsoft.com/en-us/windows/win32/dlls/dllmain) adds that "calling … COM functions can cause access violation errors, because some functions load other system components." `CoUninitialize()` hits both: it's a COM call, and it unloads in-process servers via `FreeLibrary`.

Warp builds with the default `panic = "unwind"`, so a panic on that teardown path unwinds into the `extern "system"` TLS callback (a non-unwindable boundary) and Rust converts it to `__fastfail` → `0xC0000409`. Background runtimes are created and dropped repeatedly during a session, so the teardown path runs repeatedly, matching the "crashes every ~30s / N times" reports.

### Fix

Replace the `thread_local!` with a scoped RAII `ComGuard` created at the top of `scan()` and dropped at the end of that synchronous scope. `CoUninitialize()` now runs on the live worker thread, immediately after the COM objects are released — never in a TLS destructor at thread teardown, never under the loader lock. The guard is declared before the COM interface pointers so it drops last, and `scan()` has no `.await` between init and drop, so init/uninit stay on one thread.

To keep that invariant enforced, `ComGuard` is `!Send` (via a `PhantomData<Rc<()>>` marker). If anyone later holds it across an `.await` on the multi-threaded background runtime, the spawned future becomes `!Send` and fails to compile at the `background_executor().spawn_boxed` site — turning the "same-thread `CoUninitialize`" rule into a compile-time guarantee.

## Linked Issue
Fixes #11952
Fixes #13135

## Testing
Root cause was established by analyzing the four minidumps from #13135: all four show `0x7 FAST_FAIL_FATAL_APP_EXIT`, a faulting `background-executor-*` thread, the same `warp+0x22718a2` fault offset, and `ntdll!LdrpCallTlsInitializers` as the caller.

- `cargo fmt -p warp -- --check` passes.
- Change is COM-init scoping only; `scan()`'s future stays `Send` (the `!Send` guard is never held across an `.await`), so the existing spawn site still compiles.
- [ ] I have manually tested my changes locally with `./script/run`

> Note: `cargo check`/`cargo clippy` and a manual Windows launch were **not** completed in this session — please run `./script/presubmit` and smoke-test on Windows before merging.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed a Windows crash (0xC0000409) that could occur shortly after launch, caused by COM being uninitialized from a thread-local destructor during background-thread teardown.

---
Conversation: https://staging.warp.dev/conversation/f0b8410d-8255-4220-af43-e3b36b185c34

Co-Authored-By: Oz <oz-agent@warp.dev>
