### PR TITLE
[CODE-1829] Render agent task lists in the TUI transcript

### DIFF
--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -3416,6 +3416,13 @@ impl AIConversation {
         &self.todo_lists
     }
 
+    /// Replaces the conversation's todo lists directly, bypassing the normal
+    /// todo-operation replay, for projection tests.
+    #[cfg(test)]
+    pub(crate) fn set_todo_lists_for_test(&mut self, todo_lists: Vec<AIAgentTodoList>) {
+        self.todo_lists = todo_lists;
+    }
+
     pub fn active_todo_list(&self) -> Option<&AIAgentTodoList> {
         self.todo_lists.last()
     }

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -948,9 +948,8 @@ impl BlocklistAIHistoryModel {
     }
 
     /// Returns the render status of one todo item in the conversation's todo
-    /// history (see [`AIConversation::todo_status`]). A narrow projection so
-    /// TUI consumers don't need the whole `AIConversation` exported through
-    /// `tui_export`.
+    /// history (see [`AIConversation::todo_status`]) — a narrow projection
+    /// for consumers that don't need the whole `AIConversation`.
     pub fn todo_status(
         &self,
         conversation_id: &AIConversationId,
@@ -959,8 +958,8 @@ impl BlocklistAIHistoryModel {
         self.conversation(conversation_id)?.todo_status(todo_id)
     }
 
-    /// Returns the conversation's active (most recent) todo list, if any. A
-    /// narrow projection for TUI consumers (see [`Self::todo_status`]).
+    /// Returns the conversation's active (most recent) todo list, if any — a
+    /// narrow projection (see [`Self::todo_status`]).
     pub fn active_todo_list(&self, conversation_id: &AIConversationId) -> Option<&AIAgentTodoList> {
         self.conversation(conversation_id)?.active_todo_list()
     }

--- a/app/src/ai/blocklist/history_model.rs
+++ b/app/src/ai/blocklist/history_model.rs
@@ -26,15 +26,16 @@ use super::persistence::{PersistedAIInput, PersistedAIInputType};
 use super::RequestInput;
 use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::{
-    AIConversation, AIConversationId, ConversationStatus, ServerAIConversationMetadata,
+    AIConversation, AIConversationId, ConversationStatus, ServerAIConversationMetadata, TodoStatus,
     UpdateConversationError,
 };
 use crate::ai::agent::task::helper::{MessageExt, ToolCallExt};
 use crate::ai::agent::task::TaskId;
+use crate::ai::agent::todos::AIAgentTodoList;
 use crate::ai::agent::{
     AIAgentActionId, AIAgentExchange, AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus,
-    CancellationReason, FinishedAIAgentOutput, MessageId, RenderableAIError, RequestCost,
-    Suggestions,
+    AIAgentTodoId, CancellationReason, FinishedAIAgentOutput, MessageId, RenderableAIError,
+    RequestCost, Suggestions,
 };
 use crate::ai::artifacts::Artifact;
 use crate::ai::document::ai_document_model::AIDocumentModel;
@@ -944,6 +945,24 @@ impl BlocklistAIHistoryModel {
     ) -> Option<&ConversationStatus> {
         self.conversation(conversation_id)
             .map(|conversation| conversation.status())
+    }
+
+    /// Returns the render status of one todo item in the conversation's todo
+    /// history (see [`AIConversation::todo_status`]). A narrow projection so
+    /// TUI consumers don't need the whole `AIConversation` exported through
+    /// `tui_export`.
+    pub fn todo_status(
+        &self,
+        conversation_id: &AIConversationId,
+        todo_id: &AIAgentTodoId,
+    ) -> Option<TodoStatus> {
+        self.conversation(conversation_id)?.todo_status(todo_id)
+    }
+
+    /// Returns the conversation's active (most recent) todo list, if any. A
+    /// narrow projection for TUI consumers (see [`Self::todo_status`]).
+    pub fn active_todo_list(&self, conversation_id: &AIConversationId) -> Option<&AIAgentTodoList> {
+        self.conversation(conversation_id)?.active_todo_list()
     }
 
     /// Returns the terminal surface ID for the given conversation, if any.

--- a/app/src/ai/blocklist/history_model_tests.rs
+++ b/app/src/ai/blocklist/history_model_tests.rs
@@ -16,12 +16,14 @@ use super::{
 use crate::ai::agent::api::ServerConversationToken;
 use crate::ai::agent::conversation::{
     AIAgentHarness, AIConversation, AIConversationId, ConversationStatus,
-    ServerAIConversationMetadata,
+    ServerAIConversationMetadata, TodoStatus,
 };
 use crate::ai::agent::task::helper::MessageExt;
+use crate::ai::agent::todos::AIAgentTodoList;
 use crate::ai::agent::{
-    AIAgentExchange, AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus, FinishedAIAgentOutput,
-    RenderableAIError, Shared, TransientNetworkErrorKind, UserQueryMode,
+    AIAgentExchange, AIAgentExchangeId, AIAgentInput, AIAgentOutputStatus, AIAgentTodo,
+    AIAgentTodoId, FinishedAIAgentOutput, RenderableAIError, Shared, TransientNetworkErrorKind,
+    UserQueryMode,
 };
 use crate::ai::ambient_agents::{
     conversation_output_status_from_conversation, AmbientAgentTaskId, AmbientConversationStatus,
@@ -5088,5 +5090,56 @@ fn fork_exact_reconciles_fork_point_client_tool_calls() {
             result_for(orphan_id).is_none(),
             "no result may be synthesized outside the fork-point exchange"
         );
+    });
+}
+
+#[test]
+fn todo_projections_delegate_to_the_conversation() {
+    App::test((), |mut app| async move {
+        let history_model = app.add_singleton_model(|_| BlocklistAIHistoryModel::new_for_test());
+        let terminal_view_id = EntityId::new();
+        let conversation_id = history_model.update(&mut app, |history, ctx| {
+            history.start_new_conversation(terminal_view_id, false, false, false, ctx)
+        });
+
+        let completed = AIAgentTodo::new("t1".to_owned().into(), "one".to_owned(), String::new());
+        let pending_first =
+            AIAgentTodo::new("t2".to_owned().into(), "two".to_owned(), String::new());
+        let pending_second =
+            AIAgentTodo::new("t3".to_owned().into(), "three".to_owned(), String::new());
+        history_model.update(&mut app, |history, _| {
+            history
+                .conversation_mut(&conversation_id)
+                .expect("conversation exists")
+                .set_todo_lists_for_test(vec![AIAgentTodoList::default()
+                    .with_completed_items(vec![completed.clone()])
+                    .with_pending_items(vec![pending_first, pending_second.clone()])]);
+        });
+
+        history_model.read(&app, |history, _| {
+            assert_eq!(
+                history.todo_status(&conversation_id, &completed.id),
+                Some(TodoStatus::Completed)
+            );
+            // Non-head pending items are Pending regardless of conversation status.
+            assert_eq!(
+                history.todo_status(&conversation_id, &pending_second.id),
+                Some(TodoStatus::Pending)
+            );
+            assert_eq!(
+                history.todo_status(&conversation_id, &AIAgentTodoId::from("missing".to_owned())),
+                None
+            );
+            assert_eq!(
+                history
+                    .active_todo_list(&conversation_id)
+                    .map(AIAgentTodoList::len),
+                Some(3)
+            );
+            // Unknown conversations yield no projections at all.
+            let unknown = AIConversationId::new();
+            assert_eq!(history.todo_status(&unknown, &completed.id), None);
+            assert!(history.active_todo_list(&unknown).is_none());
+        });
     });
 }

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -5,17 +5,19 @@ pub use repo_metadata::repositories::RepoDetectionSource;
 pub use crate::ai::agent::api::ServerConversationToken;
 pub use crate::ai::agent::conversation::{
     AIConversation, AIConversationAutoexecuteMode, AIConversationId, ConversationStatus,
-    ConversationUsageTotals,
+    ConversationUsageTotals, TodoStatus,
 };
 pub use crate::ai::agent::task::TaskId;
+pub use crate::ai::agent::todos::AIAgentTodoList;
 pub use crate::ai::agent::{
     AIAgentAction, AIAgentActionId, AIAgentActionResult, AIAgentActionResultType,
     AIAgentActionType, AIAgentExchangeId, AIAgentInput, AIAgentOutput, AIAgentOutputMessage,
-    AIAgentOutputMessageType, AIAgentPtyWriteMode, AIAgentText, AIAgentTextSection,
-    AskUserQuestionResult, CancellationReason, FileGlobV2Result, GrepResult, MessageId,
-    RequestCommandOutputResult, RunAgentsAgentOutcomeKind, RunAgentsResult,
+    AIAgentOutputMessageType, AIAgentPtyWriteMode, AIAgentText, AIAgentTextSection, AIAgentTodo,
+    AIAgentTodoId, AskUserQuestionResult, CancellationReason, FileGlobV2Result, GrepResult,
+    MessageId, RequestCommandOutputResult, RunAgentsAgentOutcomeKind, RunAgentsResult,
     SearchCodebaseFailureReason, SearchCodebaseResult, ServerOutputId, Shared,
-    StartAgentExecutionMode, SuggestNewConversationResult, SummarizationType, UserQueryMode,
+    StartAgentExecutionMode, SuggestNewConversationResult, SummarizationType, TodoOperation,
+    UserQueryMode,
 };
 pub use crate::ai::blocklist::agent_view::{
     AgentViewController, AgentViewDisplayMode, AgentViewEntryOrigin, EnterAgentViewError,

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -191,6 +191,11 @@ pub(super) struct TuiAIBlock {
     /// Populated by [`Self::sync_action_views`]; stateless tool calls never
     /// get entries here.
     action_views: HashMap<AIAgentActionId, TuiToolCallView>,
+    /// Whether the exchange's output contains any todo-operation message,
+    /// maintained by [`Self::sync_action_views`]. Lets the transcript scope
+    /// conversation-wide todo/status invalidations to the blocks whose
+    /// rendering can actually change.
+    renders_todos: bool,
     last_measured_width: Cell<Option<u16>>,
 }
 
@@ -218,6 +223,7 @@ impl TuiAIBlock {
             collapsible_states: Default::default(),
             action_ids: HashSet::new(),
             action_views: HashMap::new(),
+            renders_todos: false,
             last_measured_width: Cell::new(None),
         };
         block.sync_action_views(&action_model, ctx);
@@ -257,9 +263,9 @@ impl TuiAIBlock {
         block
     }
 
-    /// Records the exchange's tool-call action ids and creates child views
-    /// for stateful tool calls that don't have one yet. Rendering can't
-    /// create views since it only sees `&AppContext`.
+    /// Records the exchange's tool-call action ids and todo presence, and
+    /// creates child views for stateful tool calls that don't have one yet.
+    /// Rendering can't create views since it only sees `&AppContext`.
     fn sync_action_views(
         &mut self,
         action_model: &ModelHandle<BlocklistAIActionModel>,
@@ -271,6 +277,10 @@ impl TuiAIBlock {
         let mut shell_command_actions = Vec::new();
         if let Some(output) = status.output_to_render() {
             for message in &output.get().messages {
+                if matches!(&message.message, AIAgentOutputMessageType::TodoOperation(_)) {
+                    self.renders_todos = true;
+                    continue;
+                }
                 let AIAgentOutputMessageType::Action(action) = &message.message else {
                     continue;
                 };
@@ -350,6 +360,13 @@ impl TuiAIBlock {
     /// [`Self::sync_action_views`], so per-action-event checks stay cheap.
     fn renders_action(&self, action_id: &AIAgentActionId) -> bool {
         self.action_ids.contains(action_id)
+    }
+
+    /// Returns whether this block's output contains any todo-operation
+    /// message (a task list or a completion row) — the only content whose
+    /// styling depends on conversation-wide todo and status state.
+    pub(super) fn renders_todos(&self) -> bool {
+        self.renders_todos
     }
 
     /// Invalidates this block and its stateful command child after an owned

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -15,10 +15,11 @@ use itertools::Itertools;
 use parking_lot::FairMutex;
 use warp::tui_export::{
     AIAgentAction, AIAgentActionId, AIAgentActionType, AIAgentExchangeId, AIAgentOutputMessageType,
-    AIAgentTextSection, AIBlockModel, AIConversationId, BlockId, BlocklistAIActionEvent,
-    BlocklistAIActionModel, MessageId, ModelEvent, ModelEventDispatcher, SummarizationType,
-    TerminalModel,
+    AIAgentTextSection, AIAgentTodo, AIBlockModel, AIConversationId, BlockId,
+    BlocklistAIActionEvent, BlocklistAIActionModel, BlocklistAIHistoryModel, MessageId, ModelEvent,
+    ModelEventDispatcher, SummarizationType, TerminalModel, TodoOperation, TodoStatus,
 };
+use warpui::SingletonEntity;
 use warpui_core::elements::tui::{
     TuiChildView, TuiConstraint, TuiContainer, TuiElement, TuiFlex, TuiLayoutContext,
     TuiParentElement, TuiSize,
@@ -31,8 +32,9 @@ use warpui_core::{
 use super::tui_file_edits_view::{TuiFileEditsView, TuiFileEditsViewEvent};
 use super::tui_shell_command_view::{TuiShellCommandView, TuiShellCommandViewEvent};
 use crate::agent_block_sections::{
-    render_fallback_tool_call_section, render_input_section, render_plain_text_section,
-    render_summarization_section, render_thinking_section,
+    render_completed_todos_section, render_fallback_tool_call_section, render_input_section,
+    render_plain_text_section, render_summarization_section, render_thinking_section,
+    render_todo_list_section,
 };
 use crate::transcript_view::BLOCK_TOP_PADDING_ROWS;
 
@@ -55,37 +57,48 @@ enum TuiAIBlockSection {
         finished: bool,
         body: String,
     },
+    /// The agent's task list (todo list), rendered as a collapsible block.
+    TodoList {
+        message_id: MessageId,
+        todos: Vec<AIAgentTodo>,
+    },
+    /// A compact completion row for todos the agent just marked done.
+    CompletedTodos {
+        completed: Vec<AIAgentTodo>,
+    },
 }
 
-/// Per-message UI state for thinking blocks, keyed by reasoning message.
+/// Per-message UI state for collapsible sections (thinking blocks,
+/// conversation summaries, and task lists), keyed by the owning output
+/// message.
 #[derive(Default)]
-pub(crate) struct ThinkingBlockStates {
-    states: RefCell<HashMap<MessageId, ThinkingBlockState>>,
+pub(crate) struct CollapsibleSectionStates {
+    states: RefCell<HashMap<MessageId, CollapsibleSectionState>>,
 }
 
-/// UI state for a single thinking block.
+/// UI state for a single collapsible section.
 #[derive(Default)]
-struct ThinkingBlockState {
-    /// Manual collapse override. `None` means the default: collapsed iff
-    /// reasoning has finished, so a block streams expanded and auto-collapses
-    /// on finish unless the user has toggled it — a recorded override wins
+struct CollapsibleSectionState {
+    /// Manual collapse override. `None` means the section's default (supplied
+    /// per render by the caller: thinking blocks default to collapsed once
+    /// finished, task lists default to expanded) — a recorded override wins
     /// permanently.
     collapse_override: Option<bool>,
-    /// Hover state for the thinking header. Owned here (not created inline
+    /// Hover state for the section header. Owned here (not created inline
     /// during render) so it survives element-tree rebuilds, following the
     /// GUI's `MouseStateHandle` pattern.
     hover_state: MouseStateHandle,
 }
 
-impl ThinkingBlockStates {
-    /// Whether the thinking block for `message_id` is collapsed: the manual
-    /// override if one was recorded, else collapsed iff `finished`.
-    pub(crate) fn is_collapsed(&self, message_id: &MessageId, finished: bool) -> bool {
+impl CollapsibleSectionStates {
+    /// Whether the section for `message_id` is collapsed: the manual override
+    /// if one was recorded, else `default_collapsed`.
+    pub(crate) fn is_collapsed(&self, message_id: &MessageId, default_collapsed: bool) -> bool {
         self.states
             .borrow()
             .get(message_id)
             .and_then(|state| state.collapse_override)
-            .unwrap_or(finished)
+            .unwrap_or(default_collapsed)
     }
 
     /// Records a manual collapse override for `message_id`.
@@ -145,7 +158,7 @@ pub(super) enum TuiAIBlockEvent {
 /// User interactions handled by the owning agent block.
 #[derive(Clone, Debug)]
 pub(crate) enum TuiAIBlockAction {
-    SetThinkingCollapsed {
+    SetSectionCollapsed {
         message_id: MessageId,
         collapsed: bool,
     },
@@ -166,8 +179,9 @@ pub(super) struct TuiAIBlock {
     /// ground-truth state for agent-monitored commands (see
     /// [`Self::lrc_command_state`]). Locked only in short, render-time scopes.
     terminal_model: Arc<FairMutex<TerminalModel>>,
-    /// Per-message UI state for this exchange's thinking blocks.
-    thinking_states: ThinkingBlockStates,
+    /// Per-message UI state for this exchange's collapsible sections
+    /// (thinking blocks and task lists).
+    collapsible_states: CollapsibleSectionStates,
     /// Every tool-call action id seen in this exchange's output, maintained by
     /// [`Self::sync_action_views`]. Mirrors the GUI `AIBlock`'s
     /// `requested_action_ids` so per-action-event lookups are a cheap set
@@ -201,7 +215,7 @@ impl TuiAIBlock {
             block_model,
             action_model: action_model.clone(),
             terminal_model,
-            thinking_states: Default::default(),
+            collapsible_states: Default::default(),
             action_ids: HashSet::new(),
             action_views: HashMap::new(),
             last_measured_width: Cell::new(None),
@@ -482,10 +496,28 @@ impl TuiAIBlock {
                             });
                         }
                     }
+                    AIAgentOutputMessageType::TodoOperation(operation) => match operation {
+                        TodoOperation::UpdateTodos { todos } if !todos.is_empty() => {
+                            sections.push(TuiAIBlockSection::TodoList {
+                                message_id: message.id.clone(),
+                                todos: todos.clone(),
+                            });
+                        }
+                        TodoOperation::MarkAsCompleted { completed_todos }
+                            if !completed_todos.is_empty() =>
+                        {
+                            sections.push(TuiAIBlockSection::CompletedTodos {
+                                completed: completed_todos.clone(),
+                            });
+                        }
+                        // Empty operations carry nothing to render (matching
+                        // the GUI's guards).
+                        TodoOperation::UpdateTodos { .. }
+                        | TodoOperation::MarkAsCompleted { .. } => {}
+                    },
                     // Other message kinds are not rendered by the TUI transcript yet.
                     AIAgentOutputMessageType::Summarization { .. }
                     | AIAgentOutputMessageType::Subagent(_)
-                    | AIAgentOutputMessageType::TodoOperation(_)
                     | AIAgentOutputMessageType::WebSearch(_)
                     | AIAgentOutputMessageType::WebFetch(_)
                     | AIAgentOutputMessageType::CommentsAddressed { .. }
@@ -531,7 +563,7 @@ impl TuiAIBlock {
                     finished_duration,
                     body,
                 } => render_thinking_section(
-                    &self.thinking_states,
+                    &self.collapsible_states,
                     message_id,
                     *finished_duration,
                     body,
@@ -542,12 +574,40 @@ impl TuiAIBlock {
                     finished,
                     body,
                 } => render_summarization_section(
-                    &self.thinking_states,
+                    &self.collapsible_states,
                     message_id,
                     *finished,
                     body,
                     app,
                 ),
+                TuiAIBlockSection::TodoList { message_id, todos } => {
+                    // Statuses resolve against the conversation's todo
+                    // history at render time, so superseded lists restyle
+                    // without needing a dedicated invalidation. Items the
+                    // conversation no longer knows belong to a superseded
+                    // list (matching the GUI's fallback).
+                    let history = BlocklistAIHistoryModel::as_ref(app);
+                    let rows: Vec<(String, TodoStatus)> = todos
+                        .iter()
+                        .map(|todo| {
+                            (
+                                todo.title.clone(),
+                                history
+                                    .todo_status(&self.conversation_id, &todo.id)
+                                    .unwrap_or(TodoStatus::Cancelled),
+                            )
+                        })
+                        .collect();
+                    render_todo_list_section(&self.collapsible_states, message_id, &rows, app)
+                }
+                TuiAIBlockSection::CompletedTodos { completed } => {
+                    let history = BlocklistAIHistoryModel::as_ref(app);
+                    render_completed_todos_section(
+                        completed,
+                        history.active_todo_list(&self.conversation_id),
+                        app,
+                    )
+                }
             };
 
             // One row of bottom padding separates sections; the last section
@@ -596,11 +656,11 @@ impl TypedActionView for TuiAIBlock {
 
     fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
         match action {
-            TuiAIBlockAction::SetThinkingCollapsed {
+            TuiAIBlockAction::SetSectionCollapsed {
                 message_id,
                 collapsed,
             } => {
-                self.thinking_states
+                self.collapsible_states
                     .set_collapsed(message_id.clone(), *collapsed);
                 self.invalidate_layout(ctx);
             }

--- a/crates/warp_tui/src/agent_block_sections.rs
+++ b/crates/warp_tui/src/agent_block_sections.rs
@@ -1,18 +1,23 @@
 //! Pure render functions for each agent block section kind.
 //!
-//! Each render function takes a section's data (plus the block's thinking
-//! block states for collapse/hover state) and returns its element. Spacing
+//! Each render function takes a section's data (plus the block's collapsible
+//! section states for collapse/hover state) and returns its element. Spacing
 //! between sections is owned by the composer in `agent_block.rs`, not by these
 //! renderers.
 
 use std::time::Duration;
 
-use warp::tui_export::{format_elapsed_seconds, AIActionStatus, AIAgentAction, MessageId};
-use warpui_core::elements::tui::{TuiContainer, TuiElement, TuiFlex, TuiStyle, TuiText};
+use warp::tui_export::{
+    format_elapsed_seconds, AIActionStatus, AIAgentAction, AIAgentTodo, AIAgentTodoList, MessageId,
+    TodoStatus,
+};
+use warpui_core::elements::tui::{
+    Modifier, TuiContainer, TuiElement, TuiFlex, TuiParentElement, TuiStyle, TuiText,
+};
 use warpui_core::elements::CrossAxisAlignment;
 use warpui_core::AppContext;
 
-use crate::agent_block::{ThinkingBlockStates, TuiAIBlockAction};
+use crate::agent_block::{CollapsibleSectionStates, TuiAIBlockAction};
 use crate::tool_call_labels::{
     tool_call_display_state, tool_call_glyph, tool_call_label, ResolvedCommandBlock,
     ToolCallDisplayState,
@@ -20,6 +25,9 @@ use crate::tool_call_labels::{
 use crate::tui_builder::TuiUiBuilder;
 
 const INPUT_PREFIX: &str = "≫ ";
+
+/// Leading glyph on the task-list header, per the TUI Figma design.
+const TASK_LIST_HEADER_GLYPH: &str = "☰";
 
 /// Renders the input section: the user's submitted query on a highlighted
 /// background with a `≫` prompt marker.
@@ -141,7 +149,7 @@ pub(crate) fn render_fallback_tool_call_section(
 
 /// Renders a reasoning message as a collapsible thinking block.
 pub(crate) fn render_thinking_section(
-    states: &ThinkingBlockStates,
+    states: &CollapsibleSectionStates,
     message_id: &MessageId,
     finished_duration: Option<Duration>,
     body: &str,
@@ -166,7 +174,7 @@ pub(crate) fn render_thinking_section(
 /// Renders a streamed conversation summary with the same persistent
 /// collapse/hover behavior as a reasoning section.
 pub(crate) fn render_summarization_section(
-    states: &ThinkingBlockStates,
+    states: &CollapsibleSectionStates,
     message_id: &MessageId,
     finished: bool,
     body: &str,
@@ -184,7 +192,7 @@ pub(crate) fn render_summarization_section(
 }
 
 fn render_collapsible_message_section(
-    states: &ThinkingBlockStates,
+    states: &CollapsibleSectionStates,
     message_id: &MessageId,
     header: String,
     finished: bool,
@@ -209,10 +217,129 @@ fn render_collapsible_message_section(
         states.hover_state(message_id),
         body_element.finish(),
         move |event_ctx, _app| {
-            event_ctx.dispatch_typed_action(TuiAIBlockAction::SetThinkingCollapsed {
+            event_ctx.dispatch_typed_action(TuiAIBlockAction::SetSectionCollapsed {
                 message_id: toggle_message_id.clone(),
                 collapsed: !collapsed,
             });
         },
     )
+}
+
+/// Renders the agent's task list as a collapsible block: a bold
+/// `☰ Tasks N` header (prominent, unlike the muted thinking header, per the
+/// TUI Figma design) over one status row per task. Statuses are resolved by
+/// the caller from the conversation's todo history; like tool-call rows,
+/// state lives in each row's glyph.
+///
+/// Task lists default to expanded and collapse only on manual toggle (the
+/// GUI's `TodoListElementState` behavior), so the default passed to the
+/// state map is never "collapsed" — unlike thinking blocks, which
+/// auto-collapse on finish.
+pub(crate) fn render_todo_list_section(
+    states: &CollapsibleSectionStates,
+    message_id: &MessageId,
+    todos: &[(String, TodoStatus)],
+    app: &AppContext,
+) -> Box<dyn TuiElement> {
+    let builder = TuiUiBuilder::from_app(app);
+    let header = format!("{TASK_LIST_HEADER_GLYPH} Tasks {}", todos.len());
+
+    let mut rows = TuiFlex::column();
+    for (title, status) in todos {
+        let (glyph, glyph_style) = todo_glyph(status, &builder);
+        let title_style = match status {
+            TodoStatus::Pending | TodoStatus::InProgress | TodoStatus::Completed => {
+                builder.primary_text_style()
+            }
+            // Cancelled items are struck through in the GUI; stopped items
+            // just read as de-emphasized.
+            TodoStatus::Cancelled => builder
+                .muted_text_style()
+                .add_modifier(Modifier::CROSSED_OUT),
+            TodoStatus::Stopped => builder.muted_text_style(),
+        };
+        rows.add_child(
+            TuiFlex::row()
+                .child(
+                    TuiText::new(format!("{glyph} "))
+                        .with_style(glyph_style)
+                        .finish(),
+                )
+                .child(TuiText::new(title.clone()).with_style(title_style).finish())
+                .finish(),
+        );
+    }
+    // Indent rows so the status glyphs sit under the header label.
+    let body = TuiContainer::new(rows.finish()).with_padding_left(2);
+
+    let collapsed = states.is_collapsed(message_id, false);
+    let toggle_message_id = message_id.clone();
+    builder.prominent_collapsible(
+        collapsed,
+        header,
+        states.hover_state(message_id),
+        body.finish(),
+        move |event_ctx, _app| {
+            event_ctx.dispatch_typed_action(TuiAIBlockAction::SetSectionCollapsed {
+                message_id: toggle_message_id.clone(),
+                collapsed: !collapsed,
+            });
+        },
+    )
+}
+
+/// The status glyph and its style for one task row. Pending and in-progress
+/// glyphs follow the TUI Figma design; terminal states reuse the tool-call
+/// glyph vocabulary (see `tool_call_glyph`).
+fn todo_glyph(status: &TodoStatus, builder: &TuiUiBuilder) -> (&'static str, TuiStyle) {
+    match status {
+        TodoStatus::Pending => ("◌", builder.primary_text_style()),
+        TodoStatus::InProgress => ("•", builder.attention_glyph_style()),
+        TodoStatus::Completed => ("✓", builder.success_glyph_style()),
+        TodoStatus::Cancelled | TodoStatus::Stopped => ("■", builder.muted_text_style()),
+    }
+}
+
+/// Renders the compact completion row for todos the agent just marked done:
+/// `✓ Completed <title> (n/m)`, muted like the GUI's sub-text treatment.
+/// `active_list` supplies each item's `(n/m)` position; the position is
+/// omitted for items no longer in the active list.
+pub(crate) fn render_completed_todos_section(
+    completed: &[AIAgentTodo],
+    active_list: Option<&AIAgentTodoList>,
+    app: &AppContext,
+) -> Box<dyn TuiElement> {
+    let builder = TuiUiBuilder::from_app(app);
+    let style = builder.muted_text_style();
+    TuiFlex::row()
+        .child(TuiText::new("✓ ").with_style(style).finish())
+        .child(
+            TuiText::new(completed_todos_label(completed, active_list))
+                .with_style(style)
+                .finish(),
+        )
+        .finish()
+}
+
+/// Builds the `Completed a (1/3), b (2/3)` label text, a port of the GUI's
+/// `render_completed_todo_items` text logic.
+pub(crate) fn completed_todos_label(
+    completed: &[AIAgentTodo],
+    active_list: Option<&AIAgentTodoList>,
+) -> String {
+    let mut label = String::new();
+    for (index, item) in completed.iter().enumerate() {
+        let position = active_list
+            .and_then(|list| {
+                list.get_item_index(&item.id)
+                    .map(|i| format!(" ({}/{})", i + 1, list.len()))
+            })
+            .unwrap_or_default();
+        if index == 0 {
+            label += &format!("Completed {}{position}", item.title);
+        } else {
+            label += &format!(", {}{position}", item.title);
+        }
+    }
+    label
 }

--- a/crates/warp_tui/src/agent_block_sections.rs
+++ b/crates/warp_tui/src/agent_block_sections.rs
@@ -242,7 +242,6 @@ pub(crate) fn render_todo_list_section(
     app: &AppContext,
 ) -> Box<dyn TuiElement> {
     let builder = TuiUiBuilder::from_app(app);
-    let header = format!("{TASK_LIST_HEADER_GLYPH} Tasks {}", todos.len());
 
     let mut rows = TuiFlex::column();
     for (title, status) in todos {
@@ -276,7 +275,8 @@ pub(crate) fn render_todo_list_section(
     let toggle_message_id = message_id.clone();
     builder.prominent_collapsible(
         collapsed,
-        header,
+        TASK_LIST_HEADER_GLYPH,
+        format!("Tasks {}", todos.len()),
         states.hover_state(message_id),
         body.finish(),
         move |event_ctx, _app| {

--- a/crates/warp_tui/src/agent_block_sections.rs
+++ b/crates/warp_tui/src/agent_block_sections.rs
@@ -26,8 +26,9 @@ use crate::tui_builder::TuiUiBuilder;
 
 const INPUT_PREFIX: &str = "≫ ";
 
-/// Leading glyph on the task-list header, per the TUI Figma design.
-const TASK_LIST_HEADER_GLYPH: &str = "☰";
+/// Task-list header glyph. Visually interchangeable with the design's `☰`,
+/// whose inconsistent cell width across terminals leaves ghost cells behind.
+const TASK_LIST_HEADER_GLYPH: &str = "≡";
 
 /// Renders the input section: the user's submitted query on a highlighted
 /// background with a `≫` prompt marker.
@@ -226,7 +227,7 @@ fn render_collapsible_message_section(
 }
 
 /// Renders the agent's task list as a collapsible block: a bold
-/// `☰ Tasks N` header (prominent, unlike the muted thinking header, per the
+/// `≡ Tasks N` header (prominent, unlike the muted thinking header, per the
 /// TUI Figma design) over one status row per task. Statuses are resolved by
 /// the caller from the conversation's todo history; like tool-call rows,
 /// state lives in each row's glyph.

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -809,10 +809,8 @@ fn task_list_renders_header_and_status_glyph_rows() {
                 CoreFill::from(ThemeFill::from(theme.terminal_colors().normal.yellow)).into();
             let green: Color =
                 CoreFill::from(ThemeFill::from(theme.terminal_colors().normal.green)).into();
-            let white: Color =
-                CoreFill::from(ThemeFill::from(theme.terminal_colors().normal.white)).into();
-            let grey: Color =
-                CoreFill::from(ThemeFill::from(theme.terminal_colors().bright.black)).into();
+            let primary = expected_output_text_color(app_ctx);
+            let muted = expected_tool_call_text_color(app_ctx);
 
             let rows = vec![
                 ("Compile list".to_owned(), TodoStatus::Completed),
@@ -844,19 +842,19 @@ fn task_list_renders_header_and_status_glyph_rows() {
                 ],
             );
             // Header is bold primary text (the design's prominent header).
-            assert_eq!(frame.buffer[(0, 0)].fg, white);
+            assert_eq!(frame.buffer[(0, 0)].fg, primary);
             assert!(frame.buffer[(0, 0)].modifier.contains(Modifier::BOLD));
             // Completed: green check, primary title.
             assert_eq!(frame.buffer[(2, 1)].fg, green);
-            assert_eq!(frame.buffer[(4, 1)].fg, white);
+            assert_eq!(frame.buffer[(4, 1)].fg, primary);
             // In progress: yellow bullet, primary title.
             assert_eq!(frame.buffer[(2, 2)].fg, yellow);
-            assert_eq!(frame.buffer[(4, 2)].fg, white);
+            assert_eq!(frame.buffer[(4, 2)].fg, primary);
             // Pending: primary glyph and title.
-            assert_eq!(frame.buffer[(2, 3)].fg, white);
+            assert_eq!(frame.buffer[(2, 3)].fg, primary);
             // Cancelled: muted glyph, struck-through muted title.
-            assert_eq!(frame.buffer[(2, 4)].fg, grey);
-            assert_eq!(frame.buffer[(4, 4)].fg, grey);
+            assert_eq!(frame.buffer[(2, 4)].fg, muted);
+            assert_eq!(frame.buffer[(4, 4)].fg, muted);
             assert!(frame.buffer[(4, 4)]
                 .modifier
                 .contains(Modifier::CROSSED_OUT));

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -7,10 +7,10 @@ use parking_lot::FairMutex;
 use warp::tui_export::{
     AIActionStatus, AIAgentAction, AIAgentActionId, AIAgentActionResult, AIAgentActionResultType,
     AIAgentActionType, AIAgentExchangeId, AIAgentInput, AIAgentOutput, AIAgentOutputMessage,
-    AIAgentOutputMessageType, AIAgentText, AIAgentTextSection, AIBlockModel, AIBlockOutputStatus,
-    AIConversationId, AIRequestType, Appearance, LLMId, MessageId, OutputStatusUpdateCallback,
-    RequestCommandOutputResult, ServerOutputId, Shared, SummarizationType, TaskId, TerminalModel,
-    UserQueryMode,
+    AIAgentOutputMessageType, AIAgentText, AIAgentTextSection, AIAgentTodo, AIAgentTodoList,
+    AIBlockModel, AIBlockOutputStatus, AIConversationId, AIRequestType, Appearance, LLMId,
+    MessageId, OutputStatusUpdateCallback, RequestCommandOutputResult, ServerOutputId, Shared,
+    SummarizationType, TaskId, TerminalModel, TodoOperation, TodoStatus, UserQueryMode,
 };
 use warp_core::ui::color::blend::Blend;
 use warp_core::ui::theme::Fill as ThemeFill;
@@ -23,8 +23,13 @@ use warpui_core::elements::Fill as CoreFill;
 use warpui_core::presenter::tui::TuiPresenter;
 use warpui_core::{App, AppContext, EntityIdMap, ViewContext, ViewHandle};
 
-use super::{TuiAIBlock, TuiAIBlockAction, TuiAIBlockEvent, TuiAIBlockSection, TuiToolCallView};
-use crate::agent_block_sections::render_fallback_tool_call_section;
+use super::{
+    CollapsibleSectionStates, TuiAIBlock, TuiAIBlockAction, TuiAIBlockEvent, TuiAIBlockSection,
+    TuiToolCallView,
+};
+use crate::agent_block_sections::{
+    completed_todos_label, render_fallback_tool_call_section, render_todo_list_section,
+};
 use crate::test_fixtures::{add_test_action_model_and_events, TestHostView};
 use crate::tui_shell_command_view::TuiShellCommandViewAction;
 
@@ -543,7 +548,7 @@ fn manual_expand_override_shows_finished_reasoning_body() {
             let block = block.as_ref(app_ctx);
             // A manual expand wins over the collapsed-when-finished default.
             block
-                .thinking_states
+                .collapsible_states
                 .set_collapsed(MessageId::new("reasoning-1".to_owned()), false);
 
             let rendered = render_block_lines(block, 40, app_ctx);
@@ -569,7 +574,7 @@ fn thinking_action_records_a_manual_collapse_override() {
             ctx.dispatch_typed_action_for_view(
                 block.window_id(ctx),
                 block.id(),
-                &TuiAIBlockAction::SetThinkingCollapsed {
+                &TuiAIBlockAction::SetSectionCollapsed {
                     message_id: message_id.clone(),
                     collapsed: true,
                 },
@@ -577,7 +582,7 @@ fn thinking_action_records_a_manual_collapse_override() {
         });
         app.read(|app_ctx| {
             let block = block.as_ref(app_ctx);
-            assert!(block.thinking_states.is_collapsed(&message_id, false));
+            assert!(block.collapsible_states.is_collapsed(&message_id, false));
         });
     });
 }
@@ -675,7 +680,7 @@ fn expanded_conversation_summary_shows_its_body() {
         app.read(|app_ctx| {
             let block = block.as_ref(app_ctx);
             block
-                .thinking_states
+                .collapsible_states
                 .set_collapsed(MessageId::new("summary-1".to_owned()), false);
             assert_eq!(
                 render_block_lines(block, 40, app_ctx),
@@ -730,6 +735,274 @@ fn multiple_reasoning_blocks_render_independent_collapse_state() {
             assert!(rendered.iter().all(|line| !line.contains("done body")));
         });
     });
+}
+
+#[test]
+fn todo_operations_map_to_sections_in_message_order() {
+    App::test((), |mut app| async move {
+        let todos = vec![todo("t1", "Compile list"), todo("t2", "Create suggestions")];
+        let block = test_agent_block(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status: complete_output_messages(vec![
+                    plain_text_message("m1", "before"),
+                    update_todos_message("m2", todos.clone()),
+                    mark_completed_message("m3", vec![todo("t1", "Compile list")]),
+                    plain_text_message("m4", "after"),
+                ]),
+            },
+        );
+        app.read(|app_ctx| {
+            let block = block.as_ref(app_ctx);
+            assert_eq!(
+                block.sections(app_ctx),
+                vec![
+                    TuiAIBlockSection::PlainText("before".to_owned()),
+                    TuiAIBlockSection::TodoList {
+                        message_id: MessageId::new("m2".to_owned()),
+                        todos: todos.clone(),
+                    },
+                    TuiAIBlockSection::CompletedTodos {
+                        completed: vec![todo("t1", "Compile list")],
+                    },
+                    TuiAIBlockSection::PlainText("after".to_owned()),
+                ]
+            );
+        });
+    });
+}
+
+#[test]
+fn empty_todo_operations_are_ignored() {
+    App::test((), |mut app| async move {
+        let block = test_agent_block(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status: complete_output_messages(vec![
+                    update_todos_message("m1", Vec::new()),
+                    mark_completed_message("m2", Vec::new()),
+                    plain_text_message("m3", "visible"),
+                ]),
+            },
+        );
+        app.read(|app_ctx| {
+            let block = block.as_ref(app_ctx);
+            assert_eq!(
+                block.sections(app_ctx),
+                vec![TuiAIBlockSection::PlainText("visible".to_owned())]
+            );
+        });
+    });
+}
+
+#[test]
+fn task_list_renders_header_and_status_glyph_rows() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        app.read(|app_ctx| {
+            let theme = Appearance::as_ref(app_ctx).theme();
+            let yellow: Color =
+                CoreFill::from(ThemeFill::from(theme.terminal_colors().normal.yellow)).into();
+            let green: Color =
+                CoreFill::from(ThemeFill::from(theme.terminal_colors().normal.green)).into();
+            let white: Color =
+                CoreFill::from(ThemeFill::from(theme.terminal_colors().normal.white)).into();
+            let grey: Color =
+                CoreFill::from(ThemeFill::from(theme.terminal_colors().bright.black)).into();
+
+            let rows = vec![
+                ("Compile list".to_owned(), TodoStatus::Completed),
+                ("Determine duplications".to_owned(), TodoStatus::InProgress),
+                ("Create suggestions".to_owned(), TodoStatus::Pending),
+                ("Old task".to_owned(), TodoStatus::Cancelled),
+            ];
+            let states = CollapsibleSectionStates::default();
+            let message_id = MessageId::new("m1".to_owned());
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                render_todo_list_section(&states, &message_id, &rows, app_ctx),
+                TuiRect::new(0, 0, 40, 5),
+                app_ctx,
+            );
+            assert_eq!(
+                frame
+                    .buffer
+                    .to_lines()
+                    .into_iter()
+                    .map(|line| line.trim_end().to_owned())
+                    .collect::<Vec<_>>(),
+                vec![
+                    "☰ Tasks 4 ▾",
+                    "  ✓ Compile list",
+                    "  • Determine duplications",
+                    "  ◌ Create suggestions",
+                    "  ■ Old task",
+                ],
+            );
+            // Header is bold primary text (the design's prominent header).
+            assert_eq!(frame.buffer[(0, 0)].fg, white);
+            assert!(frame.buffer[(0, 0)].modifier.contains(Modifier::BOLD));
+            // Completed: green check, primary title.
+            assert_eq!(frame.buffer[(2, 1)].fg, green);
+            assert_eq!(frame.buffer[(4, 1)].fg, white);
+            // In progress: yellow bullet, primary title.
+            assert_eq!(frame.buffer[(2, 2)].fg, yellow);
+            assert_eq!(frame.buffer[(4, 2)].fg, white);
+            // Pending: primary glyph and title.
+            assert_eq!(frame.buffer[(2, 3)].fg, white);
+            // Cancelled: muted glyph, struck-through muted title.
+            assert_eq!(frame.buffer[(2, 4)].fg, grey);
+            assert_eq!(frame.buffer[(4, 4)].fg, grey);
+            assert!(frame.buffer[(4, 4)]
+                .modifier
+                .contains(Modifier::CROSSED_OUT));
+        });
+    });
+}
+
+#[test]
+fn task_list_collapse_override_hides_rows() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        app.read(|app_ctx| {
+            let rows = vec![("Compile list".to_owned(), TodoStatus::Pending)];
+            let states = CollapsibleSectionStates::default();
+            let message_id = MessageId::new("m1".to_owned());
+
+            // Default: expanded, even though nothing is streaming — task
+            // lists never default to collapsed.
+            assert!(!states.is_collapsed(&message_id, false));
+
+            states.set_collapsed(message_id.clone(), true);
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                render_todo_list_section(&states, &message_id, &rows, app_ctx),
+                TuiRect::new(0, 0, 40, 2),
+                app_ctx,
+            );
+            let lines = frame.buffer.to_lines();
+            assert_eq!(lines[0].trim_end(), "☰ Tasks 1 ▸");
+            assert!(lines.iter().all(|line| !line.contains("Compile list")));
+        });
+    });
+}
+
+#[test]
+fn task_list_desired_height_accounts_for_rows_and_collapse() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let block = test_agent_block(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status: complete_output_messages(vec![update_todos_message(
+                    "m1",
+                    vec![todo("t1", "one"), todo("t2", "two")],
+                )]),
+            },
+        );
+        app.read(|app_ctx| {
+            let block = block.as_ref(app_ctx);
+            // Top padding + header + two task rows.
+            assert_eq!(desired_height(block, 40, app_ctx), 4);
+
+            block
+                .collapsible_states
+                .set_collapsed(MessageId::new("m1".to_owned()), true);
+            // Collapsed: top padding + header only.
+            assert_eq!(desired_height(block, 40, app_ctx), 2);
+        });
+    });
+}
+
+#[test]
+fn task_list_without_conversation_state_falls_back_to_cancelled() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        // The block's conversation is unknown to the (default) history model,
+        // so every item resolves to the Cancelled fallback.
+        let block = test_agent_block(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status: complete_output_messages(vec![update_todos_message(
+                    "m1",
+                    vec![todo("t1", "orphaned task")],
+                )]),
+            },
+        );
+        app.read(|app_ctx| {
+            let block = block.as_ref(app_ctx);
+            let rendered = render_block_lines(block, 40, app_ctx);
+            assert_eq!(rendered[0], "☰ Tasks 1 ▾");
+            assert_eq!(rendered[1], "  ■ orphaned task");
+        });
+    });
+}
+
+#[test]
+fn completed_todos_render_muted_completion_row() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let block = test_agent_block(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status: complete_output_messages(vec![mark_completed_message(
+                    "m1",
+                    vec![todo("t1", "Compile list")],
+                )]),
+            },
+        );
+        app.read(|app_ctx| {
+            let block = block.as_ref(app_ctx);
+            // No active list is known to the history model, so the position
+            // suffix is omitted.
+            let rendered = render_block_lines(block, 40, app_ctx);
+            assert_eq!(rendered[0], "✓ Completed Compile list");
+
+            let frame = {
+                let mut presenter = TuiPresenter::new();
+                presenter.present_element(
+                    block.render_element(app_ctx),
+                    TuiRect::new(0, 0, 40, 2),
+                    app_ctx,
+                )
+            };
+            assert_eq!(
+                frame.buffer[(0, 1)].fg,
+                expected_tool_call_text_color(app_ctx)
+            );
+        });
+    });
+}
+
+#[test]
+fn completed_todos_label_includes_active_list_positions() {
+    let list = AIAgentTodoList::default()
+        .with_completed_items(vec![todo("t1", "one")])
+        .with_pending_items(vec![todo("t2", "two"), todo("t3", "three")]);
+
+    // Items in the active list carry their (n/m) position; unknown items omit it.
+    assert_eq!(
+        completed_todos_label(&[todo("t1", "one")], Some(&list)),
+        "Completed one (1/3)"
+    );
+    assert_eq!(
+        completed_todos_label(&[todo("t1", "one"), todo("t3", "three")], Some(&list)),
+        "Completed one (1/3), three (3/3)"
+    );
+    assert_eq!(
+        completed_todos_label(&[todo("t9", "unknown")], Some(&list)),
+        "Completed unknown"
+    );
+    assert_eq!(
+        completed_todos_label(&[todo("t1", "one")], None),
+        "Completed one"
+    );
+    assert_eq!(completed_todos_label(&[], Some(&list)), "");
 }
 
 struct FakeAgentBlockModel {
@@ -843,6 +1116,31 @@ fn debug_output_message(id: &str, text: &str) -> AIAgentOutputMessage {
         message: AIAgentOutputMessageType::DebugOutput {
             text: text.to_owned(),
         },
+        citations: Vec::new(),
+    }
+}
+
+/// Builds a todo item for task-list tests.
+fn todo(id: &str, title: &str) -> AIAgentTodo {
+    AIAgentTodo::new(id.to_owned().into(), title.to_owned(), String::new())
+}
+
+/// Builds an `UpdateTodos` todo-operation output message.
+fn update_todos_message(id: &str, todos: Vec<AIAgentTodo>) -> AIAgentOutputMessage {
+    AIAgentOutputMessage {
+        id: MessageId::new(id.to_owned()),
+        message: AIAgentOutputMessageType::TodoOperation(TodoOperation::UpdateTodos { todos }),
+        citations: Vec::new(),
+    }
+}
+
+/// Builds a `MarkAsCompleted` todo-operation output message.
+fn mark_completed_message(id: &str, completed_todos: Vec<AIAgentTodo>) -> AIAgentOutputMessage {
+    AIAgentOutputMessage {
+        id: MessageId::new(id.to_owned()),
+        message: AIAgentOutputMessageType::TodoOperation(TodoOperation::MarkAsCompleted {
+            completed_todos,
+        }),
         citations: Vec::new(),
     }
 }

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -17,11 +17,13 @@ use warp_core::ui::theme::Fill as ThemeFill;
 use warpui::platform::WindowStyle;
 use warpui::{AddWindowOptions, SingletonEntity};
 use warpui_core::elements::tui::{
-    Color, Modifier, TuiBufferExt, TuiConstraint, TuiLayoutContext, TuiRect, TuiSize,
+    Color, Modifier, TuiBufferExt, TuiConstraint, TuiEvent, TuiEventContext, TuiLayoutContext,
+    TuiPoint, TuiRect, TuiSize,
 };
 use warpui_core::elements::Fill as CoreFill;
+use warpui_core::event::ModifiersState;
 use warpui_core::presenter::tui::TuiPresenter;
-use warpui_core::{App, AppContext, EntityIdMap, ViewContext, ViewHandle};
+use warpui_core::{App, AppContext, EntityId, EntityIdMap, ViewContext, ViewHandle};
 
 use super::{
     CollapsibleSectionStates, TuiAIBlock, TuiAIBlockAction, TuiAIBlockEvent, TuiAIBlockSection,

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -836,7 +836,7 @@ fn task_list_renders_header_and_status_glyph_rows() {
                     .map(|line| line.trim_end().to_owned())
                     .collect::<Vec<_>>(),
                 vec![
-                    "☰ Tasks 4 ▾",
+                    "≡ Tasks 4 ▾",
                     "  ✓ Compile list",
                     "  • Determine duplications",
                     "  ◌ Create suggestions",
@@ -885,7 +885,7 @@ fn task_list_collapse_override_hides_rows() {
                 app_ctx,
             );
             let lines = frame.buffer.to_lines();
-            assert_eq!(lines[0].trim_end(), "☰ Tasks 1 ▸");
+            assert_eq!(lines[0].trim_end(), "≡ Tasks 1 ▸");
             assert!(lines.iter().all(|line| !line.contains("Compile list")));
         });
     });
@@ -923,8 +923,8 @@ fn task_list_header_hover_underlines_only_the_label() {
                 app_ctx,
             );
 
-            // Re-render hovered: `☰ Tasks 1 ▾` underlines exactly the label's
-            // cells — not the ☰ glyph, the chevron, or trailing cells. The
+            // Re-render hovered: `≡ Tasks 1 ▾` underlines exactly the label's
+            // cells — not the ≡ glyph, the chevron, or trailing cells. The
             // label's start column is located from the buffer since the
             // glyph's cell width varies by rendering backend.
             let mut presenter = TuiPresenter::new();
@@ -933,7 +933,7 @@ fn task_list_header_hover_underlines_only_the_label() {
                 area,
                 app_ctx,
             );
-            assert_eq!(frame.buffer.to_lines()[0].trim_end(), "☰ Tasks 1 ▾");
+            assert_eq!(frame.buffer.to_lines()[0].trim_end(), "≡ Tasks 1 ▾");
             let label_start = (0..40u16)
                 .find(|&x| frame.buffer[(x, 0)].symbol() == "T")
                 .expect("the header row contains the label");
@@ -994,7 +994,7 @@ fn task_list_without_conversation_state_falls_back_to_cancelled() {
         app.read(|app_ctx| {
             let block = block.as_ref(app_ctx);
             let rendered = render_block_lines(block, 40, app_ctx);
-            assert_eq!(rendered[0], "☰ Tasks 1 ▾");
+            assert_eq!(rendered[0], "≡ Tasks 1 ▾");
             assert_eq!(rendered[1], "  ■ orphaned task");
         });
     });

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -890,6 +890,62 @@ fn task_list_collapse_override_hides_rows() {
 }
 
 #[test]
+fn task_list_header_hover_underlines_only_the_label() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        app.read(|app_ctx| {
+            let rows = vec![("Compile list".to_owned(), TodoStatus::Pending)];
+            let states = CollapsibleSectionStates::default();
+            let message_id = MessageId::new("m1".to_owned());
+            let area = TuiRect::new(0, 0, 40, 2);
+
+            // Move the pointer onto the header row so the shared hover state
+            // reports it hovered, as the runtime would.
+            let mut element = render_todo_list_section(&states, &message_id, &rows, app_ctx);
+            let mut rendered_views = EntityIdMap::default();
+            let mut ctx = TuiLayoutContext {
+                rendered_views: &mut rendered_views,
+            };
+            element.layout(TuiConstraint::loose(TuiSize::new(40, 2)), &mut ctx, app_ctx);
+            let mut event_ctx = TuiEventContext::default();
+            event_ctx.set_origin_view(Some(EntityId::new()));
+            element.dispatch_event(
+                &TuiEvent::MouseMoved {
+                    position: TuiPoint::new(0, 0),
+                    modifiers: ModifiersState::default(),
+                    is_synthetic: false,
+                },
+                area,
+                &mut event_ctx,
+                &mut ctx,
+                app_ctx,
+            );
+
+            // Re-render hovered: `☰ Tasks 1 ▾` underlines exactly the label's
+            // cells — not the ☰ glyph, the chevron, or trailing cells. The
+            // label's start column is located from the buffer since the
+            // glyph's cell width varies by rendering backend.
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                render_todo_list_section(&states, &message_id, &rows, app_ctx),
+                area,
+                app_ctx,
+            );
+            assert_eq!(frame.buffer.to_lines()[0].trim_end(), "☰ Tasks 1 ▾");
+            let label_start = (0..40u16)
+                .find(|&x| frame.buffer[(x, 0)].symbol() == "T")
+                .expect("the header row contains the label");
+            let underlined: Vec<u16> = (0..40u16)
+                .filter(|&x| frame.buffer[(x, 0)].modifier.contains(Modifier::UNDERLINED))
+                .collect();
+            // "Tasks 1" spans seven cells.
+            let label_cells: Vec<u16> = (label_start..label_start + 7).collect();
+            assert_eq!(underlined, label_cells);
+        });
+    });
+}
+
+#[test]
 fn task_list_desired_height_accounts_for_rows_and_collapse() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| Appearance::mock());

--- a/crates/warp_tui/src/transcript_view.rs
+++ b/crates/warp_tui/src/transcript_view.rs
@@ -141,6 +141,21 @@ impl TuiTranscriptView {
             BlocklistAIHistoryEvent::UpdatedStreamingExchange { exchange_id, .. } => {
                 self.mark_exchange_dirty(*exchange_id, ctx);
             }
+            // Todo statuses are projections of conversation-wide state. A new
+            // list can cancel rows rendered by an older exchange, so dirty all
+            // blocks on this surface rather than only the exchange carrying
+            // the UpdateTodos message.
+            BlocklistAIHistoryEvent::UpdatedTodoList { .. } => {
+                self.mark_all_agent_blocks_dirty(ctx);
+            }
+            // The first pending item switches between InProgress and Stopped
+            // when its conversation starts or stops, without changing the
+            // output messages that own the rendered task list.
+            BlocklistAIHistoryEvent::UpdatedConversationStatus {
+                conversation_id, ..
+            } => {
+                self.mark_conversation_dirty(*conversation_id, ctx);
+            }
             BlocklistAIHistoryEvent::ReassignedExchange {
                 exchange_id,
                 new_conversation_id,
@@ -174,10 +189,8 @@ impl TuiTranscriptView {
             BlocklistAIHistoryEvent::StartedNewConversation { .. }
             | BlocklistAIHistoryEvent::CreatedSubtask { .. }
             | BlocklistAIHistoryEvent::UpgradedTask { .. }
-            | BlocklistAIHistoryEvent::UpdatedConversationStatus { .. }
             | BlocklistAIHistoryEvent::SetActiveConversation { .. }
             | BlocklistAIHistoryEvent::ClearedActiveConversation { .. }
-            | BlocklistAIHistoryEvent::UpdatedTodoList { .. }
             | BlocklistAIHistoryEvent::UpdatedAutoexecuteOverride { .. }
             | BlocklistAIHistoryEvent::SplitConversation { .. }
             | BlocklistAIHistoryEvent::RestoredConversations { .. }
@@ -310,6 +323,53 @@ impl TuiTranscriptView {
         if let Some(view_id) = self.view_id_for_exchange(exchange_id, ctx) {
             self.mark_agent_block_dirty(view_id, ctx);
         }
+    }
+
+    /// Marks every agent block on this terminal surface dirty. Todo-list
+    /// updates are conversation-wide: a newly active list can restyle rows in
+    /// any older exchange as cancelled.
+    fn mark_all_agent_blocks_dirty(&mut self, ctx: &mut ViewContext<Self>) {
+        let view_ids = self
+            .agent_blocks
+            .borrow()
+            .keys()
+            .copied()
+            .collect::<Vec<_>>();
+        if view_ids.is_empty() {
+            return;
+        }
+        let mut model = self.model.lock();
+        for view_id in view_ids {
+            model.block_list_mut().mark_rich_content_dirty(view_id);
+        }
+        drop(model);
+        ctx.notify();
+    }
+
+    /// Marks all agent blocks owned by `conversation_id` dirty. Conversation
+    /// status participates in the projected status of the first pending todo.
+    fn mark_conversation_dirty(
+        &mut self,
+        conversation_id: AIConversationId,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let view_ids = self
+            .agent_blocks
+            .borrow()
+            .iter()
+            .filter_map(|(view_id, view)| {
+                (view.as_ref(ctx).conversation_id() == conversation_id).then_some(*view_id)
+            })
+            .collect::<Vec<_>>();
+        if view_ids.is_empty() {
+            return;
+        }
+        let mut model = self.model.lock();
+        for view_id in view_ids {
+            model.block_list_mut().mark_rich_content_dirty(view_id);
+        }
+        drop(model);
+        ctx.notify();
     }
 
     fn reassign_exchange(

--- a/crates/warp_tui/src/transcript_view.rs
+++ b/crates/warp_tui/src/transcript_view.rs
@@ -142,11 +142,11 @@ impl TuiTranscriptView {
                 self.mark_exchange_dirty(*exchange_id, ctx);
             }
             // Todo statuses are projections of conversation-wide state. A new
-            // list can cancel rows rendered by an older exchange, so dirty all
-            // blocks on this surface rather than only the exchange carrying
-            // the UpdateTodos message.
+            // list can cancel rows rendered by an older exchange, so dirty
+            // every todo-rendering block on this surface rather than only the
+            // exchange carrying the UpdateTodos message.
             BlocklistAIHistoryEvent::UpdatedTodoList { .. } => {
-                self.mark_all_agent_blocks_dirty(ctx);
+                self.mark_todo_blocks_dirty(ctx);
             }
             // The first pending item switches between InProgress and Stopped
             // when its conversation starts or stops, without changing the
@@ -325,15 +325,17 @@ impl TuiTranscriptView {
         }
     }
 
-    /// Marks every agent block on this terminal surface dirty. Todo-list
-    /// updates are conversation-wide: a newly active list can restyle rows in
-    /// any older exchange as cancelled.
-    fn mark_all_agent_blocks_dirty(&mut self, ctx: &mut ViewContext<Self>) {
+    /// Marks every todo-rendering agent block on this terminal surface dirty.
+    /// Todo-list updates are conversation-wide — a newly active list can
+    /// restyle rows in any older exchange as cancelled — but blocks without a
+    /// todo message never change appearance, so their cached heights and
+    /// layout stay untouched.
+    fn mark_todo_blocks_dirty(&mut self, ctx: &mut ViewContext<Self>) {
         let view_ids = self
             .agent_blocks
             .borrow()
-            .keys()
-            .copied()
+            .iter()
+            .filter_map(|(view_id, view)| view.as_ref(ctx).renders_todos().then_some(*view_id))
             .collect::<Vec<_>>();
         if view_ids.is_empty() {
             return;
@@ -346,8 +348,10 @@ impl TuiTranscriptView {
         ctx.notify();
     }
 
-    /// Marks all agent blocks owned by `conversation_id` dirty. Conversation
-    /// status participates in the projected status of the first pending todo.
+    /// Marks `conversation_id`'s todo-rendering agent blocks dirty.
+    /// Conversation status participates in the projected status of the first
+    /// pending todo (InProgress vs Stopped); no other TUI block content reads
+    /// it, so blocks without todo messages keep their cached layout.
     fn mark_conversation_dirty(
         &mut self,
         conversation_id: AIConversationId,
@@ -358,7 +362,9 @@ impl TuiTranscriptView {
             .borrow()
             .iter()
             .filter_map(|(view_id, view)| {
-                (view.as_ref(ctx).conversation_id() == conversation_id).then_some(*view_id)
+                let view = view.as_ref(ctx);
+                (view.conversation_id() == conversation_id && view.renders_todos())
+                    .then_some(*view_id)
             })
             .collect::<Vec<_>>();
         if view_ids.is_empty() {

--- a/crates/warp_tui/src/transcript_view_tests.rs
+++ b/crates/warp_tui/src/transcript_view_tests.rs
@@ -3,10 +3,11 @@ use std::sync::Arc;
 
 use parking_lot::FairMutex;
 use warp::tui_export::{
-    AIAgentExchangeId, AIAgentInput, AIBlockModel, AIBlockOutputStatus, AIConversationId,
-    AIRequestType, Appearance, BlockHeightItem, BlocklistAIHistoryEvent, ConversationStatus,
-    ConversationStatusUpdate, LLMId, OutputStatusUpdateCallback, RichContentItem, RichContentType,
-    ServerOutputId, TerminalModel, UserQueryMode,
+    AIAgentExchangeId, AIAgentInput, AIAgentOutput, AIAgentOutputMessage, AIAgentOutputMessageType,
+    AIAgentTodo, AIBlockModel, AIBlockOutputStatus, AIConversationId, AIRequestType, Appearance,
+    BlockHeightItem, BlocklistAIHistoryEvent, ConversationStatus, ConversationStatusUpdate, LLMId,
+    MessageId, OutputStatusUpdateCallback, RichContentItem, RichContentType, ServerOutputId,
+    Shared, TerminalModel, TodoOperation, UserQueryMode,
 };
 use warpui::event::ModifiersState;
 use warpui::platform::WindowStyle;
@@ -133,13 +134,14 @@ fn transcript_clear_event_removes_only_named_conversations() {
 
 struct FakeAgentBlockModel {
     inputs: Vec<AIAgentInput>,
+    status: AIBlockOutputStatus,
 }
 
 impl AIBlockModel for FakeAgentBlockModel {
     type View = TuiAIBlock;
 
     fn status(&self, _app: &AppContext) -> AIBlockOutputStatus {
-        AIBlockOutputStatus::Pending
+        self.status.clone()
     }
 
     fn server_output_id(&self, _app: &AppContext) -> Option<ServerOutputId> {
@@ -274,13 +276,21 @@ fn todo_and_conversation_status_events_dirty_affected_agent_blocks() {
         let first_conversation_id = AIConversationId::new();
         let second_conversation_id = AIConversationId::new();
 
-        let (first_block_id, second_block_id) = transcript.update(&mut app, |view, ctx| {
+        // Only the first block renders todo content; the second is plain.
+        let (todo_block_id, _plain_block_id) = transcript.update(&mut app, |view, ctx| {
             (
-                append_test_agent_block(view, first_conversation_id, AIAgentExchangeId::new(), ctx),
+                append_test_agent_block(
+                    view,
+                    first_conversation_id,
+                    AIAgentExchangeId::new(),
+                    todo_output_status(),
+                    ctx,
+                ),
                 append_test_agent_block(
                     view,
                     second_conversation_id,
                     AIAgentExchangeId::new(),
+                    AIBlockOutputStatus::Pending,
                     ctx,
                 ),
             )
@@ -298,8 +308,8 @@ fn todo_and_conversation_status_events_dirty_affected_agent_blocks() {
         });
         assert_eq!(
             take_dirty_rich_content_items(&terminal_model),
-            [first_block_id, second_block_id].into_iter().collect(),
-            "a todo update can restyle task rows in any exchange on the surface"
+            [todo_block_id].into_iter().collect(),
+            "a todo update restyles todo-rendering blocks only; plain blocks keep their layout"
         );
 
         transcript.update(&mut app, |view, ctx| {
@@ -317,10 +327,49 @@ fn todo_and_conversation_status_events_dirty_affected_agent_blocks() {
         });
         assert_eq!(
             take_dirty_rich_content_items(&terminal_model),
-            [first_block_id].into_iter().collect(),
-            "a status update should only dirty blocks from that conversation"
+            [todo_block_id].into_iter().collect(),
+            "a status update should only dirty todo-rendering blocks from that conversation"
+        );
+
+        transcript.update(&mut app, |view, ctx| {
+            view.handle_history_event(
+                &BlocklistAIHistoryEvent::UpdatedConversationStatus {
+                    conversation_id: second_conversation_id,
+                    terminal_surface_id,
+                    update: ConversationStatusUpdate::Changed {
+                        prev_status: ConversationStatus::InProgress,
+                    },
+                    new_status: ConversationStatus::Success,
+                },
+                ctx,
+            );
+        });
+        assert!(
+            take_dirty_rich_content_items(&terminal_model).is_empty(),
+            "a status update for a conversation without todo blocks dirties nothing"
         );
     });
+}
+
+/// A completed output whose only message is an `UpdateTodos` operation, so
+/// the owning block renders todo content.
+fn todo_output_status() -> AIBlockOutputStatus {
+    AIBlockOutputStatus::Complete {
+        output: Shared::new(AIAgentOutput {
+            messages: vec![AIAgentOutputMessage {
+                id: MessageId::new("todo-1".to_owned()),
+                message: AIAgentOutputMessageType::TodoOperation(TodoOperation::UpdateTodos {
+                    todos: vec![AIAgentTodo::new(
+                        "t1".to_owned().into(),
+                        "task".to_owned(),
+                        String::new(),
+                    )],
+                }),
+                citations: Vec::new(),
+            }],
+            ..Default::default()
+        }),
+    }
 }
 #[test]
 fn transcript_view_scrolls_only_with_the_mouse_wheel() {
@@ -453,7 +502,10 @@ fn insert_test_agent_block(
             TuiAIBlock::new(
                 conversation_id,
                 exchange_id,
-                Rc::new(FakeAgentBlockModel { inputs }),
+                Rc::new(FakeAgentBlockModel {
+                    inputs,
+                    status: AIBlockOutputStatus::Pending,
+                }),
                 action_model,
                 &model_events,
                 terminal_model,
@@ -542,6 +594,7 @@ fn append_test_agent_block(
     view: &mut TuiTranscriptView,
     conversation_id: AIConversationId,
     exchange_id: AIAgentExchangeId,
+    status: AIBlockOutputStatus,
     ctx: &mut ViewContext<TuiTranscriptView>,
 ) -> EntityId {
     let action_model = view.action_model.clone();
@@ -551,7 +604,10 @@ fn append_test_agent_block(
         TuiAIBlock::new(
             conversation_id,
             exchange_id,
-            Rc::new(FakeAgentBlockModel { inputs: Vec::new() }),
+            Rc::new(FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status,
+            }),
             action_model,
             &model_events,
             terminal_model,

--- a/crates/warp_tui/src/transcript_view_tests.rs
+++ b/crates/warp_tui/src/transcript_view_tests.rs
@@ -4,9 +4,9 @@ use std::sync::Arc;
 use parking_lot::FairMutex;
 use warp::tui_export::{
     AIAgentExchangeId, AIAgentInput, AIBlockModel, AIBlockOutputStatus, AIConversationId,
-    AIRequestType, Appearance, BlockHeightItem, BlocklistAIHistoryEvent, LLMId,
-    OutputStatusUpdateCallback, RichContentItem, RichContentType, ServerOutputId, TerminalModel,
-    UserQueryMode,
+    AIRequestType, Appearance, BlockHeightItem, BlocklistAIHistoryEvent, ConversationStatus,
+    ConversationStatusUpdate, LLMId, OutputStatusUpdateCallback, RichContentItem, RichContentType,
+    ServerOutputId, TerminalModel, UserQueryMode,
 };
 use warpui::event::ModifiersState;
 use warpui::platform::WindowStyle;
@@ -248,6 +248,75 @@ fn transcript_agent_block_lifecycle_updates_canonical_rich_content() {
 }
 
 #[test]
+fn todo_and_conversation_status_events_dirty_affected_agent_blocks() {
+    App::test((), |mut app| async move {
+        let terminal_surface_id = EntityId::new();
+        let terminal_model = Arc::new(FairMutex::new(TerminalModel::mock(None, None)));
+        let model_for_view = terminal_model.clone();
+        let action_model = add_test_action_model(&mut app);
+        let (_, transcript) = app.update(|ctx| {
+            ctx.add_tui_window(
+                AddWindowOptions {
+                    window_style: WindowStyle::NotStealFocus,
+                    ..Default::default()
+                },
+                |ctx| {
+                    TuiTranscriptView::new(terminal_surface_id, model_for_view, action_model, ctx)
+                },
+            )
+        });
+        let first_conversation_id = AIConversationId::new();
+        let second_conversation_id = AIConversationId::new();
+
+        let (first_block_id, second_block_id) = transcript.update(&mut app, |view, ctx| {
+            (
+                append_test_agent_block(view, first_conversation_id, AIAgentExchangeId::new(), ctx),
+                append_test_agent_block(
+                    view,
+                    second_conversation_id,
+                    AIAgentExchangeId::new(),
+                    ctx,
+                ),
+            )
+        });
+        // Drain append invalidations so each event's effects are isolated.
+        take_dirty_rich_content_items(&terminal_model);
+
+        transcript.update(&mut app, |view, ctx| {
+            view.handle_history_event(
+                &BlocklistAIHistoryEvent::UpdatedTodoList {
+                    terminal_surface_id,
+                },
+                ctx,
+            );
+        });
+        assert_eq!(
+            take_dirty_rich_content_items(&terminal_model),
+            [first_block_id, second_block_id].into_iter().collect(),
+            "a todo update can restyle task rows in any exchange on the surface"
+        );
+
+        transcript.update(&mut app, |view, ctx| {
+            view.handle_history_event(
+                &BlocklistAIHistoryEvent::UpdatedConversationStatus {
+                    conversation_id: first_conversation_id,
+                    terminal_surface_id,
+                    update: ConversationStatusUpdate::Changed {
+                        prev_status: ConversationStatus::InProgress,
+                    },
+                    new_status: ConversationStatus::Success,
+                },
+                ctx,
+            );
+        });
+        assert_eq!(
+            take_dirty_rich_content_items(&terminal_model),
+            [first_block_id].into_iter().collect(),
+            "a status update should only dirty blocks from that conversation"
+        );
+    });
+}
+#[test]
 fn transcript_view_scrolls_only_with_the_mouse_wheel() {
     App::test((), |mut app| async move {
         let mut terminal_model = TerminalModel::mock(None, None);
@@ -461,6 +530,31 @@ fn dispatch_event(
         event_ctx.set_origin_view(Some(EntityId::new()));
         element.dispatch_event(event, area, &mut event_ctx, &mut layout_ctx, app)
     })
+}
+
+fn append_test_agent_block(
+    view: &mut TuiTranscriptView,
+    conversation_id: AIConversationId,
+    exchange_id: AIAgentExchangeId,
+    ctx: &mut ViewContext<TuiTranscriptView>,
+) -> EntityId {
+    let agent_block = ctx.add_tui_view(|ctx| {
+        TuiAIBlock::new(
+            conversation_id,
+            exchange_id,
+            Rc::new(EmptyAgentBlockModel),
+            view.action_model.clone(),
+            view.model.clone(),
+            ctx,
+        )
+    });
+    let view_id = agent_block.id();
+    view.agent_blocks.borrow_mut().insert(view_id, agent_block);
+    view.model.lock().block_list_mut().append_rich_content(
+        RichContentItem::new(Some(RichContentType::AIBlock), view_id, None, false),
+        false,
+    );
+    view_id
 }
 fn rich_content_count(model: &Arc<FairMutex<TerminalModel>>) -> usize {
     model

--- a/crates/warp_tui/src/transcript_view_tests.rs
+++ b/crates/warp_tui/src/transcript_view_tests.rs
@@ -253,7 +253,7 @@ fn todo_and_conversation_status_events_dirty_affected_agent_blocks() {
         let terminal_surface_id = EntityId::new();
         let terminal_model = Arc::new(FairMutex::new(TerminalModel::mock(None, None)));
         let model_for_view = terminal_model.clone();
-        let action_model = add_test_action_model(&mut app);
+        let (action_model, model_events) = add_test_action_model_and_events(&mut app);
         let (_, transcript) = app.update(|ctx| {
             ctx.add_tui_window(
                 AddWindowOptions {
@@ -261,7 +261,13 @@ fn todo_and_conversation_status_events_dirty_affected_agent_blocks() {
                     ..Default::default()
                 },
                 |ctx| {
-                    TuiTranscriptView::new(terminal_surface_id, model_for_view, action_model, ctx)
+                    TuiTranscriptView::new(
+                        terminal_surface_id,
+                        model_for_view,
+                        action_model,
+                        &model_events,
+                        ctx,
+                    )
                 },
             )
         });
@@ -538,13 +544,17 @@ fn append_test_agent_block(
     exchange_id: AIAgentExchangeId,
     ctx: &mut ViewContext<TuiTranscriptView>,
 ) -> EntityId {
+    let action_model = view.action_model.clone();
+    let model_events = view.model_events.clone();
+    let terminal_model = view.model.clone();
     let agent_block = ctx.add_tui_view(|ctx| {
         TuiAIBlock::new(
             conversation_id,
             exchange_id,
-            Rc::new(EmptyAgentBlockModel),
-            view.action_model.clone(),
-            view.model.clone(),
+            Rc::new(FakeAgentBlockModel { inputs: Vec::new() }),
+            action_model,
+            &model_events,
+            terminal_model,
             ctx,
         )
     });

--- a/crates/warp_tui/src/tui_block_list_viewport_source_tests.rs
+++ b/crates/warp_tui/src/tui_block_list_viewport_source_tests.rs
@@ -507,7 +507,7 @@ fn reasoning_agent_block_source(
 fn expand_thinking_section(app: &mut App, agent_block: &ViewHandle<TuiAIBlock>) {
     agent_block.update(app, |block, ctx| {
         block.handle_action(
-            &TuiAIBlockAction::SetThinkingCollapsed {
+            &TuiAIBlockAction::SetSectionCollapsed {
                 message_id: MessageId::new("reasoning-1".to_owned()),
                 collapsed: false,
             },

--- a/crates/warp_tui/src/tui_builder.rs
+++ b/crates/warp_tui/src/tui_builder.rs
@@ -218,13 +218,16 @@ impl TuiUiBuilder {
         )
     }
 
-    /// Prominent [`tui_collapsible`] variant: a bold primary-text header
-    /// (e.g. the task-list header, which the design renders bold white).
-    /// Since the header is already bold, hover signals with an underline
-    /// instead of the muted collapsible's brighten-on-hover.
+    /// Prominent [`tui_collapsible`] variant: a bold primary-text header of
+    /// a leading `glyph` and a `label` (e.g. the task-list header, which the
+    /// design renders bold white). Since the header is already bold, hover
+    /// signals with an underline instead of the muted collapsible's
+    /// brighten-on-hover — applied to the label only, so the decorative
+    /// glyph and the chevron don't pick up a clashing underline.
     pub(crate) fn prominent_collapsible(
         &self,
         collapsed: bool,
+        glyph: impl Into<String>,
         label: impl Into<String>,
         mouse_state: MouseStateHandle,
         body: Box<dyn TuiElement>,
@@ -238,7 +241,10 @@ impl TuiUiBuilder {
         };
         tui_collapsible(
             collapsed,
-            [(label.into(), label_style)],
+            [
+                (format!("{} ", glyph.into()), header_style),
+                (label.into(), label_style),
+            ],
             header_style,
             mouse_state,
             move || body,

--- a/crates/warp_tui/src/tui_builder.rs
+++ b/crates/warp_tui/src/tui_builder.rs
@@ -217,6 +217,34 @@ impl TuiUiBuilder {
             on_toggle,
         )
     }
+
+    /// Prominent [`tui_collapsible`] variant: a bold primary-text header
+    /// (e.g. the task-list header, which the design renders bold white).
+    /// Since the header is already bold, hover signals with an underline
+    /// instead of the muted collapsible's brighten-on-hover.
+    pub(crate) fn prominent_collapsible(
+        &self,
+        collapsed: bool,
+        label: impl Into<String>,
+        mouse_state: MouseStateHandle,
+        body: Box<dyn TuiElement>,
+        on_toggle: impl FnMut(&mut TuiEventContext, &AppContext) + 'static,
+    ) -> Box<dyn TuiElement> {
+        let header_style = self.primary_text_style().add_modifier(Modifier::BOLD);
+        let label_style = if mouse_state.lock().unwrap().is_hovered() {
+            header_style.add_modifier(Modifier::UNDERLINED)
+        } else {
+            header_style
+        };
+        tui_collapsible(
+            collapsed,
+            [(label.into(), label_style)],
+            header_style,
+            mouse_state,
+            move || body,
+            on_toggle,
+        )
+    }
 }
 
 /// Converts a theme fill into a terminal-cell color.

--- a/crates/warpui_core/src/elements/tui/collapsible_tests.rs
+++ b/crates/warpui_core/src/elements/tui/collapsible_tests.rs
@@ -2,9 +2,10 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use super::tui_collapsible;
+use crate::elements::tui::test_support::with_paint_context;
 use crate::elements::tui::{
-    TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext, TuiPoint, TuiRect,
-    TuiSize, TuiStyle, TuiText,
+    Modifier, TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiEvent, TuiEventContext,
+    TuiLayoutContext, TuiPoint, TuiRect, TuiSize, TuiStyle, TuiText,
 };
 use crate::elements::MouseStateHandle;
 use crate::event::ModifiersState;
@@ -58,6 +59,52 @@ fn only_a_header_click_invokes_on_toggle() {
             assert_eq!(hits.get(), 1);
             assert!(!click(1));
             assert_eq!(hits.get(), 1);
+        });
+    });
+}
+
+#[test]
+fn header_styles_apply_per_span_without_bleeding_past_the_text() {
+    App::test((), |app| async move {
+        app.read(|app_ctx| {
+            // A plain glyph span beside an underlined label span; the
+            // chevron carries its own style. Nothing may bleed past the
+            // header text into the row's trailing cells.
+            let underlined = TuiStyle::default().add_modifier(Modifier::UNDERLINED);
+            let mut collapsible = tui_collapsible(
+                false,
+                [
+                    ("☰ ".to_owned(), TuiStyle::default()),
+                    ("Tasks 3".to_owned(), underlined),
+                ],
+                TuiStyle::default(),
+                MouseStateHandle::default(),
+                || TuiText::new("body").finish(),
+                |_, _| {},
+            );
+            let mut rendered_views = EntityIdMap::default();
+            let mut ctx = TuiLayoutContext {
+                rendered_views: &mut rendered_views,
+            };
+            let area = TuiRect::new(0, 0, 20, 2);
+            collapsible.layout(TuiConstraint::loose(TuiSize::new(20, 2)), &mut ctx, app_ctx);
+            let mut buffer = TuiBuffer::empty(area);
+            with_paint_context(|paint_ctx| collapsible.render(area, &mut buffer, paint_ctx));
+
+            // The underline covers exactly the label's cells — not the
+            // glyph, the chevron, or the trailing cells past the text. The
+            // label's start column is located from the buffer since the
+            // glyph's cell width varies by rendering backend.
+            assert_eq!(buffer.to_lines()[0].trim_end(), "☰ Tasks 3 ▾");
+            let label_start = (0..20u16)
+                .find(|&x| buffer[(x, 0)].symbol() == "T")
+                .expect("the header row contains the label");
+            let underlined: Vec<u16> = (0..20u16)
+                .filter(|&x| buffer[(x, 0)].modifier.contains(Modifier::UNDERLINED))
+                .collect();
+            // "Tasks 3" spans seven cells.
+            let label_cells: Vec<u16> = (label_start..label_start + 7).collect();
+            assert_eq!(underlined, label_cells);
         });
     });
 }

--- a/specs/CODE-1829/TECH.md
+++ b/specs/CODE-1829/TECH.md
@@ -92,9 +92,8 @@ Add to `crates/warp_tui/src/agent_block_sections.rs`:
 
 ### Redraw and heights
 
-No new subscriptions are needed:
-- New `TodoOperation` messages enter through the existing response-stream path; `UpdatedStreamingExchange` already dirties the owning rich-content item, and `TuiBlockListViewportSource` re-measures via `desired_height`.
-- Per-item status restyling (e.g. an older list's items becoming `Cancelled` when a new list supersedes it) changes colors but not row count; statuses are read at render time, so any frame redraw picks them up without a height invalidation.
+- New `TodoOperation` messages enter through the existing response-stream path; `UpdatedStreamingExchange` dirties the owning rich-content item, and `TuiBlockListViewportSource` re-measures via `desired_height`.
+- Per-item statuses are projections of conversation-wide state. `UpdatedTodoList` therefore dirties every agent block on the terminal surface: a new list can make rows in older exchanges `Cancelled`. `UpdatedConversationStatus` dirties blocks for that conversation because the first pending row switches between `InProgress` and `Stopped`.
 - Collapse toggles change height and follow the same notify path the thinking section already uses.
 
 ## Testing and validation

--- a/specs/CODE-1829/TECH.md
+++ b/specs/CODE-1829/TECH.md
@@ -1,0 +1,126 @@
+# TUI agent task list — TECH
+
+Linear: [CODE-1829](https://linear.app/warpdotdev/issue/CODE-1829/agent-task-list)
+Design: [Figma — TUI / Task list (node 323:17832)](https://www.figma.com/design/yg5nbPZuGoAszHS3Rhvehu/TUI?node-id=323-17832)
+
+## Context
+
+The agent's todo list is invisible in the TUI transcript. The Figma design renders it inline in the conversation as a collapsible block: a bold `☰ Tasks 3 ▾` header row followed by one row per task — a yellow `•` glyph for the in-progress item, `◌` for pending items, white titles indented under the header.
+
+All of the data already flows through production-shaped models the TUI consumes:
+
+- `app/src/ai/agent/mod.rs:1716` — `TodoOperation` (`UpdateTodos { todos }` / `MarkAsCompleted { completed_todos }`) arrives in exchange output as `AIAgentOutputMessageType::TodoOperation`.
+- `app/src/ai/agent/todos/mod.rs` — `AIAgentTodoList` (pending + completed items) is the aggregate list state.
+- `app/src/ai/agent/conversation.rs (3256-3299)` — `AIConversation` owns the `todo_lists` stack; `active_todo_list()` returns the latest, and `todo_status(&AIAgentTodoId)` derives per-item `TodoStatus` (`Pending`, `InProgress`, `Completed`, `Cancelled`, `Stopped`), including cancelling items from superseded lists.
+- `app/src/ai/blocklist/block/view_impl/todos.rs` — the GUI reference: `render_todos` renders `UpdateTodos` as a collapsible "Tasks" card with per-item status icons from `conversation.todo_status()` (falling back to `Cancelled` for unknown ids), and `render_completed_todo_items` renders `MarkAsCompleted` as a one-line `✓ Completed <title> (n/m)` row using the active list for index/length.
+- `app/src/ai/blocklist/block.rs (573-587, 6761-6765)` — GUI per-message `TodoListElementState` defaults to expanded; collapse only changes on manual toggle.
+
+On the TUI side:
+
+- `crates/warp_tui/src/agent_block.rs:325` — `TuiAIBlock::sections` walks `output.messages` in order and currently drops `TodoOperation` (line 385) in the unsupported-message arm.
+- `crates/warp_tui/src/agent_block.rs (54-102)` — `ThinkingBlockStates` is the existing per-message collapse/hover state pattern (manual override map + owned `MouseStateHandle`s keyed by `MessageId`).
+- `crates/warp_tui/src/agent_block_sections.rs` — pure per-section render functions; `render_thinking_section` already composes `TuiUiBuilder::collapsible` for a toggleable header + indented body, and `render_fallback_tool_call_section` establishes the glyph-gutter row style (colored state glyph, then label).
+- `app/src/tui_export.rs` — the narrow export boundary; `BlocklistAIHistoryModel` is already exported, but none of the todo types are.
+
+Per the design review: mirror the GUI's full `TodoStatus` taxonomy (not just the two states visible in the Figma frame); default expanded with manual-toggle-only collapse, matching the GUI. `MarkAsCompleted` progress rows are included (matching the GUI). The GUI's "Outdated" badge is deferred — superseded lists just show cancelled-styled items.
+
+## Proposed changes
+
+### tui_export additions
+
+Export the todo data types `warp_tui` must name: `TodoOperation`, `AIAgentTodo`, `AIAgentTodoId`, `AIAgentTodoList`, and `TodoStatus`.
+
+Do not export `AIConversation`. Instead, add two narrow projections on the already-exported `BlocklistAIHistoryModel`, following the `ConversationUsageTotals` precedent of keeping conversation internals out of the boundary:
+
+```rust
+pub fn todo_status(
+    &self,
+    conversation_id: &AIConversationId,
+    todo_id: &AIAgentTodoId,
+) -> Option<TodoStatus>;
+
+pub fn active_todo_list(
+    &self,
+    conversation_id: &AIConversationId,
+) -> Option<&AIAgentTodoList>;
+```
+
+Both delegate to the conversation's existing methods.
+
+### Section adapter
+
+Add two variants to `TuiAIBlockSection` and matching arms in `TuiAIBlock::sections`:
+
+```rust
+TodoList {
+    message_id: MessageId,
+    todos: Vec<AIAgentTodo>,
+},
+CompletedTodos {
+    completed: Vec<AIAgentTodo>,
+},
+```
+
+- `TodoOperation::UpdateTodos { todos }` with non-empty `todos` becomes `TodoList`; empty lists are ignored (matching the GUI's guard).
+- `TodoOperation::MarkAsCompleted { completed_todos }` becomes `CompletedTodos`.
+
+Ordering stays sourced from the single pass over `output.messages`, per the established adapter rules in `specs/tui-agent-tool-calls/TECH.md`.
+
+### Collapse state
+
+Rename `ThinkingBlockStates` to a shared `CollapsibleSectionStates` and reuse the same instance for task lists. The struct's semantics already fit both consumers: `is_collapsed(message_id, default_collapsed)` returns the manual override if recorded, else the default. Thinking sections keep passing `finished` as the default; task lists pass `false` (always default-expanded, manual toggle wins permanently — the GUI behavior). `MessageId`s are unique across message kinds, so one map per block cannot collide.
+
+### Renderers
+
+Add to `crates/warp_tui/src/agent_block_sections.rs`:
+
+`render_todo_list_section(states, message_id, todos, conversation_id, app)`:
+- Header: `☰ Tasks {todos.len()}` rendered through `TuiUiBuilder::collapsible` with the block's persistent hover state, bold/primary styling per the Figma. The collapsible helper owns the `▾`/`▸` affordance and toggle callback (record override, `event_ctx.notify()`), exactly like the thinking section.
+- Body: one row per todo, indented under the header, in a glyph gutter + title layout mirroring `render_fallback_tool_call_section`. Status comes from the new `BlocklistAIHistoryModel::todo_status` projection, falling back to `Cancelled` like the GUI. Glyph/style mapping:
+  - `InProgress` — `•` with `attention_glyph_style` (yellow), title in `primary_text_style` (Figma).
+  - `Pending` — `◌` and title in `primary_text_style` (Figma).
+  - `Completed` — `✓` with `success_glyph_style`, title in `primary_text_style`.
+  - `Cancelled` — cancelled glyph from the tool-call glyph conventions, title in `muted_text_style` with the crossed-out modifier if `TuiText` styling supports it; otherwise muted color alone.
+  - `Stopped` — stop glyph, `muted_text_style`.
+
+  Reuse/extend the glyph table in `crates/warp_tui/src/tool_call_labels.rs` rather than introducing a second glyph vocabulary.
+
+`render_completed_todos_section(completed, active_list, app)`:
+- A single muted row: `✓ Completed <title> (n/m)`, joining multiple completions with commas, using `active_todo_list` for index/length and omitting `(n/m)` when the item is not in the active list — a direct port of the GUI's `render_completed_todo_items` text logic. Returns nothing when the text would be empty.
+
+`TuiAIBlock::render_element` dispatches the new variants; `TuiAIBlock` passes its `conversation_id` through to the todo-list renderer for status lookups.
+
+### Redraw and heights
+
+No new subscriptions are needed:
+- New `TodoOperation` messages enter through the existing response-stream path; `UpdatedStreamingExchange` already dirties the owning rich-content item, and `TuiBlockListViewportSource` re-measures via `desired_height`.
+- Per-item status restyling (e.g. an older list's items becoming `Cancelled` when a new list supersedes it) changes colors but not row count; statuses are read at render time, so any frame redraw picks them up without a height invalidation.
+- Collapse toggles change height and follow the same notify path the thinking section already uses.
+
+## Testing and validation
+
+Unit tests in `crates/warp_tui/src/agent_block_tests.rs`:
+- `UpdateTodos` produces a `TodoList` section in message order between adjacent text/tool-call sections; empty `UpdateTodos` is ignored.
+- `MarkAsCompleted` produces a `CompletedTodos` section; the rendered text includes `(n/m)` when the item is in the active list and omits it otherwise.
+- Glyph/style mapping per `TodoStatus`, including the `Cancelled` fallback for ids missing from the conversation.
+- Default-expanded behavior and manual collapse override via `CollapsibleSectionStates`, and `desired_height` differing between expanded and collapsed.
+- Existing thinking-section tests keep passing after the state-struct rename.
+
+App-side test for the two `BlocklistAIHistoryModel` projections (status delegation and active-list lookup) next to existing history-model tests.
+
+Manual validation: run `cargo run -p warp_tui`, prompt the agent into a multi-step task that creates todos, and verify the Tasks block matches the Figma (header count, glyphs, indentation), updates as items complete, and collapses/expands on header click.
+
+Run:
+- `cargo nextest run -p warp_tui`
+- `cargo nextest run -p warp history_model`
+- `./script/format`
+- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings`
+
+## Parallelization
+
+No child agents. This is a small, tightly coupled change inside one crate plus a narrow export addition — the adapter variant, renderers, and state rename all touch the same files, so parallel branches would only create merge overhead. Implement sequentially on `ian/code-1829-agent-task-list`.
+
+## Follow-ups
+
+- "Outdated" indicator for superseded task lists (GUI parity), deferred from v1.
+- Strikethrough support in `TuiText` styling if the crossed-out modifier is not currently plumbed through, so cancelled items can match GUI treatment fully.


### PR DESCRIPTION
## Description
- Render agent `UpdateTodos` and `MarkAsCompleted` operations inline in the TUI transcript with status glyphs, collapse state, and semantic theme styling.
- Derive task status from canonical conversation todo state so active, stopped, completed, cancelled, and superseded lists stay consistent with Agent Mode.
- Extend the generic TUI collapsible header to support independently styled spans, keeping hover underline on the task label without underlining the leading glyph or chevron.
- Refresh affected transcript blocks when conversation-wide todo or status projections change, preventing cached older task lists from showing stale state.
- Document the implementation and redraw model in `specs/CODE-1829/TECH.md`.

## Linked Issue
[CODE-1829: Agent task list](https://linear.app/warpdotdev/issue/CODE-1829/agent-task-list)

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `./script/format --check`
- `./script/check_no_inline_test_modules`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `cargo nextest run -p warp_tui --no-fail-fast` (113 passed)
- `cargo nextest run -p warp history_model` (71 passed)
- `cargo nextest run -p warpui_core --features tui collapsible` (2 passed)
- `cargo build -p warp_tui --bin warp-tui-oss`
- Manually verified expanded/collapsed task rendering, status styling, and label-only hover underline in the macOS TUI using tmux capture.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- [Conversation](https://staging.warp.dev/conversation/2ed8235b-00a7-4d25-a377-f503987542fc)
- [Run](https://oz.staging.warp.dev/runs/019f489c-78ce-7639-ac2b-1dcacc92c04d)

CHANGELOG-IMPROVEMENT: Agent task lists now render inline in the terminal UI transcript.

Co-Authored-By: Oz <oz-agent@warp.dev>
