### PR TITLE
Add TUI slash command query state

### DIFF
--- a/app/src/terminal/input/slash_command_model.rs
+++ b/app/src/terminal/input/slash_command_model.rs
@@ -119,6 +119,17 @@ impl SlashCommandEntryState {
     }
 }
 
+pub fn slash_command_composition_filter(input: &str) -> Option<&str> {
+    let pending_command = input.strip_prefix('/')?;
+    let command_token = pending_command
+        .split_once(' ')
+        .map_or(pending_command, |(command, _)| command);
+    if command_token.contains('/') {
+        None
+    } else {
+        Some(pending_command)
+    }
+}
 pub struct SlashCommandModel {
     input_buffer_model: ModelHandle<InputBufferModel>,
     ai_input_model: ModelHandle<BlocklistAIInputModel>,
@@ -367,48 +378,43 @@ impl SlashCommandModel {
                 self.state = SlashCommandEntryState::SkillCommand(detected_skill);
             }
             _ if new.starts_with('/') => {
-                let pending_command = &new[1..];
-                if self
-                    .state
-                    .pending_command()
-                    .is_some_and(|command| command == pending_command)
-                {
-                    return;
-                }
+                let pending_command = slash_command_composition_filter(new);
+                if let Some(pending_command) = pending_command {
+                    if self
+                        .state
+                        .pending_command()
+                        .is_some_and(|command| command == pending_command)
+                    {
+                        return;
+                    }
 
-                if !FeatureFlag::AgentView.is_enabled() {
-                    // In the old modality, when composing a slash command, the input _must_ be in
-                    // AI mode; we don't respect `StaticCommand::auto_enter_ai_mode = false`. That
-                    // field is only used in the new modality.
-                    //
-                    // We don't even rely on the fact that the input is in AI mode while a slash
-                    // command is being composed, its solely used to disable error underlining.
-                    //
-                    // In the new modality, slash commands declare whether or not they are
-                    // available in terminal mode, and syntax highlighting/error underlining is
-                    // handled appropriately. I am just making this change to preserve the existing
-                    // product behavior (agent icon in NLD toggle becomes yellow).
-                    self.ai_input_model.update(ctx, |input_model, ctx| {
-                        input_model.set_input_type(
-                            InputType::AI,
-                            Some(InputTypeAutoDetectionSource::SlashCommand),
-                            ctx,
-                        );
-                    });
-                }
-
-                if pending_command
-                    .split_once(' ')
-                    .map_or(pending_command, |(command, _)| command)
-                    .contains('/')
-                {
-                    // If the user typed a second '/' in the command token (e.g., /foo/bar),
-                    // the user is likely not trying to enter or find a slash command.
-                    self.state = SlashCommandEntryState::None;
-                } else {
+                    if !FeatureFlag::AgentView.is_enabled() {
+                        // In the old modality, when composing a slash command, the input _must_ be in
+                        // AI mode; we don't respect `StaticCommand::auto_enter_ai_mode = false`. That
+                        // field is only used in the new modality.
+                        //
+                        // We don't even rely on the fact that the input is in AI mode while a slash
+                        // command is being composed, its solely used to disable error underlining.
+                        //
+                        // In the new modality, slash commands declare whether or not they are
+                        // available in terminal mode, and syntax highlighting/error underlining is
+                        // handled appropriately. I am just making this change to preserve the existing
+                        // product behavior (agent icon in NLD toggle becomes yellow).
+                        self.ai_input_model.update(ctx, |input_model, ctx| {
+                            input_model.set_input_type(
+                                InputType::AI,
+                                Some(InputTypeAutoDetectionSource::SlashCommand),
+                                ctx,
+                            );
+                        });
+                    }
                     self.state = SlashCommandEntryState::Composing {
                         filter: pending_command.to_owned(),
                     };
+                } else {
+                    // If the user typed a second '/' in the command token (e.g., /foo/bar),
+                    // the user is likely not trying to enter or find a slash command.
+                    self.state = SlashCommandEntryState::None;
                 }
             }
             _ => {

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -56,6 +56,7 @@ pub use crate::code::DiffResult;
 pub use crate::settings::AISettingsChangedEvent;
 pub use crate::terminal::color::{Colors as TerminalColors, List as TerminalColorList};
 pub use crate::terminal::event::AfterBlockCompletedEvent;
+pub use crate::terminal::input::slash_command_model::slash_command_composition_filter;
 pub use crate::terminal::input::slash_commands::{
     build_slash_command_mixer, slash_command_query, AcceptSlashCommandOrSavedPrompt, InlineItem,
     SlashCommandDataSource, SlashCommandMixer, TuiDataSourceArgs as TuiSlashCommandDataSourceArgs,

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -22,6 +22,7 @@ mod editor_element;
 mod exit_confirmation;
 mod input_mode_policy;
 mod keybindings;
+mod slash_commands;
 mod terminal_background;
 mod terminal_block;
 mod terminal_session_view;

--- a/crates/warp_tui/src/slash_commands.rs
+++ b/crates/warp_tui/src/slash_commands.rs
@@ -1,0 +1,179 @@
+//! TUI slash command query state.
+//!
+//! This module owns the TUI-side slash command state and search mixer wiring.
+//! Rendering and keyboard dispatch live in later layers; this model is only
+//! responsible for tracking when slash command composition is active, running
+//! shared-source queries, and snapshotting render-friendly row data.
+
+use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
+use warp::search::data_source::QueryResult;
+use warp::search::mixer::SearchMixerEvent;
+use warp::tui_export::{
+    slash_command_composition_filter, slash_command_query, AcceptSlashCommandOrSavedPrompt,
+    SlashCommandMixer, TuiSlashCommandDataSource, UpdatedActiveCommands,
+};
+use warp_editor::model::CoreEditorModel;
+use warpui_core::{AppContext, Entity, ModelContext, ModelHandle};
+
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub(crate) struct TuiSlashCommandRow {
+    pub(crate) title: String,
+    pub(crate) description: Option<String>,
+    pub(crate) action: AcceptSlashCommandOrSavedPrompt,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Default)]
+pub(crate) enum TuiSlashCommandState {
+    #[default]
+    Closed,
+    Open {
+        query: String,
+        rows: Vec<TuiSlashCommandRow>,
+        selected_index: usize,
+        is_loading: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TuiSlashCommandModelEvent;
+
+pub(crate) struct TuiSlashCommandModel {
+    input_editor: ModelHandle<CodeEditorModel>,
+    mixer: ModelHandle<SlashCommandMixer>,
+    state: TuiSlashCommandState,
+}
+
+impl TuiSlashCommandModel {
+    pub(crate) fn new(
+        input_editor: ModelHandle<CodeEditorModel>,
+        slash_commands_source: ModelHandle<TuiSlashCommandDataSource>,
+        mixer: ModelHandle<SlashCommandMixer>,
+        ctx: &mut ModelContext<Self>,
+    ) -> Self {
+        ctx.subscribe_to_model(&input_editor, |me, _, event, ctx| {
+            if matches!(event, CodeEditorModelEvent::ContentChanged { .. }) {
+                me.update_from_input(ctx);
+            }
+        });
+        ctx.subscribe_to_model(
+            &slash_commands_source,
+            |me, _, _: &UpdatedActiveCommands, ctx| {
+                if let Some(query) = me.query().map(str::to_owned) {
+                    me.run_query(query, true, ctx);
+                }
+            },
+        );
+        ctx.subscribe_to_model(&mixer, |me, _, event, ctx| {
+            if matches!(event, SearchMixerEvent::ResultsChanged) {
+                me.refresh_rows(ctx);
+            }
+        });
+
+        let mut model = Self {
+            input_editor,
+            mixer,
+            state: TuiSlashCommandState::Closed,
+        };
+        model.update_from_input(ctx);
+        model
+    }
+
+    pub(crate) fn query(&self) -> Option<&str> {
+        match &self.state {
+            TuiSlashCommandState::Closed => None,
+            TuiSlashCommandState::Open { query, .. } => Some(query),
+        }
+    }
+
+    pub(crate) fn is_open(&self) -> bool {
+        matches!(self.state, TuiSlashCommandState::Open { .. })
+    }
+
+    fn update_from_input(&mut self, ctx: &mut ModelContext<Self>) {
+        let input = input_text(&self.input_editor, ctx);
+        let Some(query) = slash_command_composition_filter(&input).map(str::to_owned) else {
+            self.close(ctx);
+            return;
+        };
+        self.run_query(query, false, ctx);
+    }
+
+    fn run_query(&mut self, query: String, force: bool, ctx: &mut ModelContext<Self>) {
+        let previous_selected_index = match &self.state {
+            TuiSlashCommandState::Closed => 0,
+            TuiSlashCommandState::Open { selected_index, .. } => *selected_index,
+        };
+        self.state = TuiSlashCommandState::Open {
+            query: query.clone(),
+            rows: Vec::new(),
+            selected_index: previous_selected_index,
+            is_loading: true,
+        };
+        self.mixer.update(ctx, |mixer, ctx| {
+            if !force && mixer.current_query().is_some_and(|q| q.text == query) {
+                return;
+            }
+            mixer.run_query(slash_command_query(&query), ctx);
+        });
+        self.refresh_rows(ctx);
+    }
+
+    fn refresh_rows(&mut self, ctx: &mut ModelContext<Self>) {
+        let TuiSlashCommandState::Open {
+            selected_index,
+            rows,
+            is_loading,
+            ..
+        } = &mut self.state
+        else {
+            return;
+        };
+
+        let mixer = self.mixer.as_ref(ctx);
+        *rows = mixer.results().iter().filter_map(row_from_result).collect();
+        *is_loading = mixer.is_loading();
+        *selected_index = (*selected_index).min(rows.len().saturating_sub(1));
+        ctx.emit(TuiSlashCommandModelEvent);
+    }
+
+    fn close(&mut self, ctx: &mut ModelContext<Self>) {
+        if !self.is_open() {
+            return;
+        }
+        self.state = TuiSlashCommandState::Closed;
+        self.mixer.update(ctx, |mixer, ctx| {
+            mixer.reset_results(ctx);
+        });
+        ctx.emit(TuiSlashCommandModelEvent);
+    }
+}
+
+impl Entity for TuiSlashCommandModel {
+    type Event = TuiSlashCommandModelEvent;
+}
+
+fn input_text(input_editor: &ModelHandle<CodeEditorModel>, ctx: &AppContext) -> String {
+    let editor = input_editor.as_ref(ctx);
+    let content = editor.content().as_ref(ctx);
+    if content.is_empty() {
+        String::new()
+    } else {
+        content.text().into_string()
+    }
+}
+
+fn row_from_result(
+    result: &QueryResult<AcceptSlashCommandOrSavedPrompt>,
+) -> Option<TuiSlashCommandRow> {
+    if result.is_static_separator() || result.is_disabled() {
+        return None;
+    }
+    let detail = result.detail_data()?;
+    Some(TuiSlashCommandRow {
+        title: detail.title,
+        description: detail.description,
+        action: result.accept_result(),
+    })
+}

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -9,15 +9,17 @@ use parking_lot::FairMutex;
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp::settings::{AISettings, AISettingsChangedEvent};
 use warp::tui_export::{
-    detect_possible_git_repo, throttle, AIAgentPtyWriteMode, ActiveSession, ActiveSessionEvent,
-    AgentInteractionMetadata, AgentViewEntryOrigin, BlocklistAIActionModel,
-    BlocklistAIContextModel, BlocklistAIController, BlocklistAIHistoryEvent,
-    BlocklistAIHistoryModel, BlocklistAIInputModel, CancellationReason, ChangelogModel,
-    ChangelogModelEvent, ChangelogRequestType, CommandExecutionSource, ConversationSelection,
-    ConversationSelectionHandle, ConversationUsageTotals, ExecuteCommandEvent,
-    GetRelevantFilesController, LLMPreferences, LLMPreferencesEvent, ModelEvent, PtyIntent,
-    PtyIntentEvent, RepoDetectionSessionType, RepoDetectionSource, ShellCommandExecutorEvent,
-    TerminalModel, TerminalSurface, TerminalSurfaceInit, WAKEUP_THROTTLE_PERIOD,
+    build_slash_command_mixer, detect_possible_git_repo, throttle, AIAgentPtyWriteMode,
+    ActiveSession, ActiveSessionEvent, AgentInteractionMetadata, AgentViewEntryOrigin,
+    BlocklistAIActionModel, BlocklistAIContextModel, BlocklistAIController,
+    BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIInputModel, CLISubagentController,
+    CancellationReason, ChangelogModel, ChangelogModelEvent, ChangelogRequestType,
+    CommandExecutionSource, ConversationSelection, ConversationSelectionHandle,
+    ConversationUsageTotals, ExecuteCommandEvent, GetRelevantFilesController, LLMPreferences,
+    LLMPreferencesEvent, ModelEvent, PtyIntent, PtyIntentEvent, RepoDetectionSessionType,
+    RepoDetectionSource, ShellCommandExecutorEvent, TerminalModel, TerminalSurface,
+    TerminalSurfaceInit, TuiSlashCommandDataSource, TuiSlashCommandDataSourceArgs,
+    TuiZeroStateDataSource, WAKEUP_THROTTLE_PERIOD,
 };
 use warp_core::settings::Setting;
 use warp_editor::model::CoreEditorModel;
@@ -39,6 +41,7 @@ use crate::exit_confirmation::{ExitConfirmation, CTRL_C_EXIT_WINDOW};
 use crate::input::{TuiInputView, TuiInputViewEvent};
 use crate::input_mode_policy::{self, TuiInputModePolicy};
 use crate::keybindings::TUI_BINDING_GROUP;
+use crate::slash_commands::TuiSlashCommandModel;
 use crate::transcript_view::TuiTranscriptView;
 use crate::transient_hint::TransientHint;
 use crate::tui_builder::TuiUiBuilder;
@@ -98,6 +101,7 @@ pub(crate) enum TuiTerminalSessionAction {
 pub(crate) struct TuiTerminalSessionView {
     transcript: ViewHandle<TuiTranscriptView>,
     input_view: ViewHandle<TuiInputView>,
+    slash_commands: ModelHandle<TuiSlashCommandModel>,
     conversation_selection: ConversationSelectionHandle,
     ai_controller: ModelHandle<BlocklistAIController>,
     /// Read by the footer for the active session's working directory.
@@ -190,6 +194,17 @@ impl TuiTerminalSessionView {
                 ctx,
             )
         });
+        let cli_subagent_controller = ctx.add_model(|ctx| {
+            CLISubagentController::new(
+                &ai_controller,
+                &action_model,
+                None,
+                model.clone(),
+                &model_events,
+                terminal_surface_id,
+                ctx,
+            )
+        });
         let transcript = ctx.add_typed_action_tui_view(|ctx| {
             TuiTranscriptView::new(
                 terminal_surface_id,
@@ -201,6 +216,29 @@ impl TuiTerminalSessionView {
         });
         let input_editor_model =
             ctx.add_model(|ctx| CodeEditorModel::new_tui(INITIAL_INPUT_WIDTH, ctx));
+        let slash_commands_source = ctx.add_model(|ctx| {
+            TuiSlashCommandDataSource::new(
+                TuiSlashCommandDataSourceArgs {
+                    active_session: active_session.clone(),
+                    cli_subagent_controller,
+                    terminal_view_id: terminal_surface_id,
+                },
+                ctx,
+            )
+        });
+        let zero_state_source = TuiZeroStateDataSource::new(&slash_commands_source);
+        let slash_commands_mixer = ctx.add_model(|ctx| {
+            build_slash_command_mixer(slash_commands_source.clone(), zero_state_source, ctx)
+        });
+        let slash_commands = ctx.add_model(|ctx| {
+            TuiSlashCommandModel::new(
+                input_editor_model.clone(),
+                slash_commands_source,
+                slash_commands_mixer,
+                ctx,
+            )
+        });
+        ctx.subscribe_to_model(&slash_commands, |_, _, _, ctx| ctx.notify());
         // Typing after a ctrl-c press disarms the pending exit confirmation.
         // The ctrl-c buffer clear leaves the buffer empty, so the window it
         // arms survives its own clear.
@@ -379,6 +417,7 @@ impl TuiTerminalSessionView {
         Self {
             transcript,
             input_view,
+            slash_commands,
             conversation_selection,
             ai_controller,
             active_session,
@@ -765,6 +804,7 @@ impl TuiView for TuiTerminalSessionView {
     }
 
     fn render(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
+        let _slash_commands_open = self.slash_commands.as_ref(ctx).is_open();
         // The border takes the shell-mode accent while in shell mode.
         let builder = TuiUiBuilder::from_app(ctx);
         let border_style = if self.is_shell_mode(ctx) {


### PR DESCRIPTION
## Description

Adds the non-visual TUI slash command query-state layer on top of the data-source split from the parent PR.

### Query state

- Adds `TuiSlashCommandModel`, which observes the TUI input editor and opens when slash command composition begins.
- Runs `slash_command_query` through the shared `SlashCommandMixer` and snapshots results into TUI-owned rows containing a title, optional description, and acceptance action.
- Refreshes the query when active commands change and refreshes rows when mixer results change.
- Resets mixer results and closes the state when the input no longer represents slash command composition.
- Extracts `slash_command_composition_filter` from the GUI model so GUI and TUI use the same composition rules.

### TUI wiring

- Constructs `TuiSlashCommandDataSource` with `TuiSlashCommandDataSourceArgs`; it does not use the GUI source or optional GUI handles.
- Constructs `TuiZeroStateDataSource` explicitly and passes it to the generic mixer builder.
- Registers the new `slash_commands` module and wires the model into `TuiTerminalSessionView` for later rendering and dispatch layers.

This PR intentionally does not render the menu or execute selections. Those behaviors are added by the next two PRs in the stack.

## Linked Issue

N/A

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `cargo check -p warp_tui`
- `./script/format`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz [oz-agent@warp.dev](mailto:oz-agent@warp.dev)
