### PR TITLE
Enable terminal lifecycle recovery logic in prod.

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -694,6 +694,7 @@ default = [
     "billing_and_usage_page_v2",
     "remote_code_review",
     "git_operations_in_code_review",
+    "terminal_lifecycle_recovery",
 ]
 # Enable this feature to automatically perform heap profiling.  NOTE: This will
 # substantially slow down program execution.
@@ -844,6 +845,7 @@ tab_close_button_on_left = []
 team_features_override = []
 test-util = ["cloud_object_client/test-util", "warp_server_auth/test-util"]
 team_workflows = ["team_features_override"]
+terminal_lifecycle_recovery = []
 toggle_bootstrap_block = []
 # Feature enabled only when app is compiled for integration tests.
 integration_tests = [

--- a/app/src/features.rs
+++ b/app/src/features.rs
@@ -513,6 +513,8 @@ fn enabled_features() -> HashSet<FeatureFlag> {
         FeatureFlag::NldPromptHistoryMatch,
         #[cfg(feature = "prompt_cache_expiry_warning")]
         FeatureFlag::PromptCacheExpiryWarning,
+        #[cfg(feature = "terminal_lifecycle_recovery")]
+        FeatureFlag::TerminalLifecycleRecovery,
     ]);
 
     flags

--- a/crates/warp_features/src/features_tests.rs
+++ b/crates/warp_features/src/features_tests.rs
@@ -18,10 +18,3 @@ fn local_child_harnesses_are_local_only_by_default() {
     assert!(!DEBUG_FLAGS.contains(&FeatureFlag::LocalClaudeCodexChildHarnesses));
     assert!(!DOGFOOD_FLAGS.contains(&FeatureFlag::LocalClaudeCodexChildHarnesses));
 }
-
-#[test]
-fn terminal_lifecycle_recovery_is_dogfood_only_by_default() {
-    assert!(DOGFOOD_FLAGS.contains(&FeatureFlag::TerminalLifecycleRecovery));
-    assert!(!PREVIEW_FLAGS.contains(&FeatureFlag::TerminalLifecycleRecovery));
-    assert!(!RELEASE_FLAGS.contains(&FeatureFlag::TerminalLifecycleRecovery));
-}


### PR DESCRIPTION
## Description

This has been live on staging for two weeks now, with no reports of it causing any issues.  Let's roll it out to prod.

Dogfood rollout PR: https://github.com/warpdotdev/warp/pull/12859
