### PR TITLE
Gracefully fall back when the full terminal use (CLI agent) model is disabled

### DIFF
--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -324,6 +324,16 @@ impl LLMInfo {
         self.reasoning_level.clone()
     }
 
+    /// Whether the model is effectively usable for the current user: not
+    /// disabled, or disabled for a reason that a BYOK key for its provider
+    /// overrides (see [`DisableReason::should_clear_preference`]).
+    fn is_usable(&self, app: &AppContext) -> bool {
+        let has_byok_key = is_using_api_key_for_provider(&self.provider, app);
+        self.disable_reason
+            .as_ref()
+            .is_none_or(|reason| !reason.should_clear_preference(has_byok_key))
+    }
+
     #[cfg(feature = "integration_tests")]
     fn new_for_test(llm_name: &str) -> Self {
         Self {
@@ -401,17 +411,20 @@ impl AvailableLLMs {
     /// Returns the info for the given id only if the model is usable (present
     /// and not effectively disabled for the current user).
     fn usable_info_for_id(&self, id: &LLMId, app: &AppContext) -> Option<&LLMInfo> {
-        self.info_for_id(id).filter(|info| {
-            let has_byok_key = is_using_api_key_for_provider(&info.provider, app);
-            info.disable_reason
-                .as_ref()
-                .is_none_or(|reason| !reason.should_clear_preference(has_byok_key))
-        })
+        self.info_for_id(id).filter(|info| info.is_usable(app))
     }
 
     fn default_llm_info(&self) -> &LLMInfo {
         self.info_for_id(&self.default_id)
             .expect("Default LLM ID must be present in choices")
+    }
+
+    /// Returns the default choice when it is usable, otherwise the first usable
+    /// choice. `None` when every choice is effectively disabled for the current
+    /// user (e.g. Direct API admin-disabled with no cloud host configured).
+    fn usable_default_llm_info(&self, app: &AppContext) -> Option<&LLMInfo> {
+        self.usable_info_for_id(&self.default_id, app)
+            .or_else(|| self.choices.iter().find(|info| info.is_usable(app)))
     }
 
     #[cfg(feature = "integration_tests")]
@@ -810,6 +823,12 @@ impl LLMPreferences {
     }
 
     /// Returns the `LLMInfo` for the CLI agent model.
+    ///
+    /// Degrades gracefully when the selection or the server default is
+    /// effectively disabled (e.g. Direct API admin-disabled with no cloud
+    /// host): falls back to the first usable choice, then to the base model
+    /// when it is a custom endpoint (custom endpoints are valid CLI agent
+    /// models server-side), and only then to the raw default.
     pub fn get_active_cli_agent_model<'a>(
         &'a self,
         app: &'a AppContext,
@@ -824,10 +843,25 @@ impl LLMPreferences {
             .clone()
             .and_then(|id| {
                 available
-                    .info_for_id(&id)
+                    .usable_info_for_id(&id, app)
                     .or_else(|| self.custom_llm_info_for_id_if_enabled(&id, app))
             })
+            .or_else(|| available.usable_default_llm_info(app))
+            .or_else(|| self.active_base_custom_endpoint(app, terminal_view_id))
             .unwrap_or_else(|| available.default_llm_info())
+    }
+
+    /// Returns the active base model when it is one of the user's custom
+    /// endpoints. Used as a CLI agent fallback when every CLI agent choice is
+    /// effectively disabled, mirroring the server's own "empty CLI agent model
+    /// falls back to the base model" behavior.
+    fn active_base_custom_endpoint<'a>(
+        &'a self,
+        app: &'a AppContext,
+        terminal_view_id: Option<EntityId>,
+    ) -> Option<&'a LLMInfo> {
+        let base_id = self.get_active_base_model(app, terminal_view_id).id.clone();
+        self.custom_llm_info_for_id_if_enabled(&base_id, app)
     }
 
     /// Returns the default CLI agent model as a fallback.

--- a/app/src/ai/llms_tests.rs
+++ b/app/src/ai/llms_tests.rs
@@ -418,3 +418,215 @@ fn reconcile_preserves_custom_models_saved_on_execution_profile() {
         });
     });
 }
+
+// -- get_active_cli_agent_model fallback tests --
+
+/// Registers the singleton models needed to construct `LLMPreferences` in a
+/// test app. Handles are re-fetched in tests via `SingletonEntity::handle`.
+fn setup_llm_preferences_test(app: &mut App) {
+    initialize_settings_for_tests(app);
+    app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+    app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+    app.add_singleton_model(AuthManager::new_for_test);
+    app.add_singleton_model(|_| NetworkStatus::new());
+    app.add_singleton_model(UserWorkspaces::default_mock);
+    app.add_singleton_model(CloudModel::mock);
+    app.add_singleton_model(TeamTesterStatus::mock);
+    app.add_singleton_model(SyncQueue::mock);
+    app.add_singleton_model(UpdateManager::mock);
+    app.add_singleton_model(|_| TemplatableMCPServerManager::default());
+    app.add_singleton_model(|ctx| {
+        AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+    });
+    app.add_singleton_model(LLMPreferences::new);
+}
+
+/// Builds a bare `LLMInfo` choice for CLI agent fallback tests.
+fn cli_llm(id: &str, disable_reason: Option<DisableReason>) -> LLMInfo {
+    LLMInfo {
+        display_name: id.to_string(),
+        base_model_name: id.to_string(),
+        id: id.into(),
+        reasoning_level: None,
+        usage_metadata: LLMUsageMetadata {
+            request_multiplier: 1,
+            credit_multiplier: None,
+        },
+        description: None,
+        disable_reason,
+        vision_supported: false,
+        spec: None,
+        provider: LLMProvider::Unknown,
+        host_configs: HashMap::new(),
+        discount_percentage: None,
+        context_window: LLMContextWindow::default(),
+    }
+}
+
+fn models_with_cli_agent(default_id: &str, choices: Vec<LLMInfo>) -> ModelsByFeature {
+    ModelsByFeature {
+        cli_agent: Some(AvailableLLMs {
+            default_id: default_id.into(),
+            choices,
+            preferred_codex_model_id: None,
+        }),
+        ..ModelsByFeature::default()
+    }
+}
+
+#[test]
+fn cli_agent_usable_stored_preference_wins() {
+    App::test((), |mut app| async move {
+        setup_llm_preferences_test(&mut app);
+
+        let models = models_with_cli_agent(
+            "cli-agent-auto",
+            vec![cli_llm("cli-agent-auto", None), cli_llm("gpt-x", None)],
+        );
+        LLMPreferences::handle(&app).update(&mut app, |prefs, ctx| {
+            prefs.update_feature_model_choices(Ok(models), ctx);
+        });
+        let profiles = AIExecutionProfilesModel::handle(&app);
+        let profile_id = profiles.read(&app, |profiles, _| profiles.default_profile_id());
+        profiles.update(&mut app, |profiles, ctx| {
+            profiles.set_cli_agent_model(profile_id, Some("gpt-x".into()), ctx);
+        });
+
+        LLMPreferences::handle(&app).read(&app, |prefs, ctx| {
+            assert_eq!(
+                prefs.get_active_cli_agent_model(ctx, None).id.as_str(),
+                "gpt-x"
+            );
+        });
+    });
+}
+
+#[test]
+fn cli_agent_disabled_stored_preference_is_skipped() {
+    App::test((), |mut app| async move {
+        setup_llm_preferences_test(&mut app);
+
+        let models = models_with_cli_agent(
+            "live-model",
+            vec![
+                cli_llm("dead-model", Some(DisableReason::AdminDisabled)),
+                cli_llm("live-model", None),
+            ],
+        );
+        LLMPreferences::handle(&app).update(&mut app, |prefs, ctx| {
+            prefs.update_feature_model_choices(Ok(models), ctx);
+        });
+        // Set the stale preference after the server update so it is exercised at
+        // read time rather than being cleared by reconciliation.
+        let profiles = AIExecutionProfilesModel::handle(&app);
+        let profile_id = profiles.read(&app, |profiles, _| profiles.default_profile_id());
+        profiles.update(&mut app, |profiles, ctx| {
+            profiles.set_cli_agent_model(profile_id, Some("dead-model".into()), ctx);
+        });
+
+        LLMPreferences::handle(&app).read(&app, |prefs, ctx| {
+            assert_eq!(
+                prefs.get_active_cli_agent_model(ctx, None).id.as_str(),
+                "live-model"
+            );
+        });
+    });
+}
+
+#[test]
+fn cli_agent_default_falls_back_to_first_usable_choice_when_disabled() {
+    App::test((), |mut app| async move {
+        setup_llm_preferences_test(&mut app);
+
+        let models = models_with_cli_agent(
+            "cli-agent-auto",
+            vec![
+                cli_llm("cli-agent-auto", Some(DisableReason::AdminDisabled)),
+                cli_llm("team-endpoint-config-key", None),
+            ],
+        );
+        LLMPreferences::handle(&app).update(&mut app, |prefs, ctx| {
+            prefs.update_feature_model_choices(Ok(models), ctx);
+        });
+
+        LLMPreferences::handle(&app).read(&app, |prefs, ctx| {
+            assert_eq!(
+                prefs.get_active_cli_agent_model(ctx, None).id.as_str(),
+                "team-endpoint-config-key"
+            );
+        });
+    });
+}
+
+#[test]
+fn cli_agent_falls_back_to_custom_endpoint_base_when_all_choices_disabled() {
+    App::test((), |mut app| async move {
+        setup_llm_preferences_test(&mut app);
+
+        let models = models_with_cli_agent(
+            "cli-agent-auto",
+            vec![cli_llm(
+                "cli-agent-auto",
+                Some(DisableReason::AdminDisabled),
+            )],
+        );
+        LLMPreferences::handle(&app).update(&mut app, |prefs, ctx| {
+            prefs.update_feature_model_choices(Ok(models), ctx);
+        });
+
+        // The user's base selection is one of their custom endpoint models.
+        let custom_model_id = LLMId::from("custom-endpoint-config-key");
+        ApiKeyManager::handle(&app).update(&mut app, |api_key_manager, ctx| {
+            api_key_manager.add_custom_endpoint(
+                "local".to_string(),
+                "https://example.com/v1".to_string(),
+                "test-key".to_string(),
+                vec![(
+                    "custom-model".to_string(),
+                    None,
+                    Some(custom_model_id.to_string()),
+                )],
+                ctx,
+            );
+        });
+        let profiles = AIExecutionProfilesModel::handle(&app);
+        let profile_id = profiles.read(&app, |profiles, _| profiles.default_profile_id());
+        profiles.update(&mut app, |profiles, ctx| {
+            profiles.set_base_model(profile_id, Some(custom_model_id.clone()), ctx);
+        });
+
+        LLMPreferences::handle(&app).read(&app, |prefs, ctx| {
+            assert_eq!(
+                prefs.get_active_cli_agent_model(ctx, None).id,
+                custom_model_id
+            );
+        });
+    });
+}
+
+#[test]
+fn cli_agent_keeps_raw_default_when_nothing_usable() {
+    App::test((), |mut app| async move {
+        setup_llm_preferences_test(&mut app);
+
+        let models = models_with_cli_agent(
+            "cli-agent-auto",
+            vec![cli_llm(
+                "cli-agent-auto",
+                Some(DisableReason::AdminDisabled),
+            )],
+        );
+        LLMPreferences::handle(&app).update(&mut app, |prefs, ctx| {
+            prefs.update_feature_model_choices(Ok(models), ctx);
+        });
+
+        // No usable choice and no custom endpoint base: legacy behavior returns
+        // the raw default so the request shape is unchanged.
+        LLMPreferences::handle(&app).read(&app, |prefs, ctx| {
+            assert_eq!(
+                prefs.get_active_cli_agent_model(ctx, None).id.as_str(),
+                "cli-agent-auto"
+            );
+        });
+    });
+}


### PR DESCRIPTION
## Description

**What:** When the selected full-terminal-use (CLI agent) model is effectively disabled, the client now degrades gracefully instead of sending a model the server will reject. `get_active_cli_agent_model` resolves in order: stored preference (only if usable, or a custom endpoint) → server default (only if usable) → first usable choice in the CLI agent bucket → the base model when it is one of the user's custom endpoints → the raw default (unchanged legacy shape when nothing is usable).

**Why:** With Direct API admin-disabled and no cloud host, every hosted CLI agent choice — including the `cli-agent-auto` default — carries `DisableReason::AdminDisabled`. The client still sent the raw default, so every agent request failed server-side with `invalid request: the requested cli agent model (cli-agent-auto) is not allowed for your account`, even when the user's *base* model was a perfectly valid custom endpoint. This also breaks Oz agent runs with custom models, since the headless client pins the same default. The existing `reconcile_disabled_model_preferences` pass already clears disabled *stored preferences*; this closes the remaining hole in the *fallback* path.

**How:** Extracted `LLMInfo::is_usable` (the BYOK-aware disable check already used by `usable_info_for_id`), added `AvailableLLMs::usable_default_llm_info` (default-if-usable else first usable), and reworked `get_active_cli_agent_model` to use them plus a base-model-custom-endpoint fallback — mirroring the server's own "empty CLI agent model falls back to the base model" behavior (`model_config.go`). Custom endpoints are valid CLI agent models server-side (resolved via `custom_model_providers`, validation skips custom choices).

Companion server PR: warp-server#12336 surfaces *team-managed* BYO endpoint models as CLI agent choices; with both changes, step 3 picks those up too when everything hosted is disabled.

## Linked Issue

N/A — follow-up to the team BYOK/BYOE rollout testing (server chain: warp-server#12171/#12172/#12185/#12226/#12336).

## Testing

- 5 new unit tests in `llms_tests.rs`: usable stored preference wins; disabled stored preference skipped at read time; disabled default falls back to first usable choice; all-choices-disabled falls back to the custom-endpoint base; nothing-usable keeps the raw default (legacy shape).
- `cargo nextest run -p warp -E 'test(cli_agent_)'`: 177 passed (5 new + pre-existing cli-agent suite).
- `./script/format` clean; presubmit clippy (workspace + `warp_completer` legs) clean.
- Manual repro pending (draft): admin disables Direct API, base model = custom/team endpoint → agent request should now carry a usable CLI agent model instead of 400ing.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed agent requests failing with "the requested CLI agent model is not allowed for your account" when an admin disables Direct API and the user relies on a custom inference endpoint.

Co-Authored-By: Oz <oz-agent@warp.dev>
