### PR TITLE
Fix softwrapped line not expanding the input box

### DIFF
--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -1246,9 +1246,22 @@ impl TuiInputElement {
         // so the buffer row under the pointer is `scroll_offset + row_in_view`
         // (floored at the first row).
         let visual_row = (i64::from(self.scroll_offset) + row_in_view).max(0) as u32;
-        // ...and capped at the last real visual row, so a drag below the text
-        // resolves to the buffer's end rather than past it.
+        // The rendered layout can include a "phantom" row one past the soft-wrap
+        // map's last row when the final logical line exactly fills the terminal
+        // width (deferred wrap; see `build`). The map has no entry for it —
+        // every cell on it is the end-of-buffer gap — so resolve it directly
+        // instead of clamping into the preceding real row (which would map the
+        // click near that row's start).
         let last_row = render.max_line().as_u32().max(1).saturating_sub(1);
+        let end_char_count = self.text.chars().count();
+        let end_gap_row = render
+            .offset_to_softwrap_point(CharOffset::from(end_char_count))
+            .row();
+        if visual_row > last_row && end_gap_row > last_row {
+            return CharOffset::from(end_char_count + 1);
+        }
+        // ...otherwise cap at the last real visual row, so a drag below the
+        // text resolves to the buffer's end rather than past it.
         let visual_row = visual_row.min(last_row);
 
         // Column within that row, in display cells (0 is the input's left edge).

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -797,8 +797,9 @@ impl TypedActionView for TuiInputView {
             }
         }
 
-        let visible_rows = cmp::min(self.visual_line_count(ctx), self.max_visible_rows);
-        self.scroll_to_cursor(visible_rows.max(1), ctx);
+        let total_rows = self.total_visual_rows(ctx);
+        let visible_rows = cmp::min(total_rows, self.max_visible_rows);
+        self.scroll_to_cursor(total_rows, visible_rows.max(1), ctx);
         ctx.notify();
     }
 }
@@ -867,17 +868,39 @@ impl TuiInputView {
             .max(1)
     }
 
-    // ── Scroll ────────────────────────────────────────────────────────────────
-
-    fn scroll_to_cursor(&mut self, visible_rows: u32, ctx: &AppContext) {
+    /// The cursor's visual row in the char-cell soft-wrap map (0-based).
+    fn cursor_visual_row(&self, ctx: &AppContext) -> u32 {
         let cursor_offset = self.cursor_offset(ctx);
         let inner = self.model.as_ref(ctx);
         let render = inner.render_state().as_ref(ctx);
         // `offset_to_softwrap_point` is 0-based (see `char_cell_offset_to_softwrap_point`),
         // while the cursor is a 1-based `CharOffset`, so convert by subtracting 1.
         let cursor_char_index = CharOffset::from(cursor_offset.as_usize().saturating_sub(1));
-        let pt = render.offset_to_softwrap_point(cursor_char_index);
-        let cursor_row = pt.row();
+        render.offset_to_softwrap_point(cursor_char_index).row()
+    }
+
+    /// Total visual rows the input occupies, including the "phantom" row the
+    /// cursor wraps onto when a logical line exactly fills the terminal width
+    /// (deferred wrap). [`Self::visual_line_count`] never counts that row — the
+    /// soft-wrap map only adds a row once a character actually overflows — but
+    /// the cursor legitimately sits there, so sizing and scrolling must include
+    /// it or the viewport scrolls to a row that is never rendered.
+    fn total_visual_rows(&self, ctx: &AppContext) -> u32 {
+        self.visual_line_count(ctx)
+            .max(self.cursor_visual_row(ctx) + 1)
+    }
+
+    // ── Scroll ────────────────────────────────────────────────────────────────────
+
+    fn scroll_to_cursor(&mut self, total_rows: u32, visible_rows: u32, ctx: &AppContext) {
+        let cursor_row = self.cursor_visual_row(ctx);
+
+        // A stale offset can point past the last remaining row (e.g. after a
+        // deletion shrank the content); clamp it so the visible window always
+        // overlaps real rows before following the cursor.
+        self.scroll_offset = self
+            .scroll_offset
+            .min(total_rows.saturating_sub(visible_rows));
 
         if cursor_row < self.scroll_offset {
             self.scroll_offset = cursor_row;
@@ -890,7 +913,7 @@ impl TuiInputView {
     /// top), clamped to `[0, max_scroll]`. Independent of the cursor, so callers
     /// must not follow it with `scroll_to_cursor`.
     fn scroll_by(&mut self, rows: isize, ctx: &AppContext) {
-        let lines = self.visual_line_count(ctx);
+        let lines = self.total_visual_rows(ctx);
         let visible_rows = cmp::min(lines, self.max_visible_rows).max(1);
         let max_scroll = lines.saturating_sub(visible_rows) as isize;
         let new_offset = (self.scroll_offset as isize + rows).clamp(0, max_scroll);
@@ -1128,14 +1151,28 @@ impl TuiInputElement {
             && cursor_visual_row < self.scroll_offset + visible_rows;
 
         let rows_with_offsets = build_visual_rows_with_offsets(&self.text, terminal_width);
+        // The cursor sits one row past the last text row when a logical line
+        // exactly fills the width (deferred wrap); that phantom row is part of
+        // the layout, so include it when windowing the visible rows.
+        let total_rows = rows_with_offsets.len().max(cursor_visual_row as usize + 1);
         let visible_start = self.scroll_offset as usize;
-        let visible_end =
-            (self.scroll_offset as usize + visible_rows as usize).min(rows_with_offsets.len());
-        let visible_rows_slice: Vec<(String, usize)> = if visible_start < rows_with_offsets.len() {
-            rows_with_offsets[visible_start..visible_end].to_vec()
+        let visible_end = (visible_start + visible_rows as usize).min(total_rows);
+        let text_rows_end = visible_end.min(rows_with_offsets.len());
+        let mut visible_rows_slice: Vec<(String, usize)> = if visible_start < text_rows_end {
+            rows_with_offsets[visible_start..text_rows_end].to_vec()
         } else {
-            vec![(String::new(), 0)]
+            Vec::new()
         };
+        // Pad any phantom rows in the window with empty text at the buffer's
+        // end offset, so the cursor's row renders and selection math stays
+        // in bounds.
+        let end_char_offset = self.text.chars().count();
+        while visible_rows_slice.len() < visible_end.saturating_sub(visible_start) {
+            visible_rows_slice.push((String::new(), end_char_offset));
+        }
+        if visible_rows_slice.is_empty() {
+            visible_rows_slice.push((String::new(), 0));
+        }
 
         // Selection spans per visible row. Selection offsets are char indices;
         // terminal highlighting works in display columns, so convert via each
@@ -1296,7 +1333,12 @@ impl TuiElement for TuiInputElement {
             cc.set_terminal_width(terminal_width);
         }
         let visual_line_count = render_state.as_ref(app).max_line().as_u32().max(1);
-        let visible_rows = cmp::min(visual_line_count, self.max_visible_rows);
+        // Include the "phantom" row the cursor wraps onto when a logical line
+        // exactly fills the width (deferred wrap): `max_line` doesn't count it,
+        // but the input must grow so the cursor's row is rendered.
+        let (cursor_row, _) = char_cell_cursor_pos(&self.text, self.cursor_offset, terminal_width);
+        let total_rows = visual_line_count.max(cursor_row + 1);
+        let visible_rows = cmp::min(total_rows, self.max_visible_rows);
 
         self.build(terminal_width, visible_rows);
         self.column.layout(constraint, ctx, app)

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -520,6 +520,31 @@ fn single_click_places_cursor() {
     });
 }
 
+/// Clicking the phantom deferred-wrap row (rendered when a logical line
+/// exactly fills the width) must resolve to the end-of-buffer gap — where the
+/// cursor visibly sits — not clamp into the preceding full row and teleport
+/// the cursor to its start.
+#[test]
+fn click_on_phantom_wrap_row_keeps_cursor_at_end() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            type_str(&view, ctx, &"a".repeat(W as usize));
+            // The exactly-full line renders two rows: the text row and the
+            // phantom cursor row below it.
+            assert_eq!(cursor_and_height(&view, ctx), (Some((0, 1)), 2));
+
+            // Click the phantom row at its left edge.
+            assert!(mouse(&view, ctx, &left_down(0, 1, 1, false)));
+            assert!(mouse(&view, ctx, &left_up(0, 1)));
+
+            // The cursor stays at the buffer end (and the row stays rendered).
+            assert_eq!(cursor_and_height(&view, ctx), (Some((0, 1)), 2));
+            assert_eq!(selected_text(&view, ctx), None);
+        });
+    });
+}
+
 #[test]
 fn click_outside_area_is_ignored() {
     App::test((), |mut app| async move {

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -379,6 +379,51 @@ fn cursor_accounts_for_zero_width_chars() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Soft-wrap growth
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Typing until the first line exactly fills the terminal width wraps the
+/// cursor to the next visual row (deferred-wrap terminal behavior), so the
+/// input must grow to show that row — and must not scroll the first row away.
+#[test]
+fn input_grows_when_line_exactly_fills_width() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            type_str(&view, ctx, &"a".repeat(W as usize));
+            assert_eq!(
+                view.as_ref(ctx).scroll_offset,
+                0,
+                "first row must stay visible"
+            );
+            let (cursor, height) = cursor_and_height(&view, ctx);
+            assert_eq!(height, 2, "wrapped cursor row must be shown");
+            assert_eq!(cursor, Some((0, 1)), "cursor wraps to start of next row");
+        });
+    });
+}
+
+/// Once the first line soft-wraps past the terminal width, the input must be
+/// two rows tall with both rows visible.
+#[test]
+fn input_grows_when_first_line_softwraps() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            type_str(&view, ctx, &"a".repeat(W as usize + 5));
+            assert_eq!(
+                view.as_ref(ctx).scroll_offset,
+                0,
+                "first row must stay visible"
+            );
+            let (cursor, height) = cursor_and_height(&view, ctx);
+            assert_eq!(height, 2, "two visual rows expected");
+            assert_eq!(cursor, Some((5, 1)), "cursor on second row after wrap");
+        });
+    });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Mouse selection
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Description
Fixes the TUI input editor not growing when the first line soft-wraps past the terminal width. Once the typed text reached the input's inner width, the first row scrolled out of view permanently, the box stayed one row shorter than the content, and the top row never came back even after deleting text.

**Root cause:** an off-by-one mismatch between two char-cell layout helpers:
- `char_cell_line_gap_position` intentionally wraps an end-of-line cursor onto the next visual row when a logical line *exactly* fills the terminal width (deferred wrap, matching plain monospace terminal behavior).
- `char_cell_line_row_starts` / `char_cell_max_line` only count a new row once a character actually overflows, so that "phantom" cursor row is never included in the row count.

As a result, `TuiInputView::scroll_to_cursor` saw the cursor on row 1 while `max_line` reported 1 total row, bumped `scroll_offset` to a row that doesn't exist, and nothing ever clamped it back. Since `TuiInputElement::build` derives the input's height from the visible-row slice starting at `scroll_offset`, the input stayed one row short forever and the first visual row was never rendered.

**Fix (all in `crates/warp_tui/src/input/view.rs`):**
- Added `cursor_visual_row` / `total_visual_rows` helpers so sizing and scrolling account for the phantom deferred-wrap row (`max(max_line, cursor_row + 1)`).
- `TuiInputElement::layout` and `build` include the phantom row when computing height and windowing visible rows, padding it with an empty row so the cursor's row renders.
- `scroll_to_cursor` now clamps a stale `scroll_offset` back into `[0, total_rows - visible_rows]` so the viewport self-heals (e.g. after large deletions); `scroll_by` uses the phantom-aware total.

## Linked Issue
N/A — found while dogfooding the TUI.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- Added two regression tests in `crates/warp_tui/src/input/view_tests.rs`:
  - `input_grows_when_line_exactly_fills_width` — typing exactly the terminal width grows the input to 2 rows with the cursor at the start of the new row and `scroll_offset` still 0.
  - `input_grows_when_first_line_softwraps` — typing past the width keeps both rows visible.
  - Both failed before the fix (`scroll_offset` jumped to a nonexistent row) and pass after.
- `cargo nextest run -p warp_tui` — all 65 tests pass.
- Manually validated end-to-end with `./script/run-tui`: typed ~340 chars on one line and confirmed the input grows 1→2→…→6 rows (capped), the first row stays visible the whole time, there is no blank-box moment at the exact-width boundary, and the box shrinks cleanly while deleting.
- `cargo clippy -p warp_tui --all-targets -- -D warnings` and `cargo fmt -p warp_tui -- --check` are clean.

- [x] I have manually tested my changes locally

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation](https://staging.warp.dev/conversation/75a9f4ed-77a4-41f5-895d-8a7c006fbd75)

CHANGELOG-NONE
