### PR TITLE
GUI/TUI agnostic file execution

### DIFF
--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -1259,6 +1259,13 @@ impl BlocklistAIActionModel {
 
         let action_id = action_result.id.clone();
 
+        // Every terminal outcome (success, failure, cancellation — from any
+        // path) funnels through here, so this is the one place executor-held
+        // per-action state is released.
+        self.executor.update(ctx, |executor, ctx| {
+            executor.discard_action_state(&action_id, ctx);
+        });
+
         // If a command action entered long-running mode (returned a snapshot), cancel all other
         // pending RequestCommandOutput actions. Only one command can be active at a time, and the
         // server can only spawn one CLI subagent. We don't cancel other actions because those

--- a/app/src/ai/blocklist/action_model/execute.rs
+++ b/app/src/ai/blocklist/action_model/execute.rs
@@ -916,6 +916,28 @@ impl BlocklistAIActionExecutor {
         }
     }
 
+    /// Drops executor-held per-action state now that the action has reached a
+    /// terminal result. Called from the action model's terminal-result choke
+    /// point (`handle_action_result`), which every outcome — success, failure,
+    /// or cancellation via any path — funnels through.
+    ///
+    /// Participation is per-executor opt-in: an executor may only be added
+    /// here if its per-action state is never read after the action's terminal
+    /// result. Prepared file edits qualify (consumed by execute, dead
+    /// otherwise). Do NOT add state that outlives completion, e.g. the
+    /// search-codebase executor's root repo paths (read at render time after
+    /// the action finishes) or long-running-command state (the command
+    /// outlives its action's snapshot result).
+    pub(super) fn discard_action_state(
+        &mut self,
+        action_id: &AIAgentActionId,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        self.request_file_edits_executor.update(ctx, |executor, _| {
+            executor.discard_pending(action_id);
+        });
+    }
+
     pub fn cancel_all_running_async_actions_for_conversation(
         &mut self,
         conversation_id: AIConversationId,

--- a/app/src/ai/blocklist/action_model/execute/request_file_edits.rs
+++ b/app/src/ai/blocklist/action_model/execute/request_file_edits.rs
@@ -270,10 +270,11 @@ impl RequestFileEditsExecutor {
     ) {
         tx.send(()).ok();
 
+        // Expected when the action reached a terminal result (e.g. was
+        // cancelled) mid-apply and its storage was discarded; a storage that
+        // was never registered still warns at execute time.
         let Some(storage) = self.diff_storages.get(&id) else {
-            log::warn!(
-                "Tried to apply diffs for a RequestFileEdits action without a registered storage"
-            );
+            log::info!("No registered storage for RequestFileEdits action at apply completion");
             return;
         };
 

--- a/app/src/ai/blocklist/action_model/execute/request_file_edits.rs
+++ b/app/src/ai/blocklist/action_model/execute/request_file_edits.rs
@@ -30,9 +30,7 @@ use crate::ai::agent::{
     AIAgentAction, AIAgentActionId, AIAgentActionResultType, AIAgentActionType,
     AIAgentOutputMessage, AIAgentOutputMessageType, AIIdentifiers, RequestFileEditsResult,
 };
-use crate::ai::blocklist::diff_storage::{
-    HeadlessDiffStorage, HeadlessDiffStorageModel, RegisteredDiffStorage,
-};
+use crate::ai::blocklist::diff_storage::RegisteredDiffStorage;
 use crate::ai::blocklist::diff_types::{DiffSessionType, FileDiff};
 use crate::ai::blocklist::{BlocklistAIPermissions, RequestedEditResolution};
 use crate::ai::paths::host_native_absolute_path;
@@ -40,21 +38,13 @@ use crate::terminal::model::session::active_session::ActiveSession;
 use crate::terminal::model::session::SessionType;
 use crate::{safe_warn, BlocklistAIHistoryModel};
 
-/// Per-action state carried from `preprocess_action` to `execute`.
-enum PendingFileEdits {
-    /// The storage surface that owns the diffs while the action is pending.
-    /// Registered by a review surface (GUI/TUI), or a headless placeholder
-    /// created by the executor when diffs resolve with no surface registered.
-    Storage(Box<dyn RegisteredDiffStorage>),
-    /// Diff application failed during preprocess; `execute` reports it to the LLM.
-    Failed(Vec1<DiffApplicationError>),
-}
-
 pub struct RequestFileEditsExecutor {
     active_session: ModelHandle<ActiveSession>,
     apply_diff_model: ModelHandle<ApplyDiffModel>,
-    /// Per-action state produced by preprocess and consumed by execute.
-    pending_file_edits: HashMap<AIAgentActionId, PendingFileEdits>,
+    /// The registered diff storage surface for each pending action.
+    diff_storages: HashMap<AIAgentActionId, Box<dyn RegisteredDiffStorage>>,
+    /// Set of action IDs where diff application failed.
+    diff_application_failures: HashMap<AIAgentActionId, Vec1<DiffApplicationError>>,
     terminal_view_id: EntityId,
 }
 
@@ -68,7 +58,8 @@ impl RequestFileEditsExecutor {
         Self {
             active_session,
             apply_diff_model,
-            pending_file_edits: HashMap::new(),
+            diff_storages: HashMap::new(),
+            diff_application_failures: HashMap::new(),
             terminal_view_id,
         }
     }
@@ -111,10 +102,10 @@ impl RequestFileEditsExecutor {
         // from the LLM.
         // If we don't do this, a failed diff application will block execution of the entire AI conversation
         // without any possibility of recovery.
-        if matches!(
-            self.pending_file_edits.get(&input.action.id),
-            Some(PendingFileEdits::Failed(_))
-        ) {
+        if self
+            .diff_application_failures
+            .contains_key(&input.action.id)
+        {
             return true;
         }
 
@@ -123,40 +114,22 @@ impl RequestFileEditsExecutor {
             .is_allowed()
     }
 
-    /// Registers the storage surface that owns an action's diffs.
-    ///
-    /// May be called before or after preprocess resolves the diffs: when a
-    /// placeholder storage (the headless fallback) already holds prepared
-    /// diffs, they are handed to the newly registered surface. An existing
-    /// storage that does not relinquish its diffs (a review surface, or a
-    /// placeholder already saving) stays registered and the new registration
-    /// is dropped.
+    /// Registers the diff storage surface that handles a RequestFileEdits action.
+    /// Note this MUST be called before `execute` or `preprocess_action` is invoked in
+    /// order for the necessary state to be set to handle the action.
     pub fn register_requested_edits(
         &mut self,
         action_id: &AIAgentActionId,
         storage: Box<dyn RegisteredDiffStorage>,
-        ctx: &mut ModelContext<Self>,
     ) {
-        match self.pending_file_edits.get(action_id) {
-            None => {
-                self.pending_file_edits
-                    .insert(action_id.clone(), PendingFileEdits::Storage(storage));
-            }
-            Some(PendingFileEdits::Storage(existing)) => {
-                if let Some((diffs, session_type)) = existing.take_candidate_diffs(ctx) {
-                    storage.set_candidate_diffs(diffs, session_type, ctx);
-                    self.pending_file_edits
-                        .insert(action_id.clone(), PendingFileEdits::Storage(storage));
-                }
-            }
-            Some(PendingFileEdits::Failed(_)) => {}
-        }
+        self.diff_storages.insert(action_id.clone(), storage);
     }
 
     /// Drops any per-action state for a cancelled or rejected action so
     /// prepared file contents don't outlive the action.
     pub(super) fn discard_pending(&mut self, action_id: &AIAgentActionId) {
-        self.pending_file_edits.remove(action_id);
+        self.diff_storages.remove(action_id);
+        self.diff_application_failures.remove(action_id);
     }
 
     pub(super) fn execute(
@@ -177,24 +150,23 @@ impl RequestFileEditsExecutor {
             return ActionExecution::InvalidAction;
         };
 
-        let result_future = match self.pending_file_edits.get(id) {
-            // The storage surface persists its (possibly user-edited) diffs and
-            // resolves with the assembled result. The entry stays registered
-            // until the action's terminal result funnels through
-            // `discard_pending`.
-            Some(PendingFileEdits::Storage(storage)) => storage.accept_and_save(ctx),
-            Some(PendingFileEdits::Failed(errors)) => {
-                return ActionExecution::Sync(AIAgentActionResultType::RequestFileEdits(
-                    RequestFileEditsResult::DiffApplicationFailed {
-                        error: DiffApplicationError::error_for_conversation(errors),
-                    },
-                ));
-            }
-            None => {
-                log::warn!("Tried to execute a RequestFileEdits action without prepared diffs");
-                return ActionExecution::NotReady;
-            }
+        // If diff application failed, early exit.
+        if let Some(errors) = self.diff_application_failures.remove(id) {
+            return ActionExecution::Sync(AIAgentActionResultType::RequestFileEdits(
+                RequestFileEditsResult::DiffApplicationFailed {
+                    error: DiffApplicationError::error_for_conversation(&errors),
+                },
+            ));
+        }
+
+        // The storage surface persists its (possibly user-edited) diffs and
+        // resolves with the assembled result. The entry stays registered until
+        // the action's terminal result funnels through `discard_pending`.
+        let Some(storage) = self.diff_storages.get(id) else {
+            log::warn!("Tried to execute a RequestFileEdits action without a registered storage");
+            return ActionExecution::NotReady;
         };
+        let result_future = storage.accept_and_save(ctx);
 
         let identifiers = self
             .generate_ai_identifiers(&input.conversation_id, id, ctx)
@@ -298,15 +270,20 @@ impl RequestFileEditsExecutor {
     ) {
         tx.send(()).ok();
 
+        let Some(storage) = self.diff_storages.get(&id) else {
+            log::warn!(
+                "Tried to apply diffs for a RequestFileEdits action without a registered storage"
+            );
+            return;
+        };
+
         let applied_diffs = match applied_diffs {
             Ok(diffs) if !diffs.is_empty() => diffs,
             Ok(_) => {
                 // We didn't generate any diffs--consider this a failure.
                 log::warn!("No diffs generated");
-                self.pending_file_edits.insert(
-                    id,
-                    PendingFileEdits::Failed(vec1![DiffApplicationError::EmptyDiff]),
-                );
+                self.diff_application_failures
+                    .insert(id, vec1![DiffApplicationError::EmptyDiff]);
                 return;
             }
             Err(err) => {
@@ -314,8 +291,7 @@ impl RequestFileEditsExecutor {
                     safe: ("Failed to generate diffs"),
                     full: ("Failed to generate diffs {err:?}")
                 );
-                self.pending_file_edits
-                    .insert(id, PendingFileEdits::Failed(err));
+                self.diff_application_failures.insert(id, err);
                 return;
             }
         };
@@ -335,38 +311,20 @@ impl RequestFileEditsExecutor {
                 &shell_launch_data,
                 &current_working_directory,
             );
-            diffs.push(FileDiff::new(diff.original_content, path, diff.diff_type));
+            let file_diff = FileDiff::new(diff.original_content, path, diff.diff_type);
+            diffs.push(file_diff);
         }
 
-        // Seed the registered storage surface with the resolved diffs; when no
-        // surface has registered yet (autoexecution racing view creation, or a
-        // headless conversation), create the headless placeholder so the action
-        // stays executable. A surface registering later takes the diffs over
-        // via `register_requested_edits`.
-        let session_type = self.resolve_diff_session_type(ctx);
-        match self.pending_file_edits.get(&id) {
-            Some(PendingFileEdits::Storage(storage)) => {
-                storage.set_candidate_diffs(diffs, session_type, ctx);
-            }
-            Some(PendingFileEdits::Failed(_)) | None => {
-                let model =
-                    ctx.add_model(|ctx| HeadlessDiffStorageModel::new(diffs, session_type, ctx));
-                self.pending_file_edits.insert(
-                    id,
-                    PendingFileEdits::Storage(Box::new(HeadlessDiffStorage(model))),
-                );
-            }
-        }
-    }
-
-    /// Resolves whether file writes target the local filesystem or a remote host.
-    fn resolve_diff_session_type(&self, ctx: &mut ModelContext<Self>) -> DiffSessionType {
-        match self.active_session.as_ref(ctx).session_type(ctx) {
+        // Set the session type so save/delete/create routes through the
+        // correct FileModel backend.
+        let diff_session_type = match self.active_session.as_ref(ctx).session_type(ctx) {
             Some(SessionType::WarpifiedRemote {
                 host_id: Some(host_id),
             }) => DiffSessionType::Remote(host_id.clone()),
             _ => DiffSessionType::Local,
-        }
+        };
+
+        storage.set_candidate_diffs(diffs, diff_session_type, ctx);
     }
 
     fn generate_ai_identifiers(

--- a/app/src/ai/blocklist/action_model/execute/request_file_edits.rs
+++ b/app/src/ai/blocklist/action_model/execute/request_file_edits.rs
@@ -22,32 +22,39 @@ pub use telemetry::{
 };
 use vec1::{vec1, Vec1};
 use warp_core::send_telemetry_from_ctx;
-use warp_util::file::FileSaveError;
-use warpui::{Entity, EntityId, ModelContext, ModelHandle, SingletonEntity as _, ViewHandle};
+use warpui::{Entity, EntityId, ModelContext, ModelHandle, SingletonEntity as _};
 
 use super::{ActionExecution, AnyActionExecution, ExecuteActionInput, PreprocessActionInput};
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent::{
     AIAgentAction, AIAgentActionId, AIAgentActionResultType, AIAgentActionType,
-    AIAgentOutputMessage, AIAgentOutputMessageType, AIIdentifiers, AnyFileContent, FileContext,
-    FileLocations, RequestFileEditsResult, UpdatedFileContext,
+    AIAgentOutputMessage, AIAgentOutputMessageType, AIIdentifiers, RequestFileEditsResult,
 };
-use crate::ai::blocklist::inline_action::code_diff_view::{
-    CodeDiffView, CodeDiffViewEvent, DiffSessionType, FileDiff,
+use crate::ai::blocklist::diff_storage::{
+    HeadlessDiffStorage, HeadlessDiffStorageModel, RegisteredDiffStorage,
 };
+use crate::ai::blocklist::diff_types::{DiffSessionType, FileDiff};
 use crate::ai::blocklist::{BlocklistAIPermissions, RequestedEditResolution};
 use crate::ai::paths::host_native_absolute_path;
 use crate::terminal::model::session::active_session::ActiveSession;
 use crate::terminal::model::session::SessionType;
 use crate::{safe_warn, BlocklistAIHistoryModel};
-const APPLY_DIFF_RESULT_CONTEXT_LINES: usize = 10;
+
+/// Per-action state carried from `preprocess_action` to `execute`.
+enum PendingFileEdits {
+    /// The storage surface that owns the diffs while the action is pending.
+    /// Registered by a review surface (GUI/TUI), or a headless placeholder
+    /// created by the executor when diffs resolve with no surface registered.
+    Storage(Box<dyn RegisteredDiffStorage>),
+    /// Diff application failed during preprocess; `execute` reports it to the LLM.
+    Failed(Vec1<DiffApplicationError>),
+}
 
 pub struct RequestFileEditsExecutor {
     active_session: ModelHandle<ActiveSession>,
     apply_diff_model: ModelHandle<ApplyDiffModel>,
-    diff_views: HashMap<AIAgentActionId, ViewHandle<CodeDiffView>>,
-    /// Set of action IDs where diff application failed.
-    diff_application_failures: HashMap<AIAgentActionId, Vec1<DiffApplicationError>>,
+    /// Per-action state produced by preprocess and consumed by execute.
+    pending_file_edits: HashMap<AIAgentActionId, PendingFileEdits>,
     terminal_view_id: EntityId,
 }
 
@@ -61,8 +68,7 @@ impl RequestFileEditsExecutor {
         Self {
             active_session,
             apply_diff_model,
-            diff_views: HashMap::new(),
-            diff_application_failures: HashMap::new(),
+            pending_file_edits: HashMap::new(),
             terminal_view_id,
         }
     }
@@ -105,10 +111,10 @@ impl RequestFileEditsExecutor {
         // from the LLM.
         // If we don't do this, a failed diff application will block execution of the entire AI conversation
         // without any possibility of recovery.
-        if self
-            .diff_application_failures
-            .contains_key(&input.action.id)
-        {
+        if matches!(
+            self.pending_file_edits.get(&input.action.id),
+            Some(PendingFileEdits::Failed(_))
+        ) {
             return true;
         }
 
@@ -117,15 +123,40 @@ impl RequestFileEditsExecutor {
             .is_allowed()
     }
 
-    /// Registers a diff view to handle a RequestFileEdits action.
-    /// Note this MUST be called before `execute` or `preprocess_action` is invoked in
-    /// order for the necessary state to be set to handle the action.
+    /// Registers the storage surface that owns an action's diffs.
+    ///
+    /// May be called before or after preprocess resolves the diffs: when a
+    /// placeholder storage (the headless fallback) already holds prepared
+    /// diffs, they are handed to the newly registered surface. An existing
+    /// storage that does not relinquish its diffs (a review surface, or a
+    /// placeholder already saving) stays registered and the new registration
+    /// is dropped.
     pub fn register_requested_edits(
         &mut self,
         action_id: &AIAgentActionId,
-        view: &ViewHandle<CodeDiffView>,
+        storage: Box<dyn RegisteredDiffStorage>,
+        ctx: &mut ModelContext<Self>,
     ) {
-        self.diff_views.insert(action_id.clone(), view.clone());
+        match self.pending_file_edits.get(action_id) {
+            None => {
+                self.pending_file_edits
+                    .insert(action_id.clone(), PendingFileEdits::Storage(storage));
+            }
+            Some(PendingFileEdits::Storage(existing)) => {
+                if let Some((diffs, session_type)) = existing.take_candidate_diffs(ctx) {
+                    storage.set_candidate_diffs(diffs, session_type, ctx);
+                    self.pending_file_edits
+                        .insert(action_id.clone(), PendingFileEdits::Storage(storage));
+                }
+            }
+            Some(PendingFileEdits::Failed(_)) => {}
+        }
+    }
+
+    /// Drops any per-action state for a cancelled or rejected action so
+    /// prepared file contents don't outlive the action.
+    pub(super) fn discard_pending(&mut self, action_id: &AIAgentActionId) {
+        self.pending_file_edits.remove(action_id);
     }
 
     pub(super) fn execute(
@@ -146,22 +177,24 @@ impl RequestFileEditsExecutor {
             return ActionExecution::InvalidAction;
         };
 
-        // TODO(surface-agnostic-file-edit-execution): non-GUI surfaces (e.g. the TUI) have no
-        // CodeDiffView, so file-edit tool calls are not executable here yet. The stacked
-        // surface-agnostic refactor routes execution through a shared PersistDiffModel instead.
-        let Some(diff_view) = self.diff_views.get(id) else {
-            log::warn!("Tried to execute a RequestFileEdits action without a diff view");
-            return ActionExecution::NotReady;
+        let result_future = match self.pending_file_edits.get(id) {
+            // The storage surface persists its (possibly user-edited) diffs and
+            // resolves with the assembled result. The entry stays registered
+            // until the action's terminal result funnels through
+            // `discard_pending`.
+            Some(PendingFileEdits::Storage(storage)) => storage.accept_and_save(ctx),
+            Some(PendingFileEdits::Failed(errors)) => {
+                return ActionExecution::Sync(AIAgentActionResultType::RequestFileEdits(
+                    RequestFileEditsResult::DiffApplicationFailed {
+                        error: DiffApplicationError::error_for_conversation(errors),
+                    },
+                ));
+            }
+            None => {
+                log::warn!("Tried to execute a RequestFileEdits action without prepared diffs");
+                return ActionExecution::NotReady;
+            }
         };
-
-        // If diff application failed, early exit.
-        if let Some(errors) = self.diff_application_failures.remove(id) {
-            return ActionExecution::Sync(AIAgentActionResultType::RequestFileEdits(
-                RequestFileEditsResult::DiffApplicationFailed {
-                    error: DiffApplicationError::error_for_conversation(&errors),
-                },
-            ));
-        }
 
         let identifiers = self
             .generate_ai_identifiers(&input.conversation_id, id, ctx)
@@ -169,87 +202,32 @@ impl RequestFileEditsExecutor {
                 client_conversation_id: Some(input.conversation_id),
                 ..Default::default()
             });
+        let passive_diff = BlocklistAIHistoryModel::as_ref(ctx)
+            .is_entirely_passive_conversation(&input.conversation_id);
 
-        let (result_tx, result_rx) = oneshot::channel();
-        let mut result_tx = Some(result_tx);
-
-        ctx.subscribe_to_view(diff_view, move |_me, _, event, ctx| match event {
-            CodeDiffViewEvent::Rejected => {
-                let Some(result_tx) = result_tx.take() else {
-                    return;
-                };
-                let _ = result_tx.send(RequestFileEditsResult::Cancelled);
-            }
-            CodeDiffViewEvent::SavedAcceptedDiffs {
-                diff,
+        ActionExecution::new_async(result_future, move |result, ctx| {
+            if let RequestFileEditsResult::Success {
                 updated_files,
-                file_contents,
-                deleted_files,
-                save_errors,
-            } => {
-                let Some(result_tx) = result_tx.take() else {
-                    return;
-                };
-
-                // If saving any file failed, report it as an error to the LLM. Other files may
-                // have saved successfully, but we're ignoring this edge case for now.
-                if !save_errors.is_empty() {
-                    let error = save_errors
-                        .iter()
-                        .filter_map(|err| match err.as_ref() {
-                            FileSaveError::IOError { error, path } => {
-                                Some(format!("Failed to save file {path:?}: {error}"))
-                            }
-                            _ => None,
-                        })
-                        .join("\n");
-
-                    let _ = result_tx.send(RequestFileEditsResult::DiffApplicationFailed { error });
-                    return;
-                }
-
-                let passive_diff = BlocklistAIHistoryModel::as_ref(ctx)
-                    .is_entirely_passive_conversation(&input.conversation_id);
+                lines_added,
+                lines_removed,
+                ..
+            } = &result
+            {
                 send_telemetry_from_ctx!(
                     RequestFileEditsTelemetryEvent::EditResolved(EditResolvedEvent {
                         identifiers: identifiers.clone(),
                         response: RequestedEditResolution::Accept,
                         stats: EditStats {
                             files_edited: updated_files.len(),
-                            lines_added: diff.lines_added,
-                            lines_removed: diff.lines_removed,
+                            lines_added: *lines_added,
+                            lines_removed: *lines_removed,
                         },
                         passive_diff,
-                    },),
+                    }),
                     ctx
                 );
-
-                // Build a map of file path → content from the editor buffers.
-                // This avoids re-reading files from disk or the remote server.
-                let content_map: HashMap<String, String> = file_contents.iter().cloned().collect();
-
-                let _ = result_tx.send(RequestFileEditsResult::Success {
-                    diff: diff.unified_diff.clone(),
-                    updated_files: updated_file_contexts_from_editor_buffers(
-                        updated_files,
-                        &content_map,
-                    ),
-                    deleted_files: deleted_files.clone(),
-                    lines_added: diff.lines_added,
-                    lines_removed: diff.lines_removed,
-                });
             }
-            _ => (),
-        });
-        diff_view.update(ctx, |diff_view, ctx| {
-            diff_view.accept_and_save(ctx);
-        });
-
-        ActionExecution::new_async(result_rx, |result, _ctx| match result {
-            Ok(result) => AIAgentActionResultType::RequestFileEdits(result),
-            Err(oneshot::Canceled) => {
-                AIAgentActionResultType::RequestFileEdits(RequestFileEditsResult::Cancelled)
-            }
+            AIAgentActionResultType::RequestFileEdits(result)
         })
     }
 
@@ -320,20 +298,15 @@ impl RequestFileEditsExecutor {
     ) {
         tx.send(()).ok();
 
-        let Some(diff_view) = self.diff_views.get(&id) else {
-            log::warn!(
-                "Tried to apply diffs for a RequestFileEdits action without a corresponding diff view"
-            );
-            return;
-        };
-
         let applied_diffs = match applied_diffs {
             Ok(diffs) if !diffs.is_empty() => diffs,
             Ok(_) => {
                 // We didn't generate any diffs--consider this a failure.
                 log::warn!("No diffs generated");
-                self.diff_application_failures
-                    .insert(id, vec1![DiffApplicationError::EmptyDiff]);
+                self.pending_file_edits.insert(
+                    id,
+                    PendingFileEdits::Failed(vec1![DiffApplicationError::EmptyDiff]),
+                );
                 return;
             }
             Err(err) => {
@@ -341,7 +314,8 @@ impl RequestFileEditsExecutor {
                     safe: ("Failed to generate diffs"),
                     full: ("Failed to generate diffs {err:?}")
                 );
-                self.diff_application_failures.insert(id, err);
+                self.pending_file_edits
+                    .insert(id, PendingFileEdits::Failed(err));
                 return;
             }
         };
@@ -361,23 +335,38 @@ impl RequestFileEditsExecutor {
                 &shell_launch_data,
                 &current_working_directory,
             );
-            let file_diff = FileDiff::new(diff.original_content, path, diff.diff_type);
-            diffs.push(file_diff);
+            diffs.push(FileDiff::new(diff.original_content, path, diff.diff_type));
         }
 
-        // Set the session type on the diff view so save/delete/create routes
-        // through the correct FileModel backend.
-        let diff_session_type = match self.active_session.as_ref(ctx).session_type(ctx) {
+        // Seed the registered storage surface with the resolved diffs; when no
+        // surface has registered yet (autoexecution racing view creation, or a
+        // headless conversation), create the headless placeholder so the action
+        // stays executable. A surface registering later takes the diffs over
+        // via `register_requested_edits`.
+        let session_type = self.resolve_diff_session_type(ctx);
+        match self.pending_file_edits.get(&id) {
+            Some(PendingFileEdits::Storage(storage)) => {
+                storage.set_candidate_diffs(diffs, session_type, ctx);
+            }
+            Some(PendingFileEdits::Failed(_)) | None => {
+                let model =
+                    ctx.add_model(|ctx| HeadlessDiffStorageModel::new(diffs, session_type, ctx));
+                self.pending_file_edits.insert(
+                    id,
+                    PendingFileEdits::Storage(Box::new(HeadlessDiffStorage(model))),
+                );
+            }
+        }
+    }
+
+    /// Resolves whether file writes target the local filesystem or a remote host.
+    fn resolve_diff_session_type(&self, ctx: &mut ModelContext<Self>) -> DiffSessionType {
+        match self.active_session.as_ref(ctx).session_type(ctx) {
             Some(SessionType::WarpifiedRemote {
                 host_id: Some(host_id),
             }) => DiffSessionType::Remote(host_id.clone()),
             _ => DiffSessionType::Local,
-        };
-
-        diff_view.update(ctx, |diff_view, ctx| {
-            diff_view.set_diff_session_type(diff_session_type);
-            diff_view.set_candidate_diffs(diffs, ctx);
-        });
+        }
     }
 
     fn generate_ai_identifiers(
@@ -411,72 +400,6 @@ impl RequestFileEditsExecutor {
                 .map(Into::into),
             model_id,
         })
-    }
-}
-
-fn updated_file_contexts_from_editor_buffers(
-    updated_files: &[(FileLocations, bool)],
-    content_map: &HashMap<String, String>,
-) -> Vec<UpdatedFileContext> {
-    updated_files
-        .iter()
-        .flat_map(|(file_location, was_edited)| {
-            let content = content_map
-                .get(&file_location.name)
-                .cloned()
-                .unwrap_or_default();
-            let line_count = content.lines().count();
-
-            let mut file_location = file_location.clone();
-            file_location.expand_surrounding_context(APPLY_DIFF_RESULT_CONTEXT_LINES);
-            clamp_to_file_context_range_start(&mut file_location);
-
-            if file_location.lines.is_empty() {
-                return vec![UpdatedFileContext {
-                    was_edited_by_user: *was_edited,
-                    file_context: FileContext {
-                        file_name: file_location.name,
-                        content: AnyFileContent::StringContent(content),
-                        line_range: None,
-                        last_modified: None,
-                        line_count,
-                    },
-                }];
-            }
-
-            let lines = content.lines().collect_vec();
-            file_location
-                .lines
-                .into_iter()
-                .map(|range| {
-                    let start = range.start.saturating_sub(1).min(lines.len());
-                    let end = range.end.saturating_sub(1).min(lines.len());
-                    let fragment = if start >= end {
-                        String::new()
-                    } else {
-                        lines[start..end].join("\n")
-                    };
-
-                    UpdatedFileContext {
-                        was_edited_by_user: *was_edited,
-                        file_context: FileContext {
-                            file_name: file_location.name.clone(),
-                            content: AnyFileContent::StringContent(fragment),
-                            line_range: Some(range),
-                            last_modified: None,
-                            line_count,
-                        },
-                    }
-                })
-                .collect_vec()
-        })
-        .collect()
-}
-
-fn clamp_to_file_context_range_start(file_location: &mut FileLocations) {
-    for range in &mut file_location.lines {
-        range.start = range.start.max(1);
-        range.end = range.end.max(range.start);
     }
 }
 

--- a/app/src/ai/blocklist/action_model/execute/request_file_edits_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/request_file_edits_tests.rs
@@ -1,7 +1,7 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
-use ai::diff_validation::DiffType;
+use ai::diff_validation::{AIRequestedCodeDiff, DiffType};
 use async_channel::unbounded;
 use futures::FutureExt;
 use warpui::{App, AppContext, EntityId};
@@ -14,17 +14,13 @@ use crate::terminal::model_events::ModelEventDispatcher;
 /// Shared observable state for a [`TestStorage`].
 struct TestStorageState {
     diffs: RefCell<Option<(Vec<FileDiff>, DiffSessionType)>>,
-    /// Whether `take_candidate_diffs` hands the diffs over (headless-placeholder
-    /// behavior) or keeps them (review-surface behavior).
-    relinquishes: bool,
     accepted: Cell<bool>,
 }
 
 impl TestStorageState {
-    fn new(relinquishes: bool) -> Rc<Self> {
+    fn new() -> Rc<Self> {
         Rc::new(Self {
             diffs: RefCell::new(None),
-            relinquishes,
             accepted: Cell::new(false),
         })
     }
@@ -41,17 +37,6 @@ impl RegisteredDiffStorage for TestStorage {
         _app: &mut AppContext,
     ) {
         *self.0.diffs.borrow_mut() = Some((diffs, session_type));
-    }
-
-    fn take_candidate_diffs(
-        &self,
-        _app: &mut AppContext,
-    ) -> Option<(Vec<FileDiff>, DiffSessionType)> {
-        if self.0.relinquishes {
-            self.0.diffs.borrow_mut().take()
-        } else {
-            None
-        }
     }
 
     fn accept_and_save(&self, _app: &mut AppContext) -> BoxFuture<'static, RequestFileEditsResult> {
@@ -78,26 +63,16 @@ fn add_executor(app: &mut App) -> ModelHandle<RequestFileEditsExecutor> {
     app.add_model(|ctx| RequestFileEditsExecutor::new(active_session, EntityId::new(), ctx))
 }
 
-/// Builds a prepared diff creating `/tmp/x.rs`.
-fn test_diff() -> FileDiff {
-    FileDiff::new(
-        String::new(),
-        "/tmp/x.rs".to_owned(),
-        DiffType::creation("fn main() {}\n".to_owned()),
-    )
-}
-
 /// Registers a `TestStorage` for `action_id` and returns its observable state.
 fn register_storage(
     app: &mut App,
     executor: &ModelHandle<RequestFileEditsExecutor>,
     action_id: &AIAgentActionId,
-    relinquishes: bool,
 ) -> Rc<TestStorageState> {
-    let state = TestStorageState::new(relinquishes);
+    let state = TestStorageState::new();
     let storage = Box::new(TestStorage(state.clone()));
-    executor.update(app, |executor, ctx| {
-        executor.register_requested_edits(action_id, storage, ctx);
+    executor.update(app, |executor, _| {
+        executor.register_requested_edits(action_id, storage);
     });
     state
 }
@@ -137,45 +112,32 @@ fn execute(
 }
 
 #[test]
-fn register_hands_prepared_diffs_to_new_surface() {
+fn on_diffs_applied_seeds_registered_storage() {
     App::test((), |mut app| async move {
         let executor = add_executor(&mut app);
         let action_id = AIAgentActionId::from("edit-1".to_owned());
+        let storage = register_storage(&mut app, &executor, &action_id);
 
-        // A placeholder holding prepared diffs relinquishes them to a
-        // registering review surface.
-        let placeholder = register_storage(&mut app, &executor, &action_id, true);
-        *placeholder.diffs.borrow_mut() = Some((vec![test_diff()], DiffSessionType::Local));
+        let (tx, _rx) = oneshot::channel();
+        executor.update(&mut app, |executor, ctx| {
+            executor.on_diffs_applied(
+                Ok(vec![AIRequestedCodeDiff {
+                    file_name: "/tmp/x.rs".to_owned(),
+                    diff_type: DiffType::creation("fn main() {}\n".to_owned()),
+                    failures: None,
+                    original_content: String::new(),
+                }]),
+                action_id.clone(),
+                tx,
+                ctx,
+            );
+        });
 
-        let surface = register_storage(&mut app, &executor, &action_id, false);
-        let seeded = surface.diffs.borrow_mut().take();
-        let (diffs, session_type) = seeded.expect("surface should be seeded with the diffs");
+        let seeded = storage.diffs.borrow_mut().take();
+        let (diffs, session_type) = seeded.expect("registered storage should be seeded");
         assert_eq!(diffs.len(), 1);
         assert_eq!(diffs[0].file_path(), "/tmp/x.rs");
         assert!(matches!(session_type, DiffSessionType::Local));
-        assert!(placeholder.diffs.borrow().is_none());
-    });
-}
-
-#[test]
-fn register_keeps_owner_that_does_not_relinquish() {
-    App::test((), |mut app| async move {
-        let executor = add_executor(&mut app);
-        let action_id = AIAgentActionId::from("edit-1".to_owned());
-
-        // A review surface owns the entry and never relinquishes.
-        let owner = register_storage(&mut app, &executor, &action_id, false);
-        *owner.diffs.borrow_mut() = Some((vec![test_diff()], DiffSessionType::Local));
-
-        let late = register_storage(&mut app, &executor, &action_id, false);
-        assert!(late.diffs.borrow().is_none());
-
-        // The original owner still serves execution.
-        app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
-        let execution = execute(&mut app, &executor, &action_id);
-        assert!(matches!(execution, AnyActionExecution::Async { .. }));
-        assert!(owner.accepted.get());
-        assert!(!late.accepted.get());
     });
 }
 
@@ -185,7 +147,7 @@ fn execute_accepts_through_registered_storage() {
         app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
         let executor = add_executor(&mut app);
         let action_id = AIAgentActionId::from("edit-1".to_owned());
-        let storage = register_storage(&mut app, &executor, &action_id, false);
+        let storage = register_storage(&mut app, &executor, &action_id);
 
         let execution = execute(&mut app, &executor, &action_id);
 
@@ -194,7 +156,7 @@ fn execute_accepts_through_registered_storage() {
         // The entry stays registered until the action's terminal result
         // funnels through `discard_pending`.
         executor.update(&mut app, |executor, _| {
-            assert!(executor.pending_file_edits.contains_key(&action_id));
+            assert!(executor.diff_storages.contains_key(&action_id));
         });
     });
 }
@@ -205,10 +167,9 @@ fn execute_reports_preprocess_failure() {
         let executor = add_executor(&mut app);
         let action_id = AIAgentActionId::from("edit-failed".to_owned());
         executor.update(&mut app, |executor, _| {
-            executor.pending_file_edits.insert(
-                action_id.clone(),
-                PendingFileEdits::Failed(vec1![DiffApplicationError::EmptyDiff]),
-            );
+            executor
+                .diff_application_failures
+                .insert(action_id.clone(), vec1![DiffApplicationError::EmptyDiff]);
         });
 
         let execution = execute(&mut app, &executor, &action_id);
@@ -241,21 +202,20 @@ fn discard_pending_drops_state_in_any_state() {
 
         // Registered storage entry (e.g. rejected during review).
         let storage_id = AIAgentActionId::from("edit-storage".to_owned());
-        register_storage(&mut app, &executor, &storage_id, false);
+        register_storage(&mut app, &executor, &storage_id);
         executor.update(&mut app, |executor, _| {
             executor.discard_pending(&storage_id);
-            assert!(!executor.pending_file_edits.contains_key(&storage_id));
+            assert!(!executor.diff_storages.contains_key(&storage_id));
         });
 
         // Failed entry (diff application failed during preprocess).
         let failed_id = AIAgentActionId::from("edit-failed".to_owned());
         executor.update(&mut app, |executor, _| {
-            executor.pending_file_edits.insert(
-                failed_id.clone(),
-                PendingFileEdits::Failed(vec1![DiffApplicationError::EmptyDiff]),
-            );
+            executor
+                .diff_application_failures
+                .insert(failed_id.clone(), vec1![DiffApplicationError::EmptyDiff]);
             executor.discard_pending(&failed_id);
-            assert!(!executor.pending_file_edits.contains_key(&failed_id));
+            assert!(!executor.diff_application_failures.contains_key(&failed_id));
         });
     });
 }

--- a/app/src/ai/blocklist/action_model/execute/request_file_edits_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/request_file_edits_tests.rs
@@ -1,63 +1,261 @@
-use std::collections::HashMap;
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
 
-use ai::agent::action_result::AnyFileContent;
-use ai::agent::FileLocations;
+use ai::diff_validation::DiffType;
+use async_channel::unbounded;
+use futures::FutureExt;
+use warpui::{App, AppContext, EntityId};
 
-use super::updated_file_contexts_from_editor_buffers;
+use super::*;
+use crate::ai::agent::task::TaskId;
+use crate::terminal::model::session::Sessions;
+use crate::terminal::model_events::ModelEventDispatcher;
 
-#[test]
-fn updated_file_contexts_from_editor_buffers_returns_changed_lines_with_context() {
-    let updated_files = vec![(
-        FileLocations {
-            name: "src/main.rs".to_string(),
-            lines: std::iter::once(12..13).collect(),
+/// Shared observable state for a [`TestStorage`].
+struct TestStorageState {
+    diffs: RefCell<Option<(Vec<FileDiff>, DiffSessionType)>>,
+    /// Whether `take_candidate_diffs` hands the diffs over (headless-placeholder
+    /// behavior) or keeps them (review-surface behavior).
+    relinquishes: bool,
+    accepted: Cell<bool>,
+}
+
+impl TestStorageState {
+    fn new(relinquishes: bool) -> Rc<Self> {
+        Rc::new(Self {
+            diffs: RefCell::new(None),
+            relinquishes,
+            accepted: Cell::new(false),
+        })
+    }
+}
+
+/// A registrable storage double that records seeding and accepts immediately.
+struct TestStorage(Rc<TestStorageState>);
+
+impl RegisteredDiffStorage for TestStorage {
+    fn set_candidate_diffs(
+        &self,
+        diffs: Vec<FileDiff>,
+        session_type: DiffSessionType,
+        _app: &mut AppContext,
+    ) {
+        *self.0.diffs.borrow_mut() = Some((diffs, session_type));
+    }
+
+    fn take_candidate_diffs(
+        &self,
+        _app: &mut AppContext,
+    ) -> Option<(Vec<FileDiff>, DiffSessionType)> {
+        if self.0.relinquishes {
+            self.0.diffs.borrow_mut().take()
+        } else {
+            None
+        }
+    }
+
+    fn accept_and_save(&self, _app: &mut AppContext) -> BoxFuture<'static, RequestFileEditsResult> {
+        self.0.accepted.set(true);
+        futures::future::ready(RequestFileEditsResult::Success {
+            diff: String::new(),
+            updated_files: Vec::new(),
+            deleted_files: Vec::new(),
+            lines_added: 0,
+            lines_removed: 0,
+        })
+        .boxed()
+    }
+}
+
+/// Builds an executor over a minimal test session.
+fn add_executor(app: &mut App) -> ModelHandle<RequestFileEditsExecutor> {
+    let sessions = app.add_model(|_| Sessions::new_for_test());
+    let (_, model_events_rx) = unbounded();
+    let dispatcher =
+        app.add_model(|ctx| ModelEventDispatcher::new(model_events_rx, sessions.clone(), ctx));
+    let active_session =
+        app.add_model(|ctx| ActiveSession::new(sessions.clone(), dispatcher.clone(), ctx));
+    app.add_model(|ctx| RequestFileEditsExecutor::new(active_session, EntityId::new(), ctx))
+}
+
+/// Builds a prepared diff creating `/tmp/x.rs`.
+fn test_diff() -> FileDiff {
+    FileDiff::new(
+        String::new(),
+        "/tmp/x.rs".to_owned(),
+        DiffType::creation("fn main() {}\n".to_owned()),
+    )
+}
+
+/// Registers a `TestStorage` for `action_id` and returns its observable state.
+fn register_storage(
+    app: &mut App,
+    executor: &ModelHandle<RequestFileEditsExecutor>,
+    action_id: &AIAgentActionId,
+    relinquishes: bool,
+) -> Rc<TestStorageState> {
+    let state = TestStorageState::new(relinquishes);
+    let storage = Box::new(TestStorage(state.clone()));
+    executor.update(app, |executor, ctx| {
+        executor.register_requested_edits(action_id, storage, ctx);
+    });
+    state
+}
+
+/// Builds a `RequestFileEdits` action with the given id.
+fn edit_action(id: &AIAgentActionId) -> AIAgentAction {
+    AIAgentAction {
+        id: id.clone(),
+        task_id: TaskId::new("task".to_owned()),
+        action: AIAgentActionType::RequestFileEdits {
+            file_edits: Vec::new(),
+            title: None,
         },
-        true,
-    )];
-    let content = (1..=30)
-        .map(|line| format!("line {line}"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let content_map = HashMap::from([("src/main.rs".to_string(), content)]);
+        requires_result: true,
+    }
+}
 
-    let contexts = updated_file_contexts_from_editor_buffers(&updated_files, &content_map);
-
-    assert_eq!(contexts.len(), 1);
-    assert!(contexts[0].was_edited_by_user);
-    assert_eq!(contexts[0].file_context.file_name, "src/main.rs");
-    assert_eq!(contexts[0].file_context.line_range, Some(2..23));
-    assert_eq!(contexts[0].file_context.line_count, 30);
-    assert_eq!(
-        contexts[0].file_context.content,
-        AnyFileContent::StringContent(
-            (2..=22)
-                .map(|line| format!("line {line}"))
-                .collect::<Vec<_>>()
-                .join("\n")
-        )
-    );
+/// Runs `execute` for the given action.
+fn execute(
+    app: &mut App,
+    executor: &ModelHandle<RequestFileEditsExecutor>,
+    action_id: &AIAgentActionId,
+) -> AnyActionExecution {
+    let action = edit_action(action_id);
+    let conversation_id = AIConversationId::new();
+    executor.update(app, |executor, ctx| {
+        executor
+            .execute(
+                ExecuteActionInput {
+                    action: &action,
+                    conversation_id,
+                },
+                ctx,
+            )
+            .into()
+    })
 }
 
 #[test]
-fn updated_file_contexts_from_editor_buffers_preserves_full_file_when_no_ranges() {
-    let updated_files = vec![(
-        FileLocations {
-            name: "src/main.rs".to_string(),
-            lines: vec![],
-        },
-        false,
-    )];
-    let content = "line 1\nline 2\n".to_string();
-    let content_map = HashMap::from([("src/main.rs".to_string(), content.clone())]);
+fn register_hands_prepared_diffs_to_new_surface() {
+    App::test((), |mut app| async move {
+        let executor = add_executor(&mut app);
+        let action_id = AIAgentActionId::from("edit-1".to_owned());
 
-    let contexts = updated_file_contexts_from_editor_buffers(&updated_files, &content_map);
+        // A placeholder holding prepared diffs relinquishes them to a
+        // registering review surface.
+        let placeholder = register_storage(&mut app, &executor, &action_id, true);
+        *placeholder.diffs.borrow_mut() = Some((vec![test_diff()], DiffSessionType::Local));
 
-    assert_eq!(contexts.len(), 1);
-    assert!(!contexts[0].was_edited_by_user);
-    assert_eq!(contexts[0].file_context.line_range, None);
-    assert_eq!(contexts[0].file_context.line_count, 2);
-    assert_eq!(
-        contexts[0].file_context.content,
-        AnyFileContent::StringContent(content)
-    );
+        let surface = register_storage(&mut app, &executor, &action_id, false);
+        let seeded = surface.diffs.borrow_mut().take();
+        let (diffs, session_type) = seeded.expect("surface should be seeded with the diffs");
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].file_path(), "/tmp/x.rs");
+        assert!(matches!(session_type, DiffSessionType::Local));
+        assert!(placeholder.diffs.borrow().is_none());
+    });
+}
+
+#[test]
+fn register_keeps_owner_that_does_not_relinquish() {
+    App::test((), |mut app| async move {
+        let executor = add_executor(&mut app);
+        let action_id = AIAgentActionId::from("edit-1".to_owned());
+
+        // A review surface owns the entry and never relinquishes.
+        let owner = register_storage(&mut app, &executor, &action_id, false);
+        *owner.diffs.borrow_mut() = Some((vec![test_diff()], DiffSessionType::Local));
+
+        let late = register_storage(&mut app, &executor, &action_id, false);
+        assert!(late.diffs.borrow().is_none());
+
+        // The original owner still serves execution.
+        app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let execution = execute(&mut app, &executor, &action_id);
+        assert!(matches!(execution, AnyActionExecution::Async { .. }));
+        assert!(owner.accepted.get());
+        assert!(!late.accepted.get());
+    });
+}
+
+#[test]
+fn execute_accepts_through_registered_storage() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let executor = add_executor(&mut app);
+        let action_id = AIAgentActionId::from("edit-1".to_owned());
+        let storage = register_storage(&mut app, &executor, &action_id, false);
+
+        let execution = execute(&mut app, &executor, &action_id);
+
+        assert!(matches!(execution, AnyActionExecution::Async { .. }));
+        assert!(storage.accepted.get());
+        // The entry stays registered until the action's terminal result
+        // funnels through `discard_pending`.
+        executor.update(&mut app, |executor, _| {
+            assert!(executor.pending_file_edits.contains_key(&action_id));
+        });
+    });
+}
+
+#[test]
+fn execute_reports_preprocess_failure() {
+    App::test((), |mut app| async move {
+        let executor = add_executor(&mut app);
+        let action_id = AIAgentActionId::from("edit-failed".to_owned());
+        executor.update(&mut app, |executor, _| {
+            executor.pending_file_edits.insert(
+                action_id.clone(),
+                PendingFileEdits::Failed(vec1![DiffApplicationError::EmptyDiff]),
+            );
+        });
+
+        let execution = execute(&mut app, &executor, &action_id);
+
+        assert!(matches!(
+            execution,
+            AnyActionExecution::Sync(AIAgentActionResultType::RequestFileEdits(
+                RequestFileEditsResult::DiffApplicationFailed { .. }
+            ))
+        ));
+    });
+}
+
+#[test]
+fn execute_without_prepared_diffs_is_not_ready() {
+    App::test((), |mut app| async move {
+        let executor = add_executor(&mut app);
+        let action_id = AIAgentActionId::from("edit-1".to_owned());
+
+        let execution = execute(&mut app, &executor, &action_id);
+
+        assert!(matches!(execution, AnyActionExecution::NotReady));
+    });
+}
+
+#[test]
+fn discard_pending_drops_state_in_any_state() {
+    App::test((), |mut app| async move {
+        let executor = add_executor(&mut app);
+
+        // Registered storage entry (e.g. rejected during review).
+        let storage_id = AIAgentActionId::from("edit-storage".to_owned());
+        register_storage(&mut app, &executor, &storage_id, false);
+        executor.update(&mut app, |executor, _| {
+            executor.discard_pending(&storage_id);
+            assert!(!executor.pending_file_edits.contains_key(&storage_id));
+        });
+
+        // Failed entry (diff application failed during preprocess).
+        let failed_id = AIAgentActionId::from("edit-failed".to_owned());
+        executor.update(&mut app, |executor, _| {
+            executor.pending_file_edits.insert(
+                failed_id.clone(),
+                PendingFileEdits::Failed(vec1![DiffApplicationError::EmptyDiff]),
+            );
+            executor.discard_pending(&failed_id);
+            assert!(!executor.pending_file_edits.contains_key(&failed_id));
+        });
+    });
 }

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -67,14 +67,12 @@ use warpui::{
     ViewHandle, WeakViewHandle, WindowId,
 };
 
-#[cfg(feature = "agent_mode_debug")]
-use self::code_diff_view::FileDiff;
 use self::model::{AIBlockModel, AIBlockModelHelper};
 use super::action_model::{AIActionStatus, BlocklistAIActionEvent, RequestFileEditsFormatKind};
 use super::code_block::CodeSnippetButtonHandles;
 use super::controller::ClientIdentifiers;
 use super::inline_action::code_diff_view::{
-    CodeDiffState, CodeDiffView, CodeDiffViewAction, CodeDiffViewEvent,
+    CodeDiffState, CodeDiffView, CodeDiffViewAction, CodeDiffViewEvent, GuiDiffStorage,
 };
 use super::inline_action::requested_action::{CTRL_C_KEYSTROKE, ENTER_KEYSTROKE};
 use super::inline_action::requested_command_attribution::is_command_copied_from_document;
@@ -108,6 +106,8 @@ use crate::ai::blocklist::block::keyboard_navigable_buttons::{
     KeyboardNavigableButtonBuilder, KeyboardNavigableButtons,
 };
 use crate::ai::blocklist::context_model::AttachmentType;
+#[cfg(feature = "agent_mode_debug")]
+use crate::ai::blocklist::diff_types::FileDiff;
 use crate::ai::blocklist::inline_action::ask_user_question_view::{
     self, AskUserQuestionView, AskUserQuestionViewEvent,
 };
@@ -3167,9 +3167,6 @@ impl AIBlock {
             .action_model
             .as_ref(ctx)
             .request_file_edits_executor(ctx);
-        executor.update(ctx, |executor, _| {
-            executor.register_requested_edits(action_id, &view);
-        });
 
         // If the diff is being viewed in a shared session (read-only mode), populate diffs from the payload.
         if self.action_model.as_ref(ctx).is_view_only() {
@@ -3182,12 +3179,25 @@ impl AIBlock {
             view.update(ctx, |diff_view, ctx| {
                 diff_view.set_candidate_diffs(file_diffs, ctx);
             });
+        } else {
+            // Register the review view as the action's diff storage. The
+            // executor seeds it with diffs when preprocess resolves — or
+            // immediately, taking them over from the headless placeholder, if
+            // they already have.
+            let storage = Box::new(GuiDiffStorage(view.downgrade()));
+            executor.update(ctx, |executor, ctx| {
+                executor.register_requested_edits(action_id, storage, ctx);
+            });
         }
 
         let action_id_clone = action_id.clone();
         ctx.subscribe_to_view(&view, move |me, view, event, ctx| {
             match event {
                 CodeDiffViewEvent::TryAccept => {
+                    // The executor drives the save through the registered
+                    // `GuiDiffStorage` at execute time, pulling the (possibly
+                    // edited) final content from the view's editor buffers.
+                    view.update(ctx, |view, ctx| view.send_malformed_line_telemetry(ctx));
                     me.action_model.update(ctx, |action_model, ctx| {
                         action_model.execute_action(
                             &action_id_clone,
@@ -3391,7 +3401,7 @@ impl AIBlock {
                     match action_status {
                         Some(AIActionStatus::Finished(result)) => {
                             if result.result.is_successful() {
-                                CodeDiffState::Accepted(None)
+                                CodeDiffState::Accepted
                             } else {
                                 // For other finished states, default to rejected
                                 CodeDiffState::Rejected

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -72,7 +72,7 @@ use super::action_model::{AIActionStatus, BlocklistAIActionEvent, RequestFileEdi
 use super::code_block::CodeSnippetButtonHandles;
 use super::controller::ClientIdentifiers;
 use super::inline_action::code_diff_view::{
-    CodeDiffState, CodeDiffView, CodeDiffViewAction, CodeDiffViewEvent, GuiDiffStorage,
+    CodeDiffState, CodeDiffView, CodeDiffViewAction, CodeDiffViewEvent,
 };
 use super::inline_action::requested_action::{CTRL_C_KEYSTROKE, ENTER_KEYSTROKE};
 use super::inline_action::requested_command_attribution::is_command_copied_from_document;
@@ -3180,13 +3180,16 @@ impl AIBlock {
                 diff_view.set_candidate_diffs(file_diffs, ctx);
             });
         } else {
-            // Register the review view as the action's diff storage. The
-            // executor seeds it with diffs when preprocess resolves — or
-            // immediately, taking them over from the headless placeholder, if
-            // they already have.
-            let storage = Box::new(GuiDiffStorage(view.downgrade()));
-            executor.update(ctx, |executor, ctx| {
-                executor.register_requested_edits(action_id, storage, ctx);
+            // Register the review view as the action's diff storage: the
+            // executor seeds it with the resolved diffs when preprocess
+            // completes and drives its save at execute time.
+            //
+            // View-only (shared-session viewer) diffs must not be registered:
+            // registration wires the view into the persistence flow, and a
+            // spectator's view must never become the surface that writes the
+            // edits to disk.
+            executor.update(ctx, |executor, _| {
+                executor.register_requested_edits(action_id, Box::new(view.downgrade()));
             });
         }
 
@@ -3195,7 +3198,7 @@ impl AIBlock {
             match event {
                 CodeDiffViewEvent::TryAccept => {
                     // The executor drives the save through the registered
-                    // `GuiDiffStorage` at execute time, pulling the (possibly
+                    // diff storage at execute time, pulling the (possibly
                     // edited) final content from the view's editor buffers.
                     view.update(ctx, |view, ctx| view.send_malformed_line_telemetry(ctx));
                     me.action_model.update(ctx, |action_model, ctx| {

--- a/app/src/ai/blocklist/diff_storage.rs
+++ b/app/src/ai/blocklist/diff_storage.rs
@@ -3,12 +3,12 @@
 //!
 //! Every surface that stores pending diffs — the GUI `CodeDiffView` and the
 //! up-stack TUI diff storage — implements [`DiffStorage`], a required-methods-
-//! only contract: state accessors plus the surface-specific write kickoff.
-//! The shared save-completion flow is [`DiffStorageHelper`], blanket-implemented
-//! for every `DiffStorage` so no surface can override it: it tracks per-file
-//! progress in a [`DiffSaveState`] and assembles the final
-//! [`RequestFileEditsResult`], so every surface produces results through the
-//! same code.
+//! only contract: an accept-time snapshot of per-file state plus the
+//! surface-specific write kickoff. The shared save-completion flow is
+//! [`DiffStorageHelper`], blanket-implemented for every `DiffStorage` so no
+//! surface can override it: it joins the per-file save futures, computes each
+//! file's result diff, and assembles the final [`RequestFileEditsResult`], so
+//! every surface produces results through the same code.
 //!
 //! The executor knows surfaces only through [`RegisteredDiffStorage`], a small
 //! object-safe handle trait, because GUI `ViewHandle`s and model `ModelHandle`s
@@ -19,12 +19,12 @@
 //! storage.
 use std::collections::HashMap;
 use std::ops::Range;
-use std::rc::Rc;
+use std::sync::Arc;
 
-use futures::channel::oneshot;
-use futures::future::BoxFuture;
+use futures::future::{join_all, BoxFuture};
 use futures::FutureExt;
 use itertools::Itertools;
+use warp_editor::multiline::{AnyMultilineString, MultilineString, LF};
 use warp_util::file::FileSaveError;
 use warpui::AppContext;
 
@@ -32,162 +32,83 @@ use crate::ai::agent::{
     AnyFileContent, FileContext, FileLocations, RequestFileEditsResult, UpdatedFileContext,
 };
 use crate::ai::blocklist::diff_types::{DiffSessionType, FileDiff};
+use crate::code::editor::compute_unified_diff;
 use crate::code::DiffResult;
 
 const APPLY_DIFF_RESULT_CONTEXT_LINES: usize = 10;
 
+/// Resolves with the outcome of one file's dispatched save.
+pub type SaveFuture = BoxFuture<'static, Result<(), Arc<FileSaveError>>>;
+
 /// A surface that stores pending file-edit diffs and persists them on accept.
 ///
 /// This trait is only ever implemented, never imported for its methods: every
-/// method is required — state accessors (the fields live on each impl, since
-/// traits cannot hold state) plus the surface-specific write kickoff
-/// ([`Self::start_saving`]). The shared save-completion flow lives on
+/// method is required — the accept-time snapshot (the fields live on each
+/// impl, since traits cannot hold state) plus the surface-specific write
+/// kickoff ([`Self::start_saving`]). The shared save-completion flow lives on
 /// [`DiffStorageHelper`]; callers drive an accept solely through
 /// [`DiffStorageHelper::accept_and_save`].
 pub trait DiffStorage {
-    /// The in-flight accept's progress and result channel. Impls just store a
-    /// [`DiffSaveState`]; only the [`DiffStorageHelper`] flow acts on it.
-    fn save_state_mut(&mut self) -> &mut DiffSaveState;
+    /// Snapshot of per-file state for result assembly, captured as the accept
+    /// kicks off: reported paths, changed lines, contents, and user-edit
+    /// flags. Snapshotting at kickoff means the result reports exactly the
+    /// content handed to [`Self::start_saving`].
+    fn snapshot_pending_files(&self, app: &AppContext) -> Vec<FileSnapshot>;
 
-    /// Number of pending file diffs; sizes the per-file save tracking.
-    fn pending_diff_count(&self) -> usize;
-
-    /// Snapshot of per-file state for result assembly: reported paths, changed
-    /// lines, final contents, and user-edit flags.
-    fn pending_file_state(&self, app: &AppContext) -> Vec<PendingFileState>;
-
-    /// Kicks off persistence for every pending file.
+    /// Kicks off persistence for every pending file, returning each
+    /// dispatched save's completion future.
     ///
     /// The surface-specific hook invoked by
     /// [`DiffStorageHelper::accept_and_save`] — never called directly by
     /// callers. The GUI saves through its editor buffers; surfaces without
-    /// editor buffers dispatch writes to `FileModel`. Each file's completion
-    /// must be reported back through [`DiffStorageHelper::handle_file_saved`]
-    /// and [`DiffStorageHelper::handle_diff_computed`].
-    fn start_saving(&mut self, app: &mut AppContext);
+    /// editor buffers dispatch writes to `FileModel`.
+    fn start_saving(&mut self, app: &mut AppContext) -> Vec<SaveFuture>;
 }
 
 /// The shared save-completion flow over an impl of [`DiffStorage`].
 ///
-/// These are defined within a separate trait rather than default
-/// implementations of `DiffStorage` so implementations cannot errantly
-/// override them (the same convention as `AIBlockModelHelper`).
+/// Defined within a separate trait rather than a default implementation of
+/// `DiffStorage` so implementations cannot errantly override it (the same
+/// convention as `AIBlockModelHelper`).
 pub trait DiffStorageHelper {
-    /// The entry point for accepting a surface's diffs: persists them all,
-    /// resolving with the assembled result once every file's save and
-    /// result-diff computation completes.
-    ///
-    /// Dropping the surface mid-save drops the stored sender, resolving the
-    /// returned future with [`RequestFileEditsResult::Cancelled`].
+    /// The entry point for accepting a surface's diffs: snapshots per-file
+    /// state, persists every file, and resolves with the assembled result
+    /// once every save completes.
     fn accept_and_save(
         &mut self,
         app: &mut AppContext,
     ) -> BoxFuture<'static, RequestFileEditsResult>;
-
-    /// Records one file's save completion (or failure).
-    fn handle_file_saved(&mut self, idx: usize, error: Option<Rc<FileSaveError>>, app: &AppContext);
-
-    /// Records one file's computed result diff.
-    fn handle_diff_computed(&mut self, idx: usize, diff: Rc<DiffResult>, app: &AppContext);
 }
 
-// Each flow method ends by assembling and delivering the result once every
-// file is saved and its result diff computed (`DiffSaveState::is_complete`).
 impl<T: DiffStorage> DiffStorageHelper for T {
     fn accept_and_save(
         &mut self,
         app: &mut AppContext,
     ) -> BoxFuture<'static, RequestFileEditsResult> {
-        let count = self.pending_diff_count();
-        let result = self.save_state_mut().begin(count);
-        self.start_saving(app);
-        // Zero-file accepts are already complete.
-        if self.save_state_mut().is_complete() {
-            let files = self.pending_file_state(app);
-            self.save_state_mut().finish(files);
+        let files = self.snapshot_pending_files(app);
+        let saves = self.start_saving(app);
+        async move {
+            let save_errors = join_all(saves)
+                .await
+                .into_iter()
+                .filter_map(Result::err)
+                .collect_vec();
+            if !save_errors.is_empty() {
+                return save_failure_result(&save_errors);
+            }
+
+            let mut combined = DiffResult::default();
+            for file in &files {
+                let base: MultilineString<LF> =
+                    AnyMultilineString::infer(file.diff_base.clone()).to_format();
+                let new: MultilineString<LF> =
+                    AnyMultilineString::infer(file.diff_new.clone()).to_format();
+                combined +=
+                    &compute_unified_diff(base.as_ref(), new.as_ref(), &file.diff_name).await;
+            }
+            assemble_result(combined, files)
         }
-        result
-    }
-
-    fn handle_file_saved(
-        &mut self,
-        idx: usize,
-        error: Option<Rc<FileSaveError>>,
-        app: &AppContext,
-    ) {
-        self.save_state_mut().mark_diff_saved(idx, error);
-        if self.save_state_mut().is_complete() {
-            let files = self.pending_file_state(app);
-            self.save_state_mut().finish(files);
-        }
-    }
-
-    fn handle_diff_computed(&mut self, idx: usize, diff: Rc<DiffResult>, app: &AppContext) {
-        self.save_state_mut().mark_diff_computed(idx, diff);
-        if self.save_state_mut().is_complete() {
-            let files = self.pending_file_state(app);
-            self.save_state_mut().finish(files);
-        }
-    }
-}
-
-/// Progress and result delivery for one in-flight accept.
-///
-/// Each [`DiffStorage`] impl stores one of these and exposes it via
-/// [`DiffStorage::save_state_mut`]; the [`DiffStorageHelper`] flow drives it.
-#[derive(Default)]
-pub struct DiffSaveState {
-    /// Per-file save/diff-computation tracking; `Some` while an accept is in flight.
-    saving: Option<SavingDiffs>,
-    /// Delivery channel for the in-flight accept's result.
-    result_tx: Option<oneshot::Sender<RequestFileEditsResult>>,
-}
-
-impl DiffSaveState {
-    /// Starts tracking an accept over `count` files, returning the future that
-    /// resolves with the delivered result.
-    fn begin(&mut self, count: usize) -> BoxFuture<'static, RequestFileEditsResult> {
-        let (tx, rx) = oneshot::channel();
-        self.result_tx = Some(tx);
-        self.saving = Some(SavingDiffs::new(count));
-        async move { rx.await.unwrap_or(RequestFileEditsResult::Cancelled) }.boxed()
-    }
-
-    /// True while an accept is being persisted.
-    pub fn is_saving(&self) -> bool {
-        self.saving.is_some()
-    }
-
-    /// Records the save outcome for the file at `idx`.
-    fn mark_diff_saved(&mut self, idx: usize, error: Option<Rc<FileSaveError>>) {
-        if let Some(saving) = &mut self.saving {
-            saving.mark_diff_saved(idx, error);
-        }
-    }
-
-    /// Records the computed result diff for the file at `idx`.
-    fn mark_diff_computed(&mut self, idx: usize, diff: Rc<DiffResult>) {
-        if let Some(saving) = &mut self.saving {
-            saving.mark_diff_computed(idx, diff);
-        }
-    }
-
-    /// True once every file is saved and its result diff computed.
-    fn is_complete(&self) -> bool {
-        self.saving
-            .as_ref()
-            .is_some_and(SavingDiffs::pending_diff_is_complete)
-    }
-
-    /// Delivers the assembled result and clears the in-flight state.
-    fn finish(&mut self, files: Vec<PendingFileState>) {
-        let Some(saving) = self.saving.take() else {
-            return;
-        };
-        let Some(tx) = self.result_tx.take() else {
-            return;
-        };
-        let _ = tx.send(assemble_result(saving, files));
+        .boxed()
     }
 }
 
@@ -211,92 +132,20 @@ pub trait RegisteredDiffStorage {
     fn accept_and_save(&self, app: &mut AppContext) -> BoxFuture<'static, RequestFileEditsResult>;
 }
 
-/// Per-file progress for one accepted edit.
-///
-/// Saving and result-diff computation complete independently per file; the
-/// accept finishes when every file has both.
-#[derive(Clone, Debug)]
-struct SavingDiffs {
-    pending_diffs: Vec<DiffApplicationState>,
-}
-
-impl SavingDiffs {
-    /// Initializes tracking for `length` files.
-    fn new(length: usize) -> Self {
-        Self {
-            pending_diffs: vec![DiffApplicationState::default(); length],
-        }
-    }
-
-    /// Returns true once every file is saved and its result diff computed.
-    fn pending_diff_is_complete(&self) -> bool {
-        self.pending_diffs
-            .iter()
-            .all(|diff| diff.computed_diff.is_some() && diff.save_status.is_complete())
-    }
-
-    /// Records the save outcome for the file at `idx`.
-    fn mark_diff_saved(&mut self, idx: usize, save_error: Option<Rc<FileSaveError>>) {
-        if let Some(state) = self.pending_diffs.get_mut(idx) {
-            state.save_status = match save_error {
-                None => SaveStatus::Success,
-                Some(error) => SaveStatus::Failed(error),
-            };
-        }
-    }
-
-    /// Records the computed result diff for the file at `idx`.
-    fn mark_diff_computed(&mut self, idx: usize, diff: Rc<DiffResult>) {
-        if let Some(state) = self.pending_diffs.get_mut(idx) {
-            state.computed_diff = Some(diff);
-        }
-    }
-
-    /// Splits into the combined result diff and any save errors.
-    fn into_parts(self) -> (DiffResult, Vec<Rc<FileSaveError>>) {
-        let mut combined = DiffResult::default();
-        let mut save_errors = Vec::new();
-        for state in self.pending_diffs {
-            if let Some(diff) = state.computed_diff {
-                combined += diff.as_ref();
-            }
-            if let SaveStatus::Failed(error) = state.save_status {
-                save_errors.push(error);
-            }
-        }
-        (combined, save_errors)
-    }
-}
-
-/// The status of saving a single file.
-#[derive(Clone, Debug, Default)]
-enum SaveStatus {
-    #[default]
-    Pending,
-    Success,
-    Failed(Rc<FileSaveError>),
-}
-
-impl SaveStatus {
-    fn is_complete(&self) -> bool {
-        !matches!(self, SaveStatus::Pending)
-    }
-}
-
-/// The save/diff-computation state for a single file.
-#[derive(Clone, Debug, Default)]
-struct DiffApplicationState {
-    computed_diff: Option<Rc<DiffResult>>,
-    save_status: SaveStatus,
-}
-
-/// One file's contribution to the assembled result.
+/// One file's contribution to the assembled result, snapshotted at accept
+/// time.
 #[derive(Clone)]
-pub struct PendingFileState {
+pub struct FileSnapshot {
     /// The updated file, reported at its final path; `None` for deletions.
     pub updated: Option<UpdatedFileState>,
     /// Paths reported as deleted (the deleted file, or a rename's source path).
     pub deleted_paths: Vec<String>,
+    /// Base content the result diff is computed against.
+    pub diff_base: String,
+    /// Final content the result diff is computed from.
+    pub diff_new: String,
+    /// Path used for the result diff's header.
+    pub diff_name: String,
 }
 
 /// Report state for a created or updated file.
@@ -312,23 +161,23 @@ pub struct UpdatedFileState {
     pub was_edited: bool,
 }
 
-/// Combines per-file progress and report state into one
-/// [`RequestFileEditsResult`], failing the whole edit if any file failed to save.
-fn assemble_result(saving: SavingDiffs, files: Vec<PendingFileState>) -> RequestFileEditsResult {
-    let (combined, save_errors) = saving.into_parts();
-    if !save_errors.is_empty() {
-        let error = save_errors
-            .iter()
-            .map(|error| match error.as_ref() {
-                FileSaveError::IOError { error, path } => {
-                    format!("Failed to save file {path:?}: {error}")
-                }
-                other => other.to_string(),
-            })
-            .join("\n");
-        return RequestFileEditsResult::DiffApplicationFailed { error };
-    }
+/// Fails the whole edit when any file failed to save.
+fn save_failure_result(errors: &[Arc<FileSaveError>]) -> RequestFileEditsResult {
+    let error = errors
+        .iter()
+        .map(|error| match error.as_ref() {
+            FileSaveError::IOError { error, path } => {
+                format!("Failed to save file {path:?}: {error}")
+            }
+            other => other.to_string(),
+        })
+        .join("\n");
+    RequestFileEditsResult::DiffApplicationFailed { error }
+}
 
+/// Combines per-file report state and the combined result diff into one
+/// [`RequestFileEditsResult`].
+fn assemble_result(combined: DiffResult, files: Vec<FileSnapshot>) -> RequestFileEditsResult {
     let mut updated_files = Vec::new();
     let mut deleted_files = Vec::new();
     let mut content_map: HashMap<String, String> = HashMap::new();

--- a/app/src/ai/blocklist/diff_storage.rs
+++ b/app/src/ai/blocklist/diff_storage.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use futures::future::{join_all, BoxFuture};
 use futures::FutureExt;
 use itertools::Itertools;
-use warp_editor::multiline::{AnyMultilineString, MultilineString, LF};
+use warp_editor::multiline::AnyMultilineString;
 use warp_util::file::FileSaveError;
 use warpui::AppContext;
 
@@ -99,12 +99,14 @@ impl<T: DiffStorage> DiffStorageHelper for T {
 
             let mut combined = DiffResult::default();
             for file in &files {
-                let base: MultilineString<LF> =
-                    AnyMultilineString::infer(file.diff_base.clone()).to_format();
-                let new: MultilineString<LF> =
-                    AnyMultilineString::infer(file.diff_new.clone()).to_format();
-                combined +=
-                    &compute_unified_diff(base.as_ref(), new.as_ref(), &file.diff_name).await;
+                let base = AnyMultilineString::infer(file.diff_base.clone());
+                let new = AnyMultilineString::infer(file.diff_new.clone());
+                combined += &compute_unified_diff(
+                    base.to_format().as_ref(),
+                    new.to_format().as_ref(),
+                    &file.diff_name,
+                )
+                .await;
             }
             assemble_result(combined, files)
         }

--- a/app/src/ai/blocklist/diff_storage.rs
+++ b/app/src/ai/blocklist/diff_storage.rs
@@ -2,17 +2,17 @@
 //! diffs.
 //!
 //! Every surface that stores pending diffs — the GUI `CodeDiffView` and the
-//! up-stack TUI diff storage — implements [`DiffStorageView`]. The trait's
+//! up-stack TUI diff storage — implements [`DiffStorage`]. The trait's
 //! provided methods are the shared save-completion flow: they track per-file
 //! progress in a [`DiffSaveState`] and assemble the final
 //! [`RequestFileEditsResult`], so every surface produces results through the
-//! same code. Only the write kickoff ([`DiffStorageView::start_saving`]) is
+//! same code. Only the write kickoff ([`DiffStorage::start_saving`]) is
 //! surface-specific: the GUI saves through its editor buffers.
 //!
 //! The executor knows surfaces only through [`RegisteredDiffStorage`], a small
 //! object-safe handle trait, because GUI `ViewHandle`s and model `ModelHandle`s
 //! share no common handle type. Each surface's handle type implements it
-//! directly, delegating to the entity's [`DiffStorageView`]. Every surface must
+//! directly, delegating to the entity's [`DiffStorage`]. Every surface must
 //! register its storage before the action's diffs resolve
 //! (`register_requested_edits`); preprocess and execute assume a registered
 //! storage.
@@ -42,7 +42,7 @@ const APPLY_DIFF_RESULT_CONTEXT_LINES: usize = 10;
 /// ([`Self::start_saving`]). Provided methods are the shared save-completion
 /// flow, so every surface assembles its [`RequestFileEditsResult`] through the
 /// same code. Callers drive an accept solely through [`Self::accept_and_save`].
-pub trait DiffStorageView {
+pub trait DiffStorage {
     /// The in-flight accept's progress and result channel. Impls just store a
     /// [`DiffSaveState`]; only the provided methods below act on it.
     fn save_state_mut(&mut self) -> &mut DiffSaveState;
@@ -109,8 +109,8 @@ pub trait DiffStorageView {
 
 /// Progress and result delivery for one in-flight accept.
 ///
-/// Each [`DiffStorageView`] impl stores one of these and exposes it via
-/// [`DiffStorageView::save_state_mut`]; the trait's provided methods drive it.
+/// Each [`DiffStorage`] impl stores one of these and exposes it via
+/// [`DiffStorage::save_state_mut`]; the trait's provided methods drive it.
 #[derive(Default)]
 pub struct DiffSaveState {
     /// Per-file save/diff-computation tracking; `Some` while an accept is in flight.
@@ -167,13 +167,13 @@ impl DiffSaveState {
     }
 }
 
-/// The executor-facing handle over a registered [`DiffStorageView`] surface.
+/// The executor-facing handle over a registered [`DiffStorage`] surface.
 ///
-/// A separate trait from [`DiffStorageView`] because the executor holds
+/// A separate trait from [`DiffStorage`] because the executor holds
 /// surfaces by handle, and GUI view handles and model handles share no common
 /// type. Each surface's handle type (e.g. `WeakViewHandle<CodeDiffView>`)
 /// implements this directly, delegating each call to its entity's
-/// [`DiffStorageView`].
+/// [`DiffStorage`].
 pub trait RegisteredDiffStorage {
     /// Pushes resolved diffs into the surface (called when preprocess resolves).
     fn set_candidate_diffs(

--- a/app/src/ai/blocklist/diff_storage.rs
+++ b/app/src/ai/blocklist/diff_storage.rs
@@ -2,18 +2,19 @@
 //! diffs.
 //!
 //! Every surface that stores pending diffs — the GUI `CodeDiffView` and the
-//! up-stack TUI diff storage — implements [`DiffStorage`]. The trait's
-//! provided methods are the shared save-completion flow: they track per-file
-//! progress in a [`DiffSaveState`] and assemble the final
+//! up-stack TUI diff storage — implements [`DiffStorage`], a required-methods-
+//! only contract: state accessors plus the surface-specific write kickoff.
+//! The shared save-completion flow is [`DiffStorageHelper`], blanket-implemented
+//! for every `DiffStorage` so no surface can override it: it tracks per-file
+//! progress in a [`DiffSaveState`] and assembles the final
 //! [`RequestFileEditsResult`], so every surface produces results through the
-//! same code. Only the write kickoff ([`DiffStorage::start_saving`]) is
-//! surface-specific: the GUI saves through its editor buffers.
+//! same code.
 //!
 //! The executor knows surfaces only through [`RegisteredDiffStorage`], a small
 //! object-safe handle trait, because GUI `ViewHandle`s and model `ModelHandle`s
 //! share no common handle type. Each surface's handle type implements it
-//! directly, delegating to the entity's [`DiffStorage`]. Every surface must
-//! register its storage before the action's diffs resolve
+//! directly, delegating to its entity's [`DiffStorageHelper`] flow. Every
+//! surface must register its storage before the action's diffs resolve
 //! (`register_requested_edits`); preprocess and execute assume a registered
 //! storage.
 use std::collections::HashMap;
@@ -37,14 +38,15 @@ const APPLY_DIFF_RESULT_CONTEXT_LINES: usize = 10;
 
 /// A surface that stores pending file-edit diffs and persists them on accept.
 ///
-/// Required methods are state accessors (the fields live on each impl, since
+/// This trait is only ever implemented, never imported for its methods: every
+/// method is required — state accessors (the fields live on each impl, since
 /// traits cannot hold state) plus the surface-specific write kickoff
-/// ([`Self::start_saving`]). Provided methods are the shared save-completion
-/// flow, so every surface assembles its [`RequestFileEditsResult`] through the
-/// same code. Callers drive an accept solely through [`Self::accept_and_save`].
+/// ([`Self::start_saving`]). The shared save-completion flow lives on
+/// [`DiffStorageHelper`]; callers drive an accept solely through
+/// [`DiffStorageHelper::accept_and_save`].
 pub trait DiffStorage {
     /// The in-flight accept's progress and result channel. Impls just store a
-    /// [`DiffSaveState`]; only the provided methods below act on it.
+    /// [`DiffSaveState`]; only the [`DiffStorageHelper`] flow acts on it.
     fn save_state_mut(&mut self) -> &mut DiffSaveState;
 
     /// Number of pending file diffs; sizes the per-file save tracking.
@@ -56,13 +58,21 @@ pub trait DiffStorage {
 
     /// Kicks off persistence for every pending file.
     ///
-    /// The surface-specific hook invoked by [`Self::accept_and_save`] — never
-    /// called directly by callers. The GUI saves through its editor buffers;
-    /// surfaces without editor buffers dispatch writes to `FileModel`. Each
-    /// file's completion must be reported back through
-    /// [`Self::handle_file_saved`] and [`Self::handle_diff_computed`].
+    /// The surface-specific hook invoked by
+    /// [`DiffStorageHelper::accept_and_save`] — never called directly by
+    /// callers. The GUI saves through its editor buffers; surfaces without
+    /// editor buffers dispatch writes to `FileModel`. Each file's completion
+    /// must be reported back through [`DiffStorageHelper::handle_file_saved`]
+    /// and [`DiffStorageHelper::handle_diff_computed`].
     fn start_saving(&mut self, app: &mut AppContext);
+}
 
+/// The shared save-completion flow over an impl of [`DiffStorage`].
+///
+/// These are defined within a separate trait rather than default
+/// implementations of `DiffStorage` so implementations cannot errantly
+/// override them (the same convention as `AIBlockModelHelper`).
+pub trait DiffStorageHelper {
     /// The entry point for accepting a surface's diffs: persists them all,
     /// resolving with the assembled result once every file's save and
     /// result-diff computation completes.
@@ -72,15 +82,33 @@ pub trait DiffStorage {
     fn accept_and_save(
         &mut self,
         app: &mut AppContext,
+    ) -> BoxFuture<'static, RequestFileEditsResult>;
+
+    /// Records one file's save completion (or failure).
+    fn handle_file_saved(&mut self, idx: usize, error: Option<Rc<FileSaveError>>, app: &AppContext);
+
+    /// Records one file's computed result diff.
+    fn handle_diff_computed(&mut self, idx: usize, diff: Rc<DiffResult>, app: &AppContext);
+}
+
+// Each flow method ends by assembling and delivering the result once every
+// file is saved and its result diff computed (`DiffSaveState::is_complete`).
+impl<T: DiffStorage> DiffStorageHelper for T {
+    fn accept_and_save(
+        &mut self,
+        app: &mut AppContext,
     ) -> BoxFuture<'static, RequestFileEditsResult> {
         let count = self.pending_diff_count();
         let result = self.save_state_mut().begin(count);
         self.start_saving(app);
-        self.try_finish(app);
+        // Zero-file accepts are already complete.
+        if self.save_state_mut().is_complete() {
+            let files = self.pending_file_state(app);
+            self.save_state_mut().finish(files);
+        }
         result
     }
 
-    /// Records one file's save completion (or failure).
     fn handle_file_saved(
         &mut self,
         idx: usize,
@@ -88,29 +116,25 @@ pub trait DiffStorage {
         app: &AppContext,
     ) {
         self.save_state_mut().mark_diff_saved(idx, error);
-        self.try_finish(app);
+        if self.save_state_mut().is_complete() {
+            let files = self.pending_file_state(app);
+            self.save_state_mut().finish(files);
+        }
     }
 
-    /// Records one file's computed result diff.
     fn handle_diff_computed(&mut self, idx: usize, diff: Rc<DiffResult>, app: &AppContext) {
         self.save_state_mut().mark_diff_computed(idx, diff);
-        self.try_finish(app);
-    }
-
-    /// Assembles and delivers the result once every file is saved and computed.
-    fn try_finish(&mut self, app: &AppContext) {
-        if !self.save_state_mut().is_complete() {
-            return;
+        if self.save_state_mut().is_complete() {
+            let files = self.pending_file_state(app);
+            self.save_state_mut().finish(files);
         }
-        let files = self.pending_file_state(app);
-        self.save_state_mut().finish(files);
     }
 }
 
 /// Progress and result delivery for one in-flight accept.
 ///
 /// Each [`DiffStorage`] impl stores one of these and exposes it via
-/// [`DiffStorage::save_state_mut`]; the trait's provided methods drive it.
+/// [`DiffStorage::save_state_mut`]; the [`DiffStorageHelper`] flow drives it.
 #[derive(Default)]
 pub struct DiffSaveState {
     /// Per-file save/diff-computation tracking; `Some` while an accept is in flight.
@@ -173,7 +197,7 @@ impl DiffSaveState {
 /// surfaces by handle, and GUI view handles and model handles share no common
 /// type. Each surface's handle type (e.g. `WeakViewHandle<CodeDiffView>`)
 /// implements this directly, delegating each call to its entity's
-/// [`DiffStorage`].
+/// [`DiffStorageHelper`] flow.
 pub trait RegisteredDiffStorage {
     /// Pushes resolved diffs into the surface (called when preprocess resolves).
     fn set_candidate_diffs(

--- a/app/src/ai/blocklist/diff_storage.rs
+++ b/app/src/ai/blocklist/diff_storage.rs
@@ -1,0 +1,775 @@
+//! Surface-owned storage and the shared persistence flow for `RequestFileEdits`
+//! diffs.
+//!
+//! Every surface that stores pending diffs — the GUI `CodeDiffView`, the TUI
+//! diff view, and the headless fallback below — implements [`DiffStorageView`].
+//! The trait's provided methods are the shared save-completion flow: they track
+//! per-file progress in [`SavingDiffs`] and assemble the final
+//! [`RequestFileEditsResult`], so every surface produces results through the
+//! same code. Only the write kickoff ([`DiffStorageView::start_saving`]) is
+//! surface-specific: the GUI saves through its editor buffers, while headless
+//! surfaces dispatch to `FileModel` via the helpers in this module.
+//!
+//! The executor knows surfaces only through [`RegisteredDiffStorage`], a small
+//! object-safe handle trait, because GUI `ViewHandle`s and model `ModelHandle`s
+//! share no common handle type.
+use std::collections::HashMap;
+use std::ops::Range;
+use std::rc::Rc;
+
+use ai::diff_validation::{DiffDelta, DiffType};
+use futures::channel::oneshot;
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use itertools::Itertools;
+use warp_util::file::FileSaveError;
+use warpui::{AppContext, Entity, ModelContext, ModelHandle};
+#[cfg(not(target_family = "wasm"))]
+use {
+    similar::{DiffOp, TextDiff},
+    std::path::{Path, PathBuf},
+    warp_files::{FileModel, FileModelEvent},
+    warp_util::content_version::ContentVersion,
+    warp_util::file::FileId,
+    warp_util::standardized_path::StandardizedPath,
+    warpui::SingletonEntity,
+};
+
+use crate::ai::agent::{
+    AnyFileContent, FileContext, FileLocations, RequestFileEditsResult, UpdatedFileContext,
+};
+use crate::ai::blocklist::diff_types::{changed_lines_from_op, DiffSessionType, FileDiff};
+use crate::code::DiffResult;
+
+const APPLY_DIFF_RESULT_CONTEXT_LINES: usize = 10;
+
+/// A surface that stores pending file-edit diffs and persists them on accept.
+///
+/// Required methods are state accessors (the fields live on each impl, since
+/// traits cannot hold state) plus the surface-specific write kickoff. Provided
+/// methods are the shared save-completion flow, so every surface assembles its
+/// [`RequestFileEditsResult`] through the same code.
+pub trait DiffStorageView {
+    /// Per-file save/diff-computation tracking for the in-flight accept.
+    fn saving_diffs_mut(&mut self) -> &mut Option<SavingDiffs>;
+
+    /// Delivery channel for the in-flight accept's result.
+    fn result_tx_mut(&mut self) -> &mut Option<oneshot::Sender<RequestFileEditsResult>>;
+
+    /// Number of pending file diffs; sizes [`SavingDiffs`].
+    fn pending_diff_count(&self) -> usize;
+
+    /// Snapshot of per-file state for result assembly: reported paths, changed
+    /// lines, final contents, and user-edit flags.
+    fn pending_file_state(&self, app: &AppContext) -> Vec<PendingFileState>;
+
+    /// Kicks off persistence for every pending file.
+    ///
+    /// Surface-specific: the GUI saves through its editor buffers; headless
+    /// surfaces dispatch via [`dispatch_write`]. Each file's completion must be
+    /// reported back through [`Self::handle_file_saved`] and
+    /// [`Self::handle_diff_computed`].
+    fn start_saving(&mut self, app: &mut AppContext);
+
+    /// Persists all pending diffs, resolving with the assembled result once
+    /// every file's save and result-diff computation completes.
+    ///
+    /// Dropping the surface mid-save drops the stored sender, resolving the
+    /// returned future with [`RequestFileEditsResult::Cancelled`].
+    fn accept_and_save(
+        &mut self,
+        app: &mut AppContext,
+    ) -> BoxFuture<'static, RequestFileEditsResult> {
+        let (tx, rx) = oneshot::channel();
+        *self.result_tx_mut() = Some(tx);
+        *self.saving_diffs_mut() = Some(SavingDiffs::new(self.pending_diff_count()));
+        self.start_saving(app);
+        self.try_finish(app);
+        async move { rx.await.unwrap_or(RequestFileEditsResult::Cancelled) }.boxed()
+    }
+
+    /// Records one file's save completion (or failure).
+    fn handle_file_saved(
+        &mut self,
+        idx: usize,
+        error: Option<Rc<FileSaveError>>,
+        app: &AppContext,
+    ) {
+        if let Some(saving) = self.saving_diffs_mut() {
+            saving.mark_diff_saved(idx, error);
+        }
+        self.try_finish(app);
+    }
+
+    /// Records one file's computed result diff.
+    fn handle_diff_computed(&mut self, idx: usize, diff: Rc<DiffResult>, app: &AppContext) {
+        if let Some(saving) = self.saving_diffs_mut() {
+            saving.mark_diff_computed(idx, diff);
+        }
+        self.try_finish(app);
+    }
+
+    /// Fails the in-flight accept outright (e.g. the surface cannot save at all).
+    fn fail_saving(&mut self, error: String) {
+        *self.saving_diffs_mut() = None;
+        if let Some(tx) = self.result_tx_mut().take() {
+            let _ = tx.send(RequestFileEditsResult::DiffApplicationFailed { error });
+        }
+    }
+
+    /// Assembles and delivers the result once every file is saved and computed.
+    fn try_finish(&mut self, app: &AppContext) {
+        let complete = self
+            .saving_diffs_mut()
+            .as_ref()
+            .is_some_and(SavingDiffs::pending_diff_is_complete);
+        if !complete {
+            return;
+        }
+        let saving = self
+            .saving_diffs_mut()
+            .take()
+            .expect("checked complete above");
+        let Some(tx) = self.result_tx_mut().take() else {
+            return;
+        };
+        let files = self.pending_file_state(app);
+        let _ = tx.send(assemble_result(saving, files));
+    }
+}
+
+/// The executor-facing handle over a registered [`DiffStorageView`] surface.
+///
+/// GUI views and models share no common handle type, so each surface registers
+/// a thin wrapper that delegates through its own handle.
+pub trait RegisteredDiffStorage {
+    /// Pushes resolved diffs into the surface (called when preprocess resolves).
+    fn set_candidate_diffs(
+        &self,
+        diffs: Vec<FileDiff>,
+        session_type: DiffSessionType,
+        app: &mut AppContext,
+    );
+
+    /// Hands the diffs back out so a newly registered surface can take over.
+    /// Returns `None` if this storage keeps ownership (e.g. saving started).
+    fn take_candidate_diffs(
+        &self,
+        app: &mut AppContext,
+    ) -> Option<(Vec<FileDiff>, DiffSessionType)>;
+
+    /// Persists all diffs, resolving with the result reported to the LLM.
+    fn accept_and_save(&self, app: &mut AppContext) -> BoxFuture<'static, RequestFileEditsResult>;
+}
+
+/// Per-file progress for one accepted edit.
+///
+/// Saving and result-diff computation complete independently per file; the
+/// accept finishes when every file has both.
+#[derive(Clone, Debug)]
+pub struct SavingDiffs {
+    pending_diffs: Vec<DiffApplicationState>,
+}
+
+impl SavingDiffs {
+    /// Initializes tracking for `length` files.
+    fn new(length: usize) -> Self {
+        Self {
+            pending_diffs: vec![DiffApplicationState::default(); length],
+        }
+    }
+
+    /// Returns true once every file is saved and its result diff computed.
+    fn pending_diff_is_complete(&self) -> bool {
+        self.pending_diffs
+            .iter()
+            .all(|diff| diff.computed_diff.is_some() && diff.save_status.is_complete())
+    }
+
+    /// Records the save outcome for the file at `idx`.
+    fn mark_diff_saved(&mut self, idx: usize, save_error: Option<Rc<FileSaveError>>) {
+        if let Some(state) = self.pending_diffs.get_mut(idx) {
+            state.save_status = match save_error {
+                None => SaveStatus::Success,
+                Some(error) => SaveStatus::Failed(error),
+            };
+        }
+    }
+
+    /// Records the computed result diff for the file at `idx`.
+    fn mark_diff_computed(&mut self, idx: usize, diff: Rc<DiffResult>) {
+        if let Some(state) = self.pending_diffs.get_mut(idx) {
+            state.computed_diff = Some(diff);
+        }
+    }
+
+    /// Splits into the combined result diff and any save errors.
+    fn into_parts(self) -> (DiffResult, Vec<Rc<FileSaveError>>) {
+        let mut combined = DiffResult::default();
+        let mut save_errors = Vec::new();
+        for state in self.pending_diffs {
+            if let Some(diff) = state.computed_diff {
+                combined += diff.as_ref();
+            }
+            if let SaveStatus::Failed(error) = state.save_status {
+                save_errors.push(error);
+            }
+        }
+        (combined, save_errors)
+    }
+}
+
+/// The status of saving a single file.
+#[derive(Clone, Debug, Default)]
+enum SaveStatus {
+    #[default]
+    Pending,
+    Success,
+    Failed(Rc<FileSaveError>),
+}
+
+impl SaveStatus {
+    fn is_complete(&self) -> bool {
+        !matches!(self, SaveStatus::Pending)
+    }
+}
+
+/// The save/diff-computation state for a single file.
+#[derive(Clone, Debug, Default)]
+struct DiffApplicationState {
+    computed_diff: Option<Rc<DiffResult>>,
+    save_status: SaveStatus,
+}
+
+/// One file's contribution to the assembled result.
+#[derive(Clone)]
+pub struct PendingFileState {
+    /// The updated file, reported at its final path; `None` for deletions.
+    pub updated: Option<UpdatedFileState>,
+    /// Paths reported as deleted (the deleted file, or a rename's source path).
+    pub deleted_paths: Vec<String>,
+}
+
+/// Report state for a created or updated file.
+#[derive(Clone)]
+pub struct UpdatedFileState {
+    /// Path the update is reported at (the rename target when renamed).
+    pub path: String,
+    /// 1-indexed changed line ranges.
+    pub changed_lines: Vec<Range<usize>>,
+    /// Final file content.
+    pub final_content: String,
+    /// Whether the user hand-edited the content during review.
+    pub was_edited: bool,
+}
+
+/// Combines per-file progress and report state into one
+/// [`RequestFileEditsResult`], failing the whole edit if any file failed to save.
+fn assemble_result(saving: SavingDiffs, files: Vec<PendingFileState>) -> RequestFileEditsResult {
+    let (combined, save_errors) = saving.into_parts();
+    if !save_errors.is_empty() {
+        let error = save_errors
+            .iter()
+            .map(|error| match error.as_ref() {
+                FileSaveError::IOError { error, path } => {
+                    format!("Failed to save file {path:?}: {error}")
+                }
+                other => other.to_string(),
+            })
+            .join("\n");
+        return RequestFileEditsResult::DiffApplicationFailed { error };
+    }
+
+    let mut updated_files = Vec::new();
+    let mut deleted_files = Vec::new();
+    let mut content_map: HashMap<String, String> = HashMap::new();
+    for file in files {
+        if let Some(updated) = file.updated {
+            content_map.insert(updated.path.clone(), updated.final_content);
+            updated_files.push((
+                FileLocations {
+                    name: updated.path,
+                    lines: updated.changed_lines,
+                },
+                updated.was_edited,
+            ));
+        }
+        deleted_files.extend(file.deleted_paths);
+    }
+
+    RequestFileEditsResult::Success {
+        diff: combined.unified_diff,
+        updated_files: updated_file_contexts_from_content_map(&updated_files, &content_map),
+        deleted_files,
+        lines_added: combined.lines_added,
+        lines_removed: combined.lines_removed,
+    }
+}
+
+/// Expands each updated file's changed lines with surrounding context and
+/// extracts the corresponding fragments from the final file content.
+fn updated_file_contexts_from_content_map(
+    updated_files: &[(FileLocations, bool)],
+    content_map: &HashMap<String, String>,
+) -> Vec<UpdatedFileContext> {
+    updated_files
+        .iter()
+        .flat_map(|(file_location, was_edited)| {
+            let content = content_map
+                .get(&file_location.name)
+                .cloned()
+                .unwrap_or_default();
+            let line_count = content.lines().count();
+
+            let mut file_location = file_location.clone();
+            file_location.expand_surrounding_context(APPLY_DIFF_RESULT_CONTEXT_LINES);
+            clamp_to_file_context_range_start(&mut file_location);
+
+            if file_location.lines.is_empty() {
+                return vec![UpdatedFileContext {
+                    was_edited_by_user: *was_edited,
+                    file_context: FileContext {
+                        file_name: file_location.name,
+                        content: AnyFileContent::StringContent(content),
+                        line_range: None,
+                        last_modified: None,
+                        line_count,
+                    },
+                }];
+            }
+
+            let lines = content.lines().collect_vec();
+            file_location
+                .lines
+                .into_iter()
+                .map(|range| {
+                    let start = range.start.saturating_sub(1).min(lines.len());
+                    let end = range.end.saturating_sub(1).min(lines.len());
+                    let fragment = if start >= end {
+                        String::new()
+                    } else {
+                        lines[start..end].join("\n")
+                    };
+
+                    UpdatedFileContext {
+                        was_edited_by_user: *was_edited,
+                        file_context: FileContext {
+                            file_name: file_location.name.clone(),
+                            content: AnyFileContent::StringContent(fragment),
+                            line_range: Some(range),
+                            last_modified: None,
+                            line_count,
+                        },
+                    }
+                })
+                .collect_vec()
+        })
+        .collect()
+}
+
+/// Clamps line ranges to the 1-indexed space used by file contexts.
+fn clamp_to_file_context_range_start(file_location: &mut FileLocations) {
+    for range in &mut file_location.lines {
+        range.start = range.start.max(1);
+        range.end = range.end.max(range.start);
+    }
+}
+
+/// Derives the final file content for a diff from its base content and deltas.
+///
+/// Used by surfaces without editor buffers (headless, TUI); the GUI reads final
+/// content from its buffers instead.
+pub(crate) fn final_content_from_op(base_content: &str, op: &DiffType) -> Result<String, String> {
+    match op {
+        DiffType::Create { delta } => Ok(delta.insertion.clone()),
+        DiffType::Update { deltas, .. } => apply_deltas_to_content(base_content, deltas),
+        DiffType::Delete { .. } => Ok(String::new()),
+    }
+}
+
+/// Applies line-range replacement deltas to `content`, producing the new content.
+fn apply_deltas_to_content(content: &str, deltas: &[DiffDelta]) -> Result<String, String> {
+    let mut lines = split_lines_preserving_newlines(content);
+    let mut deltas = deltas.to_vec();
+    deltas.sort_by_key(|delta| delta.replacement_line_range.start);
+
+    for delta in deltas.into_iter().rev() {
+        let start = delta.replacement_line_range.start.saturating_sub(1);
+        let end = delta.replacement_line_range.end.saturating_sub(1);
+        if start > lines.len() || end > lines.len() || start > end {
+            return Err(format!(
+                "Diff range {:?} is out of bounds for file with {} lines",
+                delta.replacement_line_range,
+                lines.len()
+            ));
+        }
+        let replacement = split_lines_preserving_newlines(&delta.insertion);
+        lines.splice(start..end, replacement);
+    }
+
+    Ok(lines.concat())
+}
+
+/// Splits content into lines while keeping trailing newlines, so reassembly via
+/// `concat` reproduces the original byte-for-byte.
+fn split_lines_preserving_newlines(content: &str) -> Vec<String> {
+    if content.is_empty() {
+        Vec::new()
+    } else {
+        content.split_inclusive('\n').map(str::to_string).collect()
+    }
+}
+
+/// The actual write operation performed for a file — the single source of truth
+/// that both the reported outcome and the [`FileModel`] dispatch derive from,
+/// so they cannot drift apart.
+#[cfg(not(target_family = "wasm"))]
+enum PersistAction {
+    /// Write the final content at the file's original path.
+    Write,
+    /// Move the file to the new path and write the final content there.
+    Rename(PathBuf),
+    /// Delete the file.
+    Delete,
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl PersistAction {
+    /// Decides the write operation once from the diff op and backend. Remote
+    /// sessions have no rename primitive, so remote renames fall back to an
+    /// in-place write at the original path (and are reported as such).
+    fn resolve(op: &DiffType, session_type: &DiffSessionType, path: &str) -> Self {
+        match (op, session_type) {
+            (DiffType::Delete { .. }, _) => PersistAction::Delete,
+            (
+                DiffType::Update {
+                    rename: Some(to), ..
+                },
+                DiffSessionType::Local,
+            ) if to.to_string_lossy() != path => PersistAction::Rename(to.clone()),
+            _ => PersistAction::Write,
+        }
+    }
+}
+
+/// Registers `path` with [`FileModel`] using the session's local/remote backend.
+#[cfg(not(target_family = "wasm"))]
+fn register_file(
+    file_model: &mut FileModel,
+    session_type: &DiffSessionType,
+    path: &str,
+    ctx: &mut ModelContext<FileModel>,
+) -> Result<FileId, FileSaveError> {
+    match session_type {
+        DiffSessionType::Local => Ok(file_model.register_file_path(Path::new(path), false, ctx)),
+        DiffSessionType::Remote(host_id) => {
+            let standardized = StandardizedPath::try_new(path)
+                .map_err(|_| FileSaveError::RemoteError(format!("Invalid remote path: {path}")))?;
+            Ok(file_model.register_remote_file(host_id.clone(), standardized))
+        }
+    }
+}
+
+/// Registers a file with [`FileModel`] and dispatches its write, returning the
+/// registered [`FileId`] on success.
+#[cfg(not(target_family = "wasm"))]
+fn dispatch_write(
+    file_model: &mut FileModel,
+    session_type: &DiffSessionType,
+    action: &PersistAction,
+    path: &str,
+    final_content: String,
+    ctx: &mut ModelContext<FileModel>,
+) -> Result<FileId, FileSaveError> {
+    let file_id = register_file(file_model, session_type, path, ctx)?;
+    let version = ContentVersion::new();
+    let dispatch = match action {
+        PersistAction::Delete => file_model.delete(file_id, version, ctx),
+        PersistAction::Rename(to) => {
+            file_model.rename_and_save(file_id, to.clone(), final_content, version, ctx)
+        }
+        PersistAction::Write => file_model.save(file_id, final_content, version, ctx),
+    };
+    if dispatch.is_err() {
+        // No save event will ever arrive for this file; release it now.
+        file_model.unsubscribe(file_id, ctx);
+    }
+    dispatch.map(|()| file_id)
+}
+
+/// Computes a similar-based unified diff and line counts between `before` and
+/// `after`, for surfaces without an editor-computed diff.
+#[cfg(not(target_family = "wasm"))]
+fn diff_result(before: &str, after: &str, file_name: &str) -> DiffResult {
+    if before == after {
+        return DiffResult::default();
+    }
+
+    let text_diff = TextDiff::from_lines(before, after);
+    let mut lines_added = 0;
+    let mut lines_removed = 0;
+    for op in text_diff.ops() {
+        match op {
+            DiffOp::Equal { .. } => {}
+            DiffOp::Delete { old_len, .. } => lines_removed += old_len,
+            DiffOp::Insert { new_len, .. } => lines_added += new_len,
+            DiffOp::Replace {
+                old_len, new_len, ..
+            } => {
+                lines_removed += old_len;
+                lines_added += new_len;
+            }
+        }
+    }
+
+    DiffResult {
+        unified_diff: text_diff
+            .unified_diff()
+            .context_radius(3)
+            .header(file_name, file_name)
+            .missing_newline_hint(false)
+            .to_string(),
+        lines_added,
+        lines_removed,
+    }
+}
+
+/// Builds a file's report state and similar-based result diff to mirror the
+/// write that `action` will actually perform.
+#[cfg(not(target_family = "wasm"))]
+fn headless_file_outcome(
+    action: &PersistAction,
+    diff: &FileDiff,
+    path: &str,
+    final_content: &str,
+) -> (PendingFileState, DiffResult) {
+    let changed_lines = changed_lines_from_op(&diff.diff_type);
+    match action {
+        PersistAction::Delete => (
+            PendingFileState {
+                updated: None,
+                deleted_paths: vec![path.to_owned()],
+            },
+            diff_result(&diff.base.content, "", path),
+        ),
+        PersistAction::Rename(to) => {
+            let target = to.to_string_lossy().to_string();
+            (
+                PendingFileState {
+                    updated: Some(UpdatedFileState {
+                        path: target.clone(),
+                        changed_lines,
+                        final_content: final_content.to_owned(),
+                        was_edited: false,
+                    }),
+                    deleted_paths: vec![path.to_owned()],
+                },
+                diff_result(&diff.base.content, final_content, &target),
+            )
+        }
+        PersistAction::Write => (
+            PendingFileState {
+                updated: Some(UpdatedFileState {
+                    path: path.to_owned(),
+                    changed_lines,
+                    final_content: final_content.to_owned(),
+                    was_edited: false,
+                }),
+                deleted_paths: Vec::new(),
+            },
+            diff_result(&diff.base.content, final_content, path),
+        ),
+    }
+}
+
+/// GUI-less [`DiffStorageView`]: plain diff storage with no review UI.
+///
+/// The executor creates one per action when diffs resolve with no registered
+/// surface (autoexecution racing view creation, or headless/TUI-driven
+/// conversations), so file edits stay executable everywhere. Final content is
+/// derived by applying each diff's deltas to its base. This is also the
+/// template the TUI's diff storage builds on.
+pub(crate) struct HeadlessDiffStorageModel {
+    diffs: Vec<FileDiff>,
+    session_type: DiffSessionType,
+    saving_diffs: Option<SavingDiffs>,
+    result_tx: Option<oneshot::Sender<RequestFileEditsResult>>,
+    /// `FileModel` registration for each in-flight write, index-aligned with `diffs`.
+    #[cfg(not(target_family = "wasm"))]
+    in_flight_file_ids: Vec<Option<FileId>>,
+    /// Report state built when saving starts, consumed by result assembly.
+    resolved: Vec<PendingFileState>,
+}
+
+impl HeadlessDiffStorageModel {
+    /// Creates storage over resolved diffs and subscribes to [`FileModel`] save
+    /// events for its own writes.
+    pub(crate) fn new(
+        diffs: Vec<FileDiff>,
+        session_type: DiffSessionType,
+        ctx: &mut ModelContext<Self>,
+    ) -> Self {
+        #[cfg(not(target_family = "wasm"))]
+        ctx.subscribe_to_model(&FileModel::handle(ctx), |me, _, event, ctx| {
+            me.handle_file_model_event(event, ctx);
+        });
+        #[cfg(target_family = "wasm")]
+        let _ = ctx;
+
+        Self {
+            diffs,
+            session_type,
+            saving_diffs: None,
+            result_tx: None,
+            #[cfg(not(target_family = "wasm"))]
+            in_flight_file_ids: Vec::new(),
+            resolved: Vec::new(),
+        }
+    }
+
+    /// Replaces the stored diffs and session backend.
+    fn set_candidate_diffs(&mut self, diffs: Vec<FileDiff>, session_type: DiffSessionType) {
+        self.diffs = diffs;
+        self.session_type = session_type;
+    }
+
+    /// Relinquishes the diffs to a newly registered surface, unless saving has
+    /// already started (or finished — `resolved` outlives the save).
+    fn take_candidate_diffs(&mut self) -> Option<(Vec<FileDiff>, DiffSessionType)> {
+        if self.saving_diffs.is_some() || !self.resolved.is_empty() || self.diffs.is_empty() {
+            return None;
+        }
+        Some((std::mem::take(&mut self.diffs), self.session_type.clone()))
+    }
+
+    /// Routes this model's own [`FileModel`] save events into the shared flow.
+    #[cfg(not(target_family = "wasm"))]
+    fn handle_file_model_event(&mut self, event: &FileModelEvent, ctx: &mut ModelContext<Self>) {
+        let file_id = event.file_id();
+        let save_error = match event {
+            FileModelEvent::FileSaved { .. } => None,
+            FileModelEvent::FailedToSave { error, .. } => Some(error.clone()),
+            // Other file events (loads, external updates) are unrelated to our writes.
+            _ => return,
+        };
+        let Some(idx) = self
+            .in_flight_file_ids
+            .iter()
+            .position(|id| *id == Some(file_id))
+        else {
+            return;
+        };
+        self.in_flight_file_ids[idx] = None;
+
+        // The write is done either way; release the registration so FileModel
+        // state doesn't grow unboundedly.
+        FileModel::handle(ctx).update(ctx, |file_model, ctx| {
+            file_model.unsubscribe(file_id, ctx);
+        });
+
+        self.handle_file_saved(idx, save_error, ctx);
+    }
+}
+
+impl DiffStorageView for HeadlessDiffStorageModel {
+    fn saving_diffs_mut(&mut self) -> &mut Option<SavingDiffs> {
+        &mut self.saving_diffs
+    }
+
+    fn result_tx_mut(&mut self) -> &mut Option<oneshot::Sender<RequestFileEditsResult>> {
+        &mut self.result_tx
+    }
+
+    fn pending_diff_count(&self) -> usize {
+        self.diffs.len()
+    }
+
+    fn pending_file_state(&self, _app: &AppContext) -> Vec<PendingFileState> {
+        self.resolved.clone()
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn start_saving(&mut self, app: &mut AppContext) {
+        self.resolved.clear();
+        self.in_flight_file_ids = vec![None; self.diffs.len()];
+        let diffs = self.diffs.clone();
+        let session_type = self.session_type.clone();
+        let file_model = FileModel::handle(app);
+
+        for (idx, diff) in diffs.into_iter().enumerate() {
+            let path = diff.file_path();
+            let final_content = match final_content_from_op(&diff.base.content, &diff.diff_type) {
+                Ok(content) => content,
+                Err(error) => {
+                    self.fail_saving(error);
+                    return;
+                }
+            };
+
+            let action = PersistAction::resolve(&diff.diff_type, &session_type, &path);
+            let (state, result_diff) = headless_file_outcome(&action, &diff, &path, &final_content);
+            self.resolved.push(state);
+            // No editor computes the result diff here; the similar-based diff
+            // is available immediately.
+            self.handle_diff_computed(idx, Rc::new(result_diff), app);
+
+            let dispatch = file_model.update(app, |file_model, ctx| {
+                dispatch_write(
+                    file_model,
+                    &session_type,
+                    &action,
+                    &path,
+                    final_content,
+                    ctx,
+                )
+            });
+            match dispatch {
+                Ok(file_id) => self.in_flight_file_ids[idx] = Some(file_id),
+                Err(error) => self.handle_file_saved(idx, Some(Rc::new(error)), app),
+            }
+        }
+    }
+
+    /// On wasm there is no local/remote file backend, so file edits cannot execute.
+    #[cfg(target_family = "wasm")]
+    fn start_saving(&mut self, _app: &mut AppContext) {
+        self.fail_saving("file editing is not supported in this environment".to_string());
+    }
+}
+
+impl Entity for HeadlessDiffStorageModel {
+    type Event = ();
+}
+
+/// [`RegisteredDiffStorage`] wrapper over a [`HeadlessDiffStorageModel`].
+pub(crate) struct HeadlessDiffStorage(pub(crate) ModelHandle<HeadlessDiffStorageModel>);
+
+impl RegisteredDiffStorage for HeadlessDiffStorage {
+    fn set_candidate_diffs(
+        &self,
+        diffs: Vec<FileDiff>,
+        session_type: DiffSessionType,
+        app: &mut AppContext,
+    ) {
+        self.0.update(app, |model, _| {
+            model.set_candidate_diffs(diffs, session_type)
+        });
+    }
+
+    fn take_candidate_diffs(
+        &self,
+        app: &mut AppContext,
+    ) -> Option<(Vec<FileDiff>, DiffSessionType)> {
+        self.0.update(app, |model, _| model.take_candidate_diffs())
+    }
+
+    fn accept_and_save(&self, app: &mut AppContext) -> BoxFuture<'static, RequestFileEditsResult> {
+        self.0.update(app, |model, ctx| {
+            DiffStorageView::accept_and_save(model, ctx)
+        })
+    }
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+#[path = "diff_storage_tests.rs"]
+mod tests;

--- a/app/src/ai/blocklist/diff_storage.rs
+++ b/app/src/ai/blocklist/diff_storage.rs
@@ -1,44 +1,36 @@
 //! Surface-owned storage and the shared persistence flow for `RequestFileEdits`
 //! diffs.
 //!
-//! Every surface that stores pending diffs — the GUI `CodeDiffView`, the TUI
-//! diff view, and the headless fallback below — implements [`DiffStorageView`].
-//! The trait's provided methods are the shared save-completion flow: they track
-//! per-file progress in [`SavingDiffs`] and assemble the final
+//! Every surface that stores pending diffs — the GUI `CodeDiffView` and the
+//! up-stack TUI diff storage — implements [`DiffStorageView`]. The trait's
+//! provided methods are the shared save-completion flow: they track per-file
+//! progress in a [`DiffSaveState`] and assemble the final
 //! [`RequestFileEditsResult`], so every surface produces results through the
 //! same code. Only the write kickoff ([`DiffStorageView::start_saving`]) is
-//! surface-specific: the GUI saves through its editor buffers, while headless
-//! surfaces dispatch to `FileModel` via the helpers in this module.
+//! surface-specific: the GUI saves through its editor buffers.
 //!
 //! The executor knows surfaces only through [`RegisteredDiffStorage`], a small
 //! object-safe handle trait, because GUI `ViewHandle`s and model `ModelHandle`s
-//! share no common handle type.
+//! share no common handle type. Each surface's handle type implements it
+//! directly, delegating to the entity's [`DiffStorageView`]. Every surface must
+//! register its storage before the action's diffs resolve
+//! (`register_requested_edits`); preprocess and execute assume a registered
+//! storage.
 use std::collections::HashMap;
 use std::ops::Range;
 use std::rc::Rc;
 
-use ai::diff_validation::{DiffDelta, DiffType};
 use futures::channel::oneshot;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use itertools::Itertools;
 use warp_util::file::FileSaveError;
-use warpui::{AppContext, Entity, ModelContext, ModelHandle};
-#[cfg(not(target_family = "wasm"))]
-use {
-    similar::{DiffOp, TextDiff},
-    std::path::{Path, PathBuf},
-    warp_files::{FileModel, FileModelEvent},
-    warp_util::content_version::ContentVersion,
-    warp_util::file::FileId,
-    warp_util::standardized_path::StandardizedPath,
-    warpui::SingletonEntity,
-};
+use warpui::AppContext;
 
 use crate::ai::agent::{
     AnyFileContent, FileContext, FileLocations, RequestFileEditsResult, UpdatedFileContext,
 };
-use crate::ai::blocklist::diff_types::{changed_lines_from_op, DiffSessionType, FileDiff};
+use crate::ai::blocklist::diff_types::{DiffSessionType, FileDiff};
 use crate::code::DiffResult;
 
 const APPLY_DIFF_RESULT_CONTEXT_LINES: usize = 10;
@@ -46,17 +38,16 @@ const APPLY_DIFF_RESULT_CONTEXT_LINES: usize = 10;
 /// A surface that stores pending file-edit diffs and persists them on accept.
 ///
 /// Required methods are state accessors (the fields live on each impl, since
-/// traits cannot hold state) plus the surface-specific write kickoff. Provided
-/// methods are the shared save-completion flow, so every surface assembles its
-/// [`RequestFileEditsResult`] through the same code.
+/// traits cannot hold state) plus the surface-specific write kickoff
+/// ([`Self::start_saving`]). Provided methods are the shared save-completion
+/// flow, so every surface assembles its [`RequestFileEditsResult`] through the
+/// same code. Callers drive an accept solely through [`Self::accept_and_save`].
 pub trait DiffStorageView {
-    /// Per-file save/diff-computation tracking for the in-flight accept.
-    fn saving_diffs_mut(&mut self) -> &mut Option<SavingDiffs>;
+    /// The in-flight accept's progress and result channel. Impls just store a
+    /// [`DiffSaveState`]; only the provided methods below act on it.
+    fn save_state_mut(&mut self) -> &mut DiffSaveState;
 
-    /// Delivery channel for the in-flight accept's result.
-    fn result_tx_mut(&mut self) -> &mut Option<oneshot::Sender<RequestFileEditsResult>>;
-
-    /// Number of pending file diffs; sizes [`SavingDiffs`].
+    /// Number of pending file diffs; sizes the per-file save tracking.
     fn pending_diff_count(&self) -> usize;
 
     /// Snapshot of per-file state for result assembly: reported paths, changed
@@ -65,14 +56,16 @@ pub trait DiffStorageView {
 
     /// Kicks off persistence for every pending file.
     ///
-    /// Surface-specific: the GUI saves through its editor buffers; headless
-    /// surfaces dispatch via [`dispatch_write`]. Each file's completion must be
-    /// reported back through [`Self::handle_file_saved`] and
-    /// [`Self::handle_diff_computed`].
+    /// The surface-specific hook invoked by [`Self::accept_and_save`] — never
+    /// called directly by callers. The GUI saves through its editor buffers;
+    /// surfaces without editor buffers dispatch writes to `FileModel`. Each
+    /// file's completion must be reported back through
+    /// [`Self::handle_file_saved`] and [`Self::handle_diff_computed`].
     fn start_saving(&mut self, app: &mut AppContext);
 
-    /// Persists all pending diffs, resolving with the assembled result once
-    /// every file's save and result-diff computation completes.
+    /// The entry point for accepting a surface's diffs: persists them all,
+    /// resolving with the assembled result once every file's save and
+    /// result-diff computation completes.
     ///
     /// Dropping the surface mid-save drops the stored sender, resolving the
     /// returned future with [`RequestFileEditsResult::Cancelled`].
@@ -80,12 +73,11 @@ pub trait DiffStorageView {
         &mut self,
         app: &mut AppContext,
     ) -> BoxFuture<'static, RequestFileEditsResult> {
-        let (tx, rx) = oneshot::channel();
-        *self.result_tx_mut() = Some(tx);
-        *self.saving_diffs_mut() = Some(SavingDiffs::new(self.pending_diff_count()));
+        let count = self.pending_diff_count();
+        let result = self.save_state_mut().begin(count);
         self.start_saving(app);
         self.try_finish(app);
-        async move { rx.await.unwrap_or(RequestFileEditsResult::Cancelled) }.boxed()
+        result
     }
 
     /// Records one file's save completion (or failure).
@@ -95,53 +87,93 @@ pub trait DiffStorageView {
         error: Option<Rc<FileSaveError>>,
         app: &AppContext,
     ) {
-        if let Some(saving) = self.saving_diffs_mut() {
-            saving.mark_diff_saved(idx, error);
-        }
+        self.save_state_mut().mark_diff_saved(idx, error);
         self.try_finish(app);
     }
 
     /// Records one file's computed result diff.
     fn handle_diff_computed(&mut self, idx: usize, diff: Rc<DiffResult>, app: &AppContext) {
-        if let Some(saving) = self.saving_diffs_mut() {
-            saving.mark_diff_computed(idx, diff);
-        }
+        self.save_state_mut().mark_diff_computed(idx, diff);
         self.try_finish(app);
-    }
-
-    /// Fails the in-flight accept outright (e.g. the surface cannot save at all).
-    fn fail_saving(&mut self, error: String) {
-        *self.saving_diffs_mut() = None;
-        if let Some(tx) = self.result_tx_mut().take() {
-            let _ = tx.send(RequestFileEditsResult::DiffApplicationFailed { error });
-        }
     }
 
     /// Assembles and delivers the result once every file is saved and computed.
     fn try_finish(&mut self, app: &AppContext) {
-        let complete = self
-            .saving_diffs_mut()
-            .as_ref()
-            .is_some_and(SavingDiffs::pending_diff_is_complete);
-        if !complete {
+        if !self.save_state_mut().is_complete() {
             return;
         }
-        let saving = self
-            .saving_diffs_mut()
-            .take()
-            .expect("checked complete above");
-        let Some(tx) = self.result_tx_mut().take() else {
+        let files = self.pending_file_state(app);
+        self.save_state_mut().finish(files);
+    }
+}
+
+/// Progress and result delivery for one in-flight accept.
+///
+/// Each [`DiffStorageView`] impl stores one of these and exposes it via
+/// [`DiffStorageView::save_state_mut`]; the trait's provided methods drive it.
+#[derive(Default)]
+pub struct DiffSaveState {
+    /// Per-file save/diff-computation tracking; `Some` while an accept is in flight.
+    saving: Option<SavingDiffs>,
+    /// Delivery channel for the in-flight accept's result.
+    result_tx: Option<oneshot::Sender<RequestFileEditsResult>>,
+}
+
+impl DiffSaveState {
+    /// Starts tracking an accept over `count` files, returning the future that
+    /// resolves with the delivered result.
+    fn begin(&mut self, count: usize) -> BoxFuture<'static, RequestFileEditsResult> {
+        let (tx, rx) = oneshot::channel();
+        self.result_tx = Some(tx);
+        self.saving = Some(SavingDiffs::new(count));
+        async move { rx.await.unwrap_or(RequestFileEditsResult::Cancelled) }.boxed()
+    }
+
+    /// True while an accept is being persisted.
+    pub fn is_saving(&self) -> bool {
+        self.saving.is_some()
+    }
+
+    /// Records the save outcome for the file at `idx`.
+    fn mark_diff_saved(&mut self, idx: usize, error: Option<Rc<FileSaveError>>) {
+        if let Some(saving) = &mut self.saving {
+            saving.mark_diff_saved(idx, error);
+        }
+    }
+
+    /// Records the computed result diff for the file at `idx`.
+    fn mark_diff_computed(&mut self, idx: usize, diff: Rc<DiffResult>) {
+        if let Some(saving) = &mut self.saving {
+            saving.mark_diff_computed(idx, diff);
+        }
+    }
+
+    /// True once every file is saved and its result diff computed.
+    fn is_complete(&self) -> bool {
+        self.saving
+            .as_ref()
+            .is_some_and(SavingDiffs::pending_diff_is_complete)
+    }
+
+    /// Delivers the assembled result and clears the in-flight state.
+    fn finish(&mut self, files: Vec<PendingFileState>) {
+        let Some(saving) = self.saving.take() else {
             return;
         };
-        let files = self.pending_file_state(app);
+        let Some(tx) = self.result_tx.take() else {
+            return;
+        };
         let _ = tx.send(assemble_result(saving, files));
     }
 }
 
 /// The executor-facing handle over a registered [`DiffStorageView`] surface.
 ///
-/// GUI views and models share no common handle type, so each surface registers
-/// a thin wrapper that delegates through its own handle.
+/// A separate trait from [`DiffStorageView`] because the executor holds
+/// surfaces by handle, and GUI view handles and model handles share no common
+/// type. Each surface's handle type (e.g. `WeakViewHandle<CodeDiffView>`)
+/// implements this directly, delegating each call to its entity's
+/// [`DiffStorageView`].
 pub trait RegisteredDiffStorage {
     /// Pushes resolved diffs into the surface (called when preprocess resolves).
     fn set_candidate_diffs(
@@ -150,13 +182,6 @@ pub trait RegisteredDiffStorage {
         session_type: DiffSessionType,
         app: &mut AppContext,
     );
-
-    /// Hands the diffs back out so a newly registered surface can take over.
-    /// Returns `None` if this storage keeps ownership (e.g. saving started).
-    fn take_candidate_diffs(
-        &self,
-        app: &mut AppContext,
-    ) -> Option<(Vec<FileDiff>, DiffSessionType)>;
 
     /// Persists all diffs, resolving with the result reported to the LLM.
     fn accept_and_save(&self, app: &mut AppContext) -> BoxFuture<'static, RequestFileEditsResult>;
@@ -167,7 +192,7 @@ pub trait RegisteredDiffStorage {
 /// Saving and result-diff computation complete independently per file; the
 /// accept finishes when every file has both.
 #[derive(Clone, Debug)]
-pub struct SavingDiffs {
+struct SavingDiffs {
     pending_diffs: Vec<DiffApplicationState>,
 }
 
@@ -372,401 +397,6 @@ fn clamp_to_file_context_range_start(file_location: &mut FileLocations) {
     for range in &mut file_location.lines {
         range.start = range.start.max(1);
         range.end = range.end.max(range.start);
-    }
-}
-
-/// Derives the final file content for a diff from its base content and deltas.
-///
-/// Used by surfaces without editor buffers (headless, TUI); the GUI reads final
-/// content from its buffers instead.
-pub(crate) fn final_content_from_op(base_content: &str, op: &DiffType) -> Result<String, String> {
-    match op {
-        DiffType::Create { delta } => Ok(delta.insertion.clone()),
-        DiffType::Update { deltas, .. } => apply_deltas_to_content(base_content, deltas),
-        DiffType::Delete { .. } => Ok(String::new()),
-    }
-}
-
-/// Applies line-range replacement deltas to `content`, producing the new content.
-fn apply_deltas_to_content(content: &str, deltas: &[DiffDelta]) -> Result<String, String> {
-    let mut lines = split_lines_preserving_newlines(content);
-    let mut deltas = deltas.to_vec();
-    deltas.sort_by_key(|delta| delta.replacement_line_range.start);
-
-    for delta in deltas.into_iter().rev() {
-        let start = delta.replacement_line_range.start.saturating_sub(1);
-        let end = delta.replacement_line_range.end.saturating_sub(1);
-        if start > lines.len() || end > lines.len() || start > end {
-            return Err(format!(
-                "Diff range {:?} is out of bounds for file with {} lines",
-                delta.replacement_line_range,
-                lines.len()
-            ));
-        }
-        let replacement = split_lines_preserving_newlines(&delta.insertion);
-        lines.splice(start..end, replacement);
-    }
-
-    Ok(lines.concat())
-}
-
-/// Splits content into lines while keeping trailing newlines, so reassembly via
-/// `concat` reproduces the original byte-for-byte.
-fn split_lines_preserving_newlines(content: &str) -> Vec<String> {
-    if content.is_empty() {
-        Vec::new()
-    } else {
-        content.split_inclusive('\n').map(str::to_string).collect()
-    }
-}
-
-/// The actual write operation performed for a file — the single source of truth
-/// that both the reported outcome and the [`FileModel`] dispatch derive from,
-/// so they cannot drift apart.
-#[cfg(not(target_family = "wasm"))]
-enum PersistAction {
-    /// Write the final content at the file's original path.
-    Write,
-    /// Move the file to the new path and write the final content there.
-    Rename(PathBuf),
-    /// Delete the file.
-    Delete,
-}
-
-#[cfg(not(target_family = "wasm"))]
-impl PersistAction {
-    /// Decides the write operation once from the diff op and backend. Remote
-    /// sessions have no rename primitive, so remote renames fall back to an
-    /// in-place write at the original path (and are reported as such).
-    fn resolve(op: &DiffType, session_type: &DiffSessionType, path: &str) -> Self {
-        match (op, session_type) {
-            (DiffType::Delete { .. }, _) => PersistAction::Delete,
-            (
-                DiffType::Update {
-                    rename: Some(to), ..
-                },
-                DiffSessionType::Local,
-            ) if to.to_string_lossy() != path => PersistAction::Rename(to.clone()),
-            _ => PersistAction::Write,
-        }
-    }
-}
-
-/// Registers `path` with [`FileModel`] using the session's local/remote backend.
-#[cfg(not(target_family = "wasm"))]
-fn register_file(
-    file_model: &mut FileModel,
-    session_type: &DiffSessionType,
-    path: &str,
-    ctx: &mut ModelContext<FileModel>,
-) -> Result<FileId, FileSaveError> {
-    match session_type {
-        DiffSessionType::Local => Ok(file_model.register_file_path(Path::new(path), false, ctx)),
-        DiffSessionType::Remote(host_id) => {
-            let standardized = StandardizedPath::try_new(path)
-                .map_err(|_| FileSaveError::RemoteError(format!("Invalid remote path: {path}")))?;
-            Ok(file_model.register_remote_file(host_id.clone(), standardized))
-        }
-    }
-}
-
-/// Registers a file with [`FileModel`] and dispatches its write, returning the
-/// registered [`FileId`] on success.
-#[cfg(not(target_family = "wasm"))]
-fn dispatch_write(
-    file_model: &mut FileModel,
-    session_type: &DiffSessionType,
-    action: &PersistAction,
-    path: &str,
-    final_content: String,
-    ctx: &mut ModelContext<FileModel>,
-) -> Result<FileId, FileSaveError> {
-    let file_id = register_file(file_model, session_type, path, ctx)?;
-    let version = ContentVersion::new();
-    let dispatch = match action {
-        PersistAction::Delete => file_model.delete(file_id, version, ctx),
-        PersistAction::Rename(to) => {
-            file_model.rename_and_save(file_id, to.clone(), final_content, version, ctx)
-        }
-        PersistAction::Write => file_model.save(file_id, final_content, version, ctx),
-    };
-    if dispatch.is_err() {
-        // No save event will ever arrive for this file; release it now.
-        file_model.unsubscribe(file_id, ctx);
-    }
-    dispatch.map(|()| file_id)
-}
-
-/// Computes a similar-based unified diff and line counts between `before` and
-/// `after`, for surfaces without an editor-computed diff.
-#[cfg(not(target_family = "wasm"))]
-fn diff_result(before: &str, after: &str, file_name: &str) -> DiffResult {
-    if before == after {
-        return DiffResult::default();
-    }
-
-    let text_diff = TextDiff::from_lines(before, after);
-    let mut lines_added = 0;
-    let mut lines_removed = 0;
-    for op in text_diff.ops() {
-        match op {
-            DiffOp::Equal { .. } => {}
-            DiffOp::Delete { old_len, .. } => lines_removed += old_len,
-            DiffOp::Insert { new_len, .. } => lines_added += new_len,
-            DiffOp::Replace {
-                old_len, new_len, ..
-            } => {
-                lines_removed += old_len;
-                lines_added += new_len;
-            }
-        }
-    }
-
-    DiffResult {
-        unified_diff: text_diff
-            .unified_diff()
-            .context_radius(3)
-            .header(file_name, file_name)
-            .missing_newline_hint(false)
-            .to_string(),
-        lines_added,
-        lines_removed,
-    }
-}
-
-/// Builds a file's report state and similar-based result diff to mirror the
-/// write that `action` will actually perform.
-#[cfg(not(target_family = "wasm"))]
-fn headless_file_outcome(
-    action: &PersistAction,
-    diff: &FileDiff,
-    path: &str,
-    final_content: &str,
-) -> (PendingFileState, DiffResult) {
-    let changed_lines = changed_lines_from_op(&diff.diff_type);
-    match action {
-        PersistAction::Delete => (
-            PendingFileState {
-                updated: None,
-                deleted_paths: vec![path.to_owned()],
-            },
-            diff_result(&diff.base.content, "", path),
-        ),
-        PersistAction::Rename(to) => {
-            let target = to.to_string_lossy().to_string();
-            (
-                PendingFileState {
-                    updated: Some(UpdatedFileState {
-                        path: target.clone(),
-                        changed_lines,
-                        final_content: final_content.to_owned(),
-                        was_edited: false,
-                    }),
-                    deleted_paths: vec![path.to_owned()],
-                },
-                diff_result(&diff.base.content, final_content, &target),
-            )
-        }
-        PersistAction::Write => (
-            PendingFileState {
-                updated: Some(UpdatedFileState {
-                    path: path.to_owned(),
-                    changed_lines,
-                    final_content: final_content.to_owned(),
-                    was_edited: false,
-                }),
-                deleted_paths: Vec::new(),
-            },
-            diff_result(&diff.base.content, final_content, path),
-        ),
-    }
-}
-
-/// GUI-less [`DiffStorageView`]: plain diff storage with no review UI.
-///
-/// The executor creates one per action when diffs resolve with no registered
-/// surface (autoexecution racing view creation, or headless/TUI-driven
-/// conversations), so file edits stay executable everywhere. Final content is
-/// derived by applying each diff's deltas to its base. This is also the
-/// template the TUI's diff storage builds on.
-pub(crate) struct HeadlessDiffStorageModel {
-    diffs: Vec<FileDiff>,
-    session_type: DiffSessionType,
-    saving_diffs: Option<SavingDiffs>,
-    result_tx: Option<oneshot::Sender<RequestFileEditsResult>>,
-    /// `FileModel` registration for each in-flight write, index-aligned with `diffs`.
-    #[cfg(not(target_family = "wasm"))]
-    in_flight_file_ids: Vec<Option<FileId>>,
-    /// Report state built when saving starts, consumed by result assembly.
-    resolved: Vec<PendingFileState>,
-}
-
-impl HeadlessDiffStorageModel {
-    /// Creates storage over resolved diffs and subscribes to [`FileModel`] save
-    /// events for its own writes.
-    pub(crate) fn new(
-        diffs: Vec<FileDiff>,
-        session_type: DiffSessionType,
-        ctx: &mut ModelContext<Self>,
-    ) -> Self {
-        #[cfg(not(target_family = "wasm"))]
-        ctx.subscribe_to_model(&FileModel::handle(ctx), |me, _, event, ctx| {
-            me.handle_file_model_event(event, ctx);
-        });
-        #[cfg(target_family = "wasm")]
-        let _ = ctx;
-
-        Self {
-            diffs,
-            session_type,
-            saving_diffs: None,
-            result_tx: None,
-            #[cfg(not(target_family = "wasm"))]
-            in_flight_file_ids: Vec::new(),
-            resolved: Vec::new(),
-        }
-    }
-
-    /// Replaces the stored diffs and session backend.
-    fn set_candidate_diffs(&mut self, diffs: Vec<FileDiff>, session_type: DiffSessionType) {
-        self.diffs = diffs;
-        self.session_type = session_type;
-    }
-
-    /// Relinquishes the diffs to a newly registered surface, unless saving has
-    /// already started (or finished — `resolved` outlives the save).
-    fn take_candidate_diffs(&mut self) -> Option<(Vec<FileDiff>, DiffSessionType)> {
-        if self.saving_diffs.is_some() || !self.resolved.is_empty() || self.diffs.is_empty() {
-            return None;
-        }
-        Some((std::mem::take(&mut self.diffs), self.session_type.clone()))
-    }
-
-    /// Routes this model's own [`FileModel`] save events into the shared flow.
-    #[cfg(not(target_family = "wasm"))]
-    fn handle_file_model_event(&mut self, event: &FileModelEvent, ctx: &mut ModelContext<Self>) {
-        let file_id = event.file_id();
-        let save_error = match event {
-            FileModelEvent::FileSaved { .. } => None,
-            FileModelEvent::FailedToSave { error, .. } => Some(error.clone()),
-            // Other file events (loads, external updates) are unrelated to our writes.
-            _ => return,
-        };
-        let Some(idx) = self
-            .in_flight_file_ids
-            .iter()
-            .position(|id| *id == Some(file_id))
-        else {
-            return;
-        };
-        self.in_flight_file_ids[idx] = None;
-
-        // The write is done either way; release the registration so FileModel
-        // state doesn't grow unboundedly.
-        FileModel::handle(ctx).update(ctx, |file_model, ctx| {
-            file_model.unsubscribe(file_id, ctx);
-        });
-
-        self.handle_file_saved(idx, save_error, ctx);
-    }
-}
-
-impl DiffStorageView for HeadlessDiffStorageModel {
-    fn saving_diffs_mut(&mut self) -> &mut Option<SavingDiffs> {
-        &mut self.saving_diffs
-    }
-
-    fn result_tx_mut(&mut self) -> &mut Option<oneshot::Sender<RequestFileEditsResult>> {
-        &mut self.result_tx
-    }
-
-    fn pending_diff_count(&self) -> usize {
-        self.diffs.len()
-    }
-
-    fn pending_file_state(&self, _app: &AppContext) -> Vec<PendingFileState> {
-        self.resolved.clone()
-    }
-
-    #[cfg(not(target_family = "wasm"))]
-    fn start_saving(&mut self, app: &mut AppContext) {
-        self.resolved.clear();
-        self.in_flight_file_ids = vec![None; self.diffs.len()];
-        let diffs = self.diffs.clone();
-        let session_type = self.session_type.clone();
-        let file_model = FileModel::handle(app);
-
-        for (idx, diff) in diffs.into_iter().enumerate() {
-            let path = diff.file_path();
-            let final_content = match final_content_from_op(&diff.base.content, &diff.diff_type) {
-                Ok(content) => content,
-                Err(error) => {
-                    self.fail_saving(error);
-                    return;
-                }
-            };
-
-            let action = PersistAction::resolve(&diff.diff_type, &session_type, &path);
-            let (state, result_diff) = headless_file_outcome(&action, &diff, &path, &final_content);
-            self.resolved.push(state);
-            // No editor computes the result diff here; the similar-based diff
-            // is available immediately.
-            self.handle_diff_computed(idx, Rc::new(result_diff), app);
-
-            let dispatch = file_model.update(app, |file_model, ctx| {
-                dispatch_write(
-                    file_model,
-                    &session_type,
-                    &action,
-                    &path,
-                    final_content,
-                    ctx,
-                )
-            });
-            match dispatch {
-                Ok(file_id) => self.in_flight_file_ids[idx] = Some(file_id),
-                Err(error) => self.handle_file_saved(idx, Some(Rc::new(error)), app),
-            }
-        }
-    }
-
-    /// On wasm there is no local/remote file backend, so file edits cannot execute.
-    #[cfg(target_family = "wasm")]
-    fn start_saving(&mut self, _app: &mut AppContext) {
-        self.fail_saving("file editing is not supported in this environment".to_string());
-    }
-}
-
-impl Entity for HeadlessDiffStorageModel {
-    type Event = ();
-}
-
-/// [`RegisteredDiffStorage`] wrapper over a [`HeadlessDiffStorageModel`].
-pub(crate) struct HeadlessDiffStorage(pub(crate) ModelHandle<HeadlessDiffStorageModel>);
-
-impl RegisteredDiffStorage for HeadlessDiffStorage {
-    fn set_candidate_diffs(
-        &self,
-        diffs: Vec<FileDiff>,
-        session_type: DiffSessionType,
-        app: &mut AppContext,
-    ) {
-        self.0.update(app, |model, _| {
-            model.set_candidate_diffs(diffs, session_type)
-        });
-    }
-
-    fn take_candidate_diffs(
-        &self,
-        app: &mut AppContext,
-    ) -> Option<(Vec<FileDiff>, DiffSessionType)> {
-        self.0.update(app, |model, _| model.take_candidate_diffs())
-    }
-
-    fn accept_and_save(&self, app: &mut AppContext) -> BoxFuture<'static, RequestFileEditsResult> {
-        self.0.update(app, |model, ctx| {
-            DiffStorageView::accept_and_save(model, ctx)
-        })
     }
 }
 

--- a/app/src/ai/blocklist/diff_storage_tests.rs
+++ b/app/src/ai/blocklist/diff_storage_tests.rs
@@ -1,50 +1,48 @@
 use std::collections::HashMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use ai::agent::action_result::AnyFileContent;
 use ai::agent::FileLocations;
+use futures::FutureExt as _;
 use warpui::{App, Entity, ModelHandle};
 
 use super::*;
 
-/// Minimal [`DiffStorage`] impl: canned report state and a no-op write
-/// kickoff, so tests drive completion through the [`DiffStorageHelper`] flow.
+/// Minimal [`DiffStorage`] impl: canned snapshots and save outcomes, so tests
+/// drive completion through the [`DiffStorageHelper`] flow.
 struct TestSurface {
-    save_state: DiffSaveState,
-    files: Vec<PendingFileState>,
+    files: Vec<FileSnapshot>,
+    save_results: Vec<Result<(), Arc<FileSaveError>>>,
 }
 
 impl TestSurface {
-    fn new(files: Vec<PendingFileState>) -> Self {
+    fn new(files: Vec<FileSnapshot>, save_results: Vec<Result<(), Arc<FileSaveError>>>) -> Self {
         Self {
-            save_state: DiffSaveState::default(),
             files,
+            save_results,
         }
     }
 }
 
 impl DiffStorage for TestSurface {
-    fn save_state_mut(&mut self) -> &mut DiffSaveState {
-        &mut self.save_state
-    }
-
-    fn pending_diff_count(&self) -> usize {
-        self.files.len()
-    }
-
-    fn pending_file_state(&self, _app: &AppContext) -> Vec<PendingFileState> {
+    fn snapshot_pending_files(&self, _app: &AppContext) -> Vec<FileSnapshot> {
         self.files.clone()
     }
 
-    fn start_saving(&mut self, _app: &mut AppContext) {}
+    fn start_saving(&mut self, _app: &mut AppContext) -> Vec<SaveFuture> {
+        std::mem::take(&mut self.save_results)
+            .into_iter()
+            .map(|result| futures::future::ready(result).boxed() as SaveFuture)
+            .collect()
+    }
 }
 
 impl Entity for TestSurface {
     type Event = ();
 }
 
-fn updated_file(path: &str, content: &str) -> PendingFileState {
-    PendingFileState {
+fn updated_file(path: &str, content: &str) -> FileSnapshot {
+    FileSnapshot {
         updated: Some(UpdatedFileState {
             path: path.to_owned(),
             changed_lines: std::iter::once(1..2).collect(),
@@ -52,31 +50,29 @@ fn updated_file(path: &str, content: &str) -> PendingFileState {
             was_edited: false,
         }),
         deleted_paths: Vec::new(),
+        diff_base: String::new(),
+        diff_new: content.to_owned(),
+        diff_name: path.to_owned(),
     }
 }
 
-fn add_surface(app: &mut App, files: Vec<PendingFileState>) -> ModelHandle<TestSurface> {
-    app.add_model(|_| TestSurface::new(files))
+fn add_surface(
+    app: &mut App,
+    files: Vec<FileSnapshot>,
+    save_results: Vec<Result<(), Arc<FileSaveError>>>,
+) -> ModelHandle<TestSurface> {
+    app.add_model(|_| TestSurface::new(files, save_results))
 }
 
 #[test]
-fn accept_resolves_once_every_file_is_saved_and_computed() {
+fn accept_resolves_with_computed_diffs_once_saves_complete() {
     App::test((), |mut app| async move {
-        let surface = add_surface(&mut app, vec![updated_file("/tmp/x.rs", "fn main() {}\n")]);
+        let surface = add_surface(
+            &mut app,
+            vec![updated_file("/tmp/x.rs", "fn main() {}\n")],
+            vec![Ok(())],
+        );
         let future = surface.update(&mut app, |surface, ctx| surface.accept_and_save(ctx));
-
-        surface.update(&mut app, |surface, ctx| {
-            surface.handle_diff_computed(
-                0,
-                Rc::new(DiffResult {
-                    unified_diff: "+fn main() {}".to_owned(),
-                    lines_added: 1,
-                    lines_removed: 0,
-                }),
-                ctx,
-            );
-            surface.handle_file_saved(0, None, ctx);
-        });
 
         let RequestFileEditsResult::Success {
             diff,
@@ -88,7 +84,7 @@ fn accept_resolves_once_every_file_is_saved_and_computed() {
         else {
             panic!("expected accept to succeed");
         };
-        assert_eq!(diff, "+fn main() {}");
+        assert!(diff.contains("+fn main() {}"));
         assert_eq!(lines_added, 1);
         assert_eq!(lines_removed, 0);
         assert_eq!(deleted_files, Vec::<String>::new());
@@ -100,17 +96,14 @@ fn accept_resolves_once_every_file_is_saved_and_computed() {
 #[test]
 fn accept_reports_save_failure_for_the_whole_edit() {
     App::test((), |mut app| async move {
-        let surface = add_surface(&mut app, vec![updated_file("/tmp/x.rs", "content\n")]);
+        let surface = add_surface(
+            &mut app,
+            vec![updated_file("/tmp/x.rs", "content\n")],
+            vec![Err(Arc::new(FileSaveError::RemoteError(
+                "disk full".to_owned(),
+            )))],
+        );
         let future = surface.update(&mut app, |surface, ctx| surface.accept_and_save(ctx));
-
-        surface.update(&mut app, |surface, ctx| {
-            surface.handle_diff_computed(0, Rc::new(DiffResult::default()), ctx);
-            surface.handle_file_saved(
-                0,
-                Some(Rc::new(FileSaveError::RemoteError("disk full".to_owned()))),
-                ctx,
-            );
-        });
 
         let RequestFileEditsResult::DiffApplicationFailed { error } = future.await else {
             panic!("expected a failed save to fail the edit");
@@ -124,21 +117,21 @@ fn deleted_paths_are_reported_as_deleted_files() {
     App::test((), |mut app| async move {
         let surface = add_surface(
             &mut app,
-            vec![PendingFileState {
+            vec![FileSnapshot {
                 updated: None,
                 deleted_paths: vec!["/tmp/gone.rs".to_owned()],
+                diff_base: "old content\n".to_owned(),
+                diff_new: String::new(),
+                diff_name: "/tmp/gone.rs".to_owned(),
             }],
+            vec![Ok(())],
         );
         let future = surface.update(&mut app, |surface, ctx| surface.accept_and_save(ctx));
-
-        surface.update(&mut app, |surface, ctx| {
-            surface.handle_diff_computed(0, Rc::new(DiffResult::default()), ctx);
-            surface.handle_file_saved(0, None, ctx);
-        });
 
         let RequestFileEditsResult::Success {
             updated_files,
             deleted_files,
+            lines_removed,
             ..
         } = future.await
         else {
@@ -146,6 +139,7 @@ fn deleted_paths_are_reported_as_deleted_files() {
         };
         assert!(updated_files.is_empty());
         assert_eq!(deleted_files, vec!["/tmp/gone.rs".to_owned()]);
+        assert_eq!(lines_removed, 1);
     });
 }
 

--- a/app/src/ai/blocklist/diff_storage_tests.rs
+++ b/app/src/ai/blocklist/diff_storage_tests.rs
@@ -1,0 +1,320 @@
+use std::collections::HashMap;
+use std::fs;
+
+use ai::agent::action_result::AnyFileContent;
+use ai::agent::FileLocations;
+use ai::diff_validation::{DiffDelta, DiffType};
+use warp_core::HostId;
+use warp_files::FileModel;
+use warpui::{App, ModelHandle};
+
+use super::*;
+
+/// Builds a headless storage over `diffs`, registering the `FileModel` its
+/// writes go through.
+fn add_headless(
+    app: &mut App,
+    diffs: Vec<FileDiff>,
+    session_type: DiffSessionType,
+) -> ModelHandle<HeadlessDiffStorageModel> {
+    app.add_singleton_model(FileModel::new);
+    app.add_model(|ctx| HeadlessDiffStorageModel::new(diffs, session_type, ctx))
+}
+
+/// Runs the shared accept flow for local diffs on a fresh app and awaits the result.
+async fn accept_local(app: &mut App, diffs: Vec<FileDiff>) -> RequestFileEditsResult {
+    let model = add_headless(app, diffs, DiffSessionType::Local);
+    let future = model.update(app, |model, ctx| {
+        DiffStorageView::accept_and_save(model, ctx)
+    });
+    future.await
+}
+
+#[test]
+fn accept_creates_a_new_file() {
+    App::test((), |mut app| async move {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("new.rs").to_string_lossy().to_string();
+
+        let result = accept_local(
+            &mut app,
+            vec![FileDiff::new(
+                String::new(),
+                path.clone(),
+                DiffType::creation("fn main() {}\n".to_owned()),
+            )],
+        )
+        .await;
+
+        let RequestFileEditsResult::Success {
+            updated_files,
+            deleted_files,
+            lines_added,
+            ..
+        } = result
+        else {
+            panic!("expected create to succeed");
+        };
+        assert_eq!(fs::read_to_string(&path).unwrap(), "fn main() {}\n");
+        assert_eq!(lines_added, 1);
+        assert_eq!(deleted_files, Vec::<String>::new());
+        assert_eq!(updated_files.len(), 1);
+        assert_eq!(updated_files[0].file_context.file_name, path);
+    });
+}
+
+#[test]
+fn accept_applies_deltas_to_update_a_file() {
+    App::test((), |mut app| async move {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("main.rs").to_string_lossy().to_string();
+        fs::write(&path, "one\ntwo\nthree\n").unwrap();
+
+        let result = accept_local(
+            &mut app,
+            vec![FileDiff::new(
+                "one\ntwo\nthree\n".to_owned(),
+                path.clone(),
+                DiffType::update(
+                    vec![DiffDelta {
+                        replacement_line_range: 2..3,
+                        insertion: "TWO\n".to_owned(),
+                    }],
+                    None,
+                ),
+            )],
+        )
+        .await;
+
+        assert!(matches!(result, RequestFileEditsResult::Success { .. }));
+        assert_eq!(fs::read_to_string(&path).unwrap(), "one\nTWO\nthree\n");
+    });
+}
+
+#[test]
+fn accept_renames_and_reports_source_as_deleted() {
+    App::test((), |mut app| async move {
+        let dir = tempfile::tempdir().unwrap();
+        let old_path = dir.path().join("old.rs").to_string_lossy().to_string();
+        let new_path = dir.path().join("new.rs").to_string_lossy().to_string();
+        fs::write(&old_path, "content\n").unwrap();
+
+        let result = accept_local(
+            &mut app,
+            vec![FileDiff::new(
+                "content\n".to_owned(),
+                old_path.clone(),
+                DiffType::update(Vec::new(), Some(new_path.clone())),
+            )],
+        )
+        .await;
+
+        let RequestFileEditsResult::Success { deleted_files, .. } = result else {
+            panic!("expected rename to succeed");
+        };
+        assert_eq!(fs::read_to_string(&new_path).unwrap(), "content\n");
+        assert!(!std::path::Path::new(&old_path).exists());
+        assert_eq!(deleted_files, vec![old_path]);
+    });
+}
+
+#[test]
+fn accept_deletes_a_file() {
+    App::test((), |mut app| async move {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gone.rs").to_string_lossy().to_string();
+        fs::write(&path, "delete me\n").unwrap();
+
+        let result = accept_local(
+            &mut app,
+            vec![FileDiff::new(
+                "delete me\n".to_owned(),
+                path.clone(),
+                DiffType::deletion(1),
+            )],
+        )
+        .await;
+
+        let RequestFileEditsResult::Success { deleted_files, .. } = result else {
+            panic!("expected delete to succeed");
+        };
+        assert!(!std::path::Path::new(&path).exists());
+        assert_eq!(deleted_files, vec![path]);
+    });
+}
+
+#[test]
+fn accept_reports_save_failure() {
+    App::test((), |mut app| async move {
+        let dir = tempfile::tempdir().unwrap();
+        // Create a regular file, then target a path *under* it. Creating the parent
+        // directory fails because a file exists where a directory is expected.
+        let blocking_file = dir.path().join("not_a_dir");
+        fs::write(&blocking_file, "x").unwrap();
+        let path = blocking_file.join("child.rs").to_string_lossy().to_string();
+
+        let result = accept_local(
+            &mut app,
+            vec![FileDiff::new(
+                String::new(),
+                path,
+                DiffType::creation("data\n".to_owned()),
+            )],
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            RequestFileEditsResult::DiffApplicationFailed { .. }
+        ));
+    });
+}
+
+#[test]
+fn take_candidate_diffs_relinquishes_only_before_saving() {
+    App::test((), |mut app| async move {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("x.rs").to_string_lossy().to_string();
+        let diff = FileDiff::new(
+            String::new(),
+            path,
+            DiffType::creation("fn main() {}\n".to_owned()),
+        );
+
+        // Before saving: the placeholder hands its diffs over exactly once.
+        let model = add_headless(&mut app, vec![diff.clone()], DiffSessionType::Local);
+        let taken = model.update(&mut app, |model, _| model.take_candidate_diffs());
+        assert!(taken.is_some());
+        let retaken = model.update(&mut app, |model, _| model.take_candidate_diffs());
+        assert!(retaken.is_none());
+
+        // Once saving has started, the diffs are no longer up for grabs.
+        let model = app.add_model(|ctx| {
+            HeadlessDiffStorageModel::new(vec![diff], DiffSessionType::Local, ctx)
+        });
+        let future = model.update(&mut app, |model, ctx| {
+            DiffStorageView::accept_and_save(model, ctx)
+        });
+        let taken = model.update(&mut app, |model, _| model.take_candidate_diffs());
+        assert!(taken.is_none());
+        future.await;
+    });
+}
+
+#[test]
+fn persist_action_renames_only_on_local_sessions() {
+    let rename_op = DiffType::update(Vec::new(), Some("/tmp/new.rs".to_owned()));
+
+    assert!(matches!(
+        PersistAction::resolve(&rename_op, &DiffSessionType::Local, "/tmp/old.rs"),
+        PersistAction::Rename(_)
+    ));
+    // Remote sessions have no rename primitive: the file is written in place.
+    assert!(matches!(
+        PersistAction::resolve(
+            &rename_op,
+            &DiffSessionType::Remote(HostId::new("host".to_owned())),
+            "/tmp/old.rs"
+        ),
+        PersistAction::Write
+    ));
+    // A "rename" to the same path is just a write.
+    assert!(matches!(
+        PersistAction::resolve(&rename_op, &DiffSessionType::Local, "/tmp/new.rs"),
+        PersistAction::Write
+    ));
+}
+
+#[test]
+fn remote_rename_outcome_reports_update_at_original_path() {
+    // The reported outcome must match the actual write: a remote rename falls
+    // back to writing the original path, so nothing is deleted and the update
+    // is reported at the original path — not the rename target.
+    let op = DiffType::update(Vec::new(), Some("/tmp/new.rs".to_owned()));
+    let diff = FileDiff::new("content\n".to_owned(), "/tmp/old.rs".to_owned(), op.clone());
+    let action = PersistAction::resolve(
+        &op,
+        &DiffSessionType::Remote(HostId::new("host".to_owned())),
+        "/tmp/old.rs",
+    );
+
+    let (state, _) = headless_file_outcome(&action, &diff, "/tmp/old.rs", "content!\n");
+
+    let updated = state.updated.expect("expected an updated file");
+    assert_eq!(updated.path, "/tmp/old.rs");
+    assert_eq!(state.deleted_paths, Vec::<String>::new());
+}
+
+#[test]
+fn final_content_from_op_applies_deltas() {
+    // No surface-supplied content (headless/TUI): final content is derived
+    // from the diff's deltas.
+    let op = DiffType::update(
+        vec![DiffDelta {
+            replacement_line_range: 2..3,
+            insertion: "TWO\n".to_owned(),
+        }],
+        None,
+    );
+
+    let final_content = final_content_from_op("one\ntwo\nthree\n", &op).unwrap();
+
+    assert_eq!(final_content, "one\nTWO\nthree\n");
+}
+
+#[test]
+fn updated_file_contexts_from_content_map_returns_changed_lines_with_context() {
+    let updated_files = vec![(
+        FileLocations {
+            name: "src/main.rs".to_string(),
+            lines: std::iter::once(12..13).collect(),
+        },
+        true,
+    )];
+    let content = (1..=30)
+        .map(|line| format!("line {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let content_map = HashMap::from([("src/main.rs".to_string(), content)]);
+
+    let contexts = updated_file_contexts_from_content_map(&updated_files, &content_map);
+
+    assert_eq!(contexts.len(), 1);
+    assert!(contexts[0].was_edited_by_user);
+    assert_eq!(contexts[0].file_context.file_name, "src/main.rs");
+    assert_eq!(contexts[0].file_context.line_range, Some(2..23));
+    assert_eq!(contexts[0].file_context.line_count, 30);
+    assert_eq!(
+        contexts[0].file_context.content,
+        AnyFileContent::StringContent(
+            (2..=22)
+                .map(|line| format!("line {line}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+    );
+}
+
+#[test]
+fn updated_file_contexts_from_content_map_preserves_full_file_when_no_ranges() {
+    let updated_files = vec![(
+        FileLocations {
+            name: "src/main.rs".to_string(),
+            lines: vec![],
+        },
+        false,
+    )];
+    let content = "line 1\nline 2\n".to_string();
+    let content_map = HashMap::from([("src/main.rs".to_string(), content.clone())]);
+
+    let contexts = updated_file_contexts_from_content_map(&updated_files, &content_map);
+
+    assert_eq!(contexts.len(), 1);
+    assert!(!contexts[0].was_edited_by_user);
+    assert_eq!(contexts[0].file_context.line_range, None);
+    assert_eq!(contexts[0].file_context.line_count, 2);
+    assert_eq!(
+        contexts[0].file_context.content,
+        AnyFileContent::StringContent(content)
+    );
+}

--- a/app/src/ai/blocklist/diff_storage_tests.rs
+++ b/app/src/ai/blocklist/diff_storage_tests.rs
@@ -8,7 +8,7 @@ use warpui::{App, Entity, ModelHandle};
 use super::*;
 
 /// Minimal [`DiffStorage`] impl: canned report state and a no-op write
-/// kickoff, so tests drive completion through the shared flow's handlers.
+/// kickoff, so tests drive completion through the [`DiffStorageHelper`] flow.
 struct TestSurface {
     save_state: DiffSaveState,
     files: Vec<PendingFileState>,

--- a/app/src/ai/blocklist/diff_storage_tests.rs
+++ b/app/src/ai/blocklist/diff_storage_tests.rs
@@ -1,265 +1,152 @@
 use std::collections::HashMap;
-use std::fs;
+use std::rc::Rc;
 
 use ai::agent::action_result::AnyFileContent;
 use ai::agent::FileLocations;
-use ai::diff_validation::{DiffDelta, DiffType};
-use warp_core::HostId;
-use warp_files::FileModel;
-use warpui::{App, ModelHandle};
+use warpui::{App, Entity, ModelHandle};
 
 use super::*;
 
-/// Builds a headless storage over `diffs`, registering the `FileModel` its
-/// writes go through.
-fn add_headless(
-    app: &mut App,
-    diffs: Vec<FileDiff>,
-    session_type: DiffSessionType,
-) -> ModelHandle<HeadlessDiffStorageModel> {
-    app.add_singleton_model(FileModel::new);
-    app.add_model(|ctx| HeadlessDiffStorageModel::new(diffs, session_type, ctx))
+/// Minimal [`DiffStorageView`] impl: canned report state and a no-op write
+/// kickoff, so tests drive completion through the shared flow's handlers.
+struct TestSurface {
+    save_state: DiffSaveState,
+    files: Vec<PendingFileState>,
 }
 
-/// Runs the shared accept flow for local diffs on a fresh app and awaits the result.
-async fn accept_local(app: &mut App, diffs: Vec<FileDiff>) -> RequestFileEditsResult {
-    let model = add_headless(app, diffs, DiffSessionType::Local);
-    let future = model.update(app, |model, ctx| {
-        DiffStorageView::accept_and_save(model, ctx)
-    });
-    future.await
+impl TestSurface {
+    fn new(files: Vec<PendingFileState>) -> Self {
+        Self {
+            save_state: DiffSaveState::default(),
+            files,
+        }
+    }
+}
+
+impl DiffStorageView for TestSurface {
+    fn save_state_mut(&mut self) -> &mut DiffSaveState {
+        &mut self.save_state
+    }
+
+    fn pending_diff_count(&self) -> usize {
+        self.files.len()
+    }
+
+    fn pending_file_state(&self, _app: &AppContext) -> Vec<PendingFileState> {
+        self.files.clone()
+    }
+
+    fn start_saving(&mut self, _app: &mut AppContext) {}
+}
+
+impl Entity for TestSurface {
+    type Event = ();
+}
+
+fn updated_file(path: &str, content: &str) -> PendingFileState {
+    PendingFileState {
+        updated: Some(UpdatedFileState {
+            path: path.to_owned(),
+            changed_lines: std::iter::once(1..2).collect(),
+            final_content: content.to_owned(),
+            was_edited: false,
+        }),
+        deleted_paths: Vec::new(),
+    }
+}
+
+fn add_surface(app: &mut App, files: Vec<PendingFileState>) -> ModelHandle<TestSurface> {
+    app.add_model(|_| TestSurface::new(files))
 }
 
 #[test]
-fn accept_creates_a_new_file() {
+fn accept_resolves_once_every_file_is_saved_and_computed() {
     App::test((), |mut app| async move {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("new.rs").to_string_lossy().to_string();
+        let surface = add_surface(&mut app, vec![updated_file("/tmp/x.rs", "fn main() {}\n")]);
+        let future = surface.update(&mut app, |surface, ctx| surface.accept_and_save(ctx));
 
-        let result = accept_local(
+        surface.update(&mut app, |surface, ctx| {
+            surface.handle_diff_computed(
+                0,
+                Rc::new(DiffResult {
+                    unified_diff: "+fn main() {}".to_owned(),
+                    lines_added: 1,
+                    lines_removed: 0,
+                }),
+                ctx,
+            );
+            surface.handle_file_saved(0, None, ctx);
+        });
+
+        let RequestFileEditsResult::Success {
+            diff,
+            updated_files,
+            deleted_files,
+            lines_added,
+            lines_removed,
+        } = future.await
+        else {
+            panic!("expected accept to succeed");
+        };
+        assert_eq!(diff, "+fn main() {}");
+        assert_eq!(lines_added, 1);
+        assert_eq!(lines_removed, 0);
+        assert_eq!(deleted_files, Vec::<String>::new());
+        assert_eq!(updated_files.len(), 1);
+        assert_eq!(updated_files[0].file_context.file_name, "/tmp/x.rs");
+    });
+}
+
+#[test]
+fn accept_reports_save_failure_for_the_whole_edit() {
+    App::test((), |mut app| async move {
+        let surface = add_surface(&mut app, vec![updated_file("/tmp/x.rs", "content\n")]);
+        let future = surface.update(&mut app, |surface, ctx| surface.accept_and_save(ctx));
+
+        surface.update(&mut app, |surface, ctx| {
+            surface.handle_diff_computed(0, Rc::new(DiffResult::default()), ctx);
+            surface.handle_file_saved(
+                0,
+                Some(Rc::new(FileSaveError::RemoteError("disk full".to_owned()))),
+                ctx,
+            );
+        });
+
+        let RequestFileEditsResult::DiffApplicationFailed { error } = future.await else {
+            panic!("expected a failed save to fail the edit");
+        };
+        assert!(error.contains("disk full"));
+    });
+}
+
+#[test]
+fn deleted_paths_are_reported_as_deleted_files() {
+    App::test((), |mut app| async move {
+        let surface = add_surface(
             &mut app,
-            vec![FileDiff::new(
-                String::new(),
-                path.clone(),
-                DiffType::creation("fn main() {}\n".to_owned()),
-            )],
-        )
-        .await;
+            vec![PendingFileState {
+                updated: None,
+                deleted_paths: vec!["/tmp/gone.rs".to_owned()],
+            }],
+        );
+        let future = surface.update(&mut app, |surface, ctx| surface.accept_and_save(ctx));
+
+        surface.update(&mut app, |surface, ctx| {
+            surface.handle_diff_computed(0, Rc::new(DiffResult::default()), ctx);
+            surface.handle_file_saved(0, None, ctx);
+        });
 
         let RequestFileEditsResult::Success {
             updated_files,
             deleted_files,
-            lines_added,
             ..
-        } = result
+        } = future.await
         else {
-            panic!("expected create to succeed");
-        };
-        assert_eq!(fs::read_to_string(&path).unwrap(), "fn main() {}\n");
-        assert_eq!(lines_added, 1);
-        assert_eq!(deleted_files, Vec::<String>::new());
-        assert_eq!(updated_files.len(), 1);
-        assert_eq!(updated_files[0].file_context.file_name, path);
-    });
-}
-
-#[test]
-fn accept_applies_deltas_to_update_a_file() {
-    App::test((), |mut app| async move {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("main.rs").to_string_lossy().to_string();
-        fs::write(&path, "one\ntwo\nthree\n").unwrap();
-
-        let result = accept_local(
-            &mut app,
-            vec![FileDiff::new(
-                "one\ntwo\nthree\n".to_owned(),
-                path.clone(),
-                DiffType::update(
-                    vec![DiffDelta {
-                        replacement_line_range: 2..3,
-                        insertion: "TWO\n".to_owned(),
-                    }],
-                    None,
-                ),
-            )],
-        )
-        .await;
-
-        assert!(matches!(result, RequestFileEditsResult::Success { .. }));
-        assert_eq!(fs::read_to_string(&path).unwrap(), "one\nTWO\nthree\n");
-    });
-}
-
-#[test]
-fn accept_renames_and_reports_source_as_deleted() {
-    App::test((), |mut app| async move {
-        let dir = tempfile::tempdir().unwrap();
-        let old_path = dir.path().join("old.rs").to_string_lossy().to_string();
-        let new_path = dir.path().join("new.rs").to_string_lossy().to_string();
-        fs::write(&old_path, "content\n").unwrap();
-
-        let result = accept_local(
-            &mut app,
-            vec![FileDiff::new(
-                "content\n".to_owned(),
-                old_path.clone(),
-                DiffType::update(Vec::new(), Some(new_path.clone())),
-            )],
-        )
-        .await;
-
-        let RequestFileEditsResult::Success { deleted_files, .. } = result else {
-            panic!("expected rename to succeed");
-        };
-        assert_eq!(fs::read_to_string(&new_path).unwrap(), "content\n");
-        assert!(!std::path::Path::new(&old_path).exists());
-        assert_eq!(deleted_files, vec![old_path]);
-    });
-}
-
-#[test]
-fn accept_deletes_a_file() {
-    App::test((), |mut app| async move {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("gone.rs").to_string_lossy().to_string();
-        fs::write(&path, "delete me\n").unwrap();
-
-        let result = accept_local(
-            &mut app,
-            vec![FileDiff::new(
-                "delete me\n".to_owned(),
-                path.clone(),
-                DiffType::deletion(1),
-            )],
-        )
-        .await;
-
-        let RequestFileEditsResult::Success { deleted_files, .. } = result else {
             panic!("expected delete to succeed");
         };
-        assert!(!std::path::Path::new(&path).exists());
-        assert_eq!(deleted_files, vec![path]);
+        assert!(updated_files.is_empty());
+        assert_eq!(deleted_files, vec!["/tmp/gone.rs".to_owned()]);
     });
-}
-
-#[test]
-fn accept_reports_save_failure() {
-    App::test((), |mut app| async move {
-        let dir = tempfile::tempdir().unwrap();
-        // Create a regular file, then target a path *under* it. Creating the parent
-        // directory fails because a file exists where a directory is expected.
-        let blocking_file = dir.path().join("not_a_dir");
-        fs::write(&blocking_file, "x").unwrap();
-        let path = blocking_file.join("child.rs").to_string_lossy().to_string();
-
-        let result = accept_local(
-            &mut app,
-            vec![FileDiff::new(
-                String::new(),
-                path,
-                DiffType::creation("data\n".to_owned()),
-            )],
-        )
-        .await;
-
-        assert!(matches!(
-            result,
-            RequestFileEditsResult::DiffApplicationFailed { .. }
-        ));
-    });
-}
-
-#[test]
-fn take_candidate_diffs_relinquishes_only_before_saving() {
-    App::test((), |mut app| async move {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("x.rs").to_string_lossy().to_string();
-        let diff = FileDiff::new(
-            String::new(),
-            path,
-            DiffType::creation("fn main() {}\n".to_owned()),
-        );
-
-        // Before saving: the placeholder hands its diffs over exactly once.
-        let model = add_headless(&mut app, vec![diff.clone()], DiffSessionType::Local);
-        let taken = model.update(&mut app, |model, _| model.take_candidate_diffs());
-        assert!(taken.is_some());
-        let retaken = model.update(&mut app, |model, _| model.take_candidate_diffs());
-        assert!(retaken.is_none());
-
-        // Once saving has started, the diffs are no longer up for grabs.
-        let model = app.add_model(|ctx| {
-            HeadlessDiffStorageModel::new(vec![diff], DiffSessionType::Local, ctx)
-        });
-        let future = model.update(&mut app, |model, ctx| {
-            DiffStorageView::accept_and_save(model, ctx)
-        });
-        let taken = model.update(&mut app, |model, _| model.take_candidate_diffs());
-        assert!(taken.is_none());
-        future.await;
-    });
-}
-
-#[test]
-fn persist_action_renames_only_on_local_sessions() {
-    let rename_op = DiffType::update(Vec::new(), Some("/tmp/new.rs".to_owned()));
-
-    assert!(matches!(
-        PersistAction::resolve(&rename_op, &DiffSessionType::Local, "/tmp/old.rs"),
-        PersistAction::Rename(_)
-    ));
-    // Remote sessions have no rename primitive: the file is written in place.
-    assert!(matches!(
-        PersistAction::resolve(
-            &rename_op,
-            &DiffSessionType::Remote(HostId::new("host".to_owned())),
-            "/tmp/old.rs"
-        ),
-        PersistAction::Write
-    ));
-    // A "rename" to the same path is just a write.
-    assert!(matches!(
-        PersistAction::resolve(&rename_op, &DiffSessionType::Local, "/tmp/new.rs"),
-        PersistAction::Write
-    ));
-}
-
-#[test]
-fn remote_rename_outcome_reports_update_at_original_path() {
-    // The reported outcome must match the actual write: a remote rename falls
-    // back to writing the original path, so nothing is deleted and the update
-    // is reported at the original path — not the rename target.
-    let op = DiffType::update(Vec::new(), Some("/tmp/new.rs".to_owned()));
-    let diff = FileDiff::new("content\n".to_owned(), "/tmp/old.rs".to_owned(), op.clone());
-    let action = PersistAction::resolve(
-        &op,
-        &DiffSessionType::Remote(HostId::new("host".to_owned())),
-        "/tmp/old.rs",
-    );
-
-    let (state, _) = headless_file_outcome(&action, &diff, "/tmp/old.rs", "content!\n");
-
-    let updated = state.updated.expect("expected an updated file");
-    assert_eq!(updated.path, "/tmp/old.rs");
-    assert_eq!(state.deleted_paths, Vec::<String>::new());
-}
-
-#[test]
-fn final_content_from_op_applies_deltas() {
-    // No surface-supplied content (headless/TUI): final content is derived
-    // from the diff's deltas.
-    let op = DiffType::update(
-        vec![DiffDelta {
-            replacement_line_range: 2..3,
-            insertion: "TWO\n".to_owned(),
-        }],
-        None,
-    );
-
-    let final_content = final_content_from_op("one\ntwo\nthree\n", &op).unwrap();
-
-    assert_eq!(final_content, "one\nTWO\nthree\n");
 }
 
 #[test]

--- a/app/src/ai/blocklist/diff_storage_tests.rs
+++ b/app/src/ai/blocklist/diff_storage_tests.rs
@@ -7,7 +7,7 @@ use warpui::{App, Entity, ModelHandle};
 
 use super::*;
 
-/// Minimal [`DiffStorageView`] impl: canned report state and a no-op write
+/// Minimal [`DiffStorage`] impl: canned report state and a no-op write
 /// kickoff, so tests drive completion through the shared flow's handlers.
 struct TestSurface {
     save_state: DiffSaveState,
@@ -23,7 +23,7 @@ impl TestSurface {
     }
 }
 
-impl DiffStorageView for TestSurface {
+impl DiffStorage for TestSurface {
     fn save_state_mut(&mut self) -> &mut DiffSaveState {
         &mut self.save_state
     }

--- a/app/src/ai/blocklist/diff_types.rs
+++ b/app/src/ai/blocklist/diff_types.rs
@@ -1,0 +1,107 @@
+//! Plain data types describing a resolved file diff, plus small pure helpers
+//! over them.
+//!
+//! These live outside the GUI `code_diff_view` module so that the shared,
+//! surface-agnostic executor and persistence models can name them without
+//! depending on any GUI view.
+use std::ops::Range;
+
+use ai::diff_validation::{DiffDelta, DiffType};
+use warp_core::HostId;
+
+/// The base content and file path for a diff.
+#[derive(Clone)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub struct DiffBase {
+    /// The original file content before the diff is applied.
+    /// Empty for new file creation.
+    pub content: String,
+    /// The absolute file path.
+    pub file_path: String,
+}
+
+/// User-visible file diff with the original contents of the file
+/// and the changes to those contents.
+#[derive(Clone)]
+#[cfg_attr(debug_assertions, derive(Debug))]
+pub struct FileDiff {
+    pub base: DiffBase,
+    pub diff_type: DiffType,
+}
+
+impl FileDiff {
+    /// Creates a `FileDiff` from base content, an absolute path, and the diff to apply.
+    pub fn new(content: String, file_path: String, diff_type: DiffType) -> FileDiff {
+        FileDiff {
+            base: DiffBase { content, file_path },
+            diff_type,
+        }
+    }
+
+    /// Returns the absolute path this diff targets.
+    pub fn file_path(&self) -> String {
+        self.base.file_path.clone()
+    }
+
+    /// Returns `(lines_added, lines_removed)` described by this diff's op.
+    pub fn line_stats(&self) -> (usize, usize) {
+        match &self.diff_type {
+            DiffType::Create { delta } => (line_count(&delta.insertion), 0),
+            DiffType::Delete { delta } => (
+                0,
+                delta
+                    .replacement_line_range
+                    .end
+                    .saturating_sub(delta.replacement_line_range.start),
+            ),
+            DiffType::Update { deltas, .. } => deltas.iter().fold((0, 0), |(add, rem), delta| {
+                let removed = delta
+                    .replacement_line_range
+                    .end
+                    .saturating_sub(delta.replacement_line_range.start);
+                (add + line_count(&delta.insertion), rem + removed)
+            }),
+        }
+    }
+}
+
+/// Counts lines in `content`, treating non-empty trailing text as its own line.
+fn line_count(content: &str) -> usize {
+    content.lines().count()
+}
+
+/// Whether a code diff targets the local filesystem or a remote host.
+#[derive(Clone, Debug)]
+pub enum DiffSessionType {
+    Local,
+    Remote(HostId),
+}
+
+/// Derives the 1-indexed changed line ranges described by a diff's deltas.
+pub(crate) fn changed_lines_from_op(diff_type: &DiffType) -> Vec<Range<usize>> {
+    match diff_type {
+        DiffType::Create { delta } => inserted_content_range(1, &delta.insertion)
+            .into_iter()
+            .collect(),
+        DiffType::Update { deltas, .. } => deltas
+            .iter()
+            .filter_map(changed_line_range_for_delta)
+            .collect(),
+        DiffType::Delete { .. } => vec![],
+    }
+}
+
+/// Maps a single delta to the line range it changed.
+fn changed_line_range_for_delta(delta: &DiffDelta) -> Option<Range<usize>> {
+    let replacement_range = &delta.replacement_line_range;
+    if replacement_range.start == replacement_range.end {
+        return inserted_content_range(replacement_range.start.max(1), &delta.insertion);
+    }
+    Some(replacement_range.clone())
+}
+
+/// Returns the line range covered by inserted content starting at `start`.
+fn inserted_content_range(start: usize, content: &str) -> Option<Range<usize>> {
+    let line_count = content.lines().count();
+    (line_count > 0).then_some(start..start + line_count)
+}

--- a/app/src/ai/blocklist/inline_action/code_diff_view.rs
+++ b/app/src/ai/blocklist/inline_action/code_diff_view.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -10,6 +9,9 @@ use ai::diff_validation::{
     SearchAndReplace, V4AHunk,
 };
 use anyhow::Result;
+use futures::channel::oneshot;
+use futures::future::BoxFuture;
+use futures::FutureExt;
 use lazy_static::lazy_static;
 use markdown_parser::{FormattedText, FormattedTextFragment, FormattedTextLine};
 use pathfinder_geometry::vector::vec2f;
@@ -22,10 +24,8 @@ use warp_core::ui::appearance::Appearance;
 use warp_core::ui::color::CLAUDE_ORANGE;
 use warp_core::ui::theme::color::internal_colors::{fg_overlay_6, neutral_1, neutral_4};
 use warp_core::ui::theme::Fill;
-use warp_core::HostId;
 use warp_editor::content::buffer::InitialBufferState;
 use warp_editor::render::element::VerticalExpansionBehavior;
-use warp_util::file::FileSaveError;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::remote_path::RemotePath;
 use warp_util::standardized_path::StandardizedPath;
@@ -44,17 +44,23 @@ use warpui::platform::{Cursor, OperatingSystem};
 use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
 use warpui::{
     AppContext, Element, Entity, FocusContext, ModelHandle, SingletonEntity, TypedActionView, View,
-    ViewContext, ViewHandle,
+    ViewContext, ViewHandle, WeakViewHandle,
 };
 
 use super::malformed_line_heuristics::has_malformed_terminal_correction_signal;
 use crate::ai::agent::icons::{self, yellow_stop_icon};
-use crate::ai::agent::{AIAgentActionId, AIIdentifiers, FileEdit, FileLocations, ServerOutputId};
+use crate::ai::agent::{
+    AIAgentActionId, AIIdentifiers, FileEdit, RequestFileEditsResult, ServerOutputId,
+};
 use crate::ai::blocklist::action_model::{
     AIActionStatus, BlocklistAIActionEvent, BlocklistAIActionModel,
     EditAcceptAndContinueClickedEvent, EditAcceptClickedEvent, EditResolvedEvent, EditStats,
     MalformedFinalLineProxyEvent, RequestFileEditsFormatKind, RequestFileEditsTelemetryEvent,
 };
+use crate::ai::blocklist::diff_storage::{
+    DiffStorageView, PendingFileState, RegisteredDiffStorage, SavingDiffs, UpdatedFileState,
+};
+use crate::ai::blocklist::diff_types::{changed_lines_from_op, DiffSessionType, FileDiff};
 use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
 use crate::ai::blocklist::inline_action::inline_action_header::INLINE_ACTION_HORIZONTAL_PADDING;
 use crate::ai::blocklist::inline_action::inline_action_icons::{
@@ -74,7 +80,6 @@ use crate::code::diff_viewer::{DiffViewer, DisplayMode};
 use crate::code::editor::view::{CodeEditorEvent, CodeEditorRenderOptions, CodeEditorView};
 use crate::code::editor::{add_color, remove_color};
 use crate::code::inline_diff::{InlineDiffView, InlineDiffViewEvent};
-use crate::code::DiffResult;
 use crate::code_review::telemetry_event::CodeReviewPaneEntrypoint;
 use crate::menu::{Event as MenuEvent, Menu, MenuItemFields, MenuVariant};
 use crate::pane_group::focus_state::PaneFocusHandle;
@@ -212,17 +217,6 @@ struct CodeDiffViewMouseStates {
 pub enum CodeDiffViewEvent {
     TryAccept,
     EnableAutoexecuteMode,
-    SavedAcceptedDiffs {
-        diff: DiffResult,
-        updated_files: Vec<(FileLocations, bool)>,
-        /// The accepted file contents keyed by file path, extracted from the
-        /// editor buffers at the time of acceptance. This avoids re-reading
-        /// files from disk (or the remote server) when building context for
-        /// the LLM.
-        file_contents: Vec<(String, String)>,
-        deleted_files: Vec<String>,
-        save_errors: Vec<Rc<FileSaveError>>,
-    },
     Rejected,
     Pane(PaneEvent),
     EditModeChanged {
@@ -258,109 +252,6 @@ pub enum CodeDiffViewEvent {
     },
 }
 
-/// The base content and file path for a diff.
-#[derive(Clone)]
-#[cfg_attr(debug_assertions, derive(Debug))]
-pub struct DiffBase {
-    /// The original file content before the diff is applied.
-    /// Empty for new file creation.
-    pub content: String,
-    /// The absolute file path.
-    pub file_path: String,
-}
-
-/// User-visible file diff with the original contents of the file
-/// and the changes to those contents.
-#[derive(Clone)]
-#[cfg_attr(debug_assertions, derive(Debug))]
-pub struct FileDiff {
-    pub base: DiffBase,
-    pub diff_type: DiffType,
-}
-
-impl FileDiff {
-    pub fn new(content: String, file_path: String, diff_type: DiffType) -> FileDiff {
-        FileDiff {
-            base: DiffBase { content, file_path },
-            diff_type,
-        }
-    }
-
-    pub fn file_path(&self) -> String {
-        self.base.file_path.clone()
-    }
-}
-
-/// The state of the saving diffs for a list of files.
-///
-/// When the requested edit is accepted, we have to 1) wait for the diff to be computed
-/// by the CodeDiffModel for each file 2) wait for the changes to be saved locally.
-///
-/// After the above two conditions are all met, we can emit the Accepted event with all of the diffs.
-/// This tracks which diffs have been computed.
-#[derive(Clone, Debug)]
-#[cfg_attr(target_family = "wasm", allow(dead_code))]
-pub struct SavingDiffs {
-    pending_diffs: Vec<DiffApplicationState>,
-}
-
-impl SavingDiffs {
-    /// Initialize an accepted diff state with N files.
-    fn new(length: usize) -> Self {
-        Self {
-            pending_diffs: vec![DiffApplicationState::default(); length],
-        }
-    }
-
-    /// Returns true if all of the diffs are saved and computed.
-    fn pending_diff_is_complete(&self) -> bool {
-        self.pending_diffs
-            .iter()
-            .all(|diff| diff.computed_diff.is_some() && diff.save_status.is_complete())
-    }
-
-    /// Update the diff application save state at the given idx.
-    fn mark_diff_saved(&mut self, idx: usize, save_error: Option<Rc<FileSaveError>>) {
-        if let Some(state) = self.pending_diffs.get_mut(idx) {
-            state.save_status = match save_error {
-                None => SaveStatus::Success,
-                Some(error) => SaveStatus::Failed(error),
-            };
-        }
-    }
-
-    /// Update the diff application compute state at the given idx.
-    fn mark_diff_computed(&mut self, idx: usize, diff: Rc<DiffResult>) {
-        if let Some(state) = self.pending_diffs.get_mut(idx) {
-            state.computed_diff = Some(diff);
-        }
-    }
-}
-
-/// The status of saving a file.
-#[derive(Clone, Debug, Default)]
-#[cfg_attr(target_family = "wasm", allow(dead_code))]
-enum SaveStatus {
-    #[default]
-    Pending,
-    Success,
-    Failed(Rc<FileSaveError>),
-}
-
-impl SaveStatus {
-    fn is_complete(&self) -> bool {
-        !matches!(self, SaveStatus::Pending)
-    }
-}
-
-/// The diff application state for a single file.
-#[derive(Clone, Debug, Default)]
-#[cfg_attr(target_family = "wasm", allow(dead_code))]
-struct DiffApplicationState {
-    computed_diff: Option<Rc<DiffResult>>,
-    save_status: SaveStatus,
-}
-
 #[derive(Clone, Debug)]
 pub enum CodeDiffState {
     /// The diff is received, but is queued for interaction behind another action.
@@ -368,10 +259,8 @@ pub enum CodeDiffState {
     /// The user is reviewing (and possibly editing) the code diff.
     /// Unlike requested commands, a [`CodeDiffView`] is only created upon stream completion.
     WaitingForUser,
-    /// If the payload is some, the code diff was accepted but the individual file changes have not
-    /// been fully computed and saved yet. We cache the accepted diff state to collect unified diffs
-    /// from each file source.
-    Accepted(Option<SavingDiffs>),
+    /// The user accepted the diff; persistence happens off-view.
+    Accepted,
     /// The user rejected this code diff.
     Rejected,
     /// The changes were reverted after acceptance.
@@ -385,7 +274,7 @@ impl CodeDiffState {
     fn is_complete(&self) -> bool {
         matches!(
             self,
-            CodeDiffState::Accepted(_)
+            CodeDiffState::Accepted
                 | CodeDiffState::Rejected
                 | CodeDiffState::Reverted
                 | CodeDiffState::ViewOnly { is_complete: true }
@@ -441,20 +330,57 @@ enum AcceptSelection {
     AndContinueWithAgent,
 }
 
-/// Whether a code diff targets the local filesystem or a remote host.
-#[derive(Clone, Debug)]
-pub enum DiffSessionType {
-    Local,
-    Remote(HostId),
-}
-
 #[derive(Clone)]
 struct PendingDiff {
     diff_view: ViewHandle<InlineDiffView>,
     tab_handle: MouseStateHandle,
 }
 
-#[derive(Clone)]
+/// Executor-registered [`RegisteredDiffStorage`] over a GUI [`CodeDiffView`].
+///
+/// Holds a weak handle so the executor never keeps a dead review view alive; a
+/// dead view at execute time fails recoverably.
+pub struct GuiDiffStorage(pub WeakViewHandle<CodeDiffView>);
+
+impl RegisteredDiffStorage for GuiDiffStorage {
+    fn set_candidate_diffs(
+        &self,
+        diffs: Vec<FileDiff>,
+        session_type: DiffSessionType,
+        app: &mut AppContext,
+    ) {
+        let Some(view) = self.0.upgrade(app) else {
+            return;
+        };
+        view.update(app, |view, ctx| {
+            view.set_diff_session_type(session_type);
+            view.set_candidate_diffs(diffs, ctx);
+        });
+    }
+
+    /// The GUI never relinquishes its diffs; they live in its editor buffers.
+    fn take_candidate_diffs(
+        &self,
+        _app: &mut AppContext,
+    ) -> Option<(Vec<FileDiff>, DiffSessionType)> {
+        None
+    }
+
+    fn accept_and_save(&self, app: &mut AppContext) -> BoxFuture<'static, RequestFileEditsResult> {
+        let Some(view) = self.0.upgrade(app) else {
+            log::warn!("RequestFileEdits review view vanished before execute");
+            return futures::future::ready(RequestFileEditsResult::DiffApplicationFailed {
+                error: "The review surface holding these edits no longer exists".to_string(),
+            })
+            .boxed();
+        };
+        view.update(app, |view, ctx| {
+            view.mark_accepted_for_save(ctx);
+            DiffStorageView::accept_and_save(view, ctx)
+        })
+    }
+}
+
 pub struct CodeDiffView {
     action_id: AIAgentActionId,
 
@@ -494,6 +420,11 @@ pub struct CodeDiffView {
     session_platform: Option<SessionPlatform>,
     /// Whether diffs target local disk or a remote host.
     diff_session_type: DiffSessionType,
+    /// Per-file save/diff progress for an in-flight accept (shared
+    /// [`DiffStorageView`] flow).
+    saving_diffs: Option<SavingDiffs>,
+    /// Result delivery for an in-flight accept.
+    save_result_tx: Option<oneshot::Sender<RequestFileEditsResult>>,
 }
 
 impl CodeDiffView {
@@ -626,7 +557,7 @@ impl CodeDiffView {
             }
             #[cfg(not(target_family = "wasm"))]
             InlineDiffViewEvent::FileSaved => {
-                me.handle_save_completed(idx, None, ctx);
+                me.handle_file_saved(idx, None, ctx);
             }
             #[cfg(not(target_family = "wasm"))]
             InlineDiffViewEvent::FailedToSave { error } => {
@@ -640,10 +571,10 @@ impl CodeDiffView {
                 ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
                     toast_stack.add_ephemeral_toast(toast, window_id, ctx);
                 });
-                me.handle_save_completed(idx, Some(error.clone()), ctx);
+                me.handle_file_saved(idx, Some(error.clone()), ctx);
             }
             InlineDiffViewEvent::DiffAccepted { diff } => {
-                me.accepted_file_diff_computed(idx, diff.clone(), ctx);
+                me.handle_diff_computed(idx, diff.clone(), ctx);
             }
             InlineDiffViewEvent::UserEdited => {
                 if me.user_edited_file_contents {
@@ -714,6 +645,13 @@ impl CodeDiffView {
                             } else if status.is_cancelled() {
                                 me.state = CodeDiffState::Rejected;
                                 me.should_expand_when_complete = false;
+                            } else if status.is_success() {
+                                // Terminal success without this view having saved
+                                // (e.g. the headless fallback executed before this
+                                // view registered): stop offering Accept for edits
+                                // that already executed.
+                                me.state = CodeDiffState::Accepted;
+                                me.minimize(ctx);
                             }
                             ctx.notify();
                         }
@@ -930,6 +868,8 @@ impl CodeDiffView {
             should_show_speedbump,
             session_platform,
             diff_session_type: DiffSessionType::Local,
+            saving_diffs: None,
+            save_result_tx: None,
         }
     }
 
@@ -1018,24 +958,6 @@ impl CodeDiffView {
         ctx.notify();
     }
 
-    /// Save the file and mark the diff as accepted.
-    pub fn accept_and_save(&mut self, ctx: &mut ViewContext<Self>) {
-        // Don't let users save an old diff while in view-only mode.
-        if matches!(self.state, CodeDiffState::ViewOnly { .. }) {
-            return;
-        }
-
-        // Todo:   kc INT-328 Handle error in save
-        for diff in &self.pending_diffs {
-            diff.diff_view
-                .update(ctx, |v, ctx| v.accept_and_save_diff(ctx));
-        }
-        self.state = CodeDiffState::Accepted(Some(SavingDiffs::new(self.pending_diffs.len())));
-        ctx.notify();
-
-        self.minimize(ctx);
-    }
-
     pub fn try_accept_action(&mut self, ctx: &mut ViewContext<Self>) {
         let _ = self.try_accept_action_with_selection(AcceptSelection::Only, ctx);
     }
@@ -1082,7 +1004,27 @@ impl CodeDiffView {
         }
 
         ctx.emit(CodeDiffViewEvent::TryAccept);
+
+        // Persistence and result assembly run through the shared
+        // [`DiffStorageView`] flow once the executor (or the passive handler)
+        // calls `accept_and_save`. Optimistically mark the diff accepted and
+        // minimize the review UI.
+        self.state = CodeDiffState::Accepted;
+        self.minimize(ctx);
+        ctx.notify();
         Ok(())
+    }
+
+    /// Flips the view into the accepted state as persistence kicks off. No-op
+    /// once the diff reached a terminal state (user-initiated accepts already
+    /// flipped it in `try_accept_action_with_selection`).
+    pub fn mark_accepted_for_save(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.state.is_complete() {
+            return;
+        }
+        self.state = CodeDiffState::Accepted;
+        self.minimize(ctx);
+        ctx.notify();
     }
 
     /// Mark the diff as rejected.
@@ -1116,9 +1058,9 @@ impl CodeDiffView {
     /// Revert all changes by replacing file contents with the base version.
     /// For newly created files, this deletes them instead.
     fn revert_changes(&mut self, ctx: &mut ViewContext<Self>) {
-        if !matches!(self.state, CodeDiffState::Accepted(None)) {
+        if !matches!(self.state, CodeDiffState::Accepted) || self.saving_diffs.is_some() {
             log::warn!(
-                "Attempted to revert changes when not in Accepted(None) state - actual state: {:?}",
+                "Attempted to revert changes when not in a settled Accepted state - actual state: {:?}",
                 self.state
             );
             return;
@@ -1438,7 +1380,7 @@ impl CodeDiffView {
         };
 
         let icon = match self.state {
-            CodeDiffState::Accepted(_) | CodeDiffState::ViewOnly { is_complete: true } => {
+            CodeDiffState::Accepted | CodeDiffState::ViewOnly { is_complete: true } => {
                 green_check_icon(appearance).finish()
             }
             CodeDiffState::Rejected => cancelled_icon(appearance).finish(),
@@ -2269,196 +2211,75 @@ impl CodeDiffView {
         );
     }
 
-    /// We are processing unified diff and saving files concurrently. That's why
-    /// we need to have separate handlers for diff calculation and save completed.
-    ///
-    /// The diffs applied for each CodeEditorView are received individually.
-    /// Store this diff, and try to emit the diffs saved event.
-    #[cfg_attr(target_family = "wasm", allow(dead_code))]
-    fn accepted_file_diff_computed(
-        &mut self,
-        file_idx: usize,
-        diff: Rc<DiffResult>,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        if let CodeDiffState::Accepted(Some(state)) = &mut self.state {
-            state.mark_diff_computed(file_idx, diff);
-            self.try_emit_diffs_saved(ctx);
-        } else {
-            log::warn!("Received computed diff when not in accepted state");
-        }
-    }
+    /// Emits the malformed-final-line proxy telemetry, computed from editor state
+    /// at accept time. Called by the review surface when the user accepts.
+    pub fn send_malformed_line_telemetry(&self, ctx: &mut ViewContext<Self>) {
+        let mut edited_file_count = 0;
+        let mut correction_count = 0;
+        let mut edited_correction_count = 0;
+        let mut unedited_correction_count = 0;
 
-    /// We are processing unified diff and saving files concurrently. That's why
-    /// we need to have separate handlers for diff calculation and save completed.
-    ///
-    /// The save state for each CodeEditorView are received individually.
-    /// Update the accepted diff state, and try to emit the diffs saved event.
-    #[cfg_attr(target_family = "wasm", allow(dead_code))]
-    fn handle_save_completed(
-        &mut self,
-        file_idx: usize,
-        save_error: Option<Rc<FileSaveError>>,
-        ctx: &mut ViewContext<Self>,
-    ) {
-        if let CodeDiffState::Accepted(Some(state)) = &mut self.state {
-            state.mark_diff_saved(file_idx, save_error);
-            self.try_emit_diffs_saved(ctx);
-        } else if !matches!(self.state, CodeDiffState::Reverted) {
-            log::warn!("Received saved diff when not in accepted or reverted state");
-        }
-    }
-
-    /// Check if we have all pending diffs computed and saved.
-    /// Emit the SavedAcceptedDiffs event if so.
-    #[cfg_attr(target_family = "wasm", allow(dead_code))]
-    fn try_emit_diffs_saved(&mut self, ctx: &mut ViewContext<Self>) {
-        if let CodeDiffState::Accepted(state) = &mut self.state {
-            let is_complete = state
-                .as_ref()
-                .map(|diff_state| diff_state.pending_diff_is_complete())
-                .unwrap_or(false);
-
-            if is_complete {
-                let replaced_state = state.take().expect("Checked above");
-
-                let mut combined_diff = DiffResult::default();
-                let mut save_errors = Vec::new();
-                for diff_state in replaced_state.pending_diffs {
-                    if let Some(diff) = diff_state.computed_diff {
-                        combined_diff += diff.as_ref();
-                    }
-                    if let SaveStatus::Failed(error) = diff_state.save_status {
-                        save_errors.push(error);
-                    }
-                }
-
-                let mut updated_files = Vec::new();
-                let mut deleted_files = Vec::new();
-                let mut edited_file_count = 0;
-                let mut correction_count = 0;
-                let mut edited_correction_count = 0;
-                let mut unedited_correction_count = 0;
-
-                for diff in self.pending_diffs.iter() {
-                    let Some(path) = diff.diff_view.as_ref(ctx).file_path() else {
-                        continue;
-                    };
-
-                    let mut file_path_str = path.to_string();
-                    if matches!(
-                        diff.diff_view.as_ref(ctx).diff(),
-                        Some(DiffType::Delete { .. })
-                    ) {
-                        deleted_files.push(file_path_str);
-                    } else {
-                        // If this was a rename, the file being renamed should be considered "deleted".
-                        if let Some(DiffType::Update {
-                            rename: Some(rename),
-                            ..
-                        }) = diff.diff_view.as_ref(ctx).diff()
-                        {
-                            deleted_files.push(file_path_str);
-                            file_path_str = rename.to_string_lossy().to_string();
-                        }
-                        let was_edited = diff.diff_view.as_ref(ctx).was_edited();
-                        let editor_changed_lines = diff.diff_view.as_ref(ctx).changed_lines(ctx);
-                        let changed_lines = changed_lines_for_result(
-                            editor_changed_lines.clone(),
-                            diff.diff_view.as_ref(ctx).diff(),
-                        );
-                        let changed_lines_for_malformed_signal = if editor_changed_lines.is_empty()
-                        {
-                            changed_lines
-                                .iter()
-                                .cloned()
-                                .map(file_context_range_to_editor_range)
-                                .collect()
-                        } else {
-                            editor_changed_lines
-                        };
-                        let has_malformed_terminal_signal = diff
-                            .diff_view
-                            .as_ref(ctx)
-                            .diff()
-                            .is_some_and(|editor_diff| {
-                                has_malformed_terminal_correction_signal(
-                                    editor_diff,
-                                    &changed_lines_for_malformed_signal,
-                                )
-                            });
-
-                        if was_edited {
-                            edited_file_count += 1;
-                        }
-                        if has_malformed_terminal_signal {
-                            correction_count += 1;
-                            if was_edited {
-                                edited_correction_count += 1;
-                            } else {
-                                unedited_correction_count += 1;
-                            }
-                        }
-                        updated_files.push((
-                            FileLocations {
-                                name: file_path_str,
-                                lines: changed_lines,
-                            },
-                            was_edited,
-                        ));
-                    }
-                }
-                if correction_count > 0 {
-                    send_telemetry_from_ctx!(
-                        RequestFileEditsTelemetryEvent::MalformedFinalLineProxy(
-                            MalformedFinalLineProxyEvent {
-                                identifiers: self.identifiers.clone(),
-                                file_count: self.pending_diffs.len(),
-                                edited_file_count,
-                                correction_count,
-                                edited_correction_count,
-                                unedited_correction_count,
-                                format_kind: self.edit_format_kind,
-                                passive_diff: self.is_passive,
-                            }
-                        ),
-                        ctx
-                    );
-                }
-
-                // Extract accepted file contents from editor buffers so the
-                // executor doesn't need to re-read from disk or the network.
-                let file_contents: Vec<(String, String)> = self
-                    .pending_diffs
-                    .iter()
-                    .filter_map(|diff| {
-                        let path = diff.diff_view.as_ref(ctx).file_path()?.to_string();
-                        // Skip deleted files — they have no meaningful content.
-                        if matches!(
-                            diff.diff_view.as_ref(ctx).diff(),
-                            Some(DiffType::Delete { .. })
-                        ) {
-                            return None;
-                        }
-                        let content = diff
-                            .diff_view
-                            .as_ref(ctx)
-                            .editor()
-                            .as_ref(ctx)
-                            .text(ctx)
-                            .into_string();
-                        Some((path, content))
-                    })
-                    .collect();
-
-                ctx.emit(CodeDiffViewEvent::SavedAcceptedDiffs {
-                    diff: combined_diff,
-                    updated_files,
-                    file_contents,
-                    deleted_files,
-                    save_errors,
-                });
+        for diff in self.pending_diffs.iter() {
+            // Deletes have no content changes to analyze.
+            if matches!(
+                diff.diff_view.as_ref(ctx).diff(),
+                Some(DiffType::Delete { .. })
+            ) {
+                continue;
             }
+            let was_edited = diff.diff_view.as_ref(ctx).was_edited();
+            let editor_changed_lines = diff.diff_view.as_ref(ctx).changed_lines(ctx);
+            let changed_lines_for_malformed_signal = if editor_changed_lines.is_empty() {
+                changed_lines_for_result(
+                    editor_changed_lines.clone(),
+                    diff.diff_view.as_ref(ctx).diff(),
+                )
+                .into_iter()
+                .map(file_context_range_to_editor_range)
+                .collect()
+            } else {
+                editor_changed_lines
+            };
+            let has_malformed_terminal_signal =
+                diff.diff_view
+                    .as_ref(ctx)
+                    .diff()
+                    .is_some_and(|editor_diff| {
+                        has_malformed_terminal_correction_signal(
+                            editor_diff,
+                            &changed_lines_for_malformed_signal,
+                        )
+                    });
+
+            if was_edited {
+                edited_file_count += 1;
+            }
+            if has_malformed_terminal_signal {
+                correction_count += 1;
+                if was_edited {
+                    edited_correction_count += 1;
+                } else {
+                    unedited_correction_count += 1;
+                }
+            }
+        }
+
+        if correction_count > 0 {
+            send_telemetry_from_ctx!(
+                RequestFileEditsTelemetryEvent::MalformedFinalLineProxy(
+                    MalformedFinalLineProxyEvent {
+                        identifiers: self.identifiers.clone(),
+                        file_count: self.pending_diffs.len(),
+                        edited_file_count,
+                        correction_count,
+                        edited_correction_count,
+                        unedited_correction_count,
+                        format_kind: self.edit_format_kind,
+                        passive_diff: self.is_passive,
+                    }
+                ),
+                ctx
+            );
         }
     }
 
@@ -3129,6 +2950,74 @@ pub fn convert_file_edits_to_file_diffs(
         .collect()
 }
 
+impl DiffStorageView for CodeDiffView {
+    fn saving_diffs_mut(&mut self) -> &mut Option<SavingDiffs> {
+        &mut self.saving_diffs
+    }
+
+    fn result_tx_mut(&mut self) -> &mut Option<oneshot::Sender<RequestFileEditsResult>> {
+        &mut self.save_result_tx
+    }
+
+    fn pending_diff_count(&self) -> usize {
+        self.pending_diffs.len()
+    }
+
+    /// Extracts each file's report state from the diff views and editor
+    /// buffers: final (possibly user-edited) content, changed lines, and
+    /// rename/delete bookkeeping.
+    fn pending_file_state(&self, app: &AppContext) -> Vec<PendingFileState> {
+        self.pending_diffs
+            .iter()
+            .filter_map(|diff| {
+                let diff_view = diff.diff_view.as_ref(app);
+                let path = diff_view.file_path()?.to_string();
+                if matches!(diff_view.diff(), Some(DiffType::Delete { .. })) {
+                    return Some(PendingFileState {
+                        updated: None,
+                        deleted_paths: vec![path],
+                    });
+                }
+
+                // A rename reports the source path as deleted and the update
+                // at the rename target.
+                let mut deleted_paths = Vec::new();
+                let mut report_path = path;
+                if let Some(DiffType::Update {
+                    rename: Some(rename),
+                    ..
+                }) = diff_view.diff()
+                {
+                    deleted_paths.push(report_path.clone());
+                    report_path = rename.to_string_lossy().to_string();
+                }
+
+                let changed_lines =
+                    changed_lines_for_result(diff_view.changed_lines(app), diff_view.diff());
+                let final_content = diff_view.editor().as_ref(app).text(app).into_string();
+                Some(PendingFileState {
+                    updated: Some(UpdatedFileState {
+                        path: report_path,
+                        changed_lines,
+                        final_content,
+                        was_edited: diff_view.was_edited(),
+                    }),
+                    deleted_paths,
+                })
+            })
+            .collect()
+    }
+
+    /// Saves every file through its editor buffer; completions arrive via the
+    /// per-file `InlineDiffView` subscriptions.
+    fn start_saving(&mut self, app: &mut AppContext) {
+        for diff in &self.pending_diffs {
+            diff.diff_view
+                .update(app, |view, ctx| view.accept_and_save_diff(ctx));
+        }
+    }
+}
+
 impl BackingView for CodeDiffView {
     type PaneHeaderOverflowMenuAction = CodeDiffViewAction;
     type CustomAction = ();
@@ -3219,30 +3108,7 @@ fn changed_lines_for_result(
             .collect();
     }
 
-    match diff_type {
-        Some(DiffType::Create { delta }) => inserted_content_range(1, &delta.insertion)
-            .into_iter()
-            .collect(),
-        Some(DiffType::Update { deltas, .. }) => deltas
-            .iter()
-            .filter_map(changed_line_range_for_delta)
-            .collect(),
-        Some(DiffType::Delete { .. }) | None => vec![],
-    }
-}
-
-fn changed_line_range_for_delta(delta: &DiffDelta) -> Option<Range<usize>> {
-    let replacement_range = &delta.replacement_line_range;
-    if replacement_range.start == replacement_range.end {
-        return inserted_content_range(replacement_range.start.max(1), &delta.insertion);
-    }
-
-    Some(replacement_range.clone())
-}
-
-fn inserted_content_range(start: usize, content: &str) -> Option<Range<usize>> {
-    let line_count = content.lines().count();
-    (line_count > 0).then_some(start..start + line_count)
+    diff_type.map(changed_lines_from_op).unwrap_or_default()
 }
 
 fn editor_range_to_file_context_range(range: Range<usize>) -> Range<usize> {

--- a/app/src/ai/blocklist/inline_action/code_diff_view.rs
+++ b/app/src/ai/blocklist/inline_action/code_diff_view.rs
@@ -347,6 +347,7 @@ impl RegisteredDiffStorage for WeakViewHandle<CodeDiffView> {
         app: &mut AppContext,
     ) {
         let Some(view) = self.upgrade(app) else {
+            log::error!("RequestFileEdits review view vanished before diffs resolved");
             return;
         };
         view.update(app, |view, ctx| {
@@ -627,12 +628,6 @@ impl CodeDiffView {
                             } else if status.is_cancelled() {
                                 me.state = CodeDiffState::Rejected;
                                 me.should_expand_when_complete = false;
-                            } else if status.is_success() {
-                                // Terminal success that didn't flow through this
-                                // view's save (e.g. a restored conversation whose
-                                // edits already executed): stop offering Accept.
-                                me.state = CodeDiffState::Accepted;
-                                me.minimize(ctx);
                             }
                             ctx.notify();
                         }
@@ -988,9 +983,7 @@ impl CodeDiffView {
         // [`DiffStorageHelper`] flow once the executor (or the passive
         // handler) calls `accept_and_save`. Optimistically mark the diff
         // accepted and minimize the review UI.
-        self.state = CodeDiffState::Accepted;
-        self.minimize(ctx);
-        ctx.notify();
+        self.mark_accepted_for_save(ctx);
         Ok(())
     }
 

--- a/app/src/ai/blocklist/inline_action/code_diff_view.rs
+++ b/app/src/ai/blocklist/inline_action/code_diff_view.rs
@@ -9,7 +9,6 @@ use ai::diff_validation::{
     SearchAndReplace, V4AHunk,
 };
 use anyhow::Result;
-use futures::channel::oneshot;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use lazy_static::lazy_static;
@@ -58,7 +57,7 @@ use crate::ai::blocklist::action_model::{
     MalformedFinalLineProxyEvent, RequestFileEditsFormatKind, RequestFileEditsTelemetryEvent,
 };
 use crate::ai::blocklist::diff_storage::{
-    DiffStorageView, PendingFileState, RegisteredDiffStorage, SavingDiffs, UpdatedFileState,
+    DiffSaveState, DiffStorageView, PendingFileState, RegisteredDiffStorage, UpdatedFileState,
 };
 use crate::ai::blocklist::diff_types::{changed_lines_from_op, DiffSessionType, FileDiff};
 use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
@@ -336,20 +335,17 @@ struct PendingDiff {
     tab_handle: MouseStateHandle,
 }
 
-/// Executor-registered [`RegisteredDiffStorage`] over a GUI [`CodeDiffView`].
-///
-/// Holds a weak handle so the executor never keeps a dead review view alive; a
-/// dead view at execute time fails recoverably.
-pub struct GuiDiffStorage(pub WeakViewHandle<CodeDiffView>);
-
-impl RegisteredDiffStorage for GuiDiffStorage {
+/// The GUI review surface registers as a weak handle so the executor never
+/// keeps a dead review view alive; a dead view at execute time fails
+/// recoverably.
+impl RegisteredDiffStorage for WeakViewHandle<CodeDiffView> {
     fn set_candidate_diffs(
         &self,
         diffs: Vec<FileDiff>,
         session_type: DiffSessionType,
         app: &mut AppContext,
     ) {
-        let Some(view) = self.0.upgrade(app) else {
+        let Some(view) = self.upgrade(app) else {
             return;
         };
         view.update(app, |view, ctx| {
@@ -358,16 +354,8 @@ impl RegisteredDiffStorage for GuiDiffStorage {
         });
     }
 
-    /// The GUI never relinquishes its diffs; they live in its editor buffers.
-    fn take_candidate_diffs(
-        &self,
-        _app: &mut AppContext,
-    ) -> Option<(Vec<FileDiff>, DiffSessionType)> {
-        None
-    }
-
     fn accept_and_save(&self, app: &mut AppContext) -> BoxFuture<'static, RequestFileEditsResult> {
-        let Some(view) = self.0.upgrade(app) else {
+        let Some(view) = self.upgrade(app) else {
             log::warn!("RequestFileEdits review view vanished before execute");
             return futures::future::ready(RequestFileEditsResult::DiffApplicationFailed {
                 error: "The review surface holding these edits no longer exists".to_string(),
@@ -420,11 +408,8 @@ pub struct CodeDiffView {
     session_platform: Option<SessionPlatform>,
     /// Whether diffs target local disk or a remote host.
     diff_session_type: DiffSessionType,
-    /// Per-file save/diff progress for an in-flight accept (shared
-    /// [`DiffStorageView`] flow).
-    saving_diffs: Option<SavingDiffs>,
-    /// Result delivery for an in-flight accept.
-    save_result_tx: Option<oneshot::Sender<RequestFileEditsResult>>,
+    /// In-flight accept progress (shared [`DiffStorageView`] flow).
+    save_state: DiffSaveState,
 }
 
 impl CodeDiffView {
@@ -646,10 +631,9 @@ impl CodeDiffView {
                                 me.state = CodeDiffState::Rejected;
                                 me.should_expand_when_complete = false;
                             } else if status.is_success() {
-                                // Terminal success without this view having saved
-                                // (e.g. the headless fallback executed before this
-                                // view registered): stop offering Accept for edits
-                                // that already executed.
+                                // Terminal success that didn't flow through this
+                                // view's save (e.g. a restored conversation whose
+                                // edits already executed): stop offering Accept.
                                 me.state = CodeDiffState::Accepted;
                                 me.minimize(ctx);
                             }
@@ -868,8 +852,7 @@ impl CodeDiffView {
             should_show_speedbump,
             session_platform,
             diff_session_type: DiffSessionType::Local,
-            saving_diffs: None,
-            save_result_tx: None,
+            save_state: DiffSaveState::default(),
         }
     }
 
@@ -1058,7 +1041,7 @@ impl CodeDiffView {
     /// Revert all changes by replacing file contents with the base version.
     /// For newly created files, this deletes them instead.
     fn revert_changes(&mut self, ctx: &mut ViewContext<Self>) {
-        if !matches!(self.state, CodeDiffState::Accepted) || self.saving_diffs.is_some() {
+        if !matches!(self.state, CodeDiffState::Accepted) || self.save_state.is_saving() {
             log::warn!(
                 "Attempted to revert changes when not in a settled Accepted state - actual state: {:?}",
                 self.state
@@ -2951,12 +2934,8 @@ pub fn convert_file_edits_to_file_diffs(
 }
 
 impl DiffStorageView for CodeDiffView {
-    fn saving_diffs_mut(&mut self) -> &mut Option<SavingDiffs> {
-        &mut self.saving_diffs
-    }
-
-    fn result_tx_mut(&mut self) -> &mut Option<oneshot::Sender<RequestFileEditsResult>> {
-        &mut self.save_result_tx
+    fn save_state_mut(&mut self) -> &mut DiffSaveState {
+        &mut self.save_state
     }
 
     fn pending_diff_count(&self) -> usize {

--- a/app/src/ai/blocklist/inline_action/code_diff_view.rs
+++ b/app/src/ai/blocklist/inline_action/code_diff_view.rs
@@ -57,7 +57,8 @@ use crate::ai::blocklist::action_model::{
     MalformedFinalLineProxyEvent, RequestFileEditsFormatKind, RequestFileEditsTelemetryEvent,
 };
 use crate::ai::blocklist::diff_storage::{
-    DiffSaveState, DiffStorage, PendingFileState, RegisteredDiffStorage, UpdatedFileState,
+    DiffSaveState, DiffStorage, DiffStorageHelper, PendingFileState, RegisteredDiffStorage,
+    UpdatedFileState,
 };
 use crate::ai::blocklist::diff_types::{changed_lines_from_op, DiffSessionType, FileDiff};
 use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
@@ -364,7 +365,7 @@ impl RegisteredDiffStorage for WeakViewHandle<CodeDiffView> {
         };
         view.update(app, |view, ctx| {
             view.mark_accepted_for_save(ctx);
-            DiffStorage::accept_and_save(view, ctx)
+            DiffStorageHelper::accept_and_save(view, ctx)
         })
     }
 }
@@ -408,7 +409,7 @@ pub struct CodeDiffView {
     session_platform: Option<SessionPlatform>,
     /// Whether diffs target local disk or a remote host.
     diff_session_type: DiffSessionType,
-    /// In-flight accept progress (shared [`DiffStorage`] flow).
+    /// In-flight accept progress (shared [`DiffStorageHelper`] flow).
     save_state: DiffSaveState,
 }
 
@@ -989,9 +990,9 @@ impl CodeDiffView {
         ctx.emit(CodeDiffViewEvent::TryAccept);
 
         // Persistence and result assembly run through the shared
-        // [`DiffStorage`] flow once the executor (or the passive handler)
-        // calls `accept_and_save`. Optimistically mark the diff accepted and
-        // minimize the review UI.
+        // [`DiffStorageHelper`] flow once the executor (or the passive
+        // handler) calls `accept_and_save`. Optimistically mark the diff
+        // accepted and minimize the review UI.
         self.state = CodeDiffState::Accepted;
         self.minimize(ctx);
         ctx.notify();

--- a/app/src/ai/blocklist/inline_action/code_diff_view.rs
+++ b/app/src/ai/blocklist/inline_action/code_diff_view.rs
@@ -57,7 +57,7 @@ use crate::ai::blocklist::action_model::{
     MalformedFinalLineProxyEvent, RequestFileEditsFormatKind, RequestFileEditsTelemetryEvent,
 };
 use crate::ai::blocklist::diff_storage::{
-    DiffSaveState, DiffStorageView, PendingFileState, RegisteredDiffStorage, UpdatedFileState,
+    DiffSaveState, DiffStorage, PendingFileState, RegisteredDiffStorage, UpdatedFileState,
 };
 use crate::ai::blocklist::diff_types::{changed_lines_from_op, DiffSessionType, FileDiff};
 use crate::ai::blocklist::history_model::BlocklistAIHistoryModel;
@@ -364,7 +364,7 @@ impl RegisteredDiffStorage for WeakViewHandle<CodeDiffView> {
         };
         view.update(app, |view, ctx| {
             view.mark_accepted_for_save(ctx);
-            DiffStorageView::accept_and_save(view, ctx)
+            DiffStorage::accept_and_save(view, ctx)
         })
     }
 }
@@ -408,7 +408,7 @@ pub struct CodeDiffView {
     session_platform: Option<SessionPlatform>,
     /// Whether diffs target local disk or a remote host.
     diff_session_type: DiffSessionType,
-    /// In-flight accept progress (shared [`DiffStorageView`] flow).
+    /// In-flight accept progress (shared [`DiffStorage`] flow).
     save_state: DiffSaveState,
 }
 
@@ -989,7 +989,7 @@ impl CodeDiffView {
         ctx.emit(CodeDiffViewEvent::TryAccept);
 
         // Persistence and result assembly run through the shared
-        // [`DiffStorageView`] flow once the executor (or the passive handler)
+        // [`DiffStorage`] flow once the executor (or the passive handler)
         // calls `accept_and_save`. Optimistically mark the diff accepted and
         // minimize the review UI.
         self.state = CodeDiffState::Accepted;
@@ -2933,7 +2933,7 @@ pub fn convert_file_edits_to_file_diffs(
         .collect()
 }
 
-impl DiffStorageView for CodeDiffView {
+impl DiffStorage for CodeDiffView {
     fn save_state_mut(&mut self) -> &mut DiffSaveState {
         &mut self.save_state
     }

--- a/app/src/ai/blocklist/inline_action/code_diff_view.rs
+++ b/app/src/ai/blocklist/inline_action/code_diff_view.rs
@@ -57,7 +57,7 @@ use crate::ai::blocklist::action_model::{
     MalformedFinalLineProxyEvent, RequestFileEditsFormatKind, RequestFileEditsTelemetryEvent,
 };
 use crate::ai::blocklist::diff_storage::{
-    DiffSaveState, DiffStorage, DiffStorageHelper, PendingFileState, RegisteredDiffStorage,
+    DiffStorage, DiffStorageHelper, FileSnapshot, RegisteredDiffStorage, SaveFuture,
     UpdatedFileState,
 };
 use crate::ai::blocklist::diff_types::{changed_lines_from_op, DiffSessionType, FileDiff};
@@ -409,8 +409,8 @@ pub struct CodeDiffView {
     session_platform: Option<SessionPlatform>,
     /// Whether diffs target local disk or a remote host.
     diff_session_type: DiffSessionType,
-    /// In-flight accept progress (shared [`DiffStorageHelper`] flow).
-    save_state: DiffSaveState,
+    /// Number of dispatched saves still in flight; guards revert while saving.
+    pending_saves: usize,
 }
 
 impl CodeDiffView {
@@ -518,11 +518,10 @@ impl CodeDiffView {
         editor
     }
 
-    /// Sets up event subscriptions for an `InlineDiffView` at the given index.
+    /// Sets up event subscriptions for an `InlineDiffView`.
     fn setup_diff_view_subscriptions(
         &self,
         diff_view: &ViewHandle<InlineDiffView>,
-        idx: usize,
         file_path_for_error: String,
         ctx: &mut ViewContext<Self>,
     ) {
@@ -543,7 +542,7 @@ impl CodeDiffView {
             }
             #[cfg(not(target_family = "wasm"))]
             InlineDiffViewEvent::FileSaved => {
-                me.handle_file_saved(idx, None, ctx);
+                me.pending_saves = me.pending_saves.saturating_sub(1);
             }
             #[cfg(not(target_family = "wasm"))]
             InlineDiffViewEvent::FailedToSave { error } => {
@@ -557,10 +556,7 @@ impl CodeDiffView {
                 ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
                     toast_stack.add_ephemeral_toast(toast, window_id, ctx);
                 });
-                me.handle_file_saved(idx, Some(error.clone()), ctx);
-            }
-            InlineDiffViewEvent::DiffAccepted { diff } => {
-                me.handle_diff_computed(idx, diff.clone(), ctx);
+                me.pending_saves = me.pending_saves.saturating_sub(1);
             }
             InlineDiffViewEvent::UserEdited => {
                 if me.user_edited_file_contents {
@@ -853,7 +849,7 @@ impl CodeDiffView {
             should_show_speedbump,
             session_platform,
             diff_session_type: DiffSessionType::Local,
-            save_state: DiffSaveState::default(),
+            pending_saves: 0,
         }
     }
 
@@ -895,8 +891,7 @@ impl CodeDiffView {
         let display_mode = self.display_mode;
         let pending_diffs = diffs
             .into_iter()
-            .enumerate()
-            .map(|(idx, diff)| {
+            .map(|diff| {
                 #[cfg(debug_assertions)]
                 log::debug!("Create CodeEditorView with diff: {diff:#?}");
                 let editor = self.create_editor_with_subscriptions(ctx);
@@ -928,7 +923,7 @@ impl CodeDiffView {
                     diff_viewer.update(ctx, |view, ctx| view.register_file(session_type, ctx));
                 }
 
-                self.setup_diff_view_subscriptions(&diff_viewer, idx, file_path, ctx);
+                self.setup_diff_view_subscriptions(&diff_viewer, file_path, ctx);
 
                 PendingDiff {
                     diff_view: diff_viewer,
@@ -1042,7 +1037,7 @@ impl CodeDiffView {
     /// Revert all changes by replacing file contents with the base version.
     /// For newly created files, this deletes them instead.
     fn revert_changes(&mut self, ctx: &mut ViewContext<Self>) {
-        if !matches!(self.state, CodeDiffState::Accepted) || self.save_state.is_saving() {
+        if !matches!(self.state, CodeDiffState::Accepted) || self.pending_saves > 0 {
             log::warn!(
                 "Attempted to revert changes when not in a settled Accepted state - actual state: {:?}",
                 self.state
@@ -2935,34 +2930,32 @@ pub fn convert_file_edits_to_file_diffs(
 }
 
 impl DiffStorage for CodeDiffView {
-    fn save_state_mut(&mut self) -> &mut DiffSaveState {
-        &mut self.save_state
-    }
-
-    fn pending_diff_count(&self) -> usize {
-        self.pending_diffs.len()
-    }
-
-    /// Extracts each file's report state from the diff views and editor
-    /// buffers: final (possibly user-edited) content, changed lines, and
-    /// rename/delete bookkeeping.
-    fn pending_file_state(&self, app: &AppContext) -> Vec<PendingFileState> {
+    /// Extracts each file's report state and diff inputs from the diff views
+    /// and editor buffers: final (possibly user-edited) content, changed
+    /// lines, base content, and rename/delete bookkeeping.
+    fn snapshot_pending_files(&self, app: &AppContext) -> Vec<FileSnapshot> {
         self.pending_diffs
             .iter()
             .filter_map(|diff| {
                 let diff_view = diff.diff_view.as_ref(app);
                 let path = diff_view.file_path()?.to_string();
+                let diff_base = diff_view.base_content(app).unwrap_or_default();
+                let final_content = diff_view.editor().as_ref(app).text(app).into_string();
+
                 if matches!(diff_view.diff(), Some(DiffType::Delete { .. })) {
-                    return Some(PendingFileState {
+                    return Some(FileSnapshot {
                         updated: None,
-                        deleted_paths: vec![path],
+                        deleted_paths: vec![path.clone()],
+                        diff_base,
+                        diff_new: final_content,
+                        diff_name: path,
                     });
                 }
 
                 // A rename reports the source path as deleted and the update
                 // at the rename target.
                 let mut deleted_paths = Vec::new();
-                let mut report_path = path;
+                let mut report_path = path.clone();
                 if let Some(DiffType::Update {
                     rename: Some(rename),
                     ..
@@ -2974,27 +2967,35 @@ impl DiffStorage for CodeDiffView {
 
                 let changed_lines =
                     changed_lines_for_result(diff_view.changed_lines(app), diff_view.diff());
-                let final_content = diff_view.editor().as_ref(app).text(app).into_string();
-                Some(PendingFileState {
+                Some(FileSnapshot {
                     updated: Some(UpdatedFileState {
                         path: report_path,
                         changed_lines,
-                        final_content,
+                        final_content: final_content.clone(),
                         was_edited: diff_view.was_edited(),
                     }),
                     deleted_paths,
+                    diff_base,
+                    diff_new: final_content,
+                    diff_name: path,
                 })
             })
             .collect()
     }
 
-    /// Saves every file through its editor buffer; completions arrive via the
-    /// per-file `InlineDiffView` subscriptions.
-    fn start_saving(&mut self, app: &mut AppContext) {
-        for diff in &self.pending_diffs {
-            diff.diff_view
-                .update(app, |view, ctx| view.accept_and_save_diff(ctx));
-        }
+    /// Saves every file through its editor buffer, tracking the number of
+    /// dispatched saves for the revert guard.
+    fn start_saving(&mut self, app: &mut AppContext) -> Vec<SaveFuture> {
+        let saves: Vec<SaveFuture> = self
+            .pending_diffs
+            .iter()
+            .filter_map(|diff| {
+                diff.diff_view
+                    .update(app, |view, ctx| view.accept_and_save_diff(ctx))
+            })
+            .collect();
+        self.pending_saves = saves.len();
+        saves
     }
 }
 

--- a/app/src/ai/blocklist/mod.rs
+++ b/app/src/ai/blocklist/mod.rs
@@ -6,6 +6,8 @@ pub mod code_block;
 mod context_model;
 mod controller;
 pub(crate) mod conversation_selection;
+pub(crate) mod diff_storage;
+pub(crate) mod diff_types;
 pub(crate) mod handoff;
 
 pub(crate) mod local_agent_task_sync_model;

--- a/app/src/ai/blocklist/passive_suggestions/maa.rs
+++ b/app/src/ai/blocklist/passive_suggestions/maa.rs
@@ -16,7 +16,7 @@ use crate::ai::agent::{
     ShellCommandCompletedTrigger,
 };
 use crate::ai::block_context::BlockContext;
-use crate::ai::blocklist::inline_action::code_diff_view::FileDiff;
+use crate::ai::blocklist::diff_types::FileDiff;
 use crate::ai::blocklist::{
     apply_edits, BlocklistAIHistoryModel, FileReadResult, RequestFileEditsFormatKind,
     SessionContext,

--- a/app/src/code/diff_viewer.rs
+++ b/app/src/code/diff_viewer.rs
@@ -152,8 +152,6 @@ where
             .update(ctx, |editor, ctx| editor.navigate_previous_diff_hunk(ctx));
     }
 
-    fn accept_and_save_diff(&self, _ctx: &mut ViewContext<Self>) {}
-
     fn reject_diff(&mut self, _ctx: &mut ViewContext<Self>) {}
 
     fn restore_diff_base(&mut self, _ctx: &mut ViewContext<Self>) -> Result<(), String> {

--- a/app/src/code/editor/diff.rs
+++ b/app/src/code/editor/diff.rs
@@ -92,6 +92,53 @@ pub enum DiffModelEvent {
     UnifiedDiffComputed(Rc<DiffResult>),
 }
 
+/// Computes the unified diff (3 context lines, git style) and line stats
+/// between two contents.
+pub(crate) async fn compute_unified_diff(
+    base: &MultilineStr<LF>,
+    new: &MultilineStr<LF>,
+    file_name: &str,
+) -> DiffResult {
+    if base == new {
+        return DiffResult {
+            unified_diff: String::new(),
+            lines_added: 0,
+            lines_removed: 0,
+        };
+    }
+
+    let text_diff = TextDiff::from_lines(base.as_str(), new.as_str());
+
+    // Calculate diff statistics.
+    let mut lines_added = 0;
+    let mut lines_removed = 0;
+
+    for op in text_diff.ops() {
+        match op {
+            DiffOp::Equal { .. } => (),
+            DiffOp::Delete { old_len, .. } => lines_removed += old_len,
+            DiffOp::Insert { new_len, .. } => lines_added += new_len,
+            DiffOp::Replace {
+                old_len, new_len, ..
+            } => {
+                lines_added += new_len;
+                lines_removed += old_len;
+            }
+        }
+    }
+
+    DiffResult {
+        unified_diff: text_diff
+            .unified_diff()
+            .context_radius(3)
+            .header(file_name, file_name)
+            .missing_newline_hint(false)
+            .to_string(),
+        lines_added,
+        lines_removed,
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum ChangeType {
     Replacement {
@@ -606,59 +653,12 @@ impl DiffModel {
         ctx.spawn(
             async move {
                 let new = new.to_format();
-                Self::retrieve_unified_diff_internal(&base_text, new.as_ref(), file_name.as_str())
-                    .await
+                compute_unified_diff(&base_text, new.as_ref(), file_name.as_str()).await
             },
             |_, unified_diff, ctx| {
                 ctx.emit(DiffModelEvent::UnifiedDiffComputed(Rc::new(unified_diff)));
             },
         );
-    }
-
-    async fn retrieve_unified_diff_internal(
-        base: &MultilineStr<LF>,
-        new: &MultilineStr<LF>,
-        file_name: &str,
-    ) -> DiffResult {
-        if base == new {
-            return DiffResult {
-                unified_diff: String::new(),
-                lines_added: 0,
-                lines_removed: 0,
-            };
-        }
-
-        // Show 3 context lines (standard of git diff).
-        let text_diff = TextDiff::from_lines(base.as_str(), new.as_str());
-
-        // Calculate diff statistics.
-        let mut lines_added = 0;
-        let mut lines_removed = 0;
-
-        for op in text_diff.ops() {
-            match op {
-                DiffOp::Equal { .. } => (),
-                DiffOp::Delete { old_len, .. } => lines_removed += old_len,
-                DiffOp::Insert { new_len, .. } => lines_added += new_len,
-                DiffOp::Replace {
-                    old_len, new_len, ..
-                } => {
-                    lines_added += new_len;
-                    lines_removed += old_len;
-                }
-            }
-        }
-
-        DiffResult {
-            unified_diff: text_diff
-                .unified_diff()
-                .context_radius(3)
-                .header(file_name, file_name)
-                .missing_newline_hint(false)
-                .to_string(),
-            lines_added,
-            lines_removed,
-        }
     }
 
     async fn compute_diff_internal(

--- a/app/src/code/editor/diff_tests.rs
+++ b/app/src/code/editor/diff_tests.rs
@@ -4,7 +4,7 @@ use rangemap::RangeMap;
 use unindent::Unindent as _;
 use warp_editor::multiline::{MultilineStr, MultilineString};
 
-use super::DiffModel;
+use super::{compute_unified_diff, DiffModel};
 use crate::code::editor::diff::ChangeType;
 
 #[test]
@@ -374,7 +374,7 @@ fn test_diff_count_before_line() {
 fn test_unified_diff() {
     use warpui::App;
     App::test((), |_| async move {
-        let diff = DiffModel::retrieve_unified_diff_internal(
+        let diff = compute_unified_diff(
             MultilineStr::try_new("Hello World\nThis is the second line.\nThis is the third.")
                 .unwrap(),
             MultilineStr::try_new(

--- a/app/src/code/editor/mod.rs
+++ b/app/src/code/editor/mod.rs
@@ -16,6 +16,6 @@ pub mod view;
 
 pub use comment_editor::{CommentEditor, CommentEditorEvent};
 pub use comments::{EditorCommentsModel, EditorReviewComment};
-pub(crate) use diff::{add_color, remove_color};
+pub(crate) use diff::{add_color, compute_unified_diff, remove_color};
 pub use element::GutterHoverTarget;
 pub use nav_bar::NavBarBehavior;

--- a/app/src/code/editor/view.rs
+++ b/app/src/code/editor/view.rs
@@ -4,7 +4,6 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::ops::Range;
 use std::path::Path;
-use std::rc::Rc;
 
 use ai::diff_validation::DiffDelta;
 use lazy_static::lazy_static;
@@ -71,8 +70,8 @@ use crate::code::editor::nav_bar::{NavBar, NavBarBehavior, NavBarEvent};
 use crate::code::editor::scroll::{ScrollPosition, ScrollTrigger, ScrollWheelBehavior};
 use crate::code::editor::EditorReviewComment;
 use crate::code::{
-    DiffResult, NoopCommentEditorProvider, NoopFindReferencesCardProvider,
-    ShowCommentEditorProvider, ShowFindReferencesCardProvider,
+    NoopCommentEditorProvider, NoopFindReferencesCardProvider, ShowCommentEditorProvider,
+    ShowFindReferencesCardProvider,
 };
 use crate::code_review::comments::{CommentId, CommentOrigin};
 use crate::editor::InteractionState;
@@ -101,9 +100,8 @@ pub enum CodeEditorEvent {
     ContentChanged {
         origin: EditOrigin,
     },
-    /// Emitted when a unified diff computation completes, carrying the computed
-    /// result diff.
-    UnifiedDiffComputed(Rc<DiffResult>),
+    /// Emitted when a unified diff computation completes.
+    UnifiedDiffComputed,
     SelectionChanged,
     SelectionStart,
     SelectionEnd,
@@ -1276,8 +1274,8 @@ impl CodeEditorView {
                 }
                 ctx.emit(CodeEditorEvent::ContentChanged { origin: *origin });
             }
-            CodeEditorModelEvent::UnifiedDiffComputed(diff) => {
-                ctx.emit(CodeEditorEvent::UnifiedDiffComputed(diff.clone()));
+            CodeEditorModelEvent::UnifiedDiffComputed(_) => {
+                ctx.emit(CodeEditorEvent::UnifiedDiffComputed);
             }
             CodeEditorModelEvent::ViewportUpdated(version) => {
                 if let Some(trigger) = self

--- a/app/src/code/editor/view.rs
+++ b/app/src/code/editor/view.rs
@@ -101,6 +101,8 @@ pub enum CodeEditorEvent {
     ContentChanged {
         origin: EditOrigin,
     },
+    /// Emitted when a unified diff computation completes, carrying the computed
+    /// result diff.
     UnifiedDiffComputed(Rc<DiffResult>),
     SelectionChanged,
     SelectionStart,

--- a/app/src/code/global_buffer_model.rs
+++ b/app/src/code/global_buffer_model.rs
@@ -2,6 +2,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Duration;
 
 use bimap::BiMap;
@@ -269,7 +270,7 @@ pub enum GlobalBufferModelEvent {
     },
     FailedToSave {
         file_id: FileId,
-        error: Rc<FileSaveError>,
+        error: Arc<FileSaveError>,
     },
     /// A remote buffer update conflicted with local edits.
     /// The UI should present a resolution dialog.
@@ -850,7 +851,7 @@ impl GlobalBufferModel {
                             log::warn!("Remote save failed: {error}");
                             ctx.emit(GlobalBufferModelEvent::FailedToSave {
                                 file_id,
-                                error: Rc::new(FileSaveError::RemoteError(error.to_string())),
+                                error: Arc::new(FileSaveError::RemoteError(error.to_string())),
                             });
                         }
                     },
@@ -859,9 +860,12 @@ impl GlobalBufferModel {
             }
         }
 
-        FileModel::handle(ctx).update(ctx, |file_model, ctx| {
-            file_model.save(file_id, content, version, ctx)
-        })
+        // Completion is observed via `FileModelEvent`s; drop the save future.
+        FileModel::handle(ctx)
+            .update(ctx, |file_model, ctx| {
+                file_model.save(file_id, content, version, ctx)
+            })
+            .map(drop)
     }
 
     /// Rename a file and save its content via FileModel.
@@ -1977,9 +1981,12 @@ impl GlobalBufferModel {
         };
         let content = buffer.as_ref(ctx).text().into_string();
         let version = buffer.as_ref(ctx).version();
-        FileModel::handle(ctx).update(ctx, |file_model, ctx| {
-            file_model.save(file_id, content, version, ctx)
-        })
+        // Completion is observed via `FileModelEvent`s; drop the save future.
+        FileModel::handle(ctx)
+            .update(ctx, |file_model, ctx| {
+                file_model.save(file_id, content, version, ctx)
+            })
+            .map(drop)
     }
 
     /// Resolve a conflict by accepting the client's content.
@@ -2023,9 +2030,12 @@ impl GlobalBufferModel {
         let content = client_content.to_string();
         let save_version = ContentVersion::new();
         state.set_base_content_version(save_version);
-        FileModel::handle(ctx).update(ctx, |file_model, ctx| {
-            file_model.save(file_id, content, save_version, ctx)
-        })
+        // Completion is observed via `FileModelEvent`s; drop the save future.
+        FileModel::handle(ctx)
+            .update(ctx, |file_model, ctx| {
+                file_model.save(file_id, content, save_version, ctx)
+            })
+            .map(drop)
     }
 
     // ── Public accessors ──────────────────────────────────────────────

--- a/app/src/code/inline_diff.rs
+++ b/app/src/code/inline_diff.rs
@@ -1,6 +1,9 @@
-use std::rc::Rc;
+#[cfg(not(target_family = "wasm"))]
+use std::sync::Arc;
 
 use ai::diff_validation::DiffType;
+#[cfg(not(target_family = "wasm"))]
+use futures::FutureExt;
 #[cfg(not(target_family = "wasm"))]
 use warp_files::{FileModel, FileModelEvent};
 use warp_util::file::FileId;
@@ -16,7 +19,7 @@ use super::diff_viewer::{DiffViewer, DisplayMode};
 use super::editor::scroll::{ScrollPosition, ScrollTrigger};
 use super::editor::view::{CodeEditorEvent, CodeEditorView};
 use super::editor::NavBarBehavior;
-use super::DiffResult;
+use crate::ai::blocklist::diff_storage::SaveFuture;
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::blocklist::diff_types::DiffSessionType;
 use crate::editor::InteractionState;
@@ -29,11 +32,7 @@ pub enum InlineDiffViewEvent {
     FileSaved,
     #[cfg(not(target_family = "wasm"))]
     FailedToSave {
-        error: Rc<FileSaveError>,
-    },
-    /// The result diff for an accepted edit has been computed by the editor.
-    DiffAccepted {
-        diff: Rc<DiffResult>,
+        error: Arc<FileSaveError>,
     },
     UserEdited,
 }
@@ -78,9 +77,6 @@ impl InlineDiffView {
         ctx.subscribe_to_view(&editor, |me, _view, event, ctx| match event {
             CodeEditorEvent::DiffUpdated => {
                 ctx.emit(InlineDiffViewEvent::DiffStatusUpdated);
-            }
-            CodeEditorEvent::UnifiedDiffComputed(diff) => {
-                ctx.emit(InlineDiffViewEvent::DiffAccepted { diff: diff.clone() });
             }
             CodeEditorEvent::ContentChanged { origin } => {
                 if origin.from_user() && !me.was_edited {
@@ -217,50 +213,61 @@ impl InlineDiffView {
         });
     }
 
-    /// Saves the current editor content through `FileModel`; completion arrives
-    /// as `FileSaved` / `FailedToSave`.
+    /// Saves the current editor content through `FileModel`, returning the
+    /// save's completion future. `FileSaved` / `FailedToSave` events still
+    /// fire alongside. `None` when no file is registered.
     #[cfg(not(target_family = "wasm"))]
-    fn save_content(&self, ctx: &mut ViewContext<Self>) {
-        let Some(file_id) = self.backing_file_id else {
-            return;
-        };
+    fn save_content(&self, ctx: &mut ViewContext<Self>) -> Option<SaveFuture> {
+        let file_id = self.backing_file_id?;
         let content = self.editor.as_ref(ctx).text(ctx).into_string();
         let version = self.editor.as_ref(ctx).version(ctx);
 
-        if let Err(err) = FileModel::handle(ctx).update(ctx, |file_model, ctx| {
+        match FileModel::handle(ctx).update(ctx, |file_model, ctx| {
             file_model.save(file_id, content, version, ctx)
         }) {
-            ctx.emit(InlineDiffViewEvent::FailedToSave {
-                error: Rc::new(err),
-            });
+            Ok(save_future) => Some(save_future),
+            Err(err) => {
+                let error = Arc::new(err);
+                ctx.emit(InlineDiffViewEvent::FailedToSave {
+                    error: error.clone(),
+                });
+                Some(futures::future::ready(Err(error)).boxed())
+            }
         }
     }
 
-    /// Accepts the diff: computes the result diff (delivered via
-    /// [`InlineDiffViewEvent::DiffAccepted`]) and saves the editor content to
-    /// the backing file. No-op when no file is registered (WASM / restored
-    /// conversations).
-    pub fn accept_and_save_diff(&self, ctx: &mut ViewContext<Self>) {
-        if self.backing_file_id.is_none() {
-            return;
-        }
-
-        // Compute the result diff (arrives via CodeEditorEvent::UnifiedDiffComputed).
-        if let Some(file_path) = &self.file_path {
-            let file_name = file_path.to_string();
-            self.editor.update(ctx, |editor, ctx| {
-                editor.retrieve_unified_diff(file_name, ctx)
-            });
-        }
-        // Save the current editor content to disk.
+    /// Accepts the diff by saving the editor content to the backing file,
+    /// returning the save's completion future. `None` when no file is
+    /// registered (WASM / restored conversations), in which case nothing is
+    /// dispatched.
+    pub fn accept_and_save_diff(&self, ctx: &mut ViewContext<Self>) -> Option<SaveFuture> {
         #[cfg(not(target_family = "wasm"))]
-        self.save_content(ctx);
+        {
+            self.save_content(ctx)
+        }
+        #[cfg(target_family = "wasm")]
+        {
+            let _ = ctx;
+            None
+        }
     }
 }
 
 impl InlineDiffView {
     pub fn file_path(&self) -> Option<&StandardizedPath> {
         self.file_path.as_ref()
+    }
+
+    /// Base content of the diff (from the editor's diff model), if set.
+    pub fn base_content(&self, app: &AppContext) -> Option<String> {
+        self.editor
+            .as_ref(app)
+            .model
+            .as_ref(app)
+            .diff()
+            .as_ref(app)
+            .base()
+            .map(|base| base.to_string())
     }
 
     pub fn file_name(&self) -> Option<String> {
@@ -337,10 +344,12 @@ impl DiffViewer for InlineDiffView {
                 .to_string();
 
             let version = self.editor.as_ref(_ctx).version(_ctx);
+            // The revert save's completion is observed via `FileSaved` events.
             FileModel::handle(_ctx)
                 .update(_ctx, |file_model, ctx| {
                     file_model.save(file_id, base_content, version, ctx)
                 })
+                .map(drop)
                 .map_err(|e| format!("Failed to save file: {e:?}"))?;
         }
 

--- a/app/src/code/inline_diff.rs
+++ b/app/src/code/inline_diff.rs
@@ -18,7 +18,7 @@ use super::editor::view::{CodeEditorEvent, CodeEditorView};
 use super::editor::NavBarBehavior;
 use super::DiffResult;
 #[cfg(not(target_family = "wasm"))]
-use crate::ai::blocklist::inline_action::code_diff_view::DiffSessionType;
+use crate::ai::blocklist::diff_types::DiffSessionType;
 use crate::editor::InteractionState;
 
 pub enum InlineDiffViewEvent {
@@ -31,6 +31,7 @@ pub enum InlineDiffViewEvent {
     FailedToSave {
         error: Rc<FileSaveError>,
     },
+    /// The result diff for an accepted edit has been computed by the editor.
     DiffAccepted {
         diff: Rc<DiffResult>,
     },
@@ -216,6 +217,8 @@ impl InlineDiffView {
         });
     }
 
+    /// Saves the current editor content through `FileModel`; completion arrives
+    /// as `FileSaved` / `FailedToSave`.
     #[cfg(not(target_family = "wasm"))]
     fn save_content(&self, ctx: &mut ViewContext<Self>) {
         let Some(file_id) = self.backing_file_id else {
@@ -231,6 +234,27 @@ impl InlineDiffView {
                 error: Rc::new(err),
             });
         }
+    }
+
+    /// Accepts the diff: computes the result diff (delivered via
+    /// [`InlineDiffViewEvent::DiffAccepted`]) and saves the editor content to
+    /// the backing file. No-op when no file is registered (WASM / restored
+    /// conversations).
+    pub fn accept_and_save_diff(&self, ctx: &mut ViewContext<Self>) {
+        if self.backing_file_id.is_none() {
+            return;
+        }
+
+        // Compute the result diff (arrives via CodeEditorEvent::UnifiedDiffComputed).
+        if let Some(file_path) = &self.file_path {
+            let file_name = file_path.to_string();
+            self.editor.update(ctx, |editor, ctx| {
+                editor.retrieve_unified_diff(file_name, ctx)
+            });
+        }
+        // Save the current editor content to disk.
+        #[cfg(not(target_family = "wasm"))]
+        self.save_content(ctx);
     }
 }
 
@@ -275,24 +299,6 @@ impl DiffViewer for InlineDiffView {
             editor.set_show_nav_bar(mode.show_nav_bar());
             editor.set_nav_bar_behavior(NavBarBehavior::NotClosable, ctx);
         });
-    }
-
-    fn accept_and_save_diff(&self, ctx: &mut ViewContext<Self>) {
-        // No-op when no file is registered (WASM / restored conversations).
-        if self.backing_file_id.is_none() {
-            return;
-        }
-
-        // Compute the unified diff (result arrives via CodeEditorEvent::UnifiedDiffComputed).
-        if let Some(file_path) = &self.file_path {
-            let file_name = file_path.to_string();
-            self.editor.update(ctx, |editor, ctx| {
-                editor.retrieve_unified_diff(file_name, ctx)
-            });
-        }
-        // Save the current editor content to disk.
-        #[cfg(not(target_family = "wasm"))]
-        self.save_content(ctx);
     }
 
     fn restore_diff_base(&mut self, _ctx: &mut ViewContext<Self>) -> Result<(), String> {

--- a/app/src/code/local_code_editor.rs
+++ b/app/src/code/local_code_editor.rs
@@ -321,7 +321,7 @@ impl LocalCodeEditorView {
         });
 
         ctx.subscribe_to_view(&editor, |me, _, event, ctx| match event {
-            CodeEditorEvent::UnifiedDiffComputed(_) => {
+            CodeEditorEvent::UnifiedDiffComputed => {
                 ctx.emit(LocalCodeEditorEvent::DiffAccepted);
             }
             CodeEditorEvent::ContentChanged { origin, .. } => {

--- a/app/src/code/local_code_editor.rs
+++ b/app/src/code/local_code_editor.rs
@@ -2079,22 +2079,6 @@ impl DiffViewer for LocalCodeEditorView {
         self.was_edited
     }
 
-    /// Automatically accept and save this diff. Unlike [`Self::accept_diff`] and [`Self::save_local`], this
-    /// waits for the initial file contents to be loaded.
-    fn accept_and_save_diff(&self, ctx: &mut ViewContext<Self>) {
-        ctx.spawn(self.file_loaded.wait(), move |me, _, ctx| {
-            me.accept_diff(ctx);
-            if let Err(err) = me.save_local(ctx) {
-                log::error!("{err:?}");
-                if let ImmediateSaveError::FailedToSave(err) = err {
-                    ctx.emit(LocalCodeEditorEvent::FailedToSave {
-                        error: Rc::new(err),
-                    });
-                }
-            }
-        });
-    }
-
     fn reject_diff(&mut self, ctx: &mut ViewContext<Self>) {
         ctx.emit(LocalCodeEditorEvent::DiffRejected);
     }

--- a/app/src/code/local_code_editor.rs
+++ b/app/src/code/local_code_editor.rs
@@ -6,6 +6,7 @@ use std::{
     ops::Range,
     path::{Path, PathBuf},
     rc::Rc,
+    sync::Arc,
     time::Duration,
 };
 
@@ -108,7 +109,7 @@ pub enum LocalCodeEditorEvent {
     },
     FileSaved,
     FailedToSave {
-        error: Rc<FileSaveError>,
+        error: Arc<FileSaveError>,
     },
     DiffAccepted,
     DiffRejected,
@@ -1137,7 +1138,7 @@ impl LocalCodeEditorView {
         if let Err(err) = result {
             log::error!("Failed to save file: {err:?}");
             ctx.emit(LocalCodeEditorEvent::FailedToSave {
-                error: Rc::new(err),
+                error: Arc::new(err),
             });
         }
     }
@@ -1682,7 +1683,7 @@ impl LocalCodeEditorView {
             }) {
             log::error!("Failed to save file to new path: {err:?}");
             ctx.emit(LocalCodeEditorEvent::FailedToSave {
-                error: Rc::new(err),
+                error: Arc::new(err),
             });
             SaveOutcome::Failed
         } else {
@@ -2286,7 +2287,7 @@ impl TypedActionView for LocalCodeEditorView {
                 if let Err(ImmediateSaveError::FailedToSave(err)) = self.save_local(ctx) {
                     log::error!("Failed to save file {err:?}");
                     ctx.emit(LocalCodeEditorEvent::FailedToSave {
-                        error: Rc::new(err),
+                        error: Arc::new(err),
                     });
                 };
             }

--- a/app/src/code/local_code_editor_wasm.rs
+++ b/app/src/code/local_code_editor_wasm.rs
@@ -1,6 +1,7 @@
 use std::ops::Range;
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use ai::diff_validation::DiffType;
 use warp_core::ui::appearance::Appearance;
@@ -29,7 +30,7 @@ pub enum LocalCodeEditorEvent {
     #[allow(dead_code)]
     FileSaved,
     #[allow(dead_code)]
-    FailedToSave { error: Rc<FileSaveError> },
+    FailedToSave { error: Arc<FileSaveError> },
     #[allow(dead_code)]
     DiffAccepted,
     #[allow(dead_code)]

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -235,7 +235,7 @@ use crate::ai::blocklist::block::{AIBlockAction, FinishReason};
 use crate::ai::blocklist::codebase_index_speedbump_banner::{
     CodebaseIndexSpeedbumpBannerAction, CodebaseIndexSpeedbumpBannerState, VisibilityState,
 };
-use crate::ai::blocklist::diff_storage::DiffStorageView;
+use crate::ai::blocklist::diff_storage::DiffStorage;
 use crate::ai::blocklist::diff_types::FileDiff;
 use crate::ai::blocklist::inline_action::code_diff_view::CodeDiffView;
 use crate::ai::blocklist::model::{
@@ -15407,12 +15407,12 @@ impl TerminalView {
             match event {
                 CodeDiffViewEvent::TryAccept => {
                     // Persist the accepted (possibly edited) passive suggestion
-                    // through the shared DiffStorageView flow. The result isn't
+                    // through the shared DiffStorage flow. The result isn't
                     // surfaced to the LLM on this path; failed writes surface
                     // per-file toasts from the view's save subscriptions.
                     let _save_future = view.update(ctx, |diff_view, ctx| {
                         diff_view.send_malformed_line_telemetry(ctx);
-                        DiffStorageView::accept_and_save(diff_view, ctx)
+                        DiffStorage::accept_and_save(diff_view, ctx)
                     });
                     ctx.notify();
                 }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -235,7 +235,7 @@ use crate::ai::blocklist::block::{AIBlockAction, FinishReason};
 use crate::ai::blocklist::codebase_index_speedbump_banner::{
     CodebaseIndexSpeedbumpBannerAction, CodebaseIndexSpeedbumpBannerState, VisibilityState,
 };
-use crate::ai::blocklist::diff_storage::DiffStorage;
+use crate::ai::blocklist::diff_storage::DiffStorageHelper;
 use crate::ai::blocklist::diff_types::FileDiff;
 use crate::ai::blocklist::inline_action::code_diff_view::CodeDiffView;
 use crate::ai::blocklist::model::{
@@ -15407,12 +15407,13 @@ impl TerminalView {
             match event {
                 CodeDiffViewEvent::TryAccept => {
                     // Persist the accepted (possibly edited) passive suggestion
-                    // through the shared DiffStorage flow. The result isn't
-                    // surfaced to the LLM on this path; failed writes surface
-                    // per-file toasts from the view's save subscriptions.
+                    // through the shared DiffStorageHelper flow. The result
+                    // isn't surfaced to the LLM on this path; failed writes
+                    // surface per-file toasts from the view's save
+                    // subscriptions.
                     let _save_future = view.update(ctx, |diff_view, ctx| {
                         diff_view.send_malformed_line_telemetry(ctx);
-                        DiffStorage::accept_and_save(diff_view, ctx)
+                        DiffStorageHelper::accept_and_save(diff_view, ctx)
                     });
                     ctx.notify();
                 }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -235,7 +235,9 @@ use crate::ai::blocklist::block::{AIBlockAction, FinishReason};
 use crate::ai::blocklist::codebase_index_speedbump_banner::{
     CodebaseIndexSpeedbumpBannerAction, CodebaseIndexSpeedbumpBannerState, VisibilityState,
 };
-use crate::ai::blocklist::inline_action::code_diff_view::{CodeDiffView, FileDiff};
+use crate::ai::blocklist::diff_storage::DiffStorageView;
+use crate::ai::blocklist::diff_types::FileDiff;
+use crate::ai::blocklist::inline_action::code_diff_view::CodeDiffView;
 use crate::ai::blocklist::model::{
     AIBlockModel, AIBlockModelHelper, AIBlockModelImpl, AIBlockOutputStatus,
 };
@@ -15404,11 +15406,14 @@ impl TerminalView {
         ctx.subscribe_to_view(&diff_view, move |me, view, event, ctx| {
             match event {
                 CodeDiffViewEvent::TryAccept => {
-                    view.update(ctx, |diff_view, ctx| {
-                        diff_view.accept_and_save(ctx);
+                    // Persist the accepted (possibly edited) passive suggestion
+                    // through the shared DiffStorageView flow. The result isn't
+                    // surfaced to the LLM on this path; failed writes surface
+                    // per-file toasts from the view's save subscriptions.
+                    let _save_future = view.update(ctx, |diff_view, ctx| {
+                        diff_view.send_malformed_line_telemetry(ctx);
+                        DiffStorageView::accept_and_save(diff_view, ctx)
                     });
-                }
-                CodeDiffViewEvent::SavedAcceptedDiffs { .. } => {
                     ctx.notify();
                 }
                 CodeDiffViewEvent::CancelPassive => {

--- a/crates/warp_files/src/lib.rs
+++ b/crates/warp_files/src/lib.rs
@@ -9,11 +9,14 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::rc::Rc;
+use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use async_channel::Sender;
+use futures::channel::oneshot;
+use futures::future::BoxFuture;
 use futures::io::{AsyncBufReadExt, BufReader};
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use notify_debouncer_full::notify::{RecursiveMode, WatchFilter};
 use remote_server::manager::RemoteServerManager;
 use repo_metadata::repositories::DetectedRepositories;
@@ -47,7 +50,7 @@ pub enum FileModelEvent {
     },
     FailedToSave {
         id: FileId,
-        error: Rc<FileSaveError>,
+        error: Arc<FileSaveError>,
     },
     FileUpdated {
         id: FileId,
@@ -56,6 +59,10 @@ pub enum FileModelEvent {
         new_version: ContentVersion,
     },
 }
+
+/// Resolves with the outcome of one dispatched save. The sender is only
+/// dropped on app teardown, in which case the outcome is treated as success.
+pub type SaveFuture = BoxFuture<'static, Result<(), Arc<FileSaveError>>>;
 
 impl FileModelEvent {
     pub fn file_id(&self) -> FileId {
@@ -679,18 +686,22 @@ impl FileModel {
         // Remote files have no watcher to clean up.
     }
 
+    /// Saves the file's content, returning a future that resolves with the
+    /// write outcome. `FileSaved` / `FailedToSave` events are still emitted
+    /// for subscribers; the future is a per-request completion signal.
     pub fn save(
         &mut self,
         file_id: FileId,
         content: String,
         version: ContentVersion,
         ctx: &mut ModelContext<Self>,
-    ) -> Result<(), FileSaveError> {
+    ) -> Result<SaveFuture, FileSaveError> {
         let backend = self
             .file_state
             .get(file_id)
             .ok_or(FileSaveError::NoFilePath(file_id))?;
 
+        let (tx, rx) = oneshot::channel();
         match backend {
             FileBackend::Local(_) => {
                 let file_path = self
@@ -713,8 +724,9 @@ impl FileModel {
                         })
                     },
                     move |me, write_result: Result<(), FileSaveError>, ctx| {
-                        match write_result {
-                            Ok(_) => {
+                        let result = write_result.map_err(Arc::new);
+                        match &result {
+                            Ok(()) => {
                                 me.set_version(file_id, version);
                                 ctx.emit(FileModelEvent::FileSaved {
                                     id: file_id,
@@ -723,9 +735,10 @@ impl FileModel {
                             }
                             Err(err) => ctx.emit(FileModelEvent::FailedToSave {
                                 id: file_id,
-                                error: Rc::new(err),
+                                error: err.clone(),
                             }),
                         };
+                        let _ = tx.send(result);
                     },
                 );
             }
@@ -734,26 +747,31 @@ impl FileModel {
                 let path = path.as_str().to_string();
                 ctx.spawn(
                     async move { handle.write_file(path, content).await },
-                    move |me, result, ctx| match result {
-                        Ok(()) => {
-                            me.set_version(file_id, version);
-                            ctx.emit(FileModelEvent::FileSaved {
-                                id: file_id,
-                                version,
-                            });
+                    move |me, result, ctx| {
+                        let result = result
+                            .map_err(|e| Arc::new(FileSaveError::RemoteError(e.to_string())));
+                        match &result {
+                            Ok(()) => {
+                                me.set_version(file_id, version);
+                                ctx.emit(FileModelEvent::FileSaved {
+                                    id: file_id,
+                                    version,
+                                });
+                            }
+                            Err(err) => {
+                                ctx.emit(FileModelEvent::FailedToSave {
+                                    id: file_id,
+                                    error: err.clone(),
+                                });
+                            }
                         }
-                        Err(e) => {
-                            ctx.emit(FileModelEvent::FailedToSave {
-                                id: file_id,
-                                error: Rc::new(FileSaveError::RemoteError(e.to_string())),
-                            });
-                        }
+                        let _ = tx.send(result);
                     },
                 );
             }
         }
 
-        Ok(())
+        Ok(async move { rx.await.unwrap_or(Ok(())) }.boxed())
     }
 
     /// Renames a file and also saves its content.
@@ -815,7 +833,7 @@ impl FileModel {
                     }
                     Err(err) => ctx.emit(FileModelEvent::FailedToSave {
                         id: file_id,
-                        error: Rc::new(err),
+                        error: Arc::new(err),
                     }),
                 };
             },
@@ -868,7 +886,7 @@ impl FileModel {
                             }
                             Err(err) => ctx.emit(FileModelEvent::FailedToSave {
                                 id: file_id,
-                                error: Rc::new(err),
+                                error: Arc::new(err),
                             }),
                         };
                     },
@@ -890,7 +908,7 @@ impl FileModel {
                         Err(e) => {
                             ctx.emit(FileModelEvent::FailedToSave {
                                 id: file_id,
-                                error: Rc::new(FileSaveError::RemoteError(e.to_string())),
+                                error: Arc::new(FileSaveError::RemoteError(e.to_string())),
                             });
                         }
                     },

--- a/crates/warp_files/src/lib.rs
+++ b/crates/warp_files/src/lib.rs
@@ -748,8 +748,8 @@ impl FileModel {
                 ctx.spawn(
                     async move { handle.write_file(path, content).await },
                     move |me, result, ctx| {
-                        let result = result
-                            .map_err(|e| Arc::new(FileSaveError::RemoteError(e.to_string())));
+                        let result =
+                            result.map_err(|e| Arc::new(FileSaveError::RemoteError(e.to_string())));
                         match &result {
                             Ok(()) => {
                                 me.set_version(file_id, version);

--- a/crates/warp_files/src/lib_tests.rs
+++ b/crates/warp_files/src/lib_tests.rs
@@ -106,10 +106,10 @@ fn test_save_uninitialized_file() {
                 ContentVersion::new(),
                 ctx,
             );
-            assert!(result.is_err());
-
-            let e = result.unwrap_err();
-            assert!(matches!(e, FileSaveError::NoFilePath(file_id) if file_id == id));
+            assert!(
+                matches!(result, Err(FileSaveError::NoFilePath(file_id)) if file_id == id),
+                "expected NoFilePath error"
+            );
         });
     });
 }

--- a/specs/surface-agnostic-file-edit-execution/TECH.md
+++ b/specs/surface-agnostic-file-edit-execution/TECH.md
@@ -48,16 +48,17 @@ User Accept ──> TryAccept ──> executor::execute(id)
   └─ diff_storages[id].accept_and_save()      [RegisteredDiffStorage]
         │  (handle upgrade/update)
         ▼
-     DiffStorage::accept_and_save          [shared, provided]
+     DiffStorageHelper::accept_and_save    [shared blanket impl]
        ├─ save_state.begin(count) ──> returns result future ──┐
        └─ start_saving()          [surface-specific:          │
             GUI: editor buffers / InlineDiffView;              │
             TUI (up-stack): FileModel write dispatch]          │
         │                                                     │
-     callbacks: handle_file_saved / handle_diff_computed      │
+     callbacks: handle_file_saved /                           │
+                handle_diff_computed  [DiffStorageHelper]     │
         │                                                     │
-     try_finish ──> assemble_result(progress,                 │
-                    pending_file_state()) ──> send ───────────┘
+     all complete ──> assemble_result(progress,               │
+                      pending_file_state()) ──> send ────────┘
         │
         ▼
 ActionExecution::new_async(future) ──> telemetry ──> LLM
@@ -65,16 +66,16 @@ ActionExecution::new_async(future) ──> telemetry ──> LLM
 
 ## Design
 
-### The `DiffStorage` trait (`app/src/ai/blocklist/diff_storage.rs`)
+### The `DiffStorage` / `DiffStorageHelper` traits (`app/src/ai/blocklist/diff_storage.rs`)
 
-Implemented by every surface that stores pending diffs. Required methods are state accessors — the fields live on each impl, since traits cannot hold state — plus the surface-specific write kickoff. Provided methods are the shared save-completion flow:
+The surface contract and the shared flow follow the `AIBlockModel` / `AIBlockModelHelper` convention (`app/src/ai/blocklist/block/model/helper.rs`): a required-methods-only trait that surfaces implement, and a `Helper` trait whose methods are defined once in a blanket impl so implementations cannot errantly override them:
 
-- Required: `save_state_mut` (the in-flight accept's [`DiffSaveState`]), `pending_diff_count`, `pending_file_state` (per-file report state: reported paths, changed lines, final contents, user-edit flags), and `start_saving` (the write kickoff — the hook `accept_and_save` invokes, never called by callers directly).
-- Provided: `accept_and_save` (the sole entry point: begins tracking, calls `start_saving`, returns a `BoxFuture<RequestFileEditsResult>`), `handle_file_saved` / `handle_diff_computed` (record per-file completion), and `try_finish` (when every file is saved and its result diff computed, assembles the result and sends it).
+- `DiffStorage` — implemented by every surface that stores pending diffs. All methods required: state accessors — the fields live on each impl, since traits cannot hold state — plus the surface-specific write kickoff: `save_state_mut` (the in-flight accept's [`DiffSaveState`]), `pending_diff_count`, `pending_file_state` (per-file report state: reported paths, changed lines, final contents, user-edit flags), and `start_saving` (the write kickoff — the hook `accept_and_save` invokes, never called by callers directly).
+- `DiffStorageHelper` — the shared flow, blanket-implemented for every `DiffStorage`: `accept_and_save` (the sole entry point: begins tracking, calls `start_saving`, returns a `BoxFuture<RequestFileEditsResult>`) and `handle_file_saved` / `handle_diff_computed` (record per-file completion; surfaces call these from their save-completion events). Each flow method ends with the completion check: when every file is saved and its result diff computed, assemble the result and send it.
 
 `DiffSaveState` encapsulates the in-flight accept: per-file progress (`SavingDiffs`) plus the result-delivery oneshot, with private fields so surfaces cannot reach into the channel. Each surface stores one and exposes it via `save_state_mut`; only `is_saving` is public (revert guards).
 
-`try_finish` is master's `try_emit_diffs_saved` relocated to shared code: it combines the per-file `DiffResult`s into the unified diff, builds updated/deleted file state from `pending_file_state` (`updated_file_contexts_from_content_map`), and maps save errors to `DiffApplicationFailed`. Delivery through the stored oneshot replaces master's `SavedAcceptedDiffs` event + executor subscription. Dropping a surface mid-save drops the sender, resolving the future with `Cancelled`.
+The completion check + `assemble_result` is master's `try_emit_diffs_saved` relocated to shared code: it combines the per-file `DiffResult`s into the unified diff, builds updated/deleted file state from `pending_file_state` (`updated_file_contexts_from_content_map`), and maps save errors to `DiffApplicationFailed`. Delivery through the stored oneshot replaces master's `SavedAcceptedDiffs` event + executor subscription. Dropping a surface mid-save drops the sender, resolving the future with `Cancelled`.
 
 `SavingDiffs` (per-file save status + computed result diff, complete when every file has both) moves from `code_diff_view.rs` to `diff_storage.rs` unchanged in behavior.
 
@@ -85,7 +86,7 @@ The executor-facing handle over a registered surface. GUI `ViewHandle`s and mode
 - `set_candidate_diffs(diffs, session_type, app)` — preprocess pushes resolved diffs into the surface.
 - `accept_and_save(app)` — persists everything, resolving with the result for the LLM.
 
-The GUI impl is on `WeakViewHandle<CodeDiffView>` (`code_diff_view.rs`): it upgrades and delegates, so the executor never keeps a dead review view alive; a dead view at execute time resolves `DiffApplicationFailed` recoverably. It flips the view to `Accepted` (`mark_accepted_for_save`) as persistence kicks off, then runs the trait's `accept_and_save`.
+The GUI impl is on `WeakViewHandle<CodeDiffView>` (`code_diff_view.rs`): it upgrades and delegates, so the executor never keeps a dead review view alive; a dead view at execute time resolves `DiffApplicationFailed` recoverably. It flips the view to `Accepted` (`mark_accepted_for_save`) as persistence kicks off, then runs `DiffStorageHelper::accept_and_save`.
 
 ### Executor (`request_file_edits.rs`)
 
@@ -111,7 +112,7 @@ Per-action state keeps master's two-field shape:
 
 ### Passive path (`terminal/view.rs`)
 
-`on_maa_code_diff_generated`'s `TryAccept` handler calls the view's `accept_and_save` (the shared trait flow) directly — passive diffs are not executor actions, so the view is the sole owner. The result is not surfaced to the LLM; failed writes surface the per-file toasts.
+`on_maa_code_diff_generated`'s `TryAccept` handler calls `DiffStorageHelper::accept_and_save` on the view directly — passive diffs are not executor actions, so the view is the sole owner. The result is not surfaced to the LLM; failed writes surface the per-file toasts.
 
 ### TUI surface (up-stack)
 
@@ -126,7 +127,7 @@ The TUI surface registers its own storage through `register_requested_edits` for
 
 ## Testing and validation
 
-- Shared-flow tests exercise the provided trait methods through a minimal test surface (`app/src/ai/blocklist/diff_storage_tests.rs`): result assembly on success, save failure → `DiffApplicationFailed`, deleted-file reporting, and the context-fragment extraction.
+- Shared-flow tests exercise the `DiffStorageHelper` flow through a minimal test surface (`app/src/ai/blocklist/diff_storage_tests.rs`): result assembly on success, save failure → `DiffApplicationFailed`, deleted-file reporting, and the context-fragment extraction.
 - Executor tests cover the registry lifecycle (`request_file_edits_tests.rs`): preprocess seeding of the registered storage, execution through the registered storage, preprocess failure reporting, `NotReady` without a registered storage, and `discard_pending`.
 
 ```bash

--- a/specs/surface-agnostic-file-edit-execution/TECH.md
+++ b/specs/surface-agnostic-file-edit-execution/TECH.md
@@ -10,7 +10,58 @@ On master the GUI view owns the whole persistence flow: `CodeDiffView::accept_an
 
 ## Goal
 
-Make file-edit tool calls executable on any surface (GUI, TUI, headless) by keeping master's surface-owned persistence flow but expressing its shared parts as a trait, so the GUI `CodeDiffView`, the up-stack TUI diff view, and a headless fallback all run the same save-completion and result-assembly code.
+Make file-edit tool calls executable on any surface (GUI, and the up-stack TUI) by keeping master's surface-owned persistence flow but expressing its shared parts as a trait, so every surface runs the same save-completion and result-assembly code. Every surface must register its diff storage with the executor before the action's diffs resolve — the same contract master had with the GUI view — so the executor's flow stays exactly master's, just behind a surface-agnostic interface.
+
+## Flow
+
+Old flow (master) — executor is bound to the concrete GUI view, and result assembly is split between the view (event payload) and the executor (subscription handler):
+
+```text
+output complete ──> AIBlock creates CodeDiffView
+                    └─ register_requested_edits(ViewHandle<CodeDiffView>)
+preprocess ──> on_diffs_applied ──> diff_views[id].set_candidate_diffs()
+
+User Accept ──> TryAccept ──> executor::execute(id)
+  ├─ subscribe_to_view(diff_view)  ◄──────────────────┐ SavedAcceptedDiffs /
+  └─ diff_view.accept_and_save()                     │ Rejected events
+        │  state = Accepted(Some(SavingDiffs))       │
+        ▼                                            │
+     per file: InlineDiffView save + diff compute    │
+     (tracked inside CodeDiffState)                  │
+        │                                            │
+     all done => emit SavedAcceptedDiffs{diff,       │
+     updated_files, file_contents, ...} ─────────────┘
+        │
+        ▼
+executor's event handler assembles
+RequestFileEditsResult + telemetry ──> LLM
+```
+
+New flow — identical shape, but the executor talks to the surface-agnostic interface, and persistence + result assembly live entirely in `diff_storage.rs`:
+
+```text
+output complete ──> surface creates its review storage
+                    └─ register_requested_edits(Box<dyn RegisteredDiffStorage>)
+preprocess ──> on_diffs_applied ──> diff_storages[id].set_candidate_diffs()
+
+User Accept ──> TryAccept ──> executor::execute(id)
+  └─ diff_storages[id].accept_and_save()      [RegisteredDiffStorage]
+        │  (handle upgrade/update)
+        ▼
+     DiffStorageView::accept_and_save          [shared, provided]
+       ├─ save_state.begin(count) ──> returns result future ──┐
+       └─ start_saving()          [surface-specific:          │
+            GUI: editor buffers / InlineDiffView;              │
+            TUI (up-stack): FileModel write dispatch]          │
+        │                                                     │
+     callbacks: handle_file_saved / handle_diff_computed      │
+        │                                                     │
+     try_finish ──> assemble_result(progress,                 │
+                    pending_file_state()) ──> send ───────────┘
+        │
+        ▼
+ActionExecution::new_async(future) ──> telemetry ──> LLM
+```
 
 ## Design
 
@@ -18,8 +69,10 @@ Make file-edit tool calls executable on any surface (GUI, TUI, headless) by keep
 
 Implemented by every surface that stores pending diffs. Required methods are state accessors — the fields live on each impl, since traits cannot hold state — plus the surface-specific write kickoff. Provided methods are the shared save-completion flow:
 
-- Required: `saving_diffs_mut` (per-file progress), `result_tx_mut` (result delivery channel), `pending_diff_count`, `pending_file_state` (per-file report state: reported paths, changed lines, final contents, user-edit flags), and `start_saving` (the write kickoff).
-- Provided: `accept_and_save` (creates a oneshot, sizes `SavingDiffs`, calls `start_saving`, returns the receiver as a `BoxFuture<RequestFileEditsResult>`), `handle_file_saved` / `handle_diff_computed` (record per-file completion), `fail_saving`, and `try_finish` (when every file is saved and its result diff computed, assembles the result and sends it).
+- Required: `save_state_mut` (the in-flight accept's [`DiffSaveState`]), `pending_diff_count`, `pending_file_state` (per-file report state: reported paths, changed lines, final contents, user-edit flags), and `start_saving` (the write kickoff — the hook `accept_and_save` invokes, never called by callers directly).
+- Provided: `accept_and_save` (the sole entry point: begins tracking, calls `start_saving`, returns a `BoxFuture<RequestFileEditsResult>`), `handle_file_saved` / `handle_diff_computed` (record per-file completion), and `try_finish` (when every file is saved and its result diff computed, assembles the result and sends it).
+
+`DiffSaveState` encapsulates the in-flight accept: per-file progress (`SavingDiffs`) plus the result-delivery oneshot, with private fields so surfaces cannot reach into the channel. Each surface stores one and exposes it via `save_state_mut`; only `is_saving` is public (revert guards).
 
 `try_finish` is master's `try_emit_diffs_saved` relocated to shared code: it combines the per-file `DiffResult`s into the unified diff, builds updated/deleted file state from `pending_file_state` (`updated_file_contexts_from_content_map`), and maps save errors to `DiffApplicationFailed`. Delivery through the stored oneshot replaces master's `SavedAcceptedDiffs` event + executor subscription. Dropping a surface mid-save drops the sender, resolving the future with `Cancelled`.
 
@@ -27,36 +80,25 @@ Implemented by every surface that stores pending diffs. Required methods are sta
 
 ### The `RegisteredDiffStorage` trait
 
-The executor-facing handle over a registered surface. GUI `ViewHandle`s and model `ModelHandle`s share no common handle type, so each surface registers a thin wrapper that delegates through its own handle:
+The executor-facing handle over a registered surface. GUI `ViewHandle`s and model `ModelHandle`s share no common handle type, so each surface's handle type implements this directly, delegating to its entity's `DiffStorageView`:
 
 - `set_candidate_diffs(diffs, session_type, app)` — preprocess pushes resolved diffs into the surface.
-- `take_candidate_diffs(app)` — hands diffs back out so a newly registered surface can take over; `None` when this storage keeps ownership.
 - `accept_and_save(app)` — persists everything, resolving with the result for the LLM.
 
-`GuiDiffStorage(WeakViewHandle<CodeDiffView>)` (`code_diff_view.rs`) upgrades and delegates; a dead view at execute time resolves `DiffApplicationFailed` recoverably. It flips the view to `Accepted` (`mark_accepted_for_save`) as persistence kicks off, then runs the trait's `accept_and_save`. It never relinquishes diffs — they live in the view's editor buffers.
-
-### `HeadlessDiffStorageModel`
-
-GUI-less `DiffStorageView`: plain diff storage with no review UI, created by the executor when diffs resolve with no registered surface (autoexecution racing view creation, or headless/TUI-driven conversations), so file edits stay executable everywhere. Its `start_saving` derives each file's final content by applying the diff's deltas to the base (`final_content_from_op` / `apply_deltas_to_content`), decides the actual write once via `PersistAction` (`Write` / `Rename` — local only, remote renames fall back to an in-place write reported at the original path / `Delete`), dispatches through `FileModel` (`register_file_path`/`register_remote_file` → `save`/`rename_and_save`/`delete` → `unsubscribe`), computes a `similar`-based `DiffResult` immediately, and forwards its own `FileModel` save events into the shared flow. `headless_file_outcome` derives the reported outcome from the same `PersistAction` as the dispatch, so report and write cannot drift. On wasm, `start_saving` fails the batch (`file editing is not supported in this environment`).
-
-This model is also the template the up-stack TUI diff storage builds on.
+The GUI impl is on `WeakViewHandle<CodeDiffView>` (`code_diff_view.rs`): it upgrades and delegates, so the executor never keeps a dead review view alive; a dead view at execute time resolves `DiffApplicationFailed` recoverably. It flips the view to `Accepted` (`mark_accepted_for_save`) as persistence kicks off, then runs the trait's `accept_and_save`.
 
 ### Executor (`request_file_edits.rs`)
 
-Per-action state is a registry:
+Per-action state keeps master's two-field shape:
 
-```rust
-enum PendingFileEdits {
-    Storage(Box<dyn RegisteredDiffStorage>),
-    Failed(Vec1<DiffApplicationError>),
-}
-```
+- `diff_storages: HashMap<AIAgentActionId, Box<dyn RegisteredDiffStorage>>` — master's `diff_views`, with the storage interface in place of the concrete GUI view handle.
+- `diff_application_failures: HashMap<AIAgentActionId, Vec1<DiffApplicationError>>` — unchanged.
 
-- `register_requested_edits(action_id, storage)` may be called before or after preprocess resolves. When a placeholder storage already holds prepared diffs, they are handed to the newly registered surface via `take_candidate_diffs`/`set_candidate_diffs`; an owner that does not relinquish (a review surface, or a placeholder already saving) stays registered.
-- `on_diffs_applied` seeds the registered storage with the resolved diffs, or creates the headless placeholder when none is registered. Failures insert `Failed`.
-- `execute`: `Storage` → `storage.accept_and_save(ctx)` wrapped in `ActionExecution::new_async` with the `EditResolved` accept telemetry; `Failed` → `DiffApplicationFailed`; no entry → `NotReady` (only reachable before preprocess resolves).
-- Cleanup: every terminal outcome funnels through the action model's `handle_action_result` → `discard_action_state` → `discard_pending`, which drops the registry entry (and with it the headless model or GUI weak wrapper), so prepared content never outlives its action.
-- `should_autoexecute` allows continue-on-failure for `Failed` entries, unchanged.
+- `register_requested_edits(action_id, storage)` is a plain insert and MUST be called before `preprocess_action` or `execute` (master's contract, now stated for every surface).
+- `on_diffs_applied` seeds the registered storage with the resolved diffs; with none registered it warns and drops them (master behavior). Failures insert into `diff_application_failures`.
+- `execute`: failures → `DiffApplicationFailed`; otherwise `storage.accept_and_save(ctx)` wrapped in `ActionExecution::new_async` with the `EditResolved` accept telemetry; no entry → `NotReady`.
+- Cleanup: every terminal outcome funnels through the action model's `handle_action_result` → `discard_action_state` → `discard_pending`, which drops both maps' entries, so prepared content never outlives its action.
+- `should_autoexecute` allows continue-on-failure for failed diff application, unchanged.
 
 ### GUI (`code_diff_view.rs`, `block.rs`, `inline_diff.rs`)
 
@@ -64,8 +106,8 @@ enum PendingFileEdits {
 
 - `start_saving` drives `InlineDiffView::accept_and_save_diff` per file (compute result diff + save editor content through `FileModel`); completions arrive via the per-file `FileSaved`/`FailedToSave`/`DiffAccepted` subscriptions, which forward into `handle_file_saved`/`handle_diff_computed` by index. The GUI's result diff stays editor-computed, as on master; save failures surface master's per-file toasts.
 - `pending_file_state` is master's result extraction behind the accessor: final content from the editor buffers (possibly user-edited), changed lines from editor state, rename/delete bookkeeping.
-- `saving_diffs` and `save_result_tx` are view fields; `CodeDiffState::Accepted` is payloadless. Revert requires a settled accept (`Accepted` with no in-flight save).
-- `block.rs` registers `GuiDiffStorage(view.downgrade())` with the executor at view creation (`handle_requested_edit_complete`); registration order relative to preprocess no longer matters. On `TryAccept` the block emits malformed-line telemetry and calls `execute_action`, as before. View-only sessions still populate payload diffs directly and never register.
+- `save_state: DiffSaveState` is a view field; `CodeDiffState::Accepted` is payloadless. Revert requires a settled accept (`Accepted` with no in-flight save).
+- `block.rs` registers `Box::new(view.downgrade())` with the executor at view creation (`handle_requested_edit_complete`), upholding the register-before-preprocess contract exactly as master did. On `TryAccept` the block emits malformed-line telemetry and calls `execute_action`, as before. View-only sessions still populate payload diffs directly and never register — a spectator's view must never become the surface that writes edits to disk.
 
 ### Passive path (`terminal/view.rs`)
 
@@ -73,19 +115,19 @@ enum PendingFileEdits {
 
 ### TUI surface (up-stack)
 
-The TUI surface registers its own storage through `register_requested_edits`: a diff-storage model shaped like `HeadlessDiffStorageModel` plus display state, reusing the trait's provided flow and the shared `FileModel` dispatch helpers. `FileDiff::line_stats` (in `diff_types.rs`) exists for its summary rendering.
+The TUI surface registers its own storage through `register_requested_edits` for every `RequestFileEdits` action — including auto-approved edits with no review UI — upholding the same registration contract as the GUI. Its headless persistence (final-content derivation from diff deltas, `FileModel` write dispatch, `similar`-based result diffs) lives up-stack with that surface. `FileDiff::line_stats` (in `diff_types.rs`) exists for its summary rendering.
 
 ## Boundaries
 
 - The review surface's state is the only resident copy of diff content while under review; the executor holds only erased storage handles (weak, for the GUI).
 - The resolve side (`ApplyDiffModel`) is unchanged.
 - Revert stays GUI-local via `InlineDiffView::restore_diff_base`.
-- Result diffs are editor-computed on the GUI (master behavior) and `similar`-based on headless/TUI surfaces; the divergence is accepted.
+- A surface that fails to register before diffs resolve leaves the action unexecutable (`NotReady`), as on master; the registration contract is upheld by each surface at action-arrival time.
 
 ## Testing and validation
 
-- Shared-flow tests exercise the provided trait methods through `HeadlessDiffStorageModel` (`app/src/ai/blocklist/diff_storage_tests.rs`): create/update/delete/rename write-through and reported results, save failure → `DiffApplicationFailed`, delta application, remote-rename fallback reporting, and `take_candidate_diffs` ownership rules.
-- Executor tests cover the registry lifecycle (`request_file_edits_tests.rs`): placeholder→surface diff handoff, non-relinquishing owners, execution through the registered storage, preprocess failure reporting, `NotReady` without prepared diffs, and `discard_pending`.
+- Shared-flow tests exercise the provided trait methods through a minimal test surface (`app/src/ai/blocklist/diff_storage_tests.rs`): result assembly on success, save failure → `DiffApplicationFailed`, deleted-file reporting, and the context-fragment extraction.
+- Executor tests cover the registry lifecycle (`request_file_edits_tests.rs`): preprocess seeding of the registered storage, execution through the registered storage, preprocess failure reporting, `NotReady` without a registered storage, and `discard_pending`.
 
 ```bash
 cargo nextest run -p warp diff_storage request_file_edits

--- a/specs/surface-agnostic-file-edit-execution/TECH.md
+++ b/specs/surface-agnostic-file-edit-execution/TECH.md
@@ -48,7 +48,7 @@ User Accept ──> TryAccept ──> executor::execute(id)
   └─ diff_storages[id].accept_and_save()      [RegisteredDiffStorage]
         │  (handle upgrade/update)
         ▼
-     DiffStorageView::accept_and_save          [shared, provided]
+     DiffStorage::accept_and_save          [shared, provided]
        ├─ save_state.begin(count) ──> returns result future ──┐
        └─ start_saving()          [surface-specific:          │
             GUI: editor buffers / InlineDiffView;              │
@@ -65,7 +65,7 @@ ActionExecution::new_async(future) ──> telemetry ──> LLM
 
 ## Design
 
-### The `DiffStorageView` trait (`app/src/ai/blocklist/diff_storage.rs`)
+### The `DiffStorage` trait (`app/src/ai/blocklist/diff_storage.rs`)
 
 Implemented by every surface that stores pending diffs. Required methods are state accessors — the fields live on each impl, since traits cannot hold state — plus the surface-specific write kickoff. Provided methods are the shared save-completion flow:
 
@@ -80,7 +80,7 @@ Implemented by every surface that stores pending diffs. Required methods are sta
 
 ### The `RegisteredDiffStorage` trait
 
-The executor-facing handle over a registered surface. GUI `ViewHandle`s and model `ModelHandle`s share no common handle type, so each surface's handle type implements this directly, delegating to its entity's `DiffStorageView`:
+The executor-facing handle over a registered surface. GUI `ViewHandle`s and model `ModelHandle`s share no common handle type, so each surface's handle type implements this directly, delegating to its entity's `DiffStorage`:
 
 - `set_candidate_diffs(diffs, session_type, app)` — preprocess pushes resolved diffs into the surface.
 - `accept_and_save(app)` — persists everything, resolving with the result for the LLM.
@@ -102,7 +102,7 @@ Per-action state keeps master's two-field shape:
 
 ### GUI (`code_diff_view.rs`, `block.rs`, `inline_diff.rs`)
 
-`CodeDiffView` implements `DiffStorageView`; its core save flow is master's, untouched:
+`CodeDiffView` implements `DiffStorage`; its core save flow is master's, untouched:
 
 - `start_saving` drives `InlineDiffView::accept_and_save_diff` per file (compute result diff + save editor content through `FileModel`); completions arrive via the per-file `FileSaved`/`FailedToSave`/`DiffAccepted` subscriptions, which forward into `handle_file_saved`/`handle_diff_computed` by index. The GUI's result diff stays editor-computed, as on master; save failures surface master's per-file toasts.
 - `pending_file_state` is master's result extraction behind the accessor: final content from the editor buffers (possibly user-edited), changed lines from editor state, rename/delete bookkeeping.

--- a/specs/surface-agnostic-file-edit-execution/TECH.md
+++ b/specs/surface-agnostic-file-edit-execution/TECH.md
@@ -1,0 +1,94 @@
+# Surface-Agnostic File-Edit Execution TECH
+
+## Context
+
+This branch builds on the TUI agent tool-calling work (now on `master`), which renders `RequestFileEdits` in the transcript like any other tool call but leaves it unexecuted on non-GUI surfaces: `RequestFileEditsExecutor::execute` required a registered GUI `CodeDiffView` and returned `NotReady` otherwise, blocking the conversation (`app/src/ai/blocklist/action_model/execute/request_file_edits.rs`).
+
+On master the GUI view owns the whole persistence flow: `CodeDiffView::accept_and_save` drives per-file editor-buffer saves through `InlineDiffView`, tracks completion in `SavingDiffs`, and assembles the `RequestFileEditsResult` in `try_emit_diffs_saved`, which the executor consumes via a `SavedAcceptedDiffs` event subscription. That flow is well proven, but it is expressed entirely in terms of one concrete GUI view, so no other surface can execute file edits.
+
+`RequestFileEdits` has a two-phase lifecycle: `preprocess_action` resolves the LLM's edits into concrete diffs (async file reads via `ApplyDiffModel::apply_diffs`) and `execute` runs later to persist them. State computed in preprocess must survive an arbitrary user-interaction gap; the review surface's buffers are that survivor.
+
+## Goal
+
+Make file-edit tool calls executable on any surface (GUI, TUI, headless) by keeping master's surface-owned persistence flow but expressing its shared parts as a trait, so the GUI `CodeDiffView`, the up-stack TUI diff view, and a headless fallback all run the same save-completion and result-assembly code.
+
+## Design
+
+### The `DiffStorageView` trait (`app/src/ai/blocklist/diff_storage.rs`)
+
+Implemented by every surface that stores pending diffs. Required methods are state accessors — the fields live on each impl, since traits cannot hold state — plus the surface-specific write kickoff. Provided methods are the shared save-completion flow:
+
+- Required: `saving_diffs_mut` (per-file progress), `result_tx_mut` (result delivery channel), `pending_diff_count`, `pending_file_state` (per-file report state: reported paths, changed lines, final contents, user-edit flags), and `start_saving` (the write kickoff).
+- Provided: `accept_and_save` (creates a oneshot, sizes `SavingDiffs`, calls `start_saving`, returns the receiver as a `BoxFuture<RequestFileEditsResult>`), `handle_file_saved` / `handle_diff_computed` (record per-file completion), `fail_saving`, and `try_finish` (when every file is saved and its result diff computed, assembles the result and sends it).
+
+`try_finish` is master's `try_emit_diffs_saved` relocated to shared code: it combines the per-file `DiffResult`s into the unified diff, builds updated/deleted file state from `pending_file_state` (`updated_file_contexts_from_content_map`), and maps save errors to `DiffApplicationFailed`. Delivery through the stored oneshot replaces master's `SavedAcceptedDiffs` event + executor subscription. Dropping a surface mid-save drops the sender, resolving the future with `Cancelled`.
+
+`SavingDiffs` (per-file save status + computed result diff, complete when every file has both) moves from `code_diff_view.rs` to `diff_storage.rs` unchanged in behavior.
+
+### The `RegisteredDiffStorage` trait
+
+The executor-facing handle over a registered surface. GUI `ViewHandle`s and model `ModelHandle`s share no common handle type, so each surface registers a thin wrapper that delegates through its own handle:
+
+- `set_candidate_diffs(diffs, session_type, app)` — preprocess pushes resolved diffs into the surface.
+- `take_candidate_diffs(app)` — hands diffs back out so a newly registered surface can take over; `None` when this storage keeps ownership.
+- `accept_and_save(app)` — persists everything, resolving with the result for the LLM.
+
+`GuiDiffStorage(WeakViewHandle<CodeDiffView>)` (`code_diff_view.rs`) upgrades and delegates; a dead view at execute time resolves `DiffApplicationFailed` recoverably. It flips the view to `Accepted` (`mark_accepted_for_save`) as persistence kicks off, then runs the trait's `accept_and_save`. It never relinquishes diffs — they live in the view's editor buffers.
+
+### `HeadlessDiffStorageModel`
+
+GUI-less `DiffStorageView`: plain diff storage with no review UI, created by the executor when diffs resolve with no registered surface (autoexecution racing view creation, or headless/TUI-driven conversations), so file edits stay executable everywhere. Its `start_saving` derives each file's final content by applying the diff's deltas to the base (`final_content_from_op` / `apply_deltas_to_content`), decides the actual write once via `PersistAction` (`Write` / `Rename` — local only, remote renames fall back to an in-place write reported at the original path / `Delete`), dispatches through `FileModel` (`register_file_path`/`register_remote_file` → `save`/`rename_and_save`/`delete` → `unsubscribe`), computes a `similar`-based `DiffResult` immediately, and forwards its own `FileModel` save events into the shared flow. `headless_file_outcome` derives the reported outcome from the same `PersistAction` as the dispatch, so report and write cannot drift. On wasm, `start_saving` fails the batch (`file editing is not supported in this environment`).
+
+This model is also the template the up-stack TUI diff storage builds on.
+
+### Executor (`request_file_edits.rs`)
+
+Per-action state is a registry:
+
+```rust
+enum PendingFileEdits {
+    Storage(Box<dyn RegisteredDiffStorage>),
+    Failed(Vec1<DiffApplicationError>),
+}
+```
+
+- `register_requested_edits(action_id, storage)` may be called before or after preprocess resolves. When a placeholder storage already holds prepared diffs, they are handed to the newly registered surface via `take_candidate_diffs`/`set_candidate_diffs`; an owner that does not relinquish (a review surface, or a placeholder already saving) stays registered.
+- `on_diffs_applied` seeds the registered storage with the resolved diffs, or creates the headless placeholder when none is registered. Failures insert `Failed`.
+- `execute`: `Storage` → `storage.accept_and_save(ctx)` wrapped in `ActionExecution::new_async` with the `EditResolved` accept telemetry; `Failed` → `DiffApplicationFailed`; no entry → `NotReady` (only reachable before preprocess resolves).
+- Cleanup: every terminal outcome funnels through the action model's `handle_action_result` → `discard_action_state` → `discard_pending`, which drops the registry entry (and with it the headless model or GUI weak wrapper), so prepared content never outlives its action.
+- `should_autoexecute` allows continue-on-failure for `Failed` entries, unchanged.
+
+### GUI (`code_diff_view.rs`, `block.rs`, `inline_diff.rs`)
+
+`CodeDiffView` implements `DiffStorageView`; its core save flow is master's, untouched:
+
+- `start_saving` drives `InlineDiffView::accept_and_save_diff` per file (compute result diff + save editor content through `FileModel`); completions arrive via the per-file `FileSaved`/`FailedToSave`/`DiffAccepted` subscriptions, which forward into `handle_file_saved`/`handle_diff_computed` by index. The GUI's result diff stays editor-computed, as on master; save failures surface master's per-file toasts.
+- `pending_file_state` is master's result extraction behind the accessor: final content from the editor buffers (possibly user-edited), changed lines from editor state, rename/delete bookkeeping.
+- `saving_diffs` and `save_result_tx` are view fields; `CodeDiffState::Accepted` is payloadless. Revert requires a settled accept (`Accepted` with no in-flight save).
+- `block.rs` registers `GuiDiffStorage(view.downgrade())` with the executor at view creation (`handle_requested_edit_complete`); registration order relative to preprocess no longer matters. On `TryAccept` the block emits malformed-line telemetry and calls `execute_action`, as before. View-only sessions still populate payload diffs directly and never register.
+
+### Passive path (`terminal/view.rs`)
+
+`on_maa_code_diff_generated`'s `TryAccept` handler calls the view's `accept_and_save` (the shared trait flow) directly — passive diffs are not executor actions, so the view is the sole owner. The result is not surfaced to the LLM; failed writes surface the per-file toasts.
+
+### TUI surface (up-stack)
+
+The TUI surface registers its own storage through `register_requested_edits`: a diff-storage model shaped like `HeadlessDiffStorageModel` plus display state, reusing the trait's provided flow and the shared `FileModel` dispatch helpers. `FileDiff::line_stats` (in `diff_types.rs`) exists for its summary rendering.
+
+## Boundaries
+
+- The review surface's state is the only resident copy of diff content while under review; the executor holds only erased storage handles (weak, for the GUI).
+- The resolve side (`ApplyDiffModel`) is unchanged.
+- Revert stays GUI-local via `InlineDiffView::restore_diff_base`.
+- Result diffs are editor-computed on the GUI (master behavior) and `similar`-based on headless/TUI surfaces; the divergence is accepted.
+
+## Testing and validation
+
+- Shared-flow tests exercise the provided trait methods through `HeadlessDiffStorageModel` (`app/src/ai/blocklist/diff_storage_tests.rs`): create/update/delete/rename write-through and reported results, save failure → `DiffApplicationFailed`, delta application, remote-rename fallback reporting, and `take_candidate_diffs` ownership rules.
+- Executor tests cover the registry lifecycle (`request_file_edits_tests.rs`): placeholder→surface diff handoff, non-relinquishing owners, execution through the registered storage, preprocess failure reporting, `NotReady` without prepared diffs, and `discard_pending`.
+
+```bash
+cargo nextest run -p warp diff_storage request_file_edits
+./script/format
+cargo clippy --workspace --all-targets --all-features --tests -- -D warnings
+```


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

`RequestFileEdits` was only executable on the GUI: the shared executor required a registered `CodeDiffView`, and that view was the sole thing that could save files and assemble a `RequestFileEditsResult`. This PR makes file-edit execution surface-agnostic while keeping master's surface-owned persistence flow: the shared parts of that flow (save-completion tracking and result assembly) are expressed as the `DiffStorage` / `DiffStorageHelper` trait pair, so the GUI `CodeDiffView` and the up-stack TUI storage all run the same code.

The executor knows surfaces only through `RegisteredDiffStorage`, a small object-safe handle trait (GUI views and models share no common handle type). A surface registers its storage when the action arrives — the same register-before-preprocess contract master had with the GUI view, now stated for every surface; the executor seeds it with resolved diffs when preprocess completes and calls `accept_and_save` on it at execute time, getting back a `BoxFuture<RequestFileEditsResult>`. Every terminal outcome funnels through the action model's result choke point, which drops the executor's per-action state so prepared file contents never outlive their action.

This unblocks the TUI file-edits surface up-stack (`harry/tui-file-edits-surface`), which registers a headless storage of its own (base + deltas → `FileModel` writes) and renders a summary over it.

## Call flow

Before (GUI-only):

```
PHASE 1 — preprocess
    apply_diffs ──> on_diffs_applied ──> diff_view.set_candidate_diffs
                                          (diffs live inside the GUI view's editor buffers)

    ╌╌╌╌╌╌╌╌ GAP: user reviews / edits / clicks Accept ╌╌╌╌╌╌╌╌

PHASE 2 — execute
    diff_views[id] ──> accept_and_save
        ──> view reads its editor buffers
        ──> FileModel::save per file
        ──> SavedAcceptedDiffs ──> result (assembled by the view)
```
After (surface-agnostic):

```
registration (at action arrival, before preprocess resolves)
    surface ──> register_requested_edits(id, Box<dyn RegisteredDiffStorage>)
        GUI:  WeakViewHandle<CodeDiffView>
        TUI:  its own headless storage (up-stack)

PHASE 1 — preprocess
    apply_diffs ──> on_diffs_applied ──> storage.set_candidate_diffs(diffs)

    ╌╌╌╌╌╌╌╌ GAP: user reviews / edits in place (GUI) ╌╌╌╌╌╌╌╌

PHASE 2 — execute
    storage.accept_and_save() ──> BoxFuture<RequestFileEditsResult>
        shared DiffStorageHelper flow:
            start_saving (surface-specific write kickoff)
                GUI:            editor-buffer saves via InlineDiffView (master's flow)
                TUI (up-stack): base + deltas ──> FileModel write/rename/delete
            handle_file_saved / handle_diff_computed per file
            all complete ──> assemble result ──> resolve the future
```
## what to read

- `specs/surface-agnostic-file-edit-execution/TECH.md` — the design doc; worth reading first.
- `app/src/ai/blocklist/diff_storage.rs` — the new module. `DiffStorage` is the trait every surface implements: all methods are required — state accessors (traits can't hold fields) plus `start_saving`. `DiffStorageHelper` is the shared save-completion flow (`accept_and_save`, `handle_file_saved`, `handle_diff_computed`), blanket-implemented so surfaces can't override it — master's `SavingDiffs`/`try_emit_diffs_saved` machinery relocated. Result delivery is a oneshot stored in `DiffSaveState` instead of the `SavedAcceptedDiffs` event + executor subscription.
- `app/src/ai/blocklist/diff_types.rs` — plain diff data types (`FileDiff`, `DiffSessionType`, changed-line derivation) moved out of the GUI view module so shared code can name them without depending on any view.
- `app/src/ai/blocklist/action_model/execute/request_file_edits.rs` — the executor: a `Box<dyn RegisteredDiffStorage>` registry replaces the view map; `execute` just calls `accept_and_save` on the registered storage. Per-action state is dropped at the action model's terminal-result choke point.
- `app/src/ai/blocklist/inline_action/code_diff_view.rs` — `CodeDiffView` implements `DiffStorage`; its editor-buffer save flow is master's, with completions forwarded into the shared trait methods. `WeakViewHandle<CodeDiffView>` is the registered handle, so the executor never keeps a dead review view alive; a dead view at execute time fails recoverably.

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

code diff tests pass and code diffs still work.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

_Conversation: https://staging.warp.dev/conversation/4cdd3733-0e92-4383-b2c2-3e708ce2b7c7_
_Run: https://oz.staging.warp.dev/runs/019f2518-9260-72f2-8fbf-f35fc5184114_
_Plans:_
- _[File-edit persistence via DiffStorageView trait](https://staging.warp.dev/drive/notebook/rkKsLXQAekrqQgqJXi0kOF)_

_This PR was generated with [Oz](https://warp.dev/oz)._
