### PR TITLE
Mint IAP tokens for Oz runners via WIF (bootstrapped by injected OIDC JWT)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15848,6 +15848,7 @@ dependencies = [
  "serde_json",
  "session-sharing-protocol",
  "settings_value",
+ "tempfile",
  "thiserror 2.0.17",
  "url",
  "uuid",

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -39,6 +39,7 @@ use warp_isolation_platform::IsolationPlatformError;
 #[cfg(not(target_family = "wasm"))]
 use warp_logging::log_file_path;
 use warp_managed_secrets::ManagedSecretManager;
+use warp_server_client::iap::{IapManager, IapManagerEvent};
 use warpui::platform::TerminationMode;
 use warpui::{AppContext, ModelSpawner, SingletonEntity};
 
@@ -1577,6 +1578,52 @@ fn launch_command(
         ));
     }
 
+    // On staging the warp-server is fronted by IAP, so establish an IAP token
+    // before *any* warp-server request.
+    let iap = IapManager::handle(ctx);
+    if !iap.as_ref(ctx).is_enabled() || iap.as_ref(ctx).has_valid_token() {
+        refresh_auth_and_dispatch(ctx, command, global_options);
+        return Ok(());
+    }
+
+    let mut handled = false;
+    ctx.subscribe_to_model(&iap, move |_, event, ctx| {
+        if handled {
+            return;
+        }
+        match event {
+            IapManagerEvent::StateChanged
+                if IapManager::handle(ctx).as_ref(ctx).has_valid_token() =>
+            {
+                handled = true;
+                refresh_auth_and_dispatch(ctx, command.clone(), global_options.clone());
+            }
+            IapManagerEvent::AccessUnavailable => {
+                handled = true;
+                report_fatal_error(
+                    anyhow::anyhow!("Timed out establishing IAP access to warp-server."),
+                    ctx,
+                );
+            }
+            _ => {}
+        }
+    });
+
+    iap.update(ctx, |manager, ctx| manager.ensure_access(ctx));
+
+    Ok(())
+}
+
+/// Subscribes to auth events, triggers a user refresh, and dispatches the
+/// command once auth completes. Assumes IAP access (if applicable) is already
+/// established, since the auth refresh is itself an IAP-gated warp-server request.
+fn refresh_auth_and_dispatch(
+    ctx: &mut AppContext,
+    command: CliCommand,
+    global_options: GlobalOptions,
+) {
+    let cli_name = warp_cli::binary_name().unwrap_or_else(|| "warp".to_string());
+
     // User is logged in — subscribe to auth events, trigger a refresh, and wait
     // for the result before running the command.
     let mut dispatched = false;
@@ -1613,8 +1660,6 @@ fn launch_command(
     AuthManager::handle(ctx).update(ctx, |auth_manager, ctx| {
         auth_manager.refresh_user(ctx);
     });
-
-    Ok(())
 }
 
 /// Check if we're running within Warp (for example, if this is an invocation of the Warp CLI

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -2162,7 +2162,21 @@ pub(crate) fn initialize_app(
         ctx.add_singleton_model(system::SystemInfo::new);
     }
 
-    // `IapManager` drives gcloud-based IAP token refresh for staging builds.
+    // In a sandboxed Oz runner, mint IAP tokens by self-minting via Workload
+    // Identity Federation (impersonating the IAP access service account). Gated
+    // on runner context (ambient-agent run id) so local staging clients keep
+    // using the gcloud path.
+    #[cfg(not(target_family = "wasm"))]
+    let managed_iap_mint = std::env::var(warp_cli::OZ_RUN_ID_ENV).is_ok().then(|| {
+        let client = server_api_provider.as_ref(ctx).get_managed_secrets_client();
+        warp_server_client::iap::ManagedIapMint::new(Arc::new(
+            crate::server::iap_identity_minter::ManagedSecretsIapMinter::new(client),
+        ))
+    });
+    #[cfg(target_family = "wasm")]
+    let managed_iap_mint: Option<warp_server_client::iap::ManagedIapMint> = None;
+
+    // `IapManager` drives IAP token refresh for staging builds.
     // Register it after `LocalShellState`: the Manager needs to know where the gcloud
     // cli lives & thus needs PATH config set by ~/.zshrc et al.
     //
@@ -2184,7 +2198,7 @@ pub(crate) fn initialize_app(
 
             path_future
         });
-        IapManager::new(iap_state, path_resolver, ctx)
+        IapManager::new(iap_state, path_resolver, managed_iap_mint, ctx)
     });
     // Subscribe to IAP manager events to show toasts when refresh fails.
     ctx.subscribe_to_model(&IapManager::handle(ctx), |_, e, ctx| {

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -230,7 +230,7 @@ use warp_errors::{report_error, report_if_error};
 use warp_files::FileModel;
 use warp_logging::LogDestination;
 use warp_managed_secrets::ManagedSecretManager;
-use warp_server_client::iap::{IapManager, IapManagerEvent, IapState};
+use warp_server_client::iap::{IapManager, IapManagerEvent, IapState, ManagedIapMint};
 use warp_server_client::network_logging::NetworkLogModel;
 use warpui::integration::TestDriver;
 use warpui::modals::{AlertDialogWithCallbacks, AppModalCallback};
@@ -245,6 +245,8 @@ use workspace::sync_inputs::SyncedInputState;
 use self::features::FeatureFlag;
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::ambient_agents::github_auth_notifier::GitHubAuthNotifier;
+#[cfg(not(target_family = "wasm"))]
+use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::RecordingController;
 use crate::ai::connected_self_hosted_workers::ConnectedSelfHostedWorkersModel;
 use crate::ai::document::ai_document_model::AIDocumentModel;
@@ -289,6 +291,8 @@ use crate::root_view::{
 use crate::server::cloud_objects::listener::Listener;
 use crate::server::cloud_objects::update_manager::UpdateManager;
 use crate::server::experiments::ServerExperiments;
+#[cfg(not(target_family = "wasm"))]
+use crate::server::iap_identity_minter::ManagedSecretsIapMinter;
 use crate::server::sync_queue::{QueueItem, SyncQueue};
 pub use crate::server::telemetry::{
     AgentModeEntrypoint, AgentModeEntrypointSelectionType, TelemetryEvent,
@@ -1372,13 +1376,21 @@ pub(crate) fn initialize_app(
     });
 
     let server_api = server_api_provider.as_ref(ctx).get();
+    // Parse the ambient-agent task id once. A set-but-unparseable OZ_RUN_ID is
+    // treated as absent everywhere: it identifies no task and must not enable the
+    // runner-context IAP WIF mint below.
     #[cfg(not(target_family = "wasm"))]
-    if let Ok(run_id) = std::env::var(warp_cli::OZ_RUN_ID_ENV) {
-        match run_id.parse() {
-            Ok(task_id) => server_api.set_ambient_agent_task_id(Some(task_id)),
-            Err(err) => log::warn!("Ignoring invalid {}: {err}", warp_cli::OZ_RUN_ID_ENV),
-        }
-    }
+    let ambient_agent_task_id: Option<AmbientAgentTaskId> = std::env::var(warp_cli::OZ_RUN_ID_ENV)
+        .ok()
+        .and_then(|run_id| match run_id.parse() {
+            Ok(task_id) => Some(task_id),
+            Err(err) => {
+                log::warn!("Ignoring invalid {}: {err}", warp_cli::OZ_RUN_ID_ENV);
+                None
+            }
+        });
+    #[cfg(not(target_family = "wasm"))]
+    server_api.set_ambient_agent_task_id(ambient_agent_task_id);
     let ai_client = server_api_provider.as_ref(ctx).get_ai_client();
     #[cfg(not(target_family = "wasm"))]
     // Refresh starts only after the authenticated server client exists; tracing initialization
@@ -2164,17 +2176,15 @@ pub(crate) fn initialize_app(
 
     // In a sandboxed Oz runner, mint IAP tokens by self-minting via Workload
     // Identity Federation (impersonating the IAP access service account). Gated
-    // on runner context (ambient-agent run id) so local staging clients keep
-    // using the gcloud path.
+    // on a valid ambient-agent task id so local staging clients — and any runner
+    // with a stray or malformed OZ_RUN_ID — keep using the gcloud path.
     #[cfg(not(target_family = "wasm"))]
-    let managed_iap_mint = std::env::var(warp_cli::OZ_RUN_ID_ENV).is_ok().then(|| {
+    let managed_iap_mint = ambient_agent_task_id.is_some().then(|| {
         let client = server_api_provider.as_ref(ctx).get_managed_secrets_client();
-        warp_server_client::iap::ManagedIapMint::new(Arc::new(
-            crate::server::iap_identity_minter::ManagedSecretsIapMinter::new(client),
-        ))
+        ManagedIapMint::new(Arc::new(ManagedSecretsIapMinter::new(client)))
     });
     #[cfg(target_family = "wasm")]
-    let managed_iap_mint: Option<warp_server_client::iap::ManagedIapMint> = None;
+    let managed_iap_mint: Option<ManagedIapMint> = None;
 
     // `IapManager` drives IAP token refresh for staging builds.
     // Register it after `LocalShellState`: the Manager needs to know where the gcloud

--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -119,6 +119,7 @@ fn initialize_app(app: &mut App) {
         IapManager::new(
             None,
             Box::new(|_| futures::FutureExt::boxed(futures::future::ready(None::<String>))),
+            None,
             ctx,
         )
     });

--- a/app/src/server/iap_identity_minter.rs
+++ b/app/src/server/iap_identity_minter.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::FutureExt as _;
+use vec1::vec1;
+use warp_managed_secrets::client::{IdentityTokenOptions, ManagedSecretsClient};
+use warp_server_client::iap::IapIdentityTokenMinter;
+use warpui::r#async::BoxFuture;
+
+/// Mints Warp-signed OIDC identity tokens for the runner-context IAP Workload
+/// Identity Federation flow, backed by the managed-secrets client. Lives in the
+/// app crate so `warp_server_client` need not depend on the managed-secrets
+/// stack.
+pub struct ManagedSecretsIapMinter {
+    client: Arc<dyn ManagedSecretsClient>,
+}
+
+impl ManagedSecretsIapMinter {
+    pub fn new(client: Arc<dyn ManagedSecretsClient>) -> Self {
+        Self { client }
+    }
+}
+
+impl IapIdentityTokenMinter for ManagedSecretsIapMinter {
+    fn mint_identity_token(
+        &self,
+        audience: String,
+        requested_duration: Duration,
+    ) -> BoxFuture<'static, anyhow::Result<String>> {
+        let client = self.client.clone();
+        async move {
+            let token = client
+                .issue_task_identity_token(IdentityTokenOptions {
+                    audience,
+                    requested_duration,
+                    subject_template: vec1!["principal".to_string()],
+                })
+                .await?;
+            Ok(token.token)
+        }
+        .boxed()
+    }
+}

--- a/app/src/server/mod.rs
+++ b/app/src/server/mod.rs
@@ -2,6 +2,7 @@ pub mod block;
 pub mod cloud_objects;
 pub mod experiments;
 pub mod graphql;
+pub mod iap_identity_minter;
 pub mod ids;
 pub mod network_log_pane_manager;
 pub mod network_log_view;

--- a/app/src/server/mod.rs
+++ b/app/src/server/mod.rs
@@ -2,6 +2,9 @@ pub mod block;
 pub mod cloud_objects;
 pub mod experiments;
 pub mod graphql;
+// Runner-only: the minter is constructed solely in the native, ambient-agent-run
+// code path (see lib.rs), so it doesn't compile or ship on wasm.
+#[cfg(not(target_family = "wasm"))]
 pub mod iap_identity_minter;
 pub mod ids;
 pub mod network_log_pane_manager;

--- a/app/src/settings_view/main_page.rs
+++ b/app/src/settings_view/main_page.rs
@@ -1114,9 +1114,6 @@ impl SettingsWidget for IapCredentialsWidget {
                 (format!("Loaded (refreshes in ~{mins}m)"), active)
             }
             IapCredentialsState::Failed { message, .. } => (format!("Failed: {message}"), ansi_red),
-            IapCredentialsState::EnvInjected { .. } => {
-                ("Using injected token (WARP_IAP_TOKEN)".to_string(), active)
-            }
         };
 
         let is_refreshing = matches!(state, IapCredentialsState::Refreshing { .. });

--- a/app/src/terminal/shared_session/sharer/network_tests.rs
+++ b/app/src/terminal/shared_session/sharer/network_tests.rs
@@ -661,6 +661,7 @@ fn test_messages_are_buffered_while_reconnecting() {
             IapManager::new(
                 None,
                 Box::new(|_| futures::FutureExt::boxed(futures::future::ready(None::<String>))),
+                None,
                 ctx,
             )
         });

--- a/app/src/test_util/terminal.rs
+++ b/app/src/test_util/terminal.rs
@@ -82,6 +82,7 @@ pub fn initialize_app_for_terminal_view(app: &mut App) {
         IapManager::new(
             None,
             Box::new(|_| futures::FutureExt::boxed(futures::future::ready(None::<String>))),
+            None,
             ctx,
         )
     });

--- a/app/src/workspace/view_tests.rs
+++ b/app/src/workspace/view_tests.rs
@@ -208,6 +208,7 @@ pub(crate) fn initialize_app(app: &mut App) {
         warp_server_client::iap::IapManager::new(
             None,
             Box::new(|_| futures::FutureExt::boxed(futures::future::ready(None::<String>))),
+            None,
             ctx,
         )
     });

--- a/crates/warp_server_client/Cargo.toml
+++ b/crates/warp_server_client/Cargo.toml
@@ -60,6 +60,7 @@ warpui_core.workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 diesel = { workspace = true, features = ["sqlite", "chrono"] }
+tempfile.workspace = true
 websocket.workspace = true
 
 [dev-dependencies]

--- a/crates/warp_server_client/src/iap.rs
+++ b/crates/warp_server_client/src/iap.rs
@@ -36,8 +36,7 @@ const WIF_MINT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 /// Env var carrying a Warp OIDC task-identity JWT (audience = the WIF provider
 /// resource name), injected by warp-server so a cold sandboxed runner can
 /// bootstrap its first IAP mint without calling the IAP-gated identity-token
-/// endpoint. This is NOT the IAP bearer token — it is the subject token for the
-/// STS exchange.
+/// endpoint.
 const STAGING_IAP_BOOTSTRAP_TOKEN_ENV_VAR: &str = "WARP_STAGING_IAP_BOOTSTRAP_JWT";
 
 pub type PathResolver = Box<dyn Fn(&mut AppContext) -> BoxFuture<'static, Option<String>>>;

--- a/crates/warp_server_client/src/iap.rs
+++ b/crates/warp_server_client/src/iap.rs
@@ -38,7 +38,7 @@ const WIF_MINT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 /// bootstrap its first IAP mint without calling the IAP-gated identity-token
 /// endpoint. This is NOT the IAP bearer token — it is the subject token for the
 /// STS exchange.
-const INJECTED_OIDC_JWT_ENV_VAR: &str = "WARP_IAP_OIDC_JWT";
+const INJECTED_OIDC_JWT_ENV_VAR: &str = "WARP_STAGING_IAP_BOOTSTRAP_JWT";
 
 pub type PathResolver = Box<dyn Fn(&mut AppContext) -> BoxFuture<'static, Option<String>>>;
 

--- a/crates/warp_server_client/src/iap.rs
+++ b/crates/warp_server_client/src/iap.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use base64::Engine;
 use blocking::unblock;
 use instant::Instant;
+use serde::{Deserialize, Serialize};
 use warp_core::channel::IapConfig;
 use warpui_core::r#async::{BoxFuture, FutureExt as _, Timer};
 use warpui_core::{AppContext, Entity, ModelContext, SingletonEntity};
@@ -12,7 +13,6 @@ use warpui_core::{AppContext, Entity, ModelContext, SingletonEntity};
 use websocket::connect_error_http_response;
 
 const PROACTIVE_REFRESH_BUFFER: Duration = Duration::from_secs(5 * 60);
-const INJECTED_TOKEN_ENV_VAR: &str = "WARP_IAP_TOKEN";
 
 const BASE_FAILURE_RETRY_DELAY: Duration = Duration::from_secs(30);
 const MAX_FAILURE_RETRY_DELAY: Duration = Duration::from_secs(5 * 60);
@@ -22,7 +22,49 @@ const MAX_FAILURE_RETRY_DELAY: Duration = Duration::from_secs(5 * 60);
 /// bad credentials) doesn't loop forever.
 const MAX_FAILURE_RETRIES: u32 = 5;
 
+// Endpoints and constants for the runner-context Workload Identity Federation
+// mint (GCP STS token exchange + IAM Credentials `generateIdToken`).
+const STS_TOKEN_URL: &str = "https://sts.googleapis.com/v1/token";
+const IAM_GENERATE_ID_TOKEN_URL: &str = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{sa_email}:generateIdToken";
+const CLOUD_PLATFORM_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
+const TOKEN_EXCHANGE_GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:token-exchange";
+const SUBJECT_TOKEN_TYPE_ID_TOKEN: &str = "urn:ietf:params:oauth:token-type:id_token";
+const REQUESTED_TOKEN_TYPE_ACCESS_TOKEN: &str = "urn:ietf:params:oauth:token-type:access_token";
+const WIF_IDENTITY_TOKEN_DURATION: Duration = Duration::from_secs(60 * 60);
+const WIF_MINT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Env var carrying a Warp OIDC task-identity JWT (audience = the WIF provider
+/// resource name), injected by warp-server so a cold sandboxed runner can
+/// bootstrap its first IAP mint without calling the IAP-gated identity-token
+/// endpoint. This is NOT the IAP bearer token — it is the subject token for the
+/// STS exchange.
+const INJECTED_OIDC_JWT_ENV_VAR: &str = "WARP_IAP_OIDC_JWT";
+
 pub type PathResolver = Box<dyn Fn(&mut AppContext) -> BoxFuture<'static, Option<String>>>;
+
+/// Mints a Warp-signed OIDC identity token for a given audience. Implemented in
+/// the `app` crate over the managed-secrets client so this crate need not depend
+/// on the managed-secrets stack.
+pub trait IapIdentityTokenMinter: Send + Sync + 'static {
+    fn mint_identity_token(
+        &self,
+        audience: String,
+        requested_duration: Duration,
+    ) -> BoxFuture<'static, Result<String>>;
+}
+
+/// Lets a sandboxed Oz runner self-mint IAP tokens via Workload Identity
+/// Federation. Present only in runner context.
+#[derive(Clone)]
+pub struct ManagedIapMint {
+    minter: Arc<dyn IapIdentityTokenMinter>,
+}
+
+impl ManagedIapMint {
+    pub fn new(minter: Arc<dyn IapIdentityTokenMinter>) -> Self {
+        Self { minter }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct CachedToken {
@@ -52,15 +94,6 @@ pub enum IapCredentialsState {
         // in case the last token still works... we can try to use that for a couple more mins
         previous: Option<CachedToken>,
     },
-    /// Represents a terminal state in the iap creds state machine.
-    /// The gcloud refresh loop will never run, and an IAP challenge is logged
-    /// rather than triggering a refresh (we have no way to refresh a new token
-    /// from ambient agent context yet).
-    /// TODO(Isaiah/Jason): implement token refreshing scheme.
-    /// see: https://linear.app/warpdotdev/issue/REMOTE-1370/refresh-github-token
-    EnvInjected {
-        token: String,
-    },
 }
 
 impl IapCredentialsState {
@@ -69,7 +102,7 @@ impl IapCredentialsState {
             IapCredentialsState::Loaded(cached) => Some(cached.clone()),
             IapCredentialsState::Refreshing { previous }
             | IapCredentialsState::Failed { previous, .. } => previous.clone(),
-            IapCredentialsState::EnvInjected { .. } | IapCredentialsState::Missing => None,
+            IapCredentialsState::Missing => None,
         }
     }
 }
@@ -82,15 +115,10 @@ pub struct IapState {
 
 impl IapState {
     pub fn new(config: &IapConfig) -> Self {
-        let initial = std::env::var(INJECTED_TOKEN_ENV_VAR)
-            .ok()
-            .filter(|s| !s.is_empty())
-            .map(|token| IapCredentialsState::EnvInjected { token })
-            .unwrap_or(IapCredentialsState::Missing);
         Self {
             audiences: config.audiences.to_string(),
             service_account_email: config.service_account_email.to_string(),
-            inner: RwLock::new(initial),
+            inner: RwLock::new(IapCredentialsState::Missing),
         }
     }
 
@@ -102,7 +130,6 @@ impl IapState {
             // IAP challenge. Returning `None` lets the caller proceed without a
             // doomed token while the reactive refresh recovers.
             IapCredentialsState::Loaded(cached) => cached.valid_token(),
-            IapCredentialsState::EnvInjected { token } => Some(token.clone()),
             IapCredentialsState::Refreshing { previous }
             | IapCredentialsState::Failed { previous, .. } => {
                 previous.as_ref().and_then(CachedToken::valid_token)
@@ -159,6 +186,9 @@ impl http_client::iap::IapTokenProvider for IapState {
 pub struct IapManager {
     state: Option<Arc<IapState>>,
     path_resolver: PathResolver,
+    /// Runner-context Workload Identity Federation mint. When present, refreshes
+    /// self-mint via WIF instead of shelling out to gcloud.
+    managed_mint: Option<ManagedIapMint>,
     /// Number of consecutive failed fetches since the last success.
     consecutive_failures: u32,
 }
@@ -177,11 +207,13 @@ impl IapManager {
     pub fn new(
         state: Option<Arc<IapState>>,
         path_resolver: PathResolver,
+        managed_mint: Option<ManagedIapMint>,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         let mut manager = Self {
             state,
             path_resolver,
+            managed_mint,
             consecutive_failures: 0,
         };
         manager.start_refresh(ctx);
@@ -207,16 +239,6 @@ impl IapManager {
     }
 
     pub fn handle_challenge(&mut self, ctx: &mut ModelContext<Self>) {
-        let Some(state) = self.state.as_ref() else {
-            return;
-        };
-        if matches!(state.state(), IapCredentialsState::EnvInjected { .. }) {
-            log::warn!(
-                "Env-injected IAP token ({INJECTED_TOKEN_ENV_VAR}) was rejected by IAP; \
-                 token is likely stale — re-inject to recover"
-            );
-            return;
-        }
         self.consecutive_failures = 0;
         self.start_refresh(ctx);
     }
@@ -225,14 +247,19 @@ impl IapManager {
         let Some(state) = self.state.clone() else {
             return;
         };
-        // Don't touch state if a refresh is already running, or if we're
-        // in the terminal env-injected state (no refresh path exists).
-        if matches!(
-            state.state(),
-            IapCredentialsState::Refreshing { .. } | IapCredentialsState::EnvInjected { .. }
-        ) {
+        // Don't touch state if a refresh is already running.
+        if matches!(state.state(), IapCredentialsState::Refreshing { .. }) {
             return;
         }
+
+        // Runner context: self-mint via Workload Identity Federation. This is the
+        // only refresh path that works in a sandboxed Oz runner, which ships
+        // without gcloud.
+        if let Some(mint) = self.managed_mint.clone() {
+            self.start_wif_refresh(state, mint, ctx);
+            return;
+        }
+
         state.set_refreshing();
         ctx.emit(IapManagerEvent::StateChanged);
         ctx.notify();
@@ -272,36 +299,61 @@ impl IapManager {
                 })
                 .await
             },
-            move |manager, result, ctx| {
-                let Some(state) = manager.state.as_ref() else {
-                    return;
-                };
-                match result {
-                    Ok(cached) => {
-                        let expires_at = cached.expires_at;
-                        state.set_loaded(cached);
-                        manager.consecutive_failures = 0;
-                        log::info!("Warp Staging IAP token refreshed");
-                        ctx.emit(IapManagerEvent::StateChanged);
-                        ctx.notify();
-                        manager.schedule_next_refresh(expires_at, ctx);
-                    }
-                    Err(err) => {
-                        let message = format!("{err:#}");
-                        log::warn!("Warp Staging IAP token fetch failed: {message}");
-                        let is_first_failure_of_streak = manager.consecutive_failures == 0;
-                        state.set_failed(message.clone());
-                        ctx.emit(IapManagerEvent::RefreshFailed {
-                            message,
-                            is_first_failure_of_streak,
-                        });
-                        ctx.emit(IapManagerEvent::StateChanged);
-                        ctx.notify();
-                        manager.schedule_failure_retry(ctx);
-                    }
-                }
-            },
+            move |manager, result, ctx| manager.apply_refresh_result(result, ctx),
         );
+    }
+
+    /// Runner-context refresh: mint an IAP-valid ID token via Workload Identity
+    /// Federation (Warp OIDC JWT -> STS -> IAM `generateIdToken`). No gcloud.
+    fn start_wif_refresh(
+        &mut self,
+        state: Arc<IapState>,
+        mint: ManagedIapMint,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        state.set_refreshing();
+        ctx.emit(IapManagerEvent::StateChanged);
+        ctx.notify();
+
+        let minter = mint.minter.clone();
+        let iap_audience = state.audiences().to_string();
+        let service_account_email = state.service_account_email().to_string();
+
+        ctx.spawn(
+            async move { fetch_iap_token_via_wif(minter, iap_audience, service_account_email).await },
+            move |manager, result, ctx| manager.apply_refresh_result(result, ctx),
+        );
+    }
+
+    /// Shared completion handler for both the gcloud and WIF refresh paths.
+    fn apply_refresh_result(&mut self, result: Result<CachedToken>, ctx: &mut ModelContext<Self>) {
+        let Some(state) = self.state.as_ref() else {
+            return;
+        };
+        match result {
+            Ok(cached) => {
+                let expires_at = cached.expires_at;
+                state.set_loaded(cached);
+                self.consecutive_failures = 0;
+                log::info!("Warp Staging IAP token refreshed");
+                ctx.emit(IapManagerEvent::StateChanged);
+                ctx.notify();
+                self.schedule_next_refresh(expires_at, ctx);
+            }
+            Err(err) => {
+                let message = format!("{err:#}");
+                log::warn!("Warp Staging IAP token fetch failed: {message}");
+                let is_first_failure_of_streak = self.consecutive_failures == 0;
+                state.set_failed(message.clone());
+                ctx.emit(IapManagerEvent::RefreshFailed {
+                    message,
+                    is_first_failure_of_streak,
+                });
+                ctx.emit(IapManagerEvent::StateChanged);
+                ctx.notify();
+                self.schedule_failure_retry(ctx);
+            }
+        }
     }
 
     fn schedule_next_refresh(&mut self, expires_at: Instant, ctx: &mut ModelContext<Self>) {
@@ -371,6 +423,125 @@ impl Entity for IapManager {
 }
 
 impl SingletonEntity for IapManager {}
+
+#[derive(Serialize)]
+struct StsTokenExchangeRequest<'a> {
+    grant_type: &'a str,
+    audience: &'a str,
+    scope: &'a str,
+    requested_token_type: &'a str,
+    subject_token: &'a str,
+    subject_token_type: &'a str,
+}
+
+#[derive(Deserialize)]
+struct StsTokenExchangeResponse {
+    access_token: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GenerateIdTokenRequest<'a> {
+    audience: &'a str,
+    include_email: bool,
+}
+
+#[derive(Deserialize)]
+struct GenerateIdTokenResponse {
+    token: String,
+}
+
+/// Mints an IAP-valid ID token for a sandboxed Oz runner via Workload Identity
+/// Federation: Warp OIDC JWT -> GCP STS federated token -> IAM `generateIdToken`
+/// impersonating the IAP access service account. Requires no local gcloud.
+async fn fetch_iap_token_via_wif(
+    minter: Arc<dyn IapIdentityTokenMinter>,
+    iap_audience: String,
+    service_account_email: String,
+) -> Result<CachedToken> {
+    // The WIF provider resource name is the `aud` of the server-injected bootstrap
+    // JWT, so we read it straight off that token instead of carrying it as
+    // separate client config. The env var persists for the process lifetime, so
+    // its `aud` stays readable even once the token itself has expired.
+    let injected_jwt = std::env::var(INJECTED_OIDC_JWT_ENV_VAR)
+        .ok()
+        .filter(|jwt| !jwt.is_empty())
+        .ok_or_else(|| {
+            anyhow::anyhow!("{INJECTED_OIDC_JWT_ENV_VAR} is unset; cannot mint an IAP token via WIF")
+        })?;
+    let federation_audience = parse_aud_from_jwt(&injected_jwt)
+        .ok_or_else(|| anyhow::anyhow!("injected OIDC JWT has no readable `aud` claim"))?;
+
+    // Leg 1: obtain a Warp-signed OIDC JWT (audience = the WIF provider resource
+    // name). Prefer the injected bootstrap JWT while it's still valid so a cold
+    // runner needn't call the IAP-gated identity-token endpoint; once it expires,
+    // mint a fresh one via the server (now reachable through IAP).
+    let identity_token = if get_expires_at(&injected_jwt).is_ok() {
+        injected_jwt
+    } else {
+        minter
+            .mint_identity_token(federation_audience.clone(), WIF_IDENTITY_TOKEN_DURATION)
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to mint Warp identity token: {err:#}"))?
+    };
+
+    // Leg 2: exchange the JWT at GCP STS for a federated access token.
+    let response = http_client::Client::new()
+        .post(STS_TOKEN_URL)
+        .form(&StsTokenExchangeRequest {
+            grant_type: TOKEN_EXCHANGE_GRANT_TYPE,
+            audience: &federation_audience,
+            scope: CLOUD_PLATFORM_SCOPE,
+            requested_token_type: REQUESTED_TOKEN_TYPE_ACCESS_TOKEN,
+            subject_token: &identity_token,
+            subject_token_type: SUBJECT_TOKEN_TYPE_ID_TOKEN,
+        })
+        .timeout(WIF_MINT_REQUEST_TIMEOUT)
+        .send()
+        .await
+        .map_err(|err| anyhow::anyhow!("STS token exchange request failed: {err:#}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("STS token exchange failed (status {status}): {body}");
+    }
+    let sts_response: StsTokenExchangeResponse = response
+        .json()
+        .await
+        .map_err(|err| anyhow::anyhow!("failed to parse the STS response: {err:#}"))?;
+
+    // Leg 3: impersonate the IAP access service account to mint an ID token whose
+    // audience is the IAP OAuth client ID. IAM authorizes this only if the
+    // runner's federated identity holds roles/iam.serviceAccountTokenCreator on
+    // the service account.
+    let url = IAM_GENERATE_ID_TOKEN_URL.replace("{sa_email}", &service_account_email);
+    let response = http_client::Client::new()
+        .post(&url)
+        .bearer_auth(&sts_response.access_token)
+        .json(&GenerateIdTokenRequest {
+            audience: &iap_audience,
+            include_email: true,
+        })
+        .timeout(WIF_MINT_REQUEST_TIMEOUT)
+        .send()
+        .await
+        .map_err(|err| anyhow::anyhow!("generateIdToken request failed: {err:#}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("generateIdToken failed (status {status}): {body}");
+    }
+    let id_token_response: GenerateIdTokenResponse = response
+        .json()
+        .await
+        .map_err(|err| anyhow::anyhow!("failed to parse the generateIdToken response: {err:#}"))?;
+
+    let expires_at = get_expires_at(&id_token_response.token)?;
+    Ok(CachedToken {
+        token: id_token_response.token,
+        expires_at,
+    })
+}
 
 /// How long to wait for `auth print-identity-token` command to respond before killing it.
 const GCLOUD_TIMEOUT: Duration = Duration::from_secs(30);
@@ -468,13 +639,26 @@ fn get_expires_at(token: &str) -> Result<Instant> {
     Ok(Instant::now() + Duration::from_secs(secs_remaining))
 }
 
-fn parse_exp_from_jwt(token: &str) -> Option<u64> {
+fn decode_jwt_payload(token: &str) -> Option<serde_json::Value> {
     let payload_b64 = token.split('.').nth(1)?;
     let payload_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .decode(payload_b64)
         .ok()?;
-    let payload: serde_json::Value = serde_json::from_slice(&payload_bytes).ok()?;
-    payload.get("exp")?.as_u64()
+    serde_json::from_slice(&payload_bytes).ok()
+}
+
+fn parse_exp_from_jwt(token: &str) -> Option<u64> {
+    decode_jwt_payload(token)?.get("exp")?.as_u64()
+}
+
+/// Reads the `aud` claim from a JWT. `aud` may be a single string or an array of
+/// strings (per RFC 7519); we take the first entry in the array case.
+fn parse_aud_from_jwt(token: &str) -> Option<String> {
+    match decode_jwt_payload(token)?.get("aud")? {
+        serde_json::Value::String(aud) => Some(aud.clone()),
+        serde_json::Value::Array(auds) => auds.iter().find_map(|v| v.as_str().map(str::to_string)),
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/crates/warp_server_client/src/iap.rs
+++ b/crates/warp_server_client/src/iap.rs
@@ -38,7 +38,7 @@ const WIF_MINT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 /// bootstrap its first IAP mint without calling the IAP-gated identity-token
 /// endpoint. This is NOT the IAP bearer token — it is the subject token for the
 /// STS exchange.
-const INJECTED_OIDC_JWT_ENV_VAR: &str = "WARP_STAGING_IAP_BOOTSTRAP_JWT";
+const STAGING_IAP_BOOTSTRAP_TOKEN_ENV_VAR: &str = "WARP_STAGING_IAP_BOOTSTRAP_JWT";
 
 pub type PathResolver = Box<dyn Fn(&mut AppContext) -> BoxFuture<'static, Option<String>>>;
 
@@ -463,11 +463,11 @@ async fn fetch_iap_token_via_wif(
     // JWT, so we read it straight off that token instead of carrying it as
     // separate client config. The env var persists for the process lifetime, so
     // its `aud` stays readable even once the token itself has expired.
-    let injected_jwt = std::env::var(INJECTED_OIDC_JWT_ENV_VAR)
+    let injected_jwt = std::env::var(STAGING_IAP_BOOTSTRAP_TOKEN_ENV_VAR)
         .ok()
         .filter(|jwt| !jwt.is_empty())
         .ok_or_else(|| {
-            anyhow::anyhow!("{INJECTED_OIDC_JWT_ENV_VAR} is unset; cannot mint an IAP token via WIF")
+            anyhow::anyhow!("{STAGING_IAP_BOOTSTRAP_TOKEN_ENV_VAR} is unset; cannot mint an IAP token via WIF")
         })?;
     let federation_audience = parse_aud_from_jwt(&injected_jwt)
         .ok_or_else(|| anyhow::anyhow!("injected OIDC JWT has no readable `aud` claim"))?;

--- a/crates/warp_server_client/src/iap.rs
+++ b/crates/warp_server_client/src/iap.rs
@@ -254,9 +254,14 @@ impl IapManager {
             .is_some_and(|s| s.get_cached().is_some())
     }
 
-    /// Establishes IAP access for a blocking caller: triggers a refresh
-    // and if no valid token lands within [`IAP_ACCESS_TIMEOUT`], emits
-    // [`IapManagerEvent::AccessUnavailable`] so the caller can fail closed.
+    /// Establishes IAP access for a blocking caller: triggers a refresh and, if
+    /// no valid token lands within [`IAP_ACCESS_TIMEOUT`], emits
+    /// [`IapManagerEvent::AccessUnavailable`] so the caller can fail closed.
+    /// A no-op when IAP is inactive.
+    ///
+    /// Callers should subscribe before calling: on [`IapManagerEvent::StateChanged`],
+    /// check [`Self::has_valid_token`] and, once it returns `true`, proceed with the
+    /// IAP-gated request; treat [`IapManagerEvent::AccessUnavailable`] as fatal.
     pub fn ensure_access(&mut self, ctx: &mut ModelContext<Self>) {
         if self.state.is_none() {
             return;
@@ -774,7 +779,8 @@ mod cache {
     const CACHE_SKEW: Duration = Duration::from_secs(30);
 
     fn cache_path() -> std::path::PathBuf {
-        warp_core::paths::state_dir()
+        warp_core::paths::secure_state_dir()
+            .unwrap_or_else(warp_core::paths::state_dir)
             .join("staging")
             .join("iap_cache.jwt")
     }
@@ -799,34 +805,20 @@ mod cache {
     }
 
     fn write_atomic(token: &str) -> std::io::Result<()> {
-        let path = cache_path();
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        // Write to a sibling temp file then rename so a reader never observes a
-        // partially-written token.
-        let tmp = path.with_extension("tmp");
-        write_owner_only(&tmp, token.as_bytes())?;
-        std::fs::rename(&tmp, &path)
-    }
-
-    #[cfg(unix)]
-    fn write_owner_only(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
         use std::io::Write as _;
-        use std::os::unix::fs::OpenOptionsExt as _;
 
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(path)?;
-        file.write_all(bytes)
-    }
-
-    #[cfg(not(unix))]
-    fn write_owner_only(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
-        std::fs::write(path, bytes)
+        let path = cache_path();
+        let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+        std::fs::create_dir_all(parent)?;
+        // Write to a uniquely-named temp file in the same dir, then atomically
+        // persist it over the target: readers never observe a partial token,
+        // concurrent writers don't share a temp path, and the temp file is
+        // cleaned up on drop if any step before `persist` fails. `NamedTempFile`
+        // is created owner-only (0600) on unix.
+        let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
+        tmp.write_all(token.as_bytes())?;
+        tmp.persist(&path)?;
+        Ok(())
     }
 }
 

--- a/crates/warp_server_client/src/iap.rs
+++ b/crates/warp_server_client/src/iap.rs
@@ -22,6 +22,12 @@ const MAX_FAILURE_RETRY_DELAY: Duration = Duration::from_secs(5 * 60);
 /// bad credentials) doesn't loop forever.
 const MAX_FAILURE_RETRIES: u32 = 5;
 
+/// Upper bound on establishing IAP access for a blocking caller (e.g. a one-shot
+/// CLI command) before giving up, rather than hanging or firing a doomed (401)
+/// warp-server request. Generous enough to cover a couple of STS/IAM round trips
+/// plus a retry.
+const IAP_ACCESS_TIMEOUT: Duration = Duration::from_secs(60);
+
 // Endpoints and constants for the runner-context Workload Identity Federation
 // mint (GCP STS token exchange + IAM Credentials `generateIdToken`).
 const STS_TOKEN_URL: &str = "https://sts.googleapis.com/v1/token";
@@ -194,6 +200,9 @@ pub struct IapManager {
 
 pub enum IapManagerEvent {
     StateChanged,
+    /// Emitted when IAP access could not be established within the gate timeout,
+    /// so a blocking caller can fail closed instead of hanging.
+    AccessUnavailable,
     RefreshFailed {
         /// A human-readable error message describing why the refresh failed.
         message: String,
@@ -235,6 +244,32 @@ impl IapManager {
     /// a `ModelContext` without reaching through `ServerApi`.
     pub fn iap_state(&self) -> Option<Arc<IapState>> {
         self.state.clone()
+    }
+
+    /// Returns `true` when a currently-valid (unexpired) IAP token is available.
+    /// Used to gate warp-server requests until IAP access is established.
+    pub fn has_valid_token(&self) -> bool {
+        self.state
+            .as_ref()
+            .is_some_and(|s| s.get_cached().is_some())
+    }
+
+    /// Establishes IAP access for a blocking caller: triggers a refresh
+    // and if no valid token lands within [`IAP_ACCESS_TIMEOUT`], emits
+    // [`IapManagerEvent::AccessUnavailable`] so the caller can fail closed.
+    pub fn ensure_access(&mut self, ctx: &mut ModelContext<Self>) {
+        if self.state.is_none() {
+            return;
+        }
+        self.start_refresh(ctx);
+        ctx.spawn(
+            async { Timer::after(IAP_ACCESS_TIMEOUT).await },
+            |manager, _, ctx| {
+                if !manager.has_valid_token() {
+                    ctx.emit(IapManagerEvent::AccessUnavailable);
+                }
+            },
+        );
     }
 
     pub fn handle_challenge(&mut self, ctx: &mut ModelContext<Self>) {
@@ -310,6 +345,18 @@ impl IapManager {
         mint: ManagedIapMint,
         ctx: &mut ModelContext<Self>,
     ) {
+        // Fast path: reuse a fresh IAP token cache. This is actually required by
+        // child processes when the main process spawns a child oz sub-process...
+        // i.e. GCP SDK calling `oz federate issue-token --audience warp-cloud-agent-otel`
+        if let Some(cached) = cache::read() {
+            let expires_at = cached.expires_at;
+            state.set_loaded(cached);
+            ctx.emit(IapManagerEvent::StateChanged);
+            ctx.notify();
+            self.schedule_next_refresh(expires_at, ctx);
+            return;
+        }
+
         state.set_refreshing();
         ctx.emit(IapManagerEvent::StateChanged);
         ctx.notify();
@@ -336,7 +383,11 @@ impl IapManager {
                     injected_jwt,
                     iap_audience,
                     service_account_email,
-                    &WifEndpoints::production(),
+                    &WifEndpoints {
+                        sts_token_url: STS_TOKEN_URL.to_string(),
+                        iam_generate_id_token_url_template: IAM_GENERATE_ID_TOKEN_URL
+                            .to_string(),
+                    },
                 )
                 .await
             },
@@ -352,6 +403,12 @@ impl IapManager {
         match result {
             Ok(cached) => {
                 let expires_at = cached.expires_at;
+                // Publish for short-lived child `oz` processes to reuse
+                // i.e. `oz federate issue-token --audience warp-cloud-agent-otel`
+                // needs to transit IAP to get the token from warp-server
+                if self.managed_mint.is_some() {
+                    cache::write(&cached.token);
+                }
                 state.set_loaded(cached);
                 self.consecutive_failures = 0;
                 log::info!("Warp Staging IAP token refreshed");
@@ -470,22 +527,13 @@ struct GenerateIdTokenResponse {
     token: String,
 }
 
-/// GCP endpoints for the WIF mint. `production()` targets the real Google
-/// endpoints; tests override them to point at a mock server.
+/// GCP endpoints for the WIF mint. The production call site passes the real
+/// Google endpoint consts; tests override them to point at a mock server.
 struct WifEndpoints {
     sts_token_url: String,
     /// `generateIdToken` URL carrying a `{sa_email}` placeholder for the
     /// impersonated service account.
     iam_generate_id_token_url_template: String,
-}
-
-impl WifEndpoints {
-    fn production() -> Self {
-        Self {
-            sts_token_url: STS_TOKEN_URL.to_string(),
-            iam_generate_id_token_url_template: IAM_GENERATE_ID_TOKEN_URL.to_string(),
-        }
-    }
 }
 
 /// Leg 1 of the WIF mint: pick the OIDC subject token for the STS exchange.
@@ -703,6 +751,96 @@ fn parse_aud_from_jwt(token: &str) -> Option<String> {
         serde_json::Value::Array(auds) => auds.iter().find_map(|v| v.as_str().map(str::to_string)),
         _ => None,
     }
+}
+
+/// On-disk cache of the current IAP token, written by the long-lived parent
+/// process (which keeps it fresh) so short-lived child `oz` processes can reuse
+/// it instead of each doing their own STS/IAM mint. The file stores the raw IAP
+/// JWT; validity is derived from its own `exp` claim on read.
+///
+/// This is a plain owner-only file rather than OS secure storage: it only exists
+/// in the staging Oz runner (headless Linux), where no keyring is available and
+/// the container already holds the bootstrap JWT / API key / GitHub token.
+#[cfg(not(target_family = "wasm"))]
+mod cache {
+    use std::time::Duration;
+
+    use instant::Instant;
+
+    use super::{CachedToken, get_expires_at};
+
+    /// Discard a cached token with less than this remaining, so we never hand back
+    /// a near-dead credential the mint path should refresh instead.
+    const CACHE_SKEW: Duration = Duration::from_secs(30);
+
+    fn cache_path() -> std::path::PathBuf {
+        warp_core::paths::state_dir()
+            .join("staging")
+            .join("iap_cache.jwt")
+    }
+
+    pub(super) fn read() -> Option<CachedToken> {
+        let token = std::fs::read_to_string(cache_path()).ok()?;
+        let token = token.trim().to_owned();
+        if token.is_empty() {
+            return None;
+        }
+        let expires_at = get_expires_at(&token).ok()?;
+        if expires_at <= Instant::now() + CACHE_SKEW {
+            return None;
+        }
+        Some(CachedToken { token, expires_at })
+    }
+
+    pub(super) fn write(token: &str) {
+        if let Err(err) = write_atomic(token) {
+            log::warn!("Failed to write IAP token cache: {err}");
+        }
+    }
+
+    fn write_atomic(token: &str) -> std::io::Result<()> {
+        let path = cache_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        // Write to a sibling temp file then rename so a reader never observes a
+        // partially-written token.
+        let tmp = path.with_extension("tmp");
+        write_owner_only(&tmp, token.as_bytes())?;
+        std::fs::rename(&tmp, &path)
+    }
+
+    #[cfg(unix)]
+    fn write_owner_only(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+        use std::io::Write as _;
+        use std::os::unix::fs::OpenOptionsExt as _;
+
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        file.write_all(bytes)
+    }
+
+    #[cfg(not(unix))]
+    fn write_owner_only(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+        std::fs::write(path, bytes)
+    }
+}
+
+/// On wasm there is no filesystem, and IAP self-minting never runs, so the cache
+/// is a no-op.
+#[cfg(target_family = "wasm")]
+mod cache {
+    use super::CachedToken;
+
+    pub(super) fn read() -> Option<CachedToken> {
+        None
+    }
+
+    pub(super) fn write(_token: &str) {}
 }
 
 #[cfg(test)]

--- a/crates/warp_server_client/src/iap.rs
+++ b/crates/warp_server_client/src/iap.rs
@@ -319,7 +319,27 @@ impl IapManager {
         let service_account_email = state.service_account_email().to_string();
 
         ctx.spawn(
-            async move { fetch_iap_token_via_wif(minter, iap_audience, service_account_email).await },
+            async move {
+                // The env var persists for the process lifetime, so its `aud` stays
+                // readable even once the token itself has expired, which is what
+                // refresh-time minting needs.
+                let injected_jwt = std::env::var(STAGING_IAP_BOOTSTRAP_TOKEN_ENV_VAR)
+                    .ok()
+                    .filter(|jwt| !jwt.is_empty())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "{STAGING_IAP_BOOTSTRAP_TOKEN_ENV_VAR} is unset; cannot mint an IAP token via WIF"
+                        )
+                    })?;
+                fetch_iap_token_via_wif(
+                    minter,
+                    injected_jwt,
+                    iap_audience,
+                    service_account_email,
+                    &WifEndpoints::production(),
+                )
+                .await
+            },
             move |manager, result, ctx| manager.apply_refresh_result(result, ctx),
         );
     }
@@ -450,43 +470,66 @@ struct GenerateIdTokenResponse {
     token: String,
 }
 
+/// GCP endpoints for the WIF mint. `production()` targets the real Google
+/// endpoints; tests override them to point at a mock server.
+struct WifEndpoints {
+    sts_token_url: String,
+    /// `generateIdToken` URL carrying a `{sa_email}` placeholder for the
+    /// impersonated service account.
+    iam_generate_id_token_url_template: String,
+}
+
+impl WifEndpoints {
+    fn production() -> Self {
+        Self {
+            sts_token_url: STS_TOKEN_URL.to_string(),
+            iam_generate_id_token_url_template: IAM_GENERATE_ID_TOKEN_URL.to_string(),
+        }
+    }
+}
+
+/// Leg 1 of the WIF mint: pick the OIDC subject token for the STS exchange.
+/// Prefer the injected bootstrap JWT while it's still valid so a cold runner
+/// needn't call the IAP-gated identity-token endpoint; once it expires, mint a
+/// fresh one via the server (now reachable through IAP).
+async fn resolve_wif_identity_token(
+    injected_jwt: String,
+    federation_audience: &str,
+    minter: &Arc<dyn IapIdentityTokenMinter>,
+) -> Result<String> {
+    if get_expires_at(&injected_jwt).is_ok() {
+        Ok(injected_jwt)
+    } else {
+        minter
+            .mint_identity_token(federation_audience.to_string(), WIF_IDENTITY_TOKEN_DURATION)
+            .await
+            .map_err(|err| anyhow::anyhow!("failed to mint Warp identity token: {err:#}"))
+    }
+}
+
 /// Mints an IAP-valid ID token for a sandboxed Oz runner via Workload Identity
 /// Federation: Warp OIDC JWT -> GCP STS federated token -> IAM `generateIdToken`
 /// impersonating the IAP access service account. Requires no local gcloud.
 async fn fetch_iap_token_via_wif(
     minter: Arc<dyn IapIdentityTokenMinter>,
+    injected_jwt: String,
     iap_audience: String,
     service_account_email: String,
+    endpoints: &WifEndpoints,
 ) -> Result<CachedToken> {
     // The WIF provider resource name is the `aud` of the server-injected bootstrap
     // JWT, so we read it straight off that token instead of carrying it as
-    // separate client config. The env var persists for the process lifetime, so
-    // its `aud` stays readable even once the token itself has expired.
-    let injected_jwt = std::env::var(STAGING_IAP_BOOTSTRAP_TOKEN_ENV_VAR)
-        .ok()
-        .filter(|jwt| !jwt.is_empty())
-        .ok_or_else(|| {
-            anyhow::anyhow!("{STAGING_IAP_BOOTSTRAP_TOKEN_ENV_VAR} is unset; cannot mint an IAP token via WIF")
-        })?;
+    // separate client config.
     let federation_audience = parse_aud_from_jwt(&injected_jwt)
         .ok_or_else(|| anyhow::anyhow!("injected OIDC JWT has no readable `aud` claim"))?;
 
-    // Leg 1: obtain a Warp-signed OIDC JWT (audience = the WIF provider resource
-    // name). Prefer the injected bootstrap JWT while it's still valid so a cold
-    // runner needn't call the IAP-gated identity-token endpoint; once it expires,
-    // mint a fresh one via the server (now reachable through IAP).
-    let identity_token = if get_expires_at(&injected_jwt).is_ok() {
-        injected_jwt
-    } else {
-        minter
-            .mint_identity_token(federation_audience.clone(), WIF_IDENTITY_TOKEN_DURATION)
-            .await
-            .map_err(|err| anyhow::anyhow!("failed to mint Warp identity token: {err:#}"))?
-    };
+    // Leg 1: obtain the Warp-signed OIDC JWT used as the STS subject token.
+    let identity_token =
+        resolve_wif_identity_token(injected_jwt, &federation_audience, &minter).await?;
 
     // Leg 2: exchange the JWT at GCP STS for a federated access token.
     let response = http_client::Client::new()
-        .post(STS_TOKEN_URL)
+        .post(&endpoints.sts_token_url)
         .form(&StsTokenExchangeRequest {
             grant_type: TOKEN_EXCHANGE_GRANT_TYPE,
             audience: &federation_audience,
@@ -513,7 +556,9 @@ async fn fetch_iap_token_via_wif(
     // audience is the IAP OAuth client ID. IAM authorizes this only if the
     // runner's federated identity holds roles/iam.serviceAccountTokenCreator on
     // the service account.
-    let url = IAM_GENERATE_ID_TOKEN_URL.replace("{sa_email}", &service_account_email);
+    let url = endpoints
+        .iam_generate_id_token_url_template
+        .replace("{sa_email}", &service_account_email);
     let response = http_client::Client::new()
         .post(&url)
         .bearer_auth(&sts_response.access_token)

--- a/crates/warp_server_client/src/iap_tests.rs
+++ b/crates/warp_server_client/src/iap_tests.rs
@@ -58,6 +58,27 @@ fn parse_exp_from_jwt_not_a_jwt_is_none() {
 }
 
 #[test]
+fn parse_aud_from_jwt_reads_string_aud() {
+    let token = jwt_with_payload(r#"{"aud": "//iam.googleapis.com/projects/1/x", "sub": "y"}"#);
+    assert_eq!(
+        parse_aud_from_jwt(&token).as_deref(),
+        Some("//iam.googleapis.com/projects/1/x")
+    );
+}
+
+#[test]
+fn parse_aud_from_jwt_reads_first_array_aud() {
+    let token = jwt_with_payload(r#"{"aud": ["first-aud", "second-aud"]}"#);
+    assert_eq!(parse_aud_from_jwt(&token).as_deref(), Some("first-aud"));
+}
+
+#[test]
+fn parse_aud_from_jwt_missing_aud_is_none() {
+    let token = jwt_with_payload(r#"{"sub": "y"}"#);
+    assert_eq!(parse_aud_from_jwt(&token), None);
+}
+
+#[test]
 fn parse_exp_from_jwt_invalid_base64_is_none() {
     assert_eq!(parse_exp_from_jwt("aaa.!!!not-base64!!!.ccc"), None);
 }
@@ -117,4 +138,29 @@ fn get_cached_failed_uses_valid_previous_token() {
     state.set_loaded(cached("prev-token", Some(Duration::from_secs(60))));
     state.set_failed("gcloud blew up".to_string());
     assert_eq!(state.get_cached().as_deref(), Some("prev-token"));
+}
+
+#[test]
+fn generate_id_token_request_uses_camel_case_include_email() {
+    let value = serde_json::to_value(GenerateIdTokenRequest {
+        audience: "iap-client-id",
+        include_email: true,
+    })
+    .unwrap();
+    assert_eq!(value["audience"], "iap-client-id");
+    assert_eq!(value["includeEmail"], true);
+}
+
+#[test]
+fn generate_id_token_response_parses_token() {
+    let parsed: GenerateIdTokenResponse =
+        serde_json::from_str(r#"{"token": "an-id-token"}"#).unwrap();
+    assert_eq!(parsed.token, "an-id-token");
+}
+
+#[test]
+fn sts_response_parses_and_ignores_extra_fields() {
+    let parsed: StsTokenExchangeResponse =
+        serde_json::from_str(r#"{"access_token": "federated", "expires_in": 3600}"#).unwrap();
+    assert_eq!(parsed.access_token, "federated");
 }

--- a/crates/warp_server_client/src/iap_tests.rs
+++ b/crates/warp_server_client/src/iap_tests.rs
@@ -1,8 +1,12 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use base64::Engine;
+use futures::executor::block_on;
 use instant::Instant;
-use warp_core::channel::IapConfig;
+use warp_core::channel::{ChannelState, IapConfig};
+use warpui_core::r#async::BoxFuture;
 
 use super::*;
 
@@ -163,4 +167,190 @@ fn sts_response_parses_and_ignores_extra_fields() {
     let parsed: StsTokenExchangeResponse =
         serde_json::from_str(r#"{"access_token": "federated", "expires_in": 3600}"#).unwrap();
     assert_eq!(parsed.access_token, "federated");
+}
+
+/// Records how many times it was asked to mint, so tests can assert whether the
+/// injected-JWT fast path or the minter fallback was taken.
+struct FakeMinter {
+    calls: Arc<AtomicUsize>,
+    token: String,
+}
+
+impl IapIdentityTokenMinter for FakeMinter {
+    fn mint_identity_token(
+        &self,
+        _audience: String,
+        _requested_duration: Duration,
+    ) -> BoxFuture<'static, anyhow::Result<String>> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let token = self.token.clone();
+        Box::pin(async move { Ok(token) })
+    }
+}
+
+fn fake_minter(token: &str) -> (Arc<dyn IapIdentityTokenMinter>, Arc<AtomicUsize>) {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let minter: Arc<dyn IapIdentityTokenMinter> = Arc::new(FakeMinter {
+        calls: calls.clone(),
+        token: token.to_string(),
+    });
+    (minter, calls)
+}
+
+fn bootstrap_jwt(aud: &str, exp: u64) -> String {
+    jwt_with_payload(&format!(r#"{{"aud":"{aud}","exp":{exp}}}"#))
+}
+
+fn wif_endpoints(base: &str) -> WifEndpoints {
+    WifEndpoints {
+        sts_token_url: format!("{base}/v1/token"),
+        iam_generate_id_token_url_template: format!(
+            "{base}/v1/projects/-/serviceAccounts/{{sa_email}}:generateIdToken"
+        ),
+    }
+}
+
+const TEST_SA_EMAIL: &str = "iap-access@example.iam.gserviceaccount.com";
+
+#[test]
+fn resolve_wif_identity_token_prefers_valid_injected_jwt() {
+    let (minter, calls) = fake_minter("freshly-minted");
+    let injected = bootstrap_jwt("//iam/providers/p", now_unix() + 3600);
+
+    let token = block_on(resolve_wif_identity_token(
+        injected.clone(),
+        "//iam/providers/p",
+        &minter,
+    ))
+    .unwrap();
+
+    assert_eq!(token, injected);
+    assert_eq!(calls.load(Ordering::SeqCst), 0, "minter must not be called");
+}
+
+#[test]
+fn resolve_wif_identity_token_mints_when_injected_expired() {
+    let (minter, calls) = fake_minter("freshly-minted");
+    let injected = bootstrap_jwt("//iam/providers/p", 1);
+
+    let token = block_on(resolve_wif_identity_token(
+        injected,
+        "//iam/providers/p",
+        &minter,
+    ))
+    .unwrap();
+
+    assert_eq!(token, "freshly-minted");
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn fetch_iap_token_via_wif_returns_token_on_success() {
+    let mut server = ChannelState::mock_server();
+    let base = server.url();
+
+    let sts = server
+        .mock("POST", "/v1/token")
+        .with_status(200)
+        .with_body(r#"{"access_token":"federated-abc"}"#)
+        .create();
+    let id_token = jwt_with_payload(&format!(r#"{{"exp":{}}}"#, now_unix() + 3600));
+    let iam = server
+        .mock(
+            "POST",
+            mockito::Matcher::Regex(r"/serviceAccounts/.*:generateIdToken$".to_string()),
+        )
+        .match_header("authorization", "Bearer federated-abc")
+        .with_status(200)
+        .with_body(format!(r#"{{"token":"{id_token}"}}"#))
+        .create();
+
+    let (minter, calls) = fake_minter("unused");
+    let injected = bootstrap_jwt("//iam/providers/oz-oidc-staging-iap", now_unix() + 3600);
+    let endpoints = wif_endpoints(&base);
+
+    let cached = block_on(fetch_iap_token_via_wif(
+        minter,
+        injected,
+        "iap-client-id".to_string(),
+        TEST_SA_EMAIL.to_string(),
+        &endpoints,
+    ))
+    .unwrap();
+
+    assert_eq!(cached.token, id_token);
+    assert!(cached.expires_at > Instant::now());
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "a valid injected JWT should skip the minter"
+    );
+    sts.assert();
+    iam.assert();
+}
+
+#[test]
+fn fetch_iap_token_via_wif_errors_on_sts_failure() {
+    let mut server = ChannelState::mock_server();
+    let base = server.url();
+    let _sts = server
+        .mock("POST", "/v1/token")
+        .with_status(400)
+        .with_body("bad subject token")
+        .create();
+
+    let (minter, _) = fake_minter("unused");
+    let injected = bootstrap_jwt("//iam/providers/p", now_unix() + 3600);
+    let endpoints = wif_endpoints(&base);
+
+    let err = block_on(fetch_iap_token_via_wif(
+        minter,
+        injected,
+        "iap-client-id".to_string(),
+        TEST_SA_EMAIL.to_string(),
+        &endpoints,
+    ))
+    .unwrap_err();
+
+    assert!(
+        err.to_string().contains("STS token exchange failed"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
+fn fetch_iap_token_via_wif_errors_on_iam_failure() {
+    let mut server = ChannelState::mock_server();
+    let base = server.url();
+    let _sts = server
+        .mock("POST", "/v1/token")
+        .with_status(200)
+        .with_body(r#"{"access_token":"federated-abc"}"#)
+        .create();
+    let _iam = server
+        .mock(
+            "POST",
+            mockito::Matcher::Regex(r"/serviceAccounts/.*:generateIdToken$".to_string()),
+        )
+        .with_status(403)
+        .with_body("permission denied")
+        .create();
+
+    let (minter, _) = fake_minter("unused");
+    let injected = bootstrap_jwt("//iam/providers/p", now_unix() + 3600);
+    let endpoints = wif_endpoints(&base);
+
+    let err = block_on(fetch_iap_token_via_wif(
+        minter,
+        injected,
+        "iap-client-id".to_string(),
+        TEST_SA_EMAIL.to_string(),
+        &endpoints,
+    ))
+    .unwrap_err();
+
+    assert!(
+        err.to_string().contains("generateIdToken failed"),
+        "unexpected error: {err:#}"
+    );
 }


### PR DESCRIPTION
## What
Sandboxed Oz runners authenticate to staging through IAP by self-minting an IAP-valid ID token via Workload Identity Federation, replacing the server-injected IAP bearer token.

## Why
After IAP was enabled on staging, runners 403 at the proxy — the injected `WARP_IAP_TOKEN` was minted as warp-server's own SA identity (not an authorized IAP member) and never refreshed (REMOTE-1370). The runner image has no `gcloud`/ADC, so the existing gcloud path can't run there.

## How
Mint chain (native HTTP, no gcloud):
1. **Warp OIDC JWT** (audience = the `oz-agents` WIF provider). Leg 1 prefers a server-injected **bootstrap JWT** (`WARP_STAGING_IAP_BOOTSTRAP_JWT`) so a cold runner needn't call the IAP-gated identity-token endpoint (chicken-and-egg: minting the JWT via `issue_task_identity_token` itself goes through IAP-gated warp-server). Once the injected JWT expires, refreshes mint a fresh one via `issue_task_identity_token` — reachable through IAP by then because a valid IAP token exists.
2. **GCP STS** token exchange → federated access token.
3. **IAM `generateIdToken`** impersonating `iap-access@` (audience = the IAP OAuth client ID), an authorized IAP member.

Flows through the existing `IapManager` lifecycle (proactive + reactive refresh), closing the no-refresh gap.

## Notes
- The **WIF provider audience is derived from the bootstrap JWT's `aud` claim** — no client config needed. The server already mints that JWT with `aud` = the provider resource name (GCP STS requires the subject token's `aud` to match the provider), so the value is already delivered to the runner. The env var persists for the process lifetime, so its `aud` stays readable even after the token itself expires (needed for refresh-time minting). This keeps a single source of truth (terraform → warp-server config) with no third copy in channel config.
- Gated on runner context (ambient-agent run id); local staging clients keep the gcloud impersonation path.
- Old `WARP_IAP_TOKEN` handling removed.
- Minting abstracted behind `IapIdentityTokenMinter` (impl in the app crate) so `warp_server_client` doesn't depend on the managed-secrets stack.

## Dependencies (must land together)
- warp-terraform: `serviceAccountTokenCreator` for the staging Oz Warp-team principalSet on `iap-access@`.
- warp-server: inject `WARP_STAGING_IAP_BOOTSTRAP_JWT` (a task-identity OIDC JWT whose `aud` is the WIF-provider resource name) into runner containers — separate PR. This JWT's `aud` is now the sole source of the federation audience, so it must be set correctly.

## Testing
- `cargo nextest run -p warp_server_client iap` — 21 passing (incl. new `aud`-parsing cases).
- `cargo check -p warp` (lib.rs wiring) passes; `cargo clippy -p warp_server_client -p warp_core --all-targets --tests -- -D warnings` clean.
- Not exercised end-to-end (needs the grant + injection live).

[Conversation](https://staging.warp.dev/conversation/89ccf173-dc13-461c-b90f-6bee7612f989)

Co-Authored-By: Oz <oz-agent@warp.dev>

