### PR TITLE
Remove the lightened background overlay in Agent Mode

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_message_bar.rs
+++ b/app/src/ai/blocklist/agent_view/agent_message_bar.rs
@@ -5,7 +5,7 @@ use warp_core::features::FeatureFlag;
 use warp_core::ui::appearance::Appearance;
 use warp_core::ui::theme::Fill;
 use warpui::assets::asset_cache::AssetSource;
-use warpui::elements::{Container, Element, Empty, MouseStateHandle};
+use warpui::elements::{Element, Empty, MouseStateHandle};
 use warpui::keymap::Keystroke;
 use warpui::platform::OperatingSystem;
 use warpui::{
@@ -20,7 +20,7 @@ use crate::ai::agent::{
 use crate::ai::blocklist::agent_view::shortcuts::AgentShortcutViewModel;
 use crate::ai::blocklist::agent_view::zero_state_block::render_ambient_credits_banner;
 use crate::ai::blocklist::agent_view::{
-    agent_view_bg_fill, is_in_cloud_context, AgentViewController, AgentViewControllerEvent,
+    is_in_cloud_context, AgentViewController, AgentViewControllerEvent,
 };
 use crate::ai::blocklist::{
     ai_brand_color, BlocklistAIContextEvent, BlocklistAIContextModel, BlocklistAIHistoryEvent,
@@ -414,14 +414,7 @@ impl View for AgentMessageBar {
             Some(FigmaMcpStatus::Running) | None => {}
         }
 
-        let message_bar = render_standard_message_bar(message, right_element, app);
-        if self.agent_view_controller.as_ref(app).is_inline() {
-            Container::new(message_bar)
-                .with_background(agent_view_bg_fill(app))
-                .finish()
-        } else {
-            message_bar
-        }
+        render_standard_message_bar(message, right_element, app)
     }
 }
 

--- a/app/src/ai/blocklist/agent_view/mod.rs
+++ b/app/src/ai/blocklist/agent_view/mod.rs
@@ -27,11 +27,9 @@ pub use inline_agent_view_header::*;
 pub use orchestration_pill_bar::{render_orchestration_breadcrumbs, OrchestrationPillBar};
 use pathfinder_color::ColorU;
 use warp_core::ui::appearance::Appearance;
-use warp_core::ui::color::blend::Blend;
 use warp_core::ui::theme::Fill;
 use warpui::fonts::Properties;
 use warpui::keymap::Keystroke;
-use warpui::{AppContext, SingletonEntity};
 pub use zero_state_block::*;
 
 use crate::terminal::model::TerminalModel;
@@ -93,17 +91,6 @@ pub fn is_in_cloud_context(
     origin_is_cloud
         || terminal_model.is_conversation_transcript_viewer()
         || terminal_model.is_dummy_cloud_mode_session()
-}
-
-pub fn agent_view_bg_fill(app: &AppContext) -> Fill {
-    let appearance = Appearance::as_ref(app);
-    appearance.theme().surface_overlay_1()
-}
-
-pub fn agent_view_bg_color(app: &AppContext) -> ColorU {
-    agent_view_bg_fill(app)
-        .blend(&Appearance::as_ref(app).theme().background())
-        .into_solid()
 }
 
 pub struct AgentViewHeaderTheme;

--- a/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
+++ b/app/src/ai/blocklist/agent_view/orchestration_pill_bar.rs
@@ -47,9 +47,7 @@ use crate::ai::blocklist::agent_view::orchestration_conversation_links::{
 use crate::ai::blocklist::agent_view::orchestration_pill_bar_model::{
     OrchestrationPillBarEvent, OrchestrationPillBarModel,
 };
-use crate::ai::blocklist::agent_view::{
-    agent_view_bg_color, AgentViewController, AgentViewControllerEvent,
-};
+use crate::ai::blocklist::agent_view::{AgentViewController, AgentViewControllerEvent};
 use crate::ai::blocklist::orchestration_topology::{
     aggregated_orchestrator_status, descendant_conversation_ids_in_pill_order,
     descendant_conversation_ids_in_spawn_order,
@@ -1740,12 +1738,14 @@ fn render_pill(
     let is_remote_child = spec.is_remote_child;
 
     // Per Figma: fg_overlay_2 at rest, fg_overlay_3 on hover, composed over
-    // the agent-view surface. Pre-blend to a solid so the avatar cutout ring
+    // the theme background. Pre-blend to a solid so the avatar cutout ring
     // matches the painted pill exactly.
-    let pill_rest_bg = Fill::from(agent_view_bg_color(app))
+    let pill_rest_bg = theme
+        .background()
         .blend(&internal_colors::fg_overlay_2(theme))
         .into_solid();
-    let pill_hover_bg = Fill::from(agent_view_bg_color(app))
+    let pill_hover_bg = theme
+        .background()
         .blend(&internal_colors::fg_overlay_3(theme))
         .into_solid();
     let pill_text_color = internal_colors::fg_overlay_6(theme).into_solid();

--- a/app/src/ai/blocklist/agent_view/zero_state_block.rs
+++ b/app/src/ai/blocklist/agent_view/zero_state_block.rs
@@ -29,8 +29,8 @@ use warpui::{
 use crate::ai::active_agent_views_model::{ActiveAgentViewsModel, ConversationOrTaskId};
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::blocklist::agent_view::{
-    agent_view_bg_color, AgentViewController, AgentViewEntryOrigin,
-    ENTER_AGENT_VIEW_NEW_CONVERSATION_KEYSTROKE, ENTER_CLOUD_AGENT_VIEW_NEW_CONVERSATION_KEYSTROKE,
+    AgentViewController, AgentViewEntryOrigin, ENTER_AGENT_VIEW_NEW_CONVERSATION_KEYSTROKE,
+    ENTER_CLOUD_AGENT_VIEW_NEW_CONVERSATION_KEYSTROKE,
 };
 use crate::ai::blocklist::history_model::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::ai::conversation_navigation::ConversationNavigationData;
@@ -617,9 +617,9 @@ fn render_title_and_description(props: HeaderProps, app: &AppContext) -> Vec<Box
             .finish(),
     );
 
-    let bg = agent_view_bg_color(app);
-    let sub_text_color = theme.sub_text_color(bg.into()).into_solid();
-    let main_text_color = theme.main_text_color(bg.into()).into_solid();
+    let bg = theme.background();
+    let sub_text_color = theme.sub_text_color(bg).into_solid();
+    let main_text_color = theme.main_text_color(bg).into_solid();
 
     match description {
         AgentViewDescription::PlainText(text_items) => {
@@ -804,9 +804,7 @@ fn render_body(props: ZeroStateBodyProps<'_>, app: &AppContext) -> Vec<Box<dyn E
     if should_show_init_callout {
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
-        let main_text_color = theme
-            .main_text_color(agent_view_bg_color(app).into())
-            .into_solid();
+        let main_text_color = theme.main_text_color(theme.background()).into_solid();
         let init_message = Message::new(vec![
             MessageItem::keystroke(Keystroke {
                 key: "/init".to_owned(),
@@ -1178,9 +1176,7 @@ fn render_oz_updates(props: OzUpdatesProps<'_>, app: &AppContext) -> Option<Box<
                 appearance.monospace_font_size() - 2.,
                 appearance.ui_font_family(),
                 appearance.monospace_font_family(),
-                theme
-                    .main_text_color(agent_view_bg_color(app).into())
-                    .into_solid(),
+                theme.main_text_color(theme.background()).into_solid(),
                 state_handles
                     .update_hyperlinks
                     .get(i)

--- a/app/src/ai/blocklist/block/status_bar.rs
+++ b/app/src/ai/blocklist/block/status_bar.rs
@@ -36,8 +36,7 @@ use crate::ai::agent::{
 use crate::ai::agent_tips::AITipModel;
 use crate::ai::blocklist::agent_view::shortcuts::AgentShortcutViewModel;
 use crate::ai::blocklist::agent_view::{
-    agent_view_bg_fill, is_in_cloud_context, AgentMessageBar, AgentViewController,
-    EphemeralMessageModel,
+    is_in_cloud_context, AgentMessageBar, AgentViewController, EphemeralMessageModel,
 };
 use crate::ai::blocklist::model::AIBlockModelHelper;
 use crate::ai::blocklist::summarization_cancel_dialog::{
@@ -1265,9 +1264,7 @@ impl View for BlocklistAIStatusBar {
 
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
-        let background = if agent_view_controller.is_inline() {
-            agent_view_bg_fill(app)
-        } else if InputSettings::as_ref(app).is_universal_developer_input_enabled(app)
+        let background = if InputSettings::as_ref(app).is_universal_developer_input_enabled(app)
             || FeatureFlag::AgentView.is_enabled()
         {
             // Use a fully transparent background for universal developer input (or unconditionally, if the new

--- a/app/src/terminal/block_list_element.rs
+++ b/app/src/terminal/block_list_element.rs
@@ -60,7 +60,7 @@ use super::view::{
 };
 use super::warpify::render::{draw_flag_pole, render_subshell_flag};
 use super::{heights_approx_eq, TerminalModel, HEIGHT_FUDGE_FACTOR_LINES};
-use crate::ai::blocklist::agent_view::{agent_view_bg_fill, AgentViewState};
+use crate::ai::blocklist::agent_view::AgentViewState;
 use crate::ai::blocklist::{ai_brand_color, ATTACH_AS_AGENT_MODE_CONTEXT_TEXT};
 use crate::ai_assistant::{AI_ASSISTANT_SVG_PATH, ASK_AI_ASSISTANT_TEXT};
 use crate::appearance::Appearance;
@@ -2367,7 +2367,6 @@ impl BlockListElement {
         ai_render_context: &BlocklistAIRenderContext,
         agent_view_state: &AgentViewState,
         ctx: &mut PaintContext,
-        app: &AppContext,
     ) {
         let block_height = block.height(agent_view_state).as_f64() as f32 * cell_size.y();
         if block.is_restored()
@@ -2379,16 +2378,6 @@ impl BlockListElement {
                     Vector2F::new(bounds.width(), block_height),
                 ))
                 .with_background(warp_theme.restored_blocks_overlay());
-        }
-
-        // Update the background for the current active long running command when the inline agent view is active.
-        if agent_view_state.is_inline() && block.is_active_and_long_running() {
-            ctx.scene
-                .draw_rect_with_hit_recording(RectF::new(
-                    grid_origin,
-                    Vector2F::new(bounds.width(), block_height),
-                ))
-                .with_background(agent_view_bg_fill(app));
         }
 
         let mut did_render_ai_stripe = false;
@@ -2498,7 +2487,6 @@ impl BlockListElement {
             ai_render_context,
             agent_view_state,
             ctx,
-            app,
         );
 
         let cell_size_height = block_grid_params.grid_render_params.cell_size.y();

--- a/app/src/terminal/input/agent.rs
+++ b/app/src/terminal/input/agent.rs
@@ -19,7 +19,7 @@ use super::{Input, InputAction, InputDropTargetData};
 use crate::ai::blocklist::agent_view::shortcuts::{
     render_agent_shortcuts_view, AgentShortcutsViewContext,
 };
-use crate::ai::blocklist::agent_view::{agent_view_bg_fill, AgentViewState};
+use crate::ai::blocklist::agent_view::AgentViewState;
 use crate::ai::blocklist::InputType;
 use crate::ai::harness_availability::HarnessAvailabilityModel;
 use crate::appearance::Appearance;
@@ -219,7 +219,7 @@ impl Input {
             styles::default_border_color(appearance.theme())
         };
 
-        let mut input = Container::new(
+        let input = Container::new(
             Hoverable::new(self.hoverable_handle.clone(), |_| drop_target)
                 .on_hover(|is_hovered, ctx, _app, _position| {
                     ctx.dispatch_typed_action(InputAction::SetUDIHovered(is_hovered));
@@ -230,13 +230,8 @@ impl Input {
                 .finish(),
         )
         .with_border(Border::top(1.).with_border_color(border_color))
-        .with_padding_bottom(4.);
-
-        if self.agent_view_controller.as_ref(app).is_inline() {
-            input = input.with_background(agent_view_bg_fill(app));
-        }
-
-        let input = input.finish();
+        .with_padding_bottom(4.)
+        .finish();
 
         let mut column = Flex::column();
 

--- a/app/src/terminal/input/inline_menu/styles.rs
+++ b/app/src/terminal/input/inline_menu/styles.rs
@@ -4,12 +4,10 @@
 //! implementations (models, slash commands, conversations) to ensure consistent
 //! visual design matching the Figma specifications.
 use warp_core::ui::appearance::Appearance;
-use warp_core::ui::color::blend::Blend;
 use warp_core::ui::theme::{Fill, WarpTheme};
 use warpui::color::ColorU;
 use warpui::{AppContext, SingletonEntity};
 
-use crate::ai::blocklist::agent_view::agent_view_bg_fill;
 use crate::search::result_renderer::ItemHighlightState;
 
 /// Font size used for inline menu items.
@@ -31,7 +29,7 @@ pub const HEADER_BORDER: f32 = 1.;
 pub fn menu_background_color(app: &AppContext) -> ColorU {
     let appearance = Appearance::as_ref(app);
     let theme = appearance.theme();
-    theme.background().blend(&agent_view_bg_fill(app)).into()
+    theme.background().into_solid()
 }
 
 pub fn item_background(

--- a/app/src/terminal/input/inline_menu/view.rs
+++ b/app/src/terminal/input/inline_menu/view.rs
@@ -31,9 +31,7 @@ use warpui::{
     ViewContext, ViewHandle, WeakViewHandle,
 };
 
-use crate::ai::blocklist::agent_view::{
-    agent_view_bg_color, AgentViewController, AgentViewControllerEvent,
-};
+use crate::ai::blocklist::agent_view::{AgentViewController, AgentViewControllerEvent};
 use crate::search::item::IconLocation;
 use crate::search::mixer::{SearchMixer, SearchMixerEvent};
 use crate::search::result_renderer::{
@@ -1001,15 +999,7 @@ impl<A: InlineMenuAction, T: 'static + Send + Sync> InlineMenuView<A, T> {
                 appearance.ui_font_family(),
                 inline_styles::font_size(appearance),
             )
-            .with_color(
-                theme
-                    .disabled_text_color(if self.agent_view_controller.as_ref(app).is_active() {
-                        agent_view_bg_color(app).into()
-                    } else {
-                        theme.background()
-                    })
-                    .into_solid(),
-            )
+            .with_color(theme.disabled_text_color(theme.background()).into_solid())
             .finish(),
         )
         .finish()

--- a/app/src/terminal/input/message_bar/common.rs
+++ b/app/src/terminal/input/message_bar/common.rs
@@ -12,7 +12,6 @@ use warpui::prelude::{Align, ConstrainedBox, CrossAxisAlignment, Flex, MainAxisS
 use warpui::ui_components::keyboard_shortcut::keystroke_to_keys;
 use warpui::{AppContext, SingletonEntity};
 
-use crate::ai::blocklist::agent_view::agent_view_bg_color;
 use crate::ai::blocklist::agent_view::shortcuts::render_keystroke_with_color_overrides;
 use crate::terminal;
 use crate::terminal::input::message_bar::{ChipHorizontalAlignment, Message, MessageItem};
@@ -508,7 +507,7 @@ pub fn disableable_message_item_color_overrides(
         Some(
             appearance
                 .theme()
-                .disabled_text_color(agent_view_bg_color(app).into())
+                .disabled_text_color(appearance.theme().background())
                 .into_solid(),
         ),
         Some(blended_colors::neutral_2(appearance.theme())),

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -221,11 +221,11 @@ use crate::ai::ambient_agents::{
 };
 use crate::ai::blocklist::agent_view::agent_input_footer::toolbar_item::AgentToolbarItemKind;
 use crate::ai::blocklist::agent_view::{
-    agent_view_bg_fill, fork_from_last_known_good_state_exchange_id,
-    get_agent_view_entry_block_position_id, is_in_cloud_context, AgentViewController,
-    AgentViewControllerEvent, AgentViewConversationSelection, AgentViewDisplayMode,
-    AgentViewEntryBlockParams, AgentViewEntryOrigin, AgentViewHeaderDisabledTheme,
-    AgentViewHeaderTheme, AgentViewZeroStateBlock, AgentViewZeroStateEvent, EphemeralMessageModel,
+    fork_from_last_known_good_state_exchange_id, get_agent_view_entry_block_position_id,
+    is_in_cloud_context, AgentViewController, AgentViewControllerEvent,
+    AgentViewConversationSelection, AgentViewDisplayMode, AgentViewEntryBlockParams,
+    AgentViewEntryOrigin, AgentViewHeaderDisabledTheme, AgentViewHeaderTheme,
+    AgentViewZeroStateBlock, AgentViewZeroStateEvent, EphemeralMessageModel,
     ExitConfirmationTrigger, GuiInputModePolicy, InlineAgentViewHeader, OrchestrationPillBar,
     ENTER_OR_EXIT_CONFIRMATION_WINDOW,
 };
@@ -28094,12 +28094,6 @@ impl View for TerminalView {
             Container::new(element)
                 .with_foreground_overlay(appearance.theme().accent_overlay())
                 .finish()
-        } else if FeatureFlag::AgentView.is_enabled()
-            && self.agent_view_controller.as_ref(app).is_fullscreen()
-        {
-            Container::new(element)
-                .with_foreground_overlay(agent_view_bg_fill(app))
-                .finish()
         } else {
             element
         };
@@ -28114,18 +28108,12 @@ impl View for TerminalView {
             && self.can_show_conversation_details_ui_from_model(&model, app);
 
         if should_show_panel {
-            // Wrap panel with agent view background for visual consistency
-            let panel_with_background =
-                Container::new(ChildView::new(&self.conversation_details_panel).finish())
-                    .with_background(agent_view_bg_fill(app))
-                    .finish();
-
             Container::new(
                 Flex::row()
                     .with_main_axis_size(warpui::elements::MainAxisSize::Max)
                     .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
                     .with_child(Shrinkable::new(1., final_element).finish())
-                    .with_child(panel_with_background)
+                    .with_child(ChildView::new(&self.conversation_details_panel).finish())
                     .finish(),
             )
             .with_border(Border::top(1.0).with_border_fill(appearance.theme().outline()))

--- a/app/src/terminal/view/ambient_agent/block/setup_command_text.rs
+++ b/app/src/terminal/view/ambient_agent/block/setup_command_text.rs
@@ -10,7 +10,7 @@ use warpui::{
     AppContext, Element, Entity, ModelHandle, SingletonEntity, TypedActionView, View, ViewContext,
 };
 
-use crate::ai::blocklist::agent_view::{agent_view_bg_color, AgentViewController};
+use crate::ai::blocklist::agent_view::AgentViewController;
 use crate::ai::blocklist::inline_action::inline_action_icons;
 use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::terminal::view::ambient_agent::{AmbientAgentViewModel, AmbientAgentViewModelEvent};
@@ -171,7 +171,7 @@ impl View for CloudModeSetupTextBlock {
         let icon_size = inline_action_icons::icon_size(app);
         let text_color = appearance
             .theme()
-            .disabled_text_color(agent_view_bg_color(app).into())
+            .disabled_text_color(appearance.theme().background())
             .into_solid();
         let expandable = Hoverable::new(self.mouse_state.clone(), move |_is_hovered| {
             Flex::row()

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -22,7 +22,6 @@ use super::{Event, PaneConfiguration, TerminalAction, TerminalViewState, Viewer}
 use crate::ai::agent::conversation::{
     AIConversation, ConversationStatus, ServerAIConversationMetadata,
 };
-use crate::ai::blocklist::agent_view::agent_view_bg_fill;
 use crate::ai::blocklist::agent_view::orchestration_conversation_links::parent_conversation_navigation_card;
 use crate::ai::blocklist::orchestration_topology::orchestration_aware_conversation_status;
 use crate::ai::blocklist::BlocklistAIHistoryModel;
@@ -586,19 +585,11 @@ impl TerminalView {
             header_ctx.draggable_state.clone(),
             app,
         );
-        let header = self.maybe_add_parent_navigation_card(
+        self.maybe_add_parent_navigation_card(
             draggable_header,
             parent_conversation_header_card,
             app,
-        );
-
-        if is_fullscreen_agent_view {
-            Container::new(header)
-                .with_background(agent_view_bg_fill(app))
-                .finish()
-        } else {
-            header
-        }
+        )
     }
 }
 

--- a/app/src/terminal/view/use_agent_footer/mod.rs
+++ b/app/src/terminal/view/use_agent_footer/mod.rs
@@ -47,7 +47,6 @@ use warpui::{
 };
 
 use super::{RichContentInsertionPosition, TerminalAction, TerminalView};
-use crate::ai::blocklist::agent_view::agent_view_bg_fill;
 use crate::ai::blocklist::block::cli_controller::CLISubagentEvent;
 use crate::cmd_or_ctrl_shift;
 use crate::code_review::diff_state::GitDeltaPreference;
@@ -1374,8 +1373,6 @@ impl View for UseAgentToolbar {
             if let Some(bg_color) = terminal_model.alt_screen().inferred_bg_color() {
                 container = container.with_background(bg_color);
             }
-        } else if terminal_model.block_list().agent_view_state().is_inline() {
-            container = container.with_background(agent_view_bg_fill(app));
         }
 
         container.finish()


### PR DESCRIPTION
## Description
Removes the translucent `surface_overlay_1` background that Agent Mode painted over the pane (fullscreen agent view, plus the inline agent chrome: input, message bar, status bar, use-agent footer, and the active long-running command block). Agent conversations now render with the plain theme background, exactly like a terminal pane.



https://github.com/user-attachments/assets/6d4e0edb-4e7e-432d-a3d9-7e644942b8ee





**Why:**
- Dark themes never rendered fully dark in agent conversations (#11561)
- The luminance shift overloaded the existing "dim inactive panes" / unfocused-window semantic — dim reads as "inactive", not "agent"
- Agent Mode is already signaled by stronger cues: the tab icon, the "← ESC for terminal" breadcrumb, and the distinct input footer

**How:** Deleted `agent_view_bg_fill` / `agent_view_bg_color` and all call sites. Since the old overlay was translucent (it never occluded content), the now-redundant background wrappers are removed outright rather than repainted with the theme background — repainting would double-composite and show darker patches on themes with translucent backgrounds. Contrast-computation call sites now pass `theme.background()`.

Net: 14 files, +37/−118.

## Linked Issue
Fixes #11561
Closes #13489

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `./script/format` — clean
- `cargo clippy -p warp --all-targets --all-features --tests -- -D warnings` — no errors from this change (17 pre-existing dead-code errors in untouched `local_tty`/`writeable_pty`/`shared_session` files also fail on master with `--all-features`)
- `cargo nextest run --no-fail-fast -p warp` — 5554 passed, 0 failed
- No new tests: this is a pure visual removal with no logic changes; existing layout tests cover the touched views

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Before/after screenshots comparing terminal vs. agent panes to follow (will also be posted on #13489 for feedback).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/832ff89f-ca31-47ff-9ee9-d25307fd5f7b

CHANGELOG-IMPROVEMENT: Agent conversations now respect your theme's background color instead of rendering with a lightened overlay.

Co-Authored-By: Oz <oz-agent@warp.dev>