### PR TITLE
Add tabbed terminals within a pane

### DIFF
--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -314,6 +314,10 @@ pub enum PaneGroupAction {
     ToggleMaximizePane,
     HandleFocusChange,
     FocusTerminalView(EntityId),
+    NewTabInPane,
+    NextPaneTab,
+    PrevPaneTab,
+    ClosePaneTab,
 }
 #[derive(PartialEq)]
 enum PaneRemovalReason {
@@ -482,6 +486,38 @@ pub fn init(app: &mut AppContext) {
         )
         .with_context_predicate(id!("PaneGroup") & !id!("PaneGroup_PaneDragging"))
         .with_custom_action(CustomAction::ToggleMaximizePane),
+    ]);
+
+    app.register_editable_bindings([
+        EditableBinding::new(
+            "pane_group:new_tab_in_pane",
+            "New tab in pane",
+            PaneGroupAction::NewTabInPane,
+        )
+        .with_context_predicate(id!("PaneGroup") & !id!("PaneGroup_PaneDragging"))
+        .with_enabled(|| ContextFlag::CreateNewSession.is_enabled())
+        .with_key_binding("ctrl-shift-T"),
+        EditableBinding::new(
+            "pane_group:next_pane_tab",
+            "Next tab in pane",
+            PaneGroupAction::NextPaneTab,
+        )
+        .with_context_predicate(id!("PaneGroup") & !id!("PaneGroup_PaneDragging"))
+        .with_key_binding("ctrl-shift-L"),
+        EditableBinding::new(
+            "pane_group:prev_pane_tab",
+            "Previous tab in pane",
+            PaneGroupAction::PrevPaneTab,
+        )
+        .with_context_predicate(id!("PaneGroup") & !id!("PaneGroup_PaneDragging"))
+        .with_key_binding("ctrl-shift-H"),
+        EditableBinding::new(
+            "pane_group:close_pane_tab",
+            "Close tab in pane",
+            PaneGroupAction::ClosePaneTab,
+        )
+        .with_context_predicate(id!("PaneGroup") & !id!("PaneGroup_PaneDragging"))
+        .with_key_binding("ctrl-shift-W"),
     ]);
 
     if ChannelState::channel() == Channel::Integration {
@@ -1275,6 +1311,21 @@ impl PaneGroup {
                     self.focus_pane_by_id(pane_id, ctx);
                     ctx.emit(Event::TerminalViewStateChanged);
                     ctx.notify();
+                }
+                PaneViewEvent::NewPaneTabRequested => {
+                    self.add_terminal_tab_in_pane(pane_id, ctx);
+                }
+                PaneViewEvent::SelectPaneTab { index } => {
+                    self.set_active_tab_in_pane(pane_id, *index, ctx);
+                }
+                PaneViewEvent::ClosePaneTab { index } => {
+                    self.close_tab_in_pane(pane_id, *index, ctx);
+                }
+                PaneViewEvent::CloseOtherPaneTabs { index } => {
+                    self.close_other_tabs_in_pane(pane_id, *index, ctx);
+                }
+                PaneViewEvent::ClosePaneTabsToRight { index } => {
+                    self.close_tabs_to_right_in_pane(pane_id, *index, ctx);
                 }
             }
         } else {
@@ -3850,6 +3901,218 @@ impl PaneGroup {
         new_pane_id
     }
 
+    /// Adds a new terminal tab (a nested shell) inside the pane identified by
+    /// `pane_id`, making it the active tab. No-op if the pane is not a terminal
+    /// pane. Unlike [`Self::add_terminal_pane`], this does not split the layout —
+    /// the new shell shares the same pane rectangle and is surfaced via the
+    /// pane's tab strip.
+    pub fn add_terminal_tab_in_pane(&mut self, pane_id: PaneId, ctx: &mut ViewContext<Self>) {
+        let Some(terminal_pane) = self.terminal_session_by_id(pane_id) else {
+            return;
+        };
+        let pane_stack = terminal_pane.pane_stack(ctx);
+
+        // Inherit the shell and (where configured) the working directory of the
+        // pane's current session, matching split-pane behavior.
+        let chosen_shell = self
+            .terminal_view_from_pane_id(pane_id, ctx)
+            .and_then(|view| {
+                let model = view.as_ref(ctx).model.lock();
+                model.shell_launch_state().available_shell()
+            });
+
+        let base_session_id = pane_id.as_terminal_pane_id();
+        let ignore_custom_startup_directory =
+            self.should_ignore_custom_startup_directory(&chosen_shell, ctx);
+        let initial_directory_from_current_session =
+            self.startup_path_for_new_session(base_session_id, ctx);
+        let startup_directory = SessionSettings::handle(ctx).read(ctx, |settings, _ctx| {
+            settings
+                .working_directory_config
+                .initial_directory_for_new_session(
+                    NewSessionSource::SplitPane,
+                    initial_directory_from_current_session,
+                    ignore_custom_startup_directory,
+                )
+        });
+
+        let (view, terminal_manager) =
+            self.create_tab_terminal_session(startup_directory, chosen_shell, ctx);
+
+        pane_stack.update(ctx, |stack, ctx| {
+            stack.add_tab(terminal_manager, view, ctx);
+        });
+
+        self.focus_pane(pane_id, true, ctx);
+        ctx.emit(Event::AppStateChanged);
+    }
+
+    pub fn set_active_tab_in_pane(
+        &mut self,
+        pane_id: PaneId,
+        index: usize,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(terminal_pane) = self.terminal_session_by_id(pane_id) else {
+            return;
+        };
+        let pane_stack = terminal_pane.pane_stack(ctx);
+        pane_stack.update(ctx, |stack, ctx| stack.set_active_index(index, ctx));
+        self.focus_pane(pane_id, true, ctx);
+    }
+
+    /// Cycles the active tab within `pane_id` forward (or backward), wrapping
+    /// around. No-op when the pane has fewer than two tabs.
+    pub fn cycle_tab_in_pane(
+        &mut self,
+        pane_id: PaneId,
+        forward: bool,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(terminal_pane) = self.terminal_session_by_id(pane_id) else {
+            return;
+        };
+        let pane_stack = terminal_pane.pane_stack(ctx);
+        let (tab_count, active) = {
+            let stack = pane_stack.as_ref(ctx);
+            (stack.tab_count(), stack.active_index())
+        };
+        if tab_count <= 1 {
+            return;
+        }
+        // Cycle within the tab region only. If a nav-stack view is on top, treat
+        // the last tab as the current position.
+        let current = active.min(tab_count - 1);
+        let next = if forward {
+            (current + 1) % tab_count
+        } else {
+            (current + tab_count - 1) % tab_count
+        };
+        pane_stack.update(ctx, |stack, ctx| stack.set_active_index(next, ctx));
+        self.focus_pane(pane_id, true, ctx);
+    }
+
+    pub fn close_active_tab_in_pane(&mut self, pane_id: PaneId, ctx: &mut ViewContext<Self>) {
+        let Some(terminal_pane) = self.terminal_session_by_id(pane_id) else {
+            return;
+        };
+        let index = {
+            let stack = terminal_pane.pane_stack(ctx);
+            let stack = stack.as_ref(ctx);
+            if stack.has_nav_entries() {
+                return;
+            }
+            stack.active_index()
+        };
+        self.close_tab_in_pane(pane_id, index, ctx);
+    }
+
+    /// Closes every tab in `pane_id` except the one at `keep_index`.
+    pub fn close_other_tabs_in_pane(
+        &mut self,
+        pane_id: PaneId,
+        keep_index: usize,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(terminal_pane) = self.terminal_session_by_id(pane_id) else {
+            return;
+        };
+        let pane_stack = terminal_pane.pane_stack(ctx);
+        // Remove from the highest tab index down so earlier indices stay valid,
+        // skipping the tab we're keeping.
+        let tab_count = pane_stack.as_ref(ctx).tab_count();
+        for index in (0..tab_count).rev() {
+            if index == keep_index {
+                continue;
+            }
+            pane_stack.update(ctx, |stack, ctx| {
+                stack.remove_at(index, ctx);
+            });
+        }
+        self.focus_pane(pane_id, true, ctx);
+        ctx.emit(Event::AppStateChanged);
+    }
+
+    /// Closes every tab in `pane_id` positioned after `index`.
+    pub fn close_tabs_to_right_in_pane(
+        &mut self,
+        pane_id: PaneId,
+        index: usize,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(terminal_pane) = self.terminal_session_by_id(pane_id) else {
+            return;
+        };
+        let pane_stack = terminal_pane.pane_stack(ctx);
+        let tab_count = pane_stack.as_ref(ctx).tab_count();
+        // Remove from the last tab down to just after `index`.
+        for tab_index in (index + 1..tab_count).rev() {
+            pane_stack.update(ctx, |stack, ctx| {
+                stack.remove_at(tab_index, ctx);
+            });
+        }
+        self.focus_pane(pane_id, true, ctx);
+        ctx.emit(Event::AppStateChanged);
+    }
+
+    /// Closes the tab at `index` within `pane_id`. When it is the pane's last
+    /// remaining tab, the whole pane is closed instead.
+    pub fn close_tab_in_pane(
+        &mut self,
+        pane_id: PaneId,
+        index: usize,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(terminal_pane) = self.terminal_session_by_id(pane_id) else {
+            return;
+        };
+        let pane_stack = terminal_pane.pane_stack(ctx);
+        if pane_stack.as_ref(ctx).tab_count() <= 1 {
+            self.close_pane_with_confirmation(pane_id, ctx);
+            return;
+        }
+        let _removed = pane_stack.update(ctx, |stack, ctx| stack.remove_at(index, ctx));
+        self.focus_pane(pane_id, true, ctx);
+        ctx.emit(Event::AppStateChanged);
+    }
+
+    /// Creates a new terminal session (view + manager) for use as a tab inside
+    /// an existing pane's [`PaneStack`]. Unlike [`Self::create_terminal_pane_data`],
+    /// it does not wrap the session in a new `TerminalPane`/pane-tree leaf.
+    fn create_tab_terminal_session(
+        &self,
+        startup_directory: Option<PathBuf>,
+        chosen_shell: Option<AvailableShell>,
+        ctx: &mut ViewContext<Self>,
+    ) -> (
+        ViewHandle<TerminalView>,
+        ModelHandle<Box<dyn TerminalManager>>,
+    ) {
+        let uuid = Uuid::new_v4();
+        let resources = TerminalViewResources {
+            tips_completed: self.tips_completed.clone(),
+            server_api: self.server_api.clone(),
+            model_event_sender: self.model_event_sender.clone(),
+        };
+        let view_bounds = Self::estimated_view_bounds(ctx);
+        PaneGroup::create_session(
+            startup_directory,
+            HashMap::new(),
+            uuid.as_bytes(),
+            IsSharedSessionCreator::No,
+            resources,
+            None, /* restored_blocks */
+            None, /* conversation_restoration */
+            self.user_default_shell_unsupported_banner_model_handle
+                .clone(),
+            view_bounds.size(),
+            self.model_event_sender.clone(),
+            chosen_shell,
+            None, /* initial_input_config */
+            ctx,
+        )
+    }
+
     /// Adds a terminal split pane without applying the user's default session mode.
     pub fn add_terminal_pane_ignoring_default_session_mode(
         &mut self,
@@ -5737,21 +6000,53 @@ impl PaneGroup {
         }
     }
 
+    /// Close the pane tab containing `terminal_view_id`, or the pane itself when
+    /// the view is not one of the pane's sibling tabs.
+    pub(in crate::pane_group) fn close_terminal_tab_for_view(
+        &mut self,
+        pane_id: PaneId,
+        terminal_view_id: EntityId,
+        confirm_last_tab: bool,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let Some(index) = self.terminal_tab_index_for_view(pane_id, terminal_view_id, ctx) else {
+            if self
+                .terminal_view_by_id_in_pane(pane_id, terminal_view_id, ctx)
+                .is_none()
+            {
+                return;
+            }
+
+            if confirm_last_tab {
+                self.close_pane_with_confirmation(pane_id, ctx);
+            } else {
+                self.close_pane(pane_id, ctx);
+            }
+            return;
+        };
+
+        let tab_count = self
+            .terminal_session_by_id(pane_id)
+            .map(|pane| pane.pane_stack(ctx).as_ref(ctx).tab_count())
+            .unwrap_or(0);
+        if tab_count > 1 {
+            self.close_tab_in_pane(pane_id, index, ctx);
+        } else if confirm_last_tab {
+            self.close_pane_with_confirmation(pane_id, ctx);
+        } else {
+            self.close_pane(pane_id, ctx);
+        }
+    }
+
     /// Focused the specified terminal view, if it belongs to this pane group.
     pub fn focus_terminal_view(&mut self, terminal_view_id: EntityId, ctx: &mut ViewContext<Self>) {
-        let pane_id = self
-            .pane_contents
-            .keys()
-            .find(|id| {
-                if let Some(terminal_view) = self.terminal_view_from_pane_id(**id, ctx) {
-                    terminal_view_id == terminal_view.id()
-                } else {
-                    false
-                }
-            })
-            .cloned();
+        let pane_id_and_tab_index = self.pane_contents.keys().find_map(|id| {
+            self.terminal_tab_index_for_view(*id, terminal_view_id, ctx)
+                .map(|index| (*id, index))
+        });
 
-        if let Some(pane_id) = pane_id {
+        if let Some((pane_id, index)) = pane_id_and_tab_index {
+            self.set_active_tab_in_pane(pane_id, index, ctx);
             self.focus_pane_by_id(pane_id, ctx);
         }
     }
@@ -6848,6 +7143,42 @@ impl PaneGroup {
             .map(|session| session.terminal_view(ctx))
     }
 
+    /// Given a pane ID and terminal view ID, retrieve that terminal view if it
+    /// belongs to the pane's stack.
+    pub(in crate::pane_group) fn terminal_view_by_id_in_pane(
+        &self,
+        pane_id: PaneId,
+        terminal_view_id: EntityId,
+        ctx: &AppContext,
+    ) -> Option<ViewHandle<TerminalView>> {
+        let terminal_pane = self.terminal_session_by_id(pane_id)?;
+        terminal_pane
+            .pane_stack(ctx)
+            .as_ref(ctx)
+            .entries()
+            .iter()
+            .find_map(|(_, view)| (view.id() == terminal_view_id).then(|| view.clone()))
+    }
+
+    /// Given a pane ID and terminal view ID, retrieve the sibling pane-tab index
+    /// for that view. Navigation-stack entries are not pane tabs and do not
+    /// produce an index.
+    fn terminal_tab_index_for_view(
+        &self,
+        pane_id: PaneId,
+        terminal_view_id: EntityId,
+        ctx: &AppContext,
+    ) -> Option<usize> {
+        let terminal_pane = self.terminal_session_by_id(pane_id)?;
+        let pane_stack = terminal_pane.pane_stack(ctx);
+        let stack = pane_stack.as_ref(ctx);
+        stack
+            .entries()
+            .iter()
+            .take(stack.tab_count())
+            .position(|(_, view)| view.id() == terminal_view_id)
+    }
+
     pub fn attach_execution_session_to_ambient_pane(
         &mut self,
         pane_id: PaneId,
@@ -7905,6 +8236,22 @@ impl TypedActionView for PaneGroup {
             } => self.move_pane(*id, *target_pane_id, *direction, ctx),
             HandleFocusChange => self.handle_focus_change(ctx),
             FocusTerminalView(terminal_view_id) => self.focus_terminal_view(*terminal_view_id, ctx),
+            NewTabInPane => {
+                let pane_id = self.focused_pane_id(ctx);
+                self.add_terminal_tab_in_pane(pane_id, ctx);
+            }
+            NextPaneTab => {
+                let pane_id = self.focused_pane_id(ctx);
+                self.cycle_tab_in_pane(pane_id, true, ctx);
+            }
+            PrevPaneTab => {
+                let pane_id = self.focused_pane_id(ctx);
+                self.cycle_tab_in_pane(pane_id, false, ctx);
+            }
+            ClosePaneTab => {
+                let pane_id = self.focused_pane_id(ctx);
+                self.close_active_tab_in_pane(pane_id, ctx);
+            }
         }
     }
 }

--- a/app/src/pane_group/pane/mod.rs
+++ b/app/src/pane_group/pane/mod.rs
@@ -891,21 +891,42 @@ pub enum PaneStackEvent<P: View> {
     ViewAdded(ViewHandle<P>),
     /// A view was removed from the stack.
     ViewRemoved(ViewHandle<P>),
+    /// The active (rendered) entry changed without a view being added or
+    /// removed — e.g. the user switched between pane tabs.
+    ActiveChanged,
 }
 
 /// A navigation stack of backing views for a pane.
 ///
-/// This model allows panes to support a stack of views, where only the topmost
-/// view is active/rendered. Views can be pushed onto the stack and popped to
-/// return to the previous view.
+/// This model allows panes to support a stack of views, where only the active
+/// view is rendered. It serves two roles:
+///
+/// * As a *navigation stack*: views can be pushed on top and popped to return
+///   to the previous view (used e.g. by nested cloud-mode agent views). Push
+///   and pop always leave the topmost view active.
+/// * As a set of *pane tabs*: several sibling views (each its own shell) can be
+///   held at once, with [`Self::set_active_index`] switching which one is
+///   rendered and [`Self::remove_at`] closing an individual tab.
 ///
 /// The stack is guaranteed to always have at least one view.
 ///
 /// Each view in the stack can have associated data of type [`BackingView::AssociatedData`].
 /// This is useful for storing per-view metadata that should be tied to the view's own lifetime.
 pub struct PaneStack<P: BackingView> {
-    /// The stack of backing views with associated data. The last element is the active (topmost) view.
+    /// The stack of backing views with associated data.
+    ///
+    /// The first `tab_count` entries are sibling *pane tabs*; any entries above
+    /// them are transient *navigation-stack pushes* (nested cloud-mode agents,
+    /// docker sandboxes, …). Keeping the two contiguous lets us tell "the pane
+    /// has multiple shells" apart from "a nested view is pushed on top", which
+    /// drive very different UI (a tab strip vs. an Esc-to-go-back affordance).
     children: vec1::Vec1<(P::AssociatedData, ViewHandle<P>)>,
+    /// Index into `children` of the active (rendered) entry. Push/pop keep this
+    /// pinned to the top of the stack, preserving the navigation-stack
+    /// semantics; pane-tab switching moves it freely within the tab region.
+    active_index: usize,
+    /// Number of leading `children` that are sibling pane tabs (always >= 1).
+    tab_count: usize,
 }
 
 impl<P: BackingView> Entity for PaneStack<P> {
@@ -933,22 +954,40 @@ impl<P: BackingView> PaneStack<P> {
         });
         Self {
             children: vec1::vec1![(data, initial_view)],
+            active_index: 0,
+            tab_count: 1,
         }
     }
 
-    /// Returns the topmost (active) view in the stack.
+    /// Returns the active (rendered) view in the stack.
     pub fn active_view(&self) -> &ViewHandle<P> {
-        &self.children.last().1
+        &self.children[self.active_index].1
     }
 
-    /// Returns the associated data for the topmost (active) view in the stack.
+    /// Returns the associated data for the active (rendered) view in the stack.
     pub fn active_data(&self) -> &P::AssociatedData {
-        &self.children.last().0
+        &self.children[self.active_index].0
     }
 
-    /// Returns a mutable reference to the associated data for the topmost (active) view.
+    /// Returns a mutable reference to the associated data for the active (rendered) view.
     pub fn active_data_mut(&mut self) -> &mut P::AssociatedData {
-        &mut self.children.last_mut().0
+        &mut self.children[self.active_index].0
+    }
+
+    /// The index of the active (rendered) entry.
+    pub fn active_index(&self) -> usize {
+        self.active_index
+    }
+
+    /// The number of sibling pane tabs (the leading entries of the stack).
+    pub fn tab_count(&self) -> usize {
+        self.tab_count
+    }
+
+    /// Whether a navigation-stack view (a nested cloud-mode agent, docker
+    /// sandbox, …) is currently pushed above the pane's tabs.
+    pub fn has_nav_entries(&self) -> bool {
+        self.children.len() > self.tab_count
     }
 
     /// Returns all views in the stack.
@@ -978,7 +1017,43 @@ impl<P: BackingView> PaneStack<P> {
             view.set_pane_stack(weak_handle, ctx);
         });
         self.children.push((data, view.clone()));
+        // A push makes the newly added view active (top of the stack). It is a
+        // navigation-stack entry, not a tab, so `tab_count` is left unchanged.
+        self.active_index = self.children.len() - 1;
         ctx.emit(PaneStackEvent::ViewAdded(view));
+    }
+
+    /// Adds a new sibling *tab* to the pane (as opposed to [`Self::push`], which
+    /// adds a transient navigation-stack view). The tab is inserted after the
+    /// existing tabs and becomes active when no navigation-stack view is
+    /// currently on top.
+    pub fn add_tab(
+        &mut self,
+        data: P::AssociatedData,
+        view: ViewHandle<P>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let weak_handle = ctx.handle();
+        view.update(ctx, |view, ctx| {
+            view.set_pane_stack(weak_handle, ctx);
+        });
+
+        let had_nav_entries = self.has_nav_entries();
+        let insert_at = self.tab_count;
+        self.children.insert(insert_at, (data, view.clone()));
+        self.tab_count += 1;
+
+        // Keep the active entry stable across the insertion, then focus the new
+        // tab unless a navigation-stack view is currently on top.
+        if self.active_index >= insert_at {
+            self.active_index += 1;
+        }
+        if !had_nav_entries {
+            self.active_index = insert_at;
+        }
+
+        ctx.emit(PaneStackEvent::ViewAdded(view));
+        ctx.emit(PaneStackEvent::ActiveChanged);
     }
 
     /// Pops the topmost view from the stack.
@@ -988,8 +1063,51 @@ impl<P: BackingView> PaneStack<P> {
         ctx: &mut ModelContext<Self>,
     ) -> Option<(P::AssociatedData, ViewHandle<P>)> {
         let popped = self.children.pop().ok()?;
+        // Keep the active index in bounds; popping leaves the new top active.
+        self.active_index = self.active_index.min(self.children.len() - 1);
+        // If a tab was popped (only possible once the nav-stack region is
+        // empty), keep `tab_count` in sync.
+        self.tab_count = self.tab_count.min(self.children.len());
         ctx.emit(PaneStackEvent::ViewRemoved(popped.1.clone()));
         Some(popped)
+    }
+
+    /// Switches the active (rendered) entry to `index`. No-op if `index` is out
+    /// of bounds or already active.
+    pub fn set_active_index(&mut self, index: usize, ctx: &mut ModelContext<Self>) {
+        if index >= self.children.len() || index == self.active_index {
+            return;
+        }
+        self.active_index = index;
+        ctx.emit(PaneStackEvent::ActiveChanged);
+    }
+
+    /// Removes the entry at `index`, returning it (with its associated data).
+    /// Returns `None` when removing it would empty the stack — a stack always
+    /// keeps at least one view — or when `index` is out of bounds.
+    pub fn remove_at(
+        &mut self,
+        index: usize,
+        ctx: &mut ModelContext<Self>,
+    ) -> Option<(P::AssociatedData, ViewHandle<P>)> {
+        if self.children.len() <= 1 || index >= self.children.len() {
+            return None;
+        }
+        let removed = self.children.remove(index).ok()?;
+
+        if index < self.tab_count {
+            self.tab_count -= 1;
+        }
+
+        // Keep `active_index` pointing at the same entry (or a neighbor when the
+        // active entry itself was removed).
+        if index < self.active_index || self.active_index >= self.children.len() {
+            self.active_index = self.active_index.saturating_sub(1);
+        }
+
+        ctx.emit(PaneStackEvent::ViewRemoved(removed.1.clone()));
+        ctx.emit(PaneStackEvent::ActiveChanged);
+        Some(removed)
     }
 }
 
@@ -1058,6 +1176,12 @@ pub trait BackingView: View {
 
     fn should_render_header(&self, _app: &AppContext) -> bool {
         true
+    }
+
+    /// Short label shown for this view in the pane's tab strip when the pane
+    /// holds more than one tab. Defaults to an empty string.
+    fn tab_title(&self, _app: &AppContext) -> String {
+        String::new()
     }
 
     /// Called when this view is added to a [`PaneStack`]. Views are given a handle to their owning stack so that they can:

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -18,8 +18,8 @@ use warpui::{
 #[cfg(not(target_family = "wasm"))]
 use super::local_harness_launch::{prepare_local_harness_child_launch, PreparedLocalHarnessLaunch};
 use super::{
-    DetachType, PaneConfiguration, PaneContent, PaneId, PaneStackEvent, PaneView, ShareableLink,
-    ShareableLinkError, TerminalPaneId,
+    DetachType, PaneConfiguration, PaneContent, PaneId, PaneStack, PaneStackEvent, PaneView,
+    ShareableLink, ShareableLinkError, TerminalPaneId,
 };
 use crate::ai::active_agent_views_model::ActiveAgentViewsModel;
 use crate::ai::agent::conversation::{AIConversationId, ConversationStatus};
@@ -219,6 +219,15 @@ impl TerminalPane {
     /// The [`TerminalView`] backing the [`PaneView`] for this terminal pane.
     pub(crate) fn terminal_view(&self, ctx: &AppContext) -> ViewHandle<TerminalView> {
         self.view.as_ref(ctx).child(ctx)
+    }
+
+    /// The [`PaneStack`] backing this terminal pane. It holds one entry per
+    /// nested shell (tab) hosted inside the pane.
+    pub(in crate::pane_group) fn pane_stack(
+        &self,
+        ctx: &AppContext,
+    ) -> ModelHandle<PaneStack<TerminalView>> {
+        self.view.as_ref(ctx).pane_stack().clone()
     }
 
     /// The UUID that identifies this terminal session across app restarts.
@@ -915,8 +924,8 @@ fn attach_terminal_view(
 ) {
     ctx.subscribe_to_view(
         terminal_view,
-        move |group: &mut PaneGroup, _, event, ctx| {
-            handle_terminal_view_event(group, terminal_pane_id, event, ctx);
+        move |group: &mut PaneGroup, terminal_view, event, ctx| {
+            handle_terminal_view_event(group, terminal_pane_id, terminal_view.id(), event, ctx);
         },
     );
 }
@@ -935,6 +944,7 @@ fn handle_pane_stack_event(
         PaneStackEvent::ViewRemoved(terminal_view) => {
             ctx.unsubscribe_to_view(terminal_view);
         }
+        PaneStackEvent::ActiveChanged => {}
     }
 
     // Ensure we use the new top-level view's title and active session status.
@@ -947,6 +957,7 @@ fn handle_pane_stack_event(
 fn handle_terminal_view_event(
     group: &mut PaneGroup,
     terminal_pane_id: TerminalPaneId,
+    terminal_view_id: EntityId,
     event: &Event,
     ctx: &mut ViewContext<PaneGroup>,
 ) {
@@ -963,19 +974,19 @@ fn handle_terminal_view_event(
                 // keep the pane open.  There might be useful information visible
                 // in the output, and if this was the first shell spawned when the
                 // user started the app, it will prevent it from suddenly quitting.
-                if group
-                    .terminal_view_from_pane_id(terminal_pane_id, ctx)
+                if !group
+                    .terminal_view_by_id_in_pane(pane_id, terminal_view_id, ctx)
                     .is_some_and(|terminal_view| {
-                        !terminal_view.as_ref(ctx).is_login_shell_bootstrapped()
+                        terminal_view.as_ref(ctx).is_login_shell_bootstrapped()
                     })
                 {
                     return;
                 }
 
-                group.close_pane(pane_id, ctx);
+                group.close_terminal_tab_for_view(pane_id, terminal_view_id, false, ctx);
             }
             Event::CloseRequested => {
-                group.close_pane_with_confirmation(pane_id, ctx);
+                group.close_terminal_tab_for_view(pane_id, terminal_view_id, true, ctx);
             }
             Event::Pane(pane_event) => group.handle_pane_event(pane_id, pane_event, ctx),
             Event::BlockListCleared => {

--- a/app/src/pane_group/pane/view/header/mod.rs
+++ b/app/src/pane_group/pane/view/header/mod.rs
@@ -184,7 +184,9 @@ impl<P: BackingView> PaneHeader<P> {
         // Re-render when the active view changes
         if matches!(
             event,
-            PaneStackEvent::ViewAdded(_) | PaneStackEvent::ViewRemoved(_)
+            PaneStackEvent::ViewAdded(_)
+                | PaneStackEvent::ViewRemoved(_)
+                | PaneStackEvent::ActiveChanged
         ) {
             ctx.notify();
         }

--- a/app/src/pane_group/pane/view/mod.rs
+++ b/app/src/pane_group/pane/view/mod.rs
@@ -9,9 +9,15 @@ pub use header_content::{
 };
 use pathfinder_geometry::rect::RectF;
 use warpui::elements::{
-    Border, Container, DropTarget, DropTargetData, Flex, MainAxisSize, ParentElement, SavePosition,
-    Shrinkable,
+    Border, ChildAnchor, ConstrainedBox, Container, CrossAxisAlignment, DispatchEventResult,
+    DropTarget, DropTargetData, EventHandler, Flex, MainAxisSize, OffsetPositioning, ParentElement,
+    PositionedElementAnchor, PositionedElementOffsetBounds, SavePosition, Shrinkable, Stack, Text,
 };
+use warpui::geometry::vector::vec2f;
+use warpui::text_layout::ClipConfig;
+
+use crate::menu::{Event as MenuEvent, Menu, MenuItemFields};
+use crate::ui_components::blended_colors;
 use warpui::keymap::EditableBinding;
 use warpui::presenter::ChildView;
 use warpui::{
@@ -61,11 +67,30 @@ pub enum PaneViewEvent {
     PaneDraggedOutsideTabBarOrPaneGroup,
     PaneDragEnded,
     PaneHeaderClicked,
+    NewPaneTabRequested,
+    SelectPaneTab {
+        index: usize,
+    },
+    ClosePaneTab {
+        index: usize,
+    },
+    CloseOtherPaneTabs {
+        index: usize,
+    },
+    ClosePaneTabsToRight {
+        index: usize,
+    },
 }
 
 #[derive(Debug, Clone)]
 pub enum PaneAction {
     ShareContents,
+    SelectTab(usize),
+    CloseTab(usize),
+    NewTab,
+    OpenTabContextMenu { index: usize },
+    CloseOtherTabs(usize),
+    CloseTabsToRight(usize),
 }
 
 impl<P: BackingView> Entity for PaneView<P> {
@@ -80,6 +105,8 @@ pub struct PaneView<P: BackingView> {
     header: ViewHandle<PaneHeader<P>>,
     is_being_dragged: bool,
     focus_handle: Option<PaneFocusHandle>,
+    tab_context_menu: ViewHandle<Menu<PaneAction>>,
+    tab_context_menu_anchor: Option<usize>,
 }
 
 impl<P: BackingView> PaneView<P> {
@@ -118,6 +145,17 @@ impl<P: BackingView> PaneView<P> {
             }
         });
 
+        let tab_context_menu = ctx.add_typed_action_view(|_| {
+            Menu::new()
+                .with_safe_triangle()
+                .prevent_interaction_with_other_elements()
+        });
+        ctx.subscribe_to_view(&tab_context_menu, |me, _, event, ctx| {
+            if let MenuEvent::Close { .. } = event {
+                me.close_tab_context_menu(ctx);
+            }
+        });
+
         Self {
             pane_id,
             pane_stack,
@@ -125,6 +163,45 @@ impl<P: BackingView> PaneView<P> {
             header,
             is_being_dragged: false,
             focus_handle: None,
+            tab_context_menu,
+            tab_context_menu_anchor: None,
+        }
+    }
+
+    fn tab_position_id(&self, index: usize) -> String {
+        format!("pane_tab:{}:{}", self.pane_id.position_id(), index)
+    }
+
+    fn open_tab_context_menu(&mut self, index: usize, ctx: &mut ViewContext<Self>) {
+        let tab_count = self.pane_stack.as_ref(ctx).tab_count();
+        let is_last = index + 1 >= tab_count;
+        let items = vec![
+            MenuItemFields::new("Close")
+                .with_on_select_action(PaneAction::CloseTab(index))
+                .into_item(),
+            MenuItemFields::new("Close others")
+                .with_on_select_action(PaneAction::CloseOtherTabs(index))
+                .with_disabled(tab_count <= 1)
+                .into_item(),
+            MenuItemFields::new("Close to the right")
+                .with_on_select_action(PaneAction::CloseTabsToRight(index))
+                .with_disabled(is_last)
+                .into_item(),
+        ];
+        self.tab_context_menu.update(ctx, |menu, ctx| {
+            menu.set_items(items, ctx);
+        });
+        self.tab_context_menu_anchor = Some(index);
+        ctx.focus(&self.tab_context_menu);
+        ctx.notify();
+    }
+
+    fn close_tab_context_menu(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.tab_context_menu_anchor.take().is_some() {
+            self.tab_context_menu.update(ctx, |menu, ctx| {
+                menu.reset_selection(ctx);
+            });
+            ctx.notify();
         }
     }
 
@@ -351,6 +428,122 @@ impl<P: BackingView> PaneView<P> {
     pub fn pane_id(&self) -> PaneId {
         self.pane_id
     }
+
+    fn render_pane_tab_strip(&self, app: &AppContext) -> Box<dyn Element> {
+        let appearance = Appearance::as_ref(app);
+        let theme = appearance.theme();
+        let font_family = appearance.ui_font_family();
+        let font_size = appearance.ui_font_size();
+
+        let stack = self.pane_stack.as_ref(app);
+        let active_index = stack.active_index();
+        let tab_count = stack.tab_count();
+        let tabs: Vec<(usize, String, bool)> = stack
+            .entries()
+            .iter()
+            .take(tab_count)
+            .enumerate()
+            .map(|(index, (_, view))| {
+                let title = view.read(app, |view, app| view.tab_title(app));
+                (index, title, index == active_index)
+            })
+            .collect();
+
+        let mut row = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
+
+        for (index, title, is_active) in tabs {
+            let label = if title.trim().is_empty() {
+                format!("Terminal {}", index + 1)
+            } else {
+                title
+            };
+            let background = if is_active {
+                theme.surface_1()
+            } else {
+                theme.background()
+            };
+            let text_color = if is_active {
+                blended_colors::text_main(&theme, background)
+            } else {
+                blended_colors::text_sub(&theme, background)
+            };
+
+            let mut tab_row = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
+            tab_row.add_child(
+                Container::new(
+                    Text::new_inline(label, font_family, font_size)
+                        .with_color(text_color)
+                        .with_clip(ClipConfig::end())
+                        .finish(),
+                )
+                .with_margin_right(6.)
+                .finish(),
+            );
+            tab_row.add_child(
+                EventHandler::new(
+                    Text::new_inline("×", font_family, font_size)
+                        .with_color(text_color)
+                        .finish(),
+                )
+                .on_left_mouse_down(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(PaneAction::CloseTab(index));
+                    DispatchEventResult::StopPropagation
+                })
+                .finish(),
+            );
+
+            let tab = Container::new(tab_row.finish())
+                .with_horizontal_padding(10.)
+                .with_vertical_padding(4.)
+                .with_background_color(background.into())
+                .with_margin_right(2.)
+                .finish();
+
+            row.add_child(
+                SavePosition::new(
+                    ConstrainedBox::new(
+                        EventHandler::new(tab)
+                            .on_left_mouse_down(move |ctx, _, _| {
+                                ctx.dispatch_typed_action(PaneAction::SelectTab(index));
+                                DispatchEventResult::StopPropagation
+                            })
+                            .on_right_mouse_down(move |ctx, _, _| {
+                                ctx.dispatch_typed_action(PaneAction::OpenTabContextMenu { index });
+                                DispatchEventResult::StopPropagation
+                            })
+                            .finish(),
+                    )
+                    .with_max_width(200.)
+                    .finish(),
+                    &self.tab_position_id(index),
+                )
+                .finish(),
+            );
+        }
+
+        row.add_child(
+            EventHandler::new(
+                Container::new(
+                    Text::new_inline("+", font_family, font_size)
+                        .with_color(blended_colors::text_sub(&theme, theme.background()))
+                        .finish(),
+                )
+                .with_horizontal_padding(10.)
+                .with_vertical_padding(4.)
+                .finish(),
+            )
+            .on_left_mouse_down(|ctx, _, _| {
+                ctx.dispatch_typed_action(PaneAction::NewTab);
+                DispatchEventResult::StopPropagation
+            })
+            .finish(),
+        );
+
+        Container::new(row.finish())
+            .with_background_color(theme.background().into())
+            .with_border(Border::bottom(1.).with_border_fill(theme.surface_1()))
+            .finish()
+    }
 }
 
 #[derive(PartialEq, Copy, Clone, Debug)]
@@ -394,6 +587,16 @@ impl<P: BackingView> View for PaneView<P> {
             column.add_child(ChildView::new(&self.header).finish());
         }
 
+        // When the pane hosts more than one shell (tab), show a tab strip to
+        // switch between them. Suppress it while a navigation-stack view (e.g. a
+        // nested cloud-mode agent) is pushed on top.
+        {
+            let stack = self.pane_stack.as_ref(app);
+            if stack.tab_count() >= 2 && !stack.has_nav_entries() {
+                column.add_child(self.render_pane_tab_strip(app));
+            }
+        }
+
         // Add the underlying pane view.
         column.add_child(Shrinkable::new(1., ChildView::new(&active_child).finish()).finish());
 
@@ -422,11 +625,31 @@ impl<P: BackingView> View for PaneView<P> {
             container = container.with_foreground_overlay(appearance.theme().surface_2())
         }
 
-        SavePosition::new(
+        let pane_element = SavePosition::new(
             DropTarget::new(container.finish(), PaneDropTargetData { id: self.pane_id }).finish(),
             &self.pane_id.position_id(),
         )
-        .finish()
+        .finish();
+
+        // Overlay the tab context menu (if open), anchored just below the
+        // clicked tab element.
+        if let Some(index) = self.tab_context_menu_anchor {
+            let mut stack = Stack::new();
+            stack.add_child(pane_element);
+            stack.add_positioned_overlay_child(
+                ChildView::new(&self.tab_context_menu).finish(),
+                OffsetPositioning::offset_from_save_position_element(
+                    self.tab_position_id(index),
+                    vec2f(0., 4.),
+                    PositionedElementOffsetBounds::WindowByPosition,
+                    PositionedElementAnchor::BottomLeft,
+                    ChildAnchor::TopLeft,
+                ),
+            );
+            stack.finish()
+        } else {
+            pane_element
+        }
     }
 
     fn keymap_context(&self, ctx: &AppContext) -> warpui::keymap::Context {
@@ -446,7 +669,7 @@ impl<P: BackingView> View for PaneView<P> {
         // it is transferred between windows; otherwise a backing view would
         // be orphaned in the source window and later trip a "circular view
         // reference" panic when accessed from its new window.
-        let mut ids = vec![self.header.id()];
+        let mut ids = vec![self.header.id(), self.tab_context_menu.id()];
         ids.extend(self.pane_stack.as_ref(app).views().map(|view| view.id()));
         ids
     }
@@ -460,6 +683,20 @@ impl<P: BackingView> TypedActionView for PaneView<P> {
             PaneAction::ShareContents => self.header.update(ctx, |header, ctx| {
                 header.share_pane_contents(SharingDialogSource::CommandPalette, ctx);
             }),
+            PaneAction::SelectTab(index) => {
+                ctx.emit(PaneViewEvent::SelectPaneTab { index: *index })
+            }
+            PaneAction::CloseTab(index) => ctx.emit(PaneViewEvent::ClosePaneTab { index: *index }),
+            PaneAction::NewTab => ctx.emit(PaneViewEvent::NewPaneTabRequested),
+            PaneAction::OpenTabContextMenu { index } => {
+                self.open_tab_context_menu(*index, ctx);
+            }
+            PaneAction::CloseOtherTabs(index) => {
+                ctx.emit(PaneViewEvent::CloseOtherPaneTabs { index: *index })
+            }
+            PaneAction::CloseTabsToRight(index) => {
+                ctx.emit(PaneViewEvent::ClosePaneTabsToRight { index: *index })
+            }
         }
     }
 }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4886,7 +4886,7 @@ impl TerminalView {
                 .pane_stack
                 .as_ref()
                 .and_then(|h| h.upgrade(ctx))
-                .filter(|stack| stack.as_ref(ctx).depth() > 1)
+                .filter(|stack| stack.as_ref(ctx).has_nav_entries())
             {
                 pane_stack.update(ctx, |stack, ctx| {
                     stack.pop(ctx);
@@ -21382,7 +21382,7 @@ impl TerminalView {
                 let initial_prompt = initial_prompt.clone();
 
                 if let Some(pane_stack) = self.pane_stack.as_ref().and_then(|h| h.upgrade(ctx)) {
-                    let should_pop = pane_stack.as_ref(ctx).depth() > 1;
+                    let should_pop = pane_stack.as_ref(ctx).has_nav_entries();
                     if should_pop {
                         pane_stack.update(ctx, |stack, ctx| {
                             stack.pop(ctx);

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -692,9 +692,9 @@ impl TerminalView {
                 return;
             };
 
-            if pane_stack.as_ref(ctx).depth() <= 1 {
+            if !pane_stack.as_ref(ctx).has_nav_entries() {
                 log::warn!(
-                    "Nested cloud mode pane stack depth <= 1; cannot pop to start sibling cloud mode session"
+                    "Nested cloud mode pane stack has no pushed view; cannot pop to start sibling cloud mode session"
                 );
                 return;
             }

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -245,11 +245,14 @@ impl TerminalView {
             return Flex::row().finish();
         }
 
+        // Only a genuine navigation-stack push (a nested cloud-mode agent,
+        // docker sandbox, …) shows the "Esc for terminal" back button — sibling
+        // pane tabs also grow the stack but must not surface it.
         let in_nav_stack = self
             .pane_stack
             .as_ref()
             .and_then(|h| h.upgrade(app))
-            .is_some_and(|stack| stack.as_ref(app).depth() > 1);
+            .is_some_and(|stack| stack.as_ref(app).has_nav_entries());
 
         let is_transcript_viewer = self.model.lock().is_conversation_transcript_viewer();
         let is_ambient_agent = self.is_ambient_agent_session(app);
@@ -709,6 +712,24 @@ impl BackingView for TerminalView {
         }
 
         items
+    }
+
+    fn tab_title(&self, app: &AppContext) -> String {
+        let title = self
+            .pane_configuration
+            .as_ref(app)
+            .title()
+            .trim()
+            .to_owned();
+        if !title.is_empty() {
+            return title;
+        }
+        let raw = self.terminal_title.trim();
+        if !raw.is_empty() {
+            raw.to_owned()
+        } else {
+            "Terminal".to_owned()
+        }
     }
 
     fn should_render_header(&self, app: &AppContext) -> bool {

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -7896,3 +7896,150 @@ fn cmd_k_in_agent_view_cancels_in_progress_conversation_and_starts_new_one() {
         });
     })
 }
+
+#[test]
+fn pane_stack_supports_tab_switching_and_removal() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let t0 = add_window_with_terminal(&mut app, None);
+        let t1 = add_window_with_terminal(&mut app, None);
+        let t2 = add_window_with_terminal(&mut app, None);
+
+        let m0 = t0.read(&app, |view, _| view.model.clone());
+        let m1 = t1.read(&app, |view, _| view.model.clone());
+        let m2 = t2.read(&app, |view, _| view.model.clone());
+        let (v0, v1, v2) = (t0.clone(), t1.clone(), t2.clone());
+        let (v0b, v1b, v2b) = (t0.clone(), t1.clone(), t2.clone());
+
+        let pane_stack = app.update(move |ctx| {
+            let mgr0 = ctx.add_model(|_| {
+                let m: Box<dyn TerminalManager> = Box::new(TestTerminalManager {
+                    model: m0,
+                    _view: v0,
+                });
+                m
+            });
+            let mgr1 = ctx.add_model(|_| {
+                let m: Box<dyn TerminalManager> = Box::new(TestTerminalManager {
+                    model: m1,
+                    _view: v1,
+                });
+                m
+            });
+            let mgr2 = ctx.add_model(|_| {
+                let m: Box<dyn TerminalManager> = Box::new(TestTerminalManager {
+                    model: m2,
+                    _view: v2,
+                });
+                m
+            });
+            let pane_stack = ctx.add_model(|ctx| PaneStack::new(mgr0, v0b, ctx));
+            pane_stack.update(ctx, |stack, ctx| {
+                stack.add_tab(mgr1, v1b, ctx);
+                stack.add_tab(mgr2, v2b, ctx);
+            });
+            pane_stack
+        });
+
+        pane_stack.read(&app, |stack, _| {
+            assert_eq!(stack.depth(), 3);
+            assert_eq!(stack.tab_count(), 3);
+            assert!(!stack.has_nav_entries());
+            assert_eq!(stack.active_index(), 2);
+            assert_eq!(stack.active_view().id(), t2.id());
+        });
+
+        pane_stack.update(&mut app, |stack, ctx| stack.set_active_index(0, ctx));
+        pane_stack.read(&app, |stack, _| {
+            assert_eq!(stack.active_index(), 0);
+            assert_eq!(stack.active_view().id(), t0.id());
+        });
+
+        pane_stack.update(&mut app, |stack, ctx| stack.set_active_index(2, ctx));
+        let removed = pane_stack.update(&mut app, |stack, ctx| stack.remove_at(0, ctx));
+        assert!(removed.is_some());
+        pane_stack.read(&app, |stack, _| {
+            assert_eq!(stack.depth(), 2);
+            assert_eq!(stack.tab_count(), 2);
+            assert_eq!(stack.active_index(), 1);
+            assert_eq!(stack.active_view().id(), t2.id());
+        });
+
+        let _ = pane_stack.update(&mut app, |stack, ctx| stack.remove_at(1, ctx));
+        pane_stack.read(&app, |stack, _| {
+            assert_eq!(stack.depth(), 1);
+            assert_eq!(stack.tab_count(), 1);
+            assert_eq!(stack.active_index(), 0);
+            assert_eq!(stack.active_view().id(), t1.id());
+        });
+
+        let none = pane_stack.update(&mut app, |stack, ctx| stack.remove_at(0, ctx));
+        assert!(none.is_none());
+    })
+}
+
+#[test]
+fn pane_stack_distinguishes_tabs_from_nav_pushes() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let t0 = add_window_with_terminal(&mut app, None);
+        let t1 = add_window_with_terminal(&mut app, None);
+        let t2 = add_window_with_terminal(&mut app, None);
+
+        let m0 = t0.read(&app, |view, _| view.model.clone());
+        let m1 = t1.read(&app, |view, _| view.model.clone());
+        let m2 = t2.read(&app, |view, _| view.model.clone());
+        let (v0, v1, v2) = (t0.clone(), t1.clone(), t2.clone());
+        let (v0b, v1b, v2b) = (t0.clone(), t1.clone(), t2.clone());
+
+        let pane_stack = app.update(move |ctx| {
+            let mgr0 = ctx.add_model(|_| {
+                let m: Box<dyn TerminalManager> = Box::new(TestTerminalManager {
+                    model: m0,
+                    _view: v0,
+                });
+                m
+            });
+            let mgr1 = ctx.add_model(|_| {
+                let m: Box<dyn TerminalManager> = Box::new(TestTerminalManager {
+                    model: m1,
+                    _view: v1,
+                });
+                m
+            });
+            let mgr2 = ctx.add_model(|_| {
+                let m: Box<dyn TerminalManager> = Box::new(TestTerminalManager {
+                    model: m2,
+                    _view: v2,
+                });
+                m
+            });
+            let pane_stack = ctx.add_model(|ctx| PaneStack::new(mgr0, v0b, ctx));
+            pane_stack.update(ctx, |stack, ctx| {
+                // One sibling tab, then a nav-stack push on top (like cloud mode).
+                stack.add_tab(mgr1, v1b, ctx);
+                stack.push(mgr2, v2b, ctx);
+            });
+            pane_stack
+        });
+
+        // The push is a nav-stack entry, not a tab: two tabs, a nav entry on
+        // top, and the pushed view is active.
+        pane_stack.read(&app, |stack, _| {
+            assert_eq!(stack.depth(), 3);
+            assert_eq!(stack.tab_count(), 2);
+            assert!(stack.has_nav_entries());
+            assert_eq!(stack.active_view().id(), t2.id());
+        });
+
+        // Popping the nav entry returns to the tabs with nothing pushed.
+        let _ = pane_stack.update(&mut app, |stack, ctx| stack.pop(ctx));
+        pane_stack.read(&app, |stack, _| {
+            assert_eq!(stack.depth(), 2);
+            assert_eq!(stack.tab_count(), 2);
+            assert!(!stack.has_nav_entries());
+        });
+    })
+}


### PR DESCRIPTION
## Description

This PR adds tabbed terminals within a single pane, so you can run several shells side-by-side under one pane and switch between them with a tab strip.

## Linked Issue

Resolves https://github.com/warpdotdev/warp/issues/10972

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Added two unit tests in `app/src/terminal/view_tests.rs`:
- `pane_stack_supports_tab_switching_and_removal` — covers `add_tab`, `set_active_index`, and `remove_at`, including active-index bookkeeping and the always-at-least-one-view invariant.
- `pane_stack_distinguishes_tabs_from_nav_pushes` — verifies a nav-stack `push` is not counted as a tab and that popping it restores the tab region.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
https://github.com/user-attachments/assets/c6a54e6f-8c21-4955-a488-3544fe3514ff

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-IMPROVEMENT: Terminal panes now support multiple tabs, each its own shell — add with ctrl-shift-T, switch with ctrl-shift-L/H, close with ctrl-shift-W, or use the pane's tab strip.
-->