### PR TITLE
Fix Settings search for navigation labels

### DIFF
--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -970,6 +970,108 @@ enum CycleDirection {
     Down,
 }
 
+/// Returns whether `label` starts with the non-empty, trimmed search query.
+///
+/// Navigation labels use prefix matching so users can progressively type a
+/// page name (for example, "fe" for "Features") without broad infix matches
+/// such as "and" matching "Billing and usage".
+fn navigation_label_matches_query(label: &str, query: &str) -> bool {
+    let query = query.trim().to_lowercase();
+    !query.is_empty() && label.to_lowercase().starts_with(&query)
+}
+
+/// Returns the concrete settings sections whose visible navigation labels
+/// match `query`. Matching an umbrella label includes all of its subpages.
+fn navigation_sections_matching_query(
+    nav_items: &[SettingsNavItem],
+    query: &str,
+) -> Vec<SettingsSection> {
+    nav_items
+        .iter()
+        .flat_map(|item| match item {
+            SettingsNavItem::Page(section) => {
+                navigation_label_matches_query(&section.to_string(), query)
+                    .then_some(*section)
+                    .into_iter()
+                    .collect()
+            }
+            SettingsNavItem::Umbrella(umbrella) => {
+                let mut matches = Vec::new();
+                if navigation_label_matches_query(umbrella.label, query) {
+                    matches.extend(umbrella.subpages.iter().copied());
+                }
+                matches.extend(
+                    umbrella.subpages.iter().copied().filter(|section| {
+                        navigation_label_matches_query(&section.to_string(), query)
+                    }),
+                );
+                matches
+            }
+        })
+        .unique()
+        .collect()
+}
+
+/// Returns the section that should be selected for a navigation-label query.
+///
+/// An exact label match wins. Otherwise, a prefix is preferred only when it
+/// resolves to one concrete section, avoiding arbitrary navigation for broad
+/// prefixes such as "a".
+fn preferred_navigation_section(
+    nav_items: &[SettingsNavItem],
+    query: &str,
+) -> Option<SettingsSection> {
+    let query = query.trim().to_lowercase();
+    if query.is_empty() {
+        return None;
+    }
+
+    let candidates = nav_items
+        .iter()
+        .flat_map(|item| match item {
+            SettingsNavItem::Page(section) => vec![(section.to_string(), *section)],
+            SettingsNavItem::Umbrella(umbrella) => {
+                let mut candidates = umbrella
+                    .subpages
+                    .first()
+                    .map(|section| vec![(umbrella.label.to_string(), *section)])
+                    .unwrap_or_default();
+                candidates.extend(
+                    umbrella
+                        .subpages
+                        .iter()
+                        .map(|section| (section.to_string(), *section)),
+                );
+                candidates
+            }
+        })
+        .collect_vec();
+
+    if let Some((_, section)) = candidates
+        .iter()
+        .find(|(label, _)| label.to_lowercase() == query)
+    {
+        return Some(*section);
+    }
+
+    let matching_sections = candidates
+        .iter()
+        .filter(|(label, _)| label.to_lowercase().starts_with(&query))
+        .map(|(_, section)| *section)
+        .unique()
+        .collect_vec();
+    (matching_sections.len() == 1).then(|| matching_sections[0])
+}
+
+fn backing_page_has_navigation_match(
+    page_section: SettingsSection,
+    matching_sections: &[SettingsSection],
+) -> bool {
+    matching_sections
+        .iter()
+        .any(|section| section.parent_page_section() == page_section)
+}
+
 /// A stop in the arrow-key navigation order over the sidebar.
 ///
 /// A collapsed umbrella occupies a single stop rather than being skipped,
@@ -1475,6 +1577,10 @@ impl SettingsView {
             EditorEvent::Edited(_) => {
                 let search_query = editor.as_ref(ctx).buffer_text(ctx);
                 let is_search_active = !search_query.is_empty();
+                let navigation_matches =
+                    navigation_sections_matching_query(&self.nav_items, &search_query);
+                let preferred_navigation_section =
+                    preferred_navigation_section(&self.nav_items, &search_query);
 
                 if is_search_active {
                     // Save umbrella expanded state before search modifies it.
@@ -1496,25 +1602,43 @@ impl SettingsView {
                             continue;
                         }
                         if let Some(subpage) = AISubpage::from_section(subpage_section) {
+                            let navigation_match = navigation_matches.contains(&subpage_section);
+                            let filter_query = if navigation_match { "" } else { &search_query };
                             self.ai_page_handle.update(ctx, |view, ctx| {
                                 view.set_active_subpage(Some(subpage), ctx);
                             });
                             let match_data = self
                                 .ai_page_handle
-                                .update(ctx, |view, ctx| view.update_filter(&search_query, ctx));
-                            self.subpage_filter.insert(subpage_section, match_data);
+                                .update(ctx, |view, ctx| view.update_filter(filter_query, ctx));
+                            self.subpage_filter.insert(
+                                subpage_section,
+                                if navigation_match {
+                                    MatchData::Uncounted(true)
+                                } else {
+                                    match_data
+                                },
+                            );
                         }
                     }
                     // Do the same for Code subpages.
                     for &subpage_section in SettingsSection::code_subpages() {
                         if let Some(subpage) = CodeSubpage::from_section(subpage_section) {
+                            let navigation_match = navigation_matches.contains(&subpage_section);
+                            let filter_query = if navigation_match { "" } else { &search_query };
                             self.code_page_handle.update(ctx, |view, ctx| {
                                 view.set_active_subpage(Some(subpage), ctx);
                             });
                             let match_data = self
                                 .code_page_handle
-                                .update(ctx, |view, ctx| view.update_filter(&search_query, ctx));
-                            self.subpage_filter.insert(subpage_section, match_data);
+                                .update(ctx, |view, ctx| view.update_filter(filter_query, ctx));
+                            self.subpage_filter.insert(
+                                subpage_section,
+                                if navigation_match {
+                                    MatchData::Uncounted(true)
+                                } else {
+                                    match_data
+                                },
+                            );
                         }
                     }
                 } else {
@@ -1543,34 +1667,23 @@ impl SettingsView {
                 }
 
                 for (i, page) in self.settings_pages.iter().enumerate() {
-                    self.pages_filter[i] = update_page!(
+                    let navigation_match =
+                        backing_page_has_navigation_match(page.section, &navigation_matches);
+                    let filter_query = if navigation_match { "" } else { &search_query };
+                    let match_data = update_page!(
                         &page.view_handle,
                         |view, ctx| {
-                            let match_data = view.update_filter(&search_query, ctx);
+                            let match_data = view.update_filter(filter_query, ctx);
                             ctx.notify();
                             match_data
                         },
                         ctx
                     );
-                }
-
-                // Restore the active subpage after filtering.
-                if is_search_active {
-                    let current = self.current_settings_page;
-                    if current.is_ai_subpage() && current != SettingsSection::AgentMCPServers {
-                        if let Some(subpage) = AISubpage::from_section(current) {
-                            self.ai_page_handle.update(ctx, |view, ctx| {
-                                view.set_active_subpage(Some(subpage), ctx);
-                            });
-                        }
-                    }
-                    if current.is_code_subpage() {
-                        if let Some(subpage) = CodeSubpage::from_section(current) {
-                            self.code_page_handle.update(ctx, |view, ctx| {
-                                view.set_active_subpage(Some(subpage), ctx);
-                            });
-                        }
-                    }
+                    self.pages_filter[i] = if navigation_match {
+                        MatchData::Uncounted(true)
+                    } else {
+                        match_data
+                    };
                 }
 
                 // Auto-expand umbrellas that have matching subpages during search.
@@ -1617,7 +1730,19 @@ impl SettingsView {
                         .any(|(page, _)| page.section == current_backing)
                 };
 
-                if !current_still_visible {
+                let preferred_navigation_section = preferred_navigation_section
+                    .filter(|section| self.section_passes_search_filter(*section));
+
+                if let Some(new_section) = preferred_navigation_section {
+                    if new_section != self.current_settings_page {
+                        self.set_and_refresh_current_page_internal(
+                            new_section,
+                            false, /* should_clear_query */
+                            false, /* allow_steal_focus */
+                            ctx,
+                        );
+                    }
+                } else if !current_still_visible {
                     // Find the first visible section: check subpages first, then pages.
                     let first_visible = if is_search_active {
                         self.nav_items
@@ -1650,6 +1775,35 @@ impl SettingsView {
                             false, /* allow_steal_focus */
                             ctx,
                         );
+                    }
+                }
+
+                // Subpage selection rebuilds its PageType, resetting the saved widget
+                // filter. Restore the final active subpage after auto-selection and
+                // immediately reapply the effective query so its rendered contents
+                // stay filtered like standalone settings pages.
+                if is_search_active {
+                    let current = self.current_settings_page;
+                    let filter_query = if navigation_matches.contains(&current) {
+                        ""
+                    } else {
+                        &search_query
+                    };
+                    if current.is_ai_subpage() && current != SettingsSection::AgentMCPServers {
+                        if let Some(subpage) = AISubpage::from_section(current) {
+                            self.ai_page_handle.update(ctx, |view, ctx| {
+                                view.set_active_subpage(Some(subpage), ctx);
+                                view.update_filter(filter_query, ctx);
+                            });
+                        }
+                    }
+                    if current.is_code_subpage() {
+                        if let Some(subpage) = CodeSubpage::from_section(current) {
+                            self.code_page_handle.update(ctx, |view, ctx| {
+                                view.set_active_subpage(Some(subpage), ctx);
+                                view.update_filter(filter_query, ctx);
+                            });
+                        }
                     }
                 }
                 ctx.notify();

--- a/app/src/settings_view/mod_tests.rs
+++ b/app/src/settings_view/mod_tests.rs
@@ -654,6 +654,103 @@ fn realistic_nav_items() -> Vec<SettingsNavItem> {
     ]
 }
 
+fn search_nav_items() -> Vec<SettingsNavItem> {
+    let mut nav_items = realistic_nav_items();
+    nav_items.extend([
+        SettingsNavItem::Page(SettingsSection::Appearance),
+        SettingsNavItem::Page(SettingsSection::Features),
+        SettingsNavItem::Page(SettingsSection::About),
+    ]);
+    nav_items
+}
+
+// ── Navigation-label search ─────────────────────────────────────────────────
+
+#[test]
+fn navigation_label_search_matches_page_name_prefixes_case_insensitively() {
+    let nav_items = search_nav_items();
+
+    assert_eq!(
+        navigation_sections_matching_query(&nav_items, "Appearance"),
+        vec![SettingsSection::Appearance]
+    );
+    assert_eq!(
+        navigation_sections_matching_query(&nav_items, "fe"),
+        vec![SettingsSection::Features]
+    );
+    assert_eq!(
+        navigation_sections_matching_query(&nav_items, "billing and"),
+        vec![SettingsSection::BillingAndUsage]
+    );
+}
+
+#[test]
+fn navigation_label_search_does_not_match_label_infixes() {
+    let nav_items = search_nav_items();
+
+    assert_eq!(
+        navigation_sections_matching_query(&nav_items, "and"),
+        Vec::<SettingsSection>::new()
+    );
+    assert_eq!(
+        navigation_sections_matching_query(&nav_items, "usage"),
+        Vec::<SettingsSection>::new()
+    );
+}
+
+#[test]
+fn navigation_label_search_matches_umbrella_and_subpage_labels() {
+    let nav_items = search_nav_items();
+
+    assert_eq!(
+        navigation_sections_matching_query(&nav_items, "Agents"),
+        SettingsSection::ai_subpages()
+    );
+    assert_eq!(
+        navigation_sections_matching_query(&nav_items, "Warp Agent"),
+        vec![SettingsSection::WarpAgent]
+    );
+}
+
+#[test]
+fn preferred_navigation_section_prioritizes_exact_and_unique_prefix_matches() {
+    let nav_items = search_nav_items();
+
+    assert_eq!(
+        preferred_navigation_section(&nav_items, "Appearance"),
+        Some(SettingsSection::Appearance)
+    );
+    assert_eq!(
+        preferred_navigation_section(&nav_items, "fe"),
+        Some(SettingsSection::Features)
+    );
+    assert_eq!(
+        preferred_navigation_section(&nav_items, "Agents"),
+        Some(SettingsSection::WarpAgent)
+    );
+    assert_eq!(preferred_navigation_section(&nav_items, "a"), None);
+}
+
+#[test]
+fn backing_page_navigation_match_handles_direct_pages_and_subpages() {
+    assert!(backing_page_has_navigation_match(
+        SettingsSection::Appearance,
+        &[SettingsSection::Appearance]
+    ));
+    assert!(backing_page_has_navigation_match(
+        SettingsSection::AI,
+        &[SettingsSection::WarpAgent]
+    ));
+    assert!(backing_page_has_navigation_match(
+        SettingsSection::MCPServers,
+        &[SettingsSection::AgentMCPServers]
+    ));
+    assert!(!backing_page_has_navigation_match(
+        SettingsSection::Account,
+        &[SettingsSection::Appearance]
+    ));
+}
+
 /// Mutably flips an umbrella's `expanded` flag at `nav_index`.
 fn set_expanded(nav_items: &mut [SettingsNavItem], nav_index: usize, expanded: bool) {
     if let Some(SettingsNavItem::Umbrella(u)) = nav_items.get_mut(nav_index) {


### PR DESCRIPTION
## Description
- Match Settings sidebar page and subpage labels with case-insensitive prefixes, independently of per-widget search terms.
- Show the complete page when its navigation label matches and prioritize exact or unique label matches for selection.
- Preserve granular widget filtering, including after Agent and Code subpages rebuild their page content.
- Add regression coverage for Appearance, Features, Billing and usage, umbrella/subpage labels, ambiguous prefixes, and backing-page mapping.

## Linked Issue
No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `./script/format --check`
- `CARGO_BUILD_JOBS=1 CARGO_PROFILE_DEV_DEBUG=0 cargo +1.92.0 clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `CARGO_BUILD_JOBS=1 CARGO_PROFILE_DEV_DEBUG=0 cargo +1.92.0 clippy -p warp_completer --all-targets --tests -- -D warnings`
- `CARGO_BUILD_JOBS=1 CARGO_PROFILE_TEST_DEBUG=0 cargo +1.92.0 test -p warp --lib settings_view::tests` (52 passed)
- `CARGO_BUILD_JOBS=1 CARGO_PROFILE_DEV_DEBUG=0 cargo +1.92.0 build -p warp --bin warp`
- Manually opened the built internal Warp app, searched for `Appearance`, and confirmed that the Appearance navigation item was selected and the full page was displayed. Also confirmed `Tools panel` still performs granular widget filtering.

- [x] I have manually tested my changes locally with the internal Warp GUI build

### Screenshots / Videos
The before screenshot (`settings-search-before.png`) and Appearance search proof (`settings-search-appearance.png`) are attached to the linked conversation below. The proof shows only the Appearance sidebar item remaining, highlighted in pink, with the full Appearance page rendered.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed Settings searches for page names such as Appearance, Features, and Billing and usage.

Co-Authored-By: Oz <oz-agent@warp.dev>

_This PR was generated with [Oz](https://warp.dev/oz)._
