### PR TITLE
Fix session freeze when opening shared session from web in native app (REMOTE-2189)

### DIFF
--- a/app/src/root_view.rs
+++ b/app/src/root_view.rs
@@ -2629,9 +2629,34 @@ impl RootView {
         ctx: &mut ViewContext<Self>,
     ) -> bool {
         if let AuthOnboardingState::Terminal(handle) = &self.auth_onboarding_state {
+            // Check if we already have a pane viewing or sharing this session. If so,
+            // focus the existing pane instead of opening a duplicate viewer. This handles
+            // the cross-platform scenario where a user opens a session link in the native
+            // app from the web while the session is already open in another pane — without
+            // this check a new read-only viewer pane would be created, leaving the user
+            // with a frozen input.
+            use crate::terminal::shared_session::manager::Manager;
+            let existing_viewer_id = Manager::as_ref(ctx)
+                .joined_view_by_session_id(session_id, ctx)
+                .or_else(|| Manager::as_ref(ctx).shared_view_by_session_id(session_id, ctx))
+                .map(|view| view.id());
+
+            let session_id = *session_id;
             handle.update(ctx, |workspace, ctx| {
+                if let Some(existing_terminal_view_id) = existing_viewer_id {
+                    // Focus the existing pane so the user continues interacting with their
+                    // already-established session (which may have executor access), rather
+                    // than opening a new read-only viewer.
+                    if workspace.focus_terminal_view(existing_terminal_view_id, ctx) {
+                        log::info!(
+                            "Focused existing pane for session {session_id} instead of creating a new viewer"
+                        );
+                        return;
+                    }
+                }
+                // No existing pane found — create a new viewer.
                 // Generic session link: ambient-ness (if any) is discovered at SessionJoined.
-                workspace.add_tab_for_joining_shared_session(*session_id, false, ctx);
+                workspace.add_tab_for_joining_shared_session(session_id, false, ctx);
             });
             let window_id = ctx.window_id();
             ctx.windows().show_window_and_focus_app(window_id);

--- a/app/src/terminal/shared_session/manager.rs
+++ b/app/src/terminal/shared_session/manager.rs
@@ -99,6 +99,26 @@ impl Manager {
         view_handle
     }
 
+    /// Returns the view handle for an active joined session with the given session ID, if any.
+    pub fn joined_view_by_session_id(
+        &self,
+        session_id: &SessionId,
+        ctx: &AppContext,
+    ) -> Option<ViewHandle<TerminalView>> {
+        let weak_handle = self
+            .joined
+            .values()
+            .find(|state| state.session_id == *session_id)
+            .map(|state| state.view_handle.clone())?;
+
+        let view_handle = weak_handle.upgrade(ctx);
+        if view_handle.is_none() {
+            log::warn!("Failed to upgrade a joined terminal view in the shared session manager");
+        }
+
+        view_handle
+    }
+
     /// Returns the view handle to the joined terminal view, identified by `terminal_view_id`, if it's being viewed.
     pub fn joined_view_by_id(
         &self,

--- a/app/src/terminal/view/shared_session/view_impl.rs
+++ b/app/src/terminal/view/shared_session/view_impl.rs
@@ -210,6 +210,13 @@ impl TerminalView {
         ctx: &mut ViewContext<Self>,
     ) {
         self.pending_cloud_followup_task_id = Some(task_id);
+        // Reset the action model's view-only flag when transitioning from a shared session viewer
+        // to an interactive follow-up state. The view-only flag is set during session replay
+        // (in on_shared_init) to prevent viewers from accepting AI actions during an active run,
+        // but must be cleared when the session ends and the user becomes the owner of the follow-up.
+        self.ai_action_model.update(ctx, |action_model, _| {
+            action_model.set_view_only(false);
+        });
         self.input.update(ctx, |input, ctx| {
             input.reset_after_cloud_followup_submission(ctx);
             input.set_input_mode_agent(true, ctx);

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -5821,6 +5821,33 @@ impl Workspace {
     }
 
     /// Searches this workspace's tabs for the given terminal view and focuses it.
+    /// Also searches other windows if not found locally. Returns true if found and focused.
+    /// Used when navigating to an existing pane (e.g., when re-opening a session already open).
+    pub fn focus_terminal_view(
+        &mut self,
+        terminal_view_id: EntityId,
+        ctx: &mut ViewContext<Self>,
+    ) -> bool {
+        if self.focus_terminal_view_locally(terminal_view_id, ctx) {
+            return true;
+        }
+        self.focus_terminal_view_in_other_window(terminal_view_id, ctx);
+        // focus_terminal_view_in_other_window doesn't return a bool, but dispatches
+        // cross-window actions. Report success based on whether we found the view in another window.
+        WorkspaceRegistry::as_ref(ctx)
+            .all_workspaces(ctx)
+            .iter()
+            .any(|(_, workspace)| {
+                workspace.as_ref(ctx).tab_views().any(|pane_group| {
+                    pane_group
+                        .as_ref(ctx)
+                        .find_pane_id_for_terminal_view(terminal_view_id, ctx)
+                        .is_some()
+                })
+            })
+    }
+
+    /// Searches this workspace's tabs for the given terminal view and focuses it.
     /// Returns true if the terminal view was found and focused.
     fn focus_terminal_view_locally(
         &mut self,


### PR DESCRIPTION
## Description

Fixes session freeze issues when a user accesses a cloud agent session across platforms (Linear → web → native desktop app).

Two root causes identified:

### 1. `view_only` flag never reset after session replay

`action_model.set_view_only(true)` is called in `on_shared_init` during every shared session response event (including replay), but `set_view_only(false)` is **never called anywhere**. This causes the action model to remain stuck in view-only mode after:
- A session is replayed when opening a viewer pane
- The session ends and the user transitions to follow-up mode

In view-only mode, users cannot accept AI actions (code diffs, command suggestions) even when they're the session owner doing a follow-up.

**Fix:** Reset `view_only = false` in `enable_cloud_followup_input` — the transition point from viewer mode to interactive follow-up.

### 2. Opening session link from web creates a duplicate read-only viewer pane

When a user clicks "Open in Desktop App" from `app.warp.dev`, the native app's URI handler calls `join_shared_session_in_existing_window`, which **always creates a new viewer pane** without checking if the session is already open. The new pane joins with the default `Reader` role, which sets `InteractionState::Selectable` (non-editable) on the editor — the user can't type.

The original pane created from the Linear launch may already have `Executor` access and a fully working editable input.

**Fix:** Before creating a new viewer pane, check `shared_session::manager::Manager` for an existing joined/shared pane for the session. If found, focus it instead.

## Linked Issue

REMOTE-2189

## Changes

- `terminal/shared_session/manager.rs`: Add `joined_view_by_session_id()` — mirrors the existing `shared_view_by_session_id()` for joined sessions.
- `terminal/view/shared_session/view_impl.rs`: Reset `action_model.view_only = false` in `enable_cloud_followup_input`.
- `workspace/view.rs`: Add public `focus_terminal_view()` that searches both local tabs and other windows.
- `root_view.rs`: In `join_shared_session_in_existing_window`, deduplicate by checking for an existing pane before creating a new viewer.

## Testing

- [ ] I have manually tested my changes locally with `./script/run`

> **Note**: Testing for this specific cross-platform scenario requires:
> 1. Starting a cloud agent session from Linear
> 2. Opening it in the web browser
> 3. Clicking "Open in Desktop App" — should focus the existing pane rather than create a new read-only viewer

### Screenshots / Videos

N/A (the fix is about preventing a frozen state rather than a visual change)

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed a session freeze where the Warp desktop app would stop accepting input after opening a cloud agent session that was previously viewed in the web browser.
-->

_Conversation: https://staging.warp.dev/conversation/26ff37f1-ff08-4665-befd-242c2e5b59c2_
_Run: https://oz.staging.warp.dev/runs/019f6c52-0fdb-79ab-9e20-1c4a014ef1d8_

_This PR was generated with [Oz](https://warp.dev/oz)._
