### PR TITLE
Add editor-backed code blocks for TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15921,6 +15921,7 @@ dependencies = [
  "parking_lot",
  "pathfinder_color",
  "pathfinder_geometry",
+ "rangemap",
  "serde_json",
  "similar",
  "string-offset",

--- a/crates/warp_tui/Cargo.toml
+++ b/crates/warp_tui/Cargo.toml
@@ -53,6 +53,7 @@ num-traits.workspace = true
 parking_lot.workspace = true
 pathfinder_color.workspace = true
 pathfinder_geometry.workspace = true
+rangemap.workspace = true
 serde_json.workspace = true
 similar.workspace = true
 string-offset.workspace = true

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -43,6 +43,9 @@ mod transcript_view;
 mod transient_hint;
 mod tui_block_list_viewport_source;
 mod tui_cli_subagent_view;
+// The view's production consumer lands in the next PR in this stack.
+#[allow(dead_code)]
+mod tui_code_block_view;
 mod tui_column_layout;
 mod tui_diff_storage;
 mod tui_file_edits_view;

--- a/crates/warp_tui/src/transcript_view_tests.rs
+++ b/crates/warp_tui/src/transcript_view_tests.rs
@@ -4,17 +4,19 @@ use std::sync::Arc;
 use parking_lot::FairMutex;
 use warp::tui_export::{
     AIAgentExchangeId, AIAgentInput, AIAgentOutput, AIAgentOutputMessage, AIAgentOutputMessageType,
-    AIAgentTodo, AIBlockModel, AIBlockOutputStatus, AIConversationId, AIRequestType, Appearance,
-    BlockHeightItem, BlocklistAIHistoryEvent, ConversationStatus, ConversationStatusUpdate, LLMId,
-    MessageId, OutputStatusUpdateCallback, RichContentItem, RichContentType, ServerOutputId,
-    Shared, TerminalModel, TodoOperation, UserQueryMode,
+    AIAgentText, AIAgentTextSection, AIAgentTodo, AIBlockModel, AIBlockOutputStatus,
+    AIConversationId, AIRequestType, Appearance, BlockHeightItem, BlocklistAIHistoryEvent,
+    ConversationStatus, ConversationStatusUpdate, LLMId, MessageId, OutputStatusUpdateCallback,
+    RichContentItem, RichContentType, ServerOutputId, Shared, TerminalModel, TodoOperation,
+    UserQueryMode,
 };
 use warpui::event::ModifiersState;
 use warpui::platform::WindowStyle;
 use warpui::{AddWindowOptions, App, EntityId, EntityIdMap, TuiView};
 use warpui_core::elements::tui::{
-    TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiEvent, TuiEventContext,
-    TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiRect, TuiScreenPosition, TuiSize,
+    Modifier, TuiBuffer, TuiBufferExt, TuiConstraint, TuiElement, TuiEvent, TuiEventContext,
+    TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiRect, TuiScene, TuiScreenPosition,
+    TuiSize,
 };
 use warpui_core::keymap::Keystroke;
 use warpui_core::presenter::tui::TuiPresenter;
@@ -485,6 +487,130 @@ fn presenter_draw_resolves_agent_blocks_from_cached_elements() {
     });
 }
 
+#[test]
+fn dragging_inside_markdown_highlights_transcript_text() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let terminal_model = Arc::new(FairMutex::new(TerminalModel::mock(None, None)));
+        let model_for_view = terminal_model.clone();
+        let (action_model, model_events) = add_test_action_model_and_events(&mut app);
+        let (_, transcript) = app.update(|ctx| {
+            ctx.add_tui_window(
+                AddWindowOptions {
+                    window_style: WindowStyle::NotStealFocus,
+                    ..Default::default()
+                },
+                |ctx| {
+                    TuiTranscriptView::new(
+                        EntityId::new(),
+                        model_for_view,
+                        action_model,
+                        &model_events,
+                        ctx,
+                    )
+                },
+            )
+        });
+        let agent_block_id = transcript.update(&mut app, |view, ctx| {
+            append_test_agent_block(
+                view,
+                AIConversationId::new(),
+                AIAgentExchangeId::new(),
+                markdown_output_status(
+                    "# Overview\n\nDrag selectable text.\n\n```rust\nfn main() {}\n```",
+                ),
+                ctx,
+            )
+        });
+        let agent_block = app.read(|ctx| {
+            transcript
+                .as_ref(ctx)
+                .agent_blocks
+                .borrow()
+                .get(&agent_block_id)
+                .expect("agent block should be registered")
+                .clone()
+        });
+        let mut rendered_views = app.read(|ctx| {
+            let mut rendered_views = EntityIdMap::default();
+            rendered_views.insert(agent_block_id, agent_block.as_ref(ctx).render(ctx));
+            rendered_views
+        });
+        let mut element = app.read(|ctx| transcript.as_ref(ctx).render(ctx));
+        let area = TuiRect::new(0, 0, 40, 8);
+        let (initial, scene) =
+            render_retained_element(&app, element.as_mut(), &mut rendered_views, area);
+        let lines = initial.to_lines();
+        let row = lines
+            .iter()
+            .position(|line| line.contains("Drag selectable text."))
+            .expect("rendered transcript should contain Markdown body");
+        let selectable_start_byte = lines[row]
+            .find("selectable")
+            .expect("rendered Markdown should contain selection target");
+        let selectable_start = lines[row][..selectable_start_byte].chars().count() as u16;
+        let selectable_end = selectable_start + "selectable".chars().count() as u16 - 1;
+
+        assert!(dispatch_retained_event(
+            &app,
+            transcript.id(),
+            element.as_mut(),
+            &mut rendered_views,
+            scene,
+            &TuiEvent::LeftMouseDown {
+                position: (selectable_start, row as u16).into(),
+                modifiers: ModifiersState::default(),
+                click_count: 1,
+                is_first_mouse: false,
+            },
+        ));
+        let (_, scene) = render_retained_element(&app, element.as_mut(), &mut rendered_views, area);
+        assert!(dispatch_retained_event(
+            &app,
+            transcript.id(),
+            element.as_mut(),
+            &mut rendered_views,
+            scene,
+            &TuiEvent::LeftMouseDragged {
+                position: (selectable_end, row as u16).into(),
+                modifiers: ModifiersState::default(),
+            },
+        ));
+
+        let (selected, scene) =
+            render_retained_element(&app, element.as_mut(), &mut rendered_views, area);
+        for column in selectable_start..=selectable_end {
+            assert!(
+                selected[(column, row as u16)]
+                    .modifier
+                    .contains(Modifier::REVERSED),
+                "selected Markdown cell at column {column} should be reversed"
+            );
+        }
+
+        assert!(dispatch_retained_event(
+            &app,
+            transcript.id(),
+            element.as_mut(),
+            &mut rendered_views,
+            scene,
+            &TuiEvent::LeftMouseUp {
+                position: (selectable_end, row as u16).into(),
+                modifiers: ModifiersState::default(),
+            },
+        ));
+        let (settled, _) =
+            render_retained_element(&app, element.as_mut(), &mut rendered_views, area);
+        for column in selectable_start..=selectable_end {
+            assert!(
+                settled[(column, row as u16)]
+                    .modifier
+                    .contains(Modifier::REVERSED),
+                "Markdown selection should persist after mouse-up"
+            );
+        }
+    });
+}
 /// Registers an agent block over a fake model with `inputs` on the transcript
 /// and appends its canonical rich-content item, returning the block's view id.
 fn insert_test_agent_block(
@@ -538,6 +664,65 @@ fn query_input(query: &str) -> AIAgentInput {
     }
 }
 
+fn markdown_output_status(markdown: &str) -> AIBlockOutputStatus {
+    AIBlockOutputStatus::Complete {
+        output: Shared::new(AIAgentOutput {
+            messages: vec![AIAgentOutputMessage {
+                id: MessageId::new("markdown-1".to_owned()),
+                message: AIAgentOutputMessageType::Text(AIAgentText {
+                    sections: vec![AIAgentTextSection::PlainText {
+                        text: markdown.to_owned().into(),
+                    }],
+                }),
+                citations: Vec::new(),
+            }],
+            ..Default::default()
+        }),
+    }
+}
+
+fn render_retained_element(
+    app: &App,
+    element: &mut dyn TuiElement,
+    rendered_views: &mut EntityIdMap<Box<dyn TuiElement>>,
+    area: TuiRect,
+) -> (TuiBuffer, Rc<TuiScene>) {
+    app.read(|app| {
+        let mut layout_ctx = TuiLayoutContext { rendered_views };
+        element.layout(
+            TuiConstraint::tight(TuiSize::new(area.width, area.height)),
+            &mut layout_ctx,
+            app,
+        );
+        let mut buffer = TuiBuffer::empty(area);
+        let mut paint_ctx = TuiPaintContext::new(rendered_views);
+        {
+            let mut surface = TuiPaintSurface::new(&mut buffer);
+            element.render(
+                TuiScreenPosition::new(i32::from(area.x), i32::from(area.y)),
+                &mut surface,
+                &mut paint_ctx,
+            );
+        }
+        let scene = Rc::new(paint_ctx.scene.clone());
+        (buffer, scene)
+    })
+}
+
+fn dispatch_retained_event(
+    app: &App,
+    origin_view_id: EntityId,
+    element: &mut dyn TuiElement,
+    rendered_views: &mut EntityIdMap<Box<dyn TuiElement>>,
+    scene: Rc<TuiScene>,
+    event: &TuiEvent,
+) -> bool {
+    app.read(|app| {
+        let mut event_ctx = TuiEventContext::new(scene, rendered_views);
+        event_ctx.set_origin_view(Some(origin_view_id));
+        element.dispatch_event(event, &mut event_ctx, app)
+    })
+}
 /// Lays out and renders a retained TUI element.
 fn render_element(app: &App, element: &mut dyn TuiElement, area: TuiRect) -> Vec<String> {
     app.read(|app| {

--- a/crates/warp_tui/src/tui_code_block_view.rs
+++ b/crates/warp_tui/src/tui_code_block_view.rs
@@ -169,11 +169,8 @@ impl TuiCodeBlockView {
                         colors
                             .iter()
                             .map(|(range, color)| {
-                                let start =
-                                    CharOffset::from(range.start.as_usize().saturating_sub(1));
-                                let end = CharOffset::from(range.end.as_usize().saturating_sub(1));
                                 (
-                                    start..end,
+                                    range.clone(),
                                     TuiStyle::default().fg(Color::Rgb(color.r, color.g, color.b)),
                                 )
                             })
@@ -205,11 +202,10 @@ impl TuiCodeBlockView {
     }
 }
 
-fn should_use_fallback(code: &str) -> bool {
-    code.len() > MAX_HIGHLIGHT_BYTES || code.lines().count() > MAX_CODE_LINES
-}
+/// Returns no fallback for code that is safe to highlight, or a UTF-8-safe
+/// prefix bounded by both highlight limits with an explicit truncation notice.
 fn bounded_fallback_text(code: &str) -> Option<String> {
-    if !should_use_fallback(code) {
+    if code.len() <= MAX_HIGHLIGHT_BYTES && code.lines().count() <= MAX_CODE_LINES {
         return None;
     }
 

--- a/crates/warp_tui/src/tui_code_block_view.rs
+++ b/crates/warp_tui/src/tui_code_block_view.rs
@@ -1,0 +1,269 @@
+//! Reusable read-only code block for TUI Markdown surfaces.
+//!
+//! The view owns a char-cell [`CodeEditorModel`], translates its syntax
+//! decorations into [`TuiEditorElement`] character overlays, and falls back to
+//! lightweight text for pathological inputs.
+
+use rangemap::RangeSet;
+use string_offset::CharOffset;
+use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
+use warp_editor::content::buffer::InitialBufferState;
+use warp_editor::content::version::BufferVersion;
+use warp_editor::model::CoreEditorModel;
+use warpui_core::elements::tui::{
+    Color, TuiContainer, TuiElement, TuiFlex, TuiParentElement, TuiStyle, TuiText,
+};
+use warpui_core::{AppContext, Entity, ModelHandle, TuiView, ViewContext};
+
+use crate::editor_element::{TuiEditorElement, TuiEditorStyles};
+use crate::tui_builder::TuiUiBuilder;
+
+const MAX_HIGHLIGHT_BYTES: usize = 256 * 1024;
+const MAX_CODE_LINES: usize = 5_000;
+const TRUNCATION_NOTICE: &str = "… code block truncated …";
+
+/// Events emitted to the Markdown-owning parent.
+pub(crate) enum TuiCodeBlockViewEvent {
+    LayoutChanged,
+    SyntaxUpdated,
+}
+
+/// Persistent payload identity for one code child.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct TuiCodeBlockPayload {
+    pub code: String,
+    pub language: Option<String>,
+}
+
+impl TuiCodeBlockPayload {
+    pub(crate) fn new(code: impl Into<String>, language: Option<String>) -> Self {
+        Self {
+            code: code.into(),
+            language,
+        }
+    }
+}
+
+/// One editor-backed code block retained across parent redraws.
+pub(crate) struct TuiCodeBlockView {
+    editor: ModelHandle<CodeEditorModel>,
+    payload: TuiCodeBlockPayload,
+    expected_syntax_version: Option<BufferVersion>,
+    text_overrides: Vec<(std::ops::Range<CharOffset>, TuiStyle)>,
+    fallback_text: Option<String>,
+}
+
+impl TuiCodeBlockView {
+    pub(crate) fn new(payload: TuiCodeBlockPayload, ctx: &mut ViewContext<Self>) -> Self {
+        let editor = Self::create_editor(ctx);
+        let mut view = Self {
+            editor,
+            payload: TuiCodeBlockPayload::new(String::new(), None),
+            expected_syntax_version: None,
+            text_overrides: Vec::new(),
+            fallback_text: None,
+        };
+        view.sync(payload, ctx);
+        view
+    }
+
+    fn create_editor(ctx: &mut ViewContext<Self>) -> ModelHandle<CodeEditorModel> {
+        let editor = ctx.add_model(|ctx| CodeEditorModel::new_tui(0, ctx));
+        ctx.subscribe_to_model(&editor, |me, source, event, ctx| {
+            // A language change replaces the editor model. Events already
+            // queued by the old parser must not style the replacement.
+            if source.id() != me.editor.id() {
+                return;
+            }
+            match event {
+                CodeEditorModelEvent::SyntaxHighlightingUpdated => {
+                    me.refresh_highlights(ctx);
+                    ctx.emit(TuiCodeBlockViewEvent::SyntaxUpdated);
+                    ctx.notify();
+                }
+                CodeEditorModelEvent::LayoutInvalidated => {
+                    ctx.emit(TuiCodeBlockViewEvent::LayoutChanged);
+                    ctx.notify();
+                }
+                CodeEditorModelEvent::ContentChanged { .. }
+                | CodeEditorModelEvent::SelectionChanged
+                | CodeEditorModelEvent::DiffUpdated
+                | CodeEditorModelEvent::UnifiedDiffComputed(_)
+                | CodeEditorModelEvent::ViewportUpdated(_)
+                | CodeEditorModelEvent::InteractionStateChanged
+                | CodeEditorModelEvent::DelayedRenderingFlushed => {}
+                #[cfg(windows)]
+                CodeEditorModelEvent::WindowsCtrlC { .. } => {}
+            }
+        });
+        editor
+    }
+
+    /// Updates the retained child only when its code or language changes.
+    pub(crate) fn sync(
+        &mut self,
+        payload: TuiCodeBlockPayload,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
+        if self.payload == payload {
+            return false;
+        }
+
+        let language_changed = self.payload.language != payload.language;
+        self.payload = payload;
+        self.text_overrides.clear();
+        self.expected_syntax_version = None;
+        self.fallback_text = bounded_fallback_text(&self.payload.code);
+
+        if self.fallback_text.is_some() {
+            ctx.emit(TuiCodeBlockViewEvent::LayoutChanged);
+            ctx.notify();
+            return true;
+        }
+
+        if language_changed {
+            self.editor = Self::create_editor(ctx);
+        }
+        self.editor.update(ctx, |editor, ctx| {
+            if let Some(language) = &self.payload.language {
+                editor.set_language_with_name(language, ctx);
+            }
+            editor.reset_content(InitialBufferState::plain_text(&self.payload.code), ctx);
+            // Explicitly bootstrap parsing after a whole-buffer replacement.
+            // This is also required in tests, where replacement event handling
+            // intentionally returns before scheduling syntax work.
+            editor.rebuild_layout_with_syntax_highlighting(ctx);
+        });
+        self.expected_syntax_version = Some(
+            self.editor
+                .as_ref(ctx)
+                .content()
+                .as_ref(ctx)
+                .buffer_version(),
+        );
+        ctx.emit(TuiCodeBlockViewEvent::LayoutChanged);
+        ctx.notify();
+        true
+    }
+
+    /// Re-reads decorations only for the buffer version associated with the
+    /// latest synchronized payload. A late parser event for an older revision
+    /// therefore yields no map and cannot style newer streamed code.
+    fn refresh_highlights(&mut self, ctx: &mut ViewContext<Self>) {
+        let Some(expected_version) = self.expected_syntax_version else {
+            return;
+        };
+        let overrides = {
+            let editor = self.editor.as_ref(ctx);
+            let end = editor.content().as_ref(ctx).max_charoffset();
+            if end <= CharOffset::from(1) {
+                Vec::new()
+            } else {
+                let mut ranges = RangeSet::new();
+                ranges.insert(CharOffset::from(1)..end);
+                editor
+                    .text_decoration_for_ranges(ranges, Some(expected_version), ctx)
+                    .base_color_map
+                    .as_ref()
+                    .map(|colors| {
+                        colors
+                            .iter()
+                            .map(|(range, color)| {
+                                let start =
+                                    CharOffset::from(range.start.as_usize().saturating_sub(1));
+                                let end = CharOffset::from(range.end.as_usize().saturating_sub(1));
+                                (
+                                    start..end,
+                                    TuiStyle::default().fg(Color::Rgb(color.r, color.g, color.b)),
+                                )
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            }
+        };
+        self.text_overrides = overrides;
+    }
+
+    fn render_body(&self, app: &AppContext) -> Box<dyn TuiElement> {
+        let builder = TuiUiBuilder::from_app(app);
+        if let Some(fallback_text) = &self.fallback_text {
+            return TuiText::new(fallback_text.clone())
+                .with_style(builder.primary_text_style())
+                .finish();
+        }
+        TuiEditorElement::new(&self.editor, app)
+            .with_styles(TuiEditorStyles {
+                text: builder.primary_text_style(),
+                ghost: builder.primary_text_style(),
+                gap: builder.dim_text_style(),
+                line_overrides: Vec::new(),
+                text_overrides: self.text_overrides.clone(),
+            })
+            .hide_trailing_empty_line()
+            .finish()
+    }
+}
+
+fn should_use_fallback(code: &str) -> bool {
+    code.len() > MAX_HIGHLIGHT_BYTES || code.lines().count() > MAX_CODE_LINES
+}
+fn bounded_fallback_text(code: &str) -> Option<String> {
+    if !should_use_fallback(code) {
+        return None;
+    }
+
+    let mut end = 0;
+    let mut line_count = 1;
+    for (offset, character) in code.char_indices() {
+        let character_end = offset.saturating_add(character.len_utf8());
+        if line_count > MAX_CODE_LINES || character_end > MAX_HIGHLIGHT_BYTES {
+            break;
+        }
+        end = character_end;
+        if character == '\n' {
+            line_count += 1;
+        }
+    }
+
+    let mut fallback_text = code[..end].to_owned();
+    if end < code.len() {
+        if !fallback_text.ends_with('\n') {
+            fallback_text.push('\n');
+        }
+        fallback_text.push_str(TRUNCATION_NOTICE);
+    }
+    Some(fallback_text)
+}
+
+impl Entity for TuiCodeBlockView {
+    type Event = TuiCodeBlockViewEvent;
+}
+
+impl TuiView for TuiCodeBlockView {
+    fn ui_name() -> &'static str {
+        "TuiCodeBlockView"
+    }
+
+    fn render(&self, app: &AppContext) -> Box<dyn TuiElement> {
+        let builder = TuiUiBuilder::from_app(app);
+        let mut column = TuiFlex::column();
+        if let Some(language) = &self.payload.language {
+            column.add_child(
+                TuiText::new(language.clone())
+                    .with_style(builder.muted_text_style())
+                    .truncate()
+                    .finish(),
+            );
+        }
+        column.add_child(self.render_body(app));
+        TuiContainer::new(column.finish())
+            .with_border_style(builder.muted_text_style())
+            .with_padding_x(1)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+#[path = "tui_code_block_view_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/tui_code_block_view_tests.rs
+++ b/crates/warp_tui/src/tui_code_block_view_tests.rs
@@ -1,0 +1,159 @@
+use futures::channel::oneshot;
+use warp::tui_export::Appearance;
+use warpui::platform::WindowStyle;
+use warpui::{AddWindowOptions, App};
+use warpui_core::elements::tui::{TuiBufferExt, TuiRect};
+use warpui_core::presenter::tui::TuiPresenter;
+use warpui_core::{TuiView, ViewHandle};
+
+use super::{
+    bounded_fallback_text, TuiCodeBlockPayload, TuiCodeBlockView, TuiCodeBlockViewEvent,
+    MAX_CODE_LINES, MAX_HIGHLIGHT_BYTES, TRUNCATION_NOTICE,
+};
+use crate::test_fixtures::TestHostView;
+
+#[test]
+fn renders_read_only_code_with_language_and_wrapping() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let view = add_code_view(&mut app, |ctx| {
+            TuiCodeBlockView::new(
+                TuiCodeBlockPayload::new(
+                    "fn main() {\n    println!(\"hello world\");\n}",
+                    Some("rust".to_owned()),
+                ),
+                ctx,
+            )
+        });
+        app.read(|ctx| {
+            let mut presenter = TuiPresenter::new();
+            let frame = presenter.present_element(
+                view.as_ref(ctx).render(ctx),
+                TuiRect::new(0, 0, 18, 10),
+                ctx,
+            );
+            let lines = frame
+                .buffer
+                .to_lines()
+                .into_iter()
+                .map(|line| line.trim_end().to_owned())
+                .take_while(|line| !line.is_empty() || line.starts_with('│'))
+                .collect::<Vec<_>>();
+            assert_eq!(
+                lines,
+                vec![
+                    "┌────────────────┐",
+                    "│ rust           │",
+                    "│ fn main() {    │",
+                    "│     println!   │",
+                    "│ (\"hello        │",
+                    "│ world\");       │",
+                    "│ }              │",
+                    "└────────────────┘",
+                ]
+            );
+        });
+    });
+}
+
+fn add_code_view(
+    app: &mut App,
+    build: impl FnOnce(&mut warpui_core::ViewContext<TuiCodeBlockView>) -> TuiCodeBlockView + 'static,
+) -> ViewHandle<TuiCodeBlockView> {
+    app.update(|ctx| {
+        let (window_id, _) = ctx.add_tui_window(
+            AddWindowOptions {
+                window_style: WindowStyle::NotStealFocus,
+                ..Default::default()
+            },
+            |_| TestHostView,
+        );
+        ctx.add_tui_view(window_id, build)
+    })
+}
+
+#[test]
+fn oversized_code_stores_a_bounded_fallback() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let code = "x".repeat(MAX_HIGHLIGHT_BYTES + 1);
+        let view = add_code_view(&mut app, |ctx| {
+            TuiCodeBlockView::new(TuiCodeBlockPayload::new(code, None), ctx)
+        });
+        app.read(|ctx| {
+            let view = view.as_ref(ctx);
+            let fallback_text = view
+                .fallback_text
+                .as_deref()
+                .expect("oversized code should use the fallback");
+            assert_eq!(
+                fallback_text.lines().next().map(str::len),
+                Some(MAX_HIGHLIGHT_BYTES)
+            );
+            assert_eq!(fallback_text.lines().last(), Some(TRUNCATION_NOTICE));
+            assert!(view.text_overrides.is_empty());
+        });
+    });
+}
+
+#[test]
+fn fallback_bounds_the_number_of_lines() {
+    let code = std::iter::repeat_n("line", MAX_CODE_LINES + 1)
+        .collect::<Vec<_>>()
+        .join("\n");
+    let fallback_text =
+        bounded_fallback_text(&code).expect("excessive lines should use the fallback");
+
+    assert_eq!(fallback_text.lines().count(), MAX_CODE_LINES + 1);
+    assert_eq!(fallback_text.lines().last(), Some(TRUNCATION_NOTICE));
+}
+
+#[test]
+fn fallback_preserves_utf8_boundaries_at_the_byte_limit() {
+    let prefix = "é".repeat(MAX_HIGHLIGHT_BYTES / 2);
+    let code = format!("{prefix}x");
+    let fallback_text =
+        bounded_fallback_text(&code).expect("oversized code should use the fallback");
+
+    assert!(fallback_text.starts_with(&prefix));
+    assert_eq!(fallback_text.lines().last(), Some(TRUNCATION_NOTICE));
+}
+#[test]
+fn syntax_highlights_apply_only_to_the_latest_editor_revision() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let view = add_code_view(&mut app, |ctx| {
+            TuiCodeBlockView::new(TuiCodeBlockPayload::new("", None), ctx)
+        });
+        let (tx, rx) = oneshot::channel();
+        app.update(|ctx| {
+            let mut tx = Some(tx);
+            ctx.subscribe_to_view(&view, move |_, event, _| {
+                if matches!(event, TuiCodeBlockViewEvent::SyntaxUpdated) {
+                    if let Some(tx) = tx.take() {
+                        let _ = tx.send(());
+                    }
+                }
+            });
+            view.update(ctx, |view, ctx| {
+                view.sync(
+                    TuiCodeBlockPayload::new("fn stale() {}", Some("rust".to_owned())),
+                    ctx,
+                );
+                view.sync(
+                    TuiCodeBlockPayload::new(
+                        "def latest():\n    return 1",
+                        Some("python".to_owned()),
+                    ),
+                    ctx,
+                );
+            });
+        });
+        rx.await.expect("latest syntax parse should complete");
+        app.read(|ctx| {
+            let view = view.as_ref(ctx);
+            assert_eq!(view.payload.code, "def latest():\n    return 1");
+            assert!(!view.text_overrides.is_empty());
+        });
+    });
+}

--- a/crates/warp_tui/src/tui_markdown_tests.rs
+++ b/crates/warp_tui/src/tui_markdown_tests.rs
@@ -1,16 +1,23 @@
 use std::cell::Cell;
 
+use futures::channel::oneshot;
 use markdown_parser::{
     parse_markdown, parse_markdown_with_gfm_tables, FormattedText, FormattedTextFragment,
     FormattedTextLine,
 };
 use warp::tui_export::Appearance;
-use warpui_core::elements::tui::{Modifier, TuiBufferExt, TuiElement, TuiRect, TuiText};
+use warpui::platform::WindowStyle;
+use warpui::AddWindowOptions;
+use warpui_core::elements::tui::{
+    Modifier, TuiBufferExt, TuiChildView, TuiElement, TuiRect, TuiText,
+};
 use warpui_core::presenter::tui::TuiPresenter;
-use warpui_core::{App, AppContext};
+use warpui_core::{App, AppContext, ViewHandle, WindowInvalidation};
 
 use super::{render_formatted_text, TuiMarkdownBlockHooks, TuiMarkdownPalette};
+use crate::test_fixtures::TestHostView;
 use crate::tui_builder::TuiUiBuilder;
+use crate::tui_code_block_view::{TuiCodeBlockPayload, TuiCodeBlockView, TuiCodeBlockViewEvent};
 
 #[test]
 fn renders_blocks_inline_styles_and_accessible_links_without_markers() {
@@ -193,6 +200,105 @@ fn delegates_code_blocks_to_the_supplied_hook() {
     });
 }
 
+#[test]
+fn fenced_markdown_code_block_applies_syntax_colors_to_exact_cells() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let formatted =
+            parse_markdown("```rust\nfn main() {}\n```").expect("Markdown should parse");
+        let code = formatted
+            .lines
+            .iter()
+            .find_map(|line| match line {
+                FormattedTextLine::CodeBlock(code) => Some(code.clone()),
+                FormattedTextLine::Line(_)
+                | FormattedTextLine::Heading(_)
+                | FormattedTextLine::OrderedList(_)
+                | FormattedTextLine::UnorderedList(_)
+                | FormattedTextLine::TaskList(_)
+                | FormattedTextLine::Table(_)
+                | FormattedTextLine::Image(_)
+                | FormattedTextLine::Embedded(_)
+                | FormattedTextLine::LineBreak
+                | FormattedTextLine::HorizontalRule => None,
+            })
+            .expect("fenced Markdown should contain a code block");
+        let code_view = add_code_view(&mut app);
+        let (tx, rx) = oneshot::channel();
+        app.update(|ctx| {
+            let mut tx = Some(tx);
+            ctx.subscribe_to_view(&code_view, move |_, event, _| {
+                if matches!(event, TuiCodeBlockViewEvent::SyntaxUpdated) {
+                    if let Some(tx) = tx.take() {
+                        let _ = tx.send(());
+                    }
+                }
+            });
+            code_view.update(ctx, |view, ctx| {
+                view.sync(TuiCodeBlockPayload::new(code.code, Some(code.lang)), ctx);
+            });
+        });
+        rx.await.expect("syntax parse should complete");
+
+        app.update(|ctx| {
+            let render_code = |index: usize, _: &markdown_parser::CodeBlockText| {
+                assert_eq!(index, 0);
+                Some(TuiChildView::new(&code_view).finish())
+            };
+            let hooks = TuiMarkdownBlockHooks {
+                render_code: Some(&render_code),
+            };
+            let palette = TuiMarkdownPalette::from_builder(&TuiUiBuilder::from_app(ctx));
+            let mut presenter = TuiPresenter::new();
+            let mut invalidation = WindowInvalidation::default();
+            invalidation.updated.insert(code_view.id());
+            presenter.invalidate(&invalidation, ctx, code_view.window_id(ctx));
+            let frame = presenter.present_element(
+                render_formatted_text(&formatted, palette, &hooks),
+                TuiRect::new(0, 0, 40, 40),
+                ctx,
+            );
+            let lines = frame
+                .buffer
+                .to_lines()
+                .into_iter()
+                .map(|line| line.trim_end().to_owned())
+                .collect::<Vec<_>>();
+            let buffer = frame.buffer;
+            let code_row = lines
+                .iter()
+                .position(|line| line.contains("fn main()"))
+                .expect("rendered Markdown should contain the code line");
+            let keyword_start_byte = lines[code_row]
+                .find("fn main()")
+                .expect("rendered code should preserve the Rust keyword");
+            let keyword_start = lines[code_row][..keyword_start_byte].chars().count();
+            let first_keyword_cell = &buffer[(keyword_start as u16, code_row as u16)];
+            let second_keyword_cell = &buffer[((keyword_start + 1) as u16, code_row as u16)];
+            let following_space_cell = &buffer[((keyword_start + 2) as u16, code_row as u16)];
+
+            assert_eq!(first_keyword_cell.symbol(), "f");
+            assert_eq!(second_keyword_cell.symbol(), "n");
+            assert_eq!(first_keyword_cell.fg, second_keyword_cell.fg);
+            assert_ne!(first_keyword_cell.fg, following_space_cell.fg);
+        });
+    });
+}
+
+fn add_code_view(app: &mut App) -> ViewHandle<TuiCodeBlockView> {
+    app.update(|ctx| {
+        let (window_id, _) = ctx.add_tui_window(
+            AddWindowOptions {
+                window_style: WindowStyle::NotStealFocus,
+                ..Default::default()
+            },
+            |_| TestHostView,
+        );
+        ctx.add_tui_view(window_id, |ctx| {
+            TuiCodeBlockView::new(TuiCodeBlockPayload::new("", None), ctx)
+        })
+    })
+}
 fn render(
     formatted: &FormattedText,
     width: u16,


### PR DESCRIPTION
## Description
Stack 2/4, based on #13728. Adds a reusable read-only TUI code-block view backed by the editor model, including language-aware syntax decoration mapping, streamed payload reconciliation, stale-decoration protection, and bounded plain-text fallback for pathological inputs.

## Linked Issue
https://linear.app/warpdotdev/issue/CODE-1849/track-markdown-rendering-for-agent-output-in-transcript-view

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- `cargo nextest run -p warp_tui tui_code_block_view --no-fail-fast`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Oz <oz-agent@warp.dev>