### PR TITLE
fix(terminal): close stale classic completion menu after backspacing past original prefix

### DIFF
--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -11636,56 +11636,47 @@ impl Input {
             return true;
         }
 
+        // The current word is everything from the start of the replacement to the
+        // cursor.
+        let current_word = &editor_text[replacement_start..cursor_position.as_usize()];
+
+        // In classic completion mode, check if the user is actively cycling through
+        // completions (selected item matches current word). If so, keep the menu open
+        // without filtering, since cycling inserts the completion text directly.
+        if self.is_classic_completions_enabled(ctx) {
+            let current_selected_item =
+                self.input_suggestions.as_ref(ctx).get_selected_item_text();
+            if current_selected_item.is_some_and(|selected| selected == current_word) {
+                return false;
+            }
+        }
+
         // If the buffer no longer starts with the original buffer text,
         // then we should close the completion menu because the result set
-        // was based on a different query.
-        //
-        // For classic completions, this is a poor heuristic: when you cycle
-        // through fuzzy matches, the text up to the cursor might not start
-        // with the original buffer text anymore.
-        // TODO: there's a bug here where if you hit tab and backspace,
-        // the result set won't go away (stale).
-        if !text_up_to_cursor.starts_with(buffer_text_original)
-            && !self.is_classic_completions_enabled(ctx)
-        {
-            // Close the input suggestions since the buffer was edited to no longer
-            // contain the text that triggered tab completion.
-            true
-        } else {
-            // The current word is everything from the start of the replacement to the
-            // cursor
-            let current_word = &editor_text[replacement_start..cursor_position.as_usize()];
-
-            if self.is_classic_completions_enabled(ctx) {
-                let current_selected_item =
-                    self.input_suggestions.as_ref(ctx).get_selected_item_text();
-                if current_selected_item.is_some_and(|selected| selected == current_word) {
-                    // If we're in classic completion mode and the selected item is equal
-                    // to the current word, then we should keep the menu open; the user is cycling.
-                    // We early-return because we don't want to filter the menu based on the
-                    // selected item.
-                    return false;
-                }
-            }
-
-            // If the user continues to type with the tab suggestions open, we perform a
-            // prefix search on the original results to filter the suggestions.
-            let should_close = self.input_suggestions.update(ctx, |suggestions, ctx| {
-                suggestions.prefix_search_for_tab_completion(
-                    current_word,
-                    completion_results,
-                    TabCompletionsPreselectOption::Unchanged,
-                    ctx,
-                );
-
-                // We should close the menu if there aren't any results
-                // after filtering.
-                suggestions.items().is_empty()
-            });
-
-            ctx.notify();
-            should_close
+        // was based on a different query. This applies in both classic and
+        // non-classic modes: if the user has edited away from the original
+        // prefix, the cached suggestions are stale.
+        if !text_up_to_cursor.starts_with(buffer_text_original) {
+            return true;
         }
+
+        // If the user continues to type with the tab suggestions open, we perform a
+        // prefix search on the original results to filter the suggestions.
+        let should_close = self.input_suggestions.update(ctx, |suggestions, ctx| {
+            suggestions.prefix_search_for_tab_completion(
+                current_word,
+                completion_results,
+                TabCompletionsPreselectOption::Unchanged,
+                ctx,
+            );
+
+            // We should close the menu if there aren't any results
+            // after filtering.
+            suggestions.items().is_empty()
+        });
+
+        ctx.notify();
+        should_close
     }
 
     fn clear_screen(&mut self, ctx: &mut ViewContext<Self>) {


### PR DESCRIPTION
## Summary

With Classic Completions enabled, pressing Tab to open the completion menu and then backspacing past the original prefix left the stale suggestion list on screen. The result set was computed for a different query than what was in the input, and backspacing to an empty prefix re-showed the entire original result set.

## Root Cause

The TODO in `update_tab_completion_menu` (app/src/terminal/input.rs:11646) called this out explicitly: the staleness check that closes the menu when `text_up_to_cursor` no longer starts with the original buffer text was gated by `&& !self.is_classic_completions_enabled(ctx)`, so classic completions never invalidated stale results.

This exception was added because cycling through fuzzy matches could temporarily put non-prefix text in the buffer. However, the active-cycling case was already handled by a separate check (`current_selected_item == current_word`), which came _after_ the staleness check and was therefore unreachable when the buffer diverged from the original prefix.

## Fix

Restructure `update_tab_completion_menu` to:

1. Compute `current_word` early.
2. Check the active-cycling case _before_ the staleness check so Tab cycling keeps the menu open in classic mode.
3. Run the staleness check in **both** classic and non-classic modes, removing the exception that prevented stale-result closure.
4. Flatten the control flow (no more if/else nesting).

This preserves Tab cycling behavior while properly closing the menu when the user edits away from the original prefix, matching the non-classic completions behavior.

Fixes #13605

## Test plan

- Enabled classic completions mode.
- In a directory with `Documents/` and `Downloads/`, typed `cd Do` → Tab → Backspace repeatedly.
- Verified that backspacing past the original `Do` prefix closes the stale completion menu.
- Verified that Tab cycling between `Documents/` and `Downloads/` still works correctly.
- Verified that continued typing after Tab (e.g. `cd Doc`) still filters results correctly.

CHANGELOG-BUG-FIX: Classic completions menu now properly closes when backspacing past the original query prefix instead of showing stale results.