### PR TITLE
Remove first telemetry batch for ownership review (David)

### DIFF
--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -1860,18 +1860,7 @@ impl AIBlock {
             self.time_to_last_token = Some(latency);
         }
 
-        let was_autodetected_ai_query = self.model.was_autodetected_ai_query(ctx);
-        let client_exchange_id = self.client_ids.client_exchange_id.to_string();
-        let conversation_id = self.client_ids.conversation_id;
-        let time_to_first_token_ms = self
-            .time_to_first_token
-            .get()
-            .map(|duration| duration.num_milliseconds() as u128);
-        let time_to_last_token_ms = self
-            .time_to_last_token
-            .map(|duration| duration.num_milliseconds() as u128);
         let status = self.model.status(ctx);
-        let is_udi_enabled = InputSettings::as_ref(ctx).is_universal_developer_input_enabled(ctx);
 
         match status {
             AIBlockOutputStatus::Pending => {
@@ -1885,23 +1874,8 @@ impl AIBlock {
             }
             AIBlockOutputStatus::Complete { output } => {
                 let output = output.get();
-                let server_output_id = self.model.server_output_id(ctx);
                 self.handle_updated_output(&output, ctx);
                 self.handle_complete_output(&output, ctx);
-                send_telemetry_from_ctx!(
-                    TelemetryEvent::AgentModeCreatedAIBlock {
-                        client_exchange_id,
-                        was_autodetected_ai_query,
-                        conversation_id,
-                        time_to_first_token_ms,
-                        time_to_last_token_ms,
-                        server_output_id,
-                        was_user_facing_error: false,
-                        cancelled: false,
-                        is_udi_enabled,
-                    },
-                    ctx
-                );
             }
             AIBlockOutputStatus::Cancelled { partial_output, .. } => {
                 if let Some(output) = partial_output.as_ref() {
@@ -1910,39 +1884,8 @@ impl AIBlock {
                 }
                 self.spawn_link_detection(ctx);
                 self.finish(FinishReason::Cancelled, ctx);
-
-                let server_output_id = self.model.server_output_id(ctx);
-                send_telemetry_from_ctx!(
-                    TelemetryEvent::AgentModeCreatedAIBlock {
-                        client_exchange_id,
-                        conversation_id,
-                        was_autodetected_ai_query,
-                        time_to_first_token_ms,
-                        time_to_last_token_ms,
-                        server_output_id,
-                        was_user_facing_error: false,
-                        cancelled: true,
-                        is_udi_enabled,
-                    },
-                    ctx
-                );
             }
             AIBlockOutputStatus::Failed { error, .. } => {
-                let server_output_id = self.model.server_output_id(ctx);
-                send_telemetry_from_ctx!(
-                    TelemetryEvent::AgentModeCreatedAIBlock {
-                        client_exchange_id,
-                        was_autodetected_ai_query,
-                        conversation_id,
-                        time_to_first_token_ms,
-                        time_to_last_token_ms,
-                        server_output_id,
-                        was_user_facing_error: true,
-                        cancelled: false,
-                        is_udi_enabled,
-                    },
-                    ctx
-                );
                 self.maybe_create_aws_bedrock_credentials_error_view(&error, ctx);
                 // There are no actions to be taken in this block, it is finished.
                 self.finish(FinishReason::Error, ctx);

--- a/app/src/ai/blocklist/block/status_bar.rs
+++ b/app/src/ai/blocklist/block/status_bar.rs
@@ -742,15 +742,6 @@ impl BlocklistAIStatusBar {
 
             // Get the current tip from the model
             self.current_tip = tip_model.as_ref(ctx).current_tip().cloned();
-
-            if let Some(tip) = self.current_tip.as_ref() {
-                send_telemetry_from_app_ctx!(
-                    TelemetryEvent::AgentTipShown {
-                        tip: tip.description.clone()
-                    },
-                    ctx
-                );
-            }
         } else {
             self.current_tip = None;
         }

--- a/app/src/experiments/mod.rs
+++ b/app/src/experiments/mod.rs
@@ -27,7 +27,6 @@ use warpui::{AppContext, SingletonEntity};
 
 use crate::auth::auth_state::AuthStateProvider;
 use crate::channel::{Channel, ChannelState};
-use crate::send_telemetry_sync_from_app_ctx;
 
 /// Number of buckets we are using to partition user traffic. The largest valid
 /// bucket index is NUM_BUCKETS - 1.
@@ -330,19 +329,6 @@ pub trait Experiment<T: Experiment<T>>: FromStr {
         if assigned_group.is_none() {
             let anonymous_id = AuthStateProvider::as_ref(ctx).get().anonymous_id();
             assigned_group = Self::layer().get_assigned_group(&anonymous_id);
-
-            if let Some(group) = assigned_group.as_ref() {
-                let group_assignment = group.variant();
-                // Send synchronously since this we rely on this event to collect experiment data.
-                send_telemetry_sync_from_app_ctx!(
-                    crate::server::telemetry::TelemetryEvent::ExperimentTriggered {
-                        experiment: Self::name(),
-                        layer: Self::layer().name(),
-                        group_assignment,
-                    },
-                    ctx
-                );
-            }
         }
 
         // If the user is in a group for this experiment, cache the result of

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2490,13 +2490,6 @@ pub(crate) fn app_callbacks(
 
             let summary = UnsavedStateSummary::for_window(window_id, ctx);
 
-            send_telemetry_from_app_ctx!(
-                TelemetryEvent::UserInitiatedClose {
-                    initiated_on: CloseTarget::Window,
-                },
-                ctx
-            );
-
             // Don't show dialog on integration test. Machine can't press buttons.
             if !is_integration_test && summary.should_display_warning(ctx) {
                 let shown = summary
@@ -2534,13 +2527,6 @@ pub(crate) fn app_callbacks(
             if source == TerminationRequestSource::System {
                 return ApproveTerminateResult::Terminate;
             }
-
-            send_telemetry_from_app_ctx!(
-                TelemetryEvent::UserInitiatedClose {
-                    initiated_on: CloseTarget::App,
-                },
-                ctx
-            );
 
             // If there's a pending autoupdate, apply that before showing the unsaved changes
             // dialog. We apply the update first so that the dialog can force-terminate.

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -10864,17 +10864,10 @@ impl Input {
                 }
             }
             EditorEvent::AutosuggestionAccepted {
-                insertion_length,
-                buffer_char_length,
+                insertion_length: _,
+                buffer_char_length: _,
                 autosuggestion_type,
             } => {
-                send_telemetry_from_ctx!(
-                    TelemetryEvent::AutosuggestionInserted {
-                        insertion_length: *insertion_length,
-                        buffer_length: *buffer_char_length
-                    },
-                    ctx
-                );
                 ctx.emit(Event::AutosuggestionAccepted);
 
                 self.input_suggestions
@@ -11038,24 +11031,12 @@ impl Input {
 
                 match token_at {
                     CommandXRayAnchor::Cursor => {
-                        send_telemetry_from_ctx!(
-                            TelemetryEvent::CommandXRayTriggered {
-                                trigger: CommandXRayTrigger::Keystroke
-                            },
-                            ctx
-                        );
                         let pos = self.start_byte_index_of_first_selection(ctx);
                         self.start_xray_at_offset(pos, CommandXRayTrigger::Keystroke, ctx);
                     }
                     CommandXRayAnchor::Hover(mouse_position) => {
                         if let Some(offset) = self.start_byte_index_at_point(mouse_position, ctx) {
                             if !self.suggestions_mode_model.as_ref(ctx).is_visible() {
-                                send_telemetry_from_ctx!(
-                                    TelemetryEvent::CommandXRayTriggered {
-                                        trigger: CommandXRayTrigger::Hover
-                                    },
-                                    ctx
-                                );
                                 self.start_xray_at_offset(offset, CommandXRayTrigger::Hover, ctx);
                             }
                         }
@@ -12655,7 +12636,6 @@ impl Input {
                 ctx,
             );
         });
-        send_telemetry_from_ctx!(TelemetryEvent::TabSingleResultAutocompletion, ctx);
     }
 
     /// Whether the editor is in a state where we should tab complete instead of indenting text

--- a/app/src/terminal/local_tty/spawner.rs
+++ b/app/src/terminal/local_tty/spawner.rs
@@ -11,8 +11,6 @@ use {
 #[cfg(target_os = "windows")]
 use super::PseudoConsoleChild;
 use super::{PtyOptions, PtySpawnResult};
-use crate::send_telemetry_from_app_ctx;
-use crate::server::telemetry::{PtySpawnMode, TelemetryEvent};
 use crate::terminal::local_tty::{self};
 /// A handle that can be used to interact with a pty process.
 pub trait PtyHandle: Send + Sync {
@@ -178,10 +176,7 @@ impl PtySpawner {
         >,
         ctx: &mut AppContext,
     ) -> Result<(PtySpawnResult, Box<dyn PtyHandle>)> {
-        #[cfg(not(unix))]
-        let is_fallback = false;
-        #[cfg(unix)]
-        let mut is_fallback = false;
+        let _ = ctx;
 
         #[cfg(unix)]
         if let Some(server) = &self.server {
@@ -206,24 +201,10 @@ impl PtySpawner {
                 report_error!(err.context(
                     "Failed to spawn pty via terminal server; falling back to spawning locally...",
                 ));
-                is_fallback = true;
             } else {
-                send_telemetry_from_app_ctx!(
-                    TelemetryEvent::PtySpawned {
-                        mode: PtySpawnMode::TerminalServer
-                    },
-                    ctx
-                );
                 return result;
             }
         }
-
-        let mode = if is_fallback {
-            PtySpawnMode::FallbackToDirect
-        } else {
-            PtySpawnMode::Direct
-        };
-        send_telemetry_from_app_ctx!(TelemetryEvent::PtySpawned { mode }, ctx);
 
         Self::spawn_pty_directly(
             options,

--- a/app/src/terminal/model/session.rs
+++ b/app/src/terminal/model/session.rs
@@ -40,7 +40,6 @@ use super::terminal_model::{HistoryEntry, SubshellInitializationInfo};
 use crate::features::FeatureFlag;
 #[cfg(feature = "local_tty")]
 use crate::remote_server::manager::{RemoteServerManager, RemoteServerManagerEvent};
-use crate::server::telemetry::{BootstrappingInfo, TelemetryEvent};
 use crate::terminal::event::{ExecutedExecutorCommandEvent, RemoteServerSetupState};
 use crate::terminal::shell::{Shell, ShellType};
 use crate::terminal::warpify::SubshellSource;
@@ -392,35 +391,8 @@ impl Sessions {
             }
         }
 
-        let bootstrap_duration_seconds =
-            pending_session_start_time.map(|start| start.elapsed().as_secs_f64());
-        let warp_attributed_bootstrap_duration_seconds =
-            match (bootstrap_duration_seconds, rcfiles_duration_seconds) {
-                (Some(total), Some(rcfiles)) => Some(total - rcfiles),
-                _ => None,
-            };
-        let was_triggered_by_rc_file = session
-            .subshell_info()
-            .clone()
-            .map(|info| info.was_triggered_by_rc_file_snippet)
-            .unwrap_or(false);
-
-        crate::send_telemetry_from_ctx!(
-            TelemetryEvent::BootstrappingSucceeded(BootstrappingInfo {
-                shell: session.shell().shell_type().name(),
-                shell_version: session.shell().version().clone(),
-                is_ssh: session.is_ssh_wrapper_session(),
-                was_triggered_by_rc_file,
-                is_subshell: session.subshell_info().is_some(),
-                is_wsl: session.is_wsl(),
-                bootstrap_duration_seconds,
-                rcfiles_duration_seconds,
-                warp_attributed_bootstrap_duration_seconds,
-                is_msys2: session.is_msys2(),
-                terminal_session_id: Some(session.id()),
-            }),
-            ctx
-        );
+        let _ = pending_session_start_time;
+        let _ = rcfiles_duration_seconds;
 
         History::handle(ctx).update(ctx, |history, ctx| {
             let session_id = session.id();

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -444,7 +444,7 @@ use crate::terminal::model::session::{
     BootstrapSessionType, Session, SessionId, SessionType, Sessions, SessionsEvent,
 };
 use crate::terminal::model::terminal_model::{
-    BlockIndex, BlockSelectionCardinality, SelectedBlocks, TerminalInputState, WithinModel,
+    BlockIndex, SelectedBlocks, TerminalInputState, WithinModel,
 };
 use crate::terminal::model::{ObfuscateSecrets, RespectObfuscatedSecrets, SecretHandle};
 use crate::terminal::model_events::{AnsiHandlerEvent, ModelEvent, ModelEventDispatcher};
@@ -2946,24 +2946,6 @@ struct DeferredCodeReviewOpen {
     focus_new_pane: bool,
 }
 
-#[derive(Copy, Clone, Serialize)]
-pub enum BlockSelectionDelta {
-    // User first selects a block, or selects a block with click
-    New,
-    // User already has block selected, and selects previous block
-    Previous,
-    // User already has block selected, and selects next block
-    Next,
-}
-
-#[derive(Copy, Clone, Serialize)]
-pub struct BlockSelectionDetails {
-    cardinality: BlockSelectionCardinality,
-    delta: BlockSelectionDelta,
-    is_cmd_down: bool,
-    is_shift_down: bool,
-}
-
 /// Why `apply_block_metadata_update` is being invoked. The two sources have
 /// different cardinalities — precmd fires exactly once per block, whereas OSC 7
 /// can fire many times mid-block from chatty prompts. Once-per-block work
@@ -4807,8 +4789,6 @@ impl TerminalView {
         if let Some(restoration) = conversation_restoration {
             terminal_view.restore_conversations_on_view_creation(restoration, ctx);
         }
-
-        send_telemetry_from_ctx!(TelemetryEvent::SessionCreation, ctx);
 
         terminal_view
     }
@@ -12563,7 +12543,6 @@ impl TerminalView {
                 // For now, this event is only used for telemetry. It may also
                 // be useful to request attention if the user's session starts
                 //receiving background output, or to auto-scroll it.
-                send_telemetry_from_ctx!(TelemetryEvent::BackgroundBlockStarted, ctx);
             }
             ModelEvent::PreInteractiveSSHSession => {}
             ModelEvent::SSH(remote_shell) => {
@@ -15843,13 +15822,6 @@ impl TerminalView {
                             .map_or_else(String::new, ToOwned::to_owned),
                     );
                     ctx.emit(Event::SendNotification(notification_content));
-                    send_telemetry_from_ctx!(
-                        TelemetryEvent::NotificationSent {
-                            trigger: long_running_trigger,
-                            agent_variant: None,
-                        },
-                        ctx
-                    );
                 }
             }
             _ => {}
@@ -15934,13 +15906,6 @@ impl TerminalView {
                 }
                 let notification_content = trigger.create_notification_content(title, description);
                 ctx.emit(Event::SendNotification(notification_content));
-                send_telemetry_from_ctx!(
-                    TelemetryEvent::NotificationSent {
-                        trigger,
-                        agent_variant,
-                    },
-                    ctx
-                );
             }
             _ => {}
         }
@@ -18079,15 +18044,6 @@ impl TerminalView {
                 if let Some(block_index) = maybe_block_index {
                     self.mouse_down_block_index = Some(*block_index);
 
-                    send_telemetry_from_ctx!(
-                        TelemetryEvent::BlockSelection(BlockSelectionDetails {
-                            cardinality: self.selected_blocks.cardinality(),
-                            delta: BlockSelectionDelta::New,
-                            is_cmd_down: false,
-                            is_shift_down: false,
-                        }),
-                        ctx
-                    );
                     self.tips_completed.update(ctx, |tips, ctx| {
                         mark_feature_used_and_write_to_user_defaults(
                             Tip::Hint(TipHint::BlockSelect),
@@ -18183,15 +18139,6 @@ impl TerminalView {
                         }
 
                         if !self.ai_input_model.as_ref(ctx).is_ai_input_enabled() {
-                            send_telemetry_from_ctx!(
-                                TelemetryEvent::BlockSelection(BlockSelectionDetails {
-                                    cardinality: self.selected_blocks.cardinality(),
-                                    delta: BlockSelectionDelta::New,
-                                    is_cmd_down: *is_cmd_down,
-                                    is_shift_down: *is_shift_down
-                                }),
-                                ctx
-                            );
                         } else if !self.selected_blocks.is_empty() {
                             send_telemetry_from_ctx!(
                                 TelemetryEvent::AgentModeAttachedBlockContext {
@@ -19705,16 +19652,6 @@ impl TerminalView {
             ctx,
         );
 
-        send_telemetry_from_ctx!(
-            TelemetryEvent::BlockSelection(BlockSelectionDetails {
-                cardinality: self.selected_blocks.cardinality(),
-                delta: BlockSelectionDelta::New,
-                is_cmd_down: false,
-                is_shift_down: false
-            }),
-            ctx
-        );
-
         self.tips_completed.update(ctx, |tips, ctx| {
             mark_feature_used_and_write_to_user_defaults(
                 Tip::Hint(TipHint::BlockSelect),
@@ -19771,16 +19708,6 @@ impl TerminalView {
 
             self.scroll_to_if_not_visible(new_block_index, ctx);
             ctx.notify();
-
-            send_telemetry_from_ctx!(
-                TelemetryEvent::BlockSelection(BlockSelectionDetails {
-                    delta: BlockSelectionDelta::Previous,
-                    is_cmd_down: false,
-                    is_shift_down,
-                    cardinality: self.selected_blocks.cardinality(),
-                }),
-                ctx
-            );
 
             self.tips_completed.update(ctx, |tips, ctx| {
                 mark_feature_used_and_write_to_user_defaults(
@@ -19844,15 +19771,6 @@ impl TerminalView {
                     self.reset_selection_to_single_block(new_block_index, ctx);
                 }
                 self.scroll_to_if_not_visible(new_block_index, ctx);
-                send_telemetry_from_ctx!(
-                    TelemetryEvent::BlockSelection(BlockSelectionDetails {
-                        cardinality: self.selected_blocks.cardinality(),
-                        delta: BlockSelectionDelta::Next,
-                        is_cmd_down,
-                        is_shift_down,
-                    }),
-                    ctx
-                );
                 self.tips_completed.update(ctx, |tips, ctx| {
                     mark_feature_used_and_write_to_user_defaults(
                         Tip::Hint(TipHint::BlockSelect),
@@ -21175,13 +21093,6 @@ impl TerminalView {
                         "Command is waiting for a password".to_string(),
                     );
                     ctx.emit(Event::SendNotification(notification_content));
-                    send_telemetry_from_ctx!(
-                        TelemetryEvent::NotificationSent {
-                            trigger: password_trigger,
-                            agent_variant: None,
-                        },
-                        ctx
-                    );
                 }
                 NotificationsMode::Unset
                     if matches!(

--- a/app/src/terminal/view/use_agent_footer/mod.rs
+++ b/app/src/terminal/view/use_agent_footer/mod.rs
@@ -511,17 +511,6 @@ impl TerminalView {
 
         let should_insert_after_block = !InputModeSettings::as_ref(ctx).is_pinned_to_top();
 
-        // Send telemetry when showing CLI agent footer
-        if let Some(session) = CLIAgentSessionsModel::as_ref(ctx).session(self.view_id) {
-            let cli_agent_type: CLIAgentType = session.agent.into();
-            send_telemetry_from_ctx!(
-                TelemetryEvent::CLIAgentToolbarShown {
-                    cli_agent: cli_agent_type,
-                },
-                ctx
-            );
-        }
-
         self.insert_rich_content(
             None,
             self.use_agent_footer.clone(),

--- a/crates/ai/src/index/full_source_code_embedding/codebase_index.rs
+++ b/crates/ai/src/index/full_source_code_embedding/codebase_index.rs
@@ -249,27 +249,15 @@ enum SyncOperationResult {
 impl SyncOperationResult {
     fn telemetry_event(
         &self,
-        sync_duration: Duration,
+        _sync_duration: Duration,
         sync_type: CodebaseContextSyncType,
-    ) -> AITelemetryEvent {
+    ) -> Option<AITelemetryEvent> {
         match self {
-            SyncOperationResult::Success {
-                flushed_node_count,
-                flushed_fragment_result,
-                cache_population_error,
-                ..
-            } => AITelemetryEvent::SyncCodebaseContextSuccess {
-                total_sync_duration: sync_duration,
-                sync_type,
-                flushed_node_count: *flushed_node_count,
-                flushed_fragment_count: flushed_fragment_result.fragment_count,
-                total_fragment_size_bytes: flushed_fragment_result.total_fragment_size_bytes,
-                cache_population_error: cache_population_error.as_ref().map(|e| e.to_string()),
-            },
-            SyncOperationResult::Error(err) => AITelemetryEvent::SyncCodebaseContextFailed {
+            SyncOperationResult::Success { .. } => None,
+            SyncOperationResult::Error(err) => Some(AITelemetryEvent::SyncCodebaseContextFailed {
                 error: err.to_string(),
                 sync_type,
-            },
+            }),
         }
     }
 
@@ -349,7 +337,7 @@ struct IncrementalUpdateResult {
 }
 
 impl IncrementalUpdateResult {
-    fn telemetry_event(&self, sync_start_time: Instant) -> AITelemetryEvent {
+    fn telemetry_event(&self, sync_start_time: Instant) -> Option<AITelemetryEvent> {
         match &self.build_result {
             IncrementalUpdateBuildResult::Success {
                 operation_result, ..
@@ -358,9 +346,9 @@ impl IncrementalUpdateResult {
                 CodebaseContextSyncType::Incremental,
             ),
             IncrementalUpdateBuildResult::Error { error, .. } => {
-                AITelemetryEvent::BuildTreeFailed {
+                Some(AITelemetryEvent::BuildTreeFailed {
                     error: error.to_string(),
-                }
+                })
             }
         }
     }
@@ -560,10 +548,11 @@ impl CodebaseIndex {
                     .await
                 },
                 move |me, incremental_update_sync_result, ctx| {
-                    send_telemetry_from_ctx!(
-                        incremental_update_sync_result.telemetry_event(sync_start_time),
-                        ctx
-                    );
+                    if let Some(event) =
+                        incremental_update_sync_result.telemetry_event(sync_start_time)
+                    {
+                        send_telemetry_from_ctx!(event, ctx);
+                    }
                     me.process_sync_update_result(incremental_update_sync_result, ctx);
                 },
             )
@@ -1195,13 +1184,11 @@ impl CodebaseIndex {
                     (tree, sync_result)
                 },
                 move |me, (tree, server_sync_result), ctx| {
-                    send_telemetry_from_ctx!(
-                        server_sync_result.telemetry_event(
-                            sync_start_time.elapsed(),
-                            CodebaseContextSyncType::Full
-                        ),
-                        ctx
-                    );
+                    if let Some(event) = server_sync_result
+                        .telemetry_event(sync_start_time.elapsed(), CodebaseContextSyncType::Full)
+                    {
+                        send_telemetry_from_ctx!(event, ctx);
+                    }
 
                     // We should only flush pending changes when we know the sync failed because of a read fragment error.
                     let should_flush_pending_changes = if let SyncOperationResult::Error(
@@ -1259,11 +1246,11 @@ impl CodebaseIndex {
             }) => {
                 // Emit telemetries for the initial sync result.
                 if let Some(sync_time) = time_tracker.compute_duration_for_interval(SYNC_TIME) {
-                    send_telemetry_from_ctx!(
-                        server_sync_result
-                            .telemetry_event(sync_time, CodebaseContextSyncType::Initial),
-                        ctx
-                    );
+                    if let Some(event) = server_sync_result
+                        .telemetry_event(sync_time, CodebaseContextSyncType::Initial)
+                    {
+                        send_telemetry_from_ctx!(event, ctx);
+                    }
                 }
 
                 if let Some((file_traversal_duration, merkle_tree_parse_duration)) = time_tracker

--- a/crates/warpui_core/src/app_focus_telemetry.rs
+++ b/crates/warpui_core/src/app_focus_telemetry.rs
@@ -1,5 +1,4 @@
 use chrono::{DateTime, Duration, Utc};
-use serde_json::json;
 
 use crate::time::get_current_time;
 
@@ -13,18 +12,8 @@ impl DailyAppFocusDuration {
     // If calendar date has advanced since the last sync, record the
     // Daily App Focus event with the current duration.
     #[allow(deprecated)]
-    fn try_record(&mut self, user_id: Option<String>, anonymous_id: String) {
+    fn try_record(&mut self, _user_id: Option<String>, _anonymous_id: String) {
         if get_current_time().date_naive() > self.last_synced_time.date_naive() {
-            let daily_app_focus_duration_seconds =
-                json!(self.duration.num_milliseconds() as f64 / 1000.);
-            crate::telemetry::record_event(
-                user_id,
-                anonymous_id,
-                "Daily App Focus Duration (seconds)".into(),
-                Some(daily_app_focus_duration_seconds),
-                false, /* contains_ugc */
-                self.last_synced_time.date().and_hms(0, 0, 0),
-            );
             self.reset();
         }
     }


### PR DESCRIPTION
## Summary
- remove emission points for the first high-volume telemetry batch grouped for David review
- keep behavior intact while dropping event sends in terminal/session/input/AI/experiment/app-focus paths
- scope is intentionally limited to this ownership group so review can confirm whether each event is still needed

## Events covered in this PR
- Bootstrapping Succeeded
- Autosuggestion Inserted
- Tab Creation (SessionCreation emission)
- Pty Spawned
- Block Selection
- experiments.client.enroll_client
- Notification Sent
- AgentTip Shown
- User Initiated Closing Something
- CLIAgentFooter.Shown
- AgentMode.CreatedAIBlock
- Tab Single Result Autocompletion
- Background Block Started
- Triggered Command XRay
- Daily App Focus Duration (seconds)

## Validation
- ./script/format
- cargo check --manifest-path app/Cargo.toml (fails in this environment: missing xcrun/metal)

Co-Authored-By: Oz <oz-agent@warp.dev>