### PR TITLE
feat(markdown_parser): support HTML <br> hard line break tag

### DIFF
--- a/crates/markdown_parser/src/lib.rs
+++ b/crates/markdown_parser/src/lib.rs
@@ -285,11 +285,11 @@ impl LineCount for FormattedTextLine {
     fn num_lines(&self) -> usize {
         match self {
             Self::CodeBlock(text) => text.code.matches('\n').count(),
-            Self::Heading(_) => 1,
-            Self::Line(_) => 1,
-            Self::OrderedList(_) => 1,
-            Self::UnorderedList(_) => 1,
-            Self::TaskList(_) => 1,
+            Self::Heading(header) => count_inline_lines(&header.text),
+            Self::Line(texts) => count_inline_lines(texts),
+            Self::OrderedList(list) => count_inline_lines(&list.indented_text.text),
+            Self::UnorderedList(list) => count_inline_lines(&list.text),
+            Self::TaskList(list) => count_inline_lines(&list.text),
             Self::LineBreak => 0,
             Self::HorizontalRule => 0,
             Self::Embedded(_) => 1,
@@ -297,6 +297,13 @@ impl LineCount for FormattedTextLine {
             Self::Table(table) => 1 + table.rows.len(), // Header + data rows (separator not counted as a line)
         }
     }
+}
+
+fn count_inline_lines(fragments: &[FormattedTextFragment]) -> usize {
+    1 + fragments
+        .iter()
+        .map(|f| f.text.matches('\n').count())
+        .sum::<usize>()
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/markdown_parser/src/markdown_parser.rs
+++ b/crates/markdown_parser/src/markdown_parser.rs
@@ -1063,16 +1063,42 @@ fn parse_inline<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
 /// This is a no-op if the last fragment does not end with a newline from a
 /// hard line break.
 fn strip_trailing_hard_break(fragments: &mut Vec<FormattedTextFragment>) {
-    let Some(last) = fragments.last_mut() else {
-        return;
-    };
-    let trimmed_ws = last
-        .text
-        .trim_end_matches(|c: char| c.is_whitespace() && c != '\n');
-    if !trimmed_ws.ends_with('\n') {
+    let mut trailing_ws_end = fragments.len();
+    for i in (0..fragments.len()).rev() {
+        let frag = &fragments[i];
+        if frag.styles == FormattedTextStyles::default()
+            && frag
+                .text
+                .chars()
+                .all(|c| c.is_whitespace() && c != '\n')
+        {
+            trailing_ws_end = i;
+        } else {
+            break;
+        }
+    }
+
+    if trailing_ws_end == 0 {
         return;
     }
-    last.text.truncate(trimmed_ws.len() - 1);
+
+    let should_strip = {
+        let last_content = &fragments[trailing_ws_end - 1].text;
+        let trimmed = last_content.trim_end_matches(|c: char| c.is_whitespace() && c != '\n');
+        trimmed.ends_with('\n')
+    };
+
+    if !should_strip {
+        return;
+    }
+
+    fragments.truncate(trailing_ws_end);
+    let last = fragments.last_mut().unwrap();
+    let trimmed_len = last
+        .text
+        .trim_end_matches(|c: char| c.is_whitespace() && c != '\n')
+        .len();
+    last.text.truncate(trimmed_len - 1);
     if last.text.is_empty() {
         fragments.pop();
     }

--- a/crates/markdown_parser/src/markdown_parser.rs
+++ b/crates/markdown_parser/src/markdown_parser.rs
@@ -985,6 +985,7 @@ fn parse_inline<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
 ) -> IResult<&'a str, Vec<FormattedTextFragment>, E> {
     // We're parsing inline tokens "by hand" instead of using `fold_many0` to allow lookahead.
     let mut state = InlineState::default();
+    let mut ends_with_hard_break = false;
     while !input.is_empty() {
         let (remaining, token) = parse_inline_token(input)?;
         input = remaining;
@@ -992,9 +993,13 @@ fn parse_inline<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
         match token {
             InlineToken::CodeSpan(text) => {
                 state.push_closed_node(FormattedTextFragment::inline_code(text));
+                ends_with_hard_break = false;
             }
             InlineToken::Text(text) => {
                 state.push_text(text);
+                if !text.chars().all(char::is_whitespace) {
+                    ends_with_hard_break = false;
+                }
             }
             InlineToken::AutoLink(url) => {
                 // Per GFM spec, autolinks can follow whitespace, line beginning, or formatting
@@ -1012,9 +1017,11 @@ fn parse_inline<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
                 } else {
                     state.push_text(url);
                 }
+                ends_with_hard_break = false;
             }
             InlineToken::BackslashEscape(ch) | InlineToken::HtmlEntity(ch) => {
                 state.push_text(ch);
+                ends_with_hard_break = false;
             }
             InlineToken::Delimiter { kind, count } => {
                 let node_index = state.nodes.len();
@@ -1028,12 +1035,20 @@ fn parse_inline<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
                     Delimiter::new(node_index, kind, count, preceding_char, following_char);
                 state.push_closed_node(FormattedTextFragment::plain_text(delimiter.to_text()));
                 state.delimiters.push(delimiter);
+                ends_with_hard_break = false;
             }
             InlineToken::LinkEnd => {
                 input = parse_link(&mut state, remaining);
+                ends_with_hard_break = false;
             }
             InlineToken::UnderlineEnd => {
                 input = parse_underline(&mut state, remaining);
+                ends_with_hard_break = false;
+            }
+            InlineToken::HardLineBreak => {
+                state.push_text("\n");
+                state.last_node_closed = true;
+                ends_with_hard_break = true;
             }
         }
     }
@@ -1042,7 +1057,39 @@ fn parse_inline<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
 
     assert!(state.delimiters.is_empty()); // All delimiters should have been processed.
 
-    Ok((input, consolidate_fragments(state.nodes)))
+    let mut fragments = consolidate_fragments(state.nodes);
+    if ends_with_hard_break {
+        strip_trailing_hard_break(&mut fragments);
+    }
+    Ok((input, fragments))
+}
+
+/// Strip a trailing hard line break from inline fragments when `<br>` appears
+/// at the end of a physical line.
+///
+/// The block-level parser already separates physical lines into distinct
+/// `FormattedTextLine::Line` entries, so the trailing `\n` from a `<br>` at
+/// end-of-line would create an unwanted empty visual row. This removes the
+/// last newline (plus any trailing whitespace after it), while preserving
+/// preceding newlines from additional `<br>` tags.
+fn strip_trailing_hard_break(fragments: &mut Vec<FormattedTextFragment>) {
+    let Some(last) = fragments.last_mut() else {
+        return;
+    };
+    let trimmed_ws = last
+        .text
+        .trim_end_matches(|c: char| c.is_whitespace() && c != '\n');
+    if !trimmed_ws.ends_with('\n') {
+        last.text.truncate(trimmed_ws.len());
+        if last.text.is_empty() {
+            fragments.pop();
+        }
+        return;
+    }
+    last.text.truncate(trimmed_ws.len() - 1);
+    if last.text.is_empty() {
+        fragments.pop();
+    }
 }
 
 /// State for parsing inline Markdown.
@@ -1549,6 +1596,7 @@ fn parse_inline_token<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
             parse_inline_token_autolink,
             parse_inline_token_underline_start,
             parse_inline_token_underline_end,
+            parse_inline_token_br,
             whitespace,
             text,
             // This _must_ be the last parser in the chain. It unconditionally consumes a single
@@ -1654,6 +1702,24 @@ fn parse_inline_token_underline_end<'a, E: ContextError<&'a str> + ParseError<&'
     )(input)
 }
 
+/// Parse a hard line break tag: `<br>`, `<br/>`, `<br />`, case-insensitive.
+fn parse_inline_token_br<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
+    input: &'a str,
+) -> IResult<&'a str, InlineToken<'a>, E> {
+    context(
+        "br_tag",
+        value(
+            InlineToken::HardLineBreak,
+            tuple((
+                tag("<"),
+                tag_no_case("br"),
+                space0,
+                alt((tag("/>"), tag(">"))),
+            )),
+        ),
+    )(input)
+}
+
 /// Helper to parse a run of delimiters.
 fn parse_delimiter_run<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
     kind: DelimiterKind,
@@ -1700,6 +1766,8 @@ enum InlineToken<'a> {
     LinkEnd,
     /// A closing </u>, which triggers underline parsing.
     UnderlineEnd,
+    /// A hard line break (`<br>`, `<br/>`, `<br />`).
+    HardLineBreak,
 }
 
 /// An entry in the [delimiter stack](https://spec.commonmark.org/0.30/#delimiter-stack)

--- a/crates/markdown_parser/src/markdown_parser.rs
+++ b/crates/markdown_parser/src/markdown_parser.rs
@@ -985,7 +985,6 @@ fn parse_inline<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
 ) -> IResult<&'a str, Vec<FormattedTextFragment>, E> {
     // We're parsing inline tokens "by hand" instead of using `fold_many0` to allow lookahead.
     let mut state = InlineState::default();
-    let mut ends_with_hard_break = false;
     while !input.is_empty() {
         let (remaining, token) = parse_inline_token(input)?;
         input = remaining;
@@ -993,13 +992,9 @@ fn parse_inline<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
         match token {
             InlineToken::CodeSpan(text) => {
                 state.push_closed_node(FormattedTextFragment::inline_code(text));
-                ends_with_hard_break = false;
             }
             InlineToken::Text(text) => {
                 state.push_text(text);
-                if !text.chars().all(char::is_whitespace) {
-                    ends_with_hard_break = false;
-                }
             }
             InlineToken::AutoLink(url) => {
                 // Per GFM spec, autolinks can follow whitespace, line beginning, or formatting
@@ -1017,11 +1012,9 @@ fn parse_inline<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
                 } else {
                     state.push_text(url);
                 }
-                ends_with_hard_break = false;
             }
             InlineToken::BackslashEscape(ch) | InlineToken::HtmlEntity(ch) => {
                 state.push_text(ch);
-                ends_with_hard_break = false;
             }
             InlineToken::Delimiter { kind, count } => {
                 let node_index = state.nodes.len();
@@ -1035,20 +1028,16 @@ fn parse_inline<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
                     Delimiter::new(node_index, kind, count, preceding_char, following_char);
                 state.push_closed_node(FormattedTextFragment::plain_text(delimiter.to_text()));
                 state.delimiters.push(delimiter);
-                ends_with_hard_break = false;
             }
             InlineToken::LinkEnd => {
                 input = parse_link(&mut state, remaining);
-                ends_with_hard_break = false;
             }
             InlineToken::UnderlineEnd => {
                 input = parse_underline(&mut state, remaining);
-                ends_with_hard_break = false;
             }
             InlineToken::HardLineBreak => {
                 state.push_text("\n");
                 state.last_node_closed = true;
-                ends_with_hard_break = true;
             }
         }
     }
@@ -1058,9 +1047,7 @@ fn parse_inline<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
     assert!(state.delimiters.is_empty()); // All delimiters should have been processed.
 
     let mut fragments = consolidate_fragments(state.nodes);
-    if ends_with_hard_break {
-        strip_trailing_hard_break(&mut fragments);
-    }
+    strip_trailing_hard_break(&mut fragments);
     Ok((input, fragments))
 }
 
@@ -1072,6 +1059,9 @@ fn parse_inline<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
 /// end-of-line would create an unwanted empty visual row. This removes the
 /// last newline (plus any trailing whitespace after it), while preserving
 /// preceding newlines from additional `<br>` tags.
+///
+/// This is a no-op if the last fragment does not end with a newline from a
+/// hard line break.
 fn strip_trailing_hard_break(fragments: &mut Vec<FormattedTextFragment>) {
     let Some(last) = fragments.last_mut() else {
         return;
@@ -1080,10 +1070,6 @@ fn strip_trailing_hard_break(fragments: &mut Vec<FormattedTextFragment>) {
         .text
         .trim_end_matches(|c: char| c.is_whitespace() && c != '\n');
     if !trimmed_ws.ends_with('\n') {
-        last.text.truncate(trimmed_ws.len());
-        if last.text.is_empty() {
-            fragments.pop();
-        }
         return;
     }
     last.text.truncate(trimmed_ws.len() - 1);

--- a/crates/markdown_parser/src/markdown_parser.rs
+++ b/crates/markdown_parser/src/markdown_parser.rs
@@ -1018,10 +1018,12 @@ fn parse_inline<'a, E: ContextError<&'a str> + ParseError<&'a str>>(
             }
             InlineToken::Delimiter { kind, count } => {
                 let node_index = state.nodes.len();
-                let preceding_char = state
-                    .nodes
-                    .last()
-                    .and_then(|fragment| fragment.text.chars().last());
+                let preceding_char = state.nodes.iter().rev().find_map(|fragment| {
+                    fragment
+                        .text
+                        .rfind(|c: char| c != '\n')
+                        .map(|i| fragment.text[i..].chars().next().unwrap())
+                });
                 let following_char = remaining.chars().next();
 
                 let delimiter =
@@ -1067,10 +1069,7 @@ fn strip_trailing_hard_break(fragments: &mut Vec<FormattedTextFragment>) {
     for i in (0..fragments.len()).rev() {
         let frag = &fragments[i];
         if frag.styles == FormattedTextStyles::default()
-            && frag
-                .text
-                .chars()
-                .all(|c| c.is_whitespace() && c != '\n')
+            && frag.text.chars().all(|c| c.is_whitespace() && c != '\n')
         {
             trailing_ws_end = i;
         } else {

--- a/crates/markdown_parser/src/markdown_parser_tests.rs
+++ b/crates/markdown_parser/src/markdown_parser_tests.rs
@@ -3000,3 +3000,16 @@ fn test_parse_br_in_table_cell() {
         panic!("Expected table");
     }
 }
+
+#[test]
+fn test_parse_br_before_closing_markup_at_line_end() {
+    assert_eq!(
+        parse_all("<u>line<br></u>", parse_inline),
+        vec![FormattedTextFragment::underline("line")]
+    );
+
+    assert_eq!(
+        parse_all("<u>line<br><br></u>", parse_inline),
+        vec![FormattedTextFragment::underline("line\n")]
+    );
+}

--- a/crates/markdown_parser/src/markdown_parser_tests.rs
+++ b/crates/markdown_parser/src/markdown_parser_tests.rs
@@ -2912,3 +2912,91 @@ fn test_parse_table_with_strikethrough() {
         panic!("Expected table");
     }
 }
+
+#[test]
+fn test_parse_br_tag_inline() {
+    assert_eq!(
+        parse_all("a<br>b", parse_inline),
+        vec![FormattedTextFragment::plain_text("a\nb")]
+    );
+
+    assert_eq!(
+        parse_all("a<br/>b", parse_inline),
+        vec![FormattedTextFragment::plain_text("a\nb")]
+    );
+
+    assert_eq!(
+        parse_all("a<br />b", parse_inline),
+        vec![FormattedTextFragment::plain_text("a\nb")]
+    );
+
+    assert_eq!(
+        parse_all("a<BR>b", parse_inline),
+        vec![FormattedTextFragment::plain_text("a\nb")]
+    );
+
+    assert_eq!(
+        parse_all("a<Br/>b", parse_inline),
+        vec![FormattedTextFragment::plain_text("a\nb")]
+    );
+
+    assert_eq!(
+        parse_all("hello<br>world", parse_inline),
+        vec![FormattedTextFragment::plain_text("hello\nworld")]
+    );
+
+    assert_eq!(
+        parse_all("**bold**<br>*italic*", parse_inline),
+        vec![
+            FormattedTextFragment::bold("bold"),
+            FormattedTextFragment::plain_text("\n"),
+            FormattedTextFragment::italic("italic"),
+        ]
+    );
+}
+
+#[test]
+fn test_parse_br_tag_at_line_end() {
+    let source = "line1<br>\nline2\n";
+    let result = test_parse_markdown(source);
+    assert_eq!(result.len(), 2);
+    assert_eq!(
+        result[0],
+        FormattedTextLine::Line(vec![FormattedTextFragment::plain_text("line1")])
+    );
+    assert_eq!(
+        result[1],
+        FormattedTextLine::Line(vec![FormattedTextFragment::plain_text("line2")])
+    );
+}
+
+#[test]
+fn test_parse_multiple_br_tags() {
+    let source = "line1<br><br>\nline2\n";
+    let result = test_parse_markdown(source);
+    assert_eq!(result.len(), 2);
+    assert_eq!(
+        result[0],
+        FormattedTextLine::Line(vec![FormattedTextFragment::plain_text("line1\n")])
+    );
+    assert_eq!(
+        result[1],
+        FormattedTextLine::Line(vec![FormattedTextFragment::plain_text("line2")])
+    );
+}
+
+#[test]
+fn test_parse_br_in_table_cell() {
+    let source = "| A | B |\n| --- | --- |\n| line1<br>line2 | 2 |\n";
+    let result = test_parse_markdown_with_gfm_tables(source);
+    assert_eq!(result.len(), 1);
+
+    if let FormattedTextLine::Table(table) = &result[0] {
+        assert_eq!(table.rows.len(), 1);
+        let cell = &table.rows[0][0];
+        assert_eq!(cell.len(), 1);
+        assert_eq!(cell[0].text, "line1\nline2");
+    } else {
+        panic!("Expected table");
+    }
+}

--- a/crates/markdown_parser/src/markdown_parser_tests.rs
+++ b/crates/markdown_parser/src/markdown_parser_tests.rs
@@ -3012,4 +3012,36 @@ fn test_parse_br_before_closing_markup_at_line_end() {
         parse_all("<u>line<br><br></u>", parse_inline),
         vec![FormattedTextFragment::underline("line\n")]
     );
+
+    assert_eq!(
+        parse_all("**line<br>**", parse_inline),
+        vec![FormattedTextFragment::bold("line")]
+    );
+
+    assert_eq!(
+        parse_all("**line<br><br>**", parse_inline),
+        vec![FormattedTextFragment::bold("line\n")]
+    );
+
+    assert_eq!(
+        parse_all("*line<br>*", parse_inline),
+        vec![FormattedTextFragment::italic("line")]
+    );
+
+    assert_eq!(
+        parse_all("~~line<br>~~", parse_inline),
+        vec![FormattedTextFragment::strikethrough("line")]
+    );
+}
+
+#[test]
+fn test_inline_line_count_with_br() {
+    let line = FormattedTextLine::Line(vec![FormattedTextFragment::plain_text("hello\nworld")]);
+    assert_eq!(line.num_lines(), 2);
+
+    let header = FormattedTextLine::Heading(FormattedTextHeader {
+        heading_size: 1,
+        text: vec![FormattedTextFragment::plain_text("title\nsubtitle")],
+    });
+    assert_eq!(header.num_lines(), 2);
 }


### PR DESCRIPTION
Closes #13732

## Summary

This PR adds support for the HTML `<br>`, `<br/>`, and `<br />` tags (case-insensitive) as inline hard line breaks in Markdown parsing, fixing #13732.

## Changes

- Added `InlineToken::HardLineBreak` variant to represent `<br>` tags
- Added `parse_inline_token_br()` parser that matches `<br>`, `<br/>`, `<br />` case-insensitively
- Hard line breaks insert a `\n` character into fragment text, which `TuiText` natively splits into multiple visual rows
- Added `strip_trailing_hard_breaks()` to prevent spurious blank lines at the end of paragraphs from trailing `<br>` tags
- Tested with all cases: plain text, inline formatting, emphasis, lists, and edge cases