### PR TITLE
[CODE-1832] Show the last response's duration and credits in the TUI indicator slot

### DIFF
--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -2,6 +2,7 @@
 use std::borrow::Cow;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::time::Duration;
 
 use ai::project_context::model::{ProjectContextModel, ProjectContextModelEvent};
 use instant::Instant;
@@ -44,7 +45,7 @@ use crate::transient_hint::TransientHint;
 use crate::tui_builder::TuiUiBuilder;
 use crate::ui::abbreviate_home_prefix;
 use crate::usage::UsageToggle;
-use crate::warping_indicator::render_warping_indicator;
+use crate::warping_indicator::{render_response_summary, render_warping_indicator};
 use crate::zero_state::render_zero_state;
 
 /// Width used before the first layout pass pushes the real terminal width into the editor.
@@ -809,18 +810,39 @@ impl TuiView for TuiTerminalSessionView {
             .and_then(|conversation_id| {
                 BlocklistAIHistoryModel::as_ref(ctx).conversation(&conversation_id)
             });
-        if let Some(in_progress_conversation) =
-            selected_conversation.filter(|conversation| conversation.status().is_in_progress())
-        {
-            let warping_elapsed = in_progress_conversation
-                .latest_exchange()
-                .and_then(|exchange| exchange.time_since_start());
-            if let Some(elapsed) = warping_elapsed {
-                column = column.child(
-                    TuiContainer::new(render_warping_indicator(elapsed, ctx))
+        if let Some(conversation) = selected_conversation {
+            if conversation.status().is_in_progress() {
+                let warping_elapsed = conversation
+                    .latest_exchange()
+                    .and_then(|exchange| exchange.time_since_start());
+                if let Some(elapsed) = warping_elapsed {
+                    column = column.child(
+                        TuiContainer::new(render_warping_indicator(elapsed, ctx))
+                            .with_padding_top(1)
+                            .finish(),
+                    );
+                }
+            } else {
+                // Once the response completes, the indicator's slot rests on
+                // the last response's summary: `∷ {duration} • {credits}`.
+                // Wall-to-wall duration is only available once the block's
+                // final exchange finished, which also keeps the row hidden
+                // for brand-new conversations.
+                let wall_to_wall = conversation
+                    .wall_to_wall_response_time_since_last_query()
+                    .and_then(|ms| u64::try_from(ms).ok())
+                    .map(Duration::from_millis);
+                if let Some(duration) = wall_to_wall {
+                    column = column.child(
+                        TuiContainer::new(render_response_summary(
+                            duration,
+                            conversation.credits_spent_for_last_block(),
+                            ctx,
+                        ))
                         .with_padding_top(1)
                         .finish(),
-                );
+                    );
+                }
             }
         }
 

--- a/crates/warp_tui/src/warping_indicator.rs
+++ b/crates/warp_tui/src/warping_indicator.rs
@@ -1,6 +1,7 @@
 //! The in-progress `⋮ Warping (Ns)` indicator row rendered between the
 //! transcript and the input box while the selected conversation is in
-//! progress — the TUI counterpart of the GUI's warping indicator.
+//! progress — the TUI counterpart of the GUI's warping indicator — and its
+//! resting form, the completed-response summary row (`∷ 5s • 0.5 credits`).
 //!
 //! All animation state (spinner frame, shimmer phase, elapsed counter) is
 //! derived from one [`AnimationClock`] carrying the exchange's elapsed time,
@@ -14,6 +15,7 @@
 use std::sync::LazyLock;
 use std::time::Duration;
 
+use warp::tui_export::format_credits;
 use warpui_core::elements::animation::{AnimationClock, Keyframe, KeyframeTimeline};
 use warpui_core::elements::shimmer_math::ShimmerConfig;
 use warpui_core::elements::tui::{
@@ -22,6 +24,10 @@ use warpui_core::elements::tui::{
 use warpui_core::AppContext;
 
 use crate::tui_builder::TuiUiBuilder;
+
+/// The spinner's resting glyph, shown by the summary row once a response
+/// completes (`∷ 1s • …`).
+const RESTING_SPINNER: &str = "∷";
 
 /// The spinner choreography from the Figma prototype: a 180° rotation right,
 /// a 180° rotation back left, then a few fast full spins right, restarting.
@@ -102,6 +108,26 @@ pub(crate) fn render_warping_indicator(elapsed: Duration, app: &AppContext) -> B
         .child(label.finish())
         .child(TuiText::new(" ").truncate().finish())
         .child(counter.finish())
+        .finish()
+}
+
+/// Renders the completed-response summary row shown in the indicator's slot
+/// once the response finishes: the resting glyph, the response's wall-to-wall
+/// duration, and the credits it spent (omitted until any are reported). The
+/// row is static — no animation, no repaint scheduling.
+pub(crate) fn render_response_summary(
+    duration: Duration,
+    block_credits: Option<f32>,
+    app: &AppContext,
+) -> Box<dyn TuiElement> {
+    let builder = TuiUiBuilder::from_app(app);
+    let mut text = format!("{RESTING_SPINNER} {}s", duration.as_secs());
+    if let Some(credits) = block_credits.filter(|credits| *credits > 0.0) {
+        text.push_str(&format!(" • {}", format_credits(credits)));
+    }
+    TuiText::new(text)
+        .with_style(builder.muted_text_style())
+        .truncate()
         .finish()
 }
 

--- a/specs/CODE-1828/TECH.md
+++ b/specs/CODE-1828/TECH.md
@@ -30,7 +30,7 @@ Data plumbing that already exists app-side (unused by the TUI):
 - `format_credits` (the GUI's formatter in `app/src/ai/blocklist/view_util.rs`) is exported through `tui_export.rs` so the TUI renders credits identically to the GUI.
 - `update_conversation_cost_and_usage_for_request` now also emits `ConversationUsageMetadataUpdated` for token-only updates (previously only for request-cost/metadata updates).
 - Export `ConversationUsageTotals` through `tui_export.rs` — `BlocklistAIHistoryEvent` is already exported.
-- Per-exchange capture (`token_usage`/`cost_in_cents` on `AIAgentExchange`, mirroring `time_to_first_token_ms`) is **deferred to PR 2** with its consumer: it touches ~14 `AIAgentExchange` construction sites and its request→exchange attribution semantics are best decided alongside the summary row.
+- No per-exchange capture is needed: the summary row consumes the existing block-level accessors (`credits_spent_for_last_block()`, `wall_to_wall_response_time_since_last_query()` — the same sources as the GUI footer's "Credits spent (last response)" and `TimingInfo`).
 
 ### 2. Shared TUI component (`crates/warp_tui/src/usage.rs`, new)
 
@@ -47,27 +47,28 @@ The reusable piece both sub-issues consume:
 - In `new`: subscribe to `BlocklistAIHistoryModel`; on `ConversationUsageMetadataUpdated` for this surface's selected conversation (`conversation_selection.selected_conversation_id`), `ctx.notify()`. Add the new event arm explicitly — no wildcard matches (repo convention).
 - In `render_footer`: after the cwd, render `• ` + the toggle component using the selected conversation's totals; hide the entry until the first usage event (mock shows it only with data). A click dispatches a typed action (`ToggleUsageDisplay`) whose handler flips the persisted display-mode setting — the element pass only holds an immutable `AppContext`, so settings writes go through the view's action handler. Branch (`↬ main`) and `+31 -12` diff stats remain out of scope.
 
-### 4. Transcript row + streaming counter (CODE-1832, after PR #13442 lands)
+### 4. Last-response summary in the indicator slot (CODE-1832, stacked PR)
 
-- App-side per-exchange capture moves here (deferred from PR 1): add `token_usage: Option<u64>` / `cost_in_cents: Option<f64>` to `AIAgentExchange`, populated from each request's `stream_finished` usage (attribution decided with the row's semantics).
-- New `TuiAIBlockSection::UsageSummary { duration, tokens }` in `agent_block.rs`, extracted when the exchange output is `Finished` and `token_usage` is present; rendered by a new function in `agent_block_sections.rs` as `∷ {duration} • {N} tokens` using the long-form formatter (static text, not clickable, per mocks). Duration from exchange start→finished timestamps (`format_elapsed_seconds` is already exported).
-- Streaming: append `• {N} tokens` to the Warping indicator row using the same formatter, updating as usage events arrive mid-stream. Integration point is the indicator element #13442 adds between transcript and input; defer wiring details until it merges.
+- Mock re-read (frames `323:17216` streaming, `323:17499` completed): usage is **hidden while streaming** (the `4 tok • +14 -54` element is `opacity: 0` next to the live `⋮ Warping (1s)` row) and appears only in the completed state as `∷ 1s • …` — the indicator's resting form in the same slot. So the Warping row ships unchanged, and on completion the slot swaps to a static summary row.
+- `render_response_summary(duration, block_credits, app)` in `warping_indicator.rs` (the row is the indicator family's resting form): `∷ {N}s • {credits}` in `muted_text_style` (mock `#8e8e8e`), credits via the GUI's `format_credits`, the credits segment omitted until any are reported (> 0).
+- Wired in `TuiTerminalSessionView::render`: in-progress → Warping row (unchanged); otherwise, when `wall_to_wall_response_time_since_last_query()` is available (requires a finished exchange, so new conversations stay clean), render the summary with `credits_spent_for_last_block()`. Repaints reuse CODE-1831's `ConversationUsageMetadataUpdated` subscription plus the status-change repaint that already removes the Warping row.
+- The mock's per-exchange transcript rows for *historical* blocks would need per-block stamping app-side; deferred as a follow-up if product wants history parity (data exists only for the last block today).
 
 ## Testing and validation
 
-- Unit tests in sibling `_tests.rs` files per repo convention (`usage_tests.rs`, extend `terminal_session_view` and `agent_block_tests.rs`): cost formatting edge cases, credits text parity with the GUI's `format_credits`, footer hidden before first usage event, footer entry renders credits form then cost form after a click event dispatch, summary section extracted only for finished exchanges with usage, dim styling sourced from theme.
+- Unit tests in sibling `_tests.rs` files per repo convention: `usage_tests.rs` (cost formatting edge cases, credits text parity with the GUI's `format_credits`, credits⇄cost toggle, shared clone state) and `warping_indicator_tests.rs` (summary row renders `∷ 5s • 2.5 credits` with no repaint scheduling; credits segment omitted for `None`/zero).
 - App-side tests in `conversation_tests.rs`: `usage_totals` reads the cumulative server credits snapshot (replace, not sum) and accumulates provider cost across requests.
 - Commands: `cargo nextest run -p warp_tui`, `cargo nextest run -p warp` (touched test files), `cargo clippy -p warp_tui --all-targets -- -D warnings`, `./script/format` — all must pass before each PR (presubmit requirement).
 - Manual: `./script/run-tui`; send a prompt; verify the footer credits entry appears and updates, click toggles `2.5 credits` ⇄ `$0.03` and back, summary row appears after completion; compare against Figma frames `323:17499`/`323:17607` (noting the deliberate tok→credits deviation).
 
 ## Parallelization
 
-Parallel child agents are not proposed: CODE-1832 is hard-blocked on PR #13442, both surfaces share the new `usage.rs` component and the app-side capture, and the touched files overlap heavily (`terminal_session_view.rs`, `tui_export.rs`). Sequential, stacked delivery is cleaner:
+Parallel child agents are not proposed for implementation: both surfaces share the usage plumbing and the touched files overlap heavily (`terminal_session_view.rs`, `tui_export.rs`), so sequential, stacked delivery is cleaner (child agents are used for verification instead — PTY byte-level checks and computer-use recordings):
 
-1. PR 1 (now): app-side conversation totals + exports + `usage.rs` + footer entry (CODE-1831), branch `ian/code-1831-tui-footer-token-usage-entry-with-click-to-toggle-cost`.
-2. PR 2 (after #13442 merges): per-exchange usage capture + transcript summary row + streaming counter (CODE-1832), branch `ian/code-1832-tui-token-usage-next-to-the-loading-indicator-end-of`, stacked on PR 1 with graphite.
+1. PR 1: app-side conversation totals + exports + `usage.rs` + footer entry (CODE-1831), branch `ian/code-1831-tui-footer-token-usage-entry-with-click-to-toggle-cost`.
+2. PR 2 (#13442 has merged): last-response summary row in the indicator slot (CODE-1832), branch `ian/code-1832-tui-credits-next-to-the-loading-indicator`, stacked on PR 1 with graphite.
 
 ## Risks and mitigations
 
-- Restored/persisted conversations predate per-exchange capture, so old exchanges have no summary row — acceptable; render nothing when `token_usage` is `None`. Persisting per-exchange usage is a follow-up if product wants history parity.
+- The summary row covers only the last response block (block-level data is all that exists); historical per-block rows in the transcript are a follow-up if product wants history parity. Restored conversations show the row once their accessors resolve from restored exchanges/metadata, and render nothing otherwise.
 - Footer click is the TUI's first mouse-interactive footer element; keep the hit target to the entry's cells only so text selection elsewhere in the footer is unaffected.


### PR DESCRIPTION
## Description
Stacked on #13492. Shows the last response's duration and credits in the TUI's indicator slot ([CODE-1832](https://linear.app/warpdotdev/issue/CODE-1832/tui-token-usage-next-to-the-loading-indicator-end-of-response-summary), parent [CODE-1828](https://linear.app/warpdotdev/issue/CODE-1828/token-cost-transparency); [Figma](https://www.figma.com/design/yg5nbPZuGoAszHS3Rhvehu/TUI?node-id=323-17499&t=ZINACTiPr1Rk74Dn-0)).

**What**
- While a response streams, the `⋮ Warping (Ns)` row (#13442) is unchanged — the mocks keep usage hidden during streaming (the usage element in frame `323:17216` is `opacity: 0`).
- Once the response completes, the same slot rests on a static summary row: `∷ 5s • 0.5 credits` — resting spinner glyph, wall-to-wall duration, and the credits the response spent (the mock's `∷ 1s • …` completed state, with credits instead of tokens per the CODE-1831 direction).
- The credits segment is omitted until any are reported; brand-new conversations show nothing.

**How**
- `render_response_summary` joins the indicator family in `warping_indicator.rs`; muted styling per the mock, credits via the GUI's `format_credits`.
- Wired in `TuiTerminalSessionView::render` from existing block-level accessors — `wall_to_wall_response_time_since_last_query()` and `credits_spent_for_last_block()` (the GUI footer's "Credits spent (last response)"). No app-side changes.
- Repaints reuse the CODE-1831 `ConversationUsageMetadataUpdated` subscription plus the status-change repaint that already removes the Warping row.
- Historical per-block rows in the transcript would need per-block stamping app-side; deferred (noted in `specs/CODE-1828/TECH.md`).

## Linked Issue
Internal Linear-driven work — [CODE-1832](https://linear.app/warpdotdev/issue/CODE-1832/tui-token-usage-next-to-the-loading-indicator-end-of-response-summary); no GitHub issue.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. (N/A — Linear-tracked internal task)
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- Unit tests in `warping_indicator_tests.rs`: the summary row renders `∷ 5s • 2.5 credits` with no repaint scheduling; the credits segment is omitted for `None`/zero. `cargo nextest run -p warp_tui` (97/97), clippy `-D warnings`, `./script/format` all clean.
- E2E verified on a live PTY run against staging (two full prompt/response cycles). Rendered-screen captures confirmed:
  - **Streaming**: `⋮ Warping (0s)` with no credits segment, for both prompts.
  - **Completion**: the slot rests on `∷ 1s • 2.4 credits` after the first response and `∷ 1s • 1 credit` after the second (singular form correct).
  - **Footer (CODE-1831 regression)**: `auto (genius) ~/warp • 2.4 credits` click-toggles to `• $0.04` and back; footer stays hidden until usage is first reported.
  - **Cycling**: the second prompt swaps the summary row back to the Warping row, then a fresh summary; footer cumulative updates 2.4 → 3.4 credits (last-response 1 credit + prior 2.4).

- [x] I have manually tested my changes locally with `./script/run-tui`

### Screenshots / Videos
Live PTY verification screen captures (streaming, completed summary rows for both responses, and the footer credits/$ toggle both directions) recorded from the run described in Testing above.

```text
⋮ Warping (0s)                                     ← streaming (no credits)
∷ 1s • 2.4 credits                                 ← completed, response 1
∷ 1s • 1 credit                                    ← completed, response 2
auto (genius) ~/warp • 2.4 credits  ⇄  • $0.04     ← footer toggle
```

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Warp conversation](https://staging.warp.dev/conversation/306c359c-b348-46db-af50-0e0a381c2a23)

<!--
## Changelog Entries for Stable
CHANGELOG-NONE
-->

Co-Authored-By: Oz <oz-agent@warp.dev>
