### PR TITLE
Background computer use in X11 environments

### DIFF
--- a/crates/computer_use/Cargo.toml
+++ b/crates/computer_use/Cargo.toml
@@ -54,7 +54,9 @@ tokio = { workspace = true, features = ["process", "time"] }
 url.workspace = true
 uuid.workspace = true
 warpui_core.workspace = true
-x11rb = { workspace = true, features = ["xtest"] }
+# `xinput` provides the XI2 (MPX) device hierarchy used for background per-window control,
+# `composite` provides off-screen window capture for background window screenshots.
+x11rb = { workspace = true, features = ["composite", "xinput", "xtest"] }
 zbus.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/crates/computer_use/src/bin/use_computer.rs
+++ b/crates/computer_use/src/bin/use_computer.rs
@@ -1,6 +1,7 @@
 //! A CLI tool for manually testing computer use actions.
 
 use std::path::PathBuf;
+use std::process::ExitCode;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use computer_use::{
@@ -30,16 +31,14 @@ struct Cli {
 }
 
 impl Cli {
-    /// Resolves the per-action / screenshot target from the CLI flags. A `--pid` selects a
-    /// background window target; otherwise the legacy whole-screen target is used. Callers must
-    /// validate that `--window-id` is present whenever `--pid` is given (see `main`), so the
-    /// ambiguous `0` sentinel is never sent to the actor.
+    /// Resolves the per-action / screenshot target from the CLI flags. `--pid` plus
+    /// `--window-id` selects a background window target; otherwise the legacy whole-screen
+    /// target is used. `main` rejects lone flags up front, so a partial combination can never
+    /// silently downgrade to screen targeting or produce a `0`-id window target.
     fn target(&self) -> Target {
         match (self.pid, self.window_id) {
             (Some(pid), Some(window_id)) => Target::Window { window_id, pid },
-            // `--pid` without `--window-id` is rejected up front in `main`; fall back to the
-            // screen target here so a missing id can never become a `0`-id window target.
-            (Some(_), None) | (None, _) => Target::Screen,
+            (Some(_), None) | (None, Some(_)) | (None, None) => Target::Screen,
         }
     }
 }
@@ -122,34 +121,50 @@ fn parse_region(s: &str) -> Result<(i32, i32, i32, i32), String> {
     Ok((x1, y1, x2, y2))
 }
 
+// The binary exits by returning an `ExitCode` rather than calling `std::process::exit`, which
+// would skip `Drop` implementations: on Linux X11 the actor owns a server-global input device
+// pair that must be removed when the actor is dropped.
 #[tokio::main(flavor = "current_thread")]
-async fn main() {
+async fn main() -> ExitCode {
     let cli = Cli::parse();
 
     // Window listing does not go through the actor's action model; handle it up front.
     if let Command::Windows = cli.command {
-        match computer_use::experimental_list_windows() {
-            Ok(text) => print!("{text}"),
+        return match computer_use::experimental_list_windows() {
+            Ok(text) => {
+                print!("{text}");
+                ExitCode::SUCCESS
+            }
             Err(e) => {
                 eprintln!("Error: {e}");
-                std::process::exit(1);
+                ExitCode::FAILURE
             }
-        }
-        return;
+        };
     }
 
-    // A window target needs a concrete window id; require it alongside `--pid` so the ambiguous
-    // `0` sentinel is never sent to the actor.
-    if cli.pid.is_some() && cli.window_id.is_none() {
-        eprintln!(
-            "--window-id is required when --pid is given. Use the `windows` subcommand to list \
-             window ids."
-        );
-        std::process::exit(1);
+    // Window targeting needs both flags: the window id addresses the window, and a lone
+    // `--window-id` must not silently downgrade to screen targeting (nor a lone `--pid`
+    // produce the ambiguous `0` window-id sentinel).
+    match (cli.pid.is_some(), cli.window_id.is_some()) {
+        (true, false) => {
+            eprintln!(
+                "--window-id is required when --pid is given. Use the `windows` subcommand to \
+                 list window ids."
+            );
+            return ExitCode::FAILURE;
+        }
+        (false, true) => {
+            eprintln!(
+                "--pid is required when --window-id is given (on Linux X11 the pid is \
+                 informational, but both flags select window targeting together). Use the \
+                 `windows` subcommand to list window ids and pids."
+            );
+            return ExitCode::FAILURE;
+        }
+        (true, true) | (false, false) => {}
     }
 
     let target = cli.target();
-    let mut actor = computer_use::create_actor();
 
     let (actions, screenshot_params, output_path) = match cli.command {
         Command::Click { x, y, button } => {
@@ -185,24 +200,12 @@ async fn main() {
             )
         }
         Command::Keypress { key } => {
-            // Parse key: if it starts with "0x", treat as keycode; otherwise as character
-            let key = if key.starts_with("0x") || key.starts_with("0X") {
-                let keycode = i32::from_str_radix(&key[2..], 16).unwrap_or_else(|_| {
-                    eprintln!("Invalid keycode: {key}");
-                    std::process::exit(1);
-                });
-                Key::Keycode(keycode)
-            } else {
-                let mut chars = key.chars();
-                let ch = chars.next().unwrap_or_else(|| {
-                    eprintln!("Key cannot be empty");
-                    std::process::exit(1);
-                });
-                if chars.next().is_some() {
-                    eprintln!("Key must be a single character, got: {key}");
-                    std::process::exit(1);
+            let key = match parse_key(&key) {
+                Ok(key) => key,
+                Err(e) => {
+                    eprintln!("{e}");
+                    return ExitCode::FAILURE;
                 }
-                Key::Char(ch)
             };
             (
                 vec![Action::KeyDown { key: key.clone() }, Action::KeyUp { key }],
@@ -210,7 +213,7 @@ async fn main() {
                 None,
             )
         }
-        // Handled before the actor is created, above.
+        // Handled up front, above.
         Command::Windows => unreachable!(),
     };
 
@@ -226,6 +229,7 @@ async fn main() {
         background_enabled: true,
     };
 
+    let mut actor = computer_use::create_actor();
     match actor.perform_actions(&actions, options).await {
         Ok(result) => {
             if let Some(pos) = result.cursor_position {
@@ -236,7 +240,7 @@ async fn main() {
             {
                 if let Err(e) = std::fs::write(&path, &screenshot.data) {
                     eprintln!("Failed to write screenshot: {e}");
-                    std::process::exit(1);
+                    return ExitCode::FAILURE;
                 }
                 println!(
                     "Screenshot saved to {} ({}x{})",
@@ -245,10 +249,28 @@ async fn main() {
                     screenshot.height
                 );
             }
+            ExitCode::SUCCESS
         }
         Err(e) => {
             eprintln!("Error: {e}");
-            std::process::exit(1);
+            ExitCode::FAILURE
         }
     }
+}
+
+/// Parses a key argument: a "0x"-prefixed platform keycode, or a single character.
+fn parse_key(key: &str) -> Result<Key, String> {
+    if key.starts_with("0x") || key.starts_with("0X") {
+        let keycode =
+            i32::from_str_radix(&key[2..], 16).map_err(|_| format!("Invalid keycode: {key}"))?;
+        return Ok(Key::Keycode(keycode));
+    }
+    let mut chars = key.chars();
+    let ch = chars
+        .next()
+        .ok_or_else(|| "Key cannot be empty".to_string())?;
+    if chars.next().is_some() {
+        return Err(format!("Key must be a single character, got: {key}"));
+    }
+    Ok(Key::Char(ch))
 }

--- a/crates/computer_use/src/bin/use_computer.rs
+++ b/crates/computer_use/src/bin/use_computer.rs
@@ -12,14 +12,16 @@ use computer_use::{
 #[command(name = "use_computer")]
 #[command(about = "Manually test computer use actions")]
 struct Cli {
-    /// Experimental (macOS only): target a specific background window/process instead of the
-    /// screen. Deliver events directly to this process ID (and `--window-id`, if given) without
-    /// moving the real cursor or raising the window.
+    /// Experimental (macOS and Linux X11): target a specific background window/process instead
+    /// of the screen, without moving the real cursor. On macOS events are delivered to this
+    /// process ID; on Linux X11 delivery is addressed by `--window-id` and the pid is
+    /// informational.
     #[arg(long, global = true)]
     pid: Option<i32>,
 
-    /// Experimental (macOS only): the CGWindowID of the window to target. Required when `--pid`
-    /// is given. Use the `windows` subcommand to list window ids.
+    /// Experimental (macOS and Linux X11): the platform window id to target (a CGWindowID on
+    /// macOS, an X window id on Linux). Required when `--pid` is given. Use the `windows`
+    /// subcommand to list window ids.
     #[arg(long, global = true)]
     window_id: Option<u32>,
 
@@ -73,8 +75,8 @@ enum Command {
         /// The key to press. Can be a single character (e.g., "a") or a keycode (e.g., "0x24" for Return on macOS).
         key: String,
     },
-    /// Experimental (macOS only): list on-screen windows with their window number, owner PID,
-    /// owner name, layer, and bounds, to help identify the right target PID/window.
+    /// Experimental (macOS and Linux X11): list on-screen windows with their window number,
+    /// owner PID, owner name, and bounds, to help identify the right target PID/window.
     Windows,
 }
 

--- a/crates/computer_use/src/lib.rs
+++ b/crates/computer_use/src/lib.rs
@@ -65,6 +65,25 @@ pub fn create_actor() -> Box<dyn Actor> {
 /// Returns whether background, per-window control (driving a specific window without raising it
 /// or moving the cursor) is available on this client and OS. When false, callers should target
 /// the whole screen / frontmost application.
+///
+/// How faithfully "background" holds varies by platform:
+///
+/// - macOS: events are posted directly to the owning process (`CGEventPostToPid`), so a window
+///   can be driven even while fully covered, and nothing user-visible changes.
+/// - Linux X11: events come from a dedicated second input seat (an XInput2/MPX master pair), so
+///   the user's cursor, keyboard focus, and modifier state are untouched and applications see
+///   real (non-synthetic) input. The trade-offs, inherent to X11's position-routed event
+///   delivery, are:
+///   - Pointer actions land on the topmost window at the target point. If the target window is
+///     covered there, the actor first raises it *without* taking the user's focus; the action
+///     fails if the raise does not take effect. Keyboard input needs no raise: it follows the
+///     agent seat's own focus even while the window is covered.
+///   - A second visible cursor appears on screen while window-targeted actions run.
+///   - Under a click-to-focus window manager, the WM itself may react to an agent click by
+///     focusing/raising the target for the user too. WM-less servers (e.g. Xvfb in cloud
+///     environments) have no such side effect.
+/// - Linux Wayland and Windows: unsupported (this returns false); only whole-screen control is
+///   available.
 pub fn background_supported() -> bool {
     if cfg!(feature = "test-util") {
         noop::background_supported()
@@ -76,17 +95,18 @@ pub fn background_supported() -> bool {
 /// Enumerates the on-screen windows, returning their metadata so a caller can pick one to
 /// target. Returns an empty list on platforms where window enumeration is unsupported.
 pub fn enumerate_windows() -> Vec<WindowInfo> {
-    #[cfg(macos)]
+    #[cfg(any(macos, linux))]
     {
         imp::enumerate_windows()
     }
-    #[cfg(not(macos))]
+    #[cfg(not(any(macos, linux)))]
     {
         Vec::new()
     }
 }
 
-/// Experimental: lists on-screen windows as a formatted diagnostic string. macOS only.
+/// Experimental: lists on-screen windows as a formatted diagnostic string. macOS and Linux
+/// (X11) only.
 ///
 /// Unlike [`enumerate_windows`], which returns slim [`WindowInfo`] records for window selection
 /// and wire serialization, this function returns richer data including window bounds, formatted
@@ -98,17 +118,27 @@ pub fn experimental_list_windows() -> Result<String, String> {
     Ok(imp::list_windows())
 }
 
-/// Experimental: lists on-screen windows. Unsupported on this platform.
-#[cfg(not(macos))]
+/// Experimental: lists on-screen windows as a formatted diagnostic string. macOS and Linux
+/// (X11) only.
+#[cfg(linux)]
 pub fn experimental_list_windows() -> Result<String, String> {
-    Err("Window listing is only supported on macOS.".to_string())
+    imp::list_windows()
+}
+
+/// Experimental: lists on-screen windows. Unsupported on this platform.
+#[cfg(not(any(macos, linux)))]
+pub fn experimental_list_windows() -> Result<String, String> {
+    Err("Window listing is only supported on macOS and Linux (X11).".to_string())
 }
 
 /// The surface that a computer-use action or screenshot targets.
 ///
 /// `Screen` reproduces the legacy behavior of acting on the whole screen / frontmost
 /// application. `Window` drives a specific background window of a specific process without
-/// raising it or moving the global cursor.
+/// moving the global cursor or taking the user's keyboard focus. On macOS the window is never
+/// raised; on Linux X11 pointer events are routed by screen position, so a window that is
+/// covered at the action point is raised (without focus) before clicks and scrolls — see
+/// [`background_supported`] for the full per-platform semantics.
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Target {
     /// Target the whole screen / frontmost application (legacy behavior).
@@ -116,12 +146,13 @@ pub enum Target {
     Screen,
     /// Target a specific background window of a specific process.
     Window {
-        /// The platform window id (a `CGWindowID` on macOS). Must be a concrete, non-zero id
-        /// selected from the enumerated window list. `0` is the "unknown" sentinel and is
-        /// rejected by the actor, since coordinate remapping and window capture both require a
-        /// known window.
+        /// The platform window id (a `CGWindowID` on macOS, an X window id on Linux X11). Must
+        /// be a concrete, non-zero id selected from the enumerated window list. `0` is the
+        /// "unknown" sentinel and is rejected by the actor, since coordinate remapping and
+        /// window capture both require a known window.
         window_id: u32,
-        /// The pid of the process that owns the window.
+        /// The pid of the process that owns the window. Used for event delivery on macOS;
+        /// informational on Linux X11, where events are addressed by window id.
         pid: i32,
     },
 }
@@ -151,7 +182,7 @@ impl TargetedAction {
 /// Mirrors the fields of the `WindowInfo` API message.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct WindowInfo {
-    /// The platform window id (a `CGWindowID` on macOS).
+    /// The platform window id (a `CGWindowID` on macOS, an X window id on Linux X11).
     pub window_id: u32,
     /// The pid of the process that owns the window.
     pub pid: i32,

--- a/crates/computer_use/src/linux/mod.rs
+++ b/crates/computer_use/src/linux/mod.rs
@@ -3,6 +3,8 @@ mod recording;
 mod wayland;
 mod x11;
 
+use std::sync::OnceLock;
+
 use async_trait::async_trait;
 pub use recording::Recorder;
 
@@ -26,10 +28,33 @@ pub fn is_supported_on_current_platform() -> bool {
     is_wayland_available() || is_x11_available()
 }
 
-/// Reports whether background, per-window control is available. The Linux input stack drives the
-/// whole screen / frontmost application, so per-window background control is unsupported.
+/// Reports whether background, per-window control is available. On X11 it is implemented with a
+/// dedicated XInput2 (MPX) master device pair, so it requires an XI2-capable server; the Wayland
+/// path drives inputs through XDG portals, which have no per-window targeting.
 pub fn background_supported() -> bool {
-    false
+    if is_wayland_available() || !is_x11_available() {
+        return false;
+    }
+    // The probe opens an X connection; cache it since this is consulted on every agent request.
+    static SUPPORTED: OnceLock<bool> = OnceLock::new();
+    *SUPPORTED.get_or_init(x11::probe_background_support)
+}
+
+/// Enumerates the on-screen windows so a caller can pick one to target. Only supported on X11;
+/// returns an empty list on Wayland or when no display is reachable.
+pub fn enumerate_windows() -> Vec<crate::WindowInfo> {
+    if is_wayland_available() || !is_x11_available() {
+        return Vec::new();
+    }
+    x11::enumerate_windows()
+}
+
+/// Lists on-screen windows as a formatted diagnostic string. Only supported on X11.
+pub fn list_windows() -> Result<String, String> {
+    if is_wayland_available() || !is_x11_available() {
+        return Err("Window listing is only supported on X11.".to_string());
+    }
+    x11::list_windows()
 }
 
 pub struct Actor {

--- a/crates/computer_use/src/linux/x11/mod.rs
+++ b/crates/computer_use/src/linux/x11/mod.rs
@@ -1,18 +1,36 @@
 //! X11 implementation of computer use actions using the XTEST extension.
+//!
+//! Screen-targeted actions drive the user's core pointer and keyboard, exactly like the
+//! pre-existing implementation. Window-targeted actions (background computer use) drive a
+//! private "agent seat" — a second master pointer/keyboard pair (see [`seat`]) — so a specific
+//! window can be controlled without moving the user's cursor or stealing the user's keyboard
+//! focus.
 
 mod keyboard;
 mod mouse;
 mod screenshot;
+mod seat;
+mod windows;
+
+use std::time::Duration;
 
 use async_trait::async_trait;
+use instant::Instant;
 use pathfinder_geometry::vector::Vector2I;
 use warpui_core::r#async::Timer;
 use x11rb::connection::Connection;
+use x11rb::protocol::xinput::ConnectionExt as _;
 use x11rb::protocol::xproto::{self, ConnectionExt as _};
 use x11rb::protocol::xtest::ConnectionExt as _;
 use x11rb::rust_connection::RustConnection;
 
-use crate::{Action, ActionResult, Options, TargetedAction};
+use crate::{Action, ActionResult, Options, Target, TargetedAction};
+
+/// How often to re-check whether a raise took effect. Raising is redirected to the window
+/// manager (when one is running), which restacks asynchronously.
+const RAISE_POLL_INTERVAL: Duration = Duration::from_millis(20);
+/// How long to wait for a raise to take effect before failing the action.
+const RAISE_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// An actor that performs computer use actions on X11.
 pub struct Actor {
@@ -21,6 +39,9 @@ pub struct Actor {
     /// Cached keyboard mapping for this connection. This avoids querying the server on every
     /// character typed.
     keyboard_mapping: xproto::GetKeyboardMappingReply,
+    /// The agent seat used for background window targets, created lazily by the first
+    /// window-targeted action and removed when the actor is dropped.
+    agent: Option<seat::AgentSeat>,
 }
 
 impl Actor {
@@ -51,6 +72,7 @@ impl Actor {
             conn,
             screen_index,
             keyboard_mapping,
+            agent: None,
         })
     }
 
@@ -60,6 +82,83 @@ impl Actor {
 
     fn screen(&self) -> &xproto::Screen {
         &self.conn.setup().roots[self.screen_index]
+    }
+}
+
+/// Probes whether the display supports the XInput2 device hierarchy required for background,
+/// per-window control. Any X server since 1.7 (2009), including Xvfb, supports it.
+pub fn probe_background_support() -> bool {
+    let Ok((conn, _screen_index)) = RustConnection::connect(None) else {
+        return false;
+    };
+    conn.xinput_xi_query_version(2, 2)
+        .ok()
+        .and_then(|cookie| cookie.reply().ok())
+        .is_some_and(|version| version.major_version >= 2)
+}
+
+/// Enumerates the on-screen windows over a short-lived connection, for callers outside an
+/// action batch. Returns an empty list when the display is unreachable.
+pub fn enumerate_windows() -> Vec<crate::WindowInfo> {
+    match RustConnection::connect(None) {
+        Ok((conn, screen_index)) => {
+            let root = conn.setup().roots[screen_index].root;
+            windows::enumerate_windows(&conn, root)
+        }
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Lists the on-screen windows (id, pid, bounds, class, title) as a human-readable table for
+/// CLI diagnostics.
+pub fn list_windows() -> Result<String, String> {
+    let (conn, screen_index) =
+        RustConnection::connect(None).map_err(|e| format!("Failed to connect to X11: {e}"))?;
+    let root = conn.setup().roots[screen_index].root;
+    let mut out = String::from("window#     pid     bounds(x,y,w,h)  class  title\n");
+    for w in windows::list_windows(&conn, root) {
+        out.push_str(&format!(
+            "{:<10}  {:<6}  ({},{},{},{})  {}  {}\n",
+            w.window, w.pid, w.x, w.y, w.width, w.height, w.app_name, w.title,
+        ));
+    }
+    Ok(out)
+}
+
+/// Ensures a button or scroll event at `point` (root coordinates) will be delivered to
+/// `window`.
+///
+/// X11 delivers pointer events to the topmost window under the pointer — there is no
+/// macOS-style "post directly to a background window" path — so if another window covers that
+/// point, the target is raised (without giving it the user's keyboard focus) and the check is
+/// retried until the restack takes effect.
+async fn ensure_window_clickable_at(
+    conn: &RustConnection,
+    root: xproto::Window,
+    window: xproto::Window,
+    point: Vector2I,
+) -> Result<(), String> {
+    if windows::window_hit_at_point(conn, root, window, point)? {
+        return Ok(());
+    }
+
+    windows::raise(conn, window)?;
+    // Under a window manager the raise request is redirected to and executed by the WM, so
+    // poll briefly for the restack to take effect.
+    let start = Instant::now();
+    loop {
+        if windows::window_hit_at_point(conn, root, window, point)? {
+            return Ok(());
+        }
+        if start.elapsed() >= RAISE_TIMEOUT {
+            return Err(format!(
+                "Target window {window} is covered by another window at ({}, {}) and raising it \
+                 did not take effect.",
+                point.x(),
+                point.y(),
+            ));
+        }
+        Timer::after(RAISE_POLL_INTERVAL).await;
     }
 }
 
@@ -74,70 +173,212 @@ impl crate::Actor for Actor {
         actions: &[TargetedAction],
         options: Options,
     ) -> Result<ActionResult, String> {
-        let mut mouse = mouse::Mouse::new(&self.conn, self.root_window());
-        let mut keyboard = keyboard::Keyboard::new(&self.conn, &self.keyboard_mapping);
+        // When background computer use is disabled, force the legacy full-screen path: ignore
+        // any window target, drive the user's core pointer/keyboard, and capture only the root
+        // window. This keeps behavior identical to the pre-existing implementation.
+        let background = options.background_enabled;
+
+        // Validate every target and create the agent seat up front, so a failure cannot leave
+        // the batch half-applied.
+        let mut needs_agent_seat = false;
+        for targeted in actions {
+            let target = if background {
+                targeted.target
+            } else {
+                Target::Screen
+            };
+            match target {
+                // A window target must carry a concrete window id. `0` is the "unknown"
+                // sentinel produced by the CLI default and by unparseable wire ids; reject it
+                // here rather than failing later in window resolution with an opaque message.
+                Target::Window { window_id: 0, .. } => {
+                    return Err(
+                        "A window target requires a non-zero window id. Select a window from \
+                         the enumerated window list."
+                            .to_string(),
+                    );
+                }
+                Target::Window { .. } => needs_agent_seat = true,
+                Target::Screen => {}
+            }
+        }
+        if needs_agent_seat && self.agent.is_none() {
+            let agent_seat = seat::AgentSeat::new()
+                .map_err(|e| format!("Background window control is unavailable: {e}"))?;
+            self.agent = Some(agent_seat);
+        }
+
+        let root = self.root_window();
+        // Input state for screen-targeted actions, driving the user's core pointer/keyboard.
+        let mut screen_mouse = mouse::Mouse::new(&self.conn, root);
+        let mut screen_keyboard = keyboard::Keyboard::new(&self.conn, &self.keyboard_mapping);
+        // Input state for window-targeted actions, driving the agent seat. Keycode resolution
+        // reuses the core keyboard mapping, which is what receiving applications use to
+        // interpret keycodes regardless of the source device.
+        let mut agent_io = self.agent.as_ref().map(|agent_seat| {
+            (
+                agent_seat,
+                mouse::Mouse::new(agent_seat.conn(), root),
+                keyboard::Keyboard::new(agent_seat.conn(), &self.keyboard_mapping),
+            )
+        });
         let mut last_mouse_position: Option<Vector2I> = None;
 
         for targeted in actions {
-            // Per-window targeting is not supported on X11; act on the screen regardless of the
-            // requested target.
+            let target = if background {
+                targeted.target
+            } else {
+                Target::Screen
+            };
             let action: &Action = &targeted.action;
-            match action {
-                Action::Wait(duration) => {
-                    Timer::after(*duration).await;
-                }
-                Action::MouseDown { button, at } => {
-                    mouse.move_to(*at)?;
-                    mouse.focus_window_under_pointer()?;
-                    mouse.button_down(button)?;
-                    last_mouse_position = Some(*at);
-                }
-                Action::MouseUp { button } => {
-                    mouse.button_up(button)?;
-                }
-                Action::MouseMove { to } => {
-                    mouse.move_to(*to)?;
-                    last_mouse_position = Some(*to);
-                }
-                Action::MouseWheel {
-                    at,
-                    direction,
-                    distance,
-                } => {
-                    mouse.move_to(*at)?;
-                    mouse.scroll(direction, distance)?;
-                    last_mouse_position = Some(*at);
-                }
-                Action::TypeText { text } => {
-                    keyboard.type_text(text)?;
-                }
-                Action::KeyDown { key } => {
-                    keyboard.key_down(key)?;
-                }
-                Action::KeyUp { key } => {
-                    keyboard.key_up(key)?;
+            match target {
+                Target::Screen => match action {
+                    Action::Wait(duration) => {
+                        Timer::after(*duration).await;
+                    }
+                    Action::MouseDown { button, at } => {
+                        screen_mouse.move_to(*at)?;
+                        screen_mouse.focus_window_under_pointer()?;
+                        screen_mouse.button_down(button)?;
+                        last_mouse_position = Some(*at);
+                    }
+                    Action::MouseUp { button } => {
+                        screen_mouse.button_up(button)?;
+                    }
+                    Action::MouseMove { to } => {
+                        screen_mouse.move_to(*to)?;
+                        last_mouse_position = Some(*to);
+                    }
+                    Action::MouseWheel {
+                        at,
+                        direction,
+                        distance,
+                    } => {
+                        screen_mouse.move_to(*at)?;
+                        screen_mouse.scroll(direction, distance)?;
+                        last_mouse_position = Some(*at);
+                    }
+                    Action::TypeText { text } => {
+                        screen_keyboard.type_text(text)?;
+                    }
+                    Action::KeyDown { key } => {
+                        screen_keyboard.key_down(key)?;
+                    }
+                    Action::KeyUp { key } => {
+                        screen_keyboard.key_up(key)?;
+                    }
+                },
+                Target::Window { window_id, .. } => {
+                    // The seat was created above for any batch containing a window target.
+                    let Some((agent_seat, agent_mouse, agent_keyboard)) = agent_io.as_mut() else {
+                        return Err("Agent input devices are missing.".to_string());
+                    };
+                    // Window-target coordinates are window-local pixels; the agent pointer
+                    // operates in root coordinates.
+                    match action {
+                        Action::Wait(duration) => {
+                            Timer::after(*duration).await;
+                        }
+                        Action::MouseDown { button, at } => {
+                            let at =
+                                windows::window_local_to_root(&self.conn, root, window_id, *at)?;
+                            ensure_window_clickable_at(&self.conn, root, window_id, at).await?;
+                            // Mirror a real click's focus effect on the agent seat only, so the
+                            // window accepts subsequent input while the user's focus stays put.
+                            agent_seat.focus_window(window_id)?;
+                            agent_mouse.move_to(at)?;
+                            agent_mouse.button_down(button)?;
+                            last_mouse_position = Some(at);
+                        }
+                        Action::MouseUp { button } => {
+                            agent_mouse.button_up(button)?;
+                        }
+                        Action::MouseMove { to } => {
+                            let to =
+                                windows::window_local_to_root(&self.conn, root, window_id, *to)?;
+                            agent_mouse.move_to(to)?;
+                            last_mouse_position = Some(to);
+                        }
+                        Action::MouseWheel {
+                            at,
+                            direction,
+                            distance,
+                        } => {
+                            let at =
+                                windows::window_local_to_root(&self.conn, root, window_id, *at)?;
+                            // Scroll events are delivered by pointer position just like button
+                            // events, so the target must be on top at the scroll point too.
+                            ensure_window_clickable_at(&self.conn, root, window_id, at).await?;
+                            agent_mouse.move_to(at)?;
+                            agent_mouse.scroll(direction, distance)?;
+                            last_mouse_position = Some(at);
+                        }
+                        Action::TypeText { text } => {
+                            agent_seat.focus_window(window_id)?;
+                            agent_keyboard.type_text(text)?;
+                        }
+                        Action::KeyDown { key } => {
+                            agent_seat.focus_window(window_id)?;
+                            agent_keyboard.key_down(key)?;
+                        }
+                        // `KeyUp` always follows a `KeyDown` that already focused the window,
+                        // and a lone `KeyUp` with no prior `KeyDown` is a no-op regardless.
+                        Action::KeyUp { key } => {
+                            agent_keyboard.key_up(key)?;
+                        }
+                    }
                 }
             }
         }
 
-        let screenshot = if let Some(params) = options.screenshot_params {
-            Some(screenshot::take(
-                &self.conn,
-                self.screen(),
-                self.root_window(),
-                params,
-            )?)
-        } else {
-            None
+        let (screenshot, captured_window) = match options.screenshot_params {
+            Some(mut params) => {
+                // With background computer use disabled, never capture a specific window: force
+                // the legacy root-window capture, which returns no captured-window metadata.
+                if !background {
+                    params.target = Target::Screen;
+                }
+                match params.target {
+                    Target::Window { window_id: 0, .. } => {
+                        return Err(
+                            "A window target requires a non-zero window id. Select a window \
+                             from the enumerated window list."
+                                .to_string(),
+                        );
+                    }
+                    Target::Window { window_id, .. } => {
+                        let (screenshot, captured) =
+                            screenshot::take_window(&self.conn, root, window_id, params)?;
+                        (Some(screenshot), captured)
+                    }
+                    Target::Screen => (
+                        Some(screenshot::take(&self.conn, self.screen(), root, params)?),
+                        None,
+                    ),
+                }
+            }
+            None => (None, None),
         };
 
         // Get the final mouse position.
         let cursor_position = if let Some(pos) = last_mouse_position {
             Some(pos)
         } else {
-            Some(mouse.current_position()?)
+            Some(screen_mouse.current_position()?)
         };
 
-        Ok(ActionResult::legacy(screenshot, cursor_position))
+        Ok(ActionResult {
+            screenshot,
+            cursor_position,
+            // Refresh the window list so the caller has up-to-date targets to choose from. When
+            // background computer use is disabled, omit it so the result matches the legacy
+            // shape.
+            windows: if background {
+                windows::enumerate_windows(&self.conn, root)
+            } else {
+                Vec::new()
+            },
+            captured_window,
+        })
     }
 }

--- a/crates/computer_use/src/linux/x11/screenshot.rs
+++ b/crates/computer_use/src/linux/x11/screenshot.rs
@@ -8,6 +8,15 @@ use x11rb::rust_connection::RustConnection;
 use super::windows;
 use crate::{CapturedWindow, Screenshot, ScreenshotParams};
 
+/// The maximum number of native pixels a window capture will read from the server.
+///
+/// The `GetImage` reply and the RGB conversion buffer are allocated at full native size before
+/// the params' downscaling limits apply, so an enormous (or hostile) window could otherwise
+/// make a capture allocate gigabytes. X11 window dimensions go up to `u16::MAX`, far beyond any
+/// real display; this cap (32 * 1024 * 1024 ≈ 33.5M pixels) still comfortably covers a full 8K
+/// display (7680 x 4320 ≈ 33.2M pixels).
+const MAX_WINDOW_CAPTURE_PIXELS: usize = 32 * 1024 * 1024;
+
 /// Takes a screenshot of the root window or a region of it.
 pub fn take(
     conn: &RustConnection,
@@ -93,6 +102,15 @@ pub fn take_window(
     } else {
         (0, 0, geometry.width, geometry.height)
     };
+
+    // Bound the native capture before issuing GetImage; see MAX_WINDOW_CAPTURE_PIXELS.
+    if usize::from(width) * usize::from(height) > MAX_WINDOW_CAPTURE_PIXELS {
+        return Err(format!(
+            "Capturing {width}x{height} pixels of window {window} exceeds the \
+             {MAX_WINDOW_CAPTURE_PIXELS}-pixel capture limit. Capture a smaller region of the \
+             window instead."
+        ));
+    }
 
     let image = capture_window_image(conn, window, geometry.border_width, x, y, width, height)?;
     let rgb_data =

--- a/crates/computer_use/src/linux/x11/screenshot.rs
+++ b/crates/computer_use/src/linux/x11/screenshot.rs
@@ -1,9 +1,12 @@
 //! Screenshot capture for X11.
 
+use x11rb::connection::Connection;
+use x11rb::protocol::composite::{ConnectionExt as _, Redirect};
 use x11rb::protocol::xproto::{self, ConnectionExt as _, ImageFormat};
 use x11rb::rust_connection::RustConnection;
 
-use crate::{Screenshot, ScreenshotParams};
+use super::windows;
+use crate::{CapturedWindow, Screenshot, ScreenshotParams};
 
 /// Takes a screenshot of the root window or a region of it.
 pub fn take(
@@ -53,6 +56,142 @@ pub fn take(
     let img = image::DynamicImage::ImageRgb8(img);
 
     crate::screenshot_utils::process_screenshot(img, params)
+}
+
+/// Captures a single window by its X window id without raising it, returning the processed
+/// image plus metadata describing the captured pixels.
+pub fn take_window(
+    conn: &RustConnection,
+    root: xproto::Window,
+    window: xproto::Window,
+    params: ScreenshotParams,
+) -> Result<(Screenshot, Option<CapturedWindow>), String> {
+    let geometry = windows::geometry(conn, root, window)?;
+
+    // Determine the capture rectangle in window-local coordinates.
+    let (x, y, width, height) = if let Some(region) = params.region {
+        region.validate()?;
+        if region.bottom_right.x() > i32::from(geometry.width)
+            || region.bottom_right.y() > i32::from(geometry.height)
+        {
+            return Err(format!(
+                "Screenshot region ({}, {}) to ({}, {}) is outside window {window} dimensions {}x{}.",
+                region.top_left.x(),
+                region.top_left.y(),
+                region.bottom_right.x(),
+                region.bottom_right.y(),
+                geometry.width,
+                geometry.height,
+            ));
+        }
+        (
+            region.top_left.x() as i16,
+            region.top_left.y() as i16,
+            (region.bottom_right.x() - region.top_left.x()) as u16,
+            (region.bottom_right.y() - region.top_left.y()) as u16,
+        )
+    } else {
+        (0, 0, geometry.width, geometry.height)
+    };
+
+    let image = capture_window_image(conn, window, geometry.border_width, x, y, width, height)?;
+    let rgb_data =
+        convert_x11_image_to_rgb(&image.data, width as usize, height as usize, image.depth)?;
+    let img = image::RgbImage::from_raw(u32::from(width), u32::from(height), rgb_data)
+        .ok_or("Failed to create image from raw data")?;
+    let img = image::DynamicImage::ImageRgb8(img);
+    let screenshot = crate::screenshot_utils::process_screenshot(img, params)?;
+
+    // The captured metadata refers to the native (pre-downscale) capture, so window-local pixel
+    // coordinates sent by the agent map directly onto the captured window image.
+    let captured = CapturedWindow {
+        window_id: window,
+        width_px: screenshot.original_width as i32,
+        height_px: screenshot.original_height as i32,
+    };
+    Ok((screenshot, Some(captured)))
+}
+
+/// Fetches a rectangle of the window's image, preferring a Composite-extension capture (which
+/// sees the full window contents even where other windows overlap it) and falling back to
+/// reading the window drawable directly (whose overlapped regions are undefined).
+fn capture_window_image(
+    conn: &RustConnection,
+    window: xproto::Window,
+    border_width: u16,
+    x: i16,
+    y: i16,
+    width: u16,
+    height: u16,
+) -> Result<xproto::GetImageReply, String> {
+    match capture_via_composite(conn, window, border_width, x, y, width, height) {
+        Ok(image) => Ok(image),
+        Err(composite_error) => {
+            log::debug!(
+                "Composite capture of window {window} failed ({composite_error}); falling back \
+                 to direct capture."
+            );
+            conn.get_image(ImageFormat::Z_PIXMAP, window, x, y, width, height, !0)
+                .map_err(|e| format!("Failed to request window screenshot: {e}"))?
+                .reply()
+                .map_err(|e| format!("Failed to capture window {window}: {e}"))
+        }
+    }
+}
+
+/// Captures a rectangle of the window via the Composite extension's off-screen backing pixmap.
+fn capture_via_composite(
+    conn: &RustConnection,
+    window: xproto::Window,
+    border_width: u16,
+    x: i16,
+    y: i16,
+    width: u16,
+    height: u16,
+) -> Result<xproto::GetImageReply, String> {
+    conn.composite_query_version(0, 4)
+        .map_err(|e| format!("Composite extension not available: {e}"))?
+        .reply()
+        .map_err(|e| format!("Composite extension not available: {e}"))?;
+
+    // Redirect the window so the server maintains its full contents off-screen. Automatic
+    // redirections are per-client and released when this connection closes, so the error from a
+    // redundant redirect (or from a compositor's existing manual redirection, under which
+    // NameWindowPixmap already works) is ignored. Content that was covered before redirection
+    // may be stale until the application repaints, which its interactions quickly trigger.
+    if let Ok(cookie) = conn.composite_redirect_window(window, Redirect::AUTOMATIC) {
+        let _ = cookie.check();
+    }
+
+    let pixmap = conn
+        .generate_id()
+        .map_err(|e| format!("Failed to allocate a pixmap id: {e}"))?;
+    conn.composite_name_window_pixmap(window, pixmap)
+        .map_err(|e| format!("Failed to name the window pixmap: {e}"))?
+        .check()
+        .map_err(|e| format!("Failed to name the window pixmap: {e}"))?;
+
+    // The backing pixmap includes the window border; the content box starts at
+    // (border_width, border_width).
+    let image = conn
+        .get_image(
+            ImageFormat::Z_PIXMAP,
+            pixmap,
+            x + border_width as i16,
+            y + border_width as i16,
+            width,
+            height,
+            !0, // plane_mask: all planes
+        )
+        .map_err(|e| format!("Failed to request window screenshot: {e}"))
+        .and_then(|cookie| {
+            cookie
+                .reply()
+                .map_err(|e| format!("Failed to capture window {window}: {e}"))
+        });
+    let _ = conn.free_pixmap(pixmap);
+    let _ = conn.flush();
+    image
 }
 
 /// Converts X11 image data (typically BGRA or BGR) to RGB.

--- a/crates/computer_use/src/linux/x11/seat.rs
+++ b/crates/computer_use/src/linux/x11/seat.rs
@@ -1,0 +1,254 @@
+//! A dedicated "agent seat": an XInput2 (MPX) master pointer/keyboard pair used to drive
+//! background windows without moving the user's cursor or stealing the user's keyboard focus.
+//!
+//! X11 has no equivalent of macOS's `CGEventPostToPid` (delivering events directly to a
+//! process). The alternatives are `XSendEvent`-style synthetic events, which most toolkits
+//! (GTK, Qt, Chromium, WINE) ignore for security reasons, or real server-generated input. This
+//! module takes the latter path using Multi-Pointer X: the X server supports any number of
+//! independent master pointer/keyboard pairs, each with its own on-screen cursor and its own
+//! keyboard focus.
+//!
+//! The server routes all *core* input-related requests of a client — XTEST fake input,
+//! `WarpPointer`, `QueryPointer`, `SetInputFocus` — through that client's "ClientPointer"
+//! master pair. By creating a private master pair and pointing a dedicated connection's
+//! ClientPointer at it (`XISetClientPointer`), the existing XTEST-based mouse and keyboard code
+//! drives the agent seat unchanged: events are indistinguishable from real hardware input to
+//! applications, while the user's own pointer, keyboard focus, and modifier state stay put.
+//!
+//! Unlike most X resources, master devices are server-global and outlive the connection that
+//! created them, so the pair is removed explicitly on drop and stale pairs from crashed
+//! processes are reaped on creation (identified by the process id embedded in the seat name).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use x11rb::connection::Connection;
+use x11rb::protocol::xinput::{
+    self, ChangeMode, ConnectionExt as _, DeviceType, HierarchyChange, HierarchyChangeData,
+    HierarchyChangeDataAddMaster, HierarchyChangeDataRemoveMaster,
+};
+use x11rb::protocol::xproto;
+use x11rb::rust_connection::RustConnection;
+
+/// The prefix of agent seat device names. A seat is named `{PREFIX}{pid}-{sequence}` and the
+/// server derives the individual device names from it (e.g. "… pointer", "… keyboard",
+/// "… XTEST pointer"). The embedded pid identifies the owning process for stale-seat reaping.
+const SEAT_NAME_PREFIX: &str = "warp-agent-cu-";
+
+/// The XI2 device id wildcard meaning "all devices" in `XIQueryDevice`.
+const ALL_DEVICES: u16 = 0;
+
+/// A private master pointer/keyboard pair plus the dedicated connection whose ClientPointer is
+/// set to it. All core input requests issued on [`AgentSeat::conn`] act on the agent's cursor
+/// and keyboard focus instead of the user's.
+pub struct AgentSeat {
+    conn: RustConnection,
+    master_keyboard: xinput::DeviceId,
+    /// The paired master pointer. Retained for the `RemoveMaster` request on drop (removing
+    /// either device of a pair removes both).
+    master_pointer: xinput::DeviceId,
+}
+
+impl AgentSeat {
+    /// Creates the agent seat: a fresh X connection plus a private master device pair, with the
+    /// connection's ClientPointer set to the new pair so all of its core input requests route
+    /// through the agent devices.
+    pub fn new() -> Result<Self, String> {
+        let (conn, _screen_index) =
+            RustConnection::connect(None).map_err(|e| format!("Failed to connect to X11: {e}"))?;
+
+        // XI 2.0 introduced the master/slave device hierarchy used here (X server >= 1.7,
+        // released 2009). The supported version must be announced before other XI2 requests.
+        let version = conn
+            .xinput_xi_query_version(2, 2)
+            .map_err(|e| format!("XInput2 extension not available: {e}"))?
+            .reply()
+            .map_err(|e| format!("XInput2 extension query failed: {e}"))?;
+        if version.major_version < 2 {
+            return Err(format!(
+                "XInput2 is required for background window control, but the server only \
+                 supports XInput {}.{}.",
+                version.major_version, version.minor_version
+            ));
+        }
+
+        // Best-effort: reap seats leaked by crashed processes so their cursors do not
+        // accumulate on the display.
+        remove_stale_seats(&conn);
+
+        let name = format!(
+            "{SEAT_NAME_PREFIX}{}-{}",
+            std::process::id(),
+            next_sequence()
+        );
+        create_master_pair(&conn, &name)?;
+        let (master_pointer, master_keyboard) = find_master_pair(&conn, &name)?;
+
+        // Route this connection's core requests (XTEST fake input, WarpPointer, QueryPointer,
+        // SetInputFocus) through the agent master pair instead of the user's virtual core
+        // pointer and keyboard. Window `None` selects the requesting client itself.
+        conn.xinput_xi_set_client_pointer(x11rb::NONE, master_pointer)
+            .map_err(|e| format!("Failed to select the agent pointer: {e}"))?
+            .check()
+            .map_err(|e| format!("Failed to select the agent pointer: {e}"))?;
+
+        Ok(Self {
+            conn,
+            master_keyboard,
+            master_pointer,
+        })
+    }
+
+    /// The connection whose core input requests act on the agent seat.
+    pub fn conn(&self) -> &RustConnection {
+        &self.conn
+    }
+
+    /// Gives the agent keyboard focus to `window` so subsequent key events are delivered there.
+    ///
+    /// Only the agent master keyboard is affected: the user's keyboard focus is a property of
+    /// their own master keyboard and stays where it is. The target application receives a
+    /// regular `FocusIn`, so it treats itself as focused (accepting input, showing its caret)
+    /// while the user's focused window does the same — the X11 analog of the macOS background
+    /// activation dance.
+    pub fn focus_window(&self, window: xproto::Window) -> Result<(), String> {
+        self.conn
+            .xinput_xi_set_focus(window, x11rb::CURRENT_TIME, self.master_keyboard)
+            .map_err(|e| format!("Failed to focus target window {window}: {e}"))?
+            .check()
+            .map_err(|e| format!("Failed to focus target window {window}: {e}"))?;
+        Ok(())
+    }
+}
+
+impl Drop for AgentSeat {
+    fn drop(&mut self) {
+        // Master devices are server-global (they outlive this connection), so remove the pair
+        // explicitly. Failures are ignored: `remove_stale_seats` reaps leftovers on the next
+        // seat creation.
+        let _ = remove_master(&self.conn, self.master_pointer);
+        let _ = self.conn.flush();
+    }
+}
+
+/// Returns a process-locally unique sequence number, so concurrent computer-use sessions in one
+/// process get distinct seat names.
+fn next_sequence() -> u64 {
+    static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+    SEQUENCE.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Creates a master pointer/keyboard pair named "{name} pointer" / "{name} keyboard". The
+/// server also creates and attaches the matching XTEST slave devices, which is what makes XTEST
+/// fake input work through the new pair.
+fn create_master_pair(conn: &RustConnection, name: &str) -> Result<(), String> {
+    let name = name.as_bytes().to_vec();
+    // A hierarchy change carries its total wire length in 4-byte units: an 8-byte fixed header
+    // plus the name, padded to a multiple of 4.
+    let len = (8 + name.len()).div_ceil(4) as u16;
+    let change = HierarchyChange {
+        len,
+        data: HierarchyChangeData::AddMaster(HierarchyChangeDataAddMaster {
+            // Send core events so non-XI2 applications see the agent's input.
+            send_core: true,
+            enable: true,
+            name,
+        }),
+    };
+    conn.xinput_xi_change_hierarchy(&[change])
+        .map_err(|e| format!("Failed to create the agent input devices: {e}"))?
+        .check()
+        .map_err(|e| format!("Failed to create the agent input devices: {e}"))?;
+    Ok(())
+}
+
+/// Removes the master pair that `master_pointer` belongs to. The pair's XTEST slave devices are
+/// destroyed with it; it has no other slaves that would need reattaching.
+fn remove_master(conn: &RustConnection, master_pointer: xinput::DeviceId) -> Result<(), String> {
+    let change = HierarchyChange {
+        // The RemoveMaster change is a fixed 12 bytes = 3 four-byte units.
+        len: 3,
+        data: HierarchyChangeData::RemoveMaster(HierarchyChangeDataRemoveMaster {
+            deviceid: master_pointer,
+            return_mode: ChangeMode::FLOAT,
+            return_pointer: 0,
+            return_keyboard: 0,
+        }),
+    };
+    conn.xinput_xi_change_hierarchy(&[change])
+        .map_err(|e| format!("Failed to remove the agent input devices: {e}"))?
+        .check()
+        .map_err(|e| format!("Failed to remove the agent input devices: {e}"))?;
+    Ok(())
+}
+
+/// Finds the device ids of the master pair created under `name`.
+fn find_master_pair(
+    conn: &RustConnection,
+    name: &str,
+) -> Result<(xinput::DeviceId, xinput::DeviceId), String> {
+    let pointer_name = format!("{name} pointer");
+    let keyboard_name = format!("{name} keyboard");
+    let reply = conn
+        .xinput_xi_query_device(ALL_DEVICES)
+        .map_err(|e| format!("Failed to query input devices: {e}"))?
+        .reply()
+        .map_err(|e| format!("Failed to query input devices: {e}"))?;
+
+    let mut pointer = None;
+    let mut keyboard = None;
+    for info in &reply.infos {
+        let device_name = String::from_utf8_lossy(&info.name);
+        if info.type_ == DeviceType::MASTER_POINTER && device_name == pointer_name {
+            pointer = Some(info.deviceid);
+        } else if info.type_ == DeviceType::MASTER_KEYBOARD && device_name == keyboard_name {
+            keyboard = Some(info.deviceid);
+        }
+    }
+    match (pointer, keyboard) {
+        (Some(pointer), Some(keyboard)) => Ok((pointer, keyboard)),
+        _ => Err("The agent input devices were not created as expected.".to_string()),
+    }
+}
+
+/// Removes agent seats whose owning process no longer exists. A crashed process never runs
+/// `Drop`, and its master devices (and their on-screen cursors) would otherwise persist until
+/// the X server restarts.
+fn remove_stale_seats(conn: &RustConnection) {
+    let Some(reply) = conn
+        .xinput_xi_query_device(ALL_DEVICES)
+        .ok()
+        .and_then(|cookie| cookie.reply().ok())
+    else {
+        return;
+    };
+    for info in &reply.infos {
+        if info.type_ != DeviceType::MASTER_POINTER {
+            continue;
+        }
+        let device_name = String::from_utf8_lossy(&info.name);
+        let Some(pid) = seat_pid(&device_name) else {
+            continue;
+        };
+        // Live seats belonging to this process are in use by concurrent sessions; skip them.
+        if pid == std::process::id() || process_alive(pid) {
+            continue;
+        }
+        let _ = remove_master(conn, info.deviceid);
+    }
+    let _ = conn.flush();
+}
+
+/// Parses the owning pid out of a seat master pointer name like "warp-agent-cu-1234-0 pointer".
+fn seat_pid(device_name: &str) -> Option<u32> {
+    let rest = device_name.strip_prefix(SEAT_NAME_PREFIX)?;
+    rest.split('-').next()?.parse().ok()
+}
+
+/// Reports whether a process with the given pid exists.
+fn process_alive(pid: u32) -> bool {
+    // Signal `None` performs error checking only. EPERM still means the process exists.
+    match nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid as i32), None) {
+        Ok(()) => true,
+        Err(errno) => errno == nix::errno::Errno::EPERM,
+    }
+}

--- a/crates/computer_use/src/linux/x11/seat.rs
+++ b/crates/computer_use/src/linux/x11/seat.rs
@@ -16,10 +16,14 @@
 //! applications, while the user's own pointer, keyboard focus, and modifier state stay put.
 //!
 //! Unlike most X resources, master devices are server-global and outlive the connection that
-//! created them, so the pair is removed explicitly on drop and stale pairs from crashed
-//! processes are reaped on creation (identified by the process id embedded in the seat name).
+//! created them, so the pair is removed explicitly on drop, and every seat creation reaps
+//! leaked pairs: pairs of this process not owned by a live [`AgentSeat`] (per a process-local
+//! registry), and pairs whose owning process (identified by the pid embedded in the seat name)
+//! no longer exists.
 
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
 
 use x11rb::connection::Connection;
 use x11rb::protocol::xinput::{
@@ -42,6 +46,8 @@ const ALL_DEVICES: u16 = 0;
 /// and keyboard focus instead of the user's.
 pub struct AgentSeat {
     conn: RustConnection,
+    /// The seat name, held in the live-seat registry for as long as this seat exists.
+    name: String,
     master_keyboard: xinput::DeviceId,
     /// The paired master pointer. Retained for the `RemoveMaster` request on drop (removing
     /// either device of a pair removes both).
@@ -71,8 +77,8 @@ impl AgentSeat {
             ));
         }
 
-        // Best-effort: reap seats leaked by crashed processes so their cursors do not
-        // accumulate on the display.
+        // Best-effort: reap seats leaked by crashed processes or by failed constructions in
+        // this process, so their cursors do not accumulate on the display.
         remove_stale_seats(&conn);
 
         let name = format!(
@@ -80,19 +86,45 @@ impl AgentSeat {
             std::process::id(),
             next_sequence()
         );
-        create_master_pair(&conn, &name)?;
-        let (master_pointer, master_keyboard) = find_master_pair(&conn, &name)?;
+        // Reserve the name before creating the devices, so a concurrent seat creation's
+        // stale-seat reaper cannot collect this pair mid-construction. Every failure path below
+        // unregisters the name, which marks any devices that were created as stale.
+        register_live_seat(&name);
+        if let Err(e) = create_master_pair(&conn, &name) {
+            unregister_live_seat(&name);
+            return Err(e);
+        }
+        let (master_pointer, master_keyboard) = match find_master_pair(&conn, &name) {
+            Ok(pair) => pair,
+            Err(e) => {
+                // The pair may exist even though it could not be identified (e.g. a transient
+                // query failure); unregistering lets the next seat creation reap it.
+                unregister_live_seat(&name);
+                return Err(e);
+            }
+        };
 
         // Route this connection's core requests (XTEST fake input, WarpPointer, QueryPointer,
         // SetInputFocus) through the agent master pair instead of the user's virtual core
         // pointer and keyboard. Window `None` selects the requesting client itself.
-        conn.xinput_xi_set_client_pointer(x11rb::NONE, master_pointer)
-            .map_err(|e| format!("Failed to select the agent pointer: {e}"))?
-            .check()
-            .map_err(|e| format!("Failed to select the agent pointer: {e}"))?;
+        let selected = conn
+            .xinput_xi_set_client_pointer(x11rb::NONE, master_pointer)
+            .map_err(|e| format!("Failed to select the agent pointer: {e}"))
+            .and_then(|cookie| {
+                cookie
+                    .check()
+                    .map_err(|e| format!("Failed to select the agent pointer: {e}"))
+            });
+        if let Err(e) = selected {
+            let _ = remove_master(&conn, master_pointer);
+            let _ = conn.flush();
+            unregister_live_seat(&name);
+            return Err(e);
+        }
 
         Ok(Self {
             conn,
+            name,
             master_keyboard,
             master_pointer,
         })
@@ -123,10 +155,11 @@ impl AgentSeat {
 impl Drop for AgentSeat {
     fn drop(&mut self) {
         // Master devices are server-global (they outlive this connection), so remove the pair
-        // explicitly. Failures are ignored: `remove_stale_seats` reaps leftovers on the next
-        // seat creation.
+        // explicitly. Failures are ignored: unregistering marks the pair as stale, so
+        // `remove_stale_seats` reaps any leftovers on the next seat creation.
         let _ = remove_master(&self.conn, self.master_pointer);
         let _ = self.conn.flush();
+        unregister_live_seat(&self.name);
     }
 }
 
@@ -135,6 +168,27 @@ impl Drop for AgentSeat {
 fn next_sequence() -> u64 {
     static SEQUENCE: AtomicU64 = AtomicU64::new(0);
     SEQUENCE.fetch_add(1, Ordering::Relaxed)
+}
+
+/// The names of seats currently owned (or being constructed) by an [`AgentSeat`] in this
+/// process. Same-process seats absent from this registry are leaks from failed constructions
+/// and are reaped by [`remove_stale_seats`]; a plain pid-liveness check cannot classify them
+/// because the owning process (this one) is alive.
+fn live_seats() -> &'static Mutex<HashSet<String>> {
+    static LIVE_SEATS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    LIVE_SEATS.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+fn register_live_seat(name: &str) {
+    live_seats().lock().unwrap().insert(name.to_string());
+}
+
+fn unregister_live_seat(name: &str) {
+    live_seats().lock().unwrap().remove(name);
+}
+
+fn is_live_seat(name: &str) -> bool {
+    live_seats().lock().unwrap().contains(name)
 }
 
 /// Creates a master pointer/keyboard pair named "{name} pointer" / "{name} keyboard". The
@@ -210,9 +264,10 @@ fn find_master_pair(
     }
 }
 
-/// Removes agent seats whose owning process no longer exists. A crashed process never runs
-/// `Drop`, and its master devices (and their on-screen cursors) would otherwise persist until
-/// the X server restarts.
+/// Removes agent seats that no longer have a live owner: seats of this process that are absent
+/// from the live-seat registry (leaked by a failed construction), and seats whose owning
+/// process no longer exists (a crashed process never runs `Drop`, and its master devices — and
+/// their on-screen cursors — would otherwise persist until the X server restarts).
 fn remove_stale_seats(conn: &RustConnection) {
     let Some(reply) = conn
         .xinput_xi_query_device(ALL_DEVICES)
@@ -225,22 +280,34 @@ fn remove_stale_seats(conn: &RustConnection) {
         if info.type_ != DeviceType::MASTER_POINTER {
             continue;
         }
+        // Master pointers are named "{seat name} pointer" by the server.
         let device_name = String::from_utf8_lossy(&info.name);
-        let Some(pid) = seat_pid(&device_name) else {
+        let Some(seat_name) = device_name.strip_suffix(" pointer") else {
             continue;
         };
-        // Live seats belonging to this process are in use by concurrent sessions; skip them.
-        if pid == std::process::id() || process_alive(pid) {
+        let Some(pid) = seat_pid(seat_name) else {
             continue;
+        };
+        let stale = if pid == std::process::id() {
+            // Seats of this process are stale unless a live (or in-construction) `AgentSeat`
+            // owns them.
+            !is_live_seat(seat_name)
+        } else {
+            // NOTE: pid reuse can make a foreign leaked seat look alive; it is then reaped
+            // once the reusing process exits, which bounds the leak without needing a
+            // process-start token in the seat name.
+            !process_alive(pid)
+        };
+        if stale {
+            let _ = remove_master(conn, info.deviceid);
         }
-        let _ = remove_master(conn, info.deviceid);
     }
     let _ = conn.flush();
 }
 
-/// Parses the owning pid out of a seat master pointer name like "warp-agent-cu-1234-0 pointer".
-fn seat_pid(device_name: &str) -> Option<u32> {
-    let rest = device_name.strip_prefix(SEAT_NAME_PREFIX)?;
+/// Parses the owning pid out of a seat name like "warp-agent-cu-1234-0".
+fn seat_pid(seat_name: &str) -> Option<u32> {
+    let rest = seat_name.strip_prefix(SEAT_NAME_PREFIX)?;
     rest.split('-').next()?.parse().ok()
 }
 

--- a/crates/computer_use/src/linux/x11/windows.rs
+++ b/crates/computer_use/src/linux/x11/windows.rs
@@ -181,7 +181,14 @@ fn top_level_windows(
     children
 }
 
+/// The maximum property length requested by [`read_property`], in 32-bit units (1 MiB total).
+/// The properties read during enumeration (client lists, titles, `WM_CLASS`, `_NET_WM_PID`) are
+/// far smaller in practice; the cap keeps a window with a pathologically large property from
+/// forcing large allocations.
+const MAX_PROPERTY_LENGTH: u32 = 256 * 1024;
+
 /// Reads a property, returning `None` when the property is missing or the request fails.
+/// Reads at most [`MAX_PROPERTY_LENGTH`] 32-bit units; anything beyond that is truncated.
 fn read_property(
     conn: &RustConnection,
     window: xproto::Window,
@@ -189,7 +196,7 @@ fn read_property(
     type_: xproto::Atom,
 ) -> Option<xproto::GetPropertyReply> {
     let reply = conn
-        .get_property(false, window, property, type_, 0, u32::MAX)
+        .get_property(false, window, property, type_, 0, MAX_PROPERTY_LENGTH)
         .ok()?
         .reply()
         .ok()?;

--- a/crates/computer_use/src/linux/x11/windows.rs
+++ b/crates/computer_use/src/linux/x11/windows.rs
@@ -1,0 +1,338 @@
+//! Window enumeration and geometry helpers for X11 background computer use.
+//!
+//! Windows are enumerated via the EWMH client list maintained by the window manager, falling
+//! back to walking the root window's children on window-manager-less servers (e.g. bare Xvfb in
+//! cloud environments). All coordinates are physical pixels; window-local coordinates have their
+//! origin at the top-left of the window's content box.
+
+use pathfinder_geometry::vector::Vector2I;
+use x11rb::connection::Connection;
+use x11rb::protocol::xproto::{
+    self, AtomEnum, ConnectionExt as _, MapState, StackMode, WindowClass,
+};
+use x11rb::rust_connection::RustConnection;
+
+/// The geometry of a window's content box, with `x`/`y` in root-window (screen) coordinates.
+#[derive(Clone, Copy, Debug)]
+pub struct WindowGeometry {
+    pub x: i32,
+    pub y: i32,
+    pub width: u16,
+    pub height: u16,
+    /// The window's border width in pixels. Needed by window capture: the composite backing
+    /// pixmap includes the border, so the content box starts at `(border_width, border_width)`.
+    pub border_width: u16,
+}
+
+/// The EWMH atoms used for window enumeration, interned once per enumeration.
+struct Atoms {
+    net_client_list_stacking: xproto::Atom,
+    net_client_list: xproto::Atom,
+    net_wm_name: xproto::Atom,
+    utf8_string: xproto::Atom,
+    net_wm_pid: xproto::Atom,
+}
+
+impl Atoms {
+    fn new(conn: &RustConnection) -> Result<Self, String> {
+        // Send all intern requests before reading any reply to avoid serial round-trips.
+        let cookies = [
+            "_NET_CLIENT_LIST_STACKING",
+            "_NET_CLIENT_LIST",
+            "_NET_WM_NAME",
+            "UTF8_STRING",
+            "_NET_WM_PID",
+        ]
+        .map(|name| conn.intern_atom(false, name.as_bytes()));
+        let mut atoms = [0 as xproto::Atom; 5];
+        for (atom, cookie) in atoms.iter_mut().zip(cookies) {
+            *atom = cookie
+                .map_err(|e| format!("Failed to intern atom: {e}"))?
+                .reply()
+                .map_err(|e| format!("Failed to intern atom: {e}"))?
+                .atom;
+        }
+        let [
+            net_client_list_stacking,
+            net_client_list,
+            net_wm_name,
+            utf8_string,
+            net_wm_pid,
+        ] = atoms;
+        Ok(Self {
+            net_client_list_stacking,
+            net_client_list,
+            net_wm_name,
+            utf8_string,
+            net_wm_pid,
+        })
+    }
+}
+
+/// Enumerates the on-screen top-level windows as crate-level [`crate::WindowInfo`] records, so
+/// the agent can pick a window to target. Ordered front-to-back.
+pub fn enumerate_windows(conn: &RustConnection, root: xproto::Window) -> Vec<crate::WindowInfo> {
+    list_windows(conn, root)
+        .into_iter()
+        .map(|w| crate::WindowInfo {
+            window_id: w.window,
+            pid: w.pid,
+            app_name: w.app_name,
+            title: w.title,
+            // X11 has no per-window layer concept for normal client windows; report the normal
+            // application layer for every window.
+            layer: 0,
+        })
+        .collect()
+}
+
+/// A description of an on-screen window, for enumeration and diagnostics.
+pub struct WindowDescription {
+    pub window: xproto::Window,
+    pub pid: i32,
+    pub app_name: String,
+    pub title: String,
+    pub x: i32,
+    pub y: i32,
+    pub width: u16,
+    pub height: u16,
+}
+
+/// Lists the viewable top-level windows, front-to-back, with their metadata and geometry.
+pub fn list_windows(conn: &RustConnection, root: xproto::Window) -> Vec<WindowDescription> {
+    let Ok(atoms) = Atoms::new(conn) else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::new();
+    for window in top_level_windows(conn, root, &atoms) {
+        // Only include viewable windows: pointer events can only be delivered to mapped
+        // windows, and the agent should not target iconified or withdrawn windows.
+        let Some(attributes) = conn
+            .get_window_attributes(window)
+            .ok()
+            .and_then(|cookie| cookie.reply().ok())
+        else {
+            continue;
+        };
+        if attributes.map_state != MapState::VIEWABLE || attributes.class == WindowClass::INPUT_ONLY
+        {
+            continue;
+        }
+        let Ok(geometry) = geometry(conn, root, window) else {
+            continue;
+        };
+        out.push(WindowDescription {
+            window,
+            pid: window_pid(conn, &atoms, window).unwrap_or(0),
+            app_name: window_class(conn, window).unwrap_or_default(),
+            title: window_title(conn, &atoms, window).unwrap_or_default(),
+            x: geometry.x,
+            y: geometry.y,
+            width: geometry.width,
+            height: geometry.height,
+        });
+    }
+    out
+}
+
+/// Returns candidate top-level client windows, ordered front-to-back.
+fn top_level_windows(
+    conn: &RustConnection,
+    root: xproto::Window,
+    atoms: &Atoms,
+) -> Vec<xproto::Window> {
+    // Prefer the EWMH client lists maintained by the window manager, which contain the client
+    // windows themselves (not the WM's frame windows). `_NET_CLIENT_LIST_STACKING` is
+    // bottom-to-top stacking order; `_NET_CLIENT_LIST` is initial-mapping order, for which
+    // reversal is still the better front-to-back approximation.
+    for atom in [atoms.net_client_list_stacking, atoms.net_client_list] {
+        let Some(reply) = read_property(conn, root, atom, AtomEnum::WINDOW.into()) else {
+            continue;
+        };
+        let Some(values) = reply.value32() else {
+            continue;
+        };
+        let mut list: Vec<xproto::Window> = values.collect();
+        if !list.is_empty() {
+            list.reverse();
+            return list;
+        }
+    }
+
+    // No EWMH window manager (e.g. bare Xvfb): fall back to the root window's direct children,
+    // which `QueryTree` returns bottom-to-top. Override-redirect windows (menus, tooltips) are
+    // excluded to mirror what an EWMH client list would contain.
+    let Some(reply) = conn
+        .query_tree(root)
+        .ok()
+        .and_then(|cookie| cookie.reply().ok())
+    else {
+        return Vec::new();
+    };
+    let mut children = reply.children;
+    children.reverse();
+    children.retain(|&window| {
+        conn.get_window_attributes(window)
+            .ok()
+            .and_then(|cookie| cookie.reply().ok())
+            .is_some_and(|attributes| !attributes.override_redirect)
+    });
+    children
+}
+
+/// Reads a property, returning `None` when the property is missing or the request fails.
+fn read_property(
+    conn: &RustConnection,
+    window: xproto::Window,
+    property: xproto::Atom,
+    type_: xproto::Atom,
+) -> Option<xproto::GetPropertyReply> {
+    let reply = conn
+        .get_property(false, window, property, type_, 0, u32::MAX)
+        .ok()?
+        .reply()
+        .ok()?;
+    (reply.format != 0).then_some(reply)
+}
+
+/// Reads the window title, preferring the UTF-8 EWMH title over the legacy `WM_NAME`.
+fn window_title(conn: &RustConnection, atoms: &Atoms, window: xproto::Window) -> Option<String> {
+    if let Some(reply) = read_property(conn, window, atoms.net_wm_name, atoms.utf8_string)
+        && reply.format == 8
+    {
+        return Some(String::from_utf8_lossy(&reply.value).into_owned());
+    }
+    let reply = read_property(conn, window, AtomEnum::WM_NAME.into(), AtomEnum::ANY.into())?;
+    (reply.format == 8).then(|| String::from_utf8_lossy(&reply.value).into_owned())
+}
+
+/// Reads the owning process id from `_NET_WM_PID`, if the application published one.
+fn window_pid(conn: &RustConnection, atoms: &Atoms, window: xproto::Window) -> Option<i32> {
+    let reply = read_property(conn, window, atoms.net_wm_pid, AtomEnum::CARDINAL.into())?;
+    reply.value32()?.next().map(|pid| pid as i32)
+}
+
+/// Reads the application name from `WM_CLASS` (the class part, falling back to the instance).
+fn window_class(conn: &RustConnection, window: xproto::Window) -> Option<String> {
+    let reply = read_property(
+        conn,
+        window,
+        AtomEnum::WM_CLASS.into(),
+        AtomEnum::STRING.into(),
+    )?;
+    if reply.format != 8 {
+        return None;
+    }
+    // WM_CLASS holds two null-terminated strings: the instance name, then the class name.
+    let mut parts = reply.value.split(|&b| b == 0).filter(|s| !s.is_empty());
+    let instance = parts.next();
+    let class = parts.next().or(instance)?;
+    Some(String::from_utf8_lossy(class).into_owned())
+}
+
+/// Returns the geometry of `window`'s content box, with its origin in root coordinates.
+pub fn geometry(
+    conn: &RustConnection,
+    root: xproto::Window,
+    window: xproto::Window,
+) -> Result<WindowGeometry, String> {
+    let geometry = conn
+        .get_geometry(window)
+        .map_err(|e| format!("Failed to query geometry of window {window}: {e}"))?
+        .reply()
+        .map_err(|e| format!("Failed to query geometry of window {window}: {e}"))?;
+    // `GetGeometry` coordinates are relative to the window's parent (e.g. a WM frame), so
+    // translate the content-box origin into root coordinates.
+    let translated = conn
+        .translate_coordinates(window, root, 0, 0)
+        .map_err(|e| format!("Failed to locate window {window}: {e}"))?
+        .reply()
+        .map_err(|e| format!("Failed to locate window {window}: {e}"))?;
+    Ok(WindowGeometry {
+        x: i32::from(translated.dst_x),
+        y: i32::from(translated.dst_y),
+        width: geometry.width,
+        height: geometry.height,
+        border_width: geometry.border_width,
+    })
+}
+
+/// Translates window-local pixel coordinates to root (screen) coordinates, validating that the
+/// point lies inside the window's content box. Unlike macOS's process-targeted event posting,
+/// X11 pointer events are delivered by screen position, so an out-of-bounds point would land on
+/// an unrelated window; reject it instead.
+pub fn window_local_to_root(
+    conn: &RustConnection,
+    root: xproto::Window,
+    window: xproto::Window,
+    point: Vector2I,
+) -> Result<Vector2I, String> {
+    let geometry = geometry(conn, root, window)?;
+    if point.x() < 0
+        || point.y() < 0
+        || point.x() >= i32::from(geometry.width)
+        || point.y() >= i32::from(geometry.height)
+    {
+        return Err(format!(
+            "Coordinates ({}, {}) are outside target window {window}'s {}x{} bounds.",
+            point.x(),
+            point.y(),
+            geometry.width,
+            geometry.height
+        ));
+    }
+    Ok(Vector2I::new(
+        geometry.x + point.x(),
+        geometry.y + point.y(),
+    ))
+}
+
+/// Reports whether a pointer event at `point` (root coordinates) would be delivered to `window`
+/// or one of its descendants.
+///
+/// The X server picks the destination of a pointer event by walking the chain of mapped windows
+/// containing the point from the root down; this performs the same walk and checks whether the
+/// target window is part of the chain (which also handles window-manager frames that reparent
+/// the target).
+pub fn window_hit_at_point(
+    conn: &RustConnection,
+    root: xproto::Window,
+    window: xproto::Window,
+    point: Vector2I,
+) -> Result<bool, String> {
+    let mut current = root;
+    // The chain cannot be deeper than the window tree; bound the walk defensively in case the
+    // tree mutates while we walk it.
+    for _ in 0..1024 {
+        if current == window {
+            return Ok(true);
+        }
+        let reply = conn
+            .translate_coordinates(root, current, point.x() as i16, point.y() as i16)
+            .map_err(|e| format!("Failed to hit-test window {window}: {e}"))?
+            .reply()
+            .map_err(|e| format!("Failed to hit-test window {window}: {e}"))?;
+        if reply.child == x11rb::NONE {
+            return Ok(false);
+        }
+        current = reply.child;
+    }
+    Ok(false)
+}
+
+/// Raises `window` to the top of the stacking order without changing any keyboard focus.
+///
+/// Under a window manager the request is redirected to the WM, which generally honors client
+/// raise requests (focus-stealing prevention may deny it, so callers must re-check visibility
+/// afterwards). Without a WM the server restacks the window directly.
+pub fn raise(conn: &RustConnection, window: xproto::Window) -> Result<(), String> {
+    conn.configure_window(
+        window,
+        &xproto::ConfigureWindowAux::new().stack_mode(StackMode::ABOVE),
+    )
+    .map_err(|e| format!("Failed to raise window {window}: {e}"))?;
+    conn.flush()
+        .map_err(|e| format!("Failed to flush X11 connection: {e}"))?;
+    Ok(())
+}

--- a/specs/x11-background-computer-use/TECH.md
+++ b/specs/x11-background-computer-use/TECH.md
@@ -1,0 +1,153 @@
+# Linux X11 Background Computer Use — TECH.md
+
+Status: implemented on `daniel/x11-background-computer-use`; this spec describes the design as
+shipped at commit `1af88ebc` and the remaining validation gaps.
+
+## Context
+
+Background computer use lets the agent drive one specific window — clicks, typing, scrolling,
+per-window screenshots — without moving the user's cursor, stealing the user's keyboard focus,
+or perturbing the user's modifier state. The cross-platform contract predates this work and is
+platform-neutral:
+
+- [`Target` @ 1af88ebc](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/lib.rs#L143) — per-action `Screen` vs `Window { window_id, pid }` targets; [`Options.background_enabled`](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/lib.rs#L445) forces the byte-identical legacy full-screen path when off.
+- [`ActionResult`](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/lib.rs#L469) — returns a refreshed [`WindowInfo`](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/lib.rs#L184) list (so the model can pick targets) and [`CapturedWindow`](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/lib.rs#L198) metadata mapping window-local coordinates onto window screenshots.
+- Capability gate: [`background_supported()` @ 1af88ebc](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/lib.rs#L87) (which also documents the per-platform limitations) feeds [`supports_background_computer_use` in the agent request settings](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/app/src/ai/agent/api/impl.rs#L104); execution is additionally gated by [`FeatureFlag::BackgroundComputerUse`](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/app/src/ai/blocklist/action_model/execute/request_computer_use.rs#L95).
+
+macOS implements this by posting Quartz events directly to the owning process
+([`PostTarget::Pid` / `CGEventPostToPid` @ 1af88ebc](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/mac/post.rs#L9)
+plus private window-addressing fields), so it can drive fully covered windows with zero visible
+side effects. X11 has no process- or window-addressed delivery that applications honor: the only
+window-addressed primitive, `XSendEvent`, marks events `send_event=true`, which GTK, Qt,
+Chromium, and WINE deliberately ignore. The X11 design therefore had to be built on genuinely
+different primitives, and its trade-offs differ from macOS.
+
+## Design
+
+### Core mechanism: an MPX "agent seat"
+
+X11 (XInput2 ≥ 2.0, any server since 2009, including Xvfb) supports multiple independent master
+pointer/keyboard pairs (Multi-Pointer X). Each master pair has its own on-screen cursor and its
+own keyboard focus, and the server creates matching XTEST slave devices for every pair. The X
+server routes a client's *core* input requests — XTEST fake input, `WarpPointer`,
+`QueryPointer`, `SetInputFocus` — through that client's "ClientPointer" master pair
+(`PickPointer`/`PickKeyboard` in the server's `Xext/xtest.c`).
+
+[`seat.rs::AgentSeat::new` @ 1af88ebc](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/linux/x11/seat.rs#L61)
+exploits exactly that: it opens a dedicated connection, creates a private master pair named
+`warp-agent-cu-<pid>-<seq>` via `XIChangeHierarchy(AddMaster)`, and points the connection's
+ClientPointer at it via `XISetClientPointer`. The pre-existing XTEST mouse/keyboard code then
+drives the agent seat completely unchanged. Consequences:
+
+- Applications receive real, server-generated device input (`synthetic NO`) — full compatibility
+  with every toolkit, unlike `XSendEvent`.
+- The user's cursor position, keyboard focus, and modifier state are properties of the user's
+  own master pair and are never touched. Agent typing follows the agent keyboard's focus, set
+  per action with `XISetFocus`, even while the target window is covered.
+- A second visible cursor exists while a window-targeted batch runs (the seat lives for the
+  `Actor`'s lifetime, i.e. one tool call).
+
+Rejected alternatives: `XSendEvent` synthetic events (silently ignored by major toolkits);
+focus/pointer save-restore juggling on the user's seat (races with concurrent user input, not
+actually background).
+
+### Seat lifecycle and leak safety
+
+Master devices are server-global and outlive the creating connection, so
+[`seat.rs`](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/linux/x11/seat.rs)
+treats leaks as a first-class concern:
+
+- `Drop` removes the pair ([`impl Drop` @ L155](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/linux/x11/seat.rs#L155)); every construction failure path after `AddMaster` either removes the pair or unregisters it so the next creation reaps it.
+- A process-local live-seat registry ([`live_seats` @ L177](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/linux/x11/seat.rs#L177)) reserves names before `AddMaster` so concurrent creations cannot reap an in-construction pair.
+- [`remove_stale_seats` @ L271](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/linux/x11/seat.rs#L271) runs at every creation: same-pid seats absent from the registry (leaked by failed constructions) and seats of dead pids (crashed processes, parsed from the seat name) are removed. Foreign pid reuse can delay reaping until the reusing process exits — a bounded, accepted residual.
+- The `use_computer` CLI returns `ExitCode` instead of calling `process::exit`, so `Drop` always
+  runs on error exits.
+
+### Per-target action routing
+
+[`x11/mod.rs::perform_actions` @ 1af88ebc](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/linux/x11/mod.rs#L171):
+
+- Prevalidates the batch (rejects the `window_id: 0` sentinel, macOS parity) and creates the
+  seat up front so failures cannot half-apply a batch. `Screen` actions keep the legacy path on
+  the user's core pointer/keyboard; with `background_enabled == false` behavior is identical to
+  the pre-existing implementation.
+- Window coordinates are window-local pixels, translated to root coordinates with bounds
+  validation ([`windows.rs::window_local_to_root` @ L265](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/linux/x11/windows.rs#L265)) — an out-of-bounds point would otherwise land on an unrelated window.
+- X11 delivers pointer events to the topmost window under the pointer, so clicks and scrolls
+  first hit-test the target at the point ([`window_hit_at_point` @ L298](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/linux/x11/windows.rs#L298) walks the same root-down `TranslateCoordinates` chain the server uses for event picking, which also handles WM reparenting frames). A covered target is raised *without focus* via `ConfigureWindow(Above)` and re-checked with a 500 ms poll ([`ensure_window_clickable_at` @ L135](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/linux/x11/mod.rs#L135)); the action fails with an actionable error if the raise does not take effect.
+- Key/type actions set the agent keyboard's focus to the target first; clicks do the same to
+  mirror a real click's focus effect on the agent seat only.
+
+### Window enumeration and screenshots
+
+- [`windows.rs::enumerate_windows` @ L74](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/linux/x11/windows.rs#L74): EWMH `_NET_CLIENT_LIST_STACKING` (reversed to front-to-back) with `_NET_CLIENT_LIST` and a `QueryTree` fallback for WM-less servers (bare Xvfb in cloud environments); titles from `_NET_WM_NAME`/`WM_NAME`, pid from `_NET_WM_PID`, app name from `WM_CLASS`. On X11 the `pid` is informational — delivery is addressed by window id.
+- [`screenshot.rs::take_window` @ L72](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/linux/x11/screenshot.rs#L72): Composite-extension capture ([`capture_via_composite` @ L161](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/linux/x11/screenshot.rs#L161): per-client `RedirectWindow(Automatic)` — auto-released at disconnect — plus `NameWindowPixmap`, honoring `border_width`) sees full contents of covered windows; falls back to direct `GetImage` on the window drawable. Native capture size is capped at [`MAX_WINDOW_CAPTURE_PIXELS` @ L18](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/linux/x11/screenshot.rs#L18) (32 Mi px, covers 8K) since the reply and RGB buffers are allocated at native size before downscaling limits apply.
+- Capability probing: [`linux/mod.rs::background_supported` @ L34](https://github.com/warpdotdev/warp/blob/1af88ebc4f77304eecd17b3ff5d47e85301afa7a/crates/computer_use/src/linux/mod.rs#L34) requires X11 (not Wayland — the portal path has no per-window targeting) plus a `OnceLock`-cached XI 2.x probe.
+
+## Testing and validation
+
+Validated on a remote Linux agent against the pre-hardening tree (all passing under
+Xvfb 1280x800, no WM):
+
+1. Enumeration lists windows front-to-back with ids/pids; empty display yields an empty list.
+2. Background click delivers `ButtonPress`/`Release` with exact window-local coordinates
+   (verified via `xev`) while the user's core pointer position is unchanged.
+3. Background typing delivers `KeyPress`/`Release`; typing into a *covered* xterm lands
+   (verified via `cat > file` in the xterm).
+4. Clicking a covered point auto-raises the target and succeeds; stacking order confirms.
+5. Covered-window screenshots capture correct dimensions and content (no bleed-through from the
+   covering window); region capture crops correctly.
+6. Device hygiene: `xinput list` shows the seat (master pair + XTEST slaves) only during a run
+   and is byte-identical to baseline afterwards.
+7. Legacy regression: screen-targeted actions still move the core pointer.
+
+Static checks: `cargo check -p computer_use`, `cargo clippy --all-targets -- -D warnings`, and
+`cargo fmt --check` pass on Linux for the initial implementation; macOS host build unaffected.
+
+Remaining gaps to close before/at rollout:
+
+- The review-hardening commit (`1af88ebc`, error-path cleanup + CLI validation + capture cap)
+  compiles on macOS but its Linux-only files have only been hand-reviewed; a Linux
+  `cargo check`/clippy run (CI or a one-off remote agent) plus a re-run of the Xvfb matrix above
+  is cheap and recommended.
+- Real-WM desktops (Mutter/KWin/i3, with a compositor): raise redirection and click-to-focus
+  side effects are documented but not yet exercised.
+- Non-US layouts and XI2-native clients (keymap divergence, see Risks).
+
+## Parallelization
+
+None proposed: the implementation is complete on this branch, and the remaining work is a
+single small remote validation job with no independent subtasks worth fanning out.
+
+## Risks and mitigations
+
+1. Under click-to-focus WMs, an agent *click* can trigger the WM's own core passive grab, which
+   may raise the window and move the user's focus to it (typing has no such side effect).
+   Documented on `background_supported`; WM-less cloud environments are unaffected.
+2. A WM's focus-stealing prevention may deny the auto-raise; the action then fails after 500 ms
+   with an error naming the covered point. Follow-up: EWMH `_NET_RESTACK_WINDOW` with a pager
+   source is the sanctioned mechanism.
+3. Keymap divergence: keycodes are resolved against the core keyboard map, which mainstream
+   toolkits also use to interpret events, but the agent seat's XTEST slave carries a
+   server-default keymap that XI2-native clients could consult; combined with the pre-existing
+   Shift-only resolver, non-US layouts (AltGr/levels/groups/dead keys) are not fully supported —
+   same as the legacy screen path.
+4. Composite capture of regions covered *before* redirection may be stale until the app
+   repaints; agent interactions trigger repaints, and the direct-capture fallback degrades
+   gracefully.
+5. A batch that presses on one target and releases on another can strand held input on the
+   first seat. The macOS implementation has the same semantic; in practice the model emits
+   down/up pairs against one target per call.
+6. Hit-test-then-click is not atomic; another client can restack between the check and the
+   press. Accepted: the same race applies to a human click, and serializing via `GrabServer`
+   would freeze all clients.
+
+## Follow-ups
+
+- XKB-aware key resolution (AltGr/levels/groups) and cloning the user's keymap onto the agent
+  keyboard.
+- `_NET_RESTACK_WINDOW`-based raising for WM desktops.
+- Scanline-stride/byte-order-aware image conversion in the (pre-existing) X11 image converter.
+- Cursor-position reporting for keyboard-only window batches currently falls back to the user's
+  core pointer position (cosmetic).
+- Optionally reject target switches while buttons/keys are held (risk 5).


### PR DESCRIPTION
## Description

Implements background (per-window) computer use for Linux X11, bringing the capability we already ship on macOS to X11 environments: the agent can drive a specific window — click, type, scroll, and screenshot it — without moving the user's cursor, stealing the user's keyboard focus, or perturbing modifier state.

macOS posts events directly to the target process (`CGEventPostToPid`), which has no X11 equivalent (`XSendEvent` synthetic events are ignored by GTK/Qt/Chromium/WINE). The X11 design instead uses an **MPX "agent seat"**:

- A private XInput2 master pointer/keyboard pair is created per session (`warp-agent-cu-<pid>-<seq>`), and a dedicated connection's ClientPointer is pointed at it — the X server then routes the existing XTEST input code through the agent seat unchanged. Apps receive real (non-synthetic) input; the user's seat is untouched. Seat lifecycle is leak-safe (removed on drop, stale seats reaped at creation).
- Window enumeration via EWMH client lists (with a `QueryTree` fallback for WM-less Xvfb in cloud environments); per-window screenshots via the Composite extension, so covered windows capture correctly.
- X11 pointer events are position-routed, so clicks/scrolls hit-test the target and auto-raise it (without focusing) when covered. Platform limitations are documented on `computer_use::background_supported()`.

No app-layer changes: the existing `BackgroundComputerUse` feature flag and `supports_background_computer_use` wiring pick up the new runtime capability probe automatically.

Design details, validation matrix, risks, and follow-ups: `specs/x11-background-computer-use/TECH.md`.

Implemented with Oz: https://staging.warp.dev/conversation/5af8d8c2-6355-4413-8398-26d7f0393cb1

## Testing

- Linux (remote agent): `cargo check`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all clean.
- Functional matrix under Xvfb via the `use_computer` CLI, all passing: window enumeration ordering; background click with exact window-local coordinate delivery (verified via `xev`) while the user's pointer stays put; background typing, including into a covered window; auto-raise on covered clicks; covered-window and region screenshots (correct dimensions/content); input-device cleanup after every run (`xinput list` matches baseline); legacy screen-path regression (unchanged behavior).
- The follow-up review-hardening commit compiles on macOS; Linux CI covers its Linux-only files.
- [ ] I have manually tested my changes locally with `./script/run` — not applicable on this macOS machine; the Linux-only paths were exercised end-to-end via the CLI matrix above.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
