### PR TITLE
feat(oz-cli): add `oz run timeline` command to expose cloud agent setup trace

### DIFF
--- a/app/src/ai/agent_sdk/ambient.rs
+++ b/app/src/ai/agent_sdk/ambient.rs
@@ -12,7 +12,7 @@ use warp_cli::json_filter::JsonOutput;
 use warp_cli::task::{
     ArtifactTypeArg, ExecutionLocationArg, ListTasksArgs, MessageCommand, MessageDeliveredArgs,
     MessageListArgs, MessageReadArgs, MessageSendArgs, MessageWatchArgs, RunSortByArg,
-    RunSourceArg, RunStateArg, TaskGetArgs,
+    RunSourceArg, RunStateArg, TaskGetArgs, TimelineGetArgs,
 };
 use warp_cli::{GlobalOptions, SortOrderArg};
 use warp_core::channel::ChannelState;
@@ -39,7 +39,7 @@ use crate::cloud_object::model::persistence::CloudModel;
 use crate::server::ids::{ServerId, SyncId};
 use crate::server::server_api::ai::{
     AIClient, AgentMessageHeader, AgentRunEvent, AgentSource, ArtifactType, ExecutionLocation,
-    ListAgentMessagesRequest, ReadAgentMessageResponse, RunSortBy, RunSortOrder,
+    ListAgentMessagesRequest, ReadAgentMessageResponse, RunSortBy, RunSortOrder, RunTimelineEvent,
     SendAgentMessageRequest, SendAgentMessageResponse, SpawnAgentRequest, TaskListFilter,
 };
 use crate::server::server_api::ServerApi;
@@ -1371,6 +1371,19 @@ impl super::output::TableFormat for AgentMessageHeader {
     }
 }
 
+/// Fetch and display the setup timeline for a cloud agent run.
+pub fn get_run_timeline(
+    ctx: &mut AppContext,
+    global_options: GlobalOptions,
+    args: TimelineGetArgs,
+) -> anyhow::Result<()> {
+    let runner = ctx.add_singleton_model(|_ctx| AmbientAgentRunner);
+    let output_format = global_options.output_format;
+    runner.update(ctx, |runner, ctx| {
+        runner.get_timeline(args, output_format, ctx)
+    })
+}
+
 /// Get a conversation by conversation ID.
 pub fn get_conversation(ctx: &mut AppContext, conversation_id: String) -> anyhow::Result<()> {
     let runner = ctx.add_singleton_model(|_ctx| AmbientAgentRunner);
@@ -1420,6 +1433,84 @@ impl AmbientAgentRunner {
         self.spawn_command(future, ctx);
 
         Ok(())
+    }
+}
+
+impl AmbientAgentRunner {
+    fn get_timeline(
+        &self,
+        args: TimelineGetArgs,
+        output_format: OutputFormat,
+        ctx: &mut ModelContext<Self>,
+    ) -> anyhow::Result<()> {
+        let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
+
+        let future = async move {
+            let run_id = args.run_id;
+            let json_output = args.json_output;
+            if matches!(output_format, OutputFormat::Json) || json_output.force_json_output() {
+                // Return the raw server JSON for machine consumption.
+                let response: serde_json::Value = ai_client
+                    .get_run_timeline(&run_id)
+                    .await
+                    .map(|r| serde_json::to_value(&r).unwrap_or(serde_json::Value::Null))?;
+                super::output::print_raw_json(response, &json_output)?;
+            } else if matches!(output_format, OutputFormat::Ndjson) {
+                let response = ai_client.get_run_timeline(&run_id).await?;
+                for event in &response.events {
+                    super::output::write_json_line(event, std::io::stdout())?;
+                }
+            } else {
+                let response = ai_client.get_run_timeline(&run_id).await?;
+                print_timeline(&run_id, &response.events);
+            }
+            Ok(())
+        };
+        self.spawn_command(future, ctx);
+
+        Ok(())
+    }
+}
+
+/// Pretty-print a list of timeline events to stdout.
+fn print_timeline(run_id: &str, events: &[RunTimelineEvent]) {
+    if events.is_empty() {
+        println!("No timeline events found for run {run_id}.");
+        println!();
+        println!("Timeline events are recorded for remote (cloud) runs only.");
+        println!("Local runs do not go through the same setup state machine and will not have timeline events.");
+        return;
+    }
+
+    println!("\nSetup timeline for run {run_id}:");
+
+    let mut table = crate::ai::agent_sdk::output::standard_table();
+    for event in events {
+        let label = timeline_event_label(&event.event_type);
+        let ts = event
+            .occurred_at
+            .format("%Y-%m-%d %H:%M:%S UTC")
+            .to_string();
+        table.add_row(vec![format!("{label}  {ts}")]);
+    }
+    println!("{table}");
+}
+
+/// Return a human-readable label for a timeline event type.
+fn timeline_event_label(event_type: &str) -> &'static str {
+    match event_type {
+        "oz_run_created" => "🆕 Run created",
+        "oz_run_claimed" => "📋 Run claimed by worker",
+        "worker_container_ready" => "📦 Worker container ready",
+        "shared_session_started" => "🔗 Shared session established",
+        "agent_started" => "🤖 Agent started",
+        "oz_run_done" => "✅ Run completed",
+        "oz_run_blocked" => "🛑 Run blocked",
+        "oz_run_cancelled" => "🚫 Run cancelled",
+        "oz_run_failed" => "❌ Run failed",
+        "oz_run_errored" => "⚠️  Run errored",
+        "vm_shutdown" => "🔌 VM shutdown",
+        _ => "📌 Event",
     }
 }
 

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -585,6 +585,7 @@ fn run_task(
                 ambient::get_ambient_agent_task_status(ctx, global_options, args)
             }
         }
+        TaskCommand::Timeline(args) => ambient::get_run_timeline(ctx, global_options, args),
         TaskCommand::Conversation(conv_cmd) => {
             if !FeatureFlag::ConversationApi.is_enabled() {
                 return Err(anyhow::anyhow!(
@@ -1529,6 +1530,7 @@ fn command_requires_auth(command: &CliCommand) -> bool {
         CliCommand::Run(task_cmd) => match task_cmd {
             TaskCommand::List { .. } => true,
             TaskCommand::Get { .. } => true,
+            TaskCommand::Timeline { .. } => true,
             TaskCommand::Conversation { .. } => true,
             TaskCommand::Message { .. } => true,
         },
@@ -1707,6 +1709,7 @@ fn command_to_telemetry_event(command: &CliCommand) -> CliTelemetryEvent {
                 CliTelemetryEvent::TaskGet
             }
         }
+        CliCommand::Run(TaskCommand::Timeline(_)) => CliTelemetryEvent::RunTimelineGet,
         CliCommand::Run(TaskCommand::Conversation(_)) => CliTelemetryEvent::ConversationGet,
         CliCommand::Run(TaskCommand::Message(message_cmd)) => match message_cmd {
             MessageCommand::Watch(_) => CliTelemetryEvent::RunMessageWatch {

--- a/app/src/ai/agent_sdk/telemetry.rs
+++ b/app/src/ai/agent_sdk/telemetry.rs
@@ -75,6 +75,8 @@ pub(super) enum CliTelemetryEvent {
     ConversationGet,
     /// Executing `warp run get <id> --conversation`
     RunConversationGet,
+    /// Executing `warp run timeline <run_id>`
+    RunTimelineGet,
     /// Executing `warp run message watch`
     RunMessageWatch { harness: &'static str },
     /// Executing `warp run message send`
@@ -200,6 +202,7 @@ impl TelemetryEvent for CliTelemetryEvent {
             CliTelemetryEvent::TaskGet => None,
             CliTelemetryEvent::ConversationGet => None,
             CliTelemetryEvent::RunConversationGet => None,
+            CliTelemetryEvent::RunTimelineGet => None,
             CliTelemetryEvent::RunMessageWatch { harness } => Some(json!({ "harness": harness })),
             CliTelemetryEvent::RunMessageSend { harness } => Some(json!({ "harness": harness })),
             CliTelemetryEvent::RunMessageList { harness } => Some(json!({ "harness": harness })),
@@ -316,6 +319,7 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
             CliTelemetryEventDiscriminants::RunConversationGet => {
                 "CLI.Execute.Run.Conversation.Get"
             }
+            CliTelemetryEventDiscriminants::RunTimelineGet => "CLI.Execute.Run.Timeline.Get",
             CliTelemetryEventDiscriminants::RunMessageWatch => "CLI.Execute.Run.Message.Watch",
             CliTelemetryEventDiscriminants::RunMessageSend => "CLI.Execute.Run.Message.Send",
             CliTelemetryEventDiscriminants::RunMessageList => "CLI.Execute.Run.Message.List",
@@ -437,6 +441,9 @@ impl TelemetryEventDesc for CliTelemetryEventDiscriminants {
             }
             CliTelemetryEventDiscriminants::RunConversationGet => {
                 "Got run conversation from the Warp CLI"
+            }
+            CliTelemetryEventDiscriminants::RunTimelineGet => {
+                "Got run setup timeline from the Warp CLI"
             }
             CliTelemetryEventDiscriminants::RunMessageWatch => {
                 "Watched run messages from the Warp CLI"

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -407,6 +407,24 @@ pub struct AgentRunClientSetupMetricPayload {
     pub is_error: bool,
 }
 
+/// A single setup/lifecycle event recorded for a cloud agent run.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct RunTimelineEvent {
+    pub event_uuid: String,
+    pub run_id: String,
+    pub execution_id: Option<i64>,
+    pub event_type: String,
+    pub occurred_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<serde_json::Value>,
+}
+
+/// Response body for the `GET /agent/runs/:runId/timeline` endpoint.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct RunTimelineResponse {
+    pub events: Vec<RunTimelineEvent>,
+}
+
 impl AgentRunClientEventRequest {
     pub fn timeline_event(event_name: impl Into<String>, timestamp: DateTime<Utc>) -> Self {
         Self {
@@ -1481,6 +1499,12 @@ pub trait AIClient: 'static + Send + Sync {
         &self,
         run_id: &str,
     ) -> anyhow::Result<serde_json::Value, anyhow::Error>;
+
+    /// Fetch the setup/lifecycle timeline events for a cloud agent run.
+    async fn get_run_timeline(
+        &self,
+        run_id: &str,
+    ) -> anyhow::Result<RunTimelineResponse, anyhow::Error>;
 
     /// Generates AI copy for code-review flows: commit messages at dialog-open
     /// time and PR titles / bodies at confirm time. `output_type` in the
@@ -2912,6 +2936,16 @@ impl AIClient for ServerApi {
     ) -> anyhow::Result<serde_json::Value, anyhow::Error> {
         let response: serde_json::Value = self
             .get_public_api(&format!("agent/runs/{run_id}/conversation"))
+            .await?;
+        Ok(response)
+    }
+
+    async fn get_run_timeline(
+        &self,
+        run_id: &str,
+    ) -> anyhow::Result<RunTimelineResponse, anyhow::Error> {
+        let response: RunTimelineResponse = self
+            .get_public_api(&format!("agent/runs/{run_id}/timeline"))
             .await?;
         Ok(response)
     }

--- a/crates/warp_cli/src/task.rs
+++ b/crates/warp_cli/src/task.rs
@@ -12,6 +12,13 @@ pub enum TaskCommand {
     List(ListTasksArgs),
     /// Get status of a specific ambient agent task.
     Get(TaskGetArgs),
+    /// Show the setup timeline for a specific cloud agent run.
+    ///
+    /// Displays the sequence of setup and lifecycle events recorded during
+    /// the cloud agent's startup process (e.g. claimed, container ready,
+    /// shared session started, agent started). Useful for diagnosing
+    /// cloud start-up failures or slow setup commands.
+    Timeline(TimelineGetArgs),
     /// Retrieve the conversation for a specific run or conversation.
     #[command(subcommand)]
     Conversation(ConversationCommand),
@@ -25,6 +32,7 @@ impl TaskCommand {
         match self {
             TaskCommand::List(_) => "run list",
             TaskCommand::Get(_) => "run get",
+            TaskCommand::Timeline(_) => "run timeline",
             TaskCommand::Conversation(_) => "run conversation",
             TaskCommand::Message(_) => "run message",
         }
@@ -303,6 +311,17 @@ pub struct TaskGetArgs {
     /// Retrieve the conversation for this run instead of the run status.
     #[arg(long = "conversation")]
     pub conversation: bool,
+
+    /// JSON formatting configuration.
+    #[command(flatten)]
+    pub json_output: JsonOutput,
+}
+
+/// Arguments for the `run timeline` subcommand.
+#[derive(Debug, Clone, Args)]
+pub struct TimelineGetArgs {
+    /// The run ID whose setup timeline should be displayed.
+    pub run_id: String,
 
     /// JSON formatting configuration.
     #[command(flatten)]


### PR DESCRIPTION
## Description

Adds a new `oz run timeline <run_id>` CLI subcommand that fetches and displays the sequence of setup and lifecycle events recorded during a cloud agent run's startup process, providing parity with the Warp terminal's setup trace view.

The command calls the existing `GET /agent/runs/:runId/timeline` server endpoint and supports all output formats:
- **Pretty** (default): human-readable table with labeled events and timestamps
- **JSON** (`--output-format json`): full JSON response for machine consumption
- **NDJSON** (`--output-format ndjson`): one event per line for streaming/scripting

Example output:
```
Setup timeline for run abc123:
┌────────────────────────────────────────────────────────────────────────┐
│ 🆕 Run created          2025-01-15 10:30:00 UTC                        │
│ 📋 Run claimed by worker  2025-01-15 10:30:02 UTC                      │
│ 📦 Worker container ready 2025-01-15 10:30:15 UTC                      │
│ 🔗 Shared session established 2025-01-15 10:30:18 UTC                  │
│ 🤖 Agent started        2025-01-15 10:30:45 UTC                        │
└────────────────────────────────────────────────────────────────────────┘
```

This is particularly useful for diagnosing cloud start-up failures or slow setup commands when iterating on environment setup scripts.

## Linked Issue

Fixes [REMOTE-2113](https://linear.app/warp/issue/REMOTE-2113)

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

The implementation follows the same patterns as `oz run get` and `oz run conversation get`. The server endpoint (`GET /agent/runs/:runId/timeline`) is already implemented and working.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-OZ: Added `oz run timeline <run_id>` CLI command to inspect the cloud agent setup/lifecycle trace, providing parity with the Warp terminal's setup trace view.
-->

_Conversation: https://staging.warp.dev/conversation/372de480-327b-4037-94dc-494d77f2f6be_
_Run: https://oz.staging.warp.dev/runs/019f4844-2da6-738f-858b-1664e5a3d02a_

_This PR was generated with [Oz](https://warp.dev/oz)._
