### PR TITLE
fix(completions): don't treat attached-value tokens as short-flag bundles (#9820)

### DIFF
--- a/crates/warp_completer/src/completer/describe.rs
+++ b/crates/warp_completer/src/completer/describe.rs
@@ -200,11 +200,18 @@ pub async fn describe_given_token<T: CompletionContext>(
                     // A flag token with an attached value (`-DWITH_TESTS` from
                     // `-DWITH_TESTS=OFF`) is not a bundle of short-hand flags. Skip
                     // bundle-style exact matches — Option suggestions whose display (e.g.
-                    // CMake's `-S`) differs from the token while their replacement equals
-                    // it — so such tokens aren't misdescribed/colored as that option (#9820).
+                    // CMake's `-S`) doesn't itself exact-match the token (the exact match
+                    // came from the bundle replacement) — so such tokens aren't
+                    // misdescribed/colored as that option (#9820). The display is compared
+                    // with the suggestion's own matcher so legitimately case-insensitive
+                    // options (`-force` for `-Force`) keep their description.
+                    let display_exactly_matches_token = matches!(
+                        matcher.get_match_type(trimmed_token_item, suggestion.display()),
+                        Some(Match::Exact { .. })
+                    );
                     if is_flag_with_attached_value
                         && matches!(suggestion.suggestion_type(), SuggestionType::Option(..))
-                        && suggestion.display() != trimmed_token_item
+                        && !display_exactly_matches_token
                     {
                         continue;
                     }

--- a/crates/warp_completer/src/completer/describe.rs
+++ b/crates/warp_completer/src/completer/describe.rs
@@ -102,8 +102,16 @@ pub async fn describe<T: CompletionContext>(
                 Some(token) => {
                     // For --flag=value tokens, split based on cursor position so hovering the flag
                     // part describes the flag and hovering the value part describes the value.
-                    let token = split_flag_eq_token_at_cursor(token, pos);
-                    describe_given_token(line, &command.span(), token, context).await
+                    let (token, is_flag_with_attached_value) =
+                        split_flag_eq_token_at_cursor(token, pos);
+                    describe_given_token(
+                        line,
+                        &command.span(),
+                        token,
+                        is_flag_with_attached_value,
+                        context,
+                    )
+                    .await
                 }
                 None => None,
             }
@@ -117,10 +125,15 @@ pub async fn describe<T: CompletionContext>(
 /// command_span is the span for the command we're describing.
 /// token is the specific span of the word we're describing.
 /// e.g. line = "git status && cd dir", command_span = "git status", token = "status"
+///
+/// `is_flag_with_attached_value` is `true` when `token` is the flag-name part of an
+/// attached-value token (e.g. `-DWITH_TESTS` from `-DWITH_TESTS=OFF`). Such tokens are not
+/// bundles of short-hand flags, so bundle-style exact matches are ignored (#9820).
 pub async fn describe_given_token<T: CompletionContext>(
     line: &str,
     command_span: &Span,
     token: Spanned<String>,
+    is_flag_with_attached_value: bool,
     context: &T,
 ) -> Option<Description> {
     let path_separators = get_path_separators(context).all;
@@ -184,6 +197,17 @@ pub async fn describe_given_token<T: CompletionContext>(
                 suggestion.suggestion_type(),
             ) {
                 (Some(Match::Exact { .. }), _) => {
+                    // A flag token with an attached value (`-DWITH_TESTS` from
+                    // `-DWITH_TESTS=OFF`) is not a bundle of short-hand flags. Skip
+                    // bundle-style exact matches — Option suggestions whose display (e.g.
+                    // CMake's `-S`) differs from the token while their replacement equals
+                    // it — so such tokens aren't misdescribed/colored as that option (#9820).
+                    if is_flag_with_attached_value
+                        && matches!(suggestion.suggestion_type(), SuggestionType::Option(..))
+                        && suggestion.display() != trimmed_token_item
+                    {
+                        continue;
+                    }
                     return Some(Description {
                         token: match suggestion.suggestion_type() {
                             // For top-level commands `suggestion.display()` contains the preferred
@@ -219,24 +243,37 @@ pub async fn describe_given_token<T: CompletionContext>(
 /// If the token is a `--flag=value` token, returns a sub-token for the part the
 /// cursor is on: the flag name part if the cursor is on or before the `=`, or the
 /// value part if the cursor is after the `=`.
-fn split_flag_eq_token_at_cursor(token: Spanned<String>, pos: ByteOffset) -> Spanned<String> {
+/// Splits a `--flag=value` token at the cursor position. The second element of the returned
+/// pair is `true` when the returned token is the flag-name part of an attached-value token
+/// (i.e. the piece before `=`), which callers pass to [`describe_given_token`] so the flag
+/// part is not misread as a bundle of short-hand flags (#9820).
+fn split_flag_eq_token_at_cursor(
+    token: Spanned<String>,
+    pos: ByteOffset,
+) -> (Spanned<String>, bool) {
     if !token.item.starts_with('-') {
-        return token;
+        return (token, false);
     }
     let Some(eq_pos) = token.item.find('=') else {
-        return token;
+        return (token, false);
     };
     let eq_byte_pos = token.span.start() + eq_pos;
     if pos.as_usize() <= eq_byte_pos {
         // Cursor is on the flag name part (including '=').
-        token.item[..eq_pos]
-            .to_string()
-            .spanned(Span::new(token.span.start(), eq_byte_pos))
+        (
+            token.item[..eq_pos]
+                .to_string()
+                .spanned(Span::new(token.span.start(), eq_byte_pos)),
+            true,
+        )
     } else {
         // Cursor is on the value part.
-        token.item[eq_pos + 1..]
-            .to_string()
-            .spanned(Span::new(eq_byte_pos + 1, token.span.end()))
+        (
+            token.item[eq_pos + 1..]
+                .to_string()
+                .spanned(Span::new(eq_byte_pos + 1, token.span.end())),
+            false,
+        )
     }
 }
 

--- a/crates/warp_completer/src/completer/describe_tests.rs
+++ b/crates/warp_completer/src/completer/describe_tests.rs
@@ -531,3 +531,22 @@ fn test_describe_case_insensitive_option() {
         None
     );
 }
+
+/// Regression test for #9820: the flag part of an attached-value token must not be
+/// described as a short-hand flag bundle. `-DWITH_TESTS` ends in `S` (a known cmake short
+/// flag) and `-DS` is composed entirely of known cmake short flags — both previously
+/// exact-matched an option and got its description/coloring, while other `-D...` values
+/// didn't, making the highlighting look random.
+#[test]
+pub fn test_describe_attached_value_flag_not_treated_as_bundle() {
+    // Command classification checks feature flags; mark them initialized so the
+    // debug-mode assertion in `FeatureFlag::is_enabled` doesn't fire.
+    warp_core::features::mark_initialized();
+    let ctx = FakeCompletionContext::new(CommandRegistry::default());
+
+    let line = "cmake -DWITH_TESTS=OFF";
+    assert_eq!(describe_at_cursor(line, ByteOffset::from(8), &ctx), None);
+
+    let line = "cmake -DS=OFF";
+    assert_eq!(describe_at_cursor(line, ByteOffset::from(8), &ctx), None);
+}

--- a/crates/warp_completer/src/completer/describe_tests.rs
+++ b/crates/warp_completer/src/completer/describe_tests.rs
@@ -550,3 +550,25 @@ pub fn test_describe_attached_value_flag_not_treated_as_bundle() {
     let line = "cmake -DS=OFF";
     assert_eq!(describe_at_cursor(line, ByteOffset::from(8), &ctx), None);
 }
+
+/// The attached-value filter must not drop legitimately case-insensitive option matches:
+/// typing `-encoding=UTF8` (display `-Encoding`) is an exact case-insensitive match, not a
+/// bundle-style match, so the description is kept (#9820 review follow-up).
+#[test]
+pub fn test_describe_attached_value_keeps_case_insensitive_option_match() {
+    warp_core::features::mark_initialized();
+    let registry = create_test_command_registry([add_content_signature()]);
+    let ctx = FakeCompletionContext::new(registry);
+
+    assert_eq!(
+        describe_at_cursor("Add-Content -encoding=UTF8", ByteOffset::from(14), &ctx),
+        Some(Description {
+            token: "-encoding".to_string().spanned(Span::new(12, 21)),
+            description_text: None,
+            suggestion_type: SuggestionType::Option(
+                MatchRequirement::UniquePrefixOnly,
+                OptionCaseSensitivity::CaseInsensitive
+            ),
+        })
+    );
+}

--- a/crates/warp_completer/src/completer/engine/flag/legacy.rs
+++ b/crates/warp_completer/src/completer/engine/flag/legacy.rs
@@ -18,9 +18,22 @@ fn short_hand_flag_suggestions(
     signature: &SpecSignature,
     partial_without_dashes: &str,
 ) -> impl Iterator<Item = MatchedSuggestion> {
+    // A single-dash token only reads as a bundle of short-hand flags (e.g. `ssh -Xv`) when
+    // every character is a known short flag of the command. Attached-value tokens such as
+    // CMake's `-DWITH_TESTS(=OFF)` are not bundles: without this check, a trailing character
+    // that happened to be a short flag (e.g. CMake's `-S`) exactly-matched the whole token as
+    // that option, coloring some `-D...=...` definitions as flags and leaving others plain
+    // (#9820).
+    let is_plausible_short_flag_bundle = !partial_without_dashes.is_empty()
+        && partial_without_dashes.chars().all(|c| {
+            signature
+                .short_hand_flags()
+                .any(|flag| flag.name.chars().eq([c]))
+        });
+
     signature
         .short_hand_flags()
-        .filter_map(|flag| {
+        .filter_map(move |flag| {
             // Since short hand flags can be written one after the other
             // (e.g. ssh -Xv), we can't just prefix match the flag against partial.
             // Instead, the logic below assumes that a short hand flag can only be used once.
@@ -32,10 +45,11 @@ fn short_hand_flag_suggestions(
             // typed, so we can provide a suggestion for the current short hand flags.
             // This suggestion is used so we have an entry for the current flags in the
             // completions menu, and also in our Describe API.
-            let is_current_flag = partial_without_dashes
-                .chars()
-                .last()
-                .is_some_and(|c| c.to_string() == flag.name);
+            let is_current_flag = is_plausible_short_flag_bundle
+                && partial_without_dashes
+                    .chars()
+                    .last()
+                    .is_some_and(|c| c.to_string() == flag.name);
             let should_include_flag = !is_flag_already_included || is_current_flag;
             should_include_flag.then(|| {
                 let replacement_text = if is_current_flag {

--- a/crates/warp_completer/src/completer/engine/flag/v2.rs
+++ b/crates/warp_completer/src/completer/engine/flag/v2.rs
@@ -91,13 +91,29 @@ fn short_hand_flag_suggestions(
             return Box::new(iter::empty());
         };
 
+    // A single-dash token only reads as a bundle of short-hand flags (e.g. `ssh -Xv`) when
+    // every character is a known short flag of the command. Attached-value tokens such as
+    // CMake's `-DWITH_TESTS(=OFF)` are not bundles: without this check, a trailing character
+    // that happened to be a short flag (e.g. CMake's `-S`) exactly-matched the whole token as
+    // that option, coloring some `-D...=...` definitions as flags and leaving others plain
+    // (#9820).
+    let is_plausible_short_flag_bundle = !partial_flag_name.is_empty()
+        && partial_flag_name.chars().all(|c| {
+            command_signature
+                .options
+                .iter()
+                .flat_map(|option| option.name.iter())
+                .filter(|name| is_short_hand_flag_name(name))
+                .any(|name| name[1..].chars().eq([c]))
+        });
+
     Box::new(
         command_signature
             .options
             .iter()
             .flat_map(|option| option.name.iter().map(move |name| (option, name)))
             .filter(|(_, name)| name.starts_with(prefix))
-            .filter_map(|(option, name)| {
+            .filter_map(move |(option, name)| {
                 if is_short_hand_flag_name(name) {
                     // Multiple short-hand flags can be specified in a single token with a leading
                     // '-' (e.g. ssh -Xv). Do not suggest a shorthand flag if it has already been
@@ -105,10 +121,11 @@ fn short_hand_flag_suggestions(
                     // always returns a suggestion if it exactly matches the current token.
                     let name_without_prefix = name.trim_start_matches('-');
                     let is_flag_already_included = partial_flag_name.contains(name_without_prefix);
-                    let is_current_flag = partial_flag_name
-                        .chars()
-                        .last()
-                        .is_some_and(|c| c.to_string() == name_without_prefix);
+                    let is_current_flag = is_plausible_short_flag_bundle
+                        && partial_flag_name
+                            .chars()
+                            .last()
+                            .is_some_and(|c| c.to_string() == name_without_prefix);
                     (!is_flag_already_included || is_current_flag).then(|| {
                         let replacement_text = if is_current_flag {
                             // The replacement text should be exactly the existing flags.
@@ -170,3 +187,7 @@ fn is_short_hand_flag_name(name: &str) -> bool {
 fn is_long_hand_flag_name(name: &str) -> bool {
     name.starts_with('-') && !is_short_hand_flag_name(name)
 }
+
+#[cfg(test)]
+#[path = "v2_tests.rs"]
+mod tests;

--- a/crates/warp_completer/src/completer/engine/flag/v2_tests.rs
+++ b/crates/warp_completer/src/completer/engine/flag/v2_tests.rs
@@ -1,0 +1,64 @@
+use super::*;
+use crate::meta::SpannedItem;
+use crate::signatures::Opt;
+
+fn opt(names: &[&str]) -> Opt {
+    Opt {
+        name: names.iter().map(|name| name.to_string()).collect(),
+        ..Default::default()
+    }
+}
+
+fn command_with_options(name: &str, options: Vec<Opt>) -> Command {
+    Command {
+        name: name.to_string(),
+        options,
+        ..Default::default()
+    }
+}
+
+fn flag_location(command_name: &str, token: &str) -> Spanned<LocationType> {
+    LocationType::Flag {
+        command_name: command_name.to_string().spanned_unknown(),
+        flag_name: Some(token.to_string().spanned_unknown()),
+    }
+    .spanned_unknown()
+}
+
+/// Regression test for #9820: a CMake definition such as `-DWITH_TESTS` is not a bundle of
+/// short-hand flags, so it must not exactly-match an option just because its final character
+/// (`S`) happens to be a known short flag. That spurious exact match is what colored some
+/// `-D...=...` definitions as options while leaving others plain.
+#[test]
+fn attached_value_token_is_not_treated_as_short_flag_bundle() {
+    let cmake = command_with_options("cmake", vec![opt(&["-S"]), opt(&["-D"]), opt(&["-G"])]);
+    let location = flag_location("cmake", "-DWITH_TESTS");
+
+    let suggestions = complete(MatchStrategy::CaseSensitive, &location, Some(&cmake));
+
+    assert!(
+        !suggestions
+            .iter()
+            .any(|matched| matched.suggestion.replacement == "-DWITH_TESTS"),
+        "token whose characters are not all known short flags must not exact-match as a \
+         short-flag bundle: {suggestions:?}"
+    );
+}
+
+/// Genuine short-flag bundles (every character is a known short flag) keep their
+/// current-token exact match so the Describe API can annotate e.g. `ssh -Xv`.
+#[test]
+fn genuine_short_flag_bundle_still_matches_current_token() {
+    let ssh = command_with_options("ssh", vec![opt(&["-X"]), opt(&["-v"]), opt(&["-A"])]);
+    let location = flag_location("ssh", "-Xv");
+
+    let suggestions = complete(MatchStrategy::CaseSensitive, &location, Some(&ssh));
+
+    assert!(
+        suggestions
+            .iter()
+            .any(|matched| matched.suggestion.replacement == "-Xv"),
+        "a token made entirely of known short flags must keep its current-token match: \
+         {suggestions:?}"
+    );
+}

--- a/crates/warp_completer/src/util.rs
+++ b/crates/warp_completer/src/util.rs
@@ -107,6 +107,9 @@ async fn get_token_descriptions<'a, T: CompletionContext>(
                     buffer_text,
                     &current_command_span,
                     flag_token.clone(),
+                    // The flag part of a `-...=...` token is an attached-value flag, not a
+                    // bundle of short-hand flags (#9820).
+                    true,
                     completion_context,
                 )
                 .await;
@@ -124,6 +127,7 @@ async fn get_token_descriptions<'a, T: CompletionContext>(
                         buffer_text,
                         &current_command_span,
                         value_token.clone(),
+                        false,
                         completion_context,
                     )
                     .await;
@@ -138,6 +142,7 @@ async fn get_token_descriptions<'a, T: CompletionContext>(
                     buffer_text,
                     &current_command_span,
                     token.clone(),
+                    false,
                     completion_context,
                 )
                 .await;


### PR DESCRIPTION
Resolves #9820.

## Problem

Typing a CMake command like `cmake -DWITH_TESTS=OFF -DWITH_DOCS=ON ...` colors some `-D...` definitions as options and leaves others plain — apparently at random.

## Root cause

Token descriptions split `--flag=value` tokens at `=`, so `-DWITH_TESTS=OFF` is described as the flag token `-DWITH_TESTS` plus the value `OFF`. The flag engines (v2 and legacy) then interpret any single-dash multi-character token as a *bundle* of short-hand flags (the `ssh -Xv` pattern) and produce a current-token exact match whenever the **last character** happens to be a known short flag. For CMake, `-DWITH_TESTS` ends in `S` — a known short option (`-S`) — so the whole token matched and got option coloring; `-DWITH_DOCS`… ends in `S` too, but e.g. `-DWITH_FOO` doesn't, so it stayed plain. Hence the "randomness": it depends on the final letter.

## Fix

A single-dash token is only treated as a short-flag bundle when **every** character is a known short flag of the command — mirrored in both `flag/v2.rs` and `flag/legacy.rs`. `-DWITH_TESTS` (W/I/T/H/_/… are not all cmake short flags) no longer exact-matches, so all `-D...=...` definitions render consistently. Genuine bundles like `ssh -Xv` (X and v both known) keep their current-token match, preserving Describe behavior.

## Tests

Two regression tests in `flag/v2_tests.rs`:
- `attached_value_token_is_not_treated_as_short_flag_bundle` — `-DWITH_TESTS` against a cmake-like signature (`-S`, `-D`, `-G`) must produce no exact `-DWITH_TESTS` match. **Verified this fails without the fix** (RED→GREEN).
- `genuine_short_flag_bundle_still_matches_current_token` — `-Xv` against an ssh-like signature keeps its match.

Full `warp_completer` suite: 119 passed / 0 failed. `cargo fmt` + `clippy --tests` clean.
