### PR TITLE
[CODE-1831] Add a credits/cost usage entry to the TUI footer

### DIFF
--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -171,6 +171,25 @@ fn footer_model_token_usage(
         .collect()
 }
 
+/// Conversation usage totals for compact displays (e.g. the TUI footer's
+/// usage entry).
+///
+/// A projection computed on demand from existing conversation state — named
+/// so the underlying types don't leak through `tui_export`.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct ConversationUsageTotals {
+    /// Total credits spent (inference + platform), from the server's
+    /// cumulative usage metadata — the same number the GUI's usage footer
+    /// shows as "Credits spent (total)" and the conversation details panel
+    /// shows as "Credits used".
+    pub credits_spent: f32,
+    /// Total provider cost across all models, in US cents. Fractional —
+    /// per-request provider costs are routinely sub-cent — and `f32` to match
+    /// both the upstream `TokenUsage.cost_in_cents` proto float it sums and
+    /// `credits_spent` above.
+    pub cost_in_cents: f32,
+}
+
 // basic info for creating a dummy command block based on an exchange's inputs
 pub(crate) struct CommandBlockInfo {
     pub(crate) command: String,
@@ -3657,6 +3676,20 @@ impl AIConversation {
     #[allow(dead_code)]
     pub fn total_token_usage(&self) -> Vec<TokenUsage> {
         self.total_token_usage_by_model.values().cloned().collect()
+    }
+
+    /// Compact usage totals for lightweight displays (e.g. the TUI footer's
+    /// usage entry): the GUI-consistent credits total plus the accumulated
+    /// provider dollar cost from the per-request `StreamFinished` usage rows.
+    pub fn usage_totals(&self) -> ConversationUsageTotals {
+        let mut totals = ConversationUsageTotals {
+            credits_spent: self.inference_credits_spent() + self.platform_credits_spent(),
+            cost_in_cents: 0.0,
+        };
+        for usage in self.total_token_usage_by_model.values() {
+            totals.cost_in_cents += usage.cost_in_cents;
+        }
+        totals
     }
 
     /// Normalize all newlines to CRLF so restored blocks render lines starting at column 0,

--- a/app/src/ai/agent/conversation_tests.rs
+++ b/app/src/ai/agent/conversation_tests.rs
@@ -7,8 +7,8 @@ use warpui::{App, SingletonEntity};
 
 use super::{
     artifact_from_fork_proto, footer_model_token_usage, AIConversation,
-    AIConversationAutoexecuteMode, AIConversationId, ConversationStatus, RecordingSpanStatus,
-    RestoreConversationError,
+    AIConversationAutoexecuteMode, AIConversationId, ConversationStatus, ConversationUsageTotals,
+    RecordingSpanStatus, RestoreConversationError,
 };
 use crate::ai::artifacts::Artifact;
 use crate::ai::llms::LLMPreferences;
@@ -668,6 +668,84 @@ fn update_cost_and_usage_uses_fallback_label_for_unknown_custom_endpoint() {
                 .get("primary_agent"),
             Some(&9)
         );
+    });
+}
+
+fn stream_token_usage(
+    model_id: &str,
+    total_input: u32,
+    output: u32,
+    cost_in_cents: f32,
+) -> api::response_event::stream_finished::TokenUsage {
+    api::response_event::stream_finished::TokenUsage {
+        model_id: model_id.to_string(),
+        total_input,
+        output,
+        input_cache_read: 0,
+        input_cache_write: 0,
+        cost_in_cents,
+    }
+}
+
+#[allow(deprecated)]
+fn credits_usage_metadata(
+    credits_spent: f32,
+    platform_credits_spent: f32,
+) -> api::response_event::stream_finished::ConversationUsageMetadata {
+    api::response_event::stream_finished::ConversationUsageMetadata {
+        context_window_usage: 0.0,
+        credits_spent,
+        platform_credits_spent,
+        summarized: false,
+        token_usage: vec![],
+        tool_usage_metadata: None,
+        total_input_tokens: 0,
+        warp_token_usage: HashMap::new(),
+        byok_token_usage: HashMap::new(),
+        context_window_segments: Vec::new(),
+        custom_endpoint_token_usage: HashMap::new(),
+    }
+}
+
+#[test]
+fn usage_totals_reads_gui_credits_and_accumulates_provider_cost() {
+    App::test((), |mut app| async move {
+        initialize_custom_endpoint_usage_test_app(&mut app);
+        app.add_singleton_model(LLMPreferences::new);
+
+        let mut conversation = AIConversation::new(false, false);
+        assert_eq!(
+            conversation.usage_totals(),
+            ConversationUsageTotals::default()
+        );
+
+        app.read(|ctx| {
+            conversation
+                .update_cost_and_usage_for_request(
+                    None,
+                    vec![stream_token_usage("model-a", 100, 20, 1.5)],
+                    Some(credits_usage_metadata(2.0, 0.5)),
+                    false,
+                    ctx,
+                )
+                .expect("usage should update");
+            // The server's usage metadata is cumulative per conversation: the
+            // newest snapshot replaces the previous credits rather than
+            // summing, while provider cost accumulates per request.
+            conversation
+                .update_cost_and_usage_for_request(
+                    None,
+                    vec![stream_token_usage("model-a", 50, 10, 1.2)],
+                    Some(credits_usage_metadata(3.0, 0.5)),
+                    false,
+                    ctx,
+                )
+                .expect("usage should update");
+        });
+
+        let totals = conversation.usage_totals();
+        assert!((totals.credits_spent - 3.5).abs() < 1e-6);
+        assert!((totals.cost_in_cents - 2.7).abs() < 1e-6);
     });
 }
 

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -1848,9 +1848,11 @@ impl BlocklistAIHistoryModel {
     ) {
         // Track whether this update changes any state derived by
         // `BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated`
-        // subscribers (e.g. the orchestration credit rollup). We emit the
-        // event only when there's actual data to react to.
-        let emits_usage_event = request_cost.is_some() || usage_metadata.is_some();
+        // subscribers (e.g. the orchestration credit rollup or the TUI
+        // footer's usage entry). We emit the event only when there's actual
+        // data to react to.
+        let emits_usage_event =
+            request_cost.is_some() || usage_metadata.is_some() || !token_usage.is_empty();
         if let Some(conversation) = self.conversations_by_id.get_mut(&conversation_id) {
             if let Err(e) = conversation.update_cost_and_usage_for_request(
                 request_cost,

--- a/app/src/ai/blocklist/mod.rs
+++ b/app/src/ai/blocklist/mod.rs
@@ -33,7 +33,7 @@ pub mod usage;
 
 pub(crate) mod codebase_index_speedbump_banner;
 pub(crate) mod telemetry_banner;
-pub(super) mod view_util;
+pub(crate) mod view_util;
 
 pub(crate) use action_model::recording_controller::RecordingController;
 // Consumed by `tui_export` for the `warp_tui` frontend.

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -436,6 +436,52 @@ settings::macros::implement_setting_for_enum!(
     description: "Controls how child-agent messages are displayed.",
 );
 
+/// Which unit the TUI's usage entry displays.
+#[derive(
+    Default,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Copy,
+    Clone,
+    EnumIter,
+    schemars::JsonSchema,
+    settings_value::SettingsValue,
+)]
+#[schemars(
+    description = "Which unit the TUI's usage entry displays.",
+    rename_all = "snake_case"
+)]
+pub enum TuiUsageDisplayMode {
+    /// Credits spent — the same number the GUI's usage footer shows (default).
+    #[default]
+    Credits,
+    /// Provider dollar cost.
+    Cost,
+}
+
+settings::macros::implement_setting_for_enum!(
+    TuiUsageDisplayMode,
+    AISettings,
+    SupportedPlatforms::ALL,
+    SyncToCloud::Never,
+    surface: settings::SettingSurfaces::TUI,
+    private: false,
+    toml_path: "agents.usage_display_mode",
+    description: "Which unit the TUI's usage entry displays: credits or provider cost.",
+);
+
+impl TuiUsageDisplayMode {
+    /// The other unit — clicking the usage entry flips to this.
+    pub fn toggled(self) -> Self {
+        match self {
+            TuiUsageDisplayMode::Credits => TuiUsageDisplayMode::Cost,
+            TuiUsageDisplayMode::Cost => TuiUsageDisplayMode::Credits,
+        }
+    }
+}
+
 impl OrchestrationMessageDisplayMode {
     /// Display name for the settings dropdown.
     pub fn display_name(&self) -> &'static str {
@@ -1066,6 +1112,12 @@ define_settings_group!(AISettings, settings: [
         toml_path: "agents.model",
         description: "The default model the TUI agent uses.",
     }
+    // Which unit the TUI footer's usage entry displays (credits or provider
+    // cost), flipped by clicking the entry.
+    //
+    // TUI-only (`surface: Tui`), like `agent_model` above: modeled as a
+    // file-backed setting so the choice persists across TUI sessions.
+    usage_display_mode: TuiUsageDisplayMode,
     // Whether or not the profile-level command autoexecution speedbump has been shown.
     //
     // Not a user-visible setting - we model it as a setting so we can track how often

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -4,7 +4,7 @@ pub use repo_metadata::repositories::RepoDetectionSource;
 
 pub use crate::ai::agent::api::ServerConversationToken;
 pub use crate::ai::agent::conversation::{
-    AIConversationAutoexecuteMode, AIConversationId, ConversationStatus,
+    AIConversationAutoexecuteMode, AIConversationId, ConversationStatus, ConversationUsageTotals,
 };
 pub use crate::ai::agent::task::TaskId;
 pub use crate::ai::agent::{
@@ -37,6 +37,7 @@ pub use crate::ai::blocklist::history_model::{
     BlocklistAIHistoryEvent, BlocklistAIHistoryModel, CloudConversationData,
     ConversationStatusUpdate,
 };
+pub use crate::ai::blocklist::view_util::format_credits;
 pub use crate::ai::blocklist::{
     AIActionStatus, BlocklistAIActionEvent, BlocklistAIActionModel, BlocklistAIContextModel,
     BlocklistAIController, BlocklistAIInputModel, InputConfig, InputModePolicy,

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -32,6 +32,7 @@ mod transient_hint;
 mod tui_block_list_viewport_source;
 mod tui_diff_storage;
 mod tui_file_edits_view;
+mod usage;
 mod warping_indicator;
 
 pub use root_view::RootTuiView;

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -12,11 +12,13 @@ use warp::tui_export::{
     AgentInteractionMetadata, AgentViewEntryOrigin, BlocklistAIActionModel,
     BlocklistAIContextModel, BlocklistAIController, BlocklistAIHistoryEvent,
     BlocklistAIHistoryModel, BlocklistAIInputModel, CancellationReason, CommandExecutionSource,
-    ConversationSelection, ConversationSelectionHandle, ExecuteCommandEvent,
-    GetRelevantFilesController, LLMPreferences, LLMPreferencesEvent, ModelEvent, PtyIntent,
-    PtyIntentEvent, RepoDetectionSessionType, RepoDetectionSource, ShellCommandExecutorEvent,
-    TerminalModel, TerminalSurface, TerminalSurfaceInit, WAKEUP_THROTTLE_PERIOD,
+    ConversationSelection, ConversationSelectionHandle, ConversationUsageTotals,
+    ExecuteCommandEvent, GetRelevantFilesController, LLMPreferences, LLMPreferencesEvent,
+    ModelEvent, PtyIntent, PtyIntentEvent, RepoDetectionSessionType, RepoDetectionSource,
+    ShellCommandExecutorEvent, TerminalModel, TerminalSurface, TerminalSurfaceInit,
+    WAKEUP_THROTTLE_PERIOD,
 };
+use warp_core::settings::Setting;
 use warp_editor::model::CoreEditorModel;
 use warp_errors::report_error;
 use warpui::SingletonEntity;
@@ -40,6 +42,7 @@ use crate::transcript_view::TuiTranscriptView;
 use crate::transient_hint::TransientHint;
 use crate::tui_builder::TuiUiBuilder;
 use crate::ui::abbreviate_home_prefix;
+use crate::usage::UsageToggle;
 use crate::warping_indicator::render_warping_indicator;
 
 /// Width used before the first layout pass pushes the real terminal width into the editor.
@@ -84,6 +87,9 @@ pub(crate) enum TuiTerminalSessionAction {
     /// conversation, else clear the input; a second press within
     /// [`CTRL_C_EXIT_WINDOW`] exits the TUI.
     Interrupt,
+    /// Click on the footer's usage entry: flips the persisted credits⇄cost
+    /// display-mode setting.
+    ToggleUsageDisplay,
 }
 
 /// The authenticated terminal/session surface rendered inside [`RootTuiView`].
@@ -100,6 +106,8 @@ pub(crate) struct TuiTerminalSessionView {
     /// Armed by a ctrl-c press; a second press while armed exits the TUI.
     /// The footer shows [`CTRL_C_EXIT_HINT`] while armed.
     exit_confirmation: ExitConfirmation,
+    /// Credits⇄cost display state for the footer's clickable usage entry.
+    usage_toggle: UsageToggle,
     ai_input_model: ModelHandle<BlocklistAIInputModel>,
     terminal_model: Arc<FairMutex<TerminalModel>>,
     /// Transient notice shown in the footer's hint slot (e.g. a rejected
@@ -249,12 +257,17 @@ impl TuiTerminalSessionView {
             | ModelEvent::FinishUpdate(_) => ctx.notify(),
             _ => {}
         });
-        // The footer shows the active model and working directory: re-render
-        // when the TUI model setting changes (e.g. settings-file hot reload),
-        // when model display names arrive from the server post-login, or when
-        // the session's working directory changes.
+        // The footer shows the active model, working directory, and usage
+        // entry: re-render when the TUI model or usage-display-mode settings
+        // change (click or settings-file hot reload), when model display
+        // names arrive from the server post-login, or when the session's
+        // working directory changes.
         ctx.subscribe_to_model(&AISettings::handle(ctx), |_, _, event, ctx| {
-            if let AISettingsChangedEvent::TuiAgentModel { .. } = event {
+            if matches!(
+                event,
+                AISettingsChangedEvent::TuiAgentModel { .. }
+                    | AISettingsChangedEvent::TuiUsageDisplayMode { .. }
+            ) {
                 ctx.notify();
             }
         });
@@ -289,6 +302,25 @@ impl TuiTerminalSessionView {
             }
             ActiveSessionEvent::Bootstrapped => {}
         });
+        // The footer's usage entry shows the selected conversation's token/cost
+        // totals: re-render when that conversation's usage metadata updates.
+        ctx.subscribe_to_model(
+            &BlocklistAIHistoryModel::handle(ctx),
+            |view, _, event, ctx| {
+                if let BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated {
+                    conversation_id,
+                } = event
+                {
+                    let selected = view
+                        .conversation_selection
+                        .as_ref(ctx)
+                        .selected_conversation_id(ctx);
+                    if selected == Some(*conversation_id) {
+                        ctx.notify();
+                    }
+                }
+            },
+        );
 
         // A wakeup is also how a running block becomes visible: its height is 0
         // until the long-running render-delay timer fires and sends a wakeup
@@ -326,6 +358,7 @@ impl TuiTerminalSessionView {
             active_session,
             terminal_surface_id,
             exit_confirmation: ExitConfirmation::default(),
+            usage_toggle: UsageToggle::default(),
             ai_input_model,
             terminal_model: model,
             transient_hint: TransientHint::default(),
@@ -470,7 +503,50 @@ impl TuiTerminalSessionView {
                     .finish(),
             );
         }
+        // Usage entry: the selected conversation's credits/cost totals,
+        // hidden until any usage has been reported. The displayed unit is the
+        // persisted `agents.usage_display_mode` setting; a click dispatches
+        // the toggle action (the element pass cannot write settings
+        // directly).
+        if let Some(totals) = self.selected_conversation_usage_totals(ctx) {
+            let mode = AISettings::as_ref(ctx).usage_display_mode;
+            footer = footer
+                .child(TuiText::new(" • ").with_style(dim).truncate().finish())
+                .child(
+                    self.usage_toggle
+                        .render_entry(mode, totals, |event_ctx, _| {
+                            event_ctx.dispatch_typed_action(
+                                TuiTerminalSessionAction::ToggleUsageDisplay,
+                            );
+                        }),
+                );
+        }
         footer
+    }
+
+    /// Flips the footer usage entry's persisted credits⇄cost display mode.
+    /// The settings-changed event re-renders every subscribed surface.
+    fn toggle_usage_display(&mut self, ctx: &mut ViewContext<Self>) {
+        let next = AISettings::as_ref(ctx).usage_display_mode.toggled();
+        AISettings::handle(ctx).update(ctx, |settings, ctx| {
+            if let Err(error) = settings.usage_display_mode.set_value(next, ctx) {
+                report_error!("failed to persist the TUI usage display mode: {error:#}");
+            }
+        });
+    }
+
+    /// The selected conversation's accumulated usage totals, or `None` (entry
+    /// hidden) until any usage has been reported.
+    fn selected_conversation_usage_totals(
+        &self,
+        ctx: &AppContext,
+    ) -> Option<ConversationUsageTotals> {
+        let totals = self
+            .conversation_selection
+            .as_ref(ctx)
+            .selected_conversation(ctx)?
+            .usage_totals();
+        (totals != ConversationUsageTotals::default()).then_some(totals)
     }
 
     /// Whether the input is in `!` shell mode (locked shell input).
@@ -725,6 +801,7 @@ impl TypedActionView for TuiTerminalSessionView {
     fn handle_action(&mut self, action: &TuiTerminalSessionAction, ctx: &mut ViewContext<Self>) {
         match action {
             TuiTerminalSessionAction::Interrupt => self.handle_interrupt(ctx),
+            TuiTerminalSessionAction::ToggleUsageDisplay => self.toggle_usage_display(ctx),
         }
     }
 }

--- a/crates/warp_tui/src/usage.rs
+++ b/crates/warp_tui/src/usage.rs
@@ -1,0 +1,77 @@
+//! Reusable usage display for the TUI.
+//!
+//! [`UsageToggle`] owns the hover state behind the footer's clickable usage
+//! entry; the credits⇄cost display mode itself is the file-backed, TUI-only
+//! `agents.usage_display_mode` setting ([`TuiUsageDisplayMode`]), so the
+//! choice persists across TUI sessions. The helpers are shared by every
+//! surface that renders usage (the footer entry today, the
+//! transcript/loading-indicator usage row next — CODE-1832).
+
+use warp::settings::TuiUsageDisplayMode;
+use warp::tui_export::{format_credits, ConversationUsageTotals};
+use warpui_core::elements::tui::{
+    Modifier, TuiElement, TuiEventContext, TuiHoverable, TuiStyle, TuiText,
+};
+use warpui_core::elements::MouseStateHandle;
+use warpui_core::AppContext;
+
+/// The clickable usage entry (`2.5 credits` ⇄ `$0.03`). Owned by the
+/// composing view (created once, cloned into render closures) so the hover
+/// state survives element-tree rebuilds.
+#[derive(Clone, Default)]
+pub(crate) struct UsageToggle {
+    /// Hover state for the entry. Owned here (not created inline during
+    /// render) so it survives element-tree rebuilds, following the GUI's
+    /// `MouseStateHandle` pattern.
+    hover_state: MouseStateHandle,
+}
+
+impl UsageToggle {
+    /// Renders the clickable usage entry (`2.5 credits` ⇄ `$0.03`), dim like
+    /// the rest of the footer metadata and brightened while hovered.
+    /// `on_click` runs on a left click; the composing view uses it to
+    /// dispatch the typed action that flips the persisted display-mode
+    /// setting (the element pass only has an immutable [`AppContext`]).
+    pub(crate) fn render_entry(
+        &self,
+        mode: TuiUsageDisplayMode,
+        totals: ConversationUsageTotals,
+        on_click: impl FnMut(&mut TuiEventContext, &AppContext) + 'static,
+    ) -> Box<dyn TuiElement> {
+        let is_hovered = self
+            .hover_state
+            .lock()
+            .is_ok_and(|state| state.is_hovered());
+        let mut style = TuiStyle::default();
+        if !is_hovered {
+            style = style.add_modifier(Modifier::DIM);
+        }
+        TuiHoverable::new(
+            self.hover_state.clone(),
+            TuiText::new(entry_text(mode, totals))
+                .with_style(style)
+                .truncate()
+                .finish(),
+        )
+        .on_click(on_click)
+        .finish()
+    }
+}
+
+/// The entry's text for `mode`: the GUI-consistent credits total (formatted
+/// with the GUI's own `format_credits`) or the provider dollar cost.
+fn entry_text(mode: TuiUsageDisplayMode, totals: ConversationUsageTotals) -> String {
+    match mode {
+        TuiUsageDisplayMode::Credits => format_credits(totals.credits_spent),
+        TuiUsageDisplayMode::Cost => format_cost(totals.cost_in_cents),
+    }
+}
+
+/// Formats an accumulated cost in US cents as dollars (`3.2` cents → `$0.03`).
+pub(crate) fn format_cost(cost_in_cents: f32) -> String {
+    format!("${:.2}", cost_in_cents / 100.0)
+}
+
+#[cfg(test)]
+#[path = "usage_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/usage_tests.rs
+++ b/crates/warp_tui/src/usage_tests.rs
@@ -1,0 +1,43 @@
+use warp::settings::TuiUsageDisplayMode;
+use warp::tui_export::ConversationUsageTotals;
+
+use super::*;
+
+fn totals(credits_spent: f32, cost_in_cents: f32) -> ConversationUsageTotals {
+    ConversationUsageTotals {
+        credits_spent,
+        cost_in_cents,
+    }
+}
+
+#[test]
+fn cost_formats_cents_as_dollars() {
+    assert_eq!(format_cost(0.0), "$0.00");
+    assert_eq!(format_cost(0.4), "$0.00");
+    assert_eq!(format_cost(3.2), "$0.03");
+    assert_eq!(format_cost(123.0), "$1.23");
+    assert_eq!(format_cost(10_000.0), "$100.00");
+}
+
+#[test]
+fn entry_text_matches_the_gui_credits_formatting() {
+    // `format_credits` is the GUI's formatter: whole values pluralize and
+    // drop the decimal, fractional values keep one decimal place.
+    let mode = TuiUsageDisplayMode::default();
+    assert_eq!(entry_text(mode, totals(1.0, 0.0)), "1 credit");
+    assert_eq!(entry_text(mode, totals(2.0, 0.0)), "2 credits");
+    assert_eq!(entry_text(mode, totals(2.5, 0.0)), "2.5 credits");
+}
+
+#[test]
+fn entry_text_follows_the_persisted_display_mode() {
+    let usage = totals(2.5, 3.2);
+    // Credits is the default mode; a click toggles to cost and back.
+    let credits = TuiUsageDisplayMode::default();
+    assert_eq!(entry_text(credits, usage), "2.5 credits");
+    assert_eq!(entry_text(credits.toggled(), usage), "$0.03");
+    assert_eq!(
+        entry_text(credits.toggled().toggled(), usage),
+        "2.5 credits"
+    );
+}

--- a/specs/CODE-1828/TECH.md
+++ b/specs/CODE-1828/TECH.md
@@ -1,0 +1,73 @@
+# Token / cost transparency in the TUI — TECH
+
+Parent: [CODE-1828](https://linear.app/warpdotdev/issue/CODE-1828/token-cost-transparency). Sub-issues: [CODE-1831](https://linear.app/warpdotdev/issue/CODE-1831/tui-footer-token-usage-entry-with-click-to-toggle-cost) (footer entry) and [CODE-1832](https://linear.app/warpdotdev/issue/CODE-1832/tui-token-usage-next-to-the-loading-indicator-end-of-response-summary) (loading indicator + end-of-response summary row, blocked on PR [#13442](https://github.com/warpdotdev/warp/pull/13442)).
+
+## Context
+
+Per the [Figma mocks](https://www.figma.com/design/yg5nbPZuGoAszHS3Rhvehu/TUI?node-id=323-17499&t=ZINACTiPr1Rk74Dn-0) (frames `323:17499` tokens, `323:17553` hover, `323:17607` cost):
+
+- The footer's right side shows a token entry between the branch and diff stats: `… ↬ main • 4 tok • +31 -12`. Clicking it toggles tokens ⇄ dollar cost (`$0.03`); no third state exists in the mocks.
+- A completed agent response ends with a dim (`bright.black`) summary row: `∷ 1s • 4 tokens`. While streaming, the token count accompanies the `⋮ Warping (Ns)` indicator added by PR #13442 (unmerged; also adds the TUI animation machinery).
+
+Current state (verified live on master and in source):
+
+- `crates/warp_tui/src/terminal_session_view.rs:317-364` — `render_footer` shows only the ctrl-c hint (left) and model name + cwd (right). No mouse handling, no tokens/cost.
+- `crates/warp_tui/src/agent_block.rs`, `agent_block_sections.rs` — agent block sections are Input / PlainText / ToolCall / Thinking only; no per-exchange usage or duration row.
+- No token-count or dollar formatting helper exists anywhere in the TUI or app crate (`format_credits` in `app/src/ai/blocklist/view_util.rs:145` formats credits, not tokens/dollars).
+
+Data plumbing that already exists app-side (unused by the TUI):
+
+- `app/src/ai/agent/conversation.rs` — `update_cost_and_usage_for_request` (line 1960) accumulates per-model `TokenUsage { total_input, output, input_cache_read, input_cache_write, cost_in_cents }` into `total_token_usage_by_model`; accessors `total_token_usage()` / `total_request_cost()` (lines 3489-3496) are `#[allow(dead_code)]` today. Dollar cost comes from `cost_in_cents` (`RequestCost` is credits, not dollars).
+- `BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { conversation_id }` (`app/src/ai/blocklist/history_model.rs:1866`) fires on every usage update; the GUI usage footer subscribes to exactly this (`ConversationUsageView::new_footer_with_rollup`, `app/src/ai/blocklist/usage/conversation_usage_view.rs:156`).
+- Per-exchange precedent for stream-derived metadata: `set_exchange_time_to_first_token` (`history_model.rs:1935`).
+- The TUI consumes app types only through `app/src/tui_export.rs`.
+
+## Proposed changes
+
+### 1. App-side: conversation usage totals + exports (`app/`)
+
+- New `ConversationUsageTotals { credits_spent: f32, cost_in_cents: f32 }` plus `AIConversation::usage_totals()`: credits come from the server's cumulative usage metadata (`inference_credits_spent() + platform_credits_spent()` — the exact number the GUI usage footer shows as "Credits spent (total)" and the details panel shows as "Credits used"), and provider dollar cost is summed across `total_token_usage_by_model` rows. Both fields are `f32`, mirroring their upstream sources (the usage metadata and the `TokenUsage.cost_in_cents` proto float); cents stay fractional — per-request provider costs are routinely sub-cent, so an integer type would truncate. A raw token count was rejected twice during review: summing per-request `total_input` re-counts the (mostly cached) context every request (`100k tok` next to `$0.05`), and even excluding cache reads the first request's ~35k system-prompt/context tokens dominate — no token semantic both matches the mock's scale and stays consistent across providers, so the entry shows the GUI's credits number instead.
+- `format_credits` (the GUI's formatter in `app/src/ai/blocklist/view_util.rs`) is exported through `tui_export.rs` so the TUI renders credits identically to the GUI.
+- `update_conversation_cost_and_usage_for_request` now also emits `ConversationUsageMetadataUpdated` for token-only updates (previously only for request-cost/metadata updates).
+- Export `ConversationUsageTotals` through `tui_export.rs` — `BlocklistAIHistoryEvent` is already exported.
+- Per-exchange capture (`token_usage`/`cost_in_cents` on `AIAgentExchange`, mirroring `time_to_first_token_ms`) is **deferred to PR 2** with its consumer: it touches ~14 `AIAgentExchange` construction sites and its request→exchange attribution semantics are best decided alongside the summary row.
+
+### 2. Shared TUI component (`crates/warp_tui/src/usage.rs`, new)
+
+The reusable piece both sub-issues consume:
+
+- Credits render via the GUI's `format_credits` (`2.5 credits`); `format_cost(cost_in_cents)` → `$0.03` (two decimals).
+- `UsageToggle` — the hover/click wrapper around the footer entry (`TuiHoverable` from `crates/warpui_core/src/elements/tui/`), owned by `TuiTerminalSessionView`. The credits⇄cost display mode itself is the file-backed, TUI-only `agents.usage_display_mode` setting (`TuiUsageDisplayMode` in `AISettings`, `surface: Tui`, never cloud-synced — the `TuiAgentModel` pattern), so the choice persists across TUI sessions and hot-reloads with the settings file. The `MouseStateHandle` must be owned by the view, not created inline during render.
+- **Deliberate mock deviation**: the Figma footer entry reads `4 tok`, but no token semantic survives contact with reality (see section 1), so the entry shows GUI-consistent credits instead — flagged for design review on CODE-1831.
+- Styles come from `TuiUiBuilder` (`dim_text_style`/`muted_text_style`), matching the mock's `#8e8e8e`.
+- Hover affordance is the DIM-removal brighten only. A pointing-hand mouse pointer (the mock's hover cursor) is **explicitly out of scope for this PR** and tracked as a fast follow in [CODE-1837](https://linear.app/warpdotdev/issue/CODE-1837/tui-pointing-hand-cursor-on-hover-over-the-footer-usage-entry-osc-22): it needs OSC 22 pointer-shape plumbing in the TUI core (a working, PTY-verified implementation is preserved in this branch's history at commit `348484d57`) plus host-terminal support that Warp's own terminal lacks today (in progress on `ian/warp-terminal-osc22-pointer-shape`).
+
+### 3. Footer entry (CODE-1831, `terminal_session_view.rs`)
+
+- In `new`: subscribe to `BlocklistAIHistoryModel`; on `ConversationUsageMetadataUpdated` for this surface's selected conversation (`conversation_selection.selected_conversation_id`), `ctx.notify()`. Add the new event arm explicitly — no wildcard matches (repo convention).
+- In `render_footer`: after the cwd, render `• ` + the toggle component using the selected conversation's totals; hide the entry until the first usage event (mock shows it only with data). A click dispatches a typed action (`ToggleUsageDisplay`) whose handler flips the persisted display-mode setting — the element pass only holds an immutable `AppContext`, so settings writes go through the view's action handler. Branch (`↬ main`) and `+31 -12` diff stats remain out of scope.
+
+### 4. Transcript row + streaming counter (CODE-1832, after PR #13442 lands)
+
+- App-side per-exchange capture moves here (deferred from PR 1): add `token_usage: Option<u64>` / `cost_in_cents: Option<f64>` to `AIAgentExchange`, populated from each request's `stream_finished` usage (attribution decided with the row's semantics).
+- New `TuiAIBlockSection::UsageSummary { duration, tokens }` in `agent_block.rs`, extracted when the exchange output is `Finished` and `token_usage` is present; rendered by a new function in `agent_block_sections.rs` as `∷ {duration} • {N} tokens` using the long-form formatter (static text, not clickable, per mocks). Duration from exchange start→finished timestamps (`format_elapsed_seconds` is already exported).
+- Streaming: append `• {N} tokens` to the Warping indicator row using the same formatter, updating as usage events arrive mid-stream. Integration point is the indicator element #13442 adds between transcript and input; defer wiring details until it merges.
+
+## Testing and validation
+
+- Unit tests in sibling `_tests.rs` files per repo convention (`usage_tests.rs`, extend `terminal_session_view` and `agent_block_tests.rs`): cost formatting edge cases, credits text parity with the GUI's `format_credits`, footer hidden before first usage event, footer entry renders credits form then cost form after a click event dispatch, summary section extracted only for finished exchanges with usage, dim styling sourced from theme.
+- App-side tests in `conversation_tests.rs`: `usage_totals` reads the cumulative server credits snapshot (replace, not sum) and accumulates provider cost across requests.
+- Commands: `cargo nextest run -p warp_tui`, `cargo nextest run -p warp` (touched test files), `cargo clippy -p warp_tui --all-targets -- -D warnings`, `./script/format` — all must pass before each PR (presubmit requirement).
+- Manual: `./script/run-tui`; send a prompt; verify the footer credits entry appears and updates, click toggles `2.5 credits` ⇄ `$0.03` and back, summary row appears after completion; compare against Figma frames `323:17499`/`323:17607` (noting the deliberate tok→credits deviation).
+
+## Parallelization
+
+Parallel child agents are not proposed: CODE-1832 is hard-blocked on PR #13442, both surfaces share the new `usage.rs` component and the app-side capture, and the touched files overlap heavily (`terminal_session_view.rs`, `tui_export.rs`). Sequential, stacked delivery is cleaner:
+
+1. PR 1 (now): app-side conversation totals + exports + `usage.rs` + footer entry (CODE-1831), branch `ian/code-1831-tui-footer-token-usage-entry-with-click-to-toggle-cost`.
+2. PR 2 (after #13442 merges): per-exchange usage capture + transcript summary row + streaming counter (CODE-1832), branch `ian/code-1832-tui-token-usage-next-to-the-loading-indicator-end-of`, stacked on PR 1 with graphite.
+
+## Risks and mitigations
+
+- Restored/persisted conversations predate per-exchange capture, so old exchanges have no summary row — acceptable; render nothing when `token_usage` is `None`. Persisting per-exchange usage is a follow-up if product wants history parity.
+- Footer click is the TUI's first mouse-interactive footer element; keep the hit target to the entry's cells only so text selection elsewhere in the footer is unaffected.


### PR DESCRIPTION
## Description
Adds a credits/cost usage entry to the Warp TUI footer ([CODE-1831](https://linear.app/warpdotdev/issue/CODE-1831/tui-footer-credits-usage-entry-with-click-to-toggle-cost), parent [CODE-1828](https://linear.app/warpdotdev/issue/CODE-1828/token-cost-transparency); [Figma](https://www.figma.com/design/yg5nbPZuGoAszHS3Rhvehu/TUI?node-id=323-17499&t=ZINACTiPr1Rk74Dn-0)).

**What**
- The TUI status footer now shows the selected conversation's usage after the model name and cwd: `… • 2.5 credits`, hidden until the first usage report arrives.
- Clicking the entry toggles it to the accumulated provider dollar cost (`• $0.04`) and back; hovering brightens it (DIM removed). The choice is a file-backed, TUI-only setting (`agents.usage_display_mode`, never cloud-synced), so it persists across TUI sessions.
- The credits⇄cost toggle lives in a reusable `crates/warp_tui/src/usage.rs` module, shared with the upcoming transcript/loading-indicator usage row ([CODE-1832](https://linear.app/warpdotdev/issue/CODE-1832/tui-token-usage-next-to-the-loading-indicator-end-of-response-summary)).

**How**
- The credits number is exactly what the GUI's interactive conversation shows ("Credits spent (total)" in the usage footer, "Credits used" in the details panel): `inference + platform` credits from the server's cumulative usage metadata, rendered with the GUI's own `format_credits` (newly exported through `tui_export`). Dollar cost is summed from the per-request `StreamFinished` usage rows.
- New `ConversationUsageTotals` projection + `AIConversation::usage_totals()` expose this through the `tui_export` boundary; `ConversationUsageMetadataUpdated` now also fires for token-only updates so the cost stays fresh.
- **Deliberate mock deviation**: the Figma entry reads `4 tok`, but no token semantic reads sensibly here — per-request `total_input` re-counts the (mostly cached) context every request (`100k tok` next to `$0.05`), and even excluding cache reads the first request's ~35k system-prompt/context tokens dominate. Showing the GUI-consistent credits number instead; flagged in `specs/CODE-1828/TECH.md` for design review.
- A pointing-hand hover cursor is out of scope (kept this PR small); tracked as a fast follow in [CODE-1837](https://linear.app/warpdotdev/issue/CODE-1837/tui-pointing-hand-cursor-on-hover-over-the-footer-usage-entry-osc-22) with a working implementation preserved at 348484d57.

## Linked Issue
Internal Linear-driven work — [CODE-1831](https://linear.app/warpdotdev/issue/CODE-1831/tui-footer-credits-usage-entry-with-click-to-toggle-cost); no GitHub issue.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. (N/A — Linear-tracked internal task)
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- Unit tests: `usage_tests.rs` (credits text parity with the GUI's `format_credits`, per-mode entry text incl. the toggled cost form, cost formatting) and `conversation_tests.rs` (`usage_totals` reads the cumulative server credits snapshot — replace, not sum — and accumulates provider cost). `cargo nextest run -p warp_tui` (93/93) and targeted `-p warp` tests pass; clippy `-D warnings` + `./script/format` clean on both crates.
- E2E: verified twice by a computer-use cloud agent against staging with screen recordings — pre-usage footer shows no entry; after a response it reads `• 1 credit` (singular), click toggles to `$0.01` and back, a second prompt updates to `• 2 credits`; a headless PTY pass additionally covered fractional formatting (`2.4 credits` ⇄ `$0.04` → `3.4 credits`) and byte-level behavior.

- [x] I have manually tested my changes locally with `./script/run-tui`

### Screenshots / Videos
Screen recording of the full flow (entry hidden → `1 credit` → click `$0.01` → click back → second prompt `2 credits`, hover brighten, clean exit), captured by the computer-use verification agent: [Oz run with recording artifacts](https://oz.staging.warp.dev/runs/019f42b8-06d7-78e3-b217-11efc24f326a) — artifact `019f43f8-0149-7bbe-9475-78a44b5a8604`.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Warp conversation](https://staging.warp.dev/conversation/306c359c-b348-46db-af50-0e0a381c2a23)

<!--
## Changelog Entries for Stable
CHANGELOG-NONE
-->

Co-Authored-By: Oz <oz-agent@warp.dev>



