### PR TITLE
Install Windows bootstrap build dependencies

### DIFF
--- a/script/windows/bootstrap.ps1
+++ b/script/windows/bootstrap.ps1
@@ -65,7 +65,7 @@ function Show-BootstrapPreview {
     Write-Output ''
 }
 
-function Add-DirectoryToPathIfExists {
+function Add-DirectoryToPathIfPresent {
     param([string]$Path)
 
     if (-not $Path -or -not (Test-Path -Path $Path -PathType Container)) {
@@ -101,7 +101,7 @@ function Add-WinGetPackageCommandToPath {
         $command = Get-ChildItem -Path $packageDir.FullName -Filter "$CommandName.exe" -Recurse -ErrorAction SilentlyContinue |
             Select-Object -First 1
         if ($command) {
-            Add-DirectoryToPathIfExists $command.DirectoryName
+            Add-DirectoryToPathIfPresent $command.DirectoryName
             return
         }
     }
@@ -115,7 +115,7 @@ function Use-LibclangIfInstalled {
 
     foreach ($dir in $candidateDirs) {
         if (Test-Path -Path (Join-Path $dir 'libclang.dll') -PathType Leaf) {
-            Add-DirectoryToPathIfExists $dir
+            Add-DirectoryToPathIfPresent $dir
             $env:LIBCLANG_PATH = $dir
             return
         }
@@ -133,7 +133,7 @@ function Use-LibclangIfInstalled {
         $libclang = Get-ChildItem -Path $packageDir.FullName -Filter 'libclang.dll' -Recurse -ErrorAction SilentlyContinue |
             Select-Object -First 1
         if ($libclang) {
-            Add-DirectoryToPathIfExists $libclang.DirectoryName
+            Add-DirectoryToPathIfPresent $libclang.DirectoryName
             $env:LIBCLANG_PATH = $libclang.DirectoryName
             return
         }
@@ -162,11 +162,11 @@ if (-not $gitBinDir) {
     Write-Error 'https://gitforwindows.org/'
     exit 1
 }
-Add-DirectoryToPathIfExists $gitBinDir
+Add-DirectoryToPathIfPresent $gitBinDir
 
 # Some Rust build scripts depend on Unix patch.exe, which ships with Git for Windows.
 $gitUsrBinDir = Join-Path (Split-Path -Parent $gitBinDir) 'usr\bin'
-Add-DirectoryToPathIfExists $gitUsrBinDir
+Add-DirectoryToPathIfPresent $gitUsrBinDir
 
 function Resolve-CommonSkillsScript {
     param([string]$ScriptName)

--- a/script/windows/bootstrap.ps1
+++ b/script/windows/bootstrap.ps1
@@ -46,7 +46,7 @@ function Show-BootstrapPreview {
     Write-Output 'It will:'
     Write-Output '  - Check for Git for Windows.'
     Write-Output '  - Install Rust if cargo is unavailable.'
-    Write-Output '  - Install Visual Studio Build Tools, jq, CMake, InnoSetup, and gcloud as needed.'
+    Write-Output '  - Install Visual Studio Build Tools, jq, CMake, Protobuf, LLVM, InnoSetup, and gcloud as needed.'
     Write-Output '  - Install Cargo test dependencies.'
 
     if (-not $InstallCommonSkills) {
@@ -63,6 +63,81 @@ function Show-BootstrapPreview {
 
     Write-Output 'Run .\script\windows\bootstrap.ps1 -Help to see options and environment overrides.'
     Write-Output ''
+}
+
+function Add-DirectoryToPathIfExists {
+    param([string]$Path)
+
+    if (-not $Path -or -not (Test-Path -Path $Path -PathType Container)) {
+        return
+    }
+
+    $pathEntries = $env:PATH -split ';'
+    if ($pathEntries -notcontains $Path) {
+        $env:PATH = "$Path;$env:PATH"
+    }
+}
+
+function Add-WinGetPackageCommandToPath {
+    param(
+        [string]$CommandName,
+        [string]$PackageId
+    )
+
+    if (Get-Command -Name $CommandName -Type Application -ErrorAction SilentlyContinue) {
+        return
+    }
+
+    $winGetPackagesDir = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
+    if (-not (Test-Path -Path $winGetPackagesDir -PathType Container)) {
+        return
+    }
+
+    $escapedPackageId = [WildcardPattern]::Escape($PackageId)
+    $packageDirs = Get-ChildItem -Path $winGetPackagesDir -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -like "$escapedPackageId*" }
+
+    foreach ($packageDir in $packageDirs) {
+        $command = Get-ChildItem -Path $packageDir.FullName -Filter "$CommandName.exe" -Recurse -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if ($command) {
+            Add-DirectoryToPathIfExists $command.DirectoryName
+            return
+        }
+    }
+}
+
+function Use-LibclangIfInstalled {
+    $candidateDirs = @(
+        "$env:ProgramFiles\LLVM\bin",
+        "${env:ProgramFiles(x86)}\LLVM\bin"
+    )
+
+    foreach ($dir in $candidateDirs) {
+        if (Test-Path -Path (Join-Path $dir 'libclang.dll') -PathType Leaf) {
+            Add-DirectoryToPathIfExists $dir
+            $env:LIBCLANG_PATH = $dir
+            return
+        }
+    }
+
+    $winGetPackagesDir = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
+    if (-not (Test-Path -Path $winGetPackagesDir -PathType Container)) {
+        return
+    }
+
+    $packageDirs = Get-ChildItem -Path $winGetPackagesDir -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -like 'LLVM.LLVM*' }
+
+    foreach ($packageDir in $packageDirs) {
+        $libclang = Get-ChildItem -Path $packageDir.FullName -Filter 'libclang.dll' -Recurse -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if ($libclang) {
+            Add-DirectoryToPathIfExists $libclang.DirectoryName
+            $env:LIBCLANG_PATH = $libclang.DirectoryName
+            return
+        }
+    }
 }
 
 if ($Help) {
@@ -87,7 +162,12 @@ if (-not $gitBinDir) {
     Write-Error 'https://gitforwindows.org/'
     exit 1
 }
-$env:PATH = "$gitBinDir;$env:PATH"
+Add-DirectoryToPathIfExists $gitBinDir
+
+# Some Rust build scripts depend on Unix patch.exe, which ships with Git for Windows.
+$gitUsrBinDir = Join-Path (Split-Path -Parent $gitBinDir) 'usr\bin'
+Add-DirectoryToPathIfExists $gitUsrBinDir
+
 function Resolve-CommonSkillsScript {
     param([string]$ScriptName)
 
@@ -153,6 +233,14 @@ winget install jqlang.jq
 
 # CMake is needed to build some dependencies, e.g.: sentry-contrib-native.
 winget install -e --id Kitware.CMake
+
+# Protoc is required by prost-build for warp-proto-apis generated crates.
+winget install -e --id Google.Protobuf
+Add-WinGetPackageCommandToPath -CommandName 'protoc' -PackageId 'Google.Protobuf'
+
+# LLVM provides libclang.dll, which is required by bindgen-based build scripts.
+winget install -e --id LLVM.LLVM
+Use-LibclangIfInstalled
 
 # We use InnoSetup to build our release bundle installer.
 winget install -e --id JRSoftware.InnoSetup


### PR DESCRIPTION
## Description

Updates `script/windows/bootstrap.ps1` so a clean Windows source checkout installs the build tools needed by the Rust workspace:

- installs Protobuf via `Google.Protobuf` and adds the WinGet package `bin` directory to the current session PATH when needed
- installs LLVM via `LLVM.LLVM`, adds the detected LLVM bin directory to PATH, and sets `LIBCLANG_PATH` for the current session
- prepends Git for Windows `usr\bin` so build scripts can find `patch.exe`
- updates the bootstrap preview text to list Protobuf and LLVM

The Protobuf PATH handling intentionally discovers the WinGet package directory under `%LOCALAPPDATA%\Microsoft\WinGet\Packages` instead of assuming a `Program Files\protobuf\bin` install path.

## Linked Issue

Closes #11301

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `powershell -NoProfile -Command '$tokens=$null; $errors=$null; $null = [System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path "script\windows\bootstrap.ps1"), [ref]$tokens, [ref]$errors); if ($errors.Count -gt 0) { $errors | Format-List; exit 1 }; "PowerShell parse OK"'`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\script\windows\bootstrap.ps1 -Help`
- `git diff --check`
- Confirmed the Protobuf WinGet package discovery finds this machine's installed `protoc.exe` under `%LOCALAPPDATA%\Microsoft\WinGet\Packages\Google.Protobuf_Microsoft.Winget.Source_8wekyb3d8bbwe\bin\protoc.exe`.

I did not run the full bootstrap end-to-end because it can install packages and enter the existing gcloud authentication flow; this change is limited to dependency installation and current-session path setup.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

N/A - Windows bootstrap script change.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE
