### PR TITLE
Open new windows on the hotkey window's screen and focus them

### DIFF
--- a/app/src/root_view.rs
+++ b/app/src/root_view.rs
@@ -32,7 +32,7 @@ use warpui::presenter::ChildView;
 use warpui::rendering::OnGPUDeviceSelected;
 use warpui::windowing::WindowManager;
 use warpui::{
-    AddWindowOptions, AppContext, DisplayId, Element, Entity, EntityId, FocusContext,
+    AddWindowOptions, AppContext, DisplayId, DisplayIdx, Element, Entity, EntityId, FocusContext,
     NextNewWindowsHasThisWindowsBoundsUponClose, SingletonEntity, TypedActionView, View,
     ViewContext, ViewHandle, WindowId, id,
 };
@@ -889,12 +889,21 @@ pub(crate) fn open_new_with_workspace_source(
 ) -> (WindowId, ViewHandle<RootView>) {
     let global_resource_handles = GlobalResourceHandlesProvider::as_ref(ctx).get().clone();
     let window_settings = WindowSettings::as_ref(ctx);
+    let opened_from_quake_window = opening_from_quake_window(ctx);
     let options = default_window_options(window_settings, ctx);
-    ctx.add_window(options, |ctx| {
+    let result = ctx.add_window(options, |ctx| {
         let mut view = RootView::new(global_resource_handles, source, ctx);
         view.focus(ctx);
         view
-    })
+    });
+    if opened_from_quake_window {
+        // The dedicated hotkey window is a non-activating panel, so opening a
+        // regular window from it does not bring the app forward on its own.
+        // Activate so the new window is focused in place on the current screen,
+        // matching a normal new-window open (see #13514).
+        ctx.windows().activate_app();
+    }
+    result
 }
 
 pub(crate) fn open_new_from_path(
@@ -1240,11 +1249,108 @@ fn open_new_tab_insert_subshell_command_and_bootstrap_if_supported(
     });
 }
 
+/// Default size of a newly-opened regular window, mirroring the platform
+/// default used when no other size is available (`INITIAL_WINDOW_WIDTH` /
+/// `INITIAL_WINDOW_HEIGHT` in the macOS window backend). Used when opening a
+/// window from the dedicated hotkey window, where there is no meaningful
+/// previous regular-window size to inherit.
+const DEFAULT_NEW_WINDOW_WIDTH: f32 = 1280.0;
+const DEFAULT_NEW_WINDOW_HEIGHT: f32 = 800.0;
+
+/// Returns bounds for a window of `size` centered on `screen`.
+///
+/// The size is clamped so the window never overflows the display, and the origin
+/// is recomputed for the (possibly clamped) size so it stays centered — used when
+/// opening a new window from the dedicated hotkey (quake) window so it appears on
+/// the hotkey window's current screen instead of inheriting a stale last-closed
+/// position on another display or the quake panel's pinned-strip geometry.
+fn window_bounds_centered_on(size: Vector2F, screen: RectF) -> WindowBounds {
+    let size = vec2f(size.x().min(screen.width()), size.y().min(screen.height()));
+    let origin = vec2f(
+        screen.origin().x() + (screen.width() - size.x()) * 0.5,
+        screen.origin().y() + (screen.height() - size.y()) * 0.5,
+    );
+    WindowBounds::ExactPosition(RectF::new(origin, size))
+}
+
+/// Returns bounds for a default-sized regular window centered on `screen`.
+fn centered_default_window_bounds(screen: RectF) -> WindowBounds {
+    window_bounds_centered_on(
+        vec2f(DEFAULT_NEW_WINDOW_WIDTH, DEFAULT_NEW_WINDOW_HEIGHT),
+        screen,
+    )
+}
+
+/// True when a new window is being opened while the dedicated hotkey (quake)
+/// window is the active window. In that case the new regular window should open
+/// on the hotkey window's current screen and be activated, rather than following
+/// the usual last-closed / cascade placement (which sends it to another display
+/// and, since the hotkey window is a non-activating panel, leaves it unfocused).
+fn opening_from_quake_window(ctx: &AppContext) -> bool {
+    let active_window_id = ctx.windows().active_window();
+    quake_mode_window_is_open()
+        && active_window_id.is_some()
+        && active_window_id == quake_mode_window_id()
+}
+
+/// Returns the bounds of the display the dedicated hotkey (quake) window is on.
+///
+/// The hotkey window is a non-activating panel, so it can be the key window on a
+/// non-main display while the app itself is inactive — in which case
+/// `NSScreen.mainScreen` (what `active_display_bounds` reports) points at the
+/// wrong display. Locate the display that actually contains the panel instead,
+/// falling back to the reported active display if it can't be resolved.
+fn hotkey_window_screen(ctx: &AppContext) -> RectF {
+    let panel_center = quake_mode_window_id()
+        .and_then(|panel_id| ctx.window_bounds(&panel_id))
+        .map(|bounds| {
+            vec2f(
+                bounds.origin().x() + bounds.width() * 0.5,
+                bounds.origin().y() + bounds.height() * 0.5,
+            )
+        });
+    if let Some(center) = panel_center {
+        let display_count = ctx.windows().display_count();
+        let candidates = std::iter::once(DisplayIdx::Primary)
+            .chain((0..display_count.saturating_sub(1)).map(DisplayIdx::External));
+        for idx in candidates {
+            if let Some(screen) = ctx.windows().bounds_for_display_idx(idx) {
+                if screen.contains_point(center) {
+                    return screen;
+                }
+            }
+        }
+    }
+    ctx.windows().active_display_bounds()
+}
+
 /// Returns the common configuration for a new "regular" window (not Quake Mode).
 fn default_window_options(window_settings: &WindowSettings, ctx: &AppContext) -> AddWindowOptions {
-    let (inherited_bounds, window_style) = ctx.next_window_bounds_and_style();
-    let next_bounds =
-        bounds_for_opening_at_custom_window_size(inherited_bounds, window_settings, ctx);
+    let (next_bounds, window_style) = if opening_from_quake_window(ctx) {
+        let screen = hotkey_window_screen(ctx);
+        // Respect a configured custom new-window size, but keep the window
+        // centered on and clamped to the hotkey window's screen: run the custom
+        // size logic to get the final size, then recenter it (the custom-size
+        // helper keeps the incoming origin, which would otherwise leave the
+        // window off-center or overflowing the display).
+        let sized = bounds_for_opening_at_custom_window_size(
+            centered_default_window_bounds(screen),
+            window_settings,
+            ctx,
+        );
+        let size = match sized {
+            WindowBounds::ExactPosition(rect) => rect.size(),
+            WindowBounds::ExactSize(size) => size,
+            WindowBounds::Default => vec2f(DEFAULT_NEW_WINDOW_WIDTH, DEFAULT_NEW_WINDOW_HEIGHT),
+        };
+        (window_bounds_centered_on(size, screen), WindowStyle::Normal)
+    } else {
+        let (inherited_bounds, window_style) = ctx.next_window_bounds_and_style();
+        (
+            bounds_for_opening_at_custom_window_size(inherited_bounds, window_settings, ctx),
+            window_style,
+        )
+    };
 
     AddWindowOptions {
         window_style,

--- a/app/src/root_view_tests.rs
+++ b/app/src/root_view_tests.rs
@@ -253,6 +253,105 @@ fn test_sync_noop_when_local_onboarding_not_completed() {
     });
 }
 
+/// Regression test for #13514: a regular window opened from the dedicated
+/// hotkey (quake) window must land on that window's current screen, centered at
+/// the default size — not on the primary display via a stale last-closed
+/// position, and not inheriting the quake panel's pinned-strip geometry.
+///
+/// Given a secondary display at `x = 1920`, the new window's bounds must be
+/// centered inside that display and stay fully within it horizontally.
+#[test]
+fn test_centered_default_window_bounds_centers_on_the_given_screen() {
+    use pathfinder_geometry::rect::RectF;
+    use pathfinder_geometry::vector::vec2f;
+    use warpui::platform::WindowBounds;
+
+    let secondary = RectF::new(vec2f(1920.0, 0.0), vec2f(1920.0, 1080.0));
+
+    let WindowBounds::ExactPosition(rect) = super::centered_default_window_bounds(secondary) else {
+        panic!("expected ExactPosition bounds on the active screen");
+    };
+
+    // Default size (fits within the 1920x1080 display).
+    assert_eq!(rect.size(), vec2f(1280.0, 800.0));
+    // Centered within the secondary display.
+    assert_eq!(
+        rect.origin(),
+        vec2f(1920.0 + (1920.0 - 1280.0) / 2.0, (1080.0 - 800.0) / 2.0)
+    );
+    // The window stays on the secondary display, not the primary one at x < 1920.
+    assert!(rect.origin().x() >= 1920.0);
+    assert!(rect.origin().x() + rect.size().x() <= 1920.0 + 1920.0);
+}
+
+/// The default window size is clamped to fit displays smaller than the default,
+/// so the new window never overflows the active screen.
+#[test]
+fn test_centered_default_window_bounds_clamps_to_small_screen() {
+    use pathfinder_geometry::rect::RectF;
+    use pathfinder_geometry::vector::vec2f;
+    use warpui::platform::WindowBounds;
+
+    let small = RectF::new(vec2f(0.0, 0.0), vec2f(1000.0, 600.0));
+
+    let WindowBounds::ExactPosition(rect) = super::centered_default_window_bounds(small) else {
+        panic!("expected ExactPosition bounds on the active screen");
+    };
+
+    assert_eq!(rect.size(), vec2f(1000.0, 600.0));
+    assert_eq!(rect.origin(), vec2f(0.0, 0.0));
+}
+
+/// A configured custom window size larger than the hotkey window's display must
+/// still be clamped to that display and re-centered, so a large rows/columns
+/// setting can't push the new window off the screen (#13514 follow-up).
+#[test]
+fn test_window_bounds_centered_on_clamps_and_recenters_oversized_size() {
+    use pathfinder_geometry::rect::RectF;
+    use pathfinder_geometry::vector::vec2f;
+    use warpui::platform::WindowBounds;
+
+    let secondary = RectF::new(vec2f(1920.0, 0.0), vec2f(1920.0, 1080.0));
+    // A custom size wider/taller than the display.
+    let oversized = vec2f(4000.0, 3000.0);
+
+    let WindowBounds::ExactPosition(rect) = super::window_bounds_centered_on(oversized, secondary)
+    else {
+        panic!("expected ExactPosition bounds on the active screen");
+    };
+
+    // Clamped to the display size...
+    assert_eq!(rect.size(), vec2f(1920.0, 1080.0));
+    // ...and pinned to the display's origin (centered for the clamped size).
+    assert_eq!(rect.origin(), vec2f(1920.0, 0.0));
+    // Never overflows the secondary display.
+    assert!(rect.origin().x() >= 1920.0);
+    assert!(rect.origin().x() + rect.size().x() <= 1920.0 + 1920.0);
+}
+
+/// A custom size smaller than the display stays centered on it (not pinned to a
+/// stale default-size origin).
+#[test]
+fn test_window_bounds_centered_on_centers_custom_size() {
+    use pathfinder_geometry::rect::RectF;
+    use pathfinder_geometry::vector::vec2f;
+    use warpui::platform::WindowBounds;
+
+    let secondary = RectF::new(vec2f(1920.0, 0.0), vec2f(1920.0, 1080.0));
+    let custom = vec2f(900.0, 500.0);
+
+    let WindowBounds::ExactPosition(rect) = super::window_bounds_centered_on(custom, secondary)
+    else {
+        panic!("expected ExactPosition bounds on the active screen");
+    };
+
+    assert_eq!(rect.size(), vec2f(900.0, 500.0));
+    assert_eq!(
+        rect.origin(),
+        vec2f(1920.0 + (1920.0 - 900.0) / 2.0, (1080.0 - 500.0) / 2.0)
+    );
+}
+
 /// The server-side flag should also be left untouched when it is already set,
 /// even if local onboarding is complete — avoids redundant server calls.
 #[test]


### PR DESCRIPTION
## Description

Opening a new window (⌘N / File → New Window) while the dedicated hotkey (quake) window is focused on a secondary display created the window on the wrong screen and left it unfocused — so on a multi-display setup it looked like nothing happened.

Two causes, both specific to the hotkey window being the active window:
- Placement came from `next_window_bounds_and_style`, which returns either a stale last-closed position (often on another display) or the hotkey panel's own pinned-strip geometry — never the panel's current screen. So the new window either jumped to another display or was created as a malformed strip cascaded off the panel.
- The hotkey window is a non-activating `NSPanel`, so creating a regular window from it does not bring the app forward, leaving the new window unfocused.

This scopes a fix to opening from the hotkey window: place a default-sized (1280×800) regular window centered on the hotkey window's screen, and activate the app so the new window is focused in place — matching a normal new-window open. The hotkey window's screen is resolved from the display that actually **contains the panel**, not `NSScreen.mainScreen`, because the panel can be key on a non-main display while the app is inactive (which is exactly when this bug triggers). A normal window → normal window ⌘N is unchanged. Changes are confined to `app/src/root_view.rs`.

## Linked Issue
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below.

Fixes #13514

## Testing
- [x] `cargo fmt -- --check`
- [x] `cargo check -p warp`
- [x] `cargo clippy -p warp --lib` (clean)
- [x] `cargo test -p warp --lib centered_default_window_bounds` — 2 new unit tests pass
- [x] I have manually tested my changes locally with `./script/run`

Added regression unit tests in `app/src/root_view_tests.rs` for the pure placement helper `centered_default_window_bounds` (centers a default-sized window on the active screen; clamps to displays smaller than the default). Manually verified on a real two-display macOS setup with separate Spaces: with the hotkey window focused on the secondary display, File → New Window now opens a normal 1280×800 window centered on that display and focused — previously it opened on the wrong display / as a malformed strip and stayed unfocused.

### Screenshots / Videos

Repro: dedicated hotkey window (quake mode) focused on the secondary display, then File → New Window.

![before and after](https://raw.githubusercontent.com/maxmilian/warp/assets/13514/before_after.jpg)

- **Before (master)**: the new window inherits the hotkey panel's pinned-strip geometry (a malformed, wide‑but‑short window) instead of opening as a usable window on the active screen.
- **After (this PR)**: the new window opens as a normal 1280×800 window centered on the hotkey panel's screen and is focused.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Open a new window from the dedicated hotkey window on the hotkey window's current screen and focus it, instead of on another display.
-->
