### PR TITLE
Fix TUI scroll position anchoring

### DIFF
--- a/crates/warpui_core/src/elements/tui/viewported_list.rs
+++ b/crates/warpui_core/src/elements/tui/viewported_list.rs
@@ -479,7 +479,8 @@ where
         }
 
         if matches!(self.state.position(), TuiViewportPosition::RowsFromTop(_))
-            && scroll_top > max_scroll_top
+            && scroll_top > 0
+            && scroll_top >= max_scroll_top
         {
             self.set_position(TuiViewportPosition::End);
         }

--- a/crates/warpui_core/src/elements/tui/viewported_list_tests.rs
+++ b/crates/warpui_core/src/elements/tui/viewported_list_tests.rs
@@ -263,6 +263,43 @@ fn rows_from_top_past_content_clamps_to_end() {
 }
 
 #[test]
+fn collapsing_bottom_content_at_new_max_restores_end_anchor() {
+    App::test((), |app| async move {
+        let content = FakeContent::new(vec![fake_item(1, 4), fake_item(2, 2)]);
+        let items_handle = content.items.clone();
+        let state = TuiViewportedListState::new_at_end();
+        state.scroll_to_rows_from_top(1);
+        let mut viewport = viewport_with_state(state.clone(), content)
+            .with_vertical_alignment(TuiViewportVerticalAlignment::GrowFromBottom);
+        let size = TuiSize::new(8, 4);
+
+        render_viewport(&app, &mut viewport, size);
+        assert_eq!(state.position(), TuiViewportPosition::RowsFromTop(1));
+
+        // The bottom item's header is visible on the last viewport row while
+        // its body extends one row below it. Collapsing the body changes the
+        // maximum scroll top from 2 to exactly the requested offset, 1.
+        *items_handle.borrow_mut() = vec![fake_item(1, 4), fake_item(2, 1)];
+        let lines = render_viewport(&app, &mut viewport, size);
+        assert_eq!(
+            state.position(),
+            TuiViewportPosition::End,
+            "a viewport at the new maximum must resume following the end",
+        );
+        assert_eq!(&lines[0][..3], "1:1");
+        assert_eq!(&lines[3][..3], "2:0");
+
+        // Once re-anchored, subsequent growth must move the window down rather
+        // than leave it fixed at RowsFromTop(1).
+        *items_handle.borrow_mut() = vec![fake_item(1, 4), fake_item(2, 2)];
+        let lines = render_viewport(&app, &mut viewport, size);
+        assert!(state.is_at_end());
+        assert_eq!(&lines[0][..3], "1:2");
+        assert_eq!(&lines[3][..3], "2:1");
+    });
+}
+
+#[test]
 fn scrolling_up_clamps_to_the_top_without_snapping_to_bottom() {
     App::test((), |app| async move {
         let content = FakeContent::new((1..=5).map(|id| fake_item(id, 3)).collect());


### PR DESCRIPTION
## Description

TUI viewports use `End` to follow content growth and `RowsFromTop` when anchored to an absolute row. When collapsing content at the bottom made a positive `RowsFromTop` offset exactly equal to the new maximum scroll position, the viewport remained visually at the bottom but did not transition back to `End`. Subsequent content growth therefore left the viewport behind.

This change restores the end anchor when a positive absolute offset is at or beyond the resolved maximum. It preserves `RowsFromTop(0)` as an explicit top-aligned position when all content fits in the viewport.

A regression test reproduces the boundary case by collapsing a bottom item so the requested offset equals the new maximum, then growing it again to verify the viewport follows the new end.

## Linked Issue

N/A

## Testing

- [x] Manually tested the TUI locally with `./script/run-tui`
- [x] `cargo nextest run -p warpui_core --features tui collapsing_bottom_content_at_new_max_restores_end_anchor`
- [x] `cargo nextest run -p warpui_core --features tui elements::tui::viewported_list::tests`
- [x] `cargo fmt --all --check`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed TUI transcripts losing follow-bottom anchoring after content at the bottom collapses.
