### PR TITLE
docs(warpctrl): specify file open wait behavior

### DIFF
--- a/specs/GH8741/product.md
+++ b/specs/GH8741/product.md
@@ -1,0 +1,116 @@
+# Product Spec: Wait for a file view opened by `warpctrl`
+
+Issue: https://github.com/warpdotdev/Warp/issues/8741
+Figma: none provided
+
+## Summary
+
+Add an opt-in `--wait` flag to `warpctrl file open PATH`. Without the flag, the
+command keeps its current nonblocking behavior. With the flag, it opens or
+focuses the same in-Warp file view that `file open` selects today and keeps the
+CLI process running until that exact logical view is closed.
+
+This gives tools that honor an `$EDITOR`-style command a simple synchronization
+contract comparable to `code --wait`, while keeping the public Warp Control
+surface limited to the existing `file.open` action.
+
+## Problem
+
+`warpctrl file open PATH` can open a file in Warp's code editor or Markdown
+viewer, but it acknowledges the request immediately. A caller that needs a
+human to review or edit a temporary file cannot tell when that interaction is
+finished, so it cannot safely resume and read the file back.
+
+## Goals
+
+- Support `warpctrl file open PATH --wait`.
+- Wait for the exact code-editor tab or Markdown viewer pane selected by that
+  invocation, including an already-open view that Warp focuses instead of
+  duplicating.
+- Preserve the existing behavior and output of `warpctrl file open PATH` when
+  `--wait` is absent.
+- Compose with the existing file-open arguments and target selectors.
+- Keep cancellation safe: stopping the waiting CLI must not close or otherwise
+  mutate the Warp view.
+
+## Non-goals
+
+- A separate public `warpctrl file wait` action.
+- Public file-view IDs, handles, inspection commands, or lifecycle APIs.
+- New file mode, viewer/editor, layout, split-direction, or sizing flags.
+- Reporting whether a view was saved, discarded, or closed unchanged.
+- Changing file-load, new-file, save, or unsaved-changes behavior.
+- Adding terminal-command execution, general pane automation, or the other
+  capabilities requested in issue #8741.
+- Changes to Oh My Pi or any other editor client. Once Warp supports `--wait`,
+  clients can opt into it through their existing editor-command configuration.
+
+## Behavior
+
+1. `warpctrl file open PATH` continues to open or focus the file and return the
+   existing `file.open` acknowledgement without waiting for the user to close
+   the view.
+
+2. `warpctrl file open PATH --wait` opens or focuses the file using the same
+   target, layout, Markdown preference, line, column, and selector resolution
+   as `file open` does today, then blocks until the exact logical file view
+   selected by that invocation is closed.
+
+3. If Warp creates a new code-editor tab or Markdown viewer pane, that new view
+   is the wait target. If the file is already open in the selected workspace and
+   Warp focuses it, that existing view is the wait target. Another view showing
+   the same path must not accidentally satisfy the wait.
+
+4. Reordering the target within its current tab or pane group, or moving the
+   target to another pane, workspace tab, or window, does not complete the
+   command. If a move merges the target into a different already-open view of
+   the same path and removes the original logical view, the original target is
+   considered closed and the wait completes.
+
+5. Closing the target code-editor tab or Markdown viewer pane completes the
+   command successfully. Closing a containing pane, workspace tab, or window
+   also completes the command when it removes the target view. Warp's
+   undo-close grace period does not delay completion after the view has left the
+   visible layout.
+
+6. For a code-editor tab with unsaved changes, choosing Save or Discard and
+   completing the close resolves the wait successfully. Canceling the close
+   leaves both the view and the CLI wait active. The successful response does
+   not classify which choice the user made.
+
+7. Multiple `file open --wait` processes may wait on the same already-open
+   logical view. Each process completes when that view closes; canceling one
+   waiter does not affect the others.
+
+8. Interrupting the CLI with Ctrl+C stops only that CLI process and its pending
+   request. The file remains open in Warp with its current content and unsaved
+   state.
+
+9. If the selected Warp process, Warp Control server, or local transport exits
+   before the target is normally closed, the CLI returns a nonzero transport or
+   bridge error rather than reporting a successful close.
+
+10. The success payload remains the existing `file.open` acknowledgement in
+    text and structured output modes. `--wait` changes when that acknowledgement
+    is returned, not its schema.
+
+11. `--wait` composes with `--line`, `--column`, `--new-tab`, `--instance`,
+    `--pid`, and the existing window/tab/pane/session selectors. Their parsing,
+    validation, and targeting behavior is unchanged.
+
+12. Existing file semantics remain unchanged. In particular, a path that the
+    code editor currently treats as a new file is still editable and saveable;
+    Markdown load errors still use the existing viewer behavior; and `--wait`
+    does not add a new preflight existence or readability check.
+
+## Success criteria
+
+1. An `$EDITOR`-style command can run `warpctrl file open temporary.md --wait`,
+   let the user edit and save in Warp, and resume only after the selected Warp
+   view closes.
+2. The same command without `--wait` remains nonblocking and wire-compatible.
+3. Waiting follows the exact selected view through ordinary moves and cannot be
+   completed by closing an unrelated duplicate path.
+4. Save, discard, cancel, Ctrl+C, multiple waiters, and Warp shutdown have the
+   behavior defined above.
+5. No new public Warp Control action or file-view identifier is introduced.

--- a/specs/GH8741/product.md
+++ b/specs/GH8741/product.md
@@ -3,114 +3,63 @@
 Issue: https://github.com/warpdotdev/Warp/issues/8741
 Figma: none provided
 
-## Summary
-
-Add an opt-in `--wait` flag to `warpctrl file open PATH`. Without the flag, the
-command keeps its current nonblocking behavior. With the flag, it opens or
-focuses the same in-Warp file view that `file open` selects today and keeps the
-CLI process running until that exact logical view is closed.
-
-This gives tools that honor an `$EDITOR`-style command a simple synchronization
-contract comparable to `code --wait`, while keeping the public Warp Control
-surface limited to the existing `file.open` action.
-
 ## Problem
 
-`warpctrl file open PATH` can open a file in Warp's code editor or Markdown
-viewer, but it acknowledges the request immediately. A caller that needs a
-human to review or edit a temporary file cannot tell when that interaction is
-finished, so it cannot safely resume and read the file back.
+`warpctrl file open PATH` returns as soon as Warp accepts the request. Tools that
+use an `$EDITOR`-style command therefore cannot wait for a user to finish
+reviewing or editing a file.
 
 ## Goals
 
-- Support `warpctrl file open PATH --wait`.
-- Wait for the exact code-editor tab or Markdown viewer pane selected by that
-  invocation, including an already-open view that Warp focuses instead of
-  duplicating.
-- Preserve the existing behavior and output of `warpctrl file open PATH` when
-  `--wait` is absent.
-- Compose with the existing file-open arguments and target selectors.
-- Keep cancellation safe: stopping the waiting CLI must not close or otherwise
-  mutate the Warp view.
+- Add `warpctrl file open PATH --wait`, comparable to `code --wait`.
+- Wait for the exact code-editor tab or Markdown pane selected by the command.
+- Preserve existing behavior, output, arguments, and targeting without
+  `--wait`.
+- Let callers cancel safely without changing the Warp view.
 
 ## Non-goals
 
-- A separate public `warpctrl file wait` action.
-- Public file-view IDs, handles, inspection commands, or lifecycle APIs.
-- New file mode, viewer/editor, layout, split-direction, or sizing flags.
-- Reporting whether a view was saved, discarded, or closed unchanged.
-- Changing file-load, new-file, save, or unsaved-changes behavior.
-- Adding terminal-command execution, general pane automation, or the other
-  capabilities requested in issue #8741.
-- Changes to Oh My Pi or any other editor client. Once Warp supports `--wait`,
-  clients can opt into it through their existing editor-command configuration.
+- A separate wait action or public file-view identifier.
+- New editor, viewer, layout, split, sizing, save, or load behavior.
+- Reporting whether the user saved, discarded, or closed an unchanged file.
+- Other automation requested in issue #8741 or changes to editor clients.
 
-## Behavior
+## Behavior invariants
 
-1. `warpctrl file open PATH` continues to open or focus the file and return the
-   existing `file.open` acknowledgement without waiting for the user to close
-   the view.
+1. Without `--wait`, `file open` keeps its current behavior and returns the
+   existing `file.open` acknowledgement immediately.
 
-2. `warpctrl file open PATH --wait` opens or focuses the file using the same
-   target, layout, Markdown preference, line, column, and selector resolution
-   as `file open` does today, then blocks until the exact logical file view
-   selected by that invocation is closed.
+2. With `--wait`, Warp uses the existing path, line, column, layout, Markdown,
+   instance, and target-selector logic, then waits for the exact logical view
+   that logic creates or focuses.
 
-3. If Warp creates a new code-editor tab or Markdown viewer pane, that new view
-   is the wait target. If the file is already open in the selected workspace and
-   Warp focuses it, that existing view is the wait target. Another view showing
-   the same path must not accidentally satisfy the wait.
+3. If Warp focuses an already-open view, that view becomes the target. Closing
+   another view of the same path does not satisfy the wait.
 
-4. Reordering the target within its current tab or pane group, or moving the
-   target to another pane, workspace tab, or window, does not complete the
-   command. If a move merges the target into a different already-open view of
-   the same path and removes the original logical view, the original target is
-   considered closed and the wait completes.
+4. Reordering or moving the target among panes, workspace tabs, or windows does
+   not complete the wait. If a move merges it into an already-open view of the
+   same path and removes the original logical view, the wait completes.
 
-5. Closing the target code-editor tab or Markdown viewer pane completes the
-   command successfully. Closing a containing pane, workspace tab, or window
-   also completes the command when it removes the target view. Warp's
-   undo-close grace period does not delay completion after the view has left the
-   visible layout.
+5. The wait succeeds when the target leaves the visible layout, whether closed
+   directly or through its containing pane, workspace tab, or window. Warp's
+   undo-close grace period does not delay completion.
 
-6. For a code-editor tab with unsaved changes, choosing Save or Discard and
-   completing the close resolves the wait successfully. Canceling the close
-   leaves both the view and the CLI wait active. The successful response does
-   not classify which choice the user made.
+6. For unsaved code-editor tabs, Save or Discard completes the wait once the tab
+   closes. Cancel leaves both the view and the wait active. The response does
+   not report which choice the user made.
 
-7. Multiple `file open --wait` processes may wait on the same already-open
-   logical view. Each process completes when that view closes; canceling one
-   waiter does not affect the others.
+7. Multiple processes may wait on the same view. They all complete when it
+   closes; canceling one does not affect the view or other waiters.
 
-8. Interrupting the CLI with Ctrl+C stops only that CLI process and its pending
-   request. The file remains open in Warp with its current content and unsaved
-   state.
+8. Ctrl+C stops only the calling CLI process. The view remains open with its
+   current content and unsaved state.
 
-9. If the selected Warp process, Warp Control server, or local transport exits
-   before the target is normally closed, the CLI returns a nonzero transport or
-   bridge error rather than reporting a successful close.
+9. If the selected Warp process, Warp Control server, or transport exits before
+   a normal close, the CLI returns a nonzero transport or bridge error.
 
-10. The success payload remains the existing `file.open` acknowledgement in
-    text and structured output modes. `--wait` changes when that acknowledgement
-    is returned, not its schema.
+10. Success remains the existing `file.open` acknowledgement in text and
+    structured output. `--wait` changes only when it is returned.
 
-11. `--wait` composes with `--line`, `--column`, `--new-tab`, `--instance`,
-    `--pid`, and the existing window/tab/pane/session selectors. Their parsing,
-    validation, and targeting behavior is unchanged.
-
-12. Existing file semantics remain unchanged. In particular, a path that the
-    code editor currently treats as a new file is still editable and saveable;
-    Markdown load errors still use the existing viewer behavior; and `--wait`
-    does not add a new preflight existence or readability check.
-
-## Success criteria
-
-1. An `$EDITOR`-style command can run `warpctrl file open temporary.md --wait`,
-   let the user edit and save in Warp, and resume only after the selected Warp
-   view closes.
-2. The same command without `--wait` remains nonblocking and wire-compatible.
-3. Waiting follows the exact selected view through ordinary moves and cannot be
-   completed by closing an unrelated duplicate path.
-4. Save, discard, cancel, Ctrl+C, multiple waiters, and Warp shutdown have the
-   behavior defined above.
-5. No new public Warp Control action or file-view identifier is introduced.
+11. Existing file semantics remain unchanged. Paths treated as new files remain
+    editable and saveable, Markdown load errors keep their current UI behavior,
+    and `--wait` adds no existence or readability preflight.

--- a/specs/GH8741/product.md
+++ b/specs/GH8741/product.md
@@ -37,8 +37,9 @@ reviewing or editing a file.
    another view of the same path does not satisfy the wait.
 
 4. Reordering or moving the target among panes, workspace tabs, or windows does
-   not complete the wait. If a move merges it into an already-open view of the
-   same path and removes the original logical view, the wait completes.
+   not complete the wait. If a move merges the target into an already-open view
+   of the same path, the wait transfers to the surviving view and completes when
+   that view closes.
 
 5. The wait succeeds when the target leaves the visible layout, whether closed
    directly or through its containing pane, workspace tab, or window. Warp's

--- a/specs/GH8741/tech.md
+++ b/specs/GH8741/tech.md
@@ -1,0 +1,285 @@
+# Tech Spec: Wait for a file view opened by `warpctrl`
+
+Issue: https://github.com/warpdotdev/Warp/issues/8741
+Product spec: `specs/GH8741/product.md`
+
+## Context
+
+Warp Control already exposes one typed file action:
+
+- `crates/warp_cli/src/local_control/mod.rs` defines
+  `FileCommand::Open(FileOpenArgs)`. `FileOpenArgs` contains the path, optional
+  line and column, `new_tab`, and the standard target selectors.
+- `crates/warp_cli/src/local_control/commands.rs::run_file_command` maps that
+  command to the existing `ActionKind::FileOpen` request.
+- `crates/local_control/src/protocol.rs::FileOpenParams` is the strict wire
+  parameter type. `crates/local_control/src/catalog.rs` declares `file.open`
+  with an acknowledgement result.
+- `crates/local_control/src/client.rs::send_request` performs one blocking HTTP
+  request and reads one response. It has no client-side request timeout, so the
+  existing transport can carry a long-lived wait without polling or streaming.
+- `app/src/local_control/mod.rs::handle_control_request` authenticates the
+  request, dispatches it to the main-thread `LocalControlBridge`, awaits the
+  bridge result, and serializes one response.
+- `app/src/local_control/bridge.rs::LocalControlBridge::handle_request` is
+  synchronous on the WarpUI model thread and currently returns a
+  `ResponseEnvelope` immediately.
+- `app/src/local_control/handlers/app_state.rs::file_open` validates the
+  parameters and target, calls `WorkspaceView::open_file_with_target`, and
+  immediately returns the acknowledgement.
+
+The selected in-Warp file surface depends on existing settings and state:
+
+- `app/src/util/openable_file_type.rs::resolve_file_target_to_open_in_warp`
+  guarantees that local-control `file.open` selects either Warp's code editor
+  or its Markdown viewer, even if the user's general editor setting points to
+  an external application.
+- `app/src/workspace/view.rs::open_file_notebook` focuses an existing Markdown
+  pane for the same path or creates a new `FilePane`.
+- `app/src/workspace/view.rs::open_code` and
+  `app/src/code/view.rs::CodeView::open_or_focus_existing` focus an existing
+  code-editor tab or create a new one.
+- A logical code-editor file is a `TabData` inside `CodeView`, not necessarily
+  the containing pane. A logical Markdown file view is a `FileNotebookView`
+  owned by `FilePane`.
+- `app/src/pane_group/pane/mod.rs::DetachType` distinguishes a real close
+  (`HiddenForClose` or `Closed`) from `Moved`. The undo-close path hides a pane
+  before destroying it.
+- Code-tab movement is not uniform. Reordering and most merges carry `TabData`,
+  while `CodeView::remove_tab_for_move` currently reconstructs a new
+  `CodePane` from its path. Waiting therefore cannot rely only on a view handle,
+  pane ID, tab index, or path.
+- `crates/warp_util/src/sync.rs::Condition` is a cloneable, set-once async
+  condition. It records completion before notifying, supports multiple and late
+  waiters, and does not require a per-waiter registry.
+
+## Proposed changes
+
+### 1. Extend the existing CLI and wire parameter
+
+In `crates/warp_cli/src/local_control/mod.rs`:
+
+- Add a Clap `--wait` boolean to `FileOpenArgs`.
+
+In `crates/local_control/src/protocol.rs`:
+
+- Add `wait: bool` to `FileOpenParams` with a Serde default.
+- Omit `wait` when false so requests from the default command retain their
+  current serialized shape.
+
+In `crates/warp_cli/src/local_control/commands.rs`:
+
+- Pass the parsed flag through the existing `ActionKind::FileOpen` request.
+- Keep `run_action_with_params`, instance selection, target selection, output
+  formatting, and the success payload unchanged.
+
+Do not add an `ActionKind`, parameter-spec variant, result-spec variant,
+endpoint, or protocol version. A new CLI using `--wait` against an older strict
+server will receive `InvalidParams` rather than silently behaving as
+nonblocking. Normal packaged usage invokes the channel-matched Warp binary, and
+an old CLI request without the field remains accepted by the new server.
+
+Update `resources/bundled/skills/warpctrl/SKILL.md` with a `file open --wait`
+example and the rule that Ctrl+C cancels the caller without closing the view.
+
+### 2. Add one private logical file-view lifecycle
+
+Create `app/src/file_view_lifecycle.rs` as the single owner of the private wait
+contract. It defines:
+
+- `FileViewLifecycle`, a cloneable wrapper around
+  `warp_util::sync::Condition`.
+- `FileViewLifecycle::close()`, an idempotent transition to closed.
+- `FileViewLifecycle::wait_until_closed()`, which completes immediately for a
+  late waiter or asynchronously for an open view.
+- `FileOpenReceipt`, which carries the lifecycle selected by an open/focus
+  operation back to local control.
+
+The lifecycle has no UUID, path lookup, serialization, save status, or public
+protocol representation. Exact identity comes from returning a clone of the
+lifecycle owned by the selected logical UI object.
+
+Do not complete the lifecycle from `Drop`. Normal UI removal paths complete it
+explicitly. This prevents app teardown from being misreported as a successful
+user close; teardown instead drops the HTTP transport and produces the existing
+nonzero client error.
+
+### 3. Return the exact lifecycle from file open/focus
+
+Change `WorkspaceView::open_file_with_target` to return an optional
+`FileOpenReceipt`:
+
+- `FileTarget::CodeEditor` and `FileTarget::MarkdownViewer` return the receipt
+  for the exact newly-created or focused logical view.
+- Targets without an in-Warp lifecycle return `None`. Existing non-control
+  callers may ignore the result.
+- `app_state::file_open` treats a missing receipt as an internal error because
+  `resolve_file_target_to_open_in_warp` guarantees an in-Warp target for this
+  action.
+
+Make the same return value available from the internal helpers:
+
+- `open_file_notebook` returns the existing `FileNotebookView` lifecycle when
+  it focuses a matching pane, or the new pane's lifecycle after creation.
+- `open_code` and `CodeView::open_or_focus_existing` return the selected
+  `TabData` lifecycle. New `TabData` receives a new lifecycle when built.
+
+Selection and lifecycle retrieval happen in the same main-thread update. There
+is no open-then-path-search gap in which an immediate close could be missed or
+an unrelated duplicate could become the target.
+
+### 4. Preserve or complete code-editor tab lifecycles at existing ownership seams
+
+Add a `FileViewLifecycle` field to `app/src/code/view.rs::TabData`.
+
+- Tab reordering and ordinary `TabData` transfer/clone paths preserve the same
+  lifecycle.
+- Replace the close-oriented use of `remove_tab_data_index` in
+  `remove_tab_for_move` with a move-specific extraction path. Reconstructing a
+  `CodePane` for that move must pass the extracted lifecycle into the new
+  `TabData` instead of allocating a replacement lifecycle.
+- Removing a tab after an unchanged close, successful Save, or Discard calls
+  `close()` at the same point the tab actually leaves the view. Cancel does not
+  remove the tab and therefore does not complete the lifecycle.
+- Closing a whole `CodePane` completes every contained tab lifecycle when the
+  pane is detached as `HiddenForClose` or `Closed`. `DetachType::Moved` carries
+  the existing pane and does not complete any lifecycle.
+- When a move/merge discards a source `TabData` because the destination already
+  contains the same path, explicitly complete the discarded source lifecycle.
+  The destination is a different pre-existing logical view, matching Product
+  Behavior #4.
+
+The lifecycle remains attached to the logical file tab rather than
+`CodeManager`, a pane ID, an index, or a path-keyed registry.
+
+### 5. Preserve or complete Markdown viewer lifecycles at pane seams
+
+Add a `FileViewLifecycle` to `FileNotebookView` and expose a clone to
+`WorkspaceView::open_file_notebook` through `FilePane`.
+
+- Focusing an already-open Markdown pane returns that pane's existing
+  lifecycle.
+- Creating a new `FilePane` returns its newly-created lifecycle.
+- `FilePane::detach` completes the lifecycle for `HiddenForClose` and `Closed`
+  and preserves it for `Moved`.
+- Rendered/Raw changes within the same `FileNotebookView` keep the lifecycle.
+  Replacing that viewer with a distinct code-editor view closes the original
+  viewer lifecycle.
+
+Existing file loading, error display, reload, and file-watching behavior is not
+part of the lifecycle contract and remains unchanged.
+
+### 6. Defer only the `--wait` HTTP response off the UI thread
+
+Introduce an app-private bridge dispatch result in
+`app/src/local_control/bridge.rs` with two states:
+
+- `Ready(ResponseEnvelope)` for all existing actions and `file.open` without
+  `wait`.
+- A deferred file-close response containing the request ID, existing
+  acknowledgement data, and selected `FileViewLifecycle` for `file.open` with
+  `wait`.
+
+`LocalControlBridge::handle_request` still performs validation, target
+resolution, and UI mutation synchronously on the WarpUI model thread. It must
+not await the user there. It returns the deferred value to
+`handle_control_request`, whose Axum task awaits `wait_until_closed()` on the
+local-control runtime and then creates the ordinary successful
+`ResponseEnvelope`.
+
+If the CLI is interrupted or disconnects, no close action is dispatched. The
+server may cancel the abandoned handler immediately or finish its pending wait
+when the view eventually closes; either way, it owns only a lifecycle clone and
+does not register mutable per-client state on the view. If Warp or the
+local-control runtime exits first, the connection drops and
+`crates/local_control/src/client.rs` maps the failure to the existing nonzero
+transport error.
+
+## Testing and validation
+
+### Protocol and CLI tests
+
+- `crates/warp_cli/src/local_control_tests.rs`
+  - `file open PATH --wait` parses `wait = true` and still maps to
+    `ActionKind::FileOpen`.
+  - Omitting the flag produces `wait = false`.
+  - `--wait` composes with line, column, new-tab, and target selectors.
+- `crates/local_control/src/protocol_tests.rs`
+  - A missing `wait` field decodes as false.
+  - False is omitted from serialization; true round-trips.
+  - Unknown fields remain rejected and the catalog still contains only the
+    existing `file.open` action.
+
+### Lifecycle and UI ownership tests
+
+- Unit tests for `FileViewLifecycle` verify multiple waiters, a late waiter,
+  idempotent close, and dropping one waiter without closing the lifecycle.
+- `app/src/workspace/view_tests.rs`
+  - Extend `test_open_file_notebook_focuses_existing_markdown_pane` to assert
+    that reopening returns the original lifecycle.
+  - Add equivalent code-editor tests for new and already-open tabs and for an
+    unrelated duplicate path not satisfying the receipt.
+- Add `app/src/code/view_tests.rs` (using the repository's separate test-module
+  convention) to verify unchanged close, Save, Discard, canceled close,
+  reorder, single-tab move, whole-pane move, and same-path merge/deduplication.
+- `app/src/notebooks/file/mod_tests.rs` and
+  `app/src/pane_group/mod_tests.rs` verify `Moved` remains pending while
+  `HiddenForClose` and `Closed` complete, including containing tab/window close.
+
+### Local-control tests
+
+- `app/src/local_control/mod_tests.rs`
+  - A non-waiting request returns the existing acknowledgement immediately.
+  - A waiting request remains pending while the selected lifecycle is open and
+    returns the same acknowledgement after close.
+  - Two requests can wait on one lifecycle.
+  - Dropping a waiting request leaves the lifecycle open.
+  - Stopping the bridge/server before close produces an error, not a successful
+    acknowledgement.
+- `crates/local_control/src/client_tests.rs`
+  - The blocking client accepts a delayed valid response.
+  - Premature server/transport disappearance maps to `TransportUnavailable`.
+
+### Manual validation
+
+1. Start a development Warp build with Warp Control enabled.
+2. Run `warpctrl file open <existing-temp-file> --wait`; confirm the CLI stays
+   pending, edits can be saved, and it exits successfully only after the exact
+   view closes.
+3. Repeat for a Markdown viewer pane and a code-editor tab, with default split
+   layout and `--new-tab`.
+4. Reorder and move the target; confirm the CLI remains pending. Close an
+   unrelated duplicate path and confirm it remains pending.
+5. Exercise Save, Discard, and Cancel in the unsaved-changes dialog.
+6. Start two waiters for the same existing view and confirm both exit on close.
+7. Press Ctrl+C while waiting and confirm the view remains open and editable.
+8. Quit Warp while waiting and confirm the CLI exits nonzero.
+
+Before pushing an implementation update, run the focused tests above followed
+by the repository-required `./script/format` and `cargo clippy` commands.
+
+## Risks and mitigations
+
+- **False completion during a move.** Some code-tab moves rebuild a pane from a
+  path. A move-specific extraction path must carry the lifecycle and must not
+  call the close-oriented removal helper.
+- **Waiting on the wrong duplicate.** Paths, pane IDs, and tab indices are not
+  sufficient identities. Returning the lifecycle directly from the atomic
+  open/focus operation avoids a later lookup.
+- **Lost close notification.** `Condition` records its set state and checks it
+  before and after listener registration, so a close that races with the Axum
+  task beginning its wait cannot hang.
+- **Blocking the UI thread.** Only the Axum request task awaits the lifecycle;
+  the WarpUI bridge returns the deferred result immediately after dispatch.
+- **App exit reported as a normal close.** The lifecycle is completed only by
+  explicit view-removal paths, not `Drop`; server shutdown therefore ends the
+  transport instead of synthesizing success.
+- **Protocol compatibility.** False is omitted and remains compatible with the
+  previous request shape. An older strict server rejects a true `wait` field
+  explicitly rather than silently ignoring it.
+
+## Follow-ups
+
+None required. Public file-view handles, a separate wait action, explicit mode
+or layout flags, and broader Warp automation should be proposed independently
+if concrete use cases require them.

--- a/specs/GH8741/tech.md
+++ b/specs/GH8741/tech.md
@@ -5,281 +5,131 @@ Product spec: `specs/GH8741/product.md`
 
 ## Context
 
-Warp Control already exposes one typed file action:
-
-- `crates/warp_cli/src/local_control/mod.rs` defines
-  `FileCommand::Open(FileOpenArgs)`. `FileOpenArgs` contains the path, optional
-  line and column, `new_tab`, and the standard target selectors.
-- `crates/warp_cli/src/local_control/commands.rs::run_file_command` maps that
-  command to the existing `ActionKind::FileOpen` request.
-- `crates/local_control/src/protocol.rs::FileOpenParams` is the strict wire
-  parameter type. `crates/local_control/src/catalog.rs` declares `file.open`
-  with an acknowledgement result.
-- `crates/local_control/src/client.rs::send_request` performs one blocking HTTP
-  request and reads one response. It has no client-side request timeout, so the
-  existing transport can carry a long-lived wait without polling or streaming.
-- `app/src/local_control/mod.rs::handle_control_request` authenticates the
-  request, dispatches it to the main-thread `LocalControlBridge`, awaits the
-  bridge result, and serializes one response.
-- `app/src/local_control/bridge.rs::LocalControlBridge::handle_request` is
-  synchronous on the WarpUI model thread and currently returns a
-  `ResponseEnvelope` immediately.
-- `app/src/local_control/handlers/app_state.rs::file_open` validates the
-  parameters and target, calls `WorkspaceView::open_file_with_target`, and
-  immediately returns the acknowledgement.
-
-The selected in-Warp file surface depends on existing settings and state:
-
-- `app/src/util/openable_file_type.rs::resolve_file_target_to_open_in_warp`
-  guarantees that local-control `file.open` selects either Warp's code editor
-  or its Markdown viewer, even if the user's general editor setting points to
-  an external application.
-- `app/src/workspace/view.rs::open_file_notebook` focuses an existing Markdown
-  pane for the same path or creates a new `FilePane`.
-- `app/src/workspace/view.rs::open_code` and
-  `app/src/code/view.rs::CodeView::open_or_focus_existing` focus an existing
-  code-editor tab or create a new one.
-- A logical code-editor file is a `TabData` inside `CodeView`, not necessarily
-  the containing pane. A logical Markdown file view is a `FileNotebookView`
-  owned by `FilePane`.
-- `app/src/pane_group/pane/mod.rs::DetachType` distinguishes a real close
-  (`HiddenForClose` or `Closed`) from `Moved`. The undo-close path hides a pane
-  before destroying it.
-- Code-tab movement is not uniform. Reordering and most merges carry `TabData`,
-  while `CodeView::remove_tab_for_move` currently reconstructs a new
-  `CodePane` from its path. Waiting therefore cannot rely only on a view handle,
-  pane ID, tab index, or path.
-- `crates/warp_util/src/sync.rs::Condition` is a cloneable, set-once async
-  condition. It records completion before notifying, supports multiple and late
-  waiters, and does not require a per-waiter registry.
+- `FileOpenArgs` and `run_file_command` define the CLI and map it to the existing
+  `file.open` action (`crates/warp_cli/src/local_control/mod.rs:720`,
+  `crates/warp_cli/src/local_control/commands.rs:682`). `FileOpenParams` is the
+  strict wire type (`crates/local_control/src/protocol.rs:95`).
+- The client already makes one blocking HTTP request. The server dispatches it
+  through `LocalControlBridge`, which currently returns a response synchronously
+  from the WarpUI model thread (`app/src/local_control/mod.rs:508`,
+  `app/src/local_control/bridge.rs:40`,
+  `app/src/local_control/handlers/app_state.rs:748`).
+- `open_file_notebook` and `open_code` create or focus the selected Markdown pane
+  or code tab (`app/src/workspace/view.rs:8415`,
+  `app/src/workspace/view.rs:8507`). A code file's logical owner is `TabData`,
+  while a Markdown view is owned by `FileNotebookView`.
+- View identity cannot be inferred from a path, pane ID, tab index, or view
+  handle. Code-tab moves may rebuild a pane from its path
+  (`app/src/code/view.rs:1194`), while `DetachType` distinguishes moves from
+  closes (`app/src/pane_group/pane/mod.rs:541`).
+- `warp_util::sync::Condition` is cloneable, set-once, and safe for multiple or
+  late waiters (`crates/warp_util/src/sync.rs:30`).
 
 ## Proposed changes
 
 ### 1. Extend the existing CLI and wire parameter
 
-In `crates/warp_cli/src/local_control/mod.rs`:
-
 - Add a Clap `--wait` boolean to `FileOpenArgs`.
+- Add `wait: bool` with a Serde default to `FileOpenParams`; omit it when false.
+- Pass it through the existing `ActionKind::FileOpen` request.
+- Document `file open --wait` and Ctrl+C behavior in
+  `resources/bundled/skills/warpctrl/SKILL.md`.
 
-In `crates/local_control/src/protocol.rs`:
+Do not add an action, endpoint, result type, or protocol version. Default
+requests retain their wire shape. An older strict server rejects `wait: true`
+with `InvalidParams` instead of silently ignoring it.
 
-- Add `wait: bool` to `FileOpenParams` with a Serde default.
-- Omit `wait` when false so requests from the default command retain their
-  current serialized shape.
+### 2. Represent one private logical lifetime
 
-In `crates/warp_cli/src/local_control/commands.rs`:
+Add `app/src/file_view_lifecycle.rs` with:
 
-- Pass the parsed flag through the existing `ActionKind::FileOpen` request.
-- Keep `run_action_with_params`, instance selection, target selection, output
-  formatting, and the success payload unchanged.
+- `FileViewLifecycle`, a cloneable wrapper around `Condition`;
+- idempotent `close()` and late-waiter-safe `wait_until_closed()` methods; and
+- `FileOpenReceipt`, which returns the selected lifecycle to local control.
 
-Do not add an `ActionKind`, parameter-spec variant, result-spec variant,
-endpoint, or protocol version. A new CLI using `--wait` against an older strict
-server will receive `InvalidParams` rather than silently behaving as
-nonblocking. Normal packaged usage invokes the channel-matched Warp binary, and
-an old CLI request without the field remains accepted by the new server.
+The lifecycle has no UUID, path registry, serialization, or save status. UI
+removal paths close it explicitly; `Drop` does not. App teardown therefore ends
+the transport instead of impersonating a user close.
 
-Update `resources/bundled/skills/warpctrl/SKILL.md` with a `file open --wait`
-example and the rule that Ctrl+C cancels the caller without closing the view.
+### 3. Return the lifecycle selected by open/focus
 
-### 2. Add one private logical file-view lifecycle
+Change `WorkspaceView::open_file_with_target` and its code/Markdown helpers to
+return the lifecycle of the exact view they create or focus:
 
-Create `app/src/file_view_lifecycle.rs` as the single owner of the private wait
-contract. It defines:
-
-- `FileViewLifecycle`, a cloneable wrapper around
-  `warp_util::sync::Condition`.
-- `FileViewLifecycle::close()`, an idempotent transition to closed.
-- `FileViewLifecycle::wait_until_closed()`, which completes immediately for a
-  late waiter or asynchronously for an open view.
-- `FileOpenReceipt`, which carries the lifecycle selected by an open/focus
-  operation back to local control.
-
-The lifecycle has no UUID, path lookup, serialization, save status, or public
-protocol representation. Exact identity comes from returning a clone of the
-lifecycle owned by the selected logical UI object.
-
-Do not complete the lifecycle from `Drop`. Normal UI removal paths complete it
-explicitly. This prevents app teardown from being misreported as a successful
-user close; teardown instead drops the HTTP transport and produces the existing
-nonzero client error.
-
-### 3. Return the exact lifecycle from file open/focus
-
-Change `WorkspaceView::open_file_with_target` to return an optional
-`FileOpenReceipt`:
-
-- `FileTarget::CodeEditor` and `FileTarget::MarkdownViewer` return the receipt
-  for the exact newly-created or focused logical view.
-- Targets without an in-Warp lifecycle return `None`. Existing non-control
-  callers may ignore the result.
-- `app_state::file_open` treats a missing receipt as an internal error because
-  `resolve_file_target_to_open_in_warp` guarantees an in-Warp target for this
-  action.
-
-Make the same return value available from the internal helpers:
-
-- `open_file_notebook` returns the existing `FileNotebookView` lifecycle when
-  it focuses a matching pane, or the new pane's lifecycle after creation.
+- `open_file_notebook` returns the matching existing pane's lifecycle or the
+  newly created pane's lifecycle.
 - `open_code` and `CodeView::open_or_focus_existing` return the selected
-  `TabData` lifecycle. New `TabData` receives a new lifecycle when built.
+  `TabData` lifecycle; new tabs receive a new lifecycle.
+- Existing non-control callers may ignore the receipt. A missing receipt is an
+  internal error for `file.open`, whose target resolver guarantees an in-Warp
+  code or Markdown view.
 
-Selection and lifecycle retrieval happen in the same main-thread update. There
-is no open-then-path-search gap in which an immediate close could be missed or
-an unrelated duplicate could become the target.
+Selection and receipt retrieval occur in the same model-thread update, avoiding
+an open-then-search race and path ambiguity.
 
-### 4. Preserve or complete code-editor tab lifecycles at existing ownership seams
+### 4. Carry code-tab lifecycles through ownership changes
 
-Add a `FileViewLifecycle` field to `app/src/code/view.rs::TabData`.
+Add a `FileViewLifecycle` to `TabData`.
 
-- Tab reordering and ordinary `TabData` transfer/clone paths preserve the same
-  lifecycle.
-- Replace the close-oriented use of `remove_tab_data_index` in
-  `remove_tab_for_move` with a move-specific extraction path. Reconstructing a
-  `CodePane` for that move must pass the extracted lifecycle into the new
-  `TabData` instead of allocating a replacement lifecycle.
-- Removing a tab after an unchanged close, successful Save, or Discard calls
-  `close()` at the same point the tab actually leaves the view. Cancel does not
-  remove the tab and therefore does not complete the lifecycle.
-- Closing a whole `CodePane` completes every contained tab lifecycle when the
-  pane is detached as `HiddenForClose` or `Closed`. `DetachType::Moved` carries
-  the existing pane and does not complete any lifecycle.
-- When a move/merge discards a source `TabData` because the destination already
-  contains the same path, explicitly complete the discarded source lifecycle.
-  The destination is a different pre-existing logical view, matching Product
-  Behavior #4.
+- Reorders and transfers preserve it.
+- `remove_tab_for_move` extracts and passes it into the rebuilt pane instead of
+  using the close-oriented removal path.
+- Actual removal after unchanged close, Save, or Discard calls `close()`; Cancel
+  does not.
+- Detaching a containing `CodePane` as `HiddenForClose` or `Closed` closes all
+  tab lifecycles; `Moved` preserves them.
+- If merge deduplication removes the source tab in favor of an existing
+  same-path destination, close the source lifecycle.
 
-The lifecycle remains attached to the logical file tab rather than
-`CodeManager`, a pane ID, an index, or a path-keyed registry.
+### 5. Apply the same contract to Markdown panes
 
-### 5. Preserve or complete Markdown viewer lifecycles at pane seams
+Add a `FileViewLifecycle` to `FileNotebookView` and expose it through
+`FilePane`.
 
-Add a `FileViewLifecycle` to `FileNotebookView` and expose a clone to
-`WorkspaceView::open_file_notebook` through `FilePane`.
+- Reopening returns the existing lifecycle; creation returns a new one.
+- `FilePane::detach` closes it for `HiddenForClose` and `Closed`, but not
+  `Moved`.
+- Rendered/raw mode changes preserve it. Replacing the viewer with a distinct
+  code-editor view closes it.
 
-- Focusing an already-open Markdown pane returns that pane's existing
-  lifecycle.
-- Creating a new `FilePane` returns its newly-created lifecycle.
-- `FilePane::detach` completes the lifecycle for `HiddenForClose` and `Closed`
-  and preserves it for `Moved`.
-- Rendered/Raw changes within the same `FileNotebookView` keep the lifecycle.
-  Replacing that viewer with a distinct code-editor view closes the original
-  viewer lifecycle.
+Loading, reload, error display, and file watching remain unchanged.
 
-Existing file loading, error display, reload, and file-watching behavior is not
-part of the lifecycle contract and remains unchanged.
+### 6. Defer only waiting responses
 
-### 6. Defer only the `--wait` HTTP response off the UI thread
+Let `LocalControlBridge::handle_request` return either:
 
-Introduce an app-private bridge dispatch result in
-`app/src/local_control/bridge.rs` with two states:
+- `Ready(ResponseEnvelope)` for existing actions and non-waiting opens; or
+- a private deferred result containing the request ID, acknowledgement data,
+  and selected lifecycle.
 
-- `Ready(ResponseEnvelope)` for all existing actions and `file.open` without
-  `wait`.
-- A deferred file-close response containing the request ID, existing
-  acknowledgement data, and selected `FileViewLifecycle` for `file.open` with
-  `wait`.
-
-`LocalControlBridge::handle_request` still performs validation, target
-resolution, and UI mutation synchronously on the WarpUI model thread. It must
-not await the user there. It returns the deferred value to
-`handle_control_request`, whose Axum task awaits `wait_until_closed()` on the
-local-control runtime and then creates the ordinary successful
-`ResponseEnvelope`.
-
-If the CLI is interrupted or disconnects, no close action is dispatched. The
-server may cancel the abandoned handler immediately or finish its pending wait
-when the view eventually closes; either way, it owns only a lifecycle clone and
-does not register mutable per-client state on the view. If Warp or the
-local-control runtime exits first, the connection drops and
-`crates/local_control/src/client.rs` maps the failure to the existing nonzero
-transport error.
+The bridge still validates and mutates UI state synchronously. The Axum request
+task awaits the lifecycle off the UI thread, then emits the ordinary
+acknowledgement. Disconnecting never dispatches a close or stores mutable
+per-client state on the view. Server or app shutdown drops the connection and
+uses the existing nonzero transport error.
 
 ## Testing and validation
 
-### Protocol and CLI tests
+| Area | Coverage |
+| --- | --- |
+| CLI and protocol | Parse default/true values; compose with existing arguments and selectors; omit false from serialization; round-trip true; keep only `file.open`. Covers invariants 1, 2, 10, and 11. |
+| Lifecycle unit tests | Multiple and late waiters, idempotent close, and canceling one waiter. Covers invariants 5 and 7. |
+| Code and Markdown ownership | New/reused views, duplicate paths, reorder, move, merge, containing-view close, Save, Discard, and Cancel. Covers invariants 2–7 and 11. |
+| Local control and client | Immediate default response, delayed response, two waiters, dropped caller, and server/transport loss. Covers invariants 1 and 7–10. |
 
-- `crates/warp_cli/src/local_control_tests.rs`
-  - `file open PATH --wait` parses `wait = true` and still maps to
-    `ActionKind::FileOpen`.
-  - Omitting the flag produces `wait = false`.
-  - `--wait` composes with line, column, new-tab, and target selectors.
-- `crates/local_control/src/protocol_tests.rs`
-  - A missing `wait` field decodes as false.
-  - False is omitted from serialization; true round-trips.
-  - Unknown fields remain rejected and the catalog still contains only the
-    existing `file.open` action.
-
-### Lifecycle and UI ownership tests
-
-- Unit tests for `FileViewLifecycle` verify multiple waiters, a late waiter,
-  idempotent close, and dropping one waiter without closing the lifecycle.
-- `app/src/workspace/view_tests.rs`
-  - Extend `test_open_file_notebook_focuses_existing_markdown_pane` to assert
-    that reopening returns the original lifecycle.
-  - Add equivalent code-editor tests for new and already-open tabs and for an
-    unrelated duplicate path not satisfying the receipt.
-- Add `app/src/code/view_tests.rs` (using the repository's separate test-module
-  convention) to verify unchanged close, Save, Discard, canceled close,
-  reorder, single-tab move, whole-pane move, and same-path merge/deduplication.
-- `app/src/notebooks/file/mod_tests.rs` and
-  `app/src/pane_group/mod_tests.rs` verify `Moved` remains pending while
-  `HiddenForClose` and `Closed` complete, including containing tab/window close.
-
-### Local-control tests
-
-- `app/src/local_control/mod_tests.rs`
-  - A non-waiting request returns the existing acknowledgement immediately.
-  - A waiting request remains pending while the selected lifecycle is open and
-    returns the same acknowledgement after close.
-  - Two requests can wait on one lifecycle.
-  - Dropping a waiting request leaves the lifecycle open.
-  - Stopping the bridge/server before close produces an error, not a successful
-    acknowledgement.
-- `crates/local_control/src/client_tests.rs`
-  - The blocking client accepts a delayed valid response.
-  - Premature server/transport disappearance maps to `TransportUnavailable`.
-
-### Manual validation
-
-1. Start a development Warp build with Warp Control enabled.
-2. Run `warpctrl file open <existing-temp-file> --wait`; confirm the CLI stays
-   pending, edits can be saved, and it exits successfully only after the exact
-   view closes.
-3. Repeat for a Markdown viewer pane and a code-editor tab, with default split
-   layout and `--new-tab`.
-4. Reorder and move the target; confirm the CLI remains pending. Close an
-   unrelated duplicate path and confirm it remains pending.
-5. Exercise Save, Discard, and Cancel in the unsaved-changes dialog.
-6. Start two waiters for the same existing view and confirm both exit on close.
-7. Press Ctrl+C while waiting and confirm the view remains open and editable.
-8. Quit Warp while waiting and confirm the CLI exits nonzero.
-
-Before pushing an implementation update, run the focused tests above followed
-by the repository-required `./script/format` and `cargo clippy` commands.
+Manual validation must exercise code and Markdown views, existing and duplicate
+paths, moves, Save/Discard/Cancel, two waiters, Ctrl+C, and Warp shutdown. Before
+pushing implementation, run the focused tests, `./script/format`, and the
+repository-required Clippy command.
 
 ## Risks and mitigations
 
-- **False completion during a move.** Some code-tab moves rebuild a pane from a
-  path. A move-specific extraction path must carry the lifecycle and must not
-  call the close-oriented removal helper.
-- **Waiting on the wrong duplicate.** Paths, pane IDs, and tab indices are not
-  sufficient identities. Returning the lifecycle directly from the atomic
-  open/focus operation avoids a later lookup.
-- **Lost close notification.** `Condition` records its set state and checks it
-  before and after listener registration, so a close that races with the Axum
-  task beginning its wait cannot hang.
-- **Blocking the UI thread.** Only the Axum request task awaits the lifecycle;
-  the WarpUI bridge returns the deferred result immediately after dispatch.
-- **App exit reported as a normal close.** The lifecycle is completed only by
-  explicit view-removal paths, not `Drop`; server shutdown therefore ends the
-  transport instead of synthesizing success.
-- **Protocol compatibility.** False is omitted and remains compatible with the
-  previous request shape. An older strict server rejects a true `wait` field
-  explicitly rather than silently ignoring it.
-
-## Follow-ups
-
-None required. Public file-view handles, a separate wait action, explicit mode
-or layout flags, and broader Warp automation should be proposed independently
-if concrete use cases require them.
+- **False completion during moves:** carry the lifecycle through move-specific
+  extraction; never use close-oriented removal.
+- **Wrong duplicate:** return the lifecycle from the atomic open/focus operation
+  instead of looking it up later.
+- **Lost notification:** use `Condition` so close state survives races and late
+  registration.
+- **Blocked UI:** await only in the Axum request task.
+- **App exit reported as close:** complete only from explicit UI removal, never
+  `Drop`.

--- a/specs/GH8741/tech.md
+++ b/specs/GH8741/tech.md
@@ -9,21 +9,40 @@ Product spec: `specs/GH8741/product.md`
   `file.open` action (`crates/warp_cli/src/local_control/mod.rs:720`,
   `crates/warp_cli/src/local_control/commands.rs:682`). `FileOpenParams` is the
   strict wire type (`crates/local_control/src/protocol.rs:95`).
-- The client already makes one blocking HTTP request. The server dispatches it
-  through `LocalControlBridge`, which currently returns a response synchronously
-  from the WarpUI model thread (`app/src/local_control/mod.rs:508`,
-  `app/src/local_control/bridge.rs:40`,
+- The client makes one blocking HTTP request with
+  `reqwest::blocking::Client::new()` (`crates/local_control/src/client.rs:54`).
+  The blocking wrapper applies a 30-second default timeout per operation even
+  though the async client defaults to none. The server is bare Axum with no
+  timeout layers (`app/src/local_control/mod.rs:252`) and holds a request open
+  indefinitely. It dispatches through `LocalControlBridge`, which currently
+  returns a response synchronously from the WarpUI model thread
+  (`app/src/local_control/mod.rs:508`, `app/src/local_control/bridge.rs:40`,
   `app/src/local_control/handlers/app_state.rs:748`).
-- `open_file_notebook` and `open_code` create or focus the selected Markdown pane
-  or code tab (`app/src/workspace/view.rs:8415`,
-  `app/src/workspace/view.rs:8507`). A code file's logical owner is `TabData`,
-  while a Markdown view is owned by `FileNotebookView`.
-- View identity cannot be inferred from a path, pane ID, tab index, or view
-  handle. Code-tab moves may rebuild a pane from its path
-  (`app/src/code/view.rs:1194`), while `DetachType` distinguishes moves from
-  closes (`app/src/pane_group/pane/mod.rs:541`).
+- `open_file_notebook` and `open_code` create or focus the selected Markdown
+  pane or code-editor tab (`app/src/workspace/view.rs:8415`,
+  `app/src/workspace/view.rs:8507`).
+- Two types are named `TabData`: the workspace tab (`app/src/tab.rs:170`), which
+  holds a `PaneGroup`, and the code-editor tab (`app/src/code/view.rs:207`),
+  which represents one file inside a `CodeView`. This spec always means the
+  editor tab. `CodeView` holds `tab_group: Vec<TabData>`
+  (`app/src/code/view.rs:237`), so one code pane can own several open files.
+- `PaneView<P: BackingView>` is the generic backing-view wrapper
+  (`app/src/pane_group/pane/view/mod.rs:84`), and `Pane::detach` receives a
+  `DetachType` that distinguishes moves from closes
+  (`app/src/pane_group/pane/mod.rs:541`). `PaneGroup` stores panes as
+  `Box<dyn AnyPaneContent>` (`app/src/pane_group/mod.rs:893`), so generic
+  lifecycle access needs an accessor on the `PaneContent` trait.
+- Editor-tab moves rebuild the destination from `CodeSource::Link` rather than
+  carrying the tab (`CodeView::remove_tab_for_move`,
+  `app/src/code/view.rs:1194`). Drag-merges deduplicate same-path tabs in
+  `CodeView::merge_tabs` (`app/src/code/view.rs:2089`), reached from the
+  `DroppedOnTabBar` path (`app/src/workspace/view.rs:16457`).
 - `warp_util::sync::Condition` is cloneable, set-once, and safe for multiple or
   late waiters (`crates/warp_util/src/sync.rs:30`).
+- `warpctrl` is the app binary re-invoked via `--warpctrl`
+  (`app/src/lib.rs:701`). The bundled macOS wrapper `exec`s the binary
+  (`script/macos/create_warpctrl_wrapper`), so terminal signals reach the CLI
+  process directly.
 
 ## Proposed changes
 
@@ -41,10 +60,14 @@ with `InvalidParams` instead of silently ignoring it.
 
 ### 2. Represent one private logical lifetime
 
-Add `app/src/file_view_lifecycle.rs` with:
+Add `app/src/pane_group/lifecycle.rs` with:
 
-- `FileViewLifecycle`, a cloneable wrapper around `Condition`;
-- idempotent `close()` and late-waiter-safe `wait_until_closed()` methods; and
+- `ViewLifecycle`, a cloneable handle built on `Condition` with an idempotent
+  `close()` and a late-waiter-safe `wait_until_closed()`;
+- `redirect(target)`, which re-points the lifecycle's current and future
+  waiters at `target` so a merged-away view's waiters follow the surviving
+  view. Waiting follows redirect chains; `close()` on a redirected lifecycle is
+  a no-op; and
 - `FileOpenReceipt`, which returns the selected lifecycle to local control.
 
 The lifecycle has no UUID, path registry, serialization, or save status. UI
@@ -56,10 +79,10 @@ the transport instead of impersonating a user close.
 Change `WorkspaceView::open_file_with_target` and its code/Markdown helpers to
 return the lifecycle of the exact view they create or focus:
 
-- `open_file_notebook` returns the matching existing pane's lifecycle or the
-  newly created pane's lifecycle.
+- `open_file_notebook` returns the `PaneView` lifecycle of the matching
+  existing `FilePane` or of the newly created one.
 - `open_code` and `CodeView::open_or_focus_existing` return the selected
-  `TabData` lifecycle; new tabs receive a new lifecycle.
+  editor-tab lifecycle; new editor tabs receive a new lifecycle.
 - Existing non-control callers may ignore the receipt. A missing receipt is an
   internal error for `file.open`, whose target resolver guarantees an in-Warp
   code or Markdown view.
@@ -67,34 +90,36 @@ return the lifecycle of the exact view they create or focus:
 Selection and receipt retrieval occur in the same model-thread update, avoiding
 an open-then-search race and path ambiguity.
 
-### 4. Carry code-tab lifecycles through ownership changes
+### 4. Two-level ownership: every pane, then editor tabs
 
-Add a `FileViewLifecycle` to `TabData`.
+**Level 1 — `PaneView`.** Add a `ViewLifecycle` to `PaneView`, exposed through
+an accessor on the `PaneContent` trait so `PaneGroup`'s type-erased storage can
+reach it. `detach` closes it for `DetachType::HiddenForClose` and
+`DetachType::Closed` and preserves it for `DetachType::Moved`. This covers
+every `BackingView` implementation. For Markdown it is the whole story: a
+`FilePane` is one pane showing one file. Reopening returns the existing
+lifecycle; rendered/raw mode changes preserve it; replacing the viewer with a
+distinct code-editor view closes it. Loading, reload, error display, and file
+watching remain unchanged.
 
-- Reorders and transfers preserve it.
-- `remove_tab_for_move` extracts and passes it into the rebuilt pane instead of
-  using the close-oriented removal path.
-- Actual removal after unchanged close, Save, or Discard calls `close()`; Cancel
-  does not.
-- Detaching a containing `CodePane` as `HiddenForClose` or `Closed` closes all
-  tab lifecycles; `Moved` preserves them.
-- If merge deduplication removes the source tab in favor of an existing
-  same-path destination, close the source lifecycle.
+**Level 2 — editor tabs.** Add a `ViewLifecycle` to the editor `TabData`,
+because a `CodeView` multiplexes several files in one pane and a pane-scoped
+wait would outlive an individual file's tab.
 
-### 5. Apply the same contract to Markdown panes
+- Reorders and transfers preserve it. `remove_tab_for_move` extracts the
+  lifecycle and passes it into the pane rebuilt from `CodeSource::Link` instead
+  of using the close-oriented removal path.
+- Actual removal after unchanged close, Save, or Discard calls `close()`;
+  Cancel does not.
+- When the owning pane's lifecycle closes, all of its editor-tab lifecycles
+  close with it.
+- If merge deduplication removes the source editor tab in favor of an existing
+  same-path destination tab (`merge_tabs` and the `DroppedOnTabBar` path),
+  redirect the source lifecycle to the destination's: the file is still on
+  screen, so the wait continues until the surviving tab closes (product
+  invariant 4).
 
-Add a `FileViewLifecycle` to `FileNotebookView` and expose it through
-`FilePane`.
-
-- Reopening returns the existing lifecycle; creation returns a new one.
-- `FilePane::detach` closes it for `HiddenForClose` and `Closed`, but not
-  `Moved`.
-- Rendered/raw mode changes preserve it. Replacing the viewer with a distinct
-  code-editor view closes it.
-
-Loading, reload, error display, and file watching remain unchanged.
-
-### 6. Defer only waiting responses
+### 5. Defer only waiting responses
 
 Let `LocalControlBridge::handle_request` return either:
 
@@ -108,28 +133,53 @@ acknowledgement. Disconnecting never dispatches a close or stores mutable
 per-client state on the view. Server or app shutdown drops the connection and
 uses the existing nonzero transport error.
 
+**Client timeout.** The blocking reqwest client's 30-second default would fail
+every wait at 30 seconds with a transport error, so the client builds waiting
+requests with `.timeout(None)`. One-shot actions keep the default, where the
+deadline is a feature. The server needs no change; it already holds a request
+open indefinitely.
+
+**Held connection.** `--wait` becomes the first local control action to hold
+its connection open; every current `ActionKind` is one-shot. Keep the single
+held request rather than adding a long-poll or SSE endpoint, and validate
+idle-connection behavior — notably across macOS sleep/wake — before calling
+the implementation done.
+
+**Ctrl+C.** Because the bundled wrapper `exec`s the CLI binary, the default
+SIGINT disposition kills the waiting process and drops the connection, which
+the server observes as a disconnect with no view change. Product invariant 8
+holds without a signal handler.
+
 ## Testing and validation
 
 | Area | Coverage |
 | --- | --- |
 | CLI and protocol | Parse default/true values; compose with existing arguments and selectors; omit false from serialization; round-trip true; keep only `file.open`. Covers invariants 1, 2, 10, and 11. |
-| Lifecycle unit tests | Multiple and late waiters, idempotent close, and canceling one waiter. Covers invariants 5 and 7. |
-| Code and Markdown ownership | New/reused views, duplicate paths, reorder, move, merge, containing-view close, Save, Discard, and Cancel. Covers invariants 2–7 and 11. |
-| Local control and client | Immediate default response, delayed response, two waiters, dropped caller, and server/transport loss. Covers invariants 1 and 7–10. |
+| Lifecycle unit tests | Multiple and late waiters, idempotent close, canceling one waiter, and redirects: waiters complete when the final target closes, and `close()` on a redirected source is a no-op. Covers invariants 4, 5, and 7. |
+| Code and Markdown ownership | New/reused views, duplicate paths, reorder, move, merge redirect to the surviving tab, containing-view close, Save, Discard, and Cancel. Covers invariants 2–7 and 11. |
+| Local control and client | Immediate default response, delayed response, no client timeout on waiting requests, two waiters, dropped caller, and server/transport loss. Covers invariants 1 and 7–10. |
 
 Manual validation must exercise code and Markdown views, existing and duplicate
-paths, moves, Save/Discard/Cancel, two waiters, Ctrl+C, and Warp shutdown. Before
-pushing implementation, run the focused tests, `./script/format`, and the
-repository-required Clippy command.
+paths, moves, merge deduplication, Save/Discard/Cancel, two waiters, Ctrl+C
+through the bundled wrapper, Warp shutdown, and a held wait that stays idle
+across macOS sleep/wake. Before pushing implementation, run the focused tests,
+`./script/format`, and the repository-required Clippy command.
 
 ## Risks and mitigations
 
 - **False completion during moves:** carry the lifecycle through move-specific
   extraction; never use close-oriented removal.
+- **False completion during merges:** redirect source waiters to the surviving
+  tab's lifecycle instead of closing.
 - **Wrong duplicate:** return the lifecycle from the atomic open/focus operation
   instead of looking it up later.
 - **Lost notification:** use `Condition` so close state survives races and late
   registration.
+- **Client deadline:** the blocking client defaults to a 30-second timeout;
+  set `.timeout(None)` on waiting requests only.
+- **Idle held connection:** hours-long loopback requests are untested across
+  macOS sleep/wake; validate before release, with long-poll or SSE as the
+  documented fallback if the held connection proves unreliable.
 - **Blocked UI:** await only in the Axum request task.
 - **App exit reported as close:** complete only from explicit UI removal, never
   `Drop`.


### PR DESCRIPTION
## Description

Adds focused product and technical specs for `warpctrl file open PATH --wait`. The proposal waits for the exact file view opened or focused by the command while keeping the default command nonblocking. It adds no public view handles or separate wait action.

This PR is spec-only. Implementation would follow after maintainer approval.

## Linked Issue

Contributes to #8741

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Screenshots are not applicable to this spec-only PR.

## Testing

- `git diff --check`
- `./script/format --check`
- Runtime testing is not applicable because this PR changes documentation only.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp AI Agent Mode
