### PR TITLE
Fix Markdown table selection after wrapped rows

### DIFF
--- a/crates/editor/src/content/buffer_tests.rs
+++ b/crates/editor/src/content/buffer_tests.rs
@@ -13020,6 +13020,71 @@ fn test_clipboard_table_copy_uses_source_offsets_for_later_formatted_cells() {
 }
 
 #[test]
+fn test_clipboard_table_copy_preserves_long_cell_spanning_text_fragments() {
+    // Regression coverage for warpdotdev/warp#10016. A long table cell exceeds the
+    // internal `TEXT_FRAGMENT_SIZE` so the source text is stored across several
+    // buffer fragments. The buffer-level clipboard pipeline used by the rendered
+    // markdown viewer must return the entire cell, never a fragment-bounded
+    // truncation, when the selection covers the full source range.
+    App::test((), |mut app| async move {
+        // 500 chars > 4x TEXT_FRAGMENT_SIZE (128) to force multi-fragment storage.
+        let long_cell: String = "abcdefghij".repeat(50);
+        assert_eq!(long_cell.chars().count(), 500);
+
+        let table_source = format!("H1\tH2\nshort\t{long_cell}");
+        let markdown = format!("```{TABLE_BLOCK_MARKDOWN_LANG}\n{table_source}\n```\n");
+        let (buffer, selection) = Buffer::mock_from_markdown(
+            &markdown,
+            None,
+            Box::new(|_, _| IndentBehavior::Ignore),
+            &mut app,
+        );
+
+        buffer.update(&mut app, |buffer, ctx| {
+            let block_start = buffer.containing_block_start(CharOffset::from(1));
+            let long_cell_offset = CharOffset::from(
+                table_source
+                    .find(&long_cell)
+                    .expect("table source should contain the long cell"),
+            );
+            let long_cell_end = long_cell_offset + CharOffset::from(long_cell.chars().count());
+
+            // Direct table-clipboard path with full cell range.
+            let copied = buffer.clipboard_table_text_in_range(
+                block_start,
+                (block_start + long_cell_offset)..(block_start + long_cell_end),
+                LineEnding::LF,
+            );
+            assert_eq!(
+                copied.chars().count(),
+                long_cell.chars().count(),
+                "direct clipboard_table_text_in_range should return the full cell"
+            );
+            assert_eq!(copied, long_cell);
+
+            // End-to-end clipboard pipeline used by the rendered markdown viewer:
+            // `selected_text_as_plain_text` reads ranges from the selection model
+            // and routes through `clipboard_text_in_ranges`.
+            let selection_start = block_start + long_cell_offset;
+            let selection_end = block_start + long_cell_end;
+            selection.update(ctx, |selection, _| {
+                set_selections(selection, vec1![selection_start..selection_end]);
+            });
+
+            let selected = buffer
+                .selected_text_as_plain_text(selection.clone(), ctx)
+                .into_string();
+            assert_eq!(
+                selected.chars().count(),
+                long_cell.chars().count(),
+                "selected_text_as_plain_text should return the full long cell"
+            );
+            assert_eq!(selected, long_cell);
+        });
+    });
+}
+
+#[test]
 fn test_multiselect_text_styling() {
     App::test((), |mut app| async move {
         let buffer = app.add_model(|_| Buffer::new(Box::new(|_, _| IndentBehavior::Ignore)));

--- a/crates/editor/src/render/model/mod.rs
+++ b/crates/editor/src/render/model/mod.rs
@@ -2081,20 +2081,29 @@ impl LaidOutTable {
     }
 
     /// Source character offset (within the table's flattened content stream) for the
-    /// start of `sub_line` within source row `row`.
+    /// leftmost cell that occupies `sub_line` within source row `row`.
     ///
-    /// Falls back to the start of the row's first cell when offset maps or layouts are
-    /// unavailable. Returns `None` when the row is out of bounds.
+    /// A row's visual height is the maximum across all cells, so later visual lines may
+    /// begin in a column other than column zero. Selecting the first cell that actually
+    /// has the requested sub-line keeps visual line starts monotonic across the flattened
+    /// table source. Empty rows still resolve their sole visual line to column zero.
     fn row_sub_line_source_offset(&self, row: usize, sub_line: usize) -> Option<CharOffset> {
-        let cell_range = self.offset_map.cell_range(row, 0)?;
-        let cell_offset_map = self.cell_offset_maps.get(row).and_then(|r| r.first())?;
-        let rendered_start = self
-            .cell_layouts
-            .get(row)
-            .and_then(|row_layouts| row_layouts.first())
-            .and_then(|cell_layout| cell_layout.line_char_ranges.get(sub_line))
-            .map(|range| range.start)
-            .unwrap_or(CharOffset::zero());
+        let row_layouts = self.cell_layouts.get(row)?;
+        let (col, rendered_start) = if sub_line == 0 {
+            (!row_layouts.is_empty()).then_some((0, CharOffset::zero()))
+        } else {
+            row_layouts
+                .iter()
+                .enumerate()
+                .find_map(|(col, cell_layout)| {
+                    cell_layout
+                        .line_char_ranges
+                        .get(sub_line)
+                        .map(|range| (col, range.start))
+                })
+        }?;
+        let cell_range = self.offset_map.cell_range(row, col)?;
+        let cell_offset_map = self.cell_offset_maps.get(row).and_then(|r| r.get(col))?;
         Some(
             cell_range.start
                 + cell_offset_map

--- a/crates/editor/src/render/model/mod.rs
+++ b/crates/editor/src/render/model/mod.rs
@@ -1730,6 +1730,17 @@ pub struct TableBlockConfig {
     pub style: TableStyle,
 }
 
+/// Visual line count for a table row (max wrapped-line count across its cells).
+///
+/// Always returns at least 1 so empty rows still occupy a visual line.
+fn visual_row_height(row_layouts: &[CellLayout]) -> usize {
+    row_layouts
+        .iter()
+        .map(|cell| cell.line_heights.len().max(1))
+        .max()
+        .unwrap_or(1)
+}
+
 /// Layout information for a single table cell, including line-level details
 /// for proper text selection rendering in cells with wrapped text.
 #[derive(Debug, Clone, Default)]
@@ -2028,8 +2039,68 @@ impl LaidOutTable {
         ))
     }
 
+    /// Number of visual lines occupied by this table.
+    ///
+    /// Cells with content that soft-wraps span multiple visual lines, so the visual line
+    /// count for a row is the maximum visual line count of any cell in that row.
+    /// The table's total visual line count is the sum across header + body rows.
+    /// This is the value softwrap point ↔ offset mapping (via [`Self::visual_row_heights`])
+    /// is keyed on; using the source-row count would undercount any wrapped row and
+    /// cause selections inside wrapped cells to resolve to the wrong source row
+    /// (see warpdotdev/warp#10016).
     pub fn lines(&self) -> LineCount {
-        LineCount(1 + self.table.rows.len())
+        LineCount(self.visual_row_heights().sum::<usize>())
+    }
+
+    /// Per-row visual line counts, in source-row order (header first, then body rows).
+    /// Each entry is at least 1.
+    pub(crate) fn visual_row_heights(&self) -> impl Iterator<Item = usize> + '_ {
+        self.cell_layouts
+            .iter()
+            .map(|row_layouts| visual_row_height(row_layouts))
+    }
+
+    /// Total number of visual lines preceding the given source row.
+    fn visual_lines_before_row(&self, row: usize) -> usize {
+        self.visual_row_heights().take(row).sum()
+    }
+
+    /// Map a visual line index within this table to its enclosing source row index
+    /// and the sub-line within that row's wrapped layout.
+    ///
+    /// Returns `None` when the visual line is past the table's last row.
+    fn visual_line_to_source_row(&self, visual_line: usize) -> Option<(usize, usize)> {
+        let mut remaining = visual_line;
+        for (row_idx, row_height) in self.visual_row_heights().enumerate() {
+            if remaining < row_height {
+                return Some((row_idx, remaining));
+            }
+            remaining -= row_height;
+        }
+        None
+    }
+
+    /// Source character offset (within the table's flattened content stream) for the
+    /// start of `sub_line` within source row `row`.
+    ///
+    /// Falls back to the start of the row's first cell when offset maps or layouts are
+    /// unavailable. Returns `None` when the row is out of bounds.
+    fn row_sub_line_source_offset(&self, row: usize, sub_line: usize) -> Option<CharOffset> {
+        let cell_range = self.offset_map.cell_range(row, 0)?;
+        let cell_offset_map = self.cell_offset_maps.get(row).and_then(|r| r.first())?;
+        let rendered_start = self
+            .cell_layouts
+            .get(row)
+            .and_then(|row_layouts| row_layouts.first())
+            .and_then(|cell_layout| cell_layout.line_char_ranges.get(sub_line))
+            .map(|range| range.start)
+            .unwrap_or(CharOffset::zero());
+        Some(
+            cell_range.start
+                + cell_offset_map
+                    .rendered_to_source(rendered_start)
+                    .as_usize(),
+        )
     }
 
     /// Maps an x/y coordinate within the table content bounds to the nearest
@@ -4520,17 +4591,17 @@ impl Positioned<'_, BlockItem> {
             | BlockItem::TemporaryBlock { .. }
             | BlockItem::Hidden { .. } => self.start_char_offset,
             BlockItem::Table(laid_out_table) => {
-                let row_in_table = point.row().saturating_sub(self.start_line.as_u32()) as usize;
-                if let Some(cell_range) = laid_out_table.offset_map.cell_range(row_in_table, 0) {
-                    let visible_cell_start = laid_out_table
-                        .cell_offset_maps
-                        .get(row_in_table)
-                        .and_then(|row| row.first())
-                        .map(|cell| cell.rendered_to_source(CharOffset::zero()))
-                        .unwrap_or(CharOffset::zero());
-                    self.start_char_offset + cell_range.start + visible_cell_start.as_usize()
-                } else {
-                    self.start_char_offset
+                // `point.row()` is a visual line index; tables may contain wrapped cells
+                // that consume multiple visual lines per source row, so we have to walk
+                // the per-row visual heights to translate visual → source coordinates.
+                // See warpdotdev/warp#10016.
+                let visual_in_table = point.row().saturating_sub(self.start_line.as_u32()) as usize;
+                match laid_out_table.visual_line_to_source_row(visual_in_table) {
+                    Some((source_row, sub_line)) => laid_out_table
+                        .row_sub_line_source_offset(source_row, sub_line)
+                        .map(|offset_in_table| self.start_char_offset + offset_in_table.as_usize())
+                        .unwrap_or(self.end_char_offset()),
+                    None => self.end_char_offset(),
                 }
             }
         }
@@ -4587,14 +4658,37 @@ impl Positioned<'_, BlockItem> {
                 SoftWrapPoint::new(self.start_line.as_u32(), ColumnUnit::pixels_zero())
             }
             BlockItem::Table(laid_out_table) => {
+                // The forward direction returns visual line indices, so the inverse must
+                // also account for cells whose rendered content wraps across multiple
+                // visual lines. See warpdotdev/warp#10016.
                 let relative_offset = offset.saturating_sub(&self.start_char_offset);
-                let row = laid_out_table
-                    .offset_map
-                    .cell_at_offset(relative_offset)
-                    .map(|c| c.row)
-                    .unwrap_or(0);
+                let cell = laid_out_table.offset_map.cell_at_offset(relative_offset);
+                let (source_row, sub_line) = match cell {
+                    Some(cell) => {
+                        let sub_line = laid_out_table
+                            .cell_offset_maps
+                            .get(cell.row)
+                            .and_then(|row_maps| row_maps.get(cell.col))
+                            .map(|cell_offset_map| {
+                                cell_offset_map.source_to_rendered(cell.offset_in_cell)
+                            })
+                            .and_then(|rendered_offset| {
+                                laid_out_table
+                                    .cell_layouts
+                                    .get(cell.row)
+                                    .and_then(|row_layouts| row_layouts.get(cell.col))
+                                    .and_then(|cell_layout| {
+                                        cell_layout.line_at_char_offset(rendered_offset)
+                                    })
+                            })
+                            .unwrap_or(0);
+                        (cell.row, sub_line)
+                    }
+                    None => (0, 0),
+                };
+                let visual_row = laid_out_table.visual_lines_before_row(source_row) + sub_line;
                 SoftWrapPoint::new(
-                    self.start_line.as_u32() + row as u32,
+                    self.start_line.as_u32() + visual_row as u32,
                     ColumnUnit::pixels_zero(),
                 )
             }

--- a/crates/editor/src/render/model/mod_tests.rs
+++ b/crates/editor/src/render/model/mod_tests.rs
@@ -1427,6 +1427,181 @@ fn test_link_at_offset_uses_cached_cell_links() {
     assert_eq!(table.link_at_offset(CharOffset::from(3)), None);
 }
 
+// Regression coverage for warpdotdev/warp#10016. The next four tests pin down the
+// visual ↔ source row mapping for tables whose cells soft-wrap.
+
+/// Build a `CellLayout` whose visible width is `cell_width_chars * 10.0` and which contains
+/// `total_chars` characters spread evenly across `num_lines` visual lines.
+fn make_wrapped_cell_layout(num_lines: usize, total_chars: usize) -> CellLayout {
+    assert!(num_lines >= 1);
+    let per_line = total_chars.div_ceil(num_lines);
+    let mut line_heights = Vec::with_capacity(num_lines);
+    let mut line_y_offsets = Vec::with_capacity(num_lines);
+    let mut line_char_ranges = Vec::with_capacity(num_lines);
+    let mut line_widths = Vec::with_capacity(num_lines);
+    let mut line_caret_positions = Vec::with_capacity(num_lines);
+    let mut consumed = 0usize;
+    for i in 0..num_lines {
+        let start = consumed;
+        let end = (start + per_line).min(total_chars);
+        consumed = end;
+        line_heights.push(20.0);
+        line_y_offsets.push(i as f32 * 20.0);
+        line_char_ranges.push(CharOffset::from(start)..CharOffset::from(end));
+        line_widths.push(((end - start) as f32) * 10.0);
+        line_caret_positions.push(
+            (start..end)
+                .map(|c| warpui::text_layout::CaretPosition {
+                    position_in_line: ((c - start) as f32) * 10.0,
+                    start_offset: c,
+                    last_offset: c,
+                })
+                .collect(),
+        );
+    }
+    CellLayout {
+        line_heights,
+        line_y_offsets,
+        line_char_ranges,
+        line_widths,
+        line_caret_positions,
+    }
+}
+
+/// Build a `LaidOutTable` modeled on `make_test_laid_out_table` but with the body row's
+/// second cell wrapped to `wrap_lines` visual lines containing `wrap_chars` characters.
+fn make_wrapped_test_laid_out_table(wrap_lines: usize, wrap_chars: usize) -> LaidOutTable {
+    let mut table = make_test_laid_out_table();
+    // The fixture is `aaa\tbbb\nccc\tddd\n`; we widen the body row's second cell so the
+    // (row, col) = (1, 1) cell wraps to multiple visual lines. The other layouts stay
+    // single-line.
+    let single_line = make_wrapped_cell_layout(1, 3);
+    let wrapped = make_wrapped_cell_layout(wrap_lines, wrap_chars);
+    table.cell_layouts = vec![
+        vec![single_line.clone(), single_line.clone()],
+        vec![single_line.clone(), wrapped],
+    ];
+    table
+}
+
+#[test]
+fn test_table_visual_line_count_matches_wrapped_rows() {
+    // Plain table — every cell is one visual line. Header + 1 body row = 2 visual lines.
+    let plain = make_test_laid_out_table();
+    assert_eq!(plain.lines(), LineCount(2));
+
+    // Wrap the body row to 5 visual lines. Total = header(1) + body(5) = 6.
+    let wrapped = make_wrapped_test_laid_out_table(5, 50);
+    assert_eq!(wrapped.lines(), LineCount(6));
+}
+
+#[test]
+fn test_table_softwrap_round_trip_inside_wrapped_cell() {
+    // Push the wrapped table into a real RenderState so we exercise the cursor-driven
+    // BlockItem::Table arms of softwrap_point_to_offset / offset_to_softwrap_point.
+    let table = make_wrapped_test_laid_out_table(3, 30);
+    // Plain row sources: "aaa\tbbb\nccc\tddd\n" -> 16 chars total.
+    // cell_range for (1, 1) is offset 12..15 (inclusive of the cell's 3 source chars,
+    // since the source map is built from the unwrapped source).
+    let mut model = RenderState::new_for_test(
+        TEST_STYLES.clone(),
+        200.0.into_pixels(),
+        200.0.into_pixels(),
+    );
+    let mut content = SumTree::new();
+    content.push(BlockItem::Table(Box::new(table)));
+    model.set_content(content);
+
+    // Visual lines: 0 = header, 1..=3 = wrapped body sublines.
+    // Each visual line on the body row should map back to the source-row-1 starting offset.
+    for visual_row in 1..=3u32 {
+        let offset = model
+            .softwrap_point_to_offset(SoftWrapPoint::new(visual_row, ColumnUnit::pixels_zero()));
+        // Round-trip: the resolved offset reports a single canonical visual line for the
+        // row. Re-mapping should land on the same row's start line.
+        let round_trip = model.offset_to_softwrap_point(offset);
+        // The body row begins on visual line 1, so the round trip should resolve to
+        // visual line 1 regardless of which subline within the body row we started on
+        // (point.row() collapses to the cell's first visual line; the column is zero).
+        assert_eq!(
+            round_trip.row(),
+            1,
+            "visual subline {visual_row} should round-trip to body-row start (visual line 1)",
+        );
+    }
+}
+
+#[test]
+fn test_table_offset_to_softwrap_point_uses_visual_rows_after_wrap() {
+    // Confirm that source offsets inside a row that follows a wrapped row resolve to a
+    // visual row that accounts for the wrap's extra visual lines.
+    let table = make_wrapped_test_laid_out_table(4, 40);
+    // Inject a second body row so we can probe an offset BEYOND the wrapped row.
+    let extra_row_source = "eee\tfff\n";
+    let new_source = format!("aaa\tbbb\nccc\tddd\n{extra_row_source}");
+    let new_table = FormattedTable::from_internal_format(&new_source);
+    let new_cell_offset_maps =
+        crate::content::text::table_cell_offset_maps(&new_table, &new_source);
+    let new_offset_map = table_offset_map::TableOffsetMap::new(
+        new_cell_offset_maps
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .map(|cell| cell.source_length().as_usize())
+                    .collect()
+            })
+            .collect(),
+    );
+    let new_content_length = new_offset_map.total_length();
+
+    let single_line = make_wrapped_cell_layout(1, 3);
+    let wrapped = make_wrapped_cell_layout(4, 40);
+    let mut t = table;
+    t.table = new_table;
+    t.cell_offset_maps = new_cell_offset_maps;
+    t.offset_map = new_offset_map;
+    t.content_length = new_content_length;
+    t.cell_layouts = vec![
+        vec![single_line.clone(), single_line.clone()],
+        vec![single_line.clone(), wrapped],
+        vec![single_line.clone(), single_line.clone()],
+    ];
+    // Add a row to row_heights and row_y_offsets so the table is internally consistent.
+    t.row_heights = vec![20.0.into_pixels(), 80.0.into_pixels(), 20.0.into_pixels()];
+    t.row_y_offsets = vec![0.0, 20.0, 100.0, 120.0];
+
+    // Total visual lines = 1 (header) + 4 (wrapped body) + 1 (third row) = 6.
+    assert_eq!(t.lines(), LineCount(6));
+
+    let mut model = RenderState::new_for_test(
+        TEST_STYLES.clone(),
+        200.0.into_pixels(),
+        200.0.into_pixels(),
+    );
+    let mut content = SumTree::new();
+    content.push(BlockItem::Table(Box::new(t)));
+    model.set_content(content);
+
+    // An offset in the third source row (row index 2) should map to visual line
+    // 1 (header) + 4 (wrapped body) = 5, not 2 like the old source-row-only mapping.
+    let third_row_offset = CharOffset::from(16); // start of "eee" in the new source.
+    let point = model.offset_to_softwrap_point(third_row_offset);
+    assert_eq!(
+        point.row(),
+        5,
+        "third row should be visual line 5 after the body row wraps to 4 lines",
+    );
+}
+
+#[test]
+fn test_table_lines_falls_back_to_one_per_empty_row() {
+    // Sanity: even if a row had empty `line_heights` for every cell, the visual row height
+    // should still report at least 1 to avoid collapsing the row entirely.
+    let mut table = make_test_laid_out_table();
+    table.cell_layouts = vec![vec![CellLayout::default(), CellLayout::default()]];
+    assert_eq!(table.lines(), LineCount(1));
+}
+
 #[test]
 fn test_first_hidden_section_line_range() {
     let mut render_state = RenderState::new_for_test(

--- a/crates/editor/src/render/model/mod_tests.rs
+++ b/crates/editor/src/render/model/mod_tests.rs
@@ -1430,8 +1430,8 @@ fn test_link_at_offset_uses_cached_cell_links() {
 // Regression coverage for warpdotdev/warp#10016. The next four tests pin down the
 // visual ↔ source row mapping for tables whose cells soft-wrap.
 
-/// Build a `CellLayout` whose visible width is `cell_width_chars * 10.0` and which contains
-/// `total_chars` characters spread evenly across `num_lines` visual lines.
+/// Build a `CellLayout` containing `total_chars` characters spread evenly across
+/// `num_lines` visual lines, with each character modeled as 10 pixels wide.
 fn make_wrapped_cell_layout(num_lines: usize, total_chars: usize) -> CellLayout {
     assert!(num_lines >= 1);
     let per_line = total_chars.div_ceil(num_lines);
@@ -1468,18 +1468,79 @@ fn make_wrapped_cell_layout(num_lines: usize, total_chars: usize) -> CellLayout 
     }
 }
 
-/// Build a `LaidOutTable` modeled on `make_test_laid_out_table` but with the body row's
-/// second cell wrapped to `wrap_lines` visual lines containing `wrap_chars` characters.
-fn make_wrapped_test_laid_out_table(wrap_lines: usize, wrap_chars: usize) -> LaidOutTable {
+/// Build a three-row table whose first body row has a short first cell and a second cell
+/// whose real source text and layout both span `wrap_lines` visual lines.
+fn make_second_column_wrapped_test_table(wrap_lines: usize) -> LaidOutTable {
+    const CHARS_PER_LINE: usize = 10;
+    let header_left = "head0";
+    let header_right = "head1";
+    let body_left = "short";
+    let wrapped_text = "x".repeat(wrap_lines * CHARS_PER_LINE);
+    let following_left = "next0";
+    let following_right = "next1";
+    let source = format!(
+        "{header_left}\t{header_right}\n{body_left}\t{wrapped_text}\n{following_left}\t{following_right}\n"
+    );
+
     let mut table = make_test_laid_out_table();
-    // The fixture is `aaa\tbbb\nccc\tddd\n`; we widen the body row's second cell so the
-    // (row, col) = (1, 1) cell wraps to multiple visual lines. The other layouts stay
-    // single-line.
-    let single_line = make_wrapped_cell_layout(1, 3);
-    let wrapped = make_wrapped_cell_layout(wrap_lines, wrap_chars);
+    table.table = FormattedTable::from_internal_format(&source);
+    table.cell_offset_maps = table_cell_offset_maps(&table.table, &source);
+    table.offset_map = table_offset_map::TableOffsetMap::new(
+        table
+            .cell_offset_maps
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .map(|cell| cell.source_length().as_usize())
+                    .collect()
+            })
+            .collect(),
+    );
+    table.content_length = table.offset_map.total_length();
+
     table.cell_layouts = vec![
-        vec![single_line.clone(), single_line.clone()],
-        vec![single_line.clone(), wrapped],
+        vec![
+            make_wrapped_cell_layout(1, header_left.len()),
+            make_wrapped_cell_layout(1, header_right.len()),
+        ],
+        vec![
+            make_wrapped_cell_layout(1, body_left.len()),
+            make_wrapped_cell_layout(wrap_lines, wrapped_text.len()),
+        ],
+        vec![
+            make_wrapped_cell_layout(1, following_left.len()),
+            make_wrapped_cell_layout(1, following_right.len()),
+        ],
+    ];
+    table.cell_text_frames = vec![
+        vec![
+            Arc::new(TextFrame::mock(header_left)),
+            Arc::new(TextFrame::mock(header_right)),
+        ],
+        vec![
+            Arc::new(TextFrame::mock(body_left)),
+            Arc::new(TextFrame::mock(&wrapped_text)),
+        ],
+        vec![
+            Arc::new(TextFrame::mock(following_left)),
+            Arc::new(TextFrame::mock(following_right)),
+        ],
+    ];
+    table.cell_links = vec![vec![vec![], vec![]]; 3];
+    table.config.width = 150.0.into_pixels();
+    table.column_widths = vec![50.0.into_pixels(), 100.0.into_pixels()];
+    table.col_x_offsets = vec![0.0, 50.0, 150.0];
+    table.row_heights = vec![
+        20.0.into_pixels(),
+        (wrap_lines as f32 * 20.0).into_pixels(),
+        20.0.into_pixels(),
+    ];
+    table.total_height = ((wrap_lines as f32 + 2.0) * 20.0).into_pixels();
+    table.row_y_offsets = vec![
+        0.0,
+        20.0,
+        20.0 + wrap_lines as f32 * 20.0,
+        40.0 + wrap_lines as f32 * 20.0,
     ];
     table
 }
@@ -1490,19 +1551,18 @@ fn test_table_visual_line_count_matches_wrapped_rows() {
     let plain = make_test_laid_out_table();
     assert_eq!(plain.lines(), LineCount(2));
 
-    // Wrap the body row to 5 visual lines. Total = header(1) + body(5) = 6.
-    let wrapped = make_wrapped_test_laid_out_table(5, 50);
-    assert_eq!(wrapped.lines(), LineCount(6));
+    // Header(1) + wrapped body(5) + following row(1) = 7 visual lines.
+    let wrapped = make_second_column_wrapped_test_table(5);
+    assert_eq!(wrapped.lines(), LineCount(7));
 }
 
 #[test]
-fn test_table_softwrap_round_trip_inside_wrapped_cell() {
-    // Push the wrapped table into a real RenderState so we exercise the cursor-driven
-    // BlockItem::Table arms of softwrap_point_to_offset / offset_to_softwrap_point.
-    let table = make_wrapped_test_laid_out_table(3, 30);
-    // Plain row sources: "aaa\tbbb\nccc\tddd\n" -> 16 chars total.
-    // cell_range for (1, 1) is offset 12..15 (inclusive of the cell's 3 source chars,
-    // since the source map is built from the unwrapped source).
+fn test_table_softwrap_line_starts_progress_across_wrapped_second_column() {
+    let table = make_second_column_wrapped_test_table(3);
+    let body_start = table.offset_map.cell_range(1, 0).unwrap().start;
+    let wrapped_start = table.offset_map.cell_range(1, 1).unwrap().start;
+    let expected_offsets = [body_start, wrapped_start + 10, wrapped_start + 20];
+
     let mut model = RenderState::new_for_test(
         TEST_STYLES.clone(),
         200.0.into_pixels(),
@@ -1512,21 +1572,20 @@ fn test_table_softwrap_round_trip_inside_wrapped_cell() {
     content.push(BlockItem::Table(Box::new(table)));
     model.set_content(content);
 
-    // Visual lines: 0 = header, 1..=3 = wrapped body sublines.
-    // Each visual line on the body row should map back to the source-row-1 starting offset.
-    for visual_row in 1..=3u32 {
+    // Visual line 1 starts in column zero. Lines 2 and 3 only exist in the wrapped
+    // second column, so their source offsets must advance through that cell instead
+    // of collapsing back to the row start.
+    for (visual_row, expected_offset) in (1..=3u32).zip(expected_offsets) {
         let offset = model
             .softwrap_point_to_offset(SoftWrapPoint::new(visual_row, ColumnUnit::pixels_zero()));
-        // Round-trip: the resolved offset reports a single canonical visual line for the
-        // row. Re-mapping should land on the same row's start line.
-        let round_trip = model.offset_to_softwrap_point(offset);
-        // The body row begins on visual line 1, so the round trip should resolve to
-        // visual line 1 regardless of which subline within the body row we started on
-        // (point.row() collapses to the cell's first visual line; the column is zero).
         assert_eq!(
-            round_trip.row(),
-            1,
-            "visual subline {visual_row} should round-trip to body-row start (visual line 1)",
+            offset, expected_offset,
+            "unexpected start for visual line {visual_row}"
+        );
+        assert_eq!(
+            model.offset_to_softwrap_point(offset).row(),
+            visual_row,
+            "visual line {visual_row} should round-trip through its source offset",
         );
     }
 }
@@ -1535,43 +1594,11 @@ fn test_table_softwrap_round_trip_inside_wrapped_cell() {
 fn test_table_offset_to_softwrap_point_uses_visual_rows_after_wrap() {
     // Confirm that source offsets inside a row that follows a wrapped row resolve to a
     // visual row that accounts for the wrap's extra visual lines.
-    let table = make_wrapped_test_laid_out_table(4, 40);
-    // Inject a second body row so we can probe an offset BEYOND the wrapped row.
-    let extra_row_source = "eee\tfff\n";
-    let new_source = format!("aaa\tbbb\nccc\tddd\n{extra_row_source}");
-    let new_table = FormattedTable::from_internal_format(&new_source);
-    let new_cell_offset_maps =
-        crate::content::text::table_cell_offset_maps(&new_table, &new_source);
-    let new_offset_map = table_offset_map::TableOffsetMap::new(
-        new_cell_offset_maps
-            .iter()
-            .map(|row| {
-                row.iter()
-                    .map(|cell| cell.source_length().as_usize())
-                    .collect()
-            })
-            .collect(),
-    );
-    let new_content_length = new_offset_map.total_length();
-
-    let single_line = make_wrapped_cell_layout(1, 3);
-    let wrapped = make_wrapped_cell_layout(4, 40);
-    let mut t = table;
-    t.table = new_table;
-    t.cell_offset_maps = new_cell_offset_maps;
-    t.offset_map = new_offset_map;
-    t.content_length = new_content_length;
-    t.cell_layouts = vec![
-        vec![single_line.clone(), single_line.clone()],
-        vec![single_line.clone(), wrapped],
-        vec![single_line.clone(), single_line.clone()],
-    ];
-    // Add a row to row_heights and row_y_offsets so the table is internally consistent.
-    t.row_heights = vec![20.0.into_pixels(), 80.0.into_pixels(), 20.0.into_pixels()];
-    t.row_y_offsets = vec![0.0, 20.0, 100.0, 120.0];
+    let table = make_second_column_wrapped_test_table(4);
+    let following_row_offset = table.offset_map.cell_range(2, 0).unwrap().start;
 
     // Total visual lines = 1 (header) + 4 (wrapped body) + 1 (third row) = 6.
-    assert_eq!(t.lines(), LineCount(6));
+    assert_eq!(table.lines(), LineCount(6));
 
     let mut model = RenderState::new_for_test(
         TEST_STYLES.clone(),
@@ -1579,13 +1606,12 @@ fn test_table_offset_to_softwrap_point_uses_visual_rows_after_wrap() {
         200.0.into_pixels(),
     );
     let mut content = SumTree::new();
-    content.push(BlockItem::Table(Box::new(t)));
+    content.push(BlockItem::Table(Box::new(table)));
     model.set_content(content);
 
     // An offset in the third source row (row index 2) should map to visual line
     // 1 (header) + 4 (wrapped body) = 5, not 2 like the old source-row-only mapping.
-    let third_row_offset = CharOffset::from(16); // start of "eee" in the new source.
-    let point = model.offset_to_softwrap_point(third_row_offset);
+    let point = model.offset_to_softwrap_point(following_row_offset);
     assert_eq!(
         point.row(),
         5,


### PR DESCRIPTION
## Description

Fixes Markdown-table selection and clipboard mapping when an earlier table row soft-wraps across multiple visual lines. Table render offsets now translate between visual lines and source rows using each row's rendered height, so later rows no longer resolve to the wrong source row.

This continues @lonexreb's prior #10707 following
[Harry Albert's request](https://github.com/warpdotdev/warp/pull/10707#issuecomment-4996369305)
for a fresh PR with a solid reproduction and recorded before/fixed behavior. The
two commits carried forward from that contribution retain the original author's
attribution; a follow-up commit hardens the mapping for tables whose widest
wrapped cell is not in the first column.

## Linked Issue

Fixes #10016

- [x] The linked issue is labeled `ready-to-implement`.
- [x] Same-fixture before/after recordings at a 430px viewer width are included below.

## Testing

- [x] Current-`master` invariant repro before the fix: expected later source row at visual row 3, got row 1
- [x] `cargo nextest run -p warp_editor` — 483 passed
- [x] Table-focused model tests — 14 passed
- [x] Long-cell clipboard regression — 1 passed
- [x] `./script/format`
- [x] All three required Clippy commands with `-D warnings`:
  - `cargo clippy --locked --workspace --exclude warp_completer --all-targets --tests -- -D warnings`
  - `cargo clippy --locked -p warp_completer --all-targets --tests -- -D warnings`
  - `cargo clippy --locked -p warp --all-targets --tests -- -D warnings`
- [x] `cargo nextest run --no-fail-fast --workspace --locked --exclude command-signatures-v2 -E 'not test(/(_ssh_|remote_server)/)' --test-threads=1` — 9,116 passed, 209 skipped
- [x] `cargo nextest run --locked -p warp_completer --features v2` — 117 passed, 4 skipped
- [x] `cargo test --workspace --locked --exclude command-signatures-v2 --doc`
- [x] I have manually tested the rendered-table selection and copy flow locally with the real-display integration harness.

### Screenshots / Videos

Both builds use the same deterministic Markdown fixture, the same `430.0 px`
rendered-editor viewport, and the same visual selection points
(`row 11, x 0` through `row 18, x 0`). The selected row contract is one leading
line separator, `TARGET-500-BYTES`, a tab, and a deterministic 500-byte payload
(`518` bytes total).

**Baseline (`267e6b62b`, before the product fix):** the identical visual points
produce no rendered selection and the Copy action leaves the 28-byte
`CLIPBOARD_UNCHANGED_SENTINEL` untouched (SHA-256
`06065a5441d5e36639e766ea92da93f0320a08758f46a7d8f36ba5791e8bb978`).

Baseline selection (the requested visual range does not resolve to a source
selection):

<img width="1280" height="800" alt="Baseline: target row is not selected" src="https://github.com/user-attachments/assets/27c75d17-3c5d-4d67-8106-57707c1b5e12" />

Baseline clipboard proof:

<img width="1280" height="800" alt="Baseline: clipboard remains unchanged" src="https://github.com/user-attachments/assets/89069000-5635-473f-a664-1a7838806cc4" />

Baseline recording:

https://github.com/user-attachments/assets/c2e886e4-0f90-4863-9c3b-a2cbaac34cf5

**Fixed (`4480de48d`):** the TARGET row is visibly selected and Copy returns all
`518` expected bytes. Expected and actual SHA-256 are both
`3a22de0fa336e2ec1065bd1ef350ca1a88a29ba1475c7c3cfbb747b47fc344f5`.

Fixed selection (the complete TARGET row is selected):

<img width="1280" height="800" alt="Fixed: complete target row is selected" src="https://github.com/user-attachments/assets/094c43ed-87f7-4320-ad3a-336c1749e554" />

Fixed clipboard proof:

<img width="1280" height="800" alt="Fixed: clipboard matches all 518 expected bytes" src="https://github.com/user-attachments/assets/8d6d67e4-c2de-4f8e-a14c-7c40cdce7532" />

Fixed recording:

https://github.com/user-attachments/assets/1371f373-f915-4b51-911d-1a28daa04ae8

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Fixed selection and clipboard offsets for Markdown tables with soft-wrapped cells.
