### PR TITLE
Fix stale classic completions after user edits

### DIFF
--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -10531,6 +10531,19 @@ impl Input {
                 // e.g., we don't want to sync EditorEvent::CmdUpOnFirstRow.
                 self.send_input_sync_event(edit_origin, ctx);
 
+                // Distinguish edits the completion system applied itself (accepting or
+                // cycling through a candidate) from edits the user made (typing,
+                // backspacing, pasting). System-applied edits are allowed to diverge from
+                // the original completion query so that classic cycling keeps working;
+                // user edits still have to be revalidated against that query.
+                let is_user_edit = !matches!(
+                    self.editor.as_ref(ctx).get_last_action(ctx),
+                    Some(
+                        PlainTextEditorViewAction::AcceptCompletionSuggestion
+                            | PlainTextEditorViewAction::CycleCompletionSuggestion
+                    )
+                );
+
                 let mode = self.suggestions_mode_model.as_ref(ctx).mode().clone();
                 match &mode {
                     InputSuggestionsMode::CompletionSuggestions {
@@ -10604,6 +10617,7 @@ impl Input {
                                 replacement_start,
                                 buffer_text_original.as_str(),
                                 &completion_results,
+                                is_user_edit,
                                 ctx,
                             );
                             if should_close {
@@ -10772,10 +10786,13 @@ impl Input {
                             let replacement_start = *replacement_start;
                             let buffer_text_original = buffer_text_original.clone();
                             let completion_results = completion_results.clone();
+                            // A selection change is a cursor move, not a buffer edit, so it
+                            // never counts as a user edit for invalidation purposes.
                             let should_close = self.update_tab_completion_menu(
                                 replacement_start,
                                 buffer_text_original.as_str(),
                                 &completion_results,
+                                /*is_user_edit=*/ false,
                                 ctx,
                             );
 
@@ -11709,6 +11726,7 @@ impl Input {
         replacement_start: usize,
         buffer_text_original: &str,
         completion_results: &SuggestionResults,
+        is_user_edit: bool,
         ctx: &mut ViewContext<Input>,
     ) -> bool {
         let editor_text = self.editor.as_ref(ctx).buffer_text(ctx);
@@ -11725,13 +11743,18 @@ impl Input {
         // then we should close the completion menu because the result set
         // was based on a different query.
         //
-        // For classic completions, this is a poor heuristic: when you cycle
-        // through fuzzy matches, the text up to the cursor might not start
-        // with the original buffer text anymore.
-        // TODO: there's a bug here where if you hit tab and backspace,
-        // the result set won't go away (stale).
+        // Classic completions get an exemption from this check, but only for
+        // system-applied edits: when the completion system cycles through fuzzy
+        // matches it rewrites the buffer to each candidate, and the text up to the
+        // cursor may no longer start with the original buffer text. Keeping the
+        // result set alive in that case is what lets cycling work.
+        //
+        // A user edit (typing, backspacing, pasting) that diverges from the original
+        // query must still invalidate the result set. Otherwise a Tab followed by
+        // Backspace past the replacement boundary would leave stale suggestions on
+        // screen (and an empty prefix would re-show the entire original result set).
         if !text_up_to_cursor.starts_with(buffer_text_original)
-            && !self.is_classic_completions_enabled(ctx)
+            && (!self.is_classic_completions_enabled(ctx) || is_user_edit)
         {
             // Close the input suggestions since the buffer was edited to no longer
             // contain the text that triggered tab completion.

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -6747,6 +6747,126 @@ fn test_tab_completions_menu_for_classic_completions_with_files() {
 }
 
 #[test]
+fn test_classic_tab_completions_close_after_user_backspace() {
+    let _flag = FeatureFlag::ClassicCompletions.override_enabled(true);
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
+        let input = terminal.read(&app, |terminal, _| terminal.input().clone());
+        let editor = input.read(&app, |input, _| input.editor().clone());
+
+        app.update(|ctx| {
+            InputSettings::handle(ctx).update(ctx, |setting, ctx| {
+                setting
+                    .classic_completions_mode
+                    .toggle_and_save_value(ctx)
+                    .expect("Able to turn on classic completions");
+            })
+        });
+
+        input.update(&mut app, |input, ctx| {
+            input.clear_buffer_and_reset_undo_stack(ctx);
+            input.user_insert("cd Do", ctx);
+        });
+
+        input.update(&mut app, |input, ctx| {
+            input.input_tab(ctx);
+            input.handle_completion_suggestions_results(
+                build_suggestion_results(
+                    vec![file_suggestion("Downloads"), file_suggestion("Documents")],
+                    (3, 5),
+                    MatchStrategy::CaseInsensitive,
+                ),
+                CompletionsTrigger::Keybinding,
+                editor_model_snapshot(input, ctx),
+                ctx,
+            );
+            // Cycle to apply a candidate into the buffer. This is a system-applied
+            // edit, which must keep the result set alive.
+            input.input_tab(ctx);
+        });
+
+        // The user now backspaces all the way past the original completion query
+        // (`cd Do`). Once the buffer no longer starts with the original query, the
+        // stale result set must be discarded and the menu closed.
+        while input.read(&app, |input, ctx| input.buffer_text(ctx).len()) > "cd ".len() {
+            editor.update(&mut app, |editor, ctx| editor.backspace(ctx));
+        }
+
+        input.read(&app, |input, ctx| {
+            assert_eq!(input.buffer_text(ctx), "cd ");
+            // A closed menu is represented by `InputSuggestionsMode::Closed`; a closed
+            // menu is never rendered, so its stale result set is no longer shown. This
+            // mirrors the existing (non-classic) backspace-past-boundary behavior.
+            assert!(
+                matches!(
+                    input.suggestions_mode_model.as_ref(ctx).mode(),
+                    InputSuggestionsMode::Closed
+                ),
+                "completion menu should close after the user backspaces past the query"
+            );
+        });
+    })
+}
+
+#[test]
+fn test_classic_tab_completions_keep_menu_open_while_cycling() {
+    let _flag = FeatureFlag::ClassicCompletions.override_enabled(true);
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
+        let input = terminal.read(&app, |terminal, _| terminal.input().clone());
+
+        app.update(|ctx| {
+            InputSettings::handle(ctx).update(ctx, |setting, ctx| {
+                setting
+                    .classic_completions_mode
+                    .toggle_and_save_value(ctx)
+                    .expect("Able to turn on classic completions");
+            })
+        });
+
+        input.update(&mut app, |input, ctx| {
+            input.clear_buffer_and_reset_undo_stack(ctx);
+            input.user_insert("cd Do", ctx);
+        });
+
+        input.update(&mut app, |input, ctx| {
+            input.input_tab(ctx);
+            input.handle_completion_suggestions_results(
+                build_suggestion_results(
+                    vec![file_suggestion("Downloads"), file_suggestion("Documents")],
+                    (3, 5),
+                    MatchStrategy::CaseInsensitive,
+                ),
+                CompletionsTrigger::Keybinding,
+                editor_model_snapshot(input, ctx),
+                ctx,
+            );
+            // Cycling rewrites the buffer to each candidate in turn. These are
+            // system-applied edits and must keep the menu open even though the
+            // buffer no longer matches the original query.
+            input.input_tab(ctx);
+            input.input_tab(ctx);
+        });
+
+        input.read(&app, |input, ctx| {
+            assert!(
+                matches!(
+                    input.suggestions_mode_model.as_ref(ctx).mode(),
+                    InputSuggestionsMode::CompletionSuggestions { .. }
+                ),
+                "completion menu should stay open while cycling candidates"
+            );
+            assert!(
+                !input.input_suggestions.as_ref(ctx).items().is_empty(),
+                "result set should be preserved while cycling candidates"
+            );
+        });
+    })
+}
+
+#[test]
 fn test_vim_escape_with_history_menu() {
     App::test((), |mut app| async move {
         initialize_app(&mut app);


### PR DESCRIPTION
## Description

With Classic Completions enabled, pressing <kbd>Tab</kbd> and then <kbd>Backspace</kbd> back past the point completion was anchored to left the old suggestion list on screen (stale), and backspacing to an empty prefix re-showed the entire original result set. This is the `TODO` in `update_tab_completion_menu` ("if you hit tab and backspace, the result set won't go away (stale)").

Non-classic completions already close the menu when the text up to the cursor no longer starts with the buffer text that triggered completion. Classic completions were exempted from that check so that Tab **cycling** (which rewrites the buffer to each candidate, diverging from the original query) keeps working. The problem is that the exemption applied to *all* edits, so genuine user edits were also allowed to keep a stale result set.

### Fix

Distinguish edits the completion system applied itself from edits the user made, using the editor's recorded last action:

```rust
let is_user_edit = !matches!(
    self.editor.as_ref(ctx).get_last_action(ctx),
    Some(
        PlainTextEditorViewAction::AcceptCompletionSuggestion
            | PlainTextEditorViewAction::CycleCompletionSuggestion
    )
);
```

The classic exemption now only applies to system-applied edits (accept / cycle). A user edit (typing, backspacing, pasting) still runs the original-query validity check and invalidates + closes the menu when the input retreats past the completion boundary or becomes incompatible. `SelectionChanged` (a cursor move, not a buffer edit) passes `is_user_edit = false`.

This reads first-class recorded editor state (`get_last_action`), set on the undo stack *before* `EditorEvent::Edited` is emitted — not a heuristic. Cycling stays exempt in both fuzzy and non-fuzzy modes because both record `CycleCompletionSuggestion`.

## Linked Issue

Closes #13605

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.  <!-- not yet triaged; keeping this PR as a draft until then -->

## Testing

- [x] I have manually tested my changes locally with `./script/run` (WarpOss built with the classic-completions feature).

Added two model tests in `app/src/terminal/input_tests.rs`:

- `test_classic_tab_completions_close_after_user_backspace` — **red before this change** (menu stayed `CompletionSuggestions` / re-showed the full result set after backspacing to `cd `), **green after** (mode becomes `Closed`).
- `test_classic_tab_completions_keep_menu_open_while_cycling` — passes before and after; guards against a cycling regression.

Validation on the affected package:

- `cargo nextest run -p warp classic_tab_completions` → 2 passed
- `cargo nextest run -p warp tab_completion` → 24 passed
- `cargo check -p warp` → ok
- `cargo clippy -p warp --tests -- -D warnings` → no issues
- `cargo fmt --all -- --check` → clean

### Screenshots / Videos

Manually verified in the real app (WarpOss built with the classic-completions feature). Same evidence is on the linked issue (#13605).

**1. `cd Do` + <kbd>Tab</kbd>** — the classic completion menu opens (Documents/Downloads).

![menu open](https://github.com/user-attachments/assets/33201802-3c19-41e9-bbc4-186d2eb1d367)

**2. After <kbd>Backspace</kbd> back past the completion boundary** — the menu closes (the fix; previously it stayed open with stale candidates, and an empty prefix re-showed the whole original result set).

![menu closed](https://github.com/user-attachments/assets/c662fc66-8ebb-4bd6-85ab-65d93898dfc3)

**3. `cd Do` + <kbd>Tab</kbd> × 3** — the menu stays open and the selection advances, so Tab cycling is unaffected.

![cycling preserved](https://github.com/user-attachments/assets/a43b7107-721f-4ee3-9ae8-28dbcfe1e0bd)

### Out of scope

IME marked-text composition and undo/redo are `skip_undo` edits that don't record a fresh action, so they keep the pre-existing classic exemption behavior (unchanged by this PR). IME completion interaction is tracked separately (#11091).

<!--
CHANGELOG-BUG-FIX: Fixed classic completions leaving a stale suggestion menu open after pressing Tab and then Backspace.
-->
