### PR TITLE
Fix orchestration viewer: defer child registration when parent conversation not yet available (REMOTE-2141)

### DIFF
--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model.rs
@@ -70,9 +70,15 @@ pub struct OrchestrationViewerModel {
     /// (Polling path.) Bumped before each fetch so stale responses can
     /// be dropped.
     fetch_generation: u64,
-    /// Set when the most recent fetch returned no children; resumed by
-    /// the next orchestrator `AppendedExchange`.
+    /// Set when the most recent fetch returned no children from the server;
+    /// resumed by the next orchestrator `AppendedExchange`. Note: this is only
+    /// set when the server truly returns no tasks, not when tasks were returned
+    /// but couldn't be registered yet due to a missing parent conversation.
     idle_due_to_no_children: bool,
+    /// Tasks returned by the server that couldn't be registered yet because
+    /// the parent conversation wasn't set. Retried when `SetActiveConversation`
+    /// fires for this terminal surface.
+    deferred_tasks: Vec<AmbientAgentTask>,
     /// (Streamer path.) Periodic timer fetching the claim-time
     /// `session_id` for not-yet-claimed children.
     pending_session_id_poll_handle: Option<SpawnedFutureHandle>,
@@ -122,6 +128,7 @@ impl OrchestrationViewerModel {
                 polling_handle: None,
                 fetch_generation: 0,
                 idle_due_to_no_children: false,
+                deferred_tasks: Vec::new(),
                 pending_session_id_poll_handle: None,
                 #[cfg(test)]
                 metadata_fetch_dispatch_count: 0,
@@ -150,6 +157,7 @@ impl OrchestrationViewerModel {
             polling_handle: None,
             fetch_generation: 0,
             idle_due_to_no_children: false,
+            deferred_tasks: Vec::new(),
             pending_session_id_poll_handle: None,
             #[cfg(test)]
             metadata_fetch_dispatch_count: 0,
@@ -183,8 +191,29 @@ impl OrchestrationViewerModel {
                 ..
             } if *terminal_surface_id == self.terminal_view_id => {
                 self.register_viewer_mode_consumer_if_possible(ctx);
+                // Retry any tasks that were deferred because the parent conversation
+                // wasn't available yet when they were first received.
+                self.flush_deferred_tasks(ctx);
             }
             _ => {}
+        }
+    }
+
+    /// Registers any previously-deferred tasks (tasks that arrived before the
+    /// parent conversation was set). Called when the active conversation becomes
+    /// available so chips and agent names resolve correctly.
+    fn flush_deferred_tasks(&mut self, ctx: &mut ModelContext<Self>) {
+        if self.deferred_tasks.is_empty() {
+            return;
+        }
+        let tasks = std::mem::take(&mut self.deferred_tasks);
+        log::info!(
+            "[orch-viewer] flushing {} deferred child task(s) for parent_task_id={}",
+            tasks.len(),
+            self.parent_task_id,
+        );
+        for task in tasks {
+            self.register_child(task, ctx);
         }
     }
 
@@ -404,7 +433,8 @@ impl OrchestrationViewerModel {
 
         // New child: register under the orchestrator's local conversation.
         // Without an active parent conversation, `start_new_child_conversation`
-        // would lose the parent linkage. Drop and try again next cycle/event.
+        // would lose the parent linkage. Defer and retry when the parent
+        // conversation becomes available (via `flush_deferred_tasks`).
         let Some(parent_conversation_id) = self.find_parent_conversation_id(ctx) else {
             log::warn!(
                 "[orch-viewer] no active parent conversation for terminal_view_id={:?} \
@@ -412,6 +442,11 @@ impl OrchestrationViewerModel {
                 self.terminal_view_id,
                 self.parent_task_id,
             );
+            // Store the task so it can be retried once the parent conversation
+            // is established. Avoid duplicates if the same task is deferred twice.
+            if !self.deferred_tasks.iter().any(|t| t.task_id == task_id) {
+                self.deferred_tasks.push(task);
+            }
             return;
         };
 
@@ -614,6 +649,9 @@ impl OrchestrationViewerModel {
                 if let Some(prior) = self.polling_handle.take() {
                     prior.abort();
                 }
+                // Flush any deferred tasks before fetching so they can
+                // register now that the parent conversation is available.
+                self.flush_deferred_tasks(ctx);
                 self.fetch_children(ctx);
             }
             return;
@@ -742,16 +780,21 @@ impl OrchestrationViewerModel {
     /// so an empty descendant list parks the timer chain until the next
     /// orchestrator `AppendedExchange` resumes it.
     fn apply_children_fetch(&mut self, tasks: Vec<AmbientAgentTask>, ctx: &mut ModelContext<Self>) {
+        let server_returned_tasks = !tasks.is_empty();
         for task in tasks {
             self.register_child(task, ctx);
         }
 
-        // Polling-cost mitigation: if no children are tracked after this
-        // fetch, stop scheduling timers. The resume signal is an
-        // `AppendedExchange` on the orchestrator (see
-        // `maybe_kick_polling`). `schedule_next_poll` honours this flag
-        // and bails before spawning a new timer.
-        if self.children.is_empty() {
+        // Polling-cost mitigation: if the server returned no children and none
+        // are tracked, stop scheduling timers. The resume signal is an
+        // `AppendedExchange` on the orchestrator (see `maybe_kick_polling`).
+        //
+        // IMPORTANT: only enter idle mode when the server truly returned no
+        // tasks. If the server returned tasks but they couldn't be registered
+        // yet (e.g. the parent conversation isn't set, so they were deferred),
+        // keep polling so deferred tasks have a chance to register on the next
+        // cycle.
+        if self.children.is_empty() && !server_returned_tasks && self.deferred_tasks.is_empty() {
             self.idle_due_to_no_children = true;
             if let Some(prior) = self.polling_handle.take() {
                 prior.abort();

--- a/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
+++ b/app/src/terminal/shared_session/viewer/orchestration_viewer_model_tests.rs
@@ -187,6 +187,7 @@ fn setup_model(
         polling_handle: None,
         fetch_generation: 0,
         idle_due_to_no_children: false,
+        deferred_tasks: Vec::new(),
         pending_session_id_poll_handle: None,
         metadata_fetch_dispatch_count: 0,
     };


### PR DESCRIPTION
## Description

Fixes a regression where orchestration agent chips (pill bar) were missing and child agents showed as "Unknown agent" when viewing a cloud Oz orchestrated run's session in the Warp client.

**Root cause:** A race condition in `OrchestrationViewerModel::register_child`. When the orchestration viewer first discovers child runs (via ancestor seed fetch or legacy polling), `find_parent_conversation_id` can return `None` because the parent conversation hasn't been established yet — the `StreamInit` event from the shared session hasn't been processed. Previously, child tasks were silently dropped with no retry, so chips and agent names never appeared.

Additionally, in the legacy polling path, when all child tasks failed to register (because the parent wasn't available), `idle_due_to_no_children = true` was set incorrectly. This stopped all future polling — even once the parent conversation became available — permanently preventing chips from appearing for completed/historical runs.

**Fix:**
- Introduce a `deferred_tasks` queue: when `register_child` can't find the parent conversation, store the task instead of dropping it
- Flush deferred tasks when the parent conversation becomes available:
  - On `SetActiveConversation`/`ConversationServerTokenAssigned` events (streaming path)
  - On orchestrator `AppendedExchange` when idle polling resumes (legacy path)
- Fix the `idle_due_to_no_children` flag: only enter idle when the server truly returned no tasks, not when tasks were received but deferred

## Linked Issue

Linear: REMOTE-2141

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

This fix addresses a race condition in the orchestration viewer model. Existing tests in `orchestration_viewer_model_tests.rs` continue to pass. The change adds the `deferred_tasks` field to the struct and updates the `setup_model` test helper accordingly.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable
CHANGELOG-BUG-FIX: Fixed missing orchestration agent chips and 'Unknown agent' labels when viewing cloud Oz orchestrated run sessions
-->

_Conversation: https://staging.warp.dev/conversation/e62aba4c-20f8-4129-a8b9-adaadd08f4c8_
_Run: https://oz.staging.warp.dev/runs/019f5cde-2c2d-7ac3-b8b7-f0d0945220bf_

_This PR was generated with [Oz](https://warp.dev/oz)._
