### PR TITLE
Remove OrchestrationViewerStreamer and OwnerOrchestrationAncestorStreamer flags

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -683,8 +683,6 @@ default = [
     "oz_handoff",
     "handoff_local_cloud",
     "run_agents_tool",
-    "orchestration_viewer_streamer",
-    "owner_orchestration_ancestor_streamer",
     "pending_user_query_indicator",
     "queue_slash_command",
     "queued_prompts_v2",
@@ -989,8 +987,6 @@ skill_arguments = []
 active_conversation_requires_interaction = []
 incremental_auto_reload = []
 run_agents_tool = []
-orchestration_viewer_streamer = []
-owner_orchestration_ancestor_streamer = []
 wait_for_events_parent_registration = []
 pending_user_query_indicator = []
 queue_slash_command = []

--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -8,7 +8,6 @@ use futures::channel::mpsc;
 use uuid::Uuid;
 use warp_cli::agent::Harness;
 use warp_core::features::FeatureFlag;
-use warp_errors::report_error;
 use warp_multi_agent_api as api;
 use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::{
@@ -43,8 +42,6 @@ const RESTORE_FETCH_PERMANENT_BACKOFF_STEPS: &[u64] = &[30];
 const SSE_DRAIN_INTERVAL_MS: u64 = 500;
 /// Cap killed-run tombstones while keeping normal sessions well below the limit.
 const MAX_KILLED_RUN_IDS: usize = 1024;
-/// Maximum number of explicit run IDs the server accepts on a `run_ids[]` SSE stream.
-const MAX_RUN_ID_STREAM_FILTER: usize = 100;
 /// Max child runs fetched per cold-start `?ancestor_run_id=` REST seed in
 /// viewer mode. Matches the legacy `OrchestrationViewerModel` poller's value
 /// (the server caps at 100 anyway).
@@ -323,13 +320,8 @@ pub enum OrchestrationEventStreamerEvent {
 enum DesiredSseFilter {
     /// Open (or keep) a stream with this filter.
     Filter(AgentEventFilter),
-    /// Nothing to watch yet (no watched run IDs); do not open a stream.
+    /// Nothing to watch yet; do not open a stream.
     NoFilter,
-    /// The conversation is a parent with more watched children than the
-    /// explicit `run_ids[]` stream allows and parent-family ancestor
-    /// streaming is unavailable. The payload is the watched-run-id total,
-    /// used only for diagnostics.
-    UnsupportedRunIdCount(usize),
 }
 
 impl OrchestrationEventStreamer {
@@ -612,8 +604,7 @@ impl OrchestrationEventStreamer {
 
     /// Completes the wait-time parent registration fetch. A non-empty
     /// `children` list confirms the conversation is an orchestrator: install
-    /// the children and reevaluate eligibility, which (with
-    /// `OwnerOrchestrationAncestorStreamer` on) opens the
+    /// the children and reevaluate eligibility, opening the
     /// `AncestorRunId { include_self: true }` stream that thereafter tracks
     /// all children dynamically. Empty children means it is not a parent; an
     /// error is a graceful no-op (the next wait re-checks).
@@ -642,11 +633,10 @@ impl OrchestrationEventStreamer {
             .map(|stream| stream.event_cursor)
             .unwrap_or(0);
         self.apply_task_children(conversation_id, &task, base_cursor);
-        // Mirror `register_watched_run_id`: also watch `self_run_id` so the
-        // parent's own inbox is delivered if `desired_sse_filter` falls back to
-        // `RunIds` (i.e. `OwnerOrchestrationAncestorStreamer` disabled, where
-        // the filter would otherwise watch only children). A no-op in the
-        // ancestor-stream path, which already covers self via `include_self`.
+        // Also watch `self_run_id` — a no-op on the ancestor-stream path
+        // (which covers self via `include_self`), but needed defensively
+        // for the no-self_run_id fallback where `RunIds` would otherwise
+        // watch only the children.
         self.ensure_self_run_id_watched(conversation_id, ctx);
         self.reevaluate_eligibility(conversation_id, ctx);
     }
@@ -1691,22 +1681,29 @@ impl OrchestrationEventStreamer {
         conversation_id: AIConversationId,
         ctx: &warpui::AppContext,
     ) -> DesiredSseFilter {
-        let is_parent = self.is_parent_agent_conversation(conversation_id, ctx);
-        if is_parent && FeatureFlag::OwnerOrchestrationAncestorStreamer.is_enabled() {
-            if let Some(self_run_id) = self.self_run_id(conversation_id, ctx) {
-                return DesiredSseFilter::Filter(AgentEventFilter::AncestorRunId {
+        if self.is_parent_agent_conversation(conversation_id, ctx) {
+            // A parent always has self_run_id by the time it has children
+            // (the server must assign the parent a run before any child can
+            // be created). Return NoFilter defensively if it's absent so
+            // `on_server_token_assigned` re-evaluates when the token arrives.
+            return match self.self_run_id(conversation_id, ctx) {
+                Some(self_run_id) => DesiredSseFilter::Filter(AgentEventFilter::AncestorRunId {
                     ancestor_run_id: self_run_id,
                     include_self: true,
-                });
-            }
+                }),
+                None => {
+                    log::warn!(
+                        "Parent conversation {conversation_id:?} has watched children \
+                         but no self_run_id; deferring SSE until token arrives"
+                    );
+                    DesiredSseFilter::NoFilter
+                }
+            };
         }
 
         let run_ids = self.run_ids_for_sse(conversation_id);
         if run_ids.is_empty() {
             return DesiredSseFilter::NoFilter;
-        }
-        if is_parent && run_ids.len() > MAX_RUN_ID_STREAM_FILTER {
-            return DesiredSseFilter::UnsupportedRunIdCount(run_ids.len());
         }
         DesiredSseFilter::Filter(AgentEventFilter::RunIds(run_ids))
     }
@@ -1892,19 +1889,6 @@ impl OrchestrationEventStreamer {
         let filter = match self.desired_sse_filter(conversation_id, ctx) {
             DesiredSseFilter::Filter(filter) => filter,
             DesiredSseFilter::NoFilter => return,
-            DesiredSseFilter::UnsupportedRunIdCount(count) => {
-                report_error!(
-                    "Owner-side SSE delivery blocked: watched run IDs exceed the explicit-run-id \
-                     limit and parent-family ancestor streaming is disabled; enable \
-                     OwnerOrchestrationAncestorStreamer to deliver events for large orchestrators",
-                    extra: {
-                        "conversation_id" => ?conversation_id,
-                        "watched_run_ids" => %count,
-                        "limit" => %MAX_RUN_ID_STREAM_FILTER
-                    }
-                );
-                return;
-            }
         };
 
         let cursor = self
@@ -1996,7 +1980,6 @@ impl OrchestrationEventStreamer {
             }
             // Nothing watchable tears down through the eligibility predicate.
             DesiredSseFilter::NoFilter => false,
-            DesiredSseFilter::UnsupportedRunIdCount(_) => true,
         }
     }
 

--- a/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer_tests.rs
@@ -1613,7 +1613,9 @@ fn reevaluate_eligibility_does_not_reconnect_when_watched_run_ids_unchanged() {
             OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
         });
 
-        // Open SSE (gen 0) with watched set == connected snapshot.
+        // Open SSE (gen 0) with an ancestor stream, which is what parents
+        // always use now. The filter is unchanged by a status transition,
+        // so reevaluate_eligibility must not reconnect.
         let (_, rx) = futures::channel::mpsc::unbounded::<SseStreamItem>();
         let consumer_id = warpui::EntityId::new();
         poller.update(&mut app, |me, _| {
@@ -1623,8 +1625,10 @@ fn reevaluate_eligibility_does_not_reconnect_when_watched_run_ids_unchanged() {
             stream.watched_run_ids.insert(child_run_id.to_string());
             stream.consumers.insert(consumer_id);
             let (abort_handle, _) = futures::future::AbortHandle::new_pair();
-            let connected_filter =
-                AgentEventFilter::RunIds(vec![own_run_id.to_string(), child_run_id.to_string()]);
+            let connected_filter = AgentEventFilter::AncestorRunId {
+                ancestor_run_id: own_run_id.to_string(),
+                include_self: true,
+            };
             stream.sse_connection = Some(SseConnectionState {
                 event_receiver: rx,
                 generation: 0,
@@ -1969,11 +1973,9 @@ fn sse_generation(
 
 #[test]
 fn parent_with_many_children_opens_one_ancestor_include_self_stream() {
-    // A parent with far more than the 100 explicit-run-id limit must open a
-    // single parent-family ancestor stream rather than a run-id vector.
+    // A parent always opens a single parent-family ancestor stream regardless
+    // of the number of watched children.
     App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(true);
-
         let history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
         let own_run_id = "550e8400-e29b-41d4-a716-446655440500";
@@ -2029,8 +2031,6 @@ fn registering_additional_child_does_not_reconnect_parent_family_stream() {
     // Once a parent-family ancestor stream is connected, registering more
     // children must not reconnect: the filter shape is unchanged.
     App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(true);
-
         let history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
         let own_run_id = "550e8400-e29b-41d4-a716-446655440501";
@@ -2091,10 +2091,8 @@ fn registering_additional_child_does_not_reconnect_parent_family_stream() {
 #[test]
 fn child_only_conversation_opens_self_run_id_filter() {
     // A child-only conversation keeps the explicit run-id stream watching
-    // only its own run_id, even when the owner-ancestor flag is enabled.
+    // only its own run_id (it is not a parent, so the ancestor filter doesn't apply).
     App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(true);
-
         let history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
         let own_run_id = "550e8400-e29b-41d4-a716-446655440502";
@@ -2137,127 +2135,10 @@ fn child_only_conversation_opens_self_run_id_filter() {
 }
 
 #[test]
-fn parent_over_run_id_limit_without_flag_does_not_open_stream() {
-    // With owner-ancestor streaming disabled, a parent that exceeds the
-    // explicit-run-id limit must not open a known-bad stream; instead it
-    // avoids opening a stream the server would reject.
-    App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(false);
-
-        let history_model =
-            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
-        let own_run_id = "550e8400-e29b-41d4-a716-446655440503";
-        let mut conversation = AIConversation::new(false, false);
-        conversation.set_run_id(own_run_id.to_string());
-        let conversation_id = conversation.id();
-        let terminal_view_id = warpui::EntityId::new();
-        history_model.update(&mut app, |model, ctx| {
-            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
-            model.update_conversation_status(
-                terminal_view_id,
-                conversation_id,
-                ConversationStatus::InProgress,
-                ctx,
-            );
-        });
-
-        let ai_client: Arc<dyn AIClient> = Arc::new(MockAIClient::new());
-        let server_api = ServerApiProvider::new_for_test().get();
-        let poller = app.add_singleton_model(|ctx| {
-            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
-        });
-
-        let consumer_id = warpui::EntityId::new();
-        poller.update(&mut app, |me, ctx| {
-            let stream = me.streams.entry(conversation_id).or_default();
-            stream.consumers.insert(consumer_id);
-            stream.watched_run_ids.insert(own_run_id.to_string());
-            for i in 0..150 {
-                stream.watched_run_ids.insert(format!("child-{i}"));
-            }
-            me.start_sse_connection(conversation_id, ctx);
-        });
-
-        poller.read(&app, |me, _| {
-            let stream = me.streams.get(&conversation_id).expect("stream present");
-            assert!(
-                stream.sse_connection.is_none(),
-                "must not open an oversized run-id stream the server would reject"
-            );
-        });
-    });
-}
-
-#[test]
-fn parent_crossing_run_id_limit_without_flag_tears_down_partial_stream() {
-    // If a parent starts below the explicit-run-id limit and later registers
-    // enough children to exceed it, the old stream has become partial. It must
-    // be torn down instead of silently missing newly-registered children.
-    App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(false);
-
-        let history_model =
-            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
-        let own_run_id = "550e8400-e29b-41d4-a716-446655440507";
-        let mut conversation = AIConversation::new(false, false);
-        conversation.set_run_id(own_run_id.to_string());
-        let conversation_id = conversation.id();
-        let terminal_view_id = warpui::EntityId::new();
-        history_model.update(&mut app, |model, ctx| {
-            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
-            model.update_conversation_status(
-                terminal_view_id,
-                conversation_id,
-                ConversationStatus::InProgress,
-                ctx,
-            );
-        });
-
-        let ai_client: Arc<dyn AIClient> = Arc::new(MockAIClient::new());
-        let server_api = ServerApiProvider::new_for_test().get();
-        let poller = app.add_singleton_model(|ctx| {
-            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
-        });
-
-        let consumer_id = warpui::EntityId::new();
-        poller.update(&mut app, |me, ctx| {
-            let stream = me.streams.entry(conversation_id).or_default();
-            stream.consumers.insert(consumer_id);
-            stream.watched_run_ids.insert(own_run_id.to_string());
-            for i in 0..99 {
-                stream.watched_run_ids.insert(format!("child-{i}"));
-            }
-            me.start_sse_connection(conversation_id, ctx);
-        });
-
-        poller.read(&app, |me, _| {
-            let stream = me.streams.get(&conversation_id).expect("stream present");
-            assert!(
-                stream.sse_connection.is_some(),
-                "100 watched run IDs is still within the explicit-run-id limit"
-            );
-        });
-
-        poller.update(&mut app, |me, ctx| {
-            me.register_watched_run_id(conversation_id, "child-over-limit".to_string(), ctx);
-        });
-
-        poller.read(&app, |me, _| {
-            let stream = me.streams.get(&conversation_id).expect("stream present");
-            assert!(
-                stream.sse_connection.is_none(),
-                "oversized parent must tear down the old partial run-id stream"
-            );
-        });
-    });
-}
-#[test]
 fn restored_parent_with_children_opens_ancestor_include_self_stream() {
     // A restored parent whose children come back from the server fetch opens
     // a parent-family ancestor stream using the merged cursor.
     App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(true);
-
         let history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
         let own_run_id = "550e8400-e29b-41d4-a716-446655440504";
@@ -2326,10 +2207,8 @@ fn restored_parent_with_children_opens_ancestor_include_self_stream() {
 #[test]
 fn restored_child_without_children_opens_self_run_id_stream() {
     // A restored child conversation with no children of its own stays on the
-    // explicit self run-id stream even when the owner-ancestor flag is on.
+    // explicit self run-id stream (it is not a parent, so the ancestor filter doesn't apply).
     App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(true);
-
         let history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
         let own_run_id = "550e8400-e29b-41d4-a716-446655440505";
@@ -2405,8 +2284,6 @@ fn wait_registration_root_with_children_opens_ancestor_include_self_stream() {
     // children, advances the cursor, and opens the parent-family ancestor
     // stream — exactly the not-parent -> parent transition QUALITY-919 adds.
     App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(true);
-
         let history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
         let own_run_id = "550e8400-e29b-41d4-a716-446655440520";
@@ -2469,8 +2346,6 @@ fn wait_registration_root_without_children_does_not_register() {
     // An empty children list means the conversation is not an orchestrator:
     // no parent role is taken and no stream opens.
     App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(true);
-
         let history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
         let own_run_id = "550e8400-e29b-41d4-a716-446655440521";
@@ -2527,8 +2402,6 @@ fn wait_registration_fetch_error_does_not_register() {
     // A failed fetch is a graceful no-op: no parent role, no stream. The next
     // wait re-checks.
     App::test((), |mut app| async move {
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(true);
-
         let history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
         let own_run_id = "550e8400-e29b-41d4-a716-446655440522";
@@ -2649,7 +2522,6 @@ fn register_parent_on_wait_already_parent_is_idempotent() {
     // re-fetch or churn the open ancestor stream.
     App::test((), |mut app| async move {
         let _flag_guard = FeatureFlag::WaitForEventsParentRegistration.override_enabled(true);
-        let _owner_guard = FeatureFlag::OwnerOrchestrationAncestorStreamer.override_enabled(true);
 
         let history_model =
             app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
@@ -2723,74 +2595,6 @@ fn register_parent_on_wait_without_self_run_id_is_noop() {
         });
         poller.read(&app, |me, _| {
             assert!(connected_filter(me, conversation_id).is_none());
-        });
-    });
-}
-
-#[test]
-fn wait_registration_runids_fallback_watches_self_for_parent_inbox() {
-    // With OwnerOrchestrationAncestorStreamer disabled, desired_sse_filter
-    // falls back to RunIds(watched_run_ids). The wait-time registration must
-    // also watch self_run_id (not just the children) so the parent's own
-    // inbox events are delivered — mirroring register_watched_run_id.
-    App::test((), |mut app| async move {
-        // OwnerOrchestrationAncestorStreamer intentionally left disabled.
-        let history_model =
-            app.add_singleton_model(|_| BlocklistAIHistoryModel::new(vec![], vec![], &[]));
-        let own_run_id = "550e8400-e29b-41d4-a716-446655440527";
-        let mut conversation = AIConversation::new(false, false);
-        conversation.set_run_id(own_run_id.to_string());
-        let conversation_id = conversation.id();
-        let terminal_view_id = warpui::EntityId::new();
-        history_model.update(&mut app, |model, ctx| {
-            model.restore_conversations(terminal_view_id, vec![conversation], ctx);
-            model.update_conversation_status(
-                terminal_view_id,
-                conversation_id,
-                ConversationStatus::InProgress,
-                ctx,
-            );
-        });
-
-        let ai_client: Arc<dyn AIClient> = Arc::new(MockAIClient::new());
-        let server_api = ServerApiProvider::new_for_test().get();
-        let poller = app.add_singleton_model(|ctx| {
-            OrchestrationEventStreamer::new_with_clients_for_test(ai_client, server_api, ctx)
-        });
-
-        // Only an active consumer — self_run_id is intentionally NOT
-        // pre-watched, so the assertion verifies registration adds it.
-        let consumer_id = warpui::EntityId::new();
-        poller.update(&mut app, |me, _| {
-            me.streams
-                .entry(conversation_id)
-                .or_default()
-                .consumers
-                .insert(consumer_id);
-        });
-
-        poller.update(&mut app, |me, ctx| {
-            me.finish_register_parent_on_wait(
-                conversation_id,
-                Ok(make_ambient_task_with_children(vec![
-                    "child-run-1".to_string()
-                ])),
-                ctx,
-            );
-        });
-
-        poller.read(&app, |me, _| match connected_filter(me, conversation_id) {
-            Some(AgentEventFilter::RunIds(run_ids)) => {
-                assert!(
-                    run_ids.contains(&own_run_id.to_string()),
-                    "RunIds fallback must watch self_run_id for the parent's own inbox; got {run_ids:?}"
-                );
-                assert!(
-                    run_ids.contains(&"child-run-1".to_string()),
-                    "RunIds fallback must watch the child; got {run_ids:?}"
-                );
-            }
-            other => panic!("expected RunIds fallback filter, got {other:?}"),
         });
     });
 }

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -421,10 +421,6 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::IncrementalAutoReload,
         #[cfg(feature = "run_agents_tool")]
         FeatureFlag::RunAgentsTool,
-        #[cfg(feature = "orchestration_viewer_streamer")]
-        FeatureFlag::OrchestrationViewerStreamer,
-        #[cfg(feature = "owner_orchestration_ancestor_streamer")]
-        FeatureFlag::OwnerOrchestrationAncestorStreamer,
         #[cfg(feature = "wait_for_events_parent_registration")]
         FeatureFlag::WaitForEventsParentRegistration,
         #[cfg(feature = "pending_user_query_indicator")]

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
@@ -1,25 +1,18 @@
 //! Drives the orchestration pill bar in shared session viewers.
 //!
 //! After the viewer joins a parent ambient-agent session, this model
-//! discovers and tracks the parent's direct children using one of two
-//! delivery paths, gated on [`FeatureFlag::OrchestrationViewerStreamer`]:
-//!
-//! 1. **Streamer-driven (flag ON, default).** Registers as a viewer-mode
-//!    consumer on [`OrchestrationEventStreamer`], which opens an ancestor
-//!    SSE (seeded by a one-shot REST snapshot) and broadcasts
-//!    `ChildSpawned`/`ChildStatusChanged` events.
-//! 2. **Legacy REST polling (flag OFF).** Periodically polls
-//!    `GET /agent/runs?ancestor_run_id=` and reconciles the full child
-//!    list each cycle.
+//! discovers and tracks the parent's direct children via the
+//! [`OrchestrationEventStreamer`], which opens an ancestor SSE (seeded
+//! by a one-shot REST snapshot) and broadcasts `ChildSpawned` /
+//! `ChildStatusChanged` events.
 //!
 //! Each viewer pane has its own model with its own placeholder
-//! conversations; the streamer (when on) is a shared singleton.
+//! conversations; the streamer is a shared singleton.
 //! Pill clicks navigate via `SwapPaneToConversation`.
 use std::collections::HashMap;
 use std::time::Duration;
 
 use session_sharing_protocol::common::SessionId;
-use warp_core::features::FeatureFlag;
 use warpui::r#async::{SpawnedFutureHandle, Timer};
 use warpui::{Entity, EntityId, ModelContext, SingletonEntity, WeakViewHandle};
 
@@ -30,16 +23,9 @@ use crate::ai::blocklist::orchestration_event_streamer::{
     OrchestrationEventStreamer, OrchestrationEventStreamerEvent,
 };
 use crate::ai::blocklist::BlocklistAIHistoryModel;
-use crate::server::server_api::ai::TaskListFilter;
 use crate::server::server_api::ServerApiProvider;
 use crate::terminal::{Event as TerminalViewEvent, TerminalView};
 
-/// Max child runs per legacy `?ancestor_run_id=` page (polling path).
-const CHILD_DISCOVERY_FETCH_LIMIT: i32 = 100;
-/// Polling cadence (legacy path) while any child is non-terminal.
-const STATUS_POLL_INTERVAL: Duration = Duration::from_secs(5);
-/// Slower polling cadence (legacy path) once every known child is terminal.
-const STATUS_POLL_INTERVAL_IDLE: Duration = Duration::from_secs(30);
 /// Refetch cadence for children whose claim-time `session_id` is not yet known.
 const PENDING_SESSION_ID_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
@@ -48,7 +34,8 @@ struct ChildAgentEntry {
     conversation_id: AIConversationId,
     /// `None` until execution has been claimed.
     session_id: Option<SessionId>,
-    /// Polling path uses this to dedupe status writes.
+    /// Cached to deduplicate status writes: we only push an update when the
+    /// state actually changes.
     last_state: AmbientAgentTaskState,
     /// True once `EnsureSharedSessionViewerChildPane` has been emitted.
     pane_materialization_requested: bool,
@@ -63,18 +50,10 @@ pub struct OrchestrationViewerModel {
     /// Placeholder conversations materialized for direct children.
     children: HashMap<AmbientAgentTaskId, ChildAgentEntry>,
     /// Secondary index keyed by stringified `run_id`, used by the streamer
-    /// path's broadcast event handler. Kept in sync with `children`.
+    /// broadcast event handler. Kept in sync with `children`.
     children_by_run_id: HashMap<String, AmbientAgentTaskId>,
-    /// (Polling path.) `None` on the streamer path.
-    polling_handle: Option<SpawnedFutureHandle>,
-    /// (Polling path.) Bumped before each fetch so stale responses can
-    /// be dropped.
-    fetch_generation: u64,
-    /// Set when the most recent fetch returned no children; resumed by
-    /// the next orchestrator `AppendedExchange`.
-    idle_due_to_no_children: bool,
-    /// (Streamer path.) Periodic timer fetching the claim-time
-    /// `session_id` for not-yet-claimed children.
+    /// Periodic timer fetching the claim-time `session_id` for
+    /// not-yet-claimed children.
     pending_session_id_poll_handle: Option<SpawnedFutureHandle>,
     /// Test-only: counts `spawn_task_metadata_fetch` invocations.
     #[cfg(test)]
@@ -91,76 +70,39 @@ impl OrchestrationViewerModel {
         self.parent_task_id
     }
     /// Builds a viewer model attached to the given parent shared session.
-    /// See the module docs for the two delivery paths.
     pub fn new(
         parent_task_id: AmbientAgentTaskId,
         terminal_view_id: EntityId,
         terminal_view: WeakViewHandle<TerminalView>,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
-        if FeatureFlag::OrchestrationViewerStreamer.is_enabled() {
-            // Streamer-driven path. Subscribe to broadcast events filtered
-            // on `parent_task_id`; the streamer handles SSE open/teardown,
-            // cold-start seed, and cursor persistence on our behalf.
-            let streamer = OrchestrationEventStreamer::handle(ctx);
-            ctx.subscribe_to_model(&streamer, move |me, _, event, ctx| {
-                me.handle_streamer_event(event, ctx);
-            });
-            ctx.subscribe_to_model(
-                &BlocklistAIHistoryModel::handle(ctx),
-                |me, _, event, ctx| {
-                    me.handle_history_event(event, ctx);
-                },
-            );
-
-            let model = Self {
-                parent_task_id,
-                terminal_view_id,
-                terminal_view,
-                children: HashMap::new(),
-                children_by_run_id: HashMap::new(),
-                polling_handle: None,
-                fetch_generation: 0,
-                idle_due_to_no_children: false,
-                pending_session_id_poll_handle: None,
-                #[cfg(test)]
-                metadata_fetch_dispatch_count: 0,
-            };
-            model.register_viewer_mode_consumer_if_possible(ctx);
-            return model;
-        }
-
-        // Legacy polling path. Kick to fast cadence on `AppendedExchange` so
-        // follow-up input that spawns new children surfaces without waiting
-        // for the next 30s idle poll.
+        // Subscribe to broadcast events filtered on `parent_task_id`; the
+        // streamer handles SSE open/teardown, cold-start seed, and cursor
+        // persistence on our behalf.
+        let streamer = OrchestrationEventStreamer::handle(ctx);
+        ctx.subscribe_to_model(&streamer, move |me, _, event, ctx| {
+            me.handle_streamer_event(event, ctx);
+        });
         ctx.subscribe_to_model(
             &BlocklistAIHistoryModel::handle(ctx),
             |me, _, event, ctx| {
-                me.maybe_kick_polling(event, ctx);
-                me.maybe_backfill_parent_agent_ids(event, ctx);
+                me.handle_history_event(event, ctx);
             },
         );
 
-        let mut model = Self {
+        let model = Self {
             parent_task_id,
             terminal_view_id,
             terminal_view,
             children: HashMap::new(),
             children_by_run_id: HashMap::new(),
-            polling_handle: None,
-            fetch_generation: 0,
-            idle_due_to_no_children: false,
             pending_session_id_poll_handle: None,
             #[cfg(test)]
             metadata_fetch_dispatch_count: 0,
         };
-
-        // Each fetch reschedules itself via its response callback.
-        model.fetch_children(ctx);
+        model.register_viewer_mode_consumer_if_possible(ctx);
         model
     }
-
-    // ---- Streamer-driven path (FeatureFlag::OrchestrationViewerStreamer on)
 
     fn handle_history_event(
         &mut self,
@@ -368,8 +310,8 @@ impl OrchestrationViewerModel {
 
         if let Some(entry) = self.children.get_mut(&task_id) {
             // Existing child: update status if it changed and fill in
-            // session id once it becomes available. (Polling path replays
-            // every cycle; streamer path can also re-register on reconnect.)
+            // session id once it becomes available. Can be called again
+            // on streamer reconnect.
             if entry.last_state != new_state {
                 let conversation_id = entry.conversation_id;
                 let terminal_view_id = self.terminal_view_id;
@@ -484,11 +426,11 @@ impl OrchestrationViewerModel {
             self.request_child_pane_materialization(conversation_id, sid, ctx);
         }
 
-        // Streamer path only: arm the session_id refetch timer.
+        // Arm the session_id refetch timer if the child arrived pre-claim.
         self.maybe_schedule_pending_session_id_poll(ctx);
     }
 
-    // ---- Pending-session_id polling (streamer path) -------------------
+    // ---- Pending-session_id polling ----------------------------------
 
     /// True iff at least one tracked child is still pending materialization.
     fn has_pending_session_id_children(&self) -> bool {
@@ -497,12 +439,9 @@ impl OrchestrationViewerModel {
             .any(|entry| entry.session_id.is_none() || !entry.pane_materialization_requested)
     }
 
-    /// Schedules the next session_id refetch tick on the streamer path.
+    /// Schedules the next session_id refetch tick.
     /// Safe to call unconditionally — bails when not needed.
     fn maybe_schedule_pending_session_id_poll(&mut self, ctx: &mut ModelContext<Self>) {
-        if !FeatureFlag::OrchestrationViewerStreamer.is_enabled() {
-            return;
-        }
         if self.pending_session_id_poll_handle.is_some() {
             return;
         }
@@ -545,112 +484,12 @@ impl OrchestrationViewerModel {
         self.maybe_schedule_pending_session_id_poll(ctx);
     }
 
-    // ---- Legacy polling path (FeatureFlag::OrchestrationViewerStreamer off)
-
-    /// Schedules the next poll: fast cadence while any child is
-    /// non-terminal, slow once all are terminal. Skipped while
-    /// [`Self::idle_due_to_no_children`] is set; [`Self::maybe_kick_polling`]
-    /// resumes on the next orchestrator `AppendedExchange`.
-    fn schedule_next_poll(&mut self, ctx: &mut ModelContext<Self>) {
-        // `SpawnedFutureHandle` doesn't abort on drop, so abort
-        // explicitly to avoid stacking parallel timer chains.
-        if let Some(prior) = self.polling_handle.take() {
-            prior.abort();
-        }
-
-        // Stay idle until an `AppendedExchange` on the orchestrator wakes
-        // us up. `apply_children_fetch` is responsible for setting this
-        // flag when an empty descendant list comes back.
-        if self.idle_due_to_no_children {
-            return;
-        }
-
-        let all_terminal = !self.children.is_empty()
-            && self
-                .children
-                .values()
-                .all(|child| child.last_state.is_terminal());
-        let interval = if all_terminal {
-            STATUS_POLL_INTERVAL_IDLE
-        } else {
-            STATUS_POLL_INTERVAL
-        };
-
-        let handle = ctx.spawn(
-            async move {
-                Timer::after(interval).await;
-            },
-            |me, _, ctx| me.fetch_children(ctx),
-        );
-        self.polling_handle = Some(handle);
-    }
-
-    /// Tightens polling on `AppendedExchange` during the idle→active
-    /// transition, and resumes from `idle_due_to_no_children` on an
-    /// orchestrator-scoped exchange. The idle-resume check runs first
-    /// because it would otherwise be conflated with the
-    /// "fetch in flight" state by the `polling_handle.is_none()` guard.
-    fn maybe_kick_polling(
-        &mut self,
-        event: &BlocklistAIHistoryEvent,
-        ctx: &mut ModelContext<Self>,
-    ) {
-        let BlocklistAIHistoryEvent::AppendedExchange {
-            conversation_id, ..
-        } = event
-        else {
-            return;
-        };
-        let conversation_id = *conversation_id;
-        let is_orchestrator = self.find_parent_conversation_id(ctx) == Some(conversation_id);
-
-        // Resume from idle-due-to-no-children. Only orchestrator-scoped
-        // exchanges count: child events are ignored because we have no
-        // tracked children to update yet, and an unrelated conversation's
-        // exchange does not imply this orchestrator just spawned a child.
-        if self.idle_due_to_no_children {
-            if is_orchestrator {
-                self.idle_due_to_no_children = false;
-                if let Some(prior) = self.polling_handle.take() {
-                    prior.abort();
-                }
-                self.fetch_children(ctx);
-            }
-            return;
-        }
-
-        let all_terminal = !self.children.is_empty()
-            && self
-                .children
-                .values()
-                .all(|child| child.last_state.is_terminal());
-        if !all_terminal {
-            return;
-        }
-        // `polling_handle = None` here means a kick fetch is already in
-        // flight (the idle-due-to-no-children case is handled above);
-        // skipping prevents pile-up when exchanges arrive in bursts.
-        if self.polling_handle.is_none() {
-            return;
-        }
-        let is_tracked_child = self
-            .children
-            .values()
-            .any(|child| child.conversation_id == conversation_id);
-        if !is_orchestrator && !is_tracked_child {
-            return;
-        }
-        if let Some(prior) = self.polling_handle.take() {
-            prior.abort();
-        }
-        self.fetch_children(ctx);
-    }
+    // ---- Helpers -------------------------------------------------------
 
     /// Backfills `parent_agent_id` on viewer-created children once the
-    /// orchestrator receives its server token / run id. First-poll
-    /// children are created with `parent_agent_id = None` because the
-    /// orchestrator hasn't been identified yet; this fixes them up so
-    /// `parent_conversation_id` resolution works.
+    /// orchestrator receives its server token. Children registered before
+    /// the parent's run_id was known would otherwise stay with
+    /// `parent_agent_id = None` and break parent-conversation lookups.
     fn maybe_backfill_parent_agent_ids(
         &mut self,
         event: &BlocklistAIHistoryEvent,
@@ -691,77 +530,6 @@ impl OrchestrationViewerModel {
             }
         });
     }
-
-    /// Issues a `GET /agent/runs?ancestor_run_id={parent_task_id}` request
-    /// and routes the response into [`Self::apply_children_fetch`]. Errors
-    /// are logged and ignored; the next poll retries.
-    fn fetch_children(&mut self, ctx: &mut ModelContext<Self>) {
-        // Bump generation BEFORE dispatch so any in-flight stale fetch
-        // is invalidated when its response callback compares.
-        self.fetch_generation = self.fetch_generation.wrapping_add(1);
-        let fetch_generation = self.fetch_generation;
-
-        let ai_client = ServerApiProvider::as_ref(ctx).get_ai_client();
-        let filter = TaskListFilter {
-            ancestor_run_id: Some(self.parent_task_id.to_string()),
-            ..TaskListFilter::default()
-        };
-        let parent_task_id = self.parent_task_id;
-
-        ctx.spawn(
-            async move {
-                ai_client
-                    .list_ambient_agent_tasks(CHILD_DISCOVERY_FETCH_LIMIT, filter)
-                    .await
-            },
-            move |me, result, ctx| {
-                // Stale fetch: a newer one's already in flight (or applied).
-                // The newer fetch owns rescheduling.
-                if me.fetch_generation != fetch_generation {
-                    return;
-                }
-                match result {
-                    Ok(tasks) => me.apply_children_fetch(tasks, ctx),
-                    Err(err) => {
-                        log::warn!(
-                            "OrchestrationViewerModel: failed to fetch children for {parent_task_id}: {err:#}"
-                        );
-                    }
-                }
-                // Always reschedule (even on error) so transient failures
-                // don't break the polling loop.
-                me.schedule_next_poll(ctx);
-            },
-        );
-    }
-
-    /// Consumes a children list response, registering new children and
-    /// updating statuses / session ids on existing ones. Each child goes
-    /// through [`Self::register_child`] which is shared with the streamer
-    /// path. Also manages the polling-path `idle_due_to_no_children` flag
-    /// so an empty descendant list parks the timer chain until the next
-    /// orchestrator `AppendedExchange` resumes it.
-    fn apply_children_fetch(&mut self, tasks: Vec<AmbientAgentTask>, ctx: &mut ModelContext<Self>) {
-        for task in tasks {
-            self.register_child(task, ctx);
-        }
-
-        // Polling-cost mitigation: if no children are tracked after this
-        // fetch, stop scheduling timers. The resume signal is an
-        // `AppendedExchange` on the orchestrator (see
-        // `maybe_kick_polling`). `schedule_next_poll` honours this flag
-        // and bails before spawning a new timer.
-        if self.children.is_empty() {
-            self.idle_due_to_no_children = true;
-            if let Some(prior) = self.polling_handle.take() {
-                prior.abort();
-            }
-        } else {
-            self.idle_due_to_no_children = false;
-        }
-    }
-
-    // ---- Shared helpers ------------------------------------------------
 
     /// Resolves the orchestrator's local conversation id via the view's
     /// active conversation, which `on_shared_init` sets on first join.

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
@@ -2,32 +2,17 @@
 //!
 //! Layout:
 //!
-//! 1. Pure-function tests for [`conversation_status_from_state`]. These carry
-//!    over unchanged from the legacy polling path.
-//! 2. Streamer-driven path tests (`OrchestrationViewerStreamer` on). The model translates
-//!    `OrchestrationEventStreamerEvent::ChildSpawned` /
-//!    `ChildStatusChanged` events into local placeholder conversations.
-//!    These tests drive the model via the streamer's emit path and a
-//!    `MockAIClient` that returns canned `get_ambient_agent_task` responses
-//!    for the pill metadata fetch.
-//! 3. Legacy polling-path tests (`OrchestrationViewerStreamer` off). The model registers children
-//!    from `register_child` (called from `apply_children_fetch`). These map
-//!    directly to the spec's polling-path semantics.
-//!
-//! `apply_children_fetch` itself is exercised through `register_child`, so
-//! we drive the polling-path tests at the same boundary by calling
-//! `register_child` from the test rather than invoking a synthetic
-//! `apply_children_fetch` shell.
+//! 1. Pure-function tests for [`conversation_status_from_state`].
+//! 2. Tests for the shared `register_child` registration path.
+//! 3. Tests for the streamer-driven event handlers (`ChildSpawned` /
+//!    `ChildStatusChanged`) and the pending-`session_id` poll timer.
 
 use std::sync::Arc;
 
 use chrono::Utc;
-use warp_core::features::FeatureFlag;
 use warpui::{App, EntityId, SingletonEntity};
 
 use super::*;
-use crate::ai::agent::task::TaskId;
-use crate::ai::agent::AIAgentExchangeId;
 use crate::ai::ambient_agents::task::{AgentConfigSnapshot, AmbientAgentTask};
 use crate::ai::blocklist::orchestration_event_streamer::OrchestrationEventStreamerEvent;
 use crate::server::server_api::ai::{AIClient, MockAIClient};
@@ -162,8 +147,7 @@ fn make_task_with_name(
 /// Wires up `BlocklistAIHistoryModel`, a real [`TerminalView`], and an
 /// orchestrator parent conversation marked active for that view. Returns
 /// the model built directly (bypassing `OrchestrationViewerModel::new`,
-/// which would otherwise kick off either a REST fetch or a streamer
-/// registration).
+/// which would otherwise kick off streamer registration).
 fn setup_model(
     app: &mut App,
     parent_task_id: AmbientAgentTaskId,
@@ -184,9 +168,6 @@ fn setup_model(
         terminal_view: terminal_view.downgrade(),
         children: HashMap::new(),
         children_by_run_id: HashMap::new(),
-        polling_handle: None,
-        fetch_generation: 0,
-        idle_due_to_no_children: false,
         pending_session_id_poll_handle: None,
         metadata_fetch_dispatch_count: 0,
     };
@@ -309,9 +290,6 @@ fn skips_child_when_no_active_parent_conversation() {
             terminal_view: terminal_view.downgrade(),
             children: HashMap::new(),
             children_by_run_id: HashMap::new(),
-            polling_handle: None,
-            fetch_generation: 0,
-            idle_due_to_no_children: false,
             pending_session_id_poll_handle: None,
             metadata_fetch_dispatch_count: 0,
         };
@@ -879,7 +857,6 @@ fn pending_session_id_poll_schedules_while_session_id_is_none() {
     // `run_pending_session_id_poll` directly (what the timer's callback
     // would do).
     App::test((), |mut app| async move {
-        let _streamer_guard = FeatureFlag::OrchestrationViewerStreamer.override_enabled(true);
         let parent = task_id(PARENT_TASK_ID);
         let (_, _, model) = setup_model(&mut app, parent);
         let model_handle = app.add_model(|_| model);
@@ -978,7 +955,6 @@ fn pending_session_id_poll_does_not_schedule_when_no_children_pending() {
     // server has already claimed execution by the time we observe the
     // child.
     App::test((), |mut app| async move {
-        let _streamer_guard = FeatureFlag::OrchestrationViewerStreamer.override_enabled(true);
         let parent = task_id(PARENT_TASK_ID);
         let (_, _, model) = setup_model(&mut app, parent);
         let model_handle = app.add_model(|_| model);
@@ -1012,7 +988,6 @@ fn pending_session_id_poll_dispatches_per_pending_child() {
     // Two pre-claim children → one timer; the tick should dispatch one
     // refetch per pending child.
     App::test((), |mut app| async move {
-        let _streamer_guard = FeatureFlag::OrchestrationViewerStreamer.override_enabled(true);
         let parent = task_id(PARENT_TASK_ID);
         let (_, _, model) = setup_model(&mut app, parent);
         let model_handle = app.add_model(|_| model);
@@ -1097,24 +1072,23 @@ fn child_status_changed_does_not_refetch_when_already_materialized() {
 
 #[test]
 fn b1_populates_agent_id_to_conversation_id_for_new_child() {
-    // After `apply_children_fetch` registers a new viewer-created child,
-    // `BlocklistAIHistoryModel::conversation_id_for_agent_id` resolves the
-    // child's `run_id` back to the local child conversation so sibling
-    // references in transcript bodies render display names instead of
-    // "Unknown agent".
+    // After a child is registered, `BlocklistAIHistoryModel::conversation_id_for_agent_id`
+    // resolves the child's `run_id` back to the local child conversation so
+    // sibling references in transcript bodies render display names instead
+    // of "Unknown agent".
     App::test((), |mut app| async move {
         let parent = task_id(PARENT_TASK_ID);
         let (_, _, model) = setup_model(&mut app, parent);
         let model_handle = app.add_model(|_| model);
 
         model_handle.update(&mut app, |model, ctx| {
-            model.apply_children_fetch(
-                vec![make_task(
+            model.register_child(
+                make_task(
                     CHILD_A_TASK_ID,
                     AmbientAgentTaskState::InProgress,
                     "Worker",
                     None,
-                )],
+                ),
                 ctx,
             );
         });
@@ -1159,13 +1133,13 @@ fn b2_backfills_parent_agent_id_on_orchestrator_token_assigned() {
         // Step 1: register a child while the parent has no orchestration
         // agent id. The child's `parent_agent_id` must be `None`.
         model_handle.update(&mut app, |model, ctx| {
-            model.apply_children_fetch(
-                vec![make_task(
+            model.register_child(
+                make_task(
                     CHILD_A_TASK_ID,
                     AmbientAgentTaskState::InProgress,
                     "Worker",
                     None,
-                )],
+                ),
                 ctx,
             );
         });
@@ -1245,13 +1219,13 @@ fn b2_does_not_overwrite_existing_parent_agent_id() {
             );
         });
         model_handle.update(&mut app, |model, ctx| {
-            model.apply_children_fetch(
-                vec![make_task(
+            model.register_child(
+                make_task(
                     CHILD_A_TASK_ID,
                     AmbientAgentTaskState::InProgress,
                     "Worker",
                     None,
-                )],
+                ),
                 ctx,
             );
         });
@@ -1290,13 +1264,13 @@ fn b2_ignores_token_assigned_for_unrelated_conversation() {
         let model_handle = app.add_model(|_| model);
 
         model_handle.update(&mut app, |model, ctx| {
-            model.apply_children_fetch(
-                vec![make_task(
+            model.register_child(
+                make_task(
                     CHILD_A_TASK_ID,
                     AmbientAgentTaskState::InProgress,
                     "Worker",
                     None,
-                )],
+                ),
                 ctx,
             );
         });
@@ -1337,251 +1311,7 @@ fn b2_ignores_token_assigned_for_unrelated_conversation() {
 //
 // Removed: tracked separately under shared-session viewer support work.
 
-// ---- idle_due_to_no_children polling-cost mitigation ----------------------
-
-/// Builds an [`AppendedExchange`] event for the given conversation, with
-/// stub identifiers for the unrelated fields. Mirrors what the history
-/// model would emit when a fresh exchange is appended; the model's
-/// `maybe_kick_polling` handler only reads `conversation_id`.
-fn make_appended_exchange_event(
-    conversation_id: AIConversationId,
-    terminal_view_id: EntityId,
-) -> BlocklistAIHistoryEvent {
-    BlocklistAIHistoryEvent::AppendedExchange {
-        exchange_id: AIAgentExchangeId::new(),
-        task_id: TaskId::new("test-task".to_string()),
-        terminal_surface_id: terminal_view_id,
-        conversation_id,
-        is_hidden: false,
-        response_stream_id: None,
-    }
-}
-
-/// Spawns a long-lived no-op future and stores its handle on the model.
-/// Used to populate `polling_handle` in tests so we can assert that the
-/// polling-state machine aborts it when transitioning to the
-/// idle-due-to-no-children state.
-///
-/// `SpawnedFutureHandle::abort()` doesn't expose an observable side-effect
-/// from outside the model, so the assertion target is
-/// `model.polling_handle.is_none()` after the transition. The timer is
-/// scheduled for an hour so it cannot fire during the test.
-fn populate_polling_handle(
-    model: &mut OrchestrationViewerModel,
-    ctx: &mut ModelContext<OrchestrationViewerModel>,
-) {
-    let handle = ctx.spawn(
-        async {
-            Timer::after(Duration::from_secs(3600)).await;
-        },
-        |_me, _, _ctx| {},
-    );
-    model.polling_handle = Some(handle);
-}
-
-#[test]
-fn empty_descendant_fetch_sets_idle_flag_and_aborts_polling() {
-    // When a non-orchestrator share's first descendant fetch returns no
-    // children, the viewer model sets `idle_due_to_no_children = true`
-    // and tears down its polling handle. `schedule_next_poll` later
-    // honours the flag and refuses to spawn another timer, so the model
-    // spends zero CPU / network until an `AppendedExchange` on the
-    // orchestrator wakes it up.
-    App::test((), |mut app| async move {
-        let parent = task_id(PARENT_TASK_ID);
-        let (_, _, model) = setup_model(&mut app, parent);
-        let model_handle = app.add_model(|_| model);
-
-        // Simulate an already-active polling cadence by pre-populating the
-        // handle. After the empty fetch this handle should be cleared.
-        model_handle.update(&mut app, |model, ctx| {
-            populate_polling_handle(model, ctx);
-        });
-        model_handle.read(&app, |model, _| {
-            assert!(
-                model.polling_handle.is_some(),
-                "sanity: polling_handle populated for the test"
-            );
-            assert!(
-                !model.idle_due_to_no_children,
-                "sanity: idle flag starts clear"
-            );
-        });
-
-        // Server returns no descendants. `apply_children_fetch` is the
-        // sync portion of the fetch callback, so calling it directly
-        // exercises the polling-state transition without an HTTP round
-        // trip.
-        model_handle.update(&mut app, |model, ctx| {
-            model.apply_children_fetch(vec![], ctx);
-        });
-
-        model_handle.read(&app, |model, _| {
-            assert!(
-                model.idle_due_to_no_children,
-                "empty fetch must mark the model as idle-due-to-no-children"
-            );
-            assert!(
-                model.polling_handle.is_none(),
-                "empty fetch must abort the prior polling handle and clear the field"
-            );
-            assert!(
-                model.children.is_empty(),
-                "sanity: no children were registered"
-            );
-        });
-    });
-}
-
-#[test]
-fn appended_exchange_on_orchestrator_resumes_from_idle() {
-    // Once the model has gone idle on an empty fetch, the next
-    // `AppendedExchange` on the orchestrator conversation must resume
-    // polling: clear the idle flag and call `fetch_children`. We observe
-    // `fetch_children` indirectly via `fetch_generation`, which is bumped
-    // synchronously at the head of the function before any spawn fires.
-    App::test((), |mut app| async move {
-        let parent = task_id(PARENT_TASK_ID);
-        let (terminal_view_id, parent_conv_id, model) = setup_model(&mut app, parent);
-        let model_handle = app.add_model(|_| model);
-
-        // Drive the model into the idle state via the same path the
-        // production fetch callback would: empty descendant list.
-        model_handle.update(&mut app, |model, ctx| {
-            model.apply_children_fetch(vec![], ctx);
-        });
-        let generation_before_resume = model_handle.read(&app, |model, _| {
-            assert!(
-                model.idle_due_to_no_children,
-                "sanity: idle flag set after empty fetch"
-            );
-            assert!(
-                model.polling_handle.is_none(),
-                "sanity: polling handle aborted"
-            );
-            model.fetch_generation
-        });
-
-        // Fire an `AppendedExchange` against the orchestrator. The model
-        // resumes via the idle-due-to-no-children branch in
-        // `maybe_kick_polling`.
-        let event = make_appended_exchange_event(parent_conv_id, terminal_view_id);
-        model_handle.update(&mut app, |model, ctx| {
-            model.maybe_kick_polling(&event, ctx);
-        });
-
-        model_handle.read(&app, |model, _| {
-            assert!(
-                !model.idle_due_to_no_children,
-                "AppendedExchange on the orchestrator must clear the idle flag"
-            );
-            assert_eq!(
-                model.fetch_generation,
-                generation_before_resume.wrapping_add(1),
-                "AppendedExchange on the orchestrator must call fetch_children, \
-                 which bumps fetch_generation by one",
-            );
-        });
-    });
-}
-
-#[test]
-fn non_empty_fetch_clears_idle_flag_and_resumes_polling() {
-    // The complementary path: a fetch that *does* discover children
-    // clears the idle flag so subsequent `schedule_next_poll` calls go
-    // back to the active cadence. We then exercise `schedule_next_poll`
-    // directly to verify that, once the flag is clear, a new
-    // `polling_handle` is created.
-    App::test((), |mut app| async move {
-        let parent = task_id(PARENT_TASK_ID);
-        let (_, _, mut model) = setup_model(&mut app, parent);
-        // Manually start from the idle state so we can confirm the
-        // non-empty fetch clears it.
-        model.idle_due_to_no_children = true;
-        let model_handle = app.add_model(|_| model);
-
-        model_handle.update(&mut app, |model, ctx| {
-            model.apply_children_fetch(
-                vec![make_task(
-                    CHILD_A_TASK_ID,
-                    AmbientAgentTaskState::InProgress,
-                    "Worker",
-                    None,
-                )],
-                ctx,
-            );
-        });
-        model_handle.read(&app, |model, _| {
-            assert!(
-                !model.idle_due_to_no_children,
-                "non-empty fetch must clear the idle flag"
-            );
-            assert_eq!(model.children.len(), 1, "child was registered");
-        });
-
-        // The fetch callback would normally call `schedule_next_poll`
-        // right after `apply_children_fetch`. Invoke it explicitly so we
-        // can assert that, with the flag now cleared, a new polling
-        // handle is installed.
-        model_handle.update(&mut app, |model, ctx| {
-            model.schedule_next_poll(ctx);
-        });
-        model_handle.read(&app, |model, _| {
-            assert!(
-                model.polling_handle.is_some(),
-                "schedule_next_poll must spawn a new timer when not idle"
-            );
-        });
-    });
-}
-
-#[test]
-fn appended_exchange_on_non_orchestrator_does_not_resume_idle() {
-    // Symmetric to the orchestrator-resume test: an exchange on an
-    // unrelated conversation (i.e. not the orchestrator tracked by this
-    // viewer) must not pull the model out of the idle-due-to-no-children
-    // state. The flag stays set and `fetch_children` is not invoked.
-    App::test((), |mut app| async move {
-        let parent = task_id(PARENT_TASK_ID);
-        let (terminal_view_id, _, model) = setup_model(&mut app, parent);
-        let model_handle = app.add_model(|_| model);
-
-        // Idle the model.
-        model_handle.update(&mut app, |model, ctx| {
-            model.apply_children_fetch(vec![], ctx);
-        });
-        let generation_before_event = model_handle.read(&app, |model, _| {
-            assert!(model.idle_due_to_no_children, "sanity: model is idle");
-            model.fetch_generation
-        });
-
-        // Fire an `AppendedExchange` for some unrelated conversation. The
-        // resume gate compares against the orchestrator id returned by
-        // `find_parent_conversation_id`, so a fresh id will not match.
-        let unrelated_conversation_id = AIConversationId::new();
-        let event = make_appended_exchange_event(unrelated_conversation_id, terminal_view_id);
-        model_handle.update(&mut app, |model, ctx| {
-            model.maybe_kick_polling(&event, ctx);
-        });
-
-        model_handle.read(&app, |model, _| {
-            assert!(
-                model.idle_due_to_no_children,
-                "AppendedExchange on an unrelated conversation must NOT resume the model"
-            );
-            assert_eq!(
-                model.fetch_generation, generation_before_event,
-                "fetch_children must not run when the resume gate doesn't match the orchestrator"
-            );
-            assert!(
-                model.polling_handle.is_none(),
-                "polling handle must remain cleared while idle"
-            );
-        });
-    });
-}
-
-// ---- Streamer-driven path tests (`OrchestrationViewerStreamer` on) ----------
+// ---- Streamer-driven path tests --------------------------------------------
 
 #[test]
 fn handle_streamer_event_filters_on_parent_task_id() {
@@ -1652,15 +1382,10 @@ fn child_spawned_with_malformed_run_id_is_dropped() {
 }
 
 #[test]
-fn streamer_consumer_is_registered_when_constructed_under_flag() {
-    // With `OrchestrationViewerStreamer` on, `OrchestrationViewerModel::new`
-    // registers the pane on the shared streamer entry and kicks off the
-    // cold-start seed.
-    use warp_core::features::FeatureFlag;
-
+fn streamer_consumer_is_registered_when_constructed() {
+    // `OrchestrationViewerModel::new` registers the pane on the shared
+    // streamer entry and kicks off the cold-start seed.
     App::test((), |mut app| async move {
-        let _streamer_guard = FeatureFlag::OrchestrationViewerStreamer.override_enabled(true);
-
         let parent = task_id(PARENT_TASK_ID);
         let (terminal_view_id, _parent_conv_id, _) = setup_model(&mut app, parent);
 
@@ -1671,8 +1396,7 @@ fn streamer_consumer_is_registered_when_constructed_under_flag() {
         // model's `register_viewer_mode_consumer` call no-ops (handle resolution
         // returns nothing) but doesn't panic.
 
-        // Try constructing the model. The construction must not panic even
-        // when the streamer is or isn't present.
+        // Try constructing the model. The construction must not panic.
         let terminal_view = add_window_with_terminal(&mut app, None);
         let _ = app.add_model(|ctx| {
             OrchestrationViewerModel::new(parent, terminal_view_id, terminal_view.downgrade(), ctx)
@@ -1680,7 +1404,7 @@ fn streamer_consumer_is_registered_when_constructed_under_flag() {
 
         // The streamer's viewer-mode registration is exercised end-to-end
         // by the streamer-side tests; here we just verify non-panicking
-        // construction of the viewer model under the flag.
+        // construction of the viewer model.
         let _ = terminal_view_id;
     });
 }
@@ -1705,14 +1429,11 @@ fn viewer_model_retries_consumer_registration_on_set_active_conversation() {
     // `parent_conversation_id` (children get one through
     // `start_new_child_conversation`). The discriminator in
     // `register_viewer_mode_consumer_if_possible` must accept this shape.
-    use warp_core::features::FeatureFlag;
     use warpui::SingletonEntity;
 
     use crate::ai::blocklist::orchestration_event_streamer::OrchestrationEventStreamer;
 
     App::test((), |mut app| async move {
-        let _streamer_guard = FeatureFlag::OrchestrationViewerStreamer.override_enabled(true);
-
         initialize_app_for_terminal_view(&mut app);
         let terminal_view = add_window_with_terminal(&mut app, None);
         let terminal_view_id = terminal_view.id();
@@ -1770,14 +1491,11 @@ fn viewer_model_does_not_register_when_active_conversation_is_a_child_placeholde
     // `SwapPaneToConversation` before the orchestrator placeholder is
     // activated — which would persist the orchestration cursor on the
     // wrong row.
-    use warp_core::features::FeatureFlag;
     use warpui::SingletonEntity;
 
     use crate::ai::blocklist::orchestration_event_streamer::OrchestrationEventStreamer;
 
     App::test((), |mut app| async move {
-        let _streamer_guard = FeatureFlag::OrchestrationViewerStreamer.override_enabled(true);
-
         initialize_app_for_terminal_view(&mut app);
         let terminal_view = add_window_with_terminal(&mut app, None);
         let terminal_view_id = terminal_view.id();

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -1701,13 +1701,10 @@ impl TerminalManager {
     /// `ctx.spawn` continuations are entity-scoped, so dropping the
     /// entity makes them no-ops; no explicit `.abort()` needed.
     ///
-    /// Under `FeatureFlag::OrchestrationViewerStreamer`, the model also
-    /// holds a viewer-mode registration on the shared
+    /// The model also holds a viewer-mode registration on the shared
     /// [`OrchestrationEventStreamer`]; we unregister explicitly here so
     /// the streamer can refcount-tear-down the ancestor SSE on the last
-    /// pane close. The unregister API is idempotent, so calling it when
-    /// the flag is off (or when the streamer has already removed the
-    /// entry) is harmless.
+    /// pane close. The unregister API is idempotent.
     fn stop_orchestration_polling(
         orchestration_viewer_model: &Arc<FairMutex<Option<ModelHandle<OrchestrationViewerModel>>>>,
         ctx: &mut AppContext,
@@ -1721,11 +1718,9 @@ impl TerminalManager {
             "[orch-viewer] stopping orchestration viewer model parent_task_id={parent_task_id} \
              consumer_id={consumer_id:?}"
         );
-        if FeatureFlag::OrchestrationViewerStreamer.is_enabled() {
-            OrchestrationEventStreamer::handle(ctx).update(ctx, move |streamer, _ctx| {
-                streamer.unregister_viewer_mode_consumer(parent_task_id, consumer_id);
-            });
-        }
+        OrchestrationEventStreamer::handle(ctx).update(ctx, move |streamer, _ctx| {
+            streamer.unregister_viewer_mode_consumer(parent_task_id, consumer_id);
+        });
         // `handle` drops here, releasing the per-pane viewer model.
         drop(handle);
     }

--- a/app/src/terminal/shared_session/viewer/terminal_manager_tests.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager_tests.rs
@@ -59,8 +59,7 @@ fn build_manager_with_registered_ovm(app: &mut App) -> (TerminalManager, Ambient
         history.set_active_conversation_id(id, terminal_view_id, ctx);
     });
 
-    // The OVM registers with the streamer on construction (streamer flag
-    // is expected to be ON in the calling test).
+    // The OVM registers with the streamer on construction.
     let ovm_handle = app.add_model(|ctx| {
         OrchestrationViewerModel::new(parent, terminal_view_id, terminal_view.downgrade(), ctx)
     });
@@ -137,8 +136,6 @@ fn on_view_detached_closed_clears_orchestration_viewer_model_slot() {
     // Regression: closing a viewer pane must drop the OVM and release its
     // streamer registration so the ancestor SSE can be torn down.
     App::test((), |mut app| async move {
-        let _streamer = FeatureFlag::OrchestrationViewerStreamer.override_enabled(true);
-
         initialize_app_for_terminal_view(&mut app);
 
         let (manager, parent) = build_manager_with_registered_ovm(&mut app);
@@ -180,8 +177,6 @@ fn on_view_detached_hidden_for_close_keeps_orchestration_viewer_model_alive() {
     // window. OVM (and the ancestor SSE registration) must stay alive so
     // the pill bar restores seamlessly if the user undoes the close.
     App::test((), |mut app| async move {
-        let _streamer = FeatureFlag::OrchestrationViewerStreamer.override_enabled(true);
-
         initialize_app_for_terminal_view(&mut app);
 
         let (manager, parent) = build_manager_with_registered_ovm(&mut app);
@@ -210,8 +205,6 @@ fn on_view_detached_moved_keeps_orchestration_viewer_model_alive() {
     // to a new pane group. Tearing down the OVM would orphan the pill
     // bar on the moved pane.
     App::test((), |mut app| async move {
-        let _streamer = FeatureFlag::OrchestrationViewerStreamer.override_enabled(true);
-
         initialize_app_for_terminal_view(&mut app);
 
         let (manager, parent) = build_manager_with_registered_ovm(&mut app);

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -709,16 +709,6 @@ pub enum FeatureFlag {
     /// `OrchestrationV2`; has no effect when v2 is off.
     RunAgentsTool,
 
-    /// Replaces `OrchestrationViewerModel`'s REST polling loop with an SSE-driven
-    /// `ancestor_run_id` stream consumed via `OrchestrationEventStreamer`'s new
-    /// viewer-mode entry. Off by default; flipping it on activates the
-    /// per-orchestrator viewer-mode consumer and the broadcast `ChildSpawned`
-    /// / `ChildStatusChanged` events. See `specs/orch-viewer-polling/TECH.md`.
-    OrchestrationViewerStreamer,
-
-    /// Uses a parent-family ancestor stream for owner-side orchestrator event delivery.
-    OwnerOrchestrationAncestorStreamer,
-
     /// On `wait_for_events`, confirms parent status against the server and
     /// registers an orchestrator for the owner-side ancestor stream so it
     /// receives events for children created out-of-band (Oz CLI / web API).


### PR DESCRIPTION
## Description

Removes two feature flags that have been in the default feature set (enabled in all builds) since they stabilized.

## What

**OrchestrationViewerStreamer**: Removes the legacy REST polling path from OrchestrationViewerModel (fetch_children, apply_children_fetch, schedule_next_poll, maybe_kick_polling and the associated struct fields/constants). The SSE-driven path via OrchestrationEventStreamer is now unconditional. Also drops the flag guard in stop_orchestration_polling in terminal_manager.rs.

**OwnerOrchestrationAncestorStreamer**: Parents now always use AncestorRunId { include_self: true } in desired_sse_filter. The UnsupportedRunIdCount variant, its report_error! handler, and MAX_RUN_ID_STREAM_FILTER are removed — the RunIds parent fallback is unreachable because a parent always has self_run_id by the time children exist (the server must assign the parent a run before any child can be created). The RunIds fallback is retained only for non-parent (child-only) conversations.

## Why

Both flags were always on in production. Removing them eliminates ~750 lines of dead code and simplifies the SSE filter logic.

## Testing

- cargo clippy -p warp --tests -- -D warnings passes
- 94 tests across the three affected modules pass (orchestration_viewer_model, orchestration_event_streamer, terminal_manager)
- Legacy polling-path tests deleted; flag override guards removed from remaining tests; two now-invalid without-flag streamer tests deleted

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE