### PR TITLE
Validate orchestration model IDs client-side before spawning agents

### DIFF
--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -27,13 +27,17 @@ use crate::ai::agent::{
     StartAgentExecutionMode,
 };
 use crate::ai::auth_secret_types::auth_secret_types_for_harness;
-use crate::ai::blocklist::inline_action::orchestration_controls::OrchestrationEditState;
+use crate::ai::blocklist::inline_action::orchestration_controls::{
+    unavailable_model_reason, OrchestrationEditState,
+};
 use crate::ai::blocklist::{BlocklistAIHistoryModel, BlocklistAIPermissions};
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
 use crate::ai::document::plan_publication::{
     prepare_plan_publications, wait_for_plan_publications,
 };
 use crate::ai::local_harness_setup::local_harness_product_disabled_message;
+use crate::settings::{AISettings, OrchestrationInvalidModelBehavior};
+use crate::LLMPreferences;
 
 /// Per-child spawn timeout. If a child agent doesn't report back within
 /// this window (e.g. binary not found, server error), the slot is failed
@@ -174,6 +178,34 @@ impl RunAgentsExecutor {
             log::warn!("RunAgentsExecutor: validation failure: {error}");
             let _ = sender.try_send(RunAgentsResult::Failure { error });
             return receiver;
+        }
+
+        // Pre-flight model check: mirror the server's pre-spawn model validation
+        // (warp-server `AddTask`) so we fail fast (or auto-select) rather than
+        // dispatching children the server would reject. The model_id/harness_type
+        // are already resolved from any approved config upstream, so this sees
+        // the final run-wide values.
+        let mut request = request;
+        let is_local = !request.execution_mode.is_remote();
+        if let Some(reason) =
+            unavailable_model_reason(&request.model_id, &request.harness_type, is_local, ctx)
+        {
+            match AISettings::as_ref(ctx).orchestration_invalid_model_behavior {
+                OrchestrationInvalidModelBehavior::Block => {
+                    log::warn!("RunAgentsExecutor: unavailable model: {reason}");
+                    let _ = sender.try_send(RunAgentsResult::Failure { error: reason });
+                    return receiver;
+                }
+                OrchestrationInvalidModelBehavior::AutoSelect => {
+                    // Substitute the Oz default; an empty default means "inherit".
+                    let fallback = LLMPreferences::as_ref(ctx).oz_cloud_default_agent_model_id();
+                    request.model_id = if fallback.trim().is_empty() {
+                        String::new()
+                    } else {
+                        fallback
+                    };
+                }
+            }
         }
         let pending_plan_publications = prepare_plan_publications(parent_conversation_id, ctx);
 

--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -28,7 +28,7 @@ use crate::ai::agent::{
 };
 use crate::ai::auth_secret_types::auth_secret_types_for_harness;
 use crate::ai::blocklist::inline_action::orchestration_controls::{
-    unavailable_model_reason, OrchestrationEditState,
+    resolve_orchestration_fallback_model_id, unavailable_model_reason, OrchestrationEditState,
 };
 use crate::ai::blocklist::{BlocklistAIHistoryModel, BlocklistAIPermissions};
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
@@ -37,7 +37,6 @@ use crate::ai::document::plan_publication::{
 };
 use crate::ai::local_harness_setup::local_harness_product_disabled_message;
 use crate::settings::{AISettings, OrchestrationInvalidModelBehavior};
-use crate::LLMPreferences;
 
 /// Per-child spawn timeout. If a child agent doesn't report back within
 /// this window (e.g. binary not found, server error), the slot is failed
@@ -197,13 +196,9 @@ impl RunAgentsExecutor {
                     return receiver;
                 }
                 OrchestrationInvalidModelBehavior::AutoSelect => {
-                    // Substitute the Oz default; an empty default means "inherit".
-                    let fallback = LLMPreferences::as_ref(ctx).oz_cloud_default_agent_model_id();
-                    request.model_id = if fallback.trim().is_empty() {
-                        String::new()
-                    } else {
-                        fallback
-                    };
+                    // Substitute the user's configured fallback model (or the Oz
+                    // default); an empty result means "inherit the default".
+                    request.model_id = resolve_orchestration_fallback_model_id(ctx);
                 }
             }
         }

--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -28,7 +28,7 @@ use crate::ai::agent::{
 };
 use crate::ai::auth_secret_types::auth_secret_types_for_harness;
 use crate::ai::blocklist::inline_action::orchestration_controls::{
-    resolve_orchestration_fallback_model_id, unavailable_model_reason, OrchestrationEditState,
+    resolve_cloud_agent_fallback_model_id, unavailable_model_reason, OrchestrationEditState,
 };
 use crate::ai::blocklist::{BlocklistAIHistoryModel, BlocklistAIPermissions};
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
@@ -36,7 +36,7 @@ use crate::ai::document::plan_publication::{
     prepare_plan_publications, wait_for_plan_publications,
 };
 use crate::ai::local_harness_setup::local_harness_product_disabled_message;
-use crate::settings::{AISettings, OrchestrationInvalidModelBehavior};
+use crate::settings::{AISettings, CloudAgentInvalidModelBehavior};
 
 /// Per-child spawn timeout. If a child agent doesn't report back within
 /// this window (e.g. binary not found, server error), the slot is failed
@@ -189,18 +189,18 @@ impl RunAgentsExecutor {
         if let Some(reason) =
             unavailable_model_reason(&request.model_id, &request.harness_type, is_local, ctx)
         {
-            match AISettings::as_ref(ctx).orchestration_invalid_model_behavior {
-                OrchestrationInvalidModelBehavior::Block => {
+            match AISettings::as_ref(ctx).cloud_agent_invalid_model_behavior {
+                CloudAgentInvalidModelBehavior::Block => {
                     log::warn!("RunAgentsExecutor: unavailable model: {reason}");
                     let _ = sender.try_send(RunAgentsResult::Failure { error: reason });
                     return receiver;
                 }
-                OrchestrationInvalidModelBehavior::AutoSelect => {
+                CloudAgentInvalidModelBehavior::AutoSelect => {
                     // Substitute the configured fallback (or Oz default) only when
                     // it's valid for this run target; otherwise inherit the default
                     // (empty). This avoids handing an Oz model id to a non-Oz
                     // harness. Mirrors `maybe_auto_select_valid_model`.
-                    let fallback = resolve_orchestration_fallback_model_id(ctx);
+                    let fallback = resolve_cloud_agent_fallback_model_id(ctx);
                     request.model_id = if unavailable_model_reason(
                         &fallback,
                         &request.harness_type,

--- a/app/src/ai/blocklist/action_model/execute/run_agents.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents.rs
@@ -196,9 +196,23 @@ impl RunAgentsExecutor {
                     return receiver;
                 }
                 OrchestrationInvalidModelBehavior::AutoSelect => {
-                    // Substitute the user's configured fallback model (or the Oz
-                    // default); an empty result means "inherit the default".
-                    request.model_id = resolve_orchestration_fallback_model_id(ctx);
+                    // Substitute the configured fallback (or Oz default) only when
+                    // it's valid for this run target; otherwise inherit the default
+                    // (empty). This avoids handing an Oz model id to a non-Oz
+                    // harness. Mirrors `maybe_auto_select_valid_model`.
+                    let fallback = resolve_orchestration_fallback_model_id(ctx);
+                    request.model_id = if unavailable_model_reason(
+                        &fallback,
+                        &request.harness_type,
+                        is_local,
+                        ctx,
+                    )
+                    .is_none()
+                    {
+                        fallback
+                    } else {
+                        String::new()
+                    };
                 }
             }
         }

--- a/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
@@ -19,7 +19,7 @@ use crate::ai::cloud_agent_settings::CloudAgentSettings;
 use crate::ai::document::ai_document_model::{AIDocumentModel, AIDocumentSaveStatus};
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::ai::execution_profiles::RunAgentsPermission;
-use crate::ai::llms::ModelsByFeature;
+use crate::ai::llms::{LLMPreferences, ModelsByFeature};
 use crate::ai::mcp::templatable_manager::TemplatableMCPServerManager;
 use crate::appearance::Appearance;
 use crate::auth::auth_manager::AuthManager;

--- a/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
@@ -19,13 +19,16 @@ use crate::ai::cloud_agent_settings::CloudAgentSettings;
 use crate::ai::document::ai_document_model::{AIDocumentModel, AIDocumentSaveStatus};
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::ai::execution_profiles::RunAgentsPermission;
+use crate::ai::llms::ModelsByFeature;
 use crate::ai::mcp::templatable_manager::TemplatableMCPServerManager;
 use crate::appearance::Appearance;
+use crate::auth::auth_manager::AuthManager;
 use crate::auth::AuthStateProvider;
 use crate::cloud_object::model::persistence::CloudModel;
 use crate::network::NetworkStatus;
 use crate::server::cloud_objects::update_manager::UpdateManager;
 use crate::server::ids::SyncId;
+use crate::server::server_api::ServerApiProvider;
 use crate::server::sync_queue::SyncQueue;
 use crate::settings::PrivacySettings;
 use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
@@ -592,6 +595,153 @@ fn set_run_agents_permission(app: &mut App, permission: RunAgentsPermission) {
     AIExecutionProfilesModel::handle(app).update(app, |profiles, ctx| {
         let profile_id = *profiles.active_profile(None, ctx).id();
         profiles.set_run_agents(profile_id, permission, ctx);
+    });
+}
+
+/// Registers `LLMPreferences` (and its deps) with the agent-mode catalog marked
+/// as server-loaded. The default catalog only contains the `auto` model, so any
+/// non-`auto` model id is treated as unavailable for cloud/Oz runs.
+fn seed_loaded_llm_catalog(app: &mut App) {
+    app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+    app.add_singleton_model(AuthManager::new_for_test);
+    let llm_preferences = app.add_singleton_model(LLMPreferences::new);
+    llm_preferences.update(app, |preferences, ctx| {
+        preferences.update_feature_model_choices(Ok(ModelsByFeature::default()), ctx);
+    });
+}
+
+fn set_invalid_model_behavior(app: &mut App, behavior: OrchestrationInvalidModelBehavior) {
+    AISettings::handle(app).update(app, |settings, ctx| {
+        settings
+            .orchestration_invalid_model_behavior
+            .set_value(behavior, ctx)
+            .expect("setting invalid-model behavior should succeed");
+    });
+}
+
+fn remote_oz_request(model_id: &str) -> RunAgentsRequest {
+    let AIAgentActionType::RunAgents(mut request) = remote_run_agents_action("oz").action else {
+        panic!("expected run_agents action");
+    };
+    request.model_id = model_id.to_string();
+    request
+}
+
+#[test]
+fn dispatch_blocks_cloud_invalid_model_and_dispatches_no_children() {
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
+        seed_loaded_llm_catalog(&mut app);
+        let captured = subscribe_to_start_agent_requests(&mut app, &state.start_agent_executor);
+        let action_id = AIAgentActionId::from("run-agents-action".to_string());
+        let request = remote_oz_request("gpt-nonexistent");
+
+        let receiver = state.executor.update(&mut app, |executor, ctx| {
+            executor.dispatch_prepared_run_agents(
+                action_id.clone(),
+                request,
+                state.conversation_id,
+                ctx,
+            )
+        });
+
+        let result = receiver
+            .try_recv()
+            .expect("blocked invalid model should fail synchronously");
+        let RunAgentsResult::Failure { error } = result else {
+            panic!("expected Failure result for blocked invalid model");
+        };
+        assert!(
+            error.contains("gpt-nonexistent"),
+            "error should name the model: {error}"
+        );
+        state.executor.read(&app, |executor, _ctx| {
+            assert!(!executor.is_pending(&action_id));
+        });
+        captured.read(&app, |captured, _ctx| {
+            assert!(captured.0.is_empty());
+        });
+    });
+}
+
+#[test]
+fn dispatch_auto_selects_cloud_invalid_model_and_proceeds() {
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
+        seed_loaded_llm_catalog(&mut app);
+        set_invalid_model_behavior(&mut app, OrchestrationInvalidModelBehavior::AutoSelect);
+        let action_id = AIAgentActionId::from("run-agents-action".to_string());
+        let request = remote_oz_request("gpt-nonexistent");
+
+        let receiver = state.executor.update(&mut app, |executor, ctx| {
+            executor.dispatch_prepared_run_agents(
+                action_id.clone(),
+                request,
+                state.conversation_id,
+                ctx,
+            )
+        });
+
+        assert!(
+            receiver.try_recv().is_err(),
+            "auto-select should proceed rather than fail synchronously"
+        );
+        state.executor.read(&app, |executor, _ctx| {
+            assert!(executor.is_pending(&action_id));
+        });
+    });
+}
+
+#[test]
+fn dispatch_allows_empty_model_and_proceeds() {
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
+        let action_id = AIAgentActionId::from("run-agents-action".to_string());
+        let request = remote_oz_request("");
+
+        let receiver = state.executor.update(&mut app, |executor, ctx| {
+            executor.dispatch_prepared_run_agents(
+                action_id.clone(),
+                request,
+                state.conversation_id,
+                ctx,
+            )
+        });
+
+        assert!(
+            receiver.try_recv().is_err(),
+            "unset model should proceed rather than fail synchronously"
+        );
+        state.executor.read(&app, |executor, _ctx| {
+            assert!(executor.is_pending(&action_id));
+        });
+    });
+}
+
+#[test]
+fn dispatch_allows_auto_model_and_proceeds() {
+    App::test((), |mut app| async move {
+        let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
+        seed_loaded_llm_catalog(&mut app);
+        let action_id = AIAgentActionId::from("run-agents-action".to_string());
+        let request = remote_oz_request("auto");
+
+        let receiver = state.executor.update(&mut app, |executor, ctx| {
+            executor.dispatch_prepared_run_agents(
+                action_id.clone(),
+                request,
+                state.conversation_id,
+                ctx,
+            )
+        });
+
+        assert!(
+            receiver.try_recv().is_err(),
+            "auto model should proceed rather than fail synchronously"
+        );
+        state.executor.read(&app, |executor, _ctx| {
+            assert!(executor.is_pending(&action_id));
+        });
     });
 }
 

--- a/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/run_agents_tests.rs
@@ -610,10 +610,10 @@ fn seed_loaded_llm_catalog(app: &mut App) {
     });
 }
 
-fn set_invalid_model_behavior(app: &mut App, behavior: OrchestrationInvalidModelBehavior) {
+fn set_invalid_model_behavior(app: &mut App, behavior: CloudAgentInvalidModelBehavior) {
     AISettings::handle(app).update(app, |settings, ctx| {
         settings
-            .orchestration_invalid_model_behavior
+            .cloud_agent_invalid_model_behavior
             .set_value(behavior, ctx)
             .expect("setting invalid-model behavior should succeed");
     });
@@ -669,7 +669,7 @@ fn dispatch_auto_selects_cloud_invalid_model_and_proceeds() {
     App::test((), |mut app| async move {
         let state = initialize_run_agents_test(&mut app, ExecutionMode::App);
         seed_loaded_llm_catalog(&mut app);
-        set_invalid_model_behavior(&mut app, OrchestrationInvalidModelBehavior::AutoSelect);
+        set_invalid_model_behavior(&mut app, CloudAgentInvalidModelBehavior::AutoSelect);
         let action_id = AIAgentActionId::from("run-agents-action".to_string());
         let request = remote_oz_request("gpt-nonexistent");
 

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -45,6 +45,7 @@ use crate::ai::local_harness_setup::{
 use crate::appearance::Appearance;
 use crate::cloud_object::CloudObjectLookup as _;
 use crate::menu::{MenuItem, MenuItemFields};
+use crate::settings::{AISettings, OrchestrationInvalidModelBehavior};
 use crate::ui_components::blended_colors;
 use crate::ui_components::icons::Icon;
 use crate::view_components::dropdown::{
@@ -674,7 +675,11 @@ pub fn unavailable_model_reason(
             return None;
         }
         let suggestions = llm_prefs.oz_cloud_agent_model_suggestions(3);
-        return Some(unavailable_model_message(trimmed, "cloud agents", &suggestions));
+        return Some(unavailable_model_message(
+            trimmed,
+            "cloud agents",
+            &suggestions,
+        ));
     }
 
     if is_model_in_filtered_choices_in_app(model_id, harness_type, is_local, ctx) {
@@ -696,6 +701,38 @@ fn unavailable_model_message(model_id: &str, target: &str, suggestions: &[String
          unavailable models in Settings \u{2192} Agents (also in the Command Palette).",
     );
     message
+}
+
+/// Under the [`OrchestrationInvalidModelBehavior::AutoSelect`] setting,
+/// substitutes a valid model when the current `state.model_id` is unavailable
+/// for the run target. Prefers the Oz cloud default; falls back to the empty
+/// string (inherit the default) when even that is unavailable for the target.
+///
+/// A no-op under [`OrchestrationInvalidModelBehavior::Block`] (the accept gate
+/// surfaces the error instead) and when the current model is already valid.
+/// Returns `true` when `state.model_id` was changed so callers can repopulate
+/// the picker.
+pub fn maybe_auto_select_valid_model(state: &mut OrchestrationEditState, ctx: &AppContext) -> bool {
+    match AISettings::as_ref(ctx).orchestration_invalid_model_behavior {
+        OrchestrationInvalidModelBehavior::Block => return false,
+        OrchestrationInvalidModelBehavior::AutoSelect => {}
+    }
+    let is_local = !state.execution_mode.is_remote();
+    if unavailable_model_reason(&state.model_id, &state.harness_type, is_local, ctx).is_none() {
+        return false;
+    }
+    let fallback = LLMPreferences::as_ref(ctx).oz_cloud_default_agent_model_id();
+    let new_id =
+        if unavailable_model_reason(&fallback, &state.harness_type, is_local, ctx).is_none() {
+            fallback
+        } else {
+            String::new()
+        };
+    if state.model_id == new_id {
+        return false;
+    }
+    state.model_id = new_id;
+    true
 }
 
 /// Returns the default model_id for the given harness.
@@ -1232,6 +1269,20 @@ pub fn accept_disabled_reason_with_auth(
     if let Some(reason) = state.accept_disabled_reason() {
         return Some(reason.to_string());
     }
+    // When the run-wide model isn't available for the chosen target, either
+    // block with an actionable message or (under auto-select) let the reset
+    // paths substitute a valid model instead of blocking here.
+    let is_local = !state.execution_mode.is_remote();
+    match AISettings::as_ref(ctx).orchestration_invalid_model_behavior {
+        OrchestrationInvalidModelBehavior::Block => {
+            if let Some(reason) =
+                unavailable_model_reason(&state.model_id, &state.harness_type, is_local, ctx)
+            {
+                return Some(reason);
+            }
+        }
+        OrchestrationInvalidModelBehavior::AutoSelect => {}
+    }
     if matches!(state.execution_mode, RunAgentsExecutionMode::Local) {
         if let Some(harness) = Harness::parse_local_child_harness(&state.harness_type) {
             match local_harness_setup_state(harness) {
@@ -1540,6 +1591,9 @@ pub fn apply_execution_mode_change<A: OrchestrationControlAction, V: View>(
             .unwrap_or_default();
         state.model_id = reset_id;
     }
+    // Under auto-select, replace a model that is valid locally but not for the
+    // new (e.g. cloud) target with a valid fallback. No-op under Block.
+    maybe_auto_select_valid_model(state, ctx);
     if let Some(handle) = &handles.model_picker {
         populate_model_picker_for_harness(
             handle,
@@ -1583,6 +1637,9 @@ pub fn repopulate_all_pickers<A: OrchestrationControlAction, V: View>(
             state.model_id = first_id;
         }
     }
+    // Under auto-select, replace a model unavailable for the target (e.g. a
+    // local-only model on a cloud run) with a valid fallback. No-op under Block.
+    maybe_auto_select_valid_model(state, ctx);
     if let Some(handle) = &handles.model_picker {
         populate_model_picker_for_harness(
             handle,

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -697,10 +697,36 @@ fn unavailable_model_message(model_id: &str, target: &str, suggestions: &[String
         message.push_str(&format!(" Try one of: {}.", suggestions.join(", ")));
     }
     message.push_str(
-        " Leave the model unset to use the default, or turn on auto-select for \
+        " Leave the model unset to use the default, or enable a fallback model for \
          unavailable models in Settings \u{2192} Agents (also in the Command Palette).",
     );
     message
+}
+
+/// Resolves the model to substitute under
+/// [`OrchestrationInvalidModelBehavior::AutoSelect`]. Prefers the user's
+/// configured fallback model (`orchestration_fallback_model_id`) when it is set
+/// and available for cloud agents; otherwise uses the Oz cloud default, or an
+/// empty string (inherit the default) as a last resort.
+pub fn resolve_orchestration_fallback_model_id(ctx: &AppContext) -> String {
+    let llm_prefs = LLMPreferences::as_ref(ctx);
+    let configured = AISettings::as_ref(ctx)
+        .orchestration_fallback_model_id
+        .value()
+        .trim()
+        .to_string();
+    if !configured.is_empty()
+        && (configured.starts_with("auto")
+            || llm_prefs.is_oz_cloud_agent_model_available(&configured))
+    {
+        return configured;
+    }
+    let default = llm_prefs.oz_cloud_default_agent_model_id();
+    if default.trim().is_empty() {
+        String::new()
+    } else {
+        default
+    }
 }
 
 /// Under the [`OrchestrationInvalidModelBehavior::AutoSelect`] setting,
@@ -721,7 +747,7 @@ pub fn maybe_auto_select_valid_model(state: &mut OrchestrationEditState, ctx: &A
     if unavailable_model_reason(&state.model_id, &state.harness_type, is_local, ctx).is_none() {
         return false;
     }
-    let fallback = LLMPreferences::as_ref(ctx).oz_cloud_default_agent_model_id();
+    let fallback = resolve_orchestration_fallback_model_id(ctx);
     let new_id =
         if unavailable_model_reason(&fallback, &state.harness_type, is_local, ctx).is_none() {
             fallback

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -1610,7 +1610,14 @@ pub fn apply_execution_mode_change<A: OrchestrationControlAction, V: View>(
             }
         }
     }
-    if !is_model_in_filtered_choices(&state.model_id, &state.harness_type, is_local, ctx) {
+    // Only auto-reset an invalid model under auto-select. Under Block, leave it
+    // in place so the accept gate surfaces the error instead of silently
+    // switching to a valid model (e.g. `auto`).
+    if matches!(
+        AISettings::as_ref(ctx).orchestration_invalid_model_behavior,
+        OrchestrationInvalidModelBehavior::AutoSelect
+    ) && !is_model_in_filtered_choices(&state.model_id, &state.harness_type, is_local, ctx)
+    {
         let reset_id = fallback_base_model_id(ctx)
             .filter(|id| is_model_in_filtered_choices(id, &state.harness_type, is_local, ctx))
             .or_else(|| first_filtered_model_id(&state.harness_type, ctx))
@@ -1618,7 +1625,7 @@ pub fn apply_execution_mode_change<A: OrchestrationControlAction, V: View>(
         state.model_id = reset_id;
     }
     // Under auto-select, replace a model that is valid locally but not for the
-    // new (e.g. cloud) target with a valid fallback. No-op under Block.
+    // new (e.g. cloud) target with the configured fallback. No-op under Block.
     maybe_auto_select_valid_model(state, ctx);
     if let Some(handle) = &handles.model_picker {
         populate_model_picker_for_harness(
@@ -1657,14 +1664,22 @@ pub fn repopulate_all_pickers<A: OrchestrationControlAction, V: View>(
     if let Some(handle) = &handles.harness_picker {
         populate_harness_picker(handle, &state.harness_type, is_local, ctx);
     }
-    // Reset model if it disappeared from the harness's catalog.
-    if !is_model_in_filtered_choices(&state.model_id, &state.harness_type, is_local, ctx) {
+    // Reset the model if it disappeared from the harness's catalog — but only
+    // under auto-select. Under Block, leave an unavailable model in place so the
+    // accept gate can surface the error instead of silently switching to a valid
+    // model (e.g. `auto`).
+    if matches!(
+        AISettings::as_ref(ctx).orchestration_invalid_model_behavior,
+        OrchestrationInvalidModelBehavior::AutoSelect
+    ) && !is_model_in_filtered_choices(&state.model_id, &state.harness_type, is_local, ctx)
+    {
         if let Some(first_id) = first_filtered_model_id(&state.harness_type, ctx) {
             state.model_id = first_id;
         }
     }
     // Under auto-select, replace a model unavailable for the target (e.g. a
-    // local-only model on a cloud run) with a valid fallback. No-op under Block.
+    // local-only model on a cloud run) with the configured fallback. No-op under
+    // Block.
     maybe_auto_select_valid_model(state, ctx);
     if let Some(handle) = &handles.model_picker {
         populate_model_picker_for_harness(

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -602,6 +602,17 @@ pub fn is_model_in_filtered_choices<V: View>(
     is_local: bool,
     ctx: &mut ViewContext<V>,
 ) -> bool {
+    is_model_in_filtered_choices_in_app(model_id, harness_type, is_local, ctx)
+}
+
+/// `&AppContext` variant of [`is_model_in_filtered_choices`] so non-view callers
+/// (e.g. the orchestration executor pre-flight) can share the same logic.
+fn is_model_in_filtered_choices_in_app(
+    model_id: &str,
+    harness_type: &str,
+    is_local: bool,
+    ctx: &AppContext,
+) -> bool {
     let harness = Harness::parse_orchestration_harness(harness_type);
     match harness {
         Some(Harness::Oz) | None => {
@@ -621,6 +632,70 @@ pub fn is_model_in_filtered_choices<V: View>(
                 .is_some_and(|models| models.iter().any(|m| m.id == model_id))
         }
     }
+}
+
+/// Returns a user-facing reason when the run-wide `model_id` is not available
+/// for the chosen orchestration run target, or `None` when it's acceptable.
+///
+/// Mirrors the server's pre-spawn model validation (warp-server `AddTask`) so we
+/// fail fast with an actionable message instead of dispatching children the
+/// server would reject:
+/// - Empty/unset (inherit the default) and `auto*` models are always allowed.
+/// - Validation fails open until the server model catalog has loaded.
+/// - Remote + Oz harness validates against the *raw* Oz cloud catalog
+///   ([`LLMPreferences::is_oz_cloud_agent_model_available`]), which excludes
+///   local-only custom endpoints/routers so they aren't mistaken for
+///   Oz-available.
+/// - Non-Oz harnesses and local runs use the existing harness-filtered
+///   membership check (local custom models are legitimately runnable locally).
+pub fn unavailable_model_reason(
+    model_id: &str,
+    harness_type: &str,
+    is_local: bool,
+    ctx: &AppContext,
+) -> Option<String> {
+    let trimmed = model_id.trim();
+    // Unset means "inherit the default", and `auto*` models are always accepted
+    // by the server (id.IsAuto()).
+    if trimmed.is_empty() || trimmed.starts_with("auto") {
+        return None;
+    }
+
+    let harness = Harness::parse_orchestration_harness(harness_type);
+    let is_oz = matches!(harness, Some(Harness::Oz) | None);
+
+    if !is_local && is_oz {
+        let llm_prefs = LLMPreferences::as_ref(ctx);
+        // Fail open until the catalog has been fetched, to avoid false
+        // rejections before the first model-choices response.
+        if !llm_prefs.oz_cloud_agent_model_catalog_loaded()
+            || llm_prefs.is_oz_cloud_agent_model_available(trimmed)
+        {
+            return None;
+        }
+        let suggestions = llm_prefs.oz_cloud_agent_model_suggestions(3);
+        return Some(unavailable_model_message(trimmed, "cloud agents", &suggestions));
+    }
+
+    if is_model_in_filtered_choices_in_app(model_id, harness_type, is_local, ctx) {
+        return None;
+    }
+    Some(unavailable_model_message(trimmed, "this run", &[]))
+}
+
+/// Builds the user-facing "model unavailable" message, including optional
+/// suggestions and a pointer to the auto-select setting (surfaced when the
+/// behavior is `Block`).
+fn unavailable_model_message(model_id: &str, target: &str, suggestions: &[String]) -> String {
+    let mut message = format!("Model \"{model_id}\" isn't available for {target}.");
+    if !suggestions.is_empty() {
+        message.push_str(&format!(" Try one of: {}.", suggestions.join(", ")));
+    }
+    message.push_str(
+        " Leave the model unset to use the default, or turn on auto-select for \
+         unavailable models in Settings \u{2192} Agents (also in the Command Palette).",
+    );
+    message
 }
 
 /// Returns the default model_id for the given harness.

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -45,7 +45,7 @@ use crate::ai::local_harness_setup::{
 use crate::appearance::Appearance;
 use crate::cloud_object::CloudObjectLookup as _;
 use crate::menu::{MenuItem, MenuItemFields};
-use crate::settings::{AISettings, OrchestrationInvalidModelBehavior};
+use crate::settings::{AISettings, CloudAgentInvalidModelBehavior};
 use crate::ui_components::blended_colors;
 use crate::ui_components::icons::Icon;
 use crate::view_components::dropdown::{
@@ -704,14 +704,14 @@ fn unavailable_model_message(model_id: &str, target: &str, suggestions: &[String
 }
 
 /// Resolves the model to substitute under
-/// [`OrchestrationInvalidModelBehavior::AutoSelect`]. Prefers the user's
-/// configured fallback model (`orchestration_fallback_model_id`) when it is set
+/// [`CloudAgentInvalidModelBehavior::AutoSelect`]. Prefers the user's
+/// configured fallback model (`cloud_agent_fallback_model_id`) when it is set
 /// and available for cloud agents; otherwise uses the Oz cloud default, or an
 /// empty string (inherit the default) as a last resort.
-pub fn resolve_orchestration_fallback_model_id(ctx: &AppContext) -> String {
+pub fn resolve_cloud_agent_fallback_model_id(ctx: &AppContext) -> String {
     let llm_prefs = LLMPreferences::as_ref(ctx);
     let configured = AISettings::as_ref(ctx)
-        .orchestration_fallback_model_id
+        .cloud_agent_fallback_model_id
         .value()
         .trim()
         .to_string();
@@ -729,25 +729,25 @@ pub fn resolve_orchestration_fallback_model_id(ctx: &AppContext) -> String {
     }
 }
 
-/// Under the [`OrchestrationInvalidModelBehavior::AutoSelect`] setting,
+/// Under the [`CloudAgentInvalidModelBehavior::AutoSelect`] setting,
 /// substitutes a valid model when the current `state.model_id` is unavailable
 /// for the run target. Prefers the Oz cloud default; falls back to the empty
 /// string (inherit the default) when even that is unavailable for the target.
 ///
-/// A no-op under [`OrchestrationInvalidModelBehavior::Block`] (the accept gate
+/// A no-op under [`CloudAgentInvalidModelBehavior::Block`] (the accept gate
 /// surfaces the error instead) and when the current model is already valid.
 /// Returns `true` when `state.model_id` was changed so callers can repopulate
 /// the picker.
 pub fn maybe_auto_select_valid_model(state: &mut OrchestrationEditState, ctx: &AppContext) -> bool {
-    match AISettings::as_ref(ctx).orchestration_invalid_model_behavior {
-        OrchestrationInvalidModelBehavior::Block => return false,
-        OrchestrationInvalidModelBehavior::AutoSelect => {}
+    match AISettings::as_ref(ctx).cloud_agent_invalid_model_behavior {
+        CloudAgentInvalidModelBehavior::Block => return false,
+        CloudAgentInvalidModelBehavior::AutoSelect => {}
     }
     let is_local = !state.execution_mode.is_remote();
     if unavailable_model_reason(&state.model_id, &state.harness_type, is_local, ctx).is_none() {
         return false;
     }
-    let fallback = resolve_orchestration_fallback_model_id(ctx);
+    let fallback = resolve_cloud_agent_fallback_model_id(ctx);
     let new_id =
         if unavailable_model_reason(&fallback, &state.harness_type, is_local, ctx).is_none() {
             fallback
@@ -1299,15 +1299,15 @@ pub fn accept_disabled_reason_with_auth(
     // block with an actionable message or (under auto-select) let the reset
     // paths substitute a valid model instead of blocking here.
     let is_local = !state.execution_mode.is_remote();
-    match AISettings::as_ref(ctx).orchestration_invalid_model_behavior {
-        OrchestrationInvalidModelBehavior::Block => {
+    match AISettings::as_ref(ctx).cloud_agent_invalid_model_behavior {
+        CloudAgentInvalidModelBehavior::Block => {
             if let Some(reason) =
                 unavailable_model_reason(&state.model_id, &state.harness_type, is_local, ctx)
             {
                 return Some(reason);
             }
         }
-        OrchestrationInvalidModelBehavior::AutoSelect => {}
+        CloudAgentInvalidModelBehavior::AutoSelect => {}
     }
     if matches!(state.execution_mode, RunAgentsExecutionMode::Local) {
         if let Some(harness) = Harness::parse_local_child_harness(&state.harness_type) {
@@ -1614,8 +1614,8 @@ pub fn apply_execution_mode_change<A: OrchestrationControlAction, V: View>(
     // in place so the accept gate surfaces the error instead of silently
     // switching to a valid model (e.g. `auto`).
     if matches!(
-        AISettings::as_ref(ctx).orchestration_invalid_model_behavior,
-        OrchestrationInvalidModelBehavior::AutoSelect
+        AISettings::as_ref(ctx).cloud_agent_invalid_model_behavior,
+        CloudAgentInvalidModelBehavior::AutoSelect
     ) && !is_model_in_filtered_choices(&state.model_id, &state.harness_type, is_local, ctx)
     {
         let reset_id = fallback_base_model_id(ctx)
@@ -1669,8 +1669,8 @@ pub fn repopulate_all_pickers<A: OrchestrationControlAction, V: View>(
     // accept gate can surface the error instead of silently switching to a valid
     // model (e.g. `auto`).
     if matches!(
-        AISettings::as_ref(ctx).orchestration_invalid_model_behavior,
-        OrchestrationInvalidModelBehavior::AutoSelect
+        AISettings::as_ref(ctx).cloud_agent_invalid_model_behavior,
+        CloudAgentInvalidModelBehavior::AutoSelect
     ) && !is_model_in_filtered_choices(&state.model_id, &state.harness_type, is_local, ctx)
     {
         if let Some(first_id) = first_filtered_model_id(&state.harness_type, ctx) {

--- a/app/src/ai/blocklist/inline_action/orchestration_controls_tests.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls_tests.rs
@@ -406,4 +406,47 @@ mod model_availability_gate_tests {
             });
         });
     }
+
+    fn set_fallback_model(app: &mut App, model_id: &str) {
+        AISettings::handle(app).update(app, |settings, ctx| {
+            settings
+                .orchestration_fallback_model_id
+                .set_value(model_id.to_string(), ctx)
+                .expect("set fallback model");
+        });
+    }
+
+    #[test]
+    fn auto_select_uses_configured_fallback_model() {
+        App::test((), |mut app| async move {
+            setup(&mut app, catalog("valid-a", &["valid-a", "valid-b"]));
+            set_behavior(&mut app, OrchestrationInvalidModelBehavior::AutoSelect);
+            // Configure an explicit fallback distinct from the catalog default.
+            set_fallback_model(&mut app, "valid-b");
+
+            app.update(|ctx| {
+                let mut state = remote_oz_state("bad-model");
+                // Substitution uses the configured fallback, not the default.
+                assert!(maybe_auto_select_valid_model(&mut state, ctx));
+                assert_eq!(state.model_id, "valid-b");
+            });
+        });
+    }
+
+    #[test]
+    fn auto_select_falls_back_to_default_when_configured_fallback_unavailable() {
+        App::test((), |mut app| async move {
+            setup(&mut app, catalog("valid-a", &["valid-a", "valid-b"]));
+            set_behavior(&mut app, OrchestrationInvalidModelBehavior::AutoSelect);
+            // A configured fallback that isn't a valid cloud model is ignored in
+            // favor of the Oz default.
+            set_fallback_model(&mut app, "also-bad");
+
+            app.update(|ctx| {
+                let mut state = remote_oz_state("bad-model");
+                assert!(maybe_auto_select_valid_model(&mut state, ctx));
+                assert_eq!(state.model_id, "valid-a");
+            });
+        });
+    }
 }

--- a/app/src/ai/blocklist/inline_action/orchestration_controls_tests.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls_tests.rs
@@ -198,3 +198,212 @@ fn select_create_new_auth_secret_marks_creating_new_from_inherit() {
         AuthSecretSelection::CreatingNew
     ));
 }
+
+/// Tests for the run-wide model-availability accept gate and the auto-select
+/// substitution behavior. These exercise `accept_disabled_reason_with_auth`
+/// and `maybe_auto_select_valid_model` against a populated Oz model catalog.
+mod model_availability_gate_tests {
+    use ai::agent::action::RunAgentsExecutionMode;
+    use settings::Setting;
+    use warp_core::features::FeatureFlag;
+    use warpui::{App, SingletonEntity};
+
+    use super::super::{accept_disabled_reason_with_auth, maybe_auto_select_valid_model};
+    use super::OrchestrationEditState;
+    use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
+    use crate::ai::llms::{AvailableLLMs, LLMId, LLMInfo, LLMPreferences, ModelsByFeature};
+    use crate::ai::mcp::TemplatableMCPServerManager;
+    use crate::auth::auth_manager::AuthManager;
+    use crate::auth::AuthStateProvider;
+    use crate::cloud_object::model::persistence::CloudModel;
+    use crate::network::NetworkStatus;
+    use crate::server::cloud_objects::update_manager::UpdateManager;
+    use crate::server::server_api::ServerApiProvider;
+    use crate::server::sync_queue::SyncQueue;
+    use crate::settings::{AISettings, OrchestrationInvalidModelBehavior};
+    use crate::test_util::settings::initialize_settings_for_tests;
+    use crate::workspaces::team_tester::TeamTesterStatus;
+    use crate::workspaces::user_workspaces::UserWorkspaces;
+    use crate::LaunchMode;
+
+    fn llm_info(id: &str) -> LLMInfo {
+        serde_json::from_str(&format!(
+            r#"{{"display_name":"{id}","id":"{id}","usage_metadata":{{"request_multiplier":1,"credit_multiplier":null}},"provider":"Unknown"}}"#
+        ))
+        .expect("llm_info json should deserialize")
+    }
+
+    /// Builds a `ModelsByFeature` whose Oz `agent_mode` catalog contains exactly
+    /// `ids`, with `default_id` as the auto-select fallback.
+    fn catalog(default_id: &str, ids: &[&str]) -> ModelsByFeature {
+        let choices: Vec<LLMInfo> = ids.iter().map(|id| llm_info(id)).collect();
+        let agent_mode = AvailableLLMs::new(LLMId::from(default_id), choices, None)
+            .expect("agent_mode catalog should build");
+        ModelsByFeature {
+            agent_mode,
+            ..Default::default()
+        }
+    }
+
+    fn setup(app: &mut App, models: ModelsByFeature) {
+        initialize_settings_for_tests(app);
+        app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+        app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+        app.add_singleton_model(AuthManager::new_for_test);
+        app.add_singleton_model(|_| NetworkStatus::new());
+        app.add_singleton_model(UserWorkspaces::default_mock);
+        app.add_singleton_model(CloudModel::mock);
+        app.add_singleton_model(TeamTesterStatus::mock);
+        app.add_singleton_model(SyncQueue::mock);
+        app.add_singleton_model(UpdateManager::mock);
+        app.add_singleton_model(|_| TemplatableMCPServerManager::default());
+        app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        let llm_preferences = app.add_singleton_model(LLMPreferences::new);
+        llm_preferences.update(app, |prefs, ctx| {
+            prefs.update_feature_model_choices(Ok(models), ctx);
+        });
+    }
+
+    fn set_behavior(app: &mut App, behavior: OrchestrationInvalidModelBehavior) {
+        AISettings::handle(app).update(app, |settings, ctx| {
+            settings
+                .orchestration_invalid_model_behavior
+                .set_value(behavior, ctx)
+                .expect("set invalid-model behavior");
+        });
+    }
+
+    fn remote_oz_state(model: &str) -> OrchestrationEditState {
+        OrchestrationEditState::from_run_agents_fields(
+            model,
+            "oz",
+            &RunAgentsExecutionMode::Remote {
+                environment_id: "env-1".to_string(),
+                worker_host: "warp".to_string(),
+                computer_use_enabled: false,
+            },
+        )
+    }
+
+    fn local_oz_state(model: &str) -> OrchestrationEditState {
+        OrchestrationEditState::from_run_agents_fields(model, "oz", &RunAgentsExecutionMode::Local)
+    }
+
+    #[test]
+    fn block_disables_accept_for_unavailable_cloud_model() {
+        App::test((), |mut app| async move {
+            setup(&mut app, catalog("valid-a", &["valid-a", "valid-b"]));
+            set_behavior(&mut app, OrchestrationInvalidModelBehavior::Block);
+
+            app.update(|ctx| {
+                let mut state = remote_oz_state("bad-model");
+                let reason = accept_disabled_reason_with_auth(&state, ctx);
+                assert!(
+                    reason
+                        .as_deref()
+                        .is_some_and(|r| r.contains("cloud agents")),
+                    "Block should disable Accept for an unavailable cloud model, got {reason:?}"
+                );
+                // Auto-select is a no-op under Block, so the model stays unchanged.
+                assert!(!maybe_auto_select_valid_model(&mut state, ctx));
+                assert_eq!(state.model_id, "bad-model");
+            });
+        });
+    }
+
+    #[test]
+    fn auto_select_allows_and_substitutes_unavailable_cloud_model() {
+        App::test((), |mut app| async move {
+            setup(&mut app, catalog("valid-a", &["valid-a", "valid-b"]));
+            set_behavior(&mut app, OrchestrationInvalidModelBehavior::AutoSelect);
+
+            app.update(|ctx| {
+                let mut state = remote_oz_state("bad-model");
+                // The gate does not block under auto-select.
+                assert_eq!(accept_disabled_reason_with_auth(&state, ctx), None);
+                // The substitution swaps in the Oz cloud default model.
+                assert!(maybe_auto_select_valid_model(&mut state, ctx));
+                assert_eq!(state.model_id, "valid-a");
+            });
+        });
+    }
+
+    #[test]
+    fn valid_cloud_model_is_not_blocked_or_substituted() {
+        App::test((), |mut app| async move {
+            setup(&mut app, catalog("valid-a", &["valid-a", "valid-b"]));
+            set_behavior(&mut app, OrchestrationInvalidModelBehavior::Block);
+
+            app.update(|ctx| {
+                let state = remote_oz_state("valid-b");
+                assert_eq!(accept_disabled_reason_with_auth(&state, ctx), None);
+            });
+
+            set_behavior(&mut app, OrchestrationInvalidModelBehavior::AutoSelect);
+            app.update(|ctx| {
+                let mut state = remote_oz_state("valid-b");
+                assert!(!maybe_auto_select_valid_model(&mut state, ctx));
+                assert_eq!(state.model_id, "valid-b");
+            });
+        });
+    }
+
+    #[test]
+    fn empty_and_auto_models_are_always_allowed() {
+        App::test((), |mut app| async move {
+            setup(&mut app, catalog("valid-a", &["valid-a", "valid-b"]));
+            set_behavior(&mut app, OrchestrationInvalidModelBehavior::Block);
+
+            app.update(|ctx| {
+                assert_eq!(
+                    accept_disabled_reason_with_auth(&remote_oz_state(""), ctx),
+                    None
+                );
+                assert_eq!(
+                    accept_disabled_reason_with_auth(&remote_oz_state("auto"), ctx),
+                    None
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn local_only_custom_model_allowed_locally_but_flagged_for_cloud() {
+        App::test((), |mut app| async move {
+            let _custom_inference = FeatureFlag::CustomInferenceEndpoints.override_enabled(true);
+            setup(&mut app, catalog("valid-a", &["valid-a", "valid-b"]));
+            set_behavior(&mut app, OrchestrationInvalidModelBehavior::Block);
+
+            let custom_id = "custom-model-config-key";
+            ai::api_keys::ApiKeyManager::handle(&app).update(&mut app, |api_key_manager, ctx| {
+                api_key_manager.add_custom_endpoint(
+                    "local".to_string(),
+                    "https://example.com/v1".to_string(),
+                    "test-key".to_string(),
+                    vec![(
+                        "custom-model".to_string(),
+                        Some("Custom Model".to_string()),
+                        Some(custom_id.to_string()),
+                    )],
+                    ctx,
+                );
+            });
+
+            app.update(|ctx| {
+                // Legitimately runnable locally: no block for a local run.
+                assert_eq!(
+                    accept_disabled_reason_with_auth(&local_oz_state(custom_id), ctx),
+                    None,
+                    "local custom model should be allowed for local runs"
+                );
+                // But not accepted by Oz for cloud runs.
+                assert!(
+                    accept_disabled_reason_with_auth(&remote_oz_state(custom_id), ctx).is_some(),
+                    "local custom model should be flagged for cloud runs"
+                );
+            });
+        });
+    }
+}

--- a/app/src/ai/blocklist/inline_action/orchestration_controls_tests.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls_tests.rs
@@ -220,7 +220,7 @@ mod model_availability_gate_tests {
     use crate::server::cloud_objects::update_manager::UpdateManager;
     use crate::server::server_api::ServerApiProvider;
     use crate::server::sync_queue::SyncQueue;
-    use crate::settings::{AISettings, OrchestrationInvalidModelBehavior};
+    use crate::settings::{AISettings, CloudAgentInvalidModelBehavior};
     use crate::test_util::settings::initialize_settings_for_tests;
     use crate::workspaces::team_tester::TeamTesterStatus;
     use crate::workspaces::user_workspaces::UserWorkspaces;
@@ -266,10 +266,10 @@ mod model_availability_gate_tests {
         });
     }
 
-    fn set_behavior(app: &mut App, behavior: OrchestrationInvalidModelBehavior) {
+    fn set_behavior(app: &mut App, behavior: CloudAgentInvalidModelBehavior) {
         AISettings::handle(app).update(app, |settings, ctx| {
             settings
-                .orchestration_invalid_model_behavior
+                .cloud_agent_invalid_model_behavior
                 .set_value(behavior, ctx)
                 .expect("set invalid-model behavior");
         });
@@ -295,7 +295,7 @@ mod model_availability_gate_tests {
     fn block_disables_accept_for_unavailable_cloud_model() {
         App::test((), |mut app| async move {
             setup(&mut app, catalog("valid-a", &["valid-a", "valid-b"]));
-            set_behavior(&mut app, OrchestrationInvalidModelBehavior::Block);
+            set_behavior(&mut app, CloudAgentInvalidModelBehavior::Block);
 
             app.update(|ctx| {
                 let mut state = remote_oz_state("bad-model");
@@ -317,7 +317,7 @@ mod model_availability_gate_tests {
     fn auto_select_allows_and_substitutes_unavailable_cloud_model() {
         App::test((), |mut app| async move {
             setup(&mut app, catalog("valid-a", &["valid-a", "valid-b"]));
-            set_behavior(&mut app, OrchestrationInvalidModelBehavior::AutoSelect);
+            set_behavior(&mut app, CloudAgentInvalidModelBehavior::AutoSelect);
 
             app.update(|ctx| {
                 let mut state = remote_oz_state("bad-model");
@@ -334,14 +334,14 @@ mod model_availability_gate_tests {
     fn valid_cloud_model_is_not_blocked_or_substituted() {
         App::test((), |mut app| async move {
             setup(&mut app, catalog("valid-a", &["valid-a", "valid-b"]));
-            set_behavior(&mut app, OrchestrationInvalidModelBehavior::Block);
+            set_behavior(&mut app, CloudAgentInvalidModelBehavior::Block);
 
             app.update(|ctx| {
                 let state = remote_oz_state("valid-b");
                 assert_eq!(accept_disabled_reason_with_auth(&state, ctx), None);
             });
 
-            set_behavior(&mut app, OrchestrationInvalidModelBehavior::AutoSelect);
+            set_behavior(&mut app, CloudAgentInvalidModelBehavior::AutoSelect);
             app.update(|ctx| {
                 let mut state = remote_oz_state("valid-b");
                 assert!(!maybe_auto_select_valid_model(&mut state, ctx));
@@ -354,7 +354,7 @@ mod model_availability_gate_tests {
     fn empty_and_auto_models_are_always_allowed() {
         App::test((), |mut app| async move {
             setup(&mut app, catalog("valid-a", &["valid-a", "valid-b"]));
-            set_behavior(&mut app, OrchestrationInvalidModelBehavior::Block);
+            set_behavior(&mut app, CloudAgentInvalidModelBehavior::Block);
 
             app.update(|ctx| {
                 assert_eq!(
@@ -374,7 +374,7 @@ mod model_availability_gate_tests {
         App::test((), |mut app| async move {
             let _custom_inference = FeatureFlag::CustomInferenceEndpoints.override_enabled(true);
             setup(&mut app, catalog("valid-a", &["valid-a", "valid-b"]));
-            set_behavior(&mut app, OrchestrationInvalidModelBehavior::Block);
+            set_behavior(&mut app, CloudAgentInvalidModelBehavior::Block);
 
             let custom_id = "custom-model-config-key";
             ai::api_keys::ApiKeyManager::handle(&app).update(&mut app, |api_key_manager, ctx| {
@@ -410,7 +410,7 @@ mod model_availability_gate_tests {
     fn set_fallback_model(app: &mut App, model_id: &str) {
         AISettings::handle(app).update(app, |settings, ctx| {
             settings
-                .orchestration_fallback_model_id
+                .cloud_agent_fallback_model_id
                 .set_value(model_id.to_string(), ctx)
                 .expect("set fallback model");
         });
@@ -420,7 +420,7 @@ mod model_availability_gate_tests {
     fn auto_select_uses_configured_fallback_model() {
         App::test((), |mut app| async move {
             setup(&mut app, catalog("valid-a", &["valid-a", "valid-b"]));
-            set_behavior(&mut app, OrchestrationInvalidModelBehavior::AutoSelect);
+            set_behavior(&mut app, CloudAgentInvalidModelBehavior::AutoSelect);
             // Configure an explicit fallback distinct from the catalog default.
             set_fallback_model(&mut app, "valid-b");
 
@@ -437,7 +437,7 @@ mod model_availability_gate_tests {
     fn auto_select_falls_back_to_default_when_configured_fallback_unavailable() {
         App::test((), |mut app| async move {
             setup(&mut app, catalog("valid-a", &["valid-a", "valid-b"]));
-            set_behavior(&mut app, OrchestrationInvalidModelBehavior::AutoSelect);
+            set_behavior(&mut app, CloudAgentInvalidModelBehavior::AutoSelect);
             // A configured fallback that isn't a valid cloud model is ignored in
             // favor of the Oz default.
             set_fallback_model(&mut app, "also-bad");

--- a/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
+++ b/app/src/ai/blocklist/inline_action/run_agents_card_view.rs
@@ -268,6 +268,10 @@ fn resolve_interactive_defaults(
             }
         }
     }
+    // Under auto-select, replace a model that isn't available for the run
+    // target with a valid fallback so the picker reflects it. No-op under
+    // Block, where the accept gate surfaces the error instead.
+    oc::maybe_auto_select_valid_model(&mut state.orch, ctx);
     if let RunAgentsExecutionMode::Remote {
         environment_id,
         worker_host,
@@ -383,6 +387,11 @@ impl RunAgentsCardView {
                 // ready for user confirmation. Re-render so the card
                 // transitions from the "Configuring agents..." placeholder
                 // to the full confirmation UI.
+                // Refresh the Oz model catalog so validation / auto-select
+                // run against a fresh list. The card subscribes to
+                // `UpdatedAvailableLLMs` and repopulates when it arrives.
+                LLMPreferences::handle(ctx)
+                    .update(ctx, |prefs, ctx| prefs.refresh_available_models(ctx));
                 resolve_interactive_defaults(&mut me.state, &*me.block_model, ctx);
                 oc::repopulate_all_pickers(&mut me.state.orch, &me.handles.pickers, ctx);
                 me.refresh_accept_button_state(ctx);

--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -809,6 +809,18 @@ impl LLMPreferences {
             .any(|llm| llm.id.as_str() == id && llm.disable_reason.is_none())
     }
 
+    /// The enabled Oz cloud agent-mode models, for building the orchestration
+    /// fallback-model picker. Uses the *raw* server catalog (excludes local-only
+    /// custom endpoints/routers) so only models valid for cloud agents appear.
+    pub fn oz_cloud_agent_models(&self) -> Vec<&LLMInfo> {
+        self.models_by_feature
+            .agent_mode
+            .choices
+            .iter()
+            .filter(|llm| llm.disable_reason.is_none())
+            .collect()
+    }
+
     /// A small sample of currently-available Oz cloud agent-mode model ids, for
     /// building actionable "try one of these" error messages.
     pub fn oz_cloud_agent_model_suggestions(&self, limit: usize) -> Vec<String> {

--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -590,11 +590,17 @@ pub struct LLMPreferences {
     custom_llms: Vec<LLMInfo>,
     /// All custom model routers, including both local and cloud-backed.
     custom_model_routers: Vec<CustomModelRouter>,
+    /// Whether the agent-mode catalog has been populated from the server (vs.
+    /// the built-in defaults). Used to fail open on cloud model validation
+    /// before the first `get_feature_model_choices` response.
+    server_models_loaded: bool,
 }
 
 impl LLMPreferences {
     pub fn new(ctx: &mut ModelContext<Self>) -> Self {
-        let models_by_feature = get_cached_models(ctx).unwrap_or_default();
+        let cached_models = get_cached_models(ctx);
+        let server_models_loaded = cached_models.is_some();
+        let models_by_feature = cached_models.unwrap_or_default();
 
         ctx.subscribe_to_model(&NetworkStatus::handle(ctx), |me, _, event, ctx| {
             if let NetworkStatusEvent::NetworkStatusChanged {
@@ -655,6 +661,7 @@ impl LLMPreferences {
             base_llm_for_terminal_view,
             custom_llms,
             custom_model_routers: Vec::new(),
+            server_models_loaded,
         };
 
         // Seed from any already-loaded local config (the async load emits
@@ -782,6 +789,51 @@ impl LLMPreferences {
             })
             .chain(self.custom_llm_choices(app))
             .chain(self.custom_router_choices())
+    }
+
+    /// Returns true when `id` is a model Oz accepts for cloud agent tasks.
+    ///
+    /// Checks the *raw* server-provided agent-mode catalog
+    /// (`models_by_feature.agent_mode`) — the same set the server validates
+    /// against in `AddTask` — and intentionally excludes client-only
+    /// augmentation (custom-endpoint LLMs and local custom routers), which are
+    /// only runnable for local sessions. Cloud-backed custom routers remain
+    /// valid because the server includes them in the agent-mode catalog.
+    /// Models with a disable reason are treated as unavailable, mirroring the
+    /// server's access check.
+    pub fn is_oz_cloud_agent_model_available(&self, id: &str) -> bool {
+        self.models_by_feature
+            .agent_mode
+            .choices
+            .iter()
+            .any(|llm| llm.id.as_str() == id && llm.disable_reason.is_none())
+    }
+
+    /// A small sample of currently-available Oz cloud agent-mode model ids, for
+    /// building actionable "try one of these" error messages.
+    pub fn oz_cloud_agent_model_suggestions(&self, limit: usize) -> Vec<String> {
+        self.models_by_feature
+            .agent_mode
+            .choices
+            .iter()
+            .filter(|llm| llm.disable_reason.is_none())
+            .map(|llm| llm.id.to_string())
+            .take(limit)
+            .collect()
+    }
+
+    /// The default agent-mode model id from the raw server catalog, used as the
+    /// fallback when auto-selecting a valid model for cloud orchestration. The
+    /// server guarantees this default is enabled.
+    pub fn oz_cloud_default_agent_model_id(&self) -> String {
+        self.models_by_feature.agent_mode.default_id.to_string()
+    }
+
+    /// Whether the agent-mode catalog has been populated from the server (vs.
+    /// the built-in defaults). Cloud model validation should fail open until
+    /// this is true.
+    pub fn oz_cloud_agent_model_catalog_loaded(&self) -> bool {
+        self.server_models_loaded
     }
 
     /// Returns the set of LLMs available for coding.
@@ -1385,6 +1437,10 @@ impl LLMPreferences {
     }
 
     fn on_server_update(&mut self, update: ModelsByFeature, ctx: &mut ModelContext<Self>) {
+        // Mark the catalog as server-populated so cloud model validation can
+        // stop failing open.
+        self.server_models_loaded = true;
+
         let has_existing_persisted_config = get_cached_models(ctx).is_some();
 
         let old = std::mem::replace(&mut self.models_by_feature, update);

--- a/app/src/ai/llms_tests.rs
+++ b/app/src/ai/llms_tests.rs
@@ -239,6 +239,7 @@ fn custom_endpoint_usage_display_label_resolves_alias_name_and_generic_fallback(
         base_llm_for_terminal_view: HashMap::new(),
         custom_llms: build_custom_llm_infos(&keys),
         custom_model_routers: Vec::new(),
+        server_models_loaded: false,
     };
 
     assert_eq!(

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -513,18 +513,18 @@ impl OrchestrationInvalidModelBehavior {
     /// Display name for the settings dropdown.
     pub fn display_name(&self) -> &'static str {
         match self {
-            OrchestrationInvalidModelBehavior::Block => "Block with an error",
-            OrchestrationInvalidModelBehavior::AutoSelect => "Auto-select a valid model",
+            OrchestrationInvalidModelBehavior::Block => "Block the run",
+            OrchestrationInvalidModelBehavior::AutoSelect => "Use a fallback model",
         }
     }
 
     pub fn command_palette_description(&self) -> &'static str {
         match self {
             OrchestrationInvalidModelBehavior::Block => {
-                "Set unavailable orchestration model behavior: block with an error"
+                "Set unavailable orchestration model behavior: block the run"
             }
             OrchestrationInvalidModelBehavior::AutoSelect => {
-                "Set unavailable orchestration model behavior: auto-select a valid model"
+                "Set unavailable orchestration model behavior: use a fallback model"
             }
         }
     }
@@ -1538,8 +1538,21 @@ define_settings_group!(AISettings, settings: [
     orchestration_message_display_mode: OrchestrationMessageDisplayMode,
 
     // Controls what happens when an orchestration run-wide model is unavailable
-    // for the chosen run target (block with an error vs. auto-select a valid model).
+    // for the chosen run target (block the run vs. use a fallback model).
     orchestration_invalid_model_behavior: OrchestrationInvalidModelBehavior,
+
+    // The model to fall back to when an orchestration model is unavailable and
+    // `orchestration_invalid_model_behavior` is `Use a fallback model`. An empty
+    // value means "let Warp pick the default".
+    orchestration_fallback_model_id: OrchestrationFallbackModelId {
+        type: String,
+        default: String::new(),
+        supported_platforms: SupportedPlatforms::ALL,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        private: false,
+        toml_path: "agents.warp_agent.other.orchestration_fallback_model_id",
+        description: "The model to fall back to when an orchestration model is unavailable and auto-select is enabled. Empty means use the default.",
+    }
 
     // Default behavior when the user submits a new prompt while the agent is still
     // responding. Per-conversation overrides live on `QueuedQueryModel`; this

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -471,6 +471,65 @@ impl OrchestrationMessageDisplayMode {
     }
 }
 
+/// Controls what happens when an orchestration run-wide model is not available
+/// for the chosen run target (e.g. a cloud agent run requesting a model Oz does
+/// not accept, or a local-only model selected for a cloud run).
+#[derive(
+    Default,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Copy,
+    Clone,
+    EnumIter,
+    schemars::JsonSchema,
+    settings_value::SettingsValue,
+)]
+#[schemars(
+    description = "What happens when an orchestration model is unavailable for the run target.",
+    rename_all = "snake_case"
+)]
+pub enum OrchestrationInvalidModelBehavior {
+    /// Block the run and surface a clear error so the user can pick a valid
+    /// model (default).
+    #[default]
+    Block,
+    /// Automatically substitute a valid model and proceed.
+    AutoSelect,
+}
+
+settings::macros::implement_setting_for_enum!(
+    OrchestrationInvalidModelBehavior,
+    AISettings,
+    SupportedPlatforms::ALL,
+    SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+    private: false,
+    toml_path: "agents.warp_agent.other.orchestration_invalid_model_behavior",
+    description: "What happens when an orchestration model is unavailable for the run target.",
+);
+
+impl OrchestrationInvalidModelBehavior {
+    /// Display name for the settings dropdown.
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            OrchestrationInvalidModelBehavior::Block => "Block with an error",
+            OrchestrationInvalidModelBehavior::AutoSelect => "Auto-select a valid model",
+        }
+    }
+
+    pub fn command_palette_description(&self) -> &'static str {
+        match self {
+            OrchestrationInvalidModelBehavior::Block => {
+                "Set unavailable orchestration model behavior: block with an error"
+            }
+            OrchestrationInvalidModelBehavior::AutoSelect => {
+                "Set unavailable orchestration model behavior: auto-select a valid model"
+            }
+        }
+    }
+}
+
 /// Controls what happens when a user submits a new prompt while the agent is
 /// still responding to an earlier prompt.
 ///
@@ -1477,6 +1536,10 @@ define_settings_group!(AISettings, settings: [
 
     // Controls how orchestration message bodies are expanded by default.
     orchestration_message_display_mode: OrchestrationMessageDisplayMode,
+
+    // Controls what happens when an orchestration run-wide model is unavailable
+    // for the chosen run target (block with an error vs. auto-select a valid model).
+    orchestration_invalid_model_behavior: OrchestrationInvalidModelBehavior,
 
     // Default behavior when the user submits a new prompt while the agent is still
     // responding. Per-conversation overrides live on `QueuedQueryModel`; this

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -471,7 +471,7 @@ impl OrchestrationMessageDisplayMode {
     }
 }
 
-/// Controls what happens when an orchestration run-wide model is not available
+/// Controls what happens when an cloud agent run-wide model is not available
 /// for the chosen run target (e.g. a cloud agent run requesting a model Oz does
 /// not accept, or a local-only model selected for a cloud run).
 #[derive(
@@ -487,10 +487,10 @@ impl OrchestrationMessageDisplayMode {
     settings_value::SettingsValue,
 )]
 #[schemars(
-    description = "What happens when an orchestration model is unavailable for the run target.",
+    description = "What happens when a cloud agent model is unavailable for the run target.",
     rename_all = "snake_case"
 )]
-pub enum OrchestrationInvalidModelBehavior {
+pub enum CloudAgentInvalidModelBehavior {
     /// Block the run and surface a clear error so the user can pick a valid
     /// model (default).
     #[default]
@@ -500,31 +500,31 @@ pub enum OrchestrationInvalidModelBehavior {
 }
 
 settings::macros::implement_setting_for_enum!(
-    OrchestrationInvalidModelBehavior,
+    CloudAgentInvalidModelBehavior,
     AISettings,
     SupportedPlatforms::ALL,
     SyncToCloud::Globally(RespectUserSyncSetting::Yes),
     private: false,
-    toml_path: "agents.warp_agent.other.orchestration_invalid_model_behavior",
-    description: "What happens when an orchestration model is unavailable for the run target.",
+    toml_path: "agents.warp_agent.other.cloud_agent_invalid_model_behavior",
+    description: "What happens when a cloud agent model is unavailable for the run target.",
 );
 
-impl OrchestrationInvalidModelBehavior {
+impl CloudAgentInvalidModelBehavior {
     /// Display name for the settings dropdown.
     pub fn display_name(&self) -> &'static str {
         match self {
-            OrchestrationInvalidModelBehavior::Block => "Block the run",
-            OrchestrationInvalidModelBehavior::AutoSelect => "Use a fallback model",
+            CloudAgentInvalidModelBehavior::Block => "Block the run",
+            CloudAgentInvalidModelBehavior::AutoSelect => "Use a fallback model",
         }
     }
 
     pub fn command_palette_description(&self) -> &'static str {
         match self {
-            OrchestrationInvalidModelBehavior::Block => {
-                "Set unavailable orchestration model behavior: block the run"
+            CloudAgentInvalidModelBehavior::Block => {
+                "Set unavailable cloud model behavior: block the run"
             }
-            OrchestrationInvalidModelBehavior::AutoSelect => {
-                "Set unavailable orchestration model behavior: use a fallback model"
+            CloudAgentInvalidModelBehavior::AutoSelect => {
+                "Set unavailable cloud model behavior: use a fallback model"
             }
         }
     }
@@ -1537,21 +1537,21 @@ define_settings_group!(AISettings, settings: [
     // Controls how orchestration message bodies are expanded by default.
     orchestration_message_display_mode: OrchestrationMessageDisplayMode,
 
-    // Controls what happens when an orchestration run-wide model is unavailable
+    // Controls what happens when an cloud agent run-wide model is unavailable
     // for the chosen run target (block the run vs. use a fallback model).
-    orchestration_invalid_model_behavior: OrchestrationInvalidModelBehavior,
+    cloud_agent_invalid_model_behavior: CloudAgentInvalidModelBehavior,
 
-    // The model to fall back to when an orchestration model is unavailable and
-    // `orchestration_invalid_model_behavior` is `Use a fallback model`. An empty
+    // The model to fall back to when a cloud agent model is unavailable and
+    // `cloud_agent_invalid_model_behavior` is `Use a fallback model`. An empty
     // value means "let Warp pick the default".
-    orchestration_fallback_model_id: OrchestrationFallbackModelId {
+    cloud_agent_fallback_model_id: CloudAgentFallbackModelId {
         type: String,
         default: String::new(),
         supported_platforms: SupportedPlatforms::ALL,
         sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
         private: false,
-        toml_path: "agents.warp_agent.other.orchestration_fallback_model_id",
-        description: "The model to fall back to when an orchestration model is unavailable and auto-select is enabled. Empty means use the default.",
+        toml_path: "agents.warp_agent.other.cloud_agent_fallback_model_id",
+        description: "The model to fall back to when a cloud agent model is unavailable and auto-select is enabled. Empty means use the default.",
     }
 
     // Default behavior when the user submits a new prompt while the agent is still

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -94,9 +94,9 @@ use crate::settings::{
     CodebaseContextEnabled, FileBasedMcpEnabled, GitOperationsAutogenEnabled,
     IncludeAgentCommandsInHistory, InputSettings, IntelligentAutosuggestionsEnabled,
     LongRunningCommandSubmissionMode, MemoryEnabled, NLDInTerminalEnabled,
-    NaturalLanguageAutosuggestionsEnabled, OrchestrationInvalidModelBehavior,
-    OrchestrationMessageDisplayMode, PromptSubmissionMode, RuleSuggestionsEnabled,
-    SharedBlockTitleGenerationEnabled, ShouldRenderCLIAgentToolbar,
+    NaturalLanguageAutosuggestionsEnabled, OrchestrationFallbackModelId,
+    OrchestrationInvalidModelBehavior, OrchestrationMessageDisplayMode, PromptSubmissionMode,
+    RuleSuggestionsEnabled, SharedBlockTitleGenerationEnabled, ShouldRenderCLIAgentToolbar,
     ShouldRenderUseAgentToolbarForUserCommands, ShouldShowOzUpdatesInZeroState, ShowAgentTips,
     ShowConversationHistory, ShowHintText, ThinkingDisplayMode, VoiceInputEnabled,
     WarpDriveContextEnabled,
@@ -171,6 +171,7 @@ const PRIMARY_HEADER_FONT_SIZE: f32 = 24.;
 
 const AI_SETTINGS_DROPDOWN_WIDTH: f32 = 250.;
 const AI_SETTINGS_DROPDOWN_MAX_HEIGHT: f32 = 250.;
+const ORCHESTRATION_FALLBACK_DEFAULT_LABEL: &str = "Use the recommended default";
 const CONTEXT_WINDOW_SLIDER_WIDTH: f32 = 220.;
 const CONTEXT_WINDOW_INPUT_BOX_WIDTH: f32 = 120.;
 
@@ -739,6 +740,7 @@ pub struct AISettingsPageView {
     thinking_display_mode_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
     orchestration_message_display_mode_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
     orchestration_invalid_model_behavior_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
+    orchestration_fallback_model_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
     default_prompt_submission_mode_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
     lrc_submission_mode_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
     #[cfg(feature = "local_fs")]
@@ -928,6 +930,18 @@ impl AISettingsPageView {
                 );
             });
         }
+
+        let orchestration_fallback_model_dropdown = ctx.add_typed_action_view(|ctx| {
+            let mut dropdown = Dropdown::new(ctx);
+            dropdown.set_top_bar_max_width(AI_SETTINGS_DROPDOWN_WIDTH);
+            dropdown.set_menu_width(AI_SETTINGS_DROPDOWN_WIDTH, ctx);
+            dropdown.set_menu_max_height(AI_SETTINGS_DROPDOWN_MAX_HEIGHT, ctx);
+            dropdown
+        });
+        Self::refresh_orchestration_fallback_model_menu(
+            &orchestration_fallback_model_dropdown,
+            ctx,
+        );
 
         let default_prompt_submission_mode_dropdown =
             OtherAIWidget::create_default_prompt_submission_mode_dropdown(ctx);
@@ -1186,6 +1200,10 @@ impl AISettingsPageView {
                 LLMPreferencesEvent::UpdatedAvailableLLMs => {
                     Self::refresh_base_model_menu(&me.base_model_dropdown, ctx);
                     Self::refresh_coding_model_menu(&me.coding_model_dropdown, ctx);
+                    Self::refresh_orchestration_fallback_model_menu(
+                        &me.orchestration_fallback_model_dropdown,
+                        ctx,
+                    );
                     me.sync_context_window_editor(ctx, false);
                 }
                 LLMPreferencesEvent::UpdatedActiveAgentModeLLM => {
@@ -1283,6 +1301,10 @@ impl AISettingsPageView {
                     );
                     Self::refresh_base_model_menu(&me.base_model_dropdown, ctx);
                     Self::refresh_coding_model_menu(&me.coding_model_dropdown, ctx);
+                    Self::refresh_orchestration_fallback_model_menu(
+                        &me.orchestration_fallback_model_dropdown,
+                        ctx,
+                    );
                     Self::refresh_mcp_allowlist_dropdown(&me.mcp_allowlist_dropdown, ctx);
                     Self::refresh_mcp_denylist_dropdown(&me.mcp_denylist_dropdown, ctx);
                     me.sync_context_window_editor(ctx, true);
@@ -1382,6 +1404,12 @@ impl AISettingsPageView {
                                 ctx,
                             );
                         },
+                    );
+                }
+                AISettingsChangedEvent::OrchestrationFallbackModelId { .. } => {
+                    Self::refresh_orchestration_fallback_model_menu(
+                        &me.orchestration_fallback_model_dropdown,
+                        ctx,
                     );
                 }
                 AISettingsChangedEvent::PromptSubmissionMode { .. } => {
@@ -2019,6 +2047,7 @@ impl AISettingsPageView {
             thinking_display_mode_dropdown,
             orchestration_message_display_mode_dropdown,
             orchestration_invalid_model_behavior_dropdown,
+            orchestration_fallback_model_dropdown,
             default_prompt_submission_mode_dropdown,
             lrc_submission_mode_dropdown,
             #[cfg(feature = "local_fs")]
@@ -3155,6 +3184,50 @@ impl AISettingsPageView {
         ctx.notify();
     }
 
+    /// Populates the orchestration fallback-model dropdown with a "use the
+    /// recommended default" entry followed by the models available for cloud
+    /// agents, selecting the currently-configured fallback.
+    pub fn refresh_orchestration_fallback_model_menu(
+        menu: &ViewHandle<Dropdown<AISettingsPageAction>>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        menu.update(ctx, |menu, ctx| {
+            if AISettings::as_ref(ctx).is_any_ai_enabled(ctx) {
+                menu.set_enabled(ctx);
+            } else {
+                menu.set_disabled(ctx);
+            }
+
+            let mut items = vec![DropdownItem::new(
+                ORCHESTRATION_FALLBACK_DEFAULT_LABEL,
+                AISettingsPageAction::SetOrchestrationFallbackModelId(String::new()),
+            )];
+            let models: Vec<(String, String)> = LLMPreferences::as_ref(ctx)
+                .oz_cloud_agent_models()
+                .into_iter()
+                .map(|llm| (llm.menu_display_name(), llm.id.to_string()))
+                .collect();
+            for (display_name, id) in models {
+                items.push(DropdownItem::new(
+                    display_name,
+                    AISettingsPageAction::SetOrchestrationFallbackModelId(id),
+                ));
+            }
+            menu.set_items(items, ctx);
+
+            let current = AISettings::as_ref(ctx)
+                .orchestration_fallback_model_id
+                .value()
+                .clone();
+            menu.set_selected_by_action(
+                AISettingsPageAction::SetOrchestrationFallbackModelId(current),
+                ctx,
+            );
+            ctx.notify();
+        });
+        ctx.notify();
+    }
+
     fn refresh_autonomy_dropdown_menu(
         menu: &ViewHandle<Dropdown<AISettingsPageAction>>,
         ctx: &mut ViewContext<Self>,
@@ -3637,6 +3710,7 @@ pub enum AISettingsPageAction {
     SetThinkingDisplayMode(ThinkingDisplayMode),
     SetOrchestrationMessageDisplayMode(OrchestrationMessageDisplayMode),
     SetOrchestrationInvalidModelBehavior(OrchestrationInvalidModelBehavior),
+    SetOrchestrationFallbackModelId(String),
     SetPromptSubmissionMode(PromptSubmissionMode),
     SetLongRunningCommandSubmissionMode(LongRunningCommandSubmissionMode),
     AttemptLoginGatedUpgrade,
@@ -4116,6 +4190,14 @@ impl TypedActionView for AISettingsPageView {
                     report_if_error!(settings
                         .orchestration_invalid_model_behavior
                         .set_value(*mode, ctx));
+                });
+                ctx.notify();
+            }
+            AISettingsPageAction::SetOrchestrationFallbackModelId(model_id) => {
+                AISettings::handle(ctx).update(ctx, |settings, ctx| {
+                    report_if_error!(settings
+                        .orchestration_fallback_model_id
+                        .set_value(model_id.clone(), ctx));
                 });
                 ctx.notify();
             }
@@ -7435,7 +7517,7 @@ impl SettingsWidget for OtherAIWidget {
             appearance,
             "Unavailable orchestration model",
             Some(
-                "What happens when an agent's model isn't available for the run target: block with an error or auto-select a valid model.",
+                "What happens when an agent's model isn't available for the run target: block the run or use a fallback model.",
             ),
             None,
             LocalOnlyIconState::for_setting(
@@ -7447,6 +7529,29 @@ impl SettingsWidget for OtherAIWidget {
             (!is_any_ai_enabled).then(|| appearance.theme().disabled_ui_text_color()),
             &view.orchestration_invalid_model_behavior_dropdown,
         ));
+
+        // Only show the fallback-model picker when the behavior is to use a
+        // fallback model (not when blocking).
+        if ai_settings.orchestration_invalid_model_behavior
+            == OrchestrationInvalidModelBehavior::AutoSelect
+        {
+            column.add_child(render_dropdown_item(
+                appearance,
+                "Fallback model",
+                Some(
+                    "The model to use when an agent's selected model isn't available for the run target.",
+                ),
+                None,
+                LocalOnlyIconState::for_setting(
+                    OrchestrationFallbackModelId::storage_key(),
+                    OrchestrationFallbackModelId::sync_to_cloud(),
+                    &mut view.local_only_icon_tooltip_states.borrow_mut(),
+                    app,
+                ),
+                (!is_any_ai_enabled).then(|| appearance.theme().disabled_ui_text_color()),
+                &view.orchestration_fallback_model_dropdown,
+            ));
+        }
 
         // TODO: OpenConversationLayoutPreference should not depend on local_fs, but it lives under the external editor settings
         // which does require local_fs. It was a mistake to put it there, but now we keep it there for backward compatibility.

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -94,8 +94,9 @@ use crate::settings::{
     CodebaseContextEnabled, FileBasedMcpEnabled, GitOperationsAutogenEnabled,
     IncludeAgentCommandsInHistory, InputSettings, IntelligentAutosuggestionsEnabled,
     LongRunningCommandSubmissionMode, MemoryEnabled, NLDInTerminalEnabled,
-    NaturalLanguageAutosuggestionsEnabled, OrchestrationMessageDisplayMode, PromptSubmissionMode,
-    RuleSuggestionsEnabled, SharedBlockTitleGenerationEnabled, ShouldRenderCLIAgentToolbar,
+    NaturalLanguageAutosuggestionsEnabled, OrchestrationInvalidModelBehavior,
+    OrchestrationMessageDisplayMode, PromptSubmissionMode, RuleSuggestionsEnabled,
+    SharedBlockTitleGenerationEnabled, ShouldRenderCLIAgentToolbar,
     ShouldRenderUseAgentToolbarForUserCommands, ShouldShowOzUpdatesInZeroState, ShowAgentTips,
     ShowConversationHistory, ShowHintText, ThinkingDisplayMode, VoiceInputEnabled,
     WarpDriveContextEnabled,
@@ -370,6 +371,32 @@ pub fn init_actions_from_parent_view<T: Action + Clone>(
                     mode.command_palette_description(),
                     builder(SettingsAction::AI(
                         AISettingsPageAction::SetOrchestrationMessageDisplayMode(mode),
+                    )),
+                    ai_context.clone() & !id!(context_flag),
+                )
+                .with_group(bindings::BindingGroup::WarpAi.as_str())
+            })
+            .collect();
+        app.register_fixed_bindings(mode_bindings);
+    }
+    {
+        use warpui::keymap::FixedBinding;
+
+        let ai_context = context.clone() & id!(flags::IS_ANY_AI_ENABLED);
+        let mode_bindings: Vec<FixedBinding> = OrchestrationInvalidModelBehavior::iter()
+            .map(|mode| {
+                let context_flag = match mode {
+                    OrchestrationInvalidModelBehavior::Block => {
+                        flags::ORCHESTRATION_INVALID_MODEL_BLOCK
+                    }
+                    OrchestrationInvalidModelBehavior::AutoSelect => {
+                        flags::ORCHESTRATION_INVALID_MODEL_AUTO_SELECT
+                    }
+                };
+                FixedBinding::empty(
+                    mode.command_palette_description(),
+                    builder(SettingsAction::AI(
+                        AISettingsPageAction::SetOrchestrationInvalidModelBehavior(mode),
                     )),
                     ai_context.clone() & !id!(context_flag),
                 )
@@ -711,6 +738,7 @@ pub struct AISettingsPageView {
 
     thinking_display_mode_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
     orchestration_message_display_mode_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
+    orchestration_invalid_model_behavior_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
     default_prompt_submission_mode_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
     lrc_submission_mode_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
     #[cfg(feature = "local_fs")]
@@ -885,6 +913,17 @@ impl AISettingsPageView {
             orchestration_message_display_mode_dropdown.update(ctx, |dropdown, ctx| {
                 dropdown.set_selected_by_action(
                     AISettingsPageAction::SetOrchestrationMessageDisplayMode(current_mode),
+                    ctx,
+                );
+            });
+        }
+        let orchestration_invalid_model_behavior_dropdown =
+            OtherAIWidget::create_orchestration_invalid_model_behavior_dropdown(ctx);
+        {
+            let current_mode = AISettings::as_ref(ctx).orchestration_invalid_model_behavior;
+            orchestration_invalid_model_behavior_dropdown.update(ctx, |dropdown, ctx| {
+                dropdown.set_selected_by_action(
+                    AISettingsPageAction::SetOrchestrationInvalidModelBehavior(current_mode),
                     ctx,
                 );
             });
@@ -1330,6 +1369,20 @@ impl AISettingsPageView {
                                 ctx,
                             );
                         });
+                }
+                AISettingsChangedEvent::OrchestrationInvalidModelBehavior { .. } => {
+                    let current_mode = AISettings::as_ref(ctx).orchestration_invalid_model_behavior;
+                    me.orchestration_invalid_model_behavior_dropdown.update(
+                        ctx,
+                        |dropdown, ctx| {
+                            dropdown.set_selected_by_action(
+                                AISettingsPageAction::SetOrchestrationInvalidModelBehavior(
+                                    current_mode,
+                                ),
+                                ctx,
+                            );
+                        },
+                    );
                 }
                 AISettingsChangedEvent::PromptSubmissionMode { .. } => {
                     let current_mode = AISettings::as_ref(ctx).default_prompt_submission_mode;
@@ -1965,6 +2018,7 @@ impl AISettingsPageView {
             mcp_denylist_mouse_state_handles,
             thinking_display_mode_dropdown,
             orchestration_message_display_mode_dropdown,
+            orchestration_invalid_model_behavior_dropdown,
             default_prompt_submission_mode_dropdown,
             lrc_submission_mode_dropdown,
             #[cfg(feature = "local_fs")]
@@ -3582,6 +3636,7 @@ pub enum AISettingsPageAction {
     ToggleShowOzUpdatesInZeroState,
     SetThinkingDisplayMode(ThinkingDisplayMode),
     SetOrchestrationMessageDisplayMode(OrchestrationMessageDisplayMode),
+    SetOrchestrationInvalidModelBehavior(OrchestrationInvalidModelBehavior),
     SetPromptSubmissionMode(PromptSubmissionMode),
     SetLongRunningCommandSubmissionMode(LongRunningCommandSubmissionMode),
     AttemptLoginGatedUpgrade,
@@ -4052,6 +4107,14 @@ impl TypedActionView for AISettingsPageView {
                 AISettings::handle(ctx).update(ctx, |settings, ctx| {
                     report_if_error!(settings
                         .orchestration_message_display_mode
+                        .set_value(*mode, ctx));
+                });
+                ctx.notify();
+            }
+            AISettingsPageAction::SetOrchestrationInvalidModelBehavior(mode) => {
+                AISettings::handle(ctx).update(ctx, |settings, ctx| {
+                    report_if_error!(settings
+                        .orchestration_invalid_model_behavior
                         .set_value(*mode, ctx));
                 });
                 ctx.notify();
@@ -7238,6 +7301,29 @@ impl OtherAIWidget {
             dropdown
         })
     }
+
+    fn create_orchestration_invalid_model_behavior_dropdown(
+        ctx: &mut ViewContext<AISettingsPageView>,
+    ) -> ViewHandle<Dropdown<AISettingsPageAction>> {
+        let items: Vec<DropdownItem<AISettingsPageAction>> =
+            OrchestrationInvalidModelBehavior::iter()
+                .map(|mode| {
+                    DropdownItem::new(
+                        mode.display_name(),
+                        AISettingsPageAction::SetOrchestrationInvalidModelBehavior(mode),
+                    )
+                })
+                .collect();
+
+        ctx.add_typed_action_view(|ctx| {
+            let mut dropdown = Dropdown::new(ctx);
+            dropdown.set_top_bar_max_width(AI_SETTINGS_DROPDOWN_WIDTH);
+            dropdown.set_menu_width(AI_SETTINGS_DROPDOWN_WIDTH, ctx);
+            dropdown.set_menu_max_height(AI_SETTINGS_DROPDOWN_MAX_HEIGHT, ctx);
+            dropdown.add_items(items, ctx);
+            dropdown
+        })
+    }
 }
 
 impl SettingsWidget for OtherAIWidget {
@@ -7343,6 +7429,23 @@ impl SettingsWidget for OtherAIWidget {
             ),
             (!is_any_ai_enabled).then(|| appearance.theme().disabled_ui_text_color()),
             &view.orchestration_message_display_mode_dropdown,
+        ));
+
+        column.add_child(render_dropdown_item(
+            appearance,
+            "Unavailable orchestration model",
+            Some(
+                "What happens when an agent's model isn't available for the run target: block with an error or auto-select a valid model.",
+            ),
+            None,
+            LocalOnlyIconState::for_setting(
+                OrchestrationInvalidModelBehavior::storage_key(),
+                OrchestrationInvalidModelBehavior::sync_to_cloud(),
+                &mut view.local_only_icon_tooltip_states.borrow_mut(),
+                app,
+            ),
+            (!is_any_ai_enabled).then(|| appearance.theme().disabled_ui_text_color()),
+            &view.orchestration_invalid_model_behavior_dropdown,
         ));
 
         // TODO: OpenConversationLayoutPreference should not depend on local_fs, but it lives under the external editor settings

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -90,16 +90,15 @@ use crate::settings::{
     AIAutoDetectionEnabled, AICommandDenylist, AISettingsChangedEvent,
     AgentModeCodingPermissionsType, AgentModeCommandExecutionDenylist,
     AgentModeCommandExecutionPredicate, AgentModeQuerySuggestionsEnabled, AwsBedrockAutoLogin,
-    AwsBedrockCredentialsEnabled, CanUseWarpCreditsForFallback, CodeSettings,
-    CodebaseContextEnabled, FileBasedMcpEnabled, GitOperationsAutogenEnabled,
-    IncludeAgentCommandsInHistory, InputSettings, IntelligentAutosuggestionsEnabled,
-    LongRunningCommandSubmissionMode, MemoryEnabled, NLDInTerminalEnabled,
-    NaturalLanguageAutosuggestionsEnabled, OrchestrationFallbackModelId,
-    OrchestrationInvalidModelBehavior, OrchestrationMessageDisplayMode, PromptSubmissionMode,
-    RuleSuggestionsEnabled, SharedBlockTitleGenerationEnabled, ShouldRenderCLIAgentToolbar,
-    ShouldRenderUseAgentToolbarForUserCommands, ShouldShowOzUpdatesInZeroState, ShowAgentTips,
-    ShowConversationHistory, ShowHintText, ThinkingDisplayMode, VoiceInputEnabled,
-    WarpDriveContextEnabled,
+    AwsBedrockCredentialsEnabled, CanUseWarpCreditsForFallback, CloudAgentFallbackModelId,
+    CloudAgentInvalidModelBehavior, CodeSettings, CodebaseContextEnabled, FileBasedMcpEnabled,
+    GitOperationsAutogenEnabled, IncludeAgentCommandsInHistory, InputSettings,
+    IntelligentAutosuggestionsEnabled, LongRunningCommandSubmissionMode, MemoryEnabled,
+    NLDInTerminalEnabled, NaturalLanguageAutosuggestionsEnabled, OrchestrationMessageDisplayMode,
+    PromptSubmissionMode, RuleSuggestionsEnabled, SharedBlockTitleGenerationEnabled,
+    ShouldRenderCLIAgentToolbar, ShouldRenderUseAgentToolbarForUserCommands,
+    ShouldShowOzUpdatesInZeroState, ShowAgentTips, ShowConversationHistory, ShowHintText,
+    ThinkingDisplayMode, VoiceInputEnabled, WarpDriveContextEnabled,
 };
 use crate::terminal::session_settings::{SessionSettings, SessionSettingsChangedEvent};
 use crate::terminal::CLIAgent;
@@ -171,7 +170,7 @@ const PRIMARY_HEADER_FONT_SIZE: f32 = 24.;
 
 const AI_SETTINGS_DROPDOWN_WIDTH: f32 = 250.;
 const AI_SETTINGS_DROPDOWN_MAX_HEIGHT: f32 = 250.;
-const ORCHESTRATION_FALLBACK_DEFAULT_LABEL: &str = "Use the recommended default";
+const CLOUD_AGENT_FALLBACK_DEFAULT_LABEL: &str = "Use the recommended default";
 const CONTEXT_WINDOW_SLIDER_WIDTH: f32 = 220.;
 const CONTEXT_WINDOW_INPUT_BOX_WIDTH: f32 = 120.;
 
@@ -384,20 +383,18 @@ pub fn init_actions_from_parent_view<T: Action + Clone>(
         use warpui::keymap::FixedBinding;
 
         let ai_context = context.clone() & id!(flags::IS_ANY_AI_ENABLED);
-        let mode_bindings: Vec<FixedBinding> = OrchestrationInvalidModelBehavior::iter()
+        let mode_bindings: Vec<FixedBinding> = CloudAgentInvalidModelBehavior::iter()
             .map(|mode| {
                 let context_flag = match mode {
-                    OrchestrationInvalidModelBehavior::Block => {
-                        flags::ORCHESTRATION_INVALID_MODEL_BLOCK
-                    }
-                    OrchestrationInvalidModelBehavior::AutoSelect => {
-                        flags::ORCHESTRATION_INVALID_MODEL_AUTO_SELECT
+                    CloudAgentInvalidModelBehavior::Block => flags::CLOUD_AGENT_INVALID_MODEL_BLOCK,
+                    CloudAgentInvalidModelBehavior::AutoSelect => {
+                        flags::CLOUD_AGENT_INVALID_MODEL_AUTO_SELECT
                     }
                 };
                 FixedBinding::empty(
                     mode.command_palette_description(),
                     builder(SettingsAction::AI(
-                        AISettingsPageAction::SetOrchestrationInvalidModelBehavior(mode),
+                        AISettingsPageAction::SetCloudAgentInvalidModelBehavior(mode),
                     )),
                     ai_context.clone() & !id!(context_flag),
                 )
@@ -739,8 +736,8 @@ pub struct AISettingsPageView {
 
     thinking_display_mode_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
     orchestration_message_display_mode_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
-    orchestration_invalid_model_behavior_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
-    orchestration_fallback_model_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
+    cloud_agent_invalid_model_behavior_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
+    cloud_agent_fallback_model_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
     default_prompt_submission_mode_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
     lrc_submission_mode_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
     #[cfg(feature = "local_fs")]
@@ -919,29 +916,26 @@ impl AISettingsPageView {
                 );
             });
         }
-        let orchestration_invalid_model_behavior_dropdown =
-            OtherAIWidget::create_orchestration_invalid_model_behavior_dropdown(ctx);
+        let cloud_agent_invalid_model_behavior_dropdown =
+            OtherAIWidget::create_cloud_agent_invalid_model_behavior_dropdown(ctx);
         {
-            let current_mode = AISettings::as_ref(ctx).orchestration_invalid_model_behavior;
-            orchestration_invalid_model_behavior_dropdown.update(ctx, |dropdown, ctx| {
+            let current_mode = AISettings::as_ref(ctx).cloud_agent_invalid_model_behavior;
+            cloud_agent_invalid_model_behavior_dropdown.update(ctx, |dropdown, ctx| {
                 dropdown.set_selected_by_action(
-                    AISettingsPageAction::SetOrchestrationInvalidModelBehavior(current_mode),
+                    AISettingsPageAction::SetCloudAgentInvalidModelBehavior(current_mode),
                     ctx,
                 );
             });
         }
 
-        let orchestration_fallback_model_dropdown = ctx.add_typed_action_view(|ctx| {
+        let cloud_agent_fallback_model_dropdown = ctx.add_typed_action_view(|ctx| {
             let mut dropdown = Dropdown::new(ctx);
             dropdown.set_top_bar_max_width(AI_SETTINGS_DROPDOWN_WIDTH);
             dropdown.set_menu_width(AI_SETTINGS_DROPDOWN_WIDTH, ctx);
             dropdown.set_menu_max_height(AI_SETTINGS_DROPDOWN_MAX_HEIGHT, ctx);
             dropdown
         });
-        Self::refresh_orchestration_fallback_model_menu(
-            &orchestration_fallback_model_dropdown,
-            ctx,
-        );
+        Self::refresh_cloud_agent_fallback_model_menu(&cloud_agent_fallback_model_dropdown, ctx);
 
         let default_prompt_submission_mode_dropdown =
             OtherAIWidget::create_default_prompt_submission_mode_dropdown(ctx);
@@ -1200,8 +1194,8 @@ impl AISettingsPageView {
                 LLMPreferencesEvent::UpdatedAvailableLLMs => {
                     Self::refresh_base_model_menu(&me.base_model_dropdown, ctx);
                     Self::refresh_coding_model_menu(&me.coding_model_dropdown, ctx);
-                    Self::refresh_orchestration_fallback_model_menu(
-                        &me.orchestration_fallback_model_dropdown,
+                    Self::refresh_cloud_agent_fallback_model_menu(
+                        &me.cloud_agent_fallback_model_dropdown,
                         ctx,
                     );
                     me.sync_context_window_editor(ctx, false);
@@ -1301,8 +1295,8 @@ impl AISettingsPageView {
                     );
                     Self::refresh_base_model_menu(&me.base_model_dropdown, ctx);
                     Self::refresh_coding_model_menu(&me.coding_model_dropdown, ctx);
-                    Self::refresh_orchestration_fallback_model_menu(
-                        &me.orchestration_fallback_model_dropdown,
+                    Self::refresh_cloud_agent_fallback_model_menu(
+                        &me.cloud_agent_fallback_model_dropdown,
                         ctx,
                     );
                     Self::refresh_mcp_allowlist_dropdown(&me.mcp_allowlist_dropdown, ctx);
@@ -1392,23 +1386,21 @@ impl AISettingsPageView {
                             );
                         });
                 }
-                AISettingsChangedEvent::OrchestrationInvalidModelBehavior { .. } => {
-                    let current_mode = AISettings::as_ref(ctx).orchestration_invalid_model_behavior;
-                    me.orchestration_invalid_model_behavior_dropdown.update(
-                        ctx,
-                        |dropdown, ctx| {
+                AISettingsChangedEvent::CloudAgentInvalidModelBehavior { .. } => {
+                    let current_mode = AISettings::as_ref(ctx).cloud_agent_invalid_model_behavior;
+                    me.cloud_agent_invalid_model_behavior_dropdown
+                        .update(ctx, |dropdown, ctx| {
                             dropdown.set_selected_by_action(
-                                AISettingsPageAction::SetOrchestrationInvalidModelBehavior(
+                                AISettingsPageAction::SetCloudAgentInvalidModelBehavior(
                                     current_mode,
                                 ),
                                 ctx,
                             );
-                        },
-                    );
+                        });
                 }
-                AISettingsChangedEvent::OrchestrationFallbackModelId { .. } => {
-                    Self::refresh_orchestration_fallback_model_menu(
-                        &me.orchestration_fallback_model_dropdown,
+                AISettingsChangedEvent::CloudAgentFallbackModelId { .. } => {
+                    Self::refresh_cloud_agent_fallback_model_menu(
+                        &me.cloud_agent_fallback_model_dropdown,
                         ctx,
                     );
                 }
@@ -2046,8 +2038,8 @@ impl AISettingsPageView {
             mcp_denylist_mouse_state_handles,
             thinking_display_mode_dropdown,
             orchestration_message_display_mode_dropdown,
-            orchestration_invalid_model_behavior_dropdown,
-            orchestration_fallback_model_dropdown,
+            cloud_agent_invalid_model_behavior_dropdown,
+            cloud_agent_fallback_model_dropdown,
             default_prompt_submission_mode_dropdown,
             lrc_submission_mode_dropdown,
             #[cfg(feature = "local_fs")]
@@ -3187,7 +3179,7 @@ impl AISettingsPageView {
     /// Populates the orchestration fallback-model dropdown with a "use the
     /// recommended default" entry followed by the models available for cloud
     /// agents, selecting the currently-configured fallback.
-    pub fn refresh_orchestration_fallback_model_menu(
+    pub fn refresh_cloud_agent_fallback_model_menu(
         menu: &ViewHandle<Dropdown<AISettingsPageAction>>,
         ctx: &mut ViewContext<Self>,
     ) {
@@ -3199,8 +3191,8 @@ impl AISettingsPageView {
             }
 
             let mut items = vec![DropdownItem::new(
-                ORCHESTRATION_FALLBACK_DEFAULT_LABEL,
-                AISettingsPageAction::SetOrchestrationFallbackModelId(String::new()),
+                CLOUD_AGENT_FALLBACK_DEFAULT_LABEL,
+                AISettingsPageAction::SetCloudAgentFallbackModelId(String::new()),
             )];
             let models: Vec<(String, String)> = LLMPreferences::as_ref(ctx)
                 .oz_cloud_agent_models()
@@ -3210,17 +3202,17 @@ impl AISettingsPageView {
             for (display_name, id) in models {
                 items.push(DropdownItem::new(
                     display_name,
-                    AISettingsPageAction::SetOrchestrationFallbackModelId(id),
+                    AISettingsPageAction::SetCloudAgentFallbackModelId(id),
                 ));
             }
             menu.set_items(items, ctx);
 
             let current = AISettings::as_ref(ctx)
-                .orchestration_fallback_model_id
+                .cloud_agent_fallback_model_id
                 .value()
                 .clone();
             menu.set_selected_by_action(
-                AISettingsPageAction::SetOrchestrationFallbackModelId(current),
+                AISettingsPageAction::SetCloudAgentFallbackModelId(current),
                 ctx,
             );
             ctx.notify();
@@ -3709,8 +3701,8 @@ pub enum AISettingsPageAction {
     ToggleShowOzUpdatesInZeroState,
     SetThinkingDisplayMode(ThinkingDisplayMode),
     SetOrchestrationMessageDisplayMode(OrchestrationMessageDisplayMode),
-    SetOrchestrationInvalidModelBehavior(OrchestrationInvalidModelBehavior),
-    SetOrchestrationFallbackModelId(String),
+    SetCloudAgentInvalidModelBehavior(CloudAgentInvalidModelBehavior),
+    SetCloudAgentFallbackModelId(String),
     SetPromptSubmissionMode(PromptSubmissionMode),
     SetLongRunningCommandSubmissionMode(LongRunningCommandSubmissionMode),
     AttemptLoginGatedUpgrade,
@@ -4185,18 +4177,18 @@ impl TypedActionView for AISettingsPageView {
                 });
                 ctx.notify();
             }
-            AISettingsPageAction::SetOrchestrationInvalidModelBehavior(mode) => {
+            AISettingsPageAction::SetCloudAgentInvalidModelBehavior(mode) => {
                 AISettings::handle(ctx).update(ctx, |settings, ctx| {
                     report_if_error!(settings
-                        .orchestration_invalid_model_behavior
+                        .cloud_agent_invalid_model_behavior
                         .set_value(*mode, ctx));
                 });
                 ctx.notify();
             }
-            AISettingsPageAction::SetOrchestrationFallbackModelId(model_id) => {
+            AISettingsPageAction::SetCloudAgentFallbackModelId(model_id) => {
                 AISettings::handle(ctx).update(ctx, |settings, ctx| {
                     report_if_error!(settings
-                        .orchestration_fallback_model_id
+                        .cloud_agent_fallback_model_id
                         .set_value(model_id.clone(), ctx));
                 });
                 ctx.notify();
@@ -7384,18 +7376,17 @@ impl OtherAIWidget {
         })
     }
 
-    fn create_orchestration_invalid_model_behavior_dropdown(
+    fn create_cloud_agent_invalid_model_behavior_dropdown(
         ctx: &mut ViewContext<AISettingsPageView>,
     ) -> ViewHandle<Dropdown<AISettingsPageAction>> {
-        let items: Vec<DropdownItem<AISettingsPageAction>> =
-            OrchestrationInvalidModelBehavior::iter()
-                .map(|mode| {
-                    DropdownItem::new(
-                        mode.display_name(),
-                        AISettingsPageAction::SetOrchestrationInvalidModelBehavior(mode),
-                    )
-                })
-                .collect();
+        let items: Vec<DropdownItem<AISettingsPageAction>> = CloudAgentInvalidModelBehavior::iter()
+            .map(|mode| {
+                DropdownItem::new(
+                    mode.display_name(),
+                    AISettingsPageAction::SetCloudAgentInvalidModelBehavior(mode),
+                )
+            })
+            .collect();
 
         ctx.add_typed_action_view(|ctx| {
             let mut dropdown = Dropdown::new(ctx);
@@ -7515,25 +7506,25 @@ impl SettingsWidget for OtherAIWidget {
 
         column.add_child(render_dropdown_item(
             appearance,
-            "Unavailable orchestration model",
+            "Unavailable cloud model",
             Some(
                 "What happens when an agent's model isn't available for the run target: block the run or use a fallback model.",
             ),
             None,
             LocalOnlyIconState::for_setting(
-                OrchestrationInvalidModelBehavior::storage_key(),
-                OrchestrationInvalidModelBehavior::sync_to_cloud(),
+                CloudAgentInvalidModelBehavior::storage_key(),
+                CloudAgentInvalidModelBehavior::sync_to_cloud(),
                 &mut view.local_only_icon_tooltip_states.borrow_mut(),
                 app,
             ),
             (!is_any_ai_enabled).then(|| appearance.theme().disabled_ui_text_color()),
-            &view.orchestration_invalid_model_behavior_dropdown,
+            &view.cloud_agent_invalid_model_behavior_dropdown,
         ));
 
         // Only show the fallback-model picker when the behavior is to use a
         // fallback model (not when blocking).
-        if ai_settings.orchestration_invalid_model_behavior
-            == OrchestrationInvalidModelBehavior::AutoSelect
+        if ai_settings.cloud_agent_invalid_model_behavior
+            == CloudAgentInvalidModelBehavior::AutoSelect
         {
             column.add_child(render_dropdown_item(
                 appearance,
@@ -7543,13 +7534,13 @@ impl SettingsWidget for OtherAIWidget {
                 ),
                 None,
                 LocalOnlyIconState::for_setting(
-                    OrchestrationFallbackModelId::storage_key(),
-                    OrchestrationFallbackModelId::sync_to_cloud(),
+                    CloudAgentFallbackModelId::storage_key(),
+                    CloudAgentFallbackModelId::sync_to_cloud(),
                     &mut view.local_only_icon_tooltip_states.borrow_mut(),
                     app,
                 ),
                 (!is_any_ai_enabled).then(|| appearance.theme().disabled_ui_text_color()),
-                &view.orchestration_fallback_model_dropdown,
+                &view.cloud_agent_fallback_model_dropdown,
             ));
         }
 

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -521,6 +521,9 @@ pub mod flags {
         "Orchestration_Message_Display_AlwaysShow";
     pub const ORCHESTRATION_MESSAGE_DISPLAY_ALWAYS_COLLAPSE: &str =
         "Orchestration_Message_Display_AlwaysCollapse";
+    pub const ORCHESTRATION_INVALID_MODEL_BLOCK: &str = "Orchestration_Invalid_Model_Block";
+    pub const ORCHESTRATION_INVALID_MODEL_AUTO_SELECT: &str =
+        "Orchestration_Invalid_Model_AutoSelect";
     pub const PROMPT_SUBMISSION_INTERRUPT: &str = "Prompt_Submission_Interrupt";
     pub const PROMPT_SUBMISSION_QUEUE: &str = "Prompt_Submission_Queue";
     pub const LRC_SUBMISSION_SEND_IMMEDIATELY: &str = "LRC_Submission_Send_Immediately";

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -521,9 +521,8 @@ pub mod flags {
         "Orchestration_Message_Display_AlwaysShow";
     pub const ORCHESTRATION_MESSAGE_DISPLAY_ALWAYS_COLLAPSE: &str =
         "Orchestration_Message_Display_AlwaysCollapse";
-    pub const ORCHESTRATION_INVALID_MODEL_BLOCK: &str = "Orchestration_Invalid_Model_Block";
-    pub const ORCHESTRATION_INVALID_MODEL_AUTO_SELECT: &str =
-        "Orchestration_Invalid_Model_AutoSelect";
+    pub const CLOUD_AGENT_INVALID_MODEL_BLOCK: &str = "Cloud_Agent_Invalid_Model_Block";
+    pub const CLOUD_AGENT_INVALID_MODEL_AUTO_SELECT: &str = "Cloud_Agent_Invalid_Model_AutoSelect";
     pub const PROMPT_SUBMISSION_INTERRUPT: &str = "Prompt_Submission_Interrupt";
     pub const PROMPT_SUBMISSION_QUEUE: &str = "Prompt_Submission_Queue";
     pub const LRC_SUBMISSION_SEND_IMMEDIATELY: &str = "LRC_Submission_Send_Immediately";

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -25,6 +25,9 @@ use crate::ai::ambient_agents::{
 use crate::ai::blocklist::handoff::touched_repos::TouchedWorkspace;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::blocklist::handoff::PendingCloudLaunch;
+use crate::ai::blocklist::inline_action::orchestration_controls::{
+    resolve_orchestration_fallback_model_id, unavailable_model_reason,
+};
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
 use crate::ai::execution_profiles::{
@@ -44,7 +47,7 @@ use crate::server::server_api::ai::{
 use crate::server::server_api::{
     AIApiError, ClientError, CloudAgentCapacityError, ServerApiProvider,
 };
-use crate::settings::PrivacySettings;
+use crate::settings::{AISettings, OrchestrationInvalidModelBehavior, PrivacySettings};
 use crate::terminal::view::ambient_agent::{SetupCommandGroupId, SetupCommandState};
 use crate::terminal::CLIAgent;
 use crate::workspaces::user_workspaces::UserWorkspaces;
@@ -1282,6 +1285,41 @@ impl AmbientAgentViewModel {
     /// handoff snapshot has settled, without re-running the UI transition that
     /// [`Self::queue_handoff_auto_submit`] already performed.
     fn start_spawn_stream(&mut self, mut request: SpawnAgentRequest, ctx: &mut ModelContext<Self>) {
+        // Pre-spawn cloud model gate: mirror the orchestration model validation
+        // for single cloud-agent launches (initial spawn + local-to-cloud
+        // handoff, which both route through here). Only the Oz base model is
+        // validated; non-Oz harnesses manage their own model catalogs. Under
+        // Block, surface a failure and don't spawn; under auto-select, substitute
+        // a valid fallback model.
+        let is_oz_cloud = request.config.as_ref().is_none_or(|c| c.harness.is_none());
+        if is_oz_cloud {
+            let model_id = request
+                .config
+                .as_ref()
+                .and_then(|c| c.model_id.clone())
+                .unwrap_or_default();
+            if let Some(reason) = unavailable_model_reason(&model_id, "oz", false, ctx) {
+                let behavior = AISettings::as_ref(ctx).orchestration_invalid_model_behavior;
+                match behavior {
+                    OrchestrationInvalidModelBehavior::Block => {
+                        self.handle_spawn_error(reason, ctx);
+                        return;
+                    }
+                    OrchestrationInvalidModelBehavior::AutoSelect => {
+                        let fallback = resolve_orchestration_fallback_model_id(ctx);
+                        let substitute =
+                            if unavailable_model_reason(&fallback, "oz", false, ctx).is_none() {
+                                (!fallback.is_empty()).then_some(fallback)
+                            } else {
+                                None
+                            };
+                        if let Some(config) = request.config.as_mut() {
+                            config.model_id = substitute;
+                        }
+                    }
+                }
+            }
+        }
         request.interactive = Some(true);
         self.request = Some(request.clone());
         self.source = None;
@@ -1297,6 +1335,11 @@ impl AmbientAgentViewModel {
     /// Spawn an ambient agent given `request`.
     fn spawn_internal(&mut self, request: SpawnAgentRequest, ctx: &mut ModelContext<Self>) {
         self.start_spawn_stream(request, ctx);
+        // If the pre-spawn model gate blocked the run, it already transitioned to
+        // Failed; don't overwrite that with WaitingForSession.
+        if matches!(self.status, Status::Failed { .. }) {
+            return;
+        }
         self.status = Status::WaitingForSession {
             progress: AgentProgress::new(),
             kind: SessionStartupKind::InitialRun,

--- a/app/src/terminal/view/ambient_agent/model.rs
+++ b/app/src/terminal/view/ambient_agent/model.rs
@@ -26,7 +26,7 @@ use crate::ai::blocklist::handoff::touched_repos::TouchedWorkspace;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::ai::blocklist::handoff::PendingCloudLaunch;
 use crate::ai::blocklist::inline_action::orchestration_controls::{
-    resolve_orchestration_fallback_model_id, unavailable_model_reason,
+    resolve_cloud_agent_fallback_model_id, unavailable_model_reason,
 };
 use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
@@ -47,7 +47,7 @@ use crate::server::server_api::ai::{
 use crate::server::server_api::{
     AIApiError, ClientError, CloudAgentCapacityError, ServerApiProvider,
 };
-use crate::settings::{AISettings, OrchestrationInvalidModelBehavior, PrivacySettings};
+use crate::settings::{AISettings, CloudAgentInvalidModelBehavior, PrivacySettings};
 use crate::terminal::view::ambient_agent::{SetupCommandGroupId, SetupCommandState};
 use crate::terminal::CLIAgent;
 use crate::workspaces::user_workspaces::UserWorkspaces;
@@ -1299,14 +1299,14 @@ impl AmbientAgentViewModel {
                 .and_then(|c| c.model_id.clone())
                 .unwrap_or_default();
             if let Some(reason) = unavailable_model_reason(&model_id, "oz", false, ctx) {
-                let behavior = AISettings::as_ref(ctx).orchestration_invalid_model_behavior;
+                let behavior = AISettings::as_ref(ctx).cloud_agent_invalid_model_behavior;
                 match behavior {
-                    OrchestrationInvalidModelBehavior::Block => {
+                    CloudAgentInvalidModelBehavior::Block => {
                         self.handle_spawn_error(reason, ctx);
                         return;
                     }
-                    OrchestrationInvalidModelBehavior::AutoSelect => {
-                        let fallback = resolve_orchestration_fallback_model_id(ctx);
+                    CloudAgentInvalidModelBehavior::AutoSelect => {
+                        let fallback = resolve_cloud_agent_fallback_model_id(ctx);
                         let substitute =
                             if unavailable_model_reason(&fallback, "oz", false, ctx).is_none() {
                                 (!fallback.is_empty()).then_some(fallback)

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -23178,6 +23178,17 @@ impl Workspace {
             }
         }
 
+        match ai_settings.orchestration_invalid_model_behavior {
+            crate::settings::OrchestrationInvalidModelBehavior::Block => {
+                context.set.insert(flags::ORCHESTRATION_INVALID_MODEL_BLOCK);
+            }
+            crate::settings::OrchestrationInvalidModelBehavior::AutoSelect => {
+                context
+                    .set
+                    .insert(flags::ORCHESTRATION_INVALID_MODEL_AUTO_SELECT);
+            }
+        }
+
         match ai_settings.default_prompt_submission_mode {
             crate::settings::PromptSubmissionMode::Interrupt => {
                 context.set.insert(flags::PROMPT_SUBMISSION_INTERRUPT);

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -23174,14 +23174,14 @@ impl Workspace {
             }
         }
 
-        match ai_settings.orchestration_invalid_model_behavior {
-            crate::settings::OrchestrationInvalidModelBehavior::Block => {
-                context.set.insert(flags::ORCHESTRATION_INVALID_MODEL_BLOCK);
+        match ai_settings.cloud_agent_invalid_model_behavior {
+            crate::settings::CloudAgentInvalidModelBehavior::Block => {
+                context.set.insert(flags::CLOUD_AGENT_INVALID_MODEL_BLOCK);
             }
-            crate::settings::OrchestrationInvalidModelBehavior::AutoSelect => {
+            crate::settings::CloudAgentInvalidModelBehavior::AutoSelect => {
                 context
                     .set
-                    .insert(flags::ORCHESTRATION_INVALID_MODEL_AUTO_SELECT);
+                    .insert(flags::CLOUD_AGENT_INVALID_MODEL_AUTO_SELECT);
             }
         }
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -91,6 +91,12 @@
       "skillPath": ".agents/skills/saga/SKILL.md",
       "computedHash": "52d94bc2b29ba1e8738267c031a1ab4ea8a83d197baae32608014653758b5a7e"
     },
+    "scan-new-specs": {
+      "source": "warpdotdev/common-skills",
+      "sourceType": "github",
+      "skillPath": ".agents/skills/scan-new-specs/SKILL.md",
+      "computedHash": "9d7122b42fb72560a6d64634fe3f7504ac5e2b2c994a72c082124c5e3314d372"
+    },
     "spec-driven-implementation": {
       "source": "warpdotdev/common-skills",
       "sourceType": "github",
@@ -108,6 +114,12 @@
       "sourceType": "github",
       "skillPath": ".agents/skills/validate-changes-match-specs/SKILL.md",
       "computedHash": "9123fd70ced064bdd773fd8d2baa8d5d5291fef910eb2c028084074b3ac72c27"
+    },
+    "write-feature-docs": {
+      "source": "warpdotdev/common-skills",
+      "sourceType": "github",
+      "skillPath": ".agents/skills/write-feature-docs/SKILL.md",
+      "computedHash": "9c3b76767f42a52331b2627d2054c3cddf9c254cde530de4965ba5b106d80b60"
     },
     "write-product-spec": {
       "source": "warpdotdev/common-skills",


### PR DESCRIPTION
## Description
Since warp-server #11971, the server validates the Oz `model_id` at cloud-task creation time (before spawning a sandbox). As a result, orchestrating with an invalid, custom, or plan-unavailable model surfaced as opaque per-child failures (or a 30s spawn timeout) instead of a clear, actionable message.

This validates the run-wide orchestration `model_id` **client-side, before dispatching children**, against the models Oz actually accepts for cloud tasks:

- **Cloud vs. local source of truth:** cloud/remote Oz runs validate against the *raw* server agent-mode catalog (the same set `AddTask` and `GET /api/v1/agent/models` use), so models valid only for local runs (custom endpoints / local routers) are no longer mistaken for Oz-available. Local runs keep the broader local catalog. No new server endpoint was needed — the existing one already exposes the Oz set.
- **New setting `OrchestrationInvalidModelBehavior` (default `Block`):** when `Block`, orchestration is blocked with a clear error (Accept disabled in the confirmation and plan cards; a retryable `Failure` in the autonomous path) that tells the user they can switch to auto-select. When `AutoSelect`, a valid model (the Oz default) is substituted and the run proceeds. Exposed in Settings → Agents and the Command Palette.
- The model catalog is refreshed when the confirmation card becomes actionable, and validation fails open until the catalog has loaded (so early/autonomous runs are never falsely blocked).

### How
- `LLMPreferences` gains raw Oz-cloud accessors + a `server_models_loaded` flag (`app/src/ai/llms.rs`).
- A shared `unavailable_model_reason(...)` helper in `orchestration_controls.rs`, wired into the Accept gate (`accept_disabled_reason_with_auth`, shared by the RunAgents card and the plan card) and the executor pre-flight (`RunAgentsExecutor::dispatch_prepared_run_agents`).
- New setting + Command Palette entries + a settings-page row.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Added unit tests:
- Executor gate (`run_agents_tests.rs`): invalid cloud model + `Block` → `RunAgentsResult::Failure`, zero children dispatched; + `AutoSelect` → proceeds with a substituted model; empty / `auto` model → proceeds.
- Accept gate / auto-select (`orchestration_controls_tests.rs`): `Block` → Accept disabled with the reason; `AutoSelect` → not disabled and model substituted; valid/empty/`auto` → allowed; a local-only custom model is allowed for local runs but flagged for cloud.

Validation on the integrated branch: `cargo fmt` clean, `cargo clippy -p warp --all-targets -- -D warnings` clean, `cargo nextest run -p warp run_agents orchestration_controls llms` → 85 passed. Full presubmit / integration suite runs in CI.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

---
Conversation: https://staging.warp.dev/conversation/90ec1637-f933-4b56-9a18-d4a01252d209
Plan: https://staging.warp.dev/drive/notebook/BvsDuGFDR7GeWcgewlOY8x

CHANGELOG-IMPROVEMENT: Orchestration now checks your selected model against the models available for cloud agents before launching, and either blocks with a clear message or auto-selects a valid model (configurable in Settings → Agents).

Co-Authored-By: Oz <oz-agent@warp.dev>
