### PR TITLE
TUI alt screen mouse interactions

### DIFF
--- a/app/src/terminal/alt_screen/alt_screen_element.rs
+++ b/app/src/terminal/alt_screen/alt_screen_element.rs
@@ -472,20 +472,13 @@ impl AltScreenElement {
             .alt_screen_mut()
             .accumulate_lines_to_scroll(delta);
 
-        if should_intercept_scroll(&self.model.lock(), app) {
-            ctx.dispatch_typed_action(TerminalAction::AltScroll { delta });
-        } else {
-            let point = self.coord_to_point(local_position);
-
-            ctx.dispatch_typed_action(TerminalAction::AltMouseAction(
-                MouseState::new(
-                    MouseButton::Wheel,
-                    MouseAction::Scrolled { delta },
-                    Default::default(),
-                )
-                .set_point(point),
-            ));
-        }
+        let point = self.coord_to_point(local_position);
+        let report_mouse = !should_intercept_scroll(&self.model.lock(), app);
+        ctx.dispatch_typed_action(TerminalAction::AltScroll {
+            delta,
+            point,
+            report_mouse,
+        });
         true
     }
 

--- a/app/src/terminal/alt_screen/alt_screen_element.rs
+++ b/app/src/terminal/alt_screen/alt_screen_element.rs
@@ -22,7 +22,7 @@ use warpui::{
     SizeConstraint,
 };
 
-use super::{should_intercept_mouse, should_intercept_scroll};
+use super::should_intercept_mouse;
 use crate::appearance::Appearance;
 use crate::pane_group::SplitPaneState;
 use crate::settings::EnforceMinimumContrast;
@@ -445,7 +445,6 @@ impl AltScreenElement {
         delta: Vector2F,
         precise: bool,
         ctx: &mut EventContext,
-        app: &AppContext,
     ) -> bool {
         let cell_height = self.grid_render_params.size_info.cell_height_px;
         let delta = if precise {
@@ -473,12 +472,7 @@ impl AltScreenElement {
             .accumulate_lines_to_scroll(delta);
 
         let point = self.coord_to_point(local_position);
-        let report_mouse = !should_intercept_scroll(&self.model.lock(), app);
-        ctx.dispatch_typed_action(TerminalAction::AltScroll {
-            delta,
-            point,
-            report_mouse,
-        });
+        ctx.dispatch_typed_action(TerminalAction::AltScroll { delta, point });
         true
     }
 
@@ -876,7 +870,7 @@ impl Element for AltScreenElement {
                 delta,
                 precise,
                 modifiers: ModifiersState { ctrl: false, .. },
-            } if in_bounds => self.on_scroll(to_local(*position), *delta, *precise, ctx, app),
+            } if in_bounds => self.on_scroll(to_local(*position), *delta, *precise, ctx),
             Event::LeftMouseDown {
                 position,
                 click_count,

--- a/app/src/terminal/mod.rs
+++ b/app/src/terminal/mod.rs
@@ -19,7 +19,7 @@ use warpui::{AppContext, WindowId};
 mod block_list_settings;
 
 mod alias;
-mod alt_screen;
+pub(crate) mod alt_screen;
 pub mod alt_screen_reporting;
 mod audible_bell;
 pub use audible_bell::AudibleBell;

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -434,7 +434,9 @@ use crate::terminal::model::blocks::{
     BlockFilter, BlockHeight, BlockHeightItem, BlockHeightSummary, BlockList, BlockListPoint, Gap,
     RemovableBlocklistItem,
 };
-use crate::terminal::model::escape_sequences::{self, EscCodes, ToEscapeSequence, C1};
+use crate::terminal::model::escape_sequences::{
+    self, alt_screen_scroll_to_pty_bytes, EscCodes, ToEscapeSequence, C1,
+};
 use crate::terminal::model::grid::grid_handler::{FragmentBoundary, TermMode};
 use crate::terminal::model::index::{Point, Side};
 use crate::terminal::model::mouse::MouseState;
@@ -9410,34 +9412,25 @@ impl TerminalView {
         true
     }
 
-    fn alt_scroll_cmd_sequence(&self, lines_to_scroll: i32) -> Vec<u8> {
-        let cmd = if lines_to_scroll > 0 {
-            EscCodes::ARROW_UP
-        } else {
-            EscCodes::ARROW_DOWN
-        };
-        EscCodes::build_escape_sequence_with_c1(C1::SS3, &[cmd])
-    }
-
-    fn alt_scroll_sequences(&mut self, lines_to_scroll: i32) -> Vec<u8> {
-        let cmd = self.alt_scroll_cmd_sequence(lines_to_scroll);
-        let lines = lines_to_scroll.unsigned_abs();
-        let mut content = Vec::with_capacity(lines as usize * 3);
-
-        for _ in 0..lines {
-            content.extend_from_slice(&cmd);
+    /// Forwards GUI wheel movement using the shared alt-screen encoder.
+    fn alt_scroll(
+        &mut self,
+        lines_to_scroll: i32,
+        point: Point,
+        report_mouse: bool,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        if !report_mouse {
+            self.highlighted_link.invalidate();
         }
-        content
-    }
-
-    fn alt_scroll(&mut self, lines_to_scroll: i32, ctx: &mut ViewContext<Self>) {
-        // Scrolling on the alt screen can cause the grid content to change, so any link highlights are
-        // no longer valid.
-        self.highlighted_link.invalidate();
-
-        let content = self.alt_scroll_sequences(lines_to_scroll);
-        self.write_user_bytes_to_pty(content, ctx);
-        ctx.notify();
+        let bytes = {
+            let model = self.model.lock();
+            alt_screen_scroll_to_pty_bytes(lines_to_scroll, point, report_mouse, model.deref())
+        };
+        if let Some(bytes) = bytes {
+            self.write_user_bytes_to_pty(bytes, ctx);
+            ctx.notify();
+        }
     }
 
     pub fn input_size_at_last_frame(&self, app: &AppContext) -> Option<Vector2F> {
@@ -26408,7 +26401,11 @@ impl TypedActionView for TerminalView {
 
         match action {
             Scroll { delta } => self.scroll(*delta, ctx),
-            AltScroll { delta } => self.alt_scroll(*delta, ctx),
+            AltScroll {
+                delta,
+                point,
+                report_mouse,
+            } => self.alt_scroll(*delta, *point, *report_mouse, ctx),
             SharedSessionViewerAltScroll { new_scroll_top } => {
                 self.alt_screen_scroll_top = *new_scroll_top;
                 ctx.notify()

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -372,6 +372,7 @@ use crate::settings_view::{flags, SettingsSection};
 use crate::shell_indicator::ShellIndicatorType;
 use crate::terminal::alias::{check_for_alias_async, AliasedCommand};
 use crate::terminal::alt_screen::alt_screen_element::AltScreenElement;
+use crate::terminal::alt_screen::should_intercept_scroll;
 use crate::terminal::alt_screen_reporting::{AltScreenReporting, AltScreenReportingChangedEvent};
 use crate::terminal::block_filter::{
     filter_button_position_id, BlockFilterEditor, BlockFilterEditorEvent, BlockFilterQuery,
@@ -9412,17 +9413,16 @@ impl TerminalView {
         true
     }
 
-    /// Forwards GUI wheel movement using the shared alt-screen encoder.
-    fn alt_scroll(
-        &mut self,
-        lines_to_scroll: i32,
-        point: Point,
-        report_mouse: bool,
-        ctx: &mut ViewContext<Self>,
-    ) {
+    /// Forwards wheel movement on the alt screen to the PTY, as SGR mouse
+    /// reports when the app requested them and arrow keys otherwise.
+    fn alt_scroll(&mut self, lines_to_scroll: i32, point: Point, ctx: &mut ViewContext<Self>) {
+        let report_mouse = !should_intercept_scroll(&self.model.lock(), ctx);
         if !report_mouse {
+            // Arrow-key scrolling can change the alt-screen grid content, so
+            // any link highlights are no longer valid.
             self.highlighted_link.invalidate();
         }
+
         let bytes = {
             let model = self.model.lock();
             alt_screen_scroll_to_pty_bytes(lines_to_scroll, point, report_mouse, model.deref())
@@ -26401,11 +26401,7 @@ impl TypedActionView for TerminalView {
 
         match action {
             Scroll { delta } => self.scroll(*delta, ctx),
-            AltScroll {
-                delta,
-                point,
-                report_mouse,
-            } => self.alt_scroll(*delta, *point, *report_mouse, ctx),
+            AltScroll { delta, point } => self.alt_scroll(*delta, *point, ctx),
             SharedSessionViewerAltScroll { new_scroll_top } => {
                 self.alt_screen_scroll_top = *new_scroll_top;
                 ctx.notify()

--- a/app/src/terminal/view/action.rs
+++ b/app/src/terminal/view/action.rs
@@ -102,6 +102,8 @@ pub enum TerminalAction {
     },
     AltScroll {
         delta: i32,
+        point: Point,
+        report_mouse: bool,
     },
     SharedSessionViewerAltScroll {
         new_scroll_top: Lines,
@@ -475,7 +477,14 @@ impl fmt::Debug for TerminalAction {
 
         match self {
             Scroll { delta } => write!(f, "Scroll {{ delta: {delta} }}"),
-            AltScroll { delta } => write!(f, "AltScroll {{ delta: {delta} }}"),
+            AltScroll {
+                delta,
+                report_mouse,
+                ..
+            } => write!(
+                f,
+                "AltScroll {{ delta: {delta}, report_mouse: {report_mouse} }}"
+            ),
             SharedSessionViewerAltScroll { new_scroll_top } => write!(
                 f,
                 "SharedSessionViewerAltScroll {{ new_scroll_top: {new_scroll_top} }}"

--- a/app/src/terminal/view/action.rs
+++ b/app/src/terminal/view/action.rs
@@ -103,7 +103,6 @@ pub enum TerminalAction {
     AltScroll {
         delta: i32,
         point: Point,
-        report_mouse: bool,
     },
     SharedSessionViewerAltScroll {
         new_scroll_top: Lines,
@@ -477,14 +476,7 @@ impl fmt::Debug for TerminalAction {
 
         match self {
             Scroll { delta } => write!(f, "Scroll {{ delta: {delta} }}"),
-            AltScroll {
-                delta,
-                report_mouse,
-                ..
-            } => write!(
-                f,
-                "AltScroll {{ delta: {delta}, report_mouse: {report_mouse} }}"
-            ),
+            AltScroll { delta, .. } => write!(f, "AltScroll {{ delta: {delta} }}"),
             SharedSessionViewerAltScroll { new_scroll_top } => write!(
                 f,
                 "SharedSessionViewerAltScroll {{ new_scroll_top: {new_scroll_top} }}"

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -3843,44 +3843,6 @@ fn test_navigate_blocks() {
 // }
 
 #[test]
-fn test_alt_scroll_sequences() {
-    App::test((), |mut app| async move {
-        initialize_app_for_terminal_view(&mut app);
-
-        let terminal = add_window_with_terminal(&mut app, None);
-        // Test scrolling a distance of zero lines.
-        terminal.update(&mut app, |view, _| {
-            let content = view.alt_scroll_sequences(0);
-            assert!(content.is_empty());
-        });
-        // Scroll down 3 lines
-        terminal.update(&mut app, |view, _| {
-            let content = view.alt_scroll_sequences(-3);
-            assert_eq!(content.len(), 3 * 3);
-            assert_eq!(
-                content
-                    .into_iter()
-                    .filter(|b| *b == escape_sequences::EscCodes::ARROW_DOWN)
-                    .count(),
-                3
-            );
-        });
-        // Scroll up 5 lines
-        terminal.update(&mut app, |view, _| {
-            let content = view.alt_scroll_sequences(5);
-            assert_eq!(content.len(), 5 * 3);
-            assert_eq!(
-                content
-                    .into_iter()
-                    .filter(|b| *b == escape_sequences::EscCodes::ARROW_UP)
-                    .count(),
-                5
-            );
-        });
-    })
-}
-
-#[test]
 fn test_not_bootstrapped() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -87,6 +87,7 @@ pub use crate::search::slash_command_menu::static_commands::commands::{
 };
 pub use crate::search::slash_command_menu::{SlashCommandId, StaticCommand};
 pub use crate::settings::AISettingsChangedEvent;
+pub use crate::terminal::alt_screen::{should_intercept_mouse, should_intercept_scroll};
 pub use crate::terminal::color::{Colors as TerminalColors, List as TerminalColorList};
 pub use crate::terminal::conversation_restoration::{
     prepare_conversation_block_restoration, ConversationBlockRestorationPlan,

--- a/crates/warp_terminal/src/model/escape_sequences.rs
+++ b/crates/warp_terminal/src/model/escape_sequences.rs
@@ -4,6 +4,7 @@ use lazy_static::lazy_static;
 use warpui_core::keymap::Keystroke;
 use warpui_core::platform::OperatingSystem;
 
+use super::indexing::Point;
 use super::mouse::{MouseAction, MouseButton, MouseState};
 use super::TermMode;
 
@@ -349,6 +350,37 @@ impl<T: ModeProvider> ToEscapeSequence<T> for MouseState {
         .repeat(repeats);
         Some(msg.into_bytes())
     }
+}
+
+/// Encodes alt-screen wheel movement as mouse reports or SS3 arrow keys.
+pub fn alt_screen_scroll_to_pty_bytes<T: ModeProvider>(
+    lines_to_scroll: i32,
+    point: Point,
+    report_mouse: bool,
+    mode_provider: &T,
+) -> Option<Vec<u8>> {
+    if lines_to_scroll == 0 {
+        return None;
+    }
+    if report_mouse {
+        return MouseState::new(
+            MouseButton::Wheel,
+            MouseAction::Scrolled {
+                delta: lines_to_scroll,
+            },
+            Default::default(),
+        )
+        .set_point(point)
+        .to_escape_sequence(mode_provider);
+    }
+
+    let arrow = if lines_to_scroll > 0 {
+        EscCodes::ARROW_UP
+    } else {
+        EscCodes::ARROW_DOWN
+    };
+    let sequence = EscCodes::build_escape_sequence_with_c1(C1::SS3, &[arrow]);
+    Some(sequence.repeat(lines_to_scroll.unsigned_abs() as usize))
 }
 
 pub trait ToModifierEscapeByte {

--- a/crates/warp_terminal/src/model/escape_sequences_tests.rs
+++ b/crates/warp_terminal/src/model/escape_sequences_tests.rs
@@ -175,6 +175,29 @@ fn test_mouse_actions_to_escape_sequence() {
 }
 
 #[test]
+fn test_alt_screen_scroll_to_pty_bytes() {
+    let terminal_model = TerminalModelMock::new();
+    let point = Point::new(3, 2);
+
+    assert_eq!(
+        alt_screen_scroll_to_pty_bytes(2, point, false, &terminal_model),
+        Some(b"\x1bOA\x1bOA".to_vec())
+    );
+    assert_eq!(
+        alt_screen_scroll_to_pty_bytes(-2, point, false, &terminal_model),
+        Some(b"\x1bOB\x1bOB".to_vec())
+    );
+    assert_eq!(
+        alt_screen_scroll_to_pty_bytes(1, point, true, &terminal_model),
+        Some(b"\x1b[<64;3;4M".to_vec())
+    );
+    assert_eq!(
+        alt_screen_scroll_to_pty_bytes(0, point, true, &terminal_model),
+        None
+    );
+}
+
+#[test]
 fn test_cursor_movement_keystroke_without_modifier_to_escape_sequence() {
     // Expected mapping taken from the xterm spec
     // [here](https://www.xfree86.org/current/ctlseqs.html).

--- a/crates/warp_tui/src/alt_screen_view.rs
+++ b/crates/warp_tui/src/alt_screen_view.rs
@@ -6,9 +6,9 @@
 //! element full-area instead of the block/transcript UI — mirroring the GUI's
 //! `AltScreenElement` (`app/src/terminal/alt_screen/alt_screen_element.rs`).
 //!
-//! Covers rendering and the cursor. PTY sizing and keyboard forwarding are
-//! handled by the session view's `TuiTerminalContentElement` wrapper. Mouse
-//! forwarding remains a follow-up.
+//! Covers rendering and the cursor. PTY sizing plus keyboard, paste, and mouse
+//! forwarding are handled by the session view's `TuiTerminalContentElement`
+//! wrapper.
 //!
 //! [`TuiTerminalSessionView`]: crate::terminal_session_view::TuiTerminalSessionView
 //! [`TerminalModel::is_alt_screen_active`]: warp::tui_export::TerminalModel

--- a/crates/warp_tui/src/terminal_content_element.rs
+++ b/crates/warp_tui/src/terminal_content_element.rs
@@ -20,7 +20,9 @@ use std::sync::Arc;
 use async_channel::Sender;
 use parking_lot::FairMutex;
 use warp::tui_export::{KeystrokeWithDetails, TermMode, TerminalModel, ToEscapeSequence as _};
-use warp_terminal::model::escape_sequences::{BRACKETED_PASTE_END, BRACKETED_PASTE_START};
+use warp_terminal::model::escape_sequences::{
+    alt_screen_scroll_to_pty_bytes, ModeProvider, BRACKETED_PASTE_END, BRACKETED_PASTE_START,
+};
 use warp_terminal::model::mouse::{MouseAction, MouseButton, MouseState};
 use warp_terminal::model::Point;
 use warpui_core::elements::tui::{
@@ -185,15 +187,57 @@ fn pty_bytes_for_event(event: &TuiEvent, model: &Arc<FairMutex<TerminalModel>>) 
     }
 }
 
-/// Encodes a supported pointer event for the foreground process.
+/// Encodes a pointer event using the current terminal state.
 fn pointer_pty_bytes(
     event: &TuiEvent,
     bounds: TuiScreenRect,
     model: &Arc<FairMutex<TerminalModel>>,
 ) -> Option<Vec<u8>> {
     let model = model.lock();
-    mouse_state_for_event(event, bounds, |mode| model.is_term_mode_set(mode))?
-        .to_escape_sequence(model.deref())
+    mouse_event_to_pty_bytes(
+        event,
+        bounds,
+        |mode| model.is_term_mode_set(mode),
+        model.is_alt_screen_active(),
+        model.deref(),
+    )
+}
+
+/// Encodes a supported pointer event for the foreground process.
+fn mouse_event_to_pty_bytes<T: ModeProvider>(
+    event: &TuiEvent,
+    bounds: TuiScreenRect,
+    is_mode_set: impl Fn(TermMode) -> bool,
+    allow_arrow_fallback: bool,
+    mode_provider: &T,
+) -> Option<Vec<u8>> {
+    if let TuiEvent::ScrollWheel {
+        position,
+        delta: (_, rows),
+        ..
+    } = event
+    {
+        if !bounds.contains(*position) {
+            return None;
+        }
+        let point = Point::new(
+            usize::try_from(i32::from(position.y) - bounds.origin.y).ok()?,
+            usize::try_from(i32::from(position.x) - bounds.origin.x).ok()?,
+        );
+        let report_mouse = is_mode_set(TermMode::SGR_MOUSE);
+        if !report_mouse && !allow_arrow_fallback {
+            return None;
+        }
+        return alt_screen_scroll_to_pty_bytes(
+            i32::try_from(*rows).ok()?,
+            point,
+            report_mouse,
+            mode_provider,
+        );
+    }
+
+    mouse_state_for_event(event, bounds, is_mode_set)
+        .and_then(|state| state.to_escape_sequence(mode_provider))
 }
 
 /// Converts a supported pointer event into the terminal's SGR mouse model.
@@ -205,10 +249,10 @@ fn mouse_state_for_event(
     if !is_mode_set(TermMode::SGR_MOUSE) {
         return None;
     }
-
-    let reports_clicks = is_mode_set(TermMode::MOUSE_REPORT_CLICK)
-        || is_mode_set(TermMode::MOUSE_DRAG)
-        || is_mode_set(TermMode::MOUSE_MOTION);
+    let reports_clicks = is_mode_set(TermMode::MOUSE_REPORT_CLICK);
+    let reports_drag = is_mode_set(TermMode::MOUSE_DRAG);
+    let reports_motion = is_mode_set(TermMode::MOUSE_MOTION);
+    let reports_clicks = reports_clicks || reports_drag || reports_motion;
     let position = event.position()?;
     if !bounds.contains(position) {
         return None;
@@ -229,8 +273,7 @@ fn mouse_state_for_event(
             MouseState::new(MouseButton::Left, MouseAction::Released, *modifiers)
         }
         TuiEvent::LeftMouseDragged { modifiers, .. }
-            if (is_mode_set(TermMode::MOUSE_DRAG) || is_mode_set(TermMode::MOUSE_MOTION))
-                && !modifiers.shift =>
+            if (reports_drag || reports_motion) && !modifiers.shift =>
         {
             MouseState::new(MouseButton::LeftDrag, MouseAction::Pressed, *modifiers)
         }
@@ -238,18 +281,7 @@ fn mouse_state_for_event(
             modifiers,
             is_synthetic: false,
             ..
-        } if is_mode_set(TermMode::MOUSE_MOTION) => {
-            MouseState::new(MouseButton::Move, MouseAction::Pressed, *modifiers)
-        }
-        TuiEvent::ScrollWheel {
-            delta: (_, rows), ..
-        } if reports_clicks && *rows != 0 => MouseState::new(
-            MouseButton::Wheel,
-            MouseAction::Scrolled {
-                delta: i32::try_from(*rows).ok()?,
-            },
-            Default::default(),
-        ),
+        } if reports_motion => MouseState::new(MouseButton::Move, MouseAction::Pressed, *modifiers),
         _ => return None,
     };
     Some(state.set_point(point))

--- a/crates/warp_tui/src/terminal_content_element.rs
+++ b/crates/warp_tui/src/terminal_content_element.rs
@@ -19,7 +19,10 @@ use std::sync::Arc;
 
 use async_channel::Sender;
 use parking_lot::FairMutex;
-use warp::tui_export::{KeystrokeWithDetails, TermMode, TerminalModel, ToEscapeSequence as _};
+use warp::tui_export::{
+    should_intercept_mouse, should_intercept_scroll, KeystrokeWithDetails, TermMode, TerminalModel,
+    ToEscapeSequence as _,
+};
 use warp_terminal::model::escape_sequences::{
     alt_screen_scroll_to_pty_bytes, ModeProvider, BRACKETED_PASTE_END, BRACKETED_PASTE_START,
 };
@@ -27,12 +30,33 @@ use warp_terminal::model::mouse::{MouseAction, MouseButton, MouseState};
 use warp_terminal::model::Point;
 use warpui_core::elements::tui::{
     TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext, TuiPaintContext,
-    TuiPaintSurface, TuiPresentationContext, TuiScreenPoint, TuiScreenPosition, TuiScreenRect,
-    TuiSize,
+    TuiPaintSurface, TuiPoint, TuiPresentationContext, TuiScreenPoint, TuiScreenPosition,
+    TuiScreenRect, TuiSize,
 };
 use warpui_core::AppContext;
 
 use crate::terminal_session_view::TuiTerminalSessionAction;
+/// Which terminal mouse reports the active process and user settings allow.
+#[derive(Clone, Copy)]
+struct MouseReportPolicy {
+    /// Clicks, releases, and drags.
+    report_buttons: bool,
+    /// Hover motion.
+    report_motion: bool,
+    /// Wheel events as SGR reports.
+    report_scroll: bool,
+}
+
+impl MouseReportPolicy {
+    /// Derives the current reporting policy from terminal state and settings.
+    fn current(model: &TerminalModel, app: &AppContext) -> Self {
+        Self {
+            report_buttons: !should_intercept_mouse(model, false, app),
+            report_motion: model.is_term_mode_set(TermMode::MOUSE_MOTION),
+            report_scroll: !should_intercept_scroll(model, app),
+        }
+    }
+}
 
 /// Wraps the element displaying PTY content, reports its laid-out size, and
 /// optionally forwards input to the foreground process.
@@ -137,7 +161,12 @@ impl TuiElement for TuiTerminalContentElement {
                             .origin()
                             .zip(self.child.size())
                             .and_then(|(origin, size)| {
-                                pointer_pty_bytes(event, TuiScreenRect::new(origin, size), model)
+                                pointer_pty_bytes(
+                                    event,
+                                    TuiScreenRect::new(origin, size),
+                                    model,
+                                    app,
+                                )
                             });
                     if let Some(bytes) = bytes {
                         event_ctx.dispatch_typed_action(
@@ -192,12 +221,13 @@ fn pointer_pty_bytes(
     event: &TuiEvent,
     bounds: TuiScreenRect,
     model: &Arc<FairMutex<TerminalModel>>,
+    app: &AppContext,
 ) -> Option<Vec<u8>> {
     let model = model.lock();
     mouse_event_to_pty_bytes(
         event,
         bounds,
-        |mode| model.is_term_mode_set(mode),
+        MouseReportPolicy::current(model.deref(), app),
         model.is_alt_screen_active(),
         model.deref(),
     )
@@ -207,73 +237,37 @@ fn pointer_pty_bytes(
 fn mouse_event_to_pty_bytes<T: ModeProvider>(
     event: &TuiEvent,
     bounds: TuiScreenRect,
-    is_mode_set: impl Fn(TermMode) -> bool,
+    policy: MouseReportPolicy,
     allow_arrow_fallback: bool,
     mode_provider: &T,
 ) -> Option<Vec<u8>> {
-    if let TuiEvent::ScrollWheel {
-        position,
-        delta: (_, rows),
-        ..
-    } = event
-    {
-        if !bounds.contains(*position) {
-            return None;
-        }
-        let point = Point::new(
-            usize::try_from(i32::from(position.y) - bounds.origin.y).ok()?,
-            usize::try_from(i32::from(position.x) - bounds.origin.x).ok()?,
-        );
-        let report_mouse = is_mode_set(TermMode::SGR_MOUSE);
-        if !report_mouse && !allow_arrow_fallback {
-            return None;
-        }
-        return alt_screen_scroll_to_pty_bytes(
-            i32::try_from(*rows).ok()?,
-            point,
-            report_mouse,
-            mode_provider,
-        );
-    }
-
-    mouse_state_for_event(event, bounds, is_mode_set)
-        .and_then(|state| state.to_escape_sequence(mode_provider))
-}
-
-/// Converts a supported pointer event into the terminal's SGR mouse model.
-fn mouse_state_for_event(
-    event: &TuiEvent,
-    bounds: TuiScreenRect,
-    is_mode_set: impl Fn(TermMode) -> bool,
-) -> Option<MouseState> {
-    if !is_mode_set(TermMode::SGR_MOUSE) {
-        return None;
-    }
-    let reports_clicks = is_mode_set(TermMode::MOUSE_REPORT_CLICK);
-    let reports_drag = is_mode_set(TermMode::MOUSE_DRAG);
-    let reports_motion = is_mode_set(TermMode::MOUSE_MOTION);
-    let reports_clicks = reports_clicks || reports_drag || reports_motion;
-    let position = event.position()?;
-    if !bounds.contains(position) {
-        return None;
-    }
-    let point = Point::new(
-        usize::try_from(i32::from(position.y) - bounds.origin.y).ok()?,
-        usize::try_from(i32::from(position.x) - bounds.origin.x).ok()?,
-    );
+    let point = cell_point(event.position()?, bounds)?;
 
     let state = match event {
-        TuiEvent::LeftMouseDown { modifiers, .. } if reports_clicks && !modifiers.shift => {
+        TuiEvent::ScrollWheel {
+            delta: (_, rows), ..
+        } => {
+            if !policy.report_scroll && !allow_arrow_fallback {
+                return None;
+            }
+            return alt_screen_scroll_to_pty_bytes(
+                i32::try_from(*rows).ok()?,
+                point,
+                policy.report_scroll,
+                mode_provider,
+            );
+        }
+        TuiEvent::LeftMouseDown { modifiers, .. } if policy.report_buttons && !modifiers.shift => {
             MouseState::new(MouseButton::Left, MouseAction::Pressed, *modifiers)
         }
-        TuiEvent::RightMouseDown { modifiers, .. } if reports_clicks && !modifiers.shift => {
+        TuiEvent::RightMouseDown { modifiers, .. } if policy.report_buttons && !modifiers.shift => {
             MouseState::new(MouseButton::Right, MouseAction::Pressed, *modifiers)
         }
-        TuiEvent::LeftMouseUp { modifiers, .. } if reports_clicks && !modifiers.shift => {
+        TuiEvent::LeftMouseUp { modifiers, .. } if policy.report_buttons && !modifiers.shift => {
             MouseState::new(MouseButton::Left, MouseAction::Released, *modifiers)
         }
         TuiEvent::LeftMouseDragged { modifiers, .. }
-            if (reports_drag || reports_motion) && !modifiers.shift =>
+            if policy.report_buttons && !modifiers.shift =>
         {
             MouseState::new(MouseButton::LeftDrag, MouseAction::Pressed, *modifiers)
         }
@@ -281,11 +275,25 @@ fn mouse_state_for_event(
             modifiers,
             is_synthetic: false,
             ..
-        } if reports_motion => MouseState::new(MouseButton::Move, MouseAction::Pressed, *modifiers),
+        } if policy.report_motion => {
+            MouseState::new(MouseButton::Move, MouseAction::Pressed, *modifiers)
+        }
         _ => return None,
     };
-    Some(state.set_point(point))
+    state.set_point(point).to_escape_sequence(mode_provider)
 }
+
+/// Converts an in-bounds screen position to terminal grid coordinates.
+fn cell_point(position: TuiPoint, bounds: TuiScreenRect) -> Option<Point> {
+    if !bounds.contains(position) {
+        return None;
+    }
+    Some(Point::new(
+        usize::try_from(i32::from(position.y) - bounds.origin.y).ok()?,
+        usize::try_from(i32::from(position.x) - bounds.origin.x).ok()?,
+    ))
+}
+
 fn paste_bytes(text: &str, needs_bracketed_paste: bool) -> Vec<u8> {
     let normalized = text.replace("\r\n", "\r").replace('\n', "\r");
     if !needs_bracketed_paste {

--- a/crates/warp_tui/src/terminal_content_element.rs
+++ b/crates/warp_tui/src/terminal_content_element.rs
@@ -10,20 +10,23 @@
 //! passes cannot do themselves.
 //!
 //! When configured with [`TuiTerminalContentElement::with_pty_input`], the same
-//! wrapper also gives the foreground process first refusal on key and paste
-//! events. Keeping both responsibilities here ensures the subtree measured for
-//! the PTY is also the subtree that owns its input.
+//! wrapper also gives the foreground process first refusal on key, paste, and
+//! pointer events. Keeping both responsibilities here ensures the subtree
+//! measured for the PTY is also the subtree that owns its input.
 
 use std::ops::Deref as _;
 use std::sync::Arc;
 
 use async_channel::Sender;
 use parking_lot::FairMutex;
-use warp::tui_export::{KeystrokeWithDetails, TerminalModel};
+use warp::tui_export::{KeystrokeWithDetails, TermMode, TerminalModel, ToEscapeSequence as _};
 use warp_terminal::model::escape_sequences::{BRACKETED_PASTE_END, BRACKETED_PASTE_START};
+use warp_terminal::model::mouse::{MouseAction, MouseButton, MouseState};
+use warp_terminal::model::Point;
 use warpui_core::elements::tui::{
     TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext, TuiPaintContext,
-    TuiPaintSurface, TuiPresentationContext, TuiScreenPoint, TuiScreenPosition, TuiSize,
+    TuiPaintSurface, TuiPresentationContext, TuiScreenPoint, TuiScreenPosition, TuiScreenRect,
+    TuiSize,
 };
 use warpui_core::AppContext;
 
@@ -47,7 +50,7 @@ impl TuiTerminalContentElement {
         }
     }
 
-    /// Gives the foreground process first refusal on key and paste events for
+    /// Gives the foreground process first refusal on input events for
     /// this terminal-content subtree.
     pub(crate) fn with_pty_input(mut self, model: Arc<FairMutex<TerminalModel>>) -> Self {
         self.pty_input_model = Some(model);
@@ -126,7 +129,21 @@ impl TuiElement for TuiTerminalContentElement {
                 | TuiEvent::LeftMouseDragged { .. }
                 | TuiEvent::MiddleMouseDown { .. }
                 | TuiEvent::RightMouseDown { .. }
-                | TuiEvent::MouseMoved { .. } => {}
+                | TuiEvent::MouseMoved { .. } => {
+                    let bytes =
+                        self.child
+                            .origin()
+                            .zip(self.child.size())
+                            .and_then(|(origin, size)| {
+                                pointer_pty_bytes(event, TuiScreenRect::new(origin, size), model)
+                            });
+                    if let Some(bytes) = bytes {
+                        event_ctx.dispatch_typed_action(
+                            TuiTerminalSessionAction::ForwardUserPtyBytes(bytes),
+                        );
+                        return true;
+                    }
+                }
             }
         }
         self.child.dispatch_event(event, event_ctx, app)
@@ -134,7 +151,7 @@ impl TuiElement for TuiTerminalContentElement {
 }
 
 /// Converts one semantic TUI input event to bytes for the foreground process.
-/// Pointer events and composing key events are left for the child subtree.
+/// Composing key and pointer events are handled separately.
 fn pty_bytes_for_event(event: &TuiEvent, model: &Arc<FairMutex<TerminalModel>>) -> Option<Vec<u8>> {
     match event {
         TuiEvent::KeyDown {
@@ -168,6 +185,75 @@ fn pty_bytes_for_event(event: &TuiEvent, model: &Arc<FairMutex<TerminalModel>>) 
     }
 }
 
+/// Encodes a supported pointer event for the foreground process.
+fn pointer_pty_bytes(
+    event: &TuiEvent,
+    bounds: TuiScreenRect,
+    model: &Arc<FairMutex<TerminalModel>>,
+) -> Option<Vec<u8>> {
+    let model = model.lock();
+    mouse_state_for_event(event, bounds, |mode| model.is_term_mode_set(mode))?
+        .to_escape_sequence(model.deref())
+}
+
+/// Converts a supported pointer event into the terminal's SGR mouse model.
+fn mouse_state_for_event(
+    event: &TuiEvent,
+    bounds: TuiScreenRect,
+    is_mode_set: impl Fn(TermMode) -> bool,
+) -> Option<MouseState> {
+    if !is_mode_set(TermMode::SGR_MOUSE) {
+        return None;
+    }
+
+    let reports_clicks = is_mode_set(TermMode::MOUSE_REPORT_CLICK)
+        || is_mode_set(TermMode::MOUSE_DRAG)
+        || is_mode_set(TermMode::MOUSE_MOTION);
+    let position = event.position()?;
+    if !bounds.contains(position) {
+        return None;
+    }
+    let point = Point::new(
+        usize::try_from(i32::from(position.y) - bounds.origin.y).ok()?,
+        usize::try_from(i32::from(position.x) - bounds.origin.x).ok()?,
+    );
+
+    let state = match event {
+        TuiEvent::LeftMouseDown { modifiers, .. } if reports_clicks && !modifiers.shift => {
+            MouseState::new(MouseButton::Left, MouseAction::Pressed, *modifiers)
+        }
+        TuiEvent::RightMouseDown { modifiers, .. } if reports_clicks && !modifiers.shift => {
+            MouseState::new(MouseButton::Right, MouseAction::Pressed, *modifiers)
+        }
+        TuiEvent::LeftMouseUp { modifiers, .. } if reports_clicks && !modifiers.shift => {
+            MouseState::new(MouseButton::Left, MouseAction::Released, *modifiers)
+        }
+        TuiEvent::LeftMouseDragged { modifiers, .. }
+            if (is_mode_set(TermMode::MOUSE_DRAG) || is_mode_set(TermMode::MOUSE_MOTION))
+                && !modifiers.shift =>
+        {
+            MouseState::new(MouseButton::LeftDrag, MouseAction::Pressed, *modifiers)
+        }
+        TuiEvent::MouseMoved {
+            modifiers,
+            is_synthetic: false,
+            ..
+        } if is_mode_set(TermMode::MOUSE_MOTION) => {
+            MouseState::new(MouseButton::Move, MouseAction::Pressed, *modifiers)
+        }
+        TuiEvent::ScrollWheel {
+            delta: (_, rows), ..
+        } if reports_clicks && *rows != 0 => MouseState::new(
+            MouseButton::Wheel,
+            MouseAction::Scrolled {
+                delta: i32::try_from(*rows).ok()?,
+            },
+            Default::default(),
+        ),
+        _ => return None,
+    };
+    Some(state.set_point(point))
+}
 fn paste_bytes(text: &str, needs_bracketed_paste: bool) -> Vec<u8> {
     let normalized = text.replace("\r\n", "\r").replace('\n', "\r");
     if !needs_bracketed_paste {

--- a/crates/warp_tui/src/terminal_content_element_tests.rs
+++ b/crates/warp_tui/src/terminal_content_element_tests.rs
@@ -15,11 +15,9 @@ use warpui_core::keymap::Keystroke;
 use warpui_core::{App, AppContext};
 
 use super::{
-    mouse_event_to_pty_bytes, paste_bytes, pty_bytes_for_event, TuiTerminalContentElement,
+    mouse_event_to_pty_bytes, paste_bytes, pty_bytes_for_event, MouseReportPolicy,
+    TuiTerminalContentElement,
 };
-const SGR_CLICK: TermMode = TermMode::SGR_MOUSE.union(TermMode::MOUSE_REPORT_CLICK);
-const SGR_DRAG: TermMode = TermMode::SGR_MOUSE.union(TermMode::MOUSE_DRAG);
-const SGR_MOTION: TermMode = TermMode::SGR_MOUSE.union(TermMode::MOUSE_MOTION);
 
 /// Builds retained screen bounds anchored at `(x, y)`.
 fn bounds(x: i32, y: i32, width: u16, height: u16) -> TuiScreenRect {
@@ -38,15 +36,27 @@ impl ModeProvider for MouseModeProvider {
     }
 }
 
+/// Builds a reporting policy with the given per-category flags.
+fn policy(buttons: bool, motion: bool, scroll: bool) -> MouseReportPolicy {
+    MouseReportPolicy {
+        report_buttons: buttons,
+        report_motion: motion,
+        report_scroll: scroll,
+    }
+}
+
+/// A policy allowing every report category.
+fn report_all() -> MouseReportPolicy {
+    policy(true, true, true)
+}
+
 /// Encodes `event` using the production TUI mouse-event adapter.
-fn mouse_bytes(event: &TuiEvent, area: TuiScreenRect, modes: TermMode) -> Option<Vec<u8>> {
-    mouse_event_to_pty_bytes(
-        event,
-        area,
-        |mode| modes.contains(mode),
-        true,
-        &MouseModeProvider,
-    )
+fn mouse_bytes(
+    event: &TuiEvent,
+    area: TuiScreenRect,
+    policy: MouseReportPolicy,
+) -> Option<Vec<u8>> {
+    mouse_event_to_pty_bytes(event, area, policy, true, &MouseModeProvider)
 }
 
 /// A leaf that fills its constraint and retains the laid-out size.
@@ -154,7 +164,6 @@ fn sgr_mouse_events_use_area_relative_coordinates() {
                 click_count: 1,
                 is_first_mouse: false,
             },
-            SGR_CLICK,
             b"\x1b[<0;3;2M".as_slice(),
         ),
         (
@@ -163,7 +172,6 @@ fn sgr_mouse_events_use_area_relative_coordinates() {
                 modifiers,
                 click_count: 1,
             },
-            SGR_CLICK,
             b"\x1b[<2;3;2M".as_slice(),
         ),
         (
@@ -171,7 +179,6 @@ fn sgr_mouse_events_use_area_relative_coordinates() {
                 position,
                 modifiers,
             },
-            SGR_CLICK,
             b"\x1b[<0;3;2m".as_slice(),
         ),
         (
@@ -179,7 +186,6 @@ fn sgr_mouse_events_use_area_relative_coordinates() {
                 position,
                 modifiers,
             },
-            SGR_DRAG,
             b"\x1b[<32;3;2M".as_slice(),
         ),
         (
@@ -188,7 +194,6 @@ fn sgr_mouse_events_use_area_relative_coordinates() {
                 modifiers,
                 is_synthetic: false,
             },
-            SGR_MOTION,
             b"\x1b[<35;3;2M".as_slice(),
         ),
         (
@@ -198,7 +203,6 @@ fn sgr_mouse_events_use_area_relative_coordinates() {
                 precise: false,
                 modifiers,
             },
-            TermMode::SGR_MOUSE,
             b"\x1b[<64;3;2M".as_slice(),
         ),
         (
@@ -208,18 +212,19 @@ fn sgr_mouse_events_use_area_relative_coordinates() {
                 precise: false,
                 modifiers,
             },
-            TermMode::SGR_MOUSE,
             b"\x1b[<65;3;2M".as_slice(),
         ),
     ];
-
-    for (event, modes, expected) in cases {
-        assert_eq!(mouse_bytes(&event, area, modes).as_deref(), Some(expected));
+    for (event, expected) in cases {
+        assert_eq!(
+            mouse_bytes(&event, area, report_all()).as_deref(),
+            Some(expected)
+        );
     }
 }
 
 #[test]
-fn click_and_motion_events_require_the_requested_reporting_mode() {
+fn events_are_gated_by_their_policy_category() {
     let area = bounds(0, 0, 10, 10);
     let position = TuiPoint::new(2, 3);
     let modifiers = ModifiersState::default();
@@ -239,13 +244,12 @@ fn click_and_motion_events_require_the_requested_reporting_mode() {
         is_synthetic: false,
     };
 
-    assert!(mouse_bytes(&left_down, area, TermMode::MOUSE_REPORT_CLICK).is_none());
-    assert!(mouse_bytes(&left_down, area, TermMode::SGR_MOUSE).is_none());
-    assert!(mouse_bytes(&left_down, area, SGR_DRAG).is_some());
-    assert!(mouse_bytes(&left_dragged, area, SGR_CLICK).is_none());
-    assert!(mouse_bytes(&left_dragged, area, SGR_DRAG).is_some());
-    assert!(mouse_bytes(&moved, area, SGR_DRAG).is_none());
-    assert!(mouse_bytes(&moved, area, SGR_MOTION).is_some());
+    assert!(mouse_bytes(&left_down, area, policy(false, true, true)).is_none());
+    assert!(mouse_bytes(&left_down, area, policy(true, false, false)).is_some());
+    assert!(mouse_bytes(&left_dragged, area, policy(false, true, true)).is_none());
+    assert!(mouse_bytes(&left_dragged, area, policy(true, false, false)).is_some());
+    assert!(mouse_bytes(&moved, area, policy(true, false, true)).is_none());
+    assert!(mouse_bytes(&moved, area, policy(false, true, false)).is_some());
 }
 
 #[test]
@@ -259,15 +263,21 @@ fn scroll_uses_sgr_when_available_and_arrows_otherwise() {
     let area = bounds(0, 0, 10, 10);
 
     assert_eq!(
-        mouse_bytes(&scroll, area, TermMode::NONE).as_deref(),
+        mouse_bytes(&scroll, area, policy(false, false, false)).as_deref(),
         Some(b"\x1bOA".as_slice())
     );
     assert_eq!(
-        mouse_bytes(&scroll, area, TermMode::SGR_MOUSE).as_deref(),
+        mouse_bytes(&scroll, area, policy(false, false, true)).as_deref(),
         Some(b"\x1b[<64;3;4M".as_slice())
     );
     assert_eq!(
-        mouse_event_to_pty_bytes(&scroll, area, |_| false, false, &MouseModeProvider,),
+        mouse_event_to_pty_bytes(
+            &scroll,
+            area,
+            policy(false, false, false),
+            false,
+            &MouseModeProvider,
+        ),
         None
     );
 }
@@ -309,11 +319,11 @@ fn unsupported_or_intercepted_mouse_events_are_not_forwarded() {
         modifiers,
     };
 
-    assert!(mouse_bytes(&outside, area, SGR_CLICK).is_none());
-    assert!(mouse_bytes(&shifted, area, SGR_CLICK).is_none());
-    assert!(mouse_bytes(&middle, area, SGR_CLICK).is_none());
-    assert!(mouse_bytes(&synthetic_move, area, SGR_MOTION).is_none());
-    assert!(mouse_bytes(&horizontal_scroll, area, SGR_CLICK).is_none());
+    assert!(mouse_bytes(&outside, area, report_all()).is_none());
+    assert!(mouse_bytes(&shifted, area, report_all()).is_none());
+    assert!(mouse_bytes(&middle, area, report_all()).is_none());
+    assert!(mouse_bytes(&synthetic_move, area, report_all()).is_none());
+    assert!(mouse_bytes(&horizontal_scroll, area, report_all()).is_none());
 }
 
 #[test]

--- a/crates/warp_tui/src/terminal_content_element_tests.rs
+++ b/crates/warp_tui/src/terminal_content_element_tests.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 
 use parking_lot::FairMutex;
-use warp::tui_export::{TermMode, TerminalModel, ToEscapeSequence as _};
-use warp_terminal::model::escape_sequences::{BRACKETED_PASTE_END, BRACKETED_PASTE_START};
+use warp::tui_export::{TermMode, TerminalModel};
+use warp_terminal::model::escape_sequences::{
+    ModeProvider, BRACKETED_PASTE_END, BRACKETED_PASTE_START,
+};
 use warpui::EntityIdMap;
 use warpui_core::elements::tui::{
     TuiConstraint, TuiElement, TuiEvent, TuiLayoutContext, TuiPaintContext, TuiPaintSurface,
@@ -12,7 +14,9 @@ use warpui_core::event::{KeyEventDetails, ModifiersState};
 use warpui_core::keymap::Keystroke;
 use warpui_core::{App, AppContext};
 
-use super::{mouse_state_for_event, paste_bytes, pty_bytes_for_event, TuiTerminalContentElement};
+use super::{
+    mouse_event_to_pty_bytes, paste_bytes, pty_bytes_for_event, TuiTerminalContentElement,
+};
 const SGR_CLICK: TermMode = TermMode::SGR_MOUSE.union(TermMode::MOUSE_REPORT_CLICK);
 const SGR_DRAG: TermMode = TermMode::SGR_MOUSE.union(TermMode::MOUSE_DRAG);
 const SGR_MOTION: TermMode = TermMode::SGR_MOUSE.union(TermMode::MOUSE_MOTION);
@@ -25,10 +29,24 @@ fn bounds(x: i32, y: i32, width: u16, height: u16) -> TuiScreenRect {
     )
 }
 
+/// Supplies no terminal modes; mouse SGR encoding does not consult them.
+struct MouseModeProvider;
+
+impl ModeProvider for MouseModeProvider {
+    fn is_term_mode_set(&self, _mode: TermMode) -> bool {
+        false
+    }
+}
+
 /// Encodes `event` using the production TUI mouse-event adapter.
 fn mouse_bytes(event: &TuiEvent, area: TuiScreenRect, modes: TermMode) -> Option<Vec<u8>> {
-    let state = mouse_state_for_event(event, area, |mode| modes.contains(mode))?;
-    state.to_escape_sequence(&TerminalModel::mock(None, None))
+    mouse_event_to_pty_bytes(
+        event,
+        area,
+        |mode| modes.contains(mode),
+        true,
+        &MouseModeProvider,
+    )
 }
 
 /// A leaf that fills its constraint and retains the laid-out size.
@@ -180,7 +198,7 @@ fn sgr_mouse_events_use_area_relative_coordinates() {
                 precise: false,
                 modifiers,
             },
-            SGR_CLICK,
+            TermMode::SGR_MOUSE,
             b"\x1b[<64;3;2M".as_slice(),
         ),
         (
@@ -190,7 +208,7 @@ fn sgr_mouse_events_use_area_relative_coordinates() {
                 precise: false,
                 modifiers,
             },
-            SGR_CLICK,
+            TermMode::SGR_MOUSE,
             b"\x1b[<65;3;2M".as_slice(),
         ),
     ];
@@ -201,7 +219,7 @@ fn sgr_mouse_events_use_area_relative_coordinates() {
 }
 
 #[test]
-fn mouse_events_require_the_requested_reporting_mode() {
+fn click_and_motion_events_require_the_requested_reporting_mode() {
     let area = bounds(0, 0, 10, 10);
     let position = TuiPoint::new(2, 3);
     let modifiers = ModifiersState::default();
@@ -228,6 +246,30 @@ fn mouse_events_require_the_requested_reporting_mode() {
     assert!(mouse_bytes(&left_dragged, area, SGR_DRAG).is_some());
     assert!(mouse_bytes(&moved, area, SGR_DRAG).is_none());
     assert!(mouse_bytes(&moved, area, SGR_MOTION).is_some());
+}
+
+#[test]
+fn scroll_uses_sgr_when_available_and_arrows_otherwise() {
+    let scroll = TuiEvent::ScrollWheel {
+        position: TuiPoint::new(2, 3),
+        delta: (0, 1),
+        precise: false,
+        modifiers: ModifiersState::default(),
+    };
+    let area = bounds(0, 0, 10, 10);
+
+    assert_eq!(
+        mouse_bytes(&scroll, area, TermMode::NONE).as_deref(),
+        Some(b"\x1bOA".as_slice())
+    );
+    assert_eq!(
+        mouse_bytes(&scroll, area, TermMode::SGR_MOUSE).as_deref(),
+        Some(b"\x1b[<64;3;4M".as_slice())
+    );
+    assert_eq!(
+        mouse_event_to_pty_bytes(&scroll, area, |_| false, false, &MouseModeProvider,),
+        None
+    );
 }
 
 #[test]

--- a/crates/warp_tui/src/terminal_content_element_tests.rs
+++ b/crates/warp_tui/src/terminal_content_element_tests.rs
@@ -1,18 +1,35 @@
 use std::sync::Arc;
 
 use parking_lot::FairMutex;
-use warp::tui_export::TerminalModel;
+use warp::tui_export::{TermMode, TerminalModel, ToEscapeSequence as _};
 use warp_terminal::model::escape_sequences::{BRACKETED_PASTE_END, BRACKETED_PASTE_START};
 use warpui::EntityIdMap;
 use warpui_core::elements::tui::{
     TuiConstraint, TuiElement, TuiEvent, TuiLayoutContext, TuiPaintContext, TuiPaintSurface,
-    TuiScreenPosition, TuiSize,
+    TuiPoint, TuiScreenPoint, TuiScreenPosition, TuiScreenRect, TuiSize, TuiZIndex,
 };
-use warpui_core::event::KeyEventDetails;
+use warpui_core::event::{KeyEventDetails, ModifiersState};
 use warpui_core::keymap::Keystroke;
 use warpui_core::{App, AppContext};
 
-use super::{paste_bytes, pty_bytes_for_event, TuiTerminalContentElement};
+use super::{mouse_state_for_event, paste_bytes, pty_bytes_for_event, TuiTerminalContentElement};
+const SGR_CLICK: TermMode = TermMode::SGR_MOUSE.union(TermMode::MOUSE_REPORT_CLICK);
+const SGR_DRAG: TermMode = TermMode::SGR_MOUSE.union(TermMode::MOUSE_DRAG);
+const SGR_MOTION: TermMode = TermMode::SGR_MOUSE.union(TermMode::MOUSE_MOTION);
+
+/// Builds retained screen bounds anchored at `(x, y)`.
+fn bounds(x: i32, y: i32, width: u16, height: u16) -> TuiScreenRect {
+    TuiScreenRect::new(
+        TuiScreenPoint::new(x, y, TuiZIndex::Normal(0)),
+        TuiSize::new(width, height),
+    )
+}
+
+/// Encodes `event` using the production TUI mouse-event adapter.
+fn mouse_bytes(event: &TuiEvent, area: TuiScreenRect, modes: TermMode) -> Option<Vec<u8>> {
+    let state = mouse_state_for_event(event, area, |mode| modes.contains(mode))?;
+    state.to_escape_sequence(&TerminalModel::mock(None, None))
+}
 
 /// A leaf that fills its constraint and retains the laid-out size.
 struct FillElement {
@@ -104,6 +121,157 @@ fn key_events_use_terminal_aware_pty_encoding() {
         pty_bytes_for_event(&key_down("é", "é", false), &model),
         Some("é".as_bytes().to_vec())
     );
+}
+
+#[test]
+fn sgr_mouse_events_use_area_relative_coordinates() {
+    let area = bounds(10, 5, 20, 10);
+    let position = TuiPoint::new(12, 6);
+    let modifiers = ModifiersState::default();
+    let cases = [
+        (
+            TuiEvent::LeftMouseDown {
+                position,
+                modifiers,
+                click_count: 1,
+                is_first_mouse: false,
+            },
+            SGR_CLICK,
+            b"\x1b[<0;3;2M".as_slice(),
+        ),
+        (
+            TuiEvent::RightMouseDown {
+                position,
+                modifiers,
+                click_count: 1,
+            },
+            SGR_CLICK,
+            b"\x1b[<2;3;2M".as_slice(),
+        ),
+        (
+            TuiEvent::LeftMouseUp {
+                position,
+                modifiers,
+            },
+            SGR_CLICK,
+            b"\x1b[<0;3;2m".as_slice(),
+        ),
+        (
+            TuiEvent::LeftMouseDragged {
+                position,
+                modifiers,
+            },
+            SGR_DRAG,
+            b"\x1b[<32;3;2M".as_slice(),
+        ),
+        (
+            TuiEvent::MouseMoved {
+                position,
+                modifiers,
+                is_synthetic: false,
+            },
+            SGR_MOTION,
+            b"\x1b[<35;3;2M".as_slice(),
+        ),
+        (
+            TuiEvent::ScrollWheel {
+                position,
+                delta: (0, 1),
+                precise: false,
+                modifiers,
+            },
+            SGR_CLICK,
+            b"\x1b[<64;3;2M".as_slice(),
+        ),
+        (
+            TuiEvent::ScrollWheel {
+                position,
+                delta: (0, -1),
+                precise: false,
+                modifiers,
+            },
+            SGR_CLICK,
+            b"\x1b[<65;3;2M".as_slice(),
+        ),
+    ];
+
+    for (event, modes, expected) in cases {
+        assert_eq!(mouse_bytes(&event, area, modes).as_deref(), Some(expected));
+    }
+}
+
+#[test]
+fn mouse_events_require_the_requested_reporting_mode() {
+    let area = bounds(0, 0, 10, 10);
+    let position = TuiPoint::new(2, 3);
+    let modifiers = ModifiersState::default();
+    let left_down = TuiEvent::LeftMouseDown {
+        position,
+        modifiers,
+        click_count: 1,
+        is_first_mouse: false,
+    };
+    let left_dragged = TuiEvent::LeftMouseDragged {
+        position,
+        modifiers,
+    };
+    let moved = TuiEvent::MouseMoved {
+        position,
+        modifiers,
+        is_synthetic: false,
+    };
+
+    assert!(mouse_bytes(&left_down, area, TermMode::MOUSE_REPORT_CLICK).is_none());
+    assert!(mouse_bytes(&left_down, area, TermMode::SGR_MOUSE).is_none());
+    assert!(mouse_bytes(&left_down, area, SGR_DRAG).is_some());
+    assert!(mouse_bytes(&left_dragged, area, SGR_CLICK).is_none());
+    assert!(mouse_bytes(&left_dragged, area, SGR_DRAG).is_some());
+    assert!(mouse_bytes(&moved, area, SGR_DRAG).is_none());
+    assert!(mouse_bytes(&moved, area, SGR_MOTION).is_some());
+}
+
+#[test]
+fn unsupported_or_intercepted_mouse_events_are_not_forwarded() {
+    let area = bounds(5, 5, 10, 10);
+    let modifiers = ModifiersState::default();
+
+    let outside = TuiEvent::LeftMouseDown {
+        position: TuiPoint::new(4, 5),
+        modifiers,
+        click_count: 1,
+        is_first_mouse: false,
+    };
+    let shifted = TuiEvent::LeftMouseDown {
+        position: TuiPoint::new(6, 6),
+        modifiers: ModifiersState {
+            shift: true,
+            ..Default::default()
+        },
+        click_count: 1,
+        is_first_mouse: false,
+    };
+    let middle = TuiEvent::MiddleMouseDown {
+        position: TuiPoint::new(6, 6),
+        modifiers,
+        click_count: 1,
+    };
+    let synthetic_move = TuiEvent::MouseMoved {
+        position: TuiPoint::new(6, 6),
+        modifiers,
+        is_synthetic: true,
+    };
+    let horizontal_scroll = TuiEvent::ScrollWheel {
+        position: TuiPoint::new(6, 6),
+        delta: (1, 0),
+        precise: false,
+        modifiers,
+    };
+
+    assert!(mouse_bytes(&outside, area, SGR_CLICK).is_none());
+    assert!(mouse_bytes(&shifted, area, SGR_CLICK).is_none());
+    assert!(mouse_bytes(&middle, area, SGR_CLICK).is_none());
+    assert!(mouse_bytes(&synthetic_move, area, SGR_MOTION).is_none());
+    assert!(mouse_bytes(&horizontal_scroll, area, SGR_CLICK).is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Description

Stacked on #13626, which adds alt-screen rendering and keyboard forwarding to the Warp TUI.

This PR adds mouse interaction for full-screen terminal applications in the TUI, and unifies the alt-screen mouse-reporting policy and wheel encoding across the GUI and TUI:

**TUI mouse forwarding (`crates/warp_tui/src/alt_screen_view.rs`)**

- Converts crossterm click, release, drag, motion, and wheel events into terminal input using pane-relative cell coordinates (single `cell_point` conversion helper).
- Gating is driven by a small `MouseReportPolicy` (buttons / motion / scroll) derived from the *same* policy functions the GUI uses — `should_intercept_mouse` / `should_intercept_scroll` — now re-exported via `tui_export`. This means the TUI honors the `AltScreenReporting` settings toggles and shared-session reader state identically to the GUI, with no duplicated mode logic.
- Keeps Shift-click available for terminal-native selection instead of forwarding it to the application; synthetic motion and out-of-bounds events are never forwarded.
- Routes the resulting bytes through the TUI's existing raw `ForwardToPty` path.

**Shared wheel encoding (`crates/warp_terminal/src/model/escape_sequences.rs`)**

- `alt_screen_scroll_to_pty_bytes` encodes alt-screen wheel movement for both front-ends:
  - Applications using SGR mouse reporting receive mouse-wheel escape sequences.
  - Applications without mouse reporting, including default Vim, receive the existing SS3 arrow-key fallback.

**GUI (behavior-preserving refactor)**

- `TerminalAction::AltScroll` now carries only event data (`{ delta, point }`); the report-vs-intercept decision moved out of the element into the `alt_scroll` handler, which calls `should_intercept_scroll` and the shared encoder. Bytes written to the PTY are unchanged; zero-delta scrolls now skip the PTY write entirely instead of writing an empty sequence.

## Testing

Automated:

- `cargo nextest run -p warp_terminal -E 'test(test_alt_screen_scroll_to_pty_bytes)'`
- `cargo nextest run -p warp_tui -E 'test(alt_screen_view)'` (policy-driven tests: byte-exact SGR coordinates, per-category gating, SGR-vs-arrow scroll fallback, rejection cases)
- `cargo nextest run -p warp -E 'test(test_alt_screen_select_with_sgr_mouse)'`
- `cargo clippy -p warp --lib -- -D warnings`
- `cargo clippy -p warp_tui --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Manual:

- Verified default Vim scrolls through the shared SS3 fallback.
- Verified Vim with SGR mouse reporting moves its cursor to the clicked terminal cell.
- Verified Vim exits back to the normal TUI surface.

- [x] I have manually tested my changes locally with `./script/run-tui`

### Screenshots / Videos

[Video demo (Loom)](https://www.loom.com/share/3172496bde19417088526b336e90ef2b)

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode
