### PR TITLE
Detect CLI agents in wrapper commands like 'headroom warp opencode'

### DIFF
--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -423,15 +423,35 @@ impl CLIAgent {
             })
             .unwrap_or(Cow::Borrowed(trimmed));
 
+        // Check multi-word special patterns first (e.g. `aifx agent run claude`).
+        if Self::is_aifx_agent_run_claude(&resolved_command, ctx) {
+            return Some(CLIAgent::Claude);
+        }
+
         // Check if resolved command matches any known CLI agent.
-        // Also matches `aifx agent run claude` as Claude for Uber employees.
-        enum_iterator::all::<CLIAgent>()
+        let direct_match = enum_iterator::all::<CLIAgent>()
             .filter(|agent| !matches!(agent, CLIAgent::Unknown))
-            .find(|agent| {
-                agent.matches_command(&resolved_command, escape_char)
-                    || (matches!(agent, CLIAgent::Claude)
-                        && Self::is_aifx_agent_run_claude(&resolved_command, ctx))
-            })
+            .find(|agent| agent.matches_command(&resolved_command, escape_char));
+
+        if direct_match.is_some() {
+            return direct_match;
+        }
+
+        // Scan the first few words for a known CLI agent. This handles wrapper
+        // commands like `headroom warp opencode` or `npx opencode` where the
+        // actual agent binary appears after launcher/subcommand words.
+        // Limited to 6 words to avoid false positives on unrelated commands.
+        for word in resolved_command.split_whitespace().take(6).skip(1) {
+            let basename = word.rsplit(['/', '\\']).next().unwrap_or(word);
+            let matched = enum_iterator::all::<CLIAgent>()
+                .filter(|agent| !matches!(agent, CLIAgent::Unknown))
+                .find(|agent| agent.command_prefixes().contains(&basename));
+            if matched.is_some() {
+                return matched;
+            }
+        }
+
+        None
     }
 
     /// Returns true if the resolved command is `aifx agent run claude` (Uber's

--- a/app/src/terminal/cli_agent_tests.rs
+++ b/app/src/terminal/cli_agent_tests.rs
@@ -339,6 +339,42 @@ fn test_detect_no_match() {
             assert_eq!(CLIAgent::detect("ls -la", None, None, ctx), None);
             assert_eq!(CLIAgent::detect("vim", None, None, ctx), None);
             assert_eq!(CLIAgent::detect("claude_wrapper", None, None, ctx), None);
+            // Agent name appearing beyond the first 6 words is not detected
+            assert_eq!(
+                CLIAgent::detect("a b c d e f opencode", None, None, ctx),
+                None
+            );
+        });
+    });
+}
+
+#[test]
+fn test_detect_wrapper_commands() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            assert_eq!(
+                CLIAgent::detect("headroom warp opencode", None, None, ctx),
+                Some(CLIAgent::OpenCode),
+            );
+            assert_eq!(
+                CLIAgent::detect("npx opencode", None, None, ctx),
+                Some(CLIAgent::OpenCode),
+            );
+            assert_eq!(
+                CLIAgent::detect("some-wrapper claude --model opus", None, None, ctx),
+                Some(CLIAgent::Claude),
+            );
+            assert_eq!(
+                CLIAgent::detect("env VAR=1 gemini", None, None, ctx),
+                Some(CLIAgent::Gemini),
+            );
+            // Agent name within first 6 words is detected (caller filters by
+            // long-running status, so quick commands like `ls` won't trigger
+            // the agent UI in practice)
+            assert_eq!(
+                CLIAgent::detect("ls opencode", None, None, ctx),
+                Some(CLIAgent::OpenCode),
+            );
         });
     });
 }


### PR DESCRIPTION
The CLIAgent::detect function previously only checked the first word of a command, which caused wrapper commands like 'headroom warp opencode' to fail detection. This prevented the CLI agent session from being created, breaking the 'attach as context' feature for wrapped agents.

Now scans up to the first 6 words for a known CLI agent match after checking the first word. Special patterns like 'aifx agent run claude' are checked first to avoid false matches on intermediate words like 'agent' (CursorCli prefix).

## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

After entering the headroom warp opencode, right-click the file list and select attach as context, which can be added normally.

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

Fixes #13420
Fixes #12721

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

https://github.com/user-attachments/assets/41f61aea-c088-405c-ae25-08f839376612


CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
