### PR TITLE
Fix MCP tool chip padding

### DIFF
--- a/app/src/settings_view/mcp_servers/server_card.rs
+++ b/app/src/settings_view/mcp_servers/server_card.rs
@@ -16,7 +16,7 @@ use warpui::fonts::Weight;
 use warpui::platform::Cursor;
 use warpui::ui_components::button::ButtonVariant;
 use warpui::ui_components::chip::Chip;
-use warpui::ui_components::components::{Coords, UiComponent, UiComponentStyles};
+use warpui::ui_components::components::{UiComponent, UiComponentStyles};
 use warpui::ui_components::switch::SwitchStateHandle;
 use warpui::{AppContext, Element, Entity, SingletonEntity, TypedActionView, View, ViewContext};
 
@@ -447,12 +447,6 @@ impl ServerCardView {
                 Chip::new(
                     tool.to_string(),
                     UiComponentStyles {
-                        margin: Some(Coords {
-                            top: 0.,
-                            bottom: 0.,
-                            left: 0.,
-                            right: 6.,
-                        }),
                         font_family_id: Some(appearance.ui_font_family()),
                         font_size: Some(style::TOOL_CHIP_TEXT_SIZE),
                         font_color: Some(blended_colors::text_main(
@@ -1049,6 +1043,7 @@ impl View for ServerCardView {
                 if let Some(tools) = &self.tools {
                     let tool_chips = ServerCardView::render_tool_chips(tools, appearance);
                     let tool_chips_row = Wrap::row()
+                        .with_spacing(6.)
                         .with_run_spacing(6.)
                         .with_children(tool_chips)
                         .finish();


### PR DESCRIPTION
## Description

Fixes uneven right padding on tool-name chips in the MCP servers page.

The 6 px gap between tools was previously supplied as a chip margin. Because `Chip` forwards its styles to the inner text span as well as applying them to the outer container, that margin also inflated the chip's right interior padding. This change removes the chip-level margin and uses the wrapping layout's native horizontal spacing instead, preserving the gap while keeping chip padding symmetric.

## Linked Issue

User-reported visual regression; no linked issue.

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

- `./script/format --check`
- `CARGO_BUILD_JOBS=1 cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- `cargo build -p warp --bin warp-oss --features gui`
- Launched the built GUI with Computer Use, opened **Settings > Agents > MCP servers**, expanded a 22-tool test server, and verified symmetric chip padding, consistent gaps, clean three-row wrapping, and no text clipping or overlap.

No automated test was added because this is a composition-only spacing change with no new component or behavior; it was validated through the GUI build and direct visual inspection.

- [x] I have manually tested my changes locally with the built GUI binary.

### Screenshots / Videos

### Before

<img width="919" height="302" alt="image" src="https://github.com/user-attachments/assets/e3b91f35-739b-487a-a1f6-38b7375cc147" />


### Computer-use screenshot

<img width="1280" height="800" alt="mcp-tool-chip-padding-after" src="https://github.com/user-attachments/assets/d5b39b7e-91ee-447e-8695-ebe1a150d441" />


## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed uneven right padding on MCP tool-name chips.

Co-Authored-By: Oz <oz-agent@warp.dev>

_This PR was generated with [Oz](https://warp.dev/oz)._
