### PR TITLE
fix(terminal-input): focus prompt on Ctrl+C despite retained block selection (#13480)

### DIFF
--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -8775,7 +8775,15 @@ impl TerminalView {
         );
 
         // We want to focus the input/rich content block if it is active.
-        self.redetermine_global_focus(ctx);
+        //
+        // A block/text selection retained through Ctrl+C (selections are kept as AI context
+        // when AI input or `AgentView` is enabled) shouldn't pin focus to the blocklist:
+        // Ctrl+C signals the user wants their prompt back (#13480). The exception is when
+        // the user is actively making a selection at this very moment.
+        self.redetermine_global_focus_with_policy(
+            SelectionFocusPolicy::HoldsFocusOnlyWhileSelecting,
+            ctx,
+        );
         ctx.notify();
     }
 

--- a/app/src/terminal/view_tests.rs
+++ b/app/src/terminal/view_tests.rs
@@ -5377,6 +5377,35 @@ fn inline_agent_view_exits_when_tagged_in_long_running_command_is_tagged_out() {
 }
 
 #[test]
+fn ctrl_c_with_retained_block_selection_focuses_input() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        FeatureFlag::AgentView.set_enabled(true);
+
+        let terminal = add_window_with_terminal(&mut app, None);
+        terminal.update(&mut app, |view, ctx| {
+            view.model.lock().simulate_block("echo hi", "hi");
+            view.selected_blocks.reset_to_single(BlockIndex::zero());
+            view.handle_action(&TerminalAction::CtrlC, ctx);
+        });
+
+        terminal.update(&mut app, |view, ctx| {
+            // The selection is retained as AI context under `AgentView`…
+            assert!(
+                !view.selected_blocks.is_empty(),
+                "block selection should be retained as AI context"
+            );
+            // …but it must not pin focus to the blocklist: Ctrl+C means the user
+            // wants their prompt back (#13480).
+            assert!(
+                view.input.as_ref(ctx).editor().as_ref(ctx).is_focused(),
+                "ctrl+c should focus the input box despite the retained selection"
+            );
+        });
+    })
+}
+
+#[test]
 fn ctrl_c_after_stop_takeover_cancels_conversation() {
     App::test((), |mut app| async move {
         initialize_app_for_terminal_view(&mut app);


### PR DESCRIPTION
Resolves #13480.

## Problem

With a block (or text) selected, Ctrl+C does not return focus to the prompt — focus stays on the terminal/blocklist, so the user has to click into the input box to type their next command.

## Root cause

When `FeatureFlag::AgentView` is enabled, `ctrl_c_internal` intentionally retains block/text selections through Ctrl+C (`clear_selections_when_shell_mode_without_focusing_input` keeps them because selections double as AI context). The subsequent `redetermine_global_focus` call uses the default `SelectionFocusPolicy::HoldsFocus`, under which any shell-mode selection keeps the terminal focused — so the retained selection pins focus to the blocklist and the input box never gets it.

## Fix

Run the post-Ctrl+C focus pass with `SelectionFocusPolicy::HoldsFocusOnlyWhileSelecting` instead. This is the exact policy (and rationale) already used when a command finishes: a selection made *earlier* shouldn't prevent focus from returning to the input box once the user signals they want their prompt, while a selection the user is actively making (mid-drag / mid block click) still holds focus. One-line change at the `ctrl_c` call site; no behavior change when selections were already cleared (flag off), since no selection remains to pin focus.

## Tests

Adds `ctrl_c_with_retained_block_selection_focuses_input`: with AgentView enabled and a completed block selected, Ctrl+C must (a) retain the selection as AI context and (b) focus the input editor. Verified the test **fails without the fix** and passes with it. All 11 `ctrl_c` tests pass; the broader `terminal::view::tests` suite shows no new failures (5 pre-existing failures reproduce identically on clean master).

## Validation

Deterministic unit regression test above covers the focus assertion end-to-end through `handle_action(TerminalAction::CtrlC)`. Happy to add a screen recording of the interactive flow if helpful.
