### PR TITLE
[MCP] Add well-known MCP type

### DIFF
--- a/app/src/ai/agent_sdk/config_file.rs
+++ b/app/src/ai/agent_sdk/config_file.rs
@@ -101,12 +101,15 @@ fn supported_keys_context() -> String {
 /// Convert an unwrapped `mcp_servers` map into runtime MCP specs for AgentDriver.
 ///
 /// Behavior:
-/// - Entries with `warp_id` become `MCPSpec::Uuid`.
+/// - Entries with a UUID `warp_id` become `MCPSpec::Uuid`.
+/// - Entries with any other non-empty `warp_id` (e.g. `"linear"`) become `MCPSpec::WellKnown`;
+///   the server owns the set of recognized ids and unknown ids are skipped at resolution.
 /// - Entries with `command`/`url` remain as inline JSON (`MCPSpec::Json`) containing the unwrapped server map.
 pub fn mcp_specs_from_mcp_servers(
     mcp_servers: &Map<String, Value>,
 ) -> anyhow::Result<Vec<MCPSpec>> {
     let mut uuids: Vec<uuid::Uuid> = Vec::new();
+    let mut well_known: Vec<String> = Vec::new();
     let mut json_map: Map<String, Value> = Map::new();
 
     for (name, config) in mcp_servers {
@@ -115,10 +118,15 @@ pub fn mcp_specs_from_mcp_servers(
             .ok_or_else(|| anyhow::anyhow!("MCP server '{name}' config must be a JSON object"))?;
 
         if let Some(warp_id) = obj.get("warp_id").and_then(Value::as_str) {
-            let uuid = uuid::Uuid::parse_str(warp_id).map_err(|_| {
-                anyhow::anyhow!("MCP server '{name}' field 'warp_id' must be a UUID")
-            })?;
-            uuids.push(uuid);
+            if let Ok(uuid) = uuid::Uuid::parse_str(warp_id) {
+                uuids.push(uuid);
+            } else if warp_id.trim().is_empty() {
+                return Err(anyhow::anyhow!(
+                    "MCP server '{name}' field 'warp_id' must be non-empty"
+                ));
+            } else {
+                well_known.push(warp_id.to_string());
+            }
         } else {
             json_map.insert(name.clone(), config.clone());
         }
@@ -126,8 +134,11 @@ pub fn mcp_specs_from_mcp_servers(
 
     uuids.sort();
     uuids.dedup();
+    well_known.sort();
+    well_known.dedup();
 
     let mut specs: Vec<MCPSpec> = uuids.into_iter().map(MCPSpec::Uuid).collect();
+    specs.extend(well_known.into_iter().map(MCPSpec::WellKnown));
 
     if !json_map.is_empty() {
         let json =

--- a/app/src/ai/agent_sdk/config_file.rs
+++ b/app/src/ai/agent_sdk/config_file.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use anyhow::Context as _;
 use serde_json::{Map, Value};
 use warp_cli::mcp::MCPSpec;
+use warp_core::features::FeatureFlag;
 
 use crate::ai::ambient_agents::AgentConfigSnapshot;
 
@@ -102,7 +103,8 @@ fn supported_keys_context() -> String {
 ///
 /// Behavior:
 /// - Entries with a UUID `warp_id` become `MCPSpec::Uuid`.
-/// - Entries with any other non-empty `warp_id` (e.g. `"linear"`) become `MCPSpec::WellKnown`;
+/// - Entries with any other non-empty `warp_id` (e.g. `"linear"`) become `MCPSpec::WellKnown`
+///   when `FeatureFlag::WellKnownMcpIds` is enabled (and are rejected otherwise);
 ///   the server owns the set of recognized ids and unknown ids are skipped at resolution.
 /// - Entries with `command`/`url` remain as inline JSON (`MCPSpec::Json`) containing the unwrapped server map.
 pub fn mcp_specs_from_mcp_servers(
@@ -120,6 +122,10 @@ pub fn mcp_specs_from_mcp_servers(
         if let Some(warp_id) = obj.get("warp_id").and_then(Value::as_str) {
             if let Ok(uuid) = uuid::Uuid::parse_str(warp_id) {
                 uuids.push(uuid);
+            } else if !FeatureFlag::WellKnownMcpIds.is_enabled() {
+                return Err(anyhow::anyhow!(
+                    "MCP server '{name}' field 'warp_id' must be a UUID"
+                ));
             } else if warp_id.trim().is_empty() {
                 return Err(anyhow::anyhow!(
                     "MCP server '{name}' field 'warp_id' must be non-empty"

--- a/app/src/ai/agent_sdk/config_file_tests.rs
+++ b/app/src/ai/agent_sdk/config_file_tests.rs
@@ -156,6 +156,51 @@ fn mcp_servers_map_converts_to_runtime_specs() {
 }
 
 #[test]
+fn well_known_warp_id_converts_to_well_known_spec() {
+    let contents = json!({
+        "mcp_servers": {
+            "linear": { "warp_id": "linear" }
+        }
+    })
+    .to_string();
+
+    let file = write_temp(".json", &contents);
+    let loaded = super::load_config_file(file.path()).unwrap();
+
+    let map = loaded.file.mcp_servers.as_ref().unwrap();
+    let specs = super::mcp_specs_from_mcp_servers(map).unwrap();
+
+    assert_eq!(specs.len(), 1);
+    assert!(
+        matches!(&specs[0], MCPSpec::WellKnown(id) if id == "linear"),
+        "well-known warp_id must become MCPSpec::WellKnown, got {specs:?}"
+    );
+}
+
+#[test]
+fn any_non_uuid_warp_id_becomes_well_known_spec() {
+    // The server owns the set of recognized ids: the client forwards any
+    // non-UUID warp_id for resolution instead of rejecting it, so new ids can
+    // be introduced server-side without a client change.
+    let map = serde_json::Map::from_iter([(
+        "future".to_string(),
+        json!({ "warp_id": "some-future-integration" }),
+    )]);
+
+    let specs = super::mcp_specs_from_mcp_servers(&map).unwrap();
+    assert_eq!(specs.len(), 1);
+    assert!(matches!(&specs[0], MCPSpec::WellKnown(id) if id == "some-future-integration"));
+}
+
+#[test]
+fn empty_warp_id_is_rejected() {
+    let map = serde_json::Map::from_iter([("bogus".to_string(), json!({ "warp_id": "" }))]);
+
+    let err = super::mcp_specs_from_mcp_servers(&map).unwrap_err();
+    assert!(format!("{err:#}").contains("must be non-empty"));
+}
+
+#[test]
 fn loads_computer_use_enabled_from_json() {
     let contents = json!({
         "computer_use_enabled": true

--- a/app/src/ai/agent_sdk/config_file_tests.rs
+++ b/app/src/ai/agent_sdk/config_file_tests.rs
@@ -4,6 +4,7 @@ use std::io::Write as _;
 
 use serde_json::json;
 use warp_cli::mcp::MCPSpec;
+use warp_core::features::FeatureFlag;
 
 use crate::ai::ambient_agents::AgentConfigSnapshot;
 
@@ -157,6 +158,7 @@ fn mcp_servers_map_converts_to_runtime_specs() {
 
 #[test]
 fn well_known_warp_id_converts_to_well_known_spec() {
+    let _flag = FeatureFlag::WellKnownMcpIds.override_enabled(true);
     let contents = json!({
         "mcp_servers": {
             "linear": { "warp_id": "linear" }
@@ -182,6 +184,7 @@ fn any_non_uuid_warp_id_becomes_well_known_spec() {
     // The server owns the set of recognized ids: the client forwards any
     // non-UUID warp_id for resolution instead of rejecting it, so new ids can
     // be introduced server-side without a client change.
+    let _flag = FeatureFlag::WellKnownMcpIds.override_enabled(true);
     let map = serde_json::Map::from_iter([(
         "future".to_string(),
         json!({ "warp_id": "some-future-integration" }),
@@ -194,10 +197,20 @@ fn any_non_uuid_warp_id_becomes_well_known_spec() {
 
 #[test]
 fn empty_warp_id_is_rejected() {
+    let _flag = FeatureFlag::WellKnownMcpIds.override_enabled(true);
     let map = serde_json::Map::from_iter([("bogus".to_string(), json!({ "warp_id": "" }))]);
 
     let err = super::mcp_specs_from_mcp_servers(&map).unwrap_err();
     assert!(format!("{err:#}").contains("must be non-empty"));
+}
+
+#[test]
+fn non_uuid_warp_id_is_rejected_when_flag_disabled() {
+    let _flag = FeatureFlag::WellKnownMcpIds.override_enabled(false);
+    let map = serde_json::Map::from_iter([("linear".to_string(), json!({ "warp_id": "linear" }))]);
+
+    let err = super::mcp_specs_from_mcp_servers(&map).unwrap_err();
+    assert!(format!("{err:#}").contains("must be a UUID"));
 }
 
 #[test]

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1228,6 +1228,14 @@ impl AgentDriver {
                     resolved.ephemeral_installations.extend(installations);
                 }
                 MCPSpec::WellKnown(id) => {
+                    // Backstop for specs created before the flag was disabled
+                    // (e.g. persisted configs): skip rather than resolve.
+                    if !FeatureFlag::WellKnownMcpIds.is_enabled() {
+                        log::warn!(
+                            "Skipping well-known MCP server '{id}': WellKnownMcpIds is disabled"
+                        );
+                        continue;
+                    }
                     // Well-known MCP ids (e.g. "linear") resolve best-effort:
                     // the server owns the set of recognized ids, and the
                     // backing integration may be disconnected or the feature

--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -1210,7 +1210,7 @@ impl AgentDriver {
                 }
                 MCPSpec::Uuid(uuid) => {
                     let client_config = managed_mcp_client
-                        .create_managed_mcp_client_config(*uuid)
+                        .create_managed_mcp_client_config(uuid.to_string())
                         .await
                         .map_err(|err| AgentDriverError::ManagedMcpResolutionFailed {
                             uid: *uuid,
@@ -1226,6 +1226,33 @@ impl AgentDriver {
                         }
                     })?;
                     resolved.ephemeral_installations.extend(installations);
+                }
+                MCPSpec::WellKnown(id) => {
+                    // Well-known MCP ids (e.g. "linear") resolve best-effort:
+                    // the server owns the set of recognized ids, and the
+                    // backing integration may be disconnected or the feature
+                    // disabled between dispatch and run setup — so resolution
+                    // failures skip the server instead of failing the run.
+                    let client_config = match managed_mcp_client
+                        .create_managed_mcp_client_config(id.clone())
+                        .await
+                    {
+                        Ok(client_config) => client_config,
+                        Err(err) => {
+                            log::warn!("Skipping well-known MCP server '{id}': {err:#}");
+                            continue;
+                        }
+                    };
+                    match Self::installations_from_managed_client_config_json(
+                        &client_config.mcp_config_json,
+                    ) {
+                        Ok(installations) => {
+                            resolved.ephemeral_installations.extend(installations);
+                        }
+                        Err(err) => {
+                            log::warn!("Skipping well-known MCP server '{id}': {err}");
+                        }
+                    }
                 }
                 MCPSpec::Json(json_str) => {
                     resolved

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -189,7 +189,7 @@ fn managed_resolver_non_local_uuid_calls_managed_client() {
     mock.expect_create_managed_mcp_client_config()
         .times(1)
         .returning(move |requested_uid| {
-            assert_eq!(requested_uid, uuid);
+            assert_eq!(requested_uid, uuid.to_string());
             Ok(managed_client_config_output(config_json))
         });
 
@@ -201,6 +201,78 @@ fn managed_resolver_non_local_uuid_calls_managed_client() {
     .unwrap();
 
     assert!(resolved.local_uuids.is_empty());
+    assert_eq!(resolved.ephemeral_installations.len(), 1);
+}
+
+#[test]
+fn well_known_spec_resolves_via_managed_client() {
+    let config_json = r#"{"mcpServers":{"linear":{"url":"https://app.warp.dev/mcp/integration-proxy/linear","headers":{"Authorization":"Bearer tok"}}}}"#;
+    let mut mock = MockManagedMcpClient::new();
+    mock.expect_create_managed_mcp_client_config()
+        .times(1)
+        .returning(move |requested_uid| {
+            assert_eq!(requested_uid, "linear");
+            Ok(managed_client_config_output(config_json))
+        });
+
+    let resolved = block_on(AgentDriver::resolve_mcp_specs_with_local_uuids(
+        &[MCPSpec::WellKnown("linear".to_string())],
+        &HashSet::new(),
+        Arc::new(mock),
+    ))
+    .unwrap();
+
+    assert!(resolved.local_uuids.is_empty());
+    assert_eq!(resolved.ephemeral_installations.len(), 1);
+}
+
+#[test]
+fn well_known_resolution_failure_skips_server() {
+    let mut mock = MockManagedMcpClient::new();
+    mock.expect_create_managed_mcp_client_config()
+        .times(1)
+        .returning(|_| Err(anyhow::anyhow!("Linear is not connected for this team")));
+
+    // Well-known references are server-injected and best-effort: a failure must
+    // skip the server, not fail run setup.
+    let resolved = block_on(AgentDriver::resolve_mcp_specs_with_local_uuids(
+        &[MCPSpec::WellKnown("linear".to_string())],
+        &HashSet::new(),
+        Arc::new(mock),
+    ))
+    .unwrap();
+
+    assert!(resolved.local_uuids.is_empty());
+    assert!(resolved.ephemeral_installations.is_empty());
+}
+
+#[test]
+fn well_known_resolution_failure_does_not_drop_other_specs() {
+    let uuid = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+    let config_json =
+        r#"{"mcpServers":{"GitHub MCP":{"command":"npx","env":{"API_TOKEN":"{{API_TOKEN}}"}}}}"#;
+    let mut mock = MockManagedMcpClient::new();
+    mock.expect_create_managed_mcp_client_config()
+        .times(2)
+        .returning(move |requested_uid| {
+            if requested_uid == "linear" {
+                Err(anyhow::anyhow!("Linear is not connected for this team"))
+            } else {
+                assert_eq!(requested_uid, uuid.to_string());
+                Ok(managed_client_config_output(config_json))
+            }
+        });
+
+    let resolved = block_on(AgentDriver::resolve_mcp_specs_with_local_uuids(
+        &[
+            MCPSpec::WellKnown("linear".to_string()),
+            MCPSpec::Uuid(uuid),
+        ],
+        &HashSet::new(),
+        Arc::new(mock),
+    ))
+    .unwrap();
+
     assert_eq!(resolved.ephemeral_installations.len(), 1);
 }
 

--- a/app/src/ai/agent_sdk/driver_tests.rs
+++ b/app/src/ai/agent_sdk/driver_tests.rs
@@ -18,6 +18,7 @@ use warp_cli::{
     SESSION_SHARING_SERVER_URL_OVERRIDE_ENV, WS_SERVER_URL_OVERRIDE_ENV,
 };
 use warp_core::channel::ChannelState;
+use warp_core::features::FeatureFlag;
 use warp_graphql::mutations::create_managed_mcp_client_config::{
     CreateManagedMcpClientConfigOutput, ManagedMcpTransportKind,
 };
@@ -206,6 +207,7 @@ fn managed_resolver_non_local_uuid_calls_managed_client() {
 
 #[test]
 fn well_known_spec_resolves_via_managed_client() {
+    let _flag = FeatureFlag::WellKnownMcpIds.override_enabled(true);
     let config_json = r#"{"mcpServers":{"linear":{"url":"https://app.warp.dev/mcp/integration-proxy/linear","headers":{"Authorization":"Bearer tok"}}}}"#;
     let mut mock = MockManagedMcpClient::new();
     mock.expect_create_managed_mcp_client_config()
@@ -228,6 +230,7 @@ fn well_known_spec_resolves_via_managed_client() {
 
 #[test]
 fn well_known_resolution_failure_skips_server() {
+    let _flag = FeatureFlag::WellKnownMcpIds.override_enabled(true);
     let mut mock = MockManagedMcpClient::new();
     mock.expect_create_managed_mcp_client_config()
         .times(1)
@@ -248,6 +251,7 @@ fn well_known_resolution_failure_skips_server() {
 
 #[test]
 fn well_known_resolution_failure_does_not_drop_other_specs() {
+    let _flag = FeatureFlag::WellKnownMcpIds.override_enabled(true);
     let uuid = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
     let config_json =
         r#"{"mcpServers":{"GitHub MCP":{"command":"npx","env":{"API_TOKEN":"{{API_TOKEN}}"}}}}"#;
@@ -274,6 +278,24 @@ fn well_known_resolution_failure_does_not_drop_other_specs() {
     .unwrap();
 
     assert_eq!(resolved.ephemeral_installations.len(), 1);
+}
+
+#[test]
+fn well_known_spec_is_skipped_when_flag_disabled() {
+    let _flag = FeatureFlag::WellKnownMcpIds.override_enabled(false);
+    // The managed client must not be called for well-known specs when the
+    // feature is disabled (e.g. a persisted config from a dogfood build).
+    let mock = MockManagedMcpClient::new();
+
+    let resolved = block_on(AgentDriver::resolve_mcp_specs_with_local_uuids(
+        &[MCPSpec::WellKnown("linear".to_string())],
+        &HashSet::new(),
+        Arc::new(mock),
+    ))
+    .unwrap();
+
+    assert!(resolved.local_uuids.is_empty());
+    assert!(resolved.ephemeral_installations.is_empty());
 }
 
 #[test]

--- a/app/src/ai/agent_sdk/mcp_config.rs
+++ b/app/src/ai/agent_sdk/mcp_config.rs
@@ -36,6 +36,17 @@ pub(super) fn build_mcp_servers_from_specs(
                     }),
                 )?;
             }
+            MCPSpec::WellKnown(id) => {
+                insert_unique(
+                    &mut merged,
+                    id.clone(),
+                    Value::Object({
+                        let mut obj = Map::new();
+                        obj.insert("warp_id".to_string(), Value::String(id.clone()));
+                        obj
+                    }),
+                )?;
+            }
             MCPSpec::Json(json_str) => {
                 let json_str = normalize_mcp_json_for_single_server(json_str)?;
                 let value = parse_json_with_optional_braces(&json_str)?;
@@ -141,9 +152,12 @@ fn validate_server_config(server_name: &str, config: &Value) -> anyhow::Result<(
             anyhow::anyhow!("MCP server '{server_name}' field 'warp_id' must be a string")
         })?;
 
-        uuid::Uuid::parse_str(warp_id).with_context(|| {
-            format!("MCP server '{server_name}' field 'warp_id' must be a UUID")
-        })?;
+        // A warp_id is either a managed MCP server UUID or a well-known id
+        // (e.g. "linear"). The server owns the set of recognized ids, so the
+        // client only requires a non-empty value.
+        if warp_id.trim().is_empty() {
+            anyhow::bail!("MCP server '{server_name}' field 'warp_id' must be non-empty");
+        }
     }
 
     if has_command {

--- a/app/src/ai/agent_sdk/mcp_config.rs
+++ b/app/src/ai/agent_sdk/mcp_config.rs
@@ -1,6 +1,7 @@
 use anyhow::Context as _;
 use serde_json::{Map, Value};
 use warp_cli::mcp::MCPSpec;
+use warp_core::features::FeatureFlag;
 
 use crate::ai::mcp::TemplatableMCPServer;
 
@@ -152,10 +153,15 @@ fn validate_server_config(server_name: &str, config: &Value) -> anyhow::Result<(
             anyhow::anyhow!("MCP server '{server_name}' field 'warp_id' must be a string")
         })?;
 
-        // A warp_id is either a managed MCP server UUID or a well-known id
-        // (e.g. "linear"). The server owns the set of recognized ids, so the
-        // client only requires a non-empty value.
-        if warp_id.trim().is_empty() {
+        // A warp_id is either a managed MCP server UUID or, behind
+        // `FeatureFlag::WellKnownMcpIds`, a well-known id (e.g. "linear").
+        // The server owns the set of recognized ids, so the client only
+        // requires a non-empty value.
+        if !FeatureFlag::WellKnownMcpIds.is_enabled() {
+            uuid::Uuid::parse_str(warp_id).with_context(|| {
+                format!("MCP server '{server_name}' field 'warp_id' must be a UUID")
+            })?;
+        } else if warp_id.trim().is_empty() {
             anyhow::bail!("MCP server '{server_name}' field 'warp_id' must be non-empty");
         }
     }

--- a/app/src/ai/agent_sdk/mcp_config_tests.rs
+++ b/app/src/ai/agent_sdk/mcp_config_tests.rs
@@ -244,7 +244,10 @@ fn validation_rejects_invalid_entries() {
     // owns the set of recognized non-UUID ids).
     let spec = json!({ "mcpServers": { "bad": { "warp_id": "" } } }).to_string();
     let err = build_mcp_servers_from_specs(&[MCPSpec::Json(spec)]).unwrap_err();
-    assert!(err.to_string().contains("field 'warp_id' must be non-empty"));
+    assert!(
+        err.to_string()
+            .contains("field 'warp_id' must be non-empty")
+    );
 
     // args must be array.
     let spec = json!({ "mcpServers": { "bad": { "command": "npx", "args": "nope" } } }).to_string();

--- a/app/src/ai/agent_sdk/mcp_config_tests.rs
+++ b/app/src/ai/agent_sdk/mcp_config_tests.rs
@@ -27,6 +27,24 @@ fn uuid_spec_is_coerced_to_warp_id() {
 }
 
 #[test]
+fn well_known_spec_is_coerced_to_warp_id() {
+    let servers = build(vec![MCPSpec::WellKnown("linear".to_string())]);
+
+    let entry = servers.get("linear").unwrap();
+    assert_eq!(entry["warp_id"].as_str(), Some("linear"));
+}
+
+#[test]
+fn well_known_warp_id_passes_validation() {
+    // Non-UUID warp_ids resolve via the same managed MCP GraphQL; the server
+    // owns the set of recognized ids, so validation accepts any non-empty id.
+    let spec = json!({ "mcpServers": { "linear": { "warp_id": "linear" } } }).to_string();
+    let servers = build(vec![MCPSpec::Json(spec)]);
+
+    assert_eq!(servers["linear"]["warp_id"].as_str(), Some("linear"));
+}
+
+#[test]
 fn wrapper_mcp_servers_is_unpacked() {
     let spec = json!({
         "mcpServers": {
@@ -222,10 +240,11 @@ fn validation_rejects_invalid_entries() {
             .contains("must have exactly one of: 'warp_id', 'command', or 'url'")
     );
 
-    // warp_id must be a UUID string.
-    let spec = json!({ "mcpServers": { "bad": { "warp_id": "not-a-uuid" } } }).to_string();
+    // warp_id must be a non-empty string (UUID or well-known id — the server
+    // owns the set of recognized non-UUID ids).
+    let spec = json!({ "mcpServers": { "bad": { "warp_id": "" } } }).to_string();
     let err = build_mcp_servers_from_specs(&[MCPSpec::Json(spec)]).unwrap_err();
-    assert!(err.to_string().contains("field 'warp_id' must be a UUID"));
+    assert!(err.to_string().contains("field 'warp_id' must be non-empty"));
 
     // args must be array.
     let spec = json!({ "mcpServers": { "bad": { "command": "npx", "args": "nope" } } }).to_string();

--- a/app/src/ai/agent_sdk/mcp_config_tests.rs
+++ b/app/src/ai/agent_sdk/mcp_config_tests.rs
@@ -1,5 +1,6 @@
 use serde_json::{Map, Value, json};
 use warp_cli::mcp::MCPSpec;
+use warp_core::features::FeatureFlag;
 
 use super::build_mcp_servers_from_specs;
 
@@ -28,6 +29,7 @@ fn uuid_spec_is_coerced_to_warp_id() {
 
 #[test]
 fn well_known_spec_is_coerced_to_warp_id() {
+    let _flag = FeatureFlag::WellKnownMcpIds.override_enabled(true);
     let servers = build(vec![MCPSpec::WellKnown("linear".to_string())]);
 
     let entry = servers.get("linear").unwrap();
@@ -38,10 +40,20 @@ fn well_known_spec_is_coerced_to_warp_id() {
 fn well_known_warp_id_passes_validation() {
     // Non-UUID warp_ids resolve via the same managed MCP GraphQL; the server
     // owns the set of recognized ids, so validation accepts any non-empty id.
+    let _flag = FeatureFlag::WellKnownMcpIds.override_enabled(true);
     let spec = json!({ "mcpServers": { "linear": { "warp_id": "linear" } } }).to_string();
     let servers = build(vec![MCPSpec::Json(spec)]);
 
     assert_eq!(servers["linear"]["warp_id"].as_str(), Some("linear"));
+}
+
+#[test]
+fn non_uuid_warp_id_fails_validation_when_flag_disabled() {
+    let _flag = FeatureFlag::WellKnownMcpIds.override_enabled(false);
+    let spec = json!({ "mcpServers": { "linear": { "warp_id": "linear" } } }).to_string();
+    let err = build_mcp_servers_from_specs(&[MCPSpec::Json(spec)]).unwrap_err();
+
+    assert!(err.to_string().contains("field 'warp_id' must be a UUID"));
 }
 
 #[test]
@@ -240,10 +252,13 @@ fn validation_rejects_invalid_entries() {
             .contains("must have exactly one of: 'warp_id', 'command', or 'url'")
     );
 
-    // warp_id must be a non-empty string (UUID or well-known id — the server
-    // owns the set of recognized non-UUID ids).
+    // warp_id must be a non-empty string (UUID or, behind WellKnownMcpIds,
+    // a well-known id — the server owns the set of recognized non-UUID ids).
     let spec = json!({ "mcpServers": { "bad": { "warp_id": "" } } }).to_string();
-    let err = build_mcp_servers_from_specs(&[MCPSpec::Json(spec)]).unwrap_err();
+    let err = {
+        let _flag = FeatureFlag::WellKnownMcpIds.override_enabled(true);
+        build_mcp_servers_from_specs(&[MCPSpec::Json(spec)]).unwrap_err()
+    };
     assert!(
         err.to_string()
             .contains("field 'warp_id' must be non-empty")

--- a/app/src/server/server_api/managed_mcp.rs
+++ b/app/src/server/server_api/managed_mcp.rs
@@ -6,7 +6,6 @@ use async_trait::async_trait;
 use cynic::MutationBuilder;
 #[cfg(test)]
 use mockall::automock;
-use uuid::Uuid;
 use warp_graphql::mutations::create_managed_mcp_client_config::{
     CreateManagedMcpClientConfig, CreateManagedMcpClientConfigInput,
     CreateManagedMcpClientConfigOutput, CreateManagedMcpClientConfigResult,
@@ -20,9 +19,11 @@ use crate::server::graphql::{get_request_context, get_user_facing_error_message}
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 pub trait ManagedMcpClient: 'static + Send + Sync {
+    /// `uid` is a managed MCP server UUID or a well-known integration id
+    /// (e.g. "linear") — the GraphQL input is an opaque `ID!`.
     async fn create_managed_mcp_client_config(
         &self,
-        uid: Uuid,
+        uid: String,
     ) -> Result<CreateManagedMcpClientConfigOutput>;
 }
 
@@ -31,11 +32,11 @@ pub trait ManagedMcpClient: 'static + Send + Sync {
 impl ManagedMcpClient for ServerApi {
     async fn create_managed_mcp_client_config(
         &self,
-        uid: Uuid,
+        uid: String,
     ) -> Result<CreateManagedMcpClientConfigOutput> {
         let variables = CreateManagedMcpClientConfigVariables {
             input: CreateManagedMcpClientConfigInput {
-                uid: cynic::Id::new(uid.to_string()),
+                uid: cynic::Id::new(uid),
             },
             request_context: get_request_context(),
         };

--- a/crates/warp_cli/Cargo.toml
+++ b/crates/warp_cli/Cargo.toml
@@ -39,3 +39,4 @@ api_key_authentication = []
 
 [dev-dependencies]
 serial_test = "0.8.0"
+warp_core = { workspace = true, features = ["test-util"] }

--- a/crates/warp_cli/src/mcp.rs
+++ b/crates/warp_cli/src/mcp.rs
@@ -27,9 +27,23 @@ impl MCPCommand {
 pub enum MCPSpec {
     /// Existing server by UUID.
     Uuid(uuid::Uuid),
+    /// Well-known non-UUID managed MCP id (e.g. "linear"), resolved by the
+    /// server. The server owns the set of recognized ids — ids it does not
+    /// recognize fail resolution and are skipped at run setup, so new ids can
+    /// be introduced server-side without a client change.
+    WellKnown(String),
     /// JSON string (full config, server map, or single server).
     /// Parsing deferred to app layer.
     Json(String),
+}
+
+/// A bare identifier (letters, digits, `-`, `_`) that is not a UUID: treated
+/// as a well-known managed MCP id and sent to the server for resolution.
+pub fn is_well_known_mcp_id(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        && uuid::Uuid::parse_str(s).is_err()
 }
 
 impl clap::builder::ValueParserFactory for MCPSpec {
@@ -70,6 +84,10 @@ impl clap::builder::TypedValueParser for MCPSpecParser {
                     format!("Failed to read MCP config file '{}': {e}", path.display()),
                 )
             })?
+        } else if is_well_known_mcp_id(s) {
+            // Bare identifiers (e.g. "linear") are well-known managed MCP ids
+            // resolved by the server at run setup.
+            return Ok(MCPSpec::WellKnown(s.to_string()));
         } else {
             // Treat as inline JSON
             s.to_string()

--- a/crates/warp_cli/src/mcp.rs
+++ b/crates/warp_cli/src/mcp.rs
@@ -3,6 +3,7 @@ use std::ffi::OsStr;
 use clap::builder::PossibleValue;
 use clap::error::ErrorKind;
 use clap::{Arg, Command, Subcommand};
+use warp_core::features::FeatureFlag;
 
 /// MCP-related subcommands.
 #[derive(Debug, Clone, Subcommand)]
@@ -84,7 +85,7 @@ impl clap::builder::TypedValueParser for MCPSpecParser {
                     format!("Failed to read MCP config file '{}': {e}", path.display()),
                 )
             })?
-        } else if is_well_known_mcp_id(s) {
+        } else if FeatureFlag::WellKnownMcpIds.is_enabled() && is_well_known_mcp_id(s) {
             // Bare identifiers (e.g. "linear") are well-known managed MCP ids
             // resolved by the server at run setup.
             return Ok(MCPSpec::WellKnown(s.to_string()));

--- a/crates/warp_cli/src/mcp_tests.rs
+++ b/crates/warp_cli/src/mcp_tests.rs
@@ -16,7 +16,16 @@ fn test_parse_uuid() {
     let result = parse_mcp_spec(uuid_str).unwrap();
     match result {
         MCPSpec::Uuid(uuid) => assert_eq!(uuid.to_string(), uuid_str),
-        MCPSpec::Json(_) => panic!("Expected Uuid variant"),
+        other => panic!("Expected Uuid variant, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_parse_well_known_integration_id() {
+    let result = parse_mcp_spec("linear").unwrap();
+    match result {
+        MCPSpec::WellKnown(id) => assert_eq!(id, "linear"),
+        other => panic!("Expected WellKnown variant, got {other:?}"),
     }
 }
 
@@ -26,7 +35,7 @@ fn test_parse_inline_json_cli_server() {
     let result = parse_mcp_spec(json).unwrap();
     match result {
         MCPSpec::Json(s) => assert_eq!(s, json),
-        MCPSpec::Uuid(_) => panic!("Expected Json variant"),
+        other => panic!("Expected Json variant, got {other:?}"),
     }
 }
 
@@ -36,7 +45,7 @@ fn test_parse_inline_json_single_server() {
     let result = parse_mcp_spec(json).unwrap();
     match result {
         MCPSpec::Json(s) => assert_eq!(s, json),
-        MCPSpec::Uuid(_) => panic!("Expected Json variant"),
+        other => panic!("Expected Json variant, got {other:?}"),
     }
 }
 
@@ -46,7 +55,7 @@ fn test_parse_inline_json_sse_server() {
     let result = parse_mcp_spec(json).unwrap();
     match result {
         MCPSpec::Json(s) => assert_eq!(s, json),
-        MCPSpec::Uuid(_) => panic!("Expected Json variant"),
+        other => panic!("Expected Json variant, got {other:?}"),
     }
 }
 
@@ -56,7 +65,7 @@ fn test_parse_inline_json_mcp_servers_wrapper() {
     let result = parse_mcp_spec(json).unwrap();
     match result {
         MCPSpec::Json(s) => assert_eq!(s, json),
-        MCPSpec::Uuid(_) => panic!("Expected Json variant"),
+        other => panic!("Expected Json variant, got {other:?}"),
     }
 }
 
@@ -69,9 +78,18 @@ fn test_uuid_takes_precedence_over_json() {
 }
 
 #[test]
-fn test_invalid_uuid_treated_as_json() {
-    // An invalid UUID that looks like it could be one should be treated as JSON
-    let invalid_uuid = "not-a-valid-uuid";
-    let result = parse_mcp_spec(invalid_uuid).unwrap();
+fn test_bare_identifier_treated_as_well_known() {
+    // A bare non-UUID identifier is a well-known managed MCP id: the server
+    // owns the set of recognized ids and unknown ones are skipped at run
+    // setup, so new ids work without a client change.
+    let result = parse_mcp_spec("not-a-valid-uuid").unwrap();
+    assert!(matches!(result, MCPSpec::WellKnown(id) if id == "not-a-valid-uuid"));
+}
+
+#[test]
+fn test_non_identifier_non_json_treated_as_json() {
+    // Anything with characters outside [A-Za-z0-9_-] that isn't a file falls
+    // through to the inline-JSON path (and fails JSON parsing later).
+    let result = parse_mcp_spec("missing-config.json").unwrap();
     assert!(matches!(result, MCPSpec::Json(_)));
 }

--- a/crates/warp_cli/src/mcp_tests.rs
+++ b/crates/warp_cli/src/mcp_tests.rs
@@ -22,11 +22,19 @@ fn test_parse_uuid() {
 
 #[test]
 fn test_parse_well_known_integration_id() {
+    let _flag = FeatureFlag::WellKnownMcpIds.override_enabled(true);
     let result = parse_mcp_spec("linear").unwrap();
     match result {
         MCPSpec::WellKnown(id) => assert_eq!(id, "linear"),
         other => panic!("Expected WellKnown variant, got {other:?}"),
     }
+}
+
+#[test]
+fn test_bare_identifier_treated_as_json_when_flag_disabled() {
+    let _flag = FeatureFlag::WellKnownMcpIds.override_enabled(false);
+    let result = parse_mcp_spec("linear").unwrap();
+    assert!(matches!(result, MCPSpec::Json(_)));
 }
 
 #[test]
@@ -82,6 +90,7 @@ fn test_bare_identifier_treated_as_well_known() {
     // A bare non-UUID identifier is a well-known managed MCP id: the server
     // owns the set of recognized ids and unknown ones are skipped at run
     // setup, so new ids work without a client change.
+    let _flag = FeatureFlag::WellKnownMcpIds.override_enabled(true);
     let result = parse_mcp_spec("not-a-valid-uuid").unwrap();
     assert!(matches!(result, MCPSpec::WellKnown(id) if id == "not-a-valid-uuid"));
 }

--- a/crates/warp_features/src/lib.rs
+++ b/crates/warp_features/src/lib.rs
@@ -924,6 +924,11 @@ pub enum FeatureFlag {
     /// Gates the account-first onboarding flow, including the reordered
     /// pre-auth slides and post-auth account offer.
     AccountFirstOnboarding,
+
+    /// Accepts well-known non-UUID managed MCP ids (e.g. `"linear"`) as
+    /// `warp_id` values in MCP configs and as bare identifiers in CLI
+    /// `--mcp` arguments, resolved server-side at run setup.
+    WellKnownMcpIds,
 }
 
 static FLAG_STATES: [AtomicBool; cardinality::<FeatureFlag>()] =
@@ -999,6 +1004,7 @@ pub const DOGFOOD_FLAGS: &[FeatureFlag] = &[
     FeatureFlag::McpJsonTreeView,
     FeatureFlag::GeminiEnterprise,
     FeatureFlag::BoxDrawingGlyphs,
+    FeatureFlag::WellKnownMcpIds,
 ];
 
 /// Features enabled for feature preview build users (e.g.: Friends of Warp).


### PR DESCRIPTION
## Description

Adds a `MCPSpec::WellKnown` variant to support non-UUID managed MCP identifiers (e.g. `"linear"`). Previously, `warp_id` fields were required to be UUIDs; now any non-empty, non-UUID string is treated as a well-known id that the server resolves. This allows new integrations to be introduced server-side without requiring a client update.

**Parsing behavior:**

- CLI: bare identifiers matching `[A-Za-z0-9_-]+` that are not UUIDs are parsed as `MCPSpec::WellKnown` instead of falling through to inline JSON.
- Config file: `warp_id` values that are not UUIDs become `MCPSpec::WellKnown`; empty `warp_id` values are rejected with an error.
- Validation no longer requires `warp_id` to be a UUID — only that it is non-empty.

**Resolution behavior:**

- `MCPSpec::WellKnown` resolves via the same `create_managed_mcp_client_config` GraphQL mutation as UUID specs, passing the id as an opaque `ID!`.
- Resolution is best-effort: if the server does not recognize the id or the integration is disconnected, the server is skipped with a warning rather than failing run setup.
- The `ManagedMcpClient::create_managed_mcp_client_config` signature is updated from `uid: Uuid` to `uid: String` to accommodate both UUIDs and well-known ids.

**Config serialization:**

- `MCPSpec::WellKnown` round-trips through the MCP servers map as `{ "warp_id": "<id>" }`, consistent with how UUID specs are represented.

## Testing

New unit tests cover:

- Well-known ids parsed from CLI and config file become `MCPSpec::WellKnown`.
- Well-known ids resolve via the managed MCP client and produce ephemeral installations.
- Resolution failures for well-known ids skip the server without failing run setup or dropping other specs.
- Empty `warp_id` values are rejected at both the config file and validation layers.
- Non-identifier, non-JSON strings fall through to the inline-JSON path.
- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode