### PR TITLE
Prevent stale share modal rendering

### DIFF
--- a/app/src/pane_group/mod_tests.rs
+++ b/app/src/pane_group/mod_tests.rs
@@ -89,12 +89,13 @@ use crate::terminal::history::History;
 use crate::terminal::keys::TerminalKeybindings;
 use crate::terminal::local_tty::spawner::PtySpawner;
 use crate::terminal::local_tty::TerminalManager;
-use crate::terminal::model::terminal_model::ConversationTranscriptViewerStatus;
+use crate::terminal::model::terminal_model::{BlockIndex, ConversationTranscriptViewerStatus};
 use crate::terminal::resizable_data::ResizableData;
 use crate::terminal::shared_session::{
     IsSharedSessionCreator, SharedSessionActionSource, SharedSessionScrollbackType,
     SharedSessionSource, SharedSessionStatus,
 };
+use crate::terminal::view::Event as TerminalViewEvent;
 use crate::test_util::settings::initialize_settings_for_tests;
 use crate::undo_close::UndoCloseStack;
 use crate::warp_managed_paths_watcher::WarpManagedPathsWatcher;
@@ -2655,6 +2656,37 @@ fn test_start_shared_session_from_modal() {
                 .header()
                 .as_ref(ctx)
                 .has_shareable_object(ctx));
+        });
+    });
+}
+
+#[test]
+fn share_block_modal_is_not_opened_for_stale_terminal_event() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let pane_group = mock_pane_group(&mut app, Default::default());
+
+        let terminal_view = pane_group.update(&mut app, |panes, ctx| {
+            let terminal_pane_id = panes
+                .terminal_session_by_pane_index(0)
+                .unwrap()
+                .terminal_pane_id();
+            let pane_id = terminal_pane_id.into();
+            let terminal_view = panes
+                .terminal_view_from_pane_id(terminal_pane_id, ctx)
+                .unwrap();
+            let notebook_pane = NotebookPane::new(new_notebook(ctx), ctx);
+            panes.pane_contents.insert(pane_id, Box::new(notebook_pane));
+            terminal_view
+        });
+
+        terminal_view.update(&mut app, |_, ctx| {
+            ctx.emit(TerminalViewEvent::ShareModalOpened(BlockIndex::zero()));
+        });
+        futures_lite::future::yield_now().await;
+
+        pane_group.read(&app, |panes, _| {
+            assert!(panes.terminal_with_open_share_block_modal.is_none());
         });
     });
 }

--- a/app/src/pane_group/pane/terminal_pane.rs
+++ b/app/src/pane_group/pane/terminal_pane.rs
@@ -986,14 +986,15 @@ fn handle_terminal_view_event(
                 }
             }
             Event::ShareModalOpened(block_id) => {
-                group.terminal_with_open_share_block_modal = Some(terminal_pane_id);
+                let Some(session) = group.terminal_view_from_pane_id(pane_id, ctx) else {
+                    return;
+                };
+                let model = session.read(ctx, |view, _| view.model.clone());
                 group.share_block_modal.update(ctx, |share_modal, ctx| {
-                    if let Some(session) = group.terminal_view_from_pane_id(pane_id, ctx) {
-                        let model = session.read(ctx, |view, _| view.model.clone());
-                        share_modal.open_with_model_update(model, *block_id, ctx);
-                        ctx.notify();
-                    }
+                    share_modal.open_with_model_update(model, *block_id, ctx);
+                    ctx.notify();
                 });
+                group.terminal_with_open_share_block_modal = Some(terminal_pane_id);
                 ctx.notify();
             }
             Event::SendNotification(notification) => {


### PR DESCRIPTION
## Description

- Resolve the emitting terminal before marking the share-block modal as open.
- Initialize the modal model before exposing the modal to the pane-group render tree.
- Add a regression test for a stale share-modal event after the terminal pane no longer resolves.

## Linked Issue

Closes #13757

- [x] The linked issue is labeled `ready-to-implement`.
- [x] Screenshots or video are not applicable because this changes invalid modal lifecycle state without changing visible UI.

## Testing

- Added `share_block_modal_is_not_opened_for_stale_terminal_event`.
- Confirmed the regression failed before the fix, logged `Tried to render share modal without a model`, and passed after the fix.
- `cargo test -p warp --lib share_block_modal_is_not_opened_for_stale_terminal_event -- --nocapture`
- `cargo check -p warp --tests`
- `cargo clippy -p warp --tests -- -D warnings`
- `cargo fmt --all -- --check`

- [ ] I have manually tested my changes locally with `./script/run`

The original periodic trigger was reported on macOS and was not manually reproduced on this Windows machine. The app-level regression deterministically exercises the stale terminal event that previously left the modal mounted without a model.

### Screenshots / Videos

Not applicable; there is no visible UI change.

## Agent Mode

- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Prevented stale share-modal state from causing repeated render warnings and UI stalls.
