### PR TITLE
Bug bash: Project Explorer gitignore + lazy-loading (findings + regression tests)

### DIFF
--- a/crates/repo_metadata/src/local_model_tests.rs
+++ b/crates/repo_metadata/src/local_model_tests.rs
@@ -2864,3 +2864,110 @@ fn lazy_root_created_directory_inserted_as_placeholder() {
         );
     });
 }
+
+/// BUG BASH: a file that is ignored ONLY by a nested (per-directory)
+/// `.gitignore` is tagged `is_ignored = false` when added incrementally via the
+/// watcher, because `compute_file_tree_mutations` classifies with only the
+/// repo-root + global gitignores (`state.gitignores`). The initial index reads
+/// nested `.gitignore` files, so `sub/existing.log` is dimmed but a live
+/// sub/new.log` is not. This test asserts the CORRECT (initial-index) behavior.
+/// It is currently ignored because it documents a known bug (bug-bash finding):
+/// the incremental watcher path does not consult nested `.gitignore` files, so a
+/// live-created file matched only by a nested `.gitignore` renders un-dimmed.
+/// Remove `#[ignore]` once `compute_file_tree_mutations` consults nested
+/// `.gitignore` files (or inherits the parent dir's ignored state).
+#[test]
+#[ignore = "known bug: incremental adds don't consult nested .gitignore (bug-bash finding)"]
+fn bugbash_incremental_add_respects_nested_gitignore() {
+    VirtualFS::test("bugbash_nested_gitignore", |dirs, mut vfs| {
+        vfs.mkdir("repo/sub").with_files(vec![
+            Stub::FileWithContent("repo/.gitignore", "build/\n"),
+            Stub::FileWithContent("repo/sub/.gitignore", "*.log\n"),
+            Stub::FileWithContent("repo/sub/new.log", "y"),
+        ]);
+
+        let repo_local = dirs.tests().join("repo");
+        let new_log_local = repo_local.join("sub").join("new.log");
+
+        let gitignores = crate::gitignores_for_directory(&repo_local);
+        let definitions = StandingQueryDefinitions::default();
+
+        let update = RepoUpdate {
+            added: vec![new_log_local.clone()],
+            ..Default::default()
+        };
+        let (mutations, _standing_results, _removed) =
+            block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+                &update,
+                &gitignores,
+                &[], /* force_included_paths */
+                &definitions,
+                false, /* lazy_load */
+            ));
+
+        let incremental_ignored = mutations
+            .iter()
+            .find_map(|mutation| match mutation {
+                FileTreeMutation::AddFile {
+                    path, is_ignored, ..
+                } if path == &new_log_local => Some(*is_ignored),
+                _ => None,
+            })
+            .expect("incremental update should contain an AddFile for sub/new.log");
+
+        assert!(
+            incremental_ignored,
+            "sub/new.log is ignored by the nested sub/.gitignore (*.log), so the incremental \
+             watcher add should tag it ignored=true to match the initial index; got ignored=false"
+        );
+    });
+}
+
+/// BUG BASH companion: a file created directly inside a directory ignored by the
+/// repo-ROOT `.gitignore` (`node_modules/`). This isolates whether the
+/// incremental classifier honors ancestor matches at all. Asserts the correct
+/// behavior (ignored=true).
+#[test]
+fn bugbash_incremental_add_direct_child_of_root_ignored_dir() {
+    VirtualFS::test("bugbash_root_ignored_dir_child", |dirs, mut vfs| {
+        vfs.mkdir("repo/node_modules").with_files(vec![
+            Stub::FileWithContent("repo/.gitignore", "node_modules/\n"),
+            Stub::FileWithContent("repo/node_modules/zzz.js", "x"),
+        ]);
+
+        let repo_local = dirs.tests().join("repo");
+        let zzz_local = repo_local.join("node_modules").join("zzz.js");
+
+        let gitignores = crate::gitignores_for_directory(&repo_local);
+        let definitions = StandingQueryDefinitions::default();
+
+        let update = RepoUpdate {
+            added: vec![zzz_local.clone()],
+            ..Default::default()
+        };
+        let (mutations, _standing_results, _removed) =
+            block_on(LocalRepoMetadataModel::compute_file_tree_mutations(
+                &update,
+                &gitignores,
+                &[], /* force_included_paths */
+                &definitions,
+                false, /* lazy_load */
+            ));
+
+        let incremental_ignored = mutations
+            .iter()
+            .find_map(|mutation| match mutation {
+                FileTreeMutation::AddFile {
+                    path, is_ignored, ..
+                } if path == &zzz_local => Some(*is_ignored),
+                _ => None,
+            })
+            .expect("incremental update should contain an AddFile for node_modules/zzz.js");
+
+        assert!(
+            incremental_ignored,
+            "node_modules/zzz.js sits under a root-gitignored directory, so the incremental \
+             watcher add should tag it ignored=true; got ignored=false"
+        );
+    });
+}


### PR DESCRIPTION
## Summary

Bug bash of the **Project Explorer (file tree)**, focused on the intersection of **gitignore** and **lazy loading**, with emphasis on whether live filesystem **mutations** are handled correctly. Testing was done against a locally-built `warp` client (`cargo run --bin warp`) driving the file tree over a set of purpose-built repos (git + non-git, nested `.gitignore`, symlinks, dotfiles, deep/ignored dirs).

This PR adds two model-level regression tests around `compute_file_tree_mutations` (`crates/repo_metadata/src/local_model.rs`). One passes (guards correct behavior); one is `#[ignore]`d because it documents a confirmed bug (keeps CI green). No behavioral/product code is changed — this is a QA finding + evidence, intended to hand the fixes to the owning team.

## Confirmed bugs

### 1. Live/incremental adds ignore nested (per-directory) `.gitignore` — files render un-dimmed
The initial index (`Entry::build_tree` → `evaluate_entry`) reads nested `.gitignore` files as it descends, so a file matched only by `sub/.gitignore` is tagged ignored (dimmed). The **incremental watcher path** (`compute_file_tree_mutations` → `LocalRepoMetadataModel::path_is_ignored`) classifies using only the repo-root + global gitignores (`state.gitignores`), so a **live-created** file matched only by a nested `.gitignore` is tagged `ignored = false` and renders normal.

- Repro (UI): open a repo containing `sub/.gitignore` = `*.log` and a pre-existing `sub/existing.log` (dimmed). Run `touch sub/new.log`. `new.log` appears **normal**, right next to the **dimmed** `existing.log`. Both are plain files (no icon confound).
- Repro (unit): `bugbash_incremental_add_respects_nested_gitignore` (this PR) asserts the correct `ignored=true` and currently fails with `got ignored=false` — hence `#[ignore]`d.
- Note: files under a **root**-gitignored dir (e.g. `node_modules/…`) are tagged correctly on live add — verified by the passing companion test `bugbash_incremental_add_direct_child_of_root_ignored_dir`. So the gap is specifically nested `.gitignore` files.
- Suggested fix direction: have the incremental classifier consult nested `.gitignore` files along the added path's ancestor chain (matching `evaluate_entry`), or inherit the parent directory's `ignored` state from the tree (matching how `Entry::load` uses `ancestor_is_ignored`). This is the same class of divergence already guarded for force-included subtrees by `incremental_force_included_dir_under_ignored_parent_matches_initial_index`.

### 2. The file tree does not react to `.gitignore` edits
`state.gitignores` is captured once at index time (`gitignores_for_directory` in `index_directory`) and is never reloaded when `.gitignore` changes. Editing `.gitignore` does not re-tag existing entries, and because the cached gitignores are stale, newly-created files are not re-classified either.

- Repro (UI): in a repo with an empty `.gitignore` and a normal `data.tmp`, run `echo '*.tmp' >> .gitignore`. `data.tmp` stays normal. `touch after.tmp` → `after.tmp` also normal. `echo 'logs/' >> .gitignore` → the `logs/` folder stays normal (not collapsed to an ignored placeholder).
- For contrast, code review's diff state *does* handle this (`app/src/code_review/diff_state/local.rs` does a full reload when `.gitignore` is modified) — the file tree's `repo_metadata` model has no equivalent.
- Suggested fix direction: detect `.gitignore` (and global excludes) changes in the watcher path and reload `state.gitignores` + re-tag/refresh the affected subtree.

## Behaviors verified correct (no action needed)

- Ignored dirs (`node_modules`, `target`, `dist`, `build/`, `.git`) show **dimmed** and as **unloaded placeholders**; expanding lazily loads their children (also dimmed), including deep chains like `target/debug/build`.
- Initial index respects nested `.gitignore` (`sub/existing.log`, `sub/secret/` dimmed).
- Tracked-dir mutations: add / rename / delete of files and directories update the tree correctly, with no stale/duplicate entries.
- **Directory** symlinks are omitted from the tree; **file** symlinks are shown (intended per `evaluate_entry`).
- Hidden-files toggle (`Toggle Hidden Files`) hides/shows dotfiles.
- Non-git **lazy root**: only the first level loads; a file created in a **collapsed** subdir does not appear until the subdir is expanded (contents read on demand); a file created in an **expanded** subdir appears.
- Delete + recreate of a watched ignored dir: it disappears and reappears (dimmed), and children load dimmed via the ancestor-inheriting `load()` path.
- Root-gitignored dir live child add is tagged ignored correctly (companion test passes).

## Minor observations (not filed as bugs)

- `.git` is shown as a dimmed, expandable folder exposing its internals (`objects`, `hooks`, `refs`, `HEAD`, …). Consistent with the "show ignored, dimmed" model, but most editors hide `.git`; worth a product decision.
- One transient during testing: adding a file inside an expanded ignored `node_modules` momentarily collapsed it in the UI (had to re-expand). The model keeps the dir `loaded` (guarded by `incremental_event_under_expanded_ignored_dir_keeps_it_loaded`), so this looks like a view-refresh transient; not reliably reproducible.

## Tests added

`crates/repo_metadata/src/local_model_tests.rs`:
- `bugbash_incremental_add_direct_child_of_root_ignored_dir` — passes; guards correct root-gitignore tagging on live add.
- `bugbash_incremental_add_respects_nested_gitignore` — `#[ignore]`d; documents bug #1. Un-ignore when the incremental path consults nested `.gitignore`.

Validation: `cargo fmt -p repo_metadata` and `cargo clippy -p repo_metadata --tests -- -D warnings` pass; `cargo test -p repo_metadata bugbash_incremental_add` shows 1 passed / 1 ignored. (Test-only change; full workspace presubmit left to CI.)

---
_Conversation: https://staging.warp.dev/conversation/85667430-54cc-4fe3-b9f8-237b750d400d_
_Run: https://oz.staging.warp.dev/runs/019f200d-d5a2-7c0d-b7d7-1499a70f0f04_

_This PR was generated with [Oz](https://warp.dev/oz)._
