### PR TITLE
Support word wrapping in TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15538,6 +15538,7 @@ dependencies = [
  "string-offset",
  "sum_tree",
  "thiserror 2.0.17",
+ "unicode-linebreak",
  "unicode-segmentation",
  "unicode-width 0.1.14",
  "urlocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -333,6 +333,7 @@ arborium = { version = "2", default-features = false, features = [
   "lang-markdown",
 ] }
 unicode-general-category = "1.1.0"
+unicode-linebreak = "0.1.5"
 unicode-segmentation = "1.11.0"
 unicode-width = "0.1.12"
 uuid = { version = "1.1.2", features = ["v4", "serde", "js"] }

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -45,6 +45,7 @@ serde_yaml.workspace = true
 string-offset.workspace = true
 sum_tree.workspace = true
 thiserror.workspace = true
+unicode-linebreak.workspace = true
 pathfinder_color = "0.5.0"
 unicode-segmentation.workspace = true
 unicode-width.workspace = true
@@ -70,3 +71,8 @@ criterion = { version = "0.5.1", features = ["html_reports"] }
 [[bench]]
 name = "buffer_bench"
 harness = false
+
+[[bench]]
+name = "char_cell_bench"
+harness = false
+required-features = ["test-util"]

--- a/crates/editor/benches/char_cell_bench.rs
+++ b/crates/editor/benches/char_cell_bench.rs
@@ -1,0 +1,200 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use string_offset::CharOffset;
+use warp_editor::render::model::CharCellState;
+
+struct CountingAllocator;
+
+static COUNT_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+static LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
+static PEAK_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+fn record_allocation(bytes: usize) {
+    ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+    let live = LIVE_BYTES.fetch_add(bytes, Ordering::Relaxed) + bytes;
+    PEAK_BYTES.fetch_max(live, Ordering::Relaxed);
+}
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() && COUNT_ALLOCATIONS.load(Ordering::Relaxed) {
+            record_allocation(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc_zeroed(layout) };
+        if !ptr.is_null() && COUNT_ALLOCATIONS.load(Ordering::Relaxed) {
+            record_allocation(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if COUNT_ALLOCATIONS.load(Ordering::Relaxed) {
+            LIVE_BYTES.fetch_sub(layout.size(), Ordering::Relaxed);
+        }
+        unsafe { System.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = unsafe { System.realloc(ptr, layout, new_size) };
+        if !new_ptr.is_null() && COUNT_ALLOCATIONS.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            if new_size >= layout.size() {
+                let added = new_size - layout.size();
+                let live = LIVE_BYTES.fetch_add(added, Ordering::Relaxed) + added;
+                PEAK_BYTES.fetch_max(live, Ordering::Relaxed);
+            } else {
+                LIVE_BYTES.fetch_sub(layout.size() - new_size, Ordering::Relaxed);
+            }
+        }
+        new_ptr
+    }
+}
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+#[derive(Clone, Copy)]
+struct AllocationStats {
+    allocations: usize,
+    live_bytes: usize,
+    peak_bytes: usize,
+}
+
+fn measure_allocations<T>(f: impl FnOnce() -> T) -> (T, AllocationStats) {
+    ALLOCATIONS.store(0, Ordering::Relaxed);
+    LIVE_BYTES.store(0, Ordering::Relaxed);
+    PEAK_BYTES.store(0, Ordering::Relaxed);
+    COUNT_ALLOCATIONS.store(true, Ordering::SeqCst);
+    let value = f();
+    COUNT_ALLOCATIONS.store(false, Ordering::SeqCst);
+    (
+        value,
+        AllocationStats {
+            allocations: ALLOCATIONS.load(Ordering::Relaxed),
+            live_bytes: LIVE_BYTES.load(Ordering::Relaxed),
+            peak_bytes: PEAK_BYTES.load(Ordering::Relaxed),
+        },
+    )
+}
+
+fn short_lines(count: usize) -> String {
+    let mut text = String::with_capacity(count * 32);
+    for line in 0..count {
+        text.push_str("fn short_line_");
+        text.push_str(&(line % 1000).to_string());
+        text.push_str("() {}\n");
+    }
+    text
+}
+
+fn long_line(chars: usize) -> String {
+    "word-with-breaks ".repeat(chars.div_ceil(17))
+}
+
+fn unicode_lines(count: usize) -> String {
+    "你好 café a\u{301} hello-world 🚀\n".repeat(count)
+}
+
+fn dense_ghosts(line_count: usize) -> Vec<(String, usize)> {
+    (0..line_count)
+        .step_by(10)
+        .map(|line| (format!("removed content at line {line}\n"), line))
+        .collect()
+}
+
+fn hidden_ranges(line_count: usize) -> Vec<std::ops::Range<usize>> {
+    (20..line_count.saturating_sub(20))
+        .step_by(100)
+        .map(|start| start..(start + 20).min(line_count))
+        .collect()
+}
+
+fn bench_dataset(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    name: &str,
+    text: String,
+    logical_lines: usize,
+) {
+    let char_count = text.chars().count();
+    group.throughput(Throughput::Elements(char_count as u64));
+
+    let state = CharCellState::new_for_test(80);
+    let (_, vector_allocations) = measure_allocations(|| state.update_text(&text));
+    let retained_bytes = state.text_index_retained_bytes();
+    let dataset = format!(
+        "{name}/chars={char_count}/retained={retained_bytes}B/allocs={}/live={}B/peak={}B",
+        vector_allocations.allocations,
+        vector_allocations.live_bytes,
+        vector_allocations.peak_bytes,
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("rebuild", &dataset),
+        &text,
+        |bench, text| bench.iter(|| state.update_text(black_box(text))),
+    );
+
+    group.bench_function(BenchmarkId::new("max_line", &dataset), |bench| {
+        bench.iter(|| black_box(state.max_line()))
+    });
+
+    let target_offset = CharOffset::from(char_count.saturating_sub(1));
+    group.bench_function(BenchmarkId::new("offset_to_point", &dataset), |bench| {
+        bench.iter(|| black_box(state.offset_to_softwrap_point(black_box(target_offset))))
+    });
+
+    let target_point = state.offset_to_softwrap_point(target_offset);
+    group.bench_function(BenchmarkId::new("point_to_offset", &dataset), |bench| {
+        bench.iter(|| black_box(state.softwrap_point_to_offset(black_box(target_point))))
+    });
+
+    group.bench_function(BenchmarkId::new("visual_row_range", &dataset), |bench| {
+        bench.iter(|| black_box(state.visual_row_char_range(black_box(target_offset))))
+    });
+
+    state.set_test_temporary_blocks(dense_ghosts(logical_lines));
+    let hidden = hidden_ranges(logical_lines);
+    group.bench_function(BenchmarkId::new("display_lattice", &dataset), |bench| {
+        bench.iter(|| {
+            let lattice = state.display_lattice(black_box(&hidden));
+            black_box(lattice.rows().len())
+        })
+    });
+
+    group.bench_function(BenchmarkId::new("resize_and_max_line", &dataset), |bench| {
+        bench.iter(|| {
+            let width = if state.terminal_width() == 80 { 81 } else { 80 };
+            state.set_terminal_width(width);
+            black_box(state.max_line())
+        })
+    });
+}
+
+fn char_cell_benchmarks(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("char_cell");
+    bench_dataset(&mut group, "short_10k", short_lines(10_000), 10_001);
+    bench_dataset(&mut group, "short_100k", short_lines(100_000), 100_001);
+    bench_dataset(&mut group, "long_100k", long_line(100_000), 1);
+    bench_dataset(&mut group, "unicode_10k", unicode_lines(10_000), 10_001);
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(1));
+    targets = char_cell_benchmarks
+}
+criterion_main!(benches);

--- a/crates/editor/benches/char_cell_bench.rs
+++ b/crates/editor/benches/char_cell_bench.rs
@@ -74,9 +74,9 @@ fn measure_allocations<T>(f: impl FnOnce() -> T) -> (T, AllocationStats) {
     ALLOCATIONS.store(0, Ordering::Relaxed);
     LIVE_BYTES.store(0, Ordering::Relaxed);
     PEAK_BYTES.store(0, Ordering::Relaxed);
-    COUNT_ALLOCATIONS.store(true, Ordering::SeqCst);
+    COUNT_ALLOCATIONS.store(true, Ordering::Relaxed);
     let value = f();
-    COUNT_ALLOCATIONS.store(false, Ordering::SeqCst);
+    COUNT_ALLOCATIONS.store(false, Ordering::Relaxed);
     (
         value,
         AllocationStats {

--- a/crates/editor/src/render/model/char_cell_display.rs
+++ b/crates/editor/src/render/model/char_cell_display.rs
@@ -35,10 +35,7 @@ use std::ops::Range;
 use string_offset::CharOffset;
 use warpui_core::text::TuiGridPoint;
 
-use super::{
-    CharCellTemporaryBlock, char_cell_display_widths, char_cell_line_gap_position,
-    char_cell_line_row_starts, char_cell_logical_line,
-};
+use super::{CharCellTemporaryBlock, CharCellTextIndex};
 
 /// What a display row was projected from.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -82,32 +79,24 @@ pub struct DisplayRow {
 /// rows.
 pub struct DisplayLattice<'a> {
     rows: Vec<DisplayRow>,
-    line_starts: Ref<'a, Vec<usize>>,
-    char_widths: Ref<'a, Vec<u8>>,
+    text_index: Ref<'a, CharCellTextIndex>,
     terminal_width: u16,
     ghosts: Ref<'a, Vec<CharCellTemporaryBlock>>,
-    hidden_line_ranges: &'a [Range<usize>],
+    hidden_line_ranges: Vec<Range<usize>>,
 }
 
 impl<'a> DisplayLattice<'a> {
     pub(super) fn new(
-        line_starts: Ref<'a, Vec<usize>>,
-        char_widths: Ref<'a, Vec<u8>>,
+        text_index: Ref<'a, CharCellTextIndex>,
         terminal_width: u16,
         ghosts: Ref<'a, Vec<CharCellTemporaryBlock>>,
-        hidden_line_ranges: &'a [Range<usize>],
+        hidden_line_ranges: &[Range<usize>],
     ) -> Self {
-        let rows = display_rows(
-            &line_starts,
-            &char_widths,
-            terminal_width,
-            &ghosts,
-            hidden_line_ranges,
-        );
+        let hidden_line_ranges = normalize_hidden_line_ranges(hidden_line_ranges);
+        let rows = display_rows(&text_index, terminal_width, &ghosts, &hidden_line_ranges);
         Self {
             rows,
-            line_starts,
-            char_widths,
+            text_index,
             terminal_width,
             ghosts,
             hidden_line_ranges,
@@ -126,9 +115,15 @@ impl<'a> DisplayLattice<'a> {
 
     /// The display columns occupied by the clamped buffer character `range`.
     pub fn display_width(&self, range: Range<CharOffset>) -> u16 {
-        let start = range.start.as_usize().min(self.char_widths.len());
-        let end = range.end.as_usize().clamp(start, self.char_widths.len());
-        self.char_widths[start..end]
+        let start = range
+            .start
+            .as_usize()
+            .min(self.text_index.char_widths.len());
+        let end = range
+            .end
+            .as_usize()
+            .clamp(start, self.text_index.char_widths.len());
+        self.text_index.char_widths[start..end]
             .iter()
             .fold(0u16, |width, &next| width.saturating_add(u16::from(next)))
     }
@@ -142,24 +137,36 @@ impl<'a> DisplayLattice<'a> {
     /// buffer gap for a cursor. Callers sizing a viewport must accommodate
     /// that phantom row.
     pub fn offset_to_display_point(&self, char_offset: CharOffset) -> Option<TuiGridPoint> {
-        let char_idx = char_offset.as_usize();
         let line_index = self
+            .text_index
             .line_starts
-            .partition_point(|&start| start <= char_idx)
+            .partition_point(|&start| start <= char_offset)
             .saturating_sub(1);
-
-        if self
-            .hidden_line_ranges
-            .iter()
-            .any(|range| range.contains(&line_index))
-        {
+        if line_is_hidden(&self.hidden_line_ranges, line_index) {
             return None;
         }
 
-        let line_start = self.line_starts.get(line_index).copied().unwrap_or(0);
-        let line = char_cell_logical_line(&self.line_starts, &self.char_widths, line_index);
-        let (row_within_line, col) =
-            char_cell_line_gap_position(line, self.terminal_width, char_idx - line_start);
+        let line_range = self.text_index.logical_line_char_range(line_index);
+        let char_index = char_offset.as_usize().min(line_range.end);
+        let visual_row = self
+            .text_index
+            .visual_row_for_offset(line_index, char_offset);
+        let row_range = self
+            .text_index
+            .visual_row_char_range(line_index, visual_row);
+        let col = self.text_index.char_widths[row_range.start..char_index]
+            .iter()
+            .map(|&width| width as usize)
+            .sum::<usize>();
+        let mut row_within_line = visual_row - self.text_index.line_visual_row_starts[line_index];
+        let mut display_col = col as u16;
+        if char_index == line_range.end
+            && self.terminal_width > 0
+            && col == self.terminal_width as usize
+        {
+            row_within_line += 1;
+            display_col = 0;
+        }
 
         // The line's display rows are contiguous by construction.
         let mut line_rows = self.rows.iter().enumerate().filter(|(_, row)| {
@@ -167,10 +174,10 @@ impl<'a> DisplayLattice<'a> {
         });
         let (first_row, _) = line_rows.next()?;
         let last_row = line_rows.next_back().map_or(first_row, |(index, _)| index);
-        if (row_within_line as usize) <= last_row - first_row {
+        if row_within_line <= last_row - first_row {
             return Some(TuiGridPoint {
-                row: first_row + row_within_line as usize,
-                col,
+                row: first_row + row_within_line,
+                col: display_col,
             });
         }
 
@@ -181,7 +188,10 @@ impl<'a> DisplayLattice<'a> {
             .iter()
             .position(|row| matches!(row.kind, DisplayRowKind::Buffer { .. }))
             .map_or(self.rows.len(), |offset| last_row + 1 + offset);
-        Some(TuiGridPoint { row, col })
+        Some(TuiGridPoint {
+            row,
+            col: display_col,
+        })
     }
 
     /// The 0-based character offset of the gap at `point`.
@@ -198,7 +208,7 @@ impl<'a> DisplayLattice<'a> {
                 let mut col = 0usize;
                 let mut offset = row.char_range.start;
                 while offset < row.char_range.end {
-                    let width = self.char_widths[offset.as_usize()] as usize;
+                    let width = self.text_index.char_widths[offset.as_usize()] as usize;
                     if col + width > target_col {
                         break;
                     }
@@ -212,19 +222,47 @@ impl<'a> DisplayLattice<'a> {
     }
 }
 
+fn normalize_hidden_line_ranges(ranges: &[Range<usize>]) -> Vec<Range<usize>> {
+    let mut ranges: Vec<_> = ranges
+        .iter()
+        .filter(|range| range.start < range.end)
+        .cloned()
+        .collect();
+    ranges.sort_by_key(|range| range.start);
+
+    let mut merged: Vec<Range<usize>> = Vec::with_capacity(ranges.len());
+    for range in ranges {
+        if let Some(previous) = merged.last_mut()
+            && range.start <= previous.end
+        {
+            previous.end = previous.end.max(range.end);
+        } else {
+            merged.push(range);
+        }
+    }
+    merged
+}
+
+fn line_is_hidden(ranges: &[Range<usize>], line_index: usize) -> bool {
+    let candidate = ranges.partition_point(|range| range.end <= line_index);
+    ranges
+        .get(candidate)
+        .is_some_and(|range| range.start <= line_index)
+}
+
 /// Projects the wrap tables + overlays into the flat display-row list
 /// described in the module docs. Ghosts always render, even when their insert
 /// position falls inside a hidden range (they represent changed content),
 /// splitting the gap.
 fn display_rows(
-    line_starts: &[usize],
-    char_widths: &[u8],
+    text_index: &CharCellTextIndex,
     terminal_width: u16,
     ghosts: &[CharCellTemporaryBlock],
     hidden_line_ranges: &[Range<usize>],
 ) -> Vec<DisplayRow> {
     let mut rows = Vec::new();
     let mut pending_ghosts = ghosts.iter().enumerate().peekable();
+    let mut hidden_ranges = hidden_line_ranges.iter().peekable();
     // Hidden lines accumulated since the last visible row; materialized as a
     // Gap row only when more visible content follows (interior gaps).
     let mut pending_hidden: Option<Range<usize>> = None;
@@ -245,10 +283,16 @@ fn display_rows(
             }
         };
 
-    for line_index in 0..line_starts.len() {
-        let hidden = hidden_line_ranges
-            .iter()
-            .any(|range| range.contains(&line_index));
+    for line_index in 0..text_index.line_starts.len() {
+        while hidden_ranges
+            .peek()
+            .is_some_and(|range| range.end <= line_index)
+        {
+            hidden_ranges.next();
+        }
+        let hidden = hidden_ranges
+            .peek()
+            .is_some_and(|range| range.start <= line_index);
         let has_ghosts_here = pending_ghosts
             .peek()
             .is_some_and(|(_, ghost)| (ghost.insert_before.as_u32() as usize) <= line_index);
@@ -272,13 +316,7 @@ fn display_rows(
                 None => pending_hidden = Some(line_index..line_index + 1),
             }
         } else {
-            push_buffer_line_rows(
-                &mut rows,
-                line_index,
-                line_starts,
-                char_widths,
-                terminal_width,
-            );
+            push_buffer_line_rows(&mut rows, line_index, text_index);
             emitted_visible = true;
         }
     }
@@ -299,18 +337,14 @@ fn display_rows(
 fn push_buffer_line_rows(
     rows: &mut Vec<DisplayRow>,
     line_index: usize,
-    line_starts: &[usize],
-    char_widths: &[u8],
-    terminal_width: u16,
+    text_index: &CharCellTextIndex,
 ) {
-    let line_start = line_starts[line_index].min(char_widths.len());
-    let line = char_cell_logical_line(line_starts, char_widths, line_index);
-    let row_starts = char_cell_line_row_starts(line, terminal_width);
-    for (row, &start) in row_starts.iter().enumerate() {
-        let end = row_starts.get(row + 1).copied().unwrap_or(line.len());
+    let line_rows = text_index.logical_line_visual_rows(line_index);
+    for (row, visual_row) in line_rows.enumerate() {
+        let range = text_index.visual_row_char_range(line_index, visual_row);
         rows.push(DisplayRow {
             kind: DisplayRowKind::Buffer { line_index },
-            char_range: CharOffset::range((line_start + start)..(line_start + end)),
+            char_range: CharOffset::range(range),
             is_continuation: row > 0,
         });
     }
@@ -327,11 +361,29 @@ fn push_ghost_rows(
     ghost: &CharCellTemporaryBlock,
     terminal_width: u16,
 ) {
-    let content = ghost.content.strip_suffix('\n').unwrap_or(&ghost.content);
-    let widths = char_cell_display_widths(content);
-    let row_starts = char_cell_line_row_starts(&widths, terminal_width);
+    let mut cached_rows = ghost.wrapped_row_starts.borrow_mut();
+    if cached_rows
+        .as_ref()
+        .is_none_or(|(width, _)| *width != terminal_width)
+    {
+        let mut row_starts = cached_rows
+            .take()
+            .map(|(_, row_starts)| row_starts)
+            .unwrap_or_default();
+        super::char_cell_line_row_starts_into(
+            &ghost.line_breaks,
+            &ghost.char_widths,
+            terminal_width,
+            &mut row_starts,
+        );
+        *cached_rows = Some((terminal_width, row_starts));
+    }
+    let row_starts = &cached_rows.as_ref().unwrap().1;
     for (row, &start) in row_starts.iter().enumerate() {
-        let end = row_starts.get(row + 1).copied().unwrap_or(widths.len());
+        let end = row_starts
+            .get(row + 1)
+            .copied()
+            .unwrap_or(ghost.char_widths.len());
         rows.push(DisplayRow {
             kind: DisplayRowKind::Ghost { ghost_index },
             char_range: CharOffset::range(start..end),

--- a/crates/editor/src/render/model/char_cell_display_tests.rs
+++ b/crates/editor/src/render/model/char_cell_display_tests.rs
@@ -15,12 +15,12 @@ fn state(text: &str, terminal_width: u16) -> CharCellState {
 }
 
 fn ghost(content: &str, insert_before: usize) -> CharCellTemporaryBlock {
-    CharCellTemporaryBlock {
-        content: content.to_string(),
-        insert_before: LineCount::from(insert_before),
-        line_decoration: None,
-        inline_decorations: Vec::new(),
-    }
+    CharCellTemporaryBlock::new(
+        content.to_string(),
+        LineCount::from(insert_before),
+        None,
+        Vec::new(),
+    )
 }
 
 /// The lattice's rows at `hidden`, for row-structure assertions.
@@ -98,15 +98,17 @@ fn ghosts_interleave_before_their_line_and_wrap() {
                 char_range(0..9),
                 false,
             ),
-            // The second ghost is 11 chars: wraps at width 9.
+            // The second ghost is 11 chars and wraps at width 9. Word-boundary
+            // wrapping breaks at the space (index 7), so "removed " (0..8) fits
+            // on row 0 and "b!!" (8..11) continues on row 1.
             (
                 DisplayRowKind::Ghost { ghost_index: 1 },
-                char_range(0..9),
+                char_range(0..8),
                 false,
             ),
             (
                 DisplayRowKind::Ghost { ghost_index: 1 },
-                char_range(9..11),
+                char_range(8..11),
                 true,
             ),
             (buffer(1), char_range(6..11), false),
@@ -150,7 +152,25 @@ fn oversized_grapheme_does_not_wrap_at_zero_width_continuation() {
     assert_eq!(point(&state, 1, &[]), Some((0, 2)));
     assert_eq!(point(&state, 2, &[]), Some((1, 0)));
 }
-
+#[test]
+fn ghosts_are_stably_sorted_by_insertion_line() {
+    let state = state("l0\nl1\nl2", 20);
+    state.set_temporary_blocks(vec![
+        ghost("last", 2),
+        ghost("same-a", 1),
+        ghost("first", 0),
+        ghost("same-b", 1),
+    ]);
+    let lattice = state.display_lattice(&[]);
+    assert_eq!(
+        lattice
+            .ghosts()
+            .iter()
+            .map(|ghost| ghost.content.as_str())
+            .collect::<Vec<_>>(),
+        vec!["first", "same-a", "same-b", "last"]
+    );
+}
 #[test]
 fn interior_hidden_ranges_become_gaps_edges_render_nothing() {
     // Lines 0-1 hidden (leading), 3-5 hidden (interior), 7 hidden (trailing).
@@ -169,6 +189,22 @@ fn interior_hidden_ranges_become_gaps_edges_render_nothing() {
     );
 }
 
+#[test]
+fn hidden_ranges_are_sorted_and_merged_before_projection() {
+    let state = state("l0\nl1\nl2\nl3\nl4\nl5", 20);
+    assert_eq!(
+        summarize(&rows(&state, &[3..5, 1..3, 2..4])),
+        vec![
+            (buffer(0), char_range(0..2), false),
+            (
+                DisplayRowKind::Gap { line_range: 1..5 },
+                CharOffset::zero().empty_range(),
+                false,
+            ),
+            (buffer(5), char_range(15..17), false),
+        ]
+    );
+}
 #[test]
 fn ghost_inside_hidden_region_still_renders_and_splits_the_gap() {
     // Lines 1-4 hidden; a ghost inserts before line 3 (inside the hidden run).

--- a/crates/editor/src/render/model/mod.rs
+++ b/crates/editor/src/render/model/mod.rs
@@ -424,6 +424,34 @@ pub struct CharCellTemporaryBlock {
     pub line_decoration: Option<ColorU>,
     /// Char-index sub-ranges of `content` with their own colors.
     pub inline_decorations: Vec<(Range<usize>, ColorU)>,
+    /// Display widths for `content` without its conventional trailing newline.
+    char_widths: Vec<u8>,
+    /// Gap-indexed Unicode line-break opportunities for `char_widths`.
+    line_breaks: Vec<bool>,
+    /// Width-keyed wrapped rows, computed lazily and reused across lattices.
+    wrapped_row_starts: RefCell<Option<(u16, Vec<usize>)>>,
+}
+
+impl CharCellTemporaryBlock {
+    fn new(
+        content: String,
+        insert_before: LineCount,
+        line_decoration: Option<ColorU>,
+        inline_decorations: Vec<(Range<usize>, ColorU)>,
+    ) -> Self {
+        let layout_content = content.strip_suffix('\n').unwrap_or(&content);
+        let char_widths = char_cell_display_widths(layout_content);
+        let line_breaks = char_cell_line_break_opportunities(layout_content);
+        Self {
+            content,
+            insert_before,
+            line_decoration,
+            inline_decorations,
+            char_widths,
+            line_breaks,
+            wrapped_row_starts: RefCell::new(None),
+        }
+    }
 }
 
 impl From<TemporaryBlock> for CharCellTemporaryBlock {
@@ -439,15 +467,172 @@ impl From<TemporaryBlock> for CharCellTemporaryBlock {
                 ))
             })
             .collect();
-        Self {
-            content: block.content,
-            insert_before: block.insert_before,
-            line_decoration: block.line_decoration.map(|fill| fill.into_solid()),
+        Self::new(
+            block.content,
+            block.insert_before,
+            block.line_decoration.map(|fill| fill.into_solid()),
             inline_decorations,
-        }
+        )
     }
 }
 
+/// Compact char-cell metadata derived from the current buffer text.
+///
+/// Keeping the parallel vectors behind one `RefCell` makes their length and
+/// indexing invariants atomic without giving up their contiguous storage.
+#[derive(Debug)]
+pub(crate) struct CharCellTextIndex {
+    /// The 0-indexed character offset of each logical line start. Never empty.
+    line_starts: Vec<CharOffset>,
+    /// One terminal display width per buffer character, including newlines.
+    char_widths: Vec<u8>,
+    /// Gap-indexed Unicode line-break opportunities; one longer than widths.
+    line_breaks: Vec<bool>,
+    /// Index into `visual_row_char_starts` for each logical line, plus one
+    /// terminal entry. This is a prefix sum of visual rows per logical line.
+    line_visual_row_starts: Vec<usize>,
+    /// Global buffer character offset of every visual row start.
+    visual_row_char_starts: Vec<CharOffset>,
+}
+
+impl Default for CharCellTextIndex {
+    fn default() -> Self {
+        Self::new(0)
+    }
+}
+
+impl CharCellTextIndex {
+    fn new(terminal_width: u16) -> Self {
+        let mut index = Self {
+            line_starts: vec![CharOffset::zero()],
+            char_widths: Vec::new(),
+            line_breaks: vec![true],
+            line_visual_row_starts: Vec::new(),
+            visual_row_char_starts: Vec::new(),
+        };
+        index.rebuild_wrap_cache(terminal_width);
+        index
+    }
+
+    fn rebuild(&mut self, text: &str, terminal_width: u16) {
+        self.rebuild_text_metadata(text);
+        self.rebuild_wrap_cache(terminal_width);
+        self.debug_validate();
+    }
+
+    fn rebuild_text_metadata(&mut self, text: &str) {
+        self.line_starts.clear();
+        self.char_widths.clear();
+        self.line_breaks.clear();
+        self.line_starts.push(CharOffset::zero());
+        let line_starts = &mut self.line_starts;
+        append_char_cell_display_widths(text, &mut self.char_widths, |ch, next_offset| {
+            if ch == '\n' {
+                line_starts.push(CharOffset::from(next_offset));
+            }
+        });
+        self.line_breaks
+            .extend(char_cell_line_break_opportunities(text));
+    }
+
+    fn rebuild_wrap_cache(&mut self, terminal_width: u16) {
+        self.line_visual_row_starts.clear();
+        self.visual_row_char_starts.clear();
+        let mut local_row_starts = Vec::new();
+        for line_index in 0..self.line_starts.len() {
+            self.line_visual_row_starts
+                .push(self.visual_row_char_starts.len());
+            let line_start = self.line_starts[line_index].as_usize();
+            let line = char_cell_logical_line(&self.line_starts, &self.char_widths, line_index);
+            let line_breaks =
+                char_cell_logical_line_breaks(&self.line_starts, &self.line_breaks, line_index);
+            char_cell_line_row_starts_into(
+                line_breaks,
+                line,
+                terminal_width,
+                &mut local_row_starts,
+            );
+            self.visual_row_char_starts.extend(
+                local_row_starts
+                    .iter()
+                    .map(|&row_start| CharOffset::from(line_start + row_start)),
+            );
+        }
+        self.line_visual_row_starts
+            .push(self.visual_row_char_starts.len());
+    }
+
+    fn logical_line_for_offset(&self, offset: CharOffset) -> usize {
+        self.line_starts
+            .partition_point(|&start| start <= offset)
+            .saturating_sub(1)
+    }
+
+    fn logical_line_char_range(&self, line_index: usize) -> Range<usize> {
+        let start = self.line_starts[line_index]
+            .as_usize()
+            .min(self.char_widths.len());
+        let end = self
+            .line_starts
+            .get(line_index + 1)
+            .map(|next| next.as_usize().saturating_sub(1))
+            .unwrap_or(self.char_widths.len())
+            .min(self.char_widths.len())
+            .max(start);
+        start..end
+    }
+
+    fn logical_line_visual_rows(&self, line_index: usize) -> Range<usize> {
+        self.line_visual_row_starts[line_index]..self.line_visual_row_starts[line_index + 1]
+    }
+
+    fn visual_row_for_offset(&self, line_index: usize, offset: CharOffset) -> usize {
+        let rows = self.logical_line_visual_rows(line_index);
+        let row_in_line = self.visual_row_char_starts[rows.clone()]
+            .partition_point(|&start| start <= offset)
+            .saturating_sub(1);
+        rows.start + row_in_line
+    }
+
+    fn visual_row_char_range(&self, line_index: usize, visual_row: usize) -> Range<usize> {
+        let line_rows = self.logical_line_visual_rows(line_index);
+        let start = self.visual_row_char_starts[visual_row].as_usize();
+        let end = if visual_row + 1 < line_rows.end {
+            self.visual_row_char_starts[visual_row + 1].as_usize()
+        } else {
+            self.logical_line_char_range(line_index).end
+        };
+        start..end
+    }
+
+    fn debug_validate(&self) {
+        debug_assert_eq!(self.line_starts.first(), Some(&CharOffset::zero()));
+        debug_assert!(
+            self.line_starts
+                .windows(2)
+                .all(|starts| starts[0] < starts[1])
+        );
+        debug_assert!(
+            self.line_starts
+                .last()
+                .is_some_and(|start| start.as_usize() <= self.char_widths.len())
+        );
+        debug_assert_eq!(self.line_breaks.len(), self.char_widths.len() + 1);
+        debug_assert_eq!(
+            self.line_visual_row_starts.len(),
+            self.line_starts.len() + 1
+        );
+        debug_assert_eq!(
+            self.line_visual_row_starts.last(),
+            Some(&self.visual_row_char_starts.len())
+        );
+        debug_assert!(
+            self.line_visual_row_starts
+                .windows(2)
+                .all(|rows| rows[0] < rows[1])
+        );
+    }
+}
 /// All state specific to the TUI char-cell rendering path.
 ///
 /// Bundled into a single struct so the [`LayoutMode`] enum cleanly separates
@@ -458,17 +643,9 @@ pub struct CharCellState {
     /// pass; interior-mutable so it can be set through a shared `&CharCellState`
     /// (mirroring how the GUI submits viewport state during layout).
     pub(crate) terminal_width: Cell<u16>,
-    /// The 0-indexed char offset of the start of each logical line (`\n`-split).
-    /// Rebuilt synchronously via [`CharCellState::update_text`]. Invariant:
-    /// never empty — it always holds at least `[0]` (logical line 0 starts at char
-    /// 0), even before the first edit, so the soft-wrap helpers can index it safely.
-    pub(crate) line_starts: RefCell<Vec<usize>>,
-    /// The terminal display width metadata for each character of the buffer,
-    /// indexed in parallel with char offsets. The first character of a grapheme
-    /// carries its full width and the remaining characters carry zero. This is
-    /// derived layout metadata, not a copy of the text. Rebuilt via
-    /// [`CharCellState::update_text`].
-    pub(crate) char_widths: RefCell<Vec<u8>>,
+    /// Buffer-derived line starts, display widths, and line-break opportunities
+    /// borrowed and rebuilt as one coherent snapshot.
+    text_index: RefCell<CharCellTextIndex>,
     /// Diff ghost lines (deleted/replaced content) to interleave at their
     /// `insert_before` line positions when rendering. Replaced wholesale on
     /// each diff refresh; empty when no diff is displayed. Deliberately not
@@ -489,21 +666,22 @@ impl CharCellState {
     fn new(terminal_width: u16, hidden_lines: Option<ModelHandle<HiddenLinesModel>>) -> Self {
         Self {
             terminal_width: Cell::new(terminal_width),
-            // Seed with logical line 0 so `line_starts` is never empty, matching
-            // the post-`update_text` state for an empty buffer. The soft-wrap
-            // helpers index `line_starts[0]` and must not panic if a navigation/
-            // scroll happens before the first edit.
-            line_starts: RefCell::new(vec![0]),
-            char_widths: RefCell::new(Vec::new()),
+            text_index: RefCell::new(CharCellTextIndex::new(terminal_width)),
             temporary_blocks: RefCell::new(Vec::new()),
             hidden_lines,
             scroll_offset: Cell::new(0),
         }
     }
 
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn new_for_test(terminal_width: u16) -> Self {
+        Self::new(terminal_width, None)
+    }
+
     /// Replace the stored ghost lines. Replace-all semantics, mirroring the
     /// GUI path's `reset_temporary_block`, so stale ghosts never linger.
-    fn set_temporary_blocks(&self, blocks: Vec<CharCellTemporaryBlock>) {
+    fn set_temporary_blocks(&self, mut blocks: Vec<CharCellTemporaryBlock>) {
+        blocks.sort_by_key(|block| block.insert_before);
         *self.temporary_blocks.borrow_mut() = blocks;
     }
 
@@ -514,10 +692,102 @@ impl CharCellState {
 
     /// Update the terminal width used for char-cell wrapping. Interior-mutable so
     /// it can be set through a shared `&CharCellState` during the element's layout
-    /// pass (which only has a shared `&AppContext`). `line_starts`/`char_widths`
-    /// don't depend on the width, so nothing else is rebuilt here.
+    /// pass (which only has a shared `&AppContext`). Width-independent text
+    /// metadata is retained; only the compact visual-row cache is rebuilt.
     pub fn set_terminal_width(&self, terminal_width: u16) {
+        if self.terminal_width.get() == terminal_width {
+            return;
+        }
         self.terminal_width.set(terminal_width);
+        self.text_index
+            .borrow_mut()
+            .rebuild_wrap_cache(terminal_width);
+    }
+
+    /// The number of soft-wrapped buffer rows, excluding ghost and hidden-line
+    /// display overlays.
+    pub fn max_line(&self) -> LineCount {
+        let text_index = self.text_index.borrow();
+        LineCount(text_index.visual_row_char_starts.len())
+    }
+
+    pub fn offset_to_softwrap_point(&self, offset: CharOffset) -> SoftWrapPoint {
+        let text_index = self.text_index.borrow();
+        let line_index = text_index.logical_line_for_offset(offset);
+        let line_range = text_index.logical_line_char_range(line_index);
+        let char_index = offset.as_usize().min(line_range.end);
+        let visual_row = text_index.visual_row_for_offset(line_index, offset);
+        let visual_range = text_index.visual_row_char_range(line_index, visual_row);
+        let col = text_index.char_widths[visual_range.start..char_index]
+            .iter()
+            .map(|&width| width as usize)
+            .sum::<usize>();
+        if char_index == line_range.end
+            && self.terminal_width.get() > 0
+            && col == self.terminal_width.get() as usize
+        {
+            SoftWrapPoint::new((visual_row + 1) as u32, ColumnUnit::Chars(0))
+        } else {
+            SoftWrapPoint::new(visual_row as u32, ColumnUnit::Chars(col as u16))
+        }
+    }
+
+    pub fn softwrap_point_to_offset(&self, point: SoftWrapPoint) -> CharOffset {
+        let text_index = self.text_index.borrow();
+        if point.row() as usize >= text_index.visual_row_char_starts.len() {
+            return CharOffset::from(text_index.char_widths.len());
+        }
+        let visual_row =
+            (point.row() as usize).min(text_index.visual_row_char_starts.len().saturating_sub(1));
+        let line_index = text_index
+            .line_visual_row_starts
+            .partition_point(|&start| start <= visual_row)
+            .saturating_sub(1)
+            .min(text_index.line_starts.len() - 1);
+        let row_range = text_index.visual_row_char_range(line_index, visual_row);
+        let target_col = match point.column() {
+            ColumnUnit::Chars(col) => col as usize,
+            ColumnUnit::Pixels(_) => 0,
+        };
+        let mut col = 0usize;
+        let mut char_index = row_range.start;
+        while char_index < row_range.end {
+            let width = text_index.char_widths[char_index] as usize;
+            if col + width > target_col {
+                break;
+            }
+            col += width;
+            char_index += 1;
+        }
+        CharOffset::from(char_index)
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn set_test_temporary_blocks(&self, blocks: Vec<(String, usize)>) {
+        self.set_temporary_blocks(
+            blocks
+                .into_iter()
+                .map(|(content, insert_before)| {
+                    CharCellTemporaryBlock::new(
+                        content,
+                        LineCount::from(insert_before),
+                        None,
+                        Vec::new(),
+                    )
+                })
+                .collect(),
+        );
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn text_index_retained_bytes(&self) -> usize {
+        let text_index = self.text_index.borrow();
+        std::mem::size_of::<CharCellTextIndex>()
+            + text_index.line_starts.capacity() * std::mem::size_of::<CharOffset>()
+            + text_index.char_widths.capacity() * std::mem::size_of::<u8>()
+            + text_index.line_breaks.capacity().div_ceil(8)
+            + text_index.line_visual_row_starts.capacity() * std::mem::size_of::<usize>()
+            + text_index.visual_row_char_starts.capacity() * std::mem::size_of::<CharOffset>()
     }
 
     /// The attached [`HiddenLinesModel`] projected to 0-based logical line
@@ -526,7 +796,8 @@ impl CharCellState {
         let Some(hidden_lines) = self.hidden_lines.as_ref() else {
             return Vec::new();
         };
-        let line_starts = self.line_starts.borrow();
+        let text_index = self.text_index.borrow();
+        let line_starts = &text_index.line_starts;
         hidden_lines
             .as_ref(app)
             .hidden_ranges_at_latest(app)
@@ -535,8 +806,8 @@ impl CharCellState {
                 // Anchor offsets are 1-based gaps sitting at line starts;
                 // convert to 0-based char indices, then to line indices. The
                 // end offset is the start of the first line *after* the run.
-                let start_char = range.start.as_usize().saturating_sub(1);
-                let end_char = range.end.as_usize().saturating_sub(1);
+                let start_char = CharOffset::from(range.start.as_usize().saturating_sub(1));
+                let end_char = CharOffset::from(range.end.as_usize().saturating_sub(1));
                 let start_line = line_starts
                     .partition_point(|&start| start <= start_char)
                     .saturating_sub(1);
@@ -557,14 +828,12 @@ impl CharCellState {
     /// model-derived set from [`CharCellState::hidden_line_ranges`].
     pub fn display_lattice<'a>(
         &'a self,
-        hidden_line_ranges: &'a [Range<usize>],
+        hidden_line_ranges: &[Range<usize>],
     ) -> DisplayLattice<'a> {
-        let line_starts = self.line_starts.borrow();
-        let char_widths = self.char_widths.borrow();
+        let text_index = self.text_index.borrow();
         let ghosts = self.temporary_blocks.borrow();
         DisplayLattice::new(
-            line_starts,
-            char_widths,
+            text_index,
             self.terminal_width.get(),
             ghosts,
             hidden_line_ranges,
@@ -578,22 +847,11 @@ impl CharCellState {
     /// follow the same display-width wrapping as everything else in this
     /// state, so e.g. kill-to-visual-line-end ranges match the rendered rows.
     pub fn visual_row_char_range(&self, char_offset: CharOffset) -> Range<CharOffset> {
-        let char_idx = char_offset.as_usize();
-        let line_starts = self.line_starts.borrow();
-        let char_widths = self.char_widths.borrow();
-        let line_index = line_starts
-            .partition_point(|&start| start <= char_idx)
-            .saturating_sub(1);
-        let line_start = line_starts[line_index].min(char_widths.len());
-        let line = char_cell_logical_line(&line_starts, &char_widths, line_index);
-        let row_starts = char_cell_line_row_starts(line, self.terminal_width.get());
-        let pos_in_line = char_idx.min(char_widths.len()).saturating_sub(line_start);
-        let row = row_starts
-            .partition_point(|&start| start <= pos_in_line)
-            .saturating_sub(1);
-        let start = row_starts[row];
-        let end = row_starts.get(row + 1).copied().unwrap_or(line.len());
-        CharOffset::range((line_start + start)..(line_start + end))
+        let text_index = self.text_index.borrow();
+        let line_index = text_index.logical_line_for_offset(char_offset);
+        let visual_row = text_index.visual_row_for_offset(line_index, char_offset);
+        let range = text_index.visual_row_char_range(line_index, visual_row);
+        CharOffset::range(range)
     }
 
     /// The first visible display row of the scroll-windowed viewport.
@@ -673,8 +931,9 @@ impl CharCellState {
         (cursor_row, total_rows)
     }
 
-    /// Rebuild the char-cell layout index — `line_starts` and the per-char display
-    /// `char_widths` — from the current buffer `text` (O(n) char scan).
+    /// Rebuild the char-cell layout index — `line_starts`, per-character
+    /// display widths, and Unicode line-break opportunities — from the current
+    /// buffer `text` (O(n) scan).
     ///
     /// ## Why TUI needs this explicit call but GUI doesn't
     ///
@@ -690,18 +949,9 @@ impl CharCellState {
     /// `text` should be the buffer's current plain text (without any trailing
     /// sentinel newline injected by the buffer layer).
     pub fn update_text(&self, text: &str) {
-        let mut starts = self.line_starts.borrow_mut();
-        let mut char_widths = self.char_widths.borrow_mut();
-        starts.clear();
-        char_widths.clear();
-        // Logical line 0 starts at char index 0.
-        starts.push(0_usize);
-        append_char_cell_display_widths(text, &mut char_widths, |ch, next_offset| {
-            if ch == '\n' {
-                // The next logical line starts at the char index after this '\n'.
-                starts.push(next_offset);
-            }
-        });
+        self.text_index
+            .borrow_mut()
+            .rebuild(text, self.terminal_width.get());
     }
 }
 
@@ -709,8 +959,7 @@ impl std::fmt::Debug for CharCellState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CharCellState")
             .field("terminal_width", &self.terminal_width.get())
-            .field("line_starts_len", &self.line_starts.borrow().len())
-            .field("total_chars", &self.char_widths.borrow().len())
+            .field("text_index", &self.text_index.borrow())
             .field(
                 "temporary_blocks_len",
                 &self.temporary_blocks.borrow().len(),
@@ -2398,11 +2647,7 @@ impl RenderState {
 
     pub fn max_line(&self) -> LineCount {
         if let LayoutMode::CharCell(ref cc) = self.layout_mode {
-            return char_cell_max_line(
-                &cc.line_starts.borrow(),
-                &cc.char_widths.borrow(),
-                cc.terminal_width.get(),
-            );
+            return cc.max_line();
         }
         self.content.borrow().summary().lines
     }
@@ -3601,12 +3846,7 @@ impl RenderState {
     pub fn offset_to_softwrap_point(&self, offset: CharOffset) -> SoftWrapPoint {
         // CharCell path: compute visual row/col from char-cell display-width arithmetic.
         if let LayoutMode::CharCell(ref cc) = self.layout_mode {
-            return char_cell_offset_to_softwrap_point(
-                offset,
-                &cc.line_starts.borrow(),
-                &cc.char_widths.borrow(),
-                cc.terminal_width.get(),
-            );
+            return cc.offset_to_softwrap_point(offset);
         }
 
         // Pixels path: use the font-laid-out SumTree<BlockItem>.
@@ -3623,12 +3863,7 @@ impl RenderState {
     pub fn softwrap_point_to_offset(&self, point: SoftWrapPoint) -> CharOffset {
         // CharCell path.
         if let LayoutMode::CharCell(ref cc) = self.layout_mode {
-            return char_cell_softwrap_point_to_offset(
-                point,
-                &cc.line_starts.borrow(),
-                &cc.char_widths.borrow(),
-                cc.terminal_width.get(),
-            );
+            return cc.softwrap_point_to_offset(point);
         }
 
         // Pixels path.
@@ -5426,97 +5661,190 @@ fn char_cell_display_widths(text: &str) -> Vec<u8> {
     widths
 }
 
-/// For one logical line, given the display width (in cells) of each of its
-/// characters, returns the 0-based char index at which each visual row begins.
+/// Returns Unicode line-break opportunities as 0-based character gaps.
+///
+/// The GUI editor delegates soft wrapping to the platform text layout engine.
+/// Precomputing these opportunities keeps char-cell layout independent of a
+/// font engine while mirroring the GUI's word-or-glyph policy; on platforms
+/// backed by cosmic-text, both paths use this same crate.
+pub(crate) fn char_cell_line_break_opportunities(text: &str) -> Vec<bool> {
+    let mut opportunities = vec![false; text.chars().count() + 1];
+    let mut char_boundaries = text
+        .char_indices()
+        .map(|(byte_offset, _)| byte_offset)
+        .chain(std::iter::once(text.len()))
+        .enumerate()
+        .peekable();
+
+    for (break_byte_offset, _) in unicode_linebreak::linebreaks(text) {
+        while char_boundaries
+            .peek()
+            .is_some_and(|(_, byte_offset)| *byte_offset < break_byte_offset)
+        {
+            char_boundaries.next();
+        }
+        if let Some(&(char_offset, byte_offset)) = char_boundaries.peek() {
+            debug_assert_eq!(byte_offset, break_byte_offset);
+            if byte_offset == break_byte_offset {
+                opportunities[char_offset] = true;
+            }
+        }
+    }
+
+    // The end of a logical line is always a valid fallback, including for an
+    // empty string.
+    *opportunities.last_mut().unwrap() = true;
+    opportunities
+}
+
+/// For one logical line, given its Unicode line-break opportunities and
+/// character display widths (in cells), returns the 0-based character index at
+/// which each visual row begins.
 /// Always returns at least `[0]`.
 ///
-/// Width-aware: a character is placed on the current row if it fits within
-/// `terminal_width` display columns; otherwise it starts a new row. Wide
-/// characters that don't fit in the remaining columns wrap (leaving a blank
-/// trailing cell); zero-width characters never force a wrap. With
-/// `terminal_width == 0`, wrapping is disabled (a single row).
-pub fn char_cell_line_row_starts(char_widths: &[u8], terminal_width: u16) -> Vec<usize> {
+/// When a character overflows the current row, the algorithm first tries the
+/// last Unicode line-break opportunity on that row. If none exists (for
+/// example, in a very long word), it falls back to a hard wrap at the overflow
+/// position. With `terminal_width == 0`, wrapping is disabled (a single row).
+pub fn char_cell_line_row_starts(
+    line_breaks: &[bool],
+    char_widths: &[u8],
+    terminal_width: u16,
+) -> Vec<usize> {
+    let mut starts = Vec::new();
+    char_cell_line_row_starts_into(line_breaks, char_widths, terminal_width, &mut starts);
+    starts
+}
+
+fn char_cell_line_row_starts_into(
+    line_breaks: &[bool],
+    char_widths: &[u8],
+    terminal_width: u16,
+    starts: &mut Vec<usize>,
+) {
+    debug_assert_eq!(line_breaks.len(), char_widths.len() + 1);
     let w = terminal_width as usize;
-    let mut starts = vec![0usize];
+    starts.clear();
+    starts.push(0);
     if w == 0 {
-        return starts;
+        return;
     }
     let mut col = 0usize;
+    let mut row_start = 0usize;
+    let mut last_break: Option<usize> = None;
     for (i, &cw) in char_widths.iter().enumerate() {
+        if line_breaks[i] && i > row_start {
+            last_break = Some(i);
+        }
         let cw = cw as usize;
         if cw > 0 && col > 0 && col + cw > w {
-            starts.push(i);
-            col = 0;
+            if let Some(new_row_start) = last_break {
+                starts.push(new_row_start);
+                row_start = new_row_start;
+                col = char_widths[new_row_start..i]
+                    .iter()
+                    .map(|&w| w as usize)
+                    .sum();
+                last_break = None;
+                // If the current character still doesn't fit after the line
+                // break (word longer than terminal width), hard-wrap here.
+                if col > 0 && col + cw > w {
+                    starts.push(i);
+                    row_start = i;
+                    col = 0;
+                }
+            } else {
+                // No line-break opportunity on the current row: hard wrap.
+                starts.push(i);
+                row_start = i;
+                col = 0;
+            }
         }
         col += cw;
     }
-    starts
 }
 
 /// The `(row_within_line, display_col)` of the gap before char `char_in_line`
 /// (or the end of the line when `char_in_line == char_widths.len()`), using the
-/// same width-aware wrapping as [`char_cell_line_row_starts`]. A cursor at the
-/// end of a row that exactly fills the width wraps to the start of the next row.
+/// same Unicode-aware wrapping as [`char_cell_line_row_starts`]. A cursor
+/// at the end of a row that exactly fills the width wraps to the start of the
+/// next row.
+#[cfg(test)]
 pub fn char_cell_line_gap_position(
+    line_breaks: &[bool],
     char_widths: &[u8],
     terminal_width: u16,
     char_in_line: usize,
 ) -> (u32, u16) {
     let w = terminal_width as usize;
     let n = char_in_line.min(char_widths.len());
-    let mut row: u32 = 0;
-    let mut col: usize = 0;
-    for &cw in char_widths.iter().take(n) {
-        let cw = cw as usize;
-        if cw > 0 && w > 0 && col > 0 && col + cw > w {
-            row += 1;
-            col = 0;
-        }
-        col += cw;
+    // Derive row boundaries from the shared wrapping algorithm so that cursor
+    // positions always agree with the rendered row layout.
+    let row_starts = char_cell_line_row_starts(line_breaks, char_widths, terminal_width);
+    // The gap before char `n` sits on the last row whose start is <= n.
+    let row_within_line = row_starts.partition_point(|&s| s <= n).saturating_sub(1);
+    let row_start = row_starts[row_within_line];
+    let col: usize = char_widths[row_start..n]
+        .iter()
+        .map(|&cw| cw as usize)
+        .sum();
+    // Special case: cursor at the end of content on a row that exactly fills
+    // the terminal width wraps to the phantom start of the next row, matching
+    // plain monospace terminal behavior.
+    if char_in_line >= char_widths.len() && w > 0 && col == w {
+        return ((row_within_line + 1) as u32, 0);
     }
-    if char_in_line < char_widths.len() {
-        // The cursor sits before char `char_in_line`; if that char would wrap,
-        // the cursor is at the start of the next row.
-        let cw = char_widths[char_in_line] as usize;
-        if cw > 0 && w > 0 && col > 0 && col + cw > w {
-            row += 1;
-            col = 0;
-        }
-    } else if w > 0 && col == w {
-        // End-of-line cursor on a row that exactly fills the width wraps to the
-        // next row's start (matches plain monospace terminal behavior).
-        row += 1;
-        col = 0;
-    }
-    (row, col as u16)
+    (row_within_line as u32, col as u16)
 }
 
 /// The number of visual rows occupied by a single logical line (always >= 1).
-fn char_cell_line_rows(char_widths: &[u8], terminal_width: u16) -> u32 {
-    char_cell_line_row_starts(char_widths, terminal_width).len() as u32
+#[cfg(test)]
+fn char_cell_line_rows(line_breaks: &[bool], char_widths: &[u8], terminal_width: u16) -> u32 {
+    char_cell_line_row_starts(line_breaks, char_widths, terminal_width).len() as u32
 }
 
 /// The `\n`-free slice of per-char display widths for logical line `i`, given
 /// the line-start indices and the full per-char width buffer.
 pub(crate) fn char_cell_logical_line<'a>(
-    line_starts: &[usize],
+    line_starts: &[CharOffset],
     char_widths: &'a [u8],
     i: usize,
 ) -> &'a [u8] {
-    let start = line_starts[i].min(char_widths.len());
+    let start = line_starts[i].as_usize().min(char_widths.len());
     // The next line starts just after this line's '\n'; exclude that newline.
     let end = line_starts
         .get(i + 1)
-        .map(|&next| next.saturating_sub(1))
+        .map(|&next| next.as_usize().saturating_sub(1))
         .unwrap_or(char_widths.len())
         .min(char_widths.len());
     &char_widths[start..end.max(start)]
 }
 
+/// The slice of gap-indexed Unicode line-break opportunities for logical line
+/// `i`, including the gap at the end of the line.
+pub(crate) fn char_cell_logical_line_breaks<'a>(
+    line_starts: &[CharOffset],
+    line_breaks: &'a [bool],
+    i: usize,
+) -> &'a [bool] {
+    let char_len = line_breaks.len().saturating_sub(1);
+    let start = line_starts[i].as_usize().min(char_len);
+    // The next line starts just after this line's '\n'; exclude that newline.
+    let end = line_starts
+        .get(i + 1)
+        .map(|&next| next.as_usize().saturating_sub(1))
+        .unwrap_or(char_len)
+        .min(char_len)
+        .max(start);
+    &line_breaks[start..=end]
+}
+
 /// Returns the total number of visual rows across all logical lines.
 /// Used by [`RenderState::max_line`] in `CharCell` mode.
+#[cfg(test)]
 pub(crate) fn char_cell_max_line(
-    line_starts: &[usize],
+    line_starts: &[CharOffset],
+    line_breaks: &[bool],
     char_widths: &[u8],
     terminal_width: u16,
 ) -> LineCount {
@@ -5526,7 +5854,8 @@ pub(crate) fn char_cell_max_line(
     let mut total: usize = 0;
     for i in 0..line_starts.len() {
         let line = char_cell_logical_line(line_starts, char_widths, i);
-        total += char_cell_line_rows(line, terminal_width) as usize;
+        let line_breaks = char_cell_logical_line_breaks(line_starts, line_breaks, i);
+        total += char_cell_line_rows(line_breaks, line, terminal_width) as usize;
     }
     LineCount(total)
 }
@@ -5538,30 +5867,36 @@ pub(crate) fn char_cell_max_line(
 /// `cursor_offset - 1` here and re-add 1 to [`char_cell_softwrap_point_to_offset`]
 /// results to convert back to the buffer's 1-based [`CharOffset`]. Keeping both modes
 /// on the same contract is what lets `navigate_line` stay layout-mode-agnostic.
+#[cfg(test)]
 pub(crate) fn char_cell_offset_to_softwrap_point(
     offset: CharOffset,
-    line_starts: &[usize],
+    line_starts: &[CharOffset],
+    line_breaks: &[bool],
     char_widths: &[u8],
     terminal_width: u16,
 ) -> SoftWrapPoint {
-    let char_idx = offset.as_usize();
-
     // Find the logical line by binary-searching line_starts.
     let logical_line = line_starts
-        .partition_point(|&s| s <= char_idx)
+        .partition_point(|&start| start <= offset)
         .saturating_sub(1);
-    let line_start_char = line_starts.get(logical_line).copied().unwrap_or(0);
-    let char_in_line = char_idx.saturating_sub(line_start_char);
+    let line_start = line_starts
+        .get(logical_line)
+        .copied()
+        .unwrap_or_else(CharOffset::zero);
+    let char_in_line = offset.as_usize().saturating_sub(line_start.as_usize());
 
     // Count visual rows from all preceding logical lines.
     let mut preceding_rows: u32 = 0;
     for i in 0..logical_line {
         let line = char_cell_logical_line(line_starts, char_widths, i);
-        preceding_rows += char_cell_line_rows(line, terminal_width);
+        let line_breaks = char_cell_logical_line_breaks(line_starts, line_breaks, i);
+        preceding_rows += char_cell_line_rows(line_breaks, line, terminal_width);
     }
 
     let line = char_cell_logical_line(line_starts, char_widths, logical_line);
-    let (row_within_line, col) = char_cell_line_gap_position(line, terminal_width, char_in_line);
+    let line_breaks = char_cell_logical_line_breaks(line_starts, line_breaks, logical_line);
+    let (row_within_line, col) =
+        char_cell_line_gap_position(line_breaks, line, terminal_width, char_in_line);
     SoftWrapPoint::new(preceding_rows + row_within_line, ColumnUnit::Chars(col))
 }
 
@@ -5573,9 +5908,11 @@ pub(crate) fn char_cell_offset_to_softwrap_point(
 /// final line is bounded by the buffer length), so it never returns an offset
 /// past the end of the buffer even when the target column is beyond a shorter
 /// final line.
+#[cfg(test)]
 pub(crate) fn char_cell_softwrap_point_to_offset(
     point: SoftWrapPoint,
-    line_starts: &[usize],
+    line_starts: &[CharOffset],
+    line_breaks: &[bool],
     char_widths: &[u8],
     terminal_width: u16,
 ) -> CharOffset {
@@ -5591,12 +5928,18 @@ pub(crate) fn char_cell_softwrap_point_to_offset(
     if line_starts.is_empty() {
         return CharOffset::from(0);
     }
+    if target_row
+        >= char_cell_max_line(line_starts, line_breaks, char_widths, terminal_width).as_u32()
+    {
+        return CharOffset::from(char_widths.len());
+    }
 
     let mut acc_rows: u32 = 0;
     for i in 0..line_starts.len() {
         let line_start = line_starts[i];
         let line = char_cell_logical_line(line_starts, char_widths, i);
-        let row_starts = char_cell_line_row_starts(line, terminal_width);
+        let line_breaks = char_cell_logical_line_breaks(line_starts, line_breaks, i);
+        let row_starts = char_cell_line_row_starts(line_breaks, line, terminal_width);
         let line_rows = row_starts.len() as u32;
         let is_last = i + 1 == line_starts.len();
 
@@ -5624,7 +5967,7 @@ pub(crate) fn char_cell_softwrap_point_to_offset(
                 col += cw;
                 idx += 1;
             }
-            return CharOffset::from(line_start + idx);
+            return line_start + idx;
         }
 
         acc_rows += line_rows;
@@ -5632,5 +5975,5 @@ pub(crate) fn char_cell_softwrap_point_to_offset(
 
     // Unreachable given the `is_last` branch always returns; fall back to the
     // start of the last logical line.
-    CharOffset::from(*line_starts.last().unwrap_or(&0))
+    line_starts.last().copied().unwrap_or_else(CharOffset::zero)
 }

--- a/crates/editor/src/render/model/mod_tests.rs
+++ b/crates/editor/src/render/model/mod_tests.rs
@@ -1477,88 +1477,139 @@ fn test_first_hidden_section_line_range_none_without_hidden_sections() {
 // ─────────────────────────────────────────────────────────────────────────────
 
 mod char_cell {
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
     use string_offset::CharOffset;
 
     use crate::render::model::{
-        ColumnUnit, LineCount, SoftWrapPoint, char_cell_display_widths, char_cell_line_row_starts,
-        char_cell_max_line, char_cell_offset_to_softwrap_point, char_cell_softwrap_point_to_offset,
+        CharCellState, ColumnUnit, LineCount, SoftWrapPoint, char_cell_display_widths,
+        char_cell_line_break_opportunities, char_cell_line_row_starts, char_cell_max_line,
+        char_cell_offset_to_softwrap_point, char_cell_softwrap_point_to_offset,
     };
 
-    /// Build the `(line_starts, char_widths)` pair from a text string (mirrors
-    /// `CharCellState::update_text` logic) so tests can construct the
-    /// char-cell layout inputs without a full `RenderState`. `char_widths` holds
-    /// the per-char display width (the derived data the layout actually needs).
-    fn line_starts_for(text: &str) -> (Vec<usize>, Vec<u8>) {
+    /// Build the `(line_starts, line_breaks, char_widths)` triple from a text
+    /// string (mirrors `CharCellState::update_text` logic) so tests can
+    /// construct the char-cell layout inputs without a full `RenderState`.
+    fn line_starts_for(text: &str) -> (Vec<CharOffset>, Vec<bool>, Vec<u8>) {
         let char_widths = char_cell_display_widths(text);
-        let mut starts = vec![0_usize];
+        let mut starts = vec![CharOffset::zero()];
         for (i, ch) in text.chars().enumerate() {
             if ch == '\n' {
-                starts.push(i + 1);
+                starts.push(CharOffset::from(i + 1));
             }
         }
-        (starts, char_widths)
+        (
+            starts,
+            char_cell_line_break_opportunities(text),
+            char_widths,
+        )
     }
 
     #[test]
     fn max_line_empty() {
-        let (starts, widths) = line_starts_for("");
+        let (starts, line_breaks, widths) = line_starts_for("");
         // Empty content → 1 visual row.
-        assert_eq!(char_cell_max_line(&starts, &widths, 80), LineCount(1));
+        assert_eq!(
+            char_cell_max_line(&starts, &line_breaks, &widths, 80),
+            LineCount(1)
+        );
     }
 
     #[test]
     fn max_line_single_short_line() {
-        let (starts, widths) = line_starts_for("hello");
-        assert_eq!(char_cell_max_line(&starts, &widths, 80), LineCount(1));
+        let (starts, line_breaks, widths) = line_starts_for("hello");
+        assert_eq!(
+            char_cell_max_line(&starts, &line_breaks, &widths, 80),
+            LineCount(1)
+        );
     }
 
     #[test]
     fn max_line_single_wrapping_line() {
-        // 10 chars, width 4 → ceil(10/4) = 3 rows.
-        let (starts, widths) = line_starts_for("0123456789");
-        assert_eq!(char_cell_max_line(&starts, &widths, 4), LineCount(3));
+        // 10 chars, width 4 → ceil(10/4) = 3 rows (no spaces → hard wrap).
+        let (starts, line_breaks, widths) = line_starts_for("0123456789");
+        assert_eq!(
+            char_cell_max_line(&starts, &line_breaks, &widths, 4),
+            LineCount(3)
+        );
     }
 
     #[test]
     fn max_line_two_logical_lines() {
         // "abc\ndef": line0 = 3 chars (1 row at width 10), line1 = 3 chars (1 row) → 2.
-        let (starts, widths) = line_starts_for("abc\ndef");
-        assert_eq!(char_cell_max_line(&starts, &widths, 10), LineCount(2));
+        let (starts, line_breaks, widths) = line_starts_for("abc\ndef");
+        assert_eq!(
+            char_cell_max_line(&starts, &line_breaks, &widths, 10),
+            LineCount(2)
+        );
     }
 
     #[test]
     fn max_line_empty_logical_line() {
         // "\n": two logical lines, both empty → 2 rows.
-        let (starts, widths) = line_starts_for("\n");
-        assert_eq!(char_cell_max_line(&starts, &widths, 80), LineCount(2));
+        let (starts, line_breaks, widths) = line_starts_for("\n");
+        assert_eq!(
+            char_cell_max_line(&starts, &line_breaks, &widths, 80),
+            LineCount(2)
+        );
     }
 
     #[test]
     fn offset_to_softwrap_single_line_short() {
         let text = "hello";
-        let (starts, widths) = line_starts_for(text);
+        let (starts, line_breaks, widths) = line_starts_for(text);
         // The softwrap API is 0-based, so char 'h' = index 0, 'e' = 1, ...
         // 'h' should be at (row=0, col=0).
-        let pt = char_cell_offset_to_softwrap_point(CharOffset::from(0), &starts, &widths, 80);
+        let pt = char_cell_offset_to_softwrap_point(
+            CharOffset::from(0),
+            &starts,
+            &line_breaks,
+            &widths,
+            80,
+        );
         assert_eq!(pt, SoftWrapPoint::new(0, ColumnUnit::Chars(0)));
         // 'l' (3rd char, index 2) at col 2.
-        let pt = char_cell_offset_to_softwrap_point(CharOffset::from(2), &starts, &widths, 80);
+        let pt = char_cell_offset_to_softwrap_point(
+            CharOffset::from(2),
+            &starts,
+            &line_breaks,
+            &widths,
+            80,
+        );
         assert_eq!(pt, SoftWrapPoint::new(0, ColumnUnit::Chars(2)));
     }
 
     #[test]
     fn offset_to_softwrap_wrapping_line() {
-        // width=4, "0123456789" — char index 4 should be on row 1, col 0.
+        // width=4, "0123456789" — no spaces, so hard wrap: char index 4 on row 1.
         let text = "0123456789";
-        let (starts, widths) = line_starts_for(text);
-        // index 4 → row 4/4=1, col 0.
-        let pt = char_cell_offset_to_softwrap_point(CharOffset::from(4), &starts, &widths, 4);
+        let (starts, line_breaks, widths) = line_starts_for(text);
+        // index 4 → row 1, col 0.
+        let pt = char_cell_offset_to_softwrap_point(
+            CharOffset::from(4),
+            &starts,
+            &line_breaks,
+            &widths,
+            4,
+        );
         assert_eq!(pt, SoftWrapPoint::new(1, ColumnUnit::Chars(0)));
-        // index 7 → row 7/4=1, col 7%4=3.
-        let pt = char_cell_offset_to_softwrap_point(CharOffset::from(7), &starts, &widths, 4);
+        // index 7 → row 1, col 3.
+        let pt = char_cell_offset_to_softwrap_point(
+            CharOffset::from(7),
+            &starts,
+            &line_breaks,
+            &widths,
+            4,
+        );
         assert_eq!(pt, SoftWrapPoint::new(1, ColumnUnit::Chars(3)));
-        // index 9 → row 9/4=2, col 9%4=1.
-        let pt = char_cell_offset_to_softwrap_point(CharOffset::from(9), &starts, &widths, 4);
+        // index 9 → row 2, col 1.
+        let pt = char_cell_offset_to_softwrap_point(
+            CharOffset::from(9),
+            &starts,
+            &line_breaks,
+            &widths,
+            4,
+        );
         assert_eq!(pt, SoftWrapPoint::new(2, ColumnUnit::Chars(1)));
     }
 
@@ -1567,41 +1618,164 @@ mod char_cell {
         // "abc\ndef", width=10
         // 'a'=index0→(row0,col0), 'd'=index4→(row1,col0)
         let text = "abc\ndef";
-        let (starts, widths) = line_starts_for(text);
-        let pt_a = char_cell_offset_to_softwrap_point(CharOffset::from(0), &starts, &widths, 10);
+        let (starts, line_breaks, widths) = line_starts_for(text);
+        let pt_a = char_cell_offset_to_softwrap_point(
+            CharOffset::from(0),
+            &starts,
+            &line_breaks,
+            &widths,
+            10,
+        );
         assert_eq!(pt_a, SoftWrapPoint::new(0, ColumnUnit::Chars(0)));
         // 'd' = index 4 (after 'abc\n'). Logical line 1, offset_in_line=0.
-        let pt_d = char_cell_offset_to_softwrap_point(CharOffset::from(4), &starts, &widths, 10);
+        let pt_d = char_cell_offset_to_softwrap_point(
+            CharOffset::from(4),
+            &starts,
+            &line_breaks,
+            &widths,
+            10,
+        );
         assert_eq!(pt_d, SoftWrapPoint::new(1, ColumnUnit::Chars(0)));
+    }
+
+    #[test]
+    fn line_starts_use_character_offsets() {
+        // The second line begins after one multibyte character and a newline:
+        // character offset 2, not UTF-8 byte offset 4.
+        let (starts, line_breaks, widths) = line_starts_for("你\n好");
+        assert_eq!(starts, vec![CharOffset::zero(), CharOffset::from(2)]);
+        let point = char_cell_offset_to_softwrap_point(
+            CharOffset::from(2),
+            &starts,
+            &line_breaks,
+            &widths,
+            10,
+        );
+        assert_eq!(point, SoftWrapPoint::new(1, ColumnUnit::Chars(0)));
+    }
+
+    #[test]
+    fn cached_state_matches_uncached_reference_for_randomized_unicode_text() {
+        let alphabet = ['a', ' ', '-', '\n', '你', '好', 'é', '\u{301}', '🚀', '_'];
+        let mut rng = StdRng::seed_from_u64(0x5eed);
+        for _ in 0..100 {
+            let len = rng.gen_range(0..100);
+            let text: String = (0..len)
+                .map(|_| alphabet[rng.gen_range(0..alphabet.len())])
+                .collect();
+            let width = rng.gen_range(0..20);
+            let state = CharCellState::new(width, None);
+            state.update_text(&text);
+            let (starts, line_breaks, widths) = line_starts_for(&text);
+            assert_eq!(
+                state.max_line(),
+                char_cell_max_line(&starts, &line_breaks, &widths, width)
+            );
+
+            for index in 0..=widths.len() {
+                let offset = CharOffset::from(index);
+                let expected_point = char_cell_offset_to_softwrap_point(
+                    offset,
+                    &starts,
+                    &line_breaks,
+                    &widths,
+                    width,
+                );
+                assert_eq!(
+                    state.offset_to_softwrap_point(offset),
+                    expected_point,
+                    "point mismatch for {text:?} at {index}, width {width}"
+                );
+                assert_eq!(
+                    state.softwrap_point_to_offset(expected_point),
+                    char_cell_softwrap_point_to_offset(
+                        expected_point,
+                        &starts,
+                        &line_breaks,
+                        &widths,
+                        width,
+                    ),
+                    "inverse mismatch for {text:?} at {index}, width {width}"
+                );
+
+                let line_index = starts
+                    .partition_point(|&start| start <= offset)
+                    .saturating_sub(1);
+                let line_start = starts[line_index].as_usize();
+                let line_end = starts
+                    .get(line_index + 1)
+                    .map(|next| next.as_usize().saturating_sub(1))
+                    .unwrap_or(widths.len());
+                let line_widths = &widths[line_start..line_end];
+                let line_breaks = &line_breaks[line_start..=line_end];
+                let row_starts = char_cell_line_row_starts(line_breaks, line_widths, width);
+                let char_in_line = index.min(line_end).saturating_sub(line_start);
+                let row = row_starts
+                    .partition_point(|&start| start <= char_in_line)
+                    .saturating_sub(1);
+                let row_start = row_starts[row];
+                let row_end = row_starts
+                    .get(row + 1)
+                    .copied()
+                    .unwrap_or(line_widths.len());
+                assert_eq!(
+                    state.visual_row_char_range(offset),
+                    CharOffset::range((line_start + row_start)..(line_start + row_end)),
+                    "row range mismatch for {text:?} at {index}, width {width}"
+                );
+            }
+        }
     }
 
     #[test]
     fn softwrap_roundtrip_single_line() {
         let text = "hello world";
-        let (starts, widths) = line_starts_for(text);
+        let (starts, line_breaks, widths) = line_starts_for(text);
         for i in 0..=(widths.len() as u64) {
             let offset = CharOffset::from(i as usize);
-            let pt = char_cell_offset_to_softwrap_point(offset, &starts, &widths, 80);
+            let pt = char_cell_offset_to_softwrap_point(offset, &starts, &line_breaks, &widths, 80);
             // Verify the column is ColumnUnit::Chars
             assert!(
                 matches!(pt.column(), ColumnUnit::Chars(_)),
                 "index {i}: expected Chars variant"
             );
-            let back = char_cell_softwrap_point_to_offset(pt, &starts, &widths, 80);
+            let back = char_cell_softwrap_point_to_offset(pt, &starts, &line_breaks, &widths, 80);
             assert_eq!(back, offset, "round-trip failed at index {i}");
         }
     }
 
     #[test]
     fn softwrap_roundtrip_wrapping() {
-        let text = "abcdefghij"; // 10 chars
-        let (starts, widths) = line_starts_for(text);
+        let text = "abcdefghij"; // 10 chars, no spaces → hard wrap
+        let (starts, line_breaks, widths) = line_starts_for(text);
         for i in 0..10 {
             let offset = CharOffset::from(i);
-            let pt = char_cell_offset_to_softwrap_point(offset, &starts, &widths, 4);
-            let back = char_cell_softwrap_point_to_offset(pt, &starts, &widths, 4);
+            let pt = char_cell_offset_to_softwrap_point(offset, &starts, &line_breaks, &widths, 4);
+            let back = char_cell_softwrap_point_to_offset(pt, &starts, &line_breaks, &widths, 4);
             assert_eq!(back, offset, "round-trip failed at index {i} with width=4");
         }
+    }
+
+    #[test]
+    fn exact_width_eof_phantom_row_round_trips() {
+        let text = "abcd";
+        let width = 4;
+        let eof = CharOffset::from(text.len());
+        let state = CharCellState::new(width, None);
+        state.update_text(text);
+        let point = state.offset_to_softwrap_point(eof);
+        assert_eq!(point, SoftWrapPoint::new(1, ColumnUnit::Chars(0)));
+        assert_eq!(state.softwrap_point_to_offset(point), eof);
+        assert_eq!(
+            state.softwrap_point_to_offset(SoftWrapPoint::new(100, ColumnUnit::Chars(3),)),
+            eof
+        );
+
+        let (starts, line_breaks, widths) = line_starts_for(text);
+        assert_eq!(
+            char_cell_softwrap_point_to_offset(point, &starts, &line_breaks, &widths, width,),
+            eof
+        );
     }
 
     #[test]
@@ -1611,10 +1785,10 @@ mod char_cell {
         // but the final line only has 1 char — the result must clamp to the end
         // of the buffer (offset 6 = total chars), never past it.
         let text = "abcd\nx";
-        let (starts, widths) = line_starts_for(text);
+        let (starts, line_breaks, widths) = line_starts_for(text);
         assert_eq!(widths.len(), 6);
         let pt = SoftWrapPoint::new(1, ColumnUnit::Chars(3));
-        let offset = char_cell_softwrap_point_to_offset(pt, &starts, &widths, 80);
+        let offset = char_cell_softwrap_point_to_offset(pt, &starts, &line_breaks, &widths, 80);
         // Final line starts at char index 5 ("x"); clamped end is 5 + 1 = 6.
         assert_eq!(offset, CharOffset::from(6));
         assert!(
@@ -1627,8 +1801,14 @@ mod char_cell {
     #[test]
     fn softwrap_returns_chars_variant_not_pixels() {
         let text = "abc";
-        let (starts, widths) = line_starts_for(text);
-        let pt = char_cell_offset_to_softwrap_point(CharOffset::from(0), &starts, &widths, 80);
+        let (starts, line_breaks, widths) = line_starts_for(text);
+        let pt = char_cell_offset_to_softwrap_point(
+            CharOffset::from(0),
+            &starts,
+            &line_breaks,
+            &widths,
+            80,
+        );
         assert!(
             matches!(pt.column(), ColumnUnit::Chars(_)),
             "CharCell path must return ColumnUnit::Chars, got {:?}",
@@ -1639,9 +1819,15 @@ mod char_cell {
     #[test]
     fn softwrap_point_zero_offset_is_row0_col0() {
         let text = "abc";
-        let (starts, widths) = line_starts_for(text);
+        let (starts, line_breaks, widths) = line_starts_for(text);
         // Index 0 = first char → (0, 0).
-        let pt = char_cell_offset_to_softwrap_point(CharOffset::from(0), &starts, &widths, 80);
+        let pt = char_cell_offset_to_softwrap_point(
+            CharOffset::from(0),
+            &starts,
+            &line_breaks,
+            &widths,
+            80,
+        );
         assert_eq!(pt.row(), 0);
         assert_eq!(pt.column(), ColumnUnit::Chars(0));
     }
@@ -1664,11 +1850,21 @@ mod char_cell {
 
     #[test]
     fn grapheme_wraps_as_one_display_unit() {
-        let (starts, widths) = line_starts_for("abc\u{2328}\u{fe0f}");
-        let before_emoji =
-            char_cell_offset_to_softwrap_point(CharOffset::from(3), &starts, &widths, 4);
-        let after_emoji =
-            char_cell_offset_to_softwrap_point(CharOffset::from(5), &starts, &widths, 4);
+        let (starts, line_breaks, widths) = line_starts_for("abc\u{2328}\u{fe0f}");
+        let before_emoji = char_cell_offset_to_softwrap_point(
+            CharOffset::from(3),
+            &starts,
+            &line_breaks,
+            &widths,
+            4,
+        );
+        let after_emoji = char_cell_offset_to_softwrap_point(
+            CharOffset::from(5),
+            &starts,
+            &line_breaks,
+            &widths,
+            4,
+        );
         assert_eq!(before_emoji, SoftWrapPoint::new(1, ColumnUnit::Chars(0)));
         assert_eq!(after_emoji, SoftWrapPoint::new(1, ColumnUnit::Chars(2)));
     }
@@ -1677,8 +1873,14 @@ mod char_cell {
     fn wide_char_occupies_two_columns() {
         // "你好world": 你(2) 好(2) w o r l d. Index 2 ('w') sits at display col 4.
         let text = "你好world";
-        let (starts, widths) = line_starts_for(text);
-        let pt = char_cell_offset_to_softwrap_point(CharOffset::from(2), &starts, &widths, 80);
+        let (starts, line_breaks, widths) = line_starts_for(text);
+        let pt = char_cell_offset_to_softwrap_point(
+            CharOffset::from(2),
+            &starts,
+            &line_breaks,
+            &widths,
+            80,
+        );
         assert_eq!(pt, SoftWrapPoint::new(0, ColumnUnit::Chars(4)));
     }
 
@@ -1687,16 +1889,25 @@ mod char_cell {
         // "你好你" at width 4: 你好 fill the first row (4 cols); the third 你
         // doesn't fit so it wraps to row 1.
         let text = "你好你";
-        let (starts, widths) = line_starts_for(text);
-        assert_eq!(char_cell_max_line(&starts, &widths, 4), LineCount(2));
+        let (starts, line_breaks, widths) = line_starts_for(text);
+        assert_eq!(
+            char_cell_max_line(&starts, &line_breaks, &widths, 4),
+            LineCount(2)
+        );
         // Cursor before the third 你 (index 2) is at the start of row 1.
-        let pt = char_cell_offset_to_softwrap_point(CharOffset::from(2), &starts, &widths, 4);
+        let pt = char_cell_offset_to_softwrap_point(
+            CharOffset::from(2),
+            &starts,
+            &line_breaks,
+            &widths,
+            4,
+        );
         assert_eq!(pt, SoftWrapPoint::new(1, ColumnUnit::Chars(0)));
         // Round-trips at each char boundary.
         for i in 0..=widths.len() {
             let offset = CharOffset::from(i);
-            let pt = char_cell_offset_to_softwrap_point(offset, &starts, &widths, 4);
-            let back = char_cell_softwrap_point_to_offset(pt, &starts, &widths, 4);
+            let pt = char_cell_offset_to_softwrap_point(offset, &starts, &line_breaks, &widths, 4);
+            let back = char_cell_softwrap_point_to_offset(pt, &starts, &line_breaks, &widths, 4);
             assert_eq!(back, offset, "wide-char round-trip failed at index {i}");
         }
     }
@@ -1706,35 +1917,140 @@ mod char_cell {
         // "a\u{0301}b": 'a' + combining acute (0 width) + 'b'. The combining
         // mark shares 'a's column, so 'b' sits at col 1 (not 2).
         let text = "a\u{0301}b";
-        let (starts, widths) = line_starts_for(text);
+        let (starts, line_breaks, widths) = line_starts_for(text);
         // Gap before 'b' (index 2) shares the accent's column.
-        let pt = char_cell_offset_to_softwrap_point(CharOffset::from(2), &starts, &widths, 80);
+        let pt = char_cell_offset_to_softwrap_point(
+            CharOffset::from(2),
+            &starts,
+            &line_breaks,
+            &widths,
+            80,
+        );
         assert_eq!(pt, SoftWrapPoint::new(0, ColumnUnit::Chars(1)));
         // End of line (index 3, after 'b') is at col 2.
-        let pt = char_cell_offset_to_softwrap_point(CharOffset::from(3), &starts, &widths, 80);
+        let pt = char_cell_offset_to_softwrap_point(
+            CharOffset::from(3),
+            &starts,
+            &line_breaks,
+            &widths,
+            80,
+        );
         assert_eq!(pt, SoftWrapPoint::new(0, ColumnUnit::Chars(2)));
     }
 
     #[test]
     fn line_row_starts_breaks_on_wide_chars() {
         // width 4, "你好你好": two wide chars per row → break before index 2.
-        let widths = char_cell_display_widths("你好你好");
-        assert_eq!(char_cell_line_row_starts(&widths, 4), vec![0, 2]);
+        let text = "你好你好";
+        let (_, line_breaks, widths) = line_starts_for(text);
+        assert_eq!(
+            char_cell_line_row_starts(&line_breaks, &widths, 4),
+            vec![0, 2]
+        );
         // width 0 disables wrapping.
-        assert_eq!(char_cell_line_row_starts(&widths, 0), vec![0]);
+        assert_eq!(char_cell_line_row_starts(&line_breaks, &widths, 0), vec![0]);
+    }
+
+    // ── Word-boundary wrap tests ───────────────────────────────────────────────
+
+    #[test]
+    fn word_wrap_breaks_at_space() {
+        // "hello world" at width 8: "hello " on row 0, "world" on row 1.
+        // The space (index 5) is the last space on row 0; new row starts at index 6.
+        let (_, line_breaks, widths) = line_starts_for("hello world");
+        let row_starts = char_cell_line_row_starts(&line_breaks, &widths, 8);
+        assert_eq!(row_starts, vec![0, 6], "should break before 'world'");
+    }
+
+    #[test]
+    fn word_wrap_preserves_words() {
+        // "hello world is great" at width 10:
+        // row 0: "hello " (6 chars, break before "world")
+        // row 1: "world is " (9 chars, break before "great")
+        // row 2: "great"
+        let (_, line_breaks, widths) = line_starts_for("hello world is great");
+        let row_starts = char_cell_line_row_starts(&line_breaks, &widths, 10);
+        // Row 0: indices 0..6, row 1: indices 6..15, row 2: indices 15..20
+        assert_eq!(row_starts, vec![0, 6, 15]);
+    }
+
+    #[test]
+    fn word_wrap_hard_wraps_long_word() {
+        // A word longer than the terminal width must be hard-wrapped.
+        let (_, line_breaks, widths) = line_starts_for("superlongword");
+        // At width 10: first 10 chars on row 0, remaining 3 on row 1.
+        let row_starts = char_cell_line_row_starts(&line_breaks, &widths, 10);
+        assert_eq!(row_starts, vec![0, 10]);
+    }
+
+    #[test]
+    fn word_wrap_uses_unicode_line_breaks() {
+        // Unicode line breaking permits a break after a hyphen even without
+        // whitespace, matching the GUI's WordOrGlyph wrapping behavior.
+        let (_, line_breaks, widths) = line_starts_for("hello-world");
+        assert_eq!(
+            char_cell_line_row_starts(&line_breaks, &widths, 8),
+            vec![0, 6]
+        );
+    }
+
+    #[test]
+    fn word_wrap_roundtrip() {
+        // Round-trip: every offset maps to a softwrap point and back.
+        let text = "hello world is great";
+        let (starts, line_breaks, widths) = line_starts_for(text);
+        for i in 0..=widths.len() {
+            let offset = CharOffset::from(i);
+            let pt = char_cell_offset_to_softwrap_point(offset, &starts, &line_breaks, &widths, 10);
+            let back = char_cell_softwrap_point_to_offset(pt, &starts, &line_breaks, &widths, 10);
+            assert_eq!(back, offset, "word-wrap round-trip failed at index {i}");
+        }
     }
 }
 
 mod char_cell_scroll {
     use string_offset::CharOffset;
 
-    use crate::render::model::CharCellState;
+    use crate::render::model::{CharCellState, ColumnUnit, LineCount, SoftWrapPoint};
 
     /// A 4-column state with five one-row logical lines ("l0".."l4").
     fn five_row_state() -> CharCellState {
         let state = CharCellState::new(4, None);
         state.update_text("l0\nl1\nl2\nl3\nl4");
         state
+    }
+
+    #[test]
+    fn text_index_rebuilds_as_one_valid_snapshot() {
+        let state = CharCellState::new(10, None);
+        state.update_text("你\nab");
+        let index = state.text_index.borrow();
+        assert_eq!(
+            index.line_starts,
+            vec![CharOffset::zero(), CharOffset::from(2)]
+        );
+        assert_eq!(index.char_widths, vec![2, 0, 1, 1]);
+        assert_eq!(index.line_breaks.len(), index.char_widths.len() + 1);
+        assert_eq!(index.line_visual_row_starts, vec![0, 1, 2]);
+        assert_eq!(
+            index.visual_row_char_starts,
+            vec![CharOffset::zero(), CharOffset::from(2)]
+        );
+    }
+
+    #[test]
+    fn terminal_width_rebuilds_only_visual_rows() {
+        let state = CharCellState::new(10, None);
+        state.update_text("abcdef");
+        assert_eq!(state.max_line(), LineCount(1));
+        state.set_terminal_width(4);
+        assert_eq!(state.max_line(), LineCount(2));
+        assert_eq!(
+            state.offset_to_softwrap_point(CharOffset::from(4)),
+            SoftWrapPoint::new(1, ColumnUnit::Chars(0))
+        );
+        state.set_terminal_width(10);
+        assert_eq!(state.max_line(), LineCount(1));
     }
 
     #[test]

--- a/crates/warp_tui/src/editor_element_tests.rs
+++ b/crates/warp_tui/src/editor_element_tests.rs
@@ -55,11 +55,12 @@ fn text_overrides_follow_soft_wrapped_character_ranges() {
             };
             let element = TuiEditorElement::new(&model, ctx).with_styles(styles);
             let buffer = render_buffer(ctx, element, 4, 10);
-
+            // Unicode line breaking wraps after '/', so the styled "/plan"
+            // range spans "/" on row 0 and "plan" on row 1.
             assert_eq!(buffer[(0, 0)].fg, Color::Blue);
-            assert_eq!(buffer[(3, 0)].fg, Color::Blue);
             assert_eq!(buffer[(0, 1)].fg, Color::Blue);
-            assert_ne!(buffer[(1, 1)].fg, Color::Blue);
+            assert_eq!(buffer[(3, 1)].fg, Color::Blue);
+            assert_ne!(buffer[(0, 2)].fg, Color::Blue);
         });
     });
 }


### PR DESCRIPTION
## Description

Adds Unicode-aware word wrapping to the TUI editor while keeping rendering, cursor navigation, selections, scrolling, and hit testing on the same char-cell row geometry.

- Wraps at Unicode line-break opportunities, including spaces, hyphens, and CJK boundaries, with hard wrapping for words wider than the terminal.
- Consolidates line starts, character widths, line-break opportunities, and visual-row caches into one coherent `CharCellTextIndex` snapshot.
- Caches visual-row prefixes and starts so `max_line` and coordinate conversions no longer rescan preceding lines.
- Precomputes and caches temporary diff-block wrapping metadata, stably orders overlays, and normalizes hidden ranges for linear display projection.
- Adds allocation-instrumented Criterion coverage for rebuilds, coordinate conversion, resize, display projection, Unicode text, long lines, and 10k/100k-line inputs.

A per-logical-line `SumTree` prototype was evaluated against the flat index. Although feasible, it approximately doubled rebuild/resize cost and retained heap on the 100k-line dataset. The retained flat-index design with global row caches was faster for both queries and resizing while preserving contiguous storage.

## Linked Issue

N/A

## Testing

- `cargo test -p warp_editor char_cell --no-fail-fast` — 38 passed
- `cargo nextest run -p warp_editor --no-fail-fast` — 470 passed
- `cargo clippy -p warp_editor --all-targets --features test-util --no-deps -- -D warnings`
- `cargo test -p warp_editor --doc`
- `cargo bench -p warp_editor --features test-util --bench char_cell_bench`
- Manually tested the TUI with `./script/run-tui`

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- [Conversation](https://staging.warp.dev/conversation/c4de8a80-09ba-4913-b4f9-2951c2ec1ff1)
- [Implementation plan and benchmark decision](https://staging.warp.dev/drive/notebook/mIm8QtqudFGcT6VZFhV9ZO)

CHANGELOG-IMPROVEMENT: The TUI editor now wraps text at Unicode word boundaries while preserving correct cursor and selection behavior.
