### PR TITLE
remove panic in ShellStarter::compute_fallback_shell

### DIFF
--- a/app/src/terminal/local_tty/shell.rs
+++ b/app/src/terminal/local_tty/shell.rs
@@ -186,9 +186,7 @@ impl ShellStarter {
     fn compute_fallback_shell() -> Option<ShellStarterSource> {
         cfg_if::cfg_if! {
             if #[cfg(unix)] {
-                let pw_shell_path = nix::unistd::User::from_uid(nix::unistd::getuid())
-                    .expect("should not fail to read user information")
-                    .expect("current user should exist")
+                let pw_shell_path = nix::unistd::User::from_uid(nix::unistd::getuid()).ok()??
                     .shell
                     .display()
                     .to_string();


### PR DESCRIPTION
## Description

Linux Crash Free Session Rate is down 2% in `v0.2026.07.01.09.21.stable_01` so far. 

<img width="1092" height="435" alt="Screenshot 2026-07-03 at 11 36 35 AM" src="https://github.com/user-attachments/assets/af81d4a0-c98a-4b87-9625-1c35f6272030" />


All due to [this one panic](https://warpdotdev.sentry.io/issues/7591313020/). Probably an anomaly... but an easy fix nonetheless. It says 41 users but they are all anonymous and based on the tags this appears to be coming from an HPC cluster. So it's probably _actually_ one user.

I should clarify that this is not a regression.