### PR TITLE
fix(markdown_parser): stop unclosed <u> from pairing via emphasis

### DIFF
--- a/crates/markdown_parser/src/markdown_parser.rs
+++ b/crates/markdown_parser/src/markdown_parser.rs
@@ -1793,6 +1793,16 @@ impl Delimiter {
             return false;
         }
 
+        // `<u>` is only ever closed by an explicit `</u>` (handled by
+        // `parse_underline`), never by pairing two openers through the emphasis
+        // path. Without this guard, an unclosed `<u>` followed by another `<u>`
+        // is matched as an opener/closer pair and both markers plus the text
+        // between them are deleted. An unclosed `<u>` should round-trip to
+        // literal text, exactly like an unclosed `*`.
+        if self.kind == DelimiterKind::UnderlineStart {
+            return false;
+        }
+
         // For strikethrough, the delimiter counts must match.
         if self.kind == DelimiterKind::Strikethrough {
             return self.count == other.count;

--- a/crates/markdown_parser/src/markdown_parser_tests.rs
+++ b/crates/markdown_parser/src/markdown_parser_tests.rs
@@ -1982,6 +1982,23 @@ fn test_parse_empty_underline() {
 }
 
 #[test]
+fn test_parse_unclosed_underline_round_trips() {
+    // Regression test for #13134: an unclosed `<u>` followed by another `<u>`
+    // used to be matched as an emphasis opener/closer pair, deleting both
+    // markers and the text between them. `<u>` is only ever closed by an
+    // explicit `</u>`, so an unclosed `<u>` must round-trip to literal text,
+    // exactly like an unclosed `*`.
+    for source in ["<u><u>", "<u>a<u>", "a <u>word<u> b"] {
+        let parsed = parse_markdown(source).unwrap_or_else(|_| panic!("{source:?} should parse"));
+        assert_eq!(
+            parsed.raw_text(),
+            format!("{source}\n"),
+            "{source:?} must round-trip without dropping text"
+        );
+    }
+}
+
+#[test]
 fn test_unordered_list_indentation_level_relative() {
     // Test that both 2-space and 4-space relative indentation produce the same structure
     let source_2space = "- top level\n  - sublevel\n    - subsublevel";


### PR DESCRIPTION
## Description

`parse_markdown` silently deletes text when a `<u>` underline marker is left unclosed and another `<u>` appears later in the same line. `<u>` is tokenized as an `UnderlineStart` delimiter and pushed onto the shared delimiter stack, so `process_emphasis` matches the two `<u>` markers as an emphasis opener/closer pair and consumes both, taking the text around them with it:

| Input | Expected | Before |
|---|---|---|
| `<u><u>` | `<u><u>` | empty line — all text gone |
| `<u>a<u>` | `<u>a<u>` | `a` |
| `a <u>word<u> b` | `a <u>word<u> b` | `a word b` |

Underline is only ever closed by an explicit `</u>` (handled by `parse_underline`, which never goes through `can_open_for`), so pairing two `<u>` openers through the emphasis path is always wrong. The fix rejects `UnderlineStart` in `can_open_for`, so an unclosed `<u>` round-trips to literal text exactly like an unclosed `*`.

Since `parse_markdown` renders agent output and markdown-viewer content, a partial/streamed `<u>` or two `<u>` tags currently drop the literal text — data loss in rendered output.

## Linked Issue

Fixes #13134

- [x] The linked issue is labeled `ready-to-implement`.

## Testing

This is platform-independent parser logic in the `markdown_parser` crate with no UI surface, so it's covered by a unit test rather than `./script/run`. Added `test_parse_unclosed_underline_round_trips`, which asserts the three cases above round-trip via `raw_text()`. It fails on `master` (`<u><u>` comes back as `"\n"` — all text dropped) and passes with this change. The full `markdown_parser` suite stays green (142 tests, including all existing underline/emphasis cases).

- [x] Added an automated regression test (`cargo nextest run -p markdown_parser`)
- [ ] I have manually tested my changes locally with `./script/run` — not applicable; crate-scoped parser logic with no user-facing UI path, verified by the unit test above.

## Agent Mode
- [ ] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

<!--
CHANGELOG-BUG-FIX: Fixed markdown rendering dropping text when a `<u>` tag is left unclosed.
-->
