### PR TITLE
fix: close stale classic completion menus

### DIFF
--- a/app/src/terminal/input.rs
+++ b/app/src/terminal/input.rs
@@ -11661,8 +11661,18 @@ impl Input {
                     // If we're in classic completion mode and the selected item is equal
                     // to the current word, then we should keep the menu open; the user is cycling.
                     // We early-return because we don't want to filter the menu based on the
-                    // selected item.
+                    // selected item. This must happen before validating the original prefix so
+                    // fuzzy matches that do not start with the original query can still cycle.
                     return false;
+                }
+
+                // Classic completions allow the buffer to diverge from the full original
+                // buffer while cycling, but the original replacement prefix must remain intact.
+                // Otherwise backspacing past the query causes an empty/short prefix search to
+                // restore the stale result set.
+                let original_word = &buffer_text_original[replacement_start..];
+                if !current_word.starts_with(original_word) {
+                    return true;
                 }
             }
 

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -6807,18 +6807,24 @@ fn test_classic_completions_close_when_backspaced_past_original_query() {
                 editor_model_snapshot(input, ctx),
                 ctx,
             );
+            input.input_tab(ctx);
         });
 
         input.read(&app, |input, ctx| {
+            assert_eq!(input.buffer_text(ctx), "cd Downloads");
             assert!(matches!(
                 input.suggestions_mode_model.as_ref(ctx).mode(),
                 InputSuggestionsMode::CompletionSuggestions { .. }
             ));
         });
 
-        // Removing one character from the original `Do` query should dismiss the menu instead
-        // of filtering with `D` and resurrecting the original result set.
-        editor.update(&mut app, |editor, ctx| editor.backspace(ctx));
+        // Backspacing through the selected result until only `D` remains should dismiss the menu
+        // instead of filtering with `D` and resurrecting the original result set.
+        editor.update(&mut app, |editor, ctx| {
+            for _ in 0.."ownloads".len() {
+                editor.backspace(ctx);
+            }
+        });
 
         input.read(&app, |input, ctx| {
             assert_eq!(input.buffer_text(ctx), "cd D");
@@ -6837,6 +6843,7 @@ fn test_classic_completions_keep_fuzzy_selection_open() {
         initialize_app(&mut app);
         let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
         let input = terminal.read(&app, |terminal, _| terminal.input().clone());
+        let editor = input.read(&app, |input, _| input.editor().clone());
 
         app.update(|ctx| {
             InputSettings::handle(ctx).update(ctx, |setting, ctx| {
@@ -6870,6 +6877,20 @@ fn test_classic_completions_keep_fuzzy_selection_open() {
                 input.suggestions_mode_model.as_ref(ctx).mode(),
                 InputSuggestionsMode::CompletionSuggestions { .. }
             ));
+        });
+
+        editor.update(&mut app, |editor, ctx| {
+            for _ in 0.."esktop".len() {
+                editor.backspace(ctx);
+            }
+        });
+
+        input.read(&app, |input, ctx| {
+            assert_eq!(input.buffer_text(ctx), "cd D");
+            assert_eq!(
+                *input.suggestions_mode_model.as_ref(ctx).mode(),
+                InputSuggestionsMode::Closed
+            );
         });
     })
 }

--- a/app/src/terminal/input_tests.rs
+++ b/app/src/terminal/input_tests.rs
@@ -6776,6 +6776,105 @@ fn test_tab_completions_menu_for_classic_completions() {
 }
 
 #[test]
+fn test_classic_completions_close_when_backspaced_past_original_query() {
+    let _flag = FeatureFlag::ClassicCompletions.override_enabled(true);
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
+        let input = terminal.read(&app, |terminal, _| terminal.input().clone());
+        let editor = input.read(&app, |input, _| input.editor().clone());
+
+        app.update(|ctx| {
+            InputSettings::handle(ctx).update(ctx, |setting, ctx| {
+                setting
+                    .classic_completions_mode
+                    .toggle_and_save_value(ctx)
+                    .expect("Able to turn on classic completions");
+            })
+        });
+
+        input.update(&mut app, |input, ctx| {
+            input.clear_buffer_and_reset_undo_stack(ctx);
+            input.user_insert("cd Do", ctx);
+            input.input_tab(ctx);
+            input.handle_completion_suggestions_results(
+                build_suggestion_results(
+                    vec![file_suggestion("Downloads"), file_suggestion("Documents")],
+                    (3, 5),
+                    MatchStrategy::CaseInsensitive,
+                ),
+                CompletionsTrigger::Keybinding,
+                editor_model_snapshot(input, ctx),
+                ctx,
+            );
+        });
+
+        input.read(&app, |input, ctx| {
+            assert!(matches!(
+                input.suggestions_mode_model.as_ref(ctx).mode(),
+                InputSuggestionsMode::CompletionSuggestions { .. }
+            ));
+        });
+
+        // Removing one character from the original `Do` query should dismiss the menu instead
+        // of filtering with `D` and resurrecting the original result set.
+        editor.update(&mut app, |editor, ctx| editor.backspace(ctx));
+
+        input.read(&app, |input, ctx| {
+            assert_eq!(input.buffer_text(ctx), "cd D");
+            assert_eq!(
+                *input.suggestions_mode_model.as_ref(ctx).mode(),
+                InputSuggestionsMode::Closed
+            );
+        });
+    })
+}
+
+#[test]
+fn test_classic_completions_keep_fuzzy_selection_open() {
+    let _flag = FeatureFlag::ClassicCompletions.override_enabled(true);
+    App::test((), |mut app| async move {
+        initialize_app(&mut app);
+        let terminal = add_window_with_bootstrapped_terminal(&mut app, None, None).await;
+        let input = terminal.read(&app, |terminal, _| terminal.input().clone());
+
+        app.update(|ctx| {
+            InputSettings::handle(ctx).update(ctx, |setting, ctx| {
+                setting
+                    .classic_completions_mode
+                    .toggle_and_save_value(ctx)
+                    .expect("Able to turn on classic completions");
+            })
+        });
+
+        input.update(&mut app, |input, ctx| {
+            input.clear_buffer_and_reset_undo_stack(ctx);
+            input.user_insert("cd Do", ctx);
+            input.input_tab(ctx);
+            input.handle_completion_suggestions_results(
+                build_suggestion_results(
+                    vec![fuzzy_argument_suggestion("Desktop", vec![0, 5])],
+                    (3, 5),
+                    MatchStrategy::Fuzzy,
+                ),
+                CompletionsTrigger::Keybinding,
+                editor_model_snapshot(input, ctx),
+                ctx,
+            );
+            input.input_tab(ctx);
+        });
+
+        input.read(&app, |input, ctx| {
+            assert_eq!(input.buffer_text(ctx), "cd Desktop");
+            assert!(matches!(
+                input.suggestions_mode_model.as_ref(ctx).mode(),
+                InputSuggestionsMode::CompletionSuggestions { .. }
+            ));
+        });
+    })
+}
+
+#[test]
 fn test_tab_completions_menu_for_classic_completions_with_files() {
     let _flag = FeatureFlag::ClassicCompletions.override_enabled(true);
     App::test((), |mut app| async move {


### PR DESCRIPTION
## Description

Classic Completions could leave a stale suggestion menu open after the user backspaced past the query that originally produced the results. The short prefix could then re-filter to the entire original result set.

The completion menu now remains valid while the original replacement prefix is intact, but closes when editing removes part of that prefix.

## Linked Issue

- [x] The linked issue is labeled `ready-to-implement`.

Fixes #13605

## Testing

- [x] `cargo fmt --all`
- [x] `cargo nextest run -p warp -E 'test(classic_completions)'`
- [x] `cargo clippy -p warp --lib --tests -- -D warnings`
- [x] `git diff --check`
- [x] Added regression coverage for Classic Completions after backspacing past the original query.
- [ ] I have manually tested my changes locally with `./script/run`

### Screenshots / Videos

Not included: this is a terminal input behavior change covered by automated tests; no GUI visual layout changed.

## Agent Mode
- [x] Warp Agent Mode - This PR was created via Warp's AI Agent Mode

CHANGELOG-BUG-FIX: Close stale Classic Completions menus after editing past the original query.
