### PR TITLE
Fix session ended banner flickering on 3p runs during task data refresh

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -121,9 +121,11 @@ use session_sharing_protocol::sharer::{
     RoleUpdateReason, SessionEndedReason, SessionRetentionReason,
 };
 use settings::{Setting, ToggleableSetting};
-use shared_session::cloud_conversation_continuation::CloudConversationContinuationUiState;
 pub(crate) use shared_session::cloud_conversation_continuation::{
     resolve_ai_query_routing, AIQueryRouting,
+};
+use shared_session::cloud_conversation_continuation::{
+    CloudConversationContinuationUiState, TombstoneCta,
 };
 use shared_session::{SharedSessionAdapter, Viewer};
 use ssh_file_upload::{FileUpload, FileUploadEvent};
@@ -2753,6 +2755,14 @@ pub struct TerminalView {
     /// The inserted conversation-ended tombstone, if this view currently has one.
     conversation_ended_tombstone_view_id: Option<EntityId>,
 
+    /// The CTA shown by the current conversation-ended tombstone, if any.
+    /// `None` means no tombstone is currently shown.
+    /// `Some(None)` means a tombstone is shown without a CTA button.
+    /// `Some(Some(cta))` means a tombstone is shown with the given CTA button.
+    /// Used to skip unnecessary remove+reinsert cycles when the CTA has not changed
+    /// (e.g. on repeated task-data-refresh events for 3p runs).
+    conversation_ended_tombstone_cta: Option<Option<TombstoneCta>>,
+
     /// The ID of the containing window.
     window_id: WindowId,
 
@@ -4383,6 +4393,7 @@ impl TerminalView {
             pending_share_source: None,
             auto_stop_sharing_on_cli_end: false,
             conversation_ended_tombstone_view_id: None,
+            conversation_ended_tombstone_cta: None,
             ai_input_model,
             ai_context_model,
             window_id,

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -1784,6 +1784,12 @@ impl TerminalView {
         ctx: &mut ViewContext<Self>,
     ) {
         if self.conversation_ended_tombstone_view_id.is_some() {
+            // If the existing tombstone already shows the same CTA, skip the remove+reinsert
+            // to prevent the tombstone from flickering on repeated task-data-refresh events
+            // (e.g. 3p runs where TasksUpdated fires frequently while task data is loaded).
+            if self.conversation_ended_tombstone_cta == Some(tombstone_cta) {
+                return;
+            }
             self.remove_conversation_ended_tombstone(ctx);
         }
         let task_id = self.ambient_agent_task_id_for_details_panel(ctx);
@@ -1817,6 +1823,7 @@ impl TerminalView {
             });
         self.insert_rich_content(None, tombstone_view_handle, None, insertion_position, ctx);
         self.conversation_ended_tombstone_view_id = Some(tombstone_view_id);
+        self.conversation_ended_tombstone_cta = Some(tombstone_cta);
     }
 
     pub(crate) fn insert_conversation_ended_tombstone_with_resolved_cta(
@@ -1852,6 +1859,7 @@ impl TerminalView {
         let Some(view_id) = self.conversation_ended_tombstone_view_id.take() else {
             return;
         };
+        self.conversation_ended_tombstone_cta = None;
         self.model
             .lock()
             .block_list_mut()


### PR DESCRIPTION
## Description

Fix session ended banner flickering during task data refresh on 3p (third-party agent) runs.

### Root Cause

When `AgentConversationsModel` fires `TasksUpdated` or `NewTasksReceived` events (which happen repeatedly during task data refresh), `maybe_insert_tombstone_for_non_running_shared_ambient_task` is called. For a finished 3p run, this function called `insert_conversation_ended_tombstone_with_cta` unconditionally — even when the tombstone was already showing the correct CTA. `insert_conversation_ended_tombstone_with_cta` always removed the existing tombstone before inserting a new one, causing visible flicker on every refresh cycle.

### Fix

Track the CTA currently shown by the tombstone in a new `conversation_ended_tombstone_cta: Option<Option<TombstoneCta>>` field on `TerminalView`. In `insert_conversation_ended_tombstone_with_cta`, return early if an existing tombstone is already displaying the same CTA, avoiding the unnecessary remove+reinsert cycle.

The CTA is still updated when it genuinely changes (e.g., from `None` to `Some(ContinueInCloud { .. })` when task data first arrives for a restored pane), preserving the correct behaviour of re-resolving the CTA on the first task-data cache update.

## Linked Issue

- APP-4866

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

The fix prevents the tombstone view from being removed and reinserted on every `TasksUpdated` event when the CTA hasn't changed. The CTA update path (from `None` to a resolved value on first task-data arrival) remains intact.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed session ended banner flickering during task data refresh on third-party agent runs.
-->

_Conversation: https://staging.warp.dev/conversation/f49d63e4-8825-4e9f-ab49-1076aceaf783_
_Run: https://oz.staging.warp.dev/runs/019f6797-d195-7470-afb0-eac2c313775e_

_This PR was generated with [Oz](https://warp.dev/oz)._
