### PR TITLE
Discover local project skills/rules via standalone standing-query walk (OnTheFlyStandingQueries)

### DIFF
--- a/app/src/ai/skills/file_watchers/skill_watcher.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher.rs
@@ -8,10 +8,12 @@ use ai::skills::{
 };
 use async_channel::Sender;
 use futures::future::BoxFuture;
-use repo_metadata::repositories::DetectedRepositories;
+use repo_metadata::repositories::{DetectedRepositories, DetectedRepositoriesEvent};
 use repo_metadata::repository::{Repository, SubscriberId};
 use repo_metadata::{DirectoryWatcher, RepoMetadataModel, RepositoryIdentifier, RepositoryUpdate};
+use warp_core::features::FeatureFlag;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warp_util::standardized_path::StandardizedPath;
 use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
 use watcher::{BulkFilesystemWatcherEvent, HomeDirectoryWatcher, HomeDirectoryWatcherEvent};
 
@@ -19,8 +21,9 @@ use super::subscribers::{
     HomeSkillSubscriber, ProjectSkillSubscriber, SkillRepositoryMessage, SymlinkSkillSubscriber,
 };
 use super::utils::{
-    find_local_project_skill_files_on_filesystem, find_project_skill_files_in_tree,
-    is_home_provider_path, is_home_skill_directory, is_skill_file, read_skills_from_directories,
+    find_local_project_skill_files_on_filesystem, find_local_project_skill_files_with_walk,
+    find_project_skill_files_in_tree, is_home_provider_path, is_home_skill_directory,
+    is_skill_file, path_is_project_skill_relevant, read_skills_from_directories,
     read_skills_from_files,
 };
 use crate::ai::remote_context_files::{
@@ -52,11 +55,14 @@ pub struct SkillWatcher {
     /// Allocates refresh generations that cannot be reused if a repository is removed
     /// and subsequently re-added while an old task is still in flight.
     next_project_skill_refresh_generation: u64,
-    /// Failed local repos still need the project file watcher path because
-    /// repo metadata indexing can fail for oversized repos. This replaces the
-    /// previous `watched_repos` set so we only subscribe when fallback is active
-    /// and can also clean up the subscriber on repo removal.
-    failed_local_project_watchers: HashMap<PathBuf, (ModelHandle<Repository>, SubscriberId)>,
+    /// Local repos with a direct project file watcher.
+    ///
+    /// With [`FeatureFlag::OnTheFlyStandingQueries`] enabled this is the primary
+    /// discovery path for every detected local repo: the `Repository` recursive
+    /// watch triggers standing-query re-walks. With the flag disabled it only
+    /// holds fallback watchers for repos whose repo metadata indexing failed
+    /// (indexing can fail for oversized repos).
+    local_project_watchers: HashMap<PathBuf, (ModelHandle<Repository>, SubscriberId)>,
     watcher_event_tx: Sender<SkillWatcherEvent>,
     /// Tracks watchers on home provider directories (e.g. ~/.agents, ~/.claude) so they
     /// can be cleaned up when the directory is deleted.
@@ -181,23 +187,42 @@ impl SkillWatcher {
         // RepoMetadataModel for both local and remote repos when available, while
         // local repos fall back to a direct project watcher only if metadata
         // indexing fails.
+        //
+        // With `OnTheFlyStandingQueries` enabled, local repos instead use the
+        // standalone standing-query walk as the primary path: metadata events
+        // only ensure the repo's direct watcher exists (covering repos indexed
+        // without a `DetectedGitRepo` event, e.g. user-added workspaces), and
+        // freshness comes from that watcher's re-walks. Remote repos keep the
+        // metadata-backed path in both modes.
         ctx.subscribe_to_model(&RepoMetadataModel::handle(ctx), |me, _, event, ctx| {
             use repo_metadata::wrapper_model::RepoMetadataEvent;
             match event {
                 RepoMetadataEvent::RepositoryUpdated { id } => {
-                    me.refresh_project_skills_for_repo(id, ctx);
+                    if local_uses_standing_query_walk(id) {
+                        me.ensure_local_project_discovery(id, ctx);
+                    } else {
+                        me.refresh_project_skills_for_repo(id, ctx);
+                    }
                 }
                 RepoMetadataEvent::StandingQueryResultsUpdated { id, delta } => {
-                    if delta.project_skills_changed() {
+                    if local_uses_standing_query_walk(id) {
+                        // Freshness is driven by the repo's direct watcher re-walks.
+                    } else if delta.project_skills_changed() {
                         me.refresh_project_skills_for_repo(id, ctx);
                     }
                 }
                 RepoMetadataEvent::RepositoryRemoved { id } => {
                     me.remove_project_skills_for_repo(id);
-                    me.stop_failed_local_project_watcher(id, ctx);
+                    me.stop_local_project_watcher(id, ctx);
                 }
                 RepoMetadataEvent::UpdatingRepositoryFailed { id } => {
-                    me.fallback_to_local_project_watcher(id, ctx);
+                    if local_uses_standing_query_walk(id) {
+                        // The walk-based primary path does not depend on
+                        // indexing; just make sure the repo is watched.
+                        me.ensure_local_project_discovery(id, ctx);
+                    } else {
+                        me.fallback_to_local_project_watcher(id, ctx);
+                    }
                 }
                 RepoMetadataEvent::FileTreeUpdated { .. }
                 | RepoMetadataEvent::FileTreeEntryUpdated { .. }
@@ -205,12 +230,24 @@ impl SkillWatcher {
             }
         });
 
+        // With `OnTheFlyStandingQueries` enabled, repo detection (rather than
+        // eager metadata indexing) is the primary trigger for local project
+        // skill discovery.
+        ctx.subscribe_to_model(&DetectedRepositories::handle(ctx), |me, _, event, ctx| {
+            if !FeatureFlag::OnTheFlyStandingQueries.is_enabled() {
+                return;
+            }
+            let DetectedRepositoriesEvent::DetectedGitRepo { repository, .. } = event;
+            let repo_id = RepositoryIdentifier::local(repository.as_ref(ctx).root_dir().clone());
+            me.ensure_local_project_discovery(&repo_id, ctx);
+        });
+
         Self {
             repository_message_tx,
             project_skill_files_by_repo: HashMap::new(),
             project_skill_refresh_generations: HashMap::new(),
             next_project_skill_refresh_generation: 0,
-            failed_local_project_watchers: HashMap::new(),
+            local_project_watchers: HashMap::new(),
             watcher_event_tx,
             home_provider_watchers,
             symlink_canonical_to_originals: HashMap::new(),
@@ -230,10 +267,27 @@ impl SkillWatcher {
                 .into_iter()
                 .collect()
         };
+        self.apply_project_skill_refresh(
+            repo_id.clone(),
+            refresh_generation,
+            current_skill_files,
+            ctx,
+        );
+    }
 
+    /// Applies a freshly discovered set of project skill files: emits deletions
+    /// for skills that disappeared, re-reads the current set, and records it as
+    /// the latest known state for the repository.
+    fn apply_project_skill_refresh(
+        &mut self,
+        repo_id: RepositoryIdentifier,
+        refresh_generation: u64,
+        current_skill_files: HashSet<LocalOrRemotePath>,
+        ctx: &mut ModelContext<Self>,
+    ) {
         let previous_skill_files = self
             .project_skill_files_by_repo
-            .get(repo_id)
+            .get(&repo_id)
             .cloned()
             .unwrap_or_default();
 
@@ -265,7 +319,111 @@ impl SkillWatcher {
         );
 
         self.project_skill_files_by_repo
-            .insert(repo_id.clone(), current_skill_files);
+            .insert(repo_id, current_skill_files);
+    }
+
+    /// Ensures the walk-based primary discovery path is active for a local
+    /// repository: registers the direct project watcher if needed and runs the
+    /// initial standing-query walk on first registration. Subsequent freshness
+    /// comes from the watcher's re-walks.
+    fn ensure_local_project_discovery(
+        &mut self,
+        repo_id: &RepositoryIdentifier,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let RepositoryIdentifier::Local(repo_root) = repo_id else {
+            return;
+        };
+        let Some(local_path) = repo_root.to_local_path() else {
+            return;
+        };
+        let newly_watched = !self.local_project_watchers.contains_key(&local_path);
+        self.watch_local_project_repo(local_path, ctx);
+        if newly_watched {
+            self.refresh_local_project_skills_via_walk(repo_id.clone(), ctx);
+        }
+    }
+
+    /// Re-discovers a local repository's project skills with the standalone
+    /// standing-query walk on a background thread.
+    fn refresh_local_project_skills_via_walk(
+        &mut self,
+        repo_id: RepositoryIdentifier,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let RepositoryIdentifier::Local(repo_root) = &repo_id else {
+            return;
+        };
+        let Some(local_path) = repo_root.to_local_path() else {
+            return;
+        };
+        let refresh_generation = self.advance_project_skill_refresh_generation(&repo_id);
+        ctx.spawn(
+            async move { find_local_project_skill_files_with_walk(&local_path) },
+            move |me, skill_files, ctx| {
+                if me.project_skill_refresh_generations.get(&repo_id) != Some(&refresh_generation) {
+                    return;
+                }
+                me.apply_project_skill_refresh(
+                    repo_id,
+                    refresh_generation,
+                    skill_files.into_iter().collect(),
+                    ctx,
+                );
+            },
+        );
+    }
+
+    /// Handles a direct project watcher update when the walk-based primary
+    /// path is active: skill-relevant changes trigger a full re-walk of the
+    /// repository's standing queries.
+    fn handle_local_project_walk_update(
+        &mut self,
+        root_dir: &StandardizedPath,
+        update: &RepositoryUpdate,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let repo_id = RepositoryIdentifier::local(root_dir.clone());
+        if !self.update_touches_project_skills(&repo_id, update) {
+            return;
+        }
+        self.refresh_local_project_skills_via_walk(repo_id, ctx);
+    }
+
+    /// Returns whether a repository update can affect project skill discovery:
+    /// a changed path is skill-relevant (a `SKILL.md` or anything at/below a
+    /// provider directory), or a deletion/move removed a directory above a
+    /// known skill file.
+    fn update_touches_project_skills(
+        &self,
+        repo_id: &RepositoryIdentifier,
+        update: &RepositoryUpdate,
+    ) -> bool {
+        let changed_paths = update
+            .added_or_modified()
+            .chain(update.deleted.iter())
+            .chain(update.moved.keys())
+            .chain(update.moved.values());
+        for target in changed_paths {
+            if path_is_project_skill_relevant(&target.path) {
+                return true;
+            }
+        }
+
+        let Some(known_skill_files) = self.project_skill_files_by_repo.get(repo_id) else {
+            return false;
+        };
+        update
+            .deleted
+            .iter()
+            .chain(update.moved.values())
+            .any(|removed| {
+                known_skill_files.iter().any(|skill| {
+                    skill
+                        .to_local_path()
+                        .is_some_and(|path| path.starts_with(&removed.path))
+                })
+            })
     }
 
     fn advance_project_skill_refresh_generation(&mut self, repo_id: &RepositoryIdentifier) -> u64 {
@@ -288,24 +446,27 @@ impl SkillWatcher {
         };
 
         self.scan_local_project_skills_from_filesystem(&local_path, ctx);
-        self.watch_failed_local_project_repo(local_path, ctx);
+        self.watch_local_project_repo(local_path, ctx);
     }
 
-    /// Register a failed local project root to watch for skill file changes.
-    fn watch_failed_local_project_repo(
-        &mut self,
-        repo_path: PathBuf,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        if self.failed_local_project_watchers.contains_key(&repo_path) {
+    /// Register a local project root to watch for skill file changes.
+    ///
+    /// This serves the flag-on walk-based primary path for every detected
+    /// repo, and the indexing-failure fallback path when the flag is off.
+    fn watch_local_project_repo(&mut self, repo_path: PathBuf, ctx: &mut ModelContext<Self>) {
+        if self.local_project_watchers.contains_key(&repo_path) {
             return;
         }
 
-        let Some(repo_handle) =
-            DetectedRepositories::as_ref(ctx).get_local_watched_repo_for_path(&repo_path, ctx)
-        else {
+        // Repos registered without a `DetectedGitRepo` event (e.g. user-added
+        // workspaces) are absent from `DetectedRepositories`; fall back to the
+        // directory watcher's registration directly.
+        let repo_handle = DetectedRepositories::as_ref(ctx)
+            .get_local_watched_repo_for_path(&repo_path, ctx)
+            .or_else(|| DirectoryWatcher::as_ref(ctx).get_watched_directory_for_path(&repo_path));
+        let Some(repo_handle) = repo_handle else {
             log::warn!(
-                "Could not start local project skill fallback watcher for {}; repo is not watched",
+                "Could not start local project skill watcher for {}; repo is not watched",
                 repo_path.display()
             );
             return;
@@ -316,17 +477,17 @@ impl SkillWatcher {
         });
         let start = repo_handle.update(ctx, |repo, ctx| repo.start_watching(subscriber, ctx));
         let subscriber_id = start.subscriber_id;
-        self.failed_local_project_watchers
+        self.local_project_watchers
             .insert(repo_path.clone(), (repo_handle.clone(), subscriber_id));
 
         ctx.spawn(start.registration_future, move |me, res, ctx| {
             if let Err(err) = res {
                 log::warn!(
-                    "Failed to start local project skill fallback watcher for {}: {err}",
+                    "Failed to start local project skill watcher for {}: {err}",
                     repo_path.display()
                 );
                 if let Some((repo_handle, subscriber_id)) =
-                    me.failed_local_project_watchers.remove(&repo_path)
+                    me.local_project_watchers.remove(&repo_path)
                 {
                     repo_handle.update(ctx, |repo, ctx| {
                         repo.stop_watching(subscriber_id, ctx);
@@ -418,7 +579,7 @@ impl SkillWatcher {
         );
     }
 
-    fn stop_failed_local_project_watcher(
+    fn stop_local_project_watcher(
         &mut self,
         repo_id: &RepositoryIdentifier,
         ctx: &mut ModelContext<Self>,
@@ -429,8 +590,7 @@ impl SkillWatcher {
         let Some(local_path) = repo_path.to_local_path() else {
             return;
         };
-        let Some((repo_handle, subscriber_id)) =
-            self.failed_local_project_watchers.remove(&local_path)
+        let Some((repo_handle, subscriber_id)) = self.local_project_watchers.remove(&local_path)
         else {
             return;
         };
@@ -497,8 +657,12 @@ impl SkillWatcher {
                     .watcher_event_tx
                     .try_send(SkillWatcherEvent::SkillsAdded { skills });
             }
-            SkillRepositoryMessage::ProjectRepositoryUpdate { update } => {
-                self.handle_failed_local_project_update(&update, ctx);
+            SkillRepositoryMessage::ProjectRepositoryUpdate { root_dir, update } => {
+                if FeatureFlag::OnTheFlyStandingQueries.is_enabled() {
+                    self.handle_local_project_walk_update(&root_dir, &update, ctx);
+                } else {
+                    self.handle_failed_local_project_update(&update, ctx);
+                }
             }
             SkillRepositoryMessage::HomeRepositoryUpdate { update } => {
                 self.handle_repository_update(&update, ctx);
@@ -1038,6 +1202,14 @@ impl SkillWatcher {
             }
         });
     }
+}
+
+/// Returns whether the walk-based standing-query path handles this repository:
+/// local repositories only, and only when `OnTheFlyStandingQueries` is enabled.
+/// Remote repositories always use the metadata-backed standing results.
+fn local_uses_standing_query_walk(repo_id: &RepositoryIdentifier) -> bool {
+    matches!(repo_id, RepositoryIdentifier::Local(_))
+        && FeatureFlag::OnTheFlyStandingQueries.is_enabled()
 }
 
 fn read_project_skill_contents(

--- a/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher_tests.rs
@@ -11,6 +11,7 @@ use repo_metadata::{
     StandingQueryContent, StandingQueryResults, StandingQueryResultsDelta, TargetFile,
 };
 use tempfile::TempDir;
+use warp_core::features::FeatureFlag;
 use warp_util::host_id::HostId;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::remote_path::RemotePath;
@@ -352,7 +353,7 @@ fn test_refresh_project_skills_for_repo_uses_repo_metadata_without_fallback_watc
         });
         skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
             skill_watcher.refresh_project_skills_for_repo(&repo_id, ctx);
-            assert!(skill_watcher.failed_local_project_watchers.is_empty());
+            assert!(skill_watcher.local_project_watchers.is_empty());
         });
 
         assert_eq!(
@@ -385,7 +386,7 @@ fn test_local_project_fallback_scans_filesystem_when_repo_metadata_fails() {
         let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
         skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
             skill_watcher.fallback_to_local_project_watcher(&repo_id, ctx);
-            assert!(skill_watcher.failed_local_project_watchers.is_empty());
+            assert!(skill_watcher.local_project_watchers.is_empty());
         });
 
         let SkillWatcherEvent::SkillsAdded { mut skills } = rx.recv().await.unwrap() else {
@@ -454,6 +455,7 @@ fn test_local_project_fallback_update_reuses_repository_update_handler() {
         let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
 
         let temp_dir = TempDir::new().unwrap();
+        let root_dir = StandardizedPath::try_from_local(temp_dir.path()).unwrap();
         let skill = create_skill_file(&temp_dir, "fallback-update", "Fallback update", "Content");
         let update = RepositoryUpdate {
             added: HashSet::new(),
@@ -467,7 +469,7 @@ fn test_local_project_fallback_update_reuses_repository_update_handler() {
 
         skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
             skill_watcher.handle_message(
-                SkillRepositoryMessage::ProjectRepositoryUpdate { update },
+                SkillRepositoryMessage::ProjectRepositoryUpdate { root_dir, update },
                 ctx,
             );
         });
@@ -492,6 +494,7 @@ fn test_local_project_fallback_directory_addition_scans_filesystem() {
         let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
 
         let temp_dir = TempDir::new().unwrap();
+        let root_dir = StandardizedPath::try_from_local(temp_dir.path()).unwrap();
         let new_dir = temp_dir.path().join("packages/frontend");
         let skill =
             create_skill_file_in_directory(&new_dir, "fallback-dir", "Fallback dir", "Content");
@@ -507,7 +510,7 @@ fn test_local_project_fallback_directory_addition_scans_filesystem() {
 
         skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
             skill_watcher.handle_message(
-                SkillRepositoryMessage::ProjectRepositoryUpdate { update },
+                SkillRepositoryMessage::ProjectRepositoryUpdate { root_dir, update },
                 ctx,
             );
         });
@@ -833,5 +836,206 @@ fn test_refresh_project_skills_for_repo_removes_missing_project_skill_paths() {
                 paths: vec![skill.path]
             }
         );
+    });
+}
+
+// ============================================================================
+// Tests for the flag-on walk-based primary discovery path
+// ============================================================================
+
+#[test]
+fn test_on_the_fly_walk_discovers_project_skills_on_repo_detection() {
+    let (tx, rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        let _flag = FeatureFlag::OnTheFlyStandingQueries.override_enabled(true);
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
+
+        let temp_dir = TempDir::new().unwrap();
+        let repo = dunce::canonicalize(temp_dir.path()).unwrap();
+        let skill = create_skill_file_in_directory(&repo, "walk-skill", "Walk skill", "Content");
+
+        let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
+        skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
+            skill_watcher.ensure_local_project_discovery(&repo_id, ctx);
+        });
+
+        assert_eq!(
+            rx.recv().await.unwrap(),
+            SkillWatcherEvent::SkillsAdded {
+                skills: vec![skill]
+            }
+        );
+    });
+}
+
+#[test]
+fn test_on_the_fly_walk_respects_gitignore() {
+    let (tx, rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        let _flag = FeatureFlag::OnTheFlyStandingQueries.override_enabled(true);
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
+
+        let temp_dir = TempDir::new().unwrap();
+        let repo = dunce::canonicalize(temp_dir.path()).unwrap();
+        // Provider directories are force-included, so the skill is discovered
+        // even though `.agents/` is gitignored...
+        let skill = create_skill_file_in_directory(&repo, "kept-skill", "Kept skill", "Content");
+        // ...while an ignored non-provider subtree containing a stray SKILL.md
+        // stays out of the results.
+        let ignored_dir = repo.join("ignored/.agents/skills/hidden");
+        fs::create_dir_all(&ignored_dir).unwrap();
+        fs::write(ignored_dir.join("SKILL.md"), "---\nname: hidden\n---\n").unwrap();
+        fs::write(repo.join(".gitignore"), "ignored/\n.agents/\n").unwrap();
+
+        let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
+        skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
+            skill_watcher.ensure_local_project_discovery(&repo_id, ctx);
+        });
+
+        let SkillWatcherEvent::SkillsAdded { skills } = rx.recv().await.unwrap() else {
+            panic!("Expected SkillsAdded event");
+        };
+        assert_eq!(skills, vec![skill]);
+    });
+}
+
+#[test]
+fn test_on_the_fly_walk_rediscovers_skills_on_relevant_update() {
+    let (tx, rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        let _flag = FeatureFlag::OnTheFlyStandingQueries.override_enabled(true);
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
+
+        let temp_dir = TempDir::new().unwrap();
+        let repo = dunce::canonicalize(temp_dir.path()).unwrap();
+        let root_dir = StandardizedPath::try_from_local(&repo).unwrap();
+        let skill =
+            create_skill_file_in_directory(&repo, "edited-skill", "Edited skill", "Content");
+
+        let update = RepositoryUpdate {
+            added: HashSet::new(),
+            modified: HashSet::from([TargetFile::new(skill_local_path(&skill), false)]),
+            deleted: HashSet::new(),
+            moved: HashMap::new(),
+            commit_updated: false,
+            index_lock_detected: false,
+            remote_ref_updated: false,
+        };
+
+        skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
+            skill_watcher.handle_message(
+                SkillRepositoryMessage::ProjectRepositoryUpdate { root_dir, update },
+                ctx,
+            );
+        });
+
+        assert_eq!(
+            rx.recv().await.unwrap(),
+            SkillWatcherEvent::SkillsAdded {
+                skills: vec![skill]
+            }
+        );
+    });
+}
+
+#[test]
+fn test_on_the_fly_walk_emits_deletions_after_skill_removed() {
+    let (tx, rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        let _flag = FeatureFlag::OnTheFlyStandingQueries.override_enabled(true);
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
+
+        let temp_dir = TempDir::new().unwrap();
+        let repo = dunce::canonicalize(temp_dir.path()).unwrap();
+        let root_dir = StandardizedPath::try_from_local(&repo).unwrap();
+        let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
+
+        // A previously known skill whose file no longer exists on disk.
+        let removed_skill_path =
+            LocalOrRemotePath::Local(repo.join(".agents/skills/removed/SKILL.md"));
+        skill_watcher_handle.update(&mut app, |skill_watcher, _| {
+            skill_watcher
+                .project_skill_files_by_repo
+                .insert(repo_id.clone(), HashSet::from([removed_skill_path.clone()]));
+        });
+
+        let update = RepositoryUpdate {
+            added: HashSet::new(),
+            modified: HashSet::new(),
+            deleted: HashSet::from([TargetFile::new(
+                removed_skill_path.to_local_path().unwrap().to_path_buf(),
+                false,
+            )]),
+            moved: HashMap::new(),
+            commit_updated: false,
+            index_lock_detected: false,
+            remote_ref_updated: false,
+        };
+
+        skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
+            skill_watcher.handle_message(
+                SkillRepositoryMessage::ProjectRepositoryUpdate { root_dir, update },
+                ctx,
+            );
+        });
+
+        assert_eq!(
+            rx.recv().await.unwrap(),
+            SkillWatcherEvent::SkillsDeleted {
+                paths: vec![removed_skill_path]
+            }
+        );
+    });
+}
+
+#[test]
+fn test_on_the_fly_walk_ignores_irrelevant_update() {
+    let (tx, _rx) = async_channel::unbounded();
+
+    App::test((), |mut app| async move {
+        let _flag = FeatureFlag::OnTheFlyStandingQueries.override_enabled(true);
+        app.add_singleton_model(DirectoryWatcher::new_for_testing);
+        app.add_singleton_model(|_| DetectedRepositories::default());
+        app.add_singleton_model(RepoMetadataModel::new);
+        let skill_watcher_handle = app.add_model(|ctx| SkillWatcher::new_for_testing(ctx, tx));
+
+        let temp_dir = TempDir::new().unwrap();
+        let repo = dunce::canonicalize(temp_dir.path()).unwrap();
+        let root_dir = StandardizedPath::try_from_local(&repo).unwrap();
+
+        let update = RepositoryUpdate {
+            added: HashSet::new(),
+            modified: HashSet::from([TargetFile::new(repo.join("src/main.rs"), false)]),
+            deleted: HashSet::new(),
+            moved: HashMap::new(),
+            commit_updated: false,
+            index_lock_detected: false,
+            remote_ref_updated: false,
+        };
+
+        skill_watcher_handle.update(&mut app, |skill_watcher, ctx| {
+            skill_watcher.handle_message(
+                SkillRepositoryMessage::ProjectRepositoryUpdate { root_dir, update },
+                ctx,
+            );
+            // No refresh was scheduled for an irrelevant change.
+            assert!(skill_watcher.project_skill_refresh_generations.is_empty());
+        });
     });
 }

--- a/app/src/ai/skills/file_watchers/subscribers.rs
+++ b/app/src/ai/skills/file_watchers/subscribers.rs
@@ -5,14 +5,18 @@ use async_channel::Sender;
 use futures::Future;
 use repo_metadata::repository::RepositorySubscriber;
 use repo_metadata::{Repository, RepositoryUpdate};
+use warp_util::standardized_path::StandardizedPath;
 use warpui::ModelContext;
 
 /// Messages sent from [`RepositorySubscriber`]s to [`SkillManager`].
 pub enum SkillRepositoryMessage {
     /// Initial scan of a home skills directory (e.g., `~/.agents`).
     HomeInitialScan { skills: Vec<ParsedSkill> },
-    /// Incremental file system updates from a local project fallback watcher.
-    ProjectRepositoryUpdate { update: RepositoryUpdate },
+    /// Incremental file system updates from a local project watcher.
+    ProjectRepositoryUpdate {
+        root_dir: StandardizedPath,
+        update: RepositoryUpdate,
+    },
     /// Incremental file system updates from a home provider directory.
     HomeRepositoryUpdate { update: RepositoryUpdate },
     /// File changes detected in a resolved symlink target directory.
@@ -37,16 +41,17 @@ impl RepositorySubscriber for ProjectSkillSubscriber {
 
     fn on_files_updated(
         &mut self,
-        _repository: &Repository,
+        repository: &Repository,
         update: &RepositoryUpdate,
         _ctx: &mut ModelContext<Repository>,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> {
         let tx = self.message_tx.clone();
+        let root_dir = repository.root_dir().clone();
         let update = update.clone();
 
         Box::pin(async move {
             let _ = tx
-                .send(SkillRepositoryMessage::ProjectRepositoryUpdate { update })
+                .send(SkillRepositoryMessage::ProjectRepositoryUpdate { root_dir, update })
                 .await;
         })
     }

--- a/app/src/ai/skills/file_watchers/utils.rs
+++ b/app/src/ai/skills/file_watchers/utils.rs
@@ -5,7 +5,10 @@ use ai::skills::{
     ParsedSkill, SkillProvider, SKILL_PROVIDER_DEFINITIONS,
 };
 use anyhow::Error;
-use repo_metadata::{RepoMetadataModel, RepositoryIdentifier};
+use repo_metadata::{
+    evaluate_standing_queries, RepoMetadataModel, RepositoryIdentifier, StandingQueryDefinitions,
+    StandingQueryWalkOptions,
+};
 use walkdir::{DirEntry, WalkDir};
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::remote_path::RemotePath;
@@ -73,6 +76,38 @@ pub(super) fn find_local_project_skill_files_on_filesystem(
                 .then_some(LocalOrRemotePath::Local(skill_file))
         })
         .collect()
+}
+
+/// Finds local project skill files with the standalone standing-query walk.
+///
+/// This is the primary local discovery path when
+/// [`FeatureFlag::OnTheFlyStandingQueries`](warp_core::features::FeatureFlag) is enabled: it
+/// evaluates the same standing-query definitions as the eager repo metadata walk (including
+/// gitignore pruning and symlinked provider children) without materializing a file tree.
+pub(super) fn find_local_project_skill_files_with_walk(scan_root: &Path) -> Vec<LocalOrRemotePath> {
+    let provider_paths: Vec<PathBuf> = SKILL_PROVIDER_DEFINITIONS
+        .iter()
+        .map(|provider| provider.skills_path.clone())
+        .collect();
+    let mut definitions = StandingQueryDefinitions::default();
+    definitions.set_project_skill_provider_paths(provider_paths.clone());
+    let options = StandingQueryWalkOptions {
+        force_included_paths: provider_paths,
+        ..Default::default()
+    };
+    evaluate_standing_queries(scan_root, &definitions, &options)
+        .project_skills()
+        .filter(|content| !content.is_directory)
+        .map(|content| LocalOrRemotePath::Local(content.path.to_local_path_lossy()))
+        .collect()
+}
+
+/// Returns whether a changed path can affect project skill discovery: the
+/// path is a `SKILL.md` file, or it is at or below a skill provider directory
+/// (e.g. `.agents/skills`).
+pub(super) fn path_is_project_skill_relevant(path: &Path) -> bool {
+    path.file_name().and_then(|name| name.to_str()) == Some("SKILL.md")
+        || path.ancestors().any(is_project_provider_path)
 }
 
 fn find_local_provider_directories_on_filesystem(scan_root: &Path) -> Vec<PathBuf> {

--- a/crates/ai/Cargo.toml
+++ b/crates/ai/Cargo.toml
@@ -81,6 +81,7 @@ notify-debouncer-full.workspace = true
 
 [dev-dependencies]
 filetime = "0.2.25"
+repo_metadata = { workspace = true, features = ["test-util"] }
 tempfile.workspace = true
 virtual-fs.workspace = true
 warp_core = { workspace = true, features = ["test-util"] }

--- a/crates/ai/src/project_context/model.rs
+++ b/crates/ai/src/project_context/model.rs
@@ -11,11 +11,20 @@ use super::GlobalRules;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "local_fs")] {
+        use std::pin::Pin;
+
+        use async_channel::Sender;
+        use repo_metadata::repositories::{DetectedRepositories, DetectedRepositoriesEvent};
+        use repo_metadata::repository::{Repository, RepositorySubscriber, SubscriberId};
         use repo_metadata::{
-            RepoMetadataEvent, RepoMetadataModel, RepositoryIdentifier, StandingQueryContent,
+            evaluate_standing_queries, DirectoryWatcher, RepoMetadataEvent, RepoMetadataModel,
+            RepositoryIdentifier, RepositoryUpdate, StandingQueryContent,
+            StandingQueryDefinitions, StandingQueryWalkOptions, STANDING_QUERY_WALK_MAX_DEPTH,
         };
+        use warp_core::features::FeatureFlag;
         use warp_util::remote_path::RemotePath;
         use warp_util::standardized_path::StandardizedPath;
+        use warpui_core::ModelHandle;
     }
 }
 
@@ -27,6 +36,64 @@ pub type ProjectRuleContentReader = fn(
     Vec<LocalOrRemotePath>,
     &AppContext,
 ) -> BoxFuture<'static, anyhow::Result<ProjectRuleContents>>;
+
+/// A repository update from a directly watched local rule root, tagged with
+/// the watched root so the model can re-walk the right repository.
+#[cfg(feature = "local_fs")]
+type LocalRuleWatchMessage = (StandardizedPath, RepositoryUpdate);
+
+/// Repository subscriber that forwards file change events for a watched local
+/// rule root back to [`ProjectContextModel`].
+#[cfg(feature = "local_fs")]
+struct ProjectRuleSubscriber {
+    message_tx: Sender<LocalRuleWatchMessage>,
+}
+
+#[cfg(feature = "local_fs")]
+impl RepositorySubscriber for ProjectRuleSubscriber {
+    fn on_scan(
+        &mut self,
+        _repository: &Repository,
+        _ctx: &mut ModelContext<Repository>,
+    ) -> Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>> {
+        // The initial walk is triggered directly when discovery starts; this
+        // subscriber only keeps rule results fresh afterward.
+        Box::pin(async {})
+    }
+
+    fn on_files_updated(
+        &mut self,
+        repository: &Repository,
+        update: &RepositoryUpdate,
+        _ctx: &mut ModelContext<Repository>,
+    ) -> Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>> {
+        let tx = self.message_tx.clone();
+        let root_dir = repository.root_dir().clone();
+        let update = update.clone();
+        Box::pin(async move {
+            let _ = tx.send((root_dir, update)).await;
+        })
+    }
+}
+
+/// Returns whether the walk-based standing-query path handles this repository:
+/// local repositories only, and only when `OnTheFlyStandingQueries` is enabled.
+/// Remote repositories always use the metadata-backed standing results.
+#[cfg(feature = "local_fs")]
+fn local_uses_standing_query_walk(repo_id: &RepositoryIdentifier) -> bool {
+    matches!(repo_id, RepositoryIdentifier::Local(_))
+        && FeatureFlag::OnTheFlyStandingQueries.is_enabled()
+}
+
+/// Returns whether a changed path can affect project rule discovery.
+#[cfg(feature = "local_fs")]
+fn path_is_project_rule_relevant(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            name.eq_ignore_ascii_case("WARP.md") || name.eq_ignore_ascii_case("AGENTS.md")
+        })
+}
 
 #[cfg(feature = "local_fs")]
 fn standing_project_rule_paths<'a>(
@@ -209,6 +276,19 @@ pub struct ProjectContextModel {
     rule_refresh_generations: HashMap<RepositoryIdentifier, u64>,
     #[cfg(feature = "local_fs")]
     next_rule_refresh_generation: u64,
+    /// App-provided rule content reader, stored so walk-based refreshes
+    /// triggered outside metadata events can read rule contents.
+    #[cfg(feature = "local_fs")]
+    project_rule_content_reader: Option<ProjectRuleContentReader>,
+    /// Sender for updates from directly watched local rule roots. Present only
+    /// after `new_from_persisted` wires up the receiving stream.
+    #[cfg(feature = "local_fs")]
+    rule_walk_message_tx: Option<Sender<LocalRuleWatchMessage>>,
+    /// Local rule roots with a direct `Repository` watcher. Only populated when
+    /// `OnTheFlyStandingQueries` is enabled: the watcher triggers standing-query
+    /// re-walks when WARP.md/AGENTS.md files change.
+    #[cfg(feature = "local_fs")]
+    local_rule_watchers: HashMap<PathBuf, (ModelHandle<Repository>, SubscriberId)>,
     /// File-based global rules and their local watcher state. Kept separate
     /// from `path_to_rules`, which is project-scoped.
     pub(super) global_rules: GlobalRules,
@@ -281,17 +361,43 @@ impl ProjectContextModel {
         let mut model = Self::default();
         #[cfg(feature = "local_fs")]
         {
+            model.project_rule_content_reader = Some(project_rule_content_reader);
+
+            // Receive updates from directly watched local rule roots (used by
+            // the flag-on walk-based discovery path).
+            let (rule_walk_tx, rule_walk_rx) = async_channel::unbounded();
+            model.rule_walk_message_tx = Some(rule_walk_tx);
+            ctx.spawn_stream_local(
+                rule_walk_rx,
+                |me, (root_dir, update): LocalRuleWatchMessage, ctx| {
+                    if FeatureFlag::OnTheFlyStandingQueries.is_enabled() {
+                        me.handle_local_rule_watch_update(root_dir, &update, ctx);
+                    }
+                },
+                |_, _| {},
+            );
+
+            // With `OnTheFlyStandingQueries` enabled, local rule discovery is
+            // driven by repo detection and the direct rule-root watchers rather
+            // than eager repo metadata indexing. Remote repos keep the
+            // metadata-backed path in both modes.
             ctx.subscribe_to_model(&RepoMetadataModel::handle(ctx), move |me, _, event, ctx| {
                 match event {
                     RepoMetadataEvent::RepositoryUpdated { id } => {
-                        me.refresh_project_rules_for_repo(
-                            id.clone(),
-                            project_rule_content_reader,
-                            ctx,
-                        );
+                        if local_uses_standing_query_walk(id) {
+                            me.ensure_local_rule_discovery(id, ctx);
+                        } else {
+                            me.refresh_project_rules_for_repo(
+                                id.clone(),
+                                project_rule_content_reader,
+                                ctx,
+                            );
+                        }
                     }
                     RepoMetadataEvent::StandingQueryResultsUpdated { id, delta } => {
-                        if delta.project_rules_changed() {
+                        if local_uses_standing_query_walk(id) {
+                            // Freshness is driven by the rule-root watcher re-walks.
+                        } else if delta.project_rules_changed() {
                             me.refresh_project_rules_for_repo(
                                 id.clone(),
                                 project_rule_content_reader,
@@ -307,6 +413,18 @@ impl ProjectContextModel {
                     | RepoMetadataEvent::UpdatingRepositoryFailed { .. }
                     | RepoMetadataEvent::IncrementalUpdateReady { .. } => {}
                 }
+            });
+
+            // With `OnTheFlyStandingQueries` enabled, repo detection is the
+            // primary trigger for local rule discovery.
+            ctx.subscribe_to_model(&DetectedRepositories::handle(ctx), |me, _, event, ctx| {
+                if !FeatureFlag::OnTheFlyStandingQueries.is_enabled() {
+                    return;
+                }
+                let DetectedRepositoriesEvent::DetectedGitRepo { repository, .. } = event;
+                let repo_id =
+                    RepositoryIdentifier::local(repository.as_ref(ctx).root_dir().clone());
+                me.ensure_local_rule_discovery(&repo_id, ctx);
             });
 
             ctx.spawn(
@@ -347,6 +465,11 @@ impl ProjectContextModel {
         {
             let repo_path = StandardizedPath::from_local_canonicalized(&root_path)?;
             let repo_id = RepositoryIdentifier::local(repo_path.clone());
+            if FeatureFlag::OnTheFlyStandingQueries.is_enabled() {
+                // Walk-based discovery: no repo metadata tracking needed.
+                self.ensure_local_rule_discovery(&repo_id, ctx);
+                return Ok(());
+            }
             if RepoMetadataModel::as_ref(ctx)
                 .standing_query_results(&repo_id, ctx)
                 .is_none()
@@ -358,6 +481,208 @@ impl ProjectContextModel {
             self.refresh_project_rules_for_repo(repo_id, project_rule_content_reader, ctx);
         }
         Ok(())
+    }
+
+    /// Ensures the walk-based rule discovery path is active for a local root:
+    /// registers the direct rule-root watcher if needed and runs the initial
+    /// standing-query walk on first registration. Subsequent freshness comes
+    /// from the watcher's re-walks.
+    #[cfg(feature = "local_fs")]
+    fn ensure_local_rule_discovery(
+        &mut self,
+        repo_id: &RepositoryIdentifier,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let RepositoryIdentifier::Local(repo_root) = repo_id else {
+            return;
+        };
+        let Some(local_path) = repo_root.to_local_path() else {
+            return;
+        };
+        let newly_watched = !self.local_rule_watchers.contains_key(&local_path);
+        self.watch_local_rule_root(local_path, ctx);
+        if newly_watched {
+            self.refresh_local_project_rules_via_walk(repo_id.clone(), ctx);
+        }
+    }
+
+    /// Registers a direct `Repository` watcher on a local rule root so
+    /// WARP.md/AGENTS.md changes trigger standing-query re-walks.
+    #[cfg(feature = "local_fs")]
+    fn watch_local_rule_root(&mut self, root_path: PathBuf, ctx: &mut ModelContext<Self>) {
+        if self.local_rule_watchers.contains_key(&root_path) {
+            return;
+        }
+        let Some(message_tx) = self.rule_walk_message_tx.clone() else {
+            return;
+        };
+        let Ok(std_path) = StandardizedPath::from_local_canonicalized(&root_path) else {
+            return;
+        };
+        // `add_directory` returns the existing registration when the root is
+        // already watched (e.g. as a detected repo), so this works for both
+        // git repositories and plain directories.
+        let repo_handle = match DirectoryWatcher::handle(ctx)
+            .update(ctx, |watcher, ctx| watcher.add_directory(std_path, ctx))
+        {
+            Ok(handle) => handle,
+            Err(err) => {
+                log::warn!(
+                    "Failed to register rule root {} for watching: {err}",
+                    root_path.display()
+                );
+                return;
+            }
+        };
+
+        let subscriber = Box::new(ProjectRuleSubscriber { message_tx });
+        let start = repo_handle.update(ctx, |repo, ctx| repo.start_watching(subscriber, ctx));
+        let subscriber_id = start.subscriber_id;
+        self.local_rule_watchers
+            .insert(root_path.clone(), (repo_handle.clone(), subscriber_id));
+
+        ctx.spawn(start.registration_future, move |me, res, ctx| {
+            if let Err(err) = res {
+                log::warn!(
+                    "Failed to start watching rule root {}: {err}",
+                    root_path.display()
+                );
+                if let Some((repo_handle, subscriber_id)) =
+                    me.local_rule_watchers.remove(&root_path)
+                {
+                    repo_handle.update(ctx, |repo, ctx| {
+                        repo.stop_watching(subscriber_id, ctx);
+                    });
+                }
+            }
+        });
+    }
+
+    /// Re-discovers a local root's project rules with the standalone
+    /// standing-query walk on a background thread.
+    #[cfg(feature = "local_fs")]
+    fn refresh_local_project_rules_via_walk(
+        &mut self,
+        repo_id: RepositoryIdentifier,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let RepositoryIdentifier::Local(repo_root) = &repo_id else {
+            return;
+        };
+        let Some(local_path) = repo_root.to_local_path() else {
+            return;
+        };
+        let Some(project_rule_content_reader) = self.project_rule_content_reader else {
+            return;
+        };
+
+        // Git repositories are walked in full (matching eager-index standing
+        // coverage); other directories only surface first-level rules
+        // (matching the lazily-loaded path coverage).
+        let max_depth = if local_path.join(".git").exists() {
+            STANDING_QUERY_WALK_MAX_DEPTH
+        } else {
+            1
+        };
+
+        self.next_rule_refresh_generation += 1;
+        let refresh_generation = self.next_rule_refresh_generation;
+        self.rule_refresh_generations
+            .insert(repo_id.clone(), refresh_generation);
+
+        ctx.spawn(
+            async move {
+                // Force-include the skill provider directories to match the
+                // eager walk, which always descends into them.
+                let force_included_paths: Vec<PathBuf> = crate::skills::SKILL_PROVIDER_DEFINITIONS
+                    .iter()
+                    .map(|provider| provider.skills_path.clone())
+                    .collect();
+                let options = StandingQueryWalkOptions {
+                    max_depth,
+                    force_included_paths,
+                };
+                let results = evaluate_standing_queries(
+                    &local_path,
+                    &StandingQueryDefinitions::default(),
+                    &options,
+                );
+                results
+                    .project_rules()
+                    .filter(|content| !content.is_directory)
+                    .filter_map(|content| {
+                        content.path.to_local_path().map(LocalOrRemotePath::Local)
+                    })
+                    .collect::<Vec<_>>()
+            },
+            move |me, rule_paths, ctx| {
+                if me.rule_refresh_generations.get(&repo_id) != Some(&refresh_generation) {
+                    return;
+                }
+                me.read_rule_contents_and_apply(
+                    repo_id,
+                    refresh_generation,
+                    rule_paths,
+                    project_rule_content_reader,
+                    ctx,
+                );
+            },
+        );
+    }
+
+    /// Handles an update from a directly watched rule root: rule-relevant
+    /// changes trigger a full re-walk of the root's standing rule queries.
+    #[cfg(feature = "local_fs")]
+    fn handle_local_rule_watch_update(
+        &mut self,
+        root_dir: StandardizedPath,
+        update: &RepositoryUpdate,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let repo_id = RepositoryIdentifier::local(root_dir);
+        if !self.update_touches_project_rules(&repo_id, update) {
+            return;
+        }
+        self.refresh_local_project_rules_via_walk(repo_id, ctx);
+    }
+
+    /// Returns whether a repository update can affect project rule discovery:
+    /// a changed path is a rule file, or a deletion/move removed a directory
+    /// above a known rule file.
+    #[cfg(feature = "local_fs")]
+    fn update_touches_project_rules(
+        &self,
+        repo_id: &RepositoryIdentifier,
+        update: &RepositoryUpdate,
+    ) -> bool {
+        let changed_paths = update
+            .added_or_modified()
+            .chain(update.deleted.iter())
+            .chain(update.moved.keys())
+            .chain(update.moved.values());
+        for target in changed_paths {
+            if path_is_project_rule_relevant(&target.path) {
+                return true;
+            }
+        }
+
+        let known_rule_paths: Vec<PathBuf> = repo_id
+            .to_local_or_remote_path()
+            .and_then(|project_root| self.path_to_rules.get(&project_root))
+            .map(|rules| rules.local_rule_paths().collect())
+            .unwrap_or_default();
+        if known_rule_paths.is_empty() {
+            return false;
+        }
+        update
+            .deleted
+            .iter()
+            .chain(update.moved.values())
+            .any(|removed| {
+                known_rule_paths
+                    .iter()
+                    .any(|rule| rule.starts_with(&removed.path))
+            })
     }
 
     #[cfg(feature = "local_fs")]
@@ -377,13 +702,32 @@ impl ProjectContextModel {
                 .into_iter()
                 .flat_map(|results| results.project_rules()),
         );
-        let read_rule_contents = project_rule_content_reader(rule_paths.clone(), ctx);
-
         self.next_rule_refresh_generation += 1;
         let refresh_generation = self.next_rule_refresh_generation;
         self.rule_refresh_generations
             .insert(repo_id.clone(), refresh_generation);
-        let repo_id_for_result = repo_id.clone();
+        self.read_rule_contents_and_apply(
+            repo_id,
+            refresh_generation,
+            rule_paths,
+            project_rule_content_reader,
+            ctx,
+        );
+    }
+
+    /// Reads the contents of the given rule paths and reconciles them into the
+    /// repository's rule state, guarded by the refresh generation.
+    #[cfg(feature = "local_fs")]
+    fn read_rule_contents_and_apply(
+        &mut self,
+        repo_id: RepositoryIdentifier,
+        refresh_generation: u64,
+        rule_paths: Vec<LocalOrRemotePath>,
+        project_rule_content_reader: ProjectRuleContentReader,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let read_rule_contents = project_rule_content_reader(rule_paths.clone(), ctx);
+        let repo_id_for_result = repo_id;
         ctx.spawn(read_rule_contents, move |me, result, ctx| {
             if me.rule_refresh_generations.get(&repo_id_for_result) != Some(&refresh_generation) {
                 return;
@@ -420,6 +764,28 @@ impl ProjectContextModel {
         existing_rules
     }
 
+    /// Stops and forgets the direct rule-root watcher for a local root, if any.
+    #[cfg(feature = "local_fs")]
+    fn stop_local_rule_watcher(
+        &mut self,
+        repo_id: &RepositoryIdentifier,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        let RepositoryIdentifier::Local(repo_root) = repo_id else {
+            return;
+        };
+        let Some(local_path) = repo_root.to_local_path() else {
+            return;
+        };
+        let Some((repo_handle, subscriber_id)) = self.local_rule_watchers.remove(&local_path)
+        else {
+            return;
+        };
+        repo_handle.update(ctx, |repo, ctx| {
+            repo.stop_watching(subscriber_id, ctx);
+        });
+    }
+
     #[cfg(feature = "local_fs")]
     fn remove_project_rules_for_repo(
         &mut self,
@@ -427,6 +793,7 @@ impl ProjectContextModel {
         ctx: &mut ModelContext<Self>,
     ) {
         self.rule_refresh_generations.remove(repo_id);
+        self.stop_local_rule_watcher(repo_id, ctx);
         let Some(project_root) = repo_id.to_local_or_remote_path() else {
             return;
         };

--- a/crates/ai/src/project_context/model_tests.rs
+++ b/crates/ai/src/project_context/model_tests.rs
@@ -653,3 +653,241 @@ fn test_remote_global_rules_only_layer_for_matching_remote_host() {
         ["local_global", "remote_project"]
     );
 }
+
+// ============================================================================
+// Tests for the flag-on walk-based local rule discovery path
+// ============================================================================
+
+#[cfg(feature = "local_fs")]
+mod standing_query_walk_tests {
+    use std::collections::{HashMap, HashSet};
+    use std::fs;
+    use std::time::Duration;
+
+    use futures::FutureExt as _;
+    use repo_metadata::repositories::DetectedRepositories;
+    use repo_metadata::{
+        DirectoryWatcher, RepoMetadataModel, RepositoryIdentifier, RepositoryUpdate, TargetFile,
+    };
+    use warp_core::features::FeatureFlag;
+    use warpui_core::r#async::Timer;
+    use warpui_core::App;
+
+    use super::*;
+
+    /// Test rule content reader that reads local files directly.
+    fn read_local_rule_contents(
+        rule_paths: Vec<LocalOrRemotePath>,
+        _ctx: &AppContext,
+    ) -> BoxFuture<'static, anyhow::Result<ProjectRuleContents>> {
+        async move {
+            Ok(rule_paths
+                .into_iter()
+                .filter_map(|path| {
+                    let local_path = path.to_local_path()?.to_path_buf();
+                    fs::read_to_string(local_path).ok().map(|c| (path, c))
+                })
+                .collect())
+        }
+        .boxed()
+    }
+
+    /// Polls until the model reports active project rules for `path`, returning
+    /// the active rule paths sorted for stable assertions.
+    async fn wait_for_active_rules(
+        app: &App,
+        model_handle: &warpui_core::ModelHandle<ProjectContextModel>,
+        path: &LocalOrRemotePath,
+        expected_count: usize,
+    ) -> Vec<LocalOrRemotePath> {
+        for _ in 0..500 {
+            let active = model_handle.read(app, |model, _| {
+                model
+                    .find_applicable_project_rules(path)
+                    .map(|result| {
+                        result
+                            .active_rules
+                            .iter()
+                            .map(|rule| rule.path.clone())
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default()
+            });
+            if active.len() >= expected_count {
+                let mut active = active;
+                active.sort_by_key(LocalOrRemotePath::display_path);
+                return active;
+            }
+            Timer::after(Duration::from_millis(10)).await;
+        }
+        panic!("Timed out waiting for {expected_count} active rules at {path:?}");
+    }
+
+    fn rule_update(paths: Vec<std::path::PathBuf>) -> RepositoryUpdate {
+        RepositoryUpdate {
+            added: HashSet::new(),
+            modified: paths
+                .into_iter()
+                .map(|path| TargetFile::new(path, false))
+                .collect(),
+            deleted: HashSet::new(),
+            moved: HashMap::new(),
+            commit_updated: false,
+            index_lock_detected: false,
+            remote_ref_updated: false,
+        }
+    }
+
+    #[test]
+    fn walk_discovers_rules_for_git_repo_at_any_depth() {
+        App::test((), |mut app| async move {
+            let _flag = FeatureFlag::OnTheFlyStandingQueries.override_enabled(true);
+            app.add_singleton_model(DirectoryWatcher::new_for_testing);
+            app.add_singleton_model(|_| DetectedRepositories::default());
+            app.add_singleton_model(RepoMetadataModel::new);
+            let model_handle = app.add_singleton_model(|ctx| {
+                ProjectContextModel::new_from_persisted(Vec::new(), read_local_rule_contents, ctx)
+            });
+
+            let temp_dir = tempfile::tempdir().unwrap();
+            let repo = dunce::canonicalize(temp_dir.path()).unwrap();
+            fs::create_dir_all(repo.join(".git")).unwrap();
+            fs::create_dir_all(repo.join("packages/api")).unwrap();
+            fs::write(repo.join("WARP.md"), "root rules").unwrap();
+            fs::write(repo.join("packages/api/AGENTS.md"), "nested rules").unwrap();
+
+            let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
+            model_handle.update(&mut app, |model, ctx| {
+                model.ensure_local_rule_discovery(&repo_id, ctx);
+            });
+
+            let active = wait_for_active_rules(
+                &app,
+                &model_handle,
+                &LocalOrRemotePath::Local(repo.join("packages/api/src")),
+                2,
+            )
+            .await;
+            let mut expected = vec![
+                LocalOrRemotePath::Local(repo.join("WARP.md")),
+                LocalOrRemotePath::Local(repo.join("packages/api/AGENTS.md")),
+            ];
+            expected.sort_by_key(LocalOrRemotePath::display_path);
+            assert_eq!(active, expected);
+        });
+    }
+
+    #[test]
+    fn walk_limits_non_git_directories_to_first_level_rules() {
+        App::test((), |mut app| async move {
+            let _flag = FeatureFlag::OnTheFlyStandingQueries.override_enabled(true);
+            app.add_singleton_model(DirectoryWatcher::new_for_testing);
+            app.add_singleton_model(|_| DetectedRepositories::default());
+            app.add_singleton_model(RepoMetadataModel::new);
+            let model_handle = app.add_singleton_model(|ctx| {
+                ProjectContextModel::new_from_persisted(Vec::new(), read_local_rule_contents, ctx)
+            });
+
+            let temp_dir = tempfile::tempdir().unwrap();
+            let dir = dunce::canonicalize(temp_dir.path()).unwrap();
+            fs::create_dir_all(dir.join("nested/deep")).unwrap();
+            fs::write(dir.join("WARP.md"), "root rules").unwrap();
+            fs::write(dir.join("nested/deep/WARP.md"), "deep rules").unwrap();
+
+            model_handle.update(&mut app, |model, ctx| {
+                model
+                    .index_and_store_rules(dir.clone(), read_local_rule_contents, ctx)
+                    .unwrap();
+            });
+
+            let active = wait_for_active_rules(
+                &app,
+                &model_handle,
+                &LocalOrRemotePath::Local(dir.join("nested/deep")),
+                1,
+            )
+            .await;
+            // Only the first-level rule is discovered, matching the coverage of
+            // the lazily-loaded path behavior with the flag off.
+            assert_eq!(active, vec![LocalOrRemotePath::Local(dir.join("WARP.md"))]);
+        });
+    }
+
+    #[test]
+    fn walk_rediscovers_rules_after_rule_file_edit() {
+        App::test((), |mut app| async move {
+            let _flag = FeatureFlag::OnTheFlyStandingQueries.override_enabled(true);
+            app.add_singleton_model(DirectoryWatcher::new_for_testing);
+            app.add_singleton_model(|_| DetectedRepositories::default());
+            app.add_singleton_model(RepoMetadataModel::new);
+            let model_handle = app.add_singleton_model(|ctx| {
+                ProjectContextModel::new_from_persisted(Vec::new(), read_local_rule_contents, ctx)
+            });
+
+            let temp_dir = tempfile::tempdir().unwrap();
+            let repo = dunce::canonicalize(temp_dir.path()).unwrap();
+            fs::create_dir_all(repo.join(".git")).unwrap();
+            fs::write(repo.join("WARP.md"), "root rules").unwrap();
+
+            let repo_id = RepositoryIdentifier::try_local(&repo).unwrap();
+            let root_dir = StandardizedPath::try_from_local(&repo).unwrap();
+            model_handle.update(&mut app, |model, ctx| {
+                model.ensure_local_rule_discovery(&repo_id, ctx);
+            });
+            wait_for_active_rules(
+                &app,
+                &model_handle,
+                &LocalOrRemotePath::Local(repo.join("src")),
+                1,
+            )
+            .await;
+
+            // A new rule file appears; the watcher update triggers a re-walk.
+            fs::create_dir_all(repo.join("packages")).unwrap();
+            fs::write(repo.join("packages/AGENTS.md"), "new rules").unwrap();
+            model_handle.update(&mut app, |model, ctx| {
+                model.handle_local_rule_watch_update(
+                    root_dir,
+                    &rule_update(vec![repo.join("packages/AGENTS.md")]),
+                    ctx,
+                );
+            });
+
+            let active = wait_for_active_rules(
+                &app,
+                &model_handle,
+                &LocalOrRemotePath::Local(repo.join("packages/src")),
+                2,
+            )
+            .await;
+            assert!(active.contains(&LocalOrRemotePath::Local(repo.join("packages/AGENTS.md"))));
+        });
+    }
+
+    #[test]
+    fn irrelevant_updates_do_not_schedule_rule_refreshes() {
+        App::test((), |mut app| async move {
+            let _flag = FeatureFlag::OnTheFlyStandingQueries.override_enabled(true);
+            app.add_singleton_model(DirectoryWatcher::new_for_testing);
+            app.add_singleton_model(|_| DetectedRepositories::default());
+            app.add_singleton_model(RepoMetadataModel::new);
+            let model_handle = app.add_singleton_model(|ctx| {
+                ProjectContextModel::new_from_persisted(Vec::new(), read_local_rule_contents, ctx)
+            });
+
+            let temp_dir = tempfile::tempdir().unwrap();
+            let repo = dunce::canonicalize(temp_dir.path()).unwrap();
+            let root_dir = StandardizedPath::try_from_local(&repo).unwrap();
+
+            model_handle.update(&mut app, |model, ctx| {
+                model.handle_local_rule_watch_update(
+                    root_dir,
+                    &rule_update(vec![repo.join("src/main.rs")]),
+                    ctx,
+                );
+                // No refresh was scheduled for an irrelevant change.
+                assert!(model.rule_refresh_generations.is_empty());
+            });
+        });
+    }
+}

--- a/crates/repo_metadata/src/lib.rs
+++ b/crates/repo_metadata/src/lib.rs
@@ -42,6 +42,7 @@ pub mod repositories;
 pub mod repository;
 pub mod repository_identifier;
 pub mod standing_queries;
+pub mod standing_query_walker;
 mod telemetry;
 pub mod watcher;
 pub mod wrapper_model;
@@ -77,6 +78,9 @@ pub use remote_model::RemoteRepoMetadataModel;
 pub use repository_identifier::{RemoteRepositoryIdentifier, RepositoryIdentifier};
 pub use standing_queries::{
     StandingQueryContent, StandingQueryDefinitions, StandingQueryResults, StandingQueryResultsDelta,
+};
+pub use standing_query_walker::{
+    evaluate_standing_queries, StandingQueryWalkOptions, STANDING_QUERY_WALK_MAX_DEPTH,
 };
 pub use wrapper_model::{RepoMetadataEvent, RepoMetadataModel};
 

--- a/crates/repo_metadata/src/standing_query_walker.rs
+++ b/crates/repo_metadata/src/standing_query_walker.rs
@@ -1,0 +1,180 @@
+#![cfg_attr(not(feature = "local_fs"), allow(dead_code))]
+//! Standalone, filename-filtered walker that evaluates standing repository
+//! queries (project skills and rules) directly from the filesystem, without
+//! materializing a file tree.
+//!
+//! This mirrors the traversal semantics of
+//! [`Entry::build_tree_with_standing_queries`](crate::entry::Entry) so that
+//! consumers switching between the eager tree-derived standing results and
+//! this walk observe the same matches:
+//! - gitignore handling starts from the root's `.gitignore` plus the global
+//!   gitignore and accumulates nested `.gitignore` files as directories are
+//!   visited; ignored directories are not descended into.
+//! - `.git` internals are pruned.
+//! - Force-included paths (e.g. skill provider directories such as
+//!   `.agents/skills`) are descended into even when gitignored or beyond the
+//!   depth limit.
+//! - Directory symlinks are not followed, but eligible symlinked project
+//!   skill directories are still surfaced via their lexical paths.
+//!
+//! Unlike the tree build, the walk has no per-build file budget: it only
+//! enumerates directory entries and retains filename matches, so covering the
+//! entire repository stays cheap even for repositories whose eager index is
+//! truncated by the file budget.
+
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+
+use ignore::gitignore::Gitignore;
+
+use crate::entry::{
+    gitignores_for_directory, is_git_internal_path, matches_force_included_path, matches_gitignores,
+};
+use crate::standing_queries::{StandingQueryDefinitions, StandingQueryResults};
+
+/// Maximum directory depth for standing-query walks of full repositories.
+///
+/// Matches the eager tree build's depth limit (`MAX_TREE_DEPTH` in
+/// `local_model.rs`) so walk coverage stays consistent with the standing
+/// results computed during eager indexing.
+pub const STANDING_QUERY_WALK_MAX_DEPTH: usize = 200;
+
+/// Options controlling a standing-query walk.
+#[derive(Debug, Clone)]
+pub struct StandingQueryWalkOptions {
+    /// Directories deeper than this (relative to the walk root) are not
+    /// descended into unless they lie on the way to a force-included path.
+    /// Use `1` to mirror the first-level-only coverage of lazily-loaded
+    /// non-repository paths.
+    pub max_depth: usize,
+    /// Repository-relative path suffixes (e.g. `.agents/skills`) that are
+    /// always descended into, even when gitignored or beyond `max_depth`.
+    pub force_included_paths: Vec<PathBuf>,
+}
+
+impl Default for StandingQueryWalkOptions {
+    fn default() -> Self {
+        Self {
+            max_depth: STANDING_QUERY_WALK_MAX_DEPTH,
+            force_included_paths: Vec::new(),
+        }
+    }
+}
+
+/// Walks `root_path` and returns every path matching a standing query.
+///
+/// This is a blocking filesystem traversal; callers should run it on a
+/// background executor for large repositories.
+pub fn evaluate_standing_queries(
+    root_path: &Path,
+    definitions: &StandingQueryDefinitions,
+    options: &StandingQueryWalkOptions,
+) -> StandingQueryResults {
+    let mut results = StandingQueryResults::default();
+    let mut gitignores = gitignores_for_directory(root_path);
+
+    let root_is_dir = root_path.is_dir();
+    results.record_path(root_path, root_is_dir, definitions);
+
+    // Mirror the tree build: directory symlinks are never followed, including
+    // at the root.
+    if !root_is_dir || root_path.is_symlink() {
+        return results;
+    }
+
+    let root_ignored = matches_gitignores(
+        root_path,
+        true,
+        &gitignores,
+        false, /* check_ancestors */
+    );
+
+    struct DirJob {
+        path: PathBuf,
+        depth: usize,
+        ignored: bool,
+    }
+
+    let mut queue = VecDeque::new();
+    queue.push_back(DirJob {
+        path: root_path.to_path_buf(),
+        depth: 0,
+        ignored: root_ignored,
+    });
+
+    while let Some(job) = queue.pop_front() {
+        let Ok(entries) = std::fs::read_dir(&job.path) else {
+            // Unreadable directories are skipped, matching the tree build's
+            // treatment of unreadable nested directories.
+            continue;
+        };
+
+        let child_depth = job.depth + 1;
+        for entry in entries {
+            let Ok(entry) = entry else {
+                continue;
+            };
+            let entry_path = entry.path();
+
+            // Directory symlinks are not followed. Eligible symlinked project
+            // skill directories are still retained through their lexical
+            // paths, matching the tree build.
+            let child_path = if entry_path.is_symlink() {
+                if entry_path.is_dir() {
+                    results.record_followed_project_skill_directory(&entry_path, definitions);
+                    continue;
+                }
+                entry_path
+            } else {
+                match dunce::canonicalize(entry_path) {
+                    Ok(path) => path,
+                    Err(_) => continue,
+                }
+            };
+
+            let is_dir = child_path.is_dir();
+            results.record_path(&child_path, is_dir, definitions);
+            if !is_dir {
+                continue;
+            }
+
+            // Load this directory's `.gitignore` before deciding whether to
+            // descend, matching `evaluate_entry` in the tree build.
+            let gitignore_path = child_path.join(".gitignore");
+            if gitignore_path.exists() {
+                let (gitignore, _) = Gitignore::new(gitignore_path);
+                gitignores.push(gitignore);
+            }
+
+            let ignored = job.ignored
+                || is_git_internal_path(&child_path)
+                || matches_gitignores(
+                    &child_path,
+                    true,
+                    &gitignores,
+                    false, /* check_ancestors */
+                );
+            let force_included =
+                matches_force_included_path(&child_path, &options.force_included_paths);
+
+            // Same descend rule as the tree build with
+            // `IgnoredPathStrategy::IncludeLazy`: ignored directories and
+            // directories past the depth limit stay unexplored unless they lie
+            // on the way to a force-included path.
+            let lazy = (ignored || child_depth >= options.max_depth) && !force_included;
+            if !lazy {
+                queue.push_back(DirJob {
+                    path: child_path,
+                    depth: child_depth,
+                    ignored,
+                });
+            }
+        }
+    }
+
+    results
+}
+
+#[cfg(test)]
+#[path = "standing_query_walker_tests.rs"]
+mod tests;

--- a/crates/repo_metadata/src/standing_query_walker_tests.rs
+++ b/crates/repo_metadata/src/standing_query_walker_tests.rs
@@ -1,0 +1,267 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use super::{evaluate_standing_queries, StandingQueryWalkOptions};
+use crate::entry::{BudgetExceededBehavior, BuildTreeOptions, Entry, IgnoredPathStrategy};
+use crate::standing_queries::{StandingQueryContent, StandingQueryDefinitions};
+use crate::StandingQueryResults;
+
+fn definitions() -> StandingQueryDefinitions {
+    let mut definitions = StandingQueryDefinitions::default();
+    definitions.set_project_skill_provider_paths([PathBuf::from(".agents/skills")]);
+    definitions
+}
+
+fn walk_options() -> StandingQueryWalkOptions {
+    StandingQueryWalkOptions {
+        force_included_paths: vec![PathBuf::from(".agents/skills")],
+        ..Default::default()
+    }
+}
+
+fn standardized(path: &Path) -> warp_util::standardized_path::StandardizedPath {
+    warp_util::standardized_path::StandardizedPath::try_from_local(path).unwrap()
+}
+
+fn contains_rule(results: &StandingQueryResults, path: &Path) -> bool {
+    results
+        .project_rules()
+        .any(|content| content == &StandingQueryContent::file(standardized(path)))
+}
+
+fn contains_skill_file(results: &StandingQueryResults, path: &Path) -> bool {
+    results
+        .project_skills()
+        .any(|content| content == &StandingQueryContent::file(standardized(path)))
+}
+
+#[test]
+fn walker_discovers_rules_and_skills_at_any_depth() {
+    virtual_fs::VirtualFS::test("walker_discovers_rules_and_skills", |dirs, mut vfs| {
+        vfs.mkdir("repo/.agents/skills/review")
+            .mkdir("repo/packages/api/nested")
+            .with_files(vec![
+                virtual_fs::Stub::FileWithContent(
+                    "repo/.agents/skills/review/SKILL.md",
+                    "name: review",
+                ),
+                virtual_fs::Stub::FileWithContent("repo/WARP.md", "root rules"),
+                virtual_fs::Stub::FileWithContent(
+                    "repo/packages/api/nested/AGENTS.md",
+                    "nested rules",
+                ),
+            ]);
+        let repo = dirs.tests().join("repo");
+
+        let results = evaluate_standing_queries(&repo, &definitions(), &walk_options());
+
+        assert!(contains_rule(&results, &repo.join("WARP.md")));
+        assert!(contains_rule(
+            &results,
+            &repo.join("packages/api/nested/AGENTS.md")
+        ));
+        assert!(contains_skill_file(
+            &results,
+            &repo.join(".agents/skills/review/SKILL.md")
+        ));
+        // The provider directory itself is retained as a directory match.
+        assert!(results.project_skills().any(|content| {
+            content == &StandingQueryContent::directory(standardized(&repo.join(".agents/skills")))
+        }));
+    });
+}
+
+#[test]
+fn walker_prunes_gitignored_directories_but_keeps_force_included_providers() {
+    virtual_fs::VirtualFS::test("walker_prunes_gitignored", |dirs, mut vfs| {
+        vfs.mkdir("repo/.agents/skills/review")
+            .mkdir("repo/ignored/nested")
+            .with_files(vec![
+                virtual_fs::Stub::FileWithContent(
+                    "repo/.agents/skills/review/SKILL.md",
+                    "name: review",
+                ),
+                virtual_fs::Stub::FileWithContent("repo/ignored/nested/WARP.md", "hidden rules"),
+            ]);
+        let repo = dirs.tests().join("repo");
+        std::fs::write(repo.join(".gitignore"), "ignored/\n.agents/\n").unwrap();
+
+        let results = evaluate_standing_queries(&repo, &definitions(), &walk_options());
+
+        // Rules below a gitignored directory are not discovered, matching the
+        // eager tree walk.
+        assert!(!contains_rule(
+            &results,
+            &repo.join("ignored/nested/WARP.md")
+        ));
+        // Force-included provider directories are still discovered even when
+        // gitignored.
+        assert!(contains_skill_file(
+            &results,
+            &repo.join(".agents/skills/review/SKILL.md")
+        ));
+    });
+}
+
+#[test]
+fn walker_respects_nested_gitignores() {
+    virtual_fs::VirtualFS::test("walker_respects_nested_gitignores", |dirs, mut vfs| {
+        vfs.mkdir("repo/src/generated/deep")
+            .with_files(vec![virtual_fs::Stub::FileWithContent(
+                "repo/src/generated/deep/AGENTS.md",
+                "generated rules",
+            )]);
+        let repo = dirs.tests().join("repo");
+        std::fs::write(repo.join("src/.gitignore"), "generated/\n").unwrap();
+
+        let results = evaluate_standing_queries(&repo, &definitions(), &walk_options());
+
+        assert!(!contains_rule(
+            &results,
+            &repo.join("src/generated/deep/AGENTS.md")
+        ));
+    });
+}
+
+#[test]
+fn walker_does_not_descend_into_git_internals() {
+    virtual_fs::VirtualFS::test("walker_skips_git_internals", |dirs, mut vfs| {
+        vfs.mkdir("repo/.git/info")
+            .with_files(vec![virtual_fs::Stub::FileWithContent(
+                "repo/.git/info/WARP.md",
+                "not a rule",
+            )]);
+        let repo = dirs.tests().join("repo");
+
+        let results = evaluate_standing_queries(&repo, &definitions(), &walk_options());
+
+        assert!(!contains_rule(&results, &repo.join(".git/info/WARP.md")));
+    });
+}
+
+#[test]
+fn walker_depth_limit_matches_lazy_path_coverage() {
+    virtual_fs::VirtualFS::test("walker_depth_limit", |dirs, mut vfs| {
+        vfs.mkdir("dir/src/deep")
+            .mkdir("dir/.agents/skills/review")
+            .with_files(vec![
+                virtual_fs::Stub::FileWithContent("dir/WARP.md", "root rules"),
+                virtual_fs::Stub::FileWithContent("dir/src/deep/WARP.md", "deep rules"),
+                virtual_fs::Stub::FileWithContent(
+                    "dir/.agents/skills/review/SKILL.md",
+                    "name: review",
+                ),
+            ]);
+        let dir = dirs.tests().join("dir");
+
+        let results = evaluate_standing_queries(
+            &dir,
+            &definitions(),
+            &StandingQueryWalkOptions {
+                max_depth: 1,
+                force_included_paths: vec![PathBuf::from(".agents/skills")],
+            },
+        );
+
+        // First-level rules are found; deeper rules are not (matching the
+        // lazily-loaded non-repository path behavior today).
+        assert!(contains_rule(&results, &dir.join("WARP.md")));
+        assert!(!contains_rule(&results, &dir.join("src/deep/WARP.md")));
+        // Force-included provider subtrees are fully explored regardless of
+        // the depth limit.
+        assert!(contains_skill_file(
+            &results,
+            &dir.join(".agents/skills/review/SKILL.md")
+        ));
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn walker_reports_symlinked_skill_directories_via_lexical_paths() {
+    virtual_fs::VirtualFS::test("walker_symlinked_skills", |dirs, mut vfs| {
+        vfs.mkdir("repo/.agents/skills")
+            .mkdir("targets/linked")
+            .with_files(vec![virtual_fs::Stub::FileWithContent(
+                "targets/linked/SKILL.md",
+                "name: linked",
+            )]);
+        let repo = dirs.tests().join("repo");
+        let linked_directory = repo.join(".agents/skills/linked");
+        std::os::unix::fs::symlink(dirs.tests().join("targets/linked"), &linked_directory).unwrap();
+
+        let results = evaluate_standing_queries(&repo, &definitions(), &walk_options());
+
+        assert!(contains_skill_file(
+            &results,
+            &linked_directory.join("SKILL.md")
+        ));
+    });
+}
+
+/// The walker must observe the same matches as the standing-query evaluation
+/// embedded in the eager tree build, so flag-gated consumers see identical
+/// results regardless of the data path.
+#[test]
+fn walker_matches_tree_build_standing_results() {
+    virtual_fs::VirtualFS::test("walker_parity_with_tree_build", |dirs, mut vfs| {
+        vfs.mkdir("repo/.agents/skills/review")
+            .mkdir("repo/packages/api")
+            .mkdir("repo/ignored/nested")
+            .mkdir("repo/.git/info")
+            .with_files(vec![
+                virtual_fs::Stub::FileWithContent(
+                    "repo/.agents/skills/review/SKILL.md",
+                    "name: review",
+                ),
+                virtual_fs::Stub::FileWithContent("repo/WARP.md", "root rules"),
+                virtual_fs::Stub::FileWithContent("repo/AGENTS.md", "agents rules"),
+                virtual_fs::Stub::FileWithContent("repo/packages/api/AGENTS.md", "nested rules"),
+                virtual_fs::Stub::FileWithContent("repo/ignored/nested/WARP.md", "hidden rules"),
+                virtual_fs::Stub::FileWithContent("repo/.git/info/WARP.md", "not a rule"),
+            ]);
+        let repo = dirs.tests().join("repo");
+        std::fs::write(repo.join(".gitignore"), "ignored/\n").unwrap();
+
+        let definitions = definitions();
+        let force_included = vec![PathBuf::from(".agents/skills")];
+
+        let mut files = Vec::new();
+        let mut gitignores = crate::entry::gitignores_for_directory(&repo);
+        let mut tree_results = StandingQueryResults::default();
+        Entry::build_tree_with_standing_queries(
+            &repo,
+            &mut files,
+            &mut gitignores,
+            None,
+            BuildTreeOptions {
+                max_depth: super::STANDING_QUERY_WALK_MAX_DEPTH,
+                current_depth: 0,
+                ignored_path_strategy: &IgnoredPathStrategy::IncludeLazy,
+                force_included_paths: &force_included,
+                budget_exceeded_behavior: BudgetExceededBehavior::StopAndLazyLoad,
+            },
+            false,
+            &mut tree_results,
+            &definitions,
+        )
+        .unwrap();
+
+        let walk_results = evaluate_standing_queries(
+            &repo,
+            &definitions,
+            &StandingQueryWalkOptions {
+                force_included_paths: force_included,
+                ..Default::default()
+            },
+        );
+
+        let tree_skills: HashSet<_> = tree_results.project_skills().cloned().collect();
+        let walk_skills: HashSet<_> = walk_results.project_skills().cloned().collect();
+        assert_eq!(walk_skills, tree_skills);
+
+        let tree_rules: HashSet<_> = tree_results.project_rules().cloned().collect();
+        let walk_rules: HashSet<_> = walk_results.project_rules().cloned().collect();
+        assert_eq!(walk_rules, tree_rules);
+    });
+}

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -991,6 +991,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::CloudRunners,
     FeatureFlag::WaitForEventsParentRegistration,
     FeatureFlag::McpJsonTreeView,
+    FeatureFlag::OnTheFlyStandingQueries,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -911,6 +911,13 @@ pub enum FeatureFlag {
     /// collapsible tree with typed colors and per-row Copy JSON, instead of
     /// a flat pretty-printed blob.
     McpJsonTreeView,
+
+    /// Stage 1 of replacing eager repo indexing with on-the-fly search:
+    /// local project skills (SKILL.md) and rules (WARP.md/AGENTS.md) are
+    /// discovered via a standalone, filename-filtered standing-query walk
+    /// instead of the standing results computed during the eager file-tree
+    /// build. Local-only; remote/SSH repositories keep the eager path.
+    OnTheFlyStandingQueries,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =


### PR DESCRIPTION
## Description
Stage 1 (part 1 of 2) of replacing eager repo indexing with on-the-fly computation, behind `FeatureFlag::OnTheFlyStandingQueries` (dogfood only).

**What**: Adds a standalone, filename-filtered standing-query walker (`crates/repo_metadata/src/standing_query_walker.rs`) that discovers project skills (SKILL.md) and rules (WARP.md/AGENTS.md) without materializing a file tree. With the flag on, local `SkillWatcher` and `ProjectContextModel` discovery routes through this walker, triggered by repo detection and kept fresh via the existing `Repository` recursive watch. Remote/SSH and cloud-env-prep paths are untouched.

**Why**: The eager per-`cd` full-repo tree build (up to 200k files) exists today largely to compute standing queries during the walk. Decoupling them is the prerequisite for removing eager indexing entirely (streaming cmd-O/@ search lands separately in the sibling PR). The walker has no file budget, so deep WARP.md/SKILL.md files in >200k-file repos become discoverable (previously silently truncated).

**How**: BFS walk mirroring `Entry::build_tree_with_standing_queries` traversal semantics (gitignore accumulation, `.git` pruning, force-included provider dirs, symlinked skill dirs, depth cap), with a parity test against the tree build. Flag off = behavior byte-for-byte identical (all new paths additive and gated).

Plan: https://staging.warp.dev/drive/notebook/FUiRCYiLxUYk81BLTNSfJH
Conversation: https://staging.warp.dev/conversation/63007a8c-38a4-4485-8e06-a65881b26fb4

## Linked Issue
N/A — part of the on-the-fly search initiative (plan linked above).

## Testing
- Parity test: walker output vs `build_tree_with_standing_queries` on a fixture
- New tests: 4 project_context walk tests, 5 flag-on skill_watcher tests (initial discovery, re-discovery on SKILL.md/WARP.md edits, gitignore exclusion)
- Suites: repo_metadata 122/122, ai 288/288 (+33 project_context), warp skill_watcher 23/23, warp_features 2/2
- Full `./script/presubmit` green (one unrelated flaky PTY test passed on isolated reruns)
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Warp <agent@warp.dev>