### PR TITLE
fix(macos): honor option-click on the zoom button

### DIFF
--- a/crates/warpui/src/platform/mac/objc/window.m
+++ b/crates/warpui/src/platform/mac/objc/window.m
@@ -444,13 +444,13 @@ void init_warp_nswindow(NSWindow<WarpWindowProtocol> *window, bool testMode, boo
 - (void)sendEvent:(NSEvent *)event {
     switch (event.type) {
         case NSEventTypeLeftMouseDown: {
-            NSButton *windowButton = [self standardWindowButtonAtEvent:event];
-            if (windowButton) {
-                _leftMouseDownStartedInNativeWindowChrome = NO;
-                [windowButton mouseDown:event];
-                break;
-            }
-            _leftMouseDownStartedInNativeWindowChrome = [self eventIsOverResizeEdge:event];
+            // Clicks on the traffic-light buttons must go through AppKit's own routing
+            // rather than being delivered to the button's mouseDown: directly; direct
+            // delivery bypasses the window's modifier handling, so option-clicking the
+            // zoom button would enter fullscreen instead of zooming the window.
+            _leftMouseDownStartedInNativeWindowChrome =
+                [self standardWindowButtonAtEvent:event] != nil ||
+                [self eventIsOverResizeEdge:event];
             [super sendEvent:event];
             break;
         }


### PR DESCRIPTION
## Description

On macOS, Option-clicking the green traffic-light button should zoom the window (fill the visible screen while staying a regular window) rather than enter native fullscreen. Since #12557, `WarpWindow`'s `sendEvent:` delivers left mouse-downs that land on a traffic-light button straight to the button via `[windowButton mouseDown:event]`. That bypasses AppKit's window-chrome event routing — which is where the Option modifier is interpreted — so the zoom button always fired its default fullscreen action even though the forwarded event carried `NSEventModifierFlagOption`.

The fix keeps the chrome hit-test from #12557 but uses it only to latch event ownership (`_leftMouseDownStartedInNativeWindowChrome`), and lets `[super sendEvent:event]` deliver the mouse-down natively — the same way resize-edge clicks are already handled. The existing latch logic keeps the subsequent mouse-up/drag routed to AppKit on macOS 27, so this does not reintroduce #12389 (unresponsive traffic lights on macOS 27), which #12557 fixed.

Implemented with Claude Code; all behavior claims below were manually verified by a human.

## Linked Issue

Fixes #13326

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. *(Issue filed alongside this PR; Oz triage was still in progress at PR-open time.)*
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

**Root-cause isolation and fix validation** were done with a standalone AppKit harness ([source gist](https://gist.github.com/ChristmasSun/11da5a221cc662d7e4bb2fa00b3b02f5)) that replicates Warp's window setup (`NSWindowStyleMaskFullSizeContentView`, transparent titlebar, host view that swallows events, and `WarpWindow`'s exact `sendEvent:` dispatch):

1. **Bisection (4 windows):** control, `sendEvent:` button-forwarding only, host-view event swallowing only, and both. Only the windows with `[windowButton mouseDown:event]` forwarding exhibit the bug — the log shows the forwarded event had the Option flag set (`option=524288`) and the window still entered fullscreen. The control and swallow-only windows zoom correctly.
2. **Fix validation (2 windows):** the patched dispatch was tested in both OS flavors — macOS 27-style (latched mouse-up/drag to `super`) and macOS ≤26-style (mouse-up/drag rerouted to the content view, matching the `@available` branches in `window.m`). In both: Option-click green → zooms; plain click green → enters fullscreen; yellow button → miniaturizes. All verified by hand on macOS 26.5 (arm64).

```
[E-fix27] chrome click via super (option=524288)
[E-fix27] >>> ZOOM (correct option-click behavior) <<<
[E-fix27] chrome click via super (option=0)
[E-fix27] >>> ENTERED NATIVE FULLSCREEN <<<
[E-fix27] >>> MINIATURIZED <<<
[F-fix26] chrome click via super (option=524288)
[F-fix26] >>> ZOOM (correct option-click behavior) <<<
[F-fix26] chrome click via super (option=0)
[F-fix26] >>> ENTERED NATIVE FULLSCREEN <<<
[F-fix26] >>> MINIATURIZED <<<
```

**Against this checkout:**

- `xcrun clang -fsyntax-only -fblocks -fobjc-exceptions -Werror -Wno-deprecated-declarations -isysroot "$(xcrun --show-sdk-path)" -I crates/warpui/src/platform/mac/objc crates/warpui/src/platform/mac/objc/window.m` — passes
- `./script/run-clang-format.py --extensions 'm' crates/warpui/src/platform/mac/objc/window.m` — clean
- `git diff --check` — clean

**Limitation:** a full `./script/run` build was not possible on this machine because the Apple Command Line Tools do not include the Xcode `metal`/`metallib` shader compilers required by `crates/warpui/build.rs` (the same limitation noted in #12557). The dispatch change is isolated to `sendEvent:` in `window.m` and is exercised end-to-end by the harness above; happy to add an in-app recording if a maintainer can run a build, or once I have a full Xcode install.

No automated regression test is included: the bug lives in AppKit's native event routing for window-chrome buttons (`NSWindow sendEvent:` → traffic-light widgets), which the Rust unit/integration harness cannot exercise — test-mode windows are hidden and events are synthesized in-process, so native chrome interactions never occur.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Harness logs above; repro/validation app source: https://gist.github.com/ChristmasSun/11da5a221cc662d7e4bb2fa00b3b02f5

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Option-clicking the green traffic-light button on macOS now zooms the window instead of entering fullscreen.
