### PR TITLE
Make IME cursor positioning explicit and testable

### DIFF
--- a/crates/warpui/src/windowing/winit/event_loop/ime_position.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/ime_position.rs
@@ -1,0 +1,119 @@
+//! Explicit IME candidate-window position tracking for winit.
+//!
+//! Winit caches the last IME cursor area by value. When the logical cursor
+//! position is unchanged but the window geometry changes (move, resize, or
+//! scale-factor change), a single `set_ime_cursor_area` call with the same
+//! values is a no-op. To force a refresh we briefly set a one-pixel-offset
+//! position and then the real position.
+//!
+//! The IME size argument is calculated even on X11, where the platform does
+//! not support it; callers should still pass it through so non-X11 backends
+//! can use it.
+
+use winit::dpi::{LogicalPosition, LogicalSize};
+
+use crate::CursorInfo;
+
+/// Why the IME candidate window should be refreshed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ImePositionRefreshReason {
+    /// The text-editing caret moved or the focused field changed.
+    CursorMoved,
+    /// The window's outer position changed.
+    WindowMoved,
+    /// The window's inner size changed.
+    WindowResized,
+    /// The display scale factor changed.
+    ScaleFactorChanged,
+}
+
+/// Logical IME cursor area passed to the platform window.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct ImeCursorArea {
+    pub position: LogicalPosition<f32>,
+    pub size: LogicalSize<f32>,
+}
+
+impl ImeCursorArea {
+    /// Builds the candidate-window area from active cursor info.
+    ///
+    /// The vertical origin is placed slightly below the caret using the font
+    /// size so the candidate window does not cover the current line. Size is
+    /// always derived from `font_size` even though X11 ignores it.
+    pub fn from_cursor_info(cursor: &CursorInfo) -> Self {
+        Self {
+            position: LogicalPosition::new(
+                cursor.position.origin_x(),
+                cursor.position.origin_y() + (1.2 * cursor.font_size),
+            ),
+            // Currently the size argument is not supported on X11. We calculate it here anyway.
+            size: LogicalSize::new(cursor.font_size, cursor.font_size),
+        }
+    }
+
+    /// One-pixel vertical offset used to bust winit's position cache.
+    fn cache_bust_offset(self) -> Self {
+        Self {
+            position: LogicalPosition::new(self.position.x, self.position.y + 1.),
+            size: self.size,
+        }
+    }
+}
+
+/// A single platform update to apply for the IME candidate window.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) enum ImePositionUpdate {
+    Set(ImeCursorArea),
+}
+
+/// Tracks IME enablement and the last area we told the platform about.
+#[derive(Debug, Default)]
+pub(super) struct ImePositionState {
+    enabled: bool,
+    last_area: Option<ImeCursorArea>,
+}
+
+impl ImePositionState {
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+        if !enabled {
+            self.last_area = None;
+        }
+    }
+
+    /// Returns the platform update sequence needed to place the IME candidate
+    /// window at `area`, or an empty sequence when IME is disabled.
+    ///
+    /// The sequence always includes a one-pixel offset followed by the real
+    /// area so winit cannot treat an identical re-application as a no-op after
+    /// window geometry changes.
+    pub fn plan_refresh(
+        &mut self,
+        area: ImeCursorArea,
+        _reason: ImePositionRefreshReason,
+    ) -> Vec<ImePositionUpdate> {
+        if !self.enabled {
+            return Vec::new();
+        }
+
+        let updates = vec![
+            ImePositionUpdate::Set(area.cache_bust_offset()),
+            ImePositionUpdate::Set(area),
+        ];
+        self.last_area = Some(area);
+        updates
+    }
+
+    #[cfg(test)]
+    pub fn last_area(&self) -> Option<ImeCursorArea> {
+        self.last_area
+    }
+}
+
+#[cfg(test)]
+#[path = "ime_position_tests.rs"]
+mod tests;

--- a/crates/warpui/src/windowing/winit/event_loop/ime_position_tests.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/ime_position_tests.rs
@@ -1,0 +1,94 @@
+use pathfinder_geometry::rect::RectF;
+use pathfinder_geometry::vector::vec2f;
+use winit::dpi::{LogicalPosition, LogicalSize};
+
+use super::{ImeCursorArea, ImePositionRefreshReason, ImePositionState, ImePositionUpdate};
+use crate::CursorInfo;
+
+fn cursor(origin_x: f32, origin_y: f32, font_size: f32) -> CursorInfo {
+    CursorInfo {
+        position: RectF::new(vec2f(origin_x, origin_y), vec2f(0., font_size)),
+        font_size,
+    }
+}
+
+fn area(x: f32, y: f32, size: f32) -> ImeCursorArea {
+    ImeCursorArea {
+        position: LogicalPosition::new(x, y),
+        size: LogicalSize::new(size, size),
+    }
+}
+
+#[test]
+fn from_cursor_info_places_area_below_caret_and_uses_font_size() {
+    let info = cursor(10., 20., 16.);
+    let derived = ImeCursorArea::from_cursor_info(&info);
+    assert_eq!(derived, area(10., 20. + 1.2 * 16., 16.));
+}
+
+#[test]
+fn plan_refresh_is_empty_when_ime_disabled() {
+    let mut state = ImePositionState::default();
+    assert!(!state.is_enabled());
+
+    let updates = state.plan_refresh(area(1., 2., 12.), ImePositionRefreshReason::CursorMoved);
+    assert!(updates.is_empty());
+    assert_eq!(state.last_area(), None);
+}
+
+#[test]
+fn plan_refresh_always_emits_cache_bust_then_real_position() {
+    let mut state = ImePositionState::default();
+    state.set_enabled(true);
+
+    let target = area(40., 80., 14.);
+    let updates = state.plan_refresh(target, ImePositionRefreshReason::CursorMoved);
+
+    assert_eq!(
+        updates,
+        vec![
+            ImePositionUpdate::Set(area(40., 81., 14.)),
+            ImePositionUpdate::Set(target),
+        ]
+    );
+    assert_eq!(state.last_area(), Some(target));
+}
+
+#[test]
+fn plan_refresh_forces_sequence_for_geometry_changes_with_same_area() {
+    let mut state = ImePositionState::default();
+    state.set_enabled(true);
+
+    let target = area(5., 10., 12.);
+    let _ = state.plan_refresh(target, ImePositionRefreshReason::CursorMoved);
+
+    for reason in [
+        ImePositionRefreshReason::WindowMoved,
+        ImePositionRefreshReason::WindowResized,
+        ImePositionRefreshReason::ScaleFactorChanged,
+        ImePositionRefreshReason::CursorMoved,
+    ] {
+        let updates = state.plan_refresh(target, reason);
+        assert_eq!(
+            updates,
+            vec![
+                ImePositionUpdate::Set(area(5., 11., 12.)),
+                ImePositionUpdate::Set(target),
+            ],
+            "reason {reason:?} should still force a cache-bust sequence"
+        );
+        assert_eq!(state.last_area(), Some(target));
+    }
+}
+
+#[test]
+fn disabling_ime_clears_last_area() {
+    let mut state = ImePositionState::default();
+    state.set_enabled(true);
+    let _ = state.plan_refresh(area(1., 2., 10.), ImePositionRefreshReason::CursorMoved);
+    assert!(state.last_area().is_some());
+
+    state.set_enabled(false);
+    assert!(!state.is_enabled());
+    assert_eq!(state.last_area(), None);
+}

--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -1,3 +1,4 @@
+mod ime_position;
 mod key_events;
 
 #[cfg(test)]
@@ -22,6 +23,9 @@ use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoopProxy};
 use winit::keyboard::{self, KeyCode};
 use winit::window::WindowId as WinitWindowId;
 
+use self::ime_position::{
+    ImeCursorArea, ImePositionRefreshReason, ImePositionState, ImePositionUpdate,
+};
 use self::key_events::convert_keyboard_input_event;
 use super::app::ClipboardEvent;
 use super::window::DEFAULT_TITLEBAR_HEIGHT;
@@ -493,7 +497,9 @@ pub(super) struct EventLoop {
     window_class: Option<String>,
     state: State,
     proxy: EventLoopProxy<CustomEvent>,
-    ime_enabled: bool,
+    /// Explicit IME candidate-window position state, including enablement and
+    /// the last area applied to the platform window.
+    ime_position: ImePositionState,
     /// Whether to downrank non-NVIDIA vulkan adapters. This is set to true when we detect a DRI3
     /// error that occurs when trying to present against a non-NVIDIA Vulkan adapter when the
     /// PRIME Profile is set to "Performance" mode.  It's not fully clear why this error occurs. Our
@@ -522,7 +528,7 @@ impl EventLoop {
             window_class,
             state: Default::default(),
             proxy,
-            ime_enabled: false,
+            ime_position: ImePositionState::default(),
             downrank_non_nvidia_vulkan_adapters: false,
             #[cfg(target_family = "wasm")]
             soft_keyboard_manager: None,
@@ -741,9 +747,7 @@ impl EventLoop {
                 });
             }
             Event::UserEvent(CustomEvent::ActiveCursorPositionUpdated) => {
-                if self.ime_enabled {
-                    self.update_ime_position();
-                }
+                self.refresh_ime_position(ImePositionRefreshReason::CursorMoved);
             }
             Event::UserEvent(CustomEvent::AboutToSleep) => {
                 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
@@ -879,6 +883,11 @@ impl EventLoop {
                         mut inner_size_writer,
                     },
             } => {
+                // Refresh IME placement whenever the scale factor changes. The logical
+                // caret coords may be unchanged, but the physical candidate-window
+                // placement still needs to move with the display scale.
+                self.refresh_ime_position(ImePositionRefreshReason::ScaleFactorChanged);
+
                 // The following correction is only needed on Windows.
                 if !cfg!(windows) {
                     return;
@@ -1058,6 +1067,10 @@ impl EventLoop {
                 window.handle_resize();
                 self.callbacks.for_window(window).window_resized(window);
                 self.callbacks.window_resized();
+                // window_resized may already report a cursor-position update, but we
+                // still force an IME refresh here so geometry-only resizes bust winit's
+                // cached candidate-window position even when the caret is unchanged.
+                self.refresh_ime_position(ImePositionRefreshReason::WindowResized);
             }
             ConvertedEvent::ModifierKeyChanged { key_code, state } => {
                 let mut window_callbacks = self.callbacks.for_window(window.as_ref());
@@ -1103,6 +1116,10 @@ impl EventLoop {
                     .for_window(window)
                     .window_moved(RectF::new(vec2f(position.x, position.y), size));
                 self.callbacks.window_moved();
+                // window_moved may already report a cursor-position update, but we still
+                // force an IME refresh so winit re-applies the candidate window after a
+                // pure geometry change.
+                self.refresh_ime_position(ImePositionRefreshReason::WindowMoved);
             }
             ConvertedEvent::MoveWindowBy {
                 current_touch,
@@ -1519,12 +1536,12 @@ impl EventLoop {
     fn handle_ime_event(&mut self, winit_window_id: WinitWindowId, event: ImeEvent) {
         match event {
             winit::event::Ime::Enabled => {
-                self.ime_enabled = true;
+                self.ime_position.set_enabled(true);
                 self.ui_app
                     .update(|ctx| ctx.report_active_cursor_position_update());
             }
             winit::event::Ime::Preedit(preedit_text, cursor_position) => {
-                if !self.ime_enabled {
+                if !self.ime_position.is_enabled() {
                     return;
                 }
 
@@ -1564,7 +1581,7 @@ impl EventLoop {
                 window_callbacks.dispatch_event(TypedCharacters { chars });
             }
             winit::event::Ime::Disabled => {
-                self.ime_enabled = false;
+                self.ime_position.set_enabled(false);
             }
         };
     }
@@ -1778,7 +1795,13 @@ impl EventLoop {
         abort_handle
     }
 
-    fn update_ime_position(&mut self) {
+    /// Recomputes the active caret's IME candidate-window area and applies the
+    /// planned platform update sequence for `reason`.
+    fn refresh_ime_position(&mut self, reason: ImePositionRefreshReason) {
+        if !self.ime_position.is_enabled() {
+            return;
+        }
+
         let Some(active_window_id) = self.ui_app.read(|ctx| ctx.windows().active_window()) else {
             return;
         };
@@ -1790,23 +1813,19 @@ impl EventLoop {
         };
 
         let mut window_callbacks = self.callbacks.for_window(window.as_ref());
-        let active_cursor_position = window_callbacks.get_active_cursor_position();
-        if let Some(active_cursor_position) = active_cursor_position {
-            let winit_window = downcast_window(window.as_ref());
-            let position = LogicalPosition::new(
-                active_cursor_position.position.origin_x(),
-                active_cursor_position.position.origin_y()
-                    + (1.2 * active_cursor_position.font_size),
-            );
-            // Currently the size argument is not supported on X11. We calculate it here anyway.
-            let size = LogicalSize::new(
-                active_cursor_position.font_size,
-                active_cursor_position.font_size,
-            );
-            // TODO(abhishek): We make sure that the position is different than last time to prevent winit from
-            // caching the old position and not properly updating on `WindowMoved` or `WindowResized` events.
-            winit_window.set_ime_position(LogicalPosition::new(position.x, position.y + 1.), size);
-            winit_window.set_ime_position(position, size);
+        let Some(active_cursor_position) = window_callbacks.get_active_cursor_position() else {
+            return;
+        };
+
+        let area = ImeCursorArea::from_cursor_info(&active_cursor_position);
+        let updates = self.ime_position.plan_refresh(area, reason);
+        let winit_window = downcast_window(window.as_ref());
+        for update in updates {
+            match update {
+                ImePositionUpdate::Set(area) => {
+                    winit_window.set_ime_position(area.position, area.size);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Description
Make winit IME candidate-window positioning explicit and testable.

The previous event-loop helper applied a one-pixel cache-bust inline whenever the active caret moved. This PR:

- Encapsulates that workaround behind `ImePositionState` / `ImeCursorArea` / `ImePositionUpdate`
- Tracks IME enablement and the last applied area explicitly
- Refreshes the candidate window on caret movement, window move, resize, and scale-factor change
- Continues calculating an IME size from font size even though X11 does not support it

## Linked Issue
- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

## Testing
- Added deterministic unit tests for the planned IME update sequence (`ime_position_tests.rs`)
- `cargo nextest run -p warpui --lib ime_position --no-fail-fast`

- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos
N/A — internal windowing/IME plumbing with no user-visible UI change.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-NONE

_Conversation: http://localhost:8080/conversation/a02d8079-712f-4099-8bc7-d87bcbd06b36_
_Run: http://localhost:8082/runs/019f6c3d-8536-7111-8f2f-d216a526f521_
_This PR was generated with [Oz](https://warp.dev/oz)._
