### PR TITLE
Enable skills and project context discovery in TUI

### DIFF
--- a/app/src/ai/persisted_workspace.rs
+++ b/app/src/ai/persisted_workspace.rs
@@ -307,13 +307,19 @@ impl PersistedWorkspace {
             });
         }
 
+        // Registered regardless of whether codebase indexing is enabled:
+        // `index_repo` also drives project-rules (and, transitively, project
+        // skills) discovery, which must work in modes that keep codebase
+        // indexing off (e.g. the TUI front-end). The embedding half of
+        // `index_repo` stays behind its own gates, and
+        // `CodebaseIndexManager::index_directory` no-ops when indexing is
+        // disabled.
         #[cfg(feature = "local_fs")]
         if !cfg!(any(
             test,
             feature = "fast_dev",
             feature = "integration_tests"
-        )) && CodebaseIndexManager::as_ref(ctx).is_indexing_enabled()
-        {
+        )) {
             ctx.subscribe_to_model(&DetectedRepositories::handle(ctx), |me, _, event, ctx| {
                 let DetectedRepositoriesEvent::DetectedGitRepo { repository, .. } = event;
                 let repo_path = repository.as_ref(ctx).root_dir().to_local_path_lossy();

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -534,8 +534,11 @@ impl LaunchMode {
             }
             LaunchMode::App { .. } | LaunchMode::Test { .. } => true,
             LaunchMode::RemoteServerProxy => false,
-            // TODO: no agent harness is wired up for the TUI front-end yet;
-            // enable indexing once it is.
+            // Codebase indexing stays off for the TUI until it has deferred
+            // persisted-index restore and multi-process-safe snapshot writes
+            // (the GUI may run concurrently against the same data dir).
+            // Project rules/skills discovery does not depend on this; see
+            // `PersistedWorkspace::new`.
             LaunchMode::Tui { .. } => false,
         }
     }

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -1,5 +1,7 @@
 //! Public app APIs used by the `warp_tui` frontend.
 
+pub use repo_metadata::repositories::RepoDetectionSource;
+
 pub use crate::ai::agent::api::ServerConversationToken;
 pub use crate::ai::agent::conversation::{
     AIConversationAutoexecuteMode, AIConversationId, ConversationStatus,
@@ -71,4 +73,5 @@ pub use crate::terminal::{
     TerminalManager as TerminalManagerTrait, TerminalModel, TerminalSurface,
 };
 pub use crate::themes::default_themes::dark_theme;
+pub use crate::util::repo_detection::detect_local_git_repo_for_directory;
 pub use crate::util::time_format::format_elapsed_seconds;

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -73,5 +73,5 @@ pub use crate::terminal::{
     TerminalManager as TerminalManagerTrait, TerminalModel, TerminalSurface,
 };
 pub use crate::themes::default_themes::dark_theme;
-pub use crate::util::repo_detection::detect_local_git_repo_for_directory;
+pub use crate::util::repo_detection::{detect_possible_git_repo, RepoDetectionSessionType};
 pub use crate::util::time_format::format_elapsed_seconds;

--- a/app/src/util/repo_detection.rs
+++ b/app/src/util/repo_detection.rs
@@ -17,7 +17,7 @@ use warp_core::SessionId;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 #[cfg(not(target_family = "wasm"))]
 use warpui::SingletonEntity;
-use warpui::{View, ViewContext};
+use warpui::{AppContext, View, ViewContext};
 
 #[cfg(not(target_family = "wasm"))]
 use crate::remote_server::manager::RemoteServerManager;
@@ -83,4 +83,34 @@ pub fn detect_possible_git_repo<V: View>(
     _ctx: &mut ViewContext<V>,
 ) -> impl Future<Output = Option<LocalOrRemotePath>> {
     ready(None)
+}
+
+/// Kicks off git repository detection for a local working directory without
+/// requiring a view context.
+///
+/// This exists for the TUI front-end, whose sessions are always local: it
+/// only needs the `DetectedRepositoriesEvent::DetectedGitRepo` side effect
+/// (project rules and skills indexing) rather than the resolved repo root,
+/// so the detection-result future is intentionally dropped. Detection itself
+/// runs on a task spawned inside [`DetectedRepositories`], so it completes
+/// regardless.
+#[cfg(not(target_family = "wasm"))]
+pub fn detect_local_git_repo_for_directory(
+    active_directory: &str,
+    source: RepoDetectionSource,
+    ctx: &mut AppContext,
+) {
+    let _detection_result = DetectedRepositories::handle(ctx).update(ctx, |repos, ctx| {
+        repos.detect_possible_local_git_repo(active_directory, source, ctx)
+    });
+}
+
+/// Repository detection is not available in WASM builds because
+/// `DetectedRepositories` is not registered there.
+#[cfg(target_family = "wasm")]
+pub fn detect_local_git_repo_for_directory(
+    _active_directory: &str,
+    _source: RepoDetectionSource,
+    _ctx: &mut AppContext,
+) {
 }

--- a/app/src/util/repo_detection.rs
+++ b/app/src/util/repo_detection.rs
@@ -1,4 +1,4 @@
-//! Helpers for constructing repo detection calls from view contexts.
+//! Helpers for constructing repo detection calls.
 //!
 //! The core detection logic lives on
 //! [`DetectedRepositories::detect_possible_git_repo`]. This module provides
@@ -15,9 +15,9 @@ use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::repositories::RepoDetectionSource;
 use warp_core::SessionId;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warpui::AppContext;
 #[cfg(not(target_family = "wasm"))]
 use warpui::SingletonEntity;
-use warpui::{AppContext, View, ViewContext};
 
 #[cfg(not(target_family = "wasm"))]
 use crate::remote_server::manager::RemoteServerManager;
@@ -38,13 +38,16 @@ pub enum RepoDetectionSessionType {
 ///
 /// The caller is responsible for registering remote repo roots in
 /// `DetectedRepositories` and triggering downstream side effects (git status,
-/// code review, etc.) in the spawn callback.
+/// code review, etc.) in the spawn callback. Callers that only need the
+/// `DetectedGitRepo` event side effect (e.g. the TUI front-end's project
+/// rules/skills indexing) may drop the returned future: detection runs on a
+/// task spawned inside [`DetectedRepositories`], so it completes regardless.
 #[cfg(not(target_family = "wasm"))]
-pub fn detect_possible_git_repo<V: View>(
+pub fn detect_possible_git_repo(
     session_type: RepoDetectionSessionType,
     active_directory: &str,
     source: RepoDetectionSource,
-    ctx: &mut ViewContext<V>,
+    ctx: &mut AppContext,
 ) -> impl Future<Output = Option<LocalOrRemotePath>> {
     // Build the remote detection future if this is a remote session.
     // For local sessions, pass None so DetectedRepositories uses the local path.
@@ -76,41 +79,11 @@ pub fn detect_possible_git_repo<V: View>(
 /// Repository detection is not available in WASM builds because
 /// `DetectedRepositories` is not registered there.
 #[cfg(target_family = "wasm")]
-pub fn detect_possible_git_repo<V: View>(
+pub fn detect_possible_git_repo(
     _session_type: RepoDetectionSessionType,
     _active_directory: &str,
     _source: RepoDetectionSource,
-    _ctx: &mut ViewContext<V>,
+    _ctx: &mut AppContext,
 ) -> impl Future<Output = Option<LocalOrRemotePath>> {
     ready(None)
-}
-
-/// Kicks off git repository detection for a local working directory without
-/// requiring a view context.
-///
-/// This exists for the TUI front-end, whose sessions are always local: it
-/// only needs the `DetectedRepositoriesEvent::DetectedGitRepo` side effect
-/// (project rules and skills indexing) rather than the resolved repo root,
-/// so the detection-result future is intentionally dropped. Detection itself
-/// runs on a task spawned inside [`DetectedRepositories`], so it completes
-/// regardless.
-#[cfg(not(target_family = "wasm"))]
-pub fn detect_local_git_repo_for_directory(
-    active_directory: &str,
-    source: RepoDetectionSource,
-    ctx: &mut AppContext,
-) {
-    let _detection_result = DetectedRepositories::handle(ctx).update(ctx, |repos, ctx| {
-        repos.detect_possible_local_git_repo(active_directory, source, ctx)
-    });
-}
-
-/// Repository detection is not available in WASM builds because
-/// `DetectedRepositories` is not registered there.
-#[cfg(target_family = "wasm")]
-pub fn detect_local_git_repo_for_directory(
-    _active_directory: &str,
-    _source: RepoDetectionSource,
-    _ctx: &mut AppContext,
-) {
 }

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -8,14 +8,14 @@ use parking_lot::FairMutex;
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp::settings::{AISettings, AISettingsChangedEvent};
 use warp::tui_export::{
-    detect_local_git_repo_for_directory, AIAgentPtyWriteMode, ActiveSession, ActiveSessionEvent,
+    detect_possible_git_repo, AIAgentPtyWriteMode, ActiveSession, ActiveSessionEvent,
     AgentInteractionMetadata, AgentViewEntryOrigin, BlocklistAIActionModel,
     BlocklistAIContextModel, BlocklistAIController, BlocklistAIHistoryEvent,
     BlocklistAIHistoryModel, BlocklistAIInputModel, CancellationReason, CommandExecutionSource,
     ConversationSelection, ConversationSelectionHandle, ExecuteCommandEvent,
     GetRelevantFilesController, LLMPreferences, LLMPreferencesEvent, ModelEvent, PtyIntent,
-    PtyIntentEvent, RepoDetectionSource, ShellCommandExecutorEvent, TerminalModel, TerminalSurface,
-    TerminalSurfaceInit,
+    PtyIntentEvent, RepoDetectionSessionType, RepoDetectionSource, ShellCommandExecutorEvent,
+    TerminalModel, TerminalSurface, TerminalSurfaceInit,
 };
 use warp_editor::model::CoreEditorModel;
 use warpui::SingletonEntity;
@@ -264,37 +264,30 @@ impl TuiTerminalSessionView {
         });
         ctx.subscribe_to_model(&active_session, |view, _, event, ctx| match event {
             ActiveSessionEvent::UpdatedPwd => {
-                // Re-run repo detection so project rules and skills follow the
+                // Run repo detection so project rules and skills follow the
                 // session's working directory (the GUI's equivalent lives in
-                // `TerminalView::apply_block_metadata_update`).
+                // `TerminalView::apply_block_metadata_update`). The first
+                // post-bootstrap precmd metadata transitions the cwd from
+                // `None` to `Some`, so this also covers the launch directory.
+                // Only the `DetectedGitRepo` event side effect is needed
+                // here, so the detection-result future is dropped.
                 if let Some(cwd) = view
                     .active_session
                     .as_ref(ctx)
                     .current_working_directory()
                     .cloned()
                 {
-                    detect_local_git_repo_for_directory(
+                    std::mem::drop(detect_possible_git_repo(
+                        RepoDetectionSessionType::Local,
                         &cwd,
                         RepoDetectionSource::TerminalNavigation,
                         ctx,
-                    );
+                    ));
                 }
                 ctx.notify();
             }
             ActiveSessionEvent::Bootstrapped => {}
         });
-
-        // Kick off repo detection for the launch directory so project rules
-        // and skills are indexed before the shell bootstraps or the user runs
-        // any command (mirrors the footer's process-cwd fallback). Later
-        // `UpdatedPwd` events re-run detection for the live session cwd.
-        if let Ok(cwd) = std::env::current_dir() {
-            detect_local_git_repo_for_directory(
-                &cwd.to_string_lossy(),
-                RepoDetectionSource::TerminalNavigation,
-                ctx,
-            );
-        }
 
         ctx.spawn_stream_local(wakeups_rx, |_, _, ctx| ctx.notify(), |_, _| {});
         // Focus the input view so the keymap responder chain is

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -8,13 +8,14 @@ use parking_lot::FairMutex;
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp::settings::{AISettings, AISettingsChangedEvent};
 use warp::tui_export::{
-    AIAgentPtyWriteMode, ActiveSession, ActiveSessionEvent, AgentInteractionMetadata,
-    AgentViewEntryOrigin, BlocklistAIActionModel, BlocklistAIContextModel, BlocklistAIController,
-    BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIInputModel, CancellationReason,
-    CommandExecutionSource, ConversationSelection, ConversationSelectionHandle,
-    ExecuteCommandEvent, GetRelevantFilesController, LLMPreferences, LLMPreferencesEvent,
-    ModelEvent, PtyIntent, PtyIntentEvent, ShellCommandExecutorEvent, TerminalModel,
-    TerminalSurface, TerminalSurfaceInit,
+    detect_local_git_repo_for_directory, AIAgentPtyWriteMode, ActiveSession, ActiveSessionEvent,
+    AgentInteractionMetadata, AgentViewEntryOrigin, BlocklistAIActionModel,
+    BlocklistAIContextModel, BlocklistAIController, BlocklistAIHistoryEvent,
+    BlocklistAIHistoryModel, BlocklistAIInputModel, CancellationReason, CommandExecutionSource,
+    ConversationSelection, ConversationSelectionHandle, ExecuteCommandEvent,
+    GetRelevantFilesController, LLMPreferences, LLMPreferencesEvent, ModelEvent, PtyIntent,
+    PtyIntentEvent, RepoDetectionSource, ShellCommandExecutorEvent, TerminalModel, TerminalSurface,
+    TerminalSurfaceInit,
 };
 use warp_editor::model::CoreEditorModel;
 use warpui::SingletonEntity;
@@ -261,10 +262,39 @@ impl TuiTerminalSessionView {
                 ctx.notify();
             }
         });
-        ctx.subscribe_to_model(&active_session, |_, _, event, ctx| match event {
-            ActiveSessionEvent::UpdatedPwd => ctx.notify(),
+        ctx.subscribe_to_model(&active_session, |view, _, event, ctx| match event {
+            ActiveSessionEvent::UpdatedPwd => {
+                // Re-run repo detection so project rules and skills follow the
+                // session's working directory (the GUI's equivalent lives in
+                // `TerminalView::apply_block_metadata_update`).
+                if let Some(cwd) = view
+                    .active_session
+                    .as_ref(ctx)
+                    .current_working_directory()
+                    .cloned()
+                {
+                    detect_local_git_repo_for_directory(
+                        &cwd,
+                        RepoDetectionSource::TerminalNavigation,
+                        ctx,
+                    );
+                }
+                ctx.notify();
+            }
             ActiveSessionEvent::Bootstrapped => {}
         });
+
+        // Kick off repo detection for the launch directory so project rules
+        // and skills are indexed before the shell bootstraps or the user runs
+        // any command (mirrors the footer's process-cwd fallback). Later
+        // `UpdatedPwd` events re-run detection for the live session cwd.
+        if let Ok(cwd) = std::env::current_dir() {
+            detect_local_git_repo_for_directory(
+                &cwd.to_string_lossy(),
+                RepoDetectionSource::TerminalNavigation,
+                ctx,
+            );
+        }
 
         ctx.spawn_stream_local(wakeups_rx, |_, _, ctx| ctx.notify(), |_, _| {});
         // Focus the input view so the keymap responder chain is


### PR DESCRIPTION
## Description

Enables project rules (`AGENTS.md`/`WARP.md`) and project-local skills (`.agents/skills/`) discovery in the `warp-tui` agent harness, bringing it to parity with the GUI for pwd-based agent context.

**What was broken:** The TUI reuses the GUI's query-time context attach machinery (`ProjectContextModel::find_applicable_rules(pwd)`, `SkillManager::get_skills_for_working_directory_with_origin`), but the *discovery* side never ran:
1. `PersistedWorkspace`'s `DetectedGitRepo → index_repo` subscription was gated on `CodebaseIndexManager::is_indexing_enabled()`, which is false for `LaunchMode::Tui`.
2. Nothing in the TUI ever triggered repo detection (`detect_possible_git_repo` was only called from the GUI's `TerminalView`).

As a result, only global rules (`~/.agents/AGENTS.md`) and rules persisted by prior GUI usage attached to TUI queries; project skills never attached.

**How:**
- `PersistedWorkspace` now registers the `DetectedGitRepo → index_repo` subscription regardless of whether codebase indexing is enabled. The rules/skills half of `index_repo` runs unconditionally; the embedding half keeps its existing gates (and `CodebaseIndexManager::index_directory` already no-ops when indexing is disabled).
- Refactored `detect_possible_git_repo` to take `&mut AppContext` instead of `&mut ViewContext<V>` (it only needs singleton access), exported it via `tui_export`, and wired the TUI to run detection on `ActiveSessionEvent::UpdatedPwd`. The first post-bootstrap precmd metadata transitions the cwd from `None` to `Some`, so this also covers the launch directory.
- Codebase indexing itself (persisted-index restore, embedding sync, snapshot writes) deliberately stays **off** for the TUI; the stale TODO on `supports_indexing()` is updated to document the remaining prerequisites (deferred restore, multi-process-safe snapshot writes).

Plan: https://staging.warp.dev/drive/notebook/2FFpDIsjU6FRBM6kebIxAQ
Conversation: https://staging.warp.dev/conversation/5bcb56c3-7dad-40da-9564-441d54d5ffd0

## Linked Issue
No linked GitHub issue — TUI harness parity work.

## Testing

- [x] I have manually tested my changes locally

Manual end-to-end validation with the `warp-tui-dev` binary, run from a fresh git repo (never indexed by the GUI) containing a marker rule in `AGENTS.md` and a project skill in `.agents/skills/`:
- The agent's response included the exact marker codeword from `AGENTS.md` (project rules attached — previously this repo would contribute no rules in the TUI).
- The project skill appeared in the agent's available-skills list alongside home-directory skills.
- TUI startup and login were unaffected; detection stays off the startup critical path.

Automated checks:
- `cargo check` for `warp` (no `tui` feature) and `warp_tui`
- `cargo clippy -p warp -p warp_tui --all-targets -- -D warnings` and `./script/format`
- `cargo nextest run -p warp_tui -p repo_metadata` (204 passed) and filtered app tests around persisted workspace/skills/rules/repo detection (108 passed)

No new unit tests: the change is thin event wiring — the underlying detection logic is already covered by `crates/repo_metadata/src/repositories_tests.rs`, and the `PersistedWorkspace` subscription is intentionally excluded from test builds (`cfg!(test)` guard, unchanged).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Warp <agent@warp.dev>
