### PR TITLE
Load cloud environment skills via standing-query walk, without indexing wait (OnTheFlyStandingQueries)

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1779,6 +1779,40 @@ impl AgentDriver {
             )
         );
 
+        // With on-the-fly standing queries, discover skills by walking the
+        // cloned repositories directly instead of waiting for repo metadata
+        // indexing to complete. The flag is read on the foreground executor so
+        // thread-local test overrides are honored.
+        let use_standing_query_walk = foreground
+            .spawn(|_, _| FeatureFlag::OnTheFlyStandingQueries.is_enabled())
+            .await
+            .unwrap_or(false);
+        if use_standing_query_walk {
+            let load_skills_result = foreground
+                .spawn(move |me, ctx| {
+                    let repo_paths: Vec<PathBuf> = repos
+                        .iter()
+                        .map(|repo| me.working_dir.join(&repo.repo))
+                        .collect();
+                    let skills = SkillWatcher::read_local_skills_for_repos_with_walk(&repo_paths);
+                    if !skills.is_empty() {
+                        log::info!("Loaded {} environment skill(s)", skills.len());
+                    } else {
+                        log::info!("No environment skills found");
+                    }
+                    SkillManager::handle(ctx).update(ctx, |manager, _| {
+                        manager.set_cloud_environment(true);
+                        manager.handle_skills_added(skills);
+                    });
+                })
+                .await;
+
+            if let Err(err) = load_skills_result {
+                log::warn!("Failed to load environment skills: {err}");
+            }
+            return;
+        }
+
         // Skill-scanning depends on the in-memory RepoMetadataModel index, so wait for
         // initial indexing of all repos to complete.
         let repo_index_waits = foreground

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -18,6 +18,7 @@ use warp_cli::{
     SESSION_SHARING_SERVER_URL_OVERRIDE_ENV, WS_SERVER_URL_OVERRIDE_ENV,
 };
 use warp_core::channel::ChannelState;
+use warp_core::features::FeatureFlag;
 use warp_graphql::mutations::create_managed_mcp_client_config::{
     CreateManagedMcpClientConfigOutput, ManagedMcpTransportKind,
 };
@@ -1135,6 +1136,78 @@ fn write_skill_file(repo: &Path, name: &str) {
     let skill_dir = repo.join(".agents").join("skills").join(name);
     fs::create_dir_all(&skill_dir).unwrap();
     fs::write(skill_dir.join("SKILL.md"), format!("Skill: {name}.")).unwrap();
+}
+
+/// With `OnTheFlyStandingQueries` enabled, `load_environment_skills` discovers
+/// skills by walking the cloned repos directly — without any repo metadata
+/// indexing having run (the repo is never registered with `DirectoryWatcher`
+/// or indexed in this test), and while honoring the repo's gitignore rules.
+#[test]
+fn env_skills_load_via_walk_without_indexing_wait() {
+    let _flag = FeatureFlag::OnTheFlyStandingQueries.override_enabled(true);
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let temp = TempDir::new().unwrap();
+        let working_dir = dunce::canonicalize(temp.path()).unwrap();
+
+        // Environment repo with two skills plus a gitignored one that must be
+        // excluded by the walk's gitignore handling.
+        let env_repo = working_dir.join("env-repo");
+        write_skill_file(&env_repo, "build");
+        write_skill_file(&env_repo, "deploy");
+        let ignored_dir = env_repo.join("ignored");
+        write_skill_file(&ignored_dir, "hidden");
+        fs::write(env_repo.join(".gitignore"), "/ignored/\n").unwrap();
+
+        // NOTE: unlike the indexing-based tests above, the repo is deliberately
+        // NOT registered or indexed — skills must load from the walk alone.
+        let terminal_view = add_window_with_terminal(&mut app, None);
+        let driver_handle = app.add_model(|ctx| {
+            let terminal_driver =
+                super::terminal::TerminalDriver::create_from_existing_view(terminal_view, ctx);
+            AgentDriver::new_for_test(working_dir.clone(), terminal_driver, ctx)
+        });
+
+        let (done_tx, done_rx) = futures::channel::oneshot::channel::<()>();
+        let env_repos = vec![SourceRepo::new(
+            CodeForge::GitHub,
+            "org".to_string(),
+            "env-repo".to_string(),
+        )];
+        driver_handle.update(&mut app, |_, ctx| {
+            let spawner = ctx.spawner();
+            ctx.spawn(
+                async move {
+                    AgentDriver::load_environment_skills(&spawner, env_repos).await;
+                    let _ = done_tx.send(());
+                },
+                |_, _, _| {},
+            );
+        });
+        done_rx.await.expect("loading task should complete");
+
+        let skill_names = SkillManager::handle(&app).read(&app, |manager: &SkillManager, ctx| {
+            manager
+                .get_skills_for_working_directory(None, ctx)
+                .into_iter()
+                .map(|s| s.name.clone())
+                .collect::<Vec<_>>()
+        });
+
+        assert!(
+            skill_names.contains(&"build".to_string()),
+            "env skill 'build' should be loaded without indexing; got: {skill_names:?}"
+        );
+        assert!(
+            skill_names.contains(&"deploy".to_string()),
+            "env skill 'deploy' should be loaded without indexing; got: {skill_names:?}"
+        );
+        assert!(
+            !skill_names.contains(&"hidden".to_string()),
+            "gitignored skill 'hidden' should NOT be loaded; got: {skill_names:?}"
+        );
+    });
 }
 
 #[test]

--- a/app/src/ai/skills/file_watchers/skill_watcher.rs
+++ b/app/src/ai/skills/file_watchers/skill_watcher.rs
@@ -98,6 +98,22 @@ impl SkillWatcher {
         read_skills_from_files(skill_files)
     }
 
+    /// Synchronously reads skills from the given local repo paths by walking
+    /// each repository with the standalone standing-query walk.
+    ///
+    /// Unlike [`Self::read_local_skills_for_repos`], this does not depend on
+    /// repo metadata indexing having completed — it discovers skill files
+    /// directly from the filesystem with the same traversal semantics as the
+    /// eager index's standing queries.
+    pub fn read_local_skills_for_repos_with_walk(repo_paths: &[PathBuf]) -> Vec<ParsedSkill> {
+        let skill_files: Vec<PathBuf> = repo_paths
+            .iter()
+            .flat_map(|repo_path| find_local_project_skill_files_with_walk(repo_path))
+            .filter_map(|path| path.to_local_path().map(Path::to_path_buf))
+            .collect();
+        read_skills_from_files(skill_files)
+    }
+
     pub fn new(ctx: &mut ModelContext<Self>, watcher_event_tx: Sender<SkillWatcherEvent>) -> Self {
         Self::new_internal(ctx, watcher_event_tx, dirs::home_dir())
     }


### PR DESCRIPTION
## Description
Stage 2 (part 2 of 2) of replacing eager repo indexing with on-the-fly computation. **Stacked on #13421** (uses its standing-query walker; base branch is `kevinyang/on-the-fly-ws1-standing-queries` — will retarget to master once #13421 merges). Gated by the same `FeatureFlag::OnTheFlyStandingQueries` (dogfood only) to keep all standing-query consumers consistent.

**What**: With the flag on, `load_environment_skills` (agent SDK driver) discovers project skills in cloned cloud-environment repos by walking them directly via `evaluate_standing_queries` (`SkillWatcher::read_local_skills_for_repos_with_walk`) instead of blocking on `repository_indexed`.

**Why**: Removes the last indexing wait in cloud environment prep — skills load without the eager full-repo index ever running, a prerequisite for stage 4's eager-path removal. Note: `register_cloned_repo` awaits repo *detection* (not indexing), which is intentionally kept — detection stays in the end-state architecture.

Plan: https://staging.warp.dev/drive/notebook/FUiRCYiLxUYk81BLTNSfJH
Conversation: https://staging.warp.dev/conversation/63007a8c-38a4-4485-8e06-a65881b26fb4

## Linked Issue
N/A — part of the on-the-fly search initiative (plan linked above).

## Testing
- New driver test proves environment skills load with NO indexing ever run (repo never registered/indexed) and gitignore rules honored via the walk
- Flag-off indexing-based tests unchanged and passing; skills/agent_sdk suites 468/468
- Full `./script/presubmit` green
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Warp <agent@warp.dev>