### PR TITLE
Dispatch TUI slash command selections

### DIFF
--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -1999,7 +1999,7 @@ impl BlocklistAIHistoryModel {
 
     /// Handle clearing the blocklist for a terminal surface.
     /// The terminal surface will also cancel the active stream on processing the event emitted here.
-    pub(crate) fn clear_conversations_for_terminal_surface(
+    pub fn clear_conversations_for_terminal_surface(
         &mut self,
         terminal_surface_id: EntityId,
         ctx: &mut ModelContext<Self>,

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -3478,7 +3478,6 @@ impl Input {
             SlashCommandModel::new(
                 &buffer_model,
                 &ai_input_model,
-                active_session.clone(),
                 slash_command_data_source.clone(),
                 ctx,
             )

--- a/app/src/terminal/input/inline_menu/view.rs
+++ b/app/src/terminal/input/inline_menu/view.rs
@@ -8,7 +8,7 @@ use warp_core::ui::appearance::Appearance;
 use warp_core::ui::color::blend::Blend;
 use warp_core::ui::theme::Fill;
 use warp_core::ui::Icon;
-use warp_search_core::inline_menu::{InitialSelection, InlineMenuSelection};
+use warp_search_core::inline_menu::{InlineMenuResultsUpdate, InlineMenuSelection};
 use warpui::color::ColorU;
 use warpui::elements::drag_resize::drag_resize_handle;
 use warpui::elements::{
@@ -416,27 +416,33 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> InlineMenuView<A, T> {
 
         ctx.subscribe_to_model(&mixer, |me, _, event, ctx| match event {
             SearchMixerEvent::ResultsChanged => {
-                if me.mixer.as_ref(ctx).is_loading() {
-                    // Keep stale results visible while async sources are pending to avoid flicker.
-                    return;
-                }
-
-                if me.mixer.as_ref(ctx).are_results_empty() {
-                    me.result_renderers.clear();
-                    me.selection.clear();
-                    me.hovered_idx = None;
-                    me.details_pane_target = DetailsPaneTarget::default();
-                    me.model.update(ctx, |model, ctx| {
-                        model.clear_selected_item(ctx);
-                    });
-
-                    if !me.mixer.as_ref(ctx).is_loading() {
-                        ctx.emit(InlineMenuEvent::NoResults);
+                let results_update = {
+                    let mixer = me.mixer.as_ref(ctx);
+                    me.selection.reconcile_results(
+                        mixer.is_loading(),
+                        mixer.results().len(),
+                        |idx| !mixer.results()[idx].is_disabled(),
+                    )
+                };
+                let selected_idx = match results_update {
+                    InlineMenuResultsUpdate::Loading => {
+                        // Keep stale results visible while async sources are pending to avoid
+                        // flicker.
+                        return;
                     }
-
-                    ctx.notify();
-                    return;
-                }
+                    InlineMenuResultsUpdate::Empty => {
+                        me.result_renderers.clear();
+                        me.hovered_idx = None;
+                        me.details_pane_target = DetailsPaneTarget::default();
+                        me.model.update(ctx, |model, ctx| {
+                            model.clear_selected_item(ctx);
+                        });
+                        ctx.emit(InlineMenuEvent::NoResults);
+                        ctx.notify();
+                        return;
+                    }
+                    InlineMenuResultsUpdate::Ready { selected_index } => selected_index,
+                };
 
                 let results = me.mixer.as_ref(ctx).results();
 
@@ -473,12 +479,6 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> InlineMenuView<A, T> {
 
                 me.hovered_idx = None;
                 me.details_pane_target = DetailsPaneTarget::default();
-                let result_renderers = &me.result_renderers;
-                let selected_idx =
-                    me.selection
-                        .reset(result_renderers.len(), InitialSelection::Last, |idx| {
-                            !result_renderers[idx].search_result.is_disabled()
-                        });
                 let selected_item = selected_idx
                     .and_then(|idx| me.result_renderers.get(idx))
                     .map(|renderer| renderer.search_result.accept_result());

--- a/app/src/terminal/input/slash_command_model.rs
+++ b/app/src/terminal/input/slash_command_model.rs
@@ -2,6 +2,7 @@ use ai::skills::SkillReference;
 use input_classifier::InputType;
 use settings::Setting as _;
 use warp_core::features::FeatureFlag;
+use warp_search_core::inline_menu::InputDrivenInlineMenuLifecycle;
 use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
 
 use crate::ai::blocklist::{
@@ -74,10 +75,6 @@ pub enum SlashCommandEntryState {
     SlashCommand(DetectedCommand),
     /// A valid skill command is entered in the input.
     SkillCommand(DetectedSkillCommand),
-    /// Slash commands are disabled until the buffer is cleared.
-    ///
-    /// In this state, buffer content is not parsed for slash commands.
-    DisabledUntilEmptyBuffer,
 }
 
 impl SlashCommandEntryState {
@@ -115,14 +112,8 @@ impl SlashCommandEntryState {
                     .is_some_and(|p| p.starts_with('/') && p[1..] == *detected.name)
                     .then_some(prefix_len)
             }
-            SlashCommandEntryState::None
-            | SlashCommandEntryState::Composing { .. }
-            | SlashCommandEntryState::DisabledUntilEmptyBuffer => None,
+            SlashCommandEntryState::None | SlashCommandEntryState::Composing { .. } => None,
         }
-    }
-
-    fn is_disabled(&self) -> bool {
-        matches!(self, Self::DisabledUntilEmptyBuffer)
     }
 
     fn pending_command(&self) -> Option<&String> {
@@ -149,6 +140,7 @@ pub struct SlashCommandModel {
     input_buffer_model: ModelHandle<InputBufferModel>,
     ai_input_model: ModelHandle<BlocklistAIInputModel>,
     state: SlashCommandEntryState,
+    lifecycle: InputDrivenInlineMenuLifecycle,
     data_source: ModelHandle<GuiSlashCommandDataSource>,
 }
 
@@ -172,15 +164,14 @@ impl SlashCommandModel {
                 BlocklistAIInputEvent::InputTypeChanged { config }
                 | BlocklistAIInputEvent::LockChanged { config } => {
                     if config.is_locked {
-                        if config.is_shell() && !me.state.is_disabled() {
-                            let old_state = std::mem::replace(
-                                &mut me.state,
-                                SlashCommandEntryState::DisabledUntilEmptyBuffer,
-                            );
-                            ctx.emit(UpdatedSlashCommandModel { old_state });
+                        if config.is_shell() && !me.is_disabled() {
+                            let input_is_empty =
+                                me.input_buffer_model.as_ref(ctx).current_value().is_empty();
+                            me.disable_until_empty_buffer(input_is_empty, ctx);
                         } else if !config.is_shell()
                             && me.input_buffer_model.as_ref(ctx).current_value().is_empty()
                         {
+                            me.lifecycle.input_changed(true, false);
                             let old_state =
                                 std::mem::replace(&mut me.state, SlashCommandEntryState::None);
                             ctx.emit(UpdatedSlashCommandModel { old_state });
@@ -195,18 +186,22 @@ impl SlashCommandModel {
             ai_input_model: ai_input_model.clone(),
             data_source,
             state: SlashCommandEntryState::None,
+            lifecycle: InputDrivenInlineMenuLifecycle::default(),
         }
     }
 
     /// Called by SlashCommandsMenu when menu is dismissed.
     /// Only `UserEscape` blocks future execution; `NoResults` allows it.
     pub fn disable(&mut self, ctx: &mut ModelContext<Self>) {
-        if self.state.is_disabled() {
+        if self.is_disabled() {
             return;
         }
-
-        let current_input = self.input_buffer_model.as_ref(ctx).current_value();
-        if current_input.is_empty() {
+        let input_is_empty = self
+            .input_buffer_model
+            .as_ref(ctx)
+            .current_value()
+            .is_empty();
+        if input_is_empty {
             return;
         }
 
@@ -228,20 +223,28 @@ impl SlashCommandModel {
             });
         }
 
-        let old_state = std::mem::replace(
-            &mut self.state,
-            SlashCommandEntryState::DisabledUntilEmptyBuffer,
-        );
-        ctx.emit(UpdatedSlashCommandModel { old_state });
+        self.disable_until_empty_buffer(input_is_empty, ctx);
     }
 
     /// Returns whether slash command execution should be allowed.
     pub fn is_disabled(&self) -> bool {
-        self.state.is_disabled()
+        !self.lifecycle.is_enabled()
     }
 
     pub fn state(&self) -> &SlashCommandEntryState {
         &self.state
+    }
+
+    fn disable_until_empty_buffer(&mut self, input_is_empty: bool, ctx: &mut ModelContext<Self>) {
+        if self.is_disabled() {
+            return;
+        }
+        self.lifecycle.disable_until_empty_buffer(input_is_empty);
+        if self.lifecycle.is_enabled() {
+            return;
+        }
+        let old_state = std::mem::replace(&mut self.state, SlashCommandEntryState::None);
+        ctx.emit(UpdatedSlashCommandModel { old_state });
     }
 
     /// Parses `text` into a `SlashCommandEntryState` without mutating the
@@ -267,19 +270,18 @@ impl SlashCommandModel {
         event: &InputBufferUpdateEvent,
         ctx: &mut ModelContext<Self>,
     ) {
+        let InputBufferUpdateEvent {
+            new_content: new, ..
+        } = event;
+        self.lifecycle
+            .input_changed(new.is_empty(), new.starts_with('/'));
         // AI-off is no longer a blanket disable: AI-dependent commands are filtered out
         // of `active_commands` via `Availability::AI_ENABLED`, so parsing still works for
         // non-AI commands like `/open-file`.
         if !FeatureFlag::AgentView.is_enabled() {
             let ai_input_model = self.ai_input_model.as_ref(ctx);
             if ai_input_model.is_input_type_locked() && !ai_input_model.is_ai_input_enabled() {
-                if !self.state.is_disabled() {
-                    let old_state = std::mem::replace(
-                        &mut self.state,
-                        SlashCommandEntryState::DisabledUntilEmptyBuffer,
-                    );
-                    ctx.emit(UpdatedSlashCommandModel { old_state });
-                }
+                self.disable_until_empty_buffer(new.is_empty(), ctx);
                 return;
             }
         } else if !self.data_source.as_ref(ctx).is_agent_view_active(ctx)
@@ -287,20 +289,11 @@ impl SlashCommandModel {
             && !*InputSettings::as_ref(ctx)
                 .enable_slash_commands_in_terminal
                 .value()
-            && !self.state.is_disabled()
+            && !self.is_disabled()
         {
-            let old_state = std::mem::replace(
-                &mut self.state,
-                SlashCommandEntryState::DisabledUntilEmptyBuffer,
-            );
-            ctx.emit(UpdatedSlashCommandModel { old_state });
+            self.disable_until_empty_buffer(new.is_empty(), ctx);
             return;
         }
-
-        let InputBufferUpdateEvent {
-            new_content: new,
-            old_content: old,
-        } = &event;
 
         if new.is_empty() {
             // The buffer was cleared, so reset state.
@@ -308,12 +301,7 @@ impl SlashCommandModel {
             ctx.emit(UpdatedSlashCommandModel { old_state });
             return;
         }
-
-        // If the state is disabled but the buffer now starts with '/', re-evaluate.
-        // This handles the case where the user types a query with '/' (disabling slash commands),
-        // then edits the buffer to insert '/plan ' at the beginning.
-        let did_add_slash = new.starts_with('/') && !old.starts_with('/');
-        if self.state.is_disabled() && !did_add_slash {
+        if self.is_disabled() {
             return;
         }
 
@@ -335,7 +323,7 @@ impl SlashCommandModel {
                     //
                     // The fact that we've even detected a command implies that the input mode is in AI
                     // mode, either locked or unlocked; if the input were locked to shell mode then the
-                    // state would be `DisabledUntilEmptyBuffer` and we would have shortcircuited above.
+                    // shared lifecycle would have short-circuited above.
                     self.ai_input_model.update(ctx, |input_model, ctx| {
                         input_model.set_input_type(
                             InputType::AI,

--- a/app/src/terminal/input/slash_command_model.rs
+++ b/app/src/terminal/input/slash_command_model.rs
@@ -7,14 +7,12 @@ use warpui::{AppContext, Entity, ModelContext, ModelHandle, SingletonEntity};
 use crate::ai::blocklist::{
     BlocklistAIInputEvent, BlocklistAIInputModel, InputTypeAutoDetectionSource,
 };
-use crate::ai::skills::SkillManager;
 use crate::search::slash_command_menu::StaticCommand;
 use crate::settings::InputSettings;
 use crate::terminal::input::buffer_model::{InputBufferModel, InputBufferUpdateEvent};
 use crate::terminal::input::slash_commands::{
     GuiSlashCommandDataSource, SlashCommandDataSource as _,
 };
-use crate::terminal::model::session::active_session::ActiveSession;
 
 /// Event emitted by the slash command model when its entry state is updated.
 #[derive(Debug, Clone)]
@@ -45,6 +43,22 @@ pub struct DetectedSkillCommand {
 
     /// The space-delimited argument to the skill command (the user's prompt).
     pub argument: Option<String>,
+}
+
+/// Surface-neutral classification of the current slash command input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParsedSlashCommandInput {
+    /// The input is not slash command composition.
+    None,
+    /// A slash command, saved prompt, or skill is being searched for.
+    Composing {
+        /// The suffix in the input after '/'.
+        filter: String,
+    },
+    /// A valid static slash command is entered in the input.
+    SlashCommand(DetectedCommand),
+    /// A valid skill command is entered in the input.
+    SkillCommand(DetectedSkillCommand),
 }
 
 #[derive(Debug, Clone)]
@@ -130,10 +144,10 @@ pub fn slash_command_composition_filter(input: &str) -> Option<&str> {
         Some(pending_command)
     }
 }
+
 pub struct SlashCommandModel {
     input_buffer_model: ModelHandle<InputBufferModel>,
     ai_input_model: ModelHandle<BlocklistAIInputModel>,
-    active_session: ModelHandle<ActiveSession>,
     state: SlashCommandEntryState,
     data_source: ModelHandle<GuiSlashCommandDataSource>,
 }
@@ -142,7 +156,6 @@ impl SlashCommandModel {
     pub fn new(
         buffer_model: &ModelHandle<InputBufferModel>,
         ai_input_model: &ModelHandle<BlocklistAIInputModel>,
-        active_session: ModelHandle<ActiveSession>,
         data_source: ModelHandle<GuiSlashCommandDataSource>,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
@@ -180,7 +193,6 @@ impl SlashCommandModel {
         Self {
             input_buffer_model: buffer_model.clone(),
             ai_input_model: ai_input_model.clone(),
-            active_session,
             data_source,
             state: SlashCommandEntryState::None,
         }
@@ -237,43 +249,17 @@ impl SlashCommandModel {
     /// Use this when you have a prompt string and need to know whether it is
     /// a slash command, skill command, or plain text.
     pub fn detect_command(&self, text: &str, ctx: &AppContext) -> SlashCommandEntryState {
-        if !text.starts_with('/') {
-            return SlashCommandEntryState::None;
+        match self.data_source.as_ref(ctx).parse_input(text, ctx) {
+            ParsedSlashCommandInput::SlashCommand(detected) => {
+                SlashCommandEntryState::SlashCommand(detected)
+            }
+            ParsedSlashCommandInput::SkillCommand(detected) => {
+                SlashCommandEntryState::SkillCommand(detected)
+            }
+            ParsedSlashCommandInput::None | ParsedSlashCommandInput::Composing { .. } => {
+                SlashCommandEntryState::None
+            }
         }
-        if let Some(detected) = self.data_source.as_ref(ctx).parse_slash_command(text) {
-            return SlashCommandEntryState::SlashCommand(detected);
-        }
-        if let Some(detected) = self.detect_skill_command(text, ctx) {
-            return SlashCommandEntryState::SkillCommand(detected);
-        }
-        SlashCommandEntryState::None
-    }
-
-    /// Detects whether `buffer` matches a known skill command.
-    /// Accepts `&AppContext` so it can be called outside a model update.
-    fn detect_skill_command(&self, buffer: &str, ctx: &AppContext) -> Option<DetectedSkillCommand> {
-        let (possible_command, possible_argument) =
-            if let Some((command, argument)) = buffer.split_once(" ") {
-                (command, Some(argument.to_owned()))
-            } else {
-                (buffer, None)
-            };
-
-        let skill_name = possible_command.strip_prefix('/')?;
-
-        let active_session = self.active_session.as_ref(ctx);
-        let cwd_path = active_session.current_working_directory_location(ctx);
-        let skills = SkillManager::handle(ctx)
-            .as_ref(ctx)
-            .get_skills_for_working_directory(cwd_path.as_ref(), ctx);
-
-        let matched_skill = skills.into_iter().find(|skill| skill.name == skill_name)?;
-
-        Some(DetectedSkillCommand {
-            reference: matched_skill.reference,
-            name: matched_skill.name,
-            argument: possible_argument,
-        })
     }
 
     fn handle_input_buffer_update(
@@ -332,8 +318,8 @@ impl SlashCommandModel {
         }
 
         let old_state = self.state.clone();
-        match self.detect_command(new, ctx) {
-            SlashCommandEntryState::SlashCommand(detected_command) => {
+        match self.data_source.as_ref(ctx).parse_input(new, ctx) {
+            ParsedSlashCommandInput::SlashCommand(detected_command) => {
                 if let SlashCommandEntryState::SlashCommand(old_detected_command) = &self.state {
                     if *old_detected_command == detected_command {
                         return;
@@ -360,7 +346,7 @@ impl SlashCommandModel {
                 }
                 self.state = SlashCommandEntryState::SlashCommand(detected_command);
             }
-            SlashCommandEntryState::SkillCommand(detected_skill) => {
+            ParsedSlashCommandInput::SkillCommand(detected_skill) => {
                 if let SlashCommandEntryState::SkillCommand(old_detected_skill) = &self.state {
                     if *old_detected_skill == detected_skill {
                         return;
@@ -377,47 +363,42 @@ impl SlashCommandModel {
                 });
                 self.state = SlashCommandEntryState::SkillCommand(detected_skill);
             }
-            _ if new.starts_with('/') => {
-                let pending_command = slash_command_composition_filter(new);
-                if let Some(pending_command) = pending_command {
-                    if self
-                        .state
-                        .pending_command()
-                        .is_some_and(|command| command == pending_command)
-                    {
-                        return;
-                    }
-
-                    if !FeatureFlag::AgentView.is_enabled() {
-                        // In the old modality, when composing a slash command, the input _must_ be in
-                        // AI mode; we don't respect `StaticCommand::auto_enter_ai_mode = false`. That
-                        // field is only used in the new modality.
-                        //
-                        // We don't even rely on the fact that the input is in AI mode while a slash
-                        // command is being composed, its solely used to disable error underlining.
-                        //
-                        // In the new modality, slash commands declare whether or not they are
-                        // available in terminal mode, and syntax highlighting/error underlining is
-                        // handled appropriately. I am just making this change to preserve the existing
-                        // product behavior (agent icon in NLD toggle becomes yellow).
-                        self.ai_input_model.update(ctx, |input_model, ctx| {
-                            input_model.set_input_type(
-                                InputType::AI,
-                                Some(InputTypeAutoDetectionSource::SlashCommand),
-                                ctx,
-                            );
-                        });
-                    }
-                    self.state = SlashCommandEntryState::Composing {
-                        filter: pending_command.to_owned(),
-                    };
-                } else {
-                    // If the user typed a second '/' in the command token (e.g., /foo/bar),
-                    // the user is likely not trying to enter or find a slash command.
-                    self.state = SlashCommandEntryState::None;
+            ParsedSlashCommandInput::Composing {
+                filter: pending_command,
+            } => {
+                if self
+                    .state
+                    .pending_command()
+                    .is_some_and(|command| command == &pending_command)
+                {
+                    return;
                 }
+
+                if !FeatureFlag::AgentView.is_enabled() {
+                    // In the old modality, when composing a slash command, the input _must_ be in
+                    // AI mode; we don't respect `StaticCommand::auto_enter_ai_mode = false`. That
+                    // field is only used in the new modality.
+                    //
+                    // We don't even rely on the fact that the input is in AI mode while a slash
+                    // command is being composed, its solely used to disable error underlining.
+                    //
+                    // In the new modality, slash commands declare whether or not they are
+                    // available in terminal mode, and syntax highlighting/error underlining is
+                    // handled appropriately. I am just making this change to preserve the existing
+                    // product behavior (agent icon in NLD toggle becomes yellow).
+                    self.ai_input_model.update(ctx, |input_model, ctx| {
+                        input_model.set_input_type(
+                            InputType::AI,
+                            Some(InputTypeAutoDetectionSource::SlashCommand),
+                            ctx,
+                        );
+                    });
+                }
+                self.state = SlashCommandEntryState::Composing {
+                    filter: pending_command,
+                };
             }
-            _ => {
+            ParsedSlashCommandInput::None => {
                 self.state = SlashCommandEntryState::None;
             }
         }
@@ -428,51 +409,6 @@ impl SlashCommandModel {
 
 impl Entity for SlashCommandModel {
     type Event = UpdatedSlashCommandModel;
-}
-
-impl GuiSlashCommandDataSource {
-    // Matches `buffer` against active slash commands, returning the detected command and
-    // space-delimited argument (if provided).
-    //
-    // If a slash command has no argument, it matches only if its an exact match or the
-    // suffix is all whitespace.
-    //
-    // If the slash command has an argument, it matches only if its an exact match, or if the argument
-    // is space-delimited.
-    fn parse_slash_command(&self, buffer: &str) -> Option<DetectedCommand> {
-        let (possible_command, possible_argument) =
-            if let Some((command, argument)) = buffer.split_once(" ") {
-                (command, Some(argument.to_owned()))
-            } else {
-                (buffer, None)
-            };
-
-        let is_matching_command = |command: &StaticCommand| -> bool {
-            if command.name != possible_command {
-                return false;
-            }
-
-            if let Some(argument) = command.argument.as_ref() {
-                argument.is_optional || possible_argument.as_ref().is_some()
-            } else {
-                possible_argument
-                    .as_ref()
-                    .is_none_or(|arg| arg.trim().is_empty())
-            }
-        };
-        let matched_command = self.active_commands().find_map(|(_, command)| {
-            if is_matching_command(command) {
-                Some(command.clone())
-            } else {
-                None
-            }
-        })?;
-
-        Some(DetectedCommand {
-            command: matched_command,
-            argument: possible_argument,
-        })
-    }
 }
 
 #[cfg(test)]

--- a/app/src/terminal/input/slash_command_model_tests.rs
+++ b/app/src/terminal/input/slash_command_model_tests.rs
@@ -180,10 +180,7 @@ fn test_disabled_until_empty_buffer_ignores_non_slash_edits() {
         });
 
         input.read(&app, |input, ctx| {
-            assert!(matches!(
-                input.slash_command_model.as_ref(ctx).state(),
-                SlashCommandEntryState::DisabledUntilEmptyBuffer
-            ));
+            assert!(input.slash_command_model.as_ref(ctx).is_disabled());
         });
 
         input.update(&mut app, |input, ctx| {
@@ -191,10 +188,7 @@ fn test_disabled_until_empty_buffer_ignores_non_slash_edits() {
         });
 
         input.read(&app, |input, ctx| {
-            assert!(matches!(
-                input.slash_command_model.as_ref(ctx).state(),
-                SlashCommandEntryState::DisabledUntilEmptyBuffer
-            ));
+            assert!(input.slash_command_model.as_ref(ctx).is_disabled());
         });
     });
 }

--- a/app/src/terminal/input/slash_commands/data_source/core.rs
+++ b/app/src/terminal/input/slash_commands/data_source/core.rs
@@ -21,6 +21,10 @@ use crate::settings::{AISettings, AISettingsChangedEvent};
 use crate::terminal::cli_agent_sessions::{
     CLIAgentInputState, CLIAgentSessionsModel, CLIAgentSessionsModelEvent,
 };
+use crate::terminal::input::slash_command_model::{
+    slash_command_composition_filter, DetectedCommand, DetectedSkillCommand,
+    ParsedSlashCommandInput,
+};
 use crate::terminal::input::slash_commands::AcceptSlashCommandOrSavedPrompt;
 use crate::terminal::model::session::active_session::{ActiveSession, ActiveSessionEvent};
 use crate::terminal::model::session::SessionType;
@@ -37,6 +41,14 @@ const SCORE_MULTIPLIER: OrderedFloat<f64> = OrderedFloat(1000.0);
 /// Add command names here to make them accessible when composing prompts
 /// for a running CLI agent (Claude Code, Codex, etc.).
 const CLI_AGENT_INPUT_ALLOWED_COMMANDS: &[&str] = &["/prompts", "/skills"];
+
+fn split_command_and_argument(buffer: &str) -> (&str, Option<&str>) {
+    buffer
+        .split_once(' ')
+        .map_or((buffer, None), |(command, argument)| {
+            (command, Some(argument))
+        })
+}
 
 /// Command availability gates whose inputs are identical on every surface.
 ///
@@ -183,6 +195,72 @@ pub trait SlashCommandDataSource {
 
     fn active_commands(&self) -> impl Iterator<Item = (&SlashCommandId, &StaticCommand)> {
         self.state().active_commands_by_id.iter()
+    }
+
+    /// Classifies slash command input consistently across GUI and TUI surfaces.
+    fn parse_input(&self, buffer: &str, ctx: &AppContext) -> ParsedSlashCommandInput {
+        if !buffer.starts_with('/') {
+            return ParsedSlashCommandInput::None;
+        }
+        if let Some(detected) = self.parse_slash_command(buffer) {
+            return ParsedSlashCommandInput::SlashCommand(detected);
+        }
+        if let Some(detected) = self.parse_skill_command(buffer, ctx) {
+            return ParsedSlashCommandInput::SkillCommand(detected);
+        }
+        match slash_command_composition_filter(buffer) {
+            Some(filter) => ParsedSlashCommandInput::Composing {
+                filter: filter.to_owned(),
+            },
+            None => ParsedSlashCommandInput::None,
+        }
+    }
+
+    /// Matches `buffer` against active slash commands, returning the detected command and
+    /// space-delimited argument, if provided.
+    fn parse_slash_command(&self, buffer: &str) -> Option<DetectedCommand> {
+        let (possible_command, possible_argument) = split_command_and_argument(buffer);
+
+        let is_matching_command = |command: &StaticCommand| {
+            if command.name != possible_command {
+                return false;
+            }
+
+            if let Some(argument) = command.argument.as_ref() {
+                argument.is_optional || possible_argument.is_some()
+            } else {
+                possible_argument.is_none_or(|argument| argument.trim().is_empty())
+            }
+        };
+        let matched_command = self
+            .active_commands()
+            .find_map(|(_, command)| is_matching_command(command).then(|| command.clone()))?;
+
+        Some(DetectedCommand {
+            command: matched_command,
+            argument: possible_argument.map(str::to_owned),
+        })
+    }
+
+    /// Matches `buffer` against skills available for the active working directory, returning the
+    /// detected skill and space-delimited argument, if provided.
+    fn parse_skill_command(&self, buffer: &str, ctx: &AppContext) -> Option<DetectedSkillCommand> {
+        let (possible_command, possible_argument) = split_command_and_argument(buffer);
+        let skill_name = possible_command.strip_prefix('/')?;
+
+        let active_session = self.active_session().as_ref(ctx);
+        let cwd_path = active_session.current_working_directory_location(ctx);
+        let matched_skill = SkillManager::handle(ctx)
+            .as_ref(ctx)
+            .get_skills_for_working_directory(cwd_path.as_ref(), ctx)
+            .into_iter()
+            .find(|skill| skill.name == skill_name)?;
+
+        Some(DetectedSkillCommand {
+            reference: matched_skill.reference,
+            name: matched_skill.name,
+            argument: possible_argument.map(str::to_owned),
+        })
     }
 
     /// Update the active repository root for this terminal. Returns whether the value changed,

--- a/app/src/terminal/input/slash_commands/data_source/tui.rs
+++ b/app/src/terminal/input/slash_commands/data_source/tui.rs
@@ -13,7 +13,9 @@ use crate::search::mixer::DataSourceRunErrorWrapper;
 use crate::search::slash_command_menu::static_commands::commands::COMMAND_REGISTRY;
 use crate::search::slash_command_menu::static_commands::Availability;
 use crate::search::SyncDataSource;
-use crate::terminal::input::slash_commands::AcceptSlashCommandOrSavedPrompt;
+use crate::terminal::input::slash_commands::{
+    slash_command_is_supported_in_tui, AcceptSlashCommandOrSavedPrompt,
+};
 use crate::terminal::model::session::active_session::ActiveSession;
 
 pub struct TuiDataSourceArgs {
@@ -69,7 +71,8 @@ impl TuiSlashCommandDataSource {
             COMMAND_REGISTRY
                 .all_commands_by_id()
                 .filter(|(_, command)| {
-                    self.command_passes_common_gates(command, availability, &gates)
+                    slash_command_is_supported_in_tui(command)
+                        && self.command_passes_common_gates(command, availability, &gates)
                 })
                 .map(|(id, command)| (id, command.clone())),
         );

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -65,11 +65,12 @@ use crate::terminal::model::session::Session;
 use crate::terminal::view::TerminalAction;
 use crate::ui_components::color_dot;
 use crate::view_components::DismissibleToast;
+use crate::workflows::command_parser::compute_workflow_display_data;
 use crate::workflows::{WorkflowSelectionSource, WorkflowSource, WorkflowType};
 use crate::workspace::{ForkedConversationDestination, ToastStack, WorkspaceAction};
 use crate::TelemetryEvent;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AcceptSlashCommandOrSavedPrompt {
     SlashCommand {
         id: SlashCommandId,
@@ -85,6 +86,50 @@ pub enum AcceptSlashCommandOrSavedPrompt {
 }
 impl InlineMenuAction for AcceptSlashCommandOrSavedPrompt {
     const MENU_TYPE: InlineMenuType = InlineMenuType::SlashCommands;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlashCommandSelectionBehavior {
+    InsertCommandText(String),
+    Execute,
+}
+
+/// Shared menu-selection policy for static slash commands.
+///
+/// GUI and TUI both first decide whether accepting a menu row should insert the
+/// slash command text for further argument entry, or execute the command
+/// immediately. Surface-specific execution remains in `Input::execute_slash_command`
+/// for GUI and in `TuiTerminalSessionView::execute_tui_slash_command` for TUI.
+pub fn slash_command_selection_behavior(command: &StaticCommand) -> SlashCommandSelectionBehavior {
+    if command
+        .argument
+        .as_ref()
+        .is_some_and(|argument| !argument.should_execute_on_selection)
+    {
+        SlashCommandSelectionBehavior::InsertCommandText(format!("{} ", command.name))
+    } else {
+        SlashCommandSelectionBehavior::Execute
+    }
+}
+/// Returns whether TUI can execute or otherwise handle the static slash command today.
+///
+/// GUI-only actions such as opening settings panes or inline menus should stay hidden until the
+/// TUI has equivalent flows.
+pub fn slash_command_is_supported_in_tui(command: &StaticCommand) -> bool {
+    command.name == commands::AGENT.name
+        || command.name == commands::NEW.name
+        || command.name == commands::COMPACT.name
+        || command.name == commands::PLAN.name
+}
+
+pub fn slash_command_for_id(id: &SlashCommandId) -> Option<&'static StaticCommand> {
+    COMMAND_REGISTRY.get_command(id)
+}
+pub fn saved_prompt_text_for_id(id: &SyncId, ctx: &AppContext) -> Option<String> {
+    let workflow = CloudModel::as_ref(ctx).get_workflow(id)?;
+    workflow.model().data.is_agent_mode_workflow().then(|| {
+        compute_workflow_display_data(&workflow.model().data).command_with_replaced_arguments
+    })
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -176,36 +221,36 @@ impl Input {
         if !self.is_slash_command_available(command, ctx) {
             return;
         }
-        if command.argument.as_ref().is_none() {
-            self.execute_slash_command(
-                command, None, trigger, /*is_queued_prompt*/ false, None, None, ctx,
-            );
-        } else if command
-            .argument
-            .as_ref()
-            .is_some_and(|arg| arg.should_execute_on_selection)
-        {
-            // TODO (zachbai): this is a hack for Oz launch. Caller
-            // should probably be invoking `execute_slash_command` in this case.
-            let argument = if !self.suggestions_mode_model.as_ref(ctx).is_slash_commands() {
-                let trimmed = self.buffer_text(ctx).trim().to_owned();
-                (!trimmed.is_empty()).then_some(trimmed)
-            } else {
-                None
-            };
-            self.execute_slash_command(
-                command,
-                argument.as_ref(),
-                trigger,
-                /*is_queued_prompt*/ false,
-                None,
-                None,
-                ctx,
-            );
-        } else {
-            self.editor.update(ctx, |editor, ctx| {
-                editor.set_buffer_text(&format!("{} ", command.name), ctx);
-            });
+        match slash_command_selection_behavior(command) {
+            SlashCommandSelectionBehavior::Execute => {
+                // TODO (zachbai): this is a hack for Oz launch. Caller
+                // should probably be invoking `execute_slash_command` in this case.
+                let argument = if command
+                    .argument
+                    .as_ref()
+                    .is_some_and(|arg| arg.should_execute_on_selection)
+                    && !self.suggestions_mode_model.as_ref(ctx).is_slash_commands()
+                {
+                    let trimmed = self.buffer_text(ctx).trim().to_owned();
+                    (!trimmed.is_empty()).then_some(trimmed)
+                } else {
+                    None
+                };
+                self.execute_slash_command(
+                    command,
+                    argument.as_ref(),
+                    trigger,
+                    /*is_queued_prompt*/ false,
+                    None,
+                    None,
+                    ctx,
+                );
+            }
+            SlashCommandSelectionBehavior::InsertCommandText(text) => {
+                self.editor.update(ctx, |editor, ctx| {
+                    editor.set_buffer_text(&text, ctx);
+                });
+            }
         }
     }
 
@@ -1467,7 +1512,7 @@ impl Input {
 /// Every other slash command emits an immediate action (forking, switching model, opening a
 /// menu, etc.), so callers gating prompt queuing or shared-session forwarding should treat those
 /// as "run now".
-pub(crate) fn slash_command_is_submitted_as_prompt(command: &StaticCommand) -> bool {
+pub fn slash_command_is_submitted_as_prompt(command: &StaticCommand) -> bool {
     command.name == commands::COMPACT.name
         || command.name == commands::PLAN.name
         || command.name == commands::ORCHESTRATE.name

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -276,7 +276,7 @@ impl Input {
         }
 
         match self.slash_command_model.as_ref(ctx).state().clone() {
-            SlashCommandEntryState::None | SlashCommandEntryState::DisabledUntilEmptyBuffer => {
+            SlashCommandEntryState::None => {
                 if self.suggestions_mode_model.as_ref(ctx).is_slash_commands() {
                     self.close_slash_commands_menu(ctx);
                 }
@@ -1341,9 +1341,7 @@ impl Input {
                 let user_query = detected_skill.argument.clone();
                 self.execute_skill_command(reference, user_query, None, None, ctx)
             }
-            SlashCommandEntryState::None
-            | SlashCommandEntryState::Composing { .. }
-            | SlashCommandEntryState::DisabledUntilEmptyBuffer => false,
+            SlashCommandEntryState::None | SlashCommandEntryState::Composing { .. } => false,
         }
     }
 
@@ -1442,9 +1440,7 @@ impl Input {
                 let user_query = detected_skill.argument.clone();
                 self.execute_skill_command(reference, user_query, None, None, ctx)
             }
-            SlashCommandEntryState::None
-            | SlashCommandEntryState::Composing { .. }
-            | SlashCommandEntryState::DisabledUntilEmptyBuffer => false,
+            SlashCommandEntryState::None | SlashCommandEntryState::Composing { .. } => false,
         }
     }
 

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -122,9 +122,6 @@ pub fn slash_command_is_supported_in_tui(command: &StaticCommand) -> bool {
         || command.name == commands::PLAN.name
 }
 
-pub fn slash_command_for_id(id: &SlashCommandId) -> Option<&'static StaticCommand> {
-    COMMAND_REGISTRY.get_command(id)
-}
 pub fn saved_prompt_text_for_id(id: &SyncId, ctx: &AppContext) -> Option<String> {
     let workflow = CloudModel::as_ref(ctx).get_workflow(id)?;
     workflow.model().data.is_agent_mode_workflow().then(|| {

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -82,7 +82,6 @@ use crate::terminal::event::{
     UserBlockCompleted,
 };
 use crate::terminal::general_settings::UserDefaultShellUnsupportedBannerState;
-use crate::terminal::input::slash_command_model::SlashCommandEntryState;
 use crate::terminal::input::slash_commands::SlashCommandsEvent;
 use crate::terminal::keys::TerminalKeybindings;
 use crate::terminal::local_shell::LocalShellState;
@@ -3844,10 +3843,7 @@ fn test_plan_slash_command_argument_with_slash_does_not_disable_slash_command_pa
 
         input.read(&app, |input, ctx| {
             assert!(
-                !matches!(
-                    input.slash_command_model.as_ref(ctx).state(),
-                    SlashCommandEntryState::DisabledUntilEmptyBuffer
-                ),
+                !input.slash_command_model.as_ref(ctx).is_disabled(),
                 "slash command parsing should not be disabled when the argument contains '/'"
             );
         });

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -56,15 +56,22 @@ pub use crate::code::DiffResult;
 pub use crate::code_review::git_repo_model::{
     GitRepoModels, GitRepoStatusModel, GitStatusMetadata,
 };
-pub use crate::search::slash_command_menu::SlashCommandId;
+pub use crate::search::slash_command_menu::static_commands::commands as slash_commands;
+pub use crate::search::slash_command_menu::{SlashCommandId, StaticCommand};
 pub use crate::settings::AISettingsChangedEvent;
 pub use crate::terminal::color::{Colors as TerminalColors, List as TerminalColorList};
 pub use crate::terminal::event::AfterBlockCompletedEvent;
-pub use crate::terminal::input::slash_command_model::slash_command_composition_filter;
+pub use crate::terminal::input::slash_command_model::{
+    slash_command_composition_filter, DetectedCommand, DetectedSkillCommand,
+    ParsedSlashCommandInput,
+};
 pub use crate::terminal::input::slash_commands::{
-    build_slash_command_mixer, slash_command_query, AcceptSlashCommandOrSavedPrompt, InlineItem,
-    SlashCommandDataSource, SlashCommandMixer, TuiDataSourceArgs as TuiSlashCommandDataSourceArgs,
-    TuiSlashCommandDataSource, TuiZeroStateDataSource, UpdatedActiveCommands,
+    build_slash_command_mixer, saved_prompt_text_for_id, slash_command_for_id,
+    slash_command_is_submitted_as_prompt, slash_command_is_supported_in_tui, slash_command_query,
+    slash_command_selection_behavior, AcceptSlashCommandOrSavedPrompt, InlineItem,
+    SlashCommandDataSource, SlashCommandMixer, SlashCommandSelectionBehavior,
+    TuiDataSourceArgs as TuiSlashCommandDataSourceArgs, TuiSlashCommandDataSource,
+    TuiZeroStateDataSource, UpdatedActiveCommands,
 };
 pub use crate::terminal::input::CommandExecutionSource;
 pub use crate::terminal::local_tty::{

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -56,7 +56,9 @@ pub use crate::code::DiffResult;
 pub use crate::code_review::git_repo_model::{
     GitRepoModels, GitRepoStatusModel, GitStatusMetadata,
 };
-pub use crate::search::slash_command_menu::static_commands::commands as slash_commands;
+pub use crate::search::slash_command_menu::static_commands::commands::{
+    self as slash_commands, COMMAND_REGISTRY,
+};
 pub use crate::search::slash_command_menu::{SlashCommandId, StaticCommand};
 pub use crate::settings::AISettingsChangedEvent;
 pub use crate::terminal::color::{Colors as TerminalColors, List as TerminalColorList};
@@ -66,12 +68,11 @@ pub use crate::terminal::input::slash_command_model::{
     ParsedSlashCommandInput,
 };
 pub use crate::terminal::input::slash_commands::{
-    build_slash_command_mixer, saved_prompt_text_for_id, slash_command_for_id,
-    slash_command_is_submitted_as_prompt, slash_command_is_supported_in_tui, slash_command_query,
-    slash_command_selection_behavior, AcceptSlashCommandOrSavedPrompt, InlineItem,
-    SlashCommandDataSource, SlashCommandMixer, SlashCommandSelectionBehavior,
-    TuiDataSourceArgs as TuiSlashCommandDataSourceArgs, TuiSlashCommandDataSource,
-    TuiZeroStateDataSource, UpdatedActiveCommands,
+    build_slash_command_mixer, saved_prompt_text_for_id, slash_command_is_submitted_as_prompt,
+    slash_command_is_supported_in_tui, slash_command_query, slash_command_selection_behavior,
+    AcceptSlashCommandOrSavedPrompt, InlineItem, SlashCommandDataSource, SlashCommandMixer,
+    SlashCommandSelectionBehavior, TuiDataSourceArgs as TuiSlashCommandDataSourceArgs,
+    TuiSlashCommandDataSource, TuiZeroStateDataSource, UpdatedActiveCommands,
 };
 pub use crate::terminal::input::CommandExecutionSource;
 pub use crate::terminal::local_tty::{

--- a/crates/warp_search_core/src/inline_menu.rs
+++ b/crates/warp_search_core/src/inline_menu.rs
@@ -1,10 +1,50 @@
-//! Headless selection state shared by inline-menu frontends.
+//! Headless lifecycle, result, and selection state shared by inline-menu frontends.
+/// Whether an input-driven inline menu may react to buffer updates.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct InputDrivenInlineMenuLifecycle {
+    state: InputDrivenInlineMenuState,
+    previous_input_had_trigger: bool,
+}
 
-/// Which selectable result should be chosen when resetting a menu.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+enum InputDrivenInlineMenuState {
+    #[default]
+    Enabled,
+    DisabledUntilEmptyBuffer,
+}
+
+impl InputDrivenInlineMenuLifecycle {
+    pub fn is_enabled(&self) -> bool {
+        matches!(self.state, InputDrivenInlineMenuState::Enabled)
+    }
+
+    /// Prevents the menu from reopening after a manual dismissal while input remains.
+    pub fn disable_until_empty_buffer(&mut self, input_is_empty: bool) {
+        if input_is_empty {
+            return;
+        }
+        self.state = InputDrivenInlineMenuState::DisabledUntilEmptyBuffer;
+    }
+
+    /// Updates lifecycle state for the latest buffer contents and returns whether menu processing
+    /// is enabled. Clearing the buffer or adding a new trigger re-enables a manually dismissed
+    /// menu.
+    pub fn input_changed(&mut self, input_is_empty: bool, input_has_trigger: bool) -> bool {
+        let did_add_trigger = input_has_trigger && !self.previous_input_had_trigger;
+        if input_is_empty || did_add_trigger {
+            self.state = InputDrivenInlineMenuState::Enabled;
+        }
+        self.previous_input_had_trigger = input_has_trigger;
+        self.is_enabled()
+    }
+}
+
+/// Surface-neutral outcome after reconciling an inline menu with its latest result set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum InitialSelection {
-    First,
-    Last,
+pub enum InlineMenuResultsUpdate {
+    Loading,
+    Empty,
+    Ready { selected_index: Option<usize> },
 }
 
 /// Logical selection over an ordered list of inline-menu results.
@@ -25,18 +65,36 @@ impl InlineMenuSelection {
     pub fn clear(&mut self) {
         self.selected_index = None;
     }
-
-    pub fn reset(
+    /// Selects the highest-scoring enabled result from a [`crate::mixer::SearchMixer`].
+    ///
+    /// Mixer results are ordered by increasing score, so the best result is the last enabled
+    /// item. Keeping this policy here prevents inline-menu frontends from interpreting the shared
+    /// result order differently.
+    pub fn reset_to_best(
         &mut self,
         item_count: usize,
-        initial_selection: InitialSelection,
         mut is_enabled: impl FnMut(usize) -> bool,
     ) -> Option<usize> {
-        self.selected_index = match initial_selection {
-            InitialSelection::First => (0..item_count).find(|&index| is_enabled(index)),
-            InitialSelection::Last => (0..item_count).rev().find(|&index| is_enabled(index)),
-        };
+        self.selected_index = (0..item_count).rev().find(|&index| is_enabled(index));
         self.selected_index
+    }
+    /// Reconciles selection with the latest mixer state using one policy for every frontend.
+    pub fn reconcile_results(
+        &mut self,
+        is_loading: bool,
+        item_count: usize,
+        is_enabled: impl FnMut(usize) -> bool,
+    ) -> InlineMenuResultsUpdate {
+        if is_loading {
+            return InlineMenuResultsUpdate::Loading;
+        }
+        if item_count == 0 {
+            self.clear();
+            return InlineMenuResultsUpdate::Empty;
+        }
+        InlineMenuResultsUpdate::Ready {
+            selected_index: self.reset_to_best(item_count, is_enabled),
+        }
     }
 
     pub fn select(

--- a/crates/warp_search_core/src/inline_menu_tests.rs
+++ b/crates/warp_search_core/src/inline_menu_tests.rs
@@ -1,38 +1,76 @@
-use super::{InitialSelection, InlineMenuSelection};
+use super::{InlineMenuResultsUpdate, InlineMenuSelection, InputDrivenInlineMenuLifecycle};
 
 #[test]
-fn reset_selects_first_or_last_enabled_item() {
-    let enabled = [false, true, false, true];
+fn manual_dismissal_remains_disabled_until_input_is_cleared() {
+    let mut lifecycle = InputDrivenInlineMenuLifecycle::default();
+
+    assert!(lifecycle.input_changed(false, true));
+    lifecycle.disable_until_empty_buffer(false);
+    assert!(!lifecycle.input_changed(false, true));
+    assert!(!lifecycle.input_changed(false, true));
+    assert!(lifecycle.input_changed(true, false));
+    assert!(lifecycle.input_changed(false, true));
+}
+
+#[test]
+fn adding_a_new_trigger_reenables_after_manual_dismissal() {
+    let mut lifecycle = InputDrivenInlineMenuLifecycle::default();
+
+    assert!(lifecycle.input_changed(false, true));
+    lifecycle.disable_until_empty_buffer(false);
+    assert!(!lifecycle.input_changed(false, false));
+    assert!(lifecycle.input_changed(false, true));
+}
+
+#[test]
+fn reset_to_best_clears_selection_when_no_item_is_enabled() {
+    let mut selection = InlineMenuSelection::default();
+    selection.select(0, 1, |_| true);
+
+    assert_eq!(selection.reset_to_best(3, |_| false), None);
+    assert_eq!(selection.selected_index(), None);
+}
+#[test]
+fn reset_to_best_selects_the_last_enabled_mixer_result() {
+    let enabled = [true, false, true, false];
     let mut selection = InlineMenuSelection::default();
 
     assert_eq!(
-        selection.reset(enabled.len(), InitialSelection::First, |index| enabled
-            [index]),
-        Some(1)
-    );
-    assert_eq!(
-        selection.reset(enabled.len(), InitialSelection::Last, |index| enabled
-            [index]),
-        Some(3)
+        selection.reset_to_best(enabled.len(), |index| enabled[index]),
+        Some(2)
     );
 }
 
 #[test]
-fn reset_clears_selection_when_no_item_is_enabled() {
+fn reconcile_results_shares_loading_empty_and_best_result_policy() {
     let mut selection = InlineMenuSelection::default();
-    selection.reset(1, InitialSelection::First, |_| true);
+    selection.select(0, 2, |_| true);
 
-    assert_eq!(selection.reset(3, InitialSelection::Last, |_| false), None);
+    assert_eq!(
+        selection.reconcile_results(true, 2, |_| true),
+        InlineMenuResultsUpdate::Loading
+    );
+    assert_eq!(selection.selected_index(), Some(0));
+
+    assert_eq!(
+        selection.reconcile_results(false, 0, |_| true),
+        InlineMenuResultsUpdate::Empty
+    );
     assert_eq!(selection.selected_index(), None);
+
+    assert_eq!(
+        selection.reconcile_results(false, 4, |index| index != 3),
+        InlineMenuResultsUpdate::Ready {
+            selected_index: Some(2)
+        }
+    );
 }
 
 #[test]
 fn next_and_previous_wrap_and_skip_disabled_items() {
     let enabled = [true, false, true, false];
     let mut selection = InlineMenuSelection::default();
-    selection.reset(enabled.len(), InitialSelection::First, |index| {
-        enabled[index]
-    });
+    selection.select(0, enabled.len(), |index| enabled[index]);
 
     assert_eq!(
         selection.select_next(enabled.len(), |index| enabled[index]),
@@ -68,9 +106,7 @@ fn navigation_from_no_selection_uses_directional_edge() {
 fn direct_selection_rejects_invalid_or_disabled_indices_without_moving() {
     let enabled = [true, false];
     let mut selection = InlineMenuSelection::default();
-    selection.reset(enabled.len(), InitialSelection::First, |index| {
-        enabled[index]
-    });
+    selection.select(0, enabled.len(), |index| enabled[index]);
 
     assert_eq!(
         selection.select(1, enabled.len(), |index| enabled[index]),
@@ -87,7 +123,7 @@ fn direct_selection_rejects_invalid_or_disabled_indices_without_moving() {
 #[test]
 fn empty_navigation_clears_stale_selection() {
     let mut selection = InlineMenuSelection::default();
-    selection.reset(1, InitialSelection::First, |_| true);
+    selection.select(0, 1, |_| true);
 
     assert_eq!(selection.select_next(0, |_| true), None);
     assert_eq!(selection.selected_index(), None);

--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -100,11 +100,9 @@ impl TuiInlineMenu {
         ctx: &mut (impl ModelAsRef + UpdateModel),
     ) -> Option<TuiInlineMenuAccepted> {
         match self {
-            Self::SlashCommands(model) => {
-                let action = model.as_ref(ctx).selected_action();
-                model.update(ctx, |model, ctx| model.dismiss(ctx));
-                action.map(TuiInlineMenuAccepted::SlashCommand)
-            }
+            Self::SlashCommands(model) => model
+                .update(ctx, |model, ctx| model.accept_selected(ctx))
+                .map(TuiInlineMenuAccepted::SlashCommand),
         }
     }
 

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -663,7 +663,7 @@ impl TuiInputView {
             m.clear_buffer(ctx);
             m.user_insert(text, ctx);
         });
-        self.scroll_offset = 0;
+        self.follow_cursor(ctx);
         ctx.notify();
     }
 

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -658,6 +658,14 @@ impl TuiInputView {
     fn render_input(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
         Box::new(self.render_element(ctx))
     }
+    pub(crate) fn set_text(&mut self, text: &str, ctx: &mut ViewContext<Self>) {
+        self.model.update(ctx, |m, ctx| {
+            m.clear_buffer(ctx);
+            m.user_insert(text, ctx);
+        });
+        self.scroll_offset = 0;
+        ctx.notify();
+    }
 
     /// Composes the shell-mode input row: the accent-styled `!` affordance in a
     /// two-column gutter (glyph plus one column of right padding), then the

--- a/crates/warp_tui/src/slash_commands.rs
+++ b/crates/warp_tui/src/slash_commands.rs
@@ -9,8 +9,9 @@ use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp::search::data_source::QueryResult;
 use warp::search::mixer::SearchMixerEvent;
 use warp::tui_export::{
-    slash_command_composition_filter, slash_command_query, AcceptSlashCommandOrSavedPrompt,
-    SlashCommandMixer, TuiSlashCommandDataSource, UpdatedActiveCommands,
+    slash_command_query, slash_command_selection_behavior, AcceptSlashCommandOrSavedPrompt,
+    ParsedSlashCommandInput, SlashCommandDataSource as _, SlashCommandMixer,
+    SlashCommandSelectionBehavior, TuiSlashCommandDataSource, UpdatedActiveCommands,
 };
 use warp_editor::model::CoreEditorModel;
 use warp_search_core::inline_menu::{InitialSelection, InlineMenuSelection};
@@ -50,6 +51,7 @@ pub(crate) struct TuiSlashCommandModelEvent;
 
 pub(crate) struct TuiSlashCommandModel {
     input_editor: ModelHandle<CodeEditorModel>,
+    slash_commands_source: Option<ModelHandle<TuiSlashCommandDataSource>>,
     mixer: ModelHandle<SlashCommandMixer>,
     state: TuiSlashCommandState,
 }
@@ -82,6 +84,7 @@ impl TuiSlashCommandModel {
 
         let mut model = Self {
             input_editor,
+            slash_commands_source: Some(slash_commands_source),
             mixer,
             state: TuiSlashCommandState::Closed,
         };
@@ -100,6 +103,7 @@ impl TuiSlashCommandModel {
         selection.select(selected_index, rows.len(), |_| true);
         Self {
             input_editor,
+            slash_commands_source: None,
             mixer,
             state: TuiSlashCommandState::Open {
                 query: String::new(),
@@ -211,7 +215,11 @@ impl TuiSlashCommandModel {
 
     fn update_from_input(&mut self, ctx: &mut ModelContext<Self>) {
         let input = input_text(&self.input_editor, ctx);
-        let Some(query) = slash_command_composition_filter(&input).map(str::to_owned) else {
+        let Some(slash_commands_source) = &self.slash_commands_source else {
+            return;
+        };
+        let parsed_input = slash_commands_source.as_ref(ctx).parse_input(&input, ctx);
+        let Some(query) = menu_query_for_parsed_input(&parsed_input) else {
             self.close(ctx);
             return;
         };
@@ -219,16 +227,24 @@ impl TuiSlashCommandModel {
     }
 
     fn run_query(&mut self, query: String, force: bool, ctx: &mut ModelContext<Self>) {
-        let (previous_query_matches, previous_selection, previous_scroll_offset) = match &self.state
-        {
-            TuiSlashCommandState::Closed => (false, InlineMenuSelection::default(), 0),
-            TuiSlashCommandState::Open {
-                query: previous_query,
-                selection,
-                scroll_offset,
-                ..
-            } => (previous_query == &query, *selection, *scroll_offset),
-        };
+        let (previous_query_matches, previous_rows, previous_selection, previous_scroll_offset) =
+            match &self.state {
+                TuiSlashCommandState::Closed => {
+                    (false, Vec::new(), InlineMenuSelection::default(), 0)
+                }
+                TuiSlashCommandState::Open {
+                    query: previous_query,
+                    rows,
+                    selection,
+                    scroll_offset,
+                    ..
+                } => (
+                    previous_query == &query,
+                    rows.clone(),
+                    *selection,
+                    *scroll_offset,
+                ),
+            };
         let select_last_result_on_refresh = query.is_empty() && !previous_query_matches;
         let scroll_offset = if select_last_result_on_refresh {
             0
@@ -237,7 +253,7 @@ impl TuiSlashCommandModel {
         };
         self.state = TuiSlashCommandState::Open {
             query: query.clone(),
-            rows: Vec::new(),
+            rows: previous_rows,
             selection: previous_selection,
             scroll_offset,
             select_last_result_on_refresh,
@@ -266,8 +282,16 @@ impl TuiSlashCommandModel {
         };
 
         let mixer = self.mixer.as_ref(ctx);
-        *rows = mixer.results().iter().filter_map(row_from_result).collect();
         *is_loading = mixer.is_loading();
+        if *is_loading {
+            return;
+        }
+
+        let previously_selected_action = selection
+            .selected_index()
+            .and_then(|index| rows.get(index))
+            .map(|row| row.action.clone());
+        *rows = mixer.results().iter().filter_map(row_from_result).collect();
         if rows.is_empty() {
             selection.clear();
             *scroll_offset = 0;
@@ -275,6 +299,10 @@ impl TuiSlashCommandModel {
             if *select_last_result_on_refresh {
                 selection.reset(rows.len(), InitialSelection::Last, |_| true);
                 *select_last_result_on_refresh = false;
+            } else if let Some(selected_index) = previously_selected_action
+                .and_then(|action| rows.iter().position(|row| row.action == action))
+            {
+                selection.select(selected_index, rows.len(), |_| true);
             } else if let Some(selected_index) = selection.selected_index() {
                 selection.select(selected_index.min(rows.len() - 1), rows.len(), |_| true);
             } else {
@@ -313,6 +341,36 @@ fn input_text(input_editor: &ModelHandle<CodeEditorModel>, ctx: &AppContext) -> 
     }
 }
 
+fn menu_query_for_parsed_input(parsed_input: &ParsedSlashCommandInput) -> Option<String> {
+    match parsed_input {
+        ParsedSlashCommandInput::None => None,
+        ParsedSlashCommandInput::Composing { filter } => Some(filter.clone()),
+        ParsedSlashCommandInput::SlashCommand(detected_command) => {
+            let is_argument_entry = detected_command.argument.is_some();
+            let executes_on_selection = matches!(
+                slash_command_selection_behavior(&detected_command.command),
+                SlashCommandSelectionBehavior::Execute
+            );
+            if is_argument_entry || executes_on_selection {
+                None
+            } else {
+                Some(
+                    detected_command
+                        .command
+                        .name
+                        .strip_prefix('/')
+                        .unwrap_or(detected_command.command.name)
+                        .to_owned(),
+                )
+            }
+        }
+        ParsedSlashCommandInput::SkillCommand(detected_skill) => detected_skill
+            .argument
+            .is_none()
+            .then(|| detected_skill.name.clone()),
+    }
+}
+
 fn row_from_result(
     result: &QueryResult<AcceptSlashCommandOrSavedPrompt>,
 ) -> Option<TuiSlashCommandRow> {
@@ -326,3 +384,7 @@ fn row_from_result(
         action: result.accept_result(),
     })
 }
+
+#[cfg(test)]
+#[path = "slash_commands_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/slash_commands.rs
+++ b/crates/warp_tui/src/slash_commands.rs
@@ -14,7 +14,9 @@ use warp::tui_export::{
     SlashCommandSelectionBehavior, TuiSlashCommandDataSource, UpdatedActiveCommands,
 };
 use warp_editor::model::CoreEditorModel;
-use warp_search_core::inline_menu::{InitialSelection, InlineMenuSelection};
+use warp_search_core::inline_menu::{
+    InlineMenuResultsUpdate, InlineMenuSelection, InputDrivenInlineMenuLifecycle,
+};
 use warpui_core::{AppContext, Entity, ModelContext, ModelHandle};
 
 use crate::inline_menu::{
@@ -41,7 +43,6 @@ pub(crate) enum TuiSlashCommandState {
         rows: Vec<TuiSlashCommandRow>,
         selection: InlineMenuSelection,
         scroll_offset: usize,
-        select_last_result_on_refresh: bool,
         is_loading: bool,
     },
 }
@@ -54,6 +55,7 @@ pub(crate) struct TuiSlashCommandModel {
     slash_commands_source: Option<ModelHandle<TuiSlashCommandDataSource>>,
     mixer: ModelHandle<SlashCommandMixer>,
     state: TuiSlashCommandState,
+    lifecycle: InputDrivenInlineMenuLifecycle,
 }
 
 impl TuiSlashCommandModel {
@@ -87,6 +89,7 @@ impl TuiSlashCommandModel {
             slash_commands_source: Some(slash_commands_source),
             mixer,
             state: TuiSlashCommandState::Closed,
+            lifecycle: InputDrivenInlineMenuLifecycle::default(),
         };
         model.update_from_input(ctx);
         model
@@ -110,9 +113,9 @@ impl TuiSlashCommandModel {
                 rows,
                 selection,
                 scroll_offset: 0,
-                select_last_result_on_refresh: false,
                 is_loading: false,
             },
+            lifecycle: InputDrivenInlineMenuLifecycle::default(),
         }
     }
 
@@ -173,7 +176,21 @@ impl TuiSlashCommandModel {
     }
 
     pub(crate) fn dismiss(&mut self, ctx: &mut ModelContext<Self>) {
+        if !self.is_open() {
+            return;
+        }
+        let input_is_empty = input_text(&self.input_editor, ctx).is_empty();
+        self.lifecycle.disable_until_empty_buffer(input_is_empty);
         self.close(ctx);
+    }
+
+    pub(crate) fn accept_selected(
+        &mut self,
+        ctx: &mut ModelContext<Self>,
+    ) -> Option<AcceptSlashCommandOrSavedPrompt> {
+        let action = self.selected_action();
+        self.close(ctx);
+        action
     }
 
     pub(crate) fn snapshot(&self) -> Option<TuiInlineMenuSnapshot> {
@@ -215,6 +232,13 @@ impl TuiSlashCommandModel {
 
     fn update_from_input(&mut self, ctx: &mut ModelContext<Self>) {
         let input = input_text(&self.input_editor, ctx);
+        if !self
+            .lifecycle
+            .input_changed(input.is_empty(), input.starts_with('/'))
+        {
+            self.close(ctx);
+            return;
+        }
         let Some(slash_commands_source) = &self.slash_commands_source else {
             return;
         };
@@ -227,36 +251,20 @@ impl TuiSlashCommandModel {
     }
 
     fn run_query(&mut self, query: String, force: bool, ctx: &mut ModelContext<Self>) {
-        let (previous_query_matches, previous_rows, previous_selection, previous_scroll_offset) =
-            match &self.state {
-                TuiSlashCommandState::Closed => {
-                    (false, Vec::new(), InlineMenuSelection::default(), 0)
-                }
-                TuiSlashCommandState::Open {
-                    query: previous_query,
-                    rows,
-                    selection,
-                    scroll_offset,
-                    ..
-                } => (
-                    previous_query == &query,
-                    rows.clone(),
-                    *selection,
-                    *scroll_offset,
-                ),
-            };
-        let select_last_result_on_refresh = query.is_empty() && !previous_query_matches;
-        let scroll_offset = if select_last_result_on_refresh {
-            0
-        } else {
-            previous_scroll_offset
+        let (previous_rows, previous_selection, previous_scroll_offset) = match &self.state {
+            TuiSlashCommandState::Closed => (Vec::new(), InlineMenuSelection::default(), 0),
+            TuiSlashCommandState::Open {
+                rows,
+                selection,
+                scroll_offset,
+                ..
+            } => (rows.clone(), *selection, *scroll_offset),
         };
         self.state = TuiSlashCommandState::Open {
             query: query.clone(),
             rows: previous_rows,
             selection: previous_selection,
-            scroll_offset,
-            select_last_result_on_refresh,
+            scroll_offset: previous_scroll_offset,
             is_loading: true,
         };
         self.mixer.update(ctx, |mixer, ctx| {
@@ -269,48 +277,45 @@ impl TuiSlashCommandModel {
     }
 
     fn refresh_rows(&mut self, ctx: &mut ModelContext<Self>) {
+        let (mixer_is_loading, new_rows): (bool, Vec<TuiSlashCommandRow>) = {
+            let mixer = self.mixer.as_ref(ctx);
+            (
+                mixer.is_loading(),
+                mixer.results().iter().filter_map(row_from_result).collect(),
+            )
+        };
+        let results_update = {
+            let TuiSlashCommandState::Open {
+                selection,
+                is_loading,
+                ..
+            } = &mut self.state
+            else {
+                return;
+            };
+            *is_loading = mixer_is_loading;
+            selection.reconcile_results(mixer_is_loading, new_rows.len(), |_| true)
+        };
+        let selected_index = match results_update {
+            InlineMenuResultsUpdate::Loading => return,
+            InlineMenuResultsUpdate::Empty => {
+                self.close(ctx);
+                return;
+            }
+            InlineMenuResultsUpdate::Ready { selected_index } => selected_index,
+        };
+
         let TuiSlashCommandState::Open {
-            selection,
             scroll_offset,
             rows,
-            select_last_result_on_refresh,
-            is_loading,
             ..
         } = &mut self.state
         else {
             return;
         };
-
-        let mixer = self.mixer.as_ref(ctx);
-        *is_loading = mixer.is_loading();
-        if *is_loading {
-            return;
-        }
-
-        let previously_selected_action = selection
-            .selected_index()
-            .and_then(|index| rows.get(index))
-            .map(|row| row.action.clone());
-        *rows = mixer.results().iter().filter_map(row_from_result).collect();
-        if rows.is_empty() {
-            selection.clear();
-            *scroll_offset = 0;
-        } else {
-            if *select_last_result_on_refresh {
-                selection.reset(rows.len(), InitialSelection::Last, |_| true);
-                *select_last_result_on_refresh = false;
-            } else if let Some(selected_index) = previously_selected_action
-                .and_then(|action| rows.iter().position(|row| row.action == action))
-            {
-                selection.select(selected_index, rows.len(), |_| true);
-            } else if let Some(selected_index) = selection.selected_index() {
-                selection.select(selected_index.min(rows.len() - 1), rows.len(), |_| true);
-            } else {
-                selection.reset(rows.len(), InitialSelection::First, |_| true);
-            }
-            if let Some(selected_index) = selection.selected_index() {
-                keep_selected_visible(rows.len(), selected_index, MAX_VISIBLE_ROWS, scroll_offset);
-            }
+        *rows = new_rows;
+        if let Some(selected_index) = selected_index {
+            keep_selected_visible(rows.len(), selected_index, MAX_VISIBLE_ROWS, scroll_offset);
         }
         ctx.emit(TuiSlashCommandModelEvent);
     }

--- a/crates/warp_tui/src/slash_commands_tests.rs
+++ b/crates/warp_tui/src/slash_commands_tests.rs
@@ -1,0 +1,29 @@
+use ai::skills::SkillReference;
+use warp::tui_export::{DetectedSkillCommand, ParsedSlashCommandInput};
+
+use super::menu_query_for_parsed_input;
+
+fn parsed_skill(argument: Option<&str>) -> ParsedSlashCommandInput {
+    ParsedSlashCommandInput::SkillCommand(DetectedSkillCommand {
+        reference: SkillReference::BundledSkillId("write-product-spec".to_owned()),
+        name: "write-product-spec".to_owned(),
+        argument: argument.map(str::to_owned),
+    })
+}
+
+#[test]
+fn skill_without_argument_remains_searchable() {
+    assert_eq!(
+        menu_query_for_parsed_input(&parsed_skill(None)).as_deref(),
+        Some("write-product-spec")
+    );
+}
+
+#[test]
+fn skill_argument_entry_closes_menu() {
+    assert_eq!(menu_query_for_parsed_input(&parsed_skill(Some(""))), None);
+    assert_eq!(
+        menu_query_for_parsed_input(&parsed_skill(Some("here is my prompt"))),
+        None
+    );
+}

--- a/crates/warp_tui/src/slash_commands_tests.rs
+++ b/crates/warp_tui/src/slash_commands_tests.rs
@@ -1,7 +1,17 @@
 use ai::skills::SkillReference;
-use warp::tui_export::{DetectedSkillCommand, ParsedSlashCommandInput};
+use warp::appearance::Appearance;
+use warp::editor::CodeEditorModel;
+use warp::tui_export::{
+    AcceptSlashCommandOrSavedPrompt, DetectedSkillCommand, ParsedSlashCommandInput, SlashCommandId,
+    SlashCommandMixer,
+};
+use warp_search_core::inline_menu::InlineMenuSelection;
+use warpui_core::App;
 
-use super::menu_query_for_parsed_input;
+use super::{
+    menu_query_for_parsed_input, TuiSlashCommandModel, TuiSlashCommandRow, MAX_VISIBLE_ROWS,
+};
+use crate::inline_menu::keep_selected_visible;
 
 fn parsed_skill(argument: Option<&str>) -> ParsedSlashCommandInput {
     ParsedSlashCommandInput::SkillCommand(DetectedSkillCommand {
@@ -26,4 +36,71 @@ fn skill_argument_entry_closes_menu() {
         menu_query_for_parsed_input(&parsed_skill(Some("here is my prompt"))),
         None
     );
+}
+
+#[test]
+fn best_result_is_selected_and_scrolled_into_view() {
+    let result_count = MAX_VISIBLE_ROWS + 1;
+    let mut selection = InlineMenuSelection::default();
+    let selected_index = selection
+        .reset_to_best(result_count, |_| true)
+        .expect("non-empty results should have a selection");
+    let mut scroll_offset = 0;
+
+    keep_selected_visible(
+        result_count,
+        selected_index,
+        MAX_VISIBLE_ROWS,
+        &mut scroll_offset,
+    );
+
+    assert_eq!(selected_index, result_count - 1);
+    assert_eq!(scroll_offset, 1);
+}
+
+#[test]
+fn completed_empty_results_close_the_menu() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let input_editor = app.add_model(|ctx| CodeEditorModel::new_tui(80, ctx));
+        let mixer = app.add_model(|_| SlashCommandMixer::new());
+        let model = app
+            .add_model(|_| TuiSlashCommandModel::new_for_test(input_editor, mixer, Vec::new(), 0));
+
+        model.update(&mut app, |model, ctx| model.refresh_rows(ctx));
+
+        model.read(&app, |model, _| {
+            assert!(!model.is_open());
+        });
+    });
+}
+
+#[test]
+fn accepting_a_result_does_not_disable_input_driven_lifecycle() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let input_editor = app.add_model(|ctx| CodeEditorModel::new_tui(80, ctx));
+        let mixer = app.add_model(|_| SlashCommandMixer::new());
+        let command_id = SlashCommandId::new();
+        let model = app.add_model(|_| {
+            TuiSlashCommandModel::new_for_test(
+                input_editor,
+                mixer,
+                vec![TuiSlashCommandRow {
+                    title: "Test command".to_owned(),
+                    description: None,
+                    action: AcceptSlashCommandOrSavedPrompt::SlashCommand { id: command_id },
+                }],
+                0,
+            )
+        });
+
+        model.update(&mut app, |model, ctx| {
+            assert_eq!(
+                model.accept_selected(ctx),
+                Some(AcceptSlashCommandOrSavedPrompt::SlashCommand { id: command_id })
+            );
+            assert!(model.lifecycle.input_changed(false, true));
+        });
+    });
 }

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -10,18 +10,20 @@ use parking_lot::FairMutex;
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp::settings::{AISettings, AISettingsChangedEvent};
 use warp::tui_export::{
-    build_slash_command_mixer, detect_possible_git_repo, throttle, AIAgentPtyWriteMode,
-    ActiveSession, ActiveSessionEvent, AgentInteractionMetadata, AgentViewEntryOrigin,
-    BlocklistAIActionModel, BlocklistAIContextModel, BlocklistAIController,
-    BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIInputModel, CLISubagentController,
-    CancellationReason, ChangelogModel, ChangelogModelEvent, ChangelogRequestType,
-    CommandExecutionSource, ConversationSelection, ConversationSelectionHandle,
-    ConversationUsageTotals, ExecuteCommandEvent, GetRelevantFilesController, GitRepoModels,
-    GitRepoStatusModel, GitStatusMetadata, LLMPreferences, LLMPreferencesEvent, ModelEvent,
-    PtyIntent, PtyIntentEvent, RepoDetectionSessionType, RepoDetectionSource,
-    ShellCommandExecutorEvent, TerminalModel, TerminalSurface, TerminalSurfaceInit,
-    TuiSlashCommandDataSource, TuiSlashCommandDataSourceArgs, TuiZeroStateDataSource,
-    WAKEUP_THROTTLE_PERIOD,
+    build_slash_command_mixer, detect_possible_git_repo, saved_prompt_text_for_id,
+    slash_command_for_id, slash_command_is_submitted_as_prompt, slash_command_selection_behavior,
+    slash_commands, throttle, AIAgentPtyWriteMode, AcceptSlashCommandOrSavedPrompt, ActiveSession,
+    ActiveSessionEvent, AgentInteractionMetadata, AgentViewEntryOrigin, BlocklistAIActionModel,
+    BlocklistAIContextModel, BlocklistAIController, BlocklistAIHistoryEvent,
+    BlocklistAIHistoryModel, BlocklistAIInputModel, CLISubagentController, CancellationReason,
+    ChangelogModel, ChangelogModelEvent, ChangelogRequestType, CommandExecutionSource,
+    ConversationSelection, ConversationSelectionHandle, ConversationUsageTotals,
+    ExecuteCommandEvent, GetRelevantFilesController, GitRepoModels, GitRepoStatusModel,
+    GitStatusMetadata, LLMPreferences, LLMPreferencesEvent, ModelEvent, PtyIntent, PtyIntentEvent,
+    RepoDetectionSessionType, RepoDetectionSource, ShellCommandExecutorEvent,
+    SlashCommandDataSource as _, SlashCommandSelectionBehavior, StaticCommand, TerminalModel,
+    TerminalSurface, TerminalSurfaceInit, TuiSlashCommandDataSource, TuiSlashCommandDataSourceArgs,
+    TuiZeroStateDataSource, WAKEUP_THROTTLE_PERIOD,
 };
 use warp_core::settings::Setting;
 use warp_editor::model::CoreEditorModel;
@@ -108,6 +110,8 @@ pub(crate) struct TuiTerminalSessionView {
     transcript: ViewHandle<TuiTranscriptView>,
     input_view: ViewHandle<TuiInputView>,
     inline_menu: TuiInlineMenu,
+    slash_commands: ModelHandle<TuiSlashCommandModel>,
+    slash_commands_source: ModelHandle<TuiSlashCommandDataSource>,
     conversation_selection: ConversationSelectionHandle,
     ai_controller: ModelHandle<BlocklistAIController>,
     /// Read by the footer for the active session's working directory.
@@ -243,7 +247,7 @@ impl TuiTerminalSessionView {
         let slash_commands = ctx.add_model(|ctx| {
             TuiSlashCommandModel::new(
                 input_editor_model.clone(),
-                slash_commands_source,
+                slash_commands_source.clone(),
                 slash_commands_mixer,
                 ctx,
             )
@@ -267,7 +271,7 @@ impl TuiTerminalSessionView {
             }
         });
         let input_mode_for_input_view = ai_input_model.clone();
-        let inline_menu = TuiInlineMenu::SlashCommands(slash_commands);
+        let inline_menu = TuiInlineMenu::SlashCommands(slash_commands.clone());
         let inline_menu_for_input = inline_menu.clone();
         let input_view = ctx.add_typed_action_tui_view(move |ctx| {
             TuiInputView::new(
@@ -280,7 +284,7 @@ impl TuiTerminalSessionView {
         ctx.subscribe_to_view(&input_view, |view, _, event, ctx| match event {
             TuiInputViewEvent::Submitted(text) => view.handle_submitted(text.clone(), ctx),
             TuiInputViewEvent::AcceptedSlashCommand(action) => {
-                log::debug!("Accepted TUI slash command menu item: {action:?}");
+                view.handle_accepted_slash_command(action, ctx);
             }
         });
         // The input box border color and the footer's shell-mode hint depend
@@ -445,6 +449,8 @@ impl TuiTerminalSessionView {
             transcript,
             input_view,
             inline_menu,
+            slash_commands,
+            slash_commands_source,
             conversation_selection,
             ai_controller,
             active_session,
@@ -731,13 +737,10 @@ impl TuiTerminalSessionView {
         if self.is_shell_mode(ctx) {
             self.execute_user_command(&text, ctx);
         } else {
-            let prompt = text.trim().to_owned();
             self.input_view.update(ctx, |input_view, ctx| {
                 input_view.clear(ctx);
             });
-            if !prompt.is_empty() {
-                self.send_prompt(prompt, ctx);
-            }
+            self.handle_submitted_input(&text, ctx);
         }
         ctx.notify();
     }
@@ -838,6 +841,120 @@ impl TuiTerminalSessionView {
         self.ai_controller.update(ctx, |controller, ctx| {
             controller.send_user_query_in_conversation(prompt, conversation_id, None, ctx);
         });
+    }
+
+    fn handle_submitted_input(&mut self, prompt: &str, ctx: &mut ViewContext<Self>) {
+        let prompt = prompt.trim();
+        if prompt.is_empty() {
+            return;
+        }
+
+        let detected_command = self
+            .slash_commands_source
+            .as_ref(ctx)
+            .parse_slash_command(prompt);
+        if let Some(detected_command) = detected_command {
+            self.execute_tui_slash_command(
+                &detected_command.command,
+                detected_command.argument.as_ref(),
+                ctx,
+            );
+        } else {
+            self.send_prompt(prompt.to_owned(), ctx);
+        }
+    }
+
+    fn handle_accepted_slash_command(
+        &mut self,
+        action: &AcceptSlashCommandOrSavedPrompt,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        match action {
+            AcceptSlashCommandOrSavedPrompt::SlashCommand { id } => {
+                let Some(command) = slash_command_for_id(id) else {
+                    log::debug!("TUI slash command selection is not supported yet: {id:?}");
+                    ctx.notify();
+                    return;
+                };
+                self.select_tui_slash_command(command, ctx);
+            }
+            AcceptSlashCommandOrSavedPrompt::SavedPrompt { id } => {
+                let Some(prompt) = saved_prompt_text_for_id(id, ctx) else {
+                    log::warn!("Tried to insert saved prompt for id {id:?} but it does not exist");
+                    return;
+                };
+                self.input_view.update(ctx, |input, ctx| {
+                    input.set_text(&prompt, ctx);
+                });
+                self.slash_commands
+                    .update(ctx, |slash_commands, ctx| slash_commands.dismiss(ctx));
+            }
+            AcceptSlashCommandOrSavedPrompt::Skill { name, .. } => {
+                self.input_view.update(ctx, |input, ctx| {
+                    input.set_text(&format!("/{name} "), ctx);
+                });
+                self.slash_commands
+                    .update(ctx, |slash_commands, ctx| slash_commands.dismiss(ctx));
+            }
+        }
+        ctx.notify();
+    }
+
+    fn select_tui_slash_command(&mut self, command: &StaticCommand, ctx: &mut ViewContext<Self>) {
+        match slash_command_selection_behavior(command) {
+            SlashCommandSelectionBehavior::InsertCommandText(text) => {
+                self.input_view.update(ctx, |input, ctx| {
+                    input.set_text(&text, ctx);
+                });
+                self.slash_commands
+                    .update(ctx, |slash_commands, ctx| slash_commands.dismiss(ctx));
+            }
+            SlashCommandSelectionBehavior::Execute => {
+                self.execute_tui_slash_command(command, None, ctx);
+            }
+        }
+    }
+
+    fn execute_tui_slash_command(
+        &mut self,
+        command: &StaticCommand,
+        argument: Option<&String>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if command.name == slash_commands::AGENT.name || command.name == slash_commands::NEW.name {
+            self.cancel_active_conversation(ctx);
+            let terminal_surface_id = ctx.view_id();
+            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                history.clear_conversations_for_terminal_surface(terminal_surface_id, ctx);
+            });
+            self.conversation_selection.update(ctx, |selection, ctx| {
+                selection.select_new_conversation(AgentViewEntryOrigin::Tui, ctx);
+            });
+            if let Some(prompt) = argument
+                .map(|argument| argument.trim())
+                .filter(|argument| !argument.is_empty())
+            {
+                self.send_prompt(prompt.to_owned(), ctx);
+            }
+            self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+        } else if slash_command_is_submitted_as_prompt(command) {
+            self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+            let prompt = argument
+                .map(|argument| {
+                    if argument.is_empty() {
+                        command.name.to_owned()
+                    } else {
+                        format!("{} {}", command.name, argument)
+                    }
+                })
+                .unwrap_or_else(|| command.name.to_owned());
+            self.send_prompt(prompt, ctx);
+        } else {
+            log::debug!(
+                "TUI slash command selection is not supported yet: {}",
+                command.name
+            );
+        }
     }
 
     /// Bridges shared shell-tool executor events into terminal-manager PTY intents.

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -110,7 +110,6 @@ pub(crate) struct TuiTerminalSessionView {
     transcript: ViewHandle<TuiTranscriptView>,
     input_view: ViewHandle<TuiInputView>,
     inline_menu: TuiInlineMenu,
-    slash_commands: ModelHandle<TuiSlashCommandModel>,
     slash_commands_source: ModelHandle<TuiSlashCommandDataSource>,
     conversation_selection: ConversationSelectionHandle,
     ai_controller: ModelHandle<BlocklistAIController>,
@@ -449,7 +448,6 @@ impl TuiTerminalSessionView {
             transcript,
             input_view,
             inline_menu,
-            slash_commands,
             slash_commands_source,
             conversation_selection,
             ai_controller,
@@ -886,15 +884,11 @@ impl TuiTerminalSessionView {
                 self.input_view.update(ctx, |input, ctx| {
                     input.set_text(&prompt, ctx);
                 });
-                self.slash_commands
-                    .update(ctx, |slash_commands, ctx| slash_commands.dismiss(ctx));
             }
             AcceptSlashCommandOrSavedPrompt::Skill { name, .. } => {
                 self.input_view.update(ctx, |input, ctx| {
                     input.set_text(&format!("/{name} "), ctx);
                 });
-                self.slash_commands
-                    .update(ctx, |slash_commands, ctx| slash_commands.dismiss(ctx));
             }
         }
         ctx.notify();
@@ -906,8 +900,6 @@ impl TuiTerminalSessionView {
                 self.input_view.update(ctx, |input, ctx| {
                     input.set_text(&text, ctx);
                 });
-                self.slash_commands
-                    .update(ctx, |slash_commands, ctx| slash_commands.dismiss(ctx));
             }
             SlashCommandSelectionBehavior::Execute => {
                 self.execute_tui_slash_command(command, None, ctx);

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -11,8 +11,8 @@ use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp::settings::{AISettings, AISettingsChangedEvent};
 use warp::tui_export::{
     build_slash_command_mixer, detect_possible_git_repo, saved_prompt_text_for_id,
-    slash_command_for_id, slash_command_is_submitted_as_prompt, slash_command_selection_behavior,
-    slash_commands, throttle, AIAgentPtyWriteMode, AcceptSlashCommandOrSavedPrompt, ActiveSession,
+    slash_command_is_submitted_as_prompt, slash_command_selection_behavior, slash_commands,
+    throttle, AIAgentPtyWriteMode, AcceptSlashCommandOrSavedPrompt, ActiveSession,
     ActiveSessionEvent, AgentInteractionMetadata, AgentViewEntryOrigin, BlocklistAIActionModel,
     BlocklistAIContextModel, BlocklistAIController, BlocklistAIHistoryEvent,
     BlocklistAIHistoryModel, BlocklistAIInputModel, CLISubagentController, CancellationReason,
@@ -23,7 +23,8 @@ use warp::tui_export::{
     RepoDetectionSessionType, RepoDetectionSource, ShellCommandExecutorEvent,
     SlashCommandDataSource as _, SlashCommandSelectionBehavior, StaticCommand, TerminalModel,
     TerminalSurface, TerminalSurfaceInit, TuiSlashCommandDataSource, TuiSlashCommandDataSourceArgs,
-    TuiZeroStateDataSource, WAKEUP_THROTTLE_PERIOD,
+    TuiZeroStateDataSource, COMMAND_REGISTRY,
+    WAKEUP_THROTTLE_PERIOD,
 };
 use warp_core::settings::Setting;
 use warp_editor::model::CoreEditorModel;
@@ -89,6 +90,8 @@ impl PtyIntentEvent for TuiTerminalSessionEvent {
 /// Transient hint shown when a shell command is rejected because the PTY is
 /// already running a command.
 const COMMAND_ALREADY_RUNNING_HINT: &str = "cannot run — command already running";
+const NEW_CONVERSATION_COMMAND_RUNNING_HINT: &str =
+    "cannot start new conversation while terminal command is running";
 
 /// Footer hint shown while the input is in `!` shell mode.
 const SHELL_MODE_HINT: &str = "shell mode · esc to exit";
@@ -127,6 +130,7 @@ pub(crate) struct TuiTerminalSessionView {
     exit_confirmation: ExitConfirmation,
     /// Credits⇄cost display state for the footer's clickable usage entry.
     usage_toggle: UsageToggle,
+    ai_context_model: ModelHandle<BlocklistAIContextModel>,
     ai_input_model: ModelHandle<BlocklistAIInputModel>,
     terminal_model: Arc<FairMutex<TerminalModel>>,
     /// Transient notice shown in the footer's hint slot (e.g. a rejected
@@ -198,7 +202,7 @@ impl TuiTerminalSessionView {
         let ai_controller = ctx.add_model(|ctx| {
             BlocklistAIController::new(
                 ai_input_model.clone(),
-                context_model,
+                context_model.clone(),
                 conversation_selection.clone(),
                 action_model.clone(),
                 active_session.clone(),
@@ -457,6 +461,7 @@ impl TuiTerminalSessionView {
             terminal_surface_id,
             exit_confirmation: ExitConfirmation::default(),
             usage_toggle: UsageToggle::default(),
+            ai_context_model: context_model,
             ai_input_model,
             terminal_model: model,
             transient_hint: TransientHint::default(),
@@ -869,7 +874,7 @@ impl TuiTerminalSessionView {
     ) {
         match action {
             AcceptSlashCommandOrSavedPrompt::SlashCommand { id } => {
-                let Some(command) = slash_command_for_id(id) else {
+                let Some(command) = COMMAND_REGISTRY.get_command(id) else {
                     log::debug!("TUI slash command selection is not supported yet: {id:?}");
                     ctx.notify();
                     return;
@@ -914,6 +919,14 @@ impl TuiTerminalSessionView {
         ctx: &mut ViewContext<Self>,
     ) {
         if command.name == slash_commands::AGENT.name || command.name == slash_commands::NEW.name {
+            if !self
+                .ai_context_model
+                .as_ref(ctx)
+                .can_start_new_conversation()
+            {
+                self.show_transient_hint(NEW_CONVERSATION_COMMAND_RUNNING_HINT.to_owned(), ctx);
+                return;
+            }
             self.cancel_active_conversation(ctx);
             let terminal_surface_id = ctx.view_id();
             BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -23,8 +23,7 @@ use warp::tui_export::{
     RepoDetectionSessionType, RepoDetectionSource, ShellCommandExecutorEvent,
     SlashCommandDataSource as _, SlashCommandSelectionBehavior, StaticCommand, TerminalModel,
     TerminalSurface, TerminalSurfaceInit, TuiSlashCommandDataSource, TuiSlashCommandDataSourceArgs,
-    TuiZeroStateDataSource, COMMAND_REGISTRY,
-    WAKEUP_THROTTLE_PERIOD,
+    TuiZeroStateDataSource, COMMAND_REGISTRY, WAKEUP_THROTTLE_PERIOD,
 };
 use warp_core::settings::Setting;
 use warp_editor::model::CoreEditorModel;


### PR DESCRIPTION
## Description

Completes TUI slash command support by parsing submitted input and dispatching accepted menu actions from the rendering layer in the parent PR.

### Shared selection and parsing behavior

- Moves slash input classification onto the shared `SlashCommandDataSource` core so GUI and TUI use the same precedence for static commands, skills, composition queries, and non-slash input.
- Shares command-and-argument tokenization across static commands and skills, preserving the distinction between no argument and argument entry beginning with a trailing space.
- Adds shared selection policy that decides whether accepting a command inserts text for argument entry or executes immediately.
- Adds helpers for resolving static commands and saved prompts and for identifying commands that are submitted as AI prompts.

### TUI dispatch

- Filters the TUI menu to commands with implemented TUI flows: `/agent`, `/new`, `/compact`, and `/plan`.
- Inserts argument-taking commands, saved prompts, and skill invocations into the TUI input.
- Keeps the menu closed once a recognized skill enters argument text, preventing saved prompts from reappearing while the user continues typing the skill prompt.
- Starts a fresh conversation for `/agent` and `/new`, optionally sending the supplied prompt.
- Submits supported AI-flow commands such as `/compact` and `/plan` as conversation prompts.
- Detects slash commands entered directly in the input, not only commands accepted from the menu.
- Retains a defensive fallback that logs unsupported selections rather than invoking GUI-only behavior.

## Linked Issue

N/A

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `cargo check -p warp_tui`
- `cargo test -p warp slash_command_model -- --nocapture` — 14 passed
- `cargo test -p warp_tui skill_ -- --nocapture` — 2 passed
- `cargo test -p warp terminal::input::slash_commands::data_source::core::tests --lib` — 6 passed
- `./script/format`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

https://www.loom.com/share/1f27c6ac098640f2992d0129b6fd59f1

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Added slash command menu support to Warp TUI.

Co-Authored-By: Oz <oz-agent@warp.dev>
