### PR TITLE
Handle multiline paste safely in the TUI

### DIFF
--- a/crates/warp_tui/src/editor_element.rs
+++ b/crates/warp_tui/src/editor_element.rs
@@ -49,6 +49,9 @@ pub(crate) enum TuiEditorAction {
     /// Insert a printable character (only emitted when the element is
     /// [`editable`](TuiEditorElement::editable)).
     InsertChar(char),
+    /// Insert one complete paste payload (only emitted when the element is
+    /// [`editable`](TuiEditorElement::editable)).
+    InsertText(String),
     /// Place the cursor / begin a character selection at `offset` (single click).
     SelectionStartAt { offset: CharOffset },
     /// Extend the active selection's head to `offset` (shift-click).
@@ -717,20 +720,32 @@ impl TuiElement for TuiEditorElement {
         }
 
         if self.editable {
-            if let TuiEvent::KeyDown {
-                keystroke, chars, ..
-            } = event
-            {
-                // Chorded editing commands are dispatched by the keymap pass
-                // (consumer keybindings) before the element pass ever sees the
-                // key. Only printable-character insertion stays element-level —
-                // text insertion is not a keybinding, matching the GUI.
-                if !keystroke.ctrl && !keystroke.alt && !chars.is_empty() {
-                    if let Some(char) = chars.chars().next() {
-                        handler(TuiEditorAction::InsertChar(char), event_ctx);
-                        return true;
+            match event {
+                TuiEvent::KeyDown {
+                    keystroke, chars, ..
+                } => {
+                    // Chorded editing commands are dispatched by the keymap pass
+                    // (consumer keybindings) before the element pass ever sees the
+                    // key. Only printable-character insertion stays element-level —
+                    // text insertion is not a keybinding, matching the GUI.
+                    if !keystroke.ctrl && !keystroke.alt && !chars.is_empty() {
+                        if let Some(char) = chars.chars().next() {
+                            handler(TuiEditorAction::InsertChar(char), event_ctx);
+                            return true;
+                        }
                     }
                 }
+                TuiEvent::Paste { text } => {
+                    handler(TuiEditorAction::InsertText(text.clone()), event_ctx);
+                    return true;
+                }
+                TuiEvent::ScrollWheel { .. }
+                | TuiEvent::LeftMouseDown { .. }
+                | TuiEvent::LeftMouseUp { .. }
+                | TuiEvent::LeftMouseDragged { .. }
+                | TuiEvent::MiddleMouseDown { .. }
+                | TuiEvent::RightMouseDown { .. }
+                | TuiEvent::MouseMoved { .. } => {}
             }
         }
 

--- a/crates/warp_tui/src/editor_element_tests.rs
+++ b/crates/warp_tui/src/editor_element_tests.rs
@@ -1,3 +1,6 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use string_offset::CharOffset;
 use warp::appearance::Appearance;
 use warp::editor::CodeEditorModel;
@@ -5,12 +8,12 @@ use warp_editor::content::buffer::InitialBufferState;
 use warp_editor::model::CoreEditorModel;
 use warpui::EntityIdMap;
 use warpui_core::elements::tui::{
-    Color, Modifier, TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiLayoutContext,
-    TuiPaintContext, TuiRect, TuiSize, TuiStyle,
+    Color, Modifier, TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiEvent, TuiEventContext,
+    TuiLayoutContext, TuiPaintContext, TuiRect, TuiSize, TuiStyle,
 };
 use warpui_core::{App, AppContext, ModelHandle};
 
-use super::{TuiEditorElement, TuiEditorStyles};
+use super::{TuiEditorAction, TuiEditorElement, TuiEditorStyles};
 
 /// A char-cell editor model seeded with `text`.
 fn model(ctx: &mut AppContext, text: &str) -> ModelHandle<CodeEditorModel> {
@@ -96,6 +99,78 @@ fn render_lines(
         .into_iter()
         .map(|line| line.trim_end().to_string())
         .collect()
+}
+fn dispatch_event(ctx: &AppContext, mut element: TuiEditorElement, event: &TuiEvent) -> bool {
+    let mut rendered_views = EntityIdMap::default();
+    let mut layout_ctx = TuiLayoutContext {
+        rendered_views: &mut rendered_views,
+    };
+    let size = element.layout(
+        TuiConstraint::loose(TuiSize::new(80, 20)),
+        &mut layout_ctx,
+        ctx,
+    );
+    let area = TuiRect::new(0, 0, size.width, size.height);
+    element.dispatch_event(
+        event,
+        area,
+        &mut TuiEventContext::default(),
+        &mut layout_ctx,
+        ctx,
+    )
+}
+
+#[test]
+fn editable_paste_emits_one_complete_text_action() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+            let model = model(ctx, "");
+            let actions = Rc::new(RefCell::new(Vec::new()));
+            let actions_for_handler = actions.clone();
+            let element = TuiEditorElement::new(&model, ctx)
+                .editable()
+                .on_action(move |action, _| actions_for_handler.borrow_mut().push(action));
+            let payload = "first\n\nsecond\n";
+
+            assert!(dispatch_event(
+                ctx,
+                element,
+                &TuiEvent::Paste {
+                    text: payload.to_owned(),
+                },
+            ));
+            let actions = actions.borrow();
+            assert_eq!(actions.len(), 1);
+            let TuiEditorAction::InsertText(text) = &actions[0] else {
+                panic!("expected InsertText");
+            };
+            assert_eq!(text, payload);
+        });
+    });
+}
+
+#[test]
+fn read_only_editor_ignores_paste() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            ctx.add_singleton_model(|_| Appearance::mock());
+            let model = model(ctx, "unchanged");
+            let actions = Rc::new(RefCell::new(Vec::new()));
+            let actions_for_handler = actions.clone();
+            let element = TuiEditorElement::new(&model, ctx)
+                .on_action(move |action, _| actions_for_handler.borrow_mut().push(action));
+
+            assert!(!dispatch_event(
+                ctx,
+                element,
+                &TuiEvent::Paste {
+                    text: "ignored".to_owned(),
+                },
+            ));
+            assert!(actions.borrow().is_empty());
+        });
+    });
 }
 
 #[test]

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -478,6 +478,8 @@ pub enum TuiInputViewEvent {
 pub enum TuiInputAction {
     /// Insert a character (`Char(c)` key events).
     InsertChar(char),
+    /// Insert one complete bracketed-paste payload without submitting it.
+    InsertText(String),
     /// Insert a hard newline (`Shift+Enter`, `Ctrl+J`, `Alt+Enter`).
     InsertNewline,
     /// Submit the current input (`Enter`).
@@ -752,6 +754,7 @@ impl From<TuiEditorAction> for TuiInputAction {
     fn from(action: TuiEditorAction) -> Self {
         match action {
             TuiEditorAction::InsertChar(c) => Self::InsertChar(c),
+            TuiEditorAction::InsertText(text) => Self::InsertText(text),
             TuiEditorAction::SelectionStartAt { offset } => Self::SelectionStartAt { offset },
             TuiEditorAction::SelectionExtendTo { offset } => Self::SelectionExtendTo { offset },
             TuiEditorAction::SelectWordAt { offset } => Self::SelectWordAt { offset },
@@ -788,6 +791,9 @@ impl TypedActionView for TuiInputView {
                     let s = c.to_string();
                     self.model.update(ctx, |m, ctx| m.user_insert(&s, ctx));
                 }
+            }
+            TuiInputAction::InsertText(text) => {
+                self.model.update(ctx, |m, ctx| m.user_insert(text, ctx));
             }
             TuiInputAction::InsertNewline => {
                 self.model.update(ctx, |m, ctx| m.user_insert("\n", ctx));

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -265,6 +265,44 @@ fn escape_dismisses_menu_and_closed_menu_submit_falls_through() {
     });
 }
 
+#[test]
+fn multiline_paste_inserts_without_submitting_until_enter() {
+    App::test((), |mut app| async move {
+        let (view, submitted) = app.update(|ctx| {
+            let view = build_view(ctx);
+            let submitted = Rc::new(RefCell::new(Vec::new()));
+            let submitted_for_subscription = submitted.clone();
+            ctx.subscribe_to_view(&view, move |_, event, _| {
+                if let TuiInputViewEvent::Submitted(text) = event {
+                    submitted_for_subscription.borrow_mut().push(text.clone());
+                }
+            });
+            (view, submitted)
+        });
+        let payload = "USER:\nhello\n\nAGENT:\nHi!\n";
+
+        app.update(|ctx| {
+            dispatch(
+                &view,
+                ctx,
+                &[TuiInputAction::InsertText(payload.to_owned())],
+            );
+        });
+        app.read(|ctx| {
+            assert_eq!(text(&view, ctx), payload);
+            assert!(
+                submitted.borrow().is_empty(),
+                "paste must not emit a submission"
+            );
+        });
+
+        app.update(|ctx| {
+            dispatch(&view, ctx, &[TuiInputAction::Submit]);
+        });
+        assert_eq!(submitted.borrow().as_slice(), &[payload]);
+    });
+}
+
 fn dispatch(view: &ViewHandle<TuiInputView>, ctx: &mut AppContext, actions: &[TuiInputAction]) {
     view.update(ctx, |v, vctx| {
         for action in actions {

--- a/crates/warpui_core/src/elements/tui/event.rs
+++ b/crates/warpui_core/src/elements/tui/event.rs
@@ -28,6 +28,9 @@ pub enum TuiEvent {
         details: KeyEventDetails,
         is_composing: bool,
     },
+    Paste {
+        text: String,
+    },
     ScrollWheel {
         position: TuiPoint,
         delta: TuiScrollDelta,
@@ -76,7 +79,7 @@ impl TuiEvent {
             | Self::MiddleMouseDown { position, .. }
             | Self::RightMouseDown { position, .. }
             | Self::MouseMoved { position, .. } => Some(*position),
-            Self::KeyDown { .. } => None,
+            Self::KeyDown { .. } | Self::Paste { .. } => None,
         }
     }
 

--- a/crates/warpui_core/src/elements/tui/selectable.rs
+++ b/crates/warpui_core/src/elements/tui/selectable.rs
@@ -341,6 +341,7 @@ where
             | TuiEvent::LeftMouseUp { .. }
             | TuiEvent::ScrollWheel { .. }
             | TuiEvent::KeyDown { .. }
+            | TuiEvent::Paste { .. }
             | TuiEvent::MiddleMouseDown { .. }
             | TuiEvent::RightMouseDown { .. }
             | TuiEvent::MouseMoved { .. } => false,

--- a/crates/warpui_core/src/runtime/event_conversion.rs
+++ b/crates/warpui_core/src/runtime/event_conversion.rs
@@ -19,12 +19,12 @@ pub fn crossterm_event_to_tui_event(event: CrosstermEvent) -> Option<TuiEvent> {
     match event {
         CrosstermEvent::Key(key_event) => key_event_to_tui_event(key_event),
         CrosstermEvent::Mouse(mouse_event) => TuiEvent::try_from(mouse_event).ok(),
-        // TODO: FocusGained, FocusLost, and Paste have no TUI equivalents yet.
+        CrosstermEvent::Paste(text) => Some(TuiEvent::Paste { text }),
+        // TODO: FocusGained and FocusLost have no TUI equivalents yet.
         // If these are needed in the future, consider adding matching TuiEvent variants.
-        CrosstermEvent::FocusGained
-        | CrosstermEvent::FocusLost
-        | CrosstermEvent::Paste(_)
-        | CrosstermEvent::Resize(_, _) => None,
+        CrosstermEvent::FocusGained | CrosstermEvent::FocusLost | CrosstermEvent::Resize(_, _) => {
+            None
+        }
     }
 }
 

--- a/crates/warpui_core/src/runtime/event_conversion_tests.rs
+++ b/crates/warpui_core/src/runtime/event_conversion_tests.rs
@@ -83,6 +83,16 @@ fn non_press_key_events_are_ignored() {
     event.kind = KeyEventKind::Release;
     assert!(crossterm_event_to_tui_event(CrosstermEvent::Key(event)).is_none());
 }
+#[test]
+fn paste_preserves_the_complete_payload() {
+    let payload = "USER:\nhello\n\nAGENT:\nHi!\n";
+    let Some(TuiEvent::Paste { text }) =
+        crossterm_event_to_tui_event(CrosstermEvent::Paste(payload.to_owned()))
+    else {
+        panic!("expected Paste");
+    };
+    assert_eq!(text, payload);
+}
 
 #[test]
 fn pure_modifier_keys_have_no_tui_equivalent() {

--- a/crates/warpui_core/src/runtime/mod.rs
+++ b/crates/warpui_core/src/runtime/mod.rs
@@ -30,7 +30,8 @@ use std::time::Duration;
 use instant::Instant;
 use ratatui::crossterm::cursor::{Hide, Show};
 use ratatui::crossterm::event::{
-    self, DisableMouseCapture, EnableMouseCapture, Event as CrosstermEvent,
+    self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+    Event as CrosstermEvent,
 };
 use ratatui::crossterm::execute;
 use ratatui::crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
@@ -567,12 +568,31 @@ trait TerminalModeControl {
 }
 
 struct CrosstermModeControl;
+fn enter_terminal_screen(out: &mut impl Write) -> io::Result<()> {
+    execute!(
+        out,
+        EnterAlternateScreen,
+        EnableMouseCapture,
+        EnableBracketedPaste,
+        Hide
+    )
+}
+
+fn leave_terminal_screen(out: &mut impl Write) -> io::Result<()> {
+    execute!(
+        out,
+        Show,
+        DisableBracketedPaste,
+        DisableMouseCapture,
+        LeaveAlternateScreen
+    )
+}
 
 impl TerminalModeControl for CrosstermModeControl {
     fn enter(&mut self) -> io::Result<()> {
         terminal::enable_raw_mode()?;
         let mut out = stdout();
-        if let Err(error) = execute!(out, EnterAlternateScreen, EnableMouseCapture, Hide) {
+        if let Err(error) = enter_terminal_screen(&mut out) {
             let _ = terminal::disable_raw_mode();
             return Err(error);
         }
@@ -581,7 +601,7 @@ impl TerminalModeControl for CrosstermModeControl {
 
     fn leave(&mut self) {
         let mut out = stdout();
-        let _ = execute!(out, Show, DisableMouseCapture, LeaveAlternateScreen);
+        let _ = leave_terminal_screen(&mut out);
         let _ = terminal::disable_raw_mode();
     }
 }

--- a/crates/warpui_core/src/runtime/mod.rs
+++ b/crates/warpui_core/src/runtime/mod.rs
@@ -593,6 +593,7 @@ impl TerminalModeControl for CrosstermModeControl {
         terminal::enable_raw_mode()?;
         let mut out = stdout();
         if let Err(error) = enter_terminal_screen(&mut out) {
+            let _ = leave_terminal_screen(&mut out);
             let _ = terminal::disable_raw_mode();
             return Err(error);
         }

--- a/crates/warpui_core/src/runtime/mod_tests.rs
+++ b/crates/warpui_core/src/runtime/mod_tests.rs
@@ -328,6 +328,26 @@ impl TerminalModeControl for RecordingControl {
 }
 
 #[test]
+fn terminal_screen_lifecycle_toggles_bracketed_paste() {
+    let mut enter_output = Vec::new();
+    enter_terminal_screen(&mut enter_output).unwrap();
+    assert!(
+        enter_output
+            .windows(b"\x1b[?2004h".len())
+            .any(|window| window == b"\x1b[?2004h"),
+        "entering the TUI should enable bracketed paste"
+    );
+
+    let mut leave_output = Vec::new();
+    leave_terminal_screen(&mut leave_output).unwrap();
+    assert!(
+        leave_output
+            .windows(b"\x1b[?2004l".len())
+            .any(|window| window == b"\x1b[?2004l"),
+        "leaving the TUI should disable bracketed paste"
+    );
+}
+#[test]
 fn raw_mode_guard_restores_on_drop() {
     let log = Rc::new(RefCell::new(Vec::new()));
     let control = RecordingControl {


### PR DESCRIPTION
## Description

**Stack:** 4 of 4. Depends on [#13604](https://github.com/warpdotdev/warp/pull/13604).

Prevents multiline clipboard content from being interpreted as a sequence of Enter keypresses and immediately submitted by the TUI. The runtime now enables terminal bracketed-paste mode, preserves each crossterm paste payload as one structured `TuiEvent`, and inserts it into editable inputs atomically.

This matches GUI editor behavior: internal and trailing newlines remain intact, read-only editor surfaces ignore paste, and submission happens only after a separate Enter keypress.

### In scope

- Enable bracketed paste when entering TUI terminal mode and disable it during guaranteed terminal restoration.
- Convert `CrosstermEvent::Paste` into a dedicated payload-preserving `TuiEvent::Paste`.
- Route editable paste through one `InsertText(String)` action and one `CodeEditorModel::user_insert` call.
- Keep paste separate from keybindings, submission, and the typed-only `!` shell-mode trigger.
- Add focused conversion, lifecycle, editable/read-only editor, and no-submit regression coverage.

### Out of scope

- Clipboard ownership or `/export-to-clipboard` behavior; this fixes paste ingestion for all sources.
- Timing-based detection of unbracketed terminal input.
- Flattening or trimming pasted newlines.
- GUI editor changes.

### How to review

1. Start with `crates/warpui_core/src/runtime/mod.rs` for bracketed-paste lifecycle and restoration.
2. Review `crates/warpui_core/src/runtime/event_conversion.rs` and `crates/warpui_core/src/elements/tui/event.rs` for exact payload preservation.
3. Review `crates/warp_tui/src/editor_element.rs` for the editable-only event-to-action boundary.
4. Review `crates/warp_tui/src/input/view.rs` for the single atomic model insertion and absence of submission behavior.
5. Finish with the focused tests in the adjacent `*_tests.rs` files.

## Linked Issue

No linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

Final-stack validation on 2026-07-11:

- `./script/format` — passed.
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings` — passed.
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings` — passed.

Previously run before the final restack:

- `cargo test -p warpui_core --features tui paste` — 2 passed.
- `cargo test -p warp_tui paste` — 3 passed.

The focused tests and manual TUI validation were not rerun after the final restack.

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Not included; manual TUI validation remains outstanding.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Prevent multiline paste from immediately submitting TUI input.

Co-Authored-By: Oz <oz-agent@warp.dev>
