### PR TITLE
fix(build): fall back to Cargo PROFILE env var when CARGO_FULL_PROFILE is unset

### DIFF
--- a/app/build.rs
+++ b/app/build.rs
@@ -117,17 +117,16 @@ fn main() -> Result<()> {
         // Retrieve the Cargo profile name so that we can put a copy of ConPTY in
         // the correct target subdirectory.
         //
-        // We need to pass this information manually through an environment variable.
-        // Of the built-in variables set by Cargo: `OUT_DIR` is only a temporary
-        // directory, and `PROFILE` can only be `debug` or `release`.
-        // See https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
-        // for more on Cargo environment variables.
+        // `CARGO_FULL_PROFILE` is set by bundle scripts for custom profiles (e.g.
+        // release-lto). Fall back to Cargo's built-in `PROFILE` ("debug"/"release")
+        // for direct `cargo build` invocations. See also:
+        // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
         //
         // Ideally we could access `CARGO_TARGET_DIR` but this doesn't exist at build time.
         // See https://github.com/rust-lang/cargo/issues/9661.
-        //
-        // Cargo defaults to the `debug` profile.
-        let cargo_full_profile = env::var("CARGO_FULL_PROFILE").unwrap_or(String::from("debug"));
+        let cargo_full_profile = env::var("CARGO_FULL_PROFILE")
+            .or_else(|_| env::var("PROFILE"))
+            .unwrap_or_else(|_| String::from("debug"));
         let target_dir =
             app_target_dir(&cargo_full_profile).expect("Could not get app target directory");
         copy_windows_assets(&target_dir);


### PR DESCRIPTION
## Summary

Fixes #11315

When running `cargo build --release` directly on Windows (without Warp's bundle scripts), the build script at `app/build.rs:130` defaulted `CARGO_FULL_PROFILE` to `"debug"`, causing `copy_windows_assets` to panic because `target/debug/` doesn't exist for release-only builds.

## Root Cause

`CARGO_FULL_PROFILE` is a custom env var set by `script/windows/bundle.ps1` to support custom profiles (e.g. `release-lto`). When contributors run `cargo build --release` directly, this var is unset and the build script fell back to a hardcoded `"debug"` instead of using Cargo's built-in `PROFILE` environment variable (which Cargo always sets to `"debug"` or `"release"` for build scripts).

## Fix

Chain `env::var("CARGO_FULL_PROFILE")` with `.or_else(|_| env::var("PROFILE"))` before the ultimate `"debug"` default. This:
- Preserves custom profile support for bundle scripts
- Correctly resolves to `"release"` for direct `cargo build --release` invocations
- Correctly resolves to `"debug"` for `cargo build`/`cargo run` (matching the previous default)