### PR TITLE
Add TUI setup migration skill

### DIFF
--- a/app/src/ai/blocklist/action_model/execute/read_skill_tests.rs
+++ b/app/src/ai/blocklist/action_model/execute/read_skill_tests.rs
@@ -9,6 +9,7 @@ use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::watcher::DirectoryWatcher;
 use tempfile::TempDir;
 use warp_core::HostId;
+use warp_core::execution_mode::{AppExecutionMode, ExecutionMode};
 use warp_core::features::FeatureFlag;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
 use warp_util::remote_path::RemotePath;
@@ -31,6 +32,7 @@ use crate::terminal::model_events::ModelEventDispatcher;
 use crate::warp_managed_paths_watcher::WarpManagedPathsWatcher;
 
 fn initialize_app(app: &mut App) {
+    app.add_singleton_model(|ctx| AppExecutionMode::new(ExecutionMode::App, false, ctx));
     app.add_singleton_model(DirectoryWatcher::new);
     app.add_singleton_model(AISettings::new_with_defaults);
     app.add_singleton_model(|_| DetectedRepositories::default());
@@ -353,6 +355,45 @@ fn test_read_skill_executor_rejects_warp_control_bundled_skills_when_disabled() 
             requires_result: false,
         };
 
+        let input = ExecuteActionInput {
+            action: &action,
+            conversation_id: AIConversationId::new(),
+        };
+
+        executor_handle.update(&mut app, |executor, ctx| {
+            let result: AnyActionExecution = executor.execute(input, ctx).into();
+            assert!(matches!(
+                result,
+                AnyActionExecution::Sync(AIAgentActionResultType::ReadSkill(
+                    ReadSkillResult::Error(_)
+                ))
+            ));
+        });
+    });
+}
+
+#[test]
+fn test_read_skill_executor_rejects_tui_only_skill_in_gui() {
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let _bundled_skills = FeatureFlag::BundledSkills.override_enabled(true);
+        let skill_id = "tui-migrate-setup";
+        SkillManager::handle(&app).update(&mut app, |manager, _ctx| {
+            manager.add_bundled_skill_for_testing(
+                skill_id,
+                bundled_skill(skill_id),
+                BundledSkillActivation::TuiOnly,
+            );
+        });
+        let executor_handle = add_test_read_skill_executor(&mut app);
+        let action = AIAgentAction {
+            id: AIAgentActionId::from(format!("test-action-id-{skill_id}")),
+            action: AIAgentActionType::ReadSkill(ReadSkillRequest {
+                skill: SkillReference::BundledSkillId(skill_id.to_string()),
+            }),
+            task_id: TaskId::new(format!("test-task-id-{skill_id}")),
+            requires_result: false,
+        };
         let input = ExecuteActionInput {
             action: &action,
             conversation_id: AIConversationId::new(),

--- a/app/src/ai/skills/bundled.rs
+++ b/app/src/ai/skills/bundled.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use ai::skills::{ParsedSkill, SkillPathOrigin, SkillReference, parse_bundled_skill};
 use futures::TryStreamExt;
 use warp_core::channel::ChannelState;
+use warp_core::execution_mode::AppExecutionMode;
 use warp_core::features::FeatureFlag;
 use warp_core::safe_warn;
 use warp_core::ui::icons::Icon;
@@ -23,6 +24,8 @@ use crate::settings::user_preferences_toml_file_path;
 pub enum BundledSkillActivation {
     /// Always active.
     Always,
+    /// Active only in the TUI frontend.
+    TuiOnly,
     /// Active only when a specific Warp feature is enabled.
     RequiresFeature(FeatureFlag),
     /// Active only when a specific MCP server is running.
@@ -35,6 +38,7 @@ impl BundledSkillActivation {
     pub fn is_enabled(&self, ctx: &AppContext) -> bool {
         match self {
             Self::Always => true,
+            Self::TuiOnly => AppExecutionMode::as_ref(ctx).is_tui(),
             Self::RequiresFeature(feature) => feature.is_enabled(),
             Self::RequiresMcp(integration) => {
                 TemplatableMCPServerManager::as_ref(ctx).is_mcp_server_running(*integration)
@@ -291,6 +295,7 @@ impl BundledSkill {
                 let icon = match &activation {
                     BundledSkillActivation::RequiresMcp(McpIntegration::Figma) => Icon::Figma,
                     BundledSkillActivation::Always
+                    | BundledSkillActivation::TuiOnly
                     | BundledSkillActivation::RequiresFeature(_)
                     | BundledSkillActivation::RequiresFile(_) => icon_for_bundled_skill(&id),
                 };
@@ -437,6 +442,10 @@ pub(crate) async fn read_bundled_skills(
     skills
 }
 
+fn display_optional_path(path: Option<PathBuf>) -> String {
+    path.unwrap_or_default().display().to_string()
+}
+
 /// Builds the context map for bundled skill variable substitution.
 ///
 /// Supported variables:
@@ -449,6 +458,10 @@ pub(crate) async fn read_bundled_skills(
 /// - `{{skill_dir}}` - Path to the bundled skill's directory
 /// - `{{settings_file_path}}` - Path to the user's settings TOML file
 /// - `{{keybindings_file_path}}` - Path to the user's keybindings YAML file
+/// - `{{gui_settings_file_path}}` - Path to the GUI settings TOML file
+/// - `{{tui_settings_file_path}}` - Path to the TUI settings TOML file
+/// - `{{gui_mcp_config_file_path}}` - Path to the GUI global MCP config
+/// - `{{tui_mcp_config_file_path}}` - Path to the TUI global MCP config
 pub(crate) fn build_bundled_skill_context(
     resources_dir: &Path,
     skill_dir: &Path,
@@ -487,6 +500,30 @@ pub(crate) fn build_bundled_skill_context(
             keybinding_file_path().display().to_string(),
         ),
         (
+            "gui_settings_file_path".to_owned(),
+            display_optional_path(
+                warp_core::paths::gui_config_local_dir()
+                    .map(|config_dir| config_dir.join("settings.toml")),
+            ),
+        ),
+        (
+            "tui_settings_file_path".to_owned(),
+            warp_core::paths::tui_config_local_dir()
+                .join("settings.toml")
+                .display()
+                .to_string(),
+        ),
+        (
+            "gui_mcp_config_file_path".to_owned(),
+            display_optional_path(warp_core::paths::gui_mcp_config_file_path()),
+        ),
+        (
+            "tui_mcp_config_file_path".to_owned(),
+            warp_core::paths::tui_mcp_config_file_path()
+                .display()
+                .to_string(),
+        ),
+        (
             "settings_schema_path".to_owned(),
             resources_dir
                 .join("settings_schema.json")
@@ -521,6 +558,7 @@ pub(crate) fn activation_for_bundled_skill(
         "modify-settings" => {
             BundledSkillActivation::RequiresFile(resources_dir.join("settings_schema.json"))
         }
+        "tui-migrate-setup" => BundledSkillActivation::TuiOnly,
         "warpctrl" => BundledSkillActivation::RequiresFeature(FeatureFlag::WarpControlCli),
         _ => BundledSkillActivation::Always,
     }

--- a/app/src/ai/skills/bundled_tests.rs
+++ b/app/src/ai/skills/bundled_tests.rs
@@ -22,6 +22,11 @@ fn bundled_skill(content: &str) -> BundledSkill {
     bundled_skill
 }
 
+#[test]
+fn unavailable_bundled_context_path_renders_as_empty_string() {
+    assert_eq!(display_optional_path(None), "");
+}
+
 fn remote_content<'a>(bundled_skills: &'a BundledSkills, host_id: &HostId) -> Option<&'a str> {
     bundled_skills
         .remote(host_id)?

--- a/app/src/ai/skills/remote.rs
+++ b/app/src/ai/skills/remote.rs
@@ -14,14 +14,16 @@ fn mcp_integration_wire_id(integration: McpIntegration) -> &'static str {
 ///
 /// `RequiresFile` activations are evaluated here — the daemon owns the
 /// files — so the client only ever receives `Always` or `RequiresMcp`
-/// conditions. The result is sorted by skill path so pushes are
-/// deterministic across daemon restarts.
+/// conditions. TUI-only local skills are omitted because a remote daemon
+/// cannot expose client-local migration behavior. The result is sorted by
+/// skill path so pushes are deterministic across daemon restarts.
 pub(crate) fn bundled_skill_snapshot_protos(catalog: &BundledSkill) -> Vec<RemoteSkillProto> {
     let mut protos: Vec<RemoteSkillProto> = catalog
         .iter_definitions()
         .filter_map(|(id, skill, activation)| {
             let requires_mcp = match activation {
                 BundledSkillActivation::Always => None,
+                BundledSkillActivation::TuiOnly => return None,
                 BundledSkillActivation::RequiresMcp(integration) => {
                     Some(mcp_integration_wire_id(*integration).to_owned())
                 }

--- a/app/src/ai/skills/remote_tests.rs
+++ b/app/src/ai/skills/remote_tests.rs
@@ -42,6 +42,11 @@ fn snapshot_protos_serialize_activation_conditions() {
             BundledSkillActivation::RequiresMcp(McpIntegration::Figma),
         ),
         (
+            "tui-migrate-setup".to_string(),
+            daemon_skill("tui-migrate-setup", "# local migration"),
+            BundledSkillActivation::TuiOnly,
+        ),
+        (
             "file-present-skill".to_string(),
             daemon_skill("file-present-skill", "# file"),
             BundledSkillActivation::RequiresFile(present_file),
@@ -57,6 +62,7 @@ fn snapshot_protos_serialize_activation_conditions() {
 
     // `RequiresFile` is evaluated daemon-side: the missing-file skill is
     // dropped, the present-file skill ships as unconditionally active.
+    // TUI-only migration is local-client behavior and is also dropped.
     let mut ids: Vec<&str> = protos
         .iter()
         .map(|proto| bundled_metadata(proto).id.as_str())

--- a/app/src/ai/skills/skill_manager_tests.rs
+++ b/app/src/ai/skills/skill_manager_tests.rs
@@ -7,6 +7,7 @@ use repo_metadata::repositories::DetectedRepositories;
 use repo_metadata::{DirectoryWatcher, RepoMetadataModel};
 use tempfile::TempDir;
 use warp_core::channel::ChannelState;
+use warp_core::execution_mode::{AppExecutionMode, ExecutionMode};
 use warp_core::features::FeatureFlag;
 use warp_util::host_id::HostId;
 use warp_util::local_or_remote_path::LocalOrRemotePath;
@@ -679,7 +680,7 @@ fn test_build_bundled_skill_context() {
     let skill_dir = resources_dir.join("bundled/skills/test-skill");
     let context = build_bundled_skill_context(resources_dir, &skill_dir);
 
-    assert_eq!(context.len(), 9);
+    assert_eq!(context.len(), 13);
     assert!(context.contains_key("warp_server_url"));
     assert!(context.contains_key("warp_cli_binary_name"));
     assert!(context.contains_key("warpctrl_binary_name"));
@@ -687,6 +688,34 @@ fn test_build_bundled_skill_context() {
     assert!(context.contains_key("warp_url_scheme"));
     assert!(context.contains_key("settings_file_path"));
     assert!(context.contains_key("keybindings_file_path"));
+    assert_eq!(
+        context.get("gui_settings_file_path").unwrap(),
+        &warp_core::paths::gui_config_local_dir()
+            .map(|path| path.join("settings.toml"))
+            .unwrap_or_default()
+            .display()
+            .to_string()
+    );
+    assert_eq!(
+        context.get("tui_settings_file_path").unwrap(),
+        &warp_core::paths::tui_config_local_dir()
+            .join("settings.toml")
+            .display()
+            .to_string()
+    );
+    assert_eq!(
+        context.get("gui_mcp_config_file_path").unwrap(),
+        &warp_core::paths::gui_mcp_config_file_path()
+            .unwrap_or_default()
+            .display()
+            .to_string()
+    );
+    assert_eq!(
+        context.get("tui_mcp_config_file_path").unwrap(),
+        &warp_core::paths::tui_mcp_config_file_path()
+            .display()
+            .to_string()
+    );
     assert_eq!(
         context.get("settings_schema_path").unwrap(),
         &resources_dir
@@ -1069,6 +1098,54 @@ fn feature_gated_bundled_skill_is_listed_only_when_enabled() {
     });
 }
 
+#[test]
+fn tui_only_bundled_skill_is_listed_and_resolved_only_in_tui() {
+    for (execution_mode, expected_active) in
+        [(ExecutionMode::App, false), (ExecutionMode::Tui, true)]
+    {
+        App::test((), |mut app| async move {
+            app.add_singleton_model(|ctx| AppExecutionMode::new(execution_mode, false, ctx));
+            app.add_singleton_model(DirectoryWatcher::new);
+            app.add_singleton_model(AISettings::new_with_defaults);
+            app.add_singleton_model(|_| DetectedRepositories::default());
+            app.add_singleton_model(RepoMetadataModel::new);
+            app.add_singleton_model(HomeDirectoryWatcher::new_for_test);
+            app.add_singleton_model(WarpManagedPathsWatcher::new_for_testing);
+            let handle = app.add_singleton_model(SkillManager::new);
+            let _bundled_skills = FeatureFlag::BundledSkills.override_enabled(true);
+            let reference = SkillReference::BundledSkillId("tui-migrate-setup".to_owned());
+
+            handle.update(&mut app, |manager, _| {
+                manager.add_bundled_skill_for_testing(
+                    "tui-migrate-setup",
+                    bundled_test_skill("tui-migrate-setup", "Migrate GUI setup"),
+                    BundledSkillActivation::TuiOnly,
+                );
+            });
+
+            let listed = handle.read(&app, |manager, ctx| {
+                manager
+                    .get_skills_for_working_directory(None, ctx)
+                    .iter()
+                    .any(|skill| skill.name == "tui-migrate-setup")
+            });
+            let resolved = handle.read(&app, |manager, ctx| {
+                manager.active_skill_by_reference(&reference, ctx).is_some()
+            });
+
+            assert_eq!(listed, expected_active);
+            assert_eq!(resolved, expected_active);
+        });
+    }
+}
+
+#[test]
+fn tui_migration_skill_has_tui_only_activation() {
+    assert!(matches!(
+        activation_for_bundled_skill("tui-migrate-setup", Path::new("/resources")),
+        BundledSkillActivation::TuiOnly
+    ));
+}
 #[test]
 fn warp_control_bundled_skill_activations_track_warp_control_feature() {
     App::test((), |app| async move {

--- a/app/src/bin/generate_settings_schema.rs
+++ b/app/src/bin/generate_settings_schema.rs
@@ -11,6 +11,7 @@ use std::io::Write;
 use schemars::SchemaGenerator;
 use serde_json::{Map, Value};
 use settings::schema::SettingSchemaEntry;
+use settings::{SettingSurfaces, SettingsMode};
 use warp_core::features::{DEBUG_FLAGS, DOGFOOD_FLAGS, FeatureFlag, PREVIEW_FLAGS, RELEASE_FLAGS};
 
 /// Ensures all `inventory::submit!` registrations from the app crate's
@@ -139,6 +140,13 @@ fn ensure_hierarchy<'a>(
     current
 }
 
+fn setting_surface_names(surfaces: SettingSurfaces) -> Vec<Value> {
+    [(SettingsMode::Gui, "gui"), (SettingsMode::Tui, "tui")]
+        .into_iter()
+        .filter(|(mode, _)| surfaces.includes(*mode))
+        .map(|(_, name)| Value::String(name.to_owned()))
+        .collect()
+}
 fn main() {
     ensure_settings_linked();
 
@@ -187,6 +195,13 @@ fn main() {
         let type_schema = (entry.schema_fn)(&mut generator);
 
         let mut schema_value: Value = type_schema.to_value();
+        schema_value
+            .as_object_mut()
+            .expect("setting schema should be an object")
+            .insert(
+                "x-warp-surfaces".to_string(),
+                Value::Array(setting_surface_names((entry.surfaces_fn)())),
+            );
 
         // Compute default value — prefer file default over serde default
         let default_json = (entry.file_default_value_fn)();
@@ -263,3 +278,7 @@ fn main() {
         println!("{output}");
     }
 }
+
+#[cfg(test)]
+#[path = "generate_settings_schema_tests.rs"]
+mod tests;

--- a/app/src/bin/generate_settings_schema_tests.rs
+++ b/app/src/bin/generate_settings_schema_tests.rs
@@ -1,0 +1,32 @@
+use super::*;
+
+#[test]
+fn surface_annotation_matches_setting_schema_entry_metadata() {
+    ensure_settings_linked();
+
+    for entry in inventory::iter::<SettingSchemaEntry> {
+        let surfaces = (entry.surfaces_fn)();
+        let annotation = setting_surface_names(surfaces);
+        let annotation_names: HashSet<&str> = annotation.iter().filter_map(Value::as_str).collect();
+
+        assert_eq!(
+            annotation_names.contains("gui"),
+            surfaces.includes(SettingsMode::Gui),
+            "GUI surface mismatch for {}",
+            entry.storage_key
+        );
+        assert_eq!(
+            annotation_names.contains("tui"),
+            surfaces.includes(SettingsMode::Tui),
+            "TUI surface mismatch for {}",
+            entry.storage_key
+        );
+        assert_eq!(
+            annotation_names.len(),
+            usize::from(surfaces.includes(SettingsMode::Gui))
+                + usize::from(surfaces.includes(SettingsMode::Tui)),
+            "unexpected surface annotation for {}",
+            entry.storage_key
+        );
+    }
+}

--- a/crates/warp_core/src/execution_mode.rs
+++ b/crates/warp_core/src/execution_mode.rs
@@ -51,6 +51,10 @@ impl AppExecutionMode {
     fn is_app(&self) -> bool {
         matches!(self.mode, ExecutionMode::App | ExecutionMode::Tui)
     }
+    /// Whether Warp is running as the headless terminal UI.
+    pub fn is_tui(&self) -> bool {
+        matches!(self.mode, ExecutionMode::Tui)
+    }
 
     /// Whether Active AI features are allowed in this execution mode.
     ///

--- a/crates/warp_core/src/paths.rs
+++ b/crates/warp_core/src/paths.rs
@@ -43,6 +43,7 @@ fn base_warp_config_dir_name() -> String {
         Channel::Local => format!("{WARP_CONFIG_DIR}-local"),
     }
 }
+
 /// Returns the home-relative Warp config directory name for the current channel and data profile.
 ///
 /// This preserves the historical `.warp*` directory shape while still isolating dev, local,
@@ -109,6 +110,28 @@ pub fn data_dir() -> PathBuf {
     }
 }
 
+/// Returns the GUI application ID for the current channel.
+///
+/// Most TUI channel binaries use the same application ID as the GUI. The OSS
+/// TUI is the exception: it uses `WarpTui`, while the corresponding GUI uses
+/// `WarpOss`.
+#[cfg(any(not(target_os = "macos"), test))]
+fn gui_app_id_for_channel(channel: Channel, current_app_id: AppId) -> AppId {
+    match channel {
+        Channel::Oss => AppId::new("dev", "warp", "WarpOss"),
+        Channel::Stable
+        | Channel::Preview
+        | Channel::Dev
+        | Channel::Integration
+        | Channel::Local => current_app_id,
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn gui_app_id() -> AppId {
+    gui_app_id_for_channel(ChannelState::channel(), ChannelState::app_id())
+}
+
 /// Returns the path to the directory where non-portable configuration files
 /// should be stored.
 pub fn config_local_dir() -> PathBuf {
@@ -123,6 +146,43 @@ pub fn config_local_dir() -> PathBuf {
                 .unwrap_or_default()
         }
     }
+}
+
+/// Resolves the GUI's non-portable configuration directory from any frontend.
+///
+/// This differs from [`config_local_dir`] when the active process uses a
+/// frontend-specific application ID, as the OSS TUI does on Linux and Windows.
+/// On macOS, development data profiles do not have an unambiguous corresponding
+/// GUI `.warp*` directory, so this fails closed instead of selecting a source
+/// profile implicitly.
+pub fn gui_config_local_dir() -> Option<PathBuf> {
+    cfg_if! {
+        if #[cfg(target_os = "macos")] {
+            if ChannelState::data_profile().is_some() {
+                return None;
+            }
+            dirs::home_dir().map(|home_dir| home_dir.join(macos_config_dir_name()))
+        } else {
+            project_dirs_for_app_id(
+                gui_app_id(),
+                ChannelState::data_profile().as_deref(),
+            )
+            .map(|dirs| dirs.config_local_dir().to_owned())
+        }
+    }
+}
+
+/// Resolves the GUI's global file-based MCP configuration from any frontend.
+///
+/// As with [`gui_config_local_dir`], macOS development data profiles fail
+/// closed because the matching GUI source profile is ambiguous.
+pub fn gui_mcp_config_file_path() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    if ChannelState::data_profile().is_some() {
+        return None;
+    }
+
+    warp_home_mcp_config_file_path()
 }
 
 /// Returns the macOS config directory name for the TUI front-end (`warp-tui`)

--- a/crates/warp_core/src/paths_tests.rs
+++ b/crates/warp_core/src/paths_tests.rs
@@ -37,6 +37,35 @@ fn test_config_local_dir_path() {
 }
 
 #[test]
+fn test_gui_app_id_maps_oss_tui_to_oss_gui() {
+    let gui_app_id = gui_app_id_for_channel(Channel::Oss, AppId::new("dev", "warp", "WarpTui"));
+
+    assert_eq!(gui_app_id.to_string(), "dev.warp.WarpOss");
+}
+
+#[test]
+fn test_gui_config_and_mcp_paths_resolve_explicit_sources() {
+    let home_dir = home_dir().expect("Should be able to compute home directory");
+    let gui_config_dir = gui_config_local_dir().expect("GUI config path should resolve");
+
+    cfg_if::cfg_if! {
+        if #[cfg(target_os = "macos")] {
+            assert_eq!(gui_config_dir, home_dir.join(".warp-oss"));
+        } else if #[cfg(any(target_os = "linux", target_os = "freebsd"))] {
+            assert_eq!(gui_config_dir, home_dir.join(".config/warp-oss"));
+        } else if #[cfg(windows)] {
+            assert_eq!(
+                gui_config_dir,
+                home_dir.join("AppData\\Local\\warp\\WarpOss\\config")
+            );
+        } else {
+            unimplemented!("Need to update tests for current platform!");
+        }
+    }
+
+    assert_eq!(gui_mcp_config_file_path(), warp_home_mcp_config_file_path());
+}
+#[test]
 fn test_warp_home_config_dir_path() {
     let home_dir = home_dir().expect("Should be able to compute home directory");
     let expected_dir_name = match ChannelState::data_profile() {

--- a/resources/bundled/skills/tui-migrate-setup/SKILL.md
+++ b/resources/bundled/skills/tui-migrate-setup/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: tui-migrate-setup
+description: Migrates the supported subset of an existing Warp GUI setup into Warp TUI without exposing credentials or application state. Use in Warp TUI when a user wants to copy or move compatible settings or global file-based MCP servers from the desktop app, set up TUI from an existing GUI installation, or understand which Warp data is already shared.
+compatibility: Requires Python 3.11 or newer for local JSON and TOML inspection. This skill is available only in Warp TUI.
+---
+
+# Migrate a Warp GUI setup to Warp TUI
+
+Guide the user through a narrow, local migration. Treat the GUI files as untrusted
+inputs and preserve the TUI destination. Read
+[references/migration-matrix.md](references/migration-matrix.md) before starting.
+
+## Resolved paths
+
+Use these host-provided paths. Do not substitute `~/.warp` or infer another
+channel/profile:
+
+- Settings schema: `{{settings_schema_path}}`
+- GUI settings: `{{gui_settings_file_path}}`
+- TUI settings: `{{tui_settings_file_path}}`
+- GUI global MCP config: `{{gui_mcp_config_file_path}}`
+- TUI global MCP config: `{{tui_mcp_config_file_path}}`
+
+If any rendered path is empty, unresolved, or still contains double braces, stop
+that part of the migration and report that the current installation could not
+resolve it. In particular, fail closed when the GUI source profile is ambiguous.
+If the rendered schema or either helper script is missing, report a build
+artifact defect and stop. Do not substitute alternate paths or inspect
+configuration files directly.
+
+## Safety boundaries
+
+- Never use a file-reading tool, `cat`, `grep`, a shell expansion, or an ad hoc
+  script to inspect either MCP config. Only
+  `scripts/merge_mcp_config.py` may read those files. Its output is intentionally
+  limited to counts, booleans, status codes, and a fingerprint.
+- Never print or summarize MCP server names, definitions, commands, URLs, headers,
+  environment variables, or values. Do not ask the user to paste them.
+- Never copy credentials, refresh tokens, API keys, Keychain/credential-store
+  items, secure storage, SQLite rows, MCP installation/running state, or OAuth
+  state. Templatable/gallery MCP installations must be reinstalled in TUI, and
+  authenticated servers must be reauthenticated there.
+- Migrate only the resolved Warp global MCP file. Do not inspect or migrate
+  project-scoped or third-party MCP files because doing so changes scope and
+  working-directory behavior.
+- Do not migrate private or GUI-only settings. The generated
+  `x-warp-surfaces` annotation is the source of truth; a setting is eligible only
+  when its array contains both `gui` and `tui`.
+- Do not overwrite a TUI value unless the user explicitly approves that exact
+  conflict. Preserve destination comments, unknown keys, and TUI-only settings.
+
+## Workflow
+
+Limit inspection to the categories the user actually requested. For an MCP-only
+request, do not inspect settings. For a request limited to templatable/gallery
+installations, OAuth, credentials, or another unsupported category, explain the
+supported TUI setup path without running either file inspector.
+
+### 1. Set expectations
+
+Briefly summarize the four migration categories from the matrix:
+
+1. Rules, user/repository skills, and bundled skills are already discovered from
+   shared paths. Drive objects, saved prompts, and cloud execution profiles appear
+   after TUI login and sync.
+2. Only schema-declared GUI-and-TUI settings and raw global file-based MCP
+   definitions can be imported.
+3. Login, templatable MCP installations, OAuth, and provider credentials require
+   reauthentication or reinstallation.
+4. Keybindings, themes, launch/tab configs, local workflows, shell/startup
+   preferences, GUI state, command history, and databases are unsupported.
+
+Do not claim that logging into TUI migrates local files.
+
+### 2. Check the local runtime
+
+Run Python 3.11 or newer. If `tomllib` is unavailable, explain that settings
+inspection is unsupported in this runtime; do not fall back to reading the GUI
+settings file into model context.
+
+### 3. Inspect without mutating
+
+Run the settings inspector:
+
+```sh
+python3 "{{skill_dir}}/scripts/inspect_shared_settings.py" \
+  --schema "{{settings_schema_path}}" \
+  --source "{{gui_settings_file_path}}" \
+  --destination "{{tui_settings_file_path}}"
+```
+
+The JSON output contains only eligible setting paths and their GUI/TUI values.
+Do not independently open the GUI settings file.
+
+Run the MCP helper in dry-run mode:
+
+```sh
+python3 "{{skill_dir}}/scripts/merge_mcp_config.py" \
+  --source "{{gui_mcp_config_file_path}}" \
+  --destination "{{tui_mcp_config_file_path}}" \
+  --dry-run
+```
+
+Retain the returned fingerprint exactly for the apply step. A dry run never
+creates a file or backup.
+
+### 4. Present a redacted proposal
+
+For settings, present only the eligible dotted names and values emitted by the
+inspector. Group them as:
+
+- missing in TUI and available to add;
+- already equal;
+- conflicting, where the TUI value remains unchanged by default.
+
+Call out that agent permission settings can expand what commands, file reads, or
+other actions are approved automatically. For a machine-local file allowlist,
+offer a source path only after checking that the path is valid on this host.
+Exclude nonexistent or host-inapplicable paths from the proposal.
+
+For MCP, report only the helper's redacted counts: eligible additions,
+destination conflicts, definitions skipped because they may contain literal
+credentials, definitions requiring reinstallation, and whether anything would
+change. Include the helper's exact fingerprint verbatim in the proposal and
+approval prompt so a later apply is bound to the reviewed inputs; the fingerprint
+is opaque and does not reveal config contents. Never infer or reveal identities
+from the counts.
+
+Ask for explicit approval before mutation. Approval must separately cover:
+
+- each settings addition;
+- each settings conflict the user wants to overwrite;
+- the redacted global MCP merge.
+
+If the user approves only some settings, edit only those settings. Destination
+values win all unapproved conflicts.
+
+### 5. Apply approved settings conservatively
+
+Before editing, reject a symlink at the TUI settings path. If the destination
+exists, create a timestamped backup beside it and restrict the backup to the
+current user on Unix. If it does not exist, create it with user-only permissions
+on Unix.
+
+Read only the TUI destination and edit it in place. Add or update only approved
+shared dotted keys. Preserve its comments, formatting outside the edited keys,
+unknown keys, and TUI-only values. Do not regenerate or replace the whole TOML
+document. If a safe surgical edit is not possible, stop and explain why rather
+than using a lossy TOML serializer.
+
+### 6. Apply the approved MCP merge
+
+Pass the exact dry-run fingerprint:
+
+```sh
+python3 "{{skill_dir}}/scripts/merge_mcp_config.py" \
+  --source "{{gui_mcp_config_file_path}}" \
+  --destination "{{tui_mcp_config_file_path}}" \
+  --apply \
+  --fingerprint "<dry-run fingerprint>"
+```
+
+If either file changed after preview, the helper rejects the fingerprint without
+writing. Run a fresh dry run and ask for approval again. The destination wins all
+name conflicts; do not offer an overwrite mode.
+
+### 7. Verify
+
+Rerun the settings inspector and MCP dry run. Confirm that approved settings now
+match and the MCP helper reports no remaining eligible additions. Do not inspect
+MCP files directly to verify.
+
+Report:
+
+- settings changed and conflicts left unchanged;
+- redacted MCP counts and whether a backup was created;
+- any skipped credential-bearing or managed definitions;
+- TUI login/sync, MCP reinstallation, or reauthentication still required;
+- whether a TUI restart is necessary based on the current product behavior.
+
+If verification fails, leave backups intact and report the sanitized helper
+status. Never expose file contents while troubleshooting.

--- a/resources/bundled/skills/tui-migrate-setup/references/migration-matrix.md
+++ b/resources/bundled/skills/tui-migrate-setup/references/migration-matrix.md
@@ -1,0 +1,79 @@
+# GUI-to-TUI migration matrix
+
+Use this matrix to set expectations before reading or changing any local file.
+
+## Already shared or available after login
+
+No file copy is needed for:
+
+- global and project rules discovered from shared paths;
+- user and repository skills discovered from shared paths;
+- bundled skills;
+- Drive objects, saved prompts, and cloud execution profiles after the user logs
+  in to TUI and sync completes.
+
+Account login is still a separate TUI action. Do not describe cloud availability
+as migration of local GUI data.
+
+## Explicit local import
+
+### Settings
+
+Only public settings whose generated JSON Schema property has
+`x-warp-surfaces` containing both `gui` and `tui` are eligible. The annotation is
+authoritative and dynamic; do not maintain a setting-name allowlist.
+
+The settings inspector may reveal only those eligible dotted paths and values.
+The user approves each mutation. Missing TUI values may be added, while existing
+TUI values win unless the user explicitly approves an overwrite. Preserve
+comments, unknown settings, and TUI-only settings.
+
+Permission changes deserve an explicit impact summary. Machine-local file
+allowlists should be offered only when their source paths exist and are valid on
+the current host.
+
+### Global file-based MCP
+
+The raw server definitions in the resolved GUI Warp global `.mcp.json` may be
+merged into the resolved TUI Warp global `.mcp.json`. The destination wins name
+conflicts. `${VAR}` and other placeholder-bearing header/environment strings are
+preserved.
+
+The helper skips source definitions that look like managed/template installation
+records or that contain literal header/environment values which may be
+credentials. It reports counts only. Project and third-party MCP configs are out
+of scope because importing them could change scope and working-directory
+behavior.
+
+## Reauthentication or reinstallation
+
+Handle these as setup tasks in TUI, not file migration:
+
+- TUI account login;
+- templatable or gallery MCP installations;
+- MCP OAuth grants and refresh tokens;
+- provider credentials, API keys, literal secrets, and secure values;
+- Keychain, Windows Credential Manager, Secret Service, or other credential-store
+  entries;
+- MCP process running state and installation state.
+
+If a raw file-based server is imported but needs authentication, tell the user to
+authenticate it in TUI. Never copy the GUI credential.
+
+## Unsupported
+
+Do not migrate:
+
+- GUI-only or private settings;
+- keybindings;
+- custom themes;
+- launch or tab configurations;
+- local workflows;
+- shell and startup preferences;
+- windows, tabs, panes, session state, or command history;
+- GUI MCP installation or running state;
+- SQLite databases or individual database rows;
+- project-scoped or third-party MCP configuration in v1.
+
+Do not invent a fallback for an unsupported category. Explain the supported TUI
+setup path, if one exists, and leave the GUI source untouched.

--- a/resources/bundled/skills/tui-migrate-setup/scripts/inspect_shared_settings.py
+++ b/resources/bundled/skills/tui-migrate-setup/scripts/inspect_shared_settings.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Inspect only GUI settings explicitly supported by both GUI and TUI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised only on Python < 3.11.
+    tomllib = None
+
+
+class InspectionError(Exception):
+    """A sanitized error safe to show without source file contents."""
+
+
+def shared_setting_paths(schema: dict[str, Any]) -> list[tuple[str, ...]]:
+    """Return settings whose property annotation includes both frontends."""
+
+    paths: list[tuple[str, ...]] = []
+
+    def visit(node: Any, prefix: tuple[str, ...]) -> None:
+        if not isinstance(node, dict):
+            return
+
+        surfaces = node.get("x-warp-surfaces")
+        if (
+            prefix
+            and isinstance(surfaces, list)
+            and "gui" in surfaces
+            and "tui" in surfaces
+        ):
+            # An annotated object is a setting value, not another hierarchy node.
+            paths.append(prefix)
+            return
+
+        properties = node.get("properties")
+        if not isinstance(properties, dict):
+            return
+
+        for key, child in properties.items():
+            if isinstance(key, str):
+                visit(child, (*prefix, key))
+
+    visit(schema, ())
+    return sorted(paths)
+
+
+def nested_value(document: dict[str, Any], path: tuple[str, ...]) -> tuple[bool, Any]:
+    current: Any = document
+    for segment in path:
+        if not isinstance(current, dict) or segment not in current:
+            return False, None
+        current = current[segment]
+    return True, current
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise InspectionError("schema_unavailable_or_invalid") from error
+    if not isinstance(value, dict):
+        raise InspectionError("schema_unavailable_or_invalid")
+    return value
+
+
+def _find_probe_path(
+    value: Any, prefix: tuple[str, ...] = ()
+) -> tuple[str, ...] | None:
+    if isinstance(value, dict):
+        if value.get("__warp_probe__") is True:
+            return prefix
+        for key, child in value.items():
+            result = _find_probe_path(child, (*prefix, key))
+            if result is not None:
+                return result
+    elif isinstance(value, list):
+        for child in value:
+            result = _find_probe_path(child, prefix)
+            if result is not None:
+                return result
+    return None
+
+
+def _table_header_path(line: str) -> tuple[bool, tuple[str, ...] | None]:
+    stripped = line.strip()
+    if not stripped.startswith("["):
+        return False, None
+    try:
+        document = tomllib.loads(f"{stripped}\n__warp_probe__ = true\n")
+    except tomllib.TOMLDecodeError:
+        return False, None
+    return True, _find_probe_path(document)
+
+
+def _select_relevant_toml(contents: str, paths: list[tuple[str, ...]]) -> str:
+    relevant_sections = {path[:-1] for path in paths}
+    current_section: tuple[str, ...] | None = ()
+    selected: list[str] = []
+
+    for line in contents.splitlines(keepends=True):
+        is_header, header_path = _table_header_path(line)
+        if is_header:
+            current_section = header_path
+        if current_section in relevant_sections:
+            selected.append(line)
+
+    return "".join(selected)
+
+
+def _read_toml_object(
+    path: Path,
+    paths: list[tuple[str, ...]],
+    *,
+    missing_ok: bool,
+    role: str,
+) -> dict[str, Any]:
+    if path.is_symlink():
+        raise InspectionError("settings_symlink_rejected")
+    if missing_ok and not path.exists():
+        return {}
+    try:
+        contents = path.read_text(encoding="utf-8")
+        selected = _select_relevant_toml(contents, paths)
+        value = tomllib.loads(selected) if selected else {}
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise InspectionError(f"{role}_settings_unavailable_or_invalid") from error
+    if not isinstance(value, dict):
+        raise InspectionError(f"{role}_settings_unavailable_or_invalid")
+    return value
+
+
+def inspect_settings(
+    schema: dict[str, Any],
+    source: dict[str, Any],
+    destination: dict[str, Any],
+) -> dict[str, Any]:
+    settings: list[dict[str, Any]] = []
+    for path in shared_setting_paths(schema):
+        source_present, source_value = nested_value(source, path)
+        if not source_present:
+            continue
+
+        destination_present, destination_value = nested_value(destination, path)
+        if not destination_present:
+            state = "missing_in_tui"
+        elif destination_value == source_value:
+            state = "already_equal"
+        else:
+            state = "destination_conflict"
+
+        item: dict[str, Any] = {
+            "path": ".".join(path),
+            "source_value": source_value,
+            "destination_present": destination_present,
+            "state": state,
+        }
+        if destination_present:
+            item["destination_value"] = destination_value
+        settings.append(item)
+
+    return {
+        "eligible_configured_count": len(settings),
+        "settings": settings,
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Inspect GUI settings declared for both Warp GUI and TUI."
+    )
+    parser.add_argument("--schema", required=True)
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--destination", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+
+    # Check raw strings before Path construction: Path("") means ".", which must
+    # never become an accidental fallback for an unavailable GUI source profile.
+    if not args.source:
+        print("error: source_path_unavailable", file=sys.stderr)
+        return 2
+    if not args.schema or not args.destination:
+        print("error: required_path_unavailable", file=sys.stderr)
+        return 2
+    if tomllib is None:
+        print("error: python_3_11_or_newer_required", file=sys.stderr)
+        return 2
+
+    try:
+        schema = _read_json_object(Path(args.schema))
+        paths = shared_setting_paths(schema)
+        source = _read_toml_object(
+            Path(args.source),
+            paths,
+            missing_ok=True,
+            role="source",
+        )
+        destination = _read_toml_object(
+            Path(args.destination),
+            paths,
+            missing_ok=True,
+            role="destination",
+        )
+        result = inspect_settings(schema, source, destination)
+    except InspectionError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    except Exception:
+        print("error: inspection_failed", file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, sort_keys=True, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/resources/bundled/skills/tui-migrate-setup/scripts/merge_mcp_config.py
+++ b/resources/bundled/skills/tui-migrate-setup/scripts/merge_mcp_config.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python3
+"""Safely merge global file-based MCP configs without revealing their contents."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import re
+import stat
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qsl, urlsplit
+
+MAX_CONFIG_BYTES = 8 * 1024 * 1024
+FINGERPRINT_VERSION = b"warp-tui-mcp-merge-v1\0"
+PLACEHOLDER = re.compile(r"\$\{[A-Za-z_][A-Za-z0-9_]*\}|\{\{[^{}\r\n]+\}\}")
+MANAGED_MARKERS = frozenset(
+    {
+        "warp_id",
+        "installation_id",
+        "installation_uuid",
+        "gallery_data",
+        "template",
+        "variables",
+        "variable_values",
+    }
+)
+WRAPPER_PATHS: tuple[tuple[str, ...], ...] = (
+    ("mcpServers",),
+    ("mcp_servers",),
+    ("servers",),
+    ("mcp", "servers"),
+)
+
+
+class MergeError(Exception):
+    """A sanitized error safe to emit without config data."""
+
+
+@dataclass(frozen=True)
+class ParsedConfig:
+    document: dict[str, Any]
+    servers: dict[str, Any]
+    wrapper_path: tuple[str, ...]
+    exists: bool
+    raw: bytes
+    mode: int | None
+
+
+@dataclass(frozen=True)
+class MergePlan:
+    document: dict[str, Any]
+    fingerprint: str
+    source_server_count: int
+    eligible_source_count: int
+    destination_server_count: int
+    add_count: int
+    conflict_count: int
+    skipped_sensitive_count: int
+    skipped_reinstall_count: int
+    result_server_count: int
+    content_change_required: bool
+    permission_update_required: bool
+
+    @property
+    def would_change(self) -> bool:
+        return self.content_change_required or self.permission_update_required
+
+
+def _path_value(document: dict[str, Any], path: tuple[str, ...]) -> Any:
+    current: Any = document
+    for segment in path:
+        if not isinstance(current, dict) or segment not in current:
+            return None
+        current = current[segment]
+    return current
+
+
+def _set_path(
+    document: dict[str, Any], path: tuple[str, ...], value: dict[str, Any]
+) -> None:
+    current = document
+    for segment in path[:-1]:
+        child = current.get(segment)
+        if not isinstance(child, dict):
+            child = {}
+            current[segment] = child
+        current = child
+    if path:
+        current[path[-1]] = value
+    else:
+        document.clear()
+        document.update(value)
+
+
+def _read_regular_file(path: Path, *, missing_ok: bool) -> tuple[bytes, int | None]:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        if missing_ok:
+            return b"", None
+        raise MergeError("source_config_unavailable")
+    except OSError as error:
+        raise MergeError("config_unavailable") from error
+
+    if stat.S_ISLNK(metadata.st_mode):
+        raise MergeError("config_symlink_rejected")
+    if not stat.S_ISREG(metadata.st_mode):
+        raise MergeError("config_not_regular_file")
+    if metadata.st_size > MAX_CONFIG_BYTES:
+        raise MergeError("config_too_large")
+
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+        with os.fdopen(descriptor, "rb") as file:
+            raw = file.read(MAX_CONFIG_BYTES + 1)
+    except OSError as error:
+        raise MergeError("config_unavailable") from error
+    if len(raw) > MAX_CONFIG_BYTES:
+        raise MergeError("config_too_large")
+    return raw, stat.S_IMODE(metadata.st_mode)
+
+
+def _decode_document(raw: bytes) -> dict[str, Any]:
+    try:
+        document = json.loads(raw.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise MergeError("invalid_json") from error
+    if not isinstance(document, dict):
+        raise MergeError("invalid_config_shape")
+    return document
+
+
+def _detect_wrapper(document: dict[str, Any]) -> tuple[tuple[str, ...], dict[str, Any]]:
+    matches: list[tuple[tuple[str, ...], dict[str, Any]]] = []
+    for wrapper_path in WRAPPER_PATHS:
+        value = _path_value(document, wrapper_path)
+        if value is not None:
+            if not isinstance(value, dict):
+                raise MergeError("invalid_wrapper_shape")
+            matches.append((wrapper_path, value))
+
+    if len(matches) > 1:
+        raise MergeError("ambiguous_wrapper")
+    if matches:
+        return matches[0]
+
+    # Warp accepts an unwrapped map. Require object-valued entries so unrelated
+    # application JSON does not silently become an MCP config.
+    if all(isinstance(value, dict) for value in document.values()):
+        return (), document
+    raise MergeError("unrecognized_wrapper")
+
+
+def load_config(path: Path) -> ParsedConfig:
+    raw, mode = _read_regular_file(path, missing_ok=True)
+    exists = mode is not None
+    if not exists:
+        return ParsedConfig(
+            document={},
+            servers={},
+            wrapper_path=("mcpServers",),
+            exists=False,
+            raw=b"",
+            mode=None,
+        )
+
+    document = _decode_document(raw)
+    wrapper_path, servers = _detect_wrapper(document)
+    for value in servers.values():
+        if not isinstance(value, dict):
+            raise MergeError("invalid_server_definition")
+    return ParsedConfig(
+        document=document,
+        servers=servers,
+        wrapper_path=wrapper_path,
+        exists=True,
+        raw=raw,
+        mode=mode,
+    )
+
+
+def _has_managed_marker(value: Any) -> bool:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key.casefold() in MANAGED_MARKERS or _has_managed_marker(child):
+                return True
+    elif isinstance(value, list):
+        return any(_has_managed_marker(child) for child in value)
+    return False
+
+
+def _placeholder_backed(value: Any) -> bool:
+    if not isinstance(value, str) or PLACEHOLDER.search(value) is None:
+        return False
+    residue = PLACEHOLDER.sub("", value)
+    normalized_residue = "".join(
+        character for character in residue.casefold() if character.isalnum()
+    )
+    return normalized_residue in {"", "basic", "bearer", "token"}
+
+
+def _looks_sensitive_key(key: str) -> bool:
+    normalized = "".join(
+        character for character in key.casefold() if character.isalnum()
+    )
+    return any(
+        marker in normalized
+        for marker in (
+            "password",
+            "passwd",
+            "secret",
+            "token",
+            "apikey",
+            "authorization",
+            "credential",
+        )
+    )
+
+
+def _url_has_literal_credentials(value: str) -> bool:
+    try:
+        parsed = urlsplit(value)
+        if parsed.username is not None or parsed.password is not None:
+            return True
+        return any(
+            _looks_sensitive_key(key) and not _placeholder_backed(item)
+            for key, item in parse_qsl(parsed.query, keep_blank_values=True)
+        )
+    except ValueError:
+        return True
+
+
+def _args_have_literal_credentials(arguments: Any) -> bool:
+    if not isinstance(arguments, list):
+        return False
+    for index, argument in enumerate(arguments):
+        if not isinstance(argument, str) or not argument.startswith("-"):
+            continue
+        flag, separator, inline_value = argument.partition("=")
+        if not _looks_sensitive_key(flag):
+            continue
+        if separator and not _placeholder_backed(inline_value):
+            return True
+        if (
+            not separator
+            and index + 1 < len(arguments)
+            and not _placeholder_backed(arguments[index + 1])
+        ):
+            return True
+    return False
+
+
+def _has_literal_sensitive_map(value: Any) -> bool:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            folded = key.casefold()
+            if folded in {"env", "headers", "http_headers", "environment"}:
+                if not isinstance(child, dict):
+                    return True
+                if any(not _placeholder_backed(item) for item in child.values()):
+                    return True
+            if folded == "args" and _args_have_literal_credentials(child):
+                return True
+            if folded in {"url", "serverurl"} and isinstance(child, str):
+                if _url_has_literal_credentials(child):
+                    return True
+            if _looks_sensitive_key(folded):
+                if isinstance(child, str) and not _placeholder_backed(child):
+                    return True
+            if _has_literal_sensitive_map(child):
+                return True
+    elif isinstance(value, list):
+        return any(_has_literal_sensitive_map(child) for child in value)
+    return False
+
+
+def _validate_source_definition(definition: dict[str, Any]) -> None:
+    command = definition.get("command")
+    url = definition.get("url", definition.get("serverUrl"))
+    if (command is None) == (url is None):
+        raise MergeError("invalid_server_definition")
+    if command is not None:
+        if not isinstance(command, str) or not command:
+            raise MergeError("invalid_server_definition")
+        arguments = definition.get("args", [])
+        if not isinstance(arguments, list) or not all(
+            isinstance(argument, str) for argument in arguments
+        ):
+            raise MergeError("invalid_server_definition")
+    if url is not None and (not isinstance(url, str) or not url):
+        raise MergeError("invalid_server_definition")
+
+
+def _classify_source(
+    servers: dict[str, Any],
+) -> tuple[dict[str, Any], int, int]:
+    eligible: dict[str, Any] = {}
+    skipped_sensitive = 0
+    skipped_reinstall = 0
+    for name, definition in servers.items():
+        if _has_managed_marker(definition):
+            skipped_reinstall += 1
+        elif _has_literal_sensitive_map(definition):
+            skipped_sensitive += 1
+        else:
+            _validate_source_definition(definition)
+            eligible[name] = definition
+    return eligible, skipped_sensitive, skipped_reinstall
+
+
+def _fingerprint(source: bytes, destination: bytes, destination_exists: bool) -> str:
+    digest = hashlib.sha256()
+    digest.update(FINGERPRINT_VERSION)
+    for label, raw in (
+        (b"source\0", source),
+        (
+            b"destination-present\0" if destination_exists else b"destination-absent\0",
+            destination,
+        ),
+    ):
+        digest.update(label)
+        digest.update(len(raw).to_bytes(8, "big"))
+        digest.update(raw)
+    return digest.hexdigest()
+
+
+def build_plan(source: ParsedConfig, destination: ParsedConfig) -> MergePlan:
+    eligible, skipped_sensitive, skipped_reinstall = _classify_source(source.servers)
+    additions = {
+        name: value
+        for name, value in eligible.items()
+        if name not in destination.servers
+    }
+    conflict_count = len(set(eligible).intersection(destination.servers))
+
+    merged_servers = copy.deepcopy(destination.servers)
+    for name, value in additions.items():
+        merged_servers[name] = copy.deepcopy(value)
+
+    if destination.exists:
+        result_document = copy.deepcopy(destination.document)
+        wrapper_path = destination.wrapper_path
+    else:
+        result_document = {}
+        wrapper_path = source.wrapper_path
+    _set_path(result_document, wrapper_path, merged_servers)
+
+    permission_update_required = (
+        destination.exists
+        and destination.mode is not None
+        and destination.mode & 0o077 != 0
+    )
+    return MergePlan(
+        document=result_document,
+        fingerprint=_fingerprint(source.raw, destination.raw, destination.exists),
+        source_server_count=len(source.servers),
+        eligible_source_count=len(eligible),
+        destination_server_count=len(destination.servers),
+        add_count=len(additions),
+        conflict_count=conflict_count,
+        skipped_sensitive_count=skipped_sensitive,
+        skipped_reinstall_count=skipped_reinstall,
+        result_server_count=len(merged_servers),
+        content_change_required=bool(additions),
+        permission_update_required=permission_update_required,
+    )
+
+
+def _serialized(document: dict[str, Any]) -> bytes:
+    return (json.dumps(document, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
+
+
+def _write_restricted_file(path: Path, contents: bytes, *, exclusive: bool) -> None:
+    flags = os.O_WRONLY | os.O_CREAT
+    flags |= os.O_EXCL if exclusive else os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb", closefd=False) as file:
+            file.write(contents)
+            file.flush()
+            os.fsync(file.fileno())
+    finally:
+        os.close(descriptor)
+
+
+def _backup_path(destination: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    for counter in range(1000):
+        candidate = destination.with_name(
+            f"{destination.name}.backup-{stamp}-{counter:03d}"
+        )
+        if not candidate.exists() and not candidate.is_symlink():
+            return candidate
+    raise MergeError("backup_name_unavailable")
+
+
+def apply_plan(
+    plan: MergePlan,
+    destination: Path,
+    destination_config: ParsedConfig,
+) -> bool:
+    """Apply a verified plan. Return whether a content backup was created."""
+
+    if not plan.content_change_required:
+        if plan.permission_update_required:
+            try:
+                os.chmod(destination, 0o600, follow_symlinks=False)
+            except (NotImplementedError, OSError) as error:
+                raise MergeError("permission_update_failed") from error
+        return False
+
+    try:
+        destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    except OSError as error:
+        raise MergeError("destination_directory_unavailable") from error
+    if destination.is_symlink():
+        raise MergeError("config_symlink_rejected")
+
+    stage_descriptor: int | None = None
+    stage_path: Path | None = None
+    try:
+        stage_descriptor, stage_name = tempfile.mkstemp(
+            prefix=f".{destination.name}.stage-", dir=destination.parent
+        )
+        stage_path = Path(stage_name)
+        os.fchmod(stage_descriptor, 0o600)
+        with os.fdopen(stage_descriptor, "wb", closefd=False) as file:
+            file.write(_serialized(plan.document))
+            file.flush()
+            os.fsync(file.fileno())
+        os.close(stage_descriptor)
+        stage_descriptor = None
+
+        backup_created = False
+        if destination_config.exists:
+            backup = _backup_path(destination)
+            _write_restricted_file(backup, destination_config.raw, exclusive=True)
+            backup_created = True
+
+        os.replace(stage_path, destination)
+        stage_path = None
+        os.chmod(destination, 0o600, follow_symlinks=False)
+        if hasattr(os, "O_DIRECTORY"):
+            directory_fd = os.open(destination.parent, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        return backup_created
+    except MergeError:
+        raise
+    except OSError as error:
+        raise MergeError("atomic_write_failed") from error
+    finally:
+        if stage_descriptor is not None:
+            os.close(stage_descriptor)
+        if stage_path is not None:
+            try:
+                stage_path.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError:
+                pass
+
+
+def _summary(
+    plan: MergePlan, *, status: str, backup_created: bool = False
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "fingerprint": plan.fingerprint,
+        "source_server_count": plan.source_server_count,
+        "eligible_source_count": plan.eligible_source_count,
+        "destination_server_count": plan.destination_server_count,
+        "add_count": plan.add_count,
+        "conflict_count": plan.conflict_count,
+        "skipped_sensitive_count": plan.skipped_sensitive_count,
+        "skipped_reinstall_count": plan.skipped_reinstall_count,
+        "result_server_count": plan.result_server_count,
+        "content_change_required": plan.content_change_required,
+        "permission_update_required": plan.permission_update_required,
+        "would_change": plan.would_change,
+        "backup_created": backup_created,
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Redacted destination-wins merge for Warp global MCP configs."
+    )
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--destination", required=True)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true")
+    mode.add_argument("--apply", action="store_true")
+    parser.add_argument("--fingerprint")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+
+    # Path("") aliases ".", so reject unavailable host context before any
+    # filesystem lookup or path synthesis.
+    if not args.source:
+        print("error: source_path_unavailable", file=sys.stderr)
+        return 2
+    if not args.destination:
+        print("error: destination_path_unavailable", file=sys.stderr)
+        return 2
+    if args.apply and not args.fingerprint:
+        print("error: fingerprint_required", file=sys.stderr)
+        return 2
+    if args.dry_run and args.fingerprint:
+        print("error: fingerprint_not_valid_for_dry_run", file=sys.stderr)
+        return 2
+
+    try:
+        source = load_config(Path(args.source))
+        destination = load_config(Path(args.destination))
+        plan = build_plan(source, destination)
+        if args.dry_run:
+            print(json.dumps(_summary(plan, status="ready"), sort_keys=True))
+            return 0
+        if args.fingerprint != plan.fingerprint:
+            raise MergeError("fingerprint_mismatch")
+        backup_created = apply_plan(plan, Path(args.destination), destination)
+        print(
+            json.dumps(
+                _summary(plan, status="applied", backup_created=backup_created),
+                sort_keys=True,
+            )
+        )
+        return 0
+    except MergeError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    except Exception:
+        print("error: merge_failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/resources/bundled/skills/tui-migrate-setup/tests/fixtures/destination_mcp.json
+++ b/resources/bundled/skills/tui-migrate-setup/tests/fixtures/destination_mcp.json
@@ -1,0 +1,13 @@
+{
+  "servers": {
+    "destination-conflict": {
+      "url": "https://destination.invalid/mcp"
+    },
+    "destination-only": {
+      "command": "destination-command"
+    }
+  },
+  "destinationMetadata": {
+    "preserve": true
+  }
+}

--- a/resources/bundled/skills/tui-migrate-setup/tests/fixtures/gui_settings.toml
+++ b/resources/bundled/skills/tui-migrate-setup/tests/fixtures/gui_settings.toml
@@ -1,0 +1,11 @@
+[agent.permissions]
+command_policy = "always-ask"
+file_allowlist = ["/tmp/shared"]
+gui_internal = "GUI_PRIVATE_SENTINEL"
+tui_internal = "TUI_ONLY_SOURCE_SENTINEL"
+
+[appearance]
+theme = "GUI_THEME_SENTINEL"
+
+[private]
+credential = "PRIVATE_SETTING_SENTINEL"

--- a/resources/bundled/skills/tui-migrate-setup/tests/fixtures/settings_schema.json
+++ b/resources/bundled/skills/tui-migrate-setup/tests/fixtures/settings_schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "agent": {
+      "type": "object",
+      "properties": {
+        "permissions": {
+          "type": "object",
+          "properties": {
+            "command_policy": {
+              "type": "string",
+              "x-warp-surfaces": ["gui", "tui"]
+            },
+            "file_allowlist": {
+              "type": "array",
+              "items": {"type": "string"},
+              "x-warp-surfaces": ["tui", "gui"]
+            },
+            "gui_internal": {
+              "type": "string",
+              "x-warp-surfaces": ["gui"]
+            },
+            "tui_internal": {
+              "type": "string",
+              "x-warp-surfaces": ["tui"]
+            }
+          }
+        }
+      }
+    },
+    "appearance": {
+      "type": "object",
+      "properties": {
+        "theme": {
+          "type": "string",
+          "x-warp-surfaces": ["gui"]
+        }
+      }
+    }
+  }
+}

--- a/resources/bundled/skills/tui-migrate-setup/tests/fixtures/source_mcp.json
+++ b/resources/bundled/skills/tui-migrate-setup/tests/fixtures/source_mcp.json
@@ -1,0 +1,25 @@
+{
+  "mcpServers": {
+    "source-placeholder": {
+      "command": "placeholder-command",
+      "env": {
+        "SAFE_TOKEN": "${SAFE_TOKEN}"
+      },
+      "headers": {
+        "Authorization": "Bearer ${SAFE_TOKEN}"
+      }
+    },
+    "destination-conflict": {
+      "url": "https://source.invalid/mcp"
+    },
+    "literal-sensitive": {
+      "command": "sensitive-command",
+      "env": {
+        "API_KEY": "LITERAL_SECRET_SENTINEL"
+      }
+    },
+    "managed-installation": {
+      "warp_id": "MANAGED_INSTALLATION_SENTINEL"
+    }
+  }
+}

--- a/resources/bundled/skills/tui-migrate-setup/tests/fixtures/tui_settings.toml
+++ b/resources/bundled/skills/tui-migrate-setup/tests/fixtures/tui_settings.toml
@@ -1,0 +1,6 @@
+# This comment must remain in the destination.
+[agent.permissions]
+command_policy = "allow-safe"
+
+[tui]
+unknown_setting = true

--- a/resources/bundled/skills/tui-migrate-setup/tests/test_inspect_shared_settings.py
+++ b/resources/bundled/skills/tui-migrate-setup/tests/test_inspect_shared_settings.py
@@ -1,0 +1,229 @@
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+SCRIPT = SKILL_DIR / "scripts" / "inspect_shared_settings.py"
+FIXTURES = Path(__file__).parent / "fixtures"
+
+spec = importlib.util.spec_from_file_location("inspect_shared_settings", SCRIPT)
+inspector = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = inspector
+spec.loader.exec_module(inspector)
+
+
+class SharedSettingPathTests(unittest.TestCase):
+    def test_selects_dynamic_gui_tui_intersection(self):
+        schema = json.loads((FIXTURES / "settings_schema.json").read_text())
+
+        self.assertEqual(
+            inspector.shared_setting_paths(schema),
+            [
+                ("agent", "permissions", "command_policy"),
+                ("agent", "permissions", "file_allowlist"),
+            ],
+        )
+
+    def test_annotated_object_setting_does_not_descend_into_value_schema(self):
+        schema = {
+            "properties": {
+                "shared_object": {
+                    "x-warp-surfaces": ["gui", "tui"],
+                    "properties": {"value_field": {"x-warp-surfaces": ["gui", "tui"]}},
+                }
+            }
+        }
+
+        self.assertEqual(
+            inspector.shared_setting_paths(schema),
+            [("shared_object",)],
+        )
+
+
+class InspectSharedSettingsCliTests(unittest.TestCase):
+    def run_script(self, *args):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_nested_toml_outputs_only_shared_configured_values(self):
+        result = self.run_script(
+            "--schema",
+            str(FIXTURES / "settings_schema.json"),
+            "--source",
+            str(FIXTURES / "gui_settings.toml"),
+            "--destination",
+            str(FIXTURES / "tui_settings.toml"),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        output = json.loads(result.stdout)
+        self.assertEqual(output["eligible_configured_count"], 2)
+        by_path = {item["path"]: item for item in output["settings"]}
+        self.assertEqual(
+            by_path["agent.permissions.command_policy"]["state"],
+            "destination_conflict",
+        )
+        self.assertEqual(
+            by_path["agent.permissions.file_allowlist"]["state"],
+            "missing_in_tui",
+        )
+        combined = result.stdout + result.stderr
+        for excluded in (
+            "GUI_PRIVATE_SENTINEL",
+            "TUI_ONLY_SOURCE_SENTINEL",
+            "GUI_THEME_SENTINEL",
+            "PRIVATE_SETTING_SENTINEL",
+        ):
+            self.assertNotIn(excluded, combined)
+
+    def test_missing_destination_is_treated_as_empty(self):
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.run_script(
+                "--schema",
+                str(FIXTURES / "settings_schema.json"),
+                "--source",
+                str(FIXTURES / "gui_settings.toml"),
+                "--destination",
+                str(Path(directory) / "missing.toml"),
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        output = json.loads(result.stdout)
+        self.assertTrue(
+            all(item["state"] == "missing_in_tui" for item in output["settings"])
+        )
+
+    def test_malformed_source_has_sanitized_error(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "source.toml"
+            destination = Path(directory) / "destination.toml"
+            secret = "MALFORMED_PRIVATE_SENTINEL"
+            source.write_text(
+                "[agent.permissions]\n"
+                f'command_policy = [invalid\\nprivate = "{secret}"'
+            )
+            destination.write_text("")
+            result = self.run_script(
+                "--schema",
+                str(FIXTURES / "settings_schema.json"),
+                "--source",
+                str(source),
+                "--destination",
+                str(destination),
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertNotIn(secret, result.stderr)
+        self.assertIn("source_settings_unavailable_or_invalid", result.stderr)
+
+    def test_invalid_unrelated_section_is_ignored(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "source.toml"
+            destination = Path(directory) / "destination.toml"
+            source.write_text(
+                '[agent.permissions]\ncommand_policy = "always-ask"\n\n'
+                "[privacy]\ninvalid_gui_only_value = [\n"
+            )
+            destination.write_text("")
+            result = self.run_script(
+                "--schema",
+                str(FIXTURES / "settings_schema.json"),
+                "--source",
+                str(source),
+                "--destination",
+                str(destination),
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        output = json.loads(result.stdout)
+        self.assertEqual(output["eligible_configured_count"], 1)
+        self.assertEqual(
+            output["settings"][0]["path"],
+            "agent.permissions.command_policy",
+        )
+
+    def test_missing_source_is_treated_as_empty(self):
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.run_script(
+                "--schema",
+                str(FIXTURES / "settings_schema.json"),
+                "--source",
+                str(Path(directory) / "missing-source.toml"),
+                "--destination",
+                str(FIXTURES / "tui_settings.toml"),
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout),
+            {"eligible_configured_count": 0, "settings": []},
+        )
+
+    def test_empty_source_path_fails_before_filesystem_access(self):
+        with tempfile.TemporaryDirectory() as directory:
+            destination = Path(directory) / "destination.toml"
+            original = "canary = true\n"
+            destination.write_text(original)
+            result = self.run_script(
+                "--schema",
+                str(Path(directory) / "missing-schema.json"),
+                "--source",
+                "",
+                "--destination",
+                str(destination),
+            )
+
+            self.assertEqual(destination.read_text(), original)
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("source_path_unavailable", result.stderr)
+
+    def test_symlink_source_is_rejected(self):
+        if sys.platform == "win32":
+            self.skipTest("symlink creation is not generally available on Windows")
+        with tempfile.TemporaryDirectory() as directory:
+            link = Path(directory) / "source.toml"
+            link.symlink_to(FIXTURES / "gui_settings.toml")
+            result = self.run_script(
+                "--schema",
+                str(FIXTURES / "settings_schema.json"),
+                "--source",
+                str(link),
+                "--destination",
+                str(FIXTURES / "tui_settings.toml"),
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("settings_symlink_rejected", result.stderr)
+
+    def test_dangling_destination_symlink_is_rejected(self):
+        if sys.platform == "win32":
+            self.skipTest("symlink creation is not generally available on Windows")
+        with tempfile.TemporaryDirectory() as directory:
+            destination = Path(directory) / "destination.toml"
+            destination.symlink_to(Path(directory) / "missing-target.toml")
+            result = self.run_script(
+                "--schema",
+                str(FIXTURES / "settings_schema.json"),
+                "--source",
+                str(FIXTURES / "gui_settings.toml"),
+                "--destination",
+                str(destination),
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("settings_symlink_rejected", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/resources/bundled/skills/tui-migrate-setup/tests/test_merge_mcp_config.py
+++ b/resources/bundled/skills/tui-migrate-setup/tests/test_merge_mcp_config.py
@@ -1,0 +1,436 @@
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+SCRIPT = SKILL_DIR / "scripts" / "merge_mcp_config.py"
+FIXTURES = Path(__file__).parent / "fixtures"
+
+spec = importlib.util.spec_from_file_location("merge_mcp_config", SCRIPT)
+merger = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = merger
+spec.loader.exec_module(merger)
+
+
+class MergeMcpConfigTests(unittest.TestCase):
+    def run_script(self, source, destination, *mode):
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--source",
+                str(source),
+                "--destination",
+                str(destination),
+                *mode,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def copy_fixtures(self, directory):
+        source = Path(directory) / "source.json"
+        destination = Path(directory) / "destination.json"
+        source.write_bytes((FIXTURES / "source_mcp.json").read_bytes())
+        destination.write_bytes((FIXTURES / "destination_mcp.json").read_bytes())
+        os.chmod(source, 0o600)
+        os.chmod(destination, 0o600)
+        return source, destination
+
+    def dry_run(self, source, destination):
+        result = self.run_script(source, destination, "--dry-run")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return result, json.loads(result.stdout)
+
+    def apply(self, source, destination, fingerprint):
+        return self.run_script(
+            source,
+            destination,
+            "--apply",
+            "--fingerprint",
+            fingerprint,
+        )
+
+    def test_dry_run_is_redacted_and_does_not_mutate(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source, destination = self.copy_fixtures(directory)
+            original = destination.read_bytes()
+
+            result, summary = self.dry_run(source, destination)
+
+            self.assertEqual(destination.read_bytes(), original)
+            self.assertEqual(summary["source_server_count"], 4)
+            self.assertEqual(summary["eligible_source_count"], 2)
+            self.assertEqual(summary["add_count"], 1)
+            self.assertEqual(summary["conflict_count"], 1)
+            self.assertEqual(summary["skipped_sensitive_count"], 1)
+            self.assertEqual(summary["skipped_reinstall_count"], 1)
+            self.assertTrue(summary["would_change"])
+            combined = result.stdout + result.stderr
+            source_document = json.loads(source.read_text())
+            for server_name, definition in source_document["mcpServers"].items():
+                self.assertNotIn(server_name, combined)
+                self.assertNotIn(
+                    json.dumps(definition, sort_keys=True),
+                    combined,
+                )
+            for forbidden in (
+                "SAFE_TOKEN",
+                "${SAFE_TOKEN}",
+                "LITERAL_SECRET_SENTINEL",
+                "MANAGED_INSTALLATION_SENTINEL",
+                "headers",
+                "env",
+            ):
+                self.assertNotIn(forbidden, combined)
+
+    def test_apply_is_destination_wins_and_preserves_placeholder(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source, destination = self.copy_fixtures(directory)
+            _, summary = self.dry_run(source, destination)
+            result = self.apply(source, destination, summary["fingerprint"])
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            applied = json.loads(destination.read_text())
+            servers = applied["servers"]
+            self.assertEqual(
+                servers["destination-conflict"]["url"],
+                "https://destination.invalid/mcp",
+            )
+            self.assertEqual(
+                servers["source-placeholder"]["env"]["SAFE_TOKEN"],
+                "${SAFE_TOKEN}",
+            )
+            self.assertEqual(
+                servers["source-placeholder"]["headers"]["Authorization"],
+                "Bearer ${SAFE_TOKEN}",
+            )
+            self.assertNotIn("literal-sensitive", servers)
+            self.assertNotIn("managed-installation", servers)
+            self.assertTrue(applied["destinationMetadata"]["preserve"])
+            output = json.loads(result.stdout)
+            self.assertTrue(output["backup_created"])
+
+    def test_apply_creates_restricted_backup_and_destination(self):
+        if os.name != "posix":
+            self.skipTest("Unix permission assertions")
+        with tempfile.TemporaryDirectory() as directory:
+            source, destination = self.copy_fixtures(directory)
+            _, summary = self.dry_run(source, destination)
+            result = self.apply(source, destination, summary["fingerprint"])
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            backups = list(Path(directory).glob("destination.json.backup-*"))
+            self.assertEqual(len(backups), 1)
+            self.assertEqual(stat.S_IMODE(destination.stat().st_mode), 0o600)
+            self.assertEqual(stat.S_IMODE(backups[0].stat().st_mode), 0o600)
+
+    def test_changed_input_rejects_apply_without_mutation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source, destination = self.copy_fixtures(directory)
+            original_destination = destination.read_bytes()
+            _, summary = self.dry_run(source, destination)
+            source.write_text(
+                source.read_text().replace("placeholder-command", "changed-command")
+            )
+            result = self.apply(source, destination, summary["fingerprint"])
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("fingerprint_mismatch", result.stderr)
+            self.assertEqual(destination.read_bytes(), original_destination)
+            self.assertEqual(
+                list(Path(directory).glob("destination.json.backup-*")),
+                [],
+            )
+
+    def test_apply_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source, destination = self.copy_fixtures(directory)
+            _, first = self.dry_run(source, destination)
+            self.assertEqual(
+                self.apply(source, destination, first["fingerprint"]).returncode,
+                0,
+            )
+            after_first = destination.read_bytes()
+
+            _, second = self.dry_run(source, destination)
+            self.assertEqual(second["add_count"], 0)
+            self.assertFalse(second["would_change"])
+            second_apply = self.apply(source, destination, second["fingerprint"])
+
+            self.assertEqual(second_apply.returncode, 0, second_apply.stderr)
+            self.assertEqual(destination.read_bytes(), after_first)
+            self.assertFalse(json.loads(second_apply.stdout)["backup_created"])
+
+    def test_missing_destination_uses_source_wrapper(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "source.json"
+            destination = Path(directory) / "nested" / "destination.json"
+            source.write_text(
+                json.dumps(
+                    {
+                        "mcp": {
+                            "servers": {
+                                "new-server": {"url": "https://example.invalid/mcp"}
+                            },
+                            "unrelated": "do-not-copy",
+                        },
+                        "sourceMetadata": "do-not-copy",
+                    }
+                )
+            )
+            _, summary = self.dry_run(source, destination)
+            result = self.apply(source, destination, summary["fingerprint"])
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            output = json.loads(destination.read_text())
+            self.assertIn("servers", output["mcp"])
+            self.assertNotIn("unrelated", output["mcp"])
+            self.assertNotIn("sourceMetadata", output)
+            self.assertFalse(json.loads(result.stdout)["backup_created"])
+            if os.name == "posix":
+                self.assertEqual(
+                    stat.S_IMODE(destination.stat().st_mode),
+                    0o600,
+                )
+
+    def test_missing_source_is_an_empty_no_op(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "missing-source.json"
+            destination = Path(directory) / "destination.json"
+            original = '{"mcpServers": {}}\n'
+            destination.write_text(original)
+
+            result, summary = self.dry_run(source, destination)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(summary["source_server_count"], 0)
+            self.assertEqual(summary["eligible_source_count"], 0)
+            self.assertEqual(summary["add_count"], 0)
+            self.assertFalse(summary["content_change_required"])
+            self.assertEqual(
+                summary["would_change"],
+                summary["permission_update_required"],
+            )
+            self.assertEqual(destination.read_text(), original)
+
+    def test_supported_wrapper_forms(self):
+        wrappers = {
+            "mcpServers": lambda servers: {"mcpServers": servers},
+            "mcp_servers": lambda servers: {"mcp_servers": servers},
+            "servers": lambda servers: {"servers": servers},
+            "mcp.servers": lambda servers: {"mcp": {"servers": servers}},
+            "flat": lambda servers: servers,
+        }
+        for name, wrap in wrappers.items():
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
+                source = Path(directory) / "source.json"
+                destination = Path(directory) / "destination.json"
+                source.write_text(
+                    json.dumps(
+                        wrap({"source-entry": {"command": "placeholder-command"}})
+                    )
+                )
+                destination.write_text(
+                    json.dumps(
+                        wrap({"destination-entry": {"command": "destination-command"}})
+                    )
+                )
+
+                _, summary = self.dry_run(source, destination)
+                result = self.apply(source, destination, summary["fingerprint"])
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                parsed = merger.load_config(destination)
+                self.assertEqual(len(parsed.servers), 2)
+                self.assertEqual(
+                    parsed.wrapper_path,
+                    {
+                        "mcpServers": ("mcpServers",),
+                        "mcp_servers": ("mcp_servers",),
+                        "servers": ("servers",),
+                        "mcp.servers": ("mcp", "servers"),
+                        "flat": (),
+                    }[name],
+                )
+
+    def test_invalid_input_is_sanitized_no_op(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "source.json"
+            destination = Path(directory) / "destination.json"
+            secret = "INVALID_JSON_SECRET_SENTINEL"
+            source.write_text('{"mcpServers": {"private": "' + secret)
+            original = '{"servers": {}}\n'
+            destination.write_text(original)
+
+            result = self.run_script(source, destination, "--dry-run")
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+            self.assertIn("invalid_json", result.stderr)
+            self.assertNotIn(secret, result.stderr)
+            self.assertEqual(destination.read_text(), original)
+
+    def test_literal_credentials_in_args_and_urls_are_skipped(self):
+        servers = {
+            "argument-secret": {
+                "command": "command",
+                "args": ["--api-key", "LITERAL_ARGUMENT_SECRET"],
+            },
+            "query-secret": {
+                "url": "https://example.invalid/mcp?access_token=LITERAL_QUERY_SECRET"
+            },
+            "placeholder-argument": {
+                "command": "command",
+                "args": ["--api-key=${API_KEY}"],
+            },
+            "placeholder-query": {
+                "url": "https://example.invalid/mcp?access_token=${ACCESS_TOKEN}"
+            },
+            "mixed-literal-placeholder": {
+                "command": "command",
+                "env": {"API_KEY": "LITERAL_PREFIX_${API_KEY}"},
+            },
+        }
+
+        eligible, skipped_sensitive, skipped_reinstall = merger._classify_source(
+            servers
+        )
+
+        self.assertEqual(len(eligible), 2)
+        self.assertEqual(skipped_sensitive, 3)
+        self.assertEqual(skipped_reinstall, 0)
+
+    def test_invalid_source_transport_is_no_op(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "source.json"
+            destination = Path(directory) / "destination.json"
+            source.write_text(
+                json.dumps(
+                    {
+                        "mcpServers": {
+                            "invalid": {
+                                "command": "command",
+                                "url": "https://example.invalid/mcp",
+                            }
+                        }
+                    }
+                )
+            )
+            original = '{"servers": {}}\n'
+            destination.write_text(original)
+
+            result = self.run_script(source, destination, "--dry-run")
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+            self.assertIn("invalid_server_definition", result.stderr)
+            self.assertNotIn("invalid", result.stderr.removeprefix("error: invalid"))
+            self.assertEqual(destination.read_text(), original)
+
+    def test_source_and_destination_symlinks_are_rejected(self):
+        if os.name != "posix":
+            self.skipTest("symlink creation is not generally available on Windows")
+        for symlink_role in ("source", "destination"):
+            with self.subTest(
+                role=symlink_role
+            ), tempfile.TemporaryDirectory() as directory:
+                source, destination = self.copy_fixtures(directory)
+                selected = source if symlink_role == "source" else destination
+                target = selected.with_suffix(".target")
+                selected.rename(target)
+                selected.symlink_to(target)
+                original = target.read_bytes()
+
+                result = self.run_script(source, destination, "--dry-run")
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("config_symlink_rejected", result.stderr)
+                self.assertEqual(target.read_bytes(), original)
+
+    def test_empty_source_path_fails_before_filesystem_access(self):
+        with tempfile.TemporaryDirectory() as directory:
+            destination = Path(directory) / "destination.json"
+            original = '{"servers": {}}\n'
+            destination.write_text(original)
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--source",
+                    "",
+                    "--destination",
+                    str(destination),
+                    "--dry-run",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                cwd=directory,
+            )
+
+            self.assertEqual(destination.read_text(), original)
+            self.assertEqual(list(Path(directory).glob("*.backup-*")), [])
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("source_path_unavailable", result.stderr)
+
+    def test_atomic_replace_failure_leaves_destination_unchanged(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source, destination = self.copy_fixtures(directory)
+            original = destination.read_bytes()
+            source_config = merger.load_config(source)
+            destination_config = merger.load_config(destination)
+            plan = merger.build_plan(source_config, destination_config)
+
+            with mock.patch.object(
+                merger.os, "replace", side_effect=OSError("private detail")
+            ):
+                with self.assertRaisesRegex(merger.MergeError, "atomic_write_failed"):
+                    merger.apply_plan(plan, destination, destination_config)
+
+            self.assertEqual(destination.read_bytes(), original)
+            self.assertEqual(
+                list(Path(directory).glob(".destination.json.stage-*")),
+                [],
+            )
+            backups = list(Path(directory).glob("destination.json.backup-*"))
+            self.assertEqual(len(backups), 1)
+            self.assertEqual(backups[0].read_bytes(), original)
+
+    def test_apply_repairs_destination_permissions_without_rewrite(self):
+        if os.name != "posix":
+            self.skipTest("Unix permission assertions")
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "source.json"
+            destination = Path(directory) / "destination.json"
+            contents = '{"servers": {"same": {"command": "command"}}}\n'
+            source.write_text(contents)
+            destination.write_text(contents)
+            os.chmod(destination, 0o644)
+
+            _, summary = self.dry_run(source, destination)
+            self.assertFalse(summary["content_change_required"])
+            self.assertTrue(summary["permission_update_required"])
+            result = self.apply(source, destination, summary["fingerprint"])
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(destination.read_text(), contents)
+            self.assertEqual(stat.S_IMODE(destination.stat().st_mode), 0o600)
+            self.assertEqual(
+                list(Path(directory).glob("destination.json.backup-*")),
+                [],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/script/run-tui
+++ b/script/run-tui
@@ -105,14 +105,19 @@ if [ -n "${TARGET_TRIPLE}" ]; then
 fi
 BUILD_DIR="${BUILD_DIR}/${PROFILE_DIR}"
 
-# Stage bundled skills next to the binary so the standalone TUI can resolve them
-# at runtime. License generation and the settings schema are skipped to keep dev
-# runs fast (mirroring script/macos/run); the vast majority of bundled skills are
-# always active and don't depend on the schema.
+# Stage bundled skills and the settings schema next to the binary so the
+# standalone TUI can resolve them at runtime. License generation remains skipped
+# for local runs. Reuse the selected Cargo profile for schema generation so its
+# dependencies do not need to be rebuilt in a separate profile.
 prepare_tui_bundled_resources() {
   echo "Preparing bundled resources at ${BUILD_DIR}/resources (channel: ${CHANNEL})..."
-  NO_LICENSES=1 SKIP_SETTINGS_SCHEMA=1 "${REPO_ROOT}/script/prepare_bundled_resources" \
-    "${BUILD_DIR}/resources" "${CHANNEL}"
+  if [ "${PROFILE_DIR}" = "debug" ]; then
+    NO_LICENSES=1 "${REPO_ROOT}/script/prepare_bundled_resources" \
+      "${BUILD_DIR}/resources" "${CHANNEL}"
+  else
+    NO_LICENSES=1 "${REPO_ROOT}/script/prepare_bundled_resources" \
+      "${BUILD_DIR}/resources" "${CHANNEL}" "${PROFILE_DIR}"
+  fi
 }
 
 if [[ "$(uname -s)" = "Darwin" ]]; then


### PR DESCRIPTION
## Description
Adds a TUI-only bundled skill that helps existing Warp GUI users migrate the subset of their setup that Warp TUI can safely consume.

- Gates `tui-migrate-setup` to the local TUI skill catalog and omits it from remote daemon snapshots.
- Annotates the bundled settings schema with authoritative GUI/TUI surface metadata and provides channel-aware GUI/TUI settings and MCP paths.
- Adds a guided, approval-gated workflow for shared settings and global file-based MCP definitions without copying credentials, OAuth state, SQLite data, or GUI-only configuration.
- Uses skill-local helpers for schema-filtered settings inspection and redacted, fingerprint-bound MCP merges.
- Stages `settings_schema.json` from `script/run-tui` so local TUI builds exercise the same workflow as packaged builds.

The migration defaults to preview-only behavior, preserves existing TUI values, and treats templatable MCP installations and authentication as reinstall/reauthentication tasks.

Implementation plan: https://staging.warp.dev/drive/notebook/7f1uF7BGqmdBI9qCc2G5IE

Agent conversation: https://staging.warp.dev/conversation/7fa84317-65c2-414c-9ba4-48b7f04916d9

## Linked Issue
N/A — this work was developed from the linked implementation plan.

## Testing
- [x] `./script/presubmit`
- [x] 25 Python helper regression tests
- [x] Bundled skill `quick_validate.py`
- [x] Focused TUI-only activation, direct-read, remote snapshot, path, and schema tests
- [x] Manually ran `./script/run-tui`, verified the skill appears under `/skills`, and exercised a preview against a real WarpDev GUI setup
- [x] Verified the preview finds only the two shared Agent permission settings and treats a missing GUI MCP file as an empty source
- [x] Ran `cargo clean`, rebuilt with `CARGO_BUILD_JOBS=2 ./script/run-tui`, and verified the schema plus both helper scripts were restaged at the resolved paths

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-OZ: Added a TUI-only skill for migrating compatible Warp GUI settings and global file-based MCP servers.

Co-Authored-By: Warp <agent@warp.dev>
