### PR TITLE
[NEW] tab_config windows maximum height set to window height and scro…

### DIFF
--- a/app/src/menu.rs
+++ b/app/src/menu.rs
@@ -37,7 +37,7 @@ use crate::util::time_format::format_approx_duration_from_now_sentence_case;
 pub const CHEVRON_RIGHT_ALIGN_SVG_PATH: &str = "bundled/svg/chevron-right-align.svg";
 
 const SUBMENU_OVERLAP: f32 = 8.;
-const MENU_VERTICAL_PADDING: f32 = 9.;
+pub(crate) const MENU_VERTICAL_PADDING: f32 = 9.;
 pub const MENU_ITEM_VERTICAL_PADDING: f32 = 5.;
 pub const MENU_ITEM_HORIZONTAL_PADDING: f32 = 14.;
 pub const SEPARATOR_VERTICAL_MARGIN: f32 = 4.;

--- a/app/src/menu.rs
+++ b/app/src/menu.rs
@@ -2388,6 +2388,16 @@ impl<A: Action + Clone> Menu<A> {
         self.menu.with_height(height);
     }
 
+    #[cfg(test)]
+    pub fn height(&self) -> f32 {
+        self.menu.height
+    }
+
+    #[cfg(test)]
+    pub fn is_scrollable(&self) -> bool {
+        matches!(self.menu.menu_variant, MenuVariant::Scrollable(_))
+    }
+
     pub fn set_items(
         &mut self,
         items: impl IntoIterator<Item = MenuItem<A>>,

--- a/app/src/menu.rs
+++ b/app/src/menu.rs
@@ -2388,16 +2388,6 @@ impl<A: Action + Clone> Menu<A> {
         self.menu.with_height(height);
     }
 
-    #[cfg(test)]
-    pub fn height(&self) -> f32 {
-        self.menu.height
-    }
-
-    #[cfg(test)]
-    pub fn is_scrollable(&self) -> bool {
-        matches!(self.menu.menu_variant, MenuVariant::Scrollable(_))
-    }
-
     pub fn set_items(
         &mut self,
         items: impl IntoIterator<Item = MenuItem<A>>,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -605,6 +605,7 @@ const TOGGLE_RESOURCE_CENTER_KEYBINDING_NAME: &str = "workspace:toggle_resource_
 const NEW_SESSION_SIDECAR_POSITION_ID: &str = "new_session_sidecar";
 const NEW_SESSION_MENU_WIDTH: f32 = 300.;
 const NEW_SESSION_MENU_WINDOW_MARGIN: f32 = 8.;
+const NEW_SESSION_MENU_VERTICAL_BUTTON_OFFSET_Y: f32 = 4.;
 const NEW_SESSION_SIDECAR_WIDTH: f32 = 300.;
 
 /// Shared position ID for the move-to-group sidecar overlay, used by both the
@@ -6724,7 +6725,7 @@ impl Workspace {
         ctx: &mut ViewContext<Self>,
     ) {
         let menu_items = self.unified_new_session_menu_items(ctx);
-        let menu_height = Self::new_session_menu_max_height(anchor, ctx);
+        let menu_height = self.new_session_menu_max_height(anchor, ctx);
         ctx.update_view(&self.new_session_dropdown_menu, |context_menu, view_ctx| {
             // Match the Figma mock width (OptionMenuItem component is 268px).
             context_menu.set_width(268.);
@@ -6744,13 +6745,42 @@ impl Workspace {
         ctx.notify();
     }
 
-    fn new_session_menu_max_height(anchor: NewSessionMenuAnchor, ctx: &ViewContext<Self>) -> f32 {
+    fn new_session_menu_max_height(
+        &self,
+        anchor: NewSessionMenuAnchor,
+        ctx: &ViewContext<Self>,
+    ) -> f32 {
         let Some(window) = ctx.windows().platform_window(ctx.window_id()) else {
             return 480.;
         };
-        let available_height =
-            window.size().y() - anchor.position().y() - NEW_SESSION_MENU_WINDOW_MARGIN;
+        let anchor_y = self.new_session_menu_height_anchor_y(anchor, ctx);
+        let available_height = window.size().y() - anchor_y - NEW_SESSION_MENU_WINDOW_MARGIN;
         available_height.max(120.)
+    }
+
+    fn new_session_menu_height_anchor_y(
+        &self,
+        anchor: NewSessionMenuAnchor,
+        ctx: &ViewContext<Self>,
+    ) -> f32 {
+        let use_vertical_tabs =
+            FeatureFlag::VerticalTabs.is_enabled() && *TabSettings::as_ref(ctx).use_vertical_tabs;
+        match anchor {
+            NewSessionMenuAnchor::AddTabButton(position)
+                if use_vertical_tabs && self.vertical_tabs_panel_open =>
+            {
+                ctx.element_position_by_id_at_last_frame(
+                    self.window_id,
+                    vertical_tabs::VERTICAL_TABS_ADD_TAB_POSITION_ID,
+                )
+                .map(|position| {
+                    position.lower_left().y() + NEW_SESSION_MENU_VERTICAL_BUTTON_OFFSET_Y
+                })
+                .unwrap_or_else(|| position.y().max(TOTAL_TAB_BAR_HEIGHT))
+            }
+            NewSessionMenuAnchor::AddTabButton(position)
+            | NewSessionMenuAnchor::Pointer(position) => position.y(),
+        }
     }
 
     pub fn open_new_session_dropdown_menu(
@@ -26557,7 +26587,7 @@ impl View for Workspace {
                         ChildView::new(&self.new_session_dropdown_menu).finish(),
                         OffsetPositioning::offset_from_save_position_element(
                             vertical_tabs::VERTICAL_TABS_ADD_TAB_POSITION_ID,
-                            vec2f(0., 4.),
+                            vec2f(0., NEW_SESSION_MENU_VERTICAL_BUTTON_OFFSET_Y),
                             PositionedElementOffsetBounds::WindowBySize,
                             anchor,
                             child_anchor,

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -277,7 +277,9 @@ use crate::env_vars::CloudEnvVarCollection;
 use crate::experiments::{BlockOnboarding, Experiment};
 use crate::launch_configs::launch_config::WindowTemplate;
 use crate::launch_configs::save_modal::{LaunchConfigModalEvent, LaunchConfigSaveModal};
-use crate::menu::{Event as MenuEvent, Menu, MenuItem, MenuItemFields, MenuSelectionSource};
+use crate::menu::{
+    Event as MenuEvent, Menu, MenuItem, MenuItemFields, MenuSelectionSource, MenuVariant,
+};
 use crate::modal::{Modal, ModalEvent, ModalViewState};
 use crate::network::{NetworkStatus, NetworkStatusEvent};
 use crate::notebooks::manager::{NotebookManager, NotebookSource};
@@ -601,6 +603,8 @@ const TOGGLE_RESOURCE_CENTER_KEYBINDING_NAME: &str = "workspace:toggle_resource_
 /// Shared position ID for the new-session sidecar overlay. Used for both the
 /// `SavePosition` wrapper and the safe-zone rect lookup.
 const NEW_SESSION_SIDECAR_POSITION_ID: &str = "new_session_sidecar";
+const NEW_SESSION_MENU_WIDTH: f32 = 300.;
+const NEW_SESSION_MENU_WINDOW_MARGIN: f32 = 8.;
 const NEW_SESSION_SIDECAR_WIDTH: f32 = 300.;
 
 /// Shared position ID for the move-to-group sidecar overlay, used by both the
@@ -1974,12 +1978,12 @@ impl Workspace {
         // don't. Going forward we may want to enhance the menu to allow for a
         // `max_width` and `min_width` instead, so we can allow the menu to
         // grow as needed.
-        const NEW_SESSION_MENU_WIDTH: f32 = 300.;
         let new_session_menu = ctx.add_typed_action_view(|ctx| {
             if FeatureFlag::ShellSelector.is_enabled() {
                 let theme = Appearance::as_ref(ctx).theme();
                 Menu::new()
                     .with_width(NEW_SESSION_MENU_WIDTH)
+                    .with_menu_variant(MenuVariant::scrollable())
                     .with_border(Border::all(1.).with_border_color(theme.outline().into()))
                     .with_drop_shadow()
                     .with_safe_triangle()
@@ -1987,6 +1991,7 @@ impl Workspace {
                     .prevent_interaction_with_other_elements()
             } else {
                 Menu::new()
+                    .with_menu_variant(MenuVariant::scrollable())
                     .with_safe_triangle()
                     .with_ignore_hover_when_covered()
                     .prevent_interaction_with_other_elements()
@@ -2000,7 +2005,7 @@ impl Workspace {
             let mut menu = Menu::new()
                 .without_item_action_dispatch()
                 .with_width(NEW_SESSION_SIDECAR_WIDTH)
-                .with_menu_variant(crate::menu::MenuVariant::scrollable());
+                .with_menu_variant(MenuVariant::scrollable());
             menu.set_height(400.);
             menu
         });
@@ -2014,7 +2019,7 @@ impl Workspace {
             let mut menu = Menu::new()
                 .with_width(MOVE_TO_GROUP_SIDECAR_WIDTH)
                 .with_drop_shadow()
-                .with_menu_variant(crate::menu::MenuVariant::scrollable());
+                .with_menu_variant(MenuVariant::scrollable());
             menu.set_height(300.);
             menu
         });
@@ -6719,9 +6724,11 @@ impl Workspace {
         ctx: &mut ViewContext<Self>,
     ) {
         let menu_items = self.unified_new_session_menu_items(ctx);
+        let menu_height = Self::new_session_menu_max_height(anchor, ctx);
         ctx.update_view(&self.new_session_dropdown_menu, |context_menu, view_ctx| {
             // Match the Figma mock width (OptionMenuItem component is 268px).
             context_menu.set_width(268.);
+            context_menu.set_height(menu_height);
             context_menu.set_items(menu_items, view_ctx);
             match open_source {
                 TabConfigsMenuOpenSource::KeyboardShortcut => {
@@ -6735,6 +6742,15 @@ impl Workspace {
         self.show_new_session_dropdown_menu = Some(anchor);
         ctx.focus(&self.new_session_dropdown_menu);
         ctx.notify();
+    }
+
+    fn new_session_menu_max_height(anchor: NewSessionMenuAnchor, ctx: &ViewContext<Self>) -> f32 {
+        let Some(window) = ctx.windows().platform_window(ctx.window_id()) else {
+            return 480.;
+        };
+        let available_height =
+            window.size().y() - anchor.position().y() - NEW_SESSION_MENU_WINDOW_MARGIN;
+        available_height.max(120.)
     }
 
     pub fn open_new_session_dropdown_menu(

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -605,6 +605,8 @@ const TOGGLE_RESOURCE_CENTER_KEYBINDING_NAME: &str = "workspace:toggle_resource_
 const NEW_SESSION_SIDECAR_POSITION_ID: &str = "new_session_sidecar";
 const NEW_SESSION_MENU_WIDTH: f32 = 300.;
 const NEW_SESSION_MENU_WINDOW_MARGIN: f32 = 8.;
+const NEW_SESSION_MENU_FALLBACK_MAX_HEIGHT: f32 = 480.;
+const NEW_SESSION_MENU_MIN_HEIGHT: f32 = 120.;
 const NEW_SESSION_MENU_VERTICAL_BUTTON_OFFSET_Y: f32 = 4.;
 const NEW_SESSION_SIDECAR_WIDTH: f32 = 300.;
 
@@ -6751,11 +6753,11 @@ impl Workspace {
         ctx: &ViewContext<Self>,
     ) -> f32 {
         let Some(window) = ctx.windows().platform_window(ctx.window_id()) else {
-            return 480.;
+            return NEW_SESSION_MENU_FALLBACK_MAX_HEIGHT;
         };
         let anchor_y = self.new_session_menu_height_anchor_y(anchor, ctx);
         let available_height = window.size().y() - anchor_y - NEW_SESSION_MENU_WINDOW_MARGIN;
-        available_height.max(120.)
+        available_height.max(NEW_SESSION_MENU_MIN_HEIGHT)
     }
 
     fn new_session_menu_height_anchor_y(

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -279,6 +279,7 @@ use crate::launch_configs::launch_config::WindowTemplate;
 use crate::launch_configs::save_modal::{LaunchConfigModalEvent, LaunchConfigSaveModal};
 use crate::menu::{
     Event as MenuEvent, Menu, MenuItem, MenuItemFields, MenuSelectionSource, MenuVariant,
+    MENU_VERTICAL_PADDING,
 };
 use crate::modal::{Modal, ModalEvent, ModalViewState};
 use crate::network::{NetworkStatus, NetworkStatusEvent};
@@ -608,6 +609,9 @@ const NEW_SESSION_MENU_WINDOW_MARGIN: f32 = 8.;
 const NEW_SESSION_MENU_FALLBACK_MAX_HEIGHT: f32 = 480.;
 const NEW_SESSION_MENU_MIN_HEIGHT: f32 = 120.;
 const NEW_SESSION_MENU_VERTICAL_BUTTON_OFFSET_Y: f32 = 4.;
+const NEW_SESSION_MENU_BORDER_WIDTH: f32 = 1.;
+const NEW_SESSION_MENU_CHROME_HEIGHT: f32 =
+    MENU_VERTICAL_PADDING * 2. + NEW_SESSION_MENU_BORDER_WIDTH * 2.;
 const NEW_SESSION_SIDECAR_WIDTH: f32 = 300.;
 
 /// Shared position ID for the move-to-group sidecar overlay, used by both the
@@ -6756,7 +6760,10 @@ impl Workspace {
             return NEW_SESSION_MENU_FALLBACK_MAX_HEIGHT;
         };
         let anchor_y = self.new_session_menu_height_anchor_y(anchor, ctx);
-        let available_height = window.size().y() - anchor_y - NEW_SESSION_MENU_WINDOW_MARGIN;
+        let available_height = window.size().y()
+            - anchor_y
+            - NEW_SESSION_MENU_WINDOW_MARGIN
+            - NEW_SESSION_MENU_CHROME_HEIGHT;
         available_height.max(NEW_SESSION_MENU_MIN_HEIGHT)
     }
 

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -2972,7 +2972,8 @@ fn test_new_session_menu_is_capped_to_window_height() {
             );
 
             let expected_height =
-                (window_height - NEW_SESSION_MENU_WINDOW_MARGIN).max(NEW_SESSION_MENU_MIN_HEIGHT);
+                (window_height - NEW_SESSION_MENU_WINDOW_MARGIN - NEW_SESSION_MENU_CHROME_HEIGHT)
+                    .max(NEW_SESSION_MENU_MIN_HEIGHT);
             let menu_height = workspace.new_session_menu_max_height(
                 crate::workspace::action::NewSessionMenuAnchor::AddTabButton(Vector2F::zero()),
                 ctx,

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -2950,6 +2950,39 @@ fn test_pointer_opened_tab_configs_menu_does_not_select_top_item() {
 }
 
 #[test]
+fn test_new_session_menu_is_scrollable_and_capped_to_window_height() {
+    let _tab_configs_guard = FeatureFlag::TabConfigs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+
+        workspace.update(&mut app, |workspace, ctx| {
+            let window_height = ctx
+                .windows()
+                .platform_window(ctx.window_id())
+                .expect("expected workspace window")
+                .size()
+                .y();
+
+            workspace.open_new_session_dropdown_menu(
+                crate::workspace::action::NewSessionMenuAnchor::AddTabButton(Vector2F::zero()),
+                ctx,
+            );
+
+            let expected_height = (window_height - NEW_SESSION_MENU_WINDOW_MARGIN).max(120.);
+            let menu_height = workspace.new_session_dropdown_menu.read(ctx, |menu, _| {
+                assert!(menu.is_scrollable());
+                menu.height()
+            });
+
+            assert!((menu_height - expected_height).abs() < f32::EPSILON);
+        });
+    });
+}
+
+#[test]
 fn test_open_tab_config_with_params_does_not_use_worktree_branch_as_implicit_title() {
     App::test((), |mut app| async move {
         initialize_app(&mut app);

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -2950,7 +2950,7 @@ fn test_pointer_opened_tab_configs_menu_does_not_select_top_item() {
 }
 
 #[test]
-fn test_new_session_menu_is_scrollable_and_capped_to_window_height() {
+fn test_new_session_menu_is_capped_to_window_height() {
     let _tab_configs_guard = FeatureFlag::TabConfigs.override_enabled(true);
 
     App::test((), |mut app| async move {
@@ -2971,13 +2971,20 @@ fn test_new_session_menu_is_scrollable_and_capped_to_window_height() {
                 ctx,
             );
 
-            let expected_height = (window_height - NEW_SESSION_MENU_WINDOW_MARGIN).max(120.);
-            let menu_height = workspace.new_session_dropdown_menu.read(ctx, |menu, _| {
-                assert!(menu.is_scrollable());
-                menu.height()
-            });
+            let expected_height =
+                (window_height - NEW_SESSION_MENU_WINDOW_MARGIN).max(NEW_SESSION_MENU_MIN_HEIGHT);
+            let menu_height = workspace.new_session_menu_max_height(
+                crate::workspace::action::NewSessionMenuAnchor::AddTabButton(Vector2F::zero()),
+                ctx,
+            );
 
             assert!((menu_height - expected_height).abs() < f32::EPSILON);
+
+            workspace.open_new_session_dropdown_menu(
+                crate::workspace::action::NewSessionMenuAnchor::AddTabButton(Vector2F::zero()),
+                ctx,
+            );
+            assert!(workspace.show_new_session_dropdown_menu.is_some());
         });
     });
 }


### PR DESCRIPTION

## Description
Makes the new session / tab configs menu height-constrained and scrollable. When users have many tab configs, the menu now caps itself to the available window height instead of extending below the terminal window, and the remaining items can be reached by scrolling.

## Linked Issue
Fixes #13223 

## Testing
- [x] I have manually tested my changes locally with ./script/run

Additional automated testing:
- `./script/format`
- `cargo test -p warp test_new_session_menu_is_scrollable_and_capped_to_window_height`
- `cargo test -p warp tab_configs_menu`
- `cargo run`

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed the tab configs menu overflowing past the terminal window when many tab configs are available.

### Demo

Attached is a short video demonstrating the proposed behavior and the user experience after this change.

https://github.com/user-attachments/assets/badabb0b-97d8-4af5-826d-dc5705b6bc29

