### PR TITLE
Support multi-character macOS keyboard translations

### DIFF
--- a/crates/warpui/src/platform/mac/keycode.rs
+++ b/crates/warpui/src/platform/mac/keycode.rs
@@ -3,7 +3,7 @@ use std::slice;
 use cocoa::base::{id, BOOL};
 use cocoa::foundation::NSUInteger;
 use objc2::rc::Retained;
-use objc2_foundation::{NSArray, NSNumber, NSString};
+use objc2_foundation::{NSArray, NSNumber, NSString, NSUTF8StringEncoding};
 use warpui_core::keymap::Keystroke;
 use warpui_core::platform::keyboard::{KeyCode, NativeKeyCode, PhysicalKey};
 
@@ -16,6 +16,29 @@ pub const CONTROL_KEY: u16 = 4096;
 extern "C" {
     fn charToKeyCodes(keyChar: id) -> id;
     fn keyCodeToChar(keyCode: NSUInteger, shifted: BOOL) -> id;
+    /// Defined in `objc/keycode.m`. Converts a translated UTF-16 sequence into a
+    /// key name, falling back to the control-key mapping for empty translations
+    /// and single control characters.
+    fn KeyNameFromTranslatedChars(chars: *const u16, length: NSUInteger, keyCode: u16) -> id;
+}
+
+/// Converts an autoreleased `NSString*` returned by the objc keycode helpers into an
+/// owned Rust string. Returns `None` for null pointers or invalid UTF-8.
+unsafe fn nsstring_id_to_string(string: id) -> Option<String> {
+    if string.is_null() {
+        return None;
+    }
+    let string = &*string.cast::<NSString>();
+    let cstr = string.UTF8String() as *const u8;
+    if cstr.is_null() {
+        return None;
+    }
+    // `len()` returns the UTF-16 length; the UTF-8 byte length can be longer for
+    // non-ASCII translations (e.g. multi-byte characters or surrogate pairs).
+    let utf8_len = string.lengthOfBytesUsingEncoding(NSUTF8StringEncoding);
+    std::str::from_utf8(slice::from_raw_parts(cstr, utf8_len))
+        .ok()
+        .map(|s| s.to_string())
 }
 
 pub struct Keycode(pub u16);
@@ -29,15 +52,7 @@ impl Keycode {
             #[allow(clippy::useless_conversion)]
             let key = keyCodeToChar(self.0 as u64, shift_key_pressed.into());
 
-            if key.is_null() {
-                return None;
-            }
-
-            let key = &*key.cast::<NSString>();
-            let cstr = key.UTF8String() as *const u8;
-            std::str::from_utf8(slice::from_raw_parts(cstr, key.len()))
-                .ok()
-                .map(|s| s.to_string())
+            nsstring_id_to_string(key)
         }
     }
 
@@ -239,4 +254,84 @@ pub(crate) fn scancode_to_physicalkey(scancode: u32) -> PhysicalKey {
         0x7f => KeyCode::Power, // On 10.7 and 10.8 only
         _ => return PhysicalKey::Unidentified(NativeKeyCode::MacOS(scancode as u16)),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use objc2::rc::autoreleasepool;
+
+    use super::*;
+
+    // Carbon virtual keycodes used by the tests.
+    const KVK_ANSI_A: u16 = 0x00;
+    const KVK_RETURN: u16 = 0x24;
+    const KVK_ESCAPE: u16 = 0x35;
+
+    fn key_name_from_chars(chars: &[u16], key_code: u16) -> Option<String> {
+        autoreleasepool(|_| unsafe {
+            let name =
+                KeyNameFromTranslatedChars(chars.as_ptr(), chars.len() as NSUInteger, key_code);
+            nsstring_id_to_string(name)
+        })
+    }
+
+    #[test]
+    fn empty_translation_falls_back_to_control_key_mapping() {
+        // A zero-character translation for a control keycode should use the
+        // control-key name instead of indexing an empty buffer.
+        assert_eq!(
+            key_name_from_chars(&[], KVK_RETURN).as_deref(),
+            Some("enter")
+        );
+    }
+
+    #[test]
+    fn empty_translation_with_unmapped_keycode_returns_none() {
+        // A zero-character translation for a non-control keycode has no name.
+        assert_eq!(key_name_from_chars(&[], KVK_ANSI_A), None);
+    }
+
+    #[test]
+    fn single_character_translation_is_preserved() {
+        assert_eq!(
+            key_name_from_chars(&[u16::from(b'a')], KVK_ANSI_A).as_deref(),
+            Some("a")
+        );
+    }
+
+    #[test]
+    fn single_control_character_uses_control_key_mapping() {
+        assert_eq!(
+            key_name_from_chars(&[0x1B], KVK_ESCAPE).as_deref(),
+            Some("escape")
+        );
+    }
+
+    #[test]
+    fn surrogate_pair_translation_is_preserved() {
+        // U+1F600 (😀) encoded as a UTF-16 surrogate pair.
+        assert_eq!(
+            key_name_from_chars(&[0xD83D, 0xDE00], KVK_ANSI_A).as_deref(),
+            Some("😀")
+        );
+    }
+
+    #[test]
+    fn multi_character_translation_is_preserved() {
+        // Some layouts translate a single keypress into multiple characters;
+        // the full sequence must be preserved.
+        let chars: Vec<u16> = "ch".encode_utf16().collect();
+        assert_eq!(
+            key_name_from_chars(&chars, KVK_ANSI_A).as_deref(),
+            Some("ch")
+        );
+
+        // Multi-character sequences are treated as text even if they contain
+        // control code units, rather than falling back to the control mapping.
+        let with_control: Vec<u16> = vec![0x1B, u16::from(b'x')];
+        assert_eq!(
+            key_name_from_chars(&with_control, KVK_ESCAPE).as_deref(),
+            Some("\u{1B}x")
+        );
+    }
 }

--- a/crates/warpui/src/platform/mac/objc/keycode.m
+++ b/crates/warpui/src/platform/mac/objc/keycode.m
@@ -109,31 +109,67 @@ CFDataRef GetKeyboardLayoutData() {
     return layout_data;
 }
 
+// Maximum number of UTF-16 code units UCKeyTranslate may produce for a single keypress.
+#define kMaxTranslatedChars 255
+
 // Referenced from chromium:
 // https://chromium.googlesource.com/chromium/src/+/lkgr/ui/events/keycodes/keyboard_code_conversion_mac.mm
 // Here we take the keyboard layout, keycode, modifier keys, and keyboard type to
-// determine the output character.
-// Notice that we don't yet handle multiple character case here. But this should
-// be minor given Chrome also doesn't support it.
-UniChar TranslatedUnicodeCharFromKeyCode(CFDataRef layout_data, UInt16 key_code,
-                                         UInt32 modifier_key_state, UInt32 keyboard_type) {
-    if (!layout_data) return 0xFFFD;  // REPLACEMENT CHARACTER
+// determine the output characters.
+// The full translated UTF-16 sequence is written to `out_chars` (which must have room
+// for at least `max_length` UniChars). Returns the number of code units written, which
+// may be zero (e.g. for dead keys or layouts that produce no output for the keycode).
+UniCharCount TranslatedUnicodeStringFromKeyCode(CFDataRef layout_data, UInt16 key_code,
+                                                UInt32 modifier_key_state, UInt32 keyboard_type,
+                                                UniChar* out_chars, UniCharCount max_length) {
+    if (!layout_data) {
+        // REPLACEMENT CHARACTER
+        if (max_length < 1) return 0;
+        out_chars[0] = 0xFFFD;
+        return 1;
+    }
 
     const UCKeyboardLayout* keyboardLayout = (const UCKeyboardLayout*)CFDataGetBytePtr(layout_data);
 
     UInt32 deadKeyState = 0;
-    UniCharCount maxStringLength = 255;
     UniCharCount actualStringLength = 0;
-    UniChar unicodeString[maxStringLength];
 
-    UCKeyTranslate(keyboardLayout, key_code, kUCKeyActionDown, modifier_key_state, keyboard_type,
-                   kUCKeyTranslateNoDeadKeysBit, &deadKeyState, maxStringLength,
-                   &actualStringLength, unicodeString);
-    // TODO(kevin): Handle multiple character case. Should be rare.
-    return unicodeString[0];
+    OSStatus status = UCKeyTranslate(keyboardLayout, key_code, kUCKeyActionDown, modifier_key_state,
+                                     keyboard_type, kUCKeyTranslateNoDeadKeysBit, &deadKeyState,
+                                     max_length, &actualStringLength, out_chars);
+    if (status != noErr) {
+        return 0;
+    }
+    // UCKeyTranslate reports the full length even if it exceeds the buffer; clamp so
+    // callers never read past what was actually written.
+    if (actualStringLength > max_length) {
+        actualStringLength = max_length;
+    }
+    return actualStringLength;
 }
 
-// Convert keycode to its corresponding character on the keyboard.
+// Converts a translated UTF-16 sequence into the key name for `keyCode`.
+//
+// UCKeyTranslate can't translate control characters like function keys and arrow
+// keys, and may produce no characters at all for some keys. We keep a separate
+// mapping for those cases. This is the same behavior as chromium:
+// https://chromium.googlesource.com/chromium/src/+/lkgr/ui/events/keycodes/keyboard_code_conversion_mac.mm#873
+//
+// Multi-character translations (including surrogate pairs) are preserved in full.
+// Exposed (non-static) so it can be unit tested from Rust.
+NSString* KeyNameFromTranslatedChars(const UniChar* chars, UniCharCount length, UInt16 keyCode) {
+    if (length == 0) {
+        // Zero-character translations: fall back to the control-key mapping so we
+        // never index into an empty buffer.
+        return KeyFromControlKeyCode(keyCode);
+    }
+    if (length == 1 && IsUnicodeControl(chars[0])) {
+        return KeyFromControlKeyCode(keyCode);
+    }
+    return [NSString stringWithCharacters:chars length:length];
+}
+
+// Convert keycode to its corresponding character(s) on the keyboard.
 NSString* keyCodeToChar(UInt16 keyCode, BOOL shifted) {
     UInt32 modifier_key_state = 0;
 
@@ -145,17 +181,12 @@ NSString* keyCodeToChar(UInt16 keyCode, BOOL shifted) {
     }
 
     CFDataRef layout_data = GetKeyboardLayoutData();
-    UniChar translated_char =
-        TranslatedUnicodeCharFromKeyCode(layout_data, keyCode, modifier_key_state, LMGetKbdLast());
+    UniChar translated_chars[kMaxTranslatedChars];
+    UniCharCount translated_length =
+        TranslatedUnicodeStringFromKeyCode(layout_data, keyCode, modifier_key_state, LMGetKbdLast(),
+                                           translated_chars, kMaxTranslatedChars);
 
-    // UCKeyTranslate can't translate control characters like function keys and arrow
-    // keys. We keep a separate mapping for this case. This is the same behavior as chromium:
-    // https://chromium.googlesource.com/chromium/src/+/lkgr/ui/events/keycodes/keyboard_code_conversion_mac.mm#873
-    if (IsUnicodeControl(translated_char)) {
-        return KeyFromControlKeyCode(keyCode);
-    } else {
-        return [NSString stringWithFormat:@"%C", translated_char];
-    }
+    return KeyNameFromTranslatedChars(translated_chars, translated_length, keyCode);
 }
 
 NSArray<NSNumber*>* charToKeyCodes(NSString* keyChar) {
@@ -168,25 +199,20 @@ NSArray<NSNumber*>* charToKeyCodes(NSString* keyChar) {
         for (i = 0; i < 128; ++i) {
             UInt32 shift_key = 1 << 1;
 
-            // Compute a shifted and unshifted version for one keycode.
-            UniChar unshifted =
-                TranslatedUnicodeCharFromKeyCode(layout_data, (UInt16)i, 0, LMGetKbdLast());
-            UniChar shifted =
-                TranslatedUnicodeCharFromKeyCode(layout_data, (UInt16)i, shift_key, LMGetKbdLast());
+            // Compute a shifted and unshifted version for one keycode, preserving the
+            // full translated UTF-16 sequence in each case.
+            UniChar unshifted_chars[kMaxTranslatedChars];
+            UniCharCount unshifted_length = TranslatedUnicodeStringFromKeyCode(
+                layout_data, (UInt16)i, 0, LMGetKbdLast(), unshifted_chars, kMaxTranslatedChars);
+            UniChar shifted_chars[kMaxTranslatedChars];
+            UniCharCount shifted_length = TranslatedUnicodeStringFromKeyCode(
+                layout_data, (UInt16)i, shift_key, LMGetKbdLast(), shifted_chars,
+                kMaxTranslatedChars);
 
-            NSString* unshifted_str;
-            if (IsUnicodeControl(unshifted)) {
-                unshifted_str = KeyFromControlKeyCode(i);
-            } else {
-                unshifted_str = [NSString stringWithFormat:@"%C", unshifted];
-            }
-
-            NSString* shifted_str;
-            if (IsUnicodeControl(shifted)) {
-                shifted_str = KeyFromControlKeyCode(i);
-            } else {
-                shifted_str = [NSString stringWithFormat:@"%C", shifted];
-            }
+            NSString* unshifted_str =
+                KeyNameFromTranslatedChars(unshifted_chars, unshifted_length, (UInt16)i);
+            NSString* shifted_str =
+                KeyNameFromTranslatedChars(shifted_chars, shifted_length, (UInt16)i);
 
             if (unshifted_str != nil && [unshifted_str length] > 0) {
                 if ([keycodeDict objectForKey:unshifted_str] == nil) {


### PR DESCRIPTION
## What & Why
`UCKeyTranslate` can return zero or multiple UTF-16 code units for a single keypress, but `crates/warpui/src/platform/mac/objc/keycode.m` discarded all but the first translated character and indexed `unicodeString[0]` even when the translation produced no characters at all.

## Changes
- Replaced `TranslatedUnicodeCharFromKeyCode` with `TranslatedUnicodeStringFromKeyCode`, which writes the complete translated UTF-16 sequence into a caller-provided buffer and returns its length (0 on `UCKeyTranslate` error or empty output — no more indexing into an empty buffer).
- Added `KeyNameFromTranslatedChars`, a shared helper that:
  - falls back to the control-key mapping (`KeyFromControlKeyCode`) for zero-character translations and single control characters — function/control-key behavior is unchanged;
  - preserves multi-character translations in full, including surrogate pairs, via `stringWithCharacters:length:`.
- Updated both `keyCodeToChar` and the reverse keycode lookup `charToKeyCodes` to use the new helpers.
- Fixed `Keycode::try_to_key_name` in `keycode.rs`, which used the UTF-16 length (`NSString.len()`) as a UTF-8 byte count and would truncate/corrupt multi-byte results; it now uses `lengthOfBytesUsingEncoding(NSUTF8StringEncoding)`.
- Added focused Rust unit tests (macOS) for `KeyNameFromTranslatedChars` covering empty, single-character, single-control-character, surrogate-pair, and multi-character translations.

## Validation
- `rustfmt --check` and `./script/run-clang-format.py` pass on the touched files.
- Note: this change was authored in a Linux sandbox, so the macOS-only code paths and new tests could not be compiled/run here — please rely on macOS CI (`cargo nextest run -p warpui` on a mac runner) for verification.

CHANGELOG-BUG-FIX: Fixed macOS key translation dropping characters when a keyboard layout produces multiple characters for a single keypress.

_Conversation: http://localhost:8080/conversation/6e0444cf-6b99-44e3-832a-6ecfd0e07326_
_Run: http://localhost:8082/runs/019f6c0a-6db5-7455-8d70-2460b9440dd9_

_This PR was generated with [Oz](https://warp.dev/oz)._
