### PR TITLE
Drop Pty Spawned telemetry emission

### DIFF
--- a/app/src/terminal/local_tty/spawner.rs
+++ b/app/src/terminal/local_tty/spawner.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 #[cfg(unix)]
 use warp_errors::report_error;
-use warpui::{AppContext, Entity, SingletonEntity};
+use warpui::{Entity, SingletonEntity};
 #[cfg(unix)]
 use {
     crate::terminal::local_tty::server::TerminalServer, anyhow::bail, std::cmp::Reverse,
@@ -11,8 +11,6 @@ use {
 #[cfg(target_os = "windows")]
 use super::PseudoConsoleChild;
 use super::{PtyOptions, PtySpawnResult};
-use crate::send_telemetry_from_app_ctx;
-use crate::server::telemetry::{PtySpawnMode, TelemetryEvent};
 use crate::terminal::local_tty::{self};
 /// A handle that can be used to interact with a pty process.
 pub trait PtyHandle: Send + Sync {
@@ -176,13 +174,7 @@ impl PtySpawner {
         #[cfg(windows)] event_loop_tx: super::mio_channel::Sender<
             crate::terminal::writeable_pty::Message,
         >,
-        ctx: &mut AppContext,
     ) -> Result<(PtySpawnResult, Box<dyn PtyHandle>)> {
-        #[cfg(not(unix))]
-        let is_fallback = false;
-        #[cfg(unix)]
-        let mut is_fallback = false;
-
         #[cfg(unix)]
         if let Some(server) = &self.server {
             let result = Self::spawn_pty_via_server(server, options.clone());
@@ -206,24 +198,10 @@ impl PtySpawner {
                 report_error!(err.context(
                     "Failed to spawn pty via terminal server; falling back to spawning locally...",
                 ));
-                is_fallback = true;
             } else {
-                send_telemetry_from_app_ctx!(
-                    TelemetryEvent::PtySpawned {
-                        mode: PtySpawnMode::TerminalServer
-                    },
-                    ctx
-                );
                 return result;
             }
         }
-
-        let mode = if is_fallback {
-            PtySpawnMode::FallbackToDirect
-        } else {
-            PtySpawnMode::Direct
-        };
-        send_telemetry_from_app_ctx!(TelemetryEvent::PtySpawned { mode }, ctx);
 
         Self::spawn_pty_directly(
             options,

--- a/app/src/terminal/local_tty/unix.rs
+++ b/app/src/terminal/local_tty/unix.rs
@@ -603,8 +603,8 @@ impl Pty {
             .context("error preparing signal handling")?;
 
         let (PtySpawnResult { pid, leader_fd }, pty_handle) = PtySpawner::handle(ctx)
-            .update(ctx, |pty_spawner, ctx| {
-                pty_spawner.spawn_pty(options, is_crash_reporting_enabled, ctx)
+            .update(ctx, |pty_spawner, _| {
+                pty_spawner.spawn_pty(options, is_crash_reporting_enabled)
             })?;
 
         log::info!(

--- a/app/src/terminal/local_tty/windows/mod.rs
+++ b/app/src/terminal/local_tty/windows/mod.rs
@@ -345,8 +345,8 @@ impl Pty {
     ) -> anyhow::Result<Self> {
         let size = options.size;
         PtySpawner::handle(ctx)
-            .update(ctx, |pty_spawner, ctx| {
-                pty_spawner.spawn_pty(options, is_crash_reporting_enabled, event_loop_tx, ctx)
+            .update(ctx, |pty_spawner, _| {
+                pty_spawner.spawn_pty(options, is_crash_reporting_enabled, event_loop_tx)
             })
             .map(
                 |(


### PR DESCRIPTION
## Description
Split from #13554 to only remove the `Pty Spawned` telemetry emission. This change removes `TelemetryEvent::PtySpawned` sends in PTY spawn paths and removes the now-unneeded `AppContext` argument plumbing for `PtySpawner::spawn_pty` call sites.

## Linked Issue
N/A (split-out follow-up from #13554)
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [ ] I have manually tested my changes locally with `./script/run`
- `./script/format`
- `cargo clippy --workspace --all-targets --all-features --tests -- -D warnings` *(fails in this environment: `xcrun: error: unable to find utility "metal"`)*

### Screenshots / Videos
Not applicable (no user-visible UI change).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>
