### PR TITLE
Fixup workflow restrictions in `warp` to match `warp-internal`.

### DIFF
--- a/.github/workflows/check_approvals.yml
+++ b/.github/workflows/check_approvals.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check OWNERS approval
     runs-on: ubuntu-latest
     # Skip draft PRs.
-    if: github.event.pull_request.draft == false && github.repository == 'warpdotdev/warp'
+    if: github.event.pull_request.draft == false && github.repository_owner == 'warpdotdev'
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     if: >-
       github.event.pull_request.draft == false &&
       (!startsWith(github.event.pull_request.head.ref, 'repo-sync/') || contains(github.event.pull_request.labels.*.name, 'repo-sync:conflict')) &&
-      github.repository == 'warpdotdev/warp'
+      github.repository_owner == 'warpdotdev'
     outputs:
       affects-database-schema: ${{ github.ref == 'master' || steps.filter.outputs.affects-database-schema }}
       affects-rust-sources: ${{ github.ref == 'master' || steps.filter.outputs.affects-rust-sources }}

--- a/.github/workflows/close_stale_fix_prs.yml
+++ b/.github/workflows/close_stale_fix_prs.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   close-stale-fix-prs:
     runs-on: ubuntu-latest
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     steps:
       - name: Close Stale Fix PRs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/cut_new_releases.yml
+++ b/.github/workflows/cut_new_releases.yml
@@ -30,7 +30,7 @@ jobs:
   get_config:
     name: Get release configuration
     runs-on: ubuntu-latest
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     env:
       SCHEDULE: ${{ github.event.schedule }}
       TARGETS: ${{ inputs.targets }}

--- a/.github/workflows/feature_flag_cleanup.yml
+++ b/.github/workflows/feature_flag_cleanup.yml
@@ -14,7 +14,7 @@ jobs:
   analyze:
     name: Analyze feature flags
     runs-on: namespace-profile-ubuntu-small
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/label_external_contributors.yml
+++ b/.github/workflows/label_external_contributors.yml
@@ -28,7 +28,7 @@ jobs:
   label-external-contributor:
     name: Label external-contributor PRs
     runs-on: ubuntu-latest
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/populate_build_cache.yml
+++ b/.github/workflows/populate_build_cache.yml
@@ -22,6 +22,6 @@ name: Populate Build Cache
 jobs:
   populate_build_cache:
     name: CI
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     uses: ./.github/workflows/ci.yml
     secrets: inherit

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   sync:
-    if: (github.event_name == 'push' || inputs.action == 'sync') && github.repository == 'warpdotdev/warp'
+    if: (github.event_name == 'push' || inputs.action == 'sync') && github.repository_owner == 'warpdotdev'
     uses: warpdotdev/repo-sync/.github/workflows/sync.yml@main
     with:
       repo_sync_ref: main
@@ -36,7 +36,7 @@ jobs:
        github.event.pull_request.merged == true ||
        (github.event.action == 'labeled' && github.event.label.name == 'repo-sync:needs-restack')
       ) &&
-      github.repository == 'warpdotdev/warp'
+      github.repository_owner == 'warpdotdev'
     uses: warpdotdev/repo-sync/.github/workflows/restack.yml@main
     with:
       repo_sync_ref: main
@@ -52,7 +52,7 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.action != 'closed' &&
       startsWith(github.event.pull_request.head.ref, 'repo-sync/') &&
-      github.repository == 'warpdotdev/warp'
+      github.repository_owner == 'warpdotdev'
     uses: warpdotdev/repo-sync/.github/workflows/approve.yml@main
     with:
       repo_sync_ref: main
@@ -63,7 +63,7 @@ jobs:
       approver_app_private_key: ${{ secrets.REPO_SYNC_APPROVER_APP_PRIVATE_KEY }}
 
   escalation:
-    if: inputs.action == 'escalation' && github.repository == 'warpdotdev/warp'
+    if: inputs.action == 'escalation' && github.repository_owner == 'warpdotdev'
     uses: warpdotdev/repo-sync/.github/workflows/escalation.yml@main
     with:
       repo_sync_ref: main

--- a/.github/workflows/stale_requested_changes_prs.yml
+++ b/.github/workflows/stale_requested_changes_prs.yml
@@ -41,7 +41,7 @@ permissions:
 jobs:
   stale-requested-changes:
     runs-on: ubuntu-latest
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/sync-pr-checks.yml
+++ b/.github/workflows/sync-pr-checks.yml
@@ -18,7 +18,7 @@ jobs:
   check:
     name: Verify PR base is the default branch
     runs-on: ubuntu-slim
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     steps:
       - name: Fail if merging a repo-sync branch into another repo-sync branch
         env:

--- a/.github/workflows/update-dedupe-local.yml
+++ b/.github/workflows/update-dedupe-local.yml
@@ -11,7 +11,7 @@ on:
         type: string
 jobs:
   update_dedupe:
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/update-pr-review-local.yml
+++ b/.github/workflows/update-pr-review-local.yml
@@ -11,7 +11,7 @@ on:
         type: string
 jobs:
   update_pr_review:
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/update-triage-local.yml
+++ b/.github/workflows/update-triage-local.yml
@@ -11,7 +11,7 @@ on:
         type: string
 jobs:
   update_triage:
-    if: github.repository == 'warpdotdev/warp'
+    if: github.repository_owner == 'warpdotdev'
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/warp_cleanup_fix_prs.yml
+++ b/.github/workflows/warp_cleanup_fix_prs.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   close-fix-prs:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'auto-fix-ci') && github.repository == 'warpdotdev/warp'
+    if: contains(github.event.pull_request.labels.*.name, 'auto-fix-ci') && github.repository_owner == 'warpdotdev'
     steps:
       - name: Close Dependent Fix PRs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
## Description

This applies https://github.com/warpdotdev/warp-internal/pull/26818/changes/4cb44dc86e0d48a6df271e0853fd984b3ad8064e to this repository, to get the workflows back into sync across both `warp` and `warp-internal`.