### PR TITLE
Fix global flags (--api-key, --debug) before subcommand causing parse error

### DIFF
--- a/crates/warp_cli/src/lib.rs
+++ b/crates/warp_cli/src/lib.rs
@@ -123,7 +123,7 @@ Use the CLI to:
 * Manage the environments that cloud agents run in
 * Upload secrets to Oz's secure storage"#
 )]
-#[clap(args_conflicts_with_subcommands = true)]
+#[clap(subcommand_precedence_over_arg = true)]
 pub struct Args {
     #[clap(flatten)]
     global_options: GlobalOptions,

--- a/crates/warp_cli/src/lib_tests.rs
+++ b/crates/warp_cli/src/lib_tests.rs
@@ -518,6 +518,46 @@ fn legacy_memory_store_memory_commands_are_rejected() {
 }
 
 #[test]
+fn api_key_before_subcommand_parses() {
+    // Regression test: `warp --api-key KEY <subcommand>` should work.
+    // Previously the top-level [URLS] positional would swallow the subcommand
+    // when --api-key preceded it.
+    let args = Args::try_parse_from(["warp", "--api-key", "test-key", "login"]).unwrap();
+
+    assert_eq!(args.api_key(), Some(&"test-key".to_string()));
+    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
+        panic!("Expected `warp login` command");
+    };
+    assert!(matches!(boxed_cmd.as_ref(), CliCommand::Login));
+}
+
+#[test]
+fn debug_before_subcommand_parses() {
+    // Regression test: `warp --debug <subcommand>` should work.
+    // Global flags like --debug must not prevent subcommand detection.
+    let args = Args::try_parse_from(["warp", "--debug", "login"]).unwrap();
+
+    assert!(args.debug());
+    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
+        panic!("Expected `warp login` command");
+    };
+    assert!(matches!(boxed_cmd.as_ref(), CliCommand::Login));
+}
+
+#[test]
+fn multiple_global_flags_before_subcommand_parse() {
+    // Both --api-key and --debug before the subcommand should work.
+    let args = Args::try_parse_from(["warp", "--api-key", "test-key", "--debug", "login"]).unwrap();
+
+    assert_eq!(args.api_key(), Some(&"test-key".to_string()));
+    assert!(args.debug());
+    let Some(Command::CommandLine(boxed_cmd)) = args.command else {
+        panic!("Expected `warp login` command");
+    };
+    assert!(matches!(boxed_cmd.as_ref(), CliCommand::Login));
+}
+
+#[test]
 fn login_parses() {
     let args = Args::try_parse_from(["warp", "login"]).unwrap();
 


### PR DESCRIPTION
## Description

Fix a CLI parsing quirk where global flags like `--api-key` or `--debug` placed before a subcommand would cause the subcommand name to be swallowed by the top-level `[URLS]` positional argument, resulting in a parse error.

**Before:**
```
warp --api-key KEY agent run --prompt "hello"  # error: invalid value 'agent' for '[URLS]...'
warp --debug login                              # error: invalid value 'login' for '[URLS]...'
```

**After:**
```
warp --api-key KEY agent run --prompt "hello"  # works
warp --debug login                             # works
```

**Root cause:** The `Args` struct had `args_conflicts_with_subcommands = true`, which interacted with the parser to prevent subcommand detection after any flag was consumed. This caused the next token (the subcommand name) to be matched against the `urls: Vec<Url>` positional argument instead.

**Fix:** Replace `args_conflicts_with_subcommands = true` with `subcommand_precedence_over_arg = true`. The new attribute instructs clap to always check an incoming token against registered subcommands before treating it as a positional value. Removing `args_conflicts_with_subcommands` is safe because Warp URLs (deep links) and CLI subcommands are never used simultaneously in practice — the app always routes on the subcommand field first.

## Linked Issue

- Fixes REMOTE-2177

## Testing

- Added unit tests for `--api-key KEY <subcommand>`, `--debug <subcommand>`, and both flags together before a subcommand.
- All 200 `warp_cli` tests pass.
- `./script/format` and `cargo clippy` pass.

- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

_Conversation: https://staging.warp.dev/conversation/62e2a4f1-c756-474d-8735-bbcccabcb145_
_Run: https://oz.staging.warp.dev/runs/019f6ab3-2423-7e62-8207-f584c7c3d2b8_

_This PR was generated with [Oz](https://warp.dev/oz)._
