### PR TITLE
Add simple TUI zero state

### DIFF
--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -46,8 +46,12 @@ pub use crate::ai::blocklist::{
 };
 pub use crate::ai::get_relevant_files::controller::GetRelevantFilesController;
 pub use crate::ai::llms::{LLMId, LLMInfo, LLMPreferences, LLMPreferencesEvent};
+pub use crate::ai::skills::SkillManager;
 pub use crate::appearance::Appearance;
 pub use crate::banner::BannerState;
+pub use crate::changelog_model::{
+    ChangelogModel, ChangelogRequestType, ChangelogState, Event as ChangelogModelEvent,
+};
 pub use crate::code::DiffResult;
 pub use crate::settings::AISettingsChangedEvent;
 pub use crate::terminal::color::{Colors as TerminalColors, List as TerminalColorList};

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -34,6 +34,7 @@ mod tui_diff_storage;
 mod tui_file_edits_view;
 mod usage;
 mod warping_indicator;
+mod zero_state;
 
 pub use root_view::RootTuiView;
 pub use session::run;

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use ai::project_context::model::{ProjectContextModel, ProjectContextModelEvent};
 use instant::Instant;
 use parking_lot::FairMutex;
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
@@ -11,12 +12,12 @@ use warp::tui_export::{
     detect_possible_git_repo, throttle, AIAgentPtyWriteMode, ActiveSession, ActiveSessionEvent,
     AgentInteractionMetadata, AgentViewEntryOrigin, BlocklistAIActionModel,
     BlocklistAIContextModel, BlocklistAIController, BlocklistAIHistoryEvent,
-    BlocklistAIHistoryModel, BlocklistAIInputModel, CancellationReason, CommandExecutionSource,
-    ConversationSelection, ConversationSelectionHandle, ConversationUsageTotals,
-    ExecuteCommandEvent, GetRelevantFilesController, LLMPreferences, LLMPreferencesEvent,
-    ModelEvent, PtyIntent, PtyIntentEvent, RepoDetectionSessionType, RepoDetectionSource,
-    ShellCommandExecutorEvent, TerminalModel, TerminalSurface, TerminalSurfaceInit,
-    WAKEUP_THROTTLE_PERIOD,
+    BlocklistAIHistoryModel, BlocklistAIInputModel, CancellationReason, ChangelogModel,
+    ChangelogModelEvent, ChangelogRequestType, CommandExecutionSource, ConversationSelection,
+    ConversationSelectionHandle, ConversationUsageTotals, ExecuteCommandEvent,
+    GetRelevantFilesController, LLMPreferences, LLMPreferencesEvent, ModelEvent, PtyIntent,
+    PtyIntentEvent, RepoDetectionSessionType, RepoDetectionSource, ShellCommandExecutorEvent,
+    TerminalModel, TerminalSurface, TerminalSurfaceInit, WAKEUP_THROTTLE_PERIOD,
 };
 use warp_core::settings::Setting;
 use warp_editor::model::CoreEditorModel;
@@ -44,6 +45,7 @@ use crate::tui_builder::TuiUiBuilder;
 use crate::ui::abbreviate_home_prefix;
 use crate::usage::UsageToggle;
 use crate::warping_indicator::render_warping_indicator;
+use crate::zero_state::render_zero_state;
 
 /// Width used before the first layout pass pushes the real terminal width into the editor.
 const INITIAL_INPUT_WIDTH: u16 = 80;
@@ -234,6 +236,29 @@ impl TuiTerminalSessionView {
             |view, _, event, ctx| view.handle_history_event(event, ctx),
         );
         ctx.subscribe_to_model(&conversation_selection, |_, _, _, ctx| ctx.notify());
+
+        // The zero state's "What's new" section: fetch the changelog once at
+        // startup and re-render when it arrives. The model no-ops when a
+        // changelog is already cached; the other changelog events (request
+        // failed, image fetched) don't change what the zero state renders.
+        ChangelogModel::handle(ctx).update(ctx, |changelog, ctx| {
+            changelog.check_for_changelog(ChangelogRequestType::WindowLaunch, ctx);
+        });
+        ctx.subscribe_to_model(&ChangelogModel::handle(ctx), |_, _, event, ctx| {
+            if let ChangelogModelEvent::ChangelogRequestComplete { .. } = event {
+                ctx.notify();
+            }
+        });
+        // The zero state's project section: rules/skills discovery is
+        // asynchronous, so re-render as indexed results land. `PathIndexed`
+        // accompanies every project-rules mutation (`KnownRulesChanged` is a
+        // persistence-oriented duplicate), and `GlobalRulesChanged` covers
+        // global rules, which the zero state doesn't show.
+        ctx.subscribe_to_model(&ProjectContextModel::handle(ctx), |_, _, event, ctx| {
+            if let ProjectContextModelEvent::PathIndexed = event {
+                ctx.notify();
+            }
+        });
 
         // Bridge shared shell-tool executor events into terminal-manager PTY intents.
         let shell_command_executor = action_model.as_ref(ctx).shell_command_executor(ctx);
@@ -482,20 +507,7 @@ impl TuiTerminalSessionView {
         footer = footer
             .flex_child(TuiFlex::row().finish())
             .child(TuiText::new(model_name).truncate().finish());
-        // The session's cwd only arrives once shell metadata flows (warpified
-        // sessions); until then fall back to the process cwd the TUI's shell
-        // was spawned with.
-        let cwd = self
-            .active_session
-            .as_ref(ctx)
-            .current_working_directory()
-            .cloned()
-            .or_else(|| {
-                std::env::current_dir()
-                    .ok()
-                    .map(|cwd| cwd.to_string_lossy().into_owned())
-            });
-        if let Some(cwd) = cwd {
+        if let Some(cwd) = self.current_working_directory(ctx) {
             footer = footer.child(
                 TuiText::new(format!(" {}", abbreviate_home_prefix(&cwd)))
                     .with_style(dim)
@@ -547,6 +559,21 @@ impl TuiTerminalSessionView {
             .selected_conversation(ctx)?
             .usage_totals();
         (totals != ConversationUsageTotals::default()).then_some(totals)
+    }
+
+    /// The session's working directory. The cwd only arrives once shell
+    /// metadata flows (warpified sessions); until then fall back to the
+    /// process cwd the TUI's shell was spawned with.
+    fn current_working_directory(&self, ctx: &AppContext) -> Option<String> {
+        self.active_session
+            .as_ref(ctx)
+            .current_working_directory()
+            .cloned()
+            .or_else(|| {
+                std::env::current_dir()
+                    .ok()
+                    .map(|cwd| cwd.to_string_lossy().into_owned())
+            })
     }
 
     /// Whether the input is in `!` shell mode (locked shell input).
@@ -754,7 +781,19 @@ impl TuiView for TuiTerminalSessionView {
         // Ctrl-c (cancel/clear/exit) is handled by the keymap pass via the
         // fixed binding registered in [`Self::init`], so no element-level key
         // handling is needed here.
-        let mut column = TuiFlex::column().flex_child(TuiChildView::new(&self.transcript).finish());
+        //
+        // While the transcript has nothing to show, the zero state fills its
+        // slot; the first accepted submission produces a visible block, which
+        // swaps the transcript back in.
+        let mut column = TuiFlex::column();
+        if self.transcript.as_ref(ctx).is_empty() {
+            column = column.flex_child(render_zero_state(
+                self.current_working_directory(ctx).as_deref(),
+                ctx,
+            ));
+        } else {
+            column = column.flex_child(TuiChildView::new(&self.transcript).finish());
+        }
 
         // While the selected conversation is in progress (the GUI warping
         // indicator's core condition), the animated warping indicator sits

--- a/crates/warp_tui/src/transcript_view.rs
+++ b/crates/warp_tui/src/transcript_view.rs
@@ -22,6 +22,7 @@ use warpui_core::{
 };
 
 use super::agent_block::TuiAIBlock;
+use super::terminal_block::should_render_terminal_block;
 use super::tui_block_list_viewport_source::{AgentBlockRegistry, TuiBlockListViewportSource};
 
 /// Rows of blank space above every transcript block. Terminal blocks get it
@@ -177,6 +178,23 @@ impl TuiTranscriptView {
             | BlocklistAIHistoryEvent::ConversationUsageMetadataUpdated { .. }
             | BlocklistAIHistoryEvent::LocalSharedSessionEstablished { .. } => {}
         }
+    }
+
+    /// Whether the transcript has no visible content: no agent block and no
+    /// terminal block it would render (per [`should_render_terminal_block`];
+    /// the idle prompt block awaiting the first command doesn't count). The
+    /// session view fills the transcript slot with the zero state exactly
+    /// while this holds.
+    pub(super) fn is_empty(&self) -> bool {
+        if !self.agent_blocks.borrow().is_empty() {
+            return false;
+        }
+        let model = self.model.lock();
+        let block_list = model.block_list();
+        !block_list
+            .blocks()
+            .iter()
+            .any(|block| should_render_terminal_block(block, block_list))
     }
 
     /// Returns the view id of the agent block rendering `exchange_id`, if any.

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -1,0 +1,194 @@
+//! The pre-first-interaction "zero state" filling the transcript area: the
+//! Warp Agent title and version, a "What's new" changelog section, and the
+//! session's project context (rules and skills discovered).
+//!
+//! The session view owns visibility: the zero state fills the transcript
+//! slot while the transcript has no visible content, so it dismisses once
+//! the first accepted submission produces a block and returns whenever the
+//! transcript empties out again.
+
+use std::path::PathBuf;
+
+use ai::project_context::model::ProjectContextModel;
+use warp::tui_export::{ChangelogModel, ChangelogState, SkillManager};
+use warp_core::channel::ChannelState;
+use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warpui::SingletonEntity;
+use warpui_core::elements::tui::{Modifier, TuiConstrainedBox, TuiElement, TuiFlex, TuiText};
+use warpui_core::AppContext;
+
+use crate::tui_builder::TuiUiBuilder;
+use crate::ui::abbreviate_home_prefix;
+
+/// Cap on "What's new" bullets, mirroring the compact zero-state mock.
+const MAX_CHANGELOG_BULLETS: usize = 3;
+
+/// Width cap on the text column so bullets wrap like the mock.
+const LEFT_COLUMN_MAX_COLS: u16 = 48;
+
+/// Renders the zero state for the transcript area. `cwd` is the session's
+/// working directory for the project section.
+pub(crate) fn render_zero_state(cwd: Option<&str>, app: &AppContext) -> Box<dyn TuiElement> {
+    let builder = TuiUiBuilder::from_app(app);
+    TuiConstrainedBox::new(render_left_column(cwd, &builder, app).finish())
+        .with_max_cols(LEFT_COLUMN_MAX_COLS)
+        .finish()
+}
+
+/// The left text column: title, version, "What's new", and project context.
+fn render_left_column(cwd: Option<&str>, builder: &TuiUiBuilder, app: &AppContext) -> TuiFlex {
+    let title_style = builder.accent_border_style().add_modifier(Modifier::BOLD);
+    let header_style = builder.primary_text_style().add_modifier(Modifier::BOLD);
+    let muted = builder.muted_text_style();
+
+    let version = ChannelState::app_version().unwrap_or("dev build");
+    let mut column = TuiFlex::column()
+        .child(
+            TuiText::new("Warp Agent")
+                .with_style(title_style)
+                .truncate()
+                .finish(),
+        )
+        .child(TuiText::new(version).with_style(muted).truncate().finish());
+
+    let bullets = changelog_bullets(app);
+    if !bullets.is_empty() {
+        column = column.child(blank_row()).child(
+            TuiText::new("What's new")
+                .with_style(header_style)
+                .truncate()
+                .finish(),
+        );
+        for bullet in bullets {
+            // A fixed (non-flex) text child still wraps against the remaining
+            // width while only reporting its natural width.
+            column = column.child(
+                TuiFlex::row()
+                    .child(TuiText::new("• ").with_style(muted).truncate().finish())
+                    .child(TuiText::new(bullet).with_style(muted).finish())
+                    .finish(),
+            );
+        }
+    }
+
+    if let Some(cwd) = cwd {
+        column = render_project_section(cwd, column, builder, app);
+    }
+    column
+}
+
+/// Appends the project section: the project root (or cwd) as a header, then
+/// one line per discovered rule file and a discovered-skill count. Discovery
+/// is asynchronous, so a placeholder shows until results land.
+fn render_project_section(
+    cwd: &str,
+    mut column: TuiFlex,
+    builder: &TuiUiBuilder,
+    app: &AppContext,
+) -> TuiFlex {
+    let header_style = builder.primary_text_style().add_modifier(Modifier::BOLD);
+    let muted = builder.muted_text_style();
+    let check = builder.success_glyph_style();
+
+    let cwd_path = LocalOrRemotePath::Local(PathBuf::from(cwd));
+    let rules = ProjectContextModel::as_ref(app).find_applicable_project_rules(&cwd_path);
+
+    // Rule files that actively apply to the cwd, deduplicated by file name
+    // (nested roots can contribute rules with the same name).
+    let mut rule_files: Vec<String> = Vec::new();
+    if let Some(rules) = &rules {
+        for rule in &rules.active_rules {
+            if let Some(name) = rule.path.file_name() {
+                if !rule_files.iter().any(|file| file == name) {
+                    rule_files.push(name.to_owned());
+                }
+            }
+        }
+    }
+
+    let project_skill_count = SkillManager::as_ref(app)
+        .get_skills_for_working_directory(Some(&cwd_path), app)
+        .iter()
+        .filter(|skill| skill.is_project_skill())
+        .count();
+
+    let header = rules
+        .as_ref()
+        .map(|rules| rules.root_path.display_path())
+        .unwrap_or_else(|| cwd.to_owned());
+    column = column.child(blank_row()).child(
+        TuiText::new(abbreviate_home_prefix(&header))
+            .with_style(header_style)
+            .truncate()
+            .finish(),
+    );
+
+    if rule_files.is_empty() && project_skill_count == 0 {
+        // Repo detection, metadata indexing, and skill scans are async, so
+        // nothing may be known yet; this also covers projects with no
+        // context at all.
+        return column.child(
+            TuiText::new("Discovering project context…")
+                .with_style(builder.dim_text_style())
+                .truncate()
+                .finish(),
+        );
+    }
+
+    let status_row = |column: TuiFlex, text: String| {
+        column.child(
+            TuiFlex::row()
+                .child(TuiText::new("✓ ").with_style(check).truncate().finish())
+                .child(TuiText::new(text).with_style(muted).truncate().finish())
+                .finish(),
+        )
+    };
+    for file in rule_files {
+        column = status_row(column, format!("{file} loaded"));
+    }
+    if project_skill_count > 0 {
+        let plural = if project_skill_count == 1 { "" } else { "s" };
+        column = status_row(
+            column,
+            format!("{project_skill_count} skill{plural} discovered"),
+        );
+    }
+    column
+}
+
+/// Up to [`MAX_CHANGELOG_BULLETS`] plain-text bullets for the current
+/// version's changelog, or empty when no changelog is available (request
+/// failed, still pending, or a channel without release changelogs).
+fn changelog_bullets(app: &AppContext) -> Vec<String> {
+    let ChangelogState::Some(changelog) = &ChangelogModel::as_ref(app).changelog else {
+        return Vec::new();
+    };
+    let from_sections = changelog
+        .sections
+        .iter()
+        .flat_map(|section| section.items.iter())
+        .take(MAX_CHANGELOG_BULLETS)
+        .cloned()
+        .collect::<Vec<_>>();
+    if !from_sections.is_empty() {
+        return from_sections;
+    }
+    // Newer payloads may only populate the markdown sections; fall back to
+    // their top-level bullet lines.
+    changelog
+        .markdown_sections
+        .iter()
+        .flat_map(|section| section.markdown.lines())
+        .filter_map(|line| {
+            let line = line.trim();
+            line.strip_prefix("* ").or_else(|| line.strip_prefix("- "))
+        })
+        .take(MAX_CHANGELOG_BULLETS)
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+/// A one-row spacer between sections.
+fn blank_row() -> Box<dyn TuiElement> {
+    TuiText::new(" ").truncate().finish()
+}


### PR DESCRIPTION
## Description
Adds a zero-state welcome screen to the Warp Agent TUI, shown in the transcript area on launch (design: [Figma mock](https://www.figma.com/design/yg5nbPZuGoAszHS3Rhvehu/TUI?node-id=478-13292)):

- **Warp Agent title + version** — from `ChannelState::app_version()`, falling back to `dev build` for local builds.
- **What's new** — up to 3 bullets for the current version's changelog, reusing the already-registered `ChangelogModel` (fetched once at startup; section hides when no changelog is available, e.g. local/OSS builds or offline).
- **Project context** — the project root (or cwd), the rule files that loaded (`AGENTS.md`/`WARP.md`), and the number of project skills discovered, driven by the existing repo-detection → project-rules/skills pipeline (#13497). Shows a muted "Discovering project context…" placeholder while discovery is in flight.

Visibility is fully derived rather than stored: the zero state renders exactly while `TuiTranscriptView::is_empty()` — no agent blocks and no terminal block the transcript would render (the idle shell prompt block awaiting the first command doesn't count). It disappears once the first accepted submission (agent prompt or `!` shell command) produces a block, and returns if the transcript empties out again.

Plumbing: re-exports `ChangelogModel` (+ event/state types) and `SkillManager` through `tui_export`; subscriptions are narrowed to the events that actually change the zero state (`ChangelogRequestComplete`, `ProjectContextModelEvent::PathIndexed`).

**Note on the mock's right-side ASCII animation:** intentionally not included in this PR — Erica (design) is rethinking the experience there, so the animation piece is on hold until the new direction lands. (The mock's "Codebase indexing complete" line is also replaced by project context/skills, since codebase indexing is disabled in TUI launch mode.)

## Linked Issue
N/A — implemented from the design mock; no tracking issue.

## Testing
- Unit: full `cargo nextest run -p warp_tui` suite passes (91/91); clippy + `./script/format` clean.
- Manual (via `./script/run-tui`, repeated interactive passes):
  - Zero state renders on launch and stays stable through shell bootstrap (idle prompt block doesn't dismiss it).
  - Rejected submissions (empty shell command, busy PTY) keep the zero state; the first accepted agent prompt or `!` command dismisses it and swaps the transcript in.
  - Project section updates asynchronously as rules/skills discovery lands (`✓ AGENTS.md loaded`, `✓ 17 skills discovered`).
  - Layout renders cleanly at narrow widths; footer/input unaffected; clean ctrl-c exit.

- [x] I have manually tested my changes locally with `./script/run-tui`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

[Conversation](https://staging.warp.dev/conversation/12ac0bfb-b0b0-4076-99fa-58706a378308) · [Plan](https://staging.warp.dev/drive/notebook/GCF9Zr4vzbJwyOE18149Kr)

CHANGELOG-IMPROVEMENT: The Warp Agent TUI now opens with a welcome screen showing the current version, recent release highlights, and the project rules and skills discovered in your working directory.
