### PR TITLE
Preserve multi-character macOS key translations

### DIFF
--- a/crates/warpui/src/platform/mac/keycode.rs
+++ b/crates/warpui/src/platform/mac/keycode.rs
@@ -1,5 +1,4 @@
-use std::slice;
-
+use super::utils::nsstring_as_str;
 use cocoa::base::{id, BOOL};
 use cocoa::foundation::NSUInteger;
 use objc2::rc::Retained;
@@ -18,6 +17,73 @@ extern "C" {
     fn keyCodeToChar(keyCode: NSUInteger, shifted: BOOL) -> id;
 }
 
+#[cfg(test)]
+mod tests {
+    use cocoa::base::id;
+
+    use super::super::AutoreleasePoolGuard;
+    use super::nsstring_as_str;
+
+    extern "C" {
+        fn KeyFromTranslatedUnicodeChars(
+            unicodeString: *const u16,
+            actualStringLength: u32,
+            keyCode: u16,
+        ) -> id;
+    }
+
+    fn key_from_translated_unicode_chars(chars: &[u16], key_code: u16) -> Option<String> {
+        let _pool = AutoreleasePoolGuard::new();
+        let key =
+            unsafe { KeyFromTranslatedUnicodeChars(chars.as_ptr(), chars.len() as u32, key_code) };
+        if key.is_null() {
+            None
+        } else {
+            unsafe { nsstring_as_str(key) }.ok().map(str::to_owned)
+        }
+    }
+
+    #[test]
+    fn empty_translation_is_handled_safely() {
+        assert_eq!(key_from_translated_unicode_chars(&[], 0), None);
+        assert_eq!(
+            key_from_translated_unicode_chars(&[], 0x24),
+            Some("enter".to_owned())
+        );
+    }
+
+    #[test]
+    fn single_character_translation_is_preserved() {
+        assert_eq!(
+            key_from_translated_unicode_chars(&['a' as u16], 0),
+            Some("a".to_owned())
+        );
+    }
+    #[test]
+    fn single_control_character_uses_control_key_mapping() {
+        assert_eq!(
+            key_from_translated_unicode_chars(&['\t' as u16], 0x30),
+            Some("tab".to_owned())
+        );
+    }
+
+    #[test]
+    fn surrogate_pair_translation_is_preserved() {
+        assert_eq!(
+            key_from_translated_unicode_chars(&[0xD83D, 0xDE00], 0),
+            Some("😀".to_owned())
+        );
+    }
+
+    #[test]
+    fn multi_character_translation_is_preserved() {
+        assert_eq!(
+            key_from_translated_unicode_chars(&['a' as u16, 'b' as u16], 0),
+            Some("ab".to_owned())
+        );
+    }
+}
+
 pub struct Keycode(pub u16);
 
 impl Keycode {
@@ -33,11 +99,7 @@ impl Keycode {
                 return None;
             }
 
-            let key = &*key.cast::<NSString>();
-            let cstr = key.UTF8String() as *const u8;
-            std::str::from_utf8(slice::from_raw_parts(cstr, key.len()))
-                .ok()
-                .map(|s| s.to_string())
+            nsstring_as_str(key).ok().map(|s| s.to_string())
         }
     }
 

--- a/crates/warpui/src/platform/mac/objc/keycode.m
+++ b/crates/warpui/src/platform/mac/objc/keycode.m
@@ -109,15 +109,30 @@ CFDataRef GetKeyboardLayoutData() {
     return layout_data;
 }
 
+// Converts the UTF-16 output of UCKeyTranslate to a key name. Control-key names
+// are derived from the keycode, as UCKeyTranslate may return either a control
+// character or no characters for those keys.
+NSString* KeyFromTranslatedUnicodeChars(const UniChar* unicodeString,
+                                        UniCharCount actualStringLength,
+                                        unsigned short keyCode) {
+    if (actualStringLength == 0) {
+        return KeyFromControlKeyCode(keyCode);
+    }
+
+    if (actualStringLength == 1 && IsUnicodeControl(unicodeString[0])) {
+        return KeyFromControlKeyCode(keyCode);
+    }
+
+    return [NSString stringWithCharacters:unicodeString length:actualStringLength];
+}
+
 // Referenced from chromium:
 // https://chromium.googlesource.com/chromium/src/+/lkgr/ui/events/keycodes/keyboard_code_conversion_mac.mm
 // Here we take the keyboard layout, keycode, modifier keys, and keyboard type to
-// determine the output character.
-// Notice that we don't yet handle multiple character case here. But this should
-// be minor given Chrome also doesn't support it.
-UniChar TranslatedUnicodeCharFromKeyCode(CFDataRef layout_data, UInt16 key_code,
-                                         UInt32 modifier_key_state, UInt32 keyboard_type) {
-    if (!layout_data) return 0xFFFD;  // REPLACEMENT CHARACTER
+// determine the complete output string.
+NSString* TranslatedUnicodeStringFromKeyCode(CFDataRef layout_data, UInt16 key_code,
+                                             UInt32 modifier_key_state, UInt32 keyboard_type) {
+    if (!layout_data) return @"\uFFFD";  // REPLACEMENT CHARACTER
 
     const UCKeyboardLayout* keyboardLayout = (const UCKeyboardLayout*)CFDataGetBytePtr(layout_data);
 
@@ -129,8 +144,7 @@ UniChar TranslatedUnicodeCharFromKeyCode(CFDataRef layout_data, UInt16 key_code,
     UCKeyTranslate(keyboardLayout, key_code, kUCKeyActionDown, modifier_key_state, keyboard_type,
                    kUCKeyTranslateNoDeadKeysBit, &deadKeyState, maxStringLength,
                    &actualStringLength, unicodeString);
-    // TODO(kevin): Handle multiple character case. Should be rare.
-    return unicodeString[0];
+    return KeyFromTranslatedUnicodeChars(unicodeString, actualStringLength, key_code);
 }
 
 // Convert keycode to its corresponding character on the keyboard.
@@ -145,17 +159,8 @@ NSString* keyCodeToChar(UInt16 keyCode, BOOL shifted) {
     }
 
     CFDataRef layout_data = GetKeyboardLayoutData();
-    UniChar translated_char =
-        TranslatedUnicodeCharFromKeyCode(layout_data, keyCode, modifier_key_state, LMGetKbdLast());
-
-    // UCKeyTranslate can't translate control characters like function keys and arrow
-    // keys. We keep a separate mapping for this case. This is the same behavior as chromium:
-    // https://chromium.googlesource.com/chromium/src/+/lkgr/ui/events/keycodes/keyboard_code_conversion_mac.mm#873
-    if (IsUnicodeControl(translated_char)) {
-        return KeyFromControlKeyCode(keyCode);
-    } else {
-        return [NSString stringWithFormat:@"%C", translated_char];
-    }
+    return TranslatedUnicodeStringFromKeyCode(layout_data, keyCode, modifier_key_state,
+                                              LMGetKbdLast());
 }
 
 NSArray<NSNumber*>* charToKeyCodes(NSString* keyChar) {
@@ -169,24 +174,10 @@ NSArray<NSNumber*>* charToKeyCodes(NSString* keyChar) {
             UInt32 shift_key = 1 << 1;
 
             // Compute a shifted and unshifted version for one keycode.
-            UniChar unshifted =
-                TranslatedUnicodeCharFromKeyCode(layout_data, (UInt16)i, 0, LMGetKbdLast());
-            UniChar shifted =
-                TranslatedUnicodeCharFromKeyCode(layout_data, (UInt16)i, shift_key, LMGetKbdLast());
-
-            NSString* unshifted_str;
-            if (IsUnicodeControl(unshifted)) {
-                unshifted_str = KeyFromControlKeyCode(i);
-            } else {
-                unshifted_str = [NSString stringWithFormat:@"%C", unshifted];
-            }
-
-            NSString* shifted_str;
-            if (IsUnicodeControl(shifted)) {
-                shifted_str = KeyFromControlKeyCode(i);
-            } else {
-                shifted_str = [NSString stringWithFormat:@"%C", shifted];
-            }
+            NSString* unshifted_str =
+                TranslatedUnicodeStringFromKeyCode(layout_data, (UInt16)i, 0, LMGetKbdLast());
+            NSString* shifted_str = TranslatedUnicodeStringFromKeyCode(
+                layout_data, (UInt16)i, shift_key, LMGetKbdLast());
 
             if (unshifted_str != nil && [unshifted_str length] > 0) {
                 if ([keycodeDict objectForKey:unshifted_str] == nil) {


### PR DESCRIPTION
## Description
Preserve the complete UTF-16 sequence returned by macOS `UCKeyTranslate` instead of retaining only the first code unit.

This change:
- builds key names from the full translated `UniChar` buffer
- safely handles zero-character results, retaining existing function/control-key fallbacks
- uses complete translated strings in reverse keycode lookup
- reads the resulting `NSString` using its UTF-8 byte length on the Rust side
- adds focused coverage for empty, printable single-character, control-character, surrogate-pair, and multi-character results

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

- `cargo fmt --manifest-path Cargo.toml -p warpui -- --check`
- `cargo check --manifest-path Cargo.toml -p warpui --lib`
- `cargo clippy --manifest-path Cargo.toml -p warpui --lib -- -D warnings`
- `cargo test --manifest-path Cargo.toml -p warpui --lib` (49 passed, 3 unrelated existing bidirectional first-line-indent tests failed on Linux, 9 ignored)
- The new translation tests are macOS-only and will run in macOS CI.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed macOS keyboard layouts losing multi-character and surrogate-pair key translations.

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: http://localhost:8080/conversation/91d78840-0266-4cba-a328-6f35da2dfcae_
_Run: http://localhost:8082/runs/019f6c3d-9121-738e-84e2-1bdf4ac7cd83_
_This PR was generated with [Oz](https://warp.dev/oz)._
