### PR TITLE
Fix child conversation stuck as InProgress when cloud child run completes (REMOTE-2187)

### DIFF
--- a/app/src/ai/blocklist/orchestration_event_streamer.rs
+++ b/app/src/ai/blocklist/orchestration_event_streamer.rs
@@ -2102,6 +2102,11 @@ impl OrchestrationEventStreamer {
                 .extend(message_ids);
         }
 
+        // Sync child conversation statuses directly so that hidden child panes
+        // reflect the completed run state immediately, without waiting for the
+        // parent agent to process the events via `wait_for_events`.
+        self.sync_child_conversation_statuses_from_events(&events, self_run_id, ctx);
+
         let lifecycle_events = convert_lifecycle_events(&events, self_run_id);
         if messages.is_empty() && lifecycle_events.is_empty() {
             return;
@@ -2110,6 +2115,89 @@ impl OrchestrationEventStreamer {
         let pending = build_pending_events(messages, lifecycle_events);
         OrchestrationEventService::handle(ctx).update(ctx, |svc, ctx| {
             svc.enqueue_event_batch(conversation_id, pending, ctx);
+        });
+    }
+
+    /// Syncs child conversation statuses in [`BlocklistAIHistoryModel`] directly
+    /// from SSE lifecycle events.
+    ///
+    /// Without this, remote child conversations stay stuck as
+    /// [`ConversationStatus::InProgress`] indefinitely after the child run
+    /// completes. The owner-side SSE delivers child lifecycle events to
+    /// [`OrchestrationEventService`] (for forwarding to the server via the parent
+    /// agent's `wait_for_events` turn), but the child conversation's local
+    /// [`ConversationStatus`] in [`BlocklistAIHistoryModel`] is never explicitly
+    /// updated, because:
+    /// - [`LocalAgentTaskSyncModel`] skips remote children to avoid race
+    ///   conditions with the worker's own status reporting.
+    /// - The child's SSE connection is excluded via `is_remote_run_view`.
+    /// - The parent's `wait_for_events` resumes the parent agent, but does not
+    ///   update the child's local `ConversationStatus`.
+    ///
+    /// This method patches the gap: when a terminal lifecycle event arrives for a
+    /// non-self run_id whose local conversation is a child agent conversation in a
+    /// non-terminal state, the status is pushed directly to
+    /// [`BlocklistAIHistoryModel`]. This ensures any open child pane's input hint
+    /// text and warping indicator reflect the completed state.
+    fn sync_child_conversation_statuses_from_events(
+        &self,
+        events: &[AgentRunEvent],
+        self_run_id: &str,
+        ctx: &mut ModelContext<Self>,
+    ) {
+        // Collect (terminal_surface_id, child_conv_id, status) tuples in a
+        // read-only pass to avoid a mutable-borrow conflict with the write below.
+        let updates: Vec<(EntityId, AIConversationId, ConversationStatus)> = {
+            let history = BlocklistAIHistoryModel::as_ref(ctx);
+            events
+                .iter()
+                .filter(|event| event.event_type != "new_message" && event.run_id != self_run_id)
+                .filter_map(|event| {
+                    let lifecycle_type = lifecycle_event_type_from_wire(event.event_type.as_str())?;
+                    let status = conversation_status_from_lifecycle_event_type(lifecycle_type);
+                    // Only apply terminal transitions. Non-terminal states (InProgress)
+                    // are already the initial default and need not be re-asserted.
+                    if !status.is_done() && !status.is_blocked() {
+                        return None;
+                    }
+                    let child_conv_id = history.conversation_id_for_agent_id(&event.run_id)?;
+                    let conversation = history.conversation(&child_conv_id)?;
+                    // Only update child agent conversations.
+                    if !conversation.is_child_agent_conversation() {
+                        return None;
+                    }
+                    // Skip conversations already in a terminal state to avoid
+                    // inadvertent status regressions.
+                    if conversation.status().is_done() || conversation.status().is_blocked() {
+                        return None;
+                    }
+                    // Only update conversations that are live in a terminal
+                    // surface; if the child pane is not open, there is no UI
+                    // to update and the next pane-open will hydrate correctly.
+                    let terminal_surface_id =
+                        history.terminal_surface_id_for_conversation(&child_conv_id)?;
+                    Some((terminal_surface_id, child_conv_id, status))
+                })
+                .collect()
+        };
+
+        if updates.is_empty() {
+            return;
+        }
+
+        BlocklistAIHistoryModel::handle(ctx).update(ctx, move |history_model, ctx| {
+            for (terminal_surface_id, child_conv_id, status) in updates {
+                log::info!(
+                    "OrchestrationEventStreamer: syncing child conversation {child_conv_id:?} \
+                     status to {status} from SSE lifecycle event"
+                );
+                history_model.update_conversation_status(
+                    terminal_surface_id,
+                    child_conv_id,
+                    status,
+                    ctx,
+                );
+            }
         });
     }
 


### PR DESCRIPTION
## Description

Fixes a bug where the Warp native client gets stuck in 'Warping...' state when a cloud Oz child agent run has completed. The conversation input area shows "Steer the {agent_name} agent" (InProgress hint text) even though the run details panel on the right shows the run as Done.

## Root Cause

When a remote child agent run completes, the owner-side `OrchestrationEventStreamer` forwards child lifecycle events (`run_succeeded`, `run_failed`, etc.) to the parent agent's `OrchestrationEventService` for server-side processing via `wait_for_events`. However, the child conversation's local `ConversationStatus` in `BlocklistAIHistoryModel` was **never updated**, leaving the child pane stuck in `InProgress`. This happened because:

1. `LocalAgentTaskSyncModel` explicitly skips remote children to avoid races with the worker's own status reporting
2. The child's SSE connection is excluded via `is_remote_run_view`  
3. The parent's `wait_for_events` only resumes the parent agent — it doesn't update the child's local `ConversationStatus`

## Fix

Added `sync_child_conversation_statuses_from_events` to `OrchestrationEventStreamer::handle_event_batch`. When terminal lifecycle events (`run_succeeded`, `run_failed`, `run_errored`, `run_cancelled`, `run_blocked`) arrive via SSE for non-self run IDs, the method:

1. Looks up the corresponding local child conversation via `conversation_id_for_agent_id`
2. Checks it's a child agent conversation in a non-terminal state
3. Updates its `ConversationStatus` directly in `BlocklistAIHistoryModel`

This causes the `agent_input_footer` to re-render, changing the hint text from "Steer the agent" (InProgress) to "Ask the agent a follow up" (Success).

## Linked Issue

Fixes REMOTE-2187

## Testing

- [ ] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- [ ] Where appropriate, screenshots or a short video of the implementation are included below (especially for user-visible or UI changes).

The fix addresses a race/desync condition that occurs when:
1. An orchestrator pane starts a remote child run via `run_agents(remote)`
2. The child run completes on the cloud worker
3. The native client's child conversation pane remains stuck showing "Warping..." / "Steer the agent" hint

Manual verification would require running an orchestrated cloud agent with child runs and confirming the child pane input transitions from "Steer the agent" to "Ask a follow up" when the child run completes.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!-- CHANGELOG-BUG-FIX: Fixed native client input stuck in 'Warping...' state for child cloud agent runs that have completed -->

_Conversation: https://staging.warp.dev/conversation/4d3bdca0-cf0f-4458-b16b-06cce3aa244e_
_Run: https://oz.staging.warp.dev/runs/019f6c51-90ca-7d9e-aa8b-eaa6240bdf25_

_This PR was generated with [Oz](https://warp.dev/oz)._
