### PR TITLE
Support merging selected tabs

### DIFF
--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -4351,6 +4351,64 @@ impl PaneGroup {
         pane_content
     }
 
+    pub(crate) fn can_drain_visible_terminal_panes_for_move(&self) -> bool {
+        let visible_pane_ids = self.visible_pane_ids();
+        !visible_pane_ids.is_empty()
+            && visible_pane_ids.len() == self.pane_contents.len()
+            && visible_pane_ids
+                .iter()
+                .all(|pane_id| pane_id.is_terminal_pane())
+    }
+
+    /// Drains all visible terminal panes for transfer into another pane group.
+    ///
+    /// This intentionally leaves the source pane tree in a transient invalid
+    /// state once the final root pane is drained. Callers must remove the source
+    /// tab immediately after this returns.
+    pub(crate) fn drain_visible_terminal_panes_for_move(
+        &mut self,
+        ctx: &mut ViewContext<Self>,
+    ) -> Vec<Box<dyn AnyPaneContent>> {
+        if !self.can_drain_visible_terminal_panes_for_move() {
+            log::warn!("drain_visible_terminal_panes_for_move called on an ineligible pane group");
+            return Vec::new();
+        }
+
+        let pane_ids = self.visible_pane_ids();
+        let mut moved_panes = Vec::with_capacity(pane_ids.len());
+
+        for pane_id in pane_ids {
+            self.panes.remove_hidden_pane(pane_id);
+
+            match self.pane_contents.get(&pane_id) {
+                Some(data) => {
+                    let pane = data.as_pane();
+                    pane.detach(self, DetachType::Moved, ctx);
+                }
+                None => log::error!("Could not find data for pane id: {pane_id:?}"),
+            }
+
+            if self.pane_count() > 1 && !self.panes.remove(pane_id) {
+                log::error!("Pane not found");
+            }
+
+            if let Some(pane_content) = self.pane_contents.remove(&pane_id) {
+                moved_panes.push(pane_content);
+            }
+        }
+
+        self.focus_state.update(ctx, |focus_state, ctx| {
+            focus_state.set_in_split_pane(false, ctx);
+            focus_state.set_focused_pane_maximized(false, ctx);
+        });
+
+        ctx.notify();
+        ctx.emit(Event::TerminalViewStateChanged);
+        ctx.emit(Event::AppStateChanged);
+
+        moved_panes
+    }
+
     pub fn notebook_pane_by_pane_id(&self, pane_id: Option<PaneId>) -> Option<&NotebookPane> {
         self.downcast_pane_by_id(pane_id?)
     }
@@ -6574,6 +6632,16 @@ impl PaneGroup {
         ctx: &mut ViewContext<Self>,
     ) {
         let _ = self.add_pane(direction, None, Box::new(pane), focus_new_pane, ctx);
+    }
+
+    pub(crate) fn add_existing_pane_with_direction(
+        &mut self,
+        direction: Direction,
+        pane: Box<dyn AnyPaneContent>,
+        focus_new_pane: bool,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let _ = self.add_pane(direction, None, pane, focus_new_pane, ctx);
     }
 
     /// Adds a new pane to this group, relative to an existing pane.

--- a/app/src/workspace/action.rs
+++ b/app/src/workspace/action.rs
@@ -224,6 +224,9 @@ pub enum WorkspaceAction {
     },
     /// Removes every selected tab from its group (requires a single shared group).
     RemoveSelectedTabsFromGroup,
+    /// Merges every selected tab into the first selected tab by moving visible
+    /// terminal panes into the destination and removing the emptied source tabs.
+    MergeSelectedTabs,
     /// Context-aware "remove from group" entry point for the keybinding:
     /// removes the multi-selection from its shared group when 2+ tabs are
     /// selected, otherwise removes the active tab.
@@ -955,6 +958,7 @@ impl WorkspaceAction {
             | NewTabGroupFromActiveOrSelectedTabs
             | MoveSelectedTabsToGroup { .. }
             | RemoveSelectedTabsFromGroup
+            | MergeSelectedTabs
             | RemoveActiveOrSelectedTabsFromGroup
             | UngroupTabs(_)
             | NewTabInGroup(_)

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -23893,6 +23893,7 @@ impl TypedActionView for Workspace {
                 self.move_selected_tabs_to_group(*group_id, ctx)
             }
             RemoveSelectedTabsFromGroup => self.remove_selected_tabs_from_group(ctx),
+            MergeSelectedTabs => self.merge_selected_tabs(ctx),
             RemoveActiveOrSelectedTabsFromGroup => {
                 self.remove_active_or_selected_tabs_from_group(ctx)
             }

--- a/app/src/workspace/view/tab_grouping.rs
+++ b/app/src/workspace/view/tab_grouping.rs
@@ -2,10 +2,11 @@ use std::collections::HashSet;
 
 use itertools::{Either, Itertools};
 use warp_core::features::FeatureFlag;
-use warpui::{EntityId, UpdateView, ViewContext};
+use warpui::{AppContext, EntityId, UpdateView, ViewContext};
 
 use super::{Workspace, group_member_indices};
 use crate::menu::{MenuItem, MenuItemFields};
+use crate::pane_group::Direction;
 use crate::tab::{MOVE_TO_GROUP_LABEL, TabData};
 use crate::workspace::action::{TabContextMenuAnchor, WorkspaceAction};
 use crate::workspace::tab_group::{TabGroup, TabGroupId};
@@ -457,17 +458,84 @@ impl Workspace {
         ctx.notify();
     }
 
+    pub(super) fn can_merge_selected_tabs(&self, ctx: &AppContext) -> bool {
+        let selected_indices = self.selected_tab_indices();
+        selected_indices.len() >= 2
+            && selected_indices.iter().all(|index| {
+                self.tabs.get(*index).is_some_and(|tab| {
+                    tab.pane_group
+                        .as_ref(ctx)
+                        .can_drain_visible_terminal_panes_for_move()
+                })
+            })
+    }
+
+    pub(super) fn merge_selected_tabs(&mut self, ctx: &mut ViewContext<Self>) {
+        if !FeatureFlag::GroupedTabs.is_enabled() {
+            return;
+        }
+
+        let selected_indices = self.selected_tab_indices();
+        if selected_indices.len() < 2 {
+            log::warn!(
+                "merge_selected_tabs called with {} selected tab(s); expected at least 2",
+                selected_indices.len()
+            );
+            return;
+        }
+
+        if !self.can_merge_selected_tabs(ctx) {
+            log::warn!("merge_selected_tabs called with an ineligible tab selection");
+            return;
+        }
+
+        let destination_index = selected_indices[0];
+        let destination_pane_group = self.tabs[destination_index].pane_group.clone();
+        let source_indices = selected_indices[1..].to_vec();
+
+        for source_index in &source_indices {
+            let source_pane_group = self.tabs[*source_index].pane_group.clone();
+            let moved_panes = source_pane_group.update(ctx, |pane_group, ctx| {
+                pane_group.drain_visible_terminal_panes_for_move(ctx)
+            });
+
+            destination_pane_group.update(ctx, |pane_group, ctx| {
+                for pane in moved_panes {
+                    pane_group.add_existing_pane_with_direction(Direction::Right, pane, false, ctx);
+                }
+            });
+        }
+
+        for source_index in source_indices.into_iter().rev() {
+            self.remove_tab(source_index, false, false, ctx);
+        }
+
+        self.activate_tab_internal(destination_index, ctx);
+        ctx.dispatch_global_action("workspace:save_app", ());
+        ctx.notify();
+    }
+
     /// Items shown in the multi-tab right-click menu. Composition depends on
     /// the selection: "Create group from tabs" is always there; "Remove from
     /// group" only when the selection has an unambiguous group; "Move to
     /// group" only when there's a destination group worth offering.
-    fn tab_selection_menu_items(&self) -> Vec<MenuItem<WorkspaceAction>> {
+    fn tab_selection_menu_items(&self, ctx: &AppContext) -> Vec<MenuItem<WorkspaceAction>> {
         let shared_group = self.selection_shared_group();
-        let mut menu_items = vec![
+        let mut menu_items = vec![];
+
+        if self.can_merge_selected_tabs(ctx) {
+            menu_items.push(
+                MenuItemFields::new("Merge selected tabs")
+                    .with_on_select_action(WorkspaceAction::MergeSelectedTabs)
+                    .into_item(),
+            );
+        }
+
+        menu_items.push(
             MenuItemFields::new("Create group from tabs")
                 .with_on_select_action(WorkspaceAction::NewTabGroupFromSelectedTabs)
                 .into_item(),
-        ];
+        );
 
         // Only single-group selections have an unambiguous group to leave.
         if shared_group.is_some() {
@@ -505,7 +573,7 @@ impl Workspace {
             return;
         }
 
-        let menu_items = self.tab_selection_menu_items();
+        let menu_items = self.tab_selection_menu_items(ctx);
         ctx.update_view(&self.tab_right_click_menu, |context_menu, view_ctx| {
             context_menu.set_items(menu_items, view_ctx);
         });

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -4187,6 +4187,100 @@ fn test_move_selected_tabs_to_group_expands_collapsed_group() {
 }
 
 #[test]
+fn test_merge_selected_tabs_appends_visible_terminal_panes_to_first_selected_tab() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            workspace.add_terminal_tab(false, ctx);
+            workspace.add_terminal_tab(false, ctx);
+            assert_eq!(workspace.tab_count(), 3);
+
+            let destination_pane_group = workspace.tabs[0].pane_group.clone();
+            let source_one_pane_group = workspace.tabs[1].pane_group.clone();
+            let source_two_pane_group = workspace.tabs[2].pane_group.clone();
+            let destination_pane_group_id = destination_pane_group.id();
+
+            source_one_pane_group.update(ctx, |pane_group, ctx| {
+                pane_group.handle_action(&PaneGroupAction::Add(Direction::Right), ctx);
+            });
+
+            let mut expected_visible_pane_ids =
+                destination_pane_group.read(ctx, |pane_group, _| pane_group.visible_pane_ids());
+            expected_visible_pane_ids.extend(
+                source_one_pane_group.read(ctx, |pane_group, _| pane_group.visible_pane_ids()),
+            );
+            expected_visible_pane_ids.extend(
+                source_two_pane_group.read(ctx, |pane_group, _| pane_group.visible_pane_ids()),
+            );
+            assert_eq!(expected_visible_pane_ids.len(), 4);
+
+            workspace.activate_tab(0, ctx);
+            workspace.tabs[1].in_multi_selection = true;
+            workspace.tabs[2].in_multi_selection = true;
+
+            workspace.handle_action(&WorkspaceAction::MergeSelectedTabs, ctx);
+
+            assert_eq!(workspace.tab_count(), 1);
+            assert_eq!(workspace.active_tab_index(), 0);
+            assert_eq!(workspace.tabs[0].pane_group.id(), destination_pane_group_id);
+            assert!(workspace.tabs.iter().all(|tab| !tab.in_multi_selection));
+
+            let actual_visible_pane_ids = workspace.tabs[0]
+                .pane_group
+                .read(ctx, |pane_group, _| pane_group.visible_pane_ids());
+            assert_eq!(actual_visible_pane_ids, expected_visible_pane_ids);
+        });
+    });
+}
+
+#[test]
+fn test_merge_selected_tabs_uses_first_selected_tab_not_active_tab_as_destination() {
+    let _grouped_tabs_guard = FeatureFlag::GroupedTabs.override_enabled(true);
+
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+
+        let workspace = mock_workspace(&mut app);
+        workspace.update(&mut app, |workspace, ctx| {
+            workspace.add_terminal_tab(false, ctx);
+            workspace.add_terminal_tab(false, ctx);
+            assert_eq!(workspace.tab_count(), 3);
+
+            let destination_pane_group = workspace.tabs[0].pane_group.clone();
+            let middle_pane_group_id = workspace.tabs[1].pane_group.id();
+            let source_pane_group = workspace.tabs[2].pane_group.clone();
+            let destination_pane_group_id = destination_pane_group.id();
+
+            let mut expected_visible_pane_ids =
+                destination_pane_group.read(ctx, |pane_group, _| pane_group.visible_pane_ids());
+            expected_visible_pane_ids
+                .extend(source_pane_group.read(ctx, |pane_group, _| pane_group.visible_pane_ids()));
+            assert_eq!(expected_visible_pane_ids.len(), 2);
+
+            workspace.activate_tab(2, ctx);
+            workspace.tabs[0].in_multi_selection = true;
+
+            workspace.handle_action(&WorkspaceAction::MergeSelectedTabs, ctx);
+
+            assert_eq!(workspace.tab_count(), 2);
+            assert_eq!(workspace.active_tab_index(), 0);
+            assert_eq!(workspace.tabs[0].pane_group.id(), destination_pane_group_id);
+            assert_eq!(workspace.tabs[1].pane_group.id(), middle_pane_group_id);
+            assert!(workspace.tabs.iter().all(|tab| !tab.in_multi_selection));
+
+            let actual_visible_pane_ids = workspace.tabs[0]
+                .pane_group
+                .read(ctx, |pane_group, _| pane_group.visible_pane_ids());
+            assert_eq!(actual_visible_pane_ids, expected_visible_pane_ids);
+        });
+    });
+}
+
+#[test]
 fn test_new_tab_in_group_expands_collapsed_group_non_member_active() {
     // When the active tab is NOT a member of the group, `new_tab_in_group`
     // must still expand the target group.


### PR DESCRIPTION
## Description

Adds a `Merge selected tabs` action to the multi-tab context menu. When multiple tabs are selected, Warp can merge the source tabs into the first selected tab by moving each selected source tab's visible terminal panes into the destination pane group and then removing the emptied source tabs.

This intentionally keeps the first implementation narrow:

- available from the selected-tabs context menu
- destination is the first selected tab by tab order
- only tabs whose panes are all visible terminal panes are eligible
- source panes are appended to the right of the destination tab
- source tabs are removed after their panes are moved

Closes #8959.

## Linked Issue

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Automated:

- `./script/format --check`
- `./script/check_no_inline_test_modules`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `./script/run-clang-format.py -r --extensions 'c,h,cpp,m' ./crates/warpui/src/ ./app/src/`
- `find . -name "*.wgsl" -exec wgslfmt --check {} +`
- `cargo nextest run -p warp -E 'test(test_merge_selected_tabs)'`
- `cargo nextest run -p warp_completer --features v2`
- `cargo test --doc`
- `git diff --check`

Attempted:

- `./script/presubmit`

`./script/presubmit` passed formatting, linting, `clang-format`, and `wgslfmt`, then reached the full workspace nextest run. The workspace nextest run executed `8552` tests: `8547` passed, `4` failed, and `1` timed out. The remaining failures were SSH/GCP integration tests that require access to Warp's `warp-ssh-integration-testing` GCP project and failed locally with `gcloud` IAP tunnel error `4033: not authorized`. GitHub CI excludes these SSH/GCP tests for fork PRs.

Manual:

- [ ] I have manually tested my changes locally with `./script/run`
- [x] Manually tested in a freshly bundled `WarpOss.app` opened from `target/debug/bundle/osx/WarpOss.app`.
- Verified locally in a freshly bundled `WarpOss.app` that selected vertical tabs can be merged from the tab context menu.

### Screenshots / Videos

https://github.com/user-attachments/assets/48e7aff7-41c0-44e6-a042-f1baaff312c9

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Add a context menu action to merge selected tabs into a split pane.