### PR TITLE
fix(window-tabs-panes): show agent status badges in vertical tabs summary view (#9868)

### DIFF
--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -29112,7 +29112,9 @@ fn render_group_member_icon_collage(
         // element (leaving room for the cloud badge). Shift right-down by
         // (1 - CIRCLE_RATIO)/2 * icon_diameter so the circle centers on the grid point.
         let collage_pos = match &kind {
-            SummaryPaneKind::OzAgent { is_ambient: true }
+            SummaryPaneKind::OzAgent {
+                is_ambient: true, ..
+            }
             | SummaryPaneKind::CLIAgent {
                 is_ambient: true, ..
             } => {

--- a/app/src/workspace/view/vertical_tabs.rs
+++ b/app/src/workspace/view/vertical_tabs.rs
@@ -897,16 +897,43 @@ enum VerticalTabsResolvedMode {
     Summary,
 }
 
+/// Wraps a value so it is ignored by `PartialEq`/`Eq`. Used to carry render-only agent
+/// status on `SummaryPaneKind` without letting it affect summary-icon dedup/pairing, which
+/// keys off pane *kind* only (an agent's status must not split it into a separate icon slot).
+#[derive(Clone, Debug, Default)]
+pub(super) struct IgnoredInEq<T>(pub T);
+
+impl<T> PartialEq for IgnoredInEq<T> {
+    fn eq(&self, _: &Self) -> bool {
+        true
+    }
+}
+
+impl<T> Eq for IgnoredInEq<T> {}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) enum SummaryPaneKind {
     Terminal,
-    OzAgent { is_ambient: bool },
-    CLIAgent { agent: CLIAgent, is_ambient: bool },
-    Code { title: String },
+    OzAgent {
+        status: IgnoredInEq<Option<ConversationStatus>>,
+        is_ambient: bool,
+    },
+    CLIAgent {
+        agent: CLIAgent,
+        status: IgnoredInEq<Option<ConversationStatus>>,
+        is_ambient: bool,
+    },
+    Code {
+        title: String,
+    },
     CodeDiff,
     File,
-    Notebook { is_plan: bool },
-    Workflow { is_ai_prompt: bool },
+    Notebook {
+        is_plan: bool,
+    },
+    Workflow {
+        is_ai_prompt: bool,
+    },
     Settings,
     EnvVarCollection,
     EnvironmentManagement,
@@ -3509,12 +3536,21 @@ impl TypedPane<'_> {
                 // Route through the shared helper so summary mode agrees with
                 // `resolve_icon_with_status_variant` on what the tab represents.
                 match terminal_view_agent_icon_variant(terminal_view, app) {
-                    Some(IconWithStatusVariant::OzAgent { is_ambient, .. }) => {
-                        SummaryPaneKind::OzAgent { is_ambient }
+                    Some(IconWithStatusVariant::OzAgent { status, is_ambient }) => {
+                        SummaryPaneKind::OzAgent {
+                            status: IgnoredInEq(status),
+                            is_ambient,
+                        }
                     }
                     Some(IconWithStatusVariant::CLIAgent {
-                        agent, is_ambient, ..
-                    }) => SummaryPaneKind::CLIAgent { agent, is_ambient },
+                        agent,
+                        status,
+                        is_ambient,
+                    }) => SummaryPaneKind::CLIAgent {
+                        agent,
+                        status: IgnoredInEq(status),
+                        is_ambient,
+                    },
                     Some(_) | None => SummaryPaneKind::Terminal,
                 }
             }
@@ -4902,11 +4938,11 @@ pub(super) fn render_summary_pane_kind_icon_circle(
     appearance: &Appearance,
 ) -> Box<dyn Element> {
     let theme = appearance.theme();
-    // For ambient Oz / CLI agent kinds, delegate to `render_icon_with_status` so the
-    // brand-color circle is overlaid with the white cloud badge (status-less in summary
-    // mode). Non-ambient agent kinds and all other pane kinds fall through to the inline
-    // circle rendering below.
-    if let Some(variant) = ambient_agent_variant(&kind) {
+    // For Oz / CLI agent kinds, delegate to `render_icon_with_status` so the brand-color
+    // circle is overlaid with the agent's status badge (or the white cloud badge when
+    // ambient) — matching the status-aware icons on regular pane rows. All other pane kinds
+    // fall through to the inline circle rendering below.
+    if let Some(variant) = agent_status_variant(&kind) {
         return render_icon_with_status(variant, total_size, 0., theme, theme.background());
     }
     let icon_size = total_size * SUMMARY_INLINE_ICON_RATIO;
@@ -4980,22 +5016,25 @@ pub(super) fn render_summary_pane_kind_icon_circle(
     .finish()
 }
 
-/// Maps an ambient Oz / CLI agent summary-pane kind to the `IconWithStatusVariant` used to
-/// render the brand-color circle with the white cloud badge. Non-ambient kinds (and all
-/// other pane kinds) return `None` so the caller falls back to its inline rendering.
-fn ambient_agent_variant(kind: &SummaryPaneKind) -> Option<IconWithStatusVariant> {
+/// Maps an Oz / CLI agent summary-pane kind to the `IconWithStatusVariant` used to render
+/// the brand-color circle with its status overlay — the same status-aware renderer the
+/// regular (non-summary) pane rows use. Ambient agents get the white cloud badge; non-ambient
+/// agents get the status badge for their `ConversationStatus`. Non-agent pane kinds return
+/// `None` so the caller falls back to its inline rendering.
+fn agent_status_variant(kind: &SummaryPaneKind) -> Option<IconWithStatusVariant> {
     match kind {
-        SummaryPaneKind::OzAgent { is_ambient: true } => Some(IconWithStatusVariant::OzAgent {
-            status: None,
-            is_ambient: true,
+        SummaryPaneKind::OzAgent { status, is_ambient } => Some(IconWithStatusVariant::OzAgent {
+            status: status.0.clone(),
+            is_ambient: *is_ambient,
         }),
         SummaryPaneKind::CLIAgent {
             agent,
-            is_ambient: true,
+            status,
+            is_ambient,
         } => Some(IconWithStatusVariant::CLIAgent {
             agent: *agent,
-            status: None,
-            is_ambient: true,
+            status: status.0.clone(),
+            is_ambient: *is_ambient,
         }),
         _ => None,
     }

--- a/app/src/workspace/view/vertical_tabs_tests.rs
+++ b/app/src/workspace/view/vertical_tabs_tests.rs
@@ -16,10 +16,10 @@ use super::{
     summary_search_text_fragments, terminal_kind_badge_label, terminal_primary_line_data,
     terminal_pull_request_badge_label, terminal_search_text_fragments,
     terminal_title_fallback_font, uses_outer_group_container, visible_pane_ids_for_detail_target,
-    vtab_diff_stats_text, AgentTabTextPreference, SummaryPaneKind, SummaryPaneKindIcons,
-    TerminalAgentText, TerminalPrimaryLineData, TerminalPrimaryLineFont, VerticalTabsDetailTarget,
-    VerticalTabsDetailTargetKind, VerticalTabsSummaryBranchEntry, VerticalTabsSummaryData,
-    VerticalTabsSummaryPrimaryLabel,
+    vtab_diff_stats_text, AgentTabTextPreference, IgnoredInEq, SummaryPaneKind,
+    SummaryPaneKindIcons, TerminalAgentText, TerminalPrimaryLineData, TerminalPrimaryLineFont,
+    VerticalTabsDetailTarget, VerticalTabsDetailTargetKind, VerticalTabsSummaryBranchEntry,
+    VerticalTabsSummaryData, VerticalTabsSummaryPrimaryLabel,
 };
 use crate::ai::agent::conversation::ConversationStatus;
 use crate::context_chips::display_chip::GitLineChanges;
@@ -42,6 +42,21 @@ fn pane_id() -> PaneId {
 fn code_summary_kind(title: &str) -> SummaryPaneKind {
     SummaryPaneKind::Code {
         title: title.to_string(),
+    }
+}
+
+fn cli_agent_kind(agent: CLIAgent, is_ambient: bool) -> SummaryPaneKind {
+    SummaryPaneKind::CLIAgent {
+        agent,
+        status: IgnoredInEq(None),
+        is_ambient,
+    }
+}
+
+fn oz_agent_kind(is_ambient: bool) -> SummaryPaneKind {
+    SummaryPaneKind::OzAgent {
+        status: IgnoredInEq(None),
+        is_ambient,
     }
 }
 
@@ -96,22 +111,13 @@ fn summary_pane_kind_icons_distinguish_agent_terminals_from_plain_terminals() {
             (EntityId::from_usize(10), SummaryPaneKind::Terminal),
             (
                 EntityId::from_usize(20),
-                SummaryPaneKind::CLIAgent {
-                    agent: CLIAgent::Claude,
-                    is_ambient: false,
-                },
+                cli_agent_kind(CLIAgent::Claude, false),
             ),
-            (
-                EntityId::from_usize(30),
-                SummaryPaneKind::OzAgent { is_ambient: false },
-            ),
+            (EntityId::from_usize(30), oz_agent_kind(false)),
         ]),
         Some(SummaryPaneKindIcons::Pair {
             primary: SummaryPaneKind::Terminal,
-            secondary: SummaryPaneKind::CLIAgent {
-                agent: CLIAgent::Claude,
-                is_ambient: false,
-            },
+            secondary: cli_agent_kind(CLIAgent::Claude, false),
         })
     );
 }
@@ -124,29 +130,41 @@ fn summary_pane_kind_icons_distinguish_ambient_claude_from_local_claude() {
         select_summary_pane_kind_icons([
             (
                 EntityId::from_usize(10),
-                SummaryPaneKind::CLIAgent {
-                    agent: CLIAgent::Claude,
-                    is_ambient: false,
-                },
+                cli_agent_kind(CLIAgent::Claude, false),
             ),
             (
                 EntityId::from_usize(20),
-                SummaryPaneKind::CLIAgent {
-                    agent: CLIAgent::Claude,
-                    is_ambient: true,
-                },
+                cli_agent_kind(CLIAgent::Claude, true),
             ),
         ]),
         Some(SummaryPaneKindIcons::Pair {
-            primary: SummaryPaneKind::CLIAgent {
-                agent: CLIAgent::Claude,
-                is_ambient: false,
-            },
-            secondary: SummaryPaneKind::CLIAgent {
-                agent: CLIAgent::Claude,
-                is_ambient: true,
-            },
+            primary: cli_agent_kind(CLIAgent::Claude, false),
+            secondary: cli_agent_kind(CLIAgent::Claude, true),
         })
+    );
+}
+
+#[test]
+fn summary_pane_kind_icons_ignore_agent_status_when_deduping() {
+    // Regression (#9868): two Claude sessions with different live statuses are still the same
+    // icon *kind*, so they must collapse to a single icon rather than rendering as a pair.
+    // Status rides along for the badge overlay but must not affect dedup/pairing.
+    let running = SummaryPaneKind::CLIAgent {
+        agent: CLIAgent::Claude,
+        status: IgnoredInEq(Some(ConversationStatus::InProgress)),
+        is_ambient: false,
+    };
+    let done = SummaryPaneKind::CLIAgent {
+        agent: CLIAgent::Claude,
+        status: IgnoredInEq(Some(ConversationStatus::Success)),
+        is_ambient: false,
+    };
+    assert_eq!(
+        select_summary_pane_kind_icons([
+            (EntityId::from_usize(10), running.clone()),
+            (EntityId::from_usize(20), done),
+        ]),
+        Some(SummaryPaneKindIcons::Single(running)),
     );
 }
 


### PR DESCRIPTION
Resolves #9868.

## Problem

In vertical tabs **Summary view**, agent rows stopped showing their status icon/badge, so you couldn't tell at a glance whether an agent was running, done, errored, cancelled, or blocked without opening it.

## Root cause

The Summary-view tab-row icon path collapsed an agent terminal to a *kind-only* icon (`SummaryPaneKind::OzAgent` / `CLIAgent`), discarding the `ConversationStatus` that the regular (non-summary) pane rows carry. `summary_pane_kind()` matched the status-aware `IconWithStatusVariant` but dropped its `status` field, and the summary renderer only delegated **ambient** agents to `render_icon_with_status` (with `status: None`), while non-ambient agents fell through to a plain brand-circle with no status overlay at all.

## Fix

- Thread `ConversationStatus` through `SummaryPaneKind::OzAgent` / `CLIAgent`.
- Route **all** agent kinds (ambient and non-ambient) through `render_icon_with_status` — the same status-aware renderer the regular pane rows use — so the status badge (or ambient cloud badge) renders consistently.
- Wrap the status in a tiny `IgnoredInEq` newtype so it rides along for rendering **without** affecting summary-icon dedup/pairing, which keys off pane *kind* only. (Two same-kind agents with different statuses must still collapse to a single icon, not render as a pair.)

## Tests

Adds `summary_pane_kind_icons_ignore_agent_status_when_deduping`, asserting two Claude sessions with different statuses collapse to a `Single` icon. Existing summary-icon tests updated to the new variant shape via helpers. `cargo fmt`, `cargo clippy --tests`, and the `warp` unit tests pass locally.

## Validation

- [ ] Screen recording: vertical tabs → Summary view, agents in running / done / errored states showing their badges. _(attaching)_
