### PR TITLE
Variable-width terminal cells: fix Indic (Telugu) script rendering

### DIFF
--- a/app/src/editor/view/snapshot.rs
+++ b/app/src/editor/view/snapshot.rs
@@ -515,13 +515,20 @@ impl ViewSnapshot {
             .map(|(cur_line_idx, stylized_chars)| {
                 let mut line = String::with_capacity(stylized_chars.len());
                 let mut style_runs = Vec::with_capacity(stylized_chars.len());
-                for (idx, stylized_char) in stylized_chars.into_iter().enumerate() {
+                let mut byte_offset = 0usize;
+                for stylized_char in stylized_chars.into_iter() {
                     // Accumulate both style information and the characters to lay out.
+                    // Use byte offsets (not char indices) so that multi-byte Unicode
+                    // codepoints (Telugu, CJK, emoji, etc.) don't split a char boundary
+                    // and cause a panic in the text layout engine.
+                    let c = stylized_char.char();
+                    let char_byte_len = c.len_utf8();
                     style_runs.push((
-                        idx..idx + 1,
+                        byte_offset..byte_offset + char_byte_len,
                         StyleAndFont::new(family_id, properties, stylized_char.style()),
                     ));
-                    line.push(stylized_char.char());
+                    line.push(c);
+                    byte_offset += char_byte_len;
                 }
 
                 layout_cache.layout_text(

--- a/app/src/terminal/alt_screen/alt_screen_element.rs
+++ b/app/src/terminal/alt_screen/alt_screen_element.rs
@@ -773,7 +773,7 @@ impl Element for AltScreenElement {
             grid_renderer::render_cursor(
                 &self.grid_render_params,
                 grid.cursor_render_point(),
-                grid.is_cursor_on_wide_char(),
+                grid.cursor_cell_span(),
                 model.alt_screen().cursor_style(),
                 padding_x,
                 adjusted_grid_origin,

--- a/app/src/terminal/blockgrid_renderer.rs
+++ b/app/src/terminal/blockgrid_renderer.rs
@@ -164,17 +164,17 @@ impl BlockGrid {
         app: &AppContext,
     ) {
         let cursor_style = self.cursor_style();
-        let (cursor_display_point, is_cursor_on_wide_char, cursor_style, cursor_hint_text) =
+        let (cursor_display_point, cursor_cell_span, cursor_style, cursor_hint_text) =
             match self.cursor_display_point() {
                 Some(CursorDisplayPoint::Visible(cursor_display_point)) => (
                     cursor_display_point,
-                    self.grid_handler().is_cursor_on_wide_char(),
+                    self.grid_handler().cursor_cell_span(),
                     cursor_style,
                     cursor_hint_text,
                 ),
                 Some(CursorDisplayPoint::HiddenCache(cursor_display_point)) => (
                     cursor_display_point,
-                    false,
+                    1,
                     CursorStyle {
                         shape: CursorShape::Hidden,
                         ..cursor_style
@@ -187,7 +187,7 @@ impl BlockGrid {
         render_cursor(
             grid_render_params,
             cursor_display_point,
-            is_cursor_on_wide_char,
+            cursor_cell_span,
             cursor_style,
             grid_render_params.size_info.padding_x_px(),
             grid_origin,

--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -634,7 +634,15 @@ fn render_grid_without_ligatures<'a>(
             if pending_run.as_ref().is_some_and(|pr| col > pr.end_col) {
                 let mut pr = pending_run.take().expect("checked Some above");
                 fill_style_run_gaps(&mut pr.style_runs, pr.shape.full_text.chars().count());
-                render_indic_run(&pr.shape.full_text, &pr.style_runs, pr.run_origin, font_size, ctx);
+                render_indic_run(
+                    &pr.shape,
+                    &pr.style_runs,
+                    pr.run_origin,
+                    pr.run_start_col,
+                    cell_size.x(),
+                    font_size,
+                    ctx,
+                );
             }
 
             let current_point = Point::new(row_idx, col);
@@ -938,7 +946,15 @@ fn render_grid_without_ligatures<'a>(
         // iteration to fire in that case).
         if let Some(mut pr) = pending_run.take() {
             fill_style_run_gaps(&mut pr.style_runs, pr.shape.full_text.chars().count());
-            render_indic_run(&pr.shape.full_text, &pr.style_runs, pr.run_origin, font_size, ctx);
+            render_indic_run(
+                &pr.shape,
+                &pr.style_runs,
+                pr.run_origin,
+                pr.run_start_col,
+                cell_size.x(),
+                font_size,
+                ctx,
+            );
         }
 
         if grid.filter_has_context_lines() {
@@ -2143,6 +2159,11 @@ struct IndicRunShape {
     /// range so the render loop's per-cell style-run accounting (one entry
     /// per non-spacer column in the run) stays in sync.
     char_ranges: Vec<Range<usize>>,
+    /// Grid column where each entry in `char_ranges` starts, parallel to it.
+    /// Used to re-anchor each word at its own logical column when drawing
+    /// (see `render_indic_run`), instead of letting the whole run's
+    /// allocation slack accumulate at its far end.
+    cols: Vec<usize>,
     /// Total grid columns (base + spacer cells + any absorbed connector
     /// cells) consumed by the whole run.
     total_span: usize,
@@ -2209,6 +2230,7 @@ fn scan_indic_run(
     let redacting_secrets = obfuscate_secrets.should_redact_secret();
     let mut full_text = String::new();
     let mut char_ranges = Vec::new();
+    let mut cols = Vec::new();
     let mut col = start_col;
     let mut committed_col = start_col;
 
@@ -2226,12 +2248,14 @@ fn scan_indic_run(
     let commit_connectors = |upto: usize,
                               full_text: &mut String,
                               char_ranges: &mut Vec<Range<usize>>,
+                              cols: &mut Vec<usize>,
                               pending: &[(usize, char)]| {
-        for &(_, c) in &pending[..upto] {
+        for &(entry_col, c) in &pending[..upto] {
             let start_char = full_text.chars().count();
             full_text.push(c);
             let end_char = full_text.chars().count();
             char_ranges.push(start_char..end_char);
+            cols.push(entry_col);
         }
     };
 
@@ -2247,13 +2271,14 @@ fn scan_indic_run(
                 break;
             }
             // Reaching Indic content commits every buffered connector.
-            commit_connectors(pending.len(), &mut full_text, &mut char_ranges, &pending);
+            commit_connectors(pending.len(), &mut full_text, &mut char_ranges, &mut cols, &pending);
             pending.clear();
 
             let start_char = full_text.chars().count();
             append_cell_display(&mut full_text, cell);
             let end_char = full_text.chars().count();
             char_ranges.push(start_char..end_char);
+            cols.push(col);
 
             col += cell.span() as usize;
             committed_col = col;
@@ -2274,7 +2299,7 @@ fn scan_indic_run(
             // Blank tail (or genuinely never-written cells) -- commit
             // everything buffered so far; nothing follows to fabricate a
             // gap against.
-            commit_connectors(pending.len(), &mut full_text, &mut char_ranges, &pending);
+            commit_connectors(pending.len(), &mut full_text, &mut char_ranges, &mut cols, &pending);
             committed_col = pending.last().map_or(committed_col, |&(c, _)| c + 1);
         } else {
             // Visible non-connector content (e.g. ASCII): commit only the
@@ -2287,7 +2312,7 @@ fn scan_indic_run(
                     commit_upto = i + 1;
                 }
             }
-            commit_connectors(commit_upto, &mut full_text, &mut char_ranges, &pending);
+            commit_connectors(commit_upto, &mut full_text, &mut char_ranges, &mut cols, &pending);
             committed_col = if commit_upto > 0 {
                 pending[commit_upto - 1].0 + 1
             } else {
@@ -2300,13 +2325,14 @@ fn scan_indic_run(
     if col >= columns {
         // Ran off the end of the row: same as an empty-cell terminator --
         // commit everything buffered.
-        commit_connectors(pending.len(), &mut full_text, &mut char_ranges, &pending);
+        commit_connectors(pending.len(), &mut full_text, &mut char_ranges, &mut cols, &pending);
         committed_col = pending.last().map_or(committed_col, |&(c, _)| c + 1);
     }
 
     IndicRunShape {
         full_text,
         char_ranges,
+        cols,
         total_span: committed_col - start_col,
     }
 }
@@ -2362,26 +2388,81 @@ fn fill_style_run_gaps(style_runs: &mut Vec<(Range<usize>, StyleAndFont)>, total
     *style_runs = filled;
 }
 
+/// Assigns each entry in `shape.char_ranges` (a real Indic cluster or an
+/// absorbed connector char) to a "word" id, so `render_indic_run` can
+/// re-anchor each word at its own grid column instead of letting a whole
+/// multi-word run's allocation slack compound across every word before it.
+///
+/// Only an actual Indic cluster can start a new word -- connectors
+/// (spaces, punctuation) never do, they always ride with whatever word is
+/// current. A new word starts at a cluster that follows at least one space
+/// since the previous cluster (i.e. two clusters joined by an absorbed
+/// space get different word ids; trailing or leading punctuation around
+/// that space rides with whichever word it's adjacent to, matching
+/// `scan_indic_run`'s own attachment rules -- it never introduces a real
+/// allocation boundary of its own, only Indic clusters do, since only
+/// clusters go through `ansi_handler.rs`'s cumulative word-allocation
+/// accounting). Pure and independent of any shaping/glyph data, so it's
+/// unit-testable on its own.
+fn entry_word_ids(shape: &IndicRunShape) -> Vec<usize> {
+    let chars: Vec<char> = shape.full_text.chars().collect();
+    let mut word_ids = Vec::with_capacity(shape.char_ranges.len());
+    let mut current_word = 0usize;
+    let mut any_cluster_seen = false;
+    let mut space_seen_since_last_cluster = false;
+    for range in &shape.char_ranges {
+        let single_char = (range.end - range.start == 1)
+            .then(|| chars.get(range.start).copied())
+            .flatten();
+        let is_space = single_char == Some(' ');
+        let is_connector = is_space || single_char.is_some_and(is_connector_punct);
+
+        if !is_connector {
+            if any_cluster_seen && space_seen_since_last_cluster {
+                current_word += 1;
+            }
+            any_cluster_seen = true;
+            space_seen_since_last_cluster = false;
+        } else if is_space {
+            space_seen_since_last_cluster = true;
+        }
+        word_ids.push(current_word);
+    }
+    word_ids
+}
+
 /// Renders a whole contiguous Indic run (possibly several syllables/words)
-/// as ONE Core Text shaping call, so inter-cluster spacing flows at the
-/// font's natural advances instead of being centred (and gapped) per
-/// cluster -- matching how a proportional rich-text renderer already draws
-/// the same text. Each style run keeps its own cluster's resolved
-/// foreground color; Core Text splits `CTRun`s at style-attribute
+/// as ONE Core Text shaping call, so inter-cluster AND inter-word spacing
+/// flows at the font's natural advances instead of being centred (and
+/// gapped) per cluster -- matching how a proportional rich-text renderer
+/// already draws the same text. Each style run keeps its own cluster's
+/// resolved foreground color; Core Text splits `CTRun`s at style-attribute
 /// boundaries on its own, so per-cluster color fidelity (search highlight,
 /// syntax color, etc.) survives being shaped together.
+///
+/// Every word is then re-anchored at its own logical grid column (rather
+/// than left at wherever continuous natural-flow positioning would put it)
+/// -- otherwise every word's small `ceil()`-rounding allocation slack
+/// (`ansi_handler.rs::flush_pending_indic_cluster`) would compound across
+/// every word in the run and surface as one large gap wherever the run
+/// ends (see the Telugu variable-width-cells plan's Phase 12 execution
+/// log for the diagnosed numbers). Re-anchoring bounds every gap to a
+/// single word's own local slack, regardless of how many words are merged
+/// into the run or what follows it.
 fn render_indic_run(
-    run_text: &str,
+    shape: &IndicRunShape,
     style_runs: &[(Range<usize>, StyleAndFont)],
     origin: Vector2F,
+    run_start_col: usize,
+    cell_width: f32,
     font_size: f32,
     ctx: &mut PaintContext,
 ) {
-    if run_text.is_empty() || style_runs.is_empty() {
+    if shape.full_text.is_empty() || style_runs.is_empty() {
         return;
     }
     let line = ctx.text_layout_cache.layout_line(
-        run_text,
+        &shape.full_text,
         LineStyle {
             font_size,
             line_height_ratio: 1.0,
@@ -2393,13 +2474,64 @@ fn render_indic_run(
         Default::default(),
         &ctx.font_cache.text_layout_system(),
     );
+
+    let word_ids = entry_word_ids(shape);
+    let num_words = word_ids.last().map_or(0, |id| id + 1);
+
+    let total_chars = shape.full_text.chars().count();
+    let mut char_idx_to_word = vec![0usize; total_chars];
+    for (entry_idx, range) in shape.char_ranges.iter().enumerate() {
+        for char_idx in range.clone() {
+            if char_idx < total_chars {
+                char_idx_to_word[char_idx] = word_ids[entry_idx];
+            }
+        }
+    }
+
+    // Leftmost natural glyph position per word (`min`, not the first glyph
+    // by string order, since Core Text can reorder glyphs within a cluster
+    // -- e.g. a pre-base vowel sign drawn before its consonant).
+    let mut natural_start = vec![f32::INFINITY; num_words];
+    for run in &line.runs {
+        for glyph in &run.glyphs {
+            let word = char_idx_to_word.get(glyph.index).copied().unwrap_or(0);
+            natural_start[word] = natural_start[word].min(glyph.position_along_baseline.x());
+        }
+    }
+
+    // First entry's grid column for each word.
+    let mut word_start_col = vec![run_start_col; num_words];
+    let mut seen = vec![false; num_words];
+    for (entry_idx, &word) in word_ids.iter().enumerate() {
+        if !seen[word] {
+            seen[word] = true;
+            word_start_col[word] = shape.cols[entry_idx];
+        }
+    }
+
+    let shifts: Vec<f32> = (0..num_words)
+        .map(|word| {
+            if !natural_start[word].is_finite() {
+                return 0.0;
+            }
+            let logical_x = (word_start_col[word] - run_start_col) as f32 * cell_width;
+            // Never negative by construction (word allocation always covers
+            // its own natural width -- see the flush_pending_indic_cluster
+            // invariant proof), but clamp defensively against float drift.
+            (logical_x - natural_start[word]).max(0.0)
+        })
+        .collect();
+
     for run in &line.runs {
         if run.glyphs.is_empty() {
             continue;
         }
         let color = run.styles.foreground_color.unwrap_or_default();
         for glyph in &run.glyphs {
-            let glyph_origin = origin + vec2f(glyph.position_along_baseline.x(), 0.0);
+            let word = char_idx_to_word.get(glyph.index).copied().unwrap_or(0);
+            let shift = shifts.get(word).copied().unwrap_or(0.0);
+            let glyph_origin =
+                origin + vec2f(glyph.position_along_baseline.x() + shift, 0.0);
             ctx.scene
                 .draw_glyph(glyph_origin, glyph.id, run.font_id, font_size, color);
         }

--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -34,9 +34,8 @@ use super::model::terminal_model::RangeInModel;
 use crate::settings::EnforceMinimumContrast;
 use crate::terminal::grid_size_util::calculate_grid_baseline_position;
 use crate::terminal::model::ansi::{Color, CursorShape, CursorStyle};
-use crate::terminal::model::cell::{Cell, Flags, DEFAULT_CHAR};
+use crate::terminal::model::cell::{Cell, Flags};
 use crate::terminal::model::indic::{is_in_indic_block, is_indic_str};
-use crate::terminal::model::grid::row::Row;
 use crate::terminal::model::grid::Dimensions;
 use crate::terminal::model::index::Point;
 use crate::terminal::model::selection::SelectionPoint;
@@ -621,38 +620,7 @@ fn render_grid_without_ligatures<'a>(
             continue;
         };
 
-        // Single scale for every Indic run on this row (Layer A shaping fix):
-        // computed once up front so all Telugu words on the line render at
-        // the SAME font size, while the row's tightest-fitting run still
-        // guarantees no run overflows into a neighbouring cell.
-        let row_indic_scale = compute_indic_row_scale(
-            &row,
-            grid.columns(),
-            cell_size.x(),
-            font_family,
-            font_size,
-            ctx,
-        );
-
-        // How many upcoming cells are absorbed by an Indic cluster that started on the
-        // previous cell (or the cell before that for 3-part clusters).  Set to 1 for a
-        // 2-cell cluster (base+virama + consonant, or consonant + vowel sign), to 2 for
-        // a 3-cell cluster (virama-conjunct + trailing vowel sign / anusvara).
-        // Decremented at the top of every column iteration; reset per row so clusters
-        // never bleed across line boundaries.
-        let mut cells_to_absorb_after: usize = 0;
-
         for col in 0..grid.columns() {
-            // Consume one absorption slot at the top of every column iteration so that
-            // early `continue` paths (WIDE_CHAR_SPACER, empty cells) don't leave stale
-            // state.  Decrementing here (rather than inside the cluster branch) keeps
-            // the count correct even when a cell is skipped by an early continue.
-            let this_cell_absorbed = if cells_to_absorb_after > 0 {
-                cells_to_absorb_after -= 1;
-                true
-            } else {
-                false
-            };
             let current_point = Point::new(row_idx, col);
 
             // Skip the cursor cell when CLI agent rich input is open
@@ -718,7 +686,6 @@ fn render_grid_without_ligatures<'a>(
                         &mut native_glyphs_to_render,
                         obfuscate_secrets,
                         None::<(&str, usize)>, // marked text cells are never part of Indic clusters
-                        1.0, // no scaling for marked-text cells
                         bg_color_sampler.as_deref_mut(),
                         ctx,
                     );
@@ -823,47 +790,27 @@ fn render_grid_without_ligatures<'a>(
                 }
             }
 
-            // Indic full-run look-ahead (Layer A + Layer B shaping fix).
-            //
-            // Instead of detecting only 2-cell conjunct clusters, we scan forward
-            // to collect ALL consecutive Indic-script cells into one proportional
-            // Core Text run.  The entire run string is shaped by Core Text in a
-            // single call, so glyphs land at their natural advance positions —
-            // exactly what Obsidian, browsers, and any proportional renderer do.
-            // No manual gap arithmetic is needed.
+            // Indic cluster rendering: the cell's own content already holds
+            // the full cluster string (written at input time via
+            // `push_zerowidth`, see `ansi_handler.rs::write_grapheme_cluster`)
+            // and its own real measured span (`Cell::span()`) -- no look-ahead
+            // scan across neighbouring cells is needed any more.
             //
             // Tuple: (run_string, span_cells).
-            //   span_cells = 0 for absorbed cells (run_string is empty).
-            //   span_cells = 1..N for the first cell of an N-cell run.
-            let cluster_for_this_cell: Option<(String, usize)> = if this_cell_absorbed {
-                Some((String::new(), 0)) // glyph absorbed; background still rendered
-            } else if is_indic_cell(cell) {
-                // Collect the full consecutive Indic run starting at this cell.
-                let mut run = String::new();
-                append_cell_display(&mut run, cell);
-                let mut span = 1usize;
-                let mut scan = col + 1;
-                while scan < grid.columns() {
-                    let sc = &row[scan];
-                    if sc.c == DEFAULT_CHAR
-                        || sc
-                            .flags()
-                            .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
-                        || !is_indic_cell(sc)
-                    {
-                        break;
-                    }
-                    append_cell_display(&mut run, sc);
-                    span += 1;
-                    scan += 1;
-                }
-                if span > 1 {
-                    cells_to_absorb_after = span - 1;
-                }
-                Some((run, span))
-            } else {
-                None
-            };
+            //   span_cells = 0 for a spacer cell (run_string is empty; its
+            //   glyph was already drawn when its cluster's base cell was
+            //   processed -- only its background/highlight still renders).
+            //   span_cells = 1..N for the base cell of an N-cell cluster.
+            let cluster_for_this_cell: Option<(String, usize)> =
+                if cell.flags().intersects(Flags::WIDE_CHAR_SPACER) {
+                    Some((String::new(), 0))
+                } else if is_indic_cell(cell) {
+                    let mut run = String::new();
+                    append_cell_display(&mut run, cell);
+                    Some((run, cell.span() as usize))
+                } else {
+                    None
+                };
 
             // Don't apply cursor contrast colouring when hide_cursor_cell
             // is active — the cursor itself won't be drawn, so the cell
@@ -898,7 +845,6 @@ fn render_grid_without_ligatures<'a>(
                 &mut native_glyphs_to_render,
                 obfuscate_secrets,
                 cluster_for_this_cell.as_ref().map(|(s, n)| (s.as_str(), *n)),
-                row_indic_scale,
                 bg_color_sampler.as_deref_mut(),
                 ctx,
             );
@@ -975,7 +921,6 @@ fn render_cell(
     native_glyphs_to_render: &mut Vec<NativeGlyph>,
     obfuscate_mode: ObfuscateSecrets,
     cluster_glyph_override: Option<(&str, usize)>,
-    row_indic_scale: f32,
     bg_color_sampler: Option<&mut ColorSampler>,
     ctx: &mut PaintContext,
 ) -> Option<CachedBackgroundColor> {
@@ -1023,7 +968,6 @@ fn render_cell(
         native_glyphs_to_render,
         obfuscate_mode,
         cluster_glyph_override,
-        row_indic_scale,
         ctx,
     );
     cell_decorations.extend(calculate_cell_decorations(
@@ -1769,7 +1713,6 @@ fn render_cell_glyph(
     //  - Some(s)  → render the full conjunct string s (e.g. "క్ష") at this position.
     // Ignored when secret redaction is active (secrets always override everything).
     cluster_glyph_override: Option<(&str, usize)>,
-    row_indic_scale: f32,
     ctx: &mut PaintContext,
 ) {
     // A cluster's base cell occupies `span()` cells (1 for a normal char, up
@@ -1824,7 +1767,19 @@ fn render_cell_glyph(
             // shapes the whole string at once — inter-glyph spacing is
             // determined by the font's natural advances, exactly as in
             // browsers and Obsidian.  No manual gap arithmetic needed.
-            let allocated_width = span as f32 * cell_size.x();
+            //
+            // `cell_size.x()` here is ALREADY scaled by `cell.span()` (see
+            // the reassignment at the top of this function) -- it's not a
+            // single cell's width any more, it's the full allocated width
+            // for this cluster's entire span. Multiplying by `span` again
+            // here would square it (e.g. span=3 -> 9x a single cell's
+            // width instead of 3x), blowing the centering math up and
+            // making clusters look torn apart with huge gaps.
+            let allocated_width = cell_size.x();
+            debug_assert_eq!(
+                span, cell.span() as usize,
+                "cluster_glyph_override's span should always match cell.span()"
+            );
             render_indic_cluster(
                 cluster_str,
                 origin,
@@ -1833,7 +1788,6 @@ fn render_cell_glyph(
                 font_size,
                 properties,
                 foreground_color,
-                row_indic_scale,
                 ctx,
             );
             None // Glyphs rendered inline; skip single-glyph path.
@@ -1849,36 +1803,19 @@ fn render_cell_glyph(
                 // the single character. For example, in \0x2601\0xFE0F, the FE0F selector causes ☁️ to be changed from a
                 // 1-width char to a 2-width char.
                 //
-                // Layer B Indic path: a cell whose Str content is an Indic grapheme cluster
-                // (e.g. "భు", "క్ష", "త్వం" — assembled by the PTY width-override) needs
-                // all Core Text glyphs drawn, not just the first one returned by glyph_for_string.
-                CharOrStr::Str(content_with_zerowidth) => {
-                    if is_indic_str(content_with_zerowidth) {
-                        // Layer B: 1-cell span.  Centre within cell_size.x().
-                        render_indic_cluster(
-                            content_with_zerowidth,
-                            origin,
-                            cell_size.x(),
-                            font_family,
-                            font_size,
-                            properties,
-                            foreground_color,
-                            row_indic_scale,
-                            ctx,
-                        );
-                        None // Rendered inline; skip single-glyph path below.
-                    } else {
-                        glyphs.glyph_for_string(
-                            content_with_zerowidth,
-                            *font_id,
-                            ctx.font_cache,
-                            font_family,
-                            font_size,
-                            properties,
-                            ctx,
-                        )
-                    }
-                }
+                // Note: Indic-script content never reaches this arm -- any
+                // cell where `is_indic_cell` is true already produced a
+                // `Some(cluster_str, span)` override above, rendered via
+                // `render_indic_cluster`.
+                CharOrStr::Str(content_with_zerowidth) => glyphs.glyph_for_string(
+                    content_with_zerowidth,
+                    *font_id,
+                    ctx.font_cache,
+                    font_family,
+                    font_size,
+                    properties,
+                    ctx,
+                ),
             }
         }
     } else {
@@ -2031,10 +1968,15 @@ fn render_image(
     }
 }
 
-/// Renders all Core Text glyphs for an Indic grapheme cluster string at `origin`.
+/// Renders all Core Text glyphs for an Indic grapheme cluster string at
+/// `origin`, centred within its allocated cell span.
 ///
-/// Called for both the Layer A look-ahead path (conjunct spanning two cells) and the
-/// Layer B path (cluster already assembled into a single cell by the PTY width override).
+/// No scaling: since `Cell::span()` is now measured from this exact same
+/// shaping call at input time (see `ClusterWidthMeasurer` /
+/// `ansi_handler.rs::handle_indic_char`), the allocated width already
+/// matches the cluster's natural width by construction -- any residual gap
+/// is just rounding from `span`'s `ceil()`, absorbed by centering exactly
+/// like a CJK wide char already is.
 ///
 /// Uses `layout_line` rather than `glyph_for_string` because:
 ///   • Conjuncts like "క్ష" produce BASE + SUBSCRIPT glyphs (≥2 per cluster).
@@ -2050,18 +1992,13 @@ fn render_indic_cluster(
     font_size: f32,
     properties: Properties,
     foreground_color: ColorU,
-    // Uniform scale for every Indic run on this row (see
-    // `compute_indic_row_scale`) — NOT computed per-word, so every Telugu
-    // word on the line renders at the same visual font size.
-    row_indic_scale: f32,
     ctx: &mut PaintContext,
 ) {
     let run_length_chars = cluster_str.chars().count();
-    let effective_font_size = font_size * row_indic_scale;
     let cluster_line = ctx.text_layout_cache.layout_line(
         cluster_str,
         LineStyle {
-            font_size: effective_font_size,
+            font_size,
             line_height_ratio: 1.0,
             baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
             fixed_width_tab_size: None,
@@ -2090,87 +2027,11 @@ fn render_indic_cluster(
                 glyph_origin,
                 glyph.id,
                 run.font_id,
-                effective_font_size,
+                font_size,
                 foreground_color,
             );
         }
     }
-}
-
-/// Scans an entire row for Indic-script runs and returns the single tightest
-/// fit-scale across all of them (capped at 1.0).  Using one scale for the
-/// whole row — rather than a per-word scale — keeps every Telugu word on the
-/// row at the SAME visual font size, while still guaranteeing no run
-/// overflows its allocated cells (the row's narrowest-fitting run sets the
-/// scale for everyone).  Returns 1.0 when the row has no Indic content.
-fn compute_indic_row_scale(
-    row: &Row,
-    columns: usize,
-    cell_width: f32,
-    font_family: FamilyId,
-    font_size: f32,
-    ctx: &mut PaintContext,
-) -> f32 {
-    let mut min_scale = 1.0f32;
-    let mut col = 0usize;
-    while col < columns {
-        let cell = &row[col];
-        if cell.c == DEFAULT_CHAR
-            || cell
-                .flags()
-                .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
-            || !is_indic_cell(cell)
-        {
-            col += 1;
-            continue;
-        }
-        let mut run = String::new();
-        append_cell_display(&mut run, cell);
-        let mut span = 1usize;
-        let mut scan = col + 1;
-        while scan < columns {
-            let sc = &row[scan];
-            if sc.c == DEFAULT_CHAR
-                || sc
-                    .flags()
-                    .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
-                || !is_indic_cell(sc)
-            {
-                break;
-            }
-            append_cell_display(&mut run, sc);
-            span += 1;
-            scan += 1;
-        }
-        let run_length_chars = run.chars().count();
-        let allocated_width = span as f32 * cell_width;
-        let natural_line = ctx.text_layout_cache.layout_line(
-            &run,
-            LineStyle {
-                font_size,
-                line_height_ratio: 1.0,
-                baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
-                fixed_width_tab_size: None,
-            },
-            &[(
-                0..run_length_chars,
-                StyleAndFont {
-                    font_family,
-                    properties: Properties::default(),
-                    style: Default::default(),
-                },
-            )],
-            f32::MAX,
-            Default::default(),
-            &ctx.font_cache.text_layout_system(),
-        );
-        if natural_line.width > 0.0 {
-            let ratio = (allocated_width / natural_line.width).min(1.0);
-            min_scale = min_scale.min(ratio);
-        }
-        col = scan;
-    }
-    min_scale
 }
 
 /// Returns `true` if `cell` contains Indic-script content (used by the full-run

--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -28,6 +28,7 @@ use super::block_filter::{BLOCK_FILTER_DOTTED_LINE_DASH, BLOCK_FILTER_DOTTED_LIN
 use super::blockgrid_renderer::GridRenderParams;
 use super::model::char_or_str::CharOrStr;
 use super::model::grid::grid_handler::{ContainsPoint, GridHandler, Link};
+use super::model::grid::row::Row;
 use super::model::grid::RespectDisplayedOutput;
 use super::model::image_map::{ImagePlacementData, StoredImageMetadata};
 use super::model::terminal_model::RangeInModel;
@@ -620,7 +621,21 @@ fn render_grid_without_ligatures<'a>(
             continue;
         };
 
+        let mut pending_run: Option<PendingIndicRun> = None;
+
         for col in 0..grid.columns() {
+            // Flush any Indic run whose last column has already been
+            // passed. Checking this at the top of the NEXT column's
+            // iteration (rather than right after the run's own last
+            // column) means it never depends on whether that column hit an
+            // early `continue` below (e.g. a trailing spacer cell skipped
+            // by the WIDE_CHAR_SPACER check) -- every column belonging to
+            // the run has already been fully processed by now regardless.
+            if pending_run.as_ref().is_some_and(|pr| col > pr.end_col) {
+                let pr = pending_run.take().expect("checked Some above");
+                render_indic_run(&pr.shape.full_text, &pr.style_runs, pr.run_origin, font_size, ctx);
+            }
+
             let current_point = Point::new(row_idx, col);
 
             // Skip the cursor cell when CLI agent rich input is open
@@ -790,28 +805,6 @@ fn render_grid_without_ligatures<'a>(
                 }
             }
 
-            // Indic cluster rendering: the cell's own content already holds
-            // the full cluster string (written at input time via
-            // `push_zerowidth`, see `ansi_handler.rs::write_grapheme_cluster`)
-            // and its own real measured span (`Cell::span()`) -- no look-ahead
-            // scan across neighbouring cells is needed any more.
-            //
-            // Tuple: (run_string, span_cells).
-            //   span_cells = 0 for a spacer cell (run_string is empty; its
-            //   glyph was already drawn when its cluster's base cell was
-            //   processed -- only its background/highlight still renders).
-            //   span_cells = 1..N for the base cell of an N-cell cluster.
-            let cluster_for_this_cell: Option<(String, usize)> =
-                if cell.flags().intersects(Flags::WIDE_CHAR_SPACER) {
-                    Some((String::new(), 0))
-                } else if is_indic_cell(cell) {
-                    let mut run = String::new();
-                    append_cell_display(&mut run, cell);
-                    Some((run, cell.span() as usize))
-                } else {
-                    None
-                };
-
             // Don't apply cursor contrast colouring when hide_cursor_cell
             // is active — the cursor itself won't be drawn, so the cell
             // should render with its normal colours.
@@ -819,6 +812,95 @@ fn render_grid_without_ligatures<'a>(
                 && grid.cursor_point() == Point::new(offset_row, col)
                 && visible_cursor_shape == Some(CursorShape::Block))
             .then(|| theme.cursor().into_solid());
+
+            let is_wide_char_spacer = cell.flags().intersects(Flags::WIDE_CHAR_SPACER);
+
+            // Start a new contiguous Indic run when we hit an unmerged base
+            // cell. `scan_indic_run` is a pure content scan (no color/match
+            // state) so it can safely look ahead across the whole run right
+            // away; per-cluster color is only resolved as the loop reaches
+            // each column below, and deferred-drawn as one shaped unit once
+            // the run's last column has been passed (see the flush check at
+            // the top of this loop, and after it for a row-ending run).
+            if pending_run.is_none() && !is_wide_char_spacer && is_indic_cell(cell) {
+                let shape =
+                    scan_indic_run(&row, col, grid.columns(), grid, offset_row, obfuscate_secrets);
+                if shape.total_span > 0 {
+                    let run_origin = grid_origin
+                        + cell_size * vec2f(col as f32, offset_row as f32)
+                        + baseline_position;
+                    pending_run = Some(PendingIndicRun {
+                        end_col: col + shape.total_span - 1,
+                        run_start_col: col,
+                        shape,
+                        run_origin,
+                        style_runs: Vec::new(),
+                        next_cluster_idx: 0,
+                    });
+                }
+                // If `shape.total_span == 0`, this cell can't be merged
+                // (e.g. it's secret-redacted) -- fall through below to the
+                // pre-existing independent-cluster rendering path, which
+                // defers correctly to `render_cell_glyph`'s own per-cell
+                // secret redaction.
+            }
+
+            // Tuple: (run_string, span_cells).
+            //   span_cells = 0 for a spacer cell, or for a cell whose glyph
+            //   is deferred to a merged run's `render_indic_run` call.
+            //   span_cells = 1..N for the base cell of an independently
+            //   rendered N-cell cluster (no active merged run covers it).
+            let cluster_for_this_cell: Option<(String, usize)> = if let Some(pr) =
+                pending_run.as_mut()
+            {
+                if col >= pr.run_start_col && col <= pr.end_col {
+                    if !is_wide_char_spacer {
+                        // Base cell of one cluster within the run: resolve
+                        // its real color now (this is exactly why
+                        // run-detection can't be a separate pre-pass --
+                        // `cell_colors` depends on the stateful
+                        // find-match/secret tracking above, valid only at
+                        // this column) and record it against this
+                        // cluster's char range. Its glyph draw is deferred
+                        // to `render_indic_run`.
+                        let this_cell_colors = cell_colors(
+                            cell,
+                            colors,
+                            override_colors,
+                            &cell_type,
+                            alpha,
+                            enforce_minimal_contrast,
+                            &mut minimal_contrast_cache,
+                            cursor_color,
+                            obfuscate_secrets,
+                        );
+                        let properties = FontStyle::from(cell.flags).to_properties();
+                        if let Some(range) = pr.shape.char_ranges.get(pr.next_cluster_idx) {
+                            pr.style_runs.push((
+                                range.clone(),
+                                StyleAndFont::new(
+                                    font_family,
+                                    properties,
+                                    TextStyle::new()
+                                        .with_foreground_color(this_cell_colors.foreground_color),
+                                ),
+                            ));
+                        }
+                        pr.next_cluster_idx += 1;
+                    }
+                    Some((String::new(), 0))
+                } else {
+                    None
+                }
+            } else if is_wide_char_spacer {
+                Some((String::new(), 0))
+            } else if is_indic_cell(cell) {
+                let mut run = String::new();
+                append_cell_display(&mut run, cell);
+                Some((run, cell.span() as usize))
+            } else {
+                None
+            };
             cached_background_color = render_cell(
                 grid,
                 offset_row,
@@ -848,6 +930,13 @@ fn render_grid_without_ligatures<'a>(
                 bg_color_sampler.as_deref_mut(),
                 ctx,
             );
+        }
+
+        // Flush a run that extends all the way to the row's last column
+        // (the `col > pr.end_col` check above never gets a "next column"
+        // iteration to fire in that case).
+        if let Some(pr) = pending_run.take() {
+            render_indic_run(&pr.shape.full_text, &pr.style_runs, pr.run_origin, font_size, ctx);
         }
 
         if grid.filter_has_context_lines() {
@@ -2030,6 +2119,137 @@ fn render_indic_cluster(
                 font_size,
                 foreground_color,
             );
+        }
+    }
+}
+
+/// Shape of one maximal contiguous run of Indic-script cells within a row, as
+/// scanned by `scan_indic_run`. Pure content scan (no color/match state) --
+/// built once, cheaply, when the render loop encounters the run's first
+/// (unmerged) base cell.
+struct IndicRunShape {
+    /// Concatenated cluster text for the whole run, shaped as ONE Core Text
+    /// call so inter-cluster spacing flows at the font's natural advances
+    /// instead of being centred (and gapped) per cluster.
+    full_text: String,
+    /// Char-index range into `full_text` for each cluster, in column order.
+    char_ranges: Vec<Range<usize>>,
+    /// Total grid columns (base + spacer cells) consumed by the whole run.
+    total_span: usize,
+}
+
+/// Scans forward from `start_col` collecting a maximal run of contiguous
+/// Indic cells (a base cell's own span, followed immediately by the next
+/// cluster's base cell, and so on) into one shape.
+///
+/// A candidate cluster that is secret-redacted stops the run right there
+/// (excluding it) rather than merging it in: a merged run's glyphs are drawn
+/// via `render_indic_run`, which bypasses `render_cell_glyph`'s per-cell
+/// secret-redaction check entirely, so a secret cluster must never be
+/// merged. `secret_at_displayed_point` is a stateless positional lookup (not
+/// a sequentially-advancing iterator like the find-match tracking in the
+/// caller), so it's safe to query here inside a lookahead.
+fn scan_indic_run(
+    row: &Row,
+    start_col: usize,
+    columns: usize,
+    grid: &GridHandler,
+    offset_row: usize,
+    obfuscate_secrets: ObfuscateSecrets,
+) -> IndicRunShape {
+    let redacting_secrets = obfuscate_secrets.should_redact_secret();
+    let mut full_text = String::new();
+    let mut char_ranges = Vec::new();
+    let mut col = start_col;
+
+    while col < columns {
+        let cell = &row[col];
+        if cell.flags().intersects(Flags::WIDE_CHAR_SPACER) {
+            col += 1;
+            continue;
+        }
+        if !is_indic_cell(cell) {
+            break;
+        }
+        if redacting_secrets
+            && grid
+                .secret_at_displayed_point(Point::new(offset_row, col))
+                .is_some()
+        {
+            break;
+        }
+
+        let start_char = full_text.chars().count();
+        append_cell_display(&mut full_text, cell);
+        let end_char = full_text.chars().count();
+        char_ranges.push(start_char..end_char);
+
+        col += cell.span() as usize;
+    }
+
+    IndicRunShape {
+        full_text,
+        char_ranges,
+        total_span: col - start_col,
+    }
+}
+
+/// State for a contiguous Indic run whose glyph drawing is deferred until
+/// the run's last column has been passed -- see `render_grid_without_ligatures`.
+struct PendingIndicRun {
+    shape: IndicRunShape,
+    run_start_col: usize,
+    /// Last grid column (inclusive) occupied by the run.
+    end_col: usize,
+    /// Origin (baseline position) of the run's first column, where the
+    /// whole run's shaped glyphs get drawn from.
+    run_origin: Vector2F,
+    style_runs: Vec<(Range<usize>, StyleAndFont)>,
+    /// Index into `shape.char_ranges` of the next cluster whose color has
+    /// not yet been resolved and pushed into `style_runs`.
+    next_cluster_idx: usize,
+}
+
+/// Renders a whole contiguous Indic run (possibly several syllables/words)
+/// as ONE Core Text shaping call, so inter-cluster spacing flows at the
+/// font's natural advances instead of being centred (and gapped) per
+/// cluster -- matching how a proportional rich-text renderer already draws
+/// the same text. Each style run keeps its own cluster's resolved
+/// foreground color; Core Text splits `CTRun`s at style-attribute
+/// boundaries on its own, so per-cluster color fidelity (search highlight,
+/// syntax color, etc.) survives being shaped together.
+fn render_indic_run(
+    run_text: &str,
+    style_runs: &[(Range<usize>, StyleAndFont)],
+    origin: Vector2F,
+    font_size: f32,
+    ctx: &mut PaintContext,
+) {
+    if run_text.is_empty() || style_runs.is_empty() {
+        return;
+    }
+    let line = ctx.text_layout_cache.layout_line(
+        run_text,
+        LineStyle {
+            font_size,
+            line_height_ratio: 1.0,
+            baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
+            fixed_width_tab_size: None,
+        },
+        style_runs,
+        f32::MAX,
+        Default::default(),
+        &ctx.font_cache.text_layout_system(),
+    );
+    for run in &line.runs {
+        if run.glyphs.is_empty() {
+            continue;
+        }
+        let color = run.styles.foreground_color.unwrap_or_default();
+        for glyph in &run.glyphs {
+            let glyph_origin = origin + vec2f(glyph.position_along_baseline.x(), 0.0);
+            ctx.scene
+                .draw_glyph(glyph_origin, glyph.id, run.font_id, font_size, color);
         }
     }
 }

--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -632,7 +632,8 @@ fn render_grid_without_ligatures<'a>(
             // by the WIDE_CHAR_SPACER check) -- every column belonging to
             // the run has already been fully processed by now regardless.
             if pending_run.as_ref().is_some_and(|pr| col > pr.end_col) {
-                let pr = pending_run.take().expect("checked Some above");
+                let mut pr = pending_run.take().expect("checked Some above");
+                fill_style_run_gaps(&mut pr.style_runs, pr.shape.full_text.chars().count());
                 render_indic_run(&pr.shape.full_text, &pr.style_runs, pr.run_origin, font_size, ctx);
             }
 
@@ -935,7 +936,8 @@ fn render_grid_without_ligatures<'a>(
         // Flush a run that extends all the way to the row's last column
         // (the `col > pr.end_col` check above never gets a "next column"
         // iteration to fire in that case).
-        if let Some(pr) = pending_run.take() {
+        if let Some(mut pr) = pending_run.take() {
+            fill_style_run_gaps(&mut pr.style_runs, pr.shape.full_text.chars().count());
             render_indic_run(&pr.shape.full_text, &pr.style_runs, pr.run_origin, font_size, ctx);
         }
 
@@ -2123,32 +2125,79 @@ fn render_indic_cluster(
     }
 }
 
-/// Shape of one maximal contiguous run of Indic-script cells within a row, as
-/// scanned by `scan_indic_run`. Pure content scan (no color/match state) --
-/// built once, cheaply, when the render loop encounters the run's first
-/// (unmerged) base cell.
+/// Shape of one maximal contiguous run of Indic-script cells (plus absorbed
+/// connector cells -- spaces and attached punctuation, see `scan_indic_run`)
+/// within a row. Pure content scan (no color/match state) -- built once,
+/// cheaply, when the render loop encounters the run's first (unmerged) base
+/// cell.
 struct IndicRunShape {
-    /// Concatenated cluster text for the whole run, shaped as ONE Core Text
-    /// call so inter-cluster spacing flows at the font's natural advances
-    /// instead of being centred (and gapped) per cluster.
+    /// Concatenated text for the whole run (clusters plus any absorbed
+    /// spaces/punctuation), shaped as ONE Core Text call so inter-cluster
+    /// AND inter-word spacing flows at the font's natural advances instead
+    /// of being centred (and gapped) per cluster or left as full fixed-cell
+    /// monospace gaps between words.
     full_text: String,
-    /// Char-index range into `full_text` for each cluster, in column order.
+    /// Char-index range into `full_text` for each "cluster" -- either a real
+    /// Indic grapheme cluster, or a single absorbed connector char (space or
+    /// punctuation), in column order. Connectors get their own one-char
+    /// range so the render loop's per-cell style-run accounting (one entry
+    /// per non-spacer column in the run) stays in sync.
     char_ranges: Vec<Range<usize>>,
-    /// Total grid columns (base + spacer cells) consumed by the whole run.
+    /// Total grid columns (base + spacer cells + any absorbed connector
+    /// cells) consumed by the whole run.
     total_span: usize,
+}
+
+/// A single-width, non-Indic cell that can be absorbed into an Indic run
+/// when it joins two runs (a space between two Telugu words) or trails one
+/// (punctuation directly after a Telugu word) -- so the whole segment shapes
+/// as one Core Text call, matching how a proportional rich-text renderer
+/// draws the same text (natural space width, attached punctuation).
+fn is_connector_cell(cell: &Cell) -> bool {
+    if cell.span() != 1 || cell.is_empty() {
+        return false;
+    }
+    matches!(
+        cell.content_for_display(),
+        CharOrStr::Char(c) if c == ' ' || is_connector_punct(c)
+    )
+}
+
+fn is_connector_punct(c: char) -> bool {
+    matches!(c, '.' | ',' | '!' | '?' | ':' | ';' | '"' | '\'' | '(' | ')' | '-')
 }
 
 /// Scans forward from `start_col` collecting a maximal run of contiguous
 /// Indic cells (a base cell's own span, followed immediately by the next
-/// cluster's base cell, and so on) into one shape.
+/// cluster's base cell, and so on), absorbing spaces/punctuation
+/// (`is_connector_cell`) between and after clusters where doing so can't
+/// fabricate a visual gap that wasn't already there. Candidate connectors
+/// are buffered, not committed immediately -- `total_span` only advances
+/// past a connector once it's actually included in the run:
 ///
-/// A candidate cluster that is secret-redacted stops the run right there
-/// (excluding it) rather than merging it in: a merged run's glyphs are drawn
-/// via `render_indic_run`, which bypasses `render_cell_glyph`'s per-cell
-/// secret-redaction check entirely, so a secret cluster must never be
-/// merged. `secret_at_displayed_point` is a stateless positional lookup (not
-/// a sequentially-advancing iterator like the find-match tracking in the
-/// caller), so it's safe to query here inside a lookahead.
+/// - Reaching another Indic cluster commits the whole buffer (a space
+///   between two Telugu words is absorbed only when Telugu text follows --
+///   this is what lets it shape as one continuous segment).
+/// - Reaching an empty cell or the end of the row commits the whole buffer
+///   (trailing punctuation/spaces before end-of-line attach to the last
+///   word; any leftover slack lands after everything, where nothing follows
+///   -- invisible).
+/// - Reaching a non-connector, non-empty (i.e. real ASCII/other-script)
+///   cell commits only the buffered prefix up through the last punctuation
+///   character that is itself followed (in the buffer) by a space -- so
+///   "తెలుగు abc" absorbs nothing (matches pre-Phase-11 behaviour exactly)
+///   and "ఉంది . abc" absorbs " ." (the gap lands in existing blank space
+///   before "abc", not fabricated), while "తెలుగు:abc" absorbs nothing
+///   (never invent a gap inside a tightly-glued word:token sequence).
+///
+/// A candidate cluster OR connector that is secret-redacted stops the scan
+/// right there, discarding any buffered-but-uncommitted connectors: a
+/// merged run's glyphs are drawn via `render_indic_run`, which bypasses
+/// `render_cell_glyph`'s per-cell secret-redaction check entirely, so
+/// nothing secret may ever be absorbed. `secret_at_displayed_point` is a
+/// stateless positional lookup (not a sequentially-advancing iterator like
+/// the find-match tracking in the caller), so it's safe to query here
+/// inside a lookahead.
 fn scan_indic_run(
     row: &Row,
     start_col: usize,
@@ -2161,6 +2210,30 @@ fn scan_indic_run(
     let mut full_text = String::new();
     let mut char_ranges = Vec::new();
     let mut col = start_col;
+    let mut committed_col = start_col;
+
+    // Buffered candidate connectors not yet committed to the run: each
+    // entry is (column, char).
+    let mut pending: Vec<(usize, char)> = Vec::new();
+
+    let is_secret_at = |col: usize| {
+        redacting_secrets
+            && grid
+                .secret_at_displayed_point(Point::new(offset_row, col))
+                .is_some()
+    };
+
+    let commit_connectors = |upto: usize,
+                              full_text: &mut String,
+                              char_ranges: &mut Vec<Range<usize>>,
+                              pending: &[(usize, char)]| {
+        for &(_, c) in &pending[..upto] {
+            let start_char = full_text.chars().count();
+            full_text.push(c);
+            let end_char = full_text.chars().count();
+            char_ranges.push(start_char..end_char);
+        }
+    };
 
     while col < columns {
         let cell = &row[col];
@@ -2168,29 +2241,73 @@ fn scan_indic_run(
             col += 1;
             continue;
         }
-        if !is_indic_cell(cell) {
-            break;
-        }
-        if redacting_secrets
-            && grid
-                .secret_at_displayed_point(Point::new(offset_row, col))
-                .is_some()
-        {
-            break;
+
+        if is_indic_cell(cell) {
+            if is_secret_at(col) {
+                break;
+            }
+            // Reaching Indic content commits every buffered connector.
+            commit_connectors(pending.len(), &mut full_text, &mut char_ranges, &pending);
+            pending.clear();
+
+            let start_char = full_text.chars().count();
+            append_cell_display(&mut full_text, cell);
+            let end_char = full_text.chars().count();
+            char_ranges.push(start_char..end_char);
+
+            col += cell.span() as usize;
+            committed_col = col;
+            continue;
         }
 
-        let start_char = full_text.chars().count();
-        append_cell_display(&mut full_text, cell);
-        let end_char = full_text.chars().count();
-        char_ranges.push(start_char..end_char);
+        if is_connector_cell(cell) {
+            if is_secret_at(col) {
+                break;
+            }
+            pending.push((col, cell.c));
+            col += 1;
+            continue;
+        }
 
-        col += cell.span() as usize;
+        // Terminator: an empty cell, or a real non-Indic/non-connector cell.
+        if cell.is_empty() {
+            // Blank tail (or genuinely never-written cells) -- commit
+            // everything buffered so far; nothing follows to fabricate a
+            // gap against.
+            commit_connectors(pending.len(), &mut full_text, &mut char_ranges, &pending);
+            committed_col = pending.last().map_or(committed_col, |&(c, _)| c + 1);
+        } else {
+            // Visible non-connector content (e.g. ASCII): commit only the
+            // buffered prefix through the last punctuation that is itself
+            // followed by a space in the buffer -- absorbing further would
+            // fabricate a gap where the source text had none.
+            let mut commit_upto = 0;
+            for (i, &(_, c)) in pending.iter().enumerate() {
+                if is_connector_punct(c) && pending.get(i + 1).is_some_and(|&(_, n)| n == ' ') {
+                    commit_upto = i + 1;
+                }
+            }
+            commit_connectors(commit_upto, &mut full_text, &mut char_ranges, &pending);
+            committed_col = if commit_upto > 0 {
+                pending[commit_upto - 1].0 + 1
+            } else {
+                committed_col
+            };
+        }
+        break;
+    }
+
+    if col >= columns {
+        // Ran off the end of the row: same as an empty-cell terminator --
+        // commit everything buffered.
+        commit_connectors(pending.len(), &mut full_text, &mut char_ranges, &pending);
+        committed_col = pending.last().map_or(committed_col, |&(c, _)| c + 1);
     }
 
     IndicRunShape {
         full_text,
         char_ranges,
-        total_span: col - start_col,
+        total_span: committed_col - start_col,
     }
 }
 
@@ -2208,6 +2325,41 @@ struct PendingIndicRun {
     /// Index into `shape.char_ranges` of the next cluster whose color has
     /// not yet been resolved and pushed into `style_runs`.
     next_cluster_idx: usize,
+}
+
+/// Defensive coverage guard for `style_runs` before it's handed to
+/// `layout_line`: a rare column-loop skip within a run (IME marked-text
+/// override, a hidden cursor cell) could in principle leave a char range in
+/// `full_text` with no matching style pushed. Rather than hand `layout_line`
+/// a `style_runs` list with a hole (undefined styling, or worse), fill any
+/// gap with the nearest already-resolved style so rendering degrades
+/// gracefully instead of misbehaving.
+fn fill_style_run_gaps(style_runs: &mut Vec<(Range<usize>, StyleAndFont)>, total_chars: usize) {
+    if total_chars == 0 {
+        return;
+    }
+    style_runs.sort_by_key(|(range, _)| range.start);
+    let mut filled = Vec::with_capacity(style_runs.len() + 1);
+    let mut next_start = 0usize;
+    for (range, style) in style_runs.drain(..) {
+        if range.start > next_start {
+            let fill_style = filled.last().map_or(style, |&(_, s)| s);
+            filled.push((next_start..range.start, fill_style));
+        }
+        next_start = next_start.max(range.end);
+        filled.push((range, style));
+    }
+    if next_start < total_chars {
+        // Only reachable if `style_runs` was empty on entry with
+        // `total_chars > 0`; `render_indic_run` already early-returns before
+        // ever calling this when `style_runs` is empty, so `FamilyId(0)` is
+        // never actually drawn -- present purely so this stays total.
+        let fill_style = filled
+            .last()
+            .map_or(StyleAndFont::new(FamilyId(0), Properties::default(), TextStyle::new()), |&(_, s)| s);
+        filled.push((next_start..total_chars, fill_style));
+    }
+    *style_runs = filled;
 }
 
 /// Renders a whole contiguous Indic run (possibly several syllables/words)

--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -1474,11 +1474,7 @@ fn render_grid_with_ligatures<'a>(
                 .flags
                 .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
             {
-                let actual_cell_size = if cell.flags.intersects(Flags::WIDE_CHAR) {
-                    cell_size * vec2f(2., 1.)
-                } else {
-                    cell_size
-                };
+                let actual_cell_size = cell_size * vec2f(cell.span() as f32, 1.);
                 if let Some(secret_content) = handle_secret_redaction(
                     cell,
                     &cell_type,
@@ -1776,12 +1772,9 @@ fn render_cell_glyph(
     row_indic_scale: f32,
     ctx: &mut PaintContext,
 ) {
-    let cell_size = if cell.flags().intersects(Flags::WIDE_CHAR) {
-        // WIDE_CHAR takes up two cells.
-        Vector2F::new(cell_size.x() * 2., cell_size.y())
-    } else {
-        cell_size
-    };
+    // A cluster's base cell occupies `span()` cells (1 for a normal char, up
+    // to 8 for a wide/measured Indic cluster) -- not just a fixed 2.
+    let cell_size = Vector2F::new(cell_size.x() * cell.span() as f32, cell_size.y());
 
     let mut cell_content = cell.content_for_display();
 
@@ -2623,11 +2616,7 @@ fn calculate_cell_decorations(
         None
     };
 
-    let actual_cell_size = if cell.flags.intersects(Flags::WIDE_CHAR) {
-        cell_size * vec2f(2., 1.)
-    } else {
-        cell_size
-    };
+    let actual_cell_size = cell_size * vec2f(cell.span() as f32, 1.);
     decoration_rect_data.map(|(thickness, y, color)| DecorationData {
         origin: grid_origin + glyph_offset + vec2f(0., y - thickness),
         size: vec2f(actual_cell_size.x(), thickness),
@@ -2666,7 +2655,7 @@ fn calculate_cursor_origin(
 pub fn render_cursor(
     grid_render_params: &GridRenderParams,
     cursor_point: Point,
-    is_cursor_on_wide_char: bool,
+    cursor_cell_span: u8,
     cursor_style: CursorStyle,
     padding_x: Pixels,
     grid_origin: Vector2F,
@@ -2681,11 +2670,9 @@ pub fn render_cursor(
         + grid_render_params.cell_size * vec2f(cursor_point.col as f32, cursor_point.row as f32);
 
     let cursor_top_origin = calculate_cursor_origin(grid_render_params, line_top_origin, ctx);
-    let cell_width = if is_cursor_on_wide_char {
-        grid_render_params.cell_size.x() * 2.
-    } else {
-        grid_render_params.cell_size.x()
-    };
+    // `cursor_cell_span` is 1 for a normal char, up to 8 for a wide/measured
+    // Indic cluster -- not just a fixed 2.
+    let cell_width = grid_render_params.cell_size.x() * cursor_cell_span as f32;
     let cursor_block_size = vec2f(
         cell_width,
         grid_render_params.font_size * DEFAULT_UI_LINE_HEIGHT_RATIO,

--- a/app/src/terminal/grid_renderer.rs
+++ b/app/src/terminal/grid_renderer.rs
@@ -34,7 +34,9 @@ use super::model::terminal_model::RangeInModel;
 use crate::settings::EnforceMinimumContrast;
 use crate::terminal::grid_size_util::calculate_grid_baseline_position;
 use crate::terminal::model::ansi::{Color, CursorShape, CursorStyle};
-use crate::terminal::model::cell::{Cell, Flags};
+use crate::terminal::model::cell::{Cell, Flags, DEFAULT_CHAR};
+use crate::terminal::model::indic::{is_in_indic_block, is_indic_str};
+use crate::terminal::model::grid::row::Row;
 use crate::terminal::model::grid::Dimensions;
 use crate::terminal::model::index::Point;
 use crate::terminal::model::selection::SelectionPoint;
@@ -619,7 +621,38 @@ fn render_grid_without_ligatures<'a>(
             continue;
         };
 
+        // Single scale for every Indic run on this row (Layer A shaping fix):
+        // computed once up front so all Telugu words on the line render at
+        // the SAME font size, while the row's tightest-fitting run still
+        // guarantees no run overflows into a neighbouring cell.
+        let row_indic_scale = compute_indic_row_scale(
+            &row,
+            grid.columns(),
+            cell_size.x(),
+            font_family,
+            font_size,
+            ctx,
+        );
+
+        // How many upcoming cells are absorbed by an Indic cluster that started on the
+        // previous cell (or the cell before that for 3-part clusters).  Set to 1 for a
+        // 2-cell cluster (base+virama + consonant, or consonant + vowel sign), to 2 for
+        // a 3-cell cluster (virama-conjunct + trailing vowel sign / anusvara).
+        // Decremented at the top of every column iteration; reset per row so clusters
+        // never bleed across line boundaries.
+        let mut cells_to_absorb_after: usize = 0;
+
         for col in 0..grid.columns() {
+            // Consume one absorption slot at the top of every column iteration so that
+            // early `continue` paths (WIDE_CHAR_SPACER, empty cells) don't leave stale
+            // state.  Decrementing here (rather than inside the cluster branch) keeps
+            // the count correct even when a cell is skipped by an early continue.
+            let this_cell_absorbed = if cells_to_absorb_after > 0 {
+                cells_to_absorb_after -= 1;
+                true
+            } else {
+                false
+            };
             let current_point = Point::new(row_idx, col);
 
             // Skip the cursor cell when CLI agent rich input is open
@@ -684,6 +717,8 @@ fn render_grid_without_ligatures<'a>(
                         baseline_position,
                         &mut native_glyphs_to_render,
                         obfuscate_secrets,
+                        None::<(&str, usize)>, // marked text cells are never part of Indic clusters
+                        1.0, // no scaling for marked-text cells
                         bg_color_sampler.as_deref_mut(),
                         ctx,
                     );
@@ -788,6 +823,48 @@ fn render_grid_without_ligatures<'a>(
                 }
             }
 
+            // Indic full-run look-ahead (Layer A + Layer B shaping fix).
+            //
+            // Instead of detecting only 2-cell conjunct clusters, we scan forward
+            // to collect ALL consecutive Indic-script cells into one proportional
+            // Core Text run.  The entire run string is shaped by Core Text in a
+            // single call, so glyphs land at their natural advance positions —
+            // exactly what Obsidian, browsers, and any proportional renderer do.
+            // No manual gap arithmetic is needed.
+            //
+            // Tuple: (run_string, span_cells).
+            //   span_cells = 0 for absorbed cells (run_string is empty).
+            //   span_cells = 1..N for the first cell of an N-cell run.
+            let cluster_for_this_cell: Option<(String, usize)> = if this_cell_absorbed {
+                Some((String::new(), 0)) // glyph absorbed; background still rendered
+            } else if is_indic_cell(cell) {
+                // Collect the full consecutive Indic run starting at this cell.
+                let mut run = String::new();
+                append_cell_display(&mut run, cell);
+                let mut span = 1usize;
+                let mut scan = col + 1;
+                while scan < grid.columns() {
+                    let sc = &row[scan];
+                    if sc.c == DEFAULT_CHAR
+                        || sc
+                            .flags()
+                            .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
+                        || !is_indic_cell(sc)
+                    {
+                        break;
+                    }
+                    append_cell_display(&mut run, sc);
+                    span += 1;
+                    scan += 1;
+                }
+                if span > 1 {
+                    cells_to_absorb_after = span - 1;
+                }
+                Some((run, span))
+            } else {
+                None
+            };
+
             // Don't apply cursor contrast colouring when hide_cursor_cell
             // is active — the cursor itself won't be drawn, so the cell
             // should render with its normal colours.
@@ -820,6 +897,8 @@ fn render_grid_without_ligatures<'a>(
                 baseline_position,
                 &mut native_glyphs_to_render,
                 obfuscate_secrets,
+                cluster_for_this_cell.as_ref().map(|(s, n)| (s.as_str(), *n)),
+                row_indic_scale,
                 bg_color_sampler.as_deref_mut(),
                 ctx,
             );
@@ -895,6 +974,8 @@ fn render_cell(
     baseline_position: Vector2F,
     native_glyphs_to_render: &mut Vec<NativeGlyph>,
     obfuscate_mode: ObfuscateSecrets,
+    cluster_glyph_override: Option<(&str, usize)>,
+    row_indic_scale: f32,
     bg_color_sampler: Option<&mut ColorSampler>,
     ctx: &mut PaintContext,
 ) -> Option<CachedBackgroundColor> {
@@ -941,6 +1022,8 @@ fn render_cell(
         cell_colors.foreground_color,
         native_glyphs_to_render,
         obfuscate_mode,
+        cluster_glyph_override,
+        row_indic_scale,
         ctx,
     );
     cell_decorations.extend(calculate_cell_decorations(
@@ -1684,6 +1767,13 @@ fn render_cell_glyph(
     foreground_color: ColorU,
     native_glyphs_to_render: &mut Vec<NativeGlyph>,
     obfuscate_mode: ObfuscateSecrets,
+    // Indic conjunct cluster override (Layer A shaping fix):
+    //  - None     → normal rendering via cell.content_for_display().
+    //  - Some("") → this cell's glyph was absorbed by the preceding cluster; skip glyph.
+    //  - Some(s)  → render the full conjunct string s (e.g. "క్ష") at this position.
+    // Ignored when secret redaction is active (secrets always override everything).
+    cluster_glyph_override: Option<(&str, usize)>,
+    row_indic_scale: f32,
     ctx: &mut PaintContext,
 ) {
     let cell_size = if cell.flags().intersects(Flags::WIDE_CHAR) {
@@ -1722,28 +1812,99 @@ fn render_cell_glyph(
     let font_id = font_id_cache.font_ids[font_style as usize]
         .get_or_insert_with(|| ctx.font_cache.select_font(font_family, properties));
 
-    let glyph_and_font = match cell_content {
-        // Special-case whitespace, which doesn't need rendering.  We
-        // explicitly check these two chars instead of using
-        // `char::is_whitespace` for performance reasons.
-        CharOrStr::Char(' ' | '\t') => None,
-        CharOrStr::Char(char) => glyphs.glyph_for_char(char, *font_id, ctx.font_cache),
-        // Certain zerowidth characters, such as emoji presentation selectors, can affect the underlying glyph and
-        // change the rendering. Hence, we need to layout/render the text as a combined string, instead of simply
-        // the single character. For example, in \0x2601\0xFE0F, the FE0F selector causes ☁️ to be changed from a
-        // 1-width char to a 2-width char.
-        CharOrStr::Str(content_with_zerowidth) => glyphs.glyph_for_string(
-            content_with_zerowidth,
-            *font_id,
-            ctx.font_cache,
-            font_family,
-            font_size,
-            properties,
-            ctx,
-        ),
-    };
-
     let origin = grid_origin + glyph_offset + baseline_position;
+
+    // Indic conjunct cluster override: when active (and no secret is being redacted),
+    // either skip this cell's glyph entirely (Some("")) or render the provided
+    // cluster string (Some(s)) which spans this cell and the cell that follows.
+    // This is the render-side half of the Layer A Indic shaping fix; the look-ahead
+    // that produces `cluster_glyph_override` lives in the rendering loop above.
+    let glyph_and_font = if cell_type.secret.is_none() {
+        if matches!(cluster_glyph_override, Some(("", _))) {
+            // This cell's glyph was absorbed by the preceding Indic run.
+            None
+        } else if let Some((cluster_str, span)) =
+            cluster_glyph_override.filter(|(s, _)| !s.is_empty())
+        {
+            // Indic full run: render the entire consecutive Indic run string,
+            // centred within its allocated span of `span` cells.  Core Text
+            // shapes the whole string at once — inter-glyph spacing is
+            // determined by the font's natural advances, exactly as in
+            // browsers and Obsidian.  No manual gap arithmetic needed.
+            let allocated_width = span as f32 * cell_size.x();
+            render_indic_cluster(
+                cluster_str,
+                origin,
+                allocated_width,
+                font_family,
+                font_size,
+                properties,
+                foreground_color,
+                row_indic_scale,
+                ctx,
+            );
+            None // Glyphs rendered inline; skip single-glyph path.
+        } else {
+            match cell_content {
+                // Special-case whitespace, which doesn't need rendering.  We
+                // explicitly check these two chars instead of using
+                // `char::is_whitespace` for performance reasons.
+                CharOrStr::Char(' ' | '\t') => None,
+                CharOrStr::Char(char) => glyphs.glyph_for_char(char, *font_id, ctx.font_cache),
+                // Certain zerowidth characters, such as emoji presentation selectors, can affect the underlying glyph and
+                // change the rendering. Hence, we need to layout/render the text as a combined string, instead of simply
+                // the single character. For example, in \0x2601\0xFE0F, the FE0F selector causes ☁️ to be changed from a
+                // 1-width char to a 2-width char.
+                //
+                // Layer B Indic path: a cell whose Str content is an Indic grapheme cluster
+                // (e.g. "భు", "క్ష", "త్వం" — assembled by the PTY width-override) needs
+                // all Core Text glyphs drawn, not just the first one returned by glyph_for_string.
+                CharOrStr::Str(content_with_zerowidth) => {
+                    if is_indic_str(content_with_zerowidth) {
+                        // Layer B: 1-cell span.  Centre within cell_size.x().
+                        render_indic_cluster(
+                            content_with_zerowidth,
+                            origin,
+                            cell_size.x(),
+                            font_family,
+                            font_size,
+                            properties,
+                            foreground_color,
+                            row_indic_scale,
+                            ctx,
+                        );
+                        None // Rendered inline; skip single-glyph path below.
+                    } else {
+                        glyphs.glyph_for_string(
+                            content_with_zerowidth,
+                            *font_id,
+                            ctx.font_cache,
+                            font_family,
+                            font_size,
+                            properties,
+                            ctx,
+                        )
+                    }
+                }
+            }
+        }
+    } else {
+        // Secret redaction is active: render the (already-overridden) cell_content normally,
+        // ignoring any cluster override.
+        match cell_content {
+            CharOrStr::Char(' ' | '\t') => None,
+            CharOrStr::Char(char) => glyphs.glyph_for_char(char, *font_id, ctx.font_cache),
+            CharOrStr::Str(content_with_zerowidth) => glyphs.glyph_for_string(
+                content_with_zerowidth,
+                *font_id,
+                ctx.font_cache,
+                font_family,
+                font_size,
+                properties,
+                ctx,
+            ),
+        }
+    };
 
     // Handle special unicode characters that will look better with native
     // rendering instead of using glyphs from the font.
@@ -1876,6 +2037,167 @@ fn render_image(
         }
     }
 }
+
+/// Renders all Core Text glyphs for an Indic grapheme cluster string at `origin`.
+///
+/// Called for both the Layer A look-ahead path (conjunct spanning two cells) and the
+/// Layer B path (cluster already assembled into a single cell by the PTY width override).
+///
+/// Uses `layout_line` rather than `glyph_for_string` because:
+///   • Conjuncts like "క్ష" produce BASE + SUBSCRIPT glyphs (≥2 per cluster).
+///   • Font substitution inserts an empty primary-font CTRun before the Telugu run.
+///   • We must draw ALL glyphs from ALL non-empty runs at their shaper-assigned positions.
+#[allow(clippy::too_many_arguments)]
+fn render_indic_cluster(
+    cluster_str: &str,
+    origin: Vector2F,
+    // Width of the cell span allocated to this cluster:
+    allocated_width: f32,
+    font_family: FamilyId,
+    font_size: f32,
+    properties: Properties,
+    foreground_color: ColorU,
+    // Uniform scale for every Indic run on this row (see
+    // `compute_indic_row_scale`) — NOT computed per-word, so every Telugu
+    // word on the line renders at the same visual font size.
+    row_indic_scale: f32,
+    ctx: &mut PaintContext,
+) {
+    let run_length_chars = cluster_str.chars().count();
+    let effective_font_size = font_size * row_indic_scale;
+    let cluster_line = ctx.text_layout_cache.layout_line(
+        cluster_str,
+        LineStyle {
+            font_size: effective_font_size,
+            line_height_ratio: 1.0,
+            baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
+            fixed_width_tab_size: None,
+        },
+        &[(
+            0..run_length_chars,
+            StyleAndFont {
+                font_family,
+                properties,
+                style: Default::default(),
+            },
+        )],
+        f32::MAX,
+        Default::default(),
+        &ctx.font_cache.text_layout_system(),
+    );
+    let center_inset = ((allocated_width - cluster_line.width) / 2.0).max(0.0);
+    for run in &cluster_line.runs {
+        if run.glyphs.is_empty() {
+            continue;
+        }
+        for glyph in &run.glyphs {
+            let glyph_origin =
+                origin + vec2f(center_inset + glyph.position_along_baseline.x(), 0.0);
+            ctx.scene.draw_glyph(
+                glyph_origin,
+                glyph.id,
+                run.font_id,
+                effective_font_size,
+                foreground_color,
+            );
+        }
+    }
+}
+
+/// Scans an entire row for Indic-script runs and returns the single tightest
+/// fit-scale across all of them (capped at 1.0).  Using one scale for the
+/// whole row — rather than a per-word scale — keeps every Telugu word on the
+/// row at the SAME visual font size, while still guaranteeing no run
+/// overflows its allocated cells (the row's narrowest-fitting run sets the
+/// scale for everyone).  Returns 1.0 when the row has no Indic content.
+fn compute_indic_row_scale(
+    row: &Row,
+    columns: usize,
+    cell_width: f32,
+    font_family: FamilyId,
+    font_size: f32,
+    ctx: &mut PaintContext,
+) -> f32 {
+    let mut min_scale = 1.0f32;
+    let mut col = 0usize;
+    while col < columns {
+        let cell = &row[col];
+        if cell.c == DEFAULT_CHAR
+            || cell
+                .flags()
+                .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
+            || !is_indic_cell(cell)
+        {
+            col += 1;
+            continue;
+        }
+        let mut run = String::new();
+        append_cell_display(&mut run, cell);
+        let mut span = 1usize;
+        let mut scan = col + 1;
+        while scan < columns {
+            let sc = &row[scan];
+            if sc.c == DEFAULT_CHAR
+                || sc
+                    .flags()
+                    .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
+                || !is_indic_cell(sc)
+            {
+                break;
+            }
+            append_cell_display(&mut run, sc);
+            span += 1;
+            scan += 1;
+        }
+        let run_length_chars = run.chars().count();
+        let allocated_width = span as f32 * cell_width;
+        let natural_line = ctx.text_layout_cache.layout_line(
+            &run,
+            LineStyle {
+                font_size,
+                line_height_ratio: 1.0,
+                baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
+                fixed_width_tab_size: None,
+            },
+            &[(
+                0..run_length_chars,
+                StyleAndFont {
+                    font_family,
+                    properties: Properties::default(),
+                    style: Default::default(),
+                },
+            )],
+            f32::MAX,
+            Default::default(),
+            &ctx.font_cache.text_layout_system(),
+        );
+        if natural_line.width > 0.0 {
+            let ratio = (allocated_width / natural_line.width).min(1.0);
+            min_scale = min_scale.min(ratio);
+        }
+        col = scan;
+    }
+    min_scale
+}
+
+/// Returns `true` if `cell` contains Indic-script content (used by the full-run
+/// look-ahead to decide whether to continue extending a run).
+fn is_indic_cell(cell: &Cell) -> bool {
+    match cell.content_for_display() {
+        CharOrStr::Str(s) => is_indic_str(s),
+        CharOrStr::Char(c) => is_in_indic_block(c),
+    }
+}
+
+/// Appends the display content of `cell` to `buf` (used when building the
+/// concatenated string for a full Indic run).
+fn append_cell_display(buf: &mut String, cell: &Cell) {
+    match cell.content_for_display() {
+        CharOrStr::Str(s) => buf.push_str(s),
+        CharOrStr::Char(c) => buf.push(c),
+    }
+}
+
 
 /// Checks to see if the cell's character is one that we can render natively
 /// using rects or other primitives, and if so, updates the paint context

--- a/app/src/terminal/grid_renderer/cell_glyph_cache.rs
+++ b/app/src/terminal/grid_renderer/cell_glyph_cache.rs
@@ -71,11 +71,9 @@ impl CellGlyphCache {
                     Default::default(),
                     &font_cache.text_layout_system(),
                 );
-                let run = line.runs.first()?;
-                if run.glyphs.len() > 1 {
-                    // If we have more than one glyph, something has gone wrong.
-                    return None;
-                }
+                // Skip empty runs: font-substituted text may produce an empty
+                // primary-font run before the run that actually contains the glyphs.
+                let run = line.runs.iter().find(|r| !r.glyphs.is_empty())?;
                 run.glyphs.first().map(|glyph| (glyph.id, run.font_id))
             });
 

--- a/app/src/terminal/grid_renderer_tests.rs
+++ b/app/src/terminal/grid_renderer_tests.rs
@@ -327,6 +327,12 @@ mod indic_run_tests {
         row[5].flags_mut().insert(Flags::WIDE_CHAR_SPACER);
 
         row[6].c = ' ';
+        // ASCII after the space, not punctuation-then-space, so the space
+        // is NOT absorbed (Phase 11 only absorbs a trailing space when
+        // nothing follows, or when it's followed by more Indic content) --
+        // this keeps the test's original intent (run stops at the word
+        // boundary) valid alongside the new connector-absorption behaviour.
+        row[7].c = 'X';
 
         let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
         assert_eq!(shape.full_text, "తెలుగు");
@@ -398,5 +404,161 @@ mod indic_run_tests {
             shape.total_span, 0,
             "secret-redacted cluster must not be merged into a run"
         );
+    }
+
+    /// Builds a 2-column Telugu cluster ("తె") at `row[start_col]`, returning
+    /// the column immediately after it.
+    fn write_two_col_cluster(row: &mut Row, start_col: usize) -> usize {
+        row[start_col].c = 'త';
+        row[start_col].push_zerowidth('ె', false);
+        row[start_col].set_span(2);
+        row[start_col + 1].flags_mut().insert(Flags::WIDE_CHAR_SPACER);
+        start_col + 2
+    }
+
+    #[test]
+    fn space_joins_two_words() {
+        let grid = test_grid(ObfuscateSecrets::No);
+        let mut row = Row::new(10);
+        let col = write_two_col_cluster(&mut row, 0);
+        row[col].c = ' ';
+        write_two_col_cluster(&mut row, col + 1);
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
+        assert_eq!(shape.full_text, "తె తె");
+        assert_eq!(shape.total_span, 5, "both clusters plus the joining space");
+        assert_eq!(shape.char_ranges.len(), 3, "cluster, space, cluster");
+    }
+
+    #[test]
+    fn multiple_consecutive_spaces_join() {
+        let grid = test_grid(ObfuscateSecrets::No);
+        let mut row = Row::new(10);
+        let col = write_two_col_cluster(&mut row, 0);
+        row[col].c = ' ';
+        row[col + 1].c = ' ';
+        write_two_col_cluster(&mut row, col + 2);
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
+        assert_eq!(shape.full_text, "తె  తె");
+        assert_eq!(shape.total_span, 6, "both clusters plus both joining spaces");
+        assert_eq!(shape.char_ranges.len(), 4, "cluster, space, space, cluster");
+    }
+
+    #[test]
+    fn trailing_punct_before_eol_absorbed() {
+        let grid = test_grid(ObfuscateSecrets::No);
+        let mut row = Row::new(4);
+        let col = write_two_col_cluster(&mut row, 0);
+        row[col].c = ' ';
+        row[col + 1].c = '.';
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
+        assert_eq!(shape.full_text, "తె .");
+        assert_eq!(shape.total_span, 4, "cluster plus trailing space and period at EOL");
+    }
+
+    #[test]
+    fn space_at_eol_absorbed() {
+        let grid = test_grid(ObfuscateSecrets::No);
+        let mut row = Row::new(3);
+        let col = write_two_col_cluster(&mut row, 0);
+        row[col].c = ' ';
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
+        assert_eq!(shape.full_text, "తె ");
+        assert_eq!(shape.total_span, 3, "cluster plus trailing space at EOL");
+    }
+
+    #[test]
+    fn space_then_ascii_backs_off() {
+        let grid = test_grid(ObfuscateSecrets::No);
+        let mut row = Row::new(10);
+        let col = write_two_col_cluster(&mut row, 0);
+        row[col].c = ' ';
+        row[col + 1].c = 'a';
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
+        assert_eq!(shape.full_text, "తె", "space before ASCII must not be absorbed");
+        assert_eq!(shape.total_span, 2, "run ends at the word boundary, matching pre-Phase-11 behaviour");
+    }
+
+    #[test]
+    fn punct_glued_to_ascii_not_absorbed() {
+        let grid = test_grid(ObfuscateSecrets::No);
+        let mut row = Row::new(10);
+        let col = write_two_col_cluster(&mut row, 0);
+        row[col].c = ':';
+        row[col + 1].c = 'a';
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
+        assert_eq!(
+            shape.full_text, "తె",
+            "colon directly glued to ASCII must not be absorbed -- no gap to fabricate"
+        );
+        assert_eq!(shape.total_span, 2);
+    }
+
+    #[test]
+    fn punct_then_space_then_ascii_commits_through_punct() {
+        let grid = test_grid(ObfuscateSecrets::No);
+        let mut row = Row::new(10);
+        let col = write_two_col_cluster(&mut row, 0);
+        row[col].c = '.';
+        row[col + 1].c = ' ';
+        row[col + 2].c = 'a';
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
+        assert_eq!(
+            shape.full_text, "తె.",
+            "period followed by a space commits (gap lands in existing blank space before ASCII)"
+        );
+        assert_eq!(shape.total_span, 3);
+    }
+
+    #[test]
+    fn secret_space_stops_absorption() {
+        secrets::set_user_and_enterprise_secret_regexes(
+            [&regex::Regex::new("SECRET").expect("valid regex")],
+            std::iter::empty(),
+        );
+        let mut grid = test_grid(ObfuscateSecrets::Yes);
+        // "SECRET" matches starting at column 2, so its range (cols 2-7)
+        // covers column 2 -- the exact column our scanned row's joining
+        // space will sit at (two-col cluster at 0-1, space at 2).
+        for c in "XXSECRET".chars() {
+            grid.input(c);
+        }
+        grid.on_finish_byte_processing(&ansi::ProcessorInput::new(&[]));
+
+        // Separate row (as in `secret_redacted_cluster_is_excluded_from_run`):
+        // a Telugu cluster, then a space that the grid's own secret range
+        // covers, then another cluster -- the space must not be absorbed,
+        // since a merged run's draw bypasses per-cell secret redaction.
+        let mut row = Row::new(10);
+        let col = write_two_col_cluster(&mut row, 0);
+        row[col].c = ' ';
+        write_two_col_cluster(&mut row, col + 1);
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::Yes);
+        assert_eq!(
+            shape.total_span, 2,
+            "run stops at the first cluster; the secret-covered space is never absorbed"
+        );
+    }
+
+    #[test]
+    fn empty_cells_not_treated_as_spaces() {
+        let grid = test_grid(ObfuscateSecrets::No);
+        let mut row = Row::new(10);
+        write_two_col_cluster(&mut row, 0);
+        // Cols 2.. stay `Cell::default()` (never written) -- these must be
+        // treated as a Blank terminator via `is_empty()`, not scanned as
+        // displayable spaces (which would desync the render loop's
+        // `next_cluster_idx` accounting against columns it actually skips).
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
+        assert_eq!(shape.full_text, "తె");
+        assert_eq!(shape.total_span, 2);
     }
 }

--- a/app/src/terminal/grid_renderer_tests.rs
+++ b/app/src/terminal/grid_renderer_tests.rs
@@ -266,7 +266,7 @@ fn test_calculate_selection_bounds() {
 mod indic_run_tests {
     use std::sync::Arc;
 
-    use super::super::scan_indic_run;
+    use super::super::{entry_word_ids, scan_indic_run};
     use crate::terminal::event_listener::ChannelEventListener;
     use crate::terminal::model::ansi::{self, Handler as _};
     use crate::terminal::model::cell::Flags;
@@ -560,5 +560,73 @@ mod indic_run_tests {
         let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
         assert_eq!(shape.full_text, "తె");
         assert_eq!(shape.total_span, 2);
+    }
+
+    #[test]
+    fn entry_word_ids_single_word_run_has_one_word() {
+        let grid = test_grid(ObfuscateSecrets::No);
+        let mut row = Row::new(10);
+        write_two_col_cluster(&mut row, 0);
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
+        assert_eq!(entry_word_ids(&shape), vec![0]);
+    }
+
+    #[test]
+    fn entry_word_ids_space_joined_words_get_separate_ids() {
+        let grid = test_grid(ObfuscateSecrets::No);
+        let mut row = Row::new(10);
+        let col = write_two_col_cluster(&mut row, 0);
+        row[col].c = ' ';
+        write_two_col_cluster(&mut row, col + 1);
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
+        // cluster, space, cluster -- the space rides with word 0; the
+        // second cluster starts word 1.
+        assert_eq!(entry_word_ids(&shape), vec![0, 0, 1]);
+    }
+
+    #[test]
+    fn entry_word_ids_multiple_spaces_stay_with_preceding_word() {
+        let grid = test_grid(ObfuscateSecrets::No);
+        let mut row = Row::new(10);
+        let col = write_two_col_cluster(&mut row, 0);
+        row[col].c = ' ';
+        row[col + 1].c = ' ';
+        write_two_col_cluster(&mut row, col + 2);
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
+        // cluster, space, space, cluster -- both spaces ride with word 0.
+        assert_eq!(entry_word_ids(&shape), vec![0, 0, 0, 1]);
+    }
+
+    #[test]
+    fn entry_word_ids_trailing_punct_rides_with_preceding_word() {
+        let grid = test_grid(ObfuscateSecrets::No);
+        let mut row = Row::new(4);
+        let col = write_two_col_cluster(&mut row, 0);
+        row[col].c = ' ';
+        row[col + 1].c = '.';
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
+        // cluster, space, period -- all one word (nothing follows the
+        // period to start a new one).
+        assert_eq!(entry_word_ids(&shape), vec![0, 0, 0]);
+    }
+
+    #[test]
+    fn entry_word_ids_punct_then_space_then_more_indic_starts_new_word() {
+        let grid = test_grid(ObfuscateSecrets::No);
+        let mut row = Row::new(10);
+        let col = write_two_col_cluster(&mut row, 0);
+        row[col].c = '.';
+        row[col + 1].c = ' ';
+        write_two_col_cluster(&mut row, col + 2);
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
+        // cluster, period, space, cluster -- period rides with word 0
+        // (immediately follows the cluster, no space between them), the
+        // space rides with word 0 too, and the second cluster starts word 1.
+        assert_eq!(entry_word_ids(&shape), vec![0, 0, 0, 1]);
     }
 }

--- a/app/src/terminal/grid_renderer_tests.rs
+++ b/app/src/terminal/grid_renderer_tests.rs
@@ -262,3 +262,141 @@ fn test_calculate_selection_bounds() {
     assert_selection_bounds(10.into_lines()); // Without scroll clipping (but on the cusp of clipping)
     assert_selection_bounds(80.into_lines()); // With scroll clipping
 }
+
+mod indic_run_tests {
+    use std::sync::Arc;
+
+    use super::super::scan_indic_run;
+    use crate::terminal::event_listener::ChannelEventListener;
+    use crate::terminal::model::ansi::{self, Handler as _};
+    use crate::terminal::model::cell::Flags;
+    use crate::terminal::model::grid::grid_handler::{GridHandler, PerformResetGridChecks};
+    use crate::terminal::model::grid::row::Row;
+    use crate::terminal::model::grid::NoopMeasurer;
+    use crate::terminal::model::secrets::{self, ObfuscateSecrets};
+    use crate::terminal::SizeInfo;
+
+    fn test_grid(obfuscate: ObfuscateSecrets) -> GridHandler {
+        GridHandler::new(
+            SizeInfo::new_without_font_metrics(5, 20),
+            0,
+            ChannelEventListener::new_for_test(),
+            false,
+            obfuscate,
+            PerformResetGridChecks::No,
+            Arc::new(NoopMeasurer),
+        )
+    }
+
+    #[test]
+    fn single_cluster_run_matches_cluster_span() {
+        let grid = test_grid(ObfuscateSecrets::No);
+        let mut row = Row::new(10);
+        row[0].c = 'ప';
+        row[0].push_zerowidth('్', false);
+        row[0].push_zerowidth('ర', false);
+        row[0].set_span(3);
+        row[1].flags_mut().insert(Flags::WIDE_CHAR_SPACER);
+        row[2].flags_mut().insert(Flags::WIDE_CHAR_SPACER);
+        row[3].c = 'a';
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
+        assert_eq!(shape.full_text, "ప్ర");
+        assert_eq!(shape.total_span, 3);
+        assert_eq!(shape.char_ranges, vec![0..shape.full_text.chars().count()]);
+    }
+
+    #[test]
+    fn multi_cluster_run_merges_whole_word() {
+        let grid = test_grid(ObfuscateSecrets::No);
+        let mut row = Row::new(10);
+        // "తె" (2 cols) + "లు" (2 cols) + "గు" (2 cols) -- one word, no spaces.
+        row[0].c = 'త';
+        row[0].push_zerowidth('ె', false);
+        row[0].set_span(2);
+        row[1].flags_mut().insert(Flags::WIDE_CHAR_SPACER);
+
+        row[2].c = 'ల';
+        row[2].push_zerowidth('ు', false);
+        row[2].set_span(2);
+        row[3].flags_mut().insert(Flags::WIDE_CHAR_SPACER);
+
+        row[4].c = 'గ';
+        row[4].push_zerowidth('ు', false);
+        row[4].set_span(2);
+        row[5].flags_mut().insert(Flags::WIDE_CHAR_SPACER);
+
+        row[6].c = ' ';
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
+        assert_eq!(shape.full_text, "తెలుగు");
+        assert_eq!(shape.total_span, 6);
+        assert_eq!(shape.char_ranges.len(), 3);
+        assert_eq!(shape.char_ranges[0].start, 0);
+        assert_eq!(shape.char_ranges[2].end, shape.full_text.chars().count());
+        for pair in shape.char_ranges.windows(2) {
+            assert_eq!(pair[0].end, pair[1].start, "ranges must partition full_text with no gaps");
+        }
+    }
+
+    #[test]
+    fn run_stops_at_non_indic_cell() {
+        let grid = test_grid(ObfuscateSecrets::No);
+        let mut row = Row::new(10);
+        row[0].c = 'త';
+        row[0].push_zerowidth('ె', false);
+        row[0].set_span(2);
+        row[1].flags_mut().insert(Flags::WIDE_CHAR_SPACER);
+        row[2].c = 'a'; // Immediately adjacent, no space.
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
+        assert_eq!(shape.full_text, "తె");
+        assert_eq!(shape.total_span, 2);
+    }
+
+    #[test]
+    fn run_extends_to_end_of_row() {
+        let grid = test_grid(ObfuscateSecrets::No);
+        let mut row = Row::new(4);
+        row[0].c = 'త';
+        row[0].push_zerowidth('ె', false);
+        row[0].set_span(2);
+        row[1].flags_mut().insert(Flags::WIDE_CHAR_SPACER);
+        row[2].c = 'ల';
+        row[2].push_zerowidth('ు', false);
+        row[2].set_span(2);
+        row[3].flags_mut().insert(Flags::WIDE_CHAR_SPACER);
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::No);
+        assert_eq!(shape.full_text, "తెలు");
+        assert_eq!(shape.total_span, 4);
+    }
+
+    #[test]
+    fn secret_redacted_cluster_is_excluded_from_run() {
+        secrets::set_user_and_enterprise_secret_regexes(
+            [&regex::Regex::new("SECRET").expect("valid regex")],
+            std::iter::empty(),
+        );
+        let mut grid = test_grid(ObfuscateSecrets::Yes);
+        for c in "SECRET".chars() {
+            grid.input(c);
+        }
+        grid.on_finish_byte_processing(&ansi::ProcessorInput::new(&[]));
+
+        // Built as a SEPARATE row -- `scan_indic_run` only consults `grid`
+        // for secret ranges by point, independent of the row argument's own
+        // content, so this validates the exclusion mechanism directly.
+        let mut row = Row::new(10);
+        row[0].c = 'త';
+        row[0].push_zerowidth('ె', false);
+        row[0].set_span(2);
+        row[1].flags_mut().insert(Flags::WIDE_CHAR_SPACER);
+
+        let shape = scan_indic_run(&row, 0, row.len(), &grid, 0, ObfuscateSecrets::Yes);
+        assert_eq!(
+            shape.total_span, 0,
+            "secret-redacted cluster must not be merged into a run"
+        );
+    }
+}

--- a/app/src/terminal/grid_renderer_tests.rs
+++ b/app/src/terminal/grid_renderer_tests.rs
@@ -630,3 +630,242 @@ mod indic_run_tests {
         assert_eq!(entry_word_ids(&shape), vec![0, 0, 0, 1]);
     }
 }
+
+/// Phase 15 (Telugu variable-width-cells plan): diagnostic to attribute the
+/// residual inter-word gap Mahārāja reported (visibly wider than a plain
+/// ASCII space at the same font/size). Two candidate causes were identified
+/// by reading the code: (1) connectors (space/punctuation) never go through
+/// `quantize_indic_span` -- each always reserves exactly 1 full monospace
+/// cell, stacking when several occur together (e.g. "word, word"); (2) an
+/// unproven-but-plausible discrepancy between the ISOLATED per-cluster
+/// natural-width measurement `flush_pending_indic_cluster` trusts at INPUT
+/// time and the IN-CONTEXT continuous shaping `render_indic_run` actually
+/// draws at RENDER time -- nothing today checks these agree.
+///
+/// This module measures both, using the real Menlo `CoreTextClusterMeasurer`
+/// and the real `layout_line` shaping path (not a synthetic stand-in), so
+/// the numbers are faithful to what actually renders.
+#[cfg(target_os = "macos")]
+mod indic_gap_diagnostics {
+    use std::sync::Arc;
+
+    use warpui::fonts::Properties;
+    use warpui::platform::mac::FontDB as MacFontDB;
+    use warpui::platform::{FontDB as _, LineStyle, TextLayoutSystem as _};
+    use warpui::text_layout::{ClipConfig, StyleAndFont, DEFAULT_TOP_BOTTOM_RATIO};
+
+    use super::super::{entry_word_ids, is_connector_punct, scan_indic_run};
+    use crate::terminal::event_listener::ChannelEventListener;
+    use crate::terminal::model::grid::cluster_measurer::{ClusterWidthMeasurer, CoreTextClusterMeasurer};
+    use crate::terminal::model::grid::grid_handler::{GridHandler, PerformResetGridChecks};
+    use crate::terminal::model::secrets::ObfuscateSecrets;
+    use crate::terminal::SizeInfo;
+    use warp_terminal::model::grid::Dimensions;
+
+    const FONT_SIZE: f32 = 13.0;
+
+    fn feed(grid: &mut GridHandler, text: &str) {
+        let mut processor = crate::terminal::model::ansi::Processor::new();
+        processor.parse_bytes(grid, text.as_bytes(), &mut std::io::sink());
+    }
+
+    /// Shapes `text` as ONE continuous line, exactly the way `render_indic_run`
+    /// does -- same `layout_line` path `CoreTextClusterMeasurer` itself uses
+    /// (`cluster_measurer.rs`), just over the whole run's text instead of one
+    /// cluster, and via a directly-owned `MacFontDB` instead of the trait
+    /// object, so this test has no dependency on a `PaintContext`/`FontCache`.
+    fn shape_continuous(
+        db: &MacFontDB,
+        family: warpui::fonts::FamilyId,
+        text: &str,
+    ) -> warpui::text_layout::Line {
+        let run_length_chars = text.chars().count();
+        db.layout_line(
+            text,
+            LineStyle {
+                font_size: FONT_SIZE,
+                line_height_ratio: 1.0,
+                baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
+                fixed_width_tab_size: None,
+            },
+            &[(
+                0..run_length_chars,
+                StyleAndFont {
+                    font_family: family,
+                    properties: Properties::default(),
+                    style: Default::default(),
+                },
+            )],
+            f32::MAX,
+            ClipConfig::default(),
+        )
+    }
+
+    #[test]
+    fn indic_gap_diag_isolated_vs_in_context_and_boundary_gaps() {
+        let mut db = MacFontDB::default();
+        let family = db.load_from_system("Menlo").expect("Menlo should be resolvable");
+        // Real Menlo advance at 13pt, used as the cell width so the numbers
+        // below are realistic (not the dummy 1px `new_without_font_metrics`
+        // would give, which would make every cluster hit the 8-cell clamp
+        // regardless of any real allocation behavior).
+        let cell_width = shape_continuous(&db, family, "MMMMMMMMMM").width / 10.0;
+        eprintln!(
+            "cell_width = {cell_width:.3}px (this is the ASCII single-space baseline used for comparison)"
+        );
+
+        let measurer = CoreTextClusterMeasurer::new("Menlo", Properties::default(), FONT_SIZE)
+            .expect("Menlo should be resolvable");
+
+        for text in [
+            "వార్త వెలుగు",
+            "వార్త, వెలుగు",
+            "ప్రభుత్వం చిత్రాలకు",
+            "శంకరాభరణం, సాగరం",
+        ] {
+            // ---- INPUT-TIME path, verbatim: feed through a real GridHandler
+            // so clustering + cumulative ceil() allocation are exactly what
+            // production does.
+            let size_info = SizeInfo::new(
+                pathfinder_geometry::vector::vec2f(80.0 * cell_width, 3.0 * 18.0),
+                warpui::units::Pixels::new(cell_width),
+                warpui::units::Pixels::new(18.0),
+                warpui::units::Pixels::zero(),
+                warpui::units::Pixels::zero(),
+            );
+            let inner_measurer = CoreTextClusterMeasurer::new("Menlo", Properties::default(), FONT_SIZE)
+                .expect("Menlo should be resolvable");
+            let mut grid = GridHandler::new(
+                size_info,
+                0,
+                ChannelEventListener::new_for_test(),
+                false,
+                ObfuscateSecrets::No,
+                PerformResetGridChecks::No,
+                Arc::new(inner_measurer),
+            );
+            feed(&mut grid, text);
+
+            // ---- RENDER-TIME path, verbatim: scan the row into an
+            // IndicRunShape (what the renderer does every frame), assign
+            // word ids, shape the whole run's text as ONE continuous line.
+            let row = grid.row(0).expect("row 0 should exist");
+            let shape = scan_indic_run(&row, 0, grid.columns(), &grid, 0, ObfuscateSecrets::No);
+            let word_ids = entry_word_ids(&shape);
+            let num_words = word_ids.last().map_or(0, |w| w + 1);
+            let line = shape_continuous(&db, family, &shape.full_text);
+
+            let chars: Vec<char> = shape.full_text.chars().collect();
+            let mut char_word = vec![usize::MAX; chars.len()];
+            let mut char_is_conn = vec![false; chars.len()];
+            for (i, range) in shape.char_ranges.iter().enumerate() {
+                let is_conn = range.len() == 1
+                    && matches!(chars.get(range.start), Some(&c) if c == ' ' || is_connector_punct(c));
+                for ci in range.clone() {
+                    char_word[ci] = word_ids[i];
+                    char_is_conn[ci] = is_conn;
+                }
+            }
+
+            // Per-word in-context extents from the ONE shaped line, over
+            // CLUSTER glyphs only (connectors excluded so a trailing
+            // absorbed comma/space doesn't drag a word's "ink end" right).
+            let mut start = vec![f32::INFINITY; num_words];
+            let mut adv_end = vec![f32::NEG_INFINITY; num_words];
+            let mut conn_advance = vec![0.0f32; num_words];
+            for run in &line.runs {
+                for g in &run.glyphs {
+                    let (Some(&w), Some(&is_conn)) = (char_word.get(g.index), char_is_conn.get(g.index))
+                    else {
+                        continue;
+                    };
+                    if w == usize::MAX {
+                        continue;
+                    }
+                    if is_conn {
+                        conn_advance[w] += g.width;
+                        continue;
+                    }
+                    start[w] = start[w].min(g.position_along_baseline.x());
+                    adv_end[w] = adv_end[w].max(g.position_along_baseline.x() + g.width);
+                }
+            }
+
+            // Per-word grid columns and per-word input-time isolated-cluster
+            // sum, read back from the actual grid cells (each base cell's
+            // content is exactly one flushed cluster, so this reconstructs
+            // precisely what `flush_pending_indic_cluster` measured).
+            let mut word_start_col = vec![0usize; num_words];
+            let mut seen = vec![false; num_words];
+            let mut isolated_sum = vec![0.0f32; num_words];
+            let mut alloc_cells = vec![0usize; num_words];
+            for (i, range) in shape.char_ranges.iter().enumerate() {
+                let w = word_ids[i];
+                if !seen[w] {
+                    seen[w] = true;
+                    word_start_col[w] = shape.cols[i];
+                }
+                let is_conn = range.len() == 1 && char_is_conn[range.start];
+                if !is_conn {
+                    let entry_text: String = chars[range.clone()].iter().collect();
+                    isolated_sum[w] += measurer.natural_width_px(&entry_text, cell_width);
+                    alloc_cells[w] += row[shape.cols[i]].span().max(1) as usize;
+                }
+            }
+
+            eprintln!("== {text:?}  full_text={:?}", shape.full_text);
+            for w in 0..num_words {
+                let in_ctx = adv_end[w] - start[w];
+                eprintln!(
+                    "  word {w}: isolated_sum={:.2}px  in_context={:.2}px  delta={:+.2}px ({:+.2} cells)  \
+                     allocated={} cells ({:.2}px)  render_slack={:.2}px",
+                    isolated_sum[w],
+                    in_ctx,
+                    isolated_sum[w] - in_ctx,
+                    (isolated_sum[w] - in_ctx) / cell_width,
+                    alloc_cells[w],
+                    alloc_cells[w] as f32 * cell_width,
+                    alloc_cells[w] as f32 * cell_width - in_ctx,
+                );
+                // The one thing that must NEVER be true: in-context shaping
+                // wider than what the allocator trusted would mean the
+                // allocation under-covers the real rendered width (risk of
+                // visual overlap/merge, the exact failure mode the round()
+                // experiment caused earlier in this rewrite).
+                assert!(
+                    in_ctx <= isolated_sum[w] + 0.5,
+                    "in-context shaping ({in_ctx:.2}px) WIDER than isolated sum ({:.2}px) for word {w} \
+                     of {text:?} -- allocation would under-cover this word's real rendered width",
+                    isolated_sum[w]
+                );
+            }
+
+            // Rendered gap at each word boundary, reproducing
+            // `render_indic_run`'s real shift formula by hand from the same
+            // data (`run_start_col` is 0 here, single run starting at col 0).
+            for w in 1..num_words {
+                let shift_prev = ((word_start_col[w - 1] as f32 * cell_width) - start[w - 1]).max(0.0);
+                let prev_ink_end = adv_end[w - 1] + shift_prev;
+                let gap = word_start_col[w] as f32 * cell_width - prev_ink_end;
+                let n_connector_cells = word_start_col[w] - (word_start_col[w - 1] + alloc_cells[w - 1]);
+                eprintln!(
+                    "  boundary {}->{}: rendered_gap={:.2}px = {:.2} cells  (connector cells N={n_connector_cells}, \
+                     connector in-context advance={:.2}px vs N*cell_width={:.2}px, excess over N*cw={:+.2}px)",
+                    w - 1,
+                    w,
+                    gap,
+                    gap / cell_width,
+                    conn_advance[w - 1],
+                    n_connector_cells as f32 * cell_width,
+                    gap - n_connector_cells as f32 * cell_width,
+                );
+                assert!(
+                    gap >= -0.5,
+                    "negative gap ({gap:.2}px) at boundary {}->{} of {text:?} -- words would overlap",
+                    w - 1,
+                    w
+                );
+            }
+        }
+    }
+}

--- a/app/src/terminal/model/alt_screen.rs
+++ b/app/src/terminal/model/alt_screen.rs
@@ -31,7 +31,7 @@ use crate::terminal::model::ansi::{
 use crate::terminal::model::grid::grid_handler::{
     FragmentBoundary, GridHandler, Link, PerformResetGridChecks, PossiblePath, TermMode,
 };
-use crate::terminal::model::grid::{Dimensions, GridStorage};
+use crate::terminal::model::grid::{ClusterWidthMeasurer, Dimensions, GridStorage};
 use crate::terminal::model::index::{Point, Side, VisibleRow};
 use crate::terminal::model::iterm_image::ITermImage;
 use crate::terminal::model::secrets::ObfuscateSecrets;
@@ -71,6 +71,7 @@ impl AltScreen {
         max_scroll_limit: usize,
         event_proxy: ChannelEventListener,
         obfuscate_secrets: ObfuscateSecrets,
+        cluster_measurer: Arc<dyn ClusterWidthMeasurer>,
     ) -> Self {
         let grid_handler = GridHandler::new(
             size_info,
@@ -79,6 +80,7 @@ impl AltScreen {
             true,
             obfuscate_secrets,
             PerformResetGridChecks::default(),
+            cluster_measurer,
         );
 
         AltScreen {

--- a/app/src/terminal/model/alt_screen_tests.rs
+++ b/app/src/terminal/model/alt_screen_tests.rs
@@ -13,6 +13,7 @@ fn new_alt_screen(size: SizeInfo) -> AltScreen {
         1_000, /* max_scroll_limit */
         ChannelEventListener::new_for_test(),
         ObfuscateSecrets::No,
+        std::sync::Arc::new(crate::terminal::model::grid::NoopMeasurer),
     )
 }
 

--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -55,6 +55,7 @@ use crate::terminal::event_listener::ChannelEventListener;
 use crate::terminal::model::ansi::{self, PrecmdValue, PreexecValue, Processor};
 use crate::terminal::model::blockgrid::BlockGrid;
 use crate::terminal::model::grid::grid_handler::TermMode;
+use crate::terminal::model::grid::ClusterWidthMeasurer;
 use crate::terminal::model::index::{Point, VisibleRow};
 use crate::terminal::model::iterm_image::ITermImage;
 use crate::terminal::model::secrets::ObfuscateSecrets;
@@ -925,6 +926,7 @@ impl Block {
         should_scan_for_secrets: ObfuscateSecrets,
         is_ai_ugc_telemetry_enabled: bool,
         conversation_id: Option<AIConversationId>,
+        cluster_measurer: Arc<dyn ClusterWidthMeasurer>,
     ) -> Self {
         let perform_reset_grid_checks = if cfg!(windows) && bootstrap_stage.is_done() {
             PerformResetGridChecks::Yes
@@ -937,6 +939,7 @@ impl Block {
             should_scan_for_secrets,
             honor_ps1,
             perform_reset_grid_checks,
+            cluster_measurer.clone(),
         );
         let rprompt_grid = BlockGrid::new(
             sizes.size,
@@ -946,6 +949,7 @@ impl Block {
             event_proxy.clone(),
             should_scan_for_secrets,
             PerformResetGridChecks::No,
+            cluster_measurer.clone(),
         );
         let output_grid = BlockGrid::new(
             sizes.size,
@@ -953,6 +957,7 @@ impl Block {
             event_proxy.clone(),
             should_scan_for_secrets,
             perform_reset_grid_checks,
+            cluster_measurer,
         );
 
         Block {

--- a/app/src/terminal/model/blockgrid.rs
+++ b/app/src/terminal/model/blockgrid.rs
@@ -20,6 +20,7 @@ use crate::terminal::model::ansi::{
     PrecmdValue, PreexecValue, StandardCharset, TabulationClearMode,
 };
 use crate::terminal::model::grid::grid_handler::{GridHandler, PerformResetGridChecks, RegexIter};
+use crate::terminal::model::grid::ClusterWidthMeasurer;
 use crate::terminal::model::grid::Dimensions;
 use crate::terminal::model::index::{Point, VisibleRow};
 use crate::terminal::model::iterm_image::ITermImage;
@@ -91,6 +92,7 @@ impl BlockGrid {
         event_proxy: ChannelEventListener,
         should_scan_for_secrets: ObfuscateSecrets,
         perform_reset_grid_checks: PerformResetGridChecks,
+        cluster_measurer: Arc<dyn ClusterWidthMeasurer>,
     ) -> Self {
         let grid_handler = GridHandler::new(
             size_info,
@@ -99,6 +101,7 @@ impl BlockGrid {
             false,
             should_scan_for_secrets,
             perform_reset_grid_checks,
+            cluster_measurer,
         );
 
         BlockGrid {

--- a/app/src/terminal/model/blockgrid_tests.rs
+++ b/app/src/terminal/model/blockgrid_tests.rs
@@ -21,6 +21,7 @@ pub fn test_finish_truncates_grid_basic() {
         ChannelEventListener::new_for_test(),
         ObfuscateSecrets::No,
         PerformResetGridChecks::default(),
+        std::sync::Arc::new(crate::terminal::model::grid::NoopMeasurer),
     );
 
     for c in "hello".chars() {
@@ -43,6 +44,7 @@ pub fn test_finish_truncates_grid_cursor_at_bottom() {
         ChannelEventListener::new_for_test(),
         ObfuscateSecrets::No,
         PerformResetGridChecks::default(),
+        std::sync::Arc::new(crate::terminal::model::grid::NoopMeasurer),
     );
 
     for _ in 0..300 {
@@ -67,6 +69,7 @@ pub fn test_resize_finished_block() {
         ChannelEventListener::new_for_test(),
         ObfuscateSecrets::No,
         PerformResetGridChecks::default(),
+        std::sync::Arc::new(crate::terminal::model::grid::NoopMeasurer),
     );
 
     for _ in 0..5 {
@@ -116,6 +119,7 @@ pub fn test_resize_finished_softwrapped_block() {
         ChannelEventListener::new_for_test(),
         ObfuscateSecrets::No,
         PerformResetGridChecks::default(),
+        std::sync::Arc::new(crate::terminal::model::grid::NoopMeasurer),
     );
 
     for _ in 0..5 {
@@ -165,6 +169,7 @@ pub fn test_trim_trailing_blank_rows_uses_active_floor_for_blank_started_grid() 
         ChannelEventListener::new_for_test(),
         ObfuscateSecrets::No,
         PerformResetGridChecks::default(),
+        std::sync::Arc::new(crate::terminal::model::grid::NoopMeasurer),
     );
 
     block_grid.start();
@@ -190,6 +195,7 @@ pub fn test_non_moving_kitty_image_keeps_finished_grid_visible() {
         ChannelEventListener::new_for_test(),
         ObfuscateSecrets::No,
         PerformResetGridChecks::default(),
+        std::sync::Arc::new(crate::terminal::model::grid::NoopMeasurer),
     );
     let mut metadata = test_utils::test_kitty_image_metadata_map(1);
     let mut action = test_utils::test_kitty_store_and_display_action(1, 1);
@@ -217,6 +223,7 @@ pub fn test_cursor_display_point_hidden_when_cursor_below_trimmed_content() {
         ChannelEventListener::new_for_test(),
         ObfuscateSecrets::No,
         PerformResetGridChecks::default(),
+        std::sync::Arc::new(crate::terminal::model::grid::NoopMeasurer),
     );
 
     block_grid.start();
@@ -252,6 +259,7 @@ pub fn test_cursor_display_point_not_clipped_when_trimming_disabled() {
         ChannelEventListener::new_for_test(),
         ObfuscateSecrets::No,
         PerformResetGridChecks::default(),
+        std::sync::Arc::new(crate::terminal::model::grid::NoopMeasurer),
     );
 
     block_grid.start();

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -48,7 +48,7 @@ use crate::terminal::model::ansi::{
 use crate::terminal::model::block::{AgentViewVisibility, Block, SerializedBlock};
 use crate::terminal::model::blockgrid::BlockGrid;
 use crate::terminal::model::bootstrap::BootstrapStage;
-use crate::terminal::model::grid::Dimensions;
+use crate::terminal::model::grid::{ClusterWidthMeasurer, Dimensions};
 use crate::terminal::model::index::{Point, VisibleRow};
 use crate::terminal::model::iterm_image::ITermImage;
 use crate::terminal::model::secrets::ObfuscateSecrets;
@@ -325,6 +325,11 @@ pub struct BlockList {
 
     obfuscate_secrets: ObfuscateSecrets,
 
+    /// Measures the real shaped width of Indic grapheme clusters for every
+    /// grid created by this block list (each new block's `Block::new` call
+    /// reuses this shared measurer). See `grid::ClusterWidthMeasurer`.
+    cluster_measurer: Arc<dyn ClusterWidthMeasurer>,
+
     /// `true` if client-side telemetry for user-generated AI data is enabled.
     is_ai_ugc_telemetry_enabled: bool,
 
@@ -575,6 +580,7 @@ impl BlockList {
         is_inverted: bool,
         obfuscate_secrets: ObfuscateSecrets,
         is_ai_ugc_telemetry_enabled: bool,
+        cluster_measurer: Arc<dyn ClusterWidthMeasurer>,
     ) -> Self {
         let mut block_list = Self::new_internal(
             sizes,
@@ -587,6 +593,7 @@ impl BlockList {
             is_inverted,
             obfuscate_secrets,
             is_ai_ugc_telemetry_enabled,
+            cluster_measurer,
         );
         block_list.initialize(restored_blocks);
         block_list
@@ -624,6 +631,7 @@ impl BlockList {
         is_inverted: bool,
         obfuscate_secrets: ObfuscateSecrets,
         is_ai_ugc_telemetry_enabled: bool,
+        cluster_measurer: Arc<dyn ClusterWidthMeasurer>,
     ) -> Self {
         let bootstrap_stage = BootstrapStage::RestoreBlocks;
         let block_heights = SumTree::new();
@@ -657,6 +665,7 @@ impl BlockList {
             last_populated_precmd_payload: None,
             cached_prompt_data: None,
             obfuscate_secrets,
+            cluster_measurer,
             is_ai_ugc_telemetry_enabled,
             scroll_position_before_filter: None,
             is_inverted,
@@ -2644,6 +2653,7 @@ impl BlockList {
             self.obfuscate_secrets,
             self.is_ai_ugc_telemetry_enabled,
             self.agent_view_state.active_conversation_id(),
+            self.cluster_measurer.clone(),
         );
         if let Some(is_local) = restored_block_was_local {
             block.set_restored_block_was_local(is_local);
@@ -2698,6 +2708,7 @@ impl BlockList {
             self.obfuscate_secrets,
             self.is_ai_ugc_telemetry_enabled,
             None,
+            self.cluster_measurer.clone(),
         )
     }
 

--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -34,6 +34,7 @@ use crate::terminal::model::ansi::{
 };
 use crate::terminal::model::cell::{Cell, Flags};
 use crate::terminal::model::char_or_str::CharOrStr;
+use crate::terminal::model::indic::{is_in_indic_block, is_indic_virama};
 use crate::terminal::model::grid::indexing::IndexRegion as _;
 use crate::terminal::model::grid::{grapheme_cursor, Dimensions as _};
 use crate::terminal::model::image_map::{ImagePlacementData, ImageType, StoredImageMetadata};
@@ -189,6 +190,12 @@ impl ansi::Handler for GridHandler {
         let Some(width) = c.width() else {
             return;
         };
+
+        // Layer B: fold virama-conjunct second consonants to width=0 so the
+        // cell allocation stays close to the font's natural advance width.
+        // A fixed uniform scale (see render_indic_cluster) then keeps all
+        // Telugu words at the same visual size without per-word variation.
+        let width = if width == 1 { self.indic_grapheme_width(c) } else { width };
 
         let num_cols = self.columns();
 
@@ -1455,6 +1462,46 @@ impl ansi::Handler for GridHandler {
 
 /// Helper functions for the [`ansi::Handler`] implementation.
 impl GridHandler {
+    /// Returns 0 if `c` (a width-1 character) should attach to the previous
+    /// cell as part of an Indic grapheme cluster, or 1 if it should occupy its
+    /// own cell normally.
+    ///
+    fn indic_grapheme_width(&self, c: char) -> usize {
+        if self.grid.cursor().input_needs_wrap {
+            return 1;
+        }
+        let col = self.grid.cursor().point.col;
+        if col == 0 {
+            return 1;
+        }
+        let row = self.grid.cursor_point().row;
+        let prev_col = col - 1;
+        let actual_prev_col = if self.grid[row][prev_col]
+            .flags
+            .contains(Flags::WIDE_CHAR_SPACER)
+            && prev_col > 0
+        {
+            prev_col - 1
+        } else {
+            prev_col
+        };
+        let prev_cell = &self.grid[row][actual_prev_col];
+        let prev_last = match prev_cell.raw_content() {
+            CharOrStr::Str(s) => s.chars().last(),
+            CharOrStr::Char(ch) => Some(ch),
+        };
+        let Some(prev_last) = prev_last else {
+            return 1;
+        };
+        // Fold the consonant after a virama into the base cell so that each
+        // virama-conjunct cluster occupies one cell instead of two.
+        if is_indic_virama(prev_last) && is_in_indic_block(c) {
+            return 0;
+        }
+        1
+    }
+
+    /// Precondition: `c.width() == Some(1)`.
     /// Advances the cursor by one cell, handling wrapping appropriately.
     fn advance_cursor_by_one_cell(&mut self) {
         let num_cols = self.columns();

--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -145,7 +145,9 @@ struct PendingIndicCluster {
 /// total allocation waste under one cell instead of accumulating roughly
 /// half a cell of `ceil()` rounding slack per cluster (see the Phase 12
 /// execution log in the Telugu variable-width-cells plan for the diagnosed
-/// numbers).
+/// numbers). Phase 13 additionally uses it to CARRY the whole word to the
+/// next line when it would otherwise split mid-word at the wrap boundary
+/// -- see `GridHandler::carry_indic_word`.
 #[derive(Clone, Debug, Default)]
 struct IndicWordAccumulator {
     /// Sum of every already-flushed cluster's real natural (unquantized)
@@ -164,6 +166,46 @@ struct IndicWordAccumulator {
     /// simpler and more robust than enumerating every cursor-movement call
     /// site that should reset it (most of which don't flush today).
     expected_point: Point,
+    /// Where this word's first cluster was written. Used to decide whether
+    /// the word can still be carried whole to the next line (only if it
+    /// started on the row the wrap is about to happen on -- a word that
+    /// already spans a previous carry, or was continued from an earlier
+    /// row some other way, is left alone).
+    word_start_point: Point,
+    /// Every cluster flushed so far in this word, in order, as (text,
+    /// natural width in px) -- enough to replay the word through the
+    /// normal cumulative-allocation flush math at a new position if it
+    /// needs to be carried to the next line. Natural px (not the
+    /// allocated span) is recorded so replay reproduces spans
+    /// deterministically via the same math, rather than needing a separate
+    /// proof that reused spans stay valid at column 0.
+    clusters: Vec<(String, f32)>,
+}
+
+impl IndicWordAccumulator {
+    /// Whether this word can be moved whole to the start of the next line
+    /// instead of splitting at `cursor_point` -- see
+    /// `GridHandler::carry_indic_word`. All of:
+    /// - the word has at least one already-flushed cluster (a word that's
+    ///   never been continued has nothing to carry -- its lone triggering
+    ///   cluster just gets today's independent-measurement mid-word split,
+    ///   which is the correct existing behaviour for a single overlong
+    ///   cluster),
+    /// - it started on the row the wrap is about to happen on (not carried
+    ///   there itself, and not resumed from some other row),
+    /// - it didn't start at column 0 (a word already at the start of a row
+    ///   that still doesn't fit cannot be moved anywhere -- and this also
+    ///   guarantees termination: a carried word restarts at column 0, so
+    ///   the same word can never be carried a second time),
+    /// - the whole word (already-allocated cells plus the new cluster's
+    ///   own independent span) fits within one line.
+    fn can_carry(&self, cursor_row: usize, columns: usize, new_cluster_independent_span: u8) -> bool {
+        !self.clusters.is_empty()
+            && self.word_start_point.row == cursor_row
+            && self.word_start_point.col > 0
+            && (self.cum_allocated_cells as usize + new_cluster_independent_span as usize)
+                <= columns
+    }
 }
 
 impl State {
@@ -1541,6 +1583,21 @@ impl GridHandler {
     /// A_{k-1})` gives `A_k = A_{k-1} + span_k >= ceil(N_k/cw)` by
     /// induction (the `max(1, _)` floor only ever adds cells, never removes
     /// them), so `A_k * cw >= N_k` holds for every prefix.
+    ///
+    /// When the cumulative span WOULD wrap, this also tries to carry the
+    /// whole in-progress word to the next line instead of splitting it
+    /// mid-word at the boundary -- see `carry_indic_word` and
+    /// `IndicWordAccumulator::can_carry`. This matters because apps that
+    /// pre-wrap their own output at word boundaries (Claude Code via Ink's
+    /// wrap-ansi, Codex CLI via ratatui/textwrap) compute width with the
+    /// universal wcwidth/UAX#11 convention -- one column per Indic
+    /// syllable cluster, zero for combining marks -- so a line they
+    /// believe fits can overflow our real (2-8 cell) allocation and get
+    /// split by the terminal itself, which those apps never expect (they
+    /// pass `hard: false` to their own wrapper specifically because they
+    /// assume the terminal never needs to). See the Phase 13 execution log
+    /// in the Telugu variable-width-cells plan for the researched
+    /// citations.
     fn flush_pending_indic_cluster(&mut self) {
         let Some(pending) = self.ansi_handler_state.pending_indic_cluster.take() else {
             return;
@@ -1565,7 +1622,10 @@ impl GridHandler {
             .indic_word_accumulator
             .take()
             .filter(|acc| acc.expected_point == cursor_point && !cursor_needs_wrap)
-            .unwrap_or_default();
+            .unwrap_or_else(|| IndicWordAccumulator {
+                word_start_point: cursor_point,
+                ..Default::default()
+            });
 
         let cumulative_span =
             Self::quantize_indic_span(acc.cum_natural_px + natural_width_px, acc.cum_allocated_cells, cell_width_px);
@@ -1575,16 +1635,38 @@ impl GridHandler {
         // fresh run the renderer anchors at column 0 of the next line --
         // fall back to measuring this cluster independently (exactly as if
         // it started a brand-new word) so the wrap decision itself is made
-        // the same way it always was, and start the new line's word fresh.
-        // An independent span is always >= the cumulative one (the
-        // cumulative formula can only ever allocate the same or fewer
-        // cells for one cluster), so this fallback is always safe -- it
-        // can only make wrapping MORE conservative, never less.
+        // the same way it always was. An independent span is always >= the
+        // cumulative one (the cumulative formula can only ever allocate
+        // the same or fewer cells for one cluster), so this fallback is
+        // always safe -- it can only make wrapping MORE conservative,
+        // never less.
         let will_wrap =
             cursor_needs_wrap || cursor_point.col + cumulative_span as usize > self.columns();
+        let independent_span = Self::quantize_indic_span(natural_width_px, 0, cell_width_px);
+
         let span = if will_wrap {
-            acc = IndicWordAccumulator::default();
-            Self::quantize_indic_span(natural_width_px, 0, cell_width_px)
+            let carry_eligible = self.ansi_handler_state.mode.contains(TermMode::LINE_WRAP)
+                && !self.ansi_handler_state.mode.contains(TermMode::INSERT)
+                && !self.ansi_handler_state.is_alt_screen
+                && acc.can_carry(cursor_point.row, self.columns(), independent_span);
+
+            if carry_eligible {
+                acc = self.carry_indic_word(acc);
+                // The word now sits at a new position (start of the next
+                // line); recompute against the replayed accumulator's
+                // (identical, by construction) cumulative state.
+                Self::quantize_indic_span(
+                    acc.cum_natural_px + natural_width_px,
+                    acc.cum_allocated_cells,
+                    cell_width_px,
+                )
+            } else {
+                acc = IndicWordAccumulator {
+                    word_start_point: self.grid.cursor_point(),
+                    ..Default::default()
+                };
+                independent_span
+            }
         } else {
             cumulative_span
         };
@@ -1593,8 +1675,91 @@ impl GridHandler {
 
         acc.cum_natural_px += natural_width_px;
         acc.cum_allocated_cells += span as u16;
+        acc.clusters.push((pending.text, natural_width_px));
         acc.expected_point = self.grid.cursor_point();
         self.ansi_handler_state.indic_word_accumulator = Some(acc);
+    }
+
+    /// Moves an entire in-progress Indic word (`acc`, whose eligibility was
+    /// already checked via `IndicWordAccumulator::can_carry`) to the start
+    /// of the next line, instead of letting it split mid-word where it
+    /// currently sits. Erases the word's already-written cells on the
+    /// current row, marks the new end-of-line boundary with `WRAPLINE` (so
+    /// copy/paste and resize treat the two rows as one logical line, and
+    /// the erased blank tail is excluded from both -- `Row::line_length`
+    /// stops at the last non-default cell, which lands exactly on the
+    /// WRAPLINE cell once the tail is blanked), advances to the next line
+    /// via the existing `wrapline()` (which also handles scroll-region-
+    /// bottom scrolling, synchronously, before this function's caller does
+    /// anything else), and replays every recorded cluster through the
+    /// normal cumulative-allocation flush math at the new position --
+    /// reproducing identical spans deterministically, so the allocated
+    /// width >= natural width invariant holds there exactly as it does for
+    /// any freshly-started word.
+    ///
+    /// Returns the new accumulator, reflecting the replayed word at its new
+    /// position. Never loops: a carried word always restarts at column 0
+    /// (`can_carry` requires `word_start_point.col > 0`), so this can never
+    /// fire twice for the same word.
+    fn carry_indic_word(&mut self, acc: IndicWordAccumulator) -> IndicWordAccumulator {
+        let row = acc.word_start_point.row;
+        let erase_start = acc.word_start_point.col;
+        let cursor_point = self.grid.cursor_point();
+        let cursor_needs_wrap = self.grid.cursor().input_needs_wrap;
+        let erase_end = if cursor_needs_wrap {
+            cursor_point.col + 1
+        } else {
+            cursor_point.col
+        };
+
+        let bg = self.grid.cursor().template.bg;
+        {
+            let grid_row = &mut self.grid[row][..];
+            let erase_end = erase_end.min(grid_row.len());
+            for col in erase_start..erase_end {
+                grid_row[col] = bg.into();
+            }
+        }
+
+        // Place WRAPLINE on the cell just before the word (its column-0
+        // predecessor -- typically the joining space) rather than the
+        // row's physical last cell, so the now-blank erased tail is
+        // excluded from `line_length`'s reverse scan and from copy/paste.
+        // Walk back to a wide/Indic cluster's base if that predecessor is
+        // one of its spacers, so the flag lands on a cell `line_length`
+        // will actually stop scanning at.
+        let mut wrapline_col = erase_start.saturating_sub(1);
+        {
+            let grid_row = &self.grid[row][..];
+            if grid_row[wrapline_col].flags.contains(Flags::WIDE_CHAR_SPACER) {
+                if let Some((base, _)) = Self::find_cluster_span(grid_row, wrapline_col) {
+                    wrapline_col = base;
+                }
+            }
+        }
+        self.update_cursor(|cursor| {
+            cursor.point.col = wrapline_col;
+            cursor.input_needs_wrap = false;
+        });
+        self.wrapline();
+
+        let cell_width_px = self.ansi_handler_state.cell_width_px;
+        let mut replayed = IndicWordAccumulator {
+            word_start_point: self.grid.cursor_point(),
+            ..Default::default()
+        };
+        for (text, natural_px) in &acc.clusters {
+            let span = Self::quantize_indic_span(
+                replayed.cum_natural_px + natural_px,
+                replayed.cum_allocated_cells,
+                cell_width_px,
+            );
+            self.write_grapheme_cluster(text, span as usize);
+            replayed.cum_natural_px += natural_px;
+            replayed.cum_allocated_cells += span as u16;
+        }
+        replayed.clusters = acc.clusters;
+        replayed
     }
 
     /// `ceil(cumulative_natural_px / cell_width_px) - already_allocated_cells`,

--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -1628,39 +1628,54 @@ impl GridHandler {
         });
     }
 
-    /// Resets both halves of a wide character pair when `col` is at the
+    /// If `col` is part of a wide/Indic cluster (either its base cell or
+    /// any of its trailing spacers), returns `(base_col, span)` for that
+    /// cluster. Otherwise `None`. Used to generalize the wide-char boundary
+    /// reset functions below from a fixed 2-cell pair to any span 1-8.
+    fn find_cluster_span(grid_row: &[Cell], col: usize) -> Option<(usize, usize)> {
+        if grid_row[col].flags.contains(Flags::WIDE_CHAR) {
+            return Some((col, grid_row[col].span() as usize));
+        }
+        if grid_row[col].flags.contains(Flags::WIDE_CHAR_SPACER) {
+            let mut base = col;
+            while base > 0 && grid_row[base].flags.contains(Flags::WIDE_CHAR_SPACER) {
+                base -= 1;
+            }
+            if grid_row[base].flags.contains(Flags::WIDE_CHAR) {
+                return Some((base, grid_row[base].span() as usize));
+            }
+        }
+        None
+    }
+
+    /// Resets every cell of a wide/Indic cluster when `col` is at the
     /// **start** of an operation's range (i.e., `col` itself is about to be
-    /// overwritten).  Handles both WIDE_CHAR_SPACER (resets the preceding
-    /// WIDE_CHAR) and WIDE_CHAR (resets the following spacer).
+    /// overwritten). Handles `col` landing on either the cluster's base or
+    /// any of its spacers.
     fn reset_wide_char_at_start_boundary(&mut self, row: usize, col: usize, bg: Color) {
-        let num_cols = self.columns();
         let grid_row = &mut self.grid[row][..];
 
-        if grid_row[col].flags.contains(Flags::WIDE_CHAR_SPACER) && col > 0 {
-            // Reset the spacer and its WIDE_CHAR partner.
-            grid_row[col] = bg.into();
-            grid_row[col - 1] = bg.into();
-        }
-
-        if grid_row[col].flags.contains(Flags::WIDE_CHAR) && col + 1 < num_cols {
-            // Reset the WIDE_CHAR and its spacer partner.
-            grid_row[col] = bg.into();
-            grid_row[col + 1] = bg.into();
+        if let Some((base, span)) = Self::find_cluster_span(grid_row, col) {
+            for c in base..(base + span).min(grid_row.len()) {
+                grid_row[c] = bg.into();
+            }
         }
     }
 
-    /// Resets a wide character pair when `col` is at the **end** of an
+    /// Resets a wide/Indic cluster when `col` is at the **end** of an
     /// operation's range (i.e., `col` is the first cell just past the range).
-    /// Only handles WIDE_CHAR_SPACER, because a WIDE_CHAR at `col` means the
-    /// entire pair is outside the range and should be left intact.
+    /// Only handles `col` landing on a spacer, because `col` landing on a
+    /// cluster's base cell means the entire cluster is outside the range
+    /// and should be left intact.
     fn reset_wide_char_at_end_boundary(&mut self, row: usize, col: usize, bg: Color) {
         let grid_row = &mut self.grid[row][..];
 
-        if grid_row[col].flags.contains(Flags::WIDE_CHAR_SPACER) && col > 0 {
-            // The spacer's WIDE_CHAR partner is inside the operation's range
-            // and is being cleared, so reset the spacer too.
-            grid_row[col] = bg.into();
-            grid_row[col - 1] = bg.into();
+        if grid_row[col].flags.contains(Flags::WIDE_CHAR_SPACER) {
+            if let Some((base, span)) = Self::find_cluster_span(grid_row, col) {
+                for c in base..(base + span).min(grid_row.len()) {
+                    grid_row[c] = bg.into();
+                }
+            }
         }
     }
 
@@ -1703,13 +1718,14 @@ impl GridHandler {
                 }
             }
 
-            // Reset the other half of the wide char pair.
-            if cell_flags.contains(Flags::WIDE_CHAR_SPACER) && col > 0 {
-                self.grid[row][col] = bg.into();
-                self.grid[row][col - 1] = bg.into();
-            } else if cell_flags.contains(Flags::WIDE_CHAR) && col + 1 < num_cols {
-                self.grid[row][col] = bg.into();
-                self.grid[row][col + 1] = bg.into();
+            // Reset every cell of the existing wide/Indic cluster that
+            // `col` overlaps (its base or any spacer) -- generalizes the
+            // fixed 2-cell-pair reset to any span 1-8.
+            let grid_row = &mut self.grid[row][..];
+            if let Some((base, span)) = Self::find_cluster_span(grid_row, col) {
+                for c in base..(base + span).min(grid_row.len()) {
+                    grid_row[c] = bg.into();
+                }
             }
         }
 

--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -298,7 +298,7 @@ impl ansi::Handler for GridHandler {
             }
 
             // Write full width glyph to current cursor cell.
-            self.write_at_cursor(c).flags.insert(Flags::WIDE_CHAR);
+            self.write_at_cursor(c).set_span(2);
 
             // Write spacer to cell following the wide glyph.
             self.move_cursor_forward(|cursor| {

--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -122,6 +122,14 @@ pub(super) struct State {
     /// real cell span can't be measured until it's complete — see
     /// `GridHandler::handle_indic_char`/`flush_pending_indic_cluster`.
     pending_indic_cluster: Option<PendingIndicCluster>,
+
+    /// Tracks the running natural width and cell allocation of the current
+    /// contiguous word of already-flushed Indic clusters, so each new
+    /// cluster's span quantizes the CUMULATIVE natural width rather than its
+    /// own width independently -- see `GridHandler::flush_pending_indic_cluster`.
+    /// `None` when no word is in progress (nothing flushed yet, or the last
+    /// flush ended a word).
+    indic_word_accumulator: Option<IndicWordAccumulator>,
 }
 
 /// See [`State::pending_indic_cluster`].
@@ -130,6 +138,32 @@ struct PendingIndicCluster {
     /// The base character plus every character appended to it so far.
     /// Never empty once `Some(_)`.
     text: String,
+}
+
+/// See [`State::indic_word_accumulator`]. Continuing the accumulator across
+/// flushes (rather than resetting per-cluster) is what keeps a whole word's
+/// total allocation waste under one cell instead of accumulating roughly
+/// half a cell of `ceil()` rounding slack per cluster (see the Phase 12
+/// execution log in the Telugu variable-width-cells plan for the diagnosed
+/// numbers).
+#[derive(Clone, Debug, Default)]
+struct IndicWordAccumulator {
+    /// Sum of every already-flushed cluster's real natural (unquantized)
+    /// width in this word, in pixels.
+    cum_natural_px: f32,
+    /// Sum of every already-flushed cluster's ACTUAL allocated span in this
+    /// word (post-clamp) -- not `ceil(cum_natural_px / cell_width_px)`,
+    /// since the two can diverge once the 1-8 cell clamp engages, and
+    /// subsequent spans must be computed against what was really allocated.
+    cum_allocated_cells: u16,
+    /// The cursor point this accumulator expects to see at the next flush
+    /// (immediately after the last flushed cluster). If the cursor is
+    /// anywhere else when the next flush happens -- moved by a cursor
+    /// command, scrolled, or left with a pending line wrap -- the word is
+    /// considered broken and a fresh accumulator starts instead. This is
+    /// simpler and more robust than enumerating every cursor-movement call
+    /// site that should reset it (most of which don't flush today).
+    expected_point: Point,
 }
 
 impl State {
@@ -169,6 +203,7 @@ impl State {
             keyboard_mode: KeyboardModes::NO_MODE,
             keyboard_mode_stack: BoundedVecDeque::new(super::KEYBOARD_MODE_STACK_MAX_DEPTH),
             pending_indic_cluster: None,
+            indic_word_accumulator: None,
         }
     }
 }
@@ -1493,15 +1528,89 @@ impl GridHandler {
     /// nothing is pending. Called whenever a non-Indic character arrives,
     /// and at the end of every PTY-read batch (`on_finish_byte_processing`)
     /// so a cluster can never be silently dropped if a read ends mid-cluster.
+    ///
+    /// The span isn't just this cluster's own width quantized independently
+    /// -- it continues `State::indic_word_accumulator`'s running total for
+    /// the current word, so `span = ceil(cumulative natural / cell width) -
+    /// cells already allocated to this word`. This bounds a whole word's
+    /// total rounding waste to under one cell (instead of accumulating
+    /// roughly half a cell of `ceil()` slack per cluster), while never
+    /// allocating less than any prefix's real natural width: writing
+    /// `A_k` for the cumulative allocated cells after cluster `k` and `N_k`
+    /// for the cumulative natural width, `span_k = max(1, ceil(N_k/cw) -
+    /// A_{k-1})` gives `A_k = A_{k-1} + span_k >= ceil(N_k/cw)` by
+    /// induction (the `max(1, _)` floor only ever adds cells, never removes
+    /// them), so `A_k * cw >= N_k` holds for every prefix.
     fn flush_pending_indic_cluster(&mut self) {
         let Some(pending) = self.ansi_handler_state.pending_indic_cluster.take() else {
             return;
         };
-        let span = self
+        let cell_width_px = self.ansi_handler_state.cell_width_px;
+        let natural_width_px = self
             .cluster_measurer
-            .measure_cells(&pending.text, self.ansi_handler_state.cell_width_px)
-            .clamp(1, 8);
+            .natural_width_px(&pending.text, cell_width_px);
+
+        let cursor_point = self.grid.cursor_point();
+        let cursor_needs_wrap = self.grid.cursor().input_needs_wrap;
+
+        // Continue the current word only if the cursor is exactly where
+        // the last flush left it -- any cursor motion (movement commands,
+        // scrolling) or a pending line wrap in between means this cluster
+        // starts a new word instead. Using the cursor position as the
+        // continuity check (rather than resetting at every cursor-movement
+        // call site) is simpler and can't miss a reset path, since ANY
+        // motion shows up here as a mismatch.
+        let mut acc = self
+            .ansi_handler_state
+            .indic_word_accumulator
+            .take()
+            .filter(|acc| acc.expected_point == cursor_point && !cursor_needs_wrap)
+            .unwrap_or_default();
+
+        let cumulative_span =
+            Self::quantize_indic_span(acc.cum_natural_px + natural_width_px, acc.cum_allocated_cells, cell_width_px);
+
+        // If writing at the cumulative span would need to wrap to a new
+        // line, the cumulative prefix invariant wouldn't carry over to the
+        // fresh run the renderer anchors at column 0 of the next line --
+        // fall back to measuring this cluster independently (exactly as if
+        // it started a brand-new word) so the wrap decision itself is made
+        // the same way it always was, and start the new line's word fresh.
+        // An independent span is always >= the cumulative one (the
+        // cumulative formula can only ever allocate the same or fewer
+        // cells for one cluster), so this fallback is always safe -- it
+        // can only make wrapping MORE conservative, never less.
+        let will_wrap =
+            cursor_needs_wrap || cursor_point.col + cumulative_span as usize > self.columns();
+        let span = if will_wrap {
+            acc = IndicWordAccumulator::default();
+            Self::quantize_indic_span(natural_width_px, 0, cell_width_px)
+        } else {
+            cumulative_span
+        };
+
         self.write_grapheme_cluster(&pending.text, span as usize);
+
+        acc.cum_natural_px += natural_width_px;
+        acc.cum_allocated_cells += span as u16;
+        acc.expected_point = self.grid.cursor_point();
+        self.ansi_handler_state.indic_word_accumulator = Some(acc);
+    }
+
+    /// `ceil(cumulative_natural_px / cell_width_px) - already_allocated_cells`,
+    /// floored at 1 and clamped to the 1-8 `Cell::span` encoding limit. See
+    /// `flush_pending_indic_cluster` for why this is computed cumulatively.
+    fn quantize_indic_span(
+        cumulative_natural_px: f32,
+        already_allocated_cells: u16,
+        cell_width_px: f32,
+    ) -> u8 {
+        if cell_width_px <= 0.0 {
+            return 1;
+        }
+        let needed_cells = (cumulative_natural_px / cell_width_px).ceil() as i64;
+        let span = needed_cells - already_allocated_cells as i64;
+        (span.max(1) as u8).clamp(1, 8)
     }
 
     /// Writes `text` (one or more chars forming a single grapheme cluster --

--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -166,6 +166,16 @@ struct IndicWordAccumulator {
     /// simpler and more robust than enumerating every cursor-movement call
     /// site that should reset it (most of which don't flush today).
     expected_point: Point,
+    /// The `input_needs_wrap` state expected alongside `expected_point` at
+    /// the next flush. A cluster that fills exactly to the last column
+    /// leaves `point` unchanged but sets `input_needs_wrap = true` -- the
+    /// very case carry exists to handle. Without tracking this separately,
+    /// the continuity check would have to reject that state (since
+    /// "cursor didn't move" alone can't distinguish "about to wrap" from
+    /// "not"), which would discard the accumulator right when carry is
+    /// needed most and make `GridHandler::carry_indic_word`'s
+    /// `cursor_needs_wrap` handling unreachable.
+    expected_needs_wrap: bool,
     /// Where this word's first cluster was written. Used to decide whether
     /// the word can still be carried whole to the next line (only if it
     /// started on the row the wrap is about to happen on -- a word that
@@ -1553,13 +1563,21 @@ impl GridHandler {
 
         self.flush_pending_indic_cluster();
 
-        // Move cursor to next line if the previous write left it pending --
-        // mirrors `input()`'s own pre-write housekeeping, needed here since
-        // we're now starting a fresh cluster at a (possibly new) position.
-        if self.grid.cursor().input_needs_wrap {
-            self.wrapline();
-        }
-
+        // Deliberately no wrap check here (unlike `input()`'s non-Indic
+        // path, which writes immediately via `write_grapheme_cluster` and
+        // so must resolve any pending wrap before writing). Buffering a
+        // cluster's text touches no grid cell -- there's nothing to
+        // position yet -- and resolving the wrap here would run it
+        // through a plain `wrapline()` with no carry consideration,
+        // pre-empting `flush_pending_indic_cluster`'s own will_wrap/carry
+        // decision for the OLD accumulator before it ever gets to run
+        // (this was a real bug: it made a word's next syllable always
+        // fall to a fresh line the instant the previous syllable filled
+        // the row exactly, instead of ever being considered for carry --
+        // see the Phase 14 execution log in the Telugu variable-width-
+        // cells plan). Deferring entirely to the eventual flush (which
+        // already reads `cursor_needs_wrap`/`cursor_point` correctly
+        // whenever it happens) is both simpler and correct.
         self.ansi_handler_state.pending_indic_cluster = Some(PendingIndicCluster {
             text: c.to_string(),
         });
@@ -1611,17 +1629,23 @@ impl GridHandler {
         let cursor_needs_wrap = self.grid.cursor().input_needs_wrap;
 
         // Continue the current word only if the cursor is exactly where
-        // the last flush left it -- any cursor motion (movement commands,
-        // scrolling) or a pending line wrap in between means this cluster
+        // the last flush left it, in the same pending-wrap state -- any
+        // cursor motion (movement commands, scrolling) means this cluster
         // starts a new word instead. Using the cursor position as the
         // continuity check (rather than resetting at every cursor-movement
         // call site) is simpler and can't miss a reset path, since ANY
-        // motion shows up here as a mismatch.
+        // motion shows up here as a mismatch. The `expected_needs_wrap`
+        // half of this check matters: a cluster that fills exactly to the
+        // last column leaves `point` unchanged but sets
+        // `input_needs_wrap = true` -- exactly the state that most needs
+        // carry to fire. Requiring `!cursor_needs_wrap` here would discard
+        // the accumulator right at that point and make
+        // `carry_indic_word`'s `cursor_needs_wrap` handling unreachable.
         let mut acc = self
             .ansi_handler_state
             .indic_word_accumulator
             .take()
-            .filter(|acc| acc.expected_point == cursor_point && !cursor_needs_wrap)
+            .filter(|acc| acc.expected_point == cursor_point && acc.expected_needs_wrap == cursor_needs_wrap)
             .unwrap_or_else(|| IndicWordAccumulator {
                 word_start_point: cursor_point,
                 ..Default::default()
@@ -1662,7 +1686,7 @@ impl GridHandler {
                 )
             } else {
                 acc = IndicWordAccumulator {
-                    word_start_point: self.grid.cursor_point(),
+                    word_start_point: cursor_point,
                     ..Default::default()
                 };
                 independent_span
@@ -1671,12 +1695,28 @@ impl GridHandler {
             cumulative_span
         };
 
-        self.write_grapheme_cluster(&pending.text, span as usize);
+        // A freshly-started accumulator's `word_start_point` was seeded
+        // from the cursor position observed BEFORE this cluster is
+        // written -- but this same `write_grapheme_cluster` call may
+        // itself wrap (and scroll) the row first if `input_needs_wrap`
+        // was already set, which would make that pre-write snapshot
+        // stale (it'd point at the wrong row relative to where the
+        // cluster actually landed). Use `write_grapheme_cluster`'s own
+        // return value -- the true post-wrap base point -- instead,
+        // whenever this cluster is the word's first (a continuing word's
+        // `word_start_point` was already fixed at its own true start and
+        // must not move).
+        let is_fresh_start = acc.clusters.is_empty();
+        let base_point = self.write_grapheme_cluster(&pending.text, span as usize);
+        if is_fresh_start {
+            acc.word_start_point = base_point;
+        }
 
         acc.cum_natural_px += natural_width_px;
         acc.cum_allocated_cells += span as u16;
         acc.clusters.push((pending.text, natural_width_px));
         acc.expected_point = self.grid.cursor_point();
+        acc.expected_needs_wrap = self.grid.cursor().input_needs_wrap;
         self.ansi_handler_state.indic_word_accumulator = Some(acc);
     }
 
@@ -1786,7 +1826,15 @@ impl GridHandler {
     /// insert-mode cell-shifting identically regardless of `width` --
     /// this generalizes what was previously separate width==1/width==2
     /// branches inline in `input()`.
-    fn write_grapheme_cluster(&mut self, text: &str, width: usize) {
+    /// Returns the grid point where the cluster's base cell actually landed
+    /// -- i.e. the cursor position AFTER any wrap/scroll this call performs,
+    /// not the position the caller observed beforehand. A caller that needs
+    /// to remember where a cluster started (e.g. `IndicWordAccumulator`'s
+    /// `word_start_point`, for the carry-to-next-line feature) must use
+    /// this return value rather than a pre-call cursor snapshot: if
+    /// `input_needs_wrap` was already set, this call wraps (and possibly
+    /// scrolls) the row before writing, which a pre-call snapshot can't see.
+    fn write_grapheme_cluster(&mut self, text: &str, width: usize) -> Point {
         debug_assert!(!text.is_empty(), "grapheme cluster text must not be empty");
         let num_cols = self.columns();
 
@@ -1821,7 +1869,8 @@ impl GridHandler {
             }
         }
 
-        if width == 1 {
+        let base_point = if width == 1 {
+            let base_point = self.grid.cursor_point();
             let mut chars = text.chars();
             // SAFETY: caller guarantees `text` is non-empty.
             let base = chars.next().unwrap();
@@ -1829,6 +1878,7 @@ impl GridHandler {
             for c in chars {
                 cell.push_zerowidth(c, /* log_long_grapheme_warnings */ true);
             }
+            base_point
         } else {
             if self.grid.cursor().point.col + width > num_cols {
                 if self.ansi_handler_state.mode.contains(TermMode::LINE_WRAP) {
@@ -1839,13 +1889,15 @@ impl GridHandler {
                     self.wrapline();
                 } else {
                     // Prevent out of bounds crash when linewrapping is disabled.
+                    let point = self.grid.cursor_point();
                     self.move_cursor_forward(|cursor| {
                         cursor.input_needs_wrap = true;
                     });
-                    return;
+                    return point;
                 }
             }
 
+            let base_point = self.grid.cursor_point();
             let mut chars = text.chars();
             // SAFETY: caller guarantees `text` is non-empty.
             let base = chars.next().unwrap();
@@ -1864,9 +1916,11 @@ impl GridHandler {
                     .flags
                     .insert(Flags::WIDE_CHAR_SPACER);
             }
-        }
+            base_point
+        };
 
         self.advance_cursor_by_one_cell();
+        base_point
     }
 
     /// Precondition: `c.width() == Some(1)`.

--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -34,7 +34,7 @@ use crate::terminal::model::ansi::{
 };
 use crate::terminal::model::cell::{Cell, Flags};
 use crate::terminal::model::char_or_str::CharOrStr;
-use crate::terminal::model::indic::{is_in_indic_block, is_indic_virama};
+use crate::terminal::model::indic::{is_in_indic_block, is_indic_combining, is_indic_virama};
 use crate::terminal::model::grid::indexing::IndexRegion as _;
 use crate::terminal::model::grid::{grapheme_cursor, Dimensions as _};
 use crate::terminal::model::image_map::{ImagePlacementData, ImageType, StoredImageMetadata};
@@ -105,6 +105,21 @@ pub(super) struct State {
     /// `push` appends the new mode; `pop` truncates and restores
     /// the previous entry as the active mode.
     pub keyboard_mode_stack: BoundedVecDeque<KeyboardModes>,
+
+    /// An Indic grapheme cluster currently being assembled from consecutive
+    /// `input()` calls, not yet written to the grid. Buffering (rather than
+    /// writing each character immediately) is necessary because the cluster's
+    /// real cell span can't be measured until it's complete — see
+    /// `GridHandler::handle_indic_char`/`flush_pending_indic_cluster`.
+    pending_indic_cluster: Option<PendingIndicCluster>,
+}
+
+/// See [`State::pending_indic_cluster`].
+#[derive(Clone, Debug, Default)]
+struct PendingIndicCluster {
+    /// The base character plus every character appended to it so far.
+    /// Never empty once `Some(_)`.
+    text: String,
 }
 
 impl State {
@@ -142,6 +157,7 @@ impl State {
             pane_size: size_info.pane_size_px(),
             keyboard_mode: KeyboardModes::NO_MODE,
             keyboard_mode_stack: BoundedVecDeque::new(super::KEYBOARD_MODE_STACK_MAX_DEPTH),
+            pending_indic_cluster: None,
         }
     }
 }
@@ -191,13 +207,17 @@ impl ansi::Handler for GridHandler {
             return;
         };
 
-        // Layer B: fold virama-conjunct second consonants to width=0 so the
-        // cell allocation stays close to the font's natural advance width.
-        // A fixed uniform scale (see render_indic_cluster) then keeps all
-        // Telugu words at the same visual size without per-word variation.
-        let width = if width == 1 { self.indic_grapheme_width(c) } else { width };
-
-        let num_cols = self.columns();
+        // Indic grapheme clusters (base consonant + optional virama-conjunct
+        // consonants + optional vowel signs/anusvara/visarga) need to be
+        // measured as a whole before we know how many cells they need — see
+        // `handle_indic_char`. Buffer them instead of writing immediately;
+        // a non-Indic char (below) flushes whatever was pending first.
+        if is_in_indic_block(c) {
+            self.handle_indic_char(c);
+            return;
+        } else if self.ansi_handler_state.pending_indic_cluster.is_some() {
+            self.flush_pending_indic_cluster();
+        }
 
         // Handle zero-width characters.
         if width == 0 {
@@ -247,70 +267,11 @@ impl ansi::Handler for GridHandler {
             return;
         }
 
-        // Move cursor to next line.
-        if self.grid.cursor().input_needs_wrap {
-            self.wrapline();
-        }
-
-        // If in insert mode, first shift cells to the right.
-        if self.ansi_handler_state.mode.contains(TermMode::INSERT)
-            && self.grid.cursor().point.col + width < num_cols
-        {
-            let cursor_point = self.grid.cursor_point();
-            let col = self.grid.cursor().point.col;
-            let bg = self.grid.cursor().template.bg;
-
-            // Reset any wide char pair at the insertion point before the
-            // shift moves cells away (write_at_cursor's own start boundary
-            // check runs too late — after the shift).
-            self.reset_wide_char_at_start_boundary(cursor_point.row, col, bg);
-
-            // Reset any wide char pair straddling the push-off boundary.
-            // Cells at [num_cols - width, num_cols) are discarded by the
-            // shift.
-            let push_off = num_cols - width;
-            self.reset_wide_char_at_end_boundary(cursor_point.row, push_off, bg);
-
-            let row = &mut self.grid[cursor_point.row][..];
-
-            for col in (col..(num_cols - width)).rev() {
-                row.swap(col + width, col);
-            }
-        }
-
-        if width == 1 {
-            self.write_at_cursor(c);
-        } else {
-            if self.grid.cursor().point.col + 1 >= num_cols {
-                if self.ansi_handler_state.mode.contains(TermMode::LINE_WRAP) {
-                    // Insert placeholder before wide char if glyph does not fit in this row.
-                    self.write_at_cursor(cell::DEFAULT_CHAR)
-                        .flags
-                        .insert(Flags::LEADING_WIDE_CHAR_SPACER);
-                    self.wrapline();
-                } else {
-                    // Prevent out of bounds crash when linewrapping is disabled.
-                    self.move_cursor_forward(|cursor| {
-                        cursor.input_needs_wrap = true;
-                    });
-                    return;
-                }
-            }
-
-            // Write full width glyph to current cursor cell.
-            self.write_at_cursor(c).set_span(2);
-
-            // Write spacer to cell following the wide glyph.
-            self.move_cursor_forward(|cursor| {
-                cursor.point.col += 1;
-            });
-
-            self.write_at_cursor(cell::DEFAULT_CHAR)
-                .flags
-                .insert(Flags::WIDE_CHAR_SPACER);
-        }
-
-        self.advance_cursor_by_one_cell();
+        // `encode_utf8` writes into a stack buffer -- no heap allocation for
+        // the extremely hot single-char case (every plain ASCII/CJK write
+        // goes through this).
+        let mut buf = [0u8; 4];
+        self.write_grapheme_cluster(c.encode_utf8(&mut buf), width);
     }
 
     fn goto(&mut self, row: VisibleRow, column: usize) {
@@ -1227,6 +1188,12 @@ impl ansi::Handler for GridHandler {
     }
 
     fn on_finish_byte_processing(&mut self, _: &ansi::ProcessorInput<'_>) {
+        // Flush any Indic grapheme cluster still buffered from this batch --
+        // otherwise a cluster that happens to end exactly at a PTY-read
+        // boundary would never get written (the next byte, if any, arrives
+        // in a future call). See `handle_indic_char`.
+        self.flush_pending_indic_cluster();
+
         // Make sure the max cursor and dirty cell range are up-to-date.
         self.grid.update_max_cursor();
         self.update_dirty_cells_range();
@@ -1462,43 +1429,160 @@ impl ansi::Handler for GridHandler {
 
 /// Helper functions for the [`ansi::Handler`] implementation.
 impl GridHandler {
-    /// Returns 0 if `c` (a width-1 character) should attach to the previous
-    /// cell as part of an Indic grapheme cluster, or 1 if it should occupy its
-    /// own cell normally.
+    /// Handles one character of an Indic grapheme cluster (Devanagari
+    /// through Sinhala, U+0900-0DFF — see `is_in_indic_block`). Rather than
+    /// writing immediately, buffers the cluster in
+    /// `State::pending_indic_cluster` until it's complete, since the real
+    /// cell span can only be measured (via `ClusterWidthMeasurer`) once the
+    /// whole cluster is known — see `flush_pending_indic_cluster`.
     ///
-    fn indic_grapheme_width(&self, c: char) -> usize {
+    /// A character extends the pending cluster if it's a combining mark
+    /// (vowel sign/anusvara/visarga), a virama, or if the pending cluster's
+    /// last character was a virama (virama-conjunct: consonant + virama +
+    /// consonant forms one visual unit). Anything else starts a new
+    /// cluster, flushing whatever was pending first.
+    fn handle_indic_char(&mut self, c: char) {
+        let extends_pending = self
+            .ansi_handler_state
+            .pending_indic_cluster
+            .as_ref()
+            .is_some_and(|pending| {
+                is_indic_combining(c)
+                    || is_indic_virama(c)
+                    || pending.text.chars().last().is_some_and(is_indic_virama)
+            });
+
+        if extends_pending {
+            // Attach to what's already buffered -- no wrap check here, same
+            // as the existing zero-width-character attach semantics: the
+            // cluster's start position was already validated when the FIRST
+            // character in it was buffered.
+            if let Some(pending) = &mut self.ansi_handler_state.pending_indic_cluster {
+                pending.text.push(c);
+            }
+            return;
+        }
+
+        self.flush_pending_indic_cluster();
+
+        // Move cursor to next line if the previous write left it pending --
+        // mirrors `input()`'s own pre-write housekeeping, needed here since
+        // we're now starting a fresh cluster at a (possibly new) position.
         if self.grid.cursor().input_needs_wrap {
-            return 1;
+            self.wrapline();
         }
-        let col = self.grid.cursor().point.col;
-        if col == 0 {
-            return 1;
+
+        self.ansi_handler_state.pending_indic_cluster = Some(PendingIndicCluster {
+            text: c.to_string(),
+        });
+    }
+
+    /// Writes out and clears any pending Indic cluster (see
+    /// `handle_indic_char`), measuring its real cell span first. A no-op if
+    /// nothing is pending. Called whenever a non-Indic character arrives,
+    /// and at the end of every PTY-read batch (`on_finish_byte_processing`)
+    /// so a cluster can never be silently dropped if a read ends mid-cluster.
+    fn flush_pending_indic_cluster(&mut self) {
+        let Some(pending) = self.ansi_handler_state.pending_indic_cluster.take() else {
+            return;
+        };
+        let cell_width_px = self.ansi_handler_state.cell_width as f32;
+        let span = self
+            .cluster_measurer
+            .measure_cells(&pending.text, cell_width_px)
+            .clamp(1, 8);
+        self.write_grapheme_cluster(&pending.text, span as usize);
+    }
+
+    /// Writes `text` (one or more chars forming a single grapheme cluster --
+    /// a plain char, a CJK wide char, or a measured Indic cluster) at the
+    /// cursor, occupying `width` cells. `text`'s first char becomes the
+    /// cell's base character; any remaining chars are attached as zero-width
+    /// continuations (`Cell::push_zerowidth`). Handles line-wrap and
+    /// insert-mode cell-shifting identically regardless of `width` --
+    /// this generalizes what was previously separate width==1/width==2
+    /// branches inline in `input()`.
+    fn write_grapheme_cluster(&mut self, text: &str, width: usize) {
+        debug_assert!(!text.is_empty(), "grapheme cluster text must not be empty");
+        let num_cols = self.columns();
+
+        // Move cursor to next line.
+        if self.grid.cursor().input_needs_wrap {
+            self.wrapline();
         }
-        let row = self.grid.cursor_point().row;
-        let prev_col = col - 1;
-        let actual_prev_col = if self.grid[row][prev_col]
-            .flags
-            .contains(Flags::WIDE_CHAR_SPACER)
-            && prev_col > 0
+
+        // If in insert mode, first shift cells to the right.
+        if self.ansi_handler_state.mode.contains(TermMode::INSERT)
+            && self.grid.cursor().point.col + width < num_cols
         {
-            prev_col - 1
-        } else {
-            prev_col
-        };
-        let prev_cell = &self.grid[row][actual_prev_col];
-        let prev_last = match prev_cell.raw_content() {
-            CharOrStr::Str(s) => s.chars().last(),
-            CharOrStr::Char(ch) => Some(ch),
-        };
-        let Some(prev_last) = prev_last else {
-            return 1;
-        };
-        // Fold the consonant after a virama into the base cell so that each
-        // virama-conjunct cluster occupies one cell instead of two.
-        if is_indic_virama(prev_last) && is_in_indic_block(c) {
-            return 0;
+            let cursor_point = self.grid.cursor_point();
+            let col = self.grid.cursor().point.col;
+            let bg = self.grid.cursor().template.bg;
+
+            // Reset any wide char pair at the insertion point before the
+            // shift moves cells away (write_at_cursor's own start boundary
+            // check runs too late — after the shift).
+            self.reset_wide_char_at_start_boundary(cursor_point.row, col, bg);
+
+            // Reset any wide char pair straddling the push-off boundary.
+            // Cells at [num_cols - width, num_cols) are discarded by the
+            // shift.
+            let push_off = num_cols - width;
+            self.reset_wide_char_at_end_boundary(cursor_point.row, push_off, bg);
+
+            let row = &mut self.grid[cursor_point.row][..];
+
+            for col in (col..(num_cols - width)).rev() {
+                row.swap(col + width, col);
+            }
         }
-        1
+
+        if width == 1 {
+            let mut chars = text.chars();
+            // SAFETY: caller guarantees `text` is non-empty.
+            let base = chars.next().unwrap();
+            let cell = self.write_at_cursor(base);
+            for c in chars {
+                cell.push_zerowidth(c, /* log_long_grapheme_warnings */ true);
+            }
+        } else {
+            if self.grid.cursor().point.col + width > num_cols {
+                if self.ansi_handler_state.mode.contains(TermMode::LINE_WRAP) {
+                    // Insert placeholder before wide char if glyph does not fit in this row.
+                    self.write_at_cursor(cell::DEFAULT_CHAR)
+                        .flags
+                        .insert(Flags::LEADING_WIDE_CHAR_SPACER);
+                    self.wrapline();
+                } else {
+                    // Prevent out of bounds crash when linewrapping is disabled.
+                    self.move_cursor_forward(|cursor| {
+                        cursor.input_needs_wrap = true;
+                    });
+                    return;
+                }
+            }
+
+            let mut chars = text.chars();
+            // SAFETY: caller guarantees `text` is non-empty.
+            let base = chars.next().unwrap();
+            let cell = self.write_at_cursor(base);
+            for c in chars {
+                cell.push_zerowidth(c, /* log_long_grapheme_warnings */ true);
+            }
+            cell.set_span(width as u8);
+
+            // Write spacer to every remaining cell in the span.
+            for _ in 1..width {
+                self.move_cursor_forward(|cursor| {
+                    cursor.point.col += 1;
+                });
+                self.write_at_cursor(cell::DEFAULT_CHAR)
+                    .flags
+                    .insert(Flags::WIDE_CHAR_SPACER);
+            }
+        }
+
+        self.advance_cursor_by_one_cell();
     }
 
     /// Precondition: `c.width() == Some(1)`.

--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -56,6 +56,16 @@ pub(super) struct State {
     pub cell_width: usize,
     pub cell_height: usize,
 
+    /// Full-precision cell width in pixels, matching exactly what the
+    /// renderer's `cell_size.x()` uses. Deliberately kept separate from
+    /// `cell_width` (a truncated `usize`, used for the existing
+    /// integer column/pixel math elsewhere in this file): truncating this
+    /// value before passing it to `ClusterWidthMeasurer` would
+    /// systematically overestimate the cells a cluster needs, producing a
+    /// visible gap after every cluster once rendered at the renderer's
+    /// true (untruncated) cell width.
+    pub cell_width_px: f32,
+
     /// Mode flags.
     pub mode: TermMode,
 
@@ -141,6 +151,7 @@ impl State {
 
         Self {
             cell_width: size_info.cell_width_px.as_f32() as usize,
+            cell_width_px: size_info.cell_width_px.as_f32(),
             cell_height: size_info.cell_height_px.as_f32() as usize,
             mode: Default::default(),
             tabs,
@@ -1486,10 +1497,9 @@ impl GridHandler {
         let Some(pending) = self.ansi_handler_state.pending_indic_cluster.take() else {
             return;
         };
-        let cell_width_px = self.ansi_handler_state.cell_width as f32;
         let span = self
             .cluster_measurer
-            .measure_cells(&pending.text, cell_width_px)
+            .measure_cells(&pending.text, self.ansi_handler_state.cell_width_px)
             .clamp(1, 8);
         self.write_grapheme_cluster(&pending.text, span as usize);
     }

--- a/app/src/terminal/model/grid/cluster_measurer.rs
+++ b/app/src/terminal/model/grid/cluster_measurer.rs
@@ -1,0 +1,144 @@
+//! Measures how many terminal cells a shaped Indic grapheme cluster needs,
+//! based on its real Core Text advance width rather than a fixed per-script
+//! guess. This is the input-time counterpart to the render-time shaping
+//! that `grid_renderer.rs` already performs — see `Cell::span`/`set_span`
+//! (crates/warp_terminal/src/model/grid/cell.rs) for the storage side.
+//!
+//! Deliberately decoupled from `AppContext`/the app-wide font `Cache`
+//! singleton: `Cache`'s font-loading methods take `&mut self`, which is
+//! incompatible with sharing it via `Arc` into the model layer (confirmed
+//! by direct investigation — see the plan's Phase 0 execution log). The
+//! real implementation instead owns a small, independent font database
+//! dedicated to this one purpose.
+
+/// Measures the number of terminal cells (1-8, matching `Cell::span`'s
+/// encoding limit) a grapheme cluster string needs when shaped at the
+/// given font size, relative to a single cell's pixel width.
+pub trait ClusterWidthMeasurer: Send + Sync {
+    fn measure_cells(&self, cluster: &str, cell_width_px: f32, font_size: f32) -> u8;
+}
+
+/// Always reports a single cell. Used as the default for test-only
+/// `GridHandler` constructors, and anywhere Indic shaping genuinely isn't
+/// available (e.g. non-macOS builds, before a platform-specific measurer
+/// exists).
+pub struct NoopMeasurer;
+
+impl ClusterWidthMeasurer for NoopMeasurer {
+    fn measure_cells(&self, _cluster: &str, _cell_width_px: f32, _font_size: f32) -> u8 {
+        1
+    }
+}
+
+// `warpui::platform::mac` (and therefore the Core Text shaping path) only
+// compiles on macOS -- see `crates/warpui/src/platform/mod.rs`'s
+// `#[cfg(target_os = "macos")] pub mod mac;`. Gate the real measurer the
+// same way; other platforms fall back to `NoopMeasurer` at the construction
+// call site.
+#[cfg(target_os = "macos")]
+mod mac_impl {
+    use warpui::fonts::{FamilyId, Properties};
+    use warpui::platform::mac::FontDB as MacFontDB;
+    use warpui::platform::{FontDB as FontDBTrait, LineStyle, TextLayoutSystem as _};
+    use warpui::text_layout::{ClipConfig, StyleAndFont, DEFAULT_TOP_BOTTOM_RATIO};
+
+    use super::ClusterWidthMeasurer;
+
+    /// Real macOS implementation, backed by a dedicated Core Text font
+    /// database loaded with the terminal's configured font family.
+    /// Constructed once (loading is `&mut self`); every subsequent call is
+    /// `&self`-only, so no interior mutability is needed once construction
+    /// completes.
+    pub struct CoreTextClusterMeasurer {
+        font_db: MacFontDB,
+        family_id: FamilyId,
+        properties: Properties,
+    }
+
+    impl CoreTextClusterMeasurer {
+        /// Loads `font_family_name` into a fresh, independent font database
+        /// and returns a measurer for it. Returns `Err` if the family can't
+        /// be resolved on the system (caller should fall back to
+        /// `NoopMeasurer`).
+        pub fn new(font_family_name: &str, properties: Properties) -> anyhow::Result<Self> {
+            let mut font_db = MacFontDB::default();
+            let family_id = font_db.load_from_system(font_family_name)?;
+            Ok(Self {
+                font_db,
+                family_id,
+                properties,
+            })
+        }
+    }
+
+    impl ClusterWidthMeasurer for CoreTextClusterMeasurer {
+        fn measure_cells(&self, cluster: &str, cell_width_px: f32, font_size: f32) -> u8 {
+            if cell_width_px <= 0.0 || cluster.is_empty() {
+                return 1;
+            }
+            let run_length_chars = cluster.chars().count();
+            let line = self.font_db.layout_line(
+                cluster,
+                LineStyle {
+                    font_size,
+                    line_height_ratio: 1.0,
+                    baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
+                    fixed_width_tab_size: None,
+                },
+                &[(
+                    0..run_length_chars,
+                    StyleAndFont {
+                        font_family: self.family_id,
+                        properties: self.properties,
+                        style: Default::default(),
+                    },
+                )],
+                f32::MAX,
+                ClipConfig::default(),
+            );
+            let cells = (line.width / cell_width_px).ceil() as u8;
+            cells.clamp(1, 8)
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub use mac_impl::CoreTextClusterMeasurer;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_measurer_always_returns_one() {
+        let measurer = NoopMeasurer;
+        assert_eq!(measurer.measure_cells("ప్రభుత్వం", 10.0, 13.0), 1);
+        assert_eq!(measurer.measure_cells("", 10.0, 13.0), 1);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn core_text_measurer_measures_real_telugu_cluster() {
+        use warpui::fonts::Properties;
+
+        // Menlo is a bundled system font guaranteed present in CI/dev macOS
+        // environments; Core Text will fall back to a Telugu-capable font
+        // automatically when shaping non-Latin text, same as the render
+        // path already does in grid_renderer.rs::render_indic_cluster.
+        let measurer = CoreTextClusterMeasurer::new("Menlo", Properties::default())
+            .expect("Menlo should be resolvable on any macOS system");
+
+        // A multi-syllable Telugu word should need more than one narrow
+        // monospace cell's worth of width.
+        let cells = measurer.measure_cells("ప్రభుత్వం", 8.0, 13.0);
+        assert!(
+            cells >= 2,
+            "expected a multi-syllable Telugu word to need >= 2 cells at a narrow cell width, got {cells}"
+        );
+        assert!(cells <= 8, "measured span must stay within the 1-8 encoding limit, got {cells}");
+
+        // A single ASCII char should fit in one narrow cell already.
+        let ascii_cells = measurer.measure_cells("a", 8.0, 13.0);
+        assert_eq!(ascii_cells, 1);
+    }
+}

--- a/app/src/terminal/model/grid/cluster_measurer.rs
+++ b/app/src/terminal/model/grid/cluster_measurer.rs
@@ -106,17 +106,18 @@ mod mac_impl {
                 f32::MAX,
                 ClipConfig::default(),
             );
-            // `round()` rather than `ceil()`: halves the average leftover
-            // slack per cluster (the gap between a cluster's real shaped
-            // width and its allocated cell count), which otherwise
-            // accumulates across a multi-cluster run and surfaces as an
-            // oversized gap before the next space/punctuation cell (see
-            // Phase 10 of the Telugu variable-width-cells rewrite). A
-            // cluster can now round down slightly under its natural width;
-            // the renderer already tolerates this gracefully (no clamp or
-            // panic on slight overflow into the next cell), so this trades
-            // a small, bounded overflow risk for less accumulated slack.
-            let cells = (line.width / cell_width_px).round() as u8;
+            // `ceil()`, not `round()`: guarantees allocated width is never
+            // less than the cluster's real shaped width. Tried `round()` to
+            // shrink leftover slack at word boundaries (Phase 10 of the
+            // Telugu variable-width-cells rewrite) but reverted it -- a
+            // real-paragraph visual test caught a virama-final conjunct
+            // glyph (e.g. "శ్") whose natural width exceeded its rounded
+            // allocation, so its glyph spilled into the following space and
+            // erased the word boundary entirely (two words rendered as one,
+            // unreadable). A visually-wide gap is a much smaller defect
+            // than words silently merging, so this reverts to the safe,
+            // never-overlaps invariant.
+            let cells = (line.width / cell_width_px).ceil() as u8;
             cells.clamp(1, 8)
         }
     }

--- a/app/src/terminal/model/grid/cluster_measurer.rs
+++ b/app/src/terminal/model/grid/cluster_measurer.rs
@@ -12,10 +12,14 @@
 //! dedicated to this one purpose.
 
 /// Measures the number of terminal cells (1-8, matching `Cell::span`'s
-/// encoding limit) a grapheme cluster string needs when shaped at the
-/// given font size, relative to a single cell's pixel width.
+/// encoding limit) a grapheme cluster string needs, relative to a single
+/// cell's pixel width. Font size is fixed at construction time (not passed
+/// per call): the measurer is meant to be reconstructed whenever the
+/// terminal's font/zoom changes, same as `SizeInfo`/`cell_width_px` already
+/// is, so `ansi_handler.rs`'s hot input path never needs to thread a font
+/// size value through per character.
 pub trait ClusterWidthMeasurer: Send + Sync {
-    fn measure_cells(&self, cluster: &str, cell_width_px: f32, font_size: f32) -> u8;
+    fn measure_cells(&self, cluster: &str, cell_width_px: f32) -> u8;
 }
 
 /// Always reports a single cell. Used as the default for test-only
@@ -25,7 +29,7 @@ pub trait ClusterWidthMeasurer: Send + Sync {
 pub struct NoopMeasurer;
 
 impl ClusterWidthMeasurer for NoopMeasurer {
-    fn measure_cells(&self, _cluster: &str, _cell_width_px: f32, _font_size: f32) -> u8 {
+    fn measure_cells(&self, _cluster: &str, _cell_width_px: f32) -> u8 {
         1
     }
 }
@@ -53,26 +57,32 @@ mod mac_impl {
         font_db: MacFontDB,
         family_id: FamilyId,
         properties: Properties,
+        font_size: f32,
     }
 
     impl CoreTextClusterMeasurer {
         /// Loads `font_family_name` into a fresh, independent font database
-        /// and returns a measurer for it. Returns `Err` if the family can't
-        /// be resolved on the system (caller should fall back to
-        /// `NoopMeasurer`).
-        pub fn new(font_family_name: &str, properties: Properties) -> anyhow::Result<Self> {
+        /// and returns a measurer for it, fixed at `font_size`. Returns
+        /// `Err` if the family can't be resolved on the system (caller
+        /// should fall back to `NoopMeasurer`).
+        pub fn new(
+            font_family_name: &str,
+            properties: Properties,
+            font_size: f32,
+        ) -> anyhow::Result<Self> {
             let mut font_db = MacFontDB::default();
             let family_id = font_db.load_from_system(font_family_name)?;
             Ok(Self {
                 font_db,
                 family_id,
                 properties,
+                font_size,
             })
         }
     }
 
     impl ClusterWidthMeasurer for CoreTextClusterMeasurer {
-        fn measure_cells(&self, cluster: &str, cell_width_px: f32, font_size: f32) -> u8 {
+        fn measure_cells(&self, cluster: &str, cell_width_px: f32) -> u8 {
             if cell_width_px <= 0.0 || cluster.is_empty() {
                 return 1;
             }
@@ -80,7 +90,7 @@ mod mac_impl {
             let line = self.font_db.layout_line(
                 cluster,
                 LineStyle {
-                    font_size,
+                    font_size: self.font_size,
                     line_height_ratio: 1.0,
                     baseline_ratio: DEFAULT_TOP_BOTTOM_RATIO,
                     fixed_width_tab_size: None,
@@ -112,8 +122,8 @@ mod tests {
     #[test]
     fn noop_measurer_always_returns_one() {
         let measurer = NoopMeasurer;
-        assert_eq!(measurer.measure_cells("ప్రభుత్వం", 10.0, 13.0), 1);
-        assert_eq!(measurer.measure_cells("", 10.0, 13.0), 1);
+        assert_eq!(measurer.measure_cells("ప్రభుత్వం", 10.0), 1);
+        assert_eq!(measurer.measure_cells("", 10.0), 1);
     }
 
     #[cfg(target_os = "macos")]
@@ -125,12 +135,12 @@ mod tests {
         // environments; Core Text will fall back to a Telugu-capable font
         // automatically when shaping non-Latin text, same as the render
         // path already does in grid_renderer.rs::render_indic_cluster.
-        let measurer = CoreTextClusterMeasurer::new("Menlo", Properties::default())
+        let measurer = CoreTextClusterMeasurer::new("Menlo", Properties::default(), 13.0)
             .expect("Menlo should be resolvable on any macOS system");
 
         // A multi-syllable Telugu word should need more than one narrow
         // monospace cell's worth of width.
-        let cells = measurer.measure_cells("ప్రభుత్వం", 8.0, 13.0);
+        let cells = measurer.measure_cells("ప్రభుత్వం", 8.0);
         assert!(
             cells >= 2,
             "expected a multi-syllable Telugu word to need >= 2 cells at a narrow cell width, got {cells}"
@@ -138,7 +148,7 @@ mod tests {
         assert!(cells <= 8, "measured span must stay within the 1-8 encoding limit, got {cells}");
 
         // A single ASCII char should fit in one narrow cell already.
-        let ascii_cells = measurer.measure_cells("a", 8.0, 13.0);
+        let ascii_cells = measurer.measure_cells("a", 8.0);
         assert_eq!(ascii_cells, 1);
     }
 }

--- a/app/src/terminal/model/grid/cluster_measurer.rs
+++ b/app/src/terminal/model/grid/cluster_measurer.rs
@@ -11,26 +11,33 @@
 //! real implementation instead owns a small, independent font database
 //! dedicated to this one purpose.
 
-/// Measures the number of terminal cells (1-8, matching `Cell::span`'s
-/// encoding limit) a grapheme cluster string needs, relative to a single
-/// cell's pixel width. Font size is fixed at construction time (not passed
-/// per call): the measurer is meant to be reconstructed whenever the
-/// terminal's font/zoom changes, same as `SizeInfo`/`cell_width_px` already
-/// is, so `ansi_handler.rs`'s hot input path never needs to thread a font
-/// size value through per character.
+/// Measures a grapheme cluster's real shaped width in pixels. Font size is
+/// fixed at construction time (not passed per call): the measurer is meant
+/// to be reconstructed whenever the terminal's font/zoom changes, same as
+/// `SizeInfo`/`cell_width_px` already is, so `ansi_handler.rs`'s hot input
+/// path never needs to thread a font size value through per character.
+///
+/// Deliberately returns a pixel width, not a quantized cell count: the
+/// caller (`ansi_handler.rs::flush_pending_indic_cluster`) accumulates
+/// natural width across a whole word and quantizes the RUNNING TOTAL, so
+/// each new cluster's allocated span is `ceil(cumulative natural / cell
+/// width) − cells already allocated to this word` rather than an
+/// independent per-cluster `ceil()`. That keeps a word's total waste under
+/// one cell (instead of accumulating ~half a cell of rounding slack per
+/// cluster) while never allocating less than any prefix's real width.
 pub trait ClusterWidthMeasurer: Send + Sync {
-    fn measure_cells(&self, cluster: &str, cell_width_px: f32) -> u8;
+    fn natural_width_px(&self, cluster: &str, cell_width_px: f32) -> f32;
 }
 
-/// Always reports a single cell. Used as the default for test-only
-/// `GridHandler` constructors, and anywhere Indic shaping genuinely isn't
-/// available (e.g. non-macOS builds, before a platform-specific measurer
-/// exists).
+/// Always reports exactly one cell's worth of width. Used as the default
+/// for test-only `GridHandler` constructors, and anywhere Indic shaping
+/// genuinely isn't available (e.g. non-macOS builds, before a
+/// platform-specific measurer exists).
 pub struct NoopMeasurer;
 
 impl ClusterWidthMeasurer for NoopMeasurer {
-    fn measure_cells(&self, _cluster: &str, _cell_width_px: f32) -> u8 {
-        1
+    fn natural_width_px(&self, _cluster: &str, cell_width_px: f32) -> f32 {
+        cell_width_px
     }
 }
 
@@ -82,9 +89,9 @@ mod mac_impl {
     }
 
     impl ClusterWidthMeasurer for CoreTextClusterMeasurer {
-        fn measure_cells(&self, cluster: &str, cell_width_px: f32) -> u8 {
+        fn natural_width_px(&self, cluster: &str, cell_width_px: f32) -> f32 {
             if cell_width_px <= 0.0 || cluster.is_empty() {
-                return 1;
+                return cell_width_px.max(0.0);
             }
             let run_length_chars = cluster.chars().count();
             let line = self.font_db.layout_line(
@@ -106,19 +113,7 @@ mod mac_impl {
                 f32::MAX,
                 ClipConfig::default(),
             );
-            // `ceil()`, not `round()`: guarantees allocated width is never
-            // less than the cluster's real shaped width. Tried `round()` to
-            // shrink leftover slack at word boundaries (Phase 10 of the
-            // Telugu variable-width-cells rewrite) but reverted it -- a
-            // real-paragraph visual test caught a virama-final conjunct
-            // glyph (e.g. "శ్") whose natural width exceeded its rounded
-            // allocation, so its glyph spilled into the following space and
-            // erased the word boundary entirely (two words rendered as one,
-            // unreadable). A visually-wide gap is a much smaller defect
-            // than words silently merging, so this reverts to the safe,
-            // never-overlaps invariant.
-            let cells = (line.width / cell_width_px).ceil() as u8;
-            cells.clamp(1, 8)
+            line.width
         }
     }
 }
@@ -131,10 +126,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn noop_measurer_always_returns_one() {
+    fn noop_measurer_always_returns_one_cell_width() {
         let measurer = NoopMeasurer;
-        assert_eq!(measurer.measure_cells("ప్రభుత్వం", 10.0), 1);
-        assert_eq!(measurer.measure_cells("", 10.0), 1);
+        assert_eq!(measurer.natural_width_px("ప్రభుత్వం", 10.0), 10.0);
+        assert_eq!(measurer.natural_width_px("", 10.0), 10.0);
     }
 
     #[cfg(target_os = "macos")]
@@ -151,15 +146,21 @@ mod tests {
 
         // A multi-syllable Telugu word should need more than one narrow
         // monospace cell's worth of width.
-        let cells = measurer.measure_cells("ప్రభుత్వం", 8.0);
+        let width_px = measurer.natural_width_px("ప్రభుత్వం", 8.0);
         assert!(
-            cells >= 2,
-            "expected a multi-syllable Telugu word to need >= 2 cells at a narrow cell width, got {cells}"
+            width_px > 2.0 * 8.0,
+            "expected a multi-syllable Telugu word to need more than 2 narrow cells' worth of width, got {width_px}px"
         );
-        assert!(cells <= 8, "measured span must stay within the 1-8 encoding limit, got {cells}");
+        assert!(
+            width_px < 8.0 * 8.0,
+            "measured natural width should stay well within the 1-8 cell encoding limit, got {width_px}px"
+        );
 
-        // A single ASCII char should fit in one narrow cell already.
-        let ascii_cells = measurer.measure_cells("a", 8.0);
-        assert_eq!(ascii_cells, 1);
+        // A single ASCII char should fit in about one narrow cell already.
+        let ascii_width_px = measurer.natural_width_px("a", 8.0);
+        assert!(
+            ascii_width_px <= 8.0,
+            "a single ASCII char should need at most one cell's width, got {ascii_width_px}px"
+        );
     }
 }

--- a/app/src/terminal/model/grid/cluster_measurer.rs
+++ b/app/src/terminal/model/grid/cluster_measurer.rs
@@ -106,7 +106,17 @@ mod mac_impl {
                 f32::MAX,
                 ClipConfig::default(),
             );
-            let cells = (line.width / cell_width_px).ceil() as u8;
+            // `round()` rather than `ceil()`: halves the average leftover
+            // slack per cluster (the gap between a cluster's real shaped
+            // width and its allocated cell count), which otherwise
+            // accumulates across a multi-cluster run and surfaces as an
+            // oversized gap before the next space/punctuation cell (see
+            // Phase 10 of the Telugu variable-width-cells rewrite). A
+            // cluster can now round down slightly under its natural width;
+            // the renderer already tolerates this gracefully (no clamp or
+            // panic on slight overflow into the next cell), so this trades
+            // a small, bounded overflow risk for less accumulated slack.
+            let cells = (line.width / cell_width_px).round() as u8;
             cells.clamp(1, 8)
         }
     }

--- a/app/src/terminal/model/grid/grapheme_cursor_tests.rs
+++ b/app/src/terminal/model/grid/grapheme_cursor_tests.rs
@@ -69,3 +69,48 @@ fn test_cursor() {
     final_cursor.move_backward();
     assert_cursor_contents_eq!(23u8 as char, final_cursor);
 }
+
+/// Regression test locking in that `move_forward`/`move_backward` already
+/// generalize to ANY cluster span (not just the CJK width=2 case) for
+/// free: both recurse internally while landing on a spacer cell, so a
+/// single call walks all the way to the cluster's base/next real cell
+/// regardless of how many spacer cells are in between. This must keep
+/// working for the variable-width-cell rewrite (spans up to 8, not just 2).
+#[test]
+fn test_cursor_skips_over_variable_width_span() {
+    let mut grid = GridHandler::new_for_test(2, 10);
+
+    // Row: [base(span=4)][spacer][spacer][spacer]['x']['y']...
+    grid.grid_storage_mut()[0][0] = cell('X');
+    grid.grid_storage_mut()[0][0].set_span(4);
+    for col in 1..4 {
+        grid.grid_storage_mut()[0][col]
+            .flags_mut()
+            .insert(cell::Flags::WIDE_CHAR_SPACER);
+    }
+    grid.grid_storage_mut()[0][4] = cell('y');
+
+    // Starting fresh at col 0 and moving forward should land on 'y' at col 4
+    // in a single move_forward() call, skipping all 3 spacer cells.
+    let mut cursor = grid.grapheme_cursor_from(Point { row: 0, col: 0 }, Wrap::All);
+    cursor.move_forward();
+    assert_eq!(Some(4), cursor.current_item().map(|item| item.point().col));
+    assert_eq!(
+        Some('y'),
+        cursor.current_item().map(|item| item.cell().c)
+    );
+
+    // Starting on a spacer cell (col 2, the middle of the span) should snap
+    // back to the base cell at col 0 -- constructor-time snapping must also
+    // handle a span wider than 2.
+    let snapped = grid.grapheme_cursor_from(Point { row: 0, col: 2 }, Wrap::All);
+    assert_eq!(Some(0), snapped.current_item().map(|item| item.point().col));
+    assert_eq!(Some('X'), snapped.current_item().map(|item| item.cell().c));
+
+    // Moving backward from 'y' should land back on the base cell at col 0
+    // in a single move_backward() call, skipping all 3 spacer cells.
+    let mut back_cursor = grid.grapheme_cursor_from(Point { row: 0, col: 4 }, Wrap::All);
+    back_cursor.move_backward();
+    assert_eq!(Some(0), back_cursor.current_item().map(|item| item.point().col));
+    assert_eq!(Some('X'), back_cursor.current_item().map(|item| item.cell().c));
+}

--- a/app/src/terminal/model/grid/grid_handler.rs
+++ b/app/src/terminal/model/grid/grid_handler.rs
@@ -1000,10 +1000,16 @@ impl GridHandler {
         let grid_row = self.row(row)?;
         let row_length = min(grid_row.line_length(), cols.end + 1);
 
-        // Include wide char when trailing spacer is selected.
-        if grid_row
-            .get(cols.start)
-            .is_some_and(|cell| cell.flags.contains(Flags::WIDE_CHAR_SPACER))
+        // Include the base cell when a trailing spacer is selected. Walks
+        // all the way back to the base (not just one cell), since a
+        // measured Indic cluster's span can be > 2 -- stepping back by
+        // exactly one cell only reaches another spacer for spans > 2,
+        // never the actual base, which would silently drop that cluster's
+        // text from the output.
+        while cols.start > 0
+            && grid_row
+                .get(cols.start)
+                .is_some_and(|cell| cell.flags.contains(Flags::WIDE_CHAR_SPACER))
         {
             cols.start -= 1;
         }
@@ -1089,7 +1095,11 @@ impl GridHandler {
         {
             if let Some(row) = self.row(row - 1) {
                 if let Some(cell) = row.get(0) {
-                    text.push(cell.c);
+                    // Push the full cluster (base char + any zero-width
+                    // continuations, e.g. a measured Indic cluster's
+                    // combining marks), not just the base codepoint --
+                    // `cell.c` alone would silently drop them.
+                    text.push_char_or_str(cell.content_for_display());
                 }
             }
         }

--- a/app/src/terminal/model/grid/grid_handler.rs
+++ b/app/src/terminal/model/grid/grid_handler.rs
@@ -1588,10 +1588,17 @@ impl GridHandler {
         });
     }
 
-    /// Determines if the rendered cursor is on a wide character, accounting for marked text.
-    pub fn is_cursor_on_wide_char(&self) -> bool {
+    /// Returns how many cells wide the cursor's current cell is (1 for a
+    /// normal char, up to 8 for a wide/measured Indic cluster), accounting
+    /// for marked text.
+    pub fn cursor_cell_span(&self) -> u8 {
         let cursor_render_point = self.cursor_render_point();
-        self.cell_type(cursor_render_point) == Some(CellType::WideChar)
+        if self.cell_type(cursor_render_point) != Some(CellType::WideChar) {
+            return 1;
+        }
+        self.row(cursor_render_point.row)
+            .and_then(|row| row.get(cursor_render_point.col).map(|cell| cell.span()))
+            .unwrap_or(1)
     }
 
     /// Updates the active [`Cursor`] using the provided `update_cursor_fn`.

--- a/app/src/terminal/model/grid/grid_handler.rs
+++ b/app/src/terminal/model/grid/grid_handler.rs
@@ -522,6 +522,27 @@ impl GridHandler {
         )
     }
 
+    /// Like [`Self::new_for_test`], but with a caller-supplied
+    /// [`ClusterWidthMeasurer`] — for tests that need deterministic,
+    /// non-1 cluster widths without depending on real Core Text shaping
+    /// (which is macOS-only and not suitable for a portable unit test).
+    #[cfg(test)]
+    pub fn new_for_test_with_measurer(
+        rows: usize,
+        columns: usize,
+        cluster_measurer: Arc<dyn ClusterWidthMeasurer>,
+    ) -> Self {
+        Self::new(
+            SizeInfo::new_without_font_metrics(rows, columns),
+            0,
+            ChannelEventListener::new_for_test(),
+            false,
+            ObfuscateSecrets::No,
+            PerformResetGridChecks::No,
+            cluster_measurer,
+        )
+    }
+
     #[cfg(test)]
     pub fn new_for_alt_screen_test(rows: usize, columns: usize) -> Self {
         Self::new(

--- a/app/src/terminal/model/grid/grid_handler.rs
+++ b/app/src/terminal/model/grid/grid_handler.rs
@@ -36,6 +36,11 @@ use warp_terminal::model::{KeyboardModes, KeyboardModesApplyBehavior};
 use warp_util::path::CleanPathResult;
 use warpui::color::ColorU;
 
+use std::sync::Arc;
+
+use super::cluster_measurer::ClusterWidthMeasurer;
+#[cfg(test)]
+use super::cluster_measurer::NoopMeasurer;
 use super::displayed_output::DisplayedOutput;
 use super::grapheme_cursor::{self, GraphemeCursor};
 use super::row::Row;
@@ -433,6 +438,13 @@ pub struct GridHandler {
     /// This allows find to be updated less frequently than byte processing while still
     /// knowing exactly which rows have changed.
     find_dirty_rows_range: Option<RangeInclusive<usize>>,
+
+    /// Measures the real shaped width of Indic grapheme clusters so
+    /// `ansi_handler`'s input path can allocate the correct cell span
+    /// (`Cell::set_span`) instead of a fixed per-script guess. `Arc` so
+    /// cloning `GridHandler` (already `#[derive(Clone)]`) is cheap and every
+    /// clone shares the same underlying font database.
+    pub(super) cluster_measurer: Arc<dyn ClusterWidthMeasurer>,
 }
 
 impl GridHandler {
@@ -443,6 +455,7 @@ impl GridHandler {
         is_alt_screen: bool,
         obfuscate_secrets: ObfuscateSecrets,
         perform_reset_grid_checks: PerformResetGridChecks,
+        cluster_measurer: Arc<dyn ClusterWidthMeasurer>,
     ) -> Self {
         // We set the maximum scrollback for grid storage to zero, as the
         // scrollback is stored in flat storage _instead_.  `GridHandler`
@@ -483,6 +496,7 @@ impl GridHandler {
             track_content_length: false,
             full_grid_clear_behavior: FullGridClearBehavior::Scroll,
             find_dirty_rows_range: None,
+            cluster_measurer,
         }
     }
 
@@ -504,6 +518,7 @@ impl GridHandler {
             false,
             ObfuscateSecrets::No,
             PerformResetGridChecks::No,
+            Arc::new(NoopMeasurer),
         )
     }
 
@@ -516,6 +531,7 @@ impl GridHandler {
             true,
             ObfuscateSecrets::No,
             PerformResetGridChecks::No,
+            Arc::new(NoopMeasurer),
         )
     }
 
@@ -615,6 +631,7 @@ impl GridHandler {
             track_content_length: false,
             full_grid_clear_behavior: FullGridClearBehavior::Scroll,
             find_dirty_rows_range: None,
+            cluster_measurer: self.cluster_measurer.clone(),
         };
 
         // Scan the full grid for secrets.  This is less performant than

--- a/app/src/terminal/model/grid/grid_handler_tests.rs
+++ b/app/src/terminal/model/grid/grid_handler_tests.rs
@@ -2835,3 +2835,76 @@ fn real_measurer_janavari_number_boundary_is_tight() {
          regression"
     );
 }
+
+/// Phase 14 (Telugu variable-width-cells plan): regression guard for the
+/// "word fills exactly to the last column, then continues" carry bug --
+/// real Menlo-measured Telugu text at 140 columns used to split "అనేక" as
+/// "అనే"|"క" (and, at the user's real terminal width, "చిత్రాలకు" as
+/// "చి"|"త్రాలకు") because the continuity filter in
+/// `flush_pending_indic_cluster` discarded the in-progress word's
+/// accumulator exactly when a cluster filled the last column
+/// (`input_needs_wrap == true`), making `carry_indic_word`'s own handling
+/// of that state unreachable.
+///
+/// `bounds_to_string` reconstructs identically whether a word split mid-way
+/// across two rows or carried whole (concatenating cell content either way
+/// doesn't care where the row boundary fell), so it can't distinguish carry
+/// from split -- this test instead dumps each row's own content
+/// independently and checks that every previously-splitting word appears
+/// intact within a SINGLE row's dump (whole on one row, whether that's the
+/// row it started on or the next row it carried to).
+#[cfg(target_os = "macos")]
+#[test]
+fn real_measurer_no_mid_word_split_across_soft_wrap() {
+    use crate::terminal::model::grid::cluster_measurer::CoreTextClusterMeasurer;
+    use warpui::fonts::Properties;
+
+    let measurer = CoreTextClusterMeasurer::new("Menlo", Properties::default(), 13.0)
+        .expect("Menlo should be resolvable");
+    let size_info = crate::terminal::SizeInfo::new(
+        pathfinder_geometry::vector::vec2f(140.0 * 8.0, 3.0 * 18.0),
+        warpui::units::Pixels::new(8.0),
+        warpui::units::Pixels::new(18.0),
+        warpui::units::Pixels::zero(),
+        warpui::units::Pixels::zero(),
+    );
+    let mut grid = GridHandler::new(
+        size_info,
+        0,
+        crate::terminal::event_listener::ChannelEventListener::new_for_test(),
+        false,
+        ObfuscateSecrets::No,
+        crate::terminal::model::grid::grid_handler::PerformResetGridChecks::No,
+        std::sync::Arc::new(measurer),
+    );
+    let text = "1974లో \"ఓ సీత కథ\" చిత్రానికి తన మొదటి పాటను రచించారు, ఇది కె. విశ్వనాథ్ దర్శకత్వంలో వచ్చింది. ఆ తరువాత శంకరాభరణం, సాగర సంగమం, సిరిసిరి మువ్వ వంటి అనేక అద్భుతమైన చిత్రాలకు పాటలు రాశారు.";
+    feed(&mut grid, text);
+
+    let mut row_dumps = Vec::new();
+    for row_idx in 0..3 {
+        let Some(row) = grid.row(row_idx) else {
+            continue;
+        };
+        let mut col = 0;
+        let mut dump = String::new();
+        while col < row.len() {
+            let cell = &row[col];
+            if cell.c == crate::terminal::model::cell::DEFAULT_CHAR {
+                col += 1;
+                continue;
+            }
+            dump.push_char_or_str(cell.content_for_display());
+            col += cell.span().max(1) as usize;
+        }
+        row_dumps.push(dump);
+    }
+
+    for word in ["అనేక", "చిత్రాలకు", "అద్భుతమైన", "శంకరాభరణం"] {
+        assert!(
+            row_dumps.iter().any(|dump| dump.contains(word)),
+            "expected \"{word}\" to appear intact within a single row's content, but it \
+             didn't -- it split across the wrap boundary instead of carrying whole. row \
+             dumps: {row_dumps:?}"
+        );
+    }
+}

--- a/app/src/terminal/model/grid/grid_handler_tests.rs
+++ b/app/src/terminal/model/grid/grid_handler_tests.rs
@@ -2651,3 +2651,33 @@ fn test_indic_cluster_wraps_to_next_line_when_it_does_not_fit() {
     assert_eq!(wrapped_cell.span(), 4);
     assert_eq!(wrapped_cell.raw_content(), CharOrStr::Str("క్షి"));
 }
+
+#[test]
+fn test_bounds_to_string_snaps_back_to_base_of_variable_width_span() {
+    // Regression test: the entry-point snap in line_to_string previously
+    // stepped back exactly one cell when the range's start landed on a
+    // spacer -- correct only for a fixed CJK width=2 span. For a span > 2,
+    // stepping back once still lands on another spacer, never reaching the
+    // actual base cell, silently dropping that cluster's text from the
+    // output. Must now walk all the way back to the base.
+    let mut grid = grid_with_fixed_width_measurer(2, 10);
+    feed(&mut grid, "aక్షిbb");
+    // "a" (col0), "క్షి" (4-codepoint cluster, base col1 span4, spacers
+    // cols2-4), "b","b" (cols5,6).
+
+    // Start the range at col3 -- the THIRD cell of the 4-wide span (a
+    // spacer, not the base, and not adjacent to it either).
+    let result = grid.bounds_to_string(
+        Point::new(0, 3),
+        Point::new(0, 6),
+        false,
+        RespectObfuscatedSecrets::No,
+        false,
+        RespectDisplayedOutput::No,
+    );
+    assert_eq!(
+        result, "క్షిbb",
+        "the full cluster text must be included even though the range \
+         started mid-span, not just adjacent to the base"
+    );
+}

--- a/app/src/terminal/model/grid/grid_handler_tests.rs
+++ b/app/src/terminal/model/grid/grid_handler_tests.rs
@@ -417,6 +417,7 @@ fn test_basic_input_and_newline() {
         false,
         ObfuscateSecrets::No,
         PerformResetGridChecks::default(),
+        std::sync::Arc::new(crate::terminal::model::grid::NoopMeasurer),
     );
     grid.input('a');
     grid.linefeed();
@@ -447,6 +448,7 @@ fn test_empty_grid_bounds_to_string() {
         false,
         ObfuscateSecrets::No,
         PerformResetGridChecks::No,
+        std::sync::Arc::new(crate::terminal::model::grid::NoopMeasurer),
     );
     assert_eq!(
         grid_handler.bounds_to_string(
@@ -1459,6 +1461,7 @@ fn test_emoji_variation_selector() {
         ChannelEventListener::new_for_test(),
         ObfuscateSecrets::No,
         PerformResetGridChecks::default(),
+        std::sync::Arc::new(crate::terminal::model::grid::NoopMeasurer),
     );
 
     blockgrid.start();

--- a/app/src/terminal/model/grid/grid_handler_tests.rs
+++ b/app/src/terminal/model/grid/grid_handler_tests.rs
@@ -2516,14 +2516,20 @@ fn test_full_grid_clear_resize_then_bounds_to_string_does_not_panic() {
 }
 
 /// Deterministic stand-in for `CoreTextClusterMeasurer` in tests: reports a
-/// span equal to the cluster's codepoint count (clamped to 1..=8), so tests
-/// can assert on a predictable multi-cell span without depending on real
-/// Core Text shaping (macOS-only, and not suitable for a portable unit test).
+/// natural width equal to the cluster's codepoint count (clamped to 1..=8)
+/// times the cell width, so tests can assert on a predictable multi-cell
+/// span without depending on real Core Text shaping (macOS-only, and not
+/// suitable for a portable unit test). The clamp is applied HERE (not left
+/// to the caller's cumulative-quantization math) so this reproduces the
+/// exact same per-cluster spans as before word-cumulative allocation existed
+/// -- every codepoint-count cluster maps to an exact integer multiple of the
+/// cell width, so cumulative quantization introduces zero extra slack and
+/// every span-dependent test using this double keeps passing unchanged.
 struct FixedWidthMeasurer;
 
 impl ClusterWidthMeasurer for FixedWidthMeasurer {
-    fn measure_cells(&self, cluster: &str, _cell_width_px: f32) -> u8 {
-        (cluster.chars().count() as u8).clamp(1, 8)
+    fn natural_width_px(&self, cluster: &str, cell_width_px: f32) -> f32 {
+        (cluster.chars().count() as u8).clamp(1, 8) as f32 * cell_width_px
     }
 }
 
@@ -2760,4 +2766,72 @@ fn test_mixed_ascii_cjk_indic_line_has_no_orphaned_spans() {
     assert_eq!(cjk_cell.c, '鳥');
     assert_eq!(row[7].c, 'b');
     assert_eq!(row[8].c, 'b');
+}
+
+/// Real-Menlo-measurer regression harness for the Phase 12 accumulated-slack
+/// bug: "జనవరి 30" (Telugu word directly followed by a non-absorbable ASCII
+/// number) used to allocate ~16 cells for "ఆయన జనవరి" (independent
+/// per-cluster `ceil()`) against a combined natural width worth ~10-11
+/// cells -- a ~5 cell gap landed right before "30". Word-cumulative
+/// allocation (`ansi_handler.rs::flush_pending_indic_cluster`) bounds a
+/// word's total waste to under one cell, so the same input should now
+/// allocate close to the natural width.
+///
+/// Uses a realistic monospace cell width (8px @ 13pt Menlo) rather than
+/// `SizeInfo::new_without_font_metrics`'s dummy 1px, since 1px next to a
+/// real 13pt-shaped cluster would make every cluster hit the 8-cell clamp
+/// regardless of any allocation bug (a false positive this test itself hit
+/// once during diagnosis).
+#[cfg(target_os = "macos")]
+#[test]
+fn real_measurer_janavari_number_boundary_is_tight() {
+    use crate::terminal::model::grid::cluster_measurer::CoreTextClusterMeasurer;
+    use warpui::fonts::Properties;
+
+    let measurer = CoreTextClusterMeasurer::new("Menlo", Properties::default(), 13.0)
+        .expect("Menlo should be resolvable");
+    let size_info = crate::terminal::SizeInfo::new(
+        pathfinder_geometry::vector::vec2f(60.0 * 8.0, 3.0 * 18.0),
+        warpui::units::Pixels::new(8.0),
+        warpui::units::Pixels::new(18.0),
+        warpui::units::Pixels::zero(),
+        warpui::units::Pixels::zero(),
+    );
+    let mut grid = GridHandler::new(
+        size_info,
+        0,
+        crate::terminal::event_listener::ChannelEventListener::new_for_test(),
+        false,
+        ObfuscateSecrets::No,
+        crate::terminal::model::grid::grid_handler::PerformResetGridChecks::No,
+        std::sync::Arc::new(measurer),
+    );
+    feed(&mut grid, "ఆయన జనవరి 30, 1936న కృష్ణా");
+
+    let mut col = 0;
+    let mut number_start_col = None;
+    while col < grid.columns() {
+        let cell = &grid.grid_storage()[VisibleRow(0)][col];
+        if cell.c == crate::terminal::model::cell::DEFAULT_CHAR {
+            break;
+        }
+        if cell.c == '3' && number_start_col.is_none() {
+            number_start_col = Some(col);
+        }
+        col += cell.span().max(1) as usize;
+    }
+
+    // "ఆయన జనవరి " (7 Telugu clusters + 2 spaces) before "30": with
+    // word-cumulative allocation this should land in the low-to-mid teens
+    // of columns, not the ~18+ columns the old independent-per-cluster
+    // `ceil()` produced. This is a regression guard, not an exact-value
+    // assertion, since real Core Text shaping can shift by a cell or two
+    // across font/OS versions.
+    let number_start_col = number_start_col.expect("'30' should appear in the fed text");
+    assert!(
+        number_start_col <= 14,
+        "expected 'ఆయన జనవరి ' to allocate no more than ~14 columns with word-cumulative \
+         quantization, but '30' started at column {number_start_col} -- an accumulated-slack \
+         regression"
+    );
 }

--- a/app/src/terminal/model/grid/grid_handler_tests.rs
+++ b/app/src/terminal/model/grid/grid_handler_tests.rs
@@ -2498,3 +2498,156 @@ fn test_full_grid_clear_resize_then_bounds_to_string_does_not_panic() {
         );
     }
 }
+
+/// Deterministic stand-in for `CoreTextClusterMeasurer` in tests: reports a
+/// span equal to the cluster's codepoint count (clamped to 1..=8), so tests
+/// can assert on a predictable multi-cell span without depending on real
+/// Core Text shaping (macOS-only, and not suitable for a portable unit test).
+struct FixedWidthMeasurer;
+
+impl ClusterWidthMeasurer for FixedWidthMeasurer {
+    fn measure_cells(&self, cluster: &str, _cell_width_px: f32) -> u8 {
+        (cluster.chars().count() as u8).clamp(1, 8)
+    }
+}
+
+fn grid_with_fixed_width_measurer(rows: usize, columns: usize) -> GridHandler {
+    GridHandler::new_for_test_with_measurer(rows, columns, Arc::new(FixedWidthMeasurer))
+}
+
+/// Feeds `text` through a real `ansi::Processor`, exactly like PTY bytes
+/// would arrive -- notably, this calls `on_finish_byte_processing` at the
+/// end, so a cluster that happens to end at the very end of `text` still
+/// gets flushed (unlike calling `grid.input(c)` directly in a loop, which
+/// stops without ever triggering that batch-end hook).
+fn feed(grid: &mut GridHandler, text: &str) {
+    let mut processor = crate::terminal::model::ansi::Processor::new();
+    processor.parse_bytes(grid, text.as_bytes(), &mut std::io::sink());
+}
+
+#[test]
+fn test_indic_virama_conjunct_gets_measured_span() {
+    // క్ష = క (KA) + ్ (virama) + ష (SSA) -- a 3-codepoint virama-conjunct
+    // cluster. FixedWidthMeasurer reports span 3 for it.
+    let mut grid = grid_with_fixed_width_measurer(2, 10);
+    feed(&mut grid, "క్ష");
+
+    let cell = &grid.grid_storage()[VisibleRow(0)][0];
+    assert_eq!(cell.span(), 3, "conjunct cluster should get a 3-cell span");
+    assert_eq!(cell.raw_content(), CharOrStr::Str("క్ష"));
+    assert!(grid.grid_storage()[VisibleRow(0)][1]
+        .flags()
+        .contains(Flags::WIDE_CHAR_SPACER));
+    assert!(grid.grid_storage()[VisibleRow(0)][2]
+        .flags()
+        .contains(Flags::WIDE_CHAR_SPACER));
+    // Cursor should have advanced past the full span.
+    assert_eq!(grid.cursor_point(), Point::new(0, 3));
+}
+
+#[test]
+fn test_indic_base_plus_vowel_sign_gets_measured_span() {
+    // కి = క (KA) + ి (vowel sign I) -- a 2-codepoint base+matra cluster.
+    let mut grid = grid_with_fixed_width_measurer(2, 10);
+    feed(&mut grid, "కి");
+
+    let cell = &grid.grid_storage()[VisibleRow(0)][0];
+    assert_eq!(cell.span(), 2);
+    assert_eq!(cell.raw_content(), CharOrStr::Str("కి"));
+    assert!(grid.grid_storage()[VisibleRow(0)][1]
+        .flags()
+        .contains(Flags::WIDE_CHAR_SPACER));
+    assert_eq!(grid.cursor_point(), Point::new(0, 2));
+}
+
+#[test]
+fn test_indic_cluster_flushes_before_ascii_char() {
+    // "కxy": Telugu base (1 codepoint, span 1) then two plain ASCII chars.
+    // The Indic char must not swallow the following ASCII input.
+    let mut grid = grid_with_fixed_width_measurer(2, 10);
+    feed(&mut grid, "కxy");
+
+    assert_eq!(
+        grid.grid_storage()[VisibleRow(0)][0].raw_content(),
+        CharOrStr::Char('క')
+    );
+    assert_eq!(grid.grid_storage()[VisibleRow(0)][1].c, 'x');
+    assert_eq!(grid.grid_storage()[VisibleRow(0)][2].c, 'y');
+}
+
+#[test]
+fn test_indic_cluster_flushes_at_end_of_batch() {
+    // A cluster that ends exactly at the end of a PTY-read batch must still
+    // be written (on_finish_byte_processing flushes it), not silently
+    // dropped just because no further character arrived to trigger the
+    // non-Indic flush path.
+    let mut grid = grid_with_fixed_width_measurer(2, 10);
+    feed(&mut grid, "క్ష");
+
+    let cell = &grid.grid_storage()[VisibleRow(0)][0];
+    assert_eq!(cell.span(), 3);
+    assert_eq!(cell.raw_content(), CharOrStr::Str("క్ష"));
+}
+
+#[test]
+fn test_indic_multiple_clusters_in_one_word_each_get_own_span() {
+    // ప్రభుత్వం ("government") is several independent syllables. Each
+    // syllable must get its OWN measured span -- the cluster boundary rule
+    // must not glue independent syllables together into one giant span,
+    // which would make cursor navigation jump the whole word at once.
+    let word = "ప్రభుత్వం";
+    let mut grid = grid_with_fixed_width_measurer(2, 20);
+    feed(&mut grid, word);
+
+    // Walk the row and collect (span, content) for each non-spacer cell.
+    let mut clusters = Vec::new();
+    let mut col = 0;
+    while col < grid.columns() {
+        let current_cell = &grid.grid_storage()[VisibleRow(0)][col];
+        if current_cell.c == crate::terminal::model::cell::DEFAULT_CHAR {
+            break;
+        }
+        let span = current_cell.span();
+        clusters.push((span, current_cell.raw_content().to_string()));
+        col += span as usize;
+    }
+
+    // The word should have decomposed into more than one cluster (not one
+    // giant span covering the whole word), and every cluster's measured
+    // span should match its own codepoint count.
+    assert!(
+        clusters.len() > 1,
+        "expected multiple independent clusters, got {clusters:?}"
+    );
+    for (span, text) in &clusters {
+        assert_eq!(
+            *span as usize,
+            text.chars().count(),
+            "cluster {text:?} span should match its own codepoint count"
+        );
+    }
+    // Reassembling every cluster's text should reproduce the original word.
+    let reassembled: String = clusters.iter().map(|(_, text)| text.as_str()).collect();
+    assert_eq!(reassembled, word);
+}
+
+#[test]
+fn test_indic_cluster_wraps_to_next_line_when_it_does_not_fit() {
+    // A 4-cell-wide cluster starting at column 8 of a 10-column grid does
+    // not fit (needs cols 8..12); it should wrap whole to the next line,
+    // not get truncated/split.
+    let mut grid = grid_with_fixed_width_measurer(3, 10);
+    // Fill columns 0..8, then feed a 4-codepoint cluster (క + ్ + ష + ి,
+    // conjunct + trailing vowel sign) which needs cols 8..12 -- doesn't fit.
+    feed(&mut grid, "aaaaaaaaక్షి");
+
+    // Row 0, cols 8-9 should NOT contain the cluster (it didn't fit) --
+    // a LEADING_WIDE_CHAR_SPACER placeholder should occupy col 8 instead.
+    assert!(grid.grid_storage()[VisibleRow(0)][8]
+        .flags()
+        .contains(Flags::LEADING_WIDE_CHAR_SPACER));
+    // The cluster should have wrapped whole onto row 1, starting at col 0.
+    let wrapped_cell = &grid.grid_storage()[VisibleRow(1)][0];
+    assert_eq!(wrapped_cell.span(), 4);
+    assert_eq!(wrapped_cell.raw_content(), CharOrStr::Str("క్షి"));
+}

--- a/app/src/terminal/model/grid/grid_handler_tests.rs
+++ b/app/src/terminal/model/grid/grid_handler_tests.rs
@@ -1697,22 +1697,38 @@ fn test_grid_rightmost_nonempty_cell() {
 
 /// Asserts that no orphaned WIDE_CHAR or WIDE_CHAR_SPACER flags exist in
 /// the visible row of a GridHandler.
-fn assert_no_orphaned_wide_chars(grid: &GridHandler, visible_row: VisibleRow) {
+/// Verifies every wide/Indic cluster in `visible_row` is internally
+/// consistent: a base cell's declared `span()` trailing cells are all
+/// `WIDE_CHAR_SPACER`, and every `WIDE_CHAR_SPACER` cell traces back to
+/// exactly one base within its own span (no orphans in either direction).
+/// Generalizes the previous `assert_no_orphaned_wide_chars`, which only
+/// checked a single adjacent cell -- correct for the old fixed CJK
+/// width=2 case, but not for a measured Indic cluster's span up to 8.
+fn assert_no_orphaned_spans(grid: &GridHandler, visible_row: VisibleRow) {
     let num_cols = grid.columns();
     let row = &grid.grid_storage()[visible_row];
-    for col in 0..num_cols {
-        if row[col].flags.contains(Flags::WIDE_CHAR) {
+    let mut col = 0;
+    while col < num_cols {
+        let span = row[col].span() as usize;
+        if span > 1 {
             assert!(
-                col + 1 < num_cols && row[col + 1].flags.contains(Flags::WIDE_CHAR_SPACER),
-                "Orphaned WIDE_CHAR at column {col}: next cell is not a WIDE_CHAR_SPACER."
+                col + span <= num_cols,
+                "Cluster at column {col} declares span {span}, but the row only has {num_cols} columns."
+            );
+            for offset in 1..span {
+                assert!(
+                    row[col + offset].flags.contains(Flags::WIDE_CHAR_SPACER),
+                    "Orphaned cluster base at column {col} (span {span}): cell at column {} is not a WIDE_CHAR_SPACER.",
+                    col + offset
+                );
+            }
+        } else {
+            assert!(
+                !row[col].flags.contains(Flags::WIDE_CHAR_SPACER),
+                "Orphaned WIDE_CHAR_SPACER at column {col}: not covered by any preceding cluster's span."
             );
         }
-        if row[col].flags.contains(Flags::WIDE_CHAR_SPACER) {
-            assert!(
-                col > 0 && row[col - 1].flags.contains(Flags::WIDE_CHAR),
-                "Orphaned WIDE_CHAR_SPACER at column {col}: previous cell is not a WIDE_CHAR."
-            );
-        }
+        col += span.max(1);
     }
 }
 
@@ -1725,7 +1741,7 @@ fn test_input_overwriting_wide_char_spacer_resets_wide_char() {
     grid.goto(VisibleRow(0), 1);
     grid.input('x');
 
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
     assert!(!grid.grid_storage()[VisibleRow(0)][0]
         .flags
         .contains(Flags::WIDE_CHAR));
@@ -1742,7 +1758,7 @@ fn test_input_overwriting_wide_char_resets_spacer() {
     grid.goto(VisibleRow(0), 0);
     grid.input('y');
 
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
     assert_eq!(grid.grid_storage()[VisibleRow(0)][0].c, 'y');
     assert!(!grid.grid_storage()[VisibleRow(0)][1]
         .flags
@@ -1759,7 +1775,7 @@ fn test_erase_chars_at_wide_char_spacer_boundary() {
     grid.goto(VisibleRow(0), 1);
     grid.erase_chars(1);
 
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
     assert!(!grid.grid_storage()[VisibleRow(0)][0]
         .flags
         .contains(Flags::WIDE_CHAR));
@@ -1778,7 +1794,7 @@ fn test_erase_chars_at_wide_char_end_boundary() {
     grid.goto(VisibleRow(0), 1);
     grid.erase_chars(2); // Erases cols 1..3.
 
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
 }
 
 #[test]
@@ -1791,7 +1807,7 @@ fn test_delete_chars_at_wide_char_spacer_boundary() {
     grid.goto(VisibleRow(0), 1);
     grid.delete_chars(1);
 
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
     assert!(!grid.grid_storage()[VisibleRow(0)][0]
         .flags
         .contains(Flags::WIDE_CHAR));
@@ -1807,7 +1823,7 @@ fn test_insert_blank_at_wide_char_spacer_boundary() {
     grid.goto(VisibleRow(0), 1);
     grid.insert_blank(1);
 
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
     assert!(!grid.grid_storage()[VisibleRow(0)][0]
         .flags
         .contains(Flags::WIDE_CHAR));
@@ -1823,7 +1839,7 @@ fn test_clear_line_right_at_wide_char_spacer() {
     grid.goto(VisibleRow(0), 1);
     grid.clear_line(ansi::LineClearMode::Right);
 
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
     assert!(!grid.grid_storage()[VisibleRow(0)][0]
         .flags
         .contains(Flags::WIDE_CHAR));
@@ -1842,7 +1858,7 @@ fn test_clear_line_left_at_wide_char() {
     grid.goto(VisibleRow(0), 2);
     grid.clear_line(ansi::LineClearMode::Left);
 
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
     assert!(!grid.grid_storage()[VisibleRow(0)][3]
         .flags
         .contains(Flags::WIDE_CHAR_SPACER));
@@ -1858,7 +1874,7 @@ fn test_clear_screen_below_at_wide_char_spacer() {
     grid.goto(VisibleRow(0), 1);
     grid.clear_screen(ansi::ClearMode::Below);
 
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
     assert!(!grid.grid_storage()[VisibleRow(0)][0]
         .flags
         .contains(Flags::WIDE_CHAR));
@@ -1877,7 +1893,7 @@ fn test_clear_screen_above_at_wide_char() {
     grid.goto(VisibleRow(0), 2);
     grid.clear_screen(ansi::ClearMode::Above);
 
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
     assert!(!grid.grid_storage()[VisibleRow(0)][3]
         .flags
         .contains(Flags::WIDE_CHAR_SPACER));
@@ -1976,7 +1992,7 @@ fn test_clear_line_left_preserves_adjacent_wide_char() {
     grid.goto(VisibleRow(0), 1);
     grid.clear_line(ansi::LineClearMode::Left);
 
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
     // The wide char at cols 2-3 must be preserved.
     assert!(
         grid.grid_storage()[VisibleRow(0)][2]
@@ -2004,7 +2020,7 @@ fn test_erase_chars_preserves_adjacent_wide_char_at_end() {
     grid.goto(VisibleRow(0), 0);
     grid.erase_chars(2);
 
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
     // The wide char at cols 2-3 must be preserved.
     assert!(
         grid.grid_storage()[VisibleRow(0)][2]
@@ -2032,7 +2048,7 @@ fn test_delete_chars_preserves_adjacent_wide_char_at_end() {
     grid.goto(VisibleRow(0), 0);
     grid.delete_chars(2);
 
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
     // The wide char should have been shifted left to cols 0-1.
     assert!(
         grid.grid_storage()[VisibleRow(0)][0]
@@ -2060,7 +2076,7 @@ fn test_clear_screen_above_preserves_adjacent_wide_char() {
     grid.goto(VisibleRow(0), 1);
     grid.clear_screen(ansi::ClearMode::Above);
 
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
     // The wide char at cols 2-3 must be preserved.
     assert!(
         grid.grid_storage()[VisibleRow(0)][2]
@@ -2088,7 +2104,7 @@ fn test_insert_mode_at_spacer_resets_wide_char() {
     grid.set_mode(ansi::Mode::Insert);
     grid.input('x');
 
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
 }
 
 #[test]
@@ -2110,7 +2126,7 @@ fn test_insert_mode_pushes_wide_char_off_end() {
     grid.set_mode(ansi::Mode::Insert);
     grid.input('x');
 
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
 }
 
 #[test]
@@ -2154,8 +2170,8 @@ fn test_write_at_cursor_clears_leading_wide_char_spacer() {
             .contains(Flags::LEADING_WIDE_CHAR_SPACER),
         "LEADING_WIDE_CHAR_SPACER was not cleared on previous row."
     );
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(1));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(1));
 }
 
 #[test]
@@ -2180,8 +2196,8 @@ fn test_write_at_cursor_clears_leading_wide_char_spacer_at_col_1() {
             .contains(Flags::LEADING_WIDE_CHAR_SPACER),
         "LEADING_WIDE_CHAR_SPACER was not cleared when overwriting col 1."
     );
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(1));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(1));
 }
 
 #[test]
@@ -2233,7 +2249,7 @@ fn test_insert_blank_resets_wide_char_pushed_off_end() {
     grid.goto(VisibleRow(0), 0);
     grid.insert_blank(2);
 
-    assert_no_orphaned_wide_chars(&grid, VisibleRow(0));
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
 }
 
 // ─── content_len / trailing blank row trimming ───────────────────────
@@ -2720,4 +2736,28 @@ fn test_real_telugu_sentence_clusters_correctly() {
             "దిం", "చా", "లి"
         ]
     );
+}
+
+#[test]
+fn test_mixed_ascii_cjk_indic_line_has_no_orphaned_spans() {
+    // A single line mixing plain ASCII, a real CJK wide char (width=2,
+    // exercised through the SAME set_span/CellType path as a measured
+    // Indic cluster -- not a special case), and a measured Indic cluster.
+    // Confirms the two span mechanisms (fixed CJK width=2, variable
+    // measured Indic span) coexist correctly on one row.
+    let mut grid = grid_with_fixed_width_measurer(2, 20);
+    feed(&mut grid, "aక్షి鳥bb");
+
+    assert_no_orphaned_spans(&grid, VisibleRow(0));
+
+    let row = &grid.grid_storage()[VisibleRow(0)];
+    assert_eq!(row[0].c, 'a');
+    let indic_cell = &row[1];
+    assert_eq!(indic_cell.span(), 4, "క్షి is a 4-codepoint measured cluster");
+    assert_eq!(indic_cell.raw_content(), CharOrStr::Str("క్షి"));
+    let cjk_cell = &row[5];
+    assert_eq!(cjk_cell.span(), 2, "鳥 is a fixed CJK width=2 char");
+    assert_eq!(cjk_cell.c, '鳥');
+    assert_eq!(row[7].c, 'b');
+    assert_eq!(row[8].c, 'b');
 }

--- a/app/src/terminal/model/grid/grid_handler_tests.rs
+++ b/app/src/terminal/model/grid/grid_handler_tests.rs
@@ -2681,3 +2681,43 @@ fn test_bounds_to_string_snaps_back_to_base_of_variable_width_span() {
          started mid-span, not just adjacent to the base"
     );
 }
+
+#[test]
+fn test_real_telugu_sentence_clusters_correctly() {
+    // A real, full Telugu sentence (multiple words, mixed conjunct and
+    // vowel-sign clusters), verifying every cluster boundary matches
+    // proper akshara segmentation -- not just the synthetic single-word
+    // tests above. Written while diagnosing a real rendering bug (see
+    // the plan's Phase 6 execution log): this test proved the clustering
+    // logic itself was already correct, which correctly pointed the
+    // investigation at the render layer instead.
+    let word = "ప్రభుత్వం అందరికీ విద్యను అందించాలి";
+    let mut grid = grid_with_fixed_width_measurer(3, 60);
+    feed(&mut grid, word);
+
+    let mut col = 0;
+    let mut clusters = Vec::new();
+    while col < grid.columns() {
+        let cell = &grid.grid_storage()[VisibleRow(0)][col];
+        if cell.c == crate::terminal::model::cell::DEFAULT_CHAR {
+            break;
+        }
+        clusters.push(cell.raw_content().to_string());
+        col += cell.span().max(1) as usize;
+    }
+
+    let reassembled: String = clusters.concat();
+    assert_eq!(
+        reassembled, word,
+        "reassembling every cluster's text should reproduce the original sentence"
+    );
+    // Every syllable boundary in this sentence: ప్ర|భు|త్వం [space]
+    // అం|ద|రి|కీ [space] వి|ద్య|ను [space] అం|దిం|చా|లి
+    assert_eq!(
+        clusters,
+        vec![
+            "ప్ర", "భు", "త్వం", " ", "అం", "ద", "రి", "కీ", " ", "వి", "ద్య", "ను", " ", "అం",
+            "దిం", "చా", "లి"
+        ]
+    );
+}

--- a/app/src/terminal/model/grid/grid_storage/resize.rs
+++ b/app/src/terminal/model/grid/grid_storage/resize.rs
@@ -164,7 +164,13 @@ impl GridStorage {
             let len = min(row.len(), num_wrapped);
 
             // Insert leading spacer when there's not enough room for reflowing wide char.
-            let mut cells = if row[len - 1].flags().contains(Flags::WIDE_CHAR) {
+            //
+            // Checks `span() > 1` (not the legacy `Flags::WIDE_CHAR`
+            // boolean, which `Cell::set_span` only keeps in sync for
+            // span == 2) so this correctly detects any measured Indic
+            // cluster's base landing at the reflow boundary, not just a
+            // fixed CJK width=2 char.
+            let mut cells = if row[len - 1].span() > 1 {
                 num_wrapped -= 1;
 
                 let mut cells = row.front_split_off(len - 1);
@@ -363,7 +369,12 @@ impl GridStorage {
                 };
 
                 // Insert spacer if a wide char would be wrapped into the last column.
-                if row.len() >= columns && row[columns - 1].flags().contains(Flags::WIDE_CHAR) {
+                //
+                // Checks `span() > 1` (not the legacy `Flags::WIDE_CHAR`
+                // boolean) so this correctly detects any measured Indic
+                // cluster's base at the new column boundary, not just a
+                // fixed CJK width=2 char.
+                if row.len() >= columns && row[columns - 1].span() > 1 {
                     let mut spacer = Cell::default();
                     spacer.flags_mut().insert(Flags::LEADING_WIDE_CHAR_SPACER);
 

--- a/app/src/terminal/model/grid/mod.rs
+++ b/app/src/terminal/model/grid/mod.rs
@@ -1,3 +1,4 @@
+pub mod cluster_measurer;
 mod displayed_output;
 pub mod grid_handler;
 mod grid_storage;
@@ -9,6 +10,7 @@ pub(super) mod grapheme_cursor;
 #[cfg(test)]
 mod tests;
 
+pub use cluster_measurer::{ClusterWidthMeasurer, NoopMeasurer};
 pub use displayed_output::RespectDisplayedOutput;
 pub use grid_storage::*;
 pub(super) use indexing::ConvertToAbsolute;

--- a/app/src/terminal/model/grid/secrets_tests.rs
+++ b/app/src/terminal/model/grid/secrets_tests.rs
@@ -27,6 +27,7 @@ fn empty_blockgrid(
         ChannelEventListener::new_for_test(),
         secret_obfuscation_mode,
         Default::default(),
+        std::sync::Arc::new(crate::terminal::model::grid::NoopMeasurer),
     )
 }
 

--- a/app/src/terminal/model/grid/selection_cursor.rs
+++ b/app/src/terminal/model/grid/selection_cursor.rs
@@ -40,10 +40,32 @@ impl<'g> SelectionCursor<'g> {
         match self.cursor_state {
             CursorState::Valid if self.has_next() => {
                 self.increment_cursor();
-                // If the cursor is on top of a wide char, move it forward an
-                // extra cell.
-                if self.is_wide_char_or_spacer() {
-                    self.increment_cursor();
+                // Original behavior (verified against the real, pre-existing
+                // `test_select_left_select_right` test): after the single
+                // step above, if we landed on the BASE of a wide/Indic
+                // cluster, its span tells us exactly how many more cells to
+                // skip to reach that same cluster's last cell -- for the
+                // old fixed CJK width=2 case this is always exactly one more
+                // step, identical to what the original code did. If instead
+                // we landed on a SPACER (we started already partway through
+                // a cluster, e.g. right on its base cell), take exactly ONE
+                // more step -- matching the original code's literal
+                // single-conditional-step behavior exactly, rather than
+                // walking to the cluster's actual last cell. (A "smarter"
+                // walk-to-the-end here changes existing width=2 behavior in
+                // a way the real test catches -- see the plan's Phase 4
+                // execution log for the full trace.)
+                match self.grid.cell_type(self.pos) {
+                    Some(CellType::WideChar) => {
+                        let span = self.current_cell_span().unwrap_or(1);
+                        for _ in 1..span {
+                            self.increment_cursor();
+                        }
+                    }
+                    Some(CellType::WideCharSpacer) => {
+                        self.increment_cursor();
+                    }
+                    _ => {}
                 }
             }
             CursorState::Valid => {
@@ -61,9 +83,13 @@ impl<'g> SelectionCursor<'g> {
         match self.cursor_state {
             CursorState::Valid if self.has_prev() => {
                 self.decrement_cursor();
-                // If the cursor is on top of a wide char, move it backward an
-                // extra cell.
-                if self.is_wide_char_or_spacer() {
+                // Mirror of `move_forward`: moving backward should land on
+                // the cluster's FIRST (base) cell, not its last. If we
+                // landed on a spacer, keep decrementing while still inside
+                // spacer cells of the same cluster -- this naturally stops
+                // exactly on the base (`WideChar`, which does NOT match
+                // `WideCharSpacer`), regardless of span.
+                while matches!(self.grid.cell_type(self.pos), Some(CellType::WideCharSpacer)) {
                     self.decrement_cursor();
                 }
             }
@@ -133,13 +159,14 @@ impl<'g> SelectionCursor<'g> {
         }
     }
 
-    /// Returns whether the current cursor point is on top of a wide char
-    /// (either the first or second cell).
-    fn is_wide_char_or_spacer(&self) -> bool {
-        matches!(
-            self.grid.cell_type(self.pos),
-            Some(CellType::WideChar) | Some(CellType::WideCharSpacer)
-        )
+    /// Returns the span of the cell at the current position, if valid. Only
+    /// meaningful when that cell is a cluster's base (`CellType::WideChar`)
+    /// -- spacer cells don't carry span information themselves.
+    fn current_cell_span(&self) -> Option<u8> {
+        self.grid
+            .row(self.pos.row)?
+            .get(self.pos.col)
+            .map(|cell| cell.span())
     }
 
     /// Returns whether the current cursor point is valid (i.e.: is within the

--- a/app/src/terminal/model/grid/selection_cursor_tests.rs
+++ b/app/src/terminal/model/grid/selection_cursor_tests.rs
@@ -52,3 +52,88 @@ fn test_cursor() {
     cursor.move_backward();
     assert_eq!(cursor.position(), Some(Point::new(4, 4)));
 }
+
+#[test]
+fn test_cursor_over_two_wide_char() {
+    // Locks in the existing (pre-variable-width-cell) convention for a
+    // fixed CJK width=2 span: moving forward from before the pair lands on
+    // its LAST cell (the spacer); moving backward from after the pair
+    // lands on its FIRST cell (the base). This must not regress when the
+    // logic generalizes to spans > 2.
+    let mut grid = GridHandler::new_for_test(2, 10);
+    grid.grid_storage_mut()[0][2].set_span(2);
+    grid.grid_storage_mut()[0][3]
+        .flags_mut()
+        .insert(crate::terminal::model::cell::Flags::WIDE_CHAR_SPACER);
+
+    let mut cursor = SelectionCursor::new(&grid, Point::new(0, 1));
+    cursor.move_forward();
+    assert_eq!(
+        cursor.position(),
+        Some(Point::new(0, 3)),
+        "forward across a 2-wide char should land on its trailing spacer"
+    );
+
+    let mut cursor = SelectionCursor::new(&grid, Point::new(0, 4));
+    cursor.move_backward();
+    assert_eq!(
+        cursor.position(),
+        Some(Point::new(0, 2)),
+        "backward across a 2-wide char should land on its base cell"
+    );
+}
+
+#[test]
+fn test_cursor_over_variable_width_span() {
+    // Generalization check: a 5-cell span (e.g. a measured Indic cluster)
+    // must behave the same way a 2-wide char does, just with more cells to
+    // skip -- forward lands on the LAST cell, backward lands on the FIRST.
+    let mut grid = GridHandler::new_for_test(2, 10);
+    grid.grid_storage_mut()[0][2].set_span(5);
+    for col in 3..7 {
+        grid.grid_storage_mut()[0][col]
+            .flags_mut()
+            .insert(crate::terminal::model::cell::Flags::WIDE_CHAR_SPACER);
+    }
+
+    let mut cursor = SelectionCursor::new(&grid, Point::new(0, 1));
+    cursor.move_forward();
+    assert_eq!(
+        cursor.position(),
+        Some(Point::new(0, 6)),
+        "forward across a 5-wide span should land on its last cell (col 6)"
+    );
+
+    let mut cursor = SelectionCursor::new(&grid, Point::new(0, 7));
+    cursor.move_backward();
+    assert_eq!(
+        cursor.position(),
+        Some(Point::new(0, 2)),
+        "backward across a 5-wide span should land on its base cell (col 2)"
+    );
+}
+
+#[test]
+fn test_cursor_starting_mid_span_does_not_overshoot() {
+    // Regression test for a real bug found while generalizing this logic:
+    // if the cursor starts DIRECTLY on a spacer cell (e.g. constructed from
+    // a raw click/serialized position, which SelectionCursor::new does not
+    // validate against), moving backward must land on the span's base --
+    // not overshoot past it into the preceding, unrelated cell.
+    let mut grid = GridHandler::new_for_test(2, 10);
+    grid.grid_storage_mut()[0][2].set_span(4);
+    for col in 3..6 {
+        grid.grid_storage_mut()[0][col]
+            .flags_mut()
+            .insert(crate::terminal::model::cell::Flags::WIDE_CHAR_SPACER);
+    }
+
+    // Start directly on the first spacer cell (col 3) -- one cell into the span.
+    let mut cursor = SelectionCursor::new(&grid, Point::new(0, 3));
+    cursor.move_backward();
+    assert_eq!(
+        cursor.position(),
+        Some(Point::new(0, 2)),
+        "must land on the base cell, not overshoot into col 1"
+    );
+}

--- a/app/src/terminal/model/grid/tests.rs
+++ b/app/src/terminal/model/grid/tests.rs
@@ -1235,15 +1235,17 @@ fn test_empty_row_with_leading_wide_char_spacer_resize_panic() {
     grid.resize(SizeInfo::new_without_font_metrics(2, 4));
 }
 
-/// Reports a span equal to a cluster's codepoint count -- used to get a
-/// deterministic, real (not just 1 or 2) multi-cell span through the real
-/// `ansi::Handler::input()` buffering path, without depending on macOS-only
-/// Core Text shaping.
+/// Reports a natural width equal to a cluster's codepoint count (clamped to
+/// 1..=8) times the cell width -- used to get a deterministic, real (not
+/// just 1 or 2) multi-cell span through the real `ansi::Handler::input()`
+/// buffering path, without depending on macOS-only Core Text shaping. The
+/// clamp lives here so cumulative word-level quantization reproduces the
+/// exact same per-cluster spans as before, with zero extra slack.
 struct FixedWidthMeasurer;
 
 impl crate::terminal::model::grid::ClusterWidthMeasurer for FixedWidthMeasurer {
-    fn measure_cells(&self, cluster: &str, _cell_width_px: f32) -> u8 {
-        (cluster.chars().count() as u8).clamp(1, 8)
+    fn natural_width_px(&self, cluster: &str, cell_width_px: f32) -> f32 {
+        (cluster.chars().count() as u8).clamp(1, 8) as f32 * cell_width_px
     }
 }
 

--- a/app/src/terminal/model/grid/tests.rs
+++ b/app/src/terminal/model/grid/tests.rs
@@ -7,6 +7,7 @@ use super::*;
 use crate::features::FeatureFlag;
 use crate::terminal::model::ansi::Handler;
 use crate::terminal::model::cell::{Cell, Flags};
+use crate::terminal::model::char_or_str::CharOrStr;
 use crate::terminal::model::grid::Dimensions;
 use crate::terminal::model::index::{Point, VisiblePoint, VisibleRow};
 use crate::terminal::model::secrets::ObfuscateSecrets;
@@ -1232,6 +1233,88 @@ fn test_empty_row_with_leading_wide_char_spacer_resize_panic() {
     // a panic where we failed to compute the content offset for the cursor, as flat
     // storage would have one too few rows, and the cursor position would be out of bounds.
     grid.resize(SizeInfo::new_without_font_metrics(2, 4));
+}
+
+/// Reports a span equal to a cluster's codepoint count -- used to get a
+/// deterministic, real (not just 1 or 2) multi-cell span through the real
+/// `ansi::Handler::input()` buffering path, without depending on macOS-only
+/// Core Text shaping.
+struct FixedWidthMeasurer;
+
+impl crate::terminal::model::grid::ClusterWidthMeasurer for FixedWidthMeasurer {
+    fn measure_cells(&self, cluster: &str, _cell_width_px: f32) -> u8 {
+        (cluster.chars().count() as u8).clamp(1, 8)
+    }
+}
+
+/// Regression test for the resize/reflow rewrite: `grow_cols`/`shrink_cols`
+/// previously detected a wide char's base cell at the reflow boundary by
+/// checking the legacy `Flags::WIDE_CHAR` boolean, which `Cell::set_span`
+/// only keeps in sync for span == 2. A real measured Indic cluster (span
+/// > 2) landing at the boundary would have been silently split from its
+/// own spacer cells -- corrupting the cluster across the two rows -- since
+/// the old check would never fire for it. This confirms the whole cluster
+/// reflows together (via `span() > 1`) for both growing and shrinking.
+#[test]
+fn test_resize_reflows_variable_width_span_as_one_unit_not_split() {
+    let mut grid = GridHandler::new_for_test_with_measurer(
+        2,
+        6,
+        std::sync::Arc::new(FixedWidthMeasurer),
+    );
+
+    // "క్షి" is a real 4-codepoint Indic cluster (క + ్ + ష + ి); the
+    // FixedWidthMeasurer reports span 4 for it. Fill columns 0-2 with 'a's,
+    // then the cluster: it doesn't fit in the remaining 3 columns of a
+    // 6-column row (needs cols 3-6, only 3-5 exist), so it should already
+    // wrap whole onto row 1 during input, matching the existing
+    // LEADING_WIDE_CHAR_SPACER wrap mechanism.
+    for c in "aaa".chars() {
+        grid.input(c);
+    }
+    for c in "క్షి".chars() {
+        grid.input(c);
+    }
+    grid.input('X'); // Flush the buffered cluster.
+
+    let row0 = grid.row(0).expect("row 0 should exist");
+    assert!(
+        row0.get(3)
+            .is_some_and(|cell| cell.flags.contains(Flags::LEADING_WIDE_CHAR_SPACER)),
+        "the cluster shouldn't fit in row 0's remaining 3 columns, so col 3 \
+         should hold a wrap placeholder"
+    );
+    let row1 = grid.row(1).expect("row 1 should exist");
+    let base = row1.get(0).expect("row 1 should have the wrapped cluster");
+    assert_eq!(base.span(), 4, "the whole cluster should have wrapped together");
+    assert_eq!(base.raw_content(), CharOrStr::Str("క్షి"));
+
+    // Now shrink the grid down to 5 columns (still >= the cluster's own
+    // span of 4, so it CAN fit within one row -- shrinking narrower than
+    // the widest already-stored cluster is a known, out-of-scope edge case
+    // for this rewrite; see the plan's Phase 4.6 execution log). The
+    // cluster should reflow whole rather than being split mid-cluster.
+    grid.resize(SizeInfo::new_without_font_metrics(3, 5));
+
+    // Find whichever row now holds the cluster's base cell and confirm the
+    // full cluster (span=4, all 4 characters) is intact -- not truncated
+    // or split across rows.
+    let mut found_intact_cluster = false;
+    for row_idx in 0..grid.total_rows() {
+        let Some(row) = grid.row(row_idx) else {
+            continue;
+        };
+        if let Some(cell) = row.get(0) {
+            if cell.span() == 4 && cell.raw_content() == CharOrStr::Str("క్షి") {
+                found_intact_cluster = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        found_intact_cluster,
+        "the 4-wide cluster must survive the shrink intact (as one unit), not split"
+    );
 }
 
 fn cell(c: char) -> Cell {

--- a/app/src/terminal/model/grid/tests.rs
+++ b/app/src/terminal/model/grid/tests.rs
@@ -1438,6 +1438,64 @@ mod indic_word_carry_tests {
     }
 
     #[test]
+    fn word_continues_carrying_after_a_cluster_fills_the_exact_last_column() {
+        // 6 columns: "aaa" (0-2) leaves exactly 3 remaining. CLUSTER_1
+        // (span 3) fills cols 3-5 EXACTLY -- `input_needs_wrap` becomes
+        // true while `point` stays at col 5 (see
+        // `word_exactly_filling_remaining_columns_does_not_carry`). The
+        // continuity filter used to require `!cursor_needs_wrap`, which
+        // discarded the accumulator right here and made carry unreachable
+        // for CLUSTER_2 below -- it would fall back to an independent
+        // mid-word split instead of carrying the whole word.
+        let mut grid =
+            GridHandler::new_for_test_with_measurer(3, 6, std::sync::Arc::new(FixedWidthMeasurer));
+        for c in "aaa".chars() {
+            grid.input(c);
+        }
+        for c in CLUSTER_1.chars() {
+            grid.input(c);
+        }
+        for c in CLUSTER_2.chars() {
+            grid.input(c);
+        }
+        grid.input('X');
+
+        let row0 = grid.row(0).expect("row 0 exists");
+        assert_eq!(row0.get(0).map(|c| c.c), Some('a'));
+        assert_eq!(row0.get(1).map(|c| c.c), Some('a'));
+        assert_eq!(row0.get(2).map(|c| c.c), Some('a'));
+        for col in 3..6 {
+            assert_eq!(
+                row0.get(col).map(|c| c.c),
+                Some(cell::DEFAULT_CHAR),
+                "col {col} should be erased once the whole word carries away"
+            );
+        }
+        assert!(
+            row0.get(2).unwrap().flags.contains(Flags::WRAPLINE),
+            "WRAPLINE should mark the boundary right before the carried word"
+        );
+
+        let row1 = grid.row(1).expect("row 1 exists");
+        let base1 = row1.get(0).expect("row 1 should hold the carried word");
+        assert_eq!(base1.span(), 3);
+        assert_eq!(base1.raw_content(), CharOrStr::Str(CLUSTER_1));
+        let base2 = row1.get(3).expect("second cluster of the carried word");
+        assert_eq!(base2.span(), 3);
+        assert_eq!(base2.raw_content(), CharOrStr::Str(CLUSTER_2));
+        // The carried word (6 cells) exactly fills row 1's 6 columns too, so
+        // 'X' has nowhere left on that row and wraps on to row 2 -- ordinary
+        // wrapping unrelated to carry, not something to special-case.
+        let row2 = grid.row(2).expect("row 2 exists");
+        assert_eq!(
+            row2.get(0).map(|c| c.c),
+            Some('X'),
+            "the triggering char continues on the row after the carried word, which itself \
+             filled row 1 exactly"
+        );
+    }
+
+    #[test]
     fn cursor_motion_mid_word_disables_carry() {
         let mut grid =
             GridHandler::new_for_test_with_measurer(3, 8, std::sync::Arc::new(FixedWidthMeasurer));

--- a/app/src/terminal/model/grid/tests.rs
+++ b/app/src/terminal/model/grid/tests.rs
@@ -1319,6 +1319,226 @@ fn test_resize_reflows_variable_width_span_as_one_unit_not_split() {
     );
 }
 
+/// Phase 13 (Telugu variable-width-cells plan): apps that pre-wrap their own
+/// output at word boundaries (Claude Code, Codex CLI) assume the universal
+/// one-column-per-syllable width convention, so a Telugu word they believe
+/// fits can overflow our real (multi-cell) allocation and get split by the
+/// terminal itself -- these tests cover the word-carry mechanism that moves
+/// the whole word to the next line instead of splitting it mid-word.
+mod indic_word_carry_tests {
+    use super::*;
+
+    /// "క్ష" and "ప్ర" are each real 3-codepoint Indic clusters (consonant +
+    /// virama + consonant); `FixedWidthMeasurer` reports span 3 for each.
+    const CLUSTER_1: &str = "క్ష";
+    const CLUSTER_2: &str = "ప్ర";
+
+    #[test]
+    fn two_cluster_word_carries_whole_to_next_line_on_wrap() {
+        // 8 columns: "aaa" (cols 0-2) leaves 5 remaining. CLUSTER_1 (span 3)
+        // fits at cols 3-5; CLUSTER_2 (span 3) would need cols 6-8, which
+        // doesn't fit (only col 6-7 remain) -- triggering carry.
+        let mut grid =
+            GridHandler::new_for_test_with_measurer(3, 8, std::sync::Arc::new(FixedWidthMeasurer));
+        for c in "aaa".chars() {
+            grid.input(c);
+        }
+        for c in CLUSTER_1.chars().chain(CLUSTER_2.chars()) {
+            grid.input(c);
+        }
+        grid.input('X'); // Flushes CLUSTER_2 and triggers the carry decision.
+
+        let row0 = grid.row(0).expect("row 0 exists");
+        assert_eq!(row0.get(0).map(|c| c.c), Some('a'));
+        assert_eq!(row0.get(1).map(|c| c.c), Some('a'));
+        assert_eq!(row0.get(2).map(|c| c.c), Some('a'));
+        for col in 3..8 {
+            assert_eq!(
+                row0.get(col).map(|c| c.c),
+                Some(cell::DEFAULT_CHAR),
+                "col {col} should be erased once the word carries away"
+            );
+        }
+        assert!(
+            row0.get(2).unwrap().flags.contains(Flags::WRAPLINE),
+            "WRAPLINE should mark the boundary right before the carried word"
+        );
+
+        let row1 = grid.row(1).expect("row 1 exists");
+        let base1 = row1.get(0).expect("row 1 should hold the carried word");
+        assert_eq!(base1.span(), 3);
+        assert_eq!(base1.raw_content(), CharOrStr::Str(CLUSTER_1));
+        let base2 = row1.get(3).expect("second cluster of the carried word");
+        assert_eq!(base2.span(), 3);
+        assert_eq!(base2.raw_content(), CharOrStr::Str(CLUSTER_2));
+        assert_eq!(
+            row1.get(6).map(|c| c.c),
+            Some('X'),
+            "the triggering char continues right after the carried word"
+        );
+    }
+
+    #[test]
+    fn word_exactly_filling_remaining_columns_does_not_carry() {
+        // 6 columns: "aaa" (0-2) leaves exactly 3 remaining -- CLUSTER_1
+        // (span 3) fits exactly, no wrap, no carry.
+        let mut grid =
+            GridHandler::new_for_test_with_measurer(3, 6, std::sync::Arc::new(FixedWidthMeasurer));
+        for c in "aaa".chars() {
+            grid.input(c);
+        }
+        for c in CLUSTER_1.chars() {
+            grid.input(c);
+        }
+        grid.input('X');
+
+        let row0 = grid.row(0).expect("row 0 exists");
+        let base = row0.get(3).expect("cluster written in place");
+        assert_eq!(base.span(), 3);
+        assert_eq!(base.raw_content(), CharOrStr::Str(CLUSTER_1));
+        assert!(
+            !row0.get(2).unwrap().flags.contains(Flags::WRAPLINE),
+            "no carry should have happened, so no WRAPLINE boundary was inserted early"
+        );
+        // 'X' wrapped to the next row (row was exactly full), independent of carry.
+        let row1 = grid.row(1).expect("row 1 exists");
+        assert_eq!(row1.get(0).map(|c| c.c), Some('X'));
+    }
+
+    #[test]
+    fn word_wider_than_full_row_falls_back_to_mid_word_split() {
+        // 4 columns total is narrower than CLUSTER_1 + CLUSTER_2 combined
+        // (6 cells) -- carry's `can_carry` requires the word to fit in one
+        // full line, so this must fall back to today's independent-span
+        // mid-word split, and must not loop.
+        let mut grid =
+            GridHandler::new_for_test_with_measurer(3, 4, std::sync::Arc::new(FixedWidthMeasurer));
+        for c in CLUSTER_1.chars().chain(CLUSTER_2.chars()) {
+            grid.input(c);
+        }
+        grid.input('X');
+
+        // CLUSTER_1 (span 3) fits at cols 0-2; CLUSTER_2 must split/wrap on
+        // its own via the existing LEADING_WIDE_CHAR_SPACER mechanism.
+        let row0 = grid.row(0).expect("row 0 exists");
+        let base1 = row0.get(0).expect("first cluster written in place");
+        assert_eq!(base1.span(), 3);
+        assert_eq!(base1.raw_content(), CharOrStr::Str(CLUSTER_1));
+        assert!(
+            row0
+                .get(3)
+                .is_some_and(|c| c.flags.contains(Flags::LEADING_WIDE_CHAR_SPACER)),
+            "CLUSTER_2 doesn't fit in row 0's last column, so it should wrap via the \
+             existing placeholder mechanism, not carry (word is too wide for one line)"
+        );
+        let row1 = grid.row(1).expect("row 1 exists");
+        let base2 = row1.get(0).expect("second cluster wrapped to row 1");
+        assert_eq!(base2.span(), 3);
+        assert_eq!(base2.raw_content(), CharOrStr::Str(CLUSTER_2));
+    }
+
+    #[test]
+    fn cursor_motion_mid_word_disables_carry() {
+        let mut grid =
+            GridHandler::new_for_test_with_measurer(3, 8, std::sync::Arc::new(FixedWidthMeasurer));
+        for c in "aaa".chars() {
+            grid.input(c);
+        }
+        for c in CLUSTER_1.chars() {
+            grid.input(c);
+        }
+        // A cursor jump breaks the accumulator's continuity -- the second
+        // cluster starts a brand-new (empty) word, so `can_carry` (which
+        // requires a non-empty accumulator) can never fire for it.
+        grid.goto(VisibleRow(0), 6);
+        for c in CLUSTER_2.chars() {
+            grid.input(c);
+        }
+        grid.input('X');
+
+        let row0 = grid.row(0).expect("row 0 exists");
+        assert!(
+            !row0.get(2).unwrap().flags.contains(Flags::WRAPLINE),
+            "no carry should occur once cursor motion has broken word continuity"
+        );
+    }
+
+    #[test]
+    fn carried_word_round_trips_through_bounds_to_string_with_no_injected_chars() {
+        let mut grid =
+            GridHandler::new_for_test_with_measurer(3, 8, std::sync::Arc::new(FixedWidthMeasurer));
+        for c in "aaa".chars() {
+            grid.input(c);
+        }
+        for c in CLUSTER_1.chars().chain(CLUSTER_2.chars()) {
+            grid.input(c);
+        }
+        grid.input('X');
+        grid.on_finish_byte_processing(&crate::terminal::model::ansi::ProcessorInput::new(&[]));
+
+        let text = grid.bounds_to_string(
+            Point::new(0, 0),
+            Point::new(1, 6),
+            false,
+            crate::terminal::model::secrets::RespectObfuscatedSecrets::No,
+            false,
+            crate::terminal::model::grid::RespectDisplayedOutput::No,
+        );
+        assert_eq!(
+            text,
+            format!("aaa{CLUSTER_1}{CLUSTER_2}X"),
+            "the carried word must reconstruct with no injected spaces or newline"
+        );
+    }
+
+    #[test]
+    fn alt_screen_disables_carry() {
+        let size_info = crate::terminal::SizeInfo::new_without_font_metrics(3, 8);
+        let mut grid = GridHandler::new(
+            size_info,
+            0,
+            crate::terminal::event_listener::ChannelEventListener::new_for_test(),
+            true, // is_alt_screen
+            ObfuscateSecrets::No,
+            crate::terminal::model::grid::grid_handler::PerformResetGridChecks::No,
+            std::sync::Arc::new(FixedWidthMeasurer),
+        );
+        for c in "aaa".chars() {
+            grid.input(c);
+        }
+        for c in CLUSTER_1.chars().chain(CLUSTER_2.chars()) {
+            grid.input(c);
+        }
+        grid.input('X');
+
+        let row0 = grid.row(0).expect("row 0 exists");
+        assert!(
+            !row0.get(2).unwrap().flags.contains(Flags::WRAPLINE),
+            "carry must be disabled on the alt screen -- full-screen apps manage their own layout"
+        );
+    }
+
+    #[test]
+    fn insert_mode_disables_carry() {
+        let mut grid =
+            GridHandler::new_for_test_with_measurer(3, 8, std::sync::Arc::new(FixedWidthMeasurer));
+        grid.set_mode(crate::terminal::model::ansi::Mode::Insert);
+        for c in "aaa".chars() {
+            grid.input(c);
+        }
+        for c in CLUSTER_1.chars().chain(CLUSTER_2.chars()) {
+            grid.input(c);
+        }
+        grid.input('X');
+
+        let row0 = grid.row(0).expect("row 0 exists");
+        assert!(
+            !row0.get(2).unwrap().flags.contains(Flags::WRAPLINE),
+            "carry must be disabled in insert mode -- replaying clusters there would shift cells nonsensically"
+        );
+    }
+}
+
 fn cell(c: char) -> Cell {
     let mut cell = Cell::default();
     cell.c = c;

--- a/app/src/terminal/model/header_grid.rs
+++ b/app/src/terminal/model/header_grid.rs
@@ -15,7 +15,7 @@ use super::blockgrid::BlockGrid;
 use super::bootstrap::BootstrapStage;
 use super::find::RegexDFAs;
 use super::grid::grid_handler::{PerformResetGridChecks, RegexIter};
-use super::grid::{Cursor, Dimensions as _, RespectDisplayedOutput};
+use super::grid::{ClusterWidthMeasurer, Cursor, Dimensions as _, RespectDisplayedOutput};
 use super::index::{Point, VisibleRow};
 use super::selection::ScrollDelta;
 use super::{ObfuscateSecrets, RespectObfuscatedSecrets};
@@ -144,6 +144,7 @@ impl HeaderGrid {
         should_scan_for_secrets: ObfuscateSecrets,
         honor_ps1: bool,
         perform_reset_grid_checks: PerformResetGridChecks,
+        cluster_measurer: std::sync::Arc<dyn ClusterWidthMeasurer>,
     ) -> Self {
         let prompt_grid = BlockGrid::new(
             sizes.size,
@@ -154,6 +155,7 @@ impl HeaderGrid {
             should_scan_for_secrets,
             // We ignore checking if we've received the Reset Grid OSC on the prompt grid.
             PerformResetGridChecks::No,
+            cluster_measurer.clone(),
         );
         let prompt_and_command_grid = BlockGrid::new(
             sizes.size,
@@ -161,6 +163,7 @@ impl HeaderGrid {
             event_proxy.clone(),
             should_scan_for_secrets,
             perform_reset_grid_checks,
+            cluster_measurer,
         );
         Self {
             prompt_grid,

--- a/app/src/terminal/model/indic.rs
+++ b/app/src/terminal/model/indic.rs
@@ -1,0 +1,233 @@
+//! Indic script Unicode helpers shared between the PTY input handler and the
+//! terminal grid renderer.
+//!
+//! Layer B shaping fix: treat virama-conjunct second consonants, vowel signs,
+//! anusvara, and visarga as zero-width (width-0) in the PTY input path so that
+//! each Indic syllable cluster occupies exactly one terminal cell instead of
+//! two or three.  The renderer then calls Core Text on the full cluster string
+//! stored in that single cell, which produces correctly-shaped conjunct glyphs
+//! with no inter-cluster gaps.
+
+// Sinhala block: U+0D80–U+0DFF.  Include it so that U+0DCA (Sinhala virama)
+// can actually trigger the conjunct path when paired with a Sinhala consonant.
+const INDIC_BLOCK_END: u32 = 0x0DFF;
+
+/// Returns `true` if `c` is an Indic virama (halant / killer mark) — the
+/// combining character that, when placed after a consonant, suppresses its
+/// inherent vowel and (if followed by another consonant) signals a conjunct.
+///
+/// Viramas are already Unicode zero-width (Mn) so the PTY assigns them
+/// width = 0; they are pushed into the preceding cell by the existing
+/// `push_zerowidth` path.  This function is used to detect whether the
+/// PREVIOUS cell already has a virama attached (indicating the next
+/// consonant should also be pulled into that cell).
+#[inline]
+pub fn is_indic_virama(c: char) -> bool {
+    matches!(
+        c,
+        '\u{094D}' | // Devanagari
+        '\u{09CD}' | // Bengali
+        '\u{0A4D}' | // Gurmukhi
+        '\u{0ACD}' | // Gujarati
+        '\u{0B4D}' | // Odia
+        '\u{0BCD}' | // Tamil
+        '\u{0C4D}' | // Telugu  ← primary target
+        '\u{0CCD}' | // Kannada
+        '\u{0D4D}' | // Malayalam
+        '\u{0DCA}'   // Sinhala
+    )
+}
+
+/// Returns `true` if `c` is an Indic spacing combining mark (Unicode category
+/// Mc) or candrabindu/anusvara/visarga that visually attaches to the preceding
+/// consonant within the same syllable.
+///
+/// These characters have `unicode_width == 1` (spacing marks occupy a cell in
+/// the POSIX/xterm model), so without the Layer B fix the PTY places each in
+/// its own cell, creating inter-syllable gaps.  By detecting them here we can
+/// override their width to 0 and push them into the preceding cell.
+#[inline]
+pub fn is_indic_combining(c: char) -> bool {
+    matches!(c,
+        // ── Telugu (U+0C00–U+0C7F) ──────────────────────────────────────────
+        // candrabindu, anusvara, visarga
+        '\u{0C01}'..='\u{0C03}' |
+        // vowel signs AA … vocalic RR
+        '\u{0C3E}'..='\u{0C44}' |
+        // vowel signs E, EE, AI
+        '\u{0C46}'..='\u{0C48}' |
+        // vowel signs O, OO, AU
+        '\u{0C4A}'..='\u{0C4C}' |
+        // vowel signs vocalic L, vocalic LL
+        '\u{0C62}' | '\u{0C63}' |
+        // ── Devanagari (U+0900–U+097F) ──────────────────────────────────────
+        '\u{0900}'..='\u{0903}' |
+        '\u{093A}'..='\u{093C}' |
+        '\u{093E}'..='\u{094C}' |
+        '\u{0955}'..='\u{0957}' |
+        '\u{0962}' | '\u{0963}' |
+        // ── Bengali (U+0980–U+09FF) ─────────────────────────────────────────
+        '\u{09BE}'..='\u{09C4}' |
+        '\u{09C7}' | '\u{09C8}' |
+        '\u{09CB}' | '\u{09CC}' |
+        '\u{09D7}' |
+        // ── Gujarati (U+0A80–U+0AFF) ────────────────────────────────────────
+        '\u{0ABE}'..='\u{0AC5}' |
+        '\u{0AC7}'..='\u{0AC9}' |
+        '\u{0ACB}' | '\u{0ACC}' |
+        // ── Tamil (U+0B80–U+0BFF) ───────────────────────────────────────────
+        '\u{0BBE}'..='\u{0BC2}' |
+        '\u{0BC6}'..='\u{0BC8}' |
+        '\u{0BCA}'..='\u{0BCC}' |
+        '\u{0BD7}' |
+        // ── Kannada (U+0C80–U+0CFF) ─────────────────────────────────────────
+        '\u{0CBE}'..='\u{0CC4}' |
+        '\u{0CC6}'..='\u{0CC8}' |
+        '\u{0CCA}'..='\u{0CCC}' |
+        '\u{0CE2}' | '\u{0CE3}' |
+        // ── Malayalam (U+0D00–U+0D7F) ───────────────────────────────────────
+        '\u{0D3E}'..='\u{0D44}' |
+        '\u{0D46}'..='\u{0D48}' |
+        '\u{0D4A}'..='\u{0D4C}' |
+        '\u{0D57}'
+    )
+}
+
+/// Returns `true` if `c` falls in one of the South Asian script Unicode blocks
+/// (U+0900–U+0DFF: Devanagari … Sinhala), covering all scripts for which
+/// `is_indic_virama` recognises a virama codepoint.
+#[inline]
+pub fn is_in_indic_block(c: char) -> bool {
+    matches!(c as u32, 0x0900..=INDIC_BLOCK_END)
+}
+
+/// Returns `true` if the string `s` (a cell's combined content) contains any
+/// character in an Indic script block.  Used by the renderer to decide whether
+/// a cell's Str content should be shaped via the full `layout_line` path
+/// (which renders all Core Text glyphs) rather than the single-glyph
+/// `glyph_for_string` cache.
+#[inline]
+pub fn is_indic_str(s: &str) -> bool {
+    s.chars().any(is_in_indic_block)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── is_indic_virama ──────────────────────────────────────────────────────
+
+    #[test]
+    fn virama_telugu() {
+        assert!(is_indic_virama('\u{0C4D}'), "Telugu virama U+0C4D");
+    }
+
+    #[test]
+    fn virama_devanagari() {
+        assert!(is_indic_virama('\u{094D}'), "Devanagari virama U+094D");
+    }
+
+    #[test]
+    fn virama_sinhala() {
+        assert!(is_indic_virama('\u{0DCA}'), "Sinhala virama U+0DCA");
+    }
+
+    #[test]
+    fn virama_ascii_not_virama() {
+        assert!(!is_indic_virama('a'));
+        assert!(!is_indic_virama('\0'));
+    }
+
+    // ── is_indic_combining ───────────────────────────────────────────────────
+
+    #[test]
+    fn combining_telugu_vowel_sign_u() {
+        // 'ు' = U+0C41 — range 0C3E..=0C44
+        assert!(is_indic_combining('\u{0C41}'), "'ు' U+0C41");
+    }
+
+    #[test]
+    fn combining_telugu_anusvara() {
+        // 'ం' = U+0C02 — range 0C01..=0C03
+        assert!(is_indic_combining('\u{0C02}'), "'ం' U+0C02");
+    }
+
+    #[test]
+    fn combining_telugu_aa() {
+        // 'ా' = U+0C3E
+        assert!(is_indic_combining('\u{0C3E}'), "'ా' U+0C3E");
+    }
+
+    #[test]
+    fn combining_ascii_not_combining() {
+        assert!(!is_indic_combining('a'));
+        assert!(!is_indic_combining('\0'));
+    }
+
+    #[test]
+    fn combining_cjk_not_combining() {
+        assert!(!is_indic_combining('中'));
+    }
+
+    // ── is_in_indic_block ────────────────────────────────────────────────────
+
+    #[test]
+    fn block_telugu_consonant() {
+        // 'ప' = U+0C2A
+        assert!(is_in_indic_block('\u{0C2A}'), "'ప' U+0C2A");
+    }
+
+    #[test]
+    fn block_telugu_ra() {
+        // 'ర' = U+0C30
+        assert!(is_in_indic_block('\u{0C30}'), "'ర' U+0C30");
+    }
+
+    #[test]
+    fn block_devanagari_ka() {
+        assert!(is_in_indic_block('\u{0915}'), "Devanagari KA U+0915");
+    }
+
+    #[test]
+    fn block_sinhala_consonant() {
+        // Sinhala LA = U+0DBD — now in range since block extended to 0x0DFF
+        assert!(is_in_indic_block('\u{0DBD}'), "Sinhala LA U+0DBD");
+    }
+
+    #[test]
+    fn block_ascii_excluded() {
+        assert!(!is_in_indic_block('a'));
+        assert!(!is_in_indic_block('Z'));
+    }
+
+    #[test]
+    fn block_cjk_excluded() {
+        assert!(!is_in_indic_block('中'));
+    }
+
+    #[test]
+    fn block_nul_excluded() {
+        assert!(!is_in_indic_block('\0'));
+    }
+
+    // ── is_indic_str ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn indic_str_telugu_cluster() {
+        assert!(is_indic_str("ప్ర"), "Telugu cluster string");
+        assert!(is_indic_str("భు"), "Telugu vowel-attached syllable");
+        assert!(is_indic_str("క్ష"), "Telugu conjunct");
+    }
+
+    #[test]
+    fn indic_str_ascii_false() {
+        assert!(!is_indic_str("hello"));
+        assert!(!is_indic_str(""));
+    }
+
+    #[test]
+    fn indic_str_mixed_ascii_indic() {
+        // A string with even one Indic char should return true.
+        assert!(is_indic_str("xప"));
+    }
+}

--- a/app/src/terminal/model/mod.rs
+++ b/app/src/terminal/model/mod.rs
@@ -15,6 +15,7 @@ macro_rules! assert_lines_approx_eq {
 
 pub mod alt_screen;
 pub mod ansi;
+pub mod indic;
 pub mod block;
 pub mod blockgrid;
 pub mod blocks;

--- a/app/src/terminal/model/selection.rs
+++ b/app/src/terminal/model/selection.rs
@@ -190,16 +190,23 @@ impl SelectionRange {
 
         let cell = &grid[point];
 
-        // Check if wide char's spacers are selected.
-        if cell.flags().contains(Flags::WIDE_CHAR) {
-            let prev = point.wrapping_sub(num_cols, 1);
-            let next = point.wrapping_add(num_cols, 1);
+        // Check if a wide/Indic cluster's spacer cells are selected. Uses
+        // `cell.span()` (not the legacy `Flags::WIDE_CHAR` boolean, which
+        // `Cell::set_span` only keeps in sync for span == 2) so this covers
+        // any span 1-8, not just the fixed CJK width=2 case.
+        let span = cell.span();
+        if span > 1 {
+            // Check every trailing spacer cell in the span, not just the
+            // single next cell.
+            for offset in 1..span as usize {
+                if self.contains(point.wrapping_add(num_cols, offset)) {
+                    return true;
+                }
+            }
 
-            // Check trailing spacer.
-            self.contains(next)
-                // Check line-wrapping, leading spacer.
-                || (grid[prev].flags().contains(Flags::LEADING_WIDE_CHAR_SPACER)
-                && self.contains(prev))
+            // Check line-wrapping, leading spacer.
+            let prev = point.wrapping_sub(num_cols, 1);
+            grid[prev].flags().contains(Flags::LEADING_WIDE_CHAR_SPACER) && self.contains(prev)
         } else {
             false
         }

--- a/app/src/terminal/model/selection_tests.rs
+++ b/app/src/terminal/model/selection_tests.rs
@@ -356,3 +356,60 @@ fn test_selection_rotate_down() {
         None
     );
 }
+
+#[test]
+fn test_selection_range_contains_cell_covers_full_variable_width_span() {
+    // Regression test: SelectionRange::contains_cell (queried with the
+    // BASE cell's point -- the only scope this function has ever
+    // supported, before or after this change) previously only checked the
+    // legacy Flags::WIDE_CHAR boolean and a single trailing spacer cell,
+    // correct only for a fixed CJK width=2 span. It must now cover ALL
+    // trailing spacer cells of a measured Indic cluster (span up to 8),
+    // using Cell::span() instead.
+    //
+    // Note: as of this writing `contains_cell` has no real callers in the
+    // codebase (verified via grep) -- this test locks in correct behavior
+    // for whenever it is used, generalizing its existing scope rather than
+    // inventing a new one (e.g. it has never supported being queried
+    // directly at a spacer cell's own point).
+    let mut grid = grid_handler(2, 10);
+    grid.grid_storage_mut()[0][2].set_span(5);
+    for col in 3..7 {
+        grid.grid_storage_mut()[0][col]
+            .flags_mut()
+            .insert(crate::terminal::model::cell::Flags::WIDE_CHAR_SPACER);
+    }
+
+    // A selection that covers only the trailing spacer at col 5 (not the
+    // base, and not via `self.contains(point)` when queried at the base)
+    // should still be found when querying at the base cell's point (col 2).
+    let range = SelectionRange {
+        start: Point::new(0, 5),
+        end: Point::new(0, 5),
+        is_reversed: false,
+    };
+    assert!(
+        range.contains_cell(
+            grid.grid_storage(),
+            Point::new(0, 2),
+            Point::new(0, 0),
+            CursorShape::Beam,
+        ),
+        "base cell should report as contained since its span (cols 2-6) \
+         overlaps the selection at col 5"
+    );
+
+    // A selection that ends just before the span (col 1) must NOT
+    // consider the base cell contained.
+    let range_before = SelectionRange {
+        start: Point::new(0, 0),
+        end: Point::new(0, 1),
+        is_reversed: false,
+    };
+    assert!(!range_before.contains_cell(
+        grid.grid_storage(),
+        Point::new(0, 2),
+        Point::new(0, 0),
+        CursorShape::Beam,
+    ));
+}

--- a/app/src/terminal/model/selection_tests.rs
+++ b/app/src/terminal/model/selection_tests.rs
@@ -12,6 +12,7 @@ fn grid_handler(rows: usize, cols: usize) -> GridHandler {
         false,
         ObfuscateSecrets::No,
         PerformResetGridChecks::No,
+        std::sync::Arc::new(crate::terminal::model::grid::NoopMeasurer),
     )
 }
 

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -65,7 +65,9 @@ use crate::terminal::model::completions::{
     ShellCompletion, ShellCompletionUpdate, ShellData as CompletionsShellData,
 };
 use crate::terminal::model::escape_sequences::ModeProvider;
-use crate::terminal::model::grid::IndexRegion;
+use crate::terminal::model::grid::{ClusterWidthMeasurer, IndexRegion};
+#[cfg(test)]
+use crate::terminal::model::grid::NoopMeasurer;
 use crate::terminal::model::index::VisibleRow;
 use crate::terminal::model::iterm_image::{ITermImage, ITermImageMetadata};
 use crate::terminal::model::secrets::ObfuscateSecrets;
@@ -976,6 +978,7 @@ impl TerminalModel {
                 display_name: ShellName::blank(),
                 shell_type: ShellType::Zsh,
             },
+            Arc::new(NoopMeasurer),
         );
 
         let session_id = 123.into();
@@ -1026,12 +1029,14 @@ impl TerminalModel {
         shell_state: ShellLaunchState,
         shared_session_status: SharedSessionStatus,
         is_dummy_cloud_mode_session: bool,
+        cluster_measurer: Arc<dyn ClusterWidthMeasurer>,
     ) -> Self {
         let alt_screen = AltScreen::new(
             sizes.size,
             0, /* max_scroll_limit */
             event_proxy.clone(),
             obfuscate_secrets,
+            cluster_measurer.clone(),
         );
         let block_list = BlockList::new(
             restored_blocks,
@@ -1045,6 +1050,7 @@ impl TerminalModel {
             is_inverted,
             obfuscate_secrets,
             is_ai_ugc_telemetry_enabled,
+            cluster_measurer,
         );
 
         Self {
@@ -1109,6 +1115,7 @@ impl TerminalModel {
         is_ai_ugc_telemetry_enabled: bool,
         session_startup_path: Option<PathBuf>,
         shell_state: ShellLaunchState,
+        cluster_measurer: Arc<dyn ClusterWidthMeasurer>,
     ) -> Self {
         Self::new_internal(
             restored_blocks,
@@ -1127,6 +1134,7 @@ impl TerminalModel {
             shell_state,
             SharedSessionStatus::NotShared,
             false,
+            cluster_measurer,
         )
     }
 
@@ -1141,6 +1149,7 @@ impl TerminalModel {
         honor_ps1: bool,
         is_inverted: bool,
         obfuscate_secrets: ObfuscateSecrets,
+        cluster_measurer: Arc<dyn ClusterWidthMeasurer>,
     ) -> Self {
         Self::new_internal(
             None,
@@ -1164,6 +1173,7 @@ impl TerminalModel {
             },
             SharedSessionStatus::ViewPending,
             true,
+            cluster_measurer,
         )
     }
 
@@ -1177,6 +1187,7 @@ impl TerminalModel {
         honor_ps1: bool,
         is_inverted: bool,
         obfuscate_secrets: ObfuscateSecrets,
+        cluster_measurer: Arc<dyn ClusterWidthMeasurer>,
     ) -> Self {
         Self::new_internal(
             None,
@@ -1200,6 +1211,7 @@ impl TerminalModel {
             },
             SharedSessionStatus::ViewPending,
             false,
+            cluster_measurer,
         )
     }
 
@@ -1214,6 +1226,7 @@ impl TerminalModel {
         honor_ps1: bool,
         is_inverted: bool,
         obfuscate_secrets: ObfuscateSecrets,
+        cluster_measurer: Arc<dyn ClusterWidthMeasurer>,
     ) -> Self {
         Self::new_for_shared_session_viewer_internal(
             sizes,
@@ -1224,6 +1237,7 @@ impl TerminalModel {
             honor_ps1,
             is_inverted,
             obfuscate_secrets,
+            cluster_measurer,
         )
     }
 

--- a/app/src/terminal/model/terminal_model_tests.rs
+++ b/app/src/terminal/model/terminal_model_tests.rs
@@ -64,6 +64,7 @@ fn cloud_mode_deferred_terminal_model_starts_view_pending() {
         false,
         false,
         ObfuscateSecrets::No,
+        Arc::new(NoopMeasurer),
     );
 
     assert!(matches!(
@@ -110,6 +111,7 @@ fn generic_shared_session_viewer_model_starts_view_pending() {
         false,
         false,
         ObfuscateSecrets::No,
+        Arc::new(NoopMeasurer),
     );
 
     assert!(matches!(

--- a/app/src/terminal/model/test_utils.rs
+++ b/app/src/terminal/model/test_utils.rs
@@ -24,6 +24,7 @@ use super::kitty::{
     KittyAction, KittyImage, KittyImageMetadata, KittyPixelDataFormat, KittyPlacementData,
     KittyTransmissionMedium, StoreAndDisplay, StoreOnly,
 };
+use super::grid::NoopMeasurer;
 use super::terminal_model::BlockIndex;
 use super::{ObfuscateSecrets, TerminalModel};
 use crate::ai::blocklist::SerializedBlockListItem;
@@ -196,6 +197,7 @@ impl<'a> TestBlockListBuilder<'a> {
             false, /* is_inverted */
             ObfuscateSecrets::No,
             false, /* is_telemetry_enabled */
+            Arc::new(NoopMeasurer),
         );
         // This is usually done by the terminal manager after constructing the blocklist,
         // but we have tests assuming the separator exists.
@@ -282,6 +284,7 @@ impl TestBlockBuilder {
             ObfuscateSecrets::No,
             false, /* is_telemetry_enabled */
             None,
+            Arc::new(NoopMeasurer),
         )
     }
 }

--- a/app/src/terminal/ref_tests/mod.rs
+++ b/app/src/terminal/ref_tests/mod.rs
@@ -140,6 +140,7 @@ fn ref_test(dir: &Path) {
             display_name: ShellName::blank(),
             shell_type: ShellType::Bash,
         },
+        Arc::new(crate::terminal::model::grid::NoopMeasurer),
     );
     terminal.start_command_execution();
     // As an implementation detail of this test, we start this block as a background block, so

--- a/app/src/terminal/shared_session/mod_tests.rs
+++ b/app/src/terminal/shared_session/mod_tests.rs
@@ -72,6 +72,7 @@ pub fn terminal_model_for_viewer(event_proxy: ChannelEventListener) -> TerminalM
         false, /* honor_ps1 */
         false, /* is_inverted */
         ObfuscateSecrets::No,
+        Arc::new(crate::terminal::model::grid::NoopMeasurer),
     )
 }
 

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -59,7 +59,9 @@ use crate::terminal::shared_session::shared_handlers::{
     build_selected_conversation_update, ActiveRemoteUpdate, RemoteUpdateGuard,
 };
 use crate::terminal::shared_session::SharedSessionStatus;
-use crate::terminal::terminal_manager::{compute_block_size, terminal_colors_list};
+use crate::terminal::terminal_manager::{
+    compute_block_size, create_cluster_measurer, terminal_colors_list,
+};
 use crate::terminal::view::ambient_agent::is_cloud_agent_pre_first_exchange;
 use crate::terminal::view::ExecuteCommandEvent;
 use crate::terminal::{
@@ -230,6 +232,7 @@ impl TerminalManager {
 
         // TODO: use the sharer's size.
         let sizes = compute_block_size(initial_size, ctx);
+        let cluster_measurer = create_cluster_measurer(ctx);
 
         let model = if is_cloud_mode {
             TerminalModel::new_for_cloud_mode_shared_session_viewer(
@@ -244,6 +247,7 @@ impl TerminalManager {
                 // secret redaction rules but rather rely on the sharer obfuscating
                 // the contents before reaching us.
                 ObfuscateSecrets::No,
+                cluster_measurer,
             )
         } else {
             TerminalModel::new_for_shared_session_viewer(
@@ -258,6 +262,7 @@ impl TerminalManager {
                 // secret redaction rules but rather rely on the sharer obfuscating
                 // the contents before reaching us.
                 ObfuscateSecrets::No,
+                cluster_measurer,
             )
         };
 

--- a/app/src/terminal/terminal_manager.rs
+++ b/app/src/terminal/terminal_manager.rs
@@ -36,10 +36,12 @@ pub(super) fn create_cluster_measurer(ctx: &mut AppContext) -> Arc<dyn ClusterWi
         if ctx.is_headless() {
             return Arc::new(NoopMeasurer);
         }
-        let family_id = Appearance::as_ref(ctx).monospace_font_family();
+        let appearance = Appearance::as_ref(ctx);
+        let family_id = appearance.monospace_font_family();
+        let font_size = appearance.monospace_font_size();
         let family_name = ctx.font_cache().load_family_name_from_id(family_id);
         if let Some(family_name) = family_name {
-            match CoreTextClusterMeasurer::new(&family_name, Default::default()) {
+            match CoreTextClusterMeasurer::new(&family_name, Default::default(), font_size) {
                 Ok(measurer) => return Arc::new(measurer),
                 Err(error) => {
                     log::warn!(

--- a/app/src/terminal/terminal_manager.rs
+++ b/app/src/terminal/terminal_manager.rs
@@ -9,6 +9,9 @@ use warpui::{AppContext, SingletonEntity};
 
 use super::event_listener::ChannelEventListener;
 use super::model::block::BlockSize;
+use super::model::grid::{ClusterWidthMeasurer, NoopMeasurer};
+#[cfg(target_os = "macos")]
+use super::model::grid::cluster_measurer::CoreTextClusterMeasurer;
 use super::safe_mode_settings::get_secret_obfuscation_mode;
 use super::session_settings::SessionSettings;
 use super::settings::TerminalSettings;
@@ -20,6 +23,40 @@ use crate::appearance::Appearance;
 use crate::pane_group::pane::DetachType;
 use crate::settings::{BlockVisibilitySettings, DebugSettings, InputModeSettings};
 use crate::PrivacySettings;
+
+/// Constructs the real Core Text-backed [`ClusterWidthMeasurer`] from the
+/// terminal's configured monospace font, falling back to a no-op measurer
+/// (every cluster reports as 1 cell, today's existing behavior) when
+/// headless, on a non-macOS platform, or if the font can't be resolved for
+/// any reason -- Indic shaping quality degrading gracefully is preferable
+/// to a hard failure constructing a terminal session.
+pub(super) fn create_cluster_measurer(ctx: &mut AppContext) -> Arc<dyn ClusterWidthMeasurer> {
+    #[cfg(target_os = "macos")]
+    {
+        if ctx.is_headless() {
+            return Arc::new(NoopMeasurer);
+        }
+        let family_id = Appearance::as_ref(ctx).monospace_font_family();
+        let family_name = ctx.font_cache().load_family_name_from_id(family_id);
+        if let Some(family_name) = family_name {
+            match CoreTextClusterMeasurer::new(&family_name, Default::default()) {
+                Ok(measurer) => return Arc::new(measurer),
+                Err(error) => {
+                    log::warn!(
+                        "Failed to construct Indic cluster width measurer for font \
+                         {family_name:?}, falling back to no-op (Telugu/Indic clusters will \
+                         render at 1 cell each): {error}"
+                    );
+                }
+            }
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = ctx;
+    }
+    Arc::new(NoopMeasurer)
+}
 
 pub trait TerminalManager: Any {
     /// Returns the backing terminal model.
@@ -98,6 +135,7 @@ pub(super) fn create_terminal_model(
     let obfuscate_secrets = get_secret_obfuscation_mode(ctx);
     let is_ai_ugc_telemetry_enabled =
         should_collect_ai_ugc_telemetry(ctx, PrivacySettings::as_ref(ctx).is_telemetry_enabled);
+    let cluster_measurer = create_cluster_measurer(ctx);
 
     TerminalModel::new(
         restored_blocks.map(|v| v.as_slice()),
@@ -114,6 +152,7 @@ pub(super) fn create_terminal_model(
         is_ai_ugc_telemetry_enabled,
         startup_directory,
         shell_state,
+        cluster_measurer,
     )
 }
 

--- a/app/src/test_util/blockgrid.rs
+++ b/app/src/test_util/blockgrid.rs
@@ -6,7 +6,7 @@ use crate::terminal::model::ansi::{self, Handler};
 use crate::terminal::model::blockgrid::BlockGrid;
 use crate::terminal::model::cell::Flags;
 use crate::terminal::model::grid::grid_handler::PerformResetGridChecks;
-use crate::terminal::model::grid::Dimensions as _;
+use crate::terminal::model::grid::{Dimensions as _, NoopMeasurer};
 use crate::terminal::model::index::{VisiblePoint, VisibleRow};
 use crate::terminal::model::ObfuscateSecrets;
 use crate::terminal::SizeInfo;
@@ -58,6 +58,7 @@ pub fn mock_blockgrid(content: &str) -> BlockGrid {
         ChannelEventListener::new_for_test(),
         ObfuscateSecrets::No,
         PerformResetGridChecks::default(),
+        std::sync::Arc::new(NoopMeasurer),
     );
 
     blockgrid.start();

--- a/crates/warp_terminal/src/model/grid/cell.rs
+++ b/crates/warp_terminal/src/model/grid/cell.rs
@@ -328,6 +328,70 @@ impl Cell {
         &mut self.flags
     }
 
+    /// Returns the number of terminal cells (including this one) occupied by
+    /// this cell's grapheme cluster: 1 for a normal cell, up to 8 for a
+    /// wide/Indic cluster. Encoded in the top 3 bits (13-15) of [`Flags`],
+    /// which are otherwise unused — this keeps `Cell` at its documented
+    /// 24-byte layout (see the struct doc comment).
+    ///
+    /// `Flags::WIDE_CHAR` is kept in sync for span == 2 (see [`Self::set_span`])
+    /// so every pre-existing consumer that reads the boolean CJK flag
+    /// continues to work unmodified. The reverse must also hold: code that
+    /// still sets `WIDE_CHAR` directly (without going through `set_span`,
+    /// e.g. existing tests that build a `Cell` by hand) leaves the span
+    /// bits at 0 — so if they're unset, fall back to the boolean flag
+    /// rather than reporting a bare cell as span 1.
+    #[inline]
+    pub fn span(&self) -> u8 {
+        let encoded = (((self.flags.bits() >> Self::SPAN_SHIFT) & Self::SPAN_MASK_BITS) + 1) as u8;
+        if encoded > 1 {
+            encoded
+        } else if self.flags.contains(Flags::WIDE_CHAR) {
+            2
+        } else {
+            1
+        }
+    }
+
+    /// Sets this cell's span (see [`Self::span`]). `span` must be in `1..=8`.
+    #[inline]
+    pub fn set_span(&mut self, span: u8) {
+        debug_assert!(
+            (1..=8).contains(&span),
+            "Cell span must be 1..=8, got {span}"
+        );
+        let cleared = self.flags.bits() & !(Self::SPAN_MASK_BITS << Self::SPAN_SHIFT);
+        let encoded = ((span - 1) as u16 & Self::SPAN_MASK_BITS) << Self::SPAN_SHIFT;
+        self.flags = Flags::from_bits_retain(cleared | encoded);
+        // Backward compat: WIDE_CHAR is the boolean flag every existing CJK
+        // consumer already reads; keep it set exactly when span == 2.
+        if span == 2 {
+            self.flags.insert(Flags::WIDE_CHAR);
+        } else {
+            self.flags.remove(Flags::WIDE_CHAR);
+        }
+    }
+
+    /// Returns this cell's flags with the span encoding (bits 13-15)
+    /// cleared. Useful for tests/diagnostics that compare flags built via
+    /// the legacy direct-flag pattern (e.g. `flags.insert(Flags::WIDE_CHAR)`)
+    /// against flags produced via [`Self::set_span`] — the two carry the
+    /// same *semantic* information but not necessarily the same bits, since
+    /// only `set_span` populates the span field. Compare span separately
+    /// via [`Self::span`].
+    #[inline]
+    pub fn flags_ignoring_span(&self) -> Flags {
+        Flags::from_bits_retain(self.flags.bits() & !(Self::SPAN_MASK_BITS << Self::SPAN_SHIFT))
+    }
+
+    /// Bit width of the span encoding (3 bits -> values 0..=7, biased by +1
+    /// to represent span 1..=8).
+    const SPAN_MASK_BITS: u16 = 0b111;
+    /// Starting bit position (13) of the span encoding within [`Flags`]'s
+    /// 16 bits; bits 13-15 are unused by any named flag (see the bitflags
+    /// block above, which tops out at `HAS_CURSOR` = bit 12).
+    const SPAN_SHIFT: u16 = 13;
+
     #[inline]
     pub(crate) fn reset(&mut self, template: &Self) {
         *self = Cell {

--- a/crates/warp_terminal/src/model/grid/cell_tests.rs
+++ b/crates/warp_terminal/src/model/grid/cell_tests.rs
@@ -100,3 +100,50 @@ fn push_zerowidth_seeds_base_char_on_first_push() {
     cell.push_zerowidth('\u{0301}', /* log_long_grapheme_warnings */ true);
     assert_eq!(cell.raw_content(), CharOrStr::Str("x\u{0301}"));
 }
+
+#[test]
+fn span_round_trips_for_all_valid_values() {
+    for span in 1u8..=8 {
+        let mut cell = Cell::default();
+        cell.set_span(span);
+        assert_eq!(cell.span(), span, "span {span} did not round-trip");
+    }
+}
+
+#[test]
+fn span_defaults_to_one_on_fresh_cell() {
+    assert_eq!(Cell::default().span(), 1);
+}
+
+#[test]
+fn set_span_keeps_wide_char_flag_in_sync() {
+    // Every existing CJK consumer reads the boolean WIDE_CHAR flag directly;
+    // it must stay set exactly when span == 2, and cleared otherwise, so
+    // those consumers keep working unmodified during the transition to
+    // span-aware code.
+    let mut cell = Cell::default();
+
+    cell.set_span(2);
+    assert!(cell.flags().contains(Flags::WIDE_CHAR));
+
+    cell.set_span(1);
+    assert!(!cell.flags().contains(Flags::WIDE_CHAR));
+
+    cell.set_span(4);
+    assert!(!cell.flags().contains(Flags::WIDE_CHAR));
+
+    cell.set_span(2);
+    assert!(cell.flags().contains(Flags::WIDE_CHAR));
+}
+
+#[test]
+fn set_span_does_not_disturb_unrelated_flags() {
+    let mut cell = Cell::default();
+    cell.flags_mut().insert(Flags::BOLD | Flags::UNDERLINE);
+
+    cell.set_span(5);
+
+    assert_eq!(cell.span(), 5);
+    assert!(cell.flags().contains(Flags::BOLD));
+    assert!(cell.flags().contains(Flags::UNDERLINE));
+}

--- a/crates/warp_terminal/src/model/grid/cell_type.rs
+++ b/crates/warp_terminal/src/model/grid/cell_type.rs
@@ -17,16 +17,24 @@ pub enum CellType {
 
 impl From<&Cell> for CellType {
     fn from(cell: &Cell) -> Self {
+        // A cell is the base of a wide/Indic cluster if its span is > 1 --
+        // NOT just when the legacy `WIDE_CHAR` flag is set, which `Cell::
+        // set_span` only keeps in sync for span == 2 (backward compat for
+        // code that still reads that boolean flag directly). Checking
+        // `span()` here is what makes this correctly generalize to any
+        // span 1-8, not just the fixed CJK width=2 case.
+        if cell.span() > 1 {
+            return Self::WideChar;
+        }
         // First, check if the cell has _any_ of the relevant flags.  If not,
         // we're able to return NarrowChar with only one comparison/branch.
         // The other cell types are much less common, so we don't care as much
         // about the cost of extra comparisons for them.
-        if !cell.flags().intersects(
-            Flags::WIDE_CHAR | Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER,
-        ) {
+        if !cell
+            .flags()
+            .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
+        {
             Self::RegularChar
-        } else if cell.flags().intersects(Flags::WIDE_CHAR) {
-            Self::WideChar
         } else if cell.flags().intersects(Flags::WIDE_CHAR_SPACER) {
             Self::WideCharSpacer
         } else {

--- a/crates/warp_terminal/src/model/grid/flat_storage/grapheme.rs
+++ b/crates/warp_terminal/src/model/grid/flat_storage/grapheme.rs
@@ -41,7 +41,7 @@ impl<'a> Grapheme<'a> {
 
     /// Constructs a new [`Grapheme`] from a [`Cell`].
     pub fn new_from_cell(cell: &'a Cell) -> Self {
-        let cell_width = 1 + cell.flags().contains(cell::Flags::WIDE_CHAR) as u8;
+        let cell_width = cell.span();
 
         let content = cell.raw_content();
         let utf8_bytes = match content {

--- a/crates/warp_terminal/src/model/grid/flat_storage/index.rs
+++ b/crates/warp_terminal/src/model/grid/flat_storage/index.rs
@@ -513,8 +513,8 @@ impl EntryBuilder {
             return;
         }
         debug_assert!(
-            info.cell_width <= 2,
-            "graphemes should not be more than two cells wide, but encountered one with width {}",
+            info.cell_width <= 8,
+            "graphemes should not be more than 8 cells wide (Cell::span's encoding limit), but encountered one with width {}",
             info.cell_width
         );
 
@@ -666,7 +666,13 @@ impl GraphemeRun {
                 "cannot compute cell type for offset {offset} in run that spans {} columns",
                 self.cols()
             );
-            if offset.is_multiple_of(2) {
+            // Each grapheme in this run occupies `cell_width` consecutive
+            // columns; `offset` is the position within the RUN, so map it to
+            // a position within its own grapheme's span first. Only the
+            // first column of that span (base cell) is WideChar; every other
+            // column in the span is a spacer. (Previously assumed a fixed
+            // 2-wide alternation, which was only correct for cell_width==2.)
+            if offset % self.info.cell_width as usize == 0 {
                 Some(CellType::WideChar)
             } else {
                 Some(CellType::WideCharSpacer)

--- a/crates/warp_terminal/src/model/grid/flat_storage/index_tests.rs
+++ b/crates/warp_terminal/src/model/grid/flat_storage/index_tests.rs
@@ -290,6 +290,60 @@ fn test_cell_type() {
     assert_eq!(storage.cell_type(2, 2), Some(CellType::WideCharSpacer));
 }
 
+#[test]
+fn test_cell_type_at_offset_for_span_wider_than_two() {
+    // Regression test for the variable-width-cell rewrite: cell_type_at_offset
+    // previously assumed a fixed 2-wide alternation (offset % 2), which only
+    // gave correct answers for cell_width == 2. A run of two 4-wide graphemes
+    // occupies columns [0..8): grapheme 0 spans [0..4), grapheme 1 spans
+    // [4..8). Only the first column of each grapheme's own span is WideChar;
+    // the rest are spacers.
+    let run = GraphemeRun {
+        count: NonZeroU16::new(2).unwrap(),
+        info: GraphemeInfo {
+            cell_width: 4,
+            utf8_bytes: NonZeroU16::new(4).unwrap(),
+        },
+    };
+
+    assert_eq!(run.cell_type_at_offset(0), Some(CellType::WideChar));
+    assert_eq!(run.cell_type_at_offset(1), Some(CellType::WideCharSpacer));
+    assert_eq!(run.cell_type_at_offset(2), Some(CellType::WideCharSpacer));
+    assert_eq!(run.cell_type_at_offset(3), Some(CellType::WideCharSpacer));
+    // Second grapheme in the run starts at offset 4 -- must be WideChar
+    // again, not a spacer (this is exactly what the old `% 2` logic got
+    // wrong for any width other than 2).
+    assert_eq!(run.cell_type_at_offset(4), Some(CellType::WideChar));
+    assert_eq!(run.cell_type_at_offset(5), Some(CellType::WideCharSpacer));
+    assert_eq!(run.cell_type_at_offset(6), Some(CellType::WideCharSpacer));
+    assert_eq!(run.cell_type_at_offset(7), Some(CellType::WideCharSpacer));
+}
+
+#[test]
+fn process_grapheme_info_accepts_full_span_range_up_to_eight() {
+    // Regression test: the debug_assert cap was raised from <= 2 to <= 8 to
+    // match Cell::set_span's 3-bit encoding limit. Widths 3 through 8 must
+    // not panic.
+    for cell_width in 3u8..=8 {
+        let mut index = Index::new(20, None);
+        let mut builder = EntryBuilder::new();
+        builder.process_grapheme_info(
+            GraphemeInfo {
+                cell_width,
+                utf8_bytes: NonZeroU16::new(4).unwrap(),
+            },
+            &mut index,
+        );
+        // No panic is the assertion here; also sanity-check the builder
+        // tracked the expected number of occupied cells.
+        assert_eq!(
+            builder.num_cells, cell_width as usize,
+            "expected {cell_width} occupied cells after processing one grapheme of that width"
+        );
+        builder.append_to_index_if_nonempty(&mut index);
+    }
+}
+
 mod offset_point_conversion {
     use super::*;
 

--- a/crates/warp_terminal/src/model/grid/flat_storage/mod.rs
+++ b/crates/warp_terminal/src/model/grid/flat_storage/mod.rs
@@ -36,6 +36,7 @@ use itertools::Itertools;
 use string_offset::ByteOffset;
 use style::BgAndStyle;
 
+use super::cell::LineLength;
 use super::row::Row;
 use super::{cell, CellType};
 use crate::model::{ansi, Point};
@@ -253,10 +254,24 @@ impl FlatStorage {
                 }
             }
 
-            // If the grid row soft wraps, the last cell will be marked
-            // with the WRAPLINE flag.
-            let row_soft_wraps = row.occ == self.columns
-                && row[self.columns - 1]
+            // If the grid row soft wraps, the cell at its true content
+            // boundary is marked with the WRAPLINE flag. This used to check
+            // only `row[self.columns - 1]` (the row's physical last cell)
+            // guarded by `row.occ == self.columns` -- correct as long as a
+            // soft-wrapped row was always fully occupied edge-to-edge,
+            // which held for every wrap this crate produced until an Indic
+            // word-carry (see `GridHandler::carry_indic_word`) can leave a
+            // soft-wrapped row's word-carried-away tail blank, with
+            // WRAPLINE sitting earlier than the physical last cell. Reusing
+            // `Row::line_length()` (already correct for exactly this: it
+            // reverse-scans to the last non-blank cell instead of assuming
+            // the row is full) handles both cases identically -- for a
+            // fully-occupied row its fast path still returns the same
+            // `self.columns` as before, so this is not a behaviour change
+            // for any pre-existing wrap path.
+            let content_length = row.line_length();
+            let row_soft_wraps = content_length > 0
+                && row[content_length - 1]
                     .flags()
                     .intersects(cell::Flags::WRAPLINE);
             if !row_soft_wraps {

--- a/crates/warp_terminal/src/model/grid/flat_storage/mod_tests.rs
+++ b/crates/warp_terminal/src/model/grid/flat_storage/mod_tests.rs
@@ -207,6 +207,60 @@ fn test_styling_change_within_trailing_empty_cells() {
     assert!(!flat_rows[1][0].flags.intersects(Flags::BOLD));
 }
 
+/// Phase 13 (Telugu variable-width-cells plan): `GridHandler::carry_indic_word`
+/// moves an in-progress Indic word to the next line instead of splitting it
+/// mid-word, and marks the soft-wrap boundary with `WRAPLINE` on the cell
+/// right before the word rather than the row's physical last cell (the tail
+/// after that point is left blank -- the word moved away). This is a NEW
+/// kind of soft-wrapped row: unlike every wrap this crate produced before,
+/// it isn't fully occupied edge-to-edge. Confirms the row-commit soft-wrap
+/// check (which used to hardcode `row[columns - 1]`) now correctly
+/// recognizes this row as continuing rather than inserting a spurious
+/// trailing newline that would split the carried word from its prefix once
+/// the row scrolls into flat storage.
+#[test]
+fn test_row_soft_wraps_with_wrapline_before_physical_last_cell() {
+    let num_cols = 8;
+    let mut rows = vec![Row::new(num_cols), Row::new(num_cols)];
+
+    // Row 0: "aaa" (0-2), WRAPLINE on col 2 (not the physical last cell,
+    // col 7) -- exactly what `carry_indic_word` produces after erasing a
+    // word's already-written cells from col 3 onward. `occ` is bumped to
+    // the full row width, mirroring the erase touching every cell up to
+    // the row's end (the same as `carry_indic_word`'s real behaviour).
+    for (i, c) in "aaa".chars().enumerate() {
+        rows[0][i].c = c;
+    }
+    rows[0][2].flags.insert(Flags::WRAPLINE);
+    rows[0].occ = num_cols;
+
+    // Row 1: the carried word's replayed content.
+    for (i, c) in "bbbbbbb".chars().enumerate() {
+        rows[1][i].c = c;
+    }
+
+    let mut storage = FlatStorage::new(num_cols, None, None);
+    storage.push_rows(&rows);
+
+    assert!(
+        storage.row_wraps(0),
+        "a row whose WRAPLINE sits before its physical last cell (because its \
+         tail was erased by an Indic word carry) must still be recognized as \
+         soft-wrapped -- otherwise a spurious hard newline gets inserted, \
+         splitting the carried word from its prefix once this row is read \
+         back from flat storage (e.g. after scrolling into history)"
+    );
+
+    let flat_rows = storage
+        .rows_from(0)
+        .map(|row| row.as_ref().clone())
+        .collect_vec();
+    assert_eq!(flat_rows[0][0].c, 'a');
+    assert_eq!(flat_rows[0][1].c, 'a');
+    assert_eq!(flat_rows[0][2].c, 'a');
+    assert_eq!(flat_rows[1][0].c, 'b');
+}
+
 #[test]
 fn test_clear_after_truncate_front() {
     let num_cols = 20;

--- a/crates/warp_terminal/src/model/grid/flat_storage/row_iterator.rs
+++ b/crates/warp_terminal/src/model/grid/flat_storage/row_iterator.rs
@@ -125,11 +125,16 @@ impl Iterator for RowIterator<'_> {
                 _ => {}
             }
 
-            // If the grapheme takes up two cells, mark the following cell as
-            // a spacer.
-            if cell_width == 2 {
-                row[idx].flags.insert(Flags::WIDE_CHAR);
-                row[idx + 1].flags.insert(Flags::WIDE_CHAR_SPACER);
+            // If the grapheme takes up more than one cell, record its span
+            // on the base cell and mark every trailing cell in its span as
+            // a spacer. (Previously only handled cell_width == 2, marking a
+            // single following cell; generalized here to any span 1..=8 —
+            // see Cell::set_span.)
+            if cell_width > 1 {
+                row[idx].set_span(cell_width);
+                for offset in 1..cell_width as usize {
+                    row[idx + offset].flags.insert(Flags::WIDE_CHAR_SPACER);
+                }
             }
 
             current_offset += grapheme.len();

--- a/crates/warp_terminal/src/model/grid/flat_storage/row_iterator.rs
+++ b/crates/warp_terminal/src/model/grid/flat_storage/row_iterator.rs
@@ -130,9 +130,20 @@ impl Iterator for RowIterator<'_> {
             // a spacer. (Previously only handled cell_width == 2, marking a
             // single following cell; generalized here to any span 1..=8 —
             // see Cell::set_span.)
+            //
+            // Defensive bound: a row can be narrower than a grapheme's
+            // stored span if the terminal was resized narrower than the
+            // widest cluster already in scrollback (an extreme edge case,
+            // not expected in practice, and not fully handled by this
+            // rewrite -- see the Telugu variable-width-cell plan's Phase
+            // 4.6 log). Rather than panic indexing past the row's end,
+            // clamp the span so materialization degrades (the cluster may
+            // render with fewer spacer cells than measured) instead of
+            // crashing.
             if cell_width > 1 {
-                row[idx].set_span(cell_width);
-                for offset in 1..cell_width as usize {
+                let clamped_width = cell_width.min((row.len() - idx) as u8);
+                row[idx].set_span(clamped_width);
+                for offset in 1..clamped_width as usize {
                     row[idx + offset].flags.insert(Flags::WIDE_CHAR_SPACER);
                 }
             }

--- a/crates/warp_terminal/src/model/grid/flat_storage/testing.rs
+++ b/crates/warp_terminal/src/model/grid/flat_storage/testing.rs
@@ -28,7 +28,16 @@ pub fn assert_rows_equal(actual: &[Row], expected: &[Row]) {
                 assert_eq!(actual.fg, expected.fg, "Expected ({row_idx}, {col_idx}) to have fg {:?} but got {:?}", expected.fg, actual.fg);
                 assert_eq!(actual.bg, expected.bg, "Expected ({row_idx}, {col_idx}) to have bg {:?} but got {:?}", expected.bg, actual.bg);
 
-                assert_eq!(actual.flags(), expected.flags(), "Expected ({row_idx}, {col_idx}) to have flags {:?} but got {:?}", expected.flags(), actual.flags());
+                // Compare span (Cell::span, which falls back to the legacy
+                // WIDE_CHAR flag) separately from the remaining flags: tests
+                // that hand-build an "expected" row via the legacy
+                // `flags.insert(Flags::WIDE_CHAR)` pattern carry the same
+                // semantic span as one built via `set_span`, but not
+                // necessarily the same raw bits (only `set_span` populates
+                // the span field), so a raw `Flags` equality would spuriously
+                // fail on the newly-added span bits.
+                assert_eq!(actual.span(), expected.span(), "Expected ({row_idx}, {col_idx}) to have span {} but got {}", expected.span(), actual.span());
+                assert_eq!(actual.flags_ignoring_span(), expected.flags_ignoring_span(), "Expected ({row_idx}, {col_idx}) to have flags {:?} but got {:?}", expected.flags(), actual.flags());
 
                 // TODO(vorporeal): Check CellExtra::end_of_prompt.
             }

--- a/crates/warpui/src/platform/mac/text_layout.rs
+++ b/crates/warpui/src/platform/mac/text_layout.rs
@@ -861,8 +861,9 @@ fn char_index_from_utf_16_byte_index(text: &str, utf_16_index: usize) -> usize {
 fn build_utf16_lookup(text: &str) -> Vec<usize> {
     // Use the UTF-8 length as a starting estimate, since each ASCII character
     // is represented by both 1 UTF-8 code point and 1 UTF-16 code point.
-    let mut table = Vec::with_capacity(text.len());
+    let mut table = Vec::with_capacity(text.len() + 1);
 
+    let mut char_count = 0usize;
     for (char_index, ch) in text.chars().enumerate() {
         // For each UTF-16 code unit in the character, add a mapping to the
         // character's index. The UTF-16 position is implicitly tracked by the
@@ -870,7 +871,13 @@ fn build_utf16_lookup(text: &str) -> Vec<usize> {
         for _ in 0..ch.len_utf16() {
             table.push(char_index);
         }
+        char_count = char_index + 1;
     }
+    // Sentinel: Core Text may report a caret edge at the past-the-end UTF-16
+    // position (= the trailing edge of the last cluster). Without this entry,
+    // the .get() call in caret_positions_for_line panics on strings whose last
+    // cluster is a multi-codepoint conjunct (e.g. Telugu ప్ర).
+    table.push(char_count);
 
     table
 }
@@ -902,8 +909,14 @@ fn caret_positions_for_line(
     let block = {
         let positions = positions.clone();
         ConcreteBlock::new(move |offset, char_index: isize, leading_edge, _stop| {
+            // Keep EVERY edge so the leading/trailing pairing stays intact.
+            // Core Text emits the two edges of each caret consecutively; dropping
+            // one edge would desync every following pair. Core Text indices are
+            // UTF-16 offsets (always >= 0 in practice); clamp the theoretical
+            // kCFNotFound (-1) sentinel to 0 rather than dropping the edge.
+            let utf16_index = usize::try_from(char_index).unwrap_or(0);
             positions.borrow_mut().push(CaretEdge {
-                utf16_index: char_index.try_into().expect("Negative UTF-16 offset"),
+                utf16_index,
                 leading_edge,
                 pixel_offset: offset,
             });
@@ -918,50 +931,56 @@ fn caret_positions_for_line(
     }
     drop(block);
 
-    let mut positions = Rc::try_unwrap(positions)
+    let positions = Rc::try_unwrap(positions)
         .expect("Block reference should be dropped")
         .into_inner();
 
-    debug_assert!(
-        positions.len() % 2 == 0,
-        "Missing a leading or trailing caret edge"
-    );
-    // Core Text sometimes swaps the order of the trailing edge of one caret and
-    // the leading edge of the next, causing edge pairs to be interspersed. So
-    // that we can pair the leading and trailing edges into carets, sort by
-    // character index, assuming that carets don't overlap with each other.
-    // positions should already be almost entirely sorted, except for swapped
-    // edges and RTL text.
-    positions.sort_unstable_by_key(|position| position.utf16_index);
+    // Pair the edges in the order Core Text emitted them. Core Text emits a
+    // caret's two edges (leading + trailing) consecutively, so every adjacent
+    // pair in emission order is exactly one caret: LTR → (leading, trailing),
+    // RTL → (trailing, leading).
+    //
+    // Do NOT sort by character index. When a grapheme cluster is shaped across
+    // multiple Core Text runs (e.g. a Telugu conjunct split by font fallback),
+    // the adjacent carets can have interleaved indices such as
+    //   leading@0 / trailing@2 / leading@1 / trailing@3
+    // Sorting by index regroups them as (leading@0, leading@1)(trailing@2, trailing@3),
+    // producing a (trailing, trailing) pair with no leading edge and a
+    // debug_assert abort.
+    //
+    // chunks_exact(2) silently discards a trailing unpaired edge, so an odd
+    // count is handled gracefully without a pop.
+    let fallback_idx = utf16_offset_to_char_idx.last().copied().unwrap_or(0);
     let mut carets: Vec<_> = positions
         .chunks_exact(2)
         .map(|edges| {
-            // Guaranteed by chunks_exact that there are 2 elements.
             let first = &edges[0];
             let second = &edges[1];
 
-            // Core Text enumerates edges in left-to-right visual order, but
-            // sets the leading edge based on logical order, so use that to
-            // handle RTL text.
-            // For any given leading/trailing edge pair, the pixel offset from
-            // the start of the line is the one for the leading edge.
+            // The caret's pixel offset belongs to the leading edge.
+            // If both edges happen to be trailing (unexpected), fall back to
+            // first.pixel_offset — a slightly misplaced caret beats an abort.
             let pixel_offset = if first.leading_edge {
                 first.pixel_offset
-            } else {
-                debug_assert!(
-                    second.leading_edge,
-                    "No leading edge in {first:?} or {second:?}"
-                );
+            } else if second.leading_edge {
                 second.pixel_offset
+            } else {
+                first.pixel_offset
             };
 
+            // Clamp out-of-range UTF-16 indices: the table covers [0, N] where
+            // N = UTF-16 length of the text (the sentinel added by
+            // build_utf16_lookup). An index beyond that can only come from an
+            // undocumented Core Text edge case; degrade to end-of-text caret.
             let first_index = utf16_offset_to_char_idx
                 .get(first.utf16_index)
-                .expect("Mapping covers whole string")
+                .copied()
+                .unwrap_or(fallback_idx)
                 + char_offset;
             let second_index = utf16_offset_to_char_idx
                 .get(second.utf16_index)
-                .expect("Mapping covers whole string")
+                .copied()
+                .unwrap_or(fallback_idx)
                 + char_offset;
 
             let (start, end) = if first_index < second_index {


### PR DESCRIPTION
Closes #13719

## Summary

Telugu (and other Indic-script) terminal output currently renders with fixed 1-cell-per-character allocation, which is wrong for a proportional/conjunct script — this causes squeezed, overlapping, or torn-apart-looking text. This PR generalizes the terminal's existing CJK "wide char = 2 cells" mechanism into "any script = N cells," giving each Indic grapheme cluster a real Core Text-measured cell width (1-8 cells).

## What changed

- `Cell::span()`/`set_span()` (3 spare bits in `Flags`) generalize the wide-char-pair mechanism to spans 1-8, keeping the legacy `WIDE_CHAR` flag in sync for backward compatibility.
- A `ClusterWidthMeasurer` trait measures a completed Indic grapheme cluster's real shaped width at input time (cluster-completion, not every repaint) via a dedicated Core Text `FontDB` instance.
- `ansi_handler.rs` buffers Indic-extending characters and writes the full cluster + measured span when the cluster completes.
- Every consumer that previously assumed a fixed 2-cell pair now uses the real span: cursor movement, selection, resize/reflow, copy/paste, line-to-string, rendering.
- The render layer detects each maximal contiguous run of Indic cells (plus absorbed spaces/attached punctuation) in a row and shapes it as ONE Core Text call, so inter-cluster and inter-word spacing flows at natural advances instead of being centered (and gapped) per cluster — matching how a proportional text renderer draws the same string. Per-cluster/per-cell foreground color is preserved via one style run per cluster (Core Text splits `CTRun`s at style-attribute boundaries).
- Cluster width allocation uses `ceil()` (never undersized) — an earlier attempt at `round()` to shrink allocation slack was reverted after it caused a conjunct glyph to visually overflow into and merge with the next word.

## Test plan

- [x] ~700 automated tests across the touched surface (cell storage, ANSI input handling, cursor/selection, resize/reflow, rendering) plus the full pre-existing suite — all pass
- [x] Visually verified on real Telugu sentences and paragraphs against Core Text's own proportional rendering (the app's rich-text input bar), across multiple sessions/restarts
- [ ] Would appreciate testing against other Indic scripts (Devanagari, Kannada, Tamil, etc.) and mixed Indic+CJK+ASCII content, since this was developed and tested primarily against Telugu

## Known limitations

- Very narrow terminals (under ~4-8 columns) resizing against scrollback content with wide clusters degrade gracefully (clamped) rather than being fully correct — no crash, but not pixel-perfect either.
- The ligature-rendering code path (`render_grid_with_ligatures`, off by default) is not yet Indic-aware; this PR only touches the default (non-ligature) render path.
