### PR TITLE
managed_secrets: add BYO first-party + endpoint WASM seal exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7981,8 +7981,11 @@ dependencies = [
 name = "managed_secrets_wasm"
 version = "0.1.0"
 dependencies = [
+ "serde",
+ "serde_json",
  "warp_managed_secrets",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/managed_secrets/src/envelope.rs
+++ b/crates/managed_secrets/src/envelope.rs
@@ -80,6 +80,29 @@ impl UploadKey {
             .encrypt(&secret_plaintext, context.encode().as_bytes())?;
         Ok(base64::prelude::BASE64_STANDARD.encode(encrypted))
     }
+
+    /// Seal an arbitrary `plaintext` under caller-provided `context_info` bytes
+    /// using this upload key's hybrid-encrypt primitive.
+    ///
+    /// This is the exact same Tink/HPKE primitive used by
+    /// [`UploadKey::encrypt_secret`], so the on-the-wire format is identical and
+    /// round-trips with the server's `tink-go` hybrid decryptor. The difference
+    /// is that the caller owns the full `context_info` and `plaintext`: unlike
+    /// [`UploadKey::encrypt_secret`] (whose context is the managed-secret
+    /// `1:<actor>:<name>:<type>` binding), this seam lets BYO credential sealing
+    /// supply its own `byo:1:TEAM:<owner>:<cred_type>:<slot>` context, which must
+    /// match the server-side `byo.UnsealCredential` contract byte-for-byte.
+    ///
+    /// Used by `managed_secrets_wasm::encrypt_byo_first_party` /
+    /// `encrypt_byo_endpoint`, which construct the BYO context and JSON payload.
+    pub fn seal_with_context(
+        &self,
+        context_info: &[u8],
+        plaintext: &[u8],
+    ) -> Result<String, EnvelopeError> {
+        let encrypted = self.encrypt.encrypt(plaintext, context_info)?;
+        Ok(base64::prelude::BASE64_STANDARD.encode(encrypted))
+    }
 }
 
 struct UploadContext<'a> {

--- a/crates/managed_secrets/src/envelope_tests.rs
+++ b/crates/managed_secrets/src/envelope_tests.rs
@@ -1,5 +1,6 @@
 use std::io;
 
+use base64::Engine;
 use tink_proto::KeysetInfo;
 use tink_proto::keyset_info::KeyInfo;
 
@@ -137,4 +138,53 @@ fn test_encrypt_decrypt() {
 fn read_keyset_json(json: &str) -> tink_core::keyset::Handle {
     let mut reader = tink_core::keyset::JsonReader::new(io::Cursor::new(json.as_bytes()));
     tink_core::keyset::insecure::read(&mut reader).expect("failed to read keyset")
+}
+
+/// BYO credential sealing round-trip via [`UploadKey::seal_with_context`].
+///
+/// Pins the exact context format shared by the WASM producer
+/// (`managed_secrets_wasm::encrypt_byo_first_party`) and the Go consumer
+/// (`byo.UnsealCredential`): `byo:1:TEAM:<owner_uid>:first_party:provider=openai`.
+/// Proves the new seam reuses the same Tink/HPKE primitive (the sealed blob
+/// round-trips) and that a mismatched context fails to unseal.
+#[test]
+fn test_seal_with_context_byo_roundtrip() {
+    super::init();
+
+    let public_key = read_keyset_json(TEST_PUBLIC_KEY);
+    let private_key = read_keyset_json(TEST_PRIVATE_KEY);
+
+    let upload_key = UploadKey {
+        encrypt: tink_hybrid::new_encrypt(&public_key).expect("failed to create encrypt primitive"),
+        public_key,
+    };
+
+    let owner_uid = "t_abc";
+    let context = format!("byo:1:TEAM:{owner_uid}:first_party:provider=openai");
+    assert_eq!(context, "byo:1:TEAM:t_abc:first_party:provider=openai");
+
+    let plaintext = br#"{"api_key":"sk-test"}"#;
+    let sealed = upload_key
+        .seal_with_context(context.as_bytes(), plaintext)
+        .expect("failed to seal BYO credential");
+
+    let ciphertext = base64::prelude::BASE64_STANDARD
+        .decode(&sealed)
+        .expect("sealed blob is not valid base64");
+
+    let decrypt =
+        tink_hybrid::new_decrypt(&private_key).expect("failed to create decrypt primitive");
+    let decrypted = decrypt
+        .decrypt(&ciphertext, context.as_bytes())
+        .expect("failed to unseal BYO credential");
+    assert_eq!(decrypted, plaintext);
+
+    // A mismatched context (e.g. wrong provider) must fail to unseal.
+    let wrong_context = format!("byo:1:TEAM:{owner_uid}:first_party:provider=anthropic");
+    assert!(
+        decrypt
+            .decrypt(&ciphertext, wrong_context.as_bytes())
+            .is_err(),
+        "unseal must fail when the context does not match"
+    );
 }

--- a/crates/managed_secrets_wasm/Cargo.toml
+++ b/crates/managed_secrets_wasm/Cargo.toml
@@ -12,3 +12,14 @@ crate-type = ["cdylib"]
 [dependencies]
 warp_managed_secrets.workspace = true
 wasm-bindgen.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+# `warp_managed_secrets` pulls in `warpui_core`, whose wasm platform code calls
+# `web_sys::Window::navigator()`. web-sys is feature-gated and `warpui_core` only
+# depends on it transitively (via `gloo`), so the `Navigator`/`Window` features
+# are not enabled unless the top-level wasm crate requests them. Depend on the
+# workspace `web-sys` (which enables those features) so this crate's standalone
+# `wasm-pack build` unifies them in and the transitive deps compile.
+[target.'cfg(target_family = "wasm")'.dependencies]
+web-sys.workspace = true

--- a/crates/managed_secrets_wasm/src/lib.rs
+++ b/crates/managed_secrets_wasm/src/lib.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use warp_managed_secrets::{ManagedSecretValue, UploadKey, init_envelope};
 use wasm_bindgen::prelude::*;
 
@@ -116,3 +117,101 @@ pub fn encrypt_openai_api_key_secret(
         &ManagedSecretValue::openai_api_key(api_key, base_url),
     )
 }
+
+// ── BYO (bring-your-own) credential sealing ─────────────────────────────────
+//
+// These exports seal enterprise BYOK / BYOE credentials for team upload. They
+// do NOT reuse the typed managed-secret encryptors above: the managed-secret
+// AEAD context is bound to the secret type (`1:<actor>:<name>:<type>`), whereas
+// BYO credentials are bound to `byo:1:TEAM:<owner_uid>:<cred_type>:<slot>` and
+// must round-trip with the server's `byo.UnsealCredential`. The context string
+// and JSON payload are constructed here (single source of truth) and sealed via
+// the crate's existing Tink/HPKE hybrid primitive for exact wire-format parity.
+
+/// Plaintext payload for a first-party (BYOK) credential. Serialized as snake_case
+/// JSON (`{"api_key":"…"}`) to match the server unseal contract.
+#[derive(Serialize)]
+struct ByoFirstPartyPayload<'a> {
+    api_key: &'a str,
+}
+
+/// Plaintext payload for a custom-endpoint (BYOE) credential. Serialized as
+/// snake_case JSON (`{"base_url":"…","api_key":"…"}`).
+#[derive(Serialize)]
+struct ByoEndpointPayload<'a> {
+    base_url: &'a str,
+    api_key: &'a str,
+}
+
+/// Build the pinned BYO first-party seal context. Must byte-for-byte match the
+/// server `byo.UnsealCredential` contract:
+/// `byo:1:TEAM:<owner_uid>:first_party:provider=<provider>`.
+fn byo_first_party_context(owner_uid: &str, provider: &str) -> String {
+    format!("byo:1:TEAM:{owner_uid}:first_party:provider={provider}")
+}
+
+/// Build the pinned BYO endpoint seal context:
+/// `byo:1:TEAM:<owner_uid>:endpoint:endpoint=<endpoint_id>`.
+fn byo_endpoint_context(owner_uid: &str, endpoint_id: &str) -> String {
+    format!("byo:1:TEAM:{owner_uid}:endpoint:endpoint={endpoint_id}")
+}
+
+/// Import the public keyset and HPKE-seal `payload` (as JSON) under `context`.
+fn seal_byo(
+    public_key_base64: &str,
+    context: &str,
+    payload: &impl Serialize,
+) -> Result<String, JsValue> {
+    let upload_key = UploadKey::import_public_keyset(public_key_base64)
+        .map_err(|e| JsValue::from_str(&format!("failed to import public key: {e}")))?;
+    let plaintext = serde_json::to_vec(payload)
+        .map_err(|e| JsValue::from_str(&format!("failed to serialize payload: {e}")))?;
+    upload_key
+        .seal_with_context(context.as_bytes(), &plaintext)
+        .map_err(|e| JsValue::from_str(&format!("encryption failed: {e}")))
+}
+
+/// Encrypt (HPKE-seal) a team BYO first-party API key.
+///
+/// Seals `{"api_key":"<api_key>"}` bound to the context
+/// `byo:1:TEAM:<owner_uid>:first_party:provider=<provider>`. `owner_uid` is the
+/// team's string UID; `provider` is one of `openai` / `anthropic` / `google`.
+#[wasm_bindgen]
+pub fn encrypt_byo_first_party(
+    public_key_base64: &str,
+    owner_uid: &str,
+    provider: &str,
+    api_key: &str,
+) -> Result<String, JsValue> {
+    let context = byo_first_party_context(owner_uid, provider);
+    seal_byo(
+        public_key_base64,
+        &context,
+        &ByoFirstPartyPayload { api_key },
+    )
+}
+
+/// Encrypt (HPKE-seal) a team BYO custom-endpoint credential.
+///
+/// Seals `{"base_url":"<base_url>","api_key":"<api_key>"}` bound to the context
+/// `byo:1:TEAM:<owner_uid>:endpoint:endpoint=<endpoint_id>`. `endpoint_id` is the
+/// client-minted endpoint UUID.
+#[wasm_bindgen]
+pub fn encrypt_byo_endpoint(
+    public_key_base64: &str,
+    owner_uid: &str,
+    endpoint_id: &str,
+    base_url: &str,
+    api_key: &str,
+) -> Result<String, JsValue> {
+    let context = byo_endpoint_context(owner_uid, endpoint_id);
+    seal_byo(
+        public_key_base64,
+        &context,
+        &ByoEndpointPayload { base_url, api_key },
+    )
+}
+
+#[cfg(test)]
+#[path = "lib_tests.rs"]
+mod tests;

--- a/crates/managed_secrets_wasm/src/lib_tests.rs
+++ b/crates/managed_secrets_wasm/src/lib_tests.rs
@@ -1,0 +1,64 @@
+//! Unit tests for BYO context / payload construction.
+//!
+//! These cover the producer side of the pinned BYO seal format (the exact
+//! `byo:1:TEAM:…` context string and the snake_case JSON payloads). The
+//! seal/unseal round-trip across the real Tink/HPKE primitive lives in
+//! `warp_managed_secrets`'s `envelope_tests.rs`, which has access to the private
+//! decrypt primitive and fixture keysets.
+
+use super::{
+    ByoEndpointPayload, ByoFirstPartyPayload, byo_endpoint_context, byo_first_party_context,
+};
+
+#[test]
+fn first_party_context_is_pinned() {
+    assert_eq!(
+        byo_first_party_context("t_abc", "openai"),
+        "byo:1:TEAM:t_abc:first_party:provider=openai"
+    );
+    assert_eq!(
+        byo_first_party_context("t_abc", "anthropic"),
+        "byo:1:TEAM:t_abc:first_party:provider=anthropic"
+    );
+    assert_eq!(
+        byo_first_party_context("t_abc", "google"),
+        "byo:1:TEAM:t_abc:first_party:provider=google"
+    );
+}
+
+#[test]
+fn endpoint_context_is_pinned() {
+    assert_eq!(
+        byo_endpoint_context("t_abc", "550e8400-e29b-41d4-a716-446655440000"),
+        "byo:1:TEAM:t_abc:endpoint:endpoint=550e8400-e29b-41d4-a716-446655440000"
+    );
+}
+
+#[test]
+fn first_party_payload_is_snake_case_json() {
+    let json = serde_json::to_string(&ByoFirstPartyPayload { api_key: "sk-test" })
+        .expect("serialize first-party payload");
+    assert_eq!(json, r#"{"api_key":"sk-test"}"#);
+}
+
+#[test]
+fn endpoint_payload_is_snake_case_json_in_order() {
+    let json = serde_json::to_string(&ByoEndpointPayload {
+        base_url: "https://example.test/v1",
+        api_key: "sk-test",
+    })
+    .expect("serialize endpoint payload");
+    assert_eq!(
+        json,
+        r#"{"base_url":"https://example.test/v1","api_key":"sk-test"}"#
+    );
+}
+
+/// Special characters in secret values must be JSON-escaped (serde handles this),
+/// proving why we serialize via serde rather than hand-building the JSON string.
+#[test]
+fn payload_escapes_special_characters() {
+    let json = serde_json::to_string(&ByoFirstPartyPayload { api_key: "a\"b\\c" })
+        .expect("serialize payload with special chars");
+    assert_eq!(json, r#"{"api_key":"a\"b\\c"}"#);
+}


### PR DESCRIPTION
## Description

Adds client-side (browser WASM) sealing for enterprise team BYOK/BYOE credentials, part of the team BYO PR chain in warp-server (#12171 / #12172 / #12185 / #12226, and companion warp-server PR #12318 which commits the regenerated artifacts + TS wrappers).

- `crates/managed_secrets/src/envelope.rs`: adds `UploadKey::seal_with_context(context_info, plaintext)` — the exact same Tink/HPKE hybrid-encrypt primitive as `encrypt_secret`, but the caller owns the AEAD context and plaintext. This lets BYO sealing bind to its own context instead of the managed-secret `1:<actor>:<name>:<type>` binding.
- `crates/managed_secrets_wasm/src/lib.rs`: adds `encrypt_byo_first_party` / `encrypt_byo_endpoint` `#[wasm_bindgen]` exports. The pinned AEAD contexts (`byo:1:TEAM:<owner_uid>:first_party:provider=<p>`, `byo:1:TEAM:<owner_uid>:endpoint:endpoint=<id>`) and snake_case JSON payloads (`{"api_key":…}`, `{"base_url":…,"api_key":…}`) are built here in Rust as the single source of truth, matching the server's `byo.UnsealCredential` contract byte-for-byte (warp-server `logic/byo/sealed_upload.go`).
- `crates/managed_secrets_wasm/Cargo.toml`: adds `serde`/`serde_json`, plus a wasm-target `web-sys` workspace dep — `warp_managed_secrets` pulls in `warpui_core`, whose wasm platform code needs `web_sys` `Window`/`Navigator` features that only unify in when a top-level crate requests them; without this, a standalone `wasm-pack build` of this crate fails. (Note for warp-internal sync: this is additive and target-gated.)

The compiled artifacts (`wasm-pack build --target web --release`) are committed in warp-server (same flow as the original managed-secrets module), where `sealByoFirstPartyKey` / `sealByoEndpointCredential` TS wrappers call these exports from the workspace admin Models page.

## Linked Issue

N/A — enterprise team BYOK/BYOE saga; server-side chain linked above.

## Testing

- `cargo nextest run -p warp_managed_secrets -p managed_secrets_wasm`: 24/24 pass, including `test_seal_with_context_byo_roundtrip` (seal → decrypt round-trip) and tests pinning the exact context strings and payload JSON (order, escaping).
- `cargo check --target wasm32-unknown-unknown -p managed_secrets_wasm`: clean.
- `./script/format` and presubmit clippy (workspace + `warp_completer` legs): clean.
- Cross-language validation: blobs sealed by these exports decrypt via the server's `byo.UnsealCredential` (tink-go), and managed-secret/wrong-context blobs are rejected — exercised against the warp-server chain during integration.
- Not manually testable via `./script/run` (browser-WASM exports consumed by the warp-server web app); end-to-end manual validation happens with warp-server + the admin Models card PR.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
