### PR TITLE
fix cross-window tab drag crash

### DIFF
--- a/app/src/workspace/cross_window_tab_drag.rs
+++ b/app/src/workspace/cross_window_tab_drag.rs
@@ -1399,28 +1399,34 @@ impl CrossWindowTabDrag {
             return DropResult::ClosePreviewOnly { preview_window_id };
         }
 
-        if let Some(ws) = WorkspaceRegistry::as_ref(ctx).get(preview_window_id, ctx) {
-            ws.update(ctx, |ws, ctx| {
-                ws.set_is_tab_drag_preview(false);
-                // The preview's `suppress_detach_panes_on_window_close` flag
-                // is latched to `true` by every forward handoff out of the
-                // preview (`prepare_for_transferred_tab_attach` in
-                // `execute_handoff_multi_tab_to_other`) and is *not* cleared
-                // by `reverse_handoff` for the multi-tab case (only
-                // `is_tab_drag_preview` is restored there). Promoting the
-                // preview to a permanent window without clearing this flag
-                // would leave a normal-looking window that silently skips
-                // pane-detach on its next user-initiated close.
-                ws.set_suppress_detach_panes_on_window_close(false);
-                ws.sync_window_button_visibility(ctx);
-                ws.update_titlebar_height(ctx);
-                ctx.notify();
-            });
-        } else {
+        let Some(ws) = WorkspaceRegistry::as_ref(ctx).get(preview_window_id, ctx) else {
+            // The preview window's workspace is already gone, so there is no
+            // window to promote and the dragged pane group no longer lives in
+            // a preview we control. Falling through would return
+            // `RemoveSourceTab` / `CloseSourceWindow` keyed on a now-stale
+            // `source_tab_index`, tearing out a bystander tab or panicking in
+            // `remove_tab`. Bail without touching the source.
             log::warn!(
-                "tab_drag: finalize_preview_as_new_window no workspace for preview_wid={preview_window_id}"
+                "tab_drag: finalize_preview_as_new_window no workspace for preview_wid={preview_window_id} -> NoOp"
             );
-        }
+            return DropResult::NoOp;
+        };
+        ws.update(ctx, |ws, ctx| {
+            ws.set_is_tab_drag_preview(false);
+            // The preview's `suppress_detach_panes_on_window_close` flag
+            // is latched to `true` by every forward handoff out of the
+            // preview (`prepare_for_transferred_tab_attach` in
+            // `execute_handoff_multi_tab_to_other`) and is *not* cleared
+            // by `reverse_handoff` for the multi-tab case (only
+            // `is_tab_drag_preview` is restored there). Promoting the
+            // preview to a permanent window without clearing this flag
+            // would leave a normal-looking window that silently skips
+            // pane-detach on its next user-initiated close.
+            ws.set_suppress_detach_panes_on_window_close(false);
+            ws.sync_window_button_visibility(ctx);
+            ws.update_titlebar_height(ctx);
+            ctx.notify();
+        });
         ctx.windows().show_window_and_focus_app(preview_window_id);
         Self::deferred_focus(preview_window_id, ctx);
 

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -28387,8 +28387,15 @@ impl Workspace {
             } => {
                 if let Some(tab) = self.tabs.get(transferred_tab_index) {
                     ctx.unsubscribe_to_view(&tab.pane_group);
+                } else {
+                    log::warn!(
+                        "tab_drag: handle_drop_result RemoveSourceTab stale index={transferred_tab_index} tabs_len={} (skipping remove)",
+                        self.tabs.len()
+                    );
                 }
-                self.remove_tab_without_undo(transferred_tab_index, ctx);
+                if transferred_tab_index < self.tabs.len() {
+                    self.remove_tab_without_undo(transferred_tab_index, ctx);
+                }
             }
             DropResult::RemoveSourceTabAndClosePreview {
                 transferred_tab_index,
@@ -28396,8 +28403,15 @@ impl Workspace {
             } => {
                 if let Some(tab) = self.tabs.get(transferred_tab_index) {
                     ctx.unsubscribe_to_view(&tab.pane_group);
+                } else {
+                    log::warn!(
+                        "tab_drag: handle_drop_result RemoveSourceTabAndClosePreview stale index={transferred_tab_index} tabs_len={} (skipping remove)",
+                        self.tabs.len()
+                    );
                 }
-                self.remove_tab_without_undo(transferred_tab_index, ctx);
+                if transferred_tab_index < self.tabs.len() {
+                    self.remove_tab_without_undo(transferred_tab_index, ctx);
+                }
                 ctx.windows()
                     .close_window(preview_window_id, TerminationMode::ContentTransferred);
             }

--- a/crates/warpui/src/platform/mac/window.rs
+++ b/crates/warpui/src/platform/mac/window.rs
@@ -1254,6 +1254,39 @@ impl WindowExt for &dyn platform::Window {
     }
 }
 
+/// Invokes the platform `window_resized` callback for `window`.
+///
+/// `window_resized` mutably borrows the global app via [`app::callback_dispatcher`]. AppKit
+/// can fire frame-size callbacks synchronously while we are already inside that borrow — for
+/// example, ordering a torn-off tab's preview window during event dispatch triggers a
+/// fullscreen transition that synchronously calls `setFrameSize:`. Invoking `window_resized`
+/// synchronously in that situation panics with "RefCell already borrowed".
+///
+/// To stay safe we defer the callback onto the foreground executor whenever the caller
+/// requests async dispatch (`force_async`) or the app is currently borrowed. Deferral is the
+/// same path AppKit-initiated resizes already use; it runs once the outer borrow is released.
+/// Callers still perform the drawable/renderer resize synchronously, since that touches no app
+/// state.
+fn dispatch_window_resized(window: &Rc<WindowState>, force_async: bool) {
+    if force_async || !app::callback_dispatcher().can_borrow_mut() {
+        let weak_window_state = Rc::downgrade(window);
+        window
+            .executor
+            .spawn(async move {
+                if let Some(window_state) = weak_window_state.upgrade() {
+                    app::callback_dispatcher()
+                        .for_window(&Window(window_state.clone()))
+                        .window_resized(window_state.as_ref());
+                }
+            })
+            .detach();
+    } else {
+        app::callback_dispatcher()
+            .for_window(&Window(window.clone()))
+            .window_resized(window.as_ref());
+    }
+}
+
 #[no_mangle]
 extern "C-unwind" fn warp_view_did_change_backing_properties(this: &Object, async_callback: bool) {
     // SAFETY: `this` is a WarpHostView carrying the window-state ivar; its backing
@@ -1287,24 +1320,7 @@ extern "C-unwind" fn warp_view_did_change_backing_properties(this: &Object, asyn
 
     window.resize_renderer();
 
-    if async_callback {
-        // Dispatch the callback asynchronously if async_callback is true.
-        let weak_window_state = Rc::downgrade(window);
-        window
-            .executor
-            .spawn(async move {
-                if let Some(window_state) = weak_window_state.upgrade() {
-                    app::callback_dispatcher()
-                        .for_window(&Window(window_state.clone()))
-                        .window_resized(window_state.as_ref());
-                }
-            })
-            .detach();
-    } else {
-        app::callback_dispatcher()
-            .for_window(&Window(window.clone()))
-            .window_resized(window.as_ref());
-    }
+    dispatch_window_resized(window, async_callback);
 }
 
 #[no_mangle]
@@ -1377,24 +1393,7 @@ extern "C-unwind" fn warp_view_set_frame_size(this: &Object, size: NSSize, async
 
     window.resize_renderer();
 
-    if async_callback {
-        // Dispatch the callback asynchronously if async_callback is true.
-        let weak_window_state = Rc::downgrade(window);
-        window
-            .executor
-            .spawn(async move {
-                if let Some(window_state) = weak_window_state.upgrade() {
-                    app::callback_dispatcher()
-                        .for_window(&Window(window_state.clone()))
-                        .window_resized(window_state.as_ref());
-                }
-            })
-            .detach();
-    } else {
-        app::callback_dispatcher()
-            .for_window(&Window(window.clone()))
-            .window_resized(window.as_ref());
-    }
+    dispatch_window_resized(window, async_callback);
 }
 
 #[no_mangle]


### PR DESCRIPTION
While a preview is being created for cross-window tab drag, `App` is being borrowed. If this happens during MacOS native full-screen mode, we perform a resize to fill up the window. This tries to borrow the already-borrowed App, causing a crash.

Sentry: https://warpdotdev.sentry.io/issues/7553556464/?project=5658526&query=&referrer=release-issue-stream&statsPeriod=14d

The fix is to add a guard to check if App can be borrowed. If not, we defer the resize instead of doing it synchronously. This is similar to what `warp_update_layer()` does.

Testing:
- Verified reproduction using fullscreen mode
- Verified fix locally using fullscreen mode