### PR TITLE
Take into account bootstrap stage when showing input

### DIFF
--- a/crates/warp_tui/src/terminal_session_view.rs
+++ b/crates/warp_tui/src/terminal_session_view.rs
@@ -75,8 +75,8 @@ use crate::skills_menu::{TuiSkillMenuEvent, TuiSkillMenuModel};
 use crate::slash_commands::TuiSlashCommandModel;
 use crate::terminal_content_element::TuiTerminalContentElement;
 use crate::terminal_use::{
-    hide_agent_requested_command_from_top_level, inline_process_owns_input,
-    terminal_use_conversation_to_resume, terminal_use_interrupt_action, TerminalUseInterruptAction,
+    hide_agent_requested_command_from_top_level, terminal_use_conversation_to_resume,
+    terminal_use_interrupt_action, tui_input_target, TerminalUseInterruptAction, TuiInputTarget,
 };
 use crate::transcript_view::{TuiTranscriptView, TuiTranscriptViewEvent};
 use crate::transient_hint::{TransientHint, TransientHintTone};
@@ -337,13 +337,11 @@ pub(crate) fn init(app: &mut AppContext) {
 }
 
 impl TuiTerminalSessionView {
-    /// Returns whether the foreground process should receive keyboard input
-    /// instead of Warp's editor. This is true for alt-screen applications and
-    /// for inline long-running commands currently controlled by the user, and
-    /// drives the session's focus, rendering, and event-routing transitions.
-    fn process_owns_input(&self) -> bool {
+    /// Selects the sole input destination for the current terminal lifecycle
+    /// state. The result drives focus, rendering, and event routing together.
+    fn input_target(&self) -> TuiInputTarget {
         let terminal_model = self.terminal_model.lock();
-        terminal_model.is_alt_screen_active() || inline_process_owns_input(&terminal_model)
+        tui_input_target(&terminal_model)
     }
 
     fn update_process_input_focus(&mut self, ctx: &mut ViewContext<Self>) {
@@ -351,12 +349,15 @@ impl TuiTerminalSessionView {
     }
 
     fn focus_current_owner(&self, ctx: &mut ViewContext<Self>) {
-        if self.process_owns_input() {
-            ctx.focus_self();
-        } else if let Some(blocker) = self.active_blocking_child(ctx) {
-            ctx.focus(&blocker);
-        } else {
-            ctx.focus(&self.input_view);
+        match self.input_target() {
+            TuiInputTarget::Disabled | TuiInputTarget::Pty => ctx.focus_self(),
+            TuiInputTarget::AgentEditor => {
+                if let Some(blocker) = self.active_blocking_child(ctx) {
+                    ctx.focus(&blocker);
+                } else {
+                    ctx.focus(&self.input_view);
+                }
+            }
         }
     }
 
@@ -487,9 +488,10 @@ impl TuiTerminalSessionView {
             .as_ref(ctx)
             .active_target()
             .map(|target| target.control_state);
-        let Some(action) =
-            terminal_use_interrupt_action(control_state.as_ref(), self.process_owns_input())
-        else {
+        let Some(action) = terminal_use_interrupt_action(
+            control_state.as_ref(),
+            self.input_target().pty_owns_input(),
+        ) else {
             return false;
         };
         match action {
@@ -922,6 +924,10 @@ impl TuiTerminalSessionView {
                 view.update_process_input_focus(ctx);
                 ctx.notify();
             }
+            ModelEvent::BootstrapPrecmdDone => {
+                view.update_process_input_focus(ctx);
+                ctx.notify();
+            }
             ModelEvent::BlockMetadataReceived(_)
             | ModelEvent::BlockWorkingDirectoryUpdated(_)
             | ModelEvent::BackgroundBlockStarted
@@ -1041,7 +1047,6 @@ impl TuiTerminalSessionView {
             |_, _| {},
         );
         ctx.spawn_stream_local(terminal_resize_rx, Self::handle_terminal_resize, |_, _| {});
-
         Self {
             transcript,
             input_view,
@@ -1716,6 +1721,11 @@ impl TuiTerminalSessionView {
     /// Routes a submission to shell execution or the agent conversation based
     /// on the input mode.
     fn handle_submitted(&mut self, text: String, ctx: &mut ViewContext<Self>) {
+        // A stale editor frame must not submit into a shell that is still
+        // bootstrapping or has handed input to a foreground process.
+        if !self.input_target().agent_editor_owns_input() {
+            return;
+        }
         if !matches!(
             self.conversation_restore_state,
             ConversationRestoreState::Idle
@@ -2290,11 +2300,11 @@ impl TuiView for TuiTerminalSessionView {
         }
         // While a full-screen (alt-screen) app is active, hand the whole pane to
         // it: render its grid and forward input, instead of the block UI.
-        let (alt_screen_active, inline_process_owns_input) = {
+        let (alt_screen_active, input_target) = {
             let terminal_model = self.terminal_model.lock();
             (
                 terminal_model.is_alt_screen_active(),
-                inline_process_owns_input(&terminal_model),
+                tui_input_target(&terminal_model),
             )
         };
         if alt_screen_active {
@@ -2306,7 +2316,8 @@ impl TuiView for TuiTerminalSessionView {
             .finish();
         }
 
-        let inline_menu = (!inline_process_owns_input)
+        let inline_menu = input_target
+            .agent_editor_owns_input()
             .then(|| {
                 active_inline_menu(
                     &self.inline_menus,
@@ -2358,7 +2369,7 @@ impl TuiView for TuiTerminalSessionView {
             .and_then(|conversation_id| {
                 BlocklistAIHistoryModel::as_ref(ctx).conversation(&conversation_id)
             })
-            .filter(|_| !blocker_active && !inline_process_owns_input);
+            .filter(|_| !blocker_active && input_target.agent_editor_owns_input());
         if let Some(conversation) = selected_conversation {
             if conversation.status().is_in_progress() {
                 let warping_elapsed = conversation
@@ -2399,7 +2410,7 @@ impl TuiView for TuiTerminalSessionView {
                 }
             }
         }
-        if !blocker_active && !inline_process_owns_input {
+        if !blocker_active && input_target.agent_editor_owns_input() {
             if let Some(menu) = inline_menu {
                 content = content.child(
                     TuiConstrainedBox::new(menu)
@@ -2432,7 +2443,7 @@ impl TuiView for TuiTerminalSessionView {
         let content = content.finish();
         let terminal_content =
             TuiTerminalContentElement::new(self.terminal_resize_tx.clone(), content);
-        let terminal_content = if inline_process_owns_input {
+        let terminal_content = if input_target.pty_owns_input() {
             terminal_content.with_pty_input(self.terminal_model.clone())
         } else {
             terminal_content

--- a/crates/warp_tui/src/terminal_use.rs
+++ b/crates/warp_tui/src/terminal_use.rs
@@ -33,6 +33,60 @@ pub(super) enum TerminalUseInterruptAction {
     InterruptCommand,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum TuiInputTarget {
+    /// No editable destination is ready, such as while Warp injects its
+    /// bootstrap script or waits for the first post-bootstrap prompt. The
+    /// session view keeps focus for reserved bindings, but hides the agent
+    /// editor and does not forward ordinary input to the PTY.
+    Disabled,
+    /// The foreground terminal process owns input during shell startup
+    /// scripts, alt-screen applications, or user-controlled long-running
+    /// commands. The agent editor is hidden, the session view is focused, and
+    /// terminal content forwards key, paste, and supported pointer events to
+    /// the PTY.
+    Pty,
+    /// The shell is at an ordinary prompt and no foreground process owns
+    /// input. The agent editor, menus, and footer are rendered, and focus moves
+    /// to the editor unless a blocking interaction takes precedence.
+    AgentEditor,
+}
+
+impl TuiInputTarget {
+    pub(super) fn agent_editor_owns_input(self) -> bool {
+        matches!(self, Self::AgentEditor)
+    }
+
+    pub(super) fn pty_owns_input(self) -> bool {
+        matches!(self, Self::Pty)
+    }
+}
+
+fn tui_input_target_for_state(
+    alt_screen_active: bool,
+    script_execution: bool,
+    bootstrap_precmd_done: bool,
+    inline_process_owns_input: bool,
+) -> TuiInputTarget {
+    if alt_screen_active || script_execution || inline_process_owns_input {
+        TuiInputTarget::Pty
+    } else if !bootstrap_precmd_done {
+        TuiInputTarget::Disabled
+    } else {
+        TuiInputTarget::AgentEditor
+    }
+}
+
+pub(super) fn tui_input_target(terminal_model: &TerminalModel) -> TuiInputTarget {
+    let block_list = terminal_model.block_list();
+    tui_input_target_for_state(
+        terminal_model.is_alt_screen_active(),
+        block_list.is_script_execution(),
+        block_list.is_bootstrapping_precmd_done(),
+        inline_process_owns_input(terminal_model),
+    )
+}
+
 pub(super) fn terminal_use_interrupt_action(
     control_state: Option<&LongRunningCommandControlState>,
     process_owns_input: bool,

--- a/crates/warp_tui/src/terminal_use_tests.rs
+++ b/crates/warp_tui/src/terminal_use_tests.rs
@@ -14,7 +14,8 @@ use warpui_core::App;
 
 use super::{
     hide_agent_requested_command_from_top_level, inline_process_owns_input,
-    terminal_use_conversation_to_resume, terminal_use_interrupt_action, TerminalUseInterruptAction,
+    terminal_use_conversation_to_resume, terminal_use_interrupt_action, tui_input_target,
+    tui_input_target_for_state, TerminalUseInterruptAction, TuiInputTarget,
 };
 use crate::tui_block_list_viewport_source::TuiBlockListViewportSource;
 
@@ -42,6 +43,18 @@ fn ordinary_long_running_command_owns_inline_input() {
     model.simulate_long_running_block("cat", "");
 
     assert!(inline_process_owns_input(&model));
+}
+#[test]
+fn shell_startup_routes_input_by_bootstrap_stage() {
+    let mut model = TerminalModel::mock(None, None);
+    assert_eq!(tui_input_target(&model), TuiInputTarget::AgentEditor);
+
+    model.block_list_mut().reinit_shell();
+    assert_eq!(tui_input_target(&model), TuiInputTarget::Disabled);
+    assert_eq!(
+        tui_input_target_for_state(false, true, false, false),
+        TuiInputTarget::Pty,
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

Fixes a Warp TUI input-routing bug during shell startup. When a startup script such as Oh My Zsh displayed an interactive update prompt, the TUI still rendered and focused the Warp Agent editor. Typing `y` and pressing Enter could therefore submit `y` to the agent, consume credits, and send the agent's subsequent terminal command bytes into the still-waiting shell prompt.

This change introduces a stage-aware TUI input target and uses it consistently for rendering, focus, and event routing:

- Bootstrap injection disables editable input without forwarding keys to the PTY.
- Shell startup scripts, alt-screen applications, and user-controlled long-running commands own raw PTY input.
- The Warp Agent editor returns only after the shell reaches its normal post-bootstrap prompt.

A stale editor submission is also ignored unless the agent editor is the active input target. The existing orchestration test fixture is updated for the current `RunAgentsAgentRunConfig` shape so the TUI test suite compiles.

## Linked Issue

No linked GitHub issue; reproduced from an internal bug report.

- [x] Where appropriate, manual end-to-end verification is documented below.

## Testing

- [x] Manually tested locally with `./script/run-tui` and an isolated older Oh My Zsh checkout.
  - Confirmed the agent editor is hidden while `[oh-my-zsh] Would you like to update? [Y/n]` is waiting.
  - Confirmed a single `y` updates Oh My Zsh successfully without submitting an agent request or consuming credits.
  - Confirmed the agent editor returns after shell bootstrap completes.
- `cargo nextest run -p warp_tui` — 354 tests passed.
- `cargo clippy -p warp_tui --all-targets --all-features --tests -- -D warnings`
- `./script/format`
- Added `shell_startup_routes_input_by_bootstrap_stage` regression coverage.

### Screenshots / Videos

Not captured; the TUI flow was driven and inspected directly under tmux during manual verification.

## Agent Mode

- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

## Changelog Entries for Stable

CHANGELOG-BUG-FIX: Fixed shell startup prompts in Warp TUI sending input to both the shell and Warp Agent.

Co-Authored-By: Warp <agent@warp.dev>
