### PR TITLE
fix(macos): declare Reminders + full-access EventKit usage keys in Info.plist (#13558)

### DIFF
--- a/script/update_plist
+++ b/script/update_plist
@@ -263,6 +263,11 @@ plutil -insert NSCameraUsageDescription -string "A program in Warp wants to use 
 plutil -insert NSMicrophoneUsageDescription -string "A program in Warp wants to use your microphone." "$WARP_PLIST_PATH"
 plutil -insert NSContactsUsageDescription -string "A program in Warp wants to use your contacts." "$WARP_PLIST_PATH"
 plutil -insert NSCalendarsUsageDescription -string "A program in Warp wants to use your calendar." "$WARP_PLIST_PATH"
+plutil -insert NSRemindersUsageDescription -string "A program in Warp wants to use your reminders." "$WARP_PLIST_PATH"
+# macOS 14+ checks the FullAccess variants instead; without them EventKit requests from
+# terminal subprocesses (e.g. icalBuddy) are silently denied with no consent prompt (#13558).
+plutil -insert NSCalendarsFullAccessUsageDescription -string "A program in Warp wants full access to your calendar." "$WARP_PLIST_PATH"
+plutil -insert NSRemindersFullAccessUsageDescription -string "A program in Warp wants full access to your reminders." "$WARP_PLIST_PATH"
 plutil -insert NSLocationUsageDescription -string "A program in Warp wants to use your location information." "$WARP_PLIST_PATH"
 plutil -insert NSPhotoLibraryUsageDescription -string "A program in Warp wants to use your photo library." "$WARP_PLIST_PATH"
 


### PR DESCRIPTION
Resolves #13558.

## Problem

Running `icalBuddy` (or any EventKit-based CLI) inside Warp fails with `error: No calendars.` even when Warp has Calendar access — while the exact same binary works in Terminal.app.

## Root cause

As diagnosed in the issue: `icalBuddy` opens both the EventKit **events** store and the **reminders** store at startup. macOS attributes both permission requests to the terminal app as the TCC responsible process, and only shows a consent prompt if the responsible app declares the matching usage-description key in its `Info.plist`. Missing key ⇒ silent denial: no prompt, and no entry in System Settings the user could flip.

Warp's `script/update_plist` declares `NSCalendarsUsageDescription` but:
- none of the **Reminders** keys, and
- neither of the **FullAccess** variants that macOS 14+ checks instead.

## Fix

Add the three missing keys alongside the existing permission descriptions, matching the established message style:

- `NSRemindersUsageDescription`
- `NSCalendarsFullAccessUsageDescription` (macOS 14+)
- `NSRemindersFullAccessUsageDescription` (macOS 14+)

## Validation

`bash -n script/update_plist` passes. The new `plutil -insert` invocations were run verbatim against a scratch plist on macOS 15 (Darwin 25.2.0):

```
$ plutil -lint Test.plist
Test.plist: OK
$ for key in NSCalendarsUsageDescription NSRemindersUsageDescription NSCalendarsFullAccessUsageDescription NSRemindersFullAccessUsageDescription; do
>   printf "%s = " "$key"; /usr/libexec/PlistBuddy -c "Print :$key" Test.plist
> done
NSCalendarsUsageDescription = A program in Warp wants to use your calendar.
NSRemindersUsageDescription = A program in Warp wants to use your reminders.
NSCalendarsFullAccessUsageDescription = A program in Warp wants full access to your calendar.
NSRemindersFullAccessUsageDescription = A program in Warp wants full access to your reminders.
```

The reporter's issue includes the TCC-level trace confirming the missing-key → silent-denial mechanism; end-to-end verification requires a signed rebuilt bundle granting the new prompts (happy to record that flow if desired).
