### PR TITLE
Support headless bootstrapping of macOS dev environment

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -28,10 +28,13 @@ Options:
   --install-common-skills-globally
                             Install or update common agent skills in ~/.agents/skills.
   --skip-common-skills     Skip installing common agent skills.
+  --skip-gcloud-auth       Skip the gcloud authentication check.
 
 Environment:
   WARP_SKIP_COMMON_SKILLS_INSTALL=1
       Skip installing common agent skills, even when --install-common-skills is provided.
+  WARP_SKIP_GCLOUD_AUTH=1
+      Skip the gcloud authentication check.
   WARP_COMMON_SKILLS_INSTALL_TARGET=project|global
       Choose the install target when no explicit prompt answer is provided.
       Target prompting and duplicate checks are delegated to
@@ -59,6 +62,12 @@ print_bootstrap_preview() {
     echo "  - Update apt package metadata."
     echo "  - Install dependencies needed to build, run, and test Warp."
     echo "  - Install linuxdeploy and check gcloud authentication."
+  fi
+
+  if [[ "${WARP_SKIP_GCLOUD_AUTH:-0}" = "1" ]]; then
+    echo "  - Skip gcloud authentication because --skip-gcloud-auth was provided."
+  else
+    echo "  - Check gcloud authentication (or prompt to log in)."
   fi
 
   if [[ "${INSTALL_COMMON_SKILLS}" -eq 0 ]]; then
@@ -105,6 +114,9 @@ for arg in "$@"; do
       ;;
     --skip-common-skills)
       INSTALL_COMMON_SKILLS=0
+      ;;
+    --skip-gcloud-auth)
+      export WARP_SKIP_GCLOUD_AUTH=1
       ;;
     *)
       PLATFORM_ARGS+=("${arg}")

--- a/script/install_cargo_binstall
+++ b/script/install_cargo_binstall
@@ -9,4 +9,4 @@ if ! command -v cargo-binstall; then
     cargo install cargo-binstall@1.14.3 --locked
 fi
 
-cargo binstall cargo-binstall
+cargo binstall --no-confirm cargo-binstall

--- a/script/linux/bootstrap
+++ b/script/linux/bootstrap
@@ -16,7 +16,7 @@ warp_sudo apt update -y
 
 # Make sure we're authenticated with the gcloud CLI, otherwise SSH integration
 # tests won't work.
-if [[ -z "$(gcloud auth print-identity-token)" ]]; then
+if [[ "${WARP_SKIP_GCLOUD_AUTH:-0}" != "1" ]] && [[ -z "$(gcloud auth print-identity-token)" ]]; then
     echo "gcloud CLI authentication missing.  Press enter to continue..."
     read var
     gcloud auth login

--- a/script/macos/bootstrap
+++ b/script/macos/bootstrap
@@ -82,7 +82,7 @@ if ! [ "$(command -v gcloud)" ]; then
     brew install google-cloud-sdk
 fi
 
-if [[ -z $(gcloud auth print-identity-token) ]]; then
+if [[ "${WARP_SKIP_GCLOUD_AUTH:-0}" != "1" ]] && [[ -z $(gcloud auth print-identity-token) ]]; then
     echo "gcloud CLI authentication missing.  Press enter to continue..."
     read var
     gcloud auth login

--- a/script/windows/bootstrap.ps1
+++ b/script/windows/bootstrap.ps1
@@ -168,11 +168,13 @@ if (-not (Get-Command -Name gcloud -Type Application -ErrorAction SilentlyContin
     Start-Process "$env:Temp\GoogleCloudSDKInstaller.exe" -Wait
 }
 
-[string]$identityToken = gcloud auth print-identity-token
-if ($identityToken.Trim().Length -eq 0) {
-    Write-Output 'gcloud CLI authentication missing.  Press enter to continue...'
-    Read-Host
-    gcloud auth login
+if ($env:WARP_SKIP_GCLOUD_AUTH -ne '1') {
+    [string]$identityToken = gcloud auth print-identity-token
+    if ($identityToken.Trim().Length -eq 0) {
+        Write-Output 'gcloud CLI authentication missing.  Press enter to continue...'
+        Read-Host
+        gcloud auth login
+    }
 }
 
 if ($InstallCommonSkills) {


### PR DESCRIPTION
## Description

Building on https://github.com/warpdotdev/warp/pull/13638, this (should) make it possible to run `./script/bootstrap` on macOS with no confirmation prompts. As of that PR, Homebrew will no longer prompt for confirmation.

The other confirmation prompts are:
1. Interactive GCP authentication -- now bypassed with a `--skip-gcloud-auth` flag, since we don't know whether or not it's needed for a given environment
2. `cargo-binstall` -- we now use `--no-confirm` consistently

## Testing

- I ran `./script/bootstrap --skip-gcloud-auth` locally and confirmed there were no approval prompts.
- I also ran it in an empty environment, with no dependencies preinstalled: https://oz.staging.warp.dev/runs/019f5bf3-42a0-74ac-ac80-5134e31c32a2

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->
