### PR TITLE
Fix rich input not auto-opening for 3p harness cloud agent viewers

### DIFF
--- a/app/src/terminal/shared_session/shared_handlers.rs
+++ b/app/src/terminal/shared_session/shared_handlers.rs
@@ -419,7 +419,13 @@ pub(crate) fn apply_cli_agent_state_update(
 
             // Update the rich input state.
             let currently_open = CLIAgentSessionsModel::as_ref(ctx).is_input_open(view_id);
-            if currently_open != effective_rich_input_open {
+            // For ambient viewers where the session already existed, preserve the
+            // viewer's own rich input state. The viewer may have opened it via
+            // ViewerHarnessResolved before the sharer's CLIAgentSessionState::Active
+            // arrived; don't let the sharer's is_rich_input_open=false close it.
+            let should_update_rich_input =
+                !(already_exists && view.as_ref(ctx).is_shared_ambient_agent_session());
+            if should_update_rich_input && currently_open != effective_rich_input_open {
                 view.update(ctx, |view, ctx| {
                     if effective_rich_input_open {
                         view.open_cli_agent_rich_input(

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -29,7 +29,10 @@ use crate::ai::blocklist::BlocklistAIHistoryModel;
 use crate::ai::conversation_details_panel::ConversationDetailsData;
 use crate::ai::AIRequestUsageModel;
 use crate::pane_group::TerminalViewResources;
-use crate::terminal::cli_agent_sessions::CLIAgentSessionsModel;
+use crate::terminal::cli_agent_sessions::{
+    CLIAgentInputEntrypoint, CLIAgentInputState, CLIAgentSession, CLIAgentSessionContext,
+    CLIAgentSessionStatus, CLIAgentSessionsModel,
+};
 use crate::terminal::view::rich_content::{RichContentInsertionPosition, RichContentMetadata};
 use crate::terminal::view::{
     ConversationDetailsPanelAutoOpenPolicy, Event as TerminalViewEvent, TerminalView,
@@ -337,6 +340,10 @@ impl TerminalView {
                 // Once we know which harness we're using from the server, try and enter the agent
                 // view if we haven't already.
                 self.sync_agent_view_for_shared_third_party_viewer(ctx);
+                // Ensure rich input is open for live 3p harness viewers. Byte-sharing without
+                // rich input has roundtrip lag. If the sharer's CLIAgentSessionState::Active
+                // hasn't arrived yet (e.g. plugin not started), open it proactively here.
+                self.maybe_open_rich_input_for_third_party_harness_viewer(ctx);
                 self.update_pane_configuration(ctx);
                 ctx.emit(TerminalViewEvent::TerminalViewStateChanged);
                 ctx.notify();
@@ -607,6 +614,64 @@ impl TerminalView {
         }
 
         Some(vehicle_conversation_id)
+    }
+
+    /// For live 3p harness viewers, opens rich input if it isn't already open and no CLI
+    /// agent session exists yet. Called from `ViewerHarnessResolved` so the composer
+    /// appears immediately on join even when the sharer's `CLIAgentSessionState::Active`
+    /// hasn't arrived yet (e.g. the plugin started after the session-sharing snapshot
+    /// was captured, or the plugin is not installed).
+    fn maybe_open_rich_input_for_third_party_harness_viewer(
+        &mut self,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if !self.is_shared_ambient_agent_session() {
+            return;
+        }
+        if !self.model.lock().shared_session_status().is_active_viewer() {
+            return;
+        }
+        if self.has_active_cli_agent_input_session(ctx) {
+            return;
+        }
+        // Only proceed if no CLI session exists yet — if it does, `apply_cli_agent_state_update`
+        // already handled or will handle the rich input lifecycle.
+        if CLIAgentSessionsModel::as_ref(ctx)
+            .session(self.view_id)
+            .is_some()
+        {
+            return;
+        }
+        let Some(cli_agent) = self
+            .ambient_agent_view_model
+            .as_ref()
+            .and_then(|m| m.as_ref(ctx).selected_third_party_cli_agent())
+        else {
+            return;
+        };
+        let view_id = self.view_id;
+        CLIAgentSessionsModel::handle(ctx).update(ctx, |sessions_model, ctx| {
+            sessions_model.set_session(
+                view_id,
+                CLIAgentSession {
+                    agent: cli_agent,
+                    status: CLIAgentSessionStatus::InProgress,
+                    session_context: CLIAgentSessionContext::default(),
+                    input_state: CLIAgentInputState::Closed,
+                    // Viewer manages its own rich input via the sync protocol.
+                    should_auto_toggle_input: false,
+                    listener: None,
+                    plugin_version: None,
+                    remote_host: None,
+                    draft_text: None,
+                    custom_command_prefix: None,
+                    received_rich_notification: false,
+                },
+                ctx,
+            );
+        });
+        self.apply_cli_agent_footer_visibility(true, ctx);
+        self.open_cli_agent_rich_input(CLIAgentInputEntrypoint::SharedSessionSync, ctx);
     }
 
     /// Returns `true` when the block's command is the CLI for the run's configured


### PR DESCRIPTION
## Description

Fix regression where cloud 3p-harness runs (e.g. Claude Code, Gemini) don't auto-open rich input when a viewer joins the session.

Two-part fix:

1. **`apply_cli_agent_state_update`**: Don't close rich input the viewer already opened when a subsequent `CLIAgentSessionState::Active` arrives with `is_rich_input_open=false`. The sharer (cloud worker) always sends `false` for its own rich input state, which shouldn't override the viewer's independently-managed rich input.

2. **`ViewerHarnessResolved` handler**: Proactively create a synthetic CLI agent session and open rich input when the harness is resolved AND the session is still active AND no `CLIAgentSession` exists yet. This covers the case where the sharer's `CLIAgentSessionState::Active` hasn't arrived (e.g. plugin not installed, or timing: viewer joins before the harness CLI emits its first OSC 777 `SessionStart`).

**Root cause**: The original auto-open logic (PR #9668) fires when `CLIAgentSessionState::Active` is received. If this event is never sent by the cloud worker (plugin not working or delayed), rich input never opens. Additionally, if the viewer pre-opens rich input via the harness resolution path and then `Active` arrives with `is_rich_input_open=false`, it would incorrectly close the viewer's input.

## Linked Issue
- [REMOTE-2086](https://linear.app/warpdotdev/issue/REMOTE-2086)

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed rich input not auto-opening when viewing a cloud 3p-harness agent session (Claude Code, Gemini, Codex).

_Conversation: https://staging.warp.dev/conversation/ebf33721-c682-4068-a7a9-d2508359ec4a_
_Run: https://oz.staging.warp.dev/runs/019f3f39-d33e-7cdb-9777-f303dd7953d3_
_This PR was generated with [Oz](https://warp.dev/oz)._
