### PR TITLE
Fix race: associate /remote-control sessions with Oz runs when task_id arrives late (REMOTE-2136)

### DIFF
--- a/app/src/ai/blocklist/local_agent_task_sync_model.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model.rs
@@ -30,7 +30,10 @@ use crate::terminal::cli_agent_sessions::{
 /// server conversation token is persisted as soon as the streamed `Init`
 /// event arrives). It also handles
 /// `BlocklistAIHistoryEvent::LocalSharedSessionEstablished` to link
-/// shared session IDs to the task row.
+/// shared session IDs to the task row, including the race-condition case
+/// where `/remote-control` is started before the conversation's task_id
+/// has been assigned: the session_id is stored in `pending_session_ids`
+/// and flushed on the next `ConversationServerTokenAssigned` event.
 ///
 /// For third-party harnesses (e.g. Claude Code), status is derived from
 /// `CLIAgentSessionsModelEvent::StatusChanged`. Because these sessions do
@@ -45,6 +48,11 @@ pub struct LocalAgentTaskSyncModel {
     cli_session_task_ids: HashMap<EntityId, AmbientAgentTaskId>,
     /// Serializes and coalesces model-owned updates independently per task.
     update_queue: LocalTaskUpdateQueue,
+    /// Session IDs from `/remote-control` sessions that arrived before the
+    /// conversation's server-assigned `task_id` was known. Keyed by
+    /// `AIConversationId`; drained when `ConversationServerTokenAssigned`
+    /// fires and the task_id becomes available, so the link is sent then.
+    pending_session_ids: HashMap<AIConversationId, SessionId>,
 }
 
 pub enum LocalAgentTaskSyncModelEvent {}
@@ -95,6 +103,7 @@ impl LocalAgentTaskSyncModel {
             ai_client,
             cli_session_task_ids: HashMap::new(),
             update_queue: LocalTaskUpdateQueue::default(),
+            pending_session_ids: HashMap::new(),
         }
     }
 
@@ -169,6 +178,11 @@ impl LocalAgentTaskSyncModel {
             // conversation, report its current status. This handles the race
             // where ConversationStatus::InProgress fires before task_id is
             // available — we catch up here once the task_id arrives.
+            //
+            // It also flushes any `pending_session_ids` entry that was stored
+            // when a `/remote-control` shared session was established before
+            // the task_id was known — the session_id is included in that
+            // same catch-up update.
             BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
                 conversation_id, ..
             } => {
@@ -180,9 +194,18 @@ impl LocalAgentTaskSyncModel {
             } => {
                 self.on_local_shared_session_established(*conversation_id, *session_id, ctx);
             }
-            BlocklistAIHistoryEvent::RemoveConversation { run_id, .. }
-            | BlocklistAIHistoryEvent::DeletedConversation { run_id, .. } => {
+            BlocklistAIHistoryEvent::RemoveConversation {
+                conversation_id,
+                run_id,
+                ..
+            }
+            | BlocklistAIHistoryEvent::DeletedConversation {
+                conversation_id,
+                run_id,
+                ..
+            } => {
                 self.remove_queued_update_state_for_run_id(run_id.as_deref());
+                self.pending_session_ids.remove(conversation_id);
             }
             _ => {}
         }
@@ -215,7 +238,7 @@ impl LocalAgentTaskSyncModel {
         conversation_id: AIConversationId,
         ctx: &mut ModelContext<Self>,
     ) {
-        let Some((task_id, Some(update))) =
+        let Some((task_id, Some(mut update))) =
             with_local_conversation(conversation_id, ctx, |conversation| {
                 // When the conversation transitions to Error but the last exchange is
                 // still streaming, the stream hasn't finished processing the error yet.
@@ -246,6 +269,13 @@ impl LocalAgentTaskSyncModel {
             return;
         };
 
+        // Drain any session_id that was stored when a `/remote-control` shared
+        // session was established before the conversation's task_id was known.
+        // Only consume it now that we have confirmed the update will be sent,
+        // so the session_id is not silently dropped if the closure returns None
+        // (e.g. mid-stream Error guard above).
+        update.session_id = self.pending_session_ids.remove(&conversation_id);
+
         self.enqueue_update(task_id, update, ctx);
     }
 
@@ -255,16 +285,32 @@ impl LocalAgentTaskSyncModel {
         session_id: SessionId,
         ctx: &mut ModelContext<Self>,
     ) {
-        let Some((task_id, update)) =
+        // Fast path: conversation already has a task_id — link immediately.
+        if let Some((task_id, update)) =
             with_local_conversation(conversation_id, ctx, |_| LocalTaskUpdate {
                 session_id: Some(session_id),
                 ..LocalTaskUpdate::default()
             })
-        else {
+        {
+            self.enqueue_update(task_id, update, ctx);
             return;
-        };
+        }
 
-        self.enqueue_update(task_id, update, ctx);
+        // Slow path: the task_id has not been assigned yet (the server's Init
+        // stream event hasn't arrived).  Store the session_id so it can be
+        // included when `ConversationServerTokenAssigned` fires and
+        // `on_conversation_status_updated` picks it up.
+        //
+        // Only store when the conversation is a locally-owned non-remote-child
+        // that simply hasn't received its task_id yet.  Skip viewers,
+        // remote-children, and unknown conversations — those are the same
+        // guards that `with_local_conversation` already enforces.
+        let history = BlocklistAIHistoryModel::as_ref(ctx);
+        if let Some(conversation) = history.conversation(&conversation_id) {
+            if !conversation.is_viewing_shared_session() && !conversation.is_remote_child() {
+                self.pending_session_ids.insert(conversation_id, session_id);
+            }
+        }
     }
 
     fn on_cli_session_status_changed(

--- a/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model_tests.rs
@@ -921,3 +921,116 @@ fn conversation_server_token_assigned_skips_without_task_id() {
         );
     });
 }
+
+/// When `/remote-control` is started before the server assigns a `task_id`
+/// (race condition: `LocalSharedSessionEstablished` fires before the Init
+/// stream event arrives), the session_id must be held in
+/// `pending_session_ids` and flushed together with the status update that
+/// fires when `ConversationServerTokenAssigned` arrives.
+#[test]
+fn shared_session_link_deferred_when_task_id_missing_then_sent_on_token_assignment() {
+    App::test((), |mut app| async move {
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+
+        // Conversation with NO task_id yet (Init event hasn't arrived).
+        let conversation = AIConversation::new(false, false);
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let session_id = fixed_session_id();
+        let task_id = fixed_task_id();
+
+        register_cli_agent_sessions_model(&mut app);
+        // The mock must be called exactly once, with the session_id included.
+        let mut mock = MockAIClient::new();
+        mock.expect_update_agent_task()
+            .withf(
+                move |arg_task_id, task_state, arg_session_id, _conv_id, _status_msg| {
+                    *arg_task_id == task_id
+                        && task_state.is_some()
+                        && *arg_session_id == Some(session_id)
+                },
+            )
+            .times(1)
+            .returning(|_, _, _, _, _| Ok(()));
+        let ai_client: Arc<dyn AIClient> = Arc::new(mock);
+        let _model = app.add_singleton_model(|ctx| {
+            LocalAgentTaskSyncModel::new_with_ai_client_for_test(ai_client, ctx)
+        });
+
+        // Step 1: shared session established (no task_id yet → stored in pending).
+        history_model.update(&mut app, |_, ctx| {
+            ctx.emit(BlocklistAIHistoryEvent::LocalSharedSessionEstablished {
+                conversation_id,
+                session_id,
+            });
+        });
+
+        // Step 2: Init event arrives — assign run_id (task_id) + conversation token.
+        history_model.update(&mut app, |model, ctx| {
+            let conv = model
+                .conversation_mut(&conversation_id)
+                .expect("conversation was just restored");
+            conv.set_run_id(task_id.to_string());
+            conv.set_server_conversation_token("server-conversation-id".to_string());
+            // Simulate ConversationServerTokenAssigned (normally emitted by
+            // initialize_output_for_response_stream).
+            ctx.emit(BlocklistAIHistoryEvent::ConversationServerTokenAssigned {
+                conversation_id,
+                terminal_surface_id: terminal_view_id,
+            });
+        });
+
+        pump_spawned_tasks().await;
+        // Mock drop verifies `.times(1)` and the predicate.
+    });
+}
+
+/// A pending session_id is silently dropped when the conversation is removed
+/// before the task_id arrives, so no stale entry leaks into memory.
+#[test]
+fn shared_session_link_clears_pending_on_conversation_remove() {
+    App::test((), |mut app| async move {
+        let history_model =
+            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
+
+        let conversation = AIConversation::new(false, false);
+        let conversation_id = conversation.id();
+        let terminal_view_id = warpui::EntityId::new();
+        history_model.update(&mut app, |model, ctx| {
+            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
+        });
+
+        let (_model, counter) = install_model_with_call_counter(&mut app);
+        let session_id = fixed_session_id();
+
+        // Store session_id in pending (no task_id yet).
+        history_model.update(&mut app, |_, ctx| {
+            ctx.emit(BlocklistAIHistoryEvent::LocalSharedSessionEstablished {
+                conversation_id,
+                session_id,
+            });
+        });
+
+        // Remove the conversation before the task_id arrives.
+        history_model.update(&mut app, |_, ctx| {
+            ctx.emit(BlocklistAIHistoryEvent::RemoveConversation {
+                terminal_surface_id: terminal_view_id,
+                conversation_id,
+                run_id: None,
+            });
+        });
+
+        pump_spawned_tasks().await;
+
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            0,
+            "no RPC must fire when conversation is removed before task_id arrives"
+        );
+    });
+}


### PR DESCRIPTION
## Description

Fixes a race condition where `/remote-control` shared sessions were not
appearing in the Oz web app runs list.

### Root cause

When a user invokes `/remote-control` before the server's Init stream event
has assigned a `task_id` to the active Oz conversation,
`LocalSharedSessionEstablished` fires but `with_local_conversation` returns
`None` (no task_id yet). The session_id update was silently dropped,
leaving the run and the shared session permanently unlinked.

### Fix

In `LocalAgentTaskSyncModel`, store the `session_id` in a new
`pending_session_ids` map (`AIConversationId → SessionId`) when the fast
path fails due to a missing task_id.  When `ConversationServerTokenAssigned`
fires (the Init event has arrived), `on_conversation_status_updated` drains
the stored session_id and includes it in the same catch-up update that
already links the `run_id` and task state.

The deferred session_id is consumed **after** confirming the update will be
sent (i.e. the closure's `None`-guard for mid-stream errors doesn't cause the
entry to be silently lost). Stale entries are evicted on `RemoveConversation`
/ `DeletedConversation`.

### Notes on scope

- Cloud agent runs already work: `AgentDriver` handles
  `TerminalDriverEvent::EstablishedSharedSession` and calls `update_agent_task`
  with the session_id immediately. This fix covers the client-side GUI case
  where no `AgentDriver` is running.
- The common case (user does `/remote-control` after conversation already has a
  task_id) continues to use the fast path and is unchanged.

## Linked Issue

REMOTE-2136

## Testing

Added two unit tests to `local_agent_task_sync_model_tests.rs`:

1. **`shared_session_link_deferred_when_task_id_missing_then_sent_on_token_assignment`**
   — verifies that when `LocalSharedSessionEstablished` fires before the
   task_id is available, the session_id is included in the update triggered
   by the subsequent `ConversationServerTokenAssigned`.

2. **`shared_session_link_clears_pending_on_conversation_remove`**
   — verifies that removing the conversation before the task_id arrives
   cleans up the pending entry without firing an RPC.

Note: full test execution requires more memory than the sandbox environment
provides; `cargo check` and `cargo clippy` both pass cleanly.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!-- CHANGELOG-BUG-FIX: Fix race condition where /remote-control sessions were not linked to their Oz runs in the webapp -->

_Conversation: https://staging.warp.dev/conversation/159eb42b-3a9b-4c1a-8a60-c54f3204a089_
_Run: https://oz.staging.warp.dev/runs/019f5b94-8e1f-7c36-ac36-ad7bc4e15104_

_This PR was generated with [Oz](https://warp.dev/oz)._
