### PR TITLE
Prevent overlapping TUI inline menus

### DIFF
--- a/crates/warp_tui/src/conversation_menu.rs
+++ b/crates/warp_tui/src/conversation_menu.rs
@@ -19,6 +19,7 @@ use crate::inline_menu::{
     result_row_capacity, TuiInlineMenuHeader, TuiInlineMenuListState, TuiInlineMenuRow,
     TuiInlineMenuRowStyle, TuiInlineMenuSnapshot, TuiInlineMenuStatus, MAX_INLINE_MENU_ROWS,
 };
+use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
 
 const MAX_VISIBLE_ROWS: usize = result_row_capacity(MAX_INLINE_MENU_ROWS, true, false);
 
@@ -47,6 +48,7 @@ pub(crate) enum TuiConversationMenuEvent {
 /// Query, selection, and model-subscription state for `/conversations`.
 pub(crate) struct TuiConversationMenuModel {
     input_editor: ModelHandle<CodeEditorModel>,
+    suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
     conversation_selection: ConversationSelectionHandle,
     window_id: WindowId,
     state: TuiConversationMenuState,
@@ -57,25 +59,27 @@ impl TuiConversationMenuModel {
     /// Creates a closed conversation menu and subscribes it to input/model changes.
     pub(crate) fn new(
         input_editor: ModelHandle<CodeEditorModel>,
+        suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
         conversation_selection: ConversationSelectionHandle,
         window_id: WindowId,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         ctx.subscribe_to_model(&input_editor, |model, _, event, ctx| {
-            if model.is_open() && matches!(event, CodeEditorModelEvent::ContentChanged { .. }) {
+            if model.is_open(ctx) && matches!(event, CodeEditorModelEvent::ContentChanged { .. }) {
                 model.refresh_rows(ctx);
             }
         });
         ctx.subscribe_to_model(
             &AgentConversationsModel::handle(ctx),
             |model, _, _: &AgentConversationsModelEvent, ctx| {
-                if model.is_open() {
+                if model.is_open(ctx) {
                     model.refresh_rows(ctx);
                 }
             },
         );
         Self {
             input_editor,
+            suggestions_mode,
             conversation_selection,
             window_id,
             state: TuiConversationMenuState::Closed,
@@ -84,15 +88,28 @@ impl TuiConversationMenuModel {
     }
 
     /// Returns whether the conversation menu is currently open.
-    pub(crate) fn is_open(&self) -> bool {
+    fn has_open_state(&self) -> bool {
         matches!(self.state, TuiConversationMenuState::Open { .. })
+    }
+
+    pub(crate) fn is_open(&self, ctx: &AppContext) -> bool {
+        self.has_open_state()
+            && self.suggestions_mode.as_ref(ctx).mode() == TuiInputSuggestionsMode::ConversationMenu
     }
 
     /// Opens the menu and registers it as an active conversation-list consumer.
     pub(crate) fn open(&mut self, ctx: &mut ModelContext<Self>) {
-        if self.is_open() {
+        if self.has_open_state() {
             return;
         }
+        let did_open = self.suggestions_mode.update(ctx, |mode, ctx| {
+            mode.try_open(TuiInputSuggestionsMode::ConversationMenu, ctx)
+        });
+        if !did_open {
+            return;
+        }
+        self.input_editor
+            .update(ctx, |editor, ctx| editor.clear_buffer(ctx));
         let mut list = TuiInlineMenuListState::default();
         list.set_loading(true);
         self.state = TuiConversationMenuState::Open { list };
@@ -107,7 +124,7 @@ impl TuiConversationMenuModel {
 
     /// Closes the menu and clears its query buffer.
     pub(crate) fn dismiss(&mut self, ctx: &mut ModelContext<Self>) {
-        if !self.is_open() {
+        if !self.is_open(ctx) {
             return;
         }
         self.close(ctx);
@@ -136,8 +153,11 @@ impl TuiConversationMenuModel {
     /// Returns the stable ID of the selected row without closing the menu.
     pub(crate) fn accept_selected(
         &mut self,
-        _ctx: &mut ModelContext<Self>,
+        ctx: &mut ModelContext<Self>,
     ) -> Option<AgentConversationEntryId> {
+        if !self.is_open(ctx) {
+            return None;
+        }
         let selected_id = match &self.state {
             TuiConversationMenuState::Open { list } => list.selected_row().map(|row| row.id),
             TuiConversationMenuState::Closed => None,
@@ -146,7 +166,10 @@ impl TuiConversationMenuModel {
     }
 
     /// Returns the render snapshot for the open menu.
-    pub(crate) fn snapshot(&self) -> Option<TuiInlineMenuSnapshot> {
+    pub(crate) fn snapshot(&self, ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
+        if !self.is_open(ctx) {
+            return None;
+        }
         let TuiConversationMenuState::Open { list } = &self.state else {
             return None;
         };
@@ -183,13 +206,18 @@ impl TuiConversationMenuModel {
 
     /// Closes the menu and unregisters its conversation-list consumer.
     fn close(&mut self, ctx: &mut ModelContext<Self>) {
-        self.state = TuiConversationMenuState::Closed;
-        let window_id = self.window_id;
-        let model_id = ctx.model_id();
-        AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
-            model.register_view_closed(window_id, model_id, ctx);
+        if self.has_open_state() {
+            self.state = TuiConversationMenuState::Closed;
+            let window_id = self.window_id;
+            let model_id = ctx.model_id();
+            AgentConversationsModel::handle(ctx).update(ctx, |model, ctx| {
+                model.register_view_closed(window_id, model_id, ctx);
+            });
+            ctx.emit(TuiConversationMenuEvent::Updated);
+        }
+        self.suggestions_mode.update(ctx, |mode, ctx| {
+            mode.close_if_active(TuiInputSuggestionsMode::ConversationMenu, ctx);
         });
-        ctx.emit(TuiConversationMenuEvent::Updated);
     }
 
     /// Rebuilds rows from the current query while preserving stable selection.

--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -14,6 +14,7 @@ use warpui_core::elements::CrossAxisAlignment;
 use warpui_core::{AppContext, ModelHandle};
 
 use crate::conversation_menu::TuiConversationMenuModel;
+use crate::input_suggestions_mode::TuiInputSuggestionsMode;
 use crate::model_menu::TuiModelMenuModel;
 use crate::skills_menu::TuiSkillMenuModel;
 use crate::slash_commands::TuiSlashCommandModel;
@@ -35,6 +36,16 @@ const SLASH_COMMAND_COLUMN_CONSTRAINTS: TuiTwoColumnConstraints = TuiTwoColumnCo
 pub(crate) enum TuiInlineMenuRowStyle {
     Default,
     InlineMenuItem,
+}
+pub(crate) fn active_inline_menu(
+    inline_menus: &[TuiInlineMenu],
+    mode: TuiInputSuggestionsMode,
+    ctx: &AppContext,
+) -> Option<TuiInlineMenu> {
+    inline_menus
+        .iter()
+        .find(|menu| menu.mode() == mode && menu.is_open(ctx))
+        .cloned()
 }
 
 pub(crate) const MAX_INLINE_MENU_ROWS: u16 = 10;
@@ -213,6 +224,8 @@ pub(crate) enum TuiInlineMenuAccepted {
 
 /// Type-erased operations shared by TUI inline-menu model handles.
 pub(crate) trait TuiInlineMenuHandle {
+    /// Returns the input-suggestions mode represented by this menu.
+    fn mode(&self) -> TuiInputSuggestionsMode;
     /// Returns whether this menu is open.
     fn is_open(&self, ctx: &AppContext) -> bool;
     /// Returns the input range highlighted by this menu.
@@ -242,6 +255,10 @@ impl TuiInlineMenu {
     }
     pub(crate) fn is_open(&self, ctx: &AppContext) -> bool {
         self.0.is_open(ctx)
+    }
+
+    pub(crate) fn mode(&self) -> TuiInputSuggestionsMode {
+        self.0.mode()
     }
 
     pub(crate) fn render(&self, ctx: &AppContext) -> Option<Box<dyn TuiElement>> {
@@ -278,8 +295,11 @@ impl TuiInlineMenu {
 }
 
 impl TuiInlineMenuHandle for ModelHandle<TuiSlashCommandModel> {
+    fn mode(&self) -> TuiInputSuggestionsMode {
+        TuiInputSuggestionsMode::SlashCommands
+    }
     fn is_open(&self, ctx: &AppContext) -> bool {
-        self.as_ref(ctx).is_open()
+        self.as_ref(ctx).is_open(ctx)
     }
     fn input_highlight_range(&self, ctx: &AppContext) -> Option<Range<CharOffset>> {
         self.as_ref(ctx).highlighted_prefix_range()
@@ -307,13 +327,16 @@ impl TuiInlineMenuHandle for ModelHandle<TuiSlashCommandModel> {
     }
 
     fn snapshot(&self, ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
-        self.as_ref(ctx).snapshot()
+        self.as_ref(ctx).snapshot(ctx)
     }
 }
 
 impl TuiInlineMenuHandle for ModelHandle<TuiConversationMenuModel> {
+    fn mode(&self) -> TuiInputSuggestionsMode {
+        TuiInputSuggestionsMode::ConversationMenu
+    }
     fn is_open(&self, ctx: &AppContext) -> bool {
-        self.as_ref(ctx).is_open()
+        self.as_ref(ctx).is_open(ctx)
     }
 
     fn input_highlight_range(&self, _ctx: &AppContext) -> Option<Range<CharOffset>> {
@@ -342,13 +365,16 @@ impl TuiInlineMenuHandle for ModelHandle<TuiConversationMenuModel> {
     }
 
     fn snapshot(&self, ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
-        self.as_ref(ctx).snapshot()
+        self.as_ref(ctx).snapshot(ctx)
     }
 }
 
 impl TuiInlineMenuHandle for ModelHandle<TuiModelMenuModel> {
+    fn mode(&self) -> TuiInputSuggestionsMode {
+        TuiInputSuggestionsMode::ModelSelector
+    }
     fn is_open(&self, ctx: &AppContext) -> bool {
-        self.as_ref(ctx).is_open()
+        self.as_ref(ctx).is_open(ctx)
     }
     fn input_highlight_range(&self, _ctx: &AppContext) -> Option<Range<CharOffset>> {
         None
@@ -368,7 +394,7 @@ impl TuiInlineMenuHandle for ModelHandle<TuiModelMenuModel> {
 
     fn accept(&self, ctx: &mut AppContext) -> Option<TuiInlineMenuAccepted> {
         self.as_ref(ctx)
-            .accept_selected()
+            .accept_selected(ctx)
             .map(TuiInlineMenuAccepted::Model)
     }
 
@@ -377,13 +403,16 @@ impl TuiInlineMenuHandle for ModelHandle<TuiModelMenuModel> {
     }
 
     fn snapshot(&self, ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
-        self.as_ref(ctx).snapshot()
+        self.as_ref(ctx).snapshot(ctx)
     }
 }
 
 impl TuiInlineMenuHandle for ModelHandle<TuiSkillMenuModel> {
+    fn mode(&self) -> TuiInputSuggestionsMode {
+        TuiInputSuggestionsMode::SkillMenu
+    }
     fn is_open(&self, ctx: &AppContext) -> bool {
-        self.as_ref(ctx).is_open()
+        self.as_ref(ctx).is_open(ctx)
     }
 
     fn input_highlight_range(&self, _ctx: &AppContext) -> Option<Range<CharOffset>> {
@@ -417,7 +446,7 @@ impl TuiInlineMenuHandle for ModelHandle<TuiSkillMenuModel> {
     }
 
     fn snapshot(&self, ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
-        self.as_ref(ctx).snapshot()
+        self.as_ref(ctx).snapshot(ctx)
     }
 }
 

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -39,8 +39,9 @@ use warpui_core::{AppContext, Entity, ModelHandle, TuiView, TypedActionView, Vie
 
 use super::kill_buffer::KillBuffer;
 use crate::editor_element::{TuiEditorAction, TuiEditorElement, TuiEditorStyles};
-use crate::inline_menu::{TuiInlineMenu, TuiInlineMenuAccepted};
+use crate::inline_menu::{active_inline_menu, TuiInlineMenu, TuiInlineMenuAccepted};
 use crate::input_mode_policy::{self, AI_LOCKED_CONFIG, SHELL_LOCKED_CONFIG};
+use crate::input_suggestions_mode::TuiInputSuggestionsModeModel;
 use crate::keybindings::TUI_BINDING_GROUP;
 use crate::tui_builder::TuiUiBuilder;
 
@@ -570,6 +571,8 @@ pub struct TuiInputView {
     model: ModelHandle<CodeEditorModel>,
     /// Shared input-mode state driving `!` shell-mode handling.
     input_mode: ModelHandle<BlocklistAIInputModel>,
+    /// Single authoritative menu mode, mirroring the GUI input's suggestions mode.
+    suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
     /// Generalized inline menus used to route prioritized menu actions.
     inline_menus: Vec<TuiInlineMenu>,
     /// Single-entry kill buffer for `Ctrl+K` / `Ctrl+U` / `Ctrl+Y`.
@@ -602,6 +605,7 @@ impl TuiInputView {
     pub(crate) fn new(
         model: ModelHandle<CodeEditorModel>,
         input_mode: ModelHandle<BlocklistAIInputModel>,
+        suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
         inline_menus: Vec<TuiInlineMenu>,
         ctx: &mut ViewContext<Self>,
     ) -> Self {
@@ -613,9 +617,11 @@ impl TuiInputView {
         // The model only emits on real config changes, and rendering branches
         // on the config (shell-mode gutter/border), so every event re-renders.
         ctx.subscribe_to_model(&input_mode, |_, _, _, ctx| ctx.notify());
+        ctx.subscribe_to_model(&suggestions_mode, |_, _, _, ctx| ctx.notify());
         Self {
             model,
             input_mode,
+            suggestions_mode,
             inline_menus,
             kill_buffer: KillBuffer::default(),
             max_visible_rows: 6,
@@ -1160,10 +1166,11 @@ impl TuiInputView {
     }
 
     fn active_inline_menu(&self, ctx: &AppContext) -> Option<TuiInlineMenu> {
-        self.inline_menus
-            .iter()
-            .find(|menu| menu.is_open(ctx))
-            .cloned()
+        active_inline_menu(
+            &self.inline_menus,
+            self.suggestions_mode.as_ref(ctx).mode(),
+            ctx,
+        )
     }
 
     // ── Kill / yank ───────────────────────────────────────────────────────────

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -34,6 +34,7 @@ use super::{
 use crate::editor_element::TuiEditorElement;
 use crate::inline_menu::TuiInlineMenu;
 use crate::input_mode_policy::TuiInputModePolicy;
+use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
 use crate::model_menu::TuiModelMenuModel;
 use crate::slash_commands::{TuiSlashCommandModel, TuiSlashCommandRow};
 use crate::test_fixtures::add_test_semantic_selection;
@@ -52,6 +53,15 @@ fn input_escape_context_is_present_only_while_escape_is_handled() {
     assert!(open.set.contains(INPUT_HANDLES_ESCAPE_FLAG));
 }
 
+fn add_suggestions_mode(
+    ctx: &mut AppContext,
+    initial_mode: TuiInputSuggestionsMode,
+) -> ModelHandle<TuiInputSuggestionsModeModel> {
+    let mode = ctx.add_model(|_| TuiInputSuggestionsModeModel::new());
+    mode.update(ctx, |mode, ctx| mode.set_mode(initial_mode, ctx));
+    mode
+}
+
 #[test]
 fn slash_command_argument_hint_renders_after_menu_closes() {
     App::test((), |mut app| async move {
@@ -64,7 +74,7 @@ fn slash_command_argument_hint_renders_after_menu_closes() {
             });
             menu_model.update(ctx, |model, ctx| {
                 model.accept_selected(ctx);
-                assert!(!model.is_open());
+                assert!(!model.is_open(ctx));
             });
 
             let buffer = render_input_buffer(&view, ctx);
@@ -117,7 +127,7 @@ fn recognized_slash_command_prefix_matches_menu_color_after_menu_closes() {
             });
             menu_model.update(ctx, |model, ctx| {
                 model.accept_selected(ctx);
-                assert!(!model.is_open());
+                assert!(!model.is_open(ctx));
             });
 
             let buffer = render_input_buffer(&view, ctx);
@@ -138,6 +148,7 @@ fn build_view(ctx: &mut AppContext) -> ViewHandle<TuiInputView> {
     ctx.add_singleton_model(|_| Appearance::mock());
     add_test_semantic_selection(ctx);
     let input_mode = BlocklistAIInputModel::mock(Rc::new(TuiInputModePolicy), ctx);
+    let suggestions_mode = add_suggestions_mode(ctx, TuiInputSuggestionsMode::Closed);
     let (_window_id, view) = ctx.add_tui_window(
         AddWindowOptions {
             window_style: WindowStyle::NotStealFocus,
@@ -145,7 +156,7 @@ fn build_view(ctx: &mut AppContext) -> ViewHandle<TuiInputView> {
         },
         |ctx| {
             let model = ctx.add_model(|ctx| CodeEditorModel::new_tui(W, ctx));
-            TuiInputView::new(model, input_mode, Vec::new(), ctx)
+            TuiInputView::new(model, input_mode, suggestions_mode, Vec::new(), ctx)
         },
     );
     view
@@ -162,6 +173,7 @@ fn build_view_with_inline_menu(
     add_test_semantic_selection(ctx);
     let input_model = ctx.add_model(|ctx| CodeEditorModel::new_tui(W, ctx));
     let input_mode = BlocklistAIInputModel::mock(Rc::new(TuiInputModePolicy), ctx);
+    let suggestions_mode = add_suggestions_mode(ctx, TuiInputSuggestionsMode::SlashCommands);
     let mixer = ctx.add_model(|_| SlashCommandMixer::new());
     let ids = [SlashCommandId::new(), SlashCommandId::new()];
     let rows = ids
@@ -173,15 +185,30 @@ fn build_view_with_inline_menu(
             action: AcceptSlashCommandOrSavedPrompt::SlashCommand { id: *id },
         })
         .collect();
-    let menu_model =
-        ctx.add_model(|_| TuiSlashCommandModel::new_for_test(input_model.clone(), mixer, rows, 0));
+    let menu_model = ctx.add_model(|_| {
+        TuiSlashCommandModel::new_for_test(
+            input_model.clone(),
+            suggestions_mode.clone(),
+            mixer,
+            rows,
+            0,
+        )
+    });
     let inline_menu = TuiInlineMenu::new(menu_model.clone());
     let (_window_id, view) = ctx.add_tui_window(
         AddWindowOptions {
             window_style: WindowStyle::NotStealFocus,
             ..Default::default()
         },
-        move |ctx| TuiInputView::new(input_model, input_mode, vec![inline_menu], ctx),
+        move |ctx| {
+            TuiInputView::new(
+                input_model,
+                input_mode,
+                suggestions_mode,
+                vec![inline_menu],
+                ctx,
+            )
+        },
     );
     (view, menu_model, ids)
 }
@@ -197,10 +224,16 @@ fn build_view_with_model_menu(
     add_test_semantic_selection(ctx);
     let input_model = ctx.add_model(|ctx| CodeEditorModel::new_tui(W, ctx));
     let input_mode = BlocklistAIInputModel::mock(Rc::new(TuiInputModePolicy), ctx);
+    let suggestions_mode = add_suggestions_mode(ctx, TuiInputSuggestionsMode::ModelSelector);
     let id = LLMId::from("gpt-5");
     let id_for_model = id.clone();
     let menu_model = ctx.add_model(|_| {
-        TuiModelMenuModel::new_for_test(input_model.clone(), vec![(id_for_model, true)], 0)
+        TuiModelMenuModel::new_for_test(
+            input_model.clone(),
+            suggestions_mode.clone(),
+            vec![(id_for_model, true)],
+            0,
+        )
     });
     let inline_menu = TuiInlineMenu::new(menu_model.clone());
     let (_window_id, view) = ctx.add_tui_window(
@@ -208,7 +241,15 @@ fn build_view_with_model_menu(
             window_style: WindowStyle::NotStealFocus,
             ..Default::default()
         },
-        move |ctx| TuiInputView::new(input_model, input_mode, vec![inline_menu], ctx),
+        move |ctx| {
+            TuiInputView::new(
+                input_model,
+                input_mode,
+                suggestions_mode,
+                vec![inline_menu],
+                ctx,
+            )
+        },
     );
     (view, menu_model, id)
 }
@@ -255,7 +296,7 @@ fn inline_menu_accept_dismisses_before_emitting_unchanged_payload() {
                 {
                     accepted_for_subscription
                         .borrow_mut()
-                        .push((*id, !menu_for_subscription.as_ref(ctx).is_open()));
+                        .push((*id, !menu_for_subscription.as_ref(ctx).is_open(ctx)));
                 }
             });
             (view, menu_model, ids, accepted)
@@ -265,7 +306,7 @@ fn inline_menu_accept_dismisses_before_emitting_unchanged_payload() {
         });
         app.read(|ctx| {
             assert_eq!(accepted.borrow().as_slice(), &[(ids[0], true)]);
-            assert!(!menu_model.as_ref(ctx).is_open());
+            assert!(!menu_model.as_ref(ctx).is_open(ctx));
         });
     });
 }
@@ -288,7 +329,7 @@ fn model_menu_accept_emits_selected_id_and_stays_open_for_persistence() {
         app.update(|ctx| dispatch(&view, ctx, &[TuiInputAction::Submit]));
         app.read(|ctx| {
             assert_eq!(accepted.borrow().as_slice(), &[id]);
-            assert!(menu_model.as_ref(ctx).is_open());
+            assert!(menu_model.as_ref(ctx).is_open(ctx));
         });
     });
 }
@@ -317,7 +358,7 @@ fn escape_dismisses_menu_and_closed_menu_submit_falls_through() {
         });
 
         app.update(|ctx| {
-            assert!(!menu_model.as_ref(ctx).is_open());
+            assert!(!menu_model.as_ref(ctx).is_open(ctx));
             assert!(view
                 .as_ref(ctx)
                 .keymap_context(ctx)

--- a/crates/warp_tui/src/input_suggestions_mode.rs
+++ b/crates/warp_tui/src/input_suggestions_mode.rs
@@ -1,0 +1,93 @@
+//! Authoritative input-suggestions mode for the TUI.
+//!
+//! This mirrors the GUI's `InputSuggestionsModeModel`: one mode owns input-menu
+//! rendering and actions at a time, and replacing a visible mode transitions
+//! through `Closed` before opening the next mode.
+
+use warpui_core::{Entity, ModelContext};
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TuiInputSuggestionsMode {
+    #[default]
+    Closed,
+    SlashCommands,
+    ConversationMenu,
+    ModelSelector,
+    SkillMenu,
+}
+
+impl TuiInputSuggestionsMode {
+    pub(crate) fn is_visible(self) -> bool {
+        self != Self::Closed
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TuiInputSuggestionsModeEvent {
+    pub(crate) mode: TuiInputSuggestionsMode,
+}
+
+pub(crate) struct TuiInputSuggestionsModeModel {
+    mode: TuiInputSuggestionsMode,
+}
+
+impl TuiInputSuggestionsModeModel {
+    pub(crate) fn new() -> Self {
+        Self {
+            mode: TuiInputSuggestionsMode::Closed,
+        }
+    }
+
+    pub(crate) fn mode(&self) -> TuiInputSuggestionsMode {
+        self.mode
+    }
+
+    pub(crate) fn set_mode(&mut self, mode: TuiInputSuggestionsMode, ctx: &mut ModelContext<Self>) {
+        if self.mode == mode {
+            return;
+        }
+
+        if self.mode.is_visible() && mode.is_visible() {
+            self.mode = TuiInputSuggestionsMode::Closed;
+            ctx.emit(TuiInputSuggestionsModeEvent { mode: self.mode });
+        }
+
+        self.mode = mode;
+        ctx.emit(TuiInputSuggestionsModeEvent { mode });
+    }
+    pub(crate) fn try_open(
+        &mut self,
+        mode: TuiInputSuggestionsMode,
+        ctx: &mut ModelContext<Self>,
+    ) -> bool {
+        match self.mode {
+            TuiInputSuggestionsMode::Closed => {
+                self.set_mode(mode, ctx);
+                true
+            }
+            active_mode if active_mode == mode => true,
+            TuiInputSuggestionsMode::SlashCommands
+            | TuiInputSuggestionsMode::ConversationMenu
+            | TuiInputSuggestionsMode::ModelSelector
+            | TuiInputSuggestionsMode::SkillMenu => false,
+        }
+    }
+
+    pub(crate) fn close_if_active(
+        &mut self,
+        mode: TuiInputSuggestionsMode,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        if self.mode == mode {
+            self.set_mode(TuiInputSuggestionsMode::Closed, ctx);
+        }
+    }
+}
+
+impl Entity for TuiInputSuggestionsModeModel {
+    type Event = TuiInputSuggestionsModeEvent;
+}
+
+#[cfg(test)]
+#[path = "input_suggestions_mode_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/input_suggestions_mode_tests.rs
+++ b/crates/warp_tui/src/input_suggestions_mode_tests.rs
@@ -1,0 +1,70 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use warpui_core::App;
+
+use super::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
+
+#[test]
+fn replacing_a_visible_mode_emits_close_before_the_new_mode() {
+    App::test((), |mut app| async move {
+        let (mode, events) = app.update(|ctx| {
+            let events = Rc::new(RefCell::new(Vec::new()));
+            let events_for_subscription = events.clone();
+            let mode = ctx.add_model(|_| TuiInputSuggestionsModeModel::new());
+            ctx.subscribe_to_model(&mode, move |_, event, _| {
+                events_for_subscription.borrow_mut().push(event.mode);
+            });
+            (mode, events)
+        });
+
+        app.update(|ctx| {
+            mode.update(ctx, |mode, ctx| {
+                mode.set_mode(TuiInputSuggestionsMode::ConversationMenu, ctx);
+                mode.set_mode(TuiInputSuggestionsMode::ModelSelector, ctx);
+            });
+        });
+
+        assert_eq!(
+            events.borrow().as_slice(),
+            &[
+                TuiInputSuggestionsMode::ConversationMenu,
+                TuiInputSuggestionsMode::Closed,
+                TuiInputSuggestionsMode::ModelSelector,
+            ]
+        );
+    });
+}
+
+#[test]
+fn opening_a_menu_does_not_replace_an_active_menu() {
+    App::test((), |mut app| async move {
+        let mode = app.add_model(|_| TuiInputSuggestionsModeModel::new());
+        mode.update(&mut app, |mode, ctx| {
+            assert!(mode.try_open(TuiInputSuggestionsMode::ConversationMenu, ctx));
+            assert!(!mode.try_open(TuiInputSuggestionsMode::SlashCommands, ctx));
+            assert!(!mode.try_open(TuiInputSuggestionsMode::ModelSelector, ctx));
+            assert!(!mode.try_open(TuiInputSuggestionsMode::SkillMenu, ctx));
+            assert_eq!(mode.mode(), TuiInputSuggestionsMode::ConversationMenu);
+
+            mode.set_mode(TuiInputSuggestionsMode::Closed, ctx);
+            assert!(mode.try_open(TuiInputSuggestionsMode::SkillMenu, ctx));
+            assert!(!mode.try_open(TuiInputSuggestionsMode::SlashCommands, ctx));
+            assert!(!mode.try_open(TuiInputSuggestionsMode::ConversationMenu, ctx));
+            assert!(!mode.try_open(TuiInputSuggestionsMode::ModelSelector, ctx));
+            assert_eq!(mode.mode(), TuiInputSuggestionsMode::SkillMenu);
+        });
+    });
+}
+
+#[test]
+fn closing_an_inactive_mode_preserves_the_active_mode() {
+    App::test((), |mut app| async move {
+        let mode = app.add_model(|_| TuiInputSuggestionsModeModel::new());
+        mode.update(&mut app, |mode, ctx| {
+            mode.set_mode(TuiInputSuggestionsMode::ConversationMenu, ctx);
+            mode.close_if_active(TuiInputSuggestionsMode::SlashCommands, ctx);
+            assert_eq!(mode.mode(), TuiInputSuggestionsMode::ConversationMenu);
+        });
+    });
+}

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -24,6 +24,7 @@ mod editor_element;
 mod exit_confirmation;
 mod inline_menu;
 mod input_mode_policy;
+mod input_suggestions_mode;
 mod keybindings;
 mod model_menu;
 mod resume;

--- a/crates/warp_tui/src/model_menu.rs
+++ b/crates/warp_tui/src/model_menu.rs
@@ -9,6 +9,7 @@ use crate::inline_menu::{
     result_row_capacity, TuiInlineMenuHeader, TuiInlineMenuListState, TuiInlineMenuRow,
     TuiInlineMenuRowStyle, TuiInlineMenuSnapshot, TuiInlineMenuStatus, MAX_INLINE_MENU_ROWS,
 };
+use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
 
 const MAX_VISIBLE_ROWS: usize = result_row_capacity(MAX_INLINE_MENU_ROWS, true, false);
 
@@ -33,21 +34,23 @@ pub(crate) struct TuiModelMenuEvent;
 
 pub(crate) struct TuiModelMenuModel {
     input_editor: ModelHandle<CodeEditorModel>,
+    suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
     state: TuiModelMenuState,
 }
 
 impl TuiModelMenuModel {
     pub(crate) fn new(
         input_editor: ModelHandle<CodeEditorModel>,
+        suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         ctx.subscribe_to_model(&input_editor, |model, _, event, ctx| {
-            if model.is_open() && matches!(event, CodeEditorModelEvent::ContentChanged { .. }) {
+            if model.is_open(ctx) && matches!(event, CodeEditorModelEvent::ContentChanged { .. }) {
                 model.refresh_rows(ctx);
             }
         });
         ctx.subscribe_to_model(&LLMPreferences::handle(ctx), |model, _, event, ctx| {
-            if model.is_open()
+            if model.is_open(ctx)
                 && matches!(
                     event,
                     LLMPreferencesEvent::UpdatedAvailableLLMs
@@ -59,6 +62,7 @@ impl TuiModelMenuModel {
         });
         Self {
             input_editor,
+            suggestions_mode,
             state: TuiModelMenuState::Closed,
         }
     }
@@ -66,6 +70,7 @@ impl TuiModelMenuModel {
     #[cfg(test)]
     pub(crate) fn new_for_test(
         input_editor: ModelHandle<CodeEditorModel>,
+        suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
         rows: Vec<(LLMId, bool)>,
         selected_index: usize,
     ) -> Self {
@@ -85,18 +90,32 @@ impl TuiModelMenuModel {
         );
         Self {
             input_editor,
+            suggestions_mode,
             state: TuiModelMenuState::Open { list },
         }
     }
 
-    pub(crate) fn is_open(&self) -> bool {
+    fn has_open_state(&self) -> bool {
         matches!(self.state, TuiModelMenuState::Open { .. })
     }
 
+    pub(crate) fn is_open(&self, ctx: &AppContext) -> bool {
+        self.has_open_state()
+            && self.suggestions_mode.as_ref(ctx).mode() == TuiInputSuggestionsMode::ModelSelector
+    }
+
     pub(crate) fn open(&mut self, ctx: &mut ModelContext<Self>) {
-        if self.is_open() {
+        if self.has_open_state() {
             return;
         }
+        let did_open = self.suggestions_mode.update(ctx, |mode, ctx| {
+            mode.try_open(TuiInputSuggestionsMode::ModelSelector, ctx)
+        });
+        if !did_open {
+            return;
+        }
+        self.input_editor
+            .update(ctx, |editor, ctx| editor.clear_buffer(ctx));
         self.state = TuiModelMenuState::Open {
             list: TuiInlineMenuListState::default(),
         };
@@ -104,10 +123,13 @@ impl TuiModelMenuModel {
     }
 
     pub(crate) fn dismiss(&mut self, ctx: &mut ModelContext<Self>) {
-        if !self.is_open() {
+        if !self.is_open(ctx) {
             return;
         }
         self.state = TuiModelMenuState::Closed;
+        self.suggestions_mode.update(ctx, |mode, ctx| {
+            mode.close_if_active(TuiInputSuggestionsMode::ModelSelector, ctx);
+        });
         self.input_editor
             .update(ctx, |editor, ctx| editor.clear_buffer(ctx));
         ctx.emit(TuiModelMenuEvent);
@@ -129,14 +151,20 @@ impl TuiModelMenuModel {
         ctx.emit(TuiModelMenuEvent);
     }
 
-    pub(crate) fn accept_selected(&self) -> Option<LLMId> {
+    pub(crate) fn accept_selected(&self, ctx: &AppContext) -> Option<LLMId> {
+        if !self.is_open(ctx) {
+            return None;
+        }
         let TuiModelMenuState::Open { list } = &self.state else {
             return None;
         };
         list.selected_row().map(|row| row.id.clone())
     }
 
-    pub(crate) fn snapshot(&self) -> Option<TuiInlineMenuSnapshot> {
+    pub(crate) fn snapshot(&self, ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
+        if !self.is_open(ctx) {
+            return None;
+        }
         let TuiModelMenuState::Open { list } = &self.state else {
             return None;
         };
@@ -166,7 +194,7 @@ impl TuiModelMenuModel {
     }
 
     fn refresh_rows(&mut self, ctx: &mut ModelContext<Self>) {
-        if !self.is_open() {
+        if !self.is_open(ctx) {
             return;
         }
         let query = input_text(&self.input_editor, ctx);

--- a/crates/warp_tui/src/skills_menu.rs
+++ b/crates/warp_tui/src/skills_menu.rs
@@ -12,6 +12,7 @@ use crate::inline_menu::{
     result_row_capacity, TuiInlineMenuHeader, TuiInlineMenuListState, TuiInlineMenuRow,
     TuiInlineMenuRowStyle, TuiInlineMenuSnapshot, TuiInlineMenuStatus, MAX_INLINE_MENU_ROWS,
 };
+use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
 
 const MAX_VISIBLE_ROWS: usize = result_row_capacity(MAX_INLINE_MENU_ROWS, true, false);
 
@@ -36,6 +37,7 @@ pub(crate) struct TuiSkillMenuEvent;
 
 pub(crate) struct TuiSkillMenuModel {
     input_editor: ModelHandle<CodeEditorModel>,
+    suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
     active_session: ModelHandle<ActiveSession>,
     slash_commands_source: ModelHandle<TuiSlashCommandDataSource>,
     terminal_view_id: EntityId,
@@ -45,18 +47,19 @@ pub(crate) struct TuiSkillMenuModel {
 impl TuiSkillMenuModel {
     pub(crate) fn new(
         input_editor: ModelHandle<CodeEditorModel>,
+        suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
         active_session: ModelHandle<ActiveSession>,
         slash_commands_source: ModelHandle<TuiSlashCommandDataSource>,
         terminal_view_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         ctx.subscribe_to_model(&input_editor, |model, _, event, ctx| {
-            if model.is_open() && matches!(event, CodeEditorModelEvent::ContentChanged { .. }) {
+            if model.is_open(ctx) && matches!(event, CodeEditorModelEvent::ContentChanged { .. }) {
                 model.refresh_rows(ctx);
             }
         });
         ctx.subscribe_to_model(&active_session, |model, _, event, ctx| {
-            if model.is_open()
+            if model.is_open(ctx)
                 && matches!(
                     event,
                     ActiveSessionEvent::UpdatedPwd | ActiveSessionEvent::Bootstrapped
@@ -67,6 +70,7 @@ impl TuiSkillMenuModel {
         });
         Self {
             input_editor,
+            suggestions_mode,
             active_session,
             slash_commands_source,
             terminal_view_id,
@@ -74,14 +78,26 @@ impl TuiSkillMenuModel {
         }
     }
 
-    pub(crate) fn is_open(&self) -> bool {
+    fn has_open_state(&self) -> bool {
         matches!(self.state, TuiSkillMenuState::Open { .. })
+    }
+    pub(crate) fn is_open(&self, ctx: &AppContext) -> bool {
+        self.has_open_state()
+            && self.suggestions_mode.as_ref(ctx).mode() == TuiInputSuggestionsMode::SkillMenu
     }
 
     pub(crate) fn open(&mut self, ctx: &mut ModelContext<Self>) {
-        if self.is_open() {
+        if self.has_open_state() {
             return;
         }
+        let did_open = self.suggestions_mode.update(ctx, |mode, ctx| {
+            mode.try_open(TuiInputSuggestionsMode::SkillMenu, ctx)
+        });
+        if !did_open {
+            return;
+        }
+        self.input_editor
+            .update(ctx, |editor, ctx| editor.clear_buffer(ctx));
         self.state = TuiSkillMenuState::Open {
             list: TuiInlineMenuListState::default(),
         };
@@ -89,10 +105,13 @@ impl TuiSkillMenuModel {
     }
 
     pub(crate) fn dismiss(&mut self, ctx: &mut ModelContext<Self>) {
-        if !self.is_open() {
+        if !self.is_open(ctx) {
             return;
         }
         self.state = TuiSkillMenuState::Closed;
+        self.suggestions_mode.update(ctx, |mode, ctx| {
+            mode.close_if_active(TuiInputSuggestionsMode::SkillMenu, ctx);
+        });
         self.input_editor
             .update(ctx, |editor, ctx| editor.clear_buffer(ctx));
         ctx.emit(TuiSkillMenuEvent);
@@ -115,11 +134,17 @@ impl TuiSkillMenuModel {
     }
 
     pub(crate) fn accept_selected(&mut self, ctx: &mut ModelContext<Self>) -> Option<AcceptSkill> {
+        if !self.is_open(ctx) {
+            return None;
+        }
         let TuiSkillMenuState::Open { list } = &self.state else {
             return None;
         };
         let row = list.selected_row()?.clone();
         self.state = TuiSkillMenuState::Closed;
+        self.suggestions_mode.update(ctx, |mode, ctx| {
+            mode.close_if_active(TuiInputSuggestionsMode::SkillMenu, ctx);
+        });
         ctx.emit(TuiSkillMenuEvent);
         Some(AcceptSkill {
             skill_name: row.name,
@@ -127,7 +152,10 @@ impl TuiSkillMenuModel {
         })
     }
 
-    pub(crate) fn snapshot(&self) -> Option<TuiInlineMenuSnapshot> {
+    pub(crate) fn snapshot(&self, ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
+        if !self.is_open(ctx) {
+            return None;
+        }
         let TuiSkillMenuState::Open { list } = &self.state else {
             return None;
         };
@@ -157,6 +185,9 @@ impl TuiSkillMenuModel {
     }
 
     fn refresh_rows(&mut self, ctx: &mut ModelContext<Self>) {
+        if !self.is_open(ctx) {
+            return;
+        }
         let TuiSkillMenuState::Open { list } = &self.state else {
             return;
         };

--- a/crates/warp_tui/src/slash_commands.rs
+++ b/crates/warp_tui/src/slash_commands.rs
@@ -23,6 +23,7 @@ use crate::inline_menu::{
     result_row_capacity, TuiInlineMenuListState, TuiInlineMenuRow, TuiInlineMenuRowStyle,
     TuiInlineMenuSnapshot, TuiInlineMenuStatus, MAX_INLINE_MENU_ROWS,
 };
+use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
 
 const MAX_VISIBLE_ROWS: usize = result_row_capacity(MAX_INLINE_MENU_ROWS, false, false);
 
@@ -79,6 +80,7 @@ pub(crate) struct TuiSlashCommandModelEvent;
 
 pub(crate) struct TuiSlashCommandModel {
     input_editor: ModelHandle<CodeEditorModel>,
+    suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
     slash_commands_source: Option<ModelHandle<TuiSlashCommandDataSource>>,
     mixer: ModelHandle<SlashCommandMixer>,
     state: TuiSlashCommandState,
@@ -90,6 +92,7 @@ pub(crate) struct TuiSlashCommandModel {
 impl TuiSlashCommandModel {
     pub(crate) fn new(
         input_editor: ModelHandle<CodeEditorModel>,
+        suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
         slash_commands_source: ModelHandle<TuiSlashCommandDataSource>,
         mixer: ModelHandle<SlashCommandMixer>,
         ctx: &mut ModelContext<Self>,
@@ -113,6 +116,7 @@ impl TuiSlashCommandModel {
 
         let mut model = Self {
             input_editor,
+            suggestions_mode,
             slash_commands_source: Some(slash_commands_source),
             mixer,
             state: TuiSlashCommandState::Closed,
@@ -127,6 +131,7 @@ impl TuiSlashCommandModel {
     #[cfg(test)]
     pub(crate) fn new_for_test(
         input_editor: ModelHandle<CodeEditorModel>,
+        suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
         mixer: ModelHandle<SlashCommandMixer>,
         rows: Vec<TuiSlashCommandRow>,
         selected_index: usize,
@@ -137,6 +142,7 @@ impl TuiSlashCommandModel {
         });
         Self {
             input_editor,
+            suggestions_mode,
             slash_commands_source: None,
             mixer,
             state: TuiSlashCommandState::Open {
@@ -159,8 +165,13 @@ impl TuiSlashCommandModel {
         self.argument_hint_text = text;
     }
 
-    pub(crate) fn is_open(&self) -> bool {
+    fn has_open_state(&self) -> bool {
         matches!(self.state, TuiSlashCommandState::Open { .. })
+    }
+
+    pub(crate) fn is_open(&self, ctx: &AppContext) -> bool {
+        self.has_open_state()
+            && self.suggestions_mode.as_ref(ctx).mode() == TuiInputSuggestionsMode::SlashCommands
     }
     pub(crate) fn highlighted_prefix_range(&self) -> Option<Range<CharOffset>> {
         self.highlighted_prefix_len
@@ -207,7 +218,7 @@ impl TuiSlashCommandModel {
     }
 
     pub(crate) fn dismiss(&mut self, ctx: &mut ModelContext<Self>) {
-        if !self.is_open() {
+        if !self.is_open(ctx) {
             return;
         }
         let input_is_empty = input_text(&self.input_editor, ctx).is_empty();
@@ -224,7 +235,10 @@ impl TuiSlashCommandModel {
         action
     }
 
-    pub(crate) fn snapshot(&self) -> Option<TuiInlineMenuSnapshot> {
+    pub(crate) fn snapshot(&self, ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
+        if !self.is_open(ctx) {
+            return None;
+        }
         let TuiSlashCommandState::Open { list, .. } = &self.state else {
             return None;
         };
@@ -258,6 +272,17 @@ impl TuiSlashCommandModel {
 
     fn update_from_input(&mut self, force_query: bool, ctx: &mut ModelContext<Self>) {
         let input = input_text(&self.input_editor, ctx);
+        if matches!(
+            self.suggestions_mode.as_ref(ctx).mode(),
+            TuiInputSuggestionsMode::ConversationMenu
+                | TuiInputSuggestionsMode::ModelSelector
+                | TuiInputSuggestionsMode::SkillMenu
+        ) {
+            self.set_highlighted_prefix_len(None, ctx);
+            self.set_argument_hint_text(None, ctx);
+            self.close(ctx);
+            return;
+        }
         if !self
             .lifecycle
             .input_changed(input.is_empty(), input.starts_with('/'))
@@ -280,7 +305,7 @@ impl TuiSlashCommandModel {
             argument_hint_text_for_parsed_input(&parsed_input, &input),
             ctx,
         );
-        let menu_was_open = self.is_open();
+        let menu_was_open = self.is_open(ctx);
         let result_count = self.mixer.as_ref(ctx).results().len();
         let Some(query) = menu_query_for_parsed_input(&parsed_input, menu_was_open, result_count)
         else {
@@ -303,6 +328,12 @@ impl TuiSlashCommandModel {
     }
 
     fn run_query(&mut self, query: String, force: bool, ctx: &mut ModelContext<Self>) {
+        let did_open = self.suggestions_mode.update(ctx, |mode, ctx| {
+            mode.try_open(TuiInputSuggestionsMode::SlashCommands, ctx)
+        });
+        if !did_open {
+            return;
+        }
         match &mut self.state {
             TuiSlashCommandState::Closed => {
                 let mut list = TuiInlineMenuListState::default();
@@ -355,14 +386,16 @@ impl TuiSlashCommandModel {
     }
 
     fn close(&mut self, ctx: &mut ModelContext<Self>) {
-        if !self.is_open() {
-            return;
+        if self.has_open_state() {
+            self.state = TuiSlashCommandState::Closed;
+            self.mixer.update(ctx, |mixer, ctx| {
+                mixer.reset_results(ctx);
+            });
+            ctx.emit(TuiSlashCommandModelEvent);
         }
-        self.state = TuiSlashCommandState::Closed;
-        self.mixer.update(ctx, |mixer, ctx| {
-            mixer.reset_results(ctx);
+        self.suggestions_mode.update(ctx, |mode, ctx| {
+            mode.close_if_active(TuiInputSuggestionsMode::SlashCommands, ctx);
         });
-        ctx.emit(TuiSlashCommandModelEvent);
     }
 }
 

--- a/crates/warp_tui/src/slash_commands_tests.rs
+++ b/crates/warp_tui/src/slash_commands_tests.rs
@@ -13,6 +13,7 @@ use super::{
     menu_query_for_parsed_input, TuiSlashCommandModel, TuiSlashCommandRow, MAX_VISIBLE_ROWS,
 };
 use crate::inline_menu::keep_selected_visible;
+use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
 
 fn parsed_skill(argument: Option<&str>) -> ParsedSlashCommandInput {
     ParsedSlashCommandInput::SkillCommand(DetectedSkillCommand {
@@ -179,16 +180,79 @@ fn completed_empty_results_close_the_menu() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| Appearance::mock());
         let input_editor = app.add_model(|ctx| CodeEditorModel::new_tui(80, ctx));
+        let suggestions_mode = app.add_model(|_| TuiInputSuggestionsModeModel::new());
+        suggestions_mode.update(&mut app, |mode, ctx| {
+            mode.set_mode(TuiInputSuggestionsMode::SlashCommands, ctx);
+        });
         let mixer = app.add_model(|_| SlashCommandMixer::new());
-        let model = app
-            .add_model(|_| TuiSlashCommandModel::new_for_test(input_editor, mixer, Vec::new(), 0));
+        let model = app.add_model(|_| {
+            TuiSlashCommandModel::new_for_test(input_editor, suggestions_mode, mixer, Vec::new(), 0)
+        });
 
         model.update(&mut app, |model, ctx| model.refresh_rows(ctx));
 
-        model.read(&app, |model, _| {
-            assert!(!model.is_open());
+        model.read(&app, |model, ctx| {
+            assert!(!model.is_open(ctx));
         });
     });
+}
+
+fn assert_explicit_menu_blocks_slash_commands(explicit_mode: TuiInputSuggestionsMode) {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| Appearance::mock());
+        let input_editor = app.add_model(|ctx| CodeEditorModel::new_tui(80, ctx));
+        let suggestions_mode = app.add_model(|_| TuiInputSuggestionsModeModel::new());
+        suggestions_mode.update(&mut app, |mode, ctx| {
+            mode.set_mode(TuiInputSuggestionsMode::SlashCommands, ctx);
+        });
+        let mixer = app.add_model(|_| SlashCommandMixer::new());
+        let model = app.add_model(|_| {
+            TuiSlashCommandModel::new_for_test(
+                input_editor,
+                suggestions_mode.clone(),
+                mixer,
+                vec![TuiSlashCommandRow {
+                    title: "Test command".to_owned(),
+                    description: None,
+                    action: AcceptSlashCommandOrSavedPrompt::SlashCommand {
+                        id: SlashCommandId::new(),
+                    },
+                }],
+                0,
+            )
+        });
+
+        model.update(&mut app, |model, ctx| {
+            model.accept_selected(ctx);
+        });
+        suggestions_mode.update(&mut app, |mode, ctx| {
+            mode.set_mode(explicit_mode, ctx);
+        });
+        model.update(&mut app, |model, ctx| {
+            model.set_highlighted_prefix_len_for_test(Some(6));
+            model.set_argument_hint_text_for_test(Some("<argument>"));
+            model.update_from_input(false, ctx);
+            model.run_query("model".to_owned(), false, ctx);
+            assert!(!model.is_open(ctx));
+            assert_eq!(model.highlighted_prefix_range(), None);
+            assert_eq!(model.argument_hint_text(), None);
+            assert_eq!(model.suggestions_mode.as_ref(ctx).mode(), explicit_mode);
+        });
+    });
+}
+
+#[test]
+fn conversation_menu_blocks_slash_command_activation() {
+    assert_explicit_menu_blocks_slash_commands(TuiInputSuggestionsMode::ConversationMenu);
+}
+
+#[test]
+fn model_menu_blocks_slash_command_activation() {
+    assert_explicit_menu_blocks_slash_commands(TuiInputSuggestionsMode::ModelSelector);
+}
+#[test]
+fn skill_menu_blocks_slash_command_activation() {
+    assert_explicit_menu_blocks_slash_commands(TuiInputSuggestionsMode::SkillMenu);
 }
 
 #[test]
@@ -196,11 +260,16 @@ fn accepting_a_result_does_not_disable_input_driven_lifecycle() {
     App::test((), |mut app| async move {
         app.add_singleton_model(|_| Appearance::mock());
         let input_editor = app.add_model(|ctx| CodeEditorModel::new_tui(80, ctx));
+        let suggestions_mode = app.add_model(|_| TuiInputSuggestionsModeModel::new());
+        suggestions_mode.update(&mut app, |mode, ctx| {
+            mode.set_mode(TuiInputSuggestionsMode::SlashCommands, ctx);
+        });
         let mixer = app.add_model(|_| SlashCommandMixer::new());
         let command_id = SlashCommandId::new();
         let model = app.add_model(|_| {
             TuiSlashCommandModel::new_for_test(
                 input_editor,
+                suggestions_mode,
                 mixer,
                 vec![TuiSlashCommandRow {
                     title: "Test command".to_owned(),

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -53,9 +53,10 @@ use crate::clipboard::copy_to_clipboard;
 use crate::conversation_menu::{TuiConversationMenuEvent, TuiConversationMenuModel};
 use crate::conversation_selection::TuiConversationSelection;
 use crate::exit_confirmation::{ExitConfirmation, CTRL_C_EXIT_WINDOW};
-use crate::inline_menu::{TuiInlineMenu, MAX_INLINE_MENU_ROWS};
+use crate::inline_menu::{active_inline_menu, TuiInlineMenu, MAX_INLINE_MENU_ROWS};
 use crate::input::{TuiInputView, TuiInputViewEvent};
 use crate::input_mode_policy::{self, TuiInputModePolicy};
+use crate::input_suggestions_mode::TuiInputSuggestionsModeModel;
 use crate::keybindings::TUI_BINDING_GROUP;
 use crate::model_menu::{TuiModelMenuEvent, TuiModelMenuModel};
 use crate::resume::TuiExitSummaryHandle;
@@ -199,6 +200,7 @@ pub(crate) struct TuiTerminalSessionView {
     transcript: ViewHandle<TuiTranscriptView>,
     input_view: ViewHandle<TuiInputView>,
     inline_menus: Vec<TuiInlineMenu>,
+    suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
     conversation_menu: ModelHandle<TuiConversationMenuModel>,
     model_menu: ModelHandle<TuiModelMenuModel>,
     skills_menu: ModelHandle<TuiSkillMenuModel>,
@@ -361,6 +363,7 @@ impl TuiTerminalSessionView {
         });
         let input_editor_model =
             ctx.add_model(|ctx| CodeEditorModel::new_tui(INITIAL_INPUT_WIDTH, ctx));
+        let suggestions_mode = ctx.add_model(|_| TuiInputSuggestionsModeModel::new());
         let slash_commands_source = ctx.add_model(|ctx| {
             TuiSlashCommandDataSource::new(
                 TuiSlashCommandDataSourceArgs {
@@ -379,6 +382,7 @@ impl TuiTerminalSessionView {
         let slash_commands = ctx.add_model(|ctx| {
             TuiSlashCommandModel::new(
                 input_editor_model.clone(),
+                suggestions_mode.clone(),
                 slash_commands_source.clone(),
                 slash_commands_mixer,
                 ctx,
@@ -389,6 +393,7 @@ impl TuiTerminalSessionView {
         let conversation_menu = ctx.add_model(|ctx| {
             TuiConversationMenuModel::new(
                 input_editor_model.clone(),
+                suggestions_mode.clone(),
                 conversation_selection.clone(),
                 window_id,
                 ctx,
@@ -404,14 +409,16 @@ impl TuiTerminalSessionView {
                 );
             }
         });
-        let model_menu =
-            ctx.add_model(|ctx| TuiModelMenuModel::new(input_editor_model.clone(), ctx));
+        let model_menu = ctx.add_model(|ctx| {
+            TuiModelMenuModel::new(input_editor_model.clone(), suggestions_mode.clone(), ctx)
+        });
         ctx.subscribe_to_model(&model_menu, |_, _, _: &TuiModelMenuEvent, ctx| {
             ctx.notify();
         });
         let skills_menu = ctx.add_model(|ctx| {
             TuiSkillMenuModel::new(
                 input_editor_model.clone(),
+                suggestions_mode.clone(),
                 active_session.clone(),
                 slash_commands_source.clone(),
                 terminal_surface_id,
@@ -466,10 +473,12 @@ impl TuiTerminalSessionView {
             TuiInlineMenu::new(skills_menu.clone()),
         ];
         let inline_menus_for_input = inline_menus.clone();
+        let suggestions_mode_for_input = suggestions_mode.clone();
         let input_view = ctx.add_typed_action_tui_view(move |ctx| {
             TuiInputView::new(
                 input_editor_model,
                 input_mode_for_input_view,
+                suggestions_mode_for_input,
                 inline_menus_for_input,
                 ctx,
             )
@@ -504,6 +513,7 @@ impl TuiTerminalSessionView {
         // The input box border color and the footer's shell-mode hint depend
         // on the input mode.
         ctx.subscribe_to_model(&ai_input_model, |_, _, _, ctx| ctx.notify());
+        ctx.subscribe_to_model(&suggestions_mode, |_, _, _, ctx| ctx.notify());
         // The warping indicator between the transcript and the input box
         // tracks the selected conversation: re-render when its status changes
         // or an exchange starts (the elapsed counter's anchor) on this
@@ -682,6 +692,7 @@ impl TuiTerminalSessionView {
             transcript,
             input_view,
             inline_menus,
+            suggestions_mode,
             conversation_menu,
             model_menu,
             skills_menu,
@@ -1572,13 +1583,11 @@ impl TuiTerminalSessionView {
                 record_static_slash_command_accepted(command.name, true, ctx);
             }
             TuiSlashCommand::Conversations => {
-                self.input_view.update(ctx, |input, ctx| input.clear(ctx));
                 self.conversation_menu
                     .update(ctx, |menu, ctx| menu.open(ctx));
                 record_static_slash_command_accepted(command.name, true, ctx);
             }
             TuiSlashCommand::Model => {
-                self.input_view.update(ctx, |input, ctx| input.clear(ctx));
                 self.model_menu.update(ctx, |menu, ctx| menu.open(ctx));
                 record_static_slash_command_accepted(command.name, true, ctx);
             }
@@ -1586,7 +1595,6 @@ impl TuiTerminalSessionView {
                 if !FeatureFlag::ListSkills.is_enabled() {
                     return;
                 }
-                self.input_view.update(ctx, |input, ctx| input.clear(ctx));
                 self.skills_menu.update(ctx, |menu, ctx| menu.open(ctx));
                 record_static_slash_command_accepted(command.name, true, ctx);
             }
@@ -1774,7 +1782,12 @@ impl TuiView for TuiTerminalSessionView {
             }
             ConversationRestoreState::Idle => {}
         }
-        let inline_menu = self.inline_menus.iter().find_map(|menu| menu.render(ctx));
+        let inline_menu = active_inline_menu(
+            &self.inline_menus,
+            self.suggestions_mode.as_ref(ctx).mode(),
+            ctx,
+        )
+        .and_then(|menu| menu.render(ctx));
         // The border takes the shell-mode accent while in shell mode.
         let builder = TuiUiBuilder::from_app(ctx);
         let border_style = if self.is_shell_mode(ctx) {


### PR DESCRIPTION
## Description

After adding the slash command, conversation, and model inline menu, it was possible to trigger a bad state where you pull up one menu on top of the other. This PR updates our TUI behavior to be consistent w the GUI behavior

<!-- Please remember to add your design buddy onto the PR for review, if it contains any UI changes! -->

## Linked Issue

<!--
Link the GitHub issue this PR addresses. Before opening this PR, please confirm:
-->

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

https://www.loom.com/share/3af19973be8247d7a16ecfcd8e20ad3c

<!--
How did you test this change? What automated tests did you add? If you didn't add any new tests, what's your justification for not adding any?

Manual testing is required for changes that can be manually tested, and almost all changes can be manually tested. If your change can be manually tested, please include screenshots or a screen recording that show it working end to end.

You can run the app locally using `./script/run` - see AGENTS.md for more details on how to get set up.
-->

- [ ] I have manually tested my changes locally with `./script/run`

<!-- Attach screenshots or a short video demonstrating the change, where appropriate. Remove this section if it is not relevant to your PR. -->

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

The entries below will be used when constructing a soft-copy of the stable release changelog. Leave blank or remove the lines if no entry in the stable changelog is needed. Entries should be on the same line, without the `{{` `}}` brackets. You can use multiple lines, even of the same type. The valid suffixes are:

- NEW-FEATURE: for new, relatively sizable features. Features listed here will likely have docs / social media posts / marketing launches associated with them, so use sparingly.
- IMPROVEMENT: for new functionality of existing features.
- BUG-FIX: for fixes related to known bugs or regressions.
- IMAGE: the image specified by the URL (hosted on GCP) will be added to Dev & Preview releases. For Stable releases, see the pinned doc in the #release Slack channel.
- OZ: Oz-related updates. Use `CHANGELOG-OZ`. At most 4 Oz updates are shown in-app per release.
- NONE: Explicitly opt out of changelog inclusion. Use `CHANGELOG-NONE` for PRs that should never appear in the changelog (e.g. refactors, internal tooling, CI changes). This prevents the changelog agent from inferring an entry.

CHANGELOG-NEW-FEATURE: {{text goes here...}}
CHANGELOG-IMPROVEMENT: {{text goes here...}}
CHANGELOG-BUG-FIX: {{text goes here...}}
CHANGELOG-BUG-FIX: {{more text goes here...}}
CHANGELOG-IMAGE: {{GCP-hosted URL goes here...}}
CHANGELOG-OZ: {{text goes here...}}
CHANGELOG-NONE
-->