### PR TITLE
Remove Gemini and OpenCode multi-harness cloud agent support

### DIFF
--- a/app/src/ai/agent/conversation.rs
+++ b/app/src/ai/agent/conversation.rs
@@ -4449,7 +4449,6 @@ impl TryFrom<String> for AIConversationId {
 pub enum AIAgentHarness {
     Oz,
     ClaudeCode,
-    Gemini,
     Codex,
     Unknown,
 }

--- a/app/src/ai/agent_conversations_model_tests.rs
+++ b/app/src/ai/agent_conversations_model_tests.rs
@@ -2114,13 +2114,13 @@ fn test_harness_filter_matches_only_selected_harness() {
         let mut model = create_test_model();
 
         let task_claude = task_with_harness(5100, "user-a", Some(Some(Harness::Claude)));
-        let task_gemini = task_with_harness(5101, "user-a", Some(Some(Harness::Gemini)));
+        let task_codex = task_with_harness(5101, "user-a", Some(Some(Harness::Codex)));
         let task_oz_default = task_with_harness(5102, "user-a", Some(None));
         let task_no_snapshot = task_with_harness(5103, "user-a", None);
 
         for task in [
             &task_claude,
-            &task_gemini,
+            &task_codex,
             &task_oz_default,
             &task_no_snapshot,
         ] {
@@ -2159,8 +2159,8 @@ fn test_harness_filter_matches_only_selected_harness() {
             let claude_items = items_for(HarnessFilter::Specific(Harness::Claude));
             assert_eq!(claude_items, vec![format!("task:{}", task_claude.task_id)]);
 
-            let gemini_items = items_for(HarnessFilter::Specific(Harness::Gemini));
-            assert_eq!(gemini_items, vec![format!("task:{}", task_gemini.task_id)]);
+            let codex_items = items_for(HarnessFilter::Specific(Harness::Codex));
+            assert_eq!(codex_items, vec![format!("task:{}", task_codex.task_id)]);
 
             let oz_items = items_for(HarnessFilter::Specific(Harness::Oz));
             assert_eq!(

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -2183,7 +2183,7 @@ impl AgentDriver {
                             .await?,
                     )
                 }
-                HarnessKind::ThirdParty(_) | HarnessKind::Unsupported(_) => None,
+                HarnessKind::ThirdParty(_) => None,
             };
 
             let harness = task.harness.harness();
@@ -2379,12 +2379,6 @@ impl AgentDriver {
                 )
                 .await
             }
-            HarnessKind::Unsupported(harness) => Err(AgentDriverError::HarnessSetupFailed {
-                harness: harness.to_string(),
-                reason: format!(
-                    "The {harness} harness is only supported for local child agent launches."
-                ),
-            }),
         }
     }
 

--- a/app/src/ai/agent_sdk/driver/harness/mod.rs
+++ b/app/src/ai/agent_sdk/driver/harness/mod.rs
@@ -40,14 +40,12 @@ pub(crate) mod claude_code;
 pub(crate) mod claude_transcript;
 mod codex;
 pub(crate) mod codex_transcript;
-mod gemini;
 mod json_utils;
 mod telemetry;
 pub(crate) use claude_code::ClaudeHarness;
 use claude_transcript::ClaudeResumeInfo;
 use codex::CodexHarness;
 use codex_transcript::CodexResumeInfo;
-use gemini::GeminiHarness;
 pub(crate) use telemetry::ThirdPartyHarnessTelemetryEvent;
 
 /// Harness-agnostic payload describing how to resume an existing conversation.
@@ -252,8 +250,6 @@ pub(crate) fn harness_kind(harness: Harness) -> Result<HarnessKind, AgentDriverE
         Harness::Oz => Ok(HarnessKind::Oz),
         Harness::Claude => Ok(HarnessKind::ThirdParty(Box::new(ClaudeHarness))),
         Harness::Codex => Ok(HarnessKind::ThirdParty(Box::new(CodexHarness))),
-        Harness::OpenCode => Ok(HarnessKind::Unsupported(Harness::OpenCode)),
-        Harness::Gemini => Ok(HarnessKind::ThirdParty(Box::new(GeminiHarness))),
         Harness::Unknown => Err(AgentDriverError::InvalidRuntimeState),
     }
 }
@@ -447,7 +443,7 @@ pub(crate) fn harness_model_env_vars(
         Harness::Claude => {
             env_vars.insert(OsString::from("ANTHROPIC_MODEL"), OsString::from(model_id));
         }
-        Harness::Oz | Harness::OpenCode | Harness::Gemini | Harness::Codex | Harness::Unknown => {}
+        Harness::Oz | Harness::Codex | Harness::Unknown => {}
     }
 
     env_vars

--- a/app/src/ai/agent_sdk/driver/harness/mod.rs
+++ b/app/src/ai/agent_sdk/driver/harness/mod.rs
@@ -216,11 +216,8 @@ pub(crate) trait ThirdPartyHarness: Send + Sync {
 /// Harness type for driver dispatch.
 pub(crate) enum HarnessKind {
     Oz,
-    /// Third-party CLI-backed harness (e.g. Claude, Gemini).
+    /// Third-party CLI-backed harness (e.g. Claude).
     ThirdParty(Box<dyn ThirdPartyHarness>),
-    /// Harnesses that exist in the shared CLI enum but are not supported by the
-    /// standalone agent driver.
-    Unsupported(Harness),
 }
 
 impl HarnessKind {
@@ -229,7 +226,6 @@ impl HarnessKind {
         match self {
             HarnessKind::Oz => Harness::Oz,
             HarnessKind::ThirdParty(h) => h.harness(),
-            HarnessKind::Unsupported(harness) => *harness,
         }
     }
 }

--- a/app/src/ai/agent_sdk/driver/harness/mod_tests.rs
+++ b/app/src/ai/agent_sdk/driver/harness/mod_tests.rs
@@ -53,27 +53,8 @@ fn codex_runtime_error_patterns_returns_slice() {
 }
 
 #[test]
-fn gemini_runtime_error_patterns_is_empty_by_default() {
-    use super::gemini::GeminiHarness;
-    use super::ThirdPartyHarness;
-    assert!(GeminiHarness.runtime_error_patterns().is_empty());
-}
-
-#[test]
-fn auth_check_command_for_gemini_is_none() {
-    assert!(auth_check_command_for(Harness::Gemini).is_none());
-}
-
-#[test]
 fn auth_check_command_for_oz_is_none() {
     assert!(auth_check_command_for(Harness::Oz).is_none());
-}
-
-#[test]
-fn auth_check_command_for_unsupported_is_none() {
-    // OpenCode is mapped to HarnessKind::Unsupported and therefore has no
-    // auth check command of its own.
-    assert!(auth_check_command_for(Harness::OpenCode).is_none());
 }
 
 #[test]

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -617,17 +617,6 @@ fn task_env_vars_propagate_message_listener_state_root_with_legacy_alias() {
 }
 
 #[test]
-fn task_env_vars_can_use_opencode_harness() {
-    let task_id: AmbientAgentTaskId = "550e8400-e29b-41d4-a716-446655440004".parse().unwrap();
-    let env_vars = task_env_vars(Some(&task_id), Some("parent-run-456"), Harness::OpenCode);
-
-    assert_eq!(
-        env_vars.get(&OsString::from(OZ_HARNESS_ENV)),
-        Some(&OsString::from("opencode"))
-    );
-}
-
-#[test]
 fn json_format_output_includes_filename_for_file_artifact_created_event() {
     let output = AIAgentOutput {
         messages: vec![AIAgentOutputMessage::artifact_created(

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -270,12 +270,6 @@ fn run_agent(
             if args.harness != Harness::Oz && !FeatureFlag::AgentHarness.is_enabled() {
                 return Err(anyhow::anyhow!("unexpected argument '--harness' found"));
             }
-            if args.harness == Harness::OpenCode {
-                return Err(anyhow::anyhow!(
-                    "The opencode harness is only supported for local child agent launches."
-                ));
-            }
-
             let server_api = ServerApiProvider::handle(ctx).as_ref(ctx).get_ai_client();
 
             // Start the agent driver runner, which will handle the rest of the setup steps
@@ -1656,8 +1650,6 @@ fn resolve_orchestration_harness_label() -> &'static str {
     match Harness::parse_orchestration_harness(&raw) {
         Some(Harness::Oz) => "oz",
         Some(Harness::Claude) => "claude",
-        Some(Harness::OpenCode) => "opencode",
-        Some(Harness::Gemini) => "gemini",
         Some(Harness::Codex) => "codex",
         Some(Harness::Unknown) | None => "unknown",
     }

--- a/app/src/ai/agent_sdk/mod.rs
+++ b/app/src/ai/agent_sdk/mod.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use ai::api_keys::{ApiKeyManager, AwsCredentialsRefreshStrategy};
 use anyhow::Context;
-pub(crate) use driver::harness::{task_env_vars, validate_cli_installed, ClaudeHarness};
+pub(crate) use driver::harness::{task_env_vars, ClaudeHarness};
 pub use driver::AgentDriver;
 use driver::AgentDriverError;
 use telemetry::CliTelemetryEvent;
@@ -740,18 +740,6 @@ impl AgentDriverRunner {
                     .map_err(AgentDriverError::AwsBedrockCredentialsFailed)?;
             }
 
-            match &task.harness {
-                HarnessKind::Unsupported(harness) => {
-                    return Err(AgentDriverError::HarnessSetupFailed {
-                        harness: harness.to_string(),
-                        reason: format!(
-                            "The {harness} harness is only supported for local child agent launches."
-                        ),
-                    });
-                }
-                HarnessKind::Oz | HarnessKind::ThirdParty(_) => {}
-            }
-
             // Validate that the third-party harness is installed and authed.
             if let HarnessKind::ThirdParty(harness) = &task.harness {
                 harness.validate()?;
@@ -1397,12 +1385,6 @@ impl AgentDriverRunner {
                         .map(|payload| driver::ResumeOptions::ThirdParty(Box::new(payload))),
                 )
             }
-            HarnessKind::Unsupported(harness) => Err(AgentDriverError::HarnessSetupFailed {
-                harness: harness.to_string(),
-                reason: format!(
-                    "The {harness} harness is only supported for local child agent launches."
-                ),
-            }),
         }
     }
 

--- a/app/src/ai/agent_sdk/mod_tests.rs
+++ b/app/src/ai/agent_sdk/mod_tests.rs
@@ -100,23 +100,6 @@ fn run_message_send_telemetry_supports_claude_code_alias() {
 
 #[test]
 #[serial_test::serial]
-fn run_message_send_telemetry_supports_opencode_harness() {
-    std::env::set_var("OZ_HARNESS", "opencode");
-    let event = command_to_telemetry_event(&CliCommand::Run(TaskCommand::Message(
-        MessageCommand::Send(MessageSendArgs {
-            to: vec!["run-456".to_string()],
-            subject: "subject".to_string(),
-            body: "body".to_string(),
-            sender_run_id: "run-123".to_string(),
-        }),
-    )));
-    std::env::remove_var("OZ_HARNESS");
-
-    assert_eq!(event.payload(), Some(json!({ "harness": "opencode" })));
-}
-
-#[test]
-#[serial_test::serial]
 fn run_message_send_telemetry_defaults_to_unknown_harness() {
     std::env::remove_var("OZ_HARNESS");
     let event = command_to_telemetry_event(&CliCommand::Run(TaskCommand::Message(
@@ -153,13 +136,13 @@ fn reconcile_task_harness_allows_matching_explicit_harness() {
 
 #[test]
 fn reconcile_task_harness_rejects_explicit_mismatch() {
-    let mut selected_harness = Harness::Gemini;
+    let mut selected_harness = Harness::Codex;
     let err = reconcile_task_harness(TASK_ID, &mut selected_harness, Harness::Claude)
         .expect_err("mismatched harness should fail");
 
-    assert_eq!(selected_harness, Harness::Gemini);
+    assert_eq!(selected_harness, Harness::Codex);
     assert!(err.to_string().contains("Task"));
-    assert!(err.to_string().contains("--harness gemini"));
+    assert!(err.to_string().contains("--harness codex"));
     assert!(err.to_string().contains("claude"));
 }
 

--- a/app/src/ai/blocklist/action_model/execute/start_agent.rs
+++ b/app/src/ai/blocklist/action_model/execute/start_agent.rs
@@ -436,16 +436,6 @@ impl StartAgentExecutor {
                 let harness_type = Harness::parse_orchestration_harness(&harness_type)
                     .map(|harness| harness.to_string())
                     .unwrap_or(harness_type);
-                if Harness::parse_orchestration_harness(&harness_type) == Some(Harness::OpenCode) {
-                    return ActionExecution::Sync(AIAgentActionResultType::StartAgent(
-                        StartAgentResult::Error {
-                            error: "Remote child agents do not support the opencode harness yet."
-                                .to_string(),
-                            version,
-                        },
-                    ));
-                }
-
                 // An empty environment_id is allowed and means the child will be spawned with an
                 // empty environment (no preconfigured repositories, secrets, or integrations).
                 // Callers are discouraged from relying on this, but we intentionally do not reject

--- a/app/src/ai/blocklist/history_model/conversation_loader.rs
+++ b/app/src/ai/blocklist/history_model/conversation_loader.rs
@@ -144,7 +144,7 @@ pub async fn load_conversation_from_server(
                         }
                     }
                 }
-                AIAgentHarness::ClaudeCode | AIAgentHarness::Gemini | AIAgentHarness::Codex => {
+                AIAgentHarness::ClaudeCode | AIAgentHarness::Codex => {
                     if !FeatureFlag::AgentHarness.is_enabled() {
                         log::warn!(
                             "Ignoring non-Oz conversation {conversation_id}: AgentHarness flag is disabled"

--- a/app/src/ai/blocklist/inline_action/orchestration_controls.rs
+++ b/app/src/ai/blocklist/inline_action/orchestration_controls.rs
@@ -665,29 +665,20 @@ pub fn populate_harness_picker<A: OrchestrationControlAction, V: View>(
         let harnesses = availability.available_harnesses();
 
         let resolve_entry_harness = |harness: Harness, display_name: &str| match harness {
-            Harness::Unknown => [
-                Harness::Oz,
-                Harness::Claude,
-                Harness::OpenCode,
-                Harness::Gemini,
-                Harness::Codex,
-            ]
-            .into_iter()
-            .find(|candidate| harness_display::display_name(*candidate) == display_name)
-            .unwrap_or(Harness::Unknown),
+            Harness::Unknown => [Harness::Oz, Harness::Claude, Harness::Codex]
+                .into_iter()
+                .find(|candidate| harness_display::display_name(*candidate) == display_name)
+                .unwrap_or(Harness::Unknown),
             harness => harness,
         };
 
         // Sort selectable harnesses before disabled ones, preserving
         // relative order within each group.
-        // Filter out Gemini — it is not yet supported as a multi-agent
-        // harness and causes an infinite "Spawning agents" hang.
         let mut sorted: Vec<_> = harnesses
             .iter()
             .filter(|entry| {
                 let harness = resolve_entry_harness(entry.harness, &entry.display_name);
-                harness != Harness::Gemini
-                    && (!is_local || local_harness_is_product_enabled(harness))
+                !is_local || local_harness_is_product_enabled(harness)
             })
             .collect();
         sorted.sort_by_key(|entry| {

--- a/app/src/ai/conversation_details_panel.rs
+++ b/app/src/ai/conversation_details_panel.rs
@@ -798,7 +798,7 @@ impl ConversationDetailsPanel {
                             .find_conversation_id_by_server_token(&server_token)
                             .map(DetailsPanelLocalContinuationInfo::Conversation)
                     }
-                    Some(Harness::Gemini | Harness::OpenCode | Harness::Unknown) => None,
+                    Some(Harness::Unknown) => None,
                 }
             }
         }

--- a/app/src/ai/conversation_details_panel_tests.rs
+++ b/app/src/ai/conversation_details_panel_tests.rs
@@ -265,7 +265,6 @@ fn test_from_conversation_metadata_passes_harness_through() {
         None,
         Some(Harness::Oz),
         Some(Harness::Claude),
-        Some(Harness::Gemini),
         Some(Harness::Unknown),
     ] {
         let data = ConversationDetailsData::from_conversation_metadata(
@@ -311,12 +310,7 @@ fn test_from_task_resolves_harness() {
             assert_eq!(data.harness, Some(Harness::Oz));
 
             // Snapshot with explicit harness_type.
-            for harness in [
-                Harness::Oz,
-                Harness::Claude,
-                Harness::Gemini,
-                Harness::Unknown,
-            ] {
+            for harness in [Harness::Oz, Harness::Claude, Harness::Unknown] {
                 let mut task = base_task.clone();
                 task.agent_config_snapshot = Some(AgentConfigSnapshot {
                     harness: Some(HarnessConfig::from_harness_type(harness)),

--- a/app/src/ai/harness_availability.rs
+++ b/app/src/ai/harness_availability.rs
@@ -407,9 +407,8 @@ fn harness_to_graphql_harness(harness: Harness) -> Option<warp_graphql::ai::Agen
     match harness {
         Harness::Oz => Some(warp_graphql::ai::AgentHarness::Oz),
         Harness::Claude => Some(warp_graphql::ai::AgentHarness::ClaudeCode),
-        Harness::Gemini => Some(warp_graphql::ai::AgentHarness::Gemini),
         Harness::Codex => Some(warp_graphql::ai::AgentHarness::Codex),
-        Harness::OpenCode | Harness::Unknown => None,
+        Harness::Unknown => None,
     }
 }
 

--- a/app/src/ai/harness_display.rs
+++ b/app/src/ai/harness_display.rs
@@ -11,7 +11,7 @@ use warp_core::ui::theme::{Fill as WarpThemeFill, WarpTheme};
 
 use crate::ai::agent::conversation::AIAgentHarness;
 use crate::ai::blocklist::CLAUDE_ORANGE;
-use crate::terminal::cli_agent::{GEMINI_BLUE, OPENAI_COLOR, OPENCODE_COLOR};
+use crate::terminal::cli_agent::OPENAI_COLOR;
 use crate::ui_components::icons::Icon;
 
 /// User-visible display name for a [`Harness`].
@@ -19,8 +19,6 @@ pub fn display_name(harness: Harness) -> &'static str {
     match harness {
         Harness::Oz => "Warp",
         Harness::Claude => "Claude Code",
-        Harness::OpenCode => "OpenCode",
-        Harness::Gemini => "Gemini CLI",
         Harness::Codex => "Codex",
         Harness::Unknown => "Unknown",
     }
@@ -31,8 +29,6 @@ pub fn icon_for(harness: Harness) -> Icon {
     match harness {
         Harness::Oz => Icon::Warp,
         Harness::Claude => Icon::ClaudeLogo,
-        Harness::OpenCode => Icon::OpenCodeLogo,
-        Harness::Gemini => Icon::GeminiLogo,
         Harness::Codex => Icon::OpenAILogo,
         Harness::Unknown => Icon::HelpCircle,
     }
@@ -44,8 +40,6 @@ pub fn brand_color(harness: Harness) -> Option<ColorU> {
     match harness {
         Harness::Oz => None,
         Harness::Claude => Some(CLAUDE_ORANGE),
-        Harness::OpenCode => None,
-        Harness::Gemini => Some(GEMINI_BLUE),
         Harness::Codex => Some(OPENAI_COLOR),
         Harness::Unknown => None,
     }
@@ -58,8 +52,6 @@ pub fn circle_background(harness: Harness, theme: &WarpTheme) -> WarpThemeFill {
         Harness::Oz => theme.background(),
         Harness::Claude => WarpThemeFill::Solid(CLAUDE_ORANGE),
         Harness::Codex => WarpThemeFill::Solid(OPENAI_COLOR),
-        Harness::Gemini => WarpThemeFill::Solid(GEMINI_BLUE),
-        Harness::OpenCode => WarpThemeFill::Solid(OPENCODE_COLOR),
         Harness::Unknown => internal_colors::fg_overlay_2(theme),
     }
 }
@@ -68,9 +60,7 @@ pub fn circle_background(harness: Harness, theme: &WarpTheme) -> WarpThemeFill {
 pub fn icon_fill_on_circle(harness: Harness, theme: &WarpTheme) -> WarpThemeFill {
     match harness {
         Harness::Oz => theme.main_text_color(theme.background()),
-        Harness::Claude | Harness::Codex | Harness::Gemini | Harness::OpenCode => {
-            WarpThemeFill::Solid(ColorU::white())
-        }
+        Harness::Claude | Harness::Codex => WarpThemeFill::Solid(ColorU::white()),
         Harness::Unknown => theme.main_text_color(internal_colors::fg_overlay_2(theme)),
     }
 }
@@ -82,7 +72,6 @@ impl From<AIAgentHarness> for Harness {
         match harness {
             AIAgentHarness::Oz => Harness::Oz,
             AIAgentHarness::ClaudeCode => Harness::Claude,
-            AIAgentHarness::Gemini => Harness::Gemini,
             AIAgentHarness::Codex => Harness::Codex,
             AIAgentHarness::Unknown => Harness::Unknown,
         }

--- a/app/src/ai/local_harness_setup.rs
+++ b/app/src/ai/local_harness_setup.rs
@@ -36,9 +36,7 @@ pub(crate) fn local_harness_product_disabled_message(harness: Harness) -> Option
         Harness::Codex if !local_codex_harness_is_enabled() => {
             Some(LOCAL_CODEX_HARNESS_DISABLED_MESSAGE)
         }
-        Harness::Oz | Harness::Claude | Harness::OpenCode | Harness::Gemini | Harness::Unknown => {
-            None
-        }
+        Harness::Oz | Harness::Claude | Harness::Unknown => None,
         Harness::Codex => None,
     }
 }
@@ -72,12 +70,9 @@ fn local_harness_setup_state_with_cli_resolver(
         Harness::Codex if !cli_is_installed("codex") => LocalHarnessSetupState::MissingHarness {
             tooltip: LOCAL_CODEX_HARNESS_INSTALLATION_REQUIRED_TOOLTIP,
         },
-        Harness::Oz
-        | Harness::Claude
-        | Harness::OpenCode
-        | Harness::Gemini
-        | Harness::Codex
-        | Harness::Unknown => LocalHarnessSetupState::Ready,
+        Harness::Oz | Harness::Claude | Harness::Codex | Harness::Unknown => {
+            LocalHarnessSetupState::Ready
+        }
     }
 }
 

--- a/app/src/pane_group/mod.rs
+++ b/app/src/pane_group/mod.rs
@@ -3759,7 +3759,6 @@ impl PaneGroup {
                 }
                 let harness = match cli_conversation.metadata.harness {
                     AIAgentHarness::ClaudeCode => Some(Harness::Claude),
-                    AIAgentHarness::Gemini => Some(Harness::Gemini),
                     AIAgentHarness::Codex => Some(Harness::Codex),
                     AIAgentHarness::Oz => None,
                     AIAgentHarness::Unknown => Some(Harness::Unknown),
@@ -5380,7 +5379,6 @@ impl PaneGroup {
                     }
                     let harness = match cli_conversation.metadata.harness {
                         AIAgentHarness::ClaudeCode => Some(Harness::Claude),
-                        AIAgentHarness::Gemini => Some(Harness::Gemini),
                         AIAgentHarness::Codex => Some(Harness::Codex),
                         AIAgentHarness::Oz => None,
                         AIAgentHarness::Unknown => Some(Harness::Unknown),

--- a/app/src/pane_group/pane/local_harness_launch.rs
+++ b/app/src/pane_group/pane/local_harness_launch.rs
@@ -126,10 +126,6 @@ pub(super) fn build_local_claude_child_command(prompt: &str) -> String {
     format!("claude --session-id {session_id} --dangerously-skip-permissions {quoted_prompt}")
 }
 
-pub(super) fn build_local_opencode_child_command(prompt: &str) -> String {
-    let quoted_prompt = shell_quote(prompt);
-    format!("opencode --prompt {quoted_prompt}")
-}
 pub(super) fn build_local_codex_child_command(prompt: &str) -> String {
     let quoted_prompt = shell_quote(prompt);
     format!("codex --dangerously-bypass-approvals-and-sandbox {quoted_prompt}")
@@ -144,7 +140,7 @@ pub(super) fn local_child_task_config(
         .and_then(normalize_orchestrator_agent_name);
     match harness {
         Harness::Oz | Harness::Unknown => None,
-        Harness::Claude | Harness::OpenCode | Harness::Gemini | Harness::Codex => {
+        Harness::Claude | Harness::Codex => {
             Some(AgentConfigSnapshot {
                 name: agent_name,
                 harness: Some(HarnessConfig::from_harness_type(harness)),
@@ -232,12 +228,6 @@ pub(super) async fn prepare_local_harness_child_launch(
             // rewrite ~/.codex/config.toml for the whole machine.
             build_local_codex_child_command(&prompt)
         }
-        Harness::OpenCode => {
-            validate_cli_installed("opencode", Some("https://opencode.ai/docs"))
-                .map_err(|error: AgentDriverError| error.to_string())?;
-            build_local_opencode_child_command(&prompt)
-        }
-        Harness::Gemini => unreachable!("normalize_local_child_harness filters out Gemini"),
     };
 
     let task_id = ai_client

--- a/app/src/pane_group/pane/local_harness_launch.rs
+++ b/app/src/pane_group/pane/local_harness_launch.rs
@@ -13,7 +13,7 @@ use crate::ai::agent_sdk::driver::harness::{
     HarnessKind,
 };
 use crate::ai::agent_sdk::driver::AgentDriverError;
-use crate::ai::agent_sdk::{task_env_vars, validate_cli_installed};
+use crate::ai::agent_sdk::task_env_vars;
 use crate::ai::ambient_agents::task::{
     normalize_orchestrator_agent_name, HarnessConfig, HarnessModelConfig,
 };
@@ -140,13 +140,11 @@ pub(super) fn local_child_task_config(
         .and_then(normalize_orchestrator_agent_name);
     match harness {
         Harness::Oz | Harness::Unknown => None,
-        Harness::Claude | Harness::Codex => {
-            Some(AgentConfigSnapshot {
-                name: agent_name,
-                harness: Some(HarnessConfig::from_harness_type(harness)),
-                ..Default::default()
-            })
-        }
+        Harness::Claude | Harness::Codex => Some(AgentConfigSnapshot {
+            name: agent_name,
+            harness: Some(HarnessConfig::from_harness_type(harness)),
+            ..Default::default()
+        }),
     }
 }
 

--- a/app/src/pane_group/pane/local_harness_launch_tests.rs
+++ b/app/src/pane_group/pane/local_harness_launch_tests.rs
@@ -7,9 +7,8 @@ use warp_cli::agent::Harness;
 use warp_core::features::FeatureFlag;
 
 use super::{
-    build_local_claude_child_command, build_local_codex_child_command,
-    build_local_opencode_child_command, local_child_task_config, local_claude_child_prompt,
-    normalize_local_child_harness, prepare_local_harness_child_launch,
+    build_local_claude_child_command, build_local_codex_child_command, local_child_task_config,
+    local_claude_child_prompt, normalize_local_child_harness, prepare_local_harness_child_launch,
     validate_local_harness_shell,
 };
 use crate::ai::agent_sdk::driver::OZ_MESSAGE_LISTENER_MANAGED_EXTERNALLY_ENV;
@@ -96,18 +95,6 @@ fn normalize_local_child_harness_accepts_supported_aliases() {
         normalize_local_child_harness("claude_code"),
         Some(Harness::Claude)
     );
-    assert_eq!(
-        normalize_local_child_harness("opencode"),
-        Some(Harness::OpenCode)
-    );
-    assert_eq!(
-        normalize_local_child_harness("open-code"),
-        Some(Harness::OpenCode)
-    );
-    assert_eq!(
-        normalize_local_child_harness("open_code"),
-        Some(Harness::OpenCode)
-    );
     assert_eq!(normalize_local_child_harness("codex"), Some(Harness::Codex));
 }
 
@@ -115,6 +102,7 @@ fn normalize_local_child_harness_accepts_supported_aliases() {
 fn normalize_local_child_harness_rejects_unsupported_values() {
     assert_eq!(normalize_local_child_harness("oz"), None);
     assert_eq!(normalize_local_child_harness("gemini"), None);
+    assert_eq!(normalize_local_child_harness("opencode"), None);
     assert_eq!(normalize_local_child_harness(""), None);
 }
 
@@ -152,14 +140,6 @@ fn build_local_claude_child_command_quotes_the_prompt() {
 }
 
 #[test]
-fn build_local_opencode_child_command_quotes_the_prompt() {
-    assert_eq!(
-        build_local_opencode_child_command("hello world"),
-        "opencode --prompt 'hello world'"
-    );
-}
-
-#[test]
 fn build_local_codex_child_command_quotes_the_prompt() {
     assert_eq!(
         build_local_codex_child_command("hello world"),
@@ -169,7 +149,7 @@ fn build_local_codex_child_command_quotes_the_prompt() {
 
 #[test]
 fn local_child_task_config_records_supported_third_party_harnesses() {
-    for harness in [Harness::Claude, Harness::OpenCode, Harness::Codex] {
+    for harness in [Harness::Claude, Harness::Codex] {
         assert_eq!(
             local_child_task_config(harness, None),
             Some(crate::ai::ambient_agents::task::AgentConfigSnapshot {
@@ -182,7 +162,7 @@ fn local_child_task_config_records_supported_third_party_harnesses() {
 
 #[test]
 fn local_child_task_config_stamps_orchestrator_name() {
-    for harness in [Harness::Claude, Harness::OpenCode, Harness::Codex] {
+    for harness in [Harness::Claude, Harness::Codex] {
         assert_eq!(
             local_child_task_config(harness, Some("frontend-tests".to_string())),
             Some(crate::ai::ambient_agents::task::AgentConfigSnapshot {

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -2069,7 +2069,7 @@ fn launch_remote_child(
                 claude_auth_secret_name: None,
                 codex_auth_secret_name: Some(name.clone()),
             }),
-            Harness::Oz | Harness::OpenCode | Harness::Gemini | Harness::Unknown => None,
+            Harness::Oz | Harness::Unknown => None,
         });
     let spawn_request = SpawnAgentRequest {
         prompt: Some(request.prompt),

--- a/app/src/server/server_api/ai.rs
+++ b/app/src/server/server_api/ai.rs
@@ -3247,16 +3247,8 @@ fn convert_harness(harness: warp_graphql::ai::AgentHarness) -> AIAgentHarness {
     match harness {
         warp_graphql::ai::AgentHarness::Oz => AIAgentHarness::Oz,
         warp_graphql::ai::AgentHarness::ClaudeCode => AIAgentHarness::ClaudeCode,
-        warp_graphql::ai::AgentHarness::Gemini => AIAgentHarness::Gemini,
         warp_graphql::ai::AgentHarness::Codex => AIAgentHarness::Codex,
-        warp_graphql::ai::AgentHarness::Other(value) => {
-            report_error!(
-                "Invalid AgentHarness; update client GraphQL types",
-                extra: { "harness" => %value },
-                warp_errors::ReportErrorLogMode::OncePerRun
-            );
-            AIAgentHarness::Unknown
-        }
+        warp_graphql::ai::AgentHarness::Other(_) => AIAgentHarness::Unknown,
     }
 }
 

--- a/app/src/terminal/cli_agent.rs
+++ b/app/src/terminal/cli_agent.rs
@@ -199,8 +199,6 @@ impl CLIAgent {
         match harness {
             Harness::Oz => None,
             Harness::Claude => Some(CLIAgent::Claude),
-            Harness::Gemini => Some(CLIAgent::Gemini),
-            Harness::OpenCode => Some(CLIAgent::OpenCode),
             Harness::Codex => Some(CLIAgent::Codex),
             Harness::Unknown => Some(CLIAgent::Unknown),
         }

--- a/app/src/terminal/view/ambient_agent/view_impl.rs
+++ b/app/src/terminal/view/ambient_agent/view_impl.rs
@@ -648,8 +648,6 @@ impl TerminalView {
         match selected_harness {
             Harness::Oz => false,
             Harness::Claude => matches!(cli_agent, CLIAgent::Claude),
-            Harness::OpenCode => matches!(cli_agent, CLIAgent::OpenCode),
-            Harness::Gemini => matches!(cli_agent, CLIAgent::Gemini),
             Harness::Codex => matches!(cli_agent, CLIAgent::Codex),
             Harness::Unknown => false,
         }

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
@@ -248,13 +248,13 @@ fn continuation_ui_state_for_harness_and_access(
             Ok(CloudConversationContinuationUiState::Tombstone { cta })
         }
         (
-            AIAgentHarness::ClaudeCode | AIAgentHarness::Gemini | AIAgentHarness::Codex,
+            AIAgentHarness::ClaudeCode | AIAgentHarness::Codex,
             ConversationAccess::Edit,
         ) => Ok(CloudConversationContinuationUiState::Tombstone {
             cta: Some(TombstoneCta::ContinueInCloud { task_id }),
         }),
         (
-            AIAgentHarness::ClaudeCode | AIAgentHarness::Gemini | AIAgentHarness::Codex,
+            AIAgentHarness::ClaudeCode | AIAgentHarness::Codex,
             ConversationAccess::ViewOnly,
         ) => Ok(CloudConversationContinuationUiState::Tombstone { cta: None }),
         (AIAgentHarness::Unknown, _) => Err(CloudConversationContinuationError::UnknownHarness),
@@ -355,9 +355,8 @@ fn task_harness(task: &AmbientAgentTask) -> AIAgentHarness {
     {
         Harness::Oz => AIAgentHarness::Oz,
         Harness::Claude => AIAgentHarness::ClaudeCode,
-        Harness::Gemini => AIAgentHarness::Gemini,
         Harness::Codex => AIAgentHarness::Codex,
-        Harness::OpenCode | Harness::Unknown => AIAgentHarness::Unknown,
+        Harness::Unknown => AIAgentHarness::Unknown,
     }
 }
 

--- a/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
+++ b/app/src/terminal/view/shared_session/cloud_conversation_continuation.rs
@@ -247,16 +247,14 @@ fn continuation_ui_state_for_harness_and_access(
                 .map(|conversation_id| TombstoneCta::ContinueLocally { conversation_id });
             Ok(CloudConversationContinuationUiState::Tombstone { cta })
         }
-        (
-            AIAgentHarness::ClaudeCode | AIAgentHarness::Codex,
-            ConversationAccess::Edit,
-        ) => Ok(CloudConversationContinuationUiState::Tombstone {
-            cta: Some(TombstoneCta::ContinueInCloud { task_id }),
-        }),
-        (
-            AIAgentHarness::ClaudeCode | AIAgentHarness::Codex,
-            ConversationAccess::ViewOnly,
-        ) => Ok(CloudConversationContinuationUiState::Tombstone { cta: None }),
+        (AIAgentHarness::ClaudeCode | AIAgentHarness::Codex, ConversationAccess::Edit) => {
+            Ok(CloudConversationContinuationUiState::Tombstone {
+                cta: Some(TombstoneCta::ContinueInCloud { task_id }),
+            })
+        }
+        (AIAgentHarness::ClaudeCode | AIAgentHarness::Codex, ConversationAccess::ViewOnly) => {
+            Ok(CloudConversationContinuationUiState::Tombstone { cta: None })
+        }
         (AIAgentHarness::Unknown, _) => Err(CloudConversationContinuationError::UnknownHarness),
         (_, ConversationAccess::Unknown) => {
             Err(CloudConversationContinuationError::UnknownConversationAccess)

--- a/app/src/ui_components/agent_icon_tests.rs
+++ b/app/src/ui_components/agent_icon_tests.rs
@@ -336,12 +336,8 @@ fn cli_agent_from_harness_maps_known_harnesses() {
         Some(CLIAgent::Claude)
     );
     assert_eq!(
-        CLIAgent::from_harness(Harness::Gemini),
-        Some(CLIAgent::Gemini)
-    );
-    assert_eq!(
-        CLIAgent::from_harness(Harness::OpenCode),
-        Some(CLIAgent::OpenCode)
+        CLIAgent::from_harness(Harness::Codex),
+        Some(CLIAgent::Codex)
     );
 }
 

--- a/crates/graphql/src/api/ai.rs
+++ b/crates/graphql/src/api/ai.rs
@@ -124,7 +124,6 @@ pub enum AIConversationArtifact {
 pub enum AgentHarness {
     Oz,
     ClaudeCode,
-    Gemini,
     Codex,
     #[cynic(fallback)]
     Other(String),

--- a/crates/graphql/src/api/queries/list_harness_auth_secrets.rs
+++ b/crates/graphql/src/api/queries/list_harness_auth_secrets.rs
@@ -11,7 +11,6 @@ use crate::schema;
 pub enum AgentHarnessInput {
     Oz,
     ClaudeCode,
-    Gemini,
     Codex,
 }
 
@@ -20,7 +19,6 @@ impl From<crate::ai::AgentHarness> for Option<AgentHarnessInput> {
         match h {
             crate::ai::AgentHarness::Oz => Some(AgentHarnessInput::Oz),
             crate::ai::AgentHarness::ClaudeCode => Some(AgentHarnessInput::ClaudeCode),
-            crate::ai::AgentHarness::Gemini => Some(AgentHarnessInput::Gemini),
             crate::ai::AgentHarness::Codex => Some(AgentHarnessInput::Codex),
             crate::ai::AgentHarness::Other(_) => None,
         }

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -126,11 +126,9 @@ impl HiddenComputerUseArgs {
         }
     }
 }
-const HARNESS_VALUE_VARIANTS: [Harness; 5] = [
+const HARNESS_VALUE_VARIANTS: [Harness; 3] = [
     Harness::Oz,
     Harness::Claude,
-    Harness::OpenCode,
-    Harness::Gemini,
     Harness::Codex,
 ];
 
@@ -143,10 +141,6 @@ pub enum Harness {
     Oz,
     /// Delegate to the `claude` CLI.
     Claude,
-    /// Delegate to the `opencode` CLI.
-    OpenCode,
-    /// Delegate to the `gemini` CLI.
-    Gemini,
     /// Delegate to the `codex` CLI.
     Codex,
     /// A harness produced by a newer client/server that this client doesn't
@@ -170,10 +164,6 @@ impl ValueEnum for Harness {
             Harness::Claude => PossibleValue::new("claude")
                 .alias("claude-code")
                 .help("Delegate to the `claude` CLI"),
-            Harness::OpenCode => PossibleValue::new("opencode")
-                .alias("open-code")
-                .help("Delegate to the `opencode` CLI"),
-            Harness::Gemini => PossibleValue::new("gemini").help("Delegate to the `gemini` CLI"),
             Harness::Codex => PossibleValue::new("codex").help("Delegate to the `codex` CLI"),
             Harness::Unknown => return None,
         };
@@ -192,16 +182,14 @@ impl Harness {
 
     pub fn parse_local_child_harness(value: &str) -> Option<Self> {
         match Self::parse_orchestration_harness(value) {
-            Some(harness @ (Self::Claude | Self::OpenCode | Self::Codex)) => Some(harness),
-            Some(Self::Oz) | Some(Self::Gemini) | Some(Self::Unknown) | None => None,
+            Some(harness @ (Self::Claude | Self::Codex)) => Some(harness),
+            Some(Self::Oz) | Some(Self::Unknown) | None => None,
         }
     }
 
     /// Whether this harness is surfaced to users in CLI `--help` for cloud runs
     /// (`oz agent run-cloud --harness`). Only the harnesses that are generally
-    /// available for cloud runs are shown; gemini and opencode aren't available
-    /// yet, so they're hidden from help. Update this when a harness becomes GA
-    /// for cloud.
+    /// available for cloud runs are shown.
     ///
     /// This is the single source of truth for the `ValueEnum` help text; the
     /// per-variant `#[value(hide = ...)]` attributes are no longer used. It does
@@ -210,7 +198,7 @@ impl Harness {
     pub fn should_display_in_help_text(self) -> bool {
         match self {
             Self::Oz | Self::Claude | Self::Codex => true,
-            Self::OpenCode | Self::Gemini | Self::Unknown => false,
+            Self::Unknown => false,
         }
     }
 
@@ -218,8 +206,6 @@ impl Harness {
         match self {
             Self::Oz => "Oz",
             Self::Claude => "Claude Code",
-            Self::OpenCode => "OpenCode",
-            Self::Gemini => "Gemini CLI",
             Self::Codex => "Codex",
             Self::Unknown => "Unknown",
         }
@@ -236,10 +222,10 @@ impl Harness {
         match name {
             "oz" => Some(Harness::Oz),
             "claude" => Some(Harness::Claude),
-            "opencode" => Some(Harness::OpenCode),
-            "gemini" => Some(Harness::Gemini),
             "codex" => Some(Harness::Codex),
             "unknown" => Some(Harness::Unknown),
+            // Legacy harness names map to Unknown for backward compatibility.
+            "opencode" | "gemini" => Some(Harness::Unknown),
             _ => None,
         }
     }
@@ -253,8 +239,6 @@ impl Harness {
         match self {
             Harness::Oz => "oz",
             Harness::Claude => "claude",
-            Harness::OpenCode => "opencode",
-            Harness::Gemini => "gemini",
             Harness::Codex => "codex",
             Harness::Unknown => "unknown",
         }

--- a/crates/warp_cli/src/agent.rs
+++ b/crates/warp_cli/src/agent.rs
@@ -126,11 +126,7 @@ impl HiddenComputerUseArgs {
         }
     }
 }
-const HARNESS_VALUE_VARIANTS: [Harness; 3] = [
-    Harness::Oz,
-    Harness::Claude,
-    Harness::Codex,
-];
+const HARNESS_VALUE_VARIANTS: [Harness; 3] = [Harness::Oz, Harness::Claude, Harness::Codex];
 
 /// The execution harness for an agent run.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]

--- a/crates/warp_cli/src/agent_tests.rs
+++ b/crates/warp_cli/src/agent_tests.rs
@@ -5,19 +5,20 @@ use super::*;
 /// added without a matching `from_config_name` arm, this round-trip test will fail.
 #[test]
 fn harness_config_name_round_trips_for_known_variants() {
-    for harness in [
-        Harness::Oz,
-        Harness::Claude,
-        Harness::OpenCode,
-        Harness::Gemini,
-        Harness::Codex,
-    ] {
+    for harness in [Harness::Oz, Harness::Claude, Harness::Codex] {
         assert_eq!(
             Harness::from_config_name(harness.config_name()),
             Some(harness),
             "round-trip failed for {harness:?}",
         );
     }
+}
+
+#[test]
+fn harness_from_config_name_legacy_names_map_to_unknown() {
+    // opencode and gemini are legacy harness names that now map to Unknown for backward compatibility.
+    assert_eq!(Harness::from_config_name("opencode"), Some(Harness::Unknown));
+    assert_eq!(Harness::from_config_name("gemini"), Some(Harness::Unknown));
 }
 
 #[test]

--- a/crates/warp_cli/src/agent_tests.rs
+++ b/crates/warp_cli/src/agent_tests.rs
@@ -17,7 +17,10 @@ fn harness_config_name_round_trips_for_known_variants() {
 #[test]
 fn harness_from_config_name_legacy_names_map_to_unknown() {
     // opencode and gemini are legacy harness names that now map to Unknown for backward compatibility.
-    assert_eq!(Harness::from_config_name("opencode"), Some(Harness::Unknown));
+    assert_eq!(
+        Harness::from_config_name("opencode"),
+        Some(Harness::Unknown)
+    );
     assert_eq!(Harness::from_config_name("gemini"), Some(Harness::Unknown));
 }
 

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -2072,19 +2072,18 @@ fn harness_parse_orchestration_harness_accepts_aliases() {
         Harness::parse_orchestration_harness("claude-code"),
         Some(Harness::Claude)
     );
+    // opencode and gemini are no longer supported harnesses; they parse as Unknown.
     assert_eq!(
         Harness::parse_orchestration_harness("open_code"),
-        Some(Harness::OpenCode)
+        None
     );
 }
 
 #[test]
-fn harness_parse_local_child_harness_rejects_oz() {
+fn harness_parse_local_child_harness_rejects_oz_and_removed_harnesses() {
     assert_eq!(Harness::parse_local_child_harness("oz"), None);
-    assert_eq!(
-        Harness::parse_local_child_harness("opencode"),
-        Some(Harness::OpenCode)
-    );
+    assert_eq!(Harness::parse_local_child_harness("opencode"), None);
+    assert_eq!(Harness::parse_local_child_harness("gemini"), None);
 }
 
 #[test]

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -2073,10 +2073,7 @@ fn harness_parse_orchestration_harness_accepts_aliases() {
         Some(Harness::Claude)
     );
     // opencode and gemini are no longer supported harnesses; they parse as Unknown.
-    assert_eq!(
-        Harness::parse_orchestration_harness("open_code"),
-        None
-    );
+    assert_eq!(Harness::parse_orchestration_harness("open_code"), None);
 }
 
 #[test]

--- a/crates/warp_graphql_schema/api/schema.graphql
+++ b/crates/warp_graphql_schema/api/schema.graphql
@@ -239,7 +239,6 @@ enum AdminEnablementSetting {
 enum AgentHarness {
   CLAUDE_CODE
   CODEX
-  GEMINI
   OZ
 }
 


### PR DESCRIPTION
## Summary

Removes Gemini and OpenCode multi-harness cloud agent support from the warp client.

### Changes

**Enum removals:**
- Remove `Harness::Gemini` and `Harness::OpenCode` from the `Harness` enum in `crates/warp_cli/src/agent.rs`
- Remove `AIAgentHarness::Gemini` from `AIAgentHarness` enum in `conversation.rs`
- Remove `Gemini` from GraphQL `AgentHarness` cynic enum (keep `Other` fallback for backward compat with existing DB data)
- Remove `Gemini` from `AgentHarnessInput` in `list_harness_auth_secrets.rs`

**Backward compatibility:**
- `"opencode"` and `"gemini"` config names now map to `Harness::Unknown` via `from_config_name()` for backward compat
- Old conversations with GEMINI harness deserialize as `AgentHarness::Other` → `AIAgentHarness::Unknown`

**Preserved (local interactive CLI sessions):**
- `CLIAgent::Gemini` and `CLIAgent::OpenCode` are **untouched** (used by `CLIAgentSessionsModel`)
- `GeminiNotifications` and `OpenCodeNotifications` feature flags are **kept** (local plugin notifications)
- `GeminiEnterprise` feature flag is **kept** (different feature - BYOLLM)

**Removed Gemini harness driver:**
- `gemini.rs` harness driver is no longer compiled (removed `mod gemini;` declaration)

This PR pairs with the warp-server PR that removes `AgentHarnessGemini`.

_Conversation: https://staging.warp.dev/conversation/e03b3457-a388-4f44-b992-ee8ac5ba731c_
_Run: https://oz.staging.warp.dev/runs/019f5dcf-ba66-7b27-b14e-17ff76dc99fe_

_This PR was generated with [Oz](https://warp.dev/oz)._
