### PR TITLE
[VA] Wire up computer-use video recording

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -3095,7 +3095,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4430,7 +4430,7 @@ checksum = "6738d2e996274e499bc7b0d693c858b7720b9cd2543a0643a3087e6cb0a4fa16"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4735,7 +4735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7070,7 +7070,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7264,7 +7264,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9662,7 +9662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -10477,8 +10477,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -10497,7 +10497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10742,7 +10742,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11722,7 +11722,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11735,7 +11735,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11803,7 +11803,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 1.0.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13475,7 +13475,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15658,7 +15658,7 @@ dependencies = [
 [[package]]
 name = "warp_multi_agent_api"
 version = "0.0.0"
-source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=45f9b1342b256b20f716aede64dc1b46a639e5e6#45f9b1342b256b20f716aede64dc1b46a639e5e6"
+source = "git+https://github.com/warpdotdev/warp-proto-apis.git?rev=4de32f256901e34905817e5d88081130a54b6384#4de32f256901e34905817e5d88081130a54b6384"
 dependencies = [
  "prost",
  "prost-reflect",
@@ -16794,7 +16794,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -338,7 +338,7 @@ version-compare = "0.1"
 vte = { git = "https://github.com/warpdotdev/vte.git", rev = "4b399c87b63ba88f45709edaa6383fc519f6c900", default-features = false }
 walkdir = "2"
 warp-workflows = { git = "https://github.com/warpdotdev/workflows", rev = "793a98ddda6ef19682aed66364faebd2829f0e01" }
-warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "45f9b1342b256b20f716aede64dc1b46a639e5e6" }
+warp_multi_agent_api = { git = "https://github.com/warpdotdev/warp-proto-apis.git", rev = "4de32f256901e34905817e5d88081130a54b6384" }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3.69", features = [

--- a/app/src/ai/agent/api/convert_conversation.rs
+++ b/app/src/ai/agent/api/convert_conversation.rs
@@ -6,10 +6,12 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 
 use ai::agent::action_result::{
     AskUserQuestionAnswerItem, AskUserQuestionResult, FetchConversationResult, ReadSkillResult,
-    RequestComputerUseResult, SendMessageToAgentResult, StartAgentResult, StartAgentVersion,
+    RecordingStarted, RecordingStopped, RequestComputerUseResult, SendMessageToAgentResult,
+    StartAgentResult, StartAgentVersion, StartRecordingResult, StopRecordingResult,
     UseComputerResult,
 };
 use ai::skills::{ParsedSkill, SkillPathOrigin};
@@ -1665,6 +1667,86 @@ pub(crate) fn convert_tool_call_result_to_input(
                 context,
             })
         }
+        Some(ToolCallResultType::StartRecording(result)) => {
+            let start_result = match &result.result {
+                Some(api::start_recording_result::Result::Success(success)) => {
+                    StartRecordingResult::Success(RecordingStarted {
+                        recording_id: success.recording_id.clone(),
+                        started_at: success
+                            .started_at
+                            .as_ref()
+                            .map(proto_timestamp_to_system_time)
+                            .unwrap_or_else(SystemTime::now),
+                        width_px: success
+                            .settings
+                            .as_ref()
+                            .map(|s| s.width_px)
+                            .unwrap_or_default(),
+                        height_px: success
+                            .settings
+                            .as_ref()
+                            .map(|s| s.height_px)
+                            .unwrap_or_default(),
+                        frame_rate: success
+                            .settings
+                            .as_ref()
+                            .map(|s| s.frame_rate)
+                            .unwrap_or_default(),
+                        max_duration: success
+                            .limits
+                            .as_ref()
+                            .and_then(|l| l.max_duration.as_ref())
+                            .map(proto_duration_to_duration),
+                        max_size_bytes: success.limits.as_ref().map(|l| l.max_size_bytes),
+                    })
+                }
+                Some(api::start_recording_result::Result::Error(error)) => {
+                    StartRecordingResult::Error(error.message.clone())
+                }
+                None => StartRecordingResult::Cancelled,
+            };
+            Some(AIAgentInput::ActionResult {
+                result: AIAgentActionResult {
+                    id: tool_call_id.into(),
+                    task_id: task_id.clone(),
+                    result: AIAgentActionResultType::StartRecording(start_result),
+                },
+                context,
+            })
+        }
+        Some(ToolCallResultType::StopRecording(result)) => {
+            let stop_result = match &result.result {
+                Some(api::stop_recording_result::Result::Success(success)) => {
+                    StopRecordingResult::Success(RecordingStopped {
+                        artifact_uid: success.artifact_uid.clone(),
+                        duration: success
+                            .duration
+                            .as_ref()
+                            .map(proto_duration_to_duration)
+                            .unwrap_or_default(),
+                        width_px: success.width_px,
+                        height_px: success.height_px,
+                        size_bytes: success.size_bytes,
+                        completion_status: convert_recording_completion_status(
+                            success.completion_status,
+                        ),
+                        termination_reason: success.termination_reason.clone(),
+                    })
+                }
+                Some(api::stop_recording_result::Result::Error(error)) => {
+                    StopRecordingResult::Error(error.message.clone())
+                }
+                None => StopRecordingResult::Cancelled,
+            };
+            Some(AIAgentInput::ActionResult {
+                result: AIAgentActionResult {
+                    id: tool_call_id.into(),
+                    task_id: task_id.clone(),
+                    result: AIAgentActionResultType::StopRecording(stop_result),
+                },
+                context,
+            })
+        }
         // Deprecated/unused result types or absent result.
         Some(ToolCallResultType::SuggestCreatePlan(..))
         | Some(ToolCallResultType::SuggestPlan(..))
@@ -1673,6 +1755,23 @@ pub(crate) fn convert_tool_call_result_to_input(
             None
         }
         Some(ToolCallResultType::WaitForEvents(_)) => None,
+    }
+}
+
+fn proto_timestamp_to_system_time(ts: &prost_types::Timestamp) -> SystemTime {
+    SystemTime::UNIX_EPOCH + Duration::new(ts.seconds.max(0) as u64, ts.nanos.max(0) as u32)
+}
+
+fn proto_duration_to_duration(duration: &prost_types::Duration) -> Duration {
+    Duration::new(duration.seconds.max(0) as u64, duration.nanos.max(0) as u32)
+}
+
+fn convert_recording_completion_status(status: i32) -> computer_use::RecordingCompletionStatus {
+    match api::stop_recording_result::CompletionStatus::try_from(status) {
+        Ok(api::stop_recording_result::CompletionStatus::Complete) => {
+            computer_use::RecordingCompletionStatus::Completed
+        }
+        _ => computer_use::RecordingCompletionStatus::StoppedEarly,
     }
 }
 
@@ -1802,6 +1901,12 @@ fn create_cancelled_result_for_tool_call(
         }
         ToolType::RunAgents(_) => {
             AIAgentActionResultType::RunAgents(ai::agent::action_result::RunAgentsResult::Cancelled)
+        }
+        ToolType::StartRecording(_) => {
+            AIAgentActionResultType::StartRecording(StartRecordingResult::Cancelled)
+        }
+        ToolType::StopRecording(_) => {
+            AIAgentActionResultType::StopRecording(StopRecordingResult::Cancelled)
         }
         // These tools are deprecated.
         ToolType::SuggestCreatePlan(_) | ToolType::SuggestPlan(_) => return None,

--- a/app/src/ai/agent/api/convert_conversation.rs
+++ b/app/src/ai/agent/api/convert_conversation.rs
@@ -1687,17 +1687,6 @@ pub(crate) fn convert_tool_call_result_to_input(
                             .as_ref()
                             .map(|s| s.height_px)
                             .unwrap_or_default(),
-                        frame_rate: success
-                            .settings
-                            .as_ref()
-                            .map(|s| s.frame_rate)
-                            .unwrap_or_default(),
-                        max_duration: success
-                            .limits
-                            .as_ref()
-                            .and_then(|l| l.max_duration.as_ref())
-                            .map(proto_duration_to_duration),
-                        max_size_bytes: success.limits.as_ref().map(|l| l.max_size_bytes),
                     })
                 }
                 Some(api::start_recording_result::Result::Error(error)) => {

--- a/app/src/ai/agent/api/convert_from.rs
+++ b/app/src/ai/agent/api/convert_from.rs
@@ -771,6 +771,12 @@ impl ConvertAPIToolCallToAIAgentAction for api::message::ToolCall {
             api::message::tool_call::Tool::RequestComputerUse(request_computer_use) => {
                 create_standard_action(request_computer_use.into())
             }
+            api::message::tool_call::Tool::StartRecording(start_recording) => {
+                create_standard_action(start_recording.into())
+            }
+            api::message::tool_call::Tool::StopRecording(stop_recording) => {
+                create_standard_action(stop_recording.into())
+            }
             api::message::tool_call::Tool::Subagent(subagent) => {
                 use api::message::tool_call::subagent::conversation_search_metadata::Target;
                 use api::message::tool_call::subagent::Metadata;

--- a/app/src/ai/agent/api/convert_to.rs
+++ b/app/src/ai/agent/api/convert_to.rs
@@ -683,6 +683,12 @@ impl TryFrom<AIAgentActionResult> for api::request::input::user_inputs::user_inp
             AIAgentActionResultType::RequestComputerUse(request_computer_use_result) => {
                 Some(request_computer_use_result.try_into()?)
             }
+            AIAgentActionResultType::StartRecording(start_recording_result) => {
+                Some(start_recording_result.try_into()?)
+            }
+            AIAgentActionResultType::StopRecording(stop_recording_result) => {
+                Some(stop_recording_result.try_into()?)
+            }
             AIAgentActionResultType::FetchConversation(fetch_conversation_result) => {
                 Some(fetch_conversation_result.try_into()?)
             }

--- a/app/src/ai/agent/api/impl.rs
+++ b/app/src/ai/agent/api/impl.rs
@@ -252,7 +252,11 @@ fn get_supported_tools(params: &RequestParams) -> Vec<api::ToolType> {
 
     if FeatureFlag::AgentModeComputerUse.is_enabled() && params.computer_use_enabled {
         supported_tools.extend(&[api::ToolType::UseComputer]);
-        supported_tools.extend(&[api::ToolType::RequestComputerUse])
+        supported_tools.extend(&[api::ToolType::RequestComputerUse]);
+
+        if FeatureFlag::VideoRecording.is_enabled() {
+            supported_tools.extend(&[api::ToolType::StartRecording, api::ToolType::StopRecording]);
+        }
     }
 
     if FeatureFlag::PRCommentsSlashCommand.is_enabled() {

--- a/app/src/ai/agent/conversation_yaml.rs
+++ b/app/src/ai/agent/conversation_yaml.rs
@@ -524,6 +524,8 @@ fn write_tool_call_args(out: &mut String, tool: &Tool) {
         Tool::ReadShellCommandOutput(_)
         | Tool::UseComputer(_)
         | Tool::RequestComputerUse(_)
+        | Tool::StartRecording(_)
+        | Tool::StopRecording(_)
         | Tool::SuggestPlan(_)
         | Tool::SuggestCreatePlan(_)
         | Tool::SuggestNewConversation(_)
@@ -601,6 +603,7 @@ fn write_tool_call_result_content(out: &mut String, result: &ToolCallResultType)
             None => {}
         },
         ToolCallResultType::WaitForEvents(_) => {}
+        ToolCallResultType::StartRecording(_) | ToolCallResultType::StopRecording(_) => {}
         ToolCallResultType::RunShellCommand(r) => {
             if let Some(res) = &r.result {
                 use api::run_shell_command_result::Result;

--- a/app/src/ai/agent/redaction.rs
+++ b/app/src/ai/agent/redaction.rs
@@ -265,6 +265,10 @@ pub(crate) fn redact_inputs(inputs: &mut [AIAgentInput]) {
                     // strings only; no user-provided text to redact.
                     AIAgentActionResultType::RunAgents(_)
                     | AIAgentActionResultType::WaitForEvents(_) => {}
+
+                    // Recording results carry an artifact ref and metadata only.
+                    AIAgentActionResultType::StartRecording(_)
+                    | AIAgentActionResultType::StopRecording(_) => {}
                 }
             }
             AIAgentInput::FetchReviewComments { repo_path, context } => {

--- a/app/src/ai/agent/task/helper.rs
+++ b/app/src/ai/agent/task/helper.rs
@@ -140,6 +140,8 @@ impl ToolExt for api::message::tool_call::Tool {
             Tool::SendMessageToAgent(_) => "send_message_to_agent",
             Tool::TransferShellCommandControlToUser(_) => "transfer_shell_command_control",
             Tool::RunAgents(_) => "orchestrate",
+            Tool::StartRecording(_) => "start_recording",
+            Tool::StopRecording(_) => "stop_recording",
             // Matches the legacy server-handled name so analytics don't
             // double-count the rollout.
             Tool::WaitForEvents(_) => "wait_for_events",

--- a/app/src/ai/agent_sdk/driver/output.rs
+++ b/app/src/ai/agent_sdk/driver/output.rs
@@ -286,6 +286,8 @@ pub mod text {
                 },
                 // TODO(AGENT-2281): implement
                 AIAgentActionResultType::RequestComputerUse(_result) => Ok(()),
+                AIAgentActionResultType::StartRecording(_)
+                | AIAgentActionResultType::StopRecording(_) => Ok(()),
                 AIAgentActionResultType::FetchConversation(result) => match result {
                     FetchConversationResult::Success { directory_path } => {
                         writeln!(w, "Fetched conversation to {directory_path}")
@@ -408,6 +410,12 @@ pub mod text {
                     }
                     AIAgentActionType::RequestComputerUse(request) => {
                         writeln!(w, "Requesting computer use: {}", request.task_summary)?;
+                    }
+                    AIAgentActionType::StartRecording => {
+                        writeln!(w, "Starting recording")?;
+                    }
+                    AIAgentActionType::StopRecording { recording_id } => {
+                        writeln!(w, "Stopping recording {recording_id}")?;
                     }
                     AIAgentActionType::ReadSkill(request) => {
                         writeln!(w, "Reading skill: {}", request.skill)?;
@@ -1094,7 +1102,9 @@ pub mod json {
                     // TODO(AGENT-2281): implement
                     AIAgentActionType::RequestComputerUse(_) => None,
                     // Internal or non-CLI tool calls: skip them
-                    AIAgentActionType::SuggestNewConversation { .. }
+                    AIAgentActionType::StartRecording
+                    | AIAgentActionType::StopRecording { .. }
+                    | AIAgentActionType::SuggestNewConversation { .. }
                     | AIAgentActionType::SuggestPrompt { .. }
                     | AIAgentActionType::InitProject
                     | AIAgentActionType::OpenCodeReview

--- a/app/src/ai/agent_sdk/driver/output.rs
+++ b/app/src/ai/agent_sdk/driver/output.rs
@@ -411,7 +411,7 @@ pub mod text {
                     AIAgentActionType::RequestComputerUse(request) => {
                         writeln!(w, "Requesting computer use: {}", request.task_summary)?;
                     }
-                    AIAgentActionType::StartRecording => {
+                    AIAgentActionType::StartRecording { .. } => {
                         writeln!(w, "Starting recording")?;
                     }
                     AIAgentActionType::StopRecording { recording_id } => {
@@ -1102,7 +1102,7 @@ pub mod json {
                     // TODO(AGENT-2281): implement
                     AIAgentActionType::RequestComputerUse(_) => None,
                     // Internal or non-CLI tool calls: skip them
-                    AIAgentActionType::StartRecording
+                    AIAgentActionType::StartRecording { .. }
                     | AIAgentActionType::StopRecording { .. }
                     | AIAgentActionType::SuggestNewConversation { .. }
                     | AIAgentActionType::SuggestPrompt { .. }

--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -14,6 +14,7 @@
 
 mod execute;
 mod preprocess;
+pub(crate) mod recording_controller;
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;

--- a/app/src/ai/blocklist/action_model/execute.rs
+++ b/app/src/ai/blocklist/action_model/execute.rs
@@ -553,7 +553,7 @@ impl BlocklistAIActionExecutor {
             AIAgentActionType::RequestComputerUse(_) => self
                 .request_computer_use_executor
                 .update(ctx, |executor, ctx| executor.preprocess_action(input, ctx)),
-            AIAgentActionType::StartRecording => self
+            AIAgentActionType::StartRecording { .. } => self
                 .start_recording_executor
                 .update(ctx, |executor, ctx| executor.preprocess_action(input, ctx)),
             AIAgentActionType::StopRecording { .. } => self
@@ -746,7 +746,7 @@ impl BlocklistAIActionExecutor {
                 .request_computer_use_executor
                 .update(ctx, |executor, ctx| executor.execute(input, ctx))
                 .into(),
-            AIAgentActionType::StartRecording => self
+            AIAgentActionType::StartRecording { .. } => self
                 .start_recording_executor
                 .update(ctx, |executor, ctx| executor.execute(input, ctx))
                 .into(),
@@ -887,7 +887,10 @@ impl BlocklistAIActionExecutor {
                 self.run_agents_executor.update(ctx, |executor, ctx| {
                     executor.cancel_execution(&running.action.id, ctx);
                 });
-            } else if matches!(running.action.action, AIAgentActionType::StartRecording) {
+            } else if matches!(
+                running.action.action,
+                AIAgentActionType::StartRecording { .. }
+            ) {
                 RecordingController::handle(ctx).update(ctx, |controller, _| {
                     controller.abort_start();
                 });
@@ -987,7 +990,7 @@ impl BlocklistAIActionExecutor {
             AIAgentActionType::RequestComputerUse(_) => self
                 .request_computer_use_executor
                 .update(ctx, |executor, ctx| executor.should_autoexecute(input, ctx)),
-            AIAgentActionType::StartRecording => self
+            AIAgentActionType::StartRecording { .. } => self
                 .start_recording_executor
                 .update(ctx, |executor, ctx| executor.should_autoexecute(input, ctx)),
             AIAgentActionType::StopRecording { .. } => self

--- a/app/src/ai/blocklist/action_model/execute.rs
+++ b/app/src/ai/blocklist/action_model/execute.rs
@@ -16,6 +16,8 @@ pub(super) mod search_codebase;
 pub(super) mod send_message;
 pub(super) mod shell_command;
 pub(super) mod start_agent;
+pub(super) mod start_recording;
+pub(super) mod stop_recording;
 pub(super) mod suggest_new_conversation;
 pub(super) mod suggest_prompt;
 pub(super) mod upload_artifact;
@@ -62,6 +64,8 @@ pub use shell_command::{ShellCommandExecutor, ShellCommandExecutorEvent};
 pub use start_agent::{
     StartAgentExecutor, StartAgentExecutorEvent, StartAgentRequest, StartAgentRequestId,
 };
+use start_recording::StartRecordingExecutor;
+use stop_recording::StopRecordingExecutor;
 pub use suggest_new_conversation::NewConversationDecision;
 use suggest_new_conversation::SuggestNewConversationExecutor;
 pub use suggest_prompt::PromptSuggestionExecutor;
@@ -87,6 +91,7 @@ use crate::ai::agent::{
     FileLocations, ServerOutputId,
 };
 use crate::ai::ambient_agents::AmbientAgentTaskId;
+use crate::ai::blocklist::action_model::recording_controller::RecordingController;
 use crate::ai::get_relevant_files::controller::GetRelevantFilesController;
 #[cfg(feature = "local_fs")]
 use crate::ai::{agent::AnyFileContent, paths::host_native_absolute_path};
@@ -260,6 +265,8 @@ pub struct BlocklistAIActionExecutor {
     create_documents_executor: ModelHandle<CreateDocumentsExecutor>,
     use_computer_executor: ModelHandle<UseComputerExecutor>,
     request_computer_use_executor: ModelHandle<RequestComputerUseExecutor>,
+    start_recording_executor: ModelHandle<StartRecordingExecutor>,
+    stop_recording_executor: ModelHandle<StopRecordingExecutor>,
     read_skill_executor: ModelHandle<ReadSkillExecutor>,
     fetch_conversation_executor: ModelHandle<FetchConversationExecutor>,
     start_agent_executor: ModelHandle<StartAgentExecutor>,
@@ -327,6 +334,8 @@ impl BlocklistAIActionExecutor {
         let use_computer_executor = ctx.add_model(|_| UseComputerExecutor::new());
         let request_computer_use_executor =
             ctx.add_model(|_| RequestComputerUseExecutor::new(terminal_view_id));
+        let start_recording_executor = ctx.add_model(|_| StartRecordingExecutor::new());
+        let stop_recording_executor = ctx.add_model(|_| StopRecordingExecutor::new());
         let read_skill_executor = ctx.add_model(|_| ReadSkillExecutor::new(active_session.clone()));
         let fetch_conversation_executor = ctx.add_model(|_| FetchConversationExecutor::new());
         let start_agent_executor = ctx.add_model(StartAgentExecutor::new);
@@ -354,6 +363,8 @@ impl BlocklistAIActionExecutor {
             create_documents_executor,
             use_computer_executor,
             request_computer_use_executor,
+            start_recording_executor,
+            stop_recording_executor,
             async_executing_actions: Default::default(),
             terminal_model,
             read_skill_executor,
@@ -542,6 +553,12 @@ impl BlocklistAIActionExecutor {
             AIAgentActionType::RequestComputerUse(_) => self
                 .request_computer_use_executor
                 .update(ctx, |executor, ctx| executor.preprocess_action(input, ctx)),
+            AIAgentActionType::StartRecording => self
+                .start_recording_executor
+                .update(ctx, |executor, ctx| executor.preprocess_action(input, ctx)),
+            AIAgentActionType::StopRecording { .. } => self
+                .stop_recording_executor
+                .update(ctx, |executor, ctx| executor.preprocess_action(input, ctx)),
             AIAgentActionType::ReadSkill(_) => self
                 .read_skill_executor
                 .update(ctx, |executor, ctx| executor.preprocess_action(input, ctx)),
@@ -729,6 +746,13 @@ impl BlocklistAIActionExecutor {
                 .request_computer_use_executor
                 .update(ctx, |executor, ctx| executor.execute(input, ctx))
                 .into(),
+            AIAgentActionType::StartRecording => self
+                .start_recording_executor
+                .update(ctx, |executor, ctx| executor.execute(input, ctx))
+                .into(),
+            AIAgentActionType::StopRecording { .. } => self
+                .stop_recording_executor
+                .update(ctx, |executor, ctx| executor.execute(input, ctx)),
             AIAgentActionType::ReadSkill(_) => self
                 .read_skill_executor
                 .update(ctx, |executor, ctx| executor.execute(input, ctx))
@@ -863,6 +887,10 @@ impl BlocklistAIActionExecutor {
                 self.run_agents_executor.update(ctx, |executor, ctx| {
                     executor.cancel_execution(&running.action.id, ctx);
                 });
+            } else if matches!(running.action.action, AIAgentActionType::StartRecording) {
+                RecordingController::handle(ctx).update(ctx, |controller, _| {
+                    controller.abort_start();
+                });
             } else if let AIAgentActionType::WaitForEvents { tool_call_id, .. } =
                 &running.action.action
             {
@@ -958,6 +986,12 @@ impl BlocklistAIActionExecutor {
                 .update(ctx, |executor, ctx| executor.should_autoexecute(input, ctx)),
             AIAgentActionType::RequestComputerUse(_) => self
                 .request_computer_use_executor
+                .update(ctx, |executor, ctx| executor.should_autoexecute(input, ctx)),
+            AIAgentActionType::StartRecording => self
+                .start_recording_executor
+                .update(ctx, |executor, ctx| executor.should_autoexecute(input, ctx)),
+            AIAgentActionType::StopRecording { .. } => self
+                .stop_recording_executor
                 .update(ctx, |executor, ctx| executor.should_autoexecute(input, ctx)),
             AIAgentActionType::ReadSkill(_) => self
                 .read_skill_executor

--- a/app/src/ai/blocklist/action_model/execute/start_recording.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_recording.rs
@@ -1,0 +1,118 @@
+use std::time::{Duration, SystemTime};
+
+use ai::agent::action_result::{AIAgentActionResultType, RecordingStarted, StartRecordingResult};
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use uuid::Uuid;
+use warp_core::features::FeatureFlag;
+use warpui::{Entity, ModelContext, SingletonEntity};
+
+use super::{ActionExecution, AnyActionExecution, ExecuteActionInput, PreprocessActionInput};
+use crate::ai::agent::AIAgentActionType;
+use crate::ai::blocklist::action_model::recording_controller::{
+    RecordingController, RecordingSession,
+};
+
+/// Enforced maximum recording duration. Bounds orphaned captures while leaving
+/// enough room for a typical computer-use task.
+const MAX_RECORDING_DURATION: Duration = Duration::from_secs(10 * 60);
+/// Enforced maximum recording size in bytes. Caps local disk growth if display
+/// content produces a large video before the time limit.
+const MAX_RECORDING_SIZE_BYTES: u64 = 1024 * 1024 * 1024;
+
+pub struct StartRecordingExecutor;
+
+impl StartRecordingExecutor {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub(super) fn should_autoexecute(
+        &self,
+        input: ExecuteActionInput,
+        _ctx: &mut ModelContext<Self>,
+    ) -> bool {
+        let ExecuteActionInput { action, .. } = input;
+        // Recording is only offered within an already-approved computer-use
+        // subagent, so approval extends to it. Still require the feature flag.
+        matches!(action.action, AIAgentActionType::StartRecording)
+            && FeatureFlag::VideoRecording.is_enabled()
+    }
+
+    pub(super) fn execute(
+        &mut self,
+        input: ExecuteActionInput,
+        ctx: &mut ModelContext<Self>,
+    ) -> impl Into<AnyActionExecution> {
+        let ExecuteActionInput { action, .. } = input;
+        let AIAgentActionType::StartRecording = &action.action else {
+            return ActionExecution::InvalidAction;
+        };
+
+        // Reserve the single runtime slot up front so a concurrent start can't
+        // race past the guard while ffmpeg is spinning up.
+        let controller = RecordingController::handle(ctx);
+        if let Err(error) = controller.update(ctx, |controller, _| controller.try_begin_start()) {
+            return ActionExecution::Sync(AIAgentActionResultType::StartRecording(
+                StartRecordingResult::Error(error.to_string()),
+            ));
+        }
+
+        ActionExecution::new_async(
+            async move {
+                let recorder = computer_use::create_recorder();
+                let config = computer_use::RecordingConfig {
+                    max_duration: Some(MAX_RECORDING_DURATION),
+                    max_size_bytes: Some(MAX_RECORDING_SIZE_BYTES),
+                    ..Default::default()
+                };
+                recorder.start(config).await
+            },
+            |result, ctx| match result {
+                Ok(handle) => {
+                    let recording_id = Uuid::new_v4().to_string();
+                    let started_at = SystemTime::now();
+                    let width_px = handle.width() as i32;
+                    let height_px = handle.height() as i32;
+                    let frame_rate = handle.frame_rate() as i32;
+                    let max_duration = handle.max_duration();
+                    let max_size_bytes = handle.max_size_bytes().map(|bytes| bytes as i64);
+                    RecordingController::handle(ctx).update(ctx, |controller, _| {
+                        controller
+                            .finish_start(recording_id.clone(), RecordingSession::new(handle));
+                    });
+                    AIAgentActionResultType::StartRecording(StartRecordingResult::Success(
+                        RecordingStarted {
+                            recording_id,
+                            started_at,
+                            width_px,
+                            height_px,
+                            frame_rate,
+                            max_duration,
+                            max_size_bytes,
+                        },
+                    ))
+                }
+                Err(error) => {
+                    RecordingController::handle(ctx)
+                        .update(ctx, |controller, _| controller.abort_start());
+                    AIAgentActionResultType::StartRecording(StartRecordingResult::Error(
+                        error.to_string(),
+                    ))
+                }
+            },
+        )
+    }
+
+    pub(super) fn preprocess_action(
+        &mut self,
+        _input: PreprocessActionInput,
+        _ctx: &mut ModelContext<Self>,
+    ) -> BoxFuture<'static, ()> {
+        futures::future::ready(()).boxed()
+    }
+}
+
+impl Entity for StartRecordingExecutor {
+    type Event = ();
+}

--- a/app/src/ai/blocklist/action_model/execute/start_recording.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_recording.rs
@@ -72,8 +72,8 @@ impl StartRecordingExecutor {
                     } else {
                         defaults.frame_rate
                     },
-                    max_duration: max_duration.or(defaults.max_duration),
-                    max_size_bytes: max_size_bytes.or(defaults.max_size_bytes),
+                    max_duration: max_duration.unwrap_or(defaults.max_duration),
+                    max_size_bytes: max_size_bytes.unwrap_or(defaults.max_size_bytes),
                 };
                 recorder.start(config).await
             },

--- a/app/src/ai/blocklist/action_model/execute/start_recording.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_recording.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 use ai::agent::action_result::{AIAgentActionResultType, RecordingStarted, StartRecordingResult};
 use futures::future::BoxFuture;
@@ -12,13 +12,6 @@ use crate::ai::agent::AIAgentActionType;
 use crate::ai::blocklist::action_model::recording_controller::{
     RecordingController, RecordingSession,
 };
-
-/// Enforced maximum recording duration. Bounds orphaned captures while leaving
-/// enough room for a typical computer-use task.
-const MAX_RECORDING_DURATION: Duration = Duration::from_secs(10 * 60);
-/// Enforced maximum recording size in bytes. Caps local disk growth if display
-/// content produces a large video before the time limit.
-const MAX_RECORDING_SIZE_BYTES: u64 = 1024 * 1024 * 1024;
 
 pub struct StartRecordingExecutor;
 
@@ -35,7 +28,7 @@ impl StartRecordingExecutor {
         let ExecuteActionInput { action, .. } = input;
         // Recording is only offered within an already-approved computer-use
         // subagent, so approval extends to it. Still require the feature flag.
-        matches!(action.action, AIAgentActionType::StartRecording)
+        matches!(action.action, AIAgentActionType::StartRecording { .. })
             && FeatureFlag::VideoRecording.is_enabled()
     }
 
@@ -45,9 +38,17 @@ impl StartRecordingExecutor {
         ctx: &mut ModelContext<Self>,
     ) -> impl Into<AnyActionExecution> {
         let ExecuteActionInput { action, .. } = input;
-        let AIAgentActionType::StartRecording = &action.action else {
+        let AIAgentActionType::StartRecording {
+            frame_rate,
+            max_duration,
+            max_size_bytes,
+        } = &action.action
+        else {
             return ActionExecution::InvalidAction;
         };
+        let frame_rate = *frame_rate;
+        let max_duration = *max_duration;
+        let max_size_bytes = *max_size_bytes;
 
         // Reserve the single runtime slot up front so a concurrent start can't
         // race past the guard while ffmpeg is spinning up.
@@ -62,9 +63,15 @@ impl StartRecordingExecutor {
             async move {
                 let recorder = computer_use::create_recorder();
                 let config = computer_use::RecordingConfig {
-                    max_duration: Some(MAX_RECORDING_DURATION),
-                    max_size_bytes: Some(MAX_RECORDING_SIZE_BYTES),
-                    ..Default::default()
+                    // A frame rate of 0 means the server did not specify one;
+                    // fall back to the recorder's default in that case.
+                    frame_rate: if frame_rate > 0 {
+                        frame_rate
+                    } else {
+                        computer_use::RecordingConfig::default().frame_rate
+                    },
+                    max_duration,
+                    max_size_bytes,
                 };
                 recorder.start(config).await
             },
@@ -74,9 +81,6 @@ impl StartRecordingExecutor {
                     let started_at = SystemTime::now();
                     let width_px = handle.width() as i32;
                     let height_px = handle.height() as i32;
-                    let frame_rate = handle.frame_rate() as i32;
-                    let max_duration = handle.max_duration();
-                    let max_size_bytes = handle.max_size_bytes().map(|bytes| bytes as i64);
                     RecordingController::handle(ctx).update(ctx, |controller, _| {
                         controller
                             .finish_start(recording_id.clone(), RecordingSession::new(handle));
@@ -87,9 +91,6 @@ impl StartRecordingExecutor {
                             started_at,
                             width_px,
                             height_px,
-                            frame_rate,
-                            max_duration,
-                            max_size_bytes,
                         },
                     ))
                 }

--- a/app/src/ai/blocklist/action_model/execute/start_recording.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_recording.rs
@@ -62,16 +62,18 @@ impl StartRecordingExecutor {
         ActionExecution::new_async(
             async move {
                 let recorder = computer_use::create_recorder();
+                // Fall back to the recorder's defaults when the server omits a value:
+                // frame rate 0 means unspecified, and absent limits would otherwise
+                // leave the capture unbounded.
+                let defaults = computer_use::RecordingConfig::default();
                 let config = computer_use::RecordingConfig {
-                    // A frame rate of 0 means the server did not specify one;
-                    // fall back to the recorder's default in that case.
                     frame_rate: if frame_rate > 0 {
                         frame_rate
                     } else {
-                        computer_use::RecordingConfig::default().frame_rate
+                        defaults.frame_rate
                     },
-                    max_duration,
-                    max_size_bytes,
+                    max_duration: max_duration.or(defaults.max_duration),
+                    max_size_bytes: max_size_bytes.or(defaults.max_size_bytes),
                 };
                 recorder.start(config).await
             },

--- a/app/src/ai/blocklist/action_model/execute/start_recording.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_recording.rs
@@ -9,9 +9,7 @@ use warpui::{Entity, ModelContext, SingletonEntity};
 
 use super::{ActionExecution, AnyActionExecution, ExecuteActionInput, PreprocessActionInput};
 use crate::ai::agent::AIAgentActionType;
-use crate::ai::blocklist::action_model::recording_controller::{
-    RecordingController, RecordingSession,
-};
+use crate::ai::blocklist::action_model::recording_controller::RecordingController;
 
 pub struct StartRecordingExecutor;
 
@@ -84,8 +82,7 @@ impl StartRecordingExecutor {
                     let width_px = handle.width() as i32;
                     let height_px = handle.height() as i32;
                     RecordingController::handle(ctx).update(ctx, |controller, _| {
-                        controller
-                            .finish_start(recording_id.clone(), RecordingSession::new(handle));
+                        controller.finish_start(recording_id.clone(), handle);
                     });
                     AIAgentActionResultType::StartRecording(StartRecordingResult::Success(
                         RecordingStarted {

--- a/app/src/ai/blocklist/action_model/execute/stop_recording.rs
+++ b/app/src/ai/blocklist/action_model/execute/stop_recording.rs
@@ -2,7 +2,9 @@
 use ai::agent::action_result::{RecordingStopped, StopRecordingResult};
 use futures::future::BoxFuture;
 use futures::FutureExt;
-use warpui::{Entity, ModelContext, SingletonEntity};
+#[cfg(not(target_family = "wasm"))]
+use warpui::SingletonEntity;
+use warpui::{Entity, ModelContext};
 
 use super::{ActionExecution, AnyActionExecution, ExecuteActionInput, PreprocessActionInput};
 use crate::ai::agent::AIAgentActionType;

--- a/app/src/ai/blocklist/action_model/execute/stop_recording.rs
+++ b/app/src/ai/blocklist/action_model/execute/stop_recording.rs
@@ -1,0 +1,168 @@
+#[cfg(not(target_family = "wasm"))]
+use ai::agent::action_result::{RecordingStopped, StopRecordingResult};
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use warpui::{Entity, ModelContext, SingletonEntity};
+
+use super::{ActionExecution, AnyActionExecution, ExecuteActionInput, PreprocessActionInput};
+use crate::ai::agent::AIAgentActionType;
+#[cfg(not(target_family = "wasm"))]
+use crate::{
+    ai::{
+        agent::AIAgentActionResultType,
+        agent_sdk::artifact_upload::{FileArtifactUploadRequest, FileArtifactUploader},
+        blocklist::action_model::recording_controller::{
+            RecordingController, StopRecordingControllerError,
+        },
+        blocklist::BlocklistAIHistoryModel,
+    },
+    server::server_api::ServerApiProvider,
+};
+
+#[cfg(not(target_family = "wasm"))]
+fn format_stop_recording_error(err: &anyhow::Error) -> String {
+    let error_chain = format!("{err:#}");
+    if error_chain != err.to_string() {
+        format!("Recording upload failed: {error_chain}")
+    } else {
+        error_chain
+    }
+}
+
+pub struct StopRecordingExecutor;
+
+impl StopRecordingExecutor {
+    pub fn new() -> Self {
+        Self
+    }
+
+    #[cfg_attr(target_family = "wasm", allow(unused_variables))]
+    pub(super) fn should_autoexecute(
+        &self,
+        input: ExecuteActionInput,
+        _ctx: &mut ModelContext<Self>,
+    ) -> bool {
+        let ExecuteActionInput { action, .. } = input;
+        matches!(action.action, AIAgentActionType::StopRecording { .. })
+            && warp_core::features::FeatureFlag::VideoRecording.is_enabled()
+    }
+
+    #[cfg_attr(target_family = "wasm", allow(unused_variables))]
+    pub(super) fn execute(
+        &mut self,
+        input: ExecuteActionInput,
+        ctx: &mut ModelContext<Self>,
+    ) -> AnyActionExecution {
+        #[cfg(target_family = "wasm")]
+        {
+            ActionExecution::<()>::InvalidAction.into()
+        }
+
+        #[cfg(not(target_family = "wasm"))]
+        {
+            let ExecuteActionInput {
+                action,
+                conversation_id,
+            } = input;
+            let AIAgentActionType::StopRecording { recording_id } = &action.action else {
+                return ActionExecution::<()>::InvalidAction.into();
+            };
+            let recording_id = recording_id.clone();
+            let server_conversation_token = BlocklistAIHistoryModel::as_ref(ctx)
+                .conversation(&conversation_id)
+                .and_then(|conversation| conversation.server_conversation_token())
+                .cloned();
+            let Some(server_conversation_token) = server_conversation_token else {
+                return ActionExecution::<()>::Sync(AIAgentActionResultType::StopRecording(
+                    StopRecordingResult::Error(
+                        StopRecordingControllerError::ConversationNotSynced.to_string(),
+                    ),
+                ))
+                .into();
+            };
+
+            let session = RecordingController::handle(ctx).update(ctx, |controller, _| {
+                controller.take_session_or_err(&recording_id)
+            });
+            let session = match session {
+                Ok(session) => session,
+                Err(error) => {
+                    return ActionExecution::<()>::Sync(AIAgentActionResultType::StopRecording(
+                        StopRecordingResult::Error(error.to_string()),
+                    ))
+                    .into();
+                }
+            };
+
+            let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
+            let server_api = ServerApiProvider::as_ref(ctx).get();
+            let handle = session.into_handle();
+
+            ActionExecution::new_async(
+                async move {
+                    let recorder = computer_use::create_recorder();
+                    let output = match recorder.stop(handle).await {
+                        Ok(output) => output,
+                        Err(error) => return StopRecordingResult::Error(error.to_string()),
+                    };
+
+                    // The local file is an implementation detail; publish it and
+                    // delete it so results only ever carry the artifact ref.
+                    let local_path = output.path.clone();
+                    let uploader = FileArtifactUploader::new(ai_client, server_api);
+                    let request = FileArtifactUploadRequest {
+                        path: output.path,
+                        run_id: None,
+                        conversation_id: Some(server_conversation_token),
+                        description: None,
+                    };
+                    let upload_result = async {
+                        let association = uploader.resolve_upload_association(&request).await?;
+                        uploader.upload_with_association(request, association).await
+                    }
+                    .await;
+                    // TODO(vkodithala): Retain or retry the local file if upload fails.
+                    let _ = std::fs::remove_file(&local_path);
+
+                    match upload_result {
+                        Ok(upload) => {
+                            let completion_status = output.completion_status;
+                            let termination_reason = match completion_status {
+                                computer_use::RecordingCompletionStatus::Completed => {
+                                    "Stopped by agent".to_string()
+                                }
+                                computer_use::RecordingCompletionStatus::StoppedEarly => {
+                                    "Recording stopped before the agent requested it".to_string()
+                                }
+                            };
+                            StopRecordingResult::Success(RecordingStopped {
+                                artifact_uid: upload.artifact.artifact_uid,
+                                duration: output.duration,
+                                width_px: output.width as i32,
+                                height_px: output.height as i32,
+                                size_bytes: output.size_bytes as i64,
+                                completion_status,
+                                termination_reason,
+                            })
+                        }
+                        Err(err) => StopRecordingResult::Error(format_stop_recording_error(&err)),
+                    }
+                },
+                |result, _ctx| AIAgentActionResultType::StopRecording(result),
+            )
+            .into()
+        }
+    }
+
+    pub(super) fn preprocess_action(
+        &mut self,
+        _input: PreprocessActionInput,
+        _ctx: &mut ModelContext<Self>,
+    ) -> BoxFuture<'static, ()> {
+        futures::future::ready(()).boxed()
+    }
+}
+
+impl Entity for StopRecordingExecutor {
+    type Event = ();
+}

--- a/app/src/ai/blocklist/action_model/execute/stop_recording.rs
+++ b/app/src/ai/blocklist/action_model/execute/stop_recording.rs
@@ -67,7 +67,6 @@ impl StopRecordingExecutor {
             let AIAgentActionType::StopRecording { recording_id } = &action.action else {
                 return ActionExecution::<()>::InvalidAction.into();
             };
-            let recording_id = recording_id.clone();
             let server_conversation_token = BlocklistAIHistoryModel::as_ref(ctx)
                 .conversation(&conversation_id)
                 .and_then(|conversation| conversation.server_conversation_token())
@@ -81,11 +80,11 @@ impl StopRecordingExecutor {
                 .into();
             };
 
-            let session = RecordingController::handle(ctx).update(ctx, |controller, _| {
-                controller.take_session_or_err(&recording_id)
+            let handle = RecordingController::handle(ctx).update(ctx, |controller, _| {
+                controller.take_handle_or_err(recording_id)
             });
-            let session = match session {
-                Ok(session) => session,
+            let handle = match handle {
+                Ok(handle) => handle,
                 Err(error) => {
                     return ActionExecution::<()>::Sync(AIAgentActionResultType::StopRecording(
                         StopRecordingResult::Error(error.to_string()),
@@ -96,7 +95,6 @@ impl StopRecordingExecutor {
 
             let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
             let server_api = ServerApiProvider::as_ref(ctx).get();
-            let handle = session.into_handle();
 
             ActionExecution::new_async(
                 async move {

--- a/app/src/ai/blocklist/action_model/recording_controller.rs
+++ b/app/src/ai/blocklist/action_model/recording_controller.rs
@@ -14,6 +14,7 @@ pub enum StartRecordingControllerError {
     AlreadyInProgress,
 }
 
+#[cfg_attr(target_family = "wasm", allow(dead_code))]
 #[derive(Debug, Error)]
 pub enum StopRecordingControllerError {
     #[error("No active recording with id '{recording_id}'.")]
@@ -23,6 +24,7 @@ pub enum StopRecordingControllerError {
 }
 
 /// The single in-progress recording: its controller id and live capture handle.
+#[cfg_attr(target_family = "wasm", allow(dead_code))]
 struct ActiveRecording {
     id: String,
     handle: computer_use::RecordingHandle,
@@ -70,6 +72,7 @@ impl RecordingController {
 
     /// Removes and returns the live handle for `recording_id`, leaving any
     /// non-matching active recording in place.
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     pub fn take_handle_or_err(
         &mut self,
         recording_id: &str,

--- a/app/src/ai/blocklist/action_model/recording_controller.rs
+++ b/app/src/ai/blocklist/action_model/recording_controller.rs
@@ -1,0 +1,100 @@
+//! Runtime-global registry of in-progress video recordings.
+//!
+//! A recording's capture process must outlive the `StartRecording` tool call
+//! that launches it and survive until a later `StopRecording` call (possibly
+//! from a later resumed turn), so the live handle lives here rather than in a
+//! per-call executor.
+
+use std::collections::HashMap;
+
+use thiserror::Error;
+use warpui::{Entity, SingletonEntity};
+
+#[derive(Debug, Error)]
+pub enum StartRecordingControllerError {
+    #[error("A recording is already in progress in this runtime.")]
+    AlreadyInProgress,
+}
+
+#[derive(Debug, Error)]
+pub enum StopRecordingControllerError {
+    #[error("No active recording with id '{recording_id}'.")]
+    NoActiveRecording { recording_id: String },
+    #[error("Current conversation has not been synced to the server yet.")]
+    ConversationNotSynced,
+}
+
+/// Holds the live capture handle for a single in-progress recording.
+pub struct RecordingSession {
+    handle: computer_use::RecordingHandle,
+}
+
+impl RecordingSession {
+    pub fn new(handle: computer_use::RecordingHandle) -> Self {
+        Self { handle }
+    }
+
+    pub fn into_handle(self) -> computer_use::RecordingHandle {
+        self.handle
+    }
+}
+
+/// Tracks recordings keyed by id and enforces one active recording per client runtime.
+///
+/// NOTE: Ambient agent environment setup currently provides one Xvfb instance
+/// per runtime, which exposes a single display to the recorder. If that changes,
+/// this controller should key active recordings by display.
+pub struct RecordingController {
+    sessions: HashMap<String, RecordingSession>,
+    /// Set while a start is in flight (after reservation, before the session is
+    /// registered) so a concurrent start cannot race past the single-slot guard.
+    starting: bool,
+}
+
+impl RecordingController {
+    pub fn new() -> Self {
+        Self {
+            sessions: HashMap::new(),
+            starting: false,
+        }
+    }
+
+    /// Reserves the single recording slot, failing if one is already active or
+    /// starting.
+    pub fn try_begin_start(&mut self) -> Result<(), StartRecordingControllerError> {
+        if self.starting || !self.sessions.is_empty() {
+            return Err(StartRecordingControllerError::AlreadyInProgress);
+        }
+        self.starting = true;
+        Ok(())
+    }
+
+    /// Registers a successfully started recording, releasing the start reservation.
+    pub fn finish_start(&mut self, recording_id: String, session: RecordingSession) {
+        self.starting = false;
+        self.sessions.insert(recording_id, session);
+    }
+
+    /// Releases the start reservation after a failed start.
+    pub fn abort_start(&mut self) {
+        self.starting = false;
+    }
+
+    /// Removes and returns the session for `recording_id`.
+    pub fn take_session_or_err(
+        &mut self,
+        recording_id: &str,
+    ) -> Result<RecordingSession, StopRecordingControllerError> {
+        self.sessions.remove(recording_id).ok_or_else(|| {
+            StopRecordingControllerError::NoActiveRecording {
+                recording_id: recording_id.to_string(),
+            }
+        })
+    }
+}
+
+impl Entity for RecordingController {
+    type Event = ();
+}
+
+impl SingletonEntity for RecordingController {}

--- a/app/src/ai/blocklist/action_model/recording_controller.rs
+++ b/app/src/ai/blocklist/action_model/recording_controller.rs
@@ -5,8 +5,6 @@
 //! from a later resumed turn), so the live handle lives here rather than in a
 //! per-call executor.
 
-use std::collections::HashMap;
-
 use thiserror::Error;
 use warpui::{Entity, SingletonEntity};
 
@@ -24,29 +22,16 @@ pub enum StopRecordingControllerError {
     ConversationNotSynced,
 }
 
-/// Holds the live capture handle for a single in-progress recording.
-pub struct RecordingSession {
+/// The single in-progress recording: its controller id and live capture handle.
+struct ActiveRecording {
+    id: String,
     handle: computer_use::RecordingHandle,
 }
 
-impl RecordingSession {
-    pub fn new(handle: computer_use::RecordingHandle) -> Self {
-        Self { handle }
-    }
-
-    pub fn into_handle(self) -> computer_use::RecordingHandle {
-        self.handle
-    }
-}
-
-/// Tracks recordings keyed by id and enforces one active recording per client runtime.
-///
-/// NOTE: Ambient agent environment setup currently provides one Xvfb instance
-/// per runtime, which exposes a single display to the recorder. If that changes,
-/// this controller should key active recordings by display.
+/// Enforces a single active recording per client runtime.
 pub struct RecordingController {
-    sessions: HashMap<String, RecordingSession>,
-    /// Set while a start is in flight (after reservation, before the session is
+    active: Option<ActiveRecording>,
+    /// Set while a start is in flight (after reservation, before the recording is
     /// registered) so a concurrent start cannot race past the single-slot guard.
     starting: bool,
 }
@@ -54,7 +39,7 @@ pub struct RecordingController {
 impl RecordingController {
     pub fn new() -> Self {
         Self {
-            sessions: HashMap::new(),
+            active: None,
             starting: false,
         }
     }
@@ -62,7 +47,7 @@ impl RecordingController {
     /// Reserves the single recording slot, failing if one is already active or
     /// starting.
     pub fn try_begin_start(&mut self) -> Result<(), StartRecordingControllerError> {
-        if self.starting || !self.sessions.is_empty() {
+        if self.starting || self.active.is_some() {
             return Err(StartRecordingControllerError::AlreadyInProgress);
         }
         self.starting = true;
@@ -70,9 +55,12 @@ impl RecordingController {
     }
 
     /// Registers a successfully started recording, releasing the start reservation.
-    pub fn finish_start(&mut self, recording_id: String, session: RecordingSession) {
+    pub fn finish_start(&mut self, recording_id: String, handle: computer_use::RecordingHandle) {
         self.starting = false;
-        self.sessions.insert(recording_id, session);
+        self.active = Some(ActiveRecording {
+            id: recording_id,
+            handle,
+        });
     }
 
     /// Releases the start reservation after a failed start.
@@ -80,16 +68,21 @@ impl RecordingController {
         self.starting = false;
     }
 
-    /// Removes and returns the session for `recording_id`.
-    pub fn take_session_or_err(
+    /// Removes and returns the live handle for `recording_id`, leaving any
+    /// non-matching active recording in place.
+    pub fn take_handle_or_err(
         &mut self,
         recording_id: &str,
-    ) -> Result<RecordingSession, StopRecordingControllerError> {
-        self.sessions.remove(recording_id).ok_or_else(|| {
-            StopRecordingControllerError::NoActiveRecording {
-                recording_id: recording_id.to_string(),
+    ) -> Result<computer_use::RecordingHandle, StopRecordingControllerError> {
+        match self.active.take() {
+            Some(active) if active.id == recording_id => Ok(active.handle),
+            other => {
+                self.active = other;
+                Err(StopRecordingControllerError::NoActiveRecording {
+                    recording_id: recording_id.to_string(),
+                })
             }
-        })
+        }
     }
 }
 

--- a/app/src/ai/blocklist/handoff/touched_repos.rs
+++ b/app/src/ai/blocklist/handoff/touched_repos.rs
@@ -375,6 +375,8 @@ fn extract_action_paths(
         | AIAgentActionType::CreateDocuments(_)
         | AIAgentActionType::UseComputer(_)
         | AIAgentActionType::RequestComputerUse(_)
+        | AIAgentActionType::StartRecording
+        | AIAgentActionType::StopRecording { .. }
         | AIAgentActionType::ReadSkill(_)
         | AIAgentActionType::FetchConversation { .. }
         | AIAgentActionType::StartAgent { .. }

--- a/app/src/ai/blocklist/handoff/touched_repos.rs
+++ b/app/src/ai/blocklist/handoff/touched_repos.rs
@@ -375,7 +375,7 @@ fn extract_action_paths(
         | AIAgentActionType::CreateDocuments(_)
         | AIAgentActionType::UseComputer(_)
         | AIAgentActionType::RequestComputerUse(_)
-        | AIAgentActionType::StartRecording
+        | AIAgentActionType::StartRecording { .. }
         | AIAgentActionType::StopRecording { .. }
         | AIAgentActionType::ReadSkill(_)
         | AIAgentActionType::FetchConversation { .. }

--- a/app/src/ai/blocklist/mod.rs
+++ b/app/src/ai/blocklist/mod.rs
@@ -32,6 +32,7 @@ pub(crate) mod codebase_index_speedbump_banner;
 pub(crate) mod telemetry_banner;
 pub(super) mod view_util;
 
+pub(crate) use action_model::recording_controller::RecordingController;
 #[cfg_attr(target_family = "wasm", allow(unused_imports))]
 pub(crate) use action_model::{
     apply_edits, read_local_file_context, BlocklistAIActionEvent, FileReadResult,

--- a/app/src/ai/blocklist/persistence.rs
+++ b/app/src/ai/blocklist/persistence.rs
@@ -366,7 +366,7 @@ impl From<&AIAgentActionType> for PersistedAIAgentActionType {
             AIAgentActionType::WaitForEvents { .. } => Self::NotPersisted,
             // Recordings are tied to a live capture process that cannot survive
             // a restart, so there is nothing useful to persist.
-            AIAgentActionType::StartRecording | AIAgentActionType::StopRecording { .. } => {
+            AIAgentActionType::StartRecording { .. } | AIAgentActionType::StopRecording { .. } => {
                 Self::NotPersisted
             }
         }

--- a/app/src/ai/blocklist/persistence.rs
+++ b/app/src/ai/blocklist/persistence.rs
@@ -364,6 +364,11 @@ impl From<&AIAgentActionType> for PersistedAIAgentActionType {
             // stays in the transcript as an orphan until the next
             // outbound request triggers the server's supersede.
             AIAgentActionType::WaitForEvents { .. } => Self::NotPersisted,
+            // Recordings are tied to a live capture process that cannot survive
+            // a restart, so there is nothing useful to persist.
+            AIAgentActionType::StartRecording | AIAgentActionType::StopRecording { .. } => {
+                Self::NotPersisted
+            }
         }
     }
 }

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -245,6 +245,7 @@ use workspace::sync_inputs::SyncedInputState;
 use self::features::FeatureFlag;
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::ambient_agents::github_auth_notifier::GitHubAuthNotifier;
+use crate::ai::blocklist::RecordingController;
 use crate::ai::connected_self_hosted_workers::ConnectedSelfHostedWorkersModel;
 use crate::ai::document::ai_document_model::AIDocumentModel;
 use crate::ai::facts::manager::AIFactManager;
@@ -1600,6 +1601,7 @@ pub(crate) fn initialize_app(
 
     ctx.add_singleton_model(|_| SettingsPaneManager::new());
     ctx.add_singleton_model(|_| AIFactManager::new());
+    ctx.add_singleton_model(|_| RecordingController::new());
     ctx.add_singleton_model(|_| ExecutionProfileEditorManager::default());
     ctx.add_singleton_model(|_| NetworkLogPaneManager::default());
     ctx.add_singleton_model(|_| pricing::PricingInfoModel::new());

--- a/crates/ai/src/agent/action/convert.rs
+++ b/crates/ai/src/agent/action/convert.rs
@@ -504,8 +504,20 @@ impl From<api::message::tool_call::RequestComputerUse> for AIAgentActionType {
 }
 
 impl From<api::message::tool_call::StartRecording> for AIAgentActionType {
-    fn from(_value: api::message::tool_call::StartRecording) -> Self {
-        AIAgentActionType::StartRecording
+    fn from(value: api::message::tool_call::StartRecording) -> Self {
+        let limits = value.limits;
+        AIAgentActionType::StartRecording {
+            frame_rate: value.frame_rate.max(0) as u32,
+            max_duration: limits
+                .as_ref()
+                .and_then(|l| l.max_duration.as_ref())
+                .map(|d| Duration::new(d.seconds.max(0) as u64, d.nanos.max(0) as u32)),
+            max_size_bytes: limits
+                .as_ref()
+                .map(|l| l.max_size_bytes)
+                .filter(|&bytes| bytes > 0)
+                .map(|bytes| bytes as u64),
+        }
     }
 }
 

--- a/crates/ai/src/agent/action/convert.rs
+++ b/crates/ai/src/agent/action/convert.rs
@@ -503,6 +503,20 @@ impl From<api::message::tool_call::RequestComputerUse> for AIAgentActionType {
     }
 }
 
+impl From<api::message::tool_call::StartRecording> for AIAgentActionType {
+    fn from(_value: api::message::tool_call::StartRecording) -> Self {
+        AIAgentActionType::StartRecording
+    }
+}
+
+impl From<api::message::tool_call::StopRecording> for AIAgentActionType {
+    fn from(value: api::message::tool_call::StopRecording) -> Self {
+        AIAgentActionType::StopRecording {
+            recording_id: value.recording_id,
+        }
+    }
+}
+
 impl From<api::message::tool_call::FetchConversation> for AIAgentActionType {
     fn from(value: api::message::tool_call::FetchConversation) -> Self {
         AIAgentActionType::FetchConversation {

--- a/crates/ai/src/agent/action/mod.rs
+++ b/crates/ai/src/agent/action/mod.rs
@@ -18,9 +18,10 @@ use crate::agent::action_result::{
     InsertReviewCommentsResult, ReadDocumentsResult, ReadFilesResult, ReadMCPResourceResult,
     ReadShellCommandOutputResult, ReadSkillResult, RequestCommandOutputResult,
     RequestComputerUseResult, RequestFileEditsResult, RunAgentsResult, SearchCodebaseResult,
-    SendMessageToAgentResult, StartAgentResult, StartAgentVersion, SuggestNewConversationResult,
-    SuggestPromptResult, TransferShellCommandControlToUserResult, UploadArtifactResult,
-    UseComputerResult, WaitForEventsResult, WriteToLongRunningShellCommandResult,
+    SendMessageToAgentResult, StartAgentResult, StartAgentVersion, StartRecordingResult,
+    StopRecordingResult, SuggestNewConversationResult, SuggestPromptResult,
+    TransferShellCommandControlToUserResult, UploadArtifactResult, UseComputerResult,
+    WaitForEventsResult, WriteToLongRunningShellCommandResult,
 };
 use crate::agent::{AIAgentCitation, FileLocations};
 use crate::diff_validation::ParsedDiff;
@@ -135,6 +136,15 @@ pub enum AIAgentActionType {
     },
 
     RequestComputerUse(RequestComputerUseRequest),
+
+    /// AI requested to start recording a video of the computer-use session.
+    /// Capture configuration is runtime-controlled, so v0 carries no arguments.
+    StartRecording,
+
+    /// AI requested to stop an in-progress recording and publish the video.
+    StopRecording {
+        recording_id: String,
+    },
 
     // AI requested to read a skill.
     ReadSkill(ReadSkillRequest),
@@ -374,6 +384,12 @@ impl AIAgentActionType {
             Self::RequestComputerUse(_) => {
                 AIAgentActionResultType::RequestComputerUse(RequestComputerUseResult::Cancelled)
             }
+            Self::StartRecording => {
+                AIAgentActionResultType::StartRecording(StartRecordingResult::Cancelled)
+            }
+            Self::StopRecording { .. } => {
+                AIAgentActionResultType::StopRecording(StopRecordingResult::Cancelled)
+            }
             Self::ReadSkill(_) => AIAgentActionResultType::ReadSkill(ReadSkillResult::Cancelled),
             Self::FetchConversation { .. } => {
                 AIAgentActionResultType::FetchConversation(FetchConversationResult::Cancelled)
@@ -433,6 +449,8 @@ impl AIAgentActionType {
                 format!("Insert {} code review comments", comments.len())
             }
             Self::RequestComputerUse(_) => "Request computer use".to_string(),
+            Self::StartRecording => "Start recording".to_string(),
+            Self::StopRecording { .. } => "Stop recording".to_string(),
             Self::ReadSkill(_) => "Read skill".to_string(),
             Self::FetchConversation { .. } => "Fetch conversation".to_string(),
             Self::StartAgent { name, .. } => format!("Start agent: {name}"),
@@ -594,6 +612,12 @@ impl Display for AIAgentActionType {
             }
             AIAgentActionType::RequestComputerUse(req) => {
                 write!(f, "RequestComputerUse: {}", req.task_summary)
+            }
+            AIAgentActionType::StartRecording => {
+                write!(f, "StartRecording")
+            }
+            AIAgentActionType::StopRecording { recording_id } => {
+                write!(f, "StopRecording: {recording_id}")
             }
             AIAgentActionType::ReadSkill(req) => {
                 write!(f, "ReadSkill: {}", req.skill)

--- a/crates/ai/src/agent/action/mod.rs
+++ b/crates/ai/src/agent/action/mod.rs
@@ -138,8 +138,13 @@ pub enum AIAgentActionType {
     RequestComputerUse(RequestComputerUseRequest),
 
     /// AI requested to start recording a video of the computer-use session.
-    /// Capture configuration is runtime-controlled, so v0 carries no arguments.
-    StartRecording,
+    /// Capture configuration (frame rate, limits) is server-owned and arrives
+    /// on the tool call; the client applies it. `frame_rate` of 0 means unset.
+    StartRecording {
+        frame_rate: u32,
+        max_duration: Option<Duration>,
+        max_size_bytes: Option<u64>,
+    },
 
     /// AI requested to stop an in-progress recording and publish the video.
     StopRecording {
@@ -384,7 +389,7 @@ impl AIAgentActionType {
             Self::RequestComputerUse(_) => {
                 AIAgentActionResultType::RequestComputerUse(RequestComputerUseResult::Cancelled)
             }
-            Self::StartRecording => {
+            Self::StartRecording { .. } => {
                 AIAgentActionResultType::StartRecording(StartRecordingResult::Cancelled)
             }
             Self::StopRecording { .. } => {
@@ -449,7 +454,7 @@ impl AIAgentActionType {
                 format!("Insert {} code review comments", comments.len())
             }
             Self::RequestComputerUse(_) => "Request computer use".to_string(),
-            Self::StartRecording => "Start recording".to_string(),
+            Self::StartRecording { .. } => "Start recording".to_string(),
             Self::StopRecording { .. } => "Stop recording".to_string(),
             Self::ReadSkill(_) => "Read skill".to_string(),
             Self::FetchConversation { .. } => "Fetch conversation".to_string(),
@@ -613,7 +618,7 @@ impl Display for AIAgentActionType {
             AIAgentActionType::RequestComputerUse(req) => {
                 write!(f, "RequestComputerUse: {}", req.task_summary)
             }
-            AIAgentActionType::StartRecording => {
+            AIAgentActionType::StartRecording { .. } => {
                 write!(f, "StartRecording")
             }
             AIAgentActionType::StopRecording { recording_id } => {

--- a/crates/ai/src/agent/action_result/convert.rs
+++ b/crates/ai/src/agent/action_result/convert.rs
@@ -1499,6 +1499,111 @@ impl TryFrom<WaitForEventsResult> for api::request::input::tool_call_result::Res
     }
 }
 
+fn system_time_to_timestamp(time: std::time::SystemTime) -> prost_types::Timestamp {
+    match time.duration_since(std::time::SystemTime::UNIX_EPOCH) {
+        Ok(elapsed) => prost_types::Timestamp {
+            seconds: elapsed.as_secs() as i64,
+            nanos: elapsed.subsec_nanos() as i32,
+        },
+        Err(_) => prost_types::Timestamp::default(),
+    }
+}
+
+fn duration_to_proto(duration: std::time::Duration) -> prost_types::Duration {
+    prost_types::Duration {
+        seconds: duration.as_secs() as i64,
+        nanos: duration.subsec_nanos() as i32,
+    }
+}
+
+fn convert_completion_status(
+    status: computer_use::RecordingCompletionStatus,
+) -> api::stop_recording_result::CompletionStatus {
+    use api::stop_recording_result::CompletionStatus;
+    match status {
+        computer_use::RecordingCompletionStatus::Completed => CompletionStatus::Complete,
+        computer_use::RecordingCompletionStatus::StoppedEarly => CompletionStatus::Incomplete,
+    }
+}
+
+impl TryFrom<StartRecordingResult> for api::request::input::tool_call_result::Result {
+    type Error = ConvertToAPITypeError;
+
+    fn try_from(result: StartRecordingResult) -> Result<Self, Self::Error> {
+        match result {
+            StartRecordingResult::Success(started) => Ok(
+                api::request::input::tool_call_result::Result::StartRecording(
+                    api::StartRecordingResult {
+                        result: Some(api::start_recording_result::Result::Success(
+                            api::start_recording_result::Success {
+                                recording_id: started.recording_id,
+                                started_at: Some(system_time_to_timestamp(started.started_at)),
+                                settings: Some(api::start_recording_result::CaptureSettings {
+                                    width_px: started.width_px,
+                                    height_px: started.height_px,
+                                    frame_rate: started.frame_rate,
+                                }),
+                                limits: Some(api::start_recording_result::Limits {
+                                    max_duration: started.max_duration.map(duration_to_proto),
+                                    max_size_bytes: started.max_size_bytes.unwrap_or_default(),
+                                }),
+                            },
+                        )),
+                    },
+                ),
+            ),
+            StartRecordingResult::Error(message) => Ok(
+                api::request::input::tool_call_result::Result::StartRecording(
+                    api::StartRecordingResult {
+                        result: Some(api::start_recording_result::Result::Error(
+                            api::start_recording_result::Error { message },
+                        )),
+                    },
+                ),
+            ),
+            StartRecordingResult::Cancelled => Err(ConvertToAPITypeError::Ignore),
+        }
+    }
+}
+
+impl TryFrom<StopRecordingResult> for api::request::input::tool_call_result::Result {
+    type Error = ConvertToAPITypeError;
+
+    fn try_from(result: StopRecordingResult) -> Result<Self, Self::Error> {
+        match result {
+            StopRecordingResult::Success(stopped) => Ok(
+                api::request::input::tool_call_result::Result::StopRecording(
+                    api::StopRecordingResult {
+                        result: Some(api::stop_recording_result::Result::Success(
+                            api::stop_recording_result::Success {
+                                artifact_uid: stopped.artifact_uid,
+                                duration: Some(duration_to_proto(stopped.duration)),
+                                width_px: stopped.width_px,
+                                height_px: stopped.height_px,
+                                size_bytes: stopped.size_bytes,
+                                completion_status: convert_completion_status(
+                                    stopped.completion_status,
+                                ) as i32,
+                                termination_reason: stopped.termination_reason,
+                            },
+                        )),
+                    },
+                ),
+            ),
+            StopRecordingResult::Error(message) => Ok(
+                api::request::input::tool_call_result::Result::StopRecording(
+                    api::StopRecordingResult {
+                        result: Some(api::stop_recording_result::Result::Error(
+                            api::stop_recording_result::Error { message },
+                        )),
+                    },
+                ),
+            ),
+            StopRecordingResult::Cancelled => Err(ConvertToAPITypeError::Ignore),
+        }
+    }
+}
+
 #[cfg(test)]
 #[path = "convert_tests.rs"]
 mod tests;

--- a/crates/ai/src/agent/action_result/convert.rs
+++ b/crates/ai/src/agent/action_result/convert.rs
@@ -1541,11 +1541,6 @@ impl TryFrom<StartRecordingResult> for api::request::input::tool_call_result::Re
                                 settings: Some(api::start_recording_result::CaptureSettings {
                                     width_px: started.width_px,
                                     height_px: started.height_px,
-                                    frame_rate: started.frame_rate,
-                                }),
-                                limits: Some(api::start_recording_result::Limits {
-                                    max_duration: started.max_duration.map(duration_to_proto),
-                                    max_size_bytes: started.max_size_bytes.unwrap_or_default(),
                                 }),
                             },
                         )),

--- a/crates/ai/src/agent/action_result/mod.rs
+++ b/crates/ai/src/agent/action_result/mod.rs
@@ -1215,8 +1215,8 @@ impl Display for RequestComputerUseResult {
     }
 }
 
-/// The result of a `StartRecording` tool call. Carries the runtime-applied
-/// capture settings and enforced limits so the agent knows the recording state.
+/// The result of a `StartRecording` tool call. Carries the resolved capture
+/// dimensions; frame rate and limits are server-owned and not echoed back.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StartRecordingResult {
     Success(RecordingStarted),
@@ -1230,9 +1230,6 @@ pub struct RecordingStarted {
     pub started_at: SystemTime,
     pub width_px: i32,
     pub height_px: i32,
-    pub frame_rate: i32,
-    pub max_duration: Option<Duration>,
-    pub max_size_bytes: Option<i64>,
 }
 
 impl Display for StartRecordingResult {
@@ -1240,8 +1237,8 @@ impl Display for StartRecordingResult {
         match self {
             StartRecordingResult::Success(started) => write!(
                 f,
-                "Recording started ({}x{} @ {}fps)",
-                started.width_px, started.height_px, started.frame_rate
+                "Recording started ({}x{})",
+                started.width_px, started.height_px
             ),
             StartRecordingResult::Error(error) => write!(f, "Start recording error: {error}"),
             StartRecordingResult::Cancelled => write!(f, "Start recording cancelled"),

--- a/crates/ai/src/agent/action_result/mod.rs
+++ b/crates/ai/src/agent/action_result/mod.rs
@@ -2,7 +2,7 @@ mod convert;
 
 use std::fmt::Display;
 use std::ops::Range;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use chrono::{DateTime, Local};
 use itertools::Itertools as _;
@@ -82,6 +82,12 @@ pub enum AIAgentActionResultType {
 
     /// The output of requesting computer use.
     RequestComputerUse(RequestComputerUseResult),
+
+    /// The result of starting a video recording.
+    StartRecording(StartRecordingResult),
+
+    /// The result of stopping a video recording.
+    StopRecording(StopRecordingResult),
 
     /// The result of fetching a conversation's tasks.
     FetchConversation(FetchConversationResult),
@@ -165,6 +171,8 @@ impl Display for AIAgentActionResultType {
             AIAgentActionResultType::UseComputer(result) => result.fmt(f),
             AIAgentActionResultType::InsertReviewComments(result) => result.fmt(f),
             AIAgentActionResultType::RequestComputerUse(result) => result.fmt(f),
+            AIAgentActionResultType::StartRecording(result) => result.fmt(f),
+            AIAgentActionResultType::StopRecording(result) => result.fmt(f),
             AIAgentActionResultType::FetchConversation(result) => result.fmt(f),
             AIAgentActionResultType::StartAgent(result) => result.fmt(f),
             AIAgentActionResultType::SendMessageToAgent(result) => result.fmt(f),
@@ -761,6 +769,8 @@ impl AIAgentActionResultType {
             AIAgentActionResultType::ReadShellCommandOutput(_) => "The shell command output",
             AIAgentActionResultType::UseComputer(_) => "The computer use result",
             AIAgentActionResultType::RequestComputerUse(_) => "The computer use request result",
+            AIAgentActionResultType::StartRecording(_) => "The result of starting a recording",
+            AIAgentActionResultType::StopRecording(_) => "The result of stopping a recording",
             AIAgentActionResultType::FetchConversation(_) => "The fetched conversation tasks",
             AIAgentActionResultType::StartAgent(_) => "The result of starting a child agent",
             AIAgentActionResultType::SendMessageToAgent(_) => "The result of sending a message",
@@ -803,6 +813,8 @@ impl AIAgentActionResultType {
             | Self::UseComputer(UseComputerResult::Success(_))
             | Self::InsertReviewComments(InsertReviewCommentsResult::Success { .. })
             | Self::RequestComputerUse(RequestComputerUseResult::Approved { .. })
+            | Self::StartRecording(StartRecordingResult::Success(_))
+            | Self::StopRecording(StopRecordingResult::Success(_))
             | Self::OpenCodeReview
             | Self::ReadSkill(ReadSkillResult::Success { .. })
             | Self::FetchConversation(FetchConversationResult::Success { .. })
@@ -837,6 +849,8 @@ impl AIAgentActionResultType {
             | Self::UseComputer(UseComputerResult::Error(_))
             | Self::InsertReviewComments(InsertReviewCommentsResult::Error { .. })
             | Self::RequestComputerUse(RequestComputerUseResult::Error(_))
+            | Self::StartRecording(StartRecordingResult::Error(_))
+            | Self::StopRecording(StopRecordingResult::Error(_))
             | Self::FetchConversation(FetchConversationResult::Error(_))
             | Self::StartAgent(StartAgentResult::Error { .. })
             | Self::SendMessageToAgent(SendMessageToAgentResult::Error(_))
@@ -877,6 +891,8 @@ impl AIAgentActionResultType {
             | Self::UseComputer(UseComputerResult::Cancelled)
             | Self::InsertReviewComments(InsertReviewCommentsResult::Cancelled)
             | Self::RequestComputerUse(RequestComputerUseResult::Cancelled)
+            | Self::StartRecording(StartRecordingResult::Cancelled)
+            | Self::StopRecording(StopRecordingResult::Cancelled)
             | Self::TransferShellCommandControlToUser(
                 TransferShellCommandControlToUserResult::Cancelled,
             )
@@ -1195,6 +1211,74 @@ impl Display for RequestComputerUseResult {
                 write!(f, "Request computer use error: {error}")
             }
             RequestComputerUseResult::Cancelled => write!(f, "Request computer use cancelled"),
+        }
+    }
+}
+
+/// The result of a `StartRecording` tool call. Carries the runtime-applied
+/// capture settings and enforced limits so the agent knows the recording state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StartRecordingResult {
+    Success(RecordingStarted),
+    Error(String),
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordingStarted {
+    pub recording_id: String,
+    pub started_at: SystemTime,
+    pub width_px: i32,
+    pub height_px: i32,
+    pub frame_rate: i32,
+    pub max_duration: Option<Duration>,
+    pub max_size_bytes: Option<i64>,
+}
+
+impl Display for StartRecordingResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StartRecordingResult::Success(started) => write!(
+                f,
+                "Recording started ({}x{} @ {}fps)",
+                started.width_px, started.height_px, started.frame_rate
+            ),
+            StartRecordingResult::Error(error) => write!(f, "Start recording error: {error}"),
+            StartRecordingResult::Cancelled => write!(f, "Start recording cancelled"),
+        }
+    }
+}
+
+/// The result of a `StopRecording` tool call. Carries the published artifact
+/// reference and video metadata; never the file path or bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StopRecordingResult {
+    Success(RecordingStopped),
+    Error(String),
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordingStopped {
+    pub artifact_uid: String,
+    pub duration: Duration,
+    pub width_px: i32,
+    pub height_px: i32,
+    pub size_bytes: i64,
+    pub completion_status: computer_use::RecordingCompletionStatus,
+    pub termination_reason: String,
+}
+
+impl Display for StopRecordingResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StopRecordingResult::Success(stopped) => write!(
+                f,
+                "Recording stopped (artifact {}, {} bytes)",
+                stopped.artifact_uid, stopped.size_bytes
+            ),
+            StopRecordingResult::Error(error) => write!(f, "Stop recording error: {error}"),
+            StopRecordingResult::Cancelled => write!(f, "Stop recording cancelled"),
         }
     }
 }

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -579,6 +579,9 @@ pub enum FeatureFlag {
     /// raising it or moving the cursor.  Currently only supported on macOS.
     BackgroundComputerUse,
 
+    /// Enables video recording of computer-use sessions for cloud agents.
+    VideoRecording,
+
     /// Enables team API key creation in the API key management UI.
     TeamApiKeys,
 
@@ -954,6 +957,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::FileGlobV2Warnings,
     FeatureFlag::SummarizationViaMessageReplacement,
     FeatureFlag::LocalComputerUse,
+    FeatureFlag::VideoRecording,
     FeatureFlag::OzLaunchModal,
     // These are enabled via 100% experiment on prod warp-server,
     // but we need to enable here for dogfood builds.


### PR DESCRIPTION
## Description

This is the second PR in the computer-use video-recording stack.

It wires the recording substrate from #13044 into agent execution: StartRecording/StopRecording API conversions, conversation YAML/redaction support, action/result model plumbing, blocklist executors, a process-local `RecordingController`, artifact upload, cancellation cleanup, and dogfood feature-flag enablement.

For context, the downstack substrate PR makes recording possible, but the agent runtime still needs a way to request bounded recordings, preserve the active recording session, stop/finalize it, and surface the resulting MP4 artifact back to the conversation and persist to GCS.

Tl;dr on the implementation: StartRecording creates a bounded recording through the singleton controller and records the applied limits/metadata in the action result. StopRecording validates upload preconditions before consuming the active session, finalizes the recorder, uploads the MP4 as an agent artifact, and reports whether the recording completed or stopped early. Cancellation handling aborts an in-flight start reservation so the controller does not get stuck.

## Stack context

- This PR is stacked on #13044 (`varoon/va-video-recording-client`), which adds only the `crates/computer_use` recorder substrate and Linux `ffmpeg` implementation.
- This PR owns app-layer/agent execution wiring and should be reviewed after or alongside #13044.
- CI/validation for this PR depends on generated `warp_multi_agent_api` types that include StartRecording/StopRecording. Locally, validation used the matching `warp-proto-apis` branch via an uncommitted top-level `Cargo.toml` patch.

## Linked Issue

N/A

## Testing

Manually tested end-to-end, here's a [demo](https://www.loom.com/share/59ea36e89f9b42479a48d9ca0d1900b2).

- `./script/format`
- `cargo check -p computer_use -p ai -p warp`
- `cargo clippy -p computer_use -p ai -p warp --all-targets -- -D warnings`

Validation note: these commands currently require the local/generated `warp_multi_agent_api` proto patch that includes StartRecording/StopRecording types. This execution layer does not compile against the current `master`\-generated API crate until that proto update lands.

- [x] I have manually tested my changes locally with `./script/run` (not yet; local macOS cannot exercise the Linux X11 recorder path end to end)

## Known issues / follow-ons before launch

These are the concrete v0 follow-ons from the video-recording launch review. They are not all intended to land in this PR, but they should be tracked before launching the feature broadly.

- Similarly to what we allow for screenshots, add video output scaling, likely with a runtime-controlled `RecordingConfig` target such as `max_long_edge_px` or `target_height_px`, and use an `ffmpeg` scale filter so output is roughly 720p. Return captured/applied dimensions in recording metadata.
- Add MP4 structural validation after stop/finalization (probably just parsed from `ffmpeg` outputs on SIGINT: parseable container, video stream present, non-zero duration, non-zero dimensions, and expected-enough codec/container for playback. Similar to what Cursor does. Mentioned in my doc.
- Improve termination reasons beyond the current coarse early-stop status: distinguish agent stop, duration limit, size limit, unexpected `ffmpeg` exit, and finalization timeout/force-kill.
- Add dedicated StartRecording/StopRecording UI cards that show recording parameters, limits, duration/size, completion state, and artifact link rather than opaque generic tool-call output.
- Capture computer-use action logs with monotonic timecodes while recording is active, including mouse move/click/wheel, key presses, and redacted/summarized typed text according to existing policy.
- Add basic overlay rendering for captured action logs, such as key/action captions, click indicators, and timestamps.
- Add lifecycle finalization/upload in a separate PR for agent-run end/cancel/timeout; explicit StopRecording after lifecycle finalization should be idempotent or report the already-finalized artifact.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz [oz-agent@warp.dev](mailto:oz-agent@warp.dev) d