### PR TITLE
Enable Linux Wayland IME and guard against KDE cursor-area loops

### DIFF
--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -494,11 +494,14 @@ pub(super) struct EventLoop {
     state: State,
     proxy: EventLoopProxy<CustomEvent>,
     ime_enabled: bool,
-    /// Last IME cursor area sent to winit. On Wayland, used to skip redundant
-    /// `set_ime_cursor_area` calls (which can re-trigger IME events on some
-    /// compositors, notably KDE Plasma). On X11 this is still recorded but
-    /// identical areas are not skipped so the position nudge can run.
-    last_ime_cursor_area: Option<(LogicalPosition<f32>, LogicalSize<f32>)>,
+    /// Last IME cursor area sent to winit, keyed by the target window. On
+    /// Wayland, used to skip redundant `set_ime_cursor_area` calls (which can
+    /// re-trigger IME events on some compositors, notably KDE Plasma). The
+    /// window id is part of the key so focusing another Warp window with the
+    /// same logical rect still updates the newly focused surface. On X11 this
+    /// is still recorded but identical areas are not skipped so the position
+    /// nudge can run.
+    last_ime_cursor_area: Option<(WindowId, LogicalPosition<f32>, LogicalSize<f32>)>,
     /// Whether to downrank non-NVIDIA vulkan adapters. This is set to true when we detect a DRI3
     /// error that occurs when trying to present against a non-NVIDIA Vulkan adapter when the
     /// PRIME Profile is set to "Performance" mode.  It's not fully clear why this error occurs. Our
@@ -1845,15 +1848,18 @@ impl EventLoop {
             // Skip identical updates on Wayland only. On KDE, repeated
             // `set_ime_cursor_area` can re-fire IME enable/preedit events and
             // recreate a feedback loop with ActiveCursorPositionUpdated.
+            // Key by window so a focus switch to another surface with the same
+            // logical rect still sends set_ime_position to the new window.
             // On X11, always continue so the nudge below can defeat winit's
             // cached IME cursor area after WindowMoved/WindowResized.
-            if is_wayland && self.last_ime_cursor_area == Some((position, size)) {
+            let next_area = (active_window_id, position, size);
+            if is_wayland && self.last_ime_cursor_area == Some(next_area) {
                 return;
             }
-            self.last_ime_cursor_area = Some((position, size));
+            self.last_ime_cursor_area = Some(next_area);
 
             log::debug!(
-                "Updating IME cursor area to position=({:.1}, {:.1}) size=({:.1}, {:.1}) is_wayland={is_wayland}",
+                "Updating IME cursor area for window={active_window_id:?} position=({:.1}, {:.1}) size=({:.1}, {:.1}) is_wayland={is_wayland}",
                 position.x,
                 position.y,
                 size.width,

--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -494,9 +494,10 @@ pub(super) struct EventLoop {
     state: State,
     proxy: EventLoopProxy<CustomEvent>,
     ime_enabled: bool,
-    /// Last IME cursor area sent to winit. Used to skip redundant
+    /// Last IME cursor area sent to winit. On Wayland, used to skip redundant
     /// `set_ime_cursor_area` calls (which can re-trigger IME events on some
-    /// Wayland compositors, notably KDE Plasma).
+    /// compositors, notably KDE Plasma). On X11 this is still recorded but
+    /// identical areas are not skipped so the position nudge can run.
     last_ime_cursor_area: Option<(LogicalPosition<f32>, LogicalSize<f32>)>,
     /// Whether to downrank non-NVIDIA vulkan adapters. This is set to true when we detect a DRI3
     /// error that occurs when trying to present against a non-NVIDIA Vulkan adapter when the
@@ -1827,26 +1828,6 @@ impl EventLoop {
                 active_cursor_position.font_size,
             );
 
-            // Skip identical updates. On Wayland (especially KDE), repeated
-            // `set_ime_cursor_area` can re-fire IME enable/preedit events and
-            // recreate a feedback loop with ActiveCursorPositionUpdated.
-            if self.last_ime_cursor_area == Some((position, size)) {
-                return;
-            }
-            self.last_ime_cursor_area = Some((position, size));
-
-            log::debug!(
-                "Updating IME cursor area to position=({:.1}, {:.1}) size=({:.1}, {:.1})",
-                position.x,
-                position.y,
-                size.width,
-                size.height
-            );
-
-            // On X11, winit can cache the previous cursor area and ignore a
-            // subsequent set with the same value after WindowMoved/Resized.
-            // Nudge once then set the real position. Do NOT do this on Wayland:
-            // the extra call has been linked to IME event storms on KDE Plasma.
             let is_wayland = {
                 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
                 {
@@ -1860,6 +1841,29 @@ impl EventLoop {
                     false
                 }
             };
+
+            // Skip identical updates on Wayland only. On KDE, repeated
+            // `set_ime_cursor_area` can re-fire IME enable/preedit events and
+            // recreate a feedback loop with ActiveCursorPositionUpdated.
+            // On X11, always continue so the nudge below can defeat winit's
+            // cached IME cursor area after WindowMoved/WindowResized.
+            if is_wayland && self.last_ime_cursor_area == Some((position, size)) {
+                return;
+            }
+            self.last_ime_cursor_area = Some((position, size));
+
+            log::debug!(
+                "Updating IME cursor area to position=({:.1}, {:.1}) size=({:.1}, {:.1}) is_wayland={is_wayland}",
+                position.x,
+                position.y,
+                size.width,
+                size.height
+            );
+
+            // On X11, winit can cache the previous cursor area and ignore a
+            // subsequent set with the same value after WindowMoved/Resized.
+            // Nudge once then set the real position. Do NOT do this on Wayland:
+            // the extra call has been linked to IME event storms on KDE Plasma.
             if !is_wayland {
                 winit_window
                     .set_ime_position(LogicalPosition::new(position.x, position.y + 1.), size);

--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -494,6 +494,10 @@ pub(super) struct EventLoop {
     state: State,
     proxy: EventLoopProxy<CustomEvent>,
     ime_enabled: bool,
+    /// Last IME cursor area sent to winit. Used to skip redundant
+    /// `set_ime_cursor_area` calls (which can re-trigger IME events on some
+    /// Wayland compositors, notably KDE Plasma).
+    last_ime_cursor_area: Option<(LogicalPosition<f32>, LogicalSize<f32>)>,
     /// Whether to downrank non-NVIDIA vulkan adapters. This is set to true when we detect a DRI3
     /// error that occurs when trying to present against a non-NVIDIA Vulkan adapter when the
     /// PRIME Profile is set to "Performance" mode.  It's not fully clear why this error occurs. Our
@@ -523,6 +527,7 @@ impl EventLoop {
             state: Default::default(),
             proxy,
             ime_enabled: false,
+            last_ime_cursor_area: None,
             downrank_non_nvidia_vulkan_adapters: false,
             #[cfg(target_family = "wasm")]
             soft_keyboard_manager: None,
@@ -1519,14 +1524,28 @@ impl EventLoop {
     fn handle_ime_event(&mut self, winit_window_id: WinitWindowId, event: ImeEvent) {
         match event {
             winit::event::Ime::Enabled => {
+                // Only push a cursor-position update on the disabled→enabled edge.
+                // Re-emitting on every `Enabled` (which some Wayland compositors send
+                // after each `set_ime_cursor_area`) previously fed an infinite
+                // Enabled → update_ime_position → set_ime_cursor_area → Enabled loop
+                // on KDE Plasma.
+                let was_enabled = self.ime_enabled;
                 self.ime_enabled = true;
-                self.ui_app
-                    .update(|ctx| ctx.report_active_cursor_position_update());
+                log::debug!("IME enabled (was_enabled={was_enabled})");
+                if !was_enabled {
+                    self.ui_app
+                        .update(|ctx| ctx.report_active_cursor_position_update());
+                }
             }
             winit::event::Ime::Preedit(preedit_text, cursor_position) => {
                 if !self.ime_enabled {
                     return;
                 }
+
+                log::debug!(
+                    "IME preedit: text_len={} cursor={cursor_position:?}",
+                    preedit_text.len()
+                );
 
                 let Some(window_state) = self.state.windows.get_mut(&winit_window_id) else {
                     return;
@@ -1547,6 +1566,8 @@ impl EventLoop {
                 });
             }
             winit::event::Ime::Commit(chars) => {
+                log::debug!("IME commit: chars_len={}", chars.len());
+
                 let Some(window_state) = self.state.windows.get_mut(&winit_window_id) else {
                     return;
                 };
@@ -1564,7 +1585,9 @@ impl EventLoop {
                 window_callbacks.dispatch_event(TypedCharacters { chars });
             }
             winit::event::Ime::Disabled => {
+                log::debug!("IME disabled");
                 self.ime_enabled = false;
+                self.last_ime_cursor_area = None;
             }
         };
     }
@@ -1803,9 +1826,44 @@ impl EventLoop {
                 active_cursor_position.font_size,
                 active_cursor_position.font_size,
             );
-            // TODO(abhishek): We make sure that the position is different than last time to prevent winit from
-            // caching the old position and not properly updating on `WindowMoved` or `WindowResized` events.
-            winit_window.set_ime_position(LogicalPosition::new(position.x, position.y + 1.), size);
+
+            // Skip identical updates. On Wayland (especially KDE), repeated
+            // `set_ime_cursor_area` can re-fire IME enable/preedit events and
+            // recreate a feedback loop with ActiveCursorPositionUpdated.
+            if self.last_ime_cursor_area == Some((position, size)) {
+                return;
+            }
+            self.last_ime_cursor_area = Some((position, size));
+
+            log::debug!(
+                "Updating IME cursor area to position=({:.1}, {:.1}) size=({:.1}, {:.1})",
+                position.x,
+                position.y,
+                size.width,
+                size.height
+            );
+
+            // On X11, winit can cache the previous cursor area and ignore a
+            // subsequent set with the same value after WindowMoved/Resized.
+            // Nudge once then set the real position. Do NOT do this on Wayland:
+            // the extra call has been linked to IME event storms on KDE Plasma.
+            let is_wayland = {
+                #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+                {
+                    matches!(
+                        super::app::WINDOWING_SYSTEM.get(),
+                        Some(super::app::WindowingSystem::Wayland)
+                    )
+                }
+                #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+                {
+                    false
+                }
+            };
+            if !is_wayland {
+                winit_window
+                    .set_ime_position(LogicalPosition::new(position.x, position.y + 1.), size);
+            }
             winit_window.set_ime_position(position, size);
         }
     }

--- a/crates/warpui/src/windowing/winit/window.rs
+++ b/crates/warpui/src/windowing/winit/window.rs
@@ -1454,14 +1454,17 @@ fn create_window(
 
     #[cfg(target_os = "linux")]
     if let Ok(window) = created_window.as_ref() {
-        use wgpu::rwh::RawDisplayHandle;
-        let is_x11 = matches!(
-            window_target.display_handle().map(|dh| dh.as_raw()),
-            Ok(RawDisplayHandle::Xlib(_)) | Ok(RawDisplayHandle::Xcb(_))
-        );
-        if is_x11 {
-            window.set_ime_allowed(true);
-        }
+        // On Linux, winit only sends `zwp_text_input_v3.enable()` (Wayland) /
+        // activates the XIM/IBUS client (X11) after `set_ime_allowed(true)`.
+        // Without this, CJK and other IME input methods appear to do nothing.
+        //
+        // Previously this was X11-only because enabling IME on Wayland could
+        // interact with aggressive `set_ime_cursor_area` updates and produce an
+        // event loop on KDE Plasma. Cursor-area updates are now deduped and the
+        // X11-only position nudge is gated off on Wayland (see
+        // `update_ime_position` / `handle_ime_event`).
+        window.set_ime_allowed(true);
+        log::debug!("IME allowed on newly created Linux window");
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
On Wayland, winit only activates text-input-v3 after set_ime_allowed(true), so Chinese and other IMEs never attached under native KDE Plasma. Re-enable IME for all Linux windows, and harden the IME path that previously looped: only report cursor position on the disabled→enabled edge, dedupe identical set_ime_cursor_area updates, and keep the X11 position nudge off Wayland.

## Description
<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue
<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`. close #7971
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

<img width="547" height="236" alt="image" src="https://github.com/user-attachments/assets/7f9b2187-0464-481e-a0e7-b239ff26e79b" />


## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->

