### PR TITLE
Align TUI slash command menu styling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15926,6 +15926,7 @@ dependencies = [
  "strum_macros 0.27.1",
  "sum_tree",
  "tempfile",
+ "unicode-width 0.1.14",
  "uuid",
  "vec1",
  "warp",

--- a/app/src/search/slash_command_menu/mod.rs
+++ b/app/src/search/slash_command_menu/mod.rs
@@ -4,4 +4,4 @@ pub mod static_commands;
 #[cfg(test)]
 mod fuzzy_match_tests;
 
-pub use static_commands::{SlashCommandId, StaticCommand};
+pub use static_commands::{SlashCommandArgumentHint, SlashCommandId, StaticCommand};

--- a/app/src/search/slash_command_menu/static_commands/mod.rs
+++ b/app/src/search/slash_command_menu/static_commands/mod.rs
@@ -99,6 +99,11 @@ pub struct StaticCommand {
     pub auto_enter_ai_mode: bool,
     pub argument: Option<Argument>,
 }
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlashCommandArgumentHint {
+    pub input_prefix: String,
+    pub text: &'static str,
+}
 
 impl StaticCommand {
     pub fn matches_filter(&self, filter_text: &str) -> bool {
@@ -116,6 +121,14 @@ impl StaticCommand {
 
     pub fn is_active(&self, session_context: Availability) -> bool {
         session_context.contains(self.availability)
+    }
+
+    pub fn argument_hint(&self) -> Option<SlashCommandArgumentHint> {
+        let text = self.argument.as_ref()?.hint_text?;
+        Some(SlashCommandArgumentHint {
+            input_prefix: format!("{} ", self.name),
+            text,
+        })
     }
 }
 

--- a/app/src/search/slash_command_menu/static_commands/mod_tests.rs
+++ b/app/src/search/slash_command_menu/static_commands/mod_tests.rs
@@ -1,4 +1,15 @@
-use super::Availability;
+use super::{commands, Availability};
+
+#[test]
+fn argument_hint_uses_shared_command_prefix_and_text() {
+    let hint = commands::EXPORT_TO_FILE
+        .argument_hint()
+        .expect("export-to-file has an argument hint");
+
+    assert_eq!(hint.input_prefix, "/export-to-file ");
+    assert_eq!(hint.text, "<optional filename>");
+    assert_eq!(commands::EXPORT_TO_CLIPBOARD.argument_hint(), None);
+}
 
 /// Helper: constructs a session context for an agent view in a local session with a repo,
 /// no active LRC, and an active conversation.

--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -6953,16 +6953,8 @@ impl Input {
         // Loop through all static commands and set placeholders for those with hint text
         self.editor.update(ctx, |editor, ctx| {
             for command in COMMAND_REGISTRY.all_commands() {
-                if let Some(hint_text) = command
-                    .argument
-                    .as_ref()
-                    .and_then(|argument| argument.hint_text)
-                {
-                    editor.set_placeholder_text_with_prefix(
-                        format!("{} ", command.name),
-                        hint_text,
-                        ctx,
-                    );
+                if let Some(hint) = command.argument_hint() {
+                    editor.set_placeholder_text_with_prefix(hint.input_prefix, hint.text, ctx);
                 }
             }
         });

--- a/crates/warp_tui/Cargo.toml
+++ b/crates/warp_tui/Cargo.toml
@@ -57,6 +57,7 @@ string-offset.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 sum_tree.workspace = true
+unicode-width.workspace = true
 vec1.workspace = true
 warp = { workspace = true, features = ["tui"] }
 warp_channel_config.workspace = true

--- a/crates/warp_tui/src/editor_element.rs
+++ b/crates/warp_tui/src/editor_element.rs
@@ -116,6 +116,7 @@ pub(crate) struct TuiEditorElement {
     /// [`Self::hide_trailing_empty_line`]).
     hide_trailing_empty_line: bool,
     styles: TuiEditorStyles,
+    trailing_ghost_text: Option<(String, TuiStyle)>,
     on_action: Option<TuiEditorActionHandler>,
 
     // ── Built during layout ─────────────────────────────────────────────────
@@ -177,6 +178,7 @@ impl TuiEditorElement {
             line_number_gutter: false,
             hide_trailing_empty_line: false,
             styles: TuiEditorStyles::default(),
+            trailing_ghost_text: None,
             on_action: None,
             column: TuiFlex::column(),
             gutter_cols: 0,
@@ -216,6 +218,15 @@ impl TuiEditorElement {
 
     pub(crate) fn with_styles(mut self, styles: TuiEditorStyles) -> Self {
         self.styles = styles;
+        self
+    }
+
+    pub(crate) fn with_trailing_ghost_text(
+        mut self,
+        text: impl Into<String>,
+        style: TuiStyle,
+    ) -> Self {
+        self.trailing_ghost_text = Some((text.into(), style));
         self
     }
 
@@ -633,6 +644,23 @@ impl TuiElement for TuiEditorElement {
 
     fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
         self.column.render(area, buffer, ctx);
+        if let Some((text, style)) = &self.trailing_ghost_text {
+            let cursor_at_end =
+                self.cursor_offset.as_usize().saturating_sub(1) == self.text.chars().count();
+            if cursor_at_end && self.cursor_visible {
+                let x = area.x.saturating_add(self.cursor_col);
+                let y = area.y.saturating_add(self.cursor_row_in_view);
+                if x < area.x.saturating_add(area.width) && y < area.y.saturating_add(area.height) {
+                    buffer.set_stringn(
+                        x,
+                        y,
+                        text,
+                        usize::from(area.width.saturating_sub(self.cursor_col)),
+                        *style,
+                    );
+                }
+            }
+        }
         for &(row_in_view, start_col, end_col, style) in &self.styled_spans {
             let y = area.y.saturating_add(row_in_view);
             let x = area.x.saturating_add(start_col);

--- a/crates/warp_tui/src/editor_element.rs
+++ b/crates/warp_tui/src/editor_element.rs
@@ -81,6 +81,9 @@ pub(crate) struct TuiEditorStyles {
     pub gap: TuiStyle,
     /// Whole-line overrides by 0-based logical line index; first match wins.
     pub line_overrides: Vec<(Range<usize>, TuiStyle)>,
+    /// Character-range style overlays over buffer rows. Applied after the
+    /// row's base style and before selection reversal.
+    pub text_overrides: Vec<(Range<CharOffset>, TuiStyle)>,
 }
 
 /// The core char-cell editor element. Construct per render via
@@ -122,6 +125,9 @@ pub(crate) struct TuiEditorElement {
     /// Selected spans `(row_in_view, start_col, exclusive_end_col)`, in
     /// element-relative columns (gutter included).
     selected_spans: Vec<(u16, u16, u16)>,
+    /// Consumer-supplied style spans in the same display-column coordinate
+    /// space as `selected_spans`.
+    styled_spans: Vec<(u16, u16, u16, TuiStyle)>,
     cursor_col: u16,
     cursor_row_in_view: u16,
     cursor_visible: bool,
@@ -175,6 +181,7 @@ impl TuiEditorElement {
             column: TuiFlex::column(),
             gutter_cols: 0,
             selected_spans: Vec::new(),
+            styled_spans: Vec::new(),
             cursor_col: 0,
             cursor_row_in_view: 0,
             cursor_visible: false,
@@ -288,7 +295,7 @@ impl TuiEditorElement {
         // One projection serves rows, cursor placement, and selection spans,
         // so everything below is geometry over the same lattice.
         let lattice = char_cell.display_lattice(&hidden);
-        let (column, selected_spans, cursor, visible_end) = {
+        let (column, selected_spans, styled_spans, cursor, visible_end) = {
             let rows = lattice.rows();
             // The cursor sits one row past the last text row when a logical
             // line exactly fills the width (deferred wrap); that phantom row
@@ -319,6 +326,7 @@ impl TuiEditorElement {
                 .saturating_sub(visible_slice.len());
 
             let mut selected_spans = Vec::new();
+            let mut styled_spans = Vec::new();
             let mut column = TuiFlex::column();
             for (vis_idx, row) in visible_slice.iter().enumerate() {
                 column.add_child(self.render_row(row, &chars, lattice.ghosts()));
@@ -329,6 +337,18 @@ impl TuiEditorElement {
                         end_col + self.gutter_cols,
                     ));
                 }
+                for (range, style) in &self.styles.text_overrides {
+                    if let Some((start_col, end_col)) =
+                        Self::char_range_span_in_row(row, &lattice, range.clone())
+                    {
+                        styled_spans.push((
+                            vis_idx as u16,
+                            start_col + self.gutter_cols,
+                            end_col + self.gutter_cols,
+                            *style,
+                        ));
+                    }
+                }
             }
             for _ in 0..phantom_rows {
                 column.add_child(TuiText::new(" ").truncate().finish());
@@ -338,11 +358,12 @@ impl TuiEditorElement {
                 // element never collapses to zero height.
                 column.add_child(TuiText::new(" ").truncate().finish());
             }
-            (column, selected_spans, cursor, visible_end)
+            (column, selected_spans, styled_spans, cursor, visible_end)
         };
 
         self.column = column;
         self.selected_spans = selected_spans;
+        self.styled_spans = styled_spans;
         if let Some(cursor) = cursor {
             self.cursor_col = cursor.col + self.gutter_cols;
             self.cursor_row_in_view = cursor.row.saturating_sub(first_visible_row) as u16;
@@ -440,14 +461,22 @@ impl TuiEditorElement {
         lattice: &DisplayLattice<'_>,
     ) -> Option<(u16, u16)> {
         let selection = self.sel_char_range.clone()?;
+        Self::char_range_span_in_row(row, lattice, selection)
+    }
+
+    fn char_range_span_in_row(
+        row: &DisplayRow,
+        lattice: &DisplayLattice<'_>,
+        range: Range<CharOffset>,
+    ) -> Option<(u16, u16)> {
         if !matches!(row.kind, DisplayRowKind::Buffer { .. }) {
             return None;
         }
-        if selection.end <= row.char_range.start || selection.start >= row.char_range.end {
+        if range.end <= row.char_range.start || range.start >= row.char_range.end {
             return None;
         }
-        let start_offset = selection.start.max(row.char_range.start);
-        let end_offset = selection.end.min(row.char_range.end);
+        let start_offset = range.start.max(row.char_range.start);
+        let end_offset = range.end.min(row.char_range.end);
         let start_col = lattice.display_width(row.char_range.start..start_offset);
         let end_col = lattice.display_width(row.char_range.start..end_offset);
         (end_col > start_col).then_some((start_col, end_col))
@@ -604,6 +633,16 @@ impl TuiElement for TuiEditorElement {
 
     fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
         self.column.render(area, buffer, ctx);
+        for &(row_in_view, start_col, end_col, style) in &self.styled_spans {
+            let y = area.y.saturating_add(row_in_view);
+            let x = area.x.saturating_add(start_col);
+            let width = end_col.saturating_sub(start_col);
+            if y < area.y + area.height && width > 0 {
+                let style_rect =
+                    TuiRect::new(x, y, width.min(area.width.saturating_sub(start_col)), 1);
+                buffer.set_style(style_rect, style);
+            }
+        }
         if !self.selected_spans.is_empty() {
             let reversed = TuiStyle::default().add_modifier(Modifier::REVERSED);
             for &(row_in_view, start_col, end_col) in &self.selected_spans {

--- a/crates/warp_tui/src/editor_element_tests.rs
+++ b/crates/warp_tui/src/editor_element_tests.rs
@@ -5,12 +5,12 @@ use warp_editor::content::buffer::InitialBufferState;
 use warp_editor::model::CoreEditorModel;
 use warpui::EntityIdMap;
 use warpui_core::elements::tui::{
-    Modifier, TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiLayoutContext,
-    TuiPaintContext, TuiRect, TuiSize,
+    Color, Modifier, TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiLayoutContext,
+    TuiPaintContext, TuiRect, TuiSize, TuiStyle,
 };
 use warpui_core::{App, AppContext, ModelHandle};
 
-use super::TuiEditorElement;
+use super::{TuiEditorElement, TuiEditorStyles};
 
 /// A char-cell editor model seeded with `text`.
 fn model(ctx: &mut AppContext, text: &str) -> ModelHandle<CodeEditorModel> {
@@ -34,6 +34,29 @@ fn selection_span_uses_grapheme_width() {
             assert!(buffer[(1, 0)].modifier.contains(Modifier::REVERSED));
             assert!(buffer[(2, 0)].modifier.contains(Modifier::REVERSED));
             assert!(!buffer[(3, 0)].modifier.contains(Modifier::REVERSED));
+        });
+    });
+}
+#[test]
+fn text_overrides_follow_soft_wrapped_character_ranges() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+            let model = model(ctx, "/plan argument");
+            let styles = TuiEditorStyles {
+                text_overrides: vec![(
+                    CharOffset::zero()..CharOffset::from(5),
+                    TuiStyle::default().fg(Color::Blue),
+                )],
+                ..Default::default()
+            };
+            let element = TuiEditorElement::new(&model, ctx).with_styles(styles);
+            let buffer = render_buffer(ctx, element, 4, 10);
+
+            assert_eq!(buffer[(0, 0)].fg, Color::Blue);
+            assert_eq!(buffer[(3, 0)].fg, Color::Blue);
+            assert_eq!(buffer[(0, 1)].fg, Color::Blue);
+            assert_ne!(buffer[(1, 1)].fg, Color::Blue);
         });
     });
 }

--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -2,6 +2,7 @@
 use std::ops::Range;
 
 use string_offset::CharOffset;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use warp::tui_export::AcceptSlashCommandOrSavedPrompt;
 use warpui_core::elements::tui::{
     TuiBuffer, TuiConstrainedBox, TuiConstraint, TuiContainer, TuiElement, TuiFlex,
@@ -12,7 +13,10 @@ use warpui_core::{AppContext, ModelAsRef, ModelHandle, UpdateModel};
 
 use crate::slash_commands::TuiSlashCommandModel;
 use crate::tui_builder::TuiUiBuilder;
+
 const SLASH_COMMAND_TITLE_COLUMNS: usize = 29;
+const SLASH_COMMAND_DESCRIPTION_GAP_COLUMNS: usize = 1;
+const SLASH_COMMAND_TITLE_ELLIPSIS: &str = "...";
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -92,6 +96,12 @@ impl TuiInlineMenu {
     pub(crate) fn input_highlight_range(&self, ctx: &AppContext) -> Option<Range<CharOffset>> {
         match self {
             Self::SlashCommands(model) => model.as_ref(ctx).highlighted_prefix_range(),
+        }
+    }
+
+    pub(crate) fn input_argument_hint_text(&self, ctx: &AppContext) -> Option<&'static str> {
+        match self {
+            Self::SlashCommands(model) => model.as_ref(ctx).argument_hint_text(),
         }
     }
 
@@ -281,6 +291,36 @@ fn menu_status_row(label: &str, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
     .with_padding_right(1)
     .finish()
 }
+fn format_slash_command_title(title: &str) -> String {
+    let available_title_columns =
+        SLASH_COMMAND_TITLE_COLUMNS - SLASH_COMMAND_DESCRIPTION_GAP_COLUMNS;
+    let title_width = UnicodeWidthStr::width(title);
+    if title_width <= available_title_columns {
+        return format!(
+            "{title}{}",
+            " ".repeat(SLASH_COMMAND_TITLE_COLUMNS - title_width)
+        );
+    }
+
+    let prefix_columns =
+        available_title_columns - UnicodeWidthStr::width(SLASH_COMMAND_TITLE_ELLIPSIS);
+    let mut prefix = String::new();
+    let mut prefix_width = 0;
+    for character in title.chars() {
+        let character_width = UnicodeWidthChar::width(character).unwrap_or_default();
+        if prefix_width + character_width > prefix_columns {
+            break;
+        }
+        prefix.push(character);
+        prefix_width += character_width;
+    }
+
+    format!(
+        "{prefix}{SLASH_COMMAND_TITLE_ELLIPSIS}{}{}",
+        " ".repeat(prefix_columns - prefix_width),
+        " ".repeat(SLASH_COMMAND_DESCRIPTION_GAP_COLUMNS),
+    )
+}
 
 fn menu_result_row(
     row: &TuiInlineMenuRow,
@@ -300,9 +340,7 @@ fn menu_result_row(
     };
     let title = match row.style {
         TuiInlineMenuRowStyle::Default => row.title.clone(),
-        TuiInlineMenuRowStyle::SlashCommand => {
-            format!("{:<SLASH_COMMAND_TITLE_COLUMNS$}", row.title)
-        }
+        TuiInlineMenuRowStyle::SlashCommand => format_slash_command_title(&row.title),
     };
     let title = TuiText::new(title)
         .with_style(title_style)

--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -1,15 +1,25 @@
 //! Reusable active-menu routing and character-cell presentation for TUI inline menus.
+use std::ops::Range;
 
+use string_offset::CharOffset;
 use warp::tui_export::AcceptSlashCommandOrSavedPrompt;
 use warpui_core::elements::tui::{
-    TuiBuffer, TuiConstraint, TuiContainer, TuiElement, TuiFlex, TuiLayoutContext, TuiPaintContext,
-    TuiRect, TuiSize, TuiText,
+    TuiBuffer, TuiConstrainedBox, TuiConstraint, TuiContainer, TuiElement, TuiFlex,
+    TuiLayoutContext, TuiPaintContext, TuiRect, TuiSize, TuiText,
 };
 use warpui_core::elements::CrossAxisAlignment;
 use warpui_core::{AppContext, ModelAsRef, ModelHandle, UpdateModel};
 
 use crate::slash_commands::TuiSlashCommandModel;
 use crate::tui_builder::TuiUiBuilder;
+const SLASH_COMMAND_TITLE_COLUMNS: usize = 29;
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TuiInlineMenuRowStyle {
+    Default,
+    SlashCommand,
+}
 
 /// A presentation-only row in a TUI inline menu.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -17,6 +27,7 @@ pub(crate) struct TuiInlineMenuRow {
     pub(crate) title: String,
     pub(crate) description: Option<String>,
     pub(crate) is_selectable: bool,
+    pub(crate) style: TuiInlineMenuRowStyle,
 }
 
 /// A presentation-only tab in a TUI inline-menu header.
@@ -77,6 +88,11 @@ impl TuiInlineMenu {
     pub(crate) fn render(&self, ctx: &AppContext) -> Option<Box<dyn TuiElement>> {
         self.snapshot(ctx)
             .map(|snapshot| render_inline_menu(&snapshot, &TuiUiBuilder::from_app(ctx)))
+    }
+    pub(crate) fn input_highlight_range(&self, ctx: &AppContext) -> Option<Range<CharOffset>> {
+        match self {
+            Self::SlashCommands(model) => model.as_ref(ctx).highlighted_prefix_range(),
+        }
     }
 
     pub(crate) fn select_previous(&self, ctx: &mut impl UpdateModel) {
@@ -220,18 +236,15 @@ fn build_inline_menu(
         }
     }
 
-    TuiContainer::new(column.finish())
-        .with_border_style(builder.accent_border_style())
-        .finish()
+    column.finish()
 }
 
 fn visible_result_capacity(snapshot: &TuiInlineMenuSnapshot, allocated_height: u16) -> usize {
-    const BORDER_ROWS: usize = 2;
     let header_rows = snapshot.header.as_ref().map_or(0, |header| {
         usize::from(header.title.is_some()) + usize::from(!header.tabs.is_empty())
     });
     usize::from(allocated_height)
-        .saturating_sub(BORDER_ROWS + header_rows)
+        .saturating_sub(header_rows)
         .min(snapshot.max_visible_rows)
 }
 
@@ -275,40 +288,58 @@ fn menu_result_row(
     builder: &TuiUiBuilder,
 ) -> Box<dyn TuiElement> {
     let title_style = if is_selected {
-        builder.input_text_style()
-    } else if row.is_selectable {
-        builder.primary_text_style()
+        builder.slash_command_selection_text_style()
     } else {
-        builder.dim_text_style()
+        match (row.is_selectable, row.style) {
+            (true, TuiInlineMenuRowStyle::SlashCommand) => builder.slash_command_text_style(),
+            (true, TuiInlineMenuRowStyle::Default) => builder.primary_text_style(),
+            (false, TuiInlineMenuRowStyle::Default | TuiInlineMenuRowStyle::SlashCommand) => {
+                builder.dim_text_style()
+            }
+        }
     };
+    let title = match row.style {
+        TuiInlineMenuRowStyle::Default => row.title.clone(),
+        TuiInlineMenuRowStyle::SlashCommand => {
+            format!("{:<SLASH_COMMAND_TITLE_COLUMNS$}", row.title)
+        }
+    };
+    let title = TuiText::new(title)
+        .with_style(title_style)
+        .truncate()
+        .finish();
     let description_style = if is_selected {
-        builder.input_text_style()
+        builder.slash_command_selection_text_style()
     } else {
-        builder.muted_text_style()
+        match row.style {
+            TuiInlineMenuRowStyle::Default => builder.muted_text_style(),
+            TuiInlineMenuRowStyle::SlashCommand => builder.primary_text_style(),
+        }
     };
 
     let mut content = TuiFlex::row()
         .with_cross_axis_alignment(CrossAxisAlignment::Center)
-        .child(
-            TuiText::new(row.title.clone())
-                .with_style(title_style)
-                .truncate()
+        .child(match row.style {
+            TuiInlineMenuRowStyle::Default => title,
+            TuiInlineMenuRowStyle::SlashCommand => TuiConstrainedBox::new(title)
+                .with_max_cols(SLASH_COMMAND_TITLE_COLUMNS as u16)
                 .finish(),
-        );
+        });
     if let Some(description) = &row.description {
+        let description = match row.style {
+            TuiInlineMenuRowStyle::Default => format!("  {description}"),
+            TuiInlineMenuRowStyle::SlashCommand => description.clone(),
+        };
         content = content.child(
-            TuiText::new(format!("  {description}"))
+            TuiText::new(description)
                 .with_style(description_style)
                 .truncate()
                 .finish(),
         );
     }
-
-    let mut container = TuiContainer::new(content.finish())
-        .with_padding_left(1)
-        .with_padding_right(1);
+    let mut container = TuiContainer::new(content.finish());
     if is_selected {
-        container = container.with_background(builder.input_background());
+        container = container.with_background(builder.slash_command_selection_background());
     }
     container.finish()
 }

--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -14,7 +14,10 @@ use warpui_core::{AppContext, ModelAsRef, ModelHandle, UpdateModel};
 use crate::slash_commands::TuiSlashCommandModel;
 use crate::tui_builder::TuiUiBuilder;
 
-const SLASH_COMMAND_TITLE_COLUMNS: usize = 29;
+const SLASH_COMMAND_PREFERRED_TITLE_COLUMNS: usize = 29;
+const SLASH_COMMAND_MIN_TITLE_COLUMNS_WITH_DESCRIPTION: usize = 8;
+const SLASH_COMMAND_MIN_DESCRIPTION_COLUMNS: usize = 12;
+const SLASH_COMMAND_PREFERRED_DESCRIPTION_COLUMNS: usize = 21;
 const SLASH_COMMAND_DESCRIPTION_GAP_COLUMNS: usize = 1;
 const SLASH_COMMAND_TITLE_ELLIPSIS: &str = "...";
 
@@ -171,7 +174,12 @@ impl TuiElement for TuiInlineMenuElement {
         ctx: &mut TuiLayoutContext,
         app: &AppContext,
     ) -> TuiSize {
-        let mut content = build_inline_menu(&self.snapshot, &self.builder, constraint.max.height);
+        let mut content = build_inline_menu(
+            &self.snapshot,
+            &self.builder,
+            constraint.max.width,
+            constraint.max.height,
+        );
         let size = content.layout(constraint, ctx, app);
         self.content = Some(content);
         size
@@ -187,8 +195,10 @@ impl TuiElement for TuiInlineMenuElement {
 fn build_inline_menu(
     snapshot: &TuiInlineMenuSnapshot,
     builder: &TuiUiBuilder,
+    allocated_width: u16,
     allocated_height: u16,
 ) -> Box<dyn TuiElement> {
+    let slash_command_columns = slash_command_column_layout(snapshot, allocated_width);
     let mut column = TuiFlex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
     if let Some(header) = &snapshot.header {
         if let Some(title) = &header.title {
@@ -241,6 +251,7 @@ fn build_inline_menu(
             column = column.child(menu_result_row(
                 row,
                 snapshot.selected_index == Some(index),
+                slash_command_columns,
                 builder,
             ));
         }
@@ -291,19 +302,98 @@ fn menu_status_row(label: &str, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
     .with_padding_right(1)
     .finish()
 }
-fn format_slash_command_title(title: &str) -> String {
-    let available_title_columns =
-        SLASH_COMMAND_TITLE_COLUMNS - SLASH_COMMAND_DESCRIPTION_GAP_COLUMNS;
-    let title_width = UnicodeWidthStr::width(title);
-    if title_width <= available_title_columns {
-        return format!(
-            "{title}{}",
-            " ".repeat(SLASH_COMMAND_TITLE_COLUMNS - title_width)
-        );
+
+/// Shared title/description allocation for every slash-command row in one menu.
+#[derive(Clone, Copy)]
+struct SlashCommandColumnLayout {
+    available_columns: usize,
+    title_columns: usize,
+    show_descriptions: bool,
+}
+
+fn slash_command_column_layout(
+    snapshot: &TuiInlineMenuSnapshot,
+    allocated_width: u16,
+) -> SlashCommandColumnLayout {
+    let available_columns = usize::from(allocated_width);
+    let described_slash_command_rows = snapshot.rows.iter().filter(|row| {
+        row.style == TuiInlineMenuRowStyle::SlashCommand && row.description.is_some()
+    });
+    let longest_title_columns = described_slash_command_rows
+        .clone()
+        .map(|row| UnicodeWidthStr::width(row.title.as_str()))
+        .max();
+    let longest_description_columns = described_slash_command_rows
+        .filter_map(|row| row.description.as_deref())
+        .map(UnicodeWidthStr::width)
+        .max();
+    let min_two_column_width =
+        SLASH_COMMAND_MIN_TITLE_COLUMNS_WITH_DESCRIPTION + SLASH_COMMAND_MIN_DESCRIPTION_COLUMNS;
+    let Some((longest_title_columns, longest_description_columns)) =
+        longest_title_columns.zip(longest_description_columns)
+    else {
+        return SlashCommandColumnLayout {
+            available_columns,
+            title_columns: available_columns,
+            show_descriptions: false,
+        };
+    };
+    if available_columns < min_two_column_width {
+        return SlashCommandColumnLayout {
+            available_columns,
+            title_columns: available_columns,
+            show_descriptions: false,
+        };
     }
 
-    let prefix_columns =
-        available_title_columns - UnicodeWidthStr::width(SLASH_COMMAND_TITLE_ELLIPSIS);
+    let preferred_title_columns = SLASH_COMMAND_PREFERRED_TITLE_COLUMNS
+        .max(longest_title_columns.saturating_add(SLASH_COMMAND_DESCRIPTION_GAP_COLUMNS));
+    let preferred_description_columns = longest_description_columns.clamp(
+        SLASH_COMMAND_MIN_DESCRIPTION_COLUMNS,
+        SLASH_COMMAND_PREFERRED_DESCRIPTION_COLUMNS,
+    );
+    // Retain the established 29-column title alignment until descriptions
+    // have their useful width, then spend surplus columns on long titles.
+    let baseline_width = SLASH_COMMAND_PREFERRED_TITLE_COLUMNS + preferred_description_columns;
+    let title_columns = if available_columns >= baseline_width {
+        let growth_columns = available_columns - baseline_width;
+        preferred_title_columns
+            .min(SLASH_COMMAND_PREFERRED_TITLE_COLUMNS.saturating_add(growth_columns))
+    } else {
+        SLASH_COMMAND_PREFERRED_TITLE_COLUMNS
+            .min(available_columns.saturating_sub(SLASH_COMMAND_MIN_DESCRIPTION_COLUMNS))
+    };
+    SlashCommandColumnLayout {
+        available_columns,
+        title_columns: title_columns.max(SLASH_COMMAND_MIN_TITLE_COLUMNS_WITH_DESCRIPTION),
+        show_descriptions: true,
+    }
+}
+
+fn format_slash_command_title(
+    title: &str,
+    title_columns: usize,
+    include_description_gap: bool,
+) -> String {
+    let description_gap_columns = if include_description_gap {
+        SLASH_COMMAND_DESCRIPTION_GAP_COLUMNS
+    } else {
+        0
+    };
+    let available_title_columns = title_columns.saturating_sub(description_gap_columns);
+    let title_width = UnicodeWidthStr::width(title);
+    if title_width <= available_title_columns {
+        return if include_description_gap {
+            format!("{title}{}", " ".repeat(title_columns - title_width))
+        } else {
+            title.to_owned()
+        };
+    }
+
+    let ellipsis_columns =
+        UnicodeWidthStr::width(SLASH_COMMAND_TITLE_ELLIPSIS).min(available_title_columns);
+    let ellipsis = &SLASH_COMMAND_TITLE_ELLIPSIS[..ellipsis_columns];
+    let prefix_columns = available_title_columns - ellipsis_columns;
     let mut prefix = String::new();
     let mut prefix_width = 0;
     for character in title.chars() {
@@ -316,15 +406,16 @@ fn format_slash_command_title(title: &str) -> String {
     }
 
     format!(
-        "{prefix}{SLASH_COMMAND_TITLE_ELLIPSIS}{}{}",
+        "{prefix}{ellipsis}{}{}",
         " ".repeat(prefix_columns - prefix_width),
-        " ".repeat(SLASH_COMMAND_DESCRIPTION_GAP_COLUMNS),
+        " ".repeat(description_gap_columns),
     )
 }
 
 fn menu_result_row(
     row: &TuiInlineMenuRow,
     is_selected: bool,
+    slash_command_columns: SlashCommandColumnLayout,
     builder: &TuiUiBuilder,
 ) -> Box<dyn TuiElement> {
     let title_style = if is_selected {
@@ -338,9 +429,22 @@ fn menu_result_row(
             }
         }
     };
+    let show_description = match row.style {
+        TuiInlineMenuRowStyle::Default => row.description.is_some(),
+        TuiInlineMenuRowStyle::SlashCommand => {
+            slash_command_columns.show_descriptions && row.description.is_some()
+        }
+    };
+    let title_columns = if show_description {
+        slash_command_columns.title_columns
+    } else {
+        slash_command_columns.available_columns
+    };
     let title = match row.style {
         TuiInlineMenuRowStyle::Default => row.title.clone(),
-        TuiInlineMenuRowStyle::SlashCommand => format_slash_command_title(&row.title),
+        TuiInlineMenuRowStyle::SlashCommand => {
+            format_slash_command_title(&row.title, title_columns, show_description)
+        }
     };
     let title = TuiText::new(title)
         .with_style(title_style)
@@ -360,10 +464,13 @@ fn menu_result_row(
         .child(match row.style {
             TuiInlineMenuRowStyle::Default => title,
             TuiInlineMenuRowStyle::SlashCommand => TuiConstrainedBox::new(title)
-                .with_max_cols(SLASH_COMMAND_TITLE_COLUMNS as u16)
+                .with_max_cols(
+                    u16::try_from(title_columns)
+                        .expect("title columns come from the u16 width constraint"),
+                )
                 .finish(),
         });
-    if let Some(description) = &row.description {
+    if let Some(description) = row.description.as_ref().filter(|_| show_description) {
         let description = match row.style {
             TuiInlineMenuRowStyle::Default => format!("  {description}"),
             TuiInlineMenuRowStyle::SlashCommand => description.clone(),

--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -2,7 +2,6 @@
 use std::ops::Range;
 
 use string_offset::CharOffset;
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use warp::tui_export::AcceptSlashCommandOrSavedPrompt;
 use warpui_core::elements::tui::{
     TuiBuffer, TuiConstrainedBox, TuiConstraint, TuiContainer, TuiElement, TuiFlex,
@@ -13,13 +12,17 @@ use warpui_core::{AppContext, ModelAsRef, ModelHandle, UpdateModel};
 
 use crate::slash_commands::TuiSlashCommandModel;
 use crate::tui_builder::TuiUiBuilder;
+use crate::tui_column_layout::{
+    format_tui_first_column, tui_two_column_layout, TuiTwoColumnConstraints, TuiTwoColumnLayout,
+};
 
-const SLASH_COMMAND_PREFERRED_TITLE_COLUMNS: usize = 29;
-const SLASH_COMMAND_MIN_TITLE_COLUMNS_WITH_DESCRIPTION: usize = 8;
-const SLASH_COMMAND_MIN_DESCRIPTION_COLUMNS: usize = 12;
-const SLASH_COMMAND_PREFERRED_DESCRIPTION_COLUMNS: usize = 21;
-const SLASH_COMMAND_DESCRIPTION_GAP_COLUMNS: usize = 1;
-const SLASH_COMMAND_TITLE_ELLIPSIS: &str = "...";
+const SLASH_COMMAND_COLUMN_CONSTRAINTS: TuiTwoColumnConstraints = TuiTwoColumnConstraints {
+    preferred_first_columns: 29,
+    minimum_first_columns: 8,
+    minimum_second_columns: 12,
+    preferred_maximum_second_columns: 21,
+    gap_columns: 1,
+};
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -198,7 +201,16 @@ fn build_inline_menu(
     allocated_width: u16,
     allocated_height: u16,
 ) -> Box<dyn TuiElement> {
-    let slash_command_columns = slash_command_column_layout(snapshot, allocated_width);
+    let slash_command_columns = tui_two_column_layout(
+        usize::from(allocated_width),
+        snapshot.rows.iter().filter_map(|row| {
+            if row.style != TuiInlineMenuRowStyle::SlashCommand {
+                return None;
+            }
+            Some((row.title.as_str(), row.description.as_deref()?))
+        }),
+        SLASH_COMMAND_COLUMN_CONSTRAINTS,
+    );
     let mut column = TuiFlex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
     if let Some(header) = &snapshot.header {
         if let Some(title) = &header.title {
@@ -303,119 +315,10 @@ fn menu_status_row(label: &str, builder: &TuiUiBuilder) -> Box<dyn TuiElement> {
     .finish()
 }
 
-/// Shared title/description allocation for every slash-command row in one menu.
-#[derive(Clone, Copy)]
-struct SlashCommandColumnLayout {
-    available_columns: usize,
-    title_columns: usize,
-    show_descriptions: bool,
-}
-
-fn slash_command_column_layout(
-    snapshot: &TuiInlineMenuSnapshot,
-    allocated_width: u16,
-) -> SlashCommandColumnLayout {
-    let available_columns = usize::from(allocated_width);
-    let described_slash_command_rows = snapshot.rows.iter().filter(|row| {
-        row.style == TuiInlineMenuRowStyle::SlashCommand && row.description.is_some()
-    });
-    let longest_title_columns = described_slash_command_rows
-        .clone()
-        .map(|row| UnicodeWidthStr::width(row.title.as_str()))
-        .max();
-    let longest_description_columns = described_slash_command_rows
-        .filter_map(|row| row.description.as_deref())
-        .map(UnicodeWidthStr::width)
-        .max();
-    let min_two_column_width =
-        SLASH_COMMAND_MIN_TITLE_COLUMNS_WITH_DESCRIPTION + SLASH_COMMAND_MIN_DESCRIPTION_COLUMNS;
-    let Some((longest_title_columns, longest_description_columns)) =
-        longest_title_columns.zip(longest_description_columns)
-    else {
-        return SlashCommandColumnLayout {
-            available_columns,
-            title_columns: available_columns,
-            show_descriptions: false,
-        };
-    };
-    if available_columns < min_two_column_width {
-        return SlashCommandColumnLayout {
-            available_columns,
-            title_columns: available_columns,
-            show_descriptions: false,
-        };
-    }
-
-    let preferred_title_columns = SLASH_COMMAND_PREFERRED_TITLE_COLUMNS
-        .max(longest_title_columns.saturating_add(SLASH_COMMAND_DESCRIPTION_GAP_COLUMNS));
-    let preferred_description_columns = longest_description_columns.clamp(
-        SLASH_COMMAND_MIN_DESCRIPTION_COLUMNS,
-        SLASH_COMMAND_PREFERRED_DESCRIPTION_COLUMNS,
-    );
-    // Retain the established 29-column title alignment until descriptions
-    // have their useful width, then spend surplus columns on long titles.
-    let baseline_width = SLASH_COMMAND_PREFERRED_TITLE_COLUMNS + preferred_description_columns;
-    let title_columns = if available_columns >= baseline_width {
-        let growth_columns = available_columns - baseline_width;
-        preferred_title_columns
-            .min(SLASH_COMMAND_PREFERRED_TITLE_COLUMNS.saturating_add(growth_columns))
-    } else {
-        SLASH_COMMAND_PREFERRED_TITLE_COLUMNS
-            .min(available_columns.saturating_sub(SLASH_COMMAND_MIN_DESCRIPTION_COLUMNS))
-    };
-    SlashCommandColumnLayout {
-        available_columns,
-        title_columns: title_columns.max(SLASH_COMMAND_MIN_TITLE_COLUMNS_WITH_DESCRIPTION),
-        show_descriptions: true,
-    }
-}
-
-fn format_slash_command_title(
-    title: &str,
-    title_columns: usize,
-    include_description_gap: bool,
-) -> String {
-    let description_gap_columns = if include_description_gap {
-        SLASH_COMMAND_DESCRIPTION_GAP_COLUMNS
-    } else {
-        0
-    };
-    let available_title_columns = title_columns.saturating_sub(description_gap_columns);
-    let title_width = UnicodeWidthStr::width(title);
-    if title_width <= available_title_columns {
-        return if include_description_gap {
-            format!("{title}{}", " ".repeat(title_columns - title_width))
-        } else {
-            title.to_owned()
-        };
-    }
-
-    let ellipsis_columns =
-        UnicodeWidthStr::width(SLASH_COMMAND_TITLE_ELLIPSIS).min(available_title_columns);
-    let ellipsis = &SLASH_COMMAND_TITLE_ELLIPSIS[..ellipsis_columns];
-    let prefix_columns = available_title_columns - ellipsis_columns;
-    let mut prefix = String::new();
-    let mut prefix_width = 0;
-    for character in title.chars() {
-        let character_width = UnicodeWidthChar::width(character).unwrap_or_default();
-        if prefix_width + character_width > prefix_columns {
-            break;
-        }
-        prefix.push(character);
-        prefix_width += character_width;
-    }
-
-    format!(
-        "{prefix}{ellipsis}{}{}",
-        " ".repeat(prefix_columns - prefix_width),
-        " ".repeat(description_gap_columns),
-    )
-}
-
 fn menu_result_row(
     row: &TuiInlineMenuRow,
     is_selected: bool,
-    slash_command_columns: SlashCommandColumnLayout,
+    slash_command_columns: TuiTwoColumnLayout,
     builder: &TuiUiBuilder,
 ) -> Box<dyn TuiElement> {
     let title_style = if is_selected {
@@ -432,19 +335,20 @@ fn menu_result_row(
     let show_description = match row.style {
         TuiInlineMenuRowStyle::Default => row.description.is_some(),
         TuiInlineMenuRowStyle::SlashCommand => {
-            slash_command_columns.show_descriptions && row.description.is_some()
+            slash_command_columns.show_second && row.description.is_some()
         }
     };
     let title_columns = if show_description {
-        slash_command_columns.title_columns
+        slash_command_columns.first_columns
     } else {
         slash_command_columns.available_columns
     };
     let title = match row.style {
         TuiInlineMenuRowStyle::Default => row.title.clone(),
-        TuiInlineMenuRowStyle::SlashCommand => {
-            format_slash_command_title(&row.title, title_columns, show_description)
-        }
+        TuiInlineMenuRowStyle::SlashCommand => format_tui_first_column(
+            &row.title,
+            slash_command_columns.with_second_visible(show_description),
+        ),
     };
     let title = TuiText::new(title)
         .with_style(title_style)

--- a/crates/warp_tui/src/inline_menu_tests.rs
+++ b/crates/warp_tui/src/inline_menu_tests.rs
@@ -1,11 +1,11 @@
 use warp::appearance::Appearance;
-use warpui_core::elements::tui::{TuiBufferExt, TuiRect};
+use warpui_core::elements::tui::{Modifier, TuiBufferExt, TuiRect};
 use warpui_core::presenter::tui::TuiPresenter;
 use warpui_core::App;
 
 use super::{
-    render_inline_menu, TuiInlineMenuHeader, TuiInlineMenuRow, TuiInlineMenuSnapshot,
-    TuiInlineMenuStatus, TuiInlineMenuTab,
+    render_inline_menu, TuiInlineMenuHeader, TuiInlineMenuRow, TuiInlineMenuRowStyle,
+    TuiInlineMenuSnapshot, TuiInlineMenuStatus, TuiInlineMenuTab,
 };
 use crate::tui_builder::TuiUiBuilder;
 
@@ -65,6 +65,7 @@ fn renders_only_the_visible_row_window() {
                 title: format!("Conversation {index}"),
                 description: None,
                 is_selectable: true,
+                style: TuiInlineMenuRowStyle::Default,
             })
             .collect(),
         selected_index: Some(3),
@@ -100,11 +101,13 @@ fn conversation_like_snapshot_reuses_header_tabs_rows_and_selection() {
                 title: "Current project".to_owned(),
                 description: Some("2 minutes ago".to_owned()),
                 is_selectable: true,
+                style: TuiInlineMenuRowStyle::Default,
             },
             TuiInlineMenuRow {
                 title: "Archived".to_owned(),
                 description: None,
                 is_selectable: false,
+                style: TuiInlineMenuRowStyle::Default,
             },
         ],
         selected_index: Some(0),
@@ -141,6 +144,7 @@ fn conversation_like_snapshot_keeps_selection_visible_within_production_height()
                     title: format!("Conversation {index}"),
                     description: None,
                     is_selectable: true,
+                    style: TuiInlineMenuRowStyle::Default,
                 })
                 .collect(),
             selected_index: Some(7),
@@ -155,8 +159,74 @@ fn conversation_like_snapshot_keeps_selection_visible_within_production_height()
     let rendered = lines.join("\n");
     assert!(rendered.contains("Conversations"));
     assert!(rendered.contains("[All]  Pinned"));
-    assert!(!rendered.contains("Conversation 0"));
-    assert!(!rendered.contains("Conversation 1"));
-    assert!(rendered.contains("Conversation 2"));
+    assert!(rendered.contains("Conversation 0"));
+    assert!(rendered.contains("Conversation 1"));
     assert!(rendered.contains("Conversation 7"));
+}
+
+#[test]
+fn slash_command_rows_match_figma_layout_and_colors() {
+    App::test((), |app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        app.read(|ctx| {
+            let builder = TuiUiBuilder::from_app(ctx);
+            let snapshot = TuiInlineMenuSnapshot {
+                header: None,
+                rows: vec![
+                    TuiInlineMenuRow {
+                        title: "/agent".to_owned(),
+                        description: Some("Start a new agent conversation".to_owned()),
+                        is_selectable: true,
+                        style: TuiInlineMenuRowStyle::SlashCommand,
+                    },
+                    TuiInlineMenuRow {
+                        title: "/plan".to_owned(),
+                        description: Some("Create a plan".to_owned()),
+                        is_selectable: true,
+                        style: TuiInlineMenuRowStyle::SlashCommand,
+                    },
+                ],
+                selected_index: Some(0),
+                scroll_offset: 0,
+                max_visible_rows: 8,
+                status: None,
+            };
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                render_inline_menu(&snapshot, &builder),
+                TuiRect::new(0, 0, 50, 2),
+                ctx,
+            );
+            let lines = frame.buffer.to_lines();
+
+            assert!(lines[0].starts_with("/agent                       Start"));
+            assert!(lines[1].starts_with("/plan                        Create"));
+            assert_eq!(
+                frame.buffer[(0, 0)].bg,
+                builder.slash_command_selection_background()
+            );
+            assert_eq!(
+                frame.buffer[(0, 0)].fg,
+                builder
+                    .slash_command_selection_text_style()
+                    .fg
+                    .expect("selected slash-command text has a foreground")
+            );
+            assert!(frame.buffer[(0, 0)].modifier.contains(Modifier::BOLD));
+            assert_eq!(
+                frame.buffer[(0, 1)].fg,
+                builder
+                    .slash_command_text_style()
+                    .fg
+                    .expect("slash-command text has a foreground")
+            );
+            assert_eq!(
+                frame.buffer[(29, 1)].fg,
+                builder
+                    .primary_text_style()
+                    .fg
+                    .expect("slash-command descriptions use primary text")
+            );
+        });
+    });
 }

--- a/crates/warp_tui/src/inline_menu_tests.rs
+++ b/crates/warp_tui/src/inline_menu_tests.rs
@@ -4,8 +4,8 @@ use warpui_core::presenter::tui::TuiPresenter;
 use warpui_core::App;
 
 use super::{
-    render_inline_menu, TuiInlineMenuHeader, TuiInlineMenuRow, TuiInlineMenuRowStyle,
-    TuiInlineMenuSnapshot, TuiInlineMenuStatus, TuiInlineMenuTab,
+    format_slash_command_title, render_inline_menu, TuiInlineMenuHeader, TuiInlineMenuRow,
+    TuiInlineMenuRowStyle, TuiInlineMenuSnapshot, TuiInlineMenuStatus, TuiInlineMenuTab,
 };
 use crate::tui_builder::TuiUiBuilder;
 
@@ -229,4 +229,31 @@ fn slash_command_rows_match_figma_layout_and_colors() {
             );
         });
     });
+}
+
+#[test]
+fn long_slash_command_titles_are_ellipsized_before_the_description() {
+    let lines = render(TuiInlineMenuSnapshot {
+        header: None,
+        rows: vec![TuiInlineMenuRow {
+            title: "/respond-to-pr-comments-in-blocklist".to_owned(),
+            description: Some("Walk users through PR review comments".to_owned()),
+            is_selectable: true,
+            style: TuiInlineMenuRowStyle::SlashCommand,
+        }],
+        selected_index: Some(0),
+        scroll_offset: 0,
+        max_visible_rows: 8,
+        status: None,
+    });
+
+    assert!(lines[0].starts_with("/respond-to-pr-comments-i... Walk users"));
+}
+
+#[test]
+fn ellipsis_follows_wide_character_prefix_without_padding() {
+    assert_eq!(
+        format_slash_command_title("/12345678901234567890123界suffix"),
+        "/12345678901234567890123...  "
+    );
 }

--- a/crates/warp_tui/src/inline_menu_tests.rs
+++ b/crates/warp_tui/src/inline_menu_tests.rs
@@ -4,8 +4,8 @@ use warpui_core::presenter::tui::TuiPresenter;
 use warpui_core::App;
 
 use super::{
-    format_slash_command_title, render_inline_menu, TuiInlineMenuHeader, TuiInlineMenuRow,
-    TuiInlineMenuRowStyle, TuiInlineMenuSnapshot, TuiInlineMenuStatus, TuiInlineMenuTab,
+    render_inline_menu, TuiInlineMenuHeader, TuiInlineMenuRow, TuiInlineMenuRowStyle,
+    TuiInlineMenuSnapshot, TuiInlineMenuStatus, TuiInlineMenuTab,
 };
 use crate::tui_builder::TuiUiBuilder;
 
@@ -321,17 +321,4 @@ fn narrow_slash_command_rows_use_the_full_width_for_titles() {
     );
 
     assert_eq!(lines[0], "/123456789012345...");
-}
-
-#[test]
-fn ellipsis_follows_wide_character_prefix_without_padding() {
-    assert_eq!(
-        format_slash_command_title("/12345678901234567890123界suffix", 29, true),
-        "/12345678901234567890123...  "
-    );
-}
-
-#[test]
-fn ellipsis_scales_down_for_extremely_narrow_titles() {
-    assert_eq!(format_slash_command_title("/agent", 2, false), "..");
 }

--- a/crates/warp_tui/src/inline_menu_tests.rs
+++ b/crates/warp_tui/src/inline_menu_tests.rs
@@ -9,14 +9,14 @@ use super::{
 };
 use crate::tui_builder::TuiUiBuilder;
 
-fn render_at_height(snapshot: TuiInlineMenuSnapshot, height: u16) -> Vec<String> {
+fn render_at_size(snapshot: TuiInlineMenuSnapshot, width: u16, height: u16) -> Vec<String> {
     App::test((), |app| async move {
         app.add_singleton_model(|_| Appearance::mock());
         app.read(move |ctx| {
             let mut presenter = TuiPresenter::new();
             let frame = presenter.present_element(
                 render_inline_menu(&snapshot, &TuiUiBuilder::from_app(ctx)),
-                TuiRect::new(0, 0, 50, height),
+                TuiRect::new(0, 0, width, height),
                 ctx,
             );
             frame.buffer.to_lines()
@@ -24,6 +24,9 @@ fn render_at_height(snapshot: TuiInlineMenuSnapshot, height: u16) -> Vec<String>
     })
 }
 
+fn render_at_height(snapshot: TuiInlineMenuSnapshot, height: u16) -> Vec<String> {
+    render_at_size(snapshot, 50, height)
+}
 fn render(snapshot: TuiInlineMenuSnapshot) -> Vec<String> {
     render_at_height(snapshot, 12)
 }
@@ -251,9 +254,84 @@ fn long_slash_command_titles_are_ellipsized_before_the_description() {
 }
 
 #[test]
+fn wide_slash_command_rows_expand_to_show_long_titles() {
+    let lines = render_at_size(
+        TuiInlineMenuSnapshot {
+            header: None,
+            rows: vec![TuiInlineMenuRow {
+                title: "/respond-to-pr-comments-in-blocklist".to_owned(),
+                description: Some("Walk users through PR review comments".to_owned()),
+                is_selectable: true,
+                style: TuiInlineMenuRowStyle::SlashCommand,
+            }],
+            selected_index: Some(0),
+            scroll_offset: 0,
+            max_visible_rows: 8,
+            status: None,
+        },
+        80,
+        1,
+    );
+
+    assert!(lines[0]
+        .starts_with("/respond-to-pr-comments-in-blocklist Walk users through PR review comments"));
+}
+
+#[test]
+fn boundary_width_preserves_useful_title_and_description_columns() {
+    let lines = render_at_size(
+        TuiInlineMenuSnapshot {
+            header: None,
+            rows: vec![TuiInlineMenuRow {
+                title: "/agent".to_owned(),
+                description: Some("Start a new agent conversation".to_owned()),
+                is_selectable: true,
+                style: TuiInlineMenuRowStyle::SlashCommand,
+            }],
+            selected_index: Some(0),
+            scroll_offset: 0,
+            max_visible_rows: 8,
+            status: None,
+        },
+        20,
+        1,
+    );
+
+    assert!(lines[0].starts_with("/agent  Start a new"));
+}
+
+#[test]
+fn narrow_slash_command_rows_use_the_full_width_for_titles() {
+    let lines = render_at_size(
+        TuiInlineMenuSnapshot {
+            header: None,
+            rows: vec![TuiInlineMenuRow {
+                title: "/12345678901234567890".to_owned(),
+                description: Some("Description hidden at narrow widths".to_owned()),
+                is_selectable: true,
+                style: TuiInlineMenuRowStyle::SlashCommand,
+            }],
+            selected_index: Some(0),
+            scroll_offset: 0,
+            max_visible_rows: 8,
+            status: None,
+        },
+        19,
+        1,
+    );
+
+    assert_eq!(lines[0], "/123456789012345...");
+}
+
+#[test]
 fn ellipsis_follows_wide_character_prefix_without_padding() {
     assert_eq!(
-        format_slash_command_title("/12345678901234567890123界suffix"),
+        format_slash_command_title("/12345678901234567890123界suffix", 29, true),
         "/12345678901234567890123...  "
     );
+}
+
+#[test]
+fn ellipsis_scales_down_for_extremely_narrow_titles() {
+    assert_eq!(format_slash_command_title("/agent", 2, false), "..");
 }

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -646,24 +646,32 @@ impl TuiInputView {
     /// boxes it (behind the shell-mode `!` gutter when active); tests construct
     /// it directly to exercise mouse dispatch.
     fn render_element(&self, ctx: &AppContext) -> TuiEditorElement {
+        let builder = TuiUiBuilder::from_app(ctx);
         let mut styles = TuiEditorStyles::default();
         if let Some(range) = self
             .inline_menu
             .as_ref()
             .and_then(|inline_menu| inline_menu.input_highlight_range(ctx))
         {
-            styles.text_overrides.push((
-                range,
-                TuiUiBuilder::from_app(ctx).slash_command_text_style(),
-            ));
+            styles
+                .text_overrides
+                .push((range, builder.slash_command_text_style()));
         }
-        TuiEditorElement::new(&self.model, ctx)
+        let mut element = TuiEditorElement::new(&self.model, ctx)
             .editable()
             .with_viewport_rows(self.max_visible_rows)
             .with_styles(styles)
             .on_action(|action, event_ctx| {
                 event_ctx.dispatch_typed_action(TuiInputAction::from(action))
-            })
+            });
+        if let Some(hint_text) = self
+            .inline_menu
+            .as_ref()
+            .and_then(|inline_menu| inline_menu.input_argument_hint_text(ctx))
+        {
+            element = element.with_trailing_ghost_text(hint_text, builder.dim_text_style());
+        }
+        element
     }
     /// Collapses the current text selection to its head without changing text.
     pub(crate) fn clear_selection(&mut self, ctx: &mut ViewContext<Self>) {

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -38,7 +38,7 @@ use warpui_core::text::word_boundaries::WordBoundariesPolicy;
 use warpui_core::{AppContext, Entity, ModelHandle, TuiView, TypedActionView, ViewContext};
 
 use super::kill_buffer::KillBuffer;
-use crate::editor_element::{TuiEditorAction, TuiEditorElement};
+use crate::editor_element::{TuiEditorAction, TuiEditorElement, TuiEditorStyles};
 use crate::inline_menu::{TuiInlineMenu, TuiInlineMenuAccepted};
 use crate::input_mode_policy::{self, AI_LOCKED_CONFIG, SHELL_LOCKED_CONFIG};
 use crate::keybindings::TUI_BINDING_GROUP;
@@ -646,9 +646,21 @@ impl TuiInputView {
     /// boxes it (behind the shell-mode `!` gutter when active); tests construct
     /// it directly to exercise mouse dispatch.
     fn render_element(&self, ctx: &AppContext) -> TuiEditorElement {
+        let mut styles = TuiEditorStyles::default();
+        if let Some(range) = self
+            .inline_menu
+            .as_ref()
+            .and_then(|inline_menu| inline_menu.input_highlight_range(ctx))
+        {
+            styles.text_overrides.push((
+                range,
+                TuiUiBuilder::from_app(ctx).slash_command_text_style(),
+            ));
+        }
         TuiEditorElement::new(&self.model, ctx)
             .editable()
             .with_viewport_rows(self.max_visible_rows)
+            .with_styles(styles)
             .on_action(|action, event_ctx| {
                 event_ctx.dispatch_typed_action(TuiInputAction::from(action))
             })

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -15,8 +15,8 @@ use warp::tui_export::{
 use warp_editor::model::CoreEditorModel;
 use warpui::EntityIdMap;
 use warpui_core::elements::tui::{
-    TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext, TuiPaintContext,
-    TuiPoint, TuiRect, TuiSize,
+    TuiBuffer, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext,
+    TuiPaintContext, TuiPoint, TuiRect, TuiSize,
 };
 use warpui_core::event::{KeyEventDetails, ModifiersState};
 use warpui_core::keymap::Keystroke;
@@ -34,6 +34,7 @@ use crate::inline_menu::TuiInlineMenu;
 use crate::input_mode_policy::TuiInputModePolicy;
 use crate::slash_commands::{TuiSlashCommandModel, TuiSlashCommandRow};
 use crate::test_fixtures::add_test_semantic_selection;
+use crate::tui_builder::TuiUiBuilder;
 
 const W: u16 = 80;
 
@@ -46,6 +47,46 @@ fn input_escape_context_is_present_only_while_escape_is_handled() {
     let open = input_keymap_context(true);
     assert!(open.set.contains("TuiInputView"));
     assert!(open.set.contains(INPUT_HANDLES_ESCAPE_FLAG));
+}
+
+fn render_input_buffer(view: &ViewHandle<TuiInputView>, ctx: &AppContext) -> TuiBuffer {
+    let mut element = view.as_ref(ctx).render_element(ctx);
+    let mut rendered_views = EntityIdMap::default();
+    let mut layout_ctx = TuiLayoutContext {
+        rendered_views: &mut rendered_views,
+    };
+    let size = element.layout(
+        TuiConstraint::loose(TuiSize::new(W, 20)),
+        &mut layout_ctx,
+        ctx,
+    );
+    let area = TuiRect::new(0, 0, size.width, size.height);
+    let mut buffer = TuiBuffer::empty(area);
+    let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
+    element.render(area, &mut buffer, &mut paint_ctx);
+    buffer
+}
+
+#[test]
+fn recognized_slash_command_prefix_matches_menu_color() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let (view, menu_model, _) = build_view_with_inline_menu(ctx);
+            view.update(ctx, |view, ctx| view.set_text("/plan argument", ctx));
+            menu_model.update(ctx, |model, _| {
+                model.set_highlighted_prefix_len_for_test(Some(5));
+            });
+
+            let buffer = render_input_buffer(&view, ctx);
+            let expected = TuiUiBuilder::from_app(ctx)
+                .slash_command_text_style()
+                .fg
+                .expect("slash-command text has a foreground");
+            assert_eq!(buffer[(0, 0)].fg, expected);
+            assert_eq!(buffer[(4, 0)].fg, expected);
+            assert_ne!(buffer[(5, 0)].fg, expected);
+        });
+    });
 }
 
 fn build_view(ctx: &mut AppContext) -> ViewHandle<TuiInputView> {

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -15,8 +15,8 @@ use warp::tui_export::{
 use warp_editor::model::CoreEditorModel;
 use warpui::EntityIdMap;
 use warpui_core::elements::tui::{
-    TuiBuffer, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext,
-    TuiPaintContext, TuiPoint, TuiRect, TuiSize,
+    TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiEvent, TuiEventContext,
+    TuiLayoutContext, TuiPaintContext, TuiPoint, TuiRect, TuiSize,
 };
 use warpui_core::event::{KeyEventDetails, ModifiersState};
 use warpui_core::keymap::Keystroke;
@@ -47,6 +47,31 @@ fn input_escape_context_is_present_only_while_escape_is_handled() {
     let open = input_keymap_context(true);
     assert!(open.set.contains("TuiInputView"));
     assert!(open.set.contains(INPUT_HANDLES_ESCAPE_FLAG));
+}
+
+#[test]
+fn slash_command_argument_hint_renders_as_ghost_text() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let (view, menu_model, _) = build_view_with_inline_menu(ctx);
+            let input = "/export-to-file ";
+            view.update(ctx, |view, ctx| view.set_text(input, ctx));
+            menu_model.update(ctx, |model, _| {
+                model.set_argument_hint_text_for_test(Some("<optional filename>"));
+            });
+
+            let buffer = render_input_buffer(&view, ctx);
+            let line = &buffer.to_lines()[0];
+            assert!(line.starts_with("/export-to-file <optional filename>"));
+
+            let hint_column = input.chars().count() as u16;
+            let expected = TuiUiBuilder::from_app(ctx)
+                .dim_text_style()
+                .fg
+                .expect("ghost text has a foreground");
+            assert_eq!(buffer[(hint_column, 0)].fg, expected);
+        });
+    });
 }
 
 fn render_input_buffer(view: &ViewHandle<TuiInputView>, ctx: &AppContext) -> TuiBuffer {

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -35,6 +35,7 @@ mod tool_call_labels;
 mod transcript_view;
 mod transient_hint;
 mod tui_block_list_viewport_source;
+mod tui_column_layout;
 mod tui_diff_storage;
 mod tui_file_edits_view;
 mod tui_shell_command_view;

--- a/crates/warp_tui/src/slash_commands.rs
+++ b/crates/warp_tui/src/slash_commands.rs
@@ -51,6 +51,20 @@ fn highlighted_prefix_len_for_parsed_input(
     }
 }
 
+fn argument_hint_text_for_parsed_input(
+    parsed_input: &ParsedSlashCommandInput,
+    input: &str,
+) -> Option<&'static str> {
+    let ParsedSlashCommandInput::SlashCommand(detected) = parsed_input else {
+        return None;
+    };
+    detected
+        .command
+        .argument_hint()
+        .filter(|hint| hint.input_prefix == input)
+        .map(|hint| hint.text)
+}
+
 #[allow(dead_code)]
 #[derive(Debug, Clone, Default)]
 pub(crate) enum TuiSlashCommandState {
@@ -75,6 +89,7 @@ pub(crate) struct TuiSlashCommandModel {
     state: TuiSlashCommandState,
     lifecycle: InputDrivenInlineMenuLifecycle,
     highlighted_prefix_len: Option<usize>,
+    argument_hint_text: Option<&'static str>,
 }
 
 impl TuiSlashCommandModel {
@@ -108,6 +123,7 @@ impl TuiSlashCommandModel {
             state: TuiSlashCommandState::Closed,
             lifecycle: InputDrivenInlineMenuLifecycle::default(),
             highlighted_prefix_len: None,
+            argument_hint_text: None,
         };
         model.update_from_input(false, ctx);
         model
@@ -135,6 +151,7 @@ impl TuiSlashCommandModel {
             },
             lifecycle: InputDrivenInlineMenuLifecycle::default(),
             highlighted_prefix_len: None,
+            argument_hint_text: None,
         }
     }
 
@@ -143,12 +160,21 @@ impl TuiSlashCommandModel {
         self.highlighted_prefix_len = len;
     }
 
+    #[cfg(test)]
+    pub(crate) fn set_argument_hint_text_for_test(&mut self, text: Option<&'static str>) {
+        self.argument_hint_text = text;
+    }
+
     pub(crate) fn is_open(&self) -> bool {
         matches!(self.state, TuiSlashCommandState::Open { .. })
     }
     pub(crate) fn highlighted_prefix_range(&self) -> Option<Range<CharOffset>> {
         self.highlighted_prefix_len
             .map(|len| CharOffset::zero()..CharOffset::from(len))
+    }
+
+    pub(crate) fn argument_hint_text(&self) -> Option<&'static str> {
+        self.argument_hint_text
     }
 
     pub(crate) fn selected_action(&self) -> Option<AcceptSlashCommandOrSavedPrompt> {
@@ -177,6 +203,18 @@ impl TuiSlashCommandModel {
         if let Some(selected_index) = selection.select_previous(rows.len(), |_| true) {
             keep_selected_visible(rows.len(), selected_index, MAX_VISIBLE_ROWS, scroll_offset);
         }
+        ctx.emit(TuiSlashCommandModelEvent);
+    }
+
+    fn set_argument_hint_text(
+        &mut self,
+        argument_hint_text: Option<&'static str>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if self.argument_hint_text == argument_hint_text {
+            return;
+        }
+        self.argument_hint_text = argument_hint_text;
         ctx.emit(TuiSlashCommandModelEvent);
     }
 
@@ -259,6 +297,7 @@ impl TuiSlashCommandModel {
             .input_changed(input.is_empty(), input.starts_with('/'))
         {
             self.set_highlighted_prefix_len(None, ctx);
+            self.set_argument_hint_text(None, ctx);
             self.close(ctx);
             return;
         }
@@ -269,6 +308,10 @@ impl TuiSlashCommandModel {
         let parsed_input = slash_commands_source.as_ref(ctx).parse_input(&input, ctx);
         self.set_highlighted_prefix_len(
             highlighted_prefix_len_for_parsed_input(&parsed_input, &input),
+            ctx,
+        );
+        self.set_argument_hint_text(
+            argument_hint_text_for_parsed_input(&parsed_input, &input),
             ctx,
         );
         let menu_was_open = self.is_open();

--- a/crates/warp_tui/src/slash_commands.rs
+++ b/crates/warp_tui/src/slash_commands.rs
@@ -4,7 +4,9 @@
 //! Rendering and keyboard dispatch live in later layers; this model is only
 //! responsible for tracking when slash command composition is active, running
 //! shared-source queries, and snapshotting render-friendly row data.
+use std::ops::Range;
 
+use string_offset::CharOffset;
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp::search::data_source::QueryResult;
 use warp::search::mixer::SearchMixerEvent;
@@ -20,7 +22,8 @@ use warp_search_core::inline_menu::{
 use warpui_core::{AppContext, Entity, ModelContext, ModelHandle};
 
 use crate::inline_menu::{
-    keep_selected_visible, TuiInlineMenuRow, TuiInlineMenuSnapshot, TuiInlineMenuStatus,
+    keep_selected_visible, TuiInlineMenuRow, TuiInlineMenuRowStyle, TuiInlineMenuSnapshot,
+    TuiInlineMenuStatus,
 };
 
 const MAX_VISIBLE_ROWS: usize = 8;
@@ -31,6 +34,21 @@ pub(crate) struct TuiSlashCommandRow {
     pub(crate) title: String,
     pub(crate) description: Option<String>,
     pub(crate) action: AcceptSlashCommandOrSavedPrompt,
+}
+fn highlighted_prefix_len_for_parsed_input(
+    parsed_input: &ParsedSlashCommandInput,
+    input: &str,
+) -> Option<usize> {
+    match parsed_input {
+        ParsedSlashCommandInput::SlashCommand(detected) => input
+            .starts_with(detected.command.name)
+            .then(|| detected.command.name.chars().count()),
+        ParsedSlashCommandInput::SkillCommand(detected) => {
+            let prefix = format!("/{}", detected.name);
+            input.starts_with(&prefix).then(|| prefix.chars().count())
+        }
+        ParsedSlashCommandInput::None | ParsedSlashCommandInput::Composing { .. } => None,
+    }
 }
 
 #[allow(dead_code)]
@@ -56,6 +74,7 @@ pub(crate) struct TuiSlashCommandModel {
     mixer: ModelHandle<SlashCommandMixer>,
     state: TuiSlashCommandState,
     lifecycle: InputDrivenInlineMenuLifecycle,
+    highlighted_prefix_len: Option<usize>,
 }
 
 impl TuiSlashCommandModel {
@@ -67,15 +86,13 @@ impl TuiSlashCommandModel {
     ) -> Self {
         ctx.subscribe_to_model(&input_editor, |me, _, event, ctx| {
             if matches!(event, CodeEditorModelEvent::ContentChanged { .. }) {
-                me.update_from_input(ctx);
+                me.update_from_input(false, ctx);
             }
         });
         ctx.subscribe_to_model(
             &slash_commands_source,
             |me, _, _: &UpdatedActiveCommands, ctx| {
-                if let Some(query) = me.query().map(str::to_owned) {
-                    me.run_query(query, true, ctx);
-                }
+                me.update_from_input(true, ctx);
             },
         );
         ctx.subscribe_to_model(&mixer, |me, _, event, ctx| {
@@ -90,8 +107,9 @@ impl TuiSlashCommandModel {
             mixer,
             state: TuiSlashCommandState::Closed,
             lifecycle: InputDrivenInlineMenuLifecycle::default(),
+            highlighted_prefix_len: None,
         };
-        model.update_from_input(ctx);
+        model.update_from_input(false, ctx);
         model
     }
 
@@ -116,18 +134,21 @@ impl TuiSlashCommandModel {
                 is_loading: false,
             },
             lifecycle: InputDrivenInlineMenuLifecycle::default(),
+            highlighted_prefix_len: None,
         }
     }
 
-    pub(crate) fn query(&self) -> Option<&str> {
-        match &self.state {
-            TuiSlashCommandState::Closed => None,
-            TuiSlashCommandState::Open { query, .. } => Some(query),
-        }
+    #[cfg(test)]
+    pub(crate) fn set_highlighted_prefix_len_for_test(&mut self, len: Option<usize>) {
+        self.highlighted_prefix_len = len;
     }
 
     pub(crate) fn is_open(&self) -> bool {
         matches!(self.state, TuiSlashCommandState::Open { .. })
+    }
+    pub(crate) fn highlighted_prefix_range(&self) -> Option<Range<CharOffset>> {
+        self.highlighted_prefix_len
+            .map(|len| CharOffset::zero()..CharOffset::from(len))
     }
 
     pub(crate) fn selected_action(&self) -> Option<AcceptSlashCommandOrSavedPrompt> {
@@ -221,6 +242,7 @@ impl TuiSlashCommandModel {
                     title: row.title.clone(),
                     description: row.description.clone(),
                     is_selectable: true,
+                    style: TuiInlineMenuRowStyle::SlashCommand,
                 })
                 .collect(),
             selected_index: selection.selected_index(),
@@ -230,19 +252,25 @@ impl TuiSlashCommandModel {
         })
     }
 
-    fn update_from_input(&mut self, ctx: &mut ModelContext<Self>) {
+    fn update_from_input(&mut self, force_query: bool, ctx: &mut ModelContext<Self>) {
         let input = input_text(&self.input_editor, ctx);
         if !self
             .lifecycle
             .input_changed(input.is_empty(), input.starts_with('/'))
         {
+            self.set_highlighted_prefix_len(None, ctx);
             self.close(ctx);
             return;
         }
         let Some(slash_commands_source) = &self.slash_commands_source else {
+            self.set_highlighted_prefix_len(None, ctx);
             return;
         };
         let parsed_input = slash_commands_source.as_ref(ctx).parse_input(&input, ctx);
+        self.set_highlighted_prefix_len(
+            highlighted_prefix_len_for_parsed_input(&parsed_input, &input),
+            ctx,
+        );
         let menu_was_open = self.is_open();
         let result_count = self.mixer.as_ref(ctx).results().len();
         let Some(query) = menu_query_for_parsed_input(&parsed_input, menu_was_open, result_count)
@@ -250,7 +278,19 @@ impl TuiSlashCommandModel {
             self.close(ctx);
             return;
         };
-        self.run_query(query, false, ctx);
+        self.run_query(query, force_query, ctx);
+    }
+
+    fn set_highlighted_prefix_len(
+        &mut self,
+        highlighted_prefix_len: Option<usize>,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if self.highlighted_prefix_len == highlighted_prefix_len {
+            return;
+        }
+        self.highlighted_prefix_len = highlighted_prefix_len;
+        ctx.emit(TuiSlashCommandModelEvent);
     }
 
     fn run_query(&mut self, query: String, force: bool, ctx: &mut ModelContext<Self>) {
@@ -338,7 +378,6 @@ impl TuiSlashCommandModel {
 impl Entity for TuiSlashCommandModel {
     type Event = TuiSlashCommandModelEvent;
 }
-
 fn input_text(input_editor: &ModelHandle<CodeEditorModel>, ctx: &AppContext) -> String {
     let editor = input_editor.as_ref(ctx);
     let content = editor.content().as_ref(ctx);

--- a/crates/warp_tui/src/slash_commands_tests.rs
+++ b/crates/warp_tui/src/slash_commands_tests.rs
@@ -9,8 +9,8 @@ use warp_search_core::inline_menu::InlineMenuSelection;
 use warpui_core::App;
 
 use super::{
-    highlighted_prefix_len_for_parsed_input, menu_query_for_parsed_input, TuiSlashCommandModel,
-    TuiSlashCommandRow, MAX_VISIBLE_ROWS,
+    argument_hint_text_for_parsed_input, highlighted_prefix_len_for_parsed_input,
+    menu_query_for_parsed_input, TuiSlashCommandModel, TuiSlashCommandRow, MAX_VISIBLE_ROWS,
 };
 use crate::inline_menu::keep_selected_visible;
 
@@ -20,6 +20,27 @@ fn parsed_skill(argument: Option<&str>) -> ParsedSlashCommandInput {
         name: "write-product-spec".to_owned(),
         argument: argument.map(str::to_owned),
     })
+}
+
+#[test]
+fn argument_hint_uses_shared_static_command_placeholder() {
+    let command = ParsedSlashCommandInput::SlashCommand(DetectedCommand {
+        command: slash_commands::EXPORT_TO_FILE.clone(),
+        argument: Some(String::new()),
+    });
+
+    assert_eq!(
+        argument_hint_text_for_parsed_input(&command, "/export-to-file "),
+        Some("<optional filename>")
+    );
+    assert_eq!(
+        argument_hint_text_for_parsed_input(&command, "/export-to-file notes.md"),
+        None
+    );
+    assert_eq!(
+        argument_hint_text_for_parsed_input(&parsed_skill(Some("")), "/write-product-spec "),
+        None
+    );
 }
 
 fn parsed_static_command(argument: Option<&str>) -> ParsedSlashCommandInput {

--- a/crates/warp_tui/src/slash_commands_tests.rs
+++ b/crates/warp_tui/src/slash_commands_tests.rs
@@ -9,7 +9,8 @@ use warp_search_core::inline_menu::InlineMenuSelection;
 use warpui_core::App;
 
 use super::{
-    menu_query_for_parsed_input, TuiSlashCommandModel, TuiSlashCommandRow, MAX_VISIBLE_ROWS,
+    highlighted_prefix_len_for_parsed_input, menu_query_for_parsed_input, TuiSlashCommandModel,
+    TuiSlashCommandRow, MAX_VISIBLE_ROWS,
 };
 use crate::inline_menu::keep_selected_visible;
 
@@ -33,6 +34,34 @@ fn exact_static_command_stays_open_when_multiple_results_were_visible() {
     assert_eq!(
         menu_query_for_parsed_input(&parsed_static_command(None), true, 2).as_deref(),
         Some("compact")
+    );
+}
+
+#[test]
+fn only_detected_command_and_skill_prefixes_are_highlighted() {
+    let command = ParsedSlashCommandInput::SlashCommand(DetectedCommand {
+        command: slash_commands::PLAN.clone(),
+        argument: Some("research this".to_owned()),
+    });
+    assert_eq!(
+        highlighted_prefix_len_for_parsed_input(&command, "/plan research this"),
+        Some(5)
+    );
+    assert_eq!(
+        highlighted_prefix_len_for_parsed_input(
+            &parsed_skill(Some("prompt")),
+            "/write-product-spec prompt"
+        ),
+        Some("/write-product-spec".chars().count())
+    );
+    assert_eq!(
+        highlighted_prefix_len_for_parsed_input(
+            &ParsedSlashCommandInput::Composing {
+                filter: "pla".to_owned(),
+            },
+            "/pla",
+        ),
+        None
     );
 }
 

--- a/crates/warp_tui/src/tui_builder.rs
+++ b/crates/warp_tui/src/tui_builder.rs
@@ -119,6 +119,29 @@ impl TuiUiBuilder {
             self.warp_theme.terminal_colors().normal.cyan,
         )))
     }
+
+    /// Blue command-name text used by the slash-command menu and recognized
+    /// slash-command prefixes in the input.
+    pub(crate) fn slash_command_text_style(&self) -> TuiStyle {
+        TuiStyle::default().fg(cell_color(ThemeFill::Solid(self.warp_theme.ansi_fg_blue())))
+    }
+
+    /// Solid cyan selection background used by the slash-command menu.
+    pub(crate) fn slash_command_selection_background(&self) -> Color {
+        cell_color(ThemeFill::from(
+            self.warp_theme.terminal_colors().normal.cyan,
+        ))
+    }
+
+    /// Bold, contrast-derived text over the slash-command selection color.
+    pub(crate) fn slash_command_selection_text_style(&self) -> TuiStyle {
+        let background_fill = ThemeFill::from(self.warp_theme.terminal_colors().normal.cyan);
+        let foreground = self.warp_theme.font_color(background_fill.into_solid());
+        TuiStyle::default()
+            .fg(cell_color(foreground))
+            .bg(cell_color(background_fill))
+            .add_modifier(Modifier::BOLD)
+    }
     /// Bold accent prompt marker over the submitted-input background.
     pub(crate) fn input_prefix_style(&self) -> TuiStyle {
         self.accent_text_style()

--- a/crates/warp_tui/src/tui_builder_tests.rs
+++ b/crates/warp_tui/src/tui_builder_tests.rs
@@ -1,7 +1,7 @@
 use warp::tui_export::light_theme;
 use warp_core::ui::color::blend::Blend;
 use warp_core::ui::theme::Fill as ThemeFill;
-use warpui_core::elements::tui::Color;
+use warpui_core::elements::tui::{Color, Modifier};
 use warpui_core::elements::Fill as CoreFill;
 
 use super::TuiUiBuilder;
@@ -33,4 +33,22 @@ fn text_styles_follow_light_theme_foreground() {
         builder.primary_text_style().fg,
         Some(CoreFill::from(ThemeFill::from(theme.terminal_colors().normal.white)).into()),
     );
+
+    let slash_command_color: Color = CoreFill::from(ThemeFill::Solid(theme.ansi_fg_blue())).into();
+    let selection_fill = ThemeFill::from(theme.terminal_colors().normal.cyan);
+    let selection_background: Color = CoreFill::from(selection_fill).into();
+    let selection_foreground: Color =
+        CoreFill::from(theme.font_color(selection_fill.into_solid())).into();
+    assert_eq!(
+        builder.slash_command_text_style().fg,
+        Some(slash_command_color)
+    );
+    assert_eq!(
+        builder.slash_command_selection_background(),
+        selection_background
+    );
+    let selection_style = builder.slash_command_selection_text_style();
+    assert_eq!(selection_style.fg, Some(selection_foreground));
+    assert_eq!(selection_style.bg, Some(selection_background));
+    assert!(selection_style.add_modifier.contains(Modifier::BOLD));
 }

--- a/crates/warp_tui/src/tui_column_layout.rs
+++ b/crates/warp_tui/src/tui_column_layout.rs
@@ -1,0 +1,150 @@
+//! Shared width allocation and text formatting for two-column TUI rows.
+
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+const ELLIPSIS: &str = "...";
+
+/// Width policy for a group of two-column rows.
+#[derive(Clone, Copy)]
+pub(crate) struct TuiTwoColumnConstraints {
+    /// Stable first-column width used when both columns fit comfortably.
+    pub(crate) preferred_first_columns: usize,
+    /// Smallest useful first-column width, including the trailing gap.
+    pub(crate) minimum_first_columns: usize,
+    /// Smallest useful second-column width.
+    pub(crate) minimum_second_columns: usize,
+    /// Width to reserve for the second column before growing the first.
+    pub(crate) preferred_maximum_second_columns: usize,
+    /// Blank columns separating the first and second columns.
+    pub(crate) gap_columns: usize,
+}
+
+/// Shared column widths for a group of rows.
+#[derive(Clone, Copy)]
+pub(crate) struct TuiTwoColumnLayout {
+    pub(crate) available_columns: usize,
+    pub(crate) first_columns: usize,
+    pub(crate) show_second: bool,
+    gap_columns: usize,
+}
+impl TuiTwoColumnLayout {
+    /// Uses the shared widths for a row that may omit its second value.
+    pub(crate) fn with_second_visible(mut self, show_second: bool) -> Self {
+        self.show_second = show_second;
+        self
+    }
+}
+
+/// Allocates shared widths for a group of two-column rows.
+///
+/// The second column is hidden when there are no complete rows or the
+/// available width cannot satisfy both minimums. Otherwise, width is reserved
+/// for a useful second column before surplus columns are given to long values
+/// in the first column.
+pub(crate) fn tui_two_column_layout<'a>(
+    available_columns: usize,
+    rows: impl IntoIterator<Item = (&'a str, &'a str)>,
+    constraints: TuiTwoColumnConstraints,
+) -> TuiTwoColumnLayout {
+    let mut longest_first_columns: Option<usize> = None;
+    let mut longest_second_columns: Option<usize> = None;
+    for (first, second) in rows {
+        longest_first_columns = Some(
+            longest_first_columns
+                .unwrap_or_default()
+                .max(UnicodeWidthStr::width(first)),
+        );
+        longest_second_columns = Some(
+            longest_second_columns
+                .unwrap_or_default()
+                .max(UnicodeWidthStr::width(second)),
+        );
+    }
+
+    let single_column_layout = || TuiTwoColumnLayout {
+        available_columns,
+        first_columns: available_columns,
+        show_second: false,
+        gap_columns: 0,
+    };
+    let Some((longest_first_columns, longest_second_columns)) =
+        longest_first_columns.zip(longest_second_columns)
+    else {
+        return single_column_layout();
+    };
+    let minimum_two_column_width =
+        constraints.minimum_first_columns + constraints.minimum_second_columns;
+    if available_columns < minimum_two_column_width {
+        return single_column_layout();
+    }
+
+    let preferred_first_columns = constraints
+        .preferred_first_columns
+        .max(longest_first_columns.saturating_add(constraints.gap_columns));
+    let preferred_second_columns = longest_second_columns.clamp(
+        constraints.minimum_second_columns,
+        constraints.preferred_maximum_second_columns,
+    );
+    let baseline_width = constraints.preferred_first_columns + preferred_second_columns;
+    let first_columns = if available_columns >= baseline_width {
+        let growth_columns = available_columns - baseline_width;
+        preferred_first_columns.min(
+            constraints
+                .preferred_first_columns
+                .saturating_add(growth_columns),
+        )
+    } else {
+        constraints
+            .preferred_first_columns
+            .min(available_columns.saturating_sub(constraints.minimum_second_columns))
+    };
+
+    TuiTwoColumnLayout {
+        available_columns,
+        first_columns: first_columns.max(constraints.minimum_first_columns),
+        show_second: true,
+        gap_columns: constraints.gap_columns,
+    }
+}
+
+/// Ellipsizes the first value when needed and pads it to the shared width.
+pub(crate) fn format_tui_first_column(text: &str, layout: TuiTwoColumnLayout) -> String {
+    let (first_columns, gap_columns) = if layout.show_second {
+        (layout.first_columns, layout.gap_columns)
+    } else {
+        (layout.available_columns, 0)
+    };
+    let content_columns = first_columns.saturating_sub(gap_columns);
+    let mut formatted = truncate_with_ellipsis(text, content_columns);
+    if layout.show_second {
+        let formatted_columns = UnicodeWidthStr::width(formatted.as_str());
+        formatted.push_str(&" ".repeat(first_columns - formatted_columns));
+    }
+    formatted
+}
+
+/// Truncates `text` to `maximum_columns`, using as much of `...` as fits.
+fn truncate_with_ellipsis(text: &str, maximum_columns: usize) -> String {
+    if UnicodeWidthStr::width(text) <= maximum_columns {
+        return text.to_owned();
+    }
+
+    let ellipsis_columns = UnicodeWidthStr::width(ELLIPSIS).min(maximum_columns);
+    let prefix_columns = maximum_columns - ellipsis_columns;
+    let mut prefix = String::new();
+    let mut prefix_width = 0;
+    for character in text.chars() {
+        let character_width = UnicodeWidthChar::width(character).unwrap_or_default();
+        if prefix_width + character_width > prefix_columns {
+            break;
+        }
+        prefix.push(character);
+        prefix_width += character_width;
+    }
+    prefix.push_str(&".".repeat(ellipsis_columns));
+    prefix
+}
+
+#[cfg(test)]
+#[path = "tui_column_layout_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/tui_column_layout_tests.rs
+++ b/crates/warp_tui/src/tui_column_layout_tests.rs
@@ -1,0 +1,68 @@
+use super::{
+    format_tui_first_column, tui_two_column_layout, TuiTwoColumnConstraints, TuiTwoColumnLayout,
+};
+
+const CONSTRAINTS: TuiTwoColumnConstraints = TuiTwoColumnConstraints {
+    preferred_first_columns: 10,
+    minimum_first_columns: 5,
+    minimum_second_columns: 5,
+    preferred_maximum_second_columns: 10,
+    gap_columns: 1,
+};
+
+#[test]
+fn hides_second_column_below_combined_minimum_width() {
+    let layout = tui_two_column_layout(9, [("first", "second")], CONSTRAINTS);
+
+    assert!(!layout.show_second);
+    assert_eq!(layout.first_columns, 9);
+}
+
+#[test]
+fn reserves_second_column_before_growing_first_column() {
+    let layout = tui_two_column_layout(25, [("long first value", "second")], CONSTRAINTS);
+
+    assert!(layout.show_second);
+    assert_eq!(layout.first_columns, 17);
+}
+
+#[test]
+fn ellipsizes_and_pads_first_column_once() {
+    let layout = TuiTwoColumnLayout {
+        available_columns: 20,
+        first_columns: 10,
+        show_second: true,
+        gap_columns: 1,
+    };
+
+    assert_eq!(
+        format_tui_first_column("long first value", layout),
+        "long f... "
+    );
+}
+#[test]
+fn ellipsis_follows_wide_character_prefix_without_overflowing() {
+    let layout = TuiTwoColumnLayout {
+        available_columns: 29,
+        first_columns: 29,
+        show_second: true,
+        gap_columns: 1,
+    };
+
+    assert_eq!(
+        format_tui_first_column("/12345678901234567890123界suffix", layout),
+        "/12345678901234567890123...  "
+    );
+}
+
+#[test]
+fn ellipsis_scales_to_extremely_narrow_columns() {
+    let layout = TuiTwoColumnLayout {
+        available_columns: 2,
+        first_columns: 2,
+        show_second: false,
+        gap_columns: 0,
+    };
+
+    assert_eq!(format_tui_first_column("first", layout), "..");
+}

--- a/crates/warp_tui/src/tui_file_edits_view.rs
+++ b/crates/warp_tui/src/tui_file_edits_view.rs
@@ -446,7 +446,7 @@ impl TuiFileEditsView {
                 ghost: builder.diff_removed_style(),
                 gap: builder.dim_text_style(),
                 line_overrides,
-                ..Default::default()
+                text_overrides: Vec::new(),
             })
             // A file's conventional trailing newline must not render as a
             // blank numbered row (the body ends at the outermost context line).

--- a/crates/warp_tui/src/tui_file_edits_view.rs
+++ b/crates/warp_tui/src/tui_file_edits_view.rs
@@ -446,6 +446,7 @@ impl TuiFileEditsView {
                 ghost: builder.diff_removed_style(),
                 gap: builder.dim_text_style(),
                 line_overrides,
+                ..Default::default()
             })
             // A file's conventional trailing newline must not render as a
             // blank numbered row (the body ends at the outermost context line).


### PR DESCRIPTION
## Description

**Stack:** 3 of 4. Depends on [#13603](https://github.com/warpdotdev/warp/pull/13603); followed by [#13612](https://github.com/warpdotdev/warp/pull/13612).

Aligns the TUI slash-command menu with the intended visual treatment. Slash-command rows gain dedicated command, description, selection-background, and contrast-derived selected-text styles. Command and description columns are allocated once per menu from the available terminal width: the established 29-column alignment remains at ordinary widths, long titles expand in wide panes, and very narrow panes fall back to title-only rendering instead of starving descriptions.

Long command names use Unicode display-width-aware ASCII ellipses, including safe `.`/`..` degradation at extremely narrow widths. Recognized command and skill prefixes use the same command color in the input.

The input highlight is implemented as a reusable character-range overlay in `TuiEditorElement`, so it follows wrapped display rows without baking slash-command policy into the editor primitive. Parameterized static commands also render dim trailing argument hints without inserting them into the buffer; the GUI and TUI derive those hints from the same `StaticCommand::argument_hint()` metadata.

This PR does not change result ranking or ordering. The TUI continues to render the shared logical result order above the input, matching the GUI's above-input behavior. The Figma frame's top-row selection is treated as a static depicted state, not as an ordering requirement.

### In scope

- Add a slash-command row presentation mode with responsive, menu-wide command and description columns.
- Preserve ordinary-width alignment while expanding titles in wide panes and using a title-only narrow fallback.
- Add theme-derived styles for command names, selected-row backgrounds, and high-contrast selected text.
- Truncate long command names with Unicode display-width-aware ASCII ellipses while preserving useful description space.
- Add generic character-range text overrides to the char-cell editor, including soft-wrap-aware projection.
- Highlight only recognized static-command and skill prefixes in the input.
- Render static-command argument hints as dim trailing ghost text.
- Share static-command hint prefixes and text with the GUI registration path.
- Add render-to-lines and style coverage for ordinary, wide, boundary, narrow, Unicode, selection, theme, wrapped overrides, prefix highlighting, and ghost hints.

### Out of scope

- Result ranking, result reversal, or selection-index changes.
- Mouse interaction; keyboard-only interaction remains unchanged.
- Pixel-exact full-screen screenshot parity. Tests validate the design's semantic layout and color treatment in terminal cells.
- Semantic command IDs or richer GUI-style saved-prompt argument editing.

### How to review

1. Start with `crates/warp_tui/src/tui_builder.rs` for semantic command and selection styles, especially contrast derivation on custom themes.
2. Review `crates/warp_tui/src/inline_menu.rs` for shared responsive column allocation, narrow fallback, Unicode-aware truncation, and selected-row treatment. Rows continue to be consumed in logical order.
3. Review `crates/warp_tui/src/inline_menu_tests.rs` for preserved 50-column alignment plus 80-column, 20-column boundary, 19-column fallback, wide-character, and two-column ellipsis cases.
4. Review `crates/warp_tui/src/editor_element.rs` as generic editor capabilities: character ranges project through the display lattice, while trailing ghost text paints only at the end cursor.
5. Review `app/src/search/slash_command_menu/static_commands/mod.rs` and `app/src/terminal/input.rs` for shared argument-hint metadata and GUI usage.
6. Review `crates/warp_tui/src/slash_commands.rs` and `crates/warp_tui/src/input/view.rs` for the narrow domain-to-presentation bridge that computes recognized-prefix styling and hint visibility.

## Linked Issue

No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

https://www.loom.com/share/a1efde950bd840178af79ccd1d788365

Final-stack validation on 2026-07-11:

- `./script/format` — passed.
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings` — passed.
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings` — passed.
- Added render coverage for ordinary-width alignment, wide expansion, exact boundary allocation, narrow title-only fallback, Unicode display width, and extremely narrow ellipses.

Cargo tests and manual TUI validation were not rerun after the final restack.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Not included; manual TUI validation remains outstanding.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Refine TUI slash-command menu styling, responsive layout, and input hints.

Co-Authored-By: Oz [oz-agent@warp.dev](mailto:oz-agent@warp.dev)