### PR TITLE
Fix PowerShell linter issues.

### DIFF
--- a/app/assets/bundled/bootstrap/pwsh.ps1
+++ b/app/assets/bundled/bootstrap/pwsh.ps1
@@ -146,16 +146,16 @@ $null = New-Module -Name Warp-Module -ScriptBlock {
         # avoiding Windows system modules and third-party modules from the Gallery. The rest are
         # loaded asynchronously later.
         $corePsModules = @(
-            'Microsoft.PowerShell.*',  # All built-in PS modules (cross-platform)
-            'Microsoft.WSMan.*',       # WS-Management (Windows PS)
-            'CimCmdlets',              # CIM/WMI (Windows)
-            'PackageManagement',       # Package management
-            'PowerShellGet',           # Package get
-            'PSReadLine',              # Line editor bundled with PS
-            'ThreadJob',               # Thread jobs (PS 7)
-            'PSDiagnostics',           # PS diagnostics
+            'Microsoft.PowerShell.*', # All built-in PS modules (cross-platform)
+            'Microsoft.WSMan.*', # WS-Management (Windows PS)
+            'CimCmdlets', # CIM/WMI (Windows)
+            'PackageManagement', # Package management
+            'PowerShellGet', # Package get
+            'PSReadLine', # Line editor bundled with PS
+            'ThreadJob', # Thread jobs (PS 7)
+            'PSDiagnostics', # PS diagnostics
             'PSDesiredStateConfiguration', # DSC (Windows PS)
-            'PSWorkflow',              # Legacy workflow (Windows PS 5)
+            'PSWorkflow', # Legacy workflow (Windows PS 5)
             'PSWorkflowUtility'        # Legacy workflow utility (Windows PS 5)
         )
         $functionNamesRaw = Get-Command -CommandType Function -Module $corePsModules |

--- a/script/windows/bundle.ps1
+++ b/script/windows/bundle.ps1
@@ -179,10 +179,10 @@ Write-Output "Built for $ARCH with executable at $BINARY_PATH"
 
 # Prepare bundled resources
 $BUNDLED_RESOURCES_DIR = "$CARGO_TARGET_OUTPUT_DIR\resources"
-Write-Output "Preparing bundled resources..."
+Write-Output 'Preparing bundled resources...'
 & "$WINDOWS_INSTALLER_DIR\prepare_bundled_resources.ps1" -DestinationDir "$BUNDLED_RESOURCES_DIR" -Channel "$CHANNEL" -CargoProfile "$CARGO_PROFILE"
 if (-Not $?) {
-    Write-Error "Failed to prepare bundled resources"
+    Write-Error 'Failed to prepare bundled resources'
     exit 1
 }
 


### PR DESCRIPTION
## Description
Resolves the PowerShell linting violations reported by `./script/lint_powershell` (PSScriptAnalyzer) so the lint stage of `./script/presubmit` passes cleanly. These were pre-existing issues unrelated to any feature work, so they are split into their own PR to keep unrelated cleanup out of feature branches.

Two rules were violated:
- **`PSUseConsistentWhitespace`** in `app/assets/bundled/bootstrap/pwsh.ps1` — the `$corePsModules` array used multiple spaces after commas to align the trailing comments, which the rule flags (it expects exactly one space after a comma). Collapsed to a single space after each comma. Comment text is unchanged; only the alignment whitespace was removed.
- **`PSAvoidUsingDoubleQuotesForConstantString`** in `script/windows/bundle.ps1` — two constant strings passed to `Write-Output` / `Write-Error` used double quotes despite having no interpolation; switched to single quotes.

Note: `script/windows/bundle.ps1` only surfaced now because the lint script `throw`s after the first source directory with violations, so `./script/windows/` was never inspected until the bootstrap file was clean.

The fixes were applied via `./script/lint_powershell -fix`, which as a side effect prepended a UTF-8 BOM to both files; those BOMs were stripped so the diff is strictly whitespace/quote changes.

## Linked Issue
N/A — internal linter/tooling cleanup, no associated issue.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Verified with the repository's own linter:
- `./script/lint_powershell -ci` → `0 rule violations found` for both inspected directories (`./app/assets/bundled/bootstrap/` and `./script/windows/`).

These are bundled shell scripts, not app runtime behavior, so there is nothing to exercise via `./script/run`.
- [ ] I have manually tested my changes locally with `./script/run` (N/A — no runtime behavior change)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
