### PR TITLE
[Stable CP] Fix client-side fallback when selected models are disabled (#13331)

### DIFF
--- a/app/src/ai/execution_profiles/editor/mod.rs
+++ b/app/src/ai/execution_profiles/editor/mod.rs
@@ -755,7 +755,7 @@ impl ExecutionProfileEditorView {
                         current_permissions.base_model.clone(),
                         |prefs, app| prefs.get_base_llm_choices_for_agent_mode(app).collect_vec(),
                         |id| ExecutionProfileEditorViewAction::SetBaseModel { id },
-                        |prefs| prefs.get_default_base_model().id.clone(),
+                        |prefs, app| prefs.get_default_base_model(app).id.clone(),
                         &me.upgrade_footer_mouse_state,
                         ctx,
                     );
@@ -769,7 +769,7 @@ impl ExecutionProfileEditorView {
                         current_permissions.cli_agent_model.clone(),
                         |prefs, app| prefs.get_cli_agent_llm_choices(app).collect_vec(),
                         |id| ExecutionProfileEditorViewAction::SetFullTerminalUseModel { id },
-                        |prefs| prefs.get_default_cli_agent_model().id.clone(),
+                        |prefs, app| prefs.get_default_cli_agent_model(app).id.clone(),
                         &me.upgrade_footer_mouse_state,
                         ctx,
                     );
@@ -778,7 +778,7 @@ impl ExecutionProfileEditorView {
                         current_permissions.computer_use_model.clone(),
                         |prefs, _| prefs.get_computer_use_llm_choices().collect_vec(),
                         |id| ExecutionProfileEditorViewAction::SetComputerUseModel { id },
-                        |prefs| prefs.get_default_computer_use_model().id.clone(),
+                        |prefs, app| prefs.get_default_computer_use_model(app).id.clone(),
                         &me.upgrade_footer_mouse_state,
                         ctx,
                     );
@@ -790,7 +790,7 @@ impl ExecutionProfileEditorView {
                         current_permissions.base_model.clone(),
                         |prefs, app| prefs.get_base_llm_choices_for_agent_mode(app).collect_vec(),
                         |id| ExecutionProfileEditorViewAction::SetBaseModel { id },
-                        |prefs| prefs.get_default_base_model().id.clone(),
+                        |prefs, app| prefs.get_default_base_model(app).id.clone(),
                         &me.upgrade_footer_mouse_state,
                         ctx,
                     );
@@ -818,7 +818,7 @@ impl ExecutionProfileEditorView {
                     current_permissions.base_model.clone(),
                     |prefs, app| prefs.get_base_llm_choices_for_agent_mode(app).collect_vec(),
                     |id| ExecutionProfileEditorViewAction::SetBaseModel { id },
-                    |prefs| prefs.get_default_base_model().id.clone(),
+                    |prefs, app| prefs.get_default_base_model(app).id.clone(),
                     &me.upgrade_footer_mouse_state,
                     ctx,
                 );
@@ -934,7 +934,7 @@ impl ExecutionProfileEditorView {
             current_permissions.base_model.clone(),
             |prefs, app| prefs.get_base_llm_choices_for_agent_mode(app).collect_vec(),
             |id| ExecutionProfileEditorViewAction::SetBaseModel { id },
-            |prefs| prefs.get_default_base_model().id.clone(),
+            |prefs, app| prefs.get_default_base_model(app).id.clone(),
             &self.upgrade_footer_mouse_state,
             ctx,
         );
@@ -948,7 +948,7 @@ impl ExecutionProfileEditorView {
             current_permissions.cli_agent_model.clone(),
             |prefs, app| prefs.get_cli_agent_llm_choices(app).collect_vec(),
             |id| ExecutionProfileEditorViewAction::SetFullTerminalUseModel { id },
-            |prefs| prefs.get_default_cli_agent_model().id.clone(),
+            |prefs, app| prefs.get_default_cli_agent_model(app).id.clone(),
             &self.upgrade_footer_mouse_state,
             ctx,
         );
@@ -957,7 +957,7 @@ impl ExecutionProfileEditorView {
             current_permissions.computer_use_model.clone(),
             |prefs, _| prefs.get_computer_use_llm_choices().collect_vec(),
             |id| ExecutionProfileEditorViewAction::SetComputerUseModel { id },
-            |prefs| prefs.get_default_computer_use_model().id.clone(),
+            |prefs, app| prefs.get_default_computer_use_model(app).id.clone(),
             &self.upgrade_footer_mouse_state,
             ctx,
         );
@@ -1166,7 +1166,7 @@ impl ExecutionProfileEditorView {
     ) where
         G: for<'a> FnOnce(&'a LLMPreferences, &AppContext) -> Vec<&'a LLMInfo>,
         A: Fn(LLMId) -> ExecutionProfileEditorViewAction,
-        D: FnOnce(&LLMPreferences) -> LLMId,
+        D: FnOnce(&LLMPreferences, &AppContext) -> LLMId,
     {
         menu.update(ctx, |dropdown, ctx| {
             let disabled_by_ai_toggle = !AISettings::as_ref(ctx).is_any_ai_enabled(ctx);
@@ -1208,7 +1208,7 @@ impl ExecutionProfileEditorView {
 
             let llm_prefs = LLMPreferences::handle(ctx);
             let llm_prefs = llm_prefs.as_ref(ctx);
-            let model_to_select = profile_model.unwrap_or_else(|| get_default_id(llm_prefs));
+            let model_to_select = profile_model.unwrap_or_else(|| get_default_id(llm_prefs, ctx));
             dropdown.set_selected_by_action(create_action(model_to_select), ctx);
             ctx.notify();
         });
@@ -1250,7 +1250,7 @@ impl ExecutionProfileEditorView {
 
             let model_to_select = profile_coding_model.unwrap_or_else(|| {
                 LLMPreferences::as_ref(ctx)
-                    .get_default_coding_model()
+                    .get_default_coding_model(ctx)
                     .id
                     .clone()
             });
@@ -1484,7 +1484,7 @@ fn initial_context_window_display_value(
         .context_window_display_value(app)
         .unwrap_or_else(|| {
             LLMPreferences::as_ref(app)
-                .get_default_base_model()
+                .get_default_base_model(app)
                 .context_window
                 .default_max
         })

--- a/app/src/ai/execution_profiles/mod.rs
+++ b/app/src/ai/execution_profiles/mod.rs
@@ -106,7 +106,7 @@ impl AIExecutionProfileAppExt for AIExecutionProfile {
             .as_ref()
             .and_then(|id| prefs.get_llm_info(id))
             .map(|info| info.context_window.clone())
-            .unwrap_or_else(|| prefs.get_default_base_model().context_window.clone());
+            .unwrap_or_else(|| prefs.get_default_base_model(app).context_window.clone());
         if cw.is_configurable && cw.max > 0 {
             Some(cw)
         } else {

--- a/app/src/ai/execution_profiles/profiles.rs
+++ b/app/src/ai/execution_profiles/profiles.rs
@@ -634,7 +634,7 @@ impl AIExecutionProfilesModel {
                 .base_model
                 .as_ref()
                 .and_then(|id| llm_preferences.get_llm_info(id))
-                .unwrap_or_else(|| llm_preferences.get_default_base_model());
+                .unwrap_or_else(|| llm_preferences.get_default_base_model(ctx));
             send_telemetry_from_ctx!(
                 TelemetryEvent::AIExecutionProfileContextWindowSelected {
                     tokens: limit,

--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -95,6 +95,16 @@ impl DisableReason {
     }
 }
 
+/// Returns `true` when the model is usable for the current user: not disabled,
+/// or disabled for a reason that doesn't block requests (see
+/// [`DisableReason::should_clear_preference`]).
+fn is_usable_llm(info: &LLMInfo, app: &AppContext) -> bool {
+    let has_byok_key = is_using_api_key_for_provider(&info.provider, app);
+    info.disable_reason
+        .as_ref()
+        .is_none_or(|reason| !reason.should_clear_preference(has_byok_key))
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct LLMSpec {
     pub cost: f32,
@@ -376,12 +386,15 @@ impl AvailableLLMs {
     /// Returns the info for the given id only if the model is usable (present
     /// and not effectively disabled for the current user).
     fn usable_info_for_id(&self, id: &LLMId, app: &AppContext) -> Option<&LLMInfo> {
-        self.info_for_id(id).filter(|info| {
-            let has_byok_key = is_using_api_key_for_provider(&info.provider, app);
-            info.disable_reason
-                .as_ref()
-                .is_none_or(|reason| !reason.should_clear_preference(has_byok_key))
-        })
+        self.info_for_id(id).filter(|info| is_usable_llm(info, app))
+    }
+
+    /// Disable-aware default: the server default when usable, otherwise the
+    /// first usable choice. `None` when no server-provided choice is usable
+    /// (e.g. an admin disabled every hosted model).
+    fn usable_default_llm_info(&self, app: &AppContext) -> Option<&LLMInfo> {
+        self.usable_info_for_id(&self.default_id, app)
+            .or_else(|| self.choices.iter().find(|info| is_usable_llm(info, app)))
     }
 
     fn default_llm_info(&self) -> &LLMInfo {
@@ -669,7 +682,22 @@ impl LLMPreferences {
                     .info_for_id(&id)
                     .or_else(|| self.custom_llm_info_for_id_if_enabled(&id, app))
             })
-            .unwrap_or_else(|| self.models_by_feature.agent_mode.default_llm_info())
+            .unwrap_or_else(|| self.fallback_llm_info(&self.models_by_feature.agent_mode, app))
+    }
+
+    /// Disable-aware fallback for when the user has no explicit (usable)
+    /// selection: the feature default when usable, else the first usable
+    /// server choice, else the user's first custom-endpoint model, else the
+    /// (possibly disabled) server default as a last resort.
+    fn fallback_llm_info<'a>(
+        &'a self,
+        available: &'a AvailableLLMs,
+        app: &AppContext,
+    ) -> &'a LLMInfo {
+        available
+            .usable_default_llm_info(app)
+            .or_else(|| self.custom_llm_choices(app).next())
+            .unwrap_or_else(|| available.default_llm_info())
     }
 
     pub fn get_active_coding_model<'a>(
@@ -698,7 +726,7 @@ impl LLMPreferences {
                     .info_for_id(&id)
                     .or_else(|| self.custom_llm_info_for_id_if_enabled(&id, app))
             })
-            .unwrap_or_else(|| self.models_by_feature.coding.default_llm_info())
+            .unwrap_or_else(|| self.fallback_llm_info(&self.models_by_feature.coding, app))
     }
 
     /// Returns the set of LLMs available for Agent Mode use.
@@ -728,9 +756,11 @@ impl LLMPreferences {
 
     /// Returns the set of LLMs available for CLI agent.
     pub fn get_cli_agent_llm_choices(&self, app: &AppContext) -> impl Iterator<Item = &LLMInfo> {
+        // Don't show admin-disabled models in the dropdown
         self.get_cli_agent_available()
             .choices
             .iter()
+            .filter(|llm| !matches!(llm.disable_reason, Some(DisableReason::AdminDisabled)))
             .chain(self.custom_llm_choices(app))
     }
 
@@ -752,12 +782,13 @@ impl LLMPreferences {
                     .info_for_id(&id)
                     .or_else(|| self.custom_llm_info_for_id_if_enabled(&id, app))
             })
-            .unwrap_or_else(|| available.default_llm_info())
+            .unwrap_or_else(|| self.fallback_llm_info(available, app))
     }
 
-    /// Returns the default CLI agent model as a fallback.
-    pub fn get_default_cli_agent_model(&self) -> &LLMInfo {
-        self.get_cli_agent_available().default_llm_info()
+    /// Returns the effective default CLI agent model as a fallback
+    /// (disable-aware, see [`Self::fallback_llm_info`]).
+    pub fn get_default_cli_agent_model(&self, app: &AppContext) -> &LLMInfo {
+        self.fallback_llm_info(self.get_cli_agent_available(), app)
     }
 
     /// Helper to get the AvailableLLMs for cli_agent, falling back to agent_mode.
@@ -787,12 +818,18 @@ impl LLMPreferences {
             .computer_use_model
             .clone()
             .and_then(|id| available.info_for_id(&id))
-            .unwrap_or_else(|| available.default_llm_info())
+            .unwrap_or_else(|| self.get_default_computer_use_model(app))
     }
 
-    /// Returns the default computer use model as a fallback.
-    pub fn get_default_computer_use_model(&self) -> &LLMInfo {
-        self.get_computer_use_available().default_llm_info()
+    /// Returns the effective default computer use model as a fallback: the
+    /// server default when usable, else the first usable choice, else the
+    /// (possibly disabled) server default. No custom-endpoint fallback here:
+    /// custom models aren't offered for computer use.
+    pub fn get_default_computer_use_model(&self, app: &AppContext) -> &LLMInfo {
+        let available = self.get_computer_use_available();
+        available
+            .usable_default_llm_info(app)
+            .unwrap_or_else(|| available.default_llm_info())
     }
 
     /// Helper to get the AvailableLLMs for computer_use.
@@ -934,14 +971,16 @@ impl LLMPreferences {
         }
     }
 
-    /// Returns the default base model as a fallback.
-    pub fn get_default_base_model(&self) -> &LLMInfo {
-        self.models_by_feature.agent_mode.default_llm_info()
+    /// Returns the effective default base model as a fallback
+    /// (disable-aware, see [`Self::fallback_llm_info`]).
+    pub fn get_default_base_model(&self, app: &AppContext) -> &LLMInfo {
+        self.fallback_llm_info(&self.models_by_feature.agent_mode, app)
     }
 
-    /// Returns the default coding model as a fallback.
-    pub fn get_default_coding_model(&self) -> &LLMInfo {
-        self.models_by_feature.coding.default_llm_info()
+    /// Returns the effective default coding model as a fallback
+    /// (disable-aware, see [`Self::fallback_llm_info`]).
+    pub fn get_default_coding_model(&self, app: &AppContext) -> &LLMInfo {
+        self.fallback_llm_info(&self.models_by_feature.coding, app)
     }
 
     /// Returns the preferred Codex model, if set by the server.

--- a/app/src/ai/llms_tests.rs
+++ b/app/src/ai/llms_tests.rs
@@ -359,6 +359,173 @@ fn removing_endpoint_purges_all_its_models_from_custom_llms() {
     assert_eq!(infos[0].id.as_str(), "uuid-k1");
 }
 
+// -- Disable-aware default fallback tests --
+
+fn server_llm(id: &str, disable_reason: Option<DisableReason>) -> LLMInfo {
+    LLMInfo {
+        display_name: id.to_string(),
+        base_model_name: id.to_string(),
+        id: id.into(),
+        reasoning_level: None,
+        usage_metadata: LLMUsageMetadata {
+            request_multiplier: 1,
+            credit_multiplier: None,
+        },
+        description: None,
+        disable_reason,
+        vision_supported: false,
+        spec: None,
+        provider: LLMProvider::Unknown,
+        host_configs: HashMap::new(),
+        discount_percentage: None,
+        context_window: LLMContextWindow::default(),
+    }
+}
+
+fn available(default_id: &str, choices: Vec<LLMInfo>) -> AvailableLLMs {
+    AvailableLLMs {
+        default_id: default_id.into(),
+        choices,
+        preferred_codex_model_id: None,
+    }
+}
+
+#[test]
+fn active_models_fall_back_to_usable_choice_or_custom_endpoint_when_default_disabled() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+        app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+        app.add_singleton_model(AuthManager::new_for_test);
+        app.add_singleton_model(|_| NetworkStatus::new());
+        app.add_singleton_model(UserWorkspaces::default_mock);
+        app.add_singleton_model(CloudModel::mock);
+        app.add_singleton_model(TeamTesterStatus::mock);
+        app.add_singleton_model(SyncQueue::mock);
+        app.add_singleton_model(UpdateManager::mock);
+        app.add_singleton_model(|_| TemplatableMCPServerManager::default());
+
+        app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        let llm_preferences = app.add_singleton_model(LLMPreferences::new);
+
+        let custom_model_id = LLMId::from("custom-config-key");
+        ApiKeyManager::handle(&app).update(&mut app, |api_key_manager, ctx| {
+            api_key_manager.add_custom_endpoint(
+                "local".to_string(),
+                "https://example.com/v1".to_string(),
+                "test-key".to_string(),
+                vec![(
+                    "custom-model".to_string(),
+                    None,
+                    Some(custom_model_id.to_string()),
+                )],
+                ctx,
+            );
+        });
+
+        // The base/coding default is admin-disabled but another hosted choice
+        // is usable; every hosted CLI agent choice is admin-disabled.
+        let models = ModelsByFeature {
+            agent_mode: available(
+                "auto",
+                vec![
+                    server_llm("auto", Some(DisableReason::AdminDisabled)),
+                    server_llm("gpt-x", None),
+                ],
+            ),
+            coding: available(
+                "auto",
+                vec![
+                    server_llm("auto", Some(DisableReason::AdminDisabled)),
+                    server_llm("gpt-x", None),
+                ],
+            ),
+            cli_agent: Some(available(
+                "cli-agent-auto",
+                vec![server_llm(
+                    "cli-agent-auto",
+                    Some(DisableReason::AdminDisabled),
+                )],
+            )),
+            computer_use: None,
+        };
+        llm_preferences.update(&mut app, |preferences, ctx| {
+            preferences.update_feature_model_choices(Ok(models), ctx);
+        });
+
+        llm_preferences.read(&app, |preferences, app| {
+            // Falls back to the first usable hosted choice.
+            assert_eq!(
+                preferences.get_active_base_model(app, None).id.as_str(),
+                "gpt-x"
+            );
+            assert_eq!(
+                preferences.get_active_coding_model(app, None).id.as_str(),
+                "gpt-x"
+            );
+            // No usable hosted CLI choice → falls back to the custom endpoint.
+            assert_eq!(
+                preferences.get_active_cli_agent_model(app, None).id,
+                custom_model_id
+            );
+        });
+    });
+}
+
+#[test]
+fn active_models_use_default_when_usable() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+        app.add_singleton_model(|_| ServerApiProvider::new_for_test());
+        app.add_singleton_model(|_| AuthStateProvider::new_for_test());
+        app.add_singleton_model(AuthManager::new_for_test);
+        app.add_singleton_model(|_| NetworkStatus::new());
+        app.add_singleton_model(UserWorkspaces::default_mock);
+        app.add_singleton_model(CloudModel::mock);
+        app.add_singleton_model(TeamTesterStatus::mock);
+        app.add_singleton_model(SyncQueue::mock);
+        app.add_singleton_model(UpdateManager::mock);
+        app.add_singleton_model(|_| TemplatableMCPServerManager::default());
+
+        app.add_singleton_model(|ctx| {
+            AIExecutionProfilesModel::new(&LaunchMode::new_for_unit_test(), ctx)
+        });
+        let llm_preferences = app.add_singleton_model(LLMPreferences::new);
+
+        let models = ModelsByFeature {
+            agent_mode: available(
+                "auto",
+                vec![server_llm("auto", None), server_llm("gpt-x", None)],
+            ),
+            coding: available("auto", vec![server_llm("auto", None)]),
+            cli_agent: Some(available(
+                "cli-agent-auto",
+                vec![server_llm("cli-agent-auto", None)],
+            )),
+            computer_use: None,
+        };
+        llm_preferences.update(&mut app, |preferences, ctx| {
+            preferences.update_feature_model_choices(Ok(models), ctx);
+        });
+
+        llm_preferences.read(&app, |preferences, app| {
+            assert_eq!(
+                preferences.get_active_base_model(app, None).id.as_str(),
+                "auto"
+            );
+            assert_eq!(
+                preferences
+                    .get_active_cli_agent_model(app, None)
+                    .id
+                    .as_str(),
+                "cli-agent-auto"
+            );
+        });
+    });
+}
+
 #[test]
 fn reconcile_preserves_custom_models_saved_on_execution_profile() {
     App::test((), |mut app| async move {

--- a/app/src/ai/onboarding.rs
+++ b/app/src/ai/onboarding.rs
@@ -26,7 +26,7 @@ pub fn build_onboarding_models(
     prefs: &LLMPreferences,
     app: &AppContext,
 ) -> (Vec<OnboardingModelInfo>, LLMId) {
-    let default_id = prefs.get_default_base_model().id.clone();
+    let default_id = prefs.get_default_base_model(app).id.clone();
     let models: Vec<OnboardingModelInfo> = prefs
         .get_base_llm_choices_for_agent_mode(app)
         .map(|llm| {

--- a/app/src/settings_view/execution_profile_view.rs
+++ b/app/src/settings_view/execution_profile_view.rs
@@ -107,7 +107,7 @@ impl View for ExecutionProfileView {
             .map(|info| info.display_name.clone())
             .unwrap_or_else(|| {
                 llm_preferences
-                    .get_default_base_model()
+                    .get_default_base_model(app)
                     .display_name
                     .clone()
             });
@@ -117,14 +117,24 @@ impl View for ExecutionProfileView {
             .as_ref()
             .and_then(|id| llm_preferences.get_llm_info(id))
             .map(|info| info.display_name.clone())
-            .unwrap_or_else(|| "Auto".to_string());
+            .unwrap_or_else(|| {
+                llm_preferences
+                    .get_default_cli_agent_model(app)
+                    .display_name
+                    .clone()
+            });
 
         let computer_use_model = profile
             .computer_use_model
             .as_ref()
             .and_then(|id| llm_preferences.get_llm_info(id))
             .map(|info| info.display_name.clone())
-            .unwrap_or_else(|| "Auto".to_string());
+            .unwrap_or_else(|| {
+                llm_preferences
+                    .get_default_computer_use_model(app)
+                    .display_name
+                    .clone()
+            });
 
         Container::new(
             Flex::column()

--- a/app/src/terminal/profile_model_selector.rs
+++ b/app/src/terminal/profile_model_selector.rs
@@ -969,7 +969,7 @@ impl ProfileModelSelector {
                     .get_llm_info(&id)
                     .map(|info| info.id.clone())
             })
-            .unwrap_or_else(|| llm_preferences.get_default_base_model().id.clone());
+            .unwrap_or_else(|| llm_preferences.get_default_base_model(ctx).id.clone());
 
         let model_id_to_add_profile_default_label_to = Some(&profile_base_model_id);
 


### PR DESCRIPTION
When a team admin disables all hosted models (e.g. direct API access is turned off), the client kept falling back to the server-provided *default* model even when that default was admin-disabled. Most visibly, users with no explicit CLI agent selection sat on `cli-agent-auto`, which the server now marks admin-disabled when no model in its fallback chain is available — so every request failed with:

```
Invalid request: the requested CLI agent model (cli-agent-auto) is not allowed for your account
```

This PR makes the no-explicit-selection fallback disable-aware:
- New `LLMPreferences::fallback_llm_info`: usable server default → first usable server choice → first custom-endpoint (team) model → raw server default as a last resort. Used by the active base, coding, and CLI agent model getters (computer use uses the same logic minus the custom-endpoint step, since custom models aren't offered there).
- The `get_default_*` getters now return the same effective default, so the profile editor dropdowns, settings profile card, context-window logic/telemetry, onboarding default, and the "(default)" model-menu label all match what requests actually send.
- The CLI agent model picker now hides admin-disabled models, matching the base/coding pickers.

N/A — fixes a regression surfaced by warpdotdev/warp-server#11498 (disabling auto models when their fallback chain has no available model).

- New unit tests in `llms_tests.rs`: base/coding fall back to the first usable hosted choice when the default is admin-disabled; CLI agent falls back to a custom endpoint when no hosted choice is usable; defaults are unchanged when usable.
- `cargo nextest run -p warp` for the llms, execution_profiles, and onboarding suites — all pass.
- [x] I have manually tested my changes locally with `./script/run` (with direct API disabled and a team custom model configured, requests now succeed with the CLI agent routed to the custom endpoint)

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation](https://staging.warp.dev/conversation/0367d782-add6-481f-829d-d7e71ded8ce9)

## Justification
Why do we need this cherry-pick? Does it align with our [guidelines](https://www.notion.so/warpdev/How-We-Work-Releases-8e7d7cb4f2ca44b880fa1d0ae4876473?pvs=4)?

## Testing
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

## Validation
- [ ] I've cut a new WarpDev to validate this change
- [ ] If this change is Wednesday or later, there's a dedicated bug bash scheduled for either this change or the release

