### PR TITLE
fix(link-detection): treat fullwidth/CJK punctuation as URL terminators

### DIFF
--- a/app/src/terminal/model/grid/grid_handler.rs
+++ b/app/src/terminal/model/grid/grid_handler.rs
@@ -147,6 +147,36 @@ pub fn is_file_link_separator(c: char) -> bool {
     )
 }
 
+/// Returns true when `c` should terminate a clickable URL.
+///
+/// Beyond the explicit ASCII set in [`URL_SEPARATORS`] (per RFC 3986 invalid
+/// URL characters), any non-ASCII Unicode whitespace or punctuation also acts
+/// as a boundary. This prevents trailing fullwidth/CJK punctuation such as
+/// `，` (U+FF0C) or `。` (U+3002) common in CJK prose from being captured as
+/// part of a URL when no ASCII whitespace follows the link. Mirrors the
+/// boundary logic in [`is_file_link_separator`]. Connectors (`Pc`) and dashes
+/// (`Pd`) are excluded since they can appear in valid URLs (e.g. query
+/// parameters, IDN).
+pub fn is_url_separator(c: char) -> bool {
+    if URL_SEPARATORS.contains(&c) {
+        return true;
+    }
+    if c.is_ascii() {
+        return false;
+    }
+    if c.is_whitespace() {
+        return true;
+    }
+    matches!(
+        get_general_category(c),
+        GeneralCategory::OpenPunctuation
+            | GeneralCategory::ClosePunctuation
+            | GeneralCategory::InitialPunctuation
+            | GeneralCategory::FinalPunctuation
+            | GeneralCategory::OtherPunctuation
+    )
+}
+
 /// Represents a range of cells with information on their combined content and total
 /// cell width.
 #[derive(Debug, PartialEq, Eq)]
@@ -712,7 +742,7 @@ impl GridHandler {
             !cell
                 .flags
                 .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
-                && URL_SEPARATORS.contains(&cell.c)
+                && is_url_separator(cell.c)
         };
         // If the point is on a separator, return directly because this can't be
         // part of a url.
@@ -779,6 +809,15 @@ impl GridHandler {
 
             if current_point >= original_point {
                 passed_point = true;
+            }
+
+            // Treat CJK/fullwidth punctuation and other URL separators as URL
+            // terminators before feeding the character to the locator, preventing
+            // trailing punctuation from being captured as part of the URL.
+            if !item.cell().flags.intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
+                && is_url_separator(item.cell().c)
+            {
+                break;
             }
 
             let last_state = mem::replace(&mut state, locator.advance(item.cell().c));

--- a/app/src/util/link_detection.rs
+++ b/app/src/util/link_detection.rs
@@ -12,7 +12,7 @@ use crate::ai::agent::{AIAgentActionType, AIAgentOutput, AIAgentTextSection, Rea
 use crate::ai::blocklist::block::view_impl::output::LinkActionConstructors;
 use crate::ai::blocklist::block::TextLocation;
 use crate::terminal::links::should_directly_open_link;
-use crate::terminal::model::grid::grid_handler::is_file_link_separator;
+use crate::terminal::model::grid::grid_handler::{is_file_link_separator, is_url_separator};
 use crate::terminal::ShellLaunchData;
 
 cfg_if::cfg_if! {
@@ -201,6 +201,19 @@ fn detect_urls(text: &str) -> Vec<Range<usize>> {
         // Reference to https://docs.rs/urlocator/latest/urlocator/#example-url-boundaries
         // We know we have fully parsed an url when the locator advances from the `UrlLocation::Url`
         // to the `UrlLocation::Reset` stage.
+        //
+        // Treat CJK/fullwidth punctuation and other URL-invalid characters as hard terminators
+        // before feeding the character to the locator, so trailing punctuation in CJK prose
+        // (e.g. `https://example.com，`) is not captured as part of the URL.
+        if is_url_separator(c) {
+            if let Some((start, end)) = start.zip(end) {
+                url_ranges.push(start..end);
+            }
+            locator = UrlLocator::new();
+            start = None;
+            end = None;
+            continue;
+        }
         match locator.advance(c) {
             UrlLocation::Url(length, end_offset) => {
                 end = Some(1 + i - end_offset as usize);


### PR DESCRIPTION
## Summary

Fixes #13088.

Warp's link detection included trailing fullwidth/CJK punctuation (e.g. `，` U+FF0C, `。` U+3002, `：` U+FF1A) as part of clickable URLs when those characters immediately followed a URL in CJK prose or AI output. This happened because:

1. **Terminal grid URL detection** (`url_at_point`): The `is_at_boundary` check used only the ASCII-only `URL_SEPARATORS` set, so the backward/forward scans did not terminate at non-ASCII punctuation.
2. **AI/rich-content URL detection** (`detect_urls`): The `UrlLocator` was fed all characters including CJK punctuation without pre-termination.

## Changes

- Added `is_url_separator(c: char) -> bool` (mirroring the existing `is_file_link_separator` pattern) that treats the following as URL terminators:
  - All existing ASCII `URL_SEPARATORS` (space, `<`, `>`, `"", `{`, `}`, `|`, `\`, `^`, `\``)
  - Non-ASCII Unicode whitespace
  - Unicode GeneralCategory::Open/Close/Initial/Final/Other punctuation
  - Connectors (`Pc`) and dashes (`Pd`) are excluded since they can appear in valid URLs (query parameters, IDN).
- Updated `url_at_point`'s `is_at_boundary` closure and forward-scan loop to use `is_url_separator`.
- Updated `detect_urls` to check `is_url_separator` before feeding characters to `UrlLocator`, finalizing any in-progress URL and resetting the locator when a separator is encountered.
- File path detection already handled CJK punctuation correctly via `is_file_link_separator` (added in #10245), so no changes needed there.

## Testing

- `cargo check` compiles cleanly up to Metal shader compilation (unavailable in CLI-only environment).
- Logic mirrors existing CJK punctuation boundary handling for file paths.
- Examples verified conceptually:
  - `https://example.com，` → detects `https://example.com` only
  - `/tmp/file.md。` → file path already correctly detected as `/tmp/file.md` (existing `is_file_link_separator` behavior)

/oz-review