### PR TITLE
Add oz factory configuration commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15376,6 +15376,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "tempfile",
  "url",
  "uuid",
  "warp_core",

--- a/app/src/ai/agent_sdk/factory.rs
+++ b/app/src/ai/agent_sdk/factory.rs
@@ -1,0 +1,592 @@
+//! Commands to manage factory config sources via the public API.
+
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{anyhow, bail};
+use warp_cli::agent::OutputFormat;
+use warp_cli::factory::{
+    ApplyFactoryArgs, ExportFactoryArgs, FactoryCommand, InitFactoryArgs, LinkFactoryArgs,
+    PlanFactoryArgs, StatusFactoryArgs,
+};
+use warp_cli::GlobalOptions;
+use warpui::platform::TerminationMode;
+use warpui::r#async::Timer;
+use warpui::{AppContext, ModelContext, SingletonEntity};
+
+use crate::server::server_api::factory::{
+    FactoryClient, FactoryExportResponse, FactoryPlannedChange, FactoryRepository,
+    FactoryResourceError, FactoryResponse, FactorySource, FactorySourceRequest,
+    FactorySyncDryRunResult, FactorySyncState, FactorySyncStatusResponse, FactorySyncSummary,
+    GITHUB_CODE_FORGE,
+};
+use crate::server::server_api::ServerApiProvider;
+
+/// How often `apply --wait` polls the sync status.
+const WAIT_POLL_INTERVAL: Duration = Duration::from_secs(2);
+/// Maximum number of `apply --wait` polls before giving up.
+const WAIT_MAX_POLLS: usize = 150;
+
+/// Singleton model that runs async work for factory CLI commands.
+struct FactoryCommandRunner;
+
+impl warpui::Entity for FactoryCommandRunner {
+    type Event = ();
+}
+
+impl SingletonEntity for FactoryCommandRunner {}
+
+/// Run a factory command.
+pub fn run(
+    ctx: &mut AppContext,
+    global_options: GlobalOptions,
+    command: FactoryCommand,
+) -> anyhow::Result<()> {
+    let runner = ctx.add_singleton_model(|_ctx| FactoryCommandRunner);
+    let output_format = global_options.output_format;
+    match command {
+        FactoryCommand::Link(args) if args.unlink => runner.update(ctx, |runner, ctx| {
+            runner.unlink(args.factory_uid, output_format, ctx)
+        }),
+        FactoryCommand::Link(args) => {
+            runner.update(ctx, |runner, ctx| runner.link(args, output_format, ctx))
+        }
+        FactoryCommand::Unlink(args) => runner.update(ctx, |runner, ctx| {
+            runner.unlink(args.factory_uid, output_format, ctx)
+        }),
+        FactoryCommand::Status(args) => {
+            runner.update(ctx, |runner, ctx| runner.status(args, output_format, ctx))
+        }
+        FactoryCommand::Plan(args) => {
+            runner.update(ctx, |runner, ctx| runner.plan(args, output_format, ctx))
+        }
+        FactoryCommand::Apply(args) => {
+            runner.update(ctx, |runner, ctx| runner.apply(args, output_format, ctx))
+        }
+        FactoryCommand::Init(args) => {
+            runner.update(ctx, |runner, ctx| runner.init(args, output_format, ctx))
+        }
+        FactoryCommand::Export(args) => {
+            runner.update(ctx, |runner, ctx| runner.export(args, output_format, ctx))
+        }
+    }
+}
+
+impl FactoryCommandRunner {
+    fn spawn_command(
+        &self,
+        future: impl warpui::r#async::Spawnable<Output = anyhow::Result<()>>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        ctx.spawn(future, |_, result, ctx| match result {
+            Ok(()) => {
+                ctx.terminate_app(TerminationMode::ForceTerminate, None);
+            }
+            Err(err) => {
+                super::report_fatal_error(err, ctx);
+            }
+        });
+    }
+
+    fn link(
+        &self,
+        args: LinkFactoryArgs,
+        output_format: OutputFormat,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<()> {
+        let factory_client = ServerApiProvider::as_ref(ctx).get_factory_client();
+        let future = async move {
+            let repo = args
+                .repo
+                .ok_or_else(|| anyhow!("--repo is required unless --unlink is set"))?;
+            let request = FactorySourceRequest {
+                code_forge: GITHUB_CODE_FORGE.to_string(),
+                repository: FactoryRepository {
+                    owner: repo.owner,
+                    repo: repo.repo,
+                },
+                r#ref: args.branch,
+                path: args.path,
+            };
+            let factory = factory_client
+                .link_factory_source(&args.factory_uid, request)
+                .await?;
+            write_linked_factory(&factory, output_format, &mut std::io::stdout())
+        };
+        self.spawn_command(future, ctx);
+        Ok(())
+    }
+
+    fn unlink(
+        &self,
+        factory_uid: String,
+        output_format: OutputFormat,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<()> {
+        let factory_client = ServerApiProvider::as_ref(ctx).get_factory_client();
+        let future = async move {
+            factory_client.unlink_factory_source(&factory_uid).await?;
+            match output_format {
+                OutputFormat::Json | OutputFormat::Ndjson => {
+                    super::output::write_json_line(
+                        &serde_json::json!({ "factory_uid": factory_uid, "unlinked": true }),
+                        std::io::stdout(),
+                    )?;
+                }
+                OutputFormat::Pretty | OutputFormat::Text => {
+                    println!("Factory {factory_uid} unlinked; it is now live-managed.");
+                }
+            }
+            Ok(())
+        };
+        self.spawn_command(future, ctx);
+        Ok(())
+    }
+
+    fn status(
+        &self,
+        args: StatusFactoryArgs,
+        output_format: OutputFormat,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<()> {
+        let factory_client = ServerApiProvider::as_ref(ctx).get_factory_client();
+        let future = async move {
+            let status = factory_client
+                .get_factory_sync_status(&args.factory_uid)
+                .await?;
+            write_status(&status, output_format, &mut std::io::stdout())
+        };
+        self.spawn_command(future, ctx);
+        Ok(())
+    }
+
+    fn plan(
+        &self,
+        args: PlanFactoryArgs,
+        output_format: OutputFormat,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<()> {
+        let factory_client = ServerApiProvider::as_ref(ctx).get_factory_client();
+        let future = async move {
+            let result = factory_client
+                .sync_factory_dry_run(&args.factory_uid, args.sha)
+                .await?;
+            write_plan(&result, output_format, &mut std::io::stdout())
+        };
+        self.spawn_command(future, ctx);
+        Ok(())
+    }
+
+    fn apply(
+        &self,
+        args: ApplyFactoryArgs,
+        output_format: OutputFormat,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<()> {
+        let factory_client = ServerApiProvider::as_ref(ctx).get_factory_client();
+        let future = async move {
+            let accepted = factory_client
+                .sync_factory(&args.factory_uid, args.sha)
+                .await?;
+            match output_format {
+                OutputFormat::Json | OutputFormat::Ndjson => {
+                    super::output::write_json_line(&accepted, std::io::stdout())?;
+                }
+                OutputFormat::Pretty | OutputFormat::Text => {
+                    println!("Sync accepted for commit {}.", accepted.commit_sha);
+                }
+            }
+
+            if !args.wait {
+                return Ok(());
+            }
+
+            if matches!(output_format, OutputFormat::Pretty | OutputFormat::Text) {
+                println!("Waiting for sync to finish...");
+            }
+            let summary = wait_for_factory_sync(
+                factory_client.as_ref(),
+                &args.factory_uid,
+                &accepted.commit_sha,
+                WAIT_POLL_INTERVAL,
+                WAIT_MAX_POLLS,
+            )
+            .await?;
+            let outcome = apply_wait_outcome(&summary)?;
+            match output_format {
+                OutputFormat::Json | OutputFormat::Ndjson => {
+                    super::output::write_json_line(&summary, std::io::stdout())?;
+                }
+                OutputFormat::Pretty | OutputFormat::Text => {
+                    print!("{outcome}");
+                }
+            }
+            Ok(())
+        };
+        self.spawn_command(future, ctx);
+        Ok(())
+    }
+
+    fn init(
+        &self,
+        args: InitFactoryArgs,
+        output_format: OutputFormat,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<()> {
+        let future = async move {
+            let dir = args.dir.unwrap_or_else(|| PathBuf::from("."));
+            let files = warp_cli::factory::init_factory_dir(&dir, args.force)?;
+            write_written_files(
+                &format!("Initialized factory scaffold in {}.", dir.display()),
+                &dir,
+                &files,
+                output_format,
+                &mut std::io::stdout(),
+            )
+        };
+        self.spawn_command(future, ctx);
+        Ok(())
+    }
+
+    fn export(
+        &self,
+        args: ExportFactoryArgs,
+        output_format: OutputFormat,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<()> {
+        let factory_client = ServerApiProvider::as_ref(ctx).get_factory_client();
+        let future = async move {
+            let (dir, files) = export_factory_to_dir(
+                factory_client.as_ref(),
+                &args.factory_uid,
+                args.out,
+                args.force,
+            )
+            .await?;
+            write_written_files(
+                &format!("Exported factory {} to {}.", args.factory_uid, dir.display()),
+                &dir,
+                &files,
+                output_format,
+                &mut std::io::stdout(),
+            )
+        };
+        self.spawn_command(future, ctx);
+        Ok(())
+    }
+}
+
+/// Download a factory's rendered config files and write them under the out
+/// directory, defaulting to `./<factory-name>` from the exported factory.yaml.
+async fn export_factory_to_dir(
+    factory_client: &dyn FactoryClient,
+    factory_uid: &str,
+    out: Option<PathBuf>,
+    force: bool,
+) -> anyhow::Result<(PathBuf, Vec<String>)> {
+    let export = factory_client.export_factory(factory_uid).await?;
+    let dir = match out {
+        Some(out) => out,
+        None => PathBuf::from(exported_factory_name(&export)?),
+    };
+    let files = warp_cli::factory::write_export_files(&dir, &export.files, force)?;
+    Ok((dir, files))
+}
+
+/// The default export directory name: the factory name declared in the
+/// exported factory.yaml.
+fn exported_factory_name(export: &FactoryExportResponse) -> anyhow::Result<String> {
+    #[derive(serde::Deserialize)]
+    struct ExportedFactorySpec {
+        name: Option<String>,
+    }
+
+    let factory_yaml = export.files.get("factory.yaml").ok_or_else(|| {
+        anyhow!("The export has no factory.yaml; pass --out to choose an output directory")
+    })?;
+    let spec: ExportedFactorySpec = serde_yaml::from_str(factory_yaml).map_err(|err| {
+        anyhow!(
+            "Could not parse the exported factory.yaml ({err}); pass --out to choose an output directory"
+        )
+    })?;
+    let name = spec.name.unwrap_or_default();
+    let mut components = Path::new(&name).components();
+    if name.is_empty()
+        || !matches!(components.next(), Some(Component::Normal(_)))
+        || components.next().is_some()
+    {
+        bail!(
+            "The exported factory.yaml has no usable name; pass --out to choose an output directory"
+        );
+    }
+    Ok(name)
+}
+
+fn write_written_files<W>(
+    headline: &str,
+    dir: &Path,
+    files: &[String],
+    output_format: OutputFormat,
+    output: &mut W,
+) -> anyhow::Result<()>
+where
+    W: Write,
+{
+    match output_format {
+        OutputFormat::Json => super::output::write_json(&written_files_json(dir, files), output),
+        OutputFormat::Ndjson => {
+            super::output::write_json_line(&written_files_json(dir, files), output)
+        }
+        OutputFormat::Pretty | OutputFormat::Text => {
+            writeln!(output, "{headline}")?;
+            for file in files {
+                writeln!(output, "  {file}")?;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn written_files_json(dir: &Path, files: &[String]) -> serde_json::Value {
+    serde_json::json!({ "dir": dir.display().to_string(), "files": files })
+}
+
+/// Poll the sync-status endpoint until the sync for `commit_sha` reaches a terminal state.
+async fn wait_for_factory_sync(
+    factory_client: &dyn FactoryClient,
+    factory_uid: &str,
+    commit_sha: &str,
+    poll_interval: Duration,
+    max_polls: usize,
+) -> anyhow::Result<FactorySyncSummary> {
+    for poll in 0..max_polls {
+        let status = factory_client.get_factory_sync_status(factory_uid).await?;
+        if let Some(summary) = terminal_sync_for_commit(&status, commit_sha) {
+            return Ok(summary);
+        }
+        if poll + 1 < max_polls {
+            Timer::after(poll_interval).await;
+        }
+    }
+    Err(anyhow!(
+        "Timed out waiting for the sync of commit {commit_sha} to finish"
+    ))
+}
+
+/// Returns the terminal sync summary for `commit_sha`, if the latest sync targets that
+/// commit and has finished.
+fn terminal_sync_for_commit(
+    status: &FactorySyncStatusResponse,
+    commit_sha: &str,
+) -> Option<FactorySyncSummary> {
+    let latest = status.latest_sync.as_ref()?;
+    if latest.commit_sha != commit_sha || !latest.status.is_terminal() {
+        return None;
+    }
+    Some(latest.clone())
+}
+
+/// Map a terminal sync summary to the human-readable outcome for `apply --wait`.
+///
+/// Failed syncs surface as an error so the process exits non-zero.
+fn apply_wait_outcome(summary: &FactorySyncSummary) -> anyhow::Result<String> {
+    let mut rendered = String::new();
+    match summary.status {
+        FactorySyncState::Failed => {
+            let mut message = format!("Sync of commit {} failed.", summary.commit_sha);
+            if !summary.resource_errors.is_empty() {
+                message.push_str("\nErrors:");
+                for error in &summary.resource_errors {
+                    message.push('\n');
+                    message.push_str(&format_resource_error(error));
+                }
+            }
+            return Err(anyhow!(message));
+        }
+        FactorySyncState::Success => {
+            rendered.push_str(&format!(
+                "Sync of commit {} succeeded.\n",
+                summary.commit_sha
+            ));
+        }
+        FactorySyncState::Noop => {
+            rendered.push_str(&format!(
+                "Sync of commit {} was a no-op; the factory is already up to date.\n",
+                summary.commit_sha
+            ));
+        }
+        FactorySyncState::Partial => {
+            rendered.push_str(&format!(
+                "Sync of commit {} applied with degraded resources.\n",
+                summary.commit_sha
+            ));
+        }
+        FactorySyncState::Pending | FactorySyncState::Running => {
+            return Err(anyhow!(
+                "Sync of commit {} is still {}",
+                summary.commit_sha,
+                summary.status.as_str()
+            ));
+        }
+    }
+    if !summary.degraded_reasons.is_empty() {
+        rendered.push_str("Degraded reasons:\n");
+        for reason in &summary.degraded_reasons {
+            rendered.push_str(&format!("- {reason}\n"));
+        }
+    }
+    Ok(rendered)
+}
+
+fn format_resource_error(error: &FactoryResourceError) -> String {
+    match error.line {
+        Some(line) => format!("- {}:{}: {}", error.resource_path, line, error.message),
+        None => format!("- {}: {}", error.resource_path, error.message),
+    }
+}
+
+fn format_source(source: &FactorySource) -> String {
+    let mut rendered = format!(
+        "{}/{} @ {} ({})",
+        source.repository.owner, source.repository.repo, source.r#ref, source.code_forge
+    );
+    if !source.path.is_empty() {
+        rendered.push_str(&format!(", path: {}", source.path));
+    }
+    rendered
+}
+
+fn write_linked_factory<W>(
+    factory: &FactoryResponse,
+    output_format: OutputFormat,
+    output: &mut W,
+) -> anyhow::Result<()>
+where
+    W: Write,
+{
+    match output_format {
+        OutputFormat::Json => super::output::write_json(factory, output),
+        OutputFormat::Ndjson => super::output::write_json_line(factory, output),
+        OutputFormat::Pretty | OutputFormat::Text => {
+            writeln!(output, "Factory {} linked.", factory.uid)?;
+            if let Some(source) = &factory.source {
+                writeln!(output, "Source: {}", format_source(source))?;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn write_status<W>(
+    status: &FactorySyncStatusResponse,
+    output_format: OutputFormat,
+    output: &mut W,
+) -> anyhow::Result<()>
+where
+    W: Write,
+{
+    match output_format {
+        OutputFormat::Json => super::output::write_json(status, output),
+        OutputFormat::Ndjson => super::output::write_json_line(status, output),
+        OutputFormat::Pretty | OutputFormat::Text => {
+            writeln!(output, "Management mode: {}", status.management_mode)?;
+            match &status.source {
+                Some(source) => writeln!(output, "Source: {}", format_source(source))?,
+                None => writeln!(output, "Source: none")?,
+            }
+            writeln!(
+                output,
+                "Last synced commit: {}",
+                status.last_synced_commit.as_deref().unwrap_or("none")
+            )?;
+            match &status.latest_sync {
+                Some(latest) => {
+                    writeln!(output, "Latest sync:")?;
+                    writeln!(output, "  Commit: {}", latest.commit_sha)?;
+                    writeln!(output, "  Status: {}", latest.status.as_str())?;
+                    writeln!(output, "  Started: {}", latest.started_at.to_rfc3339())?;
+                    if let Some(finished_at) = latest.finished_at {
+                        writeln!(output, "  Finished: {}", finished_at.to_rfc3339())?;
+                    }
+                    if !latest.resource_errors.is_empty() {
+                        writeln!(output, "  Errors:")?;
+                        for error in &latest.resource_errors {
+                            writeln!(output, "  {}", format_resource_error(error))?;
+                        }
+                    }
+                    if !latest.degraded_reasons.is_empty() {
+                        writeln!(output, "  Degraded reasons:")?;
+                        for reason in &latest.degraded_reasons {
+                            writeln!(output, "  - {reason}")?;
+                        }
+                    }
+                }
+                None => writeln!(output, "Latest sync: never synced")?,
+            }
+            Ok(())
+        }
+    }
+}
+
+fn write_plan<W>(
+    result: &FactorySyncDryRunResult,
+    output_format: OutputFormat,
+    output: &mut W,
+) -> anyhow::Result<()>
+where
+    W: Write,
+{
+    match output_format {
+        OutputFormat::Json => super::output::write_json(result, output),
+        OutputFormat::Ndjson => super::output::write_json_line(result, output),
+        OutputFormat::Pretty | OutputFormat::Text => {
+            let Some(plan) = &result.plan else {
+                let mut message = format!(
+                    "Dry-run of commit {} failed with structural errors:",
+                    result.commit_sha
+                );
+                for error in &result.resource_errors {
+                    message.push('\n');
+                    message.push_str(&format_resource_error(error));
+                }
+                return Err(anyhow!(message));
+            };
+
+            writeln!(output, "Plan for commit {}:", result.commit_sha)?;
+            let mut write_group = |label: &str,
+                                   marker: char,
+                                   changes: &[FactoryPlannedChange]|
+             -> anyhow::Result<()> {
+                if changes.is_empty() {
+                    return Ok(());
+                }
+                writeln!(output)?;
+                writeln!(output, "{label} ({}):", changes.len())?;
+                for change in changes {
+                    writeln!(
+                        output,
+                        "{marker} {} ({}): {}",
+                        change.path, change.kind, change.reason
+                    )?;
+                }
+                Ok(())
+            };
+            write_group("Create", '+', &plan.creates)?;
+            write_group("Update", '~', &plan.updates)?;
+            write_group("Delete", '-', &plan.deletes)?;
+
+            if plan.creates.is_empty() && plan.updates.is_empty() && plan.deletes.is_empty() {
+                writeln!(output)?;
+                writeln!(output, "No changes.")?;
+            }
+            writeln!(output)?;
+            writeln!(output, "{} resource(s) unchanged.", plan.no_ops)?;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "factory_tests.rs"]
+mod tests;

--- a/app/src/ai/agent_sdk/factory_tests.rs
+++ b/app/src/ai/agent_sdk/factory_tests.rs
@@ -1,0 +1,448 @@
+use std::time::Duration;
+
+use chrono::{TimeZone as _, Utc};
+use futures::executor::block_on;
+
+use super::*;
+use crate::server::server_api::factory::{FactorySyncPlan, MockFactoryClient};
+
+fn export_response(entries: &[(&str, &str)]) -> FactoryExportResponse {
+    FactoryExportResponse {
+        files: entries
+            .iter()
+            .map(|(path, content)| (path.to_string(), content.to_string()))
+            .collect(),
+    }
+}
+
+fn planned_change(path: &str, kind: &str, reason: &str) -> FactoryPlannedChange {
+    FactoryPlannedChange {
+        path: path.to_string(),
+        kind: kind.to_string(),
+        reason: reason.to_string(),
+    }
+}
+
+fn resource_error(path: &str, line: Option<i64>, message: &str) -> FactoryResourceError {
+    FactoryResourceError {
+        resource_path: path.to_string(),
+        line,
+        message: message.to_string(),
+    }
+}
+
+fn sync_summary(commit_sha: &str, status: FactorySyncState) -> FactorySyncSummary {
+    FactorySyncSummary {
+        commit_sha: commit_sha.to_string(),
+        status,
+        started_at: Utc.with_ymd_and_hms(2026, 7, 8, 5, 0, 0).unwrap(),
+        finished_at: Some(Utc.with_ymd_and_hms(2026, 7, 8, 5, 0, 10).unwrap()),
+        resource_errors: vec![],
+        degraded_reasons: vec![],
+    }
+}
+
+fn file_managed_status(latest_sync: Option<FactorySyncSummary>) -> FactorySyncStatusResponse {
+    FactorySyncStatusResponse {
+        management_mode: "file_managed".to_string(),
+        source: Some(FactorySource {
+            code_forge: "GITHUB".to_string(),
+            repository: FactoryRepository {
+                owner: "warpdotdev".to_string(),
+                repo: "factory-config".to_string(),
+            },
+            r#ref: "main".to_string(),
+            path: "factories/prod".to_string(),
+        }),
+        last_synced_commit: Some("aaa111".to_string()),
+        latest_sync,
+    }
+}
+
+fn render_status_text(status: &FactorySyncStatusResponse) -> String {
+    let mut output = Vec::new();
+    write_status(status, OutputFormat::Text, &mut output).expect("status renders");
+    String::from_utf8(output).expect("output is valid utf-8")
+}
+
+fn render_plan_text(result: &FactorySyncDryRunResult) -> anyhow::Result<String> {
+    let mut output = Vec::new();
+    write_plan(result, OutputFormat::Text, &mut output)?;
+    Ok(String::from_utf8(output).expect("output is valid utf-8"))
+}
+
+#[test]
+fn plan_rendering_matches_golden() {
+    let result = FactorySyncDryRunResult {
+        commit_sha: "abc123".to_string(),
+        plan: Some(FactorySyncPlan {
+            creates: vec![
+                planned_change("agents/reviewer.md", "Agent", "new resource"),
+                planned_change("automations/nightly.md", "Automation", "new resource"),
+            ],
+            updates: vec![planned_change(
+                "environments/prod.yaml",
+                "Environment",
+                "spec changed",
+            )],
+            deletes: vec![planned_change("runners/legacy.yaml", "Runner", "file removed")],
+            no_ops: 3,
+        }),
+        resource_errors: vec![],
+    };
+
+    let rendered = render_plan_text(&result).unwrap();
+
+    let golden = "\
+Plan for commit abc123:
+
+Create (2):
++ agents/reviewer.md (Agent): new resource
++ automations/nightly.md (Automation): new resource
+
+Update (1):
+~ environments/prod.yaml (Environment): spec changed
+
+Delete (1):
+- runners/legacy.yaml (Runner): file removed
+
+3 resource(s) unchanged.
+";
+    assert_eq!(rendered, golden);
+}
+
+#[test]
+fn empty_plan_renders_no_changes() {
+    let result = FactorySyncDryRunResult {
+        commit_sha: "abc123".to_string(),
+        plan: Some(FactorySyncPlan {
+            no_ops: 5,
+            ..Default::default()
+        }),
+        resource_errors: vec![],
+    };
+
+    let rendered = render_plan_text(&result).unwrap();
+
+    let golden = "\
+Plan for commit abc123:
+
+No changes.
+
+5 resource(s) unchanged.
+";
+    assert_eq!(rendered, golden);
+}
+
+#[test]
+fn plan_with_structural_errors_fails_with_file_and_line_details() {
+    let result = FactorySyncDryRunResult {
+        commit_sha: "abc123".to_string(),
+        plan: None,
+        resource_errors: vec![
+            resource_error("environments/prod.yaml", Some(12), "invalid enum value"),
+            resource_error("factory.yaml", None, "missing name"),
+        ],
+    };
+
+    let err = render_plan_text(&result).unwrap_err();
+
+    let message = err.to_string();
+    assert!(message.contains("structural errors"), "got: {message}");
+    assert!(
+        message.contains("- environments/prod.yaml:12: invalid enum value"),
+        "got: {message}"
+    );
+    assert!(message.contains("- factory.yaml: missing name"), "got: {message}");
+}
+
+#[test]
+fn status_rendering_covers_successful_sync() {
+    let status = file_managed_status(Some(sync_summary("aaa111", FactorySyncState::Success)));
+
+    let rendered = render_status_text(&status);
+
+    let golden = "\
+Management mode: file_managed
+Source: warpdotdev/factory-config @ main (GITHUB), path: factories/prod
+Last synced commit: aaa111
+Latest sync:
+  Commit: aaa111
+  Status: success
+  Started: 2026-07-08T05:00:00+00:00
+  Finished: 2026-07-08T05:00:10+00:00
+";
+    assert_eq!(rendered, golden);
+}
+
+#[test]
+fn status_rendering_lists_failed_sync_errors() {
+    let mut summary = sync_summary("bbb222", FactorySyncState::Failed);
+    summary.resource_errors = vec![resource_error(
+        "environments/prod.yaml",
+        Some(12),
+        "invalid enum value",
+    )];
+    let status = file_managed_status(Some(summary));
+
+    let rendered = render_status_text(&status);
+
+    assert!(rendered.contains("  Status: failed"), "got: {rendered}");
+    assert!(rendered.contains("  Errors:"), "got: {rendered}");
+    assert!(
+        rendered.contains("  - environments/prod.yaml:12: invalid enum value"),
+        "got: {rendered}"
+    );
+}
+
+#[test]
+fn status_rendering_lists_degraded_reasons() {
+    let mut summary = sync_summary("ccc333", FactorySyncState::Partial);
+    summary.degraded_reasons = vec!["missing managed secret DATADOG_API_KEY".to_string()];
+    let status = file_managed_status(Some(summary));
+
+    let rendered = render_status_text(&status);
+
+    assert!(rendered.contains("  Status: partial"), "got: {rendered}");
+    assert!(rendered.contains("  Degraded reasons:"), "got: {rendered}");
+    assert!(
+        rendered.contains("  - missing managed secret DATADOG_API_KEY"),
+        "got: {rendered}"
+    );
+}
+
+#[test]
+fn status_rendering_covers_live_managed_never_synced() {
+    let status = FactorySyncStatusResponse {
+        management_mode: "live_managed".to_string(),
+        source: None,
+        last_synced_commit: None,
+        latest_sync: None,
+    };
+
+    let rendered = render_status_text(&status);
+
+    let golden = "\
+Management mode: live_managed
+Source: none
+Last synced commit: none
+Latest sync: never synced
+";
+    assert_eq!(rendered, golden);
+}
+
+#[test]
+fn terminal_sync_requires_matching_commit_and_terminal_status() {
+    let running = file_managed_status(Some(sync_summary("abc", FactorySyncState::Running)));
+    assert!(terminal_sync_for_commit(&running, "abc").is_none());
+
+    let other_commit = file_managed_status(Some(sync_summary("def", FactorySyncState::Success)));
+    assert!(terminal_sync_for_commit(&other_commit, "abc").is_none());
+
+    let never_synced = file_managed_status(None);
+    assert!(terminal_sync_for_commit(&never_synced, "abc").is_none());
+
+    let done = file_managed_status(Some(sync_summary("abc", FactorySyncState::Noop)));
+    let summary = terminal_sync_for_commit(&done, "abc").expect("noop is terminal");
+    assert_eq!(summary.status, FactorySyncState::Noop);
+}
+
+#[test]
+fn apply_wait_outcome_fails_on_failed_sync() {
+    let mut summary = sync_summary("abc", FactorySyncState::Failed);
+    summary.resource_errors = vec![resource_error("factory.yaml", Some(3), "bad field")];
+
+    let err = apply_wait_outcome(&summary).unwrap_err();
+
+    let message = err.to_string();
+    assert!(message.contains("Sync of commit abc failed."), "got: {message}");
+    assert!(message.contains("- factory.yaml:3: bad field"), "got: {message}");
+}
+
+#[test]
+fn apply_wait_outcome_reports_success_and_degraded_reasons() {
+    let success = apply_wait_outcome(&sync_summary("abc", FactorySyncState::Success)).unwrap();
+    assert_eq!(success, "Sync of commit abc succeeded.\n");
+
+    let noop = apply_wait_outcome(&sync_summary("abc", FactorySyncState::Noop)).unwrap();
+    assert!(noop.contains("no-op"), "got: {noop}");
+
+    let mut partial_summary = sync_summary("abc", FactorySyncState::Partial);
+    partial_summary.degraded_reasons = vec!["missing managed secret FOO".to_string()];
+    let partial = apply_wait_outcome(&partial_summary).unwrap();
+    assert!(partial.contains("degraded resources"), "got: {partial}");
+    assert!(partial.contains("- missing managed secret FOO"), "got: {partial}");
+}
+
+#[test]
+fn wait_returns_summary_once_sync_for_commit_is_terminal() {
+    let mut client = MockFactoryClient::new();
+    let mut polls = 0;
+    client
+        .expect_get_factory_sync_status()
+        .times(3)
+        .returning(move |_| {
+            polls += 1;
+            let summary = match polls {
+                // Poll 1: our sync is still running. Poll 2: the ledger still shows an
+                // older commit's sync. Poll 3: our sync reached a terminal state.
+                1 => sync_summary("abc", FactorySyncState::Running),
+                2 => sync_summary("older", FactorySyncState::Success),
+                _ => sync_summary("abc", FactorySyncState::Failed),
+            };
+            Ok(file_managed_status(Some(summary)))
+        });
+
+    let summary = block_on(wait_for_factory_sync(
+        &client,
+        "fac-1",
+        "abc",
+        Duration::ZERO,
+        10,
+    ))
+    .unwrap();
+
+    assert_eq!(summary.commit_sha, "abc");
+    assert_eq!(summary.status, FactorySyncState::Failed);
+    assert!(apply_wait_outcome(&summary).is_err());
+}
+
+#[test]
+fn wait_times_out_when_sync_never_becomes_terminal() {
+    let mut client = MockFactoryClient::new();
+    client
+        .expect_get_factory_sync_status()
+        .times(2)
+        .returning(|_| {
+            Ok(file_managed_status(Some(sync_summary(
+                "abc",
+                FactorySyncState::Running,
+            ))))
+        });
+
+    let err = block_on(wait_for_factory_sync(
+        &client,
+        "fac-1",
+        "abc",
+        Duration::ZERO,
+        2,
+    ))
+    .unwrap_err();
+
+    assert!(err.to_string().contains("Timed out"), "got: {err}");
+}
+
+#[test]
+fn exported_factory_name_reads_factory_yaml() {
+    let export = export_response(&[(
+        "factory.yaml",
+        "kind: Factory\nschema_version: 1\nname: acme-factory\n",
+    )]);
+
+    assert_eq!(exported_factory_name(&export).unwrap(), "acme-factory");
+}
+
+#[test]
+fn exported_factory_name_requires_usable_name() {
+    let cases = [
+        export_response(&[("agents/reviewer/agent.md", "body")]),
+        export_response(&[("factory.yaml", "kind: Factory\n")]),
+        export_response(&[("factory.yaml", "name: ../evil\n")]),
+        export_response(&[("factory.yaml", "name: /evil\n")]),
+        export_response(&[("factory.yaml", "name: a/b\n")]),
+        export_response(&[("factory.yaml", "name: [unclosed\n")]),
+    ];
+    for export in cases {
+        let err = exported_factory_name(&export).unwrap_err();
+        assert!(err.to_string().contains("--out"), "got: {err}");
+    }
+}
+
+#[test]
+fn export_downloads_files_into_out_dir() {
+    let mut client = MockFactoryClient::new();
+    client.expect_export_factory().times(1).returning(|_| {
+        Ok(export_response(&[
+            (
+                "factory.yaml",
+                "kind: Factory\nschema_version: 1\nname: acme-factory\n",
+            ),
+            ("agents/reviewer/agent.md", "---\nkind: Agent\n---\nbody\n"),
+        ]))
+    });
+    let temp = tempfile::tempdir().expect("tempdir");
+    let out = temp.path().join("exported");
+
+    let (dir, files) =
+        block_on(export_factory_to_dir(&client, "fac-1", Some(out.clone()), false)).unwrap();
+
+    assert_eq!(dir, out);
+    assert_eq!(
+        files,
+        vec![
+            "agents/reviewer/agent.md".to_string(),
+            "factory.yaml".to_string(),
+        ]
+    );
+    assert_eq!(
+        std::fs::read_to_string(out.join("agents/reviewer/agent.md")).expect("agent.md exists"),
+        "---\nkind: Agent\n---\nbody\n"
+    );
+}
+
+#[test]
+fn export_rejects_server_supplied_path_traversal() {
+    let mut client = MockFactoryClient::new();
+    client
+        .expect_export_factory()
+        .times(1)
+        .returning(|_| Ok(export_response(&[("../escape.txt", "evil")])));
+    let temp = tempfile::tempdir().expect("tempdir");
+    let out = temp.path().join("exported");
+
+    let err = block_on(export_factory_to_dir(&client, "fac-1", Some(out.clone()), false))
+        .unwrap_err();
+
+    assert!(err.to_string().contains("unsafe path"), "got: {err}");
+    assert!(!out.exists());
+    assert!(!temp.path().join("escape.txt").exists());
+}
+
+#[test]
+fn init_scaffold_parses_as_yaml_with_expected_envelopes() {
+    let files = warp_cli::factory::scaffold_files("acme-factory");
+
+    let factory: serde_yaml::Value =
+        serde_yaml::from_str(&files["factory.yaml"]).expect("factory.yaml is valid YAML");
+    assert_eq!(factory["kind"].as_str(), Some("Factory"));
+    assert_eq!(factory["schema_version"].as_i64(), Some(1));
+    assert_eq!(factory["name"].as_str(), Some("acme-factory"));
+
+    let secrets: serde_yaml::Value =
+        serde_yaml::from_str(&files["secrets.yaml"]).expect("secrets.yaml is valid YAML");
+    assert_eq!(secrets["kind"].as_str(), Some("SecretManifest"));
+    assert_eq!(secrets["schema_version"].as_i64(), Some(1));
+    assert!(
+        secrets["secrets"]
+            .as_sequence()
+            .is_some_and(|secrets| secrets.is_empty()),
+        "secrets is an empty list"
+    );
+
+    let agent = &files[warp_cli::factory::SCAFFOLD_AGENT_PATH];
+    let (frontmatter, body) = agent
+        .strip_prefix("---\n")
+        .and_then(|rest| rest.split_once("\n---\n"))
+        .expect("agent template has frontmatter");
+    let frontmatter: serde_yaml::Value =
+        serde_yaml::from_str(frontmatter).expect("agent frontmatter is valid YAML");
+    assert_eq!(frontmatter["kind"].as_str(), Some("Agent"));
+    assert_eq!(frontmatter["schema_version"].as_i64(), Some(1));
+    assert!(
+        frontmatter["description"]
+            .as_str()
+            .is_some_and(|description| !description.is_empty()),
+        "agent description is set"
+    );
+    assert!(!body.trim().is_empty(), "agent template has a body");
+}

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -20,6 +20,7 @@ use warp_cli::agent::{
 use warp_cli::api_key::ApiKeyCommand;
 use warp_cli::artifact::ArtifactCommand;
 use warp_cli::environment::{EnvironmentCommand, ImageCommand};
+use warp_cli::factory::FactoryCommand;
 use warp_cli::federate::FederateCommand;
 use warp_cli::harness_support::{HarnessSupportCommand, ReportArtifactCommand, TaskStatus};
 use warp_cli::integration::IntegrationCommand;
@@ -84,6 +85,7 @@ mod common;
 mod config_file;
 pub(crate) mod driver;
 mod environment;
+mod factory;
 mod federate;
 mod harness_support;
 #[cfg(not(target_family = "wasm"))]
@@ -193,6 +195,7 @@ fn dispatch_command(
             }
             federate::run(ctx, global_options, federate_cmd)
         }
+        CliCommand::Factory(factory_cmd) => factory::run(ctx, global_options, factory_cmd),
         CliCommand::HarnessSupport(args) => {
             if !FeatureFlag::AgentHarness.is_enabled() {
                 return Err(anyhow::anyhow!("invalid value 'harness-support'"));
@@ -1540,6 +1543,16 @@ fn command_requires_auth(command: &CliCommand) -> bool {
         CliCommand::Schedule(_) => true,
         CliCommand::Secret(_) => true,
         CliCommand::Federate(_) => true,
+        CliCommand::Factory(factory_cmd) => match factory_cmd {
+            // Local scaffolding only; no server interaction.
+            FactoryCommand::Init(_) => false,
+            FactoryCommand::Link(_)
+            | FactoryCommand::Unlink(_)
+            | FactoryCommand::Status(_)
+            | FactoryCommand::Plan(_)
+            | FactoryCommand::Apply(_)
+            | FactoryCommand::Export(_) => true,
+        },
         CliCommand::HarnessSupport(_) => true,
         CliCommand::Artifact(_) => true,
         CliCommand::ApiKey(_) => true,
@@ -1762,6 +1775,16 @@ fn command_to_telemetry_event(command: &CliCommand) -> CliTelemetryEvent {
         CliCommand::Federate(federate_cmd) => match federate_cmd {
             FederateCommand::IssueToken(_) => CliTelemetryEvent::FederateIssueToken,
             FederateCommand::IssueGcpToken(_) => CliTelemetryEvent::FederateIssueGcpToken,
+        },
+        CliCommand::Factory(factory_cmd) => match factory_cmd {
+            FactoryCommand::Link(args) if args.unlink => CliTelemetryEvent::FactoryUnlink,
+            FactoryCommand::Link(_) => CliTelemetryEvent::FactoryLink,
+            FactoryCommand::Unlink(_) => CliTelemetryEvent::FactoryUnlink,
+            FactoryCommand::Status(_) => CliTelemetryEvent::FactoryStatus,
+            FactoryCommand::Plan(_) => CliTelemetryEvent::FactoryPlan,
+            FactoryCommand::Apply(_) => CliTelemetryEvent::FactoryApply,
+            FactoryCommand::Init(_) => CliTelemetryEvent::FactoryInit,
+            FactoryCommand::Export(_) => CliTelemetryEvent::FactoryExport,
         },
         CliCommand::HarnessSupport(args) => match &args.command {
             HarnessSupportCommand::Ping => CliTelemetryEvent::HarnessSupportPing,

--- a/app/src/ai/agent_sdk/telemetry.rs
+++ b/app/src/ai/agent_sdk/telemetry.rs
@@ -139,6 +139,20 @@ pub(super) enum CliTelemetryEvent {
     FederateIssueToken,
     /// Executing `warp federate issue-gcp-token`
     FederateIssueGcpToken,
+    /// Executing `warp factory link`
+    FactoryLink,
+    /// Executing `warp factory unlink`
+    FactoryUnlink,
+    /// Executing `warp factory status`
+    FactoryStatus,
+    /// Executing `warp factory plan`
+    FactoryPlan,
+    /// Executing `warp factory apply`
+    FactoryApply,
+    /// Executing `warp factory init`
+    FactoryInit,
+    /// Executing `warp factory export`
+    FactoryExport,
     /// Executing `warp harness-support ping`
     HarnessSupportPing,
     /// Executing `warp harness-support report-artifact`
@@ -234,6 +248,13 @@ impl TelemetryEvent for CliTelemetryEvent {
             CliTelemetryEvent::SecretList => None,
             CliTelemetryEvent::FederateIssueToken => None,
             CliTelemetryEvent::FederateIssueGcpToken => None,
+            CliTelemetryEvent::FactoryLink => None,
+            CliTelemetryEvent::FactoryUnlink => None,
+            CliTelemetryEvent::FactoryStatus => None,
+            CliTelemetryEvent::FactoryPlan => None,
+            CliTelemetryEvent::FactoryApply => None,
+            CliTelemetryEvent::FactoryInit => None,
+            CliTelemetryEvent::FactoryExport => None,
             CliTelemetryEvent::HarnessSupportPing => None,
             CliTelemetryEvent::HarnessSupportReportArtifact { artifact_type } => {
                 Some(json!({ "artifact_type": artifact_type }))
@@ -352,6 +373,13 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
             CliTelemetryEventDiscriminants::FederateIssueGcpToken => {
                 "CLI.Execute.Federate.IssueGcpToken"
             }
+            CliTelemetryEventDiscriminants::FactoryLink => "CLI.Execute.Factory.Link",
+            CliTelemetryEventDiscriminants::FactoryUnlink => "CLI.Execute.Factory.Unlink",
+            CliTelemetryEventDiscriminants::FactoryStatus => "CLI.Execute.Factory.Status",
+            CliTelemetryEventDiscriminants::FactoryPlan => "CLI.Execute.Factory.Plan",
+            CliTelemetryEventDiscriminants::FactoryApply => "CLI.Execute.Factory.Apply",
+            CliTelemetryEventDiscriminants::FactoryInit => "CLI.Execute.Factory.Init",
+            CliTelemetryEventDiscriminants::FactoryExport => "CLI.Execute.Factory.Export",
             CliTelemetryEventDiscriminants::HarnessSupportPing => "CLI.Execute.HarnessSupport.Ping",
             CliTelemetryEventDiscriminants::HarnessSupportReportArtifact => {
                 "CLI.Execute.HarnessSupport.ReportArtifact"
@@ -509,6 +537,27 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
             }
             CliTelemetryEventDiscriminants::FederateIssueGcpToken => {
                 "Issued a GCP federated identity token from the Warp CLI"
+            }
+            CliTelemetryEventDiscriminants::FactoryLink => {
+                "Linked a factory to a config source from the Warp CLI"
+            }
+            CliTelemetryEventDiscriminants::FactoryUnlink => {
+                "Unlinked a factory from its config source from the Warp CLI"
+            }
+            CliTelemetryEventDiscriminants::FactoryStatus => {
+                "Got factory sync status from the Warp CLI"
+            }
+            CliTelemetryEventDiscriminants::FactoryPlan => {
+                "Computed a factory sync plan from the Warp CLI"
+            }
+            CliTelemetryEventDiscriminants::FactoryApply => {
+                "Triggered a factory sync from the Warp CLI"
+            }
+            CliTelemetryEventDiscriminants::FactoryInit => {
+                "Scaffolded a factory config directory from the Warp CLI"
+            }
+            CliTelemetryEventDiscriminants::FactoryExport => {
+                "Exported a factory's config files from the Warp CLI"
             }
             CliTelemetryEventDiscriminants::HarnessSupportPing => {
                 "Pinged harness-support from the Warp CLI"

--- a/app/src/server/server_api.rs
+++ b/app/src/server/server_api.rs
@@ -3,6 +3,7 @@ pub mod auth;
 pub mod block;
 #[cfg(not(target_family = "wasm"))]
 pub(crate) mod download;
+pub mod factory;
 pub mod harness_support;
 pub mod integrations;
 pub mod managed_mcp;
@@ -1306,6 +1307,10 @@ impl ServerApiProvider {
     }
 
     pub fn get_ai_client(&self) -> Arc<dyn AIClient> {
+        self.server_api.clone()
+    }
+
+    pub fn get_factory_client(&self) -> Arc<dyn factory::FactoryClient> {
         self.server_api.clone()
     }
 

--- a/app/src/server/server_api/factory.rs
+++ b/app/src/server/server_api/factory.rs
@@ -1,0 +1,287 @@
+//! Client for the factory public API endpoints.
+
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+#[cfg(test)]
+use mockall::automock;
+
+use super::ServerApi;
+
+/// The only code forge supported for factory config sources.
+pub const GITHUB_CODE_FORGE: &str = "GITHUB";
+
+/// A repository scoped to a factory.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct FactoryRepository {
+    pub owner: String,
+    pub repo: String,
+}
+
+/// The repository directory that drives reconciliation for a file-managed factory.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct FactorySource {
+    pub code_forge: String,
+    pub repository: FactoryRepository,
+    pub r#ref: String,
+    pub path: String,
+}
+
+/// JSON payload sent to `POST /factory/{uid}/source`.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+pub struct FactorySourceRequest {
+    pub code_forge: String,
+    pub repository: FactoryRepository,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+/// The subset of the public factory representation rendered by the CLI.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct FactoryResponse {
+    pub uid: String,
+    pub name: String,
+    #[serde(default)]
+    pub management_mode: Option<String>,
+    #[serde(default)]
+    pub source: Option<FactorySource>,
+}
+
+/// Response body of `GET /factory/{uid}/sync-status`.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct FactorySyncStatusResponse {
+    pub management_mode: String,
+    #[serde(default)]
+    pub source: Option<FactorySource>,
+    #[serde(default)]
+    pub last_synced_commit: Option<String>,
+    #[serde(default)]
+    pub latest_sync: Option<FactorySyncSummary>,
+}
+
+/// Lifecycle status of a sync attempt.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FactorySyncState {
+    Pending,
+    Running,
+    Success,
+    Partial,
+    Failed,
+    Noop,
+}
+
+impl FactorySyncState {
+    pub fn is_terminal(&self) -> bool {
+        match self {
+            FactorySyncState::Pending | FactorySyncState::Running => false,
+            FactorySyncState::Success
+            | FactorySyncState::Partial
+            | FactorySyncState::Failed
+            | FactorySyncState::Noop => true,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FactorySyncState::Pending => "pending",
+            FactorySyncState::Running => "running",
+            FactorySyncState::Success => "success",
+            FactorySyncState::Partial => "partial",
+            FactorySyncState::Failed => "failed",
+            FactorySyncState::Noop => "noop",
+        }
+    }
+}
+
+/// One sync attempt from a file-managed factory's sync ledger.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct FactorySyncSummary {
+    pub commit_sha: String,
+    pub status: FactorySyncState,
+    pub started_at: DateTime<Utc>,
+    #[serde(default)]
+    pub finished_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub resource_errors: Vec<FactoryResourceError>,
+    #[serde(default)]
+    pub degraded_reasons: Vec<String>,
+}
+
+/// JSON payload sent to `POST /factory/{uid}/sync`.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+pub struct FactorySyncRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dry_run: Option<bool>,
+}
+
+/// 202 response body of a non-dry-run `POST /factory/{uid}/sync`.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct FactorySyncAccepted {
+    pub commit_sha: String,
+}
+
+/// 200 response body of a dry-run `POST /factory/{uid}/sync`.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct FactorySyncDryRunResult {
+    pub commit_sha: String,
+    #[serde(default)]
+    pub plan: Option<FactorySyncPlan>,
+    #[serde(default)]
+    pub resource_errors: Vec<FactoryResourceError>,
+}
+
+/// The diff a sync would apply, grouped by change type.
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct FactorySyncPlan {
+    pub creates: Vec<FactoryPlannedChange>,
+    pub updates: Vec<FactoryPlannedChange>,
+    pub deletes: Vec<FactoryPlannedChange>,
+    pub no_ops: i64,
+}
+
+/// One resource a sync would create, update, or delete.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct FactoryPlannedChange {
+    pub path: String,
+    pub kind: String,
+    pub reason: String,
+}
+
+/// A per-resource failure captured by a factory sync.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct FactoryResourceError {
+    pub resource_path: String,
+    #[serde(default)]
+    pub line: Option<i64>,
+    pub message: String,
+}
+
+/// Response body of `GET /factory/{uid}/export`: rendered config files keyed
+/// by path relative to the factory source root.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct FactoryExportResponse {
+    pub files: BTreeMap<String, String>,
+}
+
+pub(crate) fn build_factory_source_url(factory_uid: &str) -> String {
+    format!("factory/{}/source", urlencoding::encode(factory_uid))
+}
+
+pub(crate) fn build_factory_sync_status_url(factory_uid: &str) -> String {
+    format!("factory/{}/sync-status", urlencoding::encode(factory_uid))
+}
+
+pub(crate) fn build_factory_sync_url(factory_uid: &str) -> String {
+    format!("factory/{}/sync", urlencoding::encode(factory_uid))
+}
+
+pub(crate) fn build_factory_export_url(factory_uid: &str) -> String {
+    format!("factory/{}/export", urlencoding::encode(factory_uid))
+}
+
+/// Trait for the factory public API endpoints used by the CLI.
+#[cfg_attr(test, automock)]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+pub trait FactoryClient: 'static + Send + Sync {
+    /// Register a repository directory as the factory's config source.
+    async fn link_factory_source(
+        &self,
+        factory_uid: &str,
+        request: FactorySourceRequest,
+    ) -> Result<FactoryResponse>;
+
+    /// Clear the factory's config source, returning it to live-managed.
+    async fn unlink_factory_source(&self, factory_uid: &str) -> Result<()>;
+
+    /// Report the factory's management mode, config source, and sync ledger state.
+    async fn get_factory_sync_status(
+        &self,
+        factory_uid: &str,
+    ) -> Result<FactorySyncStatusResponse>;
+
+    /// Compute the plan a sync would apply without applying or recording anything.
+    async fn sync_factory_dry_run(
+        &self,
+        factory_uid: &str,
+        sha: Option<String>,
+    ) -> Result<FactorySyncDryRunResult>;
+
+    /// Start an asynchronous sync of the factory from its config source.
+    async fn sync_factory(
+        &self,
+        factory_uid: &str,
+        sha: Option<String>,
+    ) -> Result<FactorySyncAccepted>;
+
+    /// Render the factory's current projection as factory configuration files.
+    async fn export_factory(&self, factory_uid: &str) -> Result<FactoryExportResponse>;
+}
+
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+impl FactoryClient for ServerApi {
+    async fn link_factory_source(
+        &self,
+        factory_uid: &str,
+        request: FactorySourceRequest,
+    ) -> Result<FactoryResponse> {
+        self.post_public_api(&build_factory_source_url(factory_uid), &request)
+            .await
+    }
+
+    async fn unlink_factory_source(&self, factory_uid: &str) -> Result<()> {
+        self.delete_public_api_unit(&build_factory_source_url(factory_uid))
+            .await
+    }
+
+    async fn get_factory_sync_status(
+        &self,
+        factory_uid: &str,
+    ) -> Result<FactorySyncStatusResponse> {
+        self.get_public_api(&build_factory_sync_status_url(factory_uid))
+            .await
+    }
+
+    async fn sync_factory_dry_run(
+        &self,
+        factory_uid: &str,
+        sha: Option<String>,
+    ) -> Result<FactorySyncDryRunResult> {
+        let request = FactorySyncRequest {
+            sha,
+            dry_run: Some(true),
+        };
+        self.post_public_api(&build_factory_sync_url(factory_uid), &request)
+            .await
+    }
+
+    async fn sync_factory(
+        &self,
+        factory_uid: &str,
+        sha: Option<String>,
+    ) -> Result<FactorySyncAccepted> {
+        let request = FactorySyncRequest {
+            sha,
+            dry_run: None,
+        };
+        self.post_public_api(&build_factory_sync_url(factory_uid), &request)
+            .await
+    }
+
+    async fn export_factory(&self, factory_uid: &str) -> Result<FactoryExportResponse> {
+        self.get_public_api(&build_factory_export_url(factory_uid))
+            .await
+    }
+}
+
+#[cfg(test)]
+#[path = "factory_tests.rs"]
+mod tests;

--- a/app/src/server/server_api/factory_tests.rs
+++ b/app/src/server/server_api/factory_tests.rs
@@ -1,0 +1,355 @@
+use chrono::{TimeZone as _, Utc};
+use futures::executor::block_on;
+use serde_json::json;
+use warp_core::channel::ChannelState;
+
+use super::*;
+
+fn factory_response_body(uid: &str) -> String {
+    json!({
+        "uid": uid,
+        "team_uid": "team-1",
+        "name": "Prod Factory",
+        "description": null,
+        "code_forge": "GITHUB",
+        "repositories": [{ "owner": "warpdotdev", "repo": "factory-config" }],
+        "default_environment": "env-1",
+        "default_model": "model-1",
+        "management_mode": "file_managed",
+        "source": {
+            "code_forge": "GITHUB",
+            "repository": { "owner": "warpdotdev", "repo": "factory-config" },
+            "ref": "main",
+            "path": "factories/prod",
+        },
+        "created_at": "2026-07-01T00:00:00Z",
+        "updated_at": "2026-07-01T00:00:00Z",
+    })
+    .to_string()
+}
+
+#[test]
+fn build_factory_urls_encode_the_uid() {
+    assert_eq!(build_factory_source_url("fac-1"), "factory/fac-1/source");
+    assert_eq!(
+        build_factory_sync_status_url("fac-1"),
+        "factory/fac-1/sync-status"
+    );
+    assert_eq!(build_factory_sync_url("fac-1"), "factory/fac-1/sync");
+    assert_eq!(build_factory_export_url("fac-1"), "factory/fac-1/export");
+    assert_eq!(build_factory_source_url("fac/1"), "factory/fac%2F1/source");
+}
+
+#[test]
+fn link_factory_source_posts_full_source_request() {
+    // The mock only responds when method, path, and body all match, so a
+    // successful deserialization asserts the request shape end to end.
+    let _request = {
+        let mut server = ChannelState::mock_server();
+        server
+            .mock("POST", "/api/v1/factory/fac-link-full/source")
+            .match_body(mockito::Matcher::Json(json!({
+                "code_forge": "GITHUB",
+                "repository": { "owner": "warpdotdev", "repo": "factory-config" },
+                "ref": "main",
+                "path": "factories/prod",
+            })))
+            .with_status(200)
+            .with_body(factory_response_body("fac-link-full"))
+            .create()
+    };
+    let api = ServerApi::new_for_test();
+
+    let request = FactorySourceRequest {
+        code_forge: GITHUB_CODE_FORGE.to_string(),
+        repository: FactoryRepository {
+            owner: "warpdotdev".to_string(),
+            repo: "factory-config".to_string(),
+        },
+        r#ref: Some("main".to_string()),
+        path: Some("factories/prod".to_string()),
+    };
+    let factory = block_on(api.link_factory_source("fac-link-full", request)).unwrap();
+
+    assert_eq!(factory.uid, "fac-link-full");
+    assert_eq!(factory.management_mode.as_deref(), Some("file_managed"));
+    let source = factory.source.expect("source is present");
+    assert_eq!(source.r#ref, "main");
+    assert_eq!(source.path, "factories/prod");
+}
+
+#[test]
+fn link_factory_source_omits_default_ref_and_path() {
+    let _request = {
+        let mut server = ChannelState::mock_server();
+        server
+            .mock("POST", "/api/v1/factory/fac-link-defaults/source")
+            .match_body(mockito::Matcher::Json(json!({
+                "code_forge": "GITHUB",
+                "repository": { "owner": "warpdotdev", "repo": "factory-config" },
+            })))
+            .with_status(200)
+            .with_body(factory_response_body("fac-link-defaults"))
+            .create()
+    };
+    let api = ServerApi::new_for_test();
+
+    let request = FactorySourceRequest {
+        code_forge: GITHUB_CODE_FORGE.to_string(),
+        repository: FactoryRepository {
+            owner: "warpdotdev".to_string(),
+            repo: "factory-config".to_string(),
+        },
+        r#ref: None,
+        path: None,
+    };
+    let factory = block_on(api.link_factory_source("fac-link-defaults", request)).unwrap();
+
+    assert_eq!(factory.uid, "fac-link-defaults");
+}
+
+#[test]
+fn unlink_factory_source_sends_delete() {
+    let _request = {
+        let mut server = ChannelState::mock_server();
+        server
+            .mock("DELETE", "/api/v1/factory/fac-unlink/source")
+            .with_status(200)
+            .with_body(factory_response_body("fac-unlink"))
+            .create()
+    };
+    let api = ServerApi::new_for_test();
+
+    block_on(api.unlink_factory_source("fac-unlink")).unwrap();
+}
+
+#[test]
+fn get_factory_sync_status_deserializes_ledger_state() {
+    let _request = {
+        let mut server = ChannelState::mock_server();
+        server
+            .mock("GET", "/api/v1/factory/fac-status/sync-status")
+            .with_status(200)
+            .with_body(
+                json!({
+                    "management_mode": "file_managed",
+                    "source": {
+                        "code_forge": "GITHUB",
+                        "repository": { "owner": "warpdotdev", "repo": "factory-config" },
+                        "ref": "main",
+                        "path": "",
+                    },
+                    "last_synced_commit": "aaa111",
+                    "latest_sync": {
+                        "commit_sha": "bbb222",
+                        "status": "failed",
+                        "started_at": "2026-07-08T05:00:00Z",
+                        "finished_at": "2026-07-08T05:00:10Z",
+                        "resource_errors": [
+                            { "resource_path": "environments/prod.yaml", "line": 12, "message": "invalid enum value" },
+                        ],
+                        "degraded_reasons": [],
+                    },
+                })
+                .to_string(),
+            )
+            .create()
+    };
+    let api = ServerApi::new_for_test();
+
+    let status = block_on(api.get_factory_sync_status("fac-status")).unwrap();
+
+    assert_eq!(status.management_mode, "file_managed");
+    assert_eq!(status.last_synced_commit.as_deref(), Some("aaa111"));
+    let latest = status.latest_sync.expect("latest sync is present");
+    assert_eq!(latest.commit_sha, "bbb222");
+    assert_eq!(latest.status, FactorySyncState::Failed);
+    assert!(latest.status.is_terminal());
+    assert_eq!(
+        latest.started_at,
+        Utc.with_ymd_and_hms(2026, 7, 8, 5, 0, 0).unwrap()
+    );
+    assert_eq!(
+        latest.resource_errors,
+        vec![FactoryResourceError {
+            resource_path: "environments/prod.yaml".to_string(),
+            line: Some(12),
+            message: "invalid enum value".to_string(),
+        }]
+    );
+}
+
+#[test]
+fn get_factory_sync_status_tolerates_never_synced_factories() {
+    let _request = {
+        let mut server = ChannelState::mock_server();
+        server
+            .mock("GET", "/api/v1/factory/fac-never-synced/sync-status")
+            .with_status(200)
+            .with_body(json!({ "management_mode": "live_managed" }).to_string())
+            .create()
+    };
+    let api = ServerApi::new_for_test();
+
+    let status = block_on(api.get_factory_sync_status("fac-never-synced")).unwrap();
+
+    assert_eq!(status.management_mode, "live_managed");
+    assert!(status.source.is_none());
+    assert!(status.last_synced_commit.is_none());
+    assert!(status.latest_sync.is_none());
+}
+
+#[test]
+fn sync_factory_dry_run_posts_dry_run_body_and_parses_plan() {
+    let _request = {
+        let mut server = ChannelState::mock_server();
+        server
+            .mock("POST", "/api/v1/factory/fac-plan/sync")
+            .match_body(mockito::Matcher::Json(json!({ "dry_run": true })))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "dry_run": true,
+                    "commit_sha": "ccc333",
+                    "plan": {
+                        "creates": [
+                            { "path": "agents/reviewer.md", "kind": "Agent", "reason": "new resource" },
+                        ],
+                        "updates": [],
+                        "deletes": [],
+                        "no_ops": 3,
+                    },
+                    "resource_errors": [],
+                })
+                .to_string(),
+            )
+            .create()
+    };
+    let api = ServerApi::new_for_test();
+
+    let result = block_on(api.sync_factory_dry_run("fac-plan", None)).unwrap();
+
+    assert_eq!(result.commit_sha, "ccc333");
+    let plan = result.plan.expect("plan is present");
+    assert_eq!(plan.no_ops, 3);
+    assert_eq!(plan.creates.len(), 1);
+    assert_eq!(plan.creates[0].path, "agents/reviewer.md");
+    assert_eq!(plan.creates[0].kind, "Agent");
+}
+
+#[test]
+fn sync_factory_dry_run_includes_requested_sha() {
+    let _request = {
+        let mut server = ChannelState::mock_server();
+        server
+            .mock("POST", "/api/v1/factory/fac-plan-sha/sync")
+            .match_body(mockito::Matcher::Json(json!({
+                "sha": "ddd444",
+                "dry_run": true,
+            })))
+            .with_status(200)
+            .with_body(
+                json!({
+                    "dry_run": true,
+                    "commit_sha": "ddd444",
+                    "plan": { "creates": [], "updates": [], "deletes": [], "no_ops": 0 },
+                    "resource_errors": [],
+                })
+                .to_string(),
+            )
+            .create()
+    };
+    let api = ServerApi::new_for_test();
+
+    let result =
+        block_on(api.sync_factory_dry_run("fac-plan-sha", Some("ddd444".to_string()))).unwrap();
+
+    assert_eq!(result.commit_sha, "ddd444");
+}
+
+#[test]
+fn sync_factory_posts_sha_and_parses_202_accepted_body() {
+    let _request = {
+        let mut server = ChannelState::mock_server();
+        server
+            .mock("POST", "/api/v1/factory/fac-apply/sync")
+            .match_body(mockito::Matcher::Json(json!({ "sha": "eee555" })))
+            .with_status(202)
+            .with_body(json!({ "commit_sha": "eee555" }).to_string())
+            .create()
+    };
+    let api = ServerApi::new_for_test();
+
+    let accepted = block_on(api.sync_factory("fac-apply", Some("eee555".to_string()))).unwrap();
+
+    assert_eq!(accepted.commit_sha, "eee555");
+}
+
+#[test]
+fn sync_factory_without_sha_sends_empty_body() {
+    let _request = {
+        let mut server = ChannelState::mock_server();
+        server
+            .mock("POST", "/api/v1/factory/fac-apply-head/sync")
+            .match_body(mockito::Matcher::Json(json!({})))
+            .with_status(202)
+            .with_body(json!({ "commit_sha": "fff666" }).to_string())
+            .create()
+    };
+    let api = ServerApi::new_for_test();
+
+    let accepted = block_on(api.sync_factory("fac-apply-head", None)).unwrap();
+
+    assert_eq!(accepted.commit_sha, "fff666");
+}
+
+#[test]
+fn export_factory_deserializes_file_map() {
+    let _request = {
+        let mut server = ChannelState::mock_server();
+        server
+            .mock("GET", "/api/v1/factory/fac-export/export")
+            .with_status(200)
+            .with_body(
+                json!({
+                    "files": {
+                        "factory.yaml": "kind: Factory\nname: acme-factory\n",
+                        "agents/reviewer/agent.md": "---\nkind: Agent\n---\nbody\n",
+                    },
+                })
+                .to_string(),
+            )
+            .create()
+    };
+    let api = ServerApi::new_for_test();
+
+    let export = block_on(api.export_factory("fac-export")).unwrap();
+
+    assert_eq!(export.files.len(), 2);
+    assert_eq!(
+        export.files["factory.yaml"],
+        "kind: Factory\nname: acme-factory\n"
+    );
+    assert_eq!(
+        export.files["agents/reviewer/agent.md"],
+        "---\nkind: Agent\n---\nbody\n"
+    );
+}
+
+#[test]
+fn sync_request_serialization_omits_unset_fields() {
+    let empty = FactorySyncRequest {
+        sha: None,
+        dry_run: None,
+    };
+    assert_eq!(serde_json::to_value(&empty).unwrap(), json!({}));
+
+    let dry_run = FactorySyncRequest {
+        sha: Some("abc".to_string()),
+        dry_run: Some(true),
+    };
+    assert_eq!(
+        serde_json::to_value(&dry_run).unwrap(),
+        json!({ "sha": "abc", "dry_run": true })
+    );
+}

--- a/crates/warp_cli/Cargo.toml
+++ b/crates/warp_cli/Cargo.toml
@@ -39,3 +39,4 @@ api_key_authentication = []
 
 [dev-dependencies]
 serial_test = "0.8.0"
+tempfile.workspace = true

--- a/crates/warp_cli/src/factory.rs
+++ b/crates/warp_cli/src/factory.rs
@@ -1,0 +1,358 @@
+use std::collections::BTreeMap;
+use std::path::{Component, Path, PathBuf};
+use std::str::FromStr;
+use std::{fmt, fs, io};
+
+use anyhow::bail;
+use clap::{Args, Subcommand};
+
+/// Factory-related subcommands.
+#[derive(Debug, Clone, Subcommand)]
+pub enum FactoryCommand {
+    /// Link a factory to a config source repository, making it file-managed.
+    ///
+    /// Registers a repository directory as the factory's config source. Re-linking
+    /// replaces the existing source.
+    Link(LinkFactoryArgs),
+    /// Unlink a factory from its config source, returning it to live-managed.
+    Unlink(UnlinkFactoryArgs),
+    /// Show a factory's management mode, config source, and latest sync state.
+    Status(StatusFactoryArgs),
+    /// Show the changes a sync would apply, without applying anything.
+    Plan(PlanFactoryArgs),
+    /// Sync a factory from its config source.
+    Apply(ApplyFactoryArgs),
+    /// Write a scaffold factory config directory, with no server interaction.
+    Init(InitFactoryArgs),
+    /// Download a factory's rendered config files into a directory.
+    Export(ExportFactoryArgs),
+}
+
+impl FactoryCommand {
+    pub(crate) fn as_str_for_tracing(&self) -> &'static str {
+        match self {
+            FactoryCommand::Link(args) if args.unlink => "factory unlink",
+            FactoryCommand::Link(_) => "factory link",
+            FactoryCommand::Unlink(_) => "factory unlink",
+            FactoryCommand::Status(_) => "factory status",
+            FactoryCommand::Plan(_) => "factory plan",
+            FactoryCommand::Apply(_) => "factory apply",
+            FactoryCommand::Init(_) => "factory init",
+            FactoryCommand::Export(_) => "factory export",
+        }
+    }
+}
+
+/// A repository reference in `owner/name` form.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoArg {
+    pub owner: String,
+    pub repo: String,
+}
+
+impl FromStr for RepoArg {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let Some((owner, repo)) = value.split_once('/') else {
+            return Err(format!("expected `owner/name`, got `{value}`"));
+        };
+        if owner.is_empty() || repo.is_empty() || repo.contains('/') {
+            return Err(format!("expected `owner/name`, got `{value}`"));
+        }
+        Ok(RepoArg {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+        })
+    }
+}
+
+impl fmt::Display for RepoArg {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.owner, self.repo)
+    }
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct LinkFactoryArgs {
+    /// UID of the factory to link.
+    pub factory_uid: String,
+
+    /// Repository containing the factory config, in `owner/name` form.
+    #[arg(
+        long = "repo",
+        value_name = "OWNER/NAME",
+        required_unless_present = "unlink"
+    )]
+    pub repo: Option<RepoArg>,
+
+    /// Branch whose pushes drive reconciliation. Defaults to the repository's default branch.
+    #[arg(long = "branch", value_name = "BRANCH", requires = "repo")]
+    pub branch: Option<String>,
+
+    /// Directory within the repository containing the factory config. Defaults to the
+    /// repository root.
+    #[arg(long = "path", value_name = "DIR", requires = "repo")]
+    pub path: Option<String>,
+
+    /// Unlink the factory from its config source instead of linking it.
+    #[arg(long = "unlink", conflicts_with_all = ["repo", "branch", "path"])]
+    pub unlink: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct UnlinkFactoryArgs {
+    /// UID of the factory to unlink.
+    pub factory_uid: String,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct StatusFactoryArgs {
+    /// UID of the factory to inspect.
+    pub factory_uid: String,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct PlanFactoryArgs {
+    /// UID of the factory to plan against.
+    pub factory_uid: String,
+
+    /// Commit to plan against. Must be an ancestor of (or equal to) the head of the
+    /// source's production branch. Defaults to the branch head.
+    #[arg(long = "sha", value_name = "COMMIT")]
+    pub sha: Option<String>,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct ApplyFactoryArgs {
+    /// UID of the factory to sync.
+    pub factory_uid: String,
+
+    /// Commit to sync. Must be an ancestor of (or equal to) the head of the source's
+    /// production branch. Defaults to the branch head.
+    #[arg(long = "sha", value_name = "COMMIT")]
+    pub sha: Option<String>,
+
+    /// Wait for the sync to finish, exiting non-zero if it fails.
+    #[arg(long = "wait")]
+    pub wait: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct InitFactoryArgs {
+    /// Directory to write the scaffold into, created if missing. Defaults to the
+    /// current directory. The scaffolded factory name is the directory's name.
+    #[arg(value_name = "DIR")]
+    pub dir: Option<PathBuf>,
+
+    /// Write the scaffold even if the directory is not empty, overwriting any
+    /// existing scaffold files. Other files are left alone.
+    #[arg(long = "force")]
+    pub force: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct ExportFactoryArgs {
+    /// UID of the factory to export.
+    pub factory_uid: String,
+
+    /// Directory to write the exported files into. Defaults to `./<factory-name>`.
+    #[arg(long = "out", value_name = "DIR")]
+    pub out: Option<PathBuf>,
+
+    /// Write the export even if the directory is not empty, overwriting any
+    /// existing files with the same paths. Other files are left alone.
+    #[arg(long = "force")]
+    pub force: bool,
+}
+
+/// Directories created empty by `oz factory init`, ready to hold resources of
+/// the corresponding kinds.
+pub const SCAFFOLD_DIRS: [&str; 4] = ["automations", "environments", "runners", "skills"];
+
+/// Path of the example agent written by `oz factory init`.
+pub const SCAFFOLD_AGENT_PATH: &str = "agents/example-agent/agent.md";
+
+const SCAFFOLD_AGENT_TEMPLATE: &str = r#"---
+kind: Agent
+schema_version: 1
+description: An example agent. Replace this with your own.
+# harness: claude_code
+# model: claude-sonnet
+# environment: staging
+# secrets:
+#   - GITHUB_TOKEN
+# skills:
+#   - name: my-skill
+#     path: skills/my-skill
+---
+Describe the agent here. The markdown body becomes the agent's instructions.
+"#;
+
+const SCAFFOLD_SECRETS: &str = r#"kind: SecretManifest
+schema_version: 1
+# Managed secret names this factory depends on. Never secret values.
+secrets: []
+# secrets:
+#   - name: GITHUB_TOKEN
+#     description: Token for GitHub API access
+"#;
+
+fn scaffold_factory_yaml(name: &str) -> String {
+    let name = yaml_quote(name);
+    format!(
+        r#"kind: Factory
+schema_version: 1
+name: {name}
+# description: Describe this factory
+# repositories:
+#   - your-org/your-repo
+# default_environment: staging
+# default_model: claude-sonnet
+# agent_defaults:
+#   harness: claude_code
+#   model: claude-sonnet
+# agent_attribution_strategy: agent_identity
+"#
+    )
+}
+
+fn scaffold_readme(name: &str) -> String {
+    format!(
+        r#"# {name}
+
+A Warp factory configured as code.
+
+- `factory.yaml` — factory-wide settings
+- `agents/<name>/agent.md` — agent definitions (YAML frontmatter + markdown instructions)
+- `automations/<name>.md` — automation definitions (YAML frontmatter + markdown prompt)
+- `environments/<name>.yaml` — environment definitions
+- `runners/<name>.yaml` — runner definitions
+- `skills/` — skills shared by this factory's agents
+- `secrets.yaml` — managed secret names this factory depends on, never secret values
+
+Link this directory to a factory so pushes reconcile it:
+
+    oz factory link <factory-uid> --repo <owner>/<repo> [--branch <branch>] [--path <dir>]
+
+See https://docs.warp.dev for documentation.
+"#
+    )
+}
+
+fn yaml_quote(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+/// The scaffold files written by `oz factory init`, keyed by path relative to
+/// the factory root.
+pub fn scaffold_files(factory_name: &str) -> BTreeMap<&'static str, String> {
+    BTreeMap::from([
+        ("README.md", scaffold_readme(factory_name)),
+        (SCAFFOLD_AGENT_PATH, SCAFFOLD_AGENT_TEMPLATE.to_string()),
+        ("factory.yaml", scaffold_factory_yaml(factory_name)),
+        ("secrets.yaml", SCAFFOLD_SECRETS.to_string()),
+    ])
+}
+
+/// Write the factory scaffold into `dir`, creating the directory if needed.
+///
+/// Refuses to write into a non-empty directory unless `force` is set. Returns
+/// the paths of the written files, relative to `dir`.
+pub fn init_factory_dir(dir: &Path, force: bool) -> anyhow::Result<Vec<String>> {
+    if !force && dir_is_non_empty(dir)? {
+        bail!(
+            "{} is not empty; pass --force to write the scaffold anyway",
+            dir.display()
+        );
+    }
+    let files = scaffold_files(&factory_name_for_dir(dir));
+    for subdir in SCAFFOLD_DIRS {
+        fs::create_dir_all(dir.join(subdir))?;
+    }
+    for (path, content) in &files {
+        let target = dir.join(path);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&target, content)?;
+    }
+    Ok(files.keys().map(|path| path.to_string()).collect())
+}
+
+/// The factory name to scaffold for `dir`: its directory name, resolved
+/// against the working directory for relative paths like `.`.
+fn factory_name_for_dir(dir: &Path) -> String {
+    let absolute = if dir.is_absolute() {
+        dir.to_path_buf()
+    } else {
+        match std::env::current_dir() {
+            Ok(cwd) => cwd.join(dir),
+            Err(_) => dir.to_path_buf(),
+        }
+    };
+    absolute
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(name) => Some(name.to_string_lossy().into_owned()),
+            _ => None,
+        })
+        .next_back()
+        .unwrap_or_else(|| "my-factory".to_string())
+}
+
+/// Write server-exported factory files under `dir`, creating it if needed.
+///
+/// Rejects the whole export, before writing anything, if any path is absolute
+/// or would escape `dir` (e.g. contains `..`). Refuses to write into a
+/// non-empty directory unless `force` is set. Returns the written paths,
+/// relative to `dir`.
+pub fn write_export_files(
+    dir: &Path,
+    files: &BTreeMap<String, String>,
+    force: bool,
+) -> anyhow::Result<Vec<String>> {
+    for path in files.keys() {
+        validate_export_path(path)?;
+    }
+    if !force && dir_is_non_empty(dir)? {
+        bail!(
+            "{} is not empty; pass --force to write the export anyway",
+            dir.display()
+        );
+    }
+    fs::create_dir_all(dir)?;
+    let mut written = Vec::with_capacity(files.len());
+    for (path, content) in files {
+        let target = dir.join(path);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&target, content)?;
+        written.push(path.clone());
+    }
+    Ok(written)
+}
+
+fn validate_export_path(path: &str) -> anyhow::Result<()> {
+    if path.is_empty()
+        || !Path::new(path)
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+    {
+        bail!("refusing to write export file with unsafe path `{path}`");
+    }
+    Ok(())
+}
+
+fn dir_is_non_empty(dir: &Path) -> anyhow::Result<bool> {
+    match fs::read_dir(dir) {
+        Ok(mut entries) => Ok(entries.next().is_some()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err.into()),
+    }
+}
+
+#[cfg(test)]
+#[path = "factory_tests.rs"]
+mod tests;

--- a/crates/warp_cli/src/factory_tests.rs
+++ b/crates/warp_cli/src/factory_tests.rs
@@ -1,0 +1,523 @@
+use clap::Parser;
+
+use super::*;
+
+fn file_listing(root: &Path) -> Vec<String> {
+    let mut files = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir).expect("read_dir succeeds") {
+            let path = entry.expect("entry is readable").path();
+            if path.is_dir() {
+                stack.push(path);
+            } else {
+                let relative = path.strip_prefix(root).expect("path is under root");
+                files.push(relative.to_string_lossy().replace('\\', "/"));
+            }
+        }
+    }
+    files.sort();
+    files
+}
+
+fn export_file_map(entries: &[(&str, &str)]) -> BTreeMap<String, String> {
+    entries
+        .iter()
+        .map(|(path, content)| (path.to_string(), content.to_string()))
+        .collect()
+}
+
+#[derive(Debug, Parser)]
+struct TestFactory {
+    #[command(subcommand)]
+    command: FactoryCommand,
+}
+
+fn parse_command(argv: &[&str]) -> FactoryCommand {
+    let mut full = vec!["test"];
+    full.extend_from_slice(argv);
+    TestFactory::try_parse_from(full)
+        .expect("parse succeeds")
+        .command
+}
+
+fn parse_command_err(argv: &[&str]) -> clap::Error {
+    let mut full = vec!["test"];
+    full.extend_from_slice(argv);
+    TestFactory::try_parse_from(full).expect_err("parse fails")
+}
+
+#[test]
+fn link_parses_repo_branch_and_path() {
+    let command = parse_command(&[
+        "link",
+        "fac-123",
+        "--repo",
+        "warpdotdev/factory-config",
+        "--branch",
+        "main",
+        "--path",
+        "factories/prod",
+    ]);
+    let FactoryCommand::Link(args) = command else {
+        panic!("Expected link command");
+    };
+
+    assert_eq!(args.factory_uid, "fac-123");
+    assert_eq!(
+        args.repo,
+        Some(RepoArg {
+            owner: "warpdotdev".to_string(),
+            repo: "factory-config".to_string(),
+        })
+    );
+    assert_eq!(args.branch.as_deref(), Some("main"));
+    assert_eq!(args.path.as_deref(), Some("factories/prod"));
+    assert!(!args.unlink);
+}
+
+#[test]
+fn link_defaults_branch_and_path_to_none() {
+    let command = parse_command(&["link", "fac-123", "--repo", "warpdotdev/factory-config"]);
+    let FactoryCommand::Link(args) = command else {
+        panic!("Expected link command");
+    };
+
+    assert!(args.branch.is_none());
+    assert!(args.path.is_none());
+}
+
+#[test]
+fn link_requires_repo() {
+    let err = parse_command_err(&["link", "fac-123"]);
+    assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+}
+
+#[test]
+fn link_rejects_repo_without_slash() {
+    let err = parse_command_err(&["link", "fac-123", "--repo", "warpdotdev"]);
+    assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
+    assert!(
+        err.to_string().contains("owner/name"),
+        "expected error to reference owner/name, got: {err}"
+    );
+}
+
+#[test]
+fn link_rejects_repo_with_empty_owner_or_name() {
+    for repo in ["/factory-config", "warpdotdev/", "/"] {
+        let err = parse_command_err(&["link", "fac-123", "--repo", repo]);
+        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
+    }
+}
+
+#[test]
+fn link_rejects_repo_with_extra_path_segments() {
+    let err = parse_command_err(&["link", "fac-123", "--repo", "warpdotdev/factory/config"]);
+    assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
+}
+
+#[test]
+fn link_accepts_unlink_flag_without_repo() {
+    let command = parse_command(&["link", "fac-123", "--unlink"]);
+    let FactoryCommand::Link(args) = command else {
+        panic!("Expected link command");
+    };
+
+    assert!(args.unlink);
+    assert!(args.repo.is_none());
+}
+
+#[test]
+fn link_rejects_unlink_with_repo() {
+    let err = parse_command_err(&[
+        "link",
+        "fac-123",
+        "--unlink",
+        "--repo",
+        "warpdotdev/factory-config",
+    ]);
+    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
+#[test]
+fn link_rejects_unlink_with_branch() {
+    let err = parse_command_err(&["link", "fac-123", "--unlink", "--branch", "main"]);
+    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
+#[test]
+fn link_rejects_branch_without_repo() {
+    let err = parse_command_err(&["link", "fac-123", "--branch", "main"]);
+    assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+}
+
+#[test]
+fn unlink_parses() {
+    let command = parse_command(&["unlink", "fac-123"]);
+    let FactoryCommand::Unlink(args) = command else {
+        panic!("Expected unlink command");
+    };
+
+    assert_eq!(args.factory_uid, "fac-123");
+}
+
+#[test]
+fn status_parses() {
+    let command = parse_command(&["status", "fac-123"]);
+    let FactoryCommand::Status(args) = command else {
+        panic!("Expected status command");
+    };
+
+    assert_eq!(args.factory_uid, "fac-123");
+}
+
+#[test]
+fn status_requires_factory_uid() {
+    let err = parse_command_err(&["status"]);
+    assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+}
+
+#[test]
+fn plan_parses_without_sha() {
+    let command = parse_command(&["plan", "fac-123"]);
+    let FactoryCommand::Plan(args) = command else {
+        panic!("Expected plan command");
+    };
+
+    assert_eq!(args.factory_uid, "fac-123");
+    assert!(args.sha.is_none());
+}
+
+#[test]
+fn plan_parses_with_sha() {
+    let command = parse_command(&["plan", "fac-123", "--sha", "abc123"]);
+    let FactoryCommand::Plan(args) = command else {
+        panic!("Expected plan command");
+    };
+
+    assert_eq!(args.sha.as_deref(), Some("abc123"));
+}
+
+#[test]
+fn apply_parses_sha_and_wait() {
+    let command = parse_command(&["apply", "fac-123", "--sha", "abc123", "--wait"]);
+    let FactoryCommand::Apply(args) = command else {
+        panic!("Expected apply command");
+    };
+
+    assert_eq!(args.factory_uid, "fac-123");
+    assert_eq!(args.sha.as_deref(), Some("abc123"));
+    assert!(args.wait);
+}
+
+#[test]
+fn apply_defaults_to_no_wait() {
+    let command = parse_command(&["apply", "fac-123"]);
+    let FactoryCommand::Apply(args) = command else {
+        panic!("Expected apply command");
+    };
+
+    assert!(args.sha.is_none());
+    assert!(!args.wait);
+}
+
+#[test]
+fn tracing_str_distinguishes_link_unlink_shorthand() {
+    assert_eq!(
+        parse_command(&["link", "fac-123", "--repo", "a/b"]).as_str_for_tracing(),
+        "factory link"
+    );
+    assert_eq!(
+        parse_command(&["link", "fac-123", "--unlink"]).as_str_for_tracing(),
+        "factory unlink"
+    );
+    assert_eq!(
+        parse_command(&["unlink", "fac-123"]).as_str_for_tracing(),
+        "factory unlink"
+    );
+}
+
+#[test]
+fn init_parses_dir_and_force() {
+    let command = parse_command(&["init", "my-factory", "--force"]);
+    let FactoryCommand::Init(args) = command else {
+        panic!("Expected init command");
+    };
+
+    assert_eq!(args.dir, Some(PathBuf::from("my-factory")));
+    assert!(args.force);
+}
+
+#[test]
+fn init_defaults_to_current_dir_without_force() {
+    let command = parse_command(&["init"]);
+    let FactoryCommand::Init(args) = command else {
+        panic!("Expected init command");
+    };
+
+    assert!(args.dir.is_none());
+    assert!(!args.force);
+}
+
+#[test]
+fn export_parses_out_and_force() {
+    let command = parse_command(&["export", "fac-123", "--out", "exported", "--force"]);
+    let FactoryCommand::Export(args) = command else {
+        panic!("Expected export command");
+    };
+
+    assert_eq!(args.factory_uid, "fac-123");
+    assert_eq!(args.out, Some(PathBuf::from("exported")));
+    assert!(args.force);
+}
+
+#[test]
+fn export_defaults_out_and_force() {
+    let command = parse_command(&["export", "fac-123"]);
+    let FactoryCommand::Export(args) = command else {
+        panic!("Expected export command");
+    };
+
+    assert!(args.out.is_none());
+    assert!(!args.force);
+}
+
+#[test]
+fn export_requires_factory_uid() {
+    let err = parse_command_err(&["export"]);
+    assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+}
+
+#[test]
+fn tracing_str_covers_init_and_export() {
+    assert_eq!(parse_command(&["init"]).as_str_for_tracing(), "factory init");
+    assert_eq!(
+        parse_command(&["export", "fac-123"]).as_str_for_tracing(),
+        "factory export"
+    );
+}
+
+#[test]
+fn help_lists_every_factory_subcommand() {
+    let err = parse_command_err(&["--help"]);
+    assert_eq!(err.kind(), clap::error::ErrorKind::DisplayHelp);
+
+    let help = err.to_string();
+    for subcommand in ["link", "unlink", "status", "plan", "apply", "init", "export"] {
+        assert!(help.contains(subcommand), "help lists {subcommand}: {help}");
+    }
+    assert!(
+        help.contains("Write a scaffold factory config directory"),
+        "help describes init: {help}"
+    );
+    assert!(
+        help.contains("Download a factory's rendered config files"),
+        "help describes export: {help}"
+    );
+}
+
+#[test]
+fn init_creates_exact_scaffold_file_set() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().join("acme-factory");
+
+    let written = init_factory_dir(&root, false).expect("init succeeds");
+
+    let expected = vec![
+        "README.md".to_string(),
+        "agents/example-agent/agent.md".to_string(),
+        "factory.yaml".to_string(),
+        "secrets.yaml".to_string(),
+    ];
+    assert_eq!(written, expected);
+    assert_eq!(file_listing(&root), expected);
+    for subdir in SCAFFOLD_DIRS {
+        let subdir_path = root.join(subdir);
+        assert!(subdir_path.is_dir(), "{subdir} exists");
+        assert_eq!(
+            fs::read_dir(&subdir_path).expect("read_dir succeeds").count(),
+            0,
+            "{subdir} is empty"
+        );
+    }
+}
+
+#[test]
+fn init_scaffold_content_matches_golden() {
+    let files = scaffold_files("acme-factory");
+
+    let golden_factory_yaml = "\
+kind: Factory
+schema_version: 1
+name: \"acme-factory\"
+# description: Describe this factory
+# repositories:
+#   - your-org/your-repo
+# default_environment: staging
+# default_model: claude-sonnet
+# agent_defaults:
+#   harness: claude_code
+#   model: claude-sonnet
+# agent_attribution_strategy: agent_identity
+";
+    assert_eq!(files["factory.yaml"], golden_factory_yaml);
+
+    let golden_agent = "\
+---
+kind: Agent
+schema_version: 1
+description: An example agent. Replace this with your own.
+# harness: claude_code
+# model: claude-sonnet
+# environment: staging
+# secrets:
+#   - GITHUB_TOKEN
+# skills:
+#   - name: my-skill
+#     path: skills/my-skill
+---
+Describe the agent here. The markdown body becomes the agent's instructions.
+";
+    assert_eq!(files[SCAFFOLD_AGENT_PATH], golden_agent);
+
+    let golden_secrets = "\
+kind: SecretManifest
+schema_version: 1
+# Managed secret names this factory depends on. Never secret values.
+secrets: []
+# secrets:
+#   - name: GITHUB_TOKEN
+#     description: Token for GitHub API access
+";
+    assert_eq!(files["secrets.yaml"], golden_secrets);
+
+    assert!(
+        files["README.md"].contains("https://docs.warp.dev"),
+        "README points at docs"
+    );
+}
+
+#[test]
+fn init_uses_directory_name_as_factory_name() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().join("acme-factory");
+
+    init_factory_dir(&root, false).expect("init succeeds");
+
+    let factory_yaml = fs::read_to_string(root.join("factory.yaml")).expect("factory.yaml exists");
+    assert!(
+        factory_yaml.contains("name: \"acme-factory\""),
+        "got: {factory_yaml}"
+    );
+}
+
+#[test]
+fn init_refuses_non_empty_dir_without_force_and_writes_nothing() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().join("existing");
+    fs::create_dir_all(&root).expect("create root");
+    fs::write(root.join("keep.txt"), "keep").expect("write keep.txt");
+
+    let err = init_factory_dir(&root, false).expect_err("init fails");
+
+    assert!(err.to_string().contains("--force"), "got: {err}");
+    assert_eq!(file_listing(&root), vec!["keep.txt".to_string()]);
+}
+
+#[test]
+fn init_force_overwrites_scaffold_files_and_keeps_others() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().join("existing");
+    fs::create_dir_all(&root).expect("create root");
+    fs::write(root.join("factory.yaml"), "stale").expect("write stale factory.yaml");
+    fs::write(root.join("keep.txt"), "keep").expect("write keep.txt");
+
+    init_factory_dir(&root, true).expect("forced init succeeds");
+
+    let factory_yaml = fs::read_to_string(root.join("factory.yaml")).expect("factory.yaml exists");
+    assert!(
+        factory_yaml.starts_with("kind: Factory"),
+        "got: {factory_yaml}"
+    );
+    assert_eq!(
+        fs::read_to_string(root.join("keep.txt")).expect("keep.txt exists"),
+        "keep"
+    );
+}
+
+#[test]
+fn export_write_preserves_subdirectories() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().join("out");
+    let files = export_file_map(&[
+        ("factory.yaml", "kind: Factory\n"),
+        ("agents/reviewer/agent.md", "agent body\n"),
+        ("environments/staging.yaml", "kind: Environment\n"),
+    ]);
+
+    let written = write_export_files(&root, &files, false).expect("export write succeeds");
+
+    let expected = vec![
+        "agents/reviewer/agent.md".to_string(),
+        "environments/staging.yaml".to_string(),
+        "factory.yaml".to_string(),
+    ];
+    assert_eq!(written, expected);
+    assert_eq!(file_listing(&root), expected);
+    assert_eq!(
+        fs::read_to_string(root.join("agents/reviewer/agent.md")).expect("agent.md exists"),
+        "agent body\n"
+    );
+}
+
+#[test]
+fn export_write_rejects_path_traversal_and_writes_nothing() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().join("out");
+
+    for path in ["../escape.txt", "/absolute.txt", "agents/../../escape.txt", ""] {
+        let files = export_file_map(&[("factory.yaml", "ok"), (path, "evil")]);
+
+        let err = write_export_files(&root, &files, false).expect_err("export write fails");
+
+        assert!(err.to_string().contains("unsafe path"), "path `{path}` got: {err}");
+        assert!(!root.exists(), "path `{path}` must not create the out dir");
+    }
+    assert!(!temp.path().join("escape.txt").exists());
+}
+
+#[test]
+fn export_write_refuses_non_empty_dir_without_force() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().join("out");
+    fs::create_dir_all(&root).expect("create root");
+    fs::write(root.join("keep.txt"), "keep").expect("write keep.txt");
+    let files = export_file_map(&[("factory.yaml", "fresh")]);
+
+    let err = write_export_files(&root, &files, false).expect_err("export write fails");
+
+    assert!(err.to_string().contains("--force"), "got: {err}");
+    assert_eq!(file_listing(&root), vec!["keep.txt".to_string()]);
+}
+
+#[test]
+fn export_write_force_overwrites_existing_files() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().join("out");
+    fs::create_dir_all(&root).expect("create root");
+    fs::write(root.join("factory.yaml"), "stale").expect("write stale factory.yaml");
+    fs::write(root.join("keep.txt"), "keep").expect("write keep.txt");
+    let files = export_file_map(&[("factory.yaml", "fresh")]);
+
+    write_export_files(&root, &files, true).expect("forced export write succeeds");
+
+    assert_eq!(
+        fs::read_to_string(root.join("factory.yaml")).expect("factory.yaml exists"),
+        "fresh"
+    );
+    assert_eq!(
+        fs::read_to_string(root.join("keep.txt")).expect("keep.txt exists"),
+        "keep"
+    );
+}

--- a/crates/warp_cli/src/lib.rs
+++ b/crates/warp_cli/src/lib.rs
@@ -25,6 +25,7 @@ pub mod completions;
 pub mod config_file;
 mod date_time;
 pub mod environment;
+pub mod factory;
 pub mod federate;
 pub mod harness_support;
 pub mod integration;
@@ -563,6 +564,10 @@ pub enum CliCommand {
     #[command(subcommand)]
     Federate(crate::federate::FederateCommand),
 
+    /// Manage factories and their config sources.
+    #[command(subcommand)]
+    Factory(crate::factory::FactoryCommand),
+
     /// Support commands for agent harnesses to integrate with Oz.
     #[command(hide = true)]
     HarnessSupport(crate::harness_support::HarnessSupportArgs),
@@ -593,6 +598,7 @@ impl CliCommand {
             CliCommand::Schedule(command) => command.as_str_for_tracing(),
             CliCommand::Secret(command) => command.as_str_for_tracing(),
             CliCommand::Federate(command) => command.as_str_for_tracing(),
+            CliCommand::Factory(command) => command.as_str_for_tracing(),
             CliCommand::HarnessSupport(args) => args.command.as_str_for_tracing(),
             CliCommand::Artifact(command) => command.as_str_for_tracing(),
             CliCommand::ApiKey(command) => command.as_str_for_tracing(),


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
