### PR TITLE
Rename Slack labels to "Join our Slack community"

### DIFF
--- a/app/src/app_menus.rs
+++ b/app/src/app_menus.rs
@@ -931,7 +931,7 @@ fn make_new_help_menu() -> Menu {
             feedback_menu_item(),
             link_menu_item("Warp Documentation...", links::USER_DOCS_URL.into()),
             link_menu_item("GitHub Issues...", links::GITHUB_ISSUES_URL.into()),
-            link_menu_item("Warp Slack Community...", links::SLACK_URL.into()),
+            link_menu_item("Join our Slack community...", links::SLACK_URL.into()),
         ],
     )
 }

--- a/app/src/resource_center/view.rs
+++ b/app/src/resource_center/view.rs
@@ -46,7 +46,7 @@ impl ResourceCenterFooterItem {
     pub fn ui_label(&self) -> &'static str {
         match self {
             ResourceCenterFooterItem::Docs => "Docs",
-            ResourceCenterFooterItem::Slack => "Slack",
+            ResourceCenterFooterItem::Slack => "Join our Slack community",
             ResourceCenterFooterItem::Feedback => "Feedback",
         }
     }

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -9590,7 +9590,7 @@ impl Workspace {
         );
 
         items.extend([
-            MenuItemFields::new("Slack")
+            MenuItemFields::new("Join our Slack community")
                 .with_on_select_action(WorkspaceAction::JoinSlack)
                 .into_item(),
             MenuItem::Separator,


### PR DESCRIPTION
## Description
Renames the user-facing "Slack" labels to "Join our Slack community" so the call-to-action is clearer. This touches the three places that link to the Warp Slack community:
- **Resource Center footer** button (`app/src/resource_center/view.rs`)
- **Account/avatar dropdown** menu item (`app/src/workspace/view.rs`)
- **macOS Help menu** item (`app/src/app_menus.rs`)

Only the displayed text changes; the click behavior (opening the Slack community URL via `WorkspaceAction::JoinSlack` / `links::SLACK_URL`) is unchanged. The Command Palette entry (`workspace:link_to_slack`) already used this wording, so it was left as-is. Other "Slack" references in the app relate to the Oz Slack *integration* for cloud agents and were intentionally not touched.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
Text-only label changes. Verified formatting with `cargo fmt -p warp --check`.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

_Conversation: https://staging.warp.dev/conversation/e7e5f661-132e-44f9-a7a6-b2bf3eb1a7c5_
_Run: https://oz.staging.warp.dev/runs/019f4835-dd77-7e02-a42b-0bb6e40744aa_

_This PR was generated with [Oz](https://warp.dev/oz)._
