### PR TITLE
Fix tab renaming bug with tab groups in pane view

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -210,6 +210,21 @@ impl TabData {
         self.selected_color.resolve(self.default_directory_color)
     }
 
+    /// True when this tab's top-level name is not shown because it is a member of
+    /// a tab group rendered in vertical-tabs Panes view. In that layout the group
+    /// owns the container and only individual pane names are displayed, so
+    /// tab-level rename/reset should not be possible. 
+    pub fn tab_name_hidden_in_grouped_pane_view(&self, ctx: &AppContext) -> bool {
+        self.group_id.is_some()
+            && uses_vertical_tabs(ctx)
+            && matches!(
+                *TabSettings::as_ref(ctx)
+                    .vertical_tabs_display_granularity
+                    .value(),
+                VerticalTabsDisplayGranularity::Panes
+            )
+    }
+
     /// Returns the menu items for the context menu on right mouse click.
     #[allow(clippy::too_many_arguments)]
     pub fn menu_items(
@@ -470,20 +485,25 @@ impl TabData {
         let mut menu_items = vec![];
         let uses_vertical_tabs = uses_vertical_tabs(ctx);
 
-        // TODO add option to show the keybinding once we figure out a nice API to retrieve
-        // the actual keybinding (based on the user's preferences etc.)
-        menu_items.append(&mut vec![MenuItemFields::new("Rename tab")
-            .with_on_select_action(WorkspaceAction::RenameTab(index))
-            .into_item()]);
-        // Group together with rename option (note, resetting doesn't make
-        // sense unless you're able to rename a tab).
-        let title = self.pane_group.as_ref(ctx).custom_title(ctx);
-        if title.is_some() {
-            menu_items.push(
-                MenuItemFields::new("Reset tab name")
-                    .with_on_select_action(WorkspaceAction::ResetTabName(index))
-                    .into_item(),
-            );
+        // In Panes view the tab in a group has no visible top-level name (only pane
+        // rows are shown), so skip tab rename/reset and rely on the pane name
+        // items below instead.
+        if !self.tab_name_hidden_in_grouped_pane_view(ctx) {
+            // TODO add option to show the keybinding once we figure out a nice API to retrieve
+            // the actual keybinding (based on the user's preferences etc.)
+            menu_items.append(&mut vec![MenuItemFields::new("Rename tab")
+                .with_on_select_action(WorkspaceAction::RenameTab(index))
+                .into_item()]);
+            // Group together with rename option (note, resetting doesn't make
+            // sense unless you're able to rename a tab).
+            let title = self.pane_group.as_ref(ctx).custom_title(ctx);
+            if title.is_some() {
+                menu_items.push(
+                    MenuItemFields::new("Reset tab name")
+                        .with_on_select_action(WorkspaceAction::ResetTabName(index))
+                        .into_item(),
+                );
+            }
         }
         if let Some(pane_name_target) = pane_name_target {
             menu_items.extend(self.pane_name_menu_items(pane_name_target, ctx));

--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -213,7 +213,7 @@ impl TabData {
     /// True when this tab's top-level name is not shown because it is a member of
     /// a tab group rendered in vertical-tabs Panes view. In that layout the group
     /// owns the container and only individual pane names are displayed, so
-    /// tab-level rename/reset should not be possible. 
+    /// tab-level rename/reset should not be possible.
     pub fn tab_name_hidden_in_grouped_pane_view(&self, ctx: &AppContext) -> bool {
         self.group_id.is_some()
             && uses_vertical_tabs(ctx)

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -23583,7 +23583,17 @@ impl TypedActionView for Workspace {
             ResetTabName(index) => self.clear_tab_name(*index, ctx),
             RenamePane(locator) => self.rename_pane(*locator, ctx),
             ResetPaneName(locator) => self.clear_pane_name(*locator, ctx),
-            RenameActiveTab => self.rename_tab(self.active_tab_index, ctx),
+            RenameActiveTab => {
+                // In Panes view the tab in a group has no visible top-level name (only pane
+                // rows are shown). Do not allow a tab rename.
+                let tab_name_hidden = self
+                    .tabs
+                    .get(self.active_tab_index)
+                    .is_some_and(|tab| tab.tab_name_hidden_in_grouped_pane_view(ctx));
+                if !tab_name_hidden {
+                    self.rename_tab(self.active_tab_index, ctx);
+                }
+            }
             RenameActivePane => {
                 let pane_group = self.active_tab_pane_group().clone();
                 let pane_group_id = pane_group.id();


### PR DESCRIPTION
## Description

In vertical-tabs Panes view, a tab that belongs to a tab group renders without its own header — only the individual pane rows (and their names) are shown, not the top-level tab name. This makes "Rename tab" / "Reset tab name" confusing there: they act on a name the user can't see, and opening the tab rename editor spills it across the pane rows.

This PR suppresses tab-name actions for a grouped tab in Panes view:
•  Adds `TabData::tab_name_hidden_in_grouped_pane_view(ctx)` — true when the tab is in a group, vertical tabs are on, and the display granularity is Panes.
•  Hides the "Rename tab" and "Reset tab name" entries from the tab context menu in that case (pane rename/reset entries remain).
•  Makes the `RenameActiveTab` action (keyboard shortcut / command) a no-op in that case instead of opening the editor.

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4810/hide-rename-tab-option-for-tab-in-group-for-pane-view

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo video](https://www.loom.com/share/b676bb2c49f240bb8f26d9a1ebf5fb7d)