### PR TITLE
Proper TUI initialization for sentry and telemetry flushing

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -513,8 +513,7 @@ impl LaunchMode {
             LaunchMode::App { .. } => ExecutionMode::App,
             LaunchMode::CommandLine { .. } => ExecutionMode::Sdk,
             LaunchMode::Test { .. } => ExecutionMode::App,
-            // The TUI front-end is an app-style client, not the SDK.
-            LaunchMode::Tui { .. } => ExecutionMode::App,
+            LaunchMode::Tui { .. } => ExecutionMode::Tui,
             // RemoteServerProxy is a thin byte bridge; Sdk is the closest match.
             LaunchMode::RemoteServerProxy => ExecutionMode::Sdk,
             // RemoteServerDaemon gets its own mode for distinct Sentry tagging.
@@ -1109,10 +1108,27 @@ fn run_internal(mut launch_mode: LaunchMode) -> Result<()> {
     let pty_spawner =
         terminal::local_tty::spawner::PtySpawner::new().context("Failed to create pty spawner")?;
 
-    // The TUI front-end skips the GUI lifecycle callbacks (which reach for
-    // singletons/windows it never creates), so it uses empty callbacks.
+    // The TUI front-end skips the GUI lifecycle callbacks, which reach for
+    // windows and GUI-only state, but still flushes telemetry and reporting on
+    // termination.
     let callbacks = if matches!(launch_mode, LaunchMode::Tui { .. }) {
-        warpui::platform::AppCallbacks::default()
+        let mut tracing_initialization = tracing_initialization.take();
+        warpui::platform::AppCallbacks {
+            on_will_terminate: Some(Box::new(move |ctx| {
+                TelemetryCollector::handle(ctx).update(ctx, |telemetry_collector, ctx| {
+                    telemetry_collector.flush_telemetry_events_for_shutdown(ctx);
+                });
+
+                profiling::teardown();
+                if let Some(initialization) = tracing_initialization.as_mut() {
+                    initialization.shutdown();
+                }
+
+                #[cfg(feature = "crash_reporting")]
+                crash_reporting::uninit_sentry();
+            })),
+            ..Default::default()
+        }
     } else {
         app_callbacks(
             launch_mode.is_integration_test(),

--- a/crates/warp_core/src/execution_mode.rs
+++ b/crates/warp_core/src/execution_mode.rs
@@ -10,6 +10,8 @@ static GLOBAL_EXECUTION_MODE: OnceLock<ExecutionMode> = OnceLock::new();
 pub enum ExecutionMode {
     /// Warp is running as a normal desktop app.
     App,
+    /// Warp is running as the headless terminal UI.
+    Tui,
     /// Warp is running as a CLI.
     Sdk,
     /// Warp is running as the remote server daemon.
@@ -22,6 +24,7 @@ impl ExecutionMode {
     pub fn client_id(&self) -> &'static str {
         match self {
             ExecutionMode::App => "warp-app",
+            ExecutionMode::Tui => "warp-tui",
             ExecutionMode::Sdk => "warp-cli",
             ExecutionMode::RemoteServerDaemon => "warp-remote-server-daemon",
         }
@@ -44,14 +47,14 @@ impl AppExecutionMode {
         Self { mode, is_sandboxed }
     }
 
-    /// True if running as the full desktop app.
+    /// True if running as an interactive app client.
     fn is_app(&self) -> bool {
-        matches!(self.mode, ExecutionMode::App)
+        matches!(self.mode, ExecutionMode::App | ExecutionMode::Tui)
     }
 
     /// Whether Active AI features are allowed in this execution mode.
     ///
-    /// Active AI should only run in the desktop app, where there's a user
+    /// Active AI should only run in interactive clients, where there's a user
     /// to engage with it.
     pub fn allows_active_ai(&self) -> bool {
         self.is_app()
@@ -92,12 +95,12 @@ impl AppExecutionMode {
     }
 
     /// Whether telemetry should be sent synchronously at shutdown.
-    /// In CLI and daemon modes, we synchronously send events at shutdown because there's a
-    /// higher likelihood that they will be lost otherwise.
+    /// In TUI, CLI, and daemon modes, we synchronously send events at shutdown because there's
+    /// a higher likelihood that they will be lost otherwise.
     pub fn send_telemetry_at_shutdown(&self) -> bool {
         matches!(
             self.mode,
-            ExecutionMode::Sdk | ExecutionMode::RemoteServerDaemon
+            ExecutionMode::Tui | ExecutionMode::Sdk | ExecutionMode::RemoteServerDaemon
         )
     }
 
@@ -129,7 +132,7 @@ impl Entity for AppExecutionMode {
 
 impl SingletonEntity for AppExecutionMode {}
 
-/// Returns the current global client ID string ("warp-app", "warp-cli", or "warp-remote-server-daemon").
+/// Returns the current global client ID string.
 /// This is set when AppExecutionMode is constructed during application start.
 /// Returns None if the execution mode has not been set yet.
 pub fn current_client_id() -> Option<&'static str> {

--- a/crates/warp_tui/Cargo.toml
+++ b/crates/warp_tui/Cargo.toml
@@ -93,6 +93,8 @@ warp = { workspace = true, features = ["tui", "test-util"] }
 # stays off and the local bin uses the runtime generator; wiring the embedded
 # config path (a `build.rs`) is phase 2 of the channel setup.
 release_bundle = ["warp/release_bundle"]
+# Enable Rust Sentry reporting without the GUI-only Cocoa SDK.
+crash_reporting = ["warp/crash_reporting"]
 # Self-contained TUI build (the binary is not inside a `.app` bundle). Enables
 # `warp/standalone`, which turns on `warp_core/standalone` so
 # `warp_core::paths::bundled_resources_dir()` resolves the sibling `resources/`

--- a/crates/warp_tui/src/session.rs
+++ b/crates/warp_tui/src/session.rs
@@ -16,6 +16,7 @@ use warp::tui_export::{
     ServerConversationToken, TerminalManagerTrait, TerminalSurfaceResult,
 };
 use warp::{TuiLoginEvent, TuiLoginModel, TuiLoginPhase};
+use warp_core::telemetry::TelemetryEvent as _;
 use warp_errors::report_error;
 use warpui::SingletonEntity;
 use warpui_core::platform::{TerminationMode, WindowStyle};
@@ -24,6 +25,7 @@ use warpui_core::{AddWindowOptions, AppContext, Entity, ModelHandle, ViewHandle}
 
 use crate::resume::TuiExitSummaryHandle;
 use crate::root_view::RootTuiView;
+use crate::telemetry::TuiStartupTelemetryEvent;
 use crate::terminal_background::probe_and_select_theme;
 use crate::terminal_session_view::{
     TuiConversationRestoreOrigin, TuiConversationRestoreTarget, TuiTerminalSessionView,
@@ -106,6 +108,7 @@ fn init(
     exit_summary: TuiExitSummaryHandle,
     ctx: &mut AppContext,
 ) {
+    warp_core::send_telemetry_from_app_ctx!(TuiStartupTelemetryEvent, ctx);
     // Register the TUI views' keybindings (and, in debug builds, the
     // cross-surface binding validators) before any input can be dispatched.
     crate::keybindings::init(ctx);

--- a/crates/warp_tui/src/telemetry.rs
+++ b/crates/warp_tui/src/telemetry.rs
@@ -1,8 +1,52 @@
-//! Telemetry for the `warp-tui` background auto-updater.
+//! Telemetry for the `warp-tui` front-end.
 
 use serde_json::{json, Value};
 use strum_macros::{EnumDiscriminants, EnumIter};
 use warp_core::telemetry::{EnablementState, TelemetryEvent, TelemetryEventDesc};
+#[derive(Debug)]
+pub(crate) struct TuiStartupTelemetryEvent;
+
+impl TelemetryEvent for TuiStartupTelemetryEvent {
+    fn name(&self) -> &'static str {
+        "TUI.Startup"
+    }
+
+    fn payload(&self) -> Option<Value> {
+        None
+    }
+
+    fn description(&self) -> &'static str {
+        "The headless Warp TUI is launched"
+    }
+
+    fn enablement_state(&self) -> EnablementState {
+        EnablementState::Always
+    }
+
+    fn contains_ugc(&self) -> bool {
+        false
+    }
+
+    fn event_descs() -> impl Iterator<Item = Box<dyn TelemetryEventDesc>> {
+        std::iter::once(Box::new(Self) as Box<dyn TelemetryEventDesc>)
+    }
+}
+
+impl TelemetryEventDesc for TuiStartupTelemetryEvent {
+    fn name(&self) -> &'static str {
+        "TUI.Startup"
+    }
+
+    fn description(&self) -> &'static str {
+        "The headless Warp TUI is launched"
+    }
+
+    fn enablement_state(&self) -> EnablementState {
+        EnablementState::Always
+    }
+}
+
+warp_core::register_telemetry_event!(TuiStartupTelemetryEvent);
 
 /// Health signals for the TUI auto-updater. Sent when the outcome of a
 /// background update check *changes* (not on every poll), so repeated

--- a/script/macos/bundle
+++ b/script/macos/bundle
@@ -368,6 +368,9 @@ elif [[ "$ARTIFACT" == tui ]]; then
     *) WARP_BIN="warp-tui-$RELEASE_CHANNEL" ;;
   esac
   WARP_TUI_FEATURES="release_bundle,standalone"
+  if [[ "$RELEASE_CHANNEL" != "oss" ]]; then
+    WARP_TUI_FEATURES="$WARP_TUI_FEATURES,crash_reporting"
+  fi
 elif [[ "$ARTIFACT" == app ]]; then
   # All channels ship the v3 classifier and v2 heuristic.
   FEATURES="$FEATURES,gui,nld_classifier_v3,nld_heuristic_v2"


### PR DESCRIPTION
## Description

Give the headless TUI its own reporting identity and initialize its telemetry/crash-reporting lifecycle correctly.

- Add `ExecutionMode::Tui` with the dedicated `warp-tui` client ID, while preserving the TUI's existing app-style capabilities.
- Register and emit `TUI.Startup` from the TUI crate's injected mount callback.
- Enable Rust Sentry for non-OSS production TUI bundles without pulling in the GUI-only Cocoa SDK.
- Add TUI termination handling that synchronously flushes telemetry, tears down profiling/tracing, and uninitializes Sentry.

This keeps TUI events and Sentry reports distinguishable from the GUI while avoiding lost telemetry in short-lived TUI sessions.

## Linked Issue

N/A

## Testing

- [x] `./script/format`
- [x] `cargo clippy -p warp_tui --bin warp-tui-dev --features release_bundle,standalone,crash_reporting -- -D warnings`
- [x] `./script/macos/bundle --artifact tui --channel dev --check-only --nosign --nouniversal`
- [ ] I have manually tested my changes locally with `./script/run`

No new tests were added because this change is lifecycle/build-feature wiring rather than standalone algorithmic behavior.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

Co-Authored-By: Warp <agent@warp.dev>
