### PR TITLE
Preserve full UTF-16 sequences in macOS key translation

### DIFF
--- a/crates/warpui/src/platform/mac/keycode.rs
+++ b/crates/warpui/src/platform/mac/keycode.rs
@@ -240,3 +240,7 @@ pub(crate) fn scancode_to_physicalkey(scancode: u32) -> PhysicalKey {
         _ => return PhysicalKey::Unidentified(NativeKeyCode::MacOS(scancode as u16)),
     })
 }
+
+#[cfg(test)]
+#[path = "keycode_tests.rs"]
+mod tests;

--- a/crates/warpui/src/platform/mac/keycode_tests.rs
+++ b/crates/warpui/src/platform/mac/keycode_tests.rs
@@ -1,0 +1,115 @@
+//! Unit tests for the UTF-16 sequence handling in `objc/keycode.m`.
+//!
+//! `keyCodeToChar` / `charToKeyCodes` ultimately run every translation through
+//! `KeyNameFromTranslatedChars`, which turns the raw `UCKeyTranslate` output
+//! (`unicode_string` + `length`) into a key name. We exercise that helper
+//! directly with crafted UTF-16 buffers so the empty, single-character,
+//! surrogate-pair, and multi-character cases are covered deterministically,
+//! independent of whatever keyboard layout the test machine happens to use.
+use std::slice;
+
+use cocoa::base::{id, nil};
+use cocoa::foundation::NSAutoreleasePool;
+use objc2_foundation::NSString;
+
+// `kVK_ANSI_A` — a normal (non-control) key. Its empty translation has no
+// control-key fallback, so it lets us observe the raw sequence handling.
+const KEY_CODE_A: u16 = 0x00;
+// `kVK_Return` — produces a carriage-return control unit that must map to "enter".
+const KEY_CODE_RETURN: u16 = 0x24;
+// `kVK_LeftArrow` — a key `UCKeyTranslate` can't translate; used to check that an
+// empty translation still resolves through the control-key map.
+const KEY_CODE_LEFT_ARROW: u16 = 0x7B;
+
+extern "C" {
+    // Defined in `objc/keycode.m`. `length` is a `size_t` count of UTF-16 units.
+    fn KeyNameFromTranslatedChars(key_code: u16, unicode_string: *const u16, length: usize) -> id;
+}
+
+/// Calls `KeyNameFromTranslatedChars` with the given UTF-16 units and converts
+/// the (autoreleased) `NSString` result into an owned `String`, or `None` when
+/// the helper returns `nil`.
+///
+/// # Safety
+/// Must run inside an active autorelease pool so the returned string outlives
+/// the call.
+unsafe fn key_name(key_code: u16, units: &[u16]) -> Option<String> {
+    let ptr = KeyNameFromTranslatedChars(key_code, units.as_ptr(), units.len());
+    if ptr.is_null() {
+        return None;
+    }
+    let key = &*ptr.cast::<NSString>();
+    // `NSString::len` reports the UTF-8 byte count, matching `UTF8String`.
+    let cstr = key.UTF8String() as *const u8;
+    std::str::from_utf8(slice::from_raw_parts(cstr, key.len()))
+        .ok()
+        .map(|s| s.to_string())
+}
+
+#[test]
+fn single_character_result_is_preserved() {
+    unsafe {
+        let pool = NSAutoreleasePool::new(nil);
+        let units = [b'a' as u16];
+        assert_eq!(key_name(KEY_CODE_A, &units), Some("a".to_string()));
+        pool.drain();
+    }
+}
+
+#[test]
+fn multi_character_result_is_preserved() {
+    unsafe {
+        let pool = NSAutoreleasePool::new(nil);
+        // 'e' + U+0301 COMBINING ACUTE ACCENT => "é" as two UTF-16 units. The old
+        // implementation dropped the combining mark by returning only the first
+        // unit.
+        let units = [b'e' as u16, 0x0301];
+        assert_eq!(key_name(KEY_CODE_A, &units), Some("e\u{0301}".to_string()));
+        pool.drain();
+    }
+}
+
+#[test]
+fn surrogate_pair_result_is_preserved() {
+    unsafe {
+        let pool = NSAutoreleasePool::new(nil);
+        // U+1F600 GRINNING FACE is encoded as the surrogate pair D83D DE00. Both
+        // units must survive to reconstruct the code point.
+        let units = [0xD83D_u16, 0xDE00_u16];
+        assert_eq!(key_name(KEY_CODE_A, &units), Some("\u{1F600}".to_string()));
+        pool.drain();
+    }
+}
+
+#[test]
+fn empty_result_for_non_control_key_is_none() {
+    unsafe {
+        let pool = NSAutoreleasePool::new(nil);
+        // A zero-length translation must be handled safely (no out-of-bounds read)
+        // and, for a key with no control-key mapping, produce no name.
+        assert_eq!(key_name(KEY_CODE_A, &[]), None);
+        pool.drain();
+    }
+}
+
+#[test]
+fn empty_result_for_control_key_uses_control_mapping() {
+    unsafe {
+        let pool = NSAutoreleasePool::new(nil);
+        // Arrow keys can translate to nothing; the control-key map still names them.
+        assert_eq!(key_name(KEY_CODE_LEFT_ARROW, &[]), Some("left".to_string()));
+        pool.drain();
+    }
+}
+
+#[test]
+fn control_character_first_unit_uses_control_mapping() {
+    unsafe {
+        let pool = NSAutoreleasePool::new(nil);
+        // A leading control unit (here CR for Return) is not printable text, so it
+        // resolves through the control-key map rather than being emitted verbatim.
+        let units = [0x0D_u16];
+        assert_eq!(key_name(KEY_CODE_RETURN, &units), Some("enter".to_string()));
+        pool.drain();
+    }
+}

--- a/crates/warpui/src/platform/mac/objc/keycode.m
+++ b/crates/warpui/src/platform/mac/objc/keycode.m
@@ -109,28 +109,50 @@ CFDataRef GetKeyboardLayoutData() {
     return layout_data;
 }
 
+// Builds the canonical key name for a UTF-16 sequence produced by UCKeyTranslate.
+// `unicode_string`/`length` is the raw output buffer and the number of UTF-16
+// code units actually written.
+//
+// UCKeyTranslate can emit zero, one, or many code units: dead keys emit nothing,
+// while combining marks and characters outside the BMP (e.g. emoji, which arrive
+// as surrogate pairs) emit multiple units. We preserve the whole sequence instead
+// of truncating to the first unit.
+//
+// UCKeyTranslate can't translate control characters like function keys and arrow
+// keys; those arrive as a single control unit. We detect that case (and the empty
+// case) and fall back to a dedicated mapping. This matches chromium:
+// https://chromium.googlesource.com/chromium/src/+/lkgr/ui/events/keycodes/keyboard_code_conversion_mac.mm#873
+// Only the first unit is checked, which keeps existing function/control-key
+// mappings unchanged and avoids indexing an empty buffer.
+NSString* KeyNameFromTranslatedChars(UInt16 key_code, const UniChar* unicode_string,
+                                     size_t length) {
+    if (length == 0 || IsUnicodeControl(unicode_string[0])) {
+        return KeyFromControlKeyCode(key_code);
+    }
+    return [NSString stringWithCharacters:unicode_string length:length];
+}
+
 // Referenced from chromium:
 // https://chromium.googlesource.com/chromium/src/+/lkgr/ui/events/keycodes/keyboard_code_conversion_mac.mm
 // Here we take the keyboard layout, keycode, modifier keys, and keyboard type to
-// determine the output character.
-// Notice that we don't yet handle multiple character case here. But this should
-// be minor given Chrome also doesn't support it.
-UniChar TranslatedUnicodeCharFromKeyCode(CFDataRef layout_data, UInt16 key_code,
-                                         UInt32 modifier_key_state, UInt32 keyboard_type) {
-    if (!layout_data) return 0xFFFD;  // REPLACEMENT CHARACTER
+// determine the output key name, preserving the complete translated UTF-16
+// sequence.
+NSString* TranslatedKeyNameFromKeyCode(CFDataRef layout_data, UInt16 key_code,
+                                       UInt32 modifier_key_state, UInt32 keyboard_type) {
+    if (!layout_data) return @"\uFFFD";  // REPLACEMENT CHARACTER
 
     const UCKeyboardLayout* keyboardLayout = (const UCKeyboardLayout*)CFDataGetBytePtr(layout_data);
 
     UInt32 deadKeyState = 0;
-    UniCharCount maxStringLength = 255;
+    const UniCharCount maxStringLength = 255;
     UniCharCount actualStringLength = 0;
     UniChar unicodeString[maxStringLength];
 
     UCKeyTranslate(keyboardLayout, key_code, kUCKeyActionDown, modifier_key_state, keyboard_type,
                    kUCKeyTranslateNoDeadKeysBit, &deadKeyState, maxStringLength,
                    &actualStringLength, unicodeString);
-    // TODO(kevin): Handle multiple character case. Should be rare.
-    return unicodeString[0];
+
+    return KeyNameFromTranslatedChars(key_code, unicodeString, actualStringLength);
 }
 
 // Convert keycode to its corresponding character on the keyboard.
@@ -145,17 +167,7 @@ NSString* keyCodeToChar(UInt16 keyCode, BOOL shifted) {
     }
 
     CFDataRef layout_data = GetKeyboardLayoutData();
-    UniChar translated_char =
-        TranslatedUnicodeCharFromKeyCode(layout_data, keyCode, modifier_key_state, LMGetKbdLast());
-
-    // UCKeyTranslate can't translate control characters like function keys and arrow
-    // keys. We keep a separate mapping for this case. This is the same behavior as chromium:
-    // https://chromium.googlesource.com/chromium/src/+/lkgr/ui/events/keycodes/keyboard_code_conversion_mac.mm#873
-    if (IsUnicodeControl(translated_char)) {
-        return KeyFromControlKeyCode(keyCode);
-    } else {
-        return [NSString stringWithFormat:@"%C", translated_char];
-    }
+    return TranslatedKeyNameFromKeyCode(layout_data, keyCode, modifier_key_state, LMGetKbdLast());
 }
 
 NSArray<NSNumber*>* charToKeyCodes(NSString* keyChar) {
@@ -168,25 +180,13 @@ NSArray<NSNumber*>* charToKeyCodes(NSString* keyChar) {
         for (i = 0; i < 128; ++i) {
             UInt32 shift_key = 1 << 1;
 
-            // Compute a shifted and unshifted version for one keycode.
-            UniChar unshifted =
-                TranslatedUnicodeCharFromKeyCode(layout_data, (UInt16)i, 0, LMGetKbdLast());
-            UniChar shifted =
-                TranslatedUnicodeCharFromKeyCode(layout_data, (UInt16)i, shift_key, LMGetKbdLast());
-
-            NSString* unshifted_str;
-            if (IsUnicodeControl(unshifted)) {
-                unshifted_str = KeyFromControlKeyCode(i);
-            } else {
-                unshifted_str = [NSString stringWithFormat:@"%C", unshifted];
-            }
-
-            NSString* shifted_str;
-            if (IsUnicodeControl(shifted)) {
-                shifted_str = KeyFromControlKeyCode(i);
-            } else {
-                shifted_str = [NSString stringWithFormat:@"%C", shifted];
-            }
+            // Compute a shifted and unshifted key name for one keycode. The full
+            // translated sequence is used as the dictionary key so multi-unit
+            // results (surrogate pairs, combining marks) round-trip correctly.
+            NSString* unshifted_str =
+                TranslatedKeyNameFromKeyCode(layout_data, (UInt16)i, 0, LMGetKbdLast());
+            NSString* shifted_str =
+                TranslatedKeyNameFromKeyCode(layout_data, (UInt16)i, shift_key, LMGetKbdLast());
 
             if (unshifted_str != nil && [unshifted_str length] > 0) {
                 if ([keycodeDict objectForKey:unshifted_str] == nil) {


### PR DESCRIPTION
## Description
`crates/warpui/src/platform/mac/objc/keycode.m`'s `TranslatedUnicodeCharFromKeyCode` discarded everything but the first UTF-16 code unit returned by `UCKeyTranslate`, and it read `unicodeString[0]` even when the translation produced **zero** characters — reading uninitialized stack memory for dead keys and other empty translations.

This meant characters that translate to more than one UTF-16 unit (combining marks, and code points outside the BMP such as emoji, which arrive as surrogate pairs) were silently truncated to a single unit, and empty translations were undefined behavior.

### Changes
- Add `KeyNameFromTranslatedChars(key_code, unicode_string, length)` which:
  - preserves the **complete** translated UTF-16 sequence via `+[NSString stringWithCharacters:length:]`,
  - handles zero-character translations safely (no out-of-bounds read),
  - keeps function/arrow/control-key mappings unchanged by checking only the first unit for a control character and falling back to `KeyFromControlKeyCode`.
- Replace `TranslatedUnicodeCharFromKeyCode` with `TranslatedKeyNameFromKeyCode`, which wraps `UCKeyTranslate` and returns the full key name (preserving the existing `U+FFFD` fallback when layout data is unavailable).
- Simplify `keyCodeToChar` to delegate to the new function.
- Update the reverse lookup in `charToKeyCodes` to store the **complete** translated string as the dictionary key, so multi-unit results round-trip. Existing autorelease fixes on the `NSMutableArray` allocations are preserved.

## Linked Issue
N/A

## Testing
Added focused Rust FFI unit tests (`crates/warpui/src/platform/mac/keycode_tests.rs`) that drive `KeyNameFromTranslatedChars` with crafted UTF-16 buffers, independent of the active keyboard layout, covering:
- empty result for a non-control key (→ `None`, verifies safe zero-length handling),
- empty result for a control key (arrow → `left`),
- single-character result (`a`),
- multi-character result (`e` + U+0301 combining acute),
- surrogate-pair result (U+1F600),
- leading control unit (CR for Return → `enter`).

`clang-format` (repo `.clang-format`) and `rustfmt` both pass on the changed files.

> Note: the touched code is macOS-only (`#[cfg(target_os = "macos")]`), so it cannot be compiled/run in the Linux sandbox where this change was authored. The tests are written to run under `cargo nextest` on macOS.

- [ ] I have manually tested my changes locally with `./script/run`

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed macOS keyboard layouts whose keys translate to multiple characters (combining marks, emoji/surrogate pairs) being truncated to a single character.
-->

_Conversation: http://localhost:8080/conversation/796f2b23-c62b-48ab-84b8-0554cccff77f_
_Run: http://localhost:8082/runs/019f6c7a-73f0-72c6-a90f-a4d2a88fc0be_

_This PR was generated with [Oz](https://warp.dev/oz)._
