### PR TITLE
Force PTY allocation in SSH wrapper

### DIFF
--- a/app/assets/bundled/bootstrap/bash_body.sh
+++ b/app/assets/bundled/bootstrap/bash_body.sh
@@ -1068,7 +1068,7 @@ if [ -z "$WARP_BOOTSTRAPPED" ]; then
             # the remote shell is the Bourne shell to avoid asking it to parse later lines that use syntax it doesn't
             # support.
             command ssh -o ControlMaster=$control_master_mode -o ControlPath="$control_path" \
-            -t "${@:1}" \
+            -tt "${@:1}" \
 "
 export TERM_PROGRAM='WarpTerminal'
 # Mark the remote side of a Warp-managed SSH session so the bootstrap

--- a/app/assets/bundled/bootstrap/fish.sh
+++ b/app/assets/bundled/bootstrap/fish.sh
@@ -690,7 +690,7 @@ if test "$WARP_IS_LOCAL_SHELL_SESSION" = "1"
         # the remote shell is the Bourne shell to avoid asking it to parse later lines that use syntax it doesn't
         # support.
         command ssh -o ControlMaster=$control_master_mode -o ControlPath="$control_path" \
-        -t $argv \
+        -tt $argv \
 "
 export TERM_PROGRAM='WarpTerminal'
 test -n '$WARP_CLIENT_VERSION' && export WARP_CLIENT_VERSION='$WARP_CLIENT_VERSION'

--- a/app/assets/bundled/bootstrap/zsh_body.sh
+++ b/app/assets/bundled/bootstrap/zsh_body.sh
@@ -996,7 +996,7 @@ if [[ -z $WARP_BOOTSTRAPPED ]]; then
           # the remote shell is the Bourne shell to avoid asking it to parse later lines that use syntax it doesn't
           # support.
           command ssh -o ControlMaster=$control_master_mode -o ControlPath="$control_path" \
-          -t "${@:1}" \
+          -tt "${@:1}" \
 "
 export TERM_PROGRAM='WarpTerminal'
 # Mark the remote side of a Warp-managed SSH session so the bootstrap

--- a/app/src/terminal/bootstrap_tests.rs
+++ b/app/src/terminal/bootstrap_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::ASSETS;
 
 struct TestAssetProvider;
 
@@ -59,6 +60,28 @@ fn test_trims_powershell_specifics() {
     );
 }
 
+#[test]
+fn ssh_wrapper_forces_pty_allocation() {
+    let bash = decode_asset("bundled/bootstrap/bash_body.sh");
+    assert!(bash.contains(r#"-tt "${@:1}" \"#));
+    assert!(!bash.contains(r#"-t "${@:1}" \"#));
+
+    let zsh = decode_asset("bundled/bootstrap/zsh_body.sh");
+    assert!(zsh.contains(r#"-tt "${@:1}" \"#));
+    assert!(!zsh.contains(r#"-t "${@:1}" \"#));
+
+    let fish = decode_asset("bundled/bootstrap/fish.sh");
+    assert!(fish.contains("-tt $argv \\"));
+    assert!(!fish.contains("-t $argv \\"));
+}
+
 fn decode_script(bytes: &[u8]) -> &str {
     std::str::from_utf8(bytes).expect("should not fail to decode")
+}
+
+fn decode_asset(path: &str) -> String {
+    let bytes = ASSETS.get(path).expect("asset should exist");
+    std::str::from_utf8(&bytes)
+        .expect("asset should be valid utf-8")
+        .to_string()
 }


### PR DESCRIPTION
## Description
Force the legacy SSH wrapper to request a PTY with `-tt` instead of `-t` when opening the ControlMaster-backed interactive SSH session.

The wrapper only handles commands that were already classified as interactive SSH sessions, so this makes PTY allocation explicit for environments where local TTY detection can be unreliable, such as MSYS2/Git Bash on Windows.

## Linked Issue
Closes #9136

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [x] `cargo test -p warp ssh_wrapper_forces_pty_allocation -- --nocapture`
- [x] `cargo check -p warp --tests`
- [x] Local ConPTY protocol probe with Git Bash `bash 5.2.37` / OpenSSH `10.2p1` against a temporary Paramiko SSH server; confirmed the wrapper path sends a `pty` request and then an `exec` request with the Warp bootstrap payload.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A - shell bootstrap behavior; protocol-level verification is described above.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed SSH wrapper PTY allocation for interactive SSH sessions on Windows/MSYS2.
