### PR TITLE
Add Reminders and full-access EventKit usage descriptions to Info.plist

### DIFF
--- a/script/update_plist
+++ b/script/update_plist
@@ -263,6 +263,9 @@ plutil -insert NSCameraUsageDescription -string "A program in Warp wants to use 
 plutil -insert NSMicrophoneUsageDescription -string "A program in Warp wants to use your microphone." "$WARP_PLIST_PATH"
 plutil -insert NSContactsUsageDescription -string "A program in Warp wants to use your contacts." "$WARP_PLIST_PATH"
 plutil -insert NSCalendarsUsageDescription -string "A program in Warp wants to use your calendar." "$WARP_PLIST_PATH"
+plutil -insert NSCalendarsFullAccessUsageDescription -string "A program in Warp wants full access to your calendar." "$WARP_PLIST_PATH"
+plutil -insert NSRemindersUsageDescription -string "A program in Warp wants to use your reminders." "$WARP_PLIST_PATH"
+plutil -insert NSRemindersFullAccessUsageDescription -string "A program in Warp wants full access to your reminders." "$WARP_PLIST_PATH"
 plutil -insert NSLocationUsageDescription -string "A program in Warp wants to use your location information." "$WARP_PLIST_PATH"
 plutil -insert NSPhotoLibraryUsageDescription -string "A program in Warp wants to use your photo library." "$WARP_PLIST_PATH"
 


### PR DESCRIPTION
## Description

`icalBuddy` (and other EventKit-based CLIs) fail with `error: No calendars.` inside Warp while working in Terminal.app. As @jagmit diagnosed in #13558, the cause is the generated bundle `Info.plist`: macOS attributes a CLI's permission requests to the terminal app (the TCC "responsible process") and only shows a consent prompt if that app declares the matching usage-description key. `icalBuddy` opens both the event store and the **reminders** store at startup, but Warp's plist declared only `NSCalendarsUsageDescription` — no Reminders key, and none of the macOS 14 full-access variants. The reminders request was therefore denied silently: no prompt, and no System Settings entry the user could flip.

This adds the missing keys to `script/update_plist`:

- `NSCalendarsFullAccessUsageDescription`
- `NSRemindersUsageDescription`
- `NSRemindersFullAccessUsageDescription`

matching the existing description style. No other behavior changes; not a UI/rendering change.

## Linked Issue

Closes #13558

## Testing

Ran the permission-insert block from `script/update_plist` against a fresh plist and confirmed the three new keys are inserted with the correct strings and the result is a valid plist:

```
$ plutil -extract NSRemindersUsageDescription raw Info.plist
A program in Warp wants to use your reminders.
$ plutil -extract NSRemindersFullAccessUsageDescription raw Info.plist
A program in Warp wants full access to your reminders.
$ plutil -extract NSCalendarsFullAccessUsageDescription raw Info.plist
A program in Warp wants full access to your calendar.
$ plutil -lint Info.plist
Info.plist: OK
```

`bash -n script/update_plist` passes.

## Visual evidence — consent prompt + Settings entry

macOS shows the reminders consent prompt **only if the responsible app's `Info.plist` declares the matching key** — otherwise the request is silently denied, which is this bug. The check below issues the same reminders request (`EKEventStore.requestFullAccessToReminders`, the same API path `icalBuddy` takes) under two Warp builds that differ **only** in the plist.

**Before** — build without the keys (current behavior): silently denied, no prompt, no Settings entry.

```
Reminders authorization status (before request): notDetermined
Requesting Reminders access via EventKit ...
  -> granted=false status=notDetermined error=nil
RESULT: no reminders access (silently denied — the reported bug)
```

**After** — build with this PR's keys: the consent prompt appears, and its body is verbatim the `NSRemindersFullAccessUsageDescription` string added in this PR.

<img width="254" height="224" alt="Reminders consent prompt: A program in Warp wants full access to your reminders." src="https://github.com/user-attachments/assets/775199d8-cc45-4c3a-b128-287ad005cccc" />

Granting it, Reminders access succeeds and the app appears under **System Settings → Privacy & Security → Reminders**:

<img width="620" alt="System Settings, Reminders pane, listing the app with access enabled" src="https://github.com/user-attachments/assets/9a90791e-2efa-4836-93fa-37ad73db8255" />

```
Requesting Reminders access via EventKit ...
  -> granted=true status=authorized error=nil
RESULT: reminders accessible ✅
```

The screens are from a WarpOss dev bundle with this PR's `script/update_plist` delta applied to its `Info.plist` and re-signed — the binary is untouched, since this change is plist-only. A signed release build produces the same prompt from the same keys; an external contributor can't sign a release, so this demonstrates the mechanism on a local ad-hoc-signed build.

<!--
CHANGELOG-BUG-FIX: Fixed EventKit-based CLIs like icalBuddy failing with "No calendars." by adding the missing Reminders and full-access usage-description keys to the macOS Info.plist.
-->
