### PR TITLE
fix(macOS): stop registering Warp as default handler for Markdown (.md) files

### DIFF
--- a/script/update_plist
+++ b/script/update_plist
@@ -81,18 +81,6 @@ if [[ -z "$WARP_PLIST_NO_FILE_TYPES" ]]; then
       </array>
     </dict>
     <dict>
-      <key>CFBundleTypeName</key><string>Markdown File</string>
-      <key>CFBundleTypeRole</key><string>Editor</string>
-      <key>LSHandlerRank</key><string>Alternate</string>
-      <key>LSItemContentTypes</key>
-      <array>
-        <string>net.daringfireball.markdown</string>
-        <string>com.unknown.md</string>
-        <string>net.ia.markdown</string>
-        <string>public.markdown</string>
-      </array>
-    </dict>
-    <dict>
       <key>CFBundleTypeName</key><string>Plain Text File</string>
       <key>CFBundleTypeRole</key><string>Editor</string>
       <key>LSHandlerRank</key><string>Alternate</string>
@@ -251,11 +239,6 @@ if [[ -z "$WARP_PLIST_NO_FILE_TYPES" ]]; then
     </dict>
   </array>" "$WARP_PLIST_PATH"
 fi
-
-# Unfortunately, there isn't a single standard UTI (what goes in LSItemContentTypes) for Markdown
-# files. Instead, we list all the common ones - see these for more info:
-# https://github.com/sbarex/QLMarkdown#installation
-# https://blog.smittytone.net/2021/01/19/how-tools-try-to-own-markdown/
 
 echo "Updating plist with permissions descriptions"
 plutil -insert NSAppleEventsUsageDescription -string "A program in Warp wants to use AppleScript." "$WARP_PLIST_PATH"


### PR DESCRIPTION
## Summary

Remove the 'Markdown File' `CFBundleDocumentTypes` entry from `script/update_plist` that was causing Warp to register itself as the default application for Markdown (.md) files on macOS, overriding the user's chosen editor (e.g. VS Code) after every update.

## Root Cause

`script/update_plist` injected a `Markdown File` document-type entry declaring Warp an Editor for markdown UTIs (`net.daringfireball.markdown`, `com.unknown.md`, `net.ia.markdown`, `public.markdown`) with `LSHandlerRank=Alternate`. Because macOS Launch Services prefers UTI-level handlers over extension-only registrations, Warp would win the default-app resolution for `.md` over editors (like VS Code) that register by extension only. This OS-level claim was unaffected by the in-app `prefer_markdown_viewer` setting.

## Changes

- Removed the entire `Markdown File` dict block from the generated `CFBundleDocumentTypes` array in `script/update_plist`
- Removed the now-stale comment block about Markdown UTI coverage
- Plain text/source code/other file type registrations are unchanged

Closes #13268