### PR TITLE
QUALITY-928: push-based child discovery + orchestration polling removal (client)

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -677,8 +677,6 @@ default = [
     "oz_handoff",
     "handoff_local_cloud",
     "run_agents_tool",
-    "orchestration_viewer_streamer",
-    "owner_orchestration_ancestor_streamer",
     "pending_user_query_indicator",
     "queue_slash_command",
     "queued_prompts_v2",
@@ -982,8 +980,6 @@ skill_arguments = []
 active_conversation_requires_interaction = []
 incremental_auto_reload = []
 run_agents_tool = []
-orchestration_viewer_streamer = []
-owner_orchestration_ancestor_streamer = []
 wait_for_events_parent_registration = []
 pending_user_query_indicator = []
 queue_slash_command = []

--- a/app/src/ai/blocklist/action_model/execute/wait_for_events.rs
+++ b/app/src/ai/blocklist/action_model/execute/wait_for_events.rs
@@ -104,11 +104,12 @@ impl WaitForEventsExecutor {
         let conversation_id = input.conversation_id;
         let timeout = watchdog_timeout_for_stamped_seconds(*idle_timeout_seconds);
 
-        // Blocking on descendants is the trigger to confirm parent status
-        // against the server and register for the owner-side ancestor stream,
-        // so children created out-of-band (Oz CLI / web API) are delivered.
+        // Blocking on descendants is the trigger to open the owner-side
+        // ancestor stream for a root, so children created by any path
+        // (run_agents, Oz CLI, web API) are delivered via push instead of
+        // polling.
         OrchestrationEventStreamer::handle(ctx).update(ctx, |streamer, ctx| {
-            streamer.register_parent_on_wait(conversation_id, ctx);
+            streamer.register_root_on_wait(conversation_id, ctx);
         });
 
         // Bump the counter so any prior watchdog closure observes a

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -42,8 +42,6 @@ const RESTORE_FETCH_PERMANENT_BACKOFF_STEPS: &[u64] = &[30];
 const SSE_DRAIN_INTERVAL_MS: u64 = 500;
 /// Cap killed-run tombstones while keeping normal sessions well below the limit.
 const MAX_KILLED_RUN_IDS: usize = 1024;
-/// Maximum number of explicit run IDs the server accepts on a `run_ids[]` SSE stream.
-const MAX_RUN_ID_STREAM_FILTER: usize = 100;
 /// Max child runs fetched per cold-start `?ancestor_run_id=` REST seed in
 /// viewer mode. Matches the legacy `OrchestrationViewerModel` poller's value
 /// (the server caps at 100 anyway).
@@ -324,11 +322,6 @@ enum DesiredSseFilter {
     Filter(AgentEventFilter),
     /// Nothing to watch yet (no watched run IDs); do not open a stream.
     NoFilter,
-    /// The conversation is a parent with more watched children than the
-    /// explicit `run_ids[]` stream allows and parent-family ancestor
-    /// streaming is unavailable. The payload is the watched-run-id total,
-    /// used only for diagnostics.
-    UnsupportedRunIdCount(usize),
 }
 
 impl OrchestrationEventStreamer {
@@ -611,8 +604,7 @@ impl OrchestrationEventStreamer {
 
     /// Completes the wait-time parent registration fetch. A non-empty
     /// `children` list confirms the conversation is an orchestrator: install
-    /// the children and reevaluate eligibility, which (with
-    /// `OwnerOrchestrationAncestorStreamer` on) opens the
+    /// the children and reevaluate eligibility, which opens the
     /// `AncestorRunId { include_self: true }` stream that thereafter tracks
     /// all children dynamically. Empty children means it is not a parent; an
     /// error is a graceful no-op (the next wait re-checks).
@@ -643,9 +635,9 @@ impl OrchestrationEventStreamer {
         self.apply_task_children(conversation_id, &task, base_cursor);
         // Mirror `register_watched_run_id`: also watch `self_run_id` so the
         // parent's own inbox is delivered if `desired_sse_filter` falls back to
-        // `RunIds` (i.e. `OwnerOrchestrationAncestorStreamer` disabled, where
-        // the filter would otherwise watch only children). A no-op in the
-        // ancestor-stream path, which already covers self via `include_self`.
+        // `RunIds` (i.e. when the parent has no self run id yet). A no-op in
+        // the ancestor-stream path, which already covers self via
+        // `include_self`.
         self.ensure_self_run_id_watched(conversation_id, ctx);
         self.reevaluate_eligibility(conversation_id, ctx);
     }
@@ -1691,7 +1683,7 @@ impl OrchestrationEventStreamer {
         ctx: &warpui::AppContext,
     ) -> DesiredSseFilter {
         let is_parent = self.is_parent_agent_conversation(conversation_id, ctx);
-        if is_parent && FeatureFlag::OwnerOrchestrationAncestorStreamer.is_enabled() {
+        if is_parent {
             if let Some(self_run_id) = self.self_run_id(conversation_id, ctx) {
                 return DesiredSseFilter::Filter(AgentEventFilter::AncestorRunId {
                     ancestor_run_id: self_run_id,
@@ -1699,13 +1691,9 @@ impl OrchestrationEventStreamer {
                 });
             }
         }
-
         let run_ids = self.run_ids_for_sse(conversation_id);
         if run_ids.is_empty() {
             return DesiredSseFilter::NoFilter;
-        }
-        if is_parent && run_ids.len() > MAX_RUN_ID_STREAM_FILTER {
-            return DesiredSseFilter::UnsupportedRunIdCount(run_ids.len());
         }
         DesiredSseFilter::Filter(AgentEventFilter::RunIds(run_ids))
     }
@@ -1891,15 +1879,6 @@ impl OrchestrationEventStreamer {
         let filter = match self.desired_sse_filter(conversation_id, ctx) {
             DesiredSseFilter::Filter(filter) => filter,
             DesiredSseFilter::NoFilter => return,
-            DesiredSseFilter::UnsupportedRunIdCount(count) => {
-                log::error!(
-                    "Owner-side SSE delivery blocked for {conversation_id:?}: {count} watched \
-                     run IDs exceed the {MAX_RUN_ID_STREAM_FILTER} explicit-run-id limit and \
-                     parent-family ancestor streaming is disabled; enable \
-                     OwnerOrchestrationAncestorStreamer to deliver events for large orchestrators"
-                );
-                return;
-            }
         };
 
         let cursor = self
@@ -1991,7 +1970,6 @@ impl OrchestrationEventStreamer {
             }
             // Nothing watchable tears down through the eligibility predicate.
             DesiredSseFilter::NoFilter => false,
-            DesiredSseFilter::UnsupportedRunIdCount(_) => true,
         }
     }
 

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -227,6 +227,12 @@ struct ConversationStreamState {
     /// Consecutive `get_ambient_agent_task` failure count for the
     /// post-restore retry loop; resets on success.
     restore_fetch_failures: usize,
+    /// True once this non-child root registered for the owner-side ancestor
+    /// stream from `wait_for_events` (see `register_root_on_wait`). Makes the
+    /// conversation eligible and selects the ancestor filter before any child is
+    /// known, so the stream never widens later (avoids the cursor-handoff gap in
+    /// Risks).
+    ancestor_on_wait: bool,
 }
 
 /// Per-orchestrator SSE stream state. Parallels [`ConversationStreamState`]
@@ -546,14 +552,10 @@ impl OrchestrationEventStreamer {
         }
     }
 
-    /// Confirms parent status against the server when an orchestrator blocks
-    /// on `wait_for_events`, registering it for the owner-side ancestor
-    /// stream. This is the trigger that lets a parent learn about children
-    /// created out-of-band (Oz CLI / web API), which never flowed through
-    /// [`Self::register_watched_run_id`]. Once the parent role is established
-    /// it is permanent for the conversation's life, so subsequent waits
-    /// short-circuit on the already-parent check below.
-    pub fn register_parent_on_wait(
+    /// Registers a non-child root for the owner-side ancestor stream when it
+    /// blocks on `wait_for_events`, so children created by any path (run_agents,
+    /// Oz CLI, web API) are delivered without polling. Idempotent across waits.
+    pub fn register_root_on_wait(
         &mut self,
         conversation_id: AIConversationId,
         ctx: &mut ModelContext<Self>,
@@ -561,84 +563,32 @@ impl OrchestrationEventStreamer {
         if !FeatureFlag::WaitForEventsParentRegistration.is_enabled() {
             return;
         }
-        // One-level-tree invariant: a child can never also be a parent, so
-        // skip the server fetch. The child still receives its own inbox via
-        // the existing `is_eligible` -> `RunIds(self)` stream, so there is no
-        // regression.
+        // One-level-tree invariant: a child can never be a root parent. It
+        // already receives its own inbox via the child eligibility path.
         let is_child = BlocklistAIHistoryModel::as_ref(ctx)
             .conversation(&conversation_id)
             .is_some_and(|c| c.has_parent_agent());
         if is_child {
             return;
         }
-        // Passive views of a run hosted elsewhere (shared-session viewers,
-        // remote-child placeholders) must not register: the owning process
-        // owns the inbox. Mirrors the `is_eligible` exclusion and avoids a
-        // wasted `get_ambient_agent_task` fetch.
+        // Passive view of a run hosted elsewhere: the owning process holds the
+        // inbox.
         if self.is_remote_run_view(conversation_id, ctx) {
             return;
         }
-        // Already a known parent: the live ancestor stream already discovers
-        // new children via the server `parent_run_id` JOIN, so no re-fetch is
-        // needed. The fetch below exists only to make the initial
-        // not-parent -> parent transition.
-        if self.is_parent_agent_conversation(conversation_id, ctx) {
-            return;
-        }
-        // No run_id yet (rare): nothing to query the server with; the next
-        // wait re-checks.
+        // Need a run id to scope the ancestor stream; the next wait re-checks.
         let Some(self_run_id) = self.self_run_id(conversation_id, ctx) else {
             return;
         };
-        let Ok(task_id) = self_run_id.parse::<AmbientAgentTaskId>() else {
-            return;
-        };
-        let ai_client = self.ai_client.clone();
-        ctx.spawn(
-            async move { ai_client.get_ambient_agent_task(&task_id).await },
-            move |me, result, ctx| {
-                me.finish_register_parent_on_wait(conversation_id, result, ctx);
-            },
-        );
-    }
-
-    /// Completes the wait-time parent registration fetch. A non-empty
-    /// `children` list confirms the conversation is an orchestrator: install
-    /// the children and reevaluate eligibility, which opens the
-    /// `AncestorRunId { include_self: true }` stream that thereafter tracks
-    /// all children dynamically. Empty children means it is not a parent; an
-    /// error is a graceful no-op (the next wait re-checks).
-    fn finish_register_parent_on_wait(
-        &mut self,
-        conversation_id: AIConversationId,
-        result: anyhow::Result<crate::ai::ambient_agents::task::AmbientAgentTask>,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        let task = match result {
-            Ok(task) => task,
-            Err(err) => {
-                log::warn!(
-                    "wait_for_events parent registration fetch failed for \
-                     {conversation_id:?}: {err:#}; will re-check on next wait"
-                );
-                return;
-            }
-        };
-        if task.children.is_empty() {
-            return;
+        let stream = self.streams.entry(conversation_id).or_default();
+        if stream.ancestor_on_wait {
+            return; // already registered; subsequent waits are no-ops
         }
-        let base_cursor = self
-            .streams
-            .get(&conversation_id)
-            .map(|stream| stream.event_cursor)
-            .unwrap_or(0);
-        self.apply_task_children(conversation_id, &task, base_cursor);
-        // Mirror `register_watched_run_id`: also watch `self_run_id` so the
-        // parent's own inbox is delivered if `desired_sse_filter` falls back to
-        // `RunIds` (i.e. when the parent has no self run id yet). A no-op in
-        // the ancestor-stream path, which already covers self via
-        // `include_self`.
-        self.ensure_self_run_id_watched(conversation_id, ctx);
+        stream.ancestor_on_wait = true;
+        // Watch self so the parent's own inbox is covered even if the filter
+        // ever falls back to RunIds; redundant under the ancestor
+        // (include_self) filter.
+        stream.watched_run_ids.insert(self_run_id);
         self.reevaluate_eligibility(conversation_id, ctx);
     }
 
@@ -1646,7 +1596,11 @@ impl OrchestrationEventStreamer {
         let has_parent = BlocklistAIHistoryModel::as_ref(ctx)
             .conversation(&conversation_id)
             .is_some_and(|c| c.has_parent_agent());
-        has_parent || self.is_parent_agent_conversation(conversation_id, ctx)
+        let wait_root = self
+            .streams
+            .get(&conversation_id)
+            .is_some_and(|s| s.ancestor_on_wait);
+        has_parent || self.is_parent_agent_conversation(conversation_id, ctx) || wait_root
     }
 
     /// True iff this conversation should hold the wake-only listener used for
@@ -1683,7 +1637,11 @@ impl OrchestrationEventStreamer {
         ctx: &warpui::AppContext,
     ) -> DesiredSseFilter {
         let is_parent = self.is_parent_agent_conversation(conversation_id, ctx);
-        if is_parent {
+        let wait_root = self
+            .streams
+            .get(&conversation_id)
+            .is_some_and(|s| s.ancestor_on_wait);
+        if is_parent || wait_root {
             if let Some(self_run_id) = self.self_run_id(conversation_id, ctx) {
                 return DesiredSseFilter::Filter(AgentEventFilter::AncestorRunId {
                     ancestor_run_id: self_run_id,
@@ -2034,9 +1992,49 @@ impl OrchestrationEventStreamer {
             return;
         }
 
+        self.register_children_from_events(conversation_id, &events, ctx);
+
         let self_run_id = self.self_run_id(conversation_id, ctx).unwrap_or_default();
 
         self.handle_event_batch(conversation_id, &self_run_id, cursor, events, messages, ctx);
+    }
+
+    /// Registers children announced by `child_agent_started`. The event is on
+    /// the parent run; the child run id is in `ref_id`. Idempotent
+    /// (`watched_run_ids` is a set). Flips `is_parent_agent_conversation` to
+    /// true permanently; the ancestor stream is already open, so the filter
+    /// shape is unchanged and no reconnect happens. The event itself is not
+    /// surfaced as a lifecycle/message item — `convert_lifecycle_events`
+    /// already drops it (its `run_id` equals `self_run_id`, and
+    /// `lifecycle_event_type_from_wire` returns `None`), so it only advances
+    /// the cursor and registers the child.
+    fn register_children_from_events(
+        &mut self,
+        conversation_id: AIConversationId,
+        events: &[AgentRunEvent],
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let mut registered_new = false;
+        for event in events {
+            if event.event_type != CHILD_AGENT_STARTED_EVENT {
+                continue;
+            }
+            let Some(child_run_id) = event.ref_id.clone() else {
+                continue;
+            };
+            if self
+                .streams
+                .entry(conversation_id)
+                .or_default()
+                .watched_run_ids
+                .insert(child_run_id)
+            {
+                registered_new = true;
+            }
+        }
+        if registered_new {
+            self.reevaluate_eligibility(conversation_id, ctx);
+        }
     }
 
     /// Feeds a batch of fetched events through the OrchestrationEventService,
@@ -2250,6 +2248,12 @@ pub(super) fn conversation_status_from_lifecycle_event_type(
         api::LifecycleEventType::Unspecified => ConversationStatus::Error,
     }
 }
+
+/// Wire `event_type` emitted on a parent run when a child task is created.
+/// The child run id is in `ref_id`. Not a lifecycle status, so it is handled
+/// as a discovery signal and `lifecycle_event_type_from_wire` keeps returning
+/// `None` for it (that function is unchanged).
+const CHILD_AGENT_STARTED_EVENT: &str = "child_agent_started";
 
 /// Maps a wire `event_type` string from the server's `AgentRunEvent`
 /// payload onto the corresponding [`api::LifecycleEventType`]. Returns

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -1598,7 +1598,9 @@ fn reevaluate_eligibility_does_not_reconnect_when_watched_run_ids_unchanged() {
             OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
         });
 
-        // Open SSE (gen 0) with watched set == connected snapshot.
+        // Open SSE (gen 0) with watched set == connected snapshot. The
+        // conversation has a child run id, so it is a parent and uses the
+        // parent-family ancestor (include_self) filter.
         let (_, rx) = futures::channel::mpsc::unbounded::<SseStreamItem>();
         let consumer_id = warpui::EntityId::new();
         poller.update(&mut app, |me, _| {
@@ -1608,8 +1610,10 @@ fn reevaluate_eligibility_does_not_reconnect_when_watched_run_ids_unchanged() {
             stream.watched_run_ids.insert(child_run_id.to_string());
             stream.consumers.insert(consumer_id);
             let (abort_handle, _) = futures::future::AbortHandle::new_pair();
-            let connected_filter =
-                AgentEventFilter::RunIds(vec![own_run_id.to_string(), child_run_id.to_string()]);
+            let connected_filter = AgentEventFilter::AncestorRunId {
+                ancestor_run_id: own_run_id.to_string(),
+                include_self: true,
+            };
             stream.sse_connection = Some(SseConnectionState {
                 event_receiver: rx,
                 generation: 0,
@@ -1956,8 +1960,6 @@ fn parent_with_many_children_opens_one_ancestor_include_self_stream() {
     // A parent with far more than the 100 explicit-run-id limit must open a
     // single parent-family ancestor stream rather than a run-id vector.
     App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(true);
-
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
         let own_run_id = "550e8400-e29b-41d4-a716-446655440500";
         let mut conversation = AIConversation::new(false, false);
@@ -2012,8 +2014,6 @@ fn registering_additional_child_does_not_reconnect_parent_family_stream() {
     // Once a parent-family ancestor stream is connected, registering more
     // children must not reconnect: the filter shape is unchanged.
     App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(true);
-
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
         let own_run_id = "550e8400-e29b-41d4-a716-446655440501";
         let mut conversation = AIConversation::new(false, false);
@@ -2075,8 +2075,6 @@ fn child_only_conversation_opens_self_run_id_filter() {
     // A child-only conversation keeps the explicit run-id stream watching
     // only its own run_id, even when the owner-ancestor flag is enabled.
     App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(true);
-
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
         let own_run_id = "550e8400-e29b-41d4-a716-446655440502";
         let mut conversation = AIConversation::new(false, false);
@@ -2118,125 +2116,10 @@ fn child_only_conversation_opens_self_run_id_filter() {
 }
 
 #[test]
-fn parent_over_run_id_limit_without_flag_does_not_open_stream() {
-    // With owner-ancestor streaming disabled, a parent that exceeds the
-    // explicit-run-id limit must not open a known-bad stream; instead it
-    // avoids opening a stream the server would reject.
-    App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(false);
-
-        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
-        let own_run_id = "550e8400-e29b-41d4-a716-446655440503";
-        let mut conversation = AIConversation::new(false, false);
-        conversation.set_run_id(own_run_id.to_string());
-        let conversation_id = conversation.id();
-        let terminal_view_id = warpui::EntityId::new();
-        history_model.update(&mut app, |model, ctx| {
-            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
-            model.update_conversation_status(
-                terminal_view_id,
-                conversation_id,
-                ConversationStatus::InProgress,
-                ctx,
-            );
-        });
-
-        let ai_client: Arc<dyn AIClient> = Arc::new(MockAIClient::new());
-        let server_api = ServerApiProvider::new_for_test().get();
-        let poller = app.add_singleton_model(|ctx| {
-            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
-        });
-
-        let consumer_id = warpui::EntityId::new();
-        poller.update(&mut app, |me, ctx| {
-            let stream = me.streams.entry(conversation_id).or_default();
-            stream.consumers.insert(consumer_id);
-            stream.watched_run_ids.insert(own_run_id.to_string());
-            for i in 0..150 {
-                stream.watched_run_ids.insert(format!("child-{i}"));
-            }
-            me.start_sse_connection(conversation_id, ctx);
-        });
-
-        poller.read(&app, |me, _| {
-            let stream = me.streams.get(&conversation_id).expect("stream present");
-            assert!(
-                stream.sse_connection.is_none(),
-                "must not open an oversized run-id stream the server would reject"
-            );
-        });
-    });
-}
-
-#[test]
-fn parent_crossing_run_id_limit_without_flag_tears_down_partial_stream() {
-    // If a parent starts below the explicit-run-id limit and later registers
-    // enough children to exceed it, the old stream has become partial. It must
-    // be torn down instead of silently missing newly-registered children.
-    App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(false);
-
-        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
-        let own_run_id = "550e8400-e29b-41d4-a716-446655440507";
-        let mut conversation = AIConversation::new(false, false);
-        conversation.set_run_id(own_run_id.to_string());
-        let conversation_id = conversation.id();
-        let terminal_view_id = warpui::EntityId::new();
-        history_model.update(&mut app, |model, ctx| {
-            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
-            model.update_conversation_status(
-                terminal_view_id,
-                conversation_id,
-                ConversationStatus::InProgress,
-                ctx,
-            );
-        });
-
-        let ai_client: Arc<dyn AIClient> = Arc::new(MockAIClient::new());
-        let server_api = ServerApiProvider::new_for_test().get();
-        let poller = app.add_singleton_model(|ctx| {
-            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
-        });
-
-        let consumer_id = warpui::EntityId::new();
-        poller.update(&mut app, |me, ctx| {
-            let stream = me.streams.entry(conversation_id).or_default();
-            stream.consumers.insert(consumer_id);
-            stream.watched_run_ids.insert(own_run_id.to_string());
-            for i in 0..99 {
-                stream.watched_run_ids.insert(format!("child-{i}"));
-            }
-            me.start_sse_connection(conversation_id, ctx);
-        });
-
-        poller.read(&app, |me, _| {
-            let stream = me.streams.get(&conversation_id).expect("stream present");
-            assert!(
-                stream.sse_connection.is_some(),
-                "100 watched run IDs is still within the explicit-run-id limit"
-            );
-        });
-
-        poller.update(&mut app, |me, ctx| {
-            me.register_watched_run_id(conversation_id, "child-over-limit".to_string(), ctx);
-        });
-
-        poller.read(&app, |me, _| {
-            let stream = me.streams.get(&conversation_id).expect("stream present");
-            assert!(
-                stream.sse_connection.is_none(),
-                "oversized parent must tear down the old partial run-id stream"
-            );
-        });
-    });
-}
-#[test]
 fn restored_parent_with_children_opens_ancestor_include_self_stream() {
     // A restored parent whose children come back from the server fetch opens
     // a parent-family ancestor stream using the merged cursor.
     App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(true);
-
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
         let own_run_id = "550e8400-e29b-41d4-a716-446655440504";
         let mut conversation = AIConversation::new(false, false);
@@ -2306,8 +2189,6 @@ fn restored_child_without_children_opens_self_run_id_stream() {
     // A restored child conversation with no children of its own stays on the
     // explicit self run-id stream even when the owner-ancestor flag is on.
     App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(true);
-
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
         let own_run_id = "550e8400-e29b-41d4-a716-446655440505";
         let mut conversation = AIConversation::new(false, false);
@@ -2382,8 +2263,6 @@ fn wait_registration_root_with_children_opens_ancestor_include_self_stream() {
     // children, advances the cursor, and opens the parent-family ancestor
     // stream — exactly the not-parent -> parent transition QUALITY-919 adds.
     App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(true);
-
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
         let own_run_id = "550e8400-e29b-41d4-a716-446655440520";
         let mut conversation = AIConversation::new(false, false);
@@ -2445,8 +2324,6 @@ fn wait_registration_root_without_children_does_not_register() {
     // An empty children list means the conversation is not an orchestrator:
     // no parent role is taken and no stream opens.
     App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(true);
-
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
         let own_run_id = "550e8400-e29b-41d4-a716-446655440521";
         let mut conversation = AIConversation::new(false, false);
@@ -2502,8 +2379,6 @@ fn wait_registration_fetch_error_does_not_register() {
     // A failed fetch is a graceful no-op: no parent role, no stream. The next
     // wait re-checks.
     App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(true);
-
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
         let own_run_id = "550e8400-e29b-41d4-a716-446655440522";
         let mut conversation = AIConversation::new(false, false);
@@ -2621,7 +2496,6 @@ fn register_parent_on_wait_already_parent_is_idempotent() {
     // re-fetch or churn the open ancestor stream.
     App::test((), |mut app| async move {
         let _flag_guard = FeatureFlag::WaitForEventsParentRegistration.override_enabled(true);
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(true);
 
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
         let own_run_id = "550e8400-e29b-41d4-a716-446655440525";
@@ -2693,73 +2567,6 @@ fn register_parent_on_wait_without_self_run_id_is_noop() {
         });
         poller.read(&app, |me, _| {
             assert!(connected_filter(me, conversation_id).is_none());
-        });
-    });
-}
-
-#[test]
-fn wait_registration_runids_fallback_watches_self_for_parent_inbox() {
-    // With OwnerOrchestrationAncestorStreamer disabled, desired_sse_filter
-    // falls back to RunIds(watched_run_ids). The wait-time registration must
-    // also watch self_run_id (not just the children) so the parent's own
-    // inbox events are delivered — mirroring register_watched_run_id.
-    App::test((), |mut app| async move {
-        // OwnerOrchestrationAncestorStreamer intentionally left disabled.
-        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
-        let own_run_id = "550e8400-e29b-41d4-a716-446655440527";
-        let mut conversation = AIConversation::new(false, false);
-        conversation.set_run_id(own_run_id.to_string());
-        let conversation_id = conversation.id();
-        let terminal_view_id = warpui::EntityId::new();
-        history_model.update(&mut app, |model, ctx| {
-            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
-            model.update_conversation_status(
-                terminal_view_id,
-                conversation_id,
-                ConversationStatus::InProgress,
-                ctx,
-            );
-        });
-
-        let ai_client: Arc<dyn AIClient> = Arc::new(MockAIClient::new());
-        let server_api = ServerApiProvider::new_for_test().get();
-        let poller = app.add_singleton_model(|ctx| {
-            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
-        });
-
-        // Only an active consumer — self_run_id is intentionally NOT
-        // pre-watched, so the assertion verifies registration adds it.
-        let consumer_id = warpui::EntityId::new();
-        poller.update(&mut app, |me, _| {
-            me.streams
-                .entry(conversation_id)
-                .or_default()
-                .consumers
-                .insert(consumer_id);
-        });
-
-        poller.update(&mut app, |me, ctx| {
-            me.finish_register_parent_on_wait(
-                conversation_id,
-                Ok(make_ambient_task_with_children(vec![
-                    "child-run-1".to_string()
-                ])),
-                ctx,
-            );
-        });
-
-        poller.read(&app, |me, _| match connected_filter(me, conversation_id) {
-            Some(AgentEventFilter::RunIds(run_ids)) => {
-                assert!(
-                    run_ids.contains(&own_run_id.to_string()),
-                    "RunIds fallback must watch self_run_id for the parent's own inbox; got {run_ids:?}"
-                );
-                assert!(
-                    run_ids.contains(&"child-run-1".to_string()),
-                    "RunIds fallback must watch the child; got {run_ids:?}"
-                );
-            }
-            other => panic!("expected RunIds fallback filter, got {other:?}"),
         });
     });
 }

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -2240,11 +2240,11 @@ fn restored_child_without_children_opens_self_run_id_stream() {
     });
 }
 
-// ---- wait_for_events parent registration (QUALITY-919) -------------------
+// ---- wait_for_events root registration (push-based child discovery) -------
 
 /// Builds a streamer wired to a mock `AIClient` whose `get_ambient_agent_task`
-/// must never be called. Used by the synchronous short-circuit tests to assert
-/// no server fetch is spawned.
+/// must never be called. Used to assert `register_root_on_wait` and the
+/// child-discovery drain open the owner-side stream without any server fetch.
 fn streamer_with_no_fetch_expected(
     app: &mut warpui::App,
 ) -> warpui::ModelHandle<OrchestrationEventStreamer> {
@@ -2257,316 +2257,340 @@ fn streamer_with_no_fetch_expected(
     })
 }
 
-#[test]
-fn wait_registration_root_with_children_opens_ancestor_include_self_stream() {
-    // The completion of the wait-time parent fetch installs server-recorded
-    // children, advances the cursor, and opens the parent-family ancestor
-    // stream — exactly the not-parent -> parent transition QUALITY-919 adds.
-    App::test((), |mut app| async move {
-        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
-        let own_run_id = "550e8400-e29b-41d4-a716-446655440520";
-        let mut conversation = AIConversation::new(false, false);
-        conversation.set_run_id(own_run_id.to_string());
-        let conversation_id = conversation.id();
-        let terminal_view_id = warpui::EntityId::new();
-        history_model.update(&mut app, |model, ctx| {
-            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
-            model.update_conversation_status(
-                terminal_view_id,
-                conversation_id,
-                ConversationStatus::InProgress,
-                ctx,
-            );
-        });
+/// Adds a conversation for the wait-registration tests and returns its id.
+/// `parent_agent_id` makes it a child; `viewing_shared_session` makes it a
+/// passive remote-run view.
+fn add_wait_conversation(
+    app: &mut App,
+    run_id: Option<&str>,
+    parent_agent_id: Option<&str>,
+    viewing_shared_session: bool,
+) -> AIConversationId {
+    let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+    let mut conversation = AIConversation::new(viewing_shared_session, false);
+    if let Some(run_id) = run_id {
+        conversation.set_run_id(run_id.to_string());
+    }
+    if let Some(parent_agent_id) = parent_agent_id {
+        conversation.set_parent_agent_id(parent_agent_id.to_string());
+    }
+    let conversation_id = conversation.id();
+    let terminal_view_id = warpui::EntityId::new();
+    history_model.update(app, |model, ctx| {
+        model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        model.update_conversation_status(
+            terminal_view_id,
+            conversation_id,
+            ConversationStatus::InProgress,
+            ctx,
+        );
+    });
+    conversation_id
+}
 
-        let ai_client: Arc<dyn AIClient> = Arc::new(MockAIClient::new());
-        let server_api = ServerApiProvider::new_for_test().get();
-        let poller = app.add_singleton_model(|ctx| {
-            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
-        });
+#[test]
+fn wait_root_first_wait_opens_ancestor_include_self_stream() {
+    // Criterion 1: with the flag on, a non-child, non-remote root's first
+    // `register_root_on_wait` makes the conversation eligible and connects an
+    // `AncestorRunId { include_self: true }` stream scoped to its own run id,
+    // before any child is known.
+    App::test((), |mut app| async move {
+        let _flag = FeatureFlag::WaitForEventsParentRegistration.override_enabled(true);
+        let own_run_id = "550e8400-e29b-41d4-a716-446655440520";
+        let conversation_id = add_wait_conversation(&mut app, Some(own_run_id), None, false);
+        let poller = streamer_with_no_fetch_expected(&mut app);
 
         let consumer_id = warpui::EntityId::new();
-        poller.update(&mut app, |me, _| {
-            let stream = me.streams.entry(conversation_id).or_default();
-            stream.event_cursor = 3;
-            stream.watched_run_ids.insert(own_run_id.to_string());
-            stream.consumers.insert(consumer_id);
-        });
-
-        let mut task = make_ambient_task_with_children(vec!["child-run-1".to_string()]);
-        task.last_event_sequence = Some(9);
         poller.update(&mut app, |me, ctx| {
-            me.finish_register_parent_on_wait(conversation_id, Ok(task), ctx);
+            me.streams
+                .entry(conversation_id)
+                .or_default()
+                .consumers
+                .insert(consumer_id);
+            me.register_root_on_wait(conversation_id, ctx);
         });
 
-        poller.read(&app, |me, _| {
+        poller.read(&app, |me, ctx| {
+            assert!(
+                me.is_eligible(conversation_id, ctx),
+                "a wait-registered root must be eligible for the owner-side stream"
+            );
             match connected_filter(me, conversation_id) {
                 Some(AgentEventFilter::AncestorRunId {
                     ancestor_run_id,
                     include_self,
                 }) => {
                     assert_eq!(ancestor_run_id, own_run_id);
-                    assert!(include_self);
+                    assert!(include_self, "wait-time stream must include self");
                 }
                 other => panic!("expected AncestorRunId include_self filter, got {other:?}"),
             }
-            assert_eq!(
-                me.streams.get(&conversation_id).map(|s| s.event_cursor),
-                Some(9),
-                "cursor must advance to max(local, task.last_event_sequence)"
-            );
         });
     });
 }
 
 #[test]
-fn wait_registration_root_without_children_does_not_register() {
-    // An empty children list means the conversation is not an orchestrator:
-    // no parent role is taken and no stream opens.
+fn child_agent_started_registers_child_without_reconnect() {
+    // Criterion 2: a `child_agent_started` event (emitted on the parent run
+    // with the child id in `ref_id`) routed through the owner drain registers
+    // the child in `watched_run_ids` and flips `is_parent_agent_conversation`
+    // true, with no reconnect — the ancestor stream is already open so the
+    // filter shape is unchanged.
     App::test((), |mut app| async move {
-        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        let _flag = FeatureFlag::WaitForEventsParentRegistration.override_enabled(true);
         let own_run_id = "550e8400-e29b-41d4-a716-446655440521";
-        let mut conversation = AIConversation::new(false, false);
-        conversation.set_run_id(own_run_id.to_string());
-        let conversation_id = conversation.id();
-        let terminal_view_id = warpui::EntityId::new();
-        history_model.update(&mut app, |model, ctx| {
-            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
-            model.update_conversation_status(
-                terminal_view_id,
-                conversation_id,
-                ConversationStatus::InProgress,
-                ctx,
-            );
-        });
-
-        let ai_client: Arc<dyn AIClient> = Arc::new(MockAIClient::new());
-        let server_api = ServerApiProvider::new_for_test().get();
-        let poller = app.add_singleton_model(|ctx| {
-            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
-        });
+        let conversation_id = add_wait_conversation(&mut app, Some(own_run_id), None, false);
+        let poller = streamer_with_no_fetch_expected(&mut app);
 
         let consumer_id = warpui::EntityId::new();
-        poller.update(&mut app, |me, _| {
-            let stream = me.streams.entry(conversation_id).or_default();
-            stream.watched_run_ids.insert(own_run_id.to_string());
-            stream.consumers.insert(consumer_id);
-        });
-
         poller.update(&mut app, |me, ctx| {
-            me.finish_register_parent_on_wait(
-                conversation_id,
-                Ok(make_ambient_task_with_children(vec![])),
-                ctx,
-            );
-        });
-
-        poller.read(&app, |me, ctx| {
-            assert!(
-                connected_filter(me, conversation_id).is_none(),
-                "a childless root must not open a stream"
-            );
-            assert!(
-                !me.is_parent_agent_conversation(conversation_id, ctx),
-                "a childless root must not take the parent role"
-            );
-        });
-    });
-}
-
-#[test]
-fn wait_registration_fetch_error_does_not_register() {
-    // A failed fetch is a graceful no-op: no parent role, no stream. The next
-    // wait re-checks.
-    App::test((), |mut app| async move {
-        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
-        let own_run_id = "550e8400-e29b-41d4-a716-446655440522";
-        let mut conversation = AIConversation::new(false, false);
-        conversation.set_run_id(own_run_id.to_string());
-        let conversation_id = conversation.id();
-        let terminal_view_id = warpui::EntityId::new();
-        history_model.update(&mut app, |model, ctx| {
-            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
-            model.update_conversation_status(
-                terminal_view_id,
-                conversation_id,
-                ConversationStatus::InProgress,
-                ctx,
-            );
-        });
-
-        let ai_client: Arc<dyn AIClient> = Arc::new(MockAIClient::new());
-        let server_api = ServerApiProvider::new_for_test().get();
-        let poller = app.add_singleton_model(|ctx| {
-            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
-        });
-
-        let consumer_id = warpui::EntityId::new();
-        poller.update(&mut app, |me, _| {
-            let stream = me.streams.entry(conversation_id).or_default();
-            stream.watched_run_ids.insert(own_run_id.to_string());
-            stream.consumers.insert(consumer_id);
-        });
-
-        poller.update(&mut app, |me, ctx| {
-            me.finish_register_parent_on_wait(
-                conversation_id,
-                Err(anyhow::anyhow!("server unavailable")),
-                ctx,
-            );
-        });
-
-        poller.read(&app, |me, ctx| {
-            assert!(connected_filter(me, conversation_id).is_none());
-            assert!(!me.is_parent_agent_conversation(conversation_id, ctx));
-        });
-    });
-}
-
-#[test]
-fn register_parent_on_wait_flag_off_is_noop() {
-    // With the gating flag off, `register_parent_on_wait` does not fetch.
-    App::test((), |mut app| async move {
-        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
-        let own_run_id = "550e8400-e29b-41d4-a716-446655440523";
-        let mut conversation = AIConversation::new(false, false);
-        conversation.set_run_id(own_run_id.to_string());
-        let conversation_id = conversation.id();
-        let terminal_view_id = warpui::EntityId::new();
-        history_model.update(&mut app, |model, ctx| {
-            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
-            model.update_conversation_status(
-                terminal_view_id,
-                conversation_id,
-                ConversationStatus::InProgress,
-                ctx,
-            );
-        });
-
-        let poller = streamer_with_no_fetch_expected(&mut app);
-        poller.update(&mut app, |me, ctx| {
-            me.register_parent_on_wait(conversation_id, ctx);
-        });
-        poller.read(&app, |me, _| {
-            assert!(connected_filter(me, conversation_id).is_none());
-        });
-    });
-}
-
-#[test]
-fn register_parent_on_wait_child_short_circuits() {
-    // One-level-tree invariant: a child (has_parent_agent) can never be a
-    // parent, so no server fetch is issued and no parent role is taken.
-    App::test((), |mut app| async move {
-        let _flag_guard = FeatureFlag::WaitForEventsParentRegistration.override_enabled(true);
-
-        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
-        let own_run_id = "550e8400-e29b-41d4-a716-446655440524";
-        let mut conversation = AIConversation::new(false, false);
-        conversation.set_run_id(own_run_id.to_string());
-        conversation.set_parent_agent_id("550e8400-e29b-41d4-a716-4466554405fd".to_string());
-        let conversation_id = conversation.id();
-        let terminal_view_id = warpui::EntityId::new();
-        history_model.update(&mut app, |model, ctx| {
-            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
-            model.update_conversation_status(
-                terminal_view_id,
-                conversation_id,
-                ConversationStatus::InProgress,
-                ctx,
-            );
-        });
-
-        let poller = streamer_with_no_fetch_expected(&mut app);
-        poller.update(&mut app, |me, ctx| {
-            me.register_parent_on_wait(conversation_id, ctx);
-        });
-        poller.read(&app, |me, ctx| {
-            assert!(
-                !me.is_parent_agent_conversation(conversation_id, ctx),
-                "a child must not take the parent role"
-            );
-        });
-    });
-}
-
-#[test]
-fn register_parent_on_wait_already_parent_is_idempotent() {
-    // A second call when the conversation is already a known parent must not
-    // re-fetch or churn the open ancestor stream.
-    App::test((), |mut app| async move {
-        let _flag_guard = FeatureFlag::WaitForEventsParentRegistration.override_enabled(true);
-
-        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
-        let own_run_id = "550e8400-e29b-41d4-a716-446655440525";
-        let mut conversation = AIConversation::new(false, false);
-        conversation.set_run_id(own_run_id.to_string());
-        let conversation_id = conversation.id();
-        let terminal_view_id = warpui::EntityId::new();
-        history_model.update(&mut app, |model, ctx| {
-            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
-            model.update_conversation_status(
-                terminal_view_id,
-                conversation_id,
-                ConversationStatus::InProgress,
-                ctx,
-            );
-        });
-
-        let poller = streamer_with_no_fetch_expected(&mut app);
-        let consumer_id = warpui::EntityId::new();
-        poller.update(&mut app, |me, ctx| {
-            let stream = me.streams.entry(conversation_id).or_default();
-            stream.consumers.insert(consumer_id);
-            stream.watched_run_ids.insert(own_run_id.to_string());
-            stream.watched_run_ids.insert("child-1".to_string());
-            me.start_sse_connection(conversation_id, ctx);
+            me.streams
+                .entry(conversation_id)
+                .or_default()
+                .consumers
+                .insert(consumer_id);
+            me.register_root_on_wait(conversation_id, ctx);
         });
         poller.read(&app, |me, _| {
             assert_eq!(sse_generation(me, conversation_id), Some(0));
         });
 
+        let events = vec![make_run_event(
+            CHILD_AGENT_STARTED_EVENT,
+            own_run_id,
+            Some("C"),
+        )];
         poller.update(&mut app, |me, ctx| {
-            me.register_parent_on_wait(conversation_id, ctx);
+            me.register_children_from_events(conversation_id, &events, ctx);
+        });
+
+        poller.read(&app, |me, ctx| {
+            assert!(
+                me.streams
+                    .get(&conversation_id)
+                    .is_some_and(|s| s.watched_run_ids.contains("C")),
+                "child run id must be registered in watched_run_ids"
+            );
+            assert!(
+                me.is_parent_agent_conversation(conversation_id, ctx),
+                "registering a child must flip the conversation to a parent"
+            );
+            assert_eq!(
+                sse_generation(me, conversation_id),
+                Some(0),
+                "child registration must not reconnect the open ancestor stream"
+            );
+            assert!(matches!(
+                connected_filter(me, conversation_id),
+                Some(AgentEventFilter::AncestorRunId {
+                    include_self: true,
+                    ..
+                })
+            ));
+        });
+    });
+}
+
+#[test]
+fn duplicate_child_agent_started_does_not_churn_stream() {
+    // Criterion 3: a second `child_agent_started` for an already-registered
+    // child (here pre-registered via `register_watched_run_id`) causes no
+    // filter churn — no reconnect.
+    App::test((), |mut app| async move {
+        let _flag = FeatureFlag::WaitForEventsParentRegistration.override_enabled(true);
+        let own_run_id = "550e8400-e29b-41d4-a716-446655440522";
+        let conversation_id = add_wait_conversation(&mut app, Some(own_run_id), None, false);
+        let poller = streamer_with_no_fetch_expected(&mut app);
+
+        let consumer_id = warpui::EntityId::new();
+        poller.update(&mut app, |me, ctx| {
+            me.streams
+                .entry(conversation_id)
+                .or_default()
+                .consumers
+                .insert(consumer_id);
+            me.register_root_on_wait(conversation_id, ctx);
+            // Pre-register child "C" via the run_agents path.
+            me.register_watched_run_id(conversation_id, "C".to_string(), ctx);
+        });
+        poller.read(&app, |me, _| {
+            assert_eq!(sse_generation(me, conversation_id), Some(0));
+        });
+
+        let events = vec![
+            make_run_event(CHILD_AGENT_STARTED_EVENT, own_run_id, Some("C")),
+            make_run_event(CHILD_AGENT_STARTED_EVENT, own_run_id, Some("C")),
+        ];
+        poller.update(&mut app, |me, ctx| {
+            me.register_children_from_events(conversation_id, &events, ctx);
         });
         poller.read(&app, |me, _| {
             assert_eq!(
                 sse_generation(me, conversation_id),
                 Some(0),
-                "an already-parent wait must not churn the open ancestor stream"
+                "a child_agent_started for an already-registered child must not churn the stream"
             );
         });
     });
 }
 
 #[test]
-fn register_parent_on_wait_without_self_run_id_is_noop() {
-    // No run_id yet means there is nothing to query the server with; the call
-    // is a no-op and the next wait re-checks.
+fn register_root_on_wait_flag_off_opens_no_stream() {
+    // Criterion 4: with the flag off, `register_root_on_wait` is a no-op:
+    // `ancestor_on_wait` stays false, eligibility is unchanged, and no stream
+    // opens.
     App::test((), |mut app| async move {
-        let _flag_guard = FeatureFlag::WaitForEventsParentRegistration.override_enabled(true);
+        let _flag = FeatureFlag::WaitForEventsParentRegistration.override_enabled(false);
+        let own_run_id = "550e8400-e29b-41d4-a716-446655440523";
+        let conversation_id = add_wait_conversation(&mut app, Some(own_run_id), None, false);
+        let poller = streamer_with_no_fetch_expected(&mut app);
+
+        let consumer_id = warpui::EntityId::new();
+        poller.update(&mut app, |me, ctx| {
+            me.streams
+                .entry(conversation_id)
+                .or_default()
+                .consumers
+                .insert(consumer_id);
+            me.register_root_on_wait(conversation_id, ctx);
+        });
+
+        poller.read(&app, |me, ctx| {
+            assert!(
+                me.streams
+                    .get(&conversation_id)
+                    .is_some_and(|s| !s.ancestor_on_wait),
+                "flag off must not set ancestor_on_wait"
+            );
+            assert!(
+                !me.is_eligible(conversation_id, ctx),
+                "a non-parent root must not become eligible with the flag off"
+            );
+            assert!(connected_filter(me, conversation_id).is_none());
+        });
+    });
+}
+
+#[test]
+fn register_root_on_wait_child_conversation_never_opens_wait_stream() {
+    // Criterion 4: a child (has_parent_agent) conversation never registers for
+    // the wait-time ancestor stream, even with the flag on.
+    App::test((), |mut app| async move {
+        let _flag = FeatureFlag::WaitForEventsParentRegistration.override_enabled(true);
+        let own_run_id = "550e8400-e29b-41d4-a716-446655440524";
+        let parent_agent_id = "550e8400-e29b-41d4-a716-4466554405fd";
+        let conversation_id =
+            add_wait_conversation(&mut app, Some(own_run_id), Some(parent_agent_id), false);
+        let poller = streamer_with_no_fetch_expected(&mut app);
+
+        let consumer_id = warpui::EntityId::new();
+        poller.update(&mut app, |me, ctx| {
+            me.streams
+                .entry(conversation_id)
+                .or_default()
+                .consumers
+                .insert(consumer_id);
+            me.register_root_on_wait(conversation_id, ctx);
+        });
+
+        poller.read(&app, |me, _| {
+            assert!(
+                me.streams
+                    .get(&conversation_id)
+                    .is_some_and(|s| !s.ancestor_on_wait),
+                "a child conversation must not set ancestor_on_wait"
+            );
+        });
+    });
+}
+
+#[test]
+fn register_root_on_wait_remote_view_never_opens_wait_stream() {
+    // Criterion 4: a passive remote-run view (here a shared-session viewer)
+    // never registers for the wait-time ancestor stream, even with the flag on.
+    App::test((), |mut app| async move {
+        let _flag = FeatureFlag::WaitForEventsParentRegistration.override_enabled(true);
+        let own_run_id = "550e8400-e29b-41d4-a716-446655440525";
+        let conversation_id = add_wait_conversation(&mut app, Some(own_run_id), None, true);
+        let poller = streamer_with_no_fetch_expected(&mut app);
+
+        let consumer_id = warpui::EntityId::new();
+        poller.update(&mut app, |me, ctx| {
+            me.streams
+                .entry(conversation_id)
+                .or_default()
+                .consumers
+                .insert(consumer_id);
+            me.register_root_on_wait(conversation_id, ctx);
+        });
+
+        poller.read(&app, |me, _| {
+            assert!(
+                me.streams
+                    .get(&conversation_id)
+                    .is_some_and(|s| !s.ancestor_on_wait),
+                "a remote-run view must not set ancestor_on_wait"
+            );
+        });
+    });
+}
+
+#[test]
+fn unknown_event_type_is_ignored_and_advances_cursor() {
+    // Criterion 5: an unrecognized event_type is ignored by the child-discovery
+    // drain (no child registered) and still advances the cursor via
+    // `handle_event_batch`.
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        let (sender, _receiver) = std::sync::mpsc::sync_channel::<ModelEvent>(4);
+        let mut global_resource_handles = GlobalResourceHandles::mock(&mut app);
+        global_resource_handles.model_event_sender = Some(sender);
+        app.add_singleton_model(|_| GlobalResourceHandlesProvider::new(global_resource_handles));
 
         let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
-        // Intentionally leave run_id unset.
-        let conversation = AIConversation::new(false, false);
+        let own_run_id = "550e8400-e29b-41d4-a716-446655440526";
+        let mut conversation = AIConversation::new(false, false);
+        conversation.set_run_id(own_run_id.to_string());
         let conversation_id = conversation.id();
         let terminal_view_id = warpui::EntityId::new();
         history_model.update(&mut app, |model, ctx| {
             model.restore_conversations(terminal_view_id, vec![conversation], ctx);
-            model.update_conversation_status(
-                terminal_view_id,
-                conversation_id,
-                ConversationStatus::InProgress,
-                ctx,
-            );
         });
 
-        let poller = streamer_with_no_fetch_expected(&mut app);
-        poller.update(&mut app, |me, ctx| {
-            me.register_parent_on_wait(conversation_id, ctx);
+        let mut mock = MockAIClient::new();
+        mock.expect_update_event_sequence_on_server()
+            .returning(|_, _| Ok(()));
+        let ai_client: Arc<dyn AIClient> = Arc::new(mock);
+        let server_api = ServerApiProvider::new_for_test().get();
+        let poller = app.add_singleton_model(|ctx| {
+            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
         });
-        poller.read(&app, |me, _| {
-            assert!(connected_filter(me, conversation_id).is_none());
+
+        let mut event = make_run_event("totally_unknown_event_type", "some-other-run", None);
+        event.sequence = 42;
+        let events = vec![event];
+
+        poller.update(&mut app, |me, ctx| {
+            me.streams.entry(conversation_id).or_default();
+            // The drain registers children first; an unknown event registers none.
+            me.register_children_from_events(conversation_id, &events, ctx);
+            me.handle_event_batch(conversation_id, own_run_id, 0, events, vec![], ctx);
+        });
+
+        poller.read(&app, |me, ctx| {
+            assert!(
+                !me.is_parent_agent_conversation(conversation_id, ctx),
+                "an unknown event must not register any child"
+            );
+        });
+        history_model.read(&app, |model, _| {
+            assert_eq!(
+                model
+                    .conversation(&conversation_id)
+                    .and_then(|c| c.last_event_sequence()),
+                Some(42),
+                "an unknown event must still advance the cursor"
+            );
         });
     });
 }

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -417,10 +417,6 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::IncrementalAutoReload,
         #[cfg(feature = "run_agents_tool")]
         FeatureFlag::RunAgentsTool,
-        #[cfg(feature = "orchestration_viewer_streamer")]
-        FeatureFlag::OrchestrationViewerStreamer,
-        #[cfg(feature = "owner_orchestration_ancestor_streamer")]
-        FeatureFlag::OwnerOrchestrationAncestorStreamer,
         #[cfg(feature = "wait_for_events_parent_registration")]
         FeatureFlag::WaitForEventsParentRegistration,
         #[cfg(feature = "pending_user_query_indicator")]

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -1694,8 +1694,7 @@ fn launch_local_no_harness_child(
                     // so the share-reporter in
                     // `local_tty/terminal_manager.rs` can resolve it from
                     // the selected conversation when the share handshake
-                    // succeeds. Mirrors the pattern used by
-                    // `OrchestrationViewerModel::apply_children_fetch`.
+                    // succeeds.
                     BlocklistAIHistoryModel::handle(ctx).update(ctx, |model, ctx| {
                         if let Some(conversation) = model.conversation_mut(&conversation_id) {
                             conversation.set_task_id(child_task_id);

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
@@ -10,10 +10,8 @@
 //! conversations; the streamer is a shared singleton.
 //! Pill clicks navigate via `SwapPaneToConversation`.
 use std::collections::HashMap;
-use std::time::Duration;
 
 use session_sharing_protocol::common::SessionId;
-use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::{Entity, EntityId, ModelContext, SingletonEntity, WeakViewHandle};
 
 use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
@@ -25,9 +23,6 @@ use crate::ai::blocklist::orchestration_event_streamer::{
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::server::server_api::ServerApiProvider;
 use crate::terminal::{Event as TerminalViewEvent, TerminalView};
-
-/// Refetch cadence for children whose claim-time `session_id` is not yet known.
-const PENDING_SESSION_ID_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Per-child orchestration metadata, keyed by `AmbientAgentTaskId`.
 struct ChildAgentEntry {
@@ -51,9 +46,6 @@ pub struct OrchestrationViewerModel {
     /// Secondary index keyed by stringified `run_id`, used by the
     /// broadcast event handler. Kept in sync with `children`.
     children_by_run_id: HashMap<String, AmbientAgentTaskId>,
-    /// Periodic timer fetching the claim-time `session_id` for
-    /// not-yet-claimed children.
-    pending_session_id_poll_handle: Option<SpawnedFutureHandle>,
     /// Test-only: counts `spawn_task_metadata_fetch` invocations.
     #[cfg(test)]
     metadata_fetch_dispatch_count: usize,
@@ -95,7 +87,6 @@ impl OrchestrationViewerModel {
             terminal_view,
             children: HashMap::new(),
             children_by_run_id: HashMap::new(),
-            pending_session_id_poll_handle: None,
             #[cfg(test)]
             metadata_fetch_dispatch_count: 0,
         };
@@ -340,8 +331,6 @@ impl OrchestrationViewerModel {
                 entry.pane_materialization_requested = true;
                 self.request_child_pane_materialization(conversation_id, sid, ctx);
             }
-            // Re-arm the session_id timer; no-op once all children are materialized.
-            self.maybe_schedule_pending_session_id_poll(ctx);
             return;
         }
 
@@ -426,63 +415,6 @@ impl OrchestrationViewerModel {
         if let Some(sid) = session_id {
             self.request_child_pane_materialization(conversation_id, sid, ctx);
         }
-
-        // Arm the session_id refetch timer.
-        self.maybe_schedule_pending_session_id_poll(ctx);
-    }
-
-    // ---- Pending-session_id polling
-
-    /// True iff at least one tracked child is still pending materialization.
-    fn has_pending_session_id_children(&self) -> bool {
-        self.children
-            .values()
-            .any(|entry| entry.session_id.is_none() || !entry.pane_materialization_requested)
-    }
-
-    /// Schedules the next session_id refetch tick.
-    /// Safe to call unconditionally — bails when not needed.
-    fn maybe_schedule_pending_session_id_poll(&mut self, ctx: &mut ModelContext<Self>) {
-        if self.pending_session_id_poll_handle.is_some() {
-            return;
-        }
-        if !self.has_pending_session_id_children() {
-            return;
-        }
-        let handle = ctx.spawn(
-            async {
-                Timer::after(PENDING_SESSION_ID_POLL_INTERVAL).await;
-            },
-            |me, _, ctx| {
-                me.pending_session_id_poll_handle = None;
-                me.run_pending_session_id_poll(ctx);
-            },
-        );
-        self.pending_session_id_poll_handle = Some(handle);
-    }
-
-    /// Body of the session_id timer tick. Refetches metadata for every
-    /// child still missing a `session_id`/pane, then reschedules until
-    /// the pending set is empty.
-    fn run_pending_session_id_poll(&mut self, ctx: &mut ModelContext<Self>) {
-        let pending: Vec<AmbientAgentTaskId> = self
-            .children
-            .iter()
-            .filter(|(_, entry)| {
-                entry.session_id.is_none() || !entry.pane_materialization_requested
-            })
-            .map(|(task_id, _)| *task_id)
-            .collect();
-
-        if pending.is_empty() {
-            return;
-        }
-
-        for task_id in pending {
-            self.spawn_task_metadata_fetch(task_id, "PendingSessionIdPoll", ctx);
-        }
-
-        self.maybe_schedule_pending_session_id_poll(ctx);
     }
 
     /// Backfills `parent_agent_id` on viewer-created children once the

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
@@ -1,25 +1,18 @@
 //! Drives the orchestration pill bar in shared session viewers.
 //!
 //! After the viewer joins a parent ambient-agent session, this model
-//! discovers and tracks the parent's direct children using one of two
-//! delivery paths, gated on [`FeatureFlag::OrchestrationViewerStreamer`]:
-//!
-//! 1. **Streamer-driven (flag ON, default).** Registers as a viewer-mode
-//!    consumer on [`OrchestrationEventStreamer`], which opens an ancestor
-//!    SSE (seeded by a one-shot REST snapshot) and broadcasts
-//!    `ChildSpawned`/`ChildStatusChanged` events.
-//! 2. **Legacy REST polling (flag OFF).** Periodically polls
-//!    `GET /agent/runs?ancestor_run_id=` and reconciles the full child
-//!    list each cycle.
+//! discovers and tracks the parent's direct children by registering as a
+//! viewer-mode consumer on [`OrchestrationEventStreamer`], which opens an
+//! ancestor SSE (seeded by a one-shot REST snapshot) and broadcasts
+//! `ChildSpawned`/`ChildStatusChanged` events.
 //!
 //! Each viewer pane has its own model with its own placeholder
-//! conversations; the streamer (when on) is a shared singleton.
+//! conversations; the streamer is a shared singleton.
 //! Pill clicks navigate via `SwapPaneToConversation`.
 use std::collections::HashMap;
 use std::time::Duration;
 
 use session_sharing_protocol::common::SessionId;
-use warp_core::features::FeatureFlag;
 use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::{Entity, EntityId, ModelContext, SingletonEntity, WeakViewHandle};
 
@@ -30,16 +23,9 @@ use crate::ai::blocklist::orchestration_event_streamer::{
     OrchestrationEventStreamer, OrchestrationEventStreamerEvent,
 };
 use crate::ai::blocklist::BlocklistAIHistoryModel;
-use crate::server::server_api::ai::TaskListFilter;
 use crate::server::server_api::ServerApiProvider;
 use crate::terminal::{Event as TerminalViewEvent, TerminalView};
 
-/// Max child runs per legacy `?ancestor_run_id=` page (polling path).
-const CHILD_DISCOVERY_FETCH_LIMIT: i32 = 100;
-/// Polling cadence (legacy path) while any child is non-terminal.
-const STATUS_POLL_INTERVAL: Duration = Duration::from_secs(5);
-/// Slower polling cadence (legacy path) once every known child is terminal.
-const STATUS_POLL_INTERVAL_IDLE: Duration = Duration::from_secs(30);
 /// Refetch cadence for children whose claim-time `session_id` is not yet known.
 const PENDING_SESSION_ID_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
@@ -48,7 +34,7 @@ struct ChildAgentEntry {
     conversation_id: AIConversationId,
     /// `None` until execution has been claimed.
     session_id: Option<SessionId>,
-    /// Polling path uses this to dedupe status writes.
+    /// Used to dedupe status writes when re-registering a known child.
     last_state: AmbientAgentTaskState,
     /// True once `EnsureSharedSessionViewerChildPane` has been emitted.
     pane_materialization_requested: bool,
@@ -62,19 +48,11 @@ pub struct OrchestrationViewerModel {
     terminal_view: WeakViewHandle<TerminalView>,
     /// Placeholder conversations materialized for direct children.
     children: HashMap<AmbientAgentTaskId, ChildAgentEntry>,
-    /// Secondary index keyed by stringified `run_id`, used by the streamer
-    /// path's broadcast event handler. Kept in sync with `children`.
+    /// Secondary index keyed by stringified `run_id`, used by the
+    /// broadcast event handler. Kept in sync with `children`.
     children_by_run_id: HashMap<String, AmbientAgentTaskId>,
-    /// (Polling path.) `None` on the streamer path.
-    polling_handle: Option<SpawnedFutureHandle>,
-    /// (Polling path.) Bumped before each fetch so stale responses can
-    /// be dropped.
-    fetch_generation: u64,
-    /// Set when the most recent fetch returned no children; resumed by
-    /// the next orchestrator `AppendedExchange`.
-    idle_due_to_no_children: bool,
-    /// (Streamer path.) Periodic timer fetching the claim-time
-    /// `session_id` for not-yet-claimed children.
+    /// Periodic timer fetching the claim-time `session_id` for
+    /// not-yet-claimed children.
     pending_session_id_poll_handle: Option<SpawnedFutureHandle>,
     /// Test-only: counts `spawn_task_metadata_fetch` invocations.
     #[cfg(test)]
@@ -91,76 +69,41 @@ impl OrchestrationViewerModel {
         self.parent_task_id
     }
     /// Builds a viewer model attached to the given parent shared session.
-    /// See the module docs for the two delivery paths.
+    /// Subscribes to broadcast events filtered on `parent_task_id`; the
+    /// streamer handles SSE open/teardown, cold-start seed, and cursor
+    /// persistence on our behalf.
     pub fn new(
         parent_task_id: AmbientAgentTaskId,
         terminal_view_id: EntityId,
         terminal_view: WeakViewHandle<TerminalView>,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
-        if FeatureFlag::OrchestrationViewerStreamer.is_enabled() {
-            // Streamer-driven path. Subscribe to broadcast events filtered
-            // on `parent_task_id`; the streamer handles SSE open/teardown,
-            // cold-start seed, and cursor persistence on our behalf.
-            let streamer = OrchestrationEventStreamer::handle(ctx);
-            ctx.subscribe_to_model(&streamer, move |me, _, event, ctx| {
-                me.handle_streamer_event(event, ctx);
-            });
-            ctx.subscribe_to_model(
-                &BlocklistAIHistoryModel::handle(ctx),
-                |me, _, event, ctx| {
-                    me.handle_history_event(event, ctx);
-                },
-            );
-
-            let model = Self {
-                parent_task_id,
-                terminal_view_id,
-                terminal_view,
-                children: HashMap::new(),
-                children_by_run_id: HashMap::new(),
-                polling_handle: None,
-                fetch_generation: 0,
-                idle_due_to_no_children: false,
-                pending_session_id_poll_handle: None,
-                #[cfg(test)]
-                metadata_fetch_dispatch_count: 0,
-            };
-            model.register_viewer_mode_consumer_if_possible(ctx);
-            return model;
-        }
-
-        // Legacy polling path. Kick to fast cadence on `AppendedExchange` so
-        // follow-up input that spawns new children surfaces without waiting
-        // for the next 30s idle poll.
+        let streamer = OrchestrationEventStreamer::handle(ctx);
+        ctx.subscribe_to_model(&streamer, move |me, _, event, ctx| {
+            me.handle_streamer_event(event, ctx);
+        });
         ctx.subscribe_to_model(
             &BlocklistAIHistoryModel::handle(ctx),
             |me, _, event, ctx| {
-                me.maybe_kick_polling(event, ctx);
-                me.maybe_backfill_parent_agent_ids(event, ctx);
+                me.handle_history_event(event, ctx);
             },
         );
 
-        let mut model = Self {
+        let model = Self {
             parent_task_id,
             terminal_view_id,
             terminal_view,
             children: HashMap::new(),
             children_by_run_id: HashMap::new(),
-            polling_handle: None,
-            fetch_generation: 0,
-            idle_due_to_no_children: false,
             pending_session_id_poll_handle: None,
             #[cfg(test)]
             metadata_fetch_dispatch_count: 0,
         };
-
-        // Each fetch reschedules itself via its response callback.
-        model.fetch_children(ctx);
+        model.register_viewer_mode_consumer_if_possible(ctx);
         model
     }
 
-    // ---- Streamer-driven path (FeatureFlag::OrchestrationViewerStreamer on)
+    // ---- Streamer-driven child discovery
 
     fn handle_history_event(
         &mut self,
@@ -344,7 +287,7 @@ impl OrchestrationViewerModel {
         );
     }
 
-    // ---- Shared child registration (used by both paths) -----------------
+    // ---- Child registration
 
     /// Creates the local placeholder conversation for a child task,
     /// records it in the per-pane map, and emits
@@ -368,8 +311,8 @@ impl OrchestrationViewerModel {
 
         if let Some(entry) = self.children.get_mut(&task_id) {
             // Existing child: update status if it changed and fill in
-            // session id once it becomes available. (Polling path replays
-            // every cycle; streamer path can also re-register on reconnect.)
+            // session id once it becomes available. The streamer can
+            // re-register the same child on reconnect.
             if entry.last_state != new_state {
                 let conversation_id = entry.conversation_id;
                 let terminal_view_id = self.terminal_view_id;
@@ -484,11 +427,11 @@ impl OrchestrationViewerModel {
             self.request_child_pane_materialization(conversation_id, sid, ctx);
         }
 
-        // Streamer path only: arm the session_id refetch timer.
+        // Arm the session_id refetch timer.
         self.maybe_schedule_pending_session_id_poll(ctx);
     }
 
-    // ---- Pending-session_id polling (streamer path) -------------------
+    // ---- Pending-session_id polling
 
     /// True iff at least one tracked child is still pending materialization.
     fn has_pending_session_id_children(&self) -> bool {
@@ -497,12 +440,9 @@ impl OrchestrationViewerModel {
             .any(|entry| entry.session_id.is_none() || !entry.pane_materialization_requested)
     }
 
-    /// Schedules the next session_id refetch tick on the streamer path.
+    /// Schedules the next session_id refetch tick.
     /// Safe to call unconditionally — bails when not needed.
     fn maybe_schedule_pending_session_id_poll(&mut self, ctx: &mut ModelContext<Self>) {
-        if !FeatureFlag::OrchestrationViewerStreamer.is_enabled() {
-            return;
-        }
         if self.pending_session_id_poll_handle.is_some() {
             return;
         }
@@ -545,111 +485,10 @@ impl OrchestrationViewerModel {
         self.maybe_schedule_pending_session_id_poll(ctx);
     }
 
-    // ---- Legacy polling path (FeatureFlag::OrchestrationViewerStreamer off)
-
-    /// Schedules the next poll: fast cadence while any child is
-    /// non-terminal, slow once all are terminal. Skipped while
-    /// [`Self::idle_due_to_no_children`] is set; [`Self::maybe_kick_polling`]
-    /// resumes on the next orchestrator `AppendedExchange`.
-    fn schedule_next_poll(&mut self, ctx: &mut ModelContext<Self>) {
-        // `SpawnedFutureHandle` doesn't abort on drop, so abort
-        // explicitly to avoid stacking parallel timer chains.
-        if let Some(prior) = self.polling_handle.take() {
-            prior.abort();
-        }
-
-        // Stay idle until an `AppendedExchange` on the orchestrator wakes
-        // us up. `apply_children_fetch` is responsible for setting this
-        // flag when an empty descendant list comes back.
-        if self.idle_due_to_no_children {
-            return;
-        }
-
-        let all_terminal = !self.children.is_empty()
-            && self
-                .children
-                .values()
-                .all(|child| child.last_state.is_terminal());
-        let interval = if all_terminal {
-            STATUS_POLL_INTERVAL_IDLE
-        } else {
-            STATUS_POLL_INTERVAL
-        };
-
-        let handle = ctx.spawn(
-            async move {
-                Timer::after(interval).await;
-            },
-            |me, _, ctx| me.fetch_children(ctx),
-        );
-        self.polling_handle = Some(handle);
-    }
-
-    /// Tightens polling on `AppendedExchange` during the idle→active
-    /// transition, and resumes from `idle_due_to_no_children` on an
-    /// orchestrator-scoped exchange. The idle-resume check runs first
-    /// because it would otherwise be conflated with the
-    /// "fetch in flight" state by the `polling_handle.is_none()` guard.
-    fn maybe_kick_polling(
-        &mut self,
-        event: &BlocklistAIHistoryEvent,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        let BlocklistAIHistoryEvent::AppendedExchange {
-            conversation_id, ..
-        } = event
-        else {
-            return;
-        };
-        let conversation_id = *conversation_id;
-        let is_orchestrator = self.find_parent_conversation_id(ctx) == Some(conversation_id);
-
-        // Resume from idle-due-to-no-children. Only orchestrator-scoped
-        // exchanges count: child events are ignored because we have no
-        // tracked children to update yet, and an unrelated conversation's
-        // exchange does not imply this orchestrator just spawned a child.
-        if self.idle_due_to_no_children {
-            if is_orchestrator {
-                self.idle_due_to_no_children = false;
-                if let Some(prior) = self.polling_handle.take() {
-                    prior.abort();
-                }
-                self.fetch_children(ctx);
-            }
-            return;
-        }
-
-        let all_terminal = !self.children.is_empty()
-            && self
-                .children
-                .values()
-                .all(|child| child.last_state.is_terminal());
-        if !all_terminal {
-            return;
-        }
-        // `polling_handle = None` here means a kick fetch is already in
-        // flight (the idle-due-to-no-children case is handled above);
-        // skipping prevents pile-up when exchanges arrive in bursts.
-        if self.polling_handle.is_none() {
-            return;
-        }
-        let is_tracked_child = self
-            .children
-            .values()
-            .any(|child| child.conversation_id == conversation_id);
-        if !is_orchestrator && !is_tracked_child {
-            return;
-        }
-        if let Some(prior) = self.polling_handle.take() {
-            prior.abort();
-        }
-        self.fetch_children(ctx);
-    }
-
     /// Backfills `parent_agent_id` on viewer-created children once the
-    /// orchestrator receives its server token / run id. First-poll
-    /// children are created with `parent_agent_id = None` because the
-    /// orchestrator hasn't been identified yet; this fixes them up so
+    /// orchestrator receives its server token / run id. Children
+    /// registered before the orchestrator was identified are created with
+    /// `parent_agent_id = None`; this fixes them up so
     /// `parent_conversation_id` resolution works.
     fn maybe_backfill_parent_agent_ids(
         &mut self,
@@ -690,75 +529,6 @@ impl OrchestrationViewerModel {
                 child.set_parent_agent_id(parent_agent_id.clone());
             }
         });
-    }
-
-    /// Issues a `GET /agent/runs?ancestor_run_id={parent_task_id}` request
-    /// and routes the response into [`Self::apply_children_fetch`]. Errors
-    /// are logged and ignored; the next poll retries.
-    fn fetch_children(&mut self, ctx: &mut ModelContext<Self>) {
-        // Bump generation BEFORE dispatch so any in-flight stale fetch
-        // is invalidated when its response callback compares.
-        self.fetch_generation = self.fetch_generation.wrapping_add(1);
-        let fetch_generation = self.fetch_generation;
-
-        let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
-        let filter = TaskListFilter {
-            ancestor_run_id: Some(self.parent_task_id.to_string()),
-            ..TaskListFilter::default()
-        };
-        let parent_task_id = self.parent_task_id;
-
-        ctx.spawn(
-            async move {
-                ai_client
-                    .list_ambient_agent_tasks(CHILD_DISCOVERY_FETCH_LIMIT, filter)
-                    .await
-            },
-            move |me, result, ctx| {
-                // Stale fetch: a newer one's already in flight (or applied).
-                // The newer fetch owns rescheduling.
-                if me.fetch_generation != fetch_generation {
-                    return;
-                }
-                match result {
-                    Ok(tasks) => me.apply_children_fetch(tasks, ctx),
-                    Err(err) => {
-                        log::warn!(
-                            "OrchestrationViewerModel: failed to fetch children for {parent_task_id}: {err:#}"
-                        );
-                    }
-                }
-                // Always reschedule (even on error) so transient failures
-                // don't break the polling loop.
-                me.schedule_next_poll(ctx);
-            },
-        );
-    }
-
-    /// Consumes a children list response, registering new children and
-    /// updating statuses / session ids on existing ones. Each child goes
-    /// through [`Self::register_child`] which is shared with the streamer
-    /// path. Also manages the polling-path `idle_due_to_no_children` flag
-    /// so an empty descendant list parks the timer chain until the next
-    /// orchestrator `AppendedExchange` resumes it.
-    fn apply_children_fetch(&mut self, tasks: Vec<AmbientAgentTask>, ctx: &mut ModelContext<Self>) {
-        for task in tasks {
-            self.register_child(task, ctx);
-        }
-
-        // Polling-cost mitigation: if no children are tracked after this
-        // fetch, stop scheduling timers. The resume signal is an
-        // `AppendedExchange` on the orchestrator (see
-        // `maybe_kick_polling`). `schedule_next_poll` honours this flag
-        // and bails before spawning a new timer.
-        if self.children.is_empty() {
-            self.idle_due_to_no_children = true;
-            if let Some(prior) = self.polling_handle.take() {
-                prior.abort();
-            }
-        } else {
-            self.idle_due_to_no_children = false;
-        }
     }
 
     // ---- Shared helpers ------------------------------------------------

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
@@ -172,7 +172,6 @@ fn setup_model(
         terminal_view: terminal_view.downgrade(),
         children: HashMap::new(),
         children_by_run_id: HashMap::new(),
-        pending_session_id_poll_handle: None,
         metadata_fetch_dispatch_count: 0,
     };
 
@@ -294,7 +293,6 @@ fn skips_child_when_no_active_parent_conversation() {
             terminal_view: terminal_view.downgrade(),
             children: HashMap::new(),
             children_by_run_id: HashMap::new(),
-            pending_session_id_poll_handle: None,
             metadata_fetch_dispatch_count: 0,
         };
         let model_handle = app.add_model(|_| model);
@@ -841,182 +839,6 @@ fn child_status_changed_refetches_metadata_while_session_id_is_pending() {
                 model.metadata_fetch_dispatch_count, 1,
                 "materialized child + session_id present ⇒ status-only writes; \
                  no additional refetch"
-            );
-        });
-    });
-}
-
-#[test]
-fn pending_session_id_poll_schedules_while_session_id_is_none() {
-    // Regression for the session_id-discovery latency case: when a child
-    // is first observed with session_id=None and no ChildStatusChanged
-    // event fires for many seconds, the pre-existing
-    // `handle_child_status_changed` refetch hook never gets a chance to
-    // run. `maybe_schedule_pending_session_id_poll` plugs that gap by
-    // periodically calling `spawn_task_metadata_fetch` until the entry
-    // is materialized.
-    //
-    // This test verifies the scheduling decision and the poll-tick
-    // dispatch decision without advancing the timer; we drive
-    // `run_pending_session_id_poll` directly (what the timer's callback
-    // would do).
-    App::test((), |mut app| async move {
-        let parent = task_id(PARENT_TASK_ID);
-        let (_, _, model) = setup_model(&mut app, parent);
-        let model_handle = app.add_model(|_| model);
-
-        // Register a pre-claim child (session_id=None).
-        model_handle.update(&mut app, |model, ctx| {
-            model.register_child(
-                make_task(
-                    CHILD_A_TASK_ID,
-                    AmbientAgentTaskState::Queued,
-                    "Worker",
-                    None,
-                ),
-                ctx,
-            );
-        });
-        model_handle.read(&app, |model, _| {
-            assert!(
-                model.has_pending_session_id_children(),
-                "sanity: pre-claim child should be pending materialization"
-            );
-            assert!(
-                model.pending_session_id_poll_handle.is_some(),
-                "register_child for a pre-claim child must schedule the polling timer"
-            );
-            assert_eq!(
-                model.metadata_fetch_dispatch_count, 0,
-                "direct register_child bypasses spawn_task_metadata_fetch; \
-                 the counter only increments on poll-tick dispatch"
-            );
-        });
-
-        // Simulate a timer tick by directly invoking the poll body. The
-        // tick should dispatch one metadata refetch and reschedule the
-        // timer because the child is still pending.
-        model_handle.update(&mut app, |model, ctx| {
-            model.run_pending_session_id_poll(ctx);
-        });
-        model_handle.read(&app, |model, _| {
-            assert_eq!(
-                model.metadata_fetch_dispatch_count, 1,
-                "poll tick must dispatch one metadata refetch per pending child"
-            );
-            assert!(
-                model.pending_session_id_poll_handle.is_some(),
-                "poll tick must reschedule the timer while children remain pending"
-            );
-        });
-
-        // Simulate the refetch callback delivering a task with a session_id;
-        // the existing-entry branch of register_child flips
-        // pane_materialization_requested and the poll should self-cancel
-        // on the next tick.
-        model_handle.update(&mut app, |model, ctx| {
-            model.register_child(
-                make_task(
-                    CHILD_A_TASK_ID,
-                    AmbientAgentTaskState::InProgress,
-                    "Worker",
-                    Some(SESSION_A),
-                ),
-                ctx,
-            );
-        });
-        model_handle.read(&app, |model, _| {
-            assert!(
-                !model.has_pending_session_id_children(),
-                "materialized child must clear the pending gate"
-            );
-        });
-
-        // Drive the next tick: it should observe no pending children and
-        // NOT reschedule the timer.
-        model_handle.update(&mut app, |model, ctx| {
-            model.pending_session_id_poll_handle = None;
-            model.run_pending_session_id_poll(ctx);
-        });
-        model_handle.read(&app, |model, _| {
-            assert_eq!(
-                model.metadata_fetch_dispatch_count, 1,
-                "poll tick with no pending children must dispatch zero refetches"
-            );
-            assert!(
-                model.pending_session_id_poll_handle.is_none(),
-                "poll tick with no pending children must NOT reschedule the timer"
-            );
-        });
-    });
-}
-
-#[test]
-fn pending_session_id_poll_does_not_schedule_when_no_children_pending() {
-    // Belt-and-braces: registering a child that already has a session_id
-    // should NOT schedule the polling timer at all, since there's nothing
-    // to discover. This bounds polling cost in the common case where the
-    // server has already claimed execution by the time we observe the
-    // child.
-    App::test((), |mut app| async move {
-        let parent = task_id(PARENT_TASK_ID);
-        let (_, _, model) = setup_model(&mut app, parent);
-        let model_handle = app.add_model(|_| model);
-
-        model_handle.update(&mut app, |model, ctx| {
-            model.register_child(
-                make_task(
-                    CHILD_A_TASK_ID,
-                    AmbientAgentTaskState::InProgress,
-                    "Worker",
-                    Some(SESSION_A),
-                ),
-                ctx,
-            );
-        });
-        model_handle.read(&app, |model, _| {
-            assert!(
-                !model.has_pending_session_id_children(),
-                "sanity: post-claim child is not pending"
-            );
-            assert!(
-                model.pending_session_id_poll_handle.is_none(),
-                "post-claim child must NOT schedule the polling timer"
-            );
-        });
-    });
-}
-
-#[test]
-fn pending_session_id_poll_dispatches_per_pending_child() {
-    // Two pre-claim children → one timer; the tick should dispatch one
-    // refetch per pending child.
-    App::test((), |mut app| async move {
-        let parent = task_id(PARENT_TASK_ID);
-        let (_, _, model) = setup_model(&mut app, parent);
-        let model_handle = app.add_model(|_| model);
-
-        for child_id in [CHILD_A_TASK_ID, CHILD_B_TASK_ID] {
-            model_handle.update(&mut app, |model, ctx| {
-                model.register_child(
-                    make_task(child_id, AmbientAgentTaskState::Queued, "Worker", None),
-                    ctx,
-                );
-            });
-        }
-        model_handle.read(&app, |model, _| {
-            assert_eq!(model.children.len(), 2);
-            assert!(model.pending_session_id_poll_handle.is_some());
-            assert_eq!(model.metadata_fetch_dispatch_count, 0);
-        });
-
-        model_handle.update(&mut app, |model, ctx| {
-            model.run_pending_session_id_poll(ctx);
-        });
-        model_handle.read(&app, |model, _| {
-            assert_eq!(
-                model.metadata_fetch_dispatch_count, 2,
-                "poll tick must dispatch one refetch per pending child"
             );
         });
     });

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
@@ -2,32 +2,21 @@
 //!
 //! Layout:
 //!
-//! 1. Pure-function tests for [`conversation_status_from_state`]. These carry
-//!    over unchanged from the legacy polling path.
-//! 2. Streamer-driven path tests (`OrchestrationViewerStreamer` on). The model translates
+//! 1. Pure-function tests for [`conversation_status_from_state`].
+//! 2. `register_child` tests covering the shared registration path.
+//! 3. Streamer-driven path tests. The model translates
 //!    `OrchestrationEventStreamerEvent::ChildSpawned` /
 //!    `ChildStatusChanged` events into local placeholder conversations.
 //!    These tests drive the model via the streamer's emit path and a
 //!    `MockAIClient` that returns canned `get_ambient_agent_task` responses
 //!    for the pill metadata fetch.
-//! 3. Legacy polling-path tests (`OrchestrationViewerStreamer` off). The model registers children
-//!    from `register_child` (called from `apply_children_fetch`). These map
-//!    directly to the spec's polling-path semantics.
-//!
-//! `apply_children_fetch` itself is exercised through `register_child`, so
-//! we drive the polling-path tests at the same boundary by calling
-//! `register_child` from the test rather than invoking a synthetic
-//! `apply_children_fetch` shell.
 
 use std::sync::Arc;
 
 use chrono::Utc;
-use warp_core::features::FeatureFlag;
 use warpui::{App, EntityId, SingletonEntity};
 
 use super::*;
-use crate::ai::agent::task::TaskId;
-use crate::ai::agent::AIAgentExchangeId;
 use crate::ai::ambient_agents::task::{AgentConfigSnapshot, AmbientAgentTask};
 use crate::ai::blocklist::orchestration_event_streamer::OrchestrationEventStreamerEvent;
 use crate::server::server_api::ai::{AIClient, MockAIClient};
@@ -162,8 +151,7 @@ fn make_task_with_name(
 /// Wires up `BlocklistAIHistoryModel`, a real [`TerminalView`], and an
 /// orchestrator parent conversation marked active for that view. Returns
 /// the model built directly (bypassing `OrchestrationViewerModel::new`,
-/// which would otherwise kick off either a REST fetch or a streamer
-/// registration).
+/// which would otherwise kick off a streamer registration).
 fn setup_model(
     app: &mut App,
     parent_task_id: AmbientAgentTaskId,
@@ -184,9 +172,6 @@ fn setup_model(
         terminal_view: terminal_view.downgrade(),
         children: HashMap::new(),
         children_by_run_id: HashMap::new(),
-        polling_handle: None,
-        fetch_generation: 0,
-        idle_due_to_no_children: false,
         pending_session_id_poll_handle: None,
         metadata_fetch_dispatch_count: 0,
     };
@@ -302,16 +287,13 @@ fn skips_child_when_no_active_parent_conversation() {
 
         // Do NOT create a parent conversation for this terminal view.
         // find_parent_conversation_id() should return None and the child
-        // registration should be deferred to the next event/poll.
+        // registration should be deferred to the next event.
         let model = OrchestrationViewerModel {
             parent_task_id: task_id(PARENT_TASK_ID),
             terminal_view_id,
             terminal_view: terminal_view.downgrade(),
             children: HashMap::new(),
             children_by_run_id: HashMap::new(),
-            polling_handle: None,
-            fetch_generation: 0,
-            idle_due_to_no_children: false,
             pending_session_id_poll_handle: None,
             metadata_fetch_dispatch_count: 0,
         };
@@ -879,7 +861,6 @@ fn pending_session_id_poll_schedules_while_session_id_is_none() {
     // `run_pending_session_id_poll` directly (what the timer's callback
     // would do).
     App::test((), |mut app| async move {
-        let _streamer_guard = FeatureFlag::OrchestrationViewerStreamer.override_enabled(true);
         let parent = task_id(PARENT_TASK_ID);
         let (_, _, model) = setup_model(&mut app, parent);
         let model_handle = app.add_model(|_| model);
@@ -978,7 +959,6 @@ fn pending_session_id_poll_does_not_schedule_when_no_children_pending() {
     // server has already claimed execution by the time we observe the
     // child.
     App::test((), |mut app| async move {
-        let _streamer_guard = FeatureFlag::OrchestrationViewerStreamer.override_enabled(true);
         let parent = task_id(PARENT_TASK_ID);
         let (_, _, model) = setup_model(&mut app, parent);
         let model_handle = app.add_model(|_| model);
@@ -1012,7 +992,6 @@ fn pending_session_id_poll_dispatches_per_pending_child() {
     // Two pre-claim children → one timer; the tick should dispatch one
     // refetch per pending child.
     App::test((), |mut app| async move {
-        let _streamer_guard = FeatureFlag::OrchestrationViewerStreamer.override_enabled(true);
         let parent = task_id(PARENT_TASK_ID);
         let (_, _, model) = setup_model(&mut app, parent);
         let model_handle = app.add_model(|_| model);
@@ -1097,7 +1076,7 @@ fn child_status_changed_does_not_refetch_when_already_materialized() {
 
 #[test]
 fn b1_populates_agent_id_to_conversation_id_for_new_child() {
-    // After `apply_children_fetch` registers a new viewer-created child,
+    // After `register_child` registers a new viewer-created child,
     // `BlocklistAIHistoryModel::conversation_id_for_agent_id` resolves the
     // child's `run_id` back to the local child conversation so sibling
     // references in transcript bodies render display names instead of
@@ -1108,13 +1087,13 @@ fn b1_populates_agent_id_to_conversation_id_for_new_child() {
         let model_handle = app.add_model(|_| model);
 
         model_handle.update(&mut app, |model, ctx| {
-            model.apply_children_fetch(
-                vec![make_task(
+            model.register_child(
+                make_task(
                     CHILD_A_TASK_ID,
                     AmbientAgentTaskState::InProgress,
                     "Worker",
                     None,
-                )],
+                ),
                 ctx,
             );
         });
@@ -1159,13 +1138,13 @@ fn b2_backfills_parent_agent_id_on_orchestrator_token_assigned() {
         // Step 1: register a child while the parent has no orchestration
         // agent id. The child's `parent_agent_id` must be `None`.
         model_handle.update(&mut app, |model, ctx| {
-            model.apply_children_fetch(
-                vec![make_task(
+            model.register_child(
+                make_task(
                     CHILD_A_TASK_ID,
                     AmbientAgentTaskState::InProgress,
                     "Worker",
                     None,
-                )],
+                ),
                 ctx,
             );
         });
@@ -1245,13 +1224,13 @@ fn b2_does_not_overwrite_existing_parent_agent_id() {
             );
         });
         model_handle.update(&mut app, |model, ctx| {
-            model.apply_children_fetch(
-                vec![make_task(
+            model.register_child(
+                make_task(
                     CHILD_A_TASK_ID,
                     AmbientAgentTaskState::InProgress,
                     "Worker",
                     None,
-                )],
+                ),
                 ctx,
             );
         });
@@ -1290,13 +1269,13 @@ fn b2_ignores_token_assigned_for_unrelated_conversation() {
         let model_handle = app.add_model(|_| model);
 
         model_handle.update(&mut app, |model, ctx| {
-            model.apply_children_fetch(
-                vec![make_task(
+            model.register_child(
+                make_task(
                     CHILD_A_TASK_ID,
                     AmbientAgentTaskState::InProgress,
                     "Worker",
                     None,
-                )],
+                ),
                 ctx,
             );
         });
@@ -1337,251 +1316,7 @@ fn b2_ignores_token_assigned_for_unrelated_conversation() {
 //
 // Removed: tracked separately under shared-session viewer support work.
 
-// ---- idle_due_to_no_children polling-cost mitigation ----------------------
-
-/// Builds an [`AppendedExchange`] event for the given conversation, with
-/// stub identifiers for the unrelated fields. Mirrors what the history
-/// model would emit when a fresh exchange is appended; the model's
-/// `maybe_kick_polling` handler only reads `conversation_id`.
-fn make_appended_exchange_event(
-    conversation_id: AIConversationId,
-    terminal_view_id: EntityId,
-) -> BlocklistAIHistoryEvent {
-    BlocklistAIHistoryEvent::AppendedExchange {
-        exchange_id: AIAgentExchangeId::new(),
-        task_id: TaskId::new("test-task".to_string()),
-        terminal_surface_id: terminal_view_id,
-        conversation_id,
-        is_hidden: false,
-        response_stream_id: None,
-    }
-}
-
-/// Spawns a long-lived no-op future and stores its handle on the model.
-/// Used to populate `polling_handle` in tests so we can assert that the
-/// polling-state machine aborts it when transitioning to the
-/// idle-due-to-no-children state.
-///
-/// `SpawnedFutureHandle::abort()` doesn't expose an observable side-effect
-/// from outside the model, so the assertion target is
-/// `model.polling_handle.is_none()` after the transition. The timer is
-/// scheduled for an hour so it cannot fire during the test.
-fn populate_polling_handle(
-    model: &mut OrchestrationViewerModel,
-    ctx: &mut ModelContext<OrchestrationViewerModel>,
-) {
-    let handle = ctx.spawn(
-        async {
-            Timer::after(Duration::from_secs(3600)).await;
-        },
-        |_me, _, _ctx| {},
-    );
-    model.polling_handle = Some(handle);
-}
-
-#[test]
-fn empty_descendant_fetch_sets_idle_flag_and_aborts_polling() {
-    // When a non-orchestrator share's first descendant fetch returns no
-    // children, the viewer model sets `idle_due_to_no_children = true`
-    // and tears down its polling handle. `schedule_next_poll` later
-    // honours the flag and refuses to spawn another timer, so the model
-    // spends zero CPU / network until an `AppendedExchange` on the
-    // orchestrator wakes it up.
-    App::test((), |mut app| async move {
-        let parent = task_id(PARENT_TASK_ID);
-        let (_, _, model) = setup_model(&mut app, parent);
-        let model_handle = app.add_model(|_| model);
-
-        // Simulate an already-active polling cadence by pre-populating the
-        // handle. After the empty fetch this handle should be cleared.
-        model_handle.update(&mut app, |model, ctx| {
-            populate_polling_handle(model, ctx);
-        });
-        model_handle.read(&app, |model, _| {
-            assert!(
-                model.polling_handle.is_some(),
-                "sanity: polling_handle populated for the test"
-            );
-            assert!(
-                !model.idle_due_to_no_children,
-                "sanity: idle flag starts clear"
-            );
-        });
-
-        // Server returns no descendants. `apply_children_fetch` is the
-        // sync portion of the fetch callback, so calling it directly
-        // exercises the polling-state transition without an HTTP round
-        // trip.
-        model_handle.update(&mut app, |model, ctx| {
-            model.apply_children_fetch(vec![], ctx);
-        });
-
-        model_handle.read(&app, |model, _| {
-            assert!(
-                model.idle_due_to_no_children,
-                "empty fetch must mark the model as idle-due-to-no-children"
-            );
-            assert!(
-                model.polling_handle.is_none(),
-                "empty fetch must abort the prior polling handle and clear the field"
-            );
-            assert!(
-                model.children.is_empty(),
-                "sanity: no children were registered"
-            );
-        });
-    });
-}
-
-#[test]
-fn appended_exchange_on_orchestrator_resumes_from_idle() {
-    // Once the model has gone idle on an empty fetch, the next
-    // `AppendedExchange` on the orchestrator conversation must resume
-    // polling: clear the idle flag and call `fetch_children`. We observe
-    // `fetch_children` indirectly via `fetch_generation`, which is bumped
-    // synchronously at the head of the function before any spawn fires.
-    App::test((), |mut app| async move {
-        let parent = task_id(PARENT_TASK_ID);
-        let (terminal_view_id, parent_conv_id, model) = setup_model(&mut app, parent);
-        let model_handle = app.add_model(|_| model);
-
-        // Drive the model into the idle state via the same path the
-        // production fetch callback would: empty descendant list.
-        model_handle.update(&mut app, |model, ctx| {
-            model.apply_children_fetch(vec![], ctx);
-        });
-        let generation_before_resume = model_handle.read(&app, |model, _| {
-            assert!(
-                model.idle_due_to_no_children,
-                "sanity: idle flag set after empty fetch"
-            );
-            assert!(
-                model.polling_handle.is_none(),
-                "sanity: polling handle aborted"
-            );
-            model.fetch_generation
-        });
-
-        // Fire an `AppendedExchange` against the orchestrator. The model
-        // resumes via the idle-due-to-no-children branch in
-        // `maybe_kick_polling`.
-        let event = make_appended_exchange_event(parent_conv_id, terminal_view_id);
-        model_handle.update(&mut app, |model, ctx| {
-            model.maybe_kick_polling(&event, ctx);
-        });
-
-        model_handle.read(&app, |model, _| {
-            assert!(
-                !model.idle_due_to_no_children,
-                "AppendedExchange on the orchestrator must clear the idle flag"
-            );
-            assert_eq!(
-                model.fetch_generation,
-                generation_before_resume.wrapping_add(1),
-                "AppendedExchange on the orchestrator must call fetch_children, \
-                 which bumps fetch_generation by one",
-            );
-        });
-    });
-}
-
-#[test]
-fn non_empty_fetch_clears_idle_flag_and_resumes_polling() {
-    // The complementary path: a fetch that *does* discover children
-    // clears the idle flag so subsequent `schedule_next_poll` calls go
-    // back to the active cadence. We then exercise `schedule_next_poll`
-    // directly to verify that, once the flag is clear, a new
-    // `polling_handle` is created.
-    App::test((), |mut app| async move {
-        let parent = task_id(PARENT_TASK_ID);
-        let (_, _, mut model) = setup_model(&mut app, parent);
-        // Manually start from the idle state so we can confirm the
-        // non-empty fetch clears it.
-        model.idle_due_to_no_children = true;
-        let model_handle = app.add_model(|_| model);
-
-        model_handle.update(&mut app, |model, ctx| {
-            model.apply_children_fetch(
-                vec![make_task(
-                    CHILD_A_TASK_ID,
-                    AmbientAgentTaskState::InProgress,
-                    "Worker",
-                    None,
-                )],
-                ctx,
-            );
-        });
-        model_handle.read(&app, |model, _| {
-            assert!(
-                !model.idle_due_to_no_children,
-                "non-empty fetch must clear the idle flag"
-            );
-            assert_eq!(model.children.len(), 1, "child was registered");
-        });
-
-        // The fetch callback would normally call `schedule_next_poll`
-        // right after `apply_children_fetch`. Invoke it explicitly so we
-        // can assert that, with the flag now cleared, a new polling
-        // handle is installed.
-        model_handle.update(&mut app, |model, ctx| {
-            model.schedule_next_poll(ctx);
-        });
-        model_handle.read(&app, |model, _| {
-            assert!(
-                model.polling_handle.is_some(),
-                "schedule_next_poll must spawn a new timer when not idle"
-            );
-        });
-    });
-}
-
-#[test]
-fn appended_exchange_on_non_orchestrator_does_not_resume_idle() {
-    // Symmetric to the orchestrator-resume test: an exchange on an
-    // unrelated conversation (i.e. not the orchestrator tracked by this
-    // viewer) must not pull the model out of the idle-due-to-no-children
-    // state. The flag stays set and `fetch_children` is not invoked.
-    App::test((), |mut app| async move {
-        let parent = task_id(PARENT_TASK_ID);
-        let (terminal_view_id, _, model) = setup_model(&mut app, parent);
-        let model_handle = app.add_model(|_| model);
-
-        // Idle the model.
-        model_handle.update(&mut app, |model, ctx| {
-            model.apply_children_fetch(vec![], ctx);
-        });
-        let generation_before_event = model_handle.read(&app, |model, _| {
-            assert!(model.idle_due_to_no_children, "sanity: model is idle");
-            model.fetch_generation
-        });
-
-        // Fire an `AppendedExchange` for some unrelated conversation. The
-        // resume gate compares against the orchestrator id returned by
-        // `find_parent_conversation_id`, so a fresh id will not match.
-        let unrelated_conversation_id = AIConversationId::new();
-        let event = make_appended_exchange_event(unrelated_conversation_id, terminal_view_id);
-        model_handle.update(&mut app, |model, ctx| {
-            model.maybe_kick_polling(&event, ctx);
-        });
-
-        model_handle.read(&app, |model, _| {
-            assert!(
-                model.idle_due_to_no_children,
-                "AppendedExchange on an unrelated conversation must NOT resume the model"
-            );
-            assert_eq!(
-                model.fetch_generation, generation_before_event,
-                "fetch_children must not run when the resume gate doesn't match the orchestrator"
-            );
-            assert!(
-                model.polling_handle.is_none(),
-                "polling handle must remain cleared while idle"
-            );
-        });
-    });
-}
-
-// ---- Streamer-driven path tests (`OrchestrationViewerStreamer` on) ----------
+// ---- Streamer-driven path tests ---------------------------------------------
 
 #[test]
 fn handle_streamer_event_filters_on_parent_task_id() {
@@ -1652,15 +1387,11 @@ fn child_spawned_with_malformed_run_id_is_dropped() {
 }
 
 #[test]
-fn streamer_consumer_is_registered_when_constructed_under_flag() {
-    // With `OrchestrationViewerStreamer` on, `OrchestrationViewerModel::new`
-    // registers the pane on the shared streamer entry and kicks off the
-    // cold-start seed.
-    use warp_core::features::FeatureFlag;
+fn streamer_consumer_is_registered_when_constructed() {
+    // `OrchestrationViewerModel::new` registers the pane on the shared
+    // streamer entry and kicks off the cold-start seed.
 
     App::test((), |mut app| async move {
-        let _streamer_guard = FeatureFlag::OrchestrationViewerStreamer.override_enabled(true);
-
         let parent = task_id(PARENT_TASK_ID);
         let (terminal_view_id, _parent_conv_id, _) = setup_model(&mut app, parent);
 
@@ -1680,7 +1411,7 @@ fn streamer_consumer_is_registered_when_constructed_under_flag() {
 
         // The streamer's viewer-mode registration is exercised end-to-end
         // by the streamer-side tests; here we just verify non-panicking
-        // construction of the viewer model under the flag.
+        // construction of the viewer model.
         let _ = terminal_view_id;
     });
 }
@@ -1705,14 +1436,11 @@ fn viewer_model_retries_consumer_registration_on_set_active_conversation() {
     // `parent_conversation_id` (children get one through
     // `start_new_child_conversation`). The discriminator in
     // `register_viewer_mode_consumer_if_possible` must accept this shape.
-    use warp_core::features::FeatureFlag;
     use warpui::SingletonEntity;
 
     use crate::ai::blocklist::orchestration_event_streamer::OrchestrationEventStreamer;
 
     App::test((), |mut app| async move {
-        let _streamer_guard = FeatureFlag::OrchestrationViewerStreamer.override_enabled(true);
-
         initialize_app_for_terminal_view(&mut app);
         let terminal_view = add_window_with_terminal(&mut app, None);
         let terminal_view_id = terminal_view.id();
@@ -1770,14 +1498,11 @@ fn viewer_model_does_not_register_when_active_conversation_is_a_child_placeholde
     // `SwapPaneToConversation` before the orchestrator placeholder is
     // activated — which would persist the orchestration cursor on the
     // wrong row.
-    use warp_core::features::FeatureFlag;
     use warpui::SingletonEntity;
 
     use crate::ai::blocklist::orchestration_event_streamer::OrchestrationEventStreamer;
 
     App::test((), |mut app| async move {
-        let _streamer_guard = FeatureFlag::OrchestrationViewerStreamer.override_enabled(true);
-
         initialize_app_for_terminal_view(&mut app);
         let terminal_view = add_window_with_terminal(&mut app, None);
         let terminal_view_id = terminal_view.id();

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -1676,13 +1676,11 @@ impl TerminalManager {
     /// `ctx.spawn` continuations are entity-scoped, so dropping the
     /// entity makes them no-ops; no explicit `.abort()` needed.
     ///
-    /// Under `FeatureFlag::OrchestrationViewerStreamer`, the model also
-    /// holds a viewer-mode registration on the shared
+    /// The model also holds a viewer-mode registration on the shared
     /// [`OrchestrationEventStreamer`]; we unregister explicitly here so
     /// the streamer can refcount-tear-down the ancestor SSE on the last
     /// pane close. The unregister API is idempotent, so calling it when
-    /// the flag is off (or when the streamer has already removed the
-    /// entry) is harmless.
+    /// the streamer has already removed the entry is harmless.
     fn stop_orchestration_polling(
         orchestration_viewer_model: &Arc<FairMutex<Option<ModelHandle<OrchestrationViewerModel>>>>,
         ctx: &mut AppContext,
@@ -1696,11 +1694,9 @@ impl TerminalManager {
             "[orch-viewer] stopping orchestration viewer model parent_task_id={parent_task_id} \
              consumer_id={consumer_id:?}"
         );
-        if FeatureFlag::OrchestrationViewerStreamer.is_enabled() {
-            OrchestrationEventStreamer::handle(ctx).update(ctx, move |streamer, _ctx| {
-                streamer.unregister_viewer_mode_consumer(parent_task_id, consumer_id);
-            });
-        }
+        OrchestrationEventStreamer::handle(ctx).update(ctx, move |streamer, _ctx| {
+            streamer.unregister_viewer_mode_consumer(parent_task_id, consumer_id);
+        });
         // `handle` drops here, releasing the per-pane viewer model.
         drop(handle);
     }

--- a/app/src/terminal/shared_session/viewer/terminal_manager_tests.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager_tests.rs
@@ -137,8 +137,6 @@ fn on_view_detached_closed_clears_orchestration_viewer_model_slot() {
     // Regression: closing a viewer pane must drop the OVM and release its
     // streamer registration so the ancestor SSE can be torn down.
     App::test((), |mut app| async move {
-        let _streamer = FeatureFlag::OrchestrationViewerStreamer.override_enabled(true);
-
         initialize_app_for_terminal_view(&mut app);
 
         let (manager, parent) = build_manager_with_registered_ovm(&mut app);
@@ -180,8 +178,6 @@ fn on_view_detached_hidden_for_close_keeps_orchestration_viewer_model_alive() {
     // window. OVM (and the ancestor SSE registration) must stay alive so
     // the pill bar restores seamlessly if the user undoes the close.
     App::test((), |mut app| async move {
-        let _streamer = FeatureFlag::OrchestrationViewerStreamer.override_enabled(true);
-
         initialize_app_for_terminal_view(&mut app);
 
         let (manager, parent) = build_manager_with_registered_ovm(&mut app);
@@ -210,8 +206,6 @@ fn on_view_detached_moved_keeps_orchestration_viewer_model_alive() {
     // to a new pane group. Tearing down the OVM would orphan the pill
     // bar on the moved pane.
     App::test((), |mut app| async move {
-        let _streamer = FeatureFlag::OrchestrationViewerStreamer.override_enabled(true);
-
         initialize_app_for_terminal_view(&mut app);
 
         let (manager, parent) = build_manager_with_registered_ovm(&mut app);

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -698,9 +698,12 @@ pub enum FeatureFlag {
     /// `OrchestrationV2`; has no effect when v2 is off.
     RunAgentsTool,
 
-    /// On `wait_for_events`, confirms parent status against the server and
-    /// registers an orchestrator for the owner-side ancestor stream so it
-    /// receives events for children created out-of-band (Oz CLI / web API).
+    /// On a root's first `wait_for_events`, opens the owner-side ancestor
+    /// stream (`AncestorRunId { include_self: true }`) so children created by
+    /// any path (run_agents, Oz CLI, web API) are discovered via the pushed
+    /// `child_agent_started` event instead of polling. When off, reverts to
+    /// pre-#13208 behavior: roots are discovered only via `run_agents` /
+    /// restore and no wait-time stream is opened.
     WaitForEventsParentRegistration,
 
     /// Shows a pending user query indicator during summarization when a follow-up

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -698,16 +698,6 @@ pub enum FeatureFlag {
     /// `OrchestrationV2`; has no effect when v2 is off.
     RunAgentsTool,
 
-    /// Replaces `OrchestrationViewerModel`'s REST polling loop with an SSE-driven
-    /// `ancestor_run_id` stream consumed via `OrchestrationEventStreamer`'s new
-    /// viewer-mode entry. Off by default; flipping it on activates the
-    /// per-orchestrator viewer-mode consumer and the broadcast `ChildSpawned`
-    /// / `ChildStatusChanged` events. See `specs/orch-viewer-polling/TECH.md`.
-    OrchestrationViewerStreamer,
-
-    /// Uses a parent-family ancestor stream for owner-side orchestrator event delivery.
-    OwnerOrchestrationAncestorStreamer,
-
     /// On `wait_for_events`, confirms parent status against the server and
     /// registers an orchestrator for the owner-side ancestor stream so it
     /// receives events for children created out-of-band (Oz CLI / web API).

--- a/specs/QUALITY-928/TECH.md
+++ b/specs/QUALITY-928/TECH.md
@@ -1,0 +1,298 @@
+# TECH: `child_agent_started` event for push-based child discovery + orchestration polling removal
+
+Linear: QUALITY-928 — Emit a `child_agent_started` event so parents discover children via push, and remove orchestration child-discovery polling.
+
+Follow-up to [QUALITY-919](https://linear.app/warpdotdev/issue/QUALITY-919) (PR #13208), whose spec already sketched this work under "Always-on child discovery (lazy listening at first wait)" — see [`specs/QUALITY-919/TECH.md` (147-149) @ c0902a2](https://github.com/warpdotdev/warp/blob/c0902a246934b879390977d048f398b1a8e879d8/specs/QUALITY-919/TECH.md#L147-L149).
+
+This spec is written to be self-contained: an implementer should be able to execute it without prior knowledge of the orchestration event system. Code blocks are the exact shape to write; line references point at the current code to change.
+
+## Context
+An orchestrator (parent) receives its children's lifecycle and inbox events through an owner-side SSE stream managed by `OrchestrationEventStreamer`. Today the parent only learns it *has* children by **fetching/polling**:
+- **Legacy viewer REST poll** — `OrchestrationViewerModel` polls `GET /agent/runs?ancestor_run_id=` every 5s (30s once idle, forever) plus a separate 5s per-child `session_id` poll. [`orchestration_viewer_model.rs` (37-44, 554-586, 698-736) @ c0902a2](https://github.com/warpdotdev/warp/blob/c0902a246934b879390977d048f398b1a8e879d8/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs#L37-L44).
+- **Per-`wait_for_events` fetch** — `register_parent_on_wait` does a `get_ambient_agent_task` on every wait to confirm parent status (the QUALITY-919 mechanism). [`orchestration_event_streamer.rs` (563-651) @ c0902a2](https://github.com/warpdotdev/warp/blob/c0902a246934b879390977d048f398b1a8e879d8/app/src/ai/blocklist/orchestration_event_streamer.rs#L563-L651).
+- **Restore-on-startup fetch** — one-shot `get_ambient_agent_task(...).children` per restored conversation. [`orchestration_event_streamer.rs` (1370-1442) @ c0902a2](https://github.com/warpdotdev/warp/blob/c0902a246934b879390977d048f398b1a8e879d8/app/src/ai/blocklist/orchestration_event_streamer.rs#L1370-L1442).
+
+The server already has the primitives to push instead: an append-only `ai_run_event_log` with monotonic `sequence`, a publish path (`PublishLifecycleEvent` → `publishAgentRunEvent`), and an SSE handler with `run_ids[]` and `ancestor_run_id`/`include_self` filters whose ancestor query JOINs `ai_tasks.parent_run_id`. Children are created (any path: `run_agents`, Oz CLI, web API) through one funnel, `AddTask`. Relevant server code:
+- [`logic/ai/ambient_agents/add_task.go` (348-388) @ 029c643](https://github.com/warpdotdev/warp-server/blob/029c643e189a57fba62b596142d5900dd1eb4137/logic/ai/ambient_agents/add_task.go#L348-L388) — the child row insert; the natural emit point.
+- [`logic/agent_lifecycle.go` (13-81) @ 029c643](https://github.com/warpdotdev/warp-server/blob/029c643e189a57fba62b596142d5900dd1eb4137/logic/agent_lifecycle.go#L13-L81) — event-type constants + `PublishLifecycleEvent(WithParent)`.
+- [`logic/agent_event_publish.go` (14-79) @ 029c643](https://github.com/warpdotdev/warp-server/blob/029c643e189a57fba62b596142d5900dd1eb4137/logic/agent_event_publish.go#L14-L79) — payload (`id, run_id, event_type, ref_id, execution_id, sequence, occurred_at`) + PubSub metadata.
+- [`model/ai_run_event_log.go` (35-120) @ 029c643](https://github.com/warpdotdev/warp-server/blob/029c643e189a57fba62b596142d5900dd1eb4137/model/ai_run_event_log.go#L35-L120) — `InsertEvent` and the ancestor JOIN.
+
+This is event-delivery correctness/efficiency, so no `PRODUCT.md` accompanies this spec. Behavioral contract: whenever a child task is created with `parent_run_id = P` (by any method), a parent client watching `P` discovers that child within one SSE round-trip — no polling — and surfaces its subsequent lifecycle and inbox events.
+
+**Invariant (carried over from QUALITY-919, load-bearing):** orchestration trees are one level deep (a run is either a root orchestrator or a leaf child). The server ancestor query is single-level (`parent_run_id = $1`), consistent end-to-end. Revisit alongside the server query if multi-level trees are introduced.
+
+## Rollout state of existing orchestration flags
+Three orchestration flags are already in the `default` Cargo feature set ([`app/Cargo.toml` (679-681) @ c0902a2](https://github.com/warpdotdev/warp/blob/c0902a246934b879390977d048f398b1a8e879d8/app/Cargo.toml#L679-L681)), i.e. enabled on all channels:
+- **`OrchestrationViewerStreamer`** — fully rolled out. Its flag-OFF branch is the legacy REST poller, now dead on every channel. **Remove the flag and delete the legacy polling path** (Step C1–C2).
+- **`OwnerOrchestrationAncestorStreamer`** — fully rolled out. Gates the parent's `AncestorRunId { include_self: true }` filter selection in `desired_sse_filter` ([`orchestration_event_streamer.rs` (1693-1711) @ c0902a2](https://github.com/warpdotdev/warp/blob/c0902a246934b879390977d048f398b1a8e879d8/app/src/ai/blocklist/orchestration_event_streamer.rs#L1693-L1711)). **Remove the flag; make the ancestor stream the unconditional parent path** (Step C3). This is also a precondition for opening the ancestor stream at first wait.
+- **`RunAgentsTool`** — also default-on, but removing it is cross-cutting (server negotiation of `SupportsOrchestrate`, replaces `start_agent`). **Out of scope**; note only.
+
+`WaitForEventsParentRegistration` is dogfood-only (shipped in #13208) and gates exactly the trigger this change keeps — "on `wait_for_events`, ensure the orchestrator is registered as a parent." This work swaps the *mechanism* behind that trigger (per-wait fetch → ancestor stream opened at first wait + pushed event), so we **reuse this flag** rather than adding a new one. Because it is unshipped, redefining what "on" means is safe. "Off" reverts to pre-#13208 behavior (parents discovered only via `run_agents`/restore).
+
+## Proposed changes
+### Server (warp-server) — emit the event
+**S1 — add the event-type constant.** In `logic/agent_lifecycle.go`, alongside the existing `LifecycleEvent*` constants (`:13-20`):
+```go
+const (
+	LifecycleEventRunInProgress = "run_in_progress"
+	// ... existing constants unchanged ...
+	LifecycleEventRunCancelled  = "run_cancelled"
+
+	// EventChildAgentStarted is emitted on a PARENT run when a child task is
+	// created with parent_run_id = <parent>. The child run id is carried in
+	// ref_id. This is a discovery signal, not a run status.
+	EventChildAgentStarted = "child_agent_started"
+)
+```
+**S2 — emit after the child is committed.** In `AddTask` (`logic/ai/ambient_agents/add_task.go`) the child row is inserted inside `database.TransactionWithNoResult(...)` (`:348-368`). Add the emit *after* that block returns successfully, next to the other post-commit side effects (`:370-378`):
+```go
+// Notify the parent (if any) that a child was created so its client discovers
+// the child via push instead of polling. Emitted on the PARENT run with the
+// child run id in ref_id. Best-effort: a failure must not fail child creation.
+// Placed after the commit because PublishLifecycleEvent both inserts and
+// publishes and must not run inside the caller's transaction.
+if params.ParentRunID != nil && *params.ParentRunID != "" {
+	if _, err := logic.PublishLifecycleEvent(
+		ctx,
+		td.db,
+		td.datastores,
+		*params.ParentRunID,          // run_id the event is recorded on
+		nil,                          // execution_id: the parent has none here
+		logic.EventChildAgentStarted, // event_type
+		&task.ID,                     // ref_id: the new child run id
+	); err != nil {
+		log.Warnf(ctx, "Failed to emit %s on parent %s for child %s: %v",
+			logic.EventChildAgentStarted, *params.ParentRunID, task.ID, err)
+	}
+}
+```
+`PublishLifecycleEvent` (`logic/agent_lifecycle.go:47`) inserts into `ai_run_event_log` (assigning the monotonic `sequence` via `InsertEvent`) and publishes the `eventPublishPayload` (`logic/agent_event_publish.go:17-25`) to PubSub/SSE. Its `resolveParentRunIDForPublish` looks up the *parent's own* parent for routing metadata, which is `nil` under the one-level-tree invariant.
+
+**S3 — document the type.** Add `child_agent_started` to the `event_type` enum/description for the events schemas in `public_api/openapi.yaml`.
+
+**S4 — tests.** In the `AddTask` test suite, inject a mock via `getEventPubSubClient` (`agent_event_publish.go:28`) and assert: a task created with `ParentRunID` set produces exactly one published event with `event_type=child_agent_started`, `run_id=<parent>`, `ref_id=<child>`; a task with `ParentRunID` nil produces none.
+
+No schema/migration changes: the event lives on the parent run in the existing `ai_run_event_log`, so it is delivered by both a `run_ids=[P]` stream and the `ancestor_run_id=P&include_self=true` stream (the parent's own events). The ancestor JOIN is keyed on the *child's* `parent_run_id`, which is why discovery must be an event on the parent run, not a JOIN artifact.
+
+**No server feature flag.** The event is additive; existing clients ignore unknown `event_type` values (`lifecycle_event_type_from_wire` returns `None`, viewer drain `continue`s, owner-side `convert_lifecycle_events` skips). The cursor still advances harmlessly. Consumption is gated client-side.
+
+### Client (warp) — Part 1: remove fully-rolled-out flags + legacy polling (no behavior change)
+Follow the `remove-feature-flag` skill for the two flags.
+
+**C1 — remove `OrchestrationViewerStreamer`.** Delete the enum variant (`crates/warp_features/src/lib.rs:706`), its `app/src/features.rs` arm (`:420-421`), and its `app/Cargo.toml` feature definition (`:985`) and `default`-list entry (`:680`). Collapse call sites to the enabled branch: in `orchestration_viewer_model.rs`, `new` (`:95`) branches on `FeatureFlag::OrchestrationViewerStreamer.is_enabled()` (`:101`) — keep only the streamer-driven arm (`:101-130`) and delete the legacy-polling arm (`:132-160`).
+
+**C2 — delete the legacy poller** in `orchestration_viewer_model.rs`: methods `fetch_children` (`:698`), `apply_children_fetch` (`:744`), `schedule_next_poll` (`:554`), `maybe_kick_polling` (`:593`); consts `STATUS_POLL_INTERVAL`/`STATUS_POLL_INTERVAL_IDLE`/`CHILD_DISCOVERY_FETCH_LIMIT` (`:38-42`); and fields `polling_handle`/`fetch_generation`/`idle_due_to_no_children` (`:69-75`). The streamer-driven path (`handle_streamer_event` → `register_child`, `ChildSpawned`/`ChildStatusChanged`) becomes the only path. (`run_pending_session_id_poll` and its timer are handled in C9.)
+
+**C3 — remove `OwnerOrchestrationAncestorStreamer` and simplify `desired_sse_filter`.** Delete the enum variant (`crates/warp_features/src/lib.rs:709`), its `app/src/features.rs` arm (`:422-423`), and its `app/Cargo.toml` feature definition (`:986`) and `default`-list entry (`:681`). Its only runtime use is the `is_enabled()` guard in `desired_sse_filter` (`orchestration_event_streamer.rs:1694`). Rewrite it so a parent — and a wait-registered root (the `ancestor_on_wait` field added in C5) — always takes the ancestor branch:
+```rust
+fn desired_sse_filter(
+    &self,
+    conversation_id: AIConversationId,
+    ctx: &warpui::AppContext,
+) -> DesiredSseFilter {
+    let is_parent = self.is_parent_agent_conversation(conversation_id, ctx);
+    let wait_root = self
+        .streams
+        .get(&conversation_id)
+        .is_some_and(|s| s.ancestor_on_wait);
+    if is_parent || wait_root {
+        if let Some(self_run_id) = self.self_run_id(conversation_id, ctx) {
+            return DesiredSseFilter::Filter(AgentEventFilter::AncestorRunId {
+                ancestor_run_id: self_run_id,
+                include_self: true,
+            });
+        }
+    }
+    let run_ids = self.run_ids_for_sse(conversation_id);
+    if run_ids.is_empty() {
+        return DesiredSseFilter::NoFilter;
+    }
+    DesiredSseFilter::Filter(AgentEventFilter::RunIds(run_ids))
+}
+```
+A parent now always uses the ancestor stream, so the `UnsupportedRunIdCount` arm and the `MAX_RUN_ID_STREAM_FILTER` parent check are unreachable for parents. Leave the `DesiredSseFilter::UnsupportedRunIdCount` variant and its match arms (in `start_sse_connection` and `stream_filter_stale`) in place — harmless — or remove them if you prefer; non-parents still use `RunIds`.
+
+### Client (warp) — Part 2: push-based discovery via `child_agent_started`
+**C4 — event-type constant.** Near `lifecycle_event_type_from_wire` (`orchestration_event_streamer.rs:2287`):
+```rust
+/// Wire `event_type` emitted on a parent run when a child task is created.
+/// The child run id is in `ref_id`. Not a lifecycle status, so it is handled
+/// as a discovery signal and `lifecycle_event_type_from_wire` keeps returning
+/// `None` for it (that function is unchanged).
+const CHILD_AGENT_STARTED_EVENT: &str = "child_agent_started";
+```
+**C5 — per-conversation wait state.** Add a field to `ConversationStreamState` (`:198`, which is `#[derive(Default)]`):
+```rust
+/// True once this non-child root registered for the owner-side ancestor
+/// stream from `wait_for_events` (see `register_root_on_wait`). Makes the
+/// conversation eligible and selects the ancestor filter before any child is
+/// known, so the stream never widens later (avoids the cursor-handoff gap in
+/// Risks).
+ancestor_on_wait: bool,
+```
+**C6 — open the ancestor stream at first wait.** Replace `register_parent_on_wait` (`:563`) and delete `finish_register_parent_on_wait` (`:619`, including its `get_ambient_agent_task` fetch). The new method does no network fetch:
+```rust
+/// Registers a non-child root for the owner-side ancestor stream when it
+/// blocks on `wait_for_events`, so children created by any path (run_agents,
+/// Oz CLI, web API) are delivered without polling. Idempotent across waits.
+pub fn register_root_on_wait(
+    &mut self,
+    conversation_id: AIConversationId,
+    ctx: &mut ModelContext<Self>,
+) {
+    if !FeatureFlag::WaitForEventsParentRegistration.is_enabled() {
+        return;
+    }
+    // One-level-tree invariant: a child can never be a root parent. It already
+    // receives its own inbox via the child eligibility path.
+    let is_child = BlocklistAIHistoryModel::as_ref(ctx)
+        .conversation(&conversation_id)
+        .is_some_and(|c| c.has_parent_agent());
+    if is_child {
+        return;
+    }
+    // Passive view of a run hosted elsewhere: the owning process holds the inbox.
+    if self.is_remote_run_view(conversation_id, ctx) {
+        return;
+    }
+    // Need a run id to scope the ancestor stream; the next wait re-checks.
+    let Some(self_run_id) = self.self_run_id(conversation_id, ctx) else {
+        return;
+    };
+    let stream = self.streams.entry(conversation_id).or_default();
+    if stream.ancestor_on_wait {
+        return; // already registered; subsequent waits are no-ops
+    }
+    stream.ancestor_on_wait = true;
+    // Watch self so the parent's own inbox is covered even if the filter ever
+    // falls back to RunIds; redundant under the ancestor (include_self) filter.
+    stream.watched_run_ids.insert(self_run_id);
+    self.reevaluate_eligibility(conversation_id, ctx);
+}
+```
+Update the call site in `wait_for_events.rs::execute` (`:110-112`) to call `register_root_on_wait` instead of `register_parent_on_wait`.
+
+**C7 — make a wait-registered root eligible.** In `is_eligible` (`:1641`), the final predicate becomes:
+```rust
+let wait_root = self
+    .streams
+    .get(&conversation_id)
+    .is_some_and(|s| s.ancestor_on_wait);
+has_parent || self.is_parent_agent_conversation(conversation_id, ctx) || wait_root
+```
+Opening the connection seeds `since` from `stream.event_cursor` (`start_sse_connection:1905-1909`), i.e. the conversation's persisted cursor — so the ancestor stream replays from there and no later filter change occurs.
+
+**C8 — register children from `child_agent_started` (owner path).** In `drain_sse_events` (`:2027`), after the `while let` fills `events` and before `handle_event_batch`, call a new helper:
+```rust
+// inside drain_sse_events, after building `events`, before computing self_run_id:
+self.register_children_from_events(conversation_id, &events, ctx);
+```
+```rust
+/// Registers children announced by `child_agent_started`. The event is on the
+/// parent run; the child run id is in `ref_id`. Idempotent (`watched_run_ids`
+/// is a set). Flips `is_parent_agent_conversation` to true permanently; the
+/// ancestor stream is already open, so the filter shape is unchanged and no
+/// reconnect happens. The event itself is not surfaced as a lifecycle/message
+/// item — `convert_lifecycle_events` (`:2307`) already drops it (its `run_id`
+/// equals `self_run_id`, and `lifecycle_event_type_from_wire` returns `None`),
+/// so it only advances the cursor and registers the child.
+fn register_children_from_events(
+    &mut self,
+    conversation_id: AIConversationId,
+    events: &[AgentRunEvent],
+    ctx: &mut ModelContext<Self>,
+) {
+    let mut registered_new = false;
+    for event in events {
+        if event.event_type != CHILD_AGENT_STARTED_EVENT {
+            continue;
+        }
+        let Some(child_run_id) = event.ref_id.clone() else {
+            continue;
+        };
+        if self
+            .streams
+            .entry(conversation_id)
+            .or_default()
+            .watched_run_ids
+            .insert(child_run_id)
+        {
+            registered_new = true;
+        }
+    }
+    if registered_new {
+        self.reevaluate_eligibility(conversation_id, ctx);
+    }
+}
+```
+`AgentRunEvent` is `{ event_type, run_id, ref_id: Option<String>, execution_id, occurred_at, sequence }` (`app/src/server/server_api/ai.rs:364-372`). This helper is **not** gated: registering a child id is harmless when no stream is open, and it lets `run_agents`/restore parents pick up out-of-band siblings too.
+
+**C9 — replace the viewer `session_id` timer (polling removal).** In `orchestration_viewer_model.rs`, delete the field `pending_session_id_poll_handle` (`:78`), methods `maybe_schedule_pending_session_id_poll` (`:502`) and `run_pending_session_id_poll` (`:527`), and the const `PENDING_SESSION_ID_POLL_INTERVAL` (`:44`). Keep `spawn_task_metadata_fetch` and drive it event-driven: it already runs on `ChildSpawned`; additionally, in `handle_child_status_changed`, re-fetch metadata when a tracked child's `session_id` is still `None` and its status advances to `InProgress` (claim time, when `session_id` first exists).
+
+**C10 — viewer discovery scope (no change needed).** `child_agent_started` is emitted on the parent run and the viewer's ancestor stream uses `include_self: false` (`:920-923`), so it is *not* delivered to viewers; viewer child discovery stays on the child's first lifecycle event (unchanged). Earlier creation-time viewer discovery is a follow-up (would require `include_self: true` plus filtering the parent's own events in `drain_ancestor_events`).
+
+**Gating summary.** Only `register_root_on_wait` is behind `WaitForEventsParentRegistration` (flag off ⇒ pre-#13208 behavior: roots discovered only via `run_agents`/restore; `ancestor_on_wait` is never set, so `desired_sse_filter`/`is_eligible` behave as before). `register_children_from_events` is ungated and harmless. Update the flag's doc comment (`crates/warp_features/src/lib.rs:711-714`) to describe the new mechanism.
+
+### Decision flow
+```mermaid
+flowchart TD
+  Create["AddTask(parent_run_id=P)"] --> Emit["server: emit child_agent_started on run P (ref_id=child)"]
+  Wait["client: first wait_for_events (root)"] --> Anc["register_root_on_wait: open AncestorRunId include_self=true (since = persisted cursor)"]
+  Emit --> Recv["client receives child_agent_started: register child run id, flip is_parent"]
+  Anc --> Recv
+  Anc --> Track["child lifecycle + inbox delivered via JOIN + AncestorKey fan-out; no filter change"]
+```
+
+### Design tradeoff — why open the ancestor stream directly instead of upgrading from a self stream
+The QUALITY-919 follow-up sketched opening a cheap `RunIds([self])` self stream and *upgrading* to the ancestor filter on the first `child_agent_started`. That introduces a cursor-handoff gap (see Risks): the per-conversation `event_cursor` is a single scalar over the *global* sequence space, but the self stream only delivers run-`P` events, so a parent-self event can advance the cursor past a lower-sequenced child event the narrow filter never delivered; the ancestor reconnect then resumes from the advanced cursor and skips it. Opening the ancestor (superset) stream from the start means the filter never widens, so the cursor always covers the full watched set and there is no gap. The cost — a childless waiting root holds an ancestor (JOIN) stream rather than a plain run-ids stream — is negligible: it is one idle SSE connection either way, differing only in server query shape. The self-stream variant would instead require resetting `event_cursor` back to the `child_agent_started` sequence on upgrade and de-duplicating the replayed parent-self events (lifecycle is idempotent, but replayed inbox messages would need message-id dedup) — strictly more complex for no real savings. Consequence: `child_agent_started` is a discovery-latency optimization (flip `is_parent` at creation instead of at the child's first lifecycle event), not a correctness-critical upgrade trigger.
+
+## Testing and validation
+Server (Go): unit-test `AddTask` per S4. Verify the event surfaces on both a `run_ids=[P]` stream and an `ancestor_run_id=P&include_self=true` stream. Run `./script/presubmit`, `go fmt ./...`, `go vet ./...`.
+
+Client (Rust), in `orchestration_event_streamer_tests.rs` (follow the existing `*_ancestor_include_self_stream` tests):
+- First `wait_for_events` on a root opens `AncestorRunId { include_self: true }` (assert the connected filter) seeded from the persisted cursor; a child created afterward is delivered without a reconnect/filter change.
+- `register_children_from_events`: a `child_agent_started` event with `ref_id = C` inserts `C` into `watched_run_ids` and flips `is_parent_agent_conversation` to true; the connected ancestor filter is unchanged (no reconnect).
+- Idempotency: a duplicate `child_agent_started`, or one for a child already registered via `run_agents`, does not churn the stream.
+- Flag off (`WaitForEventsParentRegistration`) → `register_root_on_wait` is a no-op (no wait-time stream); child (`has_parent_agent`) and remote-view conversations never open a wait-time stream regardless of the flag.
+- Unknown/forward-compat: an unrecognized `event_type` is ignored and advances the cursor.
+- `orchestration_viewer_model_tests.rs`: rewrite the legacy-poller fixtures to the event-driven path (`ChildSpawned` → placeholder; `ChildStatusChanged` → status; metadata fetch on spawn and on the `InProgress` transition, no timer).
+- Run via `cargo nextest run -p warp`; `./script/format` and `cargo clippy` (the `./script/presubmit` versions) must be clean.
+
+Manual (dogfood, flag on): create a child via the Oz CLI/web API with `parent_run_id`, then have the parent `wait_for_events`; verify the child surfaces without the 5s poll cadence and the watchdog does not fire first. Cross-check that a viewer pill bar still populates with the legacy poller deleted.
+
+## Environment
+- Worktrees (already created on branch `matthew/child-agent-started-events`):
+  - `~/src/child-agent-started-events/warp-server` (base `origin/develop`)
+  - `~/src/child-agent-started-events/warp` (base `origin/master`)
+  - `~/src/child-agent-started-events/warp-proto-apis` (base `origin/main`)
+- No `warp-proto-apis` change is expected: event types are Go string constants surfaced via `openapi.yaml`, and the client deserializes generically into `AgentRunEvent` (child id rides in `ref_id`).
+- Pinned research SHAs: warp `c0902a2`, warp-server `029c643`, warp-proto-apis `ac1af73`.
+
+## Parallelization
+The work splits cleanly by repo/language with one coordination point — the event-type string `child_agent_started` and `ref_id = child run id`, fixed up front in this spec.
+- **server-agent** (local, warp-server worktree): S1–S4. Owns warp-server only. Lands as its own PR against `develop`. Output: the event observable on the SSE streams.
+- **client-agent** (local, warp worktree): C1–C10 (Part 1 then Part 2), Part 2 behind the reused `WaitForEventsParentRegistration`. Owns warp only. Lands as its own PR against `master`. Can develop and unit-test independently of the server agent against the fixed contract; end-to-end manual validation needs the server change running locally.
+- Dependency: client Part 2 manual validation depends on server-agent's emit, but neither blocks the other's implementation or unit tests. Recommend a code-review agent in an iterative loop on each PR as a quality gate (mirrors QUALITY-919).
+
+```mermaid
+flowchart LR
+  Spec([Spec approved]) --> S["server-agent — warp-server<br/>S1-S4: emit child_agent_started"]
+  Spec --> C1["client-agent — warp<br/>Part 1 (C1-C3): remove flags + legacy polling"]
+  C1 --> C2["client-agent — warp<br/>Part 2 (C4-C10): consume event + ancestor stream at first wait"]
+  S --> V["manual e2e validation"]
+  C2 --> V
+```
+
+## Risks and mitigations
+- **One-level-tree assumption** — unchanged from QUALITY-919; documented and consistent with the server single-level JOIN.
+- **Timing race** — a child created during an already-blocked empty wait before the ancestor stream is open is caught when the stream connects (replay from cursor) or on the next wait. Self-healing.
+- **Cursor-handoff gap (avoided by design)** — a single global `event_cursor` plus a narrow→wide filter change can skip child events whose sequence is below a parent-self event already drained on the narrow filter (`drain_sse_events` dedup floor at `:2046`, `handle_event_batch` advancing to the batch max at `:2076-2083`, `start_sse_connection` seeding `since` from `event_cursor` at `:1905-1909`). Opening the ancestor stream directly (Proposed changes) avoids the filter change entirely. If a self→ancestor upgrade is ever reintroduced, seed the reconnect from the `child_agent_started` sequence (≤ all of that child's events) and dedup replayed self events.
+- **Forward/backward compat** — old clients ignore `child_agent_started`; new clients with `WaitForEventsParentRegistration` off do no wait-time registration (pre-#13208 behavior). Server emit is safe to ship first.
+- **Flag removal regressions** — removing `OrchestrationViewerStreamer`/`OwnerOrchestrationAncestorStreamer` deletes the only-dead-on-paper fallback paths; covered by the rewritten viewer tests and the ancestor-filter assertions.
+
+## Follow-ups
+- After `WaitForEventsParentRegistration` stabilizes in dogfood, promote it (`promote-feature`) and later remove it (`remove-feature-flag`).
+- Earlier creation-time viewer discovery: flip the viewer ancestor stream to `include_self: true` and handle `child_agent_started` (`ref_id` → child) in `drain_ancestor_events`, filtering the parent's own lifecycle events.
+- Consider carrying claim-time `session_id` (and title/harness) on a later child event to eliminate the on-demand metadata fetch entirely.
+- Open draft PRs per repo workflow (template at `.github/pull_request_template.md`), likely `CHANGELOG-NONE`.


### PR DESCRIPTION
## Description

Client side of **QUALITY-928** — push-based child-agent discovery + orchestration polling removal. Follow-up to QUALITY-919 (#13208). Tech spec: `specs/QUALITY-928/TECH.md` (included in this PR).

**Part 1 — remove fully-rolled-out flags + legacy polling (no behavior change):**
- Removed the `OrchestrationViewerStreamer` and `OwnerOrchestrationAncestorStreamer` feature flags (both already in the `default` cargo set, i.e. on for all channels).
- Deleted the legacy `OrchestrationViewerModel` REST polling path (`fetch_children`/`schedule_next_poll`/`maybe_kick_polling`/`apply_children_fetch`, interval consts, polling fields). The SSE streamer-driven viewer path is now the only path.
- Simplified `desired_sse_filter` so a parent always uses the `AncestorRunId { include_self: true }` stream; removed the now-dead `UnsupportedRunIdCount` variant + `MAX_RUN_ID_STREAM_FILTER`.

**Part 2 — push-based discovery via `child_agent_started`:**
- Consume the new server `child_agent_started` event (`ref_id` = child run id) and register the child on the owner side.
- A non-child root opens the owner-side `AncestorRunId { include_self: true }` stream on its first `wait_for_events`, replacing the per-wait `get_ambient_agent_task` fetch from #13208. Opening the ancestor (superset) stream directly avoids a cursor-handoff gap that a self→ancestor upgrade would introduce (see the spec's Risks).
- Removed the viewer `session_id` poll timer in favor of an event-driven metadata fetch.
- Reuses the existing `WaitForEventsParentRegistration` dogfood flag (no new flag); flag-off restores pre-#13208 behavior.

Depends on the warp-server PR (the `child_agent_started` emit) for end-to-end behavior; the client tolerates its absence.

## Testing

- Added unit tests in `orchestration_event_streamer_tests.rs`: ancestor-stream-at-first-wait, child registration without reconnect, idempotency, flag-off no-op, child/remote-view exclusions, unknown-event-ignored-advances-cursor; plus rewritten viewer fixtures.
- `cargo nextest run -p warp`: 5404 passed, 0 failed. `./script/format` and `cargo clippy` (presubmit versions) clean.
- [ ] Manual e2e (dogfood, flag on): out-of-band child surfaces to the parent without the old 5s poll latency — pending.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/b0596521-fc34-4c03-8316-8aa227fea159_

CHANGELOG-NONE
