### PR TITLE
fix synthetic mouse build scene pass

### DIFF
--- a/crates/warpui_core/src/elements/gui/hoverable.rs
+++ b/crates/warpui_core/src/elements/gui/hoverable.rs
@@ -86,7 +86,8 @@ pub struct MouseState {
     /// events that both want to alter the hover state, we stop the
     /// invocation to prevent the potential infinite loop. Note that
     /// any non-synthetic event should reset this state to false.
-    last_event_is_synthetic_hover: bool,
+    /// Shared with the TUI `TuiHoverable`, which applies the same guard.
+    pub(crate) last_event_is_synthetic_hover: bool,
 
     /// A timer that starts when the mouse begins hovering the element.
     ///

--- a/crates/warpui_core/src/elements/tui/hoverable.rs
+++ b/crates/warpui_core/src/elements/tui/hoverable.rs
@@ -158,6 +158,7 @@ impl TuiElement for TuiHoverable {
                 if *is_synthetic && was_synthetic {
                     return false;
                 }
+
                 state.is_hovered = is_hovered;
                 drop(state);
                 event_ctx.notify();

--- a/crates/warpui_core/src/elements/tui/hoverable.rs
+++ b/crates/warpui_core/src/elements/tui/hoverable.rs
@@ -29,6 +29,7 @@
 //! handler only when released inside the footprint. (Hover delays and the
 //! other [`MouseState`] fields are unused.)
 
+use std::mem;
 use std::sync::MutexGuard;
 
 use super::{
@@ -139,10 +140,24 @@ impl TuiElement for TuiHoverable {
     ) -> bool {
         let child_handled = self.child.dispatch_event(event, event_ctx, app);
 
-        if let TuiEvent::MouseMoved { position, .. } = event {
+        if let TuiEvent::MouseMoved {
+            position,
+            is_synthetic,
+            ..
+        } = event
+        {
             let is_hovered = self.is_mouse_over_element(*position, event_ctx);
             let mut state = self.state();
             if is_hovered != state.is_hovered() {
+                // Guard against layout<->hover feedback loops (mirrors the GUI
+                // Hoverable): a synthetic move replayed after a redraw may flip
+                // hover, which relayouts and replays another synthetic move; two
+                // consecutive synthetic flips are suppressed to break the cycle.
+                let was_synthetic =
+                    mem::replace(&mut state.last_event_is_synthetic_hover, *is_synthetic);
+                if *is_synthetic && was_synthetic {
+                    return false;
+                }
                 state.is_hovered = is_hovered;
                 drop(state);
                 event_ctx.notify();
@@ -151,6 +166,8 @@ impl TuiElement for TuiHoverable {
             // their own transitions from the same event.
             return false;
         }
+        // Any non-move event re-arms the synthetic-flip guard, mirroring the GUI.
+        self.state().last_event_is_synthetic_hover = false;
 
         if child_handled {
             return true;

--- a/crates/warpui_core/src/elements/tui/hoverable_tests.rs
+++ b/crates/warpui_core/src/elements/tui/hoverable_tests.rs
@@ -214,6 +214,46 @@ impl TuiElement for AlwaysHandles {
 }
 
 #[test]
+fn consecutive_synthetic_hover_flips_are_suppressed() {
+    App::test((), |app| async move {
+        app.read(|app_ctx| {
+            let handle = MouseStateHandle::default();
+            let hoverable = TuiHoverable::new(handle.clone(), TuiText::new("hello").finish());
+            let mut presenter = TuiPresenter::new();
+            presenter.present_element(
+                hoverable.finish(),
+                crate::elements::tui::TuiRect::new(0, 0, 10, 1),
+                app_ctx,
+            );
+            let mut move_to = |x, y, is_synthetic| {
+                dispatch_presented_event(
+                    &mut presenter,
+                    &TuiEvent::MouseMoved {
+                        position: TuiPoint::new(x, y),
+                        modifiers: ModifiersState::default(),
+                        is_synthetic,
+                    },
+                    app_ctx,
+                )
+            };
+
+            // A synthetic flip in is allowed: the previous flip was not synthetic.
+            move_to(2, 0, true);
+            assert!(handle.lock().unwrap().is_hovered());
+
+            // A second consecutive synthetic flip (out) is suppressed to break
+            // potential layout<->hover feedback loops.
+            move_to(9, 0, true);
+            assert!(handle.lock().unwrap().is_hovered());
+
+            // A real move out flips immediately.
+            move_to(9, 0, false);
+            assert!(!handle.lock().unwrap().is_hovered());
+        });
+    });
+}
+
+#[test]
 fn child_consumes_the_event_before_the_click_handler() {
     App::test((), |app| async move {
         app.read(|app_ctx| {

--- a/crates/warpui_core/src/elements/tui/hoverable_tests.rs
+++ b/crates/warpui_core/src/elements/tui/hoverable_tests.rs
@@ -28,11 +28,11 @@ fn left_mouse_up(x: u16, y: u16) -> TuiEvent {
     }
 }
 
-fn mouse_moved(x: u16, y: u16) -> TuiEvent {
+fn mouse_moved(x: u16, y: u16, is_synthetic: bool) -> TuiEvent {
     TuiEvent::MouseMoved {
         position: TuiPoint::new(x, y),
         modifiers: ModifiersState::default(),
-        is_synthetic: false,
+        is_synthetic,
     }
 }
 
@@ -64,19 +64,19 @@ fn mouse_moves_toggle_hover_state_and_notify_without_consuming_the_event() {
             );
 
             assert_eq!(
-                dispatch_presented_event(&mut presenter, &mouse_moved(2, 0), app_ctx),
+                dispatch_presented_event(&mut presenter, &mouse_moved(2, 0, false), app_ctx),
                 (false, 1)
             );
             assert!(handle.lock().unwrap().is_hovered());
 
             assert_eq!(
-                dispatch_presented_event(&mut presenter, &mouse_moved(4, 0), app_ctx),
+                dispatch_presented_event(&mut presenter, &mouse_moved(4, 0, false), app_ctx),
                 (false, 0)
             );
             assert!(handle.lock().unwrap().is_hovered());
 
             assert_eq!(
-                dispatch_presented_event(&mut presenter, &mouse_moved(4, 3), app_ctx),
+                dispatch_presented_event(&mut presenter, &mouse_moved(4, 3, false), app_ctx),
                 (false, 1)
             );
             assert!(!handle.lock().unwrap().is_hovered());
@@ -155,13 +155,13 @@ fn hit_testing_is_bounded_to_the_child_laid_out_size() {
                 app_ctx,
             );
 
-            dispatch_presented_event(&mut presenter, &mouse_moved(2, 0), app_ctx);
+            dispatch_presented_event(&mut presenter, &mouse_moved(2, 0, false), app_ctx);
             assert!(handle.lock().unwrap().is_hovered());
             assert!(dispatch_presented_event(&mut presenter, &left_mouse_down(2, 0), app_ctx).0);
             assert!(dispatch_presented_event(&mut presenter, &left_mouse_up(2, 0), app_ctx).0);
             assert_eq!(hits.get(), 1);
 
-            dispatch_presented_event(&mut presenter, &mouse_moved(7, 0), app_ctx);
+            dispatch_presented_event(&mut presenter, &mouse_moved(7, 0, false), app_ctx);
             assert!(!handle.lock().unwrap().is_hovered());
             assert!(!dispatch_presented_event(&mut presenter, &left_mouse_down(7, 0), app_ctx).0);
             assert_eq!(hits.get(), 1);
@@ -225,29 +225,18 @@ fn consecutive_synthetic_hover_flips_are_suppressed() {
                 crate::elements::tui::TuiRect::new(0, 0, 10, 1),
                 app_ctx,
             );
-            let mut move_to = |x, y, is_synthetic| {
-                dispatch_presented_event(
-                    &mut presenter,
-                    &TuiEvent::MouseMoved {
-                        position: TuiPoint::new(x, y),
-                        modifiers: ModifiersState::default(),
-                        is_synthetic,
-                    },
-                    app_ctx,
-                )
-            };
 
             // A synthetic flip in is allowed: the previous flip was not synthetic.
-            move_to(2, 0, true);
+            dispatch_presented_event(&mut presenter, &mouse_moved(2, 0, true), app_ctx);
             assert!(handle.lock().unwrap().is_hovered());
 
             // A second consecutive synthetic flip (out) is suppressed to break
             // potential layout<->hover feedback loops.
-            move_to(9, 0, true);
+            dispatch_presented_event(&mut presenter, &mouse_moved(9, 0, true), app_ctx);
             assert!(handle.lock().unwrap().is_hovered());
 
             // A real move out flips immediately.
-            move_to(9, 0, false);
+            dispatch_presented_event(&mut presenter, &mouse_moved(9, 0, false), app_ctx);
             assert!(!handle.lock().unwrap().is_hovered());
         });
     });

--- a/crates/warpui_core/src/runtime/mod.rs
+++ b/crates/warpui_core/src/runtime/mod.rs
@@ -119,27 +119,24 @@ impl<T: TuiView, R: TuiTerminal> TuiScreen<T, R> {
         let size = self.terminal.size()?;
         let area = TuiRect::new(0, 0, size.width, size.height);
 
-        let invalidation = ctx.take_all_invalidations_for_window(self.window_id);
-        self.presenter
-            .invalidate(&invalidation, ctx, self.window_id);
-        let mut frame = self.presenter.present(ctx, &self.root_view, area);
-        self.replay_mouse_position(ctx);
-
         // Mirrors the GUI's `build_scene` loop: pointer replay can invalidate
         // hover-dependent layout, requiring another presentation and replay.
-        // Cap at three total presentations so a hover/layout feedback loop
-        // cannot hang the redraw.
-        for _ in 2..=3 {
+        // The first iteration always presents; later ones only run if the
+        // replay invalidated something. Cap at three total presentations so a
+        // hover/layout feedback loop cannot hang the redraw.
+        let mut frame = None;
+        for _ in 0..3 {
             let invalidation = ctx.take_all_invalidations_for_window(self.window_id);
-            if invalidation.updated.is_empty() && !invalidation.redraw_requested {
+            if frame.is_some() && invalidation.updated.is_empty() && !invalidation.redraw_requested
+            {
                 break;
             }
             self.presenter
                 .invalidate(&invalidation, ctx, self.window_id);
-            frame = self.presenter.present(ctx, &self.root_view, area);
-
+            frame = Some(self.presenter.present(ctx, &self.root_view, area));
             self.replay_mouse_position(ctx);
         }
+        let frame = frame.expect("loop always presents at least once");
 
         let mut writer = self.terminal.writer();
         self.renderer

--- a/crates/warpui_core/src/runtime/mod.rs
+++ b/crates/warpui_core/src/runtime/mod.rs
@@ -106,35 +106,41 @@ impl<T: TuiView, R: TuiTerminal> TuiScreen<T, R> {
     }
 
     /// Lays out and paints the root view through the presenter, then flushes the
-    /// frame to the terminal. Draining this window's invalidations keeps the
-    /// manual + autotracking sets from accumulating (the frame is repainted in
-    /// full regardless). After each paint, the last pointer position is replayed
-    /// as a synthetic `MouseMoved`; resulting invalidations rebuild the frame
-    /// within this call, capped at three iterations like the GUI.
+    /// final frame to the terminal. Draining this window's invalidations keeps
+    /// the manual + autotracking sets from accumulating (the frame is repainted
+    /// in full regardless). After each presentation, the last pointer position
+    /// is replayed as a synthetic `MouseMoved`; resulting invalidations rebuild
+    /// the frame within this call, capped at three iterations like the GUI. Only
+    /// the final reconciled frame is flushed, matching the GUI's presentation.
     ///
     /// Returns the final frame's earliest requested repaint deadline so the
     /// caller can schedule a timed redraw.
     fn draw(&mut self, ctx: &mut AppContext) -> io::Result<Option<Instant>> {
         let size = self.terminal.size()?;
         let area = TuiRect::new(0, 0, size.width, size.height);
-        let mut repaint_at = None;
-        for iteration in 1..=3 {
+
+        let invalidation = ctx.take_all_invalidations_for_window(self.window_id);
+        self.presenter
+            .invalidate(&invalidation, ctx, self.window_id);
+        let mut frame = self.presenter.present(ctx, &self.root_view, area);
+        self.replay_mouse_position(ctx);
+
+        for _ in 2..=3 {
             let invalidation = ctx.take_all_invalidations_for_window(self.window_id);
-            // Always paint at least once, even with nothing invalidated.
-            if iteration > 1 && invalidation.updated.is_empty() && !invalidation.redraw_requested {
+            if invalidation.updated.is_empty() && !invalidation.redraw_requested {
                 break;
             }
             self.presenter
                 .invalidate(&invalidation, ctx, self.window_id);
-            let frame = self.presenter.present(ctx, &self.root_view, area);
-            let mut writer = self.terminal.writer();
-            self.renderer
-                .draw(&mut writer, &frame.buffer, frame.cursor)?;
-            repaint_at = frame.repaint_at;
+            frame = self.presenter.present(ctx, &self.root_view, area);
 
             self.replay_mouse_position(ctx);
         }
-        Ok(repaint_at)
+
+        let mut writer = self.terminal.writer();
+        self.renderer
+            .draw(&mut writer, &frame.buffer, frame.cursor)?;
+        Ok(frame.repaint_at)
     }
 
     /// Redispatches the last known pointer position as a synthetic

--- a/crates/warpui_core/src/runtime/mod.rs
+++ b/crates/warpui_core/src/runtime/mod.rs
@@ -36,7 +36,8 @@ use ratatui::crossterm::event::{
 use ratatui::crossterm::execute;
 use ratatui::crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 
-use crate::elements::tui::{TuiEvent, TuiEventContext, TuiRect, TuiSize};
+use crate::elements::tui::{TuiEvent, TuiEventContext, TuiPoint, TuiRect, TuiSize};
+use crate::event::ModifiersState;
 use crate::presenter::tui::TuiPresenter;
 use crate::r#async::executor::ForegroundTask;
 use crate::r#async::{block_on, Timer};
@@ -81,6 +82,10 @@ struct TuiScreen<T, R: TuiTerminal> {
     /// Synthesizes multi-click counts for left mouse presses, which crossterm
     /// does not report.
     click_tracker: ClickTracker,
+    /// The pointer position from the most recent positional event, replayed as
+    /// a synthetic `MouseMoved` after each draw so hover state tracks elements
+    /// that move under a stationary pointer.
+    last_mouse_position: Option<TuiPoint>,
 }
 
 impl<T: TuiView, R: TuiTerminal> TuiScreen<T, R> {
@@ -92,6 +97,7 @@ impl<T: TuiView, R: TuiTerminal> TuiScreen<T, R> {
             renderer: TuiFrameRenderer::new(),
             terminal,
             click_tracker: ClickTracker::default(),
+            last_mouse_position: None,
         }
     }
 
@@ -102,20 +108,51 @@ impl<T: TuiView, R: TuiTerminal> TuiScreen<T, R> {
     /// Lays out and paints the root view through the presenter, then flushes the
     /// frame to the terminal. Draining this window's invalidations keeps the
     /// manual + autotracking sets from accumulating (the frame is repainted in
-    /// full regardless). Returns the earliest repaint deadline requested by an
-    /// animated element during paint, if any, so the caller can schedule a
-    /// timed redraw.
+    /// full regardless). After each paint, the last pointer position is replayed
+    /// as a synthetic `MouseMoved`; resulting invalidations rebuild the frame
+    /// within this call, capped at three iterations like the GUI.
+    ///
+    /// Returns the final frame's earliest requested repaint deadline so the
+    /// caller can schedule a timed redraw.
     fn draw(&mut self, ctx: &mut AppContext) -> io::Result<Option<Instant>> {
         let size = self.terminal.size()?;
         let area = TuiRect::new(0, 0, size.width, size.height);
-        let invalidation = ctx.take_all_invalidations_for_window(self.window_id);
-        self.presenter
-            .invalidate(&invalidation, ctx, self.window_id);
-        let frame = self.presenter.present(ctx, &self.root_view, area);
-        let mut writer = self.terminal.writer();
-        self.renderer
-            .draw(&mut writer, &frame.buffer, frame.cursor)?;
-        Ok(frame.repaint_at)
+        let mut repaint_at = None;
+        for iteration in 1..=3 {
+            let invalidation = ctx.take_all_invalidations_for_window(self.window_id);
+            // Always paint at least once, even with nothing invalidated.
+            if iteration > 1 && invalidation.updated.is_empty() && !invalidation.redraw_requested {
+                break;
+            }
+            self.presenter
+                .invalidate(&invalidation, ctx, self.window_id);
+            let frame = self.presenter.present(ctx, &self.root_view, area);
+            let mut writer = self.terminal.writer();
+            self.renderer
+                .draw(&mut writer, &frame.buffer, frame.cursor)?;
+            repaint_at = frame.repaint_at;
+
+            self.replay_mouse_position(ctx);
+        }
+        Ok(repaint_at)
+    }
+
+    /// Redispatches the last known pointer position as a synthetic
+    /// `MouseMoved` through the freshly rendered tree, so hover state tracks
+    /// elements that moved under a stationary pointer (e.g. a collapsible
+    /// expanding and pushing its header out from under the mouse). A state
+    /// change invalidates the notified views, which `draw`'s loop picks up to
+    /// rebuild the frame within the same call.
+    fn replay_mouse_position(&mut self, ctx: &mut AppContext) {
+        let Some(position) = self.last_mouse_position else {
+            return;
+        };
+        let event = TuiEvent::MouseMoved {
+            position,
+            modifiers: ModifiersState::default(),
+            is_synthetic: true,
+        };
+        self.dispatch_event(ctx, &event);
     }
 
     /// Converts a raw crossterm event into the TUI vocabulary, annotating left
@@ -132,6 +169,10 @@ impl<T: TuiView, R: TuiTerminal> TuiScreen<T, R> {
     /// presenter (the same tree that was painted), with a `TuiLayoutContext` so
     /// `TuiChildView` can resolve its child from `rendered_views`.
     fn dispatch_event(&mut self, ctx: &mut AppContext, event: &TuiEvent) -> bool {
+        if let Some(position) = event.position() {
+            self.last_mouse_position = Some(position);
+        }
+
         // Keymap pass (GUI parity): offer a keystroke to the focused view's
         // responder chain first, exactly like the GUI window event path.
         if let Some((keystroke, is_composing)) = event.key_down() {

--- a/crates/warpui_core/src/runtime/mod.rs
+++ b/crates/warpui_core/src/runtime/mod.rs
@@ -125,6 +125,10 @@ impl<T: TuiView, R: TuiTerminal> TuiScreen<T, R> {
         let mut frame = self.presenter.present(ctx, &self.root_view, area);
         self.replay_mouse_position(ctx);
 
+        // Mirrors the GUI's `build_scene` loop: pointer replay can invalidate
+        // hover-dependent layout, requiring another presentation and replay.
+        // Cap at three total presentations so a hover/layout feedback loop
+        // cannot hang the redraw.
         for _ in 2..=3 {
             let invalidation = ctx.take_all_invalidations_for_window(self.window_id);
             if invalidation.updated.is_empty() && !invalidation.redraw_requested {

--- a/crates/warpui_core/src/runtime/mod_tests.rs
+++ b/crates/warpui_core/src/runtime/mod_tests.rs
@@ -4,14 +4,13 @@ use std::io::{self, Write};
 use std::rc::Rc;
 use std::time::Duration;
 
-use ratatui::crossterm::event::{
-    Event as CrosstermEvent, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind,
-};
+use ratatui::crossterm::event::{Event as CrosstermEvent, KeyCode, KeyEvent, KeyModifiers};
 
 use super::*;
 use crate::elements::tui::{
     TuiChildView, TuiConstraint, TuiElement, TuiEventHandler, TuiFlex, TuiHoverable,
-    TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiScreenPoint, TuiScreenPosition, TuiText,
+    TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiPoint, TuiScreenPoint,
+    TuiScreenPosition, TuiText,
 };
 use crate::elements::MouseStateHandle;
 use crate::keymap::macros::*;
@@ -387,42 +386,38 @@ fn synthetic_mouse_move_after_redraw_updates_hover() {
                 shifted: false,
             })
         });
+        let terminal = TestTerminal::new(TuiSize::new(20, 5));
+        let mut screen = TuiScreen::new(window_id, root.clone(), terminal);
+        app.update(|ctx| screen.draw(ctx)).unwrap();
 
-        let mut terminal = TestTerminal::new(TuiSize::new(20, 5));
-        // A real move over the target at row 0, then the `s` key, which shifts
-        // the target to row 1 while the pointer stays put.
-        terminal.events.push_back(CrosstermEvent::Mouse(MouseEvent {
-            kind: MouseEventKind::Moved,
-            column: 2,
-            row: 0,
-            modifiers: KeyModifiers::empty(),
-        }));
-        terminal.events.push_back(CrosstermEvent::Key(KeyEvent::new(
-            KeyCode::Char('s'),
-            KeyModifiers::empty(),
-        )));
-        let mut runtime = TuiRuntime::with_terminal(&app, window_id, root, terminal);
+        let mouse_moved = TuiEvent::MouseMoved {
+            position: TuiPoint::new(2, 0),
+            modifiers: ModifiersState::default(),
+            is_synthetic: false,
+        };
+        app.update(|ctx| screen.dispatch_event(ctx, &mouse_moved));
+        assert!(hover.lock().unwrap().is_hovered());
 
-        let hover_by_iteration = Rc::new(RefCell::new(Vec::new()));
-        let recorder = hover_by_iteration.clone();
-        let hover_for_loop = hover.clone();
-        runtime
-            .run_until(&mut app, move |_| {
-                let mut states = recorder.borrow_mut();
-                states.push(hover_for_loop.lock().unwrap().is_hovered());
-                states.len() > 4
-            })
-            .unwrap();
+        root.update(&mut app, |view, ctx| {
+            view.shifted = true;
+            ctx.notify();
+        });
+        screen.terminal.output.clear();
 
-        let states = hover_by_iteration.borrow();
+        app.update(|ctx| screen.draw(ctx)).unwrap();
+
         assert!(
-            states.contains(&true),
-            "the real mouse move should hover the target: {states:?}"
+            !hover.lock().unwrap().is_hovered(),
+            "the post-draw synthetic move should unhover the shifted target"
         );
         assert_eq!(
-            states.last(),
-            Some(&false),
-            "the post-draw synthetic move should unhover the shifted target: {states:?}"
+            screen
+                .terminal
+                .output_string()
+                .matches("\u{1b}[?2026h")
+                .count(),
+            1,
+            "multi-pass hover reconciliation should flush one terminal frame"
         );
     });
 }

--- a/crates/warpui_core/src/runtime/mod_tests.rs
+++ b/crates/warpui_core/src/runtime/mod_tests.rs
@@ -4,13 +4,16 @@ use std::io::{self, Write};
 use std::rc::Rc;
 use std::time::Duration;
 
-use ratatui::crossterm::event::{Event as CrosstermEvent, KeyCode, KeyEvent, KeyModifiers};
+use ratatui::crossterm::event::{
+    Event as CrosstermEvent, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind,
+};
 
 use super::*;
 use crate::elements::tui::{
-    TuiChildView, TuiConstraint, TuiElement, TuiEventHandler, TuiLayoutContext, TuiPaintContext,
-    TuiPaintSurface, TuiScreenPoint, TuiScreenPosition, TuiText,
+    TuiChildView, TuiConstraint, TuiElement, TuiEventHandler, TuiFlex, TuiHoverable,
+    TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiScreenPoint, TuiScreenPosition, TuiText,
 };
+use crate::elements::MouseStateHandle;
 use crate::keymap::macros::*;
 use crate::keymap::FixedBinding;
 use crate::platform::WindowStyle;
@@ -324,6 +327,103 @@ fn typed_action_from_embedded_child_reaches_parent_through_runtime_dispatch() {
         // to the parent's handler. (The legacy origin-only dispatch could not
         // do this.)
         assert_eq!(root.read(&app, |view, _| view.bumps), 1);
+    });
+}
+
+/// The typed action that shifts [`ShiftingHoverView`]'s hover target down a row.
+#[derive(Debug)]
+struct Shift;
+
+/// A root view whose hover target moves down one row after [`Shift`], used to
+/// verify the post-draw synthetic mouse move refreshes hover state.
+struct ShiftingHoverView {
+    hover: MouseStateHandle,
+    shifted: bool,
+}
+
+impl Entity for ShiftingHoverView {
+    type Event = ();
+}
+
+impl TuiView for ShiftingHoverView {
+    fn ui_name() -> &'static str {
+        "ShiftingHoverView"
+    }
+
+    fn render(&self, _: &AppContext) -> Box<dyn TuiElement> {
+        let mut column = TuiFlex::column();
+        if self.shifted {
+            column = column.child(TuiText::new("pad").finish());
+        }
+        let target = TuiHoverable::new(self.hover.clone(), TuiText::new("target").finish());
+        column = column.child(target.finish());
+        Box::new(
+            TuiEventHandler::new(column.finish())
+                .on_key("s", |_, ctx, _| ctx.dispatch_typed_action(Shift)),
+        )
+    }
+}
+
+impl TypedActionView for ShiftingHoverView {
+    type Action = Shift;
+
+    fn handle_action(&mut self, _action: &Shift, ctx: &mut ViewContext<Self>) {
+        self.shifted = true;
+        ctx.notify();
+    }
+}
+
+/// After a redraw, the runtime replays the last pointer position as a
+/// synthetic move, so a hover target that shifts out from under a stationary
+/// mouse unhoveres without any real mouse movement.
+#[test]
+fn synthetic_mouse_move_after_redraw_updates_hover() {
+    App::test((), |mut app| async move {
+        let hover = MouseStateHandle::default();
+        let hover_for_view = hover.clone();
+        let (window_id, root) = app.update(move |ctx| {
+            ctx.add_tui_window(window_options(), move |_| ShiftingHoverView {
+                hover: hover_for_view,
+                shifted: false,
+            })
+        });
+
+        let mut terminal = TestTerminal::new(TuiSize::new(20, 5));
+        // A real move over the target at row 0, then the `s` key, which shifts
+        // the target to row 1 while the pointer stays put.
+        terminal.events.push_back(CrosstermEvent::Mouse(MouseEvent {
+            kind: MouseEventKind::Moved,
+            column: 2,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        }));
+        terminal.events.push_back(CrosstermEvent::Key(KeyEvent::new(
+            KeyCode::Char('s'),
+            KeyModifiers::empty(),
+        )));
+        let mut runtime = TuiRuntime::with_terminal(&app, window_id, root, terminal);
+
+        let hover_by_iteration = Rc::new(RefCell::new(Vec::new()));
+        let recorder = hover_by_iteration.clone();
+        let hover_for_loop = hover.clone();
+        runtime
+            .run_until(&mut app, move |_| {
+                let mut states = recorder.borrow_mut();
+                states.push(hover_for_loop.lock().unwrap().is_hovered());
+                states.len() > 4
+            })
+            .unwrap();
+
+        let states = hover_by_iteration.borrow();
+        assert!(
+            states.contains(&true),
+            "the real mouse move should hover the target: {states:?}"
+        );
+        assert_eq!(
+            states.last(),
+            Some(&false),
+            "the post-draw synthetic move should unhover the shifted target: {states:?}"
+        );
     });
 }
 

--- a/specs/tui-synthetic-mouse-replay/TECH.md
+++ b/specs/tui-synthetic-mouse-replay/TECH.md
@@ -1,0 +1,55 @@
+# TUI synthetic mouse replay — Tech Spec
+
+Branch: `harry/tui-synthetic-mouse-replay`, stacked on `harry/fix-hoverable-hit-box`
+(see [`specs/tui-hoverable-hit-area/TECH.md`](../tui-hoverable-hit-area/TECH.md)).
+
+## Context
+
+TUI hover state only updates when a real `MouseMoved` arrives. When layout shifts
+under a stationary pointer — e.g. clicking a collapsed thinking header expands the
+block and pushes the header out from under the mouse — the header keeps rendering
+as hovered until the mouse physically moves.
+
+The GUI solves this with synthetic mouse moves: it caches the last `MouseMoved`
+per window and, after every scene build, redispatches it with `is_synthetic: true`
+inside a loop capped at three iterations
+([`crates/warpui_core/src/core/app.rs (2894-2961) @ e77426f0`](https://github.com/warpdotdev/warp/blob/e77426f092c84df02a519f43821ac13aa51a7c97/crates/warpui_core/src/core/app.rs#L2894-L2961)).
+Its `Hoverable` additionally suppresses two consecutive synthetic hover flips via
+`MouseState::last_event_is_synthetic_hover`, breaking layout↔hover feedback loops.
+`TuiEvent::MouseMoved` already carries an `is_synthetic` flag, but nothing emitted
+synthetic moves in the TUI. This change ports the GUI mechanism.
+
+## Changes
+
+- `crates/warpui_core/src/runtime/mod.rs`:
+  - `TuiScreen` records `last_mouse_position` from every positional event in
+    `dispatch_event`.
+  - `TuiScreen::draw` now mirrors the GUI's `build_scene` loop: up to three
+    iterations of take-invalidations → layout/paint → `replay_mouse_position`
+    (a synthetic `MouseMoved` at the cached position through the freshly
+    rendered tree). A hover flip invalidates its view, so the frame is rebuilt
+    within the same call; the first iteration always paints, and the loop breaks
+    once the replay stops invalidating.
+- `crates/warpui_core/src/elements/tui/hoverable.rs`: on a hover transition,
+  `TuiHoverable` applies the GUI's guard — the flip is suppressed when both it
+  and the previous flip came from synthetic moves; any non-move event re-arms
+  the guard. Uses the shared `MouseState::last_event_is_synthetic_hover`
+  (visibility widened to `pub(crate)` in `gui/hoverable.rs`).
+
+Known divergence from the GUI: the replay dispatches with default modifiers,
+while the GUI's cached event preserves cmd/shift held at move time. Nothing in
+the TUI reads modifiers off `MouseMoved` today; cache them alongside the
+position if that changes.
+
+## Testing and validation
+
+- `crates/warpui_core/src/runtime/mod_tests.rs`:
+  `synthetic_mouse_move_after_redraw_updates_hover` — a real move hovers a
+  target, a keypress shifts it down a row, and the post-draw replay unhovers it
+  with no further mouse input.
+- `crates/warpui_core/src/elements/tui/hoverable_tests.rs`:
+  `consecutive_synthetic_hover_flips_are_suppressed` — a synthetic flip in is
+  allowed, an immediately following synthetic flip out is suppressed, and a real
+  move flips normally.
+- Run with `cargo nextest run -p warpui_core --features tui -E 'test(tui::hoverable) or test(runtime)'`
+  (the TUI module is gated behind the `tui` feature).


### PR DESCRIPTION
## Description

Fix stale TUI hover state when layout moves beneath a stationary pointer. After each presentation, replay the last pointer position and rebuild if hover changes invalidate the view, using the same three-pass safety cap and consecutive synthetic-flip guard as the GUI.

This fixes the issue where, if you clicked on a thinking head and it subsequently moved out from under your mouse (because the row expanded), the header would stay hovered.

## Testing

- [x] confirmed the fix by manually running ./script/run-tui
https://www.loom.com/share/86efb7d1a5a948bfb9e2f8fbcf740faf

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode