### PR TITLE
Model deferred completion work per block

### DIFF
--- a/app/src/terminal/model/block.rs
+++ b/app/src/terminal/model/block.rs
@@ -413,6 +413,8 @@ pub struct Block {
     ///
     /// This is used for debugging UI shown in the block header on dogfood builds.
     nld_overridden: bool,
+    /// Whether the delayed work that runs after this block's next prompt has been resolved.
+    deferred_completion_work_resolved: bool,
 
     visible_bootstrap_block_event_sent: bool,
 }
@@ -1012,6 +1014,7 @@ impl Block {
             },
             nld_overridden: false,
             is_oz_environment_startup_command: false,
+            deferred_completion_work_resolved: false,
             visible_bootstrap_block_event_sent: false,
         }
     }
@@ -1682,6 +1685,16 @@ impl Block {
 
     pub fn finished(&self) -> bool {
         self.output_grid.finished()
+    }
+
+    /// Returns whether this block's deferred after-completion work has been resolved.
+    pub(super) fn deferred_completion_work_resolved(&self) -> bool {
+        self.deferred_completion_work_resolved
+    }
+
+    /// Marks this block's deferred after-completion work as resolved.
+    pub(super) fn resolve_deferred_completion_work(&mut self) {
+        self.deferred_completion_work_resolved = true;
     }
 
     pub fn is_receiving_prompt(&self) -> bool {

--- a/app/src/terminal/model/blocks.rs
+++ b/app/src/terminal/model/blocks.rs
@@ -299,9 +299,6 @@ pub struct BlockList {
     restored_session_ts: Option<DateTime<Local>>,
 
     latest_block_finished_time: Option<SystemTime>,
-    /// Whether the next prompt must avoid repeating deferred completion work for an already-finished
-    /// active block that recovery advanced past.
-    skip_next_after_block_completed_event: bool,
 
     /// The number of in-band commands that are "in-flight", where "in-flight" is defined as
     /// written to the PTY without yet a completed block.
@@ -662,7 +659,6 @@ impl BlockList {
             is_restored_session: false,
             restored_session_ts: None,
             latest_block_finished_time: None,
-            skip_next_after_block_completed_event: false,
             early_output: EarlyOutput::new(event_proxy),
             in_flight_in_band_command_count: 0,
             last_populated_precmd_payload: None,
@@ -3080,6 +3076,7 @@ impl BlockList {
                 cloud_workflow_id: None,
                 cloud_env_var_collection_id: None,
             }));
+        self.active_block_mut().resolve_deferred_completion_work();
 
         // Set the completed_ts to the saved completed_ts _after_ `finish`ing the block (which would have set its own completed_ts).
         self.active_block_mut().override_completed_ts(completed_ts);
@@ -3123,10 +3120,9 @@ impl BlockList {
         }
 
         if active_block_was_finished {
-            self.skip_next_after_block_completed_event = true;
+            self.active_block_mut().resolve_deferred_completion_work();
             self.latest_block_finished_time = None;
         } else {
-            self.skip_next_after_block_completed_event = false;
             self.active_block_mut().finish(data.exit_code);
             self.latest_block_finished_time = Some(instant::SystemTime::now());
         }
@@ -3195,15 +3191,18 @@ impl BlockList {
 
         // Depending on whether or not there's a background block active, the previous
         // completed block is at blocks.len - 2 or blocks.len - 3.
-        let previous_block = [2usize, 3usize]
+        let previous_block_index = [2usize, 3usize]
             .into_iter()
             .flat_map(|offset| self.blocks.len().checked_sub(offset))
-            .map(|idx| &self.blocks[idx])
-            .find(|block| !block.is_background());
-        if self.skip_next_after_block_completed_event {
-            self.skip_next_after_block_completed_event = false;
-        } else if let Some(previous_block) = previous_block {
-            self.send_after_block_completed_event(previous_block, block_finished_to_precmd_delay);
+            .find(|idx| !self.blocks[*idx].is_background());
+        if let Some(previous_block_index) = previous_block_index {
+            if !self.blocks[previous_block_index].deferred_completion_work_resolved() {
+                self.send_after_block_completed_event(
+                    &self.blocks[previous_block_index],
+                    block_finished_to_precmd_delay,
+                );
+                self.blocks[previous_block_index].resolve_deferred_completion_work();
+            }
         } else {
             self.event_proxy
                 .send_terminal_event(TerminalEvent::BootstrapPrecmdDone);
@@ -3245,30 +3244,39 @@ impl BlockList {
     /// notifies the view of the completed block, so that it can be saved for
     /// session restoration.
     fn finish_background_block(&mut self) {
-        let num_secrets_obfuscated = self
-            .background_block_mut()
-            .map(|block| block.num_secrets_obfuscated());
         let agent_view_state = self.agent_view_state.clone();
-        if let Some(background_block) = self.background_block_mut() {
-            background_block.finish(0);
-            let block_index = background_block.index();
+        if self.background_block_mut().is_some() {
+            let (block_index, event) = {
+                let background_block = self
+                    .background_block_mut()
+                    .expect("Background block should still exist.");
+                background_block.finish(0);
+                let block_index = background_block.index();
 
-            // It's common to have empty background blocks (because they only contained
-            // typeahead), so we skip serializing them.
-            if !background_block.is_empty(&agent_view_state) {
-                // This is similar to send_after_block_completed_event, but we can't
-                // call it because background_block mutably borrows self.
-                let block_type = background_block.into();
-                self.event_proxy.send_terminal_event(AfterBlockCompleted(
-                    AfterBlockCompletedEvent {
+                // It's common to have empty background blocks (because they only contained
+                // typeahead), so we skip serializing them.
+                let event = if background_block.is_empty(&agent_view_state) {
+                    None
+                } else {
+                    // This is similar to send_after_block_completed_event, but we can't
+                    // call it because background_block mutably borrows self.
+                    let block_type = (&*background_block).into();
+                    Some(AfterBlockCompletedEvent {
                         command_finished_to_precmd_delay: None,
                         block_type,
-                        num_secrets_obfuscated: num_secrets_obfuscated.unwrap_or_default(),
+                        num_secrets_obfuscated: background_block.num_secrets_obfuscated(),
                         // Background blocks are not tracked as cloud workflow executions.
                         cloud_workflow_id: None,
                         cloud_env_var_collection_id: None,
-                    },
-                ));
+                    })
+                };
+                background_block.resolve_deferred_completion_work();
+                (block_index, event)
+            };
+
+            if let Some(event) = event {
+                self.event_proxy
+                    .send_terminal_event(AfterBlockCompleted(event));
             }
 
             // Now that the block is no longer active, its height may have changed.

--- a/app/src/terminal/model/blocks_tests.rs
+++ b/app/src/terminal/model/blocks_tests.rs
@@ -171,6 +171,47 @@ fn drain_terminal_events(events_rx: &async_channel::Receiver<Event>) -> Vec<Even
     events
 }
 
+#[test]
+fn restored_blocks_resolve_deferred_completion_work() {
+    let (events_tx, events_rx) = async_channel::unbounded();
+    let mut block_list = new_bootstrapped_block_list(
+        None,
+        None,
+        ChannelEventListener::builder_for_test()
+            .with_terminal_events_tx(events_tx)
+            .build(),
+    );
+    drain_terminal_events(&events_rx);
+
+    let restored_block_id = BlockId::new();
+    let restored_block = SerializedBlock {
+        id: restored_block_id.clone(),
+        start_ts: Some(Local::now()),
+        completed_ts: Some(Local::now()),
+        ..Default::default()
+    };
+    block_list.insert_restored_block(&restored_block);
+
+    let events = drain_terminal_events(&events_rx);
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event, Event::AfterBlockCompleted(_)))
+            .count(),
+        1
+    );
+    let restored_block = block_list
+        .block_with_id(&restored_block_id)
+        .expect("The restored block should be present.");
+    assert!(restored_block.deferred_completion_work_resolved());
+
+    block_list.apply_precmd_to_active(PromptMetadata::default());
+    let events = drain_terminal_events(&events_rx);
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event, Event::AfterBlockCompleted(_))));
+}
+
 /// Advances the block list to the ScriptExecution stage.
 fn advance_to_script_execution(block_list: &mut BlockList) {
     assert!(
@@ -2254,6 +2295,12 @@ fn test_background_blocks_finished() {
         }
         other => panic!("Expected BlockType::BackgroundOutput, but was {other:?}"),
     }
+    assert!(block_list
+        .blocks()
+        .iter()
+        .find(|block| block.is_background())
+        .expect("The background block should be present.")
+        .deferred_completion_work_resolved());
 
     match &block_completed_events[2].block_type {
         BlockType::User(block) => {

--- a/crates/warp_features/src/features_tests.rs
+++ b/crates/warp_features/src/features_tests.rs
@@ -18,3 +18,10 @@ fn local_child_harnesses_are_local_only_by_default() {
     assert!(!DEBUG_FLAGS.contains(&FeatureFlag::LocalClaudeCodexChildHarnesses));
     assert!(!DOGFOOD_FLAGS.contains(&FeatureFlag::LocalClaudeCodexChildHarnesses));
 }
+
+#[test]
+fn terminal_lifecycle_recovery_is_dogfood_only_by_default() {
+    assert!(DOGFOOD_FLAGS.contains(&FeatureFlag::TerminalLifecycleRecovery));
+    assert!(!PREVIEW_FLAGS.contains(&FeatureFlag::TerminalLifecycleRecovery));
+    assert!(!RELEASE_FLAGS.contains(&FeatureFlag::TerminalLifecycleRecovery));
+}

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -973,6 +973,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::GPTConfigurableContextWindow,
     FeatureFlag::RestorePromptOnInlineModelSelectorSearch,
     FeatureFlag::WarpControlCli,
+    FeatureFlag::TerminalLifecycleRecovery,
     FeatureFlag::PromptCacheExpiryWarning,
     FeatureFlag::BackgroundComputerUse,
     FeatureFlag::ContextWindowUsageBreakdown,


### PR DESCRIPTION
## Description
This follow-up to terminal lifecycle recovery replaces the global `skip_next_after_block_completed_event` latch with per-block `deferred_completion_work_resolved` state.

The previous latch encoded "skip the next prompt-side completion event" as BlockList-level temporal state. This change attaches the idempotency marker to the completed block instead, so each block's deferred completion work is resolved at most once. Normal `Precmd` handling resolves the work after emitting `AfterBlockCompleted`, while restored, already-finished recovery, and background completion paths mark their blocks resolved when they emit or intentionally skip that deferred work.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

No linked issue.

## Testing
- [x] `./script/format`
- [x] `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- [x] `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- [x] `cargo nextest run -p warp -E 'test(recovery_advances_finished_active_block_without_republishing_completion) | test(precmd_with_completion_metadata_recovers_missing_completion_with_exact_side_effects) | test(repeated_precmd_with_completion_metadata_and_prompt_only_precmd_are_ignored) | test(restored_blocks_resolve_deferred_completion_work) | test(test_background_blocks_finished)'`
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A; this is an internal terminal lifecycle model change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>