### PR TITLE
Add mouse event handling to TUI input

### DIFF
--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -775,27 +775,43 @@ impl TuiInputElement {
         self.selected_spans = selected_spans;
     }
 
-    /// Maps a terminal cell `position` to a 1-based buffer [`CharOffset`].
+    /// Maps a terminal cell `position` to the 1-based buffer [`CharOffset`] under
+    /// it (the gap the cursor should move to for a click/drag at that cell).
     ///
-    /// Points outside the input's vertical bounds are intentionally *not*
-    /// clamped to the viewport: a point above the input maps toward row 0 and a
-    /// point below it maps past the last visible row (bounded by the buffer's
-    /// last visual row), so a drag that leaves the input drives auto-scroll.
+    /// The mouse reports an absolute terminal cell, so getting to a buffer offset
+    /// crosses three coordinate spaces:
+    ///   1. screen cell (`position`) -> row/col relative to the input's `area`,
+    ///   2. + `scroll_offset` -> the buffer's *visual* row (undoes scrolling),
+    ///   3. (visual row, col) -> char offset via the char-cell soft-wrap map.
+    ///
+    /// Points outside the input's vertical bounds are intentionally *not* clamped
+    /// to the viewport: a point above the input maps toward row 0 and a point
+    /// below it maps past the last visible row (bounded by the buffer's last
+    /// visual row), so a drag that leaves the input drives auto-scroll.
     fn offset_at(&self, position: TuiPoint, area: TuiRect, app: &AppContext) -> CharOffset {
         let inner = self.model.as_ref(app);
         let render = inner.render_state().as_ref(app);
 
-        // Buffer-relative visual row. Signed math keeps a point above `area`
-        // (smaller `y`) mapping above the current scroll offset.
+        // Step 1: row of the pointer within the input, where 0 is the input's top
+        // row. Signed so a point *above* the input (`position.y < area.y`) stays
+        // negative instead of wrapping around at 0.
         let row_in_view = i64::from(position.y) - i64::from(area.y);
+        // Step 2: the input shows buffer visual rows starting at `scroll_offset`,
+        // so the buffer row under the pointer is `scroll_offset + row_in_view`
+        // (floored at the first row).
         let visual_row = (i64::from(self.scroll_offset) + row_in_view).max(0) as u32;
+        // ...and capped at the last real visual row, so a drag below the text
+        // resolves to the buffer's end rather than past it.
         let last_row = render.max_line().as_u32().max(1).saturating_sub(1);
         let visual_row = visual_row.min(last_row);
 
+        // Column within that row, in display cells (0 is the input's left edge).
         let col = position.x.saturating_sub(area.x);
+
+        // Step 3: resolve (visual_row, col) to a char offset. The soft-wrap map
+        // clamps the column to the row's end and is 0-based, while the buffer
+        // uses 1-based gap offsets (see the kill-range helpers), so re-add 1.
         let point = SoftWrapPoint::new(visual_row, ColumnUnit::Chars(col));
-        // The char-cell soft-wrap API is 0-based; the buffer uses 1-based gap
-        // offsets (see the kill-range helpers), so re-add 1.
         let zero_based = render.softwrap_point_to_offset(point);
         CharOffset::from(zero_based.as_usize() + 1)
     }

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -24,17 +24,21 @@ use string_offset::CharOffset;
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp_editor::model::{CoreEditorModel, PlainTextEditorModel};
 use warp_editor::render::model::{
-    char_cell_display_width, char_cell_line_gap_position, char_cell_line_row_starts,
+    char_cell_display_width, char_cell_line_gap_position, char_cell_line_row_starts, ColumnUnit,
+    SoftWrapPoint,
 };
 use warp_editor::selection::TextUnit;
 use warpui_core::elements::tui::{
     Modifier, TuiBuffer, TuiColumn, TuiConstraint, TuiElement, TuiEvent, TuiEventContext,
-    TuiLayoutContext, TuiParentElement, TuiRect, TuiSize, TuiStyle, TuiText,
+    TuiLayoutContext, TuiParentElement, TuiPoint, TuiRect, TuiRectExt, TuiSize, TuiStyle, TuiText,
 };
 use warpui_core::text::word_boundaries::WordBoundariesPolicy;
 use warpui_core::{AppContext, Entity, ModelHandle, TuiView, TypedActionView, ViewContext};
 
 use super::kill_buffer::KillBuffer;
+
+/// Logical rows scrolled per mouse-wheel notch (matches `TuiScrollable`).
+const WHEEL_STEP: isize = 2;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // View events
@@ -110,6 +114,21 @@ pub enum TuiInputAction {
     Undo,
     /// Redo (`Ctrl+Shift+Z`).
     Redo,
+    /// Place the cursor / begin a character selection at `offset` (single click).
+    SelectionStartAt { offset: CharOffset },
+    /// Extend the active selection's head to `offset` (shift-click).
+    SelectionExtendTo { offset: CharOffset },
+    /// Select the word at `offset` (double click).
+    SelectWordAt { offset: CharOffset },
+    /// Select the line at `offset` (triple click).
+    SelectLineAt { offset: CharOffset },
+    /// Update the in-progress drag selection to `offset` (mouse drag).
+    SelectionUpdateTo { offset: CharOffset },
+    /// Finish the in-progress drag selection (mouse up).
+    SelectionEnd,
+    /// Scroll the viewport by `rows` visual rows without moving the cursor
+    /// (negative scrolls toward the top). Driven by the mouse wheel.
+    Scroll { rows: isize },
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -126,6 +145,9 @@ pub struct TuiInputView {
     scroll_offset: u32,
     /// Maximum number of visible rows before the input scrolls.
     max_visible_rows: u32,
+    /// Whether a mouse drag-selection is in progress (set on mouse-down, cleared
+    /// on mouse-up). Mirrors the GUI editor's `is_selecting`.
+    is_selecting: bool,
 }
 
 impl Entity for TuiInputView {
@@ -150,12 +172,44 @@ impl TuiInputView {
             kill_buffer: KillBuffer::default(),
             scroll_offset: 0,
             max_visible_rows: 6,
+            is_selecting: false,
         }
     }
 
     /// Returns a handle to the backing [`CodeEditorModel`].
     pub fn model(&self) -> &ModelHandle<CodeEditorModel> {
         &self.model
+    }
+
+    /// Builds the concrete `TuiInputElement` for this frame. `render` wraps it in
+    /// a `Box`; tests construct it directly to exercise mouse dispatch.
+    ///
+    /// Only width-independent state is gathered here; width-dependent layout (row
+    /// wrapping, cursor placement, selection spans) happens later in
+    /// `TuiInputElement::layout`, the first point that knows the terminal width.
+    fn render_element(&self, ctx: &AppContext) -> TuiInputElement {
+        let text = self.plain_text(ctx);
+        let cursor_offset = self.cursor_offset(ctx);
+        let sel_char_range = self.selection_range(ctx).map(|r| {
+            let start = r.start.as_usize().saturating_sub(1);
+            let end = r.end.as_usize().saturating_sub(1);
+            (start, end)
+        });
+
+        TuiInputElement {
+            model: self.model.clone(),
+            text,
+            cursor_offset,
+            sel_char_range,
+            scroll_offset: self.scroll_offset,
+            max_visible_rows: self.max_visible_rows,
+            is_selecting: self.is_selecting,
+            column: TuiColumn::new(),
+            cursor_col: 0,
+            cursor_row_in_view: 0,
+            cursor_visible: false,
+            selected_spans: Vec::new(),
+        }
     }
 }
 
@@ -165,30 +219,7 @@ impl TuiView for TuiInputView {
     }
 
     fn render(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
-        // Gather width-independent state. Width-dependent layout (row wrapping,
-        // cursor placement, selection spans) is deferred to
-        // `TuiInputElement::layout`, the first point that knows the terminal
-        // width (from the layout constraint).
-        let text = self.plain_text(ctx);
-        let cursor_offset = self.cursor_offset(ctx);
-        let sel_char_range = self.selection_range(ctx).map(|r| {
-            let start = r.start.as_usize().saturating_sub(1);
-            let end = r.end.as_usize().saturating_sub(1);
-            (start, end)
-        });
-
-        Box::new(TuiInputElement {
-            model: self.model.clone(),
-            text,
-            cursor_offset,
-            sel_char_range,
-            scroll_offset: self.scroll_offset,
-            max_visible_rows: self.max_visible_rows,
-            column: TuiColumn::new(),
-            cursor_col: 0,
-            cursor_row_in_view: 0,
-            selected_spans: Vec::new(),
-        })
+        Box::new(self.render_element(ctx))
     }
 }
 
@@ -316,6 +347,44 @@ impl TypedActionView for TuiInputView {
             TuiInputAction::Redo => {
                 self.model.update(ctx, |m, ctx| m.redo(ctx));
             }
+            TuiInputAction::SelectionStartAt { offset } => {
+                self.is_selecting = true;
+                self.model
+                    .update(ctx, |m, ctx| m.select_at(*offset, false, ctx));
+            }
+            TuiInputAction::SelectionExtendTo { offset } => {
+                self.model
+                    .update(ctx, |m, ctx| m.set_last_selection_head(*offset, ctx));
+            }
+            TuiInputAction::SelectWordAt { offset } => {
+                self.is_selecting = true;
+                self.model
+                    .update(ctx, |m, ctx| m.select_word_at(*offset, false, ctx));
+            }
+            TuiInputAction::SelectLineAt { offset } => {
+                self.is_selecting = true;
+                self.model
+                    .update(ctx, |m, ctx| m.select_line_at(*offset, false, ctx));
+            }
+            TuiInputAction::SelectionUpdateTo { offset } => {
+                if self.is_selecting {
+                    self.model
+                        .update(ctx, |m, ctx| m.update_pending_selection(*offset, ctx));
+                }
+            }
+            TuiInputAction::SelectionEnd => {
+                if self.is_selecting {
+                    self.is_selecting = false;
+                    self.model.update(ctx, |m, ctx| m.end_selection(ctx));
+                }
+            }
+            TuiInputAction::Scroll { rows } => {
+                // Wheel scrolling moves the viewport only; it must NOT snap back
+                // to the cursor, so it returns early (skipping `scroll_to_cursor`).
+                self.scroll_by(*rows, ctx);
+                ctx.notify();
+                return;
+            }
         }
 
         let visible_rows = cmp::min(self.visual_line_count(ctx), self.max_visible_rows);
@@ -405,6 +474,17 @@ impl TuiInputView {
         } else if cursor_row >= self.scroll_offset + visible_rows {
             self.scroll_offset = cursor_row.saturating_sub(visible_rows - 1);
         }
+    }
+
+    /// Scrolls the viewport by `rows` visual rows (negative scrolls toward the
+    /// top), clamped to `[0, max_scroll]`. Independent of the cursor, so callers
+    /// must not follow it with `scroll_to_cursor`.
+    fn scroll_by(&mut self, rows: isize, ctx: &AppContext) {
+        let lines = self.visual_line_count(ctx);
+        let visible_rows = cmp::min(lines, self.max_visible_rows).max(1);
+        let max_scroll = lines.saturating_sub(visible_rows) as isize;
+        let new_offset = (self.scroll_offset as isize + rows).clamp(0, max_scroll);
+        self.scroll_offset = new_offset as u32;
     }
 
     // ── Submit ────────────────────────────────────────────────────────────────
@@ -612,12 +692,18 @@ struct TuiInputElement {
     scroll_offset: u32,
     /// Maximum number of visible rows before the input scrolls.
     max_visible_rows: u32,
+    /// Whether a mouse drag-selection is in progress (captured from the view at
+    /// render time); gates drag/up handling in `dispatch_event`.
+    is_selecting: bool,
     /// Visible rows, built during `layout`.
     column: TuiColumn,
     /// The cursor's 0-based column within the visible area (set during `layout`).
     cursor_col: u16,
     /// The cursor's 0-based row within the visible area (set during `layout`).
     cursor_row_in_view: u16,
+    /// Whether the cursor's visual row falls within the scrolled viewport; when
+    /// false (e.g. after wheel-scrolling away) no terminal cursor is drawn.
+    cursor_visible: bool,
     /// Selected spans `(row_in_view, start_col, exclusive_end_col)` (set during `layout`).
     selected_spans: Vec<(u16, u16, u16)>,
 }
@@ -629,6 +715,8 @@ impl TuiInputElement {
         let (cursor_visual_row, cursor_col) =
             char_cell_cursor_pos(&self.text, self.cursor_offset, terminal_width);
         let cursor_row_in_view = cursor_visual_row.saturating_sub(self.scroll_offset);
+        let cursor_visible = cursor_visual_row >= self.scroll_offset
+            && cursor_visual_row < self.scroll_offset + visible_rows;
 
         let rows_with_offsets = build_visual_rows_with_offsets(&self.text, terminal_width);
         let visible_start = self.scroll_offset as usize;
@@ -683,7 +771,86 @@ impl TuiInputElement {
         self.column = column;
         self.cursor_col = cursor_col as u16;
         self.cursor_row_in_view = cursor_row_in_view as u16;
+        self.cursor_visible = cursor_visible;
         self.selected_spans = selected_spans;
+    }
+
+    /// Maps a terminal cell `position` to a 1-based buffer [`CharOffset`].
+    ///
+    /// Points outside the input's vertical bounds are intentionally *not*
+    /// clamped to the viewport: a point above the input maps toward row 0 and a
+    /// point below it maps past the last visible row (bounded by the buffer's
+    /// last visual row), so a drag that leaves the input drives auto-scroll.
+    fn offset_at(&self, position: TuiPoint, area: TuiRect, app: &AppContext) -> CharOffset {
+        let inner = self.model.as_ref(app);
+        let render = inner.render_state().as_ref(app);
+
+        // Buffer-relative visual row. Signed math keeps a point above `area`
+        // (smaller `y`) mapping above the current scroll offset.
+        let row_in_view = i64::from(position.y) - i64::from(area.y);
+        let visual_row = (i64::from(self.scroll_offset) + row_in_view).max(0) as u32;
+        let last_row = render.max_line().as_u32().max(1).saturating_sub(1);
+        let visual_row = visual_row.min(last_row);
+
+        let col = position.x.saturating_sub(area.x);
+        let point = SoftWrapPoint::new(visual_row, ColumnUnit::Chars(col));
+        // The char-cell soft-wrap API is 0-based; the buffer uses 1-based gap
+        // offsets (see the kill-range helpers), so re-add 1.
+        let zero_based = render.softwrap_point_to_offset(point);
+        CharOffset::from(zero_based.as_usize() + 1)
+    }
+
+    /// Maps a mouse `event` to the [`TuiInputAction`] it should dispatch, or
+    /// `None` when the event should be ignored (a press outside the input, a
+    /// drag/up with no selection in progress, or a non-mouse event).
+    ///
+    /// Mirrors the GUI's `left_mouse_down`/`dragged`/`up` mapping: click count 1
+    /// starts a selection (shift extends), 2 selects a word, 3 selects a line;
+    /// drag updates the pending selection and up ends it.
+    fn mouse_action(
+        &self,
+        event: &TuiEvent,
+        area: TuiRect,
+        app: &AppContext,
+    ) -> Option<TuiInputAction> {
+        match event {
+            TuiEvent::LeftMouseDown {
+                position,
+                modifiers,
+                click_count,
+                is_first_mouse,
+            } => {
+                // The focus-bringing first click has no matching mouse-up, and a
+                // press outside the input must not start a selection.
+                if *is_first_mouse || !area.contains_point(*position) {
+                    return None;
+                }
+                let offset = self.offset_at(*position, area, app);
+                Some(match *click_count {
+                    0 | 1 if modifiers.shift => TuiInputAction::SelectionExtendTo { offset },
+                    0 | 1 => TuiInputAction::SelectionStartAt { offset },
+                    2 => TuiInputAction::SelectWordAt { offset },
+                    _ => TuiInputAction::SelectLineAt { offset },
+                })
+            }
+            // Drags continue even outside the input's bounds (drag-to-scroll),
+            // but only while a selection that began inside it is active.
+            TuiEvent::LeftMouseDragged { position, .. } if self.is_selecting => {
+                Some(TuiInputAction::SelectionUpdateTo {
+                    offset: self.offset_at(*position, area, app),
+                })
+            }
+            TuiEvent::LeftMouseUp { .. } if self.is_selecting => Some(TuiInputAction::SelectionEnd),
+            // Mouse wheel over the input scrolls the viewport (cursor unmoved).
+            TuiEvent::ScrollWheel {
+                position, delta, ..
+            } if area.contains_point(*position) => Some(TuiInputAction::Scroll {
+                // crossterm reports ScrollUp as +1 row / ScrollDown as -1; negate
+                // so wheel-up scrolls toward the top (matches `TuiScrollable`).
+                rows: -(delta.1 * WHEEL_STEP),
+            }),
+            _ => None,
+        }
     }
 }
 
@@ -728,7 +895,10 @@ impl TuiElement for TuiInputElement {
     }
 
     fn cursor_position(&self, area: TuiRect, _ctx: &mut TuiLayoutContext) -> Option<(u16, u16)> {
-        if self.cursor_col >= area.width || self.cursor_row_in_view >= area.height {
+        if !self.cursor_visible
+            || self.cursor_col >= area.width
+            || self.cursor_row_in_view >= area.height
+        {
             return None;
         }
         Some((self.cursor_col, self.cursor_row_in_view))
@@ -743,6 +913,11 @@ impl TuiElement for TuiInputElement {
         app: &AppContext,
     ) -> bool {
         if self.column.dispatch_event(event, area, event_ctx, ctx, app) {
+            return true;
+        }
+
+        if let Some(action) = self.mouse_action(event, area, app) {
+            event_ctx.dispatch_typed_action(action);
             return true;
         }
 

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -6,13 +6,17 @@
 
 use warp::appearance::Appearance;
 use warp::editor::CodeEditorModel;
+use warp_core::semantic_selection::SemanticSelection;
 use warp_editor::model::CoreEditorModel;
 use warpui::EntityIdMap;
-use warpui_core::elements::tui::{TuiConstraint, TuiLayoutContext, TuiRect, TuiSize};
+use warpui_core::elements::tui::{
+    TuiConstraint, TuiElement, TuiEvent, TuiLayoutContext, TuiPoint, TuiRect, TuiSize,
+};
+use warpui_core::event::ModifiersState;
 use warpui_core::platform::WindowStyle;
 use warpui_core::{AddWindowOptions, App, AppContext, TuiView, TypedActionView, ViewHandle};
 
-use super::{TuiInputAction, TuiInputView};
+use super::{TuiInputAction, TuiInputElement, TuiInputView};
 
 const W: u16 = 80;
 
@@ -20,6 +24,9 @@ fn build_view(ctx: &mut AppContext) -> ViewHandle<TuiInputView> {
     // `CodeEditorModel::new_tui` reads syntax colors from the `Appearance`
     // singleton, so register a mock one before constructing the editor.
     ctx.add_singleton_model(|_| Appearance::mock());
+    // Double-click word selection reads the `SemanticSelection` singleton for
+    // its word-boundary policy, so register a mock one too.
+    ctx.add_singleton_model(|_| SemanticSelection::mock(true, ""));
     let (_window_id, view) = ctx.add_tui_window(
         AddWindowOptions {
             window_style: WindowStyle::NotStealFocus,
@@ -347,6 +354,264 @@ fn cursor_accounts_for_zero_width_chars() {
             type_str(&view, ctx, "a\u{0301}b");
             let (cursor, _height) = cursor_and_height(&view, ctx);
             assert_eq!(cursor, Some((2, 0)), "a + combining + b → 2 display cols");
+        });
+    });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mouse selection
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn left_down(x: u16, y: u16, click_count: u32, shift: bool) -> TuiEvent {
+    TuiEvent::LeftMouseDown {
+        position: TuiPoint::new(x, y),
+        modifiers: ModifiersState {
+            shift,
+            ..Default::default()
+        },
+        click_count,
+        is_first_mouse: false,
+    }
+}
+
+fn left_drag(x: u16, y: u16) -> TuiEvent {
+    TuiEvent::LeftMouseDragged {
+        position: TuiPoint::new(x, y),
+        modifiers: ModifiersState::default(),
+    }
+}
+
+fn left_up(x: u16, y: u16) -> TuiEvent {
+    TuiEvent::LeftMouseUp {
+        position: TuiPoint::new(x, y),
+        modifiers: ModifiersState::default(),
+    }
+}
+
+/// A mouse-wheel event at `(x, y)`. `delta_rows` follows crossterm's convention
+/// (+1 = wheel up / toward the top, -1 = wheel down).
+fn scroll_wheel(x: u16, y: u16, delta_rows: isize) -> TuiEvent {
+    TuiEvent::ScrollWheel {
+        position: TuiPoint::new(x, y),
+        delta: (0, delta_rows),
+        precise: false,
+        modifiers: ModifiersState::default(),
+    }
+}
+
+/// Types `n` short logical lines ("0".."n-1") into the input.
+fn type_lines(view: &ViewHandle<TuiInputView>, ctx: &mut AppContext, n: usize) {
+    for i in 0..n {
+        if i > 0 {
+            dispatch(view, ctx, &[TuiInputAction::InsertNewline]);
+        }
+        type_str(view, ctx, &i.to_string());
+    }
+}
+
+/// Renders + lays out the view's element at width `W` (height capped by the
+/// view), returning the concrete element and the area it occupies.
+fn laid_out_element(
+    view: &ViewHandle<TuiInputView>,
+    ctx: &AppContext,
+) -> (TuiInputElement, TuiRect) {
+    let mut element = view.as_ref(ctx).render_element(ctx);
+    let mut rendered_views = EntityIdMap::default();
+    let mut lctx = TuiLayoutContext {
+        rendered_views: &mut rendered_views,
+    };
+    let size = element.layout(TuiConstraint::loose(TuiSize::new(W, 20)), &mut lctx, ctx);
+    (element, TuiRect::new(0, 0, size.width, size.height))
+}
+
+/// Drives the full mouse path for `event`: lay out the element, map the event to
+/// its [`TuiInputAction`], and apply that action to the view. Returns whether an
+/// action fired (i.e. the event was not ignored).
+fn mouse(view: &ViewHandle<TuiInputView>, ctx: &mut AppContext, event: &TuiEvent) -> bool {
+    let action = {
+        let (element, area) = laid_out_element(view, ctx);
+        element.mouse_action(event, area, ctx)
+    };
+    match action {
+        Some(action) => {
+            dispatch(view, ctx, &[action]);
+            true
+        }
+        None => false,
+    }
+}
+
+#[test]
+fn single_click_places_cursor() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            type_str(&view, ctx, "hello world");
+            assert!(mouse(&view, ctx, &left_down(3, 0, 1, false)));
+            assert!(mouse(&view, ctx, &left_up(3, 0)));
+            assert_eq!(cursor_and_height(&view, ctx).0, Some((3, 0)));
+            assert_eq!(selected_text(&view, ctx), None);
+        });
+    });
+}
+
+#[test]
+fn click_outside_area_is_ignored() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            type_str(&view, ctx, "hi");
+            // The single-line input is one row tall; row 5 is outside it.
+            assert!(!mouse(&view, ctx, &left_down(0, 5, 1, false)));
+            assert_eq!(selected_text(&view, ctx), None);
+        });
+    });
+}
+
+#[test]
+fn drag_selects_range() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            type_str(&view, ctx, "hello world");
+            mouse(&view, ctx, &left_down(0, 0, 1, false));
+            mouse(&view, ctx, &left_drag(5, 0));
+            assert_eq!(selected_text(&view, ctx).as_deref(), Some("hello"));
+            mouse(&view, ctx, &left_up(5, 0));
+            assert_eq!(selected_text(&view, ctx).as_deref(), Some("hello"));
+        });
+    });
+}
+
+#[test]
+fn shift_click_extends_selection() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            type_str(&view, ctx, "hello world");
+            // Place the cursor at the start, then shift-click after "hello".
+            mouse(&view, ctx, &left_down(0, 0, 1, false));
+            mouse(&view, ctx, &left_up(0, 0));
+            mouse(&view, ctx, &left_down(5, 0, 1, true));
+            assert_eq!(selected_text(&view, ctx).as_deref(), Some("hello"));
+        });
+    });
+}
+
+#[test]
+fn double_click_selects_word() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            type_str(&view, ctx, "hello world");
+            assert!(mouse(&view, ctx, &left_down(2, 0, 2, false)));
+            assert_eq!(selected_text(&view, ctx).as_deref(), Some("hello"));
+        });
+    });
+}
+
+#[test]
+fn triple_click_selects_line() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            type_str(&view, ctx, "hello world");
+            assert!(mouse(&view, ctx, &left_down(2, 0, 3, false)));
+            assert_eq!(selected_text(&view, ctx).as_deref(), Some("hello world"));
+        });
+    });
+}
+
+#[test]
+fn drag_past_last_visible_row_autoscrolls() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            // 10 logical lines, exceeding the 6-row viewport.
+            for i in 0..10 {
+                if i > 0 {
+                    dispatch(&view, ctx, &[TuiInputAction::InsertNewline]);
+                }
+                type_str(&view, ctx, &i.to_string());
+            }
+            // Scroll back to the top.
+            for _ in 0..9 {
+                dispatch(&view, ctx, &[TuiInputAction::MoveUp]);
+            }
+            assert_eq!(view.as_ref(ctx).scroll_offset, 0);
+
+            // Begin a selection at the top, then drag well below the viewport.
+            mouse(&view, ctx, &left_down(0, 0, 1, false));
+            mouse(&view, ctx, &left_drag(0, 50));
+
+            // The head followed the drag to the last row, scrolling the viewport.
+            assert!(
+                view.as_ref(ctx).scroll_offset > 0,
+                "drag past the last visible row should auto-scroll"
+            );
+            assert!(selected_text(&view, ctx).is_some());
+        });
+    });
+}
+
+#[test]
+fn wheel_scrolls_viewport_without_moving_cursor() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            type_lines(&view, ctx, 10); // 10 rows > 6-row viewport
+                                        // Typing leaves the cursor at the end, scrolled to the bottom.
+            assert_eq!(view.as_ref(ctx).scroll_offset, 4);
+            let cursor_before = view.as_ref(ctx).cursor_offset(ctx);
+
+            // Wheel up (delta +1) scrolls toward the top by WHEEL_STEP (2) rows.
+            assert!(mouse(&view, ctx, &scroll_wheel(0, 0, 1)));
+            assert_eq!(view.as_ref(ctx).scroll_offset, 2);
+            // Further wheel-ups clamp at the top.
+            mouse(&view, ctx, &scroll_wheel(0, 0, 1));
+            assert_eq!(view.as_ref(ctx).scroll_offset, 0);
+            mouse(&view, ctx, &scroll_wheel(0, 0, 1));
+            assert_eq!(view.as_ref(ctx).scroll_offset, 0);
+
+            // Scrolling never moved the cursor.
+            assert_eq!(view.as_ref(ctx).cursor_offset(ctx), cursor_before);
+        });
+    });
+}
+
+#[test]
+fn wheel_scroll_down_clamps_at_bottom() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            type_lines(&view, ctx, 10);
+            // Scroll to the top first.
+            mouse(&view, ctx, &scroll_wheel(0, 0, 1));
+            mouse(&view, ctx, &scroll_wheel(0, 0, 1));
+            assert_eq!(view.as_ref(ctx).scroll_offset, 0);
+
+            // Wheel down (delta -1) scrolls toward the bottom, clamped at
+            // max_scroll = 10 rows - 6 visible = 4.
+            mouse(&view, ctx, &scroll_wheel(0, 0, -1));
+            assert_eq!(view.as_ref(ctx).scroll_offset, 2);
+            mouse(&view, ctx, &scroll_wheel(0, 0, -1));
+            assert_eq!(view.as_ref(ctx).scroll_offset, 4);
+            mouse(&view, ctx, &scroll_wheel(0, 0, -1));
+            assert_eq!(view.as_ref(ctx).scroll_offset, 4);
+        });
+    });
+}
+
+#[test]
+fn wheel_outside_area_is_ignored() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            type_lines(&view, ctx, 10);
+            let before = view.as_ref(ctx).scroll_offset;
+            // Row 50 is well outside the 6-row viewport.
+            assert!(!mouse(&view, ctx, &scroll_wheel(0, 50, 1)));
+            assert_eq!(view.as_ref(ctx).scroll_offset, before);
         });
     });
 }

--- a/crates/warpui_core/src/elements/tui/geometry.rs
+++ b/crates/warpui_core/src/elements/tui/geometry.rs
@@ -136,6 +136,21 @@ impl TuiRectExt for TuiRect {
     }
 }
 
+/// Helpers for [`TuiPoint`] (a terminal cell position) beyond what ratatui's
+/// `Position` provides.
+pub trait TuiPointExt {
+    /// Whether `self` and `other` are the same cell or immediate neighbours
+    /// (Chebyshev distance <= 1). Handy for tolerating small pointer jitter,
+    /// e.g. when detecting multi-clicks.
+    fn is_adjacent(&self, other: TuiPoint) -> bool;
+}
+
+impl TuiPointExt for TuiPoint {
+    fn is_adjacent(&self, other: TuiPoint) -> bool {
+        self.x.abs_diff(other.x) <= 1 && self.y.abs_diff(other.y) <= 1
+    }
+}
+
 #[cfg(test)]
 #[path = "geometry_tests.rs"]
 mod tests;

--- a/crates/warpui_core/src/elements/tui/geometry_tests.rs
+++ b/crates/warpui_core/src/elements/tui/geometry_tests.rs
@@ -68,3 +68,16 @@ fn contains_point_uses_half_open_cell_bounds() {
     assert!(!rect.contains_point(TuiPoint::new(1, 3)));
     assert!(!rect.contains_point(TuiPoint::new(2, 2)));
 }
+
+#[test]
+fn is_adjacent_uses_chebyshev_distance() {
+    let p = TuiPoint::new(5, 5);
+    // The same cell and all eight neighbours are adjacent.
+    assert!(p.is_adjacent(p));
+    assert!(p.is_adjacent(TuiPoint::new(6, 6)));
+    assert!(p.is_adjacent(TuiPoint::new(4, 4)));
+    assert!(p.is_adjacent(TuiPoint::new(5, 6)));
+    // Two cells away on either axis is not adjacent.
+    assert!(!p.is_adjacent(TuiPoint::new(7, 5)));
+    assert!(!p.is_adjacent(TuiPoint::new(5, 7)));
+}

--- a/crates/warpui_core/src/elements/tui/mod.rs
+++ b/crates/warpui_core/src/elements/tui/mod.rs
@@ -47,7 +47,7 @@ pub use event::{
     TuiDispatchEventResult, TuiEvent, TuiEventContext, TuiEventDispatchResult, TuiScrollDelta,
 };
 pub use event_handler::TuiEventHandler;
-pub use geometry::{TuiConstraint, TuiPoint, TuiRect, TuiRectExt, TuiSize};
+pub use geometry::{TuiConstraint, TuiPoint, TuiPointExt, TuiRect, TuiRectExt, TuiSize};
 pub use parent::TuiParentElement;
 pub use scrollable::{TuiScrollable, TuiScrollableElement};
 pub use text::TuiText;

--- a/crates/warpui_core/src/runtime/event_conversion.rs
+++ b/crates/warpui_core/src/runtime/event_conversion.rs
@@ -9,7 +9,7 @@ use ratatui::crossterm::event::{
     MouseEvent, MouseEventKind,
 };
 
-use crate::elements::tui::{TuiEvent, TuiPoint, TuiScrollDelta};
+use crate::elements::tui::{TuiEvent, TuiPoint, TuiPointExt, TuiScrollDelta};
 use crate::event::{KeyEventDetails, ModifiersState};
 use crate::keymap::Keystroke;
 
@@ -234,7 +234,7 @@ impl ClickTracker {
             Some(last)
                 if last.button == button
                     && now.duration_since(last.at) <= MULTI_CLICK_INTERVAL
-                    && is_adjacent(last.position, position) =>
+                    && last.position.is_adjacent(position) =>
             {
                 // Wrap 3 -> 1 so a fourth fast click starts a fresh cycle.
                 last.count % 3 + 1
@@ -249,12 +249,6 @@ impl ClickTracker {
         });
         count
     }
-}
-
-/// Whether two cells are the same or immediate neighbours (Chebyshev distance
-/// <= 1), tolerating slight pointer jitter between the clicks of a multi-click.
-fn is_adjacent(a: TuiPoint, b: TuiPoint) -> bool {
-    a.x.abs_diff(b.x) <= 1 && a.y.abs_diff(b.y) <= 1
 }
 
 #[cfg(test)]

--- a/crates/warpui_core/src/runtime/event_conversion.rs
+++ b/crates/warpui_core/src/runtime/event_conversion.rs
@@ -1,6 +1,9 @@
 //! Conversion from raw crossterm input events to the
 //! [`TuiEvent`](crate::elements::tui::TuiEvent) vocabulary.
 
+use std::time::Duration;
+
+use instant::Instant;
 use ratatui::crossterm::event::{
     Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton,
     MouseEvent, MouseEventKind,
@@ -164,6 +167,94 @@ fn key_without_modifiers(code: KeyCode) -> Option<String> {
         KeyCode::Char(char) => Some(char.to_lowercase().to_string()),
         _ => None,
     }
+}
+
+/// Maximum delay between consecutive presses of the same button for them to
+/// count as part of the same multi-click (double/triple). Roughly the standard
+/// desktop double-click window.
+const MULTI_CLICK_INTERVAL: Duration = Duration::from_millis(400);
+
+/// The pointer button a [`ClickTracker`] is tracking a multi-click run for.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ClickButton {
+    Left,
+    Middle,
+    Right,
+}
+
+/// Synthesizes multi-click counts for mouse presses.
+///
+/// crossterm only reports raw button presses, so the `*MouseDown` events arrive
+/// with `click_count: 1`. This tracker remembers the previous press and, when
+/// the next one is the **same button**, lands within [`MULTI_CLICK_INTERVAL`],
+/// and on (or within one cell of) the same position, escalates the count
+/// `1 -> 2 -> 3` before wrapping back to `1`. Anything else — a different
+/// button, a slower press, or a press elsewhere — resets to a single click.
+/// This mirrors the GUI, where the OS supplies a click count for every button.
+#[derive(Default)]
+pub(crate) struct ClickTracker {
+    last: Option<LastClick>,
+}
+
+#[derive(Clone, Copy)]
+struct LastClick {
+    button: ClickButton,
+    at: Instant,
+    position: TuiPoint,
+    count: u32,
+}
+
+impl ClickTracker {
+    /// Fills in the synthesized `click_count` on any mouse-down event, leaving
+    /// non-button events (scroll, move, up, drag) untouched.
+    pub(crate) fn annotate(&mut self, event: &mut TuiEvent, now: Instant) {
+        let (button, position, click_count) = match event {
+            TuiEvent::LeftMouseDown {
+                position,
+                click_count,
+                ..
+            } => (ClickButton::Left, *position, click_count),
+            TuiEvent::MiddleMouseDown {
+                position,
+                click_count,
+                ..
+            } => (ClickButton::Middle, *position, click_count),
+            TuiEvent::RightMouseDown {
+                position,
+                click_count,
+                ..
+            } => (ClickButton::Right, *position, click_count),
+            _ => return,
+        };
+        *click_count = self.register(button, position, now);
+    }
+
+    fn register(&mut self, button: ClickButton, position: TuiPoint, now: Instant) -> u32 {
+        let count = match self.last {
+            Some(last)
+                if last.button == button
+                    && now.duration_since(last.at) <= MULTI_CLICK_INTERVAL
+                    && is_adjacent(last.position, position) =>
+            {
+                // Wrap 3 -> 1 so a fourth fast click starts a fresh cycle.
+                last.count % 3 + 1
+            }
+            _ => 1,
+        };
+        self.last = Some(LastClick {
+            button,
+            at: now,
+            position,
+            count,
+        });
+        count
+    }
+}
+
+/// Whether two cells are the same or immediate neighbours (Chebyshev distance
+/// <= 1), tolerating slight pointer jitter between the clicks of a multi-click.
+fn is_adjacent(a: TuiPoint, b: TuiPoint) -> bool {
+    a.x.abs_diff(b.x) <= 1 && a.y.abs_diff(b.y) <= 1
 }
 
 #[cfg(test)]

--- a/crates/warpui_core/src/runtime/event_conversion_tests.rs
+++ b/crates/warpui_core/src/runtime/event_conversion_tests.rs
@@ -1,9 +1,12 @@
+use std::time::Duration;
+
+use instant::Instant;
 use ratatui::crossterm::event::{
     Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton,
     MouseEvent, MouseEventKind,
 };
 
-use super::crossterm_event_to_tui_event;
+use super::{crossterm_event_to_tui_event, ClickTracker};
 use crate::elements::tui::{TuiEvent, TuiPoint};
 use crate::keymap::Keystroke;
 
@@ -250,4 +253,164 @@ fn unsupported_mouse_up_and_drag_buttons_are_ignored() {
         KeyModifiers::empty()
     )
     .is_none());
+}
+
+/// Builds a `button` mouse-down at `(x, y)` via the real conversion (so it
+/// starts with `click_count: 1`).
+fn down_at(button: MouseButton, x: u16, y: u16) -> TuiEvent {
+    crossterm_event_to_tui_event(CrosstermEvent::Mouse(MouseEvent {
+        kind: MouseEventKind::Down(button),
+        column: x,
+        row: y,
+        modifiers: KeyModifiers::empty(),
+    }))
+    .expect("mouse down should convert")
+}
+
+/// The synthesized click count carried by a mouse-down event.
+fn count_of(event: &TuiEvent) -> u32 {
+    match event {
+        TuiEvent::LeftMouseDown { click_count, .. }
+        | TuiEvent::MiddleMouseDown { click_count, .. }
+        | TuiEvent::RightMouseDown { click_count, .. } => *click_count,
+        other => panic!("expected a mouse-down, got {other:?}"),
+    }
+}
+
+/// Annotates a `button` mouse-down at `(x, y)` / `now` through `tracker` and
+/// returns the synthesized click count.
+fn annotate_down(
+    tracker: &mut ClickTracker,
+    button: MouseButton,
+    x: u16,
+    y: u16,
+    now: Instant,
+) -> u32 {
+    let mut event = down_at(button, x, y);
+    tracker.annotate(&mut event, now);
+    count_of(&event)
+}
+
+/// Convenience wrapper for the common left-button case.
+fn click_count(tracker: &mut ClickTracker, x: u16, y: u16, now: Instant) -> u32 {
+    annotate_down(tracker, MouseButton::Left, x, y, now)
+}
+
+#[test]
+fn click_count_escalates_then_wraps_for_fast_clicks_on_same_cell() {
+    let mut tracker = ClickTracker::default();
+    let t = Instant::now();
+    assert_eq!(click_count(&mut tracker, 5, 2, t), 1);
+    assert_eq!(
+        click_count(&mut tracker, 5, 2, t + Duration::from_millis(100)),
+        2
+    );
+    assert_eq!(
+        click_count(&mut tracker, 5, 2, t + Duration::from_millis(200)),
+        3
+    );
+    // A fourth fast click wraps back to a single click.
+    assert_eq!(
+        click_count(&mut tracker, 5, 2, t + Duration::from_millis(300)),
+        1
+    );
+}
+
+#[test]
+fn slow_second_click_resets_to_single() {
+    let mut tracker = ClickTracker::default();
+    let t = Instant::now();
+    assert_eq!(click_count(&mut tracker, 5, 2, t), 1);
+    // Past the multi-click interval, so the next press is a fresh single click.
+    assert_eq!(
+        click_count(&mut tracker, 5, 2, t + Duration::from_millis(600)),
+        1
+    );
+}
+
+#[test]
+fn click_on_distant_cell_resets_to_single() {
+    let mut tracker = ClickTracker::default();
+    let t = Instant::now();
+    assert_eq!(click_count(&mut tracker, 5, 2, t), 1);
+    assert_eq!(
+        click_count(&mut tracker, 20, 2, t + Duration::from_millis(100)),
+        1
+    );
+}
+
+#[test]
+fn click_within_one_cell_counts_as_multi_click() {
+    let mut tracker = ClickTracker::default();
+    let t = Instant::now();
+    assert_eq!(click_count(&mut tracker, 5, 2, t), 1);
+    // One cell of jitter between presses is tolerated.
+    assert_eq!(
+        click_count(&mut tracker, 6, 2, t + Duration::from_millis(100)),
+        2
+    );
+}
+
+#[test]
+fn right_and_middle_clicks_escalate_like_left() {
+    let mut tracker = ClickTracker::default();
+    let t = Instant::now();
+    assert_eq!(annotate_down(&mut tracker, MouseButton::Right, 5, 2, t), 1);
+    assert_eq!(
+        annotate_down(
+            &mut tracker,
+            MouseButton::Right,
+            5,
+            2,
+            t + Duration::from_millis(100)
+        ),
+        2
+    );
+
+    let mut tracker = ClickTracker::default();
+    assert_eq!(annotate_down(&mut tracker, MouseButton::Middle, 5, 2, t), 1);
+    assert_eq!(
+        annotate_down(
+            &mut tracker,
+            MouseButton::Middle,
+            5,
+            2,
+            t + Duration::from_millis(100)
+        ),
+        2
+    );
+}
+
+#[test]
+fn switching_button_resets_click_count() {
+    let mut tracker = ClickTracker::default();
+    let t = Instant::now();
+    // A left press then a quick right press on the same cell are two separate
+    // single clicks, not a double-click.
+    assert_eq!(annotate_down(&mut tracker, MouseButton::Left, 5, 2, t), 1);
+    assert_eq!(
+        annotate_down(
+            &mut tracker,
+            MouseButton::Right,
+            5,
+            2,
+            t + Duration::from_millis(50)
+        ),
+        1
+    );
+}
+
+#[test]
+fn annotate_leaves_non_button_events_untouched() {
+    let mut tracker = ClickTracker::default();
+    // A scroll-wheel event carries no click count; annotate must be a no-op.
+    let mut event = crossterm_event_to_tui_event(CrosstermEvent::Mouse(MouseEvent {
+        kind: MouseEventKind::ScrollUp,
+        column: 5,
+        row: 2,
+        modifiers: KeyModifiers::empty(),
+    }))
+    .expect("scroll up should convert");
+    tracker.annotate(&mut event, Instant::now());
+    assert!(matches!(event, TuiEvent::ScrollWheel { .. }));
 }

--- a/crates/warpui_core/src/runtime/mod.rs
+++ b/crates/warpui_core/src/runtime/mod.rs
@@ -27,6 +27,7 @@ use std::rc::Rc;
 use std::thread;
 use std::time::Duration;
 
+use instant::Instant;
 use ratatui::crossterm::cursor::{Hide, Show};
 use ratatui::crossterm::event::{
     self, DisableMouseCapture, EnableMouseCapture, Event as CrosstermEvent, KeyCode, KeyModifiers,
@@ -45,6 +46,7 @@ mod event_conversion;
 mod renderer;
 
 pub use event_conversion::crossterm_event_to_tui_event;
+use event_conversion::ClickTracker;
 pub use renderer::TuiFrameRenderer;
 
 /// The host terminal the runtime draws to and reads input from. Abstracted so
@@ -71,6 +73,9 @@ struct TuiScreen<T, R: TuiTerminal> {
     presenter: TuiPresenter,
     renderer: TuiFrameRenderer,
     terminal: R,
+    /// Synthesizes multi-click counts for left mouse presses, which crossterm
+    /// does not report.
+    click_tracker: ClickTracker,
 }
 
 impl<T: TuiView, R: TuiTerminal> TuiScreen<T, R> {
@@ -81,6 +86,7 @@ impl<T: TuiView, R: TuiTerminal> TuiScreen<T, R> {
             presenter: TuiPresenter::new(),
             renderer: TuiFrameRenderer::new(),
             terminal,
+            click_tracker: ClickTracker::default(),
         }
     }
 
@@ -101,6 +107,15 @@ impl<T: TuiView, R: TuiTerminal> TuiScreen<T, R> {
         let frame = self.presenter.present(ctx, &self.root_view, area);
         let mut writer = self.terminal.writer();
         self.renderer.draw(&mut writer, &frame.buffer, frame.cursor)
+    }
+
+    /// Converts a raw crossterm event into the TUI vocabulary, annotating left
+    /// mouse-down events with a synthesized multi-click count (crossterm only
+    /// reports raw presses). Returns `None` for events with no TUI equivalent.
+    fn convert_event(&mut self, event: CrosstermEvent) -> Option<TuiEvent> {
+        let mut tui_event = crossterm_event_to_tui_event(event)?;
+        self.click_tracker.annotate(&mut tui_event, Instant::now());
+        Some(tui_event)
     }
 
     /// Dispatches a converted input event into the cached element tree, returning
@@ -258,8 +273,8 @@ where
         match event {
             CrosstermEvent::Resize(_, _) => self.dirty.set(true),
             event => {
-                if let Some(tui_event) = crossterm_event_to_tui_event(event) {
-                    let screen = &mut self.screen;
+                let screen = &mut self.screen;
+                if let Some(tui_event) = screen.convert_event(event) {
                     let handled = app.update(|ctx| screen.dispatch_event(ctx, &tui_event));
                     if handled {
                         self.dirty.set(true);
@@ -442,8 +457,9 @@ pub fn spawn_tui_driver<T: TuiView>(
                 match event {
                     CrosstermEvent::Resize(_, _) => ctx.invalidate_all_views(),
                     event => {
-                        if let Some(tui_event) = crossterm_event_to_tui_event(event) {
-                            screen.borrow_mut().dispatch_event(ctx, &tui_event);
+                        let mut screen = screen.borrow_mut();
+                        if let Some(tui_event) = screen.convert_event(event) {
+                            screen.dispatch_event(ctx, &tui_event);
                         }
                     }
                 }


### PR DESCRIPTION
## Description
Fixes CODE-1804

Adds mouse support to the TUI prompt input (`crates/warp_tui`), bringing it close to the GUI editor's mouse interactions:

- **Click** to place the cursor, **shift-click** to extend, **drag** to select (auto-scrolling when the drag leaves the viewport), **double-click** to select a word, **triple-click** to select a line.
- **Mouse wheel** to scroll the input viewport.

Most of this is wiring rather than new machinery. The TUI framework already models mouse events, and the editor model already exposes the GUI's selection API (`select_at` / `select_word_at` / `select_line_at` / `update_pending_selection` / `end_selection`), so mouse input flows through the same `element → TuiInputAction → view.handle_action → model` path that keyboard input already uses. Selection highlighting and the cell→offset reverse map (`softwrap_point_to_offset`) already existed.

Multi-cursor (alt-click) is intentionally **out of scope** — it isn't a native TUI text-input affordance and the terminal exposes a single hardware cursor; the input stays single-selection.

### Click-event synthesis — where and why

crossterm reports only raw button **press/release**; it does **not** report click counts, so double/triple-click can't come from the event stream directly. We synthesize the count in the **runtime**, not in the view:

- A `ClickTracker` lives on `TuiScreen` (`crates/warpui_core/src/runtime/`). The crossterm→`TuiEvent` conversion stays pure; `TuiScreen::convert_event` runs the tracker immediately after conversion and before dispatch, filling the `click_count` field that already exists on the `*MouseDown` events. Both dispatch paths (the blocking harness and the production `spawn_tui_driver`) go through it.
- It is **per-button**: consecutive presses of the *same* button within ~400ms and within one cell escalate `1 → 2 → 3` (then wrap to 1); a different button, a slower press, or a press elsewhere resets to 1.
- Doing this once at the event layer mirrors the GUI (where the OS supplies `click_count` for every button) and means every TUI consumer gets correct click counts for free, instead of each view re-deriving them.

### Why not `TuiScrollable` for wheel scrolling

`TuiScrollable` is designed for an element that **persistently owns its scroll position** (e.g. a virtualized list), and its `scroll_by_rows(&mut self, …)` hook has no `AppContext`/event context. That doesn't fit the input:

- `TuiInputView` is the persistent entity; `TuiInputElement` is a **per-frame snapshot** rebuilt every render from the view's `scroll_offset`. A mutation inside `scroll_by_rows` would be discarded on the very next render — which the wheel's own `notify()` triggers.
- `scroll_by_rows` can't reach the view (to persist the new offset) or the model (to compute the total visual-line count needed for clamping).
- Input scrolling is coupled to the cursor on the view (`scroll_to_cursor`); routing the wheel through the same `handle_action` path keeps a single coherent scroll model.

So the wheel is handled like every other input event: a `TuiInputAction::Scroll { rows }` adjusts the view's `scroll_offset` (clamped to the content), and — unlike other actions — returns early so it does **not** snap back to the cursor. A `cursor_visible` flag suppresses the block cursor once it's scrolled out of view. Adopting `TuiScrollable` would require refactoring scroll state into a shared handle and is the right move only once the TUI grows a general clipped-scroll adapter (which `TuiScrollable`'s own docs call out as future work).

## Linked Issue

N/A — internal TUI input framework work (not yet wired into the shipping app).

## Testing

Unit tests were added across the changed crates; all pass, and `./script/format` + `cargo clippy -- -D warnings` are clean.

- Runtime click-count synthesis: escalate/wrap, slow-press reset, distance reset, one-cell jitter tolerance, per-button reset, and non-button events left untouched.
- TUI input mouse: single-click placement, shift-click extend, drag selection, double-click word, triple-click line, click outside the input ignored, drag-past-last-row auto-scroll, wheel up/down clamping, wheel not moving the cursor, and wheel outside the input ignored.

- [x] I have manually tested my changes locally with `./script/run-tui`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE
