### PR TITLE
Separate persistence scope for TUI and GUI

### DIFF
--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -42,7 +42,7 @@ use crate::input_suggestions::HistoryOrder;
 use crate::persistence::model::{AgentConversation, AgentConversationData};
 use crate::persistence::ModelEvent;
 #[cfg(feature = "local_fs")]
-use crate::persistence::{database_file_path_for_scope, establish_ro_connection, PersistenceScope};
+use crate::persistence::{database_file_path_for_current_scope, establish_ro_connection};
 use crate::server::server_api::ServerApiProvider;
 use crate::terminal::model::block::BlockId;
 use crate::terminal::view::blocklist_filter;
@@ -307,7 +307,7 @@ impl BlocklistAIHistoryModel {
         multi_agent_conversations: &[AgentConversation],
     ) -> Self {
         #[cfg(feature = "local_fs")]
-        let db_connection = database_file_path_for_scope(&PersistenceScope::App)
+        let db_connection = database_file_path_for_current_scope()
             .to_str()
             .and_then(|db_url| {
                 establish_ro_connection(db_url)

--- a/app/src/ai/mcp/templatable_manager/native.rs
+++ b/app/src/ai/mcp/templatable_manager/native.rs
@@ -42,7 +42,7 @@ use crate::cloud_object::{
 };
 use crate::drive::CloudObjectTypeAndId;
 use crate::persistence::{
-    database_file_path_for_scope, establish_ro_connection, ModelEvent, PersistenceScope,
+    database_file_path_for_current_scope, establish_ro_connection, ModelEvent,
 };
 use crate::server::cloud_objects::update_manager::{InitiatedBy, UpdateManager};
 use crate::server::ids::{ClientId, ServerId, SyncId};
@@ -330,13 +330,14 @@ impl TemplatableMCPServerManager {
             _ => {}
         });
 
-        let database_connection = database_file_path_for_scope(&PersistenceScope::App)
-            .to_str()
-            .and_then(|db_url| {
-                establish_ro_connection(db_url)
-                    .ok()
-                    .map(|conn| Arc::new(Mutex::new(conn)))
-            });
+        let database_connection =
+            database_file_path_for_current_scope()
+                .to_str()
+                .and_then(|db_url| {
+                    establish_ro_connection(db_url)
+                        .ok()
+                        .map(|conn| Arc::new(Mutex::new(conn)))
+                });
 
         let mut me = Self {
             cloud_templatable_mcp_servers: Default::default(),

--- a/app/src/ai/predict/next_command_model.rs
+++ b/app/src/ai/predict/next_command_model.rs
@@ -28,7 +28,7 @@ use crate::ai::block_context::BlockContext;
 use crate::ai_assistant::execution_context::WarpAiExecutionContext;
 use crate::completer::SessionContext;
 #[cfg(feature = "local_fs")]
-use crate::persistence::{database_file_path_for_scope, establish_ro_connection, PersistenceScope};
+use crate::persistence::{database_file_path_for_current_scope, establish_ro_connection};
 use crate::report_error;
 use crate::server::server_api::{AIApiError, ServerApi};
 use crate::settings::AISettings;
@@ -159,7 +159,7 @@ impl NextCommandModel {
         server_api: Arc<ServerApi>,
     ) -> Self {
         #[cfg(feature = "local_fs")]
-        let conn = database_file_path_for_scope(&PersistenceScope::App)
+        let conn = database_file_path_for_current_scope()
             .to_str()
             .and_then(|db_url| {
                 establish_ro_connection(db_url)

--- a/app/src/ai/restored_conversations.rs
+++ b/app/src/ai/restored_conversations.rs
@@ -14,7 +14,7 @@ use crate::ai::blocklist::history_model::convert_persisted_conversation_to_ai_co
 #[cfg(test)]
 use crate::persistence::model::AgentConversation;
 #[cfg(feature = "local_fs")]
-use crate::persistence::{database_file_path_for_scope, establish_ro_connection, PersistenceScope};
+use crate::persistence::{database_file_path_for_current_scope, establish_ro_connection};
 
 /// Singleton model that restores agent conversations on demand.
 ///
@@ -37,7 +37,7 @@ pub struct RestoredAgentConversations {
 impl RestoredAgentConversations {
     pub fn new() -> Self {
         #[cfg(feature = "local_fs")]
-        let db_connection = database_file_path_for_scope(&PersistenceScope::App)
+        let db_connection = database_file_path_for_current_scope()
             .to_str()
             .and_then(|db_url| {
                 establish_ro_connection(db_url)

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1382,11 +1382,13 @@ pub(crate) fn initialize_app(
                 identity_key: identity_key.clone(),
             }
         }
+        // The TUI keeps its own database so GUI/TUI version skew can never
+        // migrate a shared database out from under the older binary.
+        LaunchMode::Tui { .. } => persistence::PersistenceScope::Tui,
         LaunchMode::App { .. }
         | LaunchMode::CommandLine { .. }
         | LaunchMode::RemoteServerProxy
-        | LaunchMode::Test { .. }
-        | LaunchMode::Tui { .. } => persistence::PersistenceScope::App,
+        | LaunchMode::Test { .. } => persistence::PersistenceScope::App,
     };
     // Only read the subsets of persisted data this launch mode actually
     // consumes; loading everything is expensive on large databases.

--- a/app/src/persistence/mod.rs
+++ b/app/src/persistence/mod.rs
@@ -19,7 +19,7 @@ pub mod testing;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::mpsc::SyncSender;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::thread::JoinHandle;
 
 use ai::project_context::model::ProjectRulePath;
@@ -28,6 +28,11 @@ use chrono::{DateTime, Local, Utc};
 use instant::Instant;
 use lsp::supported_servers::LSPServerType;
 #[cfg(any(feature = "local_fs", feature = "integration_tests"))]
+pub use sqlite::database_file_path_for_current_scope;
+// Only re-exported for integration tests (via `integration_testing::persistence`);
+// in-crate code should resolve paths through `database_file_path_for_current_scope`.
+#[cfg(any(feature = "local_fs", feature = "integration_tests"))]
+#[cfg_attr(not(feature = "integration_tests"), expect(unused_imports))]
 pub use sqlite::database_file_path_for_scope;
 #[cfg(any(feature = "local_fs", feature = "integration_tests"))]
 pub use sqlite::establish_ro_connection;
@@ -60,9 +65,36 @@ use crate::workflows::CloudWorkflow;
 use crate::workspaces::user_profiles::UserProfileWithUID;
 use crate::workspaces::workspace::{Workspace as WorkspaceMetadata, WorkspaceUid};
 
+#[derive(Clone)]
 pub enum PersistenceScope {
+    /// The GUI app (and other launch modes that share its database).
     App,
-    RemoteServerDaemon { identity_key: String },
+    /// The `warp-tui` front-end, which keeps its own database so GUI/TUI
+    /// version skew can never migrate a shared database out from under the
+    /// older binary. Cloud sync is the cross-front-end sharing mechanism.
+    Tui,
+    RemoteServerDaemon {
+        identity_key: String,
+    },
+}
+
+/// The [`PersistenceScope`] this process's persistence was initialized with.
+///
+/// Set once by [`initialize`]. Code that opens ad-hoc read-only connections
+/// should resolve the database path through [`current_scope`] (or
+/// `database_file_path_for_current_scope`) rather than hardcoding a scope, so
+/// it reads the same database as the writer regardless of which front-end
+/// this process is running.
+static CURRENT_SCOPE: OnceLock<PersistenceScope> = OnceLock::new();
+
+/// Returns the scope [`initialize`] was called with, defaulting to
+/// [`PersistenceScope::App`] when persistence has not been initialized (e.g.
+/// tests that construct models directly).
+pub fn current_scope() -> PersistenceScope {
+    CURRENT_SCOPE
+        .get()
+        .cloned()
+        .unwrap_or(PersistenceScope::App)
 }
 
 /// Which subsets of [`PersistedData`] a launch mode actually consumes.
@@ -126,6 +158,9 @@ pub fn initialize(
     scope: PersistenceScope,
     data_scope: PersistedDataScope,
 ) -> (Option<Box<PersistedData>>, Option<WriterHandles>) {
+    // Record the scope for ad-hoc read-only connections; keep the first value
+    // if this is ever called more than once in a process (e.g. tests).
+    let _ = CURRENT_SCOPE.set(scope.clone());
     cfg_if::cfg_if! {
         if #[cfg(feature = "local_fs")] {
             sqlite::initialize(ctx, scope, data_scope)

--- a/app/src/persistence/sqlite.rs
+++ b/app/src/persistence/sqlite.rs
@@ -430,16 +430,31 @@ fn setup_database(database_path: &Path) -> Result<SqliteConnection> {
 pub fn database_file_path_for_scope(scope: &PersistenceScope) -> PathBuf {
     match scope {
         PersistenceScope::App => app_database_file_path(),
+        PersistenceScope::Tui => tui_database_file_path(),
         PersistenceScope::RemoteServerDaemon { identity_key } => {
             remote_server_daemon_database_file_path(identity_key)
         }
     }
 }
 
+/// The database file path for the scope this process's persistence was
+/// initialized with (see [`super::current_scope`]).
+///
+/// Ad-hoc read-only connections should use this instead of hardcoding
+/// [`PersistenceScope::App`], so that a TUI process never reads the GUI's
+/// database.
+pub fn database_file_path_for_current_scope() -> PathBuf {
+    database_file_path_for_scope(&super::current_scope())
+}
+
 fn app_database_file_path() -> PathBuf {
     warp_core::paths::secure_state_dir()
         .unwrap_or_else(warp_core::paths::state_dir)
         .join(WARP_SQLITE_FILE_NAME)
+}
+
+fn tui_database_file_path() -> PathBuf {
+    warp_core::paths::tui_state_dir().join(WARP_SQLITE_FILE_NAME)
 }
 
 fn remote_server_daemon_database_file_path(identity_key: &str) -> PathBuf {

--- a/app/src/persistence/sqlite_tests.rs
+++ b/app/src/persistence/sqlite_tests.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -11,9 +12,9 @@ use warp_core::features::FeatureFlag;
 use warp_graphql::scalars::time::ServerTimestamp;
 
 use super::{
-    app_database_file_path, database_file_path_for_scope, decode_path, deduplicate_events,
-    encode_path, get_all_codebase_index_metadata, read_sqlite_data, save_app_state,
-    save_codebase_index_metadata, setup_database, start_writer,
+    app_database_file_path, database_file_path_for_current_scope, database_file_path_for_scope,
+    decode_path, deduplicate_events, encode_path, get_all_codebase_index_metadata,
+    read_sqlite_data, save_app_state, save_codebase_index_metadata, setup_database, start_writer,
 };
 use crate::app_state::{
     AppState, CodePaneSnapShot, CodePaneTabSnapshot, LeafContents, LeafSnapshot, PaneNodeSnapshot,
@@ -35,6 +36,39 @@ use crate::workspace::tab_group::TabGroupId;
 fn app_scope_database_path_matches_app_database_path() {
     assert_eq!(
         database_file_path_for_scope(&PersistenceScope::App),
+        app_database_file_path()
+    );
+}
+
+#[test]
+fn tui_scope_database_path_is_tui_subdirectory_of_app_database_dir() {
+    let tui_path = database_file_path_for_scope(&PersistenceScope::Tui);
+    let app_path = database_file_path_for_scope(&PersistenceScope::App);
+
+    assert_ne!(tui_path, app_path);
+    assert_eq!(
+        tui_path,
+        warp_core::paths::tui_state_dir().join("warp.sqlite")
+    );
+
+    // The TUI database lives in a `tui` subdirectory of the same base
+    // directory that holds the GUI database, so the two front-ends never
+    // share (or migrate) each other's database.
+    let tui_dir = tui_path
+        .parent()
+        .expect("TUI database path should have a parent");
+    assert_eq!(tui_dir.file_name(), Some(OsStr::new("tui")));
+    assert_eq!(tui_dir.parent(), app_path.parent());
+}
+
+#[test]
+fn database_path_for_current_scope_defaults_to_app_scope() {
+    // Unit tests never call `persistence::initialize`, so the process-wide
+    // scope defaults to `App` and ad-hoc read-only connections resolve to
+    // the GUI database. (nextest runs each test in its own process, so no
+    // other test can have set the scope.)
+    assert_eq!(
+        database_file_path_for_current_scope(),
         app_database_file_path()
     );
 }
@@ -123,6 +157,35 @@ fn sqlite_read_restores_app_state_and_codebase_metadata() {
         .app_state
         .expect("app state should be present for the full scope");
     assert_eq!(restored_app_state.windows.len(), 1);
+    assert_eq!(restored.codebase_indices.len(), 1);
+    assert_eq!(restored.codebase_indices[0].path, metadata.path);
+}
+
+/// Mirrors `init_db(&PersistenceScope::Tui)` in an isolated tempdir: the TUI
+/// database lives in a `tui/` subdirectory, runs the same migrations, and
+/// round-trips a write+read using the TUI's `PersistedDataScope`.
+#[test]
+fn tui_database_in_tui_subdirectory_round_trips_data() {
+    let tempdir = tempfile::tempdir().expect("tempdir should be created");
+    let database_path = tempdir.path().join("tui").join("warp.sqlite");
+    std::fs::create_dir_all(
+        database_path
+            .parent()
+            .expect("database path should have a parent"),
+    )
+    .expect("tui subdirectory should be created");
+    let mut conn = setup_database(&database_path).expect("database should initialize");
+
+    let metadata = test_codebase_metadata("/tmp/tui-repo");
+    save_codebase_index_metadata(&mut conn, metadata.clone())
+        .expect("codebase index metadata should save");
+
+    let restored = read_sqlite_data(&mut conn, None, PersistedDataScope::TuiFrontend)
+        .expect("persisted data should load");
+    // The TUI data scope skips GUI session restoration and history...
+    assert!(restored.app_state.is_none());
+    assert!(restored.command_history.is_empty());
+    // ...but still round-trips shared data like codebase index metadata.
     assert_eq!(restored.codebase_indices.len(), 1);
     assert_eq!(restored.codebase_indices[0].path, metadata.path);
 }

--- a/app/src/settings_view/mcp_servers/edit_page.rs
+++ b/app/src/settings_view/mcp_servers/edit_page.rs
@@ -39,7 +39,7 @@ use crate::cloud_object::{CloudObject, Space};
 use crate::code::editor::view::{CodeEditorRenderOptions, CodeEditorView};
 use crate::persistence::ModelEvent;
 #[cfg(feature = "local_fs")]
-use crate::persistence::{database_file_path_for_scope, establish_ro_connection, PersistenceScope};
+use crate::persistence::{database_file_path_for_current_scope, establish_ro_connection};
 use crate::server::cloud_objects::update_manager::InitiatedBy;
 use crate::server::telemetry::{MCPTemplateCreationSource, TelemetryEvent};
 use crate::settings_view::mcp_servers::destructive_mcp_confirmation_dialog::{
@@ -191,13 +191,14 @@ impl MCPServersEditPageView {
         });
 
         #[cfg(feature = "local_fs")]
-        let database_connection = database_file_path_for_scope(&PersistenceScope::App)
-            .to_str()
-            .and_then(|db_url| {
-                establish_ro_connection(db_url)
-                    .ok()
-                    .map(|conn| Arc::new(Mutex::new(conn)))
-            });
+        let database_connection =
+            database_file_path_for_current_scope()
+                .to_str()
+                .and_then(|db_url| {
+                    establish_ro_connection(db_url)
+                        .ok()
+                        .map(|conn| Arc::new(Mutex::new(conn)))
+                });
 
         Self {
             server_card_item_id: None,

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -233,7 +233,7 @@ use crate::network::NetworkStatus;
 use crate::pane_group::focus_state::PaneFocusHandle;
 use crate::pane_group::PaneGroupAction;
 #[cfg(feature = "local_fs")]
-use crate::persistence::{database_file_path_for_scope, establish_ro_connection, PersistenceScope};
+use crate::persistence::{database_file_path_for_current_scope, establish_ro_connection};
 use crate::prefix::longest_common_prefix;
 use crate::prompt::editor_modal::OpenSource as PromptEditorOpenSource;
 use crate::resource_center::{
@@ -3855,7 +3855,7 @@ impl Input {
         };
 
         #[cfg(feature = "local_fs")]
-        if let Some(db_url) = database_file_path_for_scope(&PersistenceScope::App).to_str() {
+        if let Some(db_url) = database_file_path_for_current_scope().to_str() {
             if let Ok(conn) = establish_ro_connection(db_url) {
                 input.conn = Some(Arc::new(Mutex::new(conn)));
             }

--- a/crates/warp_core/src/paths.rs
+++ b/crates/warp_core/src/paths.rs
@@ -208,6 +208,19 @@ pub fn secure_state_dir() -> Option<PathBuf> {
     None
 }
 
+/// Returns the path to the directory where non-portable application state
+/// data for the TUI front-end (`warp-tui`) should be stored.
+///
+/// This is intentionally distinct from the GUI's state directory (see
+/// [`state_dir`] / [`secure_state_dir`]) so the two front-ends never share a
+/// SQLite database: they can be on different versions with different
+/// persistence schemas, and whichever binary is newer would otherwise migrate
+/// the shared database out from under the older one. Like other on-disk
+/// names, the `tui` directory name must not be changed once established.
+pub fn tui_state_dir() -> PathBuf {
+    secure_state_dir().unwrap_or_else(state_dir).join("tui")
+}
+
 /// Returns the path to the directory containing the user's custom themes.
 pub fn themes_dir() -> PathBuf {
     data_dir().join("themes")

--- a/crates/warp_core/src/paths_tests.rs
+++ b/crates/warp_core/src/paths_tests.rs
@@ -97,6 +97,19 @@ fn test_state_dir_path() {
 }
 
 #[test]
+fn test_tui_state_dir_is_tui_subdir_of_gui_state_base() {
+    let tui_dir = tui_state_dir();
+    assert_eq!(tui_dir.file_name(), Some(std::ffi::OsStr::new("tui")));
+
+    // The TUI state dir must be a direct `tui` child of the same base
+    // directory that holds the GUI's SQLite database (the secure state dir
+    // when available, otherwise the plain state dir), so the two front-ends
+    // keep sibling — never shared — databases.
+    let gui_state_base = secure_state_dir().unwrap_or_else(state_dir);
+    assert_eq!(tui_dir.parent(), Some(gui_state_base.as_path()));
+}
+
+#[test]
 fn test_project_path_for_warp_app_id() {
     let project_dirs = project_dirs_for_app_id(AppId::new("dev", "warp", "Warp"), None)
         .expect("should be able to compute project dirs");


### PR DESCRIPTION
## Description
When the TUI and GUI front-ends are on different versions they can carry different persistence schemas, but today they share one `warp.sqlite` per channel — whichever binary is newer migrates the shared DB out from under the older one, and the two front-ends also clobber each other's session-restoration tables.

This PR gives the TUI its own SQLite database ("Option A" of the persistence-coexistence proposal), using cloud sync as the cross-front-end sharing mechanism:

- New `PersistenceScope::Tui`, mapped from `LaunchMode::Tui`. The TUI DB lives at `<state base>/tui/warp.sqlite` via a new `warp_core::paths::tui_state_dir()` helper, mirroring how `tui_config_local_dir()` already separates TUI settings. The `tui/` directory namespace leaves room for future TUI-private state files.
- Ad-hoc read-only connections now resolve the DB path through a process-wide scope (`database_file_path_for_current_scope()`, backed by a `CURRENT_SCOPE` `OnceLock` set in `persistence::initialize`) instead of hardcoding `PersistenceScope::App` at 6 call sites. This matters most for `RestoredAgentConversations` (lazy conversation loading), which would otherwise silently read the GUI DB from a TUI process.
- Logout wipe already keys off the path captured at init, so a TUI logout deletes only the TUI DB.

Notes:
- Cloud-backed data (notebooks, workflows, generic string objects/settings, MCP templates, teams/profiles) is shared via cloud sync. Local-only tables (local conversation transcripts, command/block history, project rules, MCP installations, session restoration) are intentionally per-front-end.
- No data migration: TUI-authored rows written into the shared DB to date stay visible in the GUI; the TUI starts with a fresh DB (acceptable while the TUI is dogfood-only).
- No feature flag: a runtime flag would swap the TUI between two DB files as it toggles, which is worse than either steady state, and a revert is non-destructive.

## Linked Issue
N/A — scoped from the internal TUI/GUI persistence-coexistence proposal.

## Testing
- [x] I have manually tested my changes locally with `./script/run`

- New unit tests (`app/src/persistence/sqlite_tests.rs`, `crates/warp_core/src/paths_tests.rs`): Tui vs App path mapping, `database_file_path_for_current_scope()` default, and a full migrations + write/read roundtrip against an isolated `tui/` directory with `PersistedDataScope::TuiFrontend`. `cargo nextest run -p warp persistence` → 66/66 passed; `cargo nextest run -p warp_core -E 'test(paths)'` → 10/10 passed.
- Runtime validation (local channel): launching `warp-tui` created `<state base>/tui/warp.sqlite` with all 138 migrations applied and persisted the session's conversation (`agent_conversations` count = 1); direct reads succeed; the GUI `warp.sqlite` was untouched (identical mtime/size before and after the TUI session).
- `./script/format` clean; `cargo check -p warp -p warp_tui` clean.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Warp <agent@warp.dev>
