### PR TITLE
Fix broken internal doc links in INTEGRATION_TESTING.md and wwds-variables.md

### DIFF
--- a/crates/integration/tests/INTEGRATION_TESTING.md
+++ b/crates/integration/tests/INTEGRATION_TESTING.md
@@ -61,7 +61,7 @@ fn test_simple_example() -> TestDriver {
 }
 ```
 
-I find `with_keystrokes` and `with_input_string` most helpful methods, so far. You can check the implementation (and expand it!) in [ui/src/integration/test_driver.rs](../../ui/src/integration/test_driver.ts).
+I find `with_keystrokes` and `with_input_string` most helpful methods, so far. You can check the implementation (and expand it!) in [warpui_core/src/integration/step.rs](../../warpui_core/src/integration/step.rs).
 
 ## When to use `assert!` vs `async_assert!`
 The former will fail the test the first time it's false. The latter will fail the test if we don't ever see a success in the timeout. If you don't specify a timeout, the default timeout is used.

--- a/resources/bundled/mcp_skills/figma/figma-use/references/working-with-design-systems/wwds-variables.md
+++ b/resources/bundled/mcp_skills/figma/figma-use/references/working-with-design-systems/wwds-variables.md
@@ -32,7 +32,7 @@ Code syntax is a surface area in Figma for codebase translation context. You can
 
 ### Scope
 
-`variable.scopes: VariableScope[]` specifies which properties in Figma the variable can be used for. This is important when you create and when you use variables. **Always set specific scopes rather than leaving the default `ALL_SCOPES`** — it pollutes every property picker with irrelevant tokens. The more specific the better. For the canonical scope-to-use-case mapping, see [token-creation.md § Variable Scopes — Complete Reference Table](../../figma-generate-library/references/token-creation.md).
+`variable.scopes: VariableScope[]` specifies which properties in Figma the variable can be used for. This is important when you create and when you use variables. **Always set specific scopes rather than leaving the default `ALL_SCOPES`** — it pollutes every property picker with irrelevant tokens. The more specific the better. For the canonical scope-to-use-case mapping, see [token-creation.md § Variable Scopes — Complete Reference Table](../../../figma-generate-library/references/token-creation.md).
 
 Common scope values:
 


### PR DESCRIPTION
## What
Fixes two broken in-repo documentation links in the open-source `warp` repo:

- `crates/integration/tests/INTEGRATION_TESTING.md` — the integration test driver link pointed at the non-existent `ui/src/integration/test_driver.ts`. Updated to the real file `warpui_core/src/integration/step.rs`.
- `resources/bundled/mcp_skills/figma/figma-use/references/working-with-design-systems/wwds-variables.md` — fixed the relative path depth to `token-creation.md` (`../../` → `../../../`) so it correctly resolves to `figma-generate-library/references/token-creation.md`.

## Why
Both links 404 / fail to resolve in the public repo. This was originally fixed in warp-internal (#26292), but these files are part of the open-source export, so the fix belongs here.

## Testing
Verified both corrected targets exist on `master`:
- `crates/warpui_core/src/integration/step.rs`
- `resources/bundled/mcp_skills/figma/figma-generate-library/references/token-creation.md`

_Conversation: https://staging.warp.dev/conversation/658b890d-eea7-4bf8-a366-4552688133e5_
_Run: https://oz.staging.warp.dev/runs/019f19d0-3948-721d-8f3d-724de83cac9d_

_This PR was generated with [Oz](https://warp.dev/oz)._
