### PR TITLE
Fix Ctrl+C not refocusing prompt when a block is selected (#13480)

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -16527,6 +16527,14 @@ impl TerminalView {
 
         if !self.selected_blocks.is_empty() {
             self.copy_blocks(BlockEntity::CommandAndOutput, ctx);
+            // Copying a selected block via Ctrl+C returns the user to the
+            // prompt, matching Escape / FocusInputAndClearSelection: clear the
+            // block selection and refocus the input (#13480). `focus_input_box`
+            // keeps selected blocks when AI-input / AgentView is active, since
+            // there they are attachable context — so this doesn't regress that
+            // path. The context-menu "Copy" path goes through `copy_blocks`
+            // directly and is intentionally left as-is.
+            self.focus_input_box(ctx);
         }
     }
 

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -2875,6 +2875,63 @@ fn test_copy_on_select() {
     })
 }
 
+// #13480: copying a *block* selection (not a text selection) with Ctrl+C must
+// clear the selection and return focus to the prompt, matching the Escape /
+// FocusInputAndClearSelection gesture. Before the fix, `copy` wrote the
+// clipboard but left the block selected and focus off the input.
+#[test]
+fn test_copy_selected_block_refocuses_prompt() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+
+        // Build a finished command block, then select the whole block (a
+        // block-level selection, distinct from an in-block text selection) and
+        // move focus off the input onto the terminal grid.
+        terminal.update(&mut app, |view, ctx| {
+            {
+                let mut model = view.model.lock();
+                model.start_command_execution();
+                let blocks = model.block_list_mut();
+                blocks.input('f');
+                blocks.input('o');
+                blocks.input('o');
+                blocks.linefeed();
+                blocks.preexec(PreexecValue::default());
+                blocks.on_finish_byte_processing(&ansi::ProcessorInput::new(&[]));
+            }
+            view.selected_blocks.reset_to_single(BlockIndex::zero());
+            view.focus_terminal(ctx);
+        });
+
+        // Precondition: the block is selected and the prompt editor is not
+        // focused. `input.editor().is_focused` is how the view itself checks
+        // prompt focus (see `paste`).
+        terminal.read(&app, |view, ctx| {
+            assert_eq!(
+                view.selected_blocks.cardinality().as_keymap_context_value(),
+                BlockSelectionCardinality::One.as_keymap_context_value(),
+            );
+            assert!(!view.input.as_ref(ctx).editor().is_focused(ctx));
+        });
+
+        // Ctrl+C dispatches TerminalAction::Copy -> `copy`.
+        terminal.update(&mut app, |view, ctx| {
+            view.copy(ctx);
+        });
+
+        // After the copy the selection is cleared and the prompt is focused.
+        terminal.read(&app, |view, ctx| {
+            assert_eq!(
+                view.selected_blocks.cardinality().as_keymap_context_value(),
+                BlockSelectionCardinality::None.as_keymap_context_value(),
+            );
+            assert!(view.input.as_ref(ctx).editor().is_focused(ctx));
+        });
+    })
+}
+
 #[test]
 fn test_alt_screen_copy_on_select() {
     App::test((), |mut app| async move {


### PR DESCRIPTION
## Description

Fixes the reported regression: pressing **Ctrl+C while a block is selected** copies the block to the clipboard but leaves the block selected and the prompt unfocused. Expected (and pre-regression) behavior is that the block deselects and the prompt becomes active, matching **Escape**.

Root cause: the block branch of `TerminalView::copy` (`app/src/terminal/view.rs`) calls `copy_blocks(...)` but never clears the block selection or refocuses the input. The fix reuses `focus_input_box` — the same step `Escape` / `FocusInputAndClearSelection` already run — so Ctrl+C-after-copy performs the established "back to prompt" gesture. It deliberately:

- keeps selected blocks when AI-input / `FeatureFlag::AgentView` is active (there they are attachable AI context — `focus_input_box`'s existing behavior), so agent-mode selection is not regressed; and
- leaves the **context-menu "Copy"** path (which goes through `copy_blocks` directly) unchanged — only the Ctrl+C/`copy` entry point refocuses.

## Linked Issue

Fixes #13480

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below.

## Testing

Added `test_copy_selected_block_refocuses_prompt` in `app/src/terminal/view_tests.rs`. It builds a finished command block, applies a **block-level** selection (`selected_blocks.reset_to_single(...)`, distinct from an in-block text selection), moves focus off the input, then calls `copy` and asserts:

- `selected_blocks.cardinality()` is `None` (selection cleared), and
- `view.input.is_focused(ctx)` is `true` (prompt refocused).

Both assertions fail before the fix (the block stays selected, input stays unfocused) and pass after — a red→green regression guard. The setup mirrors the existing `test_insert` (block-level selection) and `test_copy_on_select` (block construction) cases; the prompt-focus check uses `input.editor().is_focused(ctx)`, the same signal the view itself reads in `paste`.

Verified locally with `cargo nextest run -p warp test_copy_selected_block_refocuses_prompt`: passes with the fix, and fails without it (reverting the `focus_input_box` line leaves the selection uncleared and the prompt unfocused).

- [ ] I have manually tested my changes locally with `./script/run` (screen recording below)

### Screenshots / Videos

_Pending — will attach a short before/after clip prior to marking ready._

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed Ctrl+C not deselecting the block and refocusing the prompt when a block was selected
