### PR TITLE
Drop additional telemetry event emissions

### DIFF
--- a/app/src/ai/blocklist/block/status_bar.rs
+++ b/app/src/ai/blocklist/block/status_bar.rs
@@ -743,14 +743,6 @@ impl BlocklistAIStatusBar {
             // Get the current tip from the model
             self.current_tip = tip_model.as_ref(ctx).current_tip().cloned();
 
-            if let Some(tip) = self.current_tip.as_ref() {
-                send_telemetry_from_app_ctx!(
-                    TelemetryEvent::AgentTipShown {
-                        tip: tip.description.clone()
-                    },
-                    ctx
-                );
-            }
         } else {
             self.current_tip = None;
         }

--- a/app/src/context_chips/current_prompt_tests.rs
+++ b/app/src/context_chips/current_prompt_tests.rs
@@ -272,7 +272,6 @@ fn test_shell_chip_is_disabled_when_required_executable_is_missing() {
                 SessionInfo::new_for_test().with_id(session_id),
                 "test command".to_string(),
                 vec![],
-                None,
                 ctx,
             );
             sessions
@@ -425,7 +424,6 @@ fn test_disabling_chips() {
                 SessionInfo::new_for_test().with_id(session_id),
                 "test command".to_string(),
                 vec![],
-                None,
                 ctx,
             );
             sessions

--- a/app/src/experiments/mod.rs
+++ b/app/src/experiments/mod.rs
@@ -27,7 +27,6 @@ use warpui::{AppContext, SingletonEntity};
 
 use crate::auth::auth_state::AuthStateProvider;
 use crate::channel::{Channel, ChannelState};
-use crate::send_telemetry_sync_from_app_ctx;
 
 /// Number of buckets we are using to partition user traffic. The largest valid
 /// bucket index is NUM_BUCKETS - 1.
@@ -331,18 +330,6 @@ pub trait Experiment<T: Experiment<T>>: FromStr {
             let anonymous_id = AuthStateProvider::as_ref(ctx).get().anonymous_id();
             assigned_group = Self::layer().get_assigned_group(&anonymous_id);
 
-            if let Some(group) = assigned_group.as_ref() {
-                let group_assignment = group.variant();
-                // Send synchronously since this we rely on this event to collect experiment data.
-                send_telemetry_sync_from_app_ctx!(
-                    crate::server::telemetry::TelemetryEvent::ExperimentTriggered {
-                        experiment: Self::name(),
-                        layer: Self::layer().name(),
-                        group_assignment,
-                    },
-                    ctx
-                );
-            }
         }
 
         // If the user is in a group for this experiment, cache the result of

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -358,14 +358,13 @@ fn bootstrap_terminal(
             let BootstrappedEvent {
                 session_info,
                 restored_block_commands,
-                rcfiles_duration_seconds,
+                rcfiles_duration_seconds: _,
                 spawning_command,
             } = bootstrapped_event;
             sessions.initialize_bootstrapped_session(
                 *session_info,
                 spawning_command,
                 restored_block_commands,
-                rcfiles_duration_seconds,
                 ctx,
             );
         });

--- a/app/src/terminal/local_tty/spawner.rs
+++ b/app/src/terminal/local_tty/spawner.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 #[cfg(unix)]
 use warp_errors::report_error;
-use warpui::{AppContext, Entity, SingletonEntity};
+use warpui::{Entity, SingletonEntity};
 #[cfg(unix)]
 use {
     crate::terminal::local_tty::server::TerminalServer, anyhow::bail, std::cmp::Reverse,
@@ -11,8 +11,6 @@ use {
 #[cfg(target_os = "windows")]
 use super::PseudoConsoleChild;
 use super::{PtyOptions, PtySpawnResult};
-use crate::send_telemetry_from_app_ctx;
-use crate::server::telemetry::{PtySpawnMode, TelemetryEvent};
 use crate::terminal::local_tty::{self};
 /// A handle that can be used to interact with a pty process.
 pub trait PtyHandle: Send + Sync {
@@ -176,12 +174,7 @@ impl PtySpawner {
         #[cfg(windows)] event_loop_tx: super::mio_channel::Sender<
             crate::terminal::writeable_pty::Message,
         >,
-        ctx: &mut AppContext,
     ) -> Result<(PtySpawnResult, Box<dyn PtyHandle>)> {
-        #[cfg(not(unix))]
-        let is_fallback = false;
-        #[cfg(unix)]
-        let mut is_fallback = false;
 
         #[cfg(unix)]
         if let Some(server) = &self.server {
@@ -206,24 +199,10 @@ impl PtySpawner {
                 report_error!(err.context(
                     "Failed to spawn pty via terminal server; falling back to spawning locally...",
                 ));
-                is_fallback = true;
             } else {
-                send_telemetry_from_app_ctx!(
-                    TelemetryEvent::PtySpawned {
-                        mode: PtySpawnMode::TerminalServer
-                    },
-                    ctx
-                );
                 return result;
             }
         }
-
-        let mode = if is_fallback {
-            PtySpawnMode::FallbackToDirect
-        } else {
-            PtySpawnMode::Direct
-        };
-        send_telemetry_from_app_ctx!(TelemetryEvent::PtySpawned { mode }, ctx);
 
         Self::spawn_pty_directly(
             options,

--- a/app/src/terminal/local_tty/unix.rs
+++ b/app/src/terminal/local_tty/unix.rs
@@ -555,8 +555,8 @@ impl Pty {
             .context("error preparing signal handling")?;
 
         let (PtySpawnResult { pid, leader_fd }, pty_handle) = PtySpawner::handle(ctx)
-            .update(ctx, |pty_spawner, ctx| {
-                pty_spawner.spawn_pty(options, is_crash_reporting_enabled, ctx)
+            .update(ctx, |pty_spawner, _| {
+                pty_spawner.spawn_pty(options, is_crash_reporting_enabled)
             })?;
 
         log::info!(

--- a/app/src/terminal/local_tty/windows/mod.rs
+++ b/app/src/terminal/local_tty/windows/mod.rs
@@ -345,8 +345,8 @@ impl Pty {
     ) -> anyhow::Result<Self> {
         let size = options.size;
         PtySpawner::handle(ctx)
-            .update(ctx, |pty_spawner, ctx| {
-                pty_spawner.spawn_pty(options, is_crash_reporting_enabled, event_loop_tx, ctx)
+            .update(ctx, |pty_spawner, _| {
+                pty_spawner.spawn_pty(options, is_crash_reporting_enabled, event_loop_tx)
             })
             .map(
                 |(

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -37,7 +37,6 @@ use super::terminal_model::{HistoryEntry, SubshellInitializationInfo};
 use crate::features::FeatureFlag;
 #[cfg(feature = "local_tty")]
 use crate::remote_server::manager::{RemoteServerManager, RemoteServerManagerEvent};
-use crate::server::telemetry::{BootstrappingInfo, TelemetryEvent};
 use crate::terminal::event::{ExecutedExecutorCommandEvent, RemoteServerSetupState};
 use crate::terminal::shell::{Shell, ShellType};
 use crate::terminal::warpify::SubshellSource;
@@ -316,12 +315,10 @@ impl Sessions {
         session_info: SessionInfo,
         spawning_command: String,
         restored_block_commands: Vec<HistoryEntry>,
-        rcfiles_duration_seconds: Option<f64>,
         ctx: &mut ModelContext<Self>,
     ) {
         // Remove the session from the list of pending sessions.
-        let pending_session_start_time = self
-            .pending_session_start_times
+        self.pending_session_start_times
             .remove(&session_info.session_id);
 
         let session_id = session_info.session_id;
@@ -380,35 +377,6 @@ impl Sessions {
             }
         }
 
-        let bootstrap_duration_seconds =
-            pending_session_start_time.map(|start| start.elapsed().as_secs_f64());
-        let warp_attributed_bootstrap_duration_seconds =
-            match (bootstrap_duration_seconds, rcfiles_duration_seconds) {
-                (Some(total), Some(rcfiles)) => Some(total - rcfiles),
-                _ => None,
-            };
-        let was_triggered_by_rc_file = session
-            .subshell_info()
-            .clone()
-            .map(|info| info.was_triggered_by_rc_file_snippet)
-            .unwrap_or(false);
-
-        crate::send_telemetry_from_ctx!(
-            TelemetryEvent::BootstrappingSucceeded(BootstrappingInfo {
-                shell: session.shell().shell_type().name(),
-                shell_version: session.shell().version().clone(),
-                is_ssh: session.is_ssh_wrapper_session(),
-                was_triggered_by_rc_file,
-                is_subshell: session.subshell_info().is_some(),
-                is_wsl: session.is_wsl(),
-                bootstrap_duration_seconds,
-                rcfiles_duration_seconds,
-                warp_attributed_bootstrap_duration_seconds,
-                is_msys2: session.is_msys2(),
-                terminal_session_id: Some(session.id()),
-            }),
-            ctx
-        );
 
         History::handle(ctx).update(ctx, |history, ctx| {
             let session_id = session.id();

--- a/app/src/terminal/model_events.rs
+++ b/app/src/terminal/model_events.rs
@@ -282,7 +282,7 @@ impl ModelEventDispatcher {
             session_info,
             spawning_command,
             restored_block_commands,
-            rcfiles_duration_seconds,
+            rcfiles_duration_seconds: _,
         } = event;
 
         let (is_ssh_wrapper_session, session_id, shell_type_name, shell_path) = (
@@ -315,7 +315,6 @@ impl ModelEventDispatcher {
                 *session_info,
                 spawning_command,
                 restored_block_commands,
-                rcfiles_duration_seconds,
                 ctx,
             );
         });

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4808,7 +4808,6 @@ impl TerminalView {
             terminal_view.restore_conversations_on_view_creation(restoration, ctx);
         }
 
-        send_telemetry_from_ctx!(TelemetryEvent::SessionCreation, ctx);
 
         terminal_view
     }
@@ -15872,13 +15871,6 @@ impl TerminalView {
                             .map_or_else(String::new, ToOwned::to_owned),
                     );
                     ctx.emit(Event::SendNotification(notification_content));
-                    send_telemetry_from_ctx!(
-                        TelemetryEvent::NotificationSent {
-                            trigger: long_running_trigger,
-                            agent_variant: None,
-                        },
-                        ctx
-                    );
                 }
             }
             _ => {}
@@ -15963,13 +15955,6 @@ impl TerminalView {
                 }
                 let notification_content = trigger.create_notification_content(title, description);
                 ctx.emit(Event::SendNotification(notification_content));
-                send_telemetry_from_ctx!(
-                    TelemetryEvent::NotificationSent {
-                        trigger,
-                        agent_variant,
-                    },
-                    ctx
-                );
             }
             _ => {}
         }
@@ -18108,15 +18093,6 @@ impl TerminalView {
                 if let Some(block_index) = maybe_block_index {
                     self.mouse_down_block_index = Some(*block_index);
 
-                    send_telemetry_from_ctx!(
-                        TelemetryEvent::BlockSelection(BlockSelectionDetails {
-                            cardinality: self.selected_blocks.cardinality(),
-                            delta: BlockSelectionDelta::New,
-                            is_cmd_down: false,
-                            is_shift_down: false,
-                        }),
-                        ctx
-                    );
                     self.tips_completed.update(ctx, |tips, ctx| {
                         mark_feature_used_and_write_to_user_defaults(
                             Tip::Hint(TipHint::BlockSelect),
@@ -18211,17 +18187,9 @@ impl TerminalView {
                             self.reset_selection_to_single_block(*block_index, ctx);
                         }
 
-                        if !self.ai_input_model.as_ref(ctx).is_ai_input_enabled() {
-                            send_telemetry_from_ctx!(
-                                TelemetryEvent::BlockSelection(BlockSelectionDetails {
-                                    cardinality: self.selected_blocks.cardinality(),
-                                    delta: BlockSelectionDelta::New,
-                                    is_cmd_down: *is_cmd_down,
-                                    is_shift_down: *is_shift_down
-                                }),
-                                ctx
-                            );
-                        } else if !self.selected_blocks.is_empty() {
+                        if self.ai_input_model.as_ref(ctx).is_ai_input_enabled()
+                            && !self.selected_blocks.is_empty()
+                        {
                             send_telemetry_from_ctx!(
                                 TelemetryEvent::AgentModeAttachedBlockContext {
                                     method: AgentModeAttachContextMethod::Mouse
@@ -19734,15 +19702,6 @@ impl TerminalView {
             ctx,
         );
 
-        send_telemetry_from_ctx!(
-            TelemetryEvent::BlockSelection(BlockSelectionDetails {
-                cardinality: self.selected_blocks.cardinality(),
-                delta: BlockSelectionDelta::New,
-                is_cmd_down: false,
-                is_shift_down: false
-            }),
-            ctx
-        );
 
         self.tips_completed.update(ctx, |tips, ctx| {
             mark_feature_used_and_write_to_user_defaults(
@@ -19801,15 +19760,6 @@ impl TerminalView {
             self.scroll_to_if_not_visible(new_block_index, ctx);
             ctx.notify();
 
-            send_telemetry_from_ctx!(
-                TelemetryEvent::BlockSelection(BlockSelectionDetails {
-                    delta: BlockSelectionDelta::Previous,
-                    is_cmd_down: false,
-                    is_shift_down,
-                    cardinality: self.selected_blocks.cardinality(),
-                }),
-                ctx
-            );
 
             self.tips_completed.update(ctx, |tips, ctx| {
                 mark_feature_used_and_write_to_user_defaults(
@@ -19873,15 +19823,6 @@ impl TerminalView {
                     self.reset_selection_to_single_block(new_block_index, ctx);
                 }
                 self.scroll_to_if_not_visible(new_block_index, ctx);
-                send_telemetry_from_ctx!(
-                    TelemetryEvent::BlockSelection(BlockSelectionDetails {
-                        cardinality: self.selected_blocks.cardinality(),
-                        delta: BlockSelectionDelta::Next,
-                        is_cmd_down,
-                        is_shift_down,
-                    }),
-                    ctx
-                );
                 self.tips_completed.update(ctx, |tips, ctx| {
                     mark_feature_used_and_write_to_user_defaults(
                         Tip::Hint(TipHint::BlockSelect),
@@ -21204,13 +21145,6 @@ impl TerminalView {
                         "Command is waiting for a password".to_string(),
                     );
                     ctx.emit(Event::SendNotification(notification_content));
-                    send_telemetry_from_ctx!(
-                        TelemetryEvent::NotificationSent {
-                            trigger: password_trigger,
-                            agent_variant: None,
-                        },
-                        ctx
-                    );
                 }
                 NotificationsMode::Unset
                     if matches!(

--- a/crates/ai/src/index/full_source_code_embedding/codebase_index.rs
+++ b/crates/ai/src/index/full_source_code_embedding/codebase_index.rs
@@ -1195,13 +1195,12 @@ impl CodebaseIndex {
                     (tree, sync_result)
                 },
                 move |me, (tree, server_sync_result), ctx| {
-                    send_telemetry_from_ctx!(
-                        server_sync_result.telemetry_event(
-                            sync_start_time.elapsed(),
-                            CodebaseContextSyncType::Full
-                        ),
-                        ctx
-                    );
+                    let telemetry_event = server_sync_result
+                        .telemetry_event(sync_start_time.elapsed(), CodebaseContextSyncType::Full);
+                    if !matches!(telemetry_event, AITelemetryEvent::SyncCodebaseContextSuccess { .. })
+                    {
+                        send_telemetry_from_ctx!(telemetry_event, ctx);
+                    }
 
                     // We should only flush pending changes when we know the sync failed because of a read fragment error.
                     let should_flush_pending_changes = if let SyncOperationResult::Error(
@@ -1259,11 +1258,12 @@ impl CodebaseIndex {
             }) => {
                 // Emit telemetries for the initial sync result.
                 if let Some(sync_time) = time_tracker.compute_duration_for_interval(SYNC_TIME) {
-                    send_telemetry_from_ctx!(
-                        server_sync_result
-                            .telemetry_event(sync_time, CodebaseContextSyncType::Initial),
-                        ctx
-                    );
+                    let telemetry_event = server_sync_result
+                        .telemetry_event(sync_time, CodebaseContextSyncType::Initial);
+                    if !matches!(telemetry_event, AITelemetryEvent::SyncCodebaseContextSuccess { .. })
+                    {
+                        send_telemetry_from_ctx!(telemetry_event, ctx);
+                    }
                 }
 
                 if let Some((file_traversal_duration, merkle_tree_parse_duration)) = time_tracker

--- a/crates/warp_search_core/src/mixer.rs
+++ b/crates/warp_search_core/src/mixer.rs
@@ -9,12 +9,10 @@ use async_trait::async_trait;
 use futures_util::stream::AbortHandle;
 use itertools::Itertools;
 use warp_core::r#async::debounce;
-use warp_core::send_telemetry_from_ctx;
 use warpui_core::r#async::Timer;
 use warpui_core::{Action, AppContext, Entity, ModelContext};
 
 use super::data_source::{Query, QueryFilter, QueryResult};
-use crate::telemetry::TelemetryEvent;
 
 /// Maximum time to wait for matching data sources to return results before showing
 /// partial results.
@@ -362,7 +360,6 @@ impl<T: Action + Clone> SearchMixer<T> {
                 // If we get here, then we should run the query against the data source right now.
                 let query_generation = self.query_generation;
                 let source = source.clone();
-                let filters = registered_source.filters.to_owned();
                 let new_abort_handle = ctx.spawn(
                     source.run_query(&query, ctx),
                     move |mixer, new_results, ctx| {
@@ -372,15 +369,6 @@ impl<T: Action + Clone> SearchMixer<T> {
                             source.on_query_finished(ctx);
                             return;
                         }
-                        let error_payload =
-                            new_results.as_ref().err().map(|e| e.telemetry_payload());
-                        send_telemetry_from_ctx!(
-                            TelemetryEvent::CommandSearchAsyncQueryCompleted {
-                                filters,
-                                error_payload,
-                            },
-                            ctx
-                        );
                         mixer.add_new_results(data_source_id, new_results, ctx);
                         source.on_query_finished(ctx);
                     },


### PR DESCRIPTION
## Description
Removes additional telemetry emission callsites for the requested events:
- `Bootstrapping Succeeded`
- `Tab Creation`
- `Pty Spawned`
- `Block Selection`
- `AgentTip Shown`
- `experiments.client.enroll_client`
- `Command Search Async Query Completed`
- `Notification Sent`
- `AgentMode.SyncCodebaseContext.Success` (success-only emission; failure telemetry remains)

Notes:
- `CodeReview.CalculateDiffMetadataFailed` does not exist as an active event name in the current codebase. The current code-review failure event is `CodeReview.LoadMetadataFailed`, which is unchanged in this PR.
- This also updates `initialize_bootstrapped_session` callsites/tests after removing now-unused bootstrap telemetry timing arguments.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- Verified target emission callsites removed via code search.
- Could not run `./script/format` or `cargo clippy` in this environment because `cargo` is unavailable (`zsh: command not found: cargo`).

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

Co-Authored-By: Oz <oz-agent@warp.dev>
