### PR TITLE
Handle claude code StopFailure hook

### DIFF
--- a/app/src/ai/agent_management/agent_management_model.rs
+++ b/app/src/ai/agent_management/agent_management_model.rs
@@ -177,16 +177,20 @@ impl AgentNotificationsModel {
                         ctx,
                     );
                 }
-                CLIAgentSessionStatus::Failed { message } => {
+                CLIAgentSessionStatus::Failed { error_type, message } => {
                     let title = session_context
                         .display_title()
                         .unwrap_or_else(|| format!("{} failed", agent.display_name()));
+                    let body = match (message.as_deref(), error_type.as_deref()) {
+                        (Some(msg), Some(kind)) => format!("{kind}: {msg}"),
+                        (Some(msg), None) => msg.to_owned(),
+                        (None, Some(kind)) => kind.to_owned(),
+                        (None, None) => "The agent encountered an error.".to_owned(),
+                    };
                     let metadata = TerminalViewMetadata::lookup(*terminal_view_id, ctx);
                     self.add_notification(
                         title,
-                        message
-                            .clone()
-                            .unwrap_or_else(|| "The agent encountered an error.".to_owned()),
+                        body,
                         NotificationCategory::Error,
                         NotificationSourceAgent::CLI {
                             agent: *agent,

--- a/app/src/ai/agent_management/agent_management_model.rs
+++ b/app/src/ai/agent_management/agent_management_model.rs
@@ -177,7 +177,10 @@ impl AgentNotificationsModel {
                         ctx,
                     );
                 }
-                CLIAgentSessionStatus::Failed { error_type, message } => {
+                CLIAgentSessionStatus::Failed {
+                    error_type,
+                    message,
+                } => {
                     let title = session_context
                         .display_title()
                         .unwrap_or_else(|| format!("{} failed", agent.display_name()));

--- a/app/src/ai/agent_management/agent_management_model.rs
+++ b/app/src/ai/agent_management/agent_management_model.rs
@@ -177,6 +177,28 @@ impl AgentNotificationsModel {
                         ctx,
                     );
                 }
+                CLIAgentSessionStatus::Failed { message } => {
+                    let title = session_context
+                        .display_title()
+                        .unwrap_or_else(|| format!("{} failed", agent.display_name()));
+                    let metadata = TerminalViewMetadata::lookup(*terminal_view_id, ctx);
+                    self.add_notification(
+                        title,
+                        message
+                            .clone()
+                            .unwrap_or_else(|| "The agent encountered an error.".to_owned()),
+                        NotificationCategory::Error,
+                        NotificationSourceAgent::CLI {
+                            agent: *agent,
+                            is_ambient: metadata.is_ambient,
+                        },
+                        NotificationOrigin::CLISession(*terminal_view_id),
+                        *terminal_view_id,
+                        vec![],
+                        metadata.branch,
+                        ctx,
+                    );
+                }
                 CLIAgentSessionStatus::Blocked { message } => {
                     let title = session_context
                         .display_title()

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -2853,7 +2853,8 @@ impl AgentDriver {
                         ) {
                             log::info!(
                                 "Ignoring runtime failure for {harness_name}: \
-                                 session already marked Success (pattern={}, excerpt={})",
+                                 session already marked Success or Failed via plugin \
+                                 (pattern={}, excerpt={})",
                                 error.pattern,
                                 error.excerpt,
                             );

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -3435,7 +3435,9 @@ impl AgentDriver {
 
                     // Drive idle-on-complete timer for the harness exit signal.
                     match status {
-                        CLIAgentSessionStatus::Success | CLIAgentSessionStatus::Blocked { .. } => {
+                        CLIAgentSessionStatus::Success
+                        | CLIAgentSessionStatus::Failed { .. }
+                        | CLIAgentSessionStatus::Blocked { .. } => {
                             if let Some(idle_timeout) = me.idle_on_complete {
                                 log::info!(
                                     "Ambient agent CLI lifecycle: event=idle_timeout_scheduled task_id={:?} terminal_view_id={terminal_view_id:?} timeout={idle_timeout:?}",

--- a/app/src/ai/agent_sdk/driver/harness/claude_code.rs
+++ b/app/src/ai/agent_sdk/driver/harness/claude_code.rs
@@ -416,6 +416,7 @@ impl ClaudeHarnessRunner {
             cli_agent_session_status(&self.terminal_driver, foreground).await,
             Some(crate::terminal::cli_agent_sessions::CLIAgentSessionStatus::Blocked { .. })
                 | Some(crate::terminal::cli_agent_sessions::CLIAgentSessionStatus::InProgress)
+                | Some(crate::terminal::cli_agent_sessions::CLIAgentSessionStatus::Failed { .. })
         )
     }
 

--- a/app/src/ai/agent_sdk/driver/harness/codex.rs
+++ b/app/src/ai/agent_sdk/driver/harness/codex.rs
@@ -87,6 +87,9 @@ impl ThirdPartyHarness for CodexHarness {
             // OAuth refresh failures — all five Codex variants share this
             // substring (see upstream session/token messages).
             "could not be refreshed",
+            // Generically check for invalid request errors.
+            // Keep this last so more specific patterns can be matched first.
+            "\"type\": \"invalid_request_error\"",
         ]
     }
 

--- a/app/src/ai/agent_sdk/driver/harness_output_monitor.rs
+++ b/app/src/ai/agent_sdk/driver/harness_output_monitor.rs
@@ -197,6 +197,8 @@ pub(crate) async fn watch_block_for_errors(
 }
 
 pub(crate) fn should_suppress_runtime_failure(status: Option<&CLIAgentSessionStatus>) -> bool {
+    // On CLIAgentSessionStatus::Failed, we directly update the task status,
+    // so we don't need to do runtime pattern matching to find the failure.
     matches!(
         status,
         Some(CLIAgentSessionStatus::Success) | Some(CLIAgentSessionStatus::Failed { .. })

--- a/app/src/ai/agent_sdk/driver/harness_output_monitor.rs
+++ b/app/src/ai/agent_sdk/driver/harness_output_monitor.rs
@@ -197,7 +197,10 @@ pub(crate) async fn watch_block_for_errors(
 }
 
 pub(crate) fn should_suppress_runtime_failure(status: Option<&CLIAgentSessionStatus>) -> bool {
-    matches!(status, Some(CLIAgentSessionStatus::Success))
+    matches!(
+        status,
+        Some(CLIAgentSessionStatus::Success) | Some(CLIAgentSessionStatus::Failed { .. })
+    )
 }
 
 /// Cap excerpt length so we don't blow up status messages or logs with

--- a/app/src/ai/blocklist/local_agent_task_sync_model.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model.rs
@@ -548,15 +548,18 @@ fn map_cli_session_status(
     match status {
         CLIAgentSessionStatus::InProgress => (AgentTaskState::InProgress, None),
         CLIAgentSessionStatus::Success => (AgentTaskState::Succeeded, None),
-        CLIAgentSessionStatus::Failed { error_type, message } => {
+        CLIAgentSessionStatus::Failed {
+            error_type,
+            message,
+        } => {
             // User-actionable errors (bad credentials, org restrictions, billing) map to
             // FAILED. Everything else (rate limits, server errors, model errors, etc.)
             // maps to ERROR since they are typically Anthropic's or Warp's fault.
             // The list of error types on Claude Code comes from https://code.claude.com/docs/en/hooks#stopfailure-input
             let task_state = match error_type.as_deref() {
-                Some(
-                    "authentication_failed" | "oauth_org_not_allowed" | "billing_error",
-                ) => AgentTaskState::Failed,
+                Some("authentication_failed" | "oauth_org_not_allowed" | "billing_error") => {
+                    AgentTaskState::Failed
+                }
                 _ => AgentTaskState::Error,
             };
             (task_state, message.as_ref().map(TaskStatusUpdate::message))

--- a/app/src/ai/blocklist/local_agent_task_sync_model.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model.rs
@@ -548,10 +548,19 @@ fn map_cli_session_status(
     match status {
         CLIAgentSessionStatus::InProgress => (AgentTaskState::InProgress, None),
         CLIAgentSessionStatus::Success => (AgentTaskState::Succeeded, None),
-        CLIAgentSessionStatus::Failed { message, .. } => (
-            AgentTaskState::Failed,
-            message.as_ref().map(TaskStatusUpdate::message),
-        ),
+        CLIAgentSessionStatus::Failed { error_type, message } => {
+            // User-actionable errors (bad credentials, org restrictions, billing) map to
+            // FAILED. Everything else (rate limits, server errors, model errors, etc.)
+            // maps to ERROR since they are typically Anthropic's or Warp's fault.
+            // The list of error types on Claude Code comes from https://code.claude.com/docs/en/hooks#stopfailure-input
+            let task_state = match error_type.as_deref() {
+                Some(
+                    "authentication_failed" | "oauth_org_not_allowed" | "billing_error",
+                ) => AgentTaskState::Failed,
+                _ => AgentTaskState::Error,
+            };
+            (task_state, message.as_ref().map(TaskStatusUpdate::message))
+        }
         CLIAgentSessionStatus::Blocked { message } => (
             AgentTaskState::Blocked,
             message.as_ref().map(TaskStatusUpdate::message),

--- a/app/src/ai/blocklist/local_agent_task_sync_model.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model.rs
@@ -548,7 +548,7 @@ fn map_cli_session_status(
     match status {
         CLIAgentSessionStatus::InProgress => (AgentTaskState::InProgress, None),
         CLIAgentSessionStatus::Success => (AgentTaskState::Succeeded, None),
-        CLIAgentSessionStatus::Failed { message } => (
+        CLIAgentSessionStatus::Failed { message, .. } => (
             AgentTaskState::Failed,
             message.as_ref().map(TaskStatusUpdate::message),
         ),

--- a/app/src/ai/blocklist/local_agent_task_sync_model.rs
+++ b/app/src/ai/blocklist/local_agent_task_sync_model.rs
@@ -548,6 +548,10 @@ fn map_cli_session_status(
     match status {
         CLIAgentSessionStatus::InProgress => (AgentTaskState::InProgress, None),
         CLIAgentSessionStatus::Success => (AgentTaskState::Succeeded, None),
+        CLIAgentSessionStatus::Failed { message } => (
+            AgentTaskState::Failed,
+            message.as_ref().map(TaskStatusUpdate::message),
+        ),
         CLIAgentSessionStatus::Blocked { message } => (
             AgentTaskState::Blocked,
             message.as_ref().map(TaskStatusUpdate::message),

--- a/app/src/terminal/cli_agent_sessions/event/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/event/mod.rs
@@ -19,6 +19,7 @@ pub enum CLIAgentEventType {
     PromptSubmit,
     ToolComplete,
     Stop,
+    StopFailure,
     PermissionRequest,
     PermissionReplied,
     QuestionAsked,

--- a/app/src/terminal/cli_agent_sessions/event/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/event/mod.rs
@@ -47,6 +47,9 @@ pub struct CLIAgentEventPayload {
     pub tool_name: Option<String>,
     pub tool_input_preview: Option<String>,
     pub plugin_version: Option<String>,
+    /// On Claude Code, this comes from the `StopFailure` hook (e.g. `"rate_limit"`).
+    /// Not implemented for Codex.
+    pub error_type: Option<String>,
 }
 
 /// A parsed event from a CLI agent plugin.

--- a/app/src/terminal/cli_agent_sessions/event/v1.rs
+++ b/app/src/terminal/cli_agent_sessions/event/v1.rs
@@ -18,6 +18,7 @@ pub(super) fn parse(body: &str) -> Option<CLIAgentEvent> {
         "prompt_submit" => CLIAgentEventType::PromptSubmit,
         "tool_complete" => CLIAgentEventType::ToolComplete,
         "stop" => CLIAgentEventType::Stop,
+        "stop_failure" => CLIAgentEventType::StopFailure,
         "permission_request" => CLIAgentEventType::PermissionRequest,
         "permission_replied" => CLIAgentEventType::PermissionReplied,
         "question_asked" => CLIAgentEventType::QuestionAsked,

--- a/app/src/terminal/cli_agent_sessions/event/v1.rs
+++ b/app/src/terminal/cli_agent_sessions/event/v1.rs
@@ -54,6 +54,7 @@ pub(super) fn parse(body: &str) -> Option<CLIAgentEvent> {
             tool_name: raw.tool_name,
             tool_input_preview,
             plugin_version: raw.plugin_version,
+            error_type: raw.error_type,
         },
         source: CLIAgentEventSource::RichPlugin,
     })
@@ -74,4 +75,5 @@ struct RawEvent {
     tool_name: Option<String>,
     tool_input: Option<serde_json::Value>,
     plugin_version: Option<String>,
+    error_type: Option<String>,
 }

--- a/app/src/terminal/cli_agent_sessions/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/mod.rs
@@ -214,6 +214,8 @@ impl CLIAgentSession {
                 CLIAgentSessionStatus::Success
             }
             CLIAgentEventType::StopFailure => {
+                self.session_context.query = event.payload.query.clone();
+                self.session_context.response = event.payload.response.clone();
                 self.clear_permission_scoped_state();
                 CLIAgentSessionStatus::Failed {
                     error_type: event.payload.error_type.clone(),

--- a/app/src/terminal/cli_agent_sessions/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/mod.rs
@@ -21,7 +21,9 @@ pub enum CLIAgentSessionStatus {
         error_type: Option<String>,
         message: Option<String>,
     },
-    Blocked { message: Option<String> },
+    Blocked {
+        message: Option<String>,
+    },
 }
 
 impl CLIAgentSessionStatus {

--- a/app/src/terminal/cli_agent_sessions/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/mod.rs
@@ -17,6 +17,7 @@ use crate::ai::blocklist::InputConfig;
 pub enum CLIAgentSessionStatus {
     InProgress,
     Success,
+    Failed { message: Option<String> },
     Blocked { message: Option<String> },
 }
 
@@ -26,6 +27,7 @@ impl CLIAgentSessionStatus {
         match self {
             CLIAgentSessionStatus::InProgress => ConversationStatus::InProgress,
             CLIAgentSessionStatus::Success => ConversationStatus::Success,
+            CLIAgentSessionStatus::Failed { .. } => ConversationStatus::Error,
             CLIAgentSessionStatus::Blocked { message } => ConversationStatus::Blocked {
                 blocked_action: message.clone().unwrap_or_default(),
             },
@@ -205,6 +207,12 @@ impl CLIAgentSession {
                 self.session_context.response = event.payload.response.clone();
                 self.clear_permission_scoped_state();
                 CLIAgentSessionStatus::Success
+            }
+            CLIAgentEventType::StopFailure => {
+                self.clear_permission_scoped_state();
+                CLIAgentSessionStatus::Failed {
+                    message: event.payload.response.clone(),
+                }
             }
             CLIAgentEventType::PermissionRequest => {
                 self.session_context.summary = event.payload.summary.clone();

--- a/app/src/terminal/cli_agent_sessions/mod.rs
+++ b/app/src/terminal/cli_agent_sessions/mod.rs
@@ -17,7 +17,10 @@ use crate::ai::blocklist::InputConfig;
 pub enum CLIAgentSessionStatus {
     InProgress,
     Success,
-    Failed { message: Option<String> },
+    Failed {
+        error_type: Option<String>,
+        message: Option<String>,
+    },
     Blocked { message: Option<String> },
 }
 
@@ -211,6 +214,7 @@ impl CLIAgentSession {
             CLIAgentEventType::StopFailure => {
                 self.clear_permission_scoped_state();
                 CLIAgentSessionStatus::Failed {
+                    error_type: event.payload.error_type.clone(),
                     message: event.payload.response.clone(),
                 }
             }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -13479,7 +13479,9 @@ impl TerminalView {
                             ctx,
                         );
                     }
-                    CLIAgentSessionStatus::InProgress | CLIAgentSessionStatus::Success => {
+                    CLIAgentSessionStatus::InProgress
+                    | CLIAgentSessionStatus::Success
+                    | CLIAgentSessionStatus::Failed { .. } => {
                         // Auto-open rich input when the agent resumes or completes.
                         if !self.has_active_cli_agent_input_session(ctx) {
                             self.open_cli_agent_rich_input(CLIAgentInputEntrypoint::AutoShow, ctx);
@@ -13511,6 +13513,8 @@ impl TerminalView {
 
         let trigger = if matches!(status, CLIAgentSessionStatus::Blocked { .. }) {
             NotificationsTrigger::NeedsAttention
+        } else if matches!(status, CLIAgentSessionStatus::Failed { .. }) {
+            NotificationsTrigger::AgentTaskCompleted(false)
         } else {
             NotificationsTrigger::AgentTaskCompleted(true)
         };


### PR DESCRIPTION
## Description

Resolves https://linear.app/warpdotdev/issue/REMOTE-1997/oz-shows-claude-code-run-as-running-after-anthropic-api-500-error

Handle the StopFailure hook from Claude Code. We use the error type to map to Failed or Error status.

There is technically a race between this and scanning for `runtime_error_patterns`. But most of the time this will win since it's instant, and the scan for `runtime_error_patterns` will be suppressed. In the event that `runtime_error_patterns` scanning happens first, we'll end up with a duplicate task status update from the hook which is okay.

## Testing

- [x] I have manually tested my changes locally with `./script/run`

Tested locally with https://github.com/warpdotdev/claude-code-warp/pull/73

Run claude code with invalid model and using local plugin build:
`ANTHROPIC_MODEL=claude-4-8-opus-high claude --plugin-dir ~/claude-code-warp/plugins/warp`

Send a query, see a log in warp
```
12:45:03.758 [INFO] [warp::terminal::model::ansi] Received OSC 777 notification: title=Some("warp://cli-agent"), body={"v":1,"agent":"claude","event":"stop_failure","session_id":"8c574469-befe-4e9a-802a-6e3350ab2f5a","cwd":"/Users/rolandhuang","project":"rolandhuang","query":"here is another test","response":"There's an issue with the selected model (claude-4-8-opus-high). It may not exist or you may not have access to it. Run /model to pick a different model.","error_type":"model_not_found","transcript_path":"/Users/rolandhuang/.claude/projects/-Users-rolandhuang/8c574469-befe-4e9a-802a-6e3350ab2f5a.jsonl"}
```