### PR TITLE
replace dispatch time area passing w/ paint-retained size/origin

### DIFF
--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -17,8 +17,9 @@ use warp_core::ui::theme::Fill as ThemeFill;
 use warpui::platform::WindowStyle;
 use warpui::{AddWindowOptions, SingletonEntity};
 use warpui_core::elements::tui::{
-    Color, Modifier, TuiBufferExt, TuiConstraint, TuiEvent, TuiEventContext, TuiLayoutContext,
-    TuiPoint, TuiRect, TuiSize,
+    Color, Modifier, TuiBuffer, TuiBufferExt, TuiConstraint, TuiEvent, TuiEventContext,
+    TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiPoint, TuiRect, TuiScreenPosition,
+    TuiSize,
 };
 use warpui_core::elements::Fill as CoreFill;
 use warpui_core::event::ModifiersState;
@@ -907,7 +908,16 @@ fn task_list_header_hover_underlines_only_the_label() {
                 rendered_views: &mut rendered_views,
             };
             element.layout(TuiConstraint::loose(TuiSize::new(40, 2)), &mut ctx, app_ctx);
-            let mut event_ctx = TuiEventContext::default();
+            // Paint once so the element retains its scene geometry for
+            // hit-testing the hover move.
+            let scene = {
+                let mut buffer = TuiBuffer::empty(area);
+                let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
+                let mut surface = TuiPaintSurface::new(&mut buffer);
+                element.render(TuiScreenPosition::new(0, 0), &mut surface, &mut paint_ctx);
+                Rc::new(paint_ctx.scene.clone())
+            };
+            let mut event_ctx = TuiEventContext::new(scene, &mut rendered_views);
             event_ctx.set_origin_view(Some(EntityId::new()));
             element.dispatch_event(
                 &TuiEvent::MouseMoved {
@@ -915,9 +925,7 @@ fn task_list_header_hover_underlines_only_the_label() {
                     modifiers: ModifiersState::default(),
                     is_synthetic: false,
                 },
-                area,
                 &mut event_ctx,
-                &mut ctx,
                 app_ctx,
             );
 

--- a/crates/warp_tui/src/editor_element.rs
+++ b/crates/warp_tui/src/editor_element.rs
@@ -29,9 +29,9 @@ use warp_editor::render::model::{
     CharCellTemporaryBlock, DisplayLattice, DisplayRow, DisplayRowKind,
 };
 use warpui_core::elements::tui::{
-    Modifier, TuiBuffer, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiFlex,
-    TuiGridPoint, TuiLayoutContext, TuiPaintContext, TuiParentElement, TuiPoint, TuiRect,
-    TuiRectExt, TuiSize, TuiStyle, TuiText,
+    Modifier, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiFlex, TuiGridPoint,
+    TuiLayoutContext, TuiLocalPoint, TuiPaintContext, TuiPaintSurface, TuiParentElement,
+    TuiScreenPoint, TuiScreenPosition, TuiSize, TuiStyle, TuiText,
 };
 use warpui_core::{AppContext, ModelHandle};
 
@@ -70,7 +70,7 @@ pub(crate) enum TuiEditorAction {
 }
 
 /// Handler receiving the element's [`TuiEditorAction`]s during event dispatch.
-type TuiEditorActionHandler = Rc<dyn Fn(TuiEditorAction, &mut TuiEventContext)>;
+type TuiEditorActionHandler = Rc<dyn for<'a> Fn(TuiEditorAction, &mut TuiEventContext<'a>)>;
 
 /// Whole-row styles by row kind, plus per-line overrides — all consumer
 /// policy. Gutter cells take their row's style.
@@ -135,6 +135,8 @@ pub(crate) struct TuiEditorElement {
     cursor_col: u16,
     cursor_row_in_view: u16,
     cursor_visible: bool,
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
 }
 
 impl TuiEditorElement {
@@ -190,6 +192,8 @@ impl TuiEditorElement {
             cursor_col: 0,
             cursor_row_in_view: 0,
             cursor_visible: false,
+            size: None,
+            origin: None,
         }
     }
 
@@ -250,7 +254,7 @@ impl TuiEditorElement {
     /// all (a read-only, click-through body).
     pub(crate) fn on_action(
         mut self,
-        handler: impl Fn(TuiEditorAction, &mut TuiEventContext) + 'static,
+        handler: impl for<'a> Fn(TuiEditorAction, &mut TuiEventContext<'a>) + 'static,
     ) -> Self {
         self.on_action = Some(Rc::new(handler));
         self
@@ -509,7 +513,7 @@ impl TuiEditorElement {
     /// below maps to the last display row (or the buffer's end on the
     /// deferred-wrap phantom row), so a drag that leaves the element drives
     /// auto-scroll.
-    fn offset_at(&self, position: TuiPoint, area: TuiRect, app: &AppContext) -> Option<CharOffset> {
+    fn offset_at(&self, position: TuiLocalPoint, app: &AppContext) -> Option<CharOffset> {
         let inner = self.model.as_ref(app);
         let render_state = inner.render_state().as_ref(app);
         let char_cell = render_state.char_cell()?;
@@ -526,11 +530,10 @@ impl TuiEditorElement {
             0
         };
 
-        let row_in_view = i64::from(position.y) - i64::from(area.y);
+        let row_in_view = i64::from(position.y);
         let display_row = (i64::from(first_visible_row) + row_in_view).max(0) as usize;
-        let col = position
-            .x
-            .saturating_sub(area.x)
+        let col = u16::try_from(position.x.max(0))
+            .unwrap_or(u16::MAX)
             .saturating_sub(self.gutter_cols);
 
         let lattice = char_cell.display_lattice(&hidden);
@@ -568,9 +571,10 @@ impl TuiEditorElement {
     pub(crate) fn mouse_action(
         &self,
         event: &TuiEvent,
-        area: TuiRect,
+        event_ctx: &TuiEventContext<'_>,
         app: &AppContext,
     ) -> Option<TuiEditorAction> {
+        let (origin, size) = self.origin.zip(self.size)?;
         match event {
             TuiEvent::LeftMouseDown {
                 position,
@@ -580,10 +584,10 @@ impl TuiEditorElement {
             } => {
                 // The focus-bringing first click has no matching mouse-up, and
                 // a press outside the element must not start a selection.
-                if *is_first_mouse || !area.contains_point(*position) {
+                if *is_first_mouse || !event_ctx.hit_test(origin, size, *position) {
                     return None;
                 }
-                let offset = self.offset_at(*position, area, app)?;
+                let offset = self.offset_at(event_ctx.local_point(origin, *position), app)?;
                 Some(match *click_count {
                     0 | 1 if modifiers.shift => TuiEditorAction::SelectionExtendTo { offset },
                     0 | 1 => TuiEditorAction::SelectionStartAt { offset },
@@ -595,7 +599,7 @@ impl TuiEditorElement {
             // but only while a selection that began inside it is active.
             TuiEvent::LeftMouseDragged { position, .. } if self.drag_in_progress(app) => {
                 Some(TuiEditorAction::SelectionUpdateTo {
-                    offset: self.offset_at(*position, area, app)?,
+                    offset: self.offset_at(event_ctx.local_point(origin, *position), app)?,
                 })
             }
             TuiEvent::LeftMouseUp { .. } if self.drag_in_progress(app) => {
@@ -605,7 +609,7 @@ impl TuiEditorElement {
             // meaningful for scroll-windowed consumers.
             TuiEvent::ScrollWheel {
                 position, delta, ..
-            } if self.viewport_rows.is_some() && area.contains_point(*position) => {
+            } if self.viewport_rows.is_some() && event_ctx.hit_test(origin, size, *position) => {
                 // crossterm reports ScrollUp as +1 row / ScrollDown as -1;
                 // negate so wheel-up scrolls toward the top.
                 Some(TuiEditorAction::Scroll {
@@ -642,79 +646,106 @@ impl TuiElement for TuiEditorElement {
         let content_size = self.column.layout(constraint, ctx, app);
         // The editor claims the full width it was offered (its wrap width),
         // not just the longest row's width the content-sized column reports.
-        TuiSize::new(full_width, content_size.height)
+        let size = TuiSize::new(full_width, content_size.height);
+        self.size = Some(size);
+        size
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
-        self.column.render(area, buffer, ctx);
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.origin = Some(ctx.scene_point(origin));
+        let Some(size) = self.size else {
+            return;
+        };
+        self.column.render(origin, surface, ctx);
         if let Some((text, style)) = &self.trailing_ghost_text {
             let cursor_at_end =
                 self.cursor_offset.as_usize().saturating_sub(1) == self.text.chars().count();
-            if cursor_at_end && self.cursor_visible {
-                let x = area.x.saturating_add(self.cursor_col);
-                let y = area.y.saturating_add(self.cursor_row_in_view);
-                if x < area.x.saturating_add(area.width) && y < area.y.saturating_add(area.height) {
-                    buffer.set_stringn(
-                        x,
-                        y,
-                        text,
-                        usize::from(area.width.saturating_sub(self.cursor_col)),
-                        *style,
-                    );
+            if cursor_at_end
+                && self.cursor_visible
+                && self.cursor_col < size.width
+                && self.cursor_row_in_view < size.height
+            {
+                let mut col = self.cursor_col;
+                for char in text.chars() {
+                    if col >= size.width {
+                        break;
+                    }
+                    let position =
+                        origin.offset(i32::from(col), i32::from(self.cursor_row_in_view));
+                    if let Some(cell) = surface.cell_mut(position) {
+                        cell.set_char(char);
+                        cell.set_style(*style);
+                    }
+                    col += 1;
                 }
             }
         }
         for &(row_in_view, start_col, end_col, style) in &self.styled_spans {
-            let y = area.y.saturating_add(row_in_view);
-            let x = area.x.saturating_add(start_col);
             let width = end_col.saturating_sub(start_col);
-            if y < area.y + area.height && width > 0 {
-                let style_rect =
-                    TuiRect::new(x, y, width.min(area.width.saturating_sub(start_col)), 1);
-                buffer.set_style(style_rect, style);
+            if row_in_view < size.height && width > 0 {
+                surface.set_style(
+                    origin.offset(i32::from(start_col), i32::from(row_in_view)),
+                    TuiSize::new(width.min(size.width.saturating_sub(start_col)), 1),
+                    style,
+                );
             }
         }
         if !self.selected_spans.is_empty() {
             let reversed = TuiStyle::default().add_modifier(Modifier::REVERSED);
             for &(row_in_view, start_col, end_col) in &self.selected_spans {
-                let y = area.y.saturating_add(row_in_view);
-                let x = area.x.saturating_add(start_col);
                 let width = end_col.saturating_sub(start_col);
-                if y < area.y + area.height && width > 0 {
-                    let sel_rect =
-                        TuiRect::new(x, y, width.min(area.width.saturating_sub(start_col)), 1);
-                    buffer.set_style(sel_rect, reversed);
+                if row_in_view < size.height && width > 0 {
+                    surface.set_style(
+                        origin.offset(i32::from(start_col), i32::from(row_in_view)),
+                        TuiSize::new(width.min(size.width.saturating_sub(start_col)), 1),
+                        reversed,
+                    );
                 }
             }
         }
-    }
-
-    fn cursor_position(&self, area: TuiRect, _ctx: &mut TuiPaintContext) -> Option<(u16, u16)> {
-        if !self.cursor_visible
-            || self.cursor_col >= area.width
-            || self.cursor_row_in_view >= area.height
+        if self.cursor_visible
+            && self.cursor_col < size.width
+            && self.cursor_row_in_view < size.height
         {
-            return None;
+            let scene_origin = self
+                .origin
+                .expect("editor origin is retained before cursor paint");
+            ctx.set_terminal_cursor(TuiScreenPoint::new(
+                scene_origin.x.saturating_add(i32::from(self.cursor_col)),
+                scene_origin
+                    .y
+                    .saturating_add(i32::from(self.cursor_row_in_view)),
+                scene_origin.z_index,
+            ));
         }
-        Some((self.cursor_col, self.cursor_row_in_view))
     }
 
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
+    }
     fn dispatch_event(
         &mut self,
         event: &TuiEvent,
-        area: TuiRect,
-        event_ctx: &mut TuiEventContext,
-        ctx: &mut TuiLayoutContext,
+        event_ctx: &mut TuiEventContext<'_>,
         app: &AppContext,
     ) -> bool {
-        if self.column.dispatch_event(event, area, event_ctx, ctx, app) {
+        if self.column.dispatch_event(event, event_ctx, app) {
             return true;
         }
         let Some(handler) = self.on_action.clone() else {
             return false;
         };
 
-        if let Some(action) = self.mouse_action(event, area, app) {
+        if let Some(action) = self.mouse_action(event, event_ctx, app) {
             handler(action, event_ctx);
             return true;
         }

--- a/crates/warp_tui/src/editor_element_tests.rs
+++ b/crates/warp_tui/src/editor_element_tests.rs
@@ -9,7 +9,8 @@ use warp_editor::model::CoreEditorModel;
 use warpui::EntityIdMap;
 use warpui_core::elements::tui::{
     Color, Modifier, TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiEvent, TuiEventContext,
-    TuiLayoutContext, TuiPaintContext, TuiRect, TuiSize, TuiStyle,
+    TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiRect, TuiScreenPosition, TuiSize,
+    TuiStyle,
 };
 use warpui_core::{App, AppContext, ModelHandle};
 
@@ -83,7 +84,14 @@ fn render_buffer(
     let area = TuiRect::new(0, 0, size.width, size.height);
     let mut buffer = TuiBuffer::empty(area);
     let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
-    element.render(area, &mut buffer, &mut paint_ctx);
+    {
+        let mut surface = TuiPaintSurface::new(&mut buffer);
+        element.render(
+            TuiScreenPosition::new(i32::from(area.x), i32::from(area.y)),
+            &mut surface,
+            &mut paint_ctx,
+        );
+    }
     buffer
 }
 
@@ -111,13 +119,20 @@ fn dispatch_event(ctx: &AppContext, mut element: TuiEditorElement, event: &TuiEv
         ctx,
     );
     let area = TuiRect::new(0, 0, size.width, size.height);
-    element.dispatch_event(
-        event,
-        area,
-        &mut TuiEventContext::default(),
-        &mut layout_ctx,
-        ctx,
-    )
+    // Paint once so the element retains its scene geometry for hit-testing.
+    let scene = {
+        let mut buffer = TuiBuffer::empty(area);
+        let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
+        let mut surface = TuiPaintSurface::new(&mut buffer);
+        element.render(
+            TuiScreenPosition::new(i32::from(area.x), i32::from(area.y)),
+            &mut surface,
+            &mut paint_ctx,
+        );
+        Rc::new(paint_ctx.scene.clone())
+    };
+    let mut event_ctx = TuiEventContext::new(scene, &mut rendered_views);
+    element.dispatch_event(event, &mut event_ctx, ctx)
 }
 
 #[test]

--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -4,8 +4,9 @@ use std::ops::Range;
 use string_offset::CharOffset;
 use warp::tui_export::AcceptSlashCommandOrSavedPrompt;
 use warpui_core::elements::tui::{
-    TuiBuffer, TuiConstrainedBox, TuiConstraint, TuiContainer, TuiElement, TuiFlex,
-    TuiLayoutContext, TuiPaintContext, TuiRect, TuiSize, TuiText,
+    TuiConstrainedBox, TuiConstraint, TuiContainer, TuiElement, TuiEvent, TuiEventContext, TuiFlex,
+    TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiPresentationContext, TuiScreenPoint,
+    TuiScreenPosition, TuiSize, TuiText,
 };
 use warpui_core::elements::CrossAxisAlignment;
 use warpui_core::{AppContext, ModelAsRef, ModelHandle, UpdateModel};
@@ -188,10 +189,44 @@ impl TuiElement for TuiInlineMenuElement {
         size
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
-        if let Some(content) = &self.content {
-            content.render(area, buffer, ctx);
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        if let Some(content) = self.content.as_mut() {
+            content.render(origin, surface, ctx);
         }
+    }
+
+    /// Returns the laid-out content size.
+    fn size(&self) -> Option<TuiSize> {
+        self.content.as_ref()?.size()
+    }
+
+    /// Returns the painted content origin.
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.content.as_ref()?.origin()
+    }
+
+    /// Delegates child-view presentation to the laid-out content.
+    fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
+        if let Some(content) = self.content.as_mut() {
+            content.present(ctx);
+        }
+    }
+
+    /// Delegates event dispatch to the laid-out content.
+    fn dispatch_event(
+        &mut self,
+        event: &TuiEvent,
+        event_ctx: &mut TuiEventContext<'_>,
+        app: &AppContext,
+    ) -> bool {
+        self.content
+            .as_mut()
+            .is_some_and(|content| content.dispatch_event(event, event_ctx, app))
     }
 }
 

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -16,7 +16,8 @@ use warp_editor::model::CoreEditorModel;
 use warpui::EntityIdMap;
 use warpui_core::elements::tui::{
     TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiEvent, TuiEventContext,
-    TuiLayoutContext, TuiPaintContext, TuiPoint, TuiRect, TuiSize,
+    TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiPoint, TuiRect, TuiScene,
+    TuiScreenPosition, TuiSize,
 };
 use warpui_core::event::{KeyEventDetails, ModifiersState};
 use warpui_core::keymap::Keystroke;
@@ -88,7 +89,14 @@ fn render_input_buffer(view: &ViewHandle<TuiInputView>, ctx: &AppContext) -> Tui
     let area = TuiRect::new(0, 0, size.width, size.height);
     let mut buffer = TuiBuffer::empty(area);
     let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
-    element.render(area, &mut buffer, &mut paint_ctx);
+    {
+        let mut surface = TuiPaintSurface::new(&mut buffer);
+        element.render(
+            TuiScreenPosition::new(i32::from(area.x), i32::from(area.y)),
+            &mut surface,
+            &mut paint_ctx,
+        );
+    }
     buffer
 }
 
@@ -346,9 +354,16 @@ fn cursor_and_height(
         rendered_views: &mut rendered_views,
     };
     let size = element.layout(TuiConstraint::loose(TuiSize::new(W, 20)), &mut lctx, ctx);
+    let area = TuiRect::new(0, 0, size.width, size.height);
+    let mut buffer = TuiBuffer::empty(area);
     let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
-    let cursor =
-        element.cursor_position(TuiRect::new(0, 0, size.width, size.height), &mut paint_ctx);
+    {
+        let mut surface = TuiPaintSurface::new(&mut buffer);
+        element.render(TuiScreenPosition::new(0, 0), &mut surface, &mut paint_ctx);
+    }
+    let cursor = paint_ctx
+        .terminal_cursor()
+        .and_then(|point| Some((u16::try_from(point.x).ok()?, u16::try_from(point.y).ok()?)));
     (cursor, size.height)
 }
 
@@ -831,13 +846,32 @@ fn laid_out_element(
     (element, TuiRect::new(0, 0, size.width, size.height))
 }
 
+/// Paints `element` and returns its retained scene.
+fn paint_event_scene(element: &mut dyn TuiElement, area: TuiRect) -> Rc<TuiScene> {
+    let mut rendered_views = EntityIdMap::default();
+    let mut buffer = TuiBuffer::empty(area);
+    let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
+    {
+        let mut surface = TuiPaintSurface::new(&mut buffer);
+        element.render(
+            TuiScreenPosition::new(i32::from(area.x), i32::from(area.y)),
+            &mut surface,
+            &mut paint_ctx,
+        );
+    }
+    Rc::new(paint_ctx.scene.clone())
+}
+
 /// Drives the full mouse path for `event`: lay out the element, map the event to
 /// its editor action, and apply the corresponding [`TuiInputAction`] to the view.
 /// Returns whether an action fired (i.e. the event was not ignored).
 fn mouse(view: &ViewHandle<TuiInputView>, ctx: &mut AppContext, event: &TuiEvent) -> bool {
     let action = {
-        let (element, area) = laid_out_element(view, ctx);
-        element.mouse_action(event, area, ctx)
+        let (mut element, area) = laid_out_element(view, ctx);
+        let scene = paint_event_scene(&mut element, area);
+        let mut rendered_views = EntityIdMap::default();
+        let event_ctx = TuiEventContext::new(scene, &mut rendered_views);
+        element.mouse_action(event, &event_ctx, ctx)
     };
     match action {
         Some(action) => {
@@ -1136,11 +1170,9 @@ fn escape_is_not_consumed_by_the_element() {
             let view = build_view(ctx);
             type_str(&view, ctx, "ab");
             let (mut element, area) = laid_out_element(&view, ctx);
+            let scene = paint_event_scene(&mut element, area);
             let mut rendered_views = EntityIdMap::default();
-            let mut lctx = TuiLayoutContext {
-                rendered_views: &mut rendered_views,
-            };
-            let mut event_ctx = TuiEventContext::default();
+            let mut event_ctx = TuiEventContext::new(scene, &mut rendered_views);
             event_ctx.set_origin_view(Some(view.id()));
             let escape = TuiEvent::KeyDown {
                 keystroke: Keystroke {
@@ -1152,7 +1184,7 @@ fn escape_is_not_consumed_by_the_element() {
                 is_composing: false,
             };
             assert!(
-                !element.dispatch_event(&escape, area, &mut event_ctx, &mut lctx, ctx),
+                !element.dispatch_event(&escape, &mut event_ctx, ctx),
                 "escape must not be consumed by the element"
             );
 
@@ -1224,10 +1256,22 @@ fn shell_mode_offsets_cursor_by_gutter() {
         app.update(|ctx| {
             let view = build_view(ctx);
             type_str(&view, ctx, "ab");
-            let (element, area) = laid_out_shell_row(&view, ctx);
+            let (mut element, area) = laid_out_shell_row(&view, ctx);
             let mut rendered_views = EntityIdMap::default();
+            let mut buffer = TuiBuffer::empty(area);
             let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
-            assert_eq!(element.cursor_position(area, &mut paint_ctx), Some((4, 0)));
+            {
+                let mut surface = TuiPaintSurface::new(&mut buffer);
+                element.render(
+                    TuiScreenPosition::new(i32::from(area.x), i32::from(area.y)),
+                    &mut surface,
+                    &mut paint_ctx,
+                );
+            }
+            let cursor = paint_ctx.terminal_cursor().and_then(|point| {
+                Some((u16::try_from(point.x).ok()?, u16::try_from(point.y).ok()?))
+            });
+            assert_eq!(cursor, Some((4, 0)));
         });
     });
 }
@@ -1242,9 +1286,12 @@ fn shell_mode_offsets_mouse_mapping_by_gutter() {
             let view = build_view(ctx);
             type_str(&view, ctx, "hello world");
             let action = {
-                let (element, area) = laid_out_shell_content_slot(&view, ctx);
+                let (mut element, area) = laid_out_shell_content_slot(&view, ctx);
+                let scene = paint_event_scene(&mut element, area);
+                let mut rendered_views = EntityIdMap::default();
+                let event_ctx = TuiEventContext::new(scene, &mut rendered_views);
                 element
-                    .mouse_action(&left_down(2 + 3, 0, 1, false), area, ctx)
+                    .mouse_action(&left_down(2 + 3, 0, 1, false), &event_ctx, ctx)
                     .map(TuiInputAction::from)
             };
             let Some(TuiInputAction::SelectionStartAt { offset }) = action else {
@@ -1257,24 +1304,16 @@ fn shell_mode_offsets_mouse_mapping_by_gutter() {
             // release inside it fires the handler (which moves the cursor to
             // the buffer start); both halves are consumed.
             let (mut row, area) = laid_out_shell_row(&view, ctx);
+            let scene = paint_event_scene(row.as_mut(), area);
             let mut rendered_views = EntityIdMap::default();
-            let mut lctx = TuiLayoutContext {
-                rendered_views: &mut rendered_views,
-            };
-            let mut event_ctx = TuiEventContext::default();
+            let mut event_ctx = TuiEventContext::new(scene, &mut rendered_views);
             event_ctx.set_origin_view(Some(view.id()));
             assert!(
-                row.dispatch_event(
-                    &left_down(0, 0, 1, false),
-                    area,
-                    &mut event_ctx,
-                    &mut lctx,
-                    ctx
-                ),
+                row.dispatch_event(&left_down(0, 0, 1, false), &mut event_ctx, ctx),
                 "gutter presses must be consumed"
             );
             assert!(
-                row.dispatch_event(&left_up(0, 0), area, &mut event_ctx, &mut lctx, ctx),
+                row.dispatch_event(&left_up(0, 0), &mut event_ctx, ctx),
                 "the release completing a gutter click must be consumed"
             );
         });

--- a/crates/warp_tui/src/terminal_block.rs
+++ b/crates/warp_tui/src/terminal_block.rs
@@ -9,8 +9,8 @@ use warp_terminal::model::ansi::{Color, NamedColor};
 use warp_terminal::model::grid::cell::{Cell, Flags};
 use warp_terminal::model::grid::Dimensions as _;
 use warpui_core::elements::tui::{
-    Color as TuiColor, Modifier, TuiBuffer, TuiConstraint, TuiElement, TuiLayoutContext,
-    TuiPaintContext, TuiRect, TuiSize, TuiStyle,
+    Color as TuiColor, Modifier, TuiConstraint, TuiElement, TuiLayoutContext, TuiPaintContext,
+    TuiPaintSurface, TuiScreenPoint, TuiScreenPosition, TuiSize, TuiStyle,
 };
 use warpui_core::AppContext;
 
@@ -20,6 +20,13 @@ enum TerminalBlockRows {
     Visible { rows: Range<usize>, width: u16 },
     /// Every currently displayed command/output row, derived live.
     Content,
+}
+
+/// Absolute bounds used while painting one terminal block.
+#[derive(Clone, Copy)]
+struct TerminalBlockPaintBounds {
+    origin: TuiScreenPosition,
+    size: TuiSize,
 }
 
 /// Paints terminal cells from one block using either a pre-clipped transcript
@@ -36,6 +43,8 @@ pub(super) struct TerminalBlockElement {
     model: Arc<FairMutex<TerminalModel>>,
     block_id: BlockId,
     rows: TerminalBlockRows,
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
 }
 
 impl TerminalBlockElement {
@@ -53,6 +62,8 @@ impl TerminalBlockElement {
                 rows: visible_rows,
                 width,
             },
+            size: None,
+            origin: None,
         }
     }
     /// Creates an element for all currently displayed command/output rows.
@@ -61,6 +72,8 @@ impl TerminalBlockElement {
             model,
             block_id,
             rows: TerminalBlockRows::Content,
+            size: None,
+            origin: None,
         }
     }
 }
@@ -83,25 +96,51 @@ impl TuiElement for TerminalBlockElement {
                     .unwrap_or_default()
             }
         };
-        constraint.clamp(TuiSize::new(
+        let size = constraint.clamp(TuiSize::new(
             constraint.max.width,
             rows.end
                 .saturating_sub(rows.start)
                 .min(usize::from(u16::MAX)) as u16,
-        ))
+        ));
+        self.size = Some(size);
+        size
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, _ctx: &mut TuiPaintContext) {
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.origin = Some(ctx.scene_point(origin));
+        let Some(size) = self.size else {
+            return;
+        };
         let model = self.model.lock();
         let colors = model.colors();
         let Some(block) = model.block_list().block_with_id(&self.block_id) else {
             return;
         };
         let (rows, width) = match &self.rows {
-            TerminalBlockRows::Visible { rows, width } => (rows.clone(), (*width).min(area.width)),
-            TerminalBlockRows::Content => (block_content_rows(block), area.width),
+            TerminalBlockRows::Visible { rows, width } => (rows.clone(), (*width).min(size.width)),
+            TerminalBlockRows::Content => (block_content_rows(block), size.width),
         };
-        render_block_rows(block, rows, width, area, buffer, &colors);
+        render_block_rows(
+            block,
+            rows,
+            width,
+            TerminalBlockPaintBounds { origin, size },
+            surface,
+            &colors,
+        );
+    }
+
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
     }
 }
 
@@ -140,14 +179,14 @@ fn block_content_rows(block: &Block) -> Range<usize> {
 
 /// Paints the requested block-relative rows from a terminal block. A block
 /// stacks its prompt/command grid above its output grid; each call paints only
-/// the rows overlapping `visible_rows`, positioned within `area` so the two
+/// rows overlapping `visible_rows`, positioned within `size` so the two
 /// grids don't overlap.
 fn render_block_rows(
     block: &Block,
     visible_rows: Range<usize>,
     max_width: u16,
-    area: TuiRect,
-    buffer: &mut TuiBuffer,
+    bounds: TerminalBlockPaintBounds,
+    surface: &mut TuiPaintSurface<'_>,
     colors: &TerminalColorList,
 ) {
     if !block.should_hide_command_grid() {
@@ -160,8 +199,8 @@ fn render_block_rows(
                 .max(0.0) as usize,
             visible_rows.clone(),
             max_width,
-            area,
-            buffer,
+            bounds,
+            surface,
             colors,
         );
     }
@@ -172,8 +211,8 @@ fn render_block_rows(
             block.output_grid_offset().as_f64().ceil().max(0.0) as usize,
             visible_rows,
             max_width,
-            area,
-            buffer,
+            bounds,
+            surface,
             colors,
         );
     }
@@ -194,20 +233,20 @@ pub(super) fn should_render_terminal_block(block: &Block, block_list: &BlockList
 }
 
 /// Paints consecutive displayed rows of one grid starting at `*y`, advancing
-/// `y` past each row drawn and stopping at the bottom of `area`.
+/// `y` past each row drawn and stopping at the bottom of `size`.
 fn render_displayed_rows(
     block_grid: &BlockGrid,
     displayed_rows: Range<usize>,
     max_width: u16,
-    area: TuiRect,
-    buffer: &mut TuiBuffer,
+    bounds: TerminalBlockPaintBounds,
+    surface: &mut TuiPaintSurface<'_>,
     colors: &TerminalColorList,
     y: &mut u16,
 ) {
     let grid = block_grid.grid_handler();
     let end = displayed_rows.end.min(block_grid.len_displayed());
     for displayed_row in displayed_rows.start.min(end)..end {
-        if *y >= area.bottom() {
+        if *y >= bounds.size.height {
             break;
         }
         let original_row = grid.maybe_translate_row_from_displayed_to_original(displayed_row);
@@ -216,7 +255,11 @@ fn render_displayed_rows(
         };
         for column in 0..grid.columns().min(usize::from(max_width)) {
             let cell = &row[column];
-            if let Some(buffer_cell) = buffer.cell_mut((area.x.saturating_add(column as u16), *y)) {
+            if let Some(buffer_cell) = surface.cell_mut(
+                bounds
+                    .origin
+                    .offset(i32::try_from(column).unwrap_or(i32::MAX), i32::from(*y)),
+            ) {
                 buffer_cell
                     .set_symbol(&sanitized_symbol(cell))
                     .set_style(cell_to_style(cell, colors));
@@ -231,14 +274,14 @@ fn render_displayed_rows(
 /// `grid_start_row` is where this grid begins relative to the top of the block
 /// (the command grid starts at 0; the output grid starts below it). Only the
 /// intersection of the grid's rows with `visible_rows` is drawn, offset within
-/// `area` so it lands at the correct vertical position.
+/// `size` so it lands at the correct vertical position.
 fn render_grid_rows(
     block_grid: &BlockGrid,
     grid_start_row: usize,
     visible_rows: Range<usize>,
     max_width: u16,
-    area: TuiRect,
-    buffer: &mut TuiBuffer,
+    bounds: TerminalBlockPaintBounds,
+    surface: &mut TuiPaintSurface<'_>,
     colors: &TerminalColorList,
 ) {
     let grid_end_row = grid_start_row.saturating_add(block_grid.len_displayed());
@@ -251,15 +294,13 @@ fn render_grid_rows(
     let displayed_rows =
         visible_start.saturating_sub(grid_start_row)..visible_end.saturating_sub(grid_start_row);
     let y_offset = visible_start.saturating_sub(visible_rows.start);
-    let mut y = area
-        .y
-        .saturating_add(y_offset.min(usize::from(u16::MAX)) as u16);
+    let mut y = y_offset.min(usize::from(u16::MAX)) as u16;
     render_displayed_rows(
         block_grid,
         displayed_rows,
         max_width,
-        area,
-        buffer,
+        bounds,
+        surface,
         colors,
         &mut y,
     );

--- a/crates/warp_tui/src/transcript_view_tests.rs
+++ b/crates/warp_tui/src/transcript_view_tests.rs
@@ -14,7 +14,7 @@ use warpui::platform::WindowStyle;
 use warpui::{AddWindowOptions, App, EntityId, EntityIdMap, TuiView};
 use warpui_core::elements::tui::{
     TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiEvent, TuiEventContext,
-    TuiLayoutContext, TuiPaintContext, TuiRect, TuiSize,
+    TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiRect, TuiScreenPosition, TuiSize,
 };
 use warpui_core::keymap::Keystroke;
 use warpui_core::presenter::tui::TuiPresenter;
@@ -552,7 +552,14 @@ fn render_element(app: &App, element: &mut dyn TuiElement, area: TuiRect) -> Vec
         );
         let mut buffer = TuiBuffer::empty(area);
         let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
-        element.render(area, &mut buffer, &mut paint_ctx);
+        {
+            let mut surface = TuiPaintSurface::new(&mut buffer);
+            element.render(
+                TuiScreenPosition::new(i32::from(area.x), i32::from(area.y)),
+                &mut surface,
+                &mut paint_ctx,
+            );
+        }
         buffer.to_lines()
     })
 }
@@ -581,12 +588,21 @@ fn dispatch_event(
 ) -> bool {
     app.read(|app| {
         let mut rendered_views = EntityIdMap::default();
-        let mut layout_ctx = TuiLayoutContext {
-            rendered_views: &mut rendered_views,
-        };
-        let mut event_ctx = TuiEventContext::default();
+        let mut buffer = TuiBuffer::empty(area);
+        let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
+        {
+            let mut surface = TuiPaintSurface::new(&mut buffer);
+            element.render(
+                TuiScreenPosition::new(i32::from(area.x), i32::from(area.y)),
+                &mut surface,
+                &mut paint_ctx,
+            );
+        }
+        let scene = Rc::new(paint_ctx.scene.clone());
+        drop(paint_ctx);
+        let mut event_ctx = TuiEventContext::new(scene, &mut rendered_views);
         event_ctx.set_origin_view(Some(EntityId::new()));
-        element.dispatch_event(event, area, &mut event_ctx, &mut layout_ctx, app)
+        element.dispatch_event(event, &mut event_ctx, app)
     })
 }
 

--- a/crates/warpui_core/src/core/tui_view_tests.rs
+++ b/crates/warpui_core/src/core/tui_view_tests.rs
@@ -6,7 +6,8 @@
 
 use super::*;
 use crate::elements::tui::{
-    TuiBuffer, TuiConstraint, TuiElement, TuiLayoutContext, TuiPaintContext, TuiRect, TuiSize,
+    TuiConstraint, TuiElement, TuiLayoutContext, TuiPaintContext, TuiPaintSurface,
+    TuiScreenPosition, TuiSize,
 };
 use crate::platform::WindowStyle;
 
@@ -158,7 +159,13 @@ impl TuiElement for TuiEmpty {
         TuiSize::ZERO
     }
 
-    fn render(&self, _area: TuiRect, _buffer: &mut TuiBuffer, _ctx: &mut TuiPaintContext) {}
+    fn render(
+        &mut self,
+        _origin: TuiScreenPosition,
+        _surface: &mut TuiPaintSurface<'_>,
+        _ctx: &mut TuiPaintContext,
+    ) {
+    }
 }
 
 impl TuiView for ActionView {

--- a/crates/warpui_core/src/elements/tui/animated.rs
+++ b/crates/warpui_core/src/elements/tui/animated.rs
@@ -4,8 +4,8 @@
 use std::time::Duration;
 
 use super::{
-    TuiBuffer, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext,
-    TuiPaintContext, TuiPresentationContext, TuiRect, TuiSize,
+    TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext, TuiPaintContext,
+    TuiPaintSurface, TuiPresentationContext, TuiScreenPoint, TuiScreenPosition, TuiSize,
 };
 use crate::AppContext;
 
@@ -68,17 +68,24 @@ impl TuiElement for TuiAnimated {
             .layout(constraint, ctx, app)
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
-        if let Some(child) = &self.child {
-            child.render(area, buffer, ctx);
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        if let Some(child) = &mut self.child {
+            child.render(origin, surface, ctx);
         }
         ctx.repaint_after(self.repaint_interval);
     }
 
-    fn cursor_position(&self, area: TuiRect, ctx: &mut TuiPaintContext) -> Option<(u16, u16)> {
-        self.child
-            .as_ref()
-            .and_then(|child| child.cursor_position(area, ctx))
+    fn size(&self) -> Option<TuiSize> {
+        self.child.as_ref().and_then(|child| child.size())
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.child.as_ref().and_then(|child| child.origin())
     }
 
     fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
@@ -90,14 +97,12 @@ impl TuiElement for TuiAnimated {
     fn dispatch_event(
         &mut self,
         event: &TuiEvent,
-        area: TuiRect,
-        event_ctx: &mut TuiEventContext,
-        ctx: &mut TuiLayoutContext,
+        event_ctx: &mut TuiEventContext<'_>,
         app: &AppContext,
     ) -> bool {
         self.child
             .as_mut()
-            .is_some_and(|child| child.dispatch_event(event, area, event_ctx, ctx, app))
+            .is_some_and(|child| child.dispatch_event(event, event_ctx, app))
     }
 }
 

--- a/crates/warpui_core/src/elements/tui/animated_tests.rs
+++ b/crates/warpui_core/src/elements/tui/animated_tests.rs
@@ -3,10 +3,10 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use super::TuiAnimated;
-use crate::elements::tui::test_support::with_paint_context;
+use crate::elements::tui::test_support::with_paint_surface;
 use crate::elements::tui::{
-    TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiLayoutContext, TuiPaintContext, TuiRect,
-    TuiSize, TuiText,
+    TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiLayoutContext, TuiPaintContext,
+    TuiPaintSurface, TuiRect, TuiScreenPosition, TuiSize, TuiText,
 };
 use crate::{App, EntityIdMap};
 
@@ -36,7 +36,8 @@ fn rebuilds_its_frame_on_every_layout_pass_and_requests_repaints() {
 
                 let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, 10, 1));
                 let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
-                animated.render(TuiRect::new(0, 0, 10, 1), &mut buffer, &mut paint_ctx);
+                let mut surface = TuiPaintSurface::new(&mut buffer);
+                animated.render(TuiScreenPosition::new(0, 0), &mut surface, &mut paint_ctx);
                 assert_eq!(buffer.to_lines(), vec![format!("{expected:<10}")]);
                 assert!(paint_ctx.requested_repaint_at().is_some());
             }
@@ -47,10 +48,12 @@ fn rebuilds_its_frame_on_every_layout_pass_and_requests_repaints() {
 
 #[test]
 fn paints_nothing_before_its_first_layout() {
-    let animated = TuiAnimated::new(Duration::from_millis(50), || {
+    let mut animated = TuiAnimated::new(Duration::from_millis(50), || {
         TuiText::new("content").finish()
     });
     let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, 7, 1));
-    with_paint_context(|ctx| animated.render(TuiRect::new(0, 0, 7, 1), &mut buffer, ctx));
+    with_paint_surface(&mut buffer, |surface, ctx| {
+        animated.render(TuiScreenPosition::new(0, 0), surface, ctx)
+    });
     assert_eq!(buffer.to_lines(), vec!["       "]);
 }

--- a/crates/warpui_core/src/elements/tui/buffer.rs
+++ b/crates/warpui_core/src/elements/tui/buffer.rs
@@ -14,6 +14,110 @@
 use ratatui::buffer::CellWidth;
 pub use ratatui::buffer::{Buffer as TuiBuffer, Cell};
 pub use ratatui::style::{Color, Modifier, Style as TuiStyle};
+use ratatui::widgets::Widget;
+
+use super::geometry::{TuiPoint, TuiRect, TuiSize};
+use super::scene::TuiScreenPosition;
+
+/// Absolute-coordinate paint access to one ratatui buffer.
+pub struct TuiPaintSurface<'a> {
+    buffer: &'a mut TuiBuffer,
+    screen_origin: TuiScreenPosition,
+    buffer_origin: TuiPoint,
+}
+
+impl<'a> TuiPaintSurface<'a> {
+    /// Creates an identity-mapped surface over `buffer`.
+    pub fn new(buffer: &'a mut TuiBuffer) -> Self {
+        let buffer_origin = TuiPoint::new(buffer.area.x, buffer.area.y);
+        Self {
+            buffer,
+            screen_origin: TuiScreenPosition::new(
+                i32::from(buffer_origin.x),
+                i32::from(buffer_origin.y),
+            ),
+            buffer_origin,
+        }
+    }
+
+    /// Maps `screen_origin` to the top-left cell of `buffer`.
+    pub fn mapped(buffer: &'a mut TuiBuffer, screen_origin: TuiScreenPosition) -> Self {
+        Self {
+            buffer_origin: TuiPoint::new(buffer.area.x, buffer.area.y),
+            buffer,
+            screen_origin,
+        }
+    }
+
+    /// Renders a ratatui widget within absolute screen bounds.
+    pub fn render_widget(
+        &mut self,
+        widget: impl Widget,
+        origin: TuiScreenPosition,
+        size: TuiSize,
+    ) -> bool {
+        let Some(area) = self.contained_buffer_rect(origin, size) else {
+            return false;
+        };
+        widget.render(area, self.buffer);
+        true
+    }
+
+    /// Applies `style` to the visible part of the absolute screen bounds.
+    pub fn set_style(&mut self, origin: TuiScreenPosition, size: TuiSize, style: TuiStyle) {
+        let Some(area) = self.buffer_rect(origin, size) else {
+            return;
+        };
+        let area = area.intersection(self.buffer.area);
+        if !area.is_empty() {
+            self.buffer.set_style(area, style);
+        }
+    }
+
+    /// Returns the cell at an absolute screen position.
+    pub fn cell(&self, position: TuiScreenPosition) -> Option<&Cell> {
+        self.buffer_point(position)
+            .and_then(|position| self.buffer.cell(position))
+    }
+
+    /// Returns the mutable cell at an absolute screen position.
+    pub fn cell_mut(&mut self, position: TuiScreenPosition) -> Option<&mut Cell> {
+        self.buffer_point(position)
+            .and_then(|position| self.buffer.cell_mut(position))
+    }
+
+    /// Replaces the cell at an absolute screen position.
+    pub fn set_cell(&mut self, position: TuiScreenPosition, cell: Cell) -> bool {
+        let Some(destination) = self.cell_mut(position) else {
+            return false;
+        };
+        *destination = cell;
+        true
+    }
+
+    fn contained_buffer_rect(&self, origin: TuiScreenPosition, size: TuiSize) -> Option<TuiRect> {
+        let area = self.buffer_rect(origin, size)?;
+        (area.intersection(self.buffer.area) == area).then_some(area)
+    }
+
+    fn buffer_rect(&self, origin: TuiScreenPosition, size: TuiSize) -> Option<TuiRect> {
+        let origin = self.buffer_point(origin)?;
+        origin.x.checked_add(size.width)?;
+        origin.y.checked_add(size.height)?;
+        Some(TuiRect::new(origin.x, origin.y, size.width, size.height))
+    }
+
+    fn buffer_point(&self, position: TuiScreenPosition) -> Option<TuiPoint> {
+        let x = i64::from(self.buffer_origin.x)
+            .checked_add(i64::from(position.x).checked_sub(i64::from(self.screen_origin.x))?)?;
+        let y = i64::from(self.buffer_origin.y)
+            .checked_add(i64::from(position.y).checked_sub(i64::from(self.screen_origin.y))?)?;
+        Some(TuiPoint::new(
+            u16::try_from(x).ok()?,
+            u16::try_from(y).ok()?,
+        ))
+    }
+}
 
 /// Headless rendering of a [`TuiBuffer`] to one `String` per row.
 pub trait TuiBufferExt {

--- a/crates/warpui_core/src/elements/tui/buffer_tests.rs
+++ b/crates/warpui_core/src/elements/tui/buffer_tests.rs
@@ -1,6 +1,6 @@
 use ratatui::style::{Color, Style};
 
-use crate::elements::tui::{TuiBuffer, TuiBufferExt, TuiRect};
+use crate::elements::tui::{TuiBuffer, TuiBufferExt, TuiPaintSurface, TuiRect, TuiScreenPosition};
 
 fn buffer(width: u16, height: u16) -> TuiBuffer {
     TuiBuffer::empty(TuiRect::new(0, 0, width, height))
@@ -54,4 +54,34 @@ fn styled_writes_round_trip_through_cells() {
 
     assert_eq!(b[(0, 0)].symbol(), "x");
     assert_eq!(b[(0, 0)].fg, Color::Red);
+}
+
+/// Maps negative absolute positions onto a scratch buffer without exposing its origin.
+#[test]
+fn mapped_surface_writes_negative_absolute_positions() {
+    let mut b = buffer(2, 1);
+    {
+        let mut surface = TuiPaintSurface::mapped(&mut b, TuiScreenPosition::new(-5, -2));
+        surface
+            .cell_mut(TuiScreenPosition::new(-4, -2))
+            .unwrap()
+            .set_symbol("x");
+    }
+
+    assert_eq!(b.to_lines(), vec![" x"]);
+}
+
+/// Rejects positions outside the active buffer instead of clamping them.
+#[test]
+fn surface_writes_outside_the_mapping_fail_closed() {
+    let mut b = buffer(2, 1);
+    {
+        let mut surface = TuiPaintSurface::mapped(&mut b, TuiScreenPosition::new(-5, -2));
+        assert!(surface.cell_mut(TuiScreenPosition::new(-6, -2)).is_none());
+        assert!(surface
+            .cell_mut(TuiScreenPosition::new(i32::MAX, -2))
+            .is_none());
+    }
+
+    assert_eq!(b.to_lines(), vec!["  "]);
 }

--- a/crates/warpui_core/src/elements/tui/child_view.rs
+++ b/crates/warpui_core/src/elements/tui/child_view.rs
@@ -17,8 +17,9 @@
 //!   the action origin for the duration of the subtree's dispatch.
 
 use super::{
-    TuiBuffer, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext,
-    TuiPaintContext, TuiPresentationContext, TuiRect, TuiSize, TuiViewMapContext,
+    TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext, TuiPaintContext,
+    TuiPaintSurface, TuiPresentationContext, TuiScreenPoint, TuiScreenPosition, TuiSize,
+    TuiViewMapContext,
 };
 #[cfg(test)]
 use crate::EntityIdMap;
@@ -33,12 +34,16 @@ use crate::{AppContext, EntityId, TuiView, ViewHandle};
 /// `EventContext`.
 pub struct TuiChildView {
     view_id: EntityId,
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
 }
 
 impl TuiChildView {
     pub fn new<V: TuiView>(handle: &ViewHandle<V>) -> Self {
         Self {
             view_id: handle.id(),
+            size: None,
+            origin: None,
         }
     }
 
@@ -53,14 +58,22 @@ impl TuiChildView {
         rendered_views: &mut EntityIdMap<Box<dyn TuiElement>>,
     ) -> Self {
         rendered_views.insert(view_id, child);
-        Self { view_id }
+        Self {
+            view_id,
+            size: None,
+            origin: None,
+        }
     }
 
     /// Constructs a bare child-view node for tests — no element pre-inserted.
     /// The caller must populate `rendered_views` separately before any pass.
     #[cfg(test)]
     pub(crate) fn for_view_id(view_id: EntityId) -> Self {
-        Self { view_id }
+        Self {
+            view_id,
+            size: None,
+            origin: None,
+        }
     }
 }
 
@@ -71,22 +84,36 @@ impl TuiElement for TuiChildView {
         ctx: &mut TuiLayoutContext,
         app: &AppContext,
     ) -> TuiSize {
+        let size = ctx
+            .use_view(self.view_id, |child, ctx| {
+                child.layout(constraint, ctx, app)
+            })
+            .unwrap_or_else(|| {
+                log::warn!("TuiChildView: no element found for {:?}", self.view_id);
+                TuiSize::ZERO
+            });
+        self.size = Some(size);
+        size
+    }
+
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.origin = Some(ctx.scene_point(origin));
         ctx.use_view(self.view_id, |child, ctx| {
-            child.layout(constraint, ctx, app)
-        })
-        .unwrap_or_else(|| {
-            log::warn!("TuiChildView: no element found for {:?}", self.view_id);
-            TuiSize::ZERO
-        })
+            child.render(origin, surface, ctx)
+        });
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
-        ctx.use_view(self.view_id, |child, ctx| child.render(area, buffer, ctx));
+    fn size(&self) -> Option<TuiSize> {
+        self.size
     }
 
-    fn cursor_position(&self, area: TuiRect, ctx: &mut TuiPaintContext) -> Option<(u16, u16)> {
-        ctx.use_view(self.view_id, |child, ctx| child.cursor_position(area, ctx))
-            .flatten()
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
     }
 
     fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
@@ -98,18 +125,17 @@ impl TuiElement for TuiChildView {
     fn dispatch_event(
         &mut self,
         event: &TuiEvent,
-        area: TuiRect,
-        event_ctx: &mut TuiEventContext,
-        ctx: &mut TuiLayoutContext,
+        event_ctx: &mut TuiEventContext<'_>,
         app: &AppContext,
     ) -> bool {
-        ctx.use_view(self.view_id, |child, ctx| {
-            let previous_origin = event_ctx.set_origin_view(Some(self.view_id));
-            let handled = child.dispatch_event(event, area, event_ctx, ctx, app);
-            event_ctx.set_origin_view(previous_origin);
-            handled
-        })
-        .unwrap_or(false)
+        event_ctx
+            .use_view(self.view_id, |child, event_ctx| {
+                let previous_origin = event_ctx.set_origin_view(Some(self.view_id));
+                let handled = child.dispatch_event(event, event_ctx, app);
+                event_ctx.set_origin_view(previous_origin);
+                handled
+            })
+            .unwrap_or(false)
     }
 }
 

--- a/crates/warpui_core/src/elements/tui/child_view_tests.rs
+++ b/crates/warpui_core/src/elements/tui/child_view_tests.rs
@@ -1,23 +1,22 @@
 use super::TuiChildView;
-use crate::elements::tui::{
-    TuiBuffer, TuiBufferExt, TuiElement, TuiPaintContext, TuiPresentationContext, TuiRect, TuiText,
-};
-use crate::{EntityId, EntityIdMap};
+use crate::elements::tui::{TuiBufferExt, TuiElement, TuiPresentationContext, TuiRect, TuiText};
+use crate::presenter::tui::TuiPresenter;
+use crate::{App, EntityId, EntityIdMap};
 
 #[test]
 fn embeds_and_renders_the_stub_at_the_given_area() {
-    let mut rendered_views = EntityIdMap::default();
-    let view = TuiChildView::from_rendered(
-        EntityId::from_usize(1),
-        Box::new(TuiText::new("Z")),
-        &mut rendered_views,
-    );
-
-    let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, 3, 1));
-    let mut ctx = TuiPaintContext::new(&mut rendered_views);
-    // Render offset one column in: the embedded glyph must land at x = 1.
-    view.render(TuiRect::new(1, 0, 2, 1), &mut buffer, &mut ctx);
-    assert_eq!(buffer.to_lines(), vec![" Z "]);
+    App::test((), |app| async move {
+        app.read(|app_ctx| {
+            let view_id = EntityId::from_usize(1);
+            let mut presenter = TuiPresenter::new();
+            presenter
+                .rendered_views
+                .insert(view_id, Box::new(TuiText::new("Z")));
+            let view = TuiChildView::for_view_id(view_id);
+            let frame = presenter.present_element(view.finish(), TuiRect::new(1, 0, 2, 1), app_ctx);
+            assert_eq!(frame.buffer.to_lines(), vec![" Z "]);
+        });
+    });
 }
 
 #[test]

--- a/crates/warpui_core/src/elements/tui/clipped.rs
+++ b/crates/warpui_core/src/elements/tui/clipped.rs
@@ -6,8 +6,9 @@
 //! the child rows before the first visible row.
 
 use super::{
-    TuiBuffer, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext,
-    TuiPaintContext, TuiPresentationContext, TuiRect, TuiRectExt, TuiSize,
+    TuiBuffer, TuiClipBounds, TuiConstraint, TuiElement, TuiEvent, TuiEventContext,
+    TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiPresentationContext, TuiRect,
+    TuiScreenPoint, TuiScreenPosition, TuiScreenRect, TuiSize,
 };
 use crate::AppContext;
 
@@ -15,6 +16,8 @@ use crate::AppContext;
 pub struct TuiClipped {
     child: Box<dyn TuiElement>,
     viewport_origin_y: u16,
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
 }
 
 impl TuiClipped {
@@ -23,6 +26,26 @@ impl TuiClipped {
         Self {
             child,
             viewport_origin_y: 0,
+            size: None,
+            origin: None,
+        }
+    }
+
+    /// Wraps an already-laid-out child with retained viewport geometry.
+    pub(crate) fn from_laid_out_child(
+        child: Box<dyn TuiElement>,
+        viewport_origin_y: usize,
+        size: TuiSize,
+    ) -> Self {
+        debug_assert!(
+            child.size().is_some(),
+            "TuiClipped child size must be retained before wrapping"
+        );
+        Self {
+            child,
+            viewport_origin_y: viewport_origin_y.min(usize::from(u16::MAX)) as u16,
+            size: Some(size),
+            origin: None,
         }
     }
 
@@ -70,39 +93,63 @@ impl TuiElement for TuiClipped {
             self.child_height(constraint.max.height),
         );
         let child_size = self.child.layout(TuiConstraint::loose(child_max), ctx, app);
-        constraint.clamp(TuiSize::new(
+        let size = constraint.clamp(TuiSize::new(
             child_size.width,
             child_size.height.saturating_sub(self.viewport_origin_y),
-        ))
+        ));
+        self.size = Some(size);
+        size
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
-        if area.is_empty() {
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        let screen_origin = ctx.scene_point(origin);
+        self.origin = Some(screen_origin);
+        let Some(size) = self.size else {
+            return;
+        };
+        if size.width == 0 || size.height == 0 {
             return;
         }
-
-        let child_height = self.child_height(area.height);
-        let child_area = TuiRect::new(0, 0, area.width, child_height);
+        let child_size = self
+            .child
+            .size()
+            .expect("TuiClipped child size must be retained after layout");
+        let child_area = TuiRect::new(
+            0,
+            0,
+            size.width.max(child_size.width),
+            self.child_height(size.height).max(child_size.height),
+        );
         let mut child_buffer = TuiBuffer::empty(child_area);
-        self.child.render(child_area, &mut child_buffer, ctx);
+        let clip = TuiScreenRect::new(screen_origin, size);
+        let child_origin = origin.offset(0, -i32::from(self.viewport_origin_y));
+        ctx.with_scene_layer(TuiClipBounds::BoundedByActiveLayerAnd(clip), |ctx| {
+            let mut child_surface = TuiPaintSurface::mapped(&mut child_buffer, child_origin);
+            self.child.render(child_origin, &mut child_surface, ctx);
+        });
 
-        for y in 0..area.height {
+        for y in 0..size.height {
             let source_y = y.saturating_add(self.viewport_origin_y);
-            for x in 0..area.width {
-                if let Some(cell) =
-                    buffer.cell_mut((area.x.saturating_add(x), area.y.saturating_add(y)))
-                {
-                    *cell = child_buffer[(x, source_y)].clone();
-                }
+            for x in 0..size.width {
+                surface.set_cell(
+                    origin.offset(i32::from(x), i32::from(y)),
+                    child_buffer[(x, source_y)].clone(),
+                );
             }
         }
     }
 
-    fn cursor_position(&self, area: TuiRect, ctx: &mut TuiPaintContext) -> Option<(u16, u16)> {
-        let child_area = TuiRect::new(area.x, area.y, area.width, self.child_height(area.height));
-        let (x, y) = self.child.cursor_position(child_area, ctx)?;
-        let y = y.checked_sub(self.viewport_origin_y)?;
-        (y < area.height).then_some((x, y))
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
     }
 
     fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
@@ -112,30 +159,10 @@ impl TuiElement for TuiClipped {
     fn dispatch_event(
         &mut self,
         event: &TuiEvent,
-        area: TuiRect,
-        event_ctx: &mut TuiEventContext,
-        ctx: &mut TuiLayoutContext,
+        event_ctx: &mut TuiEventContext<'_>,
         app: &AppContext,
     ) -> bool {
-        // The child was laid out at its full logical height (visible +
-        // clipped rows). Filter mouse events to the visible window, then give the
-        // child its full logical area translated so `viewport_origin_y`
-        // aligns with the visible top: a container child then splits the
-        // correct height, and a click at the visible top hits logical row
-        // `viewport_origin_y`.
-        if let Some(position) = event.position() {
-            if !area.contains_point(position) {
-                return false;
-            }
-        }
-        let child_area = TuiRect::new(
-            area.x,
-            area.y.saturating_sub(self.viewport_origin_y),
-            area.width,
-            self.child_height(area.height),
-        );
-        self.child
-            .dispatch_event(event, child_area, event_ctx, ctx, app)
+        self.child.dispatch_event(event, event_ctx, app)
     }
 }
 

--- a/crates/warpui_core/src/elements/tui/clipped_tests.rs
+++ b/crates/warpui_core/src/elements/tui/clipped_tests.rs
@@ -1,15 +1,58 @@
-use std::cell::RefCell;
+use std::cell::Cell;
 use std::rc::Rc;
 
 use super::TuiClipped;
-use crate::elements::tui::test_support::{render_to_lines, with_paint_context};
+use crate::elements::tui::test_support::{dispatch_presented_event, render_to_lines};
 use crate::elements::tui::{
-    TuiBuffer, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext,
-    TuiPaintContext, TuiPoint, TuiRect, TuiSize, TuiText,
+    TuiConstraint, TuiElement, TuiEvent, TuiFlex, TuiHoverable, TuiLayoutContext, TuiPaintContext,
+    TuiPaintSurface, TuiPoint, TuiRect, TuiScreenPoint, TuiScreenPosition, TuiSize, TuiText,
 };
-use crate::event::{KeyEventDetails, ModifiersState};
-use crate::keymap::Keystroke;
+use crate::elements::MouseStateHandle;
+use crate::event::ModifiersState;
+use crate::presenter::tui::TuiPresenter;
 use crate::{App, AppContext, EntityIdMap};
+struct MissingRetainedSize;
+
+impl TuiElement for MissingRetainedSize {
+    /// Returns a non-empty layout without retaining it.
+    fn layout(
+        &mut self,
+        constraint: TuiConstraint,
+        _ctx: &mut TuiLayoutContext,
+        _app: &AppContext,
+    ) -> TuiSize {
+        constraint.clamp(TuiSize::new(1, 1))
+    }
+
+    /// Paints nothing.
+    fn render(
+        &mut self,
+        _origin: TuiScreenPosition,
+        _surface: &mut TuiPaintSurface<'_>,
+        _ctx: &mut TuiPaintContext,
+    ) {
+    }
+}
+
+/// Rejects children that violate the retained-size contract.
+#[test]
+#[should_panic(expected = "TuiClipped child size must be retained after layout")]
+fn render_requires_the_child_to_retain_its_layout_size() {
+    render_to_lines(
+        TuiClipped::new(MissingRetainedSize.finish()),
+        TuiSize::new(1, 1),
+    );
+}
+
+/// Composes absolute origins through nested scratch surfaces.
+#[test]
+fn nested_clipping_preserves_the_requested_logical_rows() {
+    let inner =
+        TuiClipped::new(TuiText::new("a\nb\nc\nd").truncate().finish()).with_viewport_origin_y(1);
+    let outer = TuiClipped::new(inner.finish()).with_viewport_origin_y(1);
+
+    assert_eq!(render_to_lines(outer, TuiSize::new(1, 2)), vec!["c", "d"],);
+}
 
 #[test]
 fn renders_from_the_requested_logical_row() {
@@ -17,7 +60,7 @@ fn renders_from_the_requested_logical_row() {
         TuiClipped::new(TuiText::new("a\nb\nc").truncate().finish()).with_viewport_origin_y(1);
 
     assert_eq!(
-        render_to_lines(&clipped, TuiSize::new(3, 2)),
+        render_to_lines(clipped, TuiSize::new(3, 2)),
         vec!["b  ", "c  "],
     );
 }
@@ -42,6 +85,8 @@ fn layout_preserves_child_width_and_reports_visible_height() {
 
 struct CursorElement {
     cursor: (u16, u16),
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
 }
 
 impl TuiElement for CursorElement {
@@ -51,63 +96,60 @@ impl TuiElement for CursorElement {
         _ctx: &mut TuiLayoutContext,
         _app: &AppContext,
     ) -> TuiSize {
-        constraint.clamp(TuiSize::new(1, 3))
+        let size = constraint.clamp(TuiSize::new(1, 3));
+        self.size = Some(size);
+        size
     }
 
-    fn render(&self, _area: TuiRect, _buffer: &mut TuiBuffer, _ctx: &mut TuiPaintContext) {}
-
-    fn cursor_position(&self, _area: TuiRect, _ctx: &mut TuiPaintContext) -> Option<(u16, u16)> {
-        Some(self.cursor)
+    fn render(
+        &mut self,
+        position: TuiScreenPosition,
+        _surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        let origin = ctx.scene_point(position);
+        self.origin = Some(origin);
+        ctx.set_terminal_cursor(TuiScreenPoint::new(
+            origin.x.saturating_add(i32::from(self.cursor.0)),
+            origin.y.saturating_add(i32::from(self.cursor.1)),
+            origin.z_index,
+        ));
     }
+
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
+    }
+}
+
+fn clipped_cursor_frame(cursor: (u16, u16)) -> crate::presenter::tui::TuiFrame {
+    App::test((), |app| async move {
+        app.read(|app_ctx| {
+            let clipped = TuiClipped::new(
+                CursorElement {
+                    cursor,
+                    size: None,
+                    origin: None,
+                }
+                .finish(),
+            )
+            .with_viewport_origin_y(1);
+            TuiPresenter::new().present_element(clipped.finish(), TuiRect::new(0, 0, 3, 2), app_ctx)
+        })
+    })
 }
 
 #[test]
 fn cursor_position_is_shifted_into_the_visible_window() {
-    let clipped =
-        TuiClipped::new(CursorElement { cursor: (0, 2) }.finish()).with_viewport_origin_y(1);
-    let cursor = with_paint_context(|ctx| clipped.cursor_position(TuiRect::new(0, 0, 3, 2), ctx));
-    assert_eq!(cursor, Some((0, 1)));
+    assert_eq!(clipped_cursor_frame((0, 2)).cursor, Some((0, 1)));
 }
 
 #[test]
 fn cursor_position_above_the_visible_window_is_hidden() {
-    let clipped =
-        TuiClipped::new(CursorElement { cursor: (0, 0) }.finish()).with_viewport_origin_y(1);
-    let cursor = with_paint_context(|ctx| clipped.cursor_position(TuiRect::new(0, 0, 3, 2), ctx));
-    assert_eq!(cursor, None);
-}
-
-// A child element that records the `area` it received in `dispatch_event`,
-// used to verify `TuiClipped` translates coordinates correctly.
-struct DispatchRecorder {
-    seen_area: Rc<RefCell<Option<TuiRect>>>,
-    handle: bool,
-}
-
-impl TuiElement for DispatchRecorder {
-    fn layout(
-        &mut self,
-        constraint: TuiConstraint,
-        _ctx: &mut TuiLayoutContext,
-        _app: &AppContext,
-    ) -> TuiSize {
-        // Claim 3 rows so origin y=1 leaves a 2-row visible window.
-        constraint.clamp(TuiSize::new(1, 3))
-    }
-
-    fn render(&self, _area: TuiRect, _buffer: &mut TuiBuffer, _ctx: &mut TuiPaintContext) {}
-
-    fn dispatch_event(
-        &mut self,
-        _event: &TuiEvent,
-        area: TuiRect,
-        _event_ctx: &mut TuiEventContext,
-        _ctx: &mut TuiLayoutContext,
-        _app: &AppContext,
-    ) -> bool {
-        *self.seen_area.borrow_mut() = Some(area);
-        self.handle
-    }
+    assert_eq!(clipped_cursor_frame((0, 0)).cursor, None);
 }
 
 fn left_mouse_down(x: u16, y: u16) -> TuiEvent {
@@ -120,98 +162,32 @@ fn left_mouse_down(x: u16, y: u16) -> TuiEvent {
 }
 
 #[test]
-fn dispatch_translates_mouse_event_to_full_logical_area() {
+fn hoverable_inside_clipped_content_uses_visible_screen_geometry() {
     App::test((), |app| async move {
         app.read(|app_ctx| {
-            let seen_area = Rc::new(RefCell::new(None));
-            let mut clipped = TuiClipped::new(
-                DispatchRecorder {
-                    seen_area: seen_area.clone(),
-                    handle: true,
-                }
-                .finish(),
-            )
-            .with_viewport_origin_y(1);
-            let mut rendered_views = EntityIdMap::default();
-            let mut ctx = TuiLayoutContext {
-                rendered_views: &mut rendered_views,
-            };
-            let mut event_ctx = TuiEventContext::default();
-            // Visible slot (0, 1, 3, 2); the child's logical row 1 maps to y=1.
-            let area = TuiRect::new(0, 1, 3, 2);
-            let event = left_mouse_down(0, 1);
-            let handled = clipped.dispatch_event(&event, area, &mut event_ctx, &mut ctx, app_ctx);
-            assert!(handled);
-            // Child sees its full logical area: y = 1 - 1 = 0, height = 2 + 1 = 3.
-            assert_eq!(*seen_area.borrow(), Some(TuiRect::new(0, 0, 3, 3)));
-        });
-    });
-}
+            let hits = Rc::new(Cell::new(0));
+            let counter = hits.clone();
+            let hoverable =
+                TuiHoverable::new(MouseStateHandle::default(), TuiText::new("hit").finish())
+                    .on_click(move |_, _| counter.set(counter.get() + 1));
+            let child = TuiFlex::column()
+                .child(TuiText::new("hidden").finish())
+                .child(hoverable.finish());
+            let clipped = TuiClipped::new(child.finish()).with_viewport_origin_y(1);
+            let mut presenter = TuiPresenter::new();
+            presenter.present_element(clipped.finish(), TuiRect::new(0, 0, 6, 1), app_ctx);
 
-#[test]
-fn dispatch_filters_mouse_events_outside_visible_window() {
-    App::test((), |app| async move {
-        app.read(|app_ctx| {
-            let seen_area = Rc::new(RefCell::new(None));
-            let mut clipped = TuiClipped::new(
-                DispatchRecorder {
-                    seen_area: seen_area.clone(),
-                    handle: true,
-                }
-                .finish(),
-            )
-            .with_viewport_origin_y(1);
-            let mut rendered_views = EntityIdMap::default();
-            let mut ctx = TuiLayoutContext {
-                rendered_views: &mut rendered_views,
-            };
-            let mut event_ctx = TuiEventContext::default();
-            let area = TuiRect::new(0, 1, 3, 2);
-            // Click at y=0, above the visible window [1, 3).
-            let event = left_mouse_down(0, 0);
-            let handled = clipped.dispatch_event(&event, area, &mut event_ctx, &mut ctx, app_ctx);
-            assert!(!handled);
-            assert!(
-                seen_area.borrow().is_none(),
-                "child should not see an out-of-window event"
-            );
-        });
-    });
-}
+            assert!(dispatch_presented_event(&mut presenter, &left_mouse_down(1, 0), app_ctx).0);
+            assert_eq!(hits.get(), 0, "click fires on release");
 
-#[test]
-fn dispatch_forwards_non_positional_events_without_filtering() {
-    App::test((), |app| async move {
-        app.read(|app_ctx| {
-            let seen_area = Rc::new(RefCell::new(None));
-            let mut clipped = TuiClipped::new(
-                DispatchRecorder {
-                    seen_area: seen_area.clone(),
-                    handle: true,
-                }
-                .finish(),
-            )
-            .with_viewport_origin_y(1);
-            let mut rendered_views = EntityIdMap::default();
-            let mut ctx = TuiLayoutContext {
-                rendered_views: &mut rendered_views,
+            let released = TuiEvent::LeftMouseUp {
+                position: TuiPoint::new(1, 0),
+                modifiers: ModifiersState::default(),
             };
-            let mut event_ctx = TuiEventContext::default();
-            let area = TuiRect::new(0, 1, 3, 2);
-            // A key event carries no position, so it bypasses the window filter
-            // and still reaches the child with its full logical area.
-            let event = TuiEvent::KeyDown {
-                keystroke: Keystroke {
-                    key: "a".to_owned(),
-                    ..Default::default()
-                },
-                chars: "a".to_owned(),
-                details: KeyEventDetails::default(),
-                is_composing: false,
-            };
-            let handled = clipped.dispatch_event(&event, area, &mut event_ctx, &mut ctx, app_ctx);
-            assert!(handled);
-            assert_eq!(*seen_area.borrow(), Some(TuiRect::new(0, 0, 3, 3)));
+            assert!(dispatch_presented_event(&mut presenter, &released, app_ctx).0);
+            assert_eq!(hits.get(), 1);
+
+            assert!(!dispatch_presented_event(&mut presenter, &left_mouse_down(1, 1), app_ctx).0);
         });
     });
 }

--- a/crates/warpui_core/src/elements/tui/collapsible_tests.rs
+++ b/crates/warpui_core/src/elements/tui/collapsible_tests.rs
@@ -2,14 +2,15 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use super::tui_collapsible;
-use crate::elements::tui::test_support::with_paint_context;
+use crate::elements::tui::test_support::{dispatch_presented_event, with_paint_surface};
 use crate::elements::tui::{
-    Modifier, TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiEvent, TuiEventContext,
-    TuiLayoutContext, TuiPoint, TuiRect, TuiSize, TuiStyle, TuiText,
+    Modifier, TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiEvent, TuiLayoutContext,
+    TuiPoint, TuiRect, TuiScreenPosition, TuiSize, TuiStyle, TuiText,
 };
 use crate::elements::MouseStateHandle;
 use crate::event::ModifiersState;
-use crate::{App, EntityId, EntityIdMap};
+use crate::presenter::tui::TuiPresenter;
+use crate::{App, EntityIdMap};
 
 #[test]
 fn only_a_header_click_invokes_on_toggle() {
@@ -17,7 +18,7 @@ fn only_a_header_click_invokes_on_toggle() {
         app.read(|app_ctx| {
             let hits = Rc::new(Cell::new(0u32));
             let counter = hits.clone();
-            let mut collapsible = tui_collapsible(
+            let collapsible = tui_collapsible(
                 false,
                 [("Thinking...".to_owned(), TuiStyle::default())],
                 TuiStyle::default(),
@@ -25,39 +26,37 @@ fn only_a_header_click_invokes_on_toggle() {
                 || TuiText::new("reasoning").finish(),
                 move |_, _| counter.set(counter.get() + 1),
             );
-            let mut rendered_views = EntityIdMap::default();
-            let mut ctx = TuiLayoutContext {
-                rendered_views: &mut rendered_views,
-            };
             let area = TuiRect::new(0, 0, 20, 4);
-            collapsible.layout(TuiConstraint::loose(TuiSize::new(20, 4)), &mut ctx, app_ctx);
+            let mut presenter = TuiPresenter::new();
+            presenter.present_element(collapsible, area, app_ctx);
             // A click is a press-then-release pair; the hoverable's arming
             // notify needs an origin view to attribute the redraw to.
-            let mut click = |y| {
-                let mut event_ctx = TuiEventContext::default();
-                event_ctx.set_origin_view(Some(EntityId::new()));
+            let mut click = |x, y| {
                 let down = TuiEvent::LeftMouseDown {
-                    position: TuiPoint::new(2, y),
+                    position: TuiPoint::new(x, y),
                     modifiers: ModifiersState::default(),
                     click_count: 1,
                     is_first_mouse: false,
                 };
-                let pressed =
-                    collapsible.dispatch_event(&down, area, &mut event_ctx, &mut ctx, app_ctx);
+                let pressed = dispatch_presented_event(&mut presenter, &down, app_ctx).0;
                 let up = TuiEvent::LeftMouseUp {
-                    position: TuiPoint::new(2, y),
+                    position: TuiPoint::new(x, y),
                     modifiers: ModifiersState::default(),
                 };
-                let released =
-                    collapsible.dispatch_event(&up, area, &mut event_ctx, &mut ctx, app_ctx);
+                let released = dispatch_presented_event(&mut presenter, &up, app_ctx).0;
                 pressed && released
             };
 
             // Row 0 is the header: the click toggles. Row 1 is the body: the
             // header's handler covers only its own slot, so it goes unhandled.
-            assert!(click(0));
+            assert!(click(2, 0));
             assert_eq!(hits.get(), 1);
-            assert!(!click(1));
+            assert!(!click(2, 1));
+            assert_eq!(hits.get(), 1);
+
+            // The blank space right of the label + chevron ("Thinking... ▾"
+            // spans 13 columns) is not part of the click target.
+            assert!(!click(15, 0));
             assert_eq!(hits.get(), 1);
         });
     });
@@ -89,7 +88,9 @@ fn header_styles_apply_per_span_without_bleeding_past_the_text() {
             let area = TuiRect::new(0, 0, 20, 2);
             collapsible.layout(TuiConstraint::loose(TuiSize::new(20, 2)), &mut ctx, app_ctx);
             let mut buffer = TuiBuffer::empty(area);
-            with_paint_context(|paint_ctx| collapsible.render(area, &mut buffer, paint_ctx));
+            with_paint_surface(&mut buffer, |surface, paint_ctx| {
+                collapsible.render(TuiScreenPosition::new(0, 0), surface, paint_ctx)
+            });
 
             // The underline covers exactly the label's cells — not the
             // glyph, the chevron, or the trailing cells past the text. The

--- a/crates/warpui_core/src/elements/tui/constrained_box.rs
+++ b/crates/warpui_core/src/elements/tui/constrained_box.rs
@@ -14,8 +14,8 @@
 //! bottom input to at most six rows) without a bespoke layout element.
 
 use super::{
-    TuiBuffer, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext,
-    TuiPaintContext, TuiPresentationContext, TuiRect, TuiSize,
+    TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext, TuiPaintContext,
+    TuiPaintSurface, TuiPresentationContext, TuiScreenPoint, TuiScreenPosition, TuiSize,
 };
 use crate::AppContext;
 
@@ -61,17 +61,6 @@ impl TuiConstrainedBox {
         );
         TuiConstraint::new(min, TuiSize::new(max_width, max_height))
     }
-
-    /// `area` clipped to the configured caps, anchored at the area's origin.
-    fn capped_area(&self, area: TuiRect) -> TuiRect {
-        let width = self
-            .max_cols
-            .map_or(area.width, |cols| area.width.min(cols));
-        let height = self
-            .max_rows
-            .map_or(area.height, |rows| area.height.min(rows));
-        TuiRect::new(area.x, area.y, width, height)
-    }
 }
 
 impl TuiElement for TuiConstrainedBox {
@@ -84,12 +73,21 @@ impl TuiElement for TuiConstrainedBox {
         self.child.layout(self.cap_constraint(constraint), ctx, app)
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
-        self.child.render(self.capped_area(area), buffer, ctx);
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.child.render(origin, surface, ctx);
     }
 
-    fn cursor_position(&self, area: TuiRect, ctx: &mut TuiPaintContext) -> Option<(u16, u16)> {
-        self.child.cursor_position(self.capped_area(area), ctx)
+    fn size(&self) -> Option<TuiSize> {
+        self.child.size()
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.child.origin()
     }
 
     fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
@@ -99,13 +97,10 @@ impl TuiElement for TuiConstrainedBox {
     fn dispatch_event(
         &mut self,
         event: &TuiEvent,
-        area: TuiRect,
-        event_ctx: &mut TuiEventContext,
-        ctx: &mut TuiLayoutContext,
+        event_ctx: &mut TuiEventContext<'_>,
         app: &AppContext,
     ) -> bool {
-        self.child
-            .dispatch_event(event, self.capped_area(area), event_ctx, ctx, app)
+        self.child.dispatch_event(event, event_ctx, app)
     }
 }
 

--- a/crates/warpui_core/src/elements/tui/container.rs
+++ b/crates/warpui_core/src/elements/tui/container.rs
@@ -25,8 +25,9 @@
 use ratatui::style::Color;
 
 use super::{
-    TuiBuffer, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext,
-    TuiPaintContext, TuiPresentationContext, TuiRect, TuiSize, TuiStyle,
+    TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext, TuiPaintContext,
+    TuiPaintSurface, TuiPresentationContext, TuiRect, TuiScreenPoint, TuiScreenPosition, TuiSize,
+    TuiStyle,
 };
 use crate::AppContext;
 
@@ -36,6 +37,8 @@ pub struct TuiContainer {
     border: bool,
     border_style: TuiStyle,
     background: Option<Color>,
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -66,6 +69,8 @@ impl TuiContainer {
             border: false,
             border_style: TuiStyle::default(),
             background: None,
+            size: None,
+            origin: None,
         }
     }
 
@@ -199,93 +204,129 @@ impl TuiElement for TuiContainer {
             inner.width.saturating_add(self.horizontal_inset()),
             inner.height.saturating_add(self.vertical_inset()),
         );
-        constraint.clamp(size)
+        let size = constraint.clamp(size);
+        self.size = Some(size);
+        size
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.origin = Some(ctx.scene_point(origin));
+        let Some(size) = self.size else {
+            return;
+        };
+        let area = TuiRect::new(0, 0, size.width, size.height);
         if area.is_empty() {
             return;
         }
+        if self.background.is_some() || self.border {
+            if let Some(bounds) = self.bounds() {
+                ctx.scene.record_hit_rect(bounds);
+            }
+        }
 
         if let Some(background) = self.background {
-            buffer.set_style(area, TuiStyle::default().bg(background));
+            surface.set_style(origin, size, TuiStyle::default().bg(background));
         }
 
         if self.border {
-            draw_border(area, buffer, self.painted_border_style());
+            draw_border(origin, size, surface, self.painted_border_style());
         }
 
-        self.child.render(self.child_area(area), buffer, ctx);
+        let child_area = self.child_area(area);
+        self.child.render(
+            origin.offset(i32::from(child_area.x), i32::from(child_area.y)),
+            surface,
+            ctx,
+        );
+    }
+
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
     }
 
     fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
         self.child.present(ctx);
     }
 
-    fn cursor_position(&self, area: TuiRect, ctx: &mut TuiPaintContext) -> Option<(u16, u16)> {
-        // `cursor_position` is reported relative to `area`'s origin, but the
-        // child reports relative to the child area. Add the child-area offset
-        // back so the cursor lands inside the border/padding.
-        let child_area = self.child_area(area);
-        self.child.cursor_position(child_area, ctx).map(|(cx, cy)| {
-            (
-                child_area.x.saturating_sub(area.x).saturating_add(cx),
-                child_area.y.saturating_sub(area.y).saturating_add(cy),
-            )
-        })
-    }
-
     fn dispatch_event(
         &mut self,
         event: &TuiEvent,
-        area: TuiRect,
-        event_ctx: &mut TuiEventContext,
-        ctx: &mut TuiLayoutContext,
+        event_ctx: &mut TuiEventContext<'_>,
         app: &AppContext,
     ) -> bool {
-        if area.is_empty() {
-            return false;
-        }
-        self.child
-            .dispatch_event(event, self.child_area(area), event_ctx, ctx, app)
+        self.child.dispatch_event(event, event_ctx, app)
     }
 }
 
-/// Paints a single-cell box-drawing frame around the perimeter of `area`.
-fn draw_border(area: TuiRect, buffer: &mut TuiBuffer, style: TuiStyle) {
-    let right = area.right().saturating_sub(1);
-    let bottom = area.bottom().saturating_sub(1);
-    let multi_column = area.width > 1;
-    let multi_row = area.height > 1;
+/// Paints a single-cell box-drawing frame around the perimeter of `size`.
+fn draw_border(
+    origin: TuiScreenPosition,
+    size: TuiSize,
+    surface: &mut TuiPaintSurface<'_>,
+    style: TuiStyle,
+) {
+    let right = size.width.saturating_sub(1);
+    let bottom = size.height.saturating_sub(1);
+    let multi_column = size.width > 1;
+    let multi_row = size.height > 1;
 
-    for x in area.x..area.right() {
-        put(buffer, x, area.y, "─", style);
+    for x in 0..size.width {
+        put(surface, origin.offset(i32::from(x), 0), "─", style);
         if multi_row {
-            put(buffer, x, bottom, "─", style);
+            put(
+                surface,
+                origin.offset(i32::from(x), i32::from(bottom)),
+                "─",
+                style,
+            );
         }
     }
-    for y in area.y..area.bottom() {
-        put(buffer, area.x, y, "│", style);
+    for y in 0..size.height {
+        put(surface, origin.offset(0, i32::from(y)), "│", style);
         if multi_column {
-            put(buffer, right, y, "│", style);
+            put(
+                surface,
+                origin.offset(i32::from(right), i32::from(y)),
+                "│",
+                style,
+            );
         }
     }
 
-    put(buffer, area.x, area.y, "┌", style);
+    put(surface, origin, "┌", style);
     if multi_column {
-        put(buffer, right, area.y, "┐", style);
+        put(surface, origin.offset(i32::from(right), 0), "┐", style);
     }
     if multi_row {
-        put(buffer, area.x, bottom, "└", style);
+        put(surface, origin.offset(0, i32::from(bottom)), "└", style);
     }
     if multi_column && multi_row {
-        put(buffer, right, bottom, "┘", style);
+        put(
+            surface,
+            origin.offset(i32::from(right), i32::from(bottom)),
+            "┘",
+            style,
+        );
     }
 }
 
-/// Writes a single styled glyph at `(x, y)`, ignoring out-of-bounds positions.
-fn put(buffer: &mut TuiBuffer, x: u16, y: u16, symbol: &str, style: TuiStyle) {
-    if let Some(cell) = buffer.cell_mut((x, y)) {
+/// Writes a single styled glyph, ignoring out-of-bounds positions.
+fn put(
+    surface: &mut TuiPaintSurface<'_>,
+    position: TuiScreenPosition,
+    symbol: &str,
+    style: TuiStyle,
+) {
+    if let Some(cell) = surface.cell_mut(position) {
         cell.set_symbol(symbol).set_style(style);
     }
 }

--- a/crates/warpui_core/src/elements/tui/container_tests.rs
+++ b/crates/warpui_core/src/elements/tui/container_tests.rs
@@ -4,20 +4,22 @@ use std::rc::Rc;
 use ratatui::style::Color;
 
 use super::TuiContainer;
-use crate::elements::tui::test_support::{render_to_lines, with_paint_context};
+use crate::elements::tui::test_support::{render_to_lines, with_event_context};
 use crate::elements::tui::{
-    TuiBuffer, TuiChildView, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiEventHandler,
-    TuiLayoutContext, TuiPaintContext, TuiPresentationContext, TuiRect, TuiSize, TuiText,
+    TuiChildView, TuiConstraint, TuiElement, TuiEvent, TuiEventHandler, TuiLayoutContext,
+    TuiPaintContext, TuiPaintSurface, TuiPresentationContext, TuiRect, TuiScreenPoint,
+    TuiScreenPosition, TuiSize, TuiText,
 };
 use crate::event::KeyEventDetails;
 use crate::keymap::Keystroke;
+use crate::presenter::tui::TuiPresenter;
 use crate::{App, AppContext, EntityId, EntityIdMap};
 
 #[test]
 fn padding_offsets_the_child() {
     let container = TuiContainer::new(TuiText::new("X").finish()).with_padding(1);
     assert_eq!(
-        render_to_lines(&container, TuiSize::new(3, 3)),
+        render_to_lines(container, TuiSize::new(3, 3)),
         vec!["   ", " X ", "   "],
     );
 }
@@ -28,7 +30,7 @@ fn directional_padding_offsets_the_child() {
         .with_padding_left(2)
         .with_padding_top(1);
     assert_eq!(
-        render_to_lines(&container, TuiSize::new(3, 2)),
+        render_to_lines(container, TuiSize::new(3, 2)),
         vec!["   ", "  X"],
     );
 }
@@ -39,7 +41,7 @@ fn axis_padding_offsets_the_child() {
         .with_padding_x(1)
         .with_padding_y(1);
     assert_eq!(
-        render_to_lines(&container, TuiSize::new(3, 3)),
+        render_to_lines(container, TuiSize::new(3, 3)),
         vec!["   ", " X ", "   "],
     );
 }
@@ -48,7 +50,7 @@ fn axis_padding_offsets_the_child() {
 fn border_frames_the_child() {
     let container = TuiContainer::new(TuiText::new("X").finish()).with_border();
     assert_eq!(
-        render_to_lines(&container, TuiSize::new(3, 3)),
+        render_to_lines(container, TuiSize::new(3, 3)),
         vec!["┌─┐", "│X│", "└─┘"],
     );
 }
@@ -74,7 +76,7 @@ fn border_and_padding_compose() {
             assert_eq!(size, TuiSize::new(5, 5));
 
             assert_eq!(
-                render_to_lines(&container, TuiSize::new(5, 5)),
+                render_to_lines(container, TuiSize::new(5, 5)),
                 vec!["┌───┐", "│   │", "│ X │", "│   │", "└───┘"],
             );
         });
@@ -83,17 +85,21 @@ fn border_and_padding_compose() {
 
 #[test]
 fn background_fills_the_padding_area() {
-    let container = TuiContainer::new(TuiText::new("X").finish())
-        .with_padding(1)
-        .with_background(Color::Blue);
+    App::test((), |app| async move {
+        app.read(|app_ctx| {
+            let container = TuiContainer::new(TuiText::new("X").finish())
+                .with_padding(1)
+                .with_background(Color::Blue);
+            let frame = TuiPresenter::new().present_element(
+                container.finish(),
+                TuiRect::new(0, 0, 3, 3),
+                app_ctx,
+            );
 
-    let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, 3, 3));
-    with_paint_context(|ctx| container.render(TuiRect::new(0, 0, 3, 3), &mut buffer, ctx));
-
-    // A padding cell carries the background fill...
-    assert_eq!(buffer[(0, 0)].bg, Color::Blue);
-    // ...and the child glyph lands in the center.
-    assert_eq!(buffer[(1, 1)].symbol(), "X");
+            assert_eq!(frame.buffer[(0, 0)].bg, Color::Blue);
+            assert_eq!(frame.buffer[(1, 1)].symbol(), "X");
+        });
+    });
 }
 
 #[test]
@@ -136,18 +142,9 @@ fn dispatch_event_forwards_to_the_child_inside_the_inset() {
                 details: KeyEventDetails::default(),
                 is_composing: false,
             };
-            let mut event_ctx = TuiEventContext::default();
-            let mut rendered_views = EntityIdMap::default();
-            let mut ctx = TuiLayoutContext {
-                rendered_views: &mut rendered_views,
-            };
-            let handled = container.dispatch_event(
-                &event,
-                TuiRect::new(0, 0, 9, 9),
-                &mut event_ctx,
-                &mut ctx,
-                app_ctx,
-            );
+            let handled = with_event_context(|event_ctx| {
+                container.dispatch_event(&event, event_ctx, app_ctx)
+            });
 
             assert!(handled);
             assert_eq!(hits.get(), 1);
@@ -156,7 +153,10 @@ fn dispatch_event_forwards_to_the_child_inside_the_inset() {
 }
 
 /// A leaf element that always reports a cursor at its own top-left `(0, 0)`.
-struct CursorElement;
+struct CursorElement {
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
+}
 
 impl TuiElement for CursorElement {
     fn layout(
@@ -165,13 +165,28 @@ impl TuiElement for CursorElement {
         _ctx: &mut TuiLayoutContext,
         _app: &AppContext,
     ) -> TuiSize {
-        constraint.clamp(TuiSize::new(1, 1))
+        let size = constraint.clamp(TuiSize::new(1, 1));
+        self.size = Some(size);
+        size
     }
 
-    fn render(&self, _area: TuiRect, _buffer: &mut TuiBuffer, _ctx: &mut TuiPaintContext) {}
+    fn render(
+        &mut self,
+        position: TuiScreenPosition,
+        _surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        let origin = ctx.scene_point(position);
+        self.origin = Some(origin);
+        ctx.set_terminal_cursor(origin);
+    }
 
-    fn cursor_position(&self, _area: TuiRect, _ctx: &mut TuiPaintContext) -> Option<(u16, u16)> {
-        Some((0, 0))
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
     }
 }
 
@@ -180,9 +195,23 @@ fn cursor_position_offsets_by_border_and_padding() {
     // The child reports its cursor at (0, 0); a 1-cell border + 1-cell padding
     // insets it by 2, so the container reports the cursor at (2, 2) within its
     // own area (inside the frame, not at the corner).
-    let container = TuiContainer::new(CursorElement.finish())
-        .with_border()
-        .with_padding(1);
-    let cursor = with_paint_context(|ctx| container.cursor_position(TuiRect::new(0, 0, 5, 5), ctx));
-    assert_eq!(cursor, Some((2, 2)));
+    App::test((), |app| async move {
+        app.read(|app_ctx| {
+            let container = TuiContainer::new(
+                CursorElement {
+                    size: None,
+                    origin: None,
+                }
+                .finish(),
+            )
+            .with_border()
+            .with_padding(1);
+            let frame = TuiPresenter::new().present_element(
+                container.finish(),
+                TuiRect::new(0, 0, 5, 5),
+                app_ctx,
+            );
+            assert_eq!(frame.cursor, Some((2, 2)));
+        });
+    });
 }

--- a/crates/warpui_core/src/elements/tui/event.rs
+++ b/crates/warpui_core/src/elements/tui/event.rs
@@ -10,11 +10,15 @@
 //! conversion lives with the runtime.
 
 use std::collections::HashSet;
+use std::rc::Rc;
 
-use super::TuiPoint;
+use super::{
+    TuiElement, TuiLocalPoint, TuiPoint, TuiScene, TuiScreenPoint, TuiScreenRect, TuiSize,
+    TuiViewMapContext,
+};
 use crate::event::{KeyEventDetails, ModifiersState};
 use crate::keymap::Keystroke;
-use crate::{Action, EntityId};
+use crate::{Action, EntityId, EntityIdMap};
 
 /// A terminal scroll delta `(columns, rows)`.
 pub type TuiScrollDelta = (isize, isize);
@@ -113,8 +117,9 @@ pub struct TuiEventDispatchResult {
     pub handled: bool,
 }
 
-#[derive(Default)]
-pub struct TuiEventContext {
+pub struct TuiEventContext<'a> {
+    scene: Rc<TuiScene>,
+    rendered_views: &'a mut EntityIdMap<Box<dyn TuiElement>>,
     notified: HashSet<EntityId>,
     typed_actions: Vec<TuiDispatchedAction>,
     origin_view_id: Option<EntityId>,
@@ -128,7 +133,49 @@ pub(crate) struct TuiDispatchedAction {
     pub(crate) action: Box<dyn Action>,
 }
 
-impl TuiEventContext {
+impl<'a> TuiEventContext<'a> {
+    /// Creates dispatch state for the last painted element tree and scene.
+    pub fn new(
+        scene: Rc<TuiScene>,
+        rendered_views: &'a mut EntityIdMap<Box<dyn TuiElement>>,
+    ) -> Self {
+        Self {
+            scene,
+            rendered_views,
+            notified: HashSet::new(),
+            typed_actions: Vec::new(),
+            origin_view_id: None,
+        }
+    }
+
+    /// Returns the visible portion of retained element bounds.
+    pub fn visible_rect(&self, origin: TuiScreenPoint, size: TuiSize) -> Option<TuiScreenRect> {
+        self.scene.visible_rect(origin, size)
+    }
+
+    /// Returns whether a higher painted layer covers `point`.
+    pub fn is_covered(&self, point: TuiScreenPoint) -> bool {
+        self.scene.is_covered(point)
+    }
+
+    /// Converts a terminal pointer position to signed element-local cells.
+    pub fn local_point(&self, origin: TuiScreenPoint, position: TuiPoint) -> TuiLocalPoint {
+        TuiLocalPoint::new(
+            i32::from(position.x).saturating_sub(origin.x),
+            i32::from(position.y).saturating_sub(origin.y),
+        )
+    }
+
+    /// Returns whether a pointer is inside visible, uncovered element bounds.
+    pub fn hit_test(&self, origin: TuiScreenPoint, size: TuiSize, position: TuiPoint) -> bool {
+        self.visible_rect(origin, size)
+            .is_some_and(|rect| rect.contains(position))
+            && !self.is_covered(TuiScreenPoint::new(
+                i32::from(position.x),
+                i32::from(position.y),
+                origin.z_index,
+            ))
+    }
     /// Queues a typed action to dispatch from the view currently being
     /// processed. Panics if called outside of view event processing, where
     /// there is no origin view to attribute the action to.
@@ -164,5 +211,11 @@ impl TuiEventContext {
     /// view's subtree.
     pub fn set_origin_view(&mut self, view_id: Option<EntityId>) -> Option<EntityId> {
         std::mem::replace(&mut self.origin_view_id, view_id)
+    }
+}
+
+impl TuiViewMapContext for TuiEventContext<'_> {
+    fn rendered_views_mut(&mut self) -> &mut EntityIdMap<Box<dyn TuiElement>> {
+        self.rendered_views
     }
 }

--- a/crates/warpui_core/src/elements/tui/event_handler.rs
+++ b/crates/warpui_core/src/elements/tui/event_handler.rs
@@ -19,12 +19,12 @@
 //! ancestors can react.
 
 use super::{
-    TuiBuffer, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext,
-    TuiPaintContext, TuiPresentationContext, TuiRect, TuiSize,
+    TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext, TuiPaintContext,
+    TuiPaintSurface, TuiPresentationContext, TuiScreenPoint, TuiScreenPosition, TuiSize,
 };
 use crate::AppContext;
 
-type KeyCallback = Box<dyn FnMut(&TuiEvent, &mut TuiEventContext, &AppContext)>;
+type KeyCallback = Box<dyn for<'a> FnMut(&TuiEvent, &mut TuiEventContext<'a>, &AppContext)>;
 
 struct KeyBinding {
     key: String,
@@ -49,7 +49,7 @@ impl TuiEventHandler {
     pub fn on_key(
         mut self,
         key: impl Into<String>,
-        callback: impl FnMut(&TuiEvent, &mut TuiEventContext, &AppContext) + 'static,
+        callback: impl for<'a> FnMut(&TuiEvent, &mut TuiEventContext<'a>, &AppContext) + 'static,
     ) -> Self {
         self.bindings.push(KeyBinding {
             key: key.into(),
@@ -69,12 +69,21 @@ impl TuiElement for TuiEventHandler {
         self.child.layout(constraint, ctx, app)
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
-        self.child.render(area, buffer, ctx);
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.child.render(origin, surface, ctx);
     }
 
-    fn cursor_position(&self, area: TuiRect, ctx: &mut TuiPaintContext) -> Option<(u16, u16)> {
-        self.child.cursor_position(area, ctx)
+    fn size(&self) -> Option<TuiSize> {
+        self.child.size()
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.child.origin()
     }
 
     fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
@@ -84,12 +93,10 @@ impl TuiElement for TuiEventHandler {
     fn dispatch_event(
         &mut self,
         event: &TuiEvent,
-        area: TuiRect,
-        event_ctx: &mut TuiEventContext,
-        ctx: &mut TuiLayoutContext,
+        event_ctx: &mut TuiEventContext<'_>,
         app: &AppContext,
     ) -> bool {
-        if self.child.dispatch_event(event, area, event_ctx, ctx, app) {
+        if self.child.dispatch_event(event, event_ctx, app) {
             return true;
         }
 

--- a/crates/warpui_core/src/elements/tui/event_handler_tests.rs
+++ b/crates/warpui_core/src/elements/tui/event_handler_tests.rs
@@ -2,10 +2,8 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use super::TuiEventHandler;
-use crate::elements::tui::{
-    TuiChildView, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext, TuiPresentationContext,
-    TuiRect,
-};
+use crate::elements::tui::test_support::with_event_context;
+use crate::elements::tui::{TuiChildView, TuiElement, TuiEvent, TuiPresentationContext};
 use crate::event::KeyEventDetails;
 use crate::keymap::Keystroke;
 use crate::{App, EntityId, EntityIdMap};
@@ -33,28 +31,16 @@ fn invokes_callback_on_matching_key_and_reports_handled() {
                     counter.set(counter.get() + 1);
                 });
 
-            let area = TuiRect::new(0, 0, 4, 1);
-            let mut event_ctx = TuiEventContext::default();
-            let mut rendered_views = EntityIdMap::default();
-            let mut ctx = TuiLayoutContext {
-                rendered_views: &mut rendered_views,
-            };
+            with_event_context(|event_ctx| {
+                let handled = handler.dispatch_event(&key_event("enter"), event_ctx, app_ctx);
+                assert!(handled);
+                assert_eq!(hits.get(), 1);
 
-            let handled = handler.dispatch_event(
-                &key_event("enter"),
-                area,
-                &mut event_ctx,
-                &mut ctx,
-                app_ctx,
-            );
-            assert!(handled);
-            assert_eq!(hits.get(), 1);
-
-            // A non-matching key is left unhandled for ancestors, runs no callback.
-            let handled =
-                handler.dispatch_event(&key_event("esc"), area, &mut event_ctx, &mut ctx, app_ctx);
-            assert!(!handled);
-            assert_eq!(hits.get(), 1);
+                // A non-matching key is left unhandled for ancestors, runs no callback.
+                let handled = handler.dispatch_event(&key_event("esc"), event_ctx, app_ctx);
+                assert!(!handled);
+                assert_eq!(hits.get(), 1);
+            });
         });
     });
 }
@@ -75,18 +61,9 @@ fn child_consumes_the_event_before_the_wrapper() {
                 outer_counter.set(outer_counter.get() + 1)
             });
 
-            let mut event_ctx = TuiEventContext::default();
-            let mut rendered_views = EntityIdMap::default();
-            let mut ctx = TuiLayoutContext {
-                rendered_views: &mut rendered_views,
-            };
-            let handled = outer.dispatch_event(
-                &key_event("enter"),
-                TuiRect::new(0, 0, 1, 1),
-                &mut event_ctx,
-                &mut ctx,
-                app_ctx,
-            );
+            let handled = with_event_context(|event_ctx| {
+                outer.dispatch_event(&key_event("enter"), event_ctx, app_ctx)
+            });
 
             assert!(handled);
             assert_eq!(inner_hits.get(), 1);

--- a/crates/warpui_core/src/elements/tui/flex.rs
+++ b/crates/warpui_core/src/elements/tui/flex.rs
@@ -40,8 +40,9 @@
 //! children's, clamped to the constraint.
 
 use super::{
-    TuiBuffer, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext,
-    TuiPaintContext, TuiPresentationContext, TuiRect, TuiRectExt, TuiSize,
+    TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext, TuiPaintContext,
+    TuiPaintSurface, TuiPresentationContext, TuiRect, TuiRectExt, TuiScreenPoint,
+    TuiScreenPosition, TuiSize,
 };
 use crate::elements::{Axis, CrossAxisAlignment};
 use crate::AppContext;
@@ -62,6 +63,8 @@ pub struct TuiFlex {
     /// so `render`, `cursor_position`, and `dispatch_event` have consistent slot
     /// information.
     child_sizes: Vec<TuiSize>,
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
 }
 
 impl TuiFlex {
@@ -71,6 +74,8 @@ impl TuiFlex {
             children: Vec::new(),
             cross_axis_alignment: CrossAxisAlignment::Start,
             child_sizes: Vec::new(),
+            size: None,
+            origin: None,
         }
     }
 
@@ -147,6 +152,26 @@ impl TuiFlex {
         }
     }
 
+    /// Returns the child slots implied by the last layout pass: the leading
+    /// main-axis extent of each laid-out child, packed from the start of
+    /// `area`, stopping once the area is exhausted. Shared by `render`,
+    /// `cursor_position`, and `dispatch_event` so paint and hit-test geometry
+    /// cannot drift.
+    fn child_slots(
+        axis: Axis,
+        area: TuiRect,
+        child_sizes: &[TuiSize],
+    ) -> impl Iterator<Item = TuiRect> + '_ {
+        child_sizes.iter().scan(area, move |remaining, size| {
+            if remaining.is_empty() {
+                return None;
+            }
+            let (slot, rest) = Self::split_main(axis, *remaining, Self::main_extent(axis, *size));
+            *remaining = rest;
+            Some(slot)
+        })
+    }
+
     /// Clamps a main-axis extent into the constraint's main-axis bounds.
     fn constrain_main(axis: Axis, constraint: TuiConstraint, extent: u16) -> u16 {
         match axis {
@@ -185,9 +210,8 @@ impl TuiFlex {
     }
 
     /// The rect a child occupies within its main-axis `slot`, positioned along
-    /// the cross axis per the alignment. `Start` and `Stretch` keep the full
-    /// slot (children paint only their content, and hit areas span the slot);
-    /// `Center` / `End` place the child's measured cross extent within it.
+    /// the cross axis per the alignment. `Stretch` keeps the full slot;
+    /// other alignments use the child's measured cross extent.
     /// Associated (not `&self`) so `dispatch_event` can call it while
     /// `children` is mutably borrowed.
     fn child_rect_for(
@@ -202,7 +226,8 @@ impl TuiFlex {
             Axis::Horizontal => (slot.height, child_size.height.min(slot.height)),
         };
         let offset = match alignment {
-            CrossAxisAlignment::Start | CrossAxisAlignment::Stretch => return slot,
+            CrossAxisAlignment::Stretch => return slot,
+            CrossAxisAlignment::Start => 0,
             CrossAxisAlignment::Center => slot_cross.saturating_sub(child_cross) / 2,
             CrossAxisAlignment::End => slot_cross.saturating_sub(child_cross),
         };
@@ -220,11 +245,6 @@ impl TuiFlex {
                 child_cross,
             ),
         }
-    }
-
-    /// [`Self::child_rect_for`] with this flex's axis and alignment.
-    fn child_rect(&self, slot: TuiRect, child_size: TuiSize) -> TuiRect {
-        Self::child_rect_for(self.axis, self.cross_axis_alignment, slot, child_size)
     }
 }
 
@@ -276,11 +296,13 @@ impl TuiElement for TuiFlex {
                 cross_max = cross_max.max(Self::cross_extent(axis, size));
                 self.child_sizes.push(size);
             }
-            return Self::size_of(
+            let size = Self::size_of(
                 axis,
                 Self::constrain_main(axis, constraint, total_main),
                 self.reported_cross(constraint, cross, cross_max),
             );
+            self.size = Some(size);
+            return size;
         }
 
         // Flex children: two passes.
@@ -328,47 +350,49 @@ impl TuiElement for TuiFlex {
             };
             self.child_sizes.push(size);
         }
-        Self::size_of(
+        let size = Self::size_of(
             axis,
             offered_main,
             self.reported_cross(constraint, cross, cross_max),
-        )
+        );
+        self.size = Some(size);
+        size
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
-        let mut remaining = area;
-        for (child, size) in self.children.iter().zip(&self.child_sizes) {
-            if remaining.is_empty() {
-                break;
-            }
-            let (slot, rest) =
-                Self::split_main(self.axis, remaining, Self::main_extent(self.axis, *size));
-            child
-                .element
-                .render(self.child_rect(slot, *size), buffer, ctx);
-            remaining = rest;
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.origin = Some(ctx.scene_point(origin));
+        let Some(size) = self.size else {
+            return;
+        };
+        let area = TuiRect::new(0, 0, size.width, size.height);
+        let axis = self.axis;
+        let alignment = self.cross_axis_alignment;
+        for ((child, size), slot) in self
+            .children
+            .iter_mut()
+            .zip(&self.child_sizes)
+            .zip(Self::child_slots(axis, area, &self.child_sizes))
+        {
+            let rect = Self::child_rect_for(axis, alignment, slot, *size);
+            child.element.render(
+                origin.offset(i32::from(rect.x), i32::from(rect.y)),
+                surface,
+                ctx,
+            );
         }
     }
 
-    fn cursor_position(&self, area: TuiRect, ctx: &mut TuiPaintContext) -> Option<(u16, u16)> {
-        let mut remaining = area;
-        for (child, size) in self.children.iter().zip(&self.child_sizes) {
-            if remaining.is_empty() {
-                break;
-            }
-            let (slot, rest) =
-                Self::split_main(self.axis, remaining, Self::main_extent(self.axis, *size));
-            let rect = self.child_rect(slot, *size);
-            if let Some((cx, cy)) = child.element.cursor_position(rect, ctx) {
-                // Offset is relative to the child's rect, not the full area.
-                return Some((
-                    rect.x.saturating_sub(area.x) + cx,
-                    rect.y.saturating_sub(area.y) + cy,
-                ));
-            }
-            remaining = rest;
-        }
-        None
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
     }
 
     fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
@@ -380,32 +404,12 @@ impl TuiElement for TuiFlex {
     fn dispatch_event(
         &mut self,
         event: &TuiEvent,
-        area: TuiRect,
-        event_ctx: &mut TuiEventContext,
-        ctx: &mut TuiLayoutContext,
+        event_ctx: &mut TuiEventContext<'_>,
         app: &AppContext,
     ) -> bool {
-        // Offer the event to each child in its rendered rect (mirrors render's
-        // packing and alignment); the first child to handle it consumes it.
-        // Children clipped past the available extent see no events.
-        let axis = self.axis;
-        let alignment = self.cross_axis_alignment;
-        let mut remaining = area;
-        for (child, size) in self.children.iter_mut().zip(&self.child_sizes) {
-            if remaining.is_empty() {
-                break;
-            }
-            let (slot, rest) = Self::split_main(axis, remaining, Self::main_extent(axis, *size));
-            let rect = Self::child_rect_for(axis, alignment, slot, *size);
-            if child
-                .element
-                .dispatch_event(event, rect, event_ctx, ctx, app)
-            {
-                return true;
-            }
-            remaining = rest;
-        }
-        false
+        self.children.iter_mut().fold(false, |handled, child| {
+            child.element.dispatch_event(event, event_ctx, app) || handled
+        })
     }
 }
 

--- a/crates/warpui_core/src/elements/tui/flex_tests.rs
+++ b/crates/warpui_core/src/elements/tui/flex_tests.rs
@@ -4,10 +4,11 @@ use std::rc::Rc;
 use ratatui::style::{Color, Modifier, Style};
 
 use super::TuiFlex;
-use crate::elements::tui::test_support::{render_to_lines, with_paint_context};
+use crate::elements::tui::test_support::{render_to_lines, with_event_context, with_paint_surface};
 use crate::elements::tui::{
-    TuiBuffer, TuiChildView, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiEventHandler,
-    TuiLayoutContext, TuiParentElement, TuiPresentationContext, TuiRect, TuiSize, TuiText,
+    TuiBuffer, TuiBufferExt, TuiChildView, TuiConstraint, TuiElement, TuiEvent, TuiEventHandler,
+    TuiLayoutContext, TuiParentElement, TuiPresentationContext, TuiRect, TuiScreenPosition,
+    TuiSize, TuiText,
 };
 use crate::elements::CrossAxisAlignment;
 use crate::event::KeyEventDetails;
@@ -37,7 +38,7 @@ fn column_stacks_two_children_top_to_bottom() {
             let size = layout_at(&mut column, TuiSize::new(2, 10), app_ctx);
             assert_eq!(size, TuiSize::new(2, 2));
             assert_eq!(
-                render_to_lines(&column, TuiSize::new(2, 2)),
+                render_to_lines(column, TuiSize::new(2, 2)),
                 vec!["AA", "BB"]
             );
         });
@@ -57,7 +58,7 @@ fn column_sums_multi_row_children_at_the_correct_offsets() {
             let size = layout_at(&mut column, TuiSize::new(2, 4), app_ctx);
             assert_eq!(size, TuiSize::new(2, 4));
             assert_eq!(
-                render_to_lines(&column, TuiSize::new(2, 4)),
+                render_to_lines(column, TuiSize::new(2, 4)),
                 vec!["A ", "BB", "CC", "D "],
             );
         });
@@ -78,7 +79,7 @@ fn column_clamps_total_height_to_the_constraint_and_clips_overflow() {
 
             // Only the first three rows fit; the final child is clipped away.
             assert_eq!(
-                render_to_lines(&column, TuiSize::new(2, 3)),
+                render_to_lines(column, TuiSize::new(2, 3)),
                 vec!["A ", "BB", "CC"],
             );
         });
@@ -102,7 +103,7 @@ fn column_flex_child_fills_leftover_and_docks_fixed_child_at_bottom() {
             // The flex spacer occupies the top three rows; the fixed input row
             // lands on the last row.
             assert_eq!(
-                render_to_lines(&column, TuiSize::new(2, 4)),
+                render_to_lines(column, TuiSize::new(2, 4)),
                 vec!["  ", "  ", "  ", "IN"],
             );
         });
@@ -122,7 +123,7 @@ fn row_packs_two_children_left_to_right() {
             let size = layout_at(&mut row, TuiSize::new(10, 1), app_ctx);
             // Without flex children the row hugs its content horizontally.
             assert_eq!(size, TuiSize::new(4, 1));
-            assert_eq!(render_to_lines(&row, TuiSize::new(4, 1)), vec!["AABB"]);
+            assert_eq!(render_to_lines(row, TuiSize::new(4, 1)), vec!["AABB"]);
         });
     });
 }
@@ -139,7 +140,7 @@ fn row_flex_spacer_pushes_trailing_children_to_the_right_edge() {
             let size = layout_at(&mut row, TuiSize::new(8, 1), app_ctx);
             // With a flex child present, the row fills the offered width.
             assert_eq!(size, TuiSize::new(8, 1));
-            assert_eq!(render_to_lines(&row, TuiSize::new(8, 1)), vec!["L     RR"]);
+            assert_eq!(render_to_lines(row, TuiSize::new(8, 1)), vec!["L     RR"]);
         });
     });
 }
@@ -158,7 +159,7 @@ fn row_splits_leftover_evenly_across_flex_children() {
             let size = layout_at(&mut row, TuiSize::new(10, 1), app_ctx);
             assert_eq!(size, TuiSize::new(10, 1));
             assert_eq!(
-                render_to_lines(&row, TuiSize::new(10, 1)),
+                render_to_lines(row, TuiSize::new(10, 1)),
                 vec!["    MID   "]
             );
         });
@@ -176,7 +177,7 @@ fn row_clips_children_past_the_available_width() {
             let size = layout_at(&mut row, TuiSize::new(6, 1), app_ctx);
             assert_eq!(size, TuiSize::new(6, 1));
             // The second child only has two columns left and is clipped.
-            assert_eq!(render_to_lines(&row, TuiSize::new(6, 1)), vec!["AAAABB"]);
+            assert_eq!(render_to_lines(row, TuiSize::new(6, 1)), vec!["AAAABB"]);
         });
     });
 }
@@ -248,10 +249,11 @@ fn center_positions_child_along_cross_axis() {
             };
             let size = row.layout(TuiConstraint::tight(TuiSize::new(5, 3)), &mut ctx, app_ctx);
             assert_eq!(size, TuiSize::new(5, 3));
-            assert_eq!(
-                render_to_lines(&row, TuiSize::new(5, 3)),
-                vec!["     ", "A    ", "     "],
-            );
+            let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, 5, 3));
+            with_paint_surface(&mut buffer, |surface, ctx| {
+                row.render(TuiScreenPosition::new(0, 0), surface, ctx)
+            });
+            assert_eq!(buffer.to_lines(), vec!["     ", "A    ", "     "],);
         });
     });
 }
@@ -271,7 +273,11 @@ fn end_positions_child_along_cross_axis() {
             };
             let size = column.layout(TuiConstraint::tight(TuiSize::new(5, 1)), &mut ctx, app_ctx);
             assert_eq!(size, TuiSize::new(5, 1));
-            assert_eq!(render_to_lines(&column, TuiSize::new(5, 1)), vec!["    A"]);
+            let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, 5, 1));
+            with_paint_surface(&mut buffer, |surface, ctx| {
+                column.render(TuiScreenPosition::new(0, 0), surface, ctx)
+            });
+            assert_eq!(buffer.to_lines(), vec!["    A"]);
         });
     });
 }
@@ -290,7 +296,9 @@ fn row_children_keep_their_own_styles() {
             layout_at(&mut row, TuiSize::new(4, 1), app_ctx);
 
             let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, 4, 1));
-            with_paint_context(|ctx| row.render(TuiRect::new(0, 0, 4, 1), &mut buffer, ctx));
+            with_paint_surface(&mut buffer, |surface, ctx| {
+                row.render(TuiScreenPosition::new(0, 0), surface, ctx)
+            });
 
             let left_cell = &buffer[(0, 0)];
             assert_eq!(left_cell.symbol(), "a");
@@ -342,7 +350,7 @@ fn key_event(key: &str) -> TuiEvent {
 }
 
 #[test]
-fn dispatch_event_offers_children_in_order_and_stops_when_handled() {
+fn dispatch_event_broadcasts_to_all_children() {
     App::test((), |app| async move {
         app.read(|app_ctx| {
             let first_hits = Rc::new(Cell::new(0u32));
@@ -365,28 +373,13 @@ fn dispatch_event_offers_children_in_order_and_stops_when_handled() {
                         }),
                 ));
 
-            // Layout must run before dispatch so TuiFlex.child_sizes is populated.
-            let mut event_ctx = TuiEventContext::default();
-            let mut rendered_views = EntityIdMap::default();
-            let mut ctx = TuiLayoutContext {
-                rendered_views: &mut rendered_views,
-            };
-            column.layout(TuiConstraint::loose(TuiSize::new(10, 5)), &mut ctx, app_ctx);
-            let handled = column.dispatch_event(
-                &key_event("x"),
-                TuiRect::new(0, 0, 10, 5),
-                &mut event_ctx,
-                &mut ctx,
-                app_ctx,
-            );
+            let handled = with_event_context(|event_ctx| {
+                column.dispatch_event(&key_event("x"), event_ctx, app_ctx)
+            });
 
             assert!(handled);
             assert_eq!(first_hits.get(), 1);
-            assert_eq!(
-                second_hits.get(),
-                0,
-                "dispatch must stop at the first child that handles the event"
-            );
+            assert_eq!(second_hits.get(), 1);
         });
     });
 }

--- a/crates/warpui_core/src/elements/tui/hoverable.rs
+++ b/crates/warpui_core/src/elements/tui/hoverable.rs
@@ -13,33 +13,40 @@
 //! are transparent — they delegate to the wrapped child.
 //!
 //! # Dispatch policy
-//! On [`MouseMoved`](TuiEvent::MouseMoved) the pointer position is compared
-//! against this element's area; a hover transition is recorded on the handle
-//! and queues a notification so the owning view re-renders. Mouse moves are
-//! never consumed, so sibling hoverables observe their own transitions from
-//! the same event. Other events are offered to the child first; clicks use the
-//! GUI's press-then-release pairing: an unconsumed
-//! [`LeftMouseDown`](TuiEvent::LeftMouseDown) inside the area arms a pending
-//! click (recorded on the shared state, so [`MouseState::is_clicked`] styling
-//! works) and is consumed; the following [`LeftMouseUp`](TuiEvent::LeftMouseUp)
-//! disarms it, running the click handler only when released inside the area.
-//! (Hover delays and the other [`MouseState`] fields are unused.)
+//! Hover and click hit-test against the child's laid-out footprint (the size
+//! returned by the most recent `layout`, anchored at the area's origin), not
+//! the whole slot the parent assigned — so trailing blank space in a flex row
+//! is not part of the target. On [`MouseMoved`](TuiEvent::MouseMoved) the
+//! pointer position is compared against that footprint; a hover transition is
+//! recorded on the handle and queues a notification so the owning view
+//! re-renders. Mouse moves are never consumed, so sibling hoverables observe
+//! their own transitions from the same event. Other events are offered to the
+//! child first; clicks use the GUI's press-then-release pairing: an unconsumed
+//! [`LeftMouseDown`](TuiEvent::LeftMouseDown) inside the footprint arms a
+//! pending click (recorded on the shared state, so [`MouseState::is_clicked`]
+//! styling works) and is consumed; the following
+//! [`LeftMouseUp`](TuiEvent::LeftMouseUp) disarms it, running the click
+//! handler only when released inside the footprint. (Hover delays and the
+//! other [`MouseState`] fields are unused.)
 
 use std::sync::MutexGuard;
 
 use super::{
-    TuiBuffer, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext,
-    TuiPaintContext, TuiPresentationContext, TuiRect, TuiRectExt, TuiSize,
+    TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext, TuiPaintContext,
+    TuiPaintSurface, TuiPoint, TuiPresentationContext, TuiScreenPoint, TuiScreenPosition, TuiSize,
+    TuiZIndex,
 };
 use crate::elements::{MouseState, MouseStateHandle};
 use crate::AppContext;
 
-type ClickCallback = Box<dyn FnMut(&mut TuiEventContext, &AppContext)>;
+type ClickCallback = Box<dyn for<'a> FnMut(&mut TuiEventContext<'a>, &AppContext)>;
 
 pub struct TuiHoverable {
     child: Box<dyn TuiElement>,
     state: MouseStateHandle,
     on_click: Option<ClickCallback>,
+    origin: Option<TuiScreenPoint>,
+    child_max_z_index: Option<TuiZIndex>,
 }
 
 impl TuiHoverable {
@@ -49,6 +56,8 @@ impl TuiHoverable {
             child,
             state,
             on_click: None,
+            origin: None,
+            child_max_z_index: None,
         }
     }
 
@@ -57,7 +66,7 @@ impl TuiHoverable {
     /// `LeftMouseUp`, both within this element's area.
     pub fn on_click(
         mut self,
-        callback: impl FnMut(&mut TuiEventContext, &AppContext) + 'static,
+        callback: impl for<'a> FnMut(&mut TuiEventContext<'a>, &AppContext) + 'static,
     ) -> Self {
         self.on_click = Some(Box::new(callback));
         self
@@ -66,6 +75,26 @@ impl TuiHoverable {
     /// Locks and returns the shared mouse state.
     fn state(&self) -> MutexGuard<'_, MouseState> {
         self.state.lock().unwrap()
+    }
+
+    /// Returns whether `position` is inside visible, uncovered child bounds.
+    fn is_mouse_over_element(&self, position: TuiPoint, event_ctx: &TuiEventContext<'_>) -> bool {
+        let Some((origin, size, z_index)) = self
+            .origin
+            .zip(self.size())
+            .zip(self.child_max_z_index)
+            .map(|((origin, size), z_index)| (origin, size, z_index))
+        else {
+            return false;
+        };
+        event_ctx
+            .visible_rect(origin, size)
+            .is_some_and(|rect| rect.contains(position))
+            && !event_ctx.is_covered(TuiScreenPoint::new(
+                i32::from(position.x),
+                i32::from(position.y),
+                z_index,
+            ))
     }
 }
 
@@ -79,12 +108,23 @@ impl TuiElement for TuiHoverable {
         self.child.layout(constraint, ctx, app)
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
-        self.child.render(area, buffer, ctx);
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.origin = Some(ctx.scene_point(origin));
+        self.child.render(origin, surface, ctx);
+        self.child_max_z_index = Some(ctx.scene.max_active_z_index());
     }
 
-    fn cursor_position(&self, area: TuiRect, ctx: &mut TuiPaintContext) -> Option<(u16, u16)> {
-        self.child.cursor_position(area, ctx)
+    fn size(&self) -> Option<TuiSize> {
+        self.child.size()
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
     }
 
     fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
@@ -94,15 +134,13 @@ impl TuiElement for TuiHoverable {
     fn dispatch_event(
         &mut self,
         event: &TuiEvent,
-        area: TuiRect,
-        event_ctx: &mut TuiEventContext,
-        ctx: &mut TuiLayoutContext,
+        event_ctx: &mut TuiEventContext<'_>,
         app: &AppContext,
     ) -> bool {
-        let child_handled = self.child.dispatch_event(event, area, event_ctx, ctx, app);
+        let child_handled = self.child.dispatch_event(event, event_ctx, app);
 
         if let TuiEvent::MouseMoved { position, .. } = event {
-            let is_hovered = area.contains_point(*position);
+            let is_hovered = self.is_mouse_over_element(*position, event_ctx);
             let mut state = self.state();
             if is_hovered != state.is_hovered() {
                 state.is_hovered = is_hovered;
@@ -119,22 +157,22 @@ impl TuiElement for TuiHoverable {
         }
 
         match event {
-            // Press inside the area: arm the pending click.
+            // Press inside the footprint: arm the pending click.
             TuiEvent::LeftMouseDown {
                 position,
                 click_count,
                 ..
-            } if self.on_click.is_some() && area.contains_point(*position) => {
+            } if self.on_click.is_some() && self.is_mouse_over_element(*position, event_ctx) => {
                 self.state().set_click_count(Some(*click_count));
                 event_ctx.notify();
                 true
             }
             // Release while armed: disarm, and fire only when released inside
-            // the area (a release elsewhere cancels the click, as in the GUI).
+            // the footprint (a release elsewhere cancels the click, as in the GUI).
             TuiEvent::LeftMouseUp { position, .. } if self.state().is_clicked() => {
                 self.state().set_click_count(None);
                 event_ctx.notify();
-                if area.contains_point(*position) {
+                if self.is_mouse_over_element(*position, event_ctx) {
                     if let Some(on_click) = self.on_click.as_mut() {
                         on_click(event_ctx, app);
                     }

--- a/crates/warpui_core/src/elements/tui/hoverable_tests.rs
+++ b/crates/warpui_core/src/elements/tui/hoverable_tests.rs
@@ -2,13 +2,15 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use super::TuiHoverable;
+use crate::elements::tui::test_support::{dispatch_presented_event, with_event_context};
 use crate::elements::tui::{
     TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext, TuiPaintContext,
-    TuiPoint, TuiRect, TuiSize,
+    TuiPaintSurface, TuiPoint, TuiScreenPoint, TuiScreenPosition, TuiSize, TuiText,
 };
 use crate::elements::MouseStateHandle;
 use crate::event::ModifiersState;
-use crate::{App, EntityId, EntityIdMap};
+use crate::presenter::tui::TuiPresenter;
+use crate::{App, AppContext};
 
 fn left_mouse_down(x: u16, y: u16) -> TuiEvent {
     TuiEvent::LeftMouseDown {
@@ -26,164 +28,189 @@ fn left_mouse_up(x: u16, y: u16) -> TuiEvent {
     }
 }
 
+fn mouse_moved(x: u16, y: u16) -> TuiEvent {
+    TuiEvent::MouseMoved {
+        position: TuiPoint::new(x, y),
+        modifiers: ModifiersState::default(),
+        is_synthetic: false,
+    }
+}
+
+#[test]
+fn pointer_dispatch_before_paint_is_unhandled() {
+    App::test((), |app| async move {
+        app.read(|app_ctx| {
+            let mut hoverable =
+                TuiHoverable::new(MouseStateHandle::default(), TuiText::new("hello").finish())
+                    .on_click(|_, _| panic!("unpainted hoverable must not click"));
+            with_event_context(|event_ctx| {
+                assert!(!hoverable.dispatch_event(&left_mouse_down(0, 0), event_ctx, app_ctx,));
+            });
+        });
+    });
+}
+
 #[test]
 fn mouse_moves_toggle_hover_state_and_notify_without_consuming_the_event() {
     App::test((), |app| async move {
         app.read(|app_ctx| {
             let handle = MouseStateHandle::default();
-            let mut hoverable = TuiHoverable::new(handle.clone(), ().finish());
+            let hoverable = TuiHoverable::new(handle.clone(), TuiText::new("0123456789").finish());
+            let mut presenter = TuiPresenter::new();
+            presenter.present_element(
+                hoverable.finish(),
+                crate::elements::tui::TuiRect::new(0, 0, 10, 1),
+                app_ctx,
+            );
 
-            let area = TuiRect::new(0, 0, 10, 1);
-            let mut rendered_views = EntityIdMap::default();
-            let mut ctx = TuiLayoutContext {
-                rendered_views: &mut rendered_views,
-            };
-            // Returns (event handled, view notified) after moving the mouse.
-            let mut move_to = |x, y| {
-                let mut event_ctx = TuiEventContext::default();
-                event_ctx.set_origin_view(Some(EntityId::new()));
-                let handled = hoverable.dispatch_event(
-                    &TuiEvent::MouseMoved {
-                        position: TuiPoint::new(x, y),
-                        modifiers: ModifiersState::default(),
-                        is_synthetic: false,
-                    },
-                    area,
-                    &mut event_ctx,
-                    &mut ctx,
-                    app_ctx,
-                );
-                (handled, !event_ctx.take_notified().is_empty())
-            };
-
-            // Hover in: state flips and the view is notified, but the move
-            // still propagates for sibling hoverables.
-            assert_eq!(move_to(2, 0), (false, true));
+            assert_eq!(
+                dispatch_presented_event(&mut presenter, &mouse_moved(2, 0), app_ctx),
+                (false, 1)
+            );
             assert!(handle.lock().unwrap().is_hovered());
 
-            // A move within the area is not a transition: no notification.
-            assert_eq!(move_to(4, 0), (false, false));
+            assert_eq!(
+                dispatch_presented_event(&mut presenter, &mouse_moved(4, 0), app_ctx),
+                (false, 0)
+            );
             assert!(handle.lock().unwrap().is_hovered());
 
-            // Hover out: state flips back and the view is notified again.
-            assert_eq!(move_to(4, 3), (false, true));
+            assert_eq!(
+                dispatch_presented_event(&mut presenter, &mouse_moved(4, 3), app_ctx),
+                (false, 1)
+            );
             assert!(!handle.lock().unwrap().is_hovered());
         });
     });
 }
 
 #[test]
-fn click_fires_on_release_after_press_inside_area() {
+fn click_fires_on_release_after_press_inside_bounds() {
     App::test((), |app| async move {
         app.read(|app_ctx| {
             let hits = Rc::new(Cell::new(0u32));
             let counter = hits.clone();
             let state = MouseStateHandle::default();
-            let mut hoverable =
-                TuiHoverable::new(state.clone(), ().finish()).on_click(move |_ctx, _app| {
-                    counter.set(counter.get() + 1);
-                });
-
-            let area = TuiRect::new(0, 0, 4, 2);
-            let mut event_ctx = TuiEventContext::default();
-            event_ctx.set_origin_view(Some(EntityId::new()));
-            let mut rendered_views = EntityIdMap::default();
-            let mut ctx = TuiLayoutContext {
-                rendered_views: &mut rendered_views,
-            };
-
-            // The press arms the click (recorded on the shared state) and is
-            // consumed, but the callback does not fire yet.
-            let handled = hoverable.dispatch_event(
-                &left_mouse_down(1, 1),
-                area,
-                &mut event_ctx,
-                &mut ctx,
+            let hoverable = TuiHoverable::new(state.clone(), TuiText::new("xxxx").finish())
+                .on_click(move |_, _| counter.set(counter.get() + 1));
+            let mut presenter = TuiPresenter::new();
+            presenter.present_element(
+                hoverable.finish(),
+                crate::elements::tui::TuiRect::new(0, 0, 4, 1),
                 app_ctx,
             );
-            assert!(handled);
+
+            assert!(dispatch_presented_event(&mut presenter, &left_mouse_down(1, 0), app_ctx).0);
             assert!(state.lock().unwrap().is_clicked());
             assert_eq!(hits.get(), 0);
 
-            // The release inside the area fires the callback and disarms.
-            let handled = hoverable.dispatch_event(
-                &left_mouse_up(1, 1),
-                area,
-                &mut event_ctx,
-                &mut ctx,
-                app_ctx,
-            );
-            assert!(handled);
+            assert!(dispatch_presented_event(&mut presenter, &left_mouse_up(1, 0), app_ctx).0);
             assert!(!state.lock().unwrap().is_clicked());
             assert_eq!(hits.get(), 1);
 
-            // A press outside the area is left unhandled and never arms.
-            let handled = hoverable.dispatch_event(
-                &left_mouse_down(10, 10),
-                area,
-                &mut event_ctx,
-                &mut ctx,
-                app_ctx,
-            );
-            assert!(!handled);
-            assert!(!state.lock().unwrap().is_clicked());
-            // ...so the following release inside the area does not fire.
-            let handled = hoverable.dispatch_event(
-                &left_mouse_up(1, 1),
-                area,
-                &mut event_ctx,
-                &mut ctx,
-                app_ctx,
-            );
-            assert!(!handled);
+            assert!(!dispatch_presented_event(&mut presenter, &left_mouse_down(10, 10), app_ctx).0);
+            assert!(!dispatch_presented_event(&mut presenter, &left_mouse_up(1, 0), app_ctx).0);
             assert_eq!(hits.get(), 1);
         });
     });
 }
 
 #[test]
-fn release_outside_area_cancels_the_click() {
+fn release_outside_bounds_cancels_the_click() {
     App::test((), |app| async move {
         app.read(|app_ctx| {
             let hits = Rc::new(Cell::new(0u32));
             let counter = hits.clone();
             let state = MouseStateHandle::default();
-            let mut hoverable =
-                TuiHoverable::new(state.clone(), ().finish()).on_click(move |_ctx, _app| {
-                    counter.set(counter.get() + 1);
-                });
-
-            let area = TuiRect::new(0, 0, 4, 2);
-            let mut event_ctx = TuiEventContext::default();
-            event_ctx.set_origin_view(Some(EntityId::new()));
-            let mut rendered_views = EntityIdMap::default();
-            let mut ctx = TuiLayoutContext {
-                rendered_views: &mut rendered_views,
-            };
-
-            assert!(hoverable.dispatch_event(
-                &left_mouse_down(1, 1),
-                area,
-                &mut event_ctx,
-                &mut ctx,
-                app_ctx,
-            ));
-            assert!(state.lock().unwrap().is_clicked());
-
-            // Releasing outside disarms without firing, and the release is
-            // left unhandled for other elements.
-            let handled = hoverable.dispatch_event(
-                &left_mouse_up(10, 10),
-                area,
-                &mut event_ctx,
-                &mut ctx,
+            let hoverable = TuiHoverable::new(state.clone(), TuiText::new("xxxx").finish())
+                .on_click(move |_, _| counter.set(counter.get() + 1));
+            let mut presenter = TuiPresenter::new();
+            presenter.present_element(
+                hoverable.finish(),
+                crate::elements::tui::TuiRect::new(0, 0, 4, 1),
                 app_ctx,
             );
-            assert!(!handled);
+
+            assert!(dispatch_presented_event(&mut presenter, &left_mouse_down(1, 0), app_ctx).0);
+            assert!(!dispatch_presented_event(&mut presenter, &left_mouse_up(10, 10), app_ctx).0);
             assert!(!state.lock().unwrap().is_clicked());
             assert_eq!(hits.get(), 0);
         });
     });
+}
+
+#[test]
+fn hit_testing_is_bounded_to_the_child_laid_out_size() {
+    App::test((), |app| async move {
+        app.read(|app_ctx| {
+            let hits = Rc::new(Cell::new(0u32));
+            let counter = hits.clone();
+            let handle = MouseStateHandle::default();
+            let hoverable = TuiHoverable::new(handle.clone(), TuiText::new("hello").finish())
+                .on_click(move |_, _| counter.set(counter.get() + 1));
+            let mut presenter = TuiPresenter::new();
+            presenter.present_element(
+                hoverable.finish(),
+                crate::elements::tui::TuiRect::new(0, 0, 10, 1),
+                app_ctx,
+            );
+
+            dispatch_presented_event(&mut presenter, &mouse_moved(2, 0), app_ctx);
+            assert!(handle.lock().unwrap().is_hovered());
+            assert!(dispatch_presented_event(&mut presenter, &left_mouse_down(2, 0), app_ctx).0);
+            assert!(dispatch_presented_event(&mut presenter, &left_mouse_up(2, 0), app_ctx).0);
+            assert_eq!(hits.get(), 1);
+
+            dispatch_presented_event(&mut presenter, &mouse_moved(7, 0), app_ctx);
+            assert!(!handle.lock().unwrap().is_hovered());
+            assert!(!dispatch_presented_event(&mut presenter, &left_mouse_down(7, 0), app_ctx).0);
+            assert_eq!(hits.get(), 1);
+        });
+    });
+}
+
+struct AlwaysHandles {
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
+}
+
+impl TuiElement for AlwaysHandles {
+    fn layout(
+        &mut self,
+        constraint: TuiConstraint,
+        _ctx: &mut TuiLayoutContext,
+        _app: &AppContext,
+    ) -> TuiSize {
+        let size = constraint.clamp(TuiSize::new(1, 1));
+        self.size = Some(size);
+        size
+    }
+
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        _surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.origin = Some(ctx.scene_point(origin));
+    }
+
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
+    }
+
+    fn dispatch_event(
+        &mut self,
+        _event: &TuiEvent,
+        _event_ctx: &mut TuiEventContext<'_>,
+        _app: &AppContext,
+    ) -> bool {
+        true
+    }
 }
 
 #[test]
@@ -192,64 +219,21 @@ fn child_consumes_the_event_before_the_click_handler() {
         app.read(|app_ctx| {
             let outer_hits = Rc::new(Cell::new(0u32));
             let outer_counter = outer_hits.clone();
-
-            // A child that always handles the event pre-empts the wrapper's click.
-            let mut hoverable =
-                TuiHoverable::new(MouseStateHandle::default(), AlwaysHandles.finish()).on_click(
-                    move |_, _| {
-                        outer_counter.set(outer_counter.get() + 1);
-                    },
-                );
-
-            let mut event_ctx = TuiEventContext::default();
-            let mut rendered_views = EntityIdMap::default();
-            let mut ctx = TuiLayoutContext {
-                rendered_views: &mut rendered_views,
+            let child = AlwaysHandles {
+                size: None,
+                origin: None,
             };
-            let handled = hoverable.dispatch_event(
-                &left_mouse_down(0, 0),
-                TuiRect::new(0, 0, 1, 1),
-                &mut event_ctx,
-                &mut ctx,
+            let hoverable = TuiHoverable::new(MouseStateHandle::default(), child.finish())
+                .on_click(move |_, _| outer_counter.set(outer_counter.get() + 1));
+            let mut presenter = TuiPresenter::new();
+            presenter.present_element(
+                hoverable.finish(),
+                crate::elements::tui::TuiRect::new(0, 0, 1, 1),
                 app_ctx,
             );
 
-            assert!(handled);
+            assert!(dispatch_presented_event(&mut presenter, &left_mouse_down(0, 0), app_ctx).0);
             assert_eq!(outer_hits.get(), 0);
         });
     });
-}
-
-/// A leaf element that reports every event as handled, used to verify the
-/// wrapper defers to its child.
-struct AlwaysHandles;
-
-impl TuiElement for AlwaysHandles {
-    fn layout(
-        &mut self,
-        constraint: TuiConstraint,
-        _ctx: &mut TuiLayoutContext,
-        _app: &crate::AppContext,
-    ) -> TuiSize {
-        constraint.min
-    }
-
-    fn render(
-        &self,
-        _area: TuiRect,
-        _buffer: &mut crate::elements::tui::TuiBuffer,
-        _ctx: &mut TuiPaintContext,
-    ) {
-    }
-
-    fn dispatch_event(
-        &mut self,
-        _event: &TuiEvent,
-        _area: TuiRect,
-        _event_ctx: &mut TuiEventContext,
-        _ctx: &mut TuiLayoutContext,
-        _app: &crate::AppContext,
-    ) -> bool {
-        true
-    }
 }

--- a/crates/warpui_core/src/elements/tui/mod.rs
+++ b/crates/warpui_core/src/elements/tui/mod.rs
@@ -41,6 +41,7 @@ mod flex;
 mod geometry;
 mod hoverable;
 mod parent;
+mod scene;
 mod scrollable;
 mod selectable;
 mod shimmering_text;
@@ -48,7 +49,7 @@ mod text;
 mod viewported_list;
 
 pub use animated::TuiAnimated;
-pub use buffer::{Cell, Color, Modifier, TuiBuffer, TuiBufferExt, TuiStyle};
+pub use buffer::{Cell, Color, Modifier, TuiBuffer, TuiBufferExt, TuiPaintSurface, TuiStyle};
 pub use child_view::TuiChildView;
 pub use clipped::TuiClipped;
 pub use collapsible::tui_collapsible;
@@ -64,6 +65,10 @@ pub use geometry::{
 };
 pub use hoverable::TuiHoverable;
 pub use parent::TuiParentElement;
+pub use scene::{
+    TuiClipBounds, TuiLocalPoint, TuiScene, TuiScreenPoint, TuiScreenPosition, TuiScreenRect,
+    TuiZIndex,
+};
 pub use scrollable::{TuiScrollable, TuiScrollableElement};
 pub use selectable::{
     point_after_col, TuiRowGlyph, TuiRowResize, TuiSelectable, TuiSelectableElement,
@@ -129,8 +134,12 @@ impl TuiViewMapContext for TuiLayoutContext<'_> {
 pub struct TuiPaintContext<'a> {
     /// Pre-rendered elements keyed by view id, consumed during paint.
     pub rendered_views: &'a mut EntityIdMap<Box<dyn TuiElement>>,
+    /// Retained clip and hit geometry produced during paint.
+    pub scene: TuiScene,
     /// The earliest repaint deadline requested by any element this frame.
     repaint_at: Option<Instant>,
+    /// Hardware terminal cursor submitted during paint.
+    terminal_cursor: Option<TuiScreenPoint>,
 }
 
 /// The soonest an element may request a repaint after the current paint.
@@ -144,8 +153,59 @@ impl<'a> TuiPaintContext<'a> {
     pub fn new(rendered_views: &'a mut EntityIdMap<Box<dyn TuiElement>>) -> Self {
         Self {
             rendered_views,
+            scene: TuiScene::default(),
             repaint_at: None,
+            terminal_cursor: None,
         }
+    }
+    /// Attaches the active scene layer to an absolute screen position.
+    pub fn scene_point(&self, position: TuiScreenPosition) -> TuiScreenPoint {
+        TuiScreenPoint::from_position(position, self.scene.z_index())
+    }
+
+    /// Submits the hardware cursor for this frame, preferring higher layers.
+    pub fn set_terminal_cursor(&mut self, cursor: TuiScreenPoint) {
+        if self
+            .terminal_cursor
+            .is_some_and(|current| current.z_index > cursor.z_index)
+        {
+            return;
+        }
+        self.terminal_cursor = Some(cursor);
+    }
+
+    /// Returns the hardware cursor submitted during paint.
+    pub fn terminal_cursor(&self) -> Option<TuiScreenPoint> {
+        self.terminal_cursor
+    }
+
+    /// Runs `f` inside a clipped normal scene layer.
+    pub fn with_scene_layer<R>(
+        &mut self,
+        bounds: TuiClipBounds,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        self.scene.start_layer(bounds);
+        let result = f(self);
+        self.scene.stop_layer();
+        result
+    }
+
+    /// Runs `f` inside a clipped overlay scene layer.
+    pub fn with_overlay_layer<R>(
+        &mut self,
+        bounds: TuiClipBounds,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        self.scene.start_overlay_layer(bounds);
+        let result = f(self);
+        self.scene.stop_layer();
+        result
+    }
+
+    /// Makes the active scene layer transparent to hit testing.
+    pub fn set_active_layer_click_through(&mut self) {
+        self.scene.set_active_layer_click_through();
     }
 
     /// Requests a repaint after `delay` (floored to [`MIN_REPAINT_DELAY`]),
@@ -166,9 +226,16 @@ impl<'a> TuiPaintContext<'a> {
         self.repaint_at = Some(new_repaint_at);
     }
 
-    /// The earliest repaint deadline requested during this paint, if any.
+    /// Returns the earliest repaint requested by the current test paint.
+    #[cfg(test)]
     pub(crate) fn requested_repaint_at(&self) -> Option<Instant> {
         self.repaint_at
+    }
+
+    /// Finishes paint and returns its retained scene and repaint request.
+    pub(crate) fn finish(self) -> (TuiScene, Option<Instant>, Option<TuiScreenPoint>) {
+        debug_assert!(self.scene.is_at_root_layer());
+        (self.scene, self.repaint_at, self.terminal_cursor)
     }
 }
 
@@ -186,11 +253,8 @@ impl TuiViewMapContext for TuiPaintContext<'_> {
 ///   [`TuiConstraint::clamp`]). The context carries the presenter's
 ///   pre-rendered view map so [`TuiChildView`](crate::elements::tui::TuiChildView)
 ///   can retrieve its child element.
-/// - [`render`](TuiElement::render): paint into `area` of `buffer`. `area` is
-///   the rect the parent allocated (its size is the value `layout` returned,
-///   clamped to what was available).
-/// - [`cursor_position`](TuiElement::cursor_position): where a text cursor
-///   should sit within `area`, if any (default: none).
+/// - [`render`](TuiElement::render): paint at an absolute screen origin through
+///   a [`TuiPaintSurface`], retaining scene geometry through [`TuiPaintContext`].
 /// - [`present`](TuiElement::present): participate in the child-view recursion
 ///   so the presenter can record parent/child view relationships (default:
 ///   nothing — only container/child-view elements override this).
@@ -209,22 +273,35 @@ pub trait TuiElement {
         app: &AppContext,
     ) -> TuiSize;
 
-    /// Paints this element into `area` of `buffer`. `ctx` carries the
+    /// Paints this element at absolute `origin`. `surface` owns the active
+    /// ratatui buffer and accepts only absolute-coordinate paint operations.
+    /// `ctx` carries the
     /// presenter's pre-rendered view map so [`TuiChildView`] can look up and
     /// render its child element without caching it locally, and collects
     /// repaint requests from animated elements
     /// ([`TuiPaintContext::repaint_after`]).
     ///
     /// [`TuiChildView`]: crate::elements::tui::TuiChildView
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext);
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    );
 
-    /// The `(x, y)` cell, within `area`, where the terminal cursor should be
-    /// placed for this element, if it owns the cursor. `ctx` is passed through
-    /// so [`TuiChildView`] can delegate to its child without caching it.
-    ///
-    /// [`TuiChildView`]: crate::elements::tui::TuiChildView
-    fn cursor_position(&self, _area: TuiRect, _ctx: &mut TuiPaintContext) -> Option<(u16, u16)> {
+    /// Returns the size retained by the most recent layout.
+    fn size(&self) -> Option<TuiSize> {
         None
+    }
+
+    /// Returns the screen origin retained by the most recent paint.
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        None
+    }
+
+    /// Returns the element's retained screen bounds.
+    fn bounds(&self) -> Option<TuiScreenRect> {
+        Some(TuiScreenRect::new(self.origin()?, self.size()?))
     }
 
     /// Walks this element during the presenter's child-view pass. Container and
@@ -232,19 +309,15 @@ pub trait TuiElement {
     /// leaf elements do nothing.
     fn present(&mut self, _ctx: &mut TuiPresentationContext<'_>) {}
 
-    /// Offers `event` to this element within `area`, returning `true` if it was
-    /// handled. `event_ctx` collects app updates and typed actions;
-    /// `ctx` carries the presenter's pre-rendered view map so [`TuiChildView`]
-    /// can look up and dispatch into its child; `app` provides read access to
-    /// the shared core during dispatch.
+    /// Offers `event` to this element, returning `true` if it was handled.
+    /// Retained geometry and the painted scene are available through
+    /// `event_ctx`; `app` provides shared core access.
     ///
     /// [`TuiChildView`]: crate::elements::tui::TuiChildView
     fn dispatch_event(
         &mut self,
         _event: &TuiEvent,
-        _area: TuiRect,
-        _event_ctx: &mut TuiEventContext,
-        _ctx: &mut TuiLayoutContext,
+        _event_ctx: &mut TuiEventContext<'_>,
         _app: &AppContext,
     ) -> bool {
         false
@@ -274,7 +347,13 @@ impl TuiElement for () {
         TuiSize::ZERO
     }
 
-    fn render(&self, _area: TuiRect, _buffer: &mut TuiBuffer, _ctx: &mut TuiPaintContext) {}
+    fn render(
+        &mut self,
+        _origin: TuiScreenPosition,
+        _surface: &mut TuiPaintSurface<'_>,
+        _ctx: &mut TuiPaintContext,
+    ) {
+    }
 }
 
 /// Threads the current view ancestry through the element tree during the
@@ -332,21 +411,68 @@ impl TuiViewMapContext for TuiPresentationContext<'_> {
 /// Shared harnesses for TUI element tests.
 #[cfg(test)]
 pub(crate) mod test_support {
-    use super::{TuiBuffer, TuiBufferExt, TuiElement, TuiPaintContext, TuiRect, TuiSize};
-    use crate::EntityIdMap;
+    use std::rc::Rc;
 
-    /// Runs `f` with a paint context over a fresh, empty view map — the
-    /// common harness for leaf-element paint tests.
-    pub(crate) fn with_paint_context<R>(f: impl FnOnce(&mut TuiPaintContext) -> R) -> R {
+    use super::{
+        TuiBuffer, TuiBufferExt, TuiElement, TuiEvent, TuiEventContext, TuiPaintContext,
+        TuiPaintSurface, TuiRect, TuiScene, TuiSize,
+    };
+    use crate::presenter::tui::{TuiFrame, TuiPresenter};
+    use crate::{App, AppContext, EntityId, EntityIdMap};
+
+    /// Runs `f` with an identity-mapped surface and fresh paint context.
+    pub(crate) fn with_paint_surface<R>(
+        buffer: &mut TuiBuffer,
+        f: impl FnOnce(&mut TuiPaintSurface<'_>, &mut TuiPaintContext<'_>) -> R,
+    ) -> R {
         let mut rendered_views = EntityIdMap::default();
-        f(&mut TuiPaintContext::new(&mut rendered_views))
+        let mut ctx = TuiPaintContext::new(&mut rendered_views);
+        let mut surface = TuiPaintSurface::new(buffer);
+        f(&mut surface, &mut ctx)
+    }
+    /// Runs `f` with dispatch state over an empty scene and view map.
+    pub(crate) fn with_event_context<R>(f: impl FnOnce(&mut TuiEventContext<'_>) -> R) -> R {
+        let mut rendered_views = EntityIdMap::default();
+        let mut ctx = TuiEventContext::new(Rc::new(TuiScene::default()), &mut rendered_views);
+        f(&mut ctx)
     }
 
     /// Renders `element` into a `size` buffer and returns the rows as strings.
-    pub(crate) fn render_to_lines(element: &dyn TuiElement, size: TuiSize) -> Vec<String> {
-        let area = TuiRect::new(0, 0, size.width, size.height);
-        let mut buffer = TuiBuffer::empty(area);
-        with_paint_context(|ctx| element.render(area, &mut buffer, ctx));
-        buffer.to_lines()
+    pub(crate) fn render_to_lines(
+        element: impl TuiElement + 'static,
+        size: TuiSize,
+    ) -> Vec<String> {
+        render_to_frame(element, size).buffer.to_lines()
+    }
+
+    /// Renders `element` through the presenter and returns the complete frame.
+    pub(crate) fn render_to_frame(element: impl TuiElement + 'static, size: TuiSize) -> TuiFrame {
+        App::test((), |app| async move {
+            app.read(|app_ctx| {
+                TuiPresenter::new().present_element(
+                    element.finish(),
+                    TuiRect::new(0, 0, size.width, size.height),
+                    app_ctx,
+                )
+            })
+        })
+    }
+
+    /// Dispatches through the element tree and scene retained by `presenter`.
+    pub(crate) fn dispatch_presented_event(
+        presenter: &mut TuiPresenter,
+        event: &TuiEvent,
+        app: &AppContext,
+    ) -> (bool, usize) {
+        let (Some(element), Some(scene)) = (
+            presenter.last_element.as_mut(),
+            presenter.last_scene.clone(),
+        ) else {
+            return (false, 0);
+        };
+        let mut event_ctx = TuiEventContext::new(scene, &mut presenter.rendered_views);
+        event_ctx.set_origin_view(Some(EntityId::new()));
+        let handled = element.dispatch_event(event, &mut event_ctx, app);
+        (handled, event_ctx.take_notified().len())
     }
 }

--- a/crates/warpui_core/src/elements/tui/scene.rs
+++ b/crates/warpui_core/src/elements/tui/scene.rs
@@ -1,0 +1,324 @@
+//! Retained screen geometry used by TUI input dispatch.
+
+use super::{TuiPoint, TuiSize};
+/// A signed absolute position in terminal screen space.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TuiScreenPosition {
+    pub x: i32,
+    pub y: i32,
+}
+
+impl TuiScreenPosition {
+    /// Creates an absolute terminal-space position.
+    pub const fn new(x: i32, y: i32) -> Self {
+        Self { x, y }
+    }
+
+    /// Returns this position translated by the signed cell offset.
+    pub fn offset(self, x: i32, y: i32) -> Self {
+        Self {
+            x: self.x.saturating_add(x),
+            y: self.y.saturating_add(y),
+        }
+    }
+}
+
+/// Paint-order index for a normal or overlay TUI scene layer.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum TuiZIndex {
+    Normal(usize),
+    Overlay(usize),
+}
+
+/// A signed point relative to an element's retained screen origin.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TuiLocalPoint {
+    pub x: i32,
+    pub y: i32,
+}
+
+impl TuiLocalPoint {
+    /// Creates an element-local point.
+    pub const fn new(x: i32, y: i32) -> Self {
+        Self { x, y }
+    }
+}
+
+/// A signed terminal-space point associated with a painted scene layer.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TuiScreenPoint {
+    pub x: i32,
+    pub y: i32,
+    pub z_index: TuiZIndex,
+}
+
+impl TuiScreenPoint {
+    /// Creates a terminal-space point on `z_index`.
+    pub const fn new(x: i32, y: i32, z_index: TuiZIndex) -> Self {
+        Self { x, y, z_index }
+    }
+    /// Attaches `z_index` to an absolute terminal-space position.
+    pub const fn from_position(position: TuiScreenPosition, z_index: TuiZIndex) -> Self {
+        Self::new(position.x, position.y, z_index)
+    }
+
+    /// Returns this point's absolute position without its scene layer.
+    pub const fn position(self) -> TuiScreenPosition {
+        TuiScreenPosition::new(self.x, self.y)
+    }
+
+    /// Returns the same position on a different scene layer.
+    fn with_z_index(self, z_index: TuiZIndex) -> Self {
+        Self { z_index, ..self }
+    }
+}
+
+/// A signed terminal-space rectangle.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TuiScreenRect {
+    pub origin: TuiScreenPoint,
+    pub size: TuiSize,
+}
+
+impl TuiScreenRect {
+    /// Creates a screen rectangle from retained element geometry.
+    pub const fn new(origin: TuiScreenPoint, size: TuiSize) -> Self {
+        Self { origin, size }
+    }
+
+    /// Returns the rectangle's exclusive right edge.
+    pub fn right(self) -> i32 {
+        self.origin.x.saturating_add(i32::from(self.size.width))
+    }
+
+    /// Returns the rectangle's exclusive bottom edge.
+    pub fn bottom(self) -> i32 {
+        self.origin.y.saturating_add(i32::from(self.size.height))
+    }
+
+    /// Returns whether `position` lies inside the half-open rectangle.
+    pub fn contains(self, position: TuiPoint) -> bool {
+        self.contains_xy(i32::from(position.x), i32::from(position.y))
+    }
+
+    /// Returns whether a signed screen coordinate lies inside the rectangle.
+    pub fn contains_xy(self, x: i32, y: i32) -> bool {
+        x >= self.origin.x && x < self.right() && y >= self.origin.y && y < self.bottom()
+    }
+
+    /// Returns the intersection of two screen rectangles.
+    pub fn intersection(self, other: Self) -> Option<Self> {
+        let left = self.origin.x.max(other.origin.x);
+        let top = self.origin.y.max(other.origin.y);
+        let right = self.right().min(other.right());
+        let bottom = self.bottom().min(other.bottom());
+        if left >= right || top >= bottom {
+            return None;
+        }
+        Some(Self::new(
+            TuiScreenPoint::new(left, top, self.origin.z_index),
+            TuiSize::new(
+                u16::try_from(right - left).unwrap_or(u16::MAX),
+                u16::try_from(bottom - top).unwrap_or(u16::MAX),
+            ),
+        ))
+    }
+
+    /// Returns the same rectangle on a different scene layer.
+    fn with_z_index(self, z_index: TuiZIndex) -> Self {
+        Self {
+            origin: self.origin.with_z_index(z_index),
+            ..self
+        }
+    }
+}
+
+/// Clip bounds to apply to a new TUI scene layer.
+#[derive(Clone, Copy, Debug)]
+pub enum TuiClipBounds {
+    ActiveLayer,
+    BoundedBy(TuiScreenRect),
+    BoundedByActiveLayerAnd(TuiScreenRect),
+    None,
+}
+
+#[derive(Clone, Default)]
+struct TuiSceneLayer {
+    hit_rects: Vec<TuiScreenRect>,
+    clip_bounds: Option<TuiScreenRect>,
+    click_through: bool,
+}
+
+/// Retained clip and occlusion data from the last TUI paint.
+#[derive(Clone)]
+pub struct TuiScene {
+    active_layers: Vec<TuiZIndex>,
+    layers: Vec<TuiSceneLayer>,
+    overlay_layers: Vec<TuiSceneLayer>,
+}
+
+impl Default for TuiScene {
+    fn default() -> Self {
+        Self {
+            active_layers: vec![TuiZIndex::Normal(0)],
+            layers: vec![TuiSceneLayer::default()],
+            overlay_layers: Vec::new(),
+        }
+    }
+}
+
+impl TuiScene {
+    /// Returns the active paint layer.
+    pub fn z_index(&self) -> TuiZIndex {
+        *self
+            .active_layers
+            .last()
+            .expect("the TUI scene always has an active root layer")
+    }
+
+    /// Returns the highest layer created in the active layer family.
+    pub fn max_active_z_index(&self) -> TuiZIndex {
+        match self.z_index() {
+            TuiZIndex::Normal(_) => TuiZIndex::Normal(self.layers.len() - 1),
+            TuiZIndex::Overlay(_) => TuiZIndex::Overlay(self.overlay_layers.len() - 1),
+        }
+    }
+
+    /// Starts a normal layer nested under the active layer.
+    pub fn start_layer(&mut self, bounds: TuiClipBounds) {
+        let layer = self.layer_for_bounds(bounds);
+        match self.z_index() {
+            TuiZIndex::Normal(_) => {
+                let z_index = TuiZIndex::Normal(self.layers.len());
+                self.layers.push(layer);
+                self.active_layers.push(z_index);
+            }
+            TuiZIndex::Overlay(_) => {
+                let z_index = TuiZIndex::Overlay(self.overlay_layers.len());
+                self.overlay_layers.push(layer);
+                self.active_layers.push(z_index);
+            }
+        }
+    }
+
+    /// Starts an overlay layer above every normal layer.
+    pub(crate) fn start_overlay_layer(&mut self, bounds: TuiClipBounds) {
+        let layer = self.layer_for_bounds(bounds);
+        self.overlay_layers.push(layer);
+        self.active_layers
+            .push(TuiZIndex::Overlay(self.overlay_layers.len() - 1));
+    }
+
+    /// Makes the active layer transparent to hit testing.
+    pub fn set_active_layer_click_through(&mut self) {
+        self.active_layer_mut().click_through = true;
+    }
+
+    /// Finishes the active layer.
+    pub fn stop_layer(&mut self) {
+        assert!(
+            self.active_layers.len() > 1,
+            "the TUI scene root layer cannot be stopped"
+        );
+        self.active_layers.pop();
+    }
+
+    /// Records a painted hit rectangle on the active layer.
+    pub fn record_hit_rect(&mut self, rect: TuiScreenRect) {
+        let z_index = self.z_index();
+        let rect = rect.with_z_index(z_index);
+        let layer = self.active_layer_mut();
+        if let Some(rect) = layer
+            .clip_bounds
+            .map_or(Some(rect), |clip| rect.intersection(clip))
+        {
+            layer.hit_rects.push(rect);
+        }
+    }
+
+    /// Returns the visible portion of retained element bounds.
+    pub fn visible_rect(&self, origin: TuiScreenPoint, size: TuiSize) -> Option<TuiScreenRect> {
+        let rect = TuiScreenRect::new(origin, size);
+        self.layer(origin.z_index).and_then(|layer| {
+            layer
+                .clip_bounds
+                .map_or(Some(rect), |clip| rect.intersection(clip))
+        })
+    }
+
+    /// Returns whether a higher opaque layer covers `point`.
+    pub fn is_covered(&self, point: TuiScreenPoint) -> bool {
+        let contains = |layer: &TuiSceneLayer| {
+            !layer.click_through
+                && layer
+                    .hit_rects
+                    .iter()
+                    .any(|rect| rect.contains_xy(point.x, point.y))
+        };
+        match point.z_index {
+            TuiZIndex::Normal(index) => self
+                .layers
+                .get(index.saturating_add(1)..)
+                .into_iter()
+                .flatten()
+                .chain(self.overlay_layers.iter())
+                .any(contains),
+            TuiZIndex::Overlay(index) => self
+                .overlay_layers
+                .get(index.saturating_add(1)..)
+                .into_iter()
+                .flatten()
+                .any(contains),
+        }
+    }
+
+    /// Returns whether all nested layers have been closed.
+    pub(crate) fn is_at_root_layer(&self) -> bool {
+        self.active_layers.len() == 1
+    }
+
+    fn layer_for_bounds(&self, bounds: TuiClipBounds) -> TuiSceneLayer {
+        let active_clip = self.active_layer().clip_bounds;
+        let clip_bounds = match bounds {
+            TuiClipBounds::ActiveLayer => active_clip,
+            TuiClipBounds::BoundedBy(bounds) => Some(bounds),
+            TuiClipBounds::BoundedByActiveLayerAnd(bounds) => {
+                active_clip.map_or(Some(bounds), |clip| {
+                    Some(
+                        bounds
+                            .intersection(clip)
+                            .unwrap_or_else(|| TuiScreenRect::new(bounds.origin, TuiSize::ZERO)),
+                    )
+                })
+            }
+            TuiClipBounds::None => None,
+        };
+        TuiSceneLayer {
+            clip_bounds,
+            ..Default::default()
+        }
+    }
+
+    fn active_layer(&self) -> &TuiSceneLayer {
+        self.layer(self.z_index())
+            .expect("the active TUI scene layer exists")
+    }
+
+    fn active_layer_mut(&mut self) -> &mut TuiSceneLayer {
+        match self.z_index() {
+            TuiZIndex::Normal(index) => &mut self.layers[index],
+            TuiZIndex::Overlay(index) => &mut self.overlay_layers[index],
+        }
+    }
+
+    fn layer(&self, z_index: TuiZIndex) -> Option<&TuiSceneLayer> {
+        match z_index {
+            TuiZIndex::Normal(index) => self.layers.get(index),
+            TuiZIndex::Overlay(index) => self.overlay_layers.get(index),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "scene_tests.rs"]
+mod tests;

--- a/crates/warpui_core/src/elements/tui/scene_tests.rs
+++ b/crates/warpui_core/src/elements/tui/scene_tests.rs
@@ -1,0 +1,140 @@
+use super::{TuiClipBounds, TuiScene, TuiScreenPoint, TuiScreenRect, TuiZIndex};
+use crate::elements::tui::{TuiPaintContext, TuiPoint, TuiSize};
+use crate::EntityIdMap;
+
+#[test]
+fn visible_rect_intersects_the_active_clip() {
+    let mut scene = TuiScene::default();
+    scene.start_layer(TuiClipBounds::BoundedBy(TuiScreenRect::new(
+        TuiScreenPoint::new(0, 2, TuiZIndex::Normal(0)),
+        TuiSize::new(5, 2),
+    )));
+    let origin = TuiScreenPoint::new(0, 1, scene.z_index());
+
+    assert_eq!(
+        scene.visible_rect(origin, TuiSize::new(5, 3)),
+        Some(TuiScreenRect::new(
+            TuiScreenPoint::new(0, 2, scene.z_index()),
+            TuiSize::new(5, 2),
+        ))
+    );
+}
+
+#[test]
+fn higher_hit_layer_covers_lower_points() {
+    let mut scene = TuiScene::default();
+    let lower = TuiScreenPoint::new(1, 1, scene.z_index());
+    scene.start_layer(TuiClipBounds::None);
+    scene.record_hit_rect(TuiScreenRect::new(
+        TuiScreenPoint::new(0, 0, scene.z_index()),
+        TuiSize::new(3, 3),
+    ));
+
+    assert!(scene.is_covered(lower));
+    assert!(!scene.is_covered(TuiScreenPoint::new(4, 4, TuiZIndex::Normal(0))));
+}
+
+/// Verifies that overlay layers occlude every normal layer.
+#[test]
+fn overlay_layer_covers_normal_layer_below_it() {
+    let mut rendered_views = EntityIdMap::default();
+    let mut ctx = TuiPaintContext::new(&mut rendered_views);
+    ctx.with_overlay_layer(TuiClipBounds::None, |ctx| {
+        ctx.scene.record_hit_rect(TuiScreenRect::new(
+            TuiScreenPoint::new(0, 0, ctx.scene.z_index()),
+            TuiSize::new(3, 3),
+        ));
+    });
+    let (scene, _, _) = ctx.finish();
+
+    assert!(scene.is_covered(TuiScreenPoint::new(1, 1, TuiZIndex::Normal(0))));
+}
+
+/// Verifies that later overlay layers occlude earlier overlays.
+#[test]
+fn higher_overlay_layer_covers_lower_overlay_layer() {
+    let mut rendered_views = EntityIdMap::default();
+    let mut ctx = TuiPaintContext::new(&mut rendered_views);
+    let lower = ctx.with_overlay_layer(TuiClipBounds::None, |ctx| {
+        let lower = TuiScreenPoint::new(1, 1, ctx.scene.z_index());
+        ctx.with_overlay_layer(TuiClipBounds::None, |ctx| {
+            ctx.scene.record_hit_rect(TuiScreenRect::new(
+                TuiScreenPoint::new(0, 0, ctx.scene.z_index()),
+                TuiSize::new(3, 3),
+            ));
+        });
+        lower
+    });
+    let (scene, _, _) = ctx.finish();
+
+    assert!(scene.is_covered(lower));
+}
+
+/// Verifies that click-through overlays leave lower targets exposed.
+#[test]
+fn click_through_overlay_does_not_cover_lower_targets() {
+    let mut rendered_views = EntityIdMap::default();
+    let mut ctx = TuiPaintContext::new(&mut rendered_views);
+    ctx.with_overlay_layer(TuiClipBounds::None, |ctx| {
+        ctx.set_active_layer_click_through();
+        ctx.scene.record_hit_rect(TuiScreenRect::new(
+            TuiScreenPoint::new(0, 0, ctx.scene.z_index()),
+            TuiSize::new(3, 3),
+        ));
+    });
+    let (scene, _, _) = ctx.finish();
+
+    assert!(!scene.is_covered(TuiScreenPoint::new(1, 1, TuiZIndex::Normal(0))));
+}
+
+#[test]
+fn disjoint_nested_clip_stays_empty() {
+    let mut scene = TuiScene::default();
+    scene.start_layer(TuiClipBounds::BoundedBy(TuiScreenRect::new(
+        TuiScreenPoint::new(0, 0, TuiZIndex::Normal(0)),
+        TuiSize::new(2, 2),
+    )));
+    scene.start_layer(TuiClipBounds::BoundedByActiveLayerAnd(TuiScreenRect::new(
+        TuiScreenPoint::new(4, 4, scene.z_index()),
+        TuiSize::new(2, 2),
+    )));
+    let origin = TuiScreenPoint::new(4, 4, scene.z_index());
+
+    assert_eq!(scene.visible_rect(origin, TuiSize::new(2, 2)), None);
+}
+
+#[test]
+fn signed_rect_contains_visible_terminal_points() {
+    let rect = TuiScreenRect::new(
+        TuiScreenPoint::new(-1, 0, TuiZIndex::Normal(0)),
+        TuiSize::new(3, 1),
+    );
+
+    assert!(rect.contains(TuiPoint::new(0, 0)));
+    assert!(!rect.contains(TuiPoint::new(2, 0)));
+}
+
+#[test]
+fn terminal_cursor_prefers_higher_layers() {
+    let mut rendered_views = EntityIdMap::default();
+    let mut ctx = TuiPaintContext::new(&mut rendered_views);
+    ctx.set_terminal_cursor(TuiScreenPoint::new(1, 0, ctx.scene.z_index()));
+    ctx.scene.start_layer(TuiClipBounds::None);
+    let higher = TuiScreenPoint::new(2, 0, ctx.scene.z_index());
+    ctx.set_terminal_cursor(higher);
+    ctx.scene.stop_layer();
+    ctx.set_terminal_cursor(TuiScreenPoint::new(3, 0, ctx.scene.z_index()));
+
+    assert_eq!(ctx.terminal_cursor(), Some(higher));
+}
+
+#[test]
+fn terminal_cursor_uses_later_submission_on_the_same_layer() {
+    let mut rendered_views = EntityIdMap::default();
+    let mut ctx = TuiPaintContext::new(&mut rendered_views);
+    let later = TuiScreenPoint::new(2, 0, ctx.scene.z_index());
+    ctx.set_terminal_cursor(TuiScreenPoint::new(1, 0, ctx.scene.z_index()));
+    ctx.set_terminal_cursor(later);
+
+    assert_eq!(ctx.terminal_cursor(), Some(later));
+}

--- a/crates/warpui_core/src/elements/tui/scrollable.rs
+++ b/crates/warpui_core/src/elements/tui/scrollable.rs
@@ -9,8 +9,8 @@
 //! [`TuiScrollableElement`] without changing this wrapper.
 
 use super::{
-    TuiBuffer, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext,
-    TuiPaintContext, TuiPresentationContext, TuiRect, TuiRectExt, TuiSize,
+    TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext, TuiPaintContext,
+    TuiPaintSurface, TuiPresentationContext, TuiScreenPoint, TuiScreenPosition, TuiSize,
 };
 use crate::AppContext;
 
@@ -75,12 +75,21 @@ impl TuiElement for TuiScrollable {
         self.child.layout(constraint, ctx, app)
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
-        self.child.render(area, buffer, ctx);
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.child.render(origin, surface, ctx);
     }
 
-    fn cursor_position(&self, area: TuiRect, ctx: &mut TuiPaintContext) -> Option<(u16, u16)> {
-        self.child.cursor_position(area, ctx)
+    fn size(&self) -> Option<TuiSize> {
+        self.child.size()
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.child.origin()
     }
 
     fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
@@ -90,21 +99,22 @@ impl TuiElement for TuiScrollable {
     fn dispatch_event(
         &mut self,
         event: &TuiEvent,
-        area: TuiRect,
-        event_ctx: &mut TuiEventContext,
-        ctx: &mut TuiLayoutContext,
+        event_ctx: &mut TuiEventContext<'_>,
         app: &AppContext,
     ) -> bool {
-        if self.child.dispatch_event(event, area, event_ctx, ctx, app) {
+        if self.child.dispatch_event(event, event_ctx, app) {
             return true;
         }
+        let Some((origin, size)) = self.origin().zip(self.size()) else {
+            return false;
+        };
         match event {
             TuiEvent::ScrollWheel {
                 position, delta, ..
-            } if area.contains_point(*position) => {
+            } if event_ctx.hit_test(origin, size, *position) => {
                 let scrolled = self
                     .child
-                    .scroll_by_rows(-(delta.1 * WHEEL_STEP), usize::from(area.height));
+                    .scroll_by_rows(-(delta.1 * WHEEL_STEP), usize::from(size.height));
                 if scrolled {
                     event_ctx.notify();
                 }

--- a/crates/warpui_core/src/elements/tui/selectable.rs
+++ b/crates/warpui_core/src/elements/tui/selectable.rs
@@ -14,9 +14,9 @@ use std::ops::Range;
 use string_offset::{ByteOffset, CharOffset};
 
 use super::{
-    TuiBuffer, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiGridPoint,
-    TuiLayoutContext, TuiPaintContext, TuiPoint, TuiPresentationContext, TuiRect,
-    TuiScrollableElement, TuiSize,
+    TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiGridPoint, TuiLayoutContext,
+    TuiLocalPoint, TuiPaintContext, TuiPaintSurface, TuiPresentationContext, TuiScreenPoint,
+    TuiScreenPosition, TuiScrollableElement, TuiSize, TuiViewMapContext,
 };
 use crate::elements::SmartSelectFn;
 use crate::text::word_boundaries::WordBoundariesPolicy;
@@ -44,11 +44,11 @@ pub struct TuiRowResize {
 
 /// Geometry, content, and rendering behavior implemented by a selectable child.
 pub trait TuiSelectableElement: TuiScrollableElement {
-    /// Resolves one screen position into a content-space point.
+    /// Resolves one element-local position into a content-space point.
     fn selection_point_at(
         &mut self,
-        position: TuiPoint,
-        area: TuiRect,
+        position: TuiLocalPoint,
+        size: TuiSize,
         clamp_outside: bool,
     ) -> Option<TuiGridPoint>;
 
@@ -65,7 +65,7 @@ pub trait TuiSelectableElement: TuiScrollableElement {
     fn selected_text(
         &self,
         selection: TuiSelectionSpan,
-        area: TuiRect,
+        size: TuiSize,
         ctx: &mut TuiLayoutContext,
         app: &AppContext,
     ) -> Option<String>;
@@ -74,8 +74,9 @@ pub trait TuiSelectableElement: TuiScrollableElement {
     fn render_selection(
         &self,
         selection: &TuiSelectionHandle,
-        area: TuiRect,
-        buffer: &mut TuiBuffer,
+        origin: TuiScreenPosition,
+        size: TuiSize,
+        surface: &mut TuiPaintSurface<'_>,
         ctx: &mut TuiPaintContext,
     );
 
@@ -123,20 +124,20 @@ where
         self
     }
 
-    /// Resolves one screen position into the configured selection unit.
+    /// Resolves one element-local position into the configured selection unit.
     fn selection_span_at(
         &mut self,
-        position: TuiPoint,
+        position: TuiLocalPoint,
         selection_type: SelectionType,
-        area: TuiRect,
+        size: TuiSize,
         clamp_outside: bool,
         ctx: &mut TuiLayoutContext,
         app: &AppContext,
     ) -> Option<TuiSelectionSpan> {
         let point = self
             .child
-            .selection_point_at(position, area, clamp_outside)?;
-        Some(self.selection_unit_span(selection_type, point, area.width, ctx, app))
+            .selection_point_at(position, size, clamp_outside)?;
+        Some(self.selection_unit_span(selection_type, point, size.width, ctx, app))
     }
 
     /// Expands one content point to a character, word, or line span.
@@ -225,13 +226,26 @@ where
         size
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
-        self.child.render(area, buffer, ctx);
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.child.render(origin, surface, ctx);
+        let Some(size) = self.child.size() else {
+            return;
+        };
         self.child
-            .render_selection(&self.selection, area, buffer, ctx);
+            .render_selection(&self.selection, origin, size, surface, ctx);
     }
-    fn cursor_position(&self, area: TuiRect, ctx: &mut TuiPaintContext) -> Option<(u16, u16)> {
-        self.child.cursor_position(area, ctx)
+
+    fn size(&self) -> Option<TuiSize> {
+        self.child.size()
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.child.origin()
     }
 
     fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
@@ -241,9 +255,7 @@ where
     fn dispatch_event(
         &mut self,
         event: &TuiEvent,
-        area: TuiRect,
-        event_ctx: &mut TuiEventContext,
-        ctx: &mut TuiLayoutContext,
+        event_ctx: &mut TuiEventContext<'_>,
         app: &AppContext,
     ) -> bool {
         let captures_drag = self.selection.is_selecting()
@@ -251,9 +263,12 @@ where
                 event,
                 TuiEvent::LeftMouseDragged { .. } | TuiEvent::LeftMouseUp { .. }
             );
-        if !captures_drag && self.child.dispatch_event(event, area, event_ctx, ctx, app) {
+        if !captures_drag && self.child.dispatch_event(event, event_ctx, app) {
             return true;
         }
+        let Some((origin, size)) = self.child.origin().zip(self.child.size()) else {
+            return false;
+        };
 
         match event {
             TuiEvent::LeftMouseDown {
@@ -261,11 +276,23 @@ where
                 click_count,
                 is_first_mouse,
                 ..
-            } if !*is_first_mouse => {
+            } if !*is_first_mouse && event_ctx.hit_test(origin, size, *position) => {
                 let selection_type = SelectionType::from_click_count(*click_count);
-                let Some(anchor_span) =
-                    self.selection_span_at(*position, selection_type, area, false, ctx, app)
-                else {
+                let local_position = event_ctx.local_point(origin, *position);
+                let anchor_span = {
+                    let mut ctx = TuiLayoutContext {
+                        rendered_views: event_ctx.rendered_views_mut(),
+                    };
+                    self.selection_span_at(
+                        local_position,
+                        selection_type,
+                        size,
+                        false,
+                        &mut ctx,
+                        app,
+                    )
+                };
+                let Some(anchor_span) = anchor_span else {
                     return false;
                 };
                 let focus_span = match selection_type {
@@ -273,7 +300,7 @@ where
                     SelectionType::Semantic | SelectionType::Lines => Some(anchor_span),
                 };
                 self.selection
-                    .start(anchor_span, focus_span, selection_type, area.width);
+                    .start(anchor_span, focus_span, selection_type, size.width);
                 if let Some(callback) = self.on_selection_start.as_mut() {
                     callback(event_ctx, app);
                 }
@@ -283,29 +310,37 @@ where
             TuiEvent::LeftMouseDragged { position, .. } if self.selection.is_selecting() => {
                 // Scroll one row per drag event at an edge. The top edge is
                 // inclusive because terminal mouse coordinates cannot go negative.
-                let scroll_rows = if position.y <= area.y {
+                let position_y = i32::from(position.y);
+                let scroll_rows = if position_y <= origin.y {
                     -1
-                } else if position.y >= area.bottom() {
+                } else if position_y >= origin.y.saturating_add(i32::from(size.height)) {
                     1
                 } else {
                     0
                 };
                 if scroll_rows != 0 {
                     self.child
-                        .scroll_by_rows(scroll_rows, usize::from(area.height));
+                        .scroll_by_rows(scroll_rows, usize::from(size.height));
                 }
 
                 let Some(interaction) = self.selection.interaction() else {
                     return false;
                 };
-                let Some(focus_span) = self.selection_span_at(
-                    *position,
-                    interaction.selection_type,
-                    area,
-                    true,
-                    ctx,
-                    app,
-                ) else {
+                let local_position = event_ctx.local_point(origin, *position);
+                let focus_span = {
+                    let mut ctx = TuiLayoutContext {
+                        rendered_views: event_ctx.rendered_views_mut(),
+                    };
+                    self.selection_span_at(
+                        local_position,
+                        interaction.selection_type,
+                        size,
+                        true,
+                        &mut ctx,
+                        app,
+                    )
+                };
+                let Some(focus_span) = focus_span else {
                     return true;
                 };
                 if matches!(
@@ -323,10 +358,15 @@ where
             }
             TuiEvent::LeftMouseUp { .. } if self.selection.is_selecting() => {
                 self.selection.finish();
-                let text = self
-                    .selection
-                    .range()
-                    .and_then(|selection| self.child.selected_text(selection, area, ctx, app));
+                let selection = self.selection.range();
+                let text = {
+                    let mut ctx = TuiLayoutContext {
+                        rendered_views: event_ctx.rendered_views_mut(),
+                    };
+                    selection.and_then(|selection| {
+                        self.child.selected_text(selection, size, &mut ctx, app)
+                    })
+                };
                 if text.is_none() {
                     self.selection.clear();
                 }

--- a/crates/warpui_core/src/elements/tui/shimmering_text.rs
+++ b/crates/warpui_core/src/elements/tui/shimmering_text.rs
@@ -13,8 +13,8 @@
 use std::time::Duration;
 
 use super::{
-    Color, Modifier, TuiBuffer, TuiConstraint, TuiElement, TuiLayoutContext, TuiPaintContext,
-    TuiRect, TuiSize, TuiStyle,
+    Color, Modifier, TuiConstraint, TuiElement, TuiLayoutContext, TuiPaintContext, TuiPaintSurface,
+    TuiScreenPoint, TuiScreenPosition, TuiSize, TuiStyle,
 };
 use crate::color::ColorU;
 use crate::elements::animation::AnimationClock;
@@ -34,6 +34,8 @@ pub struct TuiShimmeringText {
     /// The clock the band's phase is derived from.
     clock: AnimationClock,
     modifier: Modifier,
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
 }
 
 impl TuiShimmeringText {
@@ -54,6 +56,8 @@ impl TuiShimmeringText {
             config,
             clock,
             modifier: Modifier::empty(),
+            size: None,
+            origin: None,
         }
     }
 
@@ -71,18 +75,30 @@ impl TuiElement for TuiShimmeringText {
         _ctx: &mut TuiLayoutContext,
         _app: &AppContext,
     ) -> TuiSize {
-        if self.text.is_empty() {
-            return constraint.clamp(TuiSize::ZERO);
-        }
-        let width = u16::try_from(self.text.chars().count()).unwrap_or(u16::MAX);
-        TuiSize::new(
-            constraint.constrain_width(width),
-            constraint.constrain_height(1),
-        )
+        let size = if self.text.is_empty() {
+            constraint.clamp(TuiSize::ZERO)
+        } else {
+            let width = u16::try_from(self.text.chars().count()).unwrap_or(u16::MAX);
+            TuiSize::new(
+                constraint.constrain_width(width),
+                constraint.constrain_height(1),
+            )
+        };
+        self.size = Some(size);
+        size
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
-        if area.is_empty() {
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.origin = Some(ctx.scene_point(origin));
+        let Some(size) = self.size else {
+            return;
+        };
+        if size.width == 0 || size.height == 0 {
             return;
         }
 
@@ -90,10 +106,8 @@ impl TuiElement for TuiShimmeringText {
         let center = shimmer_math::shimmer_center(glyph_count, self.clock.elapsed(), &self.config);
 
         for (index, char) in self.text.chars().enumerate() {
-            let x = area
-                .x
-                .saturating_add(index.min(usize::from(u16::MAX)) as u16);
-            if x >= area.right() {
+            let x = index.min(usize::from(u16::MAX)) as u16;
+            if x >= size.width {
                 break;
             }
             let intensity = shimmer_math::intensity_at(index, center, &self.config);
@@ -102,12 +116,20 @@ impl TuiElement for TuiShimmeringText {
             let style = TuiStyle::default()
                 .fg(Color::Rgb(color.r, color.g, color.b))
                 .add_modifier(self.modifier);
-            if let Some(cell) = buffer.cell_mut((x, area.y)) {
+            if let Some(cell) = surface.cell_mut(origin.offset(i32::from(x), 0)) {
                 cell.set_symbol(char.to_string().as_str()).set_style(style);
             }
         }
 
         ctx.repaint_after(REPAINT_INTERVAL);
+    }
+
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
     }
 }
 

--- a/crates/warpui_core/src/elements/tui/shimmering_text_tests.rs
+++ b/crates/warpui_core/src/elements/tui/shimmering_text_tests.rs
@@ -6,8 +6,8 @@ use super::TuiShimmeringText;
 use crate::color::ColorU;
 use crate::elements::animation::AnimationClock;
 use crate::elements::shimmer_math::ShimmerConfig;
-use crate::elements::tui::test_support::with_paint_context;
-use crate::elements::tui::{TuiBuffer, TuiElement, TuiRect};
+use crate::elements::tui::test_support::render_to_frame;
+use crate::elements::tui::{TuiBuffer, TuiSize};
 
 const BASE: ColorU = ColorU {
     r: 254,
@@ -35,20 +35,17 @@ fn element(initial_elapsed: Duration) -> TuiShimmeringText {
 
 /// Renders `element` into a 10x1 buffer, returning the buffer and whether a
 /// repaint was requested.
-fn render(element: &TuiShimmeringText) -> (TuiBuffer, bool) {
-    let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, 10, 1));
-    let requested_repaint = with_paint_context(|ctx| {
-        element.render(TuiRect::new(0, 0, 10, 1), &mut buffer, ctx);
-        ctx.requested_repaint_at().is_some()
-    });
-    (buffer, requested_repaint)
+fn render(element: TuiShimmeringText) -> (TuiBuffer, bool) {
+    let frame = render_to_frame(element, TuiSize::new(10, 1));
+    let requested_repaint = frame.repaint_at.is_some();
+    (frame.buffer, requested_repaint)
 }
 
 #[test]
 fn paints_base_color_before_the_band_reaches_the_text() {
     // At t=0 the band center sits `padding` glyphs before the text, farther
     // than `shimmer_radius` from every glyph, so every cell is the base color.
-    let (buffer, _) = render(&element(Duration::ZERO));
+    let (buffer, _) = render(element(Duration::ZERO));
     for (index, char) in "Warping".chars().enumerate() {
         let cell = &buffer[(index as u16, 0)];
         assert_eq!(cell.symbol(), char.to_string());
@@ -62,7 +59,7 @@ fn paints_the_shimmer_color_at_the_band_center_mid_sweep() {
     let config = ShimmerConfig::default();
     // Half a period in: progress 0.5, so the center is at glyph
     // 0.5 * ((7 - 1) + 2 * padding) - padding = 3.
-    let (buffer, _) = render(&element(config.period / 2));
+    let (buffer, _) = render(element(config.period / 2));
     let center_cell = &buffer[(3, 0)];
     assert_eq!(center_cell.fg, Color::Rgb(SHIMMER.r, SHIMMER.g, SHIMMER.b));
     // A glyph at the band's edge is only partially lerped toward the shimmer.
@@ -73,6 +70,6 @@ fn paints_the_shimmer_color_at_the_band_center_mid_sweep() {
 
 #[test]
 fn requests_a_repaint_every_paint() {
-    let (_, requested_repaint) = render(&element(Duration::ZERO));
+    let (_, requested_repaint) = render(element(Duration::ZERO));
     assert!(requested_repaint);
 }

--- a/crates/warpui_core/src/elements/tui/text.rs
+++ b/crates/warpui_core/src/elements/tui/text.rs
@@ -26,11 +26,11 @@
 use std::mem;
 
 use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::{Paragraph, Widget, Wrap};
+use ratatui::widgets::{Paragraph, Wrap};
 
 use super::{
-    TuiBuffer, TuiConstraint, TuiElement, TuiLayoutContext, TuiPaintContext, TuiRect, TuiSize,
-    TuiStyle,
+    TuiConstraint, TuiElement, TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiScreenPoint,
+    TuiScreenPosition, TuiSize, TuiStyle,
 };
 use crate::AppContext;
 
@@ -41,6 +41,8 @@ pub struct TuiText {
     /// Base style beneath every span; span styles patch over it.
     style: TuiStyle,
     wrap: bool,
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
 }
 
 impl TuiText {
@@ -57,6 +59,8 @@ impl TuiText {
             spans: spans.into_iter().collect(),
             style: TuiStyle::default(),
             wrap: true,
+            size: None,
+            origin: None,
         }
     }
 
@@ -128,23 +132,44 @@ impl TuiElement for TuiText {
         _ctx: &mut TuiLayoutContext,
         _app: &AppContext,
     ) -> TuiSize {
-        if self.is_empty() {
-            return constraint.clamp(TuiSize::ZERO);
-        }
-        let paragraph = self.paragraph();
-        let height = u16::try_from(paragraph.line_count(constraint.max.width)).unwrap_or(u16::MAX);
-        let content_width = u16::try_from(paragraph.line_width()).unwrap_or(u16::MAX);
-        TuiSize::new(
-            constraint.constrain_width(content_width),
-            constraint.constrain_height(height),
-        )
+        let size = if self.is_empty() {
+            constraint.clamp(TuiSize::ZERO)
+        } else {
+            let paragraph = self.paragraph();
+            let height =
+                u16::try_from(paragraph.line_count(constraint.max.width)).unwrap_or(u16::MAX);
+            let content_width = u16::try_from(paragraph.line_width()).unwrap_or(u16::MAX);
+            TuiSize::new(
+                constraint.constrain_width(content_width),
+                constraint.constrain_height(height),
+            )
+        };
+        self.size = Some(size);
+        size
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, _ctx: &mut TuiPaintContext) {
-        if area.is_empty() {
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.origin = Some(ctx.scene_point(origin));
+        let Some(size) = self.size else {
+            return;
+        };
+        if size.width == 0 || size.height == 0 {
             return;
         }
-        Widget::render(self.paragraph(), area, buffer);
+        surface.render_widget(self.paragraph(), origin, size);
+    }
+
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
     }
 }
 

--- a/crates/warpui_core/src/elements/tui/text_tests.rs
+++ b/crates/warpui_core/src/elements/tui/text_tests.rs
@@ -1,17 +1,15 @@
 use ratatui::style::{Color, Modifier, Style};
 
 use super::TuiText;
-use crate::elements::tui::test_support::{render_to_lines, with_paint_context};
-use crate::elements::tui::{
-    TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiLayoutContext, TuiRect, TuiSize,
-};
+use crate::elements::tui::test_support::{render_to_frame, render_to_lines};
+use crate::elements::tui::{TuiBufferExt, TuiConstraint, TuiElement, TuiLayoutContext, TuiSize};
 use crate::{App, EntityIdMap};
 
 #[test]
 fn renders_a_single_short_line() {
     let text = TuiText::new("hello");
     assert_eq!(
-        render_to_lines(&text, TuiSize::new(10, 1)),
+        render_to_lines(text, TuiSize::new(10, 1)),
         vec!["hello     "],
     );
 }
@@ -41,7 +39,7 @@ fn layout_reports_content_width_and_row_count() {
 fn word_wraps_at_the_width_boundary() {
     let text = TuiText::new("hello world foo");
     assert_eq!(
-        render_to_lines(&text, TuiSize::new(11, 2)),
+        render_to_lines(text, TuiSize::new(11, 2)),
         vec!["hello world", "foo        "],
     );
 }
@@ -51,7 +49,7 @@ fn hard_breaks_a_token_wider_than_the_row() {
     let text = TuiText::new("abcdefgh");
     assert_eq!(text.desired_height(3), 3);
     assert_eq!(
-        render_to_lines(&text, TuiSize::new(3, 3)),
+        render_to_lines(text, TuiSize::new(3, 3)),
         vec!["abc", "def", "gh "],
     );
 }
@@ -61,11 +59,11 @@ fn wide_glyphs_occupy_two_columns_and_are_never_split() {
     // A wide glyph painted with one trailing column to spare drops whole: only
     // the leading "日" lands, proving it claimed two columns.
     let truncated = TuiText::new("日本").truncate();
-    assert_eq!(render_to_lines(&truncated, TuiSize::new(3, 1)), vec!["日 "]);
+    assert_eq!(render_to_lines(truncated, TuiSize::new(3, 1)), vec!["日 "]);
 
     // Given exactly four columns both wide glyphs fit.
     assert_eq!(
-        render_to_lines(&TuiText::new("日本"), TuiSize::new(4, 1)),
+        render_to_lines(TuiText::new("日本"), TuiSize::new(4, 1)),
         vec!["日本"],
     );
 
@@ -74,7 +72,7 @@ fn wide_glyphs_occupy_two_columns_and_are_never_split() {
     let wrapped = TuiText::new("日本");
     assert_eq!(wrapped.desired_height(2), 2);
     assert_eq!(
-        render_to_lines(&wrapped, TuiSize::new(2, 2)),
+        render_to_lines(wrapped, TuiSize::new(2, 2)),
         vec!["日", "本"],
     );
 }
@@ -83,9 +81,7 @@ fn wide_glyphs_occupy_two_columns_and_are_never_split() {
 fn applies_its_style_to_painted_cells() {
     let style = Style::default().fg(Color::Red).add_modifier(Modifier::BOLD);
     let text = TuiText::new("a").with_style(style);
-
-    let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, 1, 1));
-    with_paint_context(|ctx| text.render(TuiRect::new(0, 0, 1, 1), &mut buffer, ctx));
+    let buffer = render_to_frame(text, TuiSize::new(1, 1)).buffer;
 
     let cell = &buffer[(0, 0)];
     assert_eq!(cell.symbol(), "a");
@@ -98,7 +94,7 @@ fn truncation_keeps_one_row_per_hard_line() {
     let text = TuiText::new("a\nb\nc").truncate();
     assert_eq!(text.desired_height(10), 3);
     assert_eq!(
-        render_to_lines(&text, TuiSize::new(3, 3)),
+        render_to_lines(text, TuiSize::new(3, 3)),
         vec!["a  ", "b  ", "c  "],
     );
 }
@@ -112,8 +108,7 @@ fn spans_flow_as_one_paragraph_with_per_span_styles() {
     ])
     .with_style(Style::default().fg(Color::White));
 
-    let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, 6, 1));
-    with_paint_context(|ctx| text.render(TuiRect::new(0, 0, 6, 1), &mut buffer, ctx));
+    let buffer = render_to_frame(text, TuiSize::new(6, 1)).buffer;
 
     assert_eq!(buffer.to_lines(), vec!["✓ done"]);
     // The span's style patches over the base style.
@@ -131,7 +126,7 @@ fn spans_wrap_across_span_boundaries() {
     ]);
     assert_eq!(text.desired_height(5), 2);
     assert_eq!(
-        render_to_lines(&text, TuiSize::new(5, 2)),
+        render_to_lines(text, TuiSize::new(5, 2)),
         vec!["aa bb", "cc   "],
     );
 }
@@ -144,7 +139,7 @@ fn hard_newlines_inside_spans_split_lines() {
     ]);
     assert_eq!(text.desired_height(10), 2);
     assert_eq!(
-        render_to_lines(&text, TuiSize::new(3, 2)),
+        render_to_lines(text, TuiSize::new(3, 2)),
         vec!["a  ", "bc "],
     );
 }

--- a/crates/warpui_core/src/elements/tui/viewported_list.rs
+++ b/crates/warpui_core/src/elements/tui/viewported_list.rs
@@ -12,8 +12,9 @@ use std::rc::Rc;
 use super::selectable::{row_glyphs, row_text, TuiSelectionHandle};
 use super::{
     TuiBuffer, TuiClipped, TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiGridPoint,
-    TuiLayoutContext, TuiPaintContext, TuiPresentationContext, TuiRect, TuiRowResize,
-    TuiScrollableElement, TuiSelectableElement, TuiSelectionSpan, TuiSize,
+    TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiPresentationContext, TuiRect,
+    TuiRowResize, TuiScreenPoint, TuiScreenPosition, TuiScrollableElement, TuiSelectableElement,
+    TuiSelectionSpan, TuiSize,
 };
 use crate::AppContext;
 
@@ -102,11 +103,11 @@ where
 {
     fn selection_point_at(
         &mut self,
-        position: super::TuiPoint,
-        area: TuiRect,
+        position: super::TuiLocalPoint,
+        size: TuiSize,
         clamp_outside: bool,
     ) -> Option<TuiGridPoint> {
-        self.resolve_selection_point(position, area, clamp_outside)
+        self.resolve_selection_point(position, size, clamp_outside)
     }
 
     fn selection_row_glyphs(
@@ -122,51 +123,51 @@ where
     fn selected_text(
         &self,
         selection: TuiSelectionSpan,
-        area: TuiRect,
+        size: TuiSize,
         ctx: &mut TuiLayoutContext,
         app: &AppContext,
     ) -> Option<String> {
-        self.selection_text(selection, area, ctx, app)
+        self.selection_text(selection, size, ctx, app)
     }
 
     fn render_selection(
         &self,
         selection: &TuiSelectionHandle,
-        area: TuiRect,
-        buffer: &mut TuiBuffer,
+        origin: TuiScreenPosition,
+        size: TuiSize,
+        surface: &mut TuiPaintSurface<'_>,
         _ctx: &mut TuiPaintContext,
     ) {
         let Some(resolved) = self.state.resolved_viewport() else {
             return;
         };
-        let visible_height = area.height.saturating_sub(resolved.screen_offset).min(
+        let visible_height = size.height.saturating_sub(resolved.screen_offset).min(
             resolved
                 .content_height
                 .saturating_sub(resolved.window.scroll_top)
                 .min(usize::from(u16::MAX)) as u16,
         );
-        let mut snapshot = TuiBuffer::empty(TuiRect::new(0, 0, area.width, visible_height));
+        let mut snapshot = TuiBuffer::empty(TuiRect::new(0, 0, size.width, visible_height));
         for row in 0..visible_height {
-            for col in 0..area.width {
-                snapshot[(col, row)] = buffer[(
-                    area.x.saturating_add(col),
-                    area.y
-                        .saturating_add(resolved.screen_offset)
-                        .saturating_add(row),
-                )]
-                    .clone();
+            for col in 0..size.width {
+                let position = origin.offset(
+                    i32::from(col),
+                    i32::from(resolved.screen_offset.saturating_add(row)),
+                );
+                if let Some(cell) = surface.cell(position) {
+                    snapshot[(col, row)] = cell.clone();
+                }
             }
         }
         *self.selection_snapshot.borrow_mut() = Some((resolved, snapshot));
-
-        if !selection.validate_width(area.width) {
+        if !selection.validate_width(size.width) {
             return;
         }
         let Some(range) = selection.range() else {
             return;
         };
         let viewport_bottom = resolved.window.scroll_top.saturating_add(usize::from(
-            area.height.saturating_sub(resolved.screen_offset),
+            size.height.saturating_sub(resolved.screen_offset),
         ));
         let first_row = max(range.start.row, resolved.window.scroll_top);
         let end_row_exclusive = if range.end.col == 0 {
@@ -177,9 +178,8 @@ where
         let last_row = min(end_row_exclusive, viewport_bottom);
         let mut selection_rects = Vec::new();
         for row in first_row..last_row {
-            let y = area
-                .y
-                .saturating_add(resolved.screen_offset)
+            let y = resolved
+                .screen_offset
                 .saturating_add(row.saturating_sub(resolved.window.scroll_top) as u16);
             let start_col = if row == range.start.row {
                 range.start.col
@@ -189,19 +189,17 @@ where
             let end_col = if row == range.end.row {
                 range.end.col
             } else {
-                area.width
+                size.width
             };
             if start_col < end_col {
-                selection_rects.push(TuiRect::new(
-                    area.x.saturating_add(start_col),
-                    y,
-                    end_col.saturating_sub(start_col).min(area.width),
-                    1,
+                selection_rects.push((
+                    origin.offset(i32::from(start_col), i32::from(y)),
+                    TuiSize::new(end_col.saturating_sub(start_col).min(size.width), 1),
                 ));
             }
         }
-        for rect in selection_rects {
-            toggle_selection_reverse(buffer, rect);
+        for (origin, size) in selection_rects {
+            toggle_selection_reverse(surface, origin, size);
         }
     }
 
@@ -273,7 +271,17 @@ struct VisibleElement {
     height: u16,
     element: TuiClipped,
 }
-
+impl VisibleElement {
+    /// Returns this item's rendered slot within the viewport area.
+    fn slot(&self, area: TuiRect) -> Option<TuiRect> {
+        let slot_y = area.y.saturating_add(self.viewport_y);
+        if slot_y >= area.bottom() {
+            return None;
+        }
+        let height = self.height.min(area.bottom() - slot_y);
+        Some(TuiRect::new(area.x, slot_y, area.width, height))
+    }
+}
 /// Lays out visible items using the canonical viewport clipping rules.
 fn layout_visible_elements(
     content: TuiViewportContent,
@@ -312,30 +320,38 @@ fn layout_visible_elements(
             let height = visible_bottom
                 .saturating_sub(visible_top)
                 .min(usize::from(u16::MAX)) as u16;
+            let element = TuiClipped::from_laid_out_child(
+                element,
+                viewport_origin_y,
+                TuiSize::new(available_width, height),
+            );
             Some(VisibleElement {
                 viewport_y,
                 height,
-                element: TuiClipped::new(element).with_viewport_origin_y(viewport_origin_y),
+                element,
             })
         })
         .collect()
 }
 
-/// Renders canonical visible elements into `area`.
+/// Renders canonical visible elements at an absolute viewport origin.
 fn render_visible_elements(
-    visible_elements: &[VisibleElement],
-    area: TuiRect,
-    buffer: &mut TuiBuffer,
+    visible_elements: &mut [VisibleElement],
+    origin: TuiScreenPosition,
+    size: TuiSize,
+    surface: &mut TuiPaintSurface<'_>,
     ctx: &mut TuiPaintContext,
 ) {
+    let area = TuiRect::new(0, 0, size.width, size.height);
     for visible in visible_elements {
-        let slot_y = area.y.saturating_add(visible.viewport_y);
-        if slot_y >= area.bottom() {
+        let Some(slot) = visible.slot(area) else {
             continue;
-        }
-        let height = visible.height.min(area.bottom() - slot_y);
-        let slot = TuiRect::new(area.x, slot_y, area.width, height);
-        visible.element.render(slot, buffer, ctx);
+        };
+        visible.element.render(
+            origin.offset(i32::from(slot.x), i32::from(slot.y)),
+            surface,
+            ctx,
+        );
     }
 }
 
@@ -348,18 +364,35 @@ fn render_viewport_content(
     app: &AppContext,
 ) -> TuiBuffer {
     let area = TuiRect::new(0, 0, available_width, window.viewport_height);
-    let visible_elements = layout_visible_elements(content, window, 0, available_width, ctx, app);
+    let mut visible_elements =
+        layout_visible_elements(content, window, 0, available_width, ctx, app);
     let mut buffer = TuiBuffer::empty(area);
     let mut paint_ctx = TuiPaintContext::new(ctx.rendered_views);
-    render_visible_elements(&visible_elements, area, &mut buffer, &mut paint_ctx);
+    {
+        let origin = TuiScreenPosition::new(0, 0);
+        let mut surface = TuiPaintSurface::new(&mut buffer);
+        render_visible_elements(
+            &mut visible_elements,
+            origin,
+            area.as_size(),
+            &mut surface,
+            &mut paint_ctx,
+        );
+    }
     buffer
 }
 
-/// Toggles reverse video over a selected rectangle.
-fn toggle_selection_reverse(buffer: &mut TuiBuffer, rect: TuiRect) {
-    for row in rect.y..rect.bottom() {
-        for col in rect.x..rect.right() {
-            let cell = &mut buffer[(col, row)];
+/// Toggles reverse video over selected absolute bounds.
+fn toggle_selection_reverse(
+    surface: &mut TuiPaintSurface<'_>,
+    origin: TuiScreenPosition,
+    size: TuiSize,
+) {
+    for row in 0..size.height {
+        for col in 0..size.width {
+            let Some(cell) = surface.cell_mut(origin.offset(i32::from(col), i32::from(row))) else {
+                continue;
+            };
             if cell.modifier.contains(super::Modifier::REVERSED) {
                 cell.modifier.remove(super::Modifier::REVERSED);
             } else {
@@ -378,7 +411,8 @@ where
     content: Content,
     visible_elements: Vec<VisibleElement>,
     content_height: usize,
-    size: TuiSize,
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
     vertical_alignment: TuiViewportVerticalAlignment,
     selection_snapshot: RefCell<Option<(TuiResolvedViewport, TuiBuffer)>>,
 }
@@ -394,7 +428,8 @@ where
             content,
             visible_elements: Vec::new(),
             content_height: 0,
-            size: TuiSize::ZERO,
+            size: None,
+            origin: None,
             vertical_alignment: TuiViewportVerticalAlignment::Top,
             selection_snapshot: RefCell::new(None),
         }
@@ -565,16 +600,16 @@ where
     /// Maps a screen point into the latest resolved content window.
     fn resolve_selection_point(
         &self,
-        position: super::TuiPoint,
-        area: TuiRect,
+        position: super::TuiLocalPoint,
+        size: TuiSize,
         clamp_outside: bool,
     ) -> Option<TuiGridPoint> {
         let resolved = self.state.resolved_viewport()?;
-        if resolved.content_height == 0 || area.width == 0 || area.height == 0 {
+        if resolved.content_height == 0 || size.width == 0 || size.height == 0 {
             return None;
         }
-        let content_top = area.y.saturating_add(resolved.screen_offset);
-        let visible_height = area.height.saturating_sub(resolved.screen_offset);
+        let content_top = i32::from(resolved.screen_offset);
+        let visible_height = size.height.saturating_sub(resolved.screen_offset);
         let visible_content_height = min(
             usize::from(visible_height),
             resolved
@@ -585,30 +620,29 @@ where
             return None;
         }
         let row_in_view = if clamp_outside {
-            position
-                .y
-                .saturating_sub(content_top)
-                .min(visible_content_height.saturating_sub(1) as u16)
+            position.y.saturating_sub(content_top).clamp(
+                0,
+                i32::try_from(visible_content_height.saturating_sub(1)).unwrap_or(i32::MAX),
+            ) as usize
         } else {
-            if position.x < area.x
-                || position.x >= area.right()
+            if position.x < 0
+                || position.x >= i32::from(size.width)
                 || position.y < content_top
-                || usize::from(position.y.saturating_sub(content_top)) >= visible_content_height
+                || usize::try_from(position.y.saturating_sub(content_top)).ok()?
+                    >= visible_content_height
             {
                 return None;
             }
-            position.y - content_top
+            usize::try_from(position.y - content_top).ok()?
         };
         Some(TuiGridPoint {
             row: resolved
                 .window
                 .scroll_top
-                .saturating_add(usize::from(row_in_view))
+                .saturating_add(row_in_view)
                 .min(resolved.content_height.saturating_sub(1)),
-            col: position
-                .x
-                .saturating_sub(area.x)
-                .min(area.width.saturating_sub(1)),
+            col: u16::try_from(position.x.clamp(0, i32::from(size.width.saturating_sub(1))))
+                .unwrap_or_default(),
         })
     }
 
@@ -653,7 +687,7 @@ where
     fn selection_text(
         &self,
         selection: TuiSelectionSpan,
-        area: TuiRect,
+        size: TuiSize,
         ctx: &mut TuiLayoutContext,
         app: &AppContext,
     ) -> Option<String> {
@@ -672,7 +706,7 @@ where
                 end_row_exclusive,
                 chunk_start.saturating_add(usize::from(u16::MAX)),
             );
-            let buffer = self.selection_rows(chunk_start..chunk_end, area.width, ctx, app)?;
+            let buffer = self.selection_rows(chunk_start..chunk_end, size.width, ctx, app)?;
             for row in chunk_start..chunk_end {
                 let buffer_row = row.saturating_sub(chunk_start) as u16;
                 let start_col = if row == selection.start.row {
@@ -683,7 +717,7 @@ where
                 let end_col = if row == selection.end.row {
                     selection.end.col
                 } else {
-                    area.width
+                    size.width
                 };
                 lines.push(row_text(&buffer, buffer_row, start_col..end_col));
             }
@@ -704,28 +738,30 @@ where
         app: &AppContext,
     ) -> TuiSize {
         self.layout_visible_elements(constraint, ctx, app);
-        self.size = constraint.max;
+        let size = constraint.max;
+        self.size = Some(size);
+        size
+    }
+
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.origin = Some(ctx.scene_point(origin));
+        let Some(size) = self.size else {
+            return;
+        };
+        render_visible_elements(&mut self.visible_elements, origin, size, surface, ctx);
+    }
+
+    fn size(&self) -> Option<TuiSize> {
         self.size
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
-        render_visible_elements(&self.visible_elements, area, buffer, ctx);
-    }
-
-    fn cursor_position(&self, area: TuiRect, ctx: &mut TuiPaintContext) -> Option<(u16, u16)> {
-        for visible in &self.visible_elements {
-            let slot_y = area.y.saturating_add(visible.viewport_y);
-            if slot_y >= area.bottom() {
-                continue;
-            }
-            let height = visible.height.min(area.bottom() - slot_y);
-            let slot = TuiRect::new(area.x, slot_y, area.width, height);
-            let (x, y) = visible.element.cursor_position(slot, ctx)?;
-            if y < height {
-                return Some((x, slot_y.saturating_sub(area.y).saturating_add(y)));
-            }
-        }
-        None
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
     }
 
     fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
@@ -737,26 +773,14 @@ where
     fn dispatch_event(
         &mut self,
         event: &TuiEvent,
-        area: TuiRect,
-        event_ctx: &mut TuiEventContext,
-        ctx: &mut TuiLayoutContext,
+        event_ctx: &mut TuiEventContext<'_>,
         app: &AppContext,
     ) -> bool {
-        for visible in &mut self.visible_elements {
-            let slot_y = area.y.saturating_add(visible.viewport_y);
-            if slot_y >= area.bottom() {
-                continue;
-            }
-            let height = visible.height.min(area.bottom() - slot_y);
-            let slot = TuiRect::new(area.x, slot_y, area.width, height);
-            if visible
-                .element
-                .dispatch_event(event, slot, event_ctx, ctx, app)
-            {
-                return true;
-            }
-        }
-        false
+        self.visible_elements
+            .iter_mut()
+            .fold(false, |handled, visible| {
+                visible.element.dispatch_event(event, event_ctx, app) || handled
+            })
     }
 }
 

--- a/crates/warpui_core/src/elements/tui/viewported_list_tests.rs
+++ b/crates/warpui_core/src/elements/tui/viewported_list_tests.rs
@@ -9,10 +9,12 @@ use super::{
 };
 use crate::elements::tui::{
     Modifier, TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiEvent, TuiEventContext,
-    TuiLayoutContext, TuiPaintContext, TuiPoint, TuiRect, TuiScrollable, TuiScrollableElement,
-    TuiSelectable, TuiSelectionHandle, TuiSize, TuiText,
+    TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiPoint, TuiRect, TuiScreenPoint,
+    TuiScreenPosition, TuiScrollable, TuiScrollableElement, TuiSelectable, TuiSelectionHandle,
+    TuiSize, TuiText,
 };
 use crate::event::ModifiersState;
+use crate::presenter::tui::TuiPresenter;
 use crate::text::word_boundaries::WordBoundariesPolicy;
 use crate::{App, AppContext, EntityId, EntityIdMap};
 
@@ -85,6 +87,66 @@ impl TuiViewportedElement for FakeContent {
         Some(self.content(window, available_width))
     }
 }
+struct LayoutCountingElement {
+    layout_count: Rc<Cell<usize>>,
+    size: Option<TuiSize>,
+}
+
+impl TuiElement for LayoutCountingElement {
+    /// Retains a height-sensitive size and records each layout pass.
+    fn layout(
+        &mut self,
+        constraint: TuiConstraint,
+        _ctx: &mut TuiLayoutContext,
+        _app: &AppContext,
+    ) -> TuiSize {
+        self.layout_count.set(self.layout_count.get() + 1);
+        let size = constraint.clamp(TuiSize::new(1, 3));
+        self.size = Some(size);
+        size
+    }
+
+    /// Paints nothing.
+    fn render(
+        &mut self,
+        _origin: TuiScreenPosition,
+        _surface: &mut TuiPaintSurface<'_>,
+        _ctx: &mut TuiPaintContext,
+    ) {
+    }
+
+    /// Returns the retained size from the canonical layout pass.
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+}
+
+struct LayoutCountingContent {
+    layout_count: Rc<Cell<usize>>,
+}
+
+impl TuiViewportedElement for LayoutCountingContent {
+    /// Returns one item that extends below a two-row viewport.
+    fn visible_items(
+        &self,
+        _window: TuiViewportWindow,
+        _available_width: u16,
+        _ctx: &mut TuiLayoutContext,
+        _app: &AppContext,
+    ) -> TuiViewportContent {
+        TuiViewportContent {
+            content_height: 3,
+            items: vec![TuiVisibleViewportItem {
+                origin_y: 0,
+                element: LayoutCountingElement {
+                    layout_count: self.layout_count.clone(),
+                    size: None,
+                }
+                .finish(),
+            }],
+        }
+    }
+}
 
 fn fake_item(id: usize, height: usize) -> FakeItem {
     FakeItem {
@@ -100,6 +162,17 @@ fn viewport_with_state(
     TuiViewportedList::new(state, content)
 }
 
+/// Verifies viewport geometry is unavailable until layout establishes it.
+#[test]
+fn retained_size_is_absent_before_layout() {
+    let viewport = viewport_with_state(
+        TuiViewportedListState::new_at_end(),
+        FakeContent::new(Vec::new()),
+    );
+
+    assert_eq!(viewport.size(), None);
+}
+
 fn render_viewport(app: &App, viewport: &mut impl TuiElement, size: TuiSize) -> Vec<String> {
     app.read(|app_ctx| {
         let mut rendered_views = EntityIdMap::default();
@@ -110,7 +183,10 @@ fn render_viewport(app: &App, viewport: &mut impl TuiElement, size: TuiSize) -> 
         let area = TuiRect::new(0, 0, size.width, size.height);
         let mut buffer = TuiBuffer::empty(area);
         let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
-        viewport.render(area, &mut buffer, &mut paint_ctx);
+        {
+            let mut surface = TuiPaintSurface::new(&mut buffer);
+            viewport.render(TuiScreenPosition::new(0, 0), &mut surface, &mut paint_ctx);
+        }
         buffer.to_lines()
     })
 }
@@ -122,15 +198,18 @@ fn mouse(app: &App, element: &mut impl TuiElement, size: TuiSize, event: TuiEven
         let mut ctx = TuiLayoutContext {
             rendered_views: &mut rendered_views,
         };
-        let mut event_ctx = TuiEventContext::default();
+        element.layout(TuiConstraint::tight(size), &mut ctx, app_ctx);
+        let area = TuiRect::new(0, 0, size.width, size.height);
+        let mut buffer = TuiBuffer::empty(area);
+        let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
+        {
+            let mut surface = TuiPaintSurface::new(&mut buffer);
+            element.render(TuiScreenPosition::new(0, 0), &mut surface, &mut paint_ctx);
+        }
+        let (scene, _, _) = paint_ctx.finish();
+        let mut event_ctx = TuiEventContext::new(Rc::new(scene), &mut rendered_views);
         event_ctx.set_origin_view(Some(EntityId::new()));
-        element.dispatch_event(
-            &event,
-            TuiRect::new(0, 0, size.width, size.height),
-            &mut event_ctx,
-            &mut ctx,
-            app_ctx,
-        )
+        element.dispatch_event(&event, &mut event_ctx, app_ctx)
     })
 }
 
@@ -149,9 +228,20 @@ fn mouse_in_area(
             rendered_views: &mut rendered_views,
         };
         element.layout(TuiConstraint::tight(size), &mut ctx, app_ctx);
-        let mut event_ctx = TuiEventContext::default();
+        let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, area.right(), area.bottom()));
+        let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
+        {
+            let mut surface = TuiPaintSurface::new(&mut buffer);
+            element.render(
+                TuiScreenPosition::new(i32::from(area.x), i32::from(area.y)),
+                &mut surface,
+                &mut paint_ctx,
+            );
+        }
+        let (scene, _, _) = paint_ctx.finish();
+        let mut event_ctx = TuiEventContext::new(Rc::new(scene), &mut rendered_views);
         event_ctx.set_origin_view(Some(EntityId::new()));
-        element.dispatch_event(&event, area, &mut event_ctx, &mut ctx, app_ctx)
+        element.dispatch_event(&event, &mut event_ctx, app_ctx)
     })
 }
 
@@ -165,7 +255,12 @@ fn render_in_area(app: &App, element: &mut impl TuiElement, size: TuiSize, area:
         element.layout(TuiConstraint::tight(size), &mut ctx, app_ctx);
         let mut buffer = TuiBuffer::empty(TuiRect::new(0, 0, area.right(), area.bottom()));
         let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
-        element.render(area, &mut buffer, &mut paint_ctx);
+        let mut surface = TuiPaintSurface::new(&mut buffer);
+        element.render(
+            TuiScreenPosition::new(i32::from(area.x), i32::from(area.y)),
+            &mut surface,
+            &mut paint_ctx,
+        );
     });
 }
 
@@ -211,11 +306,15 @@ fn wheel_with_notify_count(
 ) -> (bool, usize) {
     app.read(|app_ctx| {
         let mut rendered_views = EntityIdMap::default();
-        let mut ctx = TuiLayoutContext {
-            rendered_views: &mut rendered_views,
-        };
         let area = TuiRect::new(0, 0, size.width, size.height);
-        let mut event_ctx = TuiEventContext::default();
+        let mut buffer = TuiBuffer::empty(area);
+        let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
+        {
+            let mut surface = TuiPaintSurface::new(&mut buffer);
+            viewport.render(TuiScreenPosition::new(0, 0), &mut surface, &mut paint_ctx);
+        }
+        let (scene, _, _) = paint_ctx.finish();
+        let mut event_ctx = TuiEventContext::new(Rc::new(scene), &mut rendered_views);
         event_ctx.set_origin_view(Some(EntityId::new()));
         let event = TuiEvent::ScrollWheel {
             position: TuiPoint::new(0, 0),
@@ -223,9 +322,29 @@ fn wheel_with_notify_count(
             precise: false,
             modifiers: ModifiersState::default(),
         };
-        let handled = viewport.dispatch_event(&event, area, &mut event_ctx, &mut ctx, app_ctx);
+        let handled = viewport.dispatch_event(&event, &mut event_ctx, app_ctx);
         (handled, event_ctx.take_notified().len())
     })
+}
+
+/// Keeps the full item layout canonical when its bottom is clipped.
+#[test]
+fn bottom_clipped_item_is_laid_out_once() {
+    App::test((), |app| async move {
+        let layout_count = Rc::new(Cell::new(0));
+        let state = TuiViewportedListState::new_at_end();
+        state.scroll_to_rows_from_top(0);
+        let mut viewport = TuiViewportedList::new(
+            state,
+            LayoutCountingContent {
+                layout_count: layout_count.clone(),
+            },
+        );
+
+        render_viewport(&app, &mut viewport, TuiSize::new(8, 2));
+
+        assert_eq!(layout_count.get(), 1);
+    });
 }
 
 #[test]
@@ -417,7 +536,10 @@ fn selectable_viewport_highlights_and_copies_linear_rows() {
             let area = TuiRect::new(0, 0, size.width, size.height);
             let mut buffer = TuiBuffer::empty(area);
             let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
-            element.render(area, &mut buffer, &mut paint_ctx);
+            {
+                let mut surface = TuiPaintSurface::new(&mut buffer);
+                element.render(TuiScreenPosition::new(0, 0), &mut surface, &mut paint_ctx);
+            }
             buffer
         });
         assert!(buffer[(0, 0)].modifier.contains(Modifier::REVERSED));
@@ -507,9 +629,10 @@ fn selection_reverse_toggles_existing_modifier() {
     let area = TuiRect::new(0, 0, 2, 1);
     let mut buffer = TuiBuffer::empty(area);
     buffer[(0, 0)].modifier.insert(Modifier::REVERSED);
-
-    super::toggle_selection_reverse(&mut buffer, area);
-
+    {
+        let mut surface = TuiPaintSurface::new(&mut buffer);
+        super::toggle_selection_reverse(&mut surface, TuiScreenPosition::new(0, 0), area.as_size());
+    }
     assert!(!buffer[(0, 0)].modifier.contains(Modifier::REVERSED));
     assert!(buffer[(1, 0)].modifier.contains(Modifier::REVERSED));
 }
@@ -963,6 +1086,8 @@ fn propagating_scrollable_returns_unhandled_when_scroll_state_does_not_change() 
 
 struct CursorElement {
     cursor: (u16, u16),
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
 }
 
 impl TuiElement for CursorElement {
@@ -972,13 +1097,32 @@ impl TuiElement for CursorElement {
         _ctx: &mut TuiLayoutContext,
         _app: &AppContext,
     ) -> TuiSize {
-        constraint.clamp(TuiSize::new(1, 3))
+        let size = constraint.clamp(TuiSize::new(1, 3));
+        self.size = Some(size);
+        size
     }
 
-    fn render(&self, _area: TuiRect, _buffer: &mut TuiBuffer, _ctx: &mut TuiPaintContext) {}
+    fn render(
+        &mut self,
+        position: TuiScreenPosition,
+        _surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        let origin = ctx.scene_point(position);
+        self.origin = Some(origin);
+        ctx.set_terminal_cursor(TuiScreenPoint::new(
+            origin.x.saturating_add(i32::from(self.cursor.0)),
+            origin.y.saturating_add(i32::from(self.cursor.1)),
+            origin.z_index,
+        ));
+    }
 
-    fn cursor_position(&self, _area: TuiRect, _ctx: &mut TuiPaintContext) -> Option<(u16, u16)> {
-        Some(self.cursor)
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
     }
 }
 
@@ -1025,90 +1169,23 @@ fn single_element_viewport(
 #[test]
 fn cursor_position_is_shifted_into_the_visible_window() {
     App::test((), |app| async move {
-        let mut viewport = single_element_viewport(
+        let viewport = single_element_viewport(
             TuiViewportPosition::RowsFromTop(1),
-            CursorElement { cursor: (0, 2) }.finish(),
-        );
-
-        app.read(|app_ctx| {
-            let mut rendered_views = EntityIdMap::default();
-            let mut ctx = TuiLayoutContext {
-                rendered_views: &mut rendered_views,
-            };
-            viewport.layout(TuiConstraint::tight(TuiSize::new(3, 2)), &mut ctx, app_ctx);
-
-            let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
-            assert_eq!(
-                viewport.cursor_position(TuiRect::new(0, 0, 3, 2), &mut paint_ctx),
-                Some((0, 1)),
-            );
-        });
-    });
-}
-
-struct DispatchRecorder {
-    called: Rc<Cell<bool>>,
-}
-
-impl TuiElement for DispatchRecorder {
-    fn layout(
-        &mut self,
-        constraint: TuiConstraint,
-        _ctx: &mut TuiLayoutContext,
-        _app: &AppContext,
-    ) -> TuiSize {
-        constraint.clamp(TuiSize::new(1, 3))
-    }
-
-    fn render(&self, _area: TuiRect, _buffer: &mut TuiBuffer, _ctx: &mut TuiPaintContext) {}
-
-    fn dispatch_event(
-        &mut self,
-        _event: &TuiEvent,
-        _area: TuiRect,
-        _event_ctx: &mut TuiEventContext,
-        _ctx: &mut TuiLayoutContext,
-        _app: &AppContext,
-    ) -> bool {
-        self.called.set(true);
-        true
-    }
-}
-
-#[test]
-fn dispatch_filters_mouse_events_outside_visible_window() {
-    App::test((), |app| async move {
-        let called = Rc::new(Cell::new(false));
-        let mut viewport = single_element_viewport(
-            TuiViewportPosition::RowsFromTop(1),
-            DispatchRecorder {
-                called: called.clone(),
+            CursorElement {
+                cursor: (0, 2),
+                size: None,
+                origin: None,
             }
             .finish(),
         );
 
         app.read(|app_ctx| {
-            let mut rendered_views = EntityIdMap::default();
-            let mut ctx = TuiLayoutContext {
-                rendered_views: &mut rendered_views,
-            };
-            let mut event_ctx = TuiEventContext::default();
-            viewport.layout(TuiConstraint::tight(TuiSize::new(3, 2)), &mut ctx, app_ctx);
-
-            let event = TuiEvent::LeftMouseDown {
-                position: TuiPoint::new(0, 2),
-                modifiers: ModifiersState::default(),
-                click_count: 1,
-                is_first_mouse: false,
-            };
-            assert!(!viewport.dispatch_event(
-                &event,
+            let frame = TuiPresenter::new().present_element(
+                viewport.finish(),
                 TuiRect::new(0, 0, 3, 2),
-                &mut event_ctx,
-                &mut ctx,
                 app_ctx,
-            ));
-            assert!(!called.get());
+            );
+            assert_eq!(frame.cursor, Some((0, 1)));
         });
     });
 }

--- a/crates/warpui_core/src/presenter/tui.rs
+++ b/crates/warpui_core/src/presenter/tui.rs
@@ -37,12 +37,13 @@
 //! records the embedded view as a child of its parent.
 //!
 //! [`TuiChildView`]: crate::elements::tui::TuiChildView
+use std::rc::Rc;
 
 use instant::Instant;
 
 use crate::elements::tui::{
-    TuiBuffer, TuiConstraint, TuiElement, TuiLayoutContext, TuiPaintContext,
-    TuiPresentationContext, TuiRect,
+    TuiBuffer, TuiConstraint, TuiElement, TuiLayoutContext, TuiPaintContext, TuiPaintSurface,
+    TuiPresentationContext, TuiRect, TuiScene, TuiScreenPosition, TuiSize,
 };
 use crate::{AppContext, EntityIdMap, TuiView, ViewHandle, WindowId, WindowInvalidation};
 
@@ -93,6 +94,8 @@ pub struct TuiPresenter {
     /// point for the next frame's layout (for unchanged child subtrees) and for
     /// event dispatch between frames.
     pub(crate) last_element: Option<Box<dyn TuiElement>>,
+    /// The retained scene painted from `last_element`.
+    pub(crate) last_scene: Option<Rc<TuiScene>>,
     /// Whether [`invalidate`](Self::invalidate) ran since the last
     /// [`present`](Self::present). When it did, every changed view was
     /// re-rendered into `rendered_views`, so `last_element` is current and a
@@ -176,6 +179,8 @@ impl TuiPresenter {
             })
             .or_else(|| ctx.render_tui_view(window_id, root_view_id).ok())
         else {
+            self.last_element = None;
+            self.last_scene = None;
             return TuiFrame::blank(area);
         };
 
@@ -195,34 +200,31 @@ impl TuiPresenter {
         }
         ctx.report_view_embeddings(window_id, embeddings);
 
-        let frame = paint(element.as_ref(), arranged, area, &mut self.rendered_views);
+        let (frame, scene) = paint(element.as_mut(), arranged, area, &mut self.rendered_views);
         self.last_element = Some(element);
+        self.last_scene = Some(Rc::new(scene));
         frame
     }
 
     /// Lays out and paints an already-rendered element tree into `area`.
     ///
     /// Exposed for the runtime and tests that drive layout/paint for an element
-    /// tree produced outside the app's view registry. No view-ancestry is
-    /// recorded and no `rendered_views` state is consulted or updated.
+    /// tree produced outside the app's view registry. No view ancestry is
+    /// recorded; the painted root and scene are retained for test dispatch.
     pub fn present_element(
         &mut self,
         mut root: Box<dyn TuiElement>,
         area: TuiRect,
         app: &AppContext,
     ) -> TuiFrame {
-        let mut empty_views = EntityIdMap::default();
         let mut layout_ctx = TuiLayoutContext {
-            rendered_views: &mut empty_views,
+            rendered_views: &mut self.rendered_views,
         };
         let arranged = arrange(root.as_mut(), area, &mut layout_ctx, app);
-        paint(root.as_ref(), arranged, area, &mut empty_views)
-    }
-
-    /// Returns a mutable reference to the root element from the last
-    /// [`present`](Self::present) call, for use by event dispatch.
-    pub fn last_element_mut(&mut self) -> Option<&mut Box<dyn TuiElement>> {
-        self.last_element.as_mut()
+        let (frame, scene) = paint(root.as_mut(), arranged, area, &mut self.rendered_views);
+        self.last_element = Some(root);
+        self.last_scene = Some(Rc::new(scene));
+        frame
     }
 }
 
@@ -244,32 +246,45 @@ fn arrange(
     )
 }
 
-/// Composite the tree into a fresh buffer and lift the root-relative cursor
-/// offset to absolute coordinates. `rendered_views` is threaded through so
-/// [`TuiChildView`] can look up its child during render and cursor passes,
-/// and the paint context's earliest requested repaint deadline is surfaced on
-/// the frame.
+/// Composite the tree into a fresh buffer. `rendered_views` is threaded
+/// through so [`TuiChildView`] can look up its child during render; the paint
+/// context surfaces the terminal cursor and earliest repaint deadline.
 ///
 /// [`TuiChildView`]: crate::elements::tui::TuiChildView
 fn paint(
-    root: &dyn TuiElement,
+    root: &mut dyn TuiElement,
     arranged: TuiRect,
     area: TuiRect,
     rendered_views: &mut EntityIdMap<Box<dyn TuiElement>>,
-) -> TuiFrame {
+) -> (TuiFrame, TuiScene) {
     let mut buffer = TuiBuffer::empty(buffer_rect_for(area));
     let mut ctx = TuiPaintContext::new(rendered_views);
-    root.render(arranged, &mut buffer, &mut ctx);
-
-    let cursor = root
-        .cursor_position(arranged, &mut ctx)
-        .map(|(x, y)| (arranged.x.saturating_add(x), arranged.y.saturating_add(y)));
-
-    TuiFrame {
-        buffer,
-        cursor,
-        repaint_at: ctx.requested_repaint_at(),
+    {
+        let mut surface = TuiPaintSurface::new(&mut buffer);
+        root.render(
+            TuiScreenPosition::new(i32::from(arranged.x), i32::from(arranged.y)),
+            &mut surface,
+            &mut ctx,
+        );
     }
+
+    let (scene, repaint_at, terminal_cursor) = ctx.finish();
+    let cursor = terminal_cursor.and_then(|point| {
+        let visible = scene.visible_rect(point, TuiSize::new(1, 1)).is_some();
+        if !visible || scene.is_covered(point) {
+            return None;
+        }
+        Some((u16::try_from(point.x).ok()?, u16::try_from(point.y).ok()?))
+    });
+
+    (
+        TuiFrame {
+            buffer,
+            cursor,
+            repaint_at,
+        },
+        scene,
+    )
 }
 
 /// The buffer rect needed to hold everything painted within `area`: it spans

--- a/crates/warpui_core/src/presenter/tui_tests.rs
+++ b/crates/warpui_core/src/presenter/tui_tests.rs
@@ -12,9 +12,9 @@ use instant::Instant;
 
 use super::TuiPresenter;
 use crate::elements::tui::{
-    TuiAnimated, TuiBuffer, TuiBufferExt, TuiChildView, TuiConstraint, TuiElement,
-    TuiLayoutContext, TuiPaintContext, TuiPresentationContext, TuiRect, TuiRectExt, TuiSize,
-    TuiStyle,
+    TuiAnimated, TuiBufferExt, TuiChildView, TuiConstraint, TuiElement, TuiLayoutContext,
+    TuiPaintContext, TuiPaintSurface, TuiPresentationContext, TuiRect, TuiRectExt, TuiScreenPoint,
+    TuiScreenPosition, TuiSize,
 };
 use crate::platform::WindowStyle;
 use crate::{
@@ -27,12 +27,16 @@ use crate::{
 /// A single line of text: as wide as its content, one row tall.
 struct TextDouble {
     text: String,
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
 }
 
 impl TextDouble {
     fn new(text: &str) -> Self {
         Self {
             text: text.to_owned(),
+            size: None,
+            origin: None,
         }
     }
 
@@ -48,17 +52,34 @@ impl TuiElement for TextDouble {
         _ctx: &mut TuiLayoutContext,
         _app: &AppContext,
     ) -> TuiSize {
-        constraint.clamp(TuiSize::new(self.width(), 1))
+        let size = constraint.clamp(TuiSize::new(self.width(), 1));
+        self.size = Some(size);
+        size
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, _ctx: &mut TuiPaintContext) {
-        buffer.set_stringn(
-            area.x,
-            area.y,
-            &self.text,
-            usize::from(area.width),
-            TuiStyle::default(),
-        );
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.origin = Some(ctx.scene_point(origin));
+        let size = self.size.unwrap();
+        for (column, character) in self.text.chars().take(usize::from(size.width)).enumerate() {
+            if let Some(cell) =
+                surface.cell_mut(origin.offset(i32::try_from(column).unwrap_or(i32::MAX), 0))
+            {
+                cell.set_char(character);
+            }
+        }
+    }
+
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
     }
 }
 
@@ -68,6 +89,8 @@ impl TuiElement for TextDouble {
 struct ColumnDouble {
     children: Vec<Box<dyn TuiElement>>,
     child_sizes: Vec<TuiSize>,
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
 }
 
 impl ColumnDouble {
@@ -75,6 +98,8 @@ impl ColumnDouble {
         Self {
             children,
             child_sizes: Vec::new(),
+            size: None,
+            origin: None,
         }
     }
 }
@@ -99,36 +124,45 @@ impl TuiElement for ColumnDouble {
             max_width = max_width.max(size.width);
             self.child_sizes.push(size);
         }
-        constraint.clamp(TuiSize::new(max_width, total_height))
+        let size = constraint.clamp(TuiSize::new(max_width, total_height));
+        self.size = Some(size);
+        size
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.origin = Some(ctx.scene_point(origin));
+        let size = self.size.unwrap();
+        let area = TuiRect::new(0, 0, size.width, size.height);
         let mut remaining = area;
-        for (child, size) in self.children.iter().zip(&self.child_sizes) {
+        for (child, size) in self.children.iter_mut().zip(&self.child_sizes) {
             let (row, rest) = remaining.split_top(size.height);
             let child_area = TuiRect::new(row.x, row.y, size.width.min(row.width), row.height);
-            child.render(child_area, buffer, ctx);
+            child.render(
+                origin.offset(i32::from(child_area.x), i32::from(child_area.y)),
+                surface,
+                ctx,
+            );
             remaining = rest;
         }
+    }
+
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
     }
 
     fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
         for child in &mut self.children {
             child.present(ctx);
         }
-    }
-
-    fn cursor_position(&self, area: TuiRect, ctx: &mut TuiPaintContext) -> Option<(u16, u16)> {
-        let mut remaining = area;
-        for (child, size) in self.children.iter().zip(&self.child_sizes) {
-            let (row, rest) = remaining.split_top(size.height);
-            let child_area = TuiRect::new(row.x, row.y, size.width.min(row.width), row.height);
-            if let Some((cx, cy)) = child.cursor_position(child_area, ctx) {
-                return Some((child_area.x - area.x + cx, child_area.y - area.y + cy));
-            }
-            remaining = rest;
-        }
-        None
     }
 }
 
@@ -139,6 +173,8 @@ struct ContainerDouble {
     padding: u16,
     fill: char,
     child_size: TuiSize,
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
 }
 
 impl ContainerDouble {
@@ -148,6 +184,8 @@ impl ContainerDouble {
             padding,
             fill,
             child_size: TuiSize::ZERO,
+            size: None,
+            origin: None,
         }
     }
 }
@@ -166,17 +204,27 @@ impl TuiElement for ContainerDouble {
         );
         let size = self.child.layout(TuiConstraint::loose(inner_max), ctx, app);
         self.child_size = size;
-        constraint.clamp(TuiSize::new(
+        let size = constraint.clamp(TuiSize::new(
             size.width.saturating_add(inset),
             size.height.saturating_add(inset),
-        ))
+        ));
+        self.size = Some(size);
+        size
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.origin = Some(ctx.scene_point(origin));
+        let size = self.size.unwrap();
+        let area = TuiRect::new(0, 0, size.width, size.height);
         let fill = self.fill.to_string();
         for y in area.y..area.bottom() {
             for x in area.x..area.right() {
-                if let Some(cell) = buffer.cell_mut((x, y)) {
+                if let Some(cell) = surface.cell_mut(origin.offset(i32::from(x), i32::from(y))) {
                     cell.set_symbol(&fill);
                 }
             }
@@ -188,7 +236,19 @@ impl TuiElement for ContainerDouble {
             self.child_size.width.min(inner.width),
             self.child_size.height.min(inner.height),
         );
-        self.child.render(child_area, buffer, ctx);
+        self.child.render(
+            origin.offset(i32::from(child_area.x), i32::from(child_area.y)),
+            surface,
+            ctx,
+        );
+    }
+
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
     }
 
     fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {
@@ -199,11 +259,17 @@ impl TuiElement for ContainerDouble {
 /// A leaf that owns the cursor, reporting it at a fixed offset within its area.
 struct CursorDouble {
     offset: (u16, u16),
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
 }
 
 impl CursorDouble {
     fn new(offset: (u16, u16)) -> Self {
-        Self { offset }
+        Self {
+            offset,
+            size: None,
+            origin: None,
+        }
     }
 }
 
@@ -214,27 +280,46 @@ impl TuiElement for CursorDouble {
         _ctx: &mut TuiLayoutContext,
         _app: &AppContext,
     ) -> TuiSize {
-        constraint.clamp(TuiSize::new(5, 1))
+        let size = constraint.clamp(TuiSize::new(5, 1));
+        self.size = Some(size);
+        size
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, _ctx: &mut TuiPaintContext) {
-        buffer.set_stringn(
-            area.x,
-            area.y,
-            "INPUT",
-            usize::from(area.width),
-            TuiStyle::default(),
-        );
+    fn render(
+        &mut self,
+        position: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        let origin = ctx.scene_point(position);
+        self.origin = Some(origin);
+        ctx.set_terminal_cursor(TuiScreenPoint::new(
+            origin.x.saturating_add(i32::from(self.offset.0)),
+            origin.y.saturating_add(i32::from(self.offset.1)),
+            origin.z_index,
+        ));
+        let size = self.size.unwrap();
+        for (column, character) in "INPUT".chars().take(usize::from(size.width)).enumerate() {
+            if let Some(cell) =
+                surface.cell_mut(position.offset(i32::try_from(column).unwrap_or(i32::MAX), 0))
+            {
+                cell.set_char(character);
+            }
+        }
+    }
+    fn size(&self) -> Option<TuiSize> {
+        self.size
     }
 
-    fn cursor_position(&self, _area: TuiRect, _ctx: &mut TuiPaintContext) -> Option<(u16, u16)> {
-        Some(self.offset)
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
     }
 }
 
 /// A leaf that requests a repaint `delay` after every paint.
 struct RepaintDouble {
     delay: Duration,
+    size: Option<TuiSize>,
 }
 
 impl TuiElement for RepaintDouble {
@@ -244,11 +329,22 @@ impl TuiElement for RepaintDouble {
         _ctx: &mut TuiLayoutContext,
         _app: &AppContext,
     ) -> TuiSize {
-        constraint.clamp(TuiSize::new(1, 1))
+        let size = constraint.clamp(TuiSize::new(1, 1));
+        self.size = Some(size);
+        size
     }
 
-    fn render(&self, _area: TuiRect, _buffer: &mut TuiBuffer, ctx: &mut TuiPaintContext) {
+    fn render(
+        &mut self,
+        _origin: TuiScreenPosition,
+        _surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
         ctx.repaint_after(self.delay);
+    }
+
+    fn size(&self) -> Option<TuiSize> {
+        self.size
     }
 }
 
@@ -435,9 +531,11 @@ fn frame_surfaces_the_earliest_requested_repaint_deadline() {
             let column = ColumnDouble::new(vec![
                 Box::new(RepaintDouble {
                     delay: Duration::from_secs(60),
+                    size: None,
                 }),
                 Box::new(RepaintDouble {
                     delay: Duration::from_millis(10),
+                    size: None,
                 }),
             ]);
 

--- a/crates/warpui_core/src/runtime/mod.rs
+++ b/crates/warpui_core/src/runtime/mod.rs
@@ -36,7 +36,7 @@ use ratatui::crossterm::event::{
 use ratatui::crossterm::execute;
 use ratatui::crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 
-use crate::elements::tui::{TuiEvent, TuiEventContext, TuiLayoutContext, TuiRect, TuiSize};
+use crate::elements::tui::{TuiEvent, TuiEventContext, TuiRect, TuiSize};
 use crate::presenter::tui::TuiPresenter;
 use crate::r#async::executor::ForegroundTask;
 use crate::r#async::{block_on, Timer};
@@ -146,18 +146,16 @@ impl<T: TuiView, R: TuiTerminal> TuiScreen<T, R> {
 
         // Element-tree pass: walk the last rendered+laid-out element tree.
         // Access the two presenter fields directly so Rust sees disjoint borrows.
-        let Some(element) = self.presenter.last_element.as_mut() else {
+        let (Some(element), Some(scene)) = (
+            self.presenter.last_element.as_mut(),
+            self.presenter.last_scene.clone(),
+        ) else {
             return false; // no draw has happened yet
         };
-        let size = self.terminal.size().unwrap_or_default();
-        let area = TuiRect::new(0, 0, size.width, size.height);
         let root_view_id = self.root_view.id();
-        let mut event_ctx = TuiEventContext::default();
+        let mut event_ctx = TuiEventContext::new(scene, &mut self.presenter.rendered_views);
         event_ctx.set_origin_view(Some(root_view_id));
-        let mut layout_ctx = TuiLayoutContext {
-            rendered_views: &mut self.presenter.rendered_views,
-        };
-        let handled = element.dispatch_event(event, area, &mut event_ctx, &mut layout_ctx, ctx);
+        let handled = element.dispatch_event(event, &mut event_ctx, ctx);
 
         let notified = event_ctx.take_notified();
         for view_id in notified {

--- a/crates/warpui_core/src/runtime/mod_tests.rs
+++ b/crates/warpui_core/src/runtime/mod_tests.rs
@@ -8,8 +8,8 @@ use ratatui::crossterm::event::{Event as CrosstermEvent, KeyCode, KeyEvent, KeyM
 
 use super::*;
 use crate::elements::tui::{
-    TuiBuffer, TuiChildView, TuiConstraint, TuiElement, TuiEventHandler, TuiLayoutContext,
-    TuiPaintContext, TuiStyle, TuiText,
+    TuiChildView, TuiConstraint, TuiElement, TuiEventHandler, TuiLayoutContext, TuiPaintContext,
+    TuiPaintSurface, TuiScreenPoint, TuiScreenPosition, TuiText,
 };
 use crate::keymap::macros::*;
 use crate::keymap::FixedBinding;
@@ -19,6 +19,8 @@ use crate::{AddWindowOptions, AppContext, Entity, TypedActionView, ViewContext};
 /// A trivial leaf element that paints a single line of text.
 struct TextElement {
     text: String,
+    size: Option<TuiSize>,
+    origin: Option<TuiScreenPoint>,
 }
 
 impl TuiElement for TextElement {
@@ -29,17 +31,34 @@ impl TuiElement for TextElement {
         _app: &AppContext,
     ) -> TuiSize {
         let width = u16::try_from(self.text.chars().count()).unwrap_or(u16::MAX);
-        constraint.clamp(TuiSize::new(width, 1))
+        let size = constraint.clamp(TuiSize::new(width, 1));
+        self.size = Some(size);
+        size
     }
 
-    fn render(&self, area: TuiRect, buffer: &mut TuiBuffer, _ctx: &mut TuiPaintContext) {
-        buffer.set_stringn(
-            area.x,
-            area.y,
-            &self.text,
-            usize::from(area.width),
-            TuiStyle::default(),
-        );
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    ) {
+        self.origin = Some(ctx.scene_point(origin));
+        let size = self.size.unwrap();
+        for (column, character) in self.text.chars().take(usize::from(size.width)).enumerate() {
+            if let Some(cell) =
+                surface.cell_mut(origin.offset(i32::try_from(column).unwrap_or(i32::MAX), 0))
+            {
+                cell.set_char(character);
+            }
+        }
+    }
+
+    fn size(&self) -> Option<TuiSize> {
+        self.size
+    }
+
+    fn origin(&self) -> Option<TuiScreenPoint> {
+        self.origin
     }
 }
 
@@ -58,6 +77,8 @@ impl TuiView for TextView {
     fn render(&self, _: &AppContext) -> Box<dyn TuiElement> {
         Box::new(TextElement {
             text: "hello".to_owned(),
+            size: None,
+            origin: None,
         })
     }
 }

--- a/specs/tui-hoverable-hit-area/TECH.md
+++ b/specs/tui-hoverable-hit-area/TECH.md
@@ -1,0 +1,329 @@
+# TUI retained geometry and hit scene — Tech Spec
+
+Branch: `harry/fix-hoverable-hit-box`.
+
+Base: [`origin/master` at `d459702`](https://github.com/warpdotdev/warp/tree/d45970299fb02c8c9295ca766d4cd86530066458).
+
+Research snapshot: [`eba8ef7`](https://github.com/warpdotdev/warp/tree/eba8ef71648f49028052e7a8dfc7803900ee4b82).
+
+## Context
+
+TUI event dispatch currently passes an `area` from the root through every parent to every child. Layout has already measured the tree, so dispatch does not repeat measurement; it repeats the arrangement walk using cached child sizes. `TuiFlex`, for example, caches `child_sizes` during layout and reconstructs child rectangles during render, cursor lookup, and dispatch ([`flex.rs:253-424 @ eba8ef7`](https://github.com/warpdotdev/warp/blob/eba8ef71648f49028052e7a8dfc7803900ee4b82/crates/warpui_core/src/elements/tui/flex.rs#L253-L424)). `TuiViewportedList` similarly reconstructs each visible item slot for all three operations ([`viewported_list.rs:338-401 @ eba8ef7`](https://github.com/warpdotdev/warp/blob/eba8ef71648f49028052e7a8dfc7803900ee4b82/crates/warpui_core/src/elements/tui/viewported_list.rs#L338-L401)).
+
+The reported bug exposes the weakness of making the dispatched area the element's geometry. A start-aligned flex child is measured to its content width but is rendered and dispatched with the full cross-axis slot ([`flex.rs:213-243 @ eba8ef7`](https://github.com/warpdotdev/warp/blob/eba8ef71648f49028052e7a8dfc7803900ee4b82/crates/warpui_core/src/elements/tui/flex.rs#L213-L243)). Consequently, the collapsible thinking header's `TuiHoverable` treats blank columns after the text and chevron as part of its target. The branch currently compensates by caching the hoverable child's last measured size and intersecting it with the parent-provided area ([`hoverable.rs:44-178 @ eba8ef7`](https://github.com/warpdotdev/warp/blob/eba8ef71648f49028052e7a8dfc7803900ee4b82/crates/warpui_core/src/elements/tui/hoverable.rs#L44-L178)). That fixes this element but leaves retained geometry as a `TuiHoverable` special case and still requires parents to reconstruct and forward correct placement.
+
+The GUI framework already has the desired contract:
+
+- `Element::layout` establishes size, mutable `paint` establishes origin, and `size`/`origin` expose retained geometry.
+- `Element::dispatch_event` receives no geometry; events are structurally broadcast and each interactive element decides whether the event applies.
+- `Scene::visible_rect` applies active clipping, while `Scene::is_covered` checks hit records on higher normal or overlay layers.
+- Paint primitives and explicit surfaces record hit regions; structural wrappers do not become opaque merely because they participate in layout.
+
+See [`elements/gui/mod.rs:106-179 @ eba8ef7`](https://github.com/warpdotdev/warp/blob/eba8ef71648f49028052e7a8dfc7803900ee4b82/crates/warpui_core/src/elements/gui/mod.rs#L106-L179), [`elements/gui/hoverable.rs:405-431 @ eba8ef7`](https://github.com/warpdotdev/warp/blob/eba8ef71648f49028052e7a8dfc7803900ee4b82/crates/warpui_core/src/elements/gui/hoverable.rs#L405-L431), and [`scene.rs:416-505 @ eba8ef7`](https://github.com/warpdotdev/warp/blob/eba8ef71648f49028052e7a8dfc7803900ee4b82/crates/warpui_core/src/scene.rs#L416-L505).
+
+The TUI implementation will adopt that model. Elements use signed absolute terminal-space coordinates for placement, retained geometry, and child composition. Ratatui's unsigned buffer-local coordinates are a private paint-backend detail: `TuiPaintSurface` maps absolute positions into whichever buffer it owns. `TuiClipped` renders a complete child into a temporary ratatui buffer rooted at `(0, 0)` and copies only the visible rows into the destination buffer ([`clipped.rs:61-139 @ eba8ef7`](https://github.com/warpdotdev/warp/blob/eba8ef71648f49028052e7a8dfc7803900ee4b82/crates/warpui_core/src/elements/tui/clipped.rs#L61-L139)); its scratch surface privately maps the child's unchanged absolute origin to that local buffer origin.
+
+## End-to-end flow
+
+```mermaid
+flowchart LR
+    Layout["Layout<br/>cache element sizes"] --> Paint["Mutable paint<br/>cache screen origins"]
+    Paint --> Scene["Build TUI scene<br/>clips, layers, hit regions"]
+    Paint --> Buffer["Build ratatui buffer<br/>including scratch buffers"]
+    Scene --> Commit["Commit element tree + scene"]
+    Buffer --> Frame["Flush visible frame"]
+    Commit --> Dispatch["Geometry-free dispatch<br/>against last painted scene"]
+```
+
+Pointer input always targets the last completely painted element tree and scene—the geometry represented by the visible frame. A terminal resize schedules a new draw; dispatch does not combine the new terminal size with measurements from the previous frame and does not synchronously lay out or paint.
+
+## Proposed changes
+
+### Retained TUI geometry
+
+Add signed, cell-based screen and scene geometry alongside ratatui's private unsigned buffer geometry:
+
+- `TuiScreenPosition`: signed absolute terminal-space `x`/`y`, used for element placement.
+- `TuiScreenPoint`: a `TuiScreenPosition` plus `TuiZIndex`, used for retained scene geometry.
+- `TuiScreenRect`: signed origin plus `TuiSize`, with intersection and point-containment helpers.
+- `TuiZIndex`: normal and overlay layer indices, matching GUI `ZIndex`.
+- `TuiClipBounds`: active layer, explicit bound, active-layer intersection, or unbounded, matching GUI `ClipBounds`.
+
+Pointer events remain unsigned terminal positions because crossterm only reports visible cells. Converting a pointer position to signed scene coordinates is lossless. Signed origins are required for logical content above or left of a viewport; clipping converts those logical bounds into visible terminal bounds.
+
+Update `TuiElement` in [`elements/tui/mod.rs:169-256 @ eba8ef7`](https://github.com/warpdotdev/warp/blob/eba8ef71648f49028052e7a8dfc7803900ee4b82/crates/warpui_core/src/elements/tui/mod.rs#L169-L256) to mirror GUI:
+
+```rust
+pub trait TuiElement {
+    fn layout(
+        &mut self,
+        constraint: TuiConstraint,
+        ctx: &mut TuiLayoutContext,
+        app: &AppContext,
+    ) -> TuiSize;
+
+    fn render(
+        &mut self,
+        origin: TuiScreenPosition,
+        surface: &mut TuiPaintSurface<'_>,
+        ctx: &mut TuiPaintContext,
+    );
+
+    fn size(&self) -> Option<TuiSize>;
+
+    fn origin(&self) -> Option<TuiScreenPoint>;
+
+    fn bounds(&self) -> Option<TuiScreenRect> {
+        TuiScreenRect::from_origin_and_size(self.origin()?, self.size()?)
+    }
+
+
+    fn present(&mut self, ctx: &mut TuiPresentationContext<'_>) {}
+
+    fn dispatch_event(
+        &mut self,
+        event: &TuiEvent,
+        ctx: &mut TuiEventContext,
+        app: &AppContext,
+    ) -> bool;
+}
+```
+
+The `origin` render parameter is always signed absolute terminal space. An element that retains geometry obtains its `TuiScreenPoint` by attaching the active scene z-index through `TuiPaintContext`; parents derive absolute child origins by adding their retained layout offsets. Elements never receive a raw ratatui buffer or buffer-local origin.
+
+Every concrete element must retain or delegate its measured size. Elements that own a visual or interaction boundary retain their screen origin during paint. Transparent wrappers may delegate `size` and `origin` when their geometry is exactly their child's, matching GUI wrapper behavior.
+
+Geometry is absent before the first successful layout and paint. Pointer hit-testing fails closed when `size`, `origin`, or the retained scene is unavailable; it never falls back to the root or parent area.
+
+The hardware terminal cursor is paint output, matching GUI editor cursors that are drawn into `Scene`. Cursor-owning leaves submit a `TuiScreenPoint` through `TuiPaintContext::set_terminal_cursor` during render; structural elements expose no cursor API and perform no cursor delegation. The paint context prefers submissions from higher layers and later submissions at the same layer. After paint, the presenter accepts the submitted cursor only when its point is inside that scene layer's clip and is not covered by a higher opaque layer, then converts the visible nonnegative coordinate to the frame's `(u16, u16)` cursor.
+
+The existing `present` pass remains between layout and paint. It is geometry-independent and continues to build child-view embeddings through `TuiPresentationContext`, which are reported to `AppContext` for focus ancestry and responder-chain propagation. It is not folded into mutable paint.
+
+### Paint context and paint surfaces
+
+Extend `TuiPaintContext` in [`elements/tui/mod.rs:105-167 @ eba8ef7`](https://github.com/warpdotdev/warp/blob/eba8ef71648f49028052e7a8dfc7803900ee4b82/crates/warpui_core/src/elements/tui/mod.rs#L105-L167) with:
+
+- a mutable `TuiScene`;
+- helpers that attach the active z-index to an absolute screen position;
+- scoped push/pop helpers for scene layers;
+- paint-time hardware cursor submission;
+- the existing child-view map and repaint deadline.
+
+Add `TuiPaintSurface`, which temporarily borrows one ratatui buffer and privately retains the mapping from an absolute screen origin to that buffer's unsigned local origin. Its public paint operations accept only absolute positions and sizes:
+
+- render a ratatui widget within absolute bounds;
+- apply a style to absolute bounds;
+- read or write a cell at an absolute position;
+- copy cells from a completed scratch buffer into absolute destination positions.
+
+The surface performs checked conversion at the write boundary. Positions not representable in the active buffer return no cell or skip the paint operation; they never saturate or clamp into a different valid cell. Whole-rectangle widget operations require their mapped bounds to fit the active buffer, while per-cell and style operations intersect with the buffer's addressable area.
+
+At the root, absolute terminal `(0, 0)` maps to buffer `(0, 0)`. Normal containers pass absolute child origins. Elements performing only structural composition never convert coordinates.
+
+`TuiClipped` keeps its current scratch-buffer rendering strategy:
+
+1. Cache the viewport's absolute screen origin and start a scene layer clipped to its visible bounds.
+2. Allocate the full logical child scratch buffer at local `(0, 0)`.
+3. Derive the child's absolute logical origin by offsetting the viewport origin upward by `viewport_origin_y`.
+4. Create a scratch `TuiPaintSurface` mapping that same absolute child origin to scratch `(0, 0)`, then pass the unchanged absolute origin to the child. Child origins and hit records therefore need no coordinate conversion and are clipped by the scene layer.
+5. Copy the visible scratch rows into the destination surface.
+6. Drop the scratch surface and pop the scene layer.
+
+Layer helpers must restore state through scoped guards or closure-based APIs, including early returns. A scratch surface's buffer borrow and mapping cannot outlive the scratch buffer.
+
+This separates two concerns:
+
+- element placement, retained geometry, and hit testing always use signed absolute terminal-space coordinates;
+- ratatui buffer coordinates remain unsigned, local to one render target, and private to `TuiPaintSurface`.
+
+Scene clipping does not proxy or intercept ratatui buffer writes. Outside `TuiClipped`, the layout invariant guarantees that each retained element size fits its parent constraint and destination surface. Every element paints the exact absolute rectangle formed from `origin + size()`. `TuiClipped` allocates a scratch buffer large enough for both the child's retained logical size and the visible viewport before painting it. Elements that perform manual cell writes use the surface's checked absolute cell API.
+
+### TUI hit scene
+
+Add a TUI-specific retained scene under `crates/warpui_core/src/elements/tui/`. It mirrors the GUI scene's input semantics without taking over terminal rendering:
+
+- ordered normal and overlay layers;
+- an active-layer stack;
+- a clip bound and click-through flag per layer;
+- clipped rectangular hit records;
+- `visible_rect(origin, size)`;
+- `is_covered(point)`;
+- `start_layer`, `start_overlay_layer`, `set_active_layer_click_through`, and `stop_layer`.
+
+Hit records are coarse layout/paint rectangles, not individual nonblank terminal cells. This keeps interaction stable across whitespace, animation, wide graphemes, and styling changes.
+
+Recording follows GUI paint semantics:
+
+- a `TuiContainer` records its complete bounds when it has a background or border; a padding-only container does not create occlusion;
+- other explicit surfaces such as panels, scrollbars, and overlay backdrops record their painted bounds;
+- structural wrappers such as flex, constrained boxes, child views, event handlers, and animation wrappers do not automatically record opaque regions;
+- text glyph writes do not independently make an entire layer opaque; an enclosing surface records coverage when the text belongs to an opaque panel;
+- intentional pass-through uses the layer click-through flag rather than omission by accident.
+
+The initial implementation may store hit rectangles in a vector because TUI scenes contain cell-scale element counts. The scene API must not expose that representation, allowing an R-tree matching GUI to replace it if profiling shows a need.
+
+### Paint-time origin and child placement
+
+Paint becomes the single top-down placement pass, matching GUI. Parents use cached child sizes to calculate absolute child origins once and call mutable child `render`. Cursor-owning leaves submit the terminal cursor during that pass, and event dispatch consumes retained child origins rather than reconstructing slots.
+
+For `TuiFlex`:
+
+- cache the flex's size during layout and absolute screen origin during paint;
+- place each child by adding its retained relative layout offset to the flex's absolute origin;
+- start-aligned children keep their measured cross-axis size;
+- stretched children fill because layout supplies a tight cross-axis constraint;
+- centered and end-aligned children receive the corresponding origin offset;
+- full-row visuals or targets must opt into tight/expanded layout instead of inheriting unused slot width.
+
+The content-sized rule fixes the reported bug structurally: the header text and chevron retain their measured width, `TuiHoverable::size` delegates to that child, and blank trailing columns are outside `Hoverable::bounds`.
+
+Other geometry-owning parents apply the same pattern:
+
+- `TuiContainer` caches its own bounds, paints its background and border through the absolute surface API, and paints its child at the absolute origin plus the retained padding/border offset.
+- `TuiViewportedList` paints each visible element at its viewport origin; clipping supplies visible bounds.
+- `TuiConstrainedBox` and other transparent wrappers delegate geometry when their bounds equal the child's.
+- `TuiAnimated` paints its current child mutably and delegates retained geometry.
+
+The branch's `TuiHoverable::laid_out`, `hit_area(area)`, and full-area fallback are removed. The shared slot helpers added to keep dispatch geometry synchronized may remain as paint-only placement helpers, but dispatch must not call them.
+
+Changing start-aligned children from full-slot paint rectangles to retained content bounds can shrink existing backgrounds, borders, dividers, or manually painted rows that implicitly relied on the oversized `area`. Before migration, inventory every `TuiContainer` under a start-aligned flex and every custom `TuiElement::render` that paints from the supplied area rather than its measured result. Each caller must either adopt tight/stretch layout to claim the full row intentionally or remain content-sized. Add visual regression tests for every migrated full-row surface.
+
+### Presenter, scene lifetime, and child views
+
+Extend `TuiPresenter` in [`presenter/tui.rs:73-226 @ eba8ef7`](https://github.com/warpdotdev/warp/blob/eba8ef71648f49028052e7a8dfc7803900ee4b82/crates/warpui_core/src/presenter/tui.rs#L73-L226) to retain the scene produced with `last_element`. Publish the newly painted element tree and scene together only after root layout and paint complete. Replace `last_element_mut` with a dispatch-state API, or borrow the presenter's disjoint element, scene, and child-view-map fields directly, so runtime dispatch cannot obtain an element tree without its paired scene.
+
+Dispatch uses that pair without querying the current terminal size. If no completed scene exists, pointer dispatch returns unhandled.
+
+`TuiChildView` gains retained `size` and `origin`, matching GUI `ChildView` ([`presenter.rs:806-868 @ eba8ef7`](https://github.com/warpdotdev/warp/blob/eba8ef71648f49028052e7a8dfc7803900ee4b82/crates/warpui_core/src/presenter.rs#L806-L868)). Layout caches the embedded view's size. Paint caches the host node's screen origin and paints the registered child through the active `TuiPaintContext`, so the child receives the same transform, clip, and scene. Dispatch still temporarily establishes the child view as the action origin before traversing its retained element subtree.
+
+An updated child view is rendered, laid out, and painted before the new tree/scene pair becomes dispatchable. Dispatch never combines a freshly replaced child element with geometry from its predecessor.
+
+### Geometry-free event context and dispatch
+
+Move dispatch-time access to `rendered_views` and the retained scene into `TuiEventContext`, paralleling GUI `EventContext`. Add:
+
+- `visible_rect(origin, size)`;
+- `is_covered(point)`;
+- conversion from a terminal event position to a signed element-local point by subtracting the element's retained screen origin;
+- a combined visible/uncovered hit-test helper for ordinary press, hover, and wheel eligibility;
+- child-view lookup/dispatch;
+- the existing notification, typed-action, and origin-view state.
+
+Nested scratch-buffer mappings do not need to be replayed during dispatch: their accumulated translation is already reflected in each element's retained screen origin. Ordinary pointer handling first uses the visible/uncovered hit-test helper, then converts the event position to local coordinates. Pointer-capture paths may use the unbounded signed local conversion after a gesture began inside the element.
+
+Remove `area` and the layout context from `TuiElement::dispatch_event`. The runtime path in [`runtime/mod.rs:109-174 @ eba8ef7`](https://github.com/warpdotdev/warp/blob/eba8ef71648f49028052e7a8dfc7803900ee4b82/crates/warpui_core/src/runtime/mod.rs#L109-L174) constructs the event context from the presenter's last element tree, retained scene, and child-view map.
+
+Dispatch follows GUI structural broadcast:
+
+- parents offer the event to every child and combine handled results;
+- each interactive element decides whether a pointer event applies using its bounds, visible scene rectangle, and higher-layer coverage;
+- wrappers dispatch to their child before running their own handler;
+- the scene supplies geometry and occlusion but does not retain callbacks, element identities, or a second copy of the element tree;
+- key events continue through the keymap/responder-chain pass before element-tree dispatch and do not require scene geometry.
+
+`TuiHoverable` mirrors GUI `Hoverable`:
+
+- `size` delegates to its child;
+- mutable paint caches its screen origin and the maximum child z-index;
+- hover and press/release containment use `visible_rect`;
+- higher scene layers suppress hover/click through `is_covered`;
+- mouse moves remain non-consuming so every hoverable can update transitions;
+- click callbacks remain child-first and preserve press/release pairing.
+
+`TuiScrollable` uses its retained visible bounds and scene coverage for wheel eligibility. `TuiClipped` no longer filters or translates events; its retained scene layer and transformed child origins already encode that result.
+
+`TuiEditorElement` migrates its area-dependent pointer logic explicitly:
+
+- mouse-down and wheel use retained visible/uncovered bounds;
+- click positions convert to signed local coordinates before gutter, row, and column calculations;
+- an active selection drag continues converting positions outside the bounds, preserving drag-to-scroll behavior;
+- mouse-up ends a captured drag even when released outside;
+- nested clipping affects initial eligibility but does not cancel an already captured drag.
+
+### Migration sequence
+
+The trait change must land atomically with all production implementations:
+
+1. Inventory full-slot visual dependencies and classify each as intentionally tight/stretch or content-sized.
+2. Add signed screen and scene geometry, `TuiScene`, and clip support to `TuiPaintContext`.
+3. Add `TuiPaintSurface` and change `TuiElement` render, geometry, presentation, and dispatch APIs; move terminal cursor output to `TuiPaintContext`.
+4. Migrate leaf elements to retain size and paint-time origin.
+5. Migrate transparent wrappers to delegate geometry and broadcast dispatch.
+6. Migrate geometry-owning parents: flex, container, constrained box, viewported list, scrollable, and clipped.
+7. Migrate `TuiChildView`, presenter scene retention, and runtime event-context construction.
+8. Replace the hoverable workaround and adapt the branch's regression tests to retained geometry.
+9. Migrate `warp_tui` implementations, including editor and terminal block elements.
+
+Do not retain an area-passing compatibility dispatch method. A partial migration would permit old and new geometry sources to disagree and would leave the framework contract ambiguous.
+
+## Testing and validation
+
+### Geometry and scene unit tests
+
+- Signed screen rectangles intersect correctly with visible terminal bounds.
+- Absolute screen positions map to root and scratch buffer coordinates through `TuiPaintSurface`.
+- Invalid or out-of-range absolute writes fail closed rather than clamping into another cell.
+- Scene layers intersect active clips correctly.
+- Normal and overlay z-order coverage matches GUI semantics.
+- Click-through layers do not cover lower targets.
+- Hit records are clipped before insertion.
+- Missing geometry and a missing scene fail closed for pointer input.
+
+### Element tests
+
+- `TuiFlex` retains content-sized bounds for start alignment and full cross-axis bounds for stretch.
+- Center/end alignment changes retained origins without changing measured size.
+- `TuiContainer` includes its border/padding in its own bounds and places the child at the retained inner origin.
+- `TuiClipped` passes one absolute child origin through retained geometry while its scratch surface maps that origin to local `(0, 0)`, and exposes only the viewport intersection.
+- Nested clipped/viewported elements preserve transforms and clips.
+- `TuiChildView` retains host and child geometry while preserving action attribution.
+- Paint-submitted cursor placement uses retained origins and excludes clipped or covered cursors.
+- Existing full-row backgrounds, borders, and dividers preserve their intended visual width through explicit tight/stretch layout.
+
+### Interaction tests
+
+- The collapsible header reacts within the text and chevron but not in trailing row space.
+- Hover transitions clear correctly because mouse movement reaches every hoverable.
+- Press inside/release outside cancels; press and release inside invokes once.
+- An opaque higher normal layer and an overlay layer suppress lower hover/click handlers.
+- A click-through overlay allows lower handlers.
+- A hoverable directly inside a clipped child is hittable at its visible screen position after scrolling.
+- Scroll wheel handling requires visible, uncovered scrollable bounds.
+- Editor clicks resolve through screen-to-local coordinates under nested clipping.
+- Editor drag selection continues outside visible bounds only after a press began inside.
+- Pointer input before the first completed paint is unhandled.
+- A resize before repaint continues to target the last painted scene; the next frame replaces it atomically.
+
+### Commands
+
+- `cargo nextest run -p warpui_core --features tui`
+- `cargo nextest run -p warp_tui`
+- `cargo check -p warpui_core --features tui`
+- `cargo check -p warp_tui`
+- `./script/format`
+- Run the clippy command selected by `./script/presubmit` for the affected workspace targets.
+
+## Risks and mitigations
+
+- **Surface/screen mapping drift:** construct each `TuiPaintSurface` with an explicit absolute-to-buffer anchor, keep conversion private, and use checked non-saturating conversion. Cover nested clipping, negative logical origins, and nonzero root origins in tests.
+- **Screen/local input drift:** centralize inverse coordinate conversion on `TuiEventContext`; test editor clicks and captured drags under nested clipping.
+- **Unbalanced scene layers:** use scoped helpers and assert root paint restores the layer stack.
+- **Stale element/scene pairs:** publish them together after paint; dispatch never reads current terminal dimensions or newly rendered-but-unpainted child trees.
+- **Unexpected event fan-out:** mirror GUI child-before-parent behavior and add overlap tests for handlers that return `true`.
+- **Over-recorded occlusion:** only paint primitives and explicit surfaces add hit records; structural layout elements remain transparent.
+- **Silent visual shrinkage:** inventory elements that paint an assigned slot wider than their measured size and migrate intentional full-row surfaces to tight/stretch layout.
+- **Migration breadth:** remove the compatibility path and require the full TUI workspace to compile before behavioral validation.
+- **Scene lookup cost:** begin with simple clipped rectangles behind a representation-independent API; profile before adopting a spatial index.
+
+## Parallelization
+
+The core implementation should have one owner because the `TuiElement` trait, paint context, presenter, and all element implementations must change atomically to keep the workspace compiling. Parallel modification would create high-conflict branches around the trait and shared test support.
+
+After the core migration compiles, independent read-only validation can run in parallel:
+
+- geometry/scene and clipping audit;
+- event propagation and hover/click audit;
+- child-view/runtime lifetime audit;
+- full test, formatting, and clippy validation.
+
+Any fixes from those audits should be integrated by the core owner into this branch so the result remains one PR.


### PR DESCRIPTION
## Description

Before this PR, TUI event dispatch carried a reconstructed `TuiRect` from the root through every parent to every child. Layout had already measured the tree, but flexes, containers, clipped viewports, child views, cursor lookup, and event dispatch each replayed placement from cached sizes. That made parent-assigned slots indistinguishable from an element's actual footprint: a start-aligned flex child could paint content only a few cells wide while a `TuiHoverable` received the entire remaining row as its hit area. This PR makes geometry retained output of layout and paint instead. Every concrete element now retains or delegates its measured size, mutable paint records its signed terminal-space origin, and pointer input targets the last fully painted element tree and scene. Start-aligned children keep content-sized bounds, stretched children still intentionally fill their cross axis, terminal cursor placement is submitted during paint, and hover, click, wheel, editor selection, and selectable transcript input all use visible, uncovered retained bounds.

The implementation is split at the layer that owns each part of the geometry lifecycle. `TuiElement` now paints from a buffer-local origin, exposes retained `size`/`origin`/`bounds`, and dispatches without an area or layout context. `TuiPaintContext` maps unsigned ratatui buffer coordinates into signed screen coordinates, including scratch buffers, and builds a lightweight `TuiScene` containing clip layers, opaque hit rectangles, overlay ordering, click-through state, and paint-time cursor submissions. Geometry-owning parents place children once during mutable paint; transparent wrappers delegate retained geometry; structural parents broadcast events so each interactive element decides applicability from the scene. `TuiClipped` keeps its scratch-buffer renderer but records a clipped scene layer and a signed child transform, so clipped descendants no longer need dispatch-time coordinate translation. `TuiPresenter` publishes the painted element tree and scene together, and `TuiEventContext` carries that scene plus the rendered child-view map. `TuiEditorElement` converts screen positions to signed local cells while preserving captured drag selection outside its bounds. There is no area-passing compatibility path and the scene stores geometry only, not callbacks or a second element tree.

The most important files to look at are:
- `crates/warpui_core/src/elements/tui/mod.rs` and `scene.rs` — the new `TuiElement` lifecycle, buffer-to-screen transforms, retained geometry types, clip/layer model, hit records, and terminal cursor submission.
- `crates/warpui_core/src/presenter/tui.rs`, `runtime/mod.rs`, and `elements/tui/event.rs` — atomic element-tree/scene publication and geometry-free runtime dispatch against the last painted frame.
- `crates/warpui_core/src/elements/tui/flex.rs` — the behavioral layout change: start/center/end children paint at measured cross-axis size, stretch remains full-slot, and dispatch becomes structural broadcast.
- `crates/warpui_core/src/elements/tui/hoverable.rs` — content-sized hover/click bounds, child-layer z-index capture, clipping, occlusion, and press/release behavior.
- `crates/warpui_core/src/elements/tui/clipped.rs`, `viewported_list.rs`, and `container.rs` — signed scratch-buffer transforms, viewport item placement, retained parent geometry, and explicit surface occlusion.

Most other touched files do not need close review.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

https://www.loom.com/share/642947edda3c4da8a90a565877752bdb

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode