### PR TITLE
refactor away extra hashmap in TaskStore

### DIFF
--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -635,7 +635,7 @@ impl AIConversation {
                 task.reassign_exchange_ids();
             });
         }
-        self.task_store.rebuild_exchange_id_index();
+        self.task_store.rebuild_exchange_index();
     }
 
     pub fn is_viewing_shared_session(&self) -> bool {

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -203,7 +203,7 @@ fn reassign_exchange_ids_keeps_exchange_lookup_consistent() {
 
     // Reassigning regenerates ids without changing the exchange count, so
     // `modify_task` does not rebuild the index; correctness relies on the
-    // explicit `rebuild_exchange_id_index()` call. The stale ids must be gone.
+    // explicit `rebuild_exchange_index()` call. The stale ids must be gone.
     for id in &old_ids {
         assert!(conversation.exchange_with_id(*id).is_none());
     }

--- a/app/src/ai/agent/task_store.rs
+++ b/app/src/ai/agent/task_store.rs
@@ -93,7 +93,7 @@ impl TaskStore {
         let is_at_dfs_tail = self
             .exchanges
             .last()
-            .map_or(true, |(_, r)| r.task_id == *task_id);
+            .is_none_or(|(_, r)| r.task_id == *task_id);
         // If we know this exchange is going at the end, it's faster to just append it.
         if is_at_dfs_tail && !has_subagent_output {
             self.exchanges.insert(
@@ -303,8 +303,7 @@ impl TaskStore {
 
     pub fn remove(&mut self, task_id: &TaskId) -> Option<Task> {
         let task = self.tasks.remove(task_id)?;
-        self.exchanges
-            .retain(|_, r| self.tasks.contains_key(&r.task_id));
+        self.rebuild_exchange_index();
         Some(task)
     }
 

--- a/app/src/ai/agent/task_store.rs
+++ b/app/src/ai/agent/task_store.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use indexmap::IndexMap;
 use warp_multi_agent_api as api;
 
 use super::task::helper::{MessageExt, ToolCallExt};
@@ -19,8 +20,7 @@ struct ExchangeRef {
 pub struct TaskStore {
     root_task_id: TaskId,
     tasks: HashMap<TaskId, Task>,
-    linearized_refs: Vec<ExchangeRef>,
-    exchange_id_index: HashMap<AIAgentExchangeId, ExchangeRef>,
+    exchanges: IndexMap<AIAgentExchangeId, ExchangeRef>,
     /// If the root task was upgraded from an optimistic (client-generated) ID
     /// to a server-assigned ID, stores the original optimistic ID so that
     /// deferred event handlers referencing the stale ID can still resolve
@@ -33,13 +33,12 @@ impl TaskStore {
         let root_task_id = root_task.id().clone();
         let mut store = Self {
             tasks: HashMap::new(),
-            linearized_refs: Vec::new(),
-            exchange_id_index: HashMap::new(),
+            exchanges: Default::default(),
             root_task_id: root_task_id.clone(),
             optimistic_root_task_id: None,
         };
         store.tasks.insert(root_task_id, root_task);
-        store.rebuild_linearized_refs_index();
+        store.rebuild_exchange_index();
         store
     }
 
@@ -48,12 +47,11 @@ impl TaskStore {
     pub fn from_tasks(tasks: HashMap<TaskId, Task>, root_task_id: TaskId) -> Self {
         let mut store = Self {
             tasks,
-            linearized_refs: Vec::new(),
-            exchange_id_index: HashMap::new(),
+            exchanges: Default::default(),
             root_task_id,
             optimistic_root_task_id: None,
         };
-        store.rebuild_linearized_refs_index();
+        store.rebuild_exchange_index();
         store
     }
 
@@ -83,7 +81,7 @@ impl TaskStore {
             return false;
         };
         task.append_exchange(exchange);
-        self.rebuild_linearized_refs_index();
+        self.rebuild_exchange_index();
         true
     }
 
@@ -96,7 +94,7 @@ impl TaskStore {
     ) -> Option<AIAgentExchange> {
         let task = self.tasks.get_mut(task_id)?;
         let exchange = task.remove_exchange(exchange_id)?;
-        self.rebuild_linearized_refs_index();
+        self.rebuild_exchange_index();
         Some(exchange)
     }
 
@@ -126,7 +124,7 @@ impl TaskStore {
             .map(|t| t.exchanges_len())
             .unwrap_or(0);
         if exchange_count_before != exchange_count_after {
-            self.rebuild_linearized_refs_index();
+            self.rebuild_exchange_index();
         }
         Some(result)
     }
@@ -156,56 +154,35 @@ impl TaskStore {
     }
 
     pub fn exchange_by_id(&self, exchange_id: AIAgentExchangeId) -> Option<&AIAgentExchange> {
-        let exchange_ref = self.exchange_id_index.get(&exchange_id)?;
+        let exchange_ref = self.exchanges.get(&exchange_id)?;
         self.lookup_exchange(exchange_ref)
     }
 
-    pub(super) fn rebuild_exchange_id_index(&mut self) {
-        self.exchange_id_index = self
-            .tasks
-            .values()
-            .flat_map(|task| {
-                let task_id = task.id().clone();
-                task.exchanges()
-                    .enumerate()
-                    .map(move |(exchange_index, exchange)| {
-                        (
-                            exchange.id,
-                            ExchangeRef {
-                                task_id: task_id.clone(),
-                                exchange_index,
-                            },
-                        )
-                    })
-            })
-            .collect();
-    }
-
     pub fn first_exchange(&self) -> Option<&AIAgentExchange> {
-        self.linearized_refs
+        self.exchanges
             .first()
-            .and_then(|r| self.lookup_exchange(r))
+            .and_then(|(_, v)| self.lookup_exchange(v))
     }
 
     pub fn latest_exchange(&self) -> Option<&AIAgentExchange> {
-        self.linearized_refs
+        self.exchanges
             .last()
-            .and_then(|r| self.lookup_exchange(r))
+            .and_then(|(_, v)| self.lookup_exchange(v))
     }
 
     pub fn exchange_count(&self) -> usize {
-        self.linearized_refs.len()
+        self.exchanges.len()
     }
 
     pub fn all_exchanges(&self) -> impl Iterator<Item = &AIAgentExchange> {
-        self.linearized_refs
-            .iter()
+        self.exchanges
+            .values()
             .filter_map(|r| self.lookup_exchange(r))
     }
 
     pub fn all_exchanges_rev(&self) -> impl Iterator<Item = &AIAgentExchange> {
-        self.linearized_refs
-            .iter()
+        self.exchanges
+            .values()
             .rev()
             .filter_map(|r| self.lookup_exchange(r))
     }
@@ -213,7 +190,7 @@ impl TaskStore {
     pub fn all_exchanges_by_task(&self) -> Vec<(TaskId, Vec<&AIAgentExchange>)> {
         let mut result: Vec<(TaskId, Vec<&AIAgentExchange>)> = Vec::new();
 
-        for exchange_ref in &self.linearized_refs {
+        for exchange_ref in self.exchanges.values() {
             let Some(exchange) = self.lookup_exchange(exchange_ref) else {
                 continue;
             };
@@ -234,7 +211,7 @@ impl TaskStore {
     }
 
     pub fn latest_skills(&self) -> Option<Vec<SkillDescriptor>> {
-        self.linearized_refs.iter().rev().find_map(|exchange_ref| {
+        self.exchanges.values().rev().find_map(|exchange_ref| {
             let exchange = self.lookup_exchange(exchange_ref);
 
             if let Some(exchange) = exchange {
@@ -296,12 +273,12 @@ impl TaskStore {
 
     pub fn insert(&mut self, task: Task) {
         self.tasks.insert(task.id().clone(), task);
-        self.rebuild_linearized_refs_index();
+        self.rebuild_exchange_index();
     }
 
     pub fn remove(&mut self, task_id: &TaskId) -> Option<Task> {
         let task = self.tasks.remove(task_id)?;
-        self.rebuild_linearized_refs_index();
+        self.exchanges.retain(|_, r| self.tasks.contains_key(&r.task_id));
         Some(task)
     }
 
@@ -346,7 +323,7 @@ impl TaskStore {
         for id in &to_remove {
             self.tasks.remove(id);
         }
-        self.rebuild_linearized_refs_index();
+        self.exchanges.retain(|_, r| self.tasks.contains_key(&r.task_id));
     }
 
     /// Computes the set of task ids reachable from the root task by following
@@ -382,31 +359,33 @@ impl TaskStore {
     }
 
     /// Rebuilds the linearized index from scratch using DFS traversal.
-    fn rebuild_linearized_refs_index(&mut self) {
-        self.linearized_refs = Self::build_linearized_refs(&self.tasks, &self.root_task_id);
-        self.rebuild_exchange_id_index();
+    pub(super) fn rebuild_exchange_index(&mut self) {
+        self.exchanges = Self::build_exchange_index(&self.tasks, &self.root_task_id);
     }
 
     /// Builds linearized exchange refs via DFS traversal without mutating self.
     /// This allows us to borrow `tasks` immutably throughout the traversal.
-    fn build_linearized_refs(
+    fn build_exchange_index(
         tasks: &HashMap<TaskId, Task>,
         root_task_id: &TaskId,
-    ) -> Vec<ExchangeRef> {
-        let mut refs = Vec::new();
+    ) -> IndexMap<AIAgentExchangeId, ExchangeRef> {
+        let mut refs = IndexMap::new();
 
         fn append_refs_for_task(
             tasks: &HashMap<TaskId, Task>,
-            refs: &mut Vec<ExchangeRef>,
+            refs: &mut IndexMap<AIAgentExchangeId, ExchangeRef>,
             task: &Task,
         ) {
             let task_id = task.id().clone();
 
             for (exchange_index, exchange) in task.exchanges().enumerate() {
-                refs.push(ExchangeRef {
-                    task_id: task_id.clone(),
-                    exchange_index,
-                });
+                refs.insert(
+                    exchange.id,
+                    ExchangeRef {
+                        task_id: task_id.clone(),
+                        exchange_index,
+                    },
+                );
 
                 // Check for subagent calls in the exchange output.
                 if let Some(output) = exchange.output_status.output() {

--- a/app/src/ai/agent/task_store.rs
+++ b/app/src/ai/agent/task_store.rs
@@ -74,14 +74,39 @@ impl TaskStore {
         self.tasks.len()
     }
 
-    /// Appends an exchange to a task and rebuilds the index.
+    /// Appends an exchange to a task and updates the index.
     /// Returns true if the task was found and the exchange was appended.
     pub fn append_exchange(&mut self, task_id: &TaskId, exchange: AIAgentExchange) -> bool {
         let Some(task) = self.tasks.get_mut(task_id) else {
             return false;
         };
+        let exchange_index = task.exchanges_len();
+        let exchange_id = exchange.id;
+        let has_subagent_output = exchange.output_status.output().is_some_and(|output| {
+            output
+                .get()
+                .messages
+                .iter()
+                .any(|m| matches!(m.message, AIAgentOutputMessageType::Subagent(_)))
+        });
         task.append_exchange(exchange);
-        self.rebuild_exchange_index();
+        let is_at_dfs_tail = self
+            .exchanges
+            .last()
+            .map_or(true, |(_, r)| r.task_id == *task_id);
+        // If we know this exchange is going at the end, it's faster to just append it.
+        if is_at_dfs_tail && !has_subagent_output {
+            self.exchanges.insert(
+                exchange_id,
+                ExchangeRef {
+                    task_id: task_id.clone(),
+                    exchange_index,
+                },
+            );
+        } else {
+            // Otherwise, we need to rebuild the whole index.
+            self.rebuild_exchange_index();
+        }
         true
     }
 
@@ -278,7 +303,8 @@ impl TaskStore {
 
     pub fn remove(&mut self, task_id: &TaskId) -> Option<Task> {
         let task = self.tasks.remove(task_id)?;
-        self.exchanges.retain(|_, r| self.tasks.contains_key(&r.task_id));
+        self.exchanges
+            .retain(|_, r| self.tasks.contains_key(&r.task_id));
         Some(task)
     }
 
@@ -323,7 +349,8 @@ impl TaskStore {
         for id in &to_remove {
             self.tasks.remove(id);
         }
-        self.exchanges.retain(|_, r| self.tasks.contains_key(&r.task_id));
+        self.exchanges
+            .retain(|_, r| self.tasks.contains_key(&r.task_id));
     }
 
     /// Computes the set of task ids reachable from the root task by following

--- a/app/src/ai/agent/task_store_tests.rs
+++ b/app/src/ai/agent/task_store_tests.rs
@@ -6,13 +6,13 @@ use uuid::Uuid;
 
 use super::TaskStore;
 use crate::ai::agent::task::{Task, TaskId};
-use crate::test_util::ai_agent_tasks::{create_api_task, create_subagent_tool_call_message};
 use crate::ai::agent::{
     AIAgentExchange, AIAgentExchangeId, AIAgentOutput, AIAgentOutputMessage,
     AIAgentOutputMessageType, AIAgentOutputStatus, FinishedAIAgentOutput, MessageId, Shared,
     SubagentCall,
 };
 use crate::ai::llms::LLMId;
+use crate::test_util::ai_agent_tasks::{create_api_task, create_subagent_tool_call_message};
 
 fn create_test_exchange() -> AIAgentExchange {
     AIAgentExchange {
@@ -798,7 +798,10 @@ fn test_prune_unreachable_subtasks_removes_nested_orphans() {
     store.insert(child_task);
 
     // child → grandchild
-    store.append_exchange(&child_id, create_exchange_with_subagent_call(&grandchild_id));
+    store.append_exchange(
+        &child_id,
+        create_exchange_with_subagent_call(&grandchild_id),
+    );
     store.insert(grandchild);
 
     // root(1) + root→child(1) + child(1) + child→grandchild(1) + grandchild(1) = 5

--- a/app/src/ai/agent/task_store_tests.rs
+++ b/app/src/ai/agent/task_store_tests.rs
@@ -1,10 +1,12 @@
 use std::collections::HashSet;
+use std::iter;
 
 use chrono::Local;
 use uuid::Uuid;
 
 use super::TaskStore;
 use crate::ai::agent::task::{Task, TaskId};
+use crate::test_util::ai_agent_tasks::{create_api_task, create_subagent_tool_call_message};
 use crate::ai::agent::{
     AIAgentExchange, AIAgentExchangeId, AIAgentOutput, AIAgentOutputMessage,
     AIAgentOutputMessageType, AIAgentOutputStatus, FinishedAIAgentOutput, MessageId, Shared,
@@ -429,10 +431,6 @@ fn test_modify_task_conditional_rebuild() {
     assert_eq!(all_ids[2], new_exchange_id);
 }
 
-// =============================================================================
-// Subtask Linearization Tests
-// =============================================================================
-
 #[test]
 fn test_linearization_parent_with_one_subtask() {
     // Create a subtask first so we have its ID
@@ -697,6 +695,129 @@ fn test_exchange_by_id_after_remove_task_exchange_index_shift() {
         store.exchange_by_id(exchange_ids[0]).map(|e| e.id),
         Some(exchange_ids[0])
     );
+}
+
+#[test]
+fn test_prune_unreachable_subtasks_noop_when_no_subtasks() {
+    let root_task = create_test_task_with_exchanges(3);
+    let root_task_id = root_task.id().clone();
+    let mut store = TaskStore::with_root_task(root_task);
+
+    store.prune_unreachable_subtasks();
+
+    assert_eq!(store.task_count(), 1);
+    assert_eq!(store.exchange_count(), 3);
+    assert!(store.get(&root_task_id).is_some());
+}
+
+#[test]
+fn test_prune_unreachable_subtasks_removes_orphan_and_its_exchanges() {
+    // Optimistic root has no api messages, so reachable_task_ids finds nothing
+    // reachable beyond the root itself — any subtask is unreachable.
+    let root_task = create_test_task_with_exchanges(1);
+    let root_task_id = root_task.id().clone();
+    let mut store = TaskStore::with_root_task(root_task);
+
+    let subtask = create_test_subtask_with_exchanges(2);
+    let subtask_id = subtask.id().clone();
+    let subtask_exchange_ids: Vec<_> = subtask.exchanges().map(|e| e.id).collect();
+
+    // Wire the subtask into the exchange DFS so its exchanges appear in the index.
+    let subagent_exchange = create_exchange_with_subagent_call(&subtask_id);
+    store.append_exchange(&root_task_id, subagent_exchange);
+    store.insert(subtask);
+
+    // 1 root + 1 subagent-call exchange + 2 subtask exchanges = 4.
+    assert_eq!(store.task_count(), 2);
+    assert_eq!(store.exchange_count(), 4);
+    assert!(store.exchange_by_id(subtask_exchange_ids[0]).is_some());
+    assert!(store.exchange_by_id(subtask_exchange_ids[1]).is_some());
+
+    store.prune_unreachable_subtasks();
+
+    assert_eq!(store.task_count(), 1);
+    assert!(store.get(&subtask_id).is_none());
+    assert!(!store.contains(&subtask_id));
+    // Subtask exchange refs are gone.
+    assert!(store.exchange_by_id(subtask_exchange_ids[0]).is_none());
+    assert!(store.exchange_by_id(subtask_exchange_ids[1]).is_none());
+    // Root's own exchanges are intact (1 original + 1 subagent-call).
+    assert_eq!(store.exchange_count(), 2);
+}
+
+#[test]
+fn test_prune_unreachable_subtasks_keeps_reachable_subtask() {
+    // Server root with an api message containing a subagent tool call — the
+    // subtask is reachable via reachable_task_ids and must survive the prune.
+    let subtask_id_str = "subtask_reachable";
+    let root_api = create_api_task(
+        "root_server",
+        vec![create_subagent_tool_call_message(
+            "msg1",
+            "root_server",
+            subtask_id_str,
+            None,
+        )],
+    );
+    let root_task = Task::new_restored_root(root_api, iter::empty());
+    let mut store = TaskStore::with_root_task(root_task);
+
+    let subtask_api = create_api_task(subtask_id_str, vec![]);
+    let subtask = Task::new_restored_root(subtask_api, iter::empty());
+    let subtask_task_id = subtask.id().clone();
+    store.insert(subtask);
+
+    assert_eq!(store.task_count(), 2);
+
+    store.prune_unreachable_subtasks();
+
+    // Subtask is reachable — must not be removed.
+    assert_eq!(store.task_count(), 2);
+    assert!(store.get(&subtask_task_id).is_some());
+    assert!(store.contains(&subtask_task_id));
+}
+
+#[test]
+fn test_prune_unreachable_subtasks_removes_nested_orphans() {
+    // Optimistic root → child (has subagent-call exchange → grandchild).
+    // root has no api messages, so neither child nor grandchild is reachable.
+    let grandchild = create_test_subtask_with_exchanges(1);
+    let grandchild_id = grandchild.id().clone();
+    let grandchild_exchange_id = grandchild.exchanges().next().unwrap().id;
+
+    let child_task = create_test_subtask_with_exchanges(1);
+    let child_id = child_task.id().clone();
+    let child_exchange_id = child_task.exchanges().next().unwrap().id;
+
+    let root_task = create_test_task_with_exchanges(1);
+    let root_task_id = root_task.id().clone();
+    let mut store = TaskStore::with_root_task(root_task);
+
+    // root → child
+    store.append_exchange(&root_task_id, create_exchange_with_subagent_call(&child_id));
+    store.insert(child_task);
+
+    // child → grandchild
+    store.append_exchange(&child_id, create_exchange_with_subagent_call(&grandchild_id));
+    store.insert(grandchild);
+
+    // root(1) + root→child(1) + child(1) + child→grandchild(1) + grandchild(1) = 5
+    assert_eq!(store.task_count(), 3);
+    assert_eq!(store.exchange_count(), 5);
+    assert!(store.exchange_by_id(child_exchange_id).is_some());
+    assert!(store.exchange_by_id(grandchild_exchange_id).is_some());
+
+    store.prune_unreachable_subtasks();
+
+    assert_eq!(store.task_count(), 1);
+    assert!(store.get(&child_id).is_none());
+    assert!(!store.contains(&child_id));
+    assert!(store.get(&grandchild_id).is_none());
+    assert!(!store.contains(&grandchild_id));
+    assert!(store.exchange_by_id(child_exchange_id).is_none());
+    assert!(store.exchange_by_id(grandchild_exchange_id).is_none());
+    // Only root's own exchanges remain (1 original + 1 subagent-call to child).
+    assert_eq!(store.exchange_count(), 2);
 }
 
 #[test]

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -121,9 +121,10 @@ use crate::terminal::cli_agent_sessions::plugin_manager::PluginModalKind;
 use crate::terminal::focus_env::add_session_focus_env_vars;
 use crate::terminal::general_settings::{GeneralSettings, GeneralSettingsChangedEvent};
 #[cfg(feature = "local_tty")]
+use crate::terminal::local_tty::TerminalManager as LocalTtyTerminalManager;
+#[cfg(all(feature = "local_tty", not(feature = "remote_tty")))]
 use crate::terminal::local_tty::{
-    create_terminal_view_surface, terminal_view_restored_blocks,
-    TerminalManager as LocalTtyTerminalManager, TerminalViewSurfaceConfig,
+    create_terminal_view_surface, terminal_view_restored_blocks, TerminalViewSurfaceConfig,
 };
 use crate::terminal::model::session::Session;
 use crate::terminal::model::terminal_model::ConversationTranscriptViewerStatus;


### PR DESCRIPTION
## Description

This PR is a follow-up to #13111.

We already had 2 fields on the `TaskStore` that needed to be kept in sync, `tasks` and `linearized_refs`. In #13111 I added yet-another field that needed to be kept in sync, `exchange_id_index`. There were also a couple of obvious optimizations for re-building the new `exchange_id_index` which I hadn't done.

This was not a good way to do this. Instead, I propose combining `linearized_refs` and `exchange_id_index` into a single field `exchanges: IndexMap<AIAgentExchangeId, ExchangeRef>`. This reduces the number of different data structures that need to be maintained into a single one that supports both ordering as in a `Vec` and constant-time lookup via the key as in a `HashMap`.

I've also implemented `TaskStore::remove` and `append_exchange` in a way that avoids rebuilding the index.


## Testing

Added a few unit tests for a method that wasn't tested.
