### PR TITLE
Add autoupdate status text

### DIFF
--- a/crates/warp_tui/src/autoupdate.rs
+++ b/crates/warp_tui/src/autoupdate.rs
@@ -154,6 +154,30 @@ impl UpdateOutcome {
     }
 }
 
+/// User-visible status of the background updater, shown next to the version
+/// in the transcript zero state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TuiAutoupdateStatus {
+    /// Nothing to show: updates are disabled for this process, or no check
+    /// has produced a stable result yet (e.g. the first check failed).
+    Idle,
+    /// Fetching the latest version for this channel.
+    Checking,
+    /// Downloading and staging a newer version.
+    Updating,
+    /// The running build is the channel's latest version.
+    UpToDate,
+    /// A newer version is staged and takes effect on the next launch.
+    PendingRestart,
+}
+
+/// Events emitted by [`TuiAutoupdater`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TuiAutoupdaterEvent {
+    /// [`TuiAutoupdater::status`] changed.
+    StatusChanged,
+}
+
 /// Whether this process runs the background update loop.
 #[derive(Clone, Debug)]
 enum AutoupdateEligibility {
@@ -211,6 +235,8 @@ impl AutoupdateEligibility {
 pub(crate) struct TuiAutoupdater {
     /// Whether (and where) this process runs background updates.
     eligibility: AutoupdateEligibility,
+    /// The user-visible status of the update loop.
+    status: TuiAutoupdateStatus,
     /// The outcome kind last reported to telemetry. Consecutive checks
     /// usually resolve to the same outcome (e.g. `up_to_date` on every
     /// poll), so only transitions are reported.
@@ -218,7 +244,7 @@ pub(crate) struct TuiAutoupdater {
 }
 
 impl Entity for TuiAutoupdater {
-    type Event = ();
+    type Event = TuiAutoupdaterEvent;
 }
 
 impl SingletonEntity for TuiAutoupdater {}
@@ -230,6 +256,7 @@ impl TuiAutoupdater {
         let eligibility = AutoupdateEligibility::determine(ctx);
         ctx.add_singleton_model(move |_| TuiAutoupdater {
             eligibility,
+            status: TuiAutoupdateStatus::Idle,
             last_reported_outcome: None,
         });
         TuiAutoupdater::handle(ctx).update(ctx, |me, ctx| match me.eligibility.clone() {
@@ -240,25 +267,93 @@ impl TuiAutoupdater {
         });
     }
 
+    /// The user-visible status of the update loop, for the zero state.
+    pub(crate) fn status(&self) -> TuiAutoupdateStatus {
+        self.status
+    }
+
+    /// Updates the status, emitting [`TuiAutoupdaterEvent::StatusChanged`]
+    /// only on actual transitions.
+    fn set_status(&mut self, status: TuiAutoupdateStatus, ctx: &mut ModelContext<Self>) {
+        if self.status == status {
+            return;
+        }
+        self.status = status;
+        ctx.emit(TuiAutoupdaterEvent::StatusChanged);
+    }
+
     /// Runs one background update check, then schedules the next one after
-    /// [`CHECK_INTERVAL`].
+    /// [`CHECK_INTERVAL`]. The pass runs in two phases so the zero state can
+    /// show progress: a lightweight version check, then — only when a newer
+    /// version needs staging — the download/install phase.
     fn check_now(&mut self, layout: InstallLayout, ctx: &mut ModelContext<Self>) {
-        let layout_for_next = layout.clone();
+        // Where the status settles when this pass fails or is skipped: the
+        // previous pass's stable status, never the transient `Checking`.
+        let fallback_status = self.status;
+        self.set_status(TuiAutoupdateStatus::Checking, ctx);
+        let check_layout = layout.clone();
         ctx.spawn(
-            async move { update_once(layout).await },
-            move |me, result, ctx| {
-                match &result {
-                    Ok(outcome) => log::info!("TUI autoupdate check finished: {outcome:?}"),
-                    // Fail quietly and let the next poll retry; transient
-                    // network errors (e.g. waking from sleep) are common here.
-                    Err(error) => log::warn!("TUI autoupdate check failed: {error:#}"),
+            async move { check_for_update(check_layout).await },
+            move |me, decision, ctx| match decision {
+                Ok(CheckDecision::Settled(outcome)) => {
+                    me.finish_check(Ok(outcome), fallback_status, layout, ctx);
                 }
-                me.report_outcome(&result, ctx);
-                ctx.spawn(
-                    async { Timer::after(CHECK_INTERVAL).await },
-                    move |me, _, ctx| me.check_now(layout_for_next, ctx),
-                );
+                Ok(CheckDecision::NeedsInstall {
+                    latest_version,
+                    already_staged,
+                }) => {
+                    me.set_status(TuiAutoupdateStatus::Updating, ctx);
+                    let install_layout = layout.clone();
+                    ctx.spawn(
+                        async move {
+                            install_update(install_layout, latest_version, already_staged).await
+                        },
+                        move |me, result, ctx| {
+                            me.finish_check(result, fallback_status, layout, ctx);
+                        },
+                    );
+                }
+                Err(error) => me.finish_check(Err(error), fallback_status, layout, ctx),
             },
+        );
+    }
+
+    /// Logs and reports the final result of an update pass, settles the
+    /// user-visible status, and schedules the next check.
+    fn finish_check(
+        &mut self,
+        result: Result<UpdateOutcome>,
+        fallback_status: TuiAutoupdateStatus,
+        layout: InstallLayout,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        match &result {
+            Ok(outcome) => log::info!("TUI autoupdate check finished: {outcome:?}"),
+            // Fail quietly and let the next poll retry; transient
+            // network errors (e.g. waking from sleep) are common here.
+            Err(error) => log::warn!("TUI autoupdate check failed: {error:#}"),
+        }
+        self.report_outcome(&result, ctx);
+        let status = match &result {
+            Ok(UpdateOutcome::UpToDate { .. }) => TuiAutoupdateStatus::UpToDate,
+            Ok(UpdateOutcome::PendingRestart { .. } | UpdateOutcome::Installed { .. }) => {
+                TuiAutoupdateStatus::PendingRestart
+            }
+            // Skipped/failed checks aren't surfaced; settle back on the
+            // previous stable status and let the next poll retry.
+            Ok(UpdateOutcome::Locked) | Err(_) => fallback_status,
+        };
+        // Once an update is staged, only a restart clears it: never downgrade
+        // from `PendingRestart` (e.g. on a server-side version rollback).
+        let status = if fallback_status == TuiAutoupdateStatus::PendingRestart {
+            TuiAutoupdateStatus::PendingRestart
+        } else {
+            status
+        };
+        self.set_status(status, ctx);
+        ctx.spawn(
+            async { Timer::after(CHECK_INTERVAL).await },
+            move |me, _, ctx| me.check_now(layout, ctx),
         );
     }
 
@@ -288,8 +383,24 @@ impl TuiAutoupdater {
     }
 }
 
-/// Performs a single check-and-install pass.
-async fn update_once(layout: InstallLayout) -> Result<UpdateOutcome> {
+/// The result of the lightweight check phase of an update pass.
+#[derive(Debug)]
+enum CheckDecision {
+    /// Nothing to install; the pass is complete with this outcome.
+    Settled(UpdateOutcome),
+    /// A newer version needs the install phase ([`install_update`]).
+    NeedsInstall {
+        latest_version: String,
+        /// A previous check already staged this version's directory; only
+        /// the `current` symlink still needs retargeting.
+        already_staged: bool,
+    },
+}
+
+/// Performs the check phase of an update pass: a single lightweight
+/// `/client_version` request plus local filesystem checks, deciding whether
+/// the (heavier) install phase is needed.
+async fn check_for_update(layout: InstallLayout) -> Result<CheckDecision> {
     let current_version =
         ChannelState::app_version().context("no release version tag baked into this build")?;
 
@@ -310,9 +421,9 @@ async fn update_once(layout: InstallLayout) -> Result<UpdateOutcome> {
     let current_parsed = ParsedVersion::try_from(current_version)
         .with_context(|| format!("invalid current version {current_version:?}"))?;
     if latest_parsed <= current_parsed {
-        return Ok(UpdateOutcome::UpToDate {
+        return Ok(CheckDecision::Settled(UpdateOutcome::UpToDate {
             version: current_version.to_owned(),
-        });
+        }));
     }
 
     let version_dir = layout.versions_dir.join(&latest_version);
@@ -326,17 +437,32 @@ async fn update_once(layout: InstallLayout) -> Result<UpdateOutcome> {
     let already_staged = fs::symlink_metadata(version_dir.join(&layout.binary_name))
         .is_ok_and(|metadata| metadata.file_type().is_file());
     if already_staged && current_points_at(&layout, &latest_version) {
-        return Ok(UpdateOutcome::PendingRestart {
+        return Ok(CheckDecision::Settled(UpdateOutcome::PendingRestart {
             version: latest_version,
-        });
+        }));
     }
 
+    Ok(CheckDecision::NeedsInstall {
+        latest_version,
+        already_staged,
+    })
+}
+
+/// Performs the install phase of an update pass: downloads and stages
+/// `latest_version` (unless already staged) and retargets `current` at it.
+async fn install_update(
+    layout: InstallLayout,
+    latest_version: String,
+    already_staged: bool,
+) -> Result<UpdateOutcome> {
     // Serialize installs across concurrent TUI processes.
     let Some(_lock) = InstallLock::acquire(&layout.root)? else {
         return Ok(UpdateOutcome::Locked);
     };
 
     if !already_staged {
+        let client = http_client::Client::new();
+        let version_dir = layout.versions_dir.join(&latest_version);
         download_and_stage(&layout, &client, &latest_version, &version_dir).await?;
     }
 

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -34,6 +34,7 @@ use warpui_core::{
     AppContext, Entity, EntityId, ModelHandle, TuiView, TypedActionView, ViewContext, ViewHandle,
 };
 
+use crate::autoupdate::{TuiAutoupdater, TuiAutoupdaterEvent};
 use crate::conversation_selection::TuiConversationSelection;
 use crate::exit_confirmation::{ExitConfirmation, CTRL_C_EXIT_WINDOW};
 use crate::input::{TuiInputView, TuiInputViewEvent};
@@ -249,6 +250,12 @@ impl TuiTerminalSessionView {
             if let ChangelogModelEvent::ChangelogRequestComplete { .. } = event {
                 ctx.notify();
             }
+        });
+        // The zero state's version line shows the background auto-update
+        // status: re-render as the updater progresses.
+        ctx.subscribe_to_model(&TuiAutoupdater::handle(ctx), |_, _, event, ctx| {
+            let TuiAutoupdaterEvent::StatusChanged = event;
+            ctx.notify();
         });
         // The zero state's project section: rules/skills discovery is
         // asynchronous, so re-render as indexed results land. `PathIndexed`

--- a/crates/warp_tui/src/zero_state.rs
+++ b/crates/warp_tui/src/zero_state.rs
@@ -17,6 +17,7 @@ use warpui::SingletonEntity;
 use warpui_core::elements::tui::{Modifier, TuiConstrainedBox, TuiElement, TuiFlex, TuiText};
 use warpui_core::AppContext;
 
+use crate::autoupdate::{TuiAutoupdateStatus, TuiAutoupdater};
 use crate::tui_builder::TuiUiBuilder;
 use crate::ui::abbreviate_home_prefix;
 
@@ -41,7 +42,6 @@ fn render_left_column(cwd: Option<&str>, builder: &TuiUiBuilder, app: &AppContex
     let header_style = builder.primary_text_style().add_modifier(Modifier::BOLD);
     let muted = builder.muted_text_style();
 
-    let version = ChannelState::app_version().unwrap_or("dev build");
     let mut column = TuiFlex::column()
         .child(
             TuiText::new("Warp Agent")
@@ -49,7 +49,7 @@ fn render_left_column(cwd: Option<&str>, builder: &TuiUiBuilder, app: &AppContex
                 .truncate()
                 .finish(),
         )
-        .child(TuiText::new(version).with_style(muted).truncate().finish());
+        .child(render_version_line(builder, app));
 
     let bullets = changelog_bullets(app);
     if !bullets.is_empty() {
@@ -75,6 +75,51 @@ fn render_left_column(cwd: Option<&str>, builder: &TuiUiBuilder, app: &AppContex
         column = render_project_section(cwd, column, builder, app);
     }
     column
+}
+
+/// The version line: the release version (or "dev build"), with the
+/// background auto-updater's status appended in parentheses. Dev builds
+/// never run the updater (and have no version), so they render plain; the
+/// `Idle` status (updater ineligible, or no stable check result yet) renders
+/// no suffix either.
+fn render_version_line(builder: &TuiUiBuilder, app: &AppContext) -> Box<dyn TuiElement> {
+    let muted = builder.muted_text_style();
+    let Some(version) = ChannelState::app_version() else {
+        return TuiText::new("dev build")
+            .with_style(muted)
+            .truncate()
+            .finish();
+    };
+    let suffix = match TuiAutoupdater::as_ref(app).status() {
+        TuiAutoupdateStatus::Idle => None,
+        TuiAutoupdateStatus::Checking => Some(("checking for updates…", muted)),
+        TuiAutoupdateStatus::Updating => Some(("updating…", muted)),
+        TuiAutoupdateStatus::UpToDate => Some(("up to date", muted)),
+        // The one state worth drawing attention to: an update is staged and
+        // a restart picks it up.
+        TuiAutoupdateStatus::PendingRestart => Some((
+            "update installed, restart to apply",
+            builder.success_glyph_style(),
+        )),
+    };
+    let Some((label, style)) = suffix else {
+        return TuiText::new(version).with_style(muted).truncate().finish();
+    };
+    // Like the bullet rows below: the version reports its natural width and
+    // the suffix wraps against the remaining column width.
+    TuiFlex::row()
+        .child(
+            TuiText::new(format!("{version} "))
+                .with_style(muted)
+                .truncate()
+                .finish(),
+        )
+        .child(
+            TuiText::new(format!("({label})"))
+                .with_style(style)
+                .finish(),
+        )
+        .finish()
 }
 
 /// Appends the project section: the project root (or cwd) as a header, then


### PR DESCRIPTION
## Description
Adds an auto-update status indicator to the TUI zero state, shown in parentheses right after the version line:

- `(checking for updates…)` — while fetching the latest version for the channel
- `(updating…)` — while downloading and staging a newer version
- `(up to date)` — when the running build is the channel's latest
- `(update installed, restart to apply)` — when a newer version is staged (rendered in the success/accent style; picked up on next launch)

**Why:** Now that the TUI has a zero state and background auto-update, users had no feedback that updates were happening or that a restart would pick one up. The update check already kicks off immediately at CLI start (`TuiAutoupdater::register` in `session.rs`), so this PR is purely about surfacing that activity. Labels follow the conventions of peer CLIs with the same silent-install model (e.g. Claude Code's "Update installed · Restart to apply").

**How:**
- `autoupdate.rs`: Added a `TuiAutoupdateStatus` enum (`Idle` / `Checking` / `Updating` / `UpToDate` / `PendingRestart`) and a `StatusChanged` event on `TuiAutoupdater`. Split the single opaque `update_once` pass into a lightweight `check_for_update` phase and an `install_update` phase so the status can transition `Checking → Updating` mid-pass. Failed/locked checks quietly settle back to the previous stable status; `PendingRestart` is sticky (a server-side rollback can't downgrade it). Telemetry and the check cadence are unchanged.
- `zero_state.rs`: Renders the parenthetical status after the version. Dev builds and ineligible installs (status `Idle`) render the plain version with no suffix. The suffix wraps within the zero-state column instead of truncating.
- `terminal_session_view.rs`: Subscribes to the autoupdater so the zero state re-renders on status transitions.

Plan: https://staging.warp.dev/drive/notebook/nlXGTiX55mbwOJQ8TKujIA
Conversation: https://staging.warp.dev/conversation/2665cac6-d05b-4d2b-8508-df79338b19b3

## Linked Issue
N/A

## Testing
- `cargo check -p warp_tui` passes
- `cargo nextest run -p warp_tui autoupdate` — all existing autoupdate tests pass
- `./script/format` and `cargo clippy -p warp_tui --all-targets --all-features` clean
- Note: the full `updating → restart to apply` path only exercises on a managed install (`versions/<v>/` layout) with a newer server-side version; dev builds render the plain "dev build" line with no status suffix by design.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: The Warp Agent CLI now shows auto-update status next to the version on launch, including when an update has been installed and a restart will apply it.

Co-Authored-By: Warp <agent@warp.dev>
