### PR TITLE
Add long-context usage warning indicator

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -1022,6 +1022,7 @@ cloud_mode_input_v2 = ["cloud_mode"]
 handoff_cloud_cloud = ["cloud_mode_setup_v2"]
 git_credential_refresh = []
 prompt_cache_expiry_warning = []
+long_context_warning = []
 
 [package.metadata.bundle.bin.warp-oss]
 category = "public.app-category.developer-tools"

--- a/app/src/ai/agent/api/convert_conversation_tests.rs
+++ b/app/src/ai/agent/api/convert_conversation_tests.rs
@@ -25,6 +25,7 @@ fn test_server_metadata(
         usage: ConversationUsageMetadata {
             was_summarized: false,
             context_window_usage: 0.0,
+            total_input_tokens: 0,
             credits_spent: 0.0,
             platform_credits_spent: 0.0,
             credits_spent_for_last_block: None,

--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -673,6 +673,12 @@ impl AIConversation {
         self.conversation_usage_metadata.context_window_usage
     }
 
+    /// Input tokens of the latest primary-agent LLM call in the latest
+    /// successfully persisted request that had Warp-charged or BYOK usage.
+    pub fn total_input_tokens(&self) -> u32 {
+        self.conversation_usage_metadata.total_input_tokens
+    }
+
     /// The per-segment breakdown of the context window (e.g. system prompt,
     /// tool definitions, conversation history). Scaled so the segments sum to
     /// `context_window_usage`. Empty when the server did not emit segments.
@@ -1968,6 +1974,13 @@ impl AIConversation {
         if let Some(usage_metadata) = usage_metadata {
             self.conversation_usage_metadata.context_window_usage =
                 usage_metadata.context_window_usage;
+            // 0 means this turn had no chargeable primary-agent call (failed,
+            // custom-endpoint-only, or old server), not a context reset. Keep the
+            // last known value, mirroring server-side merge semantics.
+            if usage_metadata.total_input_tokens != 0 {
+                self.conversation_usage_metadata.total_input_tokens =
+                    usage_metadata.total_input_tokens;
+            }
             self.conversation_usage_metadata.credits_spent = usage_metadata.credits_spent;
             self.conversation_usage_metadata.platform_credits_spent =
                 usage_metadata.platform_credits_spent;

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -785,6 +785,7 @@ fn create_server_conversation_metadata(
         usage: ConversationUsageMetadata {
             was_summarized: false,
             context_window_usage: 0.0,
+            total_input_tokens: 0,
             credits_spent: 0.0,
             platform_credits_spent: 0.0,
             credits_spent_for_last_block: None,

--- a/app/src/ai/agent_sdk/artifact_upload_tests.rs
+++ b/app/src/ai/agent_sdk/artifact_upload_tests.rs
@@ -37,6 +37,7 @@ fn create_conversation_metadata(
         usage: ConversationUsageMetadata {
             was_summarized: false,
             context_window_usage: 0.0,
+            total_input_tokens: 0,
             credits_spent: 0.0,
             platform_credits_spent: 0.0,
             credits_spent_for_last_block: None,

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -52,10 +52,13 @@ pub(crate) use self::environment_selector::{
 use crate::ai::blocklist::agent_view::is_in_cloud_context;
 use crate::ai::blocklist::history_model::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::ai::blocklist::prompt::prompt_alert::{PromptAlertEvent, PromptAlertView};
-use crate::ai::blocklist::usage::icon_for_context_window_usage;
+use crate::ai::blocklist::usage::{icon_for_context_window_usage, LongContextWarningState};
 use crate::ai::blocklist::BlocklistAIInputModel;
-use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
+use crate::ai::execution_profiles::profiles::{
+    AIExecutionProfilesModel, AIExecutionProfilesModelEvent, ClientProfileId,
+};
 use crate::ai::harness_availability::HarnessAvailabilityModel;
+use crate::ai::llms::{LLMPreferences, LLMPreferencesEvent};
 use crate::ai::AIRequestUsageModel;
 use crate::appearance::Appearance;
 use crate::auth::{AuthManager, AuthStateProvider};
@@ -123,8 +126,34 @@ const FAST_FORWARD_LOCKED_TOOLTIP: &str =
 
 const START_REMOTE_CONTROL_TOOLTIP: &str = "Start remote control";
 const START_REMOTE_CONTROL_LOGIN_REQUIRED_TOOLTIP: &str = "Log in to use /remote-control";
+const OPENAI_LONG_CONTEXT_PRICING_WARNING_TOOLTIP: &str = "OpenAI long-context pricing in effect";
 
 const CLOUD_MODE_V2_FOOTER_GAP: f32 = 4.;
+
+fn llm_preferences_event_affects_long_context_warning(event: &LLMPreferencesEvent) -> bool {
+    match event {
+        LLMPreferencesEvent::UpdatedAvailableLLMs
+        | LLMPreferencesEvent::UpdatedActiveAgentModeLLM => true,
+        LLMPreferencesEvent::UpdatedActiveCodingLLM => false,
+    }
+}
+
+fn execution_profile_event_affects_long_context_warning(
+    event: &AIExecutionProfilesModelEvent,
+    active_profile_id: ClientProfileId,
+    terminal_view_id: EntityId,
+) -> bool {
+    match event {
+        AIExecutionProfilesModelEvent::ProfileUpdated(profile_id) => {
+            *profile_id == active_profile_id
+        }
+        AIExecutionProfilesModelEvent::ProfileDeleted => true,
+        AIExecutionProfilesModelEvent::UpdatedActiveProfile {
+            terminal_view_id: updated_terminal_view_id,
+        } => *updated_terminal_view_id == terminal_view_id,
+        AIExecutionProfilesModelEvent::ProfileCreated => false,
+    }
+}
 
 /// Voice input state for the CLI agent footer. Unlike the editor-based voice
 /// flow (which goes through Input → EditorView), this state is self-contained
@@ -199,6 +228,7 @@ pub struct AgentInputFooter {
     start_remote_control_button: ViewHandle<ActionButton>,
     stop_remote_control_button: ViewHandle<ActionButton>,
     context_window_button: ViewHandle<ActionButton>,
+    long_context_warning_state: LongContextWarningState,
     model_selector: ViewHandle<ProfileModelSelector>,
     environment_selector: Option<ViewHandle<EnvironmentSelector>>,
     handoff_environment_selector: ViewHandle<EnvironmentSelector>,
@@ -329,6 +359,7 @@ impl AgentInputFooter {
                 .tooltip_message();
             mic_button.update(ctx, |button, ctx| {
                 button.set_tooltip(Some(tooltip), ctx);
+                button.set_tooltip_sublabel(None::<String>, ctx);
             });
 
             ctx.subscribe_to_model(&AISettings::handle(ctx), |me, _, event, ctx| {
@@ -713,6 +744,16 @@ impl AgentInputFooter {
         ctx.subscribe_to_model(&AIRequestUsageModel::handle(ctx), |_, _, _, ctx| {
             ctx.notify()
         });
+        ctx.subscribe_to_model(
+            &LLMPreferences::handle(ctx),
+            |me, preferences, event, ctx| {
+                if !llm_preferences_event_affects_long_context_warning(event) {
+                    return;
+                }
+                me.sync_long_context_warning_from_effective_model(preferences.as_ref(ctx), ctx);
+                me.update_context_window_button(ctx);
+            },
+        );
         ctx.subscribe_to_model(&AISettings::handle(ctx), |_, _, event, ctx| {
             if matches!(
                 event,
@@ -760,10 +801,29 @@ impl AgentInputFooter {
                 _ => {}
             },
         );
-        // Subscribe to AIExecutionProfilesModel to potentially show/hide the profile selector button when profiles are added/removed
-        ctx.subscribe_to_model(&AIExecutionProfilesModel::handle(ctx), |_, _, _, ctx| {
-            ctx.notify();
-        });
+        // Subscribe to AIExecutionProfilesModel to potentially show/hide the profile selector button
+        // when profiles are added/removed and keep the warning in sync with the active profile.
+        ctx.subscribe_to_model(
+            &AIExecutionProfilesModel::handle(ctx),
+            |me, profiles, event, ctx| {
+                let active_profile_id = *profiles
+                    .as_ref(ctx)
+                    .active_profile(Some(me.terminal_view_id), ctx)
+                    .id();
+                if execution_profile_event_affects_long_context_warning(
+                    event,
+                    active_profile_id,
+                    me.terminal_view_id,
+                ) {
+                    me.sync_long_context_warning_from_effective_model(
+                        LLMPreferences::as_ref(ctx),
+                        ctx,
+                    );
+                    me.update_context_window_button(ctx);
+                }
+                ctx.notify();
+            },
+        );
 
         ctx.subscribe_to_model(
             &BlocklistAIHistoryModel::handle(ctx),
@@ -780,12 +840,30 @@ impl AgentInputFooter {
                     | BlocklistAIHistoryEvent::SetActiveConversation { .. }
                     | BlocklistAIHistoryEvent::ClearedActiveConversation { .. }
                     | BlocklistAIHistoryEvent::ClearedConversationsForTerminalSurface { .. }
-                    | BlocklistAIHistoryEvent::RemoveConversation { .. }
-                    | BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. } => {
+                    | BlocklistAIHistoryEvent::RemoveConversation { .. } => {
+                        me.sync_long_context_warning_from_conversation(ctx);
                         me.sync_fast_forward_button(ctx);
                         me.update_context_window_button(ctx);
                         me.model_selector.update(ctx, |_, ctx| ctx.notify());
                         ctx.notify();
+                    }
+                    BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. } => {
+                        // Autoexecute changes don't affect token usage or the
+                        // effective model, so the long-context warning can't change here.
+                        me.sync_fast_forward_button(ctx);
+                        ctx.notify();
+                    }
+                    BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated {
+                        conversation_id,
+                    } => {
+                        let active_conversation_id = BlocklistAIHistoryModel::as_ref(ctx)
+                            .active_conversation(me.terminal_view_id)
+                            .map(|conversation| conversation.id());
+                        if active_conversation_id == Some(*conversation_id) {
+                            me.sync_long_context_warning_from_conversation(ctx);
+                            me.update_context_window_button(ctx);
+                            ctx.notify();
+                        }
                     }
                     BlocklistAIHistoryEvent::UpdatedTodoList { .. }
                     | BlocklistAIHistoryEvent::UpdatedConversationStatus { .. }
@@ -828,6 +906,21 @@ impl AgentInputFooter {
             None
         };
 
+        let (effective_model_provider, effective_model_threshold, is_custom_endpoint) = {
+            let preferences = LLMPreferences::as_ref(ctx);
+            let active_base_model = preferences.get_active_base_model(ctx, Some(terminal_view_id));
+            let is_custom_endpoint = preferences
+                .custom_llm_info_for_id(&active_base_model.id)
+                .is_some();
+            (
+                active_base_model.provider.clone(),
+                active_base_model.context_window.long_context_threshold,
+                is_custom_endpoint,
+            )
+        };
+        let total_input_tokens = BlocklistAIHistoryModel::as_ref(ctx)
+            .active_conversation(terminal_view_id)
+            .map_or(0, |conversation| conversation.total_input_tokens());
         let mut me = Self {
             terminal_view_id,
             ambient_agent_view_model,
@@ -847,6 +940,12 @@ impl AgentInputFooter {
             plugin_operation_in_progress: false,
             plugin_chip_ready: false,
             context_window_button,
+            long_context_warning_state: LongContextWarningState::new(
+                effective_model_provider,
+                effective_model_threshold,
+                is_custom_endpoint,
+                total_input_tokens,
+            ),
             model_selector: profile_model_selector_full,
             environment_selector,
             handoff_environment_selector,
@@ -998,6 +1097,30 @@ impl AgentInputFooter {
                 chip.update_session_context(session_context.clone(), chip_ctx);
             });
         }
+    }
+
+    fn sync_long_context_warning_from_conversation(&mut self, app: &AppContext) {
+        let total_input_tokens = BlocklistAIHistoryModel::as_ref(app)
+            .active_conversation(self.terminal_view_id)
+            .map_or(0, |conversation| conversation.total_input_tokens());
+        self.long_context_warning_state
+            .set_total_input_tokens(total_input_tokens);
+    }
+
+    fn sync_long_context_warning_from_effective_model(
+        &mut self,
+        preferences: &LLMPreferences,
+        app: &AppContext,
+    ) {
+        let active_base_model = preferences.get_active_base_model(app, Some(self.terminal_view_id));
+        let is_custom_endpoint = preferences
+            .custom_llm_info_for_id(&active_base_model.id)
+            .is_some();
+        self.long_context_warning_state.update_effective_model(
+            active_base_model.provider.clone(),
+            active_base_model.context_window.long_context_threshold,
+            is_custom_endpoint,
+        );
     }
 
     fn has_active_cli_agent_input_session(&self, app: &AppContext) -> bool {
@@ -1969,7 +2092,8 @@ impl AgentInputFooter {
             BlocklistAIHistoryModel::as_ref(ctx).active_conversation(self.terminal_view_id)
         {
             let usage = conversation.context_window_usage();
-            let icon = icon_for_context_window_usage(usage);
+            let show_long_context_warning = self.long_context_warning_state.is_visible();
+            let icon = icon_for_context_window_usage(usage, show_long_context_warning);
             let remaining_pct = ((1.0 - usage) * 100.0).round() as i32;
 
             let expiry = conversation.latest_exchange().and_then(|exchange| {
@@ -1978,7 +2102,13 @@ impl AgentInputFooter {
             });
             let is_cache_expired = FeatureFlag::PromptCacheExpiryWarning.is_enabled()
                 && expiry.is_some_and(|expiry| expiry <= Local::now());
-            let context_remaining_tooltip = format!("{remaining_pct}% context remaining");
+            let context_remaining_tooltip = if show_long_context_warning {
+                format!(
+                    "{remaining_pct}% context remaining\n{OPENAI_LONG_CONTEXT_PRICING_WARNING_TOOLTIP}"
+                )
+            } else {
+                format!("{remaining_pct}% context remaining")
+            };
             let tooltip = if is_cache_expired {
                 format!("{context_remaining_tooltip} · prompt cache expired")
             } else {
@@ -1988,6 +2118,11 @@ impl AgentInputFooter {
             self.prompt_cache_expired = is_cache_expired;
             self.context_window_button.update(ctx, |button, ctx| {
                 button.set_icon(Some(icon), ctx);
+                if show_long_context_warning {
+                    button.set_theme(LongContextWarningButtonTheme, ctx);
+                } else {
+                    button.set_theme(AgentInputButtonTheme, ctx);
+                }
                 button.set_tooltip(Some(tooltip), ctx);
             });
 
@@ -2702,6 +2837,39 @@ impl ActionButtonTheme for ActiveMicButtonTheme {
     }
 }
 
+/// Yellow-accented theme for the long-context pricing warning context window chip.
+struct LongContextWarningButtonTheme;
+
+impl ActionButtonTheme for LongContextWarningButtonTheme {
+    fn background(&self, hovered: bool, appearance: &Appearance) -> Option<Fill> {
+        let yellow = appearance.theme().ansi_fg_yellow();
+        let base = appearance.theme().surface_1();
+        Some(if hovered {
+            base.blend(&Fill::Solid(yellow).with_opacity(60))
+        } else {
+            base.blend(&Fill::Solid(yellow).with_opacity(15))
+        })
+    }
+
+    fn text_color(
+        &self,
+        _hovered: bool,
+        _background: Option<Fill>,
+        appearance: &Appearance,
+    ) -> ColorU {
+        appearance.theme().ansi_fg_yellow()
+    }
+
+    fn border(&self, appearance: &Appearance) -> Option<ColorU> {
+        let yellow = appearance.theme().ansi_fg_yellow();
+        Some(ColorU::new(yellow.r, yellow.g, yellow.b, 80))
+    }
+
+    fn should_opt_out_of_contrast_adjustment(&self) -> bool {
+        true
+    }
+}
+
 /// Green-accented theme for the "Install Warp plugin" chip.
 struct InstallPluginButtonTheme;
 
@@ -2845,3 +3013,7 @@ impl ActionButtonTheme for NLDButtonTheme {
         true
     }
 }
+
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -2092,7 +2092,8 @@ impl AgentInputFooter {
             BlocklistAIHistoryModel::as_ref(ctx).active_conversation(self.terminal_view_id)
         {
             let usage = conversation.context_window_usage();
-            let show_long_context_warning = self.long_context_warning_state.is_visible();
+            let show_long_context_warning = FeatureFlag::LongContextWarning.is_enabled()
+                && self.long_context_warning_state.is_visible();
             let icon = icon_for_context_window_usage(usage, show_long_context_warning);
             let remaining_pct = ((1.0 - usage) * 100.0).round() as i32;
 

--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod_tests.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod_tests.rs
@@ -1,0 +1,62 @@
+use warpui::EntityId;
+
+use super::{
+    execution_profile_event_affects_long_context_warning,
+    llm_preferences_event_affects_long_context_warning,
+};
+use crate::ai::execution_profiles::profiles::{AIExecutionProfilesModelEvent, ClientProfileId};
+use crate::ai::llms::LLMPreferencesEvent;
+
+#[test]
+fn model_catalog_and_active_model_changes_recompute_long_context_warning() {
+    assert!(llm_preferences_event_affects_long_context_warning(
+        &LLMPreferencesEvent::UpdatedAvailableLLMs
+    ));
+    assert!(llm_preferences_event_affects_long_context_warning(
+        &LLMPreferencesEvent::UpdatedActiveAgentModeLLM
+    ));
+    assert!(!llm_preferences_event_affects_long_context_warning(
+        &LLMPreferencesEvent::UpdatedActiveCodingLLM
+    ));
+}
+
+#[test]
+fn only_relevant_profile_changes_recompute_long_context_warning() {
+    let terminal_view_id = EntityId::new();
+    let other_terminal_view_id = EntityId::new();
+    let active_profile_id = ClientProfileId::new();
+    let inactive_profile_id = ClientProfileId::new();
+
+    assert!(execution_profile_event_affects_long_context_warning(
+        &AIExecutionProfilesModelEvent::ProfileUpdated(active_profile_id),
+        active_profile_id,
+        terminal_view_id,
+    ));
+    assert!(!execution_profile_event_affects_long_context_warning(
+        &AIExecutionProfilesModelEvent::ProfileUpdated(inactive_profile_id),
+        active_profile_id,
+        terminal_view_id,
+    ));
+    assert!(execution_profile_event_affects_long_context_warning(
+        &AIExecutionProfilesModelEvent::UpdatedActiveProfile { terminal_view_id },
+        active_profile_id,
+        terminal_view_id,
+    ));
+    assert!(!execution_profile_event_affects_long_context_warning(
+        &AIExecutionProfilesModelEvent::UpdatedActiveProfile {
+            terminal_view_id: other_terminal_view_id,
+        },
+        active_profile_id,
+        terminal_view_id,
+    ));
+    assert!(execution_profile_event_affects_long_context_warning(
+        &AIExecutionProfilesModelEvent::ProfileDeleted,
+        active_profile_id,
+        terminal_view_id,
+    ));
+    assert!(!execution_profile_event_affects_long_context_warning(
+        &AIExecutionProfilesModelEvent::ProfileCreated,
+        active_profile_id,
+        terminal_view_id,
+    ));
+}

--- a/app/src/ai/blocklist/controller/shared_session.rs
+++ b/app/src/ai/blocklist/controller/shared_session.rs
@@ -506,10 +506,10 @@ impl BlocklistAIController {
                 .conversation(&conv_id)
                 .map(|conversation| stream_finished::ConversationUsageMetadata {
                     context_window_usage: conversation.context_window_usage(),
+                    total_input_tokens: conversation.total_input_tokens(),
                     credits_spent: conversation.inference_credits_spent(),
                     platform_credits_spent: conversation.platform_credits_spent(),
                     summarized: conversation.was_summarized(),
-                    total_input_tokens: 0,
                     #[allow(deprecated)]
                     token_usage: conversation
                         .token_usage()

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -1074,6 +1074,7 @@ fn create_server_metadata(
     let usage = ConversationUsageMetadata {
         was_summarized: false,
         context_window_usage: 0.0,
+        total_input_tokens: 0,
         credits_spent,
         platform_credits_spent: 0.0,
         credits_spent_for_last_block: None,

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -234,6 +234,7 @@ fn make_server_metadata_with_harness(
         usage: ConversationUsageMetadata {
             was_summarized: false,
             context_window_usage: 0.0,
+            total_input_tokens: 0,
             credits_spent: 0.0,
             platform_credits_spent: 0.0,
             credits_spent_for_last_block: None,

--- a/app/src/ai/blocklist/usage/mod.rs
+++ b/app/src/ai/blocklist/usage/mod.rs
@@ -2,10 +2,79 @@ use warp_core::ui::theme::{Fill, WarpTheme};
 use warp_core::ui::Icon;
 use warpui::Element;
 
+use crate::ai::llms::LLMProvider;
+
 pub mod conversation_usage_view;
 pub mod rollup;
 
-pub fn icon_for_context_window_usage(context_window_usage: f32) -> Icon {
+#[derive(Debug)]
+pub(crate) struct LongContextWarningState {
+    effective_model_provider: LLMProvider,
+    /// The active model's long-context pricing threshold, in input tokens.
+    /// `None` when the model has no long-context pricing tier.
+    effective_model_threshold: Option<u32>,
+    /// Whether the active model is a user-configured custom endpoint. The
+    /// warning communicates Warp-priced OpenAI long-context tiers, which don't
+    /// apply to custom endpoints, so it is never surfaced for them.
+    is_custom_endpoint: bool,
+    /// Input tokens of the latest primary-agent LLM call in the latest
+    /// successfully persisted request, as reported by the server.
+    total_input_tokens: u32,
+}
+
+impl LongContextWarningState {
+    pub fn new(
+        effective_model_provider: LLMProvider,
+        effective_model_threshold: Option<u32>,
+        is_custom_endpoint: bool,
+        total_input_tokens: u32,
+    ) -> Self {
+        Self {
+            effective_model_provider,
+            effective_model_threshold,
+            is_custom_endpoint,
+            total_input_tokens,
+        }
+    }
+
+    pub fn set_total_input_tokens(&mut self, total_input_tokens: u32) {
+        self.total_input_tokens = total_input_tokens;
+    }
+
+    pub fn update_effective_model(
+        &mut self,
+        effective_model_provider: LLMProvider,
+        effective_model_threshold: Option<u32>,
+        is_custom_endpoint: bool,
+    ) {
+        self.effective_model_provider = effective_model_provider;
+        self.effective_model_threshold = effective_model_threshold;
+        self.is_custom_endpoint = is_custom_endpoint;
+    }
+
+    /// Visible when the latest reported input tokens exceed the active model's
+    /// long-context pricing threshold (strictly greater, matching the server's
+    /// pricing predicate). The warning communicates OpenAI's long-context
+    /// pricing tiers, so it is only surfaced for OpenAI models — even though
+    /// other providers (e.g. Gemini) also expose a threshold — and never for
+    /// custom endpoints, whose pricing Warp does not control.
+    pub fn is_visible(&self) -> bool {
+        !self.is_custom_endpoint
+            && self.effective_model_provider == LLMProvider::OpenAI
+            && self
+                .effective_model_threshold
+                .is_some_and(|threshold| self.total_input_tokens > threshold)
+    }
+}
+
+pub fn icon_for_context_window_usage(
+    context_window_usage: f32,
+    show_long_context_warning: bool,
+) -> Icon {
+    if show_long_context_warning {
+        return Icon::ContextRemaining0;
+    }
+
     // The circle's solid (white) marks represent the context *remaining*, not
     // the amount used: an empty conversation shows an all-white circle (100%
     // remaining) and counts down to an all-grey circle as the context window
@@ -43,7 +112,7 @@ pub fn render_context_window_usage_icon(
     theme: &WarpTheme,
     color_override: Option<Fill>,
 ) -> Box<dyn Element> {
-    let icon = icon_for_context_window_usage(context_window_usage);
+    let icon = icon_for_context_window_usage(context_window_usage, false);
 
     let fill = if context_window_usage >= 0.8 {
         Fill::Solid(theme.ansi_fg_red())

--- a/app/src/ai/blocklist/usage/mod_tests.rs
+++ b/app/src/ai/blocklist/usage/mod_tests.rs
@@ -1,4 +1,5 @@
-//! Tests for the context-window usage circle icon mapping.
+//! Tests for the context-window usage circle icon mapping and the
+//! long-context warning state.
 //!
 //! Regression guard for the color semantics of the context-window circle:
 //! the solid (white) marks represent the context *remaining*, not the amount
@@ -8,13 +9,121 @@
 
 use warp_core::ui::Icon;
 
-use super::icon_for_context_window_usage;
+use super::{icon_for_context_window_usage, LongContextWarningState};
+use crate::ai::llms::LLMProvider;
+
+const THRESHOLD: u32 = 272_000;
+
+#[test]
+fn visible_only_strictly_above_threshold() {
+    let below =
+        LongContextWarningState::new(LLMProvider::OpenAI, Some(THRESHOLD), false, THRESHOLD - 1);
+    assert!(!below.is_visible());
+
+    let at_threshold =
+        LongContextWarningState::new(LLMProvider::OpenAI, Some(THRESHOLD), false, THRESHOLD);
+    assert!(
+        !at_threshold.is_visible(),
+        "exactly at the threshold must not warn; the server prices long context strictly above it"
+    );
+
+    let above =
+        LongContextWarningState::new(LLMProvider::OpenAI, Some(THRESHOLD), false, THRESHOLD + 1);
+    assert!(above.is_visible());
+}
+
+#[test]
+fn set_total_input_tokens_updates_visibility() {
+    let mut state = LongContextWarningState::new(LLMProvider::OpenAI, Some(THRESHOLD), false, 0);
+    assert!(!state.is_visible());
+
+    // A qualifying request shows the warning.
+    state.set_total_input_tokens(THRESHOLD + 1);
+    assert!(state.is_visible());
+
+    // A later short request clears it.
+    state.set_total_input_tokens(12_000);
+    assert!(!state.is_visible());
+}
+
+#[test]
+fn hidden_without_threshold() {
+    // Models without a long-context pricing tier (including Auto models, whose
+    // underlying model varies) never warn, regardless of context size.
+    let state = LongContextWarningState::new(LLMProvider::OpenAI, None, false, 1_000_000);
+    assert!(!state.is_visible());
+}
+
+#[test]
+fn hidden_for_non_openai_provider_even_above_threshold() {
+    // Gemini exposes a 200K threshold, but the warning communicates OpenAI's
+    // long-context pricing tiers and must not surface for other providers.
+    let google = LongContextWarningState::new(LLMProvider::Google, Some(200_000), false, 250_000);
+    assert!(!google.is_visible());
+
+    let anthropic =
+        LongContextWarningState::new(LLMProvider::Anthropic, Some(200_000), false, 250_000);
+    assert!(!anthropic.is_visible());
+}
+
+#[test]
+fn hidden_for_custom_endpoint_even_above_threshold() {
+    // Custom endpoints are priced outside Warp's OpenAI long-context tiers, so
+    // the warning must never surface for them — even if the synthetic model
+    // somehow reports the OpenAI provider and a threshold.
+    let state = LongContextWarningState::new(LLMProvider::OpenAI, Some(THRESHOLD), true, 1_000_000);
+    assert!(!state.is_visible());
+}
+
+#[test]
+fn model_switch_recomputes_against_new_threshold() {
+    // 250K tokens is below GPT-5.4's 272K threshold...
+    let mut state =
+        LongContextWarningState::new(LLMProvider::OpenAI, Some(272_000), false, 250_000);
+    assert!(!state.is_visible());
+
+    // ...but above a hypothetical lower-threshold OpenAI model.
+    state.update_effective_model(LLMProvider::OpenAI, Some(200_000), false);
+    assert!(state.is_visible());
+
+    // Switching to a higher-threshold model hides it again from the same tokens.
+    state.update_effective_model(LLMProvider::OpenAI, Some(400_000), false);
+    assert!(!state.is_visible());
+
+    // Switching to a non-OpenAI model hides it even when its threshold is exceeded.
+    state.update_effective_model(LLMProvider::Google, Some(200_000), false);
+    assert!(!state.is_visible());
+
+    // Switching to a custom endpoint hides it even when above its threshold.
+    state.update_effective_model(LLMProvider::OpenAI, Some(200_000), true);
+    assert!(!state.is_visible());
+}
+
+#[test]
+fn zero_tokens_never_warn() {
+    // Legacy conversations and old servers report 0; the warning stays hidden.
+    let state = LongContextWarningState::new(LLMProvider::OpenAI, Some(THRESHOLD), false, 0);
+    assert!(!state.is_visible());
+}
+
+#[test]
+fn long_context_warning_forces_full_icon() {
+    // With the warning active, the icon shows the context-full state regardless of usage.
+    assert_eq!(
+        icon_for_context_window_usage(0.0, true),
+        Icon::ContextRemaining0
+    );
+    assert_eq!(
+        icon_for_context_window_usage(0.5, true),
+        Icon::ContextRemaining0
+    );
+}
 
 #[test]
 fn empty_conversation_shows_full_white_circle() {
     // 0% used == 100% remaining -> all-white circle.
     assert_eq!(
-        icon_for_context_window_usage(0.0),
+        icon_for_context_window_usage(0.0, false),
         Icon::ContextRemaining100
     );
 }
@@ -22,18 +131,27 @@ fn empty_conversation_shows_full_white_circle() {
 #[test]
 fn full_context_window_shows_all_grey_circle() {
     // 100% used == 0% remaining -> all-grey circle.
-    assert_eq!(icon_for_context_window_usage(1.0), Icon::ContextRemaining0);
+    assert_eq!(
+        icon_for_context_window_usage(1.0, false),
+        Icon::ContextRemaining0
+    );
 }
 
 #[test]
 fn icon_brightness_tracks_remaining_not_used() {
     // Lightly-used conversation: lots of context remaining -> mostly white.
-    assert_eq!(icon_for_context_window_usage(0.1), Icon::ContextRemaining90);
+    assert_eq!(
+        icon_for_context_window_usage(0.1, false),
+        Icon::ContextRemaining90
+    );
     // Half used -> half white.
-    assert_eq!(icon_for_context_window_usage(0.5), Icon::ContextRemaining50);
+    assert_eq!(
+        icon_for_context_window_usage(0.5, false),
+        Icon::ContextRemaining50
+    );
     // Heavily used (the original report's 88%): little remaining -> mostly grey.
     assert_eq!(
-        icon_for_context_window_usage(0.88),
+        icon_for_context_window_usage(0.88, false),
         Icon::ContextRemaining10
     );
 }
@@ -42,7 +160,7 @@ fn icon_brightness_tracks_remaining_not_used() {
 fn mapping_is_monotonic_more_usage_never_brightens_the_circle() {
     // As usage increases, the number of bright (remaining) marks must be
     // non-increasing — the circle only ever empties as context fills.
-    let icon_rank = |usage: f32| match icon_for_context_window_usage(usage) {
+    let icon_rank = |usage: f32| match icon_for_context_window_usage(usage, false) {
         Icon::ContextRemaining0 => 0,
         Icon::ContextRemaining10 => 10,
         Icon::ContextRemaining20 => 20,

--- a/app/src/ai/conversation_details_panel_tests.rs
+++ b/app/src/ai/conversation_details_panel_tests.rs
@@ -180,6 +180,7 @@ fn create_test_server_metadata(
         usage: ConversationUsageMetadata {
             was_summarized: false,
             context_window_usage: 0.0,
+            total_input_tokens: 0,
             credits_spent: 0.0,
             platform_credits_spent: 0.0,
             credits_spent_for_last_block: None,

--- a/app/src/ai/execution_profiles/editor/mod_tests.rs
+++ b/app/src/ai/execution_profiles/editor/mod_tests.rs
@@ -47,6 +47,7 @@ fn configurable_model(provider: LLMProvider) -> LLMInfo {
             min: 200_000,
             max: 1_000_000,
             default_max: 272_000,
+            long_context_threshold: None,
         },
     }
 }
@@ -265,6 +266,7 @@ fn openai_fixed_context_metadata_does_not_expose_control_or_warning() {
         min: 272_000,
         max: 272_000,
         default_max: 272_000,
+        long_context_threshold: None,
     };
     assert!(!has_configurable_context_window(&model, true));
     assert_context_window_limit_for_request(&model, Some(1_000_000), true, None);

--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -170,6 +170,11 @@ pub struct LLMContextWindow {
     pub max: u32,
     #[serde(default)]
     pub default_max: u32,
+    /// Input-token count above which the model's long-context pricing applies.
+    /// `None` when the model has no long-context pricing tier (including Auto
+    /// models, whose underlying model can vary).
+    #[serde(default)]
+    pub long_context_threshold: Option<u32>,
 }
 
 /// Metadata about an LLM.

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -509,6 +509,8 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::GeminiEnterprise,
         #[cfg(feature = "prompt_cache_expiry_warning")]
         FeatureFlag::PromptCacheExpiryWarning,
+        #[cfg(feature = "long_context_warning")]
+        FeatureFlag::LongContextWarning,
     ]);
 
     flags

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -347,6 +347,7 @@ fn test_server_conversation_metadata(
         usage: ConversationUsageMetadata {
             was_summarized: false,
             context_window_usage: 0.0,
+            total_input_tokens: 0,
             credits_spent: 0.0,
             platform_credits_spent: 0.0,
             credits_spent_for_last_block: None,

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -3030,6 +3030,7 @@ impl From<warp_graphql::queries::get_feature_model_choices::LlmInfo> for LLMInfo
                 min: value.context_window.min.into(),
                 max: value.context_window.max.into(),
                 default_max: value.context_window.default.into(),
+                long_context_threshold: value.context_window.long_context_threshold.map(Into::into),
             },
         }
     }
@@ -3069,6 +3070,7 @@ impl From<warp_graphql::workspace::LlmInfo> for LLMInfo {
                 min: value.context_window.min.into(),
                 max: value.context_window.max.into(),
                 default_max: value.context_window.default.into(),
+                long_context_threshold: value.context_window.long_context_threshold.map(Into::into),
             },
         }
     }
@@ -3284,6 +3286,7 @@ fn convert_conversation_format(
 fn convert_usage_metadata(
     summarized: bool,
     context_window_usage: f64,
+    total_input_tokens: i32,
     credits_spent: f64,
     platform_credits_spent: f64,
     context_window_segments: &[warp_graphql::ai::ContextWindowSegment],
@@ -3291,6 +3294,7 @@ fn convert_usage_metadata(
     ConversationUsageMetadata {
         was_summarized: summarized,
         context_window_usage: context_window_usage as f32,
+        total_input_tokens: u32::try_from(total_input_tokens).unwrap_or_default(),
         credits_spent: credits_spent as f32,
         platform_credits_spent: platform_credits_spent as f32,
         credits_spent_for_last_block: None,
@@ -3307,6 +3311,7 @@ impl TryFrom<warp_graphql::ai::AIConversation> for ServerAIConversationMetadata 
         let usage = convert_usage_metadata(
             value.usage.usage_metadata.summarized,
             value.usage.usage_metadata.context_window_usage,
+            value.usage.usage_metadata.total_input_tokens,
             value.usage.usage_metadata.credits_spent,
             value.usage.usage_metadata.platform_credits_spent,
             &value.usage.usage_metadata.context_window_segments,
@@ -3354,6 +3359,7 @@ impl TryFrom<warp_graphql::queries::list_ai_conversations::AIConversationMetadat
         let usage = convert_usage_metadata(
             value.usage.usage_metadata.summarized,
             value.usage.usage_metadata.context_window_usage,
+            value.usage.usage_metadata.total_input_tokens,
             value.usage.usage_metadata.credits_spent,
             value.usage.usage_metadata.platform_credits_spent,
             &value.usage.usage_metadata.context_window_segments,

--- a/app/src/terminal/shared_session/replay_agent_conversations.rs
+++ b/app/src/terminal/shared_session/replay_agent_conversations.rs
@@ -166,7 +166,7 @@ fn create_finished_event_from_conversation(conversation: &AIConversation) -> Res
     let usage_metadata = Some(
         api_response_event::stream_finished::ConversationUsageMetadata {
             context_window_usage: conversation.context_window_usage(),
-            total_input_tokens: 0,
+            total_input_tokens: conversation.total_input_tokens(),
             credits_spent: conversation.inference_credits_spent(),
             platform_credits_spent: conversation.platform_credits_spent(),
             summarized: conversation.was_summarized(),

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation_tests.rs
@@ -273,6 +273,7 @@ fn server_conversation_metadata(
         usage: ConversationUsageMetadata {
             was_summarized: false,
             context_window_usage: 0.0,
+            total_input_tokens: 0,
             credits_spent: 0.0,
             platform_credits_spent: 0.0,
             credits_spent_for_last_block: None,

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -626,6 +626,7 @@ fn server_conversation_metadata(
         usage: ConversationUsageMetadata {
             was_summarized: false,
             context_window_usage: 0.0,
+            total_input_tokens: 0,
             credits_spent: 0.0,
             platform_credits_spent: 0.0,
             credits_spent_for_last_block: None,

--- a/crates/graphql/src/api/ai.rs
+++ b/crates/graphql/src/api/ai.rs
@@ -167,6 +167,7 @@ pub struct ConversationUsage {
 #[derive(cynic::QueryFragment, Debug, Clone)]
 pub struct ConversationUsageMetadata {
     pub context_window_usage: f64,
+    pub total_input_tokens: i32,
     pub context_window_segments: Vec<ContextWindowSegment>,
     pub credits_spent: f64,
     pub platform_credits_spent: f64,

--- a/crates/graphql/src/api/queries/get_conversation_usage.rs
+++ b/crates/graphql/src/api/queries/get_conversation_usage.rs
@@ -24,6 +24,7 @@ query GetConversationUsage(
           lastUpdated
           usageMetadata {
             contextWindowUsage
+            totalInputTokens
             creditsSpent
             platformCreditsSpent
             summarized
@@ -114,6 +115,7 @@ pub struct ConversationUsage {
 #[derive(cynic::QueryFragment, Debug, Clone)]
 pub struct ConversationUsageMetadata {
     pub context_window_usage: f64,
+    pub total_input_tokens: i32,
     pub context_window_segments: Vec<ContextWindowSegment>,
     pub credits_spent: f64,
     pub platform_credits_spent: f64,
@@ -189,6 +191,7 @@ impl From<&ConversationUsageMetadata> for persistence::model::ConversationUsageM
         Self {
             was_summarized: gql.summarized,
             context_window_usage: gql.context_window_usage as f32,
+            total_input_tokens: u32::try_from(gql.total_input_tokens).unwrap_or_default(),
             credits_spent: gql.credits_spent as f32,
             platform_credits_spent: gql.platform_credits_spent as f32,
             credits_spent_for_last_block: None,

--- a/crates/graphql/src/api/queries/get_feature_model_choices.rs
+++ b/crates/graphql/src/api/queries/get_feature_model_choices.rs
@@ -89,6 +89,7 @@ pub struct LlmContextWindow {
     pub min: crate::scalars::Uint32,
     pub max: crate::scalars::Uint32,
     pub default: crate::scalars::Uint32,
+    pub long_context_threshold: Option<crate::scalars::Uint32>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]

--- a/crates/graphql/src/api/workspace.rs
+++ b/crates/graphql/src/api/workspace.rs
@@ -49,6 +49,7 @@ pub struct LlmContextWindow {
     pub min: crate::scalars::Uint32,
     pub max: crate::scalars::Uint32,
     pub default: crate::scalars::Uint32,
+    pub long_context_threshold: Option<crate::scalars::Uint32>,
 }
 
 #[derive(cynic::QueryFragment, Debug, Clone)]

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -1468,6 +1468,10 @@ impl From<&ContextWindowSegment> for stream_finished::ContextWindowSegment {
 pub struct ConversationUsageMetadata {
     pub was_summarized: bool,
     pub context_window_usage: f32,
+    /// Input tokens of the latest primary-agent LLM call in the latest
+    /// successfully persisted request that had Warp-charged or BYOK usage.
+    #[serde(default)]
+    pub total_input_tokens: u32,
     pub credits_spent: f32,
     #[serde(default)]
     pub platform_credits_spent: f32,

--- a/crates/persistence/src/model_tests.rs
+++ b/crates/persistence/src/model_tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use warp_multi_agent_api as api;
 
-use super::{AgentConversation, AgentConversationData, ModelTokenUsage};
+use super::{AgentConversation, AgentConversationData, ConversationUsageMetadata, ModelTokenUsage};
 
 fn parentless_task(id: &str, message_count: usize) -> api::Task {
     api::Task {
@@ -311,4 +311,25 @@ fn model_token_usage_replay_skips_non_custom_endpoint_entries() {
         ..Default::default()
     };
     assert!(warp_only.to_proto_custom_endpoint_usage().is_none());
+}
+
+#[test]
+fn conversation_usage_metadata_roundtrips_total_input_tokens() {
+    let metadata = ConversationUsageMetadata {
+        total_input_tokens: 280_123,
+        ..Default::default()
+    };
+    let json = serde_json::to_string(&metadata).expect("serialize");
+    let roundtripped: ConversationUsageMetadata = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(roundtripped.total_input_tokens, 280_123);
+}
+
+#[test]
+fn conversation_usage_metadata_legacy_rows_default_total_input_tokens_to_zero() {
+    // Rows persisted before this field landed omit it entirely;
+    // `#[serde(default)]` must accept them as `0`.
+    let legacy_json = r#"{"was_summarized":false,"context_window_usage":0.5,"credits_spent":0.0}"#;
+    let metadata: ConversationUsageMetadata =
+        serde_json::from_str(legacy_json).expect("legacy rows must deserialize");
+    assert_eq!(metadata.total_input_tokens, 0);
 }

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -901,6 +901,10 @@ pub enum FeatureFlag {
     /// Enables the `--runner` flag on `run-cloud`, which overrides an agent's
     /// compute (docker image, instance shape, setup commands) by runner ID.
     CloudRunners,
+
+    /// Controls visibility of the long-context warning UI, shown when a
+    /// conversation approaches the model's long context window limit.
+    LongContextWarning,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =
@@ -971,6 +975,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::ContextWindowUsageBreakdown,
     FeatureFlag::CloudRunners,
     FeatureFlag::WaitForEventsParentRegistration,
+    FeatureFlag::LongContextWarning,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -822,6 +822,12 @@ type ConversationUsageMetadata {
   contextWindowSegments: [ContextWindowSegment!]!
   contextWindowUsage: Float!
 
+  """
+  Input tokens of the latest primary-agent LLM call in the latest successfully
+  persisted request that had Warp-charged or BYOK usage; 0 otherwise.
+  """
+  totalInputTokens: Int!
+
   """The total number of inference credits spent so far in the conversation"""
   creditsSpent: Float!
 
@@ -2017,6 +2023,13 @@ type LlmContextWindow {
   When true, the client can pick a context window size in the range [min, max].
   """
   isConfigurable: Boolean!
+
+  """
+  Input-token count above which the model's long-context pricing applies.
+  Null when the model has no long-context pricing tier (including Auto models,
+  whose underlying model can vary).
+  """
+  longContextThreshold: Uint
 
   """
   Maximum context window size. The upper bound for any user override


### PR DESCRIPTION
Adds a **long-context usage warning indicator** to the agent input footer, with the client deciding visibility from server-provided threshold and input data.

- **What:** Thread the server's `total_input_tokens` (latest primary-agent call input tokens of the latest persisted charged/BYOK request) through the proto stream, GraphQL restore, and local persistence, and expose each model's `longContextThreshold` on `LlmContextWindow`. 
- The footer warning shows when `provider == OpenAI && total_input_tokens > threshold` for the active model.
- **Why:** Signal to users when a conversation has entered OpenAI's long-context pricing tier, without the server computing a boolean — the client recomputes against the active model's threshold (e.g. on model switch).
- **How:**
  - `crates/persistence/src/model.rs`, `app/src/ai/agent/conversation.rs`: persist/apply `total_input_tokens` (nonzero overwrites, zero keeps previous, matching server merge semantics).
  - `crates/graphql/src/api/...`, `crates/warp_graphql_schema/api/schema.graphql`: `totalInputTokens` on conversation usage; nullable `longContextThreshold` on `LlmContextWindow`; `LLMContextWindow.long_context_threshold` on the client model metadata.
  - `app/src/ai/blocklist/usage/mod.rs`: `LongContextWarningState` now holds tokens + active model provider/threshold and derives visibility; UI rendering (icon, tooltip, yellow warning theme) is unchanged.

Counterparts:
- proto: warpdotdev/warp-proto-apis#323 (`total_input_tokens`, pinned at `7de66cc8`)
- server: warpdotdev/warp-server#11843 
- 
## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `app/src/ai/blocklist/usage/mod_tests.rs`: threshold boundary (at vs +1), no-threshold model (Auto), non-OpenAI providers hidden despite threshold, model-switch recompute (lower/higher/non-OpenAI), zero tokens, icon behavior.
- `crates/persistence/src/model_tests.rs`: `total_input_tokens` JSON round-trip and legacy-row default.
- `cargo nextest` targeted run (56 tests) passes; `./script/format` run; `cargo clippy --all-targets -- -D warnings` clean on touched packages (`warp`, `persistence`, `warp_graphql`).

### Screenshots / Videos
https://www.loom.com/share/e2ea70c8db7a4ce6ada8c766c5a425da

different themes: 
https://www.loom.com/share/9d0d634e82314f39ba8e1eab0c69363e

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Plan: https://staging.warp.dev/drive/notebook/yJt0g7NfiwnSYuQdNfQAO1
Conversation: https://staging.warp.dev/conversation/4321295c-fe0b-4a19-9382-44738d7db792

<!--
CHANGELOG-IMPROVEMENT: Added a long-context pricing warning on the agent input footer's context-window usage icon.
-->

Co-Authored-By: Oz <oz-agent@warp.dev>
