### PR TITLE
Prune directory symlinks from repo watches

### DIFF
--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -988,6 +988,13 @@ pub fn should_watch_repo_directory(
         return should_watch_directory_in_git_path(path);
     }
 
+    // Match tree construction semantics: directory symlinks are not
+    // materialized as repo entries, and force-included symlink targets are
+    // watched separately via non-recursive target watches.
+    if path.is_symlink() && path.is_dir() {
+        return false;
+    }
+
     if matches_force_included_path(path, force_included_paths) {
         return true;
     }

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -248,6 +248,39 @@ fn should_watch_descends_to_force_included_under_ignored_ancestor() {
     ));
 }
 
+#[cfg(unix)]
+#[test]
+fn should_watch_prunes_force_included_directory_symlink() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = dunce::canonicalize(temp_dir.path()).unwrap();
+    fs::create_dir_all(root.join(".agents/skills")).unwrap();
+    fs::create_dir_all(root.join("outside/result-target")).unwrap();
+    std::os::unix::fs::symlink(
+        root.join("outside/result-target"),
+        root.join(".agents/skills/result"),
+    )
+    .unwrap();
+
+    let gitignores = vec![gitignore_rooted(&root, "result\nresult/\n")];
+    let force_included = vec![std::path::PathBuf::from(".agents/skills")];
+
+    assert!(super::should_watch_repo_directory(
+        &root.join(".agents"),
+        &gitignores,
+        &force_included
+    ));
+    assert!(super::should_watch_repo_directory(
+        &root.join(".agents/skills"),
+        &gitignores,
+        &force_included
+    ));
+    assert!(!super::should_watch_repo_directory(
+        &root.join(".agents/skills/result"),
+        &gitignores,
+        &force_included
+    ));
+}
+
 #[test]
 fn should_watch_handles_nested_ignored_ancestor_with_deeper_force_included() {
     let temp_dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Description

Fixes a repository watcher/indexing failure mode where force-included project skill directories could cause Warp to recursively watch directory symlinks into large external trees, such as Nix store closures.

The repo tree builder already treats directory symlinks as non-materialized entries. This change makes `should_watch_repo_directory` mirror that behavior before applying force-included path matching. Force-included provider directories such as `.agents/skills` and `.codex/skills` are still watched, and the existing non-recursive symlink-target watcher path remains responsible for standing-query symlink targets.

## Linked Issue

Fixes #13233

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

No UI screenshots are included because this is a repository watcher/resource-use fix. The issue contains the pre-fix memory screenshot.

## Testing

- [x] Added a Unix regression test for a force-included provider directory containing an ignored `result` directory symlink.
- [x] `cargo test -p repo_metadata should_watch_prunes_force_included_directory_symlink --features local_fs`
- [x] `cargo test -p repo_metadata should_watch --features local_fs`
- [x] `cargo test -p repo_metadata standing_queries_report_symlinked_skills_without_materializing_symlinked_directories --features local_fs`
- [x] `cargo test -p repo_metadata --features local_fs` (`113 passed`, `2 ignored`)
- [x] `bash ./script/format --check`
- [x] `bash ./script/check_no_inline_test_modules`
- [x] `nix develop --command bash -lc 'PATH=/tmp/warp-corepack-bin:$PATH cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings'`
- [x] `nix develop --command bash -lc 'PATH=/tmp/warp-corepack-bin:$PATH cargo clippy -p warp_completer --all-targets --tests -- -D warnings'`
- [x] `nix build .#warp-terminal-experimental --print-out-paths --print-build-logs`
- [x] Manually tested the Nix-built app locally with a real Warp profile and real/synthetic symlink-heavy repositories. I used the built binary rather than `./script/run` so the test matched the Linux/NixOS failure mode.

Manual runtime checks with the fixed binary:

- `/home/vitalyr/nix-vault`: indexed `/home/vitalyr/nix-vault` with `585` files; 95s sample kept inotify watches flat at `5293 -> 5293`, `/nix/store` fds `0 -> 0`, RSS `653572 -> 765752` KiB.
- `/home/vitalyr/nix-vault/.codex/skills`: indexed `/home/vitalyr/nix-vault` with `585` files; 90s sample kept inotify watches flat at `5293 -> 5293`, `/nix/store` fds `0 -> 0`, RSS `716380 -> 985564` KiB.
- Synthetic Git repo with `81` directory symlinks, including `40` under `.agents/skills` and `40` under `.codex/skills` pointing into `/nix/store`: indexed with `3` files; 91s sample kept inotify watches flat at `5311 -> 5311`, `/nix/store` fds `0 -> 0`.
- Same synthetic repo launched from `.agents/skills`: 93s sample kept inotify watches flat at `5311 -> 5311`, `/nix/store` fds `0 -> 0`.

For comparison, the pre-fix repro on `/home/vitalyr/nix-vault` grew from about `21.6k` to `56.9k` inotify watches and multiple GiB of RSS while opening fds under `/nix/store`.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Not applicable; this is a non-UI resource-use fix.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed a Linux repository watcher issue where directory symlinks inside project skill directories could cause excessive memory and inotify watch growth.
