### PR TITLE
Proper long running command rendering

### DIFF
--- a/app/src/terminal/model/blockgrid.rs
+++ b/app/src/terminal/model/blockgrid.rs
@@ -209,6 +209,15 @@ impl BlockGrid {
         )))
     }
 
+    /// Returns the visible cursor position in displayed-grid coordinates as
+    /// `(column, row)`. A cursor hidden below trimmed content is omitted.
+    pub fn visible_cursor_display_position(&self) -> Option<(usize, usize)> {
+        match self.cursor_display_point()? {
+            CursorDisplayPoint::Visible(point) => Some((point.col, point.row)),
+            CursorDisplayPoint::HiddenCache(_) => None,
+        }
+    }
+
     /// Determine whether the block is currently empty
     ///
     /// Note: Depending on the state of the block, it can be _currently_ empty even when it has

--- a/crates/warp_tui/src/alt_screen_view.rs
+++ b/crates/warp_tui/src/alt_screen_view.rs
@@ -1,37 +1,33 @@
-//! Full-screen alt-screen rendering + raw keyboard forwarding for the TUI.
+//! Full-screen alt-screen rendering for the TUI.
 //!
 //! When a PTY app switches to the alternate screen (vim, htop, less, …), the
 //! terminal model flips [`TerminalModel::is_alt_screen_active`] and populates a
 //! dedicated alt-screen grid. [`TuiTerminalSessionView`] then renders this
-//! element full-area instead of the block/transcript UI, and forwards
-//! keystrokes straight to the PTY as escape sequences — mirroring the GUI's
+//! element full-area instead of the block/transcript UI — mirroring the GUI's
 //! `AltScreenElement` (`app/src/terminal/alt_screen/alt_screen_element.rs`).
 //!
-//! Covers rendering, the cursor, and keyboard forwarding. PTY sizing is
-//! handled by the session view's `TuiTerminalSizeElement` wrapper, which
-//! publishes this element's laid-out dimensions after every layout. Mouse
-//! forwarding is tracked as a follow-up.
+//! Covers rendering and the cursor. PTY sizing and keyboard forwarding are
+//! handled by the session view's `TuiTerminalSizeElement` wrapper. Mouse
+//! forwarding remains a follow-up.
 //!
 //! [`TuiTerminalSessionView`]: crate::terminal_session_view::TuiTerminalSessionView
 //! [`TerminalModel::is_alt_screen_active`]: warp::tui_export::TerminalModel
 
-use std::ops::Deref as _;
 use std::sync::Arc;
 
 use parking_lot::FairMutex;
-use warp::tui_export::{KeystrokeWithDetails, TermMode, TerminalModel};
+use warp::tui_export::{TermMode, TerminalModel};
 use warp_terminal::model::grid::Dimensions as _;
 use warpui_core::elements::tui::{
-    TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext, TuiPaintContext,
-    TuiPaintSurface, TuiScreenPoint, TuiScreenPosition, TuiSize,
+    TuiConstraint, TuiElement, TuiLayoutContext, TuiPaintContext, TuiPaintSurface, TuiScreenPoint,
+    TuiScreenPosition, TuiSize,
 };
 use warpui_core::AppContext;
 
 use crate::terminal_block::render_grid_handler;
-use crate::terminal_session_view::TuiTerminalSessionAction;
 
-/// Renders the terminal's alt-screen grid full-area and forwards input to the
-/// PTY while a full-screen app is active.
+/// Renders the terminal's alt-screen grid full-area while a full-screen app is
+/// active.
 pub(crate) struct AltScreenElement {
     model: Arc<FairMutex<TerminalModel>>,
     size: Option<TuiSize>,
@@ -103,46 +99,6 @@ impl TuiElement for AltScreenElement {
 
     fn origin(&self) -> Option<TuiScreenPoint> {
         self.origin
-    }
-
-    fn dispatch_event(
-        &mut self,
-        event: &TuiEvent,
-        event_ctx: &mut TuiEventContext<'_>,
-        _app: &AppContext,
-    ) -> bool {
-        let TuiEvent::KeyDown {
-            keystroke,
-            chars,
-            details,
-            is_composing,
-        } = event
-        else {
-            // Mouse forwarding is a follow-up slice.
-            return false;
-        };
-        if *is_composing {
-            return false;
-        }
-        // Forward the key to the app. `to_pty_bytes` layers the fallbacks a
-        // single-`KeyDown` frontend needs — `Ctrl+<letter>` → C0, printable
-        // `chars`, and named control keys — on top of the shared
-        // `to_escape_sequence` encoder in `warp_terminal`. (ctrl-c never reaches
-        // here: the session view's interrupt handler forwards it to the app.)
-        let bytes = {
-            let model = self.model.lock();
-            KeystrokeWithDetails {
-                keystroke,
-                key_without_modifiers: details.key_without_modifiers.as_deref(),
-                chars: Some(chars.as_str()),
-            }
-            .to_pty_bytes(model.deref())
-        };
-        let Some(bytes) = bytes else {
-            return false;
-        };
-        event_ctx.dispatch_typed_action(TuiTerminalSessionAction::ForwardToPty(bytes));
-        true
     }
 }
 

--- a/crates/warp_tui/src/alt_screen_view.rs
+++ b/crates/warp_tui/src/alt_screen_view.rs
@@ -7,7 +7,7 @@
 //! `AltScreenElement` (`app/src/terminal/alt_screen/alt_screen_element.rs`).
 //!
 //! Covers rendering and the cursor. PTY sizing and keyboard forwarding are
-//! handled by the session view's `TuiTerminalSizeElement` wrapper. Mouse
+//! handled by the session view's `TuiTerminalContentElement` wrapper. Mouse
 //! forwarding remains a follow-up.
 //!
 //! [`TuiTerminalSessionView`]: crate::terminal_session_view::TuiTerminalSessionView

--- a/crates/warp_tui/src/alt_screen_view_tests.rs
+++ b/crates/warp_tui/src/alt_screen_view_tests.rs
@@ -22,8 +22,8 @@ fn layout_fills_the_allocated_pane() {
 
             let size = element.layout(TuiConstraint::loose(expected_size), &mut layout_ctx, app);
             assert_eq!(size, expected_size);
-            // The laid-out size is retained for the size wrapper and mouse
-            // hit-testing to read back.
+            // The laid-out size is retained for the terminal-content wrapper
+            // and mouse hit-testing to read back.
             assert_eq!(element.size(), Some(expected_size));
         });
     });

--- a/crates/warp_tui/src/lib.rs
+++ b/crates/warp_tui/src/lib.rs
@@ -33,8 +33,8 @@ mod skills_menu;
 mod slash_commands;
 mod terminal_background;
 mod terminal_block;
+mod terminal_content_element;
 mod terminal_session_view;
-mod terminal_size_element;
 mod terminal_use;
 #[cfg(test)]
 mod test_fixtures;

--- a/crates/warp_tui/src/terminal_block.rs
+++ b/crates/warp_tui/src/terminal_block.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use parking_lot::FairMutex;
 use warp::tui_export::{
-    Block, BlockGrid, BlockId, BlockList, GridHandler, TerminalColorList, TerminalModel,
+    Block, BlockGrid, BlockId, BlockList, GridHandler, TermMode, TerminalColorList, TerminalModel,
 };
 use warp_terminal::model::ansi::{Color, NamedColor};
 use warp_terminal::model::grid::cell::{Cell, Flags};
@@ -15,6 +15,8 @@ use warpui_core::elements::tui::{
     TuiPaintSurface, TuiScreenPoint, TuiScreenPosition, TuiSize, TuiStyle,
 };
 use warpui_core::AppContext;
+
+use crate::terminal_use::user_controls_running_command;
 
 /// Selects which rows of a terminal block an element paints.
 enum TerminalBlockRows {
@@ -80,6 +82,45 @@ impl TerminalBlockElement {
     }
 }
 
+fn terminal_block_cursor(
+    block: &Block,
+    visible_rows: &Range<usize>,
+    size: TuiSize,
+) -> Option<(u16, u16)> {
+    if !user_controls_running_command(block) || !block.is_mode_set(TermMode::SHOW_CURSOR) {
+        return None;
+    }
+    let (grid, grid_start_row) = if block.is_command_grid_active() {
+        if block.should_hide_command_grid() {
+            return None;
+        }
+        (
+            block.prompt_and_command_grid(),
+            block
+                .prompt_and_command_grid_offset()
+                .as_f64()
+                .ceil()
+                .max(0.0) as usize,
+        )
+    } else {
+        if block.should_hide_output_grid() {
+            return None;
+        }
+        (
+            block.output_grid(),
+            block.output_grid_offset().as_f64().ceil().max(0.0) as usize,
+        )
+    };
+    let (column, grid_row) = grid.visible_cursor_display_position()?;
+    let block_row = grid_start_row.saturating_add(grid_row);
+    if !visible_rows.contains(&block_row) {
+        return None;
+    }
+    let column = u16::try_from(column).ok()?;
+    let row = u16::try_from(block_row.saturating_sub(visible_rows.start)).ok()?;
+    (column < size.width && row < size.height).then_some((column, row))
+}
+
 impl TuiElement for TerminalBlockElement {
     fn layout(
         &mut self,
@@ -127,6 +168,7 @@ impl TuiElement for TerminalBlockElement {
             TerminalBlockRows::Visible { rows, width } => (rows.clone(), (*width).min(size.width)),
             TerminalBlockRows::Content => (block_content_rows(block), size.width),
         };
+        let cursor = terminal_block_cursor(block, &rows, size);
         render_block_rows(
             block,
             rows,
@@ -135,6 +177,10 @@ impl TuiElement for TerminalBlockElement {
             surface,
             &colors,
         );
+        drop(model);
+        if let Some((col, row)) = cursor {
+            ctx.set_terminal_cursor(ctx.scene_point(origin.offset(i32::from(col), i32::from(row))));
+        }
     }
 
     fn size(&self) -> Option<TuiSize> {

--- a/crates/warp_tui/src/terminal_block_tests.rs
+++ b/crates/warp_tui/src/terminal_block_tests.rs
@@ -2,8 +2,9 @@ use warp::tui_export::{
     AIAgentActionId, AIConversationId, AgentInteractionMetadata, BlockId, TerminalModel,
     TranscriptScope,
 };
+use warpui_core::elements::tui::TuiSize;
 
-use super::should_render_terminal_block;
+use super::{should_render_terminal_block, terminal_block_cursor};
 
 /// Builds a mock model with a single simulated (started + finished) block and
 /// returns the model together with that block's id.
@@ -101,4 +102,31 @@ fn user_command_block_is_rendered_at_top_level() {
 
     assert!(!block.is_agent_requested_command());
     assert!(should_render_terminal_block(block, block_list));
+}
+
+#[test]
+fn user_controlled_running_command_submits_cursor_within_window() {
+    let mut model = TerminalModel::mock(None, None);
+    model.simulate_long_running_block("python3", ">>> ");
+    let block = model.block_list().active_block();
+
+    // A finished/agent block never owns the inline cursor; an active
+    // user-controlled command does when its cursor lands inside the window.
+    let in_window = terminal_block_cursor(block, &(0..8), TuiSize::new(40, 8));
+    let clipped = terminal_block_cursor(block, &(0..8), TuiSize::new(40, 0));
+    assert!(in_window.is_some());
+    assert_eq!(clipped, None);
+}
+
+#[test]
+fn finished_command_does_not_submit_a_cursor() {
+    let (model, block_id) = model_with_finished_block("ls");
+    let block = model
+        .block_list()
+        .block_with_id(&block_id)
+        .expect("block should exist");
+    assert_eq!(
+        terminal_block_cursor(block, &(0..8), TuiSize::new(40, 8)),
+        None
+    );
 }

--- a/crates/warp_tui/src/terminal_content_element.rs
+++ b/crates/warp_tui/src/terminal_content_element.rs
@@ -9,10 +9,11 @@
 //! `TuiTerminalSessionView::handle_terminal_resize`), which layout and paint
 //! passes cannot do themselves.
 //!
-//! When configured with [`Self::with_pty_input`], the same wrapper also gives
-//! the foreground process first refusal on key and paste events. Keeping both
-//! responsibilities here ensures the subtree measured for the PTY is also the
-//! subtree that owns its input.
+//! When configured with [`TuiTerminalContentElement::with_pty_input`], the same
+//! wrapper also gives the foreground process first refusal on key and paste
+//! events. Keeping both responsibilities here ensures the subtree measured for
+//! the PTY is also the subtree that owns its input.
+
 use std::ops::Deref as _;
 use std::sync::Arc;
 
@@ -28,14 +29,15 @@ use warpui_core::AppContext;
 
 use crate::terminal_session_view::TuiTerminalSessionAction;
 
-/// Wraps the element displaying PTY content and reports its laid-out size.
-pub(crate) struct TuiTerminalSizeElement {
+/// Wraps the element displaying PTY content, reports its laid-out size, and
+/// optionally forwards input to the foreground process.
+pub(crate) struct TuiTerminalContentElement {
     child: Box<dyn TuiElement>,
     resize_tx: Sender<TuiSize>,
     pty_input_model: Option<Arc<FairMutex<TerminalModel>>>,
 }
 
-impl TuiTerminalSizeElement {
+impl TuiTerminalContentElement {
     /// Wraps `child`, publishing its laid-out size on `resize_tx`.
     pub(crate) fn new(resize_tx: Sender<TuiSize>, child: Box<dyn TuiElement>) -> Self {
         Self {
@@ -53,7 +55,7 @@ impl TuiTerminalSizeElement {
     }
 }
 
-impl TuiElement for TuiTerminalSizeElement {
+impl TuiElement for TuiTerminalContentElement {
     fn layout(
         &mut self,
         constraint: TuiConstraint,
@@ -182,5 +184,5 @@ fn paste_bytes(text: &str, needs_bracketed_paste: bool) -> Vec<u8> {
 }
 
 #[cfg(test)]
-#[path = "terminal_size_element_tests.rs"]
+#[path = "terminal_content_element_tests.rs"]
 mod tests;

--- a/crates/warp_tui/src/terminal_content_element_tests.rs
+++ b/crates/warp_tui/src/terminal_content_element_tests.rs
@@ -12,7 +12,7 @@ use warpui_core::event::KeyEventDetails;
 use warpui_core::keymap::Keystroke;
 use warpui_core::{App, AppContext};
 
-use super::{paste_bytes, pty_bytes_for_event, TuiTerminalSizeElement};
+use super::{paste_bytes, pty_bytes_for_event, TuiTerminalContentElement};
 
 /// A leaf that fills its constraint and retains the laid-out size.
 struct FillElement {
@@ -62,7 +62,7 @@ fn layout_measures_and_after_layout_publishes_the_size() {
         app.read(|app| {
             let (resize_tx, resize_rx) = async_channel::unbounded();
             let mut element =
-                TuiTerminalSizeElement::new(resize_tx, FillElement { size: None }.finish());
+                TuiTerminalContentElement::new(resize_tx, FillElement { size: None }.finish());
             let expected_size = TuiSize::new(42, 8);
             let mut rendered_views = EntityIdMap::default();
             let mut layout_ctx = TuiLayoutContext {
@@ -141,7 +141,7 @@ fn dropped_receiver_does_not_panic() {
             let (resize_tx, resize_rx) = async_channel::unbounded::<TuiSize>();
             drop(resize_rx);
             let mut element =
-                TuiTerminalSizeElement::new(resize_tx, FillElement { size: None }.finish());
+                TuiTerminalContentElement::new(resize_tx, FillElement { size: None }.finish());
             let mut rendered_views = EntityIdMap::default();
             let mut layout_ctx = TuiLayoutContext {
                 rendered_views: &mut rendered_views,

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -44,7 +44,7 @@ use warpui_core::elements::tui::{
     TuiChildView, TuiConstrainedBox, TuiContainer, TuiElement, TuiFlex, TuiSize, TuiText,
 };
 use warpui_core::keymap::macros::*;
-use warpui_core::keymap::FixedBinding;
+use warpui_core::keymap::{self, FixedBinding};
 use warpui_core::platform::TerminationMode;
 use warpui_core::r#async::{SpawnedFutureHandle, Timer};
 use warpui_core::{
@@ -68,8 +68,8 @@ use crate::skills_menu::{TuiSkillMenuEvent, TuiSkillMenuModel};
 use crate::slash_commands::TuiSlashCommandModel;
 use crate::terminal_size_element::TuiTerminalSizeElement;
 use crate::terminal_use::{
-    hide_agent_requested_command_from_top_level, terminal_use_conversation_to_resume,
-    terminal_use_interrupt_action, user_controlled_line_bytes, TerminalUseInterruptAction,
+    hide_agent_requested_command_from_top_level, inline_process_owns_input,
+    terminal_use_conversation_to_resume, terminal_use_interrupt_action, TerminalUseInterruptAction,
 };
 use crate::transcript_view::{TuiTranscriptView, TuiTranscriptViewEvent};
 use crate::transient_hint::{TransientHint, TransientHintTone};
@@ -88,6 +88,8 @@ const MAX_INPUT_TEXT_ROWS: u16 = 6;
 
 /// The footer hint shown while the ctrl-c exit confirmation is armed.
 const CTRL_C_EXIT_HINT: &str = "ctrl-c again to exit";
+const SESSION_CAN_CANCEL_RESTORE_FLAG: &str = "TuiSessionCanCancelRestore";
+const SESSION_CAN_HAND_BACK_CONTROL_FLAG: &str = "TuiSessionCanHandBackControl";
 
 /// Events emitted by the TUI terminal session surface.
 pub(crate) enum TuiTerminalSessionEvent {
@@ -97,6 +99,7 @@ pub(crate) enum TuiTerminalSessionEvent {
         bytes: Cow<'static, [u8]>,
         mode: AIAgentPtyWriteMode,
     },
+    WriteUserInput(Cow<'static, [u8]>),
     Resize(SizeUpdate),
 }
 
@@ -109,6 +112,7 @@ impl PtyIntentEvent for TuiTerminalSessionEvent {
                 bytes: bytes.clone(),
                 mode: *mode,
             }),
+            Self::WriteUserInput(bytes) => Some(PtyIntent::WriteBytes(bytes.clone())),
             Self::Resize(size_update) => Some(PtyIntent::Resize(*size_update)),
         }
     }
@@ -193,10 +197,8 @@ pub(crate) enum TuiTerminalSessionAction {
     /// Click on the footer's usage entry: flips the persisted credits⇄cost
     /// display-mode setting.
     ToggleUsageDisplay,
-    /// Raw bytes to forward to the PTY, produced by the alt-screen element
-    /// while a full-screen app is active (keystrokes encoded to escape
-    /// sequences). Delivered to the manager as a [`PtyIntent::WriteAgentInput`].
-    ForwardToPty(Vec<u8>),
+    /// Raw user bytes to forward to the foreground PTY process.
+    ForwardUserPtyBytes(Vec<u8>),
 }
 
 /// The authenticated terminal/session surface rendered inside [`RootTuiView`].
@@ -246,11 +248,6 @@ pub(crate) struct TuiTerminalSessionView {
     conversation_restore_state: ConversationRestoreState,
     next_restore_request_id: u64,
     exit_summary: TuiExitSummaryHandle,
-    /// Not a copy of the terminal model's alt-screen state: this is the last
-    /// alt-screen-active value the focus logic acted on, so the wakeup handler
-    /// can edge-detect enter/exit transitions and move focus (off the input
-    /// editor and back) once per transition instead of on every wakeup.
-    alt_screen_focus_active: bool,
 }
 
 /// Registers the session surface's keybindings. Called once at TUI startup
@@ -267,19 +264,37 @@ pub(crate) fn init(app: &mut AppContext) {
         FixedBinding::new(
             "escape",
             TuiTerminalSessionAction::CancelRestore,
-            id!(TuiTerminalSessionView::ui_name()),
+            id!(SESSION_CAN_CANCEL_RESTORE_FLAG),
         )
         .with_group(TUI_BINDING_GROUP),
         FixedBinding::new(
             HAND_BACK_KEY_BINDING,
             TuiTerminalSessionAction::HandBackTerminalUseControl,
-            id!(TuiTerminalSessionView::ui_name()),
+            id!(SESSION_CAN_HAND_BACK_CONTROL_FLAG),
         )
         .with_group(TUI_BINDING_GROUP),
     ]);
 }
 
 impl TuiTerminalSessionView {
+    /// Returns whether the foreground process should receive keyboard input
+    /// instead of Warp's editor. This is true for alt-screen applications and
+    /// for inline long-running commands currently controlled by the user, and
+    /// drives the session's focus, rendering, and event-routing transitions.
+    fn process_owns_input(&self) -> bool {
+        let terminal_model = self.terminal_model.lock();
+        terminal_model.is_alt_screen_active() || inline_process_owns_input(&terminal_model)
+    }
+
+    fn update_process_input_focus(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.process_owns_input() {
+            if !ctx.is_self_focused() {
+                ctx.focus_self();
+            }
+        } else if ctx.is_self_focused() {
+            ctx.focus(&self.input_view);
+        }
+    }
     fn resume_after_user_controlled_command(
         &mut self,
         block_id: &BlockId,
@@ -385,6 +400,7 @@ impl TuiTerminalSessionView {
                 });
             }
         }
+        self.update_process_input_focus(ctx);
         ctx.notify();
     }
 
@@ -402,6 +418,7 @@ impl TuiTerminalSessionView {
                         ctx,
                     );
                 });
+                self.update_process_input_focus(ctx);
                 true
             }
             TerminalUseInterruptAction::InterruptCommand => {
@@ -418,6 +435,7 @@ impl TuiTerminalSessionView {
         self.cli_subagent_controller.update(ctx, |controller, ctx| {
             controller.handoff_active_command_control_to_agent(ctx);
         });
+        self.update_process_input_focus(ctx);
     }
 
     fn active_agent_controlled_target(&self, ctx: &AppContext) -> Option<CLISubagentTarget> {
@@ -466,20 +484,6 @@ impl TuiTerminalSessionView {
         true
     }
 
-    fn send_user_controlled_pty_input(&mut self, input: &str, ctx: &mut ViewContext<Self>) -> bool {
-        if self.active_user_controlled_target(ctx).is_none() {
-            return false;
-        }
-        ctx.emit(TuiTerminalSessionEvent::WriteAgentInput {
-            bytes: Cow::Owned(user_controlled_line_bytes(input)),
-            mode: AIAgentPtyWriteMode::Raw,
-        });
-        self.input_view.update(ctx, |input, ctx| {
-            input.clear(ctx);
-            input.exit_shell_mode(ctx);
-        });
-        true
-    }
     /// Builds the transcript-capable terminal surface for a manager-backed session.
     pub(crate) fn new(
         surface_init: TerminalSurfaceInit,
@@ -784,10 +788,14 @@ impl TuiTerminalSessionView {
         ctx.subscribe_to_model(&model_events, |view, _, event, ctx| match event {
             ModelEvent::BlockCompleted(completed) => {
                 view.resume_after_user_controlled_command(&completed.block_id, ctx);
+                view.update_process_input_focus(ctx);
                 ctx.notify();
             }
-            ModelEvent::AfterBlockStarted { .. }
-            | ModelEvent::BlockMetadataReceived(_)
+            ModelEvent::AfterBlockStarted { .. } => {
+                view.update_process_input_focus(ctx);
+                ctx.notify();
+            }
+            ModelEvent::BlockMetadataReceived(_)
             | ModelEvent::BlockWorkingDirectoryUpdated(_)
             | ModelEvent::BackgroundBlockStarted
             | ModelEvent::TerminalClear
@@ -889,31 +897,14 @@ impl TuiTerminalSessionView {
         ctx.spawn_stream_local(
             throttle(WAKEUP_THROTTLE_PERIOD, wakeups_rx),
             |view, _, ctx| {
-                let alt_screen_active = {
+                {
                     let mut model = view.terminal_model.lock();
-                    let alt_screen_active = model.is_alt_screen_active();
-                    if !alt_screen_active {
+                    if !model.is_alt_screen_active() {
                         model.block_list_mut().update_background_block_height();
                         model.block_list_mut().update_active_block_height();
                     }
-                    alt_screen_active
-                };
-
-                // While the alt-screen app is active it owns the keyboard, so
-                // move focus off the input editor and onto this view: unbound
-                // keys then fall through the keymap to the alt-screen element,
-                // which forwards them to the PTY. (ctrl-c is the one bound key
-                // that still reaches the keymap; `handle_interrupt` forwards it
-                // to the app while alt-screen is active.) Restore input focus on
-                // exit.
-                if alt_screen_active != view.alt_screen_focus_active {
-                    view.alt_screen_focus_active = alt_screen_active;
-                    if alt_screen_active {
-                        ctx.focus_self();
-                    } else {
-                        ctx.focus(&view.input_view);
-                    }
                 }
+                view.update_process_input_focus(ctx);
 
                 ctx.notify();
             },
@@ -955,7 +946,6 @@ impl TuiTerminalSessionView {
             conversation_restore_state: ConversationRestoreState::Idle,
             next_restore_request_id: 0,
             exit_summary,
-            alt_screen_focus_active: false,
         }
     }
 
@@ -1305,25 +1295,25 @@ impl TuiTerminalSessionView {
             ctx.terminate_app(TerminationMode::ForceTerminate, None);
             return;
         }
-        // While a full-screen app is active, ctrl-c belongs to that app (it does
-        // its own interrupt handling, e.g. SIGINT), not the TUI. Forward the C0
-        // ETX byte to the PTY instead of cancelling the conversation or arming
-        // the TUI exit.
+        // While a full-screen app is active, ctrl-c belongs to that app.
         if self.terminal_model.lock().is_alt_screen_active() {
-            ctx.emit(TuiTerminalSessionEvent::WriteAgentInput {
-                bytes: Cow::Owned(vec![0x03]),
-                mode: AIAgentPtyWriteMode::Raw,
-            });
-            return;
-        }
-        let now = Instant::now();
-        if self.exit_confirmation.should_exit(now) {
-            ctx.terminate_app(TerminationMode::ForceTerminate, None);
+            ctx.emit(TuiTerminalSessionEvent::WriteUserInput(Cow::Owned(vec![
+                0x03,
+            ])));
             return;
         }
         if self.handle_terminal_use_interrupt(ctx) {
             self.exit_confirmation.disarm();
             ctx.notify();
+            return;
+        }
+        if self.process_owns_input() {
+            ctx.emit(TuiTerminalSessionEvent::InterruptPty);
+            return;
+        }
+        let now = Instant::now();
+        if self.exit_confirmation.should_exit(now) {
+            ctx.terminate_app(TerminationMode::ForceTerminate, None);
             return;
         }
 
@@ -1576,12 +1566,10 @@ impl TuiTerminalSessionView {
         if self.send_terminal_use_prompt(&text, ctx) {
             self.input_view
                 .update(ctx, |input, ctx| input.exit_shell_mode(ctx));
-        } else if !self.send_user_controlled_pty_input(&text, ctx) {
-            if self.is_shell_mode(ctx) {
-                self.execute_user_command(&text, ctx);
-            } else {
-                self.handle_submitted_input(&text, ctx);
-            }
+        } else if self.is_shell_mode(ctx) {
+            self.execute_user_command(&text, ctx);
+        } else {
+            self.handle_submitted_input(&text, ctx);
         }
         ctx.notify();
     }
@@ -2099,6 +2087,17 @@ impl TuiView for TuiTerminalSessionView {
         vec![self.transcript.id(), self.input_view.id()]
     }
 
+    fn keymap_context(&self, ctx: &AppContext) -> keymap::Context {
+        let mut context = Self::default_keymap_context();
+        if self.is_conversation_restore_loading() {
+            context.set.insert(SESSION_CAN_CANCEL_RESTORE_FLAG);
+        }
+        if self.active_user_controlled_target(ctx).is_some() {
+            context.set.insert(SESSION_CAN_HAND_BACK_CONTROL_FLAG);
+        }
+        context
+    }
+
     fn render(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
         match &self.conversation_restore_state {
             ConversationRestoreState::Loading {
@@ -2116,34 +2115,32 @@ impl TuiView for TuiTerminalSessionView {
         }
         // While a full-screen (alt-screen) app is active, hand the whole pane to
         // it: render its grid and forward input, instead of the block UI.
-        if self.terminal_model.lock().is_alt_screen_active() {
+        let (alt_screen_active, inline_process_owns_input) = {
+            let terminal_model = self.terminal_model.lock();
+            (
+                terminal_model.is_alt_screen_active(),
+                inline_process_owns_input(&terminal_model),
+            )
+        };
+        if alt_screen_active {
             return TuiTerminalSizeElement::new(
                 self.terminal_resize_tx.clone(),
                 AltScreenElement::new(self.terminal_model.clone()).finish(),
             )
+            .with_pty_input(self.terminal_model.clone())
             .finish();
         }
 
-        let inline_menu = active_inline_menu(
-            &self.inline_menus,
-            self.suggestions_mode.as_ref(ctx).mode(),
-            ctx,
-        )
-        .and_then(|menu| menu.render(ctx));
-        // The border takes the shell-mode accent while in shell mode.
-        let builder = TuiUiBuilder::from_app(ctx);
-        let border_style = if self.is_shell_mode(ctx) {
-            builder.shell_mode_accent_style()
-        } else {
-            builder.accent_border_style()
-        };
-        let input_box = TuiConstrainedBox::new(
-            TuiContainer::new(TuiChildView::new(&self.input_view).finish())
-                .with_padding_x(1)
-                .with_border_style(border_style)
-                .finish(),
-        )
-        .with_max_rows(MAX_INPUT_TEXT_ROWS + 2);
+        let inline_menu = (!inline_process_owns_input)
+            .then(|| {
+                active_inline_menu(
+                    &self.inline_menus,
+                    self.suggestions_mode.as_ref(ctx).mode(),
+                    ctx,
+                )
+                .and_then(|menu| menu.render(ctx))
+            })
+            .flatten();
 
         // Ctrl-c (cancel/clear/exit) is handled by the keymap pass via the
         // fixed binding registered in [`Self::init`], so no element-level key
@@ -2164,17 +2161,22 @@ impl TuiView for TuiTerminalSessionView {
 
         // While the selected conversation is in progress (the GUI warping
         // indicator's core condition), the animated warping indicator sits
-        // between the transcript and the input box. Its elapsed counter is
-        // anchored to the latest exchange's start so animation survives
-        // element-tree rebuilds; the conversation's final status update
-        // re-renders the view without it.
-        let selected_conversation = self
-            .conversation_selection
-            .as_ref(ctx)
-            .selected_conversation_id(ctx)
-            .and_then(|conversation_id| {
-                BlocklistAIHistoryModel::as_ref(ctx).conversation(&conversation_id)
-            });
+        // between the transcript and the input box. Hide it while a process
+        // owns input: user takeover intentionally leaves the conversation in
+        // progress, so the indicator would otherwise appear stuck. Its elapsed
+        // counter is anchored to the latest exchange's start so animation
+        // survives element-tree rebuilds; the conversation's final status
+        // update re-renders the view without it.
+        let selected_conversation = (!inline_process_owns_input)
+            .then(|| {
+                self.conversation_selection
+                    .as_ref(ctx)
+                    .selected_conversation_id(ctx)
+                    .and_then(|conversation_id| {
+                        BlocklistAIHistoryModel::as_ref(ctx).conversation(&conversation_id)
+                    })
+            })
+            .flatten();
         if let Some(conversation) = selected_conversation {
             if conversation.status().is_in_progress() {
                 let warping_elapsed = conversation
@@ -2222,22 +2224,46 @@ impl TuiView for TuiTerminalSessionView {
                     .finish(),
             );
         }
-        content = content.child(input_box.finish()).child(
-            TuiConstrainedBox::new(self.render_footer(ctx).finish())
-                .with_max_rows(1)
+        if !inline_process_owns_input {
+            let builder = TuiUiBuilder::from_app(ctx);
+            let border_style = if self.is_shell_mode(ctx) {
+                builder.shell_mode_accent_style()
+            } else {
+                builder.accent_border_style()
+            };
+            content = content.child(
+                TuiConstrainedBox::new(
+                    TuiContainer::new(TuiChildView::new(&self.input_view).finish())
+                        .with_padding_x(1)
+                        .with_border_style(border_style)
+                        .finish(),
+                )
+                .with_max_rows(MAX_INPUT_TEXT_ROWS + 2)
                 .finish(),
-        );
+            );
+            content = content.child(
+                TuiConstrainedBox::new(self.render_footer(ctx).finish())
+                    .with_max_rows(1)
+                    .finish(),
+            );
+        }
+        let content = content.finish();
+        let terminal_content =
+            TuiTerminalSizeElement::new(self.terminal_resize_tx.clone(), content);
+        let terminal_content = if inline_process_owns_input {
+            terminal_content.with_pty_input(self.terminal_model.clone())
+        } else {
+            terminal_content
+        };
 
         // The size wrapper sits inside the horizontal padding so the PTY's
         // columns match the width block content actually renders at (the GUI
         // wraps its view root, but its padding is sub-cell; here it is 4 whole
         // columns).
-        TuiContainer::new(
-            TuiTerminalSizeElement::new(self.terminal_resize_tx.clone(), content.finish()).finish(),
-        )
-        .with_padding_x(2)
-        .with_padding_top(2)
-        .finish()
+        TuiContainer::new(terminal_content.finish())
+            .with_padding_x(2)
+            .with_padding_top(2)
+            .finish()
     }
 }
 
@@ -2254,13 +2280,12 @@ impl TypedActionView for TuiTerminalSessionView {
                 self.hand_back_terminal_use_control(ctx)
             }
             TuiTerminalSessionAction::ToggleUsageDisplay => self.toggle_usage_display(ctx),
-            TuiTerminalSessionAction::ForwardToPty(bytes) => {
+            TuiTerminalSessionAction::ForwardUserPtyBytes(bytes) => {
                 // Raw passthrough: the bytes are already the app's escape
                 // sequence, so write them to the PTY unmodified.
-                ctx.emit(TuiTerminalSessionEvent::WriteAgentInput {
-                    bytes: Cow::Owned(bytes.clone()),
-                    mode: AIAgentPtyWriteMode::Raw,
-                });
+                ctx.emit(TuiTerminalSessionEvent::WriteUserInput(Cow::Owned(
+                    bytes.clone(),
+                )));
             }
         }
     }

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -66,7 +66,7 @@ use crate::model_menu::{TuiModelMenuEvent, TuiModelMenuModel};
 use crate::resume::TuiExitSummaryHandle;
 use crate::skills_menu::{TuiSkillMenuEvent, TuiSkillMenuModel};
 use crate::slash_commands::TuiSlashCommandModel;
-use crate::terminal_size_element::TuiTerminalSizeElement;
+use crate::terminal_content_element::TuiTerminalContentElement;
 use crate::terminal_use::{
     hide_agent_requested_command_from_top_level, inline_process_owns_input,
     terminal_use_conversation_to_resume, terminal_use_interrupt_action, TerminalUseInterruptAction,
@@ -405,10 +405,17 @@ impl TuiTerminalSessionView {
     }
 
     fn handle_terminal_use_interrupt(&mut self, ctx: &mut ViewContext<Self>) -> bool {
-        let Some(target) = self.cli_subagent_controller.as_ref(ctx).active_target() else {
+        let control_state = self
+            .cli_subagent_controller
+            .as_ref(ctx)
+            .active_target()
+            .map(|target| target.control_state);
+        let Some(action) =
+            terminal_use_interrupt_action(control_state.as_ref(), self.process_owns_input())
+        else {
             return false;
         };
-        match terminal_use_interrupt_action(&target.control_state) {
+        match action {
             TerminalUseInterruptAction::TakeControl => {
                 self.cli_subagent_controller.update(ctx, |controller, ctx| {
                     controller.switch_control_to_user(
@@ -1190,7 +1197,7 @@ impl TuiTerminalSessionView {
     /// TUI counterpart of the GUI's `after_terminal_view_layout`
     /// (`app/src/terminal/view.rs`): consumes the after-layout resize channel
     /// and commits the resize with a `ViewContext`. Fed by the
-    /// [`TuiTerminalSizeElement`] wrapping the block-list content column or the
+    /// [`TuiTerminalContentElement`] wrapping the block-list content column or the
     /// alt-screen grid, so the PTY tracks whichever region PTY content
     /// currently occupies.
     fn handle_terminal_resize(&mut self, size: TuiSize, ctx: &mut ViewContext<Self>) {
@@ -1295,20 +1302,9 @@ impl TuiTerminalSessionView {
             ctx.terminate_app(TerminationMode::ForceTerminate, None);
             return;
         }
-        // While a full-screen app is active, ctrl-c belongs to that app.
-        if self.terminal_model.lock().is_alt_screen_active() {
-            ctx.emit(TuiTerminalSessionEvent::WriteUserInput(Cow::Owned(vec![
-                0x03,
-            ])));
-            return;
-        }
         if self.handle_terminal_use_interrupt(ctx) {
             self.exit_confirmation.disarm();
             ctx.notify();
-            return;
-        }
-        if self.process_owns_input() {
-            ctx.emit(TuiTerminalSessionEvent::InterruptPty);
             return;
         }
         let now = Instant::now();
@@ -2123,7 +2119,7 @@ impl TuiView for TuiTerminalSessionView {
             )
         };
         if alt_screen_active {
-            return TuiTerminalSizeElement::new(
+            return TuiTerminalContentElement::new(
                 self.terminal_resize_tx.clone(),
                 AltScreenElement::new(self.terminal_model.clone()).finish(),
             )
@@ -2249,17 +2245,17 @@ impl TuiView for TuiTerminalSessionView {
         }
         let content = content.finish();
         let terminal_content =
-            TuiTerminalSizeElement::new(self.terminal_resize_tx.clone(), content);
+            TuiTerminalContentElement::new(self.terminal_resize_tx.clone(), content);
         let terminal_content = if inline_process_owns_input {
             terminal_content.with_pty_input(self.terminal_model.clone())
         } else {
             terminal_content
         };
 
-        // The size wrapper sits inside the horizontal padding so the PTY's
-        // columns match the width block content actually renders at (the GUI
-        // wraps its view root, but its padding is sub-cell; here it is 4 whole
-        // columns).
+        // The terminal-content wrapper sits inside the horizontal padding so
+        // the PTY's columns match the width block content actually renders at
+        // (the GUI wraps its view root, but its padding is sub-cell; here it is
+        // 4 whole columns).
         TuiContainer::new(terminal_content.finish())
             .with_padding_x(2)
             .with_padding_top(2)

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -11,6 +11,15 @@ fn interrupt_event_projects_to_high_level_pty_intent() {
 }
 
 #[test]
+fn user_input_event_projects_to_raw_user_bytes() {
+    let event = TuiTerminalSessionEvent::WriteUserInput(b"hello\r".to_vec().into());
+    let Some(PtyIntent::WriteBytes(bytes)) = event.pty_intent() else {
+        panic!("user input event should map to raw PTY bytes");
+    };
+    assert_eq!(&*bytes, b"hello\r");
+}
+
+#[test]
 fn non_command_prompt_preserves_leading_whitespace() {
     assert_eq!(raw_prompt_if_not_blank("  /compact"), Some("  /compact"));
 }

--- a/crates/warp_tui/src/terminal_size_element.rs
+++ b/crates/warp_tui/src/terminal_size_element.rs
@@ -1,4 +1,4 @@
-//! Publishes a subtree's laid-out cell size for PTY sizing.
+//! Publishes terminal content size and optionally forwards foreground PTY input.
 //!
 //! The TUI mirror of the GUI's `TerminalSizeElement`
 //! (`app/src/terminal/terminal_size_element.rs`): a transparent wrapper around
@@ -8,24 +8,48 @@
 //! with a `ViewContext` and commits the model + PTY resize (see
 //! `TuiTerminalSessionView::handle_terminal_resize`), which layout and paint
 //! passes cannot do themselves.
+//!
+//! When configured with [`Self::with_pty_input`], the same wrapper also gives
+//! the foreground process first refusal on key and paste events. Keeping both
+//! responsibilities here ensures the subtree measured for the PTY is also the
+//! subtree that owns its input.
+use std::ops::Deref as _;
+use std::sync::Arc;
 
 use async_channel::Sender;
+use parking_lot::FairMutex;
+use warp::tui_export::{KeystrokeWithDetails, TerminalModel};
+use warp_terminal::model::escape_sequences::{BRACKETED_PASTE_END, BRACKETED_PASTE_START};
 use warpui_core::elements::tui::{
     TuiConstraint, TuiElement, TuiEvent, TuiEventContext, TuiLayoutContext, TuiPaintContext,
     TuiPaintSurface, TuiPresentationContext, TuiScreenPoint, TuiScreenPosition, TuiSize,
 };
 use warpui_core::AppContext;
 
+use crate::terminal_session_view::TuiTerminalSessionAction;
+
 /// Wraps the element displaying PTY content and reports its laid-out size.
 pub(crate) struct TuiTerminalSizeElement {
     child: Box<dyn TuiElement>,
     resize_tx: Sender<TuiSize>,
+    pty_input_model: Option<Arc<FairMutex<TerminalModel>>>,
 }
 
 impl TuiTerminalSizeElement {
     /// Wraps `child`, publishing its laid-out size on `resize_tx`.
     pub(crate) fn new(resize_tx: Sender<TuiSize>, child: Box<dyn TuiElement>) -> Self {
-        Self { child, resize_tx }
+        Self {
+            child,
+            resize_tx,
+            pty_input_model: None,
+        }
+    }
+
+    /// Gives the foreground process first refusal on key and paste events for
+    /// this terminal-content subtree.
+    pub(crate) fn with_pty_input(mut self, model: Arc<FairMutex<TerminalModel>>) -> Self {
+        self.pty_input_model = Some(model);
+        self
     }
 }
 
@@ -77,8 +101,84 @@ impl TuiElement for TuiTerminalSizeElement {
         event_ctx: &mut TuiEventContext<'_>,
         app: &AppContext,
     ) -> bool {
+        if let Some(model) = self.pty_input_model.as_ref() {
+            match event {
+                TuiEvent::KeyDown {
+                    is_composing: false,
+                    ..
+                }
+                | TuiEvent::Paste { .. } => {
+                    if let Some(bytes) = pty_bytes_for_event(event, model) {
+                        event_ctx.dispatch_typed_action(
+                            TuiTerminalSessionAction::ForwardUserPtyBytes(bytes),
+                        );
+                    }
+                    return true;
+                }
+                TuiEvent::KeyDown {
+                    is_composing: true, ..
+                } => return false,
+                TuiEvent::ScrollWheel { .. }
+                | TuiEvent::LeftMouseDown { .. }
+                | TuiEvent::LeftMouseUp { .. }
+                | TuiEvent::LeftMouseDragged { .. }
+                | TuiEvent::MiddleMouseDown { .. }
+                | TuiEvent::RightMouseDown { .. }
+                | TuiEvent::MouseMoved { .. } => {}
+            }
+        }
         self.child.dispatch_event(event, event_ctx, app)
     }
+}
+
+/// Converts one semantic TUI input event to bytes for the foreground process.
+/// Pointer events and composing key events are left for the child subtree.
+fn pty_bytes_for_event(event: &TuiEvent, model: &Arc<FairMutex<TerminalModel>>) -> Option<Vec<u8>> {
+    match event {
+        TuiEvent::KeyDown {
+            keystroke,
+            chars,
+            details,
+            is_composing: false,
+        } => {
+            let model = model.lock();
+            KeystrokeWithDetails {
+                keystroke,
+                key_without_modifiers: details.key_without_modifiers.as_deref(),
+                chars: Some(chars.as_str()),
+            }
+            .to_pty_bytes(model.deref())
+        }
+        TuiEvent::Paste { text } => {
+            let needs_bracketed_paste = model.lock().needs_bracketed_paste();
+            Some(paste_bytes(text, needs_bracketed_paste))
+        }
+        TuiEvent::KeyDown {
+            is_composing: true, ..
+        }
+        | TuiEvent::ScrollWheel { .. }
+        | TuiEvent::LeftMouseDown { .. }
+        | TuiEvent::LeftMouseUp { .. }
+        | TuiEvent::LeftMouseDragged { .. }
+        | TuiEvent::MiddleMouseDown { .. }
+        | TuiEvent::RightMouseDown { .. }
+        | TuiEvent::MouseMoved { .. } => None,
+    }
+}
+
+fn paste_bytes(text: &str, needs_bracketed_paste: bool) -> Vec<u8> {
+    let normalized = text.replace("\r\n", "\r").replace('\n', "\r");
+    if !needs_bracketed_paste {
+        return normalized.into_bytes();
+    }
+
+    let mut bytes = Vec::with_capacity(
+        BRACKETED_PASTE_START.len() + normalized.len() + BRACKETED_PASTE_END.len(),
+    );
+    bytes.extend_from_slice(BRACKETED_PASTE_START);
+    bytes.extend_from_slice(normalized.as_bytes());
+    bytes.extend_from_slice(BRACKETED_PASTE_END);
+    bytes
 }
 
 #[cfg(test)]

--- a/crates/warp_tui/src/terminal_size_element_tests.rs
+++ b/crates/warp_tui/src/terminal_size_element_tests.rs
@@ -1,11 +1,18 @@
+use std::sync::Arc;
+
+use parking_lot::FairMutex;
+use warp::tui_export::TerminalModel;
+use warp_terminal::model::escape_sequences::{BRACKETED_PASTE_END, BRACKETED_PASTE_START};
 use warpui::EntityIdMap;
 use warpui_core::elements::tui::{
-    TuiConstraint, TuiElement, TuiLayoutContext, TuiPaintContext, TuiPaintSurface,
+    TuiConstraint, TuiElement, TuiEvent, TuiLayoutContext, TuiPaintContext, TuiPaintSurface,
     TuiScreenPosition, TuiSize,
 };
+use warpui_core::event::KeyEventDetails;
+use warpui_core::keymap::Keystroke;
 use warpui_core::{App, AppContext};
 
-use super::TuiTerminalSizeElement;
+use super::{paste_bytes, pty_bytes_for_event, TuiTerminalSizeElement};
 
 /// A leaf that fills its constraint and retains the laid-out size.
 struct FillElement {
@@ -33,6 +40,19 @@ impl TuiElement for FillElement {
 
     fn size(&self) -> Option<TuiSize> {
         self.size
+    }
+}
+
+fn key_down(key: &str, chars: &str, ctrl: bool) -> TuiEvent {
+    TuiEvent::KeyDown {
+        keystroke: Keystroke {
+            key: key.to_owned(),
+            ctrl,
+            ..Default::default()
+        },
+        chars: chars.to_owned(),
+        details: KeyEventDetails::default(),
+        is_composing: false,
     }
 }
 
@@ -66,6 +86,52 @@ fn layout_measures_and_after_layout_publishes_the_size() {
             );
         });
     });
+}
+
+#[test]
+fn key_events_use_terminal_aware_pty_encoding() {
+    let model = Arc::new(FairMutex::new(TerminalModel::mock(None, None)));
+
+    assert_eq!(
+        pty_bytes_for_event(&key_down("enter", "", false), &model),
+        Some(vec![b'\r'])
+    );
+    assert_eq!(
+        pty_bytes_for_event(&key_down("d", "d", true), &model),
+        Some(vec![0x04])
+    );
+    assert_eq!(
+        pty_bytes_for_event(&key_down("é", "é", false), &model),
+        Some("é".as_bytes().to_vec())
+    );
+}
+
+#[test]
+fn composing_key_event_is_not_forwarded() {
+    let model = Arc::new(FairMutex::new(TerminalModel::mock(None, None)));
+    let mut event = key_down("a", "a", false);
+    let TuiEvent::KeyDown { is_composing, .. } = &mut event else {
+        unreachable!();
+    };
+    *is_composing = true;
+
+    assert_eq!(pty_bytes_for_event(&event, &model), None);
+}
+
+#[test]
+fn paste_normalizes_newlines_and_optionally_adds_bracket_markers() {
+    assert_eq!(
+        paste_bytes("first\nsecond\r\nthird\r", false),
+        b"first\rsecond\rthird\r"
+    );
+
+    let bytes = paste_bytes("first\nsecond", true);
+    assert!(bytes.starts_with(BRACKETED_PASTE_START));
+    assert!(bytes.ends_with(BRACKETED_PASTE_END));
+    assert_eq!(
+        &bytes[BRACKETED_PASTE_START.len()..bytes.len() - BRACKETED_PASTE_END.len()],
+        b"first\rsecond"
+    );
 }
 
 #[test]

--- a/crates/warp_tui/src/terminal_use.rs
+++ b/crates/warp_tui/src/terminal_use.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 
 use parking_lot::FairMutex;
 use warp::tui_export::{
-    AIAgentActionId, AIConversationId, BlockId, LongRunningCommandControlState, TerminalModel,
+    AIAgentActionId, AIConversationId, Block, BlockId, LongRunningCommandControlState,
+    TerminalModel,
 };
 
 /// Keeps an agent-requested command's canonical block out of the TUI's
@@ -56,13 +57,18 @@ pub(super) fn terminal_use_conversation_to_resume(
     .then_some(*metadata.conversation_id())
 }
 
-pub(super) fn user_controlled_line_bytes(input: &str) -> Vec<u8> {
-    let mut bytes = input.as_bytes().to_vec();
-    #[cfg(target_os = "windows")]
-    bytes.push(b'\r');
-    #[cfg(not(target_os = "windows"))]
-    bytes.push(b'\n');
-    bytes
+/// Whether a running inline command, rather than Warp's editor or agent, owns
+/// keyboard input.
+pub(super) fn user_controls_running_command(block: &Block) -> bool {
+    block.is_active_and_long_running()
+        && block.is_bootstrapped()
+        && !block.is_in_band_command_block()
+        && !block.is_agent_driving_command()
+        && !block.is_agent_tagged_in()
+}
+
+pub(super) fn inline_process_owns_input(terminal_model: &TerminalModel) -> bool {
+    user_controls_running_command(terminal_model.block_list().active_block())
 }
 
 #[cfg(test)]

--- a/crates/warp_tui/src/terminal_use.rs
+++ b/crates/warp_tui/src/terminal_use.rs
@@ -34,11 +34,18 @@ pub(super) enum TerminalUseInterruptAction {
 }
 
 pub(super) fn terminal_use_interrupt_action(
-    control_state: &LongRunningCommandControlState,
-) -> TerminalUseInterruptAction {
+    control_state: Option<&LongRunningCommandControlState>,
+    process_owns_input: bool,
+) -> Option<TerminalUseInterruptAction> {
     match control_state {
-        LongRunningCommandControlState::Agent { .. } => TerminalUseInterruptAction::TakeControl,
-        LongRunningCommandControlState::User { .. } => TerminalUseInterruptAction::InterruptCommand,
+        Some(LongRunningCommandControlState::Agent { .. }) => {
+            Some(TerminalUseInterruptAction::TakeControl)
+        }
+        Some(LongRunningCommandControlState::User { .. }) => {
+            Some(TerminalUseInterruptAction::InterruptCommand)
+        }
+        None if process_owns_input => Some(TerminalUseInterruptAction::InterruptCommand),
+        None => None,
     }
 }
 

--- a/crates/warp_tui/src/terminal_use_tests.rs
+++ b/crates/warp_tui/src/terminal_use_tests.rs
@@ -240,8 +240,8 @@ fn terminal_use_interrupt_follows_takeover_then_process_interrupt_policy() {
         should_hide_responses: false,
     };
     assert_eq!(
-        terminal_use_interrupt_action(&agent),
-        TerminalUseInterruptAction::TakeControl
+        terminal_use_interrupt_action(Some(&agent), true),
+        Some(TerminalUseInterruptAction::TakeControl)
     );
 
     let stopped = LongRunningCommandControlState::User {
@@ -250,16 +250,16 @@ fn terminal_use_interrupt_follows_takeover_then_process_interrupt_policy() {
         },
     };
     assert_eq!(
-        terminal_use_interrupt_action(&stopped),
-        TerminalUseInterruptAction::InterruptCommand
+        terminal_use_interrupt_action(Some(&stopped), true),
+        Some(TerminalUseInterruptAction::InterruptCommand)
     );
 
     let manual = LongRunningCommandControlState::User {
         reason: UserTakeOverReason::Manual,
     };
     assert_eq!(
-        terminal_use_interrupt_action(&manual),
-        TerminalUseInterruptAction::InterruptCommand
+        terminal_use_interrupt_action(Some(&manual), true),
+        Some(TerminalUseInterruptAction::InterruptCommand)
     );
 
     let transferred = LongRunningCommandControlState::User {
@@ -268,9 +268,15 @@ fn terminal_use_interrupt_follows_takeover_then_process_interrupt_policy() {
         },
     };
     assert_eq!(
-        terminal_use_interrupt_action(&transferred),
-        TerminalUseInterruptAction::InterruptCommand
+        terminal_use_interrupt_action(Some(&transferred), true),
+        Some(TerminalUseInterruptAction::InterruptCommand)
     );
+
+    assert_eq!(
+        terminal_use_interrupt_action(None, true),
+        Some(TerminalUseInterruptAction::InterruptCommand)
+    );
+    assert_eq!(terminal_use_interrupt_action(None, false), None);
 }
 
 #[test]

--- a/crates/warp_tui/src/terminal_use_tests.rs
+++ b/crates/warp_tui/src/terminal_use_tests.rs
@@ -13,8 +13,8 @@ use warpui_core::elements::tui::{TuiLayoutContext, TuiViewportWindow, TuiViewpor
 use warpui_core::App;
 
 use super::{
-    hide_agent_requested_command_from_top_level, terminal_use_conversation_to_resume,
-    terminal_use_interrupt_action, user_controlled_line_bytes, TerminalUseInterruptAction,
+    hide_agent_requested_command_from_top_level, inline_process_owns_input,
+    terminal_use_conversation_to_resume, terminal_use_interrupt_action, TerminalUseInterruptAction,
 };
 use crate::tui_block_list_viewport_source::TuiBlockListViewportSource;
 
@@ -37,11 +37,56 @@ fn model_with_finished_block(command: &str) -> (TerminalModel, BlockId) {
 }
 
 #[test]
-fn user_controlled_line_has_no_agent_cursor_movement_prefix() {
-    #[cfg(target_os = "windows")]
-    assert_eq!(user_controlled_line_bytes("hello"), b"hello\r");
-    #[cfg(not(target_os = "windows"))]
-    assert_eq!(user_controlled_line_bytes("hello"), b"hello\n");
+fn ordinary_long_running_command_owns_inline_input() {
+    let mut model = TerminalModel::mock(None, None);
+    model.simulate_long_running_block("cat", "");
+
+    assert!(inline_process_owns_input(&model));
+}
+
+#[test]
+fn agent_command_owns_input_only_after_user_takeover() {
+    let mut model = TerminalModel::mock(None, None);
+    model.simulate_long_running_block("cargo build", "Compiling");
+    let conversation_id = AIConversationId::new();
+    let task_id = TaskId::new("terminal-use-task".to_owned());
+    {
+        let block = model.block_list_mut().active_block_mut();
+        block.set_agent_interaction_mode_for_requested_command(
+            AIAgentActionId::from("requested-command".to_owned()),
+            Some(task_id.clone()),
+            conversation_id,
+        );
+    }
+    assert!(!inline_process_owns_input(&model));
+
+    {
+        let block = model.block_list_mut().active_block_mut();
+        block
+            .set_agent_interaction_mode_for_agent_monitored_command(&task_id, conversation_id)
+            .expect("command should become agent monitored");
+    }
+    assert!(!inline_process_owns_input(&model));
+
+    {
+        let block = model.block_list_mut().active_block_mut();
+        block
+            .take_over_control_for_user(UserTakeOverReason::Manual)
+            .expect("user takeover should succeed");
+    }
+    assert!(inline_process_owns_input(&model));
+}
+
+#[test]
+fn tagged_in_agent_keeps_editor_input_visible() {
+    let mut model = TerminalModel::mock(None, None);
+    model.simulate_long_running_block("cat", "");
+    model
+        .block_list_mut()
+        .active_block_mut()
+        .set_is_agent_tagged_in(true);
+
+    assert!(!inline_process_owns_input(&model));
 }
 
 fn mark_visible_agent_requested_command(

--- a/crates/warp_tui/src/tui_shell_command_view.rs
+++ b/crates/warp_tui/src/tui_shell_command_view.rs
@@ -26,6 +26,7 @@ use crate::agent_block_sections::{
     render_fallback_tool_call_section, tool_call_glyph_style, tool_call_label_style,
 };
 use crate::terminal_block::TerminalBlockElement;
+use crate::terminal_use::user_controls_running_command;
 use crate::tool_call_labels::{
     tool_call_display_state, tool_call_glyph, tool_call_label, CommandBlockState,
     ResolvedCommandBlock,
@@ -210,6 +211,14 @@ impl TuiShellCommandView {
             },
         })
     }
+
+    fn user_controls_command(&self) -> bool {
+        self.terminal_model
+            .lock()
+            .block_list()
+            .block_for_ai_action_id(&self.action.id)
+            .is_some_and(user_controls_running_command)
+    }
 }
 
 impl Entity for TuiShellCommandView {
@@ -254,7 +263,7 @@ impl TuiView for TuiShellCommandView {
         if self.header_mouse_state.lock().unwrap().is_hovered() {
             label_style = label_style.add_modifier(Modifier::BOLD);
         }
-        let collapsed = self.state.is_collapsed();
+        let collapsed = self.state.is_collapsed() && !self.user_controls_command();
         let label = tool_call_label(&self.action, status.as_ref(), false, Some(&block.details));
         let header_spans = vec![
             (format!("{} ", tool_call_glyph(display_state)), glyph_style),
@@ -289,6 +298,9 @@ impl TypedActionView for TuiShellCommandView {
     fn handle_action(&mut self, action: &Self::Action, ctx: &mut ViewContext<Self>) {
         match action {
             TuiShellCommandViewAction::ToggleExpanded => {
+                if self.user_controls_command() {
+                    return;
+                }
                 self.state.toggle();
                 ctx.emit(TuiShellCommandViewEvent::LayoutChanged);
                 ctx.notify();


### PR DESCRIPTION
## Description
Fixes long-running process interaction in the headless TUI.

Previously, the TUI kept the editor visible and focused while a user-controlled command was running. This prevented ordinary shell commands—and agent commands after takeover—from receiving interactive input directly, left the process cursor in the wrong place, and could leave editor/footer/progress chrome visible over the running command.

This PR:
- Hides the editor, footer, inline menus, and conversation progress chrome while the foreground process owns input.
- Streams key and paste bytes directly to the PTY for ordinary long-running commands and agent commands after user takeover.
- Restores the editor when the command finishes or control returns to the agent.
- Renders the active inline terminal cursor using displayed-grid and viewport coordinates.
- Keeps user-controlled agent command output expanded so its prompt and cursor remain visible.
- Scopes Ctrl-G to agent handback and Escape to conversation restoration so other commands can receive those bytes normally.

Implementation details:
- Input ownership is derived directly from `TerminalModel`; no cached alt-screen state is maintained.
- `TuiTerminalSizeElement` is the shared transparent terminal-content wrapper. It always reports settled layout dimensions and optionally handles PTY key/paste forwarding.
- User input is emitted as `PtyIntent::WriteBytes`, while agent executor writes remain `WriteAgentInput`.
- Key encoding reuses the terminal-mode-aware encoder introduced for alt-screen support, including application-cursor and Kitty modes. Paste handling normalizes newlines and supports bracketed paste.

## Linked Issue
- [CODE-1838: Long-running commands can't receive input in TUI](https://linear.app/warpdotdev/issue/CODE-1838/long-running-commands-cant-receive-input-in-tui)
- [CODE-1857: Render long-running command with the correct blocking UI](https://linear.app/warpdotdev/issue/CODE-1857/render-long-running-command-with-the-correct-blocking-ui-with-proper)

## Testing
- [x] Manually tested locally with `./script/run-tui`.
  - Ordinary shell-mode long-running command: editor/footer hidden, inline cursor shown, input forwarded to the process.
  - Agent-run `sqlite3` command after takeover: process receives input, command-control status remains visible, warping indicator is hidden, and Ctrl-G hands control back.
- [x] `./script/format`
- [x] `cargo nextest run -p warp_tui --test-threads=1` — 229 tests passed.
- [x] `cargo clippy -p warp_tui --all-targets --all-features --tests -- -D warnings`
- [x] `cargo clippy -p warp --lib --features tui -- -D warnings`

### Screenshots / Videos
Manual verification and implementation context are available in the [Warp conversation](https://staging.warp.dev/conversation/09eccd38-3745-4b08-bbbd-640edaf0bf6a).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed interactive input and cursor rendering for long-running commands in the headless TUI.

Co-Authored-By: Warp <agent@warp.dev>
