### PR TITLE
[CODE-1860] Resume TUI session after login

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -308,7 +308,7 @@ use crate::terminal::resizable_data::ResizableData;
 use crate::terminal::view::inline_banner::ByoLlmAuthBannerSessionState;
 use crate::terminal::{AudibleBell, CustomSecretRegexUpdater, History};
 #[cfg(feature = "tui")]
-pub use crate::tui::{TuiLoginModel, TuiLoginPhase};
+pub use crate::tui::{TuiLoginEvent, TuiLoginModel, TuiLoginPhase};
 use crate::undo_close::UndoCloseStack;
 use crate::user_config::WarpConfig;
 use crate::util::bindings::is_binding_cross_platform;

--- a/app/src/tui/mod.rs
+++ b/app/src/tui/mod.rs
@@ -28,6 +28,12 @@ pub enum TuiLoginPhase {
     LoggedIn,
 }
 
+/// Events emitted by [`TuiLoginModel`].
+pub enum TuiLoginEvent {
+    /// Authentication completed and the TUI can create its terminal session.
+    LoggedIn,
+}
+
 /// Singleton holding the TUI's [`TuiLoginPhase`]. Updated by [`init`]'s auth
 /// flow and read by the `warp_tui` root view.
 pub struct TuiLoginModel {
@@ -42,7 +48,7 @@ impl TuiLoginModel {
 }
 
 impl Entity for TuiLoginModel {
-    type Event = ();
+    type Event = TuiLoginEvent;
 }
 
 impl SingletonEntity for TuiLoginModel {}
@@ -112,10 +118,19 @@ pub(crate) fn init(mount: TuiMountFn, ctx: &mut AppContext) {
 }
 
 /// Updates the shared [`TuiLoginModel`] phase and notifies observers, so the
-/// root view re-renders (and the TUI driver repaints).
+/// root view re-renders (and the TUI driver repaints). Emits
+/// [`TuiLoginEvent::LoggedIn`] when authentication completes.
 fn set_login_phase(ctx: &mut AppContext, phase: TuiLoginPhase) {
     TuiLoginModel::handle(ctx).update(ctx, |model, ctx| {
+        let logged_in = matches!(phase, TuiLoginPhase::LoggedIn);
         model.phase = phase;
         ctx.notify();
+        if logged_in {
+            ctx.emit(TuiLoginEvent::LoggedIn);
+        }
     });
 }
+
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod tests;

--- a/app/src/tui/mod_tests.rs
+++ b/app/src/tui/mod_tests.rs
@@ -1,0 +1,45 @@
+use std::cell::Cell;
+use std::rc::Rc;
+
+use warpui::{App, SingletonEntity};
+
+use super::{set_login_phase, TuiLoginEvent, TuiLoginModel, TuiLoginPhase};
+
+#[test]
+fn emits_logged_in_event_when_login_completes() {
+    App::test((), |mut app| async move {
+        app.add_singleton_model(|_| TuiLoginModel {
+            phase: TuiLoginPhase::AwaitingLogin {
+                verification_uri: None,
+                user_code: None,
+            },
+        });
+
+        let logged_in_events = Rc::new(Cell::new(0));
+        let logged_in_events_for_subscription = logged_in_events.clone();
+        app.update(|ctx| {
+            ctx.subscribe_to_model(
+                &TuiLoginModel::handle(ctx),
+                move |_, event, _| match event {
+                    TuiLoginEvent::LoggedIn => {
+                        logged_in_events_for_subscription
+                            .set(logged_in_events_for_subscription.get() + 1);
+                    }
+                },
+            );
+        });
+        app.update(|ctx| {
+            set_login_phase(
+                ctx,
+                TuiLoginPhase::AwaitingLogin {
+                    verification_uri: Some("https://example.com".to_owned()),
+                    user_code: Some("CODE".to_owned()),
+                },
+            );
+        });
+        assert_eq!(logged_in_events.get(), 0);
+
+        app.update(|ctx| set_login_phase(ctx, TuiLoginPhase::LoggedIn));
+        assert_eq!(logged_in_events.get(), 1);
+    });
+}

--- a/crates/warp_tui/src/session.rs
+++ b/crates/warp_tui/src/session.rs
@@ -15,7 +15,7 @@ use warp::tui_export::{
     Appearance, BannerState, IsSharedSessionCreator, LocalTtyTerminalManager,
     ServerConversationToken, TerminalManagerTrait, TerminalSurfaceResult,
 };
-use warp::{TuiLoginModel, TuiLoginPhase};
+use warp::{TuiLoginEvent, TuiLoginModel, TuiLoginPhase};
 use warp_errors::report_error;
 use warpui::SingletonEntity;
 use warpui_core::platform::{TerminationMode, WindowStyle};
@@ -147,15 +147,13 @@ fn init(
                 let root_for_login = root.clone();
                 let banner_for_login = banner.clone();
                 let login_model = TuiLoginModel::handle(ctx);
-                ctx.subscribe_to_model(&login_model, move |_, _, ctx| {
-                    if matches!(TuiLoginModel::as_ref(ctx).phase(), TuiLoginPhase::LoggedIn) {
-                        create_terminal_session_after_login(
-                            &session_for_login,
-                            &root_for_login,
-                            &banner_for_login,
-                            ctx,
-                        );
-                    }
+                ctx.subscribe_to_model(&login_model, move |_, event, ctx| match event {
+                    TuiLoginEvent::LoggedIn => create_terminal_session_after_login(
+                        &session_for_login,
+                        &root_for_login,
+                        &banner_for_login,
+                        ctx,
+                    ),
                 });
             }
         }


### PR DESCRIPTION
## Description
Fixes the headless TUI remaining stuck after browser device authentication completes.

`TuiLoginModel` previously updated its phase and called `ctx.notify()`, while the TUI session bootstrap used `subscribe_to_model`, which only receives explicitly emitted events. As a result, credentials were persisted but the terminal session was not created until the process restarted.

This change adds a typed `TuiLoginEvent::LoggedIn`, emits it after the login phase transitions, and creates the terminal session when `crates/warp_tui` receives that event. It also adds regression coverage for the event contract.

Agent conversation: https://staging.warp.dev/conversation/bb899416-04a1-4a5f-9ae4-9241ee9fb14f

## Linked Issue
[CODE-1860: Login intent link is broken](https://linear.app/warpdotdev/issue/CODE-1860/login-intent-link-is-broken)

## Testing
- `./script/format`
- `cargo nextest run -p warp --features tui -E 'test(emits_logged_in_event_when_login_completes)'`
- `cargo nextest run -p warp_tui` — 221 tests passed
- `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- Built and launched `target/debug/warp-tui` in a PTY; verified the live device-auth placeholder renders and exits cleanly. Full browser approval was unavailable in the headless environment; the login-completion transition is covered by the new model event regression test.

- [ ] I have manually tested the complete browser login transition locally with `./script/run-tui`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed the TUI remaining stuck on the sign-in screen after browser login completed.

Co-Authored-By: Warp <agent@warp.dev>
