### PR TITLE
Make IME candidate-window positioning explicit and testable

### DIFF
--- a/crates/warpui/src/windowing/winit/event_loop/ime_position.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/ime_position.rs
@@ -1,0 +1,165 @@
+//! Explicit tracking and planning of the IME candidate-window position.
+//!
+//! winit caches the last IME cursor area passed to
+//! [`winit::window::Window::set_ime_cursor_area`] and skips notifying the
+//! platform when the area is unchanged. That caching is keyed on the
+//! *window-relative* logical position, so after a window move, resize, or
+//! scale-factor change the platform's notion of where the candidate window
+//! should appear is stale even though the window-relative position is
+//! unchanged.
+//!
+//! [`ImePositionState`] tracks the last candidate area we applied and plans a
+//! deterministic sequence of updates for a new target area:
+//!
+//! * If the target differs from the last applied area, a single update
+//!   suffices — winit will forward it to the platform.
+//! * If the target equals the last applied area, winit would silently drop
+//!   the update, so we first apply a "nudge" area offset by one logical pixel
+//!   and then the real target, forcing winit to re-send the position.
+
+use winit::dpi::{LogicalPosition, LogicalSize};
+
+use crate::CursorInfo;
+
+/// Vertical offset factor: the candidate window is placed this many
+/// font-size-multiples below the top of the text cursor, i.e. just below the
+/// line being edited.
+const CANDIDATE_WINDOW_VERTICAL_OFFSET_FACTOR: f32 = 1.2;
+
+/// Offset (in logical pixels) used for the cache-busting nudge update.
+const CACHE_BUST_OFFSET: f32 = 1.0;
+
+/// The area (position and size) of the IME candidate window, in logical
+/// pixels relative to the window's client area.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) struct ImeCandidateArea {
+    pub position: LogicalPosition<f32>,
+    pub size: LogicalSize<f32>,
+}
+
+impl ImeCandidateArea {
+    /// Computes the candidate-window area for the given text-cursor info: the
+    /// candidate window is anchored just below the cursor, and sized to the
+    /// font size.
+    ///
+    /// Note: the size is not supported on X11 — winit ignores it there — but
+    /// we calculate it anyway for the platforms that do support it.
+    pub fn from_cursor_info(cursor_info: &CursorInfo) -> Self {
+        Self {
+            position: LogicalPosition::new(
+                cursor_info.position.origin_x(),
+                cursor_info.position.origin_y()
+                    + (CANDIDATE_WINDOW_VERTICAL_OFFSET_FACTOR * cursor_info.font_size),
+            ),
+            size: LogicalSize::new(cursor_info.font_size, cursor_info.font_size),
+        }
+    }
+
+    /// Returns a copy of this area offset by one logical pixel, used to bust
+    /// winit's cached IME cursor area (see the module docs).
+    fn nudged(&self) -> Self {
+        Self {
+            position: LogicalPosition::new(self.position.x, self.position.y + CACHE_BUST_OFFSET),
+            size: self.size,
+        }
+    }
+}
+
+/// Per-window state tracking the last IME candidate area applied to winit.
+#[derive(Debug, Default)]
+pub(super) struct ImePositionState {
+    /// The last candidate area passed to winit, i.e. the value winit has
+    /// cached. `None` until the first update.
+    last_applied: Option<ImeCandidateArea>,
+}
+
+impl ImePositionState {
+    /// Plans the sequence of candidate areas to pass to
+    /// `set_ime_cursor_area`, in order, so that the platform ends up with
+    /// `target` as the effective candidate-window area.
+    ///
+    /// The caller must apply *all* returned updates in order.
+    pub fn plan_updates(&mut self, target: ImeCandidateArea) -> Vec<ImeCandidateArea> {
+        let updates = if self.last_applied == Some(target) {
+            // winit would drop an update identical to its cached value, but
+            // the platform may still need a refresh (e.g. the window moved).
+            // Nudge the position first to force winit to re-send it.
+            vec![target.nudged(), target]
+        } else {
+            vec![target]
+        };
+        self.last_applied = Some(target);
+        updates
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pathfinder_geometry::rect::RectF;
+    use pathfinder_geometry::vector::vec2f;
+
+    use super::*;
+
+    fn cursor_info(x: f32, y: f32, font_size: f32) -> CursorInfo {
+        CursorInfo {
+            position: RectF::new(vec2f(x, y), vec2f(2.0, font_size)),
+            font_size,
+        }
+    }
+
+    fn area(x: f32, y: f32, font_size: f32) -> ImeCandidateArea {
+        ImeCandidateArea {
+            position: LogicalPosition::new(x, y),
+            size: LogicalSize::new(font_size, font_size),
+        }
+    }
+
+    #[test]
+    fn candidate_area_is_anchored_below_the_cursor() {
+        let target = ImeCandidateArea::from_cursor_info(&cursor_info(100.0, 50.0, 10.0));
+        // 50 + 1.2 * 10 = 62.
+        assert_eq!(target, area(100.0, 62.0, 10.0));
+    }
+
+    #[test]
+    fn first_update_is_applied_directly() {
+        let mut state = ImePositionState::default();
+        let target = area(10.0, 20.0, 12.0);
+        assert_eq!(state.plan_updates(target), vec![target]);
+    }
+
+    #[test]
+    fn changed_target_is_applied_directly() {
+        let mut state = ImePositionState::default();
+        let first = area(10.0, 20.0, 12.0);
+        let second = area(10.0, 35.0, 12.0);
+        state.plan_updates(first);
+        assert_eq!(state.plan_updates(second), vec![second]);
+    }
+
+    #[test]
+    fn unchanged_target_is_nudged_to_bust_winit_cache() {
+        let mut state = ImePositionState::default();
+        let target = area(10.0, 20.0, 12.0);
+        state.plan_updates(target);
+
+        // E.g. the window moved: the window-relative target is unchanged, but
+        // winit must be forced to re-send the position to the platform.
+        let updates = state.plan_updates(target);
+        assert_eq!(updates, vec![area(10.0, 21.0, 12.0), target]);
+        // The nudge differs from the cached value, and the final update
+        // differs from the nudge, so winit forwards both.
+        assert_ne!(updates[0], target);
+    }
+
+    #[test]
+    fn repeated_refreshes_generate_the_same_sequence() {
+        let mut state = ImePositionState::default();
+        let target = area(1.0, 2.0, 14.0);
+        state.plan_updates(target);
+        let first_refresh = state.plan_updates(target);
+        let second_refresh = state.plan_updates(target);
+        assert_eq!(first_refresh, second_refresh);
+        assert_eq!(second_refresh, vec![target.nudged(), target]);
+    }
+}

--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -1,3 +1,4 @@
+mod ime_position;
 mod key_events;
 
 #[cfg(test)]
@@ -22,6 +23,7 @@ use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoopProxy};
 use winit::keyboard::{self, KeyCode};
 use winit::window::WindowId as WinitWindowId;
 
+use self::ime_position::{ImeCandidateArea, ImePositionState};
 use self::key_events::convert_keyboard_input_event;
 use super::app::ClipboardEvent;
 use super::window::DEFAULT_TITLEBAR_HEIGHT;
@@ -157,6 +159,9 @@ struct WindowState {
     has_pending_drag_drop_timer: bool,
     /// The purpose of the last touch event.
     last_touch_purpose: Option<TouchPurpose>,
+    /// Tracks the IME candidate-window area last applied to winit so we can
+    /// plan cache-busting update sequences. See [`ime_position`] module docs.
+    ime_position: ImePositionState,
     /// Tracks scroll velocity during active touch scrolling and momentum scrolling.
     /// Active phase determined through `momentum_scroll_abort.is_some()`.
     scroll_velocity: Option<ScrollVelocity>,
@@ -182,6 +187,7 @@ impl WindowState {
             pending_drag_drop_files: Vec::new(),
             has_pending_drag_drop_timer: false,
             last_touch_purpose: None,
+            ime_position: ImePositionState::default(),
             scroll_velocity: None,
             momentum_scroll_abort: None,
             #[cfg(target_family = "wasm")]
@@ -741,9 +747,9 @@ impl EventLoop {
                 });
             }
             Event::UserEvent(CustomEvent::ActiveCursorPositionUpdated) => {
-                if self.ime_enabled {
-                    self.update_ime_position();
-                }
+                // The text cursor moved; keep the IME candidate window
+                // anchored to it.
+                self.refresh_ime_position_if_enabled();
             }
             Event::UserEvent(CustomEvent::AboutToSleep) => {
                 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
@@ -879,6 +885,10 @@ impl EventLoop {
                         mut inner_size_writer,
                     },
             } => {
+                // A scale-factor change moves the candidate window's physical
+                // location even when its logical position is unchanged.
+                self.refresh_ime_position_if_enabled();
+
                 // The following correction is only needed on Windows.
                 if !cfg!(windows) {
                     return;
@@ -1058,6 +1068,9 @@ impl EventLoop {
                 window.handle_resize();
                 self.callbacks.for_window(window).window_resized(window);
                 self.callbacks.window_resized();
+                // Resizing can move the text cursor (reflow) and invalidates
+                // winit's cached candidate-window position.
+                self.refresh_ime_position_if_enabled();
             }
             ConvertedEvent::ModifierKeyChanged { key_code, state } => {
                 let mut window_callbacks = self.callbacks.for_window(window.as_ref());
@@ -1103,6 +1116,10 @@ impl EventLoop {
                     .for_window(window)
                     .window_moved(RectF::new(vec2f(position.x, position.y), size));
                 self.callbacks.window_moved();
+                // Moving the window changes the candidate window's screen
+                // position while the window-relative position stays the same,
+                // so force a refresh.
+                self.refresh_ime_position_if_enabled();
             }
             ConvertedEvent::MoveWindowBy {
                 current_touch,
@@ -1778,6 +1795,20 @@ impl EventLoop {
         abort_handle
     }
 
+    /// Refreshes the IME candidate-window position for the active window, if
+    /// IME input is currently enabled.
+    ///
+    /// This must be invoked whenever the on-screen location of the text
+    /// cursor may have changed relative to the platform's cached candidate
+    /// position: text-cursor movement (via
+    /// [`CustomEvent::ActiveCursorPositionUpdated`]), window moves, window
+    /// resizes, and scale-factor changes.
+    fn refresh_ime_position_if_enabled(&mut self) {
+        if self.ime_enabled {
+            self.update_ime_position();
+        }
+    }
+
     fn update_ime_position(&mut self) {
         let Some(active_window_id) = self.ui_app.read(|ctx| ctx.windows().active_window()) else {
             return;
@@ -1790,23 +1821,28 @@ impl EventLoop {
         };
 
         let mut window_callbacks = self.callbacks.for_window(window.as_ref());
-        let active_cursor_position = window_callbacks.get_active_cursor_position();
-        if let Some(active_cursor_position) = active_cursor_position {
-            let winit_window = downcast_window(window.as_ref());
-            let position = LogicalPosition::new(
-                active_cursor_position.position.origin_x(),
-                active_cursor_position.position.origin_y()
-                    + (1.2 * active_cursor_position.font_size),
-            );
-            // Currently the size argument is not supported on X11. We calculate it here anyway.
-            let size = LogicalSize::new(
-                active_cursor_position.font_size,
-                active_cursor_position.font_size,
-            );
-            // TODO(abhishek): We make sure that the position is different than last time to prevent winit from
-            // caching the old position and not properly updating on `WindowMoved` or `WindowResized` events.
-            winit_window.set_ime_position(LogicalPosition::new(position.x, position.y + 1.), size);
-            winit_window.set_ime_position(position, size);
+        let Some(active_cursor_position) = window_callbacks.get_active_cursor_position() else {
+            return;
+        };
+        let target = ImeCandidateArea::from_cursor_info(&active_cursor_position);
+
+        let Some(window_state) = self
+            .state
+            .windows
+            .values_mut()
+            .find(|window_state| window_state.window_id == active_window_id)
+        else {
+            return;
+        };
+
+        let winit_window = downcast_window(window.as_ref());
+        // Apply the full planned sequence: when the target is unchanged, the
+        // plan includes a nudge update to bust winit's cached position (see
+        // the `ime_position` module docs).
+        for update in window_state.ime_position.plan_updates(target) {
+            // Note: the size argument is unsupported (ignored) on X11; we
+            // pass it anyway for the platforms that support it.
+            winit_window.set_ime_position(update.position, update.size);
         }
     }
 


### PR DESCRIPTION
## Description
`update_ime_position` in `crates/warpui/src/windowing/winit/event_loop/mod.rs` worked around winit's IME position caching by unconditionally setting the candidate position twice (offset by one pixel, then the real position), with a TODO noting the reason.

This PR makes that behavior explicit and testable:
- New `ime_position` module encapsulating the workaround behind a small abstraction: `ImeCandidateArea` (computed from `CursorInfo`) and `ImePositionState`, which tracks the last candidate area applied to winit per window (stored on `WindowState`).
- `ImePositionState::plan_updates` returns a deterministic update sequence: a single update when the target area changed (winit forwards it), or a one-pixel nudge followed by the target when it's unchanged (forcing winit to re-send the position after window geometry changes).
- The candidate-window position is now refreshed on window move, window resize, and scale-factor changes, in addition to the existing text-cursor movement path (`ActiveCursorPositionUpdated`).
- X11 behavior is preserved: the size argument is still computed and passed even though winit ignores it on X11.

## Testing
Added deterministic unit tests in `ime_position.rs` covering the candidate-area computation and the generated update sequences (first update, changed target, unchanged target nudge, repeated refreshes):

- `cargo nextest run -p warpui ime_position` — 5/5 pass
- `cargo check -p warpui`, `cargo clippy -p warpui --all-targets --all-features`, and `./script/format` are clean

Not manually tested with `./script/run` (headless sandbox; IME behavior requires a platform IME).

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

_Conversation: http://localhost:8080/conversation/9cfa291e-e5f3-4435-a062-3772db5615cb_
_Run: http://localhost:8082/runs/019f6c0b-872f-7367-8b59-be6acaa7e96e_

_This PR was generated with [Oz](https://warp.dev/oz)._
