### PR TITLE
Report Oz run failure instead of "Cancelled by user" when the agent's command exits the shell

### DIFF
--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -212,8 +212,12 @@ pub struct AIConversation {
     code_review: Option<CodeReview>,
 
     status: ConversationStatus,
-    /// Optional detail for the current error status.
-    status_error_message: Option<String>,
+    /// Structured error backing the current `Error`/`TransientError` status. The
+    /// single source of truth for both the human-readable message (via `Display`)
+    /// and the FAILED-vs-ERROR classification (via `classify_renderable_error`),
+    /// used by status consumers like the Oz task sync model and the ambient SDK
+    /// driver.
+    status_error: Option<RenderableAIError>,
 
     /// Tracks whether the code review has been opened at least once for this conversation.
     has_opened_code_review: bool,
@@ -350,7 +354,7 @@ impl AIConversation {
             is_cli_agent_transcript,
             todo_lists: vec![],
             status: ConversationStatus::InProgress,
-            status_error_message: None,
+            status_error: None,
             has_opened_code_review: false,
             conversation_usage_metadata: ConversationUsageMetadata::default(),
             server_conversation_token: None,
@@ -585,7 +589,7 @@ impl AIConversation {
             is_cli_agent_transcript: false,
             task_store,
             status,
-            status_error_message: None,
+            status_error: None,
             todo_lists,
             // TODO(alokedesai): Support session restoration for code review comments.
             code_review: None,
@@ -885,11 +889,11 @@ impl AIConversation {
         self.status = status;
     }
 
-    /// Test-only setter for the status error message, used to exercise
-    /// the `status_error_message` fallback in `map_conversation_status`.
+    /// Test-only setter for the structured status error, used to exercise the
+    /// `status_error` classification path in `map_conversation_status`.
     #[cfg(test)]
-    pub(crate) fn set_status_error_message_for_test(&mut self, msg: Option<String>) {
-        self.status_error_message = msg;
+    pub(crate) fn set_status_error_for_test(&mut self, error: Option<RenderableAIError>) {
+        self.status_error = error;
     }
 
     /// Test-only helper: appends an exchange to the root task so status-derivation
@@ -900,8 +904,17 @@ impl AIConversation {
             .modify_root_task(|root_task| root_task.append_exchange(exchange));
     }
 
-    pub fn status_error_message(&self) -> Option<&str> {
-        self.status_error_message.as_deref()
+    /// The human-readable message for the current error status, derived from the
+    /// structured `status_error`.
+    pub fn status_error_message(&self) -> Option<String> {
+        self.status_error.as_ref().map(|error| error.to_string())
+    }
+
+    /// The structured error backing the current `Error`/`TransientError` status.
+    /// Status consumers use it to classify the failure (e.g. FAILED vs ERROR) and
+    /// to render the message.
+    pub fn status_error(&self) -> Option<&RenderableAIError> {
+        self.status_error.as_ref()
     }
 
     pub fn update_status(
@@ -910,21 +923,27 @@ impl AIConversation {
         terminal_surface_id: EntityId,
         ctx: &mut ModelContext<BlocklistAIHistoryModel>,
     ) {
-        self.update_status_with_error_message(status, None, terminal_surface_id, ctx);
+        self.update_status_with_error(status, None, terminal_surface_id, ctx);
     }
 
-    pub fn update_status_with_error_message(
+    /// Updates the conversation status, recording the structured `error` when the
+    /// status is `Error`/`TransientError` (and clearing it otherwise). The error is
+    /// the single source of truth for both the status message and the
+    /// FAILED-vs-ERROR classification used by status consumers (Oz task sync, the
+    /// ambient SDK driver), so callers should pass a structured error rather than a
+    /// bare string — wrap free-form text via [`RenderableAIError::other`].
+    pub fn update_status_with_error(
         &mut self,
         status: ConversationStatus,
-        error_message: Option<String>,
+        error: Option<RenderableAIError>,
         terminal_surface_id: EntityId,
         ctx: &mut ModelContext<BlocklistAIHistoryModel>,
     ) {
-        self.status_error_message = if matches!(
+        self.status_error = if matches!(
             &status,
             ConversationStatus::Error | ConversationStatus::TransientError
         ) {
-            error_message.filter(|message| !message.trim().is_empty())
+            error
         } else {
             None
         };
@@ -2304,12 +2323,7 @@ impl AIConversation {
         } else {
             ConversationStatus::Error
         };
-        self.update_status_with_error_message(
-            status,
-            Some(error.to_string()),
-            terminal_surface_id,
-            ctx,
-        );
+        self.update_status_with_error(status, Some(error), terminal_surface_id, ctx);
         Ok(())
     }
 

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -48,8 +48,8 @@ use crate::ai::agent::icons::{
 use crate::ai::agent::linearization::compute_task_depths;
 use crate::ai::agent::todos::AIAgentTodoList;
 use crate::ai::agent::{
-    AIAgentOutputMessage, AIAgentOutputMessageType, AIIdentifiers, CancellationReason,
-    MessageToAIAgentOutputMessageError, SummarizationType,
+    AIAgentOutputMessage, AIAgentOutputMessageType, AIIdentifiers, CancellationOutcome,
+    CancellationReason, MessageToAIAgentOutputMessageError, SummarizationType,
 };
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::artifacts::Artifact;
@@ -2171,16 +2171,22 @@ impl AIConversation {
 
         self.write_updated_conversation_state(ctx);
 
-        // Don't mark the conversation as Cancelled if we're just cancelling to send a follow-up
-        // on the same conversation (it will be immediately set back to InProgress), or if the
-        // user manually took over the long-running command (the conversation remains in progress
-        // and will resume once the command finishes or control is handed back).
-        //
-        // A shell-exit failure is finalized as `Error` (with a message) by
-        // `BlocklistAIController::fail_conversation_due_to_shell_exit`, so don't
-        // overwrite that terminal status with `Cancelled` here.
-        if !reason.should_preserve_in_progress_status() && !reason.is_agent_exited_shell() {
-            self.update_status(ConversationStatus::Cancelled, terminal_surface_id, ctx);
+        // Finalize the conversation status from the single source of truth for
+        // this cancellation reason:
+        // * `KeepInProgress` leaves the status untouched — a follow-up request or a
+        //   resumed long-running command will continue the conversation.
+        // * `Succeeded` (e.g. an optimistic long-running-command completion or a
+        //   revert) is a successful completion, not a cancellation.
+        // * `Errored` (e.g. shell exit) is finalized as `Error` by a dedicated
+        //   path, so we must not stamp a status here.
+        match reason.conversation_outcome() {
+            CancellationOutcome::Succeeded => {
+                self.update_status(ConversationStatus::Success, terminal_surface_id, ctx);
+            }
+            CancellationOutcome::Cancelled => {
+                self.update_status(ConversationStatus::Cancelled, terminal_surface_id, ctx);
+            }
+            CancellationOutcome::KeepInProgress | CancellationOutcome::Errored => {}
         }
         Ok(())
     }

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -2168,7 +2168,11 @@ impl AIConversation {
         // on the same conversation (it will be immediately set back to InProgress), or if the
         // user manually took over the long-running command (the conversation remains in progress
         // and will resume once the command finishes or control is handed back).
-        if !reason.should_preserve_in_progress_status() {
+        //
+        // A shell-exit failure is finalized as `Error` (with a message) by
+        // `BlocklistAIController::fail_conversation_due_to_shell_exit`, so don't
+        // overwrite that terminal status with `Cancelled` here.
+        if !reason.should_preserve_in_progress_status() && !reason.is_agent_exited_shell() {
             self.update_status(ConversationStatus::Cancelled, terminal_surface_id, ctx);
         }
         Ok(())

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -2186,7 +2186,7 @@ impl AIConversation {
             CancellationOutcome::Cancelled => {
                 self.update_status(ConversationStatus::Cancelled, terminal_surface_id, ctx);
             }
-            CancellationOutcome::KeepInProgress | CancellationOutcome::Errored => {}
+            CancellationOutcome::KeepInProgress | CancellationOutcome::FinalizedExternally => {}
         }
         Ok(())
     }

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -171,62 +171,6 @@ fn latest_user_query_trims_and_skips_empty_queries() {
     );
 }
 
-/// Exhaustively pins the reason -> outcome mapping so adding a new
-/// `CancellationReason` variant forces a deliberate choice here.
-#[test]
-fn cancellation_reason_conversation_outcome_maps_each_variant() {
-    use crate::ai::agent::{CancellationOutcome, CancellationReason};
-
-    let cases = [
-        (
-            CancellationReason::ManuallyCancelled,
-            CancellationOutcome::Cancelled,
-        ),
-        (
-            CancellationReason::AutomaticCloudHandoff,
-            CancellationOutcome::Cancelled,
-        ),
-        (
-            CancellationReason::FollowUpSubmitted {
-                is_for_same_conversation: true,
-            },
-            CancellationOutcome::KeepInProgress,
-        ),
-        (
-            CancellationReason::FollowUpSubmitted {
-                is_for_same_conversation: false,
-            },
-            CancellationOutcome::Cancelled,
-        ),
-        (
-            CancellationReason::UserCommandExecuted,
-            CancellationOutcome::Cancelled,
-        ),
-        (CancellationReason::Reverted, CancellationOutcome::Succeeded),
-        (CancellationReason::Deleted, CancellationOutcome::Cancelled),
-        (
-            CancellationReason::OptimisticCLISubagentCompletion,
-            CancellationOutcome::Succeeded,
-        ),
-        (
-            CancellationReason::CLISubagentUserTakeover,
-            CancellationOutcome::KeepInProgress,
-        ),
-        (
-            CancellationReason::AgentExitedShell,
-            CancellationOutcome::Errored,
-        ),
-    ];
-
-    for (reason, expected) in cases {
-        assert_eq!(
-            reason.conversation_outcome(),
-            expected,
-            "unexpected outcome for {reason:?}"
-        );
-    }
-}
-
 #[test]
 fn title_uses_root_task_description() {
     let conversation = restored_conversation_with_root_description("Root task title");

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -171,6 +171,62 @@ fn latest_user_query_trims_and_skips_empty_queries() {
     );
 }
 
+/// Exhaustively pins the reason -> outcome mapping so adding a new
+/// `CancellationReason` variant forces a deliberate choice here.
+#[test]
+fn cancellation_reason_conversation_outcome_maps_each_variant() {
+    use crate::ai::agent::{CancellationOutcome, CancellationReason};
+
+    let cases = [
+        (
+            CancellationReason::ManuallyCancelled,
+            CancellationOutcome::Cancelled,
+        ),
+        (
+            CancellationReason::AutomaticCloudHandoff,
+            CancellationOutcome::Cancelled,
+        ),
+        (
+            CancellationReason::FollowUpSubmitted {
+                is_for_same_conversation: true,
+            },
+            CancellationOutcome::KeepInProgress,
+        ),
+        (
+            CancellationReason::FollowUpSubmitted {
+                is_for_same_conversation: false,
+            },
+            CancellationOutcome::Cancelled,
+        ),
+        (
+            CancellationReason::UserCommandExecuted,
+            CancellationOutcome::Cancelled,
+        ),
+        (CancellationReason::Reverted, CancellationOutcome::Succeeded),
+        (CancellationReason::Deleted, CancellationOutcome::Cancelled),
+        (
+            CancellationReason::OptimisticCLISubagentCompletion,
+            CancellationOutcome::Succeeded,
+        ),
+        (
+            CancellationReason::CLISubagentUserTakeover,
+            CancellationOutcome::KeepInProgress,
+        ),
+        (
+            CancellationReason::AgentExitedShell,
+            CancellationOutcome::Errored,
+        ),
+    ];
+
+    for (reason, expected) in cases {
+        assert_eq!(
+            reason.conversation_outcome(),
+            expected,
+            "unexpected outcome for {reason:?}"
+        );
+    }
+}
+
 #[test]
 fn title_uses_root_task_description() {
     let conversation = restored_conversation_with_root_description("Root task title");

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -101,7 +101,7 @@ pub enum CancellationReason {
 
     /// The long-running command completed while the agent was still streaming a response started via inline agent view.
     /// This should be treated as a successful completion, not a cancellation.
-    /// Note this is only used for inline agent view (user starting an agent to monitor an already running command), 
+    /// Note this is only used for inline agent view (user starting an agent to monitor an already running command),
     /// not when CLI subagent monitors a requested command.
     CommandFinishedDuringInlineAgentView,
 
@@ -132,10 +132,12 @@ pub enum CancellationOutcome {
     Succeeded,
     /// Finalize the conversation as a user cancellation (`Cancelled`).
     Cancelled,
-    /// The conversation is finalized as a terminal `Error` by a dedicated path
-    /// (e.g. shell-exit handling). The cancellation machinery must only avoid
-    /// stamping `Cancelled`; it must not otherwise change the status.
-    Errored,
+    /// Terminal, but a dedicated path (not the cancellation machinery) writes the
+    /// status — the cancellation is only a stop signal and must not stamp a status.
+    /// Currently used for shell exit, which is finalized as `Error` by
+    /// `fail_conversation_due_to_shell_exit`. Unlike `KeepInProgress`, the
+    /// conversation is ending; only the status write is suppressed.
+    FinalizedExternally,
 }
 
 impl Display for CancellationReason {
@@ -201,7 +203,7 @@ impl CancellationReason {
             | CancellationReason::Reverted => CancellationOutcome::Succeeded,
             // The shell died under the agent; a dedicated path finalizes this as a
             // terminal `Error`, so the cancellation machinery must not stamp a status.
-            CancellationReason::AgentExitedShell => CancellationOutcome::Errored,
+            CancellationReason::AgentExitedShell => CancellationOutcome::FinalizedExternally,
             CancellationReason::ManuallyCancelled
             | CancellationReason::AutomaticCloudHandoff
             | CancellationReason::UserCommandExecuted

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -117,6 +117,25 @@ pub enum CancellationReason {
     AgentExitedShell,
 }
 
+/// How a [`CancellationReason`] maps to the conversation's resulting status.
+/// This is the single source of truth consumed by the stream- and
+/// action-cancellation machinery; see [`CancellationReason::conversation_outcome`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CancellationOutcome {
+    /// Leave the conversation `InProgress`; it will continue on its own (a
+    /// follow-up request or a resumed long-running command) without further user
+    /// input.
+    KeepInProgress,
+    /// Finalize the conversation as a successful completion (`Success`).
+    Succeeded,
+    /// Finalize the conversation as a user cancellation (`Cancelled`).
+    Cancelled,
+    /// The conversation is finalized as a terminal `Error` by a dedicated path
+    /// (e.g. shell-exit handling). The cancellation machinery must only avoid
+    /// stamping `Cancelled`; it must not otherwise change the status.
+    Errored,
+}
+
 impl Display for CancellationReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -159,29 +178,35 @@ impl CancellationReason {
         matches!(self, CancellationReason::Reverted)
     }
 
-    pub fn is_lrc_command_completed(&self) -> bool {
-        matches!(self, CancellationReason::OptimisticCLISubagentCompletion)
-    }
-
-    /// Returns true when the stream was cancelled because the user took manual
-    /// control of the long-running command. The conversation remains in progress
-    /// and the ambient agent task should not be reported as cancelled.
-    pub fn is_cli_subagent_user_takeover(&self) -> bool {
-        matches!(self, CancellationReason::CLISubagentUserTakeover)
-    }
-
-    /// Returns true when the stream was cancelled because an agent-issued command
-    /// caused the shell process to exit. The conversation is finalized as a
-    /// terminal `Error` by the controller, so status-setting paths must not
-    /// overwrite it with `Cancelled`.
-    pub fn is_agent_exited_shell(&self) -> bool {
-        matches!(self, CancellationReason::AgentExitedShell)
-    }
-
-    /// Returns true when the stream cancellation should NOT transition the
-    /// conversation status away from InProgress.
-    pub fn should_preserve_in_progress_status(&self) -> bool {
-        self.is_follow_up_for_same_conversation() || self.is_cli_subagent_user_takeover()
+    /// The single source of truth for how a cancellation reason maps to the
+    /// conversation's resulting status. Every site that finalizes a cancelled
+    /// stream or action consults this instead of re-deriving the disposition,
+    /// so the reason -> status mapping lives in one exhaustive place.
+    pub fn conversation_outcome(&self) -> CancellationOutcome {
+        match self {
+            // The conversation continues without further user input (a follow-up
+            // request or a resumed long-running command drives it forward), so
+            // its status must stay InProgress.
+            CancellationReason::FollowUpSubmitted {
+                is_for_same_conversation: true,
+            }
+            | CancellationReason::CLISubagentUserTakeover => CancellationOutcome::KeepInProgress,
+            // A long-running command finishing (optimistically) or a revert are
+            // successful completions rather than cancellations.
+            CancellationReason::OptimisticCLISubagentCompletion | CancellationReason::Reverted => {
+                CancellationOutcome::Succeeded
+            }
+            // The shell died under the agent; a dedicated path finalizes this as a
+            // terminal `Error`, so the cancellation machinery must not stamp a status.
+            CancellationReason::AgentExitedShell => CancellationOutcome::Errored,
+            CancellationReason::ManuallyCancelled
+            | CancellationReason::AutomaticCloudHandoff
+            | CancellationReason::UserCommandExecuted
+            | CancellationReason::Deleted
+            | CancellationReason::FollowUpSubmitted {
+                is_for_same_conversation: false,
+            } => CancellationOutcome::Cancelled,
+        }
     }
 }
 

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -735,7 +735,7 @@ impl RenderableAIError {
         "Warp lost connection while receiving the agent response. This is usually temporary.";
     /// User-facing message shown when an agent-issued command exits the shell.
     pub const AGENT_EXITED_SHELL_MESSAGE: &'static str =
-        "The shell exited while the agent was running a command, so the run could not continue.";
+        "The shell exited while the agent was running a command, so the run could not continue. Ensure the agent is not asked to run commands or source scripts that can exit the shell.";
     /// Creates a transient network error. `kind` is the structured cause (including the raw API
     /// error where one exists), preserved so user reports can disambiguate the different causes
     /// behind the shared user-facing copy.
@@ -785,6 +785,19 @@ impl RenderableAIError {
     /// aggressive behavior so developers still see every transport failure.
     pub fn should_suppress_during_recovery(&self) -> bool {
         self.will_attempt_resume() && !ChannelState::channel().is_dogfood()
+    }
+
+    /// Constructs a generic [`RenderableAIError::Other`] from a message.
+    /// `is_user_error` selects the task classification (true → FAILED, false →
+    /// ERROR). The resume/network flags are false: this is for terminal,
+    /// out-of-band errors that are not auto-resumed.
+    pub fn other(error_message: impl Into<String>, is_user_error: bool) -> Self {
+        Self::Other {
+            error_message: error_message.into(),
+            will_attempt_resume: false,
+            waiting_for_network: false,
+            is_user_error,
+        }
     }
 }
 

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -108,6 +108,13 @@ pub enum CancellationReason {
     /// finishes or once the user hands control back. The stream is cancelled only to
     /// stop the CLI subagent monitoring loop, not to end the conversation.
     CLISubagentUserTakeover,
+
+    /// An agent-issued command caused the shell process to exit (e.g. it ran
+    /// `exit`, or ran a failing command after enabling `set -e`). The in-flight
+    /// stream/actions are cancelled to stop work, but the conversation is
+    /// finalized as a terminal `Error` (with a shell-exit message) by the
+    /// controller rather than reported as a user cancellation.
+    AgentExitedShell,
 }
 
 impl Display for CancellationReason {
@@ -124,6 +131,9 @@ impl Display for CancellationReason {
             }
             CancellationReason::CLISubagentUserTakeover => {
                 write!(f, "CLI subagent user takeover")
+            }
+            CancellationReason::AgentExitedShell => {
+                write!(f, "agent command exited the shell")
             }
         }
     }
@@ -158,6 +168,14 @@ impl CancellationReason {
     /// and the ambient agent task should not be reported as cancelled.
     pub fn is_cli_subagent_user_takeover(&self) -> bool {
         matches!(self, CancellationReason::CLISubagentUserTakeover)
+    }
+
+    /// Returns true when the stream was cancelled because an agent-issued command
+    /// caused the shell process to exit. The conversation is finalized as a
+    /// terminal `Error` by the controller, so status-setting paths must not
+    /// overwrite it with `Cancelled`.
+    pub fn is_agent_exited_shell(&self) -> bool {
+        matches!(self, CancellationReason::AgentExitedShell)
     }
 
     /// Returns true when the stream cancellation should NOT transition the
@@ -676,11 +694,18 @@ pub enum RenderableAIError {
         /// blocked due to fraud, plan restriction). Maps the task to FAILED state instead of ERROR.
         is_user_error: bool,
     },
+    /// An agent-issued command caused the shell process to exit, so the run
+    /// cannot continue. Surfaced as a terminal failure (FAILED) rather than a
+    /// user cancellation.
+    AgentExitedShell,
 }
 
 impl RenderableAIError {
     const TRANSIENT_NETWORK_ERROR_MESSAGE: &'static str =
         "Warp lost connection while receiving the agent response. This is usually temporary.";
+    /// User-facing message shown when an agent-issued command exits the shell.
+    pub const AGENT_EXITED_SHELL_MESSAGE: &'static str =
+        "The shell exited while the agent was running a command, so the run could not continue.";
     /// Creates a transient network error. `kind` is the structured cause (including the raw API
     /// error where one exists), preserved so user reports can disambiguate the different causes
     /// behind the shared user-facing copy.
@@ -838,6 +863,7 @@ impl Display for RenderableAIError {
                 )
             }
             Self::Other { error_message, .. } => write!(f, "{error_message}"),
+            Self::AgentExitedShell => write!(f, "{}", Self::AGENT_EXITED_SHELL_MESSAGE),
         }
     }
 }

--- a/app/src/ai/agent/mod.rs
+++ b/app/src/ai/agent/mod.rs
@@ -99,9 +99,11 @@ pub enum CancellationReason {
     // The user deleted the conversation while it was in progress.
     Deleted,
 
-    /// The long-running command completed while the agent was still streaming.
+    /// The long-running command completed while the agent was still streaming a response started via inline agent view.
     /// This should be treated as a successful completion, not a cancellation.
-    OptimisticCLISubagentCompletion,
+    /// Note this is only used for inline agent view (user starting an agent to monitor an already running command), 
+    /// not when CLI subagent monitors a requested command.
+    CommandFinishedDuringInlineAgentView,
 
     /// The user manually took control of a long-running command away from the agent.
     /// The agent conversation is still in progress — it will resume after the command
@@ -145,7 +147,7 @@ impl Display for CancellationReason {
             CancellationReason::UserCommandExecuted => write!(f, "user command execution"),
             CancellationReason::Reverted => write!(f, "revert"),
             CancellationReason::Deleted => write!(f, "deleted"),
-            CancellationReason::OptimisticCLISubagentCompletion => {
+            CancellationReason::CommandFinishedDuringInlineAgentView => {
                 write!(f, "LRC command completed")
             }
             CancellationReason::CLISubagentUserTakeover => {
@@ -178,10 +180,12 @@ impl CancellationReason {
         matches!(self, CancellationReason::Reverted)
     }
 
-    /// The single source of truth for how a cancellation reason maps to the
+    /// How a cancellation reason maps to the
     /// conversation's resulting status. Every site that finalizes a cancelled
     /// stream or action consults this instead of re-deriving the disposition,
     /// so the reason -> status mapping lives in one exhaustive place.
+    /// Note that sometimes the action result is treated as authoritative for determining
+    /// conversation status even when there is a cancellation reason (taking priority over this)
     pub fn conversation_outcome(&self) -> CancellationOutcome {
         match self {
             // The conversation continues without further user input (a follow-up
@@ -193,9 +197,8 @@ impl CancellationReason {
             | CancellationReason::CLISubagentUserTakeover => CancellationOutcome::KeepInProgress,
             // A long-running command finishing (optimistically) or a revert are
             // successful completions rather than cancellations.
-            CancellationReason::OptimisticCLISubagentCompletion | CancellationReason::Reverted => {
-                CancellationOutcome::Succeeded
-            }
+            CancellationReason::CommandFinishedDuringInlineAgentView
+            | CancellationReason::Reverted => CancellationOutcome::Succeeded,
             // The shell died under the agent; a dedicated path finalizes this as a
             // terminal `Error`, so the cancellation machinery must not stamp a status.
             CancellationReason::AgentExitedShell => CancellationOutcome::Errored,

--- a/app/src/ai/ambient_agents/mod.rs
+++ b/app/src/ai/ambient_agents/mod.rs
@@ -88,8 +88,9 @@ pub fn conversation_output_status_from_conversation(
 
         ConversationStatus::Error => {
             // Prefer the structured error on the last exchange: it carries the precise
-            // error variant and rendering hints that the string-only `status_error_message`
-            // cannot.
+            // error variant and rendering hints. Fall back to the conversation-level
+            // `status_error` for out-of-band failures (e.g. shell exit) recorded
+            // without an exchange. Both drive FAILED-vs-ERROR classification downstream.
             if let Some(AIAgentOutputStatus::Finished {
                 finished_output: FinishedAIAgentOutput::Error { error, .. },
             }) = conversation
@@ -101,18 +102,13 @@ pub fn conversation_output_status_from_conversation(
                     error: error.clone(),
                 });
             }
-            if let Some(error_message) = conversation.status_error_message() {
+            if let Some(error) = conversation.status_error() {
                 return Some(AmbientConversationStatus::Error {
-                    error: RenderableAIError::Other {
-                        error_message: error_message.to_string(),
-                        will_attempt_resume: false,
-                        waiting_for_network: false,
-                        is_user_error: false,
-                    },
+                    error: error.clone(),
                 });
             }
-            // Neither a structured exchange error nor a status message is available;
-            // fall back to whatever terminal outcome the last exchange carries.
+            // No structured error anywhere; fall back to whatever terminal outcome
+            // the last exchange carries.
             terminal_status_from_last_exchange(conversation)
         }
 

--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -1291,12 +1291,15 @@ impl BlocklistAIActionModel {
             .get(&conversation_id)
             .is_none_or(|actions| actions.is_empty())
         {
-            if !cancellation_reason.is_some_and(|r| {
-                matches!(
-                    r.conversation_outcome(),
-                    CancellationOutcome::KeepInProgress
-                )
-            }) {
+            // Only a `Cancelled` outcome stamps a status here. The other outcomes are
+            // owned elsewhere: `KeepInProgress` / `Succeeded` and `FinalizedExternally`
+            // are finalized by the controller or a dedicated path, and a normal
+            // completion (no cancellation reason) is resolved by the controller's
+            // follow-up handling. Stamping here for any of those would clobber the real
+            // status and message.
+            if cancellation_reason
+                .is_some_and(|r| matches!(r.conversation_outcome(), CancellationOutcome::Cancelled))
+            {
                 BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
                     // Treat action result as authoritative for determining status.
                     let status = if self

--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -50,7 +50,8 @@ use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
 use crate::ai::agent::{
     AIAgentAction, AIAgentActionId, AIAgentActionResult, AIAgentActionResultType,
     AIAgentActionType, AIAgentActionTypeDiscriminants, AIAgentExchange, AIAgentInput,
-    CancellationReason, CreateDocumentsResult, EditDocumentsResult, RequestCommandOutputResult,
+    CancellationOutcome, CancellationReason, CreateDocumentsResult, EditDocumentsResult,
+    RequestCommandOutputResult,
 };
 use crate::ai::ai_document_view::DEFAULT_PLANNING_DOCUMENT_TITLE;
 use crate::ai::blocklist::action_model::execute::suggest_new_conversation::SuggestNewConversationExecutor;
@@ -1290,8 +1291,14 @@ impl BlocklistAIActionModel {
             .get(&conversation_id)
             .is_none_or(|actions| actions.is_empty())
         {
-            if !cancellation_reason.is_some_and(|r| r.should_preserve_in_progress_status()) {
+            if !cancellation_reason.is_some_and(|r| {
+                matches!(
+                    r.conversation_outcome(),
+                    CancellationOutcome::KeepInProgress
+                )
+            }) {
                 BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
+                    // Treat action result as authoritative for determining status.
                     let status = if self
                         .finished_action_results
                         .get(&conversation_id)

--- a/app/src/ai/blocklist/action_model/execute/start_agent.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_agent.rs
@@ -233,7 +233,7 @@ impl StartAgentExecutor {
         };
         if let Some(error_msg) = start_agent_error_message_for_status(
             conversation.status(),
-            conversation.status_error_message(),
+            conversation.status_error_message().as_deref(),
         ) {
             self.complete_pending_as_error(request_id, child_conversation_id, error_msg, ctx);
             return;
@@ -270,7 +270,7 @@ impl StartAgentExecutor {
                 };
                 let error_msg = start_agent_error_message_for_status(
                     conversation.status(),
-                    conversation.status_error_message(),
+                    conversation.status_error_message().as_deref(),
                 );
                 if let Some(error_msg) = error_msg {
                     self.complete_pending_as_error(request_id, *conversation_id, error_msg, ctx);

--- a/app/src/ai/blocklist/action_model/execute/start_agent_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_agent_tests.rs
@@ -6,7 +6,7 @@ use super::*;
 use crate::ai::agent::conversation::ConversationStatus;
 use crate::ai::agent::task::TaskId;
 use crate::ai::agent::{
-    AIAgentAction, AIAgentActionId, AIAgentActionResultType, AIAgentActionType,
+    AIAgentAction, AIAgentActionId, AIAgentActionResultType, AIAgentActionType, RenderableAIError,
     StartAgentExecutionMode, StartAgentResult,
 };
 use crate::ai::blocklist::orchestration_event_streamer::OrchestrationEventStreamer;
@@ -251,11 +251,14 @@ fn execute_resolves_error_when_request_linkage_happens_after_child_already_faile
         });
 
         history_model.update(&mut app, |history_model, ctx| {
-            history_model.update_conversation_status_with_error_message(
+            history_model.update_conversation_status_with_error(
                 terminal_view_id,
                 child_conversation_id,
                 ConversationStatus::Error,
-                Some("'codex' CLI not found on your machine.".to_string()),
+                Some(RenderableAIError::other(
+                    "'codex' CLI not found on your machine.",
+                    false,
+                )),
                 ctx,
             );
         });
@@ -431,11 +434,14 @@ fn execute_returns_detailed_error_when_child_startup_fails_before_initialization
         });
 
         history_model.update(&mut app, |history_model, ctx| {
-            history_model.update_conversation_status_with_error_message(
+            history_model.update_conversation_status_with_error(
                 terminal_view_id,
                 child_conversation_id,
                 ConversationStatus::Error,
-                Some("Failed to resolve child agent skills: review-comments".to_string()),
+                Some(RenderableAIError::other(
+                    "Failed to resolve child agent skills: review-comments",
+                    false,
+                )),
                 ctx,
             );
         });
@@ -801,11 +807,11 @@ fn parallel_pendings_each_resolve_independently_via_recorded_child_id() {
         });
 
         history_model.update(&mut app, |history_model, ctx| {
-            history_model.update_conversation_status_with_error_message(
+            history_model.update_conversation_status_with_error(
                 terminal_view_id,
                 child_b,
                 ConversationStatus::Error,
-                Some("Agent B init failed".to_string()),
+                Some(RenderableAIError::other("Agent B init failed", false)),
                 ctx,
             );
         });
@@ -938,11 +944,14 @@ fn errored_child_launch_emits_cleanup_event() {
         let (state, _executor) = dispatch_pending_child_launch(&mut app);
         link_pending_child(&state, &mut app);
         state.history_model.update(&mut app, |model, ctx| {
-            model.update_conversation_status_with_error_message(
+            model.update_conversation_status_with_error(
                 state.terminal_view_id,
                 state.child_conversation_id,
                 ConversationStatus::Error,
-                Some("Child agent failed to spawn".to_string()),
+                Some(RenderableAIError::other(
+                    "Child agent failed to spawn",
+                    false,
+                )),
                 ctx,
             );
         });

--- a/app/src/ai/blocklist/agent_view/agent_message_bar.rs
+++ b/app/src/ai/blocklist/agent_view/agent_message_bar.rs
@@ -789,7 +789,9 @@ fn should_fork_from_last_known_good_state(
         | RenderableAIError::ContextWindowExceeded(_)
         | RenderableAIError::InvalidApiKey { .. }
         | RenderableAIError::AwsBedrockCredentialsExpiredOrInvalid { .. } => false,
-        RenderableAIError::InternalWarpError => true,
+        // A shell-exit failure can't resume in this (now-dead) pane, but the user
+        // can fork from the last known good state to continue in a fresh one.
+        RenderableAIError::InternalWarpError | RenderableAIError::AgentExitedShell => true,
         RenderableAIError::Other {
             will_attempt_resume,
             ..

--- a/app/src/ai/blocklist/block/cli_controller.rs
+++ b/app/src/ai/blocklist/block/cli_controller.rs
@@ -237,7 +237,7 @@ impl CLISubagentController {
                             me.controller.update(ctx, |controller, ctx| {
                                 controller.cancel_conversation_progress(
                                     conversation_id,
-                                    CancellationReason::OptimisticCLISubagentCompletion,
+                                    CancellationReason::CommandFinishedDuringInlineAgentView,
                                     ctx,
                                 );
                             });

--- a/app/src/ai/blocklist/block/view_impl/common.rs
+++ b/app/src/ai/blocklist/block/view_impl/common.rs
@@ -3099,6 +3099,9 @@ pub fn render_failed_output(props: FailedOutputProps, app: &AppContext) -> Box<d
             // reach here recovery has failed, so surface the error directly.
             format!("{ERROR_APOLOGY_TEXT}\n\n{error_message}")
         }
+        RenderableAIError::AgentExitedShell => {
+            format!("{ERROR_APOLOGY_TEXT}\n\n{}", props.error)
+        }
         RenderableAIError::TransientNetworkError { .. } => {
             // Recovering transient errors are handled by the early return above; once we
             // reach here recovery has failed. These carry their own complete user-facing

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -58,10 +58,11 @@ use crate::ai::agent::task::TaskId;
 use crate::ai::agent::{
     AIAgentAction, AIAgentActionId, AIAgentActionResult, AIAgentActionResultType,
     AIAgentActionType, AIAgentCitation, AIAgentInput, AIAgentOutputMessage,
-    AIAgentOutputMessageType, AIAgentText, AIAgentTextSection, CreateDocumentsResult,
-    EditDocumentsResult, MessageId, ReadFilesRequest, ReadFilesResult, RequestCommandOutputResult,
-    SearchCodebaseFailureReason, SearchCodebaseResult, SubagentCall, SubagentType,
-    SuggestNewConversationResult, SummarizationType, TodoOperation, UploadArtifactResult,
+    AIAgentOutputMessageType, AIAgentText, AIAgentTextSection, CancellationOutcome,
+    CreateDocumentsResult, EditDocumentsResult, MessageId, ReadFilesRequest, ReadFilesResult,
+    RequestCommandOutputResult, SearchCodebaseFailureReason, SearchCodebaseResult, SubagentCall,
+    SubagentType, SuggestNewConversationResult, SummarizationType, TodoOperation,
+    UploadArtifactResult,
 };
 use crate::ai::agent_conversations_model::AgentConversationsModel;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
@@ -1231,7 +1232,15 @@ fn should_render_stopped_output(props: Props, app: &AppContext) -> bool {
 
     let status = props.model.status(app);
     let cancellation_reason = status.cancellation_reason().cloned();
-    if cancellation_reason.is_some_and(|reason| reason.should_preserve_in_progress_status()) {
+    // Reasons that keep the conversation alive (follow-ups, CLI-subagent takeover)
+    // or finalize it as a success (optimistic command completion, revert) must not
+    // render a stopped banner.
+    if cancellation_reason.is_some_and(|reason| {
+        matches!(
+            reason.conversation_outcome(),
+            CancellationOutcome::KeepInProgress | CancellationOutcome::Succeeded
+        )
+    }) {
         return false;
     }
 

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -535,6 +535,10 @@ impl BlocklistAIController {
                         || treat_as_success
                     {
                         ConversationStatus::Success
+                    } else if matches!(
+                        cancellation_outcome,
+                        Some(CancellationOutcome::Errored)) {
+                        ConversationStatus::Error
                     } else {
                         // This is an imperfect heuristic that practically speaking should have no effect.
                         //

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -443,6 +443,12 @@ impl BlocklistAIController {
             else {
                 return;
             };
+            // Shell-exit failures are finalized as `Error` (with a message) by
+            // `fail_conversation_due_to_shell_exit`; don't trigger a follow-up or
+            // overwrite the terminal status here.
+            if cancellation_reason.is_some_and(|reason| reason.is_agent_exited_shell()) {
+                return;
+            }
             let action_model = me.action_model.as_ref(ctx);
             if action_model.has_unfinished_actions_for_conversation(*conversation_id) {
                 return;
@@ -2617,6 +2623,89 @@ impl BlocklistAIController {
                 action_model.cancel_all_pending_actions(conversation_id, Some(reason), ctx);
             });
             self.set_input_mode_for_cancellation(ctx);
+        }
+    }
+
+    /// Finalizes a conversation as a terminal failure because an agent-issued
+    /// command caused the shell process to exit (e.g. it ran `exit`, or ran a
+    /// failing command after enabling `set -e`).
+    ///
+    /// Invoked from the terminal view's shell-exit handler before the pane is
+    /// torn down. The conversation is moved into a terminal `Error` state with a
+    /// shell-exit message so that the Oz run reports `FAILED` (with an
+    /// explanation) instead of "Cancelled by user", and so the subsequent
+    /// pane-close cancellation — which is guarded by `is_in_progress` — becomes a
+    /// no-op and cannot overwrite the failure.
+    pub fn fail_conversation_due_to_shell_exit(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let terminal_surface_id = self.terminal_surface_id;
+        let history_model = BlocklistAIHistoryModel::handle(ctx);
+
+        // Only act on conversations that are still running. A finished
+        // conversation (e.g. the agent already completed) must not be
+        // retroactively marked as failed.
+        let is_in_progress = history_model
+            .as_ref(ctx)
+            .conversation(&conversation_id)
+            .is_some_and(|conversation| conversation.status().is_in_progress());
+        if !is_in_progress {
+            return;
+        }
+
+        // Finish any in-flight response stream(s) with the shell-exit error. This
+        // marks the streaming exchange(s) as errored, sets the conversation to
+        // `Error` (with a message), and renders the failure inline. We then cancel
+        // the underlying request so it stops streaming; the cancellation does not
+        // overwrite the status because `mark_request_cancelled` ignores the
+        // `AgentExitedShell` reason.
+        let stream_ids = self
+            .in_flight_response_streams
+            .stream_ids_for_conversation(conversation_id, ctx);
+        let had_in_flight_stream = !stream_ids.is_empty();
+        for stream_id in &stream_ids {
+            history_model.update(ctx, |history_model, ctx| {
+                history_model.mark_response_stream_completed_with_error(
+                    RenderableAIError::AgentExitedShell,
+                    /* recovery_pending */ false,
+                    stream_id,
+                    conversation_id,
+                    terminal_surface_id,
+                    ctx,
+                );
+            });
+            self.try_cancel_pending_response_stream(
+                stream_id,
+                CancellationReason::AgentExitedShell,
+                ctx,
+            );
+        }
+
+        // Stop any pending or mid-execution actions so a queued action result
+        // can't subsequently move the conversation back to Success/Cancelled.
+        self.action_model.update(ctx, |action_model, ctx| {
+            action_model.cancel_all_pending_actions(
+                conversation_id,
+                Some(CancellationReason::AgentExitedShell),
+                ctx,
+            );
+        });
+
+        // If there was no in-flight stream to attach the error to (e.g. the agent
+        // ran `exit` and no follow-up request was in flight), set the terminal
+        // `Error` status directly with the shell-exit message.
+        if !had_in_flight_stream {
+            history_model.update(ctx, |history_model, ctx| {
+                history_model.update_conversation_status_with_error_message(
+                    terminal_surface_id,
+                    conversation_id,
+                    ConversationStatus::Error,
+                    Some(RenderableAIError::AgentExitedShell.to_string()),
+                    ctx,
+                );
+            });
         }
     }
 

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -443,12 +443,14 @@ impl BlocklistAIController {
             else {
                 return;
             };
-            // The single source of truth for how this cancellation finalizes the
-            // conversation. `Errored` (e.g. shell exit) is finalized as `Error` by a
-            // dedicated path, so we must not trigger a follow-up or stamp a status here.
+            // `FinalizedExternally` (e.g. shell exit) means the conversation status and message
+            // is set elsewhere through a dedicated path, so we must not trigger a follow-up or update conversation status here.
             let cancellation_outcome =
                 cancellation_reason.map(|reason| reason.conversation_outcome());
-            if matches!(cancellation_outcome, Some(CancellationOutcome::Errored)) {
+            if matches!(
+                cancellation_outcome,
+                Some(CancellationOutcome::FinalizedExternally)
+            ) {
                 return;
             }
             let action_model = me.action_model.as_ref(ctx);
@@ -535,10 +537,6 @@ impl BlocklistAIController {
                         || treat_as_success
                     {
                         ConversationStatus::Success
-                    } else if matches!(
-                        cancellation_outcome,
-                        Some(CancellationOutcome::Errored)) {
-                        ConversationStatus::Error
                     } else {
                         // This is an imperfect heuristic that practically speaking should have no effect.
                         //

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -2706,14 +2706,16 @@ impl BlocklistAIController {
 
         // If there was no in-flight stream to attach the error to (e.g. the agent
         // ran `exit` and no follow-up request was in flight), set the terminal
-        // `Error` status directly with the shell-exit message.
+        // `Error` status directly, recording the structured shell-exit error so
+        // status consumers (Oz task sync and the ambient SDK driver) classify it
+        // as FAILED rather than a generic ERROR.
         if !had_in_flight_stream {
             history_model.update(ctx, |history_model, ctx| {
-                history_model.update_conversation_status_with_error_message(
+                history_model.update_conversation_status_with_error(
                     terminal_surface_id,
                     conversation_id,
                     ConversationStatus::Error,
-                    Some(RenderableAIError::AgentExitedShell.to_string()),
+                    Some(RenderableAIError::AgentExitedShell),
                     ctx,
                 );
             });

--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -45,8 +45,8 @@ use crate::ai::agent::task::TaskId;
 use crate::ai::agent::{
     extract_user_query_mode, AIAgentActionResult, AIAgentActionResultType, AIAgentAttachment,
     AIAgentContext, AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus, AIIdentifiers,
-    CancellationReason, DocumentContentAttachmentSource, EntrypointType, FileContext,
-    FinishedAIAgentOutput, PassiveSuggestionResultType, PassiveSuggestionTrigger,
+    CancellationOutcome, CancellationReason, DocumentContentAttachmentSource, EntrypointType,
+    FileContext, FinishedAIAgentOutput, PassiveSuggestionResultType, PassiveSuggestionTrigger,
     PassiveSuggestionTriggerType, RenderableAIError, RequestCost, RequestMetadata, RunningCommand,
     StaticQueryType, TransientNetworkErrorKind, UserQueryMode,
 };
@@ -443,10 +443,12 @@ impl BlocklistAIController {
             else {
                 return;
             };
-            // Shell-exit failures are finalized as `Error` (with a message) by
-            // `fail_conversation_due_to_shell_exit`; don't trigger a follow-up or
-            // overwrite the terminal status here.
-            if cancellation_reason.is_some_and(|reason| reason.is_agent_exited_shell()) {
+            // The single source of truth for how this cancellation finalizes the
+            // conversation. `Errored` (e.g. shell exit) is finalized as `Error` by a
+            // dedicated path, so we must not trigger a follow-up or stamp a status here.
+            let cancellation_outcome =
+                cancellation_reason.map(|reason| reason.conversation_outcome());
+            if matches!(cancellation_outcome, Some(CancellationOutcome::Errored)) {
                 return;
             }
             let action_model = me.action_model.as_ref(ctx);
@@ -485,18 +487,22 @@ impl BlocklistAIController {
                 });
             let has_manual_follow_up = me.pending_passive_follow_ups.contains(conversation_id);
 
-            let is_lrc_command_completed =
-                cancellation_reason.is_some_and(|reason| reason.is_lrc_command_completed());
-            let should_preserve_in_progress_status = cancellation_reason
-                .is_some_and(|reason| reason.should_preserve_in_progress_status());
+            // A `Succeeded` cancellation (e.g. an optimistic long-running-command
+            // completion or a revert) is itself the terminal result, so it neither
+            // triggers a follow-up nor counts as a cancellation.
+            let treat_as_success =
+                matches!(cancellation_outcome, Some(CancellationOutcome::Succeeded));
             let should_trigger_follow_up_request = (!is_passive_code_diff
-                && !is_lrc_command_completed
+                && !treat_as_success
                 && finished_action_results
                     .iter()
                     .any(|result| result.result.should_trigger_request_upon_completion()))
                 || has_manual_follow_up;
             if !should_trigger_follow_up_request {
-                if should_preserve_in_progress_status {
+                if matches!(
+                    cancellation_outcome,
+                    Some(CancellationOutcome::KeepInProgress)
+                ) {
                     return;
                 }
                 // We also check if there's an in-flight req, because it's possible that this
@@ -526,7 +532,7 @@ impl BlocklistAIController {
                     let updated_conversation_status = if finished_action_results
                         .iter()
                         .all(|result| result.result.is_successful())
-                        || is_lrc_command_completed
+                        || treat_as_success
                     {
                         ConversationStatus::Success
                     } else {
@@ -2600,7 +2606,10 @@ impl BlocklistAIController {
             //
             // TODO(REMOTE-1950): Track the parked auto-resume as a first-class cancelable so its
             // cancellation flows through the same `AfterStreamFinished` path, dropping this special case.
-            if !reason.should_preserve_in_progress_status() {
+            if matches!(
+                reason.conversation_outcome(),
+                CancellationOutcome::Cancelled
+            ) {
                 let history_model = BlocklistAIHistoryModel::handle(ctx);
                 let is_recovering = history_model
                     .as_ref(ctx)
@@ -2986,10 +2995,12 @@ impl BlocklistAIController {
                     // the conversation's InProgress status, such as follow-ups and CLI subagent user
                     // takeover, because those do not end the conversation.
                     if FeatureFlag::AgentSharedSessions.is_enabled()
-                        && !stream_cancellation
-                            .reason
-                            .should_preserve_in_progress_status()
+                        && !matches!(
+                            stream_cancellation.reason.conversation_outcome(),
+                            CancellationOutcome::KeepInProgress
+                        )
                     {
+                        // For any terminal status (not just canceled), we need to inform viewers the stream has stopped.
                         self.send_cancellation_to_viewers(ctx);
                     }
 
@@ -3004,9 +3015,10 @@ impl BlocklistAIController {
                     });
 
                     if !was_passive_request
-                        && !stream_cancellation
-                            .reason
-                            .should_preserve_in_progress_status()
+                        && matches!(
+                            stream_cancellation.reason.conversation_outcome(),
+                            CancellationOutcome::Cancelled
+                        )
                     {
                         self.set_input_mode_for_cancellation(ctx);
                     }

--- a/app/src/ai/blocklist/controller/pending_response_streams.rs
+++ b/app/src/ai/blocklist/controller/pending_response_streams.rs
@@ -34,6 +34,23 @@ impl PendingResponseStreams {
             .any(|stream_id| conversation.is_processing_response_stream(stream_id))
     }
 
+    /// Returns the IDs of all in-flight streams owned by the given conversation.
+    pub fn stream_ids_for_conversation(
+        &self,
+        conversation_id: AIConversationId,
+        app: &AppContext,
+    ) -> Vec<ResponseStreamId> {
+        let history_model = BlocklistAIHistoryModel::as_ref(app);
+        let Some(conversation) = history_model.conversation(&conversation_id) else {
+            return Vec::new();
+        };
+        self.streams
+            .keys()
+            .filter(|stream_id| conversation.is_processing_response_stream(stream_id))
+            .cloned()
+            .collect()
+    }
+
     pub fn register_new_stream(
         &mut self,
         stream_id: ResponseStreamId,

--- a/app/src/ai/blocklist/controller_tests.rs
+++ b/app/src/ai/blocklist/controller_tests.rs
@@ -466,7 +466,7 @@ fn optimistic_cli_subagent_completion_with_in_flight_stream_reports_success() {
                 // streaming, cancelling the in-flight stream optimistically.
                 controller.cancel_conversation_progress(
                     conversation_id,
-                    CancellationReason::OptimisticCLISubagentCompletion,
+                    CancellationReason::CommandFinishedDuringInlineAgentView,
                     ctx,
                 );
             });

--- a/app/src/ai/blocklist/controller_tests.rs
+++ b/app/src/ai/blocklist/controller_tests.rs
@@ -326,3 +326,87 @@ fn mock_response_stream_updates_history_through_controller() {
         )));
     });
 }
+
+/// When an agent command exits the shell, the conversation must be finalized as
+/// `Error` (not `Cancelled`), and a subsequent `ManuallyCancelled` (as fired by
+/// the pane-close path) must not overwrite that failure.
+#[test]
+fn fail_conversation_due_to_shell_exit_reports_error_and_survives_manual_cancel() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        let conversation_id = terminal.update(&mut app, |view, ctx| {
+            let terminal_surface_id = view.id();
+            let stream_id = ResponseStreamId::new_for_test();
+            let conversation_id =
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                    let conversation_id = history.start_new_conversation(
+                        terminal_surface_id,
+                        false,
+                        false,
+                        false,
+                        ctx,
+                    );
+                    let task_id = history
+                        .conversation(&conversation_id)
+                        .unwrap()
+                        .get_root_task_id()
+                        .clone();
+                    history
+                        .update_conversation_for_new_request_input(
+                            RequestInput {
+                                conversation_id,
+                                input_messages: HashMap::from([(task_id, vec![])]),
+                                working_directory: None,
+                                model_id: LLMId::from("test-model"),
+                                coding_model_id: LLMId::from("test-coding-model"),
+                                cli_agent_model_id: LLMId::from("test-cli-agent-model"),
+                                computer_use_model_id: LLMId::from("test-computer-use-model"),
+                                shared_session_response_initiator: None,
+                                request_start_ts: Local::now(),
+                                supported_tools_override: None,
+                            },
+                            stream_id.clone(),
+                            terminal_surface_id,
+                            ctx,
+                        )
+                        .unwrap();
+                    conversation_id
+                });
+            let stream = ctx.add_model(|_| ResponseStream::new_for_test(stream_id.clone()));
+            view.ai_controller().update(ctx, |controller, ctx| {
+                controller.register_mock_stream_for_test(stream_id, conversation_id, stream, ctx);
+                controller.fail_conversation_due_to_shell_exit(conversation_id, ctx);
+            });
+            conversation_id
+        });
+
+        // The in-flight request is finalized as Error (with the shell-exit error
+        // on its exchange), not Cancelled.
+        BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
+            assert_eq!(
+                history.conversation(&conversation_id).map(|c| c.status()),
+                Some(&crate::ai::agent::conversation::ConversationStatus::Error)
+            );
+        });
+
+        // The pane-close cancellation path must be a no-op now that the
+        // conversation is terminal.
+        terminal.update(&mut app, |view, ctx| {
+            view.ai_controller().update(ctx, |controller, ctx| {
+                controller.cancel_conversation_progress(
+                    conversation_id,
+                    CancellationReason::ManuallyCancelled,
+                    ctx,
+                );
+            });
+        });
+        BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
+            assert_eq!(
+                history.conversation(&conversation_id).map(|c| c.status()),
+                Some(&crate::ai::agent::conversation::ConversationStatus::Error)
+            );
+        });
+    });
+}

--- a/app/src/ai/blocklist/controller_tests.rs
+++ b/app/src/ai/blocklist/controller_tests.rs
@@ -410,3 +410,74 @@ fn fail_conversation_due_to_shell_exit_reports_error_and_survives_manual_cancel(
         });
     });
 }
+
+/// An optimistic long-running-command completion that cancels an in-flight
+/// stream must finalize the conversation as `Success`, not `Cancelled`. This is
+/// a regression test for the reason -> status mapping living in a single place
+/// (`CancellationReason::conversation_outcome`).
+#[test]
+fn optimistic_cli_subagent_completion_with_in_flight_stream_reports_success() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        let conversation_id = terminal.update(&mut app, |view, ctx| {
+            let terminal_surface_id = view.id();
+            let stream_id = ResponseStreamId::new_for_test();
+            let conversation_id =
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                    let conversation_id = history.start_new_conversation(
+                        terminal_surface_id,
+                        false,
+                        false,
+                        false,
+                        ctx,
+                    );
+                    let task_id = history
+                        .conversation(&conversation_id)
+                        .unwrap()
+                        .get_root_task_id()
+                        .clone();
+                    history
+                        .update_conversation_for_new_request_input(
+                            RequestInput {
+                                conversation_id,
+                                input_messages: HashMap::from([(task_id, vec![])]),
+                                working_directory: None,
+                                model_id: LLMId::from("test-model"),
+                                coding_model_id: LLMId::from("test-coding-model"),
+                                cli_agent_model_id: LLMId::from("test-cli-agent-model"),
+                                computer_use_model_id: LLMId::from("test-computer-use-model"),
+                                shared_session_response_initiator: None,
+                                request_start_ts: Local::now(),
+                                supported_tools_override: None,
+                            },
+                            stream_id.clone(),
+                            terminal_surface_id,
+                            ctx,
+                        )
+                        .unwrap();
+                    conversation_id
+                });
+            let stream = ctx.add_model(|_| ResponseStream::new_for_test(stream_id.clone()));
+            view.ai_controller().update(ctx, |controller, ctx| {
+                controller.register_mock_stream_for_test(stream_id, conversation_id, stream, ctx);
+                // The long-running command finished while the agent was still
+                // streaming, cancelling the in-flight stream optimistically.
+                controller.cancel_conversation_progress(
+                    conversation_id,
+                    CancellationReason::OptimisticCLISubagentCompletion,
+                    ctx,
+                );
+            });
+            conversation_id
+        });
+
+        BlocklistAIHistoryModel::handle(&app).read(&app, |history, _| {
+            assert_eq!(
+                history.conversation(&conversation_id).map(|c| c.status()),
+                Some(&crate::ai::agent::conversation::ConversationStatus::Success)
+            );
+        });
+    });
+}

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -1213,7 +1213,7 @@ impl BlocklistAIHistoryModel {
         status: ConversationStatus,
         ctx: &mut ModelContext<Self>,
     ) {
-        self.update_conversation_status_with_error_message(
+        self.update_conversation_status_with_error(
             terminal_surface_id,
             conversation_id,
             status,
@@ -1222,21 +1222,16 @@ impl BlocklistAIHistoryModel {
         );
     }
 
-    pub fn update_conversation_status_with_error_message(
+    pub fn update_conversation_status_with_error(
         &mut self,
         terminal_surface_id: EntityId,
         conversation_id: AIConversationId,
         status: ConversationStatus,
-        error_message: Option<String>,
+        error: Option<RenderableAIError>,
         ctx: &mut ModelContext<Self>,
     ) {
         if let Some(conversation) = self.conversations_by_id.get_mut(&conversation_id) {
-            conversation.update_status_with_error_message(
-                status,
-                error_message,
-                terminal_surface_id,
-                ctx,
-            );
+            conversation.update_status_with_error(status, error, terminal_surface_id, ctx);
         }
     }
 

--- a/app/src/ai/blocklist/local_agent_task_sync_model.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model.rs
@@ -395,8 +395,10 @@ fn map_conversation_status(
         // can't clear it later, so a "reconnecting" note would linger after resume.
         ConversationStatus::TransientError => (AgentTaskState::InProgress, None),
         ConversationStatus::Error => {
-            // Extract the specific RenderableAIError from the last exchange to
-            // classify ERROR vs FAILED and provide a PlatformErrorCode.
+            // Extract the specific RenderableAIError to classify ERROR vs FAILED
+            // and provide a PlatformErrorCode. Prefer the last exchange's error;
+            // fall back to the conversation's out-of-band `status_error` (set when
+            // the failure had no stream/exchange to attach to, e.g. shell exit).
             let renderable_error = conversation
                 .root_task_exchanges()
                 .last()
@@ -409,11 +411,9 @@ fn map_conversation_status(
                     } else {
                         None
                     }
-                });
-            task_update_for_conversation_error(
-                renderable_error,
-                conversation.status_error_message(),
-            )
+                })
+                .or_else(|| conversation.status_error());
+            task_update_for_conversation_error(renderable_error)
         }
         ConversationStatus::Cancelled => (
             AgentTaskState::Cancelled,
@@ -432,25 +432,18 @@ fn map_conversation_status(
 /// surface as `TransientError`, so an `Error` status is always terminal here — the
 /// `will_attempt_resume` rendering hint is deliberately ignored.
 ///
-/// When no structured exchange error is available, falls back to `status_error_message`
-/// so that the real failure reason is visible rather than the generic
-/// "Agent encountered an error" text. This covers pre-spawn failures (quota check
-/// before any stream) where the exchange is never populated.
+/// Every error-setting path records a structured `RenderableAIError` (on the last
+/// exchange or via the conversation's `status_error`), so the `None` arm is only a
+/// defensive fallback for an `Error` status set without one.
 fn task_update_for_conversation_error(
     error: Option<&RenderableAIError>,
-    status_error_message: Option<&str>,
 ) -> (AgentTaskState, Option<TaskStatusUpdate>) {
     match error {
         Some(error) => classify_renderable_error(error),
-        // No structured error on the last exchange (e.g. the status was set
-        // directly out-of-band). Surface the conversation-level message when
-        // present so the run reports why it failed instead of a generic note.
         None => (
             AgentTaskState::Error,
             Some(TaskStatusUpdate::message(
-                status_error_message
-                    .unwrap_or("Agent encountered an error")
-                    .to_string(),
+                "Agent encountered an error".to_string(),
             )),
         ),
     }

--- a/app/src/ai/blocklist/local_agent_task_sync_model.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model.rs
@@ -395,7 +395,10 @@ fn map_conversation_status(
                         None
                     }
                 });
-            task_update_for_conversation_error(renderable_error)
+            task_update_for_conversation_error(
+                renderable_error,
+                conversation.status_error_message(),
+            )
         }
         ConversationStatus::Cancelled => (
             AgentTaskState::Cancelled,
@@ -415,12 +418,18 @@ fn map_conversation_status(
 /// `will_attempt_resume` rendering hint is deliberately ignored.
 fn task_update_for_conversation_error(
     error: Option<&RenderableAIError>,
+    status_error_message: Option<&str>,
 ) -> (AgentTaskState, Option<TaskStatusUpdate>) {
     match error {
         Some(error) => classify_renderable_error(error),
+        // No structured error on the last exchange (e.g. the status was set
+        // directly out-of-band). Surface the conversation-level message when
+        // present so the run reports why it failed instead of a generic note.
         None => (
             AgentTaskState::Error,
-            Some(TaskStatusUpdate::message("Agent encountered an error")),
+            Some(TaskStatusUpdate::message(
+                status_error_message.unwrap_or("Agent encountered an error"),
+            )),
         ),
     }
 }
@@ -507,6 +516,13 @@ pub(crate) fn classify_renderable_error(
                 )
             }
         }
+        RenderableAIError::AgentExitedShell => (
+            AgentTaskState::Failed,
+            Some(TaskStatusUpdate::with_error_code(
+                error.to_string(),
+                PlatformErrorCode::InvalidRequest,
+            )),
+        ),
     }
 }
 

--- a/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
@@ -162,6 +162,16 @@ fn transient_network_error_is_error_with_internal_and_debug_details() {
     );
 }
 
+#[test]
+fn agent_exited_shell_is_failed_with_invalid_request() {
+    assert_update(
+        classify_renderable_error(&RenderableAIError::AgentExitedShell),
+        AgentTaskState::Failed,
+        Some(PlatformErrorCode::InvalidRequest),
+        Some("shell exited"),
+    );
+}
+
 // --- map_conversation_status ---
 
 /// A yielded conversation must report `IN_PROGRESS` to the task service
@@ -302,6 +312,59 @@ fn map_conversation_status_error_without_exchange_error_is_generic() {
         None,
         Some("Agent encountered an error"),
     );
+}
+
+/// A shell-exit failure surfaced on the last exchange classifies as FAILED with
+/// the shell-exit message — the run must not report "Cancelled by user".
+#[test]
+fn map_conversation_status_error_classifies_agent_exited_shell() {
+    let mut conversation = AIConversation::new(false, false);
+    conversation.append_root_exchange_for_test(error_exchange(RenderableAIError::AgentExitedShell));
+    conversation.set_status_for_test(ConversationStatus::Error);
+    assert_update(
+        map_conversation_status(&conversation),
+        AgentTaskState::Failed,
+        Some(PlatformErrorCode::InvalidRequest),
+        Some("shell exited"),
+    );
+}
+
+/// When the terminal `Error` status carries a conversation-level message but no
+/// structured exchange error (the out-of-band fallback path), the mapping
+/// surfaces that message instead of the generic note.
+#[test]
+fn map_conversation_status_error_surfaces_status_error_message() {
+    App::test((), |mut app| async move {
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+
+        let conversation = AIConversation::new(false, false);
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+        history_model.update(&mut app, |model, ctx| {
+            let conv = model
+                .conversation_mut(&conversation_id)
+                .expect("conversation was just restored");
+            conv.update_status_with_error_message(
+                ConversationStatus::Error,
+                Some(RenderableAIError::AGENT_EXITED_SHELL_MESSAGE.to_string()),
+                terminal_view_id,
+                ctx,
+            );
+        });
+
+        history_model.read(&app, |model, _| {
+            let conv = model.conversation(&conversation_id).unwrap();
+            assert_update(
+                map_conversation_status(conv),
+                AgentTaskState::Error,
+                None,
+                Some("shell exited"),
+            );
+        });
+    });
 }
 
 // --- map_cli_session_status ---

--- a/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
@@ -329,11 +329,11 @@ fn map_conversation_status_error_classifies_agent_exited_shell() {
     );
 }
 
-/// When the terminal `Error` status carries a conversation-level message but no
-/// structured exchange error (the out-of-band fallback path), the mapping
-/// surfaces that message instead of the generic note.
+/// Driving the real `update_status_with_error` setter (via the history model)
+/// records the structured error so `map_conversation_status` classifies it —
+/// here a shell-exit failure reports FAILED with the shell-exit message.
 #[test]
-fn map_conversation_status_error_surfaces_status_error_message() {
+fn map_conversation_status_error_classifies_status_error_via_setter() {
     App::test((), |mut app| async move {
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
 
@@ -347,9 +347,9 @@ fn map_conversation_status_error_surfaces_status_error_message() {
             let conv = model
                 .conversation_mut(&conversation_id)
                 .expect("conversation was just restored");
-            conv.update_status_with_error_message(
+            conv.update_status_with_error(
                 ConversationStatus::Error,
-                Some(RenderableAIError::AGENT_EXITED_SHELL_MESSAGE.to_string()),
+                Some(RenderableAIError::AgentExitedShell),
                 terminal_view_id,
                 ctx,
             );
@@ -359,29 +359,45 @@ fn map_conversation_status_error_surfaces_status_error_message() {
             let conv = model.conversation(&conversation_id).unwrap();
             assert_update(
                 map_conversation_status(conv),
-                AgentTaskState::Error,
-                None,
+                AgentTaskState::Failed,
+                Some(PlatformErrorCode::InvalidRequest),
                 Some("shell exited"),
             );
         });
     });
 }
 
-/// When the conversation has an `Error` status with no exchange error but a
-/// `status_error_message` (e.g. from a pre-spawn quota failure where no stream
-/// arrives), the real message is used instead of the generic fallback.
+/// An out-of-band `status_error` with `is_user_error: false` (e.g. a child-launch
+/// or skill-resolution failure) classifies as ERROR and surfaces its message.
 #[test]
-fn map_conversation_status_error_uses_status_error_message_when_no_exchange_error() {
+fn map_conversation_status_error_classifies_status_error_other_as_error() {
     let mut conversation = AIConversation::new(false, false);
     conversation.set_status_for_test(ConversationStatus::Error);
-    conversation.set_status_error_message_for_test(Some(
-        "Out of credits. Upgrade your Warp plan to continue running cloud agents.".into(),
-    ));
+    conversation.set_status_error_for_test(Some(RenderableAIError::other(
+        "Out of credits. Upgrade your Warp plan to continue running cloud agents.",
+        false,
+    )));
     assert_update(
         map_conversation_status(&conversation),
         AgentTaskState::Error,
-        None,
+        Some(PlatformErrorCode::InternalError),
         Some("Out of credits"),
+    );
+}
+
+/// An out-of-band `status_error` with no exchange (the shell-exit-with-no-stream
+/// path) classifies via the structured error — FAILED with the shell-exit code —
+/// not the generic ERROR fallback.
+#[test]
+fn map_conversation_status_error_classifies_status_error() {
+    let mut conversation = AIConversation::new(false, false);
+    conversation.set_status_for_test(ConversationStatus::Error);
+    conversation.set_status_error_for_test(Some(RenderableAIError::AgentExitedShell));
+    assert_update(
+        map_conversation_status(&conversation),
+        AgentTaskState::Failed,
+        Some(PlatformErrorCode::InvalidRequest),
+        Some("shell exited"),
     );
 }
 

--- a/app/src/pane_group/child_agent/mod.rs
+++ b/app/src/pane_group/child_agent/mod.rs
@@ -9,6 +9,7 @@ use warp_cli::agent::Harness;
 use warpui::{EntityId, SingletonEntity, ViewContext, ViewHandle};
 
 use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
+use crate::ai::agent::RenderableAIError;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::attachment_utils::attachments_download_dir;
 use crate::ai::blocklist::agent_view::AgentViewEntryOrigin;
@@ -267,11 +268,11 @@ pub(crate) fn create_error_child_agent_conversation(
     }
 
     BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
-        history_model.update_conversation_status_with_error_message(
+        history_model.update_conversation_status_with_error(
             terminal_view_id,
             conversation_id,
             ConversationStatus::Error,
-            Some(error_message),
+            Some(RenderableAIError::other(error_message, false)),
             ctx,
         );
     });

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -23,7 +23,7 @@ use super::{
 };
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
-use crate::ai::agent::StartAgentExecutionMode;
+use crate::ai::agent::{RenderableAIError, StartAgentExecutionMode};
 use crate::ai::ambient_agents::task::{normalize_orchestrator_agent_name, HarnessConfig};
 use crate::ai::ambient_agents::{AgentConfigSnapshot, AmbientAgentTaskId};
 use crate::ai::blocklist::agent_view::{AgentViewControllerEvent, AgentViewEntryOrigin};
@@ -2005,11 +2005,11 @@ fn launch_remote_child(
                 unresolved_references.join(", ")
             );
             BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
-                history_model.update_conversation_status_with_error_message(
+                history_model.update_conversation_status_with_error(
                     terminal_view_id,
                     conversation_id,
                     ConversationStatus::Error,
-                    Some(error_message),
+                    Some(RenderableAIError::other(error_message, false)),
                     ctx,
                 );
             });

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -11195,8 +11195,13 @@ impl TerminalView {
         ctx.notify();
     }
 
-    /// Sends telemetry if an AI-requested command caused the shell to exit.
-    fn maybe_send_agent_exited_shell_telemetry(&self, ctx: &mut ViewContext<Self>) {
+    /// Sends telemetry if an AI-requested command caused the shell to exit, and
+    /// returns the conversation that issued that command so the caller can
+    /// finalize it as a shell-exit failure.
+    fn maybe_send_agent_exited_shell_telemetry(
+        &self,
+        ctx: &mut ViewContext<Self>,
+    ) -> Option<AIConversationId> {
         let model = self.model.lock();
         let block_list = model.block_list();
         let blocks = block_list.blocks();
@@ -11218,29 +11223,29 @@ impl TerminalView {
                         .get(prev_idx)
                         .filter(|b| b.requested_command_action_id().is_some())
                 })
-            });
+            })?;
 
-        if let Some(block) = agent_block {
-            let mut command = block.command_to_string();
-            redact_secrets(&mut command);
+        let mut command = agent_block.command_to_string();
+        redact_secrets(&mut command);
 
-            let server_output_id = block.ai_conversation_id().and_then(|conversation_id| {
-                BlocklistAIHistoryModel::as_ref(ctx)
-                    .conversation(&conversation_id)
-                    .and_then(|conversation| {
-                        conversation
-                            .latest_exchange()
-                            .and_then(|e| e.output_status.server_output_id())
-                    })
-            });
-            send_telemetry_from_ctx!(
-                TelemetryEvent::AgentExitedShellProcess {
-                    command,
-                    server_output_id,
-                },
-                ctx
-            );
-        }
+        let conversation_id = agent_block.ai_conversation_id();
+        let server_output_id = conversation_id.and_then(|conversation_id| {
+            BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(&conversation_id)
+                .and_then(|conversation| {
+                    conversation
+                        .latest_exchange()
+                        .and_then(|e| e.output_status.server_output_id())
+                })
+        });
+        send_telemetry_from_ctx!(
+            TelemetryEvent::AgentExitedShellProcess {
+                command,
+                server_output_id,
+            },
+            ctx
+        );
+        conversation_id
     }
 
     /// Updates the back button's state and label. For child agents the
@@ -11609,7 +11614,17 @@ impl TerminalView {
             }
             ModelEvent::Exit { reason } => {
                 if !self.manual_pty_shutdown_requested {
-                    self.maybe_send_agent_exited_shell_telemetry(ctx);
+                    if let Some(conversation_id) = self.maybe_send_agent_exited_shell_telemetry(ctx)
+                    {
+                        // The agent's command caused the shell to exit. Finalize the
+                        // conversation as a failure (with a message) before the pane is
+                        // torn down, so the Oz run reports the failure instead of
+                        // "Cancelled by user" (which the pane-close cancellation would
+                        // otherwise produce).
+                        self.ai_controller.update(ctx, |controller, ctx| {
+                            controller.fail_conversation_due_to_shell_exit(conversation_id, ctx);
+                        });
+                    }
                 }
 
                 // If the pty spawn has failed, we've already inserted a banner.

--- a/app/src/terminal/view/ambient_agent/block/entry.rs
+++ b/app/src/terminal/view/ambient_agent/block/entry.rs
@@ -84,7 +84,7 @@ impl AmbientAgentEntryBlock {
 impl AmbientAgentEntryBlock {
     fn handle_ambient_agent_view_model_event(
         &mut self,
-            _: ModelHandle<AmbientAgentViewModel>,
+        _: ModelHandle<AmbientAgentViewModel>,
         event: &AmbientAgentViewModelEvent,
         ctx: &mut ViewContext<Self>,
     ) {

--- a/app/src/terminal/view/ambient_agent/block/entry.rs
+++ b/app/src/terminal/view/ambient_agent/block/entry.rs
@@ -84,7 +84,7 @@ impl AmbientAgentEntryBlock {
 impl AmbientAgentEntryBlock {
     fn handle_ambient_agent_view_model_event(
         &mut self,
-        _: ModelHandle<AmbientAgentViewModel>,
+            _: ModelHandle<AmbientAgentViewModel>,
         event: &AmbientAgentViewModelEvent,
         ctx: &mut ViewContext<Self>,
     ) {

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -20,7 +20,7 @@ use super::loading_screen::{
 };
 use super::{AmbientAgentEntryBlock, AmbientAgentViewModel, AmbientAgentViewModelEvent};
 use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
-use crate::ai::agent::display_user_query_with_mode;
+use crate::ai::agent::{display_user_query_with_mode, RenderableAIError};
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::agent_sdk::driver::harness::auth_check_command_for;
 use crate::ai::ambient_agents::telemetry::{CloudAgentTelemetryEvent, CloudModeEntryPoint};
@@ -62,7 +62,7 @@ impl TerminalView {
     fn update_active_ambient_agent_conversation_status(
         &self,
         status: ConversationStatus,
-        error_message: Option<String>,
+        error: Option<RenderableAIError>,
         ctx: &mut ViewContext<Self>,
     ) {
         let Some(conversation_id) = self.active_ambient_agent_conversation_id(ctx) else {
@@ -70,11 +70,11 @@ impl TerminalView {
         };
 
         BlocklistAIHistoryModel::handle(ctx).update(ctx, |history_model, ctx| {
-            history_model.update_conversation_status_with_error_message(
+            history_model.update_conversation_status_with_error(
                 self.id(),
                 conversation_id,
                 status,
-                error_message,
+                error,
                 ctx,
             );
         });
@@ -259,7 +259,7 @@ impl TerminalView {
                 self.pending_cloud_followup_task_id = None;
                 self.update_active_ambient_agent_conversation_status(
                     ConversationStatus::Error,
-                    Some(error_message.clone()),
+                    Some(RenderableAIError::other(error_message.clone(), false)),
                     ctx,
                 );
 


### PR DESCRIPTION
## Description
When an agent-issued command caused the shell process to exit mid-run (e.g. it ran `exit`, or a failing command after `set -e`), the Oz / ambient agent run was reported as **"Cancelled by user"** instead of a failure. The shell exit closed the pane, which cancelled the conversation with a `ManuallyCancelled` reason, so the terminal status was misclassified.

This PR makes a shell exit during an in-flight run a terminal **failure** with a clear explanation, and refactors the status/cancellation plumbing it touched:

- **Shell-exit failure reporting**: added `RenderableAIError::AgentExitedShell` and `CancellationReason::AgentExitedShell`. The terminal view's shell-exit handler now finalizes the conversation as a failure (finishing any in-flight stream with the error, cancelling pending actions, and otherwise setting a terminal `Error` carrying the structured error) so the run reports FAILED with a message instead of "Cancelled by user".
- **Exhaustive cancellation outcomes**: replaced the confusing `should_preserve_in_progress_status` boolean with `CancellationReason::conversation_outcome()` → `CancellationOutcome { KeepInProgress, Succeeded, Cancelled, FinalizedExternally }`, mapped exhaustively (no wildcard). This also fixes an optimistic-completion case that could land on `Cancelled` instead of `Success`.
- **Single structured status error**: replaced the conversation's `status_error_message: Option<String>` with `status_error: Option<RenderableAIError>` — one source of truth for both the message and the FAILED-vs-ERROR classification. Both status reporters (the Oz task sync model and the ambient SDK driver) read it, so the driver's terminal write no longer downgrades the failure to a generic ERROR. Added `RenderableAIError::other(message, is_user_error)`; the sites that set an `Error` from a bare string (child-launch and skill-resolution failures, cloud-mode `Failed`) now go through it.

## Linked Issue

https://linear.app/warpdotdev/issue/REMOTE-1987/cloud-agent-session-cancelled-mid-turn-with-inaccurate-cancelled-by

## Testing
- Added/updated unit tests:
  - `map_conversation_status`: `AgentExitedShell` and an out-of-band `status_error` classify as FAILED (`InvalidRequest`); an `is_user_error: false` `Other` classifies as ERROR; end-to-end-via-setter coverage.
  - Exhaustive `CancellationReason::conversation_outcome()` mapping + an optimistic-completion regression test (in-flight stream ends `Success`, not `Cancelled`).
- Reproduced manually with a local Oz run whose agent command exits the shell: the ambient task now ends as **Failed** (`is_user_error=true`) with the shell-exit message, from both the sync-model and SDK-driver paths.
- `cargo check -p warp --tests`, `cargo nextest run -p warp` (affected suites), `cargo fmt -p warp`, and `cargo clippy -p warp --lib --tests -- -D warnings` all pass.

- [x] I have manually tested my changes locally

Before changes, this would repro the oz run being marked canceled by user. After changes, it's failed with error message:
<img width="451" height="509" alt="Screenshot 2026-06-29 at 5 46 09 PM" src="https://github.com/user-attachments/assets/f6df4574-c82f-4afc-bad1-957541211269" />
<img width="1011" height="369" alt="Screenshot 2026-06-29 at 5 46 15 PM" src="https://github.com/user-attachments/assets/0d6e5aee-f8bd-4b94-8dd3-b9859937f970" />


## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

---
[Oz conversation](https://staging.warp.dev/conversation/f2ceb411-b550-4000-916f-ce8401e43eab)

Plans:
- [Report Oz run failure (not "Cancelled by user") when the agent's command exits the shell](https://staging.warp.dev/drive/notebook/CEZa2KpS7oHsBem5kbqITM)
- [Replace should_preserve_in_progress_status with an exhaustive CancellationReason → outcome mapping](https://staging.warp.dev/drive/notebook/wFld6yekfbHauoP6j6mNOr)

CHANGELOG-BUG-FIX: Fixed local Oz/ambient agent runs reporting "Cancelled by user" when an agent-issued command exited the shell; the run now reports as failed with an explanation.

Co-Authored-By: Oz <oz-agent@warp.dev>
