### PR TITLE
fix the way ReadHistoryContentsError is reported

### DIFF
--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -2,6 +2,8 @@ pub mod active_session;
 pub mod command_executor;
 
 use std::collections::{HashMap, HashSet};
+#[cfg(windows)]
+use std::ffi::OsStr;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::Deref;
@@ -24,6 +26,8 @@ use version_compare::Version;
 use warp_completer::completer::{
     CommandExitStatus, CommandOutput, PathSeparators, TopLevelCommandCaseSensitivity,
 };
+use warp_core::errors::ErrorExt;
+use warp_core::register_error;
 use warp_util::path::{
     convert_msys2_to_windows_native_path, convert_wsl_to_windows_host_path, msys2_exe_to_root,
     ShellFamily,
@@ -44,25 +48,28 @@ use crate::terminal::warpify::SubshellSource;
 use crate::terminal::{History, ShellHost, ShellLaunchData};
 
 #[derive(thiserror::Error, Debug)]
-pub enum ReadHistoryContentsError {
+enum ReadHistoryContentsError {
     #[cfg(windows)]
-    #[error("Couldn't get path to history file")]
-    HistoryFilePathError,
-
-    #[cfg(windows)]
-    #[error("Error running PowerShell commands to read history file: {0}")]
+    #[error("Error running PowerShell commands to read history file")]
     PowerShellError(anyhow::Error),
 
+    #[error("Error reading history file from filesystem")]
+    AsyncFsError(#[source] std::io::Error),
+
     #[cfg(windows)]
-    #[error("Error running PowerShell commands and reading from filesystem to read history file. PowerShell error: {powershell_error}, filesystem error: {async_fs_error}")]
+    #[error("Error running PowerShell commands and reading from filesystem to read history file.")]
     PowerShellAndAsyncFsError {
         powershell_error: anyhow::Error,
         async_fs_error: std::io::Error,
     },
-
-    #[error("Error reading history file from filesystem: {0}")]
-    AsyncFsError(std::io::Error),
 }
+
+impl ErrorExt for ReadHistoryContentsError {
+    fn is_actionable(&self) -> bool {
+        true
+    }
+}
+register_error!(ReadHistoryContentsError);
 
 // SessionId is defined in warp_core and re-exported here for backward compatibility.
 pub use warp_core::SessionId;
@@ -1376,8 +1383,7 @@ impl Session {
                 {
                     Ok(contents) => contents,
                     Err(e) => {
-                        report_error!(anyhow::Error::new(e)
-                            .context("Failed to read history contents for file"));
+                        report_error!(e);
                         continue;
                     }
                 };
@@ -1419,15 +1425,14 @@ impl Session {
         history_file: &Path,
         is_kaspersky_running: bool,
     ) -> Result<Vec<u8>, ReadHistoryContentsError> {
-        let Some(history_file_path) = history_file.as_os_str().to_str() else {
-            return Err(ReadHistoryContentsError::HistoryFilePathError);
-        };
-
         // Try reading the history file using PowerShell commands first.
-        let powershell_error = match Self::read_history_via_powershell(history_file_path).await {
-            Ok(result) => return Ok(result),
-            Err(e) => e,
-        };
+        let powershell_error =
+            match Self::read_history_via_powershell(history_file.as_os_str()).await {
+                Ok(result) => return Ok(result),
+                Err(e) => e,
+            };
+        log::error!("{powershell_error:#}");
+        report_error!(&powershell_error);
 
         // If Kaspersky is running, early return since we can't use [`async_fs`] to read the history
         // file.
@@ -1474,7 +1479,7 @@ impl Session {
     }
 
     #[cfg(windows)]
-    async fn read_history_via_powershell(history_file_path: &str) -> Result<Vec<u8>> {
+    async fn read_history_via_powershell(history_file_path: &OsStr) -> Result<Vec<u8>> {
         let Some(powershell_command) = crate::util::windows::any_powershell_path() else {
             return Err(anyhow::anyhow!(
                 "Failed to find powershell executable to read history"
@@ -1485,9 +1490,12 @@ impl Session {
             .arg("-NoProfile")
             .arg("-NoLogo")
             .arg("-Command")
-            .arg(format!(
-                "[System.IO.File]::ReadAllText('{history_file_path}')"
-            ))
+            .arg({
+                let mut cmd = std::ffi::OsString::from("[System.IO.File]::ReadAllText('");
+                cmd.push(history_file_path);
+                cmd.push("')");
+                cmd
+            })
             .output()
             .await;
         match read_result {


### PR DESCRIPTION
## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
