### PR TITLE
Render TUI slash command menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15930,6 +15930,7 @@ dependencies = [
  "warp_editor",
  "warp_errors",
  "warp_files",
+ "warp_search_core",
  "warp_terminal",
  "warp_util",
  "warpui",

--- a/app/src/terminal/input/inline_menu/model.rs
+++ b/app/src/terminal/input/inline_menu/model.rs
@@ -130,8 +130,8 @@ impl<A: InlineMenuAction, T: Send + Sync + 'static> InlineMenuModel<A, T> {
         }
     }
 
-    pub(super) fn update_selected_item(&mut self, item: A, ctx: &mut ModelContext<Self>) {
-        self.selected_item = Some(item);
+    pub(super) fn update_selected_item(&mut self, item: Option<A>, ctx: &mut ModelContext<Self>) {
+        self.selected_item = item;
         ctx.emit(InlineMenuModelEvent::UpdatedSelectedItem);
     }
 
@@ -152,3 +152,7 @@ pub enum InlineMenuModelEvent {
 impl<A: InlineMenuAction, T: 'static + Send + Sync> Entity for InlineMenuModel<A, T> {
     type Event = InlineMenuModelEvent;
 }
+
+#[cfg(test)]
+#[path = "model_tests.rs"]
+mod tests;

--- a/app/src/terminal/input/inline_menu/model_tests.rs
+++ b/app/src/terminal/input/inline_menu/model_tests.rs
@@ -1,0 +1,32 @@
+use warpui::App;
+
+use super::InlineMenuModel;
+use crate::terminal::input::inline_menu::{InlineMenuAction, InlineMenuType};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TestAction(&'static str);
+
+impl InlineMenuAction for TestAction {
+    const MENU_TYPE: InlineMenuType = InlineMenuType::SlashCommands;
+}
+
+#[test]
+fn refreshed_selection_clears_stale_selected_item() {
+    App::test((), |mut app| async move {
+        let model = app.add_model(|_| InlineMenuModel::<TestAction>::new());
+
+        model.update(&mut app, |model, ctx| {
+            model.update_selected_item(Some(TestAction("enabled")), ctx);
+        });
+        model.read(&app, |model, _| {
+            assert_eq!(model.selected_item(), Some(&TestAction("enabled")));
+        });
+
+        model.update(&mut app, |model, ctx| {
+            model.update_selected_item(None, ctx);
+        });
+        model.read(&app, |model, _| {
+            assert_eq!(model.selected_item(), None);
+        });
+    });
+}

--- a/app/src/terminal/input/inline_menu/view.rs
+++ b/app/src/terminal/input/inline_menu/view.rs
@@ -8,6 +8,7 @@ use warp_core::ui::appearance::Appearance;
 use warp_core::ui::color::blend::Blend;
 use warp_core::ui::theme::Fill;
 use warp_core::ui::Icon;
+use warp_search_core::inline_menu::{InitialSelection, InlineMenuSelection};
 use warpui::color::ColorU;
 use warpui::elements::drag_resize::drag_resize_handle;
 use warpui::elements::{
@@ -310,7 +311,7 @@ pub struct InlineMenuView<A: InlineMenuAction, T: 'static + Send + Sync = ()> {
     mixer: ModelHandle<SearchMixer<A>>,
     model: ModelHandle<InlineMenuModel<A, T>>,
     state_handles: StateHandles,
-    selected_idx: Option<usize>,
+    selection: InlineMenuSelection,
     hovered_idx: Option<usize>,
     details_pane_target: DetailsPaneTarget,
     // This is ordered by increasing score (the top match is the last item), per the `SearchMixer`
@@ -403,7 +404,7 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> InlineMenuView<A, T> {
             |me, suggestions_model, event, ctx| {
                 let InputSuggestionsModeEvent::ModeChanged { .. } = event;
                 if suggestions_model.as_ref(ctx).is_closed() {
-                    me.selected_idx = None;
+                    me.selection.clear();
                     me.hovered_idx = None;
                     me.details_pane_target = DetailsPaneTarget::default();
                     me.model.update(ctx, |model, ctx| {
@@ -422,7 +423,7 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> InlineMenuView<A, T> {
 
                 if me.mixer.as_ref(ctx).are_results_empty() {
                     me.result_renderers.clear();
-                    me.selected_idx = None;
+                    me.selection.clear();
                     me.hovered_idx = None;
                     me.details_pane_target = DetailsPaneTarget::default();
                     me.model.update(ctx, |model, ctx| {
@@ -472,23 +473,21 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> InlineMenuView<A, T> {
 
                 me.hovered_idx = None;
                 me.details_pane_target = DetailsPaneTarget::default();
-                if me.mixer.as_ref(ctx).are_results_empty() {
-                    me.selected_idx = None;
-                } else {
-                    // Select the last non-disabled item by default.
-                    let default_selected_idx = (0..me.result_renderers.len())
-                        .rev()
-                        .find(|&idx| !me.result_renderers[idx].search_result.is_disabled())
-                        .unwrap_or(me.result_renderers.len() - 1);
-                    me.selected_idx = Some(default_selected_idx);
-                    if let Some(result_renderer) = me.result_renderers.get(default_selected_idx) {
-                        let item = result_renderer.search_result.accept_result();
-                        me.model.update(ctx, |model, ctx| {
-                            model.update_selected_item(item.clone(), ctx);
+                let result_renderers = &me.result_renderers;
+                let selected_idx =
+                    me.selection
+                        .reset(result_renderers.len(), InitialSelection::Last, |idx| {
+                            !result_renderers[idx].search_result.is_disabled()
                         });
-                        ctx.emit(InlineMenuEvent::SelectedItem { item });
-                    }
-                };
+                let selected_item = selected_idx
+                    .and_then(|idx| me.result_renderers.get(idx))
+                    .map(|renderer| renderer.search_result.accept_result());
+                me.model.update(ctx, |model, ctx| {
+                    model.update_selected_item(selected_item.clone(), ctx);
+                });
+                if let Some(item) = selected_item {
+                    ctx.emit(InlineMenuEvent::SelectedItem { item });
+                }
                 me.scroll_to_selected_idx(ctx);
                 ctx.notify();
             }
@@ -506,7 +505,7 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> InlineMenuView<A, T> {
             positioner,
             message_bar,
             agent_view_controller,
-            selected_idx: None,
+            selection: InlineMenuSelection::default(),
             hovered_idx: None,
             details_pane_target: DetailsPaneTarget::default(),
             result_renderers: vec![],
@@ -552,7 +551,7 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> InlineMenuView<A, T> {
     }
 
     pub fn accept_selected_item(&mut self, cmd_or_ctrl_enter: bool, ctx: &mut ViewContext<Self>) {
-        let Some(selected_idx) = self.selected_idx else {
+        let Some(selected_idx) = self.selection.selected_index() else {
             return;
         };
         let Some(selected_result) = self
@@ -600,22 +599,31 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> InlineMenuView<A, T> {
     }
 
     pub fn selected_idx(&self) -> Option<usize> {
-        self.selected_idx
+        self.selection.selected_index()
     }
 
     pub fn select_idx(&mut self, idx: usize, ctx: &mut ViewContext<Self>) {
-        if idx >= self.result_renderers.len() {
+        let result_renderers = &self.result_renderers;
+        if self
+            .selection
+            .select(idx, result_renderers.len(), |idx| {
+                !result_renderers[idx].search_result.is_disabled()
+            })
+            .is_none()
+        {
             return;
         }
+        self.did_select_idx(idx, ctx);
+    }
 
-        self.selected_idx = Some(idx);
+    fn did_select_idx(&mut self, idx: usize, ctx: &mut ViewContext<Self>) {
         self.hovered_idx = None;
         self.details_pane_target = DetailsPaneTarget::Selection;
         self.scroll_to_selected_idx(ctx);
         if let Some(result_renderer) = self.result_renderers.get(idx) {
             let item = result_renderer.search_result.accept_result();
             self.model.update(ctx, |model, ctx| {
-                model.update_selected_item(item.clone(), ctx);
+                model.update_selected_item(Some(item.clone()), ctx);
             });
             ctx.emit(InlineMenuEvent::SelectedItem { item });
         }
@@ -657,7 +665,7 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> InlineMenuView<A, T> {
         if result_count == 0 {
             return;
         }
-        let Some(selected_idx) = self.selected_idx else {
+        let Some(selected_idx) = self.selection.selected_index() else {
             return;
         };
 
@@ -675,47 +683,24 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> InlineMenuView<A, T> {
     }
 
     fn select_next(&mut self, ctx: &mut ViewContext<Self>) {
-        let result_count = self.result_renderers.len();
-        if result_count == 0 {
-            return;
-        }
-        let start = match self.selected_idx {
-            Some(idx) if idx < result_count.saturating_sub(1) => idx + 1,
-            Some(_) | None => 0,
-        };
-        if let Some(idx) = self.next_enabled_idx(start, ScanDirection::Forward) {
-            self.select_idx(idx, ctx);
+        let result_renderers = &self.result_renderers;
+        if let Some(idx) = self.selection.select_next(result_renderers.len(), |idx| {
+            !result_renderers[idx].search_result.is_disabled()
+        }) {
+            self.did_select_idx(idx, ctx);
         }
     }
 
     fn select_prev(&mut self, ctx: &mut ViewContext<Self>) {
-        let result_count = self.result_renderers.len();
-        if result_count == 0 {
-            return;
+        let result_renderers = &self.result_renderers;
+        if let Some(idx) = self
+            .selection
+            .select_previous(result_renderers.len(), |idx| {
+                !result_renderers[idx].search_result.is_disabled()
+            })
+        {
+            self.did_select_idx(idx, ctx);
         }
-        let start = match self.selected_idx {
-            Some(idx) if idx > 0 => idx - 1,
-            Some(_) | None => result_count - 1,
-        };
-        if let Some(idx) = self.next_enabled_idx(start, ScanDirection::Backward) {
-            self.select_idx(idx, ctx);
-        }
-    }
-
-    /// Starting from `start`, scan for the nearest non-disabled item in the given direction.
-    /// Wraps around at most once. Returns `None` if every item is disabled.
-    fn next_enabled_idx(&self, start: usize, direction: ScanDirection) -> Option<usize> {
-        let count = self.result_renderers.len();
-        for offset in 0..count {
-            let candidate = match direction {
-                ScanDirection::Forward => (start + offset) % count,
-                ScanDirection::Backward => (start + count - offset) % count,
-            };
-            if !self.result_renderers[candidate].search_result.is_disabled() {
-                return Some(candidate);
-            }
-        }
-        None
     }
 
     pub fn set_active_tab(&mut self, index: usize, ctx: &mut ViewContext<Self>) {
@@ -891,7 +876,7 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> InlineMenuView<A, T> {
     ) -> Box<dyn Element> {
         let theme = Appearance::as_ref(app).theme();
 
-        let selected_idx = self.selected_idx;
+        let selected_idx = self.selection.selected_index();
         let weak_handle = self.weak_handle.clone();
 
         let scrollable_items = Scrollable::vertical(
@@ -986,7 +971,7 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> InlineMenuView<A, T> {
                 return Some(idx);
             }
         }
-        self.selected_idx
+        self.selection.selected_index()
     }
 
     fn render_no_results_state(&self, message: String, app: &AppContext) -> Box<dyn Element> {
@@ -1193,11 +1178,6 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> View for InlineMenuView<A, T
     }
 }
 
-enum ScanDirection {
-    Forward,
-    Backward,
-}
-
 /// Internal action for handling item selection via click.
 #[derive(Debug, Clone)]
 pub enum InlineMenuRowAction<A: Action + Clone> {
@@ -1224,17 +1204,11 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> TypedActionView for InlineMe
                     cmd_or_ctrl_shift_enter: *cmd_or_ctrl_enter,
                 });
             }
-            InlineMenuRowAction::Select { result_index, item } => {
-                if *result_index >= self.result_renderers.len() {
-                    return;
-                }
-                self.selected_idx = Some(*result_index);
-                self.scroll_to_selected_idx(ctx);
-                self.model.update(ctx, |model, ctx| {
-                    model.update_selected_item(item.clone(), ctx);
-                });
-                ctx.emit(InlineMenuEvent::SelectedItem { item: item.clone() });
-                ctx.notify();
+            InlineMenuRowAction::Select {
+                result_index,
+                item: _,
+            } => {
+                self.select_idx(*result_index, ctx);
             }
             InlineMenuRowAction::HoverItem { result_index } => {
                 let idx = *result_index;

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -56,6 +56,7 @@ pub use crate::code::DiffResult;
 pub use crate::code_review::git_repo_model::{
     GitRepoModels, GitRepoStatusModel, GitStatusMetadata,
 };
+pub use crate::search::slash_command_menu::SlashCommandId;
 pub use crate::settings::AISettingsChangedEvent;
 pub use crate::terminal::color::{Colors as TerminalColors, List as TerminalColorList};
 pub use crate::terminal::event::AfterBlockCompletedEvent;

--- a/crates/warp_search_core/src/inline_menu.rs
+++ b/crates/warp_search_core/src/inline_menu.rs
@@ -1,0 +1,109 @@
+//! Headless selection state shared by inline-menu frontends.
+
+/// Which selectable result should be chosen when resetting a menu.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InitialSelection {
+    First,
+    Last,
+}
+
+/// Logical selection over an ordered list of inline-menu results.
+///
+/// This type intentionally knows nothing about rendering direction, scrolling,
+/// result payloads, or menu lifecycle. Frontends supply the current item count
+/// and a predicate that excludes disabled rows and separators.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct InlineMenuSelection {
+    selected_index: Option<usize>,
+}
+
+impl InlineMenuSelection {
+    pub fn selected_index(&self) -> Option<usize> {
+        self.selected_index
+    }
+
+    pub fn clear(&mut self) {
+        self.selected_index = None;
+    }
+
+    pub fn reset(
+        &mut self,
+        item_count: usize,
+        initial_selection: InitialSelection,
+        mut is_enabled: impl FnMut(usize) -> bool,
+    ) -> Option<usize> {
+        self.selected_index = match initial_selection {
+            InitialSelection::First => (0..item_count).find(|&index| is_enabled(index)),
+            InitialSelection::Last => (0..item_count).rev().find(|&index| is_enabled(index)),
+        };
+        self.selected_index
+    }
+
+    pub fn select(
+        &mut self,
+        index: usize,
+        item_count: usize,
+        mut is_enabled: impl FnMut(usize) -> bool,
+    ) -> Option<usize> {
+        if index >= item_count || !is_enabled(index) {
+            return None;
+        }
+        self.selected_index = Some(index);
+        self.selected_index
+    }
+
+    pub fn select_next(
+        &mut self,
+        item_count: usize,
+        is_enabled: impl FnMut(usize) -> bool,
+    ) -> Option<usize> {
+        let start = match self.selected_index {
+            Some(index) if index < item_count.saturating_sub(1) => index + 1,
+            Some(_) | None => 0,
+        };
+        self.select_from(start, item_count, ScanDirection::Forward, is_enabled)
+    }
+
+    pub fn select_previous(
+        &mut self,
+        item_count: usize,
+        is_enabled: impl FnMut(usize) -> bool,
+    ) -> Option<usize> {
+        let start = match self.selected_index {
+            Some(index) if index > 0 && index < item_count => index - 1,
+            Some(_) | None => item_count.saturating_sub(1),
+        };
+        self.select_from(start, item_count, ScanDirection::Backward, is_enabled)
+    }
+
+    fn select_from(
+        &mut self,
+        start: usize,
+        item_count: usize,
+        direction: ScanDirection,
+        mut is_enabled: impl FnMut(usize) -> bool,
+    ) -> Option<usize> {
+        if item_count == 0 {
+            self.clear();
+            return None;
+        }
+
+        self.selected_index = (0..item_count)
+            .map(|offset| match direction {
+                ScanDirection::Forward => (start + offset) % item_count,
+                ScanDirection::Backward => (start + item_count - offset) % item_count,
+            })
+            .find(|&index| is_enabled(index));
+        self.selected_index
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ScanDirection {
+    Forward,
+    Backward,
+}
+
+#[cfg(test)]
+#[path = "inline_menu_tests.rs"]
+mod tests;

--- a/crates/warp_search_core/src/inline_menu_tests.rs
+++ b/crates/warp_search_core/src/inline_menu_tests.rs
@@ -1,0 +1,94 @@
+use super::{InitialSelection, InlineMenuSelection};
+
+#[test]
+fn reset_selects_first_or_last_enabled_item() {
+    let enabled = [false, true, false, true];
+    let mut selection = InlineMenuSelection::default();
+
+    assert_eq!(
+        selection.reset(enabled.len(), InitialSelection::First, |index| enabled
+            [index]),
+        Some(1)
+    );
+    assert_eq!(
+        selection.reset(enabled.len(), InitialSelection::Last, |index| enabled
+            [index]),
+        Some(3)
+    );
+}
+
+#[test]
+fn reset_clears_selection_when_no_item_is_enabled() {
+    let mut selection = InlineMenuSelection::default();
+    selection.reset(1, InitialSelection::First, |_| true);
+
+    assert_eq!(selection.reset(3, InitialSelection::Last, |_| false), None);
+    assert_eq!(selection.selected_index(), None);
+}
+
+#[test]
+fn next_and_previous_wrap_and_skip_disabled_items() {
+    let enabled = [true, false, true, false];
+    let mut selection = InlineMenuSelection::default();
+    selection.reset(enabled.len(), InitialSelection::First, |index| {
+        enabled[index]
+    });
+
+    assert_eq!(
+        selection.select_next(enabled.len(), |index| enabled[index]),
+        Some(2)
+    );
+    assert_eq!(
+        selection.select_next(enabled.len(), |index| enabled[index]),
+        Some(0)
+    );
+    assert_eq!(
+        selection.select_previous(enabled.len(), |index| enabled[index]),
+        Some(2)
+    );
+}
+
+#[test]
+fn navigation_from_no_selection_uses_directional_edge() {
+    let enabled = [true, false, true];
+    let mut selection = InlineMenuSelection::default();
+
+    assert_eq!(
+        selection.select_next(enabled.len(), |index| enabled[index]),
+        Some(0)
+    );
+    selection.clear();
+    assert_eq!(
+        selection.select_previous(enabled.len(), |index| enabled[index]),
+        Some(2)
+    );
+}
+
+#[test]
+fn direct_selection_rejects_invalid_or_disabled_indices_without_moving() {
+    let enabled = [true, false];
+    let mut selection = InlineMenuSelection::default();
+    selection.reset(enabled.len(), InitialSelection::First, |index| {
+        enabled[index]
+    });
+
+    assert_eq!(
+        selection.select(1, enabled.len(), |index| enabled[index]),
+        None
+    );
+    assert_eq!(selection.selected_index(), Some(0));
+    assert_eq!(
+        selection.select(2, enabled.len(), |index| enabled[index]),
+        None
+    );
+    assert_eq!(selection.selected_index(), Some(0));
+}
+
+#[test]
+fn empty_navigation_clears_stale_selection() {
+    let mut selection = InlineMenuSelection::default();
+    selection.reset(1, InitialSelection::First, |_| true);
+
+    assert_eq!(selection.select_next(0, |_| true), None);
+    assert_eq!(selection.selected_index(), None);
+}

--- a/crates/warp_search_core/src/lib.rs
+++ b/crates/warp_search_core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod data_source;
+pub mod inline_menu;
 pub mod item;
 pub mod macros;
 pub mod mixer;

--- a/crates/warp_tui/Cargo.toml
+++ b/crates/warp_tui/Cargo.toml
@@ -62,6 +62,7 @@ warp_core.workspace = true
 warp_errors.workspace = true
 warp_editor.workspace = true
 warp_files.workspace = true
+warp_search_core.workspace = true
 warp_terminal.workspace = true
 warp_util.workspace = true
 warpui.workspace = true

--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -1,0 +1,320 @@
+//! Reusable active-menu routing and character-cell presentation for TUI inline menus.
+
+use warp::tui_export::AcceptSlashCommandOrSavedPrompt;
+use warpui_core::elements::tui::{
+    TuiBuffer, TuiConstraint, TuiContainer, TuiElement, TuiFlex, TuiLayoutContext, TuiPaintContext,
+    TuiRect, TuiSize, TuiText,
+};
+use warpui_core::elements::CrossAxisAlignment;
+use warpui_core::{AppContext, ModelAsRef, ModelHandle, UpdateModel};
+
+use crate::slash_commands::TuiSlashCommandModel;
+use crate::tui_builder::TuiUiBuilder;
+
+/// A presentation-only row in a TUI inline menu.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TuiInlineMenuRow {
+    pub(crate) title: String,
+    pub(crate) description: Option<String>,
+    pub(crate) is_selectable: bool,
+}
+
+/// A presentation-only tab in a TUI inline-menu header.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TuiInlineMenuTab {
+    pub(crate) label: String,
+    pub(crate) is_selected: bool,
+}
+
+/// Optional header metadata rendered above menu rows.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct TuiInlineMenuHeader {
+    pub(crate) title: Option<String>,
+    pub(crate) tabs: Vec<TuiInlineMenuTab>,
+}
+
+/// Empty-list presentation for an open inline menu.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TuiInlineMenuStatus {
+    Loading(String),
+    Empty(String),
+}
+
+/// Render-friendly, domain-neutral state for a TUI inline menu.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TuiInlineMenuSnapshot {
+    pub(crate) header: Option<TuiInlineMenuHeader>,
+    pub(crate) rows: Vec<TuiInlineMenuRow>,
+    pub(crate) selected_index: Option<usize>,
+    pub(crate) scroll_offset: usize,
+    pub(crate) max_visible_rows: usize,
+    pub(crate) status: Option<TuiInlineMenuStatus>,
+}
+
+/// Domain action produced by accepting the selected item in an active menu.
+#[derive(Debug, Clone)]
+pub(crate) enum TuiInlineMenuAccepted {
+    SlashCommand(AcceptSlashCommandOrSavedPrompt),
+}
+
+/// The active TUI inline menu.
+///
+/// This is the input and placement boundary shared by menu kinds. Each variant
+/// retains its own query state and accepted action, while all variants expose
+/// the same navigation, dismissal, snapshot, and rendering behavior.
+#[derive(Clone)]
+pub(crate) enum TuiInlineMenu {
+    SlashCommands(ModelHandle<TuiSlashCommandModel>),
+}
+
+impl TuiInlineMenu {
+    pub(crate) fn is_open(&self, ctx: &AppContext) -> bool {
+        match self {
+            Self::SlashCommands(model) => model.as_ref(ctx).is_open(),
+        }
+    }
+
+    pub(crate) fn render(&self, ctx: &AppContext) -> Option<Box<dyn TuiElement>> {
+        self.snapshot(ctx)
+            .map(|snapshot| render_inline_menu(&snapshot, &TuiUiBuilder::from_app(ctx)))
+    }
+
+    pub(crate) fn select_previous(&self, ctx: &mut impl UpdateModel) {
+        match self {
+            Self::SlashCommands(model) => {
+                model.update(ctx, |model, ctx| model.select_previous(ctx));
+            }
+        }
+    }
+
+    pub(crate) fn select_next(&self, ctx: &mut impl UpdateModel) {
+        match self {
+            Self::SlashCommands(model) => {
+                model.update(ctx, |model, ctx| model.select_next(ctx));
+            }
+        }
+    }
+
+    pub(crate) fn accept(
+        &self,
+        ctx: &mut (impl ModelAsRef + UpdateModel),
+    ) -> Option<TuiInlineMenuAccepted> {
+        match self {
+            Self::SlashCommands(model) => {
+                let action = model.as_ref(ctx).selected_action();
+                model.update(ctx, |model, ctx| model.dismiss(ctx));
+                action.map(TuiInlineMenuAccepted::SlashCommand)
+            }
+        }
+    }
+
+    pub(crate) fn dismiss(&self, ctx: &mut impl UpdateModel) {
+        match self {
+            Self::SlashCommands(model) => {
+                model.update(ctx, |model, ctx| model.dismiss(ctx));
+            }
+        }
+    }
+
+    fn snapshot(&self, ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
+        match self {
+            Self::SlashCommands(model) => model.as_ref(ctx).snapshot(),
+        }
+    }
+}
+
+pub(crate) fn render_inline_menu(
+    snapshot: &TuiInlineMenuSnapshot,
+    builder: &TuiUiBuilder,
+) -> Box<dyn TuiElement> {
+    Box::new(TuiInlineMenuElement {
+        snapshot: snapshot.clone(),
+        builder: builder.clone(),
+        content: None,
+    })
+}
+
+struct TuiInlineMenuElement {
+    snapshot: TuiInlineMenuSnapshot,
+    builder: TuiUiBuilder,
+    content: Option<Box<dyn TuiElement>>,
+}
+
+impl TuiElement for TuiInlineMenuElement {
+    fn layout(
+        &mut self,
+        constraint: TuiConstraint,
+        ctx: &mut TuiLayoutContext,
+        app: &AppContext,
+    ) -> TuiSize {
+        let mut content = build_inline_menu(&self.snapshot, &self.builder, constraint.max.height);
+        let size = content.layout(constraint, ctx, app);
+        self.content = Some(content);
+        size
+    }
+
+    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
+        if let Some(content) = &self.content {
+            content.render(area, buffer, ctx);
+        }
+    }
+}
+
+fn build_inline_menu(
+    snapshot: &TuiInlineMenuSnapshot,
+    builder: &TuiUiBuilder,
+    allocated_height: u16,
+) -> Box<dyn TuiElement> {
+    let mut column = TuiFlex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+    if let Some(header) = &snapshot.header {
+        if let Some(title) = &header.title {
+            column = column.child(menu_status_row(title, builder));
+        }
+        if !header.tabs.is_empty() {
+            let labels = header
+                .tabs
+                .iter()
+                .map(|tab| {
+                    if tab.is_selected {
+                        format!("[{}]", tab.label)
+                    } else {
+                        tab.label.clone()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("  ");
+            column = column.child(menu_status_row(&labels, builder));
+        }
+    }
+
+    if snapshot.rows.is_empty() {
+        if let Some(status) = &snapshot.status {
+            let label = match status {
+                TuiInlineMenuStatus::Loading(label) | TuiInlineMenuStatus::Empty(label) => label,
+            };
+            column = column.child(menu_status_row(label, builder));
+        }
+    } else {
+        let visible_rows = visible_result_capacity(snapshot, allocated_height);
+        let mut scroll_offset = snapshot.scroll_offset;
+        if let Some(selected_index) = snapshot.selected_index {
+            keep_selected_visible(
+                snapshot.rows.len(),
+                selected_index,
+                visible_rows,
+                &mut scroll_offset,
+            );
+        } else {
+            scroll_offset = scroll_offset.min(snapshot.rows.len().saturating_sub(visible_rows));
+        }
+        for (index, row) in snapshot
+            .rows
+            .iter()
+            .enumerate()
+            .skip(scroll_offset)
+            .take(visible_rows)
+        {
+            column = column.child(menu_result_row(
+                row,
+                snapshot.selected_index == Some(index),
+                builder,
+            ));
+        }
+    }
+
+    TuiContainer::new(column.finish())
+        .with_border_style(builder.accent_border_style())
+        .finish()
+}
+
+fn visible_result_capacity(snapshot: &TuiInlineMenuSnapshot, allocated_height: u16) -> usize {
+    const BORDER_ROWS: usize = 2;
+    let header_rows = snapshot.header.as_ref().map_or(0, |header| {
+        usize::from(header.title.is_some()) + usize::from(!header.tabs.is_empty())
+    });
+    usize::from(allocated_height)
+        .saturating_sub(BORDER_ROWS + header_rows)
+        .min(snapshot.max_visible_rows)
+}
+
+/// Clamps stale scroll offsets and moves the viewport only as far as needed to
+/// keep the selected row within a window of `visible_rows`.
+pub(crate) fn keep_selected_visible(
+    rows_len: usize,
+    selected_index: usize,
+    visible_rows: usize,
+    scroll_offset: &mut usize,
+) {
+    if rows_len == 0 || visible_rows == 0 {
+        *scroll_offset = 0;
+        return;
+    }
+
+    let max_scroll_offset = rows_len.saturating_sub(visible_rows);
+    *scroll_offset = (*scroll_offset).min(max_scroll_offset);
+    if selected_index < *scroll_offset {
+        *scroll_offset = selected_index;
+    } else if selected_index >= *scroll_offset + visible_rows {
+        *scroll_offset = selected_index + 1 - visible_rows;
+    }
+}
+
+fn menu_status_row(label: &str, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
+    TuiContainer::new(
+        TuiText::new(label.to_owned())
+            .with_style(builder.dim_text_style())
+            .truncate()
+            .finish(),
+    )
+    .with_padding_left(1)
+    .with_padding_right(1)
+    .finish()
+}
+
+fn menu_result_row(
+    row: &TuiInlineMenuRow,
+    is_selected: bool,
+    builder: &TuiUiBuilder,
+) -> Box<dyn TuiElement> {
+    let title_style = if is_selected {
+        builder.input_text_style()
+    } else if row.is_selectable {
+        builder.primary_text_style()
+    } else {
+        builder.dim_text_style()
+    };
+    let description_style = if is_selected {
+        builder.input_text_style()
+    } else {
+        builder.muted_text_style()
+    };
+
+    let mut content = TuiFlex::row()
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .child(
+            TuiText::new(row.title.clone())
+                .with_style(title_style)
+                .truncate()
+                .finish(),
+        );
+    if let Some(description) = &row.description {
+        content = content.child(
+            TuiText::new(format!("  {description}"))
+                .with_style(description_style)
+                .truncate()
+                .finish(),
+        );
+    }
+
+    let mut container = TuiContainer::new(content.finish())
+        .with_padding_left(1)
+        .with_padding_right(1);
+    if is_selected {
+        container = container.with_background(builder.input_background());
+    }
+    container.finish()
+}
+
+#[cfg(test)]
+#[path = "inline_menu_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/inline_menu_tests.rs
+++ b/crates/warp_tui/src/inline_menu_tests.rs
@@ -1,0 +1,162 @@
+use warp::appearance::Appearance;
+use warpui_core::elements::tui::{TuiBufferExt, TuiRect};
+use warpui_core::presenter::tui::TuiPresenter;
+use warpui_core::App;
+
+use super::{
+    render_inline_menu, TuiInlineMenuHeader, TuiInlineMenuRow, TuiInlineMenuSnapshot,
+    TuiInlineMenuStatus, TuiInlineMenuTab,
+};
+use crate::tui_builder::TuiUiBuilder;
+
+fn render_at_height(snapshot: TuiInlineMenuSnapshot, height: u16) -> Vec<String> {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        app.read(move |ctx| {
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                render_inline_menu(&snapshot, &TuiUiBuilder::from_app(ctx)),
+                TuiRect::new(0, 0, 50, height),
+                ctx,
+            );
+            frame.buffer.to_lines()
+        })
+    })
+}
+
+fn render(snapshot: TuiInlineMenuSnapshot) -> Vec<String> {
+    render_at_height(snapshot, 12)
+}
+
+fn status_snapshot(status: TuiInlineMenuStatus) -> TuiInlineMenuSnapshot {
+    TuiInlineMenuSnapshot {
+        header: None,
+        rows: Vec::new(),
+        selected_index: None,
+        scroll_offset: 0,
+        max_visible_rows: 8,
+        status: Some(status),
+    }
+}
+
+#[test]
+fn renders_loading_and_empty_statuses() {
+    let loading = render(status_snapshot(TuiInlineMenuStatus::Loading(
+        "Loading conversations…".to_owned(),
+    )));
+    assert!(loading
+        .iter()
+        .any(|line| line.contains("Loading conversations…")));
+
+    let empty = render(status_snapshot(TuiInlineMenuStatus::Empty(
+        "No conversations found".to_owned(),
+    )));
+    assert!(empty
+        .iter()
+        .any(|line| line.contains("No conversations found")));
+}
+
+#[test]
+fn renders_only_the_visible_row_window() {
+    let lines = render(TuiInlineMenuSnapshot {
+        header: None,
+        rows: (0..5)
+            .map(|index| TuiInlineMenuRow {
+                title: format!("Conversation {index}"),
+                description: None,
+                is_selectable: true,
+            })
+            .collect(),
+        selected_index: Some(3),
+        scroll_offset: 2,
+        max_visible_rows: 2,
+        status: None,
+    });
+    let rendered = lines.join("\n");
+    assert!(!rendered.contains("Conversation 1"));
+    assert!(rendered.contains("Conversation 2"));
+    assert!(rendered.contains("Conversation 3"));
+    assert!(!rendered.contains("Conversation 4"));
+}
+
+#[test]
+fn conversation_like_snapshot_reuses_header_tabs_rows_and_selection() {
+    let lines = render(TuiInlineMenuSnapshot {
+        header: Some(TuiInlineMenuHeader {
+            title: Some("Conversations".to_owned()),
+            tabs: vec![
+                TuiInlineMenuTab {
+                    label: "All".to_owned(),
+                    is_selected: true,
+                },
+                TuiInlineMenuTab {
+                    label: "Pinned".to_owned(),
+                    is_selected: false,
+                },
+            ],
+        }),
+        rows: vec![
+            TuiInlineMenuRow {
+                title: "Current project".to_owned(),
+                description: Some("2 minutes ago".to_owned()),
+                is_selectable: true,
+            },
+            TuiInlineMenuRow {
+                title: "Archived".to_owned(),
+                description: None,
+                is_selectable: false,
+            },
+        ],
+        selected_index: Some(0),
+        scroll_offset: 0,
+        max_visible_rows: 8,
+        status: None,
+    });
+    let rendered = lines.join("\n");
+    assert!(rendered.contains("Conversations"));
+    assert!(rendered.contains("[All]  Pinned"));
+    assert!(rendered.contains("Current project  2 minutes ago"));
+    assert!(rendered.contains("Archived"));
+}
+
+#[test]
+fn conversation_like_snapshot_keeps_selection_visible_within_production_height() {
+    let lines = render_at_height(
+        TuiInlineMenuSnapshot {
+            header: Some(TuiInlineMenuHeader {
+                title: Some("Conversations".to_owned()),
+                tabs: vec![
+                    TuiInlineMenuTab {
+                        label: "All".to_owned(),
+                        is_selected: true,
+                    },
+                    TuiInlineMenuTab {
+                        label: "Pinned".to_owned(),
+                        is_selected: false,
+                    },
+                ],
+            }),
+            rows: (0..8)
+                .map(|index| TuiInlineMenuRow {
+                    title: format!("Conversation {index}"),
+                    description: None,
+                    is_selectable: true,
+                })
+                .collect(),
+            selected_index: Some(7),
+            scroll_offset: 0,
+            max_visible_rows: 8,
+            status: None,
+        },
+        10,
+    );
+
+    assert_eq!(lines.len(), 10);
+    let rendered = lines.join("\n");
+    assert!(rendered.contains("Conversations"));
+    assert!(rendered.contains("[All]  Pinned"));
+    assert!(!rendered.contains("Conversation 0"));
+    assert!(!rendered.contains("Conversation 1"));
+    assert!(rendered.contains("Conversation 2"));
+    assert!(rendered.contains("Conversation 7"));
+}

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -33,22 +33,24 @@ use warp_editor::selection::TextUnit;
 use warpui_core::elements::tui::{TuiContainer, TuiElement, TuiFlex, TuiHoverable, TuiText};
 use warpui_core::elements::MouseStateHandle;
 use warpui_core::keymap::macros::*;
-use warpui_core::keymap::{Context, EditableBinding};
+use warpui_core::keymap::{self, EditableBinding};
 use warpui_core::text::word_boundaries::WordBoundariesPolicy;
 use warpui_core::{AppContext, Entity, ModelHandle, TuiView, TypedActionView, ViewContext};
 
 use super::kill_buffer::KillBuffer;
 use crate::editor_element::{TuiEditorAction, TuiEditorElement};
+use crate::inline_menu::{TuiInlineMenu, TuiInlineMenuAccepted};
 use crate::input_mode_policy::{self, AI_LOCKED_CONFIG, SHELL_LOCKED_CONFIG};
 use crate::keybindings::TUI_BINDING_GROUP;
-use crate::slash_commands::TuiSlashCommandModel;
 use crate::tui_builder::TuiUiBuilder;
 
-/// Keymap-context flag set by [`TuiInputView::keymap_context`] while the input
-/// is in `!` shell mode; gates the `tui:input:exit_shell_mode` binding so Esc
-/// stays available to ancestors otherwise.
-const SHELL_MODE_INPUT_FLAG: &str = "ShellModeInput";
-
+/// Keymap-context flag set while the input has contextual Escape behavior.
+///
+/// The input owns a single Escape binding so modes can arbitrate explicitly in
+/// [`TuiInputView::handle_escape`] instead of relying on keymap registration
+/// order. Inline menus take priority; later input modes should be handled only
+/// after the menu branch.
+const INPUT_HANDLES_ESCAPE_FLAG: &str = "TuiInputHandlesEscape";
 // ─────────────────────────────────────────────────────────────────────────────
 // Keybindings
 // ─────────────────────────────────────────────────────────────────────────────
@@ -101,11 +103,11 @@ pub fn init(app: &mut AppContext) {
         .with_group(TUI_BINDING_GROUP)
         .with_key_binding("alt-enter"),
         EditableBinding::new(
-            "tui:input:dismiss_slash_commands",
-            "Dismiss slash commands",
-            TuiInputAction::DismissSlashCommands,
+            "tui:input:handle_escape",
+            "Handle contextual input escape",
+            TuiInputAction::HandleEscape,
         )
-        .with_context_predicate(id!("TuiInputView"))
+        .with_context_predicate(id!("TuiInputView") & id!(INPUT_HANDLES_ESCAPE_FLAG))
         .with_group(TUI_BINDING_GROUP)
         .with_key_binding("escape"),
         // ── Deletion ───────────────────────────────────────────────────
@@ -449,15 +451,6 @@ pub fn init(app: &mut AppContext) {
             .with_context_predicate(id!("TuiInputView"))
             .with_group(TUI_BINDING_GROUP)
             .with_key_binding("ctrl-shift-Z"),
-        // ── Shell mode ──────────────────────────────────────────────────
-        EditableBinding::new(
-            "tui:input:exit_shell_mode",
-            "Exit shell mode",
-            TuiInputAction::ExitShellMode,
-        )
-        .with_context_predicate(id!("TuiInputView") & id!(SHELL_MODE_INPUT_FLAG))
-        .with_group(TUI_BINDING_GROUP)
-        .with_key_binding("escape"),
     ]);
 }
 
@@ -478,7 +471,7 @@ pub enum TuiInputViewEvent {
 // Typed action enum
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// All editing operations dispatched from `TuiInputElement::dispatch_event`.
+/// All editing operations dispatched from [`TuiEditorElement`].
 ///
 /// Each variant corresponds to one or more keybindings from the spec keybinding table.
 #[derive(Debug, Clone)]
@@ -489,8 +482,8 @@ pub enum TuiInputAction {
     InsertNewline,
     /// Submit the current input (`Enter`).
     Submit,
-    /// Dismiss an open slash command menu (`Escape`).
-    DismissSlashCommands,
+    /// Handle contextual input Escape behavior, prioritizing an open inline menu.
+    HandleEscape,
     /// Delete the character before the cursor (`Backspace`, `Ctrl+H`).
     Backspace,
     /// Delete the character after the cursor (`Delete`, `Ctrl+D`).
@@ -539,8 +532,6 @@ pub enum TuiInputAction {
     Undo,
     /// Redo (`Ctrl+Shift+Z`).
     Redo,
-    /// Exit shell mode, keeping any typed text (`Esc`, only while in shell mode).
-    ExitShellMode,
     /// Place the cursor / begin a character selection at `offset` (single click).
     SelectionStartAt { offset: CharOffset },
     /// Extend the active selection's head to `offset` (shift-click).
@@ -573,8 +564,8 @@ pub struct TuiInputView {
     model: ModelHandle<CodeEditorModel>,
     /// Shared input-mode state driving `!` shell-mode handling.
     input_mode: ModelHandle<BlocklistAIInputModel>,
-    /// Optional slash command state model used to route menu keyboard actions.
-    slash_commands: Option<ModelHandle<TuiSlashCommandModel>>,
+    /// Optional generalized inline menu used to route prioritized menu actions.
+    inline_menu: Option<TuiInlineMenu>,
     /// Single-entry kill buffer for `Ctrl+K` / `Ctrl+U` / `Ctrl+Y`.
     kill_buffer: KillBuffer,
     /// Maximum number of visible rows before the input scrolls.
@@ -590,7 +581,11 @@ impl Entity for TuiInputView {
 
 impl TuiInputView {
     /// Construct a new `TuiInputView` backed by `model` (must be in char-cell
-    /// mode). The model carries the terminal width (set via
+    /// mode). Construction stays crate-internal because `inline_menu` is the
+    /// crate-private active-menu adapter; keeping this as the only constructor
+    /// prevents menu and non-menu initialization paths from diverging.
+    ///
+    /// The model carries the terminal width (set via
     /// [`CodeEditorModel::new_tui`]); the view does not keep its own copy.
     ///
     /// `input_mode` is the shared input-mode model backing `!` shell-mode
@@ -598,18 +593,10 @@ impl TuiInputView {
     ///
     /// Subscribes to [`CodeEditorModelEvent::ContentChanged`] to trigger re-renders
     /// whenever the buffer changes from outside `handle_action`.
-    pub fn new(
+    pub(crate) fn new(
         model: ModelHandle<CodeEditorModel>,
         input_mode: ModelHandle<BlocklistAIInputModel>,
-        ctx: &mut ViewContext<Self>,
-    ) -> Self {
-        Self::new_with_slash_commands(model, input_mode, None, ctx)
-    }
-
-    pub(crate) fn new_with_slash_commands(
-        model: ModelHandle<CodeEditorModel>,
-        input_mode: ModelHandle<BlocklistAIInputModel>,
-        slash_commands: Option<ModelHandle<TuiSlashCommandModel>>,
+        inline_menu: Option<TuiInlineMenu>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
         ctx.subscribe_to_model(&model, |_, _, event, ctx| {
@@ -623,7 +610,7 @@ impl TuiInputView {
         Self {
             model,
             input_mode,
-            slash_commands,
+            inline_menu,
             kill_buffer: KillBuffer::default(),
             max_visible_rows: 6,
             prefix_mouse_state: MouseStateHandle::default(),
@@ -709,12 +696,13 @@ impl TuiView for TuiInputView {
         }
     }
 
-    fn keymap_context(&self, app: &AppContext) -> Context {
-        let mut ctx = Self::default_keymap_context();
-        if self.is_shell_mode(app) {
-            ctx.set.insert(SHELL_MODE_INPUT_FLAG);
-        }
-        ctx
+    fn keymap_context(&self, ctx: &AppContext) -> keymap::Context {
+        input_keymap_context(
+            self.inline_menu
+                .as_ref()
+                .is_some_and(|inline_menu| inline_menu.is_open(ctx))
+                || self.is_shell_mode(ctx),
+        )
     }
 }
 
@@ -733,11 +721,19 @@ impl From<TuiEditorAction> for TuiInputAction {
     }
 }
 
+fn input_keymap_context(input_handles_escape: bool) -> keymap::Context {
+    let mut context = keymap::Context::default();
+    context.set.insert(TuiInputView::ui_name());
+    if input_handles_escape {
+        context.set.insert(INPUT_HANDLES_ESCAPE_FLAG);
+    }
+    context
+}
 impl TypedActionView for TuiInputView {
     type Action = TuiInputAction;
 
     fn handle_action(&mut self, action: &TuiInputAction, ctx: &mut ViewContext<Self>) {
-        if self.handle_slash_command_action(action, ctx) {
+        if self.handle_inline_menu_action(action, ctx) {
             return;
         }
         match action {
@@ -755,7 +751,9 @@ impl TypedActionView for TuiInputView {
                 self.model.update(ctx, |m, ctx| m.user_insert("\n", ctx));
             }
             TuiInputAction::Submit => self.submit(ctx),
-            TuiInputAction::DismissSlashCommands => {}
+            TuiInputAction::HandleEscape => {
+                self.handle_escape(ctx);
+            }
             TuiInputAction::Backspace => {
                 // With nothing left to delete, backspace removes the `!`
                 // affordance instead; typed text is preserved.
@@ -886,11 +884,6 @@ impl TypedActionView for TuiInputView {
             }
             TuiInputAction::Redo => {
                 self.model.update(ctx, |m, ctx| m.redo(ctx));
-            }
-            TuiInputAction::ExitShellMode => {
-                if self.is_shell_mode(ctx) {
-                    self.exit_shell_mode(ctx);
-                }
             }
             TuiInputAction::SelectionStartAt { offset } => {
                 self.model
@@ -1055,7 +1048,7 @@ impl TuiInputView {
         ctx.emit(TuiInputViewEvent::Submitted(text));
     }
 
-    fn handle_slash_command_action(
+    fn handle_inline_menu_action(
         &mut self,
         action: &TuiInputAction,
         ctx: &mut ViewContext<Self>,
@@ -1065,38 +1058,56 @@ impl TuiInputView {
             TuiInputAction::MoveUp
                 | TuiInputAction::MoveDown
                 | TuiInputAction::Submit
-                | TuiInputAction::DismissSlashCommands
+                | TuiInputAction::HandleEscape
         ) {
             return false;
         }
-        let Some(slash_commands) = self.slash_commands.clone() else {
+        let Some(inline_menu) = self.inline_menu.clone() else {
             return false;
         };
-        if !slash_commands.as_ref(ctx).is_open() {
+        if !inline_menu.is_open(ctx) {
             return false;
         }
 
         match action {
             TuiInputAction::MoveUp => {
-                slash_commands.update(ctx, |model, ctx| model.select_previous(ctx));
+                inline_menu.select_previous(ctx);
             }
             TuiInputAction::MoveDown => {
-                slash_commands.update(ctx, |model, ctx| model.select_next(ctx));
+                inline_menu.select_next(ctx);
             }
             TuiInputAction::Submit => {
-                let selected_action = slash_commands.as_ref(ctx).selected_action();
-                slash_commands.update(ctx, |model, ctx| model.dismiss(ctx));
-                if let Some(selected_action) = selected_action {
-                    ctx.emit(TuiInputViewEvent::AcceptedSlashCommand(selected_action));
+                if let Some(accepted) = inline_menu.accept(ctx) {
+                    match accepted {
+                        TuiInlineMenuAccepted::SlashCommand(action) => {
+                            ctx.emit(TuiInputViewEvent::AcceptedSlashCommand(action));
+                        }
+                    }
                 }
             }
-            TuiInputAction::DismissSlashCommands => {
-                slash_commands.update(ctx, |model, ctx| model.dismiss(ctx));
-            }
+            TuiInputAction::HandleEscape => return self.handle_escape(ctx),
             _ => return false,
         }
         ctx.notify();
         true
+    }
+
+    /// Handles the input's contextual Escape behavior in explicit priority
+    /// order. New input modes should be added after the inline-menu branch so
+    /// one Escape always closes the most local surface first.
+    fn handle_escape(&mut self, ctx: &mut ViewContext<Self>) -> bool {
+        if let Some(inline_menu) = self.inline_menu.clone() {
+            if inline_menu.is_open(ctx) {
+                inline_menu.dismiss(ctx);
+                ctx.notify();
+                return true;
+            }
+        }
+        if self.is_shell_mode(ctx) {
+            self.exit_shell_mode(ctx);
+            return true;
+        }
+        false
     }
 
     // ── Kill / yank ───────────────────────────────────────────────────────────

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -25,7 +25,9 @@ use std::ops::Range;
 
 use string_offset::CharOffset;
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
-use warp::tui_export::{BlocklistAIInputModel, InputTypeAutoDetectionSource};
+use warp::tui_export::{
+    AcceptSlashCommandOrSavedPrompt, BlocklistAIInputModel, InputTypeAutoDetectionSource,
+};
 use warp_editor::model::{CoreEditorModel, PlainTextEditorModel};
 use warp_editor::selection::TextUnit;
 use warpui_core::elements::tui::{TuiContainer, TuiElement, TuiFlex, TuiHoverable, TuiText};
@@ -39,6 +41,7 @@ use super::kill_buffer::KillBuffer;
 use crate::editor_element::{TuiEditorAction, TuiEditorElement};
 use crate::input_mode_policy::{self, AI_LOCKED_CONFIG, SHELL_LOCKED_CONFIG};
 use crate::keybindings::TUI_BINDING_GROUP;
+use crate::slash_commands::TuiSlashCommandModel;
 use crate::tui_builder::TuiUiBuilder;
 
 /// Keymap-context flag set by [`TuiInputView::keymap_context`] while the input
@@ -97,6 +100,14 @@ pub fn init(app: &mut AppContext) {
         .with_context_predicate(id!("TuiInputView"))
         .with_group(TUI_BINDING_GROUP)
         .with_key_binding("alt-enter"),
+        EditableBinding::new(
+            "tui:input:dismiss_slash_commands",
+            "Dismiss slash commands",
+            TuiInputAction::DismissSlashCommands,
+        )
+        .with_context_predicate(id!("TuiInputView"))
+        .with_group(TUI_BINDING_GROUP)
+        .with_key_binding("escape"),
         // ── Deletion ───────────────────────────────────────────────────
         EditableBinding::new(
             "tui:input:backspace",
@@ -459,6 +470,8 @@ pub fn init(app: &mut AppContext) {
 pub enum TuiInputViewEvent {
     /// The user pressed Enter to submit the current input. Contains the final text.
     Submitted(String),
+    /// The user selected a slash command menu item.
+    AcceptedSlashCommand(AcceptSlashCommandOrSavedPrompt),
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -476,6 +489,8 @@ pub enum TuiInputAction {
     InsertNewline,
     /// Submit the current input (`Enter`).
     Submit,
+    /// Dismiss an open slash command menu (`Escape`).
+    DismissSlashCommands,
     /// Delete the character before the cursor (`Backspace`, `Ctrl+H`).
     Backspace,
     /// Delete the character after the cursor (`Delete`, `Ctrl+D`).
@@ -558,6 +573,8 @@ pub struct TuiInputView {
     model: ModelHandle<CodeEditorModel>,
     /// Shared input-mode state driving `!` shell-mode handling.
     input_mode: ModelHandle<BlocklistAIInputModel>,
+    /// Optional slash command state model used to route menu keyboard actions.
+    slash_commands: Option<ModelHandle<TuiSlashCommandModel>>,
     /// Single-entry kill buffer for `Ctrl+K` / `Ctrl+U` / `Ctrl+Y`.
     kill_buffer: KillBuffer,
     /// Maximum number of visible rows before the input scrolls.
@@ -586,6 +603,15 @@ impl TuiInputView {
         input_mode: ModelHandle<BlocklistAIInputModel>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
+        Self::new_with_slash_commands(model, input_mode, None, ctx)
+    }
+
+    pub(crate) fn new_with_slash_commands(
+        model: ModelHandle<CodeEditorModel>,
+        input_mode: ModelHandle<BlocklistAIInputModel>,
+        slash_commands: Option<ModelHandle<TuiSlashCommandModel>>,
+        ctx: &mut ViewContext<Self>,
+    ) -> Self {
         ctx.subscribe_to_model(&model, |_, _, event, ctx| {
             if matches!(event, CodeEditorModelEvent::ContentChanged { .. }) {
                 ctx.notify();
@@ -597,6 +623,7 @@ impl TuiInputView {
         Self {
             model,
             input_mode,
+            slash_commands,
             kill_buffer: KillBuffer::default(),
             max_visible_rows: 6,
             prefix_mouse_state: MouseStateHandle::default(),
@@ -710,6 +737,9 @@ impl TypedActionView for TuiInputView {
     type Action = TuiInputAction;
 
     fn handle_action(&mut self, action: &TuiInputAction, ctx: &mut ViewContext<Self>) {
+        if self.handle_slash_command_action(action, ctx) {
+            return;
+        }
         match action {
             TuiInputAction::InsertChar(c) => {
                 // A `!` typed at the very start of the input enters shell mode
@@ -725,6 +755,7 @@ impl TypedActionView for TuiInputView {
                 self.model.update(ctx, |m, ctx| m.user_insert("\n", ctx));
             }
             TuiInputAction::Submit => self.submit(ctx),
+            TuiInputAction::DismissSlashCommands => {}
             TuiInputAction::Backspace => {
                 // With nothing left to delete, backspace removes the `!`
                 // affordance instead; typed text is preserved.
@@ -1022,6 +1053,50 @@ impl TuiInputView {
     fn submit(&mut self, ctx: &mut ViewContext<Self>) {
         let text = self.plain_text(ctx);
         ctx.emit(TuiInputViewEvent::Submitted(text));
+    }
+
+    fn handle_slash_command_action(
+        &mut self,
+        action: &TuiInputAction,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
+        if !matches!(
+            action,
+            TuiInputAction::MoveUp
+                | TuiInputAction::MoveDown
+                | TuiInputAction::Submit
+                | TuiInputAction::DismissSlashCommands
+        ) {
+            return false;
+        }
+        let Some(slash_commands) = self.slash_commands.clone() else {
+            return false;
+        };
+        if !slash_commands.as_ref(ctx).is_open() {
+            return false;
+        }
+
+        match action {
+            TuiInputAction::MoveUp => {
+                slash_commands.update(ctx, |model, ctx| model.select_previous(ctx));
+            }
+            TuiInputAction::MoveDown => {
+                slash_commands.update(ctx, |model, ctx| model.select_next(ctx));
+            }
+            TuiInputAction::Submit => {
+                let selected_action = slash_commands.as_ref(ctx).selected_action();
+                slash_commands.update(ctx, |model, ctx| model.dismiss(ctx));
+                if let Some(selected_action) = selected_action {
+                    ctx.emit(TuiInputViewEvent::AcceptedSlashCommand(selected_action));
+                }
+            }
+            TuiInputAction::DismissSlashCommands => {
+                slash_commands.update(ctx, |model, ctx| model.dismiss(ctx));
+            }
+            _ => return false,
+        }
+        ctx.notify();
+        true
     }
 
     // ── Kill / yank ───────────────────────────────────────────────────────────

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -3,13 +3,15 @@
 //! These drive a real [`CodeEditorModel`] (TUI char-cell mode) behind a real
 //! [`TuiInputView`] so they exercise the exact render/layout/cursor path the
 //! presenter uses, not a reimplementation of it.
-
+use std::cell::RefCell;
 use std::rc::Rc;
 
 use string_offset::CharOffset;
 use warp::appearance::Appearance;
 use warp::editor::CodeEditorModel;
-use warp::tui_export::BlocklistAIInputModel;
+use warp::tui_export::{
+    AcceptSlashCommandOrSavedPrompt, BlocklistAIInputModel, SlashCommandId, SlashCommandMixer,
+};
 use warp_core::semantic_selection::SemanticSelection;
 use warp_editor::model::CoreEditorModel;
 use warpui::EntityIdMap;
@@ -20,13 +22,31 @@ use warpui_core::elements::tui::{
 use warpui_core::event::{KeyEventDetails, ModifiersState};
 use warpui_core::keymap::Keystroke;
 use warpui_core::platform::WindowStyle;
-use warpui_core::{AddWindowOptions, App, AppContext, TuiView, TypedActionView, ViewHandle};
+use warpui_core::{
+    AddWindowOptions, App, AppContext, ModelHandle, TuiView, TypedActionView, ViewHandle,
+};
 
-use super::{TuiInputAction, TuiInputView, SHELL_MODE_INPUT_FLAG};
+use super::{
+    input_keymap_context, TuiInputAction, TuiInputView, TuiInputViewEvent,
+    INPUT_HANDLES_ESCAPE_FLAG,
+};
 use crate::editor_element::TuiEditorElement;
+use crate::inline_menu::TuiInlineMenu;
 use crate::input_mode_policy::TuiInputModePolicy;
+use crate::slash_commands::{TuiSlashCommandModel, TuiSlashCommandRow};
 
 const W: u16 = 80;
+
+#[test]
+fn input_escape_context_is_present_only_while_escape_is_handled() {
+    let closed = input_keymap_context(false);
+    assert!(closed.set.contains("TuiInputView"));
+    assert!(!closed.set.contains(INPUT_HANDLES_ESCAPE_FLAG));
+
+    let open = input_keymap_context(true);
+    assert!(open.set.contains("TuiInputView"));
+    assert!(open.set.contains(INPUT_HANDLES_ESCAPE_FLAG));
+}
 
 fn build_view(ctx: &mut AppContext) -> ViewHandle<TuiInputView> {
     // `CodeEditorModel::new_tui` reads syntax colors from the `Appearance`
@@ -43,10 +63,142 @@ fn build_view(ctx: &mut AppContext) -> ViewHandle<TuiInputView> {
         },
         |ctx| {
             let model = ctx.add_model(|ctx| CodeEditorModel::new_tui(W, ctx));
-            TuiInputView::new(model, input_mode, ctx)
+            TuiInputView::new(model, input_mode, None, ctx)
         },
     );
     view
+}
+
+fn build_view_with_inline_menu(
+    ctx: &mut AppContext,
+) -> (
+    ViewHandle<TuiInputView>,
+    ModelHandle<TuiSlashCommandModel>,
+    [SlashCommandId; 2],
+) {
+    ctx.add_singleton_model(|_| Appearance::mock());
+    ctx.add_singleton_model(|_| SemanticSelection::mock(true, ""));
+    let input_model = ctx.add_model(|ctx| CodeEditorModel::new_tui(W, ctx));
+    let input_mode = BlocklistAIInputModel::mock(Rc::new(TuiInputModePolicy), ctx);
+    let mixer = ctx.add_model(|_| SlashCommandMixer::new());
+    let ids = [SlashCommandId::new(), SlashCommandId::new()];
+    let rows = ids
+        .iter()
+        .enumerate()
+        .map(|(index, id)| TuiSlashCommandRow {
+            title: format!("Command {index}"),
+            description: None,
+            action: AcceptSlashCommandOrSavedPrompt::SlashCommand { id: *id },
+        })
+        .collect();
+    let menu_model =
+        ctx.add_model(|_| TuiSlashCommandModel::new_for_test(input_model.clone(), mixer, rows, 0));
+    let inline_menu = TuiInlineMenu::SlashCommands(menu_model.clone());
+    let (_window_id, view) = ctx.add_tui_window(
+        AddWindowOptions {
+            window_style: WindowStyle::NotStealFocus,
+            ..Default::default()
+        },
+        move |ctx| TuiInputView::new(input_model, input_mode, Some(inline_menu), ctx),
+    );
+    (view, menu_model, ids)
+}
+
+fn selected_slash_command_id(
+    menu_model: &ModelHandle<TuiSlashCommandModel>,
+    ctx: &AppContext,
+) -> Option<SlashCommandId> {
+    match menu_model.as_ref(ctx).selected_action()? {
+        AcceptSlashCommandOrSavedPrompt::SlashCommand { id } => Some(id),
+        AcceptSlashCommandOrSavedPrompt::SavedPrompt { .. }
+        | AcceptSlashCommandOrSavedPrompt::Skill { .. } => None,
+    }
+}
+
+#[test]
+fn inline_menu_navigation_routes_before_editor_navigation() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let (view, menu_model, ids) = build_view_with_inline_menu(ctx);
+            assert_eq!(selected_slash_command_id(&menu_model, ctx), Some(ids[0]));
+
+            dispatch(&view, ctx, &[TuiInputAction::MoveDown]);
+            assert_eq!(selected_slash_command_id(&menu_model, ctx), Some(ids[1]));
+
+            dispatch(&view, ctx, &[TuiInputAction::MoveUp]);
+            assert_eq!(selected_slash_command_id(&menu_model, ctx), Some(ids[0]));
+        });
+    });
+}
+
+#[test]
+fn inline_menu_accept_dismisses_before_emitting_unchanged_payload() {
+    App::test((), |mut app| async move {
+        let (view, menu_model, ids, accepted) = app.update(|ctx| {
+            let (view, menu_model, ids) = build_view_with_inline_menu(ctx);
+            let accepted = Rc::new(RefCell::new(Vec::new()));
+            let accepted_for_subscription = accepted.clone();
+            let menu_for_subscription = menu_model.clone();
+            ctx.subscribe_to_view(&view, move |_, event, ctx| {
+                if let TuiInputViewEvent::AcceptedSlashCommand(
+                    AcceptSlashCommandOrSavedPrompt::SlashCommand { id },
+                ) = event
+                {
+                    accepted_for_subscription
+                        .borrow_mut()
+                        .push((*id, !menu_for_subscription.as_ref(ctx).is_open()));
+                }
+            });
+            (view, menu_model, ids, accepted)
+        });
+        app.update(|ctx| {
+            dispatch(&view, ctx, &[TuiInputAction::Submit]);
+        });
+        app.read(|ctx| {
+            assert_eq!(accepted.borrow().as_slice(), &[(ids[0], true)]);
+            assert!(!menu_model.as_ref(ctx).is_open());
+        });
+    });
+}
+
+#[test]
+fn escape_dismisses_menu_and_closed_menu_submit_falls_through() {
+    App::test((), |mut app| async move {
+        let (view, menu_model, submitted) = app.update(|ctx| {
+            let (view, menu_model, _) = build_view_with_inline_menu(ctx);
+            type_str(&view, ctx, "!");
+            assert!(view.as_ref(ctx).is_shell_mode(ctx));
+            dispatch(&view, ctx, &[TuiInputAction::HandleEscape]);
+            assert!(
+                view.as_ref(ctx).is_shell_mode(ctx),
+                "the first escape must dismiss the menu before exiting shell mode"
+            );
+
+            let submitted = Rc::new(RefCell::new(Vec::new()));
+            let submitted_for_subscription = submitted.clone();
+            ctx.subscribe_to_view(&view, move |_, event, _| {
+                if let TuiInputViewEvent::Submitted(text) = event {
+                    submitted_for_subscription.borrow_mut().push(text.clone());
+                }
+            });
+            (view, menu_model, submitted)
+        });
+
+        app.update(|ctx| {
+            assert!(!menu_model.as_ref(ctx).is_open());
+            assert!(view
+                .as_ref(ctx)
+                .keymap_context(ctx)
+                .set
+                .contains(INPUT_HANDLES_ESCAPE_FLAG));
+            type_str(&view, ctx, "prompt");
+            dispatch(&view, ctx, &[TuiInputAction::Submit]);
+        });
+        app.read(|ctx| {
+            assert_eq!(submitted.borrow().as_slice(), &["prompt"]);
+            assert_eq!(text(&view, ctx), "prompt");
+        });
+    });
 }
 
 fn dispatch(view: &ViewHandle<TuiInputView>, ctx: &mut AppContext, actions: &[TuiInputAction]) {
@@ -787,9 +939,8 @@ fn submit_keeps_buffer_until_cleared() {
     });
 }
 
-/// Esc is never consumed by the element — the shell-mode exit is the
-/// `tui:input:exit_shell_mode` keymap binding, gated on the shell-mode
-/// keymap-context flag — and `ExitShellMode` is a no-op outside shell mode.
+/// Esc is never consumed by the element; the contextual Escape keymap binding
+/// dispatches `HandleEscape`, which is a no-op outside an inline menu or shell mode.
 #[test]
 fn escape_is_not_consumed_by_the_element() {
     App::test((), |mut app| async move {
@@ -817,14 +968,14 @@ fn escape_is_not_consumed_by_the_element() {
                 "escape must not be consumed by the element"
             );
 
-            dispatch(&view, ctx, &[TuiInputAction::ExitShellMode]);
+            dispatch(&view, ctx, &[TuiInputAction::HandleEscape]);
             assert_eq!(text(&view, ctx), "ab", "no-op outside shell mode");
         });
     });
 }
 
-/// The keymap context carries the shell-mode flag exactly while in shell
-/// mode, gating the Esc binding.
+/// The keymap context enables the unified Escape binding exactly while shell
+/// mode or an inline menu needs it.
 #[test]
 fn keymap_context_flags_shell_mode() {
     App::test((), |mut app| async move {
@@ -832,13 +983,14 @@ fn keymap_context_flags_shell_mode() {
             let view = build_view(ctx);
             assert_eq!(
                 view.as_ref(ctx).keymap_context(ctx),
-                TuiInputView::default_keymap_context()
+                input_keymap_context(false)
             );
 
             type_str(&view, ctx, "!");
-            let mut expected = TuiInputView::default_keymap_context();
-            expected.set.insert(SHELL_MODE_INPUT_FLAG);
-            assert_eq!(view.as_ref(ctx).keymap_context(ctx), expected);
+            assert_eq!(
+                view.as_ref(ctx).keymap_context(ctx),
+                input_keymap_context(true)
+            );
         });
     });
 }

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -20,6 +20,7 @@ mod ui;
 mod conversation_selection;
 mod editor_element;
 mod exit_confirmation;
+mod inline_menu;
 mod input_mode_policy;
 mod keybindings;
 mod slash_commands;

--- a/crates/warp_tui/src/slash_commands.rs
+++ b/crates/warp_tui/src/slash_commands.rs
@@ -13,11 +13,12 @@ use warp::tui_export::{
     SlashCommandMixer, TuiSlashCommandDataSource, UpdatedActiveCommands,
 };
 use warp_editor::model::CoreEditorModel;
-use warpui_core::elements::tui::{TuiContainer, TuiElement, TuiFlex, TuiText};
-use warpui_core::elements::CrossAxisAlignment;
+use warp_search_core::inline_menu::{InitialSelection, InlineMenuSelection};
 use warpui_core::{AppContext, Entity, ModelContext, ModelHandle};
 
-use crate::tui_builder::TuiUiBuilder;
+use crate::inline_menu::{
+    keep_selected_visible, TuiInlineMenuRow, TuiInlineMenuSnapshot, TuiInlineMenuStatus,
+};
 
 const MAX_VISIBLE_ROWS: usize = 8;
 
@@ -37,7 +38,7 @@ pub(crate) enum TuiSlashCommandState {
     Open {
         query: String,
         rows: Vec<TuiSlashCommandRow>,
-        selected_index: usize,
+        selection: InlineMenuSelection,
         scroll_offset: usize,
         select_last_result_on_refresh: bool,
         is_loading: bool,
@@ -88,6 +89,29 @@ impl TuiSlashCommandModel {
         model
     }
 
+    #[cfg(test)]
+    pub(crate) fn new_for_test(
+        input_editor: ModelHandle<CodeEditorModel>,
+        mixer: ModelHandle<SlashCommandMixer>,
+        rows: Vec<TuiSlashCommandRow>,
+        selected_index: usize,
+    ) -> Self {
+        let mut selection = InlineMenuSelection::default();
+        selection.select(selected_index, rows.len(), |_| true);
+        Self {
+            input_editor,
+            mixer,
+            state: TuiSlashCommandState::Open {
+                query: String::new(),
+                rows,
+                selection,
+                scroll_offset: 0,
+                select_last_result_on_refresh: false,
+                is_loading: false,
+            },
+        }
+    }
+
     pub(crate) fn query(&self) -> Option<&str> {
         match &self.state {
             TuiSlashCommandState::Closed => None,
@@ -101,53 +125,46 @@ impl TuiSlashCommandModel {
 
     pub(crate) fn selected_action(&self) -> Option<AcceptSlashCommandOrSavedPrompt> {
         let TuiSlashCommandState::Open {
-            rows,
-            selected_index,
-            ..
+            rows, selection, ..
         } = &self.state
         else {
             return None;
         };
-        rows.get(*selected_index).map(|row| row.action.clone())
+        selection
+            .selected_index()
+            .and_then(|index| rows.get(index))
+            .map(|row| row.action.clone())
     }
 
     pub(crate) fn select_previous(&mut self, ctx: &mut ModelContext<Self>) {
         let TuiSlashCommandState::Open {
             rows,
-            selected_index,
+            selection,
             scroll_offset,
             ..
         } = &mut self.state
         else {
             return;
         };
-        if rows.is_empty() {
-            return;
+        if let Some(selected_index) = selection.select_previous(rows.len(), |_| true) {
+            keep_selected_visible(rows.len(), selected_index, MAX_VISIBLE_ROWS, scroll_offset);
         }
-        *selected_index = if *selected_index == 0 {
-            rows.len() - 1
-        } else {
-            *selected_index - 1
-        };
-        keep_selected_visible(rows.len(), *selected_index, scroll_offset);
         ctx.emit(TuiSlashCommandModelEvent);
     }
 
     pub(crate) fn select_next(&mut self, ctx: &mut ModelContext<Self>) {
         let TuiSlashCommandState::Open {
             rows,
-            selected_index,
+            selection,
             scroll_offset,
             ..
         } = &mut self.state
         else {
             return;
         };
-        if rows.is_empty() {
-            return;
+        if let Some(selected_index) = selection.select_next(rows.len(), |_| true) {
+            keep_selected_visible(rows.len(), selected_index, MAX_VISIBLE_ROWS, scroll_offset);
         }
-        *selected_index = (*selected_index + 1) % rows.len();
-        keep_selected_visible(rows.len(), *selected_index, scroll_offset);
         ctx.emit(TuiSlashCommandModelEvent);
     }
 
@@ -155,10 +172,10 @@ impl TuiSlashCommandModel {
         self.close(ctx);
     }
 
-    pub(crate) fn render_menu(&self, app: &AppContext) -> Option<Box<dyn TuiElement>> {
+    pub(crate) fn snapshot(&self) -> Option<TuiInlineMenuSnapshot> {
         let TuiSlashCommandState::Open {
             rows,
-            selected_index,
+            selection,
             scroll_offset,
             is_loading,
             ..
@@ -166,32 +183,30 @@ impl TuiSlashCommandModel {
         else {
             return None;
         };
-
-        let builder = TuiUiBuilder::from_app(app);
-        let mut column = TuiFlex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
-        if rows.is_empty() {
-            let label = if *is_loading {
-                "Loading slash commands…"
+        let status = if rows.is_empty() {
+            Some(if *is_loading {
+                TuiInlineMenuStatus::Loading("Loading slash commands…".to_owned())
             } else {
-                "No slash commands found"
-            };
-            column = column.child(menu_status_row(label, &builder));
+                TuiInlineMenuStatus::Empty("No slash commands found".to_owned())
+            })
         } else {
-            for (index, row) in rows
+            None
+        };
+        Some(TuiInlineMenuSnapshot {
+            header: None,
+            rows: rows
                 .iter()
-                .enumerate()
-                .skip(*scroll_offset)
-                .take(MAX_VISIBLE_ROWS)
-            {
-                column = column.child(menu_result_row(row, index == *selected_index, &builder));
-            }
-        }
-
-        Some(
-            TuiContainer::new(column.finish())
-                .with_border_style(builder.accent_border_style())
-                .finish(),
-        )
+                .map(|row| TuiInlineMenuRow {
+                    title: row.title.clone(),
+                    description: row.description.clone(),
+                    is_selectable: true,
+                })
+                .collect(),
+            selected_index: selection.selected_index(),
+            scroll_offset: *scroll_offset,
+            max_visible_rows: MAX_VISIBLE_ROWS,
+            status,
+        })
     }
 
     fn update_from_input(&mut self, ctx: &mut ModelContext<Self>) {
@@ -204,16 +219,16 @@ impl TuiSlashCommandModel {
     }
 
     fn run_query(&mut self, query: String, force: bool, ctx: &mut ModelContext<Self>) {
-        let (previous_query_matches, previous_selected_index, previous_scroll_offset) =
-            match &self.state {
-                TuiSlashCommandState::Closed => (false, 0, 0),
-                TuiSlashCommandState::Open {
-                    query: previous_query,
-                    selected_index,
-                    scroll_offset,
-                    ..
-                } => (previous_query == &query, *selected_index, *scroll_offset),
-            };
+        let (previous_query_matches, previous_selection, previous_scroll_offset) = match &self.state
+        {
+            TuiSlashCommandState::Closed => (false, InlineMenuSelection::default(), 0),
+            TuiSlashCommandState::Open {
+                query: previous_query,
+                selection,
+                scroll_offset,
+                ..
+            } => (previous_query == &query, *selection, *scroll_offset),
+        };
         let select_last_result_on_refresh = query.is_empty() && !previous_query_matches;
         let scroll_offset = if select_last_result_on_refresh {
             0
@@ -223,7 +238,7 @@ impl TuiSlashCommandModel {
         self.state = TuiSlashCommandState::Open {
             query: query.clone(),
             rows: Vec::new(),
-            selected_index: previous_selected_index,
+            selection: previous_selection,
             scroll_offset,
             select_last_result_on_refresh,
             is_loading: true,
@@ -239,7 +254,7 @@ impl TuiSlashCommandModel {
 
     fn refresh_rows(&mut self, ctx: &mut ModelContext<Self>) {
         let TuiSlashCommandState::Open {
-            selected_index,
+            selection,
             scroll_offset,
             rows,
             select_last_result_on_refresh,
@@ -254,16 +269,20 @@ impl TuiSlashCommandModel {
         *rows = mixer.results().iter().filter_map(row_from_result).collect();
         *is_loading = mixer.is_loading();
         if rows.is_empty() {
-            *selected_index = 0;
+            selection.clear();
             *scroll_offset = 0;
         } else {
             if *select_last_result_on_refresh {
-                *selected_index = rows.len() - 1;
+                selection.reset(rows.len(), InitialSelection::Last, |_| true);
                 *select_last_result_on_refresh = false;
+            } else if let Some(selected_index) = selection.selected_index() {
+                selection.select(selected_index.min(rows.len() - 1), rows.len(), |_| true);
             } else {
-                *selected_index = (*selected_index).min(rows.len() - 1);
+                selection.reset(rows.len(), InitialSelection::First, |_| true);
             }
-            keep_selected_visible(rows.len(), *selected_index, scroll_offset);
+            if let Some(selected_index) = selection.selected_index() {
+                keep_selected_visible(rows.len(), selected_index, MAX_VISIBLE_ROWS, scroll_offset);
+            }
         }
         ctx.emit(TuiSlashCommandModelEvent);
     }
@@ -306,72 +325,4 @@ fn row_from_result(
         description: detail.description,
         action: result.accept_result(),
     })
-}
-fn keep_selected_visible(rows_len: usize, selected_index: usize, scroll_offset: &mut usize) {
-    if rows_len == 0 {
-        *scroll_offset = 0;
-        return;
-    }
-
-    let max_scroll_offset = rows_len.saturating_sub(MAX_VISIBLE_ROWS);
-    *scroll_offset = (*scroll_offset).min(max_scroll_offset);
-    if selected_index < *scroll_offset {
-        *scroll_offset = selected_index;
-    } else if selected_index >= *scroll_offset + MAX_VISIBLE_ROWS {
-        *scroll_offset = selected_index + 1 - MAX_VISIBLE_ROWS;
-    }
-}
-
-fn menu_status_row(label: &str, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
-    TuiContainer::new(
-        TuiText::new(label.to_owned())
-            .with_style(builder.dim_text_style())
-            .truncate()
-            .finish(),
-    )
-    .with_padding_left(1)
-    .with_padding_right(1)
-    .finish()
-}
-
-fn menu_result_row(
-    row: &TuiSlashCommandRow,
-    is_selected: bool,
-    builder: &TuiUiBuilder,
-) -> Box<dyn TuiElement> {
-    let title_style = if is_selected {
-        builder.input_text_style()
-    } else {
-        builder.primary_text_style()
-    };
-    let description_style = if is_selected {
-        builder.input_text_style()
-    } else {
-        builder.muted_text_style()
-    };
-
-    let mut content = TuiFlex::row()
-        .with_cross_axis_alignment(CrossAxisAlignment::Center)
-        .child(
-            TuiText::new(row.title.clone())
-                .with_style(title_style)
-                .truncate()
-                .finish(),
-        );
-    if let Some(description) = &row.description {
-        content = content.child(
-            TuiText::new(format!("  {description}"))
-                .with_style(description_style)
-                .truncate()
-                .finish(),
-        );
-    }
-
-    let mut container = TuiContainer::new(content.finish())
-        .with_padding_left(1)
-        .with_padding_right(1);
-    if is_selected {
-        container = container.with_background(builder.input_background());
-    }
-    container.finish()
 }

--- a/crates/warp_tui/src/slash_commands.rs
+++ b/crates/warp_tui/src/slash_commands.rs
@@ -13,7 +13,13 @@ use warp::tui_export::{
     SlashCommandMixer, TuiSlashCommandDataSource, UpdatedActiveCommands,
 };
 use warp_editor::model::CoreEditorModel;
+use warpui_core::elements::tui::{TuiContainer, TuiElement, TuiFlex, TuiText};
+use warpui_core::elements::CrossAxisAlignment;
 use warpui_core::{AppContext, Entity, ModelContext, ModelHandle};
+
+use crate::tui_builder::TuiUiBuilder;
+
+const MAX_VISIBLE_ROWS: usize = 8;
 
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
@@ -32,6 +38,8 @@ pub(crate) enum TuiSlashCommandState {
         query: String,
         rows: Vec<TuiSlashCommandRow>,
         selected_index: usize,
+        scroll_offset: usize,
+        select_last_result_on_refresh: bool,
         is_loading: bool,
     },
 }
@@ -91,6 +99,101 @@ impl TuiSlashCommandModel {
         matches!(self.state, TuiSlashCommandState::Open { .. })
     }
 
+    pub(crate) fn selected_action(&self) -> Option<AcceptSlashCommandOrSavedPrompt> {
+        let TuiSlashCommandState::Open {
+            rows,
+            selected_index,
+            ..
+        } = &self.state
+        else {
+            return None;
+        };
+        rows.get(*selected_index).map(|row| row.action.clone())
+    }
+
+    pub(crate) fn select_previous(&mut self, ctx: &mut ModelContext<Self>) {
+        let TuiSlashCommandState::Open {
+            rows,
+            selected_index,
+            scroll_offset,
+            ..
+        } = &mut self.state
+        else {
+            return;
+        };
+        if rows.is_empty() {
+            return;
+        }
+        *selected_index = if *selected_index == 0 {
+            rows.len() - 1
+        } else {
+            *selected_index - 1
+        };
+        keep_selected_visible(rows.len(), *selected_index, scroll_offset);
+        ctx.emit(TuiSlashCommandModelEvent);
+    }
+
+    pub(crate) fn select_next(&mut self, ctx: &mut ModelContext<Self>) {
+        let TuiSlashCommandState::Open {
+            rows,
+            selected_index,
+            scroll_offset,
+            ..
+        } = &mut self.state
+        else {
+            return;
+        };
+        if rows.is_empty() {
+            return;
+        }
+        *selected_index = (*selected_index + 1) % rows.len();
+        keep_selected_visible(rows.len(), *selected_index, scroll_offset);
+        ctx.emit(TuiSlashCommandModelEvent);
+    }
+
+    pub(crate) fn dismiss(&mut self, ctx: &mut ModelContext<Self>) {
+        self.close(ctx);
+    }
+
+    pub(crate) fn render_menu(&self, app: &AppContext) -> Option<Box<dyn TuiElement>> {
+        let TuiSlashCommandState::Open {
+            rows,
+            selected_index,
+            scroll_offset,
+            is_loading,
+            ..
+        } = &self.state
+        else {
+            return None;
+        };
+
+        let builder = TuiUiBuilder::from_app(app);
+        let mut column = TuiFlex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+        if rows.is_empty() {
+            let label = if *is_loading {
+                "Loading slash commands…"
+            } else {
+                "No slash commands found"
+            };
+            column = column.child(menu_status_row(label, &builder));
+        } else {
+            for (index, row) in rows
+                .iter()
+                .enumerate()
+                .skip(*scroll_offset)
+                .take(MAX_VISIBLE_ROWS)
+            {
+                column = column.child(menu_result_row(row, index == *selected_index, &builder));
+            }
+        }
+
+        Some(
+            TuiContainer::new(column.finish())
+                .with_border_style(builder.accent_border_style())
+                .finish(),
+        )
+    }
+
     fn update_from_input(&mut self, ctx: &mut ModelContext<Self>) {
         let input = input_text(&self.input_editor, ctx);
         let Some(query) = slash_command_composition_filter(&input).map(str::to_owned) else {
@@ -101,14 +204,28 @@ impl TuiSlashCommandModel {
     }
 
     fn run_query(&mut self, query: String, force: bool, ctx: &mut ModelContext<Self>) {
-        let previous_selected_index = match &self.state {
-            TuiSlashCommandState::Closed => 0,
-            TuiSlashCommandState::Open { selected_index, .. } => *selected_index,
+        let (previous_query_matches, previous_selected_index, previous_scroll_offset) =
+            match &self.state {
+                TuiSlashCommandState::Closed => (false, 0, 0),
+                TuiSlashCommandState::Open {
+                    query: previous_query,
+                    selected_index,
+                    scroll_offset,
+                    ..
+                } => (previous_query == &query, *selected_index, *scroll_offset),
+            };
+        let select_last_result_on_refresh = query.is_empty() && !previous_query_matches;
+        let scroll_offset = if select_last_result_on_refresh {
+            0
+        } else {
+            previous_scroll_offset
         };
         self.state = TuiSlashCommandState::Open {
             query: query.clone(),
             rows: Vec::new(),
             selected_index: previous_selected_index,
+            scroll_offset,
+            select_last_result_on_refresh,
             is_loading: true,
         };
         self.mixer.update(ctx, |mixer, ctx| {
@@ -123,7 +240,9 @@ impl TuiSlashCommandModel {
     fn refresh_rows(&mut self, ctx: &mut ModelContext<Self>) {
         let TuiSlashCommandState::Open {
             selected_index,
+            scroll_offset,
             rows,
+            select_last_result_on_refresh,
             is_loading,
             ..
         } = &mut self.state
@@ -134,7 +253,18 @@ impl TuiSlashCommandModel {
         let mixer = self.mixer.as_ref(ctx);
         *rows = mixer.results().iter().filter_map(row_from_result).collect();
         *is_loading = mixer.is_loading();
-        *selected_index = (*selected_index).min(rows.len().saturating_sub(1));
+        if rows.is_empty() {
+            *selected_index = 0;
+            *scroll_offset = 0;
+        } else {
+            if *select_last_result_on_refresh {
+                *selected_index = rows.len() - 1;
+                *select_last_result_on_refresh = false;
+            } else {
+                *selected_index = (*selected_index).min(rows.len() - 1);
+            }
+            keep_selected_visible(rows.len(), *selected_index, scroll_offset);
+        }
         ctx.emit(TuiSlashCommandModelEvent);
     }
 
@@ -176,4 +306,72 @@ fn row_from_result(
         description: detail.description,
         action: result.accept_result(),
     })
+}
+fn keep_selected_visible(rows_len: usize, selected_index: usize, scroll_offset: &mut usize) {
+    if rows_len == 0 {
+        *scroll_offset = 0;
+        return;
+    }
+
+    let max_scroll_offset = rows_len.saturating_sub(MAX_VISIBLE_ROWS);
+    *scroll_offset = (*scroll_offset).min(max_scroll_offset);
+    if selected_index < *scroll_offset {
+        *scroll_offset = selected_index;
+    } else if selected_index >= *scroll_offset + MAX_VISIBLE_ROWS {
+        *scroll_offset = selected_index + 1 - MAX_VISIBLE_ROWS;
+    }
+}
+
+fn menu_status_row(label: &str, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
+    TuiContainer::new(
+        TuiText::new(label.to_owned())
+            .with_style(builder.dim_text_style())
+            .truncate()
+            .finish(),
+    )
+    .with_padding_left(1)
+    .with_padding_right(1)
+    .finish()
+}
+
+fn menu_result_row(
+    row: &TuiSlashCommandRow,
+    is_selected: bool,
+    builder: &TuiUiBuilder,
+) -> Box<dyn TuiElement> {
+    let title_style = if is_selected {
+        builder.input_text_style()
+    } else {
+        builder.primary_text_style()
+    };
+    let description_style = if is_selected {
+        builder.input_text_style()
+    } else {
+        builder.muted_text_style()
+    };
+
+    let mut content = TuiFlex::row()
+        .with_cross_axis_alignment(CrossAxisAlignment::Center)
+        .child(
+            TuiText::new(row.title.clone())
+                .with_style(title_style)
+                .truncate()
+                .finish(),
+        );
+    if let Some(description) = &row.description {
+        content = content.child(
+            TuiText::new(format!("  {description}"))
+                .with_style(description_style)
+                .truncate()
+                .finish(),
+        );
+    }
+
+    let mut container = TuiContainer::new(content.finish())
+        .with_padding_left(1)
+        .with_padding_right(1);
+    if is_selected {
+        container = container.with_background(builder.input_background());
+    }
+    container.finish()
 }

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -42,6 +42,7 @@ use warpui_core::{
 use crate::autoupdate::{TuiAutoupdater, TuiAutoupdaterEvent};
 use crate::conversation_selection::TuiConversationSelection;
 use crate::exit_confirmation::{ExitConfirmation, CTRL_C_EXIT_WINDOW};
+use crate::inline_menu::TuiInlineMenu;
 use crate::input::{TuiInputView, TuiInputViewEvent};
 use crate::input_mode_policy::{self, TuiInputModePolicy};
 use crate::keybindings::TUI_BINDING_GROUP;
@@ -57,7 +58,7 @@ use crate::zero_state::render_zero_state;
 /// Width used before the first layout pass pushes the real terminal width into the editor.
 const INITIAL_INPUT_WIDTH: u16 = 80;
 const MAX_INPUT_TEXT_ROWS: u16 = 6;
-const MAX_SLASH_MENU_ROWS: u16 = 10;
+const MAX_INLINE_MENU_ROWS: u16 = 10;
 
 /// The footer hint shown while the ctrl-c exit confirmation is armed.
 const CTRL_C_EXIT_HINT: &str = "ctrl-c again to exit";
@@ -106,7 +107,7 @@ pub(crate) enum TuiTerminalSessionAction {
 pub(crate) struct TuiTerminalSessionView {
     transcript: ViewHandle<TuiTranscriptView>,
     input_view: ViewHandle<TuiInputView>,
-    slash_commands: ModelHandle<TuiSlashCommandModel>,
+    inline_menu: TuiInlineMenu,
     conversation_selection: ConversationSelectionHandle,
     ai_controller: ModelHandle<BlocklistAIController>,
     /// Read by the footer for the active session's working directory.
@@ -266,12 +267,13 @@ impl TuiTerminalSessionView {
             }
         });
         let input_mode_for_input_view = ai_input_model.clone();
-        let slash_commands_for_input = slash_commands.clone();
+        let inline_menu = TuiInlineMenu::SlashCommands(slash_commands);
+        let inline_menu_for_input = inline_menu.clone();
         let input_view = ctx.add_typed_action_tui_view(move |ctx| {
-            TuiInputView::new_with_slash_commands(
+            TuiInputView::new(
                 input_editor_model,
                 input_mode_for_input_view,
-                Some(slash_commands_for_input),
+                Some(inline_menu_for_input),
                 ctx,
             )
         });
@@ -442,7 +444,7 @@ impl TuiTerminalSessionView {
         Self {
             transcript,
             input_view,
-            slash_commands,
+            inline_menu,
             conversation_selection,
             ai_controller,
             active_session,
@@ -906,7 +908,7 @@ impl TuiView for TuiTerminalSessionView {
     }
 
     fn render(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
-        let slash_command_menu = self.slash_commands.as_ref(ctx).render_menu(ctx);
+        let inline_menu = self.inline_menu.render(ctx);
         // The border takes the shell-mode accent while in shell mode.
         let builder = TuiUiBuilder::from_app(ctx);
         let border_style = if self.is_shell_mode(ctx) {
@@ -987,10 +989,10 @@ impl TuiView for TuiTerminalSessionView {
                 }
             }
         }
-        if let Some(menu) = slash_command_menu {
+        if let Some(menu) = inline_menu {
             content = content.child(
                 TuiConstrainedBox::new(menu)
-                    .with_max_rows(MAX_SLASH_MENU_ROWS)
+                    .with_max_rows(MAX_INLINE_MENU_ROWS)
                     .finish(),
             );
         }

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -57,6 +57,7 @@ use crate::zero_state::render_zero_state;
 /// Width used before the first layout pass pushes the real terminal width into the editor.
 const INITIAL_INPUT_WIDTH: u16 = 80;
 const MAX_INPUT_TEXT_ROWS: u16 = 6;
+const MAX_SLASH_MENU_ROWS: u16 = 10;
 
 /// The footer hint shown while the ctrl-c exit confirmation is armed.
 const CTRL_C_EXIT_HINT: &str = "ctrl-c again to exit";
@@ -265,11 +266,20 @@ impl TuiTerminalSessionView {
             }
         });
         let input_mode_for_input_view = ai_input_model.clone();
+        let slash_commands_for_input = slash_commands.clone();
         let input_view = ctx.add_typed_action_tui_view(move |ctx| {
-            TuiInputView::new(input_editor_model, input_mode_for_input_view, ctx)
+            TuiInputView::new_with_slash_commands(
+                input_editor_model,
+                input_mode_for_input_view,
+                Some(slash_commands_for_input),
+                ctx,
+            )
         });
         ctx.subscribe_to_view(&input_view, |view, _, event, ctx| match event {
             TuiInputViewEvent::Submitted(text) => view.handle_submitted(text.clone(), ctx),
+            TuiInputViewEvent::AcceptedSlashCommand(action) => {
+                log::debug!("Accepted TUI slash command menu item: {action:?}");
+            }
         });
         // The input box border color and the footer's shell-mode hint depend
         // on the input mode.
@@ -896,7 +906,7 @@ impl TuiView for TuiTerminalSessionView {
     }
 
     fn render(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
-        let _slash_commands_open = self.slash_commands.as_ref(ctx).is_open();
+        let slash_command_menu = self.slash_commands.as_ref(ctx).render_menu(ctx);
         // The border takes the shell-mode accent while in shell mode.
         let builder = TuiUiBuilder::from_app(ctx);
         let border_style = if self.is_shell_mode(ctx) {
@@ -919,14 +929,14 @@ impl TuiView for TuiTerminalSessionView {
         // While the transcript has nothing to show, the zero state fills its
         // slot; the first accepted submission produces a visible block, which
         // swaps the transcript back in.
-        let mut column = TuiFlex::column();
+        let mut content = TuiFlex::column();
         if self.transcript.as_ref(ctx).is_empty() {
-            column = column.flex_child(render_zero_state(
+            content = content.flex_child(render_zero_state(
                 self.current_working_directory(ctx).as_deref(),
                 ctx,
             ));
         } else {
-            column = column.flex_child(TuiChildView::new(&self.transcript).finish());
+            content = content.flex_child(TuiChildView::new(&self.transcript).finish());
         }
 
         // While the selected conversation is in progress (the GUI warping
@@ -948,7 +958,7 @@ impl TuiView for TuiTerminalSessionView {
                     .latest_exchange()
                     .and_then(|exchange| exchange.time_since_start());
                 if let Some(elapsed) = warping_elapsed {
-                    column = column.child(
+                    content = content.child(
                         TuiContainer::new(render_warping_indicator(elapsed, ctx))
                             .with_padding_top(1)
                             .finish(),
@@ -965,7 +975,7 @@ impl TuiView for TuiTerminalSessionView {
                     .and_then(|ms| u64::try_from(ms).ok())
                     .map(Duration::from_millis);
                 if let Some(duration) = wall_to_wall {
-                    column = column.child(
+                    content = content.child(
                         TuiContainer::new(render_response_summary(
                             duration,
                             conversation.credits_spent_for_last_block(),
@@ -977,16 +987,22 @@ impl TuiView for TuiTerminalSessionView {
                 }
             }
         }
-
-        TuiContainer::new(
-            column
-                .child(input_box.finish())
-                .child(self.render_footer(ctx).finish())
+        if let Some(menu) = slash_command_menu {
+            content = content.child(
+                TuiConstrainedBox::new(menu)
+                    .with_max_rows(MAX_SLASH_MENU_ROWS)
+                    .finish(),
+            );
+        }
+        content = content.child(input_box.finish()).child(
+            TuiConstrainedBox::new(self.render_footer(ctx).finish())
+                .with_max_rows(1)
                 .finish(),
-        )
-        .with_padding_x(2)
-        .with_padding_top(2)
-        .finish()
+        );
+        TuiContainer::new(content.finish())
+            .with_padding_x(2)
+            .with_padding_top(2)
+            .finish()
     }
 }
 


### PR DESCRIPTION
## Description

Adds the visual and keyboard-interaction layer for the TUI slash command menu on top of the query state from the parent PR.

### Menu rendering

- Renders slash command results above the TUI input with selected, unselected, loading, and no-results states.
- Shows up to eight result rows and keeps the selected row inside the visible window while navigating.
- Preserves the selected action across result refreshes when possible and selects the highest-priority zero-state result initially.
- Constrains the rendered menu to ten terminal rows in the session layout.

### Keyboard interaction

- Routes up/down navigation to the slash command model while the menu is open.
- Routes Enter through an `AcceptedSlashCommand` input event without executing the action in this PR.
- Adds Escape dismissal for the open menu.
- Keeps normal input behavior unchanged when the slash command menu is closed.

This PR intentionally stops at rendering and selection. Command parsing and execution are added by the final PR in the stack.

## Linked Issue

N/A

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `cargo check -p warp_tui`
- `./script/format`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

![Screenshot 2026-07-08 at 5.13.55 PM.png](https://app.graphite.com/user-attachments/assets/d871c07a-ce15-4d4b-a0eb-d4ffb9a5da04.png)

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz [oz-agent@warp.dev](mailto:oz-agent@warp.dev)
