### PR TITLE
Make IME candidate positioning explicit and testable

### DIFF
--- a/crates/warpui/src/windowing/winit/event_loop/ime_position_tests.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/ime_position_tests.rs
@@ -1,0 +1,96 @@
+//! Deterministic tests for the IME candidate-window position abstraction: the
+//! geometry derived from the text cursor and the update sequence produced to
+//! work around winit's position caching.
+
+use pathfinder_geometry::rect::RectF;
+use pathfinder_geometry::vector::vec2f;
+use winit::dpi::{LogicalPosition, LogicalSize};
+
+use super::{ImeCandidateGeometry, ImeCandidatePositionTracker};
+use crate::CursorInfo;
+
+/// Builds a candidate geometry at `(x, y)` with an arbitrary but fixed size, so
+/// tests can focus on the position-driven update sequence.
+fn geometry(x: f32, y: f32) -> ImeCandidateGeometry {
+    ImeCandidateGeometry {
+        position: LogicalPosition::new(x, y),
+        size: LogicalSize::new(16.0, 16.0),
+    }
+}
+
+#[test]
+fn geometry_is_positioned_below_cursor_baseline() {
+    let cursor = CursorInfo {
+        position: RectF::new(vec2f(10.0, 20.0), vec2f(2.0, 18.0)),
+        font_size: 15.0,
+    };
+
+    let geometry = ImeCandidateGeometry::from_cursor(&cursor);
+
+    // The candidate window sits one-and-a-fifth font heights below the cursor
+    // origin, and is a square the size of the font.
+    assert_eq!(
+        geometry.position,
+        LogicalPosition::new(10.0, 20.0 + 1.2 * 15.0)
+    );
+    assert_eq!(geometry.size, LogicalSize::new(15.0, 15.0));
+}
+
+#[test]
+fn first_update_is_forwarded_without_a_nudge() {
+    let mut tracker = ImeCandidatePositionTracker::default();
+    let geo = geometry(5.0, 6.0);
+
+    // No cached position yet, so a single update is enough.
+    assert_eq!(tracker.updates_for(geo), vec![geo]);
+}
+
+#[test]
+fn unchanged_position_is_nudged_to_bust_winit_cache() {
+    let mut tracker = ImeCandidatePositionTracker::default();
+    let geo = geometry(5.0, 6.0);
+    let _ = tracker.updates_for(geo);
+
+    // Requesting the same position again (e.g. the window moved but the cursor
+    // did not move relative to it) must emit a one-pixel nudge first so winit
+    // re-forwards the position to the platform IME, then the real position.
+    assert_eq!(tracker.updates_for(geo), vec![geometry(5.0, 7.0), geo]);
+}
+
+#[test]
+fn changed_position_is_forwarded_without_a_nudge() {
+    let mut tracker = ImeCandidatePositionTracker::default();
+    let _ = tracker.updates_for(geometry(5.0, 6.0));
+
+    // A different position differs from winit's cache, so a single update
+    // suffices.
+    let moved = geometry(8.0, 9.0);
+    assert_eq!(tracker.updates_for(moved), vec![moved]);
+}
+
+#[test]
+fn generates_expected_sequence_across_repeated_and_changed_positions() {
+    let mut tracker = ImeCandidatePositionTracker::default();
+    let a = geometry(1.0, 2.0);
+    let b = geometry(3.0, 4.0);
+
+    // Fresh position: single update.
+    assert_eq!(tracker.updates_for(a), vec![a]);
+    // Same position (e.g. window moved, cursor unchanged): nudge + real.
+    assert_eq!(tracker.updates_for(a), vec![geometry(1.0, 3.0), a]);
+    // New position: single update.
+    assert_eq!(tracker.updates_for(b), vec![b]);
+    // Back to the previous position, which differs from the last one we set, so
+    // a single update is enough again.
+    assert_eq!(tracker.updates_for(a), vec![a]);
+}
+
+#[test]
+fn nudged_only_shifts_the_position_down_by_one_pixel() {
+    let geo = geometry(12.0, 34.0);
+    let nudged = geo.nudged();
+
+    assert_eq!(nudged.position, LogicalPosition::new(12.0, 35.0));
+    // The nudge must not change the size, only the position.
+    assert_eq!(nudged.size, geo.size);
+}

--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -3,6 +3,9 @@ mod key_events;
 #[cfg(test)]
 mod drag_drop_tests;
 
+#[cfg(test)]
+mod ime_position_tests;
+
 use std::collections::HashMap;
 use std::mem::ManuallyDrop;
 
@@ -41,7 +44,7 @@ use crate::rendering::wgpu::renderer;
 use crate::windowing::winit::app::RequestPermissionsCallback;
 use crate::windowing::winit::window::MIN_WINDOW_SIZE;
 use crate::Event::{ClearMarkedText, SetMarkedText, TypedCharacters};
-use crate::{AppContext, WindowId};
+use crate::{AppContext, CursorInfo, WindowId};
 
 /// This is the time duration beyond which clicks get treated as separate single clicks instead of
 /// double-click, triple-click, etc.
@@ -483,6 +486,80 @@ fn convert_touch_cancelled(
     None
 }
 
+/// The IME candidate-window geometry (position and size) derived from the
+/// active text cursor.
+///
+/// The `size` is not honored on every platform — notably X11 ignores it — but
+/// we always compute and forward it so platforms that do support it can size
+/// the candidate window correctly.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct ImeCandidateGeometry {
+    /// Position of the candidate window, in logical pixels relative to the window.
+    position: LogicalPosition<f32>,
+    /// Size of the candidate window, in logical pixels.
+    size: LogicalSize<f32>,
+}
+
+impl ImeCandidateGeometry {
+    /// Computes the candidate-window geometry for `cursor`, placing the
+    /// candidate window just below the cursor baseline.
+    fn from_cursor(cursor: &CursorInfo) -> Self {
+        Self {
+            position: LogicalPosition::new(
+                cursor.position.origin_x(),
+                cursor.position.origin_y() + (1.2 * cursor.font_size),
+            ),
+            size: LogicalSize::new(cursor.font_size, cursor.font_size),
+        }
+    }
+
+    /// Returns a copy of this geometry nudged one logical pixel downward. Used to
+    /// bust winit's position cache; see [`ImeCandidatePositionTracker`].
+    fn nudged(self) -> Self {
+        Self {
+            position: LogicalPosition::new(self.position.x, self.position.y + 1.),
+            size: self.size,
+        }
+    }
+}
+
+/// Tracks the IME candidate-window position last requested from winit and
+/// produces the sequence of `set_ime_cursor_area` updates needed to move the
+/// candidate window to a new geometry.
+///
+/// winit caches the last candidate position it was handed and skips forwarding
+/// an unchanged position to the platform IME. That cache is keyed on the
+/// *window-relative* logical position, so events that move the candidate window
+/// in screen space without changing its window-relative position — window
+/// moves, resizes, and scale-factor changes — would otherwise be dropped by
+/// winit. To force winit to re-forward the position in that case, we briefly
+/// nudge it by one logical pixel before setting the real value, which busts the
+/// cache.
+#[derive(Debug, Default)]
+struct ImeCandidatePositionTracker {
+    /// The candidate position last requested from winit, if any. This mirrors the
+    /// value winit currently has cached, letting us tell when a nudge is needed.
+    last_position: Option<LogicalPosition<f32>>,
+}
+
+impl ImeCandidatePositionTracker {
+    /// Returns the sequence of updates required to move the candidate window to
+    /// `geometry`, recording the requested position as the most recent one.
+    ///
+    /// If the requested position matches the last one we set, winit would drop
+    /// the update, so a one-pixel nudge is emitted first to bust its cache.
+    /// Otherwise a single update suffices.
+    fn updates_for(&mut self, geometry: ImeCandidateGeometry) -> Vec<ImeCandidateGeometry> {
+        let mut updates = Vec::with_capacity(2);
+        if self.last_position == Some(geometry.position) {
+            updates.push(geometry.nudged());
+        }
+        updates.push(geometry);
+        self.last_position = Some(geometry.position);
+        updates
+    }
+}
+
 /// A structure to manage state
 /// [`winit::event_loop::EventLoop`] and generate the appropriate callbacks into
 /// the UI framework.
@@ -494,6 +571,10 @@ pub(super) struct EventLoop {
     state: State,
     proxy: EventLoopProxy<CustomEvent>,
     ime_enabled: bool,
+    /// Tracks the last IME candidate-window position requested from winit so we
+    /// can refresh it (working around winit's position caching) on window move,
+    /// resize, scale-factor change, and cursor movement.
+    ime_candidate_position: ImeCandidatePositionTracker,
     /// Whether to downrank non-NVIDIA vulkan adapters. This is set to true when we detect a DRI3
     /// error that occurs when trying to present against a non-NVIDIA Vulkan adapter when the
     /// PRIME Profile is set to "Performance" mode.  It's not fully clear why this error occurs. Our
@@ -523,6 +604,7 @@ impl EventLoop {
             state: Default::default(),
             proxy,
             ime_enabled: false,
+            ime_candidate_position: ImeCandidatePositionTracker::default(),
             downrank_non_nvidia_vulkan_adapters: false,
             #[cfg(target_family = "wasm")]
             soft_keyboard_manager: None,
@@ -741,9 +823,7 @@ impl EventLoop {
                 });
             }
             Event::UserEvent(CustomEvent::ActiveCursorPositionUpdated) => {
-                if self.ime_enabled {
-                    self.update_ime_position();
-                }
+                self.refresh_ime_position();
             }
             Event::UserEvent(CustomEvent::AboutToSleep) => {
                 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
@@ -879,6 +959,12 @@ impl EventLoop {
                         mut inner_size_writer,
                     },
             } => {
+                // A scale-factor change moves the IME candidate window in screen
+                // space even though its window-relative position is unchanged, so
+                // refresh it on all platforms before the Windows-only size
+                // correction below.
+                self.refresh_ime_position();
+
                 // The following correction is only needed on Windows.
                 if !cfg!(windows) {
                     return;
@@ -1049,6 +1135,11 @@ impl EventLoop {
             return;
         };
 
+        // Window moves and resizes shift the IME candidate window in screen
+        // space (its window-relative position is unchanged), so we refresh it
+        // after handling those events. We defer the refresh until after the
+        // `match` so it does not overlap the `window_state` borrow held here.
+        let mut refresh_ime = false;
         match event {
             ConvertedEvent::Event(event) => {
                 self.handle_converted_warpui_event(window_id, event);
@@ -1058,6 +1149,7 @@ impl EventLoop {
                 window.handle_resize();
                 self.callbacks.for_window(window).window_resized(window);
                 self.callbacks.window_resized();
+                refresh_ime = true;
             }
             ConvertedEvent::ModifierKeyChanged { key_code, state } => {
                 let mut window_callbacks = self.callbacks.for_window(window.as_ref());
@@ -1103,6 +1195,7 @@ impl EventLoop {
                     .for_window(window)
                     .window_moved(RectF::new(vec2f(position.x, position.y), size));
                 self.callbacks.window_moved();
+                refresh_ime = true;
             }
             ConvertedEvent::MoveWindowBy {
                 current_touch,
@@ -1118,6 +1211,10 @@ impl EventLoop {
                     winit_window.set_outer_position(PhysicalPosition::new(target_x, target_y));
                 }
             }
+        }
+
+        if refresh_ime {
+            self.refresh_ime_position();
         }
     }
 
@@ -1778,7 +1875,22 @@ impl EventLoop {
         abort_handle
     }
 
-    fn update_ime_position(&mut self) {
+    /// Refreshes the IME candidate-window position for the active window so it
+    /// tracks the active text cursor.
+    ///
+    /// This is a no-op when IME is disabled or no editable text field is
+    /// focused. It is invoked whenever the candidate window needs to follow the
+    /// cursor: on cursor movement, and on window move, resize, and scale-factor
+    /// changes (which move the candidate window in screen space even when its
+    /// window-relative position is unchanged).
+    ///
+    /// The concrete sequence of `set_ime_cursor_area` calls — including the
+    /// one-pixel nudge that works around winit's position caching — is produced
+    /// by [`ImeCandidatePositionTracker`].
+    fn refresh_ime_position(&mut self) {
+        if !self.ime_enabled {
+            return;
+        }
         let Some(active_window_id) = self.ui_app.read(|ctx| ctx.windows().active_window()) else {
             return;
         };
@@ -1789,24 +1901,22 @@ impl EventLoop {
             return;
         };
 
-        let mut window_callbacks = self.callbacks.for_window(window.as_ref());
-        let active_cursor_position = window_callbacks.get_active_cursor_position();
-        if let Some(active_cursor_position) = active_cursor_position {
-            let winit_window = downcast_window(window.as_ref());
-            let position = LogicalPosition::new(
-                active_cursor_position.position.origin_x(),
-                active_cursor_position.position.origin_y()
-                    + (1.2 * active_cursor_position.font_size),
-            );
-            // Currently the size argument is not supported on X11. We calculate it here anyway.
-            let size = LogicalSize::new(
-                active_cursor_position.font_size,
-                active_cursor_position.font_size,
-            );
-            // TODO(abhishek): We make sure that the position is different than last time to prevent winit from
-            // caching the old position and not properly updating on `WindowMoved` or `WindowResized` events.
-            winit_window.set_ime_position(LogicalPosition::new(position.x, position.y + 1.), size);
-            winit_window.set_ime_position(position, size);
+        // Compute the target geometry while borrowing `self.callbacks`, then drop
+        // that borrow before touching `self.ime_candidate_position` below.
+        let geometry = {
+            let mut window_callbacks = self.callbacks.for_window(window.as_ref());
+            match window_callbacks.get_active_cursor_position() {
+                Some(cursor) => ImeCandidateGeometry::from_cursor(&cursor),
+                None => return,
+            }
+        };
+
+        let updates = self.ime_candidate_position.updates_for(geometry);
+        let winit_window = downcast_window(window.as_ref());
+        for update in updates {
+            // The size argument is currently ignored on X11, but we forward it
+            // anyway for platforms that do support sizing the candidate window.
+            winit_window.set_ime_position(update.position, update.size);
         }
     }
 


### PR DESCRIPTION
## Description
Makes the winit IME candidate-window positioning explicit and testable.

Previously the workaround for winit's position caching (briefly moving the IME
candidate position by one pixel and back) lived inline in `update_ime_position`
and was only invoked on text-cursor movement. As a result the candidate window
did not follow window moves, resizes, or scale-factor changes, even though the
one-pixel nudge was written specifically for those events.

This PR:
- Encapsulates the workaround behind two small abstractions in
  `crates/warpui/src/windowing/winit/event_loop/mod.rs`:
  - `ImeCandidateGeometry` — the candidate-window position/size derived from the
    active text cursor (`from_cursor`).
  - `ImeCandidatePositionTracker` — tracks the last position requested from
    winit and produces the deterministic sequence of `set_ime_cursor_area`
    updates, emitting the one-pixel nudge only when the requested position
    matches winit's cached one (a single update otherwise).
- Tracks the relevant cursor/window state explicitly via a new
  `ime_candidate_position` field on `EventLoop`.
- Refreshes the candidate position (`refresh_ime_position`) on window move,
  resize, scale-factor changes (all platforms), and cursor movement. The
  method is now internally gated on `ime_enabled`.
- Preserves X11 behavior: the size argument is still computed and forwarded,
  even though X11 ignores it.

## Linked Issue
N/A — internal refactor / latent-bug fix surfaced by the task.

## Testing
- [ ] I have manually tested my changes locally with `./script/run`

Added deterministic unit tests in
`crates/warpui/src/windowing/winit/event_loop/ime_position_tests.rs` covering:
- geometry placement below the cursor baseline,
- the fresh (single-update) case,
- the unchanged-position nudge that busts winit's cache,
- the changed-position single-update case,
- a mixed repeated/changed sequence, and
- the one-pixel nudge only shifting the position (not the size).

Validation on the `warpui` crate:
- `cargo check -p warpui --tests` — passes
- `cargo test -p warpui ime_position` — 6 passed
- `cargo clippy -p warpui --all-targets --tests -- -D warnings` — clean
- `cargo fmt -p warpui -- --check` — clean

Manual end-to-end IME verification (CJK candidate window following window
move/resize/scale on Linux/Windows) was not performed in this environment.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-NONE
-->

_Conversation: http://localhost:8080/conversation/e618f2f8-88d8-48d8-9453-34b2c2dc5c1d_
_Run: http://localhost:8082/runs/019f6c7a-6f54-78c6-8a3a-25ccbd52bc95_

_This PR was generated with [Oz](https://warp.dev/oz)._
