### PR TITLE
Remove feature flag gating from the feature-intro popup

### DIFF
--- a/app/src/workspace/one_time_modal_model.rs
+++ b/app/src/workspace/one_time_modal_model.rs
@@ -669,14 +669,11 @@ impl OneTimeModalModel {
         if !AISettings::as_ref(ctx).is_any_ai_enabled(ctx) {
             return false;
         }
-        // Show the first registered feature intro whose flag is enabled and that the
-        // user hasn't seen yet (see `FEATURE_INTROS`).
+        // Show the first registered feature intro that the user hasn't seen yet
+        // (see `FEATURE_INTROS`).
         let next_id = FEATURE_INTROS
             .iter()
-            .find(|intro| {
-                intro.flag.is_enabled()
-                    && !AISettings::as_ref(ctx).is_feature_intro_seen(intro.id.as_key())
-            })
+            .find(|intro| !AISettings::as_ref(ctx).is_feature_intro_seen(intro.id.as_key()))
             .map(|intro| intro.id);
         let Some(id) = next_id else {
             return false;

--- a/app/src/workspace/one_time_modal_model.rs
+++ b/app/src/workspace/one_time_modal_model.rs
@@ -247,6 +247,15 @@ impl OneTimeModalModel {
     ) -> bool {
         if self.active_feature_intro != intro {
             self.active_feature_intro = intro;
+            // Bind the popover to the focused window as soon as it opens. The
+            // workspace only renders / populates the view when
+            // `target_window_id` matches, and `on_active_window_changed` may not
+            // have run yet when the startup modal queue fires.
+            if intro.is_some() && self.target_window_id.is_none() {
+                if let Some(window_id) = ctx.windows().active_window() {
+                    self.target_window_id = Some(window_id);
+                }
+            }
             ctx.emit(OneTimeModalEvent::VisibilityChanged {
                 is_open: intro.is_some(),
             });
@@ -359,10 +368,21 @@ impl OneTimeModalModel {
 
     pub fn update_target_window_id(&mut self, window_id: WindowId, ctx: &mut ModelContext<Self>) {
         let was_any_modal_visible = self.is_any_modal_open();
+        // Feature intro is intentionally excluded from `is_any_modal_open`, so
+        // track it separately. Without this, activating a window after the
+        // startup queue already selected an intro never re-emits, and the
+        // workspace never calls `show_feature_intro_modal`.
+        let was_feature_intro_visible = self.active_feature_intro().is_some();
+        let previous_target = self.target_window_id;
         self.target_window_id = Some(window_id);
-        if was_any_modal_visible != self.is_any_modal_open() {
+        let is_any_modal_visible = self.is_any_modal_open();
+        let is_feature_intro_visible = self.active_feature_intro().is_some();
+        if was_any_modal_visible != is_any_modal_visible
+            || was_feature_intro_visible != is_feature_intro_visible
+            || (is_feature_intro_visible && previous_target != Some(window_id))
+        {
             ctx.emit(OneTimeModalEvent::VisibilityChanged {
-                is_open: self.is_any_modal_open(),
+                is_open: is_any_modal_visible || is_feature_intro_visible,
             });
         }
     }

--- a/app/src/workspace/one_time_modal_model_tests.rs
+++ b/app/src/workspace/one_time_modal_model_tests.rs
@@ -2,8 +2,8 @@ use futures::FutureExt;
 use warpui::{App, SingletonEntity};
 
 use super::{
-    free_ai_removal_modal_decision, AISettings, FeatureFlag, FeatureIntroId,
-    FreeAiRemovalModalDecision, OneTimeModalModel, FEATURE_INTROS,
+    free_ai_removal_modal_decision, AISettings, FeatureIntroId, FreeAiRemovalModalDecision,
+    OneTimeModalModel, FEATURE_INTROS,
 };
 use crate::test_util::terminal::{add_window_with_terminal, initialize_app_for_terminal_view};
 use crate::workspaces::workspace::CustomerType;
@@ -217,13 +217,12 @@ fn test_free_ai_removal_modal_decision_matrix() {
 }
 
 #[test]
-fn feature_intro_triggers_for_enabled_unseen_feature() {
+fn feature_intro_triggers_for_unseen_feature() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         let terminal = add_window_with_terminal(&mut app, None);
 
         terminal.update(&mut app, |_, ctx| {
-            let _flag = FeatureFlag::CustomModelRouterIntro.override_enabled(true);
             let key = FeatureIntroId::CustomModelRouter.as_key();
 
             OneTimeModalModel::handle(ctx).update(ctx, |model, ctx| {
@@ -249,34 +248,12 @@ fn feature_intro_triggers_for_enabled_unseen_feature() {
 }
 
 #[test]
-fn feature_intro_skipped_when_flag_disabled() {
-    App::test((), |mut app| async move {
-        initialize_app_for_terminal_view(&mut app);
-        let terminal = add_window_with_terminal(&mut app, None);
-
-        terminal.update(&mut app, |_, ctx| {
-            // No override: the per-feature flag defaults to disabled in tests.
-            let key = FeatureIntroId::CustomModelRouter.as_key();
-
-            OneTimeModalModel::handle(ctx).update(ctx, |model, ctx| {
-                assert!(!model.check_and_trigger_feature_intro_modal(ctx));
-                assert_eq!(model.active_feature_intro, None);
-                // A disabled feature is left unmarked so it can still show once enabled.
-                assert!(!AISettings::as_ref(ctx).is_feature_intro_seen(key));
-            });
-        });
-    });
-}
-
-#[test]
 fn feature_intro_skipped_when_all_seen() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);
         let terminal = add_window_with_terminal(&mut app, None);
 
         terminal.update(&mut app, |_, ctx| {
-            let _flag = FeatureFlag::CustomModelRouterIntro.override_enabled(true);
-
             OneTimeModalModel::handle(ctx).update(ctx, |model, ctx| {
                 // Mirror the new-user pre-dismissal: mark every registered intro seen.
                 AISettings::handle(ctx).update(ctx, |settings, ctx| {

--- a/app/src/workspace/one_time_modal_model_tests.rs
+++ b/app/src/workspace/one_time_modal_model_tests.rs
@@ -224,9 +224,14 @@ fn feature_intro_triggers_for_unseen_feature() {
 
         terminal.update(&mut app, |_, ctx| {
             let key = FeatureIntroId::CustomModelRouter.as_key();
+            let window_id = ctx.window_id();
+            let active_window = ctx.windows().active_window();
 
             OneTimeModalModel::handle(ctx).update(ctx, |model, ctx| {
                 assert!(!AISettings::as_ref(ctx).is_feature_intro_seen(key));
+                // Simulate the startup race where the modal queue runs before
+                // on_active_window_changed has assigned a target window.
+                model.target_window_id = None;
 
                 let shown = model.check_and_trigger_feature_intro_modal(ctx);
 
@@ -238,10 +243,51 @@ fn feature_intro_triggers_for_unseen_feature() {
                         model.active_feature_intro,
                         Some(FeatureIntroId::CustomModelRouter)
                     );
+                    // Prefer binding to the focused window immediately. If the
+                    // window manager has not yet reported an active window, the
+                    // intro stays pending until `update_target_window_id`.
+                    if active_window.is_some() {
+                        assert_eq!(model.target_window_id, Some(window_id));
+                        assert_eq!(
+                            model.active_feature_intro(),
+                            Some(FeatureIntroId::CustomModelRouter)
+                        );
+                    } else {
+                        assert_eq!(model.target_window_id, None);
+                        assert_eq!(model.active_feature_intro(), None);
+                    }
                 }
 
                 // It is shown at most once: a second check is a no-op.
                 assert!(!model.check_and_trigger_feature_intro_modal(ctx));
+            });
+        });
+    });
+}
+
+#[test]
+fn feature_intro_becomes_visible_when_target_window_is_assigned() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        terminal.update(&mut app, |_, ctx| {
+            let window_id = ctx.window_id();
+
+            OneTimeModalModel::handle(ctx).update(ctx, |model, ctx| {
+                // Intro selected before any window is active (no active window
+                // available to bind yet).
+                model.target_window_id = None;
+                model.active_feature_intro = Some(FeatureIntroId::CustomModelRouter);
+                assert_eq!(model.active_feature_intro(), None);
+
+                model.update_target_window_id(window_id, ctx);
+
+                assert_eq!(model.target_window_id, Some(window_id));
+                assert_eq!(
+                    model.active_feature_intro(),
+                    Some(FeatureIntroId::CustomModelRouter)
+                );
             });
         });
     });

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -1094,6 +1094,10 @@ pub struct Workspace {
     openwarp_launch_modal: ViewHandle<OpenWarpLaunchModal>,
     orchestration_launch_modal: ViewHandle<OrchestrationLaunchModal>,
     feature_intro_modal: ViewHandle<FeatureIntroModal>,
+    /// Tab that first received the feature-intro popover. The popover stays
+    /// pinned to this tab for the rest of its lifetime so switching tabs does
+    /// not re-show it elsewhere.
+    feature_intro_tab_pane_group_id: Option<EntityId>,
     auto_handoff_sleep_modal: ViewHandle<AutoHandoffSleepModal>,
     enable_auto_reload_modal: ViewHandle<EnableAutoReloadModal>,
     build_plan_migration_modal: ViewHandle<BuildPlanMigrationModal>,
@@ -3466,6 +3470,7 @@ impl Workspace {
             openwarp_launch_modal: openwarp_launch_view,
             orchestration_launch_modal: orchestration_launch_view,
             feature_intro_modal: feature_intro_view,
+            feature_intro_tab_pane_group_id: None,
             auto_handoff_sleep_modal: auto_handoff_sleep_view,
             enable_auto_reload_modal,
             agent_management_view,
@@ -12009,6 +12014,8 @@ impl Workspace {
             return;
         }
 
+        let closed_tab_id = self.tabs.get(index).map(|tab| tab.pane_group.id());
+
         let tabs_closed = self.close_tabs(
             vec![index].into_iter(),
             OpenDialogSource::CloseTab { tab_index: index },
@@ -12019,6 +12026,14 @@ impl Workspace {
 
         // Telemetry whenever tabs actually closed, not when confirmation dialog comes up.
         if tabs_closed {
+            if closed_tab_id.is_some() && closed_tab_id == self.feature_intro_tab_pane_group_id {
+                // The pinned tab is gone; drop the intro so it does not reappear
+                // on a different tab.
+                OneTimeModalModel::handle(ctx).update(ctx, |model, ctx| {
+                    model.mark_feature_intro_dismissed(ctx);
+                });
+                self.feature_intro_tab_pane_group_id = None;
+            }
             ctx.dispatch_global_action("workspace:save_app", ());
             send_telemetry_from_ctx!(
                 TelemetryEvent::TabOperations {
@@ -15872,18 +15887,12 @@ impl Workspace {
                 if self.current_workspace_state.is_resource_center_open {
                     self.current_workspace_state.is_resource_center_open = false;
                     ctx.notify();
-                } else {
-                    let should_dismiss_feature_intro = {
-                        let one_time = OneTimeModalModel::as_ref(ctx);
-                        one_time.target_window_id() == Some(self.window_id)
-                            && one_time.active_feature_intro().is_some()
-                    };
-                    if should_dismiss_feature_intro {
-                        OneTimeModalModel::handle(ctx).update(ctx, |model, ctx| {
-                            model.mark_feature_intro_dismissed(ctx);
-                        });
-                        ctx.notify();
-                    }
+                } else if self.is_feature_intro_visible_on_active_tab(ctx) {
+                    OneTimeModalModel::handle(ctx).update(ctx, |model, ctx| {
+                        model.mark_feature_intro_dismissed(ctx);
+                    });
+                    self.feature_intro_tab_pane_group_id = None;
+                    ctx.notify();
                 }
             }
             pane_group::Event::Exited { add_to_undo_stack } => {
@@ -18896,6 +18905,7 @@ impl Workspace {
         OneTimeModalModel::handle(ctx).update(ctx, |model, ctx| {
             model.mark_feature_intro_dismissed(ctx);
         });
+        self.feature_intro_tab_pane_group_id = None;
         self.focus_active_tab(ctx);
 
         if let Some(cta_target) = cta_target {
@@ -23082,13 +23092,8 @@ impl Workspace {
                 .set
                 .insert(flags::SESSION_CONFIG_TAB_CONFIG_CHIP_OPEN);
         }
-        {
-            let one_time = OneTimeModalModel::as_ref(app);
-            if one_time.active_feature_intro().is_some()
-                && one_time.target_window_id() == Some(self.window_id)
-            {
-                context.set.insert(flags::FEATURE_INTRO_MODAL_OPEN);
-            }
+        if self.is_feature_intro_visible_on_active_tab(app) {
+            context.set.insert(flags::FEATURE_INTRO_MODAL_OPEN);
         }
 
         if tab_settings
@@ -23508,11 +23513,35 @@ impl Workspace {
 
     fn show_feature_intro_modal(&mut self, id: FeatureIntroId, ctx: &mut ViewContext<Self>) {
         // Non-blocking popover: set the descriptor but intentionally do NOT focus it,
-        // so the terminal and input stay usable while it is visible.
+        // so the terminal and input stay usable while it is visible. Pin to the
+        // currently active tab so the popover only appears there for the rest of
+        // its lifetime (switching tabs hides it; returning shows it again).
+        if self.feature_intro_tab_pane_group_id.is_none() {
+            self.feature_intro_tab_pane_group_id = self
+                .tabs
+                .get(self.active_tab_index)
+                .map(|tab| tab.pane_group.id());
+        }
         let intro = feature_intro_by_id(id);
         self.feature_intro_modal.update(ctx, |modal, ctx| {
             modal.set_feature(intro, ctx);
         });
+    }
+
+    fn is_feature_intro_visible_on_active_tab(&self, app: &AppContext) -> bool {
+        let one_time = OneTimeModalModel::as_ref(app);
+        if one_time.target_window_id() != Some(self.window_id)
+            || one_time.active_feature_intro().is_none()
+        {
+            return false;
+        }
+        let Some(pinned_tab) = self.feature_intro_tab_pane_group_id else {
+            // Fallback before the pin is assigned: only the currently active tab.
+            return true;
+        };
+        self.tabs
+            .get(self.active_tab_index)
+            .is_some_and(|tab| tab.pane_group.id() == pinned_tab)
     }
 
     fn focus_auto_handoff_sleep_modal(&mut self, ctx: &mut ViewContext<Self>) {
@@ -23894,6 +23923,7 @@ impl TypedActionView for Workspace {
                 OneTimeModalModel::handle(ctx).update(ctx, |model, ctx| {
                     model.mark_feature_intro_dismissed(ctx);
                 });
+                self.feature_intro_tab_pane_group_id = None;
                 ctx.notify();
             }
             #[cfg(debug_assertions)]
@@ -27472,13 +27502,10 @@ impl View for Workspace {
         }
 
         // Feature-intro popover: a non-blocking bottom-right card anchored just above
-        // the input box (or the window corner when there is no input). Added before the
-        // changelog chip below so the chip renders above it.
-        let show_feature_intro = {
-            let one_time = OneTimeModalModel::as_ref(app);
-            one_time.target_window_id() == Some(self.window_id)
-                && one_time.active_feature_intro().is_some()
-        };
+        // the input box (or the window corner when there is no input). Pinned to
+        // the tab that first received it so it does not follow tab switches.
+        // Added before the changelog chip below so the chip renders above it.
+        let show_feature_intro = self.is_feature_intro_visible_on_active_tab(app);
         if show_feature_intro {
             let positioning = match &input_position_id {
                 Some(input_position_id) => {

--- a/app/src/workspace/view/feature_intro_modal/view.rs
+++ b/app/src/workspace/view/feature_intro_modal/view.rs
@@ -1,6 +1,5 @@
 use pathfinder_color::ColorU;
 use pathfinder_geometry::vector::vec2f;
-use warp_core::features::FeatureFlag;
 use warp_core::ui::theme::Fill;
 use warpui::assets::asset_cache::AssetSource;
 use warpui::elements::{
@@ -53,8 +52,6 @@ pub enum FeatureIntroCtaTarget {
 pub struct FeatureIntro {
     /// Stable identifier; also the persisted "seen" key.
     pub id: FeatureIntroId,
-    /// Per-feature rollout gate. The popover only triggers when this is enabled.
-    pub flag: FeatureFlag,
     /// Bundled hero image shown at the top of the card.
     pub hero_image_path: &'static str,
     /// Optional metadata label rendered above the title (e.g. "NEW").
@@ -71,11 +68,9 @@ pub struct FeatureIntro {
 }
 
 /// The registry of feature-intro popovers, in priority order. On startup the
-/// first entry whose [`FeatureIntro::flag`] is enabled and whose id has not yet
-/// been seen is shown.
+/// first entry whose id has not yet been seen is shown.
 pub const FEATURE_INTROS: &[FeatureIntro] = &[FeatureIntro {
     id: FeatureIntroId::CustomModelRouter,
-    flag: FeatureFlag::CustomModelRouterIntro,
     hero_image_path: "async/png/onboarding/custom_model_router_intro_banner.png",
     badge: Some("NEW"),
     title: "Build a custom model router for the Warp Agent.",

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -916,11 +916,6 @@ pub enum FeatureFlag {
     /// compute (docker image, instance shape, setup commands) by runner ID.
     CloudRunners,
 
-    /// Enables the one-time "custom model router" feature-intro popover. This is
-    /// the first feature announced through the reusable feature-intro framework
-    /// (see `FEATURE_INTROS`); each registry entry is gated by its own flag.
-    CustomModelRouterIntro,
-
     /// Renders MCP tool-call request and response JSON as an interactive
     /// collapsible tree with typed colors and per-row Copy JSON, instead of
     /// a flat pretty-printed blob.
@@ -999,7 +994,6 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::JupyterNotebookRendering,
     FeatureFlag::CloudRunners,
     FeatureFlag::WaitForEventsParentRegistration,
-    FeatureFlag::CustomModelRouterIntro,
     FeatureFlag::McpJsonTreeView,
 ];
 


### PR DESCRIPTION
## Description
Removes the `CustomModelRouterIntro` feature flag so the reusable feature-intro popup is no longer gated. Existing users with AI enabled will see the custom model router intro once (still controlled by the per-user seen setting); new signups continue to be pre-marked as seen.

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- Updated unit tests for feature-intro triggering without a flag override
- `./script/format`
- `cargo clippy -p warp_features -p warp --all-targets --tests -- -D warnings`
- `cargo nextest run -p warp -- feature_intro`

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A — flag removal only; no UI redesign.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Conversation: https://staging.warp.dev/conversation/3df0fb9c-ec6e-406d-9c6e-0c394ec3396d

Co-Authored-By: Oz <oz-agent@warp.dev>