### PR TITLE
Speedup TUI startup time

### DIFF
--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar_tests.rs
@@ -58,6 +58,7 @@ fn pill_bar_data_layer_finds_restored_children_before_pane_creation() {
                     })
                     .expect("child conversation data should serialize"),
                     last_modified_at: now,
+                    summary: None,
                 },
                 tasks: vec![warp_multi_agent_api::Task {
                     id: format!("task-{child_id}"),
@@ -108,6 +109,7 @@ fn pill_bar_data_layer_finds_restored_children_before_pane_creation() {
                     })
                     .expect("parent conversation data should serialize"),
                     last_modified_at: now - chrono::Duration::seconds(1),
+                    summary: None,
                 },
                 tasks: vec![warp_multi_agent_api::Task {
                     id: format!("task-{parent_id}"),

--- a/app/src/ai/blocklist/block/view_impl/orchestration_tests.rs
+++ b/app/src/ai/blocklist/block/view_impl/orchestration_tests.rs
@@ -302,6 +302,7 @@ fn participant_for_restored_child_run_id_resolves_to_agent_name() {
                 })
                 .expect("child conversation data should serialize"),
                 last_modified_at: now,
+                summary: None,
             },
             tasks: vec![warp_multi_agent_api::Task {
                 id: format!("task-{child_id}"),
@@ -355,6 +356,7 @@ fn participant_for_restored_child_run_id_resolves_to_agent_name() {
                 })
                 .expect("parent conversation data should serialize"),
                 last_modified_at: now - chrono::Duration::seconds(1),
+                summary: None,
             },
             tasks: vec![warp_multi_agent_api::Task {
                 id: format!("task-{parent_id}"),

--- a/app/src/ai/blocklist/history_model/conversation_loader.rs
+++ b/app/src/ai/blocklist/history_model/conversation_loader.rs
@@ -22,10 +22,11 @@ use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::{
     AIAgentHarness, AIConversation, AIConversationId, ServerAIConversationMetadata,
 };
-use crate::ai::agent::task::Task;
 #[cfg(feature = "local_fs")]
 use crate::persistence::agent::read_agent_conversation_by_id;
-use crate::persistence::model::{AgentConversation, AgentConversationData};
+use crate::persistence::model::{
+    AgentConversation, AgentConversationData, AgentConversationSummary,
+};
 use crate::server::server_api::ai::AIClient;
 use crate::server::server_api::ServerApiProvider;
 use crate::terminal::model::block::SerializedBlock;
@@ -473,6 +474,11 @@ impl BlocklistAIHistoryModel {
     }
 
     /// Initializes historical conversations from restored agent conversations.
+    ///
+    /// At startup the conversations carry only `agent_conversations` records
+    /// (empty task lists) whose summaries were computed at write time (or
+    /// derived once at read time); tests may pass fully-hydrated
+    /// conversations, whose summaries are derived from their tasks here.
     pub(super) fn initialize_historical_conversations(
         &mut self,
         conversations: &[AgentConversation],
@@ -481,6 +487,7 @@ impl BlocklistAIHistoryModel {
             agent_conversation: &'a AgentConversation,
             conversation_id: AIConversationId,
             conversation_data: Option<AgentConversationData>,
+            summary: AgentConversationSummary,
         }
 
         let historical_rows: Vec<_> = conversations
@@ -499,7 +506,18 @@ impl BlocklistAIHistoryModel {
                     }
                 };
 
-                if !agent_conversation.is_restorable() {
+                // Prefer the write-time summary from the `summary` column;
+                // fall back to deriving from tasks for fully-hydrated inputs.
+                let summary = agent_conversation
+                    .conversation
+                    .summary
+                    .as_deref()
+                    .and_then(|json| serde_json::from_str::<AgentConversationSummary>(json).ok())
+                    .unwrap_or_else(|| {
+                        AgentConversationSummary::from_tasks(agent_conversation.tasks.iter())
+                    });
+
+                if !summary.is_restorable {
                     return None;
                 }
 
@@ -523,6 +541,7 @@ impl BlocklistAIHistoryModel {
                     agent_conversation,
                     conversation_id,
                     conversation_data,
+                    summary,
                 })
             })
             .collect();
@@ -534,6 +553,7 @@ impl BlocklistAIHistoryModel {
                     agent_conversation,
                     conversation_id,
                     conversation_data,
+                    summary,
                 } = row;
 
                 // Child agent conversations are managed by their parent's
@@ -559,11 +579,18 @@ impl BlocklistAIHistoryModel {
                     // later when the hidden pane is materialized via
                     // `restore_conversations`. A subsequent `restore_conversations`
                     // call replaces this entry idempotently.
-                    if let Some(child_conversation) =
+                    //
+                    // Startup rows carry no tasks, so the child's task
+                    // payload is loaded from the local DB; fully-hydrated
+                    // inputs convert directly.
+                    let child_conversation = if agent_conversation.tasks.is_empty() {
+                        self.load_conversation_from_db(&conversation_id)
+                    } else {
                         convert_persisted_conversation_to_ai_conversation_with_metadata(
                             agent_conversation.clone(),
                         )
-                    {
+                    };
+                    if let Some(child_conversation) = child_conversation {
                         self.conversations_by_id
                             .insert(conversation_id, child_conversation);
                     } else {
@@ -575,67 +602,19 @@ impl BlocklistAIHistoryModel {
                     return None;
                 }
 
-                // Skip conversations that contain AutoCodeDiff system queries but do not contain any UserQuery messages.
-                // These are passive, auto-initiated diffs that were never interacted with (past accepting or rejecting the diff),
-                // so we don't want to list them as historical conversations.
-                let mut has_user_query = false;
-                let mut has_autocodediff = false;
-                for task in &agent_conversation.tasks {
-                    for message in &task.messages {
-                        match &message.message {
-                            Some(warp_multi_agent_api::message::Message::UserQuery(_)) => {
-                                has_user_query = true;
-                            }
-                            Some(warp_multi_agent_api::message::Message::SystemQuery(sys)) => {
-                                if let Some(
-                                    warp_multi_agent_api::message::system_query::Type::AutoCodeDiff(_),
-                                ) = &sys.r#type
-                                {
-                                    has_autocodediff = true;
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-                if has_autocodediff && !has_user_query {
+                // Skip conversations that only contain passive AutoCodeDiff
+                // system queries the user never interacted with (past
+                // accepting or rejecting the diff).
+                if summary.is_unlisted_auto_code_diff {
                     return None;
                 }
 
-                let root_task = agent_conversation
-                    .tasks
-                    .iter()
-                    .find(|task| task.dependencies.is_none());
-
-                let initial_query = root_task
-                    .map(|task| {
-                        // find the first task with a user query
-                        // (or in the case of a passive code diff, the summary of the diff)
-                        task.messages
-                            .iter()
-                            .find_map(|msg| match &msg.message {
-                                Some(warp_multi_agent_api::message::Message::UserQuery(
-                                    user_query,
-                                )) => Some(user_query.query.clone()),
-                                Some(warp_multi_agent_api::message::Message::ToolCall(
-                                    tool_call,
-                                )) => {
-                                    let Some(tool) = &tool_call.tool else {
-                                        return None;
-                                    };
-
-                                    if let warp_multi_agent_api::message::tool_call::Tool::ApplyFileDiffs(diff_suggestion) = tool
-                                    {
-                                        Some(diff_suggestion.summary.clone())
-                                    } else {
-                                        None
-                                    }
-                                }
-                                _ => None,
-                            })
-                            .unwrap_or_default()
-                    })
-                    .unwrap_or_default();
+                let AgentConversationSummary {
+                    initial_query,
+                    title,
+                    initial_working_directory,
+                    ..
+                } = summary;
 
                 if initial_query.is_empty() {
                     log::warn!(
@@ -644,19 +623,6 @@ impl BlocklistAIHistoryModel {
                     return None;
                 }
 
-                // We derive the title from the description of the root task,
-                // falling back to initial_query if the description is empty
-                let title = root_task
-                    .map(|task| task.description.clone())
-                    .filter(|desc| !desc.is_empty())
-                    .unwrap_or_else(|| initial_query.clone());
-
-                // Extract working directory from the first UserQuery message in the tasks
-                // TODO: search tasks in correct order once we've implemented task ordering.
-                let initial_working_directory = agent_conversation
-                    .tasks
-                    .iter()
-                    .find_map(Task::api_task_initial_working_directory);
                 let credits_spent = conversation_data
                     .as_ref()
                     .and_then(|data| data.conversation_usage_metadata.as_ref())

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -33,7 +33,8 @@ use crate::auth::AuthStateProvider;
 use crate::cloud_object::{Owner, Revision, ServerMetadata, ServerPermissions};
 use crate::input_suggestions::HistoryInputSuggestion;
 use crate::persistence::model::{
-    AgentConversation, AgentConversationData, AgentConversationRecord, PersistedAutoexecuteMode,
+    AgentConversation, AgentConversationData, AgentConversationRecord, AgentConversationSummary,
+    PersistedAutoexecuteMode,
 };
 use crate::persistence::ModelEvent;
 use crate::server::ids::ServerId;
@@ -125,6 +126,7 @@ fn persisted_agent_conversation(
             conversation_data: serde_json::to_string(&conversation_data)
                 .expect("conversation data should serialize"),
             last_modified_at,
+            summary: None,
         },
         tasks,
     }
@@ -183,6 +185,7 @@ fn persisted_agent_conversation_from_update_event(event: ModelEvent) -> AgentCon
             conversation_data: serde_json::to_string(&conversation_data)
                 .expect("conversation data should serialize"),
             last_modified_at: Utc::now().naive_utc(),
+            summary: None,
         },
         tasks: updated_tasks,
     }
@@ -703,6 +706,7 @@ fn test_initialize_historical_conversations_uses_root_task_description_title() {
                 })
                 .expect("conversation data should serialize"),
                 last_modified_at: now,
+                summary: None,
             },
             tasks: vec![warp_multi_agent_api::Task {
                 id: task_id.clone(),
@@ -731,6 +735,107 @@ fn test_initialize_historical_conversations_uses_root_task_description_title() {
         });
     });
 }
+
+#[test]
+fn test_initialize_historical_conversations_uses_summary_column_without_tasks() {
+    // Startup rows carry only `agent_conversations` records: task lists are
+    // empty and the metadata comes from the write-time `summary` column.
+    App::test((), |app| async move {
+        let conversation_id = AIConversationId::new();
+        let now = Utc::now().naive_utc();
+        let summary = AgentConversationSummary {
+            initial_query: "Initial query".to_string(),
+            title: "Summary title".to_string(),
+            initial_working_directory: Some("/tmp/repo".to_string()),
+            is_restorable: true,
+            is_unlisted_auto_code_diff: false,
+        };
+        let conversations = vec![AgentConversation {
+            conversation: AgentConversationRecord {
+                id: 0,
+                conversation_id: conversation_id.to_string(),
+                conversation_data: r#"{"server_conversation_token":null}"#.to_string(),
+                last_modified_at: now,
+                summary: Some(serde_json::to_string(&summary).expect("summary should serialize")),
+            },
+            tasks: vec![],
+        }];
+
+        let history_model = app
+            .add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &conversations));
+
+        history_model.read(&app, |model, _| {
+            let metadata = model
+                .get_conversation_metadata(&conversation_id)
+                .expect("conversation metadata should be initialized from the summary column");
+            assert_eq!(metadata.title, "Summary title");
+            assert_eq!(metadata.initial_query, "Initial query");
+            assert_eq!(
+                metadata.initial_working_directory.as_deref(),
+                Some("/tmp/repo")
+            );
+            assert!(metadata.has_local_data);
+            // The conversation itself stays on the lazy path.
+            assert!(model.conversation(&conversation_id).is_none());
+        });
+    });
+}
+
+#[test]
+fn test_initialize_historical_conversations_skips_unrestorable_and_unlisted_summaries() {
+    App::test((), |app| async move {
+        let unrestorable_id = AIConversationId::new();
+        let unlisted_id = AIConversationId::new();
+        let now = Utc::now().naive_utc();
+        let record = |id: &AIConversationId, summary: &AgentConversationSummary, row: i32| {
+            AgentConversation {
+                conversation: AgentConversationRecord {
+                    id: row,
+                    conversation_id: id.to_string(),
+                    conversation_data: r#"{"server_conversation_token":null}"#.to_string(),
+                    last_modified_at: now,
+                    summary: Some(
+                        serde_json::to_string(summary).expect("summary should serialize"),
+                    ),
+                },
+                tasks: vec![],
+            }
+        };
+        let conversations = vec![
+            record(
+                &unrestorable_id,
+                &AgentConversationSummary {
+                    initial_query: "Initial query".to_string(),
+                    title: "Unrestorable".to_string(),
+                    initial_working_directory: None,
+                    is_restorable: false,
+                    is_unlisted_auto_code_diff: false,
+                },
+                0,
+            ),
+            record(
+                &unlisted_id,
+                &AgentConversationSummary {
+                    initial_query: "diff".to_string(),
+                    title: "Passive diff".to_string(),
+                    initial_working_directory: None,
+                    is_restorable: true,
+                    is_unlisted_auto_code_diff: true,
+                },
+                1,
+            ),
+        ];
+
+        let history_model = app
+            .add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &conversations));
+
+        history_model.read(&app, |model, _| {
+            assert!(model.get_conversation_metadata(&unrestorable_id).is_none());
+            assert!(model.get_conversation_metadata(&unlisted_id).is_none());
+        });
+    });
+}
+
 #[test]
 fn test_initialize_historical_conversations_eagerly_hydrates_orchestration_children() {
     // Fix C: orchestration children should be inserted into `conversations_by_id`
@@ -1641,6 +1746,7 @@ fn test_initialize_historical_conversations_indexes_child_conversations() {
                 conversation_id: child_id.to_string(),
                 conversation_data: child_conversation_data,
                 last_modified_at: NaiveDateTime::default(),
+                summary: None,
             },
             tasks: vec![],
         }];
@@ -2352,6 +2458,7 @@ fn test_optimistic_root_restore_round_trip_yields_in_progress_optimistic_root() 
                 conversation_data: serde_json::to_string(&conversation_data)
                     .expect("conversation data should serialize"),
                 last_modified_at: Utc::now().naive_utc(),
+                summary: None,
             },
             tasks: updated_tasks,
         };

--- a/app/src/ai/restored_conversations.rs
+++ b/app/src/ai/restored_conversations.rs
@@ -1,26 +1,62 @@
-//! A singleton model for storing conversations by ID to enable restoration across terminal views.
+//! A singleton model for restoring conversations by ID across terminal views.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+#[cfg(feature = "local_fs")]
+use std::sync::{Arc, Mutex};
 
+#[cfg(feature = "local_fs")]
+use diesel::SqliteConnection;
 use warpui::{Entity, SingletonEntity};
 
 use crate::ai::agent::conversation::{AIConversation, AIConversationId};
+#[cfg_attr(not(any(feature = "local_fs", test)), allow(unused_imports))]
 use crate::ai::blocklist::history_model::convert_persisted_conversation_to_ai_conversation_with_metadata;
+#[cfg(test)]
 use crate::persistence::model::AgentConversation;
+#[cfg(feature = "local_fs")]
+use crate::persistence::{database_file_path_for_scope, establish_ro_connection, PersistenceScope};
 
-/// Singleton model that holds restored agent conversations on app startup.
+/// Singleton model that restores agent conversations on demand.
 ///
-/// Loading restored conversations into this model is a means of propagating restored data from
-/// sqlite (read at startup) to arbitrary consuming locations in the view/model hierarchy without
-/// piping it all the way from the root view to the terminal view(s) that require it.
-#[derive(Default)]
+/// Startup only loads conversation metadata, so the full task payloads are
+/// loaded lazily from the local database the first time a consumer (e.g. pane
+/// restoration) asks for a conversation. Consuming restored data this way
+/// avoids piping it from the root view down to the terminal view(s) that
+/// require it.
 pub struct RestoredAgentConversations {
-    /// All conversations stored by their ID, available for restoration
+    /// Conversations already loaded (or test-seeded) but not yet taken.
     conversations: HashMap<AIConversationId, AIConversation>,
+    /// IDs already handed out via `take_conversation(s)`. Preserves the
+    /// historical take-once semantics now that the backing database can
+    /// otherwise serve the same conversation repeatedly.
+    taken: HashSet<AIConversationId>,
+    #[cfg(feature = "local_fs")]
+    db_connection: Option<Arc<Mutex<SqliteConnection>>>,
 }
 
 impl RestoredAgentConversations {
-    pub fn new(conversations: Vec<AgentConversation>) -> Self {
+    pub fn new() -> Self {
+        #[cfg(feature = "local_fs")]
+        let db_connection = database_file_path_for_scope(&PersistenceScope::App)
+            .to_str()
+            .and_then(|db_url| {
+                establish_ro_connection(db_url)
+                    .ok()
+                    .map(|conn| Arc::new(Mutex::new(conn)))
+            });
+
+        Self {
+            conversations: HashMap::new(),
+            taken: HashSet::new(),
+            #[cfg(feature = "local_fs")]
+            db_connection,
+        }
+    }
+
+    /// Seeds the store with already-loaded conversations instead of a backing
+    /// database. Only used by tests.
+    #[cfg(test)]
+    pub fn new_seeded(conversations: Vec<AgentConversation>) -> Self {
         let mut conversations_by_id = HashMap::new();
         for conversation in conversations.into_iter() {
             let conversation_id = conversation.conversation.conversation_id.clone();
@@ -37,17 +73,61 @@ impl RestoredAgentConversations {
 
         Self {
             conversations: conversations_by_id,
+            taken: HashSet::new(),
+            #[cfg(feature = "local_fs")]
+            db_connection: None,
         }
     }
 
-    /// Gets a reference to a restored conversation without removing it.
-    pub fn get_conversation(&self, id: &AIConversationId) -> Option<&AIConversation> {
+    /// Loads and converts a conversation from the local database.
+    fn load_from_db(&self, id: &AIConversationId) -> Option<AIConversation> {
+        #[cfg(feature = "local_fs")]
+        {
+            let conn = self.db_connection.clone()?;
+            let mut conn = conn.lock().ok()?;
+            match crate::persistence::agent::read_agent_conversation_by_id(
+                &mut conn,
+                &id.to_string(),
+            ) {
+                Ok(Some(conversation)) => {
+                    convert_persisted_conversation_to_ai_conversation_with_metadata(conversation)
+                }
+                Ok(None) => None,
+                Err(e) => {
+                    log::warn!("Failed to read AgentConversation {id}: {e:?}");
+                    None
+                }
+            }
+        }
+        #[cfg(not(feature = "local_fs"))]
+        {
+            let _ = id;
+            None
+        }
+    }
+
+    /// Gets a reference to a restored conversation without taking it, loading
+    /// it from the local database when it isn't cached yet.
+    pub fn get_conversation(&mut self, id: &AIConversationId) -> Option<&AIConversation> {
+        if self.taken.contains(id) {
+            return None;
+        }
+        if !self.conversations.contains_key(id) {
+            let loaded = self.load_from_db(id)?;
+            self.conversations.insert(*id, loaded);
+        }
         self.conversations.get(id)
     }
 
-    /// Removes the restored conversation and returns it, if any.
+    /// Takes the restored conversation and returns it, if any. Each
+    /// conversation is handed out at most once.
     pub fn take_conversation(&mut self, id: &AIConversationId) -> Option<AIConversation> {
-        self.conversations.remove(id)
+        if !self.taken.insert(*id) {
+            return None;
+        }
+        self.conversations
+            .remove(id)
+            .or_else(|| self.load_from_db(id))
     }
 
     /// Takes and returns AIConversations for the given IDs, sorted by first exchange start time.
@@ -56,8 +136,8 @@ impl RestoredAgentConversations {
         conversation_ids: &[AIConversationId],
     ) -> Vec<AIConversation> {
         let mut conversations = Vec::new();
-        for &conversation_id in conversation_ids {
-            if let Some(conversation) = self.take_conversation(&conversation_id) {
+        for conversation_id in conversation_ids {
+            if let Some(conversation) = self.take_conversation(conversation_id) {
                 conversations.push(conversation);
             }
         }

--- a/app/src/ai/restored_conversations.rs
+++ b/app/src/ai/restored_conversations.rs
@@ -121,13 +121,20 @@ impl RestoredAgentConversations {
 
     /// Takes the restored conversation and returns it, if any. Each
     /// conversation is handed out at most once.
+    ///
+    /// The ID is only marked as taken once a conversation was actually
+    /// handed out, so a failed load (e.g. a transient read error) doesn't
+    /// permanently consume the restore opportunity for this session.
     pub fn take_conversation(&mut self, id: &AIConversationId) -> Option<AIConversation> {
-        if !self.taken.insert(*id) {
+        if self.taken.contains(id) {
             return None;
         }
-        self.conversations
+        let conversation = self
+            .conversations
             .remove(id)
-            .or_else(|| self.load_from_db(id))
+            .or_else(|| self.load_from_db(id))?;
+        self.taken.insert(*id);
+        Some(conversation)
     }
 
     /// Takes and returns AIConversations for the given IDs, sorted by first exchange start time.
@@ -157,3 +164,7 @@ impl Entity for RestoredAgentConversations {
 }
 
 impl SingletonEntity for RestoredAgentConversations {}
+
+#[cfg(test)]
+#[path = "restored_conversations_tests.rs"]
+mod tests;

--- a/app/src/ai/restored_conversations_tests.rs
+++ b/app/src/ai/restored_conversations_tests.rs
@@ -1,0 +1,67 @@
+use super::*;
+use crate::persistence::model::{AgentConversation, AgentConversationRecord};
+
+fn persisted_conversation(conversation_id: AIConversationId) -> AgentConversation {
+    let task_id = format!("task-{conversation_id}");
+    AgentConversation {
+        conversation: AgentConversationRecord {
+            id: 0,
+            conversation_id: conversation_id.to_string(),
+            conversation_data: r#"{"server_conversation_token":null}"#.to_string(),
+            last_modified_at: chrono::NaiveDateTime::default(),
+            summary: None,
+        },
+        tasks: vec![warp_multi_agent_api::Task {
+            id: task_id,
+            messages: vec![],
+            dependencies: None,
+            description: "Test conversation".to_string(),
+            summary: String::new(),
+            server_data: String::new(),
+        }],
+    }
+}
+
+fn ai_conversation(conversation_id: AIConversationId) -> AIConversation {
+    convert_persisted_conversation_to_ai_conversation_with_metadata(persisted_conversation(
+        conversation_id,
+    ))
+    .expect("test conversation should convert")
+}
+
+#[test]
+fn take_conversation_hands_out_each_conversation_at_most_once() {
+    let conversation_id = AIConversationId::new();
+    let mut store =
+        RestoredAgentConversations::new_seeded(vec![persisted_conversation(conversation_id)]);
+
+    assert!(store.take_conversation(&conversation_id).is_some());
+    assert!(
+        store.take_conversation(&conversation_id).is_none(),
+        "a taken conversation must not be handed out again"
+    );
+    assert!(
+        store.get_conversation(&conversation_id).is_none(),
+        "a taken conversation must not be readable either"
+    );
+}
+
+#[test]
+fn failed_take_does_not_consume_the_restore_opportunity() {
+    let conversation_id = AIConversationId::new();
+    // No seed and no backing database: the first take fails to load.
+    let mut store = RestoredAgentConversations::new_seeded(vec![]);
+    assert!(store.take_conversation(&conversation_id).is_none());
+
+    // Once the conversation becomes available (e.g. the earlier failure was
+    // transient), a retry must still succeed — a failed load must not have
+    // marked the ID as taken.
+    store
+        .conversations
+        .insert(conversation_id, ai_conversation(conversation_id));
+    assert!(
+        store.take_conversation(&conversation_id).is_some(),
+        "a failed load must not permanently consume the restore"
+    );
+    assert!(store.take_conversation(&conversation_id).is_none());
+}

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1388,7 +1388,20 @@ pub(crate) fn initialize_app(
         | LaunchMode::Test { .. }
         | LaunchMode::Tui { .. } => persistence::PersistenceScope::App,
     };
-    let (sqlite_data, writer_handles) = persistence::initialize(ctx, persistence_scope);
+    // Only read the subsets of persisted data this launch mode actually
+    // consumes; loading everything is expensive on large databases.
+    let persisted_data_scope = match launch_mode {
+        LaunchMode::Tui { .. } => persistence::PersistedDataScope::TuiFrontend,
+        LaunchMode::RemoteServerDaemon { .. } => {
+            persistence::PersistedDataScope::CodebaseIndicesOnly
+        }
+        LaunchMode::App { .. }
+        | LaunchMode::CommandLine { .. }
+        | LaunchMode::RemoteServerProxy
+        | LaunchMode::Test { .. } => persistence::PersistedDataScope::Full,
+    };
+    let (sqlite_data, writer_handles) =
+        persistence::initialize(ctx, persistence_scope, persisted_data_scope);
     timer.mark_interval_end("SQLITE_INITIALIZED");
 
     let persistence_writer = PersistenceWriter::new(writer_handles);
@@ -1423,32 +1436,32 @@ pub(crate) fn initialize_app(
     });
 
     let (
-        mut cloud_objects,
-        mut cached_workspaces,
-        mut current_workspace_uid,
-        mut app_state,
-        mut command_history,
-        mut restored_user_profiles,
-        mut time_of_next_force_object_refresh,
-        mut object_actions,
-        mut experiments,
-        mut ai_queries,
-        mut nld_prompts,
+        cloud_objects,
+        cached_workspaces,
+        current_workspace_uid,
+        app_state,
+        command_history,
+        restored_user_profiles,
+        time_of_next_force_object_refresh,
+        object_actions,
+        experiments,
+        ai_queries,
+        nld_prompts,
         persisted_workspaces,
-        mut workspace_language_servers,
-        mut multi_agent_conversations,
-        mut persisted_projects,
-        mut persisted_project_rules,
-        mut persisted_ignored_suggestions,
-        mut persisted_mcp_server_installations,
-        mut mcp_servers_to_restore,
+        workspace_language_servers,
+        multi_agent_conversations,
+        persisted_projects,
+        persisted_project_rules,
+        persisted_ignored_suggestions,
+        persisted_mcp_server_installations,
+        mcp_servers_to_restore,
     ) = sqlite_data
         .map(|sqlite_data| {
             (
                 sqlite_data.cloud_objects,
                 sqlite_data.workspaces,
                 sqlite_data.current_workspace_uid,
-                Some(sqlite_data.app_state),
+                sqlite_data.app_state,
                 sqlite_data.command_history,
                 sqlite_data.user_profiles,
                 sqlite_data.time_of_next_force_object_refresh,
@@ -1490,29 +1503,13 @@ pub(crate) fn initialize_app(
             )
         });
 
+    // The daemon's `PersistedDataScope::CodebaseIndicesOnly` read already
+    // skips everything except codebase index metadata.
     if matches!(launch_mode, LaunchMode::RemoteServerDaemon { .. }) {
         let codebase_index_count = persisted_workspaces.len();
         log::debug!(
             "[Remote codebase indexing] Restored daemon codebase index metadata: metadata_count={codebase_index_count}"
         );
-        cloud_objects = Default::default();
-        cached_workspaces = Default::default();
-        current_workspace_uid = None;
-        app_state = None;
-        command_history = Default::default();
-        restored_user_profiles = Default::default();
-        time_of_next_force_object_refresh = None;
-        object_actions = Default::default();
-        experiments = Default::default();
-        ai_queries = Default::default();
-        nld_prompts = Default::default();
-        workspace_language_servers = Default::default();
-        multi_agent_conversations = Default::default();
-        persisted_projects = Default::default();
-        persisted_project_rules = Default::default();
-        persisted_ignored_suggestions = Default::default();
-        persisted_mcp_server_installations = Default::default();
-        mcp_servers_to_restore = Default::default();
     }
 
     // Initialize a global model to track server-side experiment state.
@@ -2007,7 +2004,9 @@ pub(crate) fn initialize_app(
             ctx,
         )
     });
-    ctx.add_singleton_model(move |_| RestoredAgentConversations::new(multi_agent_conversations));
+    // Conversations restore lazily from the local DB on demand; startup only
+    // loads metadata.
+    ctx.add_singleton_model(|_| RestoredAgentConversations::new());
     ctx.add_singleton_model(|_| CLIAgentSessionsModel::new());
     // ActiveAgentViewsModel is used to track active agent conversations and notify listeners when they change.
     ctx.add_singleton_model(|_| ActiveAgentViewsModel::new());

--- a/app/src/pane_group/child_agent/restoration.rs
+++ b/app/src/pane_group/child_agent/restoration.rs
@@ -123,7 +123,7 @@ impl PaneGroup {
                         history_model.resolved_parent_conversation_id_for_conversation(conversation)
                     })
                     .or_else(|| {
-                        RestoredAgentConversations::handle(ctx).read(ctx, |store, _| {
+                        RestoredAgentConversations::handle(ctx).update(ctx, |store, _| {
                             store.get_conversation(&child_conversation_id).and_then(
                                 |conversation| {
                                     history_model.resolved_parent_conversation_id_for_conversation(

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -1635,7 +1635,7 @@ impl PaneGroup {
                     .conversation_ids_to_restore
                     .iter()
                     .filter(|&conversation_id| {
-                        RestoredAgentConversations::handle(ctx).read(ctx, |store, _| {
+                        RestoredAgentConversations::handle(ctx).update(ctx, |store, _| {
                             store
                                 .get_conversation(conversation_id)
                                 .is_some_and(|persisted_conv| {

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -206,7 +206,7 @@ fn initialize_app(app: &mut App) {
     app.add_singleton_model(|ctx| PersistedWorkspace::new(vec![], HashMap::new(), None, ctx));
     app.add_singleton_model(|_| ProjectContextModel::default());
     app.add_singleton_model(|ctx| crate::ai::agent_tips::AITipModel::new_for_agent_tips(ctx));
-    app.add_singleton_model(|_| RestoredAgentConversations::new(vec![]));
+    app.add_singleton_model(|_| RestoredAgentConversations::new_seeded(vec![]));
     app.add_singleton_model(OneTimeModalModel::new);
     app.add_singleton_model(|_| WorkspaceRegistry::new());
     app.add_singleton_model(UndoCloseStack::new);
@@ -399,6 +399,7 @@ fn persisted_remote_child_conversation(
             })
             .expect("conversation data should serialize"),
             last_modified_at: Utc::now().naive_utc(),
+            summary: None,
         },
         tasks: vec![warp_multi_agent_api::Task {
             id: Uuid::new_v4().to_string(),
@@ -1269,13 +1270,14 @@ fn test_create_missing_child_agent_panes_restores_remote_child_from_history_mode
                     .set_parent_for_conversation(child_conversation_id, parent_conversation_id);
             });
             RestoredAgentConversations::handle(ctx).update(ctx, |store, _| {
-                *store =
-                    RestoredAgentConversations::new(vec![persisted_remote_child_conversation(
+                *store = RestoredAgentConversations::new_seeded(vec![
+                    persisted_remote_child_conversation(
                         child_conversation_id,
                         Some(parent_conversation_id),
                         None,
                         task_id,
-                    )]);
+                    ),
+                ]);
             });
 
             panes.restore_missing_child_agent_panes_for_parent(
@@ -1900,13 +1902,14 @@ fn test_ensure_hidden_child_agent_pane_materializes_restored_remote_child_linked
                     .set_parent_for_conversation(child_conversation_id, parent_conversation_id);
             });
             RestoredAgentConversations::handle(ctx).update(ctx, |store, _| {
-                *store =
-                    RestoredAgentConversations::new(vec![persisted_remote_child_conversation(
+                *store = RestoredAgentConversations::new_seeded(vec![
+                    persisted_remote_child_conversation(
                         child_conversation_id,
                         None,
                         Some(parent_run_id),
                         task_id,
-                    )]);
+                    ),
+                ]);
             });
 
             assert!(!panes.child_agent_panes.contains_key(&child_conversation_id));

--- a/app/src/persistence/agent.rs
+++ b/app/src/persistence/agent.rs
@@ -8,7 +8,8 @@ use diesel::SqliteConnection;
 use prost::Message;
 use warp_multi_agent_api as api;
 
-use super::model::{AgentConversation, AgentConversationData};
+use super::model::{AgentConversation, AgentConversationData, AgentConversationSummary};
+use super::ConversationSummaryBackfill;
 use crate::persistence::model::{AgentConversationRecord, AgentTaskRecord};
 use crate::persistence::schema::{self, agent_conversations, agent_tasks};
 
@@ -17,6 +18,7 @@ use crate::persistence::schema::{self, agent_conversations, agent_tasks};
 struct NewAgentConversation {
     conversation_id: String,
     conversation_data: String,
+    summary: Option<String>,
 }
 
 #[derive(Debug, Insertable, AsChangeset)]
@@ -62,11 +64,18 @@ pub(super) fn upsert_agent_conversation<'a>(
     let tasks: Vec<&api::Task> = tasks.into_iter().collect();
     let kept_task_ids: Vec<String> = tasks.iter().map(|task| task.id.clone()).collect();
 
+    // Derive the task-based summary here (on the writer thread) so every
+    // write path keeps the `summary` column in sync with the task snapshot,
+    // letting startup list conversations without loading `agent_tasks`.
+    let serialized_summary =
+        serde_json::to_string(&AgentConversationSummary::from_tasks(tasks.iter().copied())).ok();
+
     conn.transaction::<_, Error, _>(|conn| {
         // Upsert the conversation level metadata
         let new_conversation = NewAgentConversation {
             conversation_id: conversation_id_param.to_owned(),
             conversation_data: serialized_conversation_data,
+            summary: serialized_summary,
         };
 
         diesel::insert_into(agent_conversations::table())
@@ -222,51 +231,114 @@ pub(super) fn select_conversations_to_evict(
     evicted
 }
 
-pub(super) fn read_agent_conversations(
+/// Reads conversation metadata from `agent_conversations` only, without
+/// loading or decoding the (potentially very large) `agent_tasks` blobs.
+///
+/// The returned [`AgentConversation`]s have empty `tasks`; consumers use the
+/// summary on each record plus lazy per-conversation loading
+/// ([`read_agent_conversation_by_id`]) for full task data.
+///
+/// Rows written before the `summary` column existed get their summary derived
+/// here from their own task snapshot (the one-time slow path); those
+/// derivations are returned as backfills so the writer thread can persist
+/// them and keep subsequent startups metadata-only.
+pub(super) fn read_agent_conversation_metadata(
     conn: &mut SqliteConnection,
-) -> Result<Vec<AgentConversation>, diesel::result::Error> {
+) -> Result<(Vec<AgentConversation>, Vec<ConversationSummaryBackfill>), diesel::result::Error> {
     use schema::agent_conversations::dsl::*;
 
-    let mut conversations_by_id = HashMap::<String, AgentConversation>::from_iter(
-        agent_conversations
-            .select(AgentConversationRecord::as_select())
-            .load(conn)?
-            .into_iter()
-            .map(|conversation| {
-                (
-                    conversation.conversation_id.clone(),
-                    AgentConversation {
-                        conversation,
-                        tasks: vec![],
-                    },
-                )
-            }),
-    );
-
-    let task_records: Vec<AgentTaskRecord> = agent_tasks::table
-        .select(AgentTaskRecord::as_select())
+    let records: Vec<AgentConversationRecord> = agent_conversations
+        .select(AgentConversationRecord::as_select())
         .load(conn)?;
 
-    let mut invalid_conversation_ids = HashSet::new();
-    for task_record in task_records {
-        if let Some(conversation) = conversations_by_id.get_mut(&task_record.conversation_id) {
-            match api::Task::decode(&task_record.task[..]) {
-                Ok(api_task) => {
-                    conversation.tasks.push(api_task);
-                }
-                Err(e) => {
-                    log::error!("Failed to decode task protobuf: {e}");
+    let mut conversations = Vec::with_capacity(records.len());
+    let mut backfills = Vec::new();
+    for mut record in records {
+        let has_valid_summary = record
+            .summary
+            .as_deref()
+            .is_some_and(|json| serde_json::from_str::<AgentConversationSummary>(json).is_ok());
+        if !has_valid_summary {
+            let task_records: Vec<AgentTaskRecord> = agent_tasks::table
+                .filter(schema::agent_tasks::dsl::conversation_id.eq(&record.conversation_id))
+                .select(AgentTaskRecord::as_select())
+                .load(conn)?;
 
-                    invalid_conversation_ids
-                        .insert(conversation.conversation.conversation_id.clone());
+            let mut decoded_tasks = Vec::with_capacity(task_records.len());
+            let mut decode_failed = false;
+            for task_record in task_records {
+                match api::Task::decode(&task_record.task[..]) {
+                    Ok(task) => decoded_tasks.push(task),
+                    Err(e) => {
+                        log::error!("Failed to decode task protobuf: {e}");
+                        decode_failed = true;
+                        break;
+                    }
                 }
             }
+            // Matches the historical behavior of dropping conversations with
+            // undecodable tasks.
+            if decode_failed {
+                continue;
+            }
+
+            let derived = AgentConversationSummary::from_tasks(decoded_tasks.iter());
+            let Ok(summary_json) = serde_json::to_string(&derived) else {
+                continue;
+            };
+            record.summary = Some(summary_json.clone());
+            backfills.push(ConversationSummaryBackfill {
+                conversation_id: record.conversation_id.clone(),
+                summary_json,
+                last_modified_at: record.last_modified_at,
+            });
         }
+
+        conversations.push(AgentConversation {
+            conversation: record,
+            tasks: vec![],
+        });
     }
 
-    conversations_by_id.retain(|c_id, _| !invalid_conversation_ids.contains(c_id));
+    Ok((conversations, backfills))
+}
 
-    Ok(conversations_by_id.into_values().collect())
+/// Persists read-time-derived summaries into the `summary` column so the
+/// derivation in [`read_agent_conversation_metadata`] only happens once per
+/// row.
+pub(super) fn backfill_conversation_summaries(
+    conn: &mut SqliteConnection,
+    backfills: Vec<ConversationSummaryBackfill>,
+) -> Result<(), diesel::result::Error> {
+    use schema::agent_conversations::dsl::*;
+
+    conn.transaction::<_, Error, _>(|conn| {
+        for backfill in backfills {
+            // Only fill rows that still have no summary, so a newer write
+            // that already computed one is never overwritten.
+            let updated = diesel::update(
+                agent_conversations
+                    .filter(conversation_id.eq(&backfill.conversation_id))
+                    .filter(summary.is_null()),
+            )
+            .set(summary.eq(&backfill.summary_json))
+            .execute(conn)?;
+
+            // The `update_last_modified_at_for_agent_conversations` trigger
+            // bumps `last_modified_at` on any update that leaves it
+            // unchanged; restore the original value so backfilling doesn't
+            // reorder the history list. Setting an explicit (different)
+            // value keeps the trigger from firing on this second update.
+            if updated > 0 {
+                diesel::update(
+                    agent_conversations.filter(conversation_id.eq(&backfill.conversation_id)),
+                )
+                .set(last_modified_at.eq(backfill.last_modified_at))
+                .execute(conn)?;
+            }
+        }
+        Ok(())
+    })
 }
 
 /// Read a single agent conversation by its ID, including decoded tasks.

--- a/app/src/persistence/agent.rs
+++ b/app/src/persistence/agent.rs
@@ -286,10 +286,11 @@ pub(super) fn read_agent_conversation_metadata(
             let Ok(summary_json) = serde_json::to_string(&derived) else {
                 continue;
             };
-            record.summary = Some(summary_json.clone());
+            let previous_summary = record.summary.replace(summary_json.clone());
             backfills.push(ConversationSummaryBackfill {
                 conversation_id: record.conversation_id.clone(),
                 summary_json,
+                previous_summary,
                 last_modified_at: record.last_modified_at,
             });
         }
@@ -314,15 +315,21 @@ pub(super) fn backfill_conversation_summaries(
 
     conn.transaction::<_, Error, _>(|conn| {
         for backfill in backfills {
-            // Only fill rows that still have no summary, so a newer write
-            // that already computed one is never overwritten.
-            let updated = diesel::update(
-                agent_conversations
-                    .filter(conversation_id.eq(&backfill.conversation_id))
-                    .filter(summary.is_null()),
-            )
-            .set(summary.eq(&backfill.summary_json))
-            .execute(conn)?;
+            // Compare-and-set against the value observed at read time (NULL
+            // or invalid JSON), so invalid summaries heal while a newer
+            // write's summary is never overwritten.
+            let update_target =
+                agent_conversations.filter(conversation_id.eq(&backfill.conversation_id));
+            let updated = match &backfill.previous_summary {
+                Some(previous_summary) => {
+                    diesel::update(update_target.filter(summary.eq(previous_summary)))
+                        .set(summary.eq(&backfill.summary_json))
+                        .execute(conn)?
+                }
+                None => diesel::update(update_target.filter(summary.is_null()))
+                    .set(summary.eq(&backfill.summary_json))
+                    .execute(conn)?,
+            };
 
             // The `update_last_modified_at_for_agent_conversations` trigger
             // bumps `last_modified_at` on any update that leaves it

--- a/app/src/persistence/agent_tests.rs
+++ b/app/src/persistence/agent_tests.rs
@@ -150,17 +150,72 @@ fn backfill_never_overwrites_a_newer_summary() {
     let written_summary = summary_column(&mut conn, "conv-1");
     let written_ts = last_modified_column(&mut conn, "conv-1");
 
-    // A stale backfill (e.g. computed before a newer write landed) must not
-    // clobber the row's summary or timestamp.
-    let stale = ConversationSummaryBackfill {
+    // Stale backfills (computed before a newer write landed) must not
+    // clobber the row's summary or timestamp, regardless of whether the
+    // reader observed a NULL or a since-replaced invalid value.
+    let stale_from_null = ConversationSummaryBackfill {
         conversation_id: "conv-1".to_string(),
         summary_json: "{\"stale\":true}".to_string(),
+        previous_summary: None,
         last_modified_at: ts(1),
     };
-    backfill_conversation_summaries(&mut conn, vec![stale]).expect("backfill should succeed");
+    let stale_from_invalid = ConversationSummaryBackfill {
+        conversation_id: "conv-1".to_string(),
+        summary_json: "{\"stale\":true}".to_string(),
+        previous_summary: Some("{not valid json".to_string()),
+        last_modified_at: ts(1),
+    };
+    backfill_conversation_summaries(&mut conn, vec![stale_from_null, stale_from_invalid])
+        .expect("backfill should succeed");
 
     assert_eq!(summary_column(&mut conn, "conv-1"), written_summary);
     assert_eq!(last_modified_column(&mut conn, "conv-1"), written_ts);
+}
+
+#[test]
+fn metadata_read_heals_invalid_non_null_summaries() {
+    use schema::agent_conversations::dsl::*;
+
+    let mut conn = test_connection();
+    let task = task_with_user_query("task-1", "Initial query", "Root title");
+    upsert_agent_conversation(&mut conn, "conv-1", [&task], empty_conversation_data())
+        .expect("upsert should succeed");
+
+    // Corrupt the summary with unparseable JSON.
+    let legacy_ts = ts(1_000);
+    diesel::update(agent_conversations.filter(conversation_id.eq("conv-1")))
+        .set((
+            summary.eq(Some("{not valid json")),
+            last_modified_at.eq(legacy_ts),
+        ))
+        .execute(&mut conn)
+        .expect("corrupt summary setup should succeed");
+
+    let (_, backfills) =
+        read_agent_conversation_metadata(&mut conn).expect("metadata read should succeed");
+    assert_eq!(backfills.len(), 1);
+    assert_eq!(
+        backfills[0].previous_summary.as_deref(),
+        Some("{not valid json"),
+        "the backfill must carry the observed invalid value for its compare-and-set"
+    );
+
+    backfill_conversation_summaries(&mut conn, backfills).expect("backfill should succeed");
+
+    // The invalid summary healed in place and history order is preserved.
+    let healed: AgentConversationSummary = serde_json::from_str(
+        summary_column(&mut conn, "conv-1")
+            .as_deref()
+            .expect("summary should be present after healing"),
+    )
+    .expect("healed summary should be valid JSON");
+    assert_eq!(healed.initial_query, "Initial query");
+    assert_eq!(last_modified_column(&mut conn, "conv-1"), legacy_ts);
+
+    // Subsequent startups stay metadata-only.
+    let (_, backfills) =
+        read_agent_conversation_metadata(&mut conn).expect("metadata read should succeed");
+    assert!(backfills.is_empty());
 }
 
 fn data_with_parent(parent: Option<&str>) -> String {

--- a/app/src/persistence/agent_tests.rs
+++ b/app/src/persistence/agent_tests.rs
@@ -1,6 +1,167 @@
 use chrono::NaiveDate;
+use diesel_migrations::MigrationHarness;
 
 use super::*;
+
+/// Builds an in-memory SQLite database with all migrations applied.
+fn test_connection() -> SqliteConnection {
+    let mut conn =
+        SqliteConnection::establish(":memory:").expect("in-memory sqlite connection should open");
+    conn.run_pending_migrations(::persistence::MIGRATIONS)
+        .expect("migrations should run");
+    conn
+}
+
+fn task_with_user_query(task_id: &str, query: &str, description: &str) -> api::Task {
+    api::Task {
+        id: task_id.to_string(),
+        description: description.to_string(),
+        dependencies: None,
+        messages: vec![api::Message {
+            id: format!("{task_id}-user-query"),
+            task_id: task_id.to_string(),
+            message: Some(api::message::Message::UserQuery(api::message::UserQuery {
+                query: query.to_string(),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }],
+        summary: String::new(),
+        server_data: String::new(),
+    }
+}
+
+fn empty_conversation_data() -> AgentConversationData {
+    serde_json::from_str(r#"{"server_conversation_token":null}"#)
+        .expect("minimal conversation data should deserialize")
+}
+
+fn summary_column(conn: &mut SqliteConnection, conversation: &str) -> Option<String> {
+    use schema::agent_conversations::dsl::*;
+    agent_conversations
+        .filter(conversation_id.eq(conversation))
+        .select(summary)
+        .first::<Option<String>>(conn)
+        .expect("conversation row should exist")
+}
+
+fn last_modified_column(conn: &mut SqliteConnection, conversation: &str) -> NaiveDateTime {
+    use schema::agent_conversations::dsl::*;
+    agent_conversations
+        .filter(conversation_id.eq(conversation))
+        .select(last_modified_at)
+        .first::<NaiveDateTime>(conn)
+        .expect("conversation row should exist")
+}
+
+#[test]
+fn upsert_writes_summary_and_metadata_read_skips_tasks() {
+    let mut conn = test_connection();
+    let task = task_with_user_query("task-1", "Initial query", "Root title");
+    upsert_agent_conversation(&mut conn, "conv-1", [&task], empty_conversation_data())
+        .expect("upsert should succeed");
+
+    let (conversations, backfills) =
+        read_agent_conversation_metadata(&mut conn).expect("metadata read should succeed");
+
+    assert!(
+        backfills.is_empty(),
+        "rows written with a summary must not be backfilled"
+    );
+    assert_eq!(conversations.len(), 1);
+    assert!(
+        conversations[0].tasks.is_empty(),
+        "metadata read must not hydrate task payloads"
+    );
+    let summary: AgentConversationSummary = serde_json::from_str(
+        conversations[0]
+            .conversation
+            .summary
+            .as_deref()
+            .expect("summary column should be written at upsert time"),
+    )
+    .expect("summary column should hold valid summary JSON");
+    assert_eq!(summary.initial_query, "Initial query");
+    assert_eq!(summary.title, "Root title");
+    assert!(summary.is_restorable);
+}
+
+#[test]
+fn metadata_read_derives_and_backfill_persists_summary_for_legacy_rows() {
+    use schema::agent_conversations::dsl::*;
+
+    let mut conn = test_connection();
+    let task = task_with_user_query("task-1", "Initial query", "Root title");
+    upsert_agent_conversation(&mut conn, "conv-1", [&task], empty_conversation_data())
+        .expect("upsert should succeed");
+
+    // Simulate a row written before the summary column existed. Setting
+    // `last_modified_at` explicitly keeps the update trigger from bumping it.
+    let legacy_ts = ts(1_000);
+    diesel::update(agent_conversations.filter(conversation_id.eq("conv-1")))
+        .set((summary.eq(None::<String>), last_modified_at.eq(legacy_ts)))
+        .execute(&mut conn)
+        .expect("legacy row setup should succeed");
+
+    let (conversations, backfills) =
+        read_agent_conversation_metadata(&mut conn).expect("metadata read should succeed");
+
+    // The read derives the summary from the row's own task snapshot.
+    assert_eq!(conversations.len(), 1);
+    let derived: AgentConversationSummary = serde_json::from_str(
+        conversations[0]
+            .conversation
+            .summary
+            .as_deref()
+            .expect("legacy rows should get a read-time-derived summary"),
+    )
+    .expect("derived summary should be valid JSON");
+    assert_eq!(derived.initial_query, "Initial query");
+
+    // ... and queues a backfill preserving the original timestamp.
+    assert_eq!(backfills.len(), 1);
+    assert_eq!(backfills[0].conversation_id, "conv-1");
+    assert_eq!(backfills[0].last_modified_at, legacy_ts);
+
+    backfill_conversation_summaries(&mut conn, backfills).expect("backfill should succeed");
+
+    assert!(
+        summary_column(&mut conn, "conv-1").is_some(),
+        "backfill must persist the derived summary"
+    );
+    assert_eq!(
+        last_modified_column(&mut conn, "conv-1"),
+        legacy_ts,
+        "backfill must not reorder history by bumping last_modified_at"
+    );
+
+    // Subsequent startups stay metadata-only.
+    let (_, backfills) =
+        read_agent_conversation_metadata(&mut conn).expect("metadata read should succeed");
+    assert!(backfills.is_empty());
+}
+
+#[test]
+fn backfill_never_overwrites_a_newer_summary() {
+    let mut conn = test_connection();
+    let task = task_with_user_query("task-1", "Initial query", "Root title");
+    upsert_agent_conversation(&mut conn, "conv-1", [&task], empty_conversation_data())
+        .expect("upsert should succeed");
+    let written_summary = summary_column(&mut conn, "conv-1");
+    let written_ts = last_modified_column(&mut conn, "conv-1");
+
+    // A stale backfill (e.g. computed before a newer write landed) must not
+    // clobber the row's summary or timestamp.
+    let stale = ConversationSummaryBackfill {
+        conversation_id: "conv-1".to_string(),
+        summary_json: "{\"stale\":true}".to_string(),
+        last_modified_at: ts(1),
+    };
+    backfill_conversation_summaries(&mut conn, vec![stale]).expect("backfill should succeed");
+
+    assert_eq!(summary_column(&mut conn, "conv-1"), written_summary);
+    assert_eq!(last_modified_column(&mut conn, "conv-1"), written_ts);
+}
 
 fn data_with_parent(parent: Option<&str>) -> String {
     match parent {
@@ -31,6 +192,7 @@ fn make_row(
         conversation_id: conversation_id.to_string(),
         conversation_data: data_with_parent(parent),
         last_modified_at: ts(secs),
+        summary: None,
     }
 }
 
@@ -151,6 +313,7 @@ fn parse_failure_row_is_treated_as_root_and_can_be_referenced_by_others() {
             conversation_id: "garbage".to_string(),
             conversation_data: "{not valid json".to_string(),
             last_modified_at: ts(50),
+            summary: None,
         },
         make_row(2, "a", None, 100),
         make_row(3, "b", None, 200),

--- a/app/src/persistence/mod.rs
+++ b/app/src/persistence/mod.rs
@@ -97,13 +97,18 @@ impl PersistedDataScope {
 }
 
 /// A conversation whose `summary` column had to be derived from its task
-/// snapshot at read time (rows written before the column existed). Sent to
-/// the SQLite writer thread so the derivation happens only once per row.
+/// snapshot at read time (rows written before the column existed, or rows
+/// whose stored summary failed to parse). Sent to the SQLite writer thread
+/// so the derivation happens only once per row.
 #[derive(Debug)]
 pub struct ConversationSummaryBackfill {
     pub conversation_id: String,
     /// Serialized [`model::AgentConversationSummary`].
     pub summary_json: String,
+    /// The `summary` column value observed at read time (`None` or invalid
+    /// JSON). The backfill only applies while the column still holds this
+    /// value, so it never overwrites a newer write.
+    pub previous_summary: Option<String>,
     /// The row's pre-backfill `last_modified_at`, restored after the
     /// update trigger bumps it.
     pub last_modified_at: chrono::NaiveDateTime,

--- a/app/src/persistence/mod.rs
+++ b/app/src/persistence/mod.rs
@@ -65,6 +65,50 @@ pub enum PersistenceScope {
     RemoteServerDaemon { identity_key: String },
 }
 
+/// Which subsets of [`PersistedData`] a launch mode actually consumes.
+///
+/// Loading everything unconditionally is expensive (GUI session-restore
+/// payloads dominate startup on large databases), so headless launch modes
+/// opt out of the data they never read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PersistedDataScope {
+    /// The GUI app: everything, including window/tab/block session
+    /// restoration and command history.
+    Full,
+    /// The `warp-tui` front-end: cloud objects and agent/conversation state,
+    /// but no GUI session restoration, command history, user profiles, or
+    /// pending object actions.
+    TuiFrontend,
+    /// The remote server daemon: only codebase index metadata.
+    CodebaseIndicesOnly,
+}
+
+impl PersistedDataScope {
+    /// Window/tab/pane snapshots and restored blocks.
+    fn session_restoration(self) -> bool {
+        matches!(self, PersistedDataScope::Full)
+    }
+
+    /// Command history, user profiles, and pending object actions, which
+    /// only the GUI consumes.
+    fn gui_history(self) -> bool {
+        matches!(self, PersistedDataScope::Full)
+    }
+}
+
+/// A conversation whose `summary` column had to be derived from its task
+/// snapshot at read time (rows written before the column existed). Sent to
+/// the SQLite writer thread so the derivation happens only once per row.
+#[derive(Debug)]
+pub struct ConversationSummaryBackfill {
+    pub conversation_id: String,
+    /// Serialized [`model::AgentConversationSummary`].
+    pub summary_json: String,
+    /// The row's pre-backfill `last_modified_at`, restored after the
+    /// update trigger bumps it.
+    pub last_modified_at: chrono::NaiveDateTime,
+}
+
 /// Initializes the persistence "subsystem".
 ///
 /// Returns the previously-persisted data, if any, and handles for
@@ -75,10 +119,11 @@ pub enum PersistenceScope {
 pub fn initialize(
     ctx: &mut AppContext,
     scope: PersistenceScope,
+    data_scope: PersistedDataScope,
 ) -> (Option<Box<PersistedData>>, Option<WriterHandles>) {
     cfg_if::cfg_if! {
         if #[cfg(feature = "local_fs")] {
-            sqlite::initialize(ctx, scope)
+            sqlite::initialize(ctx, scope, data_scope)
         } else {
             (None, None)
         }
@@ -182,8 +227,9 @@ impl SingletonEntity for PersistenceWriter {}
 ///
 /// For now, to address the global scoping here, we clear all persisted data on logout.
 pub struct PersistedData {
-    /// Session restoration data
-    pub app_state: AppState,
+    /// Session restoration data. `None` when the launch mode's
+    /// [`PersistedDataScope`] excludes it entirely (the daemon).
+    pub app_state: Option<AppState>,
 
     /// Shareable objects.
     pub cloud_objects: Vec<Box<dyn CloudObject>>,
@@ -204,6 +250,10 @@ pub struct PersistedData {
     pub ignored_suggestions: Vec<(String, SuggestionType)>,
     pub mcp_server_installations: HashMap<Uuid, TemplatableMCPServerInstallation>,
     pub mcp_servers_to_restore: Vec<Uuid>,
+    /// Conversation summaries derived at read time for pre-`summary`-column
+    /// rows. Drained by `sqlite::initialize`, which hands them to the writer
+    /// thread for persistence; not intended for other consumers.
+    pub conversation_summary_backfills: Vec<ConversationSummaryBackfill>,
 }
 
 #[derive(Clone, Debug)]
@@ -325,6 +375,11 @@ pub enum ModelEvent {
         conversation_id: String,
         updated_tasks: Vec<api::Task>,
         conversation_data: AgentConversationData,
+    },
+    /// Persists read-time-derived conversation summaries for rows written
+    /// before the `summary` column existed.
+    BackfillConversationSummaries {
+        backfills: Vec<ConversationSummaryBackfill>,
     },
     DeleteMultiAgentConversations {
         conversation_ids: Vec<String>,

--- a/app/src/persistence/sqlite.rs
+++ b/app/src/persistence/sqlite.rs
@@ -47,7 +47,10 @@ use warpui::platform::FullscreenState;
 use warpui::windowing::{MIN_WINDOW_HEIGHT, MIN_WINDOW_WIDTH};
 use warpui::{AppContext, SingletonEntity};
 
-use super::agent::{delete_agent_conversations, upsert_agent_conversation};
+use super::agent::{
+    backfill_conversation_summaries, delete_agent_conversations, read_agent_conversation_metadata,
+    upsert_agent_conversation,
+};
 use super::block_list::{
     delete_ai_conversation, delete_blocks, save_block, update_block_agent_view_visibility,
     upsert_ai_query,
@@ -62,8 +65,8 @@ use super::model::{
     WORKFLOW_PANE_KIND,
 };
 use super::{
-    schema, BlockCompleted, FinishedCommandMetadata, ModelEvent, PersistedData, PersistenceScope,
-    StartedCommandMetadata, WriterHandles,
+    schema, BlockCompleted, FinishedCommandMetadata, ModelEvent, PersistedData, PersistedDataScope,
+    PersistenceScope, StartedCommandMetadata, WriterHandles,
 };
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
@@ -88,7 +91,6 @@ use crate::cloud_object::{CloudObject, ObjectIdType};
 use crate::code::editor_management::CodeSource;
 use crate::drive::OpenWarpDriveObjectSettings;
 use crate::notebooks::NotebookId;
-use crate::persistence::agent::read_agent_conversations;
 use crate::persistence::block_list::{
     get_all_restored_blocks, process_ai_queries_for_nld_history_match,
     process_ai_queries_for_uparrow_prompt, read_recent_ai_queries,
@@ -130,6 +132,7 @@ const WARP_SQLITE_FILE_NAME: &str = "warp.sqlite";
 pub fn initialize(
     ctx: &mut AppContext,
     scope: PersistenceScope,
+    data_scope: PersistedDataScope,
 ) -> (Option<Box<PersistedData>>, Option<WriterHandles>) {
     unsafe {
         // Set up logging before any SQLite calls.
@@ -138,7 +141,7 @@ pub fn initialize(
     let database_path = database_file_path_for_scope(&scope);
     match init_db(&scope) {
         Ok(mut conn) => {
-            let persisted_data = read_persisted_data(&mut conn, ctx);
+            let mut persisted_data = read_persisted_data(&mut conn, ctx, data_scope);
 
             let writer_handles = match start_writer(conn, database_path.clone()) {
                 Ok(writer_handles) => Some(writer_handles),
@@ -151,6 +154,22 @@ pub fn initialize(
                     None
                 }
             };
+
+            // Persist any read-time-derived conversation summaries so the
+            // derivation only happens once per pre-`summary`-column row.
+            if let (Some(persisted_data), Some(writer_handles)) =
+                (persisted_data.as_mut(), writer_handles.as_ref())
+            {
+                let backfills = std::mem::take(&mut persisted_data.conversation_summary_backfills);
+                if !backfills.is_empty() {
+                    log::info!("Backfilling {} conversation summaries", backfills.len());
+                    report_if_error!(writer_handles
+                        .sender
+                        .send(ModelEvent::BackfillConversationSummaries { backfills })
+                        .context("Error requesting conversation summary backfill"));
+                }
+            }
+
             (persisted_data, writer_handles)
         }
         Err(err) => {
@@ -167,9 +186,10 @@ pub fn initialize(
 fn read_persisted_data(
     conn: &mut SqliteConnection,
     ctx: &mut AppContext,
+    data_scope: PersistedDataScope,
 ) -> Option<Box<PersistedData>> {
     let user_uid = AuthStateProvider::as_ref(ctx).get().user_id();
-    match read_sqlite_data(conn, user_uid) {
+    match read_sqlite_data(conn, user_uid, data_scope) {
         Ok(app_state) => Some(Box::new(app_state)),
         Err(err) => {
             send_telemetry_from_app_ctx!(TelemetryEvent::DatabaseReadError(err.to_string()), ctx);
@@ -702,6 +722,11 @@ fn handle_model_event(event: ModelEvent, connection: &mut SqliteConnection) -> a
             conversation_data,
         )
         .map_err(anyhow::Error::from),
+        ModelEvent::BackfillConversationSummaries { backfills } => {
+            backfill_conversation_summaries(connection, backfills)
+                .map_err(anyhow::Error::from)
+                .context("error backfilling conversation summaries")
+        }
         ModelEvent::DeleteMultiAgentConversations { conversation_ids } => {
             delete_agent_conversations(connection, conversation_ids)
                 .map_err(anyhow::Error::from)
@@ -2413,198 +2438,240 @@ fn box_persisted_generic_string_object(
 fn read_sqlite_data(
     conn: &mut SqliteConnection,
     current_user_id: Option<UserUid>,
+    data_scope: PersistedDataScope,
 ) -> Result<PersistedData, Error> {
-    use schema::windows::dsl::*;
+    if matches!(data_scope, PersistedDataScope::CodebaseIndicesOnly) {
+        return Ok(PersistedData {
+            app_state: None,
+            cloud_objects: Default::default(),
+            workspaces: Default::default(),
+            current_workspace_uid: None,
+            command_history: Default::default(),
+            user_profiles: Default::default(),
+            time_of_next_force_object_refresh: None,
+            object_actions: Default::default(),
+            experiments: Default::default(),
+            ai_queries: Default::default(),
+            nld_prompts: Default::default(),
+            codebase_indices: get_all_codebase_index_metadata(conn)?,
+            workspace_language_servers: Default::default(),
+            multi_agent_conversations: Default::default(),
+            projects: Default::default(),
+            project_rules: Default::default(),
+            ignored_suggestions: Default::default(),
+            mcp_server_installations: Default::default(),
+            mcp_servers_to_restore: Default::default(),
+            conversation_summary_backfills: Default::default(),
+        });
+    }
 
-    let active_window_id = schema::app::dsl::app
-        .select(schema::app::dsl::active_window_id)
-        .first::<Option<i32>>(conn)
-        .optional()?
-        .flatten();
-    let db_windows = windows.load::<Window>(conn)?;
+    let app_state = if data_scope.session_restoration() {
+        use schema::windows::dsl::*;
 
-    let mut active_window_index: Option<usize> = None;
+        let active_window_id = schema::app::dsl::app
+            .select(schema::app::dsl::active_window_id)
+            .first::<Option<i32>>(conn)
+            .optional()?
+            .flatten();
+        let db_windows = windows.load::<Window>(conn)?;
 
-    let db_tabs = Tab::belonging_to(&db_windows)
-        .order_by(schema::tabs::columns::id.asc())
-        .load::<Tab>(conn)?
-        .grouped_by(&db_windows);
+        let mut active_window_index: Option<usize> = None;
 
-    let db_panels = schema::panels::dsl::panels
-        .load::<model::Panel>(conn)?
-        .into_iter()
-        .map(|p| (p.tab_id, p))
-        .collect::<HashMap<_, _>>();
+        let db_tabs = Tab::belonging_to(&db_windows)
+            .order_by(schema::tabs::columns::id.asc())
+            .load::<Tab>(conn)?
+            .grouped_by(&db_windows);
 
-    // Load tab groups grouped per window so we can resolve `tabs.tab_group_id`
-    // through a per-window row-id lookup.
-    let db_tab_groups = TabGroup::belonging_to(&db_windows)
-        .order_by(schema::tab_groups::columns::id.asc())
-        .load::<TabGroup>(conn)?
-        .grouped_by(&db_windows);
+        let db_panels = schema::panels::dsl::panels
+            .load::<model::Panel>(conn)?
+            .into_iter()
+            .map(|p| (p.tab_id, p))
+            .collect::<HashMap<_, _>>();
 
-    let saved_windows: Vec<_> = db_windows
-        .into_iter()
-        .enumerate()
-        .zip(db_tabs)
-        .zip(db_tab_groups)
-        .map(
-            |(((idx, window), tabs_for_window), tab_groups_for_window)| {
-                // Mint a fresh `TabGroupId` per row and build a `row id -> TabGroupId`
-                // map so tabs can be reattached to their group below.
-                let mut tab_group_id_by_row_id: HashMap<i32, TabGroupId> = HashMap::new();
-                let mut tab_groups_snapshots: Vec<TabGroupSnapshot> = Vec::new();
-                for group in tab_groups_for_window {
-                    let tab_group_id = TabGroupId::new();
-                    tab_group_id_by_row_id.insert(group.id, tab_group_id);
-                    let color = group
-                        .color
-                        .as_deref()
-                        .and_then(|s| serde_yaml::from_str::<SelectedTabColor>(s).ok())
-                        .unwrap_or_default();
-                    tab_groups_snapshots.push(TabGroupSnapshot {
-                        id: tab_group_id,
-                        name: group.name,
-                        color,
-                        collapsed: group.collapsed,
-                        pinned: group.pinned,
-                    });
-                }
-                let saved_tabs: Vec<_> = tabs_for_window
-                    .into_iter()
-                    .filter_map(|tab| {
-                        let root = read_root_node(conn, tab.id).ok()?;
-                        let panel = db_panels.get(&tab.id);
+        // Load tab groups grouped per window so we can resolve `tabs.tab_group_id`
+        // through a per-window row-id lookup.
+        let db_tab_groups = TabGroup::belonging_to(&db_windows)
+            .order_by(schema::tab_groups::columns::id.asc())
+            .load::<TabGroup>(conn)?
+            .grouped_by(&db_windows);
 
-                        let left_panel = panel
-                            .and_then(|p| p.left_panel.as_ref())
-                            .and_then(|s| serde_json::from_str::<LeftPanelSnapshot>(s).ok());
-
-                        let right_panel = panel
-                            .and_then(|p| p.right_panel.as_ref())
-                            .and_then(|s| serde_json::from_str::<RightPanelSnapshot>(s).ok());
-
-                        let group_id = tab
-                            .tab_group_id
-                            .and_then(|row_id| tab_group_id_by_row_id.get(&row_id).copied());
-                        Some(TabSnapshot {
-                            root,
-                            custom_title: tab.custom_title,
-                            default_directory_color: None,
-                            selected_color: tab
-                                .color
-                                .as_deref()
-                                .and_then(|s| {
-                                    serde_yaml::from_str::<SelectedTabColor>(s)
-                                        .ok()
-                                        .or_else(|| {
-                                            // Fall back to the old format which stored a bare AnsiColorIdentifier
-                                            serde_yaml::from_str::<AnsiColorIdentifier>(s)
-                                                .ok()
-                                                .map(SelectedTabColor::Color)
-                                        })
-                                })
-                                .unwrap_or_default(),
-                            left_panel,
-                            right_panel,
-                            group_id,
-                            pinned: tab.pinned,
-                        })
-                    })
-                    .collect();
-
-                if active_window_id
-                    .map(|window_id| window.id == window_id)
-                    .unwrap_or(false)
-                {
-                    active_window_index = Some(idx);
-                }
-
-                // Default active tab index to 0 if we overflow when converting.
-                let tab_index: usize = window.active_tab_index.try_into().unwrap_or(0);
-
-                let fullscreen_state_val =
-                    FullscreenState::from_i32(window.fullscreen_state).unwrap_or_default();
-
-                // The origin and size of the bound should be all null or all non-null.
-                // Reject bounds smaller than the platform minimum window size so users
-                // with an already-corrupted warp.sqlite (see GH#10083) restore to
-                // default geometry instead of a sliver.
-                let bounds = match (
-                    window.window_width,
-                    window.window_height,
-                    window.origin_x,
-                    window.origin_y,
-                ) {
-                    (Some(mut width), Some(mut height), Some(x), Some(y))
-                        if width >= MIN_WINDOW_WIDTH && height >= MIN_WINDOW_HEIGHT =>
-                    {
-                        // When fullscreen or maximized, the `inner_size` we snapshotted will be the
-                        // size of the full screen. This will cause problems with winit. When you set
-                        // maximized/fullscreen, setting the inner_size will by the size the window
-                        // takes _after_ the user toggles _out_ of fullscreen/maximized. Therefore, we
-                        // don't want to set the size to take the full screen because the window will
-                        // appear to remain in maximized/fullscreen. We multiply each dimension by 0.8
-                        // to prevent taking the full screen while choosing a reasonable size.
-                        if !cfg!(target_os = "macos")
-                            && fullscreen_state_val != FullscreenState::Normal
-                        {
-                            width *= 0.8;
-                            height *= 0.8;
-                        }
-                        Some(RectF::new(
-                            Vector2F::new(x, y),
-                            Vector2F::new(width, height),
-                        ))
+        let saved_windows: Vec<_> = db_windows
+            .into_iter()
+            .enumerate()
+            .zip(db_tabs)
+            .zip(db_tab_groups)
+            .map(
+                |(((idx, window), tabs_for_window), tab_groups_for_window)| {
+                    // Mint a fresh `TabGroupId` per row and build a `row id -> TabGroupId`
+                    // map so tabs can be reattached to their group below.
+                    let mut tab_group_id_by_row_id: HashMap<i32, TabGroupId> = HashMap::new();
+                    let mut tab_groups_snapshots: Vec<TabGroupSnapshot> = Vec::new();
+                    for group in tab_groups_for_window {
+                        let tab_group_id = TabGroupId::new();
+                        tab_group_id_by_row_id.insert(group.id, tab_group_id);
+                        let color = group
+                            .color
+                            .as_deref()
+                            .and_then(|s| serde_yaml::from_str::<SelectedTabColor>(s).ok())
+                            .unwrap_or_default();
+                        tab_groups_snapshots.push(TabGroupSnapshot {
+                            id: tab_group_id,
+                            name: group.name,
+                            color,
+                            collapsed: group.collapsed,
+                            pinned: group.pinned,
+                        });
                     }
-                    _ => None,
-                };
+                    let saved_tabs: Vec<_> = tabs_for_window
+                        .into_iter()
+                        .filter_map(|tab| {
+                            let root = read_root_node(conn, tab.id).ok()?;
+                            let panel = db_panels.get(&tab.id);
 
-                let left_panel_width: Option<f32> =
-                    saved_tabs
-                        .get(tab_index)
-                        .and_then(|tab| match tab.left_panel.as_ref() {
-                            Some(LeftPanelSnapshot { width, .. }) => Some(*width as f32),
-                            _ => None,
-                        });
+                            let left_panel = panel
+                                .and_then(|p| p.left_panel.as_ref())
+                                .and_then(|s| serde_json::from_str::<LeftPanelSnapshot>(s).ok());
 
-                let right_panel_width: Option<f32> =
-                    saved_tabs
-                        .get(tab_index)
-                        .and_then(|tab| match tab.right_panel.as_ref() {
-                            Some(RightPanelSnapshot { width, .. }) => Some(*width as f32),
-                            _ => None,
-                        });
+                            let right_panel = panel
+                                .and_then(|p| p.right_panel.as_ref())
+                                .and_then(|s| serde_json::from_str::<RightPanelSnapshot>(s).ok());
 
-                let window_left_panel_open = window.left_panel_open.unwrap_or_else(|| {
-                    saved_tabs
-                        .get(tab_index)
-                        .and_then(|tab| tab.left_panel.as_ref())
-                        .is_some()
-                });
+                            let group_id = tab
+                                .tab_group_id
+                                .and_then(|row_id| tab_group_id_by_row_id.get(&row_id).copied());
+                            Some(TabSnapshot {
+                                root,
+                                custom_title: tab.custom_title,
+                                default_directory_color: None,
+                                selected_color: tab
+                                    .color
+                                    .as_deref()
+                                    .and_then(|s| {
+                                        serde_yaml::from_str::<SelectedTabColor>(s).ok().or_else(
+                                            || {
+                                                // Fall back to the old format which stored a bare AnsiColorIdentifier
+                                                serde_yaml::from_str::<AnsiColorIdentifier>(s)
+                                                    .ok()
+                                                    .map(SelectedTabColor::Color)
+                                            },
+                                        )
+                                    })
+                                    .unwrap_or_default(),
+                                left_panel,
+                                right_panel,
+                                group_id,
+                                pinned: tab.pinned,
+                            })
+                        })
+                        .collect();
 
-                WindowSnapshot {
-                    tabs: saved_tabs,
-                    active_tab_index: tab_index,
-                    quake_mode: window.quake_mode,
-                    bounds,
-                    universal_search_width: window.universal_search_width,
-                    warp_ai_width: window.warp_ai_width,
-                    voltron_width: window.voltron_width,
-                    warp_drive_index_width: window.warp_drive_index_width,
-                    left_panel_open: window_left_panel_open,
-                    vertical_tabs_panel_open: window.vertical_tabs_panel_open.unwrap_or(false),
-                    fullscreen_state: fullscreen_state_val,
-                    left_panel_width,
-                    right_panel_width,
-                    agent_management_filters: window
-                        .agent_management_filters
-                        .and_then(|s| serde_json::from_str(&s).ok()),
-                    tab_groups: tab_groups_snapshots,
-                }
-            },
-        )
-        .collect();
+                    if active_window_id
+                        .map(|window_id| window.id == window_id)
+                        .unwrap_or(false)
+                    {
+                        active_window_index = Some(idx);
+                    }
+
+                    // Default active tab index to 0 if we overflow when converting.
+                    let tab_index: usize = window.active_tab_index.try_into().unwrap_or(0);
+
+                    let fullscreen_state_val =
+                        FullscreenState::from_i32(window.fullscreen_state).unwrap_or_default();
+
+                    // The origin and size of the bound should be all null or all non-null.
+                    // Reject bounds smaller than the platform minimum window size so users
+                    // with an already-corrupted warp.sqlite (see GH#10083) restore to
+                    // default geometry instead of a sliver.
+                    let bounds = match (
+                        window.window_width,
+                        window.window_height,
+                        window.origin_x,
+                        window.origin_y,
+                    ) {
+                        (Some(mut width), Some(mut height), Some(x), Some(y))
+                            if width >= MIN_WINDOW_WIDTH && height >= MIN_WINDOW_HEIGHT =>
+                        {
+                            // When fullscreen or maximized, the `inner_size` we snapshotted will be the
+                            // size of the full screen. This will cause problems with winit. When you set
+                            // maximized/fullscreen, setting the inner_size will by the size the window
+                            // takes _after_ the user toggles _out_ of fullscreen/maximized. Therefore, we
+                            // don't want to set the size to take the full screen because the window will
+                            // appear to remain in maximized/fullscreen. We multiply each dimension by 0.8
+                            // to prevent taking the full screen while choosing a reasonable size.
+                            if !cfg!(target_os = "macos")
+                                && fullscreen_state_val != FullscreenState::Normal
+                            {
+                                width *= 0.8;
+                                height *= 0.8;
+                            }
+                            Some(RectF::new(
+                                Vector2F::new(x, y),
+                                Vector2F::new(width, height),
+                            ))
+                        }
+                        _ => None,
+                    };
+
+                    let left_panel_width: Option<f32> =
+                        saved_tabs
+                            .get(tab_index)
+                            .and_then(|tab| match tab.left_panel.as_ref() {
+                                Some(LeftPanelSnapshot { width, .. }) => Some(*width as f32),
+                                _ => None,
+                            });
+
+                    let right_panel_width: Option<f32> =
+                        saved_tabs
+                            .get(tab_index)
+                            .and_then(|tab| match tab.right_panel.as_ref() {
+                                Some(RightPanelSnapshot { width, .. }) => Some(*width as f32),
+                                _ => None,
+                            });
+
+                    let window_left_panel_open = window.left_panel_open.unwrap_or_else(|| {
+                        saved_tabs
+                            .get(tab_index)
+                            .and_then(|tab| tab.left_panel.as_ref())
+                            .is_some()
+                    });
+
+                    WindowSnapshot {
+                        tabs: saved_tabs,
+                        active_tab_index: tab_index,
+                        quake_mode: window.quake_mode,
+                        bounds,
+                        universal_search_width: window.universal_search_width,
+                        warp_ai_width: window.warp_ai_width,
+                        voltron_width: window.voltron_width,
+                        warp_drive_index_width: window.warp_drive_index_width,
+                        left_panel_open: window_left_panel_open,
+                        vertical_tabs_panel_open: window.vertical_tabs_panel_open.unwrap_or(false),
+                        fullscreen_state: fullscreen_state_val,
+                        left_panel_width,
+                        right_panel_width,
+                        agent_management_filters: window
+                            .agent_management_filters
+                            .and_then(|s| serde_json::from_str(&s).ok()),
+                        tab_groups: tab_groups_snapshots,
+                    }
+                },
+            )
+            .collect();
+
+        let restored_blocks = get_all_restored_blocks(conn)?;
+
+        // Load active MCP servers from database
+        let running_mcp_servers = load_active_mcp_servers(conn)?;
+
+        Some(AppState {
+            windows: saved_windows,
+            active_window_index,
+            block_lists: Arc::new(restored_blocks),
+            running_mcp_servers,
+        })
+    } else {
+        None
+    };
 
     let read_context = load_cloud_object_read_context(conn, current_user_id)?;
     let mut cloud_objects: Vec<Box<dyn CloudObject>> = Vec::new();
@@ -2717,25 +2784,39 @@ fn read_sqlite_data(
         .optional()?
         .map(|uid| uid.into());
 
-    let commands = schema::commands::dsl::commands
-        // Ensure the commands come into memory sorted chronologically.
-        .order(schema::commands::columns::id.desc())
-        .load_iter::<model::Command, DefaultLoadingMode>(conn)?
-        .filter_map(|command| command.ok())
-        .map(PersistedCommand::from)
-        .collect();
+    // Command history, user profiles, and pending object actions are only
+    // consumed by the GUI; headless launch modes skip loading them.
+    let commands = if data_scope.gui_history() {
+        schema::commands::dsl::commands
+            // Ensure the commands come into memory sorted chronologically.
+            .order(schema::commands::columns::id.desc())
+            .load_iter::<model::Command, DefaultLoadingMode>(conn)?
+            .filter_map(|command| command.ok())
+            .map(PersistedCommand::from)
+            .collect()
+    } else {
+        Vec::new()
+    };
 
-    let user_profiles = schema::user_profiles::dsl::user_profiles
-        .load_iter::<model::UserProfile, DefaultLoadingMode>(conn)?
-        .filter_map(|user_profile| user_profile.ok())
-        .map(user_profile_from_persistence)
-        .collect();
+    let user_profiles = if data_scope.gui_history() {
+        schema::user_profiles::dsl::user_profiles
+            .load_iter::<model::UserProfile, DefaultLoadingMode>(conn)?
+            .filter_map(|user_profile| user_profile.ok())
+            .map(user_profile_from_persistence)
+            .collect()
+    } else {
+        Vec::new()
+    };
 
-    let object_actions: Vec<ObjectAction> = schema::object_actions::dsl::object_actions
-        .load_iter::<model::PersistedObjectAction, DefaultLoadingMode>(conn)?
-        .filter_map(|object_action| object_action.ok()) // parse into PersistedObjectAction
-        .filter_map(|action| object_action_from_persisted(action).ok())
-        .collect();
+    let object_actions: Vec<ObjectAction> = if data_scope.gui_history() {
+        schema::object_actions::dsl::object_actions
+            .load_iter::<model::PersistedObjectAction, DefaultLoadingMode>(conn)?
+            .filter_map(|object_action| object_action.ok()) // parse into PersistedObjectAction
+            .filter_map(|action| object_action_from_persisted(action).ok())
+            .collect()
+    } else {
+        Vec::new()
+    };
 
     let server_experiments = schema::server_experiments::dsl::server_experiments
         .load_iter::<model::ServerExperiment, DefaultLoadingMode>(conn)?
@@ -2744,18 +2825,6 @@ fn read_sqlite_data(
             ServerExperiment::from_string(server_experiment.experiment).ok()
         })
         .collect();
-
-    let restored_blocks = get_all_restored_blocks(conn)?;
-
-    // Load active MCP servers from database
-    let running_mcp_servers = load_active_mcp_servers(conn)?;
-
-    let app_state = AppState {
-        windows: saved_windows,
-        active_window_index,
-        block_lists: Arc::new(restored_blocks),
-        running_mcp_servers,
-    };
 
     let time_of_next_force_object_refresh = read_time_of_next_force_object_refresh(conn)?;
 
@@ -2773,7 +2842,10 @@ fn read_sqlite_data(
 
     let codebase_indices = get_all_codebase_index_metadata(conn)?;
     let workspace_language_servers = get_all_workspace_language_servers_by_workspace(conn)?;
-    let multi_agent_conversations = read_agent_conversations(conn)?;
+    // Load conversation metadata only; task payloads are hydrated lazily
+    // per-conversation via `read_agent_conversation_by_id`.
+    let (multi_agent_conversations, conversation_summary_backfills) =
+        read_agent_conversation_metadata(conn)?;
     let projects = get_all_projects(conn)?;
     let project_rules = get_all_project_rules(conn)?;
     let ignored_suggestions = get_all_ignored_suggestions(conn)?;
@@ -2800,6 +2872,7 @@ fn read_sqlite_data(
         ignored_suggestions,
         mcp_server_installations,
         mcp_servers_to_restore,
+        conversation_summary_backfills,
     })
 }
 

--- a/app/src/persistence/sqlite_tests.rs
+++ b/app/src/persistence/sqlite_tests.rs
@@ -23,7 +23,7 @@ use crate::cloud_object::{CloudObjectPermissions, Owner};
 use crate::code::editor_management::CodeSource;
 use crate::notebooks::{CloudNotebook, CloudNotebookModel};
 use crate::persistence::model::ObjectPermissions;
-use crate::persistence::{BlockCompleted, ModelEvent, PersistenceScope};
+use crate::persistence::{BlockCompleted, ModelEvent, PersistedDataScope, PersistenceScope};
 use crate::server::ids::ClientId;
 use crate::tab::SelectedTabColor;
 use crate::terminal::model::block::SerializedBlock;
@@ -117,8 +117,12 @@ fn sqlite_read_restores_app_state_and_codebase_metadata() {
     let metadata = test_codebase_metadata("/tmp/remote-repo");
     save_codebase_index_metadata(&mut conn, metadata.clone())
         .expect("codebase index metadata should save");
-    let restored = read_sqlite_data(&mut conn, None).expect("persisted data should load");
-    assert_eq!(restored.app_state.windows.len(), 1);
+    let restored = read_sqlite_data(&mut conn, None, PersistedDataScope::Full)
+        .expect("persisted data should load");
+    let restored_app_state = restored
+        .app_state
+        .expect("app state should be present for the full scope");
+    assert_eq!(restored_app_state.windows.len(), 1);
     assert_eq!(restored.codebase_indices.len(), 1);
     assert_eq!(restored.codebase_indices[0].path, metadata.path);
 }
@@ -320,9 +324,10 @@ fn test_sqlite_round_trips_vertical_tabs_panel_open() {
 
     save_app_state(&mut conn, &app_state).expect("app state should save");
 
-    let restored = read_sqlite_data(&mut conn, None)
+    let restored = read_sqlite_data(&mut conn, None, PersistedDataScope::Full)
         .expect("app state should load")
-        .app_state;
+        .app_state
+        .expect("app state should be present for the full scope");
 
     assert_eq!(restored.active_window_index, Some(1));
     assert_eq!(
@@ -393,9 +398,10 @@ fn test_sqlite_round_trips_custom_vertical_tabs_title() {
 
     save_app_state(&mut conn, &app_state).expect("app state should save");
 
-    let restored = read_sqlite_data(&mut conn, None)
+    let restored = read_sqlite_data(&mut conn, None, PersistedDataScope::Full)
         .expect("app state should load")
-        .app_state;
+        .app_state
+        .expect("app state should be present for the full scope");
 
     let PaneNodeSnapshot::Leaf(LeafSnapshot {
         custom_vertical_tabs_title,
@@ -470,9 +476,10 @@ fn test_sqlite_round_trips_code_pane_with_multiple_tabs() {
 
     save_app_state(&mut conn, &app_state).expect("app state should save");
 
-    let restored = read_sqlite_data(&mut conn, None)
+    let restored = read_sqlite_data(&mut conn, None, PersistedDataScope::Full)
         .expect("app state should load")
-        .app_state;
+        .app_state
+        .expect("app state should be present for the full scope");
 
     assert_eq!(restored.windows.len(), 1);
     let restored_tab = &restored.windows[0].tabs[0];
@@ -593,9 +600,10 @@ fn test_sqlite_round_trips_tab_groups() {
 
     save_app_state(&mut conn, &app_state).expect("app state should save");
 
-    let restored = read_sqlite_data(&mut conn, None)
+    let restored = read_sqlite_data(&mut conn, None, PersistedDataScope::Full)
         .expect("app state should load")
-        .app_state;
+        .app_state
+        .expect("app state should be present for the full scope");
 
     assert_eq!(restored.windows.len(), 1);
     let restored_window = &restored.windows[0];
@@ -752,9 +760,10 @@ fn test_sqlite_round_trips_pinned_state() {
 
     save_app_state(&mut conn, &app_state).expect("app state should save");
 
-    let restored = read_sqlite_data(&mut conn, None)
+    let restored = read_sqlite_data(&mut conn, None, PersistedDataScope::Full)
         .expect("app state should load")
-        .app_state;
+        .app_state
+        .expect("app state should be present for the full scope");
 
     assert_eq!(restored.windows.len(), 1);
     let restored_window = &restored.windows[0];
@@ -929,9 +938,10 @@ fn test_sqlite_drops_too_small_bounds_on_read() {
     )
     .expect("corrupting update should succeed");
 
-    let restored = read_sqlite_data(&mut conn, None)
+    let restored = read_sqlite_data(&mut conn, None, PersistedDataScope::Full)
         .expect("app state should load")
-        .app_state;
+        .app_state
+        .expect("app state should be present for the full scope");
 
     assert_eq!(restored.windows.len(), 1);
     assert!(

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -312,7 +312,7 @@ pub fn initialize_app(app: &mut App) {
 
     app.update(experiments::init);
     AltScreenReporting::register(app);
-    app.add_singleton_model(|_| RestoredAgentConversations::new(vec![]));
+    app.add_singleton_model(|_| RestoredAgentConversations::new_seeded(vec![]));
     app.add_singleton_model(OneTimeModalModel::new);
     app.add_singleton_model(|_| WorkspaceRegistry::new());
     app.add_singleton_model(|_| ToastStack);

--- a/app/src/test_util/terminal.rs
+++ b/app/src/test_util/terminal.rs
@@ -171,7 +171,7 @@ pub fn initialize_app_for_terminal_view(app: &mut App) {
     #[cfg(not(target_family = "wasm"))]
     app.add_singleton_model(SystemInfo::new);
 
-    app.add_singleton_model(|_| RestoredAgentConversations::new(vec![]));
+    app.add_singleton_model(|_| RestoredAgentConversations::new_seeded(vec![]));
     app.add_singleton_model(OneTimeModalModel::new);
     app.add_singleton_model(|_| WorkspaceRegistry::new());
     app.add_singleton_model(|_| IgnoredSuggestionsModel::new(vec![]));

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -211,7 +211,7 @@ pub(crate) fn initialize_app(app: &mut App) {
             ctx,
         )
     });
-    app.add_singleton_model(|_| RestoredAgentConversations::new(vec![]));
+    app.add_singleton_model(|_| RestoredAgentConversations::new_seeded(vec![]));
     app.add_singleton_model(|ctx| {
         AIRequestUsageModel::new_for_test(ServerApiProvider::as_ref(ctx).get_ai_client(), ctx)
     });

--- a/crates/persistence/migrations/2026-07-07-000000_add_summary_to_agent_conversations/down.sql
+++ b/crates/persistence/migrations/2026-07-07-000000_add_summary_to_agent_conversations/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agent_conversations DROP COLUMN summary;

--- a/crates/persistence/migrations/2026-07-07-000000_add_summary_to_agent_conversations/up.sql
+++ b/crates/persistence/migrations/2026-07-07-000000_add_summary_to_agent_conversations/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agent_conversations ADD COLUMN summary TEXT;

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -1121,7 +1121,6 @@ impl AgentConversationSummary {
             .filter(|desc| !desc.is_empty())
             .unwrap_or_else(|| initial_query.clone());
 
-        // TODO: search tasks in correct order once we've implemented task ordering.
         let initial_working_directory = tasks
             .iter()
             .find_map(|task| api_task_initial_working_directory(task));

--- a/crates/persistence/src/model.rs
+++ b/crates/persistence/src/model.rs
@@ -906,6 +906,12 @@ pub struct AgentConversationRecord {
     pub conversation_id: String,
     pub conversation_data: String,
     pub last_modified_at: NaiveDateTime,
+    /// Serialized [`AgentConversationSummary`], computed from the task
+    /// snapshot at write time so startup can list conversations without
+    /// loading or decoding `agent_tasks`. `None` on rows written before the
+    /// column existed; readers fall back to deriving from tasks (and
+    /// backfill the column).
+    pub summary: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Queryable, Selectable)]
@@ -950,48 +956,182 @@ pub struct AgentConversation {
 impl AgentConversation {
     /// Returns `true` if the conversation is restorable.
     ///
-    /// A conversation is restorable if:
-    /// - It contains a single task or fewer, OR
-    /// - It has exactly one parentless (root) task, OR
-    /// - It has multiple parentless tasks but exactly one of them has
-    ///   non-empty `messages`. This permits restoring conversations whose
-    ///   persisted state was corrupted by the pre-QUALITY-774 optimistic-root
-    ///   writer bug, where a stub root row co-existed with the real server
-    ///   root row. `AIConversation::new_restored` deterministically picks
-    ///   the real root in that shape via its restore-side dedupe.
-    ///
-    /// Non-root tasks need not be validated here: any task that does not
-    /// match the parentless predicate has, by construction, a non-empty
-    /// `parent_task_id`.
+    /// See [`tasks_are_restorable`] for the exact rules.
     pub fn is_restorable(&self) -> bool {
-        if self.tasks.len() <= 1 {
-            return true;
+        tasks_are_restorable(self.tasks.iter())
+    }
+}
+
+/// Returns `true` if a conversation with the given task snapshot is
+/// restorable.
+///
+/// A conversation is restorable if:
+/// - It contains a single task or fewer, OR
+/// - It has exactly one parentless (root) task, OR
+/// - It has multiple parentless tasks but exactly one of them has
+///   non-empty `messages`. This permits restoring conversations whose
+///   persisted state was corrupted by the pre-QUALITY-774 optimistic-root
+///   writer bug, where a stub root row co-existed with the real server
+///   root row. `AIConversation::new_restored` deterministically picks
+///   the real root in that shape via its restore-side dedupe.
+///
+/// Non-root tasks need not be validated here: any task that does not
+/// match the parentless predicate has, by construction, a non-empty
+/// `parent_task_id`.
+pub fn tasks_are_restorable<'a>(tasks: impl IntoIterator<Item = &'a api::Task>) -> bool {
+    let tasks: Vec<&api::Task> = tasks.into_iter().collect();
+    if tasks.len() <= 1 {
+        return true;
+    }
+
+    // Find parentless (root) tasks - tasks with no dependencies or with an
+    // empty parent_task_id.
+    let root_tasks: Vec<_> = tasks
+        .iter()
+        .filter(|task| {
+            task.dependencies
+                .as_ref()
+                .map(|deps| deps.parent_task_id.is_empty())
+                .unwrap_or(true)
+        })
+        .collect();
+
+    match root_tasks.len() {
+        // Malformed: no parentless task means no root to anchor restore on.
+        0 => false,
+        // Single root: the normal happy path.
+        1 => true,
+        // Multi-root: only permit the specific [stub + real] shape
+        // produced by the pre-QUALITY-774 optimistic-root writer bug,
+        // where exactly one parentless row carries the real conversation
+        // content. The restore-side dedupe in
+        // `AIConversation::new_restored` will pick that real root.
+        _ => root_tasks.iter().filter(|t| !t.messages.is_empty()).count() == 1,
+    }
+}
+
+/// Returns the working directory of the first message in the task that
+/// carries directory context, if any.
+pub fn api_task_initial_working_directory(task: &api::Task) -> Option<String> {
+    task.messages
+        .iter()
+        .find_map(|message| {
+            message.message.as_ref().and_then(|content| {
+                let context = match content {
+                    api::message::Message::UserQuery(user_query) => user_query.context.as_ref(),
+                    api::message::Message::ToolCallResult(tool_call_result) => {
+                        tool_call_result.context.as_ref()
+                    }
+                    api::message::Message::SystemQuery(system_query) => {
+                        system_query.context.as_ref()
+                    }
+                    _ => None,
+                };
+
+                context
+                    .and_then(|ctx| ctx.directory.as_ref())
+                    .map(|dir| dir.pwd.clone())
+            })
+        })
+        .filter(|pwd| !pwd.is_empty())
+}
+
+/// Task-derived conversation metadata, serialized into the `summary` column
+/// of `agent_conversations` at write time.
+///
+/// This lets startup build the conversation history list from
+/// `agent_conversations` rows alone, without loading or protobuf-decoding the
+/// (potentially very large) `agent_tasks` blobs.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct AgentConversationSummary {
+    /// The conversation's initial user query (or passive diff summary).
+    /// Empty when the conversation has no root task with a user query.
+    #[serde(default)]
+    pub initial_query: String,
+    /// Display title: the root task description, falling back to
+    /// `initial_query`.
+    #[serde(default)]
+    pub title: String,
+    /// The working directory of the first message carrying directory context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub initial_working_directory: Option<String>,
+    /// Mirror of [`tasks_are_restorable`] over the persisted task snapshot.
+    pub is_restorable: bool,
+    /// True when the conversation only contains passive `AutoCodeDiff` system
+    /// queries and no user queries; such conversations are hidden from the
+    /// history list.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub is_unlisted_auto_code_diff: bool,
+}
+
+impl AgentConversationSummary {
+    /// Derives the summary from a conversation's full task snapshot.
+    pub fn from_tasks<'a>(tasks: impl IntoIterator<Item = &'a api::Task>) -> Self {
+        let tasks: Vec<&api::Task> = tasks.into_iter().collect();
+
+        let mut has_user_query = false;
+        let mut has_auto_code_diff = false;
+        for task in &tasks {
+            for message in &task.messages {
+                match &message.message {
+                    Some(api::message::Message::UserQuery(_)) => {
+                        has_user_query = true;
+                    }
+                    Some(api::message::Message::SystemQuery(sys)) => {
+                        if let Some(api::message::system_query::Type::AutoCodeDiff(_)) = &sys.r#type
+                        {
+                            has_auto_code_diff = true;
+                        }
+                    }
+                    _ => {}
+                }
+            }
         }
 
-        // Find parentless (root) tasks - tasks with no dependencies or with an
-        // empty parent_task_id.
-        let root_tasks: Vec<_> = self
-            .tasks
-            .iter()
-            .filter(|task| {
-                task.dependencies
-                    .as_ref()
-                    .map(|deps| deps.parent_task_id.is_empty())
-                    .unwrap_or(true)
-            })
-            .collect();
+        let root_task = tasks.iter().find(|task| task.dependencies.is_none());
 
-        match root_tasks.len() {
-            // Malformed: no parentless task means no root to anchor restore on.
-            0 => false,
-            // Single root: the normal happy path.
-            1 => true,
-            // Multi-root: only permit the specific [stub + real] shape
-            // produced by the pre-QUALITY-774 optimistic-root writer bug,
-            // where exactly one parentless row carries the real conversation
-            // content. The restore-side dedupe in
-            // `AIConversation::new_restored` will pick that real root.
-            _ => root_tasks.iter().filter(|t| !t.messages.is_empty()).count() == 1,
+        // The first user query in the root task (or, for a passive code
+        // diff, the summary of the diff).
+        let initial_query = root_task
+            .map(|task| {
+                task.messages
+                    .iter()
+                    .find_map(|msg| match &msg.message {
+                        Some(api::message::Message::UserQuery(user_query)) => {
+                            Some(user_query.query.clone())
+                        }
+                        Some(api::message::Message::ToolCall(tool_call)) => {
+                            match tool_call.tool.as_ref()? {
+                                api::message::tool_call::Tool::ApplyFileDiffs(diff_suggestion) => {
+                                    Some(diff_suggestion.summary.clone())
+                                }
+                                _ => None,
+                            }
+                        }
+                        _ => None,
+                    })
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default();
+
+        // The title is the root task description, falling back to
+        // `initial_query` when the description is empty.
+        let title = root_task
+            .map(|task| task.description.clone())
+            .filter(|desc| !desc.is_empty())
+            .unwrap_or_else(|| initial_query.clone());
+
+        // TODO: search tasks in correct order once we've implemented task ordering.
+        let initial_working_directory = tasks
+            .iter()
+            .find_map(|task| api_task_initial_working_directory(task));
+
+        Self {
+            initial_query,
+            title,
+            initial_working_directory,
+            is_restorable: tasks_are_restorable(tasks.iter().copied()),
+            is_unlisted_auto_code_diff: has_auto_code_diff && !has_user_query,
         }
     }
 }

--- a/crates/persistence/src/model_tests.rs
+++ b/crates/persistence/src/model_tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use warp_multi_agent_api as api;
 
-use super::{AgentConversation, AgentConversationData, ModelTokenUsage};
+use super::{AgentConversation, AgentConversationData, AgentConversationSummary, ModelTokenUsage};
 
 fn parentless_task(id: &str, message_count: usize) -> api::Task {
     api::Task {
@@ -100,6 +100,126 @@ fn is_restorable_accepts_single_root_plus_subtasks() {
 fn is_restorable_accepts_empty_and_single_task_conversations() {
     assert!(conversation_with_tasks(vec![]).is_restorable());
     assert!(conversation_with_tasks(vec![parentless_task("root", 0)]).is_restorable());
+}
+
+fn user_query_message(task_id: &str, query: &str, pwd: Option<&str>) -> api::Message {
+    let context = pwd.map(|pwd| api::InputContext {
+        directory: Some(api::input_context::Directory {
+            pwd: pwd.to_string(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    api::Message {
+        id: format!("{task_id}-user-query"),
+        task_id: task_id.to_string(),
+        message: Some(api::message::Message::UserQuery(api::message::UserQuery {
+            query: query.to_string(),
+            context,
+            ..Default::default()
+        })),
+        ..Default::default()
+    }
+}
+
+fn auto_code_diff_message(task_id: &str) -> api::Message {
+    api::Message {
+        id: format!("{task_id}-auto-code-diff"),
+        task_id: task_id.to_string(),
+        message: Some(api::message::Message::SystemQuery(
+            api::message::SystemQuery {
+                context: None,
+                r#type: Some(api::message::system_query::Type::AutoCodeDiff(
+                    api::message::AutoCodeDiff {
+                        query: "diff".to_string(),
+                    },
+                )),
+            },
+        )),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn summary_from_tasks_derives_query_title_and_working_directory() {
+    let mut root = parentless_task("root", 0);
+    root.description = "Root title".to_string();
+    root.messages = vec![user_query_message(
+        "root",
+        "Initial query",
+        Some("/tmp/repo"),
+    )];
+
+    let summary = AgentConversationSummary::from_tasks([&root]);
+
+    assert_eq!(summary.initial_query, "Initial query");
+    assert_eq!(summary.title, "Root title");
+    assert_eq!(
+        summary.initial_working_directory.as_deref(),
+        Some("/tmp/repo")
+    );
+    assert!(summary.is_restorable);
+    assert!(!summary.is_unlisted_auto_code_diff);
+}
+
+#[test]
+fn summary_from_tasks_falls_back_to_initial_query_when_description_is_empty() {
+    let mut root = parentless_task("root", 0);
+    root.messages = vec![user_query_message("root", "Initial query", None)];
+
+    let summary = AgentConversationSummary::from_tasks([&root]);
+
+    assert_eq!(summary.title, "Initial query");
+    assert_eq!(summary.initial_working_directory, None);
+}
+
+#[test]
+fn summary_from_tasks_flags_auto_code_diff_only_conversations_as_unlisted() {
+    let mut root = parentless_task("root", 0);
+    root.messages = vec![auto_code_diff_message("root")];
+
+    let summary = AgentConversationSummary::from_tasks([&root]);
+    assert!(summary.is_unlisted_auto_code_diff);
+
+    // A user query alongside the passive diff keeps the conversation listed.
+    let mut interacted_root = parentless_task("root", 0);
+    interacted_root.messages = vec![
+        auto_code_diff_message("root"),
+        user_query_message("root", "Follow-up", None),
+    ];
+
+    let summary = AgentConversationSummary::from_tasks([&interacted_root]);
+    assert!(!summary.is_unlisted_auto_code_diff);
+}
+
+#[test]
+fn summary_from_tasks_mirrors_restorability() {
+    // Two real roots is the genuinely ambiguous, non-restorable shape.
+    let summary = AgentConversationSummary::from_tasks([
+        &parentless_task("root-a", 1),
+        &parentless_task("root-b", 1),
+    ]);
+    assert!(!summary.is_restorable);
+
+    let summary = AgentConversationSummary::from_tasks([&parentless_task("root", 1)]);
+    assert!(summary.is_restorable);
+}
+
+#[test]
+fn summary_roundtrips_through_json() {
+    let mut root = parentless_task("root", 0);
+    root.description = "Root title".to_string();
+    root.messages = vec![user_query_message(
+        "root",
+        "Initial query",
+        Some("/tmp/repo"),
+    )];
+
+    let summary = AgentConversationSummary::from_tasks([&root]);
+    let json = serde_json::to_string(&summary).expect("summary should serialize");
+    let roundtripped: AgentConversationSummary =
+        serde_json::from_str(&json).expect("summary should deserialize");
+    assert_eq!(roundtripped, summary);
 }
 
 #[test]

--- a/crates/persistence/src/schema.rs
+++ b/crates/persistence/src/schema.rs
@@ -13,6 +13,7 @@ diesel::table! {
         conversation_id -> Text,
         conversation_data -> Text,
         last_modified_at -> Timestamp,
+        summary -> Nullable<Text>,
     }
 }
 


### PR DESCRIPTION
## Description

`warp-tui` took ~3s before first paint. The TUI reuses the full headless app bootstrap and only mounts after `initialize_app` completes, and nearly all of that time was spent inside `persistence::initialize` loading state the TUI never uses.

### 1. What's causing the slow startup

On a 580 MB `warp.sqlite` (dev-channel dogfood DB), the stall breaks down as:

- **`agent_tasks` is the dominant cost (304 MB, 1,730 rows).** Each row is a protobuf-encoded full task transcript (every message, tool call, and tool result). Startup loaded and prost-decoded *all* of them (~1.3s of raw blob I/O, roughly doubled by decode/allocation), then converted them **twice more**: once into `RestoredAgentConversations` (GUI pane restoration — unused by the TUI) and once in `initialize_historical_conversations`, which walked every task's messages just to derive list metadata (initial query, title, restorability, passive-diff filter).
- **GUI-only session-restore payloads**: windows/tabs/panes, restored blocks, 10k command-history rows, user profiles, pending object actions — all loaded for a launch mode that never reads them.
- All of this runs synchronously on the main thread before the TUI mounts.

For contrast: reading just the `agent_conversations` metadata rows (≤200, capped) takes ~7ms.

### 2. Options considered

- **Denormalized write-time summary (chosen):** compute list metadata from the task snapshot at persist time in the SQLite writer (single choke point covers live updates, forks, sync), store it in a new nullable `summary` column on `agent_conversations`, and make startup metadata-only with lazy per-conversation hydration (`read_agent_conversation_by_id`, which already existed). Pre-existing rows are derived once at read time and backfilled.
  - *Why a JSON column instead of structured columns:* the summary is only ever read whole for ≤200 rows (never filtered/sorted in SQL), evolves via `#[serde(default)]` without migrations, and follows the existing `conversation_data` precedent. A dedicated column (vs. embedding in `conversation_data`) keeps the backfill a trivially safe `UPDATE ... WHERE summary IS NULL` with no clobber risk against concurrent writes.
- **Store the summary inside `conversation_data`:** no migration, but backfill becomes read-modify-write of a user-authored blob (clobber risk) and touches ~50 construction sites. Rejected.
- **Background decode, no schema change:** hydrate the list off-thread after paint. Fixes perceived latency but every startup still pays the full 304 MB decode; list pops in late. Rejected as the primary fix.
- **Mount the TUI before `initialize_app` (paint-first):** still viable as a follow-up, but measurements show it's no longer necessary for the TUI's startup goal.
- **Normalize messages into per-row tables / move transcripts out of the DB:** the "proper" fix for both read and write costs, but a much larger migration touching the whole restore path. Deferred (see below) — this change is a compatible stepping stone.

Additionally, a `PersistedDataScope` (Full / TuiFrontend / CodebaseIndicesOnly) now gates what each launch mode reads: the TUI skips session restoration, command history, user profiles, and object actions; the remote server daemon reads only codebase indices (replacing its previous load-then-discard block).

### 3. Long-term vision

This is a low-risk stepping stone toward restructuring conversation persistence:

- **Structured `conversation_metadata` table** — one row per conversation (title, initial query, working dir, flags, credits) that supersedes both the `summary` blob and `ai_queries`' display role, unlocking SQL-side search/sort/pagination if retention grows past the current 200-row cap.
- **Incremental task persistence** — today every persist rewrites the *entire* task snapshot (replace semantics), so a growing transcript is O(n²) total bytes written over its life; this is why `agent_tasks` is 304 MB inside a 580 MB file with a 60 MB WAL. Dirty-task tracking and eventually append-only message rows fix the write amplification at the source and enable partial transcript loading.
- **Remaining TUI-scope trims** — `ai_queries` (36 MB, feeds cross-session up-arrow history the TUI doesn't surface yet) and notebooks (37 MB, Drive UI + local document-tool cache) are the next candidates once the document tools' server-fetch fallback is verified.

### Migration / rollout notes

- Additive O(1) `ALTER TABLE`; old builds ignore the new column (rollback-safe, `down.sql` provided).
- First launch on the new build derives + backfills summaries for existing rows (one startup at roughly the old cost); idempotent if interrupted; steady state from the second launch.
- Known soft spot: an old-build writer (GUI/TUI share the DB across a version skew window) updates `conversation_data`/tasks without refreshing `summary`, leaving stale list metadata until any new-build write refreshes it. Cosmetic only (transcripts always load fresh) and self-healing.

## Testing

- New unit tests: summary derivation (`crates/persistence/src/model_tests.rs`), in-memory-DB round trips for metadata read + legacy backfill + stale-backfill no-clobber (`app/src/persistence/agent_tests.rs`), summary-driven history list and skip rules (`history_model_tests.rs`).
- Full suites for touched areas pass (`persistence`, history model, pane group, sqlite tests); `./script/format` + `cargo clippy` clean.
- Manual validation against a copy of a real 580 MB dev DB: one-time backfill of all 200 conversations, second startup metadata-only, orchestration children hydrate lazily, and the conversation-list log output matches the pre-change build exactly.
- Measured with `./script/run-tui`: first launch logs `Backfilling N conversation summaries`; steady-state SQLite window drops from ~3s (dev DB, release build, old code) to sub-second.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Faster app startup: persisted agent conversations are now loaded lazily instead of being fully decoded at launch.
