### PR TITLE
fix: update ws to 8.21.0 to resolve CVE-2026-48779

### DIFF
--- a/crates/warp_graphql_schema/package.json
+++ b/crates/warp_graphql_schema/package.json
@@ -16,6 +16,7 @@
   "resolutions": {
     "immutable": "3.8.3",
     "lodash": "4.18.1",
-    "@babel/core": "7.29.6"
+    "@babel/core": "7.29.6",
+    "ws": "8.21.0"
   }
 }

--- a/crates/warp_graphql_schema/yarn.lock
+++ b/crates/warp_graphql_schema/yarn.lock
@@ -2426,10 +2426,10 @@ wrap-ansi@^7.0.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
-ws@^8.17.1, ws@^8.18.3:
-  version "8.18.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
-  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
+ws@8.21.0, ws@^8.17.1, ws@^8.18.3:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
## Summary
Resolves a high-severity DoS vulnerability in the `ws` package (memory exhaustion from tiny fragments and data chunks).

- **Advisory:** [GHSA-96hv-2xvq-fx4p](https://github.com/websockets/ws/security/advisories/GHSA-96hv-2xvq-fx4p) / [CVE-2026-48779](https://nvd.nist.gov/vuln/detail/CVE-2026-48779)
- **Dependabot alert:** https://github.com/warpdotdev/warp/security/dependabot/15
- **Severity:** High (CVSS 7.5)

## Change
`ws` is a **transitive** (dev-scope) dependency in `crates/warp_graphql_schema/yarn.lock`, previously resolved to `8.18.3` (vulnerable range `>= 8.0.0, < 8.21.0`).

Since `ws` is not a direct dependency, `yarn upgrade` did not move it. Added a `ws` entry to the `resolutions` field in `crates/warp_graphql_schema/package.json` to force the patched version, then ran `yarn install`:

- `ws` bumped `8.18.3` → `8.21.0` (patched)
- Existing constraints `^8.17.1` and `^8.18.3` are both satisfied by `8.21.0`, so no consumer code changes are required.

## Verification
- `yarn audit` → `0 vulnerabilities found - Packages audited: 435`
- The only remaining `ws`-prefixed entry below 8.21 is `@types/ws@8.18.1` (a types-only package, unaffected).

_Conversation: https://staging.warp.dev/conversation/335cfcf4-ee3d-4bad-aa56-2f857cda7c9d_

_Run: https://oz.staging.warp.dev/runs/019f479b-9200-7ed9-bdcc-e4999523d881_

_This PR was generated with [Oz](https://warp.dev/oz)._
