### PR TITLE
fix(ci): scope fork guard to repository owner so synced workflows run on warp-internal

### DIFF
--- a/.github/workflows/check_approvals.yml
+++ b/.github/workflows/check_approvals.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check OWNERS approval
     runs-on: ubuntu-latest
     # Skip draft PRs.
-    if: github.event.pull_request.draft == false && github.repository == 'warpdotdev/warp'
+    if: github.event.pull_request.draft == false && github.repository_owner == 'warpdotdev'
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     if: >-
       github.event.pull_request.draft == false &&
       (!startsWith(github.event.pull_request.head.ref, 'repo-sync/') || contains(github.event.pull_request.labels.*.name, 'repo-sync:conflict')) &&
-      github.repository == 'warpdotdev/warp'
+      github.repository_owner == 'warpdotdev'
     outputs:
       affects-database-schema: ${{ github.ref == 'master' || steps.filter.outputs.affects-database-schema }}
       affects-rust-sources: ${{ github.ref == 'master' || steps.filter.outputs.affects-rust-sources }}

--- a/.github/workflows/close_stale_fix_prs.yml
+++ b/.github/workflows/close_stale_fix_prs.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   close-stale-fix-prs:
     runs-on: ubuntu-latest
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     steps:
       - name: Close Stale Fix PRs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/cut_new_releases.yml
+++ b/.github/workflows/cut_new_releases.yml
@@ -30,7 +30,7 @@ jobs:
   get_config:
     name: Get release configuration
     runs-on: ubuntu-latest
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     env:
       SCHEDULE: ${{ github.event.schedule }}
       TARGETS: ${{ inputs.targets }}

--- a/.github/workflows/feature_flag_cleanup.yml
+++ b/.github/workflows/feature_flag_cleanup.yml
@@ -14,7 +14,7 @@ jobs:
   analyze:
     name: Analyze feature flags
     runs-on: namespace-profile-ubuntu-small
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/label_external_contributors.yml
+++ b/.github/workflows/label_external_contributors.yml
@@ -28,7 +28,7 @@ jobs:
   label-external-contributor:
     name: Label external-contributor PRs
     runs-on: ubuntu-latest
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/populate_build_cache.yml
+++ b/.github/workflows/populate_build_cache.yml
@@ -22,6 +22,6 @@ name: Populate Build Cache
 jobs:
   populate_build_cache:
     name: CI
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     uses: ./.github/workflows/ci.yml
     secrets: inherit

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   sync:
-    if: (github.event_name == 'push' || inputs.action == 'sync') && github.repository == 'warpdotdev/warp'
+    if: (github.event_name == 'push' || inputs.action == 'sync') && github.repository_owner == 'warpdotdev'
     uses: warpdotdev/repo-sync/.github/workflows/sync.yml@main
     with:
       repo_sync_ref: main
@@ -36,7 +36,7 @@ jobs:
        github.event.pull_request.merged == true ||
        (github.event.action == 'labeled' && github.event.label.name == 'repo-sync:needs-restack')
       ) &&
-      github.repository == 'warpdotdev/warp'
+      github.repository_owner == 'warpdotdev'
     uses: warpdotdev/repo-sync/.github/workflows/restack.yml@main
     with:
       repo_sync_ref: main
@@ -52,7 +52,7 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.action != 'closed' &&
       startsWith(github.event.pull_request.head.ref, 'repo-sync/') &&
-      github.repository == 'warpdotdev/warp'
+      github.repository_owner == 'warpdotdev'
     uses: warpdotdev/repo-sync/.github/workflows/approve.yml@main
     with:
       repo_sync_ref: main
@@ -63,7 +63,7 @@ jobs:
       approver_app_private_key: ${{ secrets.REPO_SYNC_APPROVER_APP_PRIVATE_KEY }}
 
   escalation:
-    if: inputs.action == 'escalation' && github.repository == 'warpdotdev/warp'
+    if: inputs.action == 'escalation' && github.repository_owner == 'warpdotdev'
     uses: warpdotdev/repo-sync/.github/workflows/escalation.yml@main
     with:
       repo_sync_ref: main

--- a/.github/workflows/stale_requested_changes_prs.yml
+++ b/.github/workflows/stale_requested_changes_prs.yml
@@ -41,7 +41,7 @@ permissions:
 jobs:
   stale-requested-changes:
     runs-on: ubuntu-latest
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/sync-pr-checks.yml
+++ b/.github/workflows/sync-pr-checks.yml
@@ -18,7 +18,7 @@ jobs:
   check:
     name: Verify PR base is the default branch
     runs-on: ubuntu-slim
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     steps:
       - name: Fail if merging a repo-sync branch into another repo-sync branch
         env:

--- a/.github/workflows/update-dedupe-local.yml
+++ b/.github/workflows/update-dedupe-local.yml
@@ -11,7 +11,7 @@ on:
         type: string
 jobs:
   update_dedupe:
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/update-pr-review-local.yml
+++ b/.github/workflows/update-pr-review-local.yml
@@ -11,7 +11,7 @@ on:
         type: string
 jobs:
   update_pr_review:
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/update-triage-local.yml
+++ b/.github/workflows/update-triage-local.yml
@@ -11,7 +11,7 @@ on:
         type: string
 jobs:
   update_triage:
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/warp_cleanup_fix_prs.yml
+++ b/.github/workflows/warp_cleanup_fix_prs.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   close-fix-prs:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'auto-fix-ci') && github.repository == 'warpdotdev/warp'
+    if: contains(github.event.pull_request.labels.*.name, 'auto-fix-ci') && github.repository_owner == 'warpdotdev'
     steps:
       - name: Close Dependent Fix PRs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
## Description

#12396 (2d936650e) added a top-level `if: github.repository == 'warpdotdev/warp'` guard to 14 workflows to prevent them from failing on forks (they reference self-hosted runners, secrets, and internal reusable workflows that forks don't have).

However, all 14 of these workflows are synced to and legitimately run on `warpdotdev/warp-internal` — where `github.repository` is `warpdotdev/warp-internal`, so the guard is false and every job is skipped. The most visible fallout is on Repo Sync: since `pull_request`-triggered workflows evaluate the workflow file from the PR's merge ref, the sync PR carrying the guard change (warp-internal#26818) skipped its own `approve` job, stalling the public→private sync queue (~19 sync PRs stuck open). Had the guard reached warp-internal `master`, it would also have disabled `ci.yml`, `cut_new_releases.yml`, `populate_build_cache.yml`, etc. there — where RCs are cut.

This PR replaces the guard with `github.repository_owner == 'warpdotdev'` in all 14 workflows:
- Still false on forks, which necessarily live under a different owner — preserving the intent of #12396. (Also stronger than a `github.event.repository.fork` check: it covers clone-and-push copies of the repo, not just GitHub forks, and `github.repository_owner` is available in every event context.)
- True on `warpdotdev/warp` **and** `warpdotdev/warp-internal`, restoring the pre-#12396 behavior on internal.

Once this merges, its own sync PR evaluates the corrected guard and should auto-approve normally, unblocking the queue. Any sync PRs that remain stuck may need a one-time manual approve or a `workflow_dispatch` sync.

## Linked Issue
Follow-up to #12396.
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Testing

CI/workflow-only change; not manually testable locally. Verified via the GitHub API that:
- `warpdotdev/warp` and `warpdotdev/warp-internal` both report `fork: false` (neither is a GitHub fork), so an owner check is required to distinguish them from forks.
- All 14 guarded workflows exist in warp-internal and previously ran there (Repo Sync runs succeeded until 2026-07-07 16:22 UTC, skipped after).

No remaining `github.repository ==` comparisons in `.github/workflows/` after this change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation](https://staging.warp.dev/conversation/2fa964be-7052-4e40-9679-fa3174a7a4a8)

Co-Authored-By: Oz <oz-agent@warp.dev>

<!--
CHANGELOG-NONE
-->
