### PR TITLE
Fix TUI running blocks not rendering until command finishes

### DIFF
--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -67,11 +67,12 @@ pub use crate::terminal::model_events::{ModelEvent, ModelEventDispatcher};
 pub use crate::terminal::shared_session::IsSharedSessionCreator;
 pub use crate::terminal::terminal_manager::BlockSpacing;
 pub use crate::terminal::view::blocklist_filter::should_show_task_in_blocklist;
-pub use crate::terminal::view::ExecuteCommandEvent;
+pub use crate::terminal::view::{ExecuteCommandEvent, WAKEUP_THROTTLE_PERIOD};
 pub use crate::terminal::{
     BlockPadding, PtyIntent, PtyIntentEvent, ShellLaunchData,
     TerminalManager as TerminalManagerTrait, TerminalModel, TerminalSurface,
 };
 pub use crate::themes::default_themes::dark_theme;
+pub use crate::throttle::throttle;
 pub use crate::util::repo_detection::{detect_possible_git_repo, RepoDetectionSessionType};
 pub use crate::util::time_format::format_elapsed_seconds;

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -8,14 +8,14 @@ use parking_lot::FairMutex;
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp::settings::{AISettings, AISettingsChangedEvent};
 use warp::tui_export::{
-    detect_possible_git_repo, AIAgentPtyWriteMode, ActiveSession, ActiveSessionEvent,
+    detect_possible_git_repo, throttle, AIAgentPtyWriteMode, ActiveSession, ActiveSessionEvent,
     AgentInteractionMetadata, AgentViewEntryOrigin, BlocklistAIActionModel,
     BlocklistAIContextModel, BlocklistAIController, BlocklistAIHistoryEvent,
     BlocklistAIHistoryModel, BlocklistAIInputModel, CancellationReason, CommandExecutionSource,
     ConversationSelection, ConversationSelectionHandle, ExecuteCommandEvent,
     GetRelevantFilesController, LLMPreferences, LLMPreferencesEvent, ModelEvent, PtyIntent,
     PtyIntentEvent, RepoDetectionSessionType, RepoDetectionSource, ShellCommandExecutorEvent,
-    TerminalModel, TerminalSurface, TerminalSurfaceInit,
+    TerminalModel, TerminalSurface, TerminalSurfaceInit, WAKEUP_THROTTLE_PERIOD,
 };
 use warp_editor::model::CoreEditorModel;
 use warpui::SingletonEntity;
@@ -289,7 +289,29 @@ impl TuiTerminalSessionView {
             ActiveSessionEvent::Bootstrapped => {}
         });
 
-        ctx.spawn_stream_local(wakeups_rx, |_, _, ctx| ctx.notify(), |_, _| {});
+        // A wakeup is also how a running block becomes visible: its height is 0
+        // until the long-running render-delay timer fires and sends a wakeup
+        // (see `Block::wakeup_after_delay`). Heights are otherwise only
+        // recomputed when PTY bytes arrive, so a silent command (e.g. `sleep`)
+        // would stay invisible until it finishes. Mirror the GUI's
+        // `handle_terminal_wakeup` by throttling the stream and refreshing
+        // live block heights here.
+        ctx.spawn_stream_local(
+            throttle(WAKEUP_THROTTLE_PERIOD, wakeups_rx),
+            |view, _, ctx| {
+                {
+                    let mut model = view.terminal_model.lock();
+                    if !model.is_alt_screen_active() {
+                        model.block_list_mut().update_background_block_height();
+                        model.block_list_mut().update_active_block_height();
+                    }
+                }
+
+                ctx.notify();
+            },
+            |_, _| {},
+        );
+
         // Focus the input view so the keymap responder chain is
         // [root, session, input]: input bindings win for keys they define,
         // and unbound keys (ctrl-c) fall through to the session/root bindings.


### PR DESCRIPTION
## Description
Fixes a bug in the headless `warp-tui` where a running command with no output (e.g. `sleep 5`) didn't appear in the transcript until it finished.

**Why it happened:** a running block's height getters all return 0 until `Block::ready_to_render()` is true, which for an executing command only flips 50ms after start via a background timer that then sends a wakeup event (`Block::wakeup_after_delay`). Cached heights in the `block_heights` SumTree are only recomputed when PTY bytes arrive (`on_finish_byte_processing`) or — in the GUI — by `TerminalView::handle_terminal_wakeup`. The TUI's wakeup handler only called `ctx.notify()`, so for a silent command the block's cached height stayed 0 (the command echo/preexec bytes all arrive within the first 50ms) and the viewport source skips height-0 blocks.

**Fix:** mirror the GUI's `handle_terminal_wakeup` in `TuiTerminalSessionView` — throttle the wakeup stream with the same `WAKEUP_THROTTLE_PERIOD` and refresh the active/background block heights (skipping when the alt screen is active) before repainting. `throttle` and `WAKEUP_THROTTLE_PERIOD` are re-exported through `tui_export` for the TUI crate.

## Testing
- [x] I have manually tested my changes locally with `./script/run`

https://www.loom.com/share/4779379062cf477cb761635a50b69a7d

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Conversation: https://staging.warp.dev/conversation/c8475077-b721-4bb1-805b-6726fc538a79

Co-Authored-By: Oz <oz-agent@warp.dev>
