### PR TITLE
Include TUI skill menu in suggestion exclusivity

### DIFF
--- a/crates/warp_tui/src/inline_menu.rs
+++ b/crates/warp_tui/src/inline_menu.rs
@@ -408,8 +408,11 @@ impl TuiInlineMenuHandle for ModelHandle<TuiModelMenuModel> {
 }
 
 impl TuiInlineMenuHandle for ModelHandle<TuiSkillMenuModel> {
+    fn mode(&self) -> TuiInputSuggestionsMode {
+        TuiInputSuggestionsMode::SkillMenu
+    }
     fn is_open(&self, ctx: &AppContext) -> bool {
-        self.as_ref(ctx).is_open()
+        self.as_ref(ctx).is_open(ctx)
     }
 
     fn input_highlight_range(&self, _ctx: &AppContext) -> Option<Range<CharOffset>> {
@@ -443,7 +446,7 @@ impl TuiInlineMenuHandle for ModelHandle<TuiSkillMenuModel> {
     }
 
     fn snapshot(&self, ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
-        self.as_ref(ctx).snapshot()
+        self.as_ref(ctx).snapshot(ctx)
     }
 }
 

--- a/crates/warp_tui/src/input_suggestions_mode.rs
+++ b/crates/warp_tui/src/input_suggestions_mode.rs
@@ -13,6 +13,7 @@ pub(crate) enum TuiInputSuggestionsMode {
     SlashCommands,
     ConversationMenu,
     ModelSelector,
+    SkillMenu,
 }
 
 impl TuiInputSuggestionsMode {
@@ -67,7 +68,8 @@ impl TuiInputSuggestionsModeModel {
             active_mode if active_mode == mode => true,
             TuiInputSuggestionsMode::SlashCommands
             | TuiInputSuggestionsMode::ConversationMenu
-            | TuiInputSuggestionsMode::ModelSelector => false,
+            | TuiInputSuggestionsMode::ModelSelector
+            | TuiInputSuggestionsMode::SkillMenu => false,
         }
     }
 

--- a/crates/warp_tui/src/input_suggestions_mode_tests.rs
+++ b/crates/warp_tui/src/input_suggestions_mode_tests.rs
@@ -44,13 +44,15 @@ fn opening_a_menu_does_not_replace_an_active_menu() {
             assert!(mode.try_open(TuiInputSuggestionsMode::ConversationMenu, ctx));
             assert!(!mode.try_open(TuiInputSuggestionsMode::SlashCommands, ctx));
             assert!(!mode.try_open(TuiInputSuggestionsMode::ModelSelector, ctx));
+            assert!(!mode.try_open(TuiInputSuggestionsMode::SkillMenu, ctx));
             assert_eq!(mode.mode(), TuiInputSuggestionsMode::ConversationMenu);
 
             mode.set_mode(TuiInputSuggestionsMode::Closed, ctx);
-            assert!(mode.try_open(TuiInputSuggestionsMode::ModelSelector, ctx));
+            assert!(mode.try_open(TuiInputSuggestionsMode::SkillMenu, ctx));
             assert!(!mode.try_open(TuiInputSuggestionsMode::SlashCommands, ctx));
             assert!(!mode.try_open(TuiInputSuggestionsMode::ConversationMenu, ctx));
-            assert_eq!(mode.mode(), TuiInputSuggestionsMode::ModelSelector);
+            assert!(!mode.try_open(TuiInputSuggestionsMode::ModelSelector, ctx));
+            assert_eq!(mode.mode(), TuiInputSuggestionsMode::SkillMenu);
         });
     });
 }

--- a/crates/warp_tui/src/skills_menu.rs
+++ b/crates/warp_tui/src/skills_menu.rs
@@ -12,6 +12,7 @@ use crate::inline_menu::{
     result_row_capacity, TuiInlineMenuHeader, TuiInlineMenuListState, TuiInlineMenuRow,
     TuiInlineMenuRowStyle, TuiInlineMenuSnapshot, TuiInlineMenuStatus, MAX_INLINE_MENU_ROWS,
 };
+use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
 
 const MAX_VISIBLE_ROWS: usize = result_row_capacity(MAX_INLINE_MENU_ROWS, true, false);
 
@@ -36,6 +37,7 @@ pub(crate) struct TuiSkillMenuEvent;
 
 pub(crate) struct TuiSkillMenuModel {
     input_editor: ModelHandle<CodeEditorModel>,
+    suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
     active_session: ModelHandle<ActiveSession>,
     slash_commands_source: ModelHandle<TuiSlashCommandDataSource>,
     terminal_view_id: EntityId,
@@ -45,18 +47,19 @@ pub(crate) struct TuiSkillMenuModel {
 impl TuiSkillMenuModel {
     pub(crate) fn new(
         input_editor: ModelHandle<CodeEditorModel>,
+        suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
         active_session: ModelHandle<ActiveSession>,
         slash_commands_source: ModelHandle<TuiSlashCommandDataSource>,
         terminal_view_id: EntityId,
         ctx: &mut ModelContext<Self>,
     ) -> Self {
         ctx.subscribe_to_model(&input_editor, |model, _, event, ctx| {
-            if model.is_open() && matches!(event, CodeEditorModelEvent::ContentChanged { .. }) {
+            if model.is_open(ctx) && matches!(event, CodeEditorModelEvent::ContentChanged { .. }) {
                 model.refresh_rows(ctx);
             }
         });
         ctx.subscribe_to_model(&active_session, |model, _, event, ctx| {
-            if model.is_open()
+            if model.is_open(ctx)
                 && matches!(
                     event,
                     ActiveSessionEvent::UpdatedPwd | ActiveSessionEvent::Bootstrapped
@@ -67,6 +70,7 @@ impl TuiSkillMenuModel {
         });
         Self {
             input_editor,
+            suggestions_mode,
             active_session,
             slash_commands_source,
             terminal_view_id,
@@ -74,14 +78,26 @@ impl TuiSkillMenuModel {
         }
     }
 
-    pub(crate) fn is_open(&self) -> bool {
+    fn has_open_state(&self) -> bool {
         matches!(self.state, TuiSkillMenuState::Open { .. })
+    }
+    pub(crate) fn is_open(&self, ctx: &AppContext) -> bool {
+        self.has_open_state()
+            && self.suggestions_mode.as_ref(ctx).mode() == TuiInputSuggestionsMode::SkillMenu
     }
 
     pub(crate) fn open(&mut self, ctx: &mut ModelContext<Self>) {
-        if self.is_open() {
+        if self.has_open_state() {
             return;
         }
+        let did_open = self.suggestions_mode.update(ctx, |mode, ctx| {
+            mode.try_open(TuiInputSuggestionsMode::SkillMenu, ctx)
+        });
+        if !did_open {
+            return;
+        }
+        self.input_editor
+            .update(ctx, |editor, ctx| editor.clear_buffer(ctx));
         self.state = TuiSkillMenuState::Open {
             list: TuiInlineMenuListState::default(),
         };
@@ -89,10 +105,13 @@ impl TuiSkillMenuModel {
     }
 
     pub(crate) fn dismiss(&mut self, ctx: &mut ModelContext<Self>) {
-        if !self.is_open() {
+        if !self.is_open(ctx) {
             return;
         }
         self.state = TuiSkillMenuState::Closed;
+        self.suggestions_mode.update(ctx, |mode, ctx| {
+            mode.close_if_active(TuiInputSuggestionsMode::SkillMenu, ctx);
+        });
         self.input_editor
             .update(ctx, |editor, ctx| editor.clear_buffer(ctx));
         ctx.emit(TuiSkillMenuEvent);
@@ -115,11 +134,17 @@ impl TuiSkillMenuModel {
     }
 
     pub(crate) fn accept_selected(&mut self, ctx: &mut ModelContext<Self>) -> Option<AcceptSkill> {
+        if !self.is_open(ctx) {
+            return None;
+        }
         let TuiSkillMenuState::Open { list } = &self.state else {
             return None;
         };
         let row = list.selected_row()?.clone();
         self.state = TuiSkillMenuState::Closed;
+        self.suggestions_mode.update(ctx, |mode, ctx| {
+            mode.close_if_active(TuiInputSuggestionsMode::SkillMenu, ctx);
+        });
         ctx.emit(TuiSkillMenuEvent);
         Some(AcceptSkill {
             skill_name: row.name,
@@ -127,7 +152,10 @@ impl TuiSkillMenuModel {
         })
     }
 
-    pub(crate) fn snapshot(&self) -> Option<TuiInlineMenuSnapshot> {
+    pub(crate) fn snapshot(&self, ctx: &AppContext) -> Option<TuiInlineMenuSnapshot> {
+        if !self.is_open(ctx) {
+            return None;
+        }
         let TuiSkillMenuState::Open { list } = &self.state else {
             return None;
         };
@@ -157,6 +185,9 @@ impl TuiSkillMenuModel {
     }
 
     fn refresh_rows(&mut self, ctx: &mut ModelContext<Self>) {
+        if !self.is_open(ctx) {
+            return;
+        }
         let TuiSkillMenuState::Open { list } = &self.state else {
             return;
         };

--- a/crates/warp_tui/src/slash_commands.rs
+++ b/crates/warp_tui/src/slash_commands.rs
@@ -274,7 +274,9 @@ impl TuiSlashCommandModel {
         let input = input_text(&self.input_editor, ctx);
         if matches!(
             self.suggestions_mode.as_ref(ctx).mode(),
-            TuiInputSuggestionsMode::ConversationMenu | TuiInputSuggestionsMode::ModelSelector
+            TuiInputSuggestionsMode::ConversationMenu
+                | TuiInputSuggestionsMode::ModelSelector
+                | TuiInputSuggestionsMode::SkillMenu
         ) {
             self.set_highlighted_prefix_len(None, ctx);
             self.set_argument_hint_text(None, ctx);

--- a/crates/warp_tui/src/slash_commands_tests.rs
+++ b/crates/warp_tui/src/slash_commands_tests.rs
@@ -229,8 +229,13 @@ fn assert_explicit_menu_blocks_slash_commands(explicit_mode: TuiInputSuggestions
             mode.set_mode(explicit_mode, ctx);
         });
         model.update(&mut app, |model, ctx| {
+            model.set_highlighted_prefix_len_for_test(Some(6));
+            model.set_argument_hint_text_for_test(Some("<argument>"));
+            model.update_from_input(false, ctx);
             model.run_query("model".to_owned(), false, ctx);
             assert!(!model.is_open(ctx));
+            assert_eq!(model.highlighted_prefix_range(), None);
+            assert_eq!(model.argument_hint_text(), None);
             assert_eq!(model.suggestions_mode.as_ref(ctx).mode(), explicit_mode);
         });
     });
@@ -244,6 +249,10 @@ fn conversation_menu_blocks_slash_command_activation() {
 #[test]
 fn model_menu_blocks_slash_command_activation() {
     assert_explicit_menu_blocks_slash_commands(TuiInputSuggestionsMode::ModelSelector);
+}
+#[test]
+fn skill_menu_blocks_slash_command_activation() {
+    assert_explicit_menu_blocks_slash_commands(TuiInputSuggestionsMode::SkillMenu);
 }
 
 #[test]

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -418,6 +418,7 @@ impl TuiTerminalSessionView {
         let skills_menu = ctx.add_model(|ctx| {
             TuiSkillMenuModel::new(
                 input_editor_model.clone(),
+                suggestions_mode.clone(),
                 active_session.clone(),
                 slash_commands_source.clone(),
                 terminal_surface_id,
@@ -1594,7 +1595,6 @@ impl TuiTerminalSessionView {
                 if !FeatureFlag::ListSkills.is_enabled() {
                     return;
                 }
-                self.input_view.update(ctx, |input, ctx| input.clear(ctx));
                 self.skills_menu.update(ctx, |menu, ctx| menu.open(ctx));
                 record_static_slash_command_accepted(command.name, true, ctx);
             }


### PR DESCRIPTION
## Description

Extend the shared TUI input suggestions mode to include the Skills menu. Opening, rendering, accepting, and dismissing the skill picker now use the same authoritative mode as slash commands, conversation search, and model selection, preventing those inline menus from overlapping.

## Linked Issue

N/A — follow-up to #13743.

## Testing

- [x] `./script/format --check`
- [x] `cargo nextest run -p warp_tui`
- [x] `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- [x] `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- [ ] Manual TUI verification was not run.

### Screenshots / Videos

N/A — behavior is covered by TUI model and rendering tests.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed the TUI Skills menu overlapping other inline suggestion menus.

[Warp Agent conversation](https://staging.warp.dev/conversation/9a821378-8616-47bc-a339-1104bc7399f0)

Co-Authored-By: Oz <oz-agent@warp.dev>
