### PR TITLE
Fix unnecessarily shared keychain storage

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -326,6 +326,7 @@ use crate::workspaces::user_workspaces::{UserWorkspaces, UserWorkspacesEvent};
 
 /// Our embedded application assets.
 pub static ASSETS: warp_assets::Assets = warp_assets::Assets;
+const TUI_SECURE_STORAGE_SERVICE_SUFFIX: &str = ".tui";
 
 fn determine_agent_source(
     launch_mode: &LaunchMode,
@@ -411,7 +412,7 @@ pub(crate) enum LaunchMode {
     },
 
     /// Run the headless TUI front-end (the `warp-tui` binary in the `warp_tui`
-    /// crate). Boots the real headless app so auth/agent state can be reused,
+    /// crate). Boots the real headless app so shared auth/agent infrastructure can be reused,
     /// then renders an editor-backed input UI to the terminal (via `mount`)
     /// instead of opening a GUI window.
     #[cfg_attr(not(feature = "tui"), allow(dead_code))]
@@ -467,6 +468,24 @@ impl LaunchMode {
             | LaunchMode::Test { .. }
             | LaunchMode::RemoteServerProxy
             | LaunchMode::RemoteServerDaemon { .. } => ::settings::SettingsMode::Gui,
+        }
+    }
+    /// The platform secure-storage service name for this launch mode.
+    ///
+    /// The TUI uses a separate namespace so it never attempts to read secrets
+    /// created by the GUI. On macOS, those items' Keychain ACLs trust the GUI's
+    /// distinct code-signing identity and would otherwise prompt for the user's
+    /// login password when the TUI accesses them.
+    fn secure_storage_service_name<'a>(&self, data_domain: &'a str) -> Cow<'a, str> {
+        match self {
+            LaunchMode::Tui { .. } => {
+                Cow::Owned(format!("{data_domain}{TUI_SECURE_STORAGE_SERVICE_SUFFIX}"))
+            }
+            LaunchMode::App { .. }
+            | LaunchMode::CommandLine { .. }
+            | LaunchMode::Test { .. }
+            | LaunchMode::RemoteServerProxy
+            | LaunchMode::RemoteServerDaemon { .. } => Cow::Borrowed(data_domain),
         }
     }
 
@@ -1255,6 +1274,7 @@ pub(crate) fn initialize_app(
     // Sentry. Only the dependencies of crash_reporting should be initialized here. Avoid adding
     // any other stuff here, as failures will be silent. Push them to pre_sentry_errors instead.
     let data_domain = ChannelState::data_domain();
+    let secure_storage_service_name = launch_mode.secure_storage_service_name(&data_domain);
 
     // Daemon auth arrives through the client handshake, so avoid platform keychains that may
     // require an interactive unlock prompt. Other headless modes still use secure storage for
@@ -1265,13 +1285,13 @@ pub(crate) fn initialize_app(
         // Register an implementation of the secure storage service.
         cfg_if::cfg_if! {
             if #[cfg(feature = "integration_tests")] {
-                warpui_extras::secure_storage::register_noop(&data_domain, ctx);
+                warpui_extras::secure_storage::register_noop(&secure_storage_service_name, ctx);
             } else if #[cfg(any(target_os = "linux", target_os = "freebsd"))] {
-                warpui_extras::secure_storage::register_with_fallback(&data_domain, warp_core::paths::state_dir(), ctx)
+                warpui_extras::secure_storage::register_with_fallback(&secure_storage_service_name, warp_core::paths::state_dir(), ctx)
             } else if #[cfg(target_os = "windows")] {
-                warpui_extras::secure_storage::register_with_dir(&data_domain, warp_core::paths::state_dir(), ctx)
+                warpui_extras::secure_storage::register_with_dir(&secure_storage_service_name, warp_core::paths::state_dir(), ctx)
             } else {
-                warpui_extras::secure_storage::register(&data_domain, ctx);
+                warpui_extras::secure_storage::register(&secure_storage_service_name, ctx);
             }
         }
     }
@@ -2930,3 +2950,7 @@ fn init_logging_for_unit_tests_glue() {
     // Initialize terminal-friendly logging for tests from the shared logger crate.
     warp_logging::init_logging_for_unit_tests();
 }
+
+#[cfg(test)]
+#[path = "lib_tests.rs"]
+mod tests;

--- a/app/src/lib_tests.rs
+++ b/app/src/lib_tests.rs
@@ -1,0 +1,27 @@
+use super::*;
+
+#[test]
+fn tui_uses_distinct_secure_storage_service_name() {
+    let launch_mode = LaunchMode::Tui {
+        mount: Box::new(|_| {}),
+        api_key: None,
+    };
+
+    assert_eq!(
+        launch_mode.secure_storage_service_name("dev.warp.Warp-Dev"),
+        "dev.warp.Warp-Dev.tui"
+    );
+}
+
+#[test]
+fn app_keeps_default_secure_storage_service_name() {
+    let launch_mode = LaunchMode::App {
+        args: Default::default(),
+        api_key: None,
+    };
+
+    assert_eq!(
+        launch_mode.secure_storage_service_name("dev.warp.Warp-Dev"),
+        "dev.warp.Warp-Dev"
+    );
+}


### PR DESCRIPTION
## Description
The TUI and GUI currently register secure storage with the same channel data domain. On macOS, that makes the independently signed TUI executable attempt to read a Keychain item created by the GUI, whose ACL trusts the GUI's different code-signing identity. macOS consequently asks users for their login password even though the downloaded TUI is signed and notarized.

This change gives `LaunchMode::Tui` a dedicated secure-storage service name by appending `.tui` to the existing channel/data-profile domain. GUI, CLI, test, proxy, and daemon launch modes keep their existing service names, and the scoped name is used consistently by the macOS, Linux, and Windows secure-storage backends.

The TUI deliberately does not probe or migrate the GUI namespace, because reading that item would recreate the prompt this change avoids. Existing TUI users complete device login once to seed the new namespace; subsequent TUI launches reuse that credential. GUI credentials remain untouched.

## Linked Issue
None.

## Testing
- [x] Added unit coverage for the distinct TUI service name and unchanged GUI service name.
- [x] `./script/format`
- [x] `cargo nextest run -p warp -E 'test(secure_storage_service_name)'` — 2 passed
- [x] `cargo nextest run -p warp_tui --no-fail-fast` — 184 passed
- [x] `cargo clippy -p warp --lib --tests -- -D warnings`
- [x] Ran `./script/run-tui` twice to exercise the initial-login and subsequent-launch paths.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
- Conversation: https://staging.warp.dev/conversation/72b3ea3a-7886-45ae-b489-4e144cb45576

CHANGELOG-NONE

Co-Authored-By: Warp <agent@warp.dev>
