### PR TITLE
fix: avoid watching directory symlink targets

### DIFF
--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -998,6 +998,7 @@ fn descend_allowlist_matches(suffix: &[Component<'_>]) -> bool {
 /// `node_modules`, build output, vendored deps, etc.
 pub fn should_watch_repo_directory(
     path: &Path,
+    repo_root: &Path,
     gitignores: &[Gitignore],
     force_included_paths: &[PathBuf],
 ) -> bool {
@@ -1010,7 +1011,7 @@ pub fn should_watch_repo_directory(
         return true;
     }
 
-    if is_within_symlink(path) {
+    if is_within_symlink(path, repo_root) {
         return false;
     }
 
@@ -1031,12 +1032,15 @@ pub fn should_watch_repo_directory(
 /// The recursive watcher requires this check to be monotonic: if a symlinked
 /// directory is rejected, its descendants must be rejected as well even
 /// though their individual paths are not themselves symlinks.
-fn is_within_symlink(path: &Path) -> bool {
+fn is_within_symlink(path: &Path, repo_root: &Path) -> bool {
     // A valid path beneath a symlink can only be reached through a directory
     // symlink, so avoid a second `metadata` syscall to resolve its target.
-    path.ancestors().any(|ancestor| {
-        std::fs::symlink_metadata(ancestor).is_ok_and(|metadata| metadata.file_type().is_symlink())
-    })
+    path.ancestors()
+        .take_while(|ancestor| ancestor.starts_with(repo_root))
+        .any(|ancestor| {
+            std::fs::symlink_metadata(ancestor)
+                .is_ok_and(|metadata| metadata.file_type().is_symlink())
+        })
 }
 
 /// Returns the [`WatchFilter`] used by repository file watchers.
@@ -1061,11 +1065,13 @@ fn is_within_symlink(path: &Path) -> bool {
 /// over-watch, never to miss events.
 #[cfg(feature = "local_fs")]
 pub fn repo_watch_filter(
+    repo_root: PathBuf,
     gitignores: Vec<Gitignore>,
     force_included_paths: Vec<PathBuf>,
 ) -> WatchFilter {
-    let should_watch =
-        move |path: &Path| should_watch_repo_directory(path, &gitignores, &force_included_paths);
+    let should_watch = move |path: &Path| {
+        should_watch_repo_directory(path, &repo_root, &gitignores, &force_included_paths)
+    };
     WatchFilter::with_filter(
         Arc::new(should_watch),
         Arc::new(|path: &Path| !should_ignore_git_path(path)),

--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -992,20 +992,30 @@ fn descend_allowlist_matches(suffix: &[Component<'_>]) -> bool {
 /// a watch on) the directory at `path`.
 ///
 /// Directories inside `.git/` follow the watcher allowlist, force-included
-/// paths are always watched even when gitignored, and any other gitignored
-/// directory is pruned so we don't register watches on `node_modules`, build
-/// output, vendored deps, etc.
+/// paths are always watched even when gitignored, directory symlinks are
+/// pruned to avoid following trees outside the repository, and any other
+/// gitignored directory is pruned so we don't register watches on
+/// `node_modules`, build output, vendored deps, etc.
 pub fn should_watch_repo_directory(
     path: &Path,
     gitignores: &[Gitignore],
     force_included_paths: &[PathBuf],
 ) -> bool {
-    if is_git_internal_path(path) {
-        return should_watch_directory_in_git_path(path);
-    }
-
+    // Do not follow directory symlinks while recursively registering watches.
+    // A repository symlink such as `result -> /nix/store/...` can otherwise
+    // make the watcher traverse a large tree outside the repository. Keep
+    // explicitly force-included paths working for project-skill providers,
+    // which intentionally support symlinked skill directories.
     if matches_force_included_path(path, force_included_paths) {
         return true;
+    }
+
+    if is_within_symlink(path) {
+        return false;
+    }
+
+    if is_git_internal_path(path) {
+        return should_watch_directory_in_git_path(path);
     }
 
     !matches_gitignores(
@@ -1014,6 +1024,19 @@ pub fn should_watch_repo_directory(
         gitignores,
         /* check_ancestors */ true,
     )
+}
+
+/// Returns whether `path` is a symlink or is below one.
+///
+/// The recursive watcher requires this check to be monotonic: if a symlinked
+/// directory is rejected, its descendants must be rejected as well even
+/// though their individual paths are not themselves symlinks.
+fn is_within_symlink(path: &Path) -> bool {
+    // A valid path beneath a symlink can only be reached through a directory
+    // symlink, so avoid a second `metadata` syscall to resolve its target.
+    path.ancestors().any(|ancestor| {
+        std::fs::symlink_metadata(ancestor).is_ok_and(|metadata| metadata.file_type().is_symlink())
+    })
 }
 
 /// Returns the [`WatchFilter`] used by repository file watchers.

--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -1036,7 +1036,10 @@ fn is_within_symlink(path: &Path, repo_root: &Path) -> bool {
     // A valid path beneath a symlink can only be reached through a directory
     // symlink, so avoid a second `metadata` syscall to resolve its target.
     path.ancestors()
-        .take_while(|ancestor| ancestor.starts_with(repo_root))
+        // The watched root itself may be a symlink (for example, a workspace
+        // opened through a user-created alias). It is the boundary of this
+        // check, not a symlinked directory to prune.
+        .take_while(|ancestor| *ancestor != repo_root)
         .any(|ancestor| {
             std::fs::symlink_metadata(ancestor)
                 .is_ok_and(|metadata| metadata.file_type().is_symlink())

--- a/crates/repo_metadata/src/entry.rs
+++ b/crates/repo_metadata/src/entry.rs
@@ -1039,7 +1039,7 @@ fn is_within_symlink(path: &Path, repo_root: &Path) -> bool {
         // The watched root itself may be a symlink (for example, a workspace
         // opened through a user-created alias). It is the boundary of this
         // check, not a symlinked directory to prune.
-        .take_while(|ancestor| *ancestor != repo_root)
+        .take_while(|ancestor| *ancestor != repo_root && ancestor.starts_with(repo_root))
         .any(|ancestor| {
             std::fs::symlink_metadata(ancestor)
                 .is_ok_and(|metadata| metadata.file_type().is_symlink())

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -199,14 +199,21 @@ fn should_watch_prunes_gitignored_directory() {
     let gitignores = vec![gitignore_rooted(&root, "node_modules/\n")];
 
     // Root and non-ignored dirs are watched; the gitignored dir is pruned.
-    assert!(super::should_watch_repo_directory(&root, &gitignores, &[]));
+    assert!(super::should_watch_repo_directory(
+        &root,
+        &root,
+        &gitignores,
+        &[]
+    ));
     assert!(super::should_watch_repo_directory(
         &root.join("src"),
+        &root,
         &gitignores,
         &[]
     ));
     assert!(!super::should_watch_repo_directory(
         &root.join("node_modules"),
+        &root,
         &gitignores,
         &[]
     ));
@@ -214,6 +221,7 @@ fn should_watch_prunes_gitignored_directory() {
     // what preserves the watcher's monotonicity invariant.
     assert!(!super::should_watch_repo_directory(
         &root.join("node_modules/foo"),
+        &root,
         &gitignores,
         &[]
     ));
@@ -231,11 +239,31 @@ fn should_watch_prunes_directory_symlinks_and_their_descendants() {
     // latter protects the watch filter's ancestor monotonicity invariant.
     assert!(!super::should_watch_repo_directory(
         &root.join("result"),
+        &root,
         &[],
         &[]
     ));
     assert!(!super::should_watch_repo_directory(
         &root.join("result/tree"),
+        &root,
+        &[],
+        &[]
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn should_watch_ignores_symlinks_above_repo_root() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let real_parent = temp_dir.path().join("real-parent");
+    let symlinked_parent = temp_dir.path().join("linked-parent");
+    fs::create_dir_all(real_parent.join("repo/src")).unwrap();
+    std::os::unix::fs::symlink(&real_parent, &symlinked_parent).unwrap();
+
+    let repo_root = symlinked_parent.join("repo");
+    assert!(super::should_watch_repo_directory(
+        &repo_root.join("src"),
+        &repo_root,
         &[],
         &[]
     ));
@@ -259,11 +287,13 @@ fn should_watch_allows_symlinked_force_included_paths() {
     // directories, so the explicit force-included path remains watchable.
     assert!(super::should_watch_repo_directory(
         &root.join(".agents/skills/linked"),
+        &root,
         &[],
         &force_included
     ));
     assert!(super::should_watch_repo_directory(
         &root.join(".agents/skills/linked/SKILL.md"),
+        &root,
         &[],
         &force_included
     ));
@@ -282,22 +312,26 @@ fn should_watch_descends_to_force_included_under_ignored_ancestor() {
     // prefix to reach the force-included path, and into its subtree.
     assert!(super::should_watch_repo_directory(
         &root.join(".agents"),
+        &root,
         &gitignores,
         &force_included
     ));
     assert!(super::should_watch_repo_directory(
         &root.join(".agents/skills"),
+        &root,
         &gitignores,
         &force_included
     ));
     assert!(super::should_watch_repo_directory(
         &root.join(".agents/skills/test"),
+        &root,
         &gitignores,
         &force_included
     ));
     // A sibling ignored dir that is not force-included is still pruned.
     assert!(!super::should_watch_repo_directory(
         &root.join(".agents/other"),
+        &root,
         &gitignores,
         &force_included
     ));
@@ -316,21 +350,25 @@ fn should_watch_handles_nested_ignored_ancestor_with_deeper_force_included() {
     // prefix and into it, while pruning the ignored sibling.
     assert!(super::should_watch_repo_directory(
         &root.join("a"),
+        &root,
         &gitignores,
         &force_included
     ));
     assert!(super::should_watch_repo_directory(
         &root.join("a/b"),
+        &root,
         &gitignores,
         &force_included
     ));
     assert!(super::should_watch_repo_directory(
         &root.join("a/b/c"),
+        &root,
         &gitignores,
         &force_included
     ));
     assert!(!super::should_watch_repo_directory(
         &root.join("a/b/other"),
+        &root,
         &gitignores,
         &force_included
     ));
@@ -348,6 +386,7 @@ fn should_watch_descends_dir_only_reinclude_negation() {
     // `parentdir` itself is not matched by `parentdir/*`, so we descend.
     assert!(super::should_watch_repo_directory(
         &root.join("parentdir"),
+        &root,
         &gitignores,
         &[]
     ));
@@ -355,6 +394,7 @@ fn should_watch_descends_dir_only_reinclude_negation() {
     // still watched even though `parentdir/*` matched it first.
     assert!(super::should_watch_repo_directory(
         &root.join("parentdir/sub"),
+        &root,
         &gitignores,
         &[]
     ));
@@ -378,11 +418,13 @@ fn should_watch_preserves_git_internal_allowlist() {
     fs::create_dir_all(repo.join(".git/objects")).unwrap();
     assert!(super::should_watch_repo_directory(
         &repo.join(".git/refs/heads"),
+        &repo,
         &[],
         &[]
     ));
     assert!(!super::should_watch_repo_directory(
         &repo.join(".git/objects"),
+        &repo,
         &[],
         &[]
     ));
@@ -925,10 +967,16 @@ fn gitignore_affects_descend_predicate_but_not_emitted_events() {
     // registration, while a tracked dir is still descended into.
     assert!(!should_watch_repo_directory(
         &node_modules,
+        &root_path,
         &gitignores,
         &[]
     ));
-    assert!(should_watch_repo_directory(&src, &gitignores, &[]));
+    assert!(should_watch_repo_directory(
+        &src,
+        &root_path,
+        &gitignores,
+        &[]
+    ));
 
     // Emit predicate building block (`!should_ignore_git_path`): gitignored,
     // non-`.git` paths are NOT suppressed, so their events still flow. Only

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -219,6 +219,56 @@ fn should_watch_prunes_gitignored_directory() {
     ));
 }
 
+#[cfg(unix)]
+#[test]
+fn should_watch_prunes_directory_symlinks_and_their_descendants() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = dunce::canonicalize(temp_dir.path()).unwrap();
+    fs::create_dir_all(root.join("target/tree")).unwrap();
+    std::os::unix::fs::symlink(root.join("target"), root.join("result")).unwrap();
+
+    // The symlink and paths reached through it must both be rejected. The
+    // latter protects the watch filter's ancestor monotonicity invariant.
+    assert!(!super::should_watch_repo_directory(
+        &root.join("result"),
+        &[],
+        &[]
+    ));
+    assert!(!super::should_watch_repo_directory(
+        &root.join("result/tree"),
+        &[],
+        &[]
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn should_watch_allows_symlinked_force_included_paths() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = dunce::canonicalize(temp_dir.path()).unwrap();
+    fs::create_dir_all(root.join("targets/skills/linked")).unwrap();
+    fs::create_dir_all(root.join(".agents/skills")).unwrap();
+    std::os::unix::fs::symlink(
+        root.join("targets/skills/linked"),
+        root.join(".agents/skills/linked"),
+    )
+    .unwrap();
+    let force_included = [std::path::PathBuf::from(".agents/skills")];
+
+    // Project-skill providers intentionally support symlinked skill
+    // directories, so the explicit force-included path remains watchable.
+    assert!(super::should_watch_repo_directory(
+        &root.join(".agents/skills/linked"),
+        &[],
+        &force_included
+    ));
+    assert!(super::should_watch_repo_directory(
+        &root.join(".agents/skills/linked/SKILL.md"),
+        &[],
+        &force_included
+    ));
+}
+
 #[test]
 fn should_watch_descends_to_force_included_under_ignored_ancestor() {
     let temp_dir = tempfile::tempdir().unwrap();
@@ -320,10 +370,12 @@ fn should_watch_descends_dir_only_reinclude_negation() {
 
 #[test]
 fn should_watch_preserves_git_internal_allowlist() {
-    // No gitignores / force-included paths needed: `.git` handling
-    // short-circuits and is path-based, mirroring
-    // `should_watch_directory_in_git_path`.
-    let repo = std::path::Path::new("/home/user/project");
+    // No gitignores / force-included paths needed: `.git` handling is
+    // path-based, mirroring `should_watch_directory_in_git_path`.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repo = dunce::canonicalize(temp_dir.path()).unwrap();
+    fs::create_dir_all(repo.join(".git/refs/heads")).unwrap();
+    fs::create_dir_all(repo.join(".git/objects")).unwrap();
     assert!(super::should_watch_repo_directory(
         &repo.join(".git/refs/heads"),
         &[],

--- a/crates/repo_metadata/src/entry_tests.rs
+++ b/crates/repo_metadata/src/entry_tests.rs
@@ -271,6 +271,29 @@ fn should_watch_ignores_symlinks_above_repo_root() {
 
 #[cfg(unix)]
 #[test]
+fn should_watch_allows_symlinked_repo_root() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let real_root = temp_dir.path().join("real-repo");
+    let symlinked_root = temp_dir.path().join("linked-repo");
+    fs::create_dir_all(real_root.join("src")).unwrap();
+    std::os::unix::fs::symlink(&real_root, &symlinked_root).unwrap();
+
+    assert!(super::should_watch_repo_directory(
+        &symlinked_root,
+        &symlinked_root,
+        &[],
+        &[]
+    ));
+    assert!(super::should_watch_repo_directory(
+        &symlinked_root.join("src"),
+        &symlinked_root,
+        &[],
+        &[]
+    ));
+}
+
+#[cfg(unix)]
+#[test]
 fn should_watch_allows_symlinked_force_included_paths() {
     let temp_dir = tempfile::tempdir().unwrap();
     let root = dunce::canonicalize(temp_dir.path()).unwrap();

--- a/crates/repo_metadata/src/local_model.rs
+++ b/crates/repo_metadata/src/local_model.rs
@@ -564,7 +564,7 @@ impl LocalRepoMetadataModel {
                 watcher.update(ctx, |watcher, _ctx| {
                     std::mem::drop(watcher.register_path(
                         target_dir,
-                        repo_watch_filter(Vec::new(), Vec::new()),
+                        repo_watch_filter(target_dir.clone(), Vec::new(), Vec::new()),
                         RecursiveMode::NonRecursive,
                     ));
                 });
@@ -971,7 +971,7 @@ impl LocalRepoMetadataModel {
                     }
                     std::mem::drop(watcher.register_path(
                         &watch_path,
-                        repo_watch_filter(gitignores, force_included_paths),
+                        repo_watch_filter(watch_path.clone(), gitignores, force_included_paths),
                         recursive_mode,
                     ));
                 });
@@ -1415,7 +1415,7 @@ impl LocalRepoMetadataModel {
             watcher.update(ctx, |watcher, _ctx| {
                 std::mem::drop(watcher.register_path(
                     &local_path,
-                    repo_watch_filter(gitignores, force_included_paths),
+                    repo_watch_filter(local_path.clone(), gitignores, force_included_paths),
                     RecursiveMode::NonRecursive,
                 ));
             });

--- a/crates/repo_metadata/src/repository.rs
+++ b/crates/repo_metadata/src/repository.rs
@@ -355,10 +355,16 @@ impl Repository {
                 // Reuse the gitignores we already built at construction so the
                 // watch descend filter doesn't re-read `.gitignore` from disk.
                 let gitignores = self.gitignores.clone();
+                let repo_root = self.root_dir().to_local_path_lossy();
 
                 Box::pin(
                     DirectoryWatcher::handle(ctx).update(ctx, move |watcher, ctx| {
-                        watcher.start_watching_directories(directories_to_watch, gitignores, ctx)
+                        watcher.start_watching_directories(
+                            &repo_root,
+                            directories_to_watch,
+                            gitignores,
+                            ctx,
+                        )
                     }),
                 )
             } else {

--- a/crates/repo_metadata/src/repository.rs
+++ b/crates/repo_metadata/src/repository.rs
@@ -355,16 +355,10 @@ impl Repository {
                 // Reuse the gitignores we already built at construction so the
                 // watch descend filter doesn't re-read `.gitignore` from disk.
                 let gitignores = self.gitignores.clone();
-                let repo_root = self.root_dir().to_local_path_lossy();
 
                 Box::pin(
                     DirectoryWatcher::handle(ctx).update(ctx, move |watcher, ctx| {
-                        watcher.start_watching_directories(
-                            &repo_root,
-                            directories_to_watch,
-                            gitignores,
-                            ctx,
-                        )
+                        watcher.start_watching_directories(directories_to_watch, gitignores, ctx)
                     }),
                 )
             } else {

--- a/crates/repo_metadata/src/watcher.rs
+++ b/crates/repo_metadata/src/watcher.rs
@@ -321,13 +321,14 @@ impl DirectoryWatcher {
     #[cfg(feature = "local_fs")]
     pub(crate) fn start_watching_directories(
         &mut self,
+        repo_root: &Path,
         directory_paths: Vec<StandardizedPath>,
         gitignores: Vec<Gitignore>,
         ctx: &mut ModelContext<Self>,
     ) -> impl Future<Output = Result<(), RepoMetadataError>> {
         let futures: Vec<_> = directory_paths
             .into_iter()
-            .map(|path| self.start_watching_directory(&path, gitignores.clone(), ctx))
+            .map(|path| self.start_watching_directory(repo_root, &path, gitignores.clone(), ctx))
             .collect();
 
         async move {
@@ -344,6 +345,7 @@ impl DirectoryWatcher {
     #[cfg(feature = "local_fs")]
     pub(crate) fn start_watching_directory(
         &mut self,
+        repo_root: &Path,
         directory_path: &StandardizedPath,
         gitignores: Vec<Gitignore>,
         ctx: &mut ModelContext<Self>,
@@ -363,7 +365,11 @@ impl DirectoryWatcher {
 
                     Some(watcher.register_path(
                         &local_path,
-                        repo_watch_filter(gitignores, force_included_paths),
+                        repo_watch_filter(
+                            repo_root.to_path_buf(),
+                            gitignores,
+                            force_included_paths,
+                        ),
                         RecursiveMode::Recursive,
                     ))
                 })

--- a/crates/repo_metadata/src/watcher.rs
+++ b/crates/repo_metadata/src/watcher.rs
@@ -321,14 +321,13 @@ impl DirectoryWatcher {
     #[cfg(feature = "local_fs")]
     pub(crate) fn start_watching_directories(
         &mut self,
-        repo_root: &Path,
         directory_paths: Vec<StandardizedPath>,
         gitignores: Vec<Gitignore>,
         ctx: &mut ModelContext<Self>,
     ) -> impl Future<Output = Result<(), RepoMetadataError>> {
         let futures: Vec<_> = directory_paths
             .into_iter()
-            .map(|path| self.start_watching_directory(repo_root, &path, gitignores.clone(), ctx))
+            .map(|path| self.start_watching_directory(&path, gitignores.clone(), ctx))
             .collect();
 
         async move {
@@ -345,7 +344,6 @@ impl DirectoryWatcher {
     #[cfg(feature = "local_fs")]
     pub(crate) fn start_watching_directory(
         &mut self,
-        repo_root: &Path,
         directory_path: &StandardizedPath,
         gitignores: Vec<Gitignore>,
         ctx: &mut ModelContext<Self>,
@@ -365,11 +363,7 @@ impl DirectoryWatcher {
 
                     Some(watcher.register_path(
                         &local_path,
-                        repo_watch_filter(
-                            repo_root.to_path_buf(),
-                            gitignores,
-                            force_included_paths,
-                        ),
+                        repo_watch_filter(local_path.clone(), gitignores, force_included_paths),
                         RecursiveMode::Recursive,
                     ))
                 })


### PR DESCRIPTION
## Description

Avoid recursively watching directory symlinks from repository watchers. On Linux/NixOS, paths such as `result -> /nix/store/...` can otherwise cause the watcher to traverse very large dependency trees and consume excessive memory.

The watcher now prunes symlinks and their descendants while preserving explicitly force-included project-skill paths.

## Linked Issue

- [x] The linked issue is labeled `ready-to-implement`.

Fixes #13233

## Testing

- `cargo fmt --all`
- `cargo nextest run -p repo_metadata --no-fail-fast`
- `cargo clippy -p repo_metadata --lib --tests -- -D warnings`
- `git diff --check`

Manual GUI testing is not applicable; this is a repository watcher change with automated coverage.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Prevent repository watchers from following directory symlinks into large external trees.
