### PR TITLE
fix: prevent DCH from erasing cells before cursor

### DIFF
--- a/app/src/terminal/model/grid/ansi_handler.rs
+++ b/app/src/terminal/model/grid/ansi_handler.rs
@@ -676,11 +676,14 @@ impl ansi::Handler for GridHandler {
         let cols = self.columns();
         let cursor = &self.grid.cursor();
         let bg = cursor.template.bg;
+        let start = cursor.point.col;
 
         // Ensure deleting within terminal bounds.
-        let count = min(count, cols);
+        let count = min(count, cols.saturating_sub(start));
+        if count == 0 {
+            return;
+        }
 
-        let start = cursor.point.col;
         let end = min(start + count, cols - 1);
         let num_cells = cols - end;
 

--- a/app/src/terminal/model/grid/grid_handler_tests.rs
+++ b/app/src/terminal/model/grid/grid_handler_tests.rs
@@ -1812,6 +1812,23 @@ fn test_delete_chars_at_wide_char_spacer_boundary() {
 }
 
 #[test]
+fn test_delete_chars_large_count_preserves_cells_before_cursor() {
+    let mut grid = GridHandler::new_for_test(1, 5);
+    for c in "abcde".chars() {
+        grid.input(c);
+    }
+    grid.goto(VisibleRow(0), 3);
+
+    grid.delete_chars(10);
+
+    assert_eq!(grid.grid_storage()[VisibleRow(0)][0].c, 'a');
+    assert_eq!(grid.grid_storage()[VisibleRow(0)][1].c, 'b');
+    assert_eq!(grid.grid_storage()[VisibleRow(0)][2].c, 'c');
+    assert_eq!(grid.grid_storage()[VisibleRow(0)][3].c, '\0');
+    assert_eq!(grid.grid_storage()[VisibleRow(0)][4].c, '\0');
+}
+
+#[test]
 fn test_insert_blank_at_wide_char_spacer_boundary() {
     // Input a wide char at col 0-1, move cursor to col 1 (spacer), and
     // insert a blank.  The WIDE_CHAR at col 0 must be cleared.


### PR DESCRIPTION
## Description
Fixes a terminal correctness bug where CSI DCH (`CSI Pn P`) could erase cells before the cursor when `Pn` exceeded the number of cells remaining on the line.

## Linked Issue
- [x] The linked issue is labeled `ready-to-spec` or `ready-to-implement`.
- Fixes #12820

## Testing
- Added `test_delete_chars_large_count_preserves_cells_before_cursor`.
- `cargo nextest run -p warp -E "test(delete_chars)"`
- `cargo clippy -p warp --lib --tests -- -D warnings`
- `cargo fmt --all`
- `git diff --check`

This is a pure terminal-grid logic change; no UI screenshots are applicable.

### Changelog
CHANGELOG-BUG-FIX: Prevent large DCH counts from erasing content before the cursor.