### PR TITLE
Fix Windows PTY shutdown process cleanup

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -404,6 +404,7 @@ windows = { workspace = true, features = [
     "Win32_Storage",
     "Win32_Storage_FileSystem",
     "Win32_System_Console",
+    "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_Diagnostics_Debug",
     "Win32_System_Environment",
     "Win32_System_IO",

--- a/app/src/terminal/local_tty/spawner.rs
+++ b/app/src/terminal/local_tty/spawner.rs
@@ -71,9 +71,7 @@ impl PtyHandle for DirectPtyHandle {
     }
 
     fn kill(&mut self) -> Result<()> {
-        // The logic to kill the process and file handles are fully contained in
-        // EventedPty::kill().
-        Ok(())
+        self.child.kill()
     }
 }
 /// Invokes the provided callback function without crash reporting enabled.

--- a/app/src/terminal/local_tty/windows/child_tests.rs
+++ b/app/src/terminal/local_tty/windows/child_tests.rs
@@ -1,8 +1,9 @@
-use std::os::windows::io::AsRawHandle;
 use std::time::Duration;
 
-use command::blocking::Command;
 use instant::Instant;
+use windows::core::PCWSTR;
+use windows::Win32::Foundation::CloseHandle;
+use windows::Win32::System::Threading::{CreateEventW, SetEvent};
 
 use super::*;
 use crate::terminal::local_tty::event_loop::CHANNEL_TOKEN;
@@ -15,9 +16,8 @@ pub fn test_event_is_emitted_when_child_exits() {
 
     let (tx, mut rx) = mio_channel::channel();
 
-    let mut child = Command::new("cmd.exe").spawn().unwrap();
-    let child_handle = HANDLE(child.as_raw_handle());
-    let mut child_exit_watcher = ChildExitWatcher::new(child_handle, tx).unwrap();
+    let event_handle = unsafe { CreateEventW(None, true, false, PCWSTR::null()).unwrap() };
+    let mut child_exit_watcher = ChildExitWatcher::new(event_handle, tx).unwrap();
     // We need to register the receiver with the poller so that it can be woken up when the child exits.
     poll.registry()
         .register(&mut rx, CHANNEL_TOKEN, Interest::READABLE)
@@ -27,7 +27,7 @@ pub fn test_event_is_emitted_when_child_exits() {
         .register(poll.registry(), CHANNEL_TOKEN, Interest::READABLE)
         .unwrap();
 
-    child.kill().unwrap();
+    unsafe { SetEvent(event_handle).unwrap() };
 
     // Poll until the event arrives or the overall timeout elapses.
     let mut events = mio::Events::with_capacity(10);
@@ -52,4 +52,9 @@ pub fn test_event_is_emitted_when_child_exits() {
     }
     // Verify that at least one `ChildEvent::Exited` was received.
     assert!(matches!(rx.try_recv(), Ok(Message::ChildExited)));
+
+    drop(child_exit_watcher);
+    unsafe {
+        CloseHandle(event_handle).unwrap();
+    }
 }

--- a/app/src/terminal/local_tty/windows/mod.rs
+++ b/app/src/terminal/local_tty/windows/mod.rs
@@ -100,7 +100,7 @@ impl PseudoConsoleChild {
         match descendant_process_ids(self.id()) {
             Ok(descendant_process_ids) => {
                 for pid in descendant_process_ids.iter().rev() {
-                    if let Err(err) = terminate_process_by_pid(*pid) {
+                    if let Err(err) = terminate_process_by_pid(self.id(), *pid) {
                         log::warn!("Failed to terminate PTY descendant process {pid}: {err:#}");
                     }
                 }
@@ -144,50 +144,107 @@ impl Drop for PseudoConsoleChild {
     }
 }
 
-fn terminate_process_by_pid(pid: u32) -> windows::core::Result<()> {
+struct OwnedHandle(HANDLE);
+
+impl OwnedHandle {
+    fn get(&self) -> HANDLE {
+        self.0
+    }
+}
+
+impl Drop for OwnedHandle {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = CloseHandle(self.0);
+        }
+    }
+}
+
+struct ProcessTreeSnapshot {
+    child_processes_by_parent: HashMap<u32, Vec<u32>>,
+    parent_process_by_child: HashMap<u32, u32>,
+}
+
+fn terminate_process_by_pid(root_pid: u32, pid: u32) -> windows::core::Result<()> {
     unsafe {
-        let process = OpenProcess(PROCESS_TERMINATE | PROCESS_SYNCHRONIZE, false, pid)?;
-        let result = TerminateProcess(process, 1);
+        let process = OwnedHandle(OpenProcess(
+            PROCESS_TERMINATE | PROCESS_SYNCHRONIZE,
+            false,
+            pid,
+        )?);
+        // Holding the handle while re-reading the process tree prevents PID reuse
+        // between descendant verification and termination.
+        if !is_descendant_process(root_pid, pid)? {
+            log::debug!(
+                "Skipping PTY descendant process {pid}; it no longer belongs to PTY root {root_pid}"
+            );
+            return Ok(());
+        }
+
+        let result = TerminateProcess(process.get(), 1);
         if result.is_ok() {
-            let wait_result = WaitForSingleObject(process, PseudoConsoleChild::TERMINATE_WAIT_MS);
+            let wait_result =
+                WaitForSingleObject(process.get(), PseudoConsoleChild::TERMINATE_WAIT_MS);
             if wait_result == WAIT_TIMEOUT {
                 log::warn!("Timed out waiting for PTY descendant process {pid} to exit");
             }
         }
-        let _ = CloseHandle(process);
         result
     }
 }
 
 fn descendant_process_ids(root_pid: u32) -> windows::core::Result<Vec<u32>> {
+    let process_tree = process_tree_snapshot()?;
+
+    Ok(collect_descendant_process_ids(
+        root_pid,
+        &process_tree.child_processes_by_parent,
+    ))
+}
+
+fn is_descendant_process(root_pid: u32, pid: u32) -> windows::core::Result<bool> {
+    let process_tree = process_tree_snapshot()?;
+
+    Ok(process_is_descendant_of_root(
+        pid,
+        root_pid,
+        &process_tree.parent_process_by_child,
+    ))
+}
+
+fn process_tree_snapshot() -> windows::core::Result<ProcessTreeSnapshot> {
     let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)? };
+    let snapshot = OwnedHandle(snapshot);
     let mut process_entry = PROCESSENTRY32W {
         dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
         ..Default::default()
     };
     let mut child_processes_by_parent = HashMap::<u32, Vec<u32>>::new();
+    let mut parent_process_by_child = HashMap::<u32, u32>::new();
 
     unsafe {
-        if Process32FirstW(snapshot, &mut process_entry).is_ok() {
+        if Process32FirstW(snapshot.get(), &mut process_entry).is_ok() {
             loop {
                 child_processes_by_parent
                     .entry(process_entry.th32ParentProcessID)
                     .or_default()
                     .push(process_entry.th32ProcessID);
+                parent_process_by_child.insert(
+                    process_entry.th32ProcessID,
+                    process_entry.th32ParentProcessID,
+                );
 
-                if Process32NextW(snapshot, &mut process_entry).is_err() {
+                if Process32NextW(snapshot.get(), &mut process_entry).is_err() {
                     break;
                 }
             }
         }
-
-        let _ = CloseHandle(snapshot);
     }
 
-    Ok(collect_descendant_process_ids(
-        root_pid,
-        &child_processes_by_parent,
-    ))
+    Ok(ProcessTreeSnapshot {
+        child_processes_by_parent,
+        parent_process_by_child,
+    })
 }
 
 fn collect_descendant_process_ids(
@@ -214,6 +271,29 @@ fn collect_descendant_process_ids(
     }
 
     descendants
+}
+
+fn process_is_descendant_of_root(
+    pid: u32,
+    root_pid: u32,
+    parent_process_by_child: &HashMap<u32, u32>,
+) -> bool {
+    let mut visited = HashSet::new();
+    let mut current_pid = pid;
+
+    while let Some(parent_pid) = parent_process_by_child.get(&current_pid) {
+        if *parent_pid == root_pid {
+            return true;
+        }
+
+        if *parent_pid == current_pid || !visited.insert(*parent_pid) {
+            return false;
+        }
+
+        current_pid = *parent_pid;
+    }
+
+    false
 }
 
 #[derive(Error, Debug)]

--- a/app/src/terminal/local_tty/windows/mod.rs
+++ b/app/src/terminal/local_tty/windows/mod.rs
@@ -4,11 +4,13 @@ mod environment;
 mod pipes;
 mod proc_thread_attribute_list;
 
+use std::collections::{HashMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::os::windows::ffi::OsStrExt;
 use std::os::windows::io::FromRawHandle as _;
 use std::path::PathBuf;
 
+use anyhow::Context as _;
 use child::ChildExitWatcher;
 pub use conpty_api::ConptyApi;
 use conpty_api::ConptyApiError;
@@ -17,12 +19,16 @@ pub use environment::get_user_and_system_env_variable;
 use thiserror::Error;
 use warpui::{AppContext, SingletonEntity};
 use windows::core::{HSTRING, PCWSTR, PWSTR};
-use windows::Win32::Foundation::{HANDLE, WAIT_OBJECT_0};
+use windows::Win32::Foundation::{CloseHandle, HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT};
 use windows::Win32::System::Console::{COORD, HPCON};
+use windows::Win32::System::Diagnostics::ToolHelp::{
+    CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W, TH32CS_SNAPPROCESS,
+};
 use windows::Win32::System::Threading::{
-    CreateProcessW, WaitForSingleObject, CREATE_BREAKAWAY_FROM_JOB, CREATE_UNICODE_ENVIRONMENT,
-    EXTENDED_STARTUPINFO_PRESENT, PROCESS_CREATION_FLAGS, PROCESS_INFORMATION,
-    STARTF_USESTDHANDLES, STARTUPINFOEXW, STARTUPINFOW,
+    CreateProcessW, OpenProcess, TerminateProcess, WaitForSingleObject, CREATE_BREAKAWAY_FROM_JOB,
+    CREATE_UNICODE_ENVIRONMENT, EXTENDED_STARTUPINFO_PRESENT, PROCESS_CREATION_FLAGS,
+    PROCESS_INFORMATION, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE, STARTF_USESTDHANDLES,
+    STARTUPINFOEXW, STARTUPINFOW,
 };
 
 use super::event_loop::{PTY_TOKEN, SIGNALS_TOKEN};
@@ -75,6 +81,8 @@ unsafe impl Send for PseudoConsoleChild {}
 unsafe impl Sync for PseudoConsoleChild {}
 
 impl PseudoConsoleChild {
+    const TERMINATE_WAIT_MS: u32 = 5_000;
+
     pub fn id(&self) -> u32 {
         self.process_info.dwProcessId
     }
@@ -83,6 +91,129 @@ impl PseudoConsoleChild {
         let wait_event = unsafe { WaitForSingleObject(self.process_info.hProcess, 0) };
         wait_event == WAIT_OBJECT_0
     }
+
+    pub fn kill(&mut self) -> anyhow::Result<()> {
+        if self.is_terminated() {
+            return Ok(());
+        }
+
+        match descendant_process_ids(self.id()) {
+            Ok(descendant_process_ids) => {
+                for pid in descendant_process_ids.iter().rev() {
+                    if let Err(err) = terminate_process_by_pid(*pid) {
+                        log::warn!("Failed to terminate PTY descendant process {pid}: {err:#}");
+                    }
+                }
+            }
+            Err(err) => {
+                log::warn!(
+                    "Failed to enumerate PTY descendant processes for {}: {err:#}",
+                    self.id()
+                );
+            }
+        }
+
+        unsafe {
+            TerminateProcess(self.process_info.hProcess, 1)
+                .map_err(anyhow::Error::from)
+                .with_context(|| format!("Failed to terminate PTY root process {}", self.id()))?;
+        }
+
+        match unsafe { WaitForSingleObject(self.process_info.hProcess, Self::TERMINATE_WAIT_MS) } {
+            WAIT_OBJECT_0 => Ok(()),
+            WAIT_TIMEOUT => {
+                anyhow::bail!(
+                    "Timed out waiting for PTY root process {} to exit",
+                    self.id()
+                )
+            }
+            wait_result => anyhow::bail!(
+                "Unexpected wait result {wait_result:?} while terminating PTY root process {}",
+                self.id()
+            ),
+        }
+    }
+}
+
+impl Drop for PseudoConsoleChild {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = CloseHandle(self.process_info.hThread);
+            let _ = CloseHandle(self.process_info.hProcess);
+        }
+    }
+}
+
+fn terminate_process_by_pid(pid: u32) -> windows::core::Result<()> {
+    unsafe {
+        let process = OpenProcess(PROCESS_TERMINATE | PROCESS_SYNCHRONIZE, false, pid)?;
+        let result = TerminateProcess(process, 1);
+        if result.is_ok() {
+            let wait_result = WaitForSingleObject(process, PseudoConsoleChild::TERMINATE_WAIT_MS);
+            if wait_result == WAIT_TIMEOUT {
+                log::warn!("Timed out waiting for PTY descendant process {pid} to exit");
+            }
+        }
+        let _ = CloseHandle(process);
+        result
+    }
+}
+
+fn descendant_process_ids(root_pid: u32) -> windows::core::Result<Vec<u32>> {
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)? };
+    let mut process_entry = PROCESSENTRY32W {
+        dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+        ..Default::default()
+    };
+    let mut child_processes_by_parent = HashMap::<u32, Vec<u32>>::new();
+
+    unsafe {
+        if Process32FirstW(snapshot, &mut process_entry).is_ok() {
+            loop {
+                child_processes_by_parent
+                    .entry(process_entry.th32ParentProcessID)
+                    .or_default()
+                    .push(process_entry.th32ProcessID);
+
+                if Process32NextW(snapshot, &mut process_entry).is_err() {
+                    break;
+                }
+            }
+        }
+
+        let _ = CloseHandle(snapshot);
+    }
+
+    Ok(collect_descendant_process_ids(
+        root_pid,
+        &child_processes_by_parent,
+    ))
+}
+
+fn collect_descendant_process_ids(
+    root_pid: u32,
+    child_processes_by_parent: &HashMap<u32, Vec<u32>>,
+) -> Vec<u32> {
+    let mut descendants = Vec::new();
+    let mut visited = HashSet::new();
+    let mut stack = child_processes_by_parent
+        .get(&root_pid)
+        .cloned()
+        .unwrap_or_default();
+
+    while let Some(pid) = stack.pop() {
+        if pid == root_pid || !visited.insert(pid) {
+            continue;
+        }
+
+        descendants.push(pid);
+
+        if let Some(children) = child_processes_by_parent.get(&pid) {
+            stack.extend(children.iter().copied());
+        }
+    }
+
+    descendants
 }
 
 #[derive(Error, Debug)]
@@ -326,13 +457,13 @@ fn append_quoted(arg: &OsStr, cmdline: &mut Vec<u16>) {
 }
 
 pub struct Pty {
+    child_exit_watcher: ChildExitWatcher,
     handle: Box<dyn PtyHandle>,
     /// An arbitrary type on Windows used to interact with the psuedoconsole.
     pty_handle: HPCON,
     pipe: mio::windows::NamedPipe,
     token: mio::Token,
     conpty_api: ConptyApi,
-    child_exit_watcher: ChildExitWatcher,
 }
 
 impl Pty {
@@ -358,12 +489,12 @@ impl Pty {
                     handle,
                 )| {
                     let mut pty = Self {
+                        child_exit_watcher,
                         handle,
                         pty_handle,
                         pipe,
                         token: PTY_TOKEN,
                         conpty_api,
-                        child_exit_watcher,
                     };
                     pty.on_resize(&size);
                     pty
@@ -437,8 +568,8 @@ impl EventedPty for Pty {
         }
     }
 
-    fn kill(self) -> anyhow::Result<()> {
-        Ok(())
+    fn kill(mut self) -> anyhow::Result<()> {
+        self.handle.kill()
     }
 }
 
@@ -464,3 +595,7 @@ impl Drop for Pty {
         let _ = self.pipe.disconnect();
     }
 }
+
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod tests;

--- a/app/src/terminal/local_tty/windows/mod_tests.rs
+++ b/app/src/terminal/local_tty/windows/mod_tests.rs
@@ -27,3 +27,36 @@ fn collect_descendant_process_ids_handles_cycles_defensively() {
 
     assert_eq!(descendants, vec![11, 12]);
 }
+
+#[test]
+fn process_is_descendant_of_root_accepts_transitive_descendants() {
+    let parent_process_by_child = HashMap::from([(11, 10), (12, 11), (13, 12)]);
+
+    assert!(process_is_descendant_of_root(
+        13,
+        10,
+        &parent_process_by_child
+    ));
+}
+
+#[test]
+fn process_is_descendant_of_root_rejects_reused_unrelated_pid() {
+    let parent_process_by_child = HashMap::from([(11, 10), (12, 11), (42, 99)]);
+
+    assert!(!process_is_descendant_of_root(
+        42,
+        10,
+        &parent_process_by_child
+    ));
+}
+
+#[test]
+fn process_is_descendant_of_root_handles_cycles_defensively() {
+    let parent_process_by_child = HashMap::from([(11, 12), (12, 11)]);
+
+    assert!(!process_is_descendant_of_root(
+        11,
+        10,
+        &parent_process_by_child
+    ));
+}

--- a/app/src/terminal/local_tty/windows/mod_tests.rs
+++ b/app/src/terminal/local_tty/windows/mod_tests.rs
@@ -1,0 +1,29 @@
+use std::collections::HashMap;
+
+use super::*;
+
+#[test]
+fn collect_descendant_process_ids_walks_full_process_tree_without_root() {
+    let child_processes_by_parent = HashMap::from([
+        (10, vec![11, 12]),
+        (11, vec![13]),
+        (12, vec![14, 15]),
+        (15, vec![16]),
+        (99, vec![100]),
+    ]);
+
+    let mut descendants = collect_descendant_process_ids(10, &child_processes_by_parent);
+    descendants.sort_unstable();
+
+    assert_eq!(descendants, vec![11, 12, 13, 14, 15, 16]);
+}
+
+#[test]
+fn collect_descendant_process_ids_handles_cycles_defensively() {
+    let child_processes_by_parent = HashMap::from([(10, vec![11]), (11, vec![12]), (12, vec![10])]);
+
+    let mut descendants = collect_descendant_process_ids(10, &child_processes_by_parent);
+    descendants.sort_unstable();
+
+    assert_eq!(descendants, vec![11, 12]);
+}


### PR DESCRIPTION
﻿## Description
Fixes Windows local PTY shutdown so Warp terminates the hosted shell process tree before closing the ConPTY handle. Previously the Windows `PtyHandle::kill()` implementation was a no-op, so shutdown fell through to closing the pseudoconsole while foreground processes such as Claude Code could still be attached.

This adds Windows process-tree enumeration for the PTY root process, terminates descendants first, waits briefly for them to exit, then terminates and waits for the root shell process before ConPTY teardown continues. It also closes the shell process/thread handles when the child wrapper is dropped.

## Linked Issue
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Closes #11398

## Testing
- [x] `cargo test -p warp terminal::local_tty::windows --lib`
- [x] `cargo clippy -p warp --tests -- -D warnings`
- [ ] I have manually tested my changes locally with `./script/run`

Manual validation:
- Built and launched local `warp-oss` from `andrekalberer/fix-pwsh-76-conpty-launch`.
- Ran PowerShell 7.6.3 via `pwsh`.
- Started Claude Code.
- Closed Warp while Claude Code was running.
- Reopened the PR build and confirmed no `Unknown Hard Error` and no stuck `Starting shell...`.

Video:
[warp-pr-13416-validation-compressed.webm](https://github.com/user-attachments/assets/c3fa3224-f303-4ce8-8c5e-db7388a257a2)

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fix Windows PTY shutdown cleanup for PowerShell and CLI-agent sessions.



