### PR TITLE
Fix stale BlocklistAIHistoryModel::new call breaking master test builds

### DIFF
--- a/app/src/ai/conversation_details_panel_tests.rs
+++ b/app/src/ai/conversation_details_panel_tests.rs
@@ -432,7 +432,8 @@ fn test_oz_run_url_present_for_task_and_absent_for_conversation() {
     // `oz_run_url` yields a URL, which happens for task-backed runs but not for
     // plain local conversations.
     App::test((), |mut app| async move {
-        let _history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], &[]));
+        let _history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
         let task_id = "550e8400-e29b-41d4-a716-000000004050";
         let task = create_test_task(task_id);
 


### PR DESCRIPTION
## Description
Fixes test builds on master, which are currently red: #13437 landed a details-panel test calling the **2-argument** `BlocklistAIHistoryModel::new(vec![], &[])`, which predates the `prompt_history` parameter — every sibling call site in `conversation_details_panel_tests.rs` already passes three arguments. Any target that compiles workspace tests fails with `E0061` (`Formatting + Clippy` on PRs, and master's `Populate Build Cache` run on `37df8314d`).

This aligns the one stale call with the 3-argument signature:

```rust
BlocklistAIHistoryModel::new(vec![], vec![], &[])
```

## Linked Issue
Build fix for a semantic merge conflict from #13437; no issue.
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. (N/A — build fix)
- [ ] Where appropriate, screenshots or a short video of the implementation are included below. (N/A — test-only build fix)

## Testing
- `cargo nextest run -p warp -E 'test(oz_run_url_present_for_task)'` — compiles the fixed test target and the affected test passes (1/1).

- [ ] I have manually tested my changes locally with `./script/run-tui` (N/A — test-only change)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable
CHANGELOG-NONE
-->

Co-Authored-By: Oz <oz-agent@warp.dev>
