### PR TITLE
Render inline plans in TUI agent output

### DIFF
--- a/app/src/ai/ai_document_view.rs
+++ b/app/src/ai/ai_document_view.rs
@@ -2,6 +2,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use ai::document::DEFAULT_PLANNING_DOCUMENT_TITLE;
 use pathfinder_geometry::vector::vec2f;
 use warp_core::ui::icons;
 use warp_core::ui::icons::ICON_DIMENSIONS;
@@ -136,8 +137,6 @@ impl From<PaneEvent> for AIDocumentEvent {
         AIDocumentEvent::Pane(event)
     }
 }
-
-pub const DEFAULT_PLANNING_DOCUMENT_TITLE: &str = "Planning document";
 
 /// Entry for the version history dropdown menu.
 struct VersionMenuEntry {

--- a/app/src/ai/blocklist/action_model.rs
+++ b/app/src/ai/blocklist/action_model.rs
@@ -22,6 +22,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use ai::document::DEFAULT_PLANNING_DOCUMENT_TITLE;
 use chrono::Local;
 pub(crate) use execute::{
     apply_edits, coerce_integer_args, FileReadResult, MalformedFinalLineProxyEvent,
@@ -58,7 +59,6 @@ use crate::ai::agent::{
     CancellationOutcome, CancellationReason, CreateDocumentsResult, EditDocumentsResult,
     RequestCommandOutputResult,
 };
-use crate::ai::ai_document_view::DEFAULT_PLANNING_DOCUMENT_TITLE;
 use crate::ai::blocklist::action_model::execute::suggest_new_conversation::SuggestNewConversationExecutor;
 use crate::ai::document::ai_document_model::AIDocumentModel;
 use crate::ai::get_relevant_files::controller::GetRelevantFilesController;

--- a/app/src/ai/blocklist/block.rs
+++ b/app/src/ai/blocklist/block.rs
@@ -24,6 +24,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use ai::agent::action::{AskUserQuestionItem, InsertReviewComment, RunAgentsRequest};
+use ai::document::DEFAULT_PLANNING_DOCUMENT_TITLE;
 use base64::Engine as _;
 use chrono::Duration;
 use cli_controller::{CLISubagentController, CLISubagentEvent};
@@ -99,7 +100,6 @@ use crate::ai::agent::{
     SummarizationType, TodoOperation,
 };
 use crate::ai::agent_conversations_model::{AgentConversationsModel, AgentConversationsModelEvent};
-use crate::ai::ai_document_view::DEFAULT_PLANNING_DOCUMENT_TITLE;
 use crate::ai::ambient_agents::AmbientAgentTaskId;
 use crate::ai::blocklist::action_model::NewConversationDecision;
 use crate::ai::blocklist::agent_view::{AgentViewController, AgentViewEntryOrigin};

--- a/app/src/ai/blocklist/block/view_impl/output.rs
+++ b/app/src/ai/blocklist/block/view_impl/output.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use ai::agent::action::{
     RequestComputerUseRequest, SuggestPromptRequest, UploadArtifactRequest, UseComputerRequest,
 };
+use ai::agent::document_action_presentation::DocumentActionPresentation;
 use ai::agent::file_locations::group_file_contexts_for_display;
 use ai::skills::{ParsedSkill, SkillReference};
 use indexmap::IndexMap;
@@ -60,10 +61,9 @@ use crate::ai::agent::task::TaskId;
 use crate::ai::agent::{
     AIAgentAction, AIAgentActionId, AIAgentActionResult, AIAgentActionResultType,
     AIAgentActionType, AIAgentCitation, AIAgentInput, AIAgentOutputMessage,
-    AIAgentOutputMessageType, AIAgentText, AIAgentTextSection, CancellationOutcome,
-    CreateDocumentsResult, EditDocumentsResult, MessageId, ReadFilesRequest, ReadFilesResult,
-    RequestCommandOutputResult, SearchCodebaseFailureReason, SearchCodebaseResult,
-    StartRecordingResult, StopRecordingResult, SubagentCall, SubagentType,
+    AIAgentOutputMessageType, AIAgentText, AIAgentTextSection, CancellationOutcome, MessageId,
+    ReadFilesRequest, ReadFilesResult, RequestCommandOutputResult, SearchCodebaseFailureReason,
+    SearchCodebaseResult, StartRecordingResult, StopRecordingResult, SubagentCall, SubagentType,
     SuggestNewConversationResult, SummarizationType, TodoOperation, UploadArtifactResult,
 };
 use crate::ai::agent_conversations_model::AgentConversationsModel;
@@ -746,26 +746,15 @@ pub(super) fn render(props: Props, app: &AppContext) -> Box<dyn Element> {
                             }
                         }
                         AIAgentOutputMessageType::Action(AIAgentAction {
-                            action: AIAgentActionType::CreateDocuments { .. },
+                            action:
+                                action @ (AIAgentActionType::CreateDocuments(_)
+                                | AIAgentActionType::EditDocuments(_)),
                             id,
                             ..
                         }) => {
                             should_render_footer = false;
-                            if let Some(create_document) =
-                                maybe_render_create_document(props, id, app)
-                            {
-                                output_items.add_child(create_document);
-                            }
-                        }
-                        AIAgentOutputMessageType::Action(AIAgentAction {
-                            action: AIAgentActionType::EditDocuments { .. },
-                            id,
-                            ..
-                        }) => {
-                            should_render_footer = false;
-                            if let Some(edit_document) = maybe_render_edit_document(props, id, app)
-                            {
-                                output_items.add_child(edit_document);
+                            if let Some(document) = maybe_render_document(props, id, action, app) {
+                                output_items.add_child(document);
                             }
                         }
                         AIAgentOutputMessageType::Action(AIAgentAction {
@@ -2034,9 +2023,10 @@ fn parsed_skill_for_common_locations(
         .flatten()
 }
 
-fn maybe_render_edit_document(
+fn maybe_render_document(
     props: Props,
     id: &AIAgentActionId,
+    action: &AIAgentActionType,
     app: &AppContext,
 ) -> Option<Box<dyn Element>> {
     let status = props.action_model.as_ref(app).get_action_status(id);
@@ -2046,64 +2036,16 @@ fn maybe_render_edit_document(
         todo!("Implement granular permissions for AI documents.");
     }
 
-    let agent_action_results = props
+    let result = props
         .action_model
         .as_ref(app)
         .get_action_result(id)
-        .map(|action_result| action_result.as_ref());
-
-    let Some(AIAgentActionResult {
-        result:
-            AIAgentActionResultType::EditDocuments(EditDocumentsResult::Success { updated_documents }),
-        ..
-    }) = agent_action_results
-    else {
-        return None;
-    };
-
-    let document = updated_documents.first()?;
+        .map(|result| &result.result);
+    let presentation = DocumentActionPresentation::resolve(action, result)?;
+    let document = presentation.documents.first()?;
     let action = CreateOrEditDocumentAction::new(
-        document.document_id,
-        document.document_version,
-        props.state_handles.ai_document_handle.clone(),
-        app,
-    )?;
-    Some(action.render(app))
-}
-
-fn maybe_render_create_document(
-    props: Props,
-    id: &AIAgentActionId,
-    app: &AppContext,
-) -> Option<Box<dyn Element>> {
-    let status = props.action_model.as_ref(app).get_action_status(id);
-
-    // Document operations are always auto-executed for now
-    if status.as_ref().is_some_and(|status| status.is_blocked()) {
-        todo!("Implement granular permissions for AI documents.");
-    }
-
-    let agent_action_results = props
-        .action_model
-        .as_ref(app)
-        .get_action_result(id)
-        .map(|action_result| action_result.as_ref());
-
-    let Some(AIAgentActionResult {
-        result:
-            AIAgentActionResultType::CreateDocuments(CreateDocumentsResult::Success {
-                created_documents,
-            }),
-        ..
-    }) = agent_action_results
-    else {
-        return None;
-    };
-
-    let document = created_documents.first()?;
-    let action = CreateOrEditDocumentAction::new(
-        document.document_id,
-        document.document_version,
+        document.document_id?,
+        document.document_version?,
         props.state_handles.ai_document_handle.clone(),
         app,
     )?;

--- a/app/src/ai/document/ai_document_model.rs
+++ b/app/src/ai/document/ai_document_model.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use ai::agent::orchestration_config::{OrchestrationConfig, OrchestrationConfigStatus};
 use ai::diff_validation::DiffDelta;
+use ai::document::DEFAULT_PLANNING_DOCUMENT_TITLE;
 // TODO(vorporeal): Remove this re-export at some point.
 pub use ai::document::{AIDocumentId, AIDocumentVersion};
 use chrono::{DateTime, Local, Utc};
@@ -21,7 +22,6 @@ use warpui::{AppContext, Entity, EntityId, ModelContext, ModelHandle, SingletonE
 
 use crate::ai::agent::conversation::AIConversationId;
 use crate::ai::agent::AIAgentActionId;
-use crate::ai::ai_document_view::DEFAULT_PLANNING_DOCUMENT_TITLE;
 use crate::ai::blocklist::{BlocklistAIHistoryEvent, BlocklistAIHistoryModel};
 use crate::ai::execution_profiles::profiles::AIExecutionProfilesModel;
 use crate::appearance::Appearance;

--- a/app/src/terminal/view/load_ai_conversation.rs
+++ b/app/src/terminal/view/load_ai_conversation.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use ai::document::DEFAULT_PLANNING_DOCUMENT_TITLE;
 use itertools::Itertools;
 use prost::Message;
 use vec1::Vec1;
@@ -21,7 +22,6 @@ use crate::ai::agent::{
     AIAgentOutput, AIAgentOutputMessage, AIAgentOutputMessageType, CreateDocumentsRequest,
     CreateDocumentsResult, EditDocumentsResult,
 };
-use crate::ai::ai_document_view::DEFAULT_PLANNING_DOCUMENT_TITLE;
 use crate::ai::blocklist::agent_view::{
     AgentViewEntryBlockParams, AgentViewEntryOrigin, DismissalStrategy, EphemeralMessage,
 };

--- a/crates/ai/src/agent/action/convert.rs
+++ b/crates/ai/src/agent/action/convert.rs
@@ -7,15 +7,16 @@ use warp_core::features::FeatureFlag;
 use warp_multi_agent_api as api;
 
 use crate::agent::action::{
-    AIAgentActionType, AIAgentPtyWriteMode, CommentSide, FileEdit, InsertReviewComment,
-    InsertedCommentLine, InsertedCommentLocation, ReadFilesRequest, SearchCodebaseRequest,
+    AIAgentActionType, AIAgentPtyWriteMode, CommentSide, CreateDocumentsRequest, DocumentDiff,
+    DocumentToCreate, EditDocumentsRequest, FileEdit, InsertReviewComment, InsertedCommentLine,
+    InsertedCommentLocation, ReadDocumentsRequest, ReadFilesRequest, SearchCodebaseRequest,
     ShellCommandDelay, SuggestPromptRequest, UploadArtifactRequest, UseComputerRequest,
 };
 use crate::agent::action_result::{AnyFileContent, FileContext};
 use crate::agent::convert::ToolToAIAgentActionError;
 use crate::agent::FileLocations;
 use crate::diff_validation::{ParsedDiff, V4AHunk};
-use crate::document::AIDocumentId;
+use crate::document::{AIDocumentId, DEFAULT_PLANNING_DOCUMENT_TITLE};
 
 impl From<api::message::tool_call::RunShellCommand> for AIAgentActionType {
     fn from(value: api::message::tool_call::RunShellCommand) -> Self {
@@ -333,7 +334,6 @@ impl From<warp_multi_agent_api::AnyFileContent> for FileContext {
 
 impl From<api::message::tool_call::ReadDocuments> for AIAgentActionType {
     fn from(value: api::message::tool_call::ReadDocuments) -> Self {
-        use crate::agent::action::ReadDocumentsRequest;
         AIAgentActionType::ReadDocuments(ReadDocumentsRequest {
             document_ids: value
                 .documents
@@ -346,7 +346,6 @@ impl From<api::message::tool_call::ReadDocuments> for AIAgentActionType {
 
 impl From<api::message::tool_call::EditDocuments> for AIAgentActionType {
     fn from(value: api::message::tool_call::EditDocuments) -> Self {
-        use crate::agent::action::{DocumentDiff, EditDocumentsRequest};
         AIAgentActionType::EditDocuments(EditDocumentsRequest {
             diffs: value
                 .diffs
@@ -367,7 +366,6 @@ impl From<api::message::tool_call::EditDocuments> for AIAgentActionType {
 
 impl From<api::message::tool_call::CreateDocuments> for AIAgentActionType {
     fn from(value: api::message::tool_call::CreateDocuments) -> Self {
-        use crate::agent::action::{CreateDocumentsRequest, DocumentToCreate};
         AIAgentActionType::CreateDocuments(CreateDocumentsRequest {
             documents: value
                 .new_documents
@@ -375,9 +373,7 @@ impl From<api::message::tool_call::CreateDocuments> for AIAgentActionType {
                 .map(|doc| DocumentToCreate {
                     content: doc.content,
                     title: if doc.title.is_empty() {
-                        // DO NOT SUBMIT
-                        // crate::ai::ai_document_view::DEFAULT_PLANNING_DOCUMENT_TITLE.to_string()
-                        "".to_string()
+                        DEFAULT_PLANNING_DOCUMENT_TITLE.to_owned()
                     } else {
                         doc.title
                     },

--- a/crates/ai/src/agent/document_action_presentation.rs
+++ b/crates/ai/src/agent/document_action_presentation.rs
@@ -1,0 +1,203 @@
+use crate::agent::action::AIAgentActionType;
+use crate::agent::action_result::{
+    AIAgentActionResultType, CreateDocumentsResult, EditDocumentsResult,
+};
+use crate::document::{AIDocumentId, AIDocumentVersion, DEFAULT_PLANNING_DOCUMENT_TITLE};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ToolCallDisplayState {
+    Constructing,
+    Pending,
+    AwaitingApproval,
+    Running,
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DocumentActionKind {
+    Create,
+    Edit,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PresentedDocument {
+    pub title: String,
+    pub content: String,
+    pub document_id: Option<AIDocumentId>,
+    pub document_version: Option<AIDocumentVersion>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DocumentActionPresentation {
+    pub kind: DocumentActionKind,
+    pub documents: Vec<PresentedDocument>,
+}
+
+impl DocumentActionPresentation {
+    pub fn resolve(
+        action: &AIAgentActionType,
+        result: Option<&AIAgentActionResultType>,
+    ) -> Option<Self> {
+        match (action, result) {
+            (
+                AIAgentActionType::CreateDocuments(request),
+                Some(AIAgentActionResultType::CreateDocuments(CreateDocumentsResult::Success {
+                    created_documents,
+                })),
+            ) => Some(Self {
+                kind: DocumentActionKind::Create,
+                documents: created_documents
+                    .iter()
+                    .enumerate()
+                    .map(|(index, document)| PresentedDocument {
+                        title: request
+                            .documents
+                            .get(index)
+                            .map(|document| document.title.as_str())
+                            .filter(|title| !title.is_empty())
+                            .map(str::to_owned)
+                            .unwrap_or_else(|| document_title(index, created_documents.len())),
+                        content: document.content.clone(),
+                        document_id: Some(document.document_id),
+                        document_version: Some(document.document_version),
+                    })
+                    .collect(),
+            }),
+            (AIAgentActionType::CreateDocuments(_), Some(_)) => Some(Self {
+                kind: DocumentActionKind::Create,
+                documents: Vec::new(),
+            }),
+            (AIAgentActionType::CreateDocuments(request), None) => Some(Self {
+                kind: DocumentActionKind::Create,
+                documents: request
+                    .documents
+                    .iter()
+                    .enumerate()
+                    .map(|(index, document)| PresentedDocument {
+                        title: if document.title.is_empty() {
+                            document_title(index, request.documents.len())
+                        } else {
+                            document.title.clone()
+                        },
+                        content: document.content.clone(),
+                        document_id: None,
+                        document_version: None,
+                    })
+                    .collect(),
+            }),
+            (
+                AIAgentActionType::EditDocuments(_),
+                Some(AIAgentActionResultType::EditDocuments(EditDocumentsResult::Success {
+                    updated_documents,
+                })),
+            ) => Some(Self {
+                kind: DocumentActionKind::Edit,
+                documents: updated_documents
+                    .iter()
+                    .enumerate()
+                    .map(|(index, document)| PresentedDocument {
+                        title: document_title(index, updated_documents.len()),
+                        content: document.content.clone(),
+                        document_id: Some(document.document_id),
+                        document_version: Some(document.document_version),
+                    })
+                    .collect(),
+            }),
+            (AIAgentActionType::EditDocuments(_), Some(_) | None) => Some(Self {
+                kind: DocumentActionKind::Edit,
+                documents: Vec::new(),
+            }),
+            (
+                AIAgentActionType::RequestCommandOutput { .. }
+                | AIAgentActionType::WriteToLongRunningShellCommand { .. }
+                | AIAgentActionType::ReadFiles(_)
+                | AIAgentActionType::UploadArtifact(_)
+                | AIAgentActionType::SearchCodebase(_)
+                | AIAgentActionType::RequestFileEdits { .. }
+                | AIAgentActionType::Grep { .. }
+                | AIAgentActionType::FileGlob { .. }
+                | AIAgentActionType::FileGlobV2 { .. }
+                | AIAgentActionType::ReadMCPResource { .. }
+                | AIAgentActionType::CallMCPTool { .. }
+                | AIAgentActionType::SuggestNewConversation { .. }
+                | AIAgentActionType::SuggestPrompt(_)
+                | AIAgentActionType::InitProject
+                | AIAgentActionType::OpenCodeReview
+                | AIAgentActionType::ReadDocuments(_)
+                | AIAgentActionType::ReadShellCommandOutput { .. }
+                | AIAgentActionType::UseComputer(_)
+                | AIAgentActionType::InsertCodeReviewComments { .. }
+                | AIAgentActionType::RequestComputerUse(_)
+                | AIAgentActionType::StartRecording { .. }
+                | AIAgentActionType::StopRecording { .. }
+                | AIAgentActionType::ReadSkill(_)
+                | AIAgentActionType::FetchConversation { .. }
+                | AIAgentActionType::StartAgent { .. }
+                | AIAgentActionType::SendMessageToAgent { .. }
+                | AIAgentActionType::TransferShellCommandControlToUser { .. }
+                | AIAgentActionType::AskUserQuestion { .. }
+                | AIAgentActionType::RunAgents(_)
+                | AIAgentActionType::WaitForEvents { .. },
+                _,
+            ) => None,
+        }
+    }
+
+    pub fn header_label(&self, state: ToolCallDisplayState) -> String {
+        let subject = if self.documents.len() == 1 {
+            self.documents[0].title.clone()
+        } else {
+            format!("{} documents", self.documents.len())
+        };
+        let verb = match (self.kind, state) {
+            (
+                DocumentActionKind::Create,
+                ToolCallDisplayState::Constructing | ToolCallDisplayState::Running,
+            ) => "Creating",
+            (
+                DocumentActionKind::Create,
+                ToolCallDisplayState::Pending | ToolCallDisplayState::AwaitingApproval,
+            ) => "Create",
+            (DocumentActionKind::Create, ToolCallDisplayState::Succeeded) => "Created",
+            (
+                DocumentActionKind::Create,
+                ToolCallDisplayState::Failed | ToolCallDisplayState::Cancelled,
+            ) => "Create",
+            (
+                DocumentActionKind::Edit,
+                ToolCallDisplayState::Constructing | ToolCallDisplayState::Running,
+            ) => "Updating",
+            (
+                DocumentActionKind::Edit,
+                ToolCallDisplayState::Pending | ToolCallDisplayState::AwaitingApproval,
+            ) => "Update",
+            (DocumentActionKind::Edit, ToolCallDisplayState::Succeeded) => "Updated",
+            (
+                DocumentActionKind::Edit,
+                ToolCallDisplayState::Failed | ToolCallDisplayState::Cancelled,
+            ) => "Update",
+        };
+        format!("{verb} {subject}")
+    }
+
+    pub fn line_count(&self) -> usize {
+        self.documents
+            .iter()
+            .map(|document| document.content.lines().count())
+            .sum()
+    }
+}
+
+fn document_title(index: usize, document_count: usize) -> String {
+    if document_count == 1 {
+        DEFAULT_PLANNING_DOCUMENT_TITLE.to_owned()
+    } else {
+        format!("Document {}", index + 1)
+    }
+}
+
+#[cfg(test)]
+#[path = "document_action_presentation_tests.rs"]
+mod tests;

--- a/crates/ai/src/agent/document_action_presentation.rs
+++ b/crates/ai/src/agent/document_action_presentation.rs
@@ -15,12 +15,6 @@ pub enum ToolCallDisplayState {
     Cancelled,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum DocumentActionKind {
-    Create,
-    Edit,
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PresentedDocument {
     pub title: String,
@@ -31,7 +25,6 @@ pub struct PresentedDocument {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DocumentActionPresentation {
-    pub kind: DocumentActionKind,
     pub documents: Vec<PresentedDocument>,
 }
 
@@ -47,7 +40,6 @@ impl DocumentActionPresentation {
                     created_documents,
                 })),
             ) => Some(Self {
-                kind: DocumentActionKind::Create,
                 documents: created_documents
                     .iter()
                     .enumerate()
@@ -66,11 +58,9 @@ impl DocumentActionPresentation {
                     .collect(),
             }),
             (AIAgentActionType::CreateDocuments(_), Some(_)) => Some(Self {
-                kind: DocumentActionKind::Create,
                 documents: Vec::new(),
             }),
             (AIAgentActionType::CreateDocuments(request), None) => Some(Self {
-                kind: DocumentActionKind::Create,
                 documents: request
                     .documents
                     .iter()
@@ -93,7 +83,6 @@ impl DocumentActionPresentation {
                     updated_documents,
                 })),
             ) => Some(Self {
-                kind: DocumentActionKind::Edit,
                 documents: updated_documents
                     .iter()
                     .enumerate()
@@ -106,7 +95,6 @@ impl DocumentActionPresentation {
                     .collect(),
             }),
             (AIAgentActionType::EditDocuments(_), Some(_) | None) => Some(Self {
-                kind: DocumentActionKind::Edit,
                 documents: Vec::new(),
             }),
             (
@@ -143,50 +131,6 @@ impl DocumentActionPresentation {
                 _,
             ) => None,
         }
-    }
-
-    pub fn header_label(&self, state: ToolCallDisplayState) -> String {
-        let subject = if self.documents.len() == 1 {
-            self.documents[0].title.clone()
-        } else {
-            format!("{} documents", self.documents.len())
-        };
-        let verb = match (self.kind, state) {
-            (
-                DocumentActionKind::Create,
-                ToolCallDisplayState::Constructing | ToolCallDisplayState::Running,
-            ) => "Creating",
-            (
-                DocumentActionKind::Create,
-                ToolCallDisplayState::Pending | ToolCallDisplayState::AwaitingApproval,
-            ) => "Create",
-            (DocumentActionKind::Create, ToolCallDisplayState::Succeeded) => "Created",
-            (
-                DocumentActionKind::Create,
-                ToolCallDisplayState::Failed | ToolCallDisplayState::Cancelled,
-            ) => "Create",
-            (
-                DocumentActionKind::Edit,
-                ToolCallDisplayState::Constructing | ToolCallDisplayState::Running,
-            ) => "Updating",
-            (
-                DocumentActionKind::Edit,
-                ToolCallDisplayState::Pending | ToolCallDisplayState::AwaitingApproval,
-            ) => "Update",
-            (DocumentActionKind::Edit, ToolCallDisplayState::Succeeded) => "Updated",
-            (
-                DocumentActionKind::Edit,
-                ToolCallDisplayState::Failed | ToolCallDisplayState::Cancelled,
-            ) => "Update",
-        };
-        format!("{verb} {subject}")
-    }
-
-    pub fn line_count(&self) -> usize {
-        self.documents
-            .iter()
-            .map(|document| document.content.lines().count())
-            .sum()
     }
 }
 

--- a/crates/ai/src/agent/document_action_presentation_tests.rs
+++ b/crates/ai/src/agent/document_action_presentation_tests.rs
@@ -1,0 +1,109 @@
+use super::{DocumentActionKind, DocumentActionPresentation, ToolCallDisplayState};
+use crate::agent::action::{
+    AIAgentActionType, CreateDocumentsRequest, DocumentDiff, DocumentToCreate, EditDocumentsRequest,
+};
+use crate::agent::action_result::{
+    AIAgentActionResultType, CreateDocumentsResult, DocumentContext, EditDocumentsResult,
+};
+use crate::document::{AIDocumentId, AIDocumentVersion, DEFAULT_PLANNING_DOCUMENT_TITLE};
+
+#[test]
+fn streamed_create_uses_canonical_fallback_titles() {
+    let action = create_action([("", "first\nbody"), ("Named plan", "second")]);
+
+    let presentation = DocumentActionPresentation::resolve(&action, None).unwrap();
+
+    assert_eq!(presentation.kind, DocumentActionKind::Create);
+    assert_eq!(
+        presentation
+            .documents
+            .iter()
+            .map(|document| document.title.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Document 1", "Named plan"]
+    );
+    assert_eq!(presentation.line_count(), 3);
+    assert_eq!(
+        presentation.header_label(ToolCallDisplayState::Running),
+        "Creating 2 documents"
+    );
+}
+
+#[test]
+fn completed_create_combines_request_titles_with_result_documents() {
+    let action = create_action([("", "streamed")]);
+    let document_id = AIDocumentId::new();
+    let result = AIAgentActionResultType::CreateDocuments(CreateDocumentsResult::Success {
+        created_documents: vec![document_context(document_id, "final")],
+    });
+
+    let presentation = DocumentActionPresentation::resolve(&action, Some(&result)).unwrap();
+    let document = &presentation.documents[0];
+
+    assert_eq!(document.title, DEFAULT_PLANNING_DOCUMENT_TITLE);
+    assert_eq!(document.content, "final");
+    assert_eq!(document.document_id, Some(document_id));
+    assert_eq!(
+        document.document_version,
+        Some(AIDocumentVersion::default())
+    );
+    assert_eq!(
+        presentation.header_label(ToolCallDisplayState::Succeeded),
+        "Created Planning document"
+    );
+}
+
+#[test]
+fn completed_edit_uses_result_content_and_references() {
+    let document_id = AIDocumentId::new();
+    let action = AIAgentActionType::EditDocuments(EditDocumentsRequest {
+        diffs: vec![DocumentDiff {
+            document_id,
+            search: "old".to_owned(),
+            replace: "new".to_owned(),
+        }],
+    });
+    let result = AIAgentActionResultType::EditDocuments(EditDocumentsResult::Success {
+        updated_documents: vec![document_context(document_id, "updated")],
+    });
+
+    let presentation = DocumentActionPresentation::resolve(&action, Some(&result)).unwrap();
+
+    assert_eq!(presentation.kind, DocumentActionKind::Edit);
+    assert_eq!(presentation.documents[0].content, "updated");
+    assert_eq!(
+        presentation.header_label(ToolCallDisplayState::Succeeded),
+        "Updated Planning document"
+    );
+}
+
+#[test]
+fn unsuccessful_result_discards_streamed_documents() {
+    let action = create_action([("Plan", "streamed")]);
+    let result = AIAgentActionResultType::CreateDocuments(CreateDocumentsResult::Cancelled);
+
+    let presentation = DocumentActionPresentation::resolve(&action, Some(&result)).unwrap();
+
+    assert!(presentation.documents.is_empty());
+}
+
+fn create_action<const N: usize>(documents: [(&str, &str); N]) -> AIAgentActionType {
+    AIAgentActionType::CreateDocuments(CreateDocumentsRequest {
+        documents: documents
+            .into_iter()
+            .map(|(title, content)| DocumentToCreate {
+                title: title.to_owned(),
+                content: content.to_owned(),
+            })
+            .collect(),
+    })
+}
+
+fn document_context(document_id: AIDocumentId, content: &str) -> DocumentContext {
+    DocumentContext {
+        document_id,
+        document_version: AIDocumentVersion::default(),
+        content: content.to_owned(),
+        line_ranges: Vec::new(),
+    }
+}

--- a/crates/ai/src/agent/document_action_presentation_tests.rs
+++ b/crates/ai/src/agent/document_action_presentation_tests.rs
@@ -1,4 +1,4 @@
-use super::{DocumentActionKind, DocumentActionPresentation, ToolCallDisplayState};
+use super::DocumentActionPresentation;
 use crate::agent::action::{
     AIAgentActionType, CreateDocumentsRequest, DocumentDiff, DocumentToCreate, EditDocumentsRequest,
 };
@@ -13,7 +13,6 @@ fn streamed_create_uses_canonical_fallback_titles() {
 
     let presentation = DocumentActionPresentation::resolve(&action, None).unwrap();
 
-    assert_eq!(presentation.kind, DocumentActionKind::Create);
     assert_eq!(
         presentation
             .documents
@@ -21,11 +20,6 @@ fn streamed_create_uses_canonical_fallback_titles() {
             .map(|document| document.title.as_str())
             .collect::<Vec<_>>(),
         vec!["Document 1", "Named plan"]
-    );
-    assert_eq!(presentation.line_count(), 3);
-    assert_eq!(
-        presentation.header_label(ToolCallDisplayState::Running),
-        "Creating 2 documents"
     );
 }
 
@@ -47,10 +41,6 @@ fn completed_create_combines_request_titles_with_result_documents() {
         document.document_version,
         Some(AIDocumentVersion::default())
     );
-    assert_eq!(
-        presentation.header_label(ToolCallDisplayState::Succeeded),
-        "Created Planning document"
-    );
 }
 
 #[test]
@@ -69,12 +59,7 @@ fn completed_edit_uses_result_content_and_references() {
 
     let presentation = DocumentActionPresentation::resolve(&action, Some(&result)).unwrap();
 
-    assert_eq!(presentation.kind, DocumentActionKind::Edit);
     assert_eq!(presentation.documents[0].content, "updated");
-    assert_eq!(
-        presentation.header_label(ToolCallDisplayState::Succeeded),
-        "Updated Planning document"
-    );
 }
 
 #[test]

--- a/crates/ai/src/agent/mod.rs
+++ b/crates/ai/src/agent/mod.rs
@@ -2,6 +2,7 @@ pub mod action;
 pub mod action_result;
 mod citation;
 pub mod convert;
+pub mod document_action_presentation;
 pub mod file_locations;
 pub mod orchestration_config;
 

--- a/crates/ai/src/document.rs
+++ b/crates/ai/src/document.rs
@@ -1,4 +1,5 @@
 use uuid::Uuid;
+pub const DEFAULT_PLANNING_DOCUMENT_TITLE: &str = "Planning document";
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct AIDocumentId(Uuid);

--- a/crates/warp_tui/src/agent_block.rs
+++ b/crates/warp_tui/src/agent_block.rs
@@ -45,6 +45,7 @@ use crate::tui_code_block_view::{TuiCodeBlockPayload, TuiCodeBlockView, TuiCodeB
 use crate::tui_markdown::{
     render_formatted_table, render_formatted_text, TuiMarkdownBlockHooks, TuiMarkdownPalette,
 };
+use crate::tui_plan_view::{TuiPlanView, TuiPlanViewEvent};
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 struct TuiCodeBlockKey {
@@ -157,6 +158,7 @@ impl CollapsibleSectionStates {
 /// when it needs owned state or interactivity.
 enum TuiToolCallView {
     FileEdits(ViewHandle<TuiFileEditsView>),
+    Plan(ViewHandle<TuiPlanView>),
     ShellCommand(ViewHandle<TuiShellCommandView>),
 }
 
@@ -165,6 +167,7 @@ impl TuiToolCallView {
     fn view_id(&self) -> EntityId {
         match self {
             Self::FileEdits(view) => view.id(),
+            Self::Plan(view) => view.id(),
             Self::ShellCommand(view) => view.id(),
         }
     }
@@ -173,6 +176,7 @@ impl TuiToolCallView {
     fn render_child(&self) -> TuiChildView {
         match self {
             Self::FileEdits(view) => TuiChildView::new(view),
+            Self::Plan(view) => TuiChildView::new(view),
             Self::ShellCommand(view) => TuiChildView::new(view),
         }
     }
@@ -316,6 +320,7 @@ impl TuiAIBlock {
         let status = self.block_model.status(ctx);
         let output_streaming = status.is_streaming();
         let mut file_edit_action_ids = Vec::new();
+        let mut plan_actions = Vec::new();
         let mut shell_command_actions = Vec::new();
         if let Some(output) = status.output_to_render() {
             for message in &output.get().messages {
@@ -329,6 +334,11 @@ impl TuiAIBlock {
                 self.action_ids.insert(action.id.clone());
                 if matches!(&action.action, AIAgentActionType::RequestFileEdits { .. }) {
                     file_edit_action_ids.push(action.id.clone());
+                } else if matches!(
+                    &action.action,
+                    AIAgentActionType::CreateDocuments(_) | AIAgentActionType::EditDocuments(_)
+                ) {
+                    plan_actions.push(action.clone());
                 } else if matches!(
                     &action.action,
                     AIAgentActionType::RequestCommandOutput { .. }
@@ -351,6 +361,25 @@ impl TuiAIBlock {
             });
             self.action_views
                 .insert(action_id, TuiToolCallView::FileEdits(view));
+            ctx.notify();
+        }
+
+        for action in plan_actions {
+            if let Some(TuiToolCallView::Plan(view)) = self.action_views.get(&action.id) {
+                view.update(ctx, |view, ctx| {
+                    view.sync_action(action, output_streaming, ctx);
+                });
+                continue;
+            }
+            let action_id = action.id.clone();
+            let view = ctx.add_typed_action_tui_view(|ctx| {
+                TuiPlanView::new(action, output_streaming, action_model, ctx)
+            });
+            ctx.subscribe_to_view(&view, |me, _, event, ctx| match event {
+                TuiPlanViewEvent::LayoutChanged => me.invalidate_layout(ctx),
+            });
+            self.action_views
+                .insert(action_id, TuiToolCallView::Plan(view));
             ctx.notify();
         }
 
@@ -543,7 +572,7 @@ impl TuiAIBlock {
         self.last_measured_width.get() != Some(width)
             || self.block_model.status(app).is_streaming()
             || self.action_views.values().any(|view| match view {
-                TuiToolCallView::FileEdits(_) => false,
+                TuiToolCallView::FileEdits(_) | TuiToolCallView::Plan(_) => false,
                 TuiToolCallView::ShellCommand(view) => {
                     view.as_ref(app).needs_continuous_height_measurement()
                 }
@@ -965,6 +994,16 @@ impl TuiAIBlock {
                 // Stateful tool calls render their registered child view; every
                 // other tool call stays a pure render fn.
                 TuiAIBlockSection::ToolCall(action) => match self.action_views.get(&action.id) {
+                    Some(TuiToolCallView::Plan(view)) if !view.as_ref(app).renders_rich_body() => {
+                        let status = self.action_model.as_ref(app).get_action_status(&action.id);
+                        render_fallback_tool_call_section(
+                            action,
+                            status.as_ref(),
+                            output_streaming,
+                            None,
+                            app,
+                        )
+                    }
                     Some(view) => TuiContainer::new(Box::new(view.render_child())).finish(),
                     None => {
                         let status = self.action_model.as_ref(app).get_action_status(&action.id);

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -3,6 +3,10 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
+use ai::agent::action::{
+    CreateDocumentsRequest, DocumentDiff, DocumentToCreate, EditDocumentsRequest,
+};
+use ai::document::AIDocumentId;
 use markdown_parser::parse_markdown;
 use parking_lot::FairMutex;
 use warp::tui_export::{
@@ -36,6 +40,7 @@ use crate::agent_block_sections::{
     completed_todos_label, render_fallback_tool_call_section, render_todo_list_section,
 };
 use crate::test_fixtures::{add_test_action_model_and_events, TestHostView};
+use crate::tui_plan_view::TuiPlanViewAction;
 use crate::tui_shell_command_view::TuiShellCommandViewAction;
 
 #[test]
@@ -83,6 +88,27 @@ fn simple_agent_block_reports_full_height_and_renders_content() {
             // terminal's own background.
             assert_eq!(frame.buffer[(0, 3)].bg, Color::Reset);
             assert_eq!(frame.buffer[(19, 3)].bg, Color::Reset);
+        });
+    });
+}
+
+#[test]
+fn agent_block_uses_fallback_row_for_edit_without_rich_body() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let edit = test_edit_documents_action("edit-1");
+        let block = test_agent_block(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status: complete_output_messages(vec![action_message("message-1", edit)]),
+            },
+        );
+
+        app.read(|ctx| {
+            let rendered = render_block_lines(block.as_ref(ctx), 60, ctx);
+            assert_eq!(rendered.len(), 1);
+            assert!(rendered[0].contains("Update"));
         });
     });
 }
@@ -432,6 +458,101 @@ fn shell_command_disclosure_invalidates_agent_block_layout() {
     });
 }
 
+#[test]
+fn agent_block_registers_create_and_edit_plan_children() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let create = test_create_documents_action(
+            "create-1",
+            vec![DocumentToCreate {
+                title: "Plan".to_owned(),
+                content: "# Overview\n\nRich body".to_owned(),
+            }],
+        );
+        let edit = test_edit_documents_action("edit-1");
+        let block = test_agent_block(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status: complete_output_messages(vec![
+                    action_message("message-1", create.clone()),
+                    action_message("message-2", edit.clone()),
+                ]),
+            },
+        );
+
+        app.read(|ctx| {
+            let block = block.as_ref(ctx);
+            let Some(TuiToolCallView::Plan(create_view)) = block.action_views.get(&create.id)
+            else {
+                panic!("create action has a plan child");
+            };
+            let Some(TuiToolCallView::Plan(edit_view)) = block.action_views.get(&edit.id) else {
+                panic!("edit action has a plan child");
+            };
+            assert!(create_view.as_ref(ctx).renders_rich_body());
+            assert!(!edit_view.as_ref(ctx).renders_rich_body());
+            assert_eq!(block.child_view_ids(ctx).len(), 2);
+            let rendered = render_tui_view_lines(create_view.as_ref(ctx), 60, 20, ctx);
+            assert!(rendered.iter().any(|line| line.trim() == "Overview"));
+            assert!(rendered.iter().any(|line| line.trim() == "Rich body"));
+        });
+    });
+}
+
+#[test]
+fn plan_collapse_invalidates_agent_block_layout() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let action = test_create_documents_action(
+            "create-1",
+            vec![DocumentToCreate {
+                title: "Plan".to_owned(),
+                content: "body".to_owned(),
+            }],
+        );
+        let action_id = action.id.clone();
+        let block = test_agent_block(
+            &mut app,
+            FakeAgentBlockModel {
+                inputs: Vec::new(),
+                status: complete_output_messages(vec![action_message("message-1", action)]),
+            },
+        );
+        let layout_invalidations = Rc::new(Cell::new(0));
+        let invalidations_for_subscription = layout_invalidations.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&block, move |_, event, _| match event {
+                TuiAIBlockEvent::LayoutInvalidated => {
+                    invalidations_for_subscription.set(invalidations_for_subscription.get() + 1);
+                }
+            });
+        });
+
+        let plan_view = app.read(|ctx| {
+            let Some(TuiToolCallView::Plan(view)) = block.as_ref(ctx).action_views.get(&action_id)
+            else {
+                panic!("create action has a plan child");
+            };
+            view.clone()
+        });
+        app.update(|ctx| {
+            ctx.dispatch_typed_action_for_view(
+                plan_view.window_id(ctx),
+                plan_view.id(),
+                &TuiPlanViewAction::SetCollapsed(true),
+            );
+        });
+
+        assert_eq!(layout_invalidations.get(), 1);
+        app.read(|ctx| {
+            assert_eq!(
+                render_tui_view_lines(plan_view.as_ref(ctx), 40, 5, ctx),
+                vec!["○ Create Plan +1 ▸"]
+            );
+        });
+    });
+}
 #[test]
 fn agent_block_ignores_unsupported_message_variants() {
     App::test((), |mut app| async move {
@@ -1453,6 +1574,30 @@ fn test_command_action(id: &str, command: &str) -> AIAgentAction {
     }
 }
 
+fn test_create_documents_action(id: &str, documents: Vec<DocumentToCreate>) -> AIAgentAction {
+    AIAgentAction {
+        id: AIAgentActionId::from(id.to_owned()),
+        task_id: TaskId::new("task-1".to_owned()),
+        action: AIAgentActionType::CreateDocuments(CreateDocumentsRequest { documents }),
+        requires_result: true,
+    }
+}
+
+fn test_edit_documents_action(id: &str) -> AIAgentAction {
+    AIAgentAction {
+        id: AIAgentActionId::from(id.to_owned()),
+        task_id: TaskId::new("task-1".to_owned()),
+        action: AIAgentActionType::EditDocuments(EditDocumentsRequest {
+            diffs: vec![DocumentDiff {
+                document_id: AIDocumentId::new(),
+                search: "old".to_owned(),
+                replace: "new".to_owned(),
+            }],
+        }),
+        requires_result: true,
+    }
+}
+
 /// Builds a `Finished` status carrying `result` for `action`.
 fn finished_status(action: &AIAgentAction, result: AIAgentActionResultType) -> AIActionStatus {
     AIActionStatus::Finished(Arc::new(AIAgentActionResult {
@@ -1566,6 +1711,23 @@ fn render_block_lines(block: &TuiAIBlock, width: u16, app: &AppContext) -> Vec<S
         app,
     );
     frame
+        .buffer
+        .to_lines()
+        .into_iter()
+        .map(|line| line.trim_end().to_owned())
+        .filter(|line| !line.is_empty())
+        .collect()
+}
+
+fn render_tui_view_lines(
+    view: &impl TuiView,
+    width: u16,
+    height: u16,
+    app: &AppContext,
+) -> Vec<String> {
+    let mut presenter = TuiPresenter::new();
+    presenter
+        .present_element(view.render(app), TuiRect::new(0, 0, width, height), app)
         .buffer
         .to_lines()
         .into_iter()

--- a/crates/warp_tui/src/agent_block_tests.rs
+++ b/crates/warp_tui/src/agent_block_tests.rs
@@ -548,7 +548,7 @@ fn plan_collapse_invalidates_agent_block_layout() {
         app.read(|ctx| {
             assert_eq!(
                 render_tui_view_lines(plan_view.as_ref(ctx), 40, 5, ctx),
-                vec!["○ Create Plan +1 ▸"]
+                vec!["○ Create plan ▸"]
             );
         });
     });

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -49,6 +49,7 @@ mod tui_column_layout;
 mod tui_diff_storage;
 mod tui_file_edits_view;
 mod tui_markdown;
+mod tui_plan_view;
 mod tui_shell_command_view;
 mod usage;
 mod warping_indicator;

--- a/crates/warp_tui/src/tool_call_labels.rs
+++ b/crates/warp_tui/src/tool_call_labels.rs
@@ -3,6 +3,7 @@
 
 use std::path::Path;
 
+pub(crate) use ai::agent::document_action_presentation::ToolCallDisplayState;
 use warp::tui_export::{
     AIActionStatus, AIAgentAction, AIAgentActionResultType, AIAgentActionType,
     AskUserQuestionResult, FileGlobV2Result, GrepResult, RequestCommandOutputResult,
@@ -41,29 +42,6 @@ pub(crate) struct ResolvedCommandBlock {
 /// Longest rendered length for interpolated values (commands, queries, paths)
 /// so tool-call rows stay scannable one-liners.
 const MAX_INLINE_LEN: usize = 80;
-
-/// The coarse display state of a tool call, derived from its action status.
-///
-/// TUI-local presentation collapse of the shared [`AIActionStatus`]; the GUI
-/// has no equivalent enum — its per-tool views consume `AIActionStatus`
-/// directly and re-derive per-site booleans (queued/cancelled/streaming).
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum ToolCallDisplayState {
-    /// The tool call's arguments are still streaming in: it has no action
-    /// status yet and the exchange output is still streaming, so argument
-    /// fields may be empty or partial and must not be interpolated.
-    Constructing,
-    /// No status yet (stream finished), preprocessing, or queued behind
-    /// other actions.
-    Pending,
-    /// Blocked on user confirmation.
-    AwaitingApproval,
-    /// Executing asynchronously.
-    Running,
-    Succeeded,
-    Failed,
-    Cancelled,
-}
 
 /// Collapses an optional action status into the coarse display state.
 /// `output_streaming` is whether the exchange output is still streaming;

--- a/crates/warp_tui/src/tui_builder.rs
+++ b/crates/warp_tui/src/tui_builder.rs
@@ -159,6 +159,13 @@ impl TuiUiBuilder {
         )
     }
 
+    /// Blue-overlay background for inline plan bodies, matching the TUI
+    /// design's `blue_overlay_1` treatment.
+    pub(crate) fn plan_background(&self) -> Color {
+        let blue = ThemeFill::Solid(self.warp_theme.ansi_fg_blue());
+        cell_color(self.base_background().blend(&blue.with_opacity(10)))
+    }
+
     /// The background the transcript actually renders over: default cells
     /// stay bg-unset, so it is the terminal's *own* background when the
     /// startup probe captured it, else the theme background as the closest

--- a/crates/warp_tui/src/tui_builder.rs
+++ b/crates/warp_tui/src/tui_builder.rs
@@ -159,13 +159,6 @@ impl TuiUiBuilder {
         )
     }
 
-    /// Blue-overlay background for inline plan bodies, matching the TUI
-    /// design's `blue_overlay_1` treatment.
-    pub(crate) fn plan_background(&self) -> Color {
-        let blue = ThemeFill::Solid(self.warp_theme.ansi_fg_blue());
-        cell_color(self.base_background().blend(&blue.with_opacity(10)))
-    }
-
     /// The background the transcript actually renders over: default cells
     /// stay bg-unset, so it is the terminal's *own* background when the
     /// startup probe captured it, else the theme background as the closest

--- a/crates/warp_tui/src/tui_builder.rs
+++ b/crates/warp_tui/src/tui_builder.rs
@@ -120,10 +120,14 @@ impl TuiUiBuilder {
         )))
     }
 
+    /// Theme-blue link text, matching linked filenames in tool-call headers.
+    pub(crate) fn link_text_style(&self) -> TuiStyle {
+        TuiStyle::default().fg(cell_color(ThemeFill::Solid(self.warp_theme.ansi_fg_blue())))
+    }
     /// Blue command-name text used by the slash-command menu and recognized
     /// slash-command prefixes in the input.
     pub(crate) fn slash_command_text_style(&self) -> TuiStyle {
-        TuiStyle::default().fg(cell_color(ThemeFill::Solid(self.warp_theme.ansi_fg_blue())))
+        self.link_text_style()
     }
 
     /// Solid cyan selection background used by the slash-command menu.

--- a/crates/warp_tui/src/tui_builder.rs
+++ b/crates/warp_tui/src/tui_builder.rs
@@ -158,6 +158,12 @@ impl TuiUiBuilder {
                 .blend(&accent.with_opacity(10)),
         )
     }
+    /// Blue-overlay background for inline plan bodies, matching the TUI
+    /// design's `blue_overlay_1` treatment.
+    pub(crate) fn plan_background(&self) -> Color {
+        let blue = ThemeFill::Solid(self.warp_theme.ansi_fg_blue());
+        cell_color(self.base_background().blend(&blue.with_opacity(10)))
+    }
 
     /// The background the transcript actually renders over: default cells
     /// stay bg-unset, so it is the terminal's *own* background when the

--- a/crates/warp_tui/src/tui_builder_tests.rs
+++ b/crates/warp_tui/src/tui_builder_tests.rs
@@ -43,6 +43,7 @@ fn text_styles_follow_light_theme_foreground() {
         builder.slash_command_text_style().fg,
         Some(slash_command_color)
     );
+    assert_eq!(builder.link_text_style().fg, Some(slash_command_color));
     assert_eq!(
         builder.slash_command_selection_background(),
         selection_background

--- a/crates/warp_tui/src/tui_plan_view.rs
+++ b/crates/warp_tui/src/tui_plan_view.rs
@@ -223,7 +223,9 @@ impl TuiPlanView {
         }
 
         TuiContainer::new(documents.finish())
-            .with_padding_left(4)
+            .with_padding_x(2)
+            .with_padding_y(1)
+            .with_background(builder.plan_background())
             .finish()
     }
 

--- a/crates/warp_tui/src/tui_plan_view.rs
+++ b/crates/warp_tui/src/tui_plan_view.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 
 use ai::agent::document_action_presentation::DocumentActionPresentation;
 use markdown_parser::{parse_markdown_with_gfm_tables, FormattedText, FormattedTextLine};
-use warp::tui_export::{AIAgentAction, BlocklistAIActionEvent, BlocklistAIActionModel};
+use warp::tui_export::{
+    AIAgentAction, AIAgentActionType, BlocklistAIActionEvent, BlocklistAIActionModel,
+};
 use warpui_core::elements::tui::{
     tui_collapsible, Modifier, TuiChildView, TuiContainer, TuiElement, TuiFlex, TuiParentElement,
     TuiText,
@@ -15,6 +17,8 @@ use warpui_core::{
     AppContext, Entity, EntityId, ModelHandle, TuiView, TypedActionView, ViewContext, ViewHandle,
 };
 
+use crate::agent_block_sections::tool_call_glyph_style;
+use crate::tool_call_labels::{tool_call_display_state, tool_call_glyph, ToolCallDisplayState};
 use crate::tui_builder::TuiUiBuilder;
 use crate::tui_code_block_view::{TuiCodeBlockPayload, TuiCodeBlockView, TuiCodeBlockViewEvent};
 use crate::tui_markdown::{render_formatted_text, TuiMarkdownBlockHooks, TuiMarkdownPalette};
@@ -180,6 +184,53 @@ impl TuiPlanView {
         }
     }
 
+    fn display_state(&self, app: &AppContext) -> ToolCallDisplayState {
+        let status = self
+            .action_model
+            .as_ref(app)
+            .get_action_status(&self.action.id);
+        tool_call_display_state(status.as_ref(), self.output_streaming, None)
+    }
+
+    fn document_subject(&self) -> String {
+        if self.presentation.documents.len() == 1 {
+            self.presentation.documents[0].title.clone()
+        } else {
+            format!("{} documents", self.presentation.documents.len())
+        }
+    }
+
+    fn header_label(&self, state: ToolCallDisplayState) -> (&'static str, Option<String>) {
+        if matches!(&self.action.action, AIAgentActionType::CreateDocuments(_)) {
+            match state {
+                ToolCallDisplayState::Constructing | ToolCallDisplayState::Running => {
+                    ("Creating ", Some(self.document_subject()))
+                }
+                ToolCallDisplayState::Pending | ToolCallDisplayState::AwaitingApproval => {
+                    ("Create plan", None)
+                }
+                ToolCallDisplayState::Succeeded => ("Created plan", None),
+                ToolCallDisplayState::Failed => ("Failed to create plan", None),
+                ToolCallDisplayState::Cancelled => ("Create plan cancelled", None),
+            }
+        } else {
+            debug_assert!(matches!(
+                &self.action.action,
+                AIAgentActionType::EditDocuments(_)
+            ));
+            match state {
+                ToolCallDisplayState::Constructing | ToolCallDisplayState::Running => {
+                    ("Updating plan", None)
+                }
+                ToolCallDisplayState::Pending | ToolCallDisplayState::AwaitingApproval => {
+                    ("Update plan", None)
+                }
+                ToolCallDisplayState::Succeeded => ("Updated plan", None),
+                ToolCallDisplayState::Failed => ("Failed to update plan", None),
+                ToolCallDisplayState::Cancelled => ("Update plan cancelled", None),
+            }
+        }
+    }
     fn render_documents(&self, app: &AppContext) -> Box<dyn TuiElement> {
         let builder = TuiUiBuilder::from_app(app);
         let palette = TuiMarkdownPalette::from_builder(&builder);
@@ -223,7 +274,7 @@ impl TuiPlanView {
         }
 
         TuiContainer::new(documents.finish())
-            .with_padding_x(2)
+            .with_padding_left(2)
             .with_padding_y(1)
             .with_background(builder.plan_background())
             .finish()
@@ -250,11 +301,26 @@ impl TuiView for TuiPlanView {
 
     fn render(&self, app: &AppContext) -> Box<dyn TuiElement> {
         let builder = TuiUiBuilder::from_app(app);
+        let state = self.display_state(app);
         let header_style = builder.primary_text_style().add_modifier(Modifier::BOLD);
+        let (label, subject) = self.header_label(state);
+        let mut header = vec![
+            (
+                format!("{} ", tool_call_glyph(state)),
+                tool_call_glyph_style(state, &builder),
+            ),
+            (label.to_owned(), header_style),
+        ];
+        if let Some(subject) = subject {
+            header.push((
+                subject,
+                builder.link_text_style().add_modifier(Modifier::BOLD),
+            ));
+        }
         let collapsed = self.collapsed;
         tui_collapsible(
             collapsed,
-            [("Planning".to_owned(), header_style)],
+            header,
             header_style,
             self.header_mouse_state.clone(),
             || self.render_documents(app),

--- a/crates/warp_tui/src/tui_plan_view.rs
+++ b/crates/warp_tui/src/tui_plan_view.rs
@@ -1,4 +1,4 @@
-//! Stateful inline Markdown card for CreateDocuments and EditDocuments tool calls.
+//! Stateful inline Markdown view for CreateDocuments and EditDocuments tool calls.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -15,8 +15,6 @@ use warpui_core::{
     AppContext, Entity, EntityId, ModelHandle, TuiView, TypedActionView, ViewContext, ViewHandle,
 };
 
-use crate::agent_block_sections::{tool_call_glyph_style, tool_call_label_style};
-use crate::tool_call_labels::{tool_call_display_state, tool_call_glyph, ToolCallDisplayState};
 use crate::tui_builder::TuiUiBuilder;
 use crate::tui_code_block_view::{TuiCodeBlockPayload, TuiCodeBlockView, TuiCodeBlockViewEvent};
 use crate::tui_markdown::{render_formatted_text, TuiMarkdownBlockHooks, TuiMarkdownPalette};
@@ -182,14 +180,6 @@ impl TuiPlanView {
         }
     }
 
-    fn display_state(&self, app: &AppContext) -> ToolCallDisplayState {
-        let status = self
-            .action_model
-            .as_ref(app)
-            .get_action_status(&self.action.id);
-        tool_call_display_state(status.as_ref(), self.output_streaming, None)
-    }
-
     fn render_documents(&self, app: &AppContext) -> Box<dyn TuiElement> {
         let builder = TuiUiBuilder::from_app(app);
         let palette = TuiMarkdownPalette::from_builder(&builder);
@@ -233,9 +223,7 @@ impl TuiPlanView {
         }
 
         TuiContainer::new(documents.finish())
-            .with_padding_x(2)
-            .with_padding_y(1)
-            .with_background(builder.plan_background())
+            .with_padding_left(4)
             .finish()
     }
 
@@ -260,30 +248,12 @@ impl TuiView for TuiPlanView {
 
     fn render(&self, app: &AppContext) -> Box<dyn TuiElement> {
         let builder = TuiUiBuilder::from_app(app);
-        let state = self.display_state(app);
-        let glyph_style = tool_call_glyph_style(state, &builder);
-        let label_style = tool_call_label_style(state, &builder).add_modifier(Modifier::BOLD);
-        let label_style = if self.header_mouse_state.lock().unwrap().is_hovered() {
-            label_style.add_modifier(Modifier::UNDERLINED)
-        } else {
-            label_style
-        };
-        let line_count = self.presentation.line_count();
-        let mut header = vec![
-            (format!("{} ", tool_call_glyph(state)), glyph_style),
-            (self.presentation.header_label(state), label_style),
-        ];
-        if line_count > 0 {
-            header.push((
-                format!(" +{line_count}"),
-                builder.diff_added_style().add_modifier(Modifier::BOLD),
-            ));
-        }
+        let header_style = builder.primary_text_style().add_modifier(Modifier::BOLD);
         let collapsed = self.collapsed;
         tui_collapsible(
             collapsed,
-            header,
-            builder.primary_text_style(),
+            [("Planning".to_owned(), header_style)],
+            header_style,
             self.header_mouse_state.clone(),
             || self.render_documents(app),
             move |event_ctx, _app| {

--- a/crates/warp_tui/src/tui_plan_view.rs
+++ b/crates/warp_tui/src/tui_plan_view.rs
@@ -209,7 +209,7 @@ impl TuiPlanView {
                 ToolCallDisplayState::Pending | ToolCallDisplayState::AwaitingApproval => {
                     ("Create plan", None)
                 }
-                ToolCallDisplayState::Succeeded => ("Created plan", None),
+                ToolCallDisplayState::Succeeded => ("Created ", Some(self.document_subject())),
                 ToolCallDisplayState::Failed => ("Failed to create plan", None),
                 ToolCallDisplayState::Cancelled => ("Create plan cancelled", None),
             }

--- a/crates/warp_tui/src/tui_plan_view.rs
+++ b/crates/warp_tui/src/tui_plan_view.rs
@@ -1,0 +1,311 @@
+//! Stateful inline Markdown card for CreateDocuments and EditDocuments tool calls.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use ai::agent::document_action_presentation::DocumentActionPresentation;
+use markdown_parser::{parse_markdown_with_gfm_tables, FormattedText, FormattedTextLine};
+use warp::tui_export::{AIAgentAction, BlocklistAIActionEvent, BlocklistAIActionModel};
+use warpui_core::elements::tui::{
+    tui_collapsible, Modifier, TuiChildView, TuiContainer, TuiElement, TuiFlex, TuiParentElement,
+    TuiText,
+};
+use warpui_core::elements::{CrossAxisAlignment, MouseStateHandle};
+use warpui_core::{
+    AppContext, Entity, EntityId, ModelHandle, TuiView, TypedActionView, ViewContext, ViewHandle,
+};
+
+use crate::agent_block_sections::{tool_call_glyph_style, tool_call_label_style};
+use crate::tool_call_labels::{tool_call_display_state, tool_call_glyph, ToolCallDisplayState};
+use crate::tui_builder::TuiUiBuilder;
+use crate::tui_code_block_view::{TuiCodeBlockPayload, TuiCodeBlockView, TuiCodeBlockViewEvent};
+use crate::tui_markdown::{render_formatted_text, TuiMarkdownBlockHooks, TuiMarkdownPalette};
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct TuiPlanCodeKey {
+    document_index: usize,
+    code_index: usize,
+}
+
+struct TuiPlanDocument {
+    formatted: Option<Arc<FormattedText>>,
+}
+
+pub(super) enum TuiPlanViewEvent {
+    LayoutChanged,
+}
+
+#[derive(Clone, Debug)]
+pub(super) enum TuiPlanViewAction {
+    SetCollapsed(bool),
+}
+
+pub(super) struct TuiPlanView {
+    action: AIAgentAction,
+    action_model: ModelHandle<BlocklistAIActionModel>,
+    output_streaming: bool,
+    presentation: DocumentActionPresentation,
+    documents: Vec<TuiPlanDocument>,
+    code_views: HashMap<TuiPlanCodeKey, ViewHandle<TuiCodeBlockView>>,
+    collapsed: bool,
+    header_mouse_state: MouseStateHandle,
+}
+
+impl TuiPlanView {
+    pub(super) fn new(
+        action: AIAgentAction,
+        output_streaming: bool,
+        action_model: &ModelHandle<BlocklistAIActionModel>,
+        ctx: &mut ViewContext<Self>,
+    ) -> Self {
+        let presentation = DocumentActionPresentation::resolve(&action.action, None)
+            .expect("TuiPlanView only supports document actions");
+        let mut view = Self {
+            action,
+            action_model: action_model.clone(),
+            output_streaming,
+            presentation,
+            documents: Vec::new(),
+            code_views: HashMap::new(),
+            collapsed: false,
+            header_mouse_state: MouseStateHandle::default(),
+        };
+        view.sync_documents(ctx);
+
+        ctx.subscribe_to_model(action_model, |me, _, event, ctx| {
+            if matches!(
+                event,
+                BlocklistAIActionEvent::FinishedAction { action_id, .. }
+                    if *action_id == me.action.id
+            ) {
+                me.sync_documents(ctx);
+                me.invalidate_layout(ctx);
+            }
+        });
+        view
+    }
+
+    pub(super) fn sync_action(
+        &mut self,
+        action: AIAgentAction,
+        output_streaming: bool,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        let status_changed = self.output_streaming != output_streaming;
+        let action_changed = self.action != action;
+        self.action = action;
+        self.output_streaming = output_streaming;
+        let documents_changed = self.sync_documents(ctx);
+        if status_changed || action_changed || documents_changed {
+            self.invalidate_layout(ctx);
+        }
+    }
+
+    pub(super) fn renders_rich_body(&self) -> bool {
+        !self.documents.is_empty()
+    }
+
+    fn sync_documents(&mut self, ctx: &mut ViewContext<Self>) -> bool {
+        let resolved = self.resolve_presentation(ctx);
+        if self.presentation == resolved && self.documents.len() == resolved.documents.len() {
+            return false;
+        }
+
+        self.documents = resolved
+            .documents
+            .iter()
+            .map(|document| TuiPlanDocument {
+                formatted: parse_markdown_with_gfm_tables(&document.content)
+                    .ok()
+                    .map(Arc::new),
+            })
+            .collect();
+        self.presentation = resolved;
+        self.sync_code_views(ctx);
+        true
+    }
+
+    fn resolve_presentation(&self, app: &AppContext) -> DocumentActionPresentation {
+        let result = self
+            .action_model
+            .as_ref(app)
+            .get_action_result(&self.action.id)
+            .map(|result| &result.result);
+        DocumentActionPresentation::resolve(&self.action.action, result)
+            .expect("TuiPlanView only supports document actions")
+    }
+
+    fn sync_code_views(&mut self, ctx: &mut ViewContext<Self>) {
+        let mut descriptors = Vec::new();
+        for (document_index, document) in self.documents.iter().enumerate() {
+            let Some(formatted) = &document.formatted else {
+                continue;
+            };
+            let mut code_index = 0;
+            for line in &formatted.lines {
+                if let FormattedTextLine::CodeBlock(code) = line {
+                    descriptors.push((
+                        TuiPlanCodeKey {
+                            document_index,
+                            code_index,
+                        },
+                        TuiCodeBlockPayload::new(
+                            code.code.clone(),
+                            (!code.lang.is_empty()).then(|| code.lang.clone()),
+                        ),
+                    ));
+                    code_index += 1;
+                }
+            }
+        }
+
+        let active_keys = descriptors
+            .iter()
+            .map(|(key, _)| *key)
+            .collect::<HashSet<_>>();
+        self.code_views.retain(|key, _| active_keys.contains(key));
+
+        for (key, payload) in descriptors {
+            if let Some(view) = self.code_views.get(&key) {
+                view.update(ctx, |view, ctx| {
+                    view.sync(payload, ctx);
+                });
+                continue;
+            }
+            let view = ctx.add_tui_view(move |ctx| TuiCodeBlockView::new(payload, ctx));
+            ctx.subscribe_to_view(&view, |me, _, event, ctx| match event {
+                TuiCodeBlockViewEvent::LayoutChanged | TuiCodeBlockViewEvent::SyntaxUpdated => {
+                    me.invalidate_layout(ctx)
+                }
+            });
+            self.code_views.insert(key, view);
+        }
+    }
+
+    fn display_state(&self, app: &AppContext) -> ToolCallDisplayState {
+        let status = self
+            .action_model
+            .as_ref(app)
+            .get_action_status(&self.action.id);
+        tool_call_display_state(status.as_ref(), self.output_streaming, None)
+    }
+
+    fn render_documents(&self, app: &AppContext) -> Box<dyn TuiElement> {
+        let builder = TuiUiBuilder::from_app(app);
+        let palette = TuiMarkdownPalette::from_builder(&builder);
+        let mut documents =
+            TuiFlex::column().with_cross_axis_alignment(CrossAxisAlignment::Stretch);
+        for (document_index, document) in self.documents.iter().enumerate() {
+            if document_index > 0 {
+                documents.add_child(TuiText::new(" ").truncate().finish());
+            }
+            if self.documents.len() > 1 {
+                documents.add_child(
+                    TuiText::new(self.presentation.documents[document_index].title.clone())
+                        .with_style(builder.primary_text_style().add_modifier(Modifier::BOLD))
+                        .finish(),
+                );
+            }
+            let content = match &document.formatted {
+                Some(formatted) => {
+                    let render_code =
+                        |code_index: usize, _code: &markdown_parser::CodeBlockText| {
+                            self.code_views
+                                .get(&TuiPlanCodeKey {
+                                    document_index,
+                                    code_index,
+                                })
+                                .map(|view| TuiChildView::new(view).finish())
+                        };
+                    render_formatted_text(
+                        formatted,
+                        palette,
+                        &TuiMarkdownBlockHooks {
+                            render_code: Some(&render_code),
+                        },
+                    )
+                }
+                None => TuiText::new(self.presentation.documents[document_index].content.clone())
+                    .with_style(palette.body)
+                    .finish(),
+            };
+            documents.add_child(content);
+        }
+
+        TuiContainer::new(documents.finish())
+            .with_padding_x(2)
+            .with_padding_y(1)
+            .with_background(builder.plan_background())
+            .finish()
+    }
+
+    fn invalidate_layout(&self, ctx: &mut ViewContext<Self>) {
+        ctx.emit(TuiPlanViewEvent::LayoutChanged);
+        ctx.notify();
+    }
+}
+
+impl Entity for TuiPlanView {
+    type Event = TuiPlanViewEvent;
+}
+
+impl TuiView for TuiPlanView {
+    fn ui_name() -> &'static str {
+        "TuiPlanView"
+    }
+
+    fn child_view_ids(&self, _app: &AppContext) -> Vec<EntityId> {
+        self.code_views.values().map(|view| view.id()).collect()
+    }
+
+    fn render(&self, app: &AppContext) -> Box<dyn TuiElement> {
+        let builder = TuiUiBuilder::from_app(app);
+        let state = self.display_state(app);
+        let glyph_style = tool_call_glyph_style(state, &builder);
+        let label_style = tool_call_label_style(state, &builder).add_modifier(Modifier::BOLD);
+        let label_style = if self.header_mouse_state.lock().unwrap().is_hovered() {
+            label_style.add_modifier(Modifier::UNDERLINED)
+        } else {
+            label_style
+        };
+        let line_count = self.presentation.line_count();
+        let mut header = vec![
+            (format!("{} ", tool_call_glyph(state)), glyph_style),
+            (self.presentation.header_label(state), label_style),
+        ];
+        if line_count > 0 {
+            header.push((
+                format!(" +{line_count}"),
+                builder.diff_added_style().add_modifier(Modifier::BOLD),
+            ));
+        }
+        let collapsed = self.collapsed;
+        tui_collapsible(
+            collapsed,
+            header,
+            builder.primary_text_style(),
+            self.header_mouse_state.clone(),
+            || self.render_documents(app),
+            move |event_ctx, _app| {
+                event_ctx.dispatch_typed_action(TuiPlanViewAction::SetCollapsed(!collapsed));
+            },
+        )
+    }
+}
+
+impl TypedActionView for TuiPlanView {
+    type Action = TuiPlanViewAction;
+
+    fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
+        match action {
+            TuiPlanViewAction::SetCollapsed(collapsed) => {
+                self.collapsed = *collapsed;
+                self.invalidate_layout(ctx);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "tui_plan_view_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/tui_plan_view_tests.rs
+++ b/crates/warp_tui/src/tui_plan_view_tests.rs
@@ -20,6 +20,7 @@ use warpui_core::{App, TuiView, ViewHandle};
 
 use super::{TuiPlanCodeKey, TuiPlanView, TuiPlanViewAction, TuiPlanViewEvent};
 use crate::test_fixtures::{add_test_action_model, TestHostView};
+use crate::tui_builder::TuiUiBuilder;
 
 #[test]
 fn streamed_create_renders_cached_markdown_and_code_children() {
@@ -42,17 +43,23 @@ fn streamed_create_renders_cached_markdown_and_code_children() {
 
             let (lines, buffer) = render(view, 80, ctx);
             assert_eq!(lines[0], "Planning ▾");
-            assert_eq!(lines[1], "    Overview");
+            assert_eq!(lines[1], "");
+            assert_eq!(lines[2], "  Overview");
             assert!(lines
                 .iter()
                 .any(|line| line.trim() == "Build a fast timer."));
             assert!(lines.iter().all(|line| !line.contains("**")));
             assert!(lines
                 .iter()
-                .skip(1)
+                .skip(2)
                 .filter(|line| !line.is_empty())
-                .all(|line| line.starts_with("    ")));
-            assert_eq!(buffer[(0, 1)].bg, Color::Reset);
+                .all(|line| line.starts_with("  ")));
+            let plan_background = TuiUiBuilder::from_app(ctx).plan_background();
+            assert_eq!(buffer[(0, 0)].bg, Color::Reset);
+            assert_eq!(buffer[(0, 1)].bg, plan_background);
+            assert_eq!(buffer[(79, 1)].bg, plan_background);
+            assert_eq!(buffer[(0, 2)].bg, plan_background);
+            assert_eq!(buffer[(79, 2)].bg, plan_background);
             assert!(buffer[(0, 0)].modifier.contains(Modifier::BOLD));
             assert!(!buffer[(0, 0)].modifier.contains(Modifier::UNDERLINED));
 

--- a/crates/warp_tui/src/tui_plan_view_tests.rs
+++ b/crates/warp_tui/src/tui_plan_view_tests.rs
@@ -14,13 +14,12 @@ use warp::tui_export::{
 };
 use warpui::platform::WindowStyle;
 use warpui::{AddWindowOptions, TypedActionView};
-use warpui_core::elements::tui::{TuiBufferExt, TuiRect};
+use warpui_core::elements::tui::{Color, Modifier, TuiBufferExt, TuiRect};
 use warpui_core::presenter::tui::TuiPresenter;
 use warpui_core::{App, TuiView, ViewHandle};
 
 use super::{TuiPlanCodeKey, TuiPlanView, TuiPlanViewAction, TuiPlanViewEvent};
 use crate::test_fixtures::{add_test_action_model, TestHostView};
-use crate::tui_builder::TuiUiBuilder;
 
 #[test]
 fn streamed_create_renders_cached_markdown_and_code_children() {
@@ -42,16 +41,20 @@ fn streamed_create_renders_cached_markdown_and_code_children() {
                 .clone();
 
             let (lines, buffer) = render(view, 80, ctx);
-            assert_eq!(lines[0], "○ Creating pomodoro-app-spec.md +7 ▾");
-            assert!(lines.iter().any(|line| line.trim() == "Overview"));
+            assert_eq!(lines[0], "Planning ▾");
+            assert_eq!(lines[1], "    Overview");
             assert!(lines
                 .iter()
                 .any(|line| line.trim() == "Build a fast timer."));
             assert!(lines.iter().all(|line| !line.contains("**")));
-            assert_eq!(
-                buffer[(79, 1)].bg,
-                TuiUiBuilder::from_app(ctx).plan_background()
-            );
+            assert!(lines
+                .iter()
+                .skip(1)
+                .filter(|line| !line.is_empty())
+                .all(|line| line.starts_with("    ")));
+            assert_eq!(buffer[(0, 1)].bg, Color::Reset);
+            assert!(buffer[(0, 0)].modifier.contains(Modifier::BOLD));
+            assert!(!buffer[(0, 0)].modifier.contains(Modifier::UNDERLINED));
 
             let code_key = TuiPlanCodeKey {
                 document_index: 0,
@@ -142,7 +145,7 @@ fn finalized_create_replaces_streamed_payload_and_keeps_action_order() {
                 vec![("First", "final first"), ("Second", "final second")]
             );
             let (lines, _) = render(view, 60, ctx);
-            assert_eq!(lines[0], "✓ Created 2 documents +2 ▾");
+            assert_eq!(lines[0], "Planning ▾");
             let positions = ["First", "final first", "Second", "final second"].map(|needle| {
                 lines
                     .iter()
@@ -186,7 +189,7 @@ fn finalized_edit_uses_full_result_content() {
                 .content
                 .contains("| Mode | Focus |"));
             let (lines, _) = render(view, 50, ctx);
-            assert_eq!(lines[0], "✓ Updated Planning document +7 ▾");
+            assert_eq!(lines[0], "Planning ▾");
             assert!(lines.iter().any(|line| line.trim() == "Updated"));
             assert!(lines.iter().any(|line| line.trim() == "Final body"));
             let joined = lines.join("\n");
@@ -228,7 +231,7 @@ fn collapse_persists_across_payload_updates_and_invalidates_layout() {
             assert!(view.collapsed);
             assert_eq!(view.presentation.documents[0].content, "second body");
             let (lines, _) = render(view, 40, ctx);
-            assert_eq!(lines, vec!["○ Creating Plan +1 ▸"]);
+            assert_eq!(lines, vec!["Planning ▸"]);
         });
         assert!(invalidations.get() >= 2);
     });

--- a/crates/warp_tui/src/tui_plan_view_tests.rs
+++ b/crates/warp_tui/src/tui_plan_view_tests.rs
@@ -135,6 +135,34 @@ fn plan_body_has_left_padding_without_right_padding() {
 }
 
 #[test]
+fn finalized_single_create_keeps_plan_name_in_header() {
+    App::test((), |mut app| async move {
+        let action = create_action("create-1", [("pomodoro-app-spec.md", "streamed content")]);
+        let (view, action_model) = test_plan_view(&mut app, action.clone(), true);
+        action_model.update(&mut app, |model, ctx| {
+            model.apply_finished_action_result(
+                AIConversationId::new(),
+                action_result(
+                    &action,
+                    AIAgentActionResultType::CreateDocuments(CreateDocumentsResult::Success {
+                        created_documents: vec![document_context(
+                            AIDocumentId::new(),
+                            "final content",
+                        )],
+                    }),
+                ),
+                ctx,
+            );
+        });
+
+        app.read(|ctx| {
+            let (lines, _) = render(view.as_ref(ctx), 60, ctx);
+            assert_eq!(lines[0], "✓ Created pomodoro-app-spec.md ▾");
+        });
+    });
+}
+
+#[test]
 fn finalized_create_replaces_streamed_payload_and_keeps_action_order() {
     App::test((), |mut app| async move {
         let action = create_action(
@@ -172,7 +200,7 @@ fn finalized_create_replaces_streamed_payload_and_keeps_action_order() {
                 vec![("First", "final first"), ("Second", "final second")]
             );
             let (lines, _) = render(view, 60, ctx);
-            assert_eq!(lines[0], "✓ Created plan ▾");
+            assert_eq!(lines[0], "✓ Created 2 documents ▾");
             let positions = ["First", "final first", "Second", "final second"].map(|needle| {
                 lines
                     .iter()

--- a/crates/warp_tui/src/tui_plan_view_tests.rs
+++ b/crates/warp_tui/src/tui_plan_view_tests.rs
@@ -1,0 +1,372 @@
+use std::rc::Rc;
+use std::sync::Arc;
+
+use ai::agent::action::{
+    CreateDocumentsRequest, DocumentDiff, DocumentToCreate, EditDocumentsRequest,
+};
+use ai::agent::action_result::{
+    AIAgentActionResultType, CreateDocumentsResult, DocumentContext, EditDocumentsResult,
+};
+use ai::document::{AIDocumentId, AIDocumentVersion};
+use warp::tui_export::{
+    AIAgentAction, AIAgentActionId, AIAgentActionResult, AIAgentActionType, AIConversationId,
+    Appearance, TaskId,
+};
+use warpui::platform::WindowStyle;
+use warpui::{AddWindowOptions, TypedActionView};
+use warpui_core::elements::tui::{TuiBufferExt, TuiRect};
+use warpui_core::presenter::tui::TuiPresenter;
+use warpui_core::{App, TuiView, ViewHandle};
+
+use super::{TuiPlanCodeKey, TuiPlanView, TuiPlanViewAction, TuiPlanViewEvent};
+use crate::test_fixtures::{add_test_action_model, TestHostView};
+use crate::tui_builder::TuiUiBuilder;
+
+#[test]
+fn streamed_create_renders_cached_markdown_and_code_children() {
+    App::test((), |mut app| async move {
+        let content = "# Overview\n\nBuild a **fast** timer.\n\n```rust\nfn main() {}\n```";
+        let action = create_action("create-1", [("pomodoro-app-spec.md", content)]);
+        let (view, _) = test_plan_view(&mut app, action.clone(), true);
+
+        app.read(|ctx| {
+            let view = view.as_ref(ctx);
+            assert!(view.renders_rich_body());
+            assert_eq!(view.documents.len(), 1);
+            assert_eq!(view.code_views.len(), 1);
+            assert_eq!(view.child_view_ids(ctx).len(), 1);
+            let formatted = view.documents[0]
+                .formatted
+                .as_ref()
+                .expect("streamed plan parses")
+                .clone();
+
+            let (lines, buffer) = render(view, 80, ctx);
+            assert_eq!(lines[0], "○ Creating pomodoro-app-spec.md +7 ▾");
+            assert!(lines.iter().any(|line| line.trim() == "Overview"));
+            assert!(lines
+                .iter()
+                .any(|line| line.trim() == "Build a fast timer."));
+            assert!(lines.iter().all(|line| !line.contains("**")));
+            assert_eq!(
+                buffer[(79, 1)].bg,
+                TuiUiBuilder::from_app(ctx).plan_background()
+            );
+
+            let code_key = TuiPlanCodeKey {
+                document_index: 0,
+                code_index: 0,
+            };
+            let code_view = view.code_views[&code_key].as_ref(ctx);
+            let (code_lines, _) = render_code(code_view, ctx);
+            assert!(code_lines.iter().any(|line| line.contains("fn main()")));
+
+            assert!(Arc::ptr_eq(
+                &formatted,
+                view.documents[0].formatted.as_ref().unwrap()
+            ));
+        });
+
+        view.update(&mut app, |view, ctx| {
+            let formatted = view.documents[0].formatted.as_ref().unwrap().clone();
+            view.sync_action(action, true, ctx);
+            assert!(Arc::ptr_eq(
+                &formatted,
+                view.documents[0].formatted.as_ref().unwrap()
+            ));
+        });
+
+        let original_code_view = app.read(|ctx| view.as_ref(ctx).child_view_ids(ctx)[0]);
+        view.update(&mut app, |view, ctx| {
+            view.sync_action(
+                create_action(
+                    "create-1",
+                    [(
+                        "pomodoro-app-spec.md",
+                        "# Overview\n\n```rust\nfn updated() {}\n```",
+                    )],
+                ),
+                true,
+                ctx,
+            );
+        });
+        app.read(|ctx| {
+            let code_view = view
+                .as_ref(ctx)
+                .code_views
+                .values()
+                .next()
+                .expect("updated plan keeps code child");
+            assert_eq!(view.as_ref(ctx).child_view_ids(ctx)[0], original_code_view);
+            let (code_lines, _) = render_code(code_view.as_ref(ctx), ctx);
+            assert!(code_lines.iter().any(|line| line.contains("fn updated()")));
+        });
+    });
+}
+
+#[test]
+fn finalized_create_replaces_streamed_payload_and_keeps_action_order() {
+    App::test((), |mut app| async move {
+        let action = create_action(
+            "create-1",
+            [("First", "streamed first"), ("Second", "streamed second")],
+        );
+        let (view, action_model) = test_plan_view(&mut app, action.clone(), true);
+        let conversation_id = AIConversationId::new();
+        let first_id = AIDocumentId::new();
+        let second_id = AIDocumentId::new();
+        action_model.update(&mut app, |model, ctx| {
+            model.apply_finished_action_result(
+                conversation_id,
+                action_result(
+                    &action,
+                    AIAgentActionResultType::CreateDocuments(CreateDocumentsResult::Success {
+                        created_documents: vec![
+                            document_context(first_id, "final first"),
+                            document_context(second_id, "final second"),
+                        ],
+                    }),
+                ),
+                ctx,
+            );
+        });
+
+        app.read(|ctx| {
+            let view = view.as_ref(ctx);
+            assert_eq!(
+                view.presentation
+                    .documents
+                    .iter()
+                    .map(|document| (document.title.as_str(), document.content.as_str()))
+                    .collect::<Vec<_>>(),
+                vec![("First", "final first"), ("Second", "final second")]
+            );
+            let (lines, _) = render(view, 60, ctx);
+            assert_eq!(lines[0], "✓ Created 2 documents +2 ▾");
+            let positions = ["First", "final first", "Second", "final second"].map(|needle| {
+                lines
+                    .iter()
+                    .position(|line| line.trim() == needle)
+                    .unwrap_or_else(|| panic!("missing {needle:?} in {lines:?}"))
+            });
+            assert!(positions.is_sorted());
+            let joined = lines.join("\n");
+            assert!(!joined.contains("streamed"));
+        });
+    });
+}
+
+#[test]
+fn finalized_edit_uses_full_result_content() {
+    App::test((), |mut app| async move {
+        let document_id = AIDocumentId::new();
+        let action = edit_action("edit-1", document_id);
+        let (view, action_model) = test_plan_view(&mut app, action.clone(), false);
+        app.read(|ctx| assert!(!view.as_ref(ctx).renders_rich_body()));
+
+        action_model.update(&mut app, |model, ctx| {
+            model.apply_finished_action_result(
+                AIConversationId::new(),
+                action_result(
+                    &action,
+                    AIAgentActionResultType::EditDocuments(EditDocumentsResult::Success {
+                        updated_documents: vec![document_context(
+                            document_id,
+                            "# Updated\n\nFinal body\n\n| Key | Value |\n| --- | --- |\n| Mode | Focus |",
+                        )],
+                    }),
+                ),
+                ctx,
+            );
+        });
+
+        app.read(|ctx| {
+            let view = view.as_ref(ctx);
+            assert!(view.presentation.documents[0]
+                .content
+                .contains("| Mode | Focus |"));
+            let (lines, _) = render(view, 50, ctx);
+            assert_eq!(lines[0], "✓ Updated Planning document +7 ▾");
+            assert!(lines.iter().any(|line| line.trim() == "Updated"));
+            assert!(lines.iter().any(|line| line.trim() == "Final body"));
+            let joined = lines.join("\n");
+            assert!(joined.contains("Key"));
+            assert!(joined.contains("Value"));
+            assert!(joined.contains("Mode"));
+            assert!(joined.contains("Focus"));
+            assert!(!joined.contains("| --- |"));
+        });
+    });
+}
+
+#[test]
+fn collapse_persists_across_payload_updates_and_invalidates_layout() {
+    App::test((), |mut app| async move {
+        let initial = create_action("create-1", [("Plan", "first body")]);
+        let (view, _) = test_plan_view(&mut app, initial, true);
+        let invalidations = Rc::new(std::cell::Cell::new(0));
+        let invalidations_for_subscription = invalidations.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_view(&view, move |_, event, _| match event {
+                TuiPlanViewEvent::LayoutChanged => {
+                    invalidations_for_subscription.set(invalidations_for_subscription.get() + 1);
+                }
+            });
+        });
+
+        view.update(&mut app, |view, ctx| {
+            view.handle_action(&TuiPlanViewAction::SetCollapsed(true), ctx);
+            view.sync_action(
+                create_action("create-1", [("Plan", "second body")]),
+                true,
+                ctx,
+            );
+        });
+
+        app.read(|ctx| {
+            let view = view.as_ref(ctx);
+            assert!(view.collapsed);
+            assert_eq!(view.presentation.documents[0].content, "second body");
+            let (lines, _) = render(view, 40, ctx);
+            assert_eq!(lines, vec!["○ Creating Plan +1 ▸"]);
+        });
+        assert!(invalidations.get() >= 2);
+    });
+}
+
+#[test]
+fn cancelled_create_discards_streamed_body_and_code_children() {
+    App::test((), |mut app| async move {
+        let action = create_action("create-1", [("Plan", "```rust\nfn streamed() {}\n```")]);
+        let (view, action_model) = test_plan_view(&mut app, action.clone(), true);
+        app.read(|ctx| assert_eq!(view.as_ref(ctx).code_views.len(), 1));
+
+        action_model.update(&mut app, |model, ctx| {
+            model.apply_finished_action_result(
+                AIConversationId::new(),
+                action_result(
+                    &action,
+                    AIAgentActionResultType::CreateDocuments(CreateDocumentsResult::Cancelled),
+                ),
+                ctx,
+            );
+        });
+
+        app.read(|ctx| {
+            let view = view.as_ref(ctx);
+            assert!(!view.renders_rich_body());
+            assert!(view.code_views.is_empty());
+        });
+    });
+}
+
+fn test_plan_view(
+    app: &mut App,
+    action: AIAgentAction,
+    output_streaming: bool,
+) -> (
+    ViewHandle<TuiPlanView>,
+    warpui_core::ModelHandle<warp::tui_export::BlocklistAIActionModel>,
+) {
+    app.add_singleton_model(|_| Appearance::mock());
+    let action_model = add_test_action_model(app);
+    let action_model_for_view = action_model.clone();
+    let view = app.update(|ctx| {
+        let (window_id, _) = ctx.add_tui_window(
+            AddWindowOptions {
+                window_style: WindowStyle::NotStealFocus,
+                ..Default::default()
+            },
+            |_| TestHostView,
+        );
+        ctx.add_typed_action_tui_view(window_id, |ctx| {
+            TuiPlanView::new(action, output_streaming, &action_model_for_view, ctx)
+        })
+    });
+    (view, action_model)
+}
+
+fn create_action<const N: usize>(id: &str, documents: [(&str, &str); N]) -> AIAgentAction {
+    AIAgentAction {
+        id: AIAgentActionId::from(id.to_owned()),
+        task_id: TaskId::new("task-1".to_owned()),
+        action: AIAgentActionType::CreateDocuments(CreateDocumentsRequest {
+            documents: documents
+                .into_iter()
+                .map(|(title, content)| DocumentToCreate {
+                    content: content.to_owned(),
+                    title: title.to_owned(),
+                })
+                .collect(),
+        }),
+        requires_result: true,
+    }
+}
+
+fn edit_action(id: &str, document_id: AIDocumentId) -> AIAgentAction {
+    AIAgentAction {
+        id: AIAgentActionId::from(id.to_owned()),
+        task_id: TaskId::new("task-1".to_owned()),
+        action: AIAgentActionType::EditDocuments(EditDocumentsRequest {
+            diffs: vec![DocumentDiff {
+                document_id,
+                search: "old".to_owned(),
+                replace: "new".to_owned(),
+            }],
+        }),
+        requires_result: true,
+    }
+}
+
+fn action_result(action: &AIAgentAction, result: AIAgentActionResultType) -> AIAgentActionResult {
+    AIAgentActionResult {
+        id: action.id.clone(),
+        task_id: action.task_id.clone(),
+        result,
+    }
+}
+
+fn document_context(document_id: AIDocumentId, content: &str) -> DocumentContext {
+    DocumentContext {
+        document_id,
+        document_version: AIDocumentVersion::default(),
+        content: content.to_owned(),
+        line_ranges: Vec::new(),
+    }
+}
+
+fn render(
+    view: &TuiPlanView,
+    width: u16,
+    app: &warpui_core::AppContext,
+) -> (Vec<String>, warpui_core::elements::tui::TuiBuffer) {
+    let mut presenter = TuiPresenter::new();
+    let frame = presenter.present_element(view.render(app), TuiRect::new(0, 0, width, 40), app);
+    let mut lines = frame
+        .buffer
+        .to_lines()
+        .into_iter()
+        .map(|line| line.trim_end().to_owned())
+        .collect::<Vec<_>>();
+    while lines.last().is_some_and(String::is_empty) {
+        lines.pop();
+    }
+    (lines, frame.buffer)
+}
+
+fn render_code(
+    view: &crate::tui_code_block_view::TuiCodeBlockView,
+    app: &warpui_core::AppContext,
+) -> (Vec<String>, warpui_core::elements::tui::TuiBuffer) {
+    let mut presenter = TuiPresenter::new();
+    let frame = presenter.present_element(view.render(app), TuiRect::new(0, 0, 40, 5), app);
+    (
+        frame
+            .buffer
+            .to_lines()
+            .into_iter()
+            .map(|line| line.trim_end().to_owned())
+            .collect(),
+        frame.buffer,
+    )
+}

--- a/crates/warp_tui/src/tui_plan_view_tests.rs
+++ b/crates/warp_tui/src/tui_plan_view_tests.rs
@@ -42,7 +42,7 @@ fn streamed_create_renders_cached_markdown_and_code_children() {
                 .clone();
 
             let (lines, buffer) = render(view, 80, ctx);
-            assert_eq!(lines[0], "Planning ▾");
+            assert_eq!(lines[0], "○ Creating pomodoro-app-spec.md ▾");
             assert_eq!(lines[1], "");
             assert_eq!(lines[2], "  Overview");
             assert!(lines
@@ -60,8 +60,12 @@ fn streamed_create_renders_cached_markdown_and_code_children() {
             assert_eq!(buffer[(79, 1)].bg, plan_background);
             assert_eq!(buffer[(0, 2)].bg, plan_background);
             assert_eq!(buffer[(79, 2)].bg, plan_background);
-            assert!(buffer[(0, 0)].modifier.contains(Modifier::BOLD));
-            assert!(!buffer[(0, 0)].modifier.contains(Modifier::UNDERLINED));
+            assert_eq!(
+                buffer[(11, 0)].fg,
+                TuiUiBuilder::from_app(ctx).link_text_style().fg.unwrap()
+            );
+            assert!(buffer[(11, 0)].modifier.contains(Modifier::BOLD));
+            assert!(!buffer[(11, 0)].modifier.contains(Modifier::UNDERLINED));
 
             let code_key = TuiPlanCodeKey {
                 document_index: 0,
@@ -115,6 +119,22 @@ fn streamed_create_renders_cached_markdown_and_code_children() {
 }
 
 #[test]
+fn plan_body_has_left_padding_without_right_padding() {
+    App::test((), |mut app| async move {
+        let content = format!("{}xyz", "word ".repeat(15));
+        assert_eq!(content.len(), 78);
+        let action = create_action("create-1", [("Plan", content.as_str())]);
+        let (view, _) = test_plan_view(&mut app, action, true);
+
+        app.read(|ctx| {
+            let (lines, buffer) = render(view.as_ref(ctx), 80, ctx);
+            assert_eq!(lines[2], format!("  {content}"));
+            assert_eq!(buffer[(79, 2)].symbol(), "z");
+        });
+    });
+}
+
+#[test]
 fn finalized_create_replaces_streamed_payload_and_keeps_action_order() {
     App::test((), |mut app| async move {
         let action = create_action(
@@ -152,7 +172,7 @@ fn finalized_create_replaces_streamed_payload_and_keeps_action_order() {
                 vec![("First", "final first"), ("Second", "final second")]
             );
             let (lines, _) = render(view, 60, ctx);
-            assert_eq!(lines[0], "Planning ▾");
+            assert_eq!(lines[0], "✓ Created plan ▾");
             let positions = ["First", "final first", "Second", "final second"].map(|needle| {
                 lines
                     .iter()
@@ -196,7 +216,7 @@ fn finalized_edit_uses_full_result_content() {
                 .content
                 .contains("| Mode | Focus |"));
             let (lines, _) = render(view, 50, ctx);
-            assert_eq!(lines[0], "Planning ▾");
+            assert_eq!(lines[0], "✓ Updated plan ▾");
             assert!(lines.iter().any(|line| line.trim() == "Updated"));
             assert!(lines.iter().any(|line| line.trim() == "Final body"));
             let joined = lines.join("\n");
@@ -238,7 +258,7 @@ fn collapse_persists_across_payload_updates_and_invalidates_layout() {
             assert!(view.collapsed);
             assert_eq!(view.presentation.documents[0].content, "second body");
             let (lines, _) = render(view, 40, ctx);
-            assert_eq!(lines, vec!["Planning ▸"]);
+            assert_eq!(lines, vec!["○ Creating Plan ▸"]);
         });
         assert!(invalidations.get() >= 2);
     });


### PR DESCRIPTION
## Description
Stack 4/4, based on #13730. Adds inline plan cards for create/edit document actions in the TUI transcript. Streamed create content renders immediately, successful finalized results replace it in action order, collapse state and code children persist across updates, and failed or cancelled actions retain the existing tool-status fallback.

The mock's `Ctrl+P` hint is intentionally omitted because that key remains bound to cursor-up in the TUI input.

## Linked Issue
https://linear.app/warpdotdev/issue/CODE-1849/track-markdown-rendering-for-agent-output-in-transcript-view

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
https://www.loom.com/share/566d90283f7f45fabe9eeb50447c289d
- `cargo check -p warp_tui --tests`
- `cargo nextest run -p warp_tui tui_plan_view --no-fail-fast`
- `cargo nextest run -p warp_tui agent_block --no-fail-fast`
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`

Integration tests were skipped as requested.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-IMPROVEMENT: Show create and edit document plans inline in the TUI transcript.

Co-Authored-By: Oz <oz-agent@warp.dev>