### PR TITLE
Respect team BYO policies in client model UI

### DIFF
--- a/app/src/ai/execution_profiles/model_menu_items.rs
+++ b/app/src/ai/execution_profiles/model_menu_items.rs
@@ -7,12 +7,12 @@ use warpui::elements::{
     Text,
 };
 use warpui::fonts::{Properties, Style};
-use warpui::{Action, AppContext, Element, SingletonEntity as _};
+use warpui::{Action, AppContext, Element};
 
 use crate::ai::custom_model_routers::is_custom_router_id;
 use crate::ai::llms::{
-    is_using_api_key_for_provider, should_show_bedrock_icon_for_model, DisableReason, LLMId,
-    LLMInfo, LLMPreferences,
+    should_show_bedrock_icon_for_model, should_show_key_icon_for_model, DisableReason, LLMId,
+    LLMInfo,
 };
 use crate::menu::{MenuItem, MenuItemFields, MenuTooltipPosition};
 
@@ -83,11 +83,8 @@ fn make_item_fields<A: Action + Clone>(
     } else {
         llm.menu_display_name()
     };
-    let is_custom_endpoint = LLMPreferences::as_ref(app)
-        .custom_llm_info_for_id(&llm.id)
-        .is_some();
     let is_using_bedrock = should_show_bedrock_icon_for_model(llm, app);
-    let is_using_api_key = is_custom_endpoint || is_using_api_key_for_provider(&llm.provider, app);
+    let is_using_api_key = should_show_key_icon_for_model(llm, app);
     let is_custom_router = is_custom_router_id(llm.id.as_str());
     let leading_icon = if is_using_bedrock {
         Icon::Aws

--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -74,8 +74,6 @@ pub fn first_party_key_source_for_provider(
     None
 }
 
-/// Returns true when inference for a first-party provider will use either an
-/// allowed member-provided key or a team-managed key configured by an admin.
 pub fn is_using_first_party_key_for_provider(provider: &LLMProvider, app: &AppContext) -> bool {
     first_party_key_source_for_provider(provider, app).is_some()
 }

--- a/app/src/ai/llms.rs
+++ b/app/src/ai/llms.rs
@@ -42,6 +42,100 @@ pub fn is_using_api_key_for_provider(provider: &LLMProvider, app: &AppContext) -
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ByoKeySource {
+    UserProvided,
+    TeamProvided,
+}
+
+impl ByoKeySource {
+    pub fn inference_label(self) -> &'static str {
+        match self {
+            ByoKeySource::UserProvided => "Inference via User-provided API key",
+            ByoKeySource::TeamProvided => "Inference via Team-provided API key",
+        }
+    }
+}
+
+/// Returns the first-party key source that will be used for this provider.
+/// Member-provided keys win when team policy allows them; otherwise a
+/// configured team-managed key is used when available.
+pub fn first_party_key_source_for_provider(
+    provider: &LLMProvider,
+    app: &AppContext,
+) -> Option<ByoKeySource> {
+    let workspaces = UserWorkspaces::as_ref(app);
+    if workspaces.are_member_byo_keys_allowed() && is_using_api_key_for_provider(provider, app) {
+        return Some(ByoKeySource::UserProvided);
+    }
+    if is_using_team_first_party_key_for_provider(provider, app) {
+        return Some(ByoKeySource::TeamProvided);
+    }
+    None
+}
+
+/// Returns true when inference for a first-party provider will use either an
+/// allowed member-provided key or a team-managed key configured by an admin.
+pub fn is_using_first_party_key_for_provider(provider: &LLMProvider, app: &AppContext) -> bool {
+    first_party_key_source_for_provider(provider, app).is_some()
+}
+
+fn is_using_team_first_party_key_for_provider(provider: &LLMProvider, app: &AppContext) -> bool {
+    UserWorkspaces::as_ref(app)
+        .current_workspace()
+        .is_some_and(|workspace| {
+            workspace.billing_metadata.is_managed_byok_byoe_enabled()
+                && workspace
+                    .settings
+                    .team_byo
+                    .as_ref()
+                    .is_some_and(|team_byo| {
+                        team_byo.first_party_enabled
+                            && team_byo
+                                .first_party_keys
+                                .iter()
+                                .any(|key| key.provider == *provider)
+                    })
+        })
+}
+
+pub fn byo_key_source_for_model(llm: &LLMInfo, app: &AppContext) -> Option<ByoKeySource> {
+    let is_custom_endpoint = LLMPreferences::as_ref(app)
+        .custom_llm_info_for_id(&llm.id)
+        .is_some();
+    if is_custom_endpoint && UserWorkspaces::as_ref(app).are_member_byo_endpoints_allowed() {
+        return Some(ByoKeySource::UserProvided);
+    }
+    if is_using_team_byo_endpoint_for_model(llm, app) {
+        return Some(ByoKeySource::TeamProvided);
+    }
+    first_party_key_source_for_provider(&llm.provider, app)
+}
+
+fn is_using_team_byo_endpoint_for_model(llm: &LLMInfo, app: &AppContext) -> bool {
+    UserWorkspaces::as_ref(app)
+        .current_workspace()
+        .is_some_and(|workspace| {
+            workspace.billing_metadata.is_managed_byok_byoe_enabled()
+                && workspace
+                    .settings
+                    .team_byo
+                    .as_ref()
+                    .is_some_and(|team_byo| {
+                        team_byo.endpoints_enabled
+                            && team_byo.endpoints.iter().any(|endpoint| {
+                                endpoint.enabled
+                                    && endpoint.models.iter().any(|model| {
+                                        model.enabled && model.config_key == llm.id.as_str()
+                                    })
+                            })
+                    })
+        })
+}
+
+pub fn should_show_key_icon_for_model(llm: &LLMInfo, app: &AppContext) -> bool {
+    byo_key_source_for_model(llm, app).is_some()
+}
 pub fn should_show_bedrock_icon_for_model(llm: &LLMInfo, app: &AppContext) -> bool {
     UserWorkspaces::as_ref(app).is_aws_bedrock_credentials_enabled(app)
         && llm
@@ -108,7 +202,7 @@ impl DisableReason {
 /// or disabled for a reason that doesn't block requests (see
 /// [`DisableReason::should_clear_preference`]).
 fn is_usable_llm(info: &LLMInfo, app: &AppContext) -> bool {
-    let has_byok_key = is_using_api_key_for_provider(&info.provider, app);
+    let has_byok_key = is_using_first_party_key_for_provider(&info.provider, app);
     info.disable_reason
         .as_ref()
         .is_none_or(|reason| !reason.should_clear_preference(has_byok_key))
@@ -1048,7 +1142,8 @@ impl LLMPreferences {
     }
 
     fn custom_inference_enabled(app: &AppContext) -> bool {
-        UserWorkspaces::as_ref(app).is_custom_inference_enabled(app)
+        let workspaces = UserWorkspaces::as_ref(app);
+        workspaces.is_custom_inference_enabled(app) && workspaces.are_member_byo_endpoints_allowed()
     }
 
     /// Resolves a custom model router by its `config_key`/`LLMId`.

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -8417,7 +8417,11 @@ impl ApiKeysWidget {
             .finish()
     }
 
-    fn render_custom_inference_info_icon(&self, appearance: &Appearance) -> Box<dyn Element> {
+    fn render_custom_inference_info_icon(
+        &self,
+        appearance: &Appearance,
+        managed_byok_byoe_enabled: bool,
+    ) -> Box<dyn Element> {
         let icon = Container::new(
             ConstrainedBox::new(
                 Icon::Info
@@ -8430,15 +8434,23 @@ impl ApiKeysWidget {
         )
         .finish();
 
-        let tooltip_text = FormattedText::new([FormattedTextLine::Line(vec![
-            FormattedTextFragment::plain_text(
-                "By using BYOK or custom endpoints, you agree to use them only as permitted by ",
-            ),
-            FormattedTextFragment::hyperlink("Warp's Terms of Service", CUSTOM_INFERENCE_TERMS_URL),
-            FormattedTextFragment::plain_text(
-                ". BYOK and custom endpoints are intended for individual use and small teams. Companies or organizations with more than 10 employees should use Warp Business or Enterprise.",
-            ),
-        ])]);
+        let tooltip_text = if managed_byok_byoe_enabled {
+            FormattedText::new([FormattedTextLine::Line(vec![
+                FormattedTextFragment::plain_text(
+                    "Custom inference settings are managed by your organization.",
+                ),
+            ])])
+        } else {
+            FormattedText::new([FormattedTextLine::Line(vec![
+                FormattedTextFragment::plain_text(
+                    "By using BYOK or custom endpoints, you agree to use them only as permitted by ",
+                ),
+                FormattedTextFragment::hyperlink("Warp's Terms of Service", CUSTOM_INFERENCE_TERMS_URL),
+                FormattedTextFragment::plain_text(
+                    ". BYOK and custom endpoints are intended for individual use and small teams. Companies or organizations with more than 10 employees should use Warp Business or Enterprise.",
+                ),
+            ])])
+        };
         let tooltip_background = appearance.theme().tooltip_background();
 
         let info_button =
@@ -8771,6 +8783,9 @@ impl SettingsWidget for ApiKeysWidget {
         let show_custom_inference_section = show_provider_keys || show_custom_inference;
         let custom_inference_section_enabled =
             provider_keys_enabled || custom_inference_controls_enabled;
+        let managed_byok_byoe_enabled = UserWorkspaces::as_ref(app)
+            .current_workspace()
+            .is_some_and(|workspace| workspace.billing_metadata.is_managed_byok_byoe_enabled());
 
         let mut column = Flex::column().with_child(render_separator(appearance));
 
@@ -8790,7 +8805,9 @@ impl SettingsWidget for ApiKeysWidget {
                     .with_margin_bottom(0.)
                     .finish(),
                 )
-                .with_child(self.render_custom_inference_info_icon(appearance))
+                .with_child(
+                    self.render_custom_inference_info_icon(appearance, managed_byok_byoe_enabled),
+                )
                 .finish();
 
             let header_row = Flex::row()

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -8917,8 +8917,8 @@ impl SettingsWidget for ApiKeysWidget {
             }
         }
 
-        // Warp credit fallback toggle (shown when BYO or custom inference is enabled)
-        if (is_byo_enabled && show_provider_keys) || show_custom_inference {
+        // Warp credit fallback applies to member-provided API keys, not custom endpoints.
+        if is_byo_enabled && show_provider_keys {
             column.add_child(
                 Container::new(self.render_warp_credit_fallback_toggle(view, app))
                     .with_margin_top(16.)

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -8396,6 +8396,7 @@ impl ApiKeysWidget {
         .finish()
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn render_api_key_input(
         &self,
         appearance: &Appearance,

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -8855,6 +8855,21 @@ impl SettingsWidget for ApiKeysWidget {
                 show_custom_inference,
                 app,
             ));
+        } else if managed_byok_byoe_enabled {
+            column.add_child(
+                build_sub_header(
+                    appearance,
+                    "Custom Inference",
+                    Some(styles::header_font_color(is_any_ai_enabled, app)),
+                )
+                .with_padding_bottom(HEADER_PADDING)
+                .finish(),
+            );
+            column.add_child(render_ai_setting_description(
+                "Your organization manages custom inference. Personal API keys and custom endpoints are currently unavailable.",
+                is_any_ai_enabled,
+                app,
+            ));
         } else {
             // Fallback: old "API Keys" header only
             column.add_child(

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -8811,13 +8811,13 @@ impl SettingsWidget for ApiKeysWidget {
         let mut column = Flex::column().with_child(render_separator(appearance));
 
         if show_custom_inference_section {
-            // Header row: "Custom inference" + info icon on left, "+ Add custom model" on right
+            // Header row: "Custom Inference" + info icon on left, "+ Add custom model" on right
             let header_left = Flex::row()
                 .with_cross_axis_alignment(CrossAxisAlignment::Center)
                 .with_child(
                     build_sub_header(
                         appearance,
-                        "Custom inference",
+                        "Custom Inference",
                         Some(styles::header_font_color(
                             custom_inference_section_enabled,
                             app,

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -8400,7 +8400,7 @@ impl ApiKeysWidget {
 
         if show_provider_keys {
             add_paragraph(vec![FormattedTextFragment::plain_text(
-                "Use your own API keys from model providers for Warp Agent. Adding an API key here will override any API key provided by your team admin. Models that use neither a personal nor team-provided key may consume Warp credits.",
+                "Use your own API keys from model providers for Warp Agent. API keys are used to make requests to your chosen model provider. Using auto models or models you do not have available API keys for will consume Warp credits.",
             )]);
         }
 
@@ -8412,7 +8412,7 @@ impl ApiKeysWidget {
 
         if show_provider_keys || show_custom_endpoints {
             add_paragraph(vec![FormattedTextFragment::plain_text(
-                "API keys and custom endpoint credentials you add here are stored only on this device, not on Warp's servers.",
+                "API keys added here are stored only on this device, not on Warp's servers.",
             )]);
             add_paragraph(vec![FormattedTextFragment::hyperlink(
                 "Learn more",

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -8879,6 +8879,60 @@ impl ApiKeysWidget {
     }
 }
 
+/// Visibility and enabled-state rules for the member-facing Custom Inference
+/// settings section (provider API keys + custom endpoints).
+#[derive(Clone, Copy)]
+struct CustomInferenceVisibility {
+    is_any_ai_enabled: bool,
+    is_byo_enabled: bool,
+    show_provider_keys: bool,
+    provider_keys_enabled: bool,
+    show_custom_inference: bool,
+    custom_inference_controls_enabled: bool,
+    managed_byok_byoe_enabled: bool,
+}
+
+impl CustomInferenceVisibility {
+    fn compute(app: &AppContext) -> Self {
+        let workspaces = UserWorkspaces::as_ref(app);
+        let is_any_ai_enabled = AISettings::as_ref(app).is_any_ai_enabled(app);
+        let is_byo_enabled = workspaces.is_byo_api_key_enabled(app);
+        let is_custom_inference_enabled = workspaces.is_custom_inference_enabled(app);
+        let member_byo_keys_allowed = workspaces.are_member_byo_keys_allowed();
+        let member_byo_endpoints_allowed = workspaces.are_member_byo_endpoints_allowed();
+
+        // BYOK: shown even when BYO is off so the upgrade CTA can render.
+        let show_provider_keys = member_byo_keys_allowed;
+        let provider_keys_enabled = show_provider_keys && is_any_ai_enabled && is_byo_enabled;
+
+        // BYOE (custom endpoints).
+        let show_custom_inference = is_custom_inference_enabled && member_byo_endpoints_allowed;
+        let custom_inference_controls_enabled = show_custom_inference && is_any_ai_enabled;
+
+        Self {
+            is_any_ai_enabled,
+            is_byo_enabled,
+            show_provider_keys,
+            provider_keys_enabled,
+            show_custom_inference,
+            custom_inference_controls_enabled,
+            managed_byok_byoe_enabled: workspaces
+                .current_workspace()
+                .is_some_and(|workspace| workspace.billing_metadata.is_managed_byok_byoe_enabled()),
+        }
+    }
+
+    /// Whether any member-facing Custom Inference content renders at all.
+    fn show_section(&self) -> bool {
+        self.show_provider_keys || self.show_custom_inference
+    }
+
+    /// Whether the section header renders in the enabled color.
+    fn section_enabled(&self) -> bool {
+        self.provider_keys_enabled || self.custom_inference_controls_enabled
+    }
+}
+
 impl SettingsWidget for ApiKeysWidget {
     type View = AISettingsPageView;
 
@@ -8892,29 +8946,20 @@ impl SettingsWidget for ApiKeysWidget {
         appearance: &Appearance,
         app: &AppContext,
     ) -> Box<dyn Element> {
-        let ai_settings = AISettings::as_ref(app);
-        let is_any_ai_enabled = ai_settings.is_any_ai_enabled(app);
-        let is_byo_enabled = UserWorkspaces::as_ref(app).is_byo_api_key_enabled(app);
-        let is_custom_inference_enabled =
-            UserWorkspaces::as_ref(app).is_custom_inference_enabled(app);
-        let member_byo_keys_allowed = UserWorkspaces::as_ref(app).are_member_byo_keys_allowed();
-        let member_byo_endpoints_allowed =
-            UserWorkspaces::as_ref(app).are_member_byo_endpoints_allowed();
-        let provider_keys_enabled = is_any_ai_enabled && is_byo_enabled && member_byo_keys_allowed;
-        let show_provider_keys = member_byo_keys_allowed;
-        let custom_inference_controls_enabled =
-            is_any_ai_enabled && is_custom_inference_enabled && member_byo_endpoints_allowed;
-        let show_custom_inference = is_custom_inference_enabled && member_byo_endpoints_allowed;
-        let show_custom_inference_section = show_provider_keys || show_custom_inference;
-        let custom_inference_section_enabled =
-            provider_keys_enabled || custom_inference_controls_enabled;
-        let managed_byok_byoe_enabled = UserWorkspaces::as_ref(app)
-            .current_workspace()
-            .is_some_and(|workspace| workspace.billing_metadata.is_managed_byok_byoe_enabled());
+        let visibility = CustomInferenceVisibility::compute(app);
+        let CustomInferenceVisibility {
+            is_any_ai_enabled,
+            is_byo_enabled,
+            show_provider_keys,
+            provider_keys_enabled,
+            show_custom_inference,
+            custom_inference_controls_enabled,
+            managed_byok_byoe_enabled,
+        } = visibility;
 
         let mut column = Flex::column().with_child(render_separator(appearance));
 
-        if show_custom_inference_section {
+        if visibility.show_section() {
             // Header row: "Custom Inference" + info icon on left, "+ Add custom model" on right
             let header_left = Flex::row()
                 .with_cross_axis_alignment(CrossAxisAlignment::Center)
@@ -8922,10 +8967,7 @@ impl SettingsWidget for ApiKeysWidget {
                     build_sub_header(
                         appearance,
                         "Custom Inference",
-                        Some(styles::header_font_color(
-                            custom_inference_section_enabled,
-                            app,
-                        )),
+                        Some(styles::header_font_color(visibility.section_enabled(), app)),
                     )
                     .with_margin_bottom(0.)
                     .finish(),
@@ -8970,7 +9012,7 @@ impl SettingsWidget for ApiKeysWidget {
                 .finish(),
             );
             column.add_child(render_ai_setting_description(
-                "Your organization manages custom inference. Personal API keys and custom endpoints are currently unavailable.",
+                "Your organization manages custom inference. Personal API keys and custom endpoints are currently disabled.",
                 is_any_ai_enabled,
                 app,
             ));

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -9060,12 +9060,22 @@ impl SettingsWidget for ApiKeysWidget {
                     .with_margin_bottom(8.)
                     .finish(),
                 );
-                column.add_child(self.render_custom_endpoints_list(
+                let endpoints_list = self.render_custom_endpoints_list(
                     view,
                     appearance,
                     custom_inference_controls_enabled,
                     app,
-                ));
+                );
+                // When the provider-key rows are hidden, this list is the
+                // section's last child, so pad it from the next separator.
+                let endpoints_list = if show_provider_keys {
+                    endpoints_list
+                } else {
+                    Container::new(endpoints_list)
+                        .with_margin_bottom(16.)
+                        .finish()
+                };
+                column.add_child(endpoints_list);
             }
         }
 

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -1738,8 +1738,9 @@ impl AISettingsPageView {
         });
 
         // Custom inference
-        let custom_inference_controls_enabled =
-            is_any_ai_enabled && UserWorkspaces::as_ref(ctx).is_custom_inference_enabled(ctx);
+        let custom_inference_controls_enabled = is_any_ai_enabled
+            && UserWorkspaces::as_ref(ctx).is_custom_inference_enabled(ctx)
+            && UserWorkspaces::as_ref(ctx).are_member_byo_endpoints_allowed();
         let custom_inference_add_button = ctx.add_typed_action_view(|_| {
             ActionButton::new("+ Add custom model", SecondaryTheme)
                 .with_size(ButtonSize::Small)
@@ -2284,6 +2285,7 @@ impl AISettingsPageView {
     fn can_use_custom_inference_controls(app: &AppContext) -> bool {
         AISettings::as_ref(app).is_any_ai_enabled(app)
             && UserWorkspaces::as_ref(app).is_custom_inference_enabled(app)
+            && UserWorkspaces::as_ref(app).are_member_byo_endpoints_allowed()
     }
 
     fn show_add_custom_endpoint_modal(&mut self, ctx: &mut ViewContext<Self>) {
@@ -8085,6 +8087,7 @@ impl ApiKeysWidget {
         let workspace_handle = UserWorkspaces::handle(ctx);
         let is_any_ai_enabled = ai_settings.is_any_ai_enabled(ctx);
         let is_byo_enabled = workspace_handle.as_ref(ctx).is_byo_api_key_enabled(ctx);
+        let member_byo_keys_allowed = workspace_handle.as_ref(ctx).are_member_byo_keys_allowed();
 
         let ApiKeys {
             openai: openai_key,
@@ -8127,7 +8130,7 @@ impl ApiKeysWidget {
                 });
                 AISettingsPageView::update_editor_interaction_state(
                     $editor.clone(),
-                    is_any_ai_enabled && is_byo_enabled,
+                    is_any_ai_enabled && is_byo_enabled && member_byo_keys_allowed,
                     ctx,
                 );
                 // The default-model prompt is driven off `KeysUpdated` (see the
@@ -8148,10 +8151,12 @@ impl ApiKeysWidget {
                         let is_any_ai_enabled =
                             AISettings::handle(ctx).as_ref(ctx).is_any_ai_enabled(ctx);
                         let is_byo_enabled = workspace.as_ref(ctx).is_byo_api_key_enabled(ctx);
+                        let member_byo_keys_allowed =
+                            workspace.as_ref(ctx).are_member_byo_keys_allowed();
                         let is_enabled = is_any_ai_enabled && is_byo_enabled;
                         let has_key = !editor_clone.as_ref(ctx).is_empty(ctx);
-
-                        // If BYO is disabled, clear the API key from the editor and storage
+                        // If BYO is disabled at the billing layer, clear the API key from the editor and storage.
+                        // Team member policy may hide the controls, but must not delete local keys.
                         if !is_byo_enabled && has_key {
                             editor_clone.update(ctx, |editor, ctx| {
                                 editor.set_buffer_text("", ctx);
@@ -8163,7 +8168,7 @@ impl ApiKeysWidget {
 
                         AISettingsPageView::update_editor_interaction_state(
                             editor_clone.clone(),
-                            is_enabled,
+                            is_enabled && member_byo_keys_allowed,
                             ctx,
                         );
                         ctx.notify();
@@ -8254,7 +8259,10 @@ impl ApiKeysWidget {
         });
         for button in [&grok_connect_button, &grok_disconnect_button] {
             button.update(ctx, |button, ctx| {
-                button.set_disabled(!(is_any_ai_enabled && is_byo_enabled), ctx);
+                button.set_disabled(
+                    !(is_any_ai_enabled && is_byo_enabled && member_byo_keys_allowed),
+                    ctx,
+                );
             });
         }
 
@@ -8265,9 +8273,13 @@ impl ApiKeysWidget {
             if let UserWorkspacesEvent::TeamsChanged = event {
                 let is_any_ai_enabled = AISettings::handle(ctx).as_ref(ctx).is_any_ai_enabled(ctx);
                 let is_byo_enabled = workspace.as_ref(ctx).is_byo_api_key_enabled(ctx);
+                let member_byo_keys_allowed = workspace.as_ref(ctx).are_member_byo_keys_allowed();
                 for button in &grok_buttons {
                     button.update(ctx, |button, ctx| {
-                        button.set_disabled(!(is_any_ai_enabled && is_byo_enabled), ctx);
+                        button.set_disabled(
+                            !(is_any_ai_enabled && is_byo_enabled && member_byo_keys_allowed),
+                            ctx,
+                        );
                     });
                 }
                 ctx.notify();
@@ -8369,12 +8381,21 @@ impl ApiKeysWidget {
         column.finish()
     }
 
-    fn render_custom_inference_description(&self, app: &AppContext) -> Box<dyn Element> {
+    fn render_custom_inference_description(
+        &self,
+        show_provider_keys: bool,
+        show_custom_endpoints: bool,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
+        let copy = match (show_provider_keys, show_custom_endpoints) {
+            (true, true) => "Use your own API keys from model providers for Warp Agent. You can also add custom endpoints to use third-party models. Custom endpoints must support the OpenAI-compatible Chat Completions API. API keys are stored only on your device, not on Warp's servers. Adding an API key here will override any API key provided by your team admin. Using auto models or models from providers you have not provided API keys for will consume Warp credits. ",
+            (true, false) => "Use your own API keys from model providers for Warp Agent. API keys are stored only on your device, not on Warp's servers. Adding an API key here will override any API key provided by your team admin. Using auto models or models from providers you have not provided API keys for will consume Warp credits. ",
+            (false, true) => "You can add custom endpoints to use third-party models. Custom endpoints must support the OpenAI-compatible Chat Completions API. API keys are stored only on your device, not on Warp's servers. ",
+            (false, false) => "",
+        };
         let text_fragments = vec![
-            FormattedTextFragment::plain_text(
-                "Use your own API keys from model providers for Warp Agent. You can also add custom endpoints to use third-party models. Custom endpoints must support the OpenAI-compatible Chat Completions API. API keys are stored only on your device, never on Warp's servers. They're used to make requests to your chosen model provider. Using auto models or models from providers you have not provided API keys for will consume Warp credits. ",
-            ),
+            FormattedTextFragment::plain_text(copy),
             FormattedTextFragment::hyperlink("Learn more", CUSTOM_INFERENCE_LEARN_MORE_URL),
         ];
         let description = FormattedTextElement::new(
@@ -8739,13 +8760,21 @@ impl SettingsWidget for ApiKeysWidget {
         let is_byo_enabled = UserWorkspaces::as_ref(app).is_byo_api_key_enabled(app);
         let is_custom_inference_enabled =
             UserWorkspaces::as_ref(app).is_custom_inference_enabled(app);
-        let provider_keys_enabled = is_any_ai_enabled && is_byo_enabled;
-        let custom_inference_controls_enabled = is_any_ai_enabled && is_custom_inference_enabled;
-        let show_custom_inference = is_custom_inference_enabled;
+        let member_byo_keys_allowed = UserWorkspaces::as_ref(app).are_member_byo_keys_allowed();
+        let member_byo_endpoints_allowed =
+            UserWorkspaces::as_ref(app).are_member_byo_endpoints_allowed();
+        let provider_keys_enabled = is_any_ai_enabled && is_byo_enabled && member_byo_keys_allowed;
+        let show_provider_keys = member_byo_keys_allowed;
+        let custom_inference_controls_enabled =
+            is_any_ai_enabled && is_custom_inference_enabled && member_byo_endpoints_allowed;
+        let show_custom_inference = is_custom_inference_enabled && member_byo_endpoints_allowed;
+        let show_custom_inference_section = show_provider_keys || show_custom_inference;
+        let custom_inference_section_enabled =
+            provider_keys_enabled || custom_inference_controls_enabled;
 
         let mut column = Flex::column().with_child(render_separator(appearance));
 
-        if show_custom_inference {
+        if show_custom_inference_section {
             // Header row: "Custom inference" + info icon on left, "+ Add custom model" on right
             let header_left = Flex::row()
                 .with_cross_axis_alignment(CrossAxisAlignment::Center)
@@ -8754,7 +8783,7 @@ impl SettingsWidget for ApiKeysWidget {
                         appearance,
                         "Custom inference",
                         Some(styles::header_font_color(
-                            custom_inference_controls_enabled,
+                            custom_inference_section_enabled,
                             app,
                         )),
                     )
@@ -8768,9 +8797,13 @@ impl SettingsWidget for ApiKeysWidget {
                 .with_main_axis_size(MainAxisSize::Max)
                 .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
                 .with_cross_axis_alignment(CrossAxisAlignment::Center)
-                .with_child(header_left)
-                .with_child(view.custom_inference_add_button.as_ref(app).render(app))
-                .finish();
+                .with_child(header_left);
+            let header_row = if show_custom_inference {
+                header_row.with_child(view.custom_inference_add_button.as_ref(app).render(app))
+            } else {
+                header_row
+            }
+            .finish();
 
             column.add_child(
                 Container::new(header_row)
@@ -8779,7 +8812,11 @@ impl SettingsWidget for ApiKeysWidget {
             );
 
             // Description with Learn more link
-            column.add_child(self.render_custom_inference_description(app));
+            column.add_child(self.render_custom_inference_description(
+                show_provider_keys,
+                show_custom_inference,
+                app,
+            ));
         } else {
             // Fallback: old "API Keys" header only
             column.add_child(
@@ -8793,8 +8830,13 @@ impl SettingsWidget for ApiKeysWidget {
             );
         }
 
-        // Provider key editors (always visible)
-        column.add_child(self.render_provider_key_editors(appearance, provider_keys_enabled, app));
+        if show_provider_keys {
+            column.add_child(self.render_provider_key_editors(
+                appearance,
+                provider_keys_enabled,
+                app,
+            ));
+        }
 
         // Custom endpoints sub-label + list (only when flag on and endpoints non-empty)
         if show_custom_inference {
@@ -8828,7 +8870,7 @@ impl SettingsWidget for ApiKeysWidget {
         }
 
         // Entrypoint for connecting a SuperGrok (xAI) subscription via OAuth.
-        if FeatureFlag::SuperGrok.is_enabled() {
+        if FeatureFlag::SuperGrok.is_enabled() && show_provider_keys {
             #[cfg(not(target_family = "wasm"))]
             let grok_tokens = ApiKeyManager::as_ref(app).grok_tokens();
             #[cfg(not(target_family = "wasm"))]
@@ -8859,7 +8901,7 @@ impl SettingsWidget for ApiKeysWidget {
         }
 
         // Warp credit fallback toggle (shown when BYO or custom inference is enabled)
-        if is_byo_enabled || show_custom_inference {
+        if (is_byo_enabled && show_provider_keys) || show_custom_inference {
             column.add_child(
                 Container::new(self.render_warp_credit_fallback_toggle(view, app))
                     .with_margin_top(16.)
@@ -8868,7 +8910,7 @@ impl SettingsWidget for ApiKeysWidget {
         }
 
         // Upgrade CTA if BYOK not enabled
-        if !is_byo_enabled {
+        if !is_byo_enabled && show_provider_keys {
             let auth_state = AuthStateProvider::as_ref(app).get();
             let upgrade_text_fragments = if let Some(team) =
                 UserWorkspaces::as_ref(app).current_team()

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -8155,8 +8155,10 @@ impl ApiKeysWidget {
                             workspace.as_ref(ctx).are_member_byo_keys_allowed();
                         let is_enabled = is_any_ai_enabled && is_byo_enabled;
                         let has_key = !editor_clone.as_ref(ctx).is_empty(ctx);
-                        // If BYO is disabled at the billing layer, clear the API key from the editor and storage.
-                        // Team member policy may hide the controls, but must not delete local keys.
+                        // Clear stored API keys when BYO is disabled at the billing layer.
+                        // Team member policy is reversible: it only hides and ignores local
+                        // keys. Preserve them so they become usable again if the admin later
+                        // re-enables member BYO.
                         if !is_byo_enabled && has_key {
                             editor_clone.update(ctx, |editor, ctx| {
                                 editor.set_buffer_text("", ctx);
@@ -8388,18 +8390,37 @@ impl ApiKeysWidget {
         app: &AppContext,
     ) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
-        let copy = match (show_provider_keys, show_custom_endpoints) {
-            (true, true) => "Use your own API keys from model providers for Warp Agent. You can also add custom endpoints to use third-party models. Custom endpoints must support the OpenAI-compatible Chat Completions API. API keys are stored only on your device, not on Warp's servers. Adding an API key here will override any API key provided by your team admin. Using auto models or models from providers you have not provided API keys for will consume Warp credits. ",
-            (true, false) => "Use your own API keys from model providers for Warp Agent. API keys are stored only on your device, not on Warp's servers. Adding an API key here will override any API key provided by your team admin. Using auto models or models from providers you have not provided API keys for will consume Warp credits. ",
-            (false, true) => "You can add custom endpoints to use third-party models. Custom endpoints must support the OpenAI-compatible Chat Completions API. API keys are stored only on your device, not on Warp's servers. ",
-            (false, false) => "",
+        let mut lines = Vec::new();
+        let mut add_paragraph = |fragments| {
+            if !lines.is_empty() {
+                lines.push(FormattedTextLine::LineBreak);
+            }
+            lines.push(FormattedTextLine::Line(fragments));
         };
-        let text_fragments = vec![
-            FormattedTextFragment::plain_text(copy),
-            FormattedTextFragment::hyperlink("Learn more", CUSTOM_INFERENCE_LEARN_MORE_URL),
-        ];
+
+        if show_provider_keys {
+            add_paragraph(vec![FormattedTextFragment::plain_text(
+                "Use your own API keys from model providers for Warp Agent. Adding an API key here will override any API key provided by your team admin. Models that use neither a personal nor team-provided key may consume Warp credits.",
+            )]);
+        }
+
+        if show_custom_endpoints {
+            add_paragraph(vec![FormattedTextFragment::plain_text(
+                "Add custom endpoints to use third-party models. Custom endpoints must support the OpenAI-compatible Chat Completions API.",
+            )]);
+        }
+
+        if show_provider_keys || show_custom_endpoints {
+            add_paragraph(vec![FormattedTextFragment::plain_text(
+                "API keys and custom endpoint credentials you add here are stored only on this device, not on Warp's servers.",
+            )]);
+            add_paragraph(vec![FormattedTextFragment::hyperlink(
+                "Learn more",
+                CUSTOM_INFERENCE_LEARN_MORE_URL,
+            )]);
+        }
         let description = FormattedTextElement::new(
-            FormattedText::new([FormattedTextLine::Line(text_fragments)]),
+            FormattedText::new(lines),
             CONTENT_FONT_SIZE,
             appearance.ui_font_family(),
             appearance.ui_font_family(),

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -8075,6 +8075,9 @@ struct ApiKeysWidget {
 
     can_use_warp_credits_for_fallback: SwitchStateHandle,
     upgrade_highlight_index: HighlightedHyperlink,
+    openai_team_key_info_tooltip: MouseStateHandle,
+    anthropic_team_key_info_tooltip: MouseStateHandle,
+    google_team_key_info_tooltip: MouseStateHandle,
 
     custom_inference_info_tooltip: MouseStateHandle,
     custom_inference_terms_index: HighlightedHyperlink,
@@ -8307,17 +8310,98 @@ impl ApiKeysWidget {
 
             can_use_warp_credits_for_fallback: Default::default(),
             upgrade_highlight_index: Default::default(),
+            openai_team_key_info_tooltip: Default::default(),
+            anthropic_team_key_info_tooltip: Default::default(),
+            google_team_key_info_tooltip: Default::default(),
 
             custom_inference_info_tooltip: Default::default(),
             custom_inference_terms_index: Default::default(),
             description_learn_more_index: Default::default(),
         }
     }
+    fn has_team_first_party_key(provider: &LLMProvider, app: &AppContext) -> bool {
+        UserWorkspaces::as_ref(app)
+            .current_workspace()
+            .is_some_and(|workspace| {
+                workspace.billing_metadata.is_managed_byok_byoe_enabled()
+                    && workspace
+                        .settings
+                        .team_byo
+                        .as_ref()
+                        .is_some_and(|team_byo| {
+                            team_byo.first_party_enabled
+                                && team_byo
+                                    .first_party_keys
+                                    .iter()
+                                    .any(|key| key.provider == *provider)
+                        })
+            })
+    }
+
+    fn render_team_key_info_icon(
+        &self,
+        provider: &LLMProvider,
+        mouse_state: MouseStateHandle,
+        appearance: &Appearance,
+    ) -> Box<dyn Element> {
+        let provider_name = provider.display_name();
+        let tooltip_text = FormattedText::new([FormattedTextLine::Line(vec![
+            FormattedTextFragment::plain_text(format!(
+                "Your organization has provided an API key for {provider_name}. A key entered here takes precedence for {provider_name} requests."
+            )),
+        ])]);
+        let tooltip_background = appearance.theme().tooltip_background();
+        let icon_color = appearance.theme().active_ui_text_color();
+
+        Hoverable::new(mouse_state, move |state| {
+            let icon = ConstrainedBox::new(Icon::Info.to_warpui_icon(icon_color).finish())
+                .with_width(13.)
+                .with_height(13.)
+                .finish();
+            let mut stack = Stack::new().with_child(icon);
+            if state.is_hovered() {
+                let tooltip = ConstrainedBox::new(
+                    Container::new(
+                        FormattedTextElement::new(
+                            tooltip_text.clone(),
+                            10.,
+                            appearance.ui_font_family(),
+                            appearance.ui_font_family(),
+                            appearance.theme().background().into_solid(),
+                            HighlightedHyperlink::default(),
+                        )
+                        .finish(),
+                    )
+                    .with_background_color(tooltip_background)
+                    .with_vertical_padding(4.)
+                    .with_horizontal_padding(8.)
+                    .with_border(Border::all(1.).with_border_fill(appearance.theme().outline()))
+                    .with_corner_radius(CornerRadius::with_all(Radius::Pixels(4.)))
+                    .finish(),
+                )
+                .with_max_width(CUSTOM_INFERENCE_INFO_TOOLTIP_MAX_WIDTH)
+                .finish();
+                stack.add_positioned_overlay_child(
+                    tooltip,
+                    OffsetPositioning::offset_from_parent(
+                        vec2f(0., -3.),
+                        ParentOffsetBounds::WindowByPosition,
+                        ParentAnchor::TopMiddle,
+                        ChildAnchor::BottomLeft,
+                    ),
+                );
+            }
+            stack.finish()
+        })
+        .finish()
+    }
 
     fn render_api_key_input(
         &self,
         appearance: &Appearance,
         label: &'static str,
+        provider: LLMProvider,
+        team_key_info_tooltip: MouseStateHandle,
         editor: ViewHandle<EditorView>,
         is_enabled: bool,
         app: &AppContext,
@@ -8337,6 +8421,20 @@ impl ApiKeysWidget {
         let label = Text::new_inline(label, appearance.ui_font_family(), CONTENT_FONT_SIZE)
             .with_color(styles::header_font_color(is_enabled, app).into())
             .finish();
+        let mut label_row = Flex::row()
+            .with_cross_axis_alignment(CrossAxisAlignment::Center)
+            .with_child(label);
+        if Self::has_team_first_party_key(&provider, app) {
+            label_row.add_child(
+                Container::new(self.render_team_key_info_icon(
+                    &provider,
+                    team_key_info_tooltip,
+                    appearance,
+                ))
+                .with_margin_left(4.)
+                .finish(),
+            );
+        }
 
         let input = appearance
             .ui_builder()
@@ -8347,7 +8445,7 @@ impl ApiKeysWidget {
 
         Flex::column()
             .with_spacing(8.)
-            .with_child(label)
+            .with_child(label_row.finish())
             .with_child(input)
             .finish()
     }
@@ -8362,6 +8460,8 @@ impl ApiKeysWidget {
         column.add_child(self.render_api_key_input(
             appearance,
             "OpenAI API key",
+            LLMProvider::OpenAI,
+            self.openai_team_key_info_tooltip.clone(),
             self.openai_api_key_editor.clone(),
             is_enabled,
             app,
@@ -8369,6 +8469,8 @@ impl ApiKeysWidget {
         column.add_child(self.render_api_key_input(
             appearance,
             "Anthropic API key",
+            LLMProvider::Anthropic,
+            self.anthropic_team_key_info_tooltip.clone(),
             self.anthropic_api_key_editor.clone(),
             is_enabled,
             app,
@@ -8376,6 +8478,8 @@ impl ApiKeysWidget {
         column.add_child(self.render_api_key_input(
             appearance,
             "Google API key",
+            LLMProvider::Google,
+            self.google_team_key_info_tooltip.clone(),
             self.google_api_key_editor.clone(),
             is_enabled,
             app,

--- a/app/src/terminal/input/common.rs
+++ b/app/src/terminal/input/common.rs
@@ -15,7 +15,7 @@ use warpui::presenter::ChildView;
 use warpui::ui_components::components::{UiComponent, UiComponentStyles};
 use warpui::{AppContext, EntityId, SingletonEntity, ViewHandle};
 
-use crate::ai::llms::{is_using_api_key_for_provider, LLMPreferences};
+use crate::ai::llms::{should_show_key_icon_for_model, LLMPreferences};
 use crate::ai::{AIRequestUsageModel, BuyCreditsBannerDisplayState};
 use crate::appearance::Appearance;
 use crate::settings::{AISettings, InputSettings};
@@ -496,10 +496,8 @@ pub(super) fn maybe_add_buy_credits_banner(
         ai_request_usage.compute_buy_addon_credits_banner_display_state(app),
         BuyCreditsBannerDisplayState::Hidden
     );
-    let is_using_api_key_for_current_model = is_using_api_key_for_provider(
-        &LLMPreferences::as_ref(app)
-            .get_active_base_model(app, Some(terminal_view_id))
-            .provider,
+    let is_using_api_key_for_current_model = should_show_key_icon_for_model(
+        LLMPreferences::as_ref(app).get_active_base_model(app, Some(terminal_view_id)),
         app,
     );
     if can_purchase_addon_credits

--- a/app/src/terminal/input/models/data_source.rs
+++ b/app/src/terminal/input/models/data_source.rs
@@ -26,8 +26,8 @@ use super::model_spec_scores::{
 use crate::ai::custom_model_routers::is_custom_router_id;
 use crate::ai::execution_profiles::model_menu_items::is_auto;
 use crate::ai::llms::{
-    is_using_api_key_for_provider, should_show_bedrock_icon_for_model, DisableReason, LLMId,
-    LLMInfo, LLMPreferences, LLMProvider, LLMSpec,
+    byo_key_source_for_model, should_show_bedrock_icon_for_model, should_show_key_icon_for_model,
+    ByoKeySource, DisableReason, LLMId, LLMInfo, LLMPreferences, LLMProvider, LLMSpec,
 };
 use crate::auth::AuthStateProvider;
 use crate::features::FeatureFlag;
@@ -273,9 +273,9 @@ struct ModelSearchItem {
     spec: Option<LLMSpec>,
     leading_icon: Icon,
     credential_icon: Option<Icon>,
+    byo_key_source: Option<ByoKeySource>,
     display_text: String,
     is_selected: bool,
-    is_custom_endpoint: bool,
     is_custom_router: bool,
     /// Source/routing description for custom model routers (from `LLMInfo.description`).
     description: Option<String>,
@@ -295,20 +295,16 @@ impl ModelSearchItem {
         // If the model requires an upgrade but the user already has a BYOK key
         // for this provider, treat it as enabled by clearing the disable reason.
         let disable_reason = if llm.disable_reason == Some(DisableReason::RequiresUpgrade)
-            && is_using_api_key_for_provider(&llm.provider, app)
+            && should_show_key_icon_for_model(llm, app)
         {
             None
         } else {
             llm.disable_reason.clone()
         };
-        let is_custom_endpoint = LLMPreferences::as_ref(app)
-            .custom_llm_info_for_id(&llm.id)
-            .is_some();
         let is_custom_router = is_custom_router_id(llm.id.as_str());
         let is_auto = is_auto(llm);
         let is_using_bedrock = should_show_bedrock_icon_for_model(llm, app);
-        let is_using_api_key =
-            is_custom_endpoint || is_using_api_key_for_provider(&llm.provider, app);
+        let byo_key_source = byo_key_source_for_model(llm, app);
         let leading_icon = if is_using_bedrock {
             Icon::Aws
         } else if is_custom_router {
@@ -316,7 +312,7 @@ impl ModelSearchItem {
         } else {
             llm.provider.icon().unwrap_or(Icon::Oz)
         };
-        let credential_icon = if !is_using_bedrock && is_using_api_key {
+        let credential_icon = if !is_using_bedrock && byo_key_source.is_some() {
             Some(Icon::Key)
         } else {
             None
@@ -327,9 +323,9 @@ impl ModelSearchItem {
             spec: llm.spec.clone(),
             leading_icon,
             credential_icon,
+            byo_key_source,
             display_text: llm.display_name.clone(),
             is_selected: &llm.id == active_llm_id,
-            is_custom_endpoint,
             is_custom_router,
             description: llm.description.clone(),
             disable_reason,
@@ -474,7 +470,7 @@ impl SearchItem for ModelSearchItem {
 
         if should_show_discount_chip(
             self.discount_percentage,
-            is_using_api_key_for_provider(&self.provider, app) || self.is_using_bedrock,
+            self.credential_icon.is_some() || self.is_using_bedrock,
         ) {
             let discount_percentage = self.discount_percentage.unwrap_or(0.);
             let chip = Container::new(
@@ -544,9 +540,7 @@ impl SearchItem for ModelSearchItem {
         };
         let header = render_model_spec_header(title, description, app);
 
-        let is_using_api_key =
-            self.is_custom_endpoint || is_using_api_key_for_provider(&self.provider, app);
-        let cost_row = if self.is_using_bedrock || is_using_api_key {
+        let cost_row = if self.is_using_bedrock || self.byo_key_source.is_some() {
             let search_query = if self.is_using_bedrock {
                 "bedrock"
             } else {
@@ -584,6 +578,8 @@ impl SearchItem for ModelSearchItem {
                     "Inference may use Bedrock"
                 } else if self.is_using_bedrock {
                     "Inference via Bedrock"
+                } else if let Some(source) = self.byo_key_source {
+                    source.inference_label()
                 } else {
                     "Inference via API key"
                 },

--- a/app/src/terminal/input/models/model_spec_scores.rs
+++ b/app/src/terminal/input/models/model_spec_scores.rs
@@ -213,7 +213,7 @@ fn render_score_row(
                 .with_main_axis_alignment(MainAxisAlignment::SpaceBetween)
                 .with_cross_axis_alignment(CrossAxisAlignment::Center)
                 .with_child(render_provider_label(label, appearance))
-                .with_child(manage_button)
+                .with_child(Container::new(manage_button).with_margin_left(8.).finish())
                 .finish(),
         )
         .finish(),

--- a/app/src/terminal/profile_model_selector.rs
+++ b/app/src/terminal/profile_model_selector.rs
@@ -46,8 +46,8 @@ use crate::ai::harness_availability::{
     HarnessAvailabilityEvent, HarnessAvailabilityModel, HarnessModelInfo,
 };
 use crate::ai::llms::{
-    dedupe_model_display_names, is_using_api_key_for_provider, LLMId, LLMInfo, LLMPreferences,
-    LLMPreferencesEvent, LLMSpec,
+    byo_key_source_for_model, dedupe_model_display_names, should_show_key_icon_for_model,
+    ByoKeySource, LLMId, LLMInfo, LLMPreferences, LLMPreferencesEvent, LLMSpec,
 };
 use crate::appearance::Appearance;
 use crate::cloud_object::model::generic_string_model::StringModel;
@@ -1072,9 +1072,11 @@ impl ProfileModelSelector {
                 right_side_fields: None,
             });
             for llm in &custom_choices {
-                let fields = MenuItemFields::new(llm.menu_display_name())
-                    .with_right_side_icon(Icon::Key)
+                let mut fields = MenuItemFields::new(llm.menu_display_name())
                     .with_on_select_action(ProfileModelSelectorAction::SelectModel(llm.id.clone()));
+                if should_show_key_icon_for_model(llm, ctx) {
+                    fields = fields.with_right_side_icon(Icon::Key);
+                }
                 items.push(MenuItem::Item(fields));
             }
         }
@@ -1932,7 +1934,11 @@ impl ProfileModelSelector {
         .finish()
     }
 
-    fn render_model_spec_api_key(&self, app: &AppContext) -> Box<dyn Element> {
+    fn render_model_spec_api_key(
+        &self,
+        byo_key_source: ByoKeySource,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
 
@@ -1951,7 +1957,7 @@ impl ProfileModelSelector {
                             .with_child(
                                 Container::new(
                                     Text::new(
-                                        "Billed to API".to_string(),
+                                        byo_key_source.inference_label().to_string(),
                                         appearance.ui_font_family(),
                                         14.,
                                     )
@@ -1975,7 +1981,7 @@ impl ProfileModelSelector {
     fn render_all_model_spec_values(
         &self,
         spec: &LLMSpec,
-        is_using_api_key: bool,
+        byo_key_source: Option<ByoKeySource>,
         bg_bar_color: ColorU,
         app: &AppContext,
     ) -> Box<dyn Element> {
@@ -1988,8 +1994,8 @@ impl ProfileModelSelector {
             ),
             self.render_model_spec_value("Speed".to_string(), spec.speed, bg_bar_color, app),
         ];
-        if is_using_api_key {
-            spec_values.push(self.render_model_spec_api_key(app));
+        if let Some(byo_key_source) = byo_key_source {
+            spec_values.push(self.render_model_spec_api_key(byo_key_source, app));
         } else {
             spec_values.push(self.render_model_spec_value(
                 "Cost".to_string(),
@@ -2005,7 +2011,7 @@ impl ProfileModelSelector {
     fn render_model_spec(
         &self,
         spec: &LLMSpec,
-        is_using_api_key: bool,
+        byo_key_source: Option<ByoKeySource>,
         app: &AppContext,
     ) -> Box<dyn Element> {
         let appearance = Appearance::as_ref(app);
@@ -2017,7 +2023,7 @@ impl ProfileModelSelector {
         );
         let spec = self.render_all_model_spec_values(
             spec,
-            is_using_api_key,
+            byo_key_source,
             internal_colors::neutral_3(theme),
             app,
         );
@@ -2064,7 +2070,7 @@ impl ProfileModelSelector {
         let sidecar_menu = ChildView::new(&self.model_spec_sidecar.dropdown).finish();
         let spec_values = self.render_all_model_spec_values(
             &spec.clone().unwrap_or_default(),
-            false,
+            None,
             internal_colors::neutral_5(theme),
             app,
         );
@@ -2291,8 +2297,8 @@ impl View for ProfileModelSelector {
                         .cloned();
                     Some(self.render_sidecar_spec_panel(&kind, &sidecar_spec, app))
                 } else if let Some(spec) = info.spec.as_ref() {
-                    let is_using_api_key = is_using_api_key_for_provider(&info.provider, app);
-                    Some(self.render_model_spec(spec, is_using_api_key, app))
+                    let byo_key_source = byo_key_source_for_model(info, app);
+                    Some(self.render_model_spec(spec, byo_key_source, app))
                 } else {
                     None
                 };

--- a/app/src/terminal/profile_model_selector.rs
+++ b/app/src/terminal/profile_model_selector.rs
@@ -1966,7 +1966,13 @@ impl ProfileModelSelector {
                                 )
                                 .finish(),
                             )
-                            .with_child(ChildView::new(&self.manage_api_key_button).finish())
+                            .with_child(
+                                Container::new(
+                                    ChildView::new(&self.manage_api_key_button).finish(),
+                                )
+                                .with_margin_left(8.)
+                                .finish(),
+                            )
                             .finish(),
                     )
                     .finish(),

--- a/app/src/workspaces/gql_convert.rs
+++ b/app/src/workspaces/gql_convert.rs
@@ -10,7 +10,7 @@ use warp_graphql::billing::{
     CustomerType as GqlCustomerType, DelinquencyStatus as GqlDelinquencyStatus,
     EnterpriseCreditsAutoReloadPolicy as GqlEnterpriseCreditsAutoReloadPolicy,
     EnterprisePayAsYouGoPolicy as GqlEnterprisePayAsYouGoPolicy, InstanceShape as GqlInstanceShape,
-    MultiAdminPolicy as GqlMultiAdminPolicy,
+    ManagedByokByoePolicy as GqlManagedByokByoePolicy, MultiAdminPolicy as GqlMultiAdminPolicy,
     PurchaseAddOnCreditsPolicy as GqlPurchaseAddOnCreditsPolicy, ServiceAgreementType,
     SessionSharingPolicy as GqlSessionSharingPolicy,
     SharedNotebooksPolicy as GqlSharedNotebooksPolicy,
@@ -30,10 +30,14 @@ use warp_graphql::workspace::{
     AddonCreditsSettings as GqlAddonCreditsSettings,
     AdminEnablementSetting as GqlAdminEnablementSetting, AiAutonomyValue as GqlAiAutonomyValue,
     AiPermissionsSettings as GqlAiPermissionsSettings,
+    ByoEndpointMetadata as GqlByoEndpointMetadata,
+    ByoEndpointModelMetadata as GqlByoEndpointModelMetadata,
+    ByoFirstPartyKey as GqlByoFirstPartyKey,
     ComputerUseAutonomyValue as GqlComputerUseAutonomyValue, EmailInvite as GqlEmailInvite,
     HostEnablementSetting as GqlHostEnablementSetting,
     InviteLinkDomainRestriction as GqlInviteLinkDomainRestriction,
-    MembershipRole as GqlMembershipRole, Team as GqlTeam, TeamMember as GqlTeamMember,
+    MembershipRole as GqlMembershipRole, Team as GqlTeam, TeamByoSettings as GqlTeamByoSettings,
+    TeamMember as GqlTeamMember,
     UgcCollectionEnablementSetting as GqlUgcCollectionEnablementSetting, Workspace as GqlWorkspace,
     WorkspaceMember as GqlWorkspaceMember, WorkspaceMemberUsageInfo as GqlWorkspaceMemberUsageInfo,
     WorkspaceSettings as GqlWorkspaceSettings,
@@ -45,15 +49,15 @@ use super::user_workspaces::WorkspacesMetadataResponse;
 use super::workspace::{
     AIAutonomyPolicy, AddonCreditsSettings, AdminEnablementSetting, AiAutonomySettings,
     AiPermissionsSettings, AmbientAgentsPolicy, BillingCycleUsageData, BillingCycleUsageEntry,
-    BillingCycleUsageSummary, BillingMetadata, CloudConversationStorageSettings,
-    CodebaseContextSettings, CustomerType, DelinquencyStatus, EmailInvite, EnterpriseSecretRegex,
-    HostEnablementSetting, InstanceShape, InviteLinkDomainRestriction, LinkSharingSettings,
-    LlmSettings, MaxPriorCycles, SandboxedAgentSettings, SecretRedactionSettings,
-    SessionSharingPolicy, SharedNotebooksPolicy, SharedWorkflowsPolicy,
-    TelemetryDataCollectionPolicy, TelemetrySettings, Tier, UgcCollectionEnablementSetting,
-    UgcCollectionSettings, UgcDataCollectionPolicy, UsageBasedPricingPolicy,
-    UsageVisibilityGranularity, UsageVisibilityPolicy, WarpAiPolicy, Workspace,
-    WorkspaceInviteCode, WorkspaceMember, WorkspaceMemberUsageInfo, WorkspaceSettings,
+    BillingCycleUsageSummary, BillingMetadata, ByoEndpointMetadata, ByoEndpointModelMetadata,
+    ByoFirstPartyKey, CloudConversationStorageSettings, CodebaseContextSettings, CustomerType,
+    DelinquencyStatus, EmailInvite, EnterpriseSecretRegex, HostEnablementSetting, InstanceShape,
+    InviteLinkDomainRestriction, LinkSharingSettings, LlmSettings, MaxPriorCycles,
+    SandboxedAgentSettings, SecretRedactionSettings, SessionSharingPolicy, SharedNotebooksPolicy,
+    SharedWorkflowsPolicy, TeamByoSettings, TelemetryDataCollectionPolicy, TelemetrySettings, Tier,
+    UgcCollectionEnablementSetting, UgcCollectionSettings, UgcDataCollectionPolicy,
+    UsageBasedPricingPolicy, UsageVisibilityGranularity, UsageVisibilityPolicy, WarpAiPolicy,
+    Workspace, WorkspaceInviteCode, WorkspaceMember, WorkspaceMemberUsageInfo, WorkspaceSettings,
     WorkspaceSizePolicy,
 };
 use crate::ai::blocklist::usage::conversation_usage_view::ConversationUsageInfo;
@@ -69,8 +73,8 @@ use crate::server::ids::ServerId;
 use crate::settings::AgentModeCommandExecutionPredicate;
 use crate::workspaces::workspace::{
     AiOverages, BonusGrantsPurchased, ByoApiKeyPolicy, ByoEndpointPolicy, CodebaseContextPolicy,
-    EnterpriseCreditsAutoReloadPolicy, EnterprisePayAsYouGoPolicy, MultiAdminPolicy,
-    PurchaseAddOnCreditsPolicy, UsageBasedPricingSettings,
+    EnterpriseCreditsAutoReloadPolicy, EnterprisePayAsYouGoPolicy, ManagedByokByoePolicy,
+    MultiAdminPolicy, PurchaseAddOnCreditsPolicy, UsageBasedPricingSettings,
 };
 use crate::{convert_to_server_experiment, report_error};
 
@@ -82,6 +86,64 @@ impl From<GqlTeamMember> for TeamMember {
             uid: UserUid::new(&gql_team_member.uid.into_inner()),
             email: gql_team_member.email,
             role: gql_team_member.role.into(),
+        }
+    }
+}
+
+impl From<GqlManagedByokByoePolicy> for ManagedByokByoePolicy {
+    fn from(gql_managed_byok_byoe_policy: GqlManagedByokByoePolicy) -> ManagedByokByoePolicy {
+        Self {
+            enabled: gql_managed_byok_byoe_policy.enabled,
+        }
+    }
+}
+
+impl From<GqlTeamByoSettings> for TeamByoSettings {
+    fn from(gql_team_byo: GqlTeamByoSettings) -> TeamByoSettings {
+        Self {
+            first_party_enabled: gql_team_byo.first_party_enabled,
+            endpoints_enabled: gql_team_byo.endpoints_enabled,
+            allow_user_keys: gql_team_byo.allow_user_keys,
+            allow_user_endpoints: gql_team_byo.allow_user_endpoints,
+            first_party_keys: gql_team_byo
+                .first_party_keys
+                .into_iter()
+                .map(From::from)
+                .collect(),
+            endpoints: gql_team_byo.endpoints.into_iter().map(From::from).collect(),
+        }
+    }
+}
+
+impl From<GqlByoFirstPartyKey> for ByoFirstPartyKey {
+    fn from(gql_key: GqlByoFirstPartyKey) -> ByoFirstPartyKey {
+        Self {
+            provider: gql_key.provider.into(),
+            credential_uid: gql_key.credential_uid.into_inner(),
+        }
+    }
+}
+
+impl From<GqlByoEndpointMetadata> for ByoEndpointMetadata {
+    fn from(gql_endpoint: GqlByoEndpointMetadata) -> ByoEndpointMetadata {
+        Self {
+            uid: gql_endpoint.uid.into_inner(),
+            name: gql_endpoint.name,
+            enabled: gql_endpoint.enabled,
+            credential_uid: gql_endpoint.credential_uid.into_inner(),
+            models: gql_endpoint.models.into_iter().map(From::from).collect(),
+        }
+    }
+}
+
+impl From<GqlByoEndpointModelMetadata> for ByoEndpointModelMetadata {
+    fn from(gql_model: GqlByoEndpointModelMetadata) -> ByoEndpointModelMetadata {
+        Self {
+            config_key: gql_model.config_key,
+            slug: gql_model.slug,
+            alias: gql_model.alias,
+            display_name: gql_model.display_name,
+            enabled: gql_model.enabled,
         }
     }
 }
@@ -549,6 +611,7 @@ impl From<GqlTier> for Tier {
             codebase_context_policy: gql_tier.codebase_context_policy.map(From::from),
             byo_api_key_policy: gql_tier.byo_api_key_policy.map(From::from),
             byo_endpoint_policy: gql_tier.byo_endpoint_policy.map(From::from),
+            managed_byok_byoe_policy: gql_tier.managed_byok_byoe_policy.map(From::from),
             purchase_add_on_credits_policy: gql_tier.purchase_add_on_credits_policy.map(From::from),
             enterprise_pay_as_you_go_policy: gql_tier
                 .enterprise_pay_as_you_go_policy
@@ -810,6 +873,7 @@ impl From<GqlWorkspaceSettings> for WorkspaceSettings {
     fn from(gql_workspace_settings: GqlWorkspaceSettings) -> WorkspaceSettings {
         Self {
             llm_settings: gql_workspace_settings.llm_settings.into(),
+            team_byo: gql_workspace_settings.team_byo.map(From::from),
             telemetry_settings: TelemetrySettings {
                 force_enabled: gql_workspace_settings.telemetry_settings.force_enabled,
             },

--- a/app/src/workspaces/user_workspaces.rs
+++ b/app/src/workspaces/user_workspaces.rs
@@ -491,6 +491,23 @@ impl UserWorkspaces {
             .map(|workspace| workspace.is_byo_api_key_enabled())
             .unwrap_or(FeatureFlag::SoloUserByok.is_enabled())
     }
+
+    /// Whether the current workspace's managed BYOK/BYOE policy allows members
+    /// to use their own provider API keys. Users with no workspace, or
+    /// workspaces without the managed BYOK/BYOE policy, have no team-level
+    /// restriction, so this returns true and the normal BYO entitlement applies.
+    pub fn are_member_byo_keys_allowed(&self) -> bool {
+        self.current_workspace().is_none_or(|workspace| {
+            !workspace.billing_metadata.is_managed_byok_byoe_enabled()
+                || workspace
+                    .settings
+                    .team_byo
+                    .as_ref()
+                    .is_some_and(|team_byo| {
+                        team_byo.first_party_enabled && team_byo.allow_user_keys
+                    })
+        })
+    }
     /// Whether custom inference endpoints are enabled for the current user.
     /// Anonymous or logged-out users are not allowed to use custom inference.
     /// Controlled by the BYO_ENDPOINT billing policy.
@@ -505,6 +522,23 @@ impl UserWorkspaces {
         self.current_workspace()
             .map(|workspace| workspace.billing_metadata.is_byo_endpoint_enabled())
             .unwrap_or(true)
+    }
+
+    /// Whether the current workspace's managed BYOK/BYOE policy allows members
+    /// to use their own custom endpoints. Users with no workspace, or
+    /// workspaces without the managed BYOK/BYOE policy, have no team-level
+    /// restriction, so this returns true and the normal BYO entitlement applies.
+    pub fn are_member_byo_endpoints_allowed(&self) -> bool {
+        self.current_workspace().is_none_or(|workspace| {
+            !workspace.billing_metadata.is_managed_byok_byoe_enabled()
+                || workspace
+                    .settings
+                    .team_byo
+                    .as_ref()
+                    .is_some_and(|team_byo| {
+                        team_byo.endpoints_enabled && team_byo.allow_user_endpoints
+                    })
+        })
     }
 
     pub fn aws_bedrock_host_settings(&self) -> Option<&super::workspace::LlmHostSettings> {

--- a/app/src/workspaces/workspace.rs
+++ b/app/src/workspaces/workspace.rs
@@ -14,7 +14,7 @@ use super::team::{MembershipRole, Team};
 use crate::ai::execution_profiles::{
     ActionPermission, ComputerUsePermission, WriteToPtyPermission,
 };
-use crate::ai::llms::LLMModelHost;
+use crate::ai::llms::{LLMModelHost, LLMProvider};
 use crate::auth::UserUid;
 use crate::server::ids::ServerId;
 use crate::settings::AgentModeCommandExecutionPredicate;
@@ -382,6 +382,11 @@ pub struct ByoEndpointPolicy {
 }
 
 #[derive(Clone, Debug, Copy, Serialize, Deserialize)]
+pub struct ManagedByokByoePolicy {
+    pub enabled: bool,
+}
+
+#[derive(Clone, Debug, Copy, Serialize, Deserialize)]
 pub struct PurchaseAddOnCreditsPolicy {
     pub enabled: bool,
 }
@@ -480,6 +485,7 @@ pub struct Tier {
     pub codebase_context_policy: Option<CodebaseContextPolicy>,
     pub byo_api_key_policy: Option<ByoApiKeyPolicy>,
     pub byo_endpoint_policy: Option<ByoEndpointPolicy>,
+    pub managed_byok_byoe_policy: Option<ManagedByokByoePolicy>,
     pub purchase_add_on_credits_policy: Option<PurchaseAddOnCreditsPolicy>,
     pub enterprise_pay_as_you_go_policy: Option<EnterprisePayAsYouGoPolicy>,
     pub enterprise_credits_auto_reload_policy: Option<EnterpriseCreditsAutoReloadPolicy>,
@@ -715,6 +721,12 @@ impl BillingMetadata {
             .is_some_and(|policy| policy.enabled)
     }
 
+    pub fn is_managed_byok_byoe_enabled(&self) -> bool {
+        self.tier
+            .managed_byok_byoe_policy
+            .is_some_and(|policy| policy.enabled)
+    }
+
     pub fn has_overages_used(&self) -> bool {
         self.ai_overages
             .as_ref()
@@ -918,6 +930,7 @@ pub struct SandboxedAgentSettings {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct WorkspaceSettings {
     pub llm_settings: LlmSettings,
+    pub team_byo: Option<TeamByoSettings>,
     pub telemetry_settings: TelemetrySettings,
     pub ugc_collection_settings: UgcCollectionSettings,
     pub cloud_conversation_storage_settings: CloudConversationStorageSettings,
@@ -937,4 +950,38 @@ pub struct WorkspaceSettings {
     pub enable_warp_attribution: AdminEnablementSetting,
     #[serde(default)]
     pub default_host_slug: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct TeamByoSettings {
+    pub first_party_enabled: bool,
+    pub endpoints_enabled: bool,
+    pub allow_user_keys: bool,
+    pub allow_user_endpoints: bool,
+    pub first_party_keys: Vec<ByoFirstPartyKey>,
+    pub endpoints: Vec<ByoEndpointMetadata>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ByoFirstPartyKey {
+    pub provider: LLMProvider,
+    pub credential_uid: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ByoEndpointMetadata {
+    pub uid: String,
+    pub name: String,
+    pub enabled: bool,
+    pub credential_uid: String,
+    pub models: Vec<ByoEndpointModelMetadata>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ByoEndpointModelMetadata {
+    pub config_key: String,
+    pub slug: String,
+    pub alias: Option<String>,
+    pub display_name: String,
+    pub enabled: bool,
 }

--- a/crates/graphql/src/api/billing.rs
+++ b/crates/graphql/src/api/billing.rs
@@ -107,6 +107,7 @@ pub struct Tier {
     pub codebase_context_policy: Option<CodebaseContextPolicy>,
     pub byo_api_key_policy: Option<ByoApiKeyPolicy>,
     pub byo_endpoint_policy: Option<ByoEndpointPolicy>,
+    pub managed_byok_byoe_policy: Option<ManagedByokByoePolicy>,
     pub purchase_add_on_credits_policy: Option<PurchaseAddOnCreditsPolicy>,
     pub enterprise_pay_as_you_go_policy: Option<EnterprisePayAsYouGoPolicy>,
     pub enterprise_credits_auto_reload_policy: Option<EnterpriseCreditsAutoReloadPolicy>,
@@ -188,6 +189,11 @@ pub struct ByoApiKeyPolicy {
 
 #[derive(cynic::QueryFragment, Debug, Clone)]
 pub struct ByoEndpointPolicy {
+    pub enabled: bool,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+pub struct ManagedByokByoePolicy {
     pub enabled: bool,
 }
 

--- a/crates/graphql/src/api/queries/get_workspaces_metadata_for_user.rs
+++ b/crates/graphql/src/api/queries/get_workspaces_metadata_for_user.rs
@@ -69,6 +69,9 @@ query GetWorkspacesMetadataForUser($requestContext: RequestContext!) {
               byoEndpointPolicy {
                 enabled
               }
+              managedByokByoePolicy {
+                enabled
+              }
               usageVisibilityPolicy {
                 adminGranularity
                 maxPriorCycles
@@ -109,6 +112,29 @@ query GetWorkspacesMetadataForUser($requestContext: RequestContext!) {
             isInviteLinkEnabled
             llmSettings {
               enabled
+            }
+            teamByo {
+              firstPartyEnabled
+              endpointsEnabled
+              allowUserKeys
+              allowUserEndpoints
+              firstPartyKeys {
+                provider
+                credentialUid
+              }
+              endpoints {
+                uid
+                name
+                enabled
+                credentialUid
+                models {
+                  configKey
+                  slug
+                  alias
+                  displayName
+                  enabled
+                }
+              }
             }
             telemetrySettings {
               forceEnabled

--- a/crates/graphql/src/api/workspace.rs
+++ b/crates/graphql/src/api/workspace.rs
@@ -140,6 +140,7 @@ pub struct WorkspaceSettings {
     pub is_discoverable: bool,
     pub is_invite_link_enabled: bool,
     pub llm_settings: LlmSettings,
+    pub team_byo: Option<TeamByoSettings>,
     pub telemetry_settings: TelemetrySettings,
     pub ugc_collection_settings: UgcCollectionSettings,
     pub cloud_conversation_storage_settings: CloudConversationStorageSettings,
@@ -152,6 +153,40 @@ pub struct WorkspaceSettings {
     pub codebase_context_settings: CodebaseContextSettings,
     pub sandboxed_agent_settings: Option<SandboxedAgentSettings>,
     pub ambient_agent_settings: Option<AmbientAgentSettings>,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+pub struct TeamByoSettings {
+    pub first_party_enabled: bool,
+    pub endpoints_enabled: bool,
+    pub allow_user_keys: bool,
+    pub allow_user_endpoints: bool,
+    pub first_party_keys: Vec<ByoFirstPartyKey>,
+    pub endpoints: Vec<ByoEndpointMetadata>,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+pub struct ByoFirstPartyKey {
+    pub provider: LlmProvider,
+    pub credential_uid: cynic::Id,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+pub struct ByoEndpointMetadata {
+    pub uid: cynic::Id,
+    pub name: String,
+    pub enabled: bool,
+    pub credential_uid: cynic::Id,
+    pub models: Vec<ByoEndpointModelMetadata>,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+pub struct ByoEndpointModelMetadata {
+    pub config_key: String,
+    pub slug: String,
+    pub alias: Option<String>,
+    pub display_name: String,
+    pub enabled: bool,
 }
 
 #[derive(cynic::QueryFragment, Debug, Clone)]

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -613,9 +613,33 @@ type BundledActions {
   latestTimestamp: Time!
   oldestTimestamp: Time!
 }
+"""
+A configured first-party provider credential. Presence in the list means a key is
+configured for that provider.
+"""
+type ByoFirstPartyKey {
+  credentialUid: ID!
+  provider: LlmProvider!
+}
 
 type ByoApiKeyPolicy {
   enabled: Boolean!
+}
+type ByoEndpointMetadata {
+  "Credential handle for this endpoint."
+  credentialUid: ID!
+  enabled: Boolean!
+  models: [ByoEndpointModelMetadata!]!
+  name: String!
+  uid: ID!
+}
+
+type ByoEndpointModelMetadata {
+  alias: String
+  configKey: String!
+  displayName: String!
+  enabled: Boolean!
+  slug: String!
 }
 
 type ByoEndpointPolicy {
@@ -2268,6 +2292,9 @@ type ManagedSecretConfig {
   """
   publicKey: String
 }
+type ManagedByokByoePolicy {
+  enabled: Boolean!
+}
 
 """A managed secret value representing an OpenAI API key."""
 type ManagedSecretOpenAiApiKeyValue {
@@ -3593,6 +3620,14 @@ type TeamSizePolicy {
   isUnlimited: Boolean!
   limit: Int!
 }
+type TeamByoSettings {
+  allowUserEndpoints: Boolean!
+  allowUserKeys: Boolean!
+  endpoints: [ByoEndpointMetadata!]!
+  endpointsEnabled: Boolean!
+  firstPartyEnabled: Boolean!
+  firstPartyKeys: [ByoFirstPartyKey!]!
+}
 
 type TelemetryDataCollectionPolicy {
   default: Boolean!
@@ -3629,6 +3664,7 @@ type Tier {
   enterpriseSecretRedactionPolicy: EnterpriseSecretRedactionPolicy
   enterpriseSpendingLimitsPolicy: EnterpriseSpendingLimitsPolicy
   enterpriseUsageThresholdsPolicy: EnterpriseUsageThresholdsPolicy
+  managedByokByoePolicy: ManagedByokByoePolicy
   multiAdminPolicy: MultiAdminPolicy
   name: String!
   pricing: TierPricing
@@ -4434,6 +4470,7 @@ type WorkspaceSettings {
   llmSettings: LlmSettings!
   sandboxedAgentSettings: SandboxedAgentSettings
   secretRedactionSettings: SecretRedactionSettings!
+  teamByo: TeamByoSettings
   telemetrySettings: TelemetrySettings!
   ugcCollectionSettings: UgcCollectionSettings!
   usageBasedPricingSettings: UsageBasedPricingSettings!


### PR DESCRIPTION
## Description

Adds read-only client support for enterprise team-managed BYOK/BYOE settings and updates Warp Agent UI to respect the effective credential source.

https://www.loom.com/share/49c21109a5cf454dbb0bd5787998a407

https://docs.warp.dev/enterprise/enterprise-features/team-managed-keys-and-endpoints

### What
- Query the stable read-only `teamByo` workspace settings projection and `managedByokByoePolicy` tier policy.
- Mirror team BYO first-party key and endpoint metadata into the workspace model.
- Hide local BYOK/BYOE controls when team admin policy disallows member-provided keys/endpoints.
- Keep locally stored user keys/endpoints on disk when hidden by team policy; they are only hidden/ignored, not deleted.
- Show model picker key icons and cost/spec labels based on the effective credential source:
  - `Inference via User-provided API key`
  - `Inference via Team-provided API key`
- Hide local custom endpoint model choices when the team admin later disables member-provided endpoints.

### Why
Enterprise admins can now provide team-managed BYOK/BYOE credentials. Members need the client to accurately reflect whether inference uses their own credentials, team-provided credentials, or Warp-managed inference, and member-local controls should respect admin policy.

### How
- Reuses existing workspace metadata sync and model picker state instead of adding any team BYO write mutations.
- Adds a `ByoKeySource` helper for user-vs-team credential precedence.
- Uses `managedByokByoePolicy.enabled` as the discriminator for when team BYO policy is in effect, because an empty `teamByo` projection alone can also mean “not managed BYO.”

## Expected UI behavior

### Settings → Warp Agent → Custom inference

| Admin allows member keys | Admin allows member endpoints | Expected settings UI |
|---|---|---|
| Yes | Yes | Shows provider API key editors, custom endpoint controls, and combined copy for both BYOK and BYOE. |
| Yes | No | Shows provider API key editors and keys-only copy. Does not show the add custom model button or local custom endpoint list. |
| No | Yes | Shows custom endpoint controls and endpoint-only copy. Does not show provider API key editors. |
| No | No | Hides local BYOK/BYOE controls. Existing local keys/endpoints remain stored locally. |

### First-party model picker behavior

| Team key configured | User key configured | Admin allows member keys | Expected model picker behavior |
|---|---|---|---|
| Yes | Yes | Yes | Shows key icon; cost row says `Inference via User-provided API key` because user keys take precedence. |
| Yes | Yes | No | Shows key icon; cost row says `Inference via Team-provided API key`. |
| Yes | No | Either | Shows key icon; cost row says `Inference via Team-provided API key`. |
| No | Yes | Yes | Shows key icon; cost row says `Inference via User-provided API key`. |
| No | Yes | No | Does not show key icon; user key is hidden/ignored by team policy. |

### Custom endpoint model picker behavior

| Team endpoint configured | User endpoint configured | Admin allows member endpoints | Expected model picker behavior |
|---|---|---|---|
| Yes | Yes | Yes | Shows both available endpoint model entries |
| Yes | Yes | No | Shows only team endpoint model entries; local endpoint models are hidden. |
| Yes | No | Either | Shows team endpoint model entries with key icon and `Inference via Team-provided API key`. |
| No | Yes | Yes | Shows local endpoint model entries with key icon and `Inference via User-provided API key`. |
| No | Yes | No | Hides local endpoint model entries. |

## Linked Issue

No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `./script/format`
- `MACOSX_DEPLOYMENT_TARGET=13.0 cargo clippy --manifest-path /Users/jaidenratti/warp/Cargo.toml --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `MACOSX_DEPLOYMENT_TARGET=13.0 cargo clippy --manifest-path /Users/jaidenratti/warp/Cargo.toml -p warp_completer --all-targets --tests -- -D warnings`
- `MACOSX_DEPLOYMENT_TARGET=13.0 cargo check --manifest-path /Users/jaidenratti/warp/Cargo.toml -p warp`

Not run:
- `./script/presubmit` full test suite.
- Manual UI screenshots/videos; this is a draft PR and the states require server-side team BYO setup.
- Integration/UI test; explicitly skipped for this draft because the change is policy-driven UI gating.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
