### PR TITLE
Support raw HTML <br> line breaks in the Markdown renderer

### DIFF
--- a/crates/editor/src/content/buffer.rs
+++ b/crates/editor/src/content/buffer.rs
@@ -2477,20 +2477,10 @@ impl Buffer {
                     let slice_end = cell_offset_map
                         .source_to_rendered(relative_end.min(cell_range.end) - cell_range.start);
                     if slice_end > slice_start {
-                        let slice = char_slice(cell, slice_start.as_usize(), slice_end.as_usize())
-                            .unwrap_or(cell);
-                        // An authored hard break (raw HTML `<br>`) is stored as an embedded
-                        // newline. Emitting it raw into this tab/newline-delimited clipboard row
-                        // would split the row, so a re-paste re-parses a spurious extra row.
-                        // Translate it back to a literal `<br>`, scoped to the table-cell context
-                        // (unlike a global change to `inline_to_text`, whose other callers may
-                        // legitimately want the newline). A cell's rendered text never contains a
-                        // newline for any other reason.
-                        if slice.contains('\n') {
-                            text.push_str(&slice.replace('\n', "<br>"));
-                        } else {
-                            text.push_str(slice);
-                        }
+                        text.push_str(
+                            char_slice(cell, slice_start.as_usize(), slice_end.as_usize())
+                                .unwrap_or(cell),
+                        );
                     }
                 }
 

--- a/crates/editor/src/content/buffer.rs
+++ b/crates/editor/src/content/buffer.rs
@@ -2477,10 +2477,20 @@ impl Buffer {
                     let slice_end = cell_offset_map
                         .source_to_rendered(relative_end.min(cell_range.end) - cell_range.start);
                     if slice_end > slice_start {
-                        text.push_str(
-                            char_slice(cell, slice_start.as_usize(), slice_end.as_usize())
-                                .unwrap_or(cell),
-                        );
+                        let slice = char_slice(cell, slice_start.as_usize(), slice_end.as_usize())
+                            .unwrap_or(cell);
+                        // An authored hard break (raw HTML `<br>`) is stored as an embedded
+                        // newline. Emitting it raw into this tab/newline-delimited clipboard row
+                        // would split the row, so a re-paste re-parses a spurious extra row.
+                        // Translate it back to a literal `<br>`, scoped to the table-cell context
+                        // (unlike a global change to `inline_to_text`, whose other callers may
+                        // legitimately want the newline). A cell's rendered text never contains a
+                        // newline for any other reason.
+                        if slice.contains('\n') {
+                            text.push_str(&slice.replace('\n', "<br>"));
+                        } else {
+                            text.push_str(slice);
+                        }
                     }
                 }
 

--- a/crates/editor/src/content/buffer_tests.rs
+++ b/crates/editor/src/content/buffer_tests.rs
@@ -13020,11 +13020,20 @@ fn test_clipboard_table_copy_uses_source_offsets_for_later_formatted_cells() {
 }
 
 #[test]
-fn test_clipboard_table_copy_preserves_br_without_splitting_row() {
+fn test_clipboard_table_copy_emits_real_newline_for_in_cell_break() {
     App::test((), |mut app| async move {
-        // A cell containing an authored hard break (`<br>`) must not split the tab-delimited
-        // clipboard row: the break has to survive as a literal `<br>`, matching the internal
-        // tab/newline format guards, so re-pasting into Warp re-parses the same single row.
+        // Product decision (#13732): the two clipboard flavors carry a `<br>` differently.
+        //
+        // - The plain-text flavor is *rendered text*: it already strips styling, so an
+        //   authored hard break emits a real `\n`, never the literal HTML string "<br>".
+        //   Injecting HTML the user didn't select would violate that rendered-text contract.
+        // - The HTML flavor (see serialize_table_cell_inline / selected_text_as_html) carries
+        //   the break as a real `<br>` element, so Warp-to-Warp paste round-trips faithfully.
+        //
+        // Accepted cost: a plain-text-only re-paste of this row into a Warp table may split it,
+        // because the in-cell newline collides with the tab/newline row delimiter. That is a
+        // standard TSV-class limitation we consciously accept — it is NOT an oversight. Do not
+        // "fix" it by re-emitting "<br>" here; that regresses the plain-text contract above.
         let table_source = "a<br>b\tc";
         let markdown = format!("```{TABLE_BLOCK_MARKDOWN_LANG}\n{table_source}\n```\n");
         let (buffer, _selection) = Buffer::mock_from_markdown(
@@ -13045,14 +13054,13 @@ fn test_clipboard_table_copy_preserves_br_without_splitting_row() {
             );
 
             assert!(
-                !copied.contains("a\nb"),
-                "in-cell break must not emit a raw newline that splits the row, got {copied:?}"
+                !copied.contains("<br>"),
+                "plain-text flavor must not contain literal HTML the user didn't select, got {copied:?}"
             );
-            // The single row copies as one line (the trailing `\n` is the row terminator, not a
-            // cell break): the in-cell break survives as a literal `<br>`.
+            // The in-cell break renders as a real newline; the trailing `\n` terminates the row.
             assert_eq!(
-                copied, "a<br>b\tc\n",
-                "cell break should survive as a literal <br> in the tab-delimited row"
+                copied, "a\nb\tc\n",
+                "in-cell break should emit a real newline in the plain-text flavor"
             );
         });
     });

--- a/crates/editor/src/content/buffer_tests.rs
+++ b/crates/editor/src/content/buffer_tests.rs
@@ -13020,6 +13020,45 @@ fn test_clipboard_table_copy_uses_source_offsets_for_later_formatted_cells() {
 }
 
 #[test]
+fn test_clipboard_table_copy_preserves_br_without_splitting_row() {
+    App::test((), |mut app| async move {
+        // A cell containing an authored hard break (`<br>`) must not split the tab-delimited
+        // clipboard row: the break has to survive as a literal `<br>`, matching the internal
+        // tab/newline format guards, so re-pasting into Warp re-parses the same single row.
+        let table_source = "a<br>b\tc";
+        let markdown = format!("```{TABLE_BLOCK_MARKDOWN_LANG}\n{table_source}\n```\n");
+        let (buffer, _selection) = Buffer::mock_from_markdown(
+            &markdown,
+            None,
+            Box::new(|_, _| IndentBehavior::Ignore),
+            &mut app,
+        );
+
+        buffer.update(&mut app, |buffer, _ctx| {
+            let block_start = buffer.containing_block_start(CharOffset::from(1));
+            let max_offset = buffer.max_charoffset();
+
+            let copied = buffer.clipboard_table_text_in_range(
+                block_start,
+                block_start..max_offset,
+                LineEnding::LF,
+            );
+
+            assert!(
+                !copied.contains("a\nb"),
+                "in-cell break must not emit a raw newline that splits the row, got {copied:?}"
+            );
+            // The single row copies as one line (the trailing `\n` is the row terminator, not a
+            // cell break): the in-cell break survives as a literal `<br>`.
+            assert_eq!(
+                copied, "a<br>b\tc\n",
+                "cell break should survive as a literal <br> in the tab-delimited row"
+            );
+        });
+    });
+}
+
+#[test]
 fn test_multiselect_text_styling() {
     App::test((), |mut app| async move {
         let buffer = app.add_model(|_| Buffer::new(Box::new(|_, _| IndentBehavior::Ignore)));

--- a/crates/editor/src/content/edit.rs
+++ b/crates/editor/src/content/edit.rs
@@ -294,8 +294,16 @@ fn measure_table_cells(
                 .collect();
             let mut line = LayOutArgs::new();
             line.highlighted_urls = highlight_urls(&runs);
+            let mut trailing_line_break = false;
             for run in &runs {
-                line.layout_run(layout, run, &paragraph_style);
+                // `layout_run` strips a trailing `\n` (from a raw HTML `<br>`) out of
+                // `line.text`; an interior `\n` is left in place. Track a break on the final
+                // run so a cell that ends in `<br>` keeps its trailing empty line (matching
+                // GitHub), rather than silently collapsing to a single line.
+                trailing_line_break = line.layout_run(layout, run, &paragraph_style);
+            }
+            if trailing_line_break {
+                line.text.push('\n');
             }
             let text_layout = InlineTextLayoutInput {
                 text: line.text,

--- a/crates/editor/src/content/edit.rs
+++ b/crates/editor/src/content/edit.rs
@@ -294,16 +294,16 @@ fn measure_table_cells(
                 .collect();
             let mut line = LayOutArgs::new();
             line.highlighted_urls = highlight_urls(&runs);
-            let mut trailing_line_break = false;
             for run in &runs {
                 // `layout_run` strips a trailing `\n` (from a raw HTML `<br>`) out of
-                // `line.text`; an interior `\n` is left in place. Track a break on the final
-                // run so a cell that ends in `<br>` keeps its trailing empty line (matching
-                // GitHub), rather than silently collapsing to a single line.
-                trailing_line_break = line.layout_run(layout, run, &paragraph_style);
-            }
-            if trailing_line_break {
-                line.text.push('\n');
+                // `line.text`; an interior `\n` is left in place. Reinsert the break at each run
+                // boundary where it occurred — a `<br>` can land at a style-run boundary (e.g.
+                // `**bold**<br>**plain**`), so the break may terminate a non-final run. Tracking
+                // only the final run's flag would drop such interior breaks and silently collapse
+                // the cell to one line.
+                if line.layout_run(layout, run, &paragraph_style) {
+                    line.text.push('\n');
+                }
             }
             let text_layout = InlineTextLayoutInput {
                 text: line.text,

--- a/crates/editor/src/content/edit_tests.rs
+++ b/crates/editor/src/content/edit_tests.rs
@@ -14,6 +14,7 @@ use warpui_core::{App, SingletonEntity};
 
 use super::{
     BlockLocation, LayOutArgs, layout_mermaid_diagram_block, layout_table_block, layout_text_block,
+    measure_table_cells,
 };
 use crate::content::buffer::{StyledBufferRun, StyledTextBlock};
 use crate::content::edit::{
@@ -838,6 +839,102 @@ fn test_layout_table_block_caches_cell_text_frames() {
             assert!(
                 table.cell_text_frames[0][1].max_width()
                     <= table.column_widths[1].as_f32() - table.config.style.cell_padding * 2.0
+            );
+        });
+    })
+}
+
+/// Lays out the given internal-format table string and returns the measured cell text strings
+/// (header row first, then body rows). The returned `String`s are the exact inputs handed to the
+/// text layout system, so a trailing `\n` here means the cell will render a trailing empty line.
+///
+/// This asserts on `measure_table_cells`' output rather than laid-out line counts because
+/// `App::test`'s text layout backend is a stub (`platform::test::delegate`'s `layout_text` ignores
+/// its input and always returns a single empty line), so `line_heights.len()` cannot observe
+/// newline handling.
+fn measured_cell_texts(text_layout: &TextLayout<'_>, content: &str) -> Vec<Vec<String>> {
+    let table =
+        crate::content::text::table_from_internal_format_with_inline_markdown(content, Vec::new());
+    let table_style = text_layout.rich_text_styles().table_style;
+    let mut header_style = text_layout.paragraph_styles(&BufferBlockStyle::table(Vec::new()));
+    header_style.font_weight = Weight::Bold;
+    let body_style = text_layout.paragraph_styles(&BufferBlockStyle::table(Vec::new()));
+
+    let (_widths, cell_text_layouts) =
+        measure_table_cells(&table, text_layout, &table_style, header_style, body_style);
+    cell_text_layouts
+        .into_iter()
+        .map(|row| row.into_iter().map(|cell| cell.text_layout.text).collect())
+        .collect()
+}
+
+/// A trailing `<br>` at the end of a table cell must preserve the trailing newline in the cell's
+/// measured text so it renders an extra empty line, matching GitHub's rendering of a trailing hard
+/// break inside a GFM pipe-table cell.
+#[test]
+fn test_measure_table_cells_trailing_br_keeps_newline() {
+    App::test((), |app| async move {
+        app.read(|ctx| {
+            let layout_cache = LayoutCache::new();
+            let text_layout = TextLayout::new(
+                &layout_cache,
+                ctx.font_cache().text_layout_system(),
+                &TEST_STYLES,
+                f32::MAX,
+            );
+            // Body cell 0 ends in `<br>`; control cell 1 is a plain single-line cell.
+            let cells = measured_cell_texts(&text_layout, "a\tb\none<br>\ttwo\n");
+
+            assert_eq!(
+                cells[1][0], "one\n",
+                "cell ending in <br> must keep its trailing newline (extra empty line)"
+            );
+            assert_eq!(
+                cells[1][1], "two",
+                "control cell without <br> must be unchanged"
+            );
+        });
+    })
+}
+
+/// A cell containing only `<br>` parses to a lone `\n` fragment; its measured text must be a lone
+/// newline (an empty content line plus a trailing empty line), not the empty string.
+#[test]
+fn test_measure_table_cells_lone_br_keeps_newline() {
+    App::test((), |app| async move {
+        app.read(|ctx| {
+            let layout_cache = LayoutCache::new();
+            let text_layout = TextLayout::new(
+                &layout_cache,
+                ctx.font_cache().text_layout_system(),
+                &TEST_STYLES,
+                f32::MAX,
+            );
+            let cells = measured_cell_texts(&text_layout, "a\tb\n<br>\ttwo\n");
+
+            assert_eq!(cells[1][0], "\n", "a lone <br> cell must keep its newline");
+        });
+    })
+}
+
+/// Embedded `<br>` (text on both sides) is the control path: the interior newline was never
+/// stripped, so it must remain untouched by the trailing-break fix.
+#[test]
+fn test_measure_table_cells_embedded_br_unchanged() {
+    App::test((), |app| async move {
+        app.read(|ctx| {
+            let layout_cache = LayoutCache::new();
+            let text_layout = TextLayout::new(
+                &layout_cache,
+                ctx.font_cache().text_layout_system(),
+                &TEST_STYLES,
+                f32::MAX,
+            );
+            let cells = measured_cell_texts(&text_layout, "a\tb\none<br>two\tthree\n");
+
+            assert_eq!(
+                cells[1][0], "one\ntwo",
+                "embedded <br> must keep its single interior newline"
             );
         });
     })

--- a/crates/editor/src/content/edit_tests.rs
+++ b/crates/editor/src/content/edit_tests.rs
@@ -940,6 +940,60 @@ fn test_measure_table_cells_embedded_br_unchanged() {
     })
 }
 
+/// A `<br>` that falls between two styled runs (e.g. `**bold**<br>**plain**`) parses to a
+/// standalone `\n` fragment sitting in a non-final run position. `layout_run` strips that run's
+/// trailing `\n` and reports the break, but the following run reports no break — so tracking only
+/// the final run's flag would drop the interior newline and collapse the two lines into one. The
+/// break must be reinserted per-run, at the run boundary.
+#[test]
+fn test_measure_table_cells_style_boundary_br_keeps_newline() {
+    App::test((), |app| async move {
+        app.read(|ctx| {
+            let layout_cache = LayoutCache::new();
+            let text_layout = TextLayout::new(
+                &layout_cache,
+                ctx.font_cache().text_layout_system(),
+                &TEST_STYLES,
+                f32::MAX,
+            );
+            // Body cell 0: bold "bold", a <br> break, bold "plain". The <br> becomes a standalone
+            // `\n` fragment between the two bold runs — a non-final run that ends in the break.
+            let cells = measured_cell_texts(&text_layout, "a\tb\n**bold**<br>**plain**\ttwo\n");
+
+            assert_eq!(
+                cells[1][0], "bold\nplain",
+                "a <br> at a style-run boundary must keep its newline between the runs"
+            );
+        });
+    })
+}
+
+/// A cell with breaks in both an interior style-boundary position and a trailing position must
+/// preserve every newline, proving the per-run reinsertion handles multiple breaks rather than
+/// only the last one.
+#[test]
+fn test_measure_table_cells_style_boundary_and_trailing_br() {
+    App::test((), |app| async move {
+        app.read(|ctx| {
+            let layout_cache = LayoutCache::new();
+            let text_layout = TextLayout::new(
+                &layout_cache,
+                ctx.font_cache().text_layout_system(),
+                &TEST_STYLES,
+                f32::MAX,
+            );
+            // Body cell 0: an interior style-boundary break (between the two bold runs) plus a
+            // trailing break at the end of the cell.
+            let cells = measured_cell_texts(&text_layout, "a\tb\n**bold**<br>**plain**<br>\ttwo\n");
+
+            assert_eq!(
+                cells[1][0], "bold\nplain\n",
+                "breaks at a style boundary and at the trailing position must both be preserved"
+            );
+        });
+    })
+}
+
 #[test]
 fn test_layout_table_block_clamps_cell_width_to_max() {
     App::test((), |app| async move {

--- a/crates/editor/src/content/markdown.rs
+++ b/crates/editor/src/content/markdown.rs
@@ -1249,10 +1249,20 @@ fn inline_to_markdown(inline: &FormattedTextInline) -> String {
     let mut previous_styles = TextStylesWithMetadata::default();
     for fragment in inline {
         let next_styles = TextStylesWithMetadata::from(fragment.styles.clone());
+        // An authored hard break (raw HTML `<br>`) is stored as an embedded newline. Emit it as
+        // literal `<br>` so it survives the GFM pipe-table serialization without splitting the
+        // cell into a spurious extra row. Inline code cannot contain a newline from the `.md`
+        // inline parser, so it is left untouched. Mirrors the guard in
+        // `markdown_parser::inline_to_markdown`.
+        let fragment_text = if !next_styles.is_inline_code() && fragment.text.contains('\n') {
+            fragment.text.replace('\n', "<br>")
+        } else {
+            fragment.text.clone()
+        };
         let content = BufferMarkdownParser::append_formatting(
             &previous_styles,
             &next_styles,
-            fragment.text.as_str(),
+            fragment_text.as_str(),
             &mut markdown,
         );
         previous_styles = next_styles;

--- a/crates/editor/src/content/markdown.rs
+++ b/crates/editor/src/content/markdown.rs
@@ -1172,7 +1172,25 @@ where
             serializer.start_elem(QualName::new(None, ns!(html), "code".into()), iter::empty())?;
         }
 
-        serializer.write_text(&fragment.text)?;
+        // An authored hard break (raw HTML `<br>`) is stored as an embedded newline. In an
+        // HTML table cell a raw newline collapses to a space, silently dropping the break, so
+        // emit a real `<br>` element between the split parts instead. Inline code cannot
+        // contain such a newline (the `.md` inline parser never produces one), so it is written
+        // verbatim. Mirrors the guard in `inline_to_markdown`.
+        if !styles.is_inline_code() && fragment.text.contains('\n') {
+            let mut parts = fragment.text.split('\n');
+            if let Some(first) = parts.next() {
+                serializer.write_text(first)?;
+            }
+            for part in parts {
+                let br_tag = QualName::new(None, ns!(html), "br".into());
+                serializer.start_elem(br_tag.clone(), iter::empty())?;
+                serializer.end_elem(br_tag)?;
+                serializer.write_text(part)?;
+            }
+        } else {
+            serializer.write_text(&fragment.text)?;
+        }
 
         if styles.is_inline_code() {
             serializer.end_elem(QualName::new(None, ns!(html), "code".into()))?;

--- a/crates/editor/src/content/markdown_tests.rs
+++ b/crates/editor/src/content/markdown_tests.rs
@@ -179,6 +179,40 @@ fn test_gfm_table_html_serialization() {
 }
 
 #[test]
+fn test_gfm_table_html_serialization_preserves_br_in_cell() {
+    App::test((), |mut app| async move {
+        let _flag = warp_core::features::FeatureFlag::MarkdownTables.override_enabled(true);
+        let markdown = "\
+| header 1 | header 2 |\n\
+| --- | --- |\n\
+| line one<br>line two | value 2 |\n";
+        let (buffer, _selection) = Buffer::mock_from_markdown(
+            markdown,
+            None,
+            Box::new(|_, _| IndentBehavior::Ignore),
+            &mut app,
+        );
+
+        let html = app.read_model(&buffer, |buffer, ctx| {
+            let range = CharOffset::from(1)..buffer.max_charoffset();
+            buffer.ranges_as_html(Vec1::try_from_vec(vec![range]).unwrap(), ctx)
+        });
+
+        let html = html.expect("table should export HTML");
+        // The in-cell break must serialize as a real <br> element, not a raw newline (which
+        // HTML collapses to a space, silently dropping the break).
+        assert!(
+            html.contains("<td align=\"left\">line one<br>line two</td>"),
+            "cell break should become a <br> element, got {html}"
+        );
+        assert!(
+            !html.contains("line one\nline two"),
+            "cell HTML must not contain a raw newline, got {html:?}"
+        );
+    });
+}
+
+#[test]
 fn test_apply_formatted_text_delta_append() {
     App::test((), |mut app| async move {
         let old_markdown = "hello world\n";

--- a/crates/editor/src/content/markdown_tests.rs
+++ b/crates/editor/src/content/markdown_tests.rs
@@ -358,6 +358,35 @@ fn test_table_markdown_export_escapes_pipe_characters() {
 }
 
 #[test]
+fn test_table_markdown_export_preserves_br_line_breaks() {
+    App::test((), |mut app| async move {
+        // A cell whose text contains a `<br>` hard break is stored internally as an
+        // embedded newline. The GFM export must emit it back as literal `<br>` so the
+        // newline does not split the pipe-table row into a spurious extra row.
+        let markdown = format!(
+            "```{}\nheader 1\theader 2\nline one<br>line two\tvalue 2\n```\n",
+            TABLE_BLOCK_MARKDOWN_LANG
+        );
+        let (buffer, _selection) = Buffer::mock_from_markdown(
+            &markdown,
+            None,
+            Box::new(|_, _| IndentBehavior::Ignore),
+            &mut app,
+        );
+
+        let exported_markdown = app.read_model(&buffer, |buffer, _| buffer.markdown_unescaped());
+        assert_eq!(
+            exported_markdown,
+            "| header 1 | header 2 |\n| --- | --- |\n| line one<br>line two | value 2 |\n"
+        );
+        assert!(
+            !exported_markdown.contains("line one\nline two"),
+            "in-cell hard break must not emit a raw newline that splits the table row: {exported_markdown:?}"
+        );
+    });
+}
+
+#[test]
 fn test_url_link_display_text_round_trip_is_stable() {
     App::test((), |mut app| async move {
         let original =

--- a/crates/editor/src/render/model/table_offset_map.rs
+++ b/crates/editor/src/render/model/table_offset_map.rs
@@ -283,6 +283,37 @@ impl TableOffsetMap {
 // per-cell offsets can be derived by seeking to boundaries instead of re-parsing the
 // whole table on every edit. The current embedded-text-plus-cached-parse model is
 // sufficient for read-only tables; see PR #24326 discussion for context.
+/// If a raw HTML `<br>` line-break token begins at `idx` in `chars`, return its length in
+/// characters. Accepts the same forms as the Markdown parser (`markdown_parser::parse_inline_token_br`):
+/// `<br>`, `<br/>`, and `<br />` with a case-insensitive `br` and any run of ASCII whitespace
+/// before an optional self-closing slash. Attributes (e.g. `<br class="x">`) are not accepted,
+/// matching the parser, so such input is walked as ordinary source text.
+fn br_token_len_at(chars: &[char], idx: usize) -> Option<usize> {
+    let mut i = idx;
+    if chars.get(i)? != &'<' {
+        return None;
+    }
+    i += 1;
+    if !chars.get(i)?.eq_ignore_ascii_case(&'b') {
+        return None;
+    }
+    i += 1;
+    if !chars.get(i)?.eq_ignore_ascii_case(&'r') {
+        return None;
+    }
+    i += 1;
+    while chars.get(i).is_some_and(|c| c.is_ascii_whitespace()) {
+        i += 1;
+    }
+    if chars.get(i) == Some(&'/') {
+        i += 1;
+    }
+    if chars.get(i)? != &'>' {
+        return None;
+    }
+    Some(i + 1 - idx)
+}
+
 impl TableCellOffsetMap {
     /// Build a cell offset map from the raw cell `source` text and the parsed `inline`
     /// fragments produced by the Markdown parser.
@@ -306,52 +337,78 @@ impl TableCellOffsetMap {
                 continue;
             }
 
-            let first_rendered = rendered_chars[0];
-            while source_idx < total_source_chars {
-                let sc = source_chars[source_idx];
-                if sc == '\\'
-                    && source_idx + 1 < total_source_chars
-                    && source_chars[source_idx + 1] == first_rendered
-                {
+            // A fragment may embed authored hard breaks (rendered `\n`, spelled `<br>` in
+            // source). Walk it in newline-delimited segments and emit one range per segment so
+            // each range keeps a linear rendered↔source correspondence; the `<br>` token span
+            // between segments becomes a gap, handled the same way as Markdown markers between
+            // fragments (see the `source_end` back-fill below).
+            for (segment_index, segment) in rendered_chars.split(|&c| c == '\n').enumerate() {
+                if segment_index > 0 {
+                    // Scan forward to the `<br>` token that produced this break (skipping any
+                    // trailing Markdown markers, e.g. the closing `**` of a bold run) and
+                    // consume it.
+                    while source_idx < total_source_chars {
+                        if let Some(token_len) = br_token_len_at(&source_chars, source_idx) {
+                            source_idx += token_len;
+                            break;
+                        }
+                        source_idx += 1;
+                    }
+                    // Account for the rendered `\n` we split on.
+                    rendered_offset += CharOffset::from(1usize);
+                }
+
+                if segment.is_empty() {
+                    continue;
+                }
+
+                let first_rendered = segment[0];
+                while source_idx < total_source_chars {
+                    let sc = source_chars[source_idx];
+                    if sc == '\\'
+                        && source_idx + 1 < total_source_chars
+                        && source_chars[source_idx + 1] == first_rendered
+                    {
+                        source_idx += 1;
+                        break;
+                    }
+                    if sc == first_rendered {
+                        break;
+                    }
                     source_idx += 1;
-                    break;
                 }
-                if sc == first_rendered {
-                    break;
+
+                let visible_source_start = CharOffset::from(source_idx);
+
+                for &rendered_char in segment {
+                    if source_idx >= total_source_chars {
+                        break;
+                    }
+                    let sc = source_chars[source_idx];
+                    if sc == '\\'
+                        && source_idx + 1 < total_source_chars
+                        && source_chars[source_idx + 1] == rendered_char
+                    {
+                        source_idx += 2;
+                    } else {
+                        source_idx += 1;
+                    }
                 }
-                source_idx += 1;
+
+                let visible_source_end = CharOffset::from(source_idx);
+                let rendered_start = rendered_offset;
+                let rendered_end = rendered_start + CharOffset::from(segment.len());
+
+                fragment_ranges.push(TableCellFragmentRange {
+                    rendered_start,
+                    rendered_end,
+                    source_end: visible_source_end,
+                    visible_source_start,
+                    visible_source_end,
+                });
+
+                rendered_offset = rendered_end;
             }
-
-            let visible_source_start = CharOffset::from(source_idx);
-
-            for &rendered_char in &rendered_chars {
-                if source_idx >= total_source_chars {
-                    break;
-                }
-                let sc = source_chars[source_idx];
-                if sc == '\\'
-                    && source_idx + 1 < total_source_chars
-                    && source_chars[source_idx + 1] == rendered_char
-                {
-                    source_idx += 2;
-                } else {
-                    source_idx += 1;
-                }
-            }
-
-            let visible_source_end = CharOffset::from(source_idx);
-            let rendered_start = rendered_offset;
-            let rendered_end = rendered_start + CharOffset::from(rendered_chars.len());
-
-            fragment_ranges.push(TableCellFragmentRange {
-                rendered_start,
-                rendered_end,
-                source_end: visible_source_end,
-                visible_source_start,
-                visible_source_end,
-            });
-
-            rendered_offset = rendered_end;
         }
 
         let total_source_offset = CharOffset::from(total_source_chars);
@@ -389,10 +446,18 @@ impl TableCellOffsetMap {
                 .unwrap_or(self.source_length);
         }
 
+        let mut previous_visible_source_end = CharOffset::zero();
         for fragment in &self.fragment_ranges {
+            // A rendered `\n` (authored `<br>`) sits in the gap before this range's
+            // `rendered_start`. Map it to the end of the previous range's visible source (the
+            // start of the `<br>` token) rather than interpolating into this range.
+            if rendered_offset < fragment.rendered_start {
+                return previous_visible_source_end;
+            }
             if rendered_offset < fragment.rendered_end {
                 return fragment.visible_source_start + (rendered_offset - fragment.rendered_start);
             }
+            previous_visible_source_end = fragment.visible_source_end;
         }
 
         self.source_length

--- a/crates/editor/src/render/model/table_offset_map_tests.rs
+++ b/crates/editor/src/render/model/table_offset_map_tests.rs
@@ -232,6 +232,115 @@ fn test_table_cell_offset_map_handles_backslash_escaped_punctuation() {
 }
 
 #[test]
+fn test_table_cell_offset_map_maps_br_source_offsets() {
+    // `<br>` is 4 source chars but renders as a single `\n`. The map must map offsets in
+    // the post-break region ("two") to their true source positions, not collapse them to
+    // the break.
+    let source = "one<br>two";
+    let inline = parse_inline_markdown(source);
+    let rendered_text: String = inline
+        .iter()
+        .map(|fragment| fragment.text.as_str())
+        .collect();
+    assert_eq!(rendered_text, "one\ntwo");
+
+    let map = TableCellOffsetMap::from_inline_and_source(source, &inline);
+    assert_eq!(
+        map.source_length(),
+        CharOffset::from(source.chars().count())
+    );
+    assert_eq!(
+        map.rendered_length(),
+        CharOffset::from(rendered_text.chars().count())
+    );
+
+    // Rendered "two" begins at rendered offset 4 and source offset 7 (after `one<br>`).
+    assert_eq!(
+        map.rendered_to_source(CharOffset::from(4)),
+        CharOffset::from(7),
+        "rendered 't' should map to source 't' after the <br> token"
+    );
+    assert_eq!(
+        map.rendered_to_source(CharOffset::from(6)),
+        CharOffset::from(9),
+    );
+    assert_eq!(
+        map.source_to_rendered(CharOffset::from(7)),
+        CharOffset::from(4),
+        "source 't' should map to rendered 't'"
+    );
+    assert_eq!(
+        map.source_to_rendered(CharOffset::from(9)),
+        CharOffset::from(6),
+    );
+
+    // Every rendered char (including the break) should map back to a source position whose
+    // char matches, except the break which corresponds to the `<` of `<br>`.
+    for (rendered_idx, rendered_char) in rendered_text.chars().enumerate() {
+        if rendered_char == '\n' {
+            continue;
+        }
+        let source_pos = map.rendered_to_source(CharOffset::from(rendered_idx));
+        assert_eq!(
+            source.chars().nth(source_pos.as_usize()),
+            Some(rendered_char),
+            "rendered {rendered_idx} ({rendered_char:?}) should map to same char in source",
+        );
+    }
+}
+
+#[test]
+fn test_table_cell_offset_map_maps_self_closing_br_source_offsets() {
+    // `<br/>` is 5 source chars, still a single rendered `\n`.
+    let source = "one<br/>two";
+    let inline = parse_inline_markdown(source);
+    let rendered_text: String = inline
+        .iter()
+        .map(|fragment| fragment.text.as_str())
+        .collect();
+    assert_eq!(rendered_text, "one\ntwo");
+
+    let map = TableCellOffsetMap::from_inline_and_source(source, &inline);
+    // Rendered "two" begins at rendered offset 4 and source offset 8 (after `one<br/>`).
+    assert_eq!(
+        map.rendered_to_source(CharOffset::from(4)),
+        CharOffset::from(8),
+    );
+    assert_eq!(
+        map.source_to_rendered(CharOffset::from(8)),
+        CharOffset::from(4),
+    );
+}
+
+#[test]
+fn test_table_cell_offset_map_maps_br_at_style_boundary() {
+    // The break falls between a bold fragment ("a") and a plain one that begins with the
+    // break ("\nb"), so the walk must handle a `\n` as the *first* rendered char too.
+    let source = "**a**<br>b";
+    let inline = parse_inline_markdown(source);
+    let rendered_text: String = inline
+        .iter()
+        .map(|fragment| fragment.text.as_str())
+        .collect();
+    assert_eq!(rendered_text, "a\nb");
+
+    let map = TableCellOffsetMap::from_inline_and_source(source, &inline);
+    assert_eq!(
+        map.source_length(),
+        CharOffset::from(source.chars().count())
+    );
+    // Rendered 'b' is at rendered offset 2 and source offset 9 (after `**a**<br>`).
+    assert_eq!(
+        map.rendered_to_source(CharOffset::from(2)),
+        CharOffset::from(9),
+    );
+    assert_eq!(
+        map.source_to_rendered(CharOffset::from(9)),
+        CharOffset::from(2),
+    );
+}
+
+#[test]
 fn test_table_cell_offset_map_handles_nested_styles() {
     let source = "**a *b* c**";
     let inline = parse_inline_markdown(source);

--- a/crates/markdown_parser/src/lib.rs
+++ b/crates/markdown_parser/src/lib.rs
@@ -431,7 +431,13 @@ impl FormattedTable {
     /// Serialize to GFM pipe-table markdown.
     pub fn to_plain_text(&self) -> String {
         fn inline_to_text(inline: &FormattedTextInline) -> String {
-            inline.iter().map(|f| f.text.as_str()).collect()
+            // Translate authored hard breaks (embedded newlines, from raw HTML `<br>`) back
+            // to `<br>` so an in-cell line break does not split the pipe-table row. A cell's
+            // text never contains a newline for any other reason.
+            inline
+                .iter()
+                .map(|f| f.text.replace('\n', "<br>"))
+                .collect()
         }
 
         let mut lines = Vec::new();
@@ -462,6 +468,14 @@ fn inline_to_markdown(inline: &FormattedTextInline) -> String {
         let mut text = fragment.text.clone();
         if text.is_empty() {
             continue;
+        }
+
+        // An authored hard break (raw HTML `<br>`) is stored as an embedded newline. Emit it
+        // as literal `<br>` so it survives the newline/tab/pipe-delimited table serialization
+        // formats without splitting a cell into a spurious extra row. Inline code spans are
+        // handled below (a newline cannot appear in one from the `.md` inline parser).
+        if !fragment.styles.inline_code && text.contains('\n') {
+            text = text.replace('\n', "<br>");
         }
 
         if fragment.styles.inline_code {

--- a/crates/markdown_parser/src/markdown_parser.rs
+++ b/crates/markdown_parser/src/markdown_parser.rs
@@ -1035,6 +1035,14 @@ fn parse_inline<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
             InlineToken::UnderlineEnd => {
                 input = parse_underline(&mut state, remaining);
             }
+            InlineToken::LineBreak => {
+                // Emit the break as a newline fragment. Both the paragraph and table-cell
+                // render paths turn an embedded newline into a real visual break. The
+                // fragment may later coalesce into adjacent plain text (the newline is
+                // preserved, so rendering is unaffected); serialization paths translate any
+                // embedded newline back to `<br>`. See `HARD_LINE_BREAK`.
+                state.push_closed_node(FormattedTextFragment::plain_text(HARD_LINE_BREAK));
+            }
         }
     }
 
@@ -1549,6 +1557,7 @@ fn parse_inline_token<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
             parse_inline_token_autolink,
             parse_inline_token_underline_start,
             parse_inline_token_underline_end,
+            parse_inline_token_br,
             whitespace,
             text,
             // This _must_ be the last parser in the chain. It unconditionally consumes a single
@@ -1654,6 +1663,33 @@ fn parse_inline_token_underline_end<'a, E: ContextError<&'a str> + ParseError<&'
     )(input)
 }
 
+/// Parse a raw HTML `<br>` line break.
+///
+/// Accepts the case-insensitive forms `<br>`, `<br/>`, and `<br />` (any run of ASCII
+/// whitespace is allowed before an optional self-closing `/`). Attributes are intentionally
+/// *not* accepted: a tag such as `<br class="x">` falls through to literal text rather than
+/// being silently reinterpreted, keeping malformed/unsupported input deterministic. A stray
+/// `<br` with no closing `>` also fails here and is emitted as literal text by the fallback
+/// `text`/`unmatched_char` parsers, matching the `<u>`/`</u>` precedent.
+fn parse_inline_token_br<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
+    input: &'a str,
+) -> IResult<&'a str, InlineToken<'a>, E> {
+    context(
+        "line_break",
+        value(
+            InlineToken::LineBreak,
+            tuple((
+                tag("<"),
+                tag_no_case("br"),
+                space0,
+                // Optional self-closing slash: `<br/>` or `<br />`.
+                map(take_while_m_n(0, 1, |c| c == '/'), |_| ()),
+                tag(">"),
+            )),
+        ),
+    )(input)
+}
+
 /// Helper to parse a run of delimiters.
 fn parse_delimiter_run<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
     kind: DelimiterKind,
@@ -1700,7 +1736,19 @@ enum InlineToken<'a> {
     LinkEnd,
     /// A closing </u>, which triggers underline parsing.
     UnderlineEnd,
+    /// A raw HTML `<br>` line break (including the `<br/>`, `<br />`, and uppercase
+    /// variants). Rendered as a forced line break within the current paragraph or table
+    /// cell. See [`HARD_LINE_BREAK`].
+    LineBreak,
 }
+
+/// The text a hard line break (raw HTML `<br>`) is represented as within a
+/// [`FormattedTextFragment`]. Both the paragraph and table-cell render paths already turn an
+/// embedded newline into a real visual break, so the break is stored as a plain-text `"\n"`
+/// fragment. Serialization paths that flatten fragments into newline/tab/pipe-delimited
+/// formats (e.g. [`inline_to_markdown`], [`FormattedTable::to_plain_text`]) must translate
+/// this sentinel back to `<br>` so it does not corrupt row/column structure.
+pub(crate) const HARD_LINE_BREAK: &str = "\n";
 
 /// An entry in the [delimiter stack](https://spec.commonmark.org/0.30/#delimiter-stack)
 #[derive(Debug, Clone)]

--- a/crates/markdown_parser/src/markdown_parser_tests.rs
+++ b/crates/markdown_parser/src/markdown_parser_tests.rs
@@ -2912,3 +2912,177 @@ fn test_parse_table_with_strikethrough() {
         panic!("Expected table");
     }
 }
+
+// --- Raw HTML `<br>` line breaks (GH13732) ---------------------------------
+//
+// A `<br>` is parsed into a bare `"\n"` fragment; both the paragraph and table-cell render
+// paths turn an embedded newline into a real visual break. These tests assert the parse-level
+// shape, the malformed-input fallbacks, and that serialization round-trips the break as
+// literal `<br>` rather than corrupting the delimited table formats.
+
+/// Collect the fragments of the single paragraph line produced by `source`.
+fn parse_single_line_fragments(source: &str) -> Vec<FormattedTextFragment> {
+    let result = test_parse_markdown(source);
+    assert_eq!(result.len(), 1, "expected a single line, got {result:?}");
+    match result.into_iter().next().unwrap() {
+        FormattedTextLine::Line(fragments) => fragments,
+        other => panic!("expected a paragraph Line, got {other:?}"),
+    }
+}
+
+/// The joined text of the single paragraph line produced by `source`. A `<br>` renders as
+/// an embedded `"\n"`; fragments with identical styles coalesce, so the break lives inside a
+/// merged fragment rather than as a standalone one — the render path breaks on the newline
+/// either way.
+fn parse_single_line_text(source: &str) -> String {
+    parse_single_line_fragments(source)
+        .iter()
+        .map(|f| f.text.as_str())
+        .collect()
+}
+
+#[test]
+fn test_br_standalone_becomes_line_break() {
+    assert_eq!(
+        parse_single_line_text("First half<br>second half"),
+        "First half\nsecond half"
+    );
+}
+
+#[test]
+fn test_br_self_closing_variants() {
+    // `<br>`, `<br/>`, and `<br />` are all recognized identically.
+    for source in ["a<br>b", "a<br/>b", "a<br />b", "a<br  />b"] {
+        assert_eq!(
+            parse_single_line_text(source),
+            "a\nb",
+            "failed for {source:?}"
+        );
+    }
+}
+
+#[test]
+fn test_br_case_insensitive() {
+    for source in ["a<BR>b", "a<Br>b", "a<bR/>b", "a<BR />b"] {
+        assert_eq!(
+            parse_single_line_text(source),
+            "a\nb",
+            "failed for {source:?}"
+        );
+    }
+}
+
+#[test]
+fn test_br_consecutive_produce_two_breaks() {
+    // `<br><br>` is two forced breaks (one visually blank line), not a paragraph boundary.
+    assert_eq!(parse_single_line_text("a<br><br>b"), "a\n\nb");
+}
+
+#[test]
+fn test_br_malformed_stays_literal() {
+    // Each of these fails the `<br>` shape and must survive as literal text, not a break.
+    // - `<br` : no closing `>`
+    // - `< br>` : whitespace before the tag name
+    // - `</br>` : end tag, not a void element
+    // - `<br class="x">` : attributes are intentionally rejected (deterministic fallback)
+    // - `<brr>` : not the `br` tag name
+    for source in [
+        "a<br b",
+        "a< br>b",
+        "a</br>b",
+        "a<br class=\"x\">b",
+        "a<brr>b",
+    ] {
+        let fragments = parse_single_line_fragments(source);
+        let joined: String = fragments.iter().map(|f| f.text.as_str()).collect();
+        assert!(
+            !joined.contains('\n'),
+            "expected no line break for malformed {source:?}, got {fragments:?}"
+        );
+        // The literal tag text survives.
+        let literal = source.trim_start_matches('a').trim_end_matches('b');
+        assert!(
+            joined.contains(literal),
+            "expected literal {literal:?} to survive for {source:?}, got {joined:?}"
+        );
+    }
+}
+
+#[test]
+fn test_br_inside_code_span_is_literal() {
+    // Code spans are consumed atomically before the `<br>` parser sees their contents.
+    let fragments = parse_single_line_fragments("before `no <br> here` after");
+    let joined: String = fragments.iter().map(|f| f.text.as_str()).collect();
+    assert!(
+        !joined.contains('\n'),
+        "expected no break inside a code span, got {fragments:?}"
+    );
+    assert!(
+        joined.contains("<br>"),
+        "expected literal <br> preserved inside code span, got {joined:?}"
+    );
+}
+
+#[test]
+fn test_kbd_tag_still_literal_control() {
+    // Control: an unrelated raw tag is NOT special-cased and stays literal text.
+    let fragments = parse_single_line_fragments("Press <kbd>K</kbd> now");
+    let joined: String = fragments.iter().map(|f| f.text.as_str()).collect();
+    assert!(!joined.contains('\n'), "kbd must not produce a break");
+    assert!(
+        joined.contains("<kbd>") && joined.contains("</kbd>"),
+        "expected literal <kbd> tags preserved, got {joined:?}"
+    );
+}
+
+#[test]
+fn test_br_inside_gfm_table_cell_becomes_line_break() {
+    let source = "| Feature | Notes |\n| --- | --- |\n| Export | Supports CSV.<br>Also JSON. |\n";
+    let result = test_parse_markdown_with_gfm_tables(source);
+    assert_eq!(result.len(), 1);
+
+    let FormattedTextLine::Table(table) = &result[0] else {
+        panic!("expected a table, got {result:?}");
+    };
+    let cell_text: String = table.rows[0][1].iter().map(|f| f.text.as_str()).collect();
+    assert_eq!(
+        cell_text, "Supports CSV.\nAlso JSON.",
+        "expected the cell to contain an embedded newline break, got {:?}",
+        table.rows[0][1]
+    );
+}
+
+#[test]
+fn test_br_in_table_cell_round_trips_as_literal_br() {
+    // A break inside a cell must serialize back to `<br>` in both the internal tab/newline
+    // format and the GFM pipe-table format, never as a raw `\n` that would split the row.
+    let source = "| A | B |\n| --- | --- |\n| one<br>two | plain |\n";
+    let result = test_parse_markdown_with_gfm_tables(source);
+    let FormattedTextLine::Table(table) = &result[0] else {
+        panic!("expected a table, got {result:?}");
+    };
+
+    let internal = table.to_internal_format();
+    // Exactly two lines (header + one data row), no spurious row from the in-cell break.
+    assert_eq!(
+        internal.lines().count(),
+        2,
+        "in-cell break must not add a table row, got {internal:?}"
+    );
+    assert!(
+        internal.contains("one<br>two"),
+        "expected <br> in internal format, got {internal:?}"
+    );
+
+    let plain = table.to_plain_text();
+    assert!(
+        plain.contains("| one<br>two |"),
+        "expected <br> in GFM plain text, got {plain:?}"
+    );
+    // Header + separator + one data row.
+    assert_eq!(
+        plain.lines().count(),
+        3,
+        "in-cell break must not add a pipe-table row, got {plain:?}"
+    );
+}

--- a/crates/markdown_parser/src/markdown_parser_tests.rs
+++ b/crates/markdown_parser/src/markdown_parser_tests.rs
@@ -3086,3 +3086,45 @@ fn test_br_in_table_cell_round_trips_as_literal_br() {
         "in-cell break must not add a pipe-table row, got {plain:?}"
     );
 }
+
+// Regression guards for `<br>` combined with inline style delimiters. A `<br>` inside a
+// styled run keeps the surrounding style on both sides of the embedded newline; fragments with
+// identical styles coalesce, so the break lives inside a single styled fragment.
+
+#[test]
+fn test_br_inside_bold_keeps_bold_across_break() {
+    let fragments = parse_single_line_fragments("**a<br>b**");
+    let joined: String = fragments.iter().map(|f| f.text.as_str()).collect();
+    assert_eq!(joined, "a\nb", "expected a single break, got {fragments:?}");
+    assert!(
+        fragments
+            .iter()
+            .all(|f| f.styles.weight == Some(CustomWeight::Bold)),
+        "both sides of the break should stay bold, got {fragments:?}"
+    );
+}
+
+#[test]
+fn test_br_inside_underline_keeps_underline_across_break() {
+    let fragments = parse_single_line_fragments("<u>a<br>b</u>");
+    let joined: String = fragments.iter().map(|f| f.text.as_str()).collect();
+    assert_eq!(joined, "a\nb", "expected a single break, got {fragments:?}");
+    assert!(
+        fragments.iter().all(|f| f.styles.underline),
+        "both sides of the break should stay underlined, got {fragments:?}"
+    );
+}
+
+#[test]
+fn test_br_inside_link_keeps_hyperlink_across_break() {
+    let fragments = parse_single_line_fragments("[a<br>b](https://x.com)");
+    let joined: String = fragments.iter().map(|f| f.text.as_str()).collect();
+    assert_eq!(joined, "a\nb", "expected a single break, got {fragments:?}");
+    assert!(
+        fragments.iter().all(|f| matches!(
+            &f.styles.hyperlink,
+            Some(Hyperlink::Url(url)) if url == "https://x.com"
+        )),
+        "both sides of the break should keep the hyperlink, got {fragments:?}"
+    );
+}


### PR DESCRIPTION
Closes #13732

The Markdown viewer rendered a raw `<br>` as literal text, both mid-paragraph and inside GFM pipe-table cells. Inside a pipe-table cell `<br>` is the only way to author a forced line break at all, so this was the more painful half of the gap.

This teaches the `.md` inline parser to recognize `<br>`, `<br/>`, and `<br />` (case-insensitive) and turn them into a real line break, in ordinary paragraphs and inside GFM table cells.

Notes:
- The break is stored as a newline fragment; the render path already turns an embedded newline into a visual break in both paragraphs and cells, so no rendering code changed. The table serialization paths translate the break back to `<br>` so an in-cell break does not corrupt row/column structure on round-trip.
- Attributes (`<br class="x">`) and malformed forms (`<br` without `>`, `< br>`, `</br>`) fall through to literal text.
- Markdown-native hard breaks (trailing double-space / backslash) are unchanged and out of scope.

Tested: new unit tests in `markdown_parser` pass, clippy and rustfmt clean, and exercised in a local dev build against the issue sample document — paragraphs, consecutive breaks, self-closing/case variants, table cells, and malformed forms all behave as described.

<details><summary>Human-focused Test Document + Screenshot</summary>

```markdown
# `<br>` line breaks (paragraphs and GFM pipe-table cells)

Each `<br>` below should render as a real line break. Malformed forms stay literal.

Mid-paragraph:

First line of the paragraph.<br>
Second line, after a raw `<br>`.

Consecutive breaks (should produce blank lines):

Before the gap.<br><br><br>After a triple `<br>`.

Self-closing and case variants (each breaks):

alpha<br/>bravo<br />charlie<BR>delta

Inside a GFM pipe-table cell (two lines, table intact):

| Feature | Notes                                |
| ------- | ------------------------------------ |
| Export  | Supports CSV.<br>Also supports JSON. |

Trailing `<br>` at the end of a cell (should add a trailing empty line inside the cell, matching GitHub):

| Feature | Notes                  |
| ------- | ---------------------- |
| Import  | Ends with a break.<br> |

Malformed / attributed forms (each should stay literal text, no break):

one</br>two &lt;br three<br class="x">four

Control (unrelated tags unaffected): a <kbd>K</kbd> stays literal.
```
<img width="985" height="1208" alt="Screenshot of the above test document" src="https://github.com/user-attachments/assets/4c0ade1d-4fe4-49cb-81cf-235547fdccb3" />

</details>

