### PR TITLE
fix(macOS): stop registering Warp as the default handler for Markdown (.md) files

### DIFF
--- a/script/update_plist
+++ b/script/update_plist
@@ -81,18 +81,6 @@ if [[ -z "$WARP_PLIST_NO_FILE_TYPES" ]]; then
       </array>
     </dict>
     <dict>
-      <key>CFBundleTypeName</key><string>Markdown File</string>
-      <key>CFBundleTypeRole</key><string>Editor</string>
-      <key>LSHandlerRank</key><string>Alternate</string>
-      <key>LSItemContentTypes</key>
-      <array>
-        <string>net.daringfireball.markdown</string>
-        <string>com.unknown.md</string>
-        <string>net.ia.markdown</string>
-        <string>public.markdown</string>
-      </array>
-    </dict>
-    <dict>
       <key>CFBundleTypeName</key><string>Plain Text File</string>
       <key>CFBundleTypeRole</key><string>Editor</string>
       <key>LSHandlerRank</key><string>Alternate</string>


### PR DESCRIPTION
## Problem

On macOS, Warp registers itself as the default application for Markdown (`.md`) files and reclaims that association after updates, overriding the user's chosen editor (e.g. VS Code). Reported in #9076 (see comments — Warp re-registering for `.md`/`.go`/`.svg` after relaunch; *"Even after selecting Always open with VS Code, Warp remains the default"*) and #5732.

## Root cause

`script/update_plist` injects a `Markdown File` `CFBundleDocumentTypes` entry declaring Warp an **Editor** for the markdown UTIs:

```xml
<string>net.daringfireball.markdown</string>
<string>com.unknown.md</string>
<string>net.ia.markdown</string>
<string>public.markdown</string>
```

`.md` resolves to the UTI `net.daringfireball.markdown`. Most editors (e.g. VS Code) register markdown only by file **extension**, not by this UTI. macOS prefers a UTI-level handler over an extension-only one, so Warp wins the default-app resolution for `.md` **even at `LSHandlerRank Alternate`**, and re-wins on every auto-update's re-registration. Because this is an OS-level Launch Services claim, disabling the in-app Markdown viewer (`prefer_markdown_viewer = false`) does not prevent it. (`com.unknown.md` also appears to be a placeholder/invalid UTI.)

## Fix

Remove the `Markdown File` document type so a terminal no longer registers itself as a Markdown editor — this also drops the invalid `com.unknown.md` UTI. The `Plain Text File` and `Source Code File` types are intentionally left in place.

Closes #13268

Related: #9076, #5732.
