### PR TITLE
Prevent Sentry requests from hanging app shutdown

### DIFF
--- a/app/src/crash_reporting/mac.rs
+++ b/app/src/crash_reporting/mac.rs
@@ -10,6 +10,7 @@ extern "C" {
         environment: &NSString,
         version: &NSString,
         isDogfood: bool,
+        shutdownTimeInterval: f64,
     );
     fn stopSentry();
     #[allow(dead_code)] // Only gets called when built in debug mode.
@@ -43,6 +44,7 @@ pub fn init_cocoa_sentry() {
                 &environment,
                 &release,
                 ChannelState::channel().is_dogfood(),
+                SENTRY_SHUTDOWN_TIMEOUT.as_secs_f64(),
             );
         }
     });

--- a/app/src/crash_reporting/mod.rs
+++ b/app/src/crash_reporting/mod.rs
@@ -10,6 +10,7 @@ use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 use std::ops::DerefMut;
 use std::sync::Arc;
+use std::time::Duration;
 
 use lazy_static::lazy_static;
 use parking_lot::{Mutex, RwLock};
@@ -30,6 +31,9 @@ use crate::auth::{AuthStateProvider, UserUid};
 use crate::channel::ChannelState;
 use crate::features::FeatureFlag;
 use crate::settings::{PrivacySettings, PrivacySettingsChangedEvent};
+
+const SENTRY_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
+const SENTRY_HTTP_TIMEOUT: Duration = Duration::from_secs(1);
 
 lazy_static! {
     /// The RAII guard returned by the call to initialize the Rust Sentry client must be kept in
@@ -406,8 +410,41 @@ fn sentry_client_options() -> sentry::ClientOptions {
         environment: Some(get_environment()),
         auto_session_tracking: true,
         session_mode: SessionMode::Application,
+        shutdown_timeout: SENTRY_SHUTDOWN_TIMEOUT,
+        transport: Some(Arc::new(bounded_sentry_http_transport)),
         ..Default::default()
     }
+}
+
+fn bounded_sentry_http_transport(options: &sentry::ClientOptions) -> Arc<dyn sentry::Transport> {
+    let mut client = reqwest::Client::builder()
+        .connect_timeout(SENTRY_HTTP_TIMEOUT)
+        .timeout(SENTRY_HTTP_TIMEOUT);
+
+    if options.accept_invalid_certs {
+        client = client.danger_accept_invalid_certs(true);
+    }
+    if let Some(proxy) = options
+        .http_proxy
+        .as_ref()
+        .and_then(|url| reqwest::Proxy::http::<&str>(url.as_ref()).ok())
+    {
+        client = client.proxy(proxy);
+    }
+    if let Some(proxy) = options
+        .https_proxy
+        .as_ref()
+        .and_then(|url| reqwest::Proxy::https::<&str>(url.as_ref()).ok())
+    {
+        client = client.proxy(proxy);
+    }
+
+    let client = client
+        .build()
+        .expect("Failed to build the Sentry HTTP client");
+    Arc::new(sentry::transports::ReqwestHttpTransport::with_client(
+        options, client,
+    ))
 }
 
 /// Returns whether the Rust Sentry client is currently initialized.
@@ -615,3 +652,7 @@ impl ToSentryTags for &AntivirusInfo {
         )]
     }
 }
+
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod tests;

--- a/app/src/crash_reporting/mod_tests.rs
+++ b/app/src/crash_reporting/mod_tests.rs
@@ -1,0 +1,45 @@
+use std::io::Read;
+use std::net::TcpListener;
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use super::*;
+
+#[test]
+fn blocked_sentry_request_does_not_block_transport_shutdown_indefinitely() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let (request_received_tx, request_received_rx) = mpsc::channel();
+    let (release_server_tx, release_server_rx) = mpsc::channel();
+
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0; 1024];
+        stream.read(&mut request).unwrap();
+        request_received_tx.send(()).unwrap();
+        release_server_rx
+            .recv_timeout(Duration::from_secs(5))
+            .unwrap();
+    });
+
+    let options = sentry::ClientOptions {
+        dsn: Some(format!("http://public@{address}/1").parse().unwrap()),
+        ..Default::default()
+    };
+    let transport = bounded_sentry_http_transport(&options);
+    transport.send_envelope(sentry::protocol::Event::default().into());
+    request_received_rx
+        .recv_timeout(Duration::from_secs(2))
+        .unwrap();
+
+    let started_at = Instant::now();
+    drop(transport);
+    assert!(
+        started_at.elapsed() < Duration::from_secs(2),
+        "Sentry transport shutdown exceeded its HTTP timeout"
+    );
+
+    release_server_tx.send(()).unwrap();
+    server.join().unwrap();
+}

--- a/app/src/platform/mac/objc/crash_reporting.m
+++ b/app/src/platform/mac/objc/crash_reporting.m
@@ -3,13 +3,15 @@
 #import <Sentry/Sentry-Swift.h>
 #import <Sentry/Sentry.h>
 
-void startSentry(id sentryUrl, id environment, id version, bool isDogfood) {
+void startSentry(id sentryUrl, id environment, id version, bool isDogfood,
+                 double shutdownTimeInterval) {
     [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
       options.dsn = sentryUrl;
       options.debug = NO;
       options.environment = environment;
       options.releaseName = version;
       options.enableAppHangTracking = isDogfood;
+      options.shutdownTimeInterval = shutdownTimeInterval;
     }];
 }
 


### PR DESCRIPTION
## Description

A blocked Sentry HTTP request can outlive the SDK's configured shutdown timeout: `sentry::TransportThread::drop` joins its worker thread after flushing, while the default Reqwest client has no total request timeout. Because Warp closes both Cocoa and Rust Sentry synchronously during AppKit termination, an unreachable ingest endpoint can leave the main thread unresponsive long enough for macOS to show Force Quit.

The concrete stackshot, shutdown log boundary, and blocked-ingest network evidence from the current report are recorded in [#13068](https://github.com/warpdotdev/warp/issues/13068#issuecomment-4991808076).

This change:

- gives the Rust Sentry transport a one-second connect and total HTTP timeout;
- explicitly bounds the Rust SDK shutdown drain to one second;
- applies the same one-second shutdown interval to Sentry Cocoa; and
- adds a regression test with a local endpoint that accepts an envelope but never responds.

Crash reporting remains best-effort, while application shutdown no longer depends on the operating system's much longer network timeout.

## Linked Issue

Closes #5314

Refs #13068

- [x] The linked issue is labeled `ready-to-implement`.
- [x] Screenshots are not applicable because this changes shutdown networking without changing UI.

## Testing

- [x] `./script/format`
- [x] `cargo test -p warp --no-default-features --features crash_reporting --lib crash_reporting::tests::blocked_sentry_request_does_not_block_transport_shutdown_indefinitely --no-fail-fast` (1 passed; completed in 1.07s)
- [x] `cargo clippy --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
- [x] `cargo clippy -p warp_completer --all-targets --tests -- -D warnings`
- [x] Built and launched `WarpOss.app` with `./script/run`, then quit it with Cmd+Q; the process exited normally with status 0.
- [x] I have manually tested my changes locally with `./script/run`

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Prevent Warp from hanging on quit when the crash-reporting endpoint is unreachable.
