### PR TITLE
Restore TUI inline menu styling

### DIFF
--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -37,7 +37,6 @@ pub(crate) enum TuiInlineMenuRowStyle {
 }
 
 pub(crate) const MAX_INLINE_MENU_ROWS: u16 = 10;
-const INLINE_MENU_BORDER_ROWS: usize = 2;
 
 /// A presentation-only row in a TUI inline menu.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -457,7 +456,7 @@ impl TuiElement for TuiInlineMenuElement {
     }
 }
 
-/// Returns the result rows available after reserving border and header chrome.
+/// Returns the result rows available after reserving header chrome.
 pub(crate) const fn result_row_capacity(
     allocated_height: u16,
     has_title: bool,
@@ -465,7 +464,7 @@ pub(crate) const fn result_row_capacity(
 ) -> usize {
     let title_rows = if has_title { 1 } else { 0 };
     let tab_rows = if has_tabs { 1 } else { 0 };
-    (allocated_height as usize).saturating_sub(INLINE_MENU_BORDER_ROWS + title_rows + tab_rows)
+    (allocated_height as usize).saturating_sub(title_rows + tab_rows)
 }
 
 fn visible_result_capacity(snapshot: &TuiInlineMenuSnapshot, allocated_height: u16) -> usize {
@@ -487,7 +486,7 @@ fn build_inline_menu(
     allocated_height: u16,
 ) -> Box<dyn TuiElement> {
     let slash_command_columns = tui_two_column_layout(
-        usize::from(allocated_width.saturating_sub(2)),
+        usize::from(allocated_width),
         snapshot.rows.iter().filter_map(|row| {
             if row.style != TuiInlineMenuRowStyle::SlashCommand {
                 return None;
@@ -554,9 +553,7 @@ fn build_inline_menu(
         }
     }
 
-    TuiContainer::new(column.finish())
-        .with_border_style(builder.accent_border_style())
-        .finish()
+    column.finish()
 }
 
 /// Clamps stale scroll offsets and moves the viewport only as far as needed to

--- a/crates/warp_tui/src/inline_menu_tests.rs
+++ b/crates/warp_tui/src/inline_menu_tests.rs
@@ -121,6 +121,7 @@ fn conversation_like_snapshot_reuses_header_tabs_rows_and_selection() {
     let rendered = lines.join("\n");
     assert!(rendered.contains("Conversations"));
     assert!(rendered.contains("[All]  Pinned"));
+    assert!(!rendered.chars().any(|glyph| "┌┐└┘─│".contains(glyph)));
     assert!(rendered.contains("Current project  2 minutes ago"));
     assert!(rendered.contains("Archived"));
 }
@@ -162,8 +163,8 @@ fn conversation_like_snapshot_keeps_selection_visible_within_production_height()
     let rendered = lines.join("\n");
     assert!(rendered.contains("Conversations"));
     assert!(rendered.contains("[All]  Pinned"));
-    assert!(!rendered.contains("Conversation 0"));
-    assert!(!rendered.contains("Conversation 1"));
+    assert!(rendered.contains("Conversation 0"));
+    assert!(rendered.contains("Conversation 1"));
     assert!(rendered.contains("Conversation 2"));
     assert!(rendered.contains("Conversation 7"));
 }
@@ -198,34 +199,37 @@ fn slash_command_rows_match_figma_layout_and_colors() {
             let mut presenter = TuiPresenter::new();
             let frame = presenter.present_element(
                 render_inline_menu(&snapshot, &builder),
-                TuiRect::new(0, 0, 52, 4),
+                TuiRect::new(0, 0, 50, 2),
                 ctx,
             );
             let lines = frame.buffer.to_lines();
 
-            assert!(lines[1].starts_with("│/agent                       Start"));
-            assert!(lines[2].starts_with("│/plan                        Create"));
+            assert!(lines[0].starts_with("/agent                       Start"));
+            assert!(lines[1].starts_with("/plan                        Create"));
+            assert!(!lines
+                .iter()
+                .any(|line| line.chars().any(|glyph| "┌┐└┘─│".contains(glyph))));
             assert_eq!(
-                frame.buffer[(1, 1)].bg,
+                frame.buffer[(0, 0)].bg,
                 builder.slash_command_selection_background()
             );
             assert_eq!(
-                frame.buffer[(1, 1)].fg,
+                frame.buffer[(0, 0)].fg,
                 builder
                     .slash_command_selection_text_style()
                     .fg
                     .expect("selected slash-command text has a foreground")
             );
-            assert!(frame.buffer[(1, 1)].modifier.contains(Modifier::BOLD));
+            assert!(frame.buffer[(0, 0)].modifier.contains(Modifier::BOLD));
             assert_eq!(
-                frame.buffer[(1, 2)].fg,
+                frame.buffer[(0, 1)].fg,
                 builder
                     .slash_command_text_style()
                     .fg
                     .expect("slash-command text has a foreground")
             );
             assert_eq!(
-                frame.buffer[(30, 2)].fg,
+                frame.buffer[(29, 1)].fg,
                 builder
                     .primary_text_style()
                     .fg
@@ -251,7 +255,7 @@ fn long_slash_command_titles_are_ellipsized_before_the_description() {
         status: None,
     });
 
-    assert!(lines[1].starts_with("│/respond-to-pr-comments-i... Walk users"));
+    assert!(lines[0].starts_with("/respond-to-pr-comments-i... Walk users"));
 }
 
 #[test]
@@ -270,13 +274,12 @@ fn wide_slash_command_rows_expand_to_show_long_titles() {
             max_visible_rows: 8,
             status: None,
         },
-        82,
-        3,
+        80,
+        1,
     );
 
-    assert!(lines[1].starts_with(
-        "│/respond-to-pr-comments-in-blocklist Walk users through PR review comments"
-    ));
+    assert!(lines[0]
+        .starts_with("/respond-to-pr-comments-in-blocklist Walk users through PR review comments"));
 }
 
 #[test]
@@ -295,11 +298,11 @@ fn boundary_width_preserves_useful_title_and_description_columns() {
             max_visible_rows: 8,
             status: None,
         },
-        22,
-        3,
+        20,
+        1,
     );
 
-    assert!(lines[1].starts_with("│/agent  Start a new"));
+    assert!(lines[0].starts_with("/agent  Start a new"));
 }
 
 #[test]
@@ -318,11 +321,11 @@ fn narrow_slash_command_rows_use_the_full_width_for_titles() {
             max_visible_rows: 8,
             status: None,
         },
-        21,
-        3,
+        19,
+        1,
     );
 
-    assert_eq!(lines[1], "│/123456789012345...│");
+    assert_eq!(lines[0], "/123456789012345...");
 }
 
 #[test]

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -655,8 +655,9 @@ impl TuiInputView {
         let builder = TuiUiBuilder::from_app(ctx);
         let mut styles = TuiEditorStyles::default();
         if let Some(range) = self
-            .active_inline_menu(ctx)
-            .and_then(|inline_menu| inline_menu.input_highlight_range(ctx))
+            .inline_menus
+            .iter()
+            .find_map(|inline_menu| inline_menu.input_highlight_range(ctx))
         {
             styles
                 .text_overrides
@@ -670,8 +671,9 @@ impl TuiInputView {
                 event_ctx.dispatch_typed_action(TuiInputAction::from(action))
             });
         if let Some(hint_text) = self
-            .active_inline_menu(ctx)
-            .and_then(|inline_menu| inline_menu.input_argument_hint_text(ctx))
+            .inline_menus
+            .iter()
+            .find_map(|inline_menu| inline_menu.input_argument_hint_text(ctx))
         {
             element = element.with_trailing_ghost_text(hint_text, builder.dim_text_style());
         }

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -53,7 +53,7 @@ fn input_escape_context_is_present_only_while_escape_is_handled() {
 }
 
 #[test]
-fn slash_command_argument_hint_renders_as_ghost_text() {
+fn slash_command_argument_hint_renders_after_menu_closes() {
     App::test((), |mut app| async move {
         app.update(|ctx| {
             let (view, menu_model, _) = build_view_with_inline_menu(ctx);
@@ -61,6 +61,10 @@ fn slash_command_argument_hint_renders_as_ghost_text() {
             view.update(ctx, |view, ctx| view.set_text(input, ctx));
             menu_model.update(ctx, |model, _| {
                 model.set_argument_hint_text_for_test(Some("<optional filename>"));
+            });
+            menu_model.update(ctx, |model, ctx| {
+                model.accept_selected(ctx);
+                assert!(!model.is_open());
             });
 
             let buffer = render_input_buffer(&view, ctx);
@@ -103,13 +107,17 @@ fn render_input_buffer(view: &ViewHandle<TuiInputView>, ctx: &AppContext) -> Tui
 }
 
 #[test]
-fn recognized_slash_command_prefix_matches_menu_color() {
+fn recognized_slash_command_prefix_matches_menu_color_after_menu_closes() {
     App::test((), |mut app| async move {
         app.update(|ctx| {
             let (view, menu_model, _) = build_view_with_inline_menu(ctx);
             view.update(ctx, |view, ctx| view.set_text("/plan argument", ctx));
             menu_model.update(ctx, |model, _| {
                 model.set_highlighted_prefix_len_for_test(Some(5));
+            });
+            menu_model.update(ctx, |model, ctx| {
+                model.accept_selected(ctx);
+                assert!(!model.is_open());
             });
 
             let buffer = render_input_buffer(&view, ctx);


### PR DESCRIPTION
## Description

Fixes two regressions from #13668's generalized TUI inline-menu routing:

- Removes the outer border that #13604 had removed to match the TUI designs, and returns the reserved rows and columns to menu content.
- Restores the pre-#13668 decoration behavior by resolving slash-command highlights and argument hints from persistent menu handles rather than only the currently open menu. Recognized commands such as `/plan ` therefore remain highlighted after exact-match handling or menu acceptance closes the menu.

Slash-command, model, and conversation menus are borderless. The input retains its border, and active-menu routing for navigation, acceptance, and Escape handling is unchanged.

## Linked Issue

N/A — regressions from #13668.

## Testing

- [x] `./script/format`
- [x] `cargo nextest run -p warp_tui -E 'test(slash_command_argument_hint_renders_after_menu_closes) | test(recognized_slash_command_prefix_matches_menu_color_after_menu_closes)'`
- [ ] Clippy was not run at the request of the author.
- [ ] Manual TUI verification was not run.

### Screenshots / Videos

Matches the borderless inline-menu treatment in the [TUI Figma mock](https://www.figma.com/design/yg5nbPZuGoAszHS3Rhvehu/TUI?node-id=323-17389&m=dev).

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed unintended borders and missing slash-command highlighting in Warp TUI inline menus.

[Warp Agent conversation](https://staging.warp.dev/conversation/93075ca5-5afb-4e3a-b778-70afb1c62d94)

Co-Authored-By: Oz <oz-agent@warp.dev>