### PR TITLE
Add per-tool-call labels for TUI tool calls

### DIFF
--- a/app/src/ai/blocklist/mod.rs
+++ b/app/src/ai/blocklist/mod.rs
@@ -46,7 +46,8 @@ pub(crate) use action_model::{
     StartAgentRequestId,
 };
 pub use action_model::{
-    BlocklistAIActionEvent, BlocklistAIActionModel, ShellCommandExecutor, ShellCommandExecutorEvent,
+    AIActionStatus, BlocklistAIActionEvent, BlocklistAIActionModel, ShellCommandExecutor,
+    ShellCommandExecutorEvent,
 };
 #[cfg(any(test, feature = "integration_tests"))]
 pub(crate) use block::model::testing::FakeAIBlockModel;

--- a/app/src/ai/blocklist/mod.rs
+++ b/app/src/ai/blocklist/mod.rs
@@ -37,6 +37,9 @@ pub(super) mod view_util;
 
 pub(crate) use action_model::recording_controller::RecordingController;
 // Consumed by `tui_export` for the `warp_tui` frontend.
+#[cfg_attr(not(feature = "tui"), allow(unused_imports))]
+pub use action_model::AIActionStatus;
+// Consumed by `tui_export` for the `warp_tui` frontend.
 #[cfg(feature = "tui")]
 pub use action_model::RequestFileEditsExecutor;
 #[cfg_attr(target_family = "wasm", allow(unused_imports))]
@@ -46,8 +49,7 @@ pub(crate) use action_model::{
     StartAgentRequestId,
 };
 pub use action_model::{
-    AIActionStatus, BlocklistAIActionEvent, BlocklistAIActionModel, ShellCommandExecutor,
-    ShellCommandExecutorEvent,
+    BlocklistAIActionEvent, BlocklistAIActionModel, ShellCommandExecutor, ShellCommandExecutorEvent,
 };
 #[cfg(any(test, feature = "integration_tests"))]
 pub(crate) use block::model::testing::FakeAIBlockModel;

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -10,7 +10,7 @@ pub use crate::ai::agent::{
     AIAgentActionType, AIAgentExchangeId, AIAgentInput, AIAgentOutput, AIAgentOutputMessage,
     AIAgentOutputMessageType, AIAgentPtyWriteMode, AIAgentText, AIAgentTextSection,
     AskUserQuestionResult, CancellationReason, FileGlobV2Result, GrepResult, MessageId,
-    RequestCommandOutputResult, RequestFileEditsResult, RunAgentsAgentOutcomeKind, RunAgentsResult,
+    RequestCommandOutputResult, RunAgentsAgentOutcomeKind, RunAgentsResult,
     SearchCodebaseFailureReason, SearchCodebaseResult, ServerOutputId, Shared,
     StartAgentExecutionMode, SuggestNewConversationResult, UserQueryMode,
 };

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -6,10 +6,13 @@ pub use crate::ai::agent::conversation::{
 };
 pub use crate::ai::agent::task::TaskId;
 pub use crate::ai::agent::{
-    AIAgentAction, AIAgentActionId, AIAgentActionType, AIAgentExchangeId, AIAgentInput,
-    AIAgentOutput, AIAgentOutputMessage, AIAgentOutputMessageType, AIAgentPtyWriteMode,
-    AIAgentText, AIAgentTextSection, CancellationReason, MessageId, ServerOutputId, Shared,
-    UserQueryMode,
+    AIAgentAction, AIAgentActionId, AIAgentActionResult, AIAgentActionResultType,
+    AIAgentActionType, AIAgentExchangeId, AIAgentInput, AIAgentOutput, AIAgentOutputMessage,
+    AIAgentOutputMessageType, AIAgentPtyWriteMode, AIAgentText, AIAgentTextSection,
+    AskUserQuestionResult, CancellationReason, FileGlobV2Result, GrepResult, MessageId,
+    RequestCommandOutputResult, RequestFileEditsResult, RunAgentsAgentOutcomeKind, RunAgentsResult,
+    SearchCodebaseFailureReason, SearchCodebaseResult, ServerOutputId, Shared,
+    StartAgentExecutionMode, SuggestNewConversationResult, UserQueryMode,
 };
 pub use crate::ai::blocklist::agent_view::{
     AgentViewDisplayMode, AgentViewEntryOrigin, EnterAgentViewError,
@@ -31,10 +34,10 @@ pub use crate::ai::blocklist::history_model::{
     ConversationStatusUpdate,
 };
 pub use crate::ai::blocklist::{
-    BlocklistAIActionEvent, BlocklistAIActionModel, BlocklistAIContextModel, BlocklistAIController,
-    BlocklistAIInputModel, InputConfig, InputModePolicy, InputModePolicyHandle, InputType,
-    InputTypeAutoDetectionSource, PolicyConfigUpdate, RequestFileEditsExecutor,
-    ShellCommandExecutor, ShellCommandExecutorEvent,
+    AIActionStatus, BlocklistAIActionEvent, BlocklistAIActionModel, BlocklistAIContextModel,
+    BlocklistAIController, BlocklistAIInputModel, InputConfig, InputModePolicy,
+    InputModePolicyHandle, InputType, InputTypeAutoDetectionSource, PolicyConfigUpdate,
+    RequestFileEditsExecutor, ShellCommandExecutor, ShellCommandExecutorEvent,
 };
 pub use crate::ai::get_relevant_files::controller::GetRelevantFilesController;
 pub use crate::ai::llms::{LLMId, LLMInfo, LLMPreferences, LLMPreferencesEvent};

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -8,12 +8,15 @@
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Duration;
 
 use itertools::Itertools;
+use parking_lot::FairMutex;
 use warp::tui_export::{
-    AIAgentAction, AIAgentActionId, AIAgentActionType, AIAgentExchangeId, AIAgentOutputMessageType,
-    AIAgentTextSection, AIBlockModel, AIConversationId, BlocklistAIActionModel, MessageId,
+    AIActionStatus, AIAgentAction, AIAgentActionId, AIAgentActionResultType, AIAgentActionType,
+    AIAgentExchangeId, AIAgentOutputMessageType, AIAgentTextSection, AIBlockModel,
+    AIConversationId, BlocklistAIActionModel, MessageId, RequestCommandOutputResult, TerminalModel,
 };
 use warpui_core::elements::tui::{
     TuiChildView, TuiConstraint, TuiContainer, TuiElement, TuiFlex, TuiLayoutContext,
@@ -29,6 +32,7 @@ use crate::agent_block_sections::{
     render_input_section, render_plain_text_section, render_thinking_section,
     render_tool_call_section,
 };
+use crate::tool_call_labels::LrcCommandState;
 
 /// Renderable pieces of an agent block; this will grow as we render richer sections.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -132,6 +136,10 @@ pub(super) struct TuiAIBlock {
     /// Source of truth for per-action execution status, consulted at render
     /// time to pick each tool-call row's text and styling.
     action_model: ModelHandle<BlocklistAIActionModel>,
+    /// The owning surface's terminal model, used to read a command block's
+    /// ground-truth state for agent-monitored commands (see
+    /// [`Self::lrc_command_state`]). Locked only in short, render-time scopes.
+    terminal_model: Arc<FairMutex<TerminalModel>>,
     /// Per-message UI state for this exchange's thinking blocks.
     thinking_states: ThinkingBlockStates,
     /// Every tool-call action id seen in this exchange's output, maintained by
@@ -156,6 +164,7 @@ impl TuiAIBlock {
         exchange_id: AIAgentExchangeId,
         block_model: Rc<dyn AIBlockModel<View = Self>>,
         action_model: ModelHandle<BlocklistAIActionModel>,
+        terminal_model: Arc<FairMutex<TerminalModel>>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
         let mut block = Self {
@@ -163,6 +172,7 @@ impl TuiAIBlock {
             exchange_id,
             block_model,
             action_model: action_model.clone(),
+            terminal_model,
             thinking_states: Default::default(),
             action_ids: HashSet::new(),
             action_views: HashMap::new(),
@@ -236,6 +246,32 @@ impl TuiAIBlock {
     /// [`Self::sync_action_views`], so per-action-event checks stay cheap.
     pub(super) fn renders_action(&self, action_id: &AIAgentActionId) -> bool {
         self.action_ids.contains(action_id)
+    }
+
+    /// Resolves the terminal block's ground-truth state for an agent-monitored
+    /// command whose stored result is a long-running snapshot. The action
+    /// model's result is never updated after the snapshot, so the block itself
+    /// is the source of truth (mirroring the GUI's stale-result override in
+    /// `RequestedCommandView`).
+    fn lrc_command_state(&self, status: Option<&AIActionStatus>) -> Option<LrcCommandState> {
+        let result = status.and_then(AIActionStatus::finished_result)?;
+        let AIAgentActionResultType::RequestCommandOutput(
+            RequestCommandOutputResult::LongRunningCommandSnapshot { block_id, .. },
+        ) = &result.result
+        else {
+            return None;
+        };
+        // Short-lived lock: the TUI layout/render pipeline drops its own model
+        // guards before rich content measures or renders, so this never nests.
+        let model = self.terminal_model.lock();
+        let block = model.block_list().block_with_id(block_id)?;
+        Some(if block.finished() {
+            LrcCommandState::Finished {
+                exit_code: block.exit_code(),
+            }
+        } else {
+            LrcCommandState::StillRunning
+        })
     }
 
     /// Returns this block's wrapped height at the given width.
@@ -348,7 +384,14 @@ impl TuiAIBlock {
                     Some(view) => TuiContainer::new(Box::new(view.render_child())).finish(),
                     None => {
                         let status = self.action_model.as_ref(app).get_action_status(&action.id);
-                        render_tool_call_section(action, status.as_ref(), output_streaming, app)
+                        let lrc_state = self.lrc_command_state(status.as_ref());
+                        render_tool_call_section(
+                            action,
+                            status.as_ref(),
+                            output_streaming,
+                            lrc_state,
+                            app,
+                        )
                     }
                 },
                 TuiAIBlockSection::Thinking {

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -6,7 +6,7 @@
 //! functions live in [`crate::agent_block_sections`].
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::time::Duration;
 
@@ -128,9 +128,17 @@ impl TuiToolCallView {
 pub(super) struct TuiAIBlock {
     conversation_id: AIConversationId,
     exchange_id: AIAgentExchangeId,
-    model: Rc<dyn AIBlockModel<View = Self>>,
+    block_model: Rc<dyn AIBlockModel<View = Self>>,
+    /// Source of truth for per-action execution status, consulted at render
+    /// time to pick each tool-call row's text and styling.
+    action_model: ModelHandle<BlocklistAIActionModel>,
     /// Per-message UI state for this exchange's thinking blocks.
     thinking_states: ThinkingBlockStates,
+    /// Every tool-call action id seen in this exchange's output, maintained by
+    /// [`Self::sync_action_views`]. Mirrors the GUI `AIBlock`'s
+    /// `requested_action_ids` so per-action-event lookups are a cheap set
+    /// membership check instead of an output-message scan.
+    action_ids: HashSet<AIAgentActionId>,
     /// Stateful per-action child views, keyed by tool-call action id.
     /// Populated by [`Self::sync_action_views`]; stateless tool calls never
     /// get entries here.
@@ -146,19 +154,21 @@ impl TuiAIBlock {
     pub(super) fn new(
         conversation_id: AIConversationId,
         exchange_id: AIAgentExchangeId,
-        model: Rc<dyn AIBlockModel<View = Self>>,
+        block_model: Rc<dyn AIBlockModel<View = Self>>,
         action_model: ModelHandle<BlocklistAIActionModel>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
         let mut block = Self {
             conversation_id,
             exchange_id,
-            model,
+            block_model,
+            action_model: action_model.clone(),
             thinking_states: Default::default(),
+            action_ids: HashSet::new(),
             action_views: HashMap::new(),
         };
         block.sync_action_views(&action_model, ctx);
-        block.model.on_updated_output(
+        block.block_model.on_updated_output(
             Box::new(move |me, ctx| {
                 me.sync_action_views(&action_model, ctx);
             }),
@@ -167,31 +177,27 @@ impl TuiAIBlock {
         block
     }
 
-    /// Creates child views for stateful tool calls that don't have one yet.
-    /// Rendering can't create views since it only sees `&AppContext`.
+    /// Records the exchange's tool-call action ids and creates child views
+    /// for stateful tool calls that don't have one yet. Rendering can't
+    /// create views since it only sees `&AppContext`.
     fn sync_action_views(
         &mut self,
         action_model: &ModelHandle<BlocklistAIActionModel>,
         ctx: &mut ViewContext<Self>,
     ) {
-        let status = self.model.status(ctx);
-        let file_edit_action_ids: Vec<AIAgentActionId> = status
-            .output_to_render()
-            .map(|output| {
-                output
-                    .get()
-                    .messages
-                    .iter()
-                    .filter_map(|message| {
-                        let AIAgentOutputMessageType::Action(action) = &message.message else {
-                            return None;
-                        };
-                        matches!(action.action, AIAgentActionType::RequestFileEdits { .. })
-                            .then(|| action.id.clone())
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
+        let status = self.block_model.status(ctx);
+        let mut file_edit_action_ids = Vec::new();
+        if let Some(output) = status.output_to_render() {
+            for message in &output.get().messages {
+                let AIAgentOutputMessageType::Action(action) = &message.message else {
+                    continue;
+                };
+                self.action_ids.insert(action.id.clone());
+                if matches!(action.action, AIAgentActionType::RequestFileEdits { .. }) {
+                    file_edit_action_ids.push(action.id.clone());
+                }
+            }
+        }
 
         for action_id in file_edit_action_ids {
             if self.action_views.contains_key(&action_id) {
@@ -205,14 +211,14 @@ impl TuiAIBlock {
         }
     }
 
-    /// Replaces the backing model when the same exchange is reassigned.
+    /// Replaces the backing block model when the same exchange is reassigned.
     pub(super) fn replace_model(
         &mut self,
         conversation_id: AIConversationId,
-        model: Rc<dyn AIBlockModel<View = Self>>,
+        block_model: Rc<dyn AIBlockModel<View = Self>>,
     ) {
         self.conversation_id = conversation_id;
-        self.model = model;
+        self.block_model = block_model;
     }
 
     /// Returns the conversation that currently owns this agent block.
@@ -223,6 +229,13 @@ impl TuiAIBlock {
     /// Returns the exchange rendered by this agent block.
     pub(super) fn exchange_id(&self) -> AIAgentExchangeId {
         self.exchange_id
+    }
+
+    /// Returns whether this block's output contains the tool call with the
+    /// given action id. A set lookup over ids recorded by
+    /// [`Self::sync_action_views`], so per-action-event checks stay cheap.
+    pub(super) fn renders_action(&self, action_id: &AIAgentActionId) -> bool {
+        self.action_ids.contains(action_id)
     }
 
     /// Returns this block's wrapped height at the given width.
@@ -248,7 +261,7 @@ impl TuiAIBlock {
     fn sections(&self, app: &AppContext) -> Vec<TuiAIBlockSection> {
         let mut sections = Vec::new();
         let input = self
-            .model
+            .block_model
             .inputs_to_render(app)
             .iter()
             .filter_map(|input| input.display_query())
@@ -258,7 +271,7 @@ impl TuiAIBlock {
         }
 
         // Walk output messages in order so tool-call rows interleave with text.
-        if let Some(output) = self.model.status(app).output_to_render() {
+        if let Some(output) = self.block_model.status(app).output_to_render() {
             let output = output.get();
             for message in &output.messages {
                 match &message.message {
@@ -323,6 +336,7 @@ impl TuiAIBlock {
 
     /// Builds this block's generic TUI element tree.
     fn render_element(&self, app: &AppContext) -> Box<dyn TuiElement> {
+        let output_streaming = self.block_model.status(app).is_streaming();
         let mut column = TuiFlex::column();
         for section in &self.sections(app) {
             let element = match section {
@@ -332,7 +346,10 @@ impl TuiAIBlock {
                 // other tool call stays a pure render fn.
                 TuiAIBlockSection::ToolCall(action) => match self.action_views.get(&action.id) {
                     Some(view) => TuiContainer::new(Box::new(view.render_child())).finish(),
-                    None => render_tool_call_section(app),
+                    None => {
+                        let status = self.action_model.as_ref(app).get_action_status(&action.id);
+                        render_tool_call_section(action, status.as_ref(), output_streaming, app)
+                    }
                 },
                 TuiAIBlockSection::Thinking {
                     message_id,

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -29,10 +29,10 @@ use warpui_core::{
 
 use super::tui_file_edits_view::TuiFileEditsView;
 use crate::agent_block_sections::{
-    render_input_section, render_plain_text_section, render_thinking_section,
-    render_tool_call_section,
+    render_fallback_tool_call_section, render_input_section, render_plain_text_section,
+    render_thinking_section,
 };
-use crate::tool_call_labels::CommandBlockState;
+use crate::tool_call_labels::{CommandBlockState, ResolvedCommandBlock};
 
 /// Renderable pieces of an agent block; this will grow as we render richer sections.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -248,17 +248,18 @@ impl TuiAIBlock {
         self.action_ids.contains(action_id)
     }
 
-    /// Resolves the ground-truth state of the terminal block backing a
-    /// shell-command tool call. When a block exists it supersedes the stored
-    /// action status/result for execution states (mirroring the GUI's
-    /// `RequestedCommandView`, which derives the row's icon and expandability
-    /// from the block whenever one exists); the stored result only covers
-    /// rows without a local block (e.g. viewers, restored sessions).
-    fn command_block_state(
+    /// Resolves the terminal block backing a shell-command tool call into
+    /// its ground-truth state and executed command. When a block exists it
+    /// supersedes the stored action status/result for execution states
+    /// (mirroring the GUI's `RequestedCommandView`, which derives the row's
+    /// icon and expandability from the block whenever one exists); the
+    /// stored result only covers rows without a local block (e.g. viewers,
+    /// restored sessions).
+    fn resolve_command_block(
         &self,
         action: &AIAgentAction,
         status: Option<&AIActionStatus>,
-    ) -> Option<CommandBlockState> {
+    ) -> Option<ResolvedCommandBlock> {
         if !action.action.is_request_command_output() {
             return None;
         }
@@ -281,12 +282,22 @@ impl TuiAIBlock {
         let block = block_list
             .block_for_ai_action_id(&action.id)
             .or_else(|| snapshot_block_id.and_then(|id| block_list.block_with_id(id)))?;
-        Some(if block.finished() {
+        // The block's command is the one actually executed (the streamed
+        // command can be edited before acceptance), so surface it for display.
+        let command = block
+            .command_with_secrets_obfuscated(false)
+            .trim()
+            .to_owned();
+        let state = if block.finished() {
             CommandBlockState::Finished {
                 exit_code: block.exit_code(),
             }
         } else {
             CommandBlockState::Running
+        };
+        Some(ResolvedCommandBlock {
+            command: (!command.is_empty()).then_some(command),
+            state,
         })
     }
 
@@ -400,12 +411,12 @@ impl TuiAIBlock {
                     Some(view) => TuiContainer::new(Box::new(view.render_child())).finish(),
                     None => {
                         let status = self.action_model.as_ref(app).get_action_status(&action.id);
-                        let block_state = self.command_block_state(action, status.as_ref());
-                        render_tool_call_section(
+                        let block = self.resolve_command_block(action, status.as_ref());
+                        render_fallback_tool_call_section(
                             action,
                             status.as_ref(),
                             output_streaming,
-                            block_state,
+                            block.as_ref(),
                             app,
                         )
                     }

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -32,7 +32,7 @@ use crate::agent_block_sections::{
     render_input_section, render_plain_text_section, render_thinking_section,
     render_tool_call_section,
 };
-use crate::tool_call_labels::LrcCommandState;
+use crate::tool_call_labels::CommandBlockState;
 
 /// Renderable pieces of an agent block; this will grow as we render richer sections.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -248,29 +248,45 @@ impl TuiAIBlock {
         self.action_ids.contains(action_id)
     }
 
-    /// Resolves the terminal block's ground-truth state for an agent-monitored
-    /// command whose stored result is a long-running snapshot. The action
-    /// model's result is never updated after the snapshot, so the block itself
-    /// is the source of truth (mirroring the GUI's stale-result override in
-    /// `RequestedCommandView`).
-    fn lrc_command_state(&self, status: Option<&AIActionStatus>) -> Option<LrcCommandState> {
-        let result = status.and_then(AIActionStatus::finished_result)?;
-        let AIAgentActionResultType::RequestCommandOutput(
-            RequestCommandOutputResult::LongRunningCommandSnapshot { block_id, .. },
-        ) = &result.result
-        else {
+    /// Resolves the ground-truth state of the terminal block backing a
+    /// shell-command tool call. When a block exists it supersedes the stored
+    /// action status/result for execution states (mirroring the GUI's
+    /// `RequestedCommandView`, which derives the row's icon and expandability
+    /// from the block whenever one exists); the stored result only covers
+    /// rows without a local block (e.g. viewers, restored sessions).
+    fn command_block_state(
+        &self,
+        action: &AIAgentAction,
+        status: Option<&AIActionStatus>,
+    ) -> Option<CommandBlockState> {
+        if !action.action.is_request_command_output() {
             return None;
+        }
+        // Long-running snapshot results carry the block id directly; used as
+        // a fallback when the block can't be found by agent-interaction
+        // metadata.
+        let snapshot_block_id = match status
+            .and_then(AIActionStatus::finished_result)
+            .map(|result| &result.result)
+        {
+            Some(AIAgentActionResultType::RequestCommandOutput(
+                RequestCommandOutputResult::LongRunningCommandSnapshot { block_id, .. },
+            )) => Some(block_id),
+            _ => None,
         };
         // Short-lived lock: the TUI layout/render pipeline drops its own model
         // guards before rich content measures or renders, so this never nests.
         let model = self.terminal_model.lock();
-        let block = model.block_list().block_with_id(block_id)?;
+        let block_list = model.block_list();
+        let block = block_list
+            .block_for_ai_action_id(&action.id)
+            .or_else(|| snapshot_block_id.and_then(|id| block_list.block_with_id(id)))?;
         Some(if block.finished() {
-            LrcCommandState::Finished {
+            CommandBlockState::Finished {
                 exit_code: block.exit_code(),
             }
         } else {
-            LrcCommandState::StillRunning
+            CommandBlockState::Running
         })
     }
 
@@ -384,12 +400,12 @@ impl TuiAIBlock {
                     Some(view) => TuiContainer::new(Box::new(view.render_child())).finish(),
                     None => {
                         let status = self.action_model.as_ref(app).get_action_status(&action.id);
-                        let lrc_state = self.lrc_command_state(status.as_ref());
+                        let block_state = self.command_block_state(action, status.as_ref());
                         render_tool_call_section(
                             action,
                             status.as_ref(),
                             output_streaming,
-                            lrc_state,
+                            block_state,
                             app,
                         )
                     }

--- a/crates/warp_tui/src/agent_block_sections.rs
+++ b/crates/warp_tui/src/agent_block_sections.rs
@@ -7,12 +7,13 @@
 
 use std::time::Duration;
 
-use warp::tui_export::{format_elapsed_seconds, MessageId};
+use warp::tui_export::{format_elapsed_seconds, AIActionStatus, AIAgentAction, MessageId};
 use warpui_core::elements::tui::{TuiContainer, TuiElement, TuiFlex, TuiText};
 use warpui_core::elements::CrossAxisAlignment;
 use warpui_core::AppContext;
 
 use crate::agent_block::ThinkingBlockStates;
+use crate::tool_call_labels::{tool_call_display_state, tool_call_label, ToolCallDisplayState};
 use crate::tui_builder::TuiUiBuilder;
 
 const INPUT_PREFIX: &str = "≫ ";
@@ -48,11 +49,28 @@ pub(crate) fn render_plain_text_section(text: &str, app: &AppContext) -> Box<dyn
         .finish()
 }
 
-/// Renders a dim status row standing in for an agent tool call.
-// TODO: add richer rendering for each tool call type. This is just a rendering stub to build off of.
-pub(crate) fn render_tool_call_section(app: &AppContext) -> Box<dyn TuiElement> {
-    TuiText::new("executed a tool call")
-        .with_style(TuiUiBuilder::from_app(app).dim_text_style())
+/// Renders a one-line status row for an agent tool call: per-tool, per-state
+/// text with de-emphasized styling for non-final states and cancellations,
+/// and error styling for failures. `output_streaming` marks tool calls whose
+/// arguments are still streaming in (see `ToolCallDisplayState::Constructing`).
+pub(crate) fn render_tool_call_section(
+    action: &AIAgentAction,
+    status: Option<&AIActionStatus>,
+    output_streaming: bool,
+    app: &AppContext,
+) -> Box<dyn TuiElement> {
+    let builder = TuiUiBuilder::from_app(app);
+    let style = match tool_call_display_state(status, output_streaming) {
+        ToolCallDisplayState::Constructing
+        | ToolCallDisplayState::Pending
+        | ToolCallDisplayState::AwaitingApproval
+        | ToolCallDisplayState::Running
+        | ToolCallDisplayState::Cancelled => builder.dim_text_style(),
+        ToolCallDisplayState::Succeeded => builder.muted_text_style(),
+        ToolCallDisplayState::Failed => builder.error_text_style(),
+    };
+    TuiText::new(tool_call_label(action, status, output_streaming))
+        .with_style(style)
         .finish()
 }
 

--- a/crates/warp_tui/src/agent_block_sections.rs
+++ b/crates/warp_tui/src/agent_block_sections.rs
@@ -14,7 +14,8 @@ use warpui_core::AppContext;
 
 use crate::agent_block::ThinkingBlockStates;
 use crate::tool_call_labels::{
-    tool_call_display_state, tool_call_label, CommandBlockState, ToolCallDisplayState,
+    tool_call_display_state, tool_call_glyph, tool_call_label, CommandBlockState,
+    ToolCallDisplayState,
 };
 use crate::tui_builder::TuiUiBuilder;
 
@@ -51,12 +52,15 @@ pub(crate) fn render_plain_text_section(text: &str, app: &AppContext) -> Box<dyn
         .finish()
 }
 
-/// Renders a one-line status row for an agent tool call: per-tool, per-state
-/// text with de-emphasized styling for non-final states and cancellations,
-/// and error styling for failures. `output_streaming` marks tool calls whose
-/// arguments are still streaming in (see `ToolCallDisplayState::Constructing`);
-/// `block_state` carries the terminal block's ground truth for shell-command
-/// tool calls (see `CommandBlockState`).
+/// Renders a status row for an agent tool call: a colored state glyph in a
+/// two-cell gutter (mirroring the GUI's inline action icons), then per-tool,
+/// per-state label text that wraps with a hanging indent under itself. State
+/// lives in the glyph, so labels keep the normal foreground except in-flight
+/// rows, which stay dim until execution starts. `output_streaming` marks tool
+/// calls whose arguments are still streaming in (see
+/// `ToolCallDisplayState::Constructing`); `block_state` carries the terminal
+/// block's ground truth for shell-command tool calls (see
+/// `CommandBlockState`).
 pub(crate) fn render_tool_call_section(
     action: &AIAgentAction,
     status: Option<&AIActionStatus>,
@@ -65,23 +69,37 @@ pub(crate) fn render_tool_call_section(
     app: &AppContext,
 ) -> Box<dyn TuiElement> {
     let builder = TuiUiBuilder::from_app(app);
-    let style = match tool_call_display_state(status, output_streaming, block_state) {
-        ToolCallDisplayState::Constructing
-        | ToolCallDisplayState::Pending
-        | ToolCallDisplayState::AwaitingApproval
-        | ToolCallDisplayState::Running
-        | ToolCallDisplayState::Cancelled => builder.dim_text_style(),
-        ToolCallDisplayState::Succeeded => builder.muted_text_style(),
+    let state = tool_call_display_state(status, output_streaming, block_state);
+    let glyph_style = match state {
+        ToolCallDisplayState::Constructing | ToolCallDisplayState::Pending => {
+            builder.dim_text_style()
+        }
+        ToolCallDisplayState::AwaitingApproval | ToolCallDisplayState::Running => {
+            builder.attention_glyph_style()
+        }
+        ToolCallDisplayState::Succeeded => builder.success_glyph_style(),
         ToolCallDisplayState::Failed => builder.error_text_style(),
+        ToolCallDisplayState::Cancelled => builder.muted_text_style(),
     };
-    TuiText::new(tool_call_label(
-        action,
-        status,
-        output_streaming,
-        block_state,
-    ))
-    .with_style(style)
-    .finish()
+    let label_style = match state {
+        ToolCallDisplayState::Constructing | ToolCallDisplayState::Pending => {
+            builder.dim_text_style()
+        }
+        ToolCallDisplayState::AwaitingApproval
+        | ToolCallDisplayState::Running
+        | ToolCallDisplayState::Succeeded
+        | ToolCallDisplayState::Failed
+        | ToolCallDisplayState::Cancelled => builder.primary_text_style(),
+    };
+    let label = tool_call_label(action, status, output_streaming, block_state);
+    TuiFlex::row()
+        .child(
+            TuiText::new(format!("{} ", tool_call_glyph(state)))
+                .with_style(glyph_style)
+                .finish(),
+        )
+        .child(TuiText::new(label).with_style(label_style).finish())
+        .finish()
 }
 
 /// Renders a reasoning message as a collapsible thinking block. The header

--- a/crates/warp_tui/src/agent_block_sections.rs
+++ b/crates/warp_tui/src/agent_block_sections.rs
@@ -14,7 +14,7 @@ use warpui_core::AppContext;
 
 use crate::agent_block::ThinkingBlockStates;
 use crate::tool_call_labels::{
-    tool_call_display_state, tool_call_label, LrcCommandState, ToolCallDisplayState,
+    tool_call_display_state, tool_call_label, CommandBlockState, ToolCallDisplayState,
 };
 use crate::tui_builder::TuiUiBuilder;
 
@@ -55,17 +55,17 @@ pub(crate) fn render_plain_text_section(text: &str, app: &AppContext) -> Box<dyn
 /// text with de-emphasized styling for non-final states and cancellations,
 /// and error styling for failures. `output_streaming` marks tool calls whose
 /// arguments are still streaming in (see `ToolCallDisplayState::Constructing`);
-/// `lrc_state` carries the terminal block's ground truth for agent-monitored
-/// commands (see `LrcCommandState`).
+/// `block_state` carries the terminal block's ground truth for shell-command
+/// tool calls (see `CommandBlockState`).
 pub(crate) fn render_tool_call_section(
     action: &AIAgentAction,
     status: Option<&AIActionStatus>,
     output_streaming: bool,
-    lrc_state: Option<LrcCommandState>,
+    block_state: Option<CommandBlockState>,
     app: &AppContext,
 ) -> Box<dyn TuiElement> {
     let builder = TuiUiBuilder::from_app(app);
-    let style = match tool_call_display_state(status, output_streaming, lrc_state) {
+    let style = match tool_call_display_state(status, output_streaming, block_state) {
         ToolCallDisplayState::Constructing
         | ToolCallDisplayState::Pending
         | ToolCallDisplayState::AwaitingApproval
@@ -74,9 +74,14 @@ pub(crate) fn render_tool_call_section(
         ToolCallDisplayState::Succeeded => builder.muted_text_style(),
         ToolCallDisplayState::Failed => builder.error_text_style(),
     };
-    TuiText::new(tool_call_label(action, status, output_streaming, lrc_state))
-        .with_style(style)
-        .finish()
+    TuiText::new(tool_call_label(
+        action,
+        status,
+        output_streaming,
+        block_state,
+    ))
+    .with_style(style)
+    .finish()
 }
 
 /// Renders a reasoning message as a collapsible thinking block. The header

--- a/crates/warp_tui/src/agent_block_sections.rs
+++ b/crates/warp_tui/src/agent_block_sections.rs
@@ -13,7 +13,9 @@ use warpui_core::elements::CrossAxisAlignment;
 use warpui_core::AppContext;
 
 use crate::agent_block::ThinkingBlockStates;
-use crate::tool_call_labels::{tool_call_display_state, tool_call_label, ToolCallDisplayState};
+use crate::tool_call_labels::{
+    tool_call_display_state, tool_call_label, LrcCommandState, ToolCallDisplayState,
+};
 use crate::tui_builder::TuiUiBuilder;
 
 const INPUT_PREFIX: &str = "≫ ";
@@ -52,15 +54,18 @@ pub(crate) fn render_plain_text_section(text: &str, app: &AppContext) -> Box<dyn
 /// Renders a one-line status row for an agent tool call: per-tool, per-state
 /// text with de-emphasized styling for non-final states and cancellations,
 /// and error styling for failures. `output_streaming` marks tool calls whose
-/// arguments are still streaming in (see `ToolCallDisplayState::Constructing`).
+/// arguments are still streaming in (see `ToolCallDisplayState::Constructing`);
+/// `lrc_state` carries the terminal block's ground truth for agent-monitored
+/// commands (see `LrcCommandState`).
 pub(crate) fn render_tool_call_section(
     action: &AIAgentAction,
     status: Option<&AIActionStatus>,
     output_streaming: bool,
+    lrc_state: Option<LrcCommandState>,
     app: &AppContext,
 ) -> Box<dyn TuiElement> {
     let builder = TuiUiBuilder::from_app(app);
-    let style = match tool_call_display_state(status, output_streaming) {
+    let style = match tool_call_display_state(status, output_streaming, lrc_state) {
         ToolCallDisplayState::Constructing
         | ToolCallDisplayState::Pending
         | ToolCallDisplayState::AwaitingApproval
@@ -69,7 +74,7 @@ pub(crate) fn render_tool_call_section(
         ToolCallDisplayState::Succeeded => builder.muted_text_style(),
         ToolCallDisplayState::Failed => builder.error_text_style(),
     };
-    TuiText::new(tool_call_label(action, status, output_streaming))
+    TuiText::new(tool_call_label(action, status, output_streaming, lrc_state))
         .with_style(style)
         .finish()
 }

--- a/crates/warp_tui/src/agent_block_sections.rs
+++ b/crates/warp_tui/src/agent_block_sections.rs
@@ -14,7 +14,7 @@ use warpui_core::AppContext;
 
 use crate::agent_block::ThinkingBlockStates;
 use crate::tool_call_labels::{
-    tool_call_display_state, tool_call_glyph, tool_call_label, CommandBlockState,
+    tool_call_display_state, tool_call_glyph, tool_call_label, ResolvedCommandBlock,
     ToolCallDisplayState,
 };
 use crate::tui_builder::TuiUiBuilder;
@@ -52,24 +52,26 @@ pub(crate) fn render_plain_text_section(text: &str, app: &AppContext) -> Box<dyn
         .finish()
 }
 
-/// Renders a status row for an agent tool call: a colored state glyph in a
-/// two-cell gutter (mirroring the GUI's inline action icons), then per-tool,
-/// per-state label text that wraps with a hanging indent under itself. State
-/// lives in the glyph, so labels keep the normal foreground except in-flight
-/// rows, which stay dim until execution starts. `output_streaming` marks tool
-/// calls whose arguments are still streaming in (see
-/// `ToolCallDisplayState::Constructing`); `block_state` carries the terminal
-/// block's ground truth for shell-command tool calls (see
-/// `CommandBlockState`).
-pub(crate) fn render_tool_call_section(
+/// Renders the fallback plain-text status row for an agent tool call, used
+/// for every tool call without a richer registered child view (the GUI's
+/// view-based action rendering has no TUI equivalent for these yet): a
+/// colored state glyph in a two-cell gutter (mirroring the GUI's inline
+/// action icons), then per-tool, per-state label text that wraps with a
+/// hanging indent under itself. State lives in the glyph, so labels keep the
+/// normal foreground except in-flight rows, which stay dim until execution
+/// starts. `output_streaming` marks tool calls whose arguments are still
+/// streaming in (see `ToolCallDisplayState::Constructing`); `block` carries
+/// the terminal block's ground truth for shell-command tool calls (see
+/// `ResolvedCommandBlock`).
+pub(crate) fn render_fallback_tool_call_section(
     action: &AIAgentAction,
     status: Option<&AIActionStatus>,
     output_streaming: bool,
-    block_state: Option<CommandBlockState>,
+    block: Option<&ResolvedCommandBlock>,
     app: &AppContext,
 ) -> Box<dyn TuiElement> {
     let builder = TuiUiBuilder::from_app(app);
-    let state = tool_call_display_state(status, output_streaming, block_state);
+    let state = tool_call_display_state(status, output_streaming, block.map(|block| block.state));
     let glyph_style = match state {
         ToolCallDisplayState::Constructing | ToolCallDisplayState::Pending => {
             builder.dim_text_style()
@@ -91,7 +93,7 @@ pub(crate) fn render_tool_call_section(
         | ToolCallDisplayState::Failed
         | ToolCallDisplayState::Cancelled => builder.primary_text_style(),
     };
-    let label = tool_call_label(action, status, output_streaming, block_state);
+    let label = tool_call_label(action, status, output_streaming, block);
     TuiFlex::row()
         .child(
             TuiText::new(format!("{} ", tool_call_glyph(state)))

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -184,7 +184,7 @@ fn agent_block_renders_tool_calls_in_message_order() {
                     .into_iter()
                     .map(|line| line.trim_end().to_owned())
                     .collect::<Vec<_>>(),
-                vec!["before", "", "executed a tool call", "", "after", ""],
+                vec!["before", "", "Init project", "", "after", ""],
             );
             assert_eq!(
                 frame.buffer[(0, 2)].fg,
@@ -234,7 +234,7 @@ fn agent_block_renders_multiple_tool_calls_in_order() {
                     .into_iter()
                     .map(|line| line.trim_end().to_owned())
                     .collect::<Vec<_>>(),
-                vec!["executed a tool call", "", "executed a tool call", ""],
+                vec!["Init project", "", "Init project", ""],
             );
         });
     });

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -4,11 +4,11 @@ use std::time::Duration;
 
 use parking_lot::FairMutex;
 use warp::tui_export::{
-    AIAgentAction, AIAgentActionId, AIAgentActionType, AIAgentExchangeId, AIAgentInput,
-    AIAgentOutput, AIAgentOutputMessage, AIAgentOutputMessageType, AIAgentText, AIAgentTextSection,
-    AIBlockModel, AIBlockOutputStatus, AIConversationId, AIRequestType, Appearance, LLMId,
-    MessageId, OutputStatusUpdateCallback, ServerOutputId, Shared, TaskId, TerminalModel,
-    UserQueryMode,
+    AIActionStatus, AIAgentAction, AIAgentActionId, AIAgentActionResult, AIAgentActionResultType,
+    AIAgentActionType, AIAgentExchangeId, AIAgentInput, AIAgentOutput, AIAgentOutputMessage,
+    AIAgentOutputMessageType, AIAgentText, AIAgentTextSection, AIBlockModel, AIBlockOutputStatus,
+    AIConversationId, AIRequestType, Appearance, LLMId, MessageId, OutputStatusUpdateCallback,
+    RequestCommandOutputResult, ServerOutputId, Shared, TaskId, TerminalModel, UserQueryMode,
 };
 use warp_core::ui::color::blend::Blend;
 use warp_core::ui::theme::Fill as ThemeFill;
@@ -24,6 +24,7 @@ use warpui_core::presenter::tui::TuiPresenter;
 use warpui_core::{App, AppContext, EntityId, EntityIdMap, ViewContext, ViewHandle};
 
 use super::{TuiAIBlock, TuiAIBlockSection};
+use crate::agent_block_sections::render_tool_call_section;
 use crate::test_fixtures::{add_test_action_model, TestHostView};
 
 #[test]
@@ -187,13 +188,19 @@ fn agent_block_renders_tool_calls_in_message_order() {
                     .into_iter()
                     .map(|line| line.trim_end().to_owned())
                     .collect::<Vec<_>>(),
-                vec!["before", "", "Init project", "", "after", ""],
+                vec!["before", "", "○ Init project", "", "after", ""],
             );
+            // A pending tool call renders a dim grey glyph and a dim label.
             assert_eq!(
                 frame.buffer[(0, 2)].fg,
                 expected_tool_call_text_color(app_ctx)
             );
             assert!(frame.buffer[(0, 2)].modifier.contains(Modifier::DIM));
+            assert_eq!(
+                frame.buffer[(2, 2)].fg,
+                expected_tool_call_text_color(app_ctx)
+            );
+            assert!(frame.buffer[(2, 2)].modifier.contains(Modifier::DIM));
         });
     });
 }
@@ -237,8 +244,89 @@ fn agent_block_renders_multiple_tool_calls_in_order() {
                     .into_iter()
                     .map(|line| line.trim_end().to_owned())
                     .collect::<Vec<_>>(),
-                vec!["Init project", "", "Init project", ""],
+                vec!["○ Init project", "", "○ Init project", ""],
             );
+        });
+    });
+}
+
+#[test]
+fn tool_call_row_glyph_and_colors_reflect_state() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        app.read(|app_ctx| {
+            let theme = Appearance::as_ref(app_ctx).theme();
+            let green: Color =
+                CoreFill::from(ThemeFill::from(theme.terminal_colors().normal.green)).into();
+            let yellow: Color =
+                CoreFill::from(ThemeFill::from(theme.terminal_colors().normal.yellow)).into();
+            let red: Color =
+                CoreFill::from(ThemeFill::from(theme.terminal_colors().normal.red)).into();
+            let white: Color =
+                CoreFill::from(ThemeFill::from(theme.terminal_colors().normal.white)).into();
+            let grey: Color =
+                CoreFill::from(ThemeFill::from(theme.terminal_colors().bright.black)).into();
+
+            let render = |action: &AIAgentAction, status: Option<&AIActionStatus>| {
+                let mut presenter = TuiPresenter::new();
+                presenter.present_element(
+                    render_tool_call_section(action, status, false, None, app_ctx),
+                    TuiRect::new(0, 0, 40, 1),
+                    app_ctx,
+                )
+            };
+
+            // Succeeded: green check in the gutter, normal-foreground label.
+            let action = test_action("action-1");
+            let succeeded = finished_status(&action, AIAgentActionResultType::InitProject);
+            let frame = render(&action, Some(&succeeded));
+            assert_eq!(
+                frame.buffer.to_lines()[0].trim_end(),
+                "✓ Init project — done"
+            );
+            assert_eq!(frame.buffer[(0, 0)].fg, green);
+            assert_eq!(frame.buffer[(2, 0)].fg, white);
+            assert!(!frame.buffer[(2, 0)].modifier.contains(Modifier::DIM));
+
+            // Running: yellow dot.
+            let frame = render(&action, Some(&AIActionStatus::RunningAsync));
+            assert_eq!(frame.buffer.to_lines()[0].trim_end(), "● Init project…");
+            assert_eq!(frame.buffer[(0, 0)].fg, yellow);
+            assert_eq!(frame.buffer[(2, 0)].fg, white);
+
+            // Failed (denylisted command): red x, normal-foreground label.
+            let command_action = test_command_action("action-2", "git status");
+            let failed = finished_status(
+                &command_action,
+                AIAgentActionResultType::RequestCommandOutput(
+                    RequestCommandOutputResult::Denylisted {
+                        command: "git status".to_owned(),
+                    },
+                ),
+            );
+            let frame = render(&command_action, Some(&failed));
+            assert_eq!(
+                frame.buffer.to_lines()[0].trim_end(),
+                "✗ `git status` denied (denylisted)"
+            );
+            assert_eq!(frame.buffer[(0, 0)].fg, red);
+            assert_eq!(frame.buffer[(2, 0)].fg, white);
+
+            // Cancelled: grey block, normal-foreground label.
+            let cancelled = finished_status(
+                &command_action,
+                AIAgentActionResultType::RequestCommandOutput(
+                    RequestCommandOutputResult::CancelledBeforeExecution,
+                ),
+            );
+            let frame = render(&command_action, Some(&cancelled));
+            assert_eq!(
+                frame.buffer.to_lines()[0].trim_end(),
+                "■ Cancelled `git status`"
+            );
+            assert_eq!(frame.buffer[(0, 0)].fg, grey);
+            assert!(!frame.buffer[(0, 0)].modifier.contains(Modifier::DIM));
+            assert_eq!(frame.buffer[(2, 0)].fg, white);
         });
     });
 }
@@ -626,6 +714,33 @@ fn test_action(id: &str) -> AIAgentAction {
         action: AIAgentActionType::InitProject,
         requires_result: true,
     }
+}
+
+/// Builds a shell-command tool-call action.
+fn test_command_action(id: &str, command: &str) -> AIAgentAction {
+    AIAgentAction {
+        id: AIAgentActionId::from(id.to_owned()),
+        task_id: TaskId::new("task-1".to_owned()),
+        action: AIAgentActionType::RequestCommandOutput {
+            command: command.to_owned(),
+            is_read_only: None,
+            is_risky: None,
+            wait_until_completion: true,
+            uses_pager: None,
+            rationale: None,
+            citations: Vec::new(),
+        },
+        requires_result: true,
+    }
+}
+
+/// Builds a `Finished` status carrying `result` for `action`.
+fn finished_status(action: &AIAgentAction, result: AIAgentActionResultType) -> AIActionStatus {
+    AIActionStatus::Finished(Arc::new(AIAgentActionResult {
+        id: action.id.clone(),
+        task_id: action.task_id.clone(),
+        result,
+    }))
 }
 
 /// Builds an output status with a single reasoning message (id `reasoning-1`)

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -24,7 +24,7 @@ use warpui_core::presenter::tui::TuiPresenter;
 use warpui_core::{App, AppContext, EntityId, EntityIdMap, ViewContext, ViewHandle};
 
 use super::{TuiAIBlock, TuiAIBlockSection};
-use crate::agent_block_sections::render_tool_call_section;
+use crate::agent_block_sections::render_fallback_tool_call_section;
 use crate::test_fixtures::{add_test_action_model, TestHostView};
 
 #[test]
@@ -270,7 +270,7 @@ fn tool_call_row_glyph_and_colors_reflect_state() {
             let render = |action: &AIAgentAction, status: Option<&AIActionStatus>| {
                 let mut presenter = TuiPresenter::new();
                 presenter.present_element(
-                    render_tool_call_section(action, status, false, None, app_ctx),
+                    render_fallback_tool_call_section(action, status, false, None, app_ctx),
                     TuiRect::new(0, 0, 40, 1),
                     app_ctx,
                 )

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -1,11 +1,14 @@
 use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Duration;
 
+use parking_lot::FairMutex;
 use warp::tui_export::{
     AIAgentAction, AIAgentActionId, AIAgentActionType, AIAgentExchangeId, AIAgentInput,
     AIAgentOutput, AIAgentOutputMessage, AIAgentOutputMessageType, AIAgentText, AIAgentTextSection,
     AIBlockModel, AIBlockOutputStatus, AIConversationId, AIRequestType, Appearance, LLMId,
-    MessageId, OutputStatusUpdateCallback, ServerOutputId, Shared, TaskId, UserQueryMode,
+    MessageId, OutputStatusUpdateCallback, ServerOutputId, Shared, TaskId, TerminalModel,
+    UserQueryMode,
 };
 use warp_core::ui::color::blend::Blend;
 use warp_core::ui::theme::Fill as ThemeFill;
@@ -510,6 +513,7 @@ struct FakeAgentBlockModel {
 /// window and backed by a real action model.
 fn test_agent_block(app: &mut App, model: FakeAgentBlockModel) -> ViewHandle<TuiAIBlock> {
     let action_model = add_test_action_model(app);
+    let terminal_model = Arc::new(FairMutex::new(TerminalModel::mock(None, None)));
     app.update(|ctx| {
         let (window_id, _) = ctx.add_tui_window(
             AddWindowOptions {
@@ -524,6 +528,7 @@ fn test_agent_block(app: &mut App, model: FakeAgentBlockModel) -> ViewHandle<Tui
                 AIAgentExchangeId::new(),
                 Rc::new(model),
                 action_model,
+                terminal_model,
                 ctx,
             )
         })

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -25,6 +25,7 @@ mod terminal_block;
 mod terminal_session_view;
 #[cfg(test)]
 mod test_fixtures;
+mod tool_call_labels;
 mod transcript_view;
 mod tui_block_list_viewport_source;
 mod tui_diff_storage;

--- a/crates/warp_tui/src/tool_call_labels.rs
+++ b/crates/warp_tui/src/tool_call_labels.rs
@@ -26,6 +26,18 @@ pub(crate) enum CommandBlockState {
     Finished { exit_code: ExitCode },
 }
 
+/// A shell-command tool call's terminal block as resolved by the caller: its
+/// execution state plus the command it actually ran. The block's command
+/// supersedes the streamed one, which the user may have edited before
+/// accepting.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ResolvedCommandBlock {
+    /// The block's command, when it has one; `None` while the block's
+    /// command grid is still empty.
+    pub(crate) command: Option<String>,
+    pub(crate) state: CommandBlockState,
+}
+
 /// Longest rendered length for interpolated values (commands, queries, paths)
 /// so tool-call rows stay scannable one-liners.
 const MAX_INLINE_LEN: usize = 80;
@@ -116,13 +128,13 @@ pub(crate) fn tool_call_label(
     action: &AIAgentAction,
     status: Option<&AIActionStatus>,
     output_streaming: bool,
-    block_state: Option<CommandBlockState>,
+    block: Option<&ResolvedCommandBlock>,
 ) -> String {
-    let state = tool_call_display_state(status, output_streaming, block_state);
+    let state = tool_call_display_state(status, output_streaming, block.map(|block| block.state));
     let result = status
         .and_then(AIActionStatus::finished_result)
         .map(|result| &result.result);
-    let label = label_for_action(&action.action, state, result, block_state);
+    let label = label_for_action(&action.action, state, result, block);
     match state {
         State::AwaitingApproval => format!("{label} (awaiting approval)"),
         State::Constructing
@@ -145,11 +157,18 @@ fn label_for_action(
     action: &AIAgentActionType,
     state: ToolCallDisplayState,
     result: Option<&AIAgentActionResultType>,
-    block_state: Option<CommandBlockState>,
+    block: Option<&ResolvedCommandBlock>,
 ) -> String {
+    let block_state = block.map(|block| block.state);
     match action {
         AIAgentActionType::RequestCommandOutput { command, .. } => {
-            let cmd = single_line(command);
+            // The streamed command can be edited before acceptance, so
+            // prefer the executed command from the finished result or the
+            // resolved block over the original suggestion.
+            let executed = result
+                .and_then(AIAgentActionResultType::command_str)
+                .or_else(|| block.and_then(|block| block.command.as_deref()));
+            let cmd = single_line(executed.unwrap_or(command));
             match state {
                 State::Constructing => "Generating command…".to_owned(),
                 State::Pending | State::AwaitingApproval => format!("Run `{cmd}`"),

--- a/crates/warp_tui/src/tool_call_labels.rs
+++ b/crates/warp_tui/src/tool_call_labels.rs
@@ -96,6 +96,21 @@ pub(crate) fn tool_call_display_state(
     }
 }
 
+/// The leading status glyph for a tool-call row; the caller colors it to
+/// mirror the GUI's inline action icons (`action_icon` in the GUI's
+/// `output.rs`): grey circle while pending, yellow block awaiting approval,
+/// yellow dot running, green check on success, red x on failure, grey block
+/// on cancellation.
+pub(crate) fn tool_call_glyph(state: ToolCallDisplayState) -> &'static str {
+    match state {
+        State::Constructing | State::Pending => "○",
+        State::AwaitingApproval | State::Cancelled => "■",
+        State::Running => "●",
+        State::Succeeded => "✓",
+        State::Failed => "✗",
+    }
+}
+
 /// Returns the one-line transcript label for a tool call in its current state.
 pub(crate) fn tool_call_label(
     action: &AIAgentAction,

--- a/crates/warp_tui/src/tool_call_labels.rs
+++ b/crates/warp_tui/src/tool_call_labels.rs
@@ -1,0 +1,631 @@
+//! Per-tool, per-state one-line labels for tool-call rows in the TUI
+//! transcript, modeled on the GUI's inline action text.
+
+use std::path::Path;
+
+use warp::tui_export::{
+    AIActionStatus, AIAgentAction, AIAgentActionResultType, AIAgentActionType,
+    AskUserQuestionResult, FileGlobV2Result, GrepResult, RequestCommandOutputResult,
+    RequestFileEditsResult, RunAgentsAgentOutcomeKind, RunAgentsResult,
+    SearchCodebaseFailureReason, SearchCodebaseResult, StartAgentExecutionMode,
+    SuggestNewConversationResult,
+};
+
+use self::ToolCallDisplayState as State;
+
+/// Longest rendered length for interpolated values (commands, queries, paths)
+/// so tool-call rows stay scannable one-liners.
+const MAX_INLINE_LEN: usize = 80;
+
+/// The coarse display state of a tool call, derived from its action status.
+///
+/// TUI-local presentation collapse of the shared [`AIActionStatus`]; the GUI
+/// has no equivalent enum — its per-tool views consume `AIActionStatus`
+/// directly and re-derive per-site booleans (queued/cancelled/streaming).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ToolCallDisplayState {
+    /// The tool call's arguments are still streaming in: it has no action
+    /// status yet and the exchange output is still streaming, so argument
+    /// fields may be empty or partial and must not be interpolated.
+    Constructing,
+    /// No status yet (stream finished), preprocessing, or queued behind
+    /// other actions.
+    Pending,
+    /// Blocked on user confirmation.
+    AwaitingApproval,
+    /// Executing asynchronously.
+    Running,
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+/// Collapses an optional action status into the coarse display state.
+/// `output_streaming` is whether the exchange output is still streaming;
+/// a status-less action in a streaming output is still being constructed
+/// (mirroring the GUI's `status.is_none() && is_streaming()` gating).
+pub(crate) fn tool_call_display_state(
+    status: Option<&AIActionStatus>,
+    output_streaming: bool,
+) -> ToolCallDisplayState {
+    match status {
+        None if output_streaming => State::Constructing,
+        None | Some(AIActionStatus::Preprocessing | AIActionStatus::Queued) => State::Pending,
+        Some(AIActionStatus::Blocked) => State::AwaitingApproval,
+        Some(AIActionStatus::RunningAsync) => State::Running,
+        Some(finished @ AIActionStatus::Finished(_)) => {
+            if finished.is_cancelled() {
+                State::Cancelled
+            } else if finished.is_failed() {
+                State::Failed
+            } else {
+                State::Succeeded
+            }
+        }
+    }
+}
+
+/// Returns the one-line transcript label for a tool call in its current state.
+pub(crate) fn tool_call_label(
+    action: &AIAgentAction,
+    status: Option<&AIActionStatus>,
+    output_streaming: bool,
+) -> String {
+    let state = tool_call_display_state(status, output_streaming);
+    let result = status
+        .and_then(AIActionStatus::finished_result)
+        .map(|result| &result.result);
+    let label = label_for_action(&action.action, state, result);
+    match state {
+        State::AwaitingApproval => format!("{label} (awaiting approval)"),
+        State::Constructing
+        | State::Pending
+        | State::Running
+        | State::Succeeded
+        | State::Failed
+        | State::Cancelled => label,
+    }
+}
+
+/// Builds the per-tool label body; the awaiting-approval suffix is applied by
+/// [`tool_call_label`]. `result` is the finished result, when there is one.
+///
+/// `Constructing` arms never interpolate argument fields (they may be empty
+/// or partial while streaming); their copy is indexed on the GUI's loading
+/// messages (`common.rs` `LOAD_OUTPUT_MESSAGE_*` and the requested-command
+/// view's "Generating command...").
+fn label_for_action(
+    action: &AIAgentActionType,
+    state: ToolCallDisplayState,
+    result: Option<&AIAgentActionResultType>,
+) -> String {
+    match action {
+        AIAgentActionType::RequestCommandOutput { command, .. } => {
+            let cmd = single_line(command);
+            match state {
+                State::Constructing => "Generating command…".to_owned(),
+                State::Pending | State::AwaitingApproval => format!("Run `{cmd}`"),
+                State::Running => format!("Running `{cmd}`"),
+                State::Succeeded => match result {
+                    Some(AIAgentActionResultType::RequestCommandOutput(
+                        RequestCommandOutputResult::LongRunningCommandSnapshot { .. },
+                    )) => format!("`{cmd}` is still running"),
+                    _ => format!("Ran `{cmd}`"),
+                },
+                State::Failed => match result {
+                    Some(AIAgentActionResultType::RequestCommandOutput(
+                        RequestCommandOutputResult::Completed { exit_code, .. },
+                    )) => format!("`{cmd}` exited with code {}", exit_code.value()),
+                    Some(AIAgentActionResultType::RequestCommandOutput(
+                        RequestCommandOutputResult::Denylisted { .. },
+                    )) => format!("`{cmd}` denied (denylisted)"),
+                    _ => format!("`{cmd}` failed"),
+                },
+                State::Cancelled => format!("Cancelled `{cmd}`"),
+            }
+        }
+        AIAgentActionType::WriteToLongRunningShellCommand { .. } => match state {
+            State::Constructing => "Writing command input…".to_owned(),
+            State::Pending | State::AwaitingApproval => "Write input to running command".to_owned(),
+            State::Running => "Writing input to running command…".to_owned(),
+            State::Succeeded => "Wrote input to running command".to_owned(),
+            State::Failed => "Failed to write to running command".to_owned(),
+            State::Cancelled => "Write to running command cancelled".to_owned(),
+        },
+        AIAgentActionType::ReadFiles(request) => {
+            let files = files_summary(request.locations.iter().map(|location| &location.name));
+            match state {
+                State::Constructing => "Reading files…".to_owned(),
+                State::Pending | State::AwaitingApproval | State::Succeeded => {
+                    format!("Read {files}")
+                }
+                State::Running => format!("Reading {files}"),
+                State::Failed => format!("Failed to read {files}"),
+                State::Cancelled => format!("Cancelled reading {files}"),
+            }
+        }
+        AIAgentActionType::UploadArtifact(request) => {
+            let file = single_line(&request.file_path);
+            match state {
+                State::Constructing => "Preparing upload…".to_owned(),
+                State::Pending | State::AwaitingApproval => format!("Upload {file}"),
+                State::Running => format!("Uploading {file}"),
+                State::Succeeded => format!("Uploaded {file}"),
+                State::Failed => format!("Upload of {file} failed"),
+                State::Cancelled => format!("Upload of {file} cancelled"),
+            }
+        }
+        AIAgentActionType::SearchCodebase(request) => {
+            let query = single_line(&request.query);
+            let scope = request
+                .codebase_path
+                .as_deref()
+                .map(|path| format!(" in {}", base_name(path)))
+                .unwrap_or_default();
+            match state {
+                State::Constructing => "Searching codebase…".to_owned(),
+                State::Pending | State::AwaitingApproval => {
+                    format!("Search for \"{query}\"{scope}")
+                }
+                State::Running => format!("Searching for \"{query}\"{scope}"),
+                State::Succeeded => match result {
+                    Some(AIAgentActionResultType::SearchCodebase(
+                        SearchCodebaseResult::Success { files },
+                    )) if files.is_empty() => {
+                        format!("Searched for \"{query}\"{scope}, no results")
+                    }
+                    Some(AIAgentActionResultType::SearchCodebase(
+                        SearchCodebaseResult::Success { files },
+                    )) => format!(
+                        "Searched for \"{query}\"{scope}, {}",
+                        count_label(files.len(), "result", "results")
+                    ),
+                    _ => format!("Searched for \"{query}\"{scope}"),
+                },
+                State::Failed => match result {
+                    Some(AIAgentActionResultType::SearchCodebase(
+                        SearchCodebaseResult::Failed {
+                            reason: SearchCodebaseFailureReason::CodebaseNotIndexed,
+                            ..
+                        },
+                    )) => format!(
+                        "Search for \"{query}\"{scope} failed because the codebase isn't indexed"
+                    ),
+                    _ => format!("Search for \"{query}\"{scope} failed"),
+                },
+                State::Cancelled => format!("Search for \"{query}\"{scope} cancelled"),
+            }
+        }
+        AIAgentActionType::RequestFileEdits { file_edits, .. } => match state {
+            State::Constructing => "Creating diff…".to_owned(),
+            State::Pending | State::AwaitingApproval | State::Running => {
+                "Preparing edits…".to_owned()
+            }
+            State::Succeeded => match result {
+                Some(AIAgentActionResultType::RequestFileEdits(
+                    RequestFileEditsResult::Success {
+                        updated_files,
+                        deleted_files,
+                        lines_added,
+                        lines_removed,
+                        ..
+                    },
+                )) => format!(
+                    "Edited {} (+{lines_added} −{lines_removed})",
+                    count_label(updated_files.len() + deleted_files.len(), "file", "files")
+                ),
+                _ => format!("Edited {}", count_label(file_edits.len(), "file", "files")),
+            },
+            State::Failed => "File edits failed".to_owned(),
+            State::Cancelled => "File edits cancelled".to_owned(),
+        },
+        AIAgentActionType::Grep { queries, path } => {
+            let queries = single_line(&queries.join(", "));
+            let path = display_path(path);
+            match state {
+                State::Constructing => "Grepping…".to_owned(),
+                State::Pending | State::AwaitingApproval => {
+                    format!("Grep for {queries} in {path}")
+                }
+                State::Running => format!("Grepping for {queries} in {path}"),
+                State::Succeeded => match result {
+                    Some(AIAgentActionResultType::Grep(GrepResult::Success { matched_files })) => {
+                        format!(
+                            "Grepped for {queries} in {path}, {}",
+                            count_label(matched_files.len(), "matching file", "matching files")
+                        )
+                    }
+                    _ => format!("Grepped for {queries} in {path}"),
+                },
+                State::Failed => format!("Grep for {queries} failed"),
+                State::Cancelled => format!("Grep for {queries} cancelled"),
+            }
+        }
+        AIAgentActionType::FileGlob { patterns, path } => {
+            file_glob_label(patterns, path.as_deref(), state, None)
+        }
+        AIAgentActionType::FileGlobV2 {
+            patterns,
+            search_dir,
+        } => {
+            let matched_count = match result {
+                Some(AIAgentActionResultType::FileGlobV2(FileGlobV2Result::Success {
+                    matched_files,
+                    ..
+                })) => Some(matched_files.len()),
+                _ => None,
+            };
+            file_glob_label(patterns, search_dir.as_deref(), state, matched_count)
+        }
+        AIAgentActionType::ReadMCPResource { name, uri, .. } => {
+            let resource = single_line(uri.as_deref().unwrap_or(name));
+            match state {
+                // The resource name arrives with the tool-call header (not
+                // the streamed args), so include it when present, like the
+                // GUI's "Reading \"{name}\" MCP resource..." loading text.
+                State::Constructing if name.is_empty() => "Reading MCP resource…".to_owned(),
+                State::Constructing => format!("Reading \"{name}\" MCP resource…"),
+                State::Pending | State::AwaitingApproval | State::Succeeded => {
+                    format!("Read MCP resource {resource}")
+                }
+                State::Running => format!("Reading MCP resource {resource}"),
+                State::Failed => format!("MCP resource {resource} failed"),
+                State::Cancelled => format!("MCP resource {resource} cancelled"),
+            }
+        }
+        AIAgentActionType::CallMCPTool { name, .. } => {
+            let name = single_line(name);
+            match state {
+                // Like the GUI's "Calling \"{name}\" MCP tool..." loading
+                // text; the tool name is available before its args finish.
+                State::Constructing if name.is_empty() => "Calling MCP tool…".to_owned(),
+                State::Constructing => format!("Calling \"{name}\" MCP tool…"),
+                State::Pending | State::AwaitingApproval => format!("Call MCP tool {name}"),
+                State::Running => format!("Calling MCP tool {name}"),
+                State::Succeeded => format!("Called MCP tool {name}"),
+                State::Failed => format!("MCP tool {name} failed"),
+                State::Cancelled => format!("MCP tool {name} cancelled"),
+            }
+        }
+        AIAgentActionType::SuggestNewConversation { .. } => match state {
+            State::Constructing => "Suggesting a new conversation…".to_owned(),
+            State::Pending | State::AwaitingApproval | State::Running | State::Failed => {
+                "Suggested starting a new conversation".to_owned()
+            }
+            State::Succeeded => match result {
+                Some(AIAgentActionResultType::SuggestNewConversation(
+                    SuggestNewConversationResult::Rejected,
+                )) => "Continuing current conversation".to_owned(),
+                _ => "New conversation started".to_owned(),
+            },
+            State::Cancelled => "New conversation suggestion cancelled".to_owned(),
+        },
+        AIAgentActionType::SuggestPrompt(_)
+        | AIAgentActionType::InitProject
+        | AIAgentActionType::OpenCodeReview => fallback_label(action, state),
+        AIAgentActionType::ReadDocuments(request) => {
+            let documents = count_label(request.document_ids.len(), "document", "documents");
+            match state {
+                State::Constructing => "Reading documents…".to_owned(),
+                State::Pending | State::AwaitingApproval | State::Succeeded => {
+                    format!("Read {documents}")
+                }
+                State::Running => format!("Reading {documents}"),
+                State::Failed => "Failed to read documents".to_owned(),
+                State::Cancelled => "Cancelled reading documents".to_owned(),
+            }
+        }
+        AIAgentActionType::EditDocuments(request) => match state {
+            State::Pending | State::AwaitingApproval => "Update plan".to_owned(),
+            State::Constructing | State::Running => "Updating plan…".to_owned(),
+            State::Succeeded => format!(
+                "Updated plan ({})",
+                count_label(request.diffs.len(), "edit", "edits")
+            ),
+            State::Failed => "Failed to update plan".to_owned(),
+            State::Cancelled => "Update plan cancelled".to_owned(),
+        },
+        AIAgentActionType::CreateDocuments(request) => match state {
+            State::Pending | State::AwaitingApproval => "Create plan".to_owned(),
+            State::Constructing | State::Running => "Generating plan…".to_owned(),
+            State::Succeeded => {
+                let count = request.documents.len();
+                if count > 1 {
+                    format!("Created {count} documents")
+                } else {
+                    "Created plan".to_owned()
+                }
+            }
+            State::Failed => "Failed to create plan".to_owned(),
+            State::Cancelled => "Create plan cancelled".to_owned(),
+        },
+        AIAgentActionType::ReadShellCommandOutput { .. } => match state {
+            State::Pending | State::AwaitingApproval | State::Succeeded => {
+                "Read command output".to_owned()
+            }
+            State::Constructing | State::Running => "Reading command output…".to_owned(),
+            State::Failed => "Failed to read command output".to_owned(),
+            State::Cancelled => "Read command output cancelled".to_owned(),
+        },
+        AIAgentActionType::UseComputer(request) => summary_label(&request.action_summary, state),
+        AIAgentActionType::InsertCodeReviewComments { comments, .. } => {
+            let comments = count_label(comments.len(), "review comment", "review comments");
+            match state {
+                State::Constructing => "Preparing review comments…".to_owned(),
+                State::Pending | State::AwaitingApproval => format!("Insert {comments}"),
+                State::Running => format!("Inserting {comments}…"),
+                State::Succeeded => format!("Inserted {comments}"),
+                State::Failed => "Failed to insert review comments".to_owned(),
+                State::Cancelled => "Insert review comments cancelled".to_owned(),
+            }
+        }
+        AIAgentActionType::RequestComputerUse(request) => {
+            summary_label(&request.task_summary, state)
+        }
+        AIAgentActionType::StartRecording { .. } => match state {
+            State::Pending | State::AwaitingApproval => "Start recording".to_owned(),
+            State::Constructing | State::Running => "Starting recording…".to_owned(),
+            State::Succeeded => "Started screen recording".to_owned(),
+            State::Failed => "Recording failed to start".to_owned(),
+            State::Cancelled => "Start recording cancelled".to_owned(),
+        },
+        AIAgentActionType::StopRecording { .. } => match state {
+            State::Pending | State::AwaitingApproval => "Stop recording".to_owned(),
+            State::Constructing | State::Running => "Stopping recording…".to_owned(),
+            State::Succeeded => "Saved screen recording".to_owned(),
+            State::Failed => "Failed to save recording".to_owned(),
+            State::Cancelled => "Stop recording cancelled".to_owned(),
+        },
+        AIAgentActionType::ReadSkill(request) => {
+            let skill = single_line(&request.skill.to_string());
+            match state {
+                State::Constructing => "Reading skill…".to_owned(),
+                State::Pending | State::AwaitingApproval | State::Succeeded => {
+                    format!("Read skill {skill}")
+                }
+                State::Running => format!("Reading skill {skill}"),
+                State::Failed => format!("Failed to read skill {skill}"),
+                State::Cancelled => format!("Cancelled reading skill {skill}"),
+            }
+        }
+        AIAgentActionType::FetchConversation { .. } => match state {
+            State::Pending | State::AwaitingApproval => "Fetch conversation".to_owned(),
+            State::Constructing | State::Running => "Fetching conversation…".to_owned(),
+            State::Succeeded => "Fetched conversation".to_owned(),
+            State::Failed => "Fetch conversation failed".to_owned(),
+            State::Cancelled => "Fetch conversation cancelled".to_owned(),
+        },
+        AIAgentActionType::StartAgent {
+            name,
+            execution_mode,
+            ..
+        } => {
+            let agent = if matches!(execution_mode, StartAgentExecutionMode::Remote { .. }) {
+                format!("remote agent {name}")
+            } else {
+                format!("agent {name}")
+            };
+            match state {
+                State::Constructing => "Configuring agent…".to_owned(),
+                State::Pending | State::AwaitingApproval => format!("Start {agent}"),
+                State::Running => format!("Starting {agent}…"),
+                State::Succeeded => format!("Started agent {name}"),
+                State::Failed => format!("Failed to start agent {name}"),
+                State::Cancelled => format!("Start agent {name} cancelled"),
+            }
+        }
+        AIAgentActionType::SendMessageToAgent {
+            addresses, subject, ..
+        } => {
+            let subject = single_line(subject);
+            match state {
+                State::Constructing => "Composing message…".to_owned(),
+                State::Pending | State::AwaitingApproval => format!("Send message: {subject}"),
+                State::Running => format!(
+                    "Sending message to {}: {subject}",
+                    count_label(addresses.len(), "agent", "agents")
+                ),
+                State::Succeeded => format!("Sent message: {subject}"),
+                State::Failed => format!("Failed to send message: {subject}"),
+                State::Cancelled => "Send message cancelled".to_owned(),
+            }
+        }
+        AIAgentActionType::TransferShellCommandControlToUser { reason } => match state {
+            State::Constructing => "Handing control to you…".to_owned(),
+            State::Pending | State::AwaitingApproval | State::Running => {
+                format!("Handing control to you: {}", single_line(reason))
+            }
+            State::Succeeded => "You are in control".to_owned(),
+            State::Failed => "Control transfer failed".to_owned(),
+            State::Cancelled => "Control transfer cancelled".to_owned(),
+        },
+        AIAgentActionType::AskUserQuestion { questions } => match state {
+            State::Constructing => "Preparing question…".to_owned(),
+            State::Pending | State::AwaitingApproval | State::Running => format!(
+                "Asking {}",
+                count_label(questions.len(), "question", "questions")
+            ),
+            State::Succeeded => match result {
+                Some(AIAgentActionResultType::AskUserQuestion(
+                    AskUserQuestionResult::Success { answers },
+                )) => {
+                    let total = answers.len();
+                    let answered = answers.iter().filter(|answer| !answer.is_skipped()).count();
+                    if answered == 0 {
+                        "Questions skipped".to_owned()
+                    } else if answered == total && total == 1 {
+                        "Answered question".to_owned()
+                    } else if answered == total {
+                        format!("Answered all {total} questions")
+                    } else {
+                        format!("Answered {answered} of {total} questions")
+                    }
+                }
+                Some(AIAgentActionResultType::AskUserQuestion(
+                    AskUserQuestionResult::SkippedByAutoApprove { .. },
+                )) => "Questions skipped".to_owned(),
+                _ => "Answered questions".to_owned(),
+            },
+            State::Failed => "Questions failed".to_owned(),
+            State::Cancelled => "Questions cancelled".to_owned(),
+        },
+        AIAgentActionType::RunAgents(request) => {
+            let total = request.agent_run_configs.len();
+            match state {
+                State::Constructing | State::Pending | State::AwaitingApproval => {
+                    "Configuring agents…".to_owned()
+                }
+                State::Running => {
+                    format!("Spawning {}…", count_label(total, "agent", "agents"))
+                }
+                State::Succeeded => match result {
+                    Some(AIAgentActionResultType::RunAgents(RunAgentsResult::Launched {
+                        agents,
+                        ..
+                    })) => {
+                        let launched = agents
+                            .iter()
+                            .filter(|agent| {
+                                matches!(agent.kind, RunAgentsAgentOutcomeKind::Launched { .. })
+                            })
+                            .count();
+                        let total = agents.len();
+                        if launched == total {
+                            format!("Spawned {}", count_label(total, "agent", "agents"))
+                        } else if launched == 0 {
+                            format!("Failed to spawn {}", count_label(total, "agent", "agents"))
+                        } else {
+                            format!("Spawned {launched} of {total} agents")
+                        }
+                    }
+                    _ => format!("Spawned {}", count_label(total, "agent", "agents")),
+                },
+                State::Failed => match result {
+                    Some(AIAgentActionResultType::RunAgents(RunAgentsResult::Denied {
+                        ..
+                    })) => "Orchestration disabled — agents not launched".to_owned(),
+                    Some(AIAgentActionResultType::RunAgents(RunAgentsResult::Failure {
+                        error,
+                    })) if !error.is_empty() => {
+                        format!("Failed to start orchestration: {}", single_line(error))
+                    }
+                    _ => "Failed to start orchestration".to_owned(),
+                },
+                State::Cancelled => "Spawn agents cancelled".to_owned(),
+            }
+        }
+        AIAgentActionType::WaitForEvents { .. } => match state {
+            State::Constructing | State::Pending | State::AwaitingApproval | State::Running => {
+                "Waiting for agent events…".to_owned()
+            }
+            State::Succeeded => "Done waiting for agent events".to_owned(),
+            State::Failed => "Waiting for agent events failed".to_owned(),
+            State::Cancelled => "Wait for events cancelled".to_owned(),
+        },
+    }
+}
+
+/// Shared label body for both file-glob action versions; only V2 results
+/// carry a match count.
+fn file_glob_label(
+    patterns: &[String],
+    path: Option<&str>,
+    state: ToolCallDisplayState,
+    matched_count: Option<usize>,
+) -> String {
+    let patterns = single_line(&patterns.join(", "));
+    let path = display_path(path.unwrap_or("."));
+    match state {
+        State::Constructing => "Finding files…".to_owned(),
+        State::Pending | State::AwaitingApproval => {
+            format!("Find files matching {patterns} in {path}")
+        }
+        State::Running => format!("Finding files matching {patterns} in {path}"),
+        State::Succeeded => match matched_count {
+            Some(count) => format!(
+                "Found {} matching {patterns}",
+                count_label(count, "file", "files")
+            ),
+            None => format!("Found files matching {patterns}"),
+        },
+        State::Failed => format!("File search for {patterns} failed"),
+        State::Cancelled => format!("File search for {patterns} cancelled"),
+    }
+}
+
+/// Labels computer-use calls with their agent-supplied summary, marking only
+/// terminal non-success states (matching the GUI, which shows the summary
+/// verbatim).
+fn summary_label(summary: &str, state: ToolCallDisplayState) -> String {
+    let summary = single_line(summary);
+    match state {
+        State::Constructing => "Preparing computer use…".to_owned(),
+        State::Pending | State::AwaitingApproval | State::Running | State::Succeeded => summary,
+        State::Failed => format!("{summary} — failed"),
+        State::Cancelled => format!("{summary} — cancelled"),
+    }
+}
+
+/// Generic label for action types without bespoke text, derived from the
+/// action's user-friendly name.
+fn fallback_label(action: &AIAgentActionType, state: ToolCallDisplayState) -> String {
+    let name = action.user_friendly_name();
+    match state {
+        State::Pending | State::AwaitingApproval => name,
+        State::Constructing | State::Running => format!("{name}…"),
+        State::Succeeded => format!("{name} — done"),
+        State::Failed => format!("{name} — failed"),
+        State::Cancelled => format!("{name} — cancelled"),
+    }
+}
+
+/// Collapses text to its first line, capped at [`MAX_INLINE_LEN`] chars, with
+/// a trailing `…` when anything was trimmed.
+fn single_line(text: &str) -> String {
+    let first_line = text.lines().next().unwrap_or_default().trim_end();
+    let mut out: String = first_line.chars().take(MAX_INLINE_LEN).collect();
+    if first_line.chars().count() > MAX_INLINE_LEN || text.lines().count() > 1 {
+        out.push('…');
+    }
+    out
+}
+
+/// Renders a search path for display, mirroring the GUI's treatment of `.`.
+fn display_path(path: &str) -> String {
+    if path == "." {
+        "the current directory".to_owned()
+    } else {
+        single_line(path)
+    }
+}
+
+/// Returns the final path component, falling back to the input when there is none.
+fn base_name(path: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.to_owned())
+}
+
+/// Summarizes file paths as comma-joined base names for up to 3 files, else a count.
+fn files_summary<'a>(paths: impl ExactSizeIterator<Item = &'a String>) -> String {
+    if paths.len() > 3 {
+        return count_label(paths.len(), "file", "files");
+    }
+    let names: Vec<String> = paths.map(|path| base_name(path)).collect();
+    if names.is_empty() {
+        "files".to_owned()
+    } else {
+        names.join(", ")
+    }
+}
+
+/// Pluralizes a counted noun, e.g. `count_label(2, "file", "files")` → "2 files".
+fn count_label(count: usize, singular: &str, plural: &str) -> String {
+    let noun = if count == 1 { singular } else { plural };
+    format!("{count} {noun}")
+}
+
+#[cfg(test)]
+#[path = "tool_call_labels_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/tool_call_labels.rs
+++ b/crates/warp_tui/src/tool_call_labels.rs
@@ -6,9 +6,8 @@ use std::path::Path;
 use warp::tui_export::{
     AIActionStatus, AIAgentAction, AIAgentActionResultType, AIAgentActionType,
     AskUserQuestionResult, FileGlobV2Result, GrepResult, RequestCommandOutputResult,
-    RequestFileEditsResult, RunAgentsAgentOutcomeKind, RunAgentsResult,
-    SearchCodebaseFailureReason, SearchCodebaseResult, StartAgentExecutionMode,
-    SuggestNewConversationResult,
+    RunAgentsAgentOutcomeKind, RunAgentsResult, SearchCodebaseFailureReason, SearchCodebaseResult,
+    StartAgentExecutionMode, SuggestNewConversationResult,
 };
 
 use self::ToolCallDisplayState as State;
@@ -196,29 +195,12 @@ fn label_for_action(
                 State::Cancelled => format!("Search for \"{query}\"{scope} cancelled"),
             }
         }
-        AIAgentActionType::RequestFileEdits { file_edits, .. } => match state {
-            State::Constructing => "Creating diff…".to_owned(),
-            State::Pending | State::AwaitingApproval | State::Running => {
-                "Preparing edits…".to_owned()
-            }
-            State::Succeeded => match result {
-                Some(AIAgentActionResultType::RequestFileEdits(
-                    RequestFileEditsResult::Success {
-                        updated_files,
-                        deleted_files,
-                        lines_added,
-                        lines_removed,
-                        ..
-                    },
-                )) => format!(
-                    "Edited {} (+{lines_added} −{lines_removed})",
-                    count_label(updated_files.len() + deleted_files.len(), "file", "files")
-                ),
-                _ => format!("Edited {}", count_label(file_edits.len(), "file", "files")),
-            },
-            State::Failed => "File edits failed".to_owned(),
-            State::Cancelled => "File edits cancelled".to_owned(),
-        },
+        // Rendered by its own stateful child view (`TuiFileEditsView`); the
+        // label path should never be reached for it.
+        AIAgentActionType::RequestFileEdits { .. } => {
+            log::warn!("tool_call_label called for RequestFileEdits, which has custom rendering");
+            String::new()
+        }
         AIAgentActionType::Grep { queries, path } => {
             let queries = single_line(&queries.join(", "));
             let path = display_path(path);

--- a/crates/warp_tui/src/tool_call_labels.rs
+++ b/crates/warp_tui/src/tool_call_labels.rs
@@ -9,8 +9,20 @@ use warp::tui_export::{
     RunAgentsAgentOutcomeKind, RunAgentsResult, SearchCodebaseFailureReason, SearchCodebaseResult,
     StartAgentExecutionMode, SuggestNewConversationResult,
 };
+use warp_core::command::ExitCode;
 
 use self::ToolCallDisplayState as State;
+
+/// Ground-truth state of an agent-monitored command's terminal block,
+/// resolved by the caller from the block itself. Needed because the action
+/// model's stored result stays a `LongRunningCommandSnapshot` forever — it is
+/// never superseded when the command finishes — so the block is the source of
+/// truth (mirroring the GUI's stale-result override in `RequestedCommandView`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LrcCommandState {
+    StillRunning,
+    Finished { exit_code: ExitCode },
+}
 
 /// Longest rendered length for interpolated values (commands, queries, paths)
 /// so tool-call rows stay scannable one-liners.
@@ -43,9 +55,12 @@ pub(crate) enum ToolCallDisplayState {
 /// `output_streaming` is whether the exchange output is still streaming;
 /// a status-less action in a streaming output is still being constructed
 /// (mirroring the GUI's `status.is_none() && is_streaming()` gating).
+/// `lrc_state` refines snapshot results with the terminal block's ground
+/// truth (see [`LrcCommandState`]).
 pub(crate) fn tool_call_display_state(
     status: Option<&AIActionStatus>,
     output_streaming: bool,
+    lrc_state: Option<LrcCommandState>,
 ) -> ToolCallDisplayState {
     match status {
         None if output_streaming => State::Constructing,
@@ -58,10 +73,32 @@ pub(crate) fn tool_call_display_state(
             } else if finished.is_failed() {
                 State::Failed
             } else {
-                State::Succeeded
+                match lrc_state {
+                    Some(LrcCommandState::Finished { exit_code }) if is_lrc_snapshot(finished) => {
+                        if exit_code.is_sigint() {
+                            State::Cancelled
+                        } else if exit_code.was_successful() {
+                            State::Succeeded
+                        } else {
+                            State::Failed
+                        }
+                    }
+                    Some(LrcCommandState::Finished { .. } | LrcCommandState::StillRunning)
+                    | None => State::Succeeded,
+                }
             }
         }
     }
+}
+
+/// Whether a finished status holds a long-running command snapshot result.
+fn is_lrc_snapshot(status: &AIActionStatus) -> bool {
+    matches!(
+        status.finished_result().map(|result| &result.result),
+        Some(AIAgentActionResultType::RequestCommandOutput(
+            RequestCommandOutputResult::LongRunningCommandSnapshot { .. }
+        ))
+    )
 }
 
 /// Returns the one-line transcript label for a tool call in its current state.
@@ -69,12 +106,13 @@ pub(crate) fn tool_call_label(
     action: &AIAgentAction,
     status: Option<&AIActionStatus>,
     output_streaming: bool,
+    lrc_state: Option<LrcCommandState>,
 ) -> String {
-    let state = tool_call_display_state(status, output_streaming);
+    let state = tool_call_display_state(status, output_streaming, lrc_state);
     let result = status
         .and_then(AIActionStatus::finished_result)
         .map(|result| &result.result);
-    let label = label_for_action(&action.action, state, result);
+    let label = label_for_action(&action.action, state, result, lrc_state);
     match state {
         State::AwaitingApproval => format!("{label} (awaiting approval)"),
         State::Constructing
@@ -97,6 +135,7 @@ fn label_for_action(
     action: &AIAgentActionType,
     state: ToolCallDisplayState,
     result: Option<&AIAgentActionResultType>,
+    lrc_state: Option<LrcCommandState>,
 ) -> String {
     match action {
         AIAgentActionType::RequestCommandOutput { command, .. } => {
@@ -108,7 +147,13 @@ fn label_for_action(
                 State::Succeeded => match result {
                     Some(AIAgentActionResultType::RequestCommandOutput(
                         RequestCommandOutputResult::LongRunningCommandSnapshot { .. },
-                    )) => format!("`{cmd}` is still running"),
+                    )) => match lrc_state {
+                        // Block ground truth: the monitored command finished.
+                        Some(LrcCommandState::Finished { .. }) => format!("Ran `{cmd}`"),
+                        Some(LrcCommandState::StillRunning) | None => {
+                            format!("`{cmd}` is still running")
+                        }
+                    },
                     _ => format!("Ran `{cmd}`"),
                 },
                 State::Failed => match result {
@@ -118,6 +163,14 @@ fn label_for_action(
                     Some(AIAgentActionResultType::RequestCommandOutput(
                         RequestCommandOutputResult::Denylisted { .. },
                     )) => format!("`{cmd}` denied (denylisted)"),
+                    Some(AIAgentActionResultType::RequestCommandOutput(
+                        RequestCommandOutputResult::LongRunningCommandSnapshot { .. },
+                    )) => match lrc_state {
+                        Some(LrcCommandState::Finished { exit_code }) => {
+                            format!("`{cmd}` exited with code {}", exit_code.value())
+                        }
+                        Some(LrcCommandState::StillRunning) | None => format!("`{cmd}` failed"),
+                    },
                     _ => format!("`{cmd}` failed"),
                 },
                 State::Cancelled => format!("Cancelled `{cmd}`"),

--- a/crates/warp_tui/src/tool_call_labels.rs
+++ b/crates/warp_tui/src/tool_call_labels.rs
@@ -13,14 +13,16 @@ use warp_core::command::ExitCode;
 
 use self::ToolCallDisplayState as State;
 
-/// Ground-truth state of an agent-monitored command's terminal block,
-/// resolved by the caller from the block itself. Needed because the action
-/// model's stored result stays a `LongRunningCommandSnapshot` forever — it is
-/// never superseded when the command finishes — so the block is the source of
-/// truth (mirroring the GUI's stale-result override in `RequestedCommandView`).
+/// Ground-truth state of the terminal block backing a shell-command tool
+/// call, resolved by the caller. When a block exists, its state supersedes
+/// the stored action status/result for execution states (mirroring the GUI's
+/// `RequestedCommandView`, which derives icon and expandability from the
+/// block whenever one exists). Notably, an agent-monitored command's stored
+/// result stays a `LongRunningCommandSnapshot` forever, so without the block
+/// its row could never leave the "still running" state.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum LrcCommandState {
-    StillRunning,
+pub(crate) enum CommandBlockState {
+    Running,
     Finished { exit_code: ExitCode },
 }
 
@@ -55,13 +57,28 @@ pub(crate) enum ToolCallDisplayState {
 /// `output_streaming` is whether the exchange output is still streaming;
 /// a status-less action in a streaming output is still being constructed
 /// (mirroring the GUI's `status.is_none() && is_streaming()` gating).
-/// `lrc_state` refines snapshot results with the terminal block's ground
-/// truth (see [`LrcCommandState`]).
+/// A resolved `block_state` supersedes the status for execution states
+/// (see [`CommandBlockState`]).
 pub(crate) fn tool_call_display_state(
     status: Option<&AIActionStatus>,
     output_streaming: bool,
-    lrc_state: Option<LrcCommandState>,
+    block_state: Option<CommandBlockState>,
 ) -> ToolCallDisplayState {
+    // A block existing means the command actually started executing, so its
+    // state is authoritative over the action status/result.
+    match block_state {
+        Some(CommandBlockState::Running) => return State::Running,
+        Some(CommandBlockState::Finished { exit_code }) => {
+            return if exit_code.is_sigint() {
+                State::Cancelled
+            } else if exit_code.was_successful() {
+                State::Succeeded
+            } else {
+                State::Failed
+            };
+        }
+        None => {}
+    }
     match status {
         None if output_streaming => State::Constructing,
         None | Some(AIActionStatus::Preprocessing | AIActionStatus::Queued) => State::Pending,
@@ -73,32 +90,10 @@ pub(crate) fn tool_call_display_state(
             } else if finished.is_failed() {
                 State::Failed
             } else {
-                match lrc_state {
-                    Some(LrcCommandState::Finished { exit_code }) if is_lrc_snapshot(finished) => {
-                        if exit_code.is_sigint() {
-                            State::Cancelled
-                        } else if exit_code.was_successful() {
-                            State::Succeeded
-                        } else {
-                            State::Failed
-                        }
-                    }
-                    Some(LrcCommandState::Finished { .. } | LrcCommandState::StillRunning)
-                    | None => State::Succeeded,
-                }
+                State::Succeeded
             }
         }
     }
-}
-
-/// Whether a finished status holds a long-running command snapshot result.
-fn is_lrc_snapshot(status: &AIActionStatus) -> bool {
-    matches!(
-        status.finished_result().map(|result| &result.result),
-        Some(AIAgentActionResultType::RequestCommandOutput(
-            RequestCommandOutputResult::LongRunningCommandSnapshot { .. }
-        ))
-    )
 }
 
 /// Returns the one-line transcript label for a tool call in its current state.
@@ -106,13 +101,13 @@ pub(crate) fn tool_call_label(
     action: &AIAgentAction,
     status: Option<&AIActionStatus>,
     output_streaming: bool,
-    lrc_state: Option<LrcCommandState>,
+    block_state: Option<CommandBlockState>,
 ) -> String {
-    let state = tool_call_display_state(status, output_streaming, lrc_state);
+    let state = tool_call_display_state(status, output_streaming, block_state);
     let result = status
         .and_then(AIActionStatus::finished_result)
         .map(|result| &result.result);
-    let label = label_for_action(&action.action, state, result, lrc_state);
+    let label = label_for_action(&action.action, state, result, block_state);
     match state {
         State::AwaitingApproval => format!("{label} (awaiting approval)"),
         State::Constructing
@@ -135,7 +130,7 @@ fn label_for_action(
     action: &AIAgentActionType,
     state: ToolCallDisplayState,
     result: Option<&AIAgentActionResultType>,
-    lrc_state: Option<LrcCommandState>,
+    block_state: Option<CommandBlockState>,
 ) -> String {
     match action {
         AIAgentActionType::RequestCommandOutput { command, .. } => {
@@ -144,34 +139,31 @@ fn label_for_action(
                 State::Constructing => "Generating command…".to_owned(),
                 State::Pending | State::AwaitingApproval => format!("Run `{cmd}`"),
                 State::Running => format!("Running `{cmd}`"),
-                State::Succeeded => match result {
-                    Some(AIAgentActionResultType::RequestCommandOutput(
-                        RequestCommandOutputResult::LongRunningCommandSnapshot { .. },
-                    )) => match lrc_state {
-                        // Block ground truth: the monitored command finished.
-                        Some(LrcCommandState::Finished { .. }) => format!("Ran `{cmd}`"),
-                        Some(LrcCommandState::StillRunning) | None => {
-                            format!("`{cmd}` is still running")
-                        }
+                State::Succeeded => match block_state {
+                    Some(CommandBlockState::Finished { .. }) => format!("Ran `{cmd}`"),
+                    // No local block: fall back to the stored result. A
+                    // snapshot result means the command was still running at
+                    // the last point we could observe it.
+                    Some(CommandBlockState::Running) | None => match result {
+                        Some(AIAgentActionResultType::RequestCommandOutput(
+                            RequestCommandOutputResult::LongRunningCommandSnapshot { .. },
+                        )) => format!("`{cmd}` is still running"),
+                        _ => format!("Ran `{cmd}`"),
                     },
-                    _ => format!("Ran `{cmd}`"),
                 },
-                State::Failed => match result {
-                    Some(AIAgentActionResultType::RequestCommandOutput(
-                        RequestCommandOutputResult::Completed { exit_code, .. },
-                    )) => format!("`{cmd}` exited with code {}", exit_code.value()),
-                    Some(AIAgentActionResultType::RequestCommandOutput(
-                        RequestCommandOutputResult::Denylisted { .. },
-                    )) => format!("`{cmd}` denied (denylisted)"),
-                    Some(AIAgentActionResultType::RequestCommandOutput(
-                        RequestCommandOutputResult::LongRunningCommandSnapshot { .. },
-                    )) => match lrc_state {
-                        Some(LrcCommandState::Finished { exit_code }) => {
-                            format!("`{cmd}` exited with code {}", exit_code.value())
-                        }
-                        Some(LrcCommandState::StillRunning) | None => format!("`{cmd}` failed"),
+                State::Failed => match block_state {
+                    Some(CommandBlockState::Finished { exit_code }) => {
+                        format!("`{cmd}` exited with code {}", exit_code.value())
+                    }
+                    Some(CommandBlockState::Running) | None => match result {
+                        Some(AIAgentActionResultType::RequestCommandOutput(
+                            RequestCommandOutputResult::Completed { exit_code, .. },
+                        )) => format!("`{cmd}` exited with code {}", exit_code.value()),
+                        Some(AIAgentActionResultType::RequestCommandOutput(
+                            RequestCommandOutputResult::Denylisted { .. },
+                        )) => format!("`{cmd}` denied (denylisted)"),
+                        _ => format!("`{cmd}` failed"),
                     },
-                    _ => format!("`{cmd}` failed"),
                 },
                 State::Cancelled => format!("Cancelled `{cmd}`"),
             }

--- a/crates/warp_tui/src/tool_call_labels_tests.rs
+++ b/crates/warp_tui/src/tool_call_labels_tests.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+
+use warp::tui_export::{
+    AIActionStatus, AIAgentAction, AIAgentActionId, AIAgentActionResult, AIAgentActionResultType,
+    AIAgentActionType, RequestCommandOutputResult, TaskId,
+};
+
+use super::tool_call_label;
+
+/// Builds a `Finished` status wrapping the given result.
+fn finished(result: AIAgentActionResultType) -> AIActionStatus {
+    AIActionStatus::Finished(Arc::new(AIAgentActionResult {
+        id: AIAgentActionId::from("action-1".to_owned()),
+        task_id: TaskId::new("task-1".to_owned()),
+        result,
+    }))
+}
+
+/// One end-to-end pass over a tool call's lifecycle: the label text must
+/// change as the action moves through constructing (args still streaming),
+/// pending, awaiting approval, running, and terminal states.
+#[test]
+fn label_changes_across_action_lifecycle() {
+    let action = AIAgentAction {
+        id: AIAgentActionId::from("action-1".to_owned()),
+        task_id: TaskId::new("task-1".to_owned()),
+        action: AIAgentActionType::RequestCommandOutput {
+            command: "git status".to_owned(),
+            is_read_only: None,
+            is_risky: None,
+            wait_until_completion: true,
+            uses_pager: None,
+            rationale: None,
+            citations: Vec::new(),
+        },
+        requires_result: true,
+    };
+    // No status while the output is still streaming: args may be partial.
+    assert_eq!(tool_call_label(&action, None, true), "Generating command…");
+    assert_eq!(tool_call_label(&action, None, false), "Run `git status`");
+    assert_eq!(
+        tool_call_label(&action, Some(&AIActionStatus::Blocked), false),
+        "Run `git status` (awaiting approval)"
+    );
+    assert_eq!(
+        tool_call_label(&action, Some(&AIActionStatus::RunningAsync), false),
+        "Running `git status`"
+    );
+    let cancelled = finished(AIAgentActionResultType::RequestCommandOutput(
+        RequestCommandOutputResult::CancelledBeforeExecution,
+    ));
+    assert_eq!(
+        tool_call_label(&action, Some(&cancelled), false),
+        "Cancelled `git status`"
+    );
+    let failed = finished(AIAgentActionResultType::RequestCommandOutput(
+        RequestCommandOutputResult::Denylisted {
+            command: "git status".to_owned(),
+        },
+    ));
+    assert_eq!(
+        tool_call_label(&action, Some(&failed), false),
+        "`git status` denied (denylisted)"
+    );
+}

--- a/crates/warp_tui/src/tool_call_labels_tests.rs
+++ b/crates/warp_tui/src/tool_call_labels_tests.rs
@@ -2,10 +2,11 @@ use std::sync::Arc;
 
 use warp::tui_export::{
     AIActionStatus, AIAgentAction, AIAgentActionId, AIAgentActionResult, AIAgentActionResultType,
-    AIAgentActionType, RequestCommandOutputResult, TaskId,
+    AIAgentActionType, BlockId, RequestCommandOutputResult, TaskId,
 };
+use warp_core::command::ExitCode;
 
-use super::tool_call_label;
+use super::{tool_call_label, LrcCommandState};
 
 /// Builds a `Finished` status wrapping the given result.
 fn finished(result: AIAgentActionResultType) -> AIActionStatus {
@@ -36,21 +37,27 @@ fn label_changes_across_action_lifecycle() {
         requires_result: true,
     };
     // No status while the output is still streaming: args may be partial.
-    assert_eq!(tool_call_label(&action, None, true), "Generating command…");
-    assert_eq!(tool_call_label(&action, None, false), "Run `git status`");
     assert_eq!(
-        tool_call_label(&action, Some(&AIActionStatus::Blocked), false),
+        tool_call_label(&action, None, true, None),
+        "Generating command…"
+    );
+    assert_eq!(
+        tool_call_label(&action, None, false, None),
+        "Run `git status`"
+    );
+    assert_eq!(
+        tool_call_label(&action, Some(&AIActionStatus::Blocked), false, None),
         "Run `git status` (awaiting approval)"
     );
     assert_eq!(
-        tool_call_label(&action, Some(&AIActionStatus::RunningAsync), false),
+        tool_call_label(&action, Some(&AIActionStatus::RunningAsync), false, None),
         "Running `git status`"
     );
     let cancelled = finished(AIAgentActionResultType::RequestCommandOutput(
         RequestCommandOutputResult::CancelledBeforeExecution,
     ));
     assert_eq!(
-        tool_call_label(&action, Some(&cancelled), false),
+        tool_call_label(&action, Some(&cancelled), false, None),
         "Cancelled `git status`"
     );
     let failed = finished(AIAgentActionResultType::RequestCommandOutput(
@@ -59,7 +66,65 @@ fn label_changes_across_action_lifecycle() {
         },
     ));
     assert_eq!(
-        tool_call_label(&action, Some(&failed), false),
+        tool_call_label(&action, Some(&failed), false, None),
         "`git status` denied (denylisted)"
+    );
+
+    // Agent-monitored command: the stored result stays a snapshot forever, so
+    // the terminal block's resolved state drives the label.
+    let snapshot = finished(AIAgentActionResultType::RequestCommandOutput(
+        RequestCommandOutputResult::LongRunningCommandSnapshot {
+            block_id: BlockId::new(),
+            command: "git status".to_owned(),
+            grid_contents: String::new(),
+            cursor: String::new(),
+            is_alt_screen_active: false,
+        },
+    ));
+    assert_eq!(
+        tool_call_label(&action, Some(&snapshot), false, None),
+        "`git status` is still running"
+    );
+    assert_eq!(
+        tool_call_label(
+            &action,
+            Some(&snapshot),
+            false,
+            Some(LrcCommandState::StillRunning)
+        ),
+        "`git status` is still running"
+    );
+    assert_eq!(
+        tool_call_label(
+            &action,
+            Some(&snapshot),
+            false,
+            Some(LrcCommandState::Finished {
+                exit_code: ExitCode::from(0)
+            })
+        ),
+        "Ran `git status`"
+    );
+    assert_eq!(
+        tool_call_label(
+            &action,
+            Some(&snapshot),
+            false,
+            Some(LrcCommandState::Finished {
+                exit_code: ExitCode::from(1)
+            })
+        ),
+        "`git status` exited with code 1"
+    );
+    assert_eq!(
+        tool_call_label(
+            &action,
+            Some(&snapshot),
+            false,
+            Some(LrcCommandState::Finished {
+                exit_code: ExitCode::from(130)
+            })
+        ),
+        "Cancelled `git status`"
     );
 }

--- a/crates/warp_tui/src/tool_call_labels_tests.rs
+++ b/crates/warp_tui/src/tool_call_labels_tests.rs
@@ -6,7 +6,7 @@ use warp::tui_export::{
 };
 use warp_core::command::ExitCode;
 
-use super::{tool_call_label, LrcCommandState};
+use super::{tool_call_label, CommandBlockState};
 
 /// Builds a `Finished` status wrapping the given result.
 fn finished(result: AIAgentActionResultType) -> AIActionStatus {
@@ -71,7 +71,8 @@ fn label_changes_across_action_lifecycle() {
     );
 
     // Agent-monitored command: the stored result stays a snapshot forever, so
-    // the terminal block's resolved state drives the label.
+    // the terminal block's resolved state drives the label whenever the block
+    // exists; the snapshot is only the no-block fallback.
     let snapshot = finished(AIAgentActionResultType::RequestCommandOutput(
         RequestCommandOutputResult::LongRunningCommandSnapshot {
             block_id: BlockId::new(),
@@ -90,16 +91,16 @@ fn label_changes_across_action_lifecycle() {
             &action,
             Some(&snapshot),
             false,
-            Some(LrcCommandState::StillRunning)
+            Some(CommandBlockState::Running)
         ),
-        "`git status` is still running"
+        "Running `git status`"
     );
     assert_eq!(
         tool_call_label(
             &action,
             Some(&snapshot),
             false,
-            Some(LrcCommandState::Finished {
+            Some(CommandBlockState::Finished {
                 exit_code: ExitCode::from(0)
             })
         ),
@@ -110,7 +111,7 @@ fn label_changes_across_action_lifecycle() {
             &action,
             Some(&snapshot),
             false,
-            Some(LrcCommandState::Finished {
+            Some(CommandBlockState::Finished {
                 exit_code: ExitCode::from(1)
             })
         ),
@@ -121,7 +122,7 @@ fn label_changes_across_action_lifecycle() {
             &action,
             Some(&snapshot),
             false,
-            Some(LrcCommandState::Finished {
+            Some(CommandBlockState::Finished {
                 exit_code: ExitCode::from(130)
             })
         ),

--- a/crates/warp_tui/src/tool_call_labels_tests.rs
+++ b/crates/warp_tui/src/tool_call_labels_tests.rs
@@ -6,7 +6,7 @@ use warp::tui_export::{
 };
 use warp_core::command::ExitCode;
 
-use super::{tool_call_label, CommandBlockState};
+use super::{tool_call_label, CommandBlockState, ResolvedCommandBlock};
 
 /// Builds a `Finished` status wrapping the given result.
 fn finished(result: AIAgentActionResultType) -> AIActionStatus {
@@ -17,16 +17,21 @@ fn finished(result: AIAgentActionResultType) -> AIActionStatus {
     }))
 }
 
-/// One end-to-end pass over a tool call's lifecycle: the label text must
-/// change as the action moves through constructing (args still streaming),
-/// pending, awaiting approval, running, and terminal states.
-#[test]
-fn label_changes_across_action_lifecycle() {
-    let action = AIAgentAction {
+/// Builds a resolved command block without a command of its own.
+fn block(state: CommandBlockState) -> ResolvedCommandBlock {
+    ResolvedCommandBlock {
+        command: None,
+        state,
+    }
+}
+
+/// Builds a `RequestCommandOutput` tool-call action for `command`.
+fn command_action(command: &str) -> AIAgentAction {
+    AIAgentAction {
         id: AIAgentActionId::from("action-1".to_owned()),
         task_id: TaskId::new("task-1".to_owned()),
         action: AIAgentActionType::RequestCommandOutput {
-            command: "git status".to_owned(),
+            command: command.to_owned(),
             is_read_only: None,
             is_risky: None,
             wait_until_completion: true,
@@ -35,7 +40,15 @@ fn label_changes_across_action_lifecycle() {
             citations: Vec::new(),
         },
         requires_result: true,
-    };
+    }
+}
+
+/// One end-to-end pass over a tool call's lifecycle: the label text must
+/// change as the action moves through constructing (args still streaming),
+/// pending, awaiting approval, running, and terminal states.
+#[test]
+fn label_changes_across_action_lifecycle() {
+    let action = command_action("git status");
     // No status while the output is still streaming: args may be partial.
     assert_eq!(
         tool_call_label(&action, None, true, None),
@@ -91,7 +104,7 @@ fn label_changes_across_action_lifecycle() {
             &action,
             Some(&snapshot),
             false,
-            Some(CommandBlockState::Running)
+            Some(&block(CommandBlockState::Running))
         ),
         "Running `git status`"
     );
@@ -100,9 +113,9 @@ fn label_changes_across_action_lifecycle() {
             &action,
             Some(&snapshot),
             false,
-            Some(CommandBlockState::Finished {
+            Some(&block(CommandBlockState::Finished {
                 exit_code: ExitCode::from(0)
-            })
+            }))
         ),
         "Ran `git status`"
     );
@@ -111,9 +124,9 @@ fn label_changes_across_action_lifecycle() {
             &action,
             Some(&snapshot),
             false,
-            Some(CommandBlockState::Finished {
+            Some(&block(CommandBlockState::Finished {
                 exit_code: ExitCode::from(1)
-            })
+            }))
         ),
         "`git status` exited with code 1"
     );
@@ -122,10 +135,60 @@ fn label_changes_across_action_lifecycle() {
             &action,
             Some(&snapshot),
             false,
-            Some(CommandBlockState::Finished {
+            Some(&block(CommandBlockState::Finished {
                 exit_code: ExitCode::from(130)
-            })
+            }))
         ),
         "Cancelled `git status`"
+    );
+}
+
+/// An accepted command can be edited before execution, so the streamed
+/// command may be stale: the executed command from the finished result or
+/// the resolved block must supersede it in the label.
+#[test]
+fn label_prefers_executed_command_over_streamed_command() {
+    let action = command_action("git status");
+
+    // Finished result carries the executed (edited) command.
+    let completed = finished(AIAgentActionResultType::RequestCommandOutput(
+        RequestCommandOutputResult::Completed {
+            block_id: BlockId::new(),
+            command: "git status -sb".to_owned(),
+            output: String::new(),
+            exit_code: ExitCode::from(0),
+            start_ts: None,
+            completed_ts: None,
+        },
+    ));
+    assert_eq!(
+        tool_call_label(&action, Some(&completed), false, None),
+        "Ran `git status -sb`"
+    );
+
+    // No result yet while executing: the resolved block's command wins.
+    let running_block = ResolvedCommandBlock {
+        command: Some("git status -sb".to_owned()),
+        state: CommandBlockState::Running,
+    };
+    assert_eq!(
+        tool_call_label(
+            &action,
+            Some(&AIActionStatus::RunningAsync),
+            false,
+            Some(&running_block)
+        ),
+        "Running `git status -sb`"
+    );
+
+    // A block without a command falls back to the streamed command.
+    assert_eq!(
+        tool_call_label(
+            &action,
+            Some(&AIActionStatus::RunningAsync),
+            false,
+            Some(&block(CommandBlockState::Running))
+        ),
+        "Running `git status`"
     );
 }

--- a/crates/warp_tui/src/transcript_view.rs
+++ b/crates/warp_tui/src/transcript_view.rs
@@ -190,8 +190,16 @@ impl TuiTranscriptView {
 
         let block_model = Rc::new(block_model);
         let action_model = self.action_model.clone();
+        let terminal_model = self.model.clone();
         let view = ctx.add_tui_view(|ctx| {
-            TuiAIBlock::new(conversation_id, exchange_id, block_model, action_model, ctx)
+            TuiAIBlock::new(
+                conversation_id,
+                exchange_id,
+                block_model,
+                action_model,
+                terminal_model,
+                ctx,
+            )
         });
         let view_id = view.id();
         self.agent_blocks.borrow_mut().insert(view_id, view);

--- a/crates/warp_tui/src/transcript_view.rs
+++ b/crates/warp_tui/src/transcript_view.rs
@@ -8,8 +8,8 @@ use std::sync::Arc;
 use parking_lot::FairMutex;
 use warp::tui_export::{
     should_show_task_in_blocklist, AIAgentExchangeId, AIBlockModelImpl, AIConversationId,
-    BlocklistAIActionModel, BlocklistAIHistoryEvent, BlocklistAIHistoryModel, RichContentItem,
-    RichContentType, TerminalModel,
+    BlocklistAIActionEvent, BlocklistAIActionModel, BlocklistAIHistoryEvent,
+    BlocklistAIHistoryModel, RichContentItem, RichContentType, TerminalModel,
 };
 use warpui_core::elements::tui::{
     TuiElement, TuiScrollable, TuiScrollableElement, TuiViewportVerticalAlignment,
@@ -43,6 +43,34 @@ impl TuiTranscriptView {
         ctx.subscribe_to_model(
             &BlocklistAIHistoryModel::handle(ctx),
             |view, _, event, ctx| view.handle_history_event(event, ctx),
+        );
+
+        // Tool-call rows derive their text from per-action status, so any
+        // status transition must re-measure and re-render the owning block.
+        // Finding the owning block is an O(1) set lookup per block (mirroring
+        // the GUI `AIBlock`'s `requested_action_ids` membership check).
+        ctx.subscribe_to_model(
+            &action_model,
+            |view, _, event: &BlocklistAIActionEvent, ctx| {
+                let action_id = event.action_id();
+                let view_id = view
+                    .agent_blocks
+                    .borrow()
+                    .iter()
+                    .find_map(|(view_id, block)| {
+                        block
+                            .as_ref(ctx)
+                            .renders_action(action_id)
+                            .then_some(*view_id)
+                    });
+                if let Some(view_id) = view_id {
+                    view.model
+                        .lock()
+                        .block_list_mut()
+                        .mark_rich_content_dirty(view_id);
+                    ctx.notify();
+                }
+            },
         );
 
         Self {

--- a/crates/warp_tui/src/transcript_view_tests.rs
+++ b/crates/warp_tui/src/transcript_view_tests.rs
@@ -117,12 +117,14 @@ fn transcript_agent_block_lifecycle_updates_canonical_rich_content() {
 
         transcript.update(&mut app, |view, ctx| {
             let action_model = view.action_model.clone();
+            let terminal_model = view.model.clone();
             let agent_block = ctx.add_tui_view(|ctx| {
                 TuiAIBlock::new(
                     original_conversation_id,
                     exchange_id,
                     Rc::new(EmptyAgentBlockModel),
                     action_model,
+                    terminal_model,
                     ctx,
                 )
             });

--- a/crates/warp_tui/src/tui_block_list_viewport_source_tests.rs
+++ b/crates/warp_tui/src/tui_block_list_viewport_source_tests.rs
@@ -229,6 +229,7 @@ fn request_top_window(
 fn add_agent_block(app: &mut App, query: &str) -> ViewHandle<TuiAIBlock> {
     let query = query.to_owned();
     let action_model = add_test_action_model(app);
+    let terminal_model = Arc::new(FairMutex::new(TerminalModel::mock(None, None)));
     app.update(|ctx| {
         let (window_id, _) = ctx.add_tui_window(
             AddWindowOptions {
@@ -245,6 +246,7 @@ fn add_agent_block(app: &mut App, query: &str) -> ViewHandle<TuiAIBlock> {
                     inputs: vec![query_input(&query)],
                 }),
                 action_model,
+                terminal_model,
                 ctx,
             )
         })

--- a/crates/warp_tui/src/tui_builder.rs
+++ b/crates/warp_tui/src/tui_builder.rs
@@ -50,10 +50,26 @@ impl TuiUiBuilder {
         self.muted_text_style().add_modifier(Modifier::DIM)
     }
 
-    /// Style for error text (e.g. failed tool-call rows).
+    /// Style for error text (e.g. failed tool-call glyphs).
     pub(crate) fn error_text_style(&self) -> TuiStyle {
         TuiStyle::default().fg(cell_color(ThemeFill::from(
             self.warp_theme.terminal_colors().normal.red,
+        )))
+    }
+
+    /// Green success glyph (e.g. ✓ on completed tool calls), mirroring the
+    /// GUI's `green_check_icon`.
+    pub(crate) fn success_glyph_style(&self) -> TuiStyle {
+        TuiStyle::default().fg(cell_color(ThemeFill::from(
+            self.warp_theme.terminal_colors().normal.green,
+        )))
+    }
+
+    /// Yellow attention glyph for executing or approval-blocked tool calls,
+    /// mirroring the GUI's `yellow_running_icon` / `yellow_stop_icon`.
+    pub(crate) fn attention_glyph_style(&self) -> TuiStyle {
+        TuiStyle::default().fg(cell_color(ThemeFill::from(
+            self.warp_theme.terminal_colors().normal.yellow,
         )))
     }
 

--- a/crates/warp_tui/src/tui_builder.rs
+++ b/crates/warp_tui/src/tui_builder.rs
@@ -50,6 +50,13 @@ impl TuiUiBuilder {
         self.muted_text_style().add_modifier(Modifier::DIM)
     }
 
+    /// Style for error text (e.g. failed tool-call rows).
+    pub(crate) fn error_text_style(&self) -> TuiStyle {
+        TuiStyle::default().fg(cell_color(ThemeFill::from(
+            self.warp_theme.terminal_colors().normal.red,
+        )))
+    }
+
     /// Bold foreground over the accent-tinted input background; pair with
     /// [`Self::input_background`] on the enclosing container.
     pub(crate) fn input_text_style(&self) -> TuiStyle {

--- a/crates/warpui_core/src/elements/tui/text.rs
+++ b/crates/warpui_core/src/elements/tui/text.rs
@@ -1,10 +1,12 @@
-//! [`TuiText`]: a styled run of text that wraps (or truncates) to the width it
-//! is laid out at, built on ratatui's `Paragraph`.
+//! [`TuiText`]: styled text that wraps (or truncates) to the width it is laid
+//! out at, built on ratatui's `Paragraph`.
 //!
 //! # Construction
-//! Build with [`TuiText::new`] and chain builders:
-//! - [`with_style`](TuiText::with_style) sets the [`TuiStyle`] applied to every
-//!   glyph.
+//! Build with [`TuiText::new`] (one uniformly-styled run) or
+//! [`TuiText::from_spans`] (multiple styled runs flowing as one paragraph)
+//! and chain builders:
+//! - [`with_style`](TuiText::with_style) sets the base [`TuiStyle`] beneath
+//!   every glyph; span styles patch over it.
 //! - [`truncate`](TuiText::truncate) switches from the default word-wrapping
 //!   policy to single-row-per-hard-line truncation.
 //!
@@ -21,13 +23,19 @@
 //! wide glyph occupies two columns and is never split across rows. An empty
 //! string occupies no rows.
 
+use std::mem;
+
+use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Paragraph, Widget, Wrap};
 
 use super::{TuiBuffer, TuiConstraint, TuiElement, TuiLayoutContext, TuiRect, TuiSize, TuiStyle};
 use crate::AppContext;
 
 pub struct TuiText {
-    text: String,
+    /// Styled runs that concatenate into the full text. Runs may contain hard
+    /// newlines, which split rows exactly as they would in a single run.
+    spans: Vec<(String, TuiStyle)>,
+    /// Base style beneath every span; span styles patch over it.
     style: TuiStyle,
     wrap: bool,
 }
@@ -35,8 +43,15 @@ pub struct TuiText {
 impl TuiText {
     /// A wrapping text element holding `text` with default styling.
     pub fn new(text: impl Into<String>) -> Self {
+        Self::from_spans([(text.into(), TuiStyle::default())])
+    }
+
+    /// A wrapping text element composed of styled runs that flow as one
+    /// paragraph (a run is never a wrap boundary by itself). Each run's style
+    /// patches over the base style set by [`with_style`](Self::with_style).
+    pub fn from_spans(spans: impl IntoIterator<Item = (String, TuiStyle)>) -> Self {
         Self {
-            text: text.into(),
+            spans: spans.into_iter().collect(),
             style: TuiStyle::default(),
             wrap: true,
         }
@@ -56,15 +71,45 @@ impl TuiText {
     /// The number of terminal rows this text occupies when laid out at `width`
     /// columns. Matches what `layout` would return as the height component.
     pub fn desired_height(&self, width: u16) -> u16 {
-        if self.text.is_empty() {
+        if self.is_empty() {
             return 0;
         }
         u16::try_from(self.paragraph().line_count(width)).unwrap_or(u16::MAX)
     }
 
+    /// Whether this element holds no text at all (and so occupies no rows).
+    fn is_empty(&self) -> bool {
+        self.spans.iter().all(|(text, _)| text.is_empty())
+    }
+
+    /// The spans re-grouped into ratatui `Line`s: hard newlines inside any
+    /// span split lines; between newlines, consecutive (sub)spans share a line.
+    fn text(&self) -> Text<'_> {
+        let mut lines = Vec::new();
+        let mut current_line = Vec::new();
+        for (content, style) in &self.spans {
+            let mut parts = content.split('\n');
+            // `split` always yields at least one part; parts after the first
+            // are each preceded by a newline, i.e. a completed line.
+            if let Some(first) = parts.next() {
+                if !first.is_empty() {
+                    current_line.push(Span::styled(first, *style));
+                }
+            }
+            for part in parts {
+                lines.push(Line::from(mem::take(&mut current_line)));
+                if !part.is_empty() {
+                    current_line.push(Span::styled(part, *style));
+                }
+            }
+        }
+        lines.push(Line::from(current_line));
+        Text::from(lines)
+    }
+
     /// The ratatui `Paragraph` backing this element's measure and paint.
     fn paragraph(&self) -> Paragraph<'_> {
-        let paragraph = Paragraph::new(self.text.as_str()).style(self.style);
+        let paragraph = Paragraph::new(self.text()).style(self.style);
         if self.wrap {
             paragraph.wrap(Wrap { trim: false })
         } else {
@@ -80,7 +125,7 @@ impl TuiElement for TuiText {
         _ctx: &mut TuiLayoutContext,
         _app: &AppContext,
     ) -> TuiSize {
-        if self.text.is_empty() {
+        if self.is_empty() {
             return constraint.clamp(TuiSize::ZERO);
         }
         let paragraph = self.paragraph();

--- a/crates/warpui_core/src/elements/tui/text_tests.rs
+++ b/crates/warpui_core/src/elements/tui/text_tests.rs
@@ -119,3 +119,62 @@ fn truncation_keeps_one_row_per_hard_line() {
         vec!["a  ", "b  ", "c  "],
     );
 }
+
+#[test]
+fn spans_flow_as_one_paragraph_with_per_span_styles() {
+    let green = Style::default().fg(Color::Green);
+    let text = TuiText::from_spans([
+        ("✓ ".to_owned(), green),
+        ("done".to_owned(), Style::default()),
+    ])
+    .with_style(Style::default().fg(Color::White));
+
+    let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, 6, 1));
+    let mut rendered_views = EntityIdMap::default();
+    let mut ctx = TuiLayoutContext {
+        rendered_views: &mut rendered_views,
+    };
+    text.render(TuiRect::new(0, 0, 6, 1), &mut buffer, &mut ctx);
+
+    assert_eq!(buffer.to_lines(), vec!["✓ done"]);
+    // The span's style patches over the base style.
+    assert_eq!(buffer[(0, 0)].fg, Color::Green);
+    assert_eq!(buffer[(2, 0)].fg, Color::White);
+}
+
+#[test]
+fn spans_wrap_across_span_boundaries() {
+    // "aa bb cc" wraps at width 5 as "aa bb" / "cc", even though the wrap
+    // point falls inside the second span.
+    let text = TuiText::from_spans([
+        ("aa ".to_owned(), Style::default()),
+        ("bb cc".to_owned(), Style::default()),
+    ]);
+    assert_eq!(text.desired_height(5), 2);
+    assert_eq!(
+        render_to_lines(&text, TuiSize::new(5, 2)),
+        vec!["aa bb", "cc   "],
+    );
+}
+
+#[test]
+fn hard_newlines_inside_spans_split_lines() {
+    let text = TuiText::from_spans([
+        ("a\nb".to_owned(), Style::default()),
+        ("c".to_owned(), Style::default()),
+    ]);
+    assert_eq!(text.desired_height(10), 2);
+    assert_eq!(
+        render_to_lines(&text, TuiSize::new(3, 2)),
+        vec!["a  ", "bc "],
+    );
+}
+
+#[test]
+fn all_empty_spans_occupy_no_rows() {
+    let text = TuiText::from_spans([
+        (String::new(), Style::default()),
+        (String::new(), Style::default()),
+    ]);
+    assert_eq!(text.desired_height(10), 0);
+}

--- a/specs/CODE-1815/TECH.md
+++ b/specs/CODE-1815/TECH.md
@@ -48,7 +48,7 @@ Placeholders: `{cmd}`=command, `{q}`=query, `{qs}`/`{pats}`=comma-joined queries
 | CallMCPTool | Call MCP tool {name} | Calling MCP tool {name} | Called MCP tool {name} | MCP tool {name} failed | MCP tool {name} cancelled |
 | ReadMCPResource | Read MCP resource {uri} | Reading MCP resource {uri} | Read MCP resource {uri} | MCP resource {uri} failed | MCP resource {uri} cancelled |
 | ReadSkill | Read skill {skill} | Reading skill {skill} | Read skill {skill} | Failed to read skill {skill} | Cancelled reading skill {skill} |
-| RequestFileEdits [6] | Preparing edits… | Preparing edits… | Edited {n} file(s) (+a −r) | File edits failed | File edits cancelled |
+| RequestFileEdits [6] | Preparing edits… | Preparing edits… | Edited {n} file(s) (+a −r) | — | — |
 | CreateDocuments | Create plan | Generating plan… | Created plan [7] | Failed to create plan | Create plan cancelled |
 | EditDocuments | Update plan | Updating plan… | Updated plan ({n} edits) | Failed to update plan | Update plan cancelled |
 | ReadDocuments | Read {n} document(s) | Reading {n} document(s) | Read {n} document(s) | Failed to read documents | Cancelled reading documents |
@@ -76,7 +76,7 @@ Footnotes:
 3. 0 results → "…, no results". `{repo}` = file name of the request's `codebase_path`; the " in {repo}" segment is omitted when absent.
 4. `CodebaseNotIndexed` appends " because the codebase isn't indexed".
 5. Legacy `FileGlob` success carries no count: "Found files matching {pats}". Missing path defaults to "the current directory".
-6. Normally rendered by the existing `TuiFileEditsView` child view (unchanged); these labels are the fallback when no child view is registered for the action.
+6. Rendered by the existing `TuiFileEditsView` child view (unchanged); the shown copy comes from that view. The label fn intentionally has no copy for tools with custom rendering — its `RequestFileEdits` arm returns an empty string and logs a warning if ever reached.
 7. More than one document → "Created {n} documents".
 8. Partial → "Spawned {launched} of {total} agents"; none launched → "Failed to spawn {n} agent(s)" (still a Succeeded display state, since `RunAgentsResult::Launched` is a successful result).
 9. `Failure` appends ": {error}" when present; `Denied` → "Orchestration disabled — agents not launched".

--- a/specs/CODE-1815/TECH.md
+++ b/specs/CODE-1815/TECH.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-The TUI transcript previously rendered every agent tool call as a static dim row reading "executed a tool call". This change gives each tool call a one-line, per-state label (pending / awaiting approval / running / succeeded / failed / cancelled), modeled on the GUI's inline action text.
+The TUI transcript previously rendered every agent tool call as a static dim row reading "executed a tool call". This change gives each tool call a one-line row with a colored status glyph and per-state label (pending / awaiting approval / running / succeeded / failed / cancelled), modeled on the GUI's inline action text and status icons.
 
 How the surrounding system works:
 
@@ -86,11 +86,18 @@ Footnotes:
 
 ### Rendering and styling
 
-`render_tool_call_section(action, status, output_streaming, block_state, app)` in `crates/warp_tui/src/agent_block_sections.rs` styles the label by display state:
+`render_tool_call_section(action, status, output_streaming, block_state, app)` in `crates/warp_tui/src/agent_block_sections.rs` renders a `TuiFlex::row()` of a two-cell status-glyph gutter followed by the label, so a wrapping label keeps a hanging indent under its own first column. The glyph mirrors the GUI's inline action icons (`action_icon` in `app/src/ai/blocklist/block/view_impl/output.rs:3501`, `inline_action_icons.rs`), per display state (`tool_call_glyph` in `crates/warp_tui/src/tool_call_labels.rs`):
 
-- Constructing / Pending / AwaitingApproval / Running / Cancelled → `TuiUiBuilder::dim_text_style()`
-- Succeeded → `TuiUiBuilder::muted_text_style()`
-- Failed → `TuiUiBuilder::error_text_style()` (new; `terminal_colors().normal.red`, `crates/warp_tui/src/tui_builder.rs`)
+- Constructing / Pending → `○` in `TuiUiBuilder::dim_text_style()` (GUI: grey circle)
+- AwaitingApproval → `■` in `TuiUiBuilder::attention_glyph_style()` (`terminal_colors().normal.yellow`; GUI: yellow stop)
+- Running → `●` in `attention_glyph_style()` (GUI: yellow running circle)
+- Succeeded → `✓` in `TuiUiBuilder::success_glyph_style()` (`terminal_colors().normal.green`; GUI: green check)
+- Failed → `✗` in `TuiUiBuilder::error_text_style()` (`terminal_colors().normal.red`; GUI: red x)
+- Cancelled → `■` in `TuiUiBuilder::muted_text_style()` (`terminal_colors().bright.black`; GUI: grey cancelled block)
+
+State lives in the glyph, so the label keeps `TuiUiBuilder::primary_text_style()` (normal foreground) for every state except Constructing / Pending, which use `dim_text_style()` until execution starts (GUI parity: labels are not tinted by outcome; only queued/streaming-not-first rows dim).
+
+`TuiText` (`crates/warpui_core/src/elements/tui/text.rs`) additionally supports multiple styled runs via `TuiText::from_spans`, flowing as one wrapped paragraph with per-run styles patching over the base style. The tool-call row itself uses two single-style texts in the flex row; `from_spans` exists for upcoming rows that need mid-line colored fragments (e.g. the file-edits `+a −r` counts).
 
 ### Status plumbing and re-render
 
@@ -101,8 +108,9 @@ Footnotes:
 ## Testing and validation
 
 - `crates/warp_tui/src/tool_call_labels_tests.rs` — a single lifecycle test asserting the label text changes as one action moves through constructing → pending → awaiting approval → running → cancelled/failed, plus the block-state overrides for a snapshot result (no block / running / exit 0 / exit 1 / exit 130). Per-tool string variants are intentionally not unit-tested; the table above is the source of truth for copy.
-- `crates/warp_tui/src/agent_block_tests.rs` — transcript rendering asserts label text, dim styling, and message ordering through the real `BlocklistAIActionModel` fixture.
-- `cargo nextest run -p warp_tui`, `./script/format --check`, and presubmit-style clippy on `warp` + `warp_tui` all pass.
+- `crates/warp_tui/src/agent_block_tests.rs` — transcript rendering asserts label text, glyph prefixes, per-state glyph/label colors (`tool_call_row_glyph_and_colors_reflect_state`), and message ordering through the real `BlocklistAIActionModel` fixture.
+- `crates/warpui_core/src/elements/tui/text_tests.rs` — span construction: per-span styles patching the base style, wrapping across span boundaries, hard newlines inside spans, and empty spans occupying no rows.
+- `cargo nextest run -p warp_tui`, `cargo nextest run -p warpui_core --features tui`, `./script/format --check`, and presubmit-style clippy on `warp` + `warp_tui` all pass.
 
 No parallelization was used: the change is a single-crate feature plus a small export surface, implemented sequentially.
 

--- a/specs/CODE-1815/TECH.md
+++ b/specs/CODE-1815/TECH.md
@@ -71,7 +71,7 @@ Placeholders: `{cmd}`=command, `{q}`=query, `{qs}`/`{pats}`=comma-joined queries
 
 Footnotes:
 
-1. `LongRunningCommandSnapshot` counts as success: "`{cmd}` is still running".
+1. `LongRunningCommandSnapshot` (agent-monitored command) counts as success. The stored action result is never superseded when the command later finishes, so the label consults the terminal `Block` (looked up by the snapshot's `block_id`, mirroring the GUI's stale-result override in `RequestedCommandView`, requested_command.rs:1368-1376): block still running → "`{cmd}` is still running"; finished → "Ran `{cmd}`" / "`{cmd}` exited with code {n}" / "Cancelled `{cmd}`" (SIGINT), per the block's exit code.
 2. `{code}` from the completed exit code; `Denylisted` → "`{cmd}` denied (denylisted)". Exit code 130 is classified as cancelled by `AIAgentActionResultType::is_cancelled`.
 3. 0 results → "…, no results". `{repo}` = file name of the request's `codebase_path`; the " in {repo}" segment is omitted when absent.
 4. `CodebaseNotIndexed` appends " because the codebase isn't indexed".
@@ -94,7 +94,7 @@ Footnotes:
 
 ### Status plumbing and re-render
 
-- `TuiAIBlock` stores the `ModelHandle<BlocklistAIActionModel>` and looks up `get_action_status(&action.id)` at render time for each tool-call section (`crates/warp_tui/src/agent_block.rs`).
+- `TuiAIBlock` stores the `ModelHandle<BlocklistAIActionModel>` and looks up `get_action_status(&action.id)` at render time for each tool-call section (`crates/warp_tui/src/agent_block.rs`). It also holds the surface's `Arc<FairMutex<TerminalModel>>`: for long-running-snapshot results it resolves the command block's ground truth via `lrc_command_state`.
 - `TuiTranscriptView` subscribes to `BlocklistAIActionEvent`; on any transition it finds the agent block whose output contains that action id (`TuiAIBlock::renders_action`), calls `mark_rich_content_dirty(view_id)`, and notifies (`crates/warp_tui/src/transcript_view.rs`). Dirty-marking is required because label text changes can change wrapped height, and block heights are cached in the block list. Each block maintains a `HashSet` of its action ids (populated by `sync_action_views` as output streams in, mirroring the GUI `AIBlock`'s `requested_action_ids`), so the per-event check is an O(1) set lookup per block rather than an output-message scan.
 - `app/src/tui_export.rs` additionally exports `AIActionStatus`, `BlocklistAIActionEvent`, and the request/result types the label logic and its tests consume; `app/src/ai/blocklist/mod.rs` re-exports `AIActionStatus` and `BlocklistAIActionEvent` publicly.
 

--- a/specs/CODE-1815/TECH.md
+++ b/specs/CODE-1815/TECH.md
@@ -1,0 +1,114 @@
+# TECH: Per-state, per-tool status text for TUI tool call rows
+
+## Context
+
+The TUI transcript previously rendered every agent tool call as a static dim row reading "executed a tool call". This change gives each tool call a one-line, per-state label (pending / awaiting approval / running / succeeded / failed / cancelled), modeled on the GUI's inline action text.
+
+How the surrounding system works:
+
+- `crates/warp_tui/src/agent_block.rs` — `TuiAIBlock::sections` extracts `AIAgentOutputMessageType::Action` messages into `TuiAIBlockSection::ToolCall(Box<AIAgentAction>)`. `RequestFileEdits` is special-cased: it gets a stateful `TuiFileEditsView` child view (`crates/warp_tui/src/tui_file_edits_view.rs`).
+- `app/src/ai/blocklist/action_model.rs:606` — `BlocklistAIActionModel::get_action_status` is the source of truth for per-action status, returning `AIActionStatus` (`Preprocessing`, `Queued`, `Blocked`, `RunningAsync`, `Finished(Arc<AIAgentActionResult>)`). The model emits `BlocklistAIActionEvent` on every status transition (same file, lines 1431-1452).
+- `crates/ai/src/agent/action_result/mod.rs` — per-tool result enums carry Success/Error/Cancelled plus payloads usable for counts (e.g. `SearchCodebaseResult::Success { files }`, `RunAgentsResult::Launched/Denied/Failure`).
+- `app/src/tui_export.rs` — the only surface through which `warp_tui` consumes app types.
+
+## Implementation
+
+### Display state
+
+`crates/warp_tui/src/tool_call_labels.rs` defines `ToolCallDisplayState` and collapses `Option<&AIActionStatus>` plus the exchange's output-streaming flag into it:
+
+- `None` while the exchange output is still streaming → `Constructing`: the tool call's arguments are still streaming in and may be empty/partial, so labels never interpolate them. Each tool has an arg-free loading label in `label_for_action`, indexed on the GUI's loading copy (`common.rs` `LOAD_OUTPUT_MESSAGE_*`, e.g. "Generating command…", "Grepping…", "Finding files…", "Reading files…", "Searching codebase…", "Preparing question…"). This mirrors the GUI's `get_action_status(id).is_none() && status.is_streaming()` gating (and fixes the blank-args window the GUI itself still has for Grep/FileGlob).
+- `None` (stream finished) / `Preprocessing` / `Queued` → `Pending`
+- `Blocked` → `AwaitingApproval` (renders the Pending text plus the suffix " (awaiting approval)")
+- `RunningAsync` → `Running`
+- `Finished(result)` → `Cancelled` / `Failed` / `Succeeded` via `is_cancelled()` / `is_failed()`, else success
+
+Per-tool special results are handled inside the per-tool match: `RunAgentsResult::Denied` (a failed state with its own copy), `SuggestNewConversationResult::Rejected` (a success-state user decision, not a failure), denylisted commands, and long-running command snapshots.
+
+### Label function
+
+`tool_call_label(action: &AIAgentAction, status: Option<&AIActionStatus>, output_streaming: bool) -> String` is a pure function matching exhaustively over all `AIAgentActionType` variants (no `_` arm); `output_streaming` comes from `AIBlockOutputStatus::is_streaming()` at render time. Helpers:
+
+- `single_line`: first line only, capped at 80 chars, `…` appended when trimmed (mirrors the GUI's `format_command_text`).
+- `display_path`: `"."` → "the current directory" (mirrors `app/src/ai/blocklist/block/view_impl/output.rs:2425-2433`).
+- `files_summary`: comma-joined base names for ≤3 files, else "{n} files".
+- `count_label`: pluralization ("1 file" / "2 files").
+
+### Text table
+
+Placeholders: `{cmd}`=command, `{q}`=query, `{qs}`/`{pats}`=comma-joined queries/patterns, `{files}`=file summary, `{n}`=count. Backticks are literal characters in the rendered row (the TUI has no inline-code styling).
+
+| Tool | Pending | Running | Success | Failed | Cancelled |
+|---|---|---|---|---|---|
+| RequestCommandOutput | Run `{cmd}` | Running `{cmd}` | Ran `{cmd}` [1] | `{cmd}` exited with code {code} [2] | Cancelled `{cmd}` |
+| ReadFiles | Read {files} | Reading {files} | Read {files} | Failed to read {files} | Cancelled reading {files} |
+| SearchCodebase | Search for "{q}" in {repo} | Searching for "{q}" in {repo} | Searched for "{q}" in {repo}, {n} results [3] | Search for "{q}" in {repo} failed [4] | Search for "{q}" in {repo} cancelled |
+| Grep | Grep for {qs} in {path} | Grepping for {qs} in {path} | Grepped for {qs} in {path}, {n} matching files | Grep for {qs} failed | Grep for {qs} cancelled |
+| FileGlob / FileGlobV2 | Find files matching {pats} in {path} | Finding files matching {pats} in {path} | Found {n} files matching {pats} [5] | File search for {pats} failed | File search for {pats} cancelled |
+| CallMCPTool | Call MCP tool {name} | Calling MCP tool {name} | Called MCP tool {name} | MCP tool {name} failed | MCP tool {name} cancelled |
+| ReadMCPResource | Read MCP resource {uri} | Reading MCP resource {uri} | Read MCP resource {uri} | MCP resource {uri} failed | MCP resource {uri} cancelled |
+| ReadSkill | Read skill {skill} | Reading skill {skill} | Read skill {skill} | Failed to read skill {skill} | Cancelled reading skill {skill} |
+| RequestFileEdits [6] | Preparing edits… | Preparing edits… | Edited {n} file(s) (+a −r) | File edits failed | File edits cancelled |
+| CreateDocuments | Create plan | Generating plan… | Created plan [7] | Failed to create plan | Create plan cancelled |
+| EditDocuments | Update plan | Updating plan… | Updated plan ({n} edits) | Failed to update plan | Update plan cancelled |
+| ReadDocuments | Read {n} document(s) | Reading {n} document(s) | Read {n} document(s) | Failed to read documents | Cancelled reading documents |
+| UploadArtifact | Upload {file} | Uploading {file} | Uploaded {file} | Upload of {file} failed | Upload of {file} cancelled |
+| UseComputer / RequestComputerUse | {summary} | {summary} | {summary} | {summary} — failed | {summary} — cancelled |
+| StartAgent | Start {remote }agent {name} | Starting {remote }agent {name}… | Started agent {name} | Failed to start agent {name} | Start agent {name} cancelled |
+| SendMessageToAgent | Send message: {subject} | Sending message to {n} agent(s): {subject} | Sent message: {subject} | Failed to send message: {subject} | Send message cancelled |
+| RunAgents | Configuring agents… | Spawning {n} agent(s)… | Spawned {n} agent(s) [8] | Failed to start orchestration [9] | Spawn agents cancelled |
+| AskUserQuestion | Asking {n} question(s) | Asking {n} question(s) | Answered all {n} questions [10] | Questions failed | Questions cancelled |
+| SuggestNewConversation | Suggested starting a new conversation | Suggested starting a new conversation | New conversation started [11] | Suggested starting a new conversation | New conversation suggestion cancelled |
+| FetchConversation | Fetch conversation | Fetching conversation… | Fetched conversation | Fetch conversation failed | Fetch conversation cancelled |
+| ReadShellCommandOutput | Read command output | Reading command output… | Read command output | Failed to read command output | Read command output cancelled |
+| WriteToLongRunningShellCommand | Write input to running command | Writing input to running command… | Wrote input to running command | Failed to write to running command | Write to running command cancelled |
+| TransferShellCommandControlToUser | Handing control to you: {reason} | Handing control to you: {reason} | You are in control | Control transfer failed | Control transfer cancelled |
+| StartRecording | Start recording | Starting recording… | Started screen recording | Recording failed to start | Start recording cancelled |
+| StopRecording | Stop recording | Stopping recording… | Saved screen recording | Failed to save recording | Stop recording cancelled |
+| InsertCodeReviewComments | Insert {n} review comment(s) | Inserting {n} review comment(s)… | Inserted {n} review comment(s) | Failed to insert review comments | Insert review comments cancelled |
+| WaitForEvents | Waiting for agent events… | Waiting for agent events… | Done waiting for agent events | Waiting for agent events failed | Wait for events cancelled |
+| Fallback [12] | {name} | {name}… | {name} — done | {name} — failed | {name} — cancelled |
+
+Footnotes:
+
+1. `LongRunningCommandSnapshot` counts as success: "`{cmd}` is still running".
+2. `{code}` from the completed exit code; `Denylisted` → "`{cmd}` denied (denylisted)". Exit code 130 is classified as cancelled by `AIAgentActionResultType::is_cancelled`.
+3. 0 results → "…, no results". `{repo}` = file name of the request's `codebase_path`; the " in {repo}" segment is omitted when absent.
+4. `CodebaseNotIndexed` appends " because the codebase isn't indexed".
+5. Legacy `FileGlob` success carries no count: "Found files matching {pats}". Missing path defaults to "the current directory".
+6. Normally rendered by the existing `TuiFileEditsView` child view (unchanged); these labels are the fallback when no child view is registered for the action.
+7. More than one document → "Created {n} documents".
+8. Partial → "Spawned {launched} of {total} agents"; none launched → "Failed to spawn {n} agent(s)" (still a Succeeded display state, since `RunAgentsResult::Launched` is a successful result).
+9. `Failure` appends ": {error}" when present; `Denied` → "Orchestration disabled — agents not launched".
+10. One question → "Answered question"; partial → "Answered {answered} of {total} questions"; all skipped or `SkippedByAutoApprove` → "Questions skipped".
+11. `Rejected` → "Continuing current conversation" (user decision, success display state).
+12. Fallback covers `SuggestPrompt`, `InitProject`, `OpenCodeReview`, and future variants; `{name}` = `AIAgentActionType::user_friendly_name()` (`crates/ai/src/agent/action/mod.rs:425`).
+
+### Rendering and styling
+
+`render_tool_call_section(action, status, app)` in `crates/warp_tui/src/agent_block_sections.rs` styles the label by display state:
+
+- Pending / AwaitingApproval / Running / Cancelled → `TuiUiBuilder::dim_text_style()`
+- Succeeded → `TuiUiBuilder::muted_text_style()`
+- Failed → `TuiUiBuilder::error_text_style()` (new; `terminal_colors().normal.red`, `crates/warp_tui/src/tui_builder.rs`)
+
+### Status plumbing and re-render
+
+- `TuiAIBlock` stores the `ModelHandle<BlocklistAIActionModel>` and looks up `get_action_status(&action.id)` at render time for each tool-call section (`crates/warp_tui/src/agent_block.rs`).
+- `TuiTranscriptView` subscribes to `BlocklistAIActionEvent`; on any transition it finds the agent block whose output contains that action id (`TuiAIBlock::renders_action`), calls `mark_rich_content_dirty(view_id)`, and notifies (`crates/warp_tui/src/transcript_view.rs`). Dirty-marking is required because label text changes can change wrapped height, and block heights are cached in the block list. Each block maintains a `HashSet` of its action ids (populated by `sync_action_views` as output streams in, mirroring the GUI `AIBlock`'s `requested_action_ids`), so the per-event check is an O(1) set lookup per block rather than an output-message scan.
+- `app/src/tui_export.rs` additionally exports `AIActionStatus`, `BlocklistAIActionEvent`, and the request/result types the label logic and its tests consume; `app/src/ai/blocklist/mod.rs` re-exports `AIActionStatus` and `BlocklistAIActionEvent` publicly.
+
+## Testing and validation
+
+- `crates/warp_tui/src/tool_call_labels_tests.rs` — a single lifecycle test asserting the label text changes as one action moves through pending → awaiting approval → running → cancelled/failed. Per-tool string variants are intentionally not unit-tested; the table above is the source of truth for copy.
+- `crates/warp_tui/src/agent_block_tests.rs` — transcript rendering asserts label text, dim styling, and message ordering through the real `BlocklistAIActionModel` fixture.
+- `cargo nextest run -p warp_tui`, `./script/format --check`, and presubmit-style clippy on `warp` + `warp_tui` all pass.
+
+No parallelization was used: the change is a single-crate feature plus a small export surface, implemented sequentially.
+
+## Gaps and follow-ups
+
+- No approval/confirmation UI in the TUI for `Blocked` actions — only the " (awaiting approval)" text suffix. An interactive accept/reject flow is future work.
+- `RequestFileEdits` keeps its existing `TuiFileEditsView` (diff summary); it does not yet reflect failed/cancelled outcomes distinctly.
+- `WebSearch` / `WebFetch` / `Subagent` output messages are separate `AIAgentOutputMessageType` variants (not tool-call actions) and remain unrendered by the TUI.
+- Rich result bodies (file lists, collapsible output) are out of scope; rows are single-line labels only.

--- a/specs/CODE-1815/TECH.md
+++ b/specs/CODE-1815/TECH.md
@@ -15,7 +15,7 @@ How the surrounding system works:
 
 ### Display state
 
-`crates/warp_tui/src/tool_call_labels.rs` defines `ToolCallDisplayState` and collapses `Option<&AIActionStatus>` plus the exchange's output-streaming flag into it:
+`crates/warp_tui/src/tool_call_labels.rs` defines `ToolCallDisplayState` and collapses `Option<&AIActionStatus>`, the exchange's output-streaming flag, and (for shell-command rows) the backing terminal block's `CommandBlockState` into it. A resolved block state supersedes the status entirely — `Running` → `Running`; `Finished` → `Cancelled` (SIGINT) / `Succeeded` (`was_successful`) / `Failed` per exit code (see footnote 1). Otherwise:
 
 - `None` while the exchange output is still streaming → `Constructing`: the tool call's arguments are still streaming in and may be empty/partial, so labels never interpolate them. Each tool has an arg-free loading label in `label_for_action`, indexed on the GUI's loading copy (`common.rs` `LOAD_OUTPUT_MESSAGE_*`, e.g. "Generating command…", "Grepping…", "Finding files…", "Reading files…", "Searching codebase…", "Preparing question…"). This mirrors the GUI's `get_action_status(id).is_none() && status.is_streaming()` gating (and fixes the blank-args window the GUI itself still has for Grep/FileGlob).
 - `None` (stream finished) / `Preprocessing` / `Queued` → `Pending`
@@ -23,11 +23,11 @@ How the surrounding system works:
 - `RunningAsync` → `Running`
 - `Finished(result)` → `Cancelled` / `Failed` / `Succeeded` via `is_cancelled()` / `is_failed()`, else success
 
-Per-tool special results are handled inside the per-tool match: `RunAgentsResult::Denied` (a failed state with its own copy), `SuggestNewConversationResult::Rejected` (a success-state user decision, not a failure), denylisted commands, and long-running command snapshots.
+Per-tool special results are handled inside the per-tool match: `RunAgentsResult::Denied` (a failed state with its own copy), `SuggestNewConversationResult::Rejected` (a success-state user decision, not a failure), denylisted commands, and long-running command snapshots (no-block fallback).
 
 ### Label function
 
-`tool_call_label(action: &AIAgentAction, status: Option<&AIActionStatus>, output_streaming: bool) -> String` is a pure function matching exhaustively over all `AIAgentActionType` variants (no `_` arm); `output_streaming` comes from `AIBlockOutputStatus::is_streaming()` at render time. Helpers:
+`tool_call_label(action: &AIAgentAction, status: Option<&AIActionStatus>, output_streaming: bool, block_state: Option<CommandBlockState>) -> String` is a pure function matching exhaustively over all `AIAgentActionType` variants (no `_` arm); `output_streaming` comes from `AIBlockOutputStatus::is_streaming()` and `block_state` from `TuiAIBlock::command_block_state` at render time. Helpers:
 
 - `single_line`: first line only, capped at 80 chars, `…` appended when trimmed (mirrors the GUI's `format_command_text`).
 - `display_path`: `"."` → "the current directory" (mirrors `app/src/ai/blocklist/block/view_impl/output.rs:2425-2433`).
@@ -71,7 +71,7 @@ Placeholders: `{cmd}`=command, `{q}`=query, `{qs}`/`{pats}`=comma-joined queries
 
 Footnotes:
 
-1. `LongRunningCommandSnapshot` (agent-monitored command) counts as success. The stored action result is never superseded when the command later finishes, so the label consults the terminal `Block` (looked up by the snapshot's `block_id`, mirroring the GUI's stale-result override in `RequestedCommandView`, requested_command.rs:1368-1376): block still running → "`{cmd}` is still running"; finished → "Ran `{cmd}`" / "`{cmd}` exited with code {n}" / "Cancelled `{cmd}`" (SIGINT), per the block's exit code.
+1. For `RequestCommandOutput` rows, the terminal `Block` backing the command supersedes the action status/result for execution states whenever it exists (GUI parity: `RequestedCommandView` derives icon and expandability from the block, requested_command.rs:1148-1154, 1275-1307). Block running → "Running `{cmd}`"; finished → "Ran `{cmd}`" / "`{cmd}` exited with code {n}" / "Cancelled `{cmd}`" (SIGINT), per the block's exit code. This matters especially for agent-monitored commands, whose stored result stays a `LongRunningCommandSnapshot` forever; with no local block (viewers, restored sessions) that snapshot result falls back to "`{cmd}` is still running".
 2. `{code}` from the completed exit code; `Denylisted` → "`{cmd}` denied (denylisted)". Exit code 130 is classified as cancelled by `AIAgentActionResultType::is_cancelled`.
 3. 0 results → "…, no results". `{repo}` = file name of the request's `codebase_path`; the " in {repo}" segment is omitted when absent.
 4. `CodebaseNotIndexed` appends " because the codebase isn't indexed".
@@ -86,21 +86,21 @@ Footnotes:
 
 ### Rendering and styling
 
-`render_tool_call_section(action, status, app)` in `crates/warp_tui/src/agent_block_sections.rs` styles the label by display state:
+`render_tool_call_section(action, status, output_streaming, block_state, app)` in `crates/warp_tui/src/agent_block_sections.rs` styles the label by display state:
 
-- Pending / AwaitingApproval / Running / Cancelled → `TuiUiBuilder::dim_text_style()`
+- Constructing / Pending / AwaitingApproval / Running / Cancelled → `TuiUiBuilder::dim_text_style()`
 - Succeeded → `TuiUiBuilder::muted_text_style()`
 - Failed → `TuiUiBuilder::error_text_style()` (new; `terminal_colors().normal.red`, `crates/warp_tui/src/tui_builder.rs`)
 
 ### Status plumbing and re-render
 
-- `TuiAIBlock` stores the `ModelHandle<BlocklistAIActionModel>` and looks up `get_action_status(&action.id)` at render time for each tool-call section (`crates/warp_tui/src/agent_block.rs`). It also holds the surface's `Arc<FairMutex<TerminalModel>>`: for long-running-snapshot results it resolves the command block's ground truth via `lrc_command_state`.
+- `TuiAIBlock` stores the `ModelHandle<BlocklistAIActionModel>` and looks up `get_action_status(&action.id)` at render time for each tool-call section (`crates/warp_tui/src/agent_block.rs`). It also holds the surface's `Arc<FairMutex<TerminalModel>>`: for every shell-command action it resolves the backing block's ground truth via `command_block_state` (lookup by `block_for_ai_action_id`, with the snapshot result's `block_id` as fallback).
 - `TuiTranscriptView` subscribes to `BlocklistAIActionEvent`; on any transition it finds the agent block whose output contains that action id (`TuiAIBlock::renders_action`), calls `mark_rich_content_dirty(view_id)`, and notifies (`crates/warp_tui/src/transcript_view.rs`). Dirty-marking is required because label text changes can change wrapped height, and block heights are cached in the block list. Each block maintains a `HashSet` of its action ids (populated by `sync_action_views` as output streams in, mirroring the GUI `AIBlock`'s `requested_action_ids`), so the per-event check is an O(1) set lookup per block rather than an output-message scan.
 - `app/src/tui_export.rs` additionally exports `AIActionStatus`, `BlocklistAIActionEvent`, and the request/result types the label logic and its tests consume; `app/src/ai/blocklist/mod.rs` re-exports `AIActionStatus` and `BlocklistAIActionEvent` publicly.
 
 ## Testing and validation
 
-- `crates/warp_tui/src/tool_call_labels_tests.rs` — a single lifecycle test asserting the label text changes as one action moves through pending → awaiting approval → running → cancelled/failed. Per-tool string variants are intentionally not unit-tested; the table above is the source of truth for copy.
+- `crates/warp_tui/src/tool_call_labels_tests.rs` — a single lifecycle test asserting the label text changes as one action moves through constructing → pending → awaiting approval → running → cancelled/failed, plus the block-state overrides for a snapshot result (no block / running / exit 0 / exit 1 / exit 130). Per-tool string variants are intentionally not unit-tested; the table above is the source of truth for copy.
 - `crates/warp_tui/src/agent_block_tests.rs` — transcript rendering asserts label text, dim styling, and message ordering through the real `BlocklistAIActionModel` fixture.
 - `cargo nextest run -p warp_tui`, `./script/format --check`, and presubmit-style clippy on `warp` + `warp_tui` all pass.
 


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

Before this PR, we were just rendering a generic "tool call executed" row whenever the agent executed a tool call. For some tool calls we'll want specific views with more detailed state (i.e. the ask questions tool, shell command execution, diffs, etc.), but for many others (like grep) we'll just want some stateful text like "grepping for ..." -> "grepped for ... w/ ... results".

This PR adds in that stateful, differentiated text for each tool call (besides file edits, which already have a special separate rendering path). As we add more specific rendering for some tool calls, we can remove them from the text match arm, but for now our text match covers all tool calls besides file edits.

## Files to look at
* `specs/CODE-1815/TECH.md`: gives a general overview of the PR's structure
* `crates/warp_tui/src/agent_block.rs`: the main thing to notice here is that, specifically for shell commands, we're referencing the command block state itself for the shell command header, instead of referencing the action model to get the action state. This is because agent-run shell commands are actually composed of multiple different tool calls + results (i.e. a shell command request, which is responded to with an LRC snapshot, and then a request when the shell command is finished to get the contents of the command). This is following GUI prior art
* `crates/warp_tui/src/tool_call_labels.rs`: this is very skim-able, but it's worth reading over the fns offered (and then skimming the giant match arm where we assign different labels for each (tool call, state) combination).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

https://www.loom.com/share/48bdbf10bce44417aa1e21c38f3231cd

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
