### PR TITLE
Exclude directories from Command Palette file search so files aren't starved from the result cap

### DIFF
--- a/app/src/search/command_palette/files/data_source.rs
+++ b/app/src/search/command_palette/files/data_source.rs
@@ -113,9 +113,6 @@ impl FileDataSource {
         match &self.mode {
             FileDataSourceMode::Repo => {
                 let file_search_model = FileSearchModel::as_ref(app);
-                // The Command Palette file filter only opens files, so exclude
-                // directories: otherwise directories matching the query consume
-                // the repo-metadata result cap and starve file matches (#12391).
                 file_search_model.get_repo_file_contents(query, app)
             }
             FileDataSourceMode::CurrentFolder { cached_contents } => {

--- a/app/src/search/command_palette/files/data_source.rs
+++ b/app/src/search/command_palette/files/data_source.rs
@@ -113,7 +113,10 @@ impl FileDataSource {
         match &self.mode {
             FileDataSourceMode::Repo => {
                 let file_search_model = FileSearchModel::as_ref(app);
-                file_search_model.get_repo_contents(query, app)
+                // The Command Palette file filter only opens files, so exclude
+                // directories: otherwise directories matching the query consume
+                // the repo-metadata result cap and starve file matches (#12391).
+                file_search_model.get_repo_file_contents(query, app)
             }
             FileDataSourceMode::CurrentFolder { cached_contents } => {
                 Arc::new(cached_contents.clone())

--- a/app/src/search/files/model.rs
+++ b/app/src/search/files/model.rs
@@ -201,14 +201,6 @@ impl FileSearchModel {
         self.get_repo_contents_with_options(query, true, app)
     }
 
-    /// Gets repository files (no directories) for the current working directory.
-    ///
-    /// Intended for search surfaces that only ever open files and cannot act on
-    /// directory entries, such as the Command Palette file filter. Excluding
-    /// directories keeps them from consuming the repo-metadata result cap, which
-    /// otherwise starves file matches when many directories match the query.
-    /// Kept separate from [`Self::get_repo_contents`] so callers
-    /// that do surface directories (e.g. the AI context menu) are unaffected.
     #[cfg(feature = "local_fs")]
     pub fn get_repo_file_contents(
         &self,

--- a/app/src/search/files/model.rs
+++ b/app/src/search/files/model.rs
@@ -198,21 +198,50 @@ impl FileSearchModel {
     /// root location, invalidated when the file tree changes.
     #[cfg(feature = "local_fs")]
     pub fn get_repo_contents(&self, query: &str, app: &AppContext) -> Arc<Vec<FileSearchResult>> {
+        self.get_repo_contents_with_options(query, true, app)
+    }
+
+    /// Gets repository files (no directories) for the current working directory.
+    ///
+    /// Intended for search surfaces that only ever open files and cannot act on
+    /// directory entries, such as the Command Palette file filter. Excluding
+    /// directories keeps them from consuming the repo-metadata result cap, which
+    /// otherwise starves file matches when many directories match the query
+    /// (see #12391). Kept separate from [`Self::get_repo_contents`] so callers
+    /// that do surface directories (e.g. the AI context menu) are unaffected.
+    #[cfg(feature = "local_fs")]
+    pub fn get_repo_file_contents(
+        &self,
+        query: &str,
+        app: &AppContext,
+    ) -> Arc<Vec<FileSearchResult>> {
+        self.get_repo_contents_with_options(query, false, app)
+    }
+
+    #[cfg(feature = "local_fs")]
+    fn get_repo_contents_with_options(
+        &self,
+        query: &str,
+        include_folders: bool,
+        app: &AppContext,
+    ) -> Arc<Vec<FileSearchResult>> {
         let Some(repo_root) = self.repo_root_location(app) else {
             return Arc::new(Vec::new());
         };
 
         // Query-filtered results are query-specific, so bypass the per-repo
-        // cache and traverse the in-memory index fresh.
-        if !query.is_empty() {
-            return Arc::new(self.get_contents_from_repo(&repo_root, query, app));
+        // cache and traverse the in-memory index fresh. The file-only variant
+        // (`!include_folders`) is likewise uncached, since the shared cache
+        // holds the directory-inclusive contents.
+        if !query.is_empty() || !include_folders {
+            return Arc::new(self.get_contents_from_repo(&repo_root, query, include_folders, app));
         }
 
         if let Some(cached) = self.repo_contents_cache.borrow().get(&repo_root) {
             return cached.clone();
         }
 
-        let contents = self.get_contents_from_repo(&repo_root, query, app);
+        let contents = self.get_contents_from_repo(&repo_root, query, include_folders, app);
 
         let arc = Arc::new(contents);
         self.repo_contents_cache
@@ -242,6 +271,16 @@ impl FileSearchModel {
         Arc::new(Vec::new())
     }
 
+    /// Gets repository files (no directories) for the current working directory (WASM stub)
+    #[cfg(not(feature = "local_fs"))]
+    pub fn get_repo_file_contents(
+        &self,
+        _query: &str,
+        _app: &AppContext,
+    ) -> Arc<Vec<FileSearchResult>> {
+        Arc::new(Vec::new())
+    }
+
     /// Gets repository contents with git status information for prioritization (WASM stub)
     #[cfg(not(feature = "local_fs"))]
     pub fn get_repo_contents_with_git_status(
@@ -259,15 +298,20 @@ impl FileSearchModel {
     /// query. Pushing the query into traversal ensures the result cap applies
     /// to *matching* files rather than the first files encountered.
     #[cfg(feature = "local_fs")]
-    fn contents_args<F>(query: &str, relative_path: F) -> GetContentsArgs
+    fn contents_args<F>(query: &str, include_folders: bool, relative_path: F) -> GetContentsArgs
     where
         F: for<'a> Fn(&repo_metadata::RepoContent<'a>) -> Option<String> + Send + Sync + 'static,
     {
+        let base = if include_folders {
+            GetContentsArgs::default()
+        } else {
+            GetContentsArgs::default().exclude_folders()
+        };
         if query.is_empty() {
-            return GetContentsArgs::default();
+            return base;
         }
         let query = query.to_string();
-        GetContentsArgs::default().with_filter(move |content| {
+        base.with_filter(move |content| {
             relative_path(content)
                 .is_some_and(|path| FileSearchModel::fuzzy_match_path(&path, &query).is_some())
         })
@@ -285,6 +329,7 @@ impl FileSearchModel {
         &self,
         repo_root: &LocalOrRemotePath,
         query: &str,
+        include_folders: bool,
         app: &AppContext,
     ) -> Vec<FileSearchResult> {
         let repo_metadata = RepoMetadataModel::as_ref(app);
@@ -297,7 +342,7 @@ impl FileSearchModel {
                 let Some(id) = RepositoryIdentifier::try_local(local_path) else {
                     return Vec::new();
                 };
-                let args = Self::contents_args(query, {
+                let args = Self::contents_args(query, include_folders, {
                     let canonical_repo_path = canonical_repo_path.clone();
                     move |content| {
                         let local = match content {
@@ -357,7 +402,7 @@ impl FileSearchModel {
             }
             LocalOrRemotePath::Remote(remote_path) => {
                 let id = RepositoryIdentifier::Remote(remote_path.clone());
-                let args = Self::contents_args(query, {
+                let args = Self::contents_args(query, include_folders, {
                     let root = remote_path.path.clone();
                     move |content| {
                         let path_std = match content {

--- a/app/src/search/files/model.rs
+++ b/app/src/search/files/model.rs
@@ -206,8 +206,8 @@ impl FileSearchModel {
     /// Intended for search surfaces that only ever open files and cannot act on
     /// directory entries, such as the Command Palette file filter. Excluding
     /// directories keeps them from consuming the repo-metadata result cap, which
-    /// otherwise starves file matches when many directories match the query
-    /// (see #12391). Kept separate from [`Self::get_repo_contents`] so callers
+    /// otherwise starves file matches when many directories match the query.
+    /// Kept separate from [`Self::get_repo_contents`] so callers
     /// that do surface directories (e.g. the AI context menu) are unaffected.
     #[cfg(feature = "local_fs")]
     pub fn get_repo_file_contents(

--- a/app/src/search/files/model.rs
+++ b/app/src/search/files/model.rs
@@ -201,6 +201,12 @@ impl FileSearchModel {
         self.get_repo_contents_with_options(query, true, app)
     }
 
+    /// Gets repository files (no directories) for the current working directory.
+    ///
+    /// Intended for search surfaces that only ever open files and cannot act on
+    /// directory entries, such as the Command Palette file filter. Excluding
+    /// directories keeps them from consuming the repo-metadata result cap, which
+    /// otherwise starves file matches when many directories match the query.
     #[cfg(feature = "local_fs")]
     pub fn get_repo_file_contents(
         &self,

--- a/app/src/search/files/model_tests.rs
+++ b/app/src/search/files/model_tests.rs
@@ -152,6 +152,30 @@ mod file_search_model_tests {
         assert!(!FileSearchModel::should_skip_overly_broad_query("a*b"));
     }
 
+    #[cfg(feature = "local_fs")]
+    #[test]
+    fn test_contents_args_keeps_folders_by_default() {
+        // The default (directory-inclusive) path is used by callers like the
+        // AI context menu and must keep folders in the traversal.
+        let args = FileSearchModel::contents_args("src", true, |_| Some("src/main.rs".into()));
+        assert!(args.include_folders);
+
+        let empty = FileSearchModel::contents_args("", true, |_| Some("src/main.rs".into()));
+        assert!(empty.include_folders);
+    }
+
+    #[cfg(feature = "local_fs")]
+    #[test]
+    fn test_contents_args_excludes_folders_for_file_only_search() {
+        // The Command Palette file filter opts out of folders so directory
+        // matches don't consume the result cap and starve files (#12391).
+        let args = FileSearchModel::contents_args("src", false, |_| Some("src/main.rs".into()));
+        assert!(!args.include_folders);
+
+        let empty = FileSearchModel::contents_args("", false, |_| Some("src/main.rs".into()));
+        assert!(!empty.include_folders);
+    }
+
     #[test]
     fn test_filename_prioritization() {
         // Filename matches should score higher than path matches

--- a/app/src/search/files/model_tests.rs
+++ b/app/src/search/files/model_tests.rs
@@ -167,8 +167,6 @@ mod file_search_model_tests {
     #[cfg(feature = "local_fs")]
     #[test]
     fn test_contents_args_excludes_folders_for_file_only_search() {
-        // The Command Palette file filter opts out of folders so directory
-        // matches don't consume the result cap and starve files (#12391).
         let args = FileSearchModel::contents_args("src", false, |_| Some("src/main.rs".into()));
         assert!(!args.include_folders);
 


### PR DESCRIPTION
## Description

Command Palette file search (the file filter / `Cmd+O`) could return **no files** when the query matched many directories. The repo-metadata traversal caps results at a fixed budget, and directory entries matching the query were consuming those slots before any files were reached — so a query like a common folder name surfaced only directories (or nothing useful), never the files the user was searching for.

This routes the Command Palette file filter through a new **file-only** contents path that excludes directories from the traversal, so the result cap is spent on file matches. The fix is deliberately scoped to that one surface:

- `FileSearchModel::get_repo_file_contents()` is a new sibling of `get_repo_contents()` that traverses with `include_folders = false`. Both delegate to a shared `get_repo_contents_with_options(query, include_folders, app)`.
- `contents_args()` applies `GetContentsArgs::exclude_folders()` when `include_folders` is false, so folders are dropped *during* traversal (before the cap), not filtered out afterward.
- Only the Command Palette file `data_source` query path is rerouted to `get_repo_file_contents()`. Callers that legitimately surface directories (e.g. the AI context menu, and the zero-state git-status listing) keep using `get_repo_contents()` unchanged — a blanket `.exclude_folders()` would have regressed them.
- The file-only path is uncached (like the existing query path), since the shared per-repo cache holds the directory-inclusive contents.
- WASM (`not(feature = "local_fs")`) gets a matching stub.

Building on the diagnosis and approach from the earlier PRs #12440 (@amlndz — root cause) and #12894 (@SkyNotSilent — the file-only design), both of which were auto-closed for inactivity; this relands that approach against current `main` and adds the before/after recording that was the one outstanding review request.

## Linked Issue
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

Closes #12391

## Testing
- [x] `cargo fmt -- --check`
- [x] `cargo check -p warp`
- [x] `cargo clippy -p warp --tests -- -D warnings` (clean)
- [x] `cargo nextest run -p warp file_search_model_tests` — 16 passed
- [x] I have manually tested my changes locally with `./script/run`

<sub>Note: `--all-features` clippy surfaces some pre-existing `dead_code`/`unused_imports` warnings in unrelated SSH/session-sharing modules that are present on `main` independent of this change; the changed files are clippy-clean.</sub>

### Screenshots / Videos

Reproduced in a repo whose matching entries are a deeply-nested chain of directories all named `widget` (every one matches the query), with three files at the bottom of the chain (`widget_alpha_FOUND.txt`, `widget_beta_FOUND.txt`, `widget_gamma_FOUND.txt`). Searching `widget` in the Command Palette file filter:

**Before** — the matching directories consume the result cap during traversal, so the three files at the bottom of the chain are never reached and the search returns nothing:

https://github.com/user-attachments/assets/e91d2623-35f9-481e-adc6-19cf6e9ca189

**After** — directories are excluded from the file-search traversal, so it descends to the files and all three are returned:

https://github.com/user-attachments/assets/c2bd868e-db27-4d77-9333-35488a602212

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fix Command Palette file search returning no files when the query matched many directories
-->

