### PR TITLE
Add NLD support to TUI

### DIFF
--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -851,7 +851,7 @@ define_settings_group!(AISettings, settings: [
         default: true,
         supported_platforms: SupportedPlatforms::ALL,
         sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
-        surface: settings::SettingSurfaces::GUI,
+        surface: settings::SettingSurfaces::ALL,
         private: false,
         toml_path: "agents.warp_agent.input.ai_auto_detection_enabled",
         description: "Controls whether AI automatically detects natural language input.",

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -2,6 +2,7 @@
 
 pub use repo_metadata::repositories::RepoDetectionSource;
 pub use warp_cli::agent::Harness;
+use warp_completer::completer::{CompletionContext as _, TopLevelCommandCaseSensitivity};
 use warp_completer::signatures::CommandRegistry;
 use warpui::SingletonEntity as _;
 
@@ -169,6 +170,42 @@ pub fn tui_completion_session_context(
         current_working_directory,
         app,
     ))
+}
+
+/// Returns whether `command` exactly matches a top-level command available in
+/// the TUI's live shell completion context.
+pub fn tui_completion_context_has_exact_command(
+    completion_context: &SessionContext,
+    command: &str,
+) -> bool {
+    let case_sensitivity = completion_context.command_case_sensitivity();
+    let is_live_shell_command =
+        completion_context
+            .top_level_commands()
+            .any(|candidate| match case_sensitivity {
+                TopLevelCommandCaseSensitivity::CaseSensitive => candidate == command,
+                TopLevelCommandCaseSensitivity::CaseInsensitive => {
+                    candidate.eq_ignore_ascii_case(command)
+                }
+            });
+    if is_live_shell_command {
+        return true;
+    }
+
+    #[cfg(feature = "completions_v2")]
+    {
+        completion_context
+            .command_registry()
+            .get_signature(command)
+            .is_some()
+    }
+    #[cfg(not(feature = "completions_v2"))]
+    {
+        completion_context
+            .command_registry()
+            .signature_from_line(command, case_sensitivity)
+            .is_some()
+    }
 }
 
 /// Returns whether cloud conversation metadata failed to load.

--- a/app/src/tui_export.rs
+++ b/app/src/tui_export.rs
@@ -2,6 +2,7 @@
 
 pub use repo_metadata::repositories::RepoDetectionSource;
 pub use warp_cli::agent::Harness;
+use warp_completer::signatures::CommandRegistry;
 use warpui::SingletonEntity as _;
 
 pub use crate::ai::agent::api::ServerConversationToken;
@@ -85,6 +86,7 @@ pub use crate::code::DiffResult;
 pub use crate::code_review::git_repo_model::{
     GitRepoModels, GitRepoStatusModel, GitStatusMetadata,
 };
+pub use crate::completer::SessionContext;
 pub use crate::search::slash_command_menu::static_commands::commands::{
     self as slash_commands, COMMAND_REGISTRY,
 };
@@ -97,6 +99,7 @@ pub use crate::terminal::conversation_restoration::{
     RestoredConversationExchange,
 };
 pub use crate::terminal::event::AfterBlockCompletedEvent;
+pub use crate::terminal::input::decorations::parse_current_commands_and_tokens;
 pub use crate::terminal::input::models::{query_model_picker_choices, ModelPickerChoice};
 pub use crate::terminal::input::skills::{
     query_selectable_skills, AcceptSkill, SelectableSkill,
@@ -150,6 +153,23 @@ pub use crate::tui::{
 };
 pub use crate::util::repo_detection::{detect_possible_git_repo, RepoDetectionSessionType};
 pub use crate::util::time_format::format_elapsed_seconds;
+
+/// Builds the live-shell completion context used to parse TUI input for NLD.
+pub fn tui_completion_session_context(
+    active_session: &ActiveSession,
+    current_working_directory: String,
+    app: &warpui::AppContext,
+) -> Option<SessionContext> {
+    let session = active_session.session(app)?;
+    let current_working_directory =
+        session.convert_directory_to_typed_path_buf(current_working_directory);
+    Some(SessionContext::new(
+        session,
+        CommandRegistry::global_instance(),
+        current_working_directory,
+        app,
+    ))
+}
 
 /// Returns whether cloud conversation metadata failed to load.
 pub fn agent_conversations_cloud_metadata_load_failed(app: &warpui::AppContext) -> bool {

--- a/crates/warp_tui/src/input/view.rs
+++ b/crates/warp_tui/src/input/view.rs
@@ -26,8 +26,8 @@ use std::ops::Range;
 use string_offset::CharOffset;
 use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp::tui_export::{
-    AcceptSlashCommandOrSavedPrompt, BlocklistAIInputModel, InputTypeAutoDetectionSource, LLMId,
-    TuiMcpAction,
+    AcceptSlashCommandOrSavedPrompt, BlocklistAIInputModel, InputType,
+    InputTypeAutoDetectionSource, LLMId, TuiMcpAction,
 };
 use warp_editor::model::{CoreEditorModel, PlainTextEditorModel};
 use warp_editor::selection::TextUnit;
@@ -575,7 +575,7 @@ pub struct TuiInputView {
     /// editor session state the input drives: viewport scroll (char-cell
     /// render state) and drag-selection state (selection model).
     model: ModelHandle<CodeEditorModel>,
-    /// Shared input-mode state driving `!` shell-mode handling.
+    /// Shared input-mode state driving NLD and explicit shell-mode handling.
     input_mode: ModelHandle<BlocklistAIInputModel>,
     /// Single authoritative menu mode, mirroring the GUI input's suggestions mode.
     suggestions_mode: ModelHandle<TuiInputSuggestionsModeModel>,
@@ -607,7 +607,7 @@ impl TuiInputView {
     /// The model carries the terminal width (set via
     /// [`CodeEditorModel::new_tui`]); the view does not keep its own copy.
     ///
-    /// `input_mode` is the shared input-mode model backing `!` shell-mode
+    /// `input_mode` is the shared input-mode model backing detected and explicit shell-mode
     /// handling; the view re-renders whenever the mode changes.
     ///
     /// Subscribes to [`CodeEditorModelEvent::ContentChanged`] to trigger re-renders
@@ -640,7 +640,7 @@ impl TuiInputView {
         }
     }
 
-    /// Whether the input is in `!` shell mode (locked shell input).
+    /// Whether the input is in detected or explicitly locked shell mode.
     pub(crate) fn is_shell_mode(&self, ctx: &AppContext) -> bool {
         input_mode_policy::is_shell_mode(self.input_mode.as_ref(ctx))
     }
@@ -655,9 +655,11 @@ impl TuiInputView {
         self.model.as_ref(ctx).content().as_ref(ctx).is_empty()
     }
 
-    /// Clears the input buffer and resets the viewport scroll.
+    /// Clears the input buffer, resets to the setting-derived agent mode, and
+    /// resets the viewport scroll.
     pub fn clear(&mut self, ctx: &mut ViewContext<Self>) {
         self.model.update(ctx, |m, ctx| m.clear_buffer(ctx));
+        self.reset_to_default_agent_mode(ctx);
         // The cursor is back at the buffer start, so following it scrolls the
         // viewport back to the top.
         self.follow_cursor(ctx);
@@ -714,7 +716,7 @@ impl TuiInputView {
 
     /// The editor element for this frame, boxed for the render tree.
     fn render_input(&self, ctx: &AppContext) -> Box<dyn TuiElement> {
-        Box::new(self.render_element(ctx))
+        self.render_element(ctx).finish()
     }
     pub(crate) fn set_text(&mut self, text: &str, ctx: &mut ViewContext<Self>) {
         self.model.update(ctx, |m, ctx| {
@@ -1132,13 +1134,27 @@ impl TuiInputView {
         });
     }
 
-    /// Restores the TUI's default agent input mode; any typed text is
-    /// preserved. Also called by the session view after an accepted shell
-    /// submission clears the input.
+    /// Explicitly forces agent mode for the current buffer; any typed text is
+    /// preserved. Clearing or submitting the buffer resumes setting-derived
+    /// autodetection.
     pub(crate) fn exit_shell_mode(&mut self, ctx: &mut ViewContext<Self>) {
         let is_input_buffer_empty = self.plain_text(ctx).is_empty();
         self.input_mode.clone().update(ctx, |input_mode, ctx| {
             input_mode.set_input_config(AI_LOCKED_CONFIG, is_input_buffer_empty, None, ctx);
+        });
+    }
+
+    fn reset_to_default_agent_mode(&mut self, ctx: &mut ViewContext<Self>) {
+        let is_autodetection_enabled = self
+            .input_mode
+            .as_ref(ctx)
+            .is_autodetection_enabled_for_current_context(ctx);
+        self.input_mode.clone().update(ctx, |input_mode, ctx| {
+            if is_autodetection_enabled {
+                input_mode.enable_autodetection(InputType::AI, ctx);
+            } else {
+                input_mode.set_input_config(AI_LOCKED_CONFIG, true, None, ctx);
+            }
         });
     }
 

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -10,8 +10,10 @@ use std::rc::Rc;
 use string_offset::CharOffset;
 use warp::appearance::Appearance;
 use warp::editor::CodeEditorModel;
+use warp::settings::AISettingsChangedEvent;
 use warp::tui_export::{
-    AcceptSlashCommandOrSavedPrompt, BlocklistAIInputModel, LLMId, SlashCommandId,
+    AcceptSlashCommandOrSavedPrompt, BlocklistAIInputModel, ConversationSelectionEvent,
+    InputConfig, InputModePolicy, InputType, LLMId, PolicyConfigUpdate, SlashCommandId,
     SlashCommandMixer,
 };
 use warp_editor::model::CoreEditorModel;
@@ -37,7 +39,7 @@ use crate::inline_menu::{
     TuiInlineMenu, TuiInlineMenuAccepted, TuiInlineMenuHandle, TuiInlineMenuHeader,
     TuiInlineMenuSnapshot, TuiInlineMenuStatus,
 };
-use crate::input_mode_policy::TuiInputModePolicy;
+use crate::input_mode_policy::{TuiInputModePolicy, AI_LOCKED_CONFIG};
 use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
 use crate::model_menu::TuiModelMenuModel;
 use crate::slash_commands::{TuiSlashCommandModel, TuiSlashCommandRow};
@@ -45,6 +47,41 @@ use crate::test_fixtures::add_test_semantic_selection;
 use crate::tui_builder::TuiUiBuilder;
 
 const W: u16 = 80;
+
+struct TestInputModePolicy;
+
+impl InputModePolicy for TestInputModePolicy {
+    fn initial_config(&self, _app: &AppContext) -> InputConfig {
+        AI_LOCKED_CONFIG
+    }
+
+    fn allows_locked_ai_input(&self, _app: &AppContext) -> bool {
+        true
+    }
+
+    fn is_autodetection_enabled(&self, _app: &AppContext) -> bool {
+        false
+    }
+
+    fn config_on_conversation_selection_changed(
+        &self,
+        _event: &ConversationSelectionEvent,
+        _current: InputConfig,
+        _app: &AppContext,
+    ) -> Option<PolicyConfigUpdate> {
+        None
+    }
+
+    fn config_on_ai_settings_changed(
+        &self,
+        _event: &AISettingsChangedEvent,
+        _current: InputConfig,
+        _is_autodetection_enabled_for_current_context: bool,
+        _app: &AppContext,
+    ) -> Option<PolicyConfigUpdate> {
+        None
+    }
+}
 
 #[test]
 fn input_escape_context_is_present_only_while_escape_is_handled() {
@@ -255,7 +292,7 @@ fn build_view(ctx: &mut AppContext) -> ViewHandle<TuiInputView> {
     // singleton, so register a mock one before constructing the editor.
     ctx.add_singleton_model(|_| Appearance::mock());
     add_test_semantic_selection(ctx);
-    let input_mode = BlocklistAIInputModel::mock(Rc::new(TuiInputModePolicy), ctx);
+    let input_mode = BlocklistAIInputModel::mock(Rc::new(TestInputModePolicy), ctx);
     let suggestions_mode = add_suggestions_mode(ctx, TuiInputSuggestionsMode::Closed);
     let (_window_id, view) = ctx.add_tui_window(
         AddWindowOptions {
@@ -316,7 +353,7 @@ fn build_view_with_inline_menu(
     ctx.add_singleton_model(|_| Appearance::mock());
     add_test_semantic_selection(ctx);
     let input_model = ctx.add_model(|ctx| CodeEditorModel::new_tui(W, ctx));
-    let input_mode = BlocklistAIInputModel::mock(Rc::new(TuiInputModePolicy), ctx);
+    let input_mode = BlocklistAIInputModel::mock(Rc::new(TestInputModePolicy), ctx);
     let suggestions_mode = add_suggestions_mode(ctx, TuiInputSuggestionsMode::SlashCommands);
     let mixer = ctx.add_model(|_| SlashCommandMixer::new());
     let ids = [SlashCommandId::new(), SlashCommandId::new()];
@@ -367,7 +404,7 @@ fn build_view_with_model_menu(
     ctx.add_singleton_model(|_| Appearance::mock());
     add_test_semantic_selection(ctx);
     let input_model = ctx.add_model(|ctx| CodeEditorModel::new_tui(W, ctx));
-    let input_mode = BlocklistAIInputModel::mock(Rc::new(TuiInputModePolicy), ctx);
+    let input_mode = BlocklistAIInputModel::mock(Rc::new(TestInputModePolicy), ctx);
     let suggestions_mode = add_suggestions_mode(ctx, TuiInputSuggestionsMode::ModelSelector);
     let id = LLMId::from("gpt-5");
     let id_for_model = id.clone();
@@ -1445,6 +1482,51 @@ fn bang_at_start_enters_shell_mode() {
             type_str(&view, ctx, "!ls");
             assert!(view.as_ref(ctx).is_shell_mode(ctx));
             assert_eq!(text(&view, ctx), "ls", "the `!` must not be inserted");
+        });
+    });
+}
+
+#[test]
+fn autodetected_unlocked_shell_uses_shell_mode_ui() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            let input_mode = view.as_ref(ctx).input_mode.clone();
+            input_mode.update(ctx, |input_mode, ctx| {
+                input_mode.set_input_config(
+                    InputConfig {
+                        input_type: InputType::Shell,
+                        is_locked: false,
+                    },
+                    false,
+                    None,
+                    ctx,
+                );
+            });
+
+            assert!(view.as_ref(ctx).is_shell_mode(ctx));
+            let mut element = view.as_ref(ctx).render(ctx);
+            let mut rendered_views = EntityIdMap::default();
+            let mut layout_ctx = TuiLayoutContext {
+                rendered_views: &mut rendered_views,
+            };
+            let size = element.layout(
+                TuiConstraint::loose(TuiSize::new(W, 20)),
+                &mut layout_ctx,
+                ctx,
+            );
+            let area = TuiRect::new(0, 0, size.width, size.height);
+            let mut buffer = TuiBuffer::empty(area);
+            let mut paint_ctx = TuiPaintContext::new(&mut rendered_views);
+            {
+                let mut surface = TuiPaintSurface::new(&mut buffer);
+                element.render(
+                    TuiScreenPosition::new(i32::from(area.x), i32::from(area.y)),
+                    &mut surface,
+                    &mut paint_ctx,
+                );
+            }
+            assert!(buffer.to_lines()[0].starts_with("! "));
         });
     });
 }

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -39,7 +39,7 @@ use crate::inline_menu::{
     TuiInlineMenu, TuiInlineMenuAccepted, TuiInlineMenuHandle, TuiInlineMenuHeader,
     TuiInlineMenuSnapshot, TuiInlineMenuStatus,
 };
-use crate::input_mode_policy::{TuiInputModePolicy, AI_LOCKED_CONFIG};
+use crate::input_mode_policy::AI_LOCKED_CONFIG;
 use crate::input_suggestions_mode::{TuiInputSuggestionsMode, TuiInputSuggestionsModeModel};
 use crate::model_menu::TuiModelMenuModel;
 use crate::slash_commands::{TuiSlashCommandModel, TuiSlashCommandRow};
@@ -317,7 +317,7 @@ fn build_view_with_conversation_menu(
     ctx.add_singleton_model(|_| Appearance::mock());
     add_test_semantic_selection(ctx);
     let input_model = ctx.add_model(|ctx| CodeEditorModel::new_tui(W, ctx));
-    let input_mode = BlocklistAIInputModel::mock(Rc::new(TuiInputModePolicy), ctx);
+    let input_mode = BlocklistAIInputModel::mock(Rc::new(TestInputModePolicy), ctx);
     let suggestions_mode = add_suggestions_mode(ctx, TuiInputSuggestionsMode::Closed);
     let menu_model = ctx.add_model(|_| TestConversationMenu {
         is_open: false,

--- a/crates/warp_tui/src/input/view_tests.rs
+++ b/crates/warp_tui/src/input/view_tests.rs
@@ -1487,6 +1487,22 @@ fn bang_at_start_enters_shell_mode() {
 }
 
 #[test]
+fn explicit_shell_mode_survives_deleting_the_buffer() {
+    App::test((), |mut app| async move {
+        app.update(|ctx| {
+            let view = build_view(ctx);
+            type_str(&view, ctx, "!cargo");
+            for _ in 0.."cargo".chars().count() {
+                dispatch(&view, ctx, &[TuiInputAction::Backspace]);
+            }
+
+            assert_eq!(text(&view, ctx), "");
+            assert!(view.as_ref(ctx).is_shell_mode(ctx));
+        });
+    });
+}
+
+#[test]
 fn autodetected_unlocked_shell_uses_shell_mode_ui() {
     App::test((), |mut app| async move {
         app.update(|ctx| {

--- a/crates/warp_tui/src/input_mode_policy.rs
+++ b/crates/warp_tui/src/input_mode_policy.rs
@@ -1,15 +1,21 @@
 //! TUI implementation of [`InputModePolicy`].
 
+use warp::settings::{AISettings, AISettingsChangedEvent};
 use warp::tui_export::{
-    AISettingsChangedEvent, BlocklistAIInputModel, ConversationSelectionEvent, InputConfig,
-    InputModePolicy, InputType, PolicyConfigUpdate,
+    BlocklistAIInputModel, ConversationSelectionEvent, InputConfig, InputModePolicy, InputType,
+    PolicyConfigUpdate,
 };
-use warpui_core::AppContext;
+use warpui_core::{AppContext, SingletonEntity};
 
-/// The TUI's default input config: agent input, no autodetection.
+/// The TUI's agent config when autodetection is disabled or explicitly overridden.
 pub(crate) const AI_LOCKED_CONFIG: InputConfig = InputConfig {
     input_type: InputType::AI,
     is_locked: true,
+};
+/// The TUI's default agent config while autodetection is enabled.
+pub(crate) const AI_UNLOCKED_CONFIG: InputConfig = InputConfig {
+    input_type: InputType::AI,
+    is_locked: false,
 };
 
 /// The config for `!` shell mode.
@@ -17,30 +23,46 @@ pub(crate) const SHELL_LOCKED_CONFIG: InputConfig = InputConfig {
     input_type: InputType::Shell,
     is_locked: true,
 };
-
-/// Whether the shared input mode is in `!` shell mode ([`SHELL_LOCKED_CONFIG`]).
-/// The single definition of "in shell mode" for every TUI read site.
-pub(crate) fn is_shell_mode(input_mode: &BlocklistAIInputModel) -> bool {
-    input_mode.input_config() == SHELL_LOCKED_CONFIG
+fn agent_config_for_autodetection(is_autodetection_enabled: bool) -> InputConfig {
+    if is_autodetection_enabled {
+        AI_UNLOCKED_CONFIG
+    } else {
+        AI_LOCKED_CONFIG
+    }
 }
 
-/// TUI input-mode policy: the input is agent-first and deterministic. It
-/// starts locked to AI, may always be locked to AI, has no autodetection (yet),
-/// and conversation/settings transitions never rewrite the mode — only
-/// explicit user actions (e.g. the `!` shell prefix) change it.
+fn config_on_autodetection_setting_changed(
+    current: InputConfig,
+    is_autodetection_enabled: bool,
+) -> Option<InputConfig> {
+    // Keep the explicit `!` override until the user exits it. Other states
+    // return to the setting-derived, agent-first default.
+    (current != SHELL_LOCKED_CONFIG)
+        .then(|| agent_config_for_autodetection(is_autodetection_enabled))
+}
+
+/// Whether the shared input mode is shell input, detected or explicitly locked.
+/// The single definition of "in shell mode" for every TUI read site.
+pub(crate) fn is_shell_mode(input_mode: &BlocklistAIInputModel) -> bool {
+    input_mode.input_type() == InputType::Shell
+}
+
+/// TUI input-mode policy: the input is agent-first, with autodetection driven
+/// by the shared AI setting. Conversation transitions do not rewrite the mode;
+/// explicit user actions may still lock the input to Agent or Shell.
 pub(crate) struct TuiInputModePolicy;
 
 impl InputModePolicy for TuiInputModePolicy {
-    fn initial_config(&self, _app: &AppContext) -> InputConfig {
-        AI_LOCKED_CONFIG
+    fn initial_config(&self, app: &AppContext) -> InputConfig {
+        agent_config_for_autodetection(AISettings::as_ref(app).is_ai_autodetection_enabled(app))
     }
 
     fn allows_locked_ai_input(&self, _app: &AppContext) -> bool {
         true
     }
 
-    fn is_autodetection_enabled(&self, _app: &AppContext) -> bool {
-        false
+    fn is_autodetection_enabled(&self, app: &AppContext) -> bool {
+        AISettings::as_ref(app).is_ai_autodetection_enabled(app)
     }
 
     fn config_on_conversation_selection_changed(
@@ -54,11 +76,24 @@ impl InputModePolicy for TuiInputModePolicy {
 
     fn config_on_ai_settings_changed(
         &self,
-        _event: &AISettingsChangedEvent,
-        _current: InputConfig,
-        _is_autodetection_enabled_for_current_context: bool,
+        event: &AISettingsChangedEvent,
+        current: InputConfig,
+        is_autodetection_enabled_for_current_context: bool,
         _app: &AppContext,
     ) -> Option<PolicyConfigUpdate> {
-        None
+        match event {
+            AISettingsChangedEvent::AIAutoDetectionEnabled { .. } => {
+                config_on_autodetection_setting_changed(
+                    current,
+                    is_autodetection_enabled_for_current_context,
+                )
+                .map(PolicyConfigUpdate::new)
+            }
+            _ => None,
+        }
     }
 }
+
+#[cfg(test)]
+#[path = "input_mode_policy_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/input_mode_policy_tests.rs
+++ b/crates/warp_tui/src/input_mode_policy_tests.rs
@@ -1,0 +1,40 @@
+use warp::tui_export::{InputConfig, InputType};
+
+use super::{
+    agent_config_for_autodetection, config_on_autodetection_setting_changed, AI_LOCKED_CONFIG,
+    AI_UNLOCKED_CONFIG, SHELL_LOCKED_CONFIG,
+};
+
+#[test]
+fn agent_default_tracks_autodetection_setting() {
+    assert_eq!(agent_config_for_autodetection(true), AI_UNLOCKED_CONFIG);
+    assert_eq!(agent_config_for_autodetection(false), AI_LOCKED_CONFIG);
+}
+
+#[test]
+fn setting_change_returns_to_agent_default() {
+    let detected_shell = InputConfig {
+        input_type: InputType::Shell,
+        is_locked: false,
+    };
+    assert_eq!(
+        config_on_autodetection_setting_changed(detected_shell, false),
+        Some(AI_LOCKED_CONFIG)
+    );
+    assert_eq!(
+        config_on_autodetection_setting_changed(AI_LOCKED_CONFIG, true),
+        Some(AI_UNLOCKED_CONFIG)
+    );
+}
+
+#[test]
+fn setting_change_preserves_explicit_shell_override() {
+    assert_eq!(
+        config_on_autodetection_setting_changed(SHELL_LOCKED_CONFIG, true),
+        None
+    );
+    assert_eq!(
+        config_on_autodetection_setting_changed(SHELL_LOCKED_CONFIG, false),
+        None
+    );
+}

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -13,19 +13,20 @@ use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp::settings::{AISettings, AISettingsChangedEvent};
 use warp::tui_export::{
     block_context_from_terminal_model, build_slash_command_mixer, detect_possible_git_repo,
-    export_conversation_markdown, prepare_conversation_block_restoration,
-    record_saved_prompt_accepted, record_static_slash_command_accepted, saved_prompt_text_for_id,
-    slash_command_selection_behavior, throttle, AIAgentActionId, AIAgentContext,
-    AIAgentPtyWriteMode, AIConversation, AIConversationId, AcceptSlashCommandOrSavedPrompt,
-    ActiveSession, ActiveSessionEvent, AgentConversationEntryId, AgentConversationListEntryState,
-    AgentConversationsModel, AgentInteractionMetadata, AgentViewEntryOrigin, BlockId,
-    BlocklistAIActionModel, BlocklistAIContextModel, BlocklistAIController,
-    BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIInputModel, CLISubagentController,
-    CLISubagentEvent, CLISubagentTarget, CancellationReason, ChangelogModel, ChangelogModelEvent,
-    ChangelogRequestType, CloudConversationData, CommandExecutionSource, ConversationFileExport,
-    ConversationSelection, ConversationSelectionHandle, ConversationUsageTotals,
-    ExecuteCommandEvent, GetRelevantFilesController, GitRepoModels, GitRepoStatusModel,
-    GitStatusMetadata, LLMId, LLMPreferences, LLMPreferencesEvent, ModelEvent,
+    export_conversation_markdown, parse_current_commands_and_tokens,
+    prepare_conversation_block_restoration, record_saved_prompt_accepted,
+    record_static_slash_command_accepted, saved_prompt_text_for_id,
+    slash_command_selection_behavior, throttle, tui_completion_session_context, AIAgentActionId,
+    AIAgentContext, AIAgentPtyWriteMode, AIConversation, AIConversationId,
+    AcceptSlashCommandOrSavedPrompt, ActiveSession, ActiveSessionEvent, AgentConversationEntryId,
+    AgentConversationListEntryState, AgentConversationsModel, AgentInteractionMetadata,
+    AgentViewEntryOrigin, BlockId, BlocklistAIActionModel, BlocklistAIContextModel,
+    BlocklistAIController, BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIInputModel,
+    CLISubagentController, CLISubagentEvent, CLISubagentTarget, CancellationReason, ChangelogModel,
+    ChangelogModelEvent, ChangelogRequestType, CloudConversationData, CommandExecutionSource,
+    ConversationFileExport, ConversationSelection, ConversationSelectionHandle,
+    ConversationUsageTotals, ExecuteCommandEvent, GetRelevantFilesController, GitRepoModels,
+    GitRepoStatusModel, GitStatusMetadata, LLMId, LLMPreferences, LLMPreferencesEvent, ModelEvent,
     ParsedSlashCommandInput, PtyIntent, PtyIntentEvent, RepoDetectionSessionType,
     RepoDetectionSource, ServerConversationToken, ShellCommandExecutorEvent, SizeInfo, SizeUpdate,
     SkillReference, SlashCommandDataSource as _, SlashCommandSelectionBehavior, StaticCommand,
@@ -86,6 +87,7 @@ use crate::zero_state::render_zero_state;
 /// Width used before the first layout pass pushes the real terminal width into the editor.
 const INITIAL_INPUT_WIDTH: u16 = 80;
 const MAX_INPUT_TEXT_ROWS: u16 = 6;
+const INPUT_AUTODETECTION_DEBOUNCE: Duration = Duration::from_millis(10);
 
 /// The footer hint shown while the ctrl-c exit confirmation is armed.
 const CTRL_C_EXIT_HINT: &str = "ctrl-c again to exit";
@@ -161,6 +163,13 @@ fn render_left_footer_hint(
     }
 }
 
+fn should_apply_input_detection(
+    parsed_buffer_text: &str,
+    current_buffer_text: &str,
+    has_active_inline_menu: bool,
+) -> bool {
+    parsed_buffer_text == current_buffer_text && !has_active_inline_menu
+}
 /// Entry point that requested conversation restoration.
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum TuiConversationRestoreOrigin {
@@ -254,6 +263,7 @@ pub(crate) struct TuiTerminalSessionView {
     usage_toggle: UsageToggle,
     ai_context_model: ModelHandle<BlocklistAIContextModel>,
     ai_input_model: ModelHandle<BlocklistAIInputModel>,
+    input_detection_future: Option<SpawnedFutureHandle>,
     terminal_model: Arc<FairMutex<TerminalModel>>,
     /// Last dimensions applied to the terminal model and PTY.
     size_info: SizeInfo,
@@ -689,9 +699,9 @@ impl TuiTerminalSessionView {
         // window it arms survives its own clear.
         let editor_for_footer = input_editor_model.clone();
         ctx.subscribe_to_model(&input_editor_model, move |view, _, event, ctx| {
-            if !matches!(event, CodeEditorModelEvent::ContentChanged { .. }) {
+            let CodeEditorModelEvent::ContentChanged { origin } = event else {
                 return;
-            }
+            };
             let is_empty = editor_for_footer
                 .as_ref(ctx)
                 .content()
@@ -700,6 +710,7 @@ impl TuiTerminalSessionView {
             if !is_empty {
                 view.exit_confirmation.disarm();
             }
+            view.handle_input_content_changed(origin.from_user(), ctx);
             ctx.notify();
         });
 
@@ -854,13 +865,16 @@ impl TuiTerminalSessionView {
         // change (click or settings-file hot reload), when model display
         // names arrive from the server post-login, or when the session's
         // working directory changes.
-        ctx.subscribe_to_model(&AISettings::handle(ctx), |_, _, event, ctx| {
+        ctx.subscribe_to_model(&AISettings::handle(ctx), |view, _, event, ctx| {
             if matches!(
                 event,
                 AISettingsChangedEvent::TuiAgentModel { .. }
                     | AISettingsChangedEvent::TuiUsageDisplayMode { .. }
             ) {
                 ctx.notify();
+            }
+            if matches!(event, AISettingsChangedEvent::AIAutoDetectionEnabled { .. }) {
+                view.schedule_input_detection(ctx);
             }
         });
         ctx.subscribe_to_model(&LLMPreferences::handle(ctx), |_, _, event, ctx| {
@@ -984,6 +998,7 @@ impl TuiTerminalSessionView {
             usage_toggle: UsageToggle::default(),
             ai_context_model: context_model,
             ai_input_model,
+            input_detection_future: None,
             terminal_model: model,
             size_info,
             terminal_resize_tx,
@@ -992,6 +1007,93 @@ impl TuiTerminalSessionView {
             next_restore_request_id: 0,
             exit_summary,
         }
+    }
+
+    fn handle_input_content_changed(&mut self, is_user_edit: bool, ctx: &mut ViewContext<Self>) {
+        self.abort_input_detection(ctx);
+        if is_user_edit {
+            self.schedule_input_detection(ctx);
+        }
+    }
+
+    fn abort_input_detection(&mut self, ctx: &mut ViewContext<Self>) {
+        if let Some(future) = self.input_detection_future.take() {
+            future.abort();
+        }
+        self.ai_input_model.update(ctx, |input_mode, _| {
+            input_mode.abort_in_progress_detection();
+        });
+    }
+
+    fn schedule_input_detection(&mut self, ctx: &mut ViewContext<Self>) {
+        self.abort_input_detection(ctx);
+        if !self
+            .ai_input_model
+            .as_ref(ctx)
+            .should_run_input_autodetection(ctx)
+        {
+            return;
+        }
+
+        let editor = self.input_view.as_ref(ctx).model().as_ref(ctx);
+        let buffer = editor.content().as_ref(ctx);
+        if buffer.is_empty() {
+            return;
+        }
+        let buffer_text = buffer.text().into_string();
+        let Some(current_working_directory) = self.current_working_directory(ctx) else {
+            return;
+        };
+        let Some(completion_context) = tui_completion_session_context(
+            self.active_session.as_ref(ctx),
+            current_working_directory,
+            ctx,
+        ) else {
+            return;
+        };
+        let completion_session = completion_context.session.clone();
+
+        self.input_detection_future = Some(ctx.spawn_abortable(
+            async move {
+                Timer::after(INPUT_AUTODETECTION_DEBOUNCE).await;
+                let parsed =
+                    parse_current_commands_and_tokens(buffer_text.clone(), &completion_context)
+                        .await;
+                (buffer_text, parsed, completion_context)
+            },
+            move |view, (parsed_buffer_text, parsed, completion_context), ctx| {
+                view.input_detection_future = None;
+                let current_buffer_text = {
+                    let editor = view.input_view.as_ref(ctx).model().as_ref(ctx);
+                    editor.content().as_ref(ctx).text().into_string()
+                };
+                let has_active_inline_menu = active_inline_menu(
+                    &view.inline_menus,
+                    view.suggestions_mode.as_ref(ctx).mode(),
+                    ctx,
+                )
+                .is_some();
+                if !should_apply_input_detection(
+                    &parsed_buffer_text,
+                    &current_buffer_text,
+                    has_active_inline_menu,
+                ) {
+                    return;
+                }
+                let session_id = completion_context.session.id();
+                view.ai_input_model.update(ctx, |input_mode, ctx| {
+                    input_mode.detect_and_set_input_type(
+                        parsed,
+                        completion_context,
+                        Some(session_id),
+                        ctx,
+                    );
+                });
+            },
+            move |_, _| {
+                completion_session.cancel_active_commands();
+            },
+        ));
     }
 
     /// Restores an Oz conversation into the TUI's sole conversation surface.
@@ -1584,7 +1686,7 @@ impl TuiTerminalSessionView {
             })
     }
 
-    /// Whether the input is in `!` shell mode (locked shell input).
+    /// Whether the input is in detected or explicitly locked shell mode.
     fn is_shell_mode(&self, ctx: &AppContext) -> bool {
         input_mode_policy::is_shell_mode(self.ai_input_model.as_ref(ctx))
     }
@@ -1675,11 +1777,10 @@ impl TuiTerminalSessionView {
             },
         )));
 
-        // The submission was accepted: clear the input and return to agent mode.
-        self.input_view.update(ctx, |input_view, ctx| {
-            input_view.clear(ctx);
-            input_view.exit_shell_mode(ctx);
-        });
+        // The submission was accepted: clear the input and return to the
+        // setting-derived agent default.
+        self.input_view
+            .update(ctx, |input_view, ctx| input_view.clear(ctx));
     }
 
     /// Sends a prompt to the TUI session's eagerly selected conversation.

--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -13,20 +13,19 @@ use warp::editor::{CodeEditorModel, CodeEditorModelEvent};
 use warp::settings::{AISettings, AISettingsChangedEvent};
 use warp::tui_export::{
     block_context_from_terminal_model, build_slash_command_mixer, detect_possible_git_repo,
-    export_conversation_markdown, parse_current_commands_and_tokens,
-    prepare_conversation_block_restoration, record_saved_prompt_accepted,
-    record_static_slash_command_accepted, saved_prompt_text_for_id,
-    slash_command_selection_behavior, throttle, tui_completion_session_context, AIAgentActionId,
-    AIAgentContext, AIAgentPtyWriteMode, AIConversation, AIConversationId,
-    AcceptSlashCommandOrSavedPrompt, ActiveSession, ActiveSessionEvent, AgentConversationEntryId,
-    AgentConversationListEntryState, AgentConversationsModel, AgentInteractionMetadata,
-    AgentViewEntryOrigin, BlockId, BlocklistAIActionModel, BlocklistAIContextModel,
-    BlocklistAIController, BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIInputModel,
-    CLISubagentController, CLISubagentEvent, CLISubagentTarget, CancellationReason, ChangelogModel,
-    ChangelogModelEvent, ChangelogRequestType, CloudConversationData, CommandExecutionSource,
-    ConversationFileExport, ConversationSelection, ConversationSelectionHandle,
-    ConversationUsageTotals, ExecuteCommandEvent, GetRelevantFilesController, GitRepoModels,
-    GitRepoStatusModel, GitStatusMetadata, LLMId, LLMPreferences, LLMPreferencesEvent, ModelEvent,
+    export_conversation_markdown, prepare_conversation_block_restoration,
+    record_saved_prompt_accepted, record_static_slash_command_accepted, saved_prompt_text_for_id,
+    slash_command_selection_behavior, throttle, AIAgentActionId, AIAgentContext,
+    AIAgentPtyWriteMode, AIConversation, AIConversationId, AcceptSlashCommandOrSavedPrompt,
+    ActiveSession, ActiveSessionEvent, AgentConversationEntryId, AgentConversationListEntryState,
+    AgentConversationsModel, AgentInteractionMetadata, AgentViewEntryOrigin, BlockId,
+    BlocklistAIActionModel, BlocklistAIContextModel, BlocklistAIController,
+    BlocklistAIHistoryEvent, BlocklistAIHistoryModel, BlocklistAIInputModel, CLISubagentController,
+    CLISubagentEvent, CLISubagentTarget, CancellationReason, ChangelogModel, ChangelogModelEvent,
+    ChangelogRequestType, CloudConversationData, CommandExecutionSource, ConversationFileExport,
+    ConversationSelection, ConversationSelectionHandle, ConversationUsageTotals,
+    ExecuteCommandEvent, GetRelevantFilesController, GitRepoModels, GitRepoStatusModel,
+    GitStatusMetadata, LLMId, LLMPreferences, LLMPreferencesEvent, ModelEvent,
     ParsedSlashCommandInput, PtyIntent, PtyIntentEvent, RepoDetectionSessionType,
     RepoDetectionSource, ServerConversationToken, ShellCommandExecutorEvent, SizeInfo, SizeUpdate,
     SkillReference, SlashCommandDataSource as _, SlashCommandSelectionBehavior, StaticCommand,
@@ -83,11 +82,13 @@ use crate::ui::{compact_footer_path, conversation_restore_failed, conversation_r
 use crate::usage::UsageToggle;
 use crate::warping_indicator::{render_response_summary, render_warping_indicator};
 use crate::zero_state::render_zero_state;
+mod input_detection;
+
+use self::input_detection::InputDetectionState;
 
 /// Width used before the first layout pass pushes the real terminal width into the editor.
 const INITIAL_INPUT_WIDTH: u16 = 80;
 const MAX_INPUT_TEXT_ROWS: u16 = 6;
-const INPUT_AUTODETECTION_DEBOUNCE: Duration = Duration::from_millis(10);
 
 /// The footer hint shown while the ctrl-c exit confirmation is armed.
 const CTRL_C_EXIT_HINT: &str = "ctrl-c again to exit";
@@ -161,14 +162,6 @@ fn render_left_footer_hint(
         ),
         None => None,
     }
-}
-
-fn should_apply_input_detection(
-    parsed_buffer_text: &str,
-    current_buffer_text: &str,
-    has_active_inline_menu: bool,
-) -> bool {
-    parsed_buffer_text == current_buffer_text && !has_active_inline_menu
 }
 /// Entry point that requested conversation restoration.
 #[derive(Clone, Copy, Debug)]
@@ -263,7 +256,7 @@ pub(crate) struct TuiTerminalSessionView {
     usage_toggle: UsageToggle,
     ai_context_model: ModelHandle<BlocklistAIContextModel>,
     ai_input_model: ModelHandle<BlocklistAIInputModel>,
-    input_detection_future: Option<SpawnedFutureHandle>,
+    input_detection: InputDetectionState,
     terminal_model: Arc<FairMutex<TerminalModel>>,
     /// Last dimensions applied to the terminal model and PTY.
     size_info: SizeInfo,
@@ -357,6 +350,7 @@ impl TuiTerminalSessionView {
             );
         });
     }
+
     fn detach_cli_subagent_view(
         &mut self,
         block_id: &BlockId,
@@ -998,7 +992,7 @@ impl TuiTerminalSessionView {
             usage_toggle: UsageToggle::default(),
             ai_context_model: context_model,
             ai_input_model,
-            input_detection_future: None,
+            input_detection: InputDetectionState::default(),
             terminal_model: model,
             size_info,
             terminal_resize_tx,
@@ -1007,93 +1001,6 @@ impl TuiTerminalSessionView {
             next_restore_request_id: 0,
             exit_summary,
         }
-    }
-
-    fn handle_input_content_changed(&mut self, is_user_edit: bool, ctx: &mut ViewContext<Self>) {
-        self.abort_input_detection(ctx);
-        if is_user_edit {
-            self.schedule_input_detection(ctx);
-        }
-    }
-
-    fn abort_input_detection(&mut self, ctx: &mut ViewContext<Self>) {
-        if let Some(future) = self.input_detection_future.take() {
-            future.abort();
-        }
-        self.ai_input_model.update(ctx, |input_mode, _| {
-            input_mode.abort_in_progress_detection();
-        });
-    }
-
-    fn schedule_input_detection(&mut self, ctx: &mut ViewContext<Self>) {
-        self.abort_input_detection(ctx);
-        if !self
-            .ai_input_model
-            .as_ref(ctx)
-            .should_run_input_autodetection(ctx)
-        {
-            return;
-        }
-
-        let editor = self.input_view.as_ref(ctx).model().as_ref(ctx);
-        let buffer = editor.content().as_ref(ctx);
-        if buffer.is_empty() {
-            return;
-        }
-        let buffer_text = buffer.text().into_string();
-        let Some(current_working_directory) = self.current_working_directory(ctx) else {
-            return;
-        };
-        let Some(completion_context) = tui_completion_session_context(
-            self.active_session.as_ref(ctx),
-            current_working_directory,
-            ctx,
-        ) else {
-            return;
-        };
-        let completion_session = completion_context.session.clone();
-
-        self.input_detection_future = Some(ctx.spawn_abortable(
-            async move {
-                Timer::after(INPUT_AUTODETECTION_DEBOUNCE).await;
-                let parsed =
-                    parse_current_commands_and_tokens(buffer_text.clone(), &completion_context)
-                        .await;
-                (buffer_text, parsed, completion_context)
-            },
-            move |view, (parsed_buffer_text, parsed, completion_context), ctx| {
-                view.input_detection_future = None;
-                let current_buffer_text = {
-                    let editor = view.input_view.as_ref(ctx).model().as_ref(ctx);
-                    editor.content().as_ref(ctx).text().into_string()
-                };
-                let has_active_inline_menu = active_inline_menu(
-                    &view.inline_menus,
-                    view.suggestions_mode.as_ref(ctx).mode(),
-                    ctx,
-                )
-                .is_some();
-                if !should_apply_input_detection(
-                    &parsed_buffer_text,
-                    &current_buffer_text,
-                    has_active_inline_menu,
-                ) {
-                    return;
-                }
-                let session_id = completion_context.session.id();
-                view.ai_input_model.update(ctx, |input_mode, ctx| {
-                    input_mode.detect_and_set_input_type(
-                        parsed,
-                        completion_context,
-                        Some(session_id),
-                        ctx,
-                    );
-                });
-            },
-            move |_, _| {
-                completion_session.cancel_active_commands();
-            },
-        ));
     }
 
     /// Restores an Oz conversation into the TUI's sole conversation surface.

--- a/crates/warp_tui/src/terminal_session_view/input_detection.rs
+++ b/crates/warp_tui/src/terminal_session_view/input_detection.rs
@@ -1,0 +1,218 @@
+//! TUI input detection coordination and Agent-biased classification gating.
+//!
+//! The parser, completion context, and
+//! [`BlocklistAIInputModel`](warp::tui_export::BlocklistAIInputModel) classifier
+//! are shared with the GUI input. The orchestration remains frontend-specific:
+//! GUI input detection is coupled to command decorations, parsed-token caching,
+//! shared-session edits, and GUI suggestion modes, while the TUI owns a
+//! separate editor, inline menus, future lifecycle, and short-input Agent bias.
+//! Keeping those coordinators separate avoids a broad callback abstraction
+//! while preserving the classification behavior in the shared model.
+
+use std::time::Duration;
+
+use warp::tui_export::{
+    parse_current_commands_and_tokens, tui_completion_context_has_exact_command,
+    tui_completion_session_context, InputType,
+};
+use warp_editor::model::CoreEditorModel;
+use warpui_core::r#async::{SpawnedFutureHandle, Timer};
+use warpui_core::ViewContext;
+
+use super::TuiTerminalSessionView;
+use crate::inline_menu::active_inline_menu;
+
+const INPUT_AUTODETECTION_DEBOUNCE: Duration = Duration::from_millis(10);
+const MIN_STANDALONE_COMMAND_CHARS: usize = 2;
+
+#[derive(Default)]
+pub(super) struct InputDetectionState {
+    future: Option<SpawnedFutureHandle>,
+}
+
+/// The next action the TUI input-detection coordinator should take for a
+/// buffer snapshot. This is not classifier confidence: it prevents empty or
+/// weak partial input from reaching the shared classifier while allowing
+/// non-empty input to be parsed and strong command candidates to be classified.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InputDetectionDecision {
+    /// Return unlocked input to Agent without running detection.
+    ResetToAgent,
+    /// Parse the non-empty buffer to gather command evidence.
+    Parse,
+    /// Run the shared Agent/Shell classifier on the parsed snapshot.
+    Classify,
+}
+
+fn input_detection_decision(
+    buffer_text: &str,
+    parsed_token_count: Option<usize>,
+    first_token_char_count: usize,
+    first_token_has_command_evidence: bool,
+) -> InputDetectionDecision {
+    if buffer_text.trim().is_empty() {
+        return InputDetectionDecision::ResetToAgent;
+    }
+    let Some(parsed_token_count) = parsed_token_count else {
+        return InputDetectionDecision::Parse;
+    };
+    if parsed_token_count >= 2
+        || (parsed_token_count == 1
+            && first_token_char_count >= MIN_STANDALONE_COMMAND_CHARS
+            && first_token_has_command_evidence)
+    {
+        InputDetectionDecision::Classify
+    } else {
+        InputDetectionDecision::ResetToAgent
+    }
+}
+
+fn should_reset_input_to_agent(
+    decision: InputDetectionDecision,
+    is_input_type_locked: bool,
+) -> bool {
+    !is_input_type_locked && decision == InputDetectionDecision::ResetToAgent
+}
+
+fn should_apply_input_detection(
+    parsed_buffer_text: &str,
+    current_buffer_text: &str,
+    has_active_inline_menu: bool,
+) -> bool {
+    parsed_buffer_text == current_buffer_text && !has_active_inline_menu
+}
+
+impl TuiTerminalSessionView {
+    pub(super) fn handle_input_content_changed(
+        &mut self,
+        is_user_edit: bool,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.abort_input_detection(ctx);
+        if is_user_edit {
+            self.schedule_input_detection(ctx);
+        }
+    }
+
+    fn abort_input_detection(&mut self, ctx: &mut ViewContext<Self>) {
+        if let Some(future) = self.input_detection.future.take() {
+            future.abort();
+        }
+        self.ai_input_model.update(ctx, |input_mode, _| {
+            input_mode.abort_in_progress_detection();
+        });
+    }
+
+    fn reset_input_to_agent(
+        &mut self,
+        decision: InputDetectionDecision,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
+        let is_input_type_locked = self.ai_input_model.as_ref(ctx).is_input_type_locked();
+        if !should_reset_input_to_agent(decision, is_input_type_locked) {
+            return false;
+        }
+        self.ai_input_model.update(ctx, |input_mode, ctx| {
+            input_mode.enable_autodetection(InputType::AI, ctx);
+        });
+        true
+    }
+
+    pub(super) fn schedule_input_detection(&mut self, ctx: &mut ViewContext<Self>) {
+        self.abort_input_detection(ctx);
+        let buffer_text = {
+            let editor = self.input_view.as_ref(ctx).model().as_ref(ctx);
+            editor.content().as_ref(ctx).text().into_string()
+        };
+        let decision = input_detection_decision(&buffer_text, None, 0, false);
+        if self.reset_input_to_agent(decision, ctx) {
+            return;
+        }
+        if !self
+            .ai_input_model
+            .as_ref(ctx)
+            .should_run_input_autodetection(ctx)
+        {
+            return;
+        }
+        let Some(current_working_directory) = self.current_working_directory(ctx) else {
+            return;
+        };
+        let Some(completion_context) = tui_completion_session_context(
+            self.active_session.as_ref(ctx),
+            current_working_directory,
+            ctx,
+        ) else {
+            return;
+        };
+        let completion_session = completion_context.session.clone();
+
+        self.input_detection.future = Some(ctx.spawn_abortable(
+            async move {
+                Timer::after(INPUT_AUTODETECTION_DEBOUNCE).await;
+                let parsed =
+                    parse_current_commands_and_tokens(buffer_text.clone(), &completion_context)
+                        .await;
+                (buffer_text, parsed, completion_context)
+            },
+            move |view, (parsed_buffer_text, parsed, completion_context), ctx| {
+                view.input_detection.future = None;
+                let current_buffer_text = {
+                    let editor = view.input_view.as_ref(ctx).model().as_ref(ctx);
+                    editor.content().as_ref(ctx).text().into_string()
+                };
+                let has_active_inline_menu = active_inline_menu(
+                    &view.inline_menus,
+                    view.suggestions_mode.as_ref(ctx).mode(),
+                    ctx,
+                )
+                .is_some();
+                if !should_apply_input_detection(
+                    &parsed_buffer_text,
+                    &current_buffer_text,
+                    has_active_inline_menu,
+                ) {
+                    return;
+                }
+                let first_token = parsed.parsed_tokens.first();
+                let first_token_has_command_evidence = first_token.is_some_and(|token| {
+                    token.token_description.is_some()
+                        || tui_completion_context_has_exact_command(
+                            &completion_context,
+                            token.token.as_str(),
+                        )
+                });
+                let decision = input_detection_decision(
+                    &parsed.buffer_text,
+                    Some(parsed.parsed_tokens.len()),
+                    first_token
+                        .map(|token| token.token.chars().count())
+                        .unwrap_or_default(),
+                    first_token_has_command_evidence,
+                );
+                if view.reset_input_to_agent(decision, ctx) {
+                    return;
+                }
+                if decision != InputDetectionDecision::Classify {
+                    return;
+                }
+                let session_id = completion_context.session.id();
+                view.ai_input_model.update(ctx, |input_mode, ctx| {
+                    input_mode.detect_and_set_input_type(
+                        parsed,
+                        completion_context,
+                        Some(session_id),
+                        ctx,
+                    );
+                });
+            },
+            move |_, _| {
+                completion_session.cancel_active_commands();
+            },
+        ));
+    }
+}
+
+#[cfg(test)]
+#[path = "input_detection_tests.rs"]
+mod tests;

--- a/crates/warp_tui/src/terminal_session_view/input_detection.rs
+++ b/crates/warp_tui/src/terminal_session_view/input_detection.rs
@@ -56,6 +56,10 @@ fn input_detection_decision(
     let Some(parsed_token_count) = parsed_token_count else {
         return InputDetectionDecision::Parse;
     };
+    // Multi-token input has enough context to send through the shared classifier. A single token
+    // is classified only when it has at least two characters and exactly matches command evidence
+    // from the live shell, completion description, or command-signature registry. This keeps short
+    // or partial input biased toward Agent while preserving known standalone commands.
     if parsed_token_count >= 2
         || (parsed_token_count == 1
             && first_token_char_count >= MIN_STANDALONE_COMMAND_CHARS
@@ -74,7 +78,12 @@ fn should_reset_input_to_agent(
     !is_input_type_locked && decision == InputDetectionDecision::ResetToAgent
 }
 
-fn should_apply_input_detection(
+/// Returns whether an asynchronous parse result still applies to the live input.
+///
+/// This only validates snapshot freshness and that the buffer is not serving as an inline-menu
+/// query. [`input_detection_decision`] separately decides whether valid parsed input should reset
+/// to Agent or run through the shared classifier.
+fn parsed_result_is_applicable(
     parsed_buffer_text: &str,
     current_buffer_text: &str,
     has_active_inline_menu: bool,
@@ -167,7 +176,7 @@ impl TuiTerminalSessionView {
                     ctx,
                 )
                 .is_some();
-                if !should_apply_input_detection(
+                if !parsed_result_is_applicable(
                     &parsed_buffer_text,
                     &current_buffer_text,
                     has_active_inline_menu,

--- a/crates/warp_tui/src/terminal_session_view/input_detection_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view/input_detection_tests.rs
@@ -1,0 +1,95 @@
+use super::{
+    input_detection_decision, should_apply_input_detection, should_reset_input_to_agent,
+    InputDetectionDecision,
+};
+
+#[test]
+fn current_nld_result_is_applied_without_inline_menu() {
+    assert!(should_apply_input_detection(
+        "git status",
+        "git status",
+        false
+    ));
+}
+
+#[test]
+fn stale_nld_result_is_ignored() {
+    assert!(!should_apply_input_detection("git", "git status", false));
+}
+
+#[test]
+fn nld_result_is_ignored_while_inline_menu_is_active() {
+    assert!(!should_apply_input_detection("/agent", "/agent", true));
+}
+
+#[test]
+fn empty_input_resets_to_agent() {
+    assert_eq!(
+        input_detection_decision("", None, 0, false),
+        InputDetectionDecision::ResetToAgent
+    );
+    assert_eq!(
+        input_detection_decision("  \n", None, 0, false),
+        InputDetectionDecision::ResetToAgent
+    );
+}
+
+#[test]
+fn nonempty_input_is_parsed_before_detection() {
+    assert_eq!(
+        input_detection_decision("cargo", None, 0, false),
+        InputDetectionDecision::Parse
+    );
+}
+
+#[test]
+fn short_or_unknown_single_tokens_reset_to_agent() {
+    assert_eq!(
+        input_detection_decision("w", Some(1), 1, true),
+        InputDetectionDecision::ResetToAgent
+    );
+    assert_eq!(
+        input_detection_decision("fi", Some(1), 2, false),
+        InputDetectionDecision::ResetToAgent
+    );
+    assert_eq!(
+        input_detection_decision("fix", Some(1), 3, false),
+        InputDetectionDecision::ResetToAgent
+    );
+}
+
+#[test]
+fn known_commands_and_multi_token_input_are_classified() {
+    assert_eq!(
+        input_detection_decision("ls", Some(1), 2, true),
+        InputDetectionDecision::Classify
+    );
+    assert_eq!(
+        input_detection_decision("cargo", Some(1), 5, true),
+        InputDetectionDecision::Classify
+    );
+    assert_eq!(
+        input_detection_decision("git status", Some(2), 3, true),
+        InputDetectionDecision::Classify
+    );
+    assert_eq!(
+        input_detection_decision("fix this", Some(2), 3, false),
+        InputDetectionDecision::Classify
+    );
+}
+
+#[test]
+fn only_unlocked_reset_decisions_change_to_agent() {
+    assert!(should_reset_input_to_agent(
+        InputDetectionDecision::ResetToAgent,
+        false
+    ));
+    assert!(!should_reset_input_to_agent(
+        InputDetectionDecision::Classify,
+        false
+    ));
+    assert!(!should_reset_input_to_agent(
+        InputDetectionDecision::ResetToAgent,
+        true
+    ));
+}

--- a/crates/warp_tui/src/terminal_session_view/input_detection_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view/input_detection_tests.rs
@@ -1,11 +1,17 @@
 use super::{
-    input_detection_decision, should_apply_input_detection, should_reset_input_to_agent,
+    input_detection_decision, parsed_result_is_applicable, should_reset_input_to_agent,
     InputDetectionDecision,
 };
 
+// These tests exercise only synchronous TUI coordinator decisions; they never invoke the NLD
+// classifier and are therefore deterministic. Shared classification behavior is covered by
+// `crates/input_classifier/src/heuristic_classifier/mod_tests.rs`, while GUI input-mode behavior
+// and shared model transitions are covered by `app/src/terminal/input_tests.rs` and
+// `app/src/ai/blocklist/input_model_tests.rs`.
+
 #[test]
-fn current_nld_result_is_applied_without_inline_menu() {
-    assert!(should_apply_input_detection(
+fn current_parse_result_is_applicable_without_inline_menu() {
+    assert!(parsed_result_is_applicable(
         "git status",
         "git status",
         false
@@ -13,13 +19,13 @@ fn current_nld_result_is_applied_without_inline_menu() {
 }
 
 #[test]
-fn stale_nld_result_is_ignored() {
-    assert!(!should_apply_input_detection("git", "git status", false));
+fn stale_parse_result_is_not_applicable() {
+    assert!(!parsed_result_is_applicable("git", "git status", false));
 }
 
 #[test]
-fn nld_result_is_ignored_while_inline_menu_is_active() {
-    assert!(!should_apply_input_detection("/agent", "/agent", true));
+fn parse_result_is_not_applicable_while_inline_menu_is_active() {
+    assert!(!parsed_result_is_applicable("/agent", "/agent", true));
 }
 
 #[test]
@@ -43,7 +49,7 @@ fn nonempty_input_is_parsed_before_detection() {
 }
 
 #[test]
-fn short_or_unknown_single_tokens_reset_to_agent() {
+fn decision_resets_short_or_unknown_single_tokens_to_agent() {
     assert_eq!(
         input_detection_decision("w", Some(1), 1, true),
         InputDetectionDecision::ResetToAgent
@@ -59,7 +65,7 @@ fn short_or_unknown_single_tokens_reset_to_agent() {
 }
 
 #[test]
-fn known_commands_and_multi_token_input_are_classified() {
+fn decision_routes_known_commands_and_multi_token_input_to_classifier() {
     assert_eq!(
         input_detection_decision("ls", Some(1), 2, true),
         InputDetectionDecision::Classify

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -11,7 +11,7 @@ use warpui_core::{App, AppContext};
 
 use super::{
     export_file_success_message, raw_prompt_if_not_blank, render_left_footer_hint,
-    should_apply_input_detection, TuiTerminalSessionEvent,
+    TuiTerminalSessionEvent,
 };
 use crate::tui_builder::TuiUiBuilder;
 
@@ -127,25 +127,6 @@ fn non_command_prompt_preserves_leading_whitespace() {
 #[test]
 fn whitespace_only_prompt_is_ignored() {
     assert_eq!(raw_prompt_if_not_blank(" \t\n"), None);
-}
-
-#[test]
-fn current_nld_result_is_applied_without_inline_menu() {
-    assert!(should_apply_input_detection(
-        "git status",
-        "git status",
-        false
-    ));
-}
-
-#[test]
-fn stale_nld_result_is_ignored() {
-    assert!(!should_apply_input_detection("git", "git status", false));
-}
-
-#[test]
-fn nld_result_is_ignored_while_inline_menu_is_active() {
-    assert!(!should_apply_input_detection("/agent", "/agent", true));
 }
 
 #[test]

--- a/crates/warp_tui/src/terminal_session_view_tests.rs
+++ b/crates/warp_tui/src/terminal_session_view_tests.rs
@@ -11,7 +11,7 @@ use warpui_core::{App, AppContext};
 
 use super::{
     export_file_success_message, raw_prompt_if_not_blank, render_left_footer_hint,
-    TuiTerminalSessionEvent,
+    should_apply_input_detection, TuiTerminalSessionEvent,
 };
 use crate::tui_builder::TuiUiBuilder;
 
@@ -127,6 +127,25 @@ fn non_command_prompt_preserves_leading_whitespace() {
 #[test]
 fn whitespace_only_prompt_is_ignored() {
     assert_eq!(raw_prompt_if_not_blank(" \t\n"), None);
+}
+
+#[test]
+fn current_nld_result_is_applied_without_inline_menu() {
+    assert!(should_apply_input_detection(
+        "git status",
+        "git status",
+        false
+    ));
+}
+
+#[test]
+fn stale_nld_result_is_ignored() {
+    assert!(!should_apply_input_detection("git", "git status", false));
+}
+
+#[test]
+fn nld_result_is_ignored_while_inline_menu_is_active() {
+    assert!(!should_apply_input_detection("/agent", "/agent", true));
 }
 
 #[test]


### PR DESCRIPTION
## Description

Adds natural language detection (NLD) to the headless TUI input so users can type shell commands without first entering explicit `!` mode, while keeping Agent as the TUI's default and preferred mode.

### What changed

- Exposes the existing `agents.warp_agent.input.ai_auto_detection_enabled` setting to the TUI.
- Connects TUI editor changes to the shared parser and `BlocklistAIInputModel` classifier using the active shell session context.
- Treats detected and explicitly locked Shell input consistently for rendering and submission.
- Shows the existing `shell mode · esc to exit` footer only while Shell mode is active; Agent mode remains visually neutral.
- Resets empty or ambiguous unlocked input to Agent, preventing short partial input such as `w` from flickering into Shell.
- Preserves exact known commands, aliases, functions, builtins, registered command signatures, and multi-token commands as Shell candidates.
- Preserves explicit overrides: `!` locks Shell mode for the current buffer and Escape locks Agent mode.

### Implementation

The parser, completion context, and classifier remain shared with GUI input detection. TUI-specific scheduling, stale-result cancellation, inline-menu suppression, and Agent-biased input gating live in a dedicated `terminal_session_view::input_detection` module because the GUI coordinator is coupled to command decorations, parsed-token caching, shared-session edits, and GUI suggestion modes.

## Linked Issue

N/A

## Testing

- [x] `cargo nextest run -p warp_tui` — 246 tests passed
- [x] `cargo clippy -p warp_tui --all-targets -- -D warnings`
- [x] `./script/format`
- [x] `cargo check -p warp_tui`
- [x] Manually tested with `./script/run-tui`

Manual verification covered:

- `cargo` automatically enters Shell mode.
- Deleting `cargo` to an empty buffer returns to Agent mode.
- `w` remains in Agent mode.
- `git status` automatically enters Shell mode.
- `!w` remains explicitly locked in Shell mode after deleting its text.
- Escape exits Shell mode and preserves the buffer where applicable.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-IMPROVEMENT: Added natural language detection to the headless TUI input, with Agent-biased mode switching and automatic Shell command detection.

Co-Authored-By: Warp <agent@warp.dev>
