### PR TITLE
Add speech language preference for voice input

### DIFF
--- a/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
+++ b/app/src/ai/blocklist/agent_view/agent_input_footer/mod.rs
@@ -1879,6 +1879,9 @@ impl AgentInputFooter {
                 let voice_transcriber = VoiceTranscriber::as_ref(ctx);
                 if let Some(transcriber) = voice_transcriber.transcriber() {
                     let transcriber = transcriber.clone();
+                    let language = AISettings::as_ref(ctx)
+                        .voice_input_language_code()
+                        .map(str::to_owned);
                     self.cli_voice_input_state = CLIVoiceInputState::Transcribing;
 
                     voice_input::VoiceInput::handle(ctx).update(ctx, |voice, _| {
@@ -1886,7 +1889,7 @@ impl AgentInputFooter {
                     });
 
                     self.cli_transcription_handle = Some(ctx.spawn(
-                        async move { transcriber.transcribe(wav_base64).await },
+                        async move { transcriber.transcribe(wav_base64, language).await },
                         Self::apply_cli_transcribed_voice_input,
                     ));
                 } else {

--- a/app/src/editor/view/voice.rs
+++ b/app/src/editor/view/voice.rs
@@ -446,6 +446,9 @@ impl EditorView {
                 let voice_transcriber = VoiceTranscriber::handle(ctx).as_ref(ctx);
                 if let Some(transcriber) = voice_transcriber.transcriber() {
                     let transcriber = transcriber.clone();
+                    let language = AISettings::as_ref(ctx)
+                        .voice_input_language_code()
+                        .map(str::to_owned);
 
                     VoiceInput::handle(ctx).update(ctx, |voice, _| {
                         voice.set_transcribing_active(true);
@@ -454,7 +457,7 @@ impl EditorView {
                     self.set_voice_input_state(
                         VoiceInputState::Transcribing {
                             handle: ctx.spawn(
-                                async move { transcriber.transcribe(wav_base64).await },
+                                async move { transcriber.transcribe(wav_base64, language).await },
                                 Self::apply_transcribed_voice_input,
                             ),
                         },

--- a/app/src/server/voice_transcriber.rs
+++ b/app/src/server/voice_transcriber.rs
@@ -20,10 +20,15 @@ impl ServerVoiceTranscriber {
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 impl Transcriber for ServerVoiceTranscriber {
-    async fn transcribe(&self, wav_base64: String) -> Result<String, TranscribeError> {
+    async fn transcribe(
+        &self,
+        wav_base64: String,
+        language: Option<String>,
+    ) -> Result<String, TranscribeError> {
         let request = TranscribeRequest {
             provider: Provider::Wispr,
             audio: Some(wav_base64),
+            language,
             ..Default::default()
         };
         let response = self.server_api.transcribe(&request).await;

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -277,6 +277,200 @@ impl VoiceInputToggleKey {
     }
 }
 
+/// Preferred spoken language for voice input transcription.
+///
+/// `Auto` leaves language detection to the transcription provider (Wispr Flow).
+/// A specific language is sent as an ISO-639-1 code to force that language.
+#[derive(
+    Default,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Copy,
+    Clone,
+    EnumIter,
+    schemars::JsonSchema,
+    settings_value::SettingsValue,
+)]
+#[schemars(
+    description = "Preferred spoken language for voice input transcription.",
+    rename_all = "snake_case"
+)]
+pub enum VoiceInputLanguage {
+    /// Let the transcription provider auto-detect the spoken language (default).
+    #[default]
+    #[schemars(description = "Auto-detect spoken language.")]
+    Auto,
+    #[schemars(description = "English.")]
+    English,
+    #[schemars(description = "Spanish.")]
+    Spanish,
+    #[schemars(description = "French.")]
+    French,
+    #[schemars(description = "German.")]
+    German,
+    #[schemars(description = "Portuguese.")]
+    Portuguese,
+    #[schemars(description = "Italian.")]
+    Italian,
+    #[schemars(description = "Dutch.")]
+    Dutch,
+    #[schemars(description = "Polish.")]
+    Polish,
+    #[schemars(description = "Russian.")]
+    Russian,
+    #[schemars(description = "Ukrainian.")]
+    Ukrainian,
+    #[schemars(description = "Japanese.")]
+    Japanese,
+    #[schemars(description = "Korean.")]
+    Korean,
+    #[schemars(description = "Chinese (Simplified/Mandarin).")]
+    Chinese,
+    #[schemars(description = "Hindi.")]
+    Hindi,
+    #[schemars(description = "Arabic.")]
+    Arabic,
+    #[schemars(description = "Turkish.")]
+    Turkish,
+    #[schemars(description = "Swedish.")]
+    Swedish,
+    #[schemars(description = "Norwegian.")]
+    Norwegian,
+    #[schemars(description = "Danish.")]
+    Danish,
+    #[schemars(description = "Finnish.")]
+    Finnish,
+    #[schemars(description = "Estonian.")]
+    Estonian,
+    #[schemars(description = "Latvian.")]
+    Latvian,
+    #[schemars(description = "Lithuanian.")]
+    Lithuanian,
+    #[schemars(description = "Czech.")]
+    Czech,
+    #[schemars(description = "Slovak.")]
+    Slovak,
+    #[schemars(description = "Hungarian.")]
+    Hungarian,
+    #[schemars(description = "Romanian.")]
+    Romanian,
+    #[schemars(description = "Greek.")]
+    Greek,
+    #[schemars(description = "Hebrew.")]
+    Hebrew,
+    #[schemars(description = "Thai.")]
+    Thai,
+    #[schemars(description = "Vietnamese.")]
+    Vietnamese,
+    #[schemars(description = "Indonesian.")]
+    Indonesian,
+    #[schemars(description = "Malay.")]
+    Malay,
+    #[schemars(description = "Catalan.")]
+    Catalan,
+}
+
+settings::macros::implement_setting_for_enum!(
+    VoiceInputLanguage,
+    AISettings,
+    SupportedPlatforms::DESKTOP,
+    SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+    surface: settings::SettingSurfaces::GUI,
+    private: false,
+    toml_path: "agents.voice.voice_input_language",
+    description: "Preferred spoken language for voice input transcription.",
+);
+
+impl VoiceInputLanguage {
+    pub fn all_possible_values() -> Vec<VoiceInputLanguage> {
+        VoiceInputLanguage::iter().collect()
+    }
+
+    /// Display name for the AI settings dropdown.
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            VoiceInputLanguage::Auto => "Auto-detect",
+            VoiceInputLanguage::English => "English",
+            VoiceInputLanguage::Spanish => "Spanish",
+            VoiceInputLanguage::French => "French",
+            VoiceInputLanguage::German => "German",
+            VoiceInputLanguage::Portuguese => "Portuguese",
+            VoiceInputLanguage::Italian => "Italian",
+            VoiceInputLanguage::Dutch => "Dutch",
+            VoiceInputLanguage::Polish => "Polish",
+            VoiceInputLanguage::Russian => "Russian",
+            VoiceInputLanguage::Ukrainian => "Ukrainian",
+            VoiceInputLanguage::Japanese => "Japanese",
+            VoiceInputLanguage::Korean => "Korean",
+            VoiceInputLanguage::Chinese => "Chinese",
+            VoiceInputLanguage::Hindi => "Hindi",
+            VoiceInputLanguage::Arabic => "Arabic",
+            VoiceInputLanguage::Turkish => "Turkish",
+            VoiceInputLanguage::Swedish => "Swedish",
+            VoiceInputLanguage::Norwegian => "Norwegian",
+            VoiceInputLanguage::Danish => "Danish",
+            VoiceInputLanguage::Finnish => "Finnish",
+            VoiceInputLanguage::Estonian => "Estonian",
+            VoiceInputLanguage::Latvian => "Latvian",
+            VoiceInputLanguage::Lithuanian => "Lithuanian",
+            VoiceInputLanguage::Czech => "Czech",
+            VoiceInputLanguage::Slovak => "Slovak",
+            VoiceInputLanguage::Hungarian => "Hungarian",
+            VoiceInputLanguage::Romanian => "Romanian",
+            VoiceInputLanguage::Greek => "Greek",
+            VoiceInputLanguage::Hebrew => "Hebrew",
+            VoiceInputLanguage::Thai => "Thai",
+            VoiceInputLanguage::Vietnamese => "Vietnamese",
+            VoiceInputLanguage::Indonesian => "Indonesian",
+            VoiceInputLanguage::Malay => "Malay",
+            VoiceInputLanguage::Catalan => "Catalan",
+        }
+    }
+
+    /// ISO-639-1 language code for the transcription API, or `None` for auto-detect.
+    pub fn iso_code(&self) -> Option<&'static str> {
+        match self {
+            VoiceInputLanguage::Auto => None,
+            VoiceInputLanguage::English => Some("en"),
+            VoiceInputLanguage::Spanish => Some("es"),
+            VoiceInputLanguage::French => Some("fr"),
+            VoiceInputLanguage::German => Some("de"),
+            VoiceInputLanguage::Portuguese => Some("pt"),
+            VoiceInputLanguage::Italian => Some("it"),
+            VoiceInputLanguage::Dutch => Some("nl"),
+            VoiceInputLanguage::Polish => Some("pl"),
+            VoiceInputLanguage::Russian => Some("ru"),
+            VoiceInputLanguage::Ukrainian => Some("uk"),
+            VoiceInputLanguage::Japanese => Some("ja"),
+            VoiceInputLanguage::Korean => Some("ko"),
+            VoiceInputLanguage::Chinese => Some("zh"),
+            VoiceInputLanguage::Hindi => Some("hi"),
+            VoiceInputLanguage::Arabic => Some("ar"),
+            VoiceInputLanguage::Turkish => Some("tr"),
+            VoiceInputLanguage::Swedish => Some("sv"),
+            VoiceInputLanguage::Norwegian => Some("no"),
+            VoiceInputLanguage::Danish => Some("da"),
+            VoiceInputLanguage::Finnish => Some("fi"),
+            VoiceInputLanguage::Estonian => Some("et"),
+            VoiceInputLanguage::Latvian => Some("lv"),
+            VoiceInputLanguage::Lithuanian => Some("lt"),
+            VoiceInputLanguage::Czech => Some("cs"),
+            VoiceInputLanguage::Slovak => Some("sk"),
+            VoiceInputLanguage::Hungarian => Some("hu"),
+            VoiceInputLanguage::Romanian => Some("ro"),
+            VoiceInputLanguage::Greek => Some("el"),
+            VoiceInputLanguage::Hebrew => Some("he"),
+            VoiceInputLanguage::Thai => Some("th"),
+            VoiceInputLanguage::Vietnamese => Some("vi"),
+            VoiceInputLanguage::Indonesian => Some("id"),
+            VoiceInputLanguage::Malay => Some("ms"),
+            VoiceInputLanguage::Catalan => Some("ca"),
+        }
+    }
+}
+
 /// The default mode for new terminal sessions.
 #[derive(
     Default,
@@ -1006,9 +1200,11 @@ define_settings_group!(AISettings, settings: [
         surface: settings::SettingSurfaces::GUI,
         private: true,
     },
-    // This field is used to store the key used for voice input toggling.
+// This field is used to store the key used for voice input toggling.
     // Note this is not the named key, but rather corresponds to the physical key.
     voice_input_toggle_key: VoiceInputToggleKey,
+    // Preferred spoken language for voice transcription (Auto or an ISO language).
+    voice_input_language: VoiceInputLanguage,
     // This is not a user-visible setting - it's merely a one-time flag to track if the user has
     // explicitly interacted with voice input. We use this to determine whether we should show a toast
     // to inform the user about voice input and auto-set the keybinding.
@@ -1893,6 +2089,11 @@ impl AISettings {
         cfg!(feature = "voice_input")
             && self.is_any_ai_enabled(app)
             && *self.voice_input_enabled_internal
+    }
+
+    /// Preferred spoken language for voice transcription, or `None` for auto-detect.
+    pub fn voice_input_language_code(&self) -> Option<&'static str> {
+        self.voice_input_language.iso_code()
     }
 
     /// Returns `true` if input autodetection is enabled.

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -1200,7 +1200,7 @@ define_settings_group!(AISettings, settings: [
         surface: settings::SettingSurfaces::GUI,
         private: true,
     },
-// This field is used to store the key used for voice input toggling.
+    // This field is used to store the key used for voice input toggling.
     // Note this is not the named key, but rather corresponds to the physical key.
     voice_input_toggle_key: VoiceInputToggleKey,
     // Preferred spoken language for voice transcription. Stored as an ISO-639-1

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -2105,11 +2105,7 @@ impl AISettings {
     /// Preferred spoken language for voice transcription, or `None` for auto-detect.
     pub fn voice_input_language_code(&self) -> Option<&str> {
         let code = self.voice_input_language.as_str();
-        if code.is_empty() {
-            None
-        } else {
-            Some(code)
-        }
+        if code.is_empty() { None } else { Some(code) }
     }
 
     /// Returns `true` if input autodetection is enabled.

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -277,199 +277,199 @@ impl VoiceInputToggleKey {
     }
 }
 
-/// Preferred spoken language for voice input transcription.
-///
-/// `Auto` leaves language detection to the transcription provider (Wispr Flow).
-/// A specific language is sent as an ISO-639-1 code to force that language.
-#[derive(
-    Default,
-    Debug,
-    serde::Serialize,
-    serde::Deserialize,
-    PartialEq,
-    Copy,
-    Clone,
-    EnumIter,
-    schemars::JsonSchema,
-    settings_value::SettingsValue,
-)]
-#[schemars(
-    description = "Preferred spoken language for voice input transcription",
-    rename_all = "snake_case"
-)]
-pub enum VoiceInputLanguage {
-    /// Let the transcription provider auto-detect the spoken language (default).
-    #[default]
-    #[schemars(description = "Auto-detect spoken language")]
-    Auto,
-    #[schemars(description = "English")]
-    English,
-    #[schemars(description = "Spanish")]
-    Spanish,
-    #[schemars(description = "French")]
-    French,
-    #[schemars(description = "German")]
-    German,
-    #[schemars(description = "Portuguese")]
-    Portuguese,
-    #[schemars(description = "Italian")]
-    Italian,
-    #[schemars(description = "Dutch")]
-    Dutch,
-    #[schemars(description = "Polish")]
-    Polish,
-    #[schemars(description = "Russian")]
-    Russian,
-    #[schemars(description = "Ukrainian")]
-    Ukrainian,
-    #[schemars(description = "Japanese")]
-    Japanese,
-    #[schemars(description = "Korean")]
-    Korean,
-    #[schemars(description = "Chinese (Simplified/Mandarin)")]
-    Chinese,
-    #[schemars(description = "Hindi")]
-    Hindi,
-    #[schemars(description = "Arabic")]
-    Arabic,
-    #[schemars(description = "Turkish")]
-    Turkish,
-    #[schemars(description = "Swedish")]
-    Swedish,
-    #[schemars(description = "Norwegian")]
-    Norwegian,
-    #[schemars(description = "Danish")]
-    Danish,
-    #[schemars(description = "Finnish")]
-    Finnish,
-    #[schemars(description = "Estonian")]
-    Estonian,
-    #[schemars(description = "Latvian")]
-    Latvian,
-    #[schemars(description = "Lithuanian")]
-    Lithuanian,
-    #[schemars(description = "Czech")]
-    Czech,
-    #[schemars(description = "Slovak")]
-    Slovak,
-    #[schemars(description = "Hungarian")]
-    Hungarian,
-    #[schemars(description = "Romanian")]
-    Romanian,
-    #[schemars(description = "Greek")]
-    Greek,
-    #[schemars(description = "Hebrew")]
-    Hebrew,
-    #[schemars(description = "Thai")]
-    Thai,
-    #[schemars(description = "Vietnamese")]
-    Vietnamese,
-    #[schemars(description = "Indonesian")]
-    Indonesian,
-    #[schemars(description = "Malay")]
-    Malay,
-    #[schemars(description = "Catalan")]
-    Catalan,
-}
-
-settings::macros::implement_setting_for_enum!(
-    VoiceInputLanguage,
-    AISettings,
-    SupportedPlatforms::DESKTOP,
-    SyncToCloud::Globally(RespectUserSyncSetting::Yes),
-    surface: settings::SettingSurfaces::GUI,
-    private: false,
-    toml_path: "agents.voice.voice_input_language",
-    description: "Preferred spoken language for voice input transcription.",
-);
-
-impl VoiceInputLanguage {
-    pub fn all_possible_values() -> Vec<VoiceInputLanguage> {
-        VoiceInputLanguage::iter().collect()
-    }
-
-    /// Display name for the AI settings dropdown.
-    pub fn display_name(&self) -> &'static str {
-        match self {
-            VoiceInputLanguage::Auto => "Auto-detect",
-            VoiceInputLanguage::English => "English",
-            VoiceInputLanguage::Spanish => "Spanish",
-            VoiceInputLanguage::French => "French",
-            VoiceInputLanguage::German => "German",
-            VoiceInputLanguage::Portuguese => "Portuguese",
-            VoiceInputLanguage::Italian => "Italian",
-            VoiceInputLanguage::Dutch => "Dutch",
-            VoiceInputLanguage::Polish => "Polish",
-            VoiceInputLanguage::Russian => "Russian",
-            VoiceInputLanguage::Ukrainian => "Ukrainian",
-            VoiceInputLanguage::Japanese => "Japanese",
-            VoiceInputLanguage::Korean => "Korean",
-            VoiceInputLanguage::Chinese => "Chinese",
-            VoiceInputLanguage::Hindi => "Hindi",
-            VoiceInputLanguage::Arabic => "Arabic",
-            VoiceInputLanguage::Turkish => "Turkish",
-            VoiceInputLanguage::Swedish => "Swedish",
-            VoiceInputLanguage::Norwegian => "Norwegian",
-            VoiceInputLanguage::Danish => "Danish",
-            VoiceInputLanguage::Finnish => "Finnish",
-            VoiceInputLanguage::Estonian => "Estonian",
-            VoiceInputLanguage::Latvian => "Latvian",
-            VoiceInputLanguage::Lithuanian => "Lithuanian",
-            VoiceInputLanguage::Czech => "Czech",
-            VoiceInputLanguage::Slovak => "Slovak",
-            VoiceInputLanguage::Hungarian => "Hungarian",
-            VoiceInputLanguage::Romanian => "Romanian",
-            VoiceInputLanguage::Greek => "Greek",
-            VoiceInputLanguage::Hebrew => "Hebrew",
-            VoiceInputLanguage::Thai => "Thai",
-            VoiceInputLanguage::Vietnamese => "Vietnamese",
-            VoiceInputLanguage::Indonesian => "Indonesian",
-            VoiceInputLanguage::Malay => "Malay",
-            VoiceInputLanguage::Catalan => "Catalan",
-        }
-    }
-
-    /// ISO-639-1 language code for the transcription API, or `None` for auto-detect.
-    pub fn iso_code(&self) -> Option<&'static str> {
-        match self {
-            VoiceInputLanguage::Auto => None,
-            VoiceInputLanguage::English => Some("en"),
-            VoiceInputLanguage::Spanish => Some("es"),
-            VoiceInputLanguage::French => Some("fr"),
-            VoiceInputLanguage::German => Some("de"),
-            VoiceInputLanguage::Portuguese => Some("pt"),
-            VoiceInputLanguage::Italian => Some("it"),
-            VoiceInputLanguage::Dutch => Some("nl"),
-            VoiceInputLanguage::Polish => Some("pl"),
-            VoiceInputLanguage::Russian => Some("ru"),
-            VoiceInputLanguage::Ukrainian => Some("uk"),
-            VoiceInputLanguage::Japanese => Some("ja"),
-            VoiceInputLanguage::Korean => Some("ko"),
-            VoiceInputLanguage::Chinese => Some("zh"),
-            VoiceInputLanguage::Hindi => Some("hi"),
-            VoiceInputLanguage::Arabic => Some("ar"),
-            VoiceInputLanguage::Turkish => Some("tr"),
-            VoiceInputLanguage::Swedish => Some("sv"),
-            VoiceInputLanguage::Norwegian => Some("no"),
-            VoiceInputLanguage::Danish => Some("da"),
-            VoiceInputLanguage::Finnish => Some("fi"),
-            VoiceInputLanguage::Estonian => Some("et"),
-            VoiceInputLanguage::Latvian => Some("lv"),
-            VoiceInputLanguage::Lithuanian => Some("lt"),
-            VoiceInputLanguage::Czech => Some("cs"),
-            VoiceInputLanguage::Slovak => Some("sk"),
-            VoiceInputLanguage::Hungarian => Some("hu"),
-            VoiceInputLanguage::Romanian => Some("ro"),
-            VoiceInputLanguage::Greek => Some("el"),
-            VoiceInputLanguage::Hebrew => Some("he"),
-            VoiceInputLanguage::Thai => Some("th"),
-            VoiceInputLanguage::Vietnamese => Some("vi"),
-            VoiceInputLanguage::Indonesian => Some("id"),
-            VoiceInputLanguage::Malay => Some("ms"),
-            VoiceInputLanguage::Catalan => Some("ca"),
-        }
-    }
-}
+/// The full ISO-639-1 language catalog offered in the voice-input Speech
+/// Language picker, as `(code, display_name)` pairs. The empty code is the
+/// `Auto-detect` sentinel: when it is the stored value, no language is forced
+/// and the transcription provider (Wispr Flow) auto-detects the language.
+/// Kept as a data table (rather than an enum) so the entire list stays easy to
+/// scan and extend; the picker is filterable, so the length is not a problem.
+pub const VOICE_INPUT_LANGUAGES: &[(&str, &str)] = &[
+    ("", "Auto-detect"),
+    ("ab", "Abkhaz"),
+    ("aa", "Afar"),
+    ("af", "Afrikaans"),
+    ("ak", "Akan"),
+    ("sq", "Albanian"),
+    ("am", "Amharic"),
+    ("ar", "Arabic"),
+    ("an", "Aragonese"),
+    ("hy", "Armenian"),
+    ("as", "Assamese"),
+    ("av", "Avaric"),
+    ("ae", "Avestan"),
+    ("ay", "Aymara"),
+    ("az", "Azerbaijani"),
+    ("bm", "Bambara"),
+    ("ba", "Bashkir"),
+    ("eu", "Basque"),
+    ("be", "Belarusian"),
+    ("bn", "Bengali"),
+    ("bh", "Bihari"),
+    ("bi", "Bislama"),
+    ("bs", "Bosnian"),
+    ("br", "Breton"),
+    ("bg", "Bulgarian"),
+    ("my", "Burmese"),
+    ("ca", "Catalan"),
+    ("ch", "Chamorro"),
+    ("ce", "Chechen"),
+    ("ny", "Chichewa"),
+    ("zh", "Chinese"),
+    ("cv", "Chuvash"),
+    ("kw", "Cornish"),
+    ("co", "Corsican"),
+    ("cr", "Cree"),
+    ("hr", "Croatian"),
+    ("cs", "Czech"),
+    ("da", "Danish"),
+    ("dv", "Divehi"),
+    ("nl", "Dutch"),
+    ("dz", "Dzongkha"),
+    ("en", "English"),
+    ("eo", "Esperanto"),
+    ("et", "Estonian"),
+    ("ee", "Ewe"),
+    ("fo", "Faroese"),
+    ("fj", "Fijian"),
+    ("fi", "Finnish"),
+    ("fr", "French"),
+    ("ff", "Fulah"),
+    ("gl", "Galician"),
+    ("lg", "Ganda"),
+    ("ka", "Georgian"),
+    ("de", "German"),
+    ("el", "Greek"),
+    ("gn", "Guarani"),
+    ("gu", "Gujarati"),
+    ("ht", "Haitian Creole"),
+    ("ha", "Hausa"),
+    ("he", "Hebrew"),
+    ("hz", "Herero"),
+    ("hi", "Hindi"),
+    ("ho", "Hiri Motu"),
+    ("hu", "Hungarian"),
+    ("is", "Icelandic"),
+    ("io", "Ido"),
+    ("ig", "Igbo"),
+    ("id", "Indonesian"),
+    ("ia", "Interlingua"),
+    ("ie", "Interlingue"),
+    ("iu", "Inuktitut"),
+    ("ik", "Inupiaq"),
+    ("ga", "Irish"),
+    ("it", "Italian"),
+    ("ja", "Japanese"),
+    ("jv", "Javanese"),
+    ("kl", "Kalaallisut"),
+    ("kn", "Kannada"),
+    ("kr", "Kanuri"),
+    ("ks", "Kashmiri"),
+    ("kk", "Kazakh"),
+    ("km", "Khmer"),
+    ("ki", "Kikuyu"),
+    ("rw", "Kinyarwanda"),
+    ("kv", "Komi"),
+    ("kg", "Kongo"),
+    ("ko", "Korean"),
+    ("ku", "Kurdish"),
+    ("kj", "Kwanyama"),
+    ("ky", "Kyrgyz"),
+    ("lo", "Lao"),
+    ("la", "Latin"),
+    ("lv", "Latvian"),
+    ("li", "Limburgish"),
+    ("ln", "Lingala"),
+    ("lt", "Lithuanian"),
+    ("lu", "Luba-Katanga"),
+    ("lb", "Luxembourgish"),
+    ("mk", "Macedonian"),
+    ("mg", "Malagasy"),
+    ("ms", "Malay"),
+    ("ml", "Malayalam"),
+    ("mt", "Maltese"),
+    ("gv", "Manx"),
+    ("mi", "Maori"),
+    ("mr", "Marathi"),
+    ("mh", "Marshallese"),
+    ("mn", "Mongolian"),
+    ("na", "Nauru"),
+    ("nv", "Navajo"),
+    ("ng", "Ndonga"),
+    ("ne", "Nepali"),
+    ("nd", "North Ndebele"),
+    ("se", "Northern Sami"),
+    ("no", "Norwegian"),
+    ("nb", "Norwegian Bokmal"),
+    ("nn", "Norwegian Nynorsk"),
+    ("ii", "Nuosu"),
+    ("oc", "Occitan"),
+    ("oj", "Ojibwe"),
+    ("cu", "Old Church Slavonic"),
+    ("or", "Oriya"),
+    ("om", "Oromo"),
+    ("os", "Ossetian"),
+    ("pi", "Pali"),
+    ("ps", "Pashto"),
+    ("fa", "Persian"),
+    ("pl", "Polish"),
+    ("pt", "Portuguese"),
+    ("pa", "Punjabi"),
+    ("qu", "Quechua"),
+    ("ro", "Romanian"),
+    ("rm", "Romansh"),
+    ("rn", "Rundi"),
+    ("ru", "Russian"),
+    ("sm", "Samoan"),
+    ("sg", "Sango"),
+    ("sa", "Sanskrit"),
+    ("sc", "Sardinian"),
+    ("gd", "Scottish Gaelic"),
+    ("sr", "Serbian"),
+    ("sn", "Shona"),
+    ("sd", "Sindhi"),
+    ("si", "Sinhala"),
+    ("sk", "Slovak"),
+    ("sl", "Slovenian"),
+    ("so", "Somali"),
+    ("nr", "South Ndebele"),
+    ("st", "Southern Sotho"),
+    ("es", "Spanish"),
+    ("su", "Sundanese"),
+    ("sw", "Swahili"),
+    ("ss", "Swati"),
+    ("sv", "Swedish"),
+    ("tl", "Tagalog"),
+    ("ty", "Tahitian"),
+    ("tg", "Tajik"),
+    ("ta", "Tamil"),
+    ("tt", "Tatar"),
+    ("te", "Telugu"),
+    ("th", "Thai"),
+    ("bo", "Tibetan"),
+    ("ti", "Tigrinya"),
+    ("to", "Tongan"),
+    ("ts", "Tsonga"),
+    ("tn", "Tswana"),
+    ("tr", "Turkish"),
+    ("tk", "Turkmen"),
+    ("tw", "Twi"),
+    ("uk", "Ukrainian"),
+    ("ur", "Urdu"),
+    ("ug", "Uyghur"),
+    ("uz", "Uzbek"),
+    ("ve", "Venda"),
+    ("vi", "Vietnamese"),
+    ("vo", "Volapuk"),
+    ("wa", "Walloon"),
+    ("cy", "Welsh"),
+    ("fy", "Western Frisian"),
+    ("wo", "Wolof"),
+    ("xh", "Xhosa"),
+    ("yi", "Yiddish"),
+    ("yo", "Yoruba"),
+    ("za", "Zhuang"),
+    ("zu", "Zulu"),
+];
 
 /// The default mode for new terminal sessions.
 #[derive(
@@ -1203,8 +1203,19 @@ define_settings_group!(AISettings, settings: [
 // This field is used to store the key used for voice input toggling.
     // Note this is not the named key, but rather corresponds to the physical key.
     voice_input_toggle_key: VoiceInputToggleKey,
-    // Preferred spoken language for voice transcription (Auto or an ISO language).
-    voice_input_language: VoiceInputLanguage,
+    // Preferred spoken language for voice transcription. Stored as an ISO-639-1
+    // code (e.g. "es"); an empty string means Auto-detect. Options come from
+    // VOICE_INPUT_LANGUAGES.
+    voice_input_language: VoiceInputLanguage {
+        type: String,
+        default: String::new(),
+        supported_platforms: SupportedPlatforms::DESKTOP,
+        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+        surface: settings::SettingSurfaces::GUI,
+        private: false,
+        toml_path: "agents.voice.voice_input_language",
+        description: "Preferred spoken language for voice input transcription.",
+    },
     // This is not a user-visible setting - it's merely a one-time flag to track if the user has
     // explicitly interacted with voice input. We use this to determine whether we should show a toast
     // to inform the user about voice input and auto-set the keybinding.
@@ -2092,8 +2103,13 @@ impl AISettings {
     }
 
     /// Preferred spoken language for voice transcription, or `None` for auto-detect.
-    pub fn voice_input_language_code(&self) -> Option<&'static str> {
-        self.voice_input_language.iso_code()
+    pub fn voice_input_language_code(&self) -> Option<&str> {
+        let code = self.voice_input_language.as_str();
+        if code.is_empty() {
+            None
+        } else {
+            Some(code)
+        }
     }
 
     /// Returns `true` if input autodetection is enabled.

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -294,81 +294,81 @@ impl VoiceInputToggleKey {
     settings_value::SettingsValue,
 )]
 #[schemars(
-    description = "Preferred spoken language for voice input transcription.",
+    description = "Preferred spoken language for voice input transcription",
     rename_all = "snake_case"
 )]
 pub enum VoiceInputLanguage {
     /// Let the transcription provider auto-detect the spoken language (default).
     #[default]
-    #[schemars(description = "Auto-detect spoken language.")]
+    #[schemars(description = "Auto-detect spoken language")]
     Auto,
-    #[schemars(description = "English.")]
+    #[schemars(description = "English")]
     English,
-    #[schemars(description = "Spanish.")]
+    #[schemars(description = "Spanish")]
     Spanish,
-    #[schemars(description = "French.")]
+    #[schemars(description = "French")]
     French,
-    #[schemars(description = "German.")]
+    #[schemars(description = "German")]
     German,
-    #[schemars(description = "Portuguese.")]
+    #[schemars(description = "Portuguese")]
     Portuguese,
-    #[schemars(description = "Italian.")]
+    #[schemars(description = "Italian")]
     Italian,
-    #[schemars(description = "Dutch.")]
+    #[schemars(description = "Dutch")]
     Dutch,
-    #[schemars(description = "Polish.")]
+    #[schemars(description = "Polish")]
     Polish,
-    #[schemars(description = "Russian.")]
+    #[schemars(description = "Russian")]
     Russian,
-    #[schemars(description = "Ukrainian.")]
+    #[schemars(description = "Ukrainian")]
     Ukrainian,
-    #[schemars(description = "Japanese.")]
+    #[schemars(description = "Japanese")]
     Japanese,
-    #[schemars(description = "Korean.")]
+    #[schemars(description = "Korean")]
     Korean,
-    #[schemars(description = "Chinese (Simplified/Mandarin).")]
+    #[schemars(description = "Chinese (Simplified/Mandarin)")]
     Chinese,
-    #[schemars(description = "Hindi.")]
+    #[schemars(description = "Hindi")]
     Hindi,
-    #[schemars(description = "Arabic.")]
+    #[schemars(description = "Arabic")]
     Arabic,
-    #[schemars(description = "Turkish.")]
+    #[schemars(description = "Turkish")]
     Turkish,
-    #[schemars(description = "Swedish.")]
+    #[schemars(description = "Swedish")]
     Swedish,
-    #[schemars(description = "Norwegian.")]
+    #[schemars(description = "Norwegian")]
     Norwegian,
-    #[schemars(description = "Danish.")]
+    #[schemars(description = "Danish")]
     Danish,
-    #[schemars(description = "Finnish.")]
+    #[schemars(description = "Finnish")]
     Finnish,
-    #[schemars(description = "Estonian.")]
+    #[schemars(description = "Estonian")]
     Estonian,
-    #[schemars(description = "Latvian.")]
+    #[schemars(description = "Latvian")]
     Latvian,
-    #[schemars(description = "Lithuanian.")]
+    #[schemars(description = "Lithuanian")]
     Lithuanian,
-    #[schemars(description = "Czech.")]
+    #[schemars(description = "Czech")]
     Czech,
-    #[schemars(description = "Slovak.")]
+    #[schemars(description = "Slovak")]
     Slovak,
-    #[schemars(description = "Hungarian.")]
+    #[schemars(description = "Hungarian")]
     Hungarian,
-    #[schemars(description = "Romanian.")]
+    #[schemars(description = "Romanian")]
     Romanian,
-    #[schemars(description = "Greek.")]
+    #[schemars(description = "Greek")]
     Greek,
-    #[schemars(description = "Hebrew.")]
+    #[schemars(description = "Hebrew")]
     Hebrew,
-    #[schemars(description = "Thai.")]
+    #[schemars(description = "Thai")]
     Thai,
-    #[schemars(description = "Vietnamese.")]
+    #[schemars(description = "Vietnamese")]
     Vietnamese,
-    #[schemars(description = "Indonesian.")]
+    #[schemars(description = "Indonesian")]
     Indonesian,
-    #[schemars(description = "Malay.")]
+    #[schemars(description = "Malay")]
     Malay,
-    #[schemars(description = "Catalan.")]
+    #[schemars(description = "Catalan")]
     Catalan,
 }
 

--- a/app/src/settings/ai_tests.rs
+++ b/app/src/settings/ai_tests.rs
@@ -791,16 +791,29 @@ fn test_voice_input_languages_codes_and_names_are_valid_and_unique() {
     let mut seen_codes = HashSet::new();
     let mut seen_names = HashSet::new();
     for (index, (code, name)) in VOICE_INPUT_LANGUAGES.iter().enumerate() {
-        assert!(!name.is_empty(), "language name must not be empty: {code:?}");
-        assert!(seen_names.insert(*name), "duplicate language name: {name:?}");
-        assert!(seen_codes.insert(*code), "duplicate language code: {code:?}");
+        assert!(
+            !name.is_empty(),
+            "language name must not be empty: {code:?}"
+        );
+        assert!(
+            seen_names.insert(*name),
+            "duplicate language name: {name:?}"
+        );
+        assert!(
+            seen_codes.insert(*code),
+            "duplicate language code: {code:?}"
+        );
 
         if index == 0 {
             // Auto-detect sentinel: empty code, validated separately.
             continue;
         }
         // Every real language uses a two-letter lowercase ISO-639-1 code.
-        assert_eq!(code.len(), 2, "expected a 2-letter ISO-639-1 code: {code:?}");
+        assert_eq!(
+            code.len(),
+            2,
+            "expected a 2-letter ISO-639-1 code: {code:?}"
+        );
         assert!(
             code.chars().all(|c| c.is_ascii_lowercase()),
             "ISO-639-1 code must be lowercase ascii: {code:?}"

--- a/app/src/settings/ai_tests.rs
+++ b/app/src/settings/ai_tests.rs
@@ -761,3 +761,61 @@ fn test_mark_quota_banner_as_dismissed() {
         });
     });
 }
+
+// VOICE_INPUT_LANGUAGES catalog tests
+
+#[test]
+fn test_voice_input_languages_auto_detect_is_first_with_empty_code() {
+    // The picker relies on the first entry being the Auto-detect sentinel with an
+    // empty code, since an empty stored value means "don't force a language".
+    let (code, name) = VOICE_INPUT_LANGUAGES[0];
+    assert_eq!(code, "");
+    assert_eq!(name, "Auto-detect");
+}
+
+#[test]
+fn test_voice_input_languages_has_full_catalog() {
+    // Sanity check that we ship the full list rather than a small curated subset:
+    // Auto-detect plus well over 100 ISO-639-1 languages.
+    assert!(
+        VOICE_INPUT_LANGUAGES.len() > 150,
+        "expected the full ISO-639-1 catalog, got {} entries",
+        VOICE_INPUT_LANGUAGES.len()
+    );
+}
+
+#[test]
+fn test_voice_input_languages_codes_and_names_are_valid_and_unique() {
+    use std::collections::HashSet;
+
+    let mut seen_codes = HashSet::new();
+    let mut seen_names = HashSet::new();
+    for (index, (code, name)) in VOICE_INPUT_LANGUAGES.iter().enumerate() {
+        assert!(!name.is_empty(), "language name must not be empty: {code:?}");
+        assert!(seen_names.insert(*name), "duplicate language name: {name:?}");
+        assert!(seen_codes.insert(*code), "duplicate language code: {code:?}");
+
+        if index == 0 {
+            // Auto-detect sentinel: empty code, validated separately.
+            continue;
+        }
+        // Every real language uses a two-letter lowercase ISO-639-1 code.
+        assert_eq!(code.len(), 2, "expected a 2-letter ISO-639-1 code: {code:?}");
+        assert!(
+            code.chars().all(|c| c.is_ascii_lowercase()),
+            "ISO-639-1 code must be lowercase ascii: {code:?}"
+        );
+    }
+}
+
+#[test]
+fn test_voice_input_languages_includes_common_languages() {
+    // A representative spot check, including Marathi (mr) which was explicitly
+    // requested in the review that motivated the full list.
+    for expected in [("en", "English"), ("es", "Spanish"), ("mr", "Marathi")] {
+        assert!(
+            VOICE_INPUT_LANGUAGES.contains(&expected),
+            "catalog is missing {expected:?}"
+        );
+    }
+}

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -7264,7 +7264,7 @@ impl VoiceWidget {
             column.add_child(render_dropdown_item(
                 appearance,
                 "Speech Language",
-                Some("Language used when transcribing voice input. Auto-detect if unsure."),
+                Some("Language used when transcribing voice input."),
                 None,
                 LocalOnlyIconState::for_setting(
                     VoiceInputLanguage::storage_key(),

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -48,8 +48,8 @@ use super::settings_page::{
     SettingsPageViewHandle, SettingsWidget, TOGGLE_BUTTON_RIGHT_PADDING, ToggleState,
     build_sub_header, build_toggle_element, render_body_item_label,
     render_body_item_label_with_icon, render_custom_size_header, render_dropdown_item,
-    render_dropdown_item_label, render_full_pane_width_ai_button, render_input_list,
-    render_separator, render_settings_info_banner,
+    render_dropdown_item_label, render_filterable_dropdown_item, render_full_pane_width_ai_button,
+    render_input_list, render_separator, render_settings_info_banner,
 };
 use super::{
     SettingActionPairContexts, SettingActionPairDescriptions, SettingsAction, SettingsSection,
@@ -157,7 +157,9 @@ use crate::server::telemetry::{
     AgentModeAutoDetectionSettingOrigin, AutonomySettingToggleSource,
     ToggleCodeSuggestionsSettingSource,
 };
-use crate::settings::{AISettings, VoiceInputLanguage, VoiceInputToggleKey};
+use crate::settings::{
+    AISettings, VoiceInputLanguage, VoiceInputToggleKey, VOICE_INPUT_LANGUAGES,
+};
 use crate::ui_components::blended_colors;
 use crate::ui_components::icons::Icon;
 use crate::util::bindings;
@@ -692,7 +694,7 @@ pub struct AISettingsPageView {
     page: PageType<Self>,
     active_subpage: Option<AISubpage>,
     voice_input_toggle_key_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
-    voice_input_language_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
+    voice_input_language_dropdown: ViewHandle<FilterableDropdown<AISettingsPageAction>>,
     local_only_icon_tooltip_states: RefCell<HashMap<String, MouseStateHandle>>,
     autodetection_denylist_editor: ViewHandle<EditorView>,
     autonomy_dropdown_menu: ViewHandle<Dropdown<AISettingsPageAction>>,
@@ -861,38 +863,33 @@ impl AISettingsPageView {
         });
 
         let voice_input_language_dropdown = ctx.add_typed_action_view(|ctx| {
-            let mut dropdown = Dropdown::new(ctx);
+            let mut dropdown = FilterableDropdown::new(ctx);
             dropdown.set_top_bar_max_width(AI_SETTINGS_DROPDOWN_WIDTH);
-            dropdown.set_menu_max_height(AI_SETTINGS_DROPDOWN_MAX_HEIGHT, ctx);
+            dropdown.set_menu_width(AI_SETTINGS_DROPDOWN_WIDTH, ctx);
             if !AISettings::as_ref(ctx).is_voice_input_enabled(ctx) {
                 dropdown.set_disabled(ctx);
             }
 
-            let values = VoiceInputLanguage::all_possible_values();
-            let current_value = AISettings::as_ref(ctx).voice_input_language.value();
-            let selected_index = values
-                .iter()
-                .position(|val| val == current_value)
-                .unwrap_or_else(|| {
-                    log::warn!(
-                        "Could not find current VoiceInputLanguage value in dropdown option list"
-                    );
-                    0
-                });
-
             dropdown.add_items(
-                values
-                    .into_iter()
-                    .map(|val| {
+                VOICE_INPUT_LANGUAGES
+                    .iter()
+                    .map(|&(code, name)| {
                         DropdownItem::new(
-                            val.display_name(),
-                            AISettingsPageAction::SetVoiceInputLanguage(val),
+                            name,
+                            AISettingsPageAction::SetVoiceInputLanguage(code.to_string()),
                         )
                     })
                     .collect(),
                 ctx,
             );
-            dropdown.set_selected_by_index(selected_index, ctx);
+            let current_code = AISettings::as_ref(ctx)
+                .voice_input_language_code()
+                .unwrap_or("")
+                .to_string();
+            dropdown.set_selected_by_action(
+                AISettingsPageAction::SetVoiceInputLanguage(current_code),
+                ctx,
+            );
 
             dropdown
         });
@@ -1349,13 +1346,16 @@ impl AISettingsPageView {
                         });
                 }
                 AISettingsChangedEvent::VoiceInputLanguage { .. } => {
-                    let current_value = AISettings::as_ref(ctx)
-                        .voice_input_language
-                        .value()
-                        .display_name();
+                    let current_code = AISettings::as_ref(ctx)
+                        .voice_input_language_code()
+                        .unwrap_or("")
+                        .to_string();
                     me.voice_input_language_dropdown
                         .update(ctx, |dropdown, ctx| {
-                            dropdown.set_selected_by_name(current_value, ctx)
+                            dropdown.set_selected_by_action(
+                                AISettingsPageAction::SetVoiceInputLanguage(current_code),
+                                ctx,
+                            )
                         });
                 }
                 AISettingsChangedEvent::AgentModeCommandExecutionAllowlist { .. } => {
@@ -3662,7 +3662,7 @@ impl Entity for AISettingsPageView {
 pub enum AISettingsPageAction {
     OpenUrl(String),
     SetVoiceInputToggleKey(VoiceInputToggleKey),
-    SetVoiceInputLanguage(VoiceInputLanguage),
+    SetVoiceInputLanguage(String),
     ToggleGlobalAI,
     ToggleActiveAI,
     ToggleIntelligentAutosuggestions,
@@ -3788,8 +3788,9 @@ impl TypedActionView for AISettingsPageView {
                 ctx.notify();
             }
             AISettingsPageAction::SetVoiceInputLanguage(language) => {
+                let language = language.clone();
                 AISettings::handle(ctx).update(ctx, |settings, ctx| {
-                    report_if_error!(settings.voice_input_language.set_value(*language, ctx));
+                    report_if_error!(settings.voice_input_language.set_value(language, ctx));
                 });
                 ctx.notify();
             }
@@ -7261,7 +7262,7 @@ impl VoiceWidget {
                 None,
                 &view.voice_input_toggle_key_dropdown,
             ));
-            column.add_child(render_dropdown_item(
+            column.add_child(render_filterable_dropdown_item(
                 appearance,
                 "Speech Language",
                 Some("Language used when transcribing voice input."),

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -157,7 +157,7 @@ use crate::server::telemetry::{
     AgentModeAutoDetectionSettingOrigin, AutonomySettingToggleSource,
     ToggleCodeSuggestionsSettingSource,
 };
-use crate::settings::{AISettings, VoiceInputToggleKey};
+use crate::settings::{AISettings, VoiceInputLanguage, VoiceInputToggleKey};
 use crate::ui_components::blended_colors;
 use crate::ui_components::icons::Icon;
 use crate::util::bindings;
@@ -692,6 +692,7 @@ pub struct AISettingsPageView {
     page: PageType<Self>,
     active_subpage: Option<AISubpage>,
     voice_input_toggle_key_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
+    voice_input_language_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
     local_only_icon_tooltip_states: RefCell<HashMap<String, MouseStateHandle>>,
     autodetection_denylist_editor: ViewHandle<EditorView>,
     autonomy_dropdown_menu: ViewHandle<Dropdown<AISettingsPageAction>>,
@@ -849,6 +850,43 @@ impl AISettingsPageView {
                         DropdownItem::new(
                             val.display_name(),
                             AISettingsPageAction::SetVoiceInputToggleKey(val),
+                        )
+                    })
+                    .collect(),
+                ctx,
+            );
+            dropdown.set_selected_by_index(selected_index, ctx);
+
+            dropdown
+        });
+
+        let voice_input_language_dropdown = ctx.add_typed_action_view(|ctx| {
+            let mut dropdown = Dropdown::new(ctx);
+            dropdown.set_top_bar_max_width(AI_SETTINGS_DROPDOWN_WIDTH);
+            dropdown.set_menu_max_height(AI_SETTINGS_DROPDOWN_MAX_HEIGHT, ctx);
+            if !AISettings::as_ref(ctx).is_voice_input_enabled(ctx) {
+                dropdown.set_disabled(ctx);
+            }
+
+            let values = VoiceInputLanguage::all_possible_values();
+            let current_value = AISettings::as_ref(ctx).voice_input_language.value();
+            let selected_index = values
+                .iter()
+                .position(|val| val == current_value)
+                .unwrap_or_else(|| {
+                    log::warn!(
+                        "Could not find current VoiceInputLanguage value in dropdown option list"
+                    );
+                    0
+                });
+
+            dropdown.add_items(
+                values
+                    .into_iter()
+                    .map(|val| {
+                        DropdownItem::new(
+                            val.display_name(),
+                            AISettingsPageAction::SetVoiceInputLanguage(val),
                         )
                     })
                     .collect(),
@@ -1306,6 +1344,16 @@ impl AISettingsPageView {
                         .value()
                         .display_name();
                     me.voice_input_toggle_key_dropdown
+                        .update(ctx, |dropdown, ctx| {
+                            dropdown.set_selected_by_name(current_value, ctx)
+                        });
+                }
+                AISettingsChangedEvent::VoiceInputLanguage { .. } => {
+                    let current_value = AISettings::as_ref(ctx)
+                        .voice_input_language
+                        .value()
+                        .display_name();
+                    me.voice_input_language_dropdown
                         .update(ctx, |dropdown, ctx| {
                             dropdown.set_selected_by_name(current_value, ctx)
                         });
@@ -1962,6 +2010,7 @@ impl AISettingsPageView {
             page: Self::build_page(None, ctx),
             active_subpage: None,
             voice_input_toggle_key_dropdown,
+            voice_input_language_dropdown,
             autodetection_denylist_editor,
             local_only_icon_tooltip_states: Default::default(),
             command_execution_allowlist_editor,
@@ -2028,6 +2077,14 @@ impl AISettingsPageView {
     fn update_voice_input_dropdown_enablement(&mut self, ctx: &mut ViewContext<Self>) {
         let is_voice_enabled = AISettings::as_ref(ctx).is_voice_input_enabled(ctx);
         self.voice_input_toggle_key_dropdown
+            .update(ctx, |dropdown, ctx| {
+                if is_voice_enabled {
+                    dropdown.set_enabled(ctx);
+                } else {
+                    dropdown.set_disabled(ctx);
+                }
+            });
+        self.voice_input_language_dropdown
             .update(ctx, |dropdown, ctx| {
                 if is_voice_enabled {
                     dropdown.set_enabled(ctx);
@@ -3605,6 +3662,7 @@ impl Entity for AISettingsPageView {
 pub enum AISettingsPageAction {
     OpenUrl(String),
     SetVoiceInputToggleKey(VoiceInputToggleKey),
+    SetVoiceInputLanguage(VoiceInputLanguage),
     ToggleGlobalAI,
     ToggleActiveAI,
     ToggleIntelligentAutosuggestions,
@@ -3726,6 +3784,12 @@ impl TypedActionView for AISettingsPageView {
                             .explicitly_interacted_with_voice
                             .set_value(true, ctx)
                     );
+                });
+                ctx.notify();
+            }
+            AISettingsPageAction::SetVoiceInputLanguage(language) => {
+                AISettings::handle(ctx).update(ctx, |settings, ctx| {
+                    report_if_error!(settings.voice_input_language.set_value(*language, ctx));
                 });
                 ctx.notify();
             }
@@ -7197,6 +7261,20 @@ impl VoiceWidget {
                 None,
                 &view.voice_input_toggle_key_dropdown,
             ));
+            column.add_child(render_dropdown_item(
+                appearance,
+                "Speech Language",
+                Some("Language used when transcribing voice input. Auto-detect if unsure."),
+                None,
+                LocalOnlyIconState::for_setting(
+                    VoiceInputLanguage::storage_key(),
+                    VoiceInputLanguage::sync_to_cloud(),
+                    &mut view.local_only_icon_tooltip_states.borrow_mut(),
+                    app,
+                ),
+                None,
+                &view.voice_input_language_dropdown,
+            ));
         }
 
         column.finish()
@@ -7207,7 +7285,7 @@ impl SettingsWidget for VoiceWidget {
     type View = AISettingsPageView;
 
     fn search_terms(&self) -> &str {
-        "voice agent oz ai a.i. speech input natural language talk english"
+        "voice agent oz ai a.i. speech input natural language talk english language spanish french german estonian finnish"
     }
 
     fn should_render(&self, app: &AppContext) -> bool {

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -7284,7 +7284,7 @@ impl SettingsWidget for VoiceWidget {
     type View = AISettingsPageView;
 
     fn search_terms(&self) -> &str {
-        "voice agent oz ai a.i. speech input natural language talk english language spanish french german estonian finnish"
+        "voice agent oz ai a.i. speech input natural language talk english spanish french german estonian finnish"
     }
 
     fn should_render(&self, app: &AppContext) -> bool {

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -157,7 +157,7 @@ use crate::server::telemetry::{
     AgentModeAutoDetectionSettingOrigin, AutonomySettingToggleSource,
     ToggleCodeSuggestionsSettingSource,
 };
-use crate::settings::{AISettings, VoiceInputLanguage, VoiceInputToggleKey, VOICE_INPUT_LANGUAGES};
+use crate::settings::{AISettings, VOICE_INPUT_LANGUAGES, VoiceInputLanguage, VoiceInputToggleKey};
 use crate::ui_components::blended_colors;
 use crate::ui_components::icons::Icon;
 use crate::util::bindings;

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -157,9 +157,7 @@ use crate::server::telemetry::{
     AgentModeAutoDetectionSettingOrigin, AutonomySettingToggleSource,
     ToggleCodeSuggestionsSettingSource,
 };
-use crate::settings::{
-    AISettings, VoiceInputLanguage, VoiceInputToggleKey, VOICE_INPUT_LANGUAGES,
-};
+use crate::settings::{AISettings, VoiceInputLanguage, VoiceInputToggleKey, VOICE_INPUT_LANGUAGES};
 use crate::ui_components::blended_colors;
 use crate::ui_components::icons::Icon;
 use crate::util::bindings;

--- a/app/src/settings_view/settings_page.rs
+++ b/app/src/settings_view/settings_page.rs
@@ -49,7 +49,9 @@ use crate::settings::CloudPreferencesSettings;
 use crate::themes::theme::Fill;
 use crate::ui_components::blended_colors;
 use crate::ui_components::icons::Icon;
-use crate::view_components::{Dropdown, DropdownItemAction, SubmittableTextInput};
+use crate::view_components::{
+    Dropdown, DropdownItemAction, FilterableDropdown, SubmittableTextInput,
+};
 
 pub const TOGGLE_BUTTON_RIGHT_PADDING: f32 = 5.;
 pub const HEADER_PADDING: f32 = 15.;
@@ -921,6 +923,49 @@ pub(crate) fn render_dropdown_item<T: DropdownItemAction>(
     local_only_icon_state: LocalOnlyIconState,
     color_override: Option<Fill>,
     handle: &ViewHandle<Dropdown<T>>,
+) -> Box<dyn Element> {
+    let row = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
+
+    let dropdown_item_label = Align::new(render_dropdown_item_label(
+        label.to_string(),
+        secondary_text.map(|secondary_text| secondary_text.to_string()),
+        local_only_icon_state,
+        color_override,
+        appearance,
+    ))
+    .left()
+    .finish();
+
+    let mut dropdown = Flex::column().with_child(ChildView::new(handle).finish());
+    if let Some(dropdown_subtext) = dropdown_subtext {
+        dropdown.add_child(dropdown_subtext);
+    }
+
+    row.with_child(
+        Shrinkable::new(
+            1.0,
+            Container::new(dropdown_item_label)
+                .with_margin_bottom(4.)
+                .with_padding_right(16.)
+                .finish(),
+        )
+        .finish(),
+    )
+    .with_child(dropdown.finish())
+    .finish()
+}
+
+/// Like [`render_dropdown_item`], but for a [`FilterableDropdown`] (a dropdown
+/// with a built-in search box). Used for long option lists such as the
+/// voice-input Speech Language picker.
+pub(crate) fn render_filterable_dropdown_item<T: DropdownItemAction>(
+    appearance: &Appearance,
+    label: &str,
+    secondary_text: Option<&str>,
+    dropdown_subtext: Option<Box<dyn Element>>,
+    local_only_icon_state: LocalOnlyIconState,
+    color_override: Option<Fill>,
+    handle: &ViewHandle<FilterableDropdown<T>>,
 ) -> Box<dyn Element> {
     let row = Flex::row().with_cross_axis_alignment(CrossAxisAlignment::Center);
 

--- a/app/src/voice/transcriber.rs
+++ b/app/src/voice/transcriber.rs
@@ -10,8 +10,15 @@ use crate::server::server_api::TranscribeError;
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 pub trait Transcriber: Send + Sync {
     /// Transcribe the given base64 encoded wav file into text.
+    ///
+    /// `language` is an optional ISO-639-1 code (e.g. `"en"`). When `None`, the
+    /// transcription provider auto-detects the spoken language.
     /// This is expected to be async and called off the main thread.
-    async fn transcribe(&self, wav_base64: String) -> Result<String, TranscribeError>;
+    async fn transcribe(
+        &self,
+        wav_base64: String,
+        language: Option<String>,
+    ) -> Result<String, TranscribeError>;
 }
 
 /// A voice transcriber that is enabled or disabled.


### PR DESCRIPTION
## Description
Adds a **Speech Language** setting under Settings → AI → Voice so users can force a spoken language for voice transcription (or keep Auto-detect).

The client already had an optional `language` field on `TranscribeRequest`; this wires a real setting into it and passes the ISO-639-1 code through both editor and CLI voice transcription paths.

List is a curated subset for v1, not Wispr’s full 100+ catalog (API takes any ISO-639-1; no complete official enum in their docs). We biased toward common languages plus Estonian/Finnish from https://github.com/warpdotdev/warp/issues/8608. Happy to expand as requested.

Depends on the matching server PR that forwards `language` to Wispr as `language: ["xx"]`.


https://github.com/user-attachments/assets/a242e901-25bf-44dd-8dbf-b7e37e1c7e29



## Linked Issue
- https://github.com/warpdotdev/warp/issues/8608

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- Server-side unit tests cover Wispr request mapping (companion PR).
- Client unit/layout compile coverage expected via CI.
- Full end-to-end voice accuracy still needs human testing against a real mic + Wispr (language forcing, Auto-detect, multilingual users).

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
Not attached — needs local app run to capture Settings → AI → Voice dropdown.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Add a Speech Language setting for voice input so multilingual users can force transcription language instead of relying only on auto-detect.

Conversation: https://staging.warp.dev/conversation/ac7a4b49-aa11-44fd-ba2e-d9b602362383

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- factory-client: {"source":"factory-client","slack_channel":"C08KTPNQN65","slack_thread_ts":"1784167576.594009","slack_permalink":"https://warpdev.slack.com/archives/C08KTPNQN65/p1784167576594009?thread_ts=1784167576.594009&cid=C08KTPNQN65","oz_run_id":"019f6d97-88ea-7881-93fe-c4280437e6ac","repo":"warpdotdev/warp","ci_fix_attempts":1} -->
