### PR TITLE
Switch tab group feature flag to stable

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -663,6 +663,7 @@ default = [
     "vertical_tabs",
     "vertical_tabs_summary_mode",
     "tab_configs",
+    "grouped_tabs",
     "agent_harness",
     "hoa_onboarding_flow",
     "hoa_remote_control",

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -970,8 +970,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).
 /// All PREVIEW_FLAGS are also automatically added to dogfood builds (WarpDev).
 pub const PREVIEW_FLAGS: &[FeatureFlag] = &[
-    #[cfg(target_os = "macos")]
-    FeatureFlag::GroupedTabs,
     FeatureFlag::AsyncFind,
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     FeatureFlag::DragTabsToWindows,
@@ -1081,7 +1079,6 @@ impl FeatureFlag {
             GitOperationsInCodeReview => Some(
                 "Enables commit, push, and create-PR actions directly from the code review panel.",
             ),
-            GroupedTabs => Some("Enables organizing tabs into named, collapsible groups."),
             AsyncFind => Some(
                 "Runs terminal find on a background thread to keep the UI responsive while searching large outputs.",
             ),


### PR DESCRIPTION
## Description

Switches tab grouping from preview to stable.

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4803/flip-tab-grouping-feature-flag-to-stable

CHANGELOG-NEW-FEATURE: Tab Groups - organize tabs into named, collapsible groups in both the horizontal and vertical tab bars. Drag tabs into groups and reorder groups within the tab bar. Customize groups with colors and names, and use keyboard shortcuts to manage them.