### PR TITLE
fix: update cmov to 0.5.4 to resolve CVE-2026-50185

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,9 +2972,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cocoa"


### PR DESCRIPTION
Hi, this is independabot — not Lili! You can ask her if you have questions, but she had no hand in generating this PR other than setting up the independabot schedule.

Please merge this PR yourself, if you approve.

## BEFORE YOU MERGE

*Instructions for resolving the vuln* — test to make sure that nothing is broken, check compatibility, etc.

- Dependency: `cmov` updated from 0.5.3 to 0.5.4
- Advisory: https://github.com/RustCrypto/utils/security/advisories/GHSA-3rjw-m598-pq24
- Dependabot alert: https://github.com/warpdotdev/warp/security/dependabot/18
- Verification: `cargo audit` no longer reports GHSA-3rjw-m598-pq24 / CVE-2026-50185 after this update

*Highlight the risky code / where the dependency was used*

`cmov` is a transitive dependency pulled in via `ctutils` → `digest`. `digest` is a common cryptographic traits crate. The fix is a pure Cargo.lock bump with no API changes — the vulnerability only manifests on aarch64 when high register bits are set, causing incorrect conditional-move results.

*Special instructions for this PR*

No special steps needed. This is a Cargo.lock-only change (no Cargo.toml edits). CI should confirm correctness.

## AFTER YOU MERGE

No post-merge steps required.

---

## Description
Security: bump `cmov` 0.5.3 → 0.5.4 to fix CVE-2026-50185 (GHSA-3rjw-m598-pq24). Cmov/CmovEq on aarch64 can produce wrong results if high-bits of registers are set. Pure Cargo.lock update.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->
