### PR TITLE
Hide shared-session copy link until a link exists

### DIFF
--- a/app/src/drive/sharing/dialog/mod.rs
+++ b/app/src/drive/sharing/dialog/mod.rs
@@ -402,13 +402,24 @@ impl SharingDialog {
             .is_some_and(|target| matches!(target, ShareableObject::Session { .. }))
     }
 
+    pub(crate) fn has_shared_session_link(&self, app: &AppContext) -> bool {
+        self.has_shared_session_target() && self.target_link(app).is_some()
+    }
+
     pub fn show_qr_code(&mut self, ctx: &mut ViewContext<Self>) {
-        if matches!(self.target, Some(ShareableObject::Session { .. })) {
+        if self.has_shared_session_link(ctx) {
             self.set_open_menu(OpenMenuState::None, ctx);
             self.mode = SharingDialogMode::QrCode;
             ctx.focus_self();
             ctx.notify();
         }
+    }
+
+    pub(crate) fn refresh_shared_session_link(&mut self, ctx: &mut ViewContext<Self>) {
+        if self.mode == SharingDialogMode::QrCode && !self.has_shared_session_link(ctx) {
+            self.mode = SharingDialogMode::Access;
+        }
+        ctx.notify();
     }
 
     /// Returns `true` if the target is an AI conversation that cannot be shared.
@@ -2787,7 +2798,7 @@ impl SharingDialog {
             .on_click(|ctx, _, _| ctx.dispatch_typed_action(SharingDialogAction::CopyLink))
             .finish();
 
-        let qr_button = matches!(self.target, Some(ShareableObject::Session { .. })).then(|| {
+        let qr_button = self.has_shared_session_link(app).then(|| {
             self.render_footer_icon_button(
                 Icon::QrCode,
                 SharingDialogAction::ShowQrCode,
@@ -2849,9 +2860,9 @@ impl View for SharingDialog {
         let appearance = Appearance::as_ref(app);
         let theme = appearance.theme();
 
-        let (contents, width) = if self.mode == SharingDialogMode::QrCode
-            && matches!(self.target, Some(ShareableObject::Session { .. }))
-        {
+        let should_render_qr_code =
+            self.mode == SharingDialogMode::QrCode && self.has_shared_session_link(app);
+        let (contents, width) = if should_render_qr_code {
             (self.render_qr_dialog(appearance, app), QR_DIALOG_WIDTH)
         } else {
             let mut contents = Flex::column();
@@ -3007,3 +3018,7 @@ impl TypedActionView for SharingDialog {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod tests;

--- a/app/src/drive/sharing/dialog/mod_tests.rs
+++ b/app/src/drive/sharing/dialog/mod_tests.rs
@@ -1,0 +1,159 @@
+use chrono::Local;
+use session_sharing_protocol::common::SessionId;
+use warpui::{App, SingletonEntity, ViewHandle};
+
+use super::{SharingDialog, SharingDialogMode};
+use crate::drive::sharing::ShareableObject;
+use crate::terminal::TerminalView;
+use crate::terminal::shared_session::manager::Manager;
+use crate::terminal::shared_session::{SharedSessionSource, SharedSessionStatus};
+use crate::test_util::add_window_with_terminal;
+use crate::test_util::terminal::initialize_app_for_terminal_view;
+
+fn set_shared_session_status(
+    terminal: &ViewHandle<TerminalView>,
+    status: SharedSessionStatus,
+    app: &mut App,
+) {
+    terminal.update(app, |view, _| {
+        view.model.lock().set_shared_session_status(status);
+    });
+}
+
+fn assert_session_link_state(
+    terminal: &ViewHandle<TerminalView>,
+    dialog: &ViewHandle<SharingDialog>,
+    expected_session_id: Option<SessionId>,
+    app: &App,
+) {
+    terminal.read(app, |view, ctx| {
+        let shared_session_status = view.model.lock().shared_session_status().clone();
+        let manager = Manager::as_ref(ctx);
+        assert_eq!(
+            manager.session_id_for_link(&view.id(), &shared_session_status),
+            expected_session_id
+        );
+        assert_eq!(
+            manager.has_session_link(&view.id(), &shared_session_status),
+            expected_session_id.is_some()
+        );
+    });
+
+    dialog.read(app, |dialog, ctx| {
+        assert_eq!(
+            dialog.has_shared_session_link(ctx),
+            expected_session_id.is_some()
+        );
+    });
+}
+
+#[test]
+fn session_qr_code_requires_status_eligible_matching_session_id() {
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        app.add_singleton_model(Manager::new);
+        app.add_singleton_model(
+            |_| crate::workspaces::user_profiles::UserProfiles::new(Vec::new()),
+        );
+        let terminal = add_window_with_terminal(&mut app, None);
+        let first_session_id = SessionId::new();
+
+        terminal.update(&mut app, |view, ctx| {
+            let window_id = ctx.window_id();
+            Manager::handle(ctx).update(ctx, |manager, ctx| {
+                manager.started_share(terminal.downgrade(), first_session_id, window_id, ctx);
+            });
+            view.model
+                .lock()
+                .set_shared_session_status(SharedSessionStatus::ActiveSharer);
+        });
+
+        let first_target = ShareableObject::Session {
+            handle: terminal.downgrade(),
+            session_id: first_session_id,
+            started_at: Local::now(),
+        };
+        let window_id = app.update(|ctx| ctx.window_ids().next().unwrap());
+        let dialog = app.add_typed_action_view(window_id, |ctx| {
+            SharingDialog::new(Some(first_target.clone()), ctx)
+        });
+
+        assert_session_link_state(&terminal, &dialog, Some(first_session_id), &app);
+        dialog.update(&mut app, |dialog, ctx| dialog.show_qr_code(ctx));
+        dialog.read(&app, |dialog, _| {
+            assert_eq!(dialog.mode, SharingDialogMode::QrCode);
+        });
+
+        Manager::handle(&app).update(&mut app, |manager, ctx| {
+            manager.stopped_share(terminal.id(), ctx);
+        });
+
+        for status in [
+            SharedSessionStatus::NotShared,
+            SharedSessionStatus::FinishedViewer,
+        ] {
+            set_shared_session_status(&terminal, status, &mut app);
+            assert_session_link_state(&terminal, &dialog, Some(first_session_id), &app);
+        }
+
+        set_shared_session_status(&terminal, SharedSessionStatus::SharePending, &mut app);
+        assert_session_link_state(&terminal, &dialog, None, &app);
+        dialog.update(&mut app, |dialog, ctx| {
+            dialog.refresh_shared_session_link(ctx);
+            assert_eq!(dialog.mode, SharingDialogMode::Access);
+        });
+
+        for status in [
+            SharedSessionStatus::ViewPending,
+            SharedSessionStatus::ActiveViewer {
+                role: Default::default(),
+            },
+            SharedSessionStatus::SharePendingPreBootstrap {
+                source: SharedSessionSource::default(),
+            },
+            SharedSessionStatus::ActiveSharer,
+        ] {
+            set_shared_session_status(&terminal, status, &mut app);
+            assert_session_link_state(&terminal, &dialog, None, &app);
+            dialog.update(&mut app, |dialog, ctx| {
+                dialog.mode = SharingDialogMode::Access;
+                dialog.show_qr_code(ctx);
+                assert_eq!(dialog.mode, SharingDialogMode::Access);
+            });
+        }
+
+        let second_session_id = SessionId::new();
+        terminal.update(&mut app, |view, ctx| {
+            let window_id = ctx.window_id();
+            Manager::handle(ctx).update(ctx, |manager, ctx| {
+                manager.started_share(terminal.downgrade(), second_session_id, window_id, ctx);
+            });
+            view.model
+                .lock()
+                .set_shared_session_status(SharedSessionStatus::ActiveSharer);
+        });
+
+        terminal.read(&app, |view, ctx| {
+            let shared_session_status = view.model.lock().shared_session_status().clone();
+            assert_eq!(
+                Manager::as_ref(ctx).session_id_for_link(&view.id(), &shared_session_status),
+                Some(second_session_id)
+            );
+        });
+        dialog.read(&app, |dialog, ctx| {
+            assert!(!dialog.has_shared_session_link(ctx));
+        });
+
+        dialog.update(&mut app, |dialog, ctx| {
+            dialog.set_target(
+                Some(ShareableObject::Session {
+                    handle: terminal.downgrade(),
+                    session_id: second_session_id,
+                    started_at: Local::now(),
+                }),
+                ctx,
+            );
+        });
+        assert_session_link_state(&terminal, &dialog, Some(second_session_id), &app);
+    });
+}

--- a/app/src/drive/sharing/mod.rs
+++ b/app/src/drive/sharing/mod.rs
@@ -15,6 +15,7 @@ use crate::server::ids::ServerId;
 use crate::server::server_api::object::GuestIdentifier;
 use crate::terminal::TerminalView;
 use crate::terminal::shared_session::join_link;
+use crate::terminal::shared_session::manager::Manager;
 use crate::ui_components::avatar::{Avatar, AvatarContent};
 use crate::ui_components::icons::Icon;
 use crate::workspaces::user_profiles::UserProfiles;
@@ -53,7 +54,21 @@ impl ShareableObject {
             ShareableObject::WarpDriveObject(id) => CloudModel::as_ref(app)
                 .get_by_uid(&id.uid())
                 .and_then(|object| object.object_link()),
-            ShareableObject::Session { session_id, .. } => Some(join_link(session_id)),
+            ShareableObject::Session {
+                handle, session_id, ..
+            } => {
+                let handle = handle.upgrade(app)?;
+                let shared_session_status = handle
+                    .as_ref(app)
+                    .model
+                    .lock()
+                    .shared_session_status()
+                    .clone();
+                let link_session_id = Manager::as_ref(app)
+                    .session_id_for_link(&handle.id(), &shared_session_status)?;
+
+                (link_session_id == *session_id).then(|| join_link(session_id))
+            }
             ShareableObject::AIConversation(id) => {
                 // Use the unified helper that checks both loaded conversation and historical metadata
                 BlocklistAIHistoryModel::as_ref(app)

--- a/app/src/pane_group/pane/mod.rs
+++ b/app/src/pane_group/pane/mod.rs
@@ -852,6 +852,10 @@ impl PaneConfiguration {
         ctx.emit(PaneConfigurationEvent::OpenSharingQrCode(source));
     }
 
+    pub fn notify_shared_session_link_changed(&mut self, ctx: &mut ModelContext<Self>) {
+        ctx.emit(PaneConfigurationEvent::SharedSessionLinkChanged);
+    }
+
     /// Notifies that the header content has changed and the pane header should re-render.
     /// Use this when the backing view's state has changed in a way that affects the header
     /// content returned by `render_header_content()`.
@@ -878,6 +882,7 @@ pub enum PaneConfigurationEvent {
     ShareableObjectChanged(Option<ShareableObject>),
     ToggleSharingDialog(SharingDialogSource),
     OpenSharingQrCode(SharingDialogSource),
+    SharedSessionLinkChanged,
     DimEvenIfFocusedUpdated,
     /// The header content has changed and should be re-rendered.
     /// This is used when the backing view's state changes in a way that

--- a/app/src/pane_group/pane/view/header/sharing.rs
+++ b/app/src/pane_group/pane/view/header/sharing.rs
@@ -139,7 +139,12 @@ impl<P: BackingView> PaneHeader<P> {
         source: SharingDialogSource,
         ctx: &mut ViewContext<Self>,
     ) {
-        if !self.is_sharing_dialog_enabled(ctx) || !self.has_shareable_shared_session(ctx) {
+        if !self.is_sharing_dialog_enabled(ctx)
+            || !self
+                .sharing_dialog()
+                .as_ref(ctx)
+                .has_shared_session_link(ctx)
+        {
             return;
         }
 
@@ -156,6 +161,12 @@ impl<P: BackingView> PaneHeader<P> {
             }
         });
         ctx.notify();
+    }
+
+    pub fn refresh_shared_session_link(&mut self, ctx: &mut ViewContext<Self>) {
+        self.sharing_dialog().update(ctx, |dialog, ctx| {
+            dialog.refresh_shared_session_link(ctx);
+        });
     }
 
     fn handle_sharing_dialog_event(

--- a/app/src/pane_group/pane/view/mod.rs
+++ b/app/src/pane_group/pane/view/mod.rs
@@ -236,7 +236,8 @@ impl<P: BackingView> PaneView<P> {
         match event {
             PaneConfigurationEvent::ShowAccentBorderUpdated
             | PaneConfigurationEvent::DimEvenIfFocusedUpdated => ctx.notify(),
-            PaneConfigurationEvent::RefreshPaneHeaderOverflowMenuItems => {
+            PaneConfigurationEvent::RefreshPaneHeaderOverflowMenuItems
+            | PaneConfigurationEvent::SharedSessionLinkChanged => {
                 let child = self.child(ctx);
                 let items = child.read(ctx, |view, ctx| view.pane_header_overflow_menu_items(ctx));
                 self.header.update(ctx, |header, ctx| {
@@ -246,6 +247,11 @@ impl<P: BackingView> PaneView<P> {
                 self.header.update(ctx, |header, ctx| {
                     header.set_toolbelt_buttons(buttons, ctx);
                 });
+                if matches!(event, PaneConfigurationEvent::SharedSessionLinkChanged) {
+                    self.header.update(ctx, |header, ctx| {
+                        header.refresh_shared_session_link(ctx);
+                    });
+                }
                 ctx.notify();
             }
             PaneConfigurationEvent::ShareableObjectChanged(object) => {

--- a/app/src/tab.rs
+++ b/app/src/tab.rs
@@ -36,6 +36,7 @@ use crate::launch_configs::launch_config::LaunchConfig;
 use crate::menu::{MenuAction, MenuItem, MenuItemFields};
 use crate::pane_group::{PaneGroup, PaneId};
 use crate::shell_indicator::ShellIndicatorType;
+use crate::terminal::shared_session::SharedSessionStatus;
 use crate::terminal::shared_session::manager::Manager;
 use crate::terminal::shared_session::render_util::shared_session_indicator_color;
 use crate::terminal::view::TerminalViewState;
@@ -354,21 +355,24 @@ impl TabData {
         // Disable the item (rather than silently no-op) when the Manager does not yet have a
         // session id (e.g. during ViewPending / SharePending while the session is still setting up).
         let focused_session_view = self.pane_group.as_ref(ctx).focused_session_view(ctx);
-        let is_shared_or_viewed = focused_session_view
-            .as_ref()
-            .map(|view| {
-                view.as_ref(ctx)
-                    .model
-                    .lock()
-                    .shared_session_status()
-                    .is_sharer_or_viewer()
-            })
-            .unwrap_or(false);
+        let focused_session_status = focused_session_view.as_ref().map(|view| {
+            view.as_ref(ctx)
+                .model
+                .lock()
+                .shared_session_status()
+                .clone()
+        });
 
-        if is_shared_or_viewed {
+        if focused_session_status
+            .as_ref()
+            .is_some_and(SharedSessionStatus::is_sharer_or_viewer)
+        {
             let has_session_link = focused_session_view
                 .as_ref()
-                .is_some_and(|view| Manager::as_ref(ctx).has_session_link(&view.id()));
+                .zip(focused_session_status.as_ref())
+                .is_some_and(|(view, status)| {
+                    Manager::as_ref(ctx).has_session_link(&view.id(), status)
+                });
             menu_items.push(
                 MenuItemFields::new("Copy link")
                     .with_on_select_action(WorkspaceAction::CopySharedSessionLinkFromTab {

--- a/app/src/terminal/local_tty/terminal_view_adaptor.rs
+++ b/app/src/terminal/local_tty/terminal_view_adaptor.rs
@@ -964,6 +964,7 @@ impl TerminalManager<TerminalView> {
                 });
 
                 terminal_view.update(ctx, |view, ctx| {
+                    view.notify_shared_session_link_changed(ctx);
                     let reason_string = failed_to_initialize_session_user_error(reason);
 
                     if matches!(

--- a/app/src/terminal/shared_session/manager.rs
+++ b/app/src/terminal/shared_session/manager.rs
@@ -7,7 +7,7 @@ use warpui::{
     WindowId,
 };
 
-use super::SharedSessionActionSource;
+use super::{SharedSessionActionSource, SharedSessionStatus};
 use crate::terminal::TerminalView;
 
 struct SharedSessionState {
@@ -61,11 +61,35 @@ impl Manager {
         self.ended_session_ids.get(terminal_view_id).copied()
     }
 
-    /// Returns true iff the Manager has a session id (active or ended) for the given terminal
-    /// view. When false, copy-link actions should be disabled rather than silently no-op.
-    pub fn has_session_link(&self, terminal_view_id: &EntityId) -> bool {
-        self.session_id(terminal_view_id).is_some()
-            || self.ended_session_id(terminal_view_id).is_some()
+    /// Returns the session id that may currently be exposed as a link for the given terminal view.
+    /// Active session ids always take precedence. Ended ids are eligible only after the terminal
+    /// has actually left its active or pending sharing state.
+    pub fn session_id_for_link(
+        &self,
+        terminal_view_id: &EntityId,
+        shared_session_status: &SharedSessionStatus,
+    ) -> Option<SessionId> {
+        self.session_id(terminal_view_id)
+            .or_else(|| match shared_session_status {
+                SharedSessionStatus::NotShared | SharedSessionStatus::FinishedViewer => {
+                    self.ended_session_id(terminal_view_id)
+                }
+                SharedSessionStatus::ViewPending
+                | SharedSessionStatus::ActiveViewer { .. }
+                | SharedSessionStatus::SharePendingPreBootstrap { .. }
+                | SharedSessionStatus::SharePending
+                | SharedSessionStatus::ActiveSharer => None,
+            })
+    }
+
+    /// Returns true iff the Manager has a session id that may currently be exposed as a link.
+    pub fn has_session_link(
+        &self,
+        terminal_view_id: &EntityId,
+        shared_session_status: &SharedSessionStatus,
+    ) -> bool {
+        self.session_id_for_link(terminal_view_id, shared_session_status)
+            .is_some()
     }
 
     /// Returns the view handle to the shared terminal view, identified by `terminal_view_id`, if it's being shared.

--- a/app/src/terminal/shared_session/viewer/terminal_manager.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager.rs
@@ -500,6 +500,9 @@ impl TerminalManager {
         self.model
             .lock()
             .set_shared_session_status(SharedSessionStatus::ViewPending);
+        self.view.update(ctx, |view, ctx| {
+            view.notify_shared_session_link_changed(ctx);
+        });
 
         let network = ctx.add_model(|ctx| {
             Network::new(
@@ -1858,6 +1861,9 @@ impl TerminalManager {
                 terminal_view.on_ambient_agent_execution_ended(ctx);
             });
         }
+        terminal_view.update(ctx, |terminal_view, ctx| {
+            terminal_view.notify_shared_session_link_changed(ctx);
+        });
         if Self::current_network(current_network)
             .is_some_and(|network| network.as_ref(ctx).session_id() == ended_session_id)
         {

--- a/app/src/terminal/shared_session/viewer/terminal_manager_tests.rs
+++ b/app/src/terminal/shared_session/viewer/terminal_manager_tests.rs
@@ -16,6 +16,7 @@ use warpui::App;
 use super::*;
 use crate::ai::blocklist::QueuedQueryModel;
 use crate::ai::blocklist::orchestration_event_streamer::OrchestrationEventStreamer;
+use crate::pane_group::PaneConfigurationEvent;
 // Bring the `TerminalManager` trait into scope (named under a different alias
 // since the local `TerminalManager` struct shadows it) so the trait method
 // `on_view_detached` is callable on the struct.
@@ -283,5 +284,78 @@ fn handle_viewer_session_end_ignores_stale_ambient_end() {
             !model.lock().shared_session_status().is_finished_viewer(),
             "an ignored stale ambient end must not finish the viewer"
         );
+    });
+}
+
+#[test]
+fn ending_ambient_session_refreshes_shared_session_link_surfaces() {
+    let _handoff_flag = FeatureFlag::HandoffCloudCloud.override_enabled(false);
+
+    App::test((), |mut app| async move {
+        initialize_app_for_terminal_view(&mut app);
+        app.add_singleton_model(Manager::new);
+
+        let terminal_view = add_window_with_terminal(&mut app, None);
+        let model = terminal_view.read(&app, |view, _| view.model.clone());
+        model
+            .lock()
+            .set_shared_session_status(SharedSessionStatus::ActiveViewer {
+                role: Default::default(),
+            });
+
+        let (wakeups_tx, _wakeups_rx) = async_channel::unbounded();
+        let (events_tx, _events_rx) = async_channel::unbounded();
+        let (pty_reads_tx, pty_reads_rx) = broadcast(8);
+        let _inactive_pty_reads_rx = pty_reads_rx.deactivate();
+        let channel_event_proxy = ChannelEventListener::new(wakeups_tx, events_tx, pty_reads_tx);
+        let (_write_to_pty_tx, write_to_pty_rx) = async_channel::unbounded();
+        let ended_network = app.add_model(|ctx| {
+            Network::new_for_test(
+                channel_event_proxy,
+                terminal_view.downgrade(),
+                model.clone(),
+                write_to_pty_rx,
+                RemoteUpdateGuard::new(),
+                ctx,
+            )
+        });
+        let ended_session_id = ended_network.read(&app, |network, _| network.session_id());
+        Manager::handle(&app).update(&mut app, |manager, ctx| {
+            manager.joined_share(terminal_view.downgrade(), ended_session_id, ctx);
+        });
+
+        let link_change_events = Arc::new(FairMutex::new(0));
+        let link_change_events_for_subscription = link_change_events.clone();
+        let pane_configuration =
+            terminal_view.read(&app, |view, _| view.pane_configuration().clone());
+        app.update(|ctx| {
+            ctx.subscribe_to_model(&pane_configuration, move |_, event, _| {
+                if matches!(event, PaneConfigurationEvent::SharedSessionLinkChanged) {
+                    *link_change_events_for_subscription.lock() += 1;
+                }
+            });
+        });
+
+        let current_network = Arc::new(FairMutex::new(Some(ended_network.clone())));
+        let handled = app.update(|ctx| {
+            TerminalManager::end_current_ambient_session(
+                &terminal_view,
+                model.clone(),
+                &current_network,
+                &ended_network,
+                ctx,
+            )
+        });
+
+        assert!(handled);
+        assert_eq!(*link_change_events.lock(), 1);
+        terminal_view.read(&app, |view, ctx| {
+            let status = view.model.lock().shared_session_status().clone();
+            assert_eq!(
+                Manager::as_ref(ctx).session_id_for_link(&view.id(), &status),
+                None,
+                "an ended id must not stay exposed while the status is still ActiveViewer"
+            );
+        });
     });
 }

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -16852,7 +16852,8 @@ impl TerminalView {
                             .block_at(tail_block_index)
                             .is_none_or(|b| b.is_restored());
 
-                    let has_session_link = Manager::as_ref(ctx).has_session_link(&ctx.view_id());
+                    let has_session_link = Manager::as_ref(ctx)
+                        .has_session_link(&ctx.view_id(), model.shared_session_status());
                     items.extend(self.session_sharing_context_menu_items(
                         &model,
                         is_share_session_disabled,
@@ -17065,7 +17066,8 @@ impl TerminalView {
                 if FeatureFlag::CreatingSharedSessions.is_enabled()
                     && ContextFlag::CreateSharedSession.is_enabled()
                 {
-                    let has_session_link = Manager::as_ref(ctx).has_session_link(&ctx.view_id());
+                    let has_session_link = Manager::as_ref(ctx)
+                        .has_session_link(&ctx.view_id(), model.shared_session_status());
                     items.extend(self.session_sharing_context_menu_items(
                         &model,
                         false,
@@ -17541,7 +17543,8 @@ impl TerminalView {
         if FeatureFlag::CreatingSharedSessions.is_enabled()
             && ContextFlag::CreateSharedSession.is_enabled()
         {
-            let has_session_link = Manager::as_ref(ctx).has_session_link(&ctx.view_id());
+            let has_session_link = Manager::as_ref(ctx)
+                .has_session_link(&ctx.view_id(), model.shared_session_status());
             items.extend(self.session_sharing_context_menu_items(&model, false, has_session_link));
         }
 
@@ -17780,7 +17783,8 @@ impl TerminalView {
         if FeatureFlag::CreatingSharedSessions.is_enabled()
             && ContextFlag::CreateSharedSession.is_enabled()
         {
-            let has_session_link = Manager::as_ref(ctx).has_session_link(&ctx.view_id());
+            let has_session_link = Manager::as_ref(ctx)
+                .has_session_link(&ctx.view_id(), model.shared_session_status());
             menu_items.extend(self.session_sharing_context_menu_items(
                 &model,
                 false,

--- a/app/src/terminal/view/pane_impl.rs
+++ b/app/src/terminal/view/pane_impl.rs
@@ -662,7 +662,8 @@ impl BackingView for TerminalView {
             if !is_ambient_agent {
                 // Disable the item (rather than silently no-op) when the Manager does not yet
                 // have a session id (e.g. during ViewPending while the session is still setting up).
-                let has_session_link = Manager::as_ref(ctx).has_session_link(&self.view_id);
+                let has_session_link =
+                    Manager::as_ref(ctx).has_session_link(&self.view_id, shared_session_status);
                 items.push(
                     MenuItemFields::new("Copy link")
                         .with_on_select_action(TerminalAction::CopySharedSessionLink { source })

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -615,6 +615,7 @@ impl TerminalView {
         self.model
             .lock()
             .set_shared_session_status(SharedSessionStatus::SharePending);
+        self.notify_shared_session_link_changed(ctx);
         log::info!("Emitting request to start sharing current session");
 
         ctx.emit(Event::StartSharingCurrentSession {
@@ -633,6 +634,12 @@ impl TerminalView {
                 ctx
             );
         }
+    }
+
+    pub(crate) fn notify_shared_session_link_changed(&mut self, ctx: &mut ViewContext<Self>) {
+        self.pane_configuration.update(ctx, |pane_config, ctx| {
+            pane_config.notify_shared_session_link_changed(ctx);
+        });
     }
 
     /// Sets the PresenceManager and decorates the view accordingly when a shared session has been started.
@@ -1469,10 +1476,10 @@ impl TerminalView {
     ) {
         #[cfg(target_family = "wasm")]
         {
+            let shared_session_status = self.model.lock().shared_session_status().clone();
             let manager = Manager::as_ref(ctx);
-            let Some(session_id) = manager
-                .session_id(&ctx.view_id())
-                .or_else(|| manager.ended_session_id(&ctx.view_id()))
+            let Some(session_id) =
+                manager.session_id_for_link(&ctx.view_id(), &shared_session_status)
             else {
                 return;
             };
@@ -1584,11 +1591,10 @@ impl TerminalView {
         ctx: &mut ViewContext<Self>,
     ) {
         let view_id = ctx.view_id();
+        let shared_session_status = self.model.lock().shared_session_status().clone();
         let session_id_opt = {
             let manager = Manager::as_ref(ctx);
-            manager
-                .session_id(&view_id)
-                .or_else(|| manager.ended_session_id(&view_id))
+            manager.session_id_for_link(&view_id, &shared_session_status)
         };
         let Some(session_id) = session_id_opt else {
             let window_id = ctx.window_id();

--- a/app/src/terminal/view/shared_session/view_impl_tests.rs
+++ b/app/src/terminal/view/shared_session/view_impl_tests.rs
@@ -30,7 +30,7 @@ use crate::auth::user::TEST_USER_UID;
 use crate::cloud_object::{Owner, Revision, ServerMetadata, ServerPermissions};
 use crate::context_chips::prompt_type::PromptType;
 use crate::editor::InteractionState;
-use crate::pane_group::BackingView;
+use crate::pane_group::{BackingView, PaneConfigurationEvent};
 use crate::server::ids::ServerId;
 #[cfg(all(feature = "local_fs", not(target_family = "wasm")))]
 use crate::server::server_api::ai::SpawnAgentRequest;
@@ -2553,6 +2553,16 @@ fn test_copy_shared_session_link_does_not_write_clipboard_when_session_pending()
         });
 
         let terminal = add_window_with_terminal(&mut app, None);
+        let link_change_events = Rc::new(RefCell::new(0));
+        let link_change_events_for_subscription = link_change_events.clone();
+        let pane_configuration = terminal.read(&app, |view, _| view.pane_configuration().clone());
+        app.update(|ctx| {
+            ctx.subscribe_to_model(&pane_configuration, move |_, event, _| {
+                if matches!(event, PaneConfigurationEvent::SharedSessionLinkChanged) {
+                    *link_change_events_for_subscription.borrow_mut() += 1;
+                }
+            });
+        });
 
         // Put the terminal in ViewPending state without registering a session_id with the Manager.
         // This simulates a cloud agent environment still setting up (no join yet).
@@ -2588,6 +2598,47 @@ fn test_copy_shared_session_link_does_not_write_clipboard_when_session_pending()
         assert_eq!(
             clipboard_text, "sentinel",
             "copy_shared_session_link must not write the join link when no session_id is registered"
+        );
+
+        // A previous ended session id must not become copyable again while a new share attempt is
+        // pending on the same terminal.
+        terminal.update(&mut app, |_, ctx| {
+            let window_id = ctx.window_id();
+            Manager::handle(ctx).update(ctx, |manager, ctx| {
+                manager.started_share(terminal.downgrade(), SessionId::new(), window_id, ctx);
+                manager.stopped_share(terminal.id(), ctx);
+            });
+        });
+        *toast_text.borrow_mut() = None;
+
+        terminal.update(&mut app, |view, ctx| {
+            view.attempt_to_share_session(
+                SharedSessionScrollbackType::None,
+                None,
+                SharedSessionSource::user(None),
+                false,
+                ctx,
+            );
+        });
+        assert_eq!(
+            *link_change_events.borrow(),
+            1,
+            "starting a new share must refresh cached link and QR surfaces"
+        );
+
+        terminal.update(&mut app, |view, ctx| {
+            view.copy_shared_session_link(SharedSessionActionSource::RightClickMenu, ctx);
+        });
+
+        assert_eq!(
+            toast_text.borrow().as_deref(),
+            Some("Sharing link not yet available"),
+            "a retained ended id must not be copied while a new session is pending"
+        );
+        let clipboard_text = terminal.update(&mut app, |_, ctx| ctx.clipboard().read().plain_text);
+        assert_eq!(
+            clipboard_text, "sentinel",
+            "a retained ended id must not overwrite the clipboard during a pending retry"
         );
     });
 }


### PR DESCRIPTION
## Description

Builds on #14431's disabled copy-link actions and defensive fallback, then closes the remaining stale-link and QR-code gaps.

- `Manager::session_id_for_link` is now the source of truth for link eligibility. An active Manager session ID always wins; a retained ended ID is exposed only while the terminal is actually `NotShared` or `FinishedViewer`.
- Right-click, tab, pane-header, direct-copy, and WASM-open paths use the same status-aware selection, so a new pending attempt cannot reuse a previous session's URL.
- The sharing dialog requires its target session ID to match the currently eligible Manager ID before rendering or opening QR, copying, or downloading. A stale dialog target cannot expose an old URL after the terminal moves to another session.
- Pending, failure, and ambient-session-end transitions refresh cached menu and dialog surfaces. If an already-open QR becomes ineligible, the dialog immediately returns to Access mode.

## Linked Issue

Closes #9736.

- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [x] Automated coverage exercises the user-visible pending, active, ended, retargeted, and open-QR transition states.

## Testing

- [x] Focused shared-session suite: 6/6 passed, covering pending/active/ended link eligibility, pane and context-menu behavior, stale target identity, QR fallback, retained-ended retry behavior, clipboard/toast safety, and ambient-session invalidation.
- [x] Fork-equivalent workspace suite: 10,786/10,786 passed (`--workspace --exclude command-signatures-v2`, excluding the private `_ssh_`/`remote_server` fixture class used by fork CI).
- [x] Completer v2: 123/123 passed, 4 skipped.
- [x] `cargo test --doc` passed; only expected ignored examples.
- [x] `./script/format --check` and `./script/check_no_inline_test_modules` passed.
- [x] All three presubmit Clippy profiles passed with `-D warnings`.
- [x] Full `./script/presubmit` passed formatting, inline-test-module, all Clippy, clang-format, and WGSL checks. Its final workspace run passed 10,910 tests; the only five failures were the private SSH integration fixtures, all timing out at `Wait for password prompt`. The fork-equivalent workspace command above excludes that unavailable fixture class and passed cleanly.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Prevent stale shared-session links and QR codes from being exposed while a new session is pending.
