### PR TITLE
Include full Debug-formatted errors in cloud agent traces.

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -614,7 +614,7 @@ impl From<PrepareEnvironmentError> for AgentDriverError {
 }
 
 impl AgentDriver {
-    #[tracing::instrument(name = "AgentDriver::new", skip_all, err, fields(
+    #[tracing::instrument(name = "AgentDriver::new", skip_all, err(Debug), fields(
         tags.cloud_agent = true,
         task_id = ?options.task_id,
         parent_run_id = ?options.parent_run_id,
@@ -1971,7 +1971,7 @@ impl AgentDriver {
     /// Driving the agent mostly requires main-thread UI framework updates, but using `async` and
     /// a `ModelSpawner` lets us express the high-level process linearly rather than in a
     /// series of callbacks and state machine updates.
-    #[tracing::instrument(name = "AgentDriver::run_internal", skip_all, err, fields(tags.cloud_agent = true))]
+    #[tracing::instrument(name = "AgentDriver::run_internal", skip_all, err(Debug), fields(tags.cloud_agent = true))]
     async fn run_internal(
         task: Task,
         foreground: ModelSpawner<Self>,

--- a/app/src/ai/agent_sdk/driver/attachments.rs
+++ b/app/src/ai/agent_sdk/driver/attachments.rs
@@ -32,7 +32,7 @@ pub const MAX_ATTACHMENT_COUNT_FOR_CLOUD_QUERY: usize = 25;
 ///
 /// Makes a best-effort attempt to download all attachments.
 /// Individual download failures are logged but don't cause the entire function to fail.
-#[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
+#[tracing::instrument(skip_all, err(Debug), fields(tags.cloud_agent = true))]
 pub(crate) async fn fetch_and_download_attachments(
     ai_client: Arc<dyn AIClient>,
     http_client: Arc<ServerApi>,
@@ -68,7 +68,7 @@ pub(crate) async fn fetch_and_download_attachments(
 /// logged at WARN level inside this function; per-file errors are not surfaced to callers.
 ///
 /// Fatal failures (listing the attachments, creating the handoff dir) return `Err`.
-#[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
+#[tracing::instrument(skip_all, err(Debug), fields(tags.cloud_agent = true))]
 pub(crate) async fn fetch_and_download_handoff_snapshot_attachments(
     ai_client: Arc<dyn AIClient>,
     http_client: &http_client::Client,
@@ -223,7 +223,7 @@ async fn download_handoff_entry(
 /// Shared download primitive: GET `download_url`, write the body to `file_path`, and retry
 /// transient HTTP failures on the shared bounded-backoff schedule. Non-2xx responses surface
 /// an [`HttpStatusError`] so the retry classifier can decide whether to retry.
-#[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
+#[tracing::instrument(skip_all, err(Debug), fields(tags.cloud_agent = true))]
 async fn download_attachment(
     http_client: &http_client::Client,
     download_url: &str,
@@ -231,7 +231,7 @@ async fn download_attachment(
 ) -> anyhow::Result<()> {
     let operation = format!("download attachment '{}'", file_path.display());
 
-    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
+    #[tracing::instrument(skip_all, err(Debug), fields(tags.cloud_agent = true))]
     async fn attempt(
         http_client: &http_client::Client,
         download_url: &str,

--- a/app/src/ai/agent_sdk/driver/bedrock_credentials.rs
+++ b/app/src/ai/agent_sdk/driver/bedrock_credentials.rs
@@ -35,7 +35,7 @@ pub(crate) const BEDROCK_CREDENTIALS_REFRESH_INTERVAL: Duration = Duration::from
 #[tracing::instrument(
     name = "bedrock_credentials::try_refresh",
     skip_all,
-    err,
+    err(Debug),
     fields(tags.cloud_agent = true, task_id)
 )]
 async fn try_refresh(

--- a/app/src/ai/agent_sdk/driver/environment.rs
+++ b/app/src/ai/agent_sdk/driver/environment.rs
@@ -375,7 +375,7 @@ pub(super) async fn clone_repos(
 
 /// Clone a source repository to `{working_dir}/{repo.repo}` if it does not already exist.
 /// This only performs the clone -- it does NOT register the repo with `DetectedRepositories`.
-#[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true, repo = %repo))]
+#[tracing::instrument(skip_all, err(Debug), fields(tags.cloud_agent = true, repo = %repo))]
 pub(super) async fn clone_repo(
     repo: &SourceRepo,
     working_dir: &Path,
@@ -436,7 +436,7 @@ pub(super) async fn clone_repo(
 
 /// Register a cloned source repository with `DetectedRepositories` so that the
 /// skill watcher and other repo-aware subsystems can discover it.
-#[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true, repo = %repo, is_sandbox = is_sandbox))]
+#[tracing::instrument(skip_all, err(Debug), fields(tags.cloud_agent = true, repo = %repo, is_sandbox = is_sandbox))]
 pub(super) async fn register_cloned_repo(
     repo: &SourceRepo,
     working_dir: &Path,
@@ -542,7 +542,7 @@ async fn subscribe_to_codebase_index_events(
         .map_err(|_| PrepareEnvironmentError::InvalidRuntimeState)
 }
 
-#[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true, repo = %repo_name))]
+#[tracing::instrument(skip_all, err(Debug), fields(tags.cloud_agent = true, repo = %repo_name))]
 async fn index_repo_codebase(
     repo_name: &str,
     working_dir: &Path,

--- a/app/src/ai/agent_sdk/driver/git_credentials.rs
+++ b/app/src/ai/agent_sdk/driver/git_credentials.rs
@@ -327,7 +327,7 @@ pub(crate) fn configure_git_identity(credentials: &[GitCredential]) {
 /// Returns `Ok(())` on success (including when the server returns no
 /// credentials). Returns `Err` when the workload-token issuance or the server
 /// API call fails — these are transient failures worth retrying.
-#[tracing::instrument(name = "git_credentials::try_refresh", skip_all, err, fields(
+#[tracing::instrument(name = "git_credentials::try_refresh", skip_all, err(Debug), fields(
     tags.cloud_agent = true,
     task_id,
 ))]

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -122,7 +122,7 @@ fn maybe_warn_team_api_key(ctx: &AppContext) {
 }
 
 /// Run a Warp CLI command.
-#[tracing::instrument(name = "agent_sdk::run", skip_all, err, fields(tags.cloud_agent = true))]
+#[tracing::instrument(name = "agent_sdk::run", skip_all, err(Debug), fields(tags.cloud_agent = true))]
 pub fn run(
     ctx: &mut AppContext,
     command: CliCommand,
@@ -613,7 +613,7 @@ impl warpui::Entity for AgentDriverRunner {
 impl warpui::SingletonEntity for AgentDriverRunner {}
 
 impl AgentDriverRunner {
-    #[tracing::instrument(skip_all, err, fields(
+    #[tracing::instrument(skip_all, err(Debug), fields(
         tags.cloud_agent = true,
         args.sandboxed = args.sandboxed,
         args.computer_use = args.computer_use.computer_use,
@@ -1350,7 +1350,7 @@ impl AgentDriverRunner {
     /// wraps the returned payload (if any) in [`driver::ResumeOptions::ThirdParty`]; each harness
     /// owns its server call and error mapping. Returns `None` if a third-party harness has no
     /// resume payload to surface.
-    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true, conversation_id = conversation_id))]
+    #[tracing::instrument(skip_all, err(Debug), fields(tags.cloud_agent = true, conversation_id = conversation_id))]
     async fn load_conversation_information(
         foreground: &ModelSpawner<Self>,
         conversation_id: String,
@@ -1412,7 +1412,7 @@ impl AgentDriverRunner {
     }
 
     /// Resolve the environment and store into `driver_options`.
-    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true, ?environment_id))]
+    #[tracing::instrument(skip_all, err(Debug), fields(tags.cloud_agent = true, ?environment_id))]
     async fn resolve_environment(
         foreground: &ModelSpawner<Self>,
         environment_id: Option<String>,

--- a/app/src/ai/bedrock_credentials.rs
+++ b/app/src/ai/bedrock_credentials.rs
@@ -35,7 +35,7 @@ pub(crate) const BEDROCK_CREDENTIALS_REFRESH_INTERVAL: Duration = Duration::from
 #[tracing::instrument(
     name = "bedrock_credentials::try_refresh",
     skip_all,
-    err,
+    err(Debug),
     fields(tags.cloud_agent = true, task_id)
 )]
 async fn try_refresh(

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -2012,7 +2012,7 @@ impl AIClient for ServerApi {
         }
     }
 
-    #[tracing::instrument(skip_all, err, fields(
+    #[tracing::instrument(skip_all, err(Debug), fields(
         tags.cloud_agent = true,
         config.worker_host = tracing::field::Empty,
         config.harness = tracing::field::Empty
@@ -2069,7 +2069,7 @@ impl AIClient for ServerApi {
         }
     }
 
-    #[tracing::instrument(skip_all, err, fields(
+    #[tracing::instrument(skip_all, err(Debug), fields(
         tags.cloud_agent = true,
         ?task_state,
         ?session_id,
@@ -2179,7 +2179,7 @@ impl AIClient for ServerApi {
         Ok(response)
     }
 
-    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
+    #[tracing::instrument(skip_all, err(Debug), fields(tags.cloud_agent = true))]
     async fn get_ambient_agent_task(
         &self,
         task_id: &AmbientAgentTaskId,
@@ -2234,7 +2234,7 @@ impl AIClient for ServerApi {
         }
     }
 
-    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
+    #[tracing::instrument(skip_all, err(Debug), fields(tags.cloud_agent = true))]
     async fn get_ai_conversation(
         &self,
         server_conversation_token: ServerConversationToken,
@@ -2614,7 +2614,7 @@ impl AIClient for ServerApi {
         }
     }
 
-    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
+    #[tracing::instrument(skip_all, err(Debug), fields(tags.cloud_agent = true))]
     async fn get_task_attachments(
         &self,
         task_id: String,
@@ -2776,7 +2776,7 @@ impl AIClient for ServerApi {
         Ok(response)
     }
 
-    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
+    #[tracing::instrument(skip_all, err(Debug), fields(tags.cloud_agent = true))]
     async fn get_handoff_snapshot_attachments(
         &self,
         task_id: &AmbientAgentTaskId,

--- a/app/src/server/server_api/team.rs
+++ b/app/src/server/server_api/team.rs
@@ -166,7 +166,7 @@ pub trait TeamClient: 'static + Send + Sync {
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 impl TeamClient for ServerApi {
-    #[tracing::instrument(skip_all, err, fields(tags.cloud_agent = true))]
+    #[tracing::instrument(skip_all, err(Debug), fields(tags.cloud_agent = true))]
     async fn workspaces_metadata(&self) -> Result<WorkspacesMetadataWithPricing> {
         let variables = GetWorkspacesMetadataForUserVariables {
             request_context: get_request_context(),

--- a/crates/managed_secrets/src/manager.rs
+++ b/crates/managed_secrets/src/manager.rs
@@ -162,7 +162,7 @@ impl ManagedSecretManager {
         task_id: String,
     ) -> impl Future<Output = anyhow::Result<HashMap<String, ManagedSecretValue>>> + use<> {
         // Define and invoke an inner async function to simplify tracing instrumentation.
-        #[tracing::instrument(name = "get_task_secrets", skip_all, err, fields(tags.cloud_agent = true))]
+        #[tracing::instrument(name = "get_task_secrets", skip_all, err(Debug), fields(tags.cloud_agent = true))]
         async fn inner(
             client: Arc<dyn ManagedSecretsClient>,
             task_id: String,


### PR DESCRIPTION
## Description

`#[tracing::instrument(err)]` formats the error using its `Display` format, which only includes the human-readable representation of the _top_ error in the causal chain.  We use `anyhow` and `thiserror` for richer, structured errors, and so we should switch to `err(Debug)` in order to get the full structured error data.