### PR TITLE
Encapsulate IME candidate position workaround behind a testable abstraction

### DIFF
--- a/crates/warpui/src/windowing/winit/event_loop/ime.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/ime.rs
@@ -1,0 +1,109 @@
+//! Positions winit's IME candidate window and works around its position cache.
+//!
+//! winit caches the most recently requested IME candidate position and skips
+//! repositioning when a subsequent request compares equal to the cached value.
+//! That breaks when the window itself moves, resizes, or changes scale factor:
+//! the candidate window is positioned relative to the window, so even though
+//! the requested logical position is unchanged its on-screen location is now
+//! stale. This module computes the candidate-window geometry from the active
+//! caret and emits a deterministic sequence of `set_ime_position` requests that
+//! forces winit to reposition only when actually necessary.
+
+use winit::dpi::{LogicalPosition, LogicalSize};
+
+use crate::CursorInfo;
+
+/// The logical position and size we ask winit to place the IME candidate window
+/// at, derived from the active text caret.
+///
+/// The candidate window is anchored at the caret's origin and pushed down by
+/// ~1.2× the font size so it appears just beneath the line of text being
+/// composed. The `size` field is a square of the font size; winit's X11 backend
+/// ignores the size argument, but we compute and forward it on every platform so
+/// the request shape stays consistent.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct ImeCandidateGeometry {
+    pub(crate) position: LogicalPosition<f32>,
+    pub(crate) size: LogicalSize<f32>,
+}
+
+impl ImeCandidateGeometry {
+    /// Builds the candidate-window geometry for the given active cursor info.
+    pub(crate) fn from_cursor_info(cursor_info: &CursorInfo) -> Self {
+        let position = LogicalPosition::new(
+            cursor_info.position.origin_x(),
+            cursor_info.position.origin_y() + (1.2 * cursor_info.font_size),
+        );
+        // The size argument is not supported on winit's X11 backend, but we
+        // calculate it here anyway so the request is identical across platforms.
+        let size = LogicalSize::new(cursor_info.font_size, cursor_info.font_size);
+        Self { position, size }
+    }
+
+    /// Returns `self` offset by one logical pixel on the y axis, leaving the
+    /// position's x and the size untouched. Used to invalidate winit's cached
+    /// position before restoring the real one.
+    fn nudged_down_by_one_pixel(&self) -> Self {
+        Self {
+            position: LogicalPosition::new(self.position.x, self.position.y + 1.),
+            size: self.size,
+        }
+    }
+}
+
+/// Tracks the last IME candidate position we handed to winit and decides what
+/// `set_ime_position` calls are needed to (re)position the candidate window.
+///
+/// [`ImeCandidatePositionTracker::refresh`] returns one of two update sequences:
+/// - `[geometry]` on the first request, or when the requested position has
+///   changed (the caret moved). winit's cache is already stale relative to the
+///   new value, so a single request repositions the candidate window.
+/// - `[nudge, geometry]` when the requested position is unchanged. winit would
+///   otherwise treat the request as a no-op, so `nudge` (the geometry offset by
+///   one pixel on the y axis) forces the cache to invalidate before `geometry`
+///   restores the real position.
+///
+/// Applying the nudge only when the position is unchanged avoids the flicker of
+/// nudging on every caret move while still repositioning after window
+/// move/resize/scale-factor changes.
+#[derive(Debug, Default)]
+pub(crate) struct ImeCandidatePositionTracker {
+    /// The last position we left the candidate window at — i.e. the restore
+    /// target of the most recent sequence, never a transient nudge.
+    last_position: Option<LogicalPosition<f32>>,
+}
+
+impl ImeCandidatePositionTracker {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the ordered sequence of candidate-window geometries to pass to
+    /// winit's `set_ime_position` in order to place the candidate window at
+    /// `geometry`, given what we last requested.
+    pub(crate) fn refresh(&mut self, geometry: ImeCandidateGeometry) -> Vec<ImeCandidateGeometry> {
+        let updates = match self.last_position {
+            // First request: winit has nothing cached, so a single set positions
+            // the candidate window.
+            None => vec![geometry],
+            // The requested logical position is unchanged, but the window may
+            // have moved, resized, or changed scale factor since we last set it.
+            // Nudge by one pixel and immediately restore to force winit to
+            // invalidate its cache and reposition.
+            Some(last) if last == geometry.position => {
+                vec![geometry.nudged_down_by_one_pixel(), geometry]
+            }
+            // The caret moved, so winit's cache is already stale relative to the
+            // new position — a single set is enough, and nudging here would only
+            // cause unnecessary flicker.
+            Some(_) => vec![geometry],
+        };
+        // Every sequence leaves the candidate window at `geometry.position`.
+        self.last_position = Some(geometry.position);
+        updates
+    }
+}
+
+#[cfg(test)]
+#[path = "ime_tests.rs"]
+mod tests;

--- a/crates/warpui/src/windowing/winit/event_loop/ime_tests.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/ime_tests.rs
@@ -1,0 +1,109 @@
+use pathfinder_geometry::rect::RectF;
+use pathfinder_geometry::vector::vec2f;
+use winit::dpi::{LogicalPosition, LogicalSize};
+
+use super::*;
+use crate::CursorInfo;
+
+/// Convenience for building a geometry with an explicit position and square
+/// size, decoupled from `from_cursor_info`'s caret-offset math so the tracker
+/// tests can use round numbers.
+fn geometry_at(position_x: f32, position_y: f32, size: f32) -> ImeCandidateGeometry {
+    ImeCandidateGeometry {
+        position: LogicalPosition::new(position_x, position_y),
+        size: LogicalSize::new(size, size),
+    }
+}
+
+#[test]
+fn geometry_from_cursor_info_offsets_below_caret() {
+    let cursor_info = CursorInfo {
+        position: RectF::new(vec2f(10., 20.), vec2f(100., 200.)),
+        font_size: 16.,
+    };
+    let geometry = ImeCandidateGeometry::from_cursor_info(&cursor_info);
+    // Anchored at the caret origin, pushed down by 1.2x the font size.
+    assert_eq!(
+        geometry.position,
+        LogicalPosition::new(10., 20. + 1.2 * 16.)
+    );
+    // Square of the font size (ignored by winit's X11 backend, but forwarded).
+    assert_eq!(geometry.size, LogicalSize::new(16., 16.));
+}
+
+#[test]
+fn first_refresh_sets_position_without_nudging() {
+    let mut tracker = ImeCandidatePositionTracker::new();
+    let geometry = geometry_at(5., 7., 12.);
+
+    let updates = tracker.refresh(geometry);
+
+    // No prior position, so a single direct set is enough — no nudge.
+    assert_eq!(updates, vec![geometry]);
+}
+
+#[test]
+fn unchanged_position_nudges_and_restores() {
+    let mut tracker = ImeCandidatePositionTracker::new();
+    let geometry = geometry_at(5., 7., 12.);
+    tracker.refresh(geometry);
+
+    let updates = tracker.refresh(geometry);
+
+    // Same position as last time: nudge by one pixel on y, then restore.
+    let nudged = geometry_at(5., 8., 12.);
+    assert_eq!(updates, vec![nudged, geometry]);
+}
+
+#[test]
+fn changed_position_sets_directly_without_nudging() {
+    let mut tracker = ImeCandidatePositionTracker::new();
+    tracker.refresh(geometry_at(5., 7., 12.));
+
+    let moved = geometry_at(50., 70., 12.);
+    let updates = tracker.refresh(moved);
+
+    // The caret moved, so winit's cache is already stale — set directly.
+    assert_eq!(updates, vec![moved]);
+}
+
+#[test]
+fn nudge_only_offsets_y_by_one_pixel() {
+    let mut tracker = ImeCandidatePositionTracker::new();
+    let geometry = geometry_at(5., 7., 12.);
+    tracker.refresh(geometry);
+
+    let updates = tracker.refresh(geometry);
+    assert_eq!(updates.len(), 2);
+    let nudged = updates[0];
+    let restored = updates[1];
+
+    // The nudge moves only y by +1; x and size are unchanged.
+    assert_eq!(nudged.position, LogicalPosition::new(5., 8.));
+    assert_eq!(nudged.size, geometry.size);
+    // The restore brings the position back to the requested one.
+    assert_eq!(restored, geometry);
+}
+
+#[test]
+fn tracker_compares_against_last_effective_position() {
+    let mut tracker = ImeCandidatePositionTracker::new();
+    let first = geometry_at(5., 7., 12.);
+    let second = geometry_at(50., 70., 12.);
+
+    // First request positions directly.
+    assert_eq!(tracker.refresh(first), vec![first]);
+    // Same position again: nudge then restore around `first`.
+    assert_eq!(
+        tracker.refresh(first),
+        vec![geometry_at(5., 8., 12.), first]
+    );
+    // Different position: a single direct set, no nudge.
+    assert_eq!(tracker.refresh(second), vec![second]);
+    // The tracker remembers the restore target (`second`), not any transient
+    // nudge, so repeating `second` nudges around `second` rather than `first`.
+    assert_eq!(
+        tracker.refresh(second),
+        vec![geometry_at(50., 71., 12.), second]
+    );
+}

--- a/crates/warpui/src/windowing/winit/event_loop/mod.rs
+++ b/crates/warpui/src/windowing/winit/event_loop/mod.rs
@@ -1,3 +1,4 @@
+mod ime;
 mod key_events;
 
 #[cfg(test)]
@@ -22,6 +23,7 @@ use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoopProxy};
 use winit::keyboard::{self, KeyCode};
 use winit::window::WindowId as WinitWindowId;
 
+use self::ime::{ImeCandidateGeometry, ImeCandidatePositionTracker};
 use self::key_events::convert_keyboard_input_event;
 use super::app::ClipboardEvent;
 use super::window::DEFAULT_TITLEBAR_HEIGHT;
@@ -494,6 +496,9 @@ pub(super) struct EventLoop {
     state: State,
     proxy: EventLoopProxy<CustomEvent>,
     ime_enabled: bool,
+    /// Tracks the last IME candidate position we requested, so we can work
+    /// around winit's position cache. See [`ImeCandidatePositionTracker`].
+    ime_position_tracker: ImeCandidatePositionTracker,
     /// Whether to downrank non-NVIDIA vulkan adapters. This is set to true when we detect a DRI3
     /// error that occurs when trying to present against a non-NVIDIA Vulkan adapter when the
     /// PRIME Profile is set to "Performance" mode.  It's not fully clear why this error occurs. Our
@@ -523,6 +528,7 @@ impl EventLoop {
             state: Default::default(),
             proxy,
             ime_enabled: false,
+            ime_position_tracker: ImeCandidatePositionTracker::new(),
             downrank_non_nvidia_vulkan_adapters: false,
             #[cfg(target_family = "wasm")]
             soft_keyboard_manager: None,
@@ -741,9 +747,7 @@ impl EventLoop {
                 });
             }
             Event::UserEvent(CustomEvent::ActiveCursorPositionUpdated) => {
-                if self.ime_enabled {
-                    self.update_ime_position();
-                }
+                self.refresh_ime_position();
             }
             Event::UserEvent(CustomEvent::AboutToSleep) => {
                 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
@@ -879,6 +883,11 @@ impl EventLoop {
                         mut inner_size_writer,
                     },
             } => {
+                // A scale-factor change can leave the IME candidate window
+                // mispositioned even though the caret's logical position is
+                // unchanged, so refresh it before the platform-specific handling.
+                self.refresh_ime_position();
+
                 // The following correction is only needed on Windows.
                 if !cfg!(windows) {
                     return;
@@ -1049,6 +1058,12 @@ impl EventLoop {
             return;
         };
 
+        // Window geometry changes can leave the IME candidate window stale
+        // even when the caret's logical position is unchanged. We track whether
+        // this event is one of those and refresh after the match, once the
+        // `window_state` borrow has been released.
+        let mut ime_position_may_be_stale = false;
+
         match event {
             ConvertedEvent::Event(event) => {
                 self.handle_converted_warpui_event(window_id, event);
@@ -1058,6 +1073,9 @@ impl EventLoop {
                 window.handle_resize();
                 self.callbacks.for_window(window).window_resized(window);
                 self.callbacks.window_resized();
+                // A resize can leave the IME candidate window mispositioned
+                // even though the caret's logical position is unchanged.
+                ime_position_may_be_stale = true;
             }
             ConvertedEvent::ModifierKeyChanged { key_code, state } => {
                 let mut window_callbacks = self.callbacks.for_window(window.as_ref());
@@ -1103,6 +1121,9 @@ impl EventLoop {
                     .for_window(window)
                     .window_moved(RectF::new(vec2f(position.x, position.y), size));
                 self.callbacks.window_moved();
+                // A move can leave the IME candidate window mispositioned even
+                // though the caret's logical position is unchanged.
+                ime_position_may_be_stale = true;
             }
             ConvertedEvent::MoveWindowBy {
                 current_touch,
@@ -1118,6 +1139,10 @@ impl EventLoop {
                     winit_window.set_outer_position(PhysicalPosition::new(target_x, target_y));
                 }
             }
+        }
+
+        if ime_position_may_be_stale {
+            self.refresh_ime_position();
         }
     }
 
@@ -1778,6 +1803,19 @@ impl EventLoop {
         abort_handle
     }
 
+    /// Repositions the IME candidate window if IME is currently enabled.
+    ///
+    /// This is the single entry point for refreshing the candidate window
+    /// position; call it whenever the caret moves or the window changes
+    /// geometry in a way that can leave the candidate window stale (move,
+    /// resize, scale-factor change). `update_ime_position` does the actual
+    /// positioning and `ImeCandidatePositionTracker` owns the cache workaround.
+    fn refresh_ime_position(&mut self) {
+        if self.ime_enabled {
+            self.update_ime_position();
+        }
+    }
+
     fn update_ime_position(&mut self) {
         let Some(active_window_id) = self.ui_app.read(|ctx| ctx.windows().active_window()) else {
             return;
@@ -1793,20 +1831,13 @@ impl EventLoop {
         let active_cursor_position = window_callbacks.get_active_cursor_position();
         if let Some(active_cursor_position) = active_cursor_position {
             let winit_window = downcast_window(window.as_ref());
-            let position = LogicalPosition::new(
-                active_cursor_position.position.origin_x(),
-                active_cursor_position.position.origin_y()
-                    + (1.2 * active_cursor_position.font_size),
-            );
-            // Currently the size argument is not supported on X11. We calculate it here anyway.
-            let size = LogicalSize::new(
-                active_cursor_position.font_size,
-                active_cursor_position.font_size,
-            );
-            // TODO(abhishek): We make sure that the position is different than last time to prevent winit from
-            // caching the old position and not properly updating on `WindowMoved` or `WindowResized` events.
-            winit_window.set_ime_position(LogicalPosition::new(position.x, position.y + 1.), size);
-            winit_window.set_ime_position(position, size);
+            let geometry = ImeCandidateGeometry::from_cursor_info(&active_cursor_position);
+            // Ask the tracker for the sequence of `set_ime_position` calls that
+            // will (re)position the candidate window, working around winit's
+            // position cache when the requested position is unchanged.
+            for update in self.ime_position_tracker.refresh(geometry) {
+                winit_window.set_ime_position(update.position, update.size);
+            }
         }
     }
 


### PR DESCRIPTION
## Description

`update_ime_position` worked around winit's IME position caching by nudging the candidate position one pixel down and back on *every* update. winit caches the most recently requested IME candidate position and skips repositioning when a new request compares equal, which leaves the candidate window in the wrong spot after the window moves, resizes, or changes scale factor — but applying the nudge unconditionally also flickered the candidate window on every caret move.

This change encapsulates the workaround behind two small, testable abstractions in a new `crates/warpui/src/windowing/winit/event_loop/ime.rs` module:

- `ImeCandidateGeometry` — computes the candidate-window position (anchored at the caret, offset ~1.2× font size below it) and size from `CursorInfo`. The `size` argument is not honored by winit's X11 backend, but it is still computed and forwarded on every platform so the request shape stays consistent (preserving the prior X11 behavior).
- `ImeCandidatePositionTracker` — tracks the last requested position and emits a deterministic update sequence:
  - first request, or a changed position → `[geometry]` (a single direct set; winit's cache is already stale relative to the new value),
  - unchanged position → `[nudge, geometry]` (offset one pixel on y, then restore) to force winit to invalidate its cache.

The nudge now applies only when the position is unchanged, eliminating the flicker on caret moves while still repositioning after window geometry changes.

The candidate-window position is now refreshed on **window move**, **window resize**, and **scale-factor changes** in addition to the existing cursor-movement (`ActiveCursorPositionUpdated`) path, all routed through a single `refresh_ime_position` entry point that no-ops when IME is disabled.

## Linked Issue

N/A — internal refactor driven by the task to make the IME cursor positioning explicit and testable.

## Testing

Added six deterministic unit tests in `crates/warpui/src/windowing/winit/event_loop/ime_tests.rs` covering:
- geometry derivation from `CursorInfo` (caret origin + 1.2× font-size offset, square size),
- first refresh sets directly without nudging,
- unchanged position nudges then restores,
- changed position sets directly without nudging,
- the nudge offsets only y by one pixel (x and size unchanged),
- the tracker compares against the last *effective* (restore) position across a multi-step sequence.

Verified locally:
- `cargo check -p warpui --tests`
- `cargo clippy -p warpui --all-targets --all-features --tests -- -D warnings`
- `cargo fmt -p warpui -- --check`
- `cargo nextest run -p warpui -E 'test(ime)'` → 6 passed

- [ ] I have manually tested my changes locally with `./script/run`

Manual end-to-end IME verification (candidate window repositioning on a real Linux X11/Wayland desktop with an active IME across window move/resize/scale-factor changes) was not performed in this environment; the cache-workaround logic is covered by the deterministic unit tests above.

### Screenshots / Videos

N/A — no visual UI change; refactor of internal IME positioning logic.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
## Changelog Entries for Stable

CHANGELOG-NONE
-->

_Conversation: http://localhost:8080/conversation/30ed4306-a76c-4461-9cbf-f782c154db68_
_Run: http://localhost:8082/runs/019f6c97-d5bf-7052-bf8c-1e3223fdad1d_

_This PR was generated with [Oz](https://warp.dev/oz)._
