### PR TITLE
Fix pinning UI for htabs

### DIFF
--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -102,6 +102,11 @@ const TAB_INDICATOR_SYNCED_COLOR: u32 = 0x4A93FFFF;
 pub(crate) const COMPACT_TAB_WIDTH_THRESHOLD: f32 = 42.0;
 // Horizontal inset for the tab close button
 const TAB_CLOSE_BUTTON_HORIZONTAL_INSET: f32 = 2.0;
+// Padding on each side of a pinned tab, reserving the pin's footprint so the title clips before it.
+const TAB_PINNED_CONTENT_HORIZONTAL_PADDING: f32 = 26.0;
+// Width below which a pinned tab/group header drops its idle pin (shared so both
+// vanish together), early enough that the pin never overlaps the centered title/icon.
+pub(crate) const TAB_PIN_VANISH_THRESHOLD: f32 = 70.0;
 
 /// Represents the user's manual tab-color selection state.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -1298,11 +1303,12 @@ impl<'a> TabComponent<'a> {
     }
 
     /// Renders the close-button slot for the tab: the close button when
-    /// hovered, a pin indicator when the tab is pinned, or an empty
+    /// hovered, a pin when pinned (unless the tab is too narrow), or an empty
     /// width-reserving placeholder otherwise.
     fn render_close_button_or_pin_icon(
         &self,
         background: Option<Fill>,
+        is_narrow: bool,
         is_hovered: bool,
     ) -> Box<dyn Element> {
         let should_render = {
@@ -1373,7 +1379,7 @@ impl<'a> TabComponent<'a> {
                     ctx.dispatch_typed_action(WorkspaceAction::CloseTab(tab_index))
                 })
                 .finish()
-        } else if self.show_pin_indicator() {
+        } else if !is_narrow && self.show_pin_indicator() {
             // Pinned: render the pin in the exact slot the close button uses so
             // hovering swaps icons in place without changing the layout.
             let theme = self.appearance.theme();
@@ -1626,7 +1632,7 @@ impl<'a> TabComponent<'a> {
             (bg, border)
         };
 
-        let full_tab_content = {
+        let build_full_content = |reserve_pin_space: bool| -> Box<dyn Element> {
             let mut flex_row = Flex::row()
                 .with_main_axis_size(MainAxisSize::Max)
                 .with_main_axis_alignment(MainAxisAlignment::Center)
@@ -1642,7 +1648,15 @@ impl<'a> TabComponent<'a> {
                 )
                 .finish(),
             );
-            let mut container = Container::new(flex_row.finish()).with_horizontal_padding(8.);
+            // Equal padding on both sides so the title stays centered; the pin
+            // vanishes before it can reach the title.
+            let horizontal_padding = if reserve_pin_space {
+                TAB_PINNED_CONTENT_HORIZONTAL_PADDING
+            } else {
+                8.
+            };
+            let mut container =
+                Container::new(flex_row.finish()).with_horizontal_padding(horizontal_padding);
             // Pad inside the Stack so the close-button overlay (anchored to
             // the Stack) stays vertically centered within the visible pill.
             if self.grouped_member {
@@ -1738,11 +1752,13 @@ impl<'a> TabComponent<'a> {
                 )
             };
 
-        let build_close_button_overlay = |is_hovered: bool| {
+        let build_close_button_overlay = |is_narrow: bool, is_hovered: bool| {
             Container::new(
-                ConstrainedBox::new(
-                    self.render_close_button_or_pin_icon(Some(close_button_background), is_hovered),
-                )
+                ConstrainedBox::new(self.render_close_button_or_pin_icon(
+                    Some(close_button_background),
+                    is_narrow,
+                    is_hovered,
+                ))
                 .with_width(TAB_CLOSE_BUTTON_WIDTH)
                 .with_height(TAB_CLOSE_BUTTON_WIDTH)
                 .finish(),
@@ -1750,23 +1766,28 @@ impl<'a> TabComponent<'a> {
             .finish()
         };
 
-        let mut full_stack = Stack::new().with_child(full_tab_content);
-        full_stack.add_positioned_child(
-            build_close_button_overlay(is_hovered),
-            OffsetPositioning::offset_from_parent(
-                vec2f(horizontal_inset, 0.0),
-                ParentOffsetBounds::ParentByPosition,
-                parent_anchor,
-                child_anchor,
-            ),
-        );
+        let build_full_stack = |is_narrow: bool| {
+            let reserve_pin_space = self.show_pin_indicator() && !is_narrow;
+            let mut full_stack = Stack::new().with_child(build_full_content(reserve_pin_space));
+            full_stack.add_positioned_child(
+                build_close_button_overlay(is_narrow, is_hovered),
+                OffsetPositioning::offset_from_parent(
+                    vec2f(horizontal_inset, 0.0),
+                    ParentOffsetBounds::ParentByPosition,
+                    parent_anchor,
+                    child_anchor,
+                ),
+            );
+            full_stack.finish()
+        };
 
         let mut compact_stack = Stack::new().with_child(compact_tab_content);
         // Only show the close button on the active tab for narrow width
         // to prevent accidental clicks
         if self.is_active_tab() {
             compact_stack.add_positioned_child(
-                build_close_button_overlay(is_hovered),
+                // Compact tabs are too narrow to show a pin icon.
+                build_close_button_overlay(true, is_hovered),
                 OffsetPositioning::offset_from_parent(
                     vec2f(horizontal_inset, 0.0),
                     ParentOffsetBounds::ParentByPosition,
@@ -1775,15 +1796,37 @@ impl<'a> TabComponent<'a> {
                 ),
             );
         }
+        let compact_stack = compact_stack.finish();
 
-        let stack = SizeConstraintSwitch::new(
-            full_stack.finish(),
-            vec![(
-                SizeConstraintCondition::WidthLessThan(COMPACT_TAB_WIDTH_THRESHOLD),
-                compact_stack.finish(),
-            )],
-        )
-        .finish();
+        let stack = if self.show_pin_indicator() {
+            // There are three cases here that conditionally render based on tab size:
+            // 1. The original tab container (displays tab name and pin icon if pinned)
+            // 2. A narrow tab container (hides pin icon)
+            // 3. A very narrow tab container (displays tab icon only)
+            SizeConstraintSwitch::new(
+                build_full_stack(false),
+                vec![
+                    (
+                        SizeConstraintCondition::WidthLessThan(COMPACT_TAB_WIDTH_THRESHOLD),
+                        compact_stack,
+                    ),
+                    (
+                        SizeConstraintCondition::WidthLessThan(TAB_PIN_VANISH_THRESHOLD),
+                        build_full_stack(true),
+                    ),
+                ],
+            )
+            .finish()
+        } else {
+            SizeConstraintSwitch::new(
+                build_full_stack(false),
+                vec![(
+                    SizeConstraintCondition::WidthLessThan(COMPACT_TAB_WIDTH_THRESHOLD),
+                    compact_stack,
+                )],
+            )
+            .finish()
+        };
 
         // Grouped member: inset rounded highlight, no side dividers. It still
         // gets its own drop target so a dragged pane can land at this member's

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -356,7 +356,7 @@ use crate::tab::{
     color_picker_menu_items, tab_position_id, uses_vertical_tabs, ColorPickerTarget,
     NewSessionMenuItem, PaneNameMenuTarget, SelectedTabColor, TabBarState, TabComponent, TabData,
     TabTelemetryAction, COMPACT_TAB_WIDTH_THRESHOLD, MOVE_TO_GROUP_LABEL, TAB_BAR_BORDER_HEIGHT,
-    TAB_INDICATOR_HEIGHT, TAB_PIN_INDICATOR_ICON_SIZE,
+    TAB_INDICATOR_HEIGHT, TAB_PIN_INDICATOR_ICON_SIZE, TAB_PIN_VANISH_THRESHOLD,
 };
 use crate::tab_configs::action_sidecar::SidecarItemKind;
 use crate::tab_configs::remove_confirmation_dialog::{
@@ -19746,12 +19746,6 @@ impl Workspace {
             }
         }
 
-        // Pinned + expanded: trailing pin indicator after the last member.
-        let group_pinned = FeatureFlag::PinnedTabs.is_enabled() && group.pinned;
-        if group_pinned && !is_collapsed {
-            row.add_child(render_horizontal_group_pin_indicator(appearance));
-        }
-
         if !is_collapsed {
             // Matching edge spacer after the last member. The trailing divider
             // lives inside this spacer's own flex slot (drawn at its right edge,
@@ -19895,55 +19889,55 @@ impl Workspace {
         let is_being_renamed = self
             .current_workspace_state
             .is_tab_group_being_renamed(group_id);
-        let name_element: Box<dyn Element> = if is_being_renamed {
-            ConstrainedBox::new(vertical_tabs::render_inline_tab_rename_editor(
-                &self.tab_group_rename_editor,
-                appearance,
-                ctx,
-            ))
-            .with_max_width(150.)
+        let title = group
+            .name
+            .clone()
+            .unwrap_or_else(|| "New Group".to_string());
+        let show_header_pin = FeatureFlag::PinnedTabs.is_enabled() && group.pinned;
+        let normal_right_pad = if is_collapsed { 8. } else { 9. };
+
+        let build_inner = |name: Box<dyn Element>, reserve_pin: bool| -> Box<dyn Element> {
+            // Equal padding on both sides when pinned so the icon + name stay
+            // centered.
+            let (left_pad, right_pad) = if reserve_pin {
+                (GROUP_HEADER_PIN_PADDING, GROUP_HEADER_PIN_PADDING)
+            } else {
+                (8., normal_right_pad)
+            };
+            Container::new(
+                Flex::row()
+                    .with_main_axis_size(MainAxisSize::Max)
+                    .with_main_axis_alignment(MainAxisAlignment::Center)
+                    .with_cross_axis_alignment(CrossAxisAlignment::Center)
+                    .with_spacing(6.)
+                    .with_child(render_group_member_icon_collage(
+                        &member_kinds,
+                        GROUP_ICON_COLLAGE_SIZE,
+                        appearance,
+                    ))
+                    .with_child(Shrinkable::new(1.0, name).finish())
+                    .finish(),
+            )
+            .with_padding_left(left_pad)
+            .with_padding_right(right_pad)
             .finish()
-        } else {
-            let title = group
-                .name
-                .clone()
-                .unwrap_or_else(|| "New Group".to_string());
-            // No inner cap: the name fills the header slot and fades like a tab
-            // title; the header's outer `ConstrainedBox` bounds the width and
-            // keeps the tab bar's unbounded measurement finite.
-            Text::new_inline(title, font_family, 12.)
-                .with_clip(ClipConfig::end())
-                .with_color(main_text_color.into())
-                .finish()
+        };
+        // Overlays the right-justified pin, like a regular tab's close/pin slot.
+        let with_pin = |inner: Box<dyn Element>| -> Box<dyn Element> {
+            let mut stack = Stack::new().with_child(inner);
+            stack.add_positioned_child(
+                render_horizontal_group_pin_indicator(appearance),
+                OffsetPositioning::offset_from_parent(
+                    vec2f(-GROUP_HEADER_PIN_EDGE_GAP, 0.0),
+                    ParentOffsetBounds::ParentByPosition,
+                    ParentAnchor::MiddleRight,
+                    ChildAnchor::MiddleRight,
+                ),
+            );
+            stack.finish()
         };
 
-        // Full header: collage + name, with the horizontal padding inside it so
-        // the size switch below measures the full slot width, like a tab.
-        let mut full_row = Flex::row()
-            // Fill the slot and center the icon + title.
-            .with_main_axis_size(MainAxisSize::Max)
-            .with_main_axis_alignment(MainAxisAlignment::Center)
-            .with_cross_axis_alignment(CrossAxisAlignment::Center)
-            .with_spacing(6.)
-            .with_child(render_group_member_icon_collage(
-                &member_kinds,
-                GROUP_ICON_COLLAGE_SIZE,
-                appearance,
-            ))
-            .with_child(Shrinkable::new(1.0, name_element).finish());
-        // Collapsed + pinned: pin indicator to the right of the name, where an
-        // ungrouped tab would show its close button. Expanded groups show the
-        // pin after their last member instead.
-        if FeatureFlag::PinnedTabs.is_enabled() && group.pinned && is_collapsed {
-            full_row.add_child(render_horizontal_group_pin_indicator(appearance));
-        }
-        let full_content = Container::new(full_row.finish())
-            .with_padding_left(8.)
-            .with_padding_right(if is_collapsed { 8. } else { 9. })
-            .finish();
-
-        // Compact header (narrow slot): just the collage at the tab's compact
-        // icon size, centered and clipped, like a tab dropping its title.
+        // Compact header: just the collage, like a tab dropping its title.
         let compact_content = Clipped::new(
             Flex::row()
                 .with_main_axis_size(MainAxisSize::Max)
@@ -19958,15 +19952,66 @@ impl Workspace {
         )
         .finish();
 
-        // Go compact at the same width as a tab, so headers and tabs shrink in step.
-        let content = SizeConstraintSwitch::new(
-            full_content,
-            vec![(
-                SizeConstraintCondition::WidthLessThan(COMPACT_TAB_WIDTH_THRESHOLD),
-                compact_content,
-            )],
-        )
-        .finish();
+        // Pinned group with a fixed name: show the pin, hide it as the header
+        // shrinks, then fall back to just the icon.
+        let content = if show_header_pin && !is_being_renamed {
+            let make_text = || {
+                Text::new_inline(title.clone(), font_family, 12.)
+                    .with_clip(ClipConfig::end())
+                    .with_color(main_text_color.into())
+                    .finish()
+            };
+            // A wide tab that group header that has space for the icon, title and pin.
+            let wide = with_pin(build_inner(make_text(), true));
+            let no_pin = build_inner(make_text(), false);
+            SizeConstraintSwitch::new(
+                // Enough room: name + pin.
+                wide,
+                vec![
+                    // Very narrow: icon only.
+                    (
+                        SizeConstraintCondition::WidthLessThan(COMPACT_TAB_WIDTH_THRESHOLD),
+                        compact_content,
+                    ),
+                    // Getting narrow: hide the pin.
+                    (
+                        SizeConstraintCondition::WidthLessThan(TAB_PIN_VANISH_THRESHOLD),
+                        no_pin,
+                    ),
+                ],
+            )
+            .finish()
+        } else {
+            let name: Box<dyn Element> = if is_being_renamed {
+                ConstrainedBox::new(vertical_tabs::render_inline_tab_rename_editor(
+                    &self.tab_group_rename_editor,
+                    appearance,
+                    ctx,
+                ))
+                .with_max_width(150.)
+                .finish()
+            } else {
+                Text::new_inline(title.clone(), font_family, 12.)
+                    .with_clip(ClipConfig::end())
+                    .with_color(main_text_color.into())
+                    .finish()
+            };
+            // The header row: icon collage + name. Reserve pin padding (both
+            // sides, so it stays centered) only when this header shows a pin.
+            let inner = build_inner(name, show_header_pin);
+            // Lay the pin over the row when pinned (here, only a pinned group
+            // mid-rename); otherwise use the bare row.
+            let full = if show_header_pin { with_pin(inner) } else { inner };
+            SizeConstraintSwitch::new(
+                full,
+                vec![(
+                    // Very narrow: icon only.
+                    SizeConstraintCondition::WidthLessThan(COMPACT_TAB_WIDTH_THRESHOLD),
+                    compact_content,
+                )],
+            )
+            .finish()
+        };
 
         let header_active_bg = internal_colors::fg_overlay_2(theme);
         let header_hover_bg = internal_colors::fg_overlay_1(theme);
@@ -28759,7 +28804,13 @@ fn should_reserve_traffic_light_space_in_tab_bar(side: TrafficLightSide) -> bool
 /// Total width/height of the collage area in the group header.
 const GROUP_ICON_COLLAGE_SIZE: f32 = 22.0;
 
-/// Renders the diagonal pin indicator shown on a pinned horizontal tab group:
+/// Gap between the pin overlay and the header's right edge.
+const GROUP_HEADER_PIN_EDGE_GAP: f32 = 8.0;
+
+/// Right padding reserving the pin's footprint so the name clips before it.
+const GROUP_HEADER_PIN_PADDING: f32 = GROUP_HEADER_PIN_EDGE_GAP + TAB_PIN_INDICATOR_ICON_SIZE;
+
+/// The diagonal pin indicator overlaid on a pinned group's header.
 /// trailing the members of an expanded group, or to the right of the name on a
 /// collapsed group's header.
 fn render_horizontal_group_pin_indicator(appearance: &Appearance) -> Box<dyn Element> {

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -20001,7 +20001,11 @@ impl Workspace {
             let inner = build_inner(name, show_header_pin);
             // Lay the pin over the row when pinned (here, only a pinned group
             // mid-rename); otherwise use the bare row.
-            let full = if show_header_pin { with_pin(inner) } else { inner };
+            let full = if show_header_pin {
+                with_pin(inner)
+            } else {
+                inner
+            };
             SizeConstraintSwitch::new(
                 full,
                 vec![(


### PR DESCRIPTION
## Description

Improves the pinning UI for horizontal tabs, both for pinned tabs and pinned groups. 

Before:
- pinned tabs had the pin icon overlap with their tab name
- pin icons lived at the end of the tab group when expanded
- pins had a fixed size container causing several bugs in the tab bar

Now:
- pin icon lives at the end of the tab group header
- tab and group names fade early so the pin icon is not overlayed on top. 

NOTE: The pinning ui specifically for expanded tab groups strays slightly from the designs. I will align with Peter here before it goes to stable, but it is moving to preview for now so I believe its fine.

There is also some slight UI polish that needs to be done here, but will address before it gets to stable. Prioritizing getting this into preview because the fixed size container for pins in htab groups caused a few bugs.

## How it works 

-  When a tab or group is pinned, a pin shows at the right edge — the same spot a tab uses for its close button.
- The title (and the group's icon) stays centered by reserving equal padding on both sides.
- As a tab or group gets narrower it steps down through: title + pin → title only (pin hidden) → icon only. The pin is hidden early, before it can bump into the title or the group icon.
- Tabs and group headers share the same width cutoff for hiding the pin, so they stay consistent.

## Linked Issue

https://linear.app/warpdotdev/issue/APP-4813/update-pinning-ui-for-horizontal-tabs

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

[Demo video](https://www.loom.com/share/9e8f09e61d674a7f953f268ac35efa7b)

Before:
<img width="1341" height="38" alt="Screenshot 2026-07-01 at 7 20 41 PM" src="https://github.com/user-attachments/assets/fa8bd741-86e2-424e-9e75-8181bacc0695" />



After: 

<img width="1338" height="41" alt="Screenshot 2026-07-01 at 7 21 52 PM" src="https://github.com/user-attachments/assets/05418c95-f463-4fc6-92bd-94239de59a0e" />

