### PR TITLE
fix(terminal): clamp DCH count to cells remaining from cursor

### DIFF
--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -670,8 +670,10 @@ impl ansi::Handler for GridHandler {
         let cursor = &self.grid.cursor();
         let bg = cursor.template.bg;
 
-        // Ensure deleting within terminal bounds.
-        let count = min(count, cols);
+        // Ensure deleting within terminal bounds. Count is clamped to cells
+        // remaining from cursor to end-of-line (not full row width), otherwise
+        // the trailing blank-fill can erase cells before the cursor.
+        let count = min(count, cols - cursor.point.col);
 
         let start = cursor.point.col;
         let end = min(start + count, cols - 1);

--- a/app/src/terminal/model/grid/grid_handler_tests.rs
+++ b/app/src/terminal/model/grid/grid_handler_tests.rs
@@ -2495,3 +2495,21 @@ fn test_full_grid_clear_resize_then_bounds_to_string_does_not_panic() {
         );
     }
 }
+
+#[test]
+fn test_delete_chars_count_exceeding_eol_does_not_erase_before_cursor() {
+    let mut grid = GridHandler::new_for_test(1, 5);
+    grid.input('a');
+    grid.input('b');
+    grid.input('c');
+    grid.input('d');
+    grid.input('e');
+    grid.goto(VisibleRow(0), 3);
+    grid.delete_chars(10);
+    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+    assert_eq!(grid.grid_storage()[VisibleRow(0)][0].c, 'a', "chars before cursor must be preserved");
+    assert_eq!(grid.grid_storage()[VisibleRow(0)][1].c, 'b', "chars before cursor must be preserved");
+    assert_eq!(grid.grid_storage()[VisibleRow(0)][2].c, 'c', "chars before cursor must be preserved");
+    assert_eq!(grid.grid_storage()[VisibleRow(0)][3].c, ' ', "cells at/after cursor must be blanked when count exceeds EOL");
+    assert_eq!(grid.grid_storage()[VisibleRow(0)][4].c, ' ', "cells at/after cursor must be blanked when count exceeds EOL");
+}


### PR DESCRIPTION
Fixes #12820.

## Problem
When DCH (CSI Pn P - Delete Character) receives a count greater than the number of cells remaining from the cursor to end-of-line, the count was clamped to the full row width (cols). This caused the trailing blank-fill loop (at cols - count) to start at an index before the cursor column, erroneously erasing characters before the cursor.

## Root Cause
In ansi_handler.rs delete_chars(), count was clamped to min(count, cols) (full row width), then the blank-fill started at cols - count. When count > cols - cursor_col, the blank-fill start falls before the cursor, wiping cells that should be preserved.

## Fix
Clamp count to cells remaining from cursor (matching the existing pattern in insert_blank): min(count, cols - cursor.point.col).

## Verification
Added regression test test_delete_chars_count_exceeding_eol_does_not_erase_before_cursor.