### PR TITLE
Add low-effort slash commands to TUI

### DIFF
--- a/app/src/ai/blocklist/controller.rs
+++ b/app/src/ai/blocklist/controller.rs
@@ -1368,6 +1368,10 @@ impl BlocklistAIController {
     ) {
         slash_command.send_request(self, None, None, ctx);
     }
+    /// Starts the create-project agent flow with the supplied project description.
+    pub fn send_create_new_project_request(&mut self, query: String, ctx: &mut ModelContext<Self>) {
+        self.send_slash_command_request(SlashCommandRequest::CreateNewProject { query }, ctx);
+    }
 
     /// Resolves a skill reference against this controller's active execution host.
     pub(crate) fn resolve_skill_for_invocation(

--- a/app/src/ai/conversation_export.rs
+++ b/app/src/ai/conversation_export.rs
@@ -1,0 +1,143 @@
+use std::fmt::{Display, Formatter};
+use std::io;
+use std::path::{Path, PathBuf};
+
+use chrono::Local;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConversationFileExport {
+    path: PathBuf,
+    overwrote_existing: bool,
+}
+
+impl ConversationFileExport {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn overwrote_existing(&self) -> bool {
+        self.overwrote_existing
+    }
+}
+
+#[derive(Debug)]
+pub struct ConversationFileExportError {
+    path: PathBuf,
+    source: io::Error,
+}
+
+impl ConversationFileExportError {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn user_message(&self) -> String {
+        match self.source.kind() {
+            io::ErrorKind::PermissionDenied => format!(
+                "Permission denied writing to {}. Check file permissions.",
+                self.path.display()
+            ),
+            io::ErrorKind::NotFound => format!(
+                "Directory not found: {}",
+                self.path
+                    .parent()
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_default()
+            ),
+            io::ErrorKind::AlreadyExists => {
+                format!("File {} already exists", self.path.display())
+            }
+            _ => format!(
+                "Failed to export to {}: {}",
+                self.path.display(),
+                self.source
+            ),
+        }
+    }
+}
+
+impl Display for ConversationFileExportError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "failed to write conversation to {}: {}",
+            self.path.display(),
+            self.source
+        )
+    }
+}
+
+impl std::error::Error for ConversationFileExportError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+pub fn export_conversation_markdown(
+    current_directory: Option<&str>,
+    filename_arg: Option<&str>,
+    conversation_title: Option<&str>,
+    markdown: &str,
+) -> Result<ConversationFileExport, ConversationFileExportError> {
+    let timestamp = Local::now().format("%Y%m%d_%H%M%S").to_string();
+    let filename = conversation_export_filename_at(filename_arg, conversation_title, &timestamp);
+    let current_directory = current_directory
+        .map(PathBuf::from)
+        .or_else(|| {
+            log::debug!("No active conversation CWD, falling back to std::env::current_dir()");
+            std::env::current_dir().ok()
+        })
+        .unwrap_or_else(|| {
+            log::warn!("Failed to determine current directory, using '.'");
+            PathBuf::from(".")
+        });
+    let path = current_directory.join(filename);
+    let overwrote_existing = path.exists();
+
+    std::fs::write(&path, markdown).map_err(|source| ConversationFileExportError {
+        path: path.clone(),
+        source,
+    })?;
+
+    Ok(ConversationFileExport {
+        path,
+        overwrote_existing,
+    })
+}
+
+fn conversation_export_filename_at(
+    filename_arg: Option<&str>,
+    conversation_title: Option<&str>,
+    timestamp: &str,
+) -> String {
+    let filename = filename_arg
+        .map(str::trim)
+        .filter(|filename| !filename.is_empty())
+        .map(str::to_owned)
+        .unwrap_or_else(|| {
+            let title = conversation_title
+                .unwrap_or("conversation")
+                .chars()
+                .map(|character| {
+                    if character.is_whitespace() {
+                        '_'
+                    } else if character.is_alphanumeric() || character == '_' || character == '-' {
+                        character
+                    } else {
+                        '_'
+                    }
+                })
+                .collect::<String>();
+            format!("{timestamp}-{title}.md")
+        });
+
+    if filename.ends_with(".md") {
+        filename
+    } else {
+        format!("{filename}.md")
+    }
+}
+
+#[cfg(test)]
+#[path = "conversation_export_tests.rs"]
+mod tests;

--- a/app/src/ai/conversation_export_tests.rs
+++ b/app/src/ai/conversation_export_tests.rs
@@ -1,0 +1,83 @@
+use tempfile::tempdir;
+
+use super::*;
+
+#[test]
+fn explicit_filename_is_trimmed_and_gets_markdown_extension() {
+    assert_eq!(
+        conversation_export_filename_at(
+            Some("  notes/session  "),
+            Some("ignored"),
+            "20260710_120000"
+        ),
+        "notes/session.md"
+    );
+    assert_eq!(
+        conversation_export_filename_at(
+            Some("conversation.md"),
+            Some("ignored"),
+            "20260710_120000"
+        ),
+        "conversation.md"
+    );
+}
+
+#[test]
+fn default_filename_sanitizes_the_conversation_title() {
+    assert_eq!(
+        conversation_export_filename_at(None, Some("Fix: slash commands / TUI"), "20260710_120000"),
+        "20260710_120000-Fix__slash_commands___TUI.md"
+    );
+    assert_eq!(
+        conversation_export_filename_at(None, None, "20260710_120000"),
+        "20260710_120000-conversation.md"
+    );
+}
+
+#[test]
+fn export_writes_markdown_and_reports_overwrites() {
+    let directory = tempdir().unwrap();
+    let directory_path = directory.path().to_string_lossy();
+
+    let first =
+        export_conversation_markdown(Some(&directory_path), Some("conversation"), None, "# First")
+            .unwrap();
+    assert_eq!(first.path(), directory.path().join("conversation.md"));
+    assert!(!first.overwrote_existing());
+    assert_eq!(std::fs::read_to_string(first.path()).unwrap(), "# First");
+
+    let second = export_conversation_markdown(
+        Some(&directory_path),
+        Some("conversation.md"),
+        None,
+        "# Second",
+    )
+    .unwrap();
+    assert!(second.overwrote_existing());
+    assert_eq!(std::fs::read_to_string(second.path()).unwrap(), "# Second");
+}
+
+#[test]
+fn missing_subdirectory_returns_a_friendly_error() {
+    let directory = tempdir().unwrap();
+    let directory_path = directory.path().to_string_lossy();
+    let error = export_conversation_markdown(
+        Some(&directory_path),
+        Some("missing/conversation.md"),
+        None,
+        "content",
+    )
+    .unwrap_err();
+
+    assert_eq!(
+        error.path(),
+        directory.path().join("missing/conversation.md")
+    );
+    assert_eq!(
+        error.user_message(),
+        format!(
+            "Directory not found: {}",
+            directory.path().join("missing").display()
+        )
+    );
+}

--- a/app/src/ai/mod.rs
+++ b/app/src/ai/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod blocklist;
 pub(crate) mod codebase_auto_indexing;
 pub mod control_code_parser;
 pub(crate) mod conversation_details_panel;
+pub(crate) mod conversation_export;
 pub(crate) mod conversation_navigation;
 pub(crate) mod conversation_rename;
 pub(crate) mod conversation_status_ui;

--- a/app/src/ai/mod.rs
+++ b/app/src/ai/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod blocklist;
 pub(crate) mod codebase_auto_indexing;
 pub mod control_code_parser;
 pub(crate) mod conversation_details_panel;
+#[cfg(feature = "local_fs")]
 pub(crate) mod conversation_export;
 pub(crate) mod conversation_navigation;
 pub(crate) mod conversation_rename;

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -182,6 +182,8 @@ use crate::ai::blocklist::{
 };
 use crate::ai::cloud_agent_settings::CloudAgentSettings;
 use crate::ai::cloud_environments::CloudAmbientAgentEnvironment;
+#[cfg(not(target_family = "wasm"))]
+use crate::ai::conversation_export::export_conversation_markdown;
 use crate::ai::document::ai_document_model::{AIDocumentId, AIDocumentVersion};
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::ai::harness_availability::HarnessAvailabilityModel;
@@ -5875,11 +5877,6 @@ impl Input {
         filename_arg: Option<String>,
         ctx: &mut ViewContext<Self>,
     ) {
-        use std::fs;
-        use std::path::PathBuf;
-
-        use chrono::Local;
-
         let history = BlocklistAIHistoryModel::handle(ctx);
         let Some(conversation) = history
             .as_ref(ctx)
@@ -5893,114 +5890,44 @@ impl Input {
             });
             return;
         };
-
-        // Determine the filename
-        let filename = if let Some(name) = filename_arg.as_ref().filter(|s| !s.trim().is_empty()) {
-            name.trim().to_string()
-        } else {
-            // Generate default filename: timestamp-conversation_title.md
-            let timestamp = Local::now().format("%Y%m%d_%H%M%S");
-            let title = conversation
-                .title()
-                .unwrap_or_else(|| "conversation".to_string())
-                .chars()
-                .map(|c| {
-                    // Replace spaces with underscores, keep alphanumeric, underscores, and hyphens
-                    if c.is_whitespace() {
-                        '_'
-                    } else if c.is_alphanumeric() || c == '_' || c == '-' {
-                        c
-                    } else {
-                        '_'
-                    }
-                })
-                .collect::<String>();
-            format!("{timestamp}-{title}.md")
-        };
-
-        // Ensure the filename has .md extension
-        let filename = if !filename.ends_with(".md") {
-            format!("{filename}.md")
-        } else {
-            filename
-        };
-
-        let current_dir = self
+        let current_directory = self
             .active_block_metadata
             .as_ref()
             .and_then(|metadata| metadata.current_working_directory())
-            .map(PathBuf::from)
-            .or_else(|| {
-                log::debug!(
-                    "No CWD from active_block_metadata, falling back to std::env::current_dir()"
-                );
-                std::env::current_dir().ok()
-            })
-            .unwrap_or_else(|| {
-                log::warn!("Failed to determine current directory, using '.'");
-                PathBuf::from(".")
-            });
-
-        let file_path = current_dir.join(&filename);
+            .map(str::to_owned);
+        let conversation_title = conversation.title();
 
         let action_model = self.ai_action_model.as_ref(ctx);
         let conversation_text = conversation.export_to_markdown(Some(action_model));
-
-        // Check if file already exists and warn user
-        let file_exists = file_path.exists();
-        if file_exists {
-            let window_id = ctx.window_id();
-            let display_path = file_path.display().to_string();
-            ToastStack::handle(ctx).update(ctx, |toast_stack, ctx| {
-                let toast = DismissibleToast::default(format!(
-                    "File {display_path} already exists and will be overwritten"
-                ));
-                toast_stack.add_ephemeral_toast(toast, window_id, ctx);
-            });
-        }
-
-        // Write to file
-        match fs::write(&file_path, conversation_text) {
-            Ok(_) => {
-                // Show success toast
+        match export_conversation_markdown(
+            current_directory.as_deref(),
+            filename_arg.as_deref(),
+            conversation_title.as_deref(),
+            &conversation_text,
+        ) {
+            Ok(export) => {
                 let window_id = ctx.window_id();
-                let display_path = file_path.display().to_string();
+                let display_path = export.path().display().to_string();
                 ToastStack::handle(ctx).update(ctx, move |toast_stack, ctx| {
+                    if export.overwrote_existing() {
+                        let toast = DismissibleToast::default(format!(
+                            "File {display_path} already exists and will be overwritten"
+                        ));
+                        toast_stack.add_ephemeral_toast(toast, window_id, ctx);
+                    }
                     let toast = DismissibleToast::default(format!(
                         "Conversation exported to {display_path}"
                     ));
                     toast_stack.add_ephemeral_toast(toast, window_id, ctx);
                 });
             }
-            Err(e) => {
-                // Show error toast with user-friendly message
-                let user_message = match e.kind() {
-                    std::io::ErrorKind::PermissionDenied => {
-                        format!(
-                            "Permission denied writing to {}. Check file permissions.",
-                            file_path.display()
-                        )
-                    }
-                    std::io::ErrorKind::NotFound => {
-                        format!(
-                            "Directory not found: {}",
-                            file_path
-                                .parent()
-                                .map(|p| p.display().to_string())
-                                .unwrap_or_default()
-                        )
-                    }
-                    std::io::ErrorKind::AlreadyExists => {
-                        format!("File {} already exists", file_path.display())
-                    }
-                    _ => {
-                        format!("Failed to export to {}: {}", file_path.display(), e)
-                    }
-                };
+            Err(error) => {
+                let user_message = error.user_message();
+                let path = error.path().to_path_buf();
 
                 report_error!(
-                    anyhow::Error::new(e).context("Failed to write conversation to file"),
-                    extra: { "path" => %file_path.display() }
+                    anyhow::Error::new(error).context("Failed to write conversation to file"),
+                    extra: { "path" => %path.display() }
                 );
                 let window_id = ctx.window_id();
                 ToastStack::handle(ctx).update(ctx, move |toast_stack, ctx| {
@@ -6009,8 +5936,6 @@ impl Input {
                 });
             }
         }
-
-        // Clear the buffer after execution
         self.editor.update(ctx, |editor, ctx| {
             editor.clear_buffer(ctx);
         });
@@ -13159,10 +13084,7 @@ impl Input {
             });
         }
         self.ai_controller.update(ctx, move |controller, ctx| {
-            controller.send_slash_command_request(
-                SlashCommandRequest::CreateNewProject { query: ai_query },
-                ctx,
-            )
+            controller.send_create_new_project_request(ai_query, ctx)
         });
     }
 

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -24,7 +24,7 @@ use warp_util::path::{CleanPathResult, LineAndColumnArg};
 use warpui::clipboard::ClipboardContent;
 use warpui::{AppContext, SingletonEntity, ViewContext};
 
-use crate::ai::agent::conversation::{AIConversation, AIConversationId};
+use crate::ai::agent::conversation::AIConversationId;
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::agent_conversations_model::AgentConversationsModel;
 #[cfg(not(target_family = "wasm"))]
@@ -137,7 +137,6 @@ pub enum TuiSlashCommand {
     CreateNewProject,
     ExportToClipboard,
     ExportToFile,
-    Cost,
 }
 
 impl TuiSlashCommand {
@@ -151,7 +150,6 @@ impl TuiSlashCommand {
             name if name == commands::CREATE_NEW_PROJECT.name => Some(Self::CreateNewProject),
             name if name == commands::EXPORT_TO_CLIPBOARD.name => Some(Self::ExportToClipboard),
             name if name == commands::EXPORT_TO_FILE.name => Some(Self::ExportToFile),
-            name if name == commands::COST.name => Some(Self::Cost),
             _ => None,
         }
     }
@@ -180,32 +178,6 @@ pub fn record_static_slash_command_accepted(
         },
         ctx
     );
-}
-
-/// Returns the user-facing validation error for `/cost`, shared by GUI and TUI.
-pub fn conversation_cost_validation_error(
-    conversation: Option<&AIConversation>,
-) -> Option<&'static str> {
-    let Some(conversation) = conversation else {
-        return Some("Cannot show conversation cost: no active conversation");
-    };
-    conversation_cost_validation_error_for_state(
-        conversation.is_empty(),
-        conversation.status().is_done(),
-    )
-}
-
-fn conversation_cost_validation_error_for_state(
-    conversation_is_empty: bool,
-    conversation_is_done: bool,
-) -> Option<&'static str> {
-    if conversation_is_empty {
-        Some("Cannot show conversation cost: conversation is empty")
-    } else if !conversation_is_done {
-        Some("Cannot show conversation cost: conversation is in progress")
-    } else {
-        None
-    }
 }
 
 /// Records a saved prompt accepted from either the GUI or TUI slash menu.
@@ -1028,8 +1000,21 @@ impl Input {
                 let conversation = history
                     .as_ref(ctx)
                     .active_conversation(self.terminal_view_id);
-                if let Some(error) = conversation_cost_validation_error(conversation) {
-                    show_error_toast(error.to_owned(), ctx);
+                if conversation.is_none() {
+                    show_error_toast(
+                        "Cannot show conversation cost: no active conversation".to_owned(),
+                        ctx,
+                    );
+                } else if conversation.is_some_and(|c| c.is_empty()) {
+                    show_error_toast(
+                        "Cannot show conversation cost: conversation is empty".to_owned(),
+                        ctx,
+                    );
+                } else if conversation.is_some_and(|c| !c.status().is_done()) {
+                    show_error_toast(
+                        "Cannot show conversation cost: conversation is in progress".to_owned(),
+                        ctx,
+                    );
                 } else {
                     ctx.dispatch_typed_action(&TerminalAction::ToggleUsageFooter);
                 }

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -24,7 +24,7 @@ use warp_util::path::{CleanPathResult, LineAndColumnArg};
 use warpui::clipboard::ClipboardContent;
 use warpui::{AppContext, SingletonEntity, ViewContext};
 
-use crate::ai::agent::conversation::AIConversationId;
+use crate::ai::agent::conversation::{AIConversation, AIConversationId};
 #[cfg(not(target_family = "wasm"))]
 use crate::ai::agent_conversations_model::AgentConversationsModel;
 #[cfg(not(target_family = "wasm"))]
@@ -132,6 +132,10 @@ pub fn slash_command_is_supported_in_tui(command: &StaticCommand) -> bool {
         || command.name == commands::NEW.name
         || command.name == commands::COMPACT.name
         || command.name == commands::PLAN.name
+        || command.name == commands::CREATE_NEW_PROJECT.name
+        || command.name == commands::EXPORT_TO_CLIPBOARD.name
+        || command.name == commands::EXPORT_TO_FILE.name
+        || command.name == commands::COST.name
 }
 /// Records a static slash command accepted from either the GUI or TUI surface.
 pub fn record_static_slash_command_accepted(
@@ -150,6 +154,31 @@ pub fn record_static_slash_command_accepted(
     );
 }
 
+/// Returns the user-facing validation error for `/cost`, shared by GUI and TUI.
+pub fn conversation_cost_validation_error(
+    conversation: Option<&AIConversation>,
+) -> Option<&'static str> {
+    let Some(conversation) = conversation else {
+        return Some("Cannot show conversation cost: no active conversation");
+    };
+    conversation_cost_validation_error_for_state(
+        conversation.is_empty(),
+        conversation.status().is_done(),
+    )
+}
+
+fn conversation_cost_validation_error_for_state(
+    conversation_is_empty: bool,
+    conversation_is_done: bool,
+) -> Option<&'static str> {
+    if conversation_is_empty {
+        Some("Cannot show conversation cost: conversation is empty")
+    } else if !conversation_is_done {
+        Some("Cannot show conversation cost: conversation is in progress")
+    } else {
+        None
+    }
+}
 /// Records a saved prompt accepted from either the GUI or TUI slash menu.
 pub fn record_saved_prompt_accepted(is_in_agent_view: bool, ctx: &mut AppContext) {
     send_telemetry_from_ctx!(
@@ -970,21 +999,8 @@ impl Input {
                 let conversation = history
                     .as_ref(ctx)
                     .active_conversation(self.terminal_view_id);
-                if conversation.is_none() {
-                    show_error_toast(
-                        "Cannot show conversation cost: no active conversation".to_owned(),
-                        ctx,
-                    );
-                } else if conversation.is_some_and(|c| c.is_empty()) {
-                    show_error_toast(
-                        "Cannot show conversation cost: conversation is empty".to_owned(),
-                        ctx,
-                    );
-                } else if conversation.is_some_and(|c| !c.status().is_done()) {
-                    show_error_toast(
-                        "Cannot show conversation cost: conversation is in progress".to_owned(),
-                        ctx,
-                    );
+                if let Some(error) = conversation_cost_validation_error(conversation) {
+                    show_error_toast(error.to_owned(), ctx);
                 } else {
                     ctx.dispatch_typed_action(&TerminalAction::ToggleUsageFooter);
                 }

--- a/app/src/terminal/input/slash_commands/mod.rs
+++ b/app/src/terminal/input/slash_commands/mod.rs
@@ -123,20 +123,48 @@ pub fn should_close_slash_command_menu_for_exact_match(
 ) -> bool {
     result_count < 2 || argument_started
 }
+
+/// Static slash commands that the TUI can execute.
+///
+/// Converting a registry command to this enum centralizes the supported-command policy and lets
+/// the TUI execution path match every supported command exhaustively.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TuiSlashCommand {
+    Agent,
+    New,
+    Compact,
+    Plan,
+    CreateNewProject,
+    ExportToClipboard,
+    ExportToFile,
+    Cost,
+}
+
+impl TuiSlashCommand {
+    /// Classifies a registry command when the TUI supports it.
+    pub fn from_static_command(command: &StaticCommand) -> Option<Self> {
+        match command.name {
+            name if name == commands::AGENT.name => Some(Self::Agent),
+            name if name == commands::NEW.name => Some(Self::New),
+            name if name == commands::COMPACT.name => Some(Self::Compact),
+            name if name == commands::PLAN.name => Some(Self::Plan),
+            name if name == commands::CREATE_NEW_PROJECT.name => Some(Self::CreateNewProject),
+            name if name == commands::EXPORT_TO_CLIPBOARD.name => Some(Self::ExportToClipboard),
+            name if name == commands::EXPORT_TO_FILE.name => Some(Self::ExportToFile),
+            name if name == commands::COST.name => Some(Self::Cost),
+            _ => None,
+        }
+    }
+}
+
 /// Returns whether TUI can execute or otherwise handle the static slash command today.
 ///
 /// GUI-only actions such as opening settings panes or inline menus should stay hidden until the
 /// TUI has equivalent flows.
 pub fn slash_command_is_supported_in_tui(command: &StaticCommand) -> bool {
-    command.name == commands::AGENT.name
-        || command.name == commands::NEW.name
-        || command.name == commands::COMPACT.name
-        || command.name == commands::PLAN.name
-        || command.name == commands::CREATE_NEW_PROJECT.name
-        || command.name == commands::EXPORT_TO_CLIPBOARD.name
-        || command.name == commands::EXPORT_TO_FILE.name
-        || command.name == commands::COST.name
+    TuiSlashCommand::from_static_command(command).is_some()
 }
+
 /// Records a static slash command accepted from either the GUI or TUI surface.
 pub fn record_static_slash_command_accepted(
     command_name: &str,
@@ -179,6 +207,7 @@ fn conversation_cost_validation_error_for_state(
         None
     }
 }
+
 /// Records a saved prompt accepted from either the GUI or TUI slash menu.
 pub fn record_saved_prompt_accepted(is_in_agent_view: bool, ctx: &mut AppContext) {
     send_telemetry_from_ctx!(

--- a/app/src/terminal/input/slash_commands/mod_tests.rs
+++ b/app/src/terminal/input/slash_commands/mod_tests.rs
@@ -1,6 +1,6 @@
 use super::{
     conversation_cost_validation_error, conversation_cost_validation_error_for_state,
-    slash_command_is_submitted_as_prompt, slash_command_is_supported_in_tui,
+    slash_command_is_submitted_as_prompt, slash_command_is_supported_in_tui, TuiSlashCommand,
 };
 use crate::features::FeatureFlag;
 use crate::search::slash_command_menu::static_commands::{commands, Availability};
@@ -40,16 +40,28 @@ fn slash_command_is_submitted_as_prompt_only_for_prompt_commands() {
 
 #[test]
 fn tui_supports_the_selected_low_effort_commands_but_not_orchestrate() {
-    for command in [
-        &*commands::AGENT,
-        &*commands::NEW,
-        &*commands::COMPACT,
-        &*commands::PLAN,
-        &*commands::CREATE_NEW_PROJECT,
-        &commands::EXPORT_TO_CLIPBOARD,
-        &*commands::EXPORT_TO_FILE,
-        &commands::COST,
+    for (command, expected) in [
+        (&*commands::AGENT, TuiSlashCommand::Agent),
+        (&*commands::NEW, TuiSlashCommand::New),
+        (&*commands::COMPACT, TuiSlashCommand::Compact),
+        (&*commands::PLAN, TuiSlashCommand::Plan),
+        (
+            &*commands::CREATE_NEW_PROJECT,
+            TuiSlashCommand::CreateNewProject,
+        ),
+        (
+            &commands::EXPORT_TO_CLIPBOARD,
+            TuiSlashCommand::ExportToClipboard,
+        ),
+        (&*commands::EXPORT_TO_FILE, TuiSlashCommand::ExportToFile),
+        (&commands::COST, TuiSlashCommand::Cost),
     ] {
+        assert_eq!(
+            TuiSlashCommand::from_static_command(command),
+            Some(expected),
+            "{} should map to its TUI command",
+            command.name
+        );
         assert!(
             slash_command_is_supported_in_tui(command),
             "{} should be supported in TUI",
@@ -57,6 +69,10 @@ fn tui_supports_the_selected_low_effort_commands_but_not_orchestrate() {
         );
     }
 
+    assert_eq!(
+        TuiSlashCommand::from_static_command(&commands::ORCHESTRATE),
+        None
+    );
     assert!(!slash_command_is_supported_in_tui(&commands::ORCHESTRATE));
 }
 

--- a/app/src/terminal/input/slash_commands/mod_tests.rs
+++ b/app/src/terminal/input/slash_commands/mod_tests.rs
@@ -1,4 +1,7 @@
-use super::slash_command_is_submitted_as_prompt;
+use super::{
+    conversation_cost_validation_error, conversation_cost_validation_error_for_state,
+    slash_command_is_submitted_as_prompt, slash_command_is_supported_in_tui,
+};
 use crate::features::FeatureFlag;
 use crate::search::slash_command_menu::static_commands::{commands, Availability};
 const BASELINE_AVAILABILITY: Availability = Availability::AGENT_VIEW
@@ -33,6 +36,48 @@ fn slash_command_is_submitted_as_prompt_only_for_prompt_commands() {
         &commands::CONVERSATIONS
     ));
     assert!(!slash_command_is_submitted_as_prompt(&commands::QUEUE));
+}
+
+#[test]
+fn tui_supports_the_selected_low_effort_commands_but_not_orchestrate() {
+    for command in [
+        &*commands::AGENT,
+        &*commands::NEW,
+        &*commands::COMPACT,
+        &*commands::PLAN,
+        &*commands::CREATE_NEW_PROJECT,
+        &commands::EXPORT_TO_CLIPBOARD,
+        &*commands::EXPORT_TO_FILE,
+        &commands::COST,
+    ] {
+        assert!(
+            slash_command_is_supported_in_tui(command),
+            "{} should be supported in TUI",
+            command.name
+        );
+    }
+
+    assert!(!slash_command_is_supported_in_tui(&commands::ORCHESTRATE));
+}
+
+#[test]
+fn conversation_cost_validation_matches_gui_and_tui_states() {
+    assert_eq!(
+        conversation_cost_validation_error(None),
+        Some("Cannot show conversation cost: no active conversation")
+    );
+    assert_eq!(
+        conversation_cost_validation_error_for_state(true, false),
+        Some("Cannot show conversation cost: conversation is empty")
+    );
+    assert_eq!(
+        conversation_cost_validation_error_for_state(false, false),
+        Some("Cannot show conversation cost: conversation is in progress")
+    );
+    assert_eq!(
+        conversation_cost_validation_error_for_state(false, true),
+        None
+    );
 }
 
 #[test]

--- a/app/src/terminal/input/slash_commands/mod_tests.rs
+++ b/app/src/terminal/input/slash_commands/mod_tests.rs
@@ -1,5 +1,4 @@
 use super::{
-    conversation_cost_validation_error, conversation_cost_validation_error_for_state,
     slash_command_is_submitted_as_prompt, slash_command_is_supported_in_tui, TuiSlashCommand,
 };
 use crate::features::FeatureFlag;
@@ -39,7 +38,7 @@ fn slash_command_is_submitted_as_prompt_only_for_prompt_commands() {
 }
 
 #[test]
-fn tui_supports_the_selected_low_effort_commands_but_not_orchestrate() {
+fn tui_supports_the_selected_low_effort_commands_but_not_cost_or_orchestrate() {
     for (command, expected) in [
         (&*commands::AGENT, TuiSlashCommand::Agent),
         (&*commands::NEW, TuiSlashCommand::New),
@@ -54,7 +53,6 @@ fn tui_supports_the_selected_low_effort_commands_but_not_orchestrate() {
             TuiSlashCommand::ExportToClipboard,
         ),
         (&*commands::EXPORT_TO_FILE, TuiSlashCommand::ExportToFile),
-        (&commands::COST, TuiSlashCommand::Cost),
     ] {
         assert_eq!(
             TuiSlashCommand::from_static_command(command),
@@ -69,31 +67,10 @@ fn tui_supports_the_selected_low_effort_commands_but_not_orchestrate() {
         );
     }
 
-    assert_eq!(
-        TuiSlashCommand::from_static_command(&commands::ORCHESTRATE),
-        None
-    );
-    assert!(!slash_command_is_supported_in_tui(&commands::ORCHESTRATE));
-}
-
-#[test]
-fn conversation_cost_validation_matches_gui_and_tui_states() {
-    assert_eq!(
-        conversation_cost_validation_error(None),
-        Some("Cannot show conversation cost: no active conversation")
-    );
-    assert_eq!(
-        conversation_cost_validation_error_for_state(true, false),
-        Some("Cannot show conversation cost: conversation is empty")
-    );
-    assert_eq!(
-        conversation_cost_validation_error_for_state(false, false),
-        Some("Cannot show conversation cost: conversation is in progress")
-    );
-    assert_eq!(
-        conversation_cost_validation_error_for_state(false, true),
-        None
-    );
+    for command in [&commands::COST, &*commands::ORCHESTRATE] {
+        assert_eq!(TuiSlashCommand::from_static_command(command), None);
+        assert!(!slash_command_is_supported_in_tui(command));
+    }
 }
 
 #[test]

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -82,7 +82,7 @@ pub use crate::terminal::input::slash_commands::{
     slash_command_is_supported_in_tui, slash_command_query, slash_command_selection_behavior,
     AcceptSlashCommandOrSavedPrompt, InlineItem, SlashCommandDataSource, SlashCommandMixer,
     SlashCommandSelectionBehavior, TuiDataSourceArgs as TuiSlashCommandDataSourceArgs,
-    TuiSlashCommandDataSource, TuiZeroStateDataSource, UpdatedActiveCommands,
+    TuiSlashCommand, TuiSlashCommandDataSource, TuiZeroStateDataSource, UpdatedActiveCommands,
 };
 pub use crate::terminal::input::CommandExecutionSource;
 pub use crate::terminal::local_tty::{

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -15,7 +15,7 @@ pub use crate::ai::agent::{
     AskUserQuestionResult, CancellationReason, FileGlobV2Result, GrepResult, MessageId,
     RequestCommandOutputResult, RunAgentsAgentOutcomeKind, RunAgentsResult,
     SearchCodebaseFailureReason, SearchCodebaseResult, ServerOutputId, Shared,
-    StartAgentExecutionMode, SuggestNewConversationResult, UserQueryMode,
+    StartAgentExecutionMode, SuggestNewConversationResult, SummarizationType, UserQueryMode,
 };
 pub use crate::ai::blocklist::agent_view::{
     AgentViewController, AgentViewDisplayMode, AgentViewEntryOrigin, EnterAgentViewError,
@@ -45,6 +45,9 @@ pub use crate::ai::blocklist::{
     InputModePolicyHandle, InputType, InputTypeAutoDetectionSource, PolicyConfigUpdate,
     RequestFileEditsExecutor, ShellCommandExecutor, ShellCommandExecutorEvent,
 };
+pub use crate::ai::conversation_export::{
+    export_conversation_markdown, ConversationFileExport, ConversationFileExportError,
+};
 pub use crate::ai::get_relevant_files::controller::GetRelevantFilesController;
 pub use crate::ai::llms::{LLMId, LLMInfo, LLMPreferences, LLMPreferencesEvent};
 pub use crate::ai::skills::{SkillManager, SkillReference};
@@ -73,13 +76,13 @@ pub use crate::terminal::input::slash_command_model::{
     ParsedSlashCommandInput,
 };
 pub use crate::terminal::input::slash_commands::{
-    build_slash_command_mixer, record_saved_prompt_accepted, record_static_slash_command_accepted,
-    saved_prompt_text_for_id, should_close_slash_command_menu_for_exact_match,
-    slash_command_is_submitted_as_prompt, slash_command_is_supported_in_tui, slash_command_query,
-    slash_command_selection_behavior, AcceptSlashCommandOrSavedPrompt, InlineItem,
-    SlashCommandDataSource, SlashCommandMixer, SlashCommandSelectionBehavior,
-    TuiDataSourceArgs as TuiSlashCommandDataSourceArgs, TuiSlashCommandDataSource,
-    TuiZeroStateDataSource, UpdatedActiveCommands,
+    build_slash_command_mixer, conversation_cost_validation_error, record_saved_prompt_accepted,
+    record_static_slash_command_accepted, saved_prompt_text_for_id,
+    should_close_slash_command_menu_for_exact_match, slash_command_is_submitted_as_prompt,
+    slash_command_is_supported_in_tui, slash_command_query, slash_command_selection_behavior,
+    AcceptSlashCommandOrSavedPrompt, InlineItem, SlashCommandDataSource, SlashCommandMixer,
+    SlashCommandSelectionBehavior, TuiDataSourceArgs as TuiSlashCommandDataSourceArgs,
+    TuiSlashCommandDataSource, TuiZeroStateDataSource, UpdatedActiveCommands,
 };
 pub use crate::terminal::input::CommandExecutionSource;
 pub use crate::terminal::local_tty::{

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -45,6 +45,7 @@ pub use crate::ai::blocklist::{
     InputModePolicyHandle, InputType, InputTypeAutoDetectionSource, PolicyConfigUpdate,
     RequestFileEditsExecutor, ShellCommandExecutor, ShellCommandExecutorEvent,
 };
+#[cfg(feature = "local_fs")]
 pub use crate::ai::conversation_export::{
     export_conversation_markdown, ConversationFileExport, ConversationFileExportError,
 };
@@ -76,13 +77,13 @@ pub use crate::terminal::input::slash_command_model::{
     ParsedSlashCommandInput,
 };
 pub use crate::terminal::input::slash_commands::{
-    build_slash_command_mixer, conversation_cost_validation_error, record_saved_prompt_accepted,
-    record_static_slash_command_accepted, saved_prompt_text_for_id,
-    should_close_slash_command_menu_for_exact_match, slash_command_is_submitted_as_prompt,
-    slash_command_is_supported_in_tui, slash_command_query, slash_command_selection_behavior,
-    AcceptSlashCommandOrSavedPrompt, InlineItem, SlashCommandDataSource, SlashCommandMixer,
-    SlashCommandSelectionBehavior, TuiDataSourceArgs as TuiSlashCommandDataSourceArgs,
-    TuiSlashCommand, TuiSlashCommandDataSource, TuiZeroStateDataSource, UpdatedActiveCommands,
+    build_slash_command_mixer, record_saved_prompt_accepted, record_static_slash_command_accepted,
+    saved_prompt_text_for_id, should_close_slash_command_menu_for_exact_match,
+    slash_command_is_submitted_as_prompt, slash_command_is_supported_in_tui, slash_command_query,
+    slash_command_selection_behavior, AcceptSlashCommandOrSavedPrompt, InlineItem,
+    SlashCommandDataSource, SlashCommandMixer, SlashCommandSelectionBehavior,
+    TuiDataSourceArgs as TuiSlashCommandDataSourceArgs, TuiSlashCommand, TuiSlashCommandDataSource,
+    TuiZeroStateDataSource, UpdatedActiveCommands,
 };
 pub use crate::terminal::input::CommandExecutionSource;
 pub use crate::terminal::local_tty::{

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -16,7 +16,8 @@ use parking_lot::FairMutex;
 use warp::tui_export::{
     AIAgentAction, AIAgentActionId, AIAgentActionType, AIAgentExchangeId, AIAgentOutputMessageType,
     AIAgentTextSection, AIBlockModel, AIConversationId, BlockId, BlocklistAIActionEvent,
-    BlocklistAIActionModel, MessageId, ModelEvent, ModelEventDispatcher, TerminalModel,
+    BlocklistAIActionModel, MessageId, ModelEvent, ModelEventDispatcher, SummarizationType,
+    TerminalModel,
 };
 use warpui_core::elements::tui::{
     TuiChildView, TuiConstraint, TuiContainer, TuiElement, TuiFlex, TuiLayoutContext,
@@ -31,7 +32,7 @@ use super::tui_file_edits_view::{TuiFileEditsView, TuiFileEditsViewEvent};
 use super::tui_shell_command_view::{TuiShellCommandView, TuiShellCommandViewEvent};
 use crate::agent_block_sections::{
     render_fallback_tool_call_section, render_input_section, render_plain_text_section,
-    render_thinking_section,
+    render_summarization_section, render_thinking_section,
 };
 use crate::transcript_view::BLOCK_TOP_PADDING_ROWS;
 
@@ -47,6 +48,11 @@ enum TuiAIBlockSection {
     Thinking {
         message_id: MessageId,
         finished_duration: Option<Duration>,
+        body: String,
+    },
+    Summarization {
+        message_id: MessageId,
+        finished: bool,
         body: String,
     },
 }
@@ -451,6 +457,31 @@ impl TuiAIBlock {
                                 .join("\n"),
                         });
                     }
+                    AIAgentOutputMessageType::Summarization {
+                        text,
+                        finished_duration,
+                        summarization_type: SummarizationType::ConversationSummary,
+                        ..
+                    } => {
+                        let body = text
+                            .sections
+                            .iter()
+                            .filter_map(|section| match section {
+                                AIAgentTextSection::PlainText { text } => Some(text.text()),
+                                AIAgentTextSection::Code { .. }
+                                | AIAgentTextSection::Table { .. }
+                                | AIAgentTextSection::Image { .. }
+                                | AIAgentTextSection::MermaidDiagram { .. } => None,
+                            })
+                            .join("\n");
+                        if !body.is_empty() {
+                            sections.push(TuiAIBlockSection::Summarization {
+                                message_id: message.id.clone(),
+                                finished: finished_duration.is_some(),
+                                body,
+                            });
+                        }
+                    }
                     // Other message kinds are not rendered by the TUI transcript yet.
                     AIAgentOutputMessageType::Summarization { .. }
                     | AIAgentOutputMessageType::Subagent(_)
@@ -503,6 +534,17 @@ impl TuiAIBlock {
                     &self.thinking_states,
                     message_id,
                     *finished_duration,
+                    body,
+                    app,
+                ),
+                TuiAIBlockSection::Summarization {
+                    message_id,
+                    finished,
+                    body,
+                } => render_summarization_section(
+                    &self.thinking_states,
+                    message_id,
+                    *finished,
                     body,
                     app,
                 ),

--- a/crates/warp_tui/src/agent_block_sections.rs
+++ b/crates/warp_tui/src/agent_block_sections.rs
@@ -152,15 +152,56 @@ pub(crate) fn render_thinking_section(
         Some(duration) => format!("Thought for {}", format_elapsed_seconds(duration)),
         None => "Thinking...".to_owned(),
     };
-    // Indent the reasoning body so every wrapped line aligns beneath the header.
+    render_collapsible_message_section(
+        states,
+        message_id,
+        header,
+        finished_duration.is_some(),
+        body,
+        builder.muted_text_style(),
+        app,
+    )
+}
+
+/// Renders a streamed conversation summary with the same persistent
+/// collapse/hover behavior as a reasoning section.
+pub(crate) fn render_summarization_section(
+    states: &ThinkingBlockStates,
+    message_id: &MessageId,
+    finished: bool,
+    body: &str,
+    app: &AppContext,
+) -> Box<dyn TuiElement> {
+    render_collapsible_message_section(
+        states,
+        message_id,
+        "Conversation summarized".to_owned(),
+        finished,
+        body,
+        TuiUiBuilder::from_app(app).primary_text_style(),
+        app,
+    )
+}
+
+fn render_collapsible_message_section(
+    states: &ThinkingBlockStates,
+    message_id: &MessageId,
+    header: String,
+    finished: bool,
+    body: &str,
+    body_style: TuiStyle,
+    app: &AppContext,
+) -> Box<dyn TuiElement> {
+    let builder = TuiUiBuilder::from_app(app);
+    // Indent the body so every wrapped line aligns beneath the header.
     let body_element = TuiContainer::new(
         TuiText::new(body.to_owned())
-            .with_style(builder.muted_text_style())
+            .with_style(body_style)
             .finish(),
     )
     .with_padding_left(4);
 
-    let collapsed = states.is_collapsed(message_id, finished_duration.is_some());
+    let collapsed = states.is_collapsed(message_id, finished);
     let toggle_message_id = message_id.clone();
     builder.collapsible(
         collapsed,

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -9,7 +9,8 @@ use warp::tui_export::{
     AIAgentActionType, AIAgentExchangeId, AIAgentInput, AIAgentOutput, AIAgentOutputMessage,
     AIAgentOutputMessageType, AIAgentText, AIAgentTextSection, AIBlockModel, AIBlockOutputStatus,
     AIConversationId, AIRequestType, Appearance, LLMId, MessageId, OutputStatusUpdateCallback,
-    RequestCommandOutputResult, ServerOutputId, Shared, TaskId, TerminalModel, UserQueryMode,
+    RequestCommandOutputResult, ServerOutputId, Shared, SummarizationType, TaskId, TerminalModel,
+    UserQueryMode,
 };
 use warp_core::ui::color::blend::Blend;
 use warp_core::ui::theme::Fill as ThemeFill;
@@ -614,6 +615,98 @@ fn reasoning_interleaves_with_plain_text_in_message_order() {
 }
 
 #[test]
+fn completed_conversation_summary_renders_collapsed_in_message_order() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let block = test_agent_block(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status: complete_output_messages(vec![
+                    plain_text_message("m1", "before"),
+                    summarization_message(
+                        "summary-1",
+                        Some(Duration::from_secs(3)),
+                        SummarizationType::ConversationSummary,
+                        "condensed context",
+                    ),
+                    plain_text_message("m2", "after"),
+                ]),
+            },
+        );
+        app.read(|app_ctx| {
+            let block = block.as_ref(app_ctx);
+            assert_eq!(
+                block.sections(app_ctx),
+                vec![
+                    TuiAIBlockSection::PlainText("before".to_owned()),
+                    TuiAIBlockSection::Summarization {
+                        message_id: MessageId::new("summary-1".to_owned()),
+                        finished: true,
+                        body: "condensed context".to_owned(),
+                    },
+                    TuiAIBlockSection::PlainText("after".to_owned()),
+                ]
+            );
+            assert_eq!(
+                render_block_lines(block, 40, app_ctx),
+                vec!["before", "Conversation summarized ▸", "after"]
+            );
+        });
+    });
+}
+
+#[test]
+fn expanded_conversation_summary_shows_its_body() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let block = test_agent_block(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status: complete_output_messages(vec![summarization_message(
+                    "summary-1",
+                    Some(Duration::from_secs(3)),
+                    SummarizationType::ConversationSummary,
+                    "condensed context",
+                )]),
+            },
+        );
+        app.read(|app_ctx| {
+            let block = block.as_ref(app_ctx);
+            block
+                .thinking_states
+                .set_collapsed(MessageId::new("summary-1".to_owned()), false);
+            assert_eq!(
+                render_block_lines(block, 40, app_ctx),
+                vec!["Conversation summarized ▾", "    condensed context"]
+            );
+        });
+    });
+}
+
+#[test]
+fn tool_call_result_summaries_remain_hidden() {
+    App::test((), |mut app| async move {
+        let block = test_agent_block(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status: complete_output_messages(vec![summarization_message(
+                    "summary-1",
+                    Some(Duration::from_secs(3)),
+                    SummarizationType::ToolCallResultSummary,
+                    "tool output",
+                )]),
+            },
+        );
+        app.read(|app_ctx| {
+            assert!(block.as_ref(app_ctx).sections(app_ctx).is_empty());
+        });
+    });
+}
+
+#[test]
 fn multiple_reasoning_blocks_render_independent_collapse_state() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| Appearance::mock());
@@ -816,6 +909,28 @@ fn reasoning_message(
                 }],
             },
             finished_duration,
+        },
+        citations: Vec::new(),
+    }
+}
+
+fn summarization_message(
+    id: &str,
+    finished_duration: Option<Duration>,
+    summarization_type: SummarizationType,
+    body: &str,
+) -> AIAgentOutputMessage {
+    AIAgentOutputMessage {
+        id: MessageId::new(id.to_owned()),
+        message: AIAgentOutputMessageType::Summarization {
+            text: AIAgentText {
+                sections: vec![AIAgentTextSection::PlainText {
+                    text: body.to_owned().into(),
+                }],
+            },
+            finished_duration,
+            summarization_type,
+            token_count: None,
         },
         citations: Vec::new(),
     }

--- a/crates/warp_tui/src/clipboard.rs
+++ b/crates/warp_tui/src/clipboard.rs
@@ -9,15 +9,15 @@ const ESC: char = '\x1b';
 const BEL: char = '\x07';
 
 /// Copies `text` through the terminal, including Linux's PRIMARY selection.
-pub(crate) fn copy_to_clipboard(text: &str) {
-    let sequence = osc52_sequences(text, std::env::var_os("TMUX").is_some());
+pub(crate) fn copy_to_clipboard(text: &str) -> io::Result<()> {
     let mut stdout = io::stdout().lock();
-    if let Err(error) = stdout
-        .write_all(sequence.as_bytes())
-        .and_then(|_| stdout.flush())
-    {
-        log::warn!("Failed to copy TUI selection via OSC 52: {error}");
-    }
+    write_osc52_sequences(text, std::env::var_os("TMUX").is_some(), &mut stdout)
+}
+
+fn write_osc52_sequences(text: &str, in_tmux: bool, writer: &mut impl Write) -> io::Result<()> {
+    let sequence = osc52_sequences(text, in_tmux);
+    writer.write_all(sequence.as_bytes())?;
+    writer.flush()
 }
 
 /// Encodes `text` as OSC 52 writes to clipboard (`c`) and PRIMARY (`p`).

--- a/crates/warp_tui/src/clipboard_tests.rs
+++ b/crates/warp_tui/src/clipboard_tests.rs
@@ -1,7 +1,9 @@
+use std::io::{self, Write};
+
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
 
-use super::{osc52_sequences, tmux_passthrough};
+use super::{osc52_sequences, tmux_passthrough, write_osc52_sequences};
 
 #[test]
 fn osc52_encodes_utf8_for_clipboard_and_primary() {
@@ -22,4 +24,36 @@ fn tmux_passthrough_wraps_and_doubles_escape_bytes() {
     let wrapped = osc52_sequences("x", true);
     assert_eq!(wrapped.matches("\x1bPtmux;").count(), 2);
     assert_eq!(wrapped.matches("\x1b\x1b]52;").count(), 2);
+}
+
+#[test]
+fn clipboard_writer_emits_exact_markdown_payload() {
+    let markdown = "# Conversation\n\nHello";
+    let mut output = Vec::new();
+
+    write_osc52_sequences(markdown, false, &mut output).unwrap();
+
+    assert_eq!(output, osc52_sequences(markdown, false).into_bytes());
+}
+
+#[test]
+fn clipboard_writer_propagates_output_errors() {
+    struct FailingWriter;
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+            Err(io::Error::other("write failed"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    assert_eq!(
+        write_osc52_sequences("conversation", false, &mut FailingWriter)
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::Other
+    );
 }

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -10,9 +10,9 @@ use parking_lot::FairMutex;
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp::settings::{AISettings, AISettingsChangedEvent};
 use warp::tui_export::{
-    build_slash_command_mixer, conversation_cost_validation_error, detect_possible_git_repo,
-    export_conversation_markdown, prepare_conversation_block_restoration,
-    record_saved_prompt_accepted, record_static_slash_command_accepted, saved_prompt_text_for_id,
+    build_slash_command_mixer, detect_possible_git_repo, export_conversation_markdown,
+    prepare_conversation_block_restoration, record_saved_prompt_accepted,
+    record_static_slash_command_accepted, saved_prompt_text_for_id,
     slash_command_selection_behavior, throttle, AIAgentActionId, AIAgentPtyWriteMode,
     AcceptSlashCommandOrSavedPrompt, ActiveSession, ActiveSessionEvent, AgentInteractionMetadata,
     AgentViewEntryOrigin, BlocklistAIActionModel, BlocklistAIContextModel, BlocklistAIController,
@@ -23,11 +23,11 @@ use warp::tui_export::{
     ExecuteCommandEvent, GetRelevantFilesController, GitRepoModels, GitRepoStatusModel,
     GitStatusMetadata, LLMPreferences, LLMPreferencesEvent, ModelEvent, ParsedSlashCommandInput,
     PtyIntent, PtyIntentEvent, RepoDetectionSessionType, RepoDetectionSource,
-    ServerConversationToken, ShellCommandExecutorEvent, SkillReference, SlashCommandDataSource as _,
-    SlashCommandSelectionBehavior, StaticCommand, TerminalModel, TerminalSurface,
-    TerminalSurfaceInit, TranscriptScope, TuiSlashCommand, TuiSlashCommandDataSource,
-    TuiSlashCommandDataSourceArgs, TuiZeroStateDataSource, COMMAND_REGISTRY,
-    WAKEUP_THROTTLE_PERIOD,
+    ServerConversationToken, ShellCommandExecutorEvent, SkillReference,
+    SlashCommandDataSource as _, SlashCommandSelectionBehavior, StaticCommand, TerminalModel,
+    TerminalSurface, TerminalSurfaceInit, TranscriptScope, TuiSlashCommand,
+    TuiSlashCommandDataSource, TuiSlashCommandDataSourceArgs, TuiZeroStateDataSource,
+    COMMAND_REGISTRY, WAKEUP_THROTTLE_PERIOD,
 };
 use warp_core::settings::Setting;
 use warp_editor::model::CoreEditorModel;
@@ -1344,19 +1344,6 @@ impl TuiTerminalSessionView {
                         );
                         self.show_transient_hint(message, ctx);
                     }
-                }
-                self.input_view.update(ctx, |input, ctx| input.clear(ctx));
-                record_static_slash_command_accepted(command.name, true, ctx);
-            }
-            TuiSlashCommand::Cost => {
-                let conversation = self
-                    .conversation_selection
-                    .as_ref(ctx)
-                    .selected_conversation(ctx);
-                if let Some(error) = conversation_cost_validation_error(conversation) {
-                    self.show_transient_hint(error.to_owned(), ctx);
-                } else {
-                    self.toggle_usage_display(ctx);
                 }
                 self.input_view.update(ctx, |input, ctx| input.clear(ctx));
                 record_static_slash_command_accepted(command.name, true, ctx);

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -10,7 +10,8 @@ use parking_lot::FairMutex;
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp::settings::{AISettings, AISettingsChangedEvent};
 use warp::tui_export::{
-    build_slash_command_mixer, detect_possible_git_repo, prepare_conversation_block_restoration,
+    build_slash_command_mixer, conversation_cost_validation_error, detect_possible_git_repo,
+    export_conversation_markdown, prepare_conversation_block_restoration,
     record_saved_prompt_accepted, record_static_slash_command_accepted, saved_prompt_text_for_id,
     slash_command_is_submitted_as_prompt, slash_command_selection_behavior, slash_commands,
     throttle, AIAgentActionId, AIAgentPtyWriteMode, AcceptSlashCommandOrSavedPrompt, ActiveSession,
@@ -32,6 +33,7 @@ use warp_core::settings::Setting;
 use warp_editor::model::CoreEditorModel;
 use warp_errors::report_error;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
+use warpui::clipboard::ClipboardContent;
 use warpui::SingletonEntity;
 use warpui_core::elements::tui::{
     TuiChildView, TuiConstrainedBox, TuiContainer, TuiElement, TuiFlex, TuiText,
@@ -117,6 +119,22 @@ fn hide_agent_requested_command_from_top_level(
         .block_list_mut()
         .set_visibility_of_block_for_ai_action(action_id, false);
     true
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClipboardExportOutcome {
+    Exported,
+    NoActiveConversation,
+}
+
+fn export_markdown_to_clipboard(
+    markdown: Option<String>,
+    clipboard: &mut dyn warpui::Clipboard,
+) -> ClipboardExportOutcome {
+    let Some(markdown) = markdown else {
+        return ClipboardExportOutcome::NoActiveConversation;
+    };
+    clipboard.write(ClipboardContent::plain_text(markdown));
+    ClipboardExportOutcome::Exported
 }
 
 fn raw_prompt_if_not_blank(input: &str) -> Option<&str> {
@@ -497,22 +515,38 @@ impl TuiTerminalSessionView {
                 // `TerminalView::apply_block_metadata_update`). The first
                 // post-bootstrap precmd metadata transitions the cwd from
                 // `None` to `Some`, so this also covers the launch directory.
-                if let Some(cwd) = view
+                let Some(cwd) = view
                     .active_session
                     .as_ref(ctx)
                     .current_working_directory()
                     .cloned()
-                {
-                    let detect_repo = detect_possible_git_repo(
-                        RepoDetectionSessionType::Local,
-                        &cwd,
-                        RepoDetectionSource::TerminalNavigation,
-                        ctx,
-                    );
-                    ctx.spawn(detect_repo, |view, repo_path, ctx| {
-                        view.update_git_status_subscription(repo_path, ctx);
+                else {
+                    view.slash_commands_source.update(ctx, |source, ctx| {
+                        source.set_active_repo_root(None, ctx);
                     });
-                }
+                    view.update_git_status_subscription(None, ctx);
+                    ctx.notify();
+                    return;
+                };
+                let detection = detect_possible_git_repo(
+                    RepoDetectionSessionType::Local,
+                    &cwd,
+                    RepoDetectionSource::TerminalNavigation,
+                    ctx,
+                );
+                ctx.spawn(detection, move |view, repo_path, ctx| {
+                    if view.active_session.as_ref(ctx).current_working_directory() != Some(&cwd) {
+                        return;
+                    }
+                    view.update_git_status_subscription(repo_path.clone(), ctx);
+                    let repo_root = repo_path
+                        .as_ref()
+                        .and_then(|path| path.to_local_path())
+                        .map(ToOwned::to_owned);
+                    view.slash_commands_source.update(ctx, |source, ctx| {
+                        source.set_active_repo_root(repo_root, ctx);
+                    });
+                });
                 ctx.notify();
             }
             ActiveSessionEvent::Bootstrapped => {}
@@ -717,6 +751,7 @@ impl TuiTerminalSessionView {
         if matches!(
             event,
             BlocklistAIHistoryEvent::AppendedExchange { .. }
+                | BlocklistAIHistoryEvent::UpdatedStreamingExchange { .. }
                 | BlocklistAIHistoryEvent::UpdatedConversationStatus { .. }
         ) {
             ctx.notify();
@@ -1221,6 +1256,95 @@ impl TuiTerminalSessionView {
             }
             self.input_view.update(ctx, |input, ctx| input.clear(ctx));
             record_static_slash_command_accepted(command.name, true, ctx);
+        } else if command.name == slash_commands::CREATE_NEW_PROJECT.name {
+            let Some(query) = argument
+                .map(|argument| argument.trim())
+                .filter(|argument| !argument.is_empty())
+            else {
+                self.show_transient_hint(
+                    "Please describe the project you want to create after /create-new-project"
+                        .to_owned(),
+                    ctx,
+                );
+                return;
+            };
+            self.ai_controller.update(ctx, |controller, ctx| {
+                controller.send_create_new_project_request(query.to_owned(), ctx);
+            });
+            self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+            record_static_slash_command_accepted(command.name, true, ctx);
+        } else if command.name == slash_commands::EXPORT_TO_CLIPBOARD.name {
+            let markdown = self
+                .conversation_selection
+                .as_ref(ctx)
+                .selected_conversation(ctx)
+                .map(|conversation| {
+                    conversation.export_to_markdown(Some(self.ai_action_model.as_ref(ctx)))
+                });
+            let message = match export_markdown_to_clipboard(markdown, ctx.clipboard()) {
+                ClipboardExportOutcome::Exported => "Conversation exported to clipboard",
+                ClipboardExportOutcome::NoActiveConversation => "No active conversation to export",
+            };
+            self.show_transient_hint(message.to_owned(), ctx);
+            self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+            record_static_slash_command_accepted(command.name, true, ctx);
+        } else if command.name == slash_commands::EXPORT_TO_FILE.name {
+            let Some(conversation) = self
+                .conversation_selection
+                .as_ref(ctx)
+                .selected_conversation(ctx)
+            else {
+                self.show_transient_hint("No active conversation to export".to_owned(), ctx);
+                return;
+            };
+            let title = conversation.title();
+            let markdown =
+                conversation.export_to_markdown(Some(self.ai_action_model.as_ref(ctx)));
+            let current_directory = self
+                .active_session
+                .as_ref(ctx)
+                .current_working_directory()
+                .cloned();
+            match export_conversation_markdown(
+                current_directory.as_deref(),
+                argument.map(String::as_str),
+                title.as_deref(),
+                &markdown,
+            ) {
+                Ok(export) => {
+                    let path = export.path().display();
+                    let message = if export.overwrote_existing() {
+                        format!("Conversation exported to {path} (overwrote existing file)")
+                    } else {
+                        format!("Conversation exported to {path}")
+                    };
+                    self.show_transient_hint(message, ctx);
+                }
+                Err(error) => {
+                    let message = error.user_message();
+                    let path = error.path().to_path_buf();
+                    report_error!(
+                        anyhow::Error::new(error)
+                            .context("Failed to write TUI conversation to file"),
+                        extra: { "path" => %path.display() }
+                    );
+                    self.show_transient_hint(message, ctx);
+                }
+            }
+            self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+            record_static_slash_command_accepted(command.name, true, ctx);
+        } else if command.name == slash_commands::COST.name {
+            let conversation = self
+                .conversation_selection
+                .as_ref(ctx)
+                .selected_conversation(ctx);
+            if let Some(error) = conversation_cost_validation_error(conversation) {
+                self.show_transient_hint(error.to_owned(), ctx);
+            } else {
+                self.toggle_usage_display(ctx);
+            }
+            self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+            record_static_slash_command_accepted(command.name, true, ctx);
         } else if slash_command_is_submitted_as_prompt(command) {
             self.input_view.update(ctx, |input, ctx| input.clear(ctx));
             let prompt = argument
@@ -1369,8 +1493,13 @@ impl TuiView for TuiTerminalSessionView {
                     .latest_exchange()
                     .and_then(|exchange| exchange.time_since_start());
                 if let Some(elapsed) = warping_elapsed {
+                    let label = if conversation.is_summarizing() {
+                        "Summarizing conversation..."
+                    } else {
+                        "Warping..."
+                    };
                     content = content.child(
-                        TuiContainer::new(render_warping_indicator(elapsed, ctx))
+                        TuiContainer::new(render_warping_indicator(label, elapsed, ctx))
                             .with_padding_top(1)
                             .finish(),
                     );

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -19,11 +19,11 @@ use warp::tui_export::{
     BlocklistAIContextModel, BlocklistAIController, BlocklistAIHistoryEvent,
     BlocklistAIHistoryModel, BlocklistAIInputModel, CLISubagentController, CLISubagentEvent,
     CancellationReason, ChangelogModel, ChangelogModelEvent, ChangelogRequestType,
-    CloudConversationData, CommandExecutionSource, ConversationSelection,
+    CloudConversationData, CommandExecutionSource, ConversationFileExport, ConversationSelection,
     ConversationSelectionHandle, ConversationUsageTotals, ExecuteCommandEvent,
-    GetRelevantFilesController, GitRepoModels, GitRepoStatusModel, GitStatusMetadata,
-    LLMPreferences, LLMPreferencesEvent, ModelEvent, ParsedSlashCommandInput, PtyIntent,
-    PtyIntentEvent, RepoDetectionSessionType, RepoDetectionSource, ServerConversationToken,
+    GetRelevantFilesController, GitRepoModels, GitRepoStatusModel, GitStatusMetadata, LLMPreferences,
+    LLMPreferencesEvent, ModelEvent, ParsedSlashCommandInput, PtyIntent, PtyIntentEvent,
+    RepoDetectionSessionType, RepoDetectionSource, ServerConversationToken,
     ShellCommandExecutorEvent, SkillReference, SlashCommandDataSource as _,
     SlashCommandSelectionBehavior, StaticCommand, TerminalModel, TerminalSurface,
     TerminalSurfaceInit, TranscriptScope, TuiSlashCommandDataSource, TuiSlashCommandDataSourceArgs,
@@ -164,6 +164,14 @@ enum ConversationRestoreState {
     Idle,
     Loading,
     Failed(String),
+}
+fn export_file_success_message(export: &ConversationFileExport) -> String {
+    let path = export.path().display();
+    if export.overwrote_existing() {
+        format!("Conversation exported to {path} (overwrote existing file)")
+    } else {
+        format!("Conversation exported to {path}")
+    }
 }
 
 /// Typed actions handled by [`TuiTerminalSessionView`].
@@ -773,11 +781,14 @@ impl TuiTerminalSessionView {
     }
 
     /// Displays success-colored feedback in the transient footer slot.
-    fn show_copy_hint(&mut self, ctx: &mut ViewContext<Self>) {
+    fn show_success_hint(&mut self, text: String, ctx: &mut ViewContext<Self>) {
         self.transient_hint
-            .show_success(COPY_SELECTION_HINT.to_owned(), ctx, |view| {
-                &mut view.transient_hint
-            });
+            .show_success(text, ctx, |view| &mut view.transient_hint);
+    }
+
+    /// Displays success-colored feedback in the transient footer slot.
+    fn show_copy_hint(&mut self, ctx: &mut ViewContext<Self>) {
+        self.show_success_hint(COPY_SELECTION_HINT.to_owned(), ctx);
     }
 
     /// Handles a ctrl-c press: a second press within [`CTRL_C_EXIT_WINDOW`]
@@ -1281,11 +1292,14 @@ impl TuiTerminalSessionView {
                 .map(|conversation| {
                     conversation.export_to_markdown(Some(self.ai_action_model.as_ref(ctx)))
                 });
-            let message = match export_markdown_to_clipboard(markdown, ctx.clipboard()) {
-                ClipboardExportOutcome::Exported => "Conversation exported to clipboard",
-                ClipboardExportOutcome::NoActiveConversation => "No active conversation to export",
-            };
-            self.show_transient_hint(message.to_owned(), ctx);
+            match export_markdown_to_clipboard(markdown, ctx.clipboard()) {
+                ClipboardExportOutcome::Exported => {
+                    self.show_success_hint("Conversation exported to clipboard".to_owned(), ctx);
+                }
+                ClipboardExportOutcome::NoActiveConversation => {
+                    self.show_transient_hint("No active conversation to export".to_owned(), ctx);
+                }
+            }
             self.input_view.update(ctx, |input, ctx| input.clear(ctx));
             record_static_slash_command_accepted(command.name, true, ctx);
         } else if command.name == slash_commands::EXPORT_TO_FILE.name {
@@ -1312,13 +1326,7 @@ impl TuiTerminalSessionView {
                 &markdown,
             ) {
                 Ok(export) => {
-                    let path = export.path().display();
-                    let message = if export.overwrote_existing() {
-                        format!("Conversation exported to {path} (overwrote existing file)")
-                    } else {
-                        format!("Conversation exported to {path}")
-                    };
-                    self.show_transient_hint(message, ctx);
+                    self.show_success_hint(export_file_success_message(&export), ctx);
                 }
                 Err(error) => {
                     let message = error.user_message();

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -33,7 +33,6 @@ use warp_core::settings::Setting;
 use warp_editor::model::CoreEditorModel;
 use warp_errors::report_error;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
-use warpui::clipboard::ClipboardContent;
 use warpui::SingletonEntity;
 use warpui_core::elements::tui::{
     TuiChildView, TuiConstrainedBox, TuiContainer, TuiElement, TuiFlex, TuiText,
@@ -102,6 +101,7 @@ const NEW_CONVERSATION_COMMAND_RUNNING_HINT: &str =
 /// Footer hint shown while the input is in `!` shell mode.
 const SHELL_MODE_HINT: &str = "shell mode · esc to exit";
 const COPY_SELECTION_HINT: &str = "copied to clipboard";
+const COPY_FAILED_HINT: &str = "failed to copy to clipboard";
 /// Keeps an agent-requested command's canonical block out of the TUI's
 /// top-level transcript. The shell-command action embeds the block's terminal
 /// content inside its own disclosure, so the canonical block must have zero
@@ -119,22 +119,6 @@ fn hide_agent_requested_command_from_top_level(
         .block_list_mut()
         .set_visibility_of_block_for_ai_action(action_id, false);
     true
-}
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ClipboardExportOutcome {
-    Exported,
-    NoActiveConversation,
-}
-
-fn export_markdown_to_clipboard(
-    markdown: Option<String>,
-    clipboard: &mut dyn warpui::Clipboard,
-) -> ClipboardExportOutcome {
-    let Some(markdown) = markdown else {
-        return ClipboardExportOutcome::NoActiveConversation;
-    };
-    clipboard.write(ClipboardContent::plain_text(markdown));
-    ClipboardExportOutcome::Exported
 }
 
 fn raw_prompt_if_not_blank(input: &str) -> Option<&str> {
@@ -418,10 +402,13 @@ impl TuiTerminalSessionView {
                 view.input_view
                     .update(ctx, |input, ctx| input.clear_selection(ctx));
             }
-            TuiTranscriptViewEvent::SelectionEnded(text) => {
-                copy_to_clipboard(text);
-                view.show_copy_hint(ctx);
-            }
+            TuiTranscriptViewEvent::SelectionEnded(text) => match copy_to_clipboard(text) {
+                Ok(()) => view.show_copy_hint(ctx),
+                Err(error) => {
+                    log::warn!("Failed to copy TUI selection via OSC 52: {error}");
+                    view.show_transient_hint(COPY_FAILED_HINT.to_owned(), ctx);
+                }
+            },
         });
 
         ctx.subscribe_to_view(&input_view, |view, _, event, ctx| match event {
@@ -1285,20 +1272,27 @@ impl TuiTerminalSessionView {
             self.input_view.update(ctx, |input, ctx| input.clear(ctx));
             record_static_slash_command_accepted(command.name, true, ctx);
         } else if command.name == slash_commands::EXPORT_TO_CLIPBOARD.name {
-            let markdown = self
+            if let Some(conversation) = self
                 .conversation_selection
                 .as_ref(ctx)
                 .selected_conversation(ctx)
-                .map(|conversation| {
-                    conversation.export_to_markdown(Some(self.ai_action_model.as_ref(ctx)))
-                });
-            match export_markdown_to_clipboard(markdown, ctx.clipboard()) {
-                ClipboardExportOutcome::Exported => {
-                    self.show_success_hint("Conversation exported to clipboard".to_owned(), ctx);
+            {
+                let markdown =
+                    conversation.export_to_markdown(Some(self.ai_action_model.as_ref(ctx)));
+                match copy_to_clipboard(&markdown) {
+                    Ok(()) => {
+                        self.show_success_hint(
+                            "Conversation sent to terminal clipboard".to_owned(),
+                            ctx,
+                        );
+                    }
+                    Err(error) => {
+                        log::warn!("Failed to export TUI conversation via OSC 52: {error}");
+                        self.show_transient_hint(COPY_FAILED_HINT.to_owned(), ctx);
+                    }
                 }
-                ClipboardExportOutcome::NoActiveConversation => {
-                    self.show_transient_hint("No active conversation to export".to_owned(), ctx);
-                }
+            } else {
+                self.show_transient_hint("No active conversation to export".to_owned(), ctx);
             }
             self.input_view.update(ctx, |input, ctx| input.clear(ctx));
             record_static_slash_command_accepted(command.name, true, ctx);

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -13,21 +13,21 @@ use warp::tui_export::{
     build_slash_command_mixer, conversation_cost_validation_error, detect_possible_git_repo,
     export_conversation_markdown, prepare_conversation_block_restoration,
     record_saved_prompt_accepted, record_static_slash_command_accepted, saved_prompt_text_for_id,
-    slash_command_is_submitted_as_prompt, slash_command_selection_behavior, slash_commands,
-    throttle, AIAgentActionId, AIAgentPtyWriteMode, AcceptSlashCommandOrSavedPrompt, ActiveSession,
-    ActiveSessionEvent, AgentInteractionMetadata, AgentViewEntryOrigin, BlocklistAIActionModel,
-    BlocklistAIContextModel, BlocklistAIController, BlocklistAIHistoryEvent,
-    BlocklistAIHistoryModel, BlocklistAIInputModel, CLISubagentController, CLISubagentEvent,
-    CancellationReason, ChangelogModel, ChangelogModelEvent, ChangelogRequestType,
-    CloudConversationData, CommandExecutionSource, ConversationFileExport, ConversationSelection,
-    ConversationSelectionHandle, ConversationUsageTotals, ExecuteCommandEvent,
-    GetRelevantFilesController, GitRepoModels, GitRepoStatusModel, GitStatusMetadata, LLMPreferences,
-    LLMPreferencesEvent, ModelEvent, ParsedSlashCommandInput, PtyIntent, PtyIntentEvent,
-    RepoDetectionSessionType, RepoDetectionSource, ServerConversationToken,
-    ShellCommandExecutorEvent, SkillReference, SlashCommandDataSource as _,
+    slash_command_selection_behavior, throttle, AIAgentActionId, AIAgentPtyWriteMode,
+    AcceptSlashCommandOrSavedPrompt, ActiveSession, ActiveSessionEvent, AgentInteractionMetadata,
+    AgentViewEntryOrigin, BlocklistAIActionModel, BlocklistAIContextModel, BlocklistAIController,
+    BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIInputModel, CLISubagentController,
+    CLISubagentEvent, CancellationReason, ChangelogModel, ChangelogModelEvent,
+    ChangelogRequestType, CloudConversationData, CommandExecutionSource, ConversationFileExport,
+    ConversationSelection, ConversationSelectionHandle, ConversationUsageTotals,
+    ExecuteCommandEvent, GetRelevantFilesController, GitRepoModels, GitRepoStatusModel,
+    GitStatusMetadata, LLMPreferences, LLMPreferencesEvent, ModelEvent, ParsedSlashCommandInput,
+    PtyIntent, PtyIntentEvent, RepoDetectionSessionType, RepoDetectionSource,
+    ServerConversationToken, ShellCommandExecutorEvent, SkillReference, SlashCommandDataSource as _,
     SlashCommandSelectionBehavior, StaticCommand, TerminalModel, TerminalSurface,
-    TerminalSurfaceInit, TranscriptScope, TuiSlashCommandDataSource, TuiSlashCommandDataSourceArgs,
-    TuiZeroStateDataSource, COMMAND_REGISTRY, WAKEUP_THROTTLE_PERIOD,
+    TerminalSurfaceInit, TranscriptScope, TuiSlashCommand, TuiSlashCommandDataSource,
+    TuiSlashCommandDataSourceArgs, TuiZeroStateDataSource, COMMAND_REGISTRY,
+    WAKEUP_THROTTLE_PERIOD,
 };
 use warp_core::settings::Setting;
 use warp_editor::model::CoreEditorModel;
@@ -1229,142 +1229,153 @@ impl TuiTerminalSessionView {
         argument: Option<&String>,
         ctx: &mut ViewContext<Self>,
     ) {
-        if command.name == slash_commands::AGENT.name || command.name == slash_commands::NEW.name {
-            if !self
-                .ai_context_model
-                .as_ref(ctx)
-                .can_start_new_conversation()
-            {
-                self.show_transient_hint(NEW_CONVERSATION_COMMAND_RUNNING_HINT.to_owned(), ctx);
-                return;
-            }
-            self.cancel_active_conversation(ctx);
-            let terminal_surface_id = ctx.view_id();
-            BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
-                history.clear_conversations_for_terminal_surface(terminal_surface_id, ctx);
-            });
-            self.conversation_selection.update(ctx, |selection, ctx| {
-                selection.select_new_conversation(AgentViewEntryOrigin::Tui, ctx);
-            });
-            if let Some(prompt) = argument
-                .map(|argument| argument.trim())
-                .filter(|argument| !argument.is_empty())
-            {
-                self.send_prompt(prompt.to_owned(), ctx);
-            }
-            self.input_view.update(ctx, |input, ctx| input.clear(ctx));
-            record_static_slash_command_accepted(command.name, true, ctx);
-        } else if command.name == slash_commands::CREATE_NEW_PROJECT.name {
-            let Some(query) = argument
-                .map(|argument| argument.trim())
-                .filter(|argument| !argument.is_empty())
-            else {
-                self.show_transient_hint(
-                    "Please describe the project you want to create after /create-new-project"
-                        .to_owned(),
-                    ctx,
-                );
-                return;
-            };
-            self.ai_controller.update(ctx, |controller, ctx| {
-                controller.send_create_new_project_request(query.to_owned(), ctx);
-            });
-            self.input_view.update(ctx, |input, ctx| input.clear(ctx));
-            record_static_slash_command_accepted(command.name, true, ctx);
-        } else if command.name == slash_commands::EXPORT_TO_CLIPBOARD.name {
-            if let Some(conversation) = self
-                .conversation_selection
-                .as_ref(ctx)
-                .selected_conversation(ctx)
-            {
-                let markdown =
-                    conversation.export_to_markdown(Some(self.ai_action_model.as_ref(ctx)));
-                match copy_to_clipboard(&markdown) {
-                    Ok(()) => {
-                        self.show_success_hint(
-                            "Conversation sent to terminal clipboard".to_owned(),
-                            ctx,
-                        );
-                    }
-                    Err(error) => {
-                        log::warn!("Failed to export TUI conversation via OSC 52: {error}");
-                        self.show_transient_hint(COPY_FAILED_HINT.to_owned(), ctx);
-                    }
-                }
-            } else {
-                self.show_transient_hint("No active conversation to export".to_owned(), ctx);
-            }
-            self.input_view.update(ctx, |input, ctx| input.clear(ctx));
-            record_static_slash_command_accepted(command.name, true, ctx);
-        } else if command.name == slash_commands::EXPORT_TO_FILE.name {
-            let Some(conversation) = self
-                .conversation_selection
-                .as_ref(ctx)
-                .selected_conversation(ctx)
-            else {
-                self.show_transient_hint("No active conversation to export".to_owned(), ctx);
-                return;
-            };
-            let title = conversation.title();
-            let markdown =
-                conversation.export_to_markdown(Some(self.ai_action_model.as_ref(ctx)));
-            let current_directory = self
-                .active_session
-                .as_ref(ctx)
-                .current_working_directory()
-                .cloned();
-            match export_conversation_markdown(
-                current_directory.as_deref(),
-                argument.map(String::as_str),
-                title.as_deref(),
-                &markdown,
-            ) {
-                Ok(export) => {
-                    self.show_success_hint(export_file_success_message(&export), ctx);
-                }
-                Err(error) => {
-                    let message = error.user_message();
-                    let path = error.path().to_path_buf();
-                    report_error!(
-                        anyhow::Error::new(error)
-                            .context("Failed to write TUI conversation to file"),
-                        extra: { "path" => %path.display() }
-                    );
-                    self.show_transient_hint(message, ctx);
-                }
-            }
-            self.input_view.update(ctx, |input, ctx| input.clear(ctx));
-            record_static_slash_command_accepted(command.name, true, ctx);
-        } else if command.name == slash_commands::COST.name {
-            let conversation = self
-                .conversation_selection
-                .as_ref(ctx)
-                .selected_conversation(ctx);
-            if let Some(error) = conversation_cost_validation_error(conversation) {
-                self.show_transient_hint(error.to_owned(), ctx);
-            } else {
-                self.toggle_usage_display(ctx);
-            }
-            self.input_view.update(ctx, |input, ctx| input.clear(ctx));
-            record_static_slash_command_accepted(command.name, true, ctx);
-        } else if slash_command_is_submitted_as_prompt(command) {
-            self.input_view.update(ctx, |input, ctx| input.clear(ctx));
-            let prompt = argument
-                .map(|argument| {
-                    if argument.is_empty() {
-                        command.name.to_owned()
-                    } else {
-                        format!("{} {}", command.name, argument)
-                    }
-                })
-                .unwrap_or_else(|| command.name.to_owned());
-            self.send_prompt(prompt, ctx);
-            record_static_slash_command_accepted(command.name, true, ctx);
-        } else {
+        let Some(tui_command) = TuiSlashCommand::from_static_command(command) else {
             log::debug!(
                 "TUI slash command selection is not supported yet: {}",
                 command.name
             );
+            return;
+        };
+
+        match tui_command {
+            TuiSlashCommand::Agent | TuiSlashCommand::New => {
+                if !self
+                    .ai_context_model
+                    .as_ref(ctx)
+                    .can_start_new_conversation()
+                {
+                    self.show_transient_hint(NEW_CONVERSATION_COMMAND_RUNNING_HINT.to_owned(), ctx);
+                    return;
+                }
+                self.cancel_active_conversation(ctx);
+                let terminal_surface_id = ctx.view_id();
+                BlocklistAIHistoryModel::handle(ctx).update(ctx, |history, ctx| {
+                    history.clear_conversations_for_terminal_surface(terminal_surface_id, ctx);
+                });
+                self.conversation_selection.update(ctx, |selection, ctx| {
+                    selection.select_new_conversation(AgentViewEntryOrigin::Tui, ctx);
+                });
+                if let Some(prompt) = argument
+                    .map(|argument| argument.trim())
+                    .filter(|argument| !argument.is_empty())
+                {
+                    self.send_prompt(prompt.to_owned(), ctx);
+                }
+                self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+                record_static_slash_command_accepted(command.name, true, ctx);
+            }
+            TuiSlashCommand::CreateNewProject => {
+                let Some(query) = argument
+                    .map(|argument| argument.trim())
+                    .filter(|argument| !argument.is_empty())
+                else {
+                    self.show_transient_hint(
+                        "Please describe the project you want to create after /create-new-project"
+                            .to_owned(),
+                        ctx,
+                    );
+                    return;
+                };
+                self.ai_controller.update(ctx, |controller, ctx| {
+                    controller.send_create_new_project_request(query.to_owned(), ctx);
+                });
+                self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+                record_static_slash_command_accepted(command.name, true, ctx);
+            }
+            TuiSlashCommand::ExportToClipboard => {
+                if let Some(conversation) = self
+                    .conversation_selection
+                    .as_ref(ctx)
+                    .selected_conversation(ctx)
+                {
+                    let markdown =
+                        conversation.export_to_markdown(Some(self.ai_action_model.as_ref(ctx)));
+                    match copy_to_clipboard(&markdown) {
+                        Ok(()) => {
+                            self.show_success_hint(
+                                "Conversation sent to terminal clipboard".to_owned(),
+                                ctx,
+                            );
+                        }
+                        Err(error) => {
+                            log::warn!("Failed to export TUI conversation via OSC 52: {error}");
+                            self.show_transient_hint(COPY_FAILED_HINT.to_owned(), ctx);
+                        }
+                    }
+                } else {
+                    self.show_transient_hint("No active conversation to export".to_owned(), ctx);
+                }
+                self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+                record_static_slash_command_accepted(command.name, true, ctx);
+            }
+            TuiSlashCommand::ExportToFile => {
+                let Some(conversation) = self
+                    .conversation_selection
+                    .as_ref(ctx)
+                    .selected_conversation(ctx)
+                else {
+                    self.show_transient_hint("No active conversation to export".to_owned(), ctx);
+                    return;
+                };
+                let title = conversation.title();
+                let markdown =
+                    conversation.export_to_markdown(Some(self.ai_action_model.as_ref(ctx)));
+                let current_directory = self
+                    .active_session
+                    .as_ref(ctx)
+                    .current_working_directory()
+                    .cloned();
+                match export_conversation_markdown(
+                    current_directory.as_deref(),
+                    argument.map(String::as_str),
+                    title.as_deref(),
+                    &markdown,
+                ) {
+                    Ok(export) => {
+                        self.show_success_hint(export_file_success_message(&export), ctx);
+                    }
+                    Err(error) => {
+                        let message = error.user_message();
+                        let path = error.path().to_path_buf();
+                        report_error!(
+                            anyhow::Error::new(error)
+                                .context("Failed to write TUI conversation to file"),
+                            extra: { "path" => %path.display() }
+                        );
+                        self.show_transient_hint(message, ctx);
+                    }
+                }
+                self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+                record_static_slash_command_accepted(command.name, true, ctx);
+            }
+            TuiSlashCommand::Cost => {
+                let conversation = self
+                    .conversation_selection
+                    .as_ref(ctx)
+                    .selected_conversation(ctx);
+                if let Some(error) = conversation_cost_validation_error(conversation) {
+                    self.show_transient_hint(error.to_owned(), ctx);
+                } else {
+                    self.toggle_usage_display(ctx);
+                }
+                self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+                record_static_slash_command_accepted(command.name, true, ctx);
+            }
+            TuiSlashCommand::Compact | TuiSlashCommand::Plan => {
+                self.input_view.update(ctx, |input, ctx| input.clear(ctx));
+                let command_name = command.name;
+                let prompt = argument
+                    .map(|argument| {
+                        if argument.is_empty() {
+                            command_name.to_owned()
+                        } else {
+                            format!("{command_name} {argument}")
+                        }
+                    })
+                    .unwrap_or_else(|| command_name.to_owned());
+                self.send_prompt(prompt, ctx);
+                record_static_slash_command_accepted(command_name, true, ctx);
+            }
         }
     }
 

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -8,14 +8,13 @@ use warp::tui_export::{
     export_conversation_markdown, AIAgentActionId, AIConversationId, AgentInteractionMetadata,
     BlockId, TerminalModel, TranscriptScope,
 };
-use warpui::clipboard::{ClipboardContent, InMemoryClipboard};
-use warpui::{Clipboard, EntityIdMap};
+use warpui::EntityIdMap;
 use warpui_core::elements::tui::{TuiLayoutContext, TuiViewportWindow, TuiViewportedElement};
 use warpui_core::App;
 
 use super::{
-    export_file_success_message, export_markdown_to_clipboard,
-    hide_agent_requested_command_from_top_level, raw_prompt_if_not_blank, ClipboardExportOutcome,
+    export_file_success_message, hide_agent_requested_command_from_top_level,
+    raw_prompt_if_not_blank,
 };
 use crate::tui_block_list_viewport_source::TuiBlockListViewportSource;
 
@@ -189,30 +188,6 @@ fn non_command_prompt_preserves_leading_whitespace() {
 #[test]
 fn whitespace_only_prompt_is_ignored() {
     assert_eq!(raw_prompt_if_not_blank(" \t\n"), None);
-}
-
-#[test]
-fn clipboard_export_writes_exact_markdown() {
-    let mut clipboard = InMemoryClipboard::default();
-
-    let outcome =
-        export_markdown_to_clipboard(Some("# Conversation\n\nHello".to_owned()), &mut clipboard);
-
-    assert_eq!(outcome, ClipboardExportOutcome::Exported);
-    assert_eq!(clipboard.read().plain_text, "# Conversation\n\nHello");
-}
-
-#[test]
-fn clipboard_export_without_conversation_does_not_modify_clipboard() {
-    let mut clipboard = InMemoryClipboard::default();
-    clipboard.write(ClipboardContent::plain_text(
-        "existing clipboard contents".to_owned(),
-    ));
-
-    let outcome = export_markdown_to_clipboard(None, &mut clipboard);
-
-    assert_eq!(outcome, ClipboardExportOutcome::NoActiveConversation);
-    assert_eq!(clipboard.read().plain_text, "existing clipboard contents");
 }
 
 #[test]

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use parking_lot::FairMutex;
 use warp::tui_export::{
-    AIAgentActionId, AIConversationId, AgentInteractionMetadata, BlockId, TerminalModel,
-    TranscriptScope,
+    export_conversation_markdown, AIAgentActionId, AIConversationId, AgentInteractionMetadata,
+    BlockId, TerminalModel, TranscriptScope,
 };
 use warpui::clipboard::{ClipboardContent, InMemoryClipboard};
 use warpui::{Clipboard, EntityIdMap};
@@ -14,8 +14,8 @@ use warpui_core::elements::tui::{TuiLayoutContext, TuiViewportWindow, TuiViewpor
 use warpui_core::App;
 
 use super::{
-    export_markdown_to_clipboard, hide_agent_requested_command_from_top_level,
-    raw_prompt_if_not_blank, ClipboardExportOutcome,
+    export_file_success_message, export_markdown_to_clipboard,
+    hide_agent_requested_command_from_top_level, raw_prompt_if_not_blank, ClipboardExportOutcome,
 };
 use crate::tui_block_list_viewport_source::TuiBlockListViewportSource;
 
@@ -213,4 +213,21 @@ fn clipboard_export_without_conversation_does_not_modify_clipboard() {
 
     assert_eq!(outcome, ClipboardExportOutcome::NoActiveConversation);
     assert_eq!(clipboard.read().plain_text, "existing clipboard contents");
+}
+
+#[test]
+fn file_export_success_message_includes_destination_path() {
+    let directory = tempfile::tempdir().expect("temp directory");
+    let export = export_conversation_markdown(
+        Some(directory.path().to_str().expect("UTF-8 temp path")),
+        Some("conversation.md"),
+        None,
+        "# Conversation",
+    )
+    .expect("conversation export");
+
+    assert_eq!(
+        export_file_success_message(&export),
+        format!("Conversation exported to {}", export.path().display())
+    );
 }

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -8,11 +8,15 @@ use warp::tui_export::{
     AIAgentActionId, AIConversationId, AgentInteractionMetadata, BlockId, TerminalModel,
     TranscriptScope,
 };
-use warpui::EntityIdMap;
+use warpui::clipboard::{ClipboardContent, InMemoryClipboard};
+use warpui::{Clipboard, EntityIdMap};
 use warpui_core::elements::tui::{TuiLayoutContext, TuiViewportWindow, TuiViewportedElement};
 use warpui_core::App;
 
-use super::{hide_agent_requested_command_from_top_level, raw_prompt_if_not_blank};
+use super::{
+    export_markdown_to_clipboard, hide_agent_requested_command_from_top_level,
+    raw_prompt_if_not_blank, ClipboardExportOutcome,
+};
 use crate::tui_block_list_viewport_source::TuiBlockListViewportSource;
 
 fn model_with_finished_block(command: &str) -> (TerminalModel, BlockId) {
@@ -185,4 +189,28 @@ fn non_command_prompt_preserves_leading_whitespace() {
 #[test]
 fn whitespace_only_prompt_is_ignored() {
     assert_eq!(raw_prompt_if_not_blank(" \t\n"), None);
+}
+
+#[test]
+fn clipboard_export_writes_exact_markdown() {
+    let mut clipboard = InMemoryClipboard::default();
+
+    let outcome =
+        export_markdown_to_clipboard(Some("# Conversation\n\nHello".to_owned()), &mut clipboard);
+
+    assert_eq!(outcome, ClipboardExportOutcome::Exported);
+    assert_eq!(clipboard.read().plain_text, "# Conversation\n\nHello");
+}
+
+#[test]
+fn clipboard_export_without_conversation_does_not_modify_clipboard() {
+    let mut clipboard = InMemoryClipboard::default();
+    clipboard.write(ClipboardContent::plain_text(
+        "existing clipboard contents".to_owned(),
+    ));
+
+    let outcome = export_markdown_to_clipboard(None, &mut clipboard);
+
+    assert_eq!(outcome, ClipboardExportOutcome::NoActiveConversation);
+    assert_eq!(clipboard.read().plain_text, "existing clipboard contents");
 }

--- a/crates/warp_tui/src/warping_indicator.rs
+++ b/crates/warp_tui/src/warping_indicator.rs
@@ -78,10 +78,13 @@ pub(crate) fn render_spinner(clock: AnimationClock, style: TuiStyle) -> Box<dyn 
     })
     .finish()
 }
-
-/// Renders the `⋮ Warping... (Ns)` row for an exchange that has been running for
-/// `elapsed`.
-pub(crate) fn render_warping_indicator(elapsed: Duration, app: &AppContext) -> Box<dyn TuiElement> {
+/// Renders the animated progress row for an exchange that has been running
+/// for `elapsed`.
+pub(crate) fn render_warping_indicator(
+    label: impl Into<String>,
+    elapsed: Duration,
+    app: &AppContext,
+) -> Box<dyn TuiElement> {
     let builder = TuiUiBuilder::from_app(app);
     // One clock, already `elapsed` into the exchange, drives all three parts
     // so they stay phase-locked; each repaint reads its current elapsed time.
@@ -92,7 +95,7 @@ pub(crate) fn render_warping_indicator(elapsed: Duration, app: &AppContext) -> B
     let spinner = render_spinner(clock, builder.warping_spinner_style());
 
     let label = TuiShimmeringText::new(
-        "Warping...",
+        label,
         builder.warping_base_color(),
         builder.warping_shimmer_color(),
         ShimmerConfig::default(),

--- a/crates/warp_tui/src/warping_indicator_tests.rs
+++ b/crates/warp_tui/src/warping_indicator_tests.rs
@@ -46,7 +46,7 @@ fn renders_the_indicator_row_and_requests_a_repaint() {
             ctx.add_singleton_model(|_| Appearance::mock());
         });
         app.read(|app_ctx| {
-            let element = render_warping_indicator(Duration::ZERO, app_ctx);
+            let element = render_warping_indicator("Warping...", Duration::ZERO, app_ctx);
             let mut presenter = TuiPresenter::new();
             let frame = presenter.present_element(element, TuiRect::new(0, 0, 20, 1), app_ctx);
 
@@ -80,7 +80,7 @@ fn shimmer_only_applies_to_the_warping_label() {
         });
         app.read(|app_ctx| {
             let config = ShimmerConfig::default();
-            let element = render_warping_indicator(config.period / 2, app_ctx);
+            let element = render_warping_indicator("Warping...", config.period / 2, app_ctx);
             let mut presenter = TuiPresenter::new();
             let frame = presenter.present_element(element, TuiRect::new(0, 0, 20, 1), app_ctx);
 
@@ -88,6 +88,28 @@ fn shimmer_only_applies_to_the_warping_label() {
             let base = Color::Rgb(base.r, base.g, base.b);
             assert_eq!(frame.buffer[(0, 0)].fg, base);
             assert_ne!(frame.buffer[(5, 0)].fg, base);
+        });
+    });
+}
+
+#[test]
+fn renders_a_custom_progress_label() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+        });
+        app.read(|app_ctx| {
+            let element =
+                render_warping_indicator("Summarizing conversation...", Duration::ZERO, app_ctx);
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(element, TuiRect::new(0, 0, 40, 1), app_ctx);
+
+            assert!(
+                frame.buffer.to_lines()[0].contains(" Summarizing conversation... (0s)"),
+                "unexpected indicator row: {:?}",
+                frame.buffer.to_lines()[0]
+            );
+            assert!(frame.repaint_at.is_some());
         });
     });
 }

--- a/crates/warpui/src/platform/headless/delegate.rs
+++ b/crates/warpui/src/platform/headless/delegate.rs
@@ -9,43 +9,6 @@ use super::event_loop::AppEvent;
 use crate::clipboard::InMemoryClipboard;
 use crate::notification::{NotificationSendError, RequestPermissionsOutcome};
 use crate::platform::{self, Cursor};
-fn create_clipboard() -> Box<dyn crate::Clipboard> {
-    cfg_if::cfg_if! {
-        if #[cfg(target_os = "macos")] {
-            match crate::platform::mac::clipboard::Clipboard::new() {
-                Ok(clipboard) => return Box::new(clipboard),
-                Err(error) => {
-                    log::warn!(
-                        "Unable to create the macOS clipboard for the headless platform; \
-                         using an in-memory clipboard: {error:#}"
-                    );
-                }
-            }
-        } else if #[cfg(any(target_os = "linux", target_os = "freebsd"))] {
-            match crate::windowing::winit::linux::LinuxClipboard::new() {
-                Ok(clipboard) => return Box::new(clipboard),
-                Err(error) => {
-                    log::warn!(
-                        "Unable to create the Linux clipboard for the headless platform; \
-                         using an in-memory clipboard: {error:#}"
-                    );
-                }
-            }
-        } else if #[cfg(target_os = "windows")] {
-            match crate::windowing::winit::windows::WindowsClipboard::new() {
-                Ok(clipboard) => return Box::new(clipboard),
-                Err(error) => {
-                    log::warn!(
-                        "Unable to create the Windows clipboard for the headless platform; \
-                         using an in-memory clipboard: {error:#}"
-                    );
-                }
-            }
-        }
-    }
-
-    Box::<InMemoryClipboard>::default()
-}
 
 /// Stores the ID of the application's main thread, which we can reference
 /// to determine if a given thread is the main thread or not.
@@ -61,7 +24,7 @@ pub(super) fn mark_current_thread_as_main() {
 }
 
 pub struct AppDelegate {
-    clipboard: Box<dyn crate::Clipboard>,
+    clipboard: InMemoryClipboard,
     cursor_shape: Mutex<Cursor>,
     event_sender: Sender<AppEvent>,
 }
@@ -69,7 +32,7 @@ pub struct AppDelegate {
 impl AppDelegate {
     pub(super) fn new(event_sender: Sender<AppEvent>) -> Self {
         Self {
-            clipboard: create_clipboard(),
+            clipboard: InMemoryClipboard::default(),
             cursor_shape: Mutex::new(Cursor::Arrow),
             event_sender,
         }
@@ -94,7 +57,7 @@ impl platform::Delegate for AppDelegate {
     }
 
     fn clipboard(&mut self) -> &mut dyn crate::Clipboard {
-        self.clipboard.as_mut()
+        &mut self.clipboard
     }
 
     fn system_theme(&self) -> platform::SystemTheme {

--- a/crates/warpui/src/platform/headless/delegate.rs
+++ b/crates/warpui/src/platform/headless/delegate.rs
@@ -9,6 +9,43 @@ use super::event_loop::AppEvent;
 use crate::clipboard::InMemoryClipboard;
 use crate::notification::{NotificationSendError, RequestPermissionsOutcome};
 use crate::platform::{self, Cursor};
+fn create_clipboard() -> Box<dyn crate::Clipboard> {
+    cfg_if::cfg_if! {
+        if #[cfg(target_os = "macos")] {
+            match crate::platform::mac::clipboard::Clipboard::new() {
+                Ok(clipboard) => return Box::new(clipboard),
+                Err(error) => {
+                    log::warn!(
+                        "Unable to create the macOS clipboard for the headless platform; \
+                         using an in-memory clipboard: {error:#}"
+                    );
+                }
+            }
+        } else if #[cfg(any(target_os = "linux", target_os = "freebsd"))] {
+            match crate::windowing::winit::linux::LinuxClipboard::new() {
+                Ok(clipboard) => return Box::new(clipboard),
+                Err(error) => {
+                    log::warn!(
+                        "Unable to create the Linux clipboard for the headless platform; \
+                         using an in-memory clipboard: {error:#}"
+                    );
+                }
+            }
+        } else if #[cfg(target_os = "windows")] {
+            match crate::windowing::winit::windows::WindowsClipboard::new() {
+                Ok(clipboard) => return Box::new(clipboard),
+                Err(error) => {
+                    log::warn!(
+                        "Unable to create the Windows clipboard for the headless platform; \
+                         using an in-memory clipboard: {error:#}"
+                    );
+                }
+            }
+        }
+    }
+
+    Box::<InMemoryClipboard>::default()
+}
 
 /// Stores the ID of the application's main thread, which we can reference
 /// to determine if a given thread is the main thread or not.
@@ -24,7 +61,7 @@ pub(super) fn mark_current_thread_as_main() {
 }
 
 pub struct AppDelegate {
-    clipboard: InMemoryClipboard,
+    clipboard: Box<dyn crate::Clipboard>,
     cursor_shape: Mutex<Cursor>,
     event_sender: Sender<AppEvent>,
 }
@@ -32,7 +69,7 @@ pub struct AppDelegate {
 impl AppDelegate {
     pub(super) fn new(event_sender: Sender<AppEvent>) -> Self {
         Self {
-            clipboard: InMemoryClipboard::default(),
+            clipboard: create_clipboard(),
             cursor_shape: Mutex::new(Cursor::Arrow),
             event_sender,
         }
@@ -57,7 +94,7 @@ impl platform::Delegate for AppDelegate {
     }
 
     fn clipboard(&mut self) -> &mut dyn crate::Clipboard {
-        &mut self.clipboard
+        self.clipboard.as_mut()
     }
 
     fn system_theme(&self) -> platform::SystemTheme {


### PR DESCRIPTION
## Description

**Stack:** 2 of 4. Depends on [#13602](https://github.com/warpdotdev/warp/pull/13602); followed by [#13604](https://github.com/warpdotdev/warp/pull/13604).

Adds slash-command effects that the TUI can support without GUI-only panes or orchestration UI: `/create-new-project`, `/export-to-clipboard`, `/export-to-file`, and `/cost`.

This keeps TUI-specific state transitions local while sharing non-visual behavior with the GUI where practical. Project and review-comment requests go through `BlocklistAIController`, conversation-file export moves into a shared helper, and `/cost` validation is shared. Clipboard export uses OSC 52 so text reaches the terminal client's clipboard rather than the headless process host, including tmux passthrough and explicit failure reporting. Successful clipboard and file exports show transient feedback; file feedback includes the destination path and whether an existing file was overwritten.

The PR also includes TUI request and execution plumbing for `/pr-comments`, but that entry is not currently visible in the local TUI. The GUI has migrated `/pr-comments` to a bundled skill, while local `./script/run-tui` does not yet stage or load bundled skill resources. Fixing local bundled-skill availability is separate follow-up work.

The `/compact` experience is completed with streamed summary rendering and a dedicated progress label.

### In scope

- Expose and execute `/create-new-project`, `/export-to-clipboard`, `/export-to-file`, and `/cost` in the TUI.
- Add the TUI request and execution plumbing needed by `/pr-comments`.
- Propagate repository and CWD context needed by repository-aware commands and file export.
- Extract conversation Markdown export policy from GUI input code for reuse by the TUI.
- Export clipboard text through OSC 52, including tmux passthrough and clipboard/PRIMARY targets.
- Show success-colored export confirmation and report clipboard/file failures accurately.
- Share project-creation, review-comment request, and cost-validation behavior with GUI paths.
- Render streamed conversation summaries as collapsible transcript sections.
- Label compaction progress distinctly.
- Add focused coverage for export behavior and feedback, command support, cost validation, OSC 52 encoding, summary rendering, and progress labels.

### Out of scope

- GUI-only commands that require settings panes, dialogs, or inline selectors.
- Bundled-skill availability in the local TUI; `/pr-comments` remains hidden until that infrastructure is available.
- Semantic command IDs or a cross-frontend handler abstraction.
- GUI-style structured argument editing for saved prompts.

### How to review

1. Start with `app/src/terminal/input/slash_commands/mod.rs` and `app/src/ai/blocklist/controller.rs` for the supported-command boundary and shared non-visual operations.
2. Review `app/src/ai/conversation_export.rs` alongside the removal from `app/src/terminal/input.rs`. Confirm filename, CWD fallback, overwrite reporting, and error behavior remain shared policy rather than TUI policy.
3. Review `crates/warp_tui/src/terminal_session_view.rs` for surface-specific command effects, validation, buffer clearing, export feedback, and telemetry.
4. Review `crates/warp_tui/src/clipboard.rs` and `clipboard_tests.rs` for OSC 52 encoding, target selection, flushing, and tmux passthrough.
5. Review `crates/warp_tui/src/agent_block.rs`, `agent_block_sections.rs`, and `warping_indicator.rs` as one compaction-presentation unit.
6. Finish with the focused tests for export destinations, command policy, cost, clipboard transport, summary sections, and progress labels.

## Linked Issue

No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

https://www.loom.com/share/a1efde950bd840178af79ccd1d788365

Final-stack validation on 2026-07-11:

- `./script/format` — passed.
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings` — passed.
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings` — passed.
- Added focused regression coverage for conversation export, destination feedback, command support, cost validation, OSC 52 transport, summary sections, and progress labels.

Cargo tests and manual TUI validation were not rerun after the final restack.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Not included; manual TUI validation remains outstanding.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Add project setup, conversation export, cost, and compact-progress support to the TUI.

Co-Authored-By: Oz [oz-agent@warp.dev](mailto:oz-agent@warp.dev)