### PR TITLE
feat: support Kitty graphics protocol animation (a=f / a=a)

### DIFF
--- a/app/src/terminal/model/blockgrid_tests.rs
+++ b/app/src/terminal/model/blockgrid_tests.rs
@@ -276,3 +276,46 @@ pub fn test_cursor_display_point_not_clipped_when_trimming_disabled() {
         Some(CursorDisplayPoint::HiddenCache(Point::new(0, 1)))
     );
 }
+
+#[test]
+pub fn test_kitty_animation_parsing_and_handling() {
+    use crate::terminal::model::kitty::{parse_kitty_chunk, PendingKittyMessage, KittyMessage};
+
+    // Test a=f (AnimationFrame) parsing
+    // Sequence: "a=f,i=2,f=24,s=30,v=30,z=500"
+    let control_bytes = b"a=f,i=2,f=24,s=30,v=30,z=500;cGF5bG9hZA==".to_vec(); // payload is "payload" in base64
+    let chunk = parse_kitty_chunk(control_bytes);
+    let pending = PendingKittyMessage {
+        control_data: chunk.control_data,
+        payload: vec![chunk.payload],
+    };
+    let message = KittyMessage::try_from(pending).expect("message should decode");
+    let action = KittyAction::try_from(message).expect("action should parse");
+
+    if let KittyAction::AnimationFrame(frame_action) = action {
+        assert_eq!(frame_action.image_id, 2);
+        assert_eq!(frame_action.frame_gap_ms, 500);
+        assert_eq!(frame_action.image.data, b"payload");
+    } else {
+        panic!("expected AnimationFrame action");
+    }
+
+    // Test a=a (AnimationControl) parsing
+    // Sequence: "a=a,i=2,s=3"
+    let control_bytes = b"a=a,i=2,s=3;".to_vec();
+    let chunk = parse_kitty_chunk(control_bytes);
+    let pending = PendingKittyMessage {
+        control_data: chunk.control_data,
+        payload: vec![chunk.payload],
+    };
+    let message = KittyMessage::try_from(pending).expect("message should decode");
+    let action = KittyAction::try_from(message).expect("action should parse");
+
+    if let KittyAction::AnimationControl(control_action) = action {
+        assert_eq!(control_action.image_id, 2);
+        assert_eq!(control_action.command, 3);
+    } else {
+        panic!("expected AnimationControl action");
+    }
+}
+

--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -41,7 +41,7 @@ use crate::terminal::model::image_map::{ImagePlacementData, ImageType, StoredIma
 use crate::terminal::model::index::{Point, VisibleRow};
 use crate::terminal::model::iterm_image::{ITermImage, ITermImageDimensionUnit};
 use crate::terminal::model::kitty::{
-    CursorMovementPolicy, KittyAction, KittyError, KittyResponse, StorageError,
+    CursorMovementPolicy, KittyAction, KittyError, KittyResponse, StorageError, AnimationFrameData, DeletionType,
 };
 use crate::terminal::model::selection::ScrollDelta;
 use crate::terminal::model::ObfuscateSecrets;
@@ -105,6 +105,7 @@ pub(super) struct State {
     /// `push` appends the new mode; `pop` truncates and restores
     /// the previous entry as the active mode.
     pub keyboard_mode_stack: BoundedVecDeque<KeyboardModes>,
+    pub(super) animation_cancellations: HashMap<u32, Arc<std::sync::atomic::AtomicBool>>,
 }
 
 impl State {
@@ -142,6 +143,7 @@ impl State {
             pane_size: size_info.pane_size_px(),
             keyboard_mode: KeyboardModes::NO_MODE,
             keyboard_mode_stack: BoundedVecDeque::new(super::KEYBOARD_MODE_STACK_MAX_DEPTH),
+            animation_cancellations: HashMap::new(),
         }
     }
 }
@@ -1969,7 +1971,92 @@ impl GridHandler {
                 });
             }
             KittyAction::QuerySupport(_) => {}
-            KittyAction::Delete { .. } => {}
+            KittyAction::Delete {
+                deletion_type,
+                delete_placements_only: _,
+            } => {
+                match deletion_type {
+                    DeletionType::DeleteAll => {
+                        for (_, cancelled) in self.ansi_handler_state.animation_cancellations.drain() {
+                            cancelled.store(true, std::sync::atomic::Ordering::SeqCst);
+                        }
+                    }
+                    DeletionType::DeleteById(delete_by_id) => {
+                        if let Some(cancelled) = self.ansi_handler_state.animation_cancellations.remove(&delete_by_id.image_id) {
+                            cancelled.store(true, std::sync::atomic::Ordering::SeqCst);
+                        }
+                    }
+                }
+            }
+            KittyAction::AnimationFrame(action) => {
+                let metadata = match metadata.get_mut(&action.image_id) {
+                    Some(StoredImageMetadata::Kitty(metadata)) => metadata,
+                    Some(_) | None => {
+                        return Err(StorageError::UnknownId {
+                            id: action.image_id,
+                        }
+                        .into())
+                    }
+                };
+
+                metadata.frames.push(AnimationFrameData {
+                    data: action.image.data,
+                    gap_ms: action.frame_gap_ms,
+                });
+            }
+            KittyAction::AnimationControl(action) => {
+                if action.command == 1 {
+                    if let Some(cancelled) = self.ansi_handler_state.animation_cancellations.remove(&action.image_id) {
+                        cancelled.store(true, std::sync::atomic::Ordering::SeqCst);
+                    }
+                } else if action.command == 2 || action.command == 3 {
+                    if let Some(cancelled) = self.ansi_handler_state.animation_cancellations.insert(
+                        action.image_id,
+                        Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                    ) {
+                        cancelled.store(true, std::sync::atomic::Ordering::SeqCst);
+                    }
+
+                    if let Some(StoredImageMetadata::Kitty(metadata)) = metadata.get(&action.image_id) {
+                        let frames = metadata.frames.clone();
+                        if !frames.is_empty() {
+                            let cancelled = self.ansi_handler_state.animation_cancellations.get(&action.image_id).cloned().unwrap();
+                            let event_proxy = self.ansi_handler_state.event_proxy.clone();
+                            let image_id = action.image_id;
+                            let loop_animation = action.command == 3;
+
+                            tokio::spawn(async move {
+                                let mut frame_index = 0;
+                                loop {
+                                    if cancelled.load(std::sync::atomic::Ordering::SeqCst) {
+                                        break;
+                                    }
+
+                                    let frame = &frames[frame_index];
+                                    event_proxy.send_terminal_event(Event::ImageReceived {
+                                        image_id,
+                                        image_data: frame.data.clone(),
+                                        image_protocol: ImageProtocol::Kitty,
+                                    });
+
+                                    let gap_ms = if frame.gap_ms > 0 { frame.gap_ms } else { 100 };
+                                    tokio::time::sleep(tokio::time::Duration::from_millis(gap_ms as u64)).await;
+
+                                    frame_index += 1;
+                                    if frame_index >= frames.len() {
+                                        if loop_animation {
+                                            frame_index = 0;
+                                        } else {
+                                            break;
+                                        }
+                                    }
+                                }
+                            });
+                        }
+                    }
+                }
+            }
+            KittyAction::FrameComposition(_) => {}
         }
 
         Ok(())

--- a/app/src/terminal/model/kitty.rs
+++ b/app/src/terminal/model/kitty.rs
@@ -30,6 +30,28 @@ pub enum KittyAction {
         delete_placements_only: bool,
         deletion_type: DeletionType,
     },
+    AnimationFrame(AnimationFrame),
+    AnimationControl(AnimationControl),
+    FrameComposition(FrameComposition),
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct AnimationFrame {
+    pub image: KittyImage,
+    pub image_id: u32,
+    pub frame_gap_ms: u32,
+    pub frame_index: Option<u32>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct AnimationControl {
+    pub image_id: u32,
+    pub command: u32,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct FrameComposition {
+    pub image_id: u32,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -132,8 +154,14 @@ impl TryFrom<KittyMessage> for KittyImage {
             }
         };
 
+        let mut metadata = KittyImageMetadata::from(message.control_data);
+        metadata.frames.push(AnimationFrameData {
+            data: decoded_data.clone(),
+            gap_ms: 0,
+        });
+
         Ok(Self {
-            metadata: KittyImageMetadata::from(message.control_data),
+            metadata,
             data: decoded_data,
         })
     }
@@ -413,9 +441,67 @@ impl TryFrom<KittyMessage> for KittyAction {
                     delete_placements_only: message.control_data.delete_placements_only,
                 })
             }
+            KittyPlacementAction::AnimationFrame => {
+                let mut action = AnimationFrame {
+                    image_id: message
+                        .control_data
+                        .image_id
+                        .unwrap_or(rand::thread_rng().gen()),
+                    frame_gap_ms: if message.control_data.z_index >= 0 {
+                        message.control_data.z_index as u32
+                    } else {
+                        0
+                    },
+                    frame_index: message.control_data.rows,
+                    image: KittyImage::try_from(message)?,
+                };
+
+                if action.image.metadata.pixel_data_format == KittyPixelDataFormat::Png {
+                    action.image = set_kitty_png_size(action.image)?;
+                } else {
+                    action.image = set_kitty_rgb_headers(action.image)?;
+                }
+
+                Ok(KittyAction::AnimationFrame(action))
+            }
+            KittyPlacementAction::AnimationControl => {
+                let id = match message.control_data.image_id {
+                    Some(id) => id,
+                    None => return Err(InvalidControlData::IdMissing.into()),
+                };
+
+                Ok(KittyAction::AnimationControl(AnimationControl {
+                    image_id: id,
+                    command: message.control_data.width,
+                }))
+            }
+            KittyPlacementAction::FrameComposition => {
+                let id = match message.control_data.image_id {
+                    Some(id) => id,
+                    None => return Err(InvalidControlData::IdMissing.into()),
+                };
+
+                Ok(KittyAction::FrameComposition(FrameComposition {
+                    image_id: id,
+                }))
+            }
             KittyPlacementAction::Unknown => Err(InvalidKittyAction::UnsupportedAction.into()),
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct AnimationFrameData {
+    pub data: Vec<u8>,
+    pub gap_ms: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AnimationState {
+    #[default]
+    Stopped,
+    Playing,
+    Paused,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -423,6 +509,9 @@ pub struct KittyImageMetadata {
     pub pixel_data_format: KittyPixelDataFormat,
     pub transmission_medium: KittyTransmissionMedium,
     pub image_size: Vector2F,
+    pub frames: Vec<AnimationFrameData>,
+    pub current_frame: usize,
+    pub animation_state: AnimationState,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -478,6 +567,7 @@ impl From<KittyControlData> for KittyImageMetadata {
             pixel_data_format: control_data.pixel_data_format,
             image_size: Vector2F::new(control_data.width as f32, control_data.height as f32),
             transmission_medium: control_data.transmission_medium,
+            ..Default::default()
         }
     }
 }
@@ -508,6 +598,9 @@ pub enum KittyPlacementAction {
     DisplayStoredImage,
     QuerySupport,
     Delete,
+    AnimationFrame,
+    AnimationControl,
+    FrameComposition,
     Unknown,
 }
 
@@ -667,6 +760,9 @@ fn parse_kitty_control_data(control_data: &[u8]) -> KittyControlData {
                     b"p" => KittyPlacementAction::DisplayStoredImage,
                     b"q" => KittyPlacementAction::QuerySupport,
                     b"d" => KittyPlacementAction::Delete,
+                    b"f" => KittyPlacementAction::AnimationFrame,
+                    b"a" => KittyPlacementAction::AnimationControl,
+                    b"c" => KittyPlacementAction::FrameComposition,
                     _ => KittyPlacementAction::Unknown,
                 }
             }

--- a/app/src/terminal/model/terminal_model.rs
+++ b/app/src/terminal/model/terminal_model.rs
@@ -3479,6 +3479,9 @@ impl ansi::Handler for TerminalModel {
                     }
                     KittyAction::DisplayStoredImage(_) => {}
                     KittyAction::QuerySupport(_) => {}
+                    KittyAction::AnimationFrame(_) => {}
+                    KittyAction::AnimationControl(_) => {}
+                    KittyAction::FrameComposition(_) => {}
                     KittyAction::Delete {
                         delete_placements_only,
                         deletion_type,

--- a/app/src/terminal/model/test_utils.rs
+++ b/app/src/terminal/model/test_utils.rs
@@ -62,6 +62,7 @@ fn test_kitty_image_metadata() -> KittyImageMetadata {
         pixel_data_format: KittyPixelDataFormat::Rgba32Bit,
         transmission_medium: KittyTransmissionMedium::Direct,
         image_size: Vector2F::new(10.0, 10.0),
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
Warp already supports static Kitty graphics protocol images (transmit, display, query, delete). This PR adds the animation extension so that tools like `kitten icat animated.gif` animate correctly in Warp instead of freezing on the first frame.

## Description

Implements `a=f` (frame transmission) and `a=a` (animation control) from the [Kitty graphics protocol animation spec](https://sw.kovidgoyal.net/kitty/graphics-protocol/#animation).

## What this does

- **`a=f` (AnimationFrame):** Parses incoming frame data and appends each frame's pixel bytes and per-frame gap timing (`z=` key in ms) to the stored image metadata
- **`a=a` (AnimationControl):** Handles playback commands:
  - `s=2` / `s=3` — spawns a `tokio` background task that cycles through frames at each frame's delay and emits `Event::ImageReceived`, causing the UI asset cache to update and repaint
  - `s=1` — signals the background task to stop via an `Arc<AtomicBool>` cancellation token
- **Cleanup:** Cancels running animation loops on image delete (`a=d`)
- **Parsing:** Maps `a=f`, `a=a`, and `a=c` action keys in `parse_kitty_control_data`
- **Test:** Adds `test_kitty_animation_parsing_and_handling` verifying both `a=f` and `a=a` parsing

## Linked Issue

Fixes #13737

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing

This is a terminal model / protocol parsing change with no direct UI component. The animation loop drives rendering via the existing `Event::ImageReceived` → `AssetCache` → `ctx.notify()` pipeline that already handles static Kitty images.

- [ ] I have manually tested my changes locally with `./script/run`

**Automated test added:** `test_kitty_animation_parsing_and_handling` in `blockgrid_tests.rs` — verifies correct parsing of `a=f` (image ID, frame gap, payload) and `a=a` (image ID, command) sequences.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!-- CHANGELOG-IMPROVEMENT: Kitty graphics protocol now supports animated images (a=f frame transmission and a=a animation control), so tools like `kitten icat animated.gif` animate correctly in Warp -->