### PR TITLE
Preserve multi-character macOS UCKeyTranslate results

### DIFF
--- a/crates/warpui/src/platform/mac/keycode.rs
+++ b/crates/warpui/src/platform/mac/keycode.rs
@@ -18,6 +18,34 @@ extern "C" {
     fn keyCodeToChar(keyCode: NSUInteger, shifted: BOOL) -> id;
 }
 
+/// Returns true for C0/C1 Unicode control code units.
+///
+/// Mirrors `IsUnicodeControl` in `objc/keycode.m`.
+fn is_unicode_control(code_unit: u16) -> bool {
+    code_unit <= 0x1F || (0x7F..=0x9F).contains(&code_unit)
+}
+
+/// Pure helper mirroring `KeyNameFromTranslatedString` in `objc/keycode.m`.
+///
+/// Given the raw UTF-16 buffer from `UCKeyTranslate` and the control-key name
+/// that `KeyFromControlKeyCode` would return for this keycode (if any), produce
+/// the key name Warp should use.
+///
+/// - Empty translations fall back to the control-key mapping.
+/// - Single control characters fall back to the control-key mapping.
+/// - Single non-control characters, multi-unit sequences, and surrogate pairs
+///   are preserved as UTF-16.
+pub(crate) fn key_name_from_utf16_translation(
+    utf16: &[u16],
+    control_key_name: Option<&str>,
+) -> Option<String> {
+    match utf16 {
+        [] => control_key_name.map(str::to_owned),
+        [code_unit] if is_unicode_control(*code_unit) => control_key_name.map(str::to_owned),
+        units => String::from_utf16(units).ok(),
+    }
+}
+
 pub struct Keycode(pub u16);
 
 impl Keycode {
@@ -240,3 +268,7 @@ pub(crate) fn scancode_to_physicalkey(scancode: u32) -> PhysicalKey {
         _ => return PhysicalKey::Unidentified(NativeKeyCode::MacOS(scancode as u16)),
     })
 }
+
+#[cfg(test)]
+#[path = "keycode_tests.rs"]
+mod tests;

--- a/crates/warpui/src/platform/mac/keycode_tests.rs
+++ b/crates/warpui/src/platform/mac/keycode_tests.rs
@@ -1,0 +1,74 @@
+//! Focused tests for macOS key translation result handling.
+//!
+//! These exercise the pure selection logic that mirrors
+//! `KeyNameFromTranslatedString` in `objc/keycode.m` so we can cover empty,
+//! single-character, surrogate-pair, and multi-character UCKeyTranslate results
+//! without needing a live keyboard layout.
+
+use super::key_name_from_utf16_translation;
+
+#[test]
+fn empty_translation_falls_back_to_control_key_name() {
+    assert_eq!(
+        key_name_from_utf16_translation(&[], Some("f1")),
+        Some("f1".to_string())
+    );
+    assert_eq!(key_name_from_utf16_translation(&[], None), None);
+}
+
+#[test]
+fn single_control_character_falls_back_to_control_key_name() {
+    // Tab is a C0 control character; function/arrow keys surface this way when
+    // UCKeyTranslate cannot produce a printable character.
+    assert_eq!(
+        key_name_from_utf16_translation(&[0x0009], Some("tab")),
+        Some("tab".to_string())
+    );
+    assert_eq!(
+        key_name_from_utf16_translation(&[0x001b], Some("escape")),
+        Some("escape".to_string())
+    );
+    // No control-key mapping available for this keycode.
+    assert_eq!(key_name_from_utf16_translation(&[0x0009], None), None);
+}
+
+#[test]
+fn single_printable_character_is_preserved() {
+    assert_eq!(
+        key_name_from_utf16_translation(&[b'a' as u16], None),
+        Some("a".to_string())
+    );
+    assert_eq!(
+        key_name_from_utf16_translation(&[b'!' as u16], Some("f1")),
+        Some("!".to_string())
+    );
+}
+
+#[test]
+fn surrogate_pair_is_preserved() {
+    // U+1F600 GRINNING FACE encodes as the UTF-16 surrogate pair D83D DE00.
+    let grin = "😀";
+    let utf16: Vec<u16> = grin.encode_utf16().collect();
+    assert_eq!(utf16.len(), 2);
+    assert_eq!(
+        key_name_from_utf16_translation(&utf16, Some("f1")),
+        Some(grin.to_string())
+    );
+}
+
+#[test]
+fn multi_character_sequence_is_preserved() {
+    // Some dead-key / multi-unit layouts can emit more than one code unit that
+    // is not a single scalar value's surrogate pair (e.g. two BMP characters).
+    let utf16 = [b'a' as u16, b'b' as u16];
+    assert_eq!(
+        key_name_from_utf16_translation(&utf16, Some("f1")),
+        Some("ab".to_string())
+    );
+}
+
+#[test]
+fn invalid_utf16_returns_none() {
+    // Lone high surrogate is not valid UTF-16.
+    assert_eq!(key_name_from_utf16_translation(&[0xD800], None), None);
+}

--- a/crates/warpui/src/platform/mac/objc/keycode.m
+++ b/crates/warpui/src/platform/mac/objc/keycode.m
@@ -112,12 +112,15 @@ CFDataRef GetKeyboardLayoutData() {
 // Referenced from chromium:
 // https://chromium.googlesource.com/chromium/src/+/lkgr/ui/events/keycodes/keyboard_code_conversion_mac.mm
 // Here we take the keyboard layout, keycode, modifier keys, and keyboard type to
-// determine the output character.
-// Notice that we don't yet handle multiple character case here. But this should
-// be minor given Chrome also doesn't support it.
-UniChar TranslatedUnicodeCharFromKeyCode(CFDataRef layout_data, UInt16 key_code,
-                                         UInt32 modifier_key_state, UInt32 keyboard_type) {
-    if (!layout_data) return 0xFFFD;  // REPLACEMENT CHARACTER
+// determine the output characters. UCKeyTranslate can return zero, one, or multiple
+// UTF-16 code units (including surrogate pairs for non-BMP characters).
+NSString* TranslatedUnicodeStringFromKeyCode(CFDataRef layout_data, UInt16 key_code,
+                                             UInt32 modifier_key_state, UInt32 keyboard_type) {
+    if (!layout_data) {
+        // REPLACEMENT CHARACTER
+        UniChar replacement = 0xFFFD;
+        return [NSString stringWithCharacters:&replacement length:1];
+    }
 
     const UCKeyboardLayout* keyboardLayout = (const UCKeyboardLayout*)CFDataGetBytePtr(layout_data);
 
@@ -129,11 +132,35 @@ UniChar TranslatedUnicodeCharFromKeyCode(CFDataRef layout_data, UInt16 key_code,
     UCKeyTranslate(keyboardLayout, key_code, kUCKeyActionDown, modifier_key_state, keyboard_type,
                    kUCKeyTranslateNoDeadKeysBit, &deadKeyState, maxStringLength,
                    &actualStringLength, unicodeString);
-    // TODO(kevin): Handle multiple character case. Should be rare.
-    return unicodeString[0];
+
+    if (actualStringLength == 0) {
+        return @"";
+    }
+
+    return [NSString stringWithCharacters:unicodeString length:actualStringLength];
 }
 
-// Convert keycode to its corresponding character on the keyboard.
+// Map a UCKeyTranslate result to the key name used by Warp.
+// Empty results and single control characters fall back to the control-key table
+// (function keys, arrows, etc.). Multi-unit sequences, including surrogate pairs,
+// are preserved as-is.
+NSString* KeyNameFromTranslatedString(NSString* translated, UInt16 keyCode) {
+    NSUInteger length = [translated length];
+    if (length == 0) {
+        return KeyFromControlKeyCode(keyCode);
+    }
+
+    // UCKeyTranslate can't translate control characters like function keys and arrow
+    // keys. We keep a separate mapping for this case. This is the same behavior as chromium:
+    // https://chromium.googlesource.com/chromium/src/+/lkgr/ui/events/keycodes/keyboard_code_conversion_mac.mm#873
+    if (length == 1 && IsUnicodeControl([translated characterAtIndex:0])) {
+        return KeyFromControlKeyCode(keyCode);
+    }
+
+    return translated;
+}
+
+// Convert keycode to its corresponding character(s) on the keyboard.
 NSString* keyCodeToChar(UInt16 keyCode, BOOL shifted) {
     UInt32 modifier_key_state = 0;
 
@@ -145,17 +172,22 @@ NSString* keyCodeToChar(UInt16 keyCode, BOOL shifted) {
     }
 
     CFDataRef layout_data = GetKeyboardLayoutData();
-    UniChar translated_char =
-        TranslatedUnicodeCharFromKeyCode(layout_data, keyCode, modifier_key_state, LMGetKbdLast());
+    NSString* translated = TranslatedUnicodeStringFromKeyCode(
+        layout_data, keyCode, modifier_key_state, LMGetKbdLast());
+    return KeyNameFromTranslatedString(translated, keyCode);
+}
 
-    // UCKeyTranslate can't translate control characters like function keys and arrow
-    // keys. We keep a separate mapping for this case. This is the same behavior as chromium:
-    // https://chromium.googlesource.com/chromium/src/+/lkgr/ui/events/keycodes/keyboard_code_conversion_mac.mm#873
-    if (IsUnicodeControl(translated_char)) {
-        return KeyFromControlKeyCode(keyCode);
-    } else {
-        return [NSString stringWithFormat:@"%C", translated_char];
+// Insert `keyName` -> `keyCode` into the reverse-lookup dictionary, if present.
+void AddKeyCodeMapping(NSString* keyName, UInt16 keyCode) {
+    if (keyName == nil || [keyName length] == 0) {
+        return;
     }
+
+    if ([keycodeDict objectForKey:keyName] == nil) {
+        [keycodeDict setObject:[[[NSMutableArray alloc] init] autorelease] forKey:keyName];
+    }
+    NSMutableArray* keycodes = [keycodeDict objectForKey:keyName];
+    [keycodes addObject:[NSNumber numberWithInt:keyCode]];
 }
 
 NSArray<NSNumber*>* charToKeyCodes(NSString* keyChar) {
@@ -169,42 +201,13 @@ NSArray<NSNumber*>* charToKeyCodes(NSString* keyChar) {
             UInt32 shift_key = 1 << 1;
 
             // Compute a shifted and unshifted version for one keycode.
-            UniChar unshifted =
-                TranslatedUnicodeCharFromKeyCode(layout_data, (UInt16)i, 0, LMGetKbdLast());
-            UniChar shifted =
-                TranslatedUnicodeCharFromKeyCode(layout_data, (UInt16)i, shift_key, LMGetKbdLast());
+            NSString* unshifted = TranslatedUnicodeStringFromKeyCode(layout_data, (UInt16)i, 0,
+                                                                     LMGetKbdLast());
+            NSString* shifted = TranslatedUnicodeStringFromKeyCode(layout_data, (UInt16)i,
+                                                                   shift_key, LMGetKbdLast());
 
-            NSString* unshifted_str;
-            if (IsUnicodeControl(unshifted)) {
-                unshifted_str = KeyFromControlKeyCode(i);
-            } else {
-                unshifted_str = [NSString stringWithFormat:@"%C", unshifted];
-            }
-
-            NSString* shifted_str;
-            if (IsUnicodeControl(shifted)) {
-                shifted_str = KeyFromControlKeyCode(i);
-            } else {
-                shifted_str = [NSString stringWithFormat:@"%C", shifted];
-            }
-
-            if (unshifted_str != nil && [unshifted_str length] > 0) {
-                if ([keycodeDict objectForKey:unshifted_str] == nil) {
-                    [keycodeDict setObject:[[[NSMutableArray alloc] init] autorelease]
-                                    forKey:unshifted_str];
-                }
-                NSMutableArray* keycodes = [keycodeDict objectForKey:unshifted_str];
-                [keycodes addObject:[NSNumber numberWithInt:i]];
-            }
-
-            if (shifted_str != nil && [shifted_str length] > 0) {
-                if ([keycodeDict objectForKey:shifted_str] == nil) {
-                    [keycodeDict setObject:[[[NSMutableArray alloc] init] autorelease]
-                                    forKey:shifted_str];
-                }
-                NSMutableArray* keycodes = [keycodeDict objectForKey:shifted_str];
-                [keycodes addObject:[NSNumber numberWithInt:i]];
-            }
+            AddKeyCodeMapping(KeyNameFromTranslatedString(unshifted, (UInt16)i), (UInt16)i);
+            AddKeyCodeMapping(KeyNameFromTranslatedString(shifted, (UInt16)i), (UInt16)i);
         }
     }
 


### PR DESCRIPTION
## Description
Preserve the complete UTF-16 sequence returned by macOS `UCKeyTranslate` when mapping virtual keycodes to key names.

Previously, `TranslatedUnicodeCharFromKeyCode` only returned `unicodeString[0]`, which:
- discarded multi-character translations and surrogate pairs
- could index an empty result when `actualStringLength == 0`

This change:
- returns the full translated `NSString` from `UCKeyTranslate`
- keeps function/control-key mappings for empty results and single control characters
- updates reverse keycode lookup (`charToKeyCodes`) to use the full translated strings
- adds pure unit tests covering empty, single-character, surrogate-pair, multi-character, and invalid UTF-16 cases

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

Added focused unit tests in `crates/warpui/src/platform/mac/keycode_tests.rs` that exercise the pure key-name selection helper for:
- empty translations
- single control characters
- single printable characters
- surrogate pairs
- multi-character sequences
- invalid UTF-16

These tests can run without a live keyboard layout. The ObjC path itself still requires macOS to compile/execute.

### Screenshots / Videos
N/A — keyboard translation plumbing change only.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed macOS key translation discarding multi-character and surrogate-pair results from UCKeyTranslate.

_Conversation: http://localhost:8080/conversation/98c4cc67-1a6c-45f9-b298-99182f5ff857_
_Run: http://localhost:8082/runs/019f6c3d-958b-7144-b4c8-97a0b6db0f51_
_This PR was generated with [Oz](https://warp.dev/oz)._
